### PR TITLE
Partest output redirection over context.reporter

### DIFF
--- a/src/dotty/tools/dotc/Bench.scala
+++ b/src/dotty/tools/dotc/Bench.scala
@@ -29,14 +29,15 @@ object Bench extends Driver {
   private def ntimes(n: Int)(op: => Reporter): Reporter =
     (emptyReporter /: (0 until n)) ((_, _) => op)
 
-  override def doCompile(compiler: Compiler, fileNames: List[String])(implicit ctx: Context): Reporter =
+  override def doCompile(compiler: Compiler, fileNames: List[String], reporter: Option[Reporter] = None)
+      (implicit ctx: Context): Reporter =
     if (new config.Settings.Setting.SettingDecorator[Boolean](ctx.base.settings.resident).value(ctx))
       resident(compiler)
     else
       ntimes(numRuns) {
         val start = System.nanoTime()
-        val r = super.doCompile(compiler, fileNames)
-        println(s"time elapsed: ${(System.nanoTime - start) / 1000000}ms")
+        val r = super.doCompile(compiler, fileNames, reporter)
+        ctx.println(s"time elapsed: ${(System.nanoTime - start) / 1000000}ms")
         r
       }
 
@@ -46,11 +47,11 @@ object Bench extends Driver {
     else (args(pos + 1).toInt, (args take pos) ++ (args drop (pos + 2)))
   }
 
-  override def process(args: Array[String], rootCtx: Context): Reporter = {
+  override def process(args: Array[String], rootCtx: Context, reporter: Option[Reporter] = None): Reporter = {
     val (numCompilers, args1) = extractNumArg(args, "#compilers")
     val (numRuns, args2) = extractNumArg(args1, "#runs")
     this.numRuns = numRuns
-    ntimes(numCompilers)(super.process(args2, rootCtx))
+    ntimes(numCompilers)(super.process(args2, rootCtx, reporter))
   }
 }
 

--- a/src/dotty/tools/dotc/Compiler.scala
+++ b/src/dotty/tools/dotc/Compiler.scala
@@ -7,7 +7,7 @@ import Periods._
 import Symbols._
 import Scopes._
 import typer.{FrontEnd, Typer, Mode, ImportInfo, RefChecks}
-import reporting.ConsoleReporter
+import reporting.{ConsoleReporter, Reporter}
 import Phases.Phase
 import dotty.tools.dotc.transform._
 import dotty.tools.dotc.transform.TreeTransforms.{TreeTransform, TreeTransformer}
@@ -93,7 +93,7 @@ class Compiler {
    *                 for type checking.
    *    imports      For each element of RootImports, an import context
    */
-  def rootContext(implicit ctx: Context): Context = {
+  def rootContext(implicit ctx: Context, r: Option[Reporter] = None): Context = {
     ctx.definitions.init(ctx)
     ctx.setPhasePlan(phases)
     val rootScope = new MutableScope
@@ -105,7 +105,7 @@ class Compiler {
       .setOwner(defn.RootClass)
       .setTyper(new Typer)
       .setMode(Mode.ImplicitsEnabled)
-      .setTyperState(new MutableTyperState(ctx.typerState, new ConsoleReporter()(ctx), isCommittable = true))
+      .setTyperState(new MutableTyperState(ctx.typerState, r.getOrElse(new ConsoleReporter()(ctx)), isCommittable = true))
     ctx.definitions.init(start) // set context of definitions to start
     def addImport(ctx: Context, symf: () => Symbol) =
       ctx.fresh.setImportInfo(ImportInfo.rootImport(symf)(ctx))
@@ -117,8 +117,8 @@ class Compiler {
     ctx.runInfo.clear()
   }
 
-  def newRun(implicit ctx: Context): Run = {
+  def newRun(implicit ctx: Context, r: Option[Reporter] = None): Run = {
     reset()
-    new Run(this)(rootContext)
+    new Run(this)(rootContext(ctx, r))
   }
 }

--- a/src/dotty/tools/dotc/FromTasty.scala
+++ b/src/dotty/tools/dotc/FromTasty.scala
@@ -12,6 +12,7 @@ import SymDenotations._
 import typer.FrontEnd
 import Phases.Phase
 import util._
+import reporting.Reporter
 import Decorators._
 import dotty.tools.dotc.transform.Pickler
 import tasty.DottyUnpickler
@@ -41,7 +42,7 @@ object FromTasty extends Driver {
       List(new ReadTastyTreesFromClasses) :: backendPhases
     }
 
-    override def newRun(implicit ctx: Context): Run = {
+    override def newRun(implicit ctx: Context, reporter: Option[Reporter] = None): Run = {
       reset()
       new TASTYRun(this)(rootContext)
     }

--- a/src/dotty/tools/dotc/Main.scala
+++ b/src/dotty/tools/dotc/Main.scala
@@ -19,10 +19,10 @@ object Main extends Driver {
 
   override def newCompiler(): Compiler = new Compiler
 
-  override def doCompile(compiler: Compiler, fileNames: List[String])(implicit ctx: Context): Reporter = {
+  override def doCompile(compiler: Compiler, fileNames: List[String], reporter: Option[Reporter] = None)(implicit ctx: Context): Reporter = {
     if (new config.Settings.Setting.SettingDecorator[Boolean](ctx.base.settings.resident).value(ctx))
       resident(compiler)
     else
-      super.doCompile(compiler, fileNames)
+      super.doCompile(compiler, fileNames, reporter)
   }
 }

--- a/src/dotty/tools/dotc/Run.scala
+++ b/src/dotty/tools/dotc/Run.scala
@@ -33,7 +33,7 @@ class Run(comp: Compiler)(implicit ctx: Context) {
     compileSources(sources)
   } catch {
     case NonFatal(ex) =>
-      println(i"exception occurred while compiling $units%, %")
+      ctx.println(i"exception occurred while compiling $units%, %")
       throw ex
   }
 
@@ -55,7 +55,7 @@ class Run(comp: Compiler)(implicit ctx: Context) {
     ctx.usePhases(phases)
     for (phase <- ctx.allPhases)
       if (!ctx.reporter.hasErrors) {
-        if (ctx.settings.verbose.value) println(s"[$phase]")
+        if (ctx.settings.verbose.value) ctx.println(s"[$phase]")
         units = phase.runOn(units)
         def foreachUnit(op: Context => Unit)(implicit ctx: Context): Unit =
           for (unit <- units) op(ctx.fresh.setPhase(phase.next).setCompilationUnit(unit))
@@ -69,8 +69,8 @@ class Run(comp: Compiler)(implicit ctx: Context) {
     val prevPhase = ctx.phase.prev // can be a mini-phase
     val squashedPhase = ctx.squashed(prevPhase)
 
-    println(s"result of $unit after ${squashedPhase}:")
-    println(unit.tpdTree.show(ctx))
+    ctx.println(s"result of $unit after ${squashedPhase}:")
+    ctx.println(unit.tpdTree.show(ctx))
   }
 
   def compile(sourceCode: String): Unit = {

--- a/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -42,8 +42,8 @@ class TreeChecker extends Phase with SymTransformer {
   private val seenClasses = collection.mutable.HashMap[String, Symbol]()
   private val seenModuleVals = collection.mutable.HashMap[String, Symbol]()
 
-  def printError(str: String) = {
-    println(Console.RED + "[error] " + Console.WHITE  + str)
+  def printError(str: String)(implicit ctx: Context) = {
+    ctx.println(Console.RED + "[error] " + Console.WHITE  + str)
   }
 
   val NoSuperClass = Trait | Package
@@ -109,7 +109,7 @@ class TreeChecker extends Phase with SymTransformer {
   def check(phasesToRun: Seq[Phase], ctx: Context) = {
     val prevPhase = ctx.phase.prev // can be a mini-phase
     val squahsedPhase = ctx.squashed(prevPhase)
-    println(s"checking ${ctx.compilationUnit} after phase ${squahsedPhase}")
+    ctx.println(s"checking ${ctx.compilationUnit} after phase ${squahsedPhase}")
     val checkingCtx = ctx.fresh
       .setTyperState(ctx.typerState.withReporter(new ThrowingReporter(ctx.typerState.reporter)))
     val checker = new Checker(previousPhases(phasesToRun.toList)(ctx))
@@ -117,7 +117,7 @@ class TreeChecker extends Phase with SymTransformer {
     catch {
       case NonFatal(ex) =>
         implicit val ctx: Context = checkingCtx
-        println(i"*** error while checking after phase ${checkingCtx.phase.prev} ***")
+        ctx.println(i"*** error while checking after phase ${checkingCtx.phase.prev} ***")
         throw ex
     }
   }
@@ -151,10 +151,10 @@ class TreeChecker extends Phase with SymTransformer {
         }
 
         nowDefinedSyms += tree.symbol
-        //println(i"defined: ${tree.symbol}")
+        //ctx.println(i"defined: ${tree.symbol}")
         val res = op
         nowDefinedSyms -= tree.symbol
-        //println(i"undefined: ${tree.symbol}")
+        //ctx.println(i"undefined: ${tree.symbol}")
         res
       case _ => op
     }

--- a/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -18,7 +18,7 @@ class FrontEnd extends Phase {
     try body
     catch {
       case NonFatal(ex) =>
-        println(s"exception occurred while $doing ${ctx.compilationUnit}")
+        ctx.println(s"exception occurred while $doing ${ctx.compilationUnit}")
         throw ex
     }
 

--- a/test/dotty/partest/DPConfig.scala
+++ b/test/dotty/partest/DPConfig.scala
@@ -1,7 +1,8 @@
 package dotty.partest
 
-import java.io.File
 import scala.collection.JavaConversions._
+import scala.reflect.io.Path
+import java.io.File
 
 
 /** Dotty Partest runs all tests in the provided testDirs located under
@@ -14,7 +15,9 @@ import scala.collection.JavaConversions._
   * otherwise pos/__defaultFlags.flags are used if the file exists).
   */
 object DPConfig {
-  val testRoot = "./tests/partest-generated"
+  val testRoot = (Path(".") / Path("tests") / Path("partest-generated")).toString
+  val genLog = Path(testRoot) / Path("gen.log")
+
   lazy val testDirs = {
     val root = new File(testRoot)
     val dirs = if (!root.exists) Array.empty[String] else root.listFiles.filter(_.isDirectory).map(_.getName)

--- a/test/test/CompilerTest.scala
+++ b/test/test/CompilerTest.scala
@@ -344,7 +344,7 @@ object CompilerTest extends App {
   lazy val init: SFile = {
     scala.reflect.io.Directory(DPConfig.testRoot).deleteRecursively
     new JFile(DPConfig.testRoot).mkdirs
-    val log = (Path(DPConfig.testRoot) / Path("gen.log")).createFile(true)
+    val log = DPConfig.genLog.createFile(true)
     println(s"CompilerTest is generating tests for partest, log: $log")
     log
   }


### PR DESCRIPTION
For concurrent partest, output redirection by redirecting sysout is not suited. In scalac, the output stream of the compiler could be set in the Global. For dotty, this is done through the context and required an additional argument when creating the initial context. However, the compiler also needs to print through `ctx.println` instead of regular `println`.