### PR TITLE
Typer#escapingRefs: don't let the types of lower bounds escape

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -257,9 +257,14 @@ object Types {
 
     /** The parts of this type which are type or term refs and which
      *  satisfy predicate `p`.
+     *
+     *  @param p                   The predicate to satisfy
+     *  @param excludeLowerBounds  If set to true, the lower bounds of abstract
+     *                             types will be ignored.
      */
-    def namedPartsWith(p: NamedType => Boolean)(implicit ctx: Context): collection.Set[NamedType] =
-      new NamedPartsAccumulator(p).apply(mutable.LinkedHashSet(), this)
+    def namedPartsWith(p: NamedType => Boolean, excludeLowerBounds: Boolean = false)
+      (implicit ctx: Context): collection.Set[NamedType] =
+      new NamedPartsAccumulator(p, excludeLowerBounds).apply(mutable.LinkedHashSet(), this)
 
     /** Map function `f` over elements of an AndType, rebuilding with function `g` */
     def mapReduceAnd[T](f: Type => T)(g: (T, T) => T)(implicit ctx: Context): T = stripTypeVar match {
@@ -3331,7 +3336,8 @@ object Types {
     def apply(x: Boolean, tp: Type) = x || tp.isUnsafeNonvariant || foldOver(x, tp)
   }
 
-  class NamedPartsAccumulator(p: NamedType => Boolean)(implicit ctx: Context) extends TypeAccumulator[mutable.Set[NamedType]] {
+  class NamedPartsAccumulator(p: NamedType => Boolean, excludeLowerBounds: Boolean = false)
+    (implicit ctx: Context) extends TypeAccumulator[mutable.Set[NamedType]] {
     override def stopAtStatic = false
     def maybeAdd(x: mutable.Set[NamedType], tp: NamedType) = if (p(tp)) x += tp else x
     val seen: mutable.Set[Type] = mutable.Set()
@@ -3344,7 +3350,8 @@ object Types {
             apply(foldOver(maybeAdd(x, tp), tp), tp.underlying)
           case tp: TypeRef =>
             foldOver(maybeAdd(x, tp), tp)
-          case TypeBounds(_, hi) =>
+          case TypeBounds(lo, hi) =>
+            if (!excludeLowerBounds) apply(x, lo)
             apply(x, hi)
           case tp: ThisType =>
             apply(x, tp.underlying)

--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -329,7 +329,9 @@ trait ImplicitRunInfo { self: RunInfo =>
             }
             tp.classSymbols(liftingCtx) foreach addClassScope
           case _ =>
-            for (part <- tp.namedPartsWith(_.isType))
+            // We exclude lower bounds to conform to SLS 7.2:
+            // "The parts of a type T are: [...] if T is an abstract type, the parts of its upper bound"
+            for (part <- tp.namedPartsWith(_.isType, excludeLowerBounds = true))
               comps ++= iscopeRefs(part)
         }
         comps

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -515,16 +515,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   def escapingRefs(block: Tree, localSyms: => List[Symbol])(implicit ctx: Context): collection.Set[NamedType] = {
-    var hoisted: Set[Symbol] = Set()
     lazy val locals = localSyms.toSet
-    def leakingTypes(tp: Type): collection.Set[NamedType] =
-      tp namedPartsWith (tp => locals.contains(tp.symbol))
-    def typeLeaks(tp: Type): Boolean = leakingTypes(tp).nonEmpty
-    def classLeaks(sym: ClassSymbol): Boolean =
-      (ctx.owner is Method) || // can't hoist classes out of method bodies
-      (sym.info.parents exists typeLeaks) ||
-      (sym.info.decls.toList exists (t => typeLeaks(t.info)))
-    leakingTypes(block.tpe)
+    block.tpe namedPartsWith (tp => locals.contains(tp.symbol))
   }
 
   /** Check that expression's type can be expressed without references to locally defined


### PR DESCRIPTION
In 0efa171e8ccca0d49fc6d800fd21e29f7b7336fd I changed the definition of `NamedPartsAccumulator` to exclude lower bounds as this is required for the implicit search, but `NamedPartsAccumulator` is also used by `Typer#escapingRefs` so in the following code:
```scala
class Foo[T]
val z = {
  class C

  ??? : Foo[_ >: C]
}
```
the type of `z` was inferred to be `Foo[_ >: C]` instead of `Foo`.

To avoid this, `NamedPartsAccumulator` will only exclude lower bounds if the parameter `excludeLowerBounds` is explicitely set to `true`.

No test because there is no way to detect that a type has escaped, this might be something that could be added to `TreeChecker`.

<hr>

This PR also removes dead code from `Typer#escapingRefs`.

<hr>

Review by @odersky .