### PR TITLE
Add option to optimize the JVM for short-runnning applications

### DIFF
--- a/bin/dotc
+++ b/bin/dotc
@@ -185,6 +185,9 @@ case "$1" in
     -d|-debug) debug=true && shift ;;
     -q|-quiet) quiet=true && shift ;;
 
+    # Optimize for short-running applications, see https://github.com/lampepfl/dotty/issues/222
+    -Oshort) addJava "-XX:+TieredCompilation -XX:TieredStopAtLevel=1" && shift ;;
+
         -repl) main_class=$ReplMain && shift ;;
      -compile) main_class=$CompilerMain && shift ;;
          -run) main_class=$ReplMain && shift ;;

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -68,7 +68,14 @@ object DottyBuild extends Build {
          else
            List()
 
-      agentOptions ::: travis_build ::: fullpath
+       val tuning =
+         if (sys.props.isDefinedAt("Oshort"))
+           // Optimize for short-running applications, see https://github.com/lampepfl/dotty/issues/222
+           List("-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1")
+        else
+          List()
+
+      tuning ::: agentOptions ::: travis_build ::: fullpath
     }
   )
 


### PR DESCRIPTION
Ideally, dotc should reuse a resident compiler and we should not fork sbt
for every task. Until this happens, this option is useful for
development. Fixes #222.

Usage:
$ sbt -DOshort=""
$ ./bin/dotc -Oshort foo.scala

Review by @DarkDimius @odersky @namin .
