### PR TITLE
Always fully define the types of lifted expressions

### DIFF
--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -21,6 +21,7 @@ import Names._
 import StdNames._
 import ProtoTypes._
 import EtaExpansion._
+import Inferencing._
 import collection.mutable
 import config.Printers._
 import TypeApplications._

--- a/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -13,6 +13,7 @@ import Decorators._
 import Names._
 import StdNames._
 import Trees._
+import Inferencing._
 import util.Positions._
 import collection.mutable
 
@@ -24,7 +25,8 @@ object EtaExpansion {
     if (isPureExpr(expr)) expr
     else {
       val name = ctx.freshName(prefix).toTermName
-      val sym = ctx.newSymbol(ctx.owner, name, EmptyFlags, expr.tpe.widen, coord = positionCoord(expr.pos))
+      val liftedType = fullyDefinedType(expr.tpe.widen, "lifted expression", expr.pos)
+      val sym = ctx.newSymbol(ctx.owner, name, EmptyFlags, liftedType, coord = positionCoord(expr.pos))
       defs += ValDef(sym, expr)
       ref(sym.valRef)
     }

--- a/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -20,7 +20,7 @@ import config.Printers._
 import annotation.tailrec
 import collection.mutable
 
-trait Inferencing { this: Checking =>
+object Inferencing {
 
   import tpd._
 
@@ -196,47 +196,6 @@ trait Inferencing { this: Checking =>
         else NoType
       case _ => NoType
     }
-
-  /** Ensure that the first type in a list of parent types Ps points to a non-trait class.
-   *  If that's not already the case, add one. The added class type CT is determined as follows.
-   *  First, let C be the unique class such that
-   *  - there is a parent P_i such that P_i derives from C, and
-   *  - for every class D: If some parent P_j, j <= i derives from D, then C derives from D.
-   *  Then, let CT be the smallest type which
-   *  - has C as its class symbol, and
-   *  - for all parents P_i: If P_i derives from C then P_i <:< CT.
-   */
-  def ensureFirstIsClass(parents: List[Type])(implicit ctx: Context): List[Type] = {
-    def realClassParent(cls: Symbol): ClassSymbol =
-      if (!cls.isClass) defn.ObjectClass
-      else if (!(cls is Trait)) cls.asClass
-      else cls.asClass.classParents match {
-        case parentRef :: _ => realClassParent(parentRef.symbol)
-        case nil => defn.ObjectClass
-      }
-    def improve(candidate: ClassSymbol, parent: Type): ClassSymbol = {
-      val pcls = realClassParent(parent.classSymbol)
-      if (pcls derivesFrom candidate) pcls else candidate
-    }
-    parents match {
-      case p :: _ if p.classSymbol.isRealClass => parents
-      case _ =>
-        val pcls = (defn.ObjectClass /: parents)(improve)
-        typr.println(i"ensure first is class $parents%, % --> ${parents map (_ baseTypeWithArgs pcls)}%, %")
-        val ptype = ctx.typeComparer.glb(
-            defn.ObjectType :: (parents map (_ baseTypeWithArgs pcls)))
-        ptype :: parents
-    }
-  }
-
-  /** Ensure that first parent tree refers to a real class. */
-  def ensureFirstIsClass(parents: List[Tree], pos: Position)(implicit ctx: Context): List[Tree] = parents match {
-    case p :: ps if p.tpe.classSymbol.isRealClass => parents
-    case _ =>
-      // add synthetic class type
-      val first :: _ = ensureFirstIsClass(parents.tpes)
-      TypeTree(checkFeasible(first, pos, d"\n in inferred parent $first")).withPos(pos) :: parents
-  }
 
   /** Interpolate those undetermined type variables in the widened type of this tree
    *  which are introduced by type application contained in the tree.

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -16,6 +16,7 @@ import ErrorReporting._
 import tpd.ListOfTreeDecorator
 import config.Printers._
 import Annotations._
+import Inferencing._
 import transform.ValueClasses._
 import language.implicitConversions
 

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -53,6 +53,7 @@ class tests extends CompilerTest {
 // This directory doesn't exist anymore
 // @Test def pickle_pickling = compileDir(coreDir, "pickling", testPickling)
   @Test def pickle_ast = compileDir(dotcDir, "ast", testPickling)
+  @Test def pickle_inf = compileFile(posDir, "pickleinf", testPickling)
 
   //@Test def pickle_core = compileDir(dotcDir, "core", testPickling, xerrors = 2) // two spurious comparison errors in Types and TypeOps
 

--- a/tests/pos/pickleinf.scala
+++ b/tests/pos/pickleinf.scala
@@ -1,0 +1,9 @@
+class Bar[N] {
+  def bar(name: N, dummy: Int = 42): N = name
+}
+
+object Test {
+  def test(): Unit = {
+    (new Bar).bar(10)
+  }
+}


### PR DESCRIPTION
Fixes #822 

Review by @odersky . I don't know if fixing this just in `EtaExpression#lift` is the correct thing to do, we could still accidentally create symbols with non-fully defined types. Should we instead call `fullyDefinedType(info)` inside `Symbols#newSymbol` ?