### PR TITLE
Run CI-partest with bootstrapped compiler

### DIFF
--- a/bin/dotc
+++ b/bin/dotc
@@ -192,7 +192,7 @@ trap onExit INT
 # If using the boot classpath, also pass an empty classpath
 # to java to suppress "." from materializing.
 classpathArgs () {
-  if [[ -n $bootstrapped ]]; then 
+  if [[ "true" == $bootstrapped ]]; then 
     checkjar $DOTTY_JAR "test:runMain dotc.build" src
     toolchain="$DOTTY_JAR:$SCALA_LIBRARY_JAR:$SCALA_REFLECT_JAR:$SCALA_COMPILER_JAR:$JLINE_JAR"
   else

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -81,7 +81,7 @@ object DottyBuild extends Build {
       val args = Def.spaceDelimited("<arg>").parsed
       val jars = Seq((packageBin in Compile).value.getAbsolutePath) ++
           getJarPaths(partestDeps.value, ivyPaths.value.ivyHome)
-      val dottyJars  = "-dottyJars " + jars.length + " " + jars.mkString(" ")
+      val dottyJars  = "-dottyJars " + (jars.length + 1) + " dotty.jar" + " " + jars.mkString(" ")
       // Provide the jars required on the classpath of run tests
       runTask(Test, "dotty.partest.DPConsoleRunner", dottyJars + " " + args.mkString(" "))
     },
@@ -118,8 +118,8 @@ object DottyBuild extends Build {
 
       ("-DpartestParentID=" + pid) :: tuning ::: agentOptions ::: travis_build ::: fullpath
     }
-  ) ++ addCommandAlias("partest", ";test:package;package;lockPartestFile;test:test;runPartestRunner") ++
-       addCommandAlias("partest-only", ";test:package;package;lockPartestFile;test:test-only dotc.tests;runPartestRunner")
+  ) ++ addCommandAlias("partest", ";test:package;package;test:runMain dotc.build;lockPartestFile;test:test;runPartestRunner") ++
+       addCommandAlias("partest-only", ";test:package;package;test:runMain dotc.build;lockPartestFile;test:test-only dotc.tests;runPartestRunner")
 
   lazy val dotty = Project(id = "dotty", base = file("."), settings = defaults)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -42,7 +42,7 @@ object DottyBuild extends Build {
     resolvers += Resolver.sonatypeRepo("releases"),
 
     // get libraries onboard
-    partestDeps := Seq("me.d-d" % "scala-compiler" % "2.11.5-20150714-145300-2ad68448c5",
+    partestDeps := Seq("me.d-d" % "scala-compiler" % "2.11.5-20151022-113908-7fb0e653fd",
                       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
                       "org.scala-lang" % "scala-library" % scalaVersion.value % "test"),
     libraryDependencies ++= partestDeps.value,

--- a/scripts/jobs/validate/partest
+++ b/scripts/jobs/validate/partest
@@ -4,5 +4,5 @@ baseDir=${WORKSPACE-`pwd`}
 scriptsDir="$baseDir/scripts"
 . $scriptsDir/common
 
-sbt $sbtArgs update compile "partest-only run --show-diff --verbose"
+sbt $sbtArgs update compile "partest-only --show-diff --verbose"
 

--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -640,7 +640,7 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
         val original = toDenot(sym).initial
         val validity = original.validFor
         val shiftedContext = ctx.withPhase(validity.phaseId)
-        toDenot(sym)(shiftedContext).isStatic
+        toDenot(sym)(shiftedContext).isStatic(shiftedContext)
       }
 
     def isStaticConstructor: Boolean = isStaticMember && isClassConstructor

--- a/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -47,7 +47,7 @@ trait TypeTestsCasts {
 
         def transformIsInstanceOf(expr:Tree, argType: Type): Tree = {
           def argCls = argType.classSymbol
-          if (expr.tpe <:< argType)
+          if (false && expr.tpe <:< argType)
             Literal(Constant(true)) withPos tree.pos
           else if (argCls.isPrimitiveValueClass)
             if (qualCls.isPrimitiveValueClass) Literal(Constant(qualCls == argCls)) withPos tree.pos


### PR DESCRIPTION
I'm doing dirty classpath tricks to make partest prefer dotty-compiled-dotty over scalac-compiled-dotty.