### PR TITLE
Drop the requirement that extractors with `get` must implement Product

### DIFF
--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -750,7 +750,6 @@ trait Applications extends Compatibility { self: Typer =>
           case _ => args
         }
         if (argTypes.length != bunchedArgs.length) {
-          println(argTypes)
           ctx.error(d"wrong number of argument patterns for $qual; expected: ($argTypes%, %)", tree.pos)
           argTypes = argTypes.take(args.length) ++
             List.fill(argTypes.length - args.length)(WildcardType)

--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -51,9 +51,12 @@ object Applications {
     sels.takeWhile(_.exists).toList
   }
 
-  def getUnapplySelectors(tp: Type, args:List[untpd.Tree], pos: Position = NoPosition)(implicit ctx: Context): List[Type] =
-    if (defn.isProductSubType(tp) && args.length > 1) productSelectorTypes(tp, pos)
-    else tp :: Nil
+  def getUnapplySelectors(tp: Type, args: List[untpd.Tree], pos: Position = NoPosition)(implicit ctx: Context): List[Type] =
+    if (args.length > 1 && !(tp.derivesFrom(defn.SeqClass))) {
+      val sels = productSelectorTypes(tp, pos)
+      if (sels.length == args.length) sels
+      else tp :: Nil
+    } else tp :: Nil
 
   def unapplyArgs(unapplyResult: Type, unapplyFn:Tree, args:List[untpd.Tree], pos: Position = NoPosition)(implicit ctx: Context): List[Type] = {
 
@@ -747,6 +750,7 @@ trait Applications extends Compatibility { self: Typer =>
           case _ => args
         }
         if (argTypes.length != bunchedArgs.length) {
+          println(argTypes)
           ctx.error(d"wrong number of argument patterns for $qual; expected: ($argTypes%, %)", tree.pos)
           argTypes = argTypes.take(args.length) ++
             List.fill(argTypes.length - args.length)(WildcardType)

--- a/tests/pos/extractors.scala
+++ b/tests/pos/extractors.scala
@@ -1,0 +1,32 @@
+object test {
+
+  class Tree
+  class Apply(val fun: Tree, val args: List[Tree]) extends Tree
+
+  trait DeconstructorCommon[T >: Null <: AnyRef] {
+    var field: T = null
+    def get: this.type = this
+    def isEmpty: Boolean = field eq null
+    def isDefined = !isEmpty
+    def unapply(s: T): this.type ={
+      field = s
+      this
+    }
+  }
+
+  trait ApplyDeconstructor extends DeconstructorCommon[Apply] {
+    def _1: Tree
+    def _2: List[Tree]
+  }
+
+  object Apply extends ApplyDeconstructor {
+    def _1: Tree = field.fun
+    def _2: List[Tree] = field.args
+  }
+
+  def assocsFromApply(tree: Tree) = {
+    tree match {
+      case Apply(fun, args) => ???
+    }
+  }
+}


### PR DESCRIPTION
We used to require that the result type of an extractor `get` is a product,
or else the type of the `get` itself would be taken as the result type of the
unapply. This is now relaxed so that we automatically select with _1, _2, ...
as soon as there are multiple argument patterns, and (1) the result type is not
a Seq, (2) the number of consecutive product selectors matches the number
of arguments.

This should fix #537. Review by @DarkDimius 