### PR TITLE
Parentheses around a wildcard should not produce a lambda

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -322,6 +322,7 @@ object Parsers {
       case Ident(name1) => placeholderParams.nonEmpty && name1 == placeholderParams.head.name
       case Typed(t1, _) => isWildcard(t1)
       case Annotated(t1, _) => isWildcard(t1)
+      case Parens(t1) => isWildcard(t1)
       case _ => false
     }
 

--- a/tests/pos/i903.scala
+++ b/tests/pos/i903.scala
@@ -1,0 +1,24 @@
+object Test {
+  def contains(s: String, i: Int) = true
+  def test1 = {
+    val f = contains("", (_: Int))
+    val ff = contains("", ((_: Int)))
+    f.apply(0)
+    //     sandbox/eta.scala:4: error: type mismatch:
+    //  found   : Int => Int
+    //  required: Int
+    //     val f = contains("", (_: Int))
+    //                          ^
+    // sandbox/eta.scala:5: error: apply is not a member of Boolean(f)
+    //     f.apply(0)
+    //      ^
+  }
+
+  def test2 = {
+    val f = "".contains("", (_: Int)) // dotc:
+    f.apply(0)
+    // sandbox/eta.scala:18: error: apply is not a member of Boolean(f)
+    //     f.apply(0)
+    //       ^
+  }
+}

--- a/tests/pos/i903.scala
+++ b/tests/pos/i903.scala
@@ -3,6 +3,8 @@ object Test {
   def test1 = {
     val f = contains("", (_: Int))
     val ff = contains("", ((_: Int)))
+    val g: Int => Boolean = contains("", (_))
+    val gg: Int => Boolean = contains("", ((_)))
     f.apply(0)
     //     sandbox/eta.scala:4: error: type mismatch:
     //  found   : Int => Int


### PR DESCRIPTION
`(_)` and `(_: T)` should not be converted to functions

    x => x
    (x: T) => x

Fixes #903. Review by @retronym?