### PR TITLE
YCheck that returned value conforms to type of the method

### DIFF
--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -78,6 +78,13 @@ class Erasure extends Phase with DenotTransformer { thisTransformer =>
       case res: tpd.This =>
         assert(!ExplicitOuter.referencesOuter(ctx.owner.enclosingClass, res),
           i"Reference to $res from ${ctx.owner.showLocated}")
+      case ret: tpd.Return =>
+        // checked only after erasure, as checking before erasure is complicated
+        // due presence of type params in returned types
+        val from = if (ret.from.isEmpty) ctx.owner.enclosingMethod else ret.from.symbol
+        val rType = from.info.finalResultType
+        assert(ret.expr.tpe <:< rType,
+          i"Returned value:${ret.expr}  does not conform to result type(${ret.expr.tpe.widen} of method $from")
       case _ =>
     }
   }


### PR DESCRIPTION
Moving those commits that were creating discussion out of #404

@odersky, those commits make compiler fail early in easy to understand location,
instead of failing inside either GenBCode or asm with `failed conversion` message.
This also helps to unserstand which phase actually broke the code, as after erasure
no phase is expected to insert adaptations.