### PR TITLE
Swap order of arguments in annotations

### DIFF
--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -843,7 +843,7 @@ class DottyBackendInterface()(implicit ctx: Context) extends BackendInterface{
          * meta-annotated annotations (@(ann @getter) val x = 0), so we don't emit a warning.
          * The type in the AnnotationInfo is an AnnotatedTpe. Tested in jvm/annotations.scala.
          */
-        case a @ AnnotatedType(_, t) =>
+        case a @ AnnotatedType(t, _) =>
           debuglog(s"typeKind of annotated type $a")
           t.toTypeKind(ct)(storage)
 

--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -44,7 +44,7 @@ object TypeErasure {
       true
     case JavaArrayType(elem) =>
       isErasedType(elem)
-    case AnnotatedType(_, tp) =>
+    case AnnotatedType(tp, _) =>
       isErasedType(tp)
     case ThisType(tref) =>
       isErasedType(tref)

--- a/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/src/dotty/tools/dotc/core/TypeOps.scala
@@ -482,7 +482,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         normalizeToRef(tp1)
       case ErrorType =>
         defn.AnyType
-      case AnnotatedType(_, tpe) =>
+      case AnnotatedType(tpe, _) =>
         normalizeToRef(tpe)
       case _ =>
         throw new TypeError(s"unexpected parent type: $tp")

--- a/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -131,7 +131,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   APPLIEDtype    Length tycon_Type arg_Type*
                   TYPEBOUNDS     Length low_Type high_Type
                   TYPEALIAS      Length alias_Type (COVARIANT | CONTRAVARIANT)?
-                  ANNOTATED      Length fullAnnotation_Term underlying_Type
+                  ANNOTATED      Length underlying_Type fullAnnotation_Term
                   ANDtype        Length left_Type right_Type
                   ORtype         Length left_Type right_Type
                   BIND           Length boundName_NameRef bounds_Type

--- a/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -239,7 +239,7 @@ class TreePickler(pickler: TastyPickler) {
         withLength { pickleType(tpe.lo, richTypes); pickleType(tpe.hi, richTypes) }
       case tpe: AnnotatedType =>
         writeByte(ANNOTATED)
-        withLength { pickleTree(tpe.annot.tree); pickleType(tpe.tpe, richTypes) }
+        withLength { pickleType(tpe.tpe, richTypes); pickleTree(tpe.annot.tree) }
       case tpe: AndOrType =>
         writeByte(if (tpe.isAnd) ANDtype else ORtype)
         withLength { pickleType(tpe.tp1, richTypes); pickleType(tpe.tp2, richTypes) }

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -199,8 +199,7 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
                 else 0
               TypeAlias(alias, variance)
             case ANNOTATED =>
-              val annot = Annotation(readTerm())
-              AnnotatedType(readType(), annot)
+              AnnotatedType(readType(), Annotation(readTerm()))
             case ANDtype =>
               AndType(readType(), readType())
             case ORtype =>

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -199,7 +199,8 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
                 else 0
               TypeAlias(alias, variance)
             case ANNOTATED =>
-              AnnotatedType(Annotation(readTerm()), readType())
+              val annot = Annotation(readTerm())
+              AnnotatedType(readType(), annot)
             case ANDtype =>
               AndType(readType(), readType())
             case ORtype =>

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -800,10 +800,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         val boundSyms = until(end, readSymbolRef)
         elimExistentials(boundSyms, restpe)
       case ANNOTATEDtpe =>
-        val tp = readTypeRef()
-        // no annotation self type is supported, so no test whether this is a symbol ref
-        val annots = until(end, readAnnotationRef)
-        AnnotatedType.make(annots, tp)
+        AnnotatedType.make(readTypeRef(), until(end, readAnnotationRef))
       case _ =>
         noSuchTypeTag(tag, end)
     }

--- a/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -158,7 +158,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
         }
       case PolyParam(pt, n) =>
         toText(polyParamName(pt.paramNames(n))) ~ polyHash(pt)
-      case AnnotatedType(annot, tpe) =>
+      case AnnotatedType(tpe, annot) =>
         toTextLocal(tpe) ~ " " ~ toText(annot)
       case tp: TypeVar =>
         if (tp.isInstantiated)

--- a/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -190,7 +190,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer  { thisTran
         case tree: TypeTree =>
           tree.withType(
             tree.tpe match {
-              case AnnotatedType(annot, tpe) => AnnotatedType(transformAnnot(annot), tpe)
+              case AnnotatedType(tpe, annot) => AnnotatedType(tpe, transformAnnot(annot))
               case tpe => tpe
             }
           )

--- a/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -179,7 +179,7 @@ object Inferencing {
   /** Recursively widen and also follow type declarations and type aliases. */
   def widenForMatchSelector(tp: Type)(implicit ctx: Context): Type = tp.widen match {
     case tp: TypeRef if !tp.symbol.isClass => widenForMatchSelector(tp.info.bounds.hi)
-    case tp: AnnotatedType => tp.derivedAnnotatedType(tp.annot, widenForMatchSelector(tp.tpe))
+    case tp: AnnotatedType => tp.derivedAnnotatedType(widenForMatchSelector(tp.tpe), tp.annot)
     case tp => tp
   }
 

--- a/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -404,7 +404,7 @@ trait TypeAssigner {
     tree.withType(sym.nonMemberTermRef)
 
   def assignType(tree: untpd.Annotated, annot: Tree, arg: Tree)(implicit ctx: Context) =
-    tree.withType(AnnotatedType(Annotation(annot), arg.tpe))
+    tree.withType(AnnotatedType(arg.tpe, Annotation(annot)))
 
   def assignType(tree: untpd.PackageDef, pid: Tree)(implicit ctx: Context) =
     tree.withType(pid.symbol.valRef)

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -1051,7 +1051,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     if (ctx.mode is Mode.Type)
       assignType(cpy.Annotated(tree)(annot1, arg1), annot1, arg1)
     else {
-      val tpt = TypeTree(AnnotatedType(Annotation(annot1), arg1.tpe.widen))
+      val tpt = TypeTree(AnnotatedType(arg1.tpe.widen, Annotation(annot1)))
       assignType(cpy.Typed(tree)(arg1, tpt), tpt)
     }
   }

--- a/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -90,7 +90,7 @@ class VarianceChecker()(implicit ctx: Context) {
           this(status, tp.resultType) // params will be checked in their TypeDef nodes.
         case tp: PolyType =>
           this(status, tp.resultType) // params will be checked in their ValDef nodes.
-        case AnnotatedType(annot, _) if annot.symbol == defn.UncheckedVarianceAnnot =>
+        case AnnotatedType(_, annot) if annot.symbol == defn.UncheckedVarianceAnnot =>
           status
         //case tp: ClassInfo =>
         //  ???  not clear what to do here yet. presumably, it's all checked at local typedefs

--- a/src/dotty/tools/dotc/typer/Variances.scala
+++ b/src/dotty/tools/dotc/typer/Variances.scala
@@ -83,8 +83,8 @@ object Variances {
       varianceInType(restpe)(tparam)
     case tp @ PolyType(_) =>
       flip(varianceInTypes(tp.paramBounds)(tparam)) & varianceInType(tp.resultType)(tparam)
-    case AnnotatedType(annot, tp) =>
-      varianceInAnnot(annot)(tparam) & varianceInType(tp)(tparam)
+    case AnnotatedType(tp, annot) =>
+      varianceInType(tp)(tparam) & varianceInAnnot(annot)(tparam)
     case tp: AndOrType =>
       varianceInType(tp.tp1)(tparam) & varianceInType(tp.tp2)(tparam)
     case _ =>


### PR DESCRIPTION
The fact that the annotation comes first is weird, because when I write
an annotated type it's <type> @<annotation>. Also, annotated types
are like RefinedTypes in that they derive from a parent type. And in
RefinedTypes the parent comes first.

So swapping the arguments improves consistency. Review by @VladimirNik.
@VladimirNik can you take this PR over to do the same change in the TASTY format?