### PR TITLE
BUG: TermRefs with uninstantiated type variables get incorrect signatures

### DIFF
--- a/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -311,6 +311,10 @@ class TreePickler(pickler: TastyPickler) {
           case tp: NamedType if tp.name.isShadowedName => tp.name
           case _ => name
         }
+        println("sel: " + tree)
+        println("sel.tpe: " + tree.tpe)
+        println("sel.tpe.widen: " + tree.tpe.widen)
+        println("sel.tpe.signature: " + tree.tpe.signature)
         val sig = tree.tpe.signature
         if (sig == Signature.NotAMethod) pickleName(realName)
         else pickleNameAndSig(realName, sig)

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -53,6 +53,7 @@ class tests extends CompilerTest {
 // This directory doesn't exist anymore
 // @Test def pickle_pickling = compileDir(coreDir, "pickling", testPickling)
   @Test def pickle_ast = compileDir(dotcDir, "ast", testPickling)
+  @Test def pickle_inf = compileFile(posDir, "pickleinf", testPickling)
 
   //@Test def pickle_core = compileDir(dotcDir, "core", testPickling, xerrors = 2) // two spurious comparison errors in Types and TypeOps
 

--- a/tests/pos/pickleinf.scala
+++ b/tests/pos/pickleinf.scala
@@ -1,0 +1,9 @@
+class Bar[N] {
+  def bar(name: N, dummy: Int = 42): N = name
+}
+
+object Test {
+  def test(): Unit = {
+    (new Bar).bar(10)
+  }
+}


### PR DESCRIPTION
This PR should not be merged, it demonstrates a bug.

After  `frontend`, `pickleinf.scala` looks like:
```scala
package <empty>.type {
  class Bar[N]() extends java.lang.Object() { 
    type Bar$$N
    private[this] type N = Bar$$N
    def bar(name: Bar.this.Bar$$N, dummy: scala.Int): Bar.this.Bar$$N = name
    def bar$default$2: scala.Int = 42
  }
  final lazy module val Test: Test$ = new Test$()
  final module class Test$() extends java.lang.Object() { this: Test.type => 
    def test(): scala.Unit = {
      {
        {
          val $1$: Bar[scala.Int] = new Bar[scala.Int]()
          $1$.bar(10, $1$.bar$default$2)
        }
        ()
      }
    }
  }
}
```
The bug only manifests itself after unpickling, but the problem is already present when we pickle the type:
```scala
sel: Select(Ident($1$),bar)
sel.tpe: TermRef(TermRef(NoPrefix,$1$),bar)
sel.tpe.widen: MethodType(List(name, dummy), List(TypeRef(TermRef(NoPrefix,$1$),Bar$$N), TypeRef(TermRef(ThisType(TypeRef(NoPrefix,<root>)),scala),Int)), TypeRef(TermRef(NoPrefix,$1$),Bar$$N))
sel.tpe.signature: Signature(List(java.lang.Object, scala.Int),java.lang.Object)
```
Notice that in the signature we get `java.lang.Object` instead of `scala.Int` for the first parameter and the return type, this happens because the signature is computed and cached before `N` is instantiated to `Int`.
CC @odersky 