### PR TITLE
Allow to compile root import classes without special option.

### DIFF
--- a/src/dotty/tools/dotc/Compiler.scala
+++ b/src/dotty/tools/dotc/Compiler.scala
@@ -104,11 +104,9 @@ class Compiler {
       .setMode(Mode.ImplicitsEnabled)
       .setTyperState(new MutableTyperState(ctx.typerState, new ConsoleReporter()(ctx), isCommittable = true))
     ctx.definitions.init(start) // set context of definitions to start
-    start.setRunInfo(new RunInfo(start))
-    def addImport(ctx: Context, sym: Symbol) =
-      ctx.fresh.setImportInfo(ImportInfo.rootImport(sym)(ctx))
-    if (ctx.settings.YnoImports.value) start
-    else (start /: defn.RootImports)(addImport)
+    def addImport(ctx: Context, symf: () => Symbol) =
+      ctx.fresh.setImportInfo(ImportInfo.rootImport(symf)(ctx))
+    (start.setRunInfo(new RunInfo(start)) /: defn.RootImportFns)(addImport)
   }
 
   def reset()(implicit ctx: Context): Unit = {

--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -449,7 +449,9 @@ class Definitions {
 
   lazy val isPolymorphicAfterErasure = Set[Symbol](Any_isInstanceOf, Any_asInstanceOf, newRefArrayMethod)
 
-  lazy val RootImports = List[Symbol](JavaLangPackageVal, ScalaPackageVal, ScalaPredefModule, DottyPredefModule)
+  val RootImportFns = List[() => Symbol](() => JavaLangPackageVal, () => ScalaPackageVal, () => ScalaPredefModule, () => DottyPredefModule)
+
+  lazy val RootImports = RootImportFns.map(_())
 
   def isTupleType(tp: Type)(implicit ctx: Context) = {
     val arity = tp.dealias.argInfos.length

--- a/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -11,10 +11,10 @@ import Decorators.StringInterpolators
 
 object ImportInfo {
   /** The import info for a root import from given symbol `sym` */
-  def rootImport(sym: Symbol)(implicit ctx: Context) = {
-    val expr = tpd.Ident(sym.valRef)
+  def rootImport(sym: () => Symbol)(implicit ctx: Context) = {
     val selectors = untpd.Ident(nme.WILDCARD) :: Nil
-    val imp = tpd.Import(expr, selectors)
+    def expr = tpd.Ident(sym().valRef)
+    def imp = tpd.Import(expr, selectors)
     new ImportInfo(imp.symbol, selectors, isRootImport = true)
   }
 }
@@ -25,7 +25,9 @@ object ImportInfo {
  *  @param   rootImport true if this is one of the implicit imports of scala, java.lang
  *                      or Predef in the start context, false otherwise.
  */
-class ImportInfo(val sym: Symbol, val selectors: List[untpd.Tree], val isRootImport: Boolean = false)(implicit ctx: Context) {
+class ImportInfo(symf: => Symbol, val selectors: List[untpd.Tree], val isRootImport: Boolean = false)(implicit ctx: Context) {
+
+  lazy val sym = symf
 
   /** The (TermRef) type of the qualifier of the import clause */
   def site(implicit ctx: Context): Type = {


### PR DESCRIPTION
Can now compile Predef/DottyPredef without -Yno-import option.
Achieved by making some parts of imports more lazy.