### PR TITLE
Fix various issues in `TypeAssigner#avoid`

### DIFF
--- a/tests/pos/escapingRefs.scala
+++ b/tests/pos/escapingRefs.scala
@@ -4,6 +4,8 @@ class Outer {
   }
 }
 
+class HasA { type A }
+
 object Test {
   def test = {
     val a: Outer#Inner = {
@@ -15,6 +17,14 @@ object Test {
       val o = new Outer
       val i = new o.Inner
       new i.Inner2
+    }
+
+    val c: HasA { type A = Int } = {
+      val h = new HasA {
+        type A = Int
+      }
+      val x: HasA { type A = h.A } = h
+      x
     }
   }
 }

--- a/tests/pos/escapingRefs.scala
+++ b/tests/pos/escapingRefs.scala
@@ -6,6 +6,8 @@ class Outer {
 
 class HasA { type A }
 
+class Foo[A]
+
 object Test {
   def test = {
     val a: Outer#Inner = {
@@ -25,6 +27,16 @@ object Test {
       }
       val x: HasA { type A = h.A } = h
       x
+    }
+
+    val d: Foo[Int] = {
+      class Bar[B] extends Foo[B]
+      new Bar[Int]
+    }
+
+    val e: Foo[_] = {
+      class Bar[B] extends Foo[B]
+      new Bar[Int]: Bar[_ <: Int]
     }
   }
 }

--- a/tests/pos/escapingRefs.scala
+++ b/tests/pos/escapingRefs.scala
@@ -1,5 +1,7 @@
 class Outer {
-  class Inner
+  class Inner {
+    class Inner2
+  }
 }
 
 object Test {
@@ -7,6 +9,12 @@ object Test {
     val a: Outer#Inner = {
       val o = new Outer
       new o.Inner
+    }
+
+    val b: Outer#Inner#Inner2 = {
+      val o = new Outer
+      val i = new o.Inner
+      new i.Inner2
     }
   }
 }

--- a/tests/pos/escapingRefs.scala
+++ b/tests/pos/escapingRefs.scala
@@ -1,0 +1,12 @@
+class Outer {
+  class Inner
+}
+
+object Test {
+  def test = {
+    val a: Outer#Inner = {
+      val o = new Outer
+      new o.Inner
+    }
+  }
+}


### PR DESCRIPTION
This fixes some of the issues with escaping refs, notably #711 and #741.

It does not include fixes for the issues with uninstantiated type parameters since we're not sure what the best solution for that is yet, see #750.

Review by @odersky