### PR TITLE
Make Child annotation lazy

### DIFF
--- a/src/dotty/tools/dotc/core/Annotations.scala
+++ b/src/dotty/tools/dotc/core/Annotations.scala
@@ -90,7 +90,8 @@ object Annotations {
         ref(TermRef.withSigAndDenot(sym.owner.thisType, sym.name, sym.signature, sym))))
 
     def makeChild(sym: Symbol)(implicit ctx: Context) =
-      apply(defn.ChildAnnot.typeRef.appliedTo(sym.owner.thisType.select(sym.name, sym)), Nil)
+      deferred(defn.ChildAnnot,
+        implicit ctx => New(defn.ChildAnnot.typeRef.appliedTo(sym.owner.thisType.select(sym.name, sym)), Nil))
   }
 
   def ThrowsAnnotation(cls: ClassSymbol)(implicit ctx: Context) = {


### PR DESCRIPTION
Otherwise we get bootstrap problems when trying to compile Child:
Completing Predef with the Scala2Unpickler causes Child annotations
to be added to parents of case classes. But completing Child would depend
on completion of Predef. Making child annotations lazy avoids the cycle.

Review by @DarkDimius 