### PR TITLE
Fix #400

### DIFF
--- a/src/dotty/tools/dotc/transform/ElimByName.scala
+++ b/src/dotty/tools/dotc/transform/ElimByName.scala
@@ -73,7 +73,8 @@ class ElimByName extends MiniPhaseTransform with InfoTransformer { thisTransform
       case formalExpr: ExprType =>
         val argType = arg.tpe.widen
         val argFun = arg match {
-          case Apply(Select(qual, nme.apply), Nil) if qual.tpe derivesFrom defn.FunctionClass(0) =>
+          case Apply(Select(qual, nme.apply), Nil) 
+          if qual.tpe.derivesFrom(defn.FunctionClass(0)) && isPureExpr(qual) =>
             qual
           case _ =>
             val meth = ctx.newSymbol(

--- a/tests/pos/i0400.scala
+++ b/tests/pos/i0400.scala
@@ -1,0 +1,13 @@
+object Test {
+  def foo: Unit = {
+    def a = () => ""
+    bar({???; a}.apply())
+  }
+  def bar(a: => Any): Unit = {
+    baz(a)
+  }
+  def baz(a: => Any): Unit = ()
+  def main(args: Array[String]): Unit = {
+    foo
+  }
+}


### PR DESCRIPTION
In a call-by-name arg, replace () => f.apply() with f only if f is pure.