### PR TITLE
Fix compiling GenBCode.scala

### DIFF
--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -885,7 +885,7 @@ object SymDenotations {
      */
     private def companionNamed(name: TypeName)(implicit ctx: Context): Symbol =
       if (owner.isClass)
-        owner.info.decl(name).suchThat(_.isCoDefinedWith(symbol)).symbol
+        owner.info.decl(name).suchThat(x => x.isCoDefinedWith(symbol) && x.isClass && x.symbol.isClass).symbol
       else if (!owner.exists || ctx.compilationUnit == null)
         NoSymbol
       else if (!ctx.compilationUnit.tpdTree.isEmpty)

--- a/src/dotty/tools/dotc/core/Symbols.scala
+++ b/src/dotty/tools/dotc/core/Symbols.scala
@@ -47,13 +47,6 @@ trait Symbols { this: Context =>
 
 // ---- Symbol creation methods ----------------------------------
 
-  /** Create a symbol from a function producing its denotation */
-  def newSymbolDenoting[N <: Name](denotFn: Symbol => SymDenotation, coord: Coord = NoCoord): Symbol { type ThisName = N } = {
-    val sym = newNakedSymbol[N](coord)
-    sym.denot = denotFn(sym)
-    sym
-  }
-
   /** Create a symbol from its fields (info may be lazy) */
   def newSymbol[N <: Name](
       owner: Symbol,

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -93,6 +93,7 @@ class tests extends CompilerTest {
   @Test def pos_packageObj = compileFile(posDir, "i0239", twice)
   @Test def pos_anonClassSubtyping = compileFile(posDir, "anonClassSubtyping", twice)
   @Test def pos_extmethods = compileFile(posDir, "extmethods", twice)
+  @Test def pos_companions = compileFile(posDir, "companions", twice)
 
   @Test def pos_all = compileFiles(posDir) // twice omitted to make tests run faster
 


### PR DESCRIPTION
Fix compiling one of dotty's files with dotty

before:
```
 ~/p/d/d/build  [14:09]> ../bin/dotc -print -verbose ../src//dotty/tools/backend/jvm/GenBCode.scala
new files detected. rebuilding
[info] Loading global plugins from /Users/svalaskevicius/.sbt/0.13/plugins
[info] Loading project definition from /Users/svalaskevicius/priv/dev/dotty/project
[info] Set current project to dotty (in build file:/Users/svalaskevicius/priv/dev/dotty/)
[info] Compiling 3 Scala sources to /Users/svalaskevicius/priv/dev/dotty/target/scala-2.11/classes...
[info] Packaging /Users/svalaskevicius/priv/dev/dotty/target/scala-2.11/dotty_2.11-0.1-SNAPSHOT.jar ...
[info] Done packaging.
[success] Total time: 17 s, completed 25-Sep-2015 14:09:37
/Users/svalaskevicius/priv/dev/dotty/build
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$GenMapFactory$$CC; assuming they are invariant
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$MapFactory$$CC; assuming they are invariant
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$MutableMapFactory$$CC; assuming they are invariant
warning: cannot merge (module: BCodeBodyBuilder.this.int.Symbol)Unit with (tree: BCodeBodyBuilder.this.int.Tree)BCodeBodyBuilder.this.bTypes.BType as members of one type; keeping only (module: BCodeBodyBuilder.this.int.Symbol)Unit
warning: cannot merge (module: BCodeBodyBuilder.this.int.Symbol)Unit with (tree: BCodeBodyBuilder.this.int.Tree)BCodeBodyBuilder.this.bTypes.BType as members of one type; keeping only (module: BCodeBodyBuilder.this.int.Symbol)Unit
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[BCodeIdiomatic.this.bTypes.BType])
  Array[BCodeIdiomatic.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[BCodeIdiomatic.this.bTypes.BType])
  Array[BCodeIdiomatic.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[BCodeIdiomatic.this.bTypes.BType])
  Array[BCodeIdiomatic.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[Int])Array[Int] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[Int])Array[Int]
warning: cannot merge (xs: scala.collection.immutable.List[Int])Array[Int] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[Int])Array[Int]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[GenBCodePipeline.this.bTypes.BType])
  Array[GenBCodePipeline.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[GenBCodePipeline.this.bTypes.BType])
  Array[GenBCodePipeline.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[GenBCodePipeline.this.bTypes.BType])
  Array[GenBCodePipeline.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[Int])Array[Int] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[Int])Array[Int]
warning: cannot merge (xs: scala.collection.immutable.List[Int])Array[Int] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[Int])Array[Int]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[GenBCodePipeline.this.bTypes.BType])
  Array[GenBCodePipeline.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[Int])Array[Int] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[Int])Array[Int]
exception while typing [cannot display due to dotty.tools.dotc.core.Types$CyclicReference: cyclic reference involving module class Select$, raw string = Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)]),<init>),List()),List(Ident(ctx)))] of class class dotty.tools.dotc.ast.Trees$Apply # 5636
exception while typing [cannot display due to dotty.tools.dotc.core.Types$CyclicReference: cyclic reference involving module class Select$, raw string = Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)]),<init>),List(Select(Select(This(GenBCode),entryPoints),toList), Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)]),<init>),List()),List(Ident(ctx)))))] of class class dotty.tools.dotc.ast.Trees$Apply # 5638
exception while typing [cannot display due to dotty.tools.dotc.core.Types$CyclicReference: cyclic reference involving module class Select$, raw string = Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)]),<init>),List(Select(Select(This(GenBCode),entryPoints),toList), Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)]),<init>),List()),List(Ident(ctx))))),List(Ident(ctx)))] of class class dotty.tools.dotc.ast.Trees$Apply # 5640
exception while typing [cannot display due to dotty.tools.dotc.core.Types$CyclicReference: cyclic reference involving module class Select$, raw string = Select(Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)]),<init>),List(Select(Select(This(GenBCode),entryPoints),toList), Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)]),<init>),List()),List(Ident(ctx))))),List(Ident(ctx))),run)] of class class dotty.tools.dotc.ast.Trees$Select # 5641
exception while typing [cannot display due to dotty.tools.dotc.core.Types$CyclicReference: cyclic reference involving module class Select$, raw string = Apply(Select(Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)]),<init>),List(Select(Select(This(GenBCode),entryPoints),toList), Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)]),<init>),List()),List(Ident(ctx))))),List(Ident(ctx))),run),List(Select(Select(Ident(ctx),compilationUnit),tpdTree)))] of class class dotty.tools.dotc.ast.Trees$Apply # 5643
exception while typing [cannot display due to dotty.tools.dotc.core.Types$CyclicReference: cyclic reference involving module class Select$, raw string = Block(List(Apply(Select(Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)]),<init>),List(Select(Select(This(GenBCode),entryPoints),toList), Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)]),<init>),List()),List(Ident(ctx))))),List(Ident(ctx))),run),List(Select(Select(Ident(ctx),compilationUnit),tpdTree)))),Apply(Select(Select(This(GenBCode),entryPoints),clear),List()))] of class class dotty.tools.dotc.ast.Trees$Block # 5645
exception while typing [cannot display due to dotty.tools.dotc.core.Types$CyclicReference: cyclic reference involving module class Select$, raw string = DefDef(run,List(),List(List(ValDef(ctx,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Contexts),Context)],EmptyTree))),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Unit)],Block(List(Apply(Select(Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)]),<init>),List(Select(Select(This(GenBCode),entryPoints),toList), Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)]),<init>),List()),List(Ident(ctx))))),List(Ident(ctx))),run),List(Select(Select(Ident(ctx),compilationUnit),tpdTree)))),Apply(Select(Select(This(GenBCode),entryPoints),clear),List())))] of class class dotty.tools.dotc.ast.Trees$DefDef # 5646
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$GenSetFactory$$CC; assuming they are invariant
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$SetFactory$$CC; assuming they are invariant
exception while typing [cannot display due to dotty.tools.dotc.core.Types$CyclicReference: cyclic reference involving module class Select$, raw string = TypeDef(GenBCode,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,util)),DotClass)]),<init>),List()), TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Phases),Phase)]),ValDef(_,EmptyTree,EmptyTree),List(DefDef(runsAfter,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),Set), scala$collection$immutable$Set$$A, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,lang)),Class), java$lang$Class$$T, TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Nothing), TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,core)),Phases$)),Phase)) | -2091368625)) | 1648975809)],Select(Super(This(GenBCode),Phase),runsAfter)), DefDef(runOn,List(),List(List(ValDef(units,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,dotc)),CompilationUnit)) | -341368939)],EmptyTree)), List(ValDef(ctx,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Contexts),Context)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,dotc)),CompilationUnit)) | -341368939)],Apply(Apply(Select(Super(This(GenBCode),Phase),runOn),List(Ident(units))),List(Ident(ctx)))), DefDef(description,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Select(Super(This(GenBCode),Phase),description)), DefDef(isCheckable,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),isCheckable)), DefDef(checkPostCondition,List(),List(List(ValDef(tree,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,ast)),tpd),Tree)],EmptyTree)), List(ValDef(ctx,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Contexts),Context)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Apply(Select(Super(This(GenBCode),Phase),checkPostCondition),List(Ident(tree))),List(Ident(ctx)))), DefDef(relaxedTyping,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),relaxedTyping)), DefDef(isTyper,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),isTyper)), DefDef(exists,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),exists)), DefDef(id,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Select(Super(This(GenBCode),Phase),id)), DefDef(period,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Periods),Period)],Select(Super(This(GenBCode),Phase),period)), DefDef(start,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Select(Super(This(GenBCode),Phase),start)), DefDef(end,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Periods),PhaseId)],Select(Super(This(GenBCode),Phase),end)), DefDef(erasedTypes,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),erasedTypes)), DefDef(flatClasses,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),flatClasses)), DefDef(refChecked,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),refChecked)), DefDef(symbolicRefs,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),symbolicRefs)), DefDef(labelsReordered,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),labelsReordered)), DefDef(init,List(),List(List(ValDef(base,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Contexts),ContextBase)],EmptyTree), ValDef(start,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree), ValDef(end,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Select(Super(This(GenBCode),Phase),init),List(Ident(base), Ident(start), Ident(end)))), DefDef(init,List(),List(List(ValDef(base,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Contexts),ContextBase)],EmptyTree), ValDef(id,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Select(Super(This(GenBCode),Phase),init),List(Ident(base), Ident(id)))), DefDef($less$eq,List(),List(List(ValDef(that,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,core)),Phases$)),Phase)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Apply(Select(Super(This(GenBCode),Phase),$less$eq),List(Ident(that)))), DefDef(prev,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,core)),Phases$)),Phase)],Select(Super(This(GenBCode),Phase),prev)), DefDef(next,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,core)),Phases$)),Phase)],Select(Super(This(GenBCode),Phase),next)), DefDef(hasNext,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),hasNext)), DefDef(iterator,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,collection)),Iterator), scala$collection$Iterator$$A, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,core)),Phases$)),Phase)) | -1208508395)],Select(Super(This(GenBCode),Phase),iterator)), DefDef(toString,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Apply(Select(Super(This(GenBCode),Phase),toString),List())), DefDef(phaseName,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Literal(Constant(genBCode))), DefDef(entryPoints,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,mutable)),HashSet), scala$collection$mutable$HashSet$$A, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)) | 1086299269)],Apply(TypeApply(Select(New(TypeTree[RefinedType(TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),collection),mutable),HashSet), scala$collection$mutable$HashSet$$A, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)) | -1190315510)]),<init>),List(TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)])),List())), DefDef(registerEntryPoint,List(),List(List(ValDef(sym,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,mutable)),HashSet), scala$collection$mutable$HashSet$$A, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)) | 1086299269)],Apply(Select(Select(This(GenBCode),entryPoints),$plus$eq),List(Ident(sym)))), DefDef(run,List(),List(List(ValDef(ctx,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Contexts),Context)],EmptyTree))),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Unit)],Block(List(Apply(Select(Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)]),<init>),List(Select(Select(This(GenBCode),entryPoints),toList), Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)]),<init>),List()),List(Ident(ctx))))),List(Ident(ctx))),run),List(Select(Select(Ident(ctx),compilationUnit),tpdTree)))),Apply(Select(Select(This(GenBCode),entryPoints),clear),List()))))))] of class class dotty.tools.dotc.ast.Trees$TypeDef # 7150
exception while typing [cannot display due to dotty.tools.dotc.core.Types$CyclicReference: cyclic reference involving module class Select$, raw string = PackageDef(Select(Select(Select(Ident(dotty),tools),backend),jvm),List(TypeDef(GenBCode,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,util)),DotClass)]),<init>),List()), TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Phases),Phase)]),ValDef(_,EmptyTree,EmptyTree),List(DefDef(runsAfter,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),Set), scala$collection$immutable$Set$$A, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,lang)),Class), java$lang$Class$$T, TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Nothing), TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,core)),Phases$)),Phase)) | -2091368625)) | 1648975809)],Select(Super(This(GenBCode),Phase),runsAfter)), DefDef(runOn,List(),List(List(ValDef(units,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,dotc)),CompilationUnit)) | -341368939)],EmptyTree)), List(ValDef(ctx,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Contexts),Context)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,dotc)),CompilationUnit)) | -341368939)],Apply(Apply(Select(Super(This(GenBCode),Phase),runOn),List(Ident(units))),List(Ident(ctx)))), DefDef(description,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Select(Super(This(GenBCode),Phase),description)), DefDef(isCheckable,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),isCheckable)), DefDef(checkPostCondition,List(),List(List(ValDef(tree,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,ast)),tpd),Tree)],EmptyTree)), List(ValDef(ctx,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Contexts),Context)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Apply(Select(Super(This(GenBCode),Phase),checkPostCondition),List(Ident(tree))),List(Ident(ctx)))), DefDef(relaxedTyping,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),relaxedTyping)), DefDef(isTyper,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),isTyper)), DefDef(exists,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),exists)), DefDef(id,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Select(Super(This(GenBCode),Phase),id)), DefDef(period,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Periods),Period)],Select(Super(This(GenBCode),Phase),period)), DefDef(start,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Select(Super(This(GenBCode),Phase),start)), DefDef(end,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Periods),PhaseId)],Select(Super(This(GenBCode),Phase),end)), DefDef(erasedTypes,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),erasedTypes)), DefDef(flatClasses,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),flatClasses)), DefDef(refChecked,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),refChecked)), DefDef(symbolicRefs,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),symbolicRefs)), DefDef(labelsReordered,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),labelsReordered)), DefDef(init,List(),List(List(ValDef(base,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Contexts),ContextBase)],EmptyTree), ValDef(start,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree), ValDef(end,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Select(Super(This(GenBCode),Phase),init),List(Ident(base), Ident(start), Ident(end)))), DefDef(init,List(),List(List(ValDef(base,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Contexts),ContextBase)],EmptyTree), ValDef(id,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Select(Super(This(GenBCode),Phase),init),List(Ident(base), Ident(id)))), DefDef($less$eq,List(),List(List(ValDef(that,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,core)),Phases$)),Phase)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Apply(Select(Super(This(GenBCode),Phase),$less$eq),List(Ident(that)))), DefDef(prev,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,core)),Phases$)),Phase)],Select(Super(This(GenBCode),Phase),prev)), DefDef(next,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,core)),Phases$)),Phase)],Select(Super(This(GenBCode),Phase),next)), DefDef(hasNext,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Select(Super(This(GenBCode),Phase),hasNext)), DefDef(iterator,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,collection)),Iterator), scala$collection$Iterator$$A, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,core)),Phases$)),Phase)) | -1208508395)],Select(Super(This(GenBCode),Phase),iterator)), DefDef(toString,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Apply(Select(Super(This(GenBCode),Phase),toString),List())), DefDef(phaseName,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Literal(Constant(genBCode))), DefDef(entryPoints,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,mutable)),HashSet), scala$collection$mutable$HashSet$$A, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)) | 1086299269)],Apply(TypeApply(Select(New(TypeTree[RefinedType(TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),collection),mutable),HashSet), scala$collection$mutable$HashSet$$A, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)) | -1190315510)]),<init>),List(TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)])),List())), DefDef(registerEntryPoint,List(),List(List(ValDef(sym,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,mutable)),HashSet), scala$collection$mutable$HashSet$$A, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)) | 1086299269)],Apply(Select(Select(This(GenBCode),entryPoints),$plus$eq),List(Ident(sym)))), DefDef(run,List(),List(List(ValDef(ctx,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Contexts),Context)],EmptyTree))),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Unit)],Block(List(Apply(Select(Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)]),<init>),List(Select(Select(This(GenBCode),entryPoints),toList), Apply(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)]),<init>),List()),List(Ident(ctx))))),List(Ident(ctx))),run),List(Select(Select(Ident(ctx),compilationUnit),tpdTree)))),Apply(Select(Select(This(GenBCode),entryPoints),clear),List())))))), ValDef(GenBCode,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCode$)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCode$)]),<init>),List())), TypeDef(GenBCode$,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCode$)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List())),ValDef(_,TypeTree[TermRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCode)],EmptyTree),List())), TypeDef(GenBCodePipeline,Template(DefDef(<init>,List(),List(List(ValDef(entryPoints,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)) | 46670353)],EmptyTree), ValDef(int,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)],EmptyTree)), List(ValDef(ctx,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Contexts),Context)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List()), TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),backend),jvm),BCodeSyncAndTry)]),ValDef(_,EmptyTree,EmptyTree),List(DefDef(mkArray,List(),List(List(ValDef(xs,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),bTypes),BType)) | -847476454)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),bTypes),BType)) | -1719631750)],Apply(Select(Super(This(GenBCodePipeline),BCodeIdiomatic),mkArray),List(Ident(xs)))), DefDef(mkArrayReverse,List(),List(List(ValDef(xs,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)) | 1773437787)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)) | 142394858)],Apply(Select(Super(This(GenBCodePipeline),BCodeIdiomatic),mkArrayReverse),List(Ident(xs)))), DefDef(coercionFrom,List(),List(List(ValDef(code,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),bTypes),BType)],Apply(Select(Super(This(GenBCodePipeline),BCodeIdiomatic),coercionFrom),List(Ident(code)))), DefDef(coercionTo,List(),List(List(ValDef(code,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),bTypes),BType)],Apply(Select(Super(This(GenBCodePipeline),BCodeIdiomatic),coercionTo),List(Ident(code)))), DefDef(InsnIterMethodNode,List(),List(List(ValDef(mnode,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,tree)),MethodNode)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),InsnIterMethodNode)],Apply(Select(Super(This(GenBCodePipeline),BCodeIdiomatic),InsnIterMethodNode),List(Ident(mnode)))), DefDef(InsnIterInsnList,List(),List(List(ValDef(lst,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,tree)),InsnList)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),InsnIterInsnList)],Apply(Select(Super(This(GenBCodePipeline),BCodeIdiomatic),InsnIterInsnList),List(Ident(lst)))), DefDef(getFile,List(),List(List(ValDef(base,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),io),package),AbstractFile)],EmptyTree), ValDef(clsName,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree), ValDef(suffix,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree))),TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),io),package),AbstractFile)],Apply(Select(Super(This(GenBCodePipeline),BytecodeWriters),getFile),List(Ident(base), Ident(clsName), Ident(suffix)))), DefDef(getFile,List(),List(List(ValDef(sym,TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),int),Symbol)],EmptyTree), ValDef(clsName,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree), ValDef(suffix,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree))),TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),io),package),AbstractFile)],Apply(Select(Super(This(GenBCodePipeline),BytecodeWriters),getFile),List(Ident(sym), Ident(clsName), Ident(suffix)))), DefDef(factoryNonJarBytecodeWriter,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),BytecodeWriter)],Apply(Select(Super(This(GenBCodePipeline),BytecodeWriters),factoryNonJarBytecodeWriter),List())), DefDef(getFileForClassfile,List(),List(List(ValDef(base,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),io),package),AbstractFile)],EmptyTree), ValDef(clsName,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree), ValDef(suffix,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree))),TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),io),package),AbstractFile)],Apply(Select(Super(This(GenBCodePipeline),BCodeHelpers),getFileForClassfile),List(Ident(base), Ident(clsName), Ident(suffix)))), DefDef(getOutFolder,List(),List(List(ValDef(csym,TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),int),Symbol)],EmptyTree), ValDef(cName,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree))),TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),io),package),AbstractFile)],Apply(Select(Super(This(GenBCodePipeline),BCodeHelpers),getOutFolder),List(Ident(csym), Ident(cName)))), DefDef(initBytecodeWriter,List(),List(List(ValDef(entryPoints,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),int),Symbol)) | 1034252784)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),BytecodeWriter)],Apply(Select(Super(This(GenBCodePipeline),BCodeHelpers),initBytecodeWriter),List(Ident(entryPoints)))), DefDef(addInnerClassesASM,List(),List(List(ValDef(jclass,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,asm)),ClassVisitor)],EmptyTree), ValDef(refedInnerClasses,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),bTypes),ClassBType)) | -129149884)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Select(Super(This(GenBCodePipeline),BCodeHelpers),addInnerClassesASM),List(Ident(jclass), Ident(refedInnerClasses)))), DefDef(entryPoints,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)) | 46670353)],EmptyTree), DefDef(int,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),DottyBackendInterface)],EmptyTree), DefDef(ctx,List(),List(),TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Contexts),Context)],EmptyTree), DefDef(tree,List(),List(),TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),Tree)],Ident(_)), DefDef(tree_$eq,List(),List(List(ValDef(x$1,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),Tree)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Literal(Constant(()))), TypeDef(PlainClassBuilder,Template(DefDef(<init>,List(),List(List(ValDef(cunit,TypeTree[TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SyncAndTryBuilder)]),<init>),List(Ident(cunit)))),ValDef(_,EmptyTree,EmptyTree),List(ValDef(cunit,TypeTree[TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)],EmptyTree), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$PlainClassBuilder$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), DefDef(PlainClassBuilder,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),PlainClassBuilder$)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),PlainClassBuilder$)]),<init>),List())), TypeDef(PlainClassBuilder$,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),PlainClassBuilder$)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List())),ValDef(_,TypeTree[TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),PlainClassBuilder)],EmptyTree),List())), DefDef(bytecodeWriter,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),BytecodeWriter)],Literal(Constant(null))), DefDef(bytecodeWriter_$eq,List(),List(List(ValDef(x$1,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),BytecodeWriter)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Literal(Constant(()))), DefDef(mirrorCodeGen,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),JMirrorBuilder)],Literal(Constant(null))), DefDef(mirrorCodeGen_$eq,List(),List(List(ValDef(x$1,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),JMirrorBuilder)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Literal(Constant(()))), DefDef(beanInfoCodeGen,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),JBeanInfoBuilder)],Literal(Constant(null))), DefDef(beanInfoCodeGen_$eq,List(),List(List(ValDef(x$1,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),JBeanInfoBuilder)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Literal(Constant(()))), TypeDef(Item1,Template(DefDef(<init>,List(),List(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), ValDef(cd,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),TypeDef)],EmptyTree), ValDef(cunit,TypeTree[TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List()), TypeTree[RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Product3), scala$Product3$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | 691157130), scala$Product3$$T2, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),TypeDef)) | -1603503168), scala$Product3$$T3, TypeAlias(TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)) | -1448473692)]),ValDef(_,EmptyTree,EmptyTree),List(DefDef(productIterator,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,collection)),Iterator), scala$collection$Iterator$$A, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | 518396976)],Select(Super(This(Item1),Product),productIterator)), DefDef(productArity,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Select(Super(This(Item1),Product3),productArity)), DefDef(productElement,List(),List(List(ValDef(n,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],Apply(Select(Super(This(Item1),Product3),productElement),List(Ident(n)))), DefDef(arrivalPos,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), DefDef(cd,List(),List(),TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),TypeDef)],EmptyTree), DefDef(cunit,List(),List(),TypeTree[TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)],EmptyTree), DefDef(isPoison,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(),Apply(Select(Ident(arrivalPos),$eq$eq),List(Literal(Constant(2147483647)))))), DefDef(copy,List(),List(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), ValDef(cd,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),TypeDef)],EmptyTree), ValDef(cunit,TypeTree[TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)]),<init>),List(Ident(arrivalPos), Ident(cd), Ident(cunit)))), DefDef(copy$default$1,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int))],Typed(Ident(arrivalPos),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int))])), DefDef(copy$default$2,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),TypeDef))],Typed(Ident(cd),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),TypeDef))])), DefDef(copy$default$3,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit))],Typed(Ident(cunit),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit))])), DefDef(isDefined,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Literal(Constant(true))), DefDef(_1,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)),scala$Product3$$T1)],Select(This(),arrivalPos)), DefDef(_2,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)),scala$Product3$$T2)],Select(This(),cd)), DefDef(_3,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)),scala$Product3$$T3)],Select(This(),cunit)), DefDef(hashCode,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Block(List(ValDef(acc,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Literal(Constant(-889275714))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Ident(arrivalPos)))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(cd)))))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(cunit))))))),Apply(Ident(finalizeHash),List(Ident(acc), Literal(Constant(3)))))), DefDef(equals,List(),List(List(ValDef(x$0,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Apply(Select(Apply(Select(This(Item1),eq),List(TypeApply(Select(Ident(x$0),asInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)])))),$bar$bar),List(Block(List(ValDef(selector11,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],Ident(x$0))),Block(List(DefDef(case11,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(DefDef(case21,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(DefDef(matchFail11,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector11))))))),If(TypeApply(Select(Ident(selector11),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)])),Block(List(),Literal(Constant(false))),Apply(Ident(matchFail11),List()))))),If(TypeApply(Select(Ident(selector11),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)])),Block(List(ValDef(x$0,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)],TypeApply(Select(Ident(selector11),asInstanceOf),List(TypeTree[TermRef(NoPrefix,x$0)])))),Block(List(),Apply(Select(Apply(Select(Apply(Select(Select(This(Item1),arrivalPos),$eq$eq),List(Select(Ident(x$0),arrivalPos))),$amp$amp),List(Apply(Select(Select(This(Item1),cd),$eq$eq),List(Select(Ident(x$0),cd))))),$amp$amp),List(Apply(Select(Select(This(Item1),cunit),$eq$eq),List(Select(Ident(x$0),cunit))))))),Apply(Ident(case21),List()))))),Apply(Ident(case11),List())))))), DefDef(toString,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Apply(Ident(_toString),List(This(Item1)))), DefDef(canEqual,List(),List(List(ValDef(that,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],TypeApply(Select(Ident(that),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)]))), DefDef(productPrefix,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Literal(Constant(Item1))), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$Item1$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), DefDef(Item1,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)]),<init>),List())), TypeDef(Item1$,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List()), TypeTree[RefinedType(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function3), scala$Function3$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | -314199973), scala$Function3$$T2, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),TypeDef)) | -2088110654), scala$Function3$$T3, TypeAlias(TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)) | -958275478), scala$Function3$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)) | 84377377)]),ValDef(_,TypeTree[TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)],EmptyTree),List(DefDef(curried,List(),List(),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)),scala$Function3$$T1)) | -1399692484), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)),scala$Function3$$T2)) | 1293281024), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)),scala$Function3$$T3)) | -1460736248), scala$Function1$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)),scala$Function3$$R)) | -428279287)) | -1747878304)) | -1925087040)],Select(Super(This(Item1$),Function3),curried)), DefDef(tupled,List(),List(),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple3), scala$Tuple3$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)),scala$Function3$$T1)) | 1873119229), scala$Tuple3$$T2, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)),scala$Function3$$T2)) | -739312263), scala$Tuple3$$T3, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)),scala$Function3$$T3)) | 1145386011)) | -1521085231), scala$Function1$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)),scala$Function3$$R)) | -2068404894)],Select(Super(This(Item1$),Function3),tupled)), DefDef(toString,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Apply(Select(Super(This(Item1$),Function3),toString),List())), DefDef(apply,List(),List(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), ValDef(cd,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),TypeDef)],EmptyTree), ValDef(cunit,TypeTree[TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1$)),scala$Function3$$R)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)]),<init>),List(Ident(arrivalPos), Ident(cd), Ident(cunit)))), DefDef(unapply,List(),List(List(ValDef(x$1,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)],Ident(x$1)), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$Item1$$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), DefDef(poison1,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1),scala$Function3$$R)],Apply(Select(Select(This(GenBCodePipeline),Item1),apply),List(Literal(Constant(2147483647)), Literal(Constant(null)), Select(Ident(ctx),compilationUnit)))), DefDef(q1,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),LinkedList), java$util$LinkedList$$E, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)) | -96249307)],Apply(TypeApply(Select(New(TypeTree[RefinedType(TypeRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),java),util),LinkedList), java$util$LinkedList$$E, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)) | -1689116404)]),<init>),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)])),List())), TypeDef(Item2,Template(DefDef(<init>,List(),List(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), ValDef(mirror,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), ValDef(plain,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), ValDef(bean,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), ValDef(outFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List()), TypeTree[RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Product5), scala$Product5$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | -815445622), scala$Product5$$T2, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | 2142704099), scala$Product5$$T3, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | -1651232306), scala$Product5$$T4, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | -1984258651), scala$Product5$$T5, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)) | 956511594)]),ValDef(_,EmptyTree,EmptyTree),List(DefDef(productIterator,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,collection)),Iterator), scala$collection$Iterator$$A, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | 518396976)],Select(Super(This(Item2),Product),productIterator)), DefDef(productArity,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Select(Super(This(Item2),Product5),productArity)), DefDef(productElement,List(),List(List(ValDef(n,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],Apply(Select(Super(This(Item2),Product5),productElement),List(Ident(n)))), DefDef(arrivalPos,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), DefDef(mirror,List(),List(),TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), DefDef(plain,List(),List(),TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), DefDef(bean,List(),List(),TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), DefDef(outFolder,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)],EmptyTree), DefDef(isPoison,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(),Apply(Select(Ident(arrivalPos),$eq$eq),List(Literal(Constant(2147483647)))))), DefDef(copy,List(),List(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), ValDef(mirror,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), ValDef(plain,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), ValDef(bean,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), ValDef(outFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)]),<init>),List(Ident(arrivalPos), Ident(mirror), Ident(plain), Ident(bean), Ident(outFolder)))), DefDef(copy$default$1,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int))],Typed(Ident(arrivalPos),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int))])), DefDef(copy$default$2,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode))],Typed(Ident(mirror),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode))])), DefDef(copy$default$3,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode))],Typed(Ident(plain),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode))])), DefDef(copy$default$4,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode))],Typed(Ident(bean),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode))])), DefDef(copy$default$5,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile))],Typed(Ident(outFolder),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile))])), DefDef(isDefined,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Literal(Constant(true))), DefDef(_1,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)),scala$Product5$$T1)],Select(This(),arrivalPos)), DefDef(_2,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)),scala$Product5$$T2)],Select(This(),mirror)), DefDef(_3,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)),scala$Product5$$T3)],Select(This(),plain)), DefDef(_4,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)),scala$Product5$$T4)],Select(This(),bean)), DefDef(_5,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)),scala$Product5$$T5)],Select(This(),outFolder)), DefDef(hashCode,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Block(List(ValDef(acc,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Literal(Constant(-889275714))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Ident(arrivalPos)))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(mirror)))))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(plain)))))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(bean)))))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(outFolder))))))),Apply(Ident(finalizeHash),List(Ident(acc), Literal(Constant(5)))))), DefDef(equals,List(),List(List(ValDef(x$0,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Apply(Select(Apply(Select(This(Item2),eq),List(TypeApply(Select(Ident(x$0),asInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)])))),$bar$bar),List(Block(List(ValDef(selector12,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],Ident(x$0))),Block(List(DefDef(case31,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(DefDef(case41,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(DefDef(matchFail21,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector12))))))),If(TypeApply(Select(Ident(selector12),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)])),Block(List(),Literal(Constant(false))),Apply(Ident(matchFail21),List()))))),If(TypeApply(Select(Ident(selector12),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)])),Block(List(ValDef(x$0,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)],TypeApply(Select(Ident(selector12),asInstanceOf),List(TypeTree[TermRef(NoPrefix,x$0)])))),Block(List(),Apply(Select(Apply(Select(Apply(Select(Apply(Select(Apply(Select(Select(This(Item2),arrivalPos),$eq$eq),List(Select(Ident(x$0),arrivalPos))),$amp$amp),List(Apply(Select(Select(This(Item2),mirror),$eq$eq),List(Select(Ident(x$0),mirror))))),$amp$amp),List(Apply(Select(Select(This(Item2),plain),$eq$eq),List(Select(Ident(x$0),plain))))),$amp$amp),List(Apply(Select(Select(This(Item2),bean),$eq$eq),List(Select(Ident(x$0),bean))))),$amp$amp),List(Apply(Select(Select(This(Item2),outFolder),$eq$eq),List(Select(Ident(x$0),outFolder))))))),Apply(Ident(case41),List()))))),Apply(Ident(case31),List())))))), DefDef(toString,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Apply(Ident(_toString),List(This(Item2)))), DefDef(canEqual,List(),List(List(ValDef(that,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],TypeApply(Select(Ident(that),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)]))), DefDef(productPrefix,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Literal(Constant(Item2))), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$Item2$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), DefDef(Item2,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)]),<init>),List())), TypeDef(Item2$,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List()), TypeTree[RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function5), scala$Function5$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | 912401177), scala$Function5$$T2, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | 1724589003), scala$Function5$$T3, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | 1342336675), scala$Function5$$T4, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | 775752881), scala$Function5$$T5, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)) | 1817731585), scala$Function5$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)) | -1500781395)]),ValDef(_,TypeTree[TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)],EmptyTree),List(DefDef(curried,List(),List(),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$T1)) | 293147652), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$T2)) | -126540375), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$T3)) | -1834086699), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$T4)) | -2113698428), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$T5)) | 354440823), scala$Function1$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$R)) | 1716125952)) | -729715494)) | 1815464888)) | 1733422089)) | 1121926686)],Select(Super(This(Item2$),Function5),curried)), DefDef(tupled,List(),List(),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple5), scala$Tuple5$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$T1)) | 1786450386), scala$Tuple5$$T2, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$T2)) | 2013304336), scala$Tuple5$$T3, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$T3)) | 1193410614), scala$Tuple5$$T4, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$T4)) | 807059778), scala$Tuple5$$T5, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$T5)) | 561282622)) | -8867437), scala$Function1$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$R)) | 369636062)],Select(Super(This(Item2$),Function5),tupled)), DefDef(toString,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Apply(Select(Super(This(Item2$),Function5),toString),List())), DefDef(apply,List(),List(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), ValDef(mirror,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), ValDef(plain,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), ValDef(bean,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree), ValDef(outFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2$)),scala$Function5$$R)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)]),<init>),List(Ident(arrivalPos), Ident(mirror), Ident(plain), Ident(bean), Ident(outFolder)))), DefDef(unapply,List(),List(List(ValDef(x$1,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)],Ident(x$1)), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$Item2$$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), DefDef(poison2,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2),scala$Function5$$R)],Apply(Select(Select(This(GenBCodePipeline),Item2),apply),List(Literal(Constant(2147483647)), Literal(Constant(null)), Literal(Constant(null)), Literal(Constant(null)), Literal(Constant(null))))), DefDef(q2,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),LinkedList), java$util$LinkedList$$E, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)) | 188580372)],Apply(TypeApply(Select(New(TypeTree[RefinedType(TypeRef(TermRef(TermRef(TermRef(NoPrefix,_root_),java),util),LinkedList), java$util$LinkedList$$E, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)) | 1521966085)]),<init>),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)])),List())), TypeDef(SubItem3,Template(DefDef(<init>,List(),List(List(ValDef(jclassName,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree), ValDef(jclassBytes,TypeTree[RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List()), TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Product2), scala$Product2$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)) | -2031111403), scala$Product2$$T2, TypeAlias(RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)) | 2041342616)]),ValDef(_,EmptyTree,EmptyTree),List(DefDef(productIterator,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,collection)),Iterator), scala$collection$Iterator$$A, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | 518396976)],Select(Super(This(SubItem3),Product),productIterator)), DefDef(productArity,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Select(Super(This(SubItem3),Product2),productArity)), DefDef(productElement,List(),List(List(ValDef(n,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],Apply(Select(Super(This(SubItem3),Product2),productElement),List(Ident(n)))), DefDef(jclassName,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree), DefDef(jclassBytes,List(),List(),TypeTree[RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)],EmptyTree), DefDef(copy,List(),List(List(ValDef(jclassName,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree), ValDef(jclassBytes,TypeTree[RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)]),<init>),List(Ident(jclassName), Ident(jclassBytes)))), DefDef(copy$default$1,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String))],Typed(Ident(jclassName),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String))])), DefDef(copy$default$2,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309))],Typed(Ident(jclassBytes),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309))])), DefDef(isDefined,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Literal(Constant(true))), DefDef(_1,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)),scala$Product2$$T1)],Select(This(),jclassName)), DefDef(_2,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)),scala$Product2$$T2)],Select(This(),jclassBytes)), DefDef(hashCode,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Block(List(ValDef(acc,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Literal(Constant(-889275714))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(jclassName)))))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(jclassBytes))))))),Apply(Ident(finalizeHash),List(Ident(acc), Literal(Constant(2)))))), DefDef(equals,List(),List(List(ValDef(x$0,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Apply(Select(Apply(Select(This(SubItem3),eq),List(TypeApply(Select(Ident(x$0),asInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)])))),$bar$bar),List(Block(List(ValDef(selector13,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],Ident(x$0))),Block(List(DefDef(case51,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(DefDef(case61,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(DefDef(matchFail31,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector13))))))),If(TypeApply(Select(Ident(selector13),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)])),Block(List(),Literal(Constant(false))),Apply(Ident(matchFail31),List()))))),If(TypeApply(Select(Ident(selector13),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)])),Block(List(ValDef(x$0,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],TypeApply(Select(Ident(selector13),asInstanceOf),List(TypeTree[TermRef(NoPrefix,x$0)])))),Block(List(),Apply(Select(Apply(Select(Select(This(SubItem3),jclassName),$eq$eq),List(Select(Ident(x$0),jclassName))),$amp$amp),List(Apply(Select(Select(This(SubItem3),jclassBytes),$eq$eq),List(Select(Ident(x$0),jclassBytes))))))),Apply(Ident(case61),List()))))),Apply(Ident(case51),List())))))), DefDef(toString,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Apply(Ident(_toString),List(This(SubItem3)))), DefDef(canEqual,List(),List(List(ValDef(that,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],TypeApply(Select(Ident(that),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)]))), DefDef(productPrefix,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Literal(Constant(SubItem3))), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$SubItem3$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), DefDef(SubItem3,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3$)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3$)]),<init>),List())), TypeDef(SubItem3$,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List()), TypeTree[RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function2), scala$Function2$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)) | -1714452344), scala$Function2$$T2, TypeAlias(RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)) | -1685387806), scala$Function2$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)) | -2008094426)]),ValDef(_,TypeTree[TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree),List(DefDef(curried,List(),List(),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3$)),scala$Function2$$T1)) | -860358437), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3$)),scala$Function2$$T2)) | 1313570838), scala$Function1$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3$)),scala$Function2$$R)) | -983181162)) | -108488497)],Select(Super(This(SubItem3$),Function2),curried)), DefDef(tupled,List(),List(),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple2), scala$Tuple2$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3$)),scala$Function2$$T1)) | -1968792243), scala$Tuple2$$T2, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3$)),scala$Function2$$T2)) | 686503809)) | 224586440), scala$Function1$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3$)),scala$Function2$$R)) | 1783720780)],Select(Super(This(SubItem3$),Function2),tupled)), DefDef(toString,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Apply(Select(Super(This(SubItem3$),Function2),toString),List())), DefDef(apply,List(),List(List(ValDef(jclassName,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],EmptyTree), ValDef(jclassBytes,TypeTree[RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3$)),scala$Function2$$R)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)]),<init>),List(Ident(jclassName), Ident(jclassBytes)))), DefDef(unapply,List(),List(List(ValDef(x$1,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],Ident(x$1)), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$SubItem3$$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), TypeDef(Item3,Template(DefDef(<init>,List(),List(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), ValDef(mirror,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), ValDef(plain,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), ValDef(bean,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), ValDef(outFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List()), TypeTree[RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Product5), scala$Product5$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | -815445622), scala$Product5$$T2, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)) | 119853890), scala$Product5$$T3, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)) | -1748713208), scala$Product5$$T4, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)) | -1295380227), scala$Product5$$T5, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)) | 1895018947)]),ValDef(_,EmptyTree,EmptyTree),List(DefDef(productIterator,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,collection)),Iterator), scala$collection$Iterator$$A, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | 518396976)],Select(Super(This(Item3),Product),productIterator)), DefDef(productArity,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Select(Super(This(Item3),Product5),productArity)), DefDef(productElement,List(),List(List(ValDef(n,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],Apply(Select(Super(This(Item3),Product5),productElement),List(Ident(n)))), DefDef(arrivalPos,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), DefDef(mirror,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), DefDef(plain,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), DefDef(bean,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), DefDef(outFolder,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)],EmptyTree), DefDef(isPoison,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(),Apply(Select(Ident(arrivalPos),$eq$eq),List(Literal(Constant(2147483647)))))), DefDef(copy,List(),List(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), ValDef(mirror,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), ValDef(plain,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), ValDef(bean,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), ValDef(outFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)]),<init>),List(Ident(arrivalPos), Ident(mirror), Ident(plain), Ident(bean), Ident(outFolder)))), DefDef(copy$default$1,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int))],Typed(Ident(arrivalPos),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int))])), DefDef(copy$default$2,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3))],Typed(Ident(mirror),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3))])), DefDef(copy$default$3,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3))],Typed(Ident(plain),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3))])), DefDef(copy$default$4,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3))],Typed(Ident(bean),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3))])), DefDef(copy$default$5,List(),List(),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile))],Typed(Ident(outFolder),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,unchecked)),uncheckedVariance)]),<init>),List())),TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile))])), DefDef(isDefined,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Literal(Constant(true))), DefDef(_1,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)),scala$Product5$$T1)],Select(This(),arrivalPos)), DefDef(_2,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)),scala$Product5$$T2)],Select(This(),mirror)), DefDef(_3,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)),scala$Product5$$T3)],Select(This(),plain)), DefDef(_4,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)),scala$Product5$$T4)],Select(This(),bean)), DefDef(_5,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)),scala$Product5$$T5)],Select(This(),outFolder)), DefDef(hashCode,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Block(List(ValDef(acc,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Literal(Constant(-889275714))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Ident(arrivalPos)))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(mirror)))))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(plain)))))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(bean)))))), Assign(Ident(acc),Apply(Ident(mix),List(Ident(acc), Apply(Ident(anyHash),List(Ident(outFolder))))))),Apply(Ident(finalizeHash),List(Ident(acc), Literal(Constant(5)))))), DefDef(equals,List(),List(List(ValDef(x$0,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Apply(Select(Apply(Select(This(Item3),eq),List(TypeApply(Select(Ident(x$0),asInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)])))),$bar$bar),List(Block(List(ValDef(selector14,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],Ident(x$0))),Block(List(DefDef(case71,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(DefDef(case81,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(DefDef(matchFail41,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector14))))))),If(TypeApply(Select(Ident(selector14),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)])),Block(List(),Literal(Constant(false))),Apply(Ident(matchFail41),List()))))),If(TypeApply(Select(Ident(selector14),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)])),Block(List(ValDef(x$0,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)],TypeApply(Select(Ident(selector14),asInstanceOf),List(TypeTree[TermRef(NoPrefix,x$0)])))),Block(List(),Apply(Select(Apply(Select(Apply(Select(Apply(Select(Apply(Select(Select(This(Item3),arrivalPos),$eq$eq),List(Select(Ident(x$0),arrivalPos))),$amp$amp),List(Apply(Select(Select(This(Item3),mirror),$eq$eq),List(Select(Ident(x$0),mirror))))),$amp$amp),List(Apply(Select(Select(This(Item3),plain),$eq$eq),List(Select(Ident(x$0),plain))))),$amp$amp),List(Apply(Select(Select(This(Item3),bean),$eq$eq),List(Select(Ident(x$0),bean))))),$amp$amp),List(Apply(Select(Select(This(Item3),outFolder),$eq$eq),List(Select(Ident(x$0),outFolder))))))),Apply(Ident(case81),List()))))),Apply(Ident(case71),List())))))), DefDef(toString,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Apply(Ident(_toString),List(This(Item3)))), DefDef(canEqual,List(),List(List(ValDef(that,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],TypeApply(Select(Ident(that),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)]))), DefDef(productPrefix,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Literal(Constant(Item3))), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$Item3$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), DefDef(Item3,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)]),<init>),List())), TypeDef(Item3$,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List()), TypeTree[RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function5), scala$Function5$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | 912401177), scala$Function5$$T2, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)) | -458356155), scala$Function5$$T3, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)) | 2137139611), scala$Function5$$T4, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)) | 602238426), scala$Function5$$T5, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)) | 1272361243), scala$Function5$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)) | 1744964800)]),ValDef(_,TypeTree[TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)],EmptyTree),List(DefDef(curried,List(),List(),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$T1)) | -1146774176), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$T2)) | -741867784), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$T3)) | 1142745599), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$T4)) | 1103938026), scala$Function1$$R, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$T5)) | 1522340751), scala$Function1$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$R)) | -1889310538)) | -206926512)) | 600099324)) | 1675393744)) | -1646410906)],Select(Super(This(Item3$),Function5),curried)), DefDef(tupled,List(),List(),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Function1), scala$Function1$$T1, TypeAlias(RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple5), scala$Tuple5$$T1, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$T1)) | 79536007), scala$Tuple5$$T2, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$T2)) | 745234903), scala$Tuple5$$T3, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$T3)) | 1830041763), scala$Tuple5$$T4, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$T4)) | 471864000), scala$Tuple5$$T5, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$T5)) | -953875151)) | 2087027467), scala$Function1$$R, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$R)) | 1542848660)],Select(Super(This(Item3$),Function5),tupled)), DefDef(toString,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Apply(Select(Super(This(Item3$),Function5),toString),List())), DefDef(apply,List(),List(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],EmptyTree), ValDef(mirror,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), ValDef(plain,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), ValDef(bean,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), ValDef(outFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3$)),scala$Function5$$R)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)]),<init>),List(Ident(arrivalPos), Ident(mirror), Ident(plain), Ident(bean), Ident(outFolder)))), DefDef(unapply,List(),List(List(ValDef(x$1,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)],Ident(x$1)), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$Item3$$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), DefDef(i3comparator,List(),List(),TypeTree[RefinedType(TypeRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),java),util),Comparator), java$util$Comparator$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)) | 1654077814)],Block(List(TypeDef($anon,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List()), TypeTree[RefinedType(TypeRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),java),util),Comparator), java$util$Comparator$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)) | 1654077814)]),ValDef(_,EmptyTree,EmptyTree),List(DefDef(reversed,List(),List(List()),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),Comparator), java$util$Comparator$$T, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T)) | 1514510520)],Apply(Select(Super(This($anon),Comparator),reversed),List())), DefDef(thenComparing,List(),List(List(ValDef(x$0,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),Comparator), java$util$Comparator$$T, TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | -2066827180)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),Comparator), java$util$Comparator$$T, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T)) | 1514510520)],Apply(Select(Super(This($anon),Comparator),thenComparing),List(Ident(x$0)))), DefDef(thenComparing,List(TypeDef(U,TypeTree[TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Nothing), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any))])),List(List(ValDef(x$0,TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,function)),Function), java$util$function$Function$$T, TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | 1998084973), java$util$function$Function$$R, TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Nothing), TypeRef(NoPrefix,U)) | 1116869198)],EmptyTree), ValDef(x$1,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),Comparator), java$util$Comparator$$T, TypeBounds(TypeRef(NoPrefix,U), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | -737393257)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),Comparator), java$util$Comparator$$T, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T)) | 1514510520)],Apply(TypeApply(Select(Super(This($anon),Comparator),thenComparing),List(TypeTree[TypeRef(NoPrefix,U)])),List(Ident(x$0), Ident(x$1)))), DefDef(thenComparing,List(TypeDef(U,TypeTree[TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Nothing), RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,lang)),Comparable), java$lang$Comparable$$T, TypeBounds(LazyRef(TypeRef(NoPrefix,U)), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | 1845623216))])),List(List(ValDef(x$0,TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,function)),Function), java$util$function$Function$$T, TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | 1998084973), java$util$function$Function$$R, TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Nothing), TypeRef(NoPrefix,U)) | -1994289022)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),Comparator), java$util$Comparator$$T, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T)) | 1514510520)],Apply(TypeApply(Select(Super(This($anon),Comparator),thenComparing),List(TypeTree[TypeRef(NoPrefix,U)])),List(Ident(x$0)))), DefDef(thenComparingInt,List(),List(List(ValDef(x$0,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,function)),ToIntFunction), java$util$function$ToIntFunction$$T, TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | 1606716155)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),Comparator), java$util$Comparator$$T, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T)) | 1514510520)],Apply(Select(Super(This($anon),Comparator),thenComparingInt),List(Ident(x$0)))), DefDef(thenComparingLong,List(),List(List(ValDef(x$0,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,function)),ToLongFunction), java$util$function$ToLongFunction$$T, TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | -48502339)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),Comparator), java$util$Comparator$$T, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T)) | 1514510520)],Apply(Select(Super(This($anon),Comparator),thenComparingLong),List(Ident(x$0)))), DefDef(thenComparingDouble,List(),List(List(ValDef(x$0,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,function)),ToDoubleFunction), java$util$function$ToDoubleFunction$$T, TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any)) | -857067145)],EmptyTree))),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),Comparator), java$util$Comparator$$T, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,$anon)),java$util$Comparator$$T)) | 1514510520)],Apply(Select(Super(This($anon),Comparator),thenComparingDouble),List(Ident(x$0)))), DefDef(compare,List(),List(List(ValDef(a,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)],EmptyTree), ValDef(b,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Block(List(),If(Apply(Select(Select(Ident(a),arrivalPos),$less),List(Select(Ident(b),arrivalPos))),Literal(Constant(-1)),If(Apply(Select(Select(Ident(a),arrivalPos),$eq$eq),List(Select(Ident(b),arrivalPos))),Literal(Constant(0)),Literal(Constant(1))))))))), DefDef($anon,List(),List(),TypeTree[TypeRef(NoPrefix,$anon$)],Apply(Select(New(TypeTree[TypeRef(NoPrefix,$anon$)]),<init>),List())), TypeDef($anon$,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(NoPrefix,$anon$)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List())),ValDef(_,TypeTree[TermRef(NoPrefix,$anon)],EmptyTree),List()))),Typed(Apply(Select(New(TypeTree[TypeRef(NoPrefix,$anon)]),<init>),List()),TypeTree[RefinedType(TypeRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),java),util),Comparator), java$util$Comparator$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)) | 1654077814)]))), DefDef(poison3,List(),List(),TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3),scala$Function5$$R)],Apply(Select(Select(This(GenBCodePipeline),Item3),apply),List(Literal(Constant(2147483647)), Literal(Constant(null)), Literal(Constant(null)), Literal(Constant(null)), Literal(Constant(null))))), DefDef(q3,List(),List(),TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),PriorityQueue), java$util$PriorityQueue$$E, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)) | 396230505)],Apply(TypeApply(Select(New(TypeTree[RefinedType(TypeRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),java),util),PriorityQueue), java$util$PriorityQueue$$E, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)) | 1454819167)]),<init>),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)])),List(Literal(Constant(1000)), Select(This(GenBCodePipeline),i3comparator)))), TypeDef(Worker1,Template(DefDef(<init>,List(),List(List(ValDef(needsOutFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Boolean)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List())),ValDef(_,EmptyTree,EmptyTree),List(ValDef(needsOutFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Boolean)],EmptyTree), DefDef(caseInsensitively,List(),List(),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,mutable)),Map), scala$collection$mutable$Map$$A, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)) | -1710795116), scala$collection$mutable$Map$$B, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)) | -293514590)],TypeApply(Select(Select(Select(Select(Ident(scala),collection),mutable),Map),empty),List(TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)], TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),Symbol)]))), DefDef(run,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Unit)],Block(List(),Block(List(DefDef(while$,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(Block(List(ValDef(item,TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),q1),java$util$LinkedList$$E)],Apply(Select(Select(This(GenBCodePipeline),q1),poll),List()))),If(Select(Ident(item),isPoison),Block(List(Apply(Select(Select(This(GenBCodePipeline),q2),add),List(Select(This(GenBCodePipeline),poison2)))),Return(Literal(Constant(())),Ident(run))),Block(List(),Try(Block(List(),Apply(Select(This(Worker1),visit),List(Ident(item)))),List(CaseDef(Bind(ex1,Ident(_)),EmptyTree,Block(List(ValDef(selector15,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Throwable)],Ident(ex1))),Block(List(DefDef(case91,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(case101,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(matchFail51,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector15))))))),Block(List(),Apply(Ident(throw),List(Ident(ex1))))))),If(Apply(Select(Ident(selector15),ne),List(Literal(Constant(null)))),Block(List(ValDef(ex,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),package),Throwable)],TypeApply(Select(Ident(selector15),asInstanceOf),List(TypeTree[TermRef(NoPrefix,ex)])))),Block(List(),Block(List(Apply(Select(Ident(ex),printStackTrace),List())),Apply(Select(Select(This(GenBCodePipeline),ctx),error),List(Apply(TypeApply(Ident($lessdummy$minusapply$greater),List(TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)])),List(Block(List(DefDef($anonfun,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Apply(Select(Apply(Select(Ident(StringContext),apply),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)])),List(JavaSeqLiteral(List(Literal(Constant(Error while emitting )), Literal(Constant(\n)), Literal(Constant()))))))),s),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)])),List(JavaSeqLiteral(List(Block(List(),Apply(Select(Select(This(GenBCodePipeline),int),sourceFileFor),List(Select(Ident(item),cunit)))), Block(List(),Apply(Select(Ident(ex),getMessage),List())))))))))),Closure(List(),Ident($anonfun),EmptyTree)))), Select(Select(This(GenBCodePipeline),ctx),error$default$2)))))),Apply(Ident(case101),List()))))),Apply(Ident(case91),List()))))),EmptyTree))))),Apply(Ident(while$),List())))),Apply(Ident(while$),List())))), DefDef(visit,List(),List(List(ValDef(item,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(ValDef($2$,TypeTree[RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple3), scala$Tuple3$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | -910750291), scala$Tuple3$$T2, TypeAlias(RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,ast)),Trees),TypeDef), dotty$tools$dotc$ast$Trees$TypeDef$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),tpd$)),dotty$tools$dotc$ast$Trees$Instance$$T)) | -1589561092)) | 1988336043), scala$Tuple3$$T3, TypeAlias(TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)) | 382819972)],Block(List(ValDef(selector16,TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),unchecked)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1))],Typed(Ident(item),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),unchecked)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1))]))),Block(List(DefDef(case111,List(),List(List()),TypeTree[RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple3), scala$Tuple3$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | -910750291), scala$Tuple3$$T2, TypeAlias(RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,ast)),Trees),TypeDef), dotty$tools$dotc$ast$Trees$TypeDef$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),tpd$)),dotty$tools$dotc$ast$Trees$Instance$$T)) | -1589561092)) | 1988336043), scala$Tuple3$$T3, TypeAlias(TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)) | 382819972)],Block(List(DefDef(matchFail61,List(),List(List()),TypeTree[RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple3), scala$Tuple3$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | -910750291), scala$Tuple3$$T2, TypeAlias(RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,ast)),Trees),TypeDef), dotty$tools$dotc$ast$Trees$TypeDef$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),tpd$)),dotty$tools$dotc$ast$Trees$Instance$$T)) | -1589561092)) | 1988336043), scala$Tuple3$$T3, TypeAlias(TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)) | 382819972)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector16))))))),Block(List(ValDef(x21,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)],Apply(Select(Select(This(GenBCodePipeline),Item1),unapply),List(Ident(selector16))))),Block(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],Select(Ident(x21),_1)), ValDef(cd,TypeTree[RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,ast)),Trees),TypeDef), dotty$tools$dotc$ast$Trees$TypeDef$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),tpd$)),dotty$tools$dotc$ast$Trees$Instance$$T)) | -1589561092)],Select(Ident(x21),_2)), ValDef(cunit,TypeTree[TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit)],Select(Ident(x21),_3))),Block(List(),Apply(TypeApply(Select(Ident(Tuple3),apply),List(TypeTree[TypeVar(PolyParam(scala$Tuple3$apply$$T1) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int))], TypeTree[TypeVar(PolyParam(scala$Tuple3$apply$$T2) -> RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,ast)),Trees),TypeDef), dotty$tools$dotc$ast$Trees$TypeDef$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),tpd$)),dotty$tools$dotc$ast$Trees$Instance$$T)) | -1589561092))], TypeTree[TypeVar(PolyParam(scala$Tuple3$apply$$T3) -> TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),CompilationUnit))])),List(Ident(arrivalPos), Ident(cd), Ident(cunit))))))))),Apply(Ident(case111),List())))), ValDef(arrivalPos,TypeTree[TypeRef(TermRef(NoPrefix,$2$),scala$Tuple3$$T1)],Select(Ident($2$),_1)), ValDef(cd,TypeTree[TypeRef(TermRef(NoPrefix,$2$),scala$Tuple3$$T2)],Select(Ident($2$),_2)), ValDef(cunit,TypeTree[TypeRef(TermRef(NoPrefix,$2$),scala$Tuple3$$T3)],Select(Ident($2$),_3)), ValDef(claszSymbol,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Symbols),Symbol)],Apply(Select(Ident(cd),symbol),List(Select(This(GenBCodePipeline),ctx)))), ValDef(mirrorC,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,tree)),ClassNode)],If(Select(Apply(Select(Select(This(GenBCodePipeline),int),symHelper),List(Ident(claszSymbol))),isTopLevelModuleClass),Block(List(),If(Apply(Select(Apply(Select(Apply(Apply(Ident(toDenot),List(Ident(claszSymbol))),List(Select(This(GenBCodePipeline),ctx))),companionClass),List(Select(This(GenBCodePipeline),ctx))),$eq$eq),List(Ident(NoSymbol))),Block(List(),Apply(Select(Select(This(GenBCodePipeline),mirrorCodeGen),genMirrorClass),List(Ident(claszSymbol), Ident(cunit)))),Block(List(Apply(Select(Select(This(GenBCodePipeline),ctx),log),List(Apply(TypeApply(Ident($lessdummy$minusapply$greater),List(TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)])),List(Block(List(DefDef($anonfun,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Apply(Select(Apply(Select(Ident(StringContext),apply),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)])),List(JavaSeqLiteral(List(Literal(Constant(No mirror class for module with linked class: )), Literal(Constant()))))))),s),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Names),Name)])),List(JavaSeqLiteral(List(Block(List(),Apply(Select(Apply(Apply(Ident(toDenot),List(Ident(claszSymbol))),List(Select(This(GenBCodePipeline),ctx))),fullName),List(Select(This(GenBCodePipeline),ctx)))))))))))),Closure(List(),Ident($anonfun),EmptyTree)))), Select(Select(This(GenBCodePipeline),ctx),log$default$2)))),Literal(Constant(null))))),Literal(Constant(null)))), ValDef(pcb,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),PlainClassBuilder)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),PlainClassBuilder)]),<init>),List(Ident(cunit)))), Apply(Select(Ident(pcb),genPlainClass),List(Ident(cd))), ValDef(outF,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),io),package),AbstractFile)],If(Ident(needsOutFolder),Apply(Select(This(GenBCodePipeline),getOutFolder),List(Ident(claszSymbol), Select(Ident(pcb),thisName))),Literal(Constant(null)))), ValDef(plainC,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,tree)),ClassNode)],Select(Ident(pcb),cnode)), If(Select(Ident(claszSymbol),isClass),Apply(TypeApply(Select(Apply(Select(Select(Select(Select(This(GenBCodePipeline),ctx),compilationUnit),picklers),get),List(Select(Ident(claszSymbol),asClass))),foreach),List(TypeTree[TypeVar(PolyParam(scala$Option$foreach$$U) -> TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit))])),List(Block(List(DefDef($anonfun,List(),List(List(ValDef(pickler,TypeTree[TypeRef(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),Map), scala$collection$immutable$Map$$A, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),core),Symbols),ClassSymbol)) | -473680749), scala$collection$immutable$Map$$B, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,tasty)),TastyPickler)) | -581248127),scala$collection$MapLike$$B)],EmptyTree))),TypeTree[TypeVar(PolyParam(scala$Option$foreach$$U) -> TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit))],Block(List(ValDef(binary,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Array), scala$Array$$T, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Byte)) | 150471801)],Apply(Select(Ident(pickler),assembleParts),List())), ValDef(dataAttr,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,asm)),CustomAttr)],Apply(Select(New(TypeTree[TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),CustomAttr)]),<init>),List(Apply(Select(Select(Ident(nme),TASTYATTR),toString),List()), Ident(binary))))),Apply(Select(If(Apply(Select(Ident(mirrorC),ne),List(Literal(Constant(null)))),Ident(mirrorC),Ident(plainC)),visitAttribute),List(Ident(dataAttr)))))),Closure(List(),Ident($anonfun),EmptyTree)))),Literal(Constant(()))), ValDef(beanC,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,tree)),ClassNode)],If(Apply(Apply(Select(Apply(Apply(Ident(toDenot),List(Ident(claszSymbol))),List(Select(This(GenBCodePipeline),ctx))),hasAnnotation),List(Select(Select(This(GenBCodePipeline),int),BeanInfoAttr))),List(Select(This(GenBCodePipeline),ctx))),Block(List(),Apply(Select(Select(This(GenBCodePipeline),beanInfoCodeGen),genBeanInfoClass),List(Ident(claszSymbol), Ident(cunit), Select(Apply(Select(Select(This(GenBCodePipeline),int),symHelper),List(Ident(claszSymbol))),fieldSymbols), Select(Apply(Select(Select(This(GenBCodePipeline),int),symHelper),List(Ident(claszSymbol))),methodSymbols)))),Literal(Constant(null)))), ValDef(item2,TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2),scala$Function5$$R)],Apply(Select(Select(This(GenBCodePipeline),Item2),apply),List(Ident(arrivalPos), Ident(mirrorC), Ident(plainC), Ident(beanC), Ident(outF))))),Apply(Select(Select(This(GenBCodePipeline),q2),add),List(Ident(item2))))), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$Worker1$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), DefDef(Worker1,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Worker1$)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Worker1$)]),<init>),List())), TypeDef(Worker1$,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Worker1$)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List())),ValDef(_,TypeTree[TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Worker1)],EmptyTree),List())), TypeDef(Worker2,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List())),ValDef(_,EmptyTree,EmptyTree),List(DefDef(localOpt,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,opt)),LocalOpt)],Apply(Select(New(TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),backend),jvm),opt),LocalOpt)]),<init>),List(Apply(Select(New(TypeTree[TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),Settings)]),<init>),List())))), DefDef(localOptimizations,List(),List(List(ValDef(classNode,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree))),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Unit)],Block(List(),Block(List(Apply(Select(Select(This(Worker2),localOpt),methodOptimizations),List(Ident(classNode)))),Literal(Constant(()))))), DefDef(run,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Unit)],Block(List(),Block(List(DefDef(while$,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(Block(List(ValDef(item,TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),q2),java$util$LinkedList$$E)],Apply(Select(Select(This(GenBCodePipeline),q2),poll),List()))),If(Select(Ident(item),isPoison),Block(List(Apply(Select(Select(This(GenBCodePipeline),q3),add),List(Select(This(GenBCodePipeline),poison3)))),Return(Literal(Constant(())),Ident(run))),Block(List(),Try(Block(List(Apply(Select(This(Worker2),localOptimizations),List(Select(Ident(item),plain)))),Apply(Select(This(Worker2),addToQ3),List(Ident(item)))),List(CaseDef(Bind(ex2,Ident(_)),EmptyTree,Block(List(ValDef(selector17,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Throwable)],Ident(ex2))),Block(List(DefDef(case121,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(case131,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(matchFail71,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector17))))))),Block(List(),Apply(Ident(throw),List(Ident(ex2))))))),If(Apply(Select(Ident(selector17),ne),List(Literal(Constant(null)))),Block(List(ValDef(ex,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),package),Throwable)],TypeApply(Select(Ident(selector17),asInstanceOf),List(TypeTree[TermRef(NoPrefix,ex)])))),Block(List(),Block(List(Apply(Select(Ident(ex),printStackTrace),List())),Apply(Select(Select(This(GenBCodePipeline),ctx),error),List(Apply(TypeApply(Ident($lessdummy$minusapply$greater),List(TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)])),List(Block(List(DefDef($anonfun,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Apply(Select(Apply(Select(Ident(StringContext),apply),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)])),List(JavaSeqLiteral(List(Literal(Constant(Error while emitting )), Literal(Constant(\n)), Literal(Constant()))))))),s),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)])),List(JavaSeqLiteral(List(Block(List(),Select(Select(Ident(item),plain),name)), Block(List(),Apply(Select(Ident(ex),getMessage),List())))))))))),Closure(List(),Ident($anonfun),EmptyTree)))), Select(Select(This(GenBCodePipeline),ctx),error$default$2)))))),Apply(Ident(case131),List()))))),Apply(Ident(case121),List()))))),EmptyTree))))),Apply(Ident(while$),List())))),Apply(Ident(while$),List())))), DefDef(addToQ3,List(),List(List(ValDef(item,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(DefDef(getByteArray,List(),List(List(ValDef(cn,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],EmptyTree))),TypeTree[RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)],Block(List(ValDef(cw,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),CClassWriter)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),CClassWriter)]),<init>),List(Select(This(GenBCodePipeline),extraProc)))), Apply(Select(Ident(cn),accept),List(Ident(cw)))),Apply(Select(Ident(cw),toByteArray),List()))), ValDef($3$,TypeTree[RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple5), scala$Tuple5$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | 2117889751), scala$Tuple5$$T2, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | -1247754157), scala$Tuple5$$T3, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | -1992452537), scala$Tuple5$$T4, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | 1828096881), scala$Tuple5$$T5, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,io)),AbstractFile)) | -2047031406)],Block(List(ValDef(selector18,TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),unchecked)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2))],Typed(Ident(item),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),unchecked)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2))]))),Block(List(DefDef(case141,List(),List(List()),TypeTree[RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple5), scala$Tuple5$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | 2117889751), scala$Tuple5$$T2, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | -1247754157), scala$Tuple5$$T3, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | -1992452537), scala$Tuple5$$T4, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | 1828096881), scala$Tuple5$$T5, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,io)),AbstractFile)) | -2047031406)],Block(List(DefDef(matchFail81,List(),List(List()),TypeTree[RefinedType(RefinedType(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple5), scala$Tuple5$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)) | 2117889751), scala$Tuple5$$T2, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | -1247754157), scala$Tuple5$$T3, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | -1992452537), scala$Tuple5$$T4, TypeAlias(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)) | 1828096881), scala$Tuple5$$T5, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,io)),AbstractFile)) | -2047031406)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector18))))))),Block(List(ValDef(x22,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)],Apply(Select(Select(This(GenBCodePipeline),Item2),unapply),List(Ident(selector18))))),Block(List(ValDef(arrivalPos,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)],Select(Ident(x22),_1)), ValDef(mirror,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],Select(Ident(x22),_2)), ValDef(plain,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],Select(Ident(x22),_3)), ValDef(bean,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode)],Select(Ident(x22),_4)), ValDef(outFolder,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,io)),AbstractFile)],Select(Ident(x22),_5))),Block(List(),Apply(TypeApply(Select(Ident(Tuple5),apply),List(TypeTree[TypeVar(PolyParam(scala$Tuple5$apply$$T1) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int))], TypeTree[TypeVar(PolyParam(scala$Tuple5$apply$$T2) -> TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode))], TypeTree[TypeVar(PolyParam(scala$Tuple5$apply$$T3) -> TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode))], TypeTree[TypeVar(PolyParam(scala$Tuple5$apply$$T4) -> TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),asm),tree),ClassNode))], TypeTree[TypeVar(PolyParam(scala$Tuple5$apply$$T5) -> TypeRef(ThisType(TypeRef(NoPrefix,io)),AbstractFile))])),List(Ident(arrivalPos), Ident(mirror), Ident(plain), Ident(bean), Ident(outFolder))))))))),Apply(Ident(case141),List())))), ValDef(arrivalPos,TypeTree[TypeRef(TermRef(NoPrefix,$3$),scala$Tuple5$$T1)],Select(Ident($3$),_1)), ValDef(mirror,TypeTree[TypeRef(TermRef(NoPrefix,$3$),scala$Tuple5$$T2)],Select(Ident($3$),_2)), ValDef(plain,TypeTree[TypeRef(TermRef(NoPrefix,$3$),scala$Tuple5$$T3)],Select(Ident($3$),_3)), ValDef(bean,TypeTree[TypeRef(TermRef(NoPrefix,$3$),scala$Tuple5$$T4)],Select(Ident($3$),_4)), ValDef(outFolder,TypeTree[TypeRef(TermRef(NoPrefix,$3$),scala$Tuple5$$T5)],Select(Ident($3$),_5)), ValDef(mirrorC,TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3),scala$Function2$$R)],If(Apply(Select(Ident(mirror),$eq$eq),List(Literal(Constant(null)))),Literal(Constant(null)),Apply(Select(Select(This(GenBCodePipeline),SubItem3),apply),List(Select(Ident(mirror),name), Apply(Ident(getByteArray),List(Ident(mirror))))))), ValDef(plainC,TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3),scala$Function2$$R)],Apply(Select(Select(This(GenBCodePipeline),SubItem3),apply),List(Select(Ident(plain),name), Apply(Ident(getByteArray),List(Ident(plain)))))), ValDef(beanC,TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3),scala$Function2$$R)],If(Apply(Select(Ident(bean),$eq$eq),List(Literal(Constant(null)))),Literal(Constant(null)),Apply(Select(Select(This(GenBCodePipeline),SubItem3),apply),List(Select(Ident(bean),name), Apply(Ident(getByteArray),List(Ident(bean))))))), If(Apply(Select(Literal(Constant(false)),$amp$amp),List(Apply(Select(Select(Ident(plain),name),contains),List(Literal(Constant()))))),Block(List(If(Select(Apply(Select(Ident(mirrorC),$eq$eq),List(Literal(Constant(null)))),unary_$bang),Apply(Select(Ident(AsmUtils),traceClass),List(Select(Ident(mirrorC),jclassBytes))),Literal(Constant(()))), Apply(Select(Ident(AsmUtils),traceClass),List(Select(Ident(plainC),jclassBytes)))),If(Select(Apply(Select(Ident(beanC),$eq$eq),List(Literal(Constant(null)))),unary_$bang),Apply(Select(Ident(AsmUtils),traceClass),List(Select(Ident(beanC),jclassBytes))),Literal(Constant(())))),Literal(Constant(())))),Apply(Select(Select(This(GenBCodePipeline),q3),add),List(Apply(Select(Select(This(GenBCodePipeline),Item3),apply),List(Ident(arrivalPos), Ident(mirrorC), Ident(plainC), Ident(beanC), Ident(outFolder))))))), DefDef($outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree), DefDef(dotty$tools$backend$jvm$GenBCodePipeline$Worker2$$$outer,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],Ident($outer))))), DefDef(Worker2,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Worker2$)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Worker2$)]),<init>),List())), TypeDef(Worker2$,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Worker2$)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List())),ValDef(_,TypeTree[TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Worker2)],EmptyTree),List())), DefDef(arrivalPos,List(),List(),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Literal(Constant(0))), DefDef(arrivalPos_$eq,List(),List(List(ValDef(x$1,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Literal(Constant(()))), DefDef(run,List(),List(List(ValDef(t,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),Tree)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(Apply(Select(This(),tree_$eq),List(Ident(t))), Apply(Select(This(GenBCodePipeline),arrivalPos_$eq),List(Literal(Constant(0)))), Apply(Select(Select(This(GenBCodePipeline),bTypes),intializeCoreBTypes),List()), Apply(Select(This(GenBCodePipeline),bytecodeWriter_$eq),List(Apply(Select(This(GenBCodePipeline),initBytecodeWriter),List(Ident(entryPoints))))), Apply(Select(This(GenBCodePipeline),mirrorCodeGen_$eq),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),JMirrorBuilder)]),<init>),List()))), Apply(Select(This(GenBCodePipeline),beanInfoCodeGen_$eq),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),JBeanInfoBuilder)]),<init>),List()))), ValDef(needsOutfileForSymbol,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],TypeApply(Select(Select(This(GenBCodePipeline),bytecodeWriter),isInstanceOf),List(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),ClassBytecodeWriter)]))), Apply(Select(This(GenBCodePipeline),buildAndSendToDisk),List(Ident(needsOutfileForSymbol)))),Apply(Select(Select(This(GenBCodePipeline),bytecodeWriter),close),List()))), DefDef(buildAndSendToDisk,List(),List(List(ValDef(needsOutFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Boolean)],EmptyTree))),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(Apply(Select(This(GenBCodePipeline),feedPipeline1),List()), Apply(Select(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Worker1)]),<init>),List(Ident(needsOutFolder))),run),List()), Apply(Select(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Worker2)]),<init>),List()),run),List())),Apply(Select(This(GenBCodePipeline),drainQ3),List()))), DefDef(feedPipeline1,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Block(List(DefDef(gen,List(),List(List(ValDef(tree,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),Tree)],EmptyTree))),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Unit)],Block(List(),Block(List(ValDef(selector19,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),Tree)],Ident(tree))),Block(List(DefDef(case151,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(case161,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(case171,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(case181,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(matchFail91,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector19))))))),If(TypeApply(Select(Ident(selector19),isInstanceOf),List(TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),TypeDef)])),Block(List(ValDef(cd,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),TypeDef)],TypeApply(Select(Ident(selector19),asInstanceOf),List(TypeTree[TermRef(NoPrefix,cd)])))),Block(List(),Block(List(Apply(Select(Select(This(GenBCodePipeline),q1),add),List(Apply(Select(Select(This(GenBCodePipeline),Item1),apply),List(Select(This(GenBCodePipeline),arrivalPos), Ident(cd), Select(Ident(int),currentUnit)))))),Apply(Select(This(GenBCodePipeline),arrivalPos_$eq),List(Apply(Select(Select(This(GenBCodePipeline),arrivalPos),$plus),List(Literal(Constant(1))))))))),Apply(Ident(matchFail91),List()))))),If(TypeApply(Select(Ident(selector19),isInstanceOf),List(TypeTree[RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),ValDef), dotty$tools$dotc$ast$Trees$ValDef$$T, TypeAlias(TypeVar(PolyParam(dotty$tools$dotc$ast$Trees$ValDef$unapply$$T) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type))) | 1655136115)])),Block(List(ValDef(x61,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),ValDef), dotty$tools$dotc$ast$Trees$ValDef$$T, TypeAlias(TypeVar(PolyParam(dotty$tools$dotc$ast$Trees$ValDef$unapply$$T) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type))) | 1655136115)],TypeApply(Select(Ident(selector19),asInstanceOf),List(TypeTree[RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),ValDef), dotty$tools$dotc$ast$Trees$ValDef$$T, TypeAlias(TypeVar(PolyParam(dotty$tools$dotc$ast$Trees$ValDef$unapply$$T) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type))) | 1655136115)])))),Block(List(ValDef(o81,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Option), scala$Option$$A, TypeAlias(RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple3), scala$Tuple3$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Names),TermName)) | -1235339982), scala$Tuple3$$T2, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),Tree), dotty$tools$dotc$ast$Trees$Tree$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type)) | -1512994206)) | -1860301830), scala$Tuple3$$T3, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),LazyTree)) | 913602918)) | -1536427974)],Apply(TypeApply(Select(Ident(ValDef),unapply),List(TypeTree[TypeVar(PolyParam(dotty$tools$dotc$ast$Trees$ValDef$unapply$$T) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type))])),List(TypeApply(Select(Ident(selector19),asInstanceOf),List(TypeTree[RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),ValDef), dotty$tools$dotc$ast$Trees$ValDef$$T, TypeAlias(TypeVar(PolyParam(dotty$tools$dotc$ast$Trees$ValDef$unapply$$T) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type))) | 1655136115)])))))),If(Select(Ident(o81),isDefined),Block(List(ValDef(x71,TypeTree[RefinedType(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple3), scala$Tuple3$$T1, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Names),TermName)) | -1235339982), scala$Tuple3$$T2, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),Tree), dotty$tools$dotc$ast$Trees$Tree$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type)) | -1512994206)) | -1860301830), scala$Tuple3$$T3, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),LazyTree)) | 913602918)],Select(Ident(o81),get))),Block(List(),Block(List(),Literal(Constant(()))))),Apply(Ident(case181),List())))),Apply(Ident(case181),List()))))),If(TypeApply(Select(Ident(selector19),isInstanceOf),List(TypeTree[RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),PackageDef), dotty$tools$dotc$ast$Trees$PackageDef$$T, TypeAlias(TypeVar(PolyParam(dotty$tools$dotc$ast$Trees$PackageDef$unapply$$T) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type))) | -655897893)])),Block(List(ValDef(x31,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),PackageDef), dotty$tools$dotc$ast$Trees$PackageDef$$T, TypeAlias(TypeVar(PolyParam(dotty$tools$dotc$ast$Trees$PackageDef$unapply$$T) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type))) | -655897893)],TypeApply(Select(Ident(selector19),asInstanceOf),List(TypeTree[RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),PackageDef), dotty$tools$dotc$ast$Trees$PackageDef$$T, TypeAlias(TypeVar(PolyParam(dotty$tools$dotc$ast$Trees$PackageDef$unapply$$T) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type))) | -655897893)])))),Block(List(ValDef(o91,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Option), scala$Option$$A, TypeAlias(RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple2), scala$Tuple2$$T1, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),RefTree), dotty$tools$dotc$ast$Trees$RefTree$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type)) | 332939404)) | 606299871), scala$Tuple2$$T2, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),Tree), dotty$tools$dotc$ast$Trees$Tree$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type)) | -1512994206)) | 1199392834)) | 206167801)) | -1651148757)],Apply(TypeApply(Select(Ident(PackageDef),unapply),List(TypeTree[TypeVar(PolyParam(dotty$tools$dotc$ast$Trees$PackageDef$unapply$$T) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type))])),List(TypeApply(Select(Ident(selector19),asInstanceOf),List(TypeTree[RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),PackageDef), dotty$tools$dotc$ast$Trees$PackageDef$$T, TypeAlias(TypeVar(PolyParam(dotty$tools$dotc$ast$Trees$PackageDef$unapply$$T) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type))) | -655897893)])))))),If(Select(Ident(o91),isDefined),Block(List(ValDef(x41,TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple2), scala$Tuple2$$T1, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),RefTree), dotty$tools$dotc$ast$Trees$RefTree$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type)) | 332939404)) | 606299871), scala$Tuple2$$T2, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),Tree), dotty$tools$dotc$ast$Trees$Tree$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type)) | -1512994206)) | 1199392834)) | 206167801)],Select(Ident(o91),get))),Block(List(ValDef(stats,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,immutable)),List), scala$collection$immutable$List$$A, TypeAlias(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),Tree), dotty$tools$dotc$ast$Trees$Tree$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type)) | -1512994206)) | 1199392834)],Select(Ident(x41),_2))),Block(List(ValDef(p51,TypeTree[RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,ast)),Trees$)),RefTree), dotty$tools$dotc$ast$Trees$RefTree$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,core)),Types),Type)) | 332939404)],Select(Ident(x41),_1))),Block(List(),Apply(TypeApply(Select(Ident(stats),foreach),List(TypeTree[TypeVar(PolyParam(scala$collection$immutable$List$foreach$$U) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Unit))])),List(Block(List(DefDef($anonfun,List(),List(List(ValDef(tree,TypeTree[TypeRef(TermRef(NoPrefix,stats),scala$collection$immutable$List$$A)],EmptyTree))),TypeTree[TypeVar(PolyParam(scala$collection$immutable$List$foreach$$U) -> TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Unit))],Apply(Ident(gen),List(Ident(tree))))),Closure(List(),Ident($anonfun),EmptyTree)))))))),Apply(Ident(case171),List())))),Apply(Ident(case171),List()))))),If(Apply(Select(Ident(EmptyTree),$eq$eq),List(Ident(selector19))),Block(List(ValDef(x23,TypeTree[TermRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),EmptyTree)],TypeApply(Select(Ident(selector19),asInstanceOf),List(TypeTree[TermRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),dotty),tools),dotc),ast),tpd),EmptyTree)])))),Block(List(),Block(List(),Literal(Constant(()))))),Apply(Ident(case161),List()))))),Apply(Ident(case151),List()))))), Apply(Ident(gen),List(Select(This(GenBCodePipeline),tree)))),Apply(Select(Select(This(GenBCodePipeline),q1),add),List(Select(This(GenBCodePipeline),poison1))))), DefDef(drainQ3,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(sendToDisk,List(),List(List(ValDef(cfr,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],EmptyTree), ValDef(outFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)],EmptyTree))),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Unit)],Block(List(),If(Select(Apply(Select(Ident(cfr),$eq$eq),List(Literal(Constant(null)))),unary_$bang),Block(List(ValDef($1$,TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple2), scala$Tuple2$$T1, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)) | -1088993271), scala$Tuple2$$T2, TypeAlias(RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)) | 963539957)],Block(List(ValDef(selector110,TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),unchecked)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3))],Typed(Ident(cfr),TypeTree[AnnotatedType(ConcreteAnnotation(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),unchecked)]),<init>),List())),TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3))]))),Block(List(DefDef(case191,List(),List(List()),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple2), scala$Tuple2$$T1, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)) | -1088993271), scala$Tuple2$$T2, TypeAlias(RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)) | 963539957)],Block(List(DefDef(matchFail101,List(),List(List()),TypeTree[RefinedType(RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Tuple2), scala$Tuple2$$T1, TypeAlias(TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)) | -1088993271), scala$Tuple2$$T2, TypeAlias(RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)) | 963539957)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector110))))))),Block(List(ValDef(x24,TypeTree[TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),SubItem3)],Apply(Select(Select(This(GenBCodePipeline),SubItem3),unapply),List(Ident(selector110))))),Block(List(ValDef(jclassName,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)],Select(Ident(x24),_1)), ValDef(jclassBytes,TypeTree[RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309)],Select(Ident(x24),_2))),Block(List(),Apply(TypeApply(Select(Ident(Tuple2),apply),List(TypeTree[TypeVar(PolyParam(scala$Tuple2$apply$$T1) -> TypeRef(ThisType(TypeRef(NoPrefix,lang)),String))], TypeTree[TypeVar(PolyParam(scala$Tuple2$apply$$T2) -> RefinedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Array), scala$Array$$T, TypeAlias(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Byte)) | 143851309))])),List(Ident(jclassName), Ident(jclassBytes))))))))),Apply(Ident(case191),List())))), ValDef(jclassName,TypeTree[TypeRef(TermRef(NoPrefix,$1$),scala$Tuple2$$T1)],Select(Ident($1$),_1)), ValDef(jclassBytes,TypeTree[TypeRef(TermRef(NoPrefix,$1$),scala$Tuple2$$T2)],Select(Ident($1$),_2))),Try(Block(List(ValDef(outFile,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),io),package),AbstractFile)],If(Apply(Select(Ident(outFolder),$eq$eq),List(Literal(Constant(null)))),Literal(Constant(null)),Apply(Select(This(GenBCodePipeline),getFileForClassfile),List(Ident(outFolder), Ident(jclassName), Literal(Constant(.class))))))),Apply(Select(Select(This(GenBCodePipeline),bytecodeWriter),writeClass),List(Ident(jclassName), Ident(jclassName), Ident(jclassBytes), Ident(outFile)))),List(CaseDef(Bind(ex3,Ident(_)),EmptyTree,Block(List(ValDef(selector111,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Throwable)],Ident(ex3))),Block(List(DefDef(case201,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(case211,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Block(List(DefDef(matchFail111,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],Apply(Ident(throw),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),MatchError)]),<init>),List(Ident(selector111))))))),Block(List(),Apply(Ident(throw),List(Ident(ex3))))))),If(TypeApply(Select(Ident(selector111),isInstanceOf),List(TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),backend),jvm),FileConflictException)])),Block(List(ValDef(e,TypeTree[TypeRef(TermRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),tools),nsc),backend),jvm),FileConflictException)],TypeApply(Select(Ident(selector111),asInstanceOf),List(TypeTree[TermRef(NoPrefix,e)])))),Block(List(),Block(List(),Apply(Select(Ident(ctx),error),List(Apply(TypeApply(Ident($lessdummy$minusapply$greater),List(TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)])),List(Block(List(DefDef($anonfun,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Apply(Select(Apply(Select(Ident(StringContext),apply),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)])),List(JavaSeqLiteral(List(Literal(Constant(error writing )), Literal(Constant(: )), Literal(Constant()))))))),s),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)])),List(JavaSeqLiteral(List(Ident(jclassName), Block(List(),Apply(Select(Ident(e),getMessage),List())))))))))),Closure(List(),Ident($anonfun),EmptyTree)))), Select(Ident(ctx),error$default$2)))))),Apply(Ident(case211),List()))))),Apply(Ident(case201),List()))))),EmptyTree)),Literal(Constant(()))))), ValDef(moreComing,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Boolean)],Literal(Constant(true))), ValDef(expected,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Int)],Literal(Constant(0))), Block(List(DefDef(while$,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,scala)),Unit)],If(Ident(moreComing),Block(List(Block(List(ValDef(incoming,TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),q3),java$util$PriorityQueue$$E)],Apply(Select(Select(This(GenBCodePipeline),q3),poll),List())), Assign(Ident(moreComing),Select(Select(Ident(incoming),isPoison),unary_$bang))),If(Ident(moreComing),Block(List(ValDef(item,TypeTree[TypeRef(TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),q3),java$util$PriorityQueue$$E)],Ident(incoming)), ValDef(outFolder,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,io)),package),AbstractFile)],Select(Ident(item),outFolder)), Apply(Ident(sendToDisk),List(Select(Ident(item),mirror), Ident(outFolder))), Apply(Ident(sendToDisk),List(Select(Ident(item),plain), Ident(outFolder))), Apply(Ident(sendToDisk),List(Select(Ident(item),bean), Ident(outFolder)))),Assign(Ident(expected),Apply(Select(Ident(expected),$plus),List(Literal(Constant(1)))))),Literal(Constant(()))))),Apply(Ident(while$),List())),Literal(Constant(()))))),Apply(Ident(while$),List())), Apply(Ident(assert),List(Apply(Select(Select(This(GenBCodePipeline),q1),isEmpty),List()), Apply(TypeApply(Ident($lessdummy$minusapply$greater),List(TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)])),List(Block(List(DefDef($anonfun,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Apply(Select(Apply(Select(Ident(StringContext),apply),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)])),List(JavaSeqLiteral(List(Literal(Constant(Some ClassDefs remained in the first queue: )), Literal(Constant()))))))),s),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),LinkedList), java$util$LinkedList$$E, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item1)) | -96249307)])),List(JavaSeqLiteral(List(Select(This(GenBCodePipeline),q1))))))))),Closure(List(),Ident($anonfun),EmptyTree)))))), Apply(Ident(assert),List(Apply(Select(Select(This(GenBCodePipeline),q2),isEmpty),List()), Apply(TypeApply(Ident($lessdummy$minusapply$greater),List(TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)])),List(Block(List(DefDef($anonfun,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Apply(Select(Apply(Select(Ident(StringContext),apply),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)])),List(JavaSeqLiteral(List(Literal(Constant(Some classfiles remained in the second queue: )), Literal(Constant()))))))),s),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),LinkedList), java$util$LinkedList$$E, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item2)) | 188580372)])),List(JavaSeqLiteral(List(Select(This(GenBCodePipeline),q2))))))))),Closure(List(),Ident($anonfun),EmptyTree))))))),Apply(Ident(assert),List(Apply(Select(Select(This(GenBCodePipeline),q3),isEmpty),List()), Apply(TypeApply(Ident($lessdummy$minusapply$greater),List(TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)])),List(Block(List(DefDef($anonfun,List(),List(List()),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,scala)),Predef),String)],Apply(Select(Apply(Select(Ident(StringContext),apply),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),String)])),List(JavaSeqLiteral(List(Literal(Constant(Some classfiles weren't written to disk: )), Literal(Constant()))))))),s),List(Apply(TypeApply(Select(Ident(Predef),wrapRefArray),List(TypeTree[RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,util)),PriorityQueue), java$util$PriorityQueue$$E, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)),Item3)) | 396230505)])),List(JavaSeqLiteral(List(Select(This(GenBCodePipeline),q3))))))))),Closure(List(),Ident($anonfun),EmptyTree))))))))))), ValDef(GenBCodePipeline,TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline$)],Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline$)]),<init>),List())), TypeDef(GenBCodePipeline$,Template(DefDef(<init>,List(),List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline$)],EmptyTree),List(Apply(Select(New(TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,lang)),Object)]),<init>),List())),ValDef(_,TypeTree[TermRef(ThisType(TypeRef(NoPrefix,jvm)),GenBCodePipeline)],EmptyTree),List()))))] of class class dotty.tools.dotc.ast.Trees$PackageDef # 7960
exception occurred while compiling ../src/dotty/tools/backend/jvm/GenBCode.scala
Exception in thread "main" java.lang.AssertionError: assertion failed: symbol (method companion$module) entered the scope of non-class owner type Select
	at scala.Predef$.assert(Predef.scala:165)
	at dotty.tools.dotc.core.Symbols$Symbol.entered(Symbols.scala:423)
	at dotty.tools.dotc.core.unpickleScala2.Scala2Unpickler$.registerCompanionPair$1(Scala2Unpickler.scala:132)
	at dotty.tools.dotc.core.unpickleScala2.Scala2Unpickler$.setClassInfo(Scala2Unpickler.scala:136)
	at dotty.tools.dotc.core.unpickleScala2.Scala2Unpickler$LocalUnpickler.dotty$tools$dotc$core$unpickleScala2$Scala2Unpickler$LocalUnpickler$$parseToCompletion$1(Scala2Unpickler.scala:544)
	at dotty.tools.dotc.core.unpickleScala2.Scala2Unpickler$LocalUnpickler$$anonfun$complete$1.apply$mcV$sp(Scala2Unpickler.scala:571)
	at dotty.tools.dotc.core.unpickleScala2.Scala2Unpickler$LocalUnpickler$$anonfun$complete$1.apply(Scala2Unpickler.scala:571)
	at dotty.tools.dotc.core.unpickleScala2.Scala2Unpickler$LocalUnpickler$$anonfun$complete$1.apply(Scala2Unpickler.scala:571)
	at dotty.tools.dotc.core.unpickleScala2.Scala2Unpickler.atReadPos(Scala2Unpickler.scala:327)
	at dotty.tools.dotc.core.unpickleScala2.Scala2Unpickler$LocalUnpickler.complete(Scala2Unpickler.scala:570)
	at dotty.tools.dotc.core.SymDenotations$SymDenotation.completeFrom(SymDenotations.scala:170)
	at dotty.tools.dotc.core.SymDenotations$SymDenotation.info(SymDenotations.scala:152)
	at dotty.tools.dotc.transform.TreeTransforms$AnnotationTransformer$class.transform(TreeTransform.scala:184)
	at dotty.tools.dotc.transform.FirstTransform.transform(FirstTransform.scala:30)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:621)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Symbols$Symbol.denot(Symbols.scala:381)
	at dotty.tools.dotc.core.Types$NamedType.denotOfSym(Types.scala:1346)
	at dotty.tools.dotc.core.Types$NamedType.computeDenot(Types.scala:1302)
	at dotty.tools.dotc.core.Types$NamedType.denotAt(Types.scala:1291)
	at dotty.tools.dotc.core.Types$NamedType.denot(Types.scala:1279)
	at dotty.tools.dotc.core.Types$NamedType.info(Types.scala:1454)
	at dotty.tools.dotc.core.TypeOps$class.needsChecking$1(TypeOps.scala:314)
	at dotty.tools.dotc.core.TypeOps$class.isVolatile(TypeOps.scala:333)
	at dotty.tools.dotc.core.Contexts$Context.isVolatile(Contexts.scala:53)
	at dotty.tools.dotc.core.SymDenotations$SymDenotation.isStable(SymDenotations.scala:514)
	at dotty.tools.dotc.transform.Getters.transformSym(Getters.scala:60)
	at dotty.tools.dotc.core.DenotTransformers$SymTransformer$class.transform(DenotTransformers.scala:66)
	at dotty.tools.dotc.transform.Getters.transform(Getters.scala:48)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:621)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:639)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Symbols$Symbol.denot(Symbols.scala:381)
	at dotty.tools.dotc.core.Symbols$Symbol.isType(Symbols.scala:400)
	at dotty.tools.dotc.core.TypeErasure$$anonfun$6.apply(TypeErasure.scala:367)
	at dotty.tools.dotc.core.TypeErasure$$anonfun$6.apply(TypeErasure.scala:367)
	at dotty.tools.dotc.core.Scopes$Scope$$anonfun$filteredScope$1.apply(Scopes.scala:133)
	at dotty.tools.dotc.core.Scopes$Scope$$anonfun$filteredScope$1.apply(Scopes.scala:132)
	at scala.collection.Iterator$class.foreach(Iterator.scala:750)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1202)
	at dotty.tools.dotc.core.Scopes$Scope.filteredScope(Scopes.scala:132)
	at dotty.tools.dotc.core.TypeErasure.dotty$tools$dotc$core$TypeErasure$$apply(TypeErasure.scala:367)
	at dotty.tools.dotc.core.TypeErasure.eraseInfo(TypeErasure.scala:398)
	at dotty.tools.dotc.core.TypeErasure$.transformInfo(TypeErasure.scala:177)
	at dotty.tools.dotc.transform.Erasure.transform(Erasure.scala:54)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.currentIfExists(Denotations.scala:621)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.current(Denotations.scala:657)
	at dotty.tools.dotc.core.Types$NamedType.computeDenot(Types.scala:1306)
	at dotty.tools.dotc.core.Types$NamedType.denotAt(Types.scala:1291)
	at dotty.tools.dotc.core.Types$NamedType.denot(Types.scala:1279)
	at dotty.tools.dotc.core.Types$NamedType.info(Types.scala:1454)
	at dotty.tools.dotc.core.Types$Type.isTightPrefix(Types.scala:134)
	at dotty.tools.dotc.core.Types$NamedType.computeDenot(Types.scala:1306)
	at dotty.tools.dotc.core.Types$NamedType.denotAt(Types.scala:1291)
	at dotty.tools.dotc.core.Types$NamedType.denot(Types.scala:1279)
	at dotty.tools.dotc.ast.Trees$DenotingTree.denot(Trees.scala:264)
	at dotty.tools.dotc.ast.Trees$ProxyTree.denot(Trees.scala:281)
	at dotty.tools.dotc.ast.Trees$Tree.symbol(Trees.scala:181)
	at dotty.tools.dotc.transform.Erasure$Typer.typedApply(Erasure.scala:420)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1040)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:91)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:1127)
	at dotty.tools.dotc.transform.Erasure$Typer$$anonfun$4.apply(Erasure.scala:429)
	at dotty.tools.dotc.transform.Erasure$Typer$$anonfun$4.apply(Erasure.scala:429)
	at dotty.tools.dotc.core.Decorators$ListDecorator$.zipWithConserve$extension(Decorators.scala:97)
	at dotty.tools.dotc.core.Decorators$ListDecorator$.zipWithConserve$extension(Decorators.scala:98)
	at dotty.tools.dotc.transform.Erasure$Typer.typedApply(Erasure.scala:429)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1040)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:91)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:1127)
	at dotty.tools.dotc.transform.Erasure$Typer.typedApply(Erasure.scala:422)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1040)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:91)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.transform.Erasure$Typer.typedSelect(Erasure.scala:377)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:1020)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1078)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:91)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:1127)
	at dotty.tools.dotc.transform.Erasure$Typer.typedApply(Erasure.scala:422)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1040)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:91)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:1118)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:1123)
	at dotty.tools.dotc.transform.Erasure$Typer.typedStats(Erasure.scala:546)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedBlock$1.apply(Typer.scala:447)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedBlock$1.apply(Typer.scala:445)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedBlock(Typer.scala:445)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1048)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:91)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:1127)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedDefDef$1.apply(Typer.scala:895)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedDefDef$1.apply(Typer.scala:888)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedDefDef(Typer.scala:888)
	at dotty.tools.dotc.transform.Erasure$Typer.typedDefDef(Erasure.scala:487)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:1028)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1078)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:91)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:1112)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:1123)
	at dotty.tools.dotc.transform.Erasure$Typer.typedStats(Erasure.scala:546)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedClassDef$1.apply(Typer.scala:924)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedClassDef$1.apply(Typer.scala:907)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedClassDef(Typer.scala:907)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:1031)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1078)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:91)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:1112)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:1123)
	at dotty.tools.dotc.transform.Erasure$Typer.typedStats(Erasure.scala:546)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedPackageDef$1.apply(Typer.scala:971)
	at dotty.tools.dotc.typer.Typer$$anonfun$typedPackageDef$1.apply(Typer.scala:962)
	at dotty.tools.dotc.util.Stats$.track(Stats.scala:36)
	at dotty.tools.dotc.typer.Typer.typedPackageDef(Typer.scala:962)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:1068)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:1080)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:91)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1090)
	at dotty.tools.dotc.typer.Typer$$anonfun$typed$2.apply(Typer.scala:1088)
	at dotty.tools.dotc.reporting.Reporting$class.traceIndented(Reporter.scala:148)
	at dotty.tools.dotc.core.Contexts$Context.traceIndented(Contexts.scala:53)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:1088)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:1127)
	at dotty.tools.dotc.transform.Erasure.run(Erasure.scala:72)
	at dotty.tools.dotc.core.Phases$Phase$$anonfun$runOn$1.apply(Phases.scala:271)
	at dotty.tools.dotc.core.Phases$Phase$$anonfun$runOn$1.apply(Phases.scala:269)
	at scala.collection.immutable.List.map(List.scala:273)
	at dotty.tools.dotc.core.Phases$Phase$class.runOn(Phases.scala:269)
	at dotty.tools.dotc.transform.Erasure.runOn(Erasure.scala:30)
	at dotty.tools.dotc.Run$$anonfun$compileUnits$1$$anonfun$apply$mcV$sp$1.apply(Run.scala:59)
	at dotty.tools.dotc.Run$$anonfun$compileUnits$1$$anonfun$apply$mcV$sp$1.apply(Run.scala:56)
	at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	at dotty.tools.dotc.Run$$anonfun$compileUnits$1.apply$mcV$sp(Run.scala:56)
	at dotty.tools.dotc.Run$$anonfun$compileUnits$1.apply(Run.scala:52)
	at dotty.tools.dotc.Run$$anonfun$compileUnits$1.apply(Run.scala:52)
	at dotty.tools.dotc.util.Stats$.monitorHeartBeat(Stats.scala:69)
	at dotty.tools.dotc.Run.compileUnits(Run.scala:52)
	at dotty.tools.dotc.Run.compileSources(Run.scala:49)
	at dotty.tools.dotc.Run.compile(Run.scala:33)
	at dotty.tools.dotc.Driver.doCompile(Driver.scala:21)
	at dotty.tools.dotc.Driver.process(Driver.scala:44)
	at dotty.tools.dotc.Driver.main(Driver.scala:48)
	at dotty.tools.dotc.Main.main(Main.scala)
```


after:
```
 ~/p/d/d/build fix-compiling-GenBCode: ! [14:10]> ../bin/dotc -print -verbose ../src//dotty/tools/backend/jvm/GenBCode.scala
new files detected. rebuilding
[info] Loading global plugins from /Users/svalaskevicius/.sbt/0.13/plugins
[info] Loading project definition from /Users/svalaskevicius/priv/dev/dotty/project
[info] Set current project to dotty (in build file:/Users/svalaskevicius/priv/dev/dotty/)
[info] Compiling 1 Scala source to /Users/svalaskevicius/priv/dev/dotty/target/scala-2.11/classes...
[info] Packaging /Users/svalaskevicius/priv/dev/dotty/target/scala-2.11/dotty_2.11-0.1-SNAPSHOT.jar ...
[info] Done packaging.
[success] Total time: 12 s, completed 25-Sep-2015 14:10:59
/Users/svalaskevicius/priv/dev/dotty/build
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$GenMapFactory$$CC; assuming they are invariant
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$MapFactory$$CC; assuming they are invariant
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$MutableMapFactory$$CC; assuming they are invariant
warning: cannot merge (module: BCodeBodyBuilder.this.int.Symbol)Unit with (tree: BCodeBodyBuilder.this.int.Tree)BCodeBodyBuilder.this.bTypes.BType as members of one type; keeping only (module: BCodeBodyBuilder.this.int.Symbol)Unit
warning: cannot merge (module: BCodeBodyBuilder.this.int.Symbol)Unit with (tree: BCodeBodyBuilder.this.int.Tree)BCodeBodyBuilder.this.bTypes.BType as members of one type; keeping only (module: BCodeBodyBuilder.this.int.Symbol)Unit
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[BCodeIdiomatic.this.bTypes.BType])
  Array[BCodeIdiomatic.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[BCodeIdiomatic.this.bTypes.BType])
  Array[BCodeIdiomatic.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[BCodeIdiomatic.this.bTypes.BType])
  Array[BCodeIdiomatic.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[Int])Array[Int] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[Int])Array[Int]
warning: cannot merge (xs: scala.collection.immutable.List[Int])Array[Int] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[Int])Array[Int]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[GenBCodePipeline.this.bTypes.BType])
  Array[GenBCodePipeline.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[GenBCodePipeline.this.bTypes.BType])
  Array[GenBCodePipeline.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[GenBCodePipeline.this.bTypes.BType])
  Array[GenBCodePipeline.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[Int])Array[Int] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[Int])Array[Int]
warning: cannot merge (xs: scala.collection.immutable.List[Int])Array[Int] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[Int])Array[Int]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[GenBCodePipeline.this.bTypes.BType])
  Array[GenBCodePipeline.this.bTypes.BType] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
warning: cannot merge (xs: scala.collection.immutable.List[Int])Array[Int] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[Int])Array[Int]
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$GenSetFactory$$CC; assuming they are invariant
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$SetFactory$$CC; assuming they are invariant
../src/dotty/tools/backend/jvm/GenBCode.scala:215: warning: cannot merge class PrefixSetting in class MutableSettings with type bounds <: ScalaSettings.super.Setting{T = scala.collection.immutable.List[String]} as members of one type; keeping only class PrefixSetting in class MutableSettings
      lazy val localOpt = new LocalOpt(new Settings())
                              ^
warning: failure to eliminate existential
original type    : TermRef(TypeRef(NoPrefix,_1103.type),s) forSome {_1103.type <:
  ScalaSettings.this.EnableSettings[ScalaSettings.this.BooleanSetting] &
    Singleton
reduces to       : TermRef(TypeRef(NoPrefix,_1103.type),s)
type used instead: TermRef(AndType(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,settings)),ScalaSettings)),EnableSettings), scala$tools$nsc$settings$MutableSettings$EnableSettings$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,settings)),ScalaSettings)),BooleanSetting)) | 1061723946),TypeRef(ThisType(TypeRef(NoPrefix,scala)),Singleton)),s)
proceed at own risk.
warning: failure to eliminate existential
original type    : TermRef(TypeRef(NoPrefix,_508.type),s) forSome {_508.type <:
  ScalaSettings.this.EnableSettings[ScalaSettings.this.BooleanSetting] &
    Singleton
reduces to       : TermRef(TypeRef(NoPrefix,_508.type),s)
type used instead: TermRef(AndType(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,settings)),ScalaSettings)),EnableSettings), scala$tools$nsc$settings$MutableSettings$EnableSettings$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,settings)),ScalaSettings)),BooleanSetting)) | 1061723946),TypeRef(ThisType(TypeRef(NoPrefix,scala)),Singleton)),s)
proceed at own risk.
warning: failure to eliminate existential
original type    : TermRef(TypeRef(NoPrefix,_97.type),s) forSome {_97.type <:
  ScalaSettings.this.EnableSettings[ScalaSettings.this.BooleanSetting] &
    Singleton
reduces to       : TermRef(TypeRef(NoPrefix,_97.type),s)
type used instead: TermRef(AndType(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,settings)),ScalaSettings)),EnableSettings), scala$tools$nsc$settings$MutableSettings$EnableSettings$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,settings)),ScalaSettings)),BooleanSetting)) | 1061723946),TypeRef(ThisType(TypeRef(NoPrefix,scala)),Singleton)),s)
proceed at own risk.
warning: failure to eliminate existential
original type    : TermRef(TypeRef(NoPrefix,_1105.type),s) forSome {_1105.type <:
  ScalaSettings.this.EnableSettings[ScalaSettings.this.BooleanSetting] &
    Singleton
reduces to       : TermRef(TypeRef(NoPrefix,_1105.type),s)
type used instead: TermRef(AndType(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,settings)),ScalaSettings)),EnableSettings), scala$tools$nsc$settings$MutableSettings$EnableSettings$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,settings)),ScalaSettings)),BooleanSetting)) | 1061723946),TypeRef(ThisType(TypeRef(NoPrefix,scala)),Singleton)),s)
proceed at own risk.
warning: failure to eliminate existential
original type    : TermRef(TypeRef(NoPrefix,_171.type),s) forSome {_171.type <:
  ScalaSettings.this.EnableSettings[ScalaSettings.this.BooleanSetting] &
    Singleton
reduces to       : TermRef(TypeRef(NoPrefix,_171.type),s)
type used instead: TermRef(AndType(RefinedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,settings)),ScalaSettings)),EnableSettings), scala$tools$nsc$settings$MutableSettings$EnableSettings$$T, TypeAlias(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,settings)),ScalaSettings)),BooleanSetting)) | 1061723946),TypeRef(ThisType(TypeRef(NoPrefix,scala)),Singleton)),s)
proceed at own risk.
../src/dotty/tools/backend/jvm/GenBCode.scala:46: warning: cannot merge (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label] with (xs: scala.collection.immutable.List[String])Array[String] as members of one type; keeping only (xs: scala.collection.immutable.List[scala.tools.asm.Label])
  Array[scala.tools.asm.Label]
class GenBCodePipeline(val entryPoints: List[Symbol], val int: DottyBackendInterface)(implicit val ctx: Context) extends BCodeSyncAndTry{
      ^
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$MutableSetFactory$$CC; assuming they are invariant
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$ImmutableSetFactory$$CC; assuming they are invariant
warning: encountered F-bounded higher-kinded type parameters for type scala$collection$generic$ImmutableMapFactory$$CC; assuming they are invariant
36 warnings found
```


minimal code for the failure:
```
package dotty.tools.backend.jvm

class GenBCodePipeline(val int: DottyBackendInterface) {
}
```
