### PR TITLE
Check that access to context base is singlethreaded.

### DIFF
--- a/src/dotty/tools/dotc/Run.scala
+++ b/src/dotty/tools/dotc/Run.scala
@@ -50,6 +50,7 @@ class Run(comp: Compiler)(implicit ctx: Context) {
     }
 
   protected def compileUnits() = Stats.monitorHeartBeat {
+    ctx.checkSingleThreaded()
     val phases = ctx.squashPhases(ctx.phasePlan,
       ctx.settings.Yskip.value, ctx.settings.YstopBefore.value, ctx.settings.YstopAfter.value, ctx.settings.Ycheck.value)
     ctx.usePhases(phases)

--- a/src/dotty/tools/dotc/core/Contexts.scala
+++ b/src/dotty/tools/dotc/core/Contexts.scala
@@ -611,6 +611,16 @@ object Contexts {
       superIdOfClass.clear()
       lastSuperId = -1
     }
+
+    // Test that access is single threaded
+
+    /** The thread on which `checkSingleThreaded was invoked last */
+    @sharable private var thread: Thread = null
+
+    /** Check that we are on the same thread as before */
+    def checkSingleThreaded() =
+      if (thread == null) thread = Thread.currentThread()
+      else assert(thread == Thread.currentThread(), "illegal multithreaded access to ContextBase")
   }
 
   object Context {


### PR DESCRIPTION
ContextBase is not intended to be threadsafe, We now test that
indeed it is not shared by compileUnits calls operating on
different threads. Review by @DarkDimius.