### PR TITLE
Update to Scala 2.11.0-RC3.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 name := "dotty"
 
-scalaVersion in Global := "2.11.0-M7"
+scalaVersion in Global := "2.11.0-RC3"
 
 version in Global := "0.1-SNAPSHOT"
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,7 +25,7 @@ object DottyBuild extends Build {
     
     // get reflect and xml onboard
     libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value,
-                                "org.scala-lang.modules" %% "scala-xml" % "1.0.0-RC7"),
+                                "org.scala-lang.modules" %% "scala-xml" % "1.0.1"),
 
     // get junit onboard
     libraryDependencies += "com.novocode" % "junit-interface" % "0.9" % "test",


### PR DESCRIPTION
This was needed for running dotc.Main using latest Scala IDE 2.11 release.
