### PR TITLE
Add/resident compiler

### DIFF
--- a/src/dotty/tools/dotc/Bench.scala
+++ b/src/dotty/tools/dotc/Bench.scala
@@ -8,19 +8,7 @@ package dotc
 import core.Contexts.Context
 import reporting.Reporter
 
-/* To do:
- *   - simplify hk types
- *   - have a second look at normalization (leave at method types if pt is method type?)
- *   - Don't open package objects from class files if they are present in source
- *   - Revise the way classes are inherited - when not followed by [...] or (...),
- *     assume the unparameterized type and forward type parameters as we do now for the synthetic head class.
- */
 object Bench extends Driver {
-  def resident(compiler: Compiler): Reporter = unsupported("resident") /*loop { line =>
-    val command = new CompilerCommand(line split "\\s+" toList, new Settings(scalacError))
-    compiler.reporter.reset()
-    new compiler.Run() compile command.files
-  }*/
 
   private var numRuns = 1
 
@@ -29,17 +17,13 @@ object Bench extends Driver {
   private def ntimes(n: Int)(op: => Reporter): Reporter =
     (emptyReporter /: (0 until n)) ((_, _) => op)
 
-  override def doCompile(compiler: Compiler, fileNames: List[String], reporter: Option[Reporter] = None)
-      (implicit ctx: Context): Reporter =
-    if (new config.Settings.Setting.SettingDecorator[Boolean](ctx.base.settings.resident).value(ctx))
-      resident(compiler)
-    else
-      ntimes(numRuns) {
-        val start = System.nanoTime()
-        val r = super.doCompile(compiler, fileNames, reporter)
-        ctx.println(s"time elapsed: ${(System.nanoTime - start) / 1000000}ms")
-        r
-      }
+  override def doCompile(compiler: Compiler, fileNames: List[String])(implicit ctx: Context): Reporter =
+    ntimes(numRuns) {
+      val start = System.nanoTime()
+      val r = super.doCompile(compiler, fileNames)
+      println(s"time elapsed: ${(System.nanoTime - start) / 1000000}ms")
+      r
+    }
 
   def extractNumArg(args: Array[String], name: String, default: Int = 1): (Int, Array[String]) = {
     val pos = args indexOf name
@@ -47,11 +31,11 @@ object Bench extends Driver {
     else (args(pos + 1).toInt, (args take pos) ++ (args drop (pos + 2)))
   }
 
-  override def process(args: Array[String], rootCtx: Context, reporter: Option[Reporter] = None): Reporter = {
+  override def process(args: Array[String], rootCtx: Context): Reporter = {
     val (numCompilers, args1) = extractNumArg(args, "#compilers")
     val (numRuns, args2) = extractNumArg(args1, "#runs")
     this.numRuns = numRuns
-    ntimes(numCompilers)(super.process(args2, rootCtx, reporter))
+    ntimes(numCompilers)(super.process(args2, rootCtx))
   }
 }
 

--- a/src/dotty/tools/dotc/Driver.scala
+++ b/src/dotty/tools/dotc/Driver.scala
@@ -8,33 +8,40 @@ import scala.util.control.NonFatal
 
 abstract class Driver extends DotClass {
 
-  val prompt = "\ndotc>"
+  val prompt = "\ndotc> "
 
   protected def newCompiler(): Compiler
 
   protected def emptyReporter: Reporter = new StoreReporter
 
-  protected def doCompile(compiler: Compiler, fileNames: List[String], reporter: Option[Reporter] = None)
-      (implicit ctx: Context): Reporter =
-    if (fileNames.nonEmpty) {
-      val run = compiler.newRun(ctx, reporter)
-      run.compile(fileNames)
-      run.printSummary()
-    } else emptyReporter
+  protected def doCompile(compiler: Compiler, fileNames: List[String])(implicit ctx: Context): Reporter =
+    if (fileNames.nonEmpty)
+      try {
+        val run = compiler.newRun
+        run.compile(fileNames)
+        run.printSummary()
+      }
+      catch {
+        case ex: FatalError  =>
+          ctx.error(ex.getMessage) // signals that we should fail compilation.
+          ctx.typerState.reporter
+      }
+    else emptyReporter
 
   protected def initCtx = (new ContextBase).initialCtx
 
-  def process(args: Array[String], rootCtx: Context, reporter: Option[Reporter] = None): Reporter = {
+  protected def sourcesRequired = true
+
+  def setup(args: Array[String], rootCtx: Context): (List[String], Context) = {
     val summary = CompilerCommand.distill(args)(rootCtx)
     implicit val ctx: Context = initCtx.fresh.setSettings(summary.sstate)
-    val fileNames = CompilerCommand.checkUsage(summary)
-    try {
-      doCompile(newCompiler(), fileNames, reporter)
-    } catch {
-      case ex: FatalError  =>
-        ctx.error(ex.getMessage) // signals that we should fail compilation.
-        ctx.typerState.reporter
-    }
+    val fileNames = CompilerCommand.checkUsage(summary, sourcesRequired)
+    (fileNames, ctx)
+  }
+
+  def process(args: Array[String], rootCtx: Context): Reporter = {
+    val (fileNames, ctx) = setup(args, rootCtx)
+    doCompile(newCompiler(), fileNames)(ctx)
   }
 
   def main(args: Array[String]): Unit =

--- a/src/dotty/tools/dotc/FromTasty.scala
+++ b/src/dotty/tools/dotc/FromTasty.scala
@@ -42,7 +42,7 @@ object FromTasty extends Driver {
       List(new ReadTastyTreesFromClasses) :: backendPhases
     }
 
-    override def newRun(implicit ctx: Context, reporter: Option[Reporter] = None): Run = {
+    override def newRun(implicit ctx: Context): Run = {
       reset()
       new TASTYRun(this)(rootContext)
     }

--- a/src/dotty/tools/dotc/Main.scala
+++ b/src/dotty/tools/dotc/Main.scala
@@ -1,7 +1,3 @@
-/* NSC -- new Scala compiler
- * Copyright 2005-2013 LAMP/EPFL
- * @author  Martin Odersky
- */
 package dotty.tools
 package dotc
 
@@ -11,18 +7,5 @@ import reporting.Reporter
 /* To do:
  */
 object Main extends Driver {
-  def resident(compiler: Compiler): Reporter = unsupported("resident") /*loop { line =>
-    val command = new CompilerCommand(line split "\\s+" toList, new Settings(scalacError))
-    compiler.reporter.reset()
-    new compiler.Run() compile command.files
-  }*/
-
   override def newCompiler(): Compiler = new Compiler
-
-  override def doCompile(compiler: Compiler, fileNames: List[String], reporter: Option[Reporter] = None)(implicit ctx: Context): Reporter = {
-    if (new config.Settings.Setting.SettingDecorator[Boolean](ctx.base.settings.resident).value(ctx))
-      resident(compiler)
-    else
-      super.doCompile(compiler, fileNames, reporter)
-  }
 }

--- a/src/dotty/tools/dotc/Resident.scala
+++ b/src/dotty/tools/dotc/Resident.scala
@@ -1,0 +1,55 @@
+package dotty.tools
+package dotc
+
+import core.Contexts.Context
+import reporting.Reporter
+import java.io.EOFException
+import scala.annotation.tailrec
+
+/** A compiler which stays resident between runs.
+ *  Usage:
+ *
+ *  > scala dotty.tools.dotc.Resident <options> <initial files>
+ *
+ *  dotc> "more options and files to compile"
+ *
+ *  ...
+ *
+ *  dotc> :reset  // reset all options to the ones passed on the command line
+ *
+ *  ...
+ *
+ *  dotc> :q     // quit
+ */
+object Resident extends Driver {
+
+  object residentCompiler extends Compiler
+
+  override def newCompiler(): Compiler = ???
+
+  override def sourcesRequired = false
+
+  private val quit = ":q"
+  private val reset = ":reset"
+
+  private def getLine() = {
+    Console.print(prompt)
+    try scala.io.StdIn.readLine() catch { case _: EOFException => quit }
+  }
+
+  final override def process(args: Array[String], rootCtx: Context): Reporter = {
+    @tailrec def loop(args: Array[String], prevCtx: Context): Reporter = {
+      var (fileNames, ctx) = setup(args, prevCtx)
+      doCompile(residentCompiler, fileNames)(ctx)
+      var nextCtx = ctx
+      var line = getLine()
+      while (line == reset) {
+        nextCtx = rootCtx
+        line = getLine()
+      }
+      if (line.startsWith(quit)) ctx.typerState.reporter
+      else loop(line split "\\s+", nextCtx)
+    }
+    loop(args, rootCtx)
+  }
+}

--- a/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -60,7 +60,7 @@ object CompilerCommand extends DotClass {
    *  are already applied in context.
    *  @return  The list of files to compile.
    */
-  def checkUsage(summary: ArgsSummary)(implicit ctx: Context): List[String] = {
+  def checkUsage(summary: ArgsSummary, sourcesRequired: Boolean)(implicit ctx: Context): List[String] = {
     val settings = ctx.settings
 
     /** Creates a help message for a subset of options based on cond */
@@ -121,8 +121,7 @@ object CompilerCommand extends DotClass {
       ctx.println(infoMessage)
       Nil
     } else {
-      if (summary.arguments.isEmpty && !settings.resident.value)
-        ctx.println(usageMessage)
+      if (sourcesRequired && summary.arguments.isEmpty) ctx.println(usageMessage)
       summary.arguments
     }
   }

--- a/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -81,7 +81,6 @@ class ScalaSettings extends Settings.SettingGroup {
   val Xprintpos = BooleanSetting("-Xprint-pos", "Print tree positions, as offsets.")
   val printtypes = BooleanSetting("-Xprint-types", "Print tree types (debugging option).")
   val prompt = BooleanSetting("-Xprompt", "Display a prompt after each error (debugging option).")
-  val resident = BooleanSetting("-Xresident", "Compiler stays resident: read source filenames from standard input.")
   val script = StringSetting("-Xscript", "object", "Treat the source file as a script and wrap it in a main method.", "")
   val mainClass = StringSetting("-Xmain-class", "path", "Class for manifest's Main-Class entry (only useful with -d <jar>)", "")
   val Xshowcls = StringSetting("-Xshow-class", "class", "Show internal representation of class.", "")

--- a/src/dotty/tools/dotc/reporting/ThrowingReporter.scala
+++ b/src/dotty/tools/dotc/reporting/ThrowingReporter.scala
@@ -7,7 +7,8 @@ import collection.mutable
 import Reporter._
 
 /**
- * This class implements a Reporter that stores all messages
+ * This class implements a Reporter that throws all errors and sends warnings and other
+ * info to the underlying reporter.
  */
 class ThrowingReporter(reportInfo: Reporter) extends Reporter {
   protected def doReport(d: Diagnostic)(implicit ctx: Context): Unit = d match {

--- a/test/dotty/partest/DPDirectCompiler.scala
+++ b/test/dotty/partest/DPDirectCompiler.scala
@@ -23,9 +23,11 @@ class DPDirectCompiler(runner: DPTestRunner) extends nest.DirectCompiler(runner)
     }
 
     try {
-      val processor = if (opts0.exists(_.startsWith("#"))) dotty.tools.dotc.Bench else dotty.tools.dotc.Main
+      val processor =
+        if (opts0.exists(_.startsWith("#"))) dotty.tools.dotc.Bench else dotty.tools.dotc.Main
       val clogger = new ConsoleReporter(writer = clogWriter)(ctx)
-      val reporter = processor.process((sources.map(_.toString) ::: opts0).toArray, ctx, Some(clogger))
+      val logCtx = ctx.fresh.setTyperState(ctx.typerState.withReporter(clogger))
+      val reporter = processor.process((sources.map(_.toString) ::: opts0).toArray, logCtx)
       if (!reporter.hasErrors) runner.genPass()
       else {
         reporter.printSummary(ctx)


### PR DESCRIPTION
This adds a resident compiler command. For usage information, see doc comment in Resident.scala.
We'll later refine this to become a general compile server.
