### PR TITLE
Constructors: fields should be set before super constructor is invoked.

### DIFF
--- a/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/src/dotty/tools/dotc/transform/Constructors.scala
@@ -245,7 +245,7 @@ class Constructors extends MiniPhaseTransform with SymTransformer { thisTransfor
 
     cpy.Template(tree)(
       constr = cpy.DefDef(constr)(
-        rhs = Block(mappedSuperCalls ::: copyParams ::: followConstrStats, unitLiteral)),
+        rhs = Block(copyParams ::: mappedSuperCalls ::: followConstrStats, unitLiteral)),
       body = clsStats.toList)
   }
 }

--- a/tests/run/i763.scala
+++ b/tests/run/i763.scala
@@ -1,0 +1,12 @@
+abstract class A {
+  val s: Int
+  assert(s == 1)
+}
+
+class B(val s: Int) extends A
+
+object Test extends B(1) {
+  def main(args: Array[String]): Unit = {
+    s
+  }
+}


### PR DESCRIPTION
Fields used to be assigned only after super constructor was called. 
They should be assigned before.

@odersky please review. Blocks bootstrap.