### PR TITLE
fix TypeMap.mapOver to not drop type annotations

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -2727,7 +2727,7 @@ object Types {
 
         case tp @ AnnotatedType(annot, underlying) =>
           val underlying1 = this(underlying)
-          if (underlying1 eq underlying) tp else underlying1
+          if (underlying1 eq underlying) tp else tp.derivedAnnotatedType(annot, underlying1)
 
         case tp @ WildcardType =>
           tp.derivedWildcardType(mapOver(tp.optBounds))

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -2727,7 +2727,7 @@ object Types {
 
         case tp @ AnnotatedType(annot, underlying) =>
           val underlying1 = this(underlying)
-          if (underlying1 eq underlying) tp else tp.derivedAnnotatedType(annot, underlying1)
+          if (underlying1 eq underlying) tp else tp.derivedAnnotatedType(mapOver(annot), underlying1)
 
         case tp @ WildcardType =>
           tp.derivedWildcardType(mapOver(tp.optBounds))

--- a/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -99,6 +99,7 @@ trait Inferencing { this: Checking =>
   /** Recursively widen and also follow type declarations and type aliases. */
   def widenForMatchSelector(tp: Type)(implicit ctx: Context): Type = tp.widen match {
     case tp: TypeRef if !tp.symbol.isClass => widenForMatchSelector(tp.info.bounds.hi)
+    case tp: AnnotatedType => tp.derivedAnnotatedType(tp.annot, widenForMatchSelector(tp.tpe))
     case tp => tp
   }
 


### PR DESCRIPTION
`TypeMap.mapOver` used to drop all annotations on the types that it was mapping over.

Fixing this fixes issue #182.

Fixing this also reveals some test failures due to missing handling of annotated types in widenForMatchSelector. The second commit 914b0ec adds the missing case to widenForMatchSelector.