### PR TITLE
Fix #511. Lambdas of traits that inherit abstract member.

### DIFF
--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -733,6 +733,10 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
 
 
     def addRemoteRemoteExceptionAnnotation: Unit = ()
+
+    def samMethod(): Symbol =
+      toDenot(sym).info.membersBasedOnFlags(Flags.Deferred, Flags.EmptyFlags).flatMap(_.altsWith(_ is Flags.Method)).
+        headOption.getOrElse(toDenot(sym).info.member(nme.apply)).symbol
   }
 
 

--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -735,8 +735,7 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
     def addRemoteRemoteExceptionAnnotation: Unit = ()
 
     def samMethod(): Symbol =
-      toDenot(sym).info.membersBasedOnFlags(Flags.Deferred, Flags.EmptyFlags).flatMap(_.altsWith(_ is Flags.Method)).
-        headOption.getOrElse(toDenot(sym).info.member(nme.apply)).symbol
+      toDenot(sym).info.abstractTermMembers.headOption.getOrElse(toDenot(sym).info.member(nme.apply)).symbol
   }
 
 


### PR DESCRIPTION
The fix will not be effective until we update scalac fork dependency to include https://github.com/DarkDimius/scala/commit/9c054bd687bbbcaa75f3f10a1d343998c6c1a2ba
As bug is minor I do not want to update scalac dependency just yet.