### PR TITLE
Show a way to reproduce #907

### DIFF
--- a/test/dotc/scala-collections.whitelist
+++ b/test/dotc/scala-collections.whitelist
@@ -61,7 +61,7 @@
 # Causes data races #907
 # java.lang.AssertionError: assertion failed: data race? overwriting symbol of Product1 / TypeRef(ThisType(TypeRef(NoPrefix,scala)),Product1) / class dotty.tools.dotc.core.Types$CachedTypeRef / 190 / 4820 / module class scala / module class scala / frontend, took 2.154 sec
 #./scala-scala/src/library/scala/Product.scala
-#./scala-scala/src/library/scala/Product1.scala
+./scala-scala/src/library/scala/Product1.scala
 #./scala-scala/src/library/scala/Product10.scala
 #./scala-scala/src/library/scala/Product11.scala
 #./scala-scala/src/library/scala/Product12.scala


### PR DESCRIPTION
```
[info] Test dotc.tests.compileStdLib started
exception occurred while indexing ./scala-scala/src/library/scala/Product1.scala
exception occurred while compiling ./scala-scala/src/library/scala/AnyValCompanion.scala, ./scala-scala/src/library/scala/Cloneable.scala, ./scala-scala/src/library/scala/DelayedInit.scala, ./scala-scala/src/library/scala/Dynamic.scala, ./scala-scala/src/library/scala/Equals.scala, ./scala-scala/src/library/scala/Immutable.scala, ./scala-scala/src/library/scala/MatchError.scala, ./scala-scala/src/library/scala/Mutable.scala, ./scala-scala/src/library/scala/NotNull.scala, ./scala-scala/src/library/scala/Option.scala, ./scala-scala/src/library/scala/PartialFunction.scala, ./scala-scala/src/library/scala/Predef.scala, ./scala-scala/src/library/scala/Product1.scala, ./scala-scala/src/library/scala/Proxy.scala, ./scala-scala/src/library/scala/SerialVersionUID.scala, ./scala-scala/src/library/scala/Serializable.scala, ./scala-scala/src/library/scala/Specializable.scala, ./scala-scala/src/library/scala/Symbol.scala, ./scala-scala/src/library/scala/UninitializedError.scala, ./scala-scala/src/library/scala/UninitializedFieldError.scala, ./scala-scala/src/library/scala/collection/IterableLike.scala, ./scala-scala/src/library/scala/collection/LinearSeqOptimized.scala, ./scala-scala/src/library/scala/collection/TraversableOnce.scala, ./scala-scala/src/library/scala/collection/generic/Growable.scala, ./scala-scala/src/library/scala/collection/generic/TraversableForwarder.scala, ./scala-scala/src/library/scala/collection/immutable/BitSet.scala, ./scala-scala/src/library/scala/collection/immutable/DefaultMap.scala, ./scala-scala/src/library/scala/collection/immutable/IndexedSeq.scala, ./scala-scala/src/library/scala/collection/immutable/Iterable.scala, ./scala-scala/src/library/scala/collection/immutable/LinearSeq.scala, ./scala-scala/src/library/scala/collection/immutable/MapProxy.scala, ./scala-scala/src/library/scala/collection/immutable/PagedSeq.scala, ./scala-scala/src/library/scala/collection/immutable/Queue.scala, ./scala-scala/src/library/scala/collection/immutable/Stack.scala, ./scala-scala/src/library/scala/collection/immutable/StringLike.scala, ./scala-scala/src/library/scala/collection/immutable/StringOps.scala, ./scala-scala/src/library/scala/collection/immutable/Traversable.scala, ./scala-scala/src/library/scala/collection/immutable/Vector.scala, ./scala-scala/src/library/scala/collection/immutable/WrappedString.scala, ./scala-scala/src/library/scala/collection/mutable/Builder.scala, ./scala-scala/src/library/scala/collection/mutable/GrowingBuilder.scala, ./scala-scala/src/library/scala/collection/mutable/WrappedArray.scala, ./scala-scala/src/library/scala/collection/mutable/WrappedArrayBuilder.scala, ./scala-scala/src/library/scala/deprecated.scala, ./scala-scala/src/library/scala/deprecatedInheritance.scala, ./scala-scala/src/library/scala/deprecatedName.scala, ./scala-scala/src/library/scala/deprecatedOverriding.scala, ./scala-scala/src/library/scala/inline.scala, ./scala-scala/src/library/scala/language.scala, ./scala-scala/src/library/scala/languageFeature.scala, ./scala-scala/src/library/scala/math/Equiv.scala, ./scala-scala/src/library/scala/math/Fractional.scala, ./scala-scala/src/library/scala/math/Integral.scala, ./scala-scala/src/library/scala/math/Numeric.scala, ./scala-scala/src/library/scala/math/Ordered.scala, ./scala-scala/src/library/scala/math/Ordering.scala, ./scala-scala/src/library/scala/math/PartialOrdering.scala, ./scala-scala/src/library/scala/math/ScalaNumericConversions.scala, ./scala-scala/src/library/scala/math/package.scala, ./scala-scala/src/library/scala/native.scala, ./scala-scala/src/library/scala/noinline.scala, ./scala-scala/src/library/scala/package.scala, ./scala-scala/src/library/scala/remote.scala, ./scala-scala/src/library/scala/specialized.scala, ./scala-scala/src/library/scala/throws.scala, ./scala-scala/src/library/scala/transient.scala, ./scala-scala/src/library/scala/unchecked.scala, ./scala-scala/src/library/scala/volatile.scala
[error] Test dotc.tests.compileStdLib failed: java.lang.AssertionError: assertion failed: data race? overwriting symbol of Product1 / TypeRef(ThisType(TypeRef(NoPrefix,scala)),Product1) / class dotty.tools.dotc.core.Types$CachedTypeRef / 190 / 4745 / module class scala / module class scala / frontend, took 0.417 sec
[error]     at scala.Predef$.assert(Predef.scala:165)
[error]     at dotty.tools.dotc.core.Types$NamedType.checkSymAssign(Types.scala:1374)
[error]     at dotty.tools.dotc.core.Types$NamedType.setDenot(Types.scala:1402)
[error]     at dotty.tools.dotc.core.Types$NamedType.withDenot(Types.scala:1395)
[error]     at dotty.tools.dotc.core.Types$TypeRef$.apply(Types.scala:1789)
[error]     at dotty.tools.dotc.core.SymDenotations$SymDenotation.typeRef(SymDenotations.scala:1039)
[error]     at dotty.tools.dotc.core.SymDenotations$ClassDenotation.typeRef(SymDenotations.scala:1275)
[error]     at dotty.tools.dotc.core.Symbols$$anonfun$synthesizeCompanionMethod$1.apply(Symbols.scala:188)
[error]     at dotty.tools.dotc.core.Symbols$$anonfun$synthesizeCompanionMethod$1.apply(Symbols.scala:188)
[error]     at dotty.tools.dotc.core.Symbols$Symbol.orElse(Symbols.scala:447)
[error]     at dotty.tools.dotc.core.Symbols$class.synthesizeCompanionMethod(Symbols.scala:187)
[error]     at dotty.tools.dotc.core.Contexts$Context.synthesizeCompanionMethod(Contexts.scala:53)
[error]     at dotty.tools.dotc.typer.Namer.dotty$tools$dotc$typer$Namer$$createLinks$1(Namer.scala:458)
[error]     at dotty.tools.dotc.typer.Namer$$anonfun$createCompanionLinks$1$2.apply(Namer.scala:466)
[error]     at dotty.tools.dotc.typer.Namer$$anonfun$createCompanionLinks$1$2.apply(Namer.scala:463)
[error]     at scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:778)
[error]     at scala.collection.mutable.HashMap$$anon$2$$anonfun$foreach$3.apply(HashMap.scala:108)
[error]     at scala.collection.mutable.HashMap$$anon$2$$anonfun$foreach$3.apply(HashMap.scala:108)
[error]     at scala.collection.mutable.HashTable$class.foreachEntry(HashTable.scala:230)
[error]     at scala.collection.mutable.HashMap.foreachEntry(HashMap.scala:40)
[error]     at scala.collection.mutable.HashMap$$anon$2.foreach(HashMap.scala:108)
[error]     at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:777)
[error]     at dotty.tools.dotc.typer.Namer.createCompanionLinks$1(Namer.scala:463)
[error]     at dotty.tools.dotc.typer.Namer.index(Namer.scala:475)
[error]     at dotty.tools.dotc.typer.Namer.indexExpanded(Namer.scala:401)
[error]     at dotty.tools.dotc.typer.Namer.index(Namer.scala:392)
[error]     at dotty.tools.dotc.typer.FrontEnd$$anonfun$enterSyms$1.apply$mcV$sp(FrontEnd.scala:38)
[error]     at dotty.tools.dotc.typer.FrontEnd.monitor(FrontEnd.scala:20)
[error]     at dotty.tools.dotc.typer.FrontEnd.enterSyms(FrontEnd.scala:36)
[error]     at dotty.tools.dotc.typer.FrontEnd$$anonfun$runOn$2.apply(FrontEnd.scala:55)
[error]     at dotty.tools.dotc.typer.FrontEnd$$anonfun$runOn$2.apply(FrontEnd.scala:55)
[error]     at scala.collection.immutable.List.foreach(List.scala:381)
[error]     at dotty.tools.dotc.typer.FrontEnd.runOn(FrontEnd.scala:55)
[error]     at dotty.tools.dotc.Run$$anonfun$compileUnits$1$$anonfun$apply$mcV$sp$1.apply(Run.scala:60)
[error]     at dotty.tools.dotc.Run$$anonfun$compileUnits$1$$anonfun$apply$mcV$sp$1.apply(Run.scala:57)
[error]     at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
[error]     at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
[error]     at dotty.tools.dotc.Run$$anonfun$compileUnits$1.apply$mcV$sp(Run.scala:57)
[error]     at dotty.tools.dotc.Run$$anonfun$compileUnits$1.apply(Run.scala:52)
[error]     at dotty.tools.dotc.Run$$anonfun$compileUnits$1.apply(Run.scala:52)
[error]     at dotty.tools.dotc.util.Stats$.monitorHeartBeat(Stats.scala:69)
[error]     at dotty.tools.dotc.Run.compileUnits(Run.scala:52)
[error]     at dotty.tools.dotc.Run.compileSources(Run.scala:49)
[error]     at dotty.tools.dotc.Run.compile(Run.scala:33)
[error]     at dotty.tools.dotc.Driver.doCompile(Driver.scala:21)
[error]     at dotty.tools.dotc.Driver.process(Driver.scala:44)
[error]     at test.CompilerTest.compileArgs(CompilerTest.scala:184)
[error]     at test.CompilerTest.compileList(CompilerTest.scala:167)
[error]     at dotc.tests.compileStdLib(tests.scala:179)
```