### PR TITLE
Bridge generation in erasure implemented.

### DIFF
--- a/tests/pos/Bridges.scala
+++ b/tests/pos/Bridges.scala
@@ -1,0 +1,11 @@
+abstract class X[T]{
+  def go2(x:T)(y:T = x): T = y
+  def go: T 
+  def go1(x: T) = x
+}
+
+class Y extends X[Int] {
+  override def go2(x: Int)(z: Int) = 2
+  override def go = 0
+  override def go1(x: Int) = x
+}


### PR DESCRIPTION
Relies on meaning of `Symbol.overriddenSymbol` to see which bridges are required.
Doesn't take in account value classes for now
Uses 'adapt' used by erasure for converting arguments and return value.
