### PR TITLE
Prevent block types with references to local symbols

### DIFF
--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -472,7 +472,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     val Block(stats, expr) = block
     val leaks = escapingRefs(block)
     if (leaks.isEmpty) block
-    else if (isFullyDefined(pt, ForceDegree.all)) {
+    else if (isFullyDefined(pt, ForceDegree.none)) {
       val expr1 = Typed(expr, TypeTree(pt))
       cpy.Block(block)(stats, expr1) withType expr1.tpe // no assignType here because avoid is redundant
     } else if (!forcedDefined) {

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -67,6 +67,7 @@ class tests extends CompilerTest {
   @Test def pos_subtyping = compileFile(posDir, "subtyping")
   @Test def pos_t2613 = compileFile(posSpecialDir, "t2613")(allowDeepSubtypes)
   @Test def pos_packageObj = compileFile(posDir, "i0239")
+  @Test def pos_anonClassSubtyping = compileFile(posDir, "anonClassSubtyping")
 
   @Test def pos_all = compileFiles(posDir, failedOther)
 
@@ -119,6 +120,7 @@ class tests extends CompilerTest {
   @Test def neg_i0248_inherit_refined = compileFile(negDir, "i0248-inherit-refined", xerrors = 4)
   @Test def neg_i0281 = compileFile(negDir, "i0281-null-primitive-conforms", xerrors = 3)
   @Test def neg_moduleSubtyping = compileFile(negDir, "moduleSubtyping", xerrors = 4)
+  @Test def neg_escapingRefs = compileFile(negDir, "escapingRefs", xerrors = 2)
 
   @Test def dotc = compileDir(dotcDir + "tools/dotc", failedOther)(allowDeepSubtypes)
   @Test def dotc_ast = compileDir(dotcDir + "tools/dotc/ast", failedOther) // similar to dotc_config

--- a/tests/neg/escapingRefs.scala
+++ b/tests/neg/escapingRefs.scala
@@ -1,0 +1,10 @@
+object O {
+  class A
+  class B
+  def f[T](x: T, y: T): T = y
+
+  val x: A = f(new A { }, new B { })
+
+  val y = f({ class C { def member: Int = 1 }; new C }, { class C { def member: Int = 1 }; new C })
+  val z = y.member
+}

--- a/tests/pos/anonClassSubtyping.scala
+++ b/tests/pos/anonClassSubtyping.scala
@@ -1,0 +1,9 @@
+object O {
+  class A
+  class B
+  def f[T](x: T, y: T): T = x
+
+  val x: A = f(new A { }, new A)
+
+  val y: A | B = f(new A { }, new B)
+}


### PR DESCRIPTION
Review by @odersky 

---

As an aside, the rules for block typing seem non-intuitive to me, the example from `tests/pos/t1569a.scala` works:
```scala
object Bug2 {
  class C { type T }
  class D extends C { type T = String }
  def foo(x: Int)(y: C)(z: y.T): Unit = {}
  foo(3)(new D)("hello")
}
```
But replacing `new D` by `new D {}` fails with:
```
tests/pos/t1569a.scala:11: error: type mismatch:
 found   : String("hello")
 required: Bug2.C#T
  foo(3)(new D { })("hello")
                    ^
one error found
```