### PR TITLE
TreeTransforms.init that returns a TreeTransform

### DIFF
--- a/src/dotty/tools/dotc/transform/CapturedVars.scala
+++ b/src/dotty/tools/dotc/transform/CapturedVars.scala
@@ -44,8 +44,10 @@ class CapturedVars extends MiniPhaseTransform with SymTransformer { thisTransfor
     }
   }
 
-  override def init(implicit ctx: Context, info: TransformerInfo): Unit =
+  override def init(transforms: Array[TreeTransform])(implicit ctx: Context) = {
     (new CollectCaptured)(ctx.withPhase(thisTransform)).runOver(ctx.compilationUnit.tpdTree)
+    this
+  }
 
   override def transformSym(sd: SymDenotation)(implicit ctx: Context): SymDenotation =
     if (captured(sd.symbol)) {

--- a/src/dotty/tools/dotc/transform/CollectEntryPoints.scala
+++ b/src/dotty/tools/dotc/transform/CollectEntryPoints.scala
@@ -26,9 +26,10 @@ import dotty.tools.dotc.config.JavaPlatform
 class CollectEntryPoints extends MiniPhaseTransform {
 
   /** perform context-dependant initialization */
-  override def init(implicit ctx: Context, info: TransformerInfo): Unit = {
+  override def init(transforms: Array[TreeTransform])(implicit ctx: Context) = {
     entryPoints = collection.immutable.TreeSet.empty[Symbol](new SymbolOrdering())
     assert(ctx.platform.isInstanceOf[JavaPlatform], "Java platform specific phase")
+    this
   }
 
   private var entryPoints: Set[Symbol] = _

--- a/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -53,11 +53,12 @@ class InterceptedMethods extends MiniPhaseTransform {
   private var primitiveGetClassMethods: Set[Symbol] = _
 
   /** perform context-dependant initialization */
-  override def init(implicit ctx: Context, info: TransformerInfo): Unit = {
+  override def init(transforms: Array[TreeTransform])(implicit ctx: Context) = {
     poundPoundMethods = Set(defn.Any_##)
     Any_comparisons = Set(defn.Any_==, defn.Any_!=)
     interceptedMethods = poundPoundMethods ++ Any_comparisons
     primitiveGetClassMethods = Set[Symbol]() ++ defn.ScalaValueClasses.map(x => x.requiredMethod(nme.getClass_))
+    this
   }
 
   // this should be removed if we have guarantee that ## will get Apply node

--- a/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -278,7 +278,7 @@ class LambdaLift extends MiniPhaseTransform with IdentityDenotTransformer { this
     }
   }
 
-  override def init(implicit ctx: Context, info: TransformerInfo) = {
+  override def init(transforms: Array[TreeTransform])(implicit ctx: Context) = {
     free.clear()
     proxyMap.clear()
     called.clear()
@@ -291,6 +291,7 @@ class LambdaLift extends MiniPhaseTransform with IdentityDenotTransformer { this
     computeLiftedOwners()
     generateProxies()(ctx.withPhase(thisTransform.next))
     liftLocals()(ctx.withPhase(thisTransform.next))
+    this
   }
 
   private def currentEnclosure(implicit ctx: Context) =

--- a/src/dotty/tools/dotc/transform/SyntheticMethods.scala
+++ b/src/dotty/tools/dotc/transform/SyntheticMethods.scala
@@ -39,9 +39,10 @@ class SyntheticMethods extends MiniPhaseTransform with IdentityDenotTransformer 
   private var valueSymbols: List[Symbol] = _
   private var caseSymbols: List[Symbol] = _
 
-  override def init(implicit ctx: Context, info: TransformerInfo) = {
+  override def init(transforms: Array[TreeTransform])(implicit ctx: Context) = {
     valueSymbols = List(defn.Any_hashCode, defn.Any_equals)
     caseSymbols = valueSymbols ++ List(defn.Any_toString, defn.Product_canEqual, defn.Product_productArity)
+    this
   }
 
   /** The synthetic methods of the case or value class `clazz`.

--- a/src/dotty/tools/dotc/transform/TreeTransform.scala
+++ b/src/dotty/tools/dotc/transform/TreeTransform.scala
@@ -140,7 +140,7 @@ object TreeTransforms {
     }
 
     /** perform context-dependant initialization */
-    def init(implicit ctx: Context, info: TransformerInfo): Unit = {}
+    def init(transforms: Array[TreeTransform])(implicit ctx: Context): TreeTransform = this
   }
 
   /** A phase that defines a TreeTransform to be used in a group */
@@ -520,12 +520,9 @@ object TreeTransforms {
 
     def transform(t: Tree)(implicit ctx: Context): Tree = {
       val initialTransformations = transformations
-      val info = new TransformerInfo(initialTransformations, new NXTransformations(initialTransformations), this)
-      initialTransformations.zipWithIndex.foreach {
-        case (transform, id) =>
-          transform.idx = id
-          transform.init(ctx, info)
-      }
+      val actualTransformations = initialTransformations.map(_.init(initialTransformations))
+      val info = new TransformerInfo(actualTransformations, new NXTransformations(actualTransformations), this)
+
       transform(t, info, 0)
     }
 


### PR DESCRIPTION
Helps with cleaning up per-run storage inside TreeTransforms.
@odersky please review.
