### PR TITLE
Fix/#536 nested classes

### DIFF
--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -682,14 +682,14 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
     /** For currently compiled classes: All locally defined classes including local classes.
      *  The empty list for classes that are not currently compiled.
      */
-    def nestedClasses: List[Symbol] = localClasses(ctx.flattenPhase)
+    def nestedClasses: List[Symbol] = definedClasses(ctx.flattenPhase)
 
     /** For currently compiled classes: All classes that are declared as members of this class
      *  (but not inherited ones). The empty list for classes that are not currently compiled.
      */
-    def memberClasses: List[Symbol] = localClasses(ctx.lambdaLiftPhase)
+    def memberClasses: List[Symbol] = definedClasses(ctx.lambdaLiftPhase)
 
-    private def localClasses(phase: Phase) =
+    private def definedClasses(phase: Phase) =
       if (sym.isDefinedInCurrentRun)
         ctx.atPhase(phase) { implicit ctx =>
           toDenot(sym).info.decls.filter(_.isClass).toList

--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -678,8 +678,24 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
 
     // members
     def primaryConstructor: Symbol = toDenot(sym).primaryConstructor
-    def nestedClasses: List[Symbol] = memberClasses //exitingPhase(currentRun.lambdaliftPhase)(sym.memberClasses)
-    def memberClasses: List[Symbol] = toDenot(sym).info.memberClasses.map(_.symbol).toList
+
+    /** For currently compiled classes: All locally defined classes including local classes.
+     *  The empty list for classes that are not currently compiled.
+     */
+    def nestedClasses: List[Symbol] = localClasses(ctx.flattenPhase)
+
+    /** For currently compiled classes: All classes that are declared as members of this class
+     *  (but not inherited ones). The empty list for classes that are not currently compiled.
+     */
+    def memberClasses: List[Symbol] = localClasses(ctx.lambdaLiftPhase)
+
+    private def localClasses(phase: Phase) =
+      if (sym.isDefinedInCurrentRun)
+        ctx.atPhase(phase) { implicit ctx =>
+          toDenot(sym).info.decls.filter(_.isClass).toList
+        }
+      else Nil
+
     def annotations: List[Annotation] = Nil
     def companionModuleMembers: List[Symbol] =  {
       // phase travel to exitingPickler: this makes sure that memberClassesOf only sees member classes,

--- a/src/dotty/tools/dotc/core/Phases.scala
+++ b/src/dotty/tools/dotc/core/Phases.scala
@@ -235,6 +235,7 @@ object Phases {
     private val extensionMethodsCache = new PhaseCache(classOf[ExtensionMethods])
     private val erasureCache = new PhaseCache(classOf[Erasure])
     private val patmatCache = new PhaseCache(classOf[PatternMatcher])
+    private val lambdaLiftCache = new PhaseCache(classOf[LambdaLift])
     private val flattenCache = new PhaseCache(classOf[Flatten])
     private val explicitOuterCache = new PhaseCache(classOf[ExplicitOuter])
     private val gettersCache = new PhaseCache(classOf[Getters])
@@ -245,6 +246,7 @@ object Phases {
     def extensionMethodsPhase = extensionMethodsCache.phase
     def erasurePhase = erasureCache.phase
     def patmatPhase = patmatCache.phase
+    def lambdaLiftPhase = lambdaLiftCache.phase
     def flattenPhase = flattenCache.phase
     def explicitOuterPhase = explicitOuterCache.phase
     def gettersPhase = gettersCache.phase

--- a/src/dotty/tools/dotc/core/Symbols.scala
+++ b/src/dotty/tools/dotc/core/Symbols.scala
@@ -406,8 +406,8 @@ object Symbols {
     }
 
     /** Subclass tests and casts */
-    final def isTerm(implicit ctx: Context): Boolean = denot.isTerm
-    final def isType(implicit ctx: Context): Boolean = denot.isType
+    final def isTerm(implicit ctx: Context): Boolean = lastDenot.isTerm
+    final def isType(implicit ctx: Context): Boolean = lastDenot.isType
     final def isClass: Boolean = isInstanceOf[ClassSymbol]
 
     final def asTerm(implicit ctx: Context): TermSymbol = { assert(isTerm, s"asTerm called on not-a-Term $this" ); asInstanceOf[TermSymbol] }

--- a/tests/pos/i536.scala
+++ b/tests/pos/i536.scala
@@ -1,0 +1,3 @@
+object Max {
+  java.util.Collections.max(null)
+}


### PR DESCRIPTION
This fixes #536. It makes the bet that member classes are only needed for classes that are currently compiled. It also fixes the implementation of memberClasses and localClasses, which was not according to spec before.

Review by @smarter, @DarkDimius 