### PR TITLE
Fix TreeTypeMap and mapSymbols to create a copy of decls for duplicated classes.

### DIFF
--- a/src/dotty/tools/dotc/core/Symbols.scala
+++ b/src/dotty/tools/dotc/core/Symbols.scala
@@ -292,7 +292,7 @@ trait Symbols { this: Context =>
         val oinfo = original.info match {
           case ClassInfo(pre, _, parents, decls, selfInfo) =>
             assert(original.isClass)
-            ClassInfo(pre, copy.asClass, parents, decls, selfInfo)
+            ClassInfo(pre, copy.asClass, parents, decls.cloneScope, selfInfo)
           case oinfo => oinfo
         }
         copy.denot = odenot.copySymDenotation(


### PR DESCRIPTION
Without this fix the duplicated classes and the original ones share the same reference to a scope,
instead of having each a separate one.

@alexsikia this should fix your problems