### PR TITLE
SyntheticMethods: override productPrefix for case classes

### DIFF
--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -324,6 +324,7 @@ class Definitions {
   lazy val ProductClass                 = ctx.requiredClass("scala.Product")
     lazy val Product_canEqual = ProductClass.requiredMethod(nme.canEqual_)
     lazy val Product_productArity = ProductClass.requiredMethod(nme.productArity)
+    lazy val Product_productPrefix = ProductClass.requiredMethod(nme.productPrefix)
   lazy val LanguageModuleClass          = ctx.requiredModule("dotty.language").moduleClass.asClass
 
   // Annotation base classes

--- a/src/dotty/tools/dotc/transform/SyntheticMethods.scala
+++ b/src/dotty/tools/dotc/transform/SyntheticMethods.scala
@@ -22,6 +22,8 @@ import scala.language.postfixOps
  *    def hashCode(): Int
  *    def canEqual(other: Any): Boolean
  *    def toString(): String
+ *    def productArity: Int
+ *    def productPrefix: String
  *  Special handling:
  *    protected def readResolve(): AnyRef
  *
@@ -40,7 +42,8 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
   private def initSymbols(implicit ctx: Context) =
     if (myValueSymbols.isEmpty) {
       myValueSymbols = List(defn.Any_hashCode, defn.Any_equals)
-      myCaseSymbols = myValueSymbols ++ List(defn.Any_toString, defn.Product_canEqual, defn.Product_productArity)
+      myCaseSymbols = myValueSymbols ++ List(defn.Any_toString, defn.Product_canEqual,
+        defn.Product_productArity, defn.Product_productPrefix)
     }
 
   def valueSymbols(implicit ctx: Context) = { initSymbols; myValueSymbols }
@@ -83,6 +86,7 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
         case nme.equals_ => vrefss => equalsBody(vrefss.head.head)
         case nme.canEqual_ => vrefss => canEqualBody(vrefss.head.head)
         case nme.productArity => vrefss => Literal(Constant(accessors.length))
+        case nme.productPrefix => vrefss => Literal(Constant(clazz.name.decode.toString))
       }
       ctx.log(s"adding $synthetic to $clazz at ${ctx.phase}")
       DefDef(synthetic, syntheticRHS(ctx.withOwner(synthetic)))

--- a/tests/run/case-class-toString.check
+++ b/tests/run/case-class-toString.check
@@ -1,0 +1,4 @@
+Zero2()
+One(1)
+Two(1,2)
+Encoded!Name(3)

--- a/tests/run/case-class-toString.scala
+++ b/tests/run/case-class-toString.scala
@@ -1,0 +1,17 @@
+case object Zero
+case class Zero2()
+case class One(x: Int)
+case class Two(x: Int, y: Int)
+case class `Encoded!Name`(x: Int)
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    // FIXME: case objects are not handled like Scala 2 currently, see #723
+    //println(Zero)
+
+    println(Zero2())
+    println(One(1))
+    println(Two(1, 2))
+    println(`Encoded!Name`(3))
+  }
+}


### PR DESCRIPTION
The productPrefix of a case class should be the name of the class itself
to match Scala 2.

Review by @DarkDimius, hopefully this should fix various pending tests which print case classes.