### PR TITLE
Showcase #918

### DIFF
--- a/tests/pos/ManifestTest.scala
+++ b/tests/pos/ManifestTest.scala
@@ -1,0 +1,3 @@
+object Pred{
+  val s = scala.reflect.Manifest // should access  https://github.com/scala/scala/blob/2.11.x/src/library/scala/reflect/package.scala#L43
+}


### PR DESCRIPTION
```
$ dotc ManifestTest.scala
ManifestTest.scala:2: error: Manifest is not a member of reflect.type
  val s = scala.reflect.Manifest
                        ^
one error found
```