### PR TITLE
Fix isNullableClass to also work after Erasure

### DIFF
--- a/src/dotty/tools/dotc/transform/ValueClasses.scala
+++ b/src/dotty/tools/dotc/transform/ValueClasses.scala
@@ -12,13 +12,9 @@ import Flags._
 object ValueClasses {
 
   def isDerivedValueClass(d: SymDenotation)(implicit ctx: Context) = {
-    val di = d.initial.asSymDenotation
-    di.isClass &&
-    di.derivesFrom(defn.AnyValClass)(ctx.withPhase(di.validFor.firstPhaseId)) &&
-      // need to check derivesFrom at initialPhase to avoid cyclic references caused
-      // by forcing in transformInfo
-    (di.symbol ne defn.AnyValClass) &&
-    !di.isPrimitiveValueClass
+    d.isValueClass &&
+    (d.initial.symbol ne defn.AnyValClass) && // Compare the initial symbol because AnyVal does not exist after erasure
+    !d.isPrimitiveValueClass
   }
 
   def isMethodWithExtension(d: SymDenotation)(implicit ctx: Context) =

--- a/tests/pos/nullAsInstanceOf.scala
+++ b/tests/pos/nullAsInstanceOf.scala
@@ -1,0 +1,11 @@
+object Test {
+  val b = null.asInstanceOf[Byte]
+  val c = null.asInstanceOf[Char]
+  val s = null.asInstanceOf[Short]
+  val i = null.asInstanceOf[Int]
+  val l = null.asInstanceOf[Long]
+  val f = null.asInstanceOf[Float]
+  val d = null.asInstanceOf[Double]
+
+  val str = null.asInstanceOf[String]
+}


### PR DESCRIPTION
Incidentally this means that:
```scala
  val d = null.asInstanceOf[Double]
```
is now correctly transformed to:
```scala
  val d = scala.Double.unbox(null)
```
Previously it was translated to:
```scala
  val d = null: Double
```
Which is wrong and fails in the backend.

Review by @odersky 