### PR TITLE
TraitConstructors: Use a valid method name for the initializer (fix #577)

### DIFF
--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -315,7 +315,7 @@ object SymDenotations {
           encl = encl.owner
           sep += "~"
         }
-        if (owner.is(ModuleClass) && sep == "$") sep = "" // duplicate scalac's behavior: don't write a double '$$' for module class members.
+        if (owner.is(ModuleClass, butNot = Package) && sep == "$") sep = "" // duplicate scalac's behavior: don't write a double '$$' for module class members.
         val fn = encl.fullNameSeparated(separator) ++ sep ++ name
         if (isType) fn.toTypeName else fn.toTermName
       }

--- a/src/dotty/tools/dotc/transform/TraitConstructors.scala
+++ b/src/dotty/tools/dotc/transform/TraitConstructors.scala
@@ -23,7 +23,8 @@ class TraitConstructors extends MiniPhaseTransform with SymTransformer {
 
   def transformSym(sym: SymDenotation)(implicit ctx: Context): SymDenotation = {
     if (sym.isPrimaryConstructor && (sym.owner is Flags.Trait))
-      sym.copySymDenotation(name = nme.INITIALIZER_PREFIX ++ sym.owner.fullName)
+      // TODO: Someone needs to carefully check if name clashes are possible with this mangling scheme
+      sym.copySymDenotation(name = nme.INITIALIZER_PREFIX ++ sym.owner.fullNameSeparated("$"))
     else sym
   }
 


### PR DESCRIPTION
Review by @odersky or @DarkDimius .