### PR TITLE
Compile dotty.*, not only dotty.tools.

### DIFF
--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -154,7 +154,7 @@ class tests extends CompilerTest {
 
   @Test def run_all = runFiles(runDir)
 
-  @Test def dotty = compileDir(dottyDir, "tools", "-deep" :: "-Ycheck-reentrant" :: allowDeepSubtypes ++ twice) // note the -deep argument
+  @Test def dotty = compileDir(dottyDir, ".", "-deep" :: "-Ycheck-reentrant" :: allowDeepSubtypes) // note the -deep argument
 
   @Test def dotc_ast = compileDir(dotcDir, "ast")
   @Test def dotc_config = compileDir(dotcDir, "config")


### PR DESCRIPTION
On my machine succeeds first compilation, but fails second, with >200 erorrs of such kind:

```
./src/dotty/./tools/dotc/core/Flags.scala:565: error: type mismatch:
 found   : (dotty.tools.dotc.core.Flags.FlagSet, dotty.tools.dotc.core.Flags.FlagSet)
 required: scala.collection.Seq[dotty.tools.dotc.core.Flags.FlagSet] @Repeated
  final val JavaInterface = allOf(JavaDefined, Trait)
```

@odersky, could you take it from here?