### PR TITLE
Mixin: fix the initialization of traits

### DIFF
--- a/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/src/dotty/tools/dotc/transform/Mixin.scala
@@ -96,7 +96,7 @@ class Mixin extends MiniPhaseTransform with SymTransformer { thisTransform =>
 
     def traitDefs(stats: List[Tree]): List[Tree] = {
       val initBuf = new mutable.ListBuffer[Tree]
-      stats flatMap {
+      stats.flatMap({
         case stat: DefDef if stat.symbol.isGetter && !stat.rhs.isEmpty && !stat.symbol.is(Flags.Lazy)  =>
           // make initializer that has all effects of previous getter,
           // replace getter rhs with empty tree.
@@ -114,7 +114,7 @@ class Mixin extends MiniPhaseTransform with SymTransformer { thisTransform =>
         case stat =>
           initBuf += stat
           Nil
-      }
+      }) ++ initBuf
     }
 
     def transformSuper(tree: Tree): Tree = {

--- a/tests/run/traitInit.check
+++ b/tests/run/traitInit.check
@@ -1,0 +1,2 @@
+Hello
+World

--- a/tests/run/traitInit.scala
+++ b/tests/run/traitInit.scala
@@ -1,0 +1,13 @@
+trait Hello {
+  println("Hello")
+  val x: Int = 1
+  println("World")
+}
+
+class A extends Hello
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    new A
+  }
+}


### PR DESCRIPTION
Before this commit, the following code:
```scala
trait Hello {
  println("Hello")
  val x: Int = 1
  println("World")
}
```

Became:
```scala
<trait> trait Hello extends Object {
  def <init>(): Hello = {
    {
      ()
    }
    this
  }
  <accessor> def x(): Int
  protected def initial$x(): Int = {
    println("Hello")
    1
  }
}
```

Notice that the initialization statements after the last getter were
missing, this is now fixed:
```scala
<trait> trait Hello extends Object {
  def <init>(): Hello = {
    {
      println("World");
      ()
    }
    this
  }
  <accessor> def x(): Int
  protected def initial$x(): Int = {
    println("Hello")
    1
  }
}
```

Review by @odersky 