### PR TITLE
TypeComparer: delay looking up members of AndTypes

### DIFF
--- a/test/dotc/scala-collections.whitelist
+++ b/test/dotc/scala-collections.whitelist
@@ -287,9 +287,7 @@
 ./scala-scala/src/library/scala/collection/generic/SortedMapFactory.scala
 ./scala-scala/src/library/scala/collection/generic/SortedSetFactory.scala
 ./scala-scala/src/library/scala/collection/generic/SetFactory.scala
-
-# deep subtype
-#./scala-scala/src/library/scala/collection/generic/ParFactory.scala
+./scala-scala/src/library/scala/collection/generic/ParFactory.scala
 
 # https://github.com/lampepfl/dotty/issues/974
 #./scala-scala/src/library/scala/collection/generic/MutableSortedSetFactory.scala


### PR DESCRIPTION
In ParFactory.scala we have checks that look like:
```scala
  (Foo { type Bar = X }) & (Foo { type Bar = X }) <:< (Foo { type Bar = X })
```
where `Foo` is a recursive type.

Before this commit, we would first try to check this by looking up `Bar`
in the `AndType` on the left, which means looking it up in both branches
and then merging the result, but the merge requires more subtyping
checks, which in turn require looking up a member inside an `AndType`,
seemingly ad infinitum.

We now avoid this by checking if either branch of the `AndType` on the left
is a subtype of the `RefinedType` on the right before looking up a member
in the `AndType` itself.

Review by @odersky 