### PR TITLE
Take expected result type into account for overloading resolution

### DIFF
--- a/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -46,7 +46,7 @@ object ProtoTypes {
      *  fits the given expected result type.
      */
     def constrainResult(mt: Type, pt: Type)(implicit ctx: Context): Boolean = pt match {
-      case _: FunProto =>
+      case pt: FunProto =>
         mt match {
           case mt: MethodType =>
             mt.isDependent || constrainResult(mt.resultType, pt.resultType)

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -1238,7 +1238,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       def expectedStr = err.expectedTypeStr(pt)
       resolveOverloaded(alts, pt) match {
         case alt :: Nil =>
-          adapt(tree.withType(alt), pt, original)
+          adapt(tree.withType(adaptByResult(alts, alt, pt)), pt, original)
         case Nil =>
           def noMatches =
             errorTree(tree,

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -1238,7 +1238,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       def expectedStr = err.expectedTypeStr(pt)
       resolveOverloaded(alts, pt) match {
         case alt :: Nil =>
-          adapt(tree.withType(adaptByResult(alts, alt, pt)), pt, original)
+          adapt(tree.withType(alt), pt, original)
         case Nil =>
           def noMatches =
             errorTree(tree,

--- a/tests/pending/pos/t8230a.scala
+++ b/tests/pending/pos/t8230a.scala
@@ -1,0 +1,26 @@
+trait Arr[T]
+object Arr {
+  def apply[T](xs: T): Arr[T]    = null
+  def apply(x: Long) : Arr[Long] = null
+}
+
+object I {
+  implicit def arrToTrav[T] (a: Arr[T])   : Traversable[T]    = null
+  implicit def longArrToTrav(a: Arr[Long]): Traversable[Long] = null
+}
+
+object Test {
+  def foo(t: Traversable[Any]) = {}
+
+  object Okay {
+    Arr("1")
+
+    import I.{ arrToTrav, longArrToTrav }
+    foo(Arr("2"))
+  }
+
+  object Fail {
+    import I.arrToTrav
+    foo(Arr("3")) // found String, expected Long
+  }
+}

--- a/tests/pos/array-overload.scala
+++ b/tests/pos/array-overload.scala
@@ -1,0 +1,8 @@
+class Test {
+  object A {
+    def apply(x: Byte, xs: Byte*): Array[Byte] = ???
+    def apply(x: Int, xs: Int*): Array[Int] = ???
+  }
+
+  val x: Array[Byte] = A.apply(1, 2)
+}

--- a/tests/run/arrayclone-new.scala
+++ b/tests/run/arrayclone-new.scala
@@ -1,4 +1,4 @@
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.ClassTag
 
 object Test extends dotty.runtime.LegacyApp{
   BooleanArrayClone;
@@ -106,3 +106,4 @@ object PolymorphicArrayClone{
 
   testIt(mangled.it, 0, 1);
 }
+


### PR DESCRIPTION
Previously, the expected result type of a FunProto type was ignored and taken into
account only in case of ambiguities. run/arrayclone-new.scala shows that this is not enough.
In a case like

    val x: Array[Byte] = Array(1, 2)

we typed 1, 2 to be Int, so overloading resolution would give the Array.apply of
type (Int, Int*)Array[Int]. But that's a dead end, since Array[Int] is not a subtype
of Array[Byte].

This commit proposes the following modified rule for overloading resolution:

  A method alternative is applicable if ... (as before), and if its result type
  is compatible with the expected type of the method application.

The commit does not pre-select alternatives based on comparing with the expected
result type. I tried that but it slowed down typechecking by a factor of at least 4.
Instead, we proceed as usual, ignoring the result type except in case of
ambiguities, but check whether the result of overloading resolution has a
compatible result type. If that's not the case, we filter all alternatives
for result type compatibility and try again.

Review by @adriaanm 