### PR TITLE
Fix #480 in LambdaLift

### DIFF
--- a/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -394,8 +394,13 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
       val sym = tree.symbol
       tree.tpe match {
         case tpe @ TermRef(prefix, _) =>
-          if ((prefix eq NoPrefix) && sym.enclosure != currentEnclosure && !sym.isStatic)
-            (if (sym is Method) memberRef(sym) else proxyRef(sym)).withPos(tree.pos)
+          if (prefix eq NoPrefix) 
+            if (sym.enclosure != currentEnclosure && !sym.isStatic)
+              (if (sym is Method) memberRef(sym) else proxyRef(sym)).withPos(tree.pos)
+            else if (sym.owner.isClass) // sym was lifted out
+              ref(sym).withPos(tree.pos)
+            else 
+              tree
           else if (!prefixIsElidable(tpe)) ref(tpe)
           else tree
         case _ =>

--- a/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -294,7 +294,7 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
         local.copySymDenotation(
           owner = newOwner,
           name = newName(local),
-          initFlags = local.flags | Private | maybeStatic | maybeNotJavaPrivate,
+          initFlags = local.flags &~ InSuperCall | Private | maybeStatic | maybeNotJavaPrivate,
           info = liftedInfo(local)).installAfter(thisTransform)
         if (local.isClass)
           for (member <- local.asClass.info.decls)

--- a/tests/pos/i342.scala
+++ b/tests/pos/i342.scala
@@ -1,0 +1,10 @@
+object Test {
+  def test2: Int = {
+    var ds: String = null
+    def s = {
+      ds = "abs"
+      ds
+    }
+    s.length
+  }
+}

--- a/tests/pos/i480.scala
+++ b/tests/pos/i480.scala
@@ -1,0 +1,4 @@
+object O {
+  val x: Function1[String, String] = a => a
+  val x2: Function1[String, String] = a => "1"
+}

--- a/tests/pos/i480a.scala
+++ b/tests/pos/i480a.scala
@@ -1,0 +1,15 @@
+package test
+
+/** A class defining symbols and types of standard definitions */
+class Definitions {
+
+  trait LazyType { def complete(): Unit }
+
+  def f(vcs: List[Int]): Unit = {
+    val completer = new LazyType  {
+      def complete(): Unit =
+        for (i <- 0 until vcs.length if vcs(i) != 0)
+          f(vcs.updated(i, 0))
+    }
+  }
+}


### PR DESCRIPTION
Fix two errors, where the first masked the second:

1) Variables defined in a method are not free variables of that method. This was mispredicated before
and caused liftedOwner to be updated to the class enclosing the method, thereby preventing any method
that refers to a local parameter or symbol to be hoisted.

Once this was fixed, methods were hoisted too far out. Test case in #480a, which takes code from Definitions. This was fixed by

2) markFree is updated to do an additional narrowLiftedOwner so that, if a free variable gets a proxy
in an enclosing class, any inner classes and methods are kept within that class.

@review by @DarkDimius 