### PR TITLE
Fixes to scala2 Mixin

### DIFF
--- a/src/dotty/tools/dotc/core/Flags.scala
+++ b/src/dotty/tools/dotc/core/Flags.scala
@@ -598,6 +598,7 @@ object Flags {
   final val SyntheticTypeParam = allOf(Synthetic, TypeParam)
   final val SyntheticCase = allOf(Synthetic, Case)
   final val AbstractAndOverride = allOf(Abstract, Override)
+  final val Scala2Trait = allOf(Scala2x, Trait)
 
   implicit def conjToFlagSet(conj: FlagConjunction): FlagSet =
     FlagSet(conj.bits)

--- a/src/dotty/tools/dotc/core/Phases.scala
+++ b/src/dotty/tools/dotc/core/Phases.scala
@@ -231,6 +231,8 @@ object Phases {
     }
 
     private val typerCache = new PhaseCache(classOf[FrontEnd])
+    private val picklerCache = new PhaseCache(classOf[Pickler])
+
     private val refChecksCache = new PhaseCache(classOf[RefChecks])
     private val extensionMethodsCache = new PhaseCache(classOf[ExtensionMethods])
     private val erasureCache = new PhaseCache(classOf[Erasure])
@@ -242,6 +244,7 @@ object Phases {
     private val genBCodeCache = new PhaseCache(classOf[GenBCode])
 
     def typerPhase = typerCache.phase
+    def picklerPhase = picklerCache.phase
     def refchecksPhase = refChecksCache.phase
     def extensionMethodsPhase = extensionMethodsCache.phase
     def erasurePhase = erasureCache.phase

--- a/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
+++ b/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
@@ -24,7 +24,7 @@ import ast.Trees._
  *   - an implementation class which defines a trait constructor and trait method implementations
  *   - trait setters for vals defined in traits
  *
- *  Furthermore, it expands the names of all private getters and setters in the trait and makes
+ *  Furthermore, it expands the names of all private getters and setters as well as super accessors in the trait and makes
  *  them not-private.
  */
 class AugmentScala2Traits extends MiniPhaseTransform with IdentityDenotTransformer with FullParameterization { thisTransform =>
@@ -89,8 +89,9 @@ class AugmentScala2Traits extends MiniPhaseTransform with IdentityDenotTransform
           else if (!sym.is(Deferred) && !sym.setter.exists &&
                    !sym.info.resultType.isInstanceOf[ConstantType])
             traitSetter(sym.asTerm).enteredAfter(thisTransform)
-        if (sym.is(PrivateAccessor, butNot = ExpandedName) &&
+        if ((sym.is(PrivateAccessor, butNot = ExpandedName) &&
           (sym.isGetter || sym.isSetter)) // strangely, Scala 2 fields are also methods that have Accessor set.
+          || sym.is(SuperAccessor)) // scala2 superaccessors are pickled as private, but are compiler as public expanded
           sym.ensureNotPrivate.installAfter(thisTransform)
       }
       ctx.log(i"Scala2x trait decls of $mixin = ${mixin.info.decls.toList.map(_.showDcl)}%\n %")

--- a/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
+++ b/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
@@ -91,7 +91,7 @@ class AugmentScala2Traits extends MiniPhaseTransform with IdentityDenotTransform
             traitSetter(sym.asTerm).enteredAfter(thisTransform)
         if ((sym.is(PrivateAccessor, butNot = ExpandedName) &&
           (sym.isGetter || sym.isSetter)) // strangely, Scala 2 fields are also methods that have Accessor set.
-          || sym.is(SuperAccessor)) // scala2 superaccessors are pickled as private, but are compiler as public expanded
+          || sym.is(SuperAccessor)) // scala2 superaccessors are pickled as private, but are compiled as public expanded
           sym.ensureNotPrivate.installAfter(thisTransform)
       }
       ctx.log(i"Scala2x trait decls of $mixin = ${mixin.info.decls.toList.map(_.showDcl)}%\n %")

--- a/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
+++ b/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
@@ -79,7 +79,7 @@ class AugmentScala2Traits extends MiniPhaseTransform with IdentityDenotTransform
           info = MethodType(getter.info.resultType :: Nil, defn.UnitType))
 
       for (sym <- mixin.info.decls) {
-        if (needsForwarder(sym) || sym.isConstructor || sym.isGetter && sym.is(Lazy))
+        if (needsForwarder(sym) || sym.isConstructor || sym.isGetter && sym.is(Lazy) || sym.is(Method, butNot = Deferred))
           implClass.enter(implMethod(sym.asTerm))
         if (sym.isGetter)
           if (sym.is(Lazy)) {

--- a/src/dotty/tools/dotc/transform/ResolveSuper.scala
+++ b/src/dotty/tools/dotc/transform/ResolveSuper.scala
@@ -59,7 +59,7 @@ class ResolveSuper extends MiniPhaseTransform with IdentityDenotTransformer { th
   private def rebindSuper(base: Symbol, acc: Symbol)(implicit ctx: Context): Symbol = {
     var bcs = base.info.baseClasses.dropWhile(acc.owner != _).tail
     var sym: Symbol = NoSymbol
-    val SuperAccessorName(memberName) = acc.name: Name // dotty deviation: ": Name" needed otherwise pattern type is neither a subtype nor a supertype of selector type
+    val SuperAccessorName(memberName) = ctx.atPhase(ctx.picklerPhase){ implicit ctx => acc.name }: Name // dotty deviation: ": Name" needed otherwise pattern type is neither a subtype nor a supertype of selector type
     ctx.debuglog(i"starting rebindsuper from $base of ${acc.showLocated}: ${acc.info} in $bcs, name = $memberName")
     while (bcs.nonEmpty && sym == NoSymbol) {
       val other = bcs.head.info.nonPrivateDecl(memberName)

--- a/tests/run/scala2mixins.scala
+++ b/tests/run/scala2mixins.scala
@@ -1,0 +1,23 @@
+import scala.collection.IndexedSeqOptimized
+import scala.collection.mutable.Builder
+
+object Test {
+  class Name extends Seq[Int]
+    with IndexedSeqOptimized[Int, Name] {
+    val underlying = 0 to 10
+    def length: Int = underlying.length
+
+    def apply(idx: Int): Int = underlying(idx)
+
+    override protected[this] def newBuilder: Builder[Int, Name] = ???
+
+    override def seq = toCollection(this)
+
+  }
+  def main(args: Array[String]): Unit = {
+    val n = new Name
+    // need to make sure that super accessors were emitted
+    // ends with calls super.endsWith if argument is not an IndexedSeq
+    assert(n.endsWith(10 :: Nil))
+  }
+}


### PR DESCRIPTION
Those fixes allow to compile files inheriting from non-trivial Scala2 traits. Needed to compile [Names.scala](https://github.com/lampepfl/dotty/blob/master/src/dotty/tools/dotc/core/Names.scala#L38-L41)