### PR TITLE
Links between companions after unpickling are added

### DIFF
--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -588,9 +588,15 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
           sym.info = readType()
           ValDef(sym.asTerm, readRhs(localCtx))
         case TYPEDEF | TYPEPARAM =>
-          if (sym.isClass)
+          if (sym.isClass) {
+            val companion = sym.scalacLinkedClass
+            if (companion != NoSymbol) {
+              import transform.SymUtils._
+              if (sym is Flags.ModuleClass) sym.registerCompanionMethod(nme.COMPANION_CLASS_METHOD, companion)
+              else sym.registerCompanionMethod(nme.COMPANION_MODULE_METHOD, companion)
+            }
             ta.assignType(untpd.TypeDef(sym.name.asTypeName, readTemplate(localCtx)), sym)
-          else {
+          } else {
             sym.info = readType()
             TypeDef(sym.asType)
           }

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -117,17 +117,10 @@ object Scala2Unpickler {
     val scalacCompanion = denot.classSymbol.scalacLinkedClass
 
     def registerCompanionPair(module: Symbol, claz: Symbol) = {
-      def registerCompanionMethod(name: Name, target: Symbol, owner: Symbol) = {
-        if (!owner.unforcedDecls.lookup(name).exists) {
-          val companionMethod = ctx.synthesizeCompanionMethod(name, target, owner)
-          if (companionMethod.exists) {
-            companionMethod.entered
-          }
-        }
-      }
-      registerCompanionMethod(nme.COMPANION_CLASS_METHOD, claz, module)
+      import transform.SymUtils._
+      module.registerCompanionMethod(nme.COMPANION_CLASS_METHOD, claz)
       if (claz.isClass) {
-        registerCompanionMethod(nme.COMPANION_MODULE_METHOD, module, claz)
+        claz.registerCompanionMethod(nme.COMPANION_MODULE_METHOD, module)
       }
     }
 

--- a/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -99,4 +99,13 @@ class SymUtils(val self: Symbol) extends AnyVal {
     self.addAnnotations(from.annotationsCarrying(meta))
     self
   }
+
+  def registerCompanionMethod(name: Name, target: Symbol)(implicit ctx: Context) = {
+    if (!self.unforcedDecls.lookup(name).exists) {
+      val companionMethod = ctx.synthesizeCompanionMethod(name, target, self)
+      if (companionMethod.exists) {
+        companionMethod.entered
+      }
+    }
+  }
 }

--- a/tests/pos/i0881/A_1.scala
+++ b/tests/pos/i0881/A_1.scala
@@ -1,0 +1,4 @@
+class A
+object A {
+  implicit val theA: A = new A
+}

--- a/tests/pos/i0881/B_2.scala
+++ b/tests/pos/i0881/B_2.scala
@@ -1,0 +1,6 @@
+class B {
+  def getA(implicit a: A): A = a
+  def test = {
+    getA
+  }
+}


### PR DESCRIPTION
Fix for the problem with missing links between companions during unpickling https://github.com/lampepfl/dotty/issues/881:
1. Companion methods generation added to TreeUnpickler;
2. def registerCompanionMethod is shared;
Old pull request https://github.com/lampepfl/dotty/pull/922

Review by @DarkDimius @odersky