### PR TITLE
fix compiling ScalaRunTime.scala

### DIFF
--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -826,7 +826,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   def typedAppliedTypeTree(tree: untpd.AppliedTypeTree)(implicit ctx: Context): Tree = track("typedAppliedTypeTree") {
-    val tpt1 = typed(tree.tpt)
+    val tpt1 = typed(tree.tpt)(ctx retractMode Mode.Pattern)
     val tparams = tpt1.tpe.typeParams
     var args = tree.args
     if (tparams.isEmpty) {

--- a/tests/pos/Patterns.scala
+++ b/tests/pos/Patterns.scala
@@ -93,6 +93,15 @@ object Patterns {
     case t: a2.B =>
       t
   }
+
+  class caseWithPatternVariableHelper1[A]
+  class caseWithPatternVariableHelper2[A]
+
+  def caseWithPatternVariable(x: Any) = x match {
+    case a: caseWithPatternVariableHelper1[_] => ()
+    case b: caseWithPatternVariableHelper2[_] => ()
+  }
+
 }
 
 object NestedPattern {


### PR DESCRIPTION
this PR fixes compiling ScalaRunTime.scala (from dotty repo):

before:
```
exception occurred while compiling ../src/scala/runtime/ScalaRunTime.scala
Exception in thread "main" java.lang.Error: internal error: type of pattern variable ? is not fully defined, pos = [3339..3345]
	at dotty.tools.dotc.typer.Inferencing$class.fullyDefinedType(Inferencing.scala:44)
	at dotty.tools.dotc.typer.Typer.fullyDefinedType(Typer.scala:58)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedBind$1.apply(Typer.scala:853)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedBind$1.apply(Typer.scala:852)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedBind(Typer.scala:852)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:1022)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1078)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedIdent$1.apply(Typer.scala:256)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedIdent$1.apply(Typer.scala:79)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedIdent(Typer.scala:79)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:1019)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1078)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedAppliedTypeTree$1.apply(Typer.scala:829)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedAppliedTypeTree$1.apply(Typer.scala:828)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedAppliedTypeTree(Typer.scala:828)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1064)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.typedType(Typer.scala:1129)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedTyped$1.regularTyped$1(Typer.scala:372)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedTyped$1.apply(Typer.scala:380)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedTyped$1.apply(Typer.scala:366)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedTyped(Typer.scala:366)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1045)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedBind$1.apply(Typer.scala:854)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedBind$1.apply(Typer.scala:852)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedBind(Typer.scala:852)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:1022)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1078)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedTyped$1.apply(Typer.scala:384)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedTyped$1.apply(Typer.scala:366)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedTyped(Typer.scala:366)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1045)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.typedPattern(Typer.scala:1131)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedCase$1.apply(Typer.scala:693)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedCase$1.apply(Typer.scala:668)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedCase(Typer.scala:668)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedCases$1.apply(Typer.scala:662)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedCases$1.apply(Typer.scala:662)
	at dotty.tools.dotc.core.Decorators$ListDecorator$.loop$1(Decorators.scala:51)
	at dotty.tools.dotc.core.Decorators$ListDecorator$.mapconserve$extension(Decorators.scala:67)
	at dotty.tools.dotc.typer.Typer.typedCases(Typer.scala:662)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedMatch$1.apply(Typer.scala:634)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedMatch$1.apply(Typer.scala:626)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedMatch(Typer.scala:625)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1052)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:1127)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedDefDef$1.apply(Typer.scala:895)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedDefDef$1.apply(Typer.scala:888)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedDefDef(Typer.scala:888)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:1028)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1078)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:1112)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:1123)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedClassDef$1.apply(Typer.scala:924)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedClassDef$1.apply(Typer.scala:907)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedClassDef(Typer.scala:907)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:1031)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1078)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:1112)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:1123)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedPackageDef$1.apply(Typer.scala:971)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedPackageDef$1.apply(Typer.scala:962)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedPackageDef(Typer.scala:962)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1068)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:1118)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:1123)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedPackageDef$1.apply(Typer.scala:971)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedPackageDef$1.apply(Typer.scala:962)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedPackageDef(Typer.scala:962)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1068)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:1127)
	at dotty.tools.dotc.typer.FrontEnd$$anonfun$typeCheck$1.apply$mcV$sp(FrontEnd.scala:42)
	at dotty.tools.dotc.typer.FrontEnd.monitor(FrontEnd.scala:19)
	at dotty.tools.dotc.typer.FrontEnd.typeCheck(FrontEnd.scala:40)
	at dotty.tools.dotc.typer.FrontEnd$$anonfun$runOn$3.apply(FrontEnd.scala:53)
	at dotty.tools.dotc.typer.FrontEnd$$anonfun$runOn$3.apply(FrontEnd.scala:53)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at dotty.tools.dotc.typer.FrontEnd.runOn(FrontEnd.scala:53)
	at dotty.tools.dotc.Run$$anonfun$compileUnits$1$$anonfun$apply$mcV$sp$1.apply(Run.scala:59)
	at dotty.tools.dotc.Run$$anonfun$compileUnits$1$$anonfun$apply$mcV$sp$1.apply(Run.scala:56)
	at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	at dotty.tools.dotc.Run$$anonfun$compileUnits$1.apply$mcV$sp(Run.scala:56)
	at dotty.tools.dotc.Run$$anonfun$compileUnits$1.apply(Run.scala:52)
	at dotty.tools.dotc.Run$$anonfun$compileUnits$1.apply(Run.scala:52)
	at dotty.tools.dotc.util.Stats$.monitorHeartBeat(Stats.scala:69)
	at dotty.tools.dotc.Run.compileUnits(Run.scala:52)
	at dotty.tools.dotc.Run.compileSources(Run.scala:49)
	at dotty.tools.dotc.Run.compile(Run.scala:33)
	at dotty.tools.dotc.Driver.doCompile(Driver.scala:21)
	at dotty.tools.dotc.Driver.process(Driver.scala:44)
	at dotty.tools.dotc.Driver.main(Driver.scala:48)
	at dotty.tools.dotc.Main.main(Main.scala)
```


after:
```
 ~/p/d/d/build fix-compiling-ScalaRunTime: ! [20:12]> ../bin/dotc -print -verbose ../src//scala/runtime/ScalaRunTime.scala
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$GenMapFactory$$CC; assuming they are invariant
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$MapFactory$$CC; assuming they are invariant
two warnings found
```


Please let me know if the change should be updated (e.g. should the mode retract be in another place instead?)

Also, I would like to add some test cases.. but couldnt find a convenient way to run just one specific test via command line - can you help with this?  it would make much simpler to debug/fix issues :)

