### PR TITLE
Reduce verbosity of logs.

### DIFF
--- a/src/dotty/tools/dotc/transform/Splitter.scala
+++ b/src/dotty/tools/dotc/transform/Splitter.scala
@@ -20,7 +20,7 @@ class Splitter extends TreeTransform {
   /** Replace self referencing idents with ThisTypes. */
   override def transformIdent(tree: Ident)(implicit ctx: Context, info: TransformerInfo) = tree.tpe match {
     case ThisType(cls) =>
-      println(s"owner = ${ctx.owner}, context = ${ctx}")
+      ctx.debuglog(s"owner = ${ctx.owner}, context = ${ctx}")
       This(cls) withPos tree.pos
     case _ => tree
   }

--- a/test/test/DottyTest.scala
+++ b/test/test/DottyTest.scala
@@ -22,18 +22,17 @@ class DottyTest {
     val base = new ContextBase
     import base.settings._
     val ctx = base.initialCtx.fresh
-      .setSetting(verbose, true)
+      //.setSetting(verbose, true)
       //      .withSetting(debug, true)
       //      .withSetting(debugTrace, true)
       //      .withSetting(prompt, true)
-      .setSetting(Ylogcp, true)
+      //.setSetting(Ylogcp, true)
       .setSetting(printtypes, true)
       .setSetting(pageWidth, 90)
       .setSetting(log, List("<some"))
     //   .withTyperState(new TyperState(new ConsoleReporter()(base.initialCtx)))
 
     //      .withSetting(uniqid, true)
-    println(ctx.settings)
     base.definitions.init(ctx)
     ctx
   }

--- a/test/test/ShowClassTests.scala
+++ b/test/test/ShowClassTests.scala
@@ -13,7 +13,7 @@ import org.junit.Test
 class ShowClassTests extends DottyTest {
 
   def debug_println(msg: => Any) = {
-    if (!sys.props.isDefinedAt("dotty.travis.build"))
+    if (sys.props.isDefinedAt("test.ShowClassTests.verbose"))
       println(msg)
   }
 

--- a/test/test/transform/CreateCompanionObjectsTest.scala
+++ b/test/test/transform/CreateCompanionObjectsTest.scala
@@ -37,7 +37,6 @@ class CreateCompanionObjectsTest extends DottyTest {
         override def name: String = "test"
       }
       val transformed = transformer.transform(tree).toString
-      println(transformed)
       val classPattern = "TypeDef(Modifiers(,,List()),A,"
       val classPos = transformed.indexOf(classPattern)
       val moduleClassPattern = "TypeDef(Modifiers(final module <synthetic>,,List()),A$"


### PR DESCRIPTION
We are already over limit on output size imposed by travis that is shown
in webpage, if we'll continue to add tests will be soon over limit even
to run builds.

This commit disables printing of classpath, and removes printlns in
several places.
In order for ShowClassTests to print info as is was printing
previously, please set "test.ShowClassTests.verbose" property.
