### PR TITLE
Fixing prefix of implicit members

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -449,7 +449,7 @@ object Types {
     final def implicitMembers(implicit ctx: Context): List[TermRef] = track("implicitMembers") {
       memberDenots(implicitFilter,
           (name, buf) => buf ++= member(name).altsWith(_ is Implicit))
-        .toList.map(_.termRefWithSig)
+        .toList.map(d => TermRef.withSig(this, d.symbol.asTerm))
     }
 
     /** The info of `sym`, seen as a member of this type. */
@@ -1311,7 +1311,7 @@ object Types {
       if (prefix eq NoPrefix) withNonMemberSym(prefix, name, sym)
       else {
         if (sym.defRunId != NoRunId && sym.isCompleted) withSig(prefix, name, sym.signature)
-        else  apply(prefix, name)
+        else apply(prefix, name)
       } withSym (sym, Signature.NotAMethod)
 
     def withSig(prefix: Type, sym: TermSymbol)(implicit ctx: Context): TermRef =

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -54,13 +54,14 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   }
 
   override def toTextPrefix(tp: Type): Text = controlled {
+    def isOmittable(sym: Symbol) = isOmittablePrefix(sym) && !ctx.settings.verbose.value
     tp match {
       case ThisType(cls) =>
-        if (isOmittablePrefix(cls)) return ""
+        if (isOmittable(cls)) return ""
       case tp @ TermRef(pre, _) =>
         val sym = tp.symbol
         if (sym.isPackageObject) return toTextPrefix(pre)
-        if (isOmittablePrefix(sym)) return ""
+        if (isOmittable(sym)) return ""
       case _ =>
     }
     super.toTextPrefix(tp)

--- a/tests/pos/implicits2.scala
+++ b/tests/pos/implicits2.scala
@@ -1,0 +1,19 @@
+/* Compile with
+
+    dotc implicits2.scala -Xprint:front -Xprint-types -verbose
+
+    and verify that the inserted wrapString comes from Predef. You should see
+
+    val x: <root>.scala.collection.immutable.WrappedString =
+      <
+        <scala.Predef.wrapString:
+          ((s: java.lang.String)scala.collection.immutable.WrappedString)
+        >
+      (<"abc":java.lang.String("abc")>):scala.collection.immutable.WrappedString
+        >
+*/
+object implicits2 {
+
+  val x: scala.collection.immutable.WrappedString = "abc"
+
+}


### PR DESCRIPTION
Implicit members are TermRefs that should have a prefix corresponding to the object of which they are a member. They used to have the ThisType of their owner before.

`implicits2` provides a way to verify that the change works. It would be good to turn this
into a more robust test at some point.  But it's not high preiority, so I prefer no test to a fragile test.
