### PR TITLE
Add/instantiation checks

### DIFF
--- a/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/src/dotty/tools/dotc/ast/Desugar.scala
@@ -786,7 +786,7 @@ object desugar {
             New(ref(defn.RepeatedAnnot.typeRef), Nil :: Nil),
             AppliedTypeTree(ref(seqClass.typeRef), t))
         } else {
-          assert(ctx.mode.isExpr, ctx.mode)
+          assert(ctx.mode.isExpr || ctx.reporter.hasErrors, ctx.mode)
           Select(t, op)
         }
       case PrefixOp(op, t) =>

--- a/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -82,6 +82,12 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
     case Block(stats, expr) => methPart(expr)
     case mp => mp
   }
+  
+  /** If tree is an instance creation expression, its New node, otherwise tree itself */
+  def newPart(tree: Tree) = methPart(tree) match {
+    case Select(nu: untpd.New, nme.CONSTRUCTOR) => nu
+    case _ => tree
+  }
 
   /** If tree is a closure, it's body, otherwise tree itself */
   def closureBody(tree: tpd.Tree)(implicit ctx: Context): tpd.Tree = tree match {

--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -382,6 +382,10 @@ object SymDenotations {
     /** is this symbol a trait representing a type lambda? */
     final def isLambdaTrait(implicit ctx: Context): Boolean =
       isClass && name.startsWith(tpnme.LambdaPrefix)
+      
+    /** Is this symbol an annotation? */
+    final def isAnnotation(implicit ctx: Context): Boolean =
+      derivesFrom(defn.AnnotationClass)
 
     /** Is this symbol a package object or its module class? */
     def isPackageObject(implicit ctx: Context): Boolean = {
@@ -986,6 +990,9 @@ object SymDenotations {
 
     def nonMemberTermRef(implicit ctx: Context): TermRef =
       TermRef.withFixedSym(owner.thisType, name.asTermName, symbol.asTerm)
+      
+    def typeRefWithArgs(implicit ctx: Context): Type = 
+      typeRef.appliedTo(typeParams.map(_.typeRef))
 
     /** The variance of this type parameter or type member as an Int, with
      *  +1 = Covariant, -1 = Contravariant, 0 = Nonvariant, or not a type parameter

--- a/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -268,9 +268,7 @@ class TypeApplications(val self: Type) extends AnyVal {
           case _ => default
         }
       case tp @ RefinedType(parent, name) if !tp.member(name).symbol.is(ExpandedTypeParam) =>
-        val pbase = parent.baseTypeWithArgs(base)
-        if (pbase.member(name).exists) RefinedType(pbase, name, tp.refinedInfo)
-        else pbase
+        tp.wrapIfMember(parent.baseTypeWithArgs(base))
       case tp: TermRef =>
         tp.underlying.baseTypeWithArgs(base)
       case AndType(tp1, tp2) =>
@@ -281,7 +279,7 @@ class TypeApplications(val self: Type) extends AnyVal {
         default
     }
   }
-
+  
   /** Translate a type of the form From[T] to To[T], keep other types as they are.
    *  `from` and `to` must be static classes, both with one type parameter, and the same variance.
    */

--- a/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -354,7 +354,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
   def toText(sym: Symbol): Text =
     (kindString(sym) ~~ {
-      if (hasMeaninglessName(sym)) simpleNameString(sym.owner) + idString(sym)
+      if (sym.isAnonymousClass) toText(sym.info.parents, " with ") ~ "{...}"
+      else if (hasMeaninglessName(sym)) simpleNameString(sym.owner) + idString(sym)
       else nameString(sym)
     }).close
 

--- a/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
+++ b/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
@@ -41,7 +41,7 @@ class ConsoleReporter(
   }
 
   override def doReport(d: Diagnostic)(implicit ctx: Context): Unit =
-    if (!d.isSuppressed) d match {
+    if (!d.isSuppressed || !hasErrors) d match {
       case d: Error =>
         printMessageAndPos(s"error: ${d.msg}", d.pos)
         if (ctx.settings.prompt.value) displayPrompt()

--- a/src/dotty/tools/dotc/typer/Checking.scala
+++ b/src/dotty/tools/dotc/typer/Checking.scala
@@ -232,7 +232,7 @@ trait Checking {
 
   /** Check that type `tp` is stable. */
   def checkStable(tp: Type, pos: Position)(implicit ctx: Context): Unit =
-    if (!tp.isStable)
+    if (!tp.isStable && !tp.isErroneous)
       ctx.error(d"$tp is not stable", pos)
 
   /** Check that type `tp` is a legal prefix for '#'.

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -155,9 +155,20 @@ class Namer { typer: Typer =>
 
   import untpd._
 
+  /** Untyped tree was already typed, the attachment value is its typed versuon */
   val TypedAhead = new Attachment.Key[tpd.Tree]
+
+  /** Tree was expanded to by desugaring; the attachment value is its expansion */
   val ExpandedTree = new Attachment.Key[Tree]
+
+  /** Tree has been assigned a symbol, which is the attachment value */
   val SymOfTree = new Attachment.Key[Symbol]
+
+  /** `New` node is part of a parent constructor of a class, and can therefore be abstract */
+  val ParentNew = new Attachment.Key[Unit]
+
+  /** `New` node is an annotation, can be abstract if the annotation is Java defined */
+  val AnnotNew = new Attachment.Key[Unit]
 
   /** A partial map from unexpanded member and pattern defs and to their expansions.
    *  Populated during enterSyms, emptied during typer.
@@ -528,7 +539,8 @@ class Namer { typer: Typer =>
             case TypeApply(core, targs) => (core, targs)
             case core => (core, Nil)
           }
-          val Select(New(tpt), nme.CONSTRUCTOR) = core
+          val Select(nu @ New(tpt), nme.CONSTRUCTOR) = core
+          nu.putAttachment(ParentNew, ())
           val targs1 = targs map (typedAheadType(_))
           val ptype = typedAheadType(tpt).tpe appliedTo targs1.tpes
           if (ptype.typeParams.isEmpty) ptype

--- a/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -71,6 +71,17 @@ object RefChecks {
     }
   }
 
+  /** Check that self type of this class conforms to self types of parents */
+  private def checkSelfType(clazz: Symbol)(implicit ctx: Context): Unit = clazz.info match {
+    case cinfo: ClassInfo =>
+      for (parent <- cinfo.classParents) {
+        val pself = parent.givenSelfType.asSeenFrom(clazz.thisType, parent.classSymbol)
+        if (pself.exists && !(cinfo.selfType <:< pself))
+          ctx.error(d"illegal inheritance: self type ${cinfo.selfType} of $clazz does not conform to self type $pself of parent ${parent.classSymbol}", clazz.pos)
+      }
+    case _ =>
+  }
+
   // Override checking ------------------------------------------------------------
 
   /** 1. Check all members of class `clazz` for overriding conditions.
@@ -770,6 +781,7 @@ class RefChecks extends MiniPhase with SymTransformer { thisTransformer =>
     override def transformTemplate(tree: Template)(implicit ctx: Context, info: TransformerInfo) = {
       val cls = ctx.owner
       checkOverloadedRestrictions(cls)
+      checkSelfType(cls)
       checkAllOverrides(cls)
       checkAnyValSubclass(cls)
       tree

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -347,8 +347,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         val clsDef = TypeDef(x, templ).withFlags(Final)
         typed(cpy.Block(tree)(clsDef :: Nil, New(Ident(x), Nil)), pt)
       case _ =>
-          val tpt1 = typedType(tree.tpt)
-          checkClassTypeWithStablePrefix(tpt1.tpe, tpt1.pos, traitReq = false)
+	      val tpt1 = typedType(tree.tpt)
+	      checkClassTypeWithStablePrefix(tpt1.tpe, tpt1.pos, concreteReq = !ctx.owner.isClass)
         assignType(cpy.New(tree)(tpt1), tpt1)
         // todo in a later phase: checkInstantiatable(cls, tpt1.pos)
     }

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -348,7 +348,12 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         typed(cpy.Block(tree)(clsDef :: Nil, New(Ident(x), Nil)), pt)
       case _ =>
 	      val tpt1 = typedType(tree.tpt)
-	      checkClassTypeWithStablePrefix(tpt1.tpe, tpt1.pos, concreteReq = !ctx.owner.isClass)
+        val cls = tpt1.tpe.classSymbol
+        val isJavaAnnot = 
+          tree.hasAttachment(AnnotNew) && cls.is(JavaDefined) && cls.isAnnotation
+        val canBeAbstract = 
+          tree.hasAttachment(ParentNew) || isJavaAnnot || ctx.isAfterTyper
+        checkClassTypeWithStablePrefix(tpt1.tpe, tree.pos, concreteReq = !canBeAbstract)
         assignType(cpy.New(tree)(tpt1), tpt1)
         // todo in a later phase: checkInstantiatable(cls, tpt1.pos)
     }

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -25,7 +25,7 @@ import EtaExpansion.etaExpand
 import dotty.tools.dotc.transform.Erasure.Boxing
 import util.Positions._
 import util.common._
-import util.SourcePosition
+import util.{SourcePosition, Attachment}
 import collection.mutable
 import annotation.tailrec
 import Implicits._
@@ -868,7 +868,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   def typedAnnotation(annot: untpd.Tree)(implicit ctx: Context): Tree = track("typedAnnotation") {
-    typed(annot, defn.AnnotationClass.typeRef)
+    labelNew(annot, AnnotNew)
+    typedExpr(annot, defn.AnnotationClass.typeRef)
   }
 
   def typedValDef(vdef: untpd.ValDef, sym: Symbol)(implicit ctx: Context) = track("typedValDef") {
@@ -940,10 +941,19 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
    */
   def ensureConstrCall(cls: ClassSymbol, parents: List[Tree])(implicit ctx: Context): List[Tree] = {
     val firstParent :: otherParents = parents
-    if (firstParent.isType && !(cls is Trait))
-      typed(untpd.New(untpd.TypedSplice(firstParent), Nil)) :: otherParents
-    else parents
+    if (firstParent.isType && !(cls is Trait)) {
+      val constr = untpd.New(untpd.TypedSplice(firstParent), Nil)
+      labelNew(constr, ParentNew)
+      typed(constr) :: otherParents
+    } else parents
   }
+
+  /** If `tree` is an instance creation expression, attach the given label to its `New` node */
+  def labelNew(tree: untpd.Tree, label: Attachment.Key[Unit]): Unit = 
+    untpd.newPart(tree) match {
+      case nu: untpd.New => nu.putAttachment(label, ())
+      case _ =>
+    }
 
   /** Overridden in retyper */
   def checkVariance(tree: Tree)(implicit ctx: Context) = VarianceChecker.check(tree)
@@ -971,7 +981,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   def typedAnnotated(tree: untpd.Annotated, pt: Type)(implicit ctx: Context): Tree = track("typedAnnotated") {
-    val annot1 = typedExpr(tree.annot, defn.AnnotationClass.typeRef)
+    val annot1 = typedAnnotation(tree.annot)
     val arg1 = typed(tree.arg, pt)
     if (ctx.mode is Mode.Type)
       assignType(cpy.Annotated(tree)(annot1, arg1), annot1, arg1)

--- a/src/dotty/tools/dotc/util/Attachment.scala
+++ b/src/dotty/tools/dotc/util/Attachment.scala
@@ -19,7 +19,15 @@ object Attachment {
       val nx = next
       if (nx == null) None
       else if (nx.key eq key) Some(nx.value.asInstanceOf[V])
-      else nx.getAttachment[V](key)
+      else nx.getAttachment(key)
+    }
+    
+    /** Does tree have an attachment corresponding to `key`? */
+    final def hasAttachment[V](key: Key[V]): Boolean = {
+      val nx = next
+      if (nx == null) false
+      else if (nx.key eq key) true
+      else nx.hasAttachment(key)
     }
 
     /** The attachment corresponding to `key`.

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -126,6 +126,7 @@ class tests extends CompilerTest {
   @Test def neg_i0281 = compileFile(negDir, "i0281-null-primitive-conforms", xerrors = 3)
   @Test def neg_moduleSubtyping = compileFile(negDir, "moduleSubtyping", xerrors = 4)
   @Test def neg_escapingRefs = compileFile(negDir, "escapingRefs", xerrors = 2)
+  @Test def neg_selfInheritance = compileFile(negDir, "selfInheritance", xerrors = 5)
 
   @Test def dotc = compileDir(dotcDir + "tools/dotc", failedOther)(allowDeepSubtypes ++ twice) // see dotc_core
   @Test def dotc_ast = compileDir(dotcDir + "tools/dotc/ast", failedOther ++ twice)

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -126,6 +126,7 @@ class tests extends CompilerTest {
   @Test def neg_i0281 = compileFile(negDir, "i0281-null-primitive-conforms", xerrors = 3)
   @Test def neg_moduleSubtyping = compileFile(negDir, "moduleSubtyping", xerrors = 4)
   @Test def neg_escapingRefs = compileFile(negDir, "escapingRefs", xerrors = 2)
+  @Test def neg_instantiateAbstract = compileFile(negDir, "instantiateAbstract", xerrors = 8)
   @Test def neg_selfInheritance = compileFile(negDir, "selfInheritance", xerrors = 5)
 
   @Test def dotc = compileDir(dotcDir + "tools/dotc", failedOther)(allowDeepSubtypes ++ twice) // see dotc_core

--- a/tests/neg/instantiateAbstract.scala
+++ b/tests/neg/instantiateAbstract.scala
@@ -1,0 +1,38 @@
+abstract class AA
+
+trait TT
+
+class A { self: B =>
+
+}
+
+@scala.annotation.Annotation class C // error
+
+class B extends A() {
+}
+
+object Test {
+
+  @scala.annotation.Annotation type T = String // ok, annotations do not count as new
+  @scala.annotation.Annotation val x = 1 // ok
+  @scala.annotation.Annotation def f = 1 //ok
+
+  (1: @scala.annotation.Annotation) // ok
+
+
+  new AA // error
+
+  new TT // error
+
+  new A // error
+
+// the following are OK in Typer but would be caught later in RefChecks
+
+  new A() {}
+
+  new AA() {}
+
+  object O extends A
+
+  object OO extends AA
+}

--- a/tests/neg/selfInheritance.scala
+++ b/tests/neg/selfInheritance.scala
@@ -1,0 +1,28 @@
+trait T { self: B => }
+
+abstract class A { self: B =>
+
+}
+
+class B extends A with T {
+}
+
+class C { self: B =>
+
+}
+
+class D extends A      // error
+
+class E extends T      // error
+
+object Test {
+
+  new B() {}
+
+  new A() {}   // error
+
+  object O extends A  // error
+
+  object M extends C // error
+
+}


### PR DESCRIPTION
Add checks that abstract classes are not instantiated and that self types conform.

This was much more involved than previously thought. Major work was needed to
 - correctly compute self types outside of the classes in which they are defined.
 - propagate information whether a class needs to be abstract (particular challenge: Java annotations).

Review by @DarkDimius 