### PR TITLE
Fix array creation v2

### DIFF
--- a/src/dotty/runtime/Arrays.scala
+++ b/src/dotty/runtime/Arrays.scala
@@ -1,0 +1,47 @@
+package dotty.runtime
+
+import scala.reflect.ClassTag
+
+/** All but the first operation should be short-circuited and implemented specially by
+ *  the backend.
+ */
+object Arrays {
+
+  /** Creates an array of some element type determined by the given `ClassTag`
+   *  argument. The erased type of applications of this method is `Object`.
+   */
+  def newGenericArray[T](length: Int)(implicit tag: ClassTag[T]): Array[T] =
+    tag.newArray(length)
+
+  /** Create an array of type T. T must be of form Array[E], with
+   *  E being a reference type.
+   */
+  def newRefArray[T](length: Int): T = ???
+
+  /** Create a Byte[] array */
+  def newByteArray(length: Int): Array[Byte] = ???
+
+  /** Create a Short[] array */
+  def newShortArray(length: Int): Array[Short] = ???
+
+  /** Create a Char[] array */
+  def newCharArray(length: Int): Array[Char] = ???
+
+  /** Create an Int[] array */
+  def newIntArray(length: Int): Array[Int] = ???
+
+  /** Create a Long[] array */
+  def newLongArray(length: Int): Array[Long] = ???
+
+  /** Create a Float[] array */
+  def newFloatArray(length: Int): Array[Float] = ???
+
+  /** Create a Double[] array */
+  def newDoubleArray(length: Int): Array[Double] = ???
+
+  /** Create a Boolean[] array */
+  def newBooleanArray(length: Int): Array[Boolean] = ???
+
+  /** Create a scala.runtime.BoxedUnit[] array */
+  def newUnitArray(length: Int): Array[Unit] = ???
+}

