### PR TITLE
Fix AnnotatedType#stripTypeVar to not strip the annotation

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -2602,7 +2602,8 @@ object Types {
       if ((annot eq this.annot) && (tpe eq this.tpe)) this
       else AnnotatedType(annot, tpe)
 
-    override def stripTypeVar(implicit ctx: Context): Type = tpe.stripTypeVar
+    override def stripTypeVar(implicit ctx: Context): Type =
+      derivedAnnotatedType(annot, tpe.stripTypeVar)
     override def stripAnnots(implicit ctx: Context): Type = tpe.stripAnnots
   }
 


### PR DESCRIPTION
This fixes `Types#hasAnnotation` which calls `stripTypeVar` which means that
it always returned false before.

@olhotak : please review