### PR TITLE
TypeErasure#erasure: do not semi-erase types by default

### DIFF
--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -110,7 +110,14 @@ object TypeErasure {
   private def erasureCtx(implicit ctx: Context) =
     if (ctx.erasedTypes) ctx.withPhase(ctx.erasurePhase).addMode(Mode.FutureDefsOK) else ctx
 
-  def erasure(tp: Type, semiEraseVCs: Boolean = true)(implicit ctx: Context): Type =
+  /** The standard erasure of a Scala type.
+   *
+   *  @param tp            The type to erase.
+   *  @param semiEraseVCs  If true, value classes are semi-erased to ErasedValueType
+   *                       (they will be fully erased in [[ElimErasedValueType]]).
+   *                       If false, they are erased like normal classes.
+   */
+  def erasure(tp: Type, semiEraseVCs: Boolean = false)(implicit ctx: Context): Type =
     erasureFn(isJava = false, semiEraseVCs, isConstructor = false, wildcardOK = false)(tp)(erasureCtx)
 
   def sigName(tp: Type, isJava: Boolean)(implicit ctx: Context): TypeName = {
@@ -134,7 +141,7 @@ object TypeErasure {
     case tp: ThisType =>
       tp
     case tp =>
-      erasure(tp)
+      erasure(tp, semiEraseVCs = true)
   }
 
   /**  The symbol's erased info. This is the type's erasure, except for the following symbols:
@@ -389,7 +396,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
   private def eraseDerivedValueClassRef(tref: TypeRef)(implicit ctx: Context): Type = {
     val cls = tref.symbol.asClass
     val underlying = underlyingOfValueClass(cls)
-    ErasedValueType(cls, erasure(underlying))
+    ErasedValueType(cls, erasure(underlying, semiEraseVCs = true))
   }
 
 

--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -268,7 +268,7 @@ object Erasure extends TypeTestsCasts{
   class Typer extends typer.ReTyper with NoChecking {
     import Boxing._
 
-    def erasedType(tree: untpd.Tree, semiEraseVCs: Boolean = true)(implicit ctx: Context): Type =
+    def erasedType(tree: untpd.Tree, semiEraseVCs: Boolean)(implicit ctx: Context): Type =
       tree.typeOpt match {
         case tp: TermRef if tree.isTerm => erasedRef(tp)
         case tp => erasure(tp, semiEraseVCs)
@@ -296,7 +296,7 @@ object Erasure extends TypeTestsCasts{
     /** This override is only needed to semi-erase type ascriptions */
     override def typedTyped(tree: untpd.Typed, pt: Type)(implicit ctx: Context): Tree = {
       val Typed(expr, tpt) = tree
-      val tpt1 = promote(tpt)
+      val tpt1 = promote(tpt, semiEraseVCs = true)
       val expr1 = typed(expr, tpt1.tpe)
       assignType(untpd.cpy.Typed(tree)(expr1, tpt1), tpt1)
     }
@@ -460,7 +460,7 @@ object Erasure extends TypeTestsCasts{
       if (pt.isValueType) pt else {
         if (tree.typeOpt.derivesFrom(ctx.definitions.UnitClass))
           tree.typeOpt
-        else erasure(tree.typeOpt)
+        else erasure(tree.typeOpt, semiEraseVCs = true)
       }
     }
 

--- a/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -65,7 +65,7 @@ class ExtensionMethods extends MiniPhaseTransform with DenotTransformer with Ful
               }
             }
 
-            val underlying = erasure(underlyingOfValueClass(valueClass))
+            val underlying = erasure(underlyingOfValueClass(valueClass), semiEraseVCs = true)
             val evt = ErasedValueType(valueClass, underlying)
             val u2evtSym = ctx.newSymbol(moduleSym, nme.U2EVT, Synthetic | Method,
               MethodType(List(nme.x_0), List(underlying), evt))

--- a/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -96,7 +96,7 @@ trait TypeTestsCasts {
           } else
             derivedTree(qual, defn.Any_asInstanceOf, argType)
         }
-        def erasedArg = erasure(tree.args.head.tpe, semiEraseVCs = false)
+        def erasedArg = erasure(tree.args.head.tpe)
         if (sym eq defn.Any_isInstanceOf)
           transformIsInstanceOf(qual, erasedArg)
         else if (sym eq defn.Any_asInstanceOf)


### PR DESCRIPTION
This way we can simplify `ClassOf`.
Review by @DarkDimius .