### PR TITLE
Do not depend on scala.collection.generic.Clearable in dotty.

### DIFF
--- a/src/dotty/tools/dotc/util/HashSet.scala
+++ b/src/dotty/tools/dotc/util/HashSet.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc.util
 
 /** A hash set that allows some privileged protected access to its internals
  */
-class HashSet[T >: Null <: AnyRef](initialCapacity: Int, loadFactor: Float = 0.25f) extends Set[T] with scala.collection.generic.Clearable {
+class HashSet[T >: Null <: AnyRef](initialCapacity: Int, loadFactor: Float = 0.25f) extends Set[T] {
   private var used: Int = _
   private var limit: Int = _
   private var table: Array[AnyRef] = _

--- a/src/dotty/tools/dotc/util/Set.scala
+++ b/src/dotty/tools/dotc/util/Set.scala
@@ -23,4 +23,5 @@ abstract class Set[T >: Null] {
 
   def toList = iterator.toList
 
+  def clear: Unit
 }


### PR DESCRIPTION
Makes bootstrap easier.