### PR TITLE
Fix of #50 - volatile

### DIFF
--- a/src/dotty/tools/dotc/config/Printers.scala
+++ b/src/dotty/tools/dotc/config/Printers.scala
@@ -14,6 +14,7 @@ object Printers {
   val core: Printer = noPrinter
   val typr: Printer = noPrinter
   val constr: Printer = noPrinter
+  val checks: Printer = noPrinter
   val overload: Printer = noPrinter
   val implicits: Printer = noPrinter
   val implicitsDetailed: Printer = noPrinter

--- a/src/dotty/tools/dotc/core/Flags.scala
+++ b/src/dotty/tools/dotc/core/Flags.scala
@@ -422,7 +422,7 @@ object Flags {
   final val RetainedTypeArgFlags = VarianceFlags | ExpandedName | Protected | Local
 
   /** Modules always have these flags set */
-  final val ModuleCreationFlags = ModuleVal
+  final val ModuleCreationFlags = ModuleVal | Final | Stable
 
   /** Module classes always have these flags set */
   final val ModuleClassCreationFlags = ModuleClass | Final

--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -355,7 +355,7 @@ object SymDenotations {
     final def isStable(implicit ctx: Context) = {
       val isUnstable =
         (this is UnstableValue) ||
-        info.isVolatile && !hasAnnotation(defn.uncheckedStableClass)
+        ctx.isVolatile(info) && !hasAnnotation(defn.uncheckedStableClass)
       (this is Stable) || isType || {
         if (isUnstable) false
         else { setFlag(Stable); true }

--- a/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/src/dotty/tools/dotc/core/TypeOps.scala
@@ -3,6 +3,8 @@ package core
 
 import Contexts._, Types._, Symbols._, Names._, Flags._, Scopes._
 import SymDenotations._
+import config.Printers._
+import Decorators._
 import util.SimpleMap
 
 trait TypeOps { this: Context =>
@@ -75,7 +77,12 @@ trait TypeOps { this: Context =>
   }
 
   final def isVolatile(tp: Type): Boolean = {
-    /** Pre-filter to avoid expensive DNF computation */
+
+    /** Pre-filter to avoid expensive DNF computation
+     *  If needsChecking returns false it is guaranteed that
+     *  DNF does not contain intersections, or abstract types with upper
+     *  bounds that themselves need checking.
+     */
     def needsChecking(tp: Type, isPart: Boolean): Boolean = tp match {
       case tp: TypeRef =>
         tp.info match {
@@ -88,30 +95,61 @@ trait TypeOps { this: Context =>
         needsChecking(tp.parent, true)
       case tp: TypeProxy =>
         needsChecking(tp.underlying, isPart)
-      case AndType(l, r) =>
-        needsChecking(l, true) || needsChecking(r, true)
-      case OrType(l, r) =>
-        isPart || needsChecking(l, isPart) && needsChecking(r, isPart)
+      case tp: AndType =>
+        true
+      case tp: OrType =>
+        isPart || needsChecking(tp.tp1, isPart) && needsChecking(tp.tp2, isPart)
       case _ =>
         false
     }
+
     needsChecking(tp, false) && {
-      tp.DNF forall { case (parents, refinedNames) =>
+      DNF(tp) forall { case (parents, refinedNames) =>
         val absParents = parents filter (_.symbol is Deferred)
-        absParents.size >= 2 || {
-          val ap = absParents.head
-          ((parents exists (p =>
-                (p ne ap)
-             || p.memberNames(abstractTypeNameFilter, tp).nonEmpty
-             || p.memberNames(abstractTermNameFilter, tp).nonEmpty))
-          || (refinedNames & tp.memberNames(abstractTypeNameFilter, tp)).nonEmpty
-          || (refinedNames & tp.memberNames(abstractTermNameFilter, tp)).nonEmpty
-          || isVolatile(ap)
-          )
+        absParents.nonEmpty && {
+          absParents.lengthCompare(2) >= 0 || {
+            val ap = absParents.head
+            ((parents exists (p =>
+              (p ne ap)
+              || p.memberNames(abstractTypeNameFilter, tp).nonEmpty
+              || p.memberNames(abstractTermNameFilter, tp).nonEmpty))
+            || (refinedNames & tp.memberNames(abstractTypeNameFilter, tp)).nonEmpty
+            || (refinedNames & tp.memberNames(abstractTermNameFilter, tp)).nonEmpty
+            || isVolatile(ap))
+          }
         }
       }
     }
   }
+
+  /** The disjunctive normal form of this type.
+   *  This collects a set of alternatives, each alternative consisting
+   *  of a set of typerefs and a set of refinement names. Both sets are represented
+   *  as lists, to obtain a deterministic order. Collected are
+   *  all type refs reachable by following aliases and type proxies, and
+   *  collecting the elements of conjunctions (&) and disjunctions (|).
+   *  The set of refinement names in each alternative
+   *  are the set of names in refinement types encountered during the collection.
+   */
+  final def DNF(tp: Type): List[(List[TypeRef], Set[Name])] = ctx.traceIndented(s"DNF($this)", checks) {
+    tp.dealias match {
+      case tp: TypeRef =>
+        (tp :: Nil, Set[Name]()) :: Nil
+      case RefinedType(parent, name) =>
+        for ((ps, rs) <- DNF(parent)) yield (ps, rs + name)
+      case tp: TypeProxy =>
+        DNF(tp.underlying)
+      case AndType(l, r) =>
+        for ((lps, lrs) <- DNF(l); (rps, rrs) <- DNF(r))
+          yield (lps | rps, lrs | rrs)
+      case OrType(l, r) =>
+        DNF(l) | DNF(r)
+      case tp =>
+        TypeOps.emptyDNF
+    }
+  }
+
+
 
   private def enterArgBinding(formal: Symbol, info: Type, cls: ClassSymbol, decls: Scope) = {
     val lazyInfo = new LazyType { // needed so we do not force `formal`.
@@ -215,6 +253,6 @@ trait TypeOps { this: Context =>
 }
 
 object TypeOps {
-
+  val emptyDNF = (Nil, Set[Name]()) :: Nil
   var track = false // !!!DEBUG
 }

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -265,11 +265,13 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
   def typedSelect(tree: untpd.Select, pt: Type)(implicit ctx: Context): Tree = track("typedSelect") {
     val qual1 = typedExpr(tree.qualifier, selectionProto(tree.name, pt, this))
+    if (tree.name.isTypeName) checkStable(qual1.tpe, qual1.pos)
     checkValue(assignType(cpy.Select(tree, qual1, tree.name), qual1), pt)
   }
 
   def typedSelectFromTypeTree(tree: untpd.SelectFromTypeTree, pt: Type)(implicit ctx: Context): SelectFromTypeTree = track("typedSelectFromTypeTree") {
     val qual1 = typedType(tree.qualifier, selectionProto(tree.name, pt, this))
+    checkLegalPrefix(qual1.tpe, qual1.pos)
     assignType(cpy.SelectFromTypeTree(tree, qual1, tree.name), qual1)
   }
 

--- a/src/dotty/tools/dotc/util/common.scala
+++ b/src/dotty/tools/dotc/util/common.scala
@@ -7,8 +7,6 @@ import core.Types.WildcardType
 /** Common values hoisted out for performance */
 object common {
 
-  val emptyDNF = (Nil, Set[Name]()) :: Nil
-
   val alwaysTrue = Function.const(true) _
   val alwaysZero = Function.const(0) _
   val alwaysWildcardType = Function.const(WildcardType) _

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -52,6 +52,7 @@ class tests extends CompilerTest {
   @Test def neg_rootImports = compileFile(negDir, "rootImplicits", xerrors = 2)
   @Test def neg_templateParents() = compileFile(negDir, "templateParents", xerrors = 3)
   @Test def neg_i39 = compileFile(negDir, "i39", xerrors = 1)
+  @Test def neg_i50_volatile = compileFile(negDir, "i50-volatile", xerrors = 4)
 
   @Test def dotc = compileDir(dotcDir + "tools/dotc")
   @Test def dotc_ast = compileDir(dotcDir + "tools/dotc/ast")

--- a/tests/neg/i50-volatile.scala
+++ b/tests/neg/i50-volatile.scala
@@ -1,0 +1,25 @@
+object Test {
+  class Base {
+    class Inner
+  }
+  type A <: Base {
+    type X = String
+  }
+  type B <: {
+    type X = Int
+  }
+  lazy val o: A & B = ???
+
+  class Client extends o.Inner
+
+  def xToString(x: o.X): String = x
+
+  def intToString(i: Int): String = xToString(i)
+}
+object Test2 {
+
+  import Test.o._
+
+  def xToString(x: X): String = x
+
+}


### PR DESCRIPTION
Volatile checking needs to take all intersections into account; previously these
could be discarded through needsChecking.

Plus several refactorings and additions.

1) Module vals now have Final and Stable flags set
2) All logic around isVolatile is now in TypeOps; some of it was moved from Types.
3) Added stability checking to Select and SelectFromType typings.

Todo: We should find a better name for isVolatile. Maybe define the negation instead under the name
"isRealizable"?.
