### PR TITLE
Make JUnit tests runnable from the command line

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,24 @@ name := "dotty"
 
 organization := "lamp"
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.11.0-M6"
+
+scalaBinaryVersion := scalaVersion.value
 
 scalaSource in Compile <<= baseDirectory / "src"
 
 scalacOptions in Global ++= Seq("-feature", "-deprecation", "-language:_")
 
-libraryDependencies <+= scalaVersion ( sv => "org.scala-lang" % "scala-reflect" % sv )
+libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+  "org.scala-lang.modules" %% "scala-xml" % "1.0.0-RC6"
+)
 
 scalaSource in Test <<= baseDirectory / "test"
+
+libraryDependencies += "junit" % "junit-dep" % "4.10" % "test"
+
+libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test"
+
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s")
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.2
+sbt.version=0.13.0

--- a/test/test/DottyTest.scala
+++ b/test/test/DottyTest.scala
@@ -25,6 +25,7 @@ class DottyTest {
       .withSetting(printtypes, true)
       .withSetting(pageWidth, 90)
       .withSetting(log, List("<some"))
+      .withSetting(usejavacp, true)
  //   .withTyperState(new TyperState(new ConsoleReporter()(base.initialCtx)))
 
 //      .withSetting(uniqid, true)


### PR DESCRIPTION
- Update the build to SBT 0.13.0
  - Update Scala dependency to 2.11.0-M6
  - Add dependency on JUnit
  - Update DottyTest to use the setting `useJavaCP = true`
  - Update PathResolver to be aware of the protocol for an embedded Scala
    instance to discover the boot and app classpaths from the host SBT
    classloader

After this, I see two test failures:

```
[error] Test test.ShowClassTests.loadClassWithPrivateInnerAndSubSelf failed: java.lang.Error: null
[error]     at dotty.tools.dotc.core.Symbols$class.newStubSymbol(Symbols.scala:188)
[error]     ...
[info] Test test.ShowClassTests.loadDotty started
[info] Test test.ShowClassTests.showReflectAliases started
[error] Test test.ShowClassTests.showReflectAliases failed: java.lang.Error: null
[error]     at dotty.tools.dotc.core.Symbols$class.newStubSymbol(Symbols.scala:188)
```
