### PR TITLE
Fix param forwarding

### DIFF
--- a/src/dotty/tools/dotc/ast/tpd.scala
+++ b/src/dotty/tools/dotc/ast/tpd.scala
@@ -828,7 +828,10 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     val alts = receiver.tpe.member(method).alternatives.map(_.termRef)
 
     val alternatives = ctx.typer.resolveOverloaded(alts, proto, Nil)
-    assert(alternatives.size == 1) // this is parsed from bytecode tree. there's nothing user can do about it
+    assert(alternatives.size == 1,
+      i"multiple overloads available for $method on ${receiver.tpe.widenDealias} with targs: $targs, args: $args and expectedType: $expectedType." +
+        i" isAnnotConstructor = $isAnnotConstructor.\n" +
+        i"alternatives: $alternatives") // this is parsed from bytecode tree. there's nothing user can do about it
 
     val selected = alternatives.head
     val fun = receiver

--- a/src/dotty/tools/dotc/transform/ExpandPrivate.scala
+++ b/src/dotty/tools/dotc/transform/ExpandPrivate.scala
@@ -23,6 +23,9 @@ import TreeTransforms._
  *  public or protected parameter accessor with the same name as the forwarder.
  *  This is necessary since private methods are not allowed to have the same name
  *  as inherited public ones.
+ *
+ *  See discussion in https://github.com/lampepfl/dotty/pull/784
+ *  and https://github.com/lampepfl/dotty/issues/783
  */
 class ExpandPrivate extends MiniPhaseTransform with IdentityDenotTransformer { thisTransform =>
   import ast.tpd._

--- a/src/dotty/tools/dotc/transform/ExpandPrivate.scala
+++ b/src/dotty/tools/dotc/transform/ExpandPrivate.scala
@@ -41,7 +41,7 @@ class ExpandPrivate extends MiniPhaseTransform with IdentityDenotTransformer { t
           // public > protected > /* default */ > private
           if (sym.is(Private)) other.is(Private)
           else if (sym.is(Protected)) other.is(Protected | Private)
-          else true // sym is private
+          else true // sym is public
         }
         val fail = sym.allOverriddenSymbols.findSymbol(x => !hasWeakerAccess(x))
         if (fail.exists) {


### PR DESCRIPTION
Parameter forwarders cannot stay private, since private members
are not allowed to have the same name as inherited public ones.

Review by @DarkDimius