### PR TITLE
Compiler#newRun: reset the context _before_ initializing a new run

### DIFF
--- a/src/dotty/tools/dotc/Compiler.scala
+++ b/src/dotty/tools/dotc/Compiler.scala
@@ -104,10 +104,8 @@ class Compiler {
   }
 
   def newRun(implicit ctx: Context): Run = {
-    try new Run(this)(rootContext)
-    finally {
-      ctx.base.reset()
-      ctx.runInfo.clear()
-    }
+    ctx.base.reset()
+    ctx.runInfo.clear()
+    new Run(this)(rootContext)
   }
 }


### PR DESCRIPTION
Previously it was incorrectly done after the run was initialized, this
fixes #391.
@odersky : Please review.