### PR TITLE
Mixin: class defined abstract members take precedence over interface defined.

### DIFF
--- a/src/dotty/tools/dotc/transform/MixinOps.scala
+++ b/src/dotty/tools/dotc/transform/MixinOps.scala
@@ -38,10 +38,12 @@ class MixinOps(cls: ClassSymbol, thisTransform: DenotTransformer)(implicit ctx: 
   def isCurrent(sym: Symbol) = cls.info.member(sym.name).hasAltWith(_.symbol == sym)
 
   def needsForwarder(meth: Symbol): Boolean = {
-    def needsDisambiguation = !meth.allOverriddenSymbols.forall(_ is Deferred)
+    lazy val overridenSymbols = meth.allOverriddenSymbols
+    def needsDisambiguation = !overridenSymbols.forall(_ is Deferred)
+    def hasNonInterfaceDefinition = overridenSymbols.forall(!_.owner.is(Trait))
     meth.is(Method, butNot = PrivateOrAccessorOrDeferred) &&
     isCurrent(meth) &&
-    (needsDisambiguation || meth.owner.is(Scala2x))
+    (needsDisambiguation || hasNonInterfaceDefinition || meth.owner.is(Scala2x))
   }
 
   final val PrivateOrAccessorOrDeferred = Private | Accessor | Deferred

--- a/tests/run/i764.scala
+++ b/tests/run/i764.scala
@@ -1,0 +1,14 @@
+abstract class A {
+ def foo: Int
+}
+
+trait B {
+ def foo = 2
+}
+
+object Test extends A with B {
+  
+  def main(args: Array[String]): Unit = {
+    this.foo
+  }
+}


### PR DESCRIPTION
http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-5.html#jvms-5.4.3.3
If there is a class that defines method, it will take precedence over all interface definitions. 
Even if class defined method is abstract but interface defined is not.

@odersky please review. Blocks bootstrap.