### PR TITLE
Fix typo in command run by Jenkins

### DIFF
--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -25,7 +25,7 @@ class tests extends CompilerTest {
   implicit val defaultOptions = noCheckOptions ++ List(
       "-Yno-deep-subtypes", "-Yno-double-bindings",
       "-d", defaultOutputDir) ++ {
-    if (isRunByJenkins) List("-Ycheck:-Ycheck:tailrec,resolveSuper,mixin,restoreScopes,labelDef") // should be Ycheck:all, but #725
+    if (isRunByJenkins) List("-Ycheck:tailrec,resolveSuper,mixin,restoreScopes,labelDef") // should be Ycheck:all, but #725
     else List("-Ycheck:tailrec,resolveSuper,mixin,restoreScopes,labelDef")
   }
 


### PR DESCRIPTION
The effect of this typo was that Ycheck:tailrec was never run on Jenkins.

Review by @DarkDimius .