### PR TITLE
Make -Ylog:X log only phase X

### DIFF
--- a/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -101,16 +101,9 @@ trait Reporting { this: Context =>
   def incompleteInputError(msg: String, pos: SourcePosition = NoSourcePosition)(implicit ctx: Context): Unit =
     reporter.incomplete(new Error(msg, pos))(ctx)
 
-  /** Log msg if current phase or its precedessor is mentioned in
-   *  settings.log.
-   *  The reason we also pick the predecessor is that during the
-   *  tree transform of phase X, we often are already in phase X+1.
-   *  It's convenient to have logging work independently of whether
-   *  we have advanced the phase or not.
-   */
+  /** Log msg if current phase is mentioned in settings.log */
   def log(msg: => String): Unit =
-    if (this.settings.log.value.containsPhase(phase) ||
-        this.settings.log.value.containsPhase(phase.prev))
+    if (this.settings.log.value.containsPhase(phase))
       echo(s"[log ${ctx.phasesStack.reverse.mkString(" -> ")}] $msg")
 
   def debuglog(msg: => String): Unit =


### PR DESCRIPTION
There is no need to log the phase after X anymore, containsPhase does
the correct thing.

Review by @odersky 
