### PR TITLE
Subtle changes to TypeComarer needed for Linker.

### DIFF
--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -218,7 +218,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
             val cls1 = tp1.cls
             cls1.classInfo.selfType.derivesFrom(cls2) &&
             cls2.classInfo.selfType.derivesFrom(cls1)
-          case tp1: TermRef if cls2.is(Module) && cls2.eq(tp1.widen.typeSymbol) =>
+          case tp1: NamedType if cls2.is(Module) && cls2.eq(tp1.widen.typeSymbol) =>
             cls2.isStaticOwner ||
             isSubType(tp1.prefix, cls2.owner.thisType) ||
             secondTry(tp1, tp2)

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -1695,8 +1695,9 @@ object Types {
     override def computeHash = unsupported("computeHash")
   }
 
-  final class TermRefWithFixedSym(prefix: Type, name: TermName, val fixedSym: TermSymbol) extends TermRef(prefix, name) with WithFixedSym
-  final class TypeRefWithFixedSym(prefix: Type, name: TypeName, val fixedSym: TypeSymbol) extends TypeRef(prefix, name) with WithFixedSym
+  // Those classes are non final as Linker extends them.
+  class TermRefWithFixedSym(prefix: Type, name: TermName, val fixedSym: TermSymbol) extends TermRef(prefix, name) with WithFixedSym
+  class TypeRefWithFixedSym(prefix: Type, name: TypeName, val fixedSym: TypeSymbol) extends TypeRef(prefix, name) with WithFixedSym
 
   /** Assert current phase does not have erasure semantics */
   private def assertUnerased()(implicit ctx: Context) =

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -1767,6 +1767,10 @@ object Types {
         withFixedSym(prefix, name, sym)
       else if (sym.defRunId != NoRunId && sym.isCompleted)
         withSig(prefix, name, sym.signature) withSym (sym, sym.signature)
+        // Linker note:
+        // this is problematic, as withSig method could return a hash-consed refference
+        // that could have symbol already set making withSym trigger a double-binding error
+        // ./tests/run/absoverride.scala demonstates this
       else
         all(prefix, name) withSym (sym, Signature.NotAMethod)
 


### PR DESCRIPTION
@Odersky those are the changes that are result of our discussion last Friday.

Only 9714565 is new here, it allows NamedTypes to static modules to be subtypes
of ThisTypes of static modules. This was already allowed for TermRefs.
The commit comment has a motivation example from stdlib.

@Odersky please review.