### PR TITLE
Fixed != comparison

### DIFF
--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -175,7 +175,7 @@ class tests extends CompilerTest {
   val stdlibFiles = Source.fromFile("./test/dotc/scala-collections.whitelist", "UTF8").getLines()
    .map(_.trim) // allow identation
    .filter(!_.startsWith("#")) // allow comment lines prefixed by #
-   .map(_.takeWhile(_ != "#").trim) // allow comments in the end of line
+   .map(_.takeWhile(_ != '#').trim) // allow comments in the end of line
    .filter(_.nonEmpty)
    .toList
 


### PR DESCRIPTION
By linter:
comparing values of types Char and String using `!=' will always yield
true