### PR TITLE
Fix #196. Errorneus tail-optimization of inner DefDef's

### DIFF
--- a/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/src/dotty/tools/dotc/transform/TailRec.scala
@@ -311,7 +311,8 @@ class TailRec extends MiniPhaseTransform with DenotTransformer with FullParamete
 
         case Return(expr, from) =>
           tpd.cpy.Return(tree)(noTailTransform(expr), from)
-
+        case t: DefDef =>
+          t // todo: could improve to handle DefDef's with a label flag calls to which are in tail position
         case _ =>
           super.transform(tree)
       }


### PR DESCRIPTION
Unless a DefDef is a result of desugaring an exception handler it shouldn't be optimized by tailrec.

There's a potential improvement here: to detect that a DefDef
 is a label def which itself is called only in tail position.

 This is a requirement to implement #194
