### PR TITLE
Fix/erasure lub alternative

### DIFF
--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -251,17 +251,9 @@ object Erasure extends TypeTestsCasts{
     override def typedLiteral(tree: untpd.Literal)(implicit ctc: Context): Literal =
       if (tree.typeOpt.isRef(defn.UnitClass)) tree.withType(tree.typeOpt)
       else super.typedLiteral(tree)
-
-    // The following methods, typedIf, typedMatch and typedTry need to compensate
-    // for the fact that after erasure, a subtype may notbe compatible with the
-    // type of a lub. Hence we might need to readapt branches to the common type.
-    // Note that the typing of SeqLiteral faces a similar problem but solves it
-    // differently: It adapts all elements to the erasure of the type that existed
-    // before. TODO: It looks like a good idea to harmonize this.
-    // 
+      
     override def typedIf(tree: untpd.If, pt: Type)(implicit ctx: Context): If = {
       val tree1 = super.typedIf(tree, pt)
-      println(i"typed if $tree1 with $pt = ${tree1.tpe}")
       if (pt.isValueType) tree1
       else cpy.If(tree1)(thenp = adapt(tree1.thenp, tree1.tpe), elsep = adapt(tree1.elsep, tree1.tpe))
     }

--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -403,8 +403,13 @@ object Erasure extends TypeTestsCasts{
     override def typedTry(tree: untpd.Try, pt: Type)(implicit ctx: Context) = 
       super.typedTry(tree, adaptProto(tree, pt))
 
-    private def adaptProto(tree: untpd.Tree, pt: Type)(implicit ctx: Context) = 
-      if (pt.isValueType) pt else erasure(tree.typeOpt)
+    private def adaptProto(tree: untpd.Tree, pt: Type)(implicit ctx: Context) = {
+      if (pt.isValueType) pt else {
+        if(tree.typeOpt.derivesFrom(ctx.definitions.UnitClass))
+          tree.typeOpt
+        else erasure(tree.typeOpt)
+      }
+    }
 
     override def typedValDef(vdef: untpd.ValDef, sym: Symbol)(implicit ctx: Context): ValDef =
       super.typedValDef(untpd.cpy.ValDef(vdef)(

--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -252,6 +252,36 @@ object Erasure extends TypeTestsCasts{
       if (tree.typeOpt.isRef(defn.UnitClass)) tree.withType(tree.typeOpt)
       else super.typedLiteral(tree)
 
+    // The following methods, typedIf, typedMatch and typedTry need to compensate
+    // for the fact that after erasure, a subtype may notbe compatible with the
+    // type of a lub. Hence we might need to readapt branches to the common type.
+    // Note that the typing of SeqLiteral faces a similar problem but solves it
+    // differently: It adapts all elements to the erasure of the type that existed
+    // before. TODO: It looks like a good idea to harmonize this.
+    // 
+    override def typedIf(tree: untpd.If, pt: Type)(implicit ctx: Context): If = {
+      val tree1 = super.typedIf(tree, pt)
+      println(i"typed if $tree1 with $pt = ${tree1.tpe}")
+      if (pt.isValueType) tree1
+      else cpy.If(tree1)(thenp = adapt(tree1.thenp, tree1.tpe), elsep = adapt(tree1.elsep, tree1.tpe))
+    }
+    
+    override def typedMatch(tree: untpd.Match, pt: Type)(implicit ctx: Context): Match = {
+      val tree1 = super.typedMatch(tree, pt).asInstanceOf[Match]
+      if (pt.isValueType) tree1
+      else cpy.Match(tree1)(tree1.selector, tree1.cases.map(adaptCase(_, tree1.tpe)))
+    }
+    
+    override def typedTry(tree: untpd.Try, pt: Type)(implicit ctx: Context): Try = {
+      val tree1 = super.typedTry(tree, pt)
+      if (pt.isValueType) tree1
+      else cpy.Try(tree1)(expr = adapt(tree1.expr, tree1.tpe), cases = tree1.cases.map(adaptCase(_, tree1.tpe)))
+    }
+
+    private def adaptCase(cdef: CaseDef, pt: Type)(implicit ctx: Context): CaseDef = 
+      cpy.CaseDef(cdef)(body = adapt(cdef.body, pt))
+      
+
     /** Type check select nodes, applying the following rewritings exhaustively
      *  on selections `e.m`, where `OT` is the type of the owner of `m` and `ET`
      *  is the erased type of the selection's original qualifier expression.

--- a/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -57,7 +57,7 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {thisTrans
     val selector =
       ctx.newSymbol(ctx.owner, ctx.freshName("ex").toTermName, Flags.Synthetic, defn.ThrowableType, coord = tree.pos)
     val sel = Ident(selector.termRef).withPos(tree.pos)
-    val rethrow = tpd.CaseDef(sel, EmptyTree, Throw(ref(selector)))
+    val rethrow = tpd.CaseDef(EmptyTree, EmptyTree, Throw(ref(selector)))
     val newCases = tpd.CaseDef(
       Bind(selector,untpd.Ident(nme.WILDCARD).withPos(tree.pos).withType(selector.info)),
       EmptyTree,

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -132,7 +132,7 @@ class tests extends CompilerTest {
   @Test def dotc_parsing = compileDir(dotcDir + "tools/dotc/parsing", failedOther)
     //  Expected primitive types I - Ljava/lang/Object
     //  Tried to return an object where expected type was Integer
-  @Test def dotc_printing = compileDir(dotcDir + "tools/dotc/printing", twice)
+  @Test def dotc_printing = compileDir(dotcDir + "tools/dotc/printing", failedOther)
   @Test def dotc_reporting = compileDir(dotcDir + "tools/dotc/reporting", twice)
   @Test def dotc_typer = compileDir(dotcDir + "tools/dotc/typer", failedOther) // similar to dotc_config
   //@Test def dotc_util = compileDir(dotcDir + "tools/dotc/util") //fails inside ExtensionMethods with ClassCastException

--- a/tests/pos/erased-lub.scala
+++ b/tests/pos/erased-lub.scala
@@ -1,0 +1,27 @@
+// Verify that expressions below perform correct boxings in erasure.
+object Test {
+  def id[T](t: T) = t
+
+  val x = true
+  val one = 1
+
+  { if (x) id(one) else 0 } + 1
+
+  { if (x) new scala.util.Random()}.asInstanceOf[Runnable]
+
+  { x match {
+      case true => id(one)
+      case _ => 0
+    }
+  } + 1
+
+  { try {
+      id(one)
+    } catch {
+      case ex: Exception => 0
+    }
+  }.asInstanceOf[Runnable]
+
+  val arr = Array(id(one), 0)
+
+}


### PR DESCRIPTION
This currently fails two tests in the backend. @DarkDimius can you take a look? I think this PR is preferable to #357 but we have to figure out the status of those failures.

(Why is it better to unbox instead of box? The difference is only there if the prototype is either a wildcard type or a selection prototype. the most common case would be the selection prototype, which in this case would be either to an operation on a primitive type or to a generic operation on object (such as equals, toString, hashCode). It seems more important to make the primitive operations fast because they occur more often and take less time than the object operations. The one exception could be equals but we will probably handle this by a decorator anyway going forward.)