### PR TITLE
Silence unchecked warning

### DIFF
--- a/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -104,7 +104,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
         toTextPrefix(tp.prefix) ~ selectionString(tp)
       case tp: RefinedType =>
         // return tp.toString // !!! DEBUG
-        val parent :: (refined: List[RefinedType]) =
+        val parent :: (refined: List[RefinedType @unchecked]) =
           refinementChain(tp).reverse
         toTextLocal(parent) ~ "{" ~ Text(refined map toTextRefinement, "; ").close ~ "}"
       case AndType(tp1, tp2) =>


### PR DESCRIPTION
Was:

```
[warn] /Users/jason/code/dotty/src/dotty/tools/dotc/printing/PlainPrinter.scala:107: non-variable type argument dotty.tools.dotc.core.Types.RefinedType in type pattern List[dotty.tools.dotc.core.Types.RefinedType] is unchecked since it is eliminated by erasure
[warn]         val parent :: (refined: List[RefinedType]) =
[warn]                                 ^
```
