### PR TITLE
Implicits#viewExists: return false after typer instead of AssertionError

### DIFF
--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -380,6 +380,7 @@ trait Implicits { self: Typer =>
   override def viewExists(from: Type, to: Type)(implicit ctx: Context): Boolean = (
        !from.isError
     && !to.isError
+    && !ctx.isAfterTyper
     && (ctx.mode is Mode.ImplicitsEnabled)
     && { from.widenExpr match {
            case from: TypeRef if defn.ScalaValueClasses contains from.symbol =>


### PR DESCRIPTION
This way, tpd#applyOverloaded can safely be used after typer. This issue
was encoutered while working on value classes, step 3 of SIP-15 contains
the following peephole optimization:
```scala
  new C(e) == new C(f) => e == f
```
Which requires us to do overloading resolution.

Review by @odersky .