### PR TITLE
NamedPartsAccumulator: also include bounds of uninstantiated type variables

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -3135,6 +3135,18 @@ object Types {
             apply(x, tp.underlying)
           case tp: PolyParam =>
             apply(x, tp.underlying)
+          case tp: TypeVar =>
+            val inst = tp.instanceOpt
+            if (inst.exists) apply(x, inst)
+            else {
+              ctx.typerState.ephemeral = true
+              val bounds =
+                if (ctx.typerState.constraint.contains(tp))
+                  ctx.typerState.constraint.fullBounds(tp.origin)
+                else
+                  tp.origin
+              apply(x, bounds)
+            }
           case _ =>
             foldOver(x, tp)
         }

--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -325,7 +325,7 @@ trait ImplicitRunInfo { self: RunInfo =>
             }
             tp.classSymbols(liftingCtx) foreach addClassScope
           case _ =>
-            for (part <- tp.namedPartsWith(_.isType))
+            for (part <- tp.namedPartsWith(_.isType, excludeLowerBounds = true))
               comps ++= iscopeRefs(part)
         }
         comps

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -450,16 +450,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   def escapingRefs(block: Tree, localSyms: => List[Symbol])(implicit ctx: Context): collection.Set[NamedType] = {
-    var hoisted: Set[Symbol] = Set()
     lazy val locals = localSyms.toSet
-    def leakingTypes(tp: Type): collection.Set[NamedType] =
-      tp namedPartsWith (tp => locals.contains(tp.symbol))
-    def typeLeaks(tp: Type): Boolean = leakingTypes(tp).nonEmpty
-    def classLeaks(sym: ClassSymbol): Boolean =
-      (ctx.owner is Method) || // can't hoist classes out of method bodies
-      (sym.info.parents exists typeLeaks) ||
-      (sym.info.decls.toList exists (t => typeLeaks(t.info)))
-    leakingTypes(block.tpe)
+    block.tpe namedPartsWith (tp => locals.contains(tp.symbol))
   }
 
   /** Check that expression's type can be expressed without references to locally defined


### PR DESCRIPTION
This PR depends on https://github.com/lampepfl/dotty/pull/749

<hr>

In the following code:

``` scala
class Foo[T](x: T)
val z = {
  class X
  new Foo(new X)
}
```

When we call `Typer#ensureNoLocalRefs` on the block, its type is:

``` scala
Foo[T] where T <: X
```

Before this commit, `Typer#escapingRefs` returned the empty set for this
type since `T` is not instantiated yet, so the type was kept as is, and `X` escaped:

``` scala
val z: Foo[X] = {
  class X
  new Foo(new X)
}
```

We avoid this by inspecting the bounds of uninstantiated type variables
in `NamedPartsAccumulator` which is used by `Typer#escapingRefs`.

<hr>

@odersky : Please review. I'm not sure if this is the proper way to fix this, maybe the instantiation of type parameters could try to avoid types which are not in scope?
