### PR TITLE
Fixes that make bridges smaller.

### DIFF
--- a/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -343,7 +343,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
    */
   private def refPurity(tree: tpd.Tree)(implicit ctx: Context): PurityLevel =
     if (!tree.tpe.widen.isParameterless) Pure
-    else if (!tree.symbol.is(Stable)) Impure
+    else if (!tree.symbol.isStable) Impure
     else if (tree.symbol.is(Lazy)) Idempotent // TODO add Module flag, sinxce Module vals or not Lazy from the start.
     else Pure
 


### PR DESCRIPTION
Ref purity was marking references to arguments of the method as impure.
This led to creating temporary variables just to pass original argument.

@smarter please review. This should fix your problems.