### PR TITLE
Fix of #39

### DIFF
--- a/src/dotty/tools/dotc/core/Denotations.scala
+++ b/src/dotty/tools/dotc/core/Denotations.scala
@@ -393,7 +393,7 @@ object Denotations {
       exists && p(this)
 
     def accessibleFrom(pre: Type, superAccess: Boolean)(implicit ctx: Context): Denotation =
-      if (symbol isAccessibleFrom (pre, superAccess)) this else NoDenotation
+      if (!symbol.exists || symbol.isAccessibleFrom(pre, superAccess)) this else NoDenotation
 
     def atSignature(sig: Signature)(implicit ctx: Context): SingleDenotation =
       if (sig matches signature) this else NoDenotation

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -40,6 +40,7 @@ class tests extends CompilerTest {
   @Test def pos_overloaded() = compileFile(posDir, "overloaded")
   @Test def pos_templateParents() = compileFile(posDir, "templateParents")
   @Test def pos_structural() = compileFile(posDir, "structural")
+  @Test def pos_i39 = compileFile(posDir, "i39")
 
   @Test def neg_blockescapes() = compileFile(negDir, "blockescapesNeg", xerrors = 1)
   @Test def neg_typedapply() = compileFile(negDir, "typedapply", xerrors = 4)
@@ -49,6 +50,7 @@ class tests extends CompilerTest {
   @Test def neg_privates() = compileFile(negDir, "privates", xerrors = 2)
   @Test def neg_rootImports = compileFile(negDir, "rootImplicits", xerrors = 2)
   @Test def neg_templateParents() = compileFile(negDir, "templateParents", xerrors = 3)
+  @Test def neg_i39 = compileFile(negDir, "i39", xerrors = 1)
 
   @Test def dotc = compileDir(dotcDir + "tools/dotc")
   @Test def dotc_ast = compileDir(dotcDir + "tools/dotc/ast")

--- a/tests/neg/i39.scala
+++ b/tests/neg/i39.scala
@@ -1,0 +1,19 @@
+object i39neg {
+
+  trait B {
+    type D <: { type T }
+    def d: D
+  }
+
+  val bc: B = new B {
+    def d: D = ???
+    private def pd: D = ???
+  }
+
+  val d: bc.D = bc.d
+  val pd: bc.D = bc.pd
+
+  // infinite loop in Typer
+  val asT: d.T = ???
+
+}

--- a/tests/pos/i39.scala
+++ b/tests/pos/i39.scala
@@ -1,0 +1,17 @@
+object i39 {
+
+  trait B {
+    type D <: { type T }
+    def d: D
+  }
+
+  val bc: B = new B {
+    def d: D = ???
+  }
+
+  val d: bc.D = bc.d
+
+  // infinite loop in Typer
+  val asT: d.T = ???
+
+}


### PR DESCRIPTION
Two fixes:
1) Avoid the infinite recursion in checkAccessible if the accessibility check fails.
2) Make accessibility succeed for the test, and in general if the target denotation does not have a symbol.

Added original test in pos and a negative test which makes accessibility fail.

Review by @DarkDimius, @samuelgruetter
