### PR TITLE
Warn if cast between incompatible primitive types

### DIFF
--- a/src/dotty/tools/dotc/ast/tpd.scala
+++ b/src/dotty/tools/dotc/ast/tpd.scala
@@ -434,7 +434,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       tree
     else {
       ctx.warning(i"conversion from ${tree.tpe.widen} to ${numericCls.typeRef} will always fail at runtime.")
-      Throw(New(defn.ClassCastExceptionClass.typeRef, Nil)) withPos tree.pos
+      // primary constructor of ClassCastException wants a message
+      val msg = i"${tree.tpe.widen} cannot be cast to ${numericCls.typeRef}"
+      Throw(New(defn.ClassCastExceptionClass.typeRef, Literal(Constant(msg)) :: Nil)) withPos tree.pos
     }
   }
 

--- a/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -36,7 +36,7 @@ class TypeTestsCasts extends TreeTransform {
         def derivedTree(qual1: Tree, sym: Symbol, tp: Type) =
           cpy.TypeApply(tree, Select(qual1, sym) withPos qual.pos, List(TypeTree(tp)))
 
-        def qualCls = qual.tpe.classSymbol
+        def qualCls = qual.tpe.widen.classSymbol
 
         def transformIsInstanceOf(expr:Tree, argType: Type): Tree = {
           if (expr.tpe <:< argType)

--- a/tests/pos/Unit2Char.scala
+++ b/tests/pos/Unit2Char.scala
@@ -1,0 +1,7 @@
+object Unit2Char extends App {
+  val y: Unit = ()
+  // Will throw java.lang.ClassCastException: scala.runtime.BoxedUnit cannot be cast to java.lang.Character
+  // Should emit warning at compile time
+  val x: Char = y.asInstanceOf[Char]
+  println("cast was successful: " + x) // will not happen
+}


### PR DESCRIPTION
When I try to cast Unit to Char, I should get a warning at compile time:

``` scala
object Unit2Char extends App {
  val y: Unit = ()
  // Will throw java.lang.ClassCastException: scala.runtime.BoxedUnit cannot be cast to java.lang.Character
  // Should emit warning at compile time
  val x: Char = y.asInstanceOf[Char]
  println("cast was successful: " + x) // will not happen
}
```

There is already code for this in TypeTestsCasts and in tpd.primitiveConversion, but it never prints the expected warning. This PR fixes that.
