### PR TITLE
Emit inner classes table.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -31,7 +31,7 @@ object DottyBuild extends Build {
     // get reflect and xml onboard
     libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value,
                                 "org.scala-lang.modules" %% "scala-xml" % "1.0.1",
-                                "me.d-d" % "scala-compiler" % "2.11.5-20150216-154453-f58d45491b",
+                                "me.d-d" % "scala-compiler" % "2.11.5-20150402-193021-0c75410da3",
                                 "jline" % "jline" % "2.12"),
 
     // get junit onboard

--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -485,7 +485,7 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
           val original = toDenot(sym).initial
           val validity = original.validFor
           val shiftedContext = ctx.withPhase(validity.phaseId)
-          val r = toDenot(sym)(shiftedContext).maybeOwner
+          val r = toDenot(sym)(shiftedContext).maybeOwner.enclosingClass(shiftedContext)
           r
         } else NoSymbol
       } catch {

--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -28,6 +28,7 @@ import dotty.tools.dotc.util.{Positions, DotClass}
 import Decorators._
 import tpd._
 import StdNames.nme
+import NameOps._
 
 class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
   trait NonExistentTree extends tpd.Tree
@@ -382,7 +383,7 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
     def toTypeName: Name = n.toTypeName
     def isTypeName: Boolean = n.isTypeName
     def toTermName: Name = n.toTermName
-    def dropModule: Name = ???
+    def dropModule: Name = n.stripModuleClassSuffix
 
     def len: Int = n.length
     def offset: Int = n.start
@@ -409,7 +410,7 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
 
     // tests
     def isClass: Boolean = {
-      sym.isClass && (sym.isPackageObject || !(sym is Flags.Package))
+      sym.isPackageObject || (sym.isClass)
     }
     def isType: Boolean = sym.isType
     def isAnonymousClass: Boolean = toDenot(sym).isAnonymousClass
@@ -475,7 +476,9 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
 
     // navigation
     def owner: Symbol = toDenot(sym).owner
-    def rawowner: Symbol = owner
+    def rawowner: Symbol = {
+      originalOwner
+    }
     def originalOwner: Symbol = {
       try {
         if (sym.exists) {
@@ -483,8 +486,7 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
           val validity = original.validFor
           val shiftedContext = ctx.withPhase(validity.phaseId)
           val r = toDenot(sym)(shiftedContext).maybeOwner
-          if(r is Flags.Package) NoSymbol
-          else r
+          r
         } else NoSymbol
       } catch {
         case e: NotDefinedHere => NoSymbol // todo: do we have a method to tests this?
@@ -511,14 +513,20 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
     def companionModule: Symbol = toDenot(sym).companionModule
     def companionSymbol: Symbol = if (sym is Flags.Module) companionClass else companionModule
     def moduleClass: Symbol = toDenot(sym).moduleClass
-    def enclosingClassSym: Symbol = enclClass //todo is handled specially for JavaDefined symbols in scalac
+    def enclosingClassSym: Symbol = {
+      if(this.isClass) {
+        val ct = ctx.withPhase(ctx.flattenPhase.prev)
+        toDenot(sym)(ct).owner.enclosingClass(ct)
+      }
+      else sym.enclosingClass(ctx.withPhase(ctx.flattenPhase.prev))
+    } //todo is handled specially for JavaDefined symbols in scalac
 
 
 
     // members
     def primaryConstructor: Symbol = toDenot(sym).primaryConstructor
     def nestedClasses: List[Symbol] = memberClasses //exitingPhase(currentRun.lambdaliftPhase)(sym.memberClasses)
-    def memberClasses: List[Symbol] = toDenot(sym).info.memberClasses.map(_.symbol).toList
+    def memberClasses: List[Symbol] = toDenot(sym).info.memberClasses(ctx.withPhase(ctx.flattenPhase.prev)).map(_.symbol).toList
     def annotations: List[Annotation] = Nil
     def companionModuleMembers: List[Symbol] =  {
       // phase travel to exitingPickler: this makes sure that memberClassesOf only sees member classes,

--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -716,6 +716,9 @@ object SymDenotations {
      *  but in turn the enclosing class of the latter. This reflects
      *  the context created by `Context#superCallContext`, `Contect#thisCallArgContext`
      *  for these definitions.
+     *
+     *  Note, that as packages have ClassSymbols, top level classes will have an `enclosingClass`
+     *  with Package flag set.
      */
     final def enclosingClass(implicit ctx: Context): Symbol = {
       def enclClass(sym: Symbol, skip: Boolean): Symbol = {


### PR DESCRIPTION
Known to fail.
Emitting inner classes table also includes reading the inner classes of all referenced classes in current run.
This makes ClassFileParser read a lot more than it was reading previosly, and it dies while reading `Signature` attributes, when accessing unknown type parameter here: https://github.com/lampepfl/dotty/blob/master/src/dotty/tools/dotc/core/pickling/ClassfileParser.scala#L328