### PR TITLE
Fix #840

### DIFF
--- a/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/src/dotty/tools/dotc/transform/Erasure.scala
@@ -400,7 +400,7 @@ object Erasure extends TypeTestsCasts{
     }
 
     override def typedTypeApply(tree: untpd.TypeApply, pt: Type)(implicit ctx: Context) = {
-      val ntree = interceptTypeApply(tree.asInstanceOf[TypeApply])
+      val ntree = interceptTypeApply(tree.asInstanceOf[TypeApply])(ctx.withPhase(ctx.erasurePhase))
 
       ntree match {
         case TypeApply(fun, args) =>

--- a/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -47,7 +47,7 @@ trait TypeTestsCasts {
 
         def transformIsInstanceOf(expr:Tree, argType: Type): Tree = {
           def argCls = argType.classSymbol
-          if (expr.tpe <:< argType)
+          if ((expr.tpe <:< argType) && isPureExpr(expr))
             Literal(Constant(true)) withPos tree.pos
           else if (argCls.isPrimitiveValueClass)
             if (qualCls.isPrimitiveValueClass) Literal(Constant(qualCls == argCls)) withPos tree.pos


### PR DESCRIPTION
Problem was that interceptTypeTestCasts was run at wrong phase.
It saw after erasure a type of the form `x.Array$$T`. Before
erasure that type is simply an alias of another type, but after
erasure, Arraya$$T is defined to be a type alias of a Wildcard type.
Review by @DarkDimius 