### PR TITLE
Fixed two problems with annotated types in patterns

### DIFF
--- a/docs/SyntaxSummary.txt
+++ b/docs/SyntaxSummary.txt
@@ -191,13 +191,13 @@ grammar.
   CaseClause        ::=  `case' (Pattern [Guard] `=>' Block | INT)              CaseDef(pat, guard?, block)   // block starts at =>
 
   Pattern           ::=  Pattern1 { `|' Pattern1 }                              Alternative(pats)
-  Pattern1          ::=  PatVar `:' SimpleType                                  Bind(name, Typed(Ident(wildcard), tpe))
+  Pattern1          ::=  PatVar `:' RefinedType                                 Bind(name, Typed(Ident(wildcard), tpe))
                       |  Pattern2
   Pattern2          ::=  [varid `@'] InfixPattern                               Bind(name, pat)
   InfixPattern      ::=  SimplePattern { id [nl] SimplePattern }                InfixOp(pat, op, pat)
   SimplePattern     ::=  PatVar                                                 Ident(wildcard)
-                      |  Literal                                                Bind(name, Ident(wildcard))                      |  Literal
-                      |  `(' [Patterns] `)'                             Parens(pats) Tuple(pats)
+                      |  Literal                                                Bind(name, Ident(wildcard))
+                      |  `(' [Patterns] `)'                                     Parens(pats) Tuple(pats)
                       |  XmlPattern
                       |  SimplePattern1 [TypeArgs] [ArgumentPatterns]
   SimplePattern1    ::=  Path

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -810,7 +810,7 @@ object Parsers {
 
     def typeDependingOn(location: Location.Value): Tree =
       if (location == Location.InParens) typ()
-      else if (location == Location.InPattern) withType()
+      else if (location == Location.InPattern) refinedType()
       else infixType()
 
 /* ----------- EXPRESSIONS ------------------------------------------------ */

--- a/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -103,8 +103,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case tp: TypeRef =>
         toTextPrefix(tp.prefix) ~ selectionString(tp)
       case tp: RefinedType =>
-        // return tp.toString // !!! DEBUG
-        val parent :: (refined: List[RefinedType]) =
+        val parent :: (refined: List[RefinedType @unchecked]) =
           refinementChain(tp).reverse
         toTextLocal(parent) ~ "{" ~ Text(refined map toTextRefinement, "; ").close ~ "}"
       case AndType(tp1, tp2) =>

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -826,7 +826,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   def typedAnnotated(tree: untpd.Annotated, pt: Type)(implicit ctx: Context): Tree = track("typedAnnotated") {
-    val annot1 = typed(tree.annot, defn.AnnotationClass.typeRef)
+    val annot1 = typedExpr(tree.annot, defn.AnnotationClass.typeRef)
     val arg1 = typed(tree.arg, pt)
     if (ctx.mode is Mode.Type)
       assignType(cpy.Annotated(tree, annot1, arg1), annot1, arg1)

--- a/tests/pos/Patterns.scala
+++ b/tests/pos/Patterns.scala
@@ -10,17 +10,23 @@ object Patterns {
     case (digit, str) => true
     case _ => false
   }
-  
+
+  (xs: Any) match {
+    case x: Int @unchecked => true
+    case xs: List[Int @ unchecked] => true
+    case _ => false
+  }
+
   def sum(xs: List[Int]): Int = xs match {
     case Nil => 0
     case x :: xs1 => x + sum(xs1)
   }
-  
+
   def len[T](xs: List[T]): Int = xs match {
     case _ :: xs1 => 1 + len(xs1)
     case Nil => 0
   }
-  
+
   final def sameLength[T](xs: List[T], ys: List[T]): Boolean = xs match {
     case _ :: xs1 =>
       ys match {


### PR DESCRIPTION
Problem 1: The parser did not accept them. It has to accept a "RefinedType" as an ascription,
not a "WithType" (as it did before), or even a "SimpleType" (as speced in the SyntaxSummary).

Problem 2: Annotations are always typed as expressions. The annotations in question were typed
as patterns before.

Tests in Patterns.scala and in the Dotty compiler itself.
