### PR TITLE
 Enable verbose printing of exceptions thrown in junit tests

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -33,6 +33,8 @@ object DottyBuild extends Build {
     // scalac options
     scalacOptions in Global ++= Seq("-feature", "-deprecation", "-language:_"),
 
+    // enable verbose exception messages for JUnit
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     // Adjust classpath for running dotty
     mainClass in (Compile, run) := Some("dotty.tools.dotc.Main"),
     fork in run := true,


### PR DESCRIPTION
By default sbt/junit-interface swallows exceptions without printing stack traces and exception class name.

Enabled verbose printing of exception  for better understanding travis logs. 
