### PR TITLE
unset CDPATH in bin/dotc to make ( cd && pwd ) work correctly

### DIFF
--- a/bin/dotc
+++ b/bin/dotc
@@ -17,7 +17,7 @@ programName=$(basename "$0")
 
 
 declare -a java_args scala_args residual_args
-unset verbose quiet cygwin toolcp colors saved_stty
+unset verbose quiet cygwin toolcp colors saved_stty CDPATH
 
 
 CompilerMain=dotty.tools.dotc.Main


### PR DESCRIPTION
When CDPATH is set, cd echoes the directory that it is switching to.
The ( cd && pwd ) pattern then prints the directory twice, causing
a mangled path.

See https://bosker.wordpress.com/2012/02/12/bash-scripters-beware-of-the-cdpath/