### PR TITLE
Fix #518 - compute denotations

### DIFF
--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -451,7 +451,6 @@ class Definitions {
 
   lazy val RootImports = List[Symbol](JavaLangPackageVal, ScalaPackageVal, ScalaPredefModule, DottyPredefModule)
 
-  lazy val overriddenBySynthetic = Set[Symbol](Any_equals, Any_hashCode, Any_toString, Product_canEqual)
   def isTupleType(tp: Type)(implicit ctx: Context) = {
     val arity = tp.dealias.argInfos.length
     arity <= MaxTupleArity && (tp isRef TupleClass(arity))

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -1283,9 +1283,7 @@ object Types {
           (lastDefRunId == NoRunId)
         } ||
         (lastSymbol.infoOrCompleter == ErrorType ||
-        defn.overriddenBySynthetic.contains(lastSymbol)
-          // for overriddenBySynthetic symbols a TermRef such as SomeCaseClass.this.hashCode
-          // might be rewritten from Object#hashCode to the hashCode generated at SyntheticMethods
+        sym.owner.derivesFrom(lastSymbol.owner) && sym.owner != lastSymbol.owner
       ),
         s"data race? overwriting symbol of ${this.show} / $this / ${this.getClass} / ${lastSymbol.id} / ${sym.id} / ${sym.owner} / ${lastSymbol.owner} / ${ctx.phase}")
 

--- a/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -54,7 +54,7 @@ class ExtensionMethods extends MiniPhaseTransform with DenotTransformer with Ful
           ctx.atPhase(thisTransformer.next) { implicit ctx =>
             // In Scala 2, extension methods are added before pickling so we should
             // not generate them again.
-            if (!(origClass is Scala2x)) {
+            if (!(origClass is Scala2x)) ctx.atPhase(thisTransformer) { implicit ctx =>
               for (decl <- origClass.classInfo.decls) {
                 if (isMethodWithExtension(decl))
                   decls1.enter(createExtensionMethod(decl, ref.symbol))
@@ -91,7 +91,6 @@ class ExtensionMethods extends MiniPhaseTransform with DenotTransformer with Ful
     else NoSymbol
 
   private def createExtensionMethod(imeth: Symbol, staticClass: Symbol)(implicit ctx: Context): TermSymbol = {
-    assert(ctx.phase == thisTransformer.next)
     val extensionName = extensionNames(imeth).head.toTermName
     val extensionMeth = ctx.newSymbol(staticClass, extensionName,
       imeth.flags | Final &~ (Override | Protected | AbsOverride),

--- a/tests/pos/i518.scala
+++ b/tests/pos/i518.scala
@@ -1,0 +1,6 @@
+class Meter(val underlying: Int) extends AnyVal
+
+class Test {
+  val x: Int = new Meter(3).hashCode()
+   // After phase VCInline the rhs should be expanded to Meter.hashCode$extension(3)
+}


### PR DESCRIPTION
Take overriding into account when cpmputing denotations. Fixes #518. Review by @smarter @DarkDimius 