### PR TITLE
Added test to TreeChecker that guards against orphan parameters.

### DIFF
--- a/src/dotty/tools/dotc/Compiler.scala
+++ b/src/dotty/tools/dotc/Compiler.scala
@@ -41,7 +41,7 @@ class Compiler {
       List(new FirstTransform,
            new SyntheticMethods),
       List(new SuperAccessors),
-      // pickling goes here
+      //List(new Pickler), // Pickler needs to come last in a group since it should not pickle trees generated later
       List(new RefChecks,
            new ElimRepeated,
            new ElimLocals,

--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -348,7 +348,7 @@ object Erasure extends TypeTestsCasts{
     }
 
     private def protoArgs(pt: Type): List[untpd.Tree] = pt match {
-      case pt: FunProto => pt.args ++ protoArgs(pt.resultType)
+      case pt: FunProto => pt.args ++ protoArgs(pt.resType)
       case _ => Nil
     }
 

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -15,7 +15,7 @@ class tests extends CompilerTest {
 
   implicit val defaultOptions = noCheckOptions ++ List(
       "-Yno-deep-subtypes",
-      "-Ycheck:resolveSuper,mixin,restoreScopes",
+      "-Ycheck:tailrec,resolveSuper,mixin,restoreScopes",
       "-d", "./out/"
   )
 


### PR DESCRIPTION
Currently, tests fail. The failures I checked are all related to tailcalls.
Not sure whether there are others.

This is a blocker for serialization. Orphan parameters cannot be serialized.

Review by @darkdimius. I made this a pull-request with the idea that you could push a fix to the same branch.

Maybe rethink the position of tailcalls? It looks to me that the repeated trouble it gives us is
more than the effort required to put an efficient tailcall recognition after pattern matching in place.
But I might be wrong.