### PR TITLE
As i566 shows, it is possible to have a package as prefix, a package

### DIFF
--- a/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -104,12 +104,11 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer  { thisTran
     private def transformAnnots(tree: MemberDef)(implicit ctx: Context): Unit =
       tree.symbol.transformAnnotations(transformAnnot)
 
-    private def transformSelect(tree: Select, targs: List[Tree])(implicit ctx: Context) = {
+    private def transformSelect(tree: Select, targs: List[Tree])(implicit ctx: Context): Tree = {
       val qual = tree.qualifier
       qual.symbol.moduleClass.denot match {
         case pkg: PackageClassDenotation if !tree.symbol.maybeOwner.is(Package) =>
-          assert(targs.isEmpty)
-          cpy.Select(tree)(qual select pkg.packageObj.symbol, tree.name)
+          transformSelect(cpy.Select(tree)(qual select pkg.packageObj.symbol, tree.name), targs)
         case _ =>
           superAcc.transformSelect(super.transform(tree), targs)
       }

--- a/tests/pos/i566.scala
+++ b/tests/pos/i566.scala
@@ -1,0 +1,5 @@
+object Test {
+  type T = String
+  type U
+  reflect.classTag[T]
+}


### PR DESCRIPTION
object as owner and be followed by type arguments:

     reflect.classTag[T]

expands to

     reflect.`package`.classTag[T]

Review by@darkdimius