### PR TITLE
Fix #545: no need to make members of static classes static.

### DIFF
--- a/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -289,9 +289,12 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
       for ((local, lOwner) <- liftedOwner) {
         val (newOwner, maybeStatic) =
           if (lOwner is Package)  {
-            if (local.enclosingClass.isStatic) // member of a static object
+              // member of a static object
+            if (local.enclosingClass.isStatic && local.enclosingClass.isProperlyContainedIn(local.topLevelClass)) {
+               // though the second condition seems weird, it's not true for symbols which are defined in some
+               // weird combinations of super calls.
               (local.enclosingClass, EmptyFlags)
-            else
+            } else
               (local.topLevelClass, JavaStatic)
           }
           else (lOwner, EmptyFlags)

--- a/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -66,7 +66,7 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
     /** A map from local methods and classes to the owners to which they will be lifted as members.
      *  For methods and classes that do not have any dependencies this will be the enclosing package.
      *  symbols with packages as lifted owners will subsequently represented as static
-     *  members of their toplevel class.
+     *  members of their toplevel class, unless their enclosing class was already static.
      */
     private val liftedOwner = new HashMap[Symbol, Symbol]
 
@@ -289,7 +289,6 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
       for ((local, lOwner) <- liftedOwner) {
         val (newOwner, maybeStatic) =
           if (lOwner is Package)  {
-            println(s"lifting $local encl class ${local.enclosingClass}")
             if (local.enclosingClass.isStatic) // member of a static object
               (local.enclosingClass, EmptyFlags)
             else

--- a/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -289,13 +289,15 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
       for ((local, lOwner) <- liftedOwner) {
         val (newOwner, maybeStatic) =
           if (lOwner is Package)  {
+            val encClass = local.enclosingClass
+            val topClass = local.topLevelClass
               // member of a static object
-            if (local.enclosingClass.isStatic && local.enclosingClass.isProperlyContainedIn(local.topLevelClass)) {
+            if (encClass.isStatic && encClass.isProperlyContainedIn(topClass)) {
                // though the second condition seems weird, it's not true for symbols which are defined in some
                // weird combinations of super calls.
-              (local.enclosingClass, EmptyFlags)
+              (encClass, EmptyFlags)
             } else
-              (local.topLevelClass, JavaStatic)
+              (topClass, JavaStatic)
           }
           else (lOwner, EmptyFlags)
         local.copySymDenotation(

--- a/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -288,7 +288,13 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
     private def liftLocals()(implicit ctx: Context): Unit = {
       for ((local, lOwner) <- liftedOwner) {
         val (newOwner, maybeStatic) =
-          if (lOwner is Package) (local.topLevelClass, JavaStatic)
+          if (lOwner is Package)  {
+            println(s"lifting $local encl class ${local.enclosingClass}")
+            if (local.enclosingClass.isStatic) // member of a static object
+              (local.enclosingClass, EmptyFlags)
+            else
+              (local.topLevelClass, JavaStatic)
+          }
           else (lOwner, EmptyFlags)
         local.copySymDenotation(
           owner = newOwner,


### PR DESCRIPTION
Otherwise we will need to rewrite references to `This` of class be
    references on ModuleVal. This is less efficient(instead of calling method
    statically known to be final, you have virtual call) and less jvm-friendly,
    as needs additional instructions to get to ModuleVal.