### PR TITLE
Allow refinements that refine already refined types.

### DIFF
--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -756,7 +756,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
   def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(implicit ctx: Context): RefinedTypeTree = track("typedRefinedTypeTree") {
     val tpt1 = if (tree.tpt.isEmpty) TypeTree(defn.ObjectType) else typedAheadType(tree.tpt)
-    val refineClsDef = desugar.refinedTypeToClass(tree)
+    val refineClsDef = desugar.refinedTypeToClass(tpt1, tree.refinements)
     val refineCls = createSymbol(refineClsDef).asClass
     val TypeDef(_, Template(_, _, _, refinements1)) = typed(refineClsDef)
     assert(tree.refinements.length == refinements1.length, s"${tree.refinements} != $refinements1")

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -106,6 +106,7 @@ class tests extends CompilerTest {
   @Test def neg_t1569_failedAvoid = compileFile(negDir, "t1569-failedAvoid", xerrors = 1)
   @Test def neg_cycles = compileFile(negDir, "cycles", xerrors = 8)
   @Test def neg_boundspropagation = compileFile(negDir, "boundspropagation", xerrors = 4)
+  @Test def neg_refinedSubtyping = compileFile(negDir, "refinedSubtyping", xerrors = 2)
 
   @Test def dotc = compileDir(dotcDir + "tools/dotc", twice)(allowDeepSubtypes)
   @Test def dotc_ast = compileDir(dotcDir + "tools/dotc/ast", twice)

--- a/tests/neg/refinedSubtyping.scala
+++ b/tests/neg/refinedSubtyping.scala
@@ -1,0 +1,23 @@
+// tests that a refinement subtype satisfies all constraint
+// of its refinemen supertype
+class Test3 {
+
+  trait A
+  trait B
+
+  class C { type T }
+
+  type T1 = C { type T <: A }
+  type T2 = T1 { type T <: B }
+
+  type U1 = C { type T <: B }
+  type U2 = C { type T <: A }
+
+  var x: T2 = _
+  val y1: U1 = ???
+  val y2: U2 = ???
+
+  x = y1 // error
+  x = y2 // error
+
+}

--- a/tests/pos/refinedSubtyping.scala
+++ b/tests/pos/refinedSubtyping.scala
@@ -17,3 +17,46 @@ class Test {
   y = x
 
 }
+
+class Test2 {
+
+  trait A
+  trait B
+
+  class C { type T }
+
+  type T1 = C { type T <: A } { type T <: B }
+
+  type U1 = C { type T <: B } { type T <: A }
+
+  var x: T1 = _
+  var y: U1 = _
+
+  x = y
+  y = x
+}
+
+
+class Test3 {
+
+  trait A
+  trait B
+
+  class C { type T }
+
+  type T1 = C { type T <: A }
+  type T2 = T1 { type T <: B }
+
+  type U1 = C { type T <: B }
+  type U2 = U1 { type T <: A }
+
+  var x: T2 = _
+  var y: U2 = _
+
+  val x1 = x
+  val y1 = y
+
+  x = y
+  y = x
+
+}


### PR DESCRIPTION
Previously, a double definition errorfor `T` was produced in a case like this:

```
 type T1 = C { T <: A }
 type T2 = T1 { T <: B }
```

This was caused by the way T1 was treated in the refinement class
that is used to typecheck the type. Desugaring of T2 with `refinedTypeToClass`
would give

```
 trait <refinement> extends T1 { type T <: B }
```

and `normalizeToClassRefs` would transform this to:

```
 trait <refinement> extends C { type T <: A; type T <: B }
```

Hence the double definition. The new scheme desugars the rhs of `T2` to:

```
 trait <refinement> extends C { this: T1 => type T <: B }
```

which avoids the problem.

Also, added tests that #232 (fix/boundsPropagation) indeed considers all refinements
together when comparing refined types.

Supersedes #243. Review by @retronym please.
