### PR TITLE
Evaluate annotations in Namer

### DIFF
--- a/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -72,9 +72,7 @@ class ReTyper extends Typer {
   override def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType)(fallBack: (Tree, TyperState) => Tree)(implicit ctx: Context): Tree =
     fallBack(tree, ctx.typerState)
 
-  override def addTypedModifiersAnnotations(mdef: untpd.MemberDef, sym: Symbol)(implicit ctx: Context): Unit =
-    () // was: typedModifiers(Modifiers(sym), sym)
-       // but annotations are not transformed after typer, so no use to check them.
+  override def completeAnnotations(mdef: untpd.MemberDef, sym: Symbol)(implicit ctx: Context): Unit = ()
 
   override def ensureConstrCall(cls: ClassSymbol, parents: List[Tree])(implicit ctx: Context): List[Tree] =
     parents

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -861,7 +861,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
   def addTypedModifiersAnnotations(mdef: untpd.MemberDef, sym: Symbol)(implicit ctx: Context): Unit = {
     val mods1 = typedModifiers(untpd.modsDeco(mdef).mods, sym)
-    for (tree <- mods1.annotations) sym.addAnnotation(Annotation(tree))
+    sym.annotations.foreach(_.tree) // force trees to be computed
   }
 
   def typedModifiers(mods: untpd.Modifiers, sym: Symbol)(implicit ctx: Context): Modifiers = track("typedModifiers") {


### PR DESCRIPTION
Annotations were evaluated in Typer, which meant that they could be used only after type checking was
complete (or compilation order dependencies would be introduced). This commit makes annotations be
installed as part of completion in Namer. However, annotations are now lazy so as to avoid cyclic
references. This is completely analogous to the scheme in unpickler and ClassfileParser.