### PR TITLE
Workaround interaction between LiftTry and CapturedVars

### DIFF
--- a/src/dotty/tools/dotc/transform/LiftTry.scala
+++ b/src/dotty/tools/dotc/transform/LiftTry.scala
@@ -42,8 +42,9 @@ class LiftTry extends MiniPhase with IdentityDenotTransformer { thisTransform =>
       else liftingTransform
 
     override def prepareForAssign(tree: Assign)(implicit ctx: Context) =
-      if (tree.lhs.symbol.maybeOwner == ctx.owner.enclosingMethod) this
-      else liftingTransform
+      /* this is inefficient in many cases,
+         but after CapturedVars is completed this assign could become one with non-empty stack */
+     liftingTransform
 
     override def prepareForReturn(tree: Return)(implicit ctx: Context) =
       if (!isNonLocalReturn(tree)) this

--- a/tests/run/LiftTryAssign.scala
+++ b/tests/run/LiftTryAssign.scala
@@ -1,0 +1,9 @@
+object Test {
+  def fun(a: Int => Unit) = a(2)
+  def foo: Int = {
+    var s = 1
+    s = try {fun(s = _); 3} catch{ case ex: Throwable => s = 4; 5 }
+    s
+  }
+  def main(args: Array[String]): Unit = foo
+}


### PR DESCRIPTION
This workaround is inefficient, but allows test to pass. 
The only complete way that I can think of currently is to run LiftTry and CapturedVars until they reach a fix point, to make sure that CapturedVars lifts everything that LiftTry lifted to a method and that LiftTry will account for all assigns that work on captured variables, as they are performed on non-empty stack.

@odersky please review.