### PR TITLE
Fix returns inside while cycles.

### DIFF
--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -422,7 +422,7 @@ object SymDenotations {
     }
 
     /** Is this a user defined "def" method? Excluded are accessors. */
-    final def isSourceMethod(implicit ctx: Context) = this is (Method, butNot = Accessor)
+    final def isSourceMethod(implicit ctx: Context) = this is (Method, butNot = AccessorOrLabel)
 
     /** Is this a setter? */
     final def isGetter(implicit ctx: Context) =
@@ -1664,4 +1664,6 @@ object SymDenotations {
     private final val NumBits = NumWords << WordSizeLog
     private final val Mask = NumBits - 1
   }
+
+  val AccessorOrLabel = Accessor | Label
 }

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -677,7 +677,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         if (cx == NoContext || owner.isType) {
           ctx.error("return outside method definition", tree.pos)
           (EmptyTree, WildcardType)
-        } else if (owner.isSourceMethod && !(owner is Flags.Label))
+        } else if (owner.isSourceMethod)
           if (owner.isCompleted) {
             val from = Ident(TermRef(NoPrefix, owner.asTerm))
             val proto = returnProto(owner)


### PR DESCRIPTION
Fix returns inside while cycles.
    typing of Returns looked for directly enclosing method, but didn't take in
    account presence of synthesised labels. So if one had a return inside a
    while loop it would be adapted to type of while, which is always unit. The
    adaption always succeeds and it was left unnoticed.

review by @odersky please
