### PR TITLE
Refactor viewExists

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -601,6 +601,19 @@ object Types {
       ctx.typeComparer.isSameType(this, that)
     }
 
+    /** Is this type a primitive value type which can be widened to the primitive value type `to`? */
+    def isValueSubType(that: Type)(implicit ctx: Context) = widenExpr match {
+      case self: TypeRef if defn.ScalaValueClasses contains self.symbol =>
+        that.widenExpr match {
+          case that: TypeRef if defn.ScalaValueClasses contains that.symbol =>
+            defn.isValueSubClass(self.symbol, that.symbol)
+          case _ =>
+            false
+        }
+      case _ =>
+        false
+    }
+
     /** Is this type a legal type for a member that overrides another
      *  member of type `that`? This is the same as `<:<`, except that
      *  the types ()T and => T are identified, and T is seen as overriding

--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -382,21 +382,10 @@ trait Implicits { self: Typer =>
     && !to.isError
     && !ctx.isAfterTyper
     && (ctx.mode is Mode.ImplicitsEnabled)
-    && { from.widenExpr match {
-           case from: TypeRef if defn.ScalaValueClasses contains from.symbol =>
-             to.widenExpr match {
-               case to: TypeRef if defn.ScalaValueClasses contains to.symbol =>
-                 util.Stats.record("isValueSubClass")
-                 return defn.isValueSubClass(from.symbol, to.symbol)
-               case _ =>
-             }
-           case from: ValueType =>
-             ;
-           case _ =>
-             return false
-         }
-         inferView(dummyTreeOfType(from), to)(ctx.fresh.setExploreTyperState).isInstanceOf[SearchSuccess]
-       }
+    && from.isInstanceOf[ValueType]
+    && (  from.isValueSubType(to)
+       || inferView(dummyTreeOfType(from), to)(ctx.fresh.setExploreTyperState).isInstanceOf[SearchSuccess]
+       )
     )
 
   /** Find an implicit conversion to apply to given tree `from` so that the


### PR DESCRIPTION
Factor out isValueSubClass into separate method. Will probably come in handly
elsewhere, and makes the code easier to understand.

Review by @darkdimius