### PR TITLE
Scopes: make sure every bucket of the hash table is used

### DIFF
--- a/src/dotty/tools/dotc/core/Scopes.scala
+++ b/src/dotty/tools/dotc/core/Scopes.scala
@@ -28,9 +28,11 @@ object Scopes {
   private final val FillFactor = 2.0/3.0
 
   /** A hashtable is created once current size exceeds MinHash * FillFactor
-   *  The initial hash table has twice that size (i.e 24).
+   *  The initial hash table has twice that size (i.e 16).
+   *  This value must be a power of two, so that the index of an element can
+   *  be computed as element.hashCode & (hashTable.length - 1)
    */
-  private final val MinHash = 12
+  private final val MinHash = 8
 
   /** The maximal permissible number of recursions when creating
    *  a hashtable


### PR DESCRIPTION
Previously, one bucket was never used because in binary,
12*2^n - 1 = 101111...

Review by @odersky @namin .
