### PR TITLE
Disable context escape detection

### DIFF
--- a/test/test/DottyTest.scala
+++ b/test/test/DottyTest.scala
@@ -14,7 +14,7 @@ import dotty.tools.dotc.Compiler
 import dotty.tools.dotc
 import dotty.tools.dotc.core.Phases.Phase
 
-class DottyTest extends ContextEscapeDetection{
+class DottyTest /*extends ContextEscapeDetection*/ {
 
   dotty.tools.dotc.parsing.Scanners // initialize keywords
 
@@ -36,11 +36,12 @@ class DottyTest extends ContextEscapeDetection{
     base.definitions.init(ctx)
     ctx
   }
-
+/*
   override def getCtx: Context = ctx
   override def clearCtx() = {
     ctx = null
   }
+*/
   private def compilerWithChecker(phase: String)(assertion:(tpd.Tree, Context) => Unit) = new Compiler {
     self =>
     override def phases = {


### PR DESCRIPTION
I get very frequent build failures due to the mutual Scala<->Java dependency in
context escape detection.
It builds for a long time, then decides that getCtx overrides nothing. The only
way to fix is another clean build. Total time lost: >5 minutes. These happened
occasionally before but have become much more frequent under ScalaIDE4.0, to the
point where this becomes a major drag on productity. Context escape detection
is nice but if it stops us getting work done, not worth the effort.

Review by @DarkDimius 
