### PR TITLE
Fix by-name arguments

### DIFF
--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -172,6 +172,11 @@ class Definitions {
     def ObjectMethods = List(Object_eq, Object_ne, Object_synchronized, Object_clone,
         Object_finalize, Object_notify, Object_notifyAll, Object_wait, Object_waitL, Object_waitLI)
 
+  /** Dummy method needed by elimByName */
+  lazy val dummyApply = newPolyMethod(
+      RootClass, nme.dummyApply, 1,
+      pt => MethodType(List(FunctionType(Nil, PolyParam(pt, 0))), PolyParam(pt, 0)))
+
   lazy val NotNullClass = ctx.requiredClass("scala.NotNull")
 
   lazy val NothingClass: ClassSymbol = newCompleteClassSymbol(

--- a/src/dotty/tools/dotc/core/StdNames.scala
+++ b/src/dotty/tools/dotc/core/StdNames.scala
@@ -372,6 +372,7 @@ object StdNames {
     val delayedInit: N          = "delayedInit"
     val delayedInitArg: N       = "delayedInit$body"
     val drop: N                 = "drop"
+    val dummyApply: N           = "<dummy-apply>"
     val elem: N                 = "elem"
     val emptyValDef: N          = "emptyValDef"
     val ensureAccessible : N    = "ensureAccessible"

--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -370,10 +370,8 @@ object Erasure extends TypeTestsCasts{
 
     override def typedApply(tree: untpd.Apply, pt: Type)(implicit ctx: Context): Tree = {
       val Apply(fun, args) = tree
-      if (tree.removeAttachment(ElimByName.ByNameArg).isDefined) {
-        val Select(qual, nme.apply) = fun
-        typedUnadapted(qual, pt)
-      }
+      if (fun.symbol == defn.dummyApply)
+        typedUnadapted(args.head, pt)
       else typedExpr(fun, FunProto(args, pt, this)) match {
         case fun1: Apply => // arguments passed in prototype were already passed
           fun1


### PR DESCRIPTION
Previous scheme relying on Attachments was fragile. We now use
a dummy method application, which transmits info reliably to
Erasure.

Review by @DarkDimius 
