### PR TITLE
Have derivedValueClass run at initial stage

### DIFF
--- a/src/dotty/tools/dotc/core/Symbols.scala
+++ b/src/dotty/tools/dotc/core/Symbols.scala
@@ -418,9 +418,12 @@ object Symbols {
     def filter(p: Symbol => Boolean): Symbol = if (p(this)) this else NoSymbol
 
     /** Is this symbol a user-defined value class? */
-    final def isDerivedValueClass(implicit ctx: Context): Boolean =
+    final def isDerivedValueClass(implicit ctx: Context): Boolean = {
+      this.derivesFrom(defn.AnyValClass)(ctx.withPhase(denot.validFor.firstPhaseId))
+        // Simulate ValueClasses.isDerivedValueClass
       false  // will migrate to ValueClasses.isDerivedValueClass;
                // unsupported value class code will continue to use this stub while it exists
+    }
 
     /** The current name of this symbol */
     final def name(implicit ctx: Context): ThisName = denot.name.asInstanceOf[ThisName]

--- a/src/dotty/tools/dotc/transform/ValueClasses.scala
+++ b/src/dotty/tools/dotc/transform/ValueClasses.scala
@@ -11,11 +11,15 @@ import Flags._
 /** Methods that apply to user-defined value classes */
 object ValueClasses {
 
-  def isDerivedValueClass(d: SymDenotation)(implicit ctx: Context) =
-    d.isClass &&
-      d.derivesFrom(defn.AnyValClass) &&
-      (d.symbol ne defn.AnyValClass) &&
-      !d.isPrimitiveValueClass
+  def isDerivedValueClass(d: SymDenotation)(implicit ctx: Context) = {
+    val di = d.initial.asSymDenotation
+    di.isClass &&
+    di.derivesFrom(defn.AnyValClass)(ctx.withPhase(di.validFor.firstPhaseId)) &&
+      // need to check derivesFrom at initialPhase to avoid cyclic references caused
+      // by forcing in transformInfo
+    (di.symbol ne defn.AnyValClass) &&
+    !di.isPrimitiveValueClass
+  }
 
   def isMethodWithExtension(d: SymDenotation)(implicit ctx: Context) =
     d.isSourceMethod &&


### PR DESCRIPTION
Fixes #412, by calling derivesFrom in isDerivedValueClass
at initial phase. Rewrite of 789dc0c070bde6ce8634aa89e73e31ec1233a6f8
by @smarter. Does the same thing in Symbol#isDerivedValueClass.

Review by @smarter