### PR TITLE
BUG: The use of isDerivedValueClass in ExtensionMethods causes cyclic references

### DIFF
--- a/src/dotty/tools/dotc/core/Symbols.scala
+++ b/src/dotty/tools/dotc/core/Symbols.scala
@@ -418,9 +418,11 @@ object Symbols {
     def filter(p: Symbol => Boolean): Symbol = if (p(this)) this else NoSymbol
 
     /** Is this symbol a user-defined value class? */
-    final def isDerivedValueClass(implicit ctx: Context): Boolean =
+    final def isDerivedValueClass(implicit ctx: Context): Boolean = {
+      this.derivesFrom(defn.AnyValClass) // Simulate ValueClasses.isDerivedValueClass
       false  // will migrate to ValueClasses.isDerivedValueClass;
                // unsupported value class code will continue to use this stub while it exists
+    }
 
     /** The current name of this symbol */
     final def name(implicit ctx: Context): ThisName = denot.name.asInstanceOf[ThisName]


### PR DESCRIPTION
In #411 I implemented value classes and started getting errors in the
backend. This commit reproduces similar errors in master with a single
change: In master Symbol#isDerivedValueClass always returns false because
value classes are non-functional, after this commit it still always
return false but it calls this.derivesFrom(defn.AnyValClass) first, this
is enough to trigger the problem.
Here's what's happening with dotc_reporter for example, you can also reproduce the problem just by running ./src/dotty/tools/dotc/reporting/ConsoleReporter.scala

- During Erasure, isDerivedValueClass is called on the class FlatHashTable
- derivesFrom forces the computation of the base classes of FlatHashTable
- HashUtils is a parent of FlatHashTable, its denotation is forced
- HashUtils is then transformed by ExplicitOuter which calls isStatic on it
- isStatic calls owner.isStaticOwner, this forces the denotation of the owner
  of HashUtils, which is the module class FlatHashTable$
- FlatHashTable$ is then transformed by ExtensionMethods which calls linkedClass
  on it to get the companion class FlatHashTable
- isDerivedValueClass is called on the class FlatHashTable
- *BOOM*

I'm opening this as a pull request so that you can easily see the failures in Travis.
@odersky, @DarkDimius : I'm unsure how to proceed. Could we add a flag ModuleValueClass for module classes whose companion class is a value class? This way we don't have to call isDerivedValueClass on the companion class.