### PR TITLE
Changes in array creation scheme

### DIFF
--- a/src/dotty/runtime/Arrays.scala
+++ b/src/dotty/runtime/Arrays.scala
@@ -1,0 +1,17 @@
+package dotty.runtime
+
+import scala.reflect.ClassTag
+
+object Arrays {
+  def newGenericArray[T](length: Int)(implicit tag: ClassTag[T]): Array[T] = tag.newArray(length)
+  def newRefArray[T](length: Int): Array[T] = ???
+  def newByteArray(length: Int): Array[Byte] = ???
+  def newShortArray(length: Int): Array[Short] = ???
+  def newCharArray(length: Int): Array[Char] = ???
+  def newIntArray(length: Int): Array[Int] = ???
+  def newLongArray(length: Int): Array[Long] = ???
+  def newFloatArray(length: Int): Array[Float] = ???
+  def newDoubleArray(length: Int): Array[Double] = ???
+  def newBooleanArray(length: Int): Array[Boolean] = ???
+  def newUnitArray(length: Int): Array[Unit] = ???
+}

--- a/src/dotty/tools/dotc/core/Contexts.scala
+++ b/src/dotty/tools/dotc/core/Contexts.scala
@@ -120,7 +120,7 @@ object Contexts {
     protected def scope_=(scope: Scope) = _scope = scope
     def scope: Scope = _scope
 
-    /** The current type assigner ot typer */
+    /** The current type assigner or typer */
     private[this] var _typeAssigner: TypeAssigner = _
     protected def typeAssigner_=(typeAssigner: TypeAssigner) = _typeAssigner = typeAssigner
     def typeAssigner: TypeAssigner = _typeAssigner

--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -193,6 +193,7 @@ class Definitions {
     def staticsMethod(name: PreName) = ctx.requiredMethod(ScalaStaticsClass, name)
 
   lazy val DottyPredefModule = ctx.requiredModule("dotty.DottyPredef")
+  lazy val DottyArraysModule = ctx.requiredModule("dotty.runtime.Arrays")
   lazy val NilModule = ctx.requiredModule("scala.collection.immutable.Nil")
   lazy val PredefConformsClass = ctx.requiredClass("scala.Predef." + tpnme.Conforms)
 
@@ -211,6 +212,7 @@ class Definitions {
     lazy val Array_update                = ctx.requiredMethod(ArrayClass, nme.update)
     lazy val Array_length                = ctx.requiredMethod(ArrayClass, nme.length)
     lazy val Array_clone                 = ctx.requiredMethod(ArrayClass, nme.clone_)
+    lazy val ArrayConstructor            = ctx.requiredMethod(ArrayClass, nme.CONSTRUCTOR)
   lazy val traversableDropMethod  = ctx.requiredMethod(ScalaRuntimeClass, nme.drop)
   lazy val uncheckedStableClass: ClassSymbol = ctx.requiredClass("scala.annotation.unchecked.uncheckedStable")
 

--- a/src/dotty/tools/dotc/core/NameOps.scala
+++ b/src/dotty/tools/dotc/core/NameOps.scala
@@ -204,7 +204,6 @@ object NameOps {
       case nme.length => nme.primitive.arrayLength
       case nme.update => nme.primitive.arrayUpdate
       case nme.clone_ => nme.clone_
-      case nme.CONSTRUCTOR => nme.primitive.arrayConstructor
     }
 
     /** If name length exceeds allowable limit, replace part of it by hash */

--- a/src/dotty/tools/dotc/core/StdNames.scala
+++ b/src/dotty/tools/dotc/core/StdNames.scala
@@ -433,7 +433,6 @@ object StdNames {
     val moduleClass : N         = "moduleClass"
     val name: N                 = "name"
     val ne: N                   = "ne"
-    val newArray: N             = "newArray"
     val newFreeTerm: N          = "newFreeTerm"
     val newFreeType: N          = "newFreeType"
     val newNestedSymbol: N      = "newNestedSymbol"
@@ -691,8 +690,7 @@ object StdNames {
       val arrayApply: TermName  = "[]apply"
       val arrayUpdate: TermName = "[]update"
       val arrayLength: TermName = "[]length"
-      val arrayConstructor: TermName = "[]<init>"
-      val names: Set[Name] = Set(arrayApply, arrayUpdate, arrayLength, arrayConstructor)
+      val names: Set[Name] = Set(arrayApply, arrayUpdate, arrayLength)
     }
 
     def isPrimitiveName(name: Name) = primitive.names.contains(name)

--- a/tests/pos/new-array.scala
+++ b/tests/pos/new-array.scala
@@ -1,0 +1,7 @@
+object Test {
+  val w = new Array[String](10)
+  val x = new Array[Int](10)
+  def f[T: reflect.ClassTag] = new Array[T](10)
+  val y = new Array[Any](10)
+  val z = new Array[Unit](10)
+}


### PR DESCRIPTION
Previous scheme was buggy; leaked Array types to backend.
Now: All `new Array[T]` methods are translated to calls of the form

```
dotty.Arrays.newXYZArray ...
```

Review by @DarkDimius please.