--- a/src/dotty/tools/dotc/TypeErasure.scala
+++ b/src/dotty/tools/dotc/TypeErasure.scala
@@ -142,7 +142,7 @@ object TypeErasure {
       tp.derivedPolyType(
         tp.paramNames, tp.paramNames map (Function.const(TypeBounds.upper(defn.ObjectType))), tp.resultType)
 
-    if ((sym eq defn.Any_asInstanceOf) || (sym eq defn.Any_isInstanceOf)) eraseParamBounds(sym.info.asInstanceOf[PolyType])
+    if (defn.isPolymorphicAfterErasure(sym)) eraseParamBounds(sym.info.asInstanceOf[PolyType])
     else if (sym.isAbstractType) TypeAlias(WildcardType)
     else if (sym.isConstructor) outer.addParam(sym.owner.asClass, erase(tp)(erasureCtx))
     else eraseInfo(tp)(erasureCtx) match {
@@ -153,10 +153,24 @@ object TypeErasure {
     }
   }
 
-  def isUnboundedGeneric(tp: Type)(implicit ctx: Context) = !(
-    (tp derivesFrom defn.ObjectClass) ||
-    tp.classSymbol.isPrimitiveValueClass ||
-    (tp.typeSymbol is JavaDefined))
+  /** Is `tp` an abstract type or polymorphic type parameter that has `Any`
+   *  as upper bound and that is not Java defined? Arrays of such types are
+   *  erased to `Object` instead of `ObjectArray`.
+   */
+  def isUnboundedGeneric(tp: Type)(implicit ctx: Context): Boolean = tp match {
+    case tp: TypeRef =>
+      tp.symbol.isAbstractType &&
+      !tp.derivesFrom(defn.ObjectClass) &&
+      !tp.typeSymbol.is(JavaDefined)
+    case tp: PolyParam =>
+      !tp.derivesFrom(defn.ObjectClass) &&
+      !tp.binder.resultType.isInstanceOf[JavaMethodType]
+    case tp: TypeProxy => isUnboundedGeneric(tp.underlying)
+    case tp: AndType => isUnboundedGeneric(tp.tp1) || isUnboundedGeneric(tp.tp2)
+    case tp: OrType => isUnboundedGeneric(tp.tp1) && isUnboundedGeneric(tp.tp2)
+    case _ => false
+  }
+
 
   /** The erased least upper bound is computed as follows
    *  - if both argument are arrays, an array of the lub of the element types

--- a/src/dotty/tools/dotc/core/Contexts.scala
+++ b/src/dotty/tools/dotc/core/Contexts.scala
@@ -120,7 +120,7 @@ object Contexts {
     protected def scope_=(scope: Scope) = _scope = scope
     def scope: Scope = _scope
 
-    /** The current type assigner ot typer */
+    /** The current type assigner or typer */
     private[this] var _typeAssigner: TypeAssigner = _
     protected def typeAssigner_=(typeAssigner: TypeAssigner) = _typeAssigner = typeAssigner
     def typeAssigner: TypeAssigner = _typeAssigner

--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -193,6 +193,10 @@ class Definitions {
     def staticsMethod(name: PreName) = ctx.requiredMethod(ScalaStaticsClass, name)
 
   lazy val DottyPredefModule = ctx.requiredModule("dotty.DottyPredef")
+  lazy val DottyArraysModule = ctx.requiredModule("dotty.runtime.Arrays")
+
+    def newRefArrayMethod = ctx.requiredMethod(DottyArraysModule.moduleClass.asClass, "newRefArray")
+
   lazy val NilModule = ctx.requiredModule("scala.collection.immutable.Nil")
   lazy val PredefConformsClass = ctx.requiredClass("scala.Predef." + tpnme.Conforms)
 
@@ -211,6 +215,7 @@ class Definitions {
     lazy val Array_update                = ctx.requiredMethod(ArrayClass, nme.update)
     lazy val Array_length                = ctx.requiredMethod(ArrayClass, nme.length)
     lazy val Array_clone                 = ctx.requiredMethod(ArrayClass, nme.clone_)
+    lazy val ArrayConstructor            = ctx.requiredMethod(ArrayClass, nme.CONSTRUCTOR)
   lazy val traversableDropMethod  = ctx.requiredMethod(ScalaRuntimeClass, nme.drop)
   lazy val uncheckedStableClass: ClassSymbol = ctx.requiredClass("scala.annotation.unchecked.uncheckedStable")
 
@@ -427,6 +432,8 @@ class Definitions {
   lazy val UnqualifiedOwners = RootImports.toSet ++ RootImports.map(_.moduleClass)
 
   lazy val PhantomClasses = Set[Symbol](AnyClass, AnyValClass, NullClass, NothingClass)
+
+  lazy val isPolymorphicAfterErasure = Set[Symbol](Any_isInstanceOf, Any_asInstanceOf, newRefArrayMethod)
 
   lazy val RootImports = List[Symbol](JavaLangPackageVal, ScalaPackageVal, ScalaPredefModule, DottyPredefModule)
 

--- a/src/dotty/tools/dotc/core/NameOps.scala
+++ b/src/dotty/tools/dotc/core/NameOps.scala
@@ -204,7 +204,6 @@ object NameOps {
       case nme.length => nme.primitive.arrayLength
       case nme.update => nme.primitive.arrayUpdate
       case nme.clone_ => nme.clone_
-      case nme.CONSTRUCTOR => nme.primitive.arrayConstructor
     }
 
     /** If name length exceeds allowable limit, replace part of it by hash */

--- a/src/dotty/tools/dotc/core/StdNames.scala
+++ b/src/dotty/tools/dotc/core/StdNames.scala
@@ -433,7 +433,6 @@ object StdNames {
     val moduleClass : N         = "moduleClass"
     val name: N                 = "name"
     val ne: N                   = "ne"
-    val newArray: N             = "newArray"
     val newFreeTerm: N          = "newFreeTerm"
     val newFreeType: N          = "newFreeType"
     val newNestedSymbol: N      = "newNestedSymbol"
@@ -691,8 +690,7 @@ object StdNames {
       val arrayApply: TermName  = "[]apply"
       val arrayUpdate: TermName = "[]update"
       val arrayLength: TermName = "[]length"
-      val arrayConstructor: TermName = "[]<init>"
-      val names: Set[Name] = Set(arrayApply, arrayUpdate, arrayLength, arrayConstructor)
+      val names: Set[Name] = Set(arrayApply, arrayUpdate, arrayLength)
     }
 
     def isPrimitiveName(name: Name) = primitive.names.contains(name)

--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -89,7 +89,7 @@ class Erasure extends Phase with DenotTransformer { thisTransformer =>
    */
   def assertErased(tree: tpd.Tree)(implicit ctx: Context): Unit = {
     assertErased(tree.typeOpt, tree)
-    if (!(tree.symbol == defn.Any_isInstanceOf || tree.symbol == defn.Any_asInstanceOf))
+    if (!defn.isPolymorphicAfterErasure(tree.symbol))
       assertErased(tree.typeOpt.widen, tree)
     if (ctx.mode.isExpr)
       tree.tpe match {

--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -596,7 +596,16 @@ trait Applications extends Compatibility { self: Typer =>
         checkBounds(typedArgs, pt)
       case _ =>
     }
-    assignType(cpy.TypeApply(tree)(typedFn, typedArgs), typedFn, typedArgs)
+    convertNewArray(
+      assignType(cpy.TypeApply(tree)(typedFn, typedArgs), typedFn, typedArgs))
+  }
+
+  /** Rewrite `new Array[T]` trees to calls of newXYZArray methods. */
+  def convertNewArray(tree: Tree)(implicit ctx: Context): Tree = tree match {
+    case TypeApply(tycon, targs) if tycon.symbol == defn.ArrayConstructor =>
+      newArray(targs.head, tree.pos)
+    case _ =>
+      tree
   }
 
   def typedUnApply(tree: untpd.Apply, selType: Type)(implicit ctx: Context): Tree = track("typedUnApply") {

--- a/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -208,7 +208,6 @@ trait TypeAssigner {
       case p.arrayApply => MethodType(defn.IntType :: Nil, arrayElemType)
       case p.arrayUpdate => MethodType(defn.IntType :: arrayElemType :: Nil, defn.UnitType)
       case p.arrayLength => MethodType(Nil, defn.IntType)
-      case p.arrayConstructor => MethodType(defn.IntType :: Nil, qualType)
       case nme.clone_ if qualType.isInstanceOf[JavaArrayType] => MethodType(Nil, qualType)
       case _ => accessibleSelectionType(tree, qual)
     }

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -1326,7 +1326,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
           if (pt.isInstanceOf[PolyProto]) tree
           else {
             val (_, tvars) = constrained(poly, tree)
-            adaptInterpolated(tree appliedToTypes tvars, pt, original)
+            convertNewArray(
+              adaptInterpolated(tree.appliedToTypes(tvars), pt, original))
           }
         case wtp =>
           pt match {

--- a/tests/pos/new-array.scala
+++ b/tests/pos/new-array.scala
@@ -1,0 +1,14 @@
+object Test {
+  val w = new Array[String](10)
+  val x = new Array[Int](10)
+  def f[T: reflect.ClassTag] = new Array[T](10)
+  val y = new Array[Any](10)
+  val z = new Array[Unit](10)
+}
+object Test2 {
+  val w: Array[String] = new Array(10)
+  val x: Array[Int] = new Array(10)
+  def f[T: reflect.ClassTag]: Array[T] = new Array(10)
+  val y: Array[Any] = new Array(10)
+  val z: Array[Unit] = new Array(10)
+}


### PR DESCRIPTION
Now: All new Array[T] methods are translated to calls of the form

```
dotty.Arrays.newXYZArray ...
```

Supersedes #252. Main change is that we now keep ref array types after erasure, and that we 
allow for local type inference of array creation arguments, i.e. new Array(len), without a type argument.

Review by @DarkDimius please.
