### PR TITLE
Show be more verbose when running partest on Jenkins

### DIFF
--- a/scripts/jobs/validate/partest
+++ b/scripts/jobs/validate/partest
@@ -4,5 +4,5 @@ baseDir=${WORKSPACE-`pwd`}
 scriptsDir="$baseDir/scripts"
 . $scriptsDir/common
 
-sbt $sbtArgs update compile "partest-only run"
+sbt $sbtArgs update compile "partest-only run --show-diff --verbose"
 


### PR DESCRIPTION
Enables printing of diffs after test failure and a more summary in the end of test suite.
Diffs do not work yet #609