### PR TITLE
Backend: emit annotations

### DIFF
--- a/tests/pos/annotations/MyAnnotation.java
+++ b/tests/pos/annotations/MyAnnotation.java
@@ -1,0 +1,10 @@
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Retention;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MyAnnotation {
+    public String Name();
+    public int[] foBaskaLi();
+}

--- a/tests/pos/annotations/MyClass.scala
+++ b/tests/pos/annotations/MyClass.scala
@@ -1,0 +1,4 @@
+class MyClass {
+  @MyAnnotation(Name="Blah", foBaskaLi = Array(1,2,3))
+  def method = ???
+}


### PR DESCRIPTION
The annotations are not emitted on arguments of backend-generated static forwarders.
Backend used to use type of method that it forwards to generate those annotations.
In dotty, there's way to get from this type to symbols of arguments.

@odersky please review. I know that this code is hard to review. But java tests actually include good coverage of annotations, including complex nested ones, so this code should be correct.