### PR TITLE
Fixes to generic arrays in backend.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -42,7 +42,7 @@ object DottyBuild extends Build {
     resolvers += Resolver.sonatypeRepo("releases"),
 
     // get libraries onboard
-    partestDeps := Seq("me.d-d" % "scala-compiler" % "2.11.5-20150506-175515-8fc7635b56",
+    partestDeps := Seq("me.d-d" % "scala-compiler" % "2.11.5-20150619-173733-3bcd390afa",
                       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
                       "org.scala-lang" % "scala-library" % scalaVersion.value % "test"),
     libraryDependencies ++= partestDeps.value,

--- a/src/dotty/runtime/Arrays.scala
+++ b/src/dotty/runtime/Arrays.scala
@@ -7,6 +7,8 @@ import scala.reflect.ClassTag
  */
 object Arrays {
 
+  // note: this class is magical. Do not touch it unless you know what you are doing.`
+
   /** Creates an array of some element type determined by the given `ClassTag`
    *  argument. The erased type of applications of this method is `Object`.
    */

--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -157,9 +157,16 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
   }.toMap
   def unboxMethods: Map[Symbol, Symbol] = defn.ScalaValueClasses.map(x => (x, Erasure.Boxing.unboxMethod(x.asClass))).toMap
 
-  private val mkArrayNames: Set[String] = Set("Byte", "Float", "Char", "Double", "Boolean", "Unit", "Long", "Int", "Short", "Ref")
+  private val mkArrayNames: Set[Name] = Set("Byte", "Float", "Char", "Double", "Boolean", "Unit", "Long", "Int", "Short", "Ref").map{ x=>
+    ("new" + x + "Array").toTermName
+  }
 
-  override lazy val syntheticArrayConstructors: Set[Symbol] = mkArrayNames.map(nm => ctx.requiredMethod(toDenot(defn.DottyArraysModule).moduleClass.asClass, s"new${nm}Array"))
+  val dottyArraysModuleClass = toDenot(defn.DottyArraysModule).moduleClass.asClass
+
+
+  override def isSyntheticArrayConstructor(s: Symbol) = {
+    (toDenot(s).maybeOwner eq dottyArraysModuleClass) && mkArrayNames.contains(s.name)
+  }
 
   def isBox(sym: Symbol): Boolean = Erasure.Boxing.isBox(sym)
   def isUnbox(sym: Symbol): Boolean = Erasure.Boxing.isUnbox(sym)


### PR DESCRIPTION
Helps bootstrap, by allowing to recompile bigger parts of dotty.
This used to be part of #672, but I want this get merged faster to continue with bootstrap.
@odersky please review.