### PR TITLE
Disable implicit conversions between from `Null` and `Nothing`.

### DIFF
--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -400,7 +400,9 @@ trait Implicits { self: Typer =>
   def inferView(from: Tree, to: Type)(implicit ctx: Context): SearchResult = track("inferView") {
     if (   (to isRef defn.AnyClass)
         || (to isRef defn.ObjectClass)
-        || (to isRef defn.UnitClass)) NoImplicitMatches
+        || (to isRef defn.UnitClass)
+        || (from.tpe isRef defn.NothingClass)
+        || (from.tpe isRef defn.NullClass)) NoImplicitMatches
     else
       try inferImplicit(to.stripTypeVar.widenExpr, from, from.pos)
       catch {

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -108,6 +108,7 @@ class tests extends CompilerTest {
   @Test def neg_boundspropagation = compileFile(negDir, "boundspropagation", xerrors = 4)
   @Test def neg_refinedSubtyping = compileFile(negDir, "refinedSubtyping", xerrors = 2)
   @Test def neg_i0248_inherit_refined = compileFile(negDir, "i0248-inherit-refined", xerrors = 4)
+  @Test def neg_i0281 = compileFile(negDir, "i0281-null-primitive-conforms", xerrors = 3)
 
   @Test def dotc = compileDir(dotcDir + "tools/dotc", twice)(allowDeepSubtypes)
   @Test def dotc_ast = compileDir(dotcDir + "tools/dotc/ast", twice)

--- a/tests/neg/i0281-null-primitive-conforms.scala
+++ b/tests/neg/i0281-null-primitive-conforms.scala
@@ -1,0 +1,6 @@
+object test {
+  val b: scala.Boolean = null
+  val c: Unit = null
+  val d: Float = null
+  val e: AnyVal = null
+}


### PR DESCRIPTION
This is necessary to reject code like

```
 val x: Boolean = null
```

Without the restriction, this code would typecheck and expand to

```
 val x: Boolean = Predef.Boolean2boolean(null)
```

since `null` counts as a value of type `java.lang.Boolean`.

Closes #291. Review by @smarter 
