### PR TITLE
Fix of FullParameterization

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -832,6 +832,10 @@ object Types {
     final def substThis(cls: ClassSymbol, tp: Type)(implicit ctx: Context): Type =
       ctx.substThis(this, cls, tp, null)
 
+    /** As substThis, but only is class is a static owner (i.e. a globally accessible object) */
+    final def substThisUnlessStatic(cls: ClassSymbol, tp: Type)(implicit ctx: Context): Type =
+      if (cls.isStaticOwner) this else ctx.substThis(this, cls, tp, null)
+
     /** Substitute all occurrences of `RefinedThis(rt)` by `tp` */
     final def substThis(rt: RefinedType, tp: Type)(implicit ctx: Context): Type =
       ctx.substThis(this, rt, tp, null)

--- a/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -98,7 +98,7 @@ trait FullParameterization {
     def resultType(mapClassParams: Type => Type) = {
       val thisParamType = mapClassParams(clazz.classInfo.selfType)
       MethodType(nme.SELF :: Nil, thisParamType :: Nil)(mt =>
-        mapClassParams(origResult).substThis(clazz, MethodParam(mt, 0)))
+        mapClassParams(origResult).substThisUnlessStatic(clazz, MethodParam(mt, 0)))
     }
 
     /** Replace class type parameters by the added type parameters of the polytype `pt` */
@@ -203,7 +203,7 @@ trait FullParameterization {
         typeMap = rewireType(_)
           .subst(origTParams, trefs)
           .subst(origVParams, argRefs.map(_.tpe))
-          .substThis(origClass, thisRef.tpe),
+          .substThisUnlessStatic(origClass, thisRef.tpe),
         ownerMap = (sym => if (sym eq origMeth) derived else sym),
         treeMap = {
           case tree: This if tree.symbol == origClass => thisRef


### PR DESCRIPTION
Avoid substitituting A.this if A is a globally accesible module. Review by @DarkDimius 
