### PR TITLE
tpd#New: Make constructor TermRefs non-ambiguous

### DIFF
--- a/src/dotty/tools/dotc/ast/tpd.scala
+++ b/src/dotty/tools/dotc/ast/tpd.scala
@@ -383,8 +383,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   /** new C(args), calling given constructor `constr` of C */
   def New(tp: Type, constr: TermSymbol, args: List[Tree])(implicit ctx: Context): Apply = {
     val targs = tp.argTypes
-    New(tp withoutArgs targs)
-      .select(TermRef.withSig(tp.normalizedPrefix, constr))
+    val tycon = tp.withoutArgs(targs)
+    New(tycon)
+      .select(TermRef.withSig(tycon, constr))
       .appliedToTypes(targs)
       .appliedToArgs(args)
   }
@@ -818,15 +819,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     val alternatives = ctx.typer.resolveOverloaded(alts, proto, Nil)
     assert(alternatives.size == 1) // this is parsed from bytecode tree. there's nothing user can do about it
 
-    val prefixTpe =
-      if (method eq nme.CONSTRUCTOR)
-        receiver.tpe.normalizedPrefix // <init> methods are part of the enclosing scope
-      else
-        receiver.tpe
-
     val selected = alternatives.head
     val fun = receiver
-      .select(TermRef.withSig(prefixTpe, selected.termSymbol.asTerm))
+      .select(TermRef.withSig(receiver.tpe, selected.termSymbol.asTerm))
       .appliedToTypes(targs)
 
     def adaptLastArg(lastParam: Tree, expectedType: Type) = {


### PR DESCRIPTION
Before this change, the prefix of a constructor TermRef was the prefix
of the class, this means that it was possible for two constructors to
have the same prefix, the same name (`<init>`) and the same signature.
This could cause double binding errors.

Review by @odersky 