### PR TITLE
Avoid spurious warnings about forward references in refinements

### DIFF
--- a/src/dotty/tools/dotc/typer/Checking.scala
+++ b/src/dotty/tools/dotc/typer/Checking.scala
@@ -162,13 +162,13 @@ object Checking {
    *  This depends also on firming up the DOT calculus. For the moment we only issue
    *  deprecated warnings, not errors.
    */
-  def checkRefinementNonCyclic(refinement: Tree, refineCls: ClassSymbol)(implicit ctx: Context): Unit = {
+  def checkRefinementNonCyclic(refinement: Tree, refineCls: ClassSymbol, seen: mutable.Set[Symbol])
+    (implicit ctx: Context): Unit = {
     def flag(what: String, tree: Tree) =
       ctx.deprecationWarning(i"$what reference in refinement is deprecated", tree.pos)
     def forwardRef(tree: Tree) = flag("forward", tree)
     def selfRef(tree: Tree) = flag("self", tree)
     val checkTree = new TreeAccumulator[Unit] {
-      private var seen = Set[Symbol]()
       def checkRef(tree: Tree, sym: Symbol) =
         if (sym.maybeOwner == refineCls && !seen(sym)) forwardRef(tree)
       def apply(x: Unit, tree: Tree) = tree match {

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -759,10 +759,11 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     val refineClsDef = desugar.refinedTypeToClass(tpt1, tree.refinements)
     val refineCls = createSymbol(refineClsDef).asClass
     val TypeDef(_, Template(_, _, _, refinements1)) = typed(refineClsDef)
+    val seen = mutable.Set[Symbol]()
     assert(tree.refinements.length == refinements1.length, s"${tree.refinements} != $refinements1")
     def addRefinement(parent: Type, refinement: Tree): Type = {
       typr.println(s"adding refinement $refinement")
-      checkRefinementNonCyclic(refinement, refineCls)
+      checkRefinementNonCyclic(refinement, refineCls, seen)
       val rsym = refinement.symbol
       val rinfo = if (rsym is Accessor) rsym.info.resultType else rsym.info
       RefinedType(parent, rsym.name, rt => rinfo.substThis(refineCls, RefinedThis(rt)))


### PR DESCRIPTION
The warning was triggered by cases like:
class A
type F = A { type T = Int; def f: T }
Which is treated differently from the following which did not produce a warning:
type F = A { type T = Int } { def f: T }

Review by @odersky 
