### PR TITLE
Stdlib traversable once

### DIFF
--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -192,6 +192,9 @@ class Definitions {
     ScalaPackageClass, tpnme.Null, AbstractFinal, List(ObjectClass.typeRef))
 
   lazy val ScalaPredefModule = ctx.requiredModule("scala.Predef")
+
+    lazy val Predef_conforms = ctx.requiredMethod(ScalaPredefModule.moduleClass.asClass, "$conforms")
+
   lazy val ScalaRuntimeModule = ctx.requiredModule("scala.runtime.ScalaRunTime")
   lazy val ScalaRuntimeClass = ScalaRuntimeModule.moduleClass.asClass
 
@@ -210,7 +213,6 @@ class Definitions {
     def newRefArrayMethod = ctx.requiredMethod(DottyArraysModule.moduleClass.asClass, "newRefArray")
 
   lazy val NilModule = ctx.requiredModule("scala.collection.immutable.Nil")
-  lazy val PredefConformsClass = ctx.requiredClass("scala.Predef." + tpnme.Conforms)
 
 //  lazy val FunctionClass: ClassSymbol = ctx.requiredClass("scala.Function")
   lazy val SingletonClass: ClassSymbol =

--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -65,7 +65,9 @@ object Implicits {
           case tpw =>
             //if (ctx.typer.isApplicable(tp, argType :: Nil, resultType))
             //  println(i"??? $tp is applicable to $this / typeSymbol = ${tpw.typeSymbol}")
-            !tpw.derivesFrom(defn.FunctionClass(1)) || tpw.isRef(defn.PredefConformsClass)
+            !tpw.derivesFrom(defn.FunctionClass(1)) ||
+            ref.symbol == defn.Predef_conforms //
+              // as an implicit conversion, Predef.$conforms is a no-op, so exclude it
         }
 
         def discardForValueType(tpw: Type): Boolean = tpw match {

--- a/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -287,7 +287,9 @@ object RefChecks {
                  !member.isAnyOverride) {
         // (*) Exclusion for default getters, fixes SI-5178. We cannot assign the Override flag to
         // the default getter: one default getter might sometimes override, sometimes not. Example in comment on ticket.
-        if (member.owner != clazz && other.owner != clazz && !(other.owner derivesFrom member.owner))
+        if (member.name == nme.isDefined && member.is(Synthetic)) // isDefined methods are added automatially, can't have an override preset.
+          member.setFlag(Override)
+        else if (member.owner != clazz && other.owner != clazz && !(other.owner derivesFrom member.owner))
           emitOverrideError(
             clazz + " inherits conflicting members:\n  "
               + infoStringWithLocation(other) + "  and\n  " + infoStringWithLocation(member)

--- a/test/dotc/scala-collections.whitelist
+++ b/test/dotc/scala-collections.whitelist
@@ -103,7 +103,7 @@
 ./scala-scala/src/library/scala/collection/LinearSeqOptimized.scala
 
 # https://github.com/lampepfl/dotty/issues/914
-#./scala-scala/src/library/scala/collection/TraversableOnce.scala
+./scala-scala/src/library/scala/collection/TraversableOnce.scala
 ./scala-scala/src/library/scala/collection/generic/Growable.scala
 ./scala-scala/src/library/scala/collection/generic/TraversableForwarder.scala
 ./scala-scala/src/library/scala/collection/immutable/BitSet.scala

--- a/test/dotc/scala-collections.whitelist
+++ b/test/dotc/scala-collections.whitelist
@@ -53,7 +53,7 @@
 ./scala-scala/src/library/scala/NotNull.scala
 
 # https://github.com/lampepfl/dotty/issues/911
-#./scala-scala/src/library/scala/Option.scala
+./scala-scala/src/library/scala/Option.scala
 
 ./scala-scala/src/library/scala/PartialFunction.scala
 ./scala-scala/src/library/scala/Predef.scala

--- a/tests/new/conforms.scala
+++ b/tests/new/conforms.scala
@@ -1,0 +1,3 @@
+object Test {
+  def f[A, B](x: A)(implicit e: <:<[A, B]): B = x
+}


### PR DESCRIPTION
Enable <:< implicits as conversions.

These were disabled before, which means that having evidence
of S <:< T did not introduce a usable implicit conversion from
S to T. We do do it like scalac: just disable Predef.$conforms.

This makes TraversableOnce compile. Fixes #914.