### PR TITLE
Speedup build start on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: scala
 sudo: false
+cache:
+  directories:
+  - $HOME/.ivy2
+  - $HOME/.m2
+  - $HOME/.sbt
 script:
   - sbt -Ddotty.travis.build=yes update compile test
 jdk:


### PR DESCRIPTION
Do 2 things: use container based infrastructure, and persist ivy, maven and sbt data.
