### PR TITLE
TypeAssigner: fix return type of clone() for arrays

### DIFF
--- a/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -210,7 +210,13 @@ trait TypeAssigner {
       case p.arrayApply => MethodType(defn.IntType :: Nil, arrayElemType)
       case p.arrayUpdate => MethodType(defn.IntType :: arrayElemType :: Nil, defn.UnitType)
       case p.arrayLength => MethodType(Nil, defn.IntType)
-      case nme.clone_ if qualType.isInstanceOf[JavaArrayType] => MethodType(Nil, qualType)
+
+      // Note that we do not need to handle calls to Array[T]#clone() specially:
+      // The JLS section 10.7 says "The return type of the clone method of an array type
+      // T[] is T[]", but the actual return type at the bytecode level is Object which
+      // is casted to T[] by javac. Since the return type of Array[T]#clone() is Array[T],
+      // this is exactly what Erasure will do.
+
       case _ => accessibleSelectionType(tree, qual)
     }
     tree.withType(tp)


### PR DESCRIPTION
Given the following code:
```scala
  val x: Array[String] = new Array[String](1)
  x(0) = "foo"
  println(x.clone().apply(0))
```

Before this commit, the last line was rewritten in Erasure to:
```scala
  println(x.clone().[]apply(0))
```
This is incorrect: clone() returns an Object, so a cast is necessary,
this resulted in the following failure at runtime:
```scala
  java.lang.VerifyError: Bad type on operand stack in aaload
```

After this commit, the last line is rewritten in Erasure to:
```scala
  println(x.clone().asInstanceOf[String[]].[]apply(0))
```
This corresponds to adding a "checkcast" instruction in the generated
bytecode, and is enough to fix the runtime error.

Review by @odersky .