### PR TITLE
Allow phases to give restrictions on pipeline position.

### DIFF
--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -25,6 +25,9 @@ class Erasure extends Phase with DenotTransformer {
 
   override def name: String = "erasure"
 
+  /** List of names of phases that should precede this phase */
+  override def runsAfter: Set[String] = Set("typeTestsCasts", "intercepted", "splitter")
+
   def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation = ref match {
     case ref: SymDenotation =>
       assert(ctx.phase == this, s"transforming $ref at ${ctx.phase}")

--- a/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -63,6 +63,17 @@ class LazyValTranformContext {
 
     override def name: String = "LazyVals"
 
+    /** List of names of phases that should have finished their processing of all compilation units
+      * before this phase starts */
+    override def runsAfterGroupsOf: Set[String] = Set("lazyValsModules")
+    /** List of names of phases that should have finished their processing of all compilation units
+      * before this phase starts */
+    override def runsAfter: Set[String] = Set("lazyValsModules")
+
+    /** List of names of phases that should have finished processing of tree
+      * before this phase starts processing same tree */
+    // override def ensureAfter: Set[String] = Set("mixin")
+
     def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation = {
       ref match {
         case ref: SymDenotation if ref.symbol.isClass =>

--- a/src/dotty/tools/dotc/transform/TreeTransform.scala
+++ b/src/dotty/tools/dotc/transform/TreeTransform.scala
@@ -51,6 +51,10 @@ object TreeTransforms {
     /** id of this treeTransform in group */
     var idx: Int = _
 
+    /** List of names of phases that should have finished their processing of all compilation units
+      * before this phase starts */
+    def runsAfterGroupsOf: Set[String] = Set.empty
+
     def prepareForIdent(tree: Ident)(implicit ctx: Context) = this
     def prepareForSelect(tree: Select)(implicit ctx: Context) = this
     def prepareForThis(tree: This)(implicit ctx: Context) = this


### PR DESCRIPTION
Phases can now specify which phases should it precede and follow.
Tree transforms can additionally specify which TreeTransforms
should have finished their processing of compilation units entirely.
