### PR TITLE
Require outer pointer also for proxies of enclosing classes.

### DIFF
--- a/tests/pos/i880.scala
+++ b/tests/pos/i880.scala
@@ -1,0 +1,17 @@
+object Test {
+  def test = {
+    val myName: String = ""
+    new AnyRef {
+      new Exception {
+        def name = myName
+      }
+    }
+    new AnyRef {
+      new Exception {
+        new AnyRef {
+          def name = myName
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
There was a missing case where an outer pointer is required. Review by @smarter.