### PR TITLE
Don't add lower bounds of abstract types to the implicit scope

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -3118,6 +3118,8 @@ object Types {
             apply(foldOver(maybeAdd(x, tp), tp), tp.underlying)
           case tp: TypeRef =>
             foldOver(maybeAdd(x, tp), tp)
+          case TypeBounds(_, hi) =>
+            apply(x, hi)
           case tp: ThisType =>
             apply(x, tp.underlying)
           case tp: ConstantType =>

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -144,6 +144,7 @@ class tests extends CompilerTest {
   @Test def neg_traitParamsTyper = compileFile(negDir, "traitParamsTyper", xerrors = 5)
   @Test def neg_traitParamsMixin = compileFile(negDir, "traitParamsMixin", xerrors = 2)
   @Test def neg_firstError = compileFile(negDir, "firstError", xerrors = 3)
+  @Test def neg_implicitLowerBound = compileFile(negDir, "implicit-lower-bound", xerrors = 1)
 
   @Test def run_all = runFiles(runDir)
 

--- a/tests/neg/implicit-lower-bound.scala
+++ b/tests/neg/implicit-lower-bound.scala
@@ -1,0 +1,14 @@
+class Foo
+
+class Bar extends Foo
+object Bar {
+  implicit val listbar: List[Bar] = ???
+}
+
+class Test {
+  def get1(implicit lf: List[_ <: Bar]) = {}
+  def get2(implicit lf: List[_ >: Bar]) = {}
+
+  get1 // works
+  get2 // error
+}


### PR DESCRIPTION
As the [spec](http://www.scala-lang.org/files/archive/spec/2.11/07-implicits.html#implicit-parameters) says:
>The parts of a type T are [...] if T is an abstract type, the parts of
its upper bound

Review by @odersky .