### PR TITLE
Fix #547: Vararg overload

### DIFF
--- a/tests/pos/varargs.scala
+++ b/tests/pos/varargs.scala
@@ -10,4 +10,8 @@ object varargs {
   g(Nil: _*)
   g(1)
   g()
+
+  def f(x: Int): Unit = ()
+  def f(x: Int*): Unit = ()
+  f(1)
 }


### PR DESCRIPTION
When comparing to types in isAsSpecific, onvert repeated parameters to their underlying type
only if both types are vararg methods. This mimics scalac behavior. Review by @DarkDimius 