### PR TITLE
Fix #540 - unbounded array test for wildcard array arguments

### DIFF
--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -182,12 +182,13 @@ object TypeErasure {
     case tp: PolyParam =>
       !tp.derivesFrom(defn.ObjectClass) &&
       !tp.binder.resultType.isInstanceOf[JavaMethodType]
+    case tp: TypeAlias => isUnboundedGeneric(tp.alias)
+    case tp: TypeBounds => !tp.hi.derivesFrom(defn.ObjectClass)
     case tp: TypeProxy => isUnboundedGeneric(tp.underlying)
     case tp: AndType => isUnboundedGeneric(tp.tp1) || isUnboundedGeneric(tp.tp2)
     case tp: OrType => isUnboundedGeneric(tp.tp1) && isUnboundedGeneric(tp.tp2)
     case _ => false
   }
-
 
   /** The erased least upper bound is computed as follows
    *  - if both argument are arrays, an array of the lub of the element types
@@ -365,6 +366,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
     val defn.ArrayType(elemtp) = tp
     def arrayErasure(tpToErase: Type) =
       erasureFn(isJava, semiEraseVCs = false, isConstructor, wildcardOK)(tpToErase)
+    println(s"erase array, elemtp = $elemtp")
     if (elemtp derivesFrom defn.NullClass) JavaArrayType(defn.ObjectType)
     else if (isUnboundedGeneric(elemtp)) defn.ObjectType
     else JavaArrayType(arrayErasure(elemtp))

--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -366,7 +366,6 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
     val defn.ArrayType(elemtp) = tp
     def arrayErasure(tpToErase: Type) =
       erasureFn(isJava, semiEraseVCs = false, isConstructor, wildcardOK)(tpToErase)
-    println(s"erase array, elemtp = $elemtp")
     if (elemtp derivesFrom defn.NullClass) JavaArrayType(defn.ObjectType)
     else if (isUnboundedGeneric(elemtp)) defn.ObjectType
     else JavaArrayType(arrayErasure(elemtp))

--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -170,9 +170,9 @@ object TypeErasure {
     }
   }
 
-  /** Is `tp` an abstract type or polymorphic type parameter that has `Any`
-   *  as upper bound and that is not Java defined? Arrays of such types are
-   *  erased to `Object` instead of `ObjectArray`.
+  /** Is `tp` an abstract type or polymorphic type parameter that has `Any`, `AnyVal`,
+   *  or a universal trait as upper bound and that is not Java defined? Arrays of such types are
+   *  erased to `Object` instead of `Object[]`.
    */
   def isUnboundedGeneric(tp: Type)(implicit ctx: Context): Boolean = tp.dealias match {
     case tp: TypeRef =>

--- a/tests/pos/i540.scala
+++ b/tests/pos/i540.scala
@@ -1,0 +1,6 @@
+trait Foo extends Any
+
+object Univ {
+  def univ[T <: Foo](x: Array[T]) = {}
+  def univ2(x: Array[_ <: Foo]) = {}
+}


### PR DESCRIPTION
Arrays with wildcard arguments such as Array[_ <: Foo] where Foo is a
universal trait are now diagnosed as unbounded generic arrays and are
erased to Object.

Review by @smarter 