### PR TITLE
InterceptedMethods: enable interception of == and !=

### DIFF
--- a/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -103,7 +103,7 @@ class InterceptedMethods extends MiniPhaseTransform { thisTransform =>
         s"that means the intercepted methods set doesn't match the code")
       tree
     }
-    if (tree.fun.symbol.isTerm && tree.args.isEmpty &&
+    if (tree.fun.symbol.isTerm &&
         (interceptedMethods contains tree.fun.symbol.asTerm)) {
       val rewrite: Tree = tree.fun match {
         case Select(qual, name) =>


### PR DESCRIPTION
It seems that this was disabled by error, but maybe there is a reason for leaving it this way?
@odersky or @DarkDimius : please review.