### PR TITLE
`AnyVal` is not a derived value class

### DIFF
--- a/src/dotty/tools/dotc/transform/ValueClasses.scala
+++ b/src/dotty/tools/dotc/transform/ValueClasses.scala
@@ -12,7 +12,10 @@ import Flags._
 object ValueClasses {
 
   def isDerivedValueClass(d: SymDenotation)(implicit ctx: Context) =
-    d.isClass && d.derivesFrom(defn.AnyValClass) && !d.isPrimitiveValueClass
+    d.isClass &&
+      (d.symbol ne defn.AnyValClass) &&
+      d.derivesFrom(defn.AnyValClass) &&
+      !d.isPrimitiveValueClass
 
   def isMethodWithExtension(d: SymDenotation)(implicit ctx: Context) =
     d.isSourceMethod &&


### PR DESCRIPTION
@odersky or @DarkDimius : Please review.
Another way to fix this would be to make `isPrimitiveValueClass` return `true` for `AnyVal` but I don't know if that's correct.
The current behavior doesn't break anything but will once value classes are done.