### PR TITLE
Avoid completing classes during enter in some cases

### DIFF
--- a/src/dotty/tools/dotc/core/Flags.scala
+++ b/src/dotty/tools/dotc/core/Flags.scala
@@ -435,15 +435,20 @@ object Flags {
   /** Flags representing access rights */
   final val AccessFlags = Private | Protected | Local
 
-  /** Flags guaranteed to be set upon symbol creation */
-  final val FromStartFlags =
+  /** Common flags guaranteed to be set upon symbol creation */
+  final val FromStartCommonFlags =
     AccessFlags | Module | Package | Deferred | Final | MethodOrHKCommon | Param | ParamAccessor | Scala2ExistentialCommon |
     InSuperCall | Touched | JavaStatic | CovariantOrOuter | ContravariantOrLabel | ExpandedName | AccessorOrSealed |
     CaseAccessorOrTypeArgument | Fresh | Frozen | Erroneous | ImplicitCommon | Permanent |
     SelfNameOrImplClass
 
-  assert(FromStartFlags.isTermFlags && FromStartFlags.isTypeFlags)
-  // TODO: Should check that FromStartFlags do not change in completion
+  assert(FromStartCommonFlags.isTermFlags && FromStartCommonFlags.isTypeFlags)
+
+  /** Type flags guaranteed to be set upon symbol creation */
+  final val FromStartTypeFlags = Trait
+  assert(FromStartTypeFlags.isTypeFlags)
+
+  // TODO: Should check that FromStartCommonFlags and FromStartTypeFlags do not change in completion
 
   /** A value that's unstable unless complemented with a Stable flag */
   final val UnstableValue = Mutable | Method

--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -123,26 +123,30 @@ object SymDenotations {
       setFlag(flags & mask)
     }
 
+    /** Are all flags in `fs` guaranteed to be set upon symbol creation? */
+    private def allFlagsFromStart(fs: FlagSet)(implicit ctx: Context): Boolean =
+      fs <= FromStartCommonFlags || (this.isType && fs <= FromStartTypeFlags)
+
     /** Has this denotation one of the flags in `fs` set? */
     final def is(fs: FlagSet)(implicit ctx: Context) = {
-      (if (fs <= FromStartFlags) myFlags else flags) is fs
+      (if (allFlagsFromStart(fs)) myFlags else flags) is fs
     }
 
     /** Has this denotation one of the flags in `fs` set, whereas none of the flags
      *  in `butNot` are set?
      */
     final def is(fs: FlagSet, butNot: FlagSet)(implicit ctx: Context) =
-      (if (fs <= FromStartFlags && butNot <= FromStartFlags) myFlags else flags) is (fs, butNot)
+      (if (allFlagsFromStart(fs) && allFlagsFromStart(butNot)) myFlags else flags) is (fs, butNot)
 
     /** Has this denotation all of the flags in `fs` set? */
     final def is(fs: FlagConjunction)(implicit ctx: Context) =
-      (if (fs <= FromStartFlags) myFlags else flags) is fs
+      (if (allFlagsFromStart(fs)) myFlags else flags) is fs
 
     /** Has this denotation all of the flags in `fs` set, whereas none of the flags
      *  in `butNot` are set?
      */
     final def is(fs: FlagConjunction, butNot: FlagSet)(implicit ctx: Context) =
-      (if (fs <= FromStartFlags && butNot <= FromStartFlags) myFlags else flags) is (fs, butNot)
+      (if (allFlagsFromStart(fs) && allFlagsFromStart(butNot)) myFlags else flags) is (fs, butNot)
 
     /** The type info.
      *  The info is an instance of TypeType iff this is a type denotation

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -95,6 +95,7 @@ class tests extends CompilerTest {
   @Test def pos_anonClassSubtyping = compileFile(posDir, "anonClassSubtyping", twice)
   @Test def pos_extmethods = compileFile(posDir, "extmethods", twice)
   @Test def pos_companions = compileFile(posDir, "companions", twice)
+  @Test def pos_i0850 = compileDir(posDir, "i0850", twice)
 
   @Test def pos_all = compileFiles(posDir) // twice omitted to make tests run faster
 

--- a/test/test/flagtest.sc
+++ b/test/test/flagtest.sc
@@ -19,9 +19,9 @@ object flagtest {
   Abstract                                        //> res7: dotty.tools.dotc.core.Flags.FlagSet = abstract
   Method == Abstract                              //> res8: Boolean = false
   Method.toCommonFlags                            //> res9: dotty.tools.dotc.core.Flags.FlagSet = <method> abstract
-  FromStartFlags                                  //> res10: dotty.tools.dotc.core.Flags.FlagSet = private protected <deferred> <p
+  FromStartCommonFlags                            //> res10: dotty.tools.dotc.core.Flags.FlagSet = private protected <deferred> <p
                                                   //| aram> <accessor> sealed <local> module <package> <expandedname> <covariant> 
                                                   //| <contravariant> <static> <touched> <frozen> <existential>
-  AccessFlags <= FromStartFlags                   //> res11: Boolean = true
-  FromStartFlags <= AccessFlags                   //> res12: Boolean = false
+  AccessFlags <= FromStartCommonFlags             //> res11: Boolean = true
+  FromStartCommonFlags <= AccessFlags             //> res12: Boolean = false
 }

--- a/tests/pos/i0850/A.scala
+++ b/tests/pos/i0850/A.scala
@@ -1,0 +1,3 @@
+import B.hello
+
+class A(private[this] var foo: Int)

--- a/tests/pos/i0850/B.scala
+++ b/tests/pos/i0850/B.scala
@@ -1,0 +1,3 @@
+object B {
+  def hello: Int = 1
+}


### PR DESCRIPTION
The `ctx.owner is Trait` check in `Desugar#valDef` forced the completion
of some classes during enter. Since `Trait` is always set upon symbol
creation the completion of the class is not needed, so we now avoid it.

Fixes #850

Review by @odersky .