### PR TITLE
Surivive Cyclic References when unpickling Scala 2 HK types

### DIFF
--- a/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -12,6 +12,7 @@ import scala.collection.{ mutable, immutable }
 import scala.collection.mutable.{ ListBuffer, ArrayBuffer }
 import scala.annotation.switch
 import typer.Checking.checkNonCyclic
+import typer.Mode
 import io.AbstractFile
 import scala.util.control.NonFatal
 
@@ -673,7 +674,7 @@ class ClassfileParser(
 
       def unpickleScala(bytes: Array[Byte]): Some[Embedded] = {
         val unpickler = new unpickleScala2.Scala2Unpickler(bytes, classRoot, moduleRoot)(ctx)
-        unpickler.run()
+        unpickler.run()(ctx.addMode(Mode.Scala2Unpickling))
         Some(unpickler)
       }
 

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -17,6 +17,7 @@ import printing.Printer
 import io.AbstractFile
 import util.common._
 import typer.Checking.checkNonCyclic
+import typer.Mode
 import PickleBuffer._
 import scala.reflect.internal.pickling.PickleFormat._
 import Decorators._
@@ -520,7 +521,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
   class LocalUnpickler extends LazyType {
     def startCoord(denot: SymDenotation): Coord = denot.symbol.coord
     def complete(denot: SymDenotation)(implicit ctx: Context): Unit = try {
-      def parseToCompletion(denot: SymDenotation) = {
+      def parseToCompletion(denot: SymDenotation)(implicit ctx: Context) = {
         val tag = readByte()
         val end = readNat() + readIndex
         def atEnd = readIndex == end
@@ -566,7 +567,8 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         }
         // println(s"unpickled ${denot.debugString}, info = ${denot.info}") !!! DEBUG
       }
-      atReadPos(startCoord(denot).toIndex, () => parseToCompletion(denot))
+      atReadPos(startCoord(denot).toIndex,
+          () => parseToCompletion(denot)(ctx.addMode(Mode.Scala2Unpickling)))
     } catch {
       case ex: RuntimeException => handleRuntimeException(ex)
     }

--- a/src/dotty/tools/dotc/typer/Mode.scala
+++ b/src/dotty/tools/dotc/typer/Mode.scala
@@ -79,5 +79,8 @@ object Mode {
    */
   val ImplicitExploration = newMode(12, "ImplicitExploration")
 
+  /** We are currently unpickling Scala2 info */
+  val Scala2Unpickling = newMode(13, "Scala2Unpickling")
+
   val PatternOrType = Pattern | Type
 }


### PR DESCRIPTION
Closes #778. It seems impossible (or very hard) to avoid Cyclic References
when unpickling Scala2 files. So we try to survive them instead.

Review by @DarkDimius