### PR TITLE
Pickling modularization reorg

### DIFF
--- a/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/src/dotty/tools/dotc/CompilationUnit.scala
@@ -2,10 +2,9 @@ package dotty.tools
 package dotc
 
 import dotty.tools.dotc.core.Types.Type
-import dotty.tools.dotc.core.pickling.{TastyBuffer, TastyPickler}
+import dotty.tools.dotc.core.tasty.{TastyBuffer, TastyPickler}
 import util.SourceFile
 import ast.{tpd, untpd}
-import TastyBuffer._
 import dotty.tools.dotc.core.Symbols._
 
 class CompilationUnit(val source: SourceFile) {

--- a/src/dotty/tools/dotc/FromTasty.scala
+++ b/src/dotty/tools/dotc/FromTasty.scala
@@ -14,7 +14,7 @@ import Phases.Phase
 import util._
 import Decorators._
 import dotty.tools.dotc.transform.Pickler
-import pickling.DottyUnpickler
+import tasty.DottyUnpickler
 import ast.tpd._
 
 /** Compiler for TASTY files.

--- a/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -27,7 +27,7 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
   /** Does tree contain an initialization part when seen as a member of a class or trait?
    */
   def isNoInitMember(tree: Tree): Boolean = unsplice(tree) match {
-    case EmptyTree | Import(_, _) | TypeDef(_, _) => true
+    case EmptyTree | Import(_, _) | TypeDef(_, _) | DefDef(_, _, _, _, _) => true
     case tree: ValDef => tree.unforcedRhs == EmptyTree
     case _ => false
   }

--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -4,7 +4,7 @@ package core
 
 import Types._, Contexts._, Symbols._, Denotations._, SymDenotations._, StdNames._, Names._
 import Flags._, Scopes._, Decorators._, NameOps._, util.Positions._
-import pickling.Scala2Unpickler.ensureConstructor
+import unpickleScala2.Scala2Unpickler.ensureConstructor
 import scala.annotation.{ switch, meta }
 import scala.collection.{ mutable, immutable }
 import PartialFunction._

--- a/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -13,7 +13,7 @@ import dotty.tools.io.{ ClassPath, AbstractFile }
 import Contexts._, Symbols._, Flags._, SymDenotations._, Types._, Scopes._, util.Positions._, Names._
 import StdNames._, NameOps._
 import Decorators.{StringDecorator, StringInterpolators}
-import pickling.ClassfileParser
+import classfile.ClassfileParser
 import scala.util.control.NonFatal
 
 object SymbolLoaders {

--- a/src/dotty/tools/dotc/core/classfile/AbstractFileReader.scala
+++ b/src/dotty/tools/dotc/core/classfile/AbstractFileReader.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package classfile
 
 import java.lang.Float.intBitsToFloat
 import java.lang.Double.longBitsToDouble

--- a/src/dotty/tools/dotc/core/classfile/ByteCodecs.scala
+++ b/src/dotty/tools/dotc/core/classfile/ByteCodecs.scala
@@ -5,7 +5,7 @@
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
 \*                                                                      */
-package dotty.tools.dotc.core.pickling
+package dotty.tools.dotc.core.classfile
 
 object ByteCodecs {
 

--- a/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
+++ b/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
@@ -1,5 +1,6 @@
-package dotty.tools.dotc.core
-package pickling
+package dotty.tools.dotc
+package core
+package classfile
 
 import scala.annotation.switch
 

--- a/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -1,10 +1,10 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package classfile
 
 import Contexts._, Symbols._, Types._, Names._, StdNames._, NameOps._, Scopes._, Decorators._
-import SymDenotations._, Scala2Unpickler._, Constants._, Annotations._, util.Positions._
+import SymDenotations._, unpickleScala2.Scala2Unpickler._, Constants._, Annotations._, util.Positions._
 import ast.tpd._
 import java.io.{ File, IOException }
 import java.lang.Integer.toHexString
@@ -672,13 +672,13 @@ class ClassfileParser(
       }
 
       def unpickleScala(bytes: Array[Byte]): Some[Embedded] = {
-        val unpickler = new Scala2Unpickler(bytes, classRoot, moduleRoot)(ctx)
+        val unpickler = new unpickleScala2.Scala2Unpickler(bytes, classRoot, moduleRoot)(ctx)
         unpickler.run()
         Some(unpickler)
       }
 
       def unpickleTASTY(bytes: Array[Byte]): Some[Embedded]  = {
-        val unpickler = new DottyUnpickler(bytes)
+        val unpickler = new tasty.DottyUnpickler(bytes)
         unpickler.enter(roots = Set(classRoot, moduleRoot, moduleRoot.sourceModule))
         Some(unpickler)
       }

--- a/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package tasty
 
 import Contexts._, SymDenotations._
 import dotty.tools.dotc.ast.tpd
@@ -9,6 +9,7 @@ import TastyUnpickler._, TastyBuffer._
 import util.Positions._
 import util.{SourceFile, NoSource}
 import PositionUnpickler._
+import classfile.ClassfileParser
 
 object DottyUnpickler {
 

--- a/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
+++ b/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package tasty
 
 import collection.mutable
 import Names.{Name, chrs}
@@ -9,7 +9,7 @@ import Decorators._, NameOps._
 import TastyBuffer._
 import scala.io.Codec
 import TastyName._
-import PickleFormat._
+import TastyFormat._
 
 class NameBuffer extends TastyBuffer(10000) {
 

--- a/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -1,11 +1,11 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package tasty
 
 import ast.tpd._
 import ast.Trees.WithLazyField
-import PickleFormat._
+import TastyFormat._
 import core._
 import Contexts._, Symbols._, Types._, Names._, Constants._, Decorators._, Annotations._
 import collection.mutable

--- a/src/dotty/tools/dotc/core/tasty/PositionUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/PositionUnpickler.scala
@@ -1,7 +1,8 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package tasty
+
 
 import util.Positions._
 import collection.mutable

--- a/src/dotty/tools/dotc/core/tasty/TastyBuffer.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyBuffer.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package tasty
 
 import util.Util.dble
 

--- a/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -1,6 +1,6 @@
 package dotty.tools.dotc
 package core
-package pickling
+package tasty
 
 /************************************************************
 Notation:
@@ -205,7 +205,7 @@ Standard Section: "Positions" sourceLength_Nat Assoc*
 
 **************************************************************************************/
 
-object PickleFormat {
+object TastyFormat {
 
   final val header = Array(0x5C, 0xA1, 0xAB, 0x1F)
   final val MajorVersion = 0

--- a/src/dotty/tools/dotc/core/tasty/TastyName.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyName.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package tasty
 
 import core.Names.TermName
 import collection.mutable

--- a/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
@@ -1,9 +1,9 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package tasty
 
-import PickleFormat._
+import TastyFormat._
 import collection.mutable
 import TastyBuffer._
 import java.util.UUID

--- a/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -1,6 +1,6 @@
 package dotty.tools.dotc
 package core
-package pickling
+package tasty
 
 import Contexts._, Decorators._
 import printing.Texts._
@@ -43,7 +43,7 @@ class TastyPrinter(bytes: Array[Byte])(implicit ctx: Context) {
   }
 
   class TreeSectionUnpickler extends SectionUnpickler[Unit]("ASTs") {
-    import PickleFormat._
+    import TastyFormat._
     def unpickle(reader: TastyReader, tastyName: TastyName.Table): Unit = {
       import reader._
       var indent = 0

--- a/src/dotty/tools/dotc/core/tasty/TastyReader.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyReader.scala
@@ -1,8 +1,7 @@
 package dotty.tools
 package dotc
 package core
-package pickling
-
+package tasty
 
 import TastyBuffer._
 import TastyName.NameRef

--- a/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -1,9 +1,9 @@
 package dotty.tools.dotc
 package core
-package pickling
+package tasty
 
 import scala.collection.mutable
-import PickleFormat._
+import TastyFormat._
 import Names.{Name, termName}
 import java.util.UUID
 

--- a/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package tasty
 
 import util.Util.{bestFit, dble}
 import TastyBuffer.{Addr, AddrWidth}
@@ -17,7 +17,7 @@ class TreeBuffer extends TastyBuffer(50000) {
   private var delta: Array[Int] = _
   private var numOffsets = 0
 
-  private[pickling] val pickledTrees = new java.util.IdentityHashMap[Tree, Any] // Value type is really Addr, but that's not compatible with null
+  private[tasty] val pickledTrees = new java.util.IdentityHashMap[Tree, Any] // Value type is really Addr, but that's not compatible with null
 
   def addrOfTree(tree: Tree): Option[Addr] = pickledTrees.get(tree) match {
     case null => None

--- a/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -1,11 +1,10 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package tasty
 
 import ast.Trees._
-import PickleFormat._
-import core._
+import TastyFormat._
 import Contexts._, Symbols._, Types._, Names._, Constants._, Decorators._, Annotations._, StdNames.tpnme, NameOps._
 import collection.mutable
 import NameOps._
@@ -190,7 +189,7 @@ class TreePickler(pickler: TastyPickler) {
           pickleName(tpe.name); pickleType(tpe.prefix)
         }
       case tpe: ThisType =>
-        if (tpe.cls.is(Flags.Package) && !tpe.cls.isEffectiveRoot) 
+        if (tpe.cls.is(Flags.Package) && !tpe.cls.isEffectiveRoot)
           picklePackageRef(tpe.cls)
         else {
           writeByte(THIS)
@@ -260,7 +259,7 @@ class TreePickler(pickler: TastyPickler) {
         println(i"error while pickling type $tpe")
         throw ex
     }
-    
+
     def picklePackageRef(pkg: Symbol): Unit = {
       writeByte(TERMREFpkg)
       pickleName(qualifiedName(pkg))

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package tasty
 
 import Contexts._, Symbols._, Types._, Scopes._, SymDenotations._, Names._, NameOps._
 import StdNames._, Denotations._, Flags._, Constants._, Annotations._
@@ -9,19 +9,18 @@ import util.Positions._
 import dotty.tools.dotc.ast.{tpd, Trees, untpd}
 import Trees._
 import Decorators._
-import TastyUnpickler._, TastyBuffer._
+import TastyUnpickler._, TastyBuffer._, PositionPickler._
 import annotation.switch
 import scala.collection.{ mutable, immutable }
 import typer.Mode
 import config.Printers.pickling
-import PositionPickler._
 
 /** Unpickler for typed trees
  *  @param reader         the reader from which to unpickle
  *  @param tastyName      the nametable
  */
 class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
-  import dotty.tools.dotc.core.pickling.PickleFormat._
+  import TastyFormat._
   import TastyName._
   import tpd._
 

--- a/src/dotty/tools/dotc/core/unpickleScala2/PickleBuffer.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/PickleBuffer.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package unpickleScala2
 
 import Flags._
 

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc
 package core
-package pickling
+package unpickleScala2
 
 import java.io.IOException
 import java.lang.Float.intBitsToFloat
@@ -20,6 +20,7 @@ import typer.Checking.checkNonCyclic
 import PickleBuffer._
 import scala.reflect.internal.pickling.PickleFormat._
 import Decorators._
+import classfile.ClassfileParser
 import scala.collection.{ mutable, immutable }
 import scala.collection.mutable.ListBuffer
 import scala.annotation.switch

--- a/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/src/dotty/tools/dotc/transform/Pickler.scala
@@ -4,7 +4,7 @@ package transform
 import core._
 import Contexts.Context
 import Decorators._
-import pickling._
+import tasty._
 import config.Printers.{noPrinter, pickling}
 import java.io.PrintStream
 import Periods._

--- a/src/dotty/tools/dotc/util/ShowPickled.scala
+++ b/src/dotty/tools/dotc/util/ShowPickled.scala
@@ -7,7 +7,7 @@ import java.lang.Float.intBitsToFloat
 import java.lang.Double.longBitsToDouble
 import scala.reflect.internal.Flags
 import scala.reflect.internal.pickling.PickleFormat
-import core.pickling.PickleBuffer
+import core.unpickleScala2.PickleBuffer
 import core.Names._
 
 object ShowPickled {


### PR DESCRIPTION
The pickling package got rather large and confusing with three
separate tasks that each had their own conventions: read JVM classfiles,
read Scala2 pickle info, read and write Tasty. The classes for each task are now in
separate packages.