### PR TITLE
Fix #523: Instantiate lower bound when bounds checking

### DIFF
--- a/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/src/dotty/tools/dotc/core/TypeOps.scala
@@ -352,10 +352,11 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         //println(i"instantiating ${bounds.hi} with $argTypes")
         //println(i" = ${instantiate(bounds.hi, argTypes)}")
         val hiBound = instantiate(bounds.hi, argTypes.mapConserve(_.bounds.hi))
+        val loBound = instantiate(bounds.lo, argTypes.mapConserve(_.bounds.lo))
           // Note that argTypes can contain a TypeBounds type for arguments that are
           // not fully determined. In that case we need to check against the hi bound of the argument.
         if (!(lo <:< hiBound)) violations += ((arg, "upper", hiBound))
-        if (!(bounds.lo <:< hi)) violations += ((arg, "lower", bounds.lo))
+        if (!(loBound <:< hi)) violations += ((arg, "lower", bounds.lo))
       }
       arg.tpe match {
         case TypeBounds(lo, hi) => checkOverlapsBounds(lo, hi)

--- a/tests/pos/i523.scala
+++ b/tests/pos/i523.scala
@@ -1,0 +1,8 @@
+class X
+class A {
+  def foo[T1, T2 >: T1]: Unit = {}
+
+  def test = {
+    foo[X, X]
+  }
+}


### PR DESCRIPTION
Lower bounds need to be instantiated just like upper bounds.
F-bounded polymorphism (which only applies to upper bounds)
is one reason for instantiating arguments, but parameters
referring to other parameters is another one. And the latter
applies to lower bounds as well.

Review by @smarter