### PR TITLE
Fix/stale symbols

### DIFF
--- a/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -4,9 +4,8 @@ package config
 
 import io.{AbstractFile,ClassPath,JavaClassPath,MergedClassPath,DeltaClassPath}
 import ClassPath.{ JavaContext, DefaultJavaContext }
-import core.Contexts._
-import core.SymDenotations._, core.Symbols._, dotty.tools.dotc.core._
-import Types._, Contexts._, Symbols._, Denotations._, SymDenotations._, StdNames._, Names._
+import core._
+import Symbols._, Types._, Contexts._, Denotations._, SymDenotations._, StdNames._, Names._
 import Flags._, Scopes._, Decorators._, NameOps._, util.Positions._
 
 class JavaPlatform extends Platform {

--- a/src/dotty/tools/dotc/core/Denotations.scala
+++ b/src/dotty/tools/dotc/core/Denotations.scala
@@ -493,6 +493,9 @@ object Denotations {
       b.toList
     }
 
+    /** Invalidate all caches and fields that depend on base classes and their contents */
+    def invalidateInheritedInfo(): Unit = ()
+ 
     /** Move validity period of this denotation to a new run. Throw a StaleSymbol error
      *  if denotation is no longer valid.
      */
@@ -502,9 +505,10 @@ object Denotations {
         var d: SingleDenotation = denot
         do {
           d.validFor = Period(ctx.period.runId, d.validFor.firstPhaseId, d.validFor.lastPhaseId)
+          d.invalidateInheritedInfo()
           d = d.nextInRun
         } while (d ne denot)
-        syncWithParents
+        this
       case _ =>
         if (coveredInterval.containsPhaseId(ctx.phaseId)) staleSymbolError
         else NoDenotation

--- a/src/dotty/tools/dotc/core/Denotations.scala
+++ b/src/dotty/tools/dotc/core/Denotations.scala
@@ -476,12 +476,14 @@ object Denotations {
     /** The version of this SingleDenotation that was valid in the first phase
      *  of this run.
      */
-    def initial: SingleDenotation = {
-      var current = nextInRun
-      while (current.validFor.code > this.myValidFor.code) current = current.nextInRun
-      current
-    }
-
+    def initial: SingleDenotation = 
+      if (validFor == Nowhere) this
+      else {
+        var current = nextInRun
+        while (current.validFor.code > this.myValidFor.code) current = current.nextInRun
+        current
+      }
+      
     def history: List[SingleDenotation] = {
       val b = new ListBuffer[SingleDenotation]
       var current = initial
@@ -615,16 +617,13 @@ object Denotations {
         val current = symbol.current
         // println(s"installing $this after $phase/${phase.id}, valid = ${current.validFor}")
         // printPeriods(current)
-        if (current.nextInRun ne current)
-          this.nextInRun = current.nextInRun
-        else
-          this.nextInRun = this
         this.validFor = Period(ctx.runId, targetId, current.validFor.lastPhaseId)
         if (current.validFor.firstPhaseId == targetId) {
           // replace current with this denotation
           var prev = current
           while (prev.nextInRun ne current) prev = prev.nextInRun
           prev.nextInRun = this
+          this.nextInRun = current.nextInRun
           current.validFor = Nowhere
         } else {
           // insert this denotation after current

--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -70,6 +70,14 @@ object SymDenotations {
 
     override def hasUniqueSym: Boolean = exists
 
+    /** Debug only
+    override def validFor_=(p: Period) = {
+      if (name == "Trees".toTermName && p.runId == 3)
+        assert(symbol.id != 6161)
+      super.validFor_=(p)
+    }
+    */
+    
     // ------ Getting and setting fields -----------------------------
 
     private[this] var myFlags: FlagSet = adaptFlags(initFlags)
@@ -171,13 +179,13 @@ object SymDenotations {
       myInfo = tp
     }
 
-    /** The name, except 
-     *   - if this is a module class, strip the module class suffix 
-     *   - if this is a companion object with a clash-avoiding name, strip the 
+    /** The name, except
+     *   - if this is a module class, strip the module class suffix
+     *   - if this is a companion object with a clash-avoiding name, strip the
      *     "avoid clash" suffix
      */
     def effectiveName(implicit ctx: Context) =
-      if (this is ModuleClass) name.stripModuleClassSuffix 
+      if (this is ModuleClass) name.stripModuleClassSuffix
       else name.stripAvoidClashSuffix
 
     /** The privateWithin boundary, NoSymbol if no boundary is given.
@@ -195,7 +203,7 @@ object SymDenotations {
 
     /** Update the annotations of this denotation */
     private[core] final def annotations_=(annots: List[Annotation]): Unit =
-       myAnnotations = annots
+      myAnnotations = annots
 
     /** Does this denotation have an annotation matching the given class symbol? */
     final def hasAnnotation(cls: Symbol)(implicit ctx: Context) =
@@ -241,9 +249,9 @@ object SymDenotations {
     /** The symbols defined in this class or object.
      *  Careful! This does not force the type, so is compilation order dependent.
      *  This method should be used only in the following circumstances:
-     *  
-     *  1. When accessing type parameters or type parameter accessors (both are entered before 
-     *     completion). 
+     *
+     *  1. When accessing type parameters or type parameter accessors (both are entered before
+     *     completion).
      *  2. When obtaining the current scope in order to enter, rename or delete something there.
      *  3. When playing it safe in order not to raise CylicReferences, e.g. for printing things
      *     or taking more efficient shortcuts (e.g. the stillValid test).
@@ -291,7 +299,6 @@ object SymDenotations {
         val fn = owner.fullNameSeparated(separator) ++ sep ++ name
         if (isType) fn.toTypeName else fn.toTermName
       }
-
 
     /** The encoded flat name of this denotation, where joined names are separated by `separator` characters. */
     def flatName(separator: Char = '$')(implicit ctx: Context): Name =
@@ -457,7 +464,7 @@ object SymDenotations {
     }
 
     /** Is this a user defined "def" method? Excluded are accessors and anonymous functions. */
-    final def isSourceMethod(implicit ctx: Context) = 
+    final def isSourceMethod(implicit ctx: Context) =
       this.is(Method, butNot = AccessorOrLabel) && !isAnonymousFunction
 
     /** Is this a setter? */
@@ -649,7 +656,7 @@ object SymDenotations {
      */
     /** The class implementing this module, NoSymbol if not applicable. */
     final def moduleClass(implicit ctx: Context): Symbol = {
-      def notFound = {println(s"missing module class for $name: $myInfo"); NoSymbol}
+      def notFound = { println(s"missing module class for $name: $myInfo"); NoSymbol }
       if (this is ModuleVal)
         myInfo match {
           case info: TypeRef           => info.symbol
@@ -1002,7 +1009,7 @@ object SymDenotations {
       s"$kindString $name"
     }
 
-    def debugString = toString+"#"+symbol.id // !!! DEBUG
+    def debugString = toString + "#" + symbol.id // !!! DEBUG
 
     // ----- copies and transforms  ----------------------------------------
 
@@ -1097,8 +1104,8 @@ object SymDenotations {
 
     private var firstRunId: RunId = initRunId
 
-    /** If caches influenced by parent classes are still valid, the denotation
-     *  itself, otherwise a freshly initialized copy.
+    /** invalidate caches influenced by parent classes if one of the parents
+     *  is younger than the denotation itself.
      */
     override def syncWithParents(implicit ctx: Context): SingleDenotation = {
       def isYounger(tref: TypeRef) = tref.symbol.denot match {
@@ -1124,7 +1131,7 @@ object SymDenotations {
     }
 
     /** Invalidate all caches and fields that depend on base classes and their contents */
-    private def invalidateInheritedInfo(): Unit = {
+    override def invalidateInheritedInfo(): Unit = {
       myBaseClasses = null
       mySuperClassBits = null
       myMemberFingerPrint = FingerPrint.unknown
@@ -1168,7 +1175,7 @@ object SymDenotations {
     private[this] var myBaseClasses: List[ClassSymbol] = null
     private[this] var mySuperClassBits: BitSet = null
 
-	  /** Invalidate baseTypeRefCache, baseClasses and superClassBits on new run */
+    /** Invalidate baseTypeRefCache, baseClasses and superClassBits on new run */
     private def checkBasesUpToDate()(implicit ctx: Context) =
       if (baseTypeRefValid != ctx.runId) {
         baseTypeRefCache = new java.util.HashMap[CachedType, Type]

--- a/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/src/dotty/tools/dotc/transform/Pickler.scala
@@ -65,6 +65,7 @@ class Pickler extends Phase {
         unpickler.enter(roots = Set())
         unpickler
       }  
+    pickling.println("************* entered toplevel ***********")
     for ((unpickler, unit) <- unpicklers zip units) {
       val unpickled = unpickler.body(readPositions = false)
       testSame(i"$unpickled%\n%", beforePickling(unit), unit)

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -25,7 +25,7 @@ class tests extends CompilerTest {
   val testPickling = List("-Xprint-types", "-Ytest-pickler", "-Ystop-after:pickler")
 
   val failedOther = List("-Ystop-before:collectEntryPoints") // some non-obvious reason. need to look deeper
-  val twice = Nil//List("#runs", "2", "-YnoDoubleBindings")
+  val twice = List("#runs", "2", "-YnoDoubleBindings")
   val staleSymbolError: List[String] = List()
 
   val allowDeepSubtypes = defaultOptions diff List("-Yno-deep-subtypes")
@@ -77,7 +77,7 @@ class tests extends CompilerTest {
   @Test def pos_anonClassSubtyping = compileFile(posDir, "anonClassSubtyping", twice)
   @Test def pos_extmethods = compileFile(posDir, "extmethods", twice)
 
-  @Test def pos_all = compileFiles(posDir, twice)
+  @Test def pos_all = compileFiles(posDir) // twice omitted to make tests run faster
 
 
 
@@ -135,7 +135,7 @@ class tests extends CompilerTest {
     // class file 'target/scala-2.11/dotty_2.11-0.1-SNAPSHOT.jar(dotty/tools/dotc/core/ConstraintHandling$$anon$1.class)'
     // has location not matching its contents: contains class $anon
 
-  @Test def dotc_core_pickling = compileDir(dotcDir + "tools/dotc/core/pickling", failedOther)(allowDeepSubtypes)
+  @Test def dotc_core_pickling = compileDir(dotcDir + "tools/dotc/core/pickling", failedOther ++ twice)(allowDeepSubtypes)
     // exception caught when loading class ClassfileParser$$anon$1: dotty.tools.dotc.core.Denotations$NotDefinedHere:
     // demanding denotation of module class ClassfileParser$$anon$1$ at phase frontend(1) outside defined interval:
     // defined periods are Period(31..36, run = 2) Period(3..24, run = 2) Period(25..26, run = 2)
@@ -143,15 +143,15 @@ class tests extends CompilerTest {
     // inside FirstTransform 	at dotty.tools.dotc.transform.FirstTransform.transform(FirstTransform.scala:33)
     // weird.
 
-  @Test def dotc_transform = compileDir(dotcDir + "tools/dotc/transform", twice)
+  @Test def dotc_transform = compileDir(dotcDir + "tools/dotc/transform")// twice omitted to make tests run faster
 
-  @Test def dotc_parsing = compileDir(dotcDir + "tools/dotc/parsing", twice)
+  @Test def dotc_parsing = compileDir(dotcDir + "tools/dotc/parsing")// twice omitted to make tests run faster
 
-  @Test def dotc_printing = compileDir(dotcDir + "tools/dotc/printing", twice)
+  @Test def dotc_printing = compileDir(dotcDir + "tools/dotc/printing") // twice omitted to make tests run faster
 
-  @Test def dotc_reporting = compileDir(dotcDir + "tools/dotc/reporting", twice)
+  @Test def dotc_reporting = compileDir(dotcDir + "tools/dotc/reporting") // twice omitted to make tests run faster
 
-  @Test def dotc_typer = compileDir(dotcDir + "tools/dotc/typer", failedOther ++ twice)
+  @Test def dotc_typer = compileDir(dotcDir + "tools/dotc/typer", failedOther) // twice omitted to make tests run faster
     // error: error while loading Checking$$anon$2$,
     // class file 'target/scala-2.11/dotty_2.11-0.1-SNAPSHOT.jar(dotty/tools/dotc/typer/Checking$$anon$2.class)'
     // has location not matching its contents: contains class $anon

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -25,7 +25,7 @@ class tests extends CompilerTest {
   val testPickling = List("-Xprint-types", "-Ytest-pickler", "-Ystop-after:pickler")
 
   val failedOther = List("-Ystop-before:collectEntryPoints") // some non-obvious reason. need to look deeper
-  val twice = List("#runs", "2", "-YnoDoubleBindings")
+  val twice = Nil//List("#runs", "2", "-YnoDoubleBindings")
   val staleSymbolError: List[String] = List()
 
   val allowDeepSubtypes = defaultOptions diff List("-Yno-deep-subtypes")
@@ -42,42 +42,42 @@ class tests extends CompilerTest {
 
   //@Test def pickle_core = compileDir(dotcDir + "tools/dotc/core", testPickling, xerrors = 2) // two spurious comparison errors in Types and TypeOps
 
-  @Test def pos_t2168_pat = compileFile(posDir, "t2168")
-  @Test def pos_erasure = compileFile(posDir, "erasure")
-  @Test def pos_Coder() = compileFile(posDir, "Coder")
-  @Test def pos_blockescapes() = compileFile(posDir, "blockescapes")
-  @Test def pos_collections() = compileFile(posDir, "collections")
-  @Test def pos_functions1() = compileFile(posDir, "functions1")
-  @Test def pos_implicits1() = compileFile(posDir, "implicits1")
-  @Test def pos_inferred() = compileFile(posDir, "inferred")
-  @Test def pos_Patterns() = compileFile(posDir, "Patterns")
-  @Test def pos_selftypes() = compileFile(posDir, "selftypes")
-  @Test def pos_varargs() = compileFile(posDir, "varargs")
-  @Test def pos_vararg_patterns() = compileFile(posDir, "vararg-pattern")
-  @Test def pos_opassign() = compileFile(posDir, "opassign")
-  @Test def pos_typedapply() = compileFile(posDir, "typedapply")
-  @Test def pos_nameddefaults() = compileFile(posDir, "nameddefaults")
-  @Test def pos_desugar() = compileFile(posDir, "desugar")
-  @Test def pos_sigs() = compileFile(posDir, "sigs")
-  @Test def pos_typers() = compileFile(posDir, "typers")
-  @Test def pos_typedidents() = compileFile(posDir, "typedIdents")
-  @Test def pos_assignments() = compileFile(posDir, "assignments")
-  @Test def pos_packageobject() = compileFile(posDir, "packageobject")
-  @Test def pos_overloaded() = compileFile(posDir, "overloaded")
-  @Test def pos_overrides() = compileFile(posDir, "overrides")
-  @Test def pos_javaOverride() = compileDir(posDir + "java-override")
-  @Test def pos_templateParents() = compileFile(posDir, "templateParents")
-  @Test def pos_overloadedAccess = compileFile(posDir, "overloadedAccess")
-  @Test def pos_approximateUnion = compileFile(posDir, "approximateUnion")
-  @Test def pos_tailcall = compileDir(posDir + "tailcall/")
+  @Test def pos_t2168_pat = compileFile(posDir, "t2168", twice)
+  @Test def pos_erasure = compileFile(posDir, "erasure", twice)
+  @Test def pos_Coder() = compileFile(posDir, "Coder", twice)
+  @Test def pos_blockescapes() = compileFile(posDir, "blockescapes", twice)
+  @Test def pos_collections() = compileFile(posDir, "collections", twice)
+  @Test def pos_functions1() = compileFile(posDir, "functions1", twice)
+  @Test def pos_implicits1() = compileFile(posDir, "implicits1", twice)
+  @Test def pos_inferred() = compileFile(posDir, "inferred", twice)
+  @Test def pos_Patterns() = compileFile(posDir, "Patterns", twice)
+  @Test def pos_selftypes() = compileFile(posDir, "selftypes", twice)
+  @Test def pos_varargs() = compileFile(posDir, "varargs", twice)
+  @Test def pos_vararg_patterns() = compileFile(posDir, "vararg-pattern", twice)
+  @Test def pos_opassign() = compileFile(posDir, "opassign", twice)
+  @Test def pos_typedapply() = compileFile(posDir, "typedapply", twice)
+  @Test def pos_nameddefaults() = compileFile(posDir, "nameddefaults", twice)
+  @Test def pos_desugar() = compileFile(posDir, "desugar", twice)
+  @Test def pos_sigs() = compileFile(posDir, "sigs", twice)
+  @Test def pos_typers() = compileFile(posDir, "typers", twice)
+  @Test def pos_typedidents() = compileFile(posDir, "typedIdents", twice)
+  @Test def pos_assignments() = compileFile(posDir, "assignments", twice)
+  @Test def pos_packageobject() = compileFile(posDir, "packageobject", twice)
+  @Test def pos_overloaded() = compileFile(posDir, "overloaded", twice)
+  @Test def pos_overrides() = compileFile(posDir, "overrides", twice)
+  @Test def pos_javaOverride() = compileDir(posDir + "java-override", twice)
+  @Test def pos_templateParents() = compileFile(posDir, "templateParents", twice)
+  @Test def pos_overloadedAccess = compileFile(posDir, "overloadedAccess", twice)
+  @Test def pos_approximateUnion = compileFile(posDir, "approximateUnion", twice)
+  @Test def pos_tailcall = compileDir(posDir + "tailcall/", twice)
   @Test def pos_nullarify = compileFile(posDir, "nullarify", "-Ycheck:nullarify" :: Nil)
-  @Test def pos_subtyping = compileFile(posDir, "subtyping")
+  @Test def pos_subtyping = compileFile(posDir, "subtyping", twice)
   @Test def pos_t2613 = compileFile(posSpecialDir, "t2613")(allowDeepSubtypes)
-  @Test def pos_packageObj = compileFile(posDir, "i0239")
-  @Test def pos_anonClassSubtyping = compileFile(posDir, "anonClassSubtyping")
-  @Test def pos_extmethods = compileFile(posDir, "extmethods")
+  @Test def pos_packageObj = compileFile(posDir, "i0239", twice)
+  @Test def pos_anonClassSubtyping = compileFile(posDir, "anonClassSubtyping", twice)
+  @Test def pos_extmethods = compileFile(posDir, "extmethods", twice)
 
-  @Test def pos_all = compileFiles(posDir)
+  @Test def pos_all = compileFiles(posDir, twice)
 
 
 
@@ -126,16 +126,16 @@ class tests extends CompilerTest {
   @Test def neg_moduleSubtyping = compileFile(negDir, "moduleSubtyping", xerrors = 4)
   @Test def neg_escapingRefs = compileFile(negDir, "escapingRefs", xerrors = 2)
 
-  @Test def dotc = compileDir(dotcDir + "tools/dotc", failedOther)(allowDeepSubtypes) // see dotc_core
-  @Test def dotc_ast = compileDir(dotcDir + "tools/dotc/ast", failedOther)
+  @Test def dotc = compileDir(dotcDir + "tools/dotc", failedOther)(allowDeepSubtypes ++ twice) // see dotc_core
+  @Test def dotc_ast = compileDir(dotcDir + "tools/dotc/ast", failedOther ++ twice)
     //similar to dotc_core_pickling but for another anon class. Still during firstTransform
-  @Test def dotc_config = compileDir(dotcDir + "tools/dotc/config")
-  @Test def dotc_core = compileDir(dotcDir + "tools/dotc/core", failedOther)(allowDeepSubtypes)
+  @Test def dotc_config = compileDir(dotcDir + "tools/dotc/config", twice)
+  @Test def dotc_core = compileDir(dotcDir + "tools/dotc/core", failedOther)(allowDeepSubtypes) // !!!twice gives "data race?" error in InterceptedMethods
     // error: error while loading ConstraintHandling$$anon$1$,
     // class file 'target/scala-2.11/dotty_2.11-0.1-SNAPSHOT.jar(dotty/tools/dotc/core/ConstraintHandling$$anon$1.class)'
     // has location not matching its contents: contains class $anon
 
-  @Test def dotc_core_pickling = compileDir(dotcDir + "tools/dotc/core/pickling")(allowDeepSubtypes)
+  @Test def dotc_core_pickling = compileDir(dotcDir + "tools/dotc/core/pickling", failedOther)(allowDeepSubtypes)
     // exception caught when loading class ClassfileParser$$anon$1: dotty.tools.dotc.core.Denotations$NotDefinedHere:
     // demanding denotation of module class ClassfileParser$$anon$1$ at phase frontend(1) outside defined interval:
     // defined periods are Period(31..36, run = 2) Period(3..24, run = 2) Period(25..26, run = 2)
@@ -143,28 +143,28 @@ class tests extends CompilerTest {
     // inside FirstTransform 	at dotty.tools.dotc.transform.FirstTransform.transform(FirstTransform.scala:33)
     // weird.
 
-  @Test def dotc_transform = compileDir(dotcDir + "tools/dotc/transform")
+  @Test def dotc_transform = compileDir(dotcDir + "tools/dotc/transform", twice)
 
-  @Test def dotc_parsing = compileDir(dotcDir + "tools/dotc/parsing")
+  @Test def dotc_parsing = compileDir(dotcDir + "tools/dotc/parsing", twice)
 
-  @Test def dotc_printing = compileDir(dotcDir + "tools/dotc/printing")
+  @Test def dotc_printing = compileDir(dotcDir + "tools/dotc/printing", twice)
 
-  @Test def dotc_reporting = compileDir(dotcDir + "tools/dotc/reporting")
+  @Test def dotc_reporting = compileDir(dotcDir + "tools/dotc/reporting", twice)
 
-  @Test def dotc_typer = compileDir(dotcDir + "tools/dotc/typer", failedOther)
+  @Test def dotc_typer = compileDir(dotcDir + "tools/dotc/typer", failedOther ++ twice)
     // error: error while loading Checking$$anon$2$,
     // class file 'target/scala-2.11/dotty_2.11-0.1-SNAPSHOT.jar(dotty/tools/dotc/typer/Checking$$anon$2.class)'
     // has location not matching its contents: contains class $anon
 
-  @Test def dotc_util = compileDir(dotcDir + "tools/dotc/util", failedOther)
+  @Test def dotc_util = compileDir(dotcDir + "tools/dotc/util", failedOther ++ twice)
     // java.lang.ClassCastException: dotty.tools.dotc.core.Types$NoType$ cannot be cast to dotty.tools.dotc.core.Types$ClassInfo
     // at dotty.tools.dotc.core.SymDenotations$ClassDenotation.classInfo(SymDenotations.scala:1026)
     // at dotty.tools.dotc.transform.ExtensionMethods.transform(ExtensionMethods.scala:38)
 
-  @Test def tools_io = compileDir(dotcDir + "tools/io", failedOther) // inner class has symbol <none>
+  @Test def tools_io = compileDir(dotcDir + "tools/io", failedOther ++ twice) // inner class has symbol <none>
 
-  @Test def helloWorld = compileFile(posDir, "HelloWorld")
-  @Test def labels = compileFile(posDir, "Labels")
+  @Test def helloWorld = compileFile(posDir, "HelloWorld", twice)
+  @Test def labels = compileFile(posDir, "Labels", twice)
   //@Test def tools = compileDir(dotcDir + "tools", "-deep" :: Nil)(allowDeepSubtypes)
 
   @Test def testNonCyclic = compileArgs(Array(
@@ -172,16 +172,16 @@ class tests extends CompilerTest {
       dotcDir + "tools/dotc/core/Types.scala",
       dotcDir + "tools/dotc/ast/Trees.scala",
       "-Xprompt"
-      ) ++ staleSymbolError)
+      ) ++ staleSymbolError ++ twice)
 
   @Test def testIssue_34 = compileArgs(Array(
       dotcDir + "tools/dotc/config/Properties.scala",
       dotcDir + "tools/dotc/config/PathResolver.scala",
       //"-Ylog:frontend",
-      "-Xprompt") ++ staleSymbolError)
+      "-Xprompt") ++ staleSymbolError ++ twice)
 
   val javaDir = "./tests/pos/java-interop/"
-  @Test def java_all = compileFiles(javaDir)
+  @Test def java_all = compileFiles(javaDir, twice)
   
   //@Test def dotc_compilercommand = compileFile(dotcDir + "tools/dotc/config/", "CompilerCommand")
 }

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -76,6 +76,7 @@ class tests extends CompilerTest {
   @Test def pos_packageObj = compileFile(posDir, "i0239", twice)
   @Test def pos_anonClassSubtyping = compileFile(posDir, "anonClassSubtyping", twice)
   @Test def pos_extmethods = compileFile(posDir, "extmethods", twice)
+  @Test def pos_companions = compileFile(posDir, "companions-twice", twice)
 
   @Test def pos_all = compileFiles(posDir) // twice omitted to make tests run faster
 

--- a/tests/pos/companions-twice.scala
+++ b/tests/pos/companions-twice.scala
@@ -1,0 +1,5 @@
+object o {
+    class A
+    class B
+    val x: A => Unit = ???
+ }


### PR DESCRIPTION
Fixed several sources of stale symbol errors detected in unpickling and by the backend. Revived -twice in tests. 

twice was tested to work everywhere except dotc_core (comment left in tests.scala), but was
dropped from some tests in last commit in order not to take too much testing time.

Review by @DarkDimius 