### PR TITLE
Make parser a phase

### DIFF
--- a/src/dotty/tools/dotc/Compiler.scala
+++ b/src/dotty/tools/dotc/Compiler.scala
@@ -6,6 +6,7 @@ import Contexts._
 import Periods._
 import Symbols._
 import Scopes._
+import parsing.Parsing
 import typer.{FrontEnd, Typer, Mode, ImportInfo, RefChecks}
 import reporting.ConsoleReporter
 import dotty.tools.dotc.core.Phases.Phase
@@ -37,6 +38,7 @@ class Compiler {
    */
   def phases: List[List[Phase]] =
     List(
+      List(new Parsing),
       List(new FrontEnd),
       List(new FirstTransform,
            new SyntheticMethods),

--- a/src/dotty/tools/dotc/core/Phases.scala
+++ b/src/dotty/tools/dotc/core/Phases.scala
@@ -9,6 +9,7 @@ import DenotTransformers._
 import Denotations._
 import config.Printers._
 import scala.collection.mutable.{ListBuffer, ArrayBuffer}
+import scala.util.control.NonFatal
 import dotty.tools.dotc.transform.TreeTransforms.{TreeTransformer, MiniPhase, TreeTransform}
 import dotty.tools.dotc.transform._
 import Periods._
@@ -279,6 +280,12 @@ object Phases {
      *  and type applications.
      */
     def relaxedTyping: Boolean = false
+    
+    /** If set, only proceed if there are no errors in run */
+    def stopOnError = true
+    
+    /** If set, result trees are untyped */
+    def untypedResult = false
 
     def exists: Boolean = true
 
@@ -330,6 +337,14 @@ object Phases {
 
     final def iterator =
       Iterator.iterate(this)(_.next) takeWhile (_.hasNext)
+
+    def monitor(doing: String)(body: => Unit)(implicit ctx: Context) =
+      try body
+      catch {
+        case NonFatal(ex) =>
+          println(s"exception occured while $doing ${ctx.compilationUnit}")
+          throw ex
+    }
 
     override def toString = phaseName
   }

--- a/src/dotty/tools/dotc/parsing/Parsing.scala
+++ b/src/dotty/tools/dotc/parsing/Parsing.scala
@@ -1,0 +1,22 @@
+package dotty.tools.dotc
+package parsing
+
+import core._
+import Phases.Phase
+import Contexts.Context
+import dotty.tools.dotc.parsing.JavaParsers.JavaParser
+import parsing.Parsers.Parser
+
+class Parsing extends Phase {
+
+  override def phaseName = "parsing"
+  
+  override def untypedResult = true
+
+  override def run(implicit ctx: Context): Unit = monitor("parsing") {
+    val unit = ctx.compilationUnit
+    unit.untpdTree =
+      if (unit.isJava) new JavaParser(unit.source).parse()
+      else new Parser(unit.source).parse()
+  }
+}


### PR DESCRIPTION
Take care that parser errors do not stop computation, and that
printing after parser prints untyped trees. Review by @DarkDimius 