### PR TITLE
Fix unset tree position

### DIFF
--- a/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -50,7 +50,7 @@ trait TypeTestsCasts {
           if (expr.tpe <:< argType)
             Literal(Constant(true)) withPos tree.pos
           else if (argCls.isPrimitiveValueClass)
-            if (qualCls.isPrimitiveValueClass) Literal(Constant(qualCls == argCls))
+            if (qualCls.isPrimitiveValueClass) Literal(Constant(qualCls == argCls)) withPos tree.pos
             else transformIsInstanceOf(expr, defn.boxedClass(argCls).typeRef)
           else argType.dealias match {
             case _: SingletonType =>


### PR DESCRIPTION
Debugs some cases where `tree.pos` wasn't initialised properly.