### PR TITLE
Fix inefficieny in the presence of aliasing.

### DIFF
--- a/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -369,7 +369,6 @@ class TypeApplications(val self: Type) extends AnyVal {
   /** If this is an encoding of a (partially) applied type, return its arguments,
    *  otherwise return Nil.
    *  Existential types in arguments are returned as TypeBounds instances.
-   *  @param interpolate   See argInfo
    */
   final def argInfos(implicit ctx: Context): List[Type] = {
     var tparams: List[TypeSymbol] = null
@@ -415,16 +414,6 @@ class TypeApplications(val self: Type) extends AnyVal {
 
   /** If this is the image of a type argument to type parameter `tparam`,
    *  recover the type argument, otherwise NoType.
-   *  @param interpolate   If true, replace type bounds as arguments corresponding to
-   *                       variant type parameters by their dominating element. I.e. an argument
-   *
-   *                           T <: U
-   *
-   *                       for a covariant type-parameter becomes U, and an argument
-   *
-   *                           T >: L
-   *
-   *                       for a contravariant type-parameter becomes L.
    */
   final def argInfo(implicit ctx: Context): Type = self match {
     case self: TypeAlias => self.alias

--- a/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -412,8 +412,8 @@ class TypeApplications(val self: Type) extends AnyVal {
       self
   }
 
-  /** If this is the image of a type argument to type parameter `tparam`,
-   *  recover the type argument, otherwise NoType.
+  /** If this is the image of a type argument; recover the type argument,
+   *  otherwise NoType.
    */
   final def argInfo(implicit ctx: Context): Type = self match {
     case self: TypeAlias => self.alias

--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -140,14 +140,14 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
 
   private def firstTry(tp1: Type, tp2: Type): Boolean = tp2 match {
     case tp2: NamedType =>
-      def compareNamed = {
+      def compareNamed(tp1: Type, tp2: NamedType): Boolean = {
         implicit val ctx: Context = this.ctx
         tp2.info match {
           case info2: TypeAlias => firstTry(tp1, info2.alias)
           case _ => tp1 match {
             case tp1: NamedType =>
               tp1.info match {
-                case info1: TypeAlias => firstTry(info1.alias, tp2)
+                case info1: TypeAlias => compareNamed(info1.alias, tp2)
                 case _ =>
                   val sym1 = tp1.symbol
                   (if ((sym1 ne NoSymbol) && (sym1 eq tp2.symbol))
@@ -171,7 +171,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
           }
         }
       }
-      compareNamed
+      compareNamed(tp1, tp2)
     case tp2: ProtoType =>
       isMatchedByProto(tp2, tp1)
     case tp2: BoundType =>

--- a/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -211,7 +211,7 @@ class TreePickler(pickler: TastyPickler) {
       case tpe: SkolemType =>
         pickleType(tpe.info)
       case tpe: RefinedType =>
-        val args = tpe.argInfos(interpolate = false)
+        val args = tpe.argInfos
         if (args.isEmpty) {
           writeByte(REFINEDtype)
           withLength {

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -109,7 +109,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       }
     homogenize(tp) match {
       case tp: RefinedType =>
-        val args = tp.argInfos(interpolate = false)
+        val args = tp.argInfos
         if (args.nonEmpty) {
           val tycon = tp.unrefine
           val cls = tycon.typeSymbol

--- a/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -155,7 +155,7 @@ trait Reporting { this: Context =>
     else {
       // Avoid evaluating question multiple time, since each evaluation
       // may cause some extra logging output.
-      val q: String = question
+      lazy val q: String = question
       traceIndented[T](s"==> $q?", (res: Any) => s"<== $q = ${resStr(res)}")(op)
     }
   }

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -848,7 +848,7 @@ class Namer { typer: Typer =>
     def apply(tp: Type): Type = {
       tp match {
         case tp: RefinedType =>
-          val args = tp.argInfos(interpolate = false).mapconserve(this)
+          val args = tp.argInfos.mapconserve(this)
           if (args.nonEmpty) {
             val tycon = tp.withoutArgs(args)
             val tparams = tycon.typeParams


### PR DESCRIPTION
The change to do compareAlias early caused a dramatic slowdown of compilation

compileStdLib went from 45 sec to 230 sec. The problem were many redundant tests
when every member of an alias chain was compared to every other.

The new scheme follows alias chains to their end before doing anything else. Review by @smarter 