### PR TITLE
Bullet-proofing companionclass/module

### DIFF
--- a/src/dotty/tools/dotc/ast/untpd.scala
+++ b/src/dotty/tools/dotc/ast/untpd.scala
@@ -9,7 +9,7 @@ import Decorators._
 import language.higherKinds
 import collection.mutable.ListBuffer
 
-object untpd extends Trees.Instance[Untyped] with TreeInfo[Untyped] {
+object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
 // ----- Tree cases that exist in untyped form only ------------------
 

--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -22,7 +22,6 @@ import StdNames._
 import ProtoTypes._
 import EtaExpansion._
 import collection.mutable
-import reflect.ClassTag
 import config.Printers._
 import TypeApplications._
 import language.implicitConversions

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -98,9 +98,9 @@ class Namer { typer: Typer =>
 
   import untpd._
 
-  val TypedAhead = new Attachment.Key[tpd.Tree]
-  val ExpandedTree = new Attachment.Key[Tree]
-  val SymOfTree = new Attachment.Key[Symbol]
+  val TypedAhead = new TypedAheadKey
+  val ExpandedTree = new ExpandedTreeKey
+  val SymOfTree = new SymOfTreeKey
 
   /** A partial map from unexpanded member and pattern defs and to their expansions.
    *  Populated during enterSyms, emptied during typer.

--- a/src/dotty/tools/dotc/util/Attachment.scala
+++ b/src/dotty/tools/dotc/util/Attachment.scala
@@ -74,10 +74,10 @@ object Attachment {
       else nx.removeAttachment(key)
     }
 
-    /** The list of all values attached to this container. */
-    final def allAttachments: List[Any] = {
+    /** The list of all keys and values attached to this container. */
+    final def allAttachments: List[(Key[_], Any)] = {
       val nx = next
-      if (nx == null) Nil else nx.value :: nx.allAttachments
+      if (nx == null) Nil else (nx.key, nx.value) :: nx.allAttachments
     }
   }
 

--- a/tests/pos/companions.scala
+++ b/tests/pos/companions.scala
@@ -1,0 +1,14 @@
+object companions {
+
+  def foo() = {
+
+    class C {
+      println(C.p)
+    }
+
+    object C {
+      private val p = 1
+    }
+  }
+
+}


### PR DESCRIPTION
Companion class/module computations now also work for local classes and modules. It suffices that some enclosing
context refers to a tree that contains the companions.

The idea is that for local classes we locate companions by locating the statement sequence that defines
the local classes from the context. To be able to do this, the policy for managing Namer/Typer attachments
has changed: We now keep SymOfTree and ExpandedTree in untyped trees, so that we can map undtyped trees to the list of
symbols they define (note that during type-checking, contexts refer to untyped trees, not typed ones).

These attachments are retained only for untyped trees. If a tree has a type it will not have one of the namer/typer
attachments after type checking. To achieve this, there's a symGC method that gets rid of redundant SymOfTree attachments.
