### PR TITLE
Neg tests check files for // error markers

### DIFF
--- a/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -210,6 +210,8 @@ abstract class Reporter {
   var warningCount = 0
   def hasErrors = errorCount > 0
   def hasWarnings = warningCount > 0
+  private var errors: List[Error] = Nil
+  def allErrors = errors
 
   val unreportedWarnings = new mutable.HashMap[String, Int] {
     override def default(key: String) = 0
@@ -220,7 +222,9 @@ abstract class Reporter {
     d match {
       case d: ConditionalWarning if !d.enablingOption.value => unreportedWarnings(d.enablingOption.name) += 1
       case d: Warning => warningCount += 1
-      case d: Error => errorCount += 1
+      case d: Error =>
+        errors = d :: errors
+        errorCount += 1
       case d: Info => // nothing to do here
       // match error if d is something else
     }

--- a/tests/neg/arrayclone-new.scala
+++ b/tests/neg/arrayclone-new.scala
@@ -7,7 +7,7 @@ object Test extends dotty.runtime.LegacyApp{
 }
 
 object ObjectArrayClone{
-  val it : Array[String] = Array("1", "0");
+  val it : Array[String] = Array("1", "0");           // error
   val cloned = it.clone();
   assert(cloned.sameElements(it));
   cloned(0) = "0";
@@ -22,7 +22,7 @@ object PolymorphicArrayClone{
     assert(it(0) == one)
   }
 
-  testIt(Array("one", "two"), "one", "two");
+  testIt(Array("one", "two"), "one", "two");          // error
 
   class Mangler[T: ClassTag](ts : T*){
     // this will always be a BoxedAnyArray even after we've unboxed its contents.

--- a/tests/neg/assignments.scala
+++ b/tests/neg/assignments.scala
@@ -13,11 +13,11 @@ object assignments {
     x = x + 1
     x *= 2
 
-    x_= = 2  // should give missing arguments + reassignment to val
+    x_= = 2  // error should give missing arguments + // error reassignment to val
   }
 
   var c = new C
-  import c._ // should give: prefix is not stable
+  import c._ // error should give: prefix is not stable
   x = x + 1
   x *= 2
 }

--- a/tests/neg/autoTuplingTest.scala
+++ b/tests/neg/autoTuplingTest.scala
@@ -2,10 +2,10 @@ import dotty.language.noAutoTupling
 
 object autoTuplingNeg {
 
-  val x = Some(1, 2)
+  val x = Some(1, 2)                                  // error
 
   x match {
-    case Some(a, b) => a + b
+    case Some(a, b) => a + b                          // error // error // error
     case None =>
   }
 }

--- a/tests/neg/blockescapesNeg.scala
+++ b/tests/neg/blockescapesNeg.scala
@@ -1,6 +1,6 @@
 object blockescapesNeg {
   def m0 = { object Foo { class Bar { val field = 2 }} ; new Foo.Bar }
-  m0.field
+  m0.field                                            // error
   class A[T]
   def m1 = { val x = 1; new A[x.type]}
 }

--- a/tests/neg/boundspropagation.scala
+++ b/tests/neg/boundspropagation.scala
@@ -13,7 +13,7 @@ object test2 {
 
 
   def f(x: Any): Tree[Null] = x match {
-    case y: Tree[_] => y
+    case y: Tree[_] => y                              // error
   }
 }
 object test3 {
@@ -21,7 +21,7 @@ object test3 {
 
 
   def f(x: Any): Tree[Null] = x match {
-    case y: Tree[_] => y
+    case y: Tree[_] => y                              // error
   }
 }
 
@@ -34,11 +34,11 @@ object test4 {
     class Tree[-S, -T >: Option[S]]
 
     def g(x: Any): Tree[_, _ <: Option[N]] = x match {
-      case y: Tree[_, _] => y
+      case y: Tree[_, _] => y                         // error
     }
   }
 }
 
 class Test5 {
-"": ({ type U = this.type })#U
+"": ({ type U = this.type })#U                        // error // error
 }

--- a/tests/neg/companions.scala
+++ b/tests/neg/companions.scala
@@ -8,7 +8,7 @@ object companionsNeg {
 
     { object C {
       private val p = 1
-      println(new C().q)
+      println(new C().q)   // error
     }}
   }
 

--- a/tests/neg/cycles.scala
+++ b/tests/neg/cycles.scala
@@ -1,21 +1,21 @@
-class Foo[T <: U, U <: T]
+class Foo[T <: U, U <: T]                             // error
 
-class Bar[T >: T]
+class Bar[T >: T]                                     // error
 
 class A {
   val x: T = ???
-  type T <: x.type
+  type T <: x.type                                    // error
 }
 
 class B {
-  type T <: x.type
+  type T <: x.type                                    // error
   val x: T = ???
 }
 
 class C {
   val x: D#T = ???
   class D {
-    type T <: x.type
+    type T <: x.type                                  // error
     val z: x.type = ???
   }
 }
@@ -23,17 +23,17 @@ class C {
 class E {
   class F {
     type T <: x.type
-    val z: x.type = ???
+    val z: x.type = ???                               // error
   }
   val x: F#T = ???
 }
 
 class T1 {
-  type X = (U, U) // cycle
+  type X = (U, U) // cycle                            // error
   type U = X & Int
 }
 class T2 {
-  type X = (U, U) // cycle
+  type X = (U, U) // cycle                            // error
   type U = X | Int
 }
 object T12 {

--- a/tests/neg/escapingRefs.scala
+++ b/tests/neg/escapingRefs.scala
@@ -3,8 +3,8 @@ object O {
   class B
   def f[T](x: T, y: T): T = y
 
-  val x: A = f(new A { }, new B { })
+  val x: A = f(new A { }, new B { })                  // error
 
   val y = f({ class C { def member: Int = 1 }; new C }, { class C { def member: Int = 1 }; new C })
-  val z = y.member
+  val z = y.member                                    // error
 }

--- a/tests/neg/i0091-infpaths.scala
+++ b/tests/neg/i0091-infpaths.scala
@@ -2,7 +2,7 @@ object infpaths {
 
   object a {
     trait T { t =>
-      type M <: t.b.M
+      type M <: t.b.M                                 // error
       type T <: a.T
       val b: t.T
     }
@@ -10,7 +10,7 @@ object infpaths {
   }
 
   val m1: a.x.M = ???
-  val m2: a.x.b.M = m1
-  val m3: a.x.b.b.M = m2
+  val m2: a.x.b.M = m1                                // error
+  val m3: a.x.b.b.M = m2                              // error
 
 }

--- a/tests/neg/i0248-inherit-refined.scala
+++ b/tests/neg/i0248-inherit-refined.scala
@@ -1,10 +1,10 @@
 object test {
   class A { type T }
   type X = A { type T = Int }
-  class B extends X
+  class B extends X                                   // error
   type Y = A & B
-  class C extends Y
+  class C extends Y                                   // error
   type Z = A | B
-  class D extends Z
-  abstract class E extends ({ val x: Int })
+  class D extends Z                                   // error
+  abstract class E extends ({ val x: Int })           // error
 }

--- a/tests/neg/i0281-null-primitive-conforms.scala
+++ b/tests/neg/i0281-null-primitive-conforms.scala
@@ -1,6 +1,6 @@
 object test {
-  val b: scala.Boolean = null
+  val b: scala.Boolean = null                         // error
   val c: Unit = null
-  val d: Float = null
-  val e: AnyVal = null
+  val d: Float = null                                 // error
+  val e: AnyVal = null                                // error
 }

--- a/tests/neg/i0583-skolemize.scala
+++ b/tests/neg/i0583-skolemize.scala
@@ -12,7 +12,7 @@ object Test1 {
 
   val xs: List[C[_]] = List(c, d)
 
-  xs(0).x = xs(1).x
+  xs(0).x = xs(1).x                                   // error
 
 }
 object Test {
@@ -20,7 +20,7 @@ object Test {
     val f: ListBuffer[Int] = ListBuffer(1,2)
     val g: ListBuffer[Double] = ListBuffer(3.0,4.0)
     val lb: ListBuffer[ListBuffer[_]] = ListBuffer(f, g)
-    lb(0)(0) = lb(1)(0)
+    lb(0)(0) = lb(1)(0)                               // error
     val x: Int = f(0)
   }
 }

--- a/tests/neg/i39.scala
+++ b/tests/neg/i39.scala
@@ -1,7 +1,7 @@
 object i39neg {
 
   trait B {
-    type D <: { type T }
+    type D <: { type T }           // error
     def d: D
   }
 
@@ -11,7 +11,7 @@ object i39neg {
   }
 
   val d: bc.D = bc.d
-  val pd: bc.D = bc.pd
+  val pd: bc.D = bc.pd             // error
 
   // infinite loop in Typer
   val asT: d.T = ???

--- a/tests/neg/i50-volatile.scala
+++ b/tests/neg/i50-volatile.scala
@@ -3,22 +3,22 @@ object Test {
     class Inner
   }
   type A <: Base {
-    type X = String
+    type X = String                                     // error
   }
   type B <: {
-    type X = Int
+    type X = Int                                        // error
   }
   lazy val o: A & B = ???
 
-  class Client extends o.Inner
+  class Client extends o.Inner                          // error // error
 
-  def xToString(x: o.X): String = x
+  def xToString(x: o.X): String = x                     // error
 
   def intToString(i: Int): String = xToString(i)
 }
 object Test2 {
 
-  import Test.o._
+  import Test.o._                                       // error
 
   def xToString(x: X): String = x
 

--- a/tests/neg/instantiateAbstract.scala
+++ b/tests/neg/instantiateAbstract.scala
@@ -24,7 +24,7 @@ object Test {
 
   new TT // error
 
-  new A // error
+  new A
 
 // the following are OK in Typer but would be caught later in RefChecks
 
@@ -36,3 +36,5 @@ object Test {
 
   object OO extends AA
 }
+
+// nopos-error: "A does not conform to its self type B; cannot be instantiated"

--- a/tests/neg/over.scala
+++ b/tests/neg/over.scala
@@ -4,14 +4,14 @@ trait T {
 
 class C extends T {
 
-  val x = 2
-  override val y = 2
+  val x = 2                // error
+  override val y = 2       // error
 
 }
 
 class D extends T {
 
-  def x(): String = ""
+  def x(): String = ""     // error
 
 }
 

--- a/tests/neg/overrides.scala
+++ b/tests/neg/overrides.scala
@@ -8,7 +8,7 @@
   }
   trait FooB extends FooA {
     type A <: Ax;
-    trait Ax extends super.Ax { def xxx : Int; }
+    trait Ax extends super.Ax { def xxx : Int; }      // error
     abstract class InnerB extends InnerA {
       // type B <: A;
       val a : A = doB;
@@ -31,7 +31,7 @@ package p2 { // all being in the same package compiles fine
   }
 
   abstract class T3 extends T2 {
-    class A {
+    class A {                                         // error
       bug()
     }
   }
@@ -45,7 +45,7 @@ class A[T] {
 
 class B extends A[Int] {
 
-  def f(x: Int)(y: Int) = y
+  def f(x: Int)(y: Int) = y                           // error
 
   f(2)()
 
@@ -55,7 +55,7 @@ class X {
   def f: A[Int] = ???
 }
 class Y extends X {
-  def f: A[Int] = ???
+  def f: A[Int] = ???                                 // error
 }
 
 
@@ -66,18 +66,18 @@ class X1 {
   def f(): A1 = ???
 }
 class Y1 extends X1 {
-  override def f(): B1 = ???
+  override def f(): B1 = ???                          // error
 }
 
 class X2 {
   type T = A1
 }
 class Y2 extends X2 {
-  type T = B1
+  type T = B1                                         // error
 }
 
 class X3 {
-  override type T = A1
+  override type T = A1                                // error
 }
 
 package p3 {
@@ -97,14 +97,14 @@ trait TOverrider { this: TCommon =>
   override def f = "in TOverrider"   // The overridden self-type member...
 }
 
-class C2 extends C1 with TOverrider  // ... fails to override, here.
+class C2 extends C1 with TOverrider  // ... fails to override, here. // error
 
 }
 
 package p4 {
 
   abstract class C[T] { def head: T }
-  case class D[T](head: Int) extends C[T]
+  case class D[T](head: Int) extends C[T]             // error
 
 }
 
@@ -114,10 +114,10 @@ class A {
 }
 
 class B extends A {
-  override val m: Int = 42
+  override val m: Int = 42                            // error
 }
 
 class C extends A {
-  override def m: Int = 42
+  override def m: Int = 42                            // error
 }
 }

--- a/tests/neg/privates.scala
+++ b/tests/neg/privates.scala
@@ -5,7 +5,7 @@ trait T {
 }
 
 class C { self: T =>
-  foo
-  bar
+  foo                                     // error
+  bar                                     // error
 }
 

--- a/tests/neg/subtyping.scala
+++ b/tests/neg/subtyping.scala
@@ -5,10 +5,10 @@ class A extends B
 
 object Test {
   def test1(): Unit = {
-    implicitly[B#X <:< A#X]
+    implicitly[B#X <:< A#X]                           // error
   }
   def test2(): Unit = {
-    val a : { type T; type U } = ???
-    implicitly[a.T <:< a.U]
+    val a : { type T; type U } = ???                  // error // error
+    implicitly[a.T <:< a.U]                           // error
   }
 }

--- a/tests/neg/t0273.scala
+++ b/tests/neg/t0273.scala
@@ -2,6 +2,6 @@ class A
 
 object Test {
 def a = () => ()
-def a[T] = (p:A) => ()
+def a[T] = (p:A) => ()              // error
 def main(args: Array[String]) = ()
 }

--- a/tests/neg/t1279a.scala
+++ b/tests/neg/t1279a.scala
@@ -4,12 +4,12 @@ abstract class M {
 
   type T
   final type selfType = M {type T <: self.T}
-  type actualSelfType >: self.type <: selfType // this no longer compiles because self.type is not a subtype of selfType
+  type actualSelfType >: self.type <: selfType // error: this no longer compiles because self.type is not a subtype of selfType
 
   def next: selfType
 
   // I don't understand why this doesn't compile, but that's a separate matter
-  // error: method all2 cannot be accessed in M.this.selfType
+  // Error: method all2 cannot be accessed in M.this.selfType
   // because its instance type => Stream[M{type T <: M.this.selfType#T}]
   // contains a malformed type: M.this.selfType#T
   def all2: Stream[M {type T <: self.T}] = Stream.cons(self: actualSelfType, next.all2)

--- a/tests/neg/t1569-failedAvoid.scala
+++ b/tests/neg/t1569-failedAvoid.scala
@@ -5,5 +5,5 @@
 object Bug {
   class C { type T }
   def foo(x: Int)(y: C)(z: y.T): Unit = {}
-  foo(3)(new C { type T = String })("hello")
+  foo(3)(new C { type T = String })("hello")          // error
 }

--- a/tests/neg/t1843-variances.scala
+++ b/tests/neg/t1843-variances.scala
@@ -6,7 +6,7 @@
 
 object Crash {
   trait UpdateType[A]
-  case class StateUpdate[+A](updateType : UpdateType[A], value : A)
+  case class StateUpdate[+A](updateType : UpdateType[A], value : A) // error
   case object IntegerUpdateType extends UpdateType[Integer]
 
   //However this method will cause a crash

--- a/tests/neg/t2660.scala
+++ b/tests/neg/t2660.scala
@@ -22,7 +22,7 @@ class A[T](x: T) {
 object T {
   def main(args: Array[String]): Unit = {
     implicit def g2h(g: G): H = new H
-    new A[Int](new H, 23)
+    new A[Int](new H, 23)                             // error
       // in the context here, either secondary constructor is applicable
       // to the other, due to the implicit in scope. So the call is ambiguous.
   }
@@ -40,7 +40,7 @@ object X {
 object T2 {
   def main(args: Array[String]): Unit = {
     implicit def g2h(g: G): H = new H
-    X.f(new H, 23)
+    X.f(new H, 23)                                    // error
   }
 }
 

--- a/tests/neg/t2994.scala
+++ b/tests/neg/t2994.scala
@@ -20,8 +20,8 @@ object Naturals {
 
   // crashes scala-2.8.0 beta1
   trait MUL[n <: NAT, m <: NAT] extends NAT {
-    trait curry[n[_[_], _], s[_]] { type f[z <: NAT] = n[s, z] } // can't do double param lists:
-      // error: `]' expected but `[` found.
+    trait curry[n[_[_], _], s[_]] { type f[z <: NAT] = n[s, z] } // can't do double param lists: // error // error
+      // Error: `]' expected but `[` found.
     type a[s[_ <: NAT] <: NAT, z <: NAT] = n#a[curry[m#a, s]#f, z]
   }
 

--- a/tests/neg/tailcall/t1672b.scala
+++ b/tests/neg/tailcall/t1672b.scala
@@ -1,6 +1,6 @@
 object Test1772B {
   @annotation.tailrec
-  def bar : Nothing = {
+  def bar : Nothing = {                               // error
     try {
       throw new RuntimeException
     } catch {
@@ -11,7 +11,7 @@ object Test1772B {
   }
 
   @annotation.tailrec
-  def baz : Nothing = {
+  def baz : Nothing = {                               // error
     try {
       throw new RuntimeException
     } catch {
@@ -22,7 +22,7 @@ object Test1772B {
   }
 
   @annotation.tailrec
-  def boz : Nothing = {
+  def boz : Nothing = {                               // error
     try {
       throw new RuntimeException
     } catch {
@@ -31,7 +31,7 @@ object Test1772B {
   }
 
   @annotation.tailrec
-  def bez : Nothing = {
+  def bez : Nothing = {                               // error
     try {
       bez
     } finally {
@@ -41,12 +41,12 @@ object Test1772B {
 
   // the `liftedTree` local method will prevent a tail call here.
   @annotation.tailrec
-  def bar(i : Int) : Int = {
+  def bar(i : Int) : Int = {                          // error
     if (i == 0) 0
     else 1 + (try {
       throw new RuntimeException
     } catch {
-      case _: Throwable => bar(i - 1)
+      case _: Throwable => bar(i - 1)                 // error
     })
   }
 }

--- a/tests/neg/tailcall/t3275.scala
+++ b/tests/neg/tailcall/t3275.scala
@@ -1,3 +1,3 @@
 object Test {
-  @annotation.tailrec def foo() = 5
+  @annotation.tailrec def foo() = 5                   // error
 }

--- a/tests/neg/tailcall/t6574.scala
+++ b/tests/neg/tailcall/t6574.scala
@@ -1,6 +1,6 @@
 class Bad[X, Y](val v: Int) extends AnyVal {
-  @annotation.tailrec final def notTailPos[Z](a: Int)(b: String): Unit = {
-    this.notTailPos[Z](a)(b)
+  @annotation.tailrec final def notTailPos[Z](a: Int)(b: String): Unit = {   // error
+    this.notTailPos[Z](a)(b)          // error
     println("tail")
   }
 

--- a/tests/neg/tailcall/tailrec-2.scala
+++ b/tests/neg/tailcall/tailrec-2.scala
@@ -13,7 +13,7 @@ class Bop2[+A](val element: A) extends Super[A] {
   @annotation.tailrec final def f[B >: A](mem: List[B]): List[B] = (null: Bop2[A]).f(mem)
 }
 object Bop3 extends Super[Nothing] {
-  @annotation.tailrec final def f[B](mem: List[B]): List[B] = (???: Bop3.type).f(mem)
+  @annotation.tailrec final def f[B](mem: List[B]): List[B] = (???: Bop3.type).f(mem) // error // error
 }
 class Bop4[+A](val element: A) extends Super[A] {
   @annotation.tailrec final def f[B >: A](mem: List[B]): List[B] = Other.f[A].f(mem)

--- a/tests/neg/tailcall/tailrec-3.scala
+++ b/tests/neg/tailcall/tailrec-3.scala
@@ -1,9 +1,9 @@
 import annotation.tailrec
 
 object Test {
-  @tailrec private def quux(xs: List[String]): List[String] = quux(quux(xs))
+  @tailrec private def quux(xs: List[String]): List[String] = quux(quux(xs)) // error
   @tailrec private def quux2(xs: List[String]): List[String] = xs match {
-    case x1 :: x2 :: rest => quux2(x1 :: quux2(rest))
+    case x1 :: x2 :: rest => quux2(x1 :: quux2(rest))                        // error
     case _                => Nil
   }
   @tailrec private def quux3(xs: List[String]): Boolean = xs match {

--- a/tests/neg/tailcall/tailrec.scala
+++ b/tests/neg/tailcall/tailrec.scala
@@ -40,19 +40,19 @@ class Winners {
 
 object Failures {
   @tailrec
-  def facfail(n: Int): Int =
+  def facfail(n: Int): Int =                          // error
     if (n == 0) 1
-    else n * facfail(n - 1)
+    else n * facfail(n - 1)                           // error
 }
 
 class Failures {
   // not private, not final
-  @tailrec def fail1(x: Int): Int = fail1(x)
+  @tailrec def fail1(x: Int): Int = fail1(x)          // error
 
   // a typical between-chair-and-keyboard error
-  @tailrec final def fail2[T](xs: List[T]): List[T] = xs match {
+  @tailrec final def fail2[T](xs: List[T]): List[T] = xs match {   // error
     case Nil      => Nil
-    case x :: xs  => x :: fail2[T](xs)
+    case x :: xs  => x :: fail2[T](xs)                // error
   }
 
   // unsafe
@@ -60,6 +60,6 @@ class Failures {
 
   // unsafe
   class Tom[T](x: Int) {
-    @tailrec final def fail4[U](other: Tom[U], x: Int): Int = other.fail4[U](other, x - 1)
+    @tailrec final def fail4[U](other: Tom[U], x: Int): Int = other.fail4[U](other, x - 1) // error // error
   }
 }

--- a/tests/neg/traitParamsTyper.scala
+++ b/tests/neg/traitParamsTyper.scala
@@ -6,7 +6,7 @@ class C(x: Int) extends T() // error
 
 trait U extends C with T
 
-trait V extends C(1) with T(2) // two errors
+trait V extends C(1) with T(2) // error // error
 
 trait W extends T(3) // error
 

--- a/tests/neg/typedIdents.scala
+++ b/tests/neg/typedIdents.scala
@@ -18,13 +18,13 @@ package P { // `X' bound by package clause
         println("L12: " + x) // `x' refers to constant `3' here
         locally {
           import Q.X._ // `x' and `y' bound by wildcard import
-          println("L14: " + x)   // reference to `x' is ambiguous here
+          println("L14: " + x)   // error: reference to `x' is ambiguous here
           import X.y // `y' bound by explicit import
           println("L16: " + y) // `y' refers to `Q.X.y' here
           locally {
             import P.X._ // `x' and `y' bound by wildcard import
             val x = "abc" // `x' bound by local definition
-            println("L19: " + y) // reference to `y' is ambiguous here
+            println("L19: " + y) // error: reference to `y' is ambiguous here
             println("L20: " + x) // `x' refers to string ``abc'' here
           }
         }

--- a/tests/neg/typedapply.scala
+++ b/tests/neg/typedapply.scala
@@ -2,16 +2,16 @@ object typedapply {
 
   def foo[X, Y](x: X, y: Y) = (x, y)
 
-  foo[Int](1, "abc")
+  foo[Int](1, "abc")                          // error
 
-  foo[Int, String, String](1, "abc")
+  foo[Int, String, String](1, "abc")          // error
 
   def bar(x: Int) = x
 
-  bar[Int](1)
+  bar[Int](1)                                 // error
 
   def baz[X >: Y, Y <: String](x: X, y: Y) = (x, y)
 
-  baz[Int, String](1, "abc")
+  baz[Int, String](1, "abc")                  // error
 
 }

--- a/tests/neg/typers.scala
+++ b/tests/neg/typers.scala
@@ -22,8 +22,8 @@ object typers {
     val z: Int
     def z(): String      // error: double def
 
-    def f(x: Any) = ()   // error: double def
-    def f(x: AnyRef): AnyRef
+    def f(x: Any) = ()
+    def f(x: AnyRef): AnyRef   // error: double def
 
     def g(x: Object): Unit
     def g[T](x: T): T = x  // error: double def
@@ -34,8 +34,8 @@ object typers {
 
   object returns {
 
-    def foo(x: Int) = {   // error: has return; needs result type
-      return 3
+    def foo(x: Int) = {
+      return 3          // error: has return; needs result type
     }
 
     return 4            // error: return outside method definition
@@ -46,8 +46,8 @@ object typers {
       if (n == 0) acc
       else factorial(acc * n, n - 1)    // error: cyclic reference
 
-    def foo(x: Int) = x                 // error: cyclic reference
-    def foo() = foo(1)
+    def foo(x: Int) = x
+    def foo() = foo(1)                  // error: cyclic reference
 
   }
 

--- a/tests/neg/typetest.scala
+++ b/tests/neg/typetest.scala
@@ -2,6 +2,6 @@ object Test {
 
   val i: Int = 1
 
-  println(i.isInstanceOf[Object])
+  println(i.isInstanceOf[Object])                     // error
 }
 

--- a/tests/neg/variances.scala
+++ b/tests/neg/variances.scala
@@ -5,7 +5,7 @@ class Foo[+A: ClassTag](x: A) {
 
   private[this] val elems: Array[A] = Array(x)
 
-  def f[B](x: Array[B] = elems): Array[B] = x // (1) should give a variance error here or ...
+  def f[B](x: Array[B] = elems): Array[B] = x // error (1) should give a variance error here or ...
 
 }
 
@@ -25,7 +25,7 @@ class Outer[+A](x: A) {
 
   def getElem: A = elem
 
-  class Inner(constrParam: A) {  // (2) should give a variance error here or ...
+  class Inner(constrParam: A) {  // error (2) should give a variance error here or ...
     elem = constrParam
   }
 

--- a/tests/neg/zoo.scala
+++ b/tests/neg/zoo.scala
@@ -1,25 +1,25 @@
 object Test {
 type Meat = {
-  type IsMeat = Any
+  type IsMeat = Any            // error
 }
 type Grass = {
-  type IsGrass = Any
+  type IsGrass = Any           // error
 }
 type Animal = {
-  type Food
-  def eats(food: Food): Unit
-  def gets: Food
+  type Food                    // error
+  def eats(food: Food): Unit   // error
+  def gets: Food               // error
 }
 type Cow = {
-  type IsMeat = Any
-  type Food <: Grass
-  def eats(food: Grass): Unit
-  def gets: Grass
+  type IsMeat = Any            // error
+  type Food <: Grass           // error
+  def eats(food: Grass): Unit  // error
+  def gets: Grass              // error
 }
 type Lion = {
-  type Food = Meat
-  def eats(food: Meat): Unit
-  def gets: Meat
+  type Food = Meat             // error
+  def eats(food: Meat): Unit   // error
+  def gets: Meat               // error
 }
 def newMeat: Meat = new {
   type IsMeat = Any

--- a/tests/pos/autoTuplingTest.scala
+++ b/tests/pos/autoTuplingTest.scala
@@ -1,9 +1,9 @@
 object autoTupling {
 
-  val x = Some(1, 2)
+  val x = Some(1, 2)                                  // error when running with -language:noAutoTupling
 
   x match {
-    case Some(a, b) => a + b
+    case Some(a, b) => a + b                          // error // error // error when running with -language:noAutoTupling
     case None =>
   }
 }


### PR DESCRIPTION
Neg tests run by JUnit now check that for each compiler error, there's a // error marker on the corresponding line in the source file. For errors that don't have a source position, add // nopos-error to any of the files (for an example of this, see [instantiateAbstract](https://github.com/vsalvis/dotty/blob/6d311edadc076e6a9d2860d5571c2ff261445164/tests/neg/instantiateAbstract.scala)).

Also FYI I had one case where not all errors get displayed by the compiler, maybe if there are more than two errors for a given line? In this file there are three errors displayed, but four errors total, and the test gets all four:
```
[info] Test dotc.tests.neg_autoTupling started
./tests/pos/autoTuplingTest.scala:3: error: too many arguments for method apply: (x: (A? >: Int(1)))Some[(A? >: Int(1))]
  val x = Some(1, 2)                                  // error when running with -language:noAutoTupling
                  ^
./tests/pos/autoTuplingTest.scala:6: error: wrong number of argument patterns for Some; expected: (Nothing)
    case Some(a, b) => a + b                          // error // error when running with -language:noAutoTupling
             ^
./tests/pos/autoTuplingTest.scala:6: error: not found: b
    case Some(a, b) => a + b                          // error // error when running with -language:noAutoTupling
                           ^
four errors found

=== found: List(./tests/pos/autoTuplingTest.scala:3)
=== found: List(./tests/pos/autoTuplingTest.scala:6, ./tests/pos/autoTuplingTest.scala:6, ./tests/pos/autoTuplingTest.scala:6)
=== all errors:
class dotty.tools.dotc.reporting.Reporter$Error at ./tests/pos/autoTuplingTest.scala:6: type mismatch:
 found   : Nothing(a)
 required: ?{ + : ? }
Note that implicit conversions cannot be applied because they are ambiguous;
 both method Double2double in object Predef$ and method unaugmentString in object Predef$ convert from Nothing(a) to ?{ + : FunProto(b):? }
class dotty.tools.dotc.reporting.Reporter$Error at ./tests/pos/autoTuplingTest.scala:6: not found: b
class dotty.tools.dotc.reporting.Reporter$Error at ./tests/pos/autoTuplingTest.scala:6: wrong number of argument patterns for Some; expected: (Nothing)
class dotty.tools.dotc.reporting.Reporter$Error at ./tests/pos/autoTuplingTest.scala:3: too many arguments for method apply: (x: (A? >: Int(1)))Some[(A? >: Int(1))]
```

Do we plan on running neg tests on partest? In that case I have to add the functionality there as well, for now it's just the JUnit tests, while partest only checks the xerrors as before.