### PR TITLE
Improvements to higher-kinded types

### DIFF
--- a/docs/SyntaxSummary.txt
+++ b/docs/SyntaxSummary.txt
@@ -249,7 +249,7 @@ grammar.
   AccessModifier    ::=  (`private' | `protected') [AccessQualifier]
   AccessQualifier   ::=  `[' (id | `this') `]'
 
-  Annotation        ::=  `@' SimpleType {ArgumentExprs}                         Apply(tpe, args)
+  Annotation        ::=  `@' SimpleType {ParArgumentExprs}                      Apply(tpe, args)
 
   TemplateBody      ::=  [nl] `{' [SelfType] TemplateStat {semi TemplateStat} `} (self, stats)
   TemplateStat      ::=  Import

--- a/docs/SyntaxSummary.txt
+++ b/docs/SyntaxSummary.txt
@@ -99,8 +99,9 @@ grammar.
   FunArgTypes       ::=  InfixType
                       | `(' [ FunArgType {`,' FunArgType } ] `)'
   InfixType         ::=  RefinedType {id [nl] RefinedType}                      InfixOp(t1, op, t2)
-  RefinedType       ::=  WithType {Annotation | [nl] Refinement}                Annotated(t, annot), RefinedTypeTree(t, ds)
-  WithType          ::=  SimpleType {`with' SimpleType}                         (deprecated)
+  RefinedType       ::=  WithType {[nl] Refinement}                             RefinedTypeTree(t, ds)
+  WithType          ::=  AnnotType {`with' AnnotType}                           (deprecated)
+  AnnotType         ::=  SimpleType {Annotation}                                Annotated(t, annot)
   SimpleType        ::=  SimpleType TypeArgs                                    AppliedTypeTree(t, args)
                       |  SimpleType `#' id                                      SelectFromTypeTree(t, name)
                       |  StableId
@@ -121,9 +122,9 @@ grammar.
 
   Expr              ::=  FunParams `=>' Expr                                    Function(args, expr), Function(ValDef([implicit], id, TypeTree(), EmptyTree), expr)
                       |  Expr1
-  FunParams         ::=   Bindings
-                      |   [`implicit'] id
-                      |   `_'
+  FunParams         ::=  Bindings
+                      |  [`implicit'] id
+                      |  `_'
   ExprInParens      ::=  PostfixExpr `:' Type
                       |  Expr
   BlockResult       ::=  (FunParams | [`implicit'] id `:' InfixType) => Block
@@ -301,7 +302,7 @@ grammar.
   TemplateOpt       ::=  [`extends' Template | [nl] TemplateBody]
   Template          ::=  ConstrApps [TemplateBody] | TemplateBody               Template(constr, parents, self, stats)
   ConstrApps        ::=  ConstrApp {`with' ConstrApp}
-  ConstrApp         ::=  SimpleType {ArgumentExprs}                             Apply(tp, args)
+  ConstrApp         ::=  AnnotType {ArgumentExprs}                              Apply(tp, args)
 
   ConstrExpr        ::=  SelfInvocation
                       |  ConstrBlock

--- a/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -38,7 +38,7 @@ class GenBCode extends Phase {
 
 
   def run(implicit ctx: Context): Unit = {
-    new GenBCodePipeline(entryPoints.toList,  new DottyBackendInterface()(ctx))(ctx).run(ctx.compilationUnit.tpdTree)
+    new GenBCodePipeline(entryPoints.toList, new DottyBackendInterface()(ctx))(ctx).run(ctx.compilationUnit.tpdTree)
     entryPoints.clear()
   }
 }

--- a/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -110,19 +110,19 @@ object CompilerCommand extends DotClass {
 
     if (summary.errors.nonEmpty) {
       summary.errors foreach (ctx.error(_))
-      ctx.echo("  dotc -help  gives more information")
+      ctx.println("  dotc -help  gives more information")
       Nil
     }
     else if (settings.version.value) {
-      ctx.echo(versionMsg)
+      ctx.println(versionMsg)
       Nil
     }
     else if (shouldStopWithInfo) {
-      ctx.echo(infoMessage)
+      ctx.println(infoMessage)
       Nil
     } else {
       if (summary.arguments.isEmpty && !settings.resident.value)
-        ctx.echo(usageMessage)
+        ctx.println(usageMessage)
       summary.arguments
     }
   }

--- a/src/dotty/tools/dotc/config/Config.scala
+++ b/src/dotty/tools/dotc/config/Config.scala
@@ -85,9 +85,17 @@ object Config {
   /** How many recursive calls to isSubType are performed before logging starts. */
   final val LogPendingSubTypesThreshold = 50
 
-  /** How many recursive calls to findMember are performed before logging names starts */
-  final val LogPendingFindMemberThreshold = 20
+  /** How many recursive calls to findMember are performed before logging names starts
+   *  Note: this threshold has to be chosen carefully. Too large, and programs
+   *  like tests/pos/IterableSelfRec go into polynomial (or even exponential?)
+   *  compile time slowdown. Too small and normal programs will cause the compiler  to
+   *  do inefficient operations on findMember. The current value is determined
+   *  so that (1) IterableSelfRec still compiles in reasonable time (< 10sec) (2) Compiling
+   *  dotty itself only causes small pending names lists to be generated (we measured
+   *  at max 6 elements) and these lists are never searched with contains.
+   */
+  final val LogPendingFindMemberThreshold = 10
 
   /** Maximal number of outstanding recursive calls to findMember  */
-  final val PendingFindMemberLimit = LogPendingFindMemberThreshold * 2
+  final val PendingFindMemberLimit = LogPendingFindMemberThreshold * 4
 }

--- a/src/dotty/tools/dotc/config/Config.scala
+++ b/src/dotty/tools/dotc/config/Config.scala
@@ -71,4 +71,23 @@ object Config {
 
   /** Check that certain types cannot be created in erasedTypes phases */
   final val checkUnerased = true
+
+
+  /** Initial size of superId table */
+  final val InitialSuperIdsSize = 4096
+
+  /** Initial capacity of uniques HashMap */
+  final val initialUniquesCapacity = 40000
+
+  /** How many recursive calls to NamedType#underlying are performed before logging starts. */
+  final val LogPendingUnderlyingThreshold = 50
+
+  /** How many recursive calls to isSubType are performed before logging starts. */
+  final val LogPendingSubTypesThreshold = 50
+
+  /** How many recursive calls to findMember are performed before logging names starts */
+  final val LogPendingFindMemberThreshold = 20
+
+  /** Maximal number of outstanding recursive calls to findMember  */
+  final val PendingFindMemberLimit = LogPendingFindMemberThreshold * 2
 }

--- a/src/dotty/tools/dotc/core/Contexts.scala
+++ b/src/dotty/tools/dotc/core/Contexts.scala
@@ -165,6 +165,14 @@ object Contexts {
       _typeComparer
     }
 
+    /** Number of findMember calls on stack */
+    private[core] var findMemberCount: Int = 0
+
+    /** List of names which have a findMemberCall on stack,
+     *  after Config.LogPendingFindMemberThreshold is reached.
+     */
+    private[core] var pendingMemberSearches: List[Name] = Nil
+
     /** The new implicit references that are introduced by this scope */
     private var implicitsCache: ContextualImplicits = null
     def implicits: ContextualImplicits = {

--- a/src/dotty/tools/dotc/core/Contexts.scala
+++ b/src/dotty/tools/dotc/core/Contexts.scala
@@ -20,6 +20,7 @@ import util.{FreshNameCreator, SimpleMap, SourceFile, NoSource}
 import typer._
 import Implicits.ContextualImplicits
 import config.Settings._
+import config.Config
 import reporting._
 import collection.mutable
 import collection.immutable.BitSet
@@ -508,7 +509,7 @@ object Contexts {
     def nextId = { _nextId += 1; _nextId }
 
     /** A map from a superclass id to the typeref of the class that has it */
-    private[core] var classOfId = new Array[ClassSymbol](InitialSuperIdsSize)
+    private[core] var classOfId = new Array[ClassSymbol](Config.InitialSuperIdsSize)
 
     /** A map from a the typeref of a class to its superclass id */
     private[core] val superIdOfClass = new mutable.AnyRefMap[ClassSymbol, Int]
@@ -529,7 +530,7 @@ object Contexts {
 
     // Types state
     /** A table for hash consing unique types */
-    private[core] val uniques = new util.HashSet[Type](initialUniquesCapacity) {
+    private[core] val uniques = new util.HashSet[Type](Config.initialUniquesCapacity) {
       override def hash(x: Type): Int = x.hash
     }
 
@@ -614,20 +615,4 @@ object Contexts {
       myBounds = myBounds.updated(sym, b)
     def bounds = myBounds
   }
-
-  /** Initial size of superId table */
-  private final val InitialSuperIdsSize = 4096
-
-  /** Initial capacity of uniques HashMap */
-  private[core] final val initialUniquesCapacity = 40000
-
-  /** How many recursive calls to NamedType#underlying are performed before
-   *  logging starts.
-   */
-  private[core] final val LogPendingUnderlyingThreshold = 50
-
-  /** How many recursive calls to isSubType are performed before
-   *  logging starts.
-   */
-  private[core] final val LogPendingSubTypesThreshold = 50
 }

--- a/src/dotty/tools/dotc/core/Decorators.scala
+++ b/src/dotty/tools/dotc/core/Decorators.scala
@@ -173,7 +173,7 @@ object Decorators {
       def treatSingleArg(arg: Any) : Any =
         try
           arg match {
-            case arg: Showable => arg.show(ctx.fresh.addMode(Mode.FutureDefsOK))
+            case arg: Showable => arg.show(ctx.addMode(Mode.FutureDefsOK))
             case _ => arg
           }
         catch {

--- a/src/dotty/tools/dotc/core/NameOps.scala
+++ b/src/dotty/tools/dotc/core/NameOps.scala
@@ -99,12 +99,18 @@ object NameOps {
 
     /** Is this the name of a higher-kinded type parameter of a Lambda? */
     def isLambdaArgName =
-      name.length > 0 && name.head == tpnme.LAMBDA_ARG_PREFIXhead && name.startsWith(tpnme.LAMBDA_ARG_PREFIX)
+      name.length > 0 &&
+      name.head == tpnme.LAMBDA_ARG_PREFIXhead &&
+      name.startsWith(tpnme.LAMBDA_ARG_PREFIX) && {
+        val digits = name.drop(tpnme.LAMBDA_ARG_PREFIX.length)
+        digits.length <= 4 && digits.forall(_.isDigit)
+      }
 
     /** The index of the higher-kinded type parameter with this name.
      *  Pre: isLambdaArgName.
      */
-    def lambdaArgIndex: Int = name.drop(name.lastIndexOf('$') + 1).toString.toInt
+    def lambdaArgIndex: Int =
+      name.drop(tpnme.LAMBDA_ARG_PREFIX.length).toString.toInt
 
     /** If the name ends with $nn where nn are
       * all digits, strip the $ and the digits.

--- a/src/dotty/tools/dotc/core/StdNames.scala
+++ b/src/dotty/tools/dotc/core/StdNames.scala
@@ -172,7 +172,7 @@ object StdNames {
     final val WILDCARD_STAR: N                  = "_*"
     final val REIFY_TREECREATOR_PREFIX: N       = "$treecreator"
     final val REIFY_TYPECREATOR_PREFIX: N       = "$typecreator"
-    final val LAMBDA_ARG_PREFIX: N              = "$hkArg$"
+    final val LAMBDA_ARG_PREFIX: N              = "HK$"
     final val LAMBDA_ARG_PREFIXhead: Char       = LAMBDA_ARG_PREFIX.head
 
     final val Any: N             = "Any"

--- a/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -515,18 +515,19 @@ class TypeApplications(val self: Type) extends AnyVal {
     self.appliedTo(tparams map (_.typeRef)).LambdaAbstract(tparams)
   }
 
-  /** Test whether this type if od the form `B[T1, ..., Tn]`, or,
-   *  if `canWiden` if true, has a base type of the form `B[T1, ..., Bn]` where the type parameters
-   *  of `B` match one-by-one the variances of `tparams`, and where the lambda
-   *  abstracted type
+  /** Test whether this type has a base type of the form `B[T1, ..., Bn]` where
+   *  the type parameters of `B` match one-by-one the variances of `tparams`,
+   *  and where the lambda abstracted type
    *
    *     LambdaXYZ { type Apply = B[$hkArg$0, ..., $hkArg$n] }
    *               { type $hkArg$0 = T1; ...; type $hkArg$n = Tn }
    *
    *  satisfies predicate `p`. Try base types in the order of their occurrence in `baseClasses`.
    *  A type parameter matches a variance V if it has V as its variance or if V == 0.
+   *  @param classBounds  A hint to bound the search. Only types that derive from one of the
+   *                      classes in classBounds are considered.
    */
-  def testLifted(tparams: List[Symbol], p: Type => Boolean, canWiden: Boolean)(implicit ctx: Context): Boolean = {
+  def testLifted(tparams: List[Symbol], p: Type => Boolean, classBounds: List[ClassSymbol])(implicit ctx: Context): Boolean = {
     def tryLift(bcs: List[ClassSymbol]): Boolean = bcs match {
       case bc :: bcs1 =>
         val tp = self.baseTypeWithArgs(bc)
@@ -534,7 +535,8 @@ class TypeApplications(val self: Type) extends AnyVal {
         val tycon = tp.withoutArgs(targs)
         def variancesMatch(param1: Symbol, param2: Symbol) =
           param2.variance == param2.variance || param2.variance == 0
-        if ((tycon.typeParams corresponds tparams)(variancesMatch)) {
+        if (classBounds.exists(tycon.derivesFrom(_)) &&
+            tycon.typeParams.corresponds(tparams)(variancesMatch)) {
           val expanded = tycon.EtaExpand
           val lifted = (expanded /: targs) { (partialInst, targ) =>
             val tparam = partialInst.typeParams.head
@@ -549,7 +551,7 @@ class TypeApplications(val self: Type) extends AnyVal {
         false
     }
     if (tparams.isEmpty) false
-    else if (typeParams.nonEmpty) p(EtaExpand) || canWiden && tryLift(self.baseClasses)
-    else canWiden && tryLift(self.baseClasses)
+    else if (typeParams.nonEmpty) p(EtaExpand) || classBounds.nonEmpty && tryLift(self.baseClasses)
+    else classBounds.nonEmpty && tryLift(self.baseClasses)
   }
 }

--- a/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -515,7 +515,8 @@ class TypeApplications(val self: Type) extends AnyVal {
     self.appliedTo(tparams map (_.typeRef)).LambdaAbstract(tparams)
   }
 
-  /** Test whether this type has a base type `B[T1, ..., Tn]` where the type parameters
+  /** Test whether this type if od the form `B[T1, ..., Tn]`, or,
+   *  if `canWiden` if true, has a base type of the form `B[T1, ..., Bn]` where the type parameters
    *  of `B` match one-by-one the variances of `tparams`, and where the lambda
    *  abstracted type
    *
@@ -525,7 +526,7 @@ class TypeApplications(val self: Type) extends AnyVal {
    *  satisfies predicate `p`. Try base types in the order of their occurrence in `baseClasses`.
    *  A type parameter matches a variance V if it has V as its variance or if V == 0.
    */
-  def testLifted(tparams: List[Symbol], p: Type => Boolean)(implicit ctx: Context): Boolean = {
+  def testLifted(tparams: List[Symbol], p: Type => Boolean, canWiden: Boolean)(implicit ctx: Context): Boolean = {
     def tryLift(bcs: List[ClassSymbol]): Boolean = bcs match {
       case bc :: bcs1 =>
         val tp = self.baseTypeWithArgs(bc)
@@ -548,7 +549,7 @@ class TypeApplications(val self: Type) extends AnyVal {
         false
     }
     if (tparams.isEmpty) false
-    else if (typeParams.nonEmpty) p(EtaExpand) || tryLift(self.baseClasses)
-    else tryLift(self.baseClasses)
+    else if (typeParams.nonEmpty) p(EtaExpand) || canWiden && tryLift(self.baseClasses)
+    else canWiden && tryLift(self.baseClasses)
   }
 }

--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -25,6 +25,9 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling wi
   private var pendingSubTypes: mutable.Set[(Type, Type)] = null
   private var recCount = 0
 
+  private[core] var findMemberCount = 0
+  private[core] var pendingMemberSearches: List[Name] = Nil
+
   private var needsGc = false
 
   /** Is a subtype check in progress? In that case we may not

--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1148,13 +1148,13 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling wi
     }
 
   /** Show subtype goal that led to an assertion failure */
-  def showGoal(tp1: Type, tp2: Type) = {
-    println(disambiguated(implicit ctx => s"assertion failure for ${tp1.show} <:< ${tp2.show}, frozen = $frozenConstraint"))
+  def showGoal(tp1: Type, tp2: Type)(implicit ctx: Context) = {
+    ctx.println(disambiguated(implicit ctx => s"assertion failure for ${tp1.show} <:< ${tp2.show}, frozen = $frozenConstraint"))
     def explainPoly(tp: Type) = tp match {
-      case tp: PolyParam => println(s"polyparam ${tp.show} found in ${tp.binder.show}")
-      case tp: TypeRef if tp.symbol.exists => println(s"typeref ${tp.show} found in ${tp.symbol.owner.show}")
-      case tp: TypeVar => println(s"typevar ${tp.show}, origin = ${tp.origin}")
-      case _ => println(s"${tp.show} is a ${tp.getClass}")
+      case tp: PolyParam => ctx.println(s"polyparam ${tp.show} found in ${tp.binder.show}")
+      case tp: TypeRef if tp.symbol.exists => ctx.println(s"typeref ${tp.show} found in ${tp.symbol.owner.show}")
+      case tp: TypeVar => ctx.println(s"typevar ${tp.show}, origin = ${tp.origin}")
+      case _ => ctx.println(s"${tp.show} is a ${tp.getClass}")
     }
     explainPoly(tp1)
     explainPoly(tp2)

--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -345,7 +345,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling wi
               || fourthTry(tp1, tp2)
               )
           normalPath ||
-            needsEtaLift(tp1, tp2) && tp1.testLifted(tp2.typeParams, isSubType(_, tp2), canWiden = true)
+            needsEtaLift(tp1, tp2) && tp1.testLifted(tp2.typeParams, isSubType(_, tp2), classBounds(tp2))
         }
         else // fast path, in particular for refinements resulting from parameterization.
           isSubType(tp1, skipped2) &&
@@ -453,7 +453,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling wi
       isNewSubType(tp1.underlying.widenExpr, tp2) || comparePaths
     case tp1: RefinedType =>
        isNewSubType(tp1.parent, tp2) ||
-         needsEtaLift(tp2, tp1) && tp2.testLifted(tp1.typeParams, isSubType(tp1, _), canWiden = false)
+         needsEtaLift(tp2, tp1) && tp2.testLifted(tp1.typeParams, isSubType(tp1, _), Nil)
     case AndType(tp11, tp12) =>
       eitherIsSubType(tp11, tp2, tp12, tp2)
     case JavaArrayType(elem1) =>
@@ -476,8 +476,11 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling wi
       lambda.exists && !other.isLambda &&
         other.testLifted(lambda.typeParams,
           if (inOrder) isSubType(projection.prefix, _) else isSubType(_, projection.prefix),
-          canWiden = !inOrder)
+          if (inOrder) Nil else classBounds(projection.prefix))
     }
+
+  /** The class symbols bounding the type of the `Apply` member of `tp` */
+  private def classBounds(tp: Type) = tp.member(tpnme.Apply).info.classSymbols
 
   /** Returns true iff either `tp11 <:< tp21` or `tp12 <:< tp22`, trying at the same time
    *  to keep the constraint as wide as possible. Specifically, if

--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -25,9 +25,6 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling wi
   private var pendingSubTypes: mutable.Set[(Type, Type)] = null
   private var recCount = 0
 
-  private[core] var findMemberCount = 0
-  private[core] var pendingMemberSearches: List[Name] = Nil
-
   private var needsGc = false
 
   /** Is a subtype check in progress? In that case we may not

--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -345,7 +345,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling wi
               || fourthTry(tp1, tp2)
               )
           normalPath ||
-            needsEtaLift(tp1, tp2) && tp1.testLifted(tp2.typeParams, isSubType(_, tp2))
+            needsEtaLift(tp1, tp2) && tp1.testLifted(tp2.typeParams, isSubType(_, tp2), canWiden = true)
         }
         else // fast path, in particular for refinements resulting from parameterization.
           isSubType(tp1, skipped2) &&
@@ -453,7 +453,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling wi
       isNewSubType(tp1.underlying.widenExpr, tp2) || comparePaths
     case tp1: RefinedType =>
        isNewSubType(tp1.parent, tp2) ||
-         needsEtaLift(tp2, tp1) && tp2.testLifted(tp1.typeParams, isSubType(tp1, _))
+         needsEtaLift(tp2, tp1) && tp2.testLifted(tp1.typeParams, isSubType(tp1, _), canWiden = false)
     case AndType(tp11, tp12) =>
       eitherIsSubType(tp11, tp2, tp12, tp2)
     case JavaArrayType(elem1) =>
@@ -475,7 +475,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling wi
       val lambda = projection.prefix.LambdaClass(forcing = true)
       lambda.exists && !other.isLambda &&
         other.testLifted(lambda.typeParams,
-          if (inOrder) isSubType(projection.prefix, _) else isSubType(_, projection.prefix))
+          if (inOrder) isSubType(projection.prefix, _) else isSubType(_, projection.prefix),
+          canWiden = !inOrder)
     }
 
   /** Returns true iff either `tp11 <:< tp21` or `tp12 <:< tp22`, trying at the same time

--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -97,7 +97,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling wi
       try {
         recCount = recCount + 1
         val result =
-          if (recCount < LogPendingSubTypesThreshold) firstTry(tp1, tp2)
+          if (recCount < Config.LogPendingSubTypesThreshold) firstTry(tp1, tp2)
           else monitoredIsSubType(tp1, tp2)
         recCount = recCount - 1
         if (!result) constraint = saved

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -2590,7 +2590,7 @@ object Types {
   abstract class TypeAlias(val alias: Type, override val variance: Int) extends TypeBounds(alias, alias) {
     /** pre: this is a type alias */
     def derivedTypeAlias(tp: Type, variance: Int = this.variance)(implicit ctx: Context) =
-      if (lo eq tp) this
+      if ((lo eq tp) && (variance == this.variance)) this
       else TypeAlias(tp, variance)
 
     override def & (that: TypeBounds)(implicit ctx: Context): TypeBounds = {

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -1426,7 +1426,7 @@ object Types {
     def isTerm = isInstanceOf[TermRef]
 
     /** Guard against cycles that can arise if given `op`
-     *  follows info. The prblematic cases are a type alias to itself or
+     *  follows info. The problematic cases are a type alias to itself or
      *  bounded by itself or a val typed as itself:
      *
      *  type T <: T
@@ -1437,7 +1437,7 @@ object Types {
      */
     final def controlled[T](op: => T)(implicit ctx: Context): T = try {
       ctx.underlyingRecursions += 1
-      if (ctx.underlyingRecursions < LogPendingUnderlyingThreshold)
+      if (ctx.underlyingRecursions < Config.LogPendingUnderlyingThreshold)
         op
       else if (ctx.pendingUnderlying contains this)
         throw CyclicReference(symbol)

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -729,6 +729,12 @@ object Types {
       case tp => tp
     }
 
+    /** If this is a TypeAlias type, its alias otherwise this type itself */
+    final def followTypeAlias(implicit ctx: Context): Type = this match {
+      case TypeAlias(alias) => alias
+      case _ => this
+    }
+
     /** Perform successive widenings and dealiasings until none can be applied anymore */
     final def widenDealias(implicit ctx: Context): Type = {
       val res = this.widen.dealias

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -1787,6 +1787,11 @@ object Types {
     lazy val ref = refFn()
     override def underlying(implicit ctx: Context) = ref
     override def toString = s"LazyRef($ref)"
+    override def equals(other: Any) = other match {
+      case other: LazyRef => this.ref.equals(other.ref)
+      case _ => false
+    }
+    override def hashCode = ref.hashCode + 37
   }
 
   // --- Refined Type ---------------------------------------------------------

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -504,7 +504,7 @@ object Types {
         case ex: MergeError =>
           throw new MergeError(s"${ex.getMessage} as members of type ${pre.show}")
         case ex: Throwable =>
-          println(i"findMember exception for $this member $name")
+          ctx.println(i"findMember exception for $this member $name")
           throw ex // DEBUG
       }
       finally {

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -1842,7 +1842,7 @@ object Types {
       else make(RefinedType(parent, names.head, infoFns.head), names.tail, infoFns.tail)
 
     def apply(parent: Type, name: Name, infoFn: RefinedType => Type)(implicit ctx: Context): RefinedType = {
-      assert(!ctx.erasedTypes)
+      assert(!ctx.erasedTypes || ctx.mode.is(Mode.Printing))
       ctx.base.uniqueRefinedTypes.enterIfNew(new CachedRefinedType(parent, name, infoFn)).checkInst
     }
 

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -812,10 +812,10 @@ object Types {
         case pre: RefinedType =>
           if (pre.refinedName ne name) loop(pre.parent)
           else pre.refinedInfo match {
-            case TypeAlias(tp) =>
-              if (!pre.refinementRefersToThis) tp
-              else tp match {
-                case TypeRef(SkolemType(`pre`), alias) => lookupRefined(alias)
+            case TypeAlias(alias) =>
+              if (!pre.refinementRefersToThis) alias
+              else alias match {
+                case TypeRef(SkolemType(`pre`), aliasName) => lookupRefined(aliasName )
                 case _ => NoType
               }
             case _ => loop(pre.parent)

--- a/src/dotty/tools/dotc/core/Uniques.scala
+++ b/src/dotty/tools/dotc/core/Uniques.scala
@@ -2,6 +2,7 @@ package dotty.tools.dotc
 package core
 
 import Types._, Contexts._, util.Stats._, Hashable._, Names._
+import config.Config
 import util.HashSet
 
 /** Defines operation `unique` for hash-consing types.
@@ -39,7 +40,7 @@ object Uniques {
   )
  */
 
-  final class NamedTypeUniques extends HashSet[NamedType](initialUniquesCapacity) with Hashable {
+  final class NamedTypeUniques extends HashSet[NamedType](Config.initialUniquesCapacity) with Hashable {
     override def hash(x: NamedType): Int = x.hash
 
     private def findPrevious(h: Int, prefix: Type, name: Name): NamedType = {
@@ -65,7 +66,7 @@ object Uniques {
     }
   }
 
-  final class TypeAliasUniques extends HashSet[TypeAlias](initialUniquesCapacity) with Hashable {
+  final class TypeAliasUniques extends HashSet[TypeAlias](Config.initialUniquesCapacity) with Hashable {
     override def hash(x: TypeAlias): Int = x.hash
 
     private def findPrevious(h: Int, alias: Type, variance: Int): TypeAlias = {
@@ -90,7 +91,7 @@ object Uniques {
     }
   }
 
-  final class RefinedUniques extends HashSet[RefinedType](initialUniquesCapacity) with Hashable {
+  final class RefinedUniques extends HashSet[RefinedType](Config.initialUniquesCapacity) with Hashable {
     override val hashSeed = classOf[CachedRefinedType].hashCode // some types start life as CachedRefinedTypes, need to have same hash seed
     override def hash(x: RefinedType): Int = x.hash
 

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -720,7 +720,7 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
         case SELECT =>
           def readQual(name: Name) = {
             val localCtx =
-              if (name == nme.CONSTRUCTOR) ctx.fresh.addMode(Mode.InSuperCall) else ctx
+              if (name == nme.CONSTRUCTOR) ctx.addMode(Mode.InSuperCall) else ctx
             readTerm()(localCtx)
           }
           def readRest(name: Name, sig: Signature) = {

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -679,25 +679,29 @@ object Parsers {
 
     def refinedTypeRest(t: Tree): Tree = {
       newLineOptWhenFollowedBy(LBRACE)
-      in.token match {
-        case AT => refinedTypeRest(atPos(t.pos.start) { Annotated(annot(), t) })
-        case LBRACE => refinedTypeRest(atPos(t.pos.start) { RefinedTypeTree(t, refinement()) })
-        case _ => t
-      }
+      if (in.token == LBRACE) refinedTypeRest(atPos(t.pos.start) { RefinedTypeTree(t, refinement()) })
+      else t
     }
 
-    /** WithType ::= SimpleType {`with' SimpleType}    (deprecated)
+    /** WithType ::= AnnotType {`with' AnnotType}    (deprecated)
      */
-    def withType(): Tree = withTypeRest(simpleType())
+    def withType(): Tree = withTypeRest(annotType())
 
-    def withTypeRest(t: Tree): Tree = {
+    def withTypeRest(t: Tree): Tree =
       if (in.token == WITH) {
         deprecationWarning("`with' as a type operator has been deprecated; use `&' instead")
         in.nextToken()
         AndTypeTree(t, withType())
       }
       else t
-    }
+
+    /** AnnotType ::= SimpleType {Annotation}
+     */
+    def annotType(): Tree = annotTypeRest(simpleType())
+
+    def annotTypeRest(t: Tree): Tree =
+      if (in.token == AT) annotTypeRest(atPos(t.pos.start) { Annotated(annot(), t) })
+      else t
 
     /** SimpleType       ::=  SimpleType TypeArgs
      *                     |  SimpleType `#' Id
@@ -1834,7 +1838,7 @@ object Parsers {
     /** ConstrApp         ::=  SimpleType {ParArgumentExprs}
      */
     val constrApp = () => {
-      val t = simpleType()
+      val t = annotType()
       if (in.token == LPAREN) parArgumentExprss(wrapNew(t))
       else t
     }

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1429,10 +1429,10 @@ object Parsers {
       else tree1
     }
 
-    /** Annotation        ::=  `@' SimpleType {ArgumentExprs}
+    /** Annotation        ::=  `@' SimpleType {ParArgumentExprs}
      */
     def annot() =
-      adjustStart(accept(AT)) { ensureApplied(argumentExprss(wrapNew(simpleType()))) }
+      adjustStart(accept(AT)) { ensureApplied(parArgumentExprss(wrapNew(simpleType()))) }
 
     def annotations(skipNewLines: Boolean = false): List[Tree] = {
       if (skipNewLines) newLineOptWhenFollowedBy(AT)

--- a/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -8,10 +8,11 @@ import StdNames.nme
 import ast.Trees._, ast._
 import java.lang.Integer.toOctalString
 import config.Config.summarizeDepth
+import typer.Mode
 import scala.annotation.switch
 
 class PlainPrinter(_ctx: Context) extends Printer {
-  protected[this] implicit def ctx: Context = _ctx
+  protected[this] implicit def ctx: Context = _ctx.fresh.addMode(Mode.Printing)
 
   protected def maxToTextRecursions = 100
 

--- a/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -170,6 +170,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
             else TypeBounds.empty
           "(" ~ toText(tp.origin) ~ "?" ~ toText(bounds) ~ ")"
         }
+      case tp: LazyRef =>
+        "LazyRef(" ~ toTextGlobal(tp.ref) ~ ")"
       case _ =>
         tp.fallbackToText(this)
     }

--- a/src/dotty/tools/dotc/printing/Showable.scala
+++ b/src/dotty/tools/dotc/printing/Showable.scala
@@ -5,6 +5,7 @@ import core._
 
 import Contexts._, Texts._, Decorators._
 import config.Config.summarizeDepth
+import scala.util.control.NonFatal
 
 trait Showable extends Any {
 
@@ -20,7 +21,11 @@ trait Showable extends Any {
   def fallbackToText(printer: Printer): Text = toString
 
   /** The string representation of this showable element. */
-  def show(implicit ctx: Context): String = toText(ctx.printer).show
+  def show(implicit ctx: Context): String =
+    try toText(ctx.printer).show
+    catch {
+      case NonFatal(ex) => s"[cannot display due to $ex, raw string = $toString]"
+    }
 
   /** The summarized string representation of this showable element.
    *  Recursion depth is limited to some smallish value. Default is

--- a/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -11,6 +11,7 @@ import config.Settings.Setting
 import config.Printers
 import java.lang.System.currentTimeMillis
 import typer.ErrorReporting.DiagnosticString
+import typer.Mode
 
 object Reporter {
 
@@ -215,7 +216,7 @@ abstract class Reporter {
   }
 
   def report(d: Diagnostic)(implicit ctx: Context): Unit = if (!isHidden(d)) {
-    doReport(d)
+    doReport(d)(ctx.addMode(Mode.Printing))
     d match {
       case d: ConditionalWarning if !d.enablingOption.value => unreportedWarnings(d.enablingOption.name) += 1
       case d: Warning => warningCount += 1
@@ -248,7 +249,7 @@ abstract class Reporter {
   }
 
   /** Should this diagnostic not be reported at all? */
-  def isHidden(d: Diagnostic)(implicit ctx: Context): Boolean = false
+  def isHidden(d: Diagnostic)(implicit ctx: Context): Boolean = ctx.mode.is(Mode.Printing)
 
   /** Does this reporter contain not yet reported errors or warnings? */
   def hasPending: Boolean = false

--- a/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -74,9 +74,9 @@ trait Reporting { this: Context =>
 
   /** For sending messages that are printed only if -verbose is set */
   def inform(msg: => String, pos: SourcePosition = NoSourcePosition): Unit =
-    if (this.settings.verbose.value) echo(msg, pos)
+    if (this.settings.verbose.value) this.println(msg, pos)
 
-  def echo(msg: => String, pos: SourcePosition = NoSourcePosition): Unit =
+  def println(msg: => String, pos: SourcePosition = NoSourcePosition): Unit =
     reporter.report(new Info(msg, pos))
 
   def deprecationWarning(msg: => String, pos: SourcePosition = NoSourcePosition): Unit =
@@ -112,7 +112,7 @@ trait Reporting { this: Context =>
    */
   def log(msg: => String, pos: SourcePosition = NoSourcePosition): Unit =
     if (this.settings.log.value.containsPhase(phase))
-      echo(s"[log ${ctx.phasesStack.reverse.mkString(" -> ")}] $msg", pos)
+      this.println(s"[log ${ctx.phasesStack.reverse.mkString(" -> ")}] $msg", pos)
 
   def debuglog(msg: => String): Unit =
     if (ctx.debug) log(msg)
@@ -232,10 +232,10 @@ abstract class Reporter {
 
   /** Print a summary */
   def printSummary(implicit ctx: Context): Unit = {
-    if (warningCount > 0) ctx.echo(countString(warningCount, "warning") + " found")
-    if (errorCount > 0) ctx.echo(countString(errorCount, "error") + " found")
+    if (warningCount > 0) ctx.println(countString(warningCount, "warning") + " found")
+    if (errorCount > 0) ctx.println(countString(errorCount, "error") + " found")
     for ((settingName, count) <- unreportedWarnings)
-      ctx.echo(s"there were $count ${settingName.tail} warning(s); re-run with $settingName for details")
+      ctx.println(s"there were $count ${settingName.tail} warning(s); re-run with $settingName for details")
   }
 
   /** Returns a string meaning "n elements". */

--- a/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -21,6 +21,7 @@ import ast.Trees._
 import Applications._
 import TypeApplications._
 import SymUtils._, core.NameOps._
+import typer.Mode
 
 import dotty.tools.dotc.util.Positions.Position
 import dotty.tools.dotc.core.Decorators._
@@ -464,8 +465,9 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {thisTrans
           // all potentially stored subpat binders
           val potentiallyStoredBinders = stored.unzip._1.toSet
           // compute intersection of all symbols in the tree `in` and all potentially stored subpat binders
-          new DeepFolder[Unit]((x: Unit, t:Tree) =>
+          def computeBinders(implicit ctx: Context) = new DeepFolder[Unit]((x: Unit, t:Tree) =>
             if (potentiallyStoredBinders(t.symbol)) usedBinders += t.symbol).apply((), in)
+          computeBinders(ctx.addMode(Mode.FutureDefsOK)) // trigged a NotDefinedHere on $outer when compiler dotc/printing
 
           if (usedBinders.isEmpty) in
           else {

--- a/src/dotty/tools/dotc/typer/Mode.scala
+++ b/src/dotty/tools/dotc/typer/Mode.scala
@@ -63,6 +63,9 @@ object Mode {
    */
   val AllowDependentFunctions = newMode(9, "AllowDependentFunctions")
 
+  /** We are currently printing something: avoid to produce more logs about
+   *  the printing
+   */
   val Printing = newMode(10, "Printing")
 
   val PatternOrType = Pattern | Type

--- a/src/dotty/tools/dotc/typer/Mode.scala
+++ b/src/dotty/tools/dotc/typer/Mode.scala
@@ -63,5 +63,7 @@ object Mode {
    */
   val AllowDependentFunctions = newMode(9, "AllowDependentFunctions")
 
+  val Printing = newMode(10, "Printing")
+
   val PatternOrType = Pattern | Type
 }

--- a/tests/pos/Iterable.scala
+++ b/tests/pos/Iterable.scala
@@ -1,0 +1,52 @@
+package dotty.collections
+package immutable
+
+import annotation.unchecked.uncheckedVariance
+
+trait Collection[+CC[X] <: Collection[CC, X], T] {
+  def companion: CollectionCompanion[CC]
+}
+
+trait Iterable[T] extends Collection[Iterable, T] {
+  def iterator: Iterator[T]
+  override def companion: IterableCompanion[Iterable] = Iterable
+}
+
+trait Seq[T] extends Iterable[T] with Collection[Seq, T] {
+  def apply(x: Int): T
+  override def companion: IterableCompanion[Seq] = Seq
+}
+
+abstract class CollectionCompanion[+CC[X] <: Collection[CC, X]]
+
+trait IterableImpls[CC[X]] {
+  def fromIterator[T](it: Iterator[T]): CC[T]
+  def toIterator[T](xs: CC[T]): Iterator[T]
+  def map[T, U](xs: CC[T], f: T => U): CC[U] =
+    fromIterator(toIterator(xs).map(f))
+  def filter[T](xs: CC[T], p: T => Boolean): CC[T] =
+    fromIterator(toIterator(xs).filter(p))
+  def flatMap[T, U](xs: CC[T], f: T => TraversableOnce[U]): CC[U] =
+    fromIterator(toIterator(xs).flatMap(f))
+}
+
+abstract class IterableCompanion[+CC[X] <: Iterable[X] with Collection[CC, X]]
+extends CollectionCompanion[CC] with IterableImpls[CC] @uncheckedVariance {
+  def toIterator[T](xs: CC[T] @uncheckedVariance) = xs.iterator
+  implicit def transformOps[T](xs: CC[T] @uncheckedVariance): TransformOps[CC, T] = new TransformOps[CC, T](xs)
+}
+
+class TransformOps[+CC[X] <: Iterable[X] with Collection[CC, X], T] (val xs: CC[T]) extends AnyVal {
+  def companion[T](xs: CC[T] @uncheckedVariance): IterableCompanion[CC] = xs.companion.asInstanceOf
+  def map[U](f: T => U): CC[U] = companion(xs).map(xs, f)
+  def filter(p: T => Boolean): CC[T] = companion(xs).filter(xs, p)
+  def flatMap[U](f: T => TraversableOnce[U]): CC[U] = companion(xs).flatMap(xs, f)
+}
+
+object Iterable extends IterableCompanion[Iterable] {
+  def fromIterator[T](it: Iterator[T]): Iterable[T] = ???
+}
+object Seq extends IterableCompanion[Seq] {
+  def fromIterator[T](it: Iterator[T]): Seq[T] = ???
+}
+

--- a/tests/pos/IterableSelfRec.scala
+++ b/tests/pos/IterableSelfRec.scala
@@ -1,0 +1,52 @@
+package dotty.collection
+package immutable
+
+import annotation.unchecked.uncheckedVariance
+
+trait Collection[T] { self =>
+  type This <: Collection { type This <: self.This }
+  def companion: CollectionCompanion[This]
+}
+
+trait Iterable[T] extends Collection[T] { self =>
+  type This <: Iterable { type This <: self.This }
+  override def companion: IterableCompanion[This] = Iterable.asInstanceOf
+
+  def iterator: Iterator[T]
+}
+
+trait Seq[T] extends Iterable[T] { self =>
+  type This <: Seq { type This <: self.This }
+  override def companion: IterableCompanion[This] = Seq.asInstanceOf
+
+  def apply(x: Int): T
+}
+
+abstract class CollectionCompanion[+CC <: Collection { type This <: CC }]
+
+abstract class IterableCompanion[+CC <: Iterable { type This <: CC }] extends CollectionCompanion[CC] {
+  def fromIterator[T](it: Iterator[T]): CC[T]
+  def map[T, U](xs: Iterable[T], f: T => U): CC[U] =
+    fromIterator(xs.iterator.map(f))
+  def filter[T](xs: Iterable[T], p: T => Boolean): CC[T] =
+    fromIterator(xs.iterator.filter(p))
+  def flatMap[T, U](xs: Iterable[T], f: T => TraversableOnce[U]): CC[U] =
+    fromIterator(xs.iterator.flatMap(f))
+
+  implicit def transformOps[T](xs: CC[T] @uncheckedVariance): TransformOps[CC, T] = ??? // new TransformOps[CC, T](xs)
+}
+
+class TransformOps[+CC <: Iterable { type This <: CC }, T] (val xs: CC[T]) extends AnyVal {
+  def companion[T](xs: CC[T] @uncheckedVariance): IterableCompanion[CC] = xs.companion
+  def map[U](f: T => U): CC[U] = companion(xs).map(xs, f)
+  def filter(p: T => Boolean): CC[T] = companion(xs).filter(xs, p)
+  def flatMap[U](f: T => TraversableOnce[U]): CC[U] = companion(xs).flatMap(xs, f)
+}
+
+object Iterable extends IterableCompanion[Iterable] {
+  def fromIterator[T](it: Iterator[T]): Iterable[T] = ???
+}
+object Seq extends IterableCompanion[Seq] {
+  def fromIterator[T](it: Iterator[T]): Seq[T] = ???
+}
+

--- a/tests/pos/annot.scala
+++ b/tests/pos/annot.scala
@@ -22,7 +22,7 @@ class Test {
 
   val x: A @uncheckedVariance with B @uncheckedVariance = ???
 
-  //class C extends A @uncheckedVariance () with B @uncheckedVariance { val x = 10 }
+  class C extends A @uncheckedVariance () with B @uncheckedVariance { val x = 10 }
 
 }
 

--- a/tests/pos/annot.scala
+++ b/tests/pos/annot.scala
@@ -1,6 +1,9 @@
 import java.beans.Transient
+import annotation.unchecked.uncheckedVariance
 
 class Test {
+
+// testing combinations of annotation syntax
 
   @SuppressWarnings(Array("hi")) def foo() = ??? // evalutation of annotation on type cannot be deferred as requires implicit resolution(only generic Array$.apply applies here)
 
@@ -11,5 +14,15 @@ class Test {
   @Transient(false) def bar = ???
 
   @Transient() def baz = ???
+
+// testing annotations in types
+
+  class A
+  trait B
+
+  val x: A @uncheckedVariance with B @uncheckedVariance = ???
+
+  //class C extends A @uncheckedVariance () with B @uncheckedVariance { val x = 10 }
+
 }
 


### PR DESCRIPTION
Lots of improvements to higher-kinded types which prevent crashes, keep types in
beta-reduced form, and improve printlng of type lambdas. The motivating example
for most of these is the included test case `Iterable.scala`. The beta-reduction
was observed in method `JavaParsers#basicType`. I did not manage to minimize
the test case without reference to `dotc` itself. Review by @adriaanm 

This PR is based on #573.
