### PR TITLE
Fix for #371

### DIFF
--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -130,7 +130,7 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
   val externalEqualsNumNum: Symbol = ctx.requiredMethod(BoxesRunTimeClass, nme.equalsNumNum)
   lazy val externalEqualsNumChar: Symbol = ??? // ctx.requiredMethod(BoxesRunTimeClass, nme.equalsNumChar) // this method is private
   val externalEqualsNumObject: Symbol = ctx.requiredMethod(BoxesRunTimeClass, nme.equalsNumObject)
-  val externalEquals: Symbol = ctx.requiredMethod(BoxesRunTimeClass, nme.equals_)
+  val externalEquals: Symbol = BoxesRunTimeClass.info.decl(nme.equals_).suchThat(toDenot(_).info.firstParamTypes.size == 2).symbol
   val MaxFunctionArity: Int = Definitions.MaxFunctionArity
   val FunctionClass: Array[Symbol] = defn.FunctionClass.asInstanceOf[Array[Symbol]]
   val AbstractFunctionClass: Array[Symbol] = defn.AbstractFunctionClass.asInstanceOf[Array[Symbol]]

--- a/src/dotty/tools/dotc/core/pickling/UnPickler.scala
+++ b/src/dotty/tools/dotc/core/pickling/UnPickler.scala
@@ -106,7 +106,8 @@ object UnPickler {
       case TempPolyType(tps, cinfo) => (tps, cinfo)
       case cinfo => (Nil, cinfo)
     }
-    val parentRefs = ctx.normalizeToClassRefs(parents, cls, decls)
+    var parentRefs = ctx.normalizeToClassRefs(parents, cls, decls)
+    if (parentRefs.isEmpty) parentRefs = defn.ObjectClass.typeRef :: Nil
     for (tparam <- tparams) {
       val tsym = decls.lookup(tparam.name)
       if (tsym.exists) tsym.setFlag(TypeParam)


### PR DESCRIPTION
This causes backend to fail with ambiguous reference when loading
member "equals" of object "BoxesRuntime".

The reference is indeed ambiguous. BoxesRunTime has a two paremeter
equals method and, with the fix, inherits the one-parameter method from
Object. The backend needs to disambiguate, e.g. by demanding the `decl`
equals in BoxesRunTime instead of the member.

Review and completion request for @darkdimius