### PR TITLE
Trees: Add toString for AST nodes which are not case classes

### DIFF
--- a/src/dotty/tools/dotc/ast/Trees.scala
+++ b/src/dotty/tools/dotc/ast/Trees.scala
@@ -346,7 +346,9 @@ object Trees {
   }
 
   class BackquotedIdent[-T >: Untyped] private[ast] (name: Name)
-    extends Ident[T](name)
+    extends Ident[T](name) {
+    override def toString = "BackquotedIdent($name)"
+  }
 
   /** qualifier.name */
   case class Select[-T >: Untyped] private[ast] (qualifier: Tree[T], name: Name)
@@ -355,7 +357,9 @@ object Trees {
   }
 
   class SelectWithSig[-T >: Untyped] private[ast] (qualifier: Tree[T], name: Name, val sig: Signature)
-    extends Select[T](qualifier, name)
+    extends Select[T](qualifier, name) {
+    override def toString = "SelectWithSig($qualifier, $name, $sig)"
+  }
 
   /** qual.this */
   case class This[-T >: Untyped] private[ast] (qual: TypeName)
@@ -519,6 +523,7 @@ object Trees {
   /** Array(elems) */
   class JavaSeqLiteral[T >: Untyped] private[ast] (elems: List[Tree[T]])
     extends SeqLiteral(elems) {
+    override def toString = s"JavaSeqLiteral($elems)"
   }
 
   /** A type tree that represents an existing or inferred type */


### PR DESCRIPTION
This makes debugging trees easier

Review by @odersky .