### PR TITLE
Make sure all non-deferred methods are implemented

### DIFF
--- a/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -89,8 +89,9 @@ class SuperAccessors extends MacroTransform with IdentityDenotTransformer { this
 
       val superAcc = clazz.info.decl(supername).suchThat(_.signature == sym.signature).symbol orElse {
         ctx.debuglog(s"add super acc ${sym.showLocated} to $clazz")
+        val maybeDeferred = if (clazz is Trait) Deferred else EmptyFlags
         val acc = ctx.newSymbol(
-            clazz, supername, SuperAccessor | Private | Artifact | Method,
+            clazz, supername, SuperAccessor | Private | Artifact | Method | maybeDeferred,
             ensureMethodic(sel.tpe.widenSingleton), coord = sym.coord).enteredAfter(thisTransformer)
         // Diagnostic for SI-7091
         if (!accDefs.contains(clazz))


### PR DESCRIPTION
Checked by a new post condition after memoize.

Two bugs were detected and fixed by the condition

(1) Memoize did not implement getters and setters of ParamAccessors
(2) ResolveSuper did not implement super accessors in non-trait classes.

Review by @DarkDimius 
