### PR TITLE
Erasure: actually emit bridges

### DIFF
--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -491,12 +491,12 @@ object Erasure extends TypeTestsCasts{
                   sym => makeBridgeDef(member, sym)(ctx)
                 }
                 emittedBridges ++= bridgeImplementations
-                traverse(newTail, oldTail)
+                traverse(newTail, oldTail, emittedBridges)
               case notADefDef :: oldTail =>
-                traverse(after, oldTail)
+                traverse(after, oldTail, emittedBridges)
             }
           case notADefDef :: newTail =>
-            traverse(newTail, before)
+            traverse(newTail, before, emittedBridges)
         }
       }
 


### PR DESCRIPTION
Review by @DarkDimius 

Example to play at home:
```scala
trait Reporter[T] {
  def report(x: T): Unit
}
class Example extends Reporter[Int] {
  override def report(x: Int) =
    println(x + 1)
}
```
Without this patch, no bridge is actually emitted.