### PR TITLE
GetClass: get classSymbol reliably

### DIFF
--- a/src/dotty/tools/dotc/transform/GetClass.scala
+++ b/src/dotty/tools/dotc/transform/GetClass.scala
@@ -28,7 +28,7 @@ class GetClass extends MiniPhaseTransform {
     tree match {
       case Apply(Select(qual, nme.getClass_), Nil) =>
         val defn = ctx.definitions
-        val claz = qual.tpe.classSymbol
+        val claz = qual.tpe.widen.classSymbol
 
         def TYPE(module: TermSymbol) = ref(module).select(nme.TYPE_).ensureConforms(tree.tpe)
         claz match {

--- a/tests/run/getclass.scala
+++ b/tests/run/getclass.scala
@@ -8,6 +8,7 @@ object Test {
     val iCls: Class[Int] = 1.getClass
     val f1: Function2[Int, Int, Unit] = (a: Int, b: Int) => println(a + b)
     val f2: Function1[Int, Boolean] = (a: Int) => a % 2 == 0
+    val one = 1
 
     println("Value types:")
     println(().getClass)
@@ -15,7 +16,7 @@ object Test {
     println(1.asInstanceOf[Byte].getClass)
     println(1.asInstanceOf[Short].getClass)
     println('a'.getClass)
-    println(1.getClass)
+    println(one.getClass)
     println(1L.getClass)
     println(1f.getClass)
     println(1d.getClass)


### PR DESCRIPTION
TermRefs do not have a classSymbol.

@AlexSikia thanks for reporting