### PR TITLE
FullParameterization: fix rewiring of Returns

### DIFF
--- a/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -176,6 +176,12 @@ trait FullParameterization {
           } else EmptyTree
         }
         tree match {
+          case Return(expr, from) if !from.isEmpty =>
+            val rewired = rewiredTarget(from, derived)
+            if (rewired.exists)
+              tpd.cpy.Return(tree)(expr, Ident(rewired.termRef))
+            else
+              EmptyTree
           case Ident(_) => rewireCall(thisRef)
           case Select(qual, _) => rewireCall(qual)
           case tree @ TypeApply(fn, targs1) =>

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -68,6 +68,7 @@ class tests extends CompilerTest {
   @Test def pos_t2613 = compileFile(posSpecialDir, "t2613")(allowDeepSubtypes)
   @Test def pos_packageObj = compileFile(posDir, "i0239")
   @Test def pos_anonClassSubtyping = compileFile(posDir, "anonClassSubtyping")
+  @Test def pos_extmethods = compileFile(posDir, "extmethods")
 
   @Test def pos_all = compileFiles(posDir, failedOther)
 

--- a/tests/pos/extmethods.scala
+++ b/tests/pos/extmethods.scala
@@ -3,4 +3,5 @@ class T[A, This <: That1[A]](val x: Int) extends AnyVal {
   self: This =>
   var next: This = _
   final def loop(x: This, cnt: Int): Int = loop(x, cnt + 1)
+  def const[B](): Boolean = return true
 }


### PR DESCRIPTION
This assumes that an `Ident` corresponding to a method with extensions only occurs as the `from` field of a `Return`, can someone confirm that this will always be the case?
EDIT: I updated the code to do a ` case Return` so the assumption above is no longer needed, but I'm still curious if `Ident` can appear anywhere else, otherwise we could remove the `case Ident`

Review by @odersky or @DarkDimius .