### PR TITLE
Reorder unpickled type params if necessary

### DIFF
--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -176,7 +176,7 @@ object SymDenotations {
       // completions.println(s"completed ${this.debugString}")
     }
 
-    protected[dotc] final def info_=(tp: Type) = {
+    protected[dotc] def info_=(tp: Type) = {
       /* // DEBUG
        def illegal: String = s"illegal type for $this: $tp"
       if (this is Module) // make sure module invariants that allow moduleClass and sourceModule to work are kept.
@@ -1175,6 +1175,11 @@ object SymDenotations {
       }
       if (myTypeParams == null) myTypeParams = computeTypeParams
       myTypeParams
+    }
+
+    override protected[dotc] final def info_=(tp: Type) = {
+      super.info_=(tp)
+      myTypeParams = null // changing the info might change decls, and with it typeParams
     }
 
     /** The denotations of all parents in this class. */

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -130,8 +130,18 @@ object Scala2Unpickler {
     } else {
       registerCompanionPair(scalacCompanion, denot.classSymbol)
     }
+    val declsTypeParams = denot.typeParams
+    val declsInRightOrder =
+      if (declsTypeParams.corresponds(tparams)(_.name == _.name)) decls
+      else { // create new scope with type parameters in right order
+        val decls1 = newScope
+        for (tparam <- tparams) decls1.enter(decls.lookup(tparam.name))
+        for (sym <- decls) if (!declsTypeParams.contains(sym)) decls1.enter(sym)
+        decls1
+      }
 
-    denot.info = ClassInfo(denot.owner.thisType, denot.classSymbol, parentRefs, decls, ost)
+    denot.info = ClassInfo(
+      denot.owner.thisType, denot.classSymbol, parentRefs, declsInRightOrder, ost)
   }
 }
 


### PR DESCRIPTION
When compiling Iterator.scala it was observed that
the type parameters of BufferedCanBuildFrom appeared
in the wrong order. This fix corrects that, making
sure that type parameters appear in the decls scope
in the same order as they are given in the explicitly
unpickled type parameter list.

Review by @VladimirNik (to change reviewer jobs a bit)