### PR TITLE
Added elimLocals miniphase

### DIFF
--- a/src/dotty/tools/dotc/Compiler.scala
+++ b/src/dotty/tools/dotc/Compiler.scala
@@ -22,7 +22,7 @@ class Compiler {
       List(new Companions),
       List(new SuperAccessors),
       // pickling and refchecks goes here
-      List(new ElimRepeated/*, new ElimLocals*/),
+      List(new ElimRepeated, new ElimLocals),
       List(new ExtensionMethods),
       List(new TailRec),
       List(new PatternMatcher,

--- a/src/dotty/tools/dotc/ElimLocals.scala
+++ b/src/dotty/tools/dotc/ElimLocals.scala
@@ -2,12 +2,21 @@ package dotty.tools.dotc
 package transform
 
 import core._
-import TreeTransforms.{TransformerInfo, TreeTransform, TreeTransformer}
-import DenotTransformers._
+import DenotTransformers.SymTransformer
+import Phases.Phase
+import Contexts.Context
+import SymDenotations.SymDenotation
+import TreeTransforms.TreeTransform
+import Flags.Local
 
 /** Widens all private[this] and protected[this] qualifiers to just private/protected */
-abstract class ElimLocals extends TreeTransform with InfoTransformer { thisTransformer =>
+class ElimLocals extends TreeTransform with SymTransformer { thisTransformer =>
+  override def name = "elimlocals"
 
-  // TODO complete
+  def transformSym(ref: SymDenotation)(implicit ctx: Context) =
+    dropLocal(ref)
 
+  private def dropLocal(ref: SymDenotation)(implicit ctx: Context) =
+    if (ref.flags is Local) ref.copySymDenotation(initFlags = ref.flags &~ Local)
+    else ref
 }

--- a/src/dotty/tools/dotc/core/DenotTransformers.scala
+++ b/src/dotty/tools/dotc/core/DenotTransformers.scala
@@ -32,11 +32,11 @@ object DenotTransformers {
     def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation
   }
 
+  /** A transformer that only transforms the info field of denotations */
   trait InfoTransformer extends DenotTransformer {
 
     def transformInfo(tp: Type, sym: Symbol)(implicit ctx: Context): Type
 
-    /** The transformation method */
     def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation = {
       val info1 = transformInfo(ref.info, ref.symbol)
       if (info1 eq ref.info) ref
@@ -44,6 +44,17 @@ object DenotTransformers {
         case ref: SymDenotation => ref.copySymDenotation(info = info1)
         case _ => ref.derivedSingleDenotation(ref.symbol, info1)
       }
+    }
+  }
+
+  /** A transformer that only transforms SymDenotations */
+  trait SymTransformer extends DenotTransformer {
+
+    def transformSym(sym: SymDenotation)(implicit ctx: Context): SymDenotation
+
+    def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation = ref match {
+      case ref: SymDenotation => transformSym(ref)
+      case _ => ref
     }
   }
 

--- a/src/dotty/tools/dotc/transform/Companions.scala
+++ b/src/dotty/tools/dotc/transform/Companions.scala
@@ -14,8 +14,7 @@ import Names.Name
 import NameOps._
 
 
-/** A transformer that provides a convenient way to create companion objects
-  */
+/** A transformer that creates companion objects for all classes except module classes. */
 class Companions extends TreeTransform with IdentityDenotTransformer { thisTransformer =>
   import ast.tpd._
 

--- a/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -66,4 +66,6 @@ class ReTyper extends Typer {
 
   override def addTypedModifiersAnnotations(mods: untpd.Modifiers, sym: Symbol)(implicit ctx: Context): Modifiers =
     typedModifiers(mods, sym)
+
+  override def checkVariance(tree: Tree)(implicit ctx: Context) = ()
 }

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -844,7 +844,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     checkNoDoubleDefs(cls)
     val impl1 = cpy.Template(impl, constr1, parents1, self1, body1)
       .withType(dummy.termRef)
-    VarianceChecker.check(impl1)
+    checkVariance(impl1)
     assignType(cpy.TypeDef(cdef, mods1, name, impl1), cls)
 
     // todo later: check that
@@ -855,6 +855,9 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     // 3. Types do not override classes.
     // 4. Polymorphic type defs override nothing.
   }
+
+  /** Overridden in retyper */
+  def checkVariance(tree: Tree)(implicit ctx: Context) = VarianceChecker.check(tree)
 
   def localDummy(cls: ClassSymbol, impl: untpd.Template)(implicit ctx: Context): Symbol =
     ctx.newLocalDummy(cls, impl.pos)


### PR DESCRIPTION
This phase drops the Local flag from all private[this] and protected[this] members.
This allows subsequent code motions where code is moved from a class to its
companion object. It invalidates variance checking, which is consequently disabled
when retyping.
