### PR TITLE
Fix hole in subtyping of modules

### DIFF
--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -197,8 +197,10 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
             val cls1 = tp1.cls
             cls1.classInfo.selfType.derivesFrom(cls2) &&
             cls2.classInfo.selfType.derivesFrom(cls1)
-          case tp1: TermRef if tp2.cls eq tp1.symbol.moduleClass =>
-            isSubType(tp1.prefix, cls2.owner.thisType)
+          case tp1: TermRef if cls2.is(Module) && cls2.eq(tp1.widen.typeSymbol) =>
+            cls2.isStaticOwner ||
+            isSubType(tp1.prefix, cls2.owner.thisType) ||
+            secondTry(tp1, tp2)
           case _ =>
             secondTry(tp1, tp2)
         }
@@ -257,9 +259,12 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         }
       comparePolyParam
     case tp1: ThisType =>
+      val cls1 = tp1.cls
       tp2 match {
-        case tp2: TermRef if tp1.cls eq tp2.symbol.moduleClass =>
-          isSubType(tp1.cls.owner.thisType, tp2.prefix)
+        case tp2: TermRef if cls1.is(Module) && cls1.eq(tp2.widen.typeSymbol) =>
+          cls1.isStaticOwner ||
+          isSubType(cls1.owner.thisType, tp2.prefix) ||
+          thirdTry(tp1, tp2)
         case _ =>
           thirdTry(tp1, tp2)
       }

--- a/tests/pos/range.scala
+++ b/tests/pos/range.scala
@@ -1,0 +1,9 @@
+import scala.math._
+import collection.immutable.NumericRange
+object Test {
+  val r1: scala.collection.immutable.Range.Partial = ???
+  val r2: scala.Range.Partial = r1
+  def until(d: BigDecimal, end: BigDecimal): Range.Partial[BigDecimal, NumericRange.Exclusive[BigDecimal]] =
+    new Range.Partial(until(d, end, _))
+  def until(d: BigDecimal, end: BigDecimal, step: BigDecimal) = Range.BigDecimal(d, end, step)
+}


### PR DESCRIPTION
We did not handle correctly the case exemplified by `range.scala`: A module this type, which
is compared with a getter to the same module. Seen in the wild in scala.math.BigDecimal.

Review by @smarter