### PR TITLE
Fix bug which prevented New over type-instantiated aliases.

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1408,12 +1408,7 @@ object Parsers {
     }
 
     /** Wrap annotation or constructor in New(...).<init> */
-    def wrapNew(tpt: Tree) = tpt match {
-      case AppliedTypeTree(tpt1, targs) =>
-        TypeApply(Select(New(tpt1), nme.CONSTRUCTOR), targs)
-      case _ =>
-        Select(New(tpt), nme.CONSTRUCTOR)
-    }
+    def wrapNew(tpt: Tree) = Select(New(tpt), nme.CONSTRUCTOR)
 
     /** Adjust start of annotation or constructor to position of preceding @ or new */
     def adjustStart(start: Offset)(tree: Tree): Tree = {

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -347,8 +347,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         val clsDef = TypeDef(x, templ).withFlags(Final)
         typed(cpy.Block(tree)(clsDef :: Nil, New(Ident(x), Nil)), pt)
       case _ =>
-	      val tpt1 = typedType(tree.tpt)
-	      checkClassTypeWithStablePrefix(tpt1.tpe, tpt1.pos, traitReq = false)
+        val tpt1 = typedType(tree.tpt)
+        checkClassTypeWithStablePrefix(tpt1.tpe, tpt1.pos, traitReq = false)
         assignType(cpy.New(tree)(tpt1), tpt1)
         // todo in a later phase: checkInstantiatable(cls, tpt1.pos)
     }
@@ -1366,9 +1366,13 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         case poly: PolyType =>
           if (pt.isInstanceOf[PolyProto]) tree
           else {
-            val (_, tvars) = constrained(poly, tree)
+            var typeArgs = tree match {
+              case Select(New(tpt), nme.CONSTRUCTOR) => tpt.tpe.dealias.argTypesLo
+              case _ => Nil
+            }
+            if (typeArgs.isEmpty) typeArgs = constrained(poly, tree)._2
             convertNewArray(
-              adaptInterpolated(tree.appliedToTypes(tvars), pt, original))
+              adaptInterpolated(tree.appliedToTypes(typeArgs), pt, original))
           }
         case wtp =>
           pt match {

--- a/tests/pos/aliasNew.scala
+++ b/tests/pos/aliasNew.scala
@@ -1,0 +1,8 @@
+object test {
+
+  type Map = collection.mutable.HashMap[String, Int]
+
+  val xs = new Map
+  xs("abc") = 1
+
+}


### PR DESCRIPTION
Previously,

     type Map = HashMap[Int, String]
     new Map

did not work. See test aliasNew.scala for a test.
Formerly this logic handled in Parsers (wrapNew),
but that one does not work for aliastypes.

Review by @DarkDimius 