### PR TITLE
Alt/instantiation checks (2)

### DIFF
--- a/src/dotty/tools/dotc/Compiler.scala
+++ b/src/dotty/tools/dotc/Compiler.scala
@@ -6,7 +6,7 @@ import Contexts._
 import Periods._
 import Symbols._
 import Scopes._
-import typer.{FrontEnd, Typer, Mode, ImportInfo, RefChecks}
+import typer.{FrontEnd, Typer, Mode, ImportInfo, RefChecks, InstChecks}
 import reporting.ConsoleReporter
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.transform._
@@ -38,6 +38,7 @@ class Compiler {
   def phases: List[List[Phase]] =
     List(
       List(new FrontEnd),
+      List(new InstChecks),
       List(new FirstTransform,
            new SyntheticMethods),
       List(new SuperAccessors),

--- a/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/src/dotty/tools/dotc/ast/Desugar.scala
@@ -786,7 +786,7 @@ object desugar {
             New(ref(defn.RepeatedAnnot.typeRef), Nil :: Nil),
             AppliedTypeTree(ref(seqClass.typeRef), t))
         } else {
-          assert(ctx.mode.isExpr, ctx.mode)
+          assert(ctx.mode.isExpr || ctx.reporter.hasErrors, ctx.mode)
           Select(t, op)
         }
       case PrefixOp(op, t) =>

--- a/src/dotty/tools/dotc/core/Decorators.scala
+++ b/src/dotty/tools/dotc/core/Decorators.scala
@@ -7,6 +7,7 @@ import Contexts._, Names._, Phases._, printing.Texts._, printing.Printer, printi
 import util.Positions.Position, util.SourcePosition
 import collection.mutable.ListBuffer
 import dotty.tools.dotc.transform.TreeTransforms._
+import typer.Mode
 import scala.language.implicitConversions
 
 /** This object provides useful implicit decorators for types defined elsewhere */
@@ -172,7 +173,7 @@ object Decorators {
       def treatSingleArg(arg: Any) : Any =
         try
           arg match {
-            case arg: Showable => arg.show
+            case arg: Showable => arg.show(ctx.fresh.addMode(Mode.FutureDefsOK))
             case _ => arg
           }
         catch {

--- a/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -268,9 +268,7 @@ class TypeApplications(val self: Type) extends AnyVal {
           case _ => default
         }
       case tp @ RefinedType(parent, name) if !tp.member(name).symbol.is(ExpandedTypeParam) =>
-        val pbase = parent.baseTypeWithArgs(base)
-        if (pbase.member(name).exists) RefinedType(pbase, name, tp.refinedInfo)
-        else pbase
+        tp.wrapIfMember(parent.baseTypeWithArgs(base))
       case tp: TermRef =>
         tp.underlying.baseTypeWithArgs(base)
       case AndType(tp1, tp2) =>
@@ -281,7 +279,7 @@ class TypeApplications(val self: Type) extends AnyVal {
         default
     }
   }
-
+  
   /** Translate a type of the form From[T] to To[T], keep other types as they are.
    *  `from` and `to` must be static classes, both with one type parameter, and the same variance.
    */

--- a/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -354,7 +354,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
   def toText(sym: Symbol): Text =
     (kindString(sym) ~~ {
-      if (hasMeaninglessName(sym)) simpleNameString(sym.owner) + idString(sym)
+      if (sym.isAnonymousClass) toText(sym.info.parents, " with ") ~ "{...}"
+      else if (hasMeaninglessName(sym)) simpleNameString(sym.owner) + idString(sym)
       else nameString(sym)
     }).close
 

--- a/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
+++ b/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
@@ -41,7 +41,7 @@ class ConsoleReporter(
   }
 
   override def doReport(d: Diagnostic)(implicit ctx: Context): Unit =
-    if (!d.isSuppressed) d match {
+    if (!d.isSuppressed || !hasErrors) d match {
       case d: Error =>
         printMessageAndPos(s"error: ${d.msg}", d.pos)
         if (ctx.settings.prompt.value) displayPrompt()

--- a/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -35,6 +35,10 @@ class FirstTransform extends MiniPhaseTransform with IdentityDenotTransformer wi
   import ast.tpd._
 
   override def phaseName = "firstTransform"
+  
+  override def runsAfter = Set(classOf[typer.InstChecks]) 
+    // This phase makes annotations disappear in types, so InstChecks should
+    // run before so that it can get at all annotations.
 
   def transformInfo(tp: Type, sym: Symbol)(implicit ctx: Context): Type = tp
 

--- a/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/src/dotty/tools/dotc/transform/Pickler.scala
@@ -27,26 +27,24 @@ class Pickler extends Phase {
 
   override def run(implicit ctx: Context): Unit = {
     val unit = ctx.compilationUnit
-    if (!unit.isJava) {
-      val tree = unit.tpdTree
-      pickling.println(i"unpickling in run ${ctx.runId}")
-      if (ctx.settings.YtestPickler.value) beforePickling(unit) = tree.show
+    val tree = unit.tpdTree
+    pickling.println(i"unpickling in run ${ctx.runId}")
+    if (ctx.settings.YtestPickler.value) beforePickling(unit) = tree.show
 
-      val pickler = unit.pickler
-      val treePkl = new TreePickler(pickler)
-      treePkl.pickle(tree :: Nil)
-      unit.addrOfTree = treePkl.buf.addrOfTree
-      unit.addrOfSym = treePkl.addrOfSym
-      if (tree.pos.exists)
-        new PositionPickler(pickler, treePkl.buf.addrOfTree).picklePositions(tree :: Nil, tree.pos)
+    val pickler = unit.pickler
+    val treePkl = new TreePickler(pickler)
+    treePkl.pickle(tree :: Nil)
+    unit.addrOfTree = treePkl.buf.addrOfTree
+    unit.addrOfSym = treePkl.addrOfSym
+    if (tree.pos.exists)
+      new PositionPickler(pickler, treePkl.buf.addrOfTree).picklePositions(tree :: Nil, tree.pos)
 
-      def rawBytes = // not needed right now, but useful to print raw format.
-        unit.pickler.assembleParts().iterator.grouped(10).toList.zipWithIndex.map {
-          case (row, i) => s"${i}0: ${row.mkString(" ")}"
-        }
-      // println(i"rawBytes = \n$rawBytes%\n%") // DEBUG
-      if (pickling ne noPrinter) new TastyPrinter(pickler.assembleParts()).printContents()
-    }
+    def rawBytes = // not needed right now, but useful to print raw format.
+      unit.pickler.assembleParts().iterator.grouped(10).toList.zipWithIndex.map {
+        case (row, i) => s"${i}0: ${row.mkString(" ")}"
+      }
+    // println(i"rawBytes = \n$rawBytes%\n%") // DEBUG
+    if (pickling ne noPrinter) new TastyPrinter(pickler.assembleParts()).printContents()
   }
 
   override def runOn(units: List[CompilationUnit])(implicit ctx: Context): List[CompilationUnit] = {

--- a/src/dotty/tools/dotc/typer/Checking.scala
+++ b/src/dotty/tools/dotc/typer/Checking.scala
@@ -232,7 +232,7 @@ trait Checking {
 
   /** Check that type `tp` is stable. */
   def checkStable(tp: Type, pos: Position)(implicit ctx: Context): Unit =
-    if (!tp.isStable)
+    if (!tp.isStable && !tp.isErroneous)
       ctx.error(d"$tp is not stable", pos)
 
   /** Check that type `tp` is a legal prefix for '#'.

--- a/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -51,7 +51,7 @@ class FrontEnd extends Phase {
     unitContexts foreach (enterSyms(_))
     unitContexts foreach (typeCheck(_))
     record("totalTrees", ast.Trees.ntrees)
-    unitContexts.map(_.compilationUnit)
+    unitContexts.map(_.compilationUnit).filter(!_.isJava)
   }
 
   override def run(implicit ctx: Context): Unit = {

--- a/src/dotty/tools/dotc/typer/InstChecks.scala
+++ b/src/dotty/tools/dotc/typer/InstChecks.scala
@@ -9,9 +9,10 @@ import Types._, Symbols._, Flags._, StdNames._
 import util.Positions._
 import ast.Trees._
 import typer.ErrorReporting._
+import DenotTransformers._
 
 /** This checks `New` nodes, verifying that they can be instantiated. */
-class InstChecks extends Phase {
+class InstChecks extends Phase with IdentityDenotTransformer {
   import ast.tpd._
 
   override def phaseName: String = "instchecks"

--- a/src/dotty/tools/dotc/typer/InstChecks.scala
+++ b/src/dotty/tools/dotc/typer/InstChecks.scala
@@ -1,0 +1,89 @@
+package dotty.tools.dotc
+package typer
+
+import core._
+import Contexts.Context
+import Decorators._
+import Phases._
+import Types._, Symbols._, Flags._, StdNames._
+import util.Positions._
+import ast.Trees._
+import typer.ErrorReporting._
+
+/** This checks `New` nodes, verifying that they can be instantiated. */
+class InstChecks extends Phase {
+  import ast.tpd._
+
+  override def phaseName: String = "instchecks"
+
+  override def run(implicit ctx: Context): Unit =
+    instCheck.traverse(ctx.compilationUnit.tpdTree)
+  
+  /** Check that `tp` refers to a nonAbstract class
+   *  and that the instance conforms to the self type of the created class.
+   */
+  def checkInstantiatable(tp: Type, pos: Position)(implicit ctx: Context): Unit =
+    tp.underlyingClassRef(refinementOK = false) match {
+      case tref: TypeRef =>
+        val cls = tref.symbol
+        if (cls.is(AbstractOrTrait))
+          ctx.error(d"$cls is abstract; cannot be instantiated", pos)
+        if (!cls.is(Module)) {
+          val selfType = tp.givenSelfType.asSeenFrom(tref.prefix, cls.owner)
+          if (selfType.exists && !(tp <:< selfType))
+            ctx.error(d"$tp does not conform to its self type $selfType; cannot be instantiated")
+        }
+      case _ =>
+    }
+  
+  def checkValidJavaAnnotation(annot: Tree)(implicit ctx: Context): Unit = {
+    // TODO fill in
+  }
+
+  val instCheck = new TreeTraverser {
+    
+    def checkAnnot(annot: Tree)(implicit ctx: Context): Unit = 
+      if (annot.symbol.is(JavaDefined)) checkValidJavaAnnotation(annot)
+      else traverse(annot)
+      
+    def traverseNoCheck(tree: Tree)(implicit ctx: Context): Unit = tree match {
+      case Apply(fn, args) =>
+        traverseNoCheck(fn)
+        args.foreach(traverse)
+      case TypeApply(fn, args) =>
+        traverseNoCheck(fn)
+        args.foreach(traverse)
+      case Select(qual, nme.CONSTRUCTOR) =>
+        traverseNoCheck(qual)
+      case New(tpt) =>
+        traverse(tpt)
+      case _ =>
+        traverse(tree)
+    }
+    
+    def traverse(tree: Tree)(implicit ctx: Context): Unit = tree match {
+      case tree: New =>
+        checkInstantiatable(tree.tpe, tree.pos)
+        traverseChildren(tree)
+      case impl @ Template(constr, parents, self, _) =>
+        traverse(constr)
+        parents.foreach(traverseNoCheck)
+        traverse(self)
+        impl.body.foreach(traverse)
+      case Annotated(annot, tree) =>
+        checkAnnot(annot)
+        traverse(tree)
+      case TypeTree(original) =>
+        tree.tpe match {
+          case AnnotatedType(annot, tpe) => checkAnnot(annot.tree)
+          case _ =>
+        }
+        traverse(original)
+      case tree: MemberDef =>
+        tree.symbol.annotations.foreach(annot => checkAnnot(annot.tree))
+        traverseChildren(tree)
+      case _ =>
+        traverseChildren(tree)
+    }
+  }
+}

--- a/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -71,6 +71,17 @@ object RefChecks {
     }
   }
 
+  /** Check that self type of this class conforms to self types of parents */
+  private def checkSelfType(clazz: Symbol)(implicit ctx: Context): Unit = clazz.info match {
+    case cinfo: ClassInfo =>
+      for (parent <- cinfo.classParents) {
+        val pself = parent.givenSelfType.asSeenFrom(clazz.thisType, parent.classSymbol)
+        if (pself.exists && !(cinfo.selfType <:< pself))
+          ctx.error(d"illegal inheritance: self type ${cinfo.selfType} of $clazz does not conform to self type $pself of parent ${parent.classSymbol}", clazz.pos)
+      }
+    case _ =>
+  }
+
   // Override checking ------------------------------------------------------------
 
   /** 1. Check all members of class `clazz` for overriding conditions.
@@ -770,6 +781,7 @@ class RefChecks extends MiniPhase with SymTransformer { thisTransformer =>
     override def transformTemplate(tree: Template)(implicit ctx: Context, info: TransformerInfo) = {
       val cls = ctx.owner
       checkOverloadedRestrictions(cls)
+      checkSelfType(cls)
       checkAllOverrides(cls)
       checkAnyValSubclass(cls)
       tree

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -126,6 +126,7 @@ class tests extends CompilerTest {
   @Test def neg_i0281 = compileFile(negDir, "i0281-null-primitive-conforms", xerrors = 3)
   @Test def neg_moduleSubtyping = compileFile(negDir, "moduleSubtyping", xerrors = 4)
   @Test def neg_escapingRefs = compileFile(negDir, "escapingRefs", xerrors = 2)
+  @Test def neg_selfInheritance = compileFile(negDir, "selfInheritance", xerrors = 5)
 
   @Test def dotc = compileDir(dotcDir + "tools/dotc", failedOther)(allowDeepSubtypes ++ twice) // see dotc_core
   @Test def dotc_ast = compileDir(dotcDir + "tools/dotc/ast", failedOther ++ twice)

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -126,6 +126,7 @@ class tests extends CompilerTest {
   @Test def neg_i0281 = compileFile(negDir, "i0281-null-primitive-conforms", xerrors = 3)
   @Test def neg_moduleSubtyping = compileFile(negDir, "moduleSubtyping", xerrors = 4)
   @Test def neg_escapingRefs = compileFile(negDir, "escapingRefs", xerrors = 2)
+  @Test def neg_instantiateAbstract = compileFile(negDir, "instantiateAbstract", xerrors = 8)
   @Test def neg_selfInheritance = compileFile(negDir, "selfInheritance", xerrors = 5)
 
   @Test def dotc = compileDir(dotcDir + "tools/dotc", failedOther)(allowDeepSubtypes ++ twice) // see dotc_core

--- a/tests/neg/instantiateAbstract.scala
+++ b/tests/neg/instantiateAbstract.scala
@@ -1,0 +1,38 @@
+abstract class AA
+
+trait TT
+
+class A { self: B =>
+
+}
+
+@scala.annotation.Annotation class C // error
+
+class B extends A() {
+}
+
+object Test {
+
+  @scala.annotation.Annotation type T = String // error
+  @scala.annotation.Annotation val x = 1 // error
+  @scala.annotation.Annotation def f = 1 //error
+
+  (1: @scala.annotation.Annotation) // error
+
+
+  new AA // error
+
+  new TT // error
+
+  new A // error
+
+// the following are OK in Typer but would be caught later in RefChecks
+
+  new A() {}
+
+  new AA() {}
+
+  object O extends A
+
+  object OO extends AA
+}

--- a/tests/neg/selfInheritance.scala
+++ b/tests/neg/selfInheritance.scala
@@ -1,0 +1,28 @@
+trait T { self: B => }
+
+abstract class A { self: B =>
+
+}
+
+class B extends A with T {
+}
+
+class C { self: B =>
+
+}
+
+class D extends A      // error
+
+class E extends T      // error
+
+object Test {
+
+  new B() {}
+
+  new A() {}   // error
+
+  object O extends A  // error
+
+  object M extends C // error
+
+}


### PR DESCRIPTION
Alternative to #471. Add a separate phase that checks that abstract classes are not instantiated and that self types conform.

This is probably easier to understand than #471 because the flow is concentrated in one tree traversal instead of being indirectly established by adding attachments to trees and looking at them.

Review by @DarkDimius