### PR TITLE
Install method for SymDenotations

### DIFF
--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -752,7 +752,7 @@ object SymDenotations {
 
     def debugString = toString+"#"+symbol.id // !!! DEBUG
 
-    // ----- copies ------------------------------------------------------
+    // ----- copies and transforms  ----------------------------------------
 
     protected def newLikeThis(s: Symbol, i: Type): SingleDenotation = new UniqueRefDenotation(s, i, validFor)
 
@@ -774,6 +774,10 @@ object SymDenotations {
       d.annotations = annotations1
       d
     }
+
+    /** Install this denotation as the result of the given denotation transformer. */
+    override def installAfter(phase: DenotTransformer)(implicit ctx: Context): Unit =
+      super.installAfter(phase)
   }
 
   /** The contents of a class definition during a period


### PR DESCRIPTION
Add a new method to install a SymDenotation after a specific
phase has run. The new denotation replaces the current denotation
of the symbol starting with the period after the given phase.
