### PR TITLE
Avoid infinite subtyping checks when intersecting denotations

### DIFF
--- a/src/dotty/tools/dotc/core/Denotations.scala
+++ b/src/dotty/tools/dotc/core/Denotations.scala
@@ -259,11 +259,12 @@ object Denotations {
      *
      *  If there is no preferred accessible denotation, return a JointRefDenotation
      *  with one of the operand symbols (unspecified which one), and an info which
-     *  is intersection (&) of the infos of the operand denotations.
+     *  is the intersection (using `&` or `safe_&` if `safeIntersection` is true)
+     *  of the infos of the operand denotations.
      *
      *  If SingleDenotations with different signatures are joined, return NoDenotation.
      */
-    def & (that: Denotation, pre: Type)(implicit ctx: Context): Denotation = {
+    def & (that: Denotation, pre: Type, safeIntersection: Boolean = false)(implicit ctx: Context): Denotation = {
 
       /** Try to merge denot1 and denot2 without adding a new signature. */
       def mergeDenot(denot1: Denotation, denot2: SingleDenotation): Denotation = denot1 match {
@@ -317,7 +318,11 @@ object Denotations {
                   else if (preferSym(sym2, sym1)) sym2
                   else sym1
                 val jointInfo =
-                  try info1 & info2
+                  try
+                    if (safeIntersection)
+                      info1 safe_& info2
+                    else
+                      info1 & info2
                   catch {
                     case ex: MergeError =>
                       if (pre.widen.classSymbol.is(Scala2x) || ctx.scala2Mode)

--- a/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -180,6 +180,15 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer  { thisTran
         case tree: DefDef =>
           transformAnnots(tree)
           superAcc.wrapDefDef(tree)(super.transform(tree).asInstanceOf[DefDef])
+        case tree: TypeDef =>
+          transformAnnots(tree)
+          val sym = tree.symbol
+          val tree1 =
+            if (sym.isClass) tree
+            else {
+              cpy.TypeDef(tree)(rhs = TypeTree(tree.symbol.info))
+            }
+          super.transform(tree1)
         case tree: MemberDef =>
           transformAnnots(tree)
           super.transform(tree)

--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -607,7 +607,6 @@ trait Applications extends Compatibility { self: Typer =>
       case pt: PolyType =>
         if (typedArgs.length <= pt.paramBounds.length)
           typedArgs = typedArgs.zipWithConserve(pt.paramBounds)(adaptTypeArg)
-        Checking.checkBounds(typedArgs, pt)
       case _ =>
     }
     assignType(cpy.TypeApply(tree)(typedFn, typedArgs), typedFn, typedArgs)

--- a/src/dotty/tools/dotc/typer/Checking.scala
+++ b/src/dotty/tools/dotc/typer/Checking.scala
@@ -50,13 +50,16 @@ object Checking {
 
   /** Check all AppliedTypeTree nodes in this tree for legal bounds */
   val boundsChecker = new TreeTraverser {
-    def traverse(tree: Tree)(implicit ctx: Context) = tree match {
-      case AppliedTypeTree(tycon, args) =>
-        val tparams = tycon.tpe.typeSymbol.typeParams
-        val bounds = tparams.map(tparam =>
-          tparam.info.asSeenFrom(tycon.tpe.normalizedPrefix, tparam.owner.owner).bounds)
-        checkBounds(args, bounds, _.substDealias(tparams, _))
-      case _ => traverseChildren(tree)
+    def traverse(tree: Tree)(implicit ctx: Context) = {
+      tree match {
+        case AppliedTypeTree(tycon, args) =>
+          val tparams = tycon.tpe.typeSymbol.typeParams
+          val bounds = tparams.map(tparam =>
+            tparam.info.asSeenFrom(tycon.tpe.normalizedPrefix, tparam.owner.owner).bounds)
+          checkBounds(args, bounds, _.substDealias(tparams, _))
+        case _ =>
+      }
+      traverseChildren(tree)
     }
   }
 

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -961,8 +961,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     val TypeDef(name, rhs) = tdef
     checkLowerNotHK(sym, tdef.tparams.map(symbolOfTree), tdef.pos)
     completeAnnotations(tdef, sym)
-    val _ = typedType(rhs) // unused, typecheck only to remove from typedTree
-    assignType(cpy.TypeDef(tdef)(name, TypeTree(sym.info), Nil), sym)
+    assignType(cpy.TypeDef(tdef)(name, typedType(rhs), Nil), sym)
   }
 
   def typedClassDef(cdef: untpd.TypeDef, cls: ClassSymbol)(implicit ctx: Context) = track("typedClassDef") {

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -186,7 +186,7 @@ class tests extends CompilerTest {
    .filter(_.nonEmpty)
    .toList
 
-  @Test def compileStdLib = compileList("compileStdLib", stdlibFiles, "-migration" :: scala2mode)(allowDeepSubtypes)
+  @Test def compileStdLib = compileList("compileStdLib", stdlibFiles, "-migration" :: scala2mode)
   @Test def compileMixed = compileLine(
       """tests/pos/B.scala
         |./scala-scala/src/library/scala/collection/immutable/Seq.scala

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -108,8 +108,8 @@ class tests extends CompilerTest {
 
   @Test def neg_abstractOverride() = compileFile(negDir, "abstract-override", xerrors = 2)
   @Test def neg_blockescapes() = compileFile(negDir, "blockescapesNeg", xerrors = 1)
-  @Test def neg_bounds() = compileFile(negDir, "bounds", xerrors = 2)
-  @Test def neg_typedapply() = compileFile(negDir, "typedapply", xerrors = 4)
+  @Test def neg_bounds() = compileFile(negDir, "bounds", xerrors = 3)
+  @Test def neg_typedapply() = compileFile(negDir, "typedapply", xerrors = 3)
   @Test def neg_typedIdents() = compileDir(negDir, "typedIdents", xerrors = 2)
   @Test def neg_assignments() = compileFile(negDir, "assignments", xerrors = 3)
   @Test def neg_typers() = compileFile(negDir, "typers", xerrors = 14)(allowDoubleBindings)
@@ -167,6 +167,7 @@ class tests extends CompilerTest {
   @Test def neg_selfreq = compileFile(negDir, "selfreq", xerrors = 2)
   @Test def neg_singletons = compileFile(negDir, "singletons", xerrors = 8)
   @Test def neg_shadowedImplicits = compileFile(negDir, "arrayclone-new", xerrors = 2)
+  @Test def neg_ski = compileFile(negDir, "ski", xerrors = 2)
   @Test def neg_traitParamsTyper = compileFile(negDir, "traitParamsTyper", xerrors = 5)
   @Test def neg_traitParamsMixin = compileFile(negDir, "traitParamsMixin", xerrors = 2)
   @Test def neg_firstError = compileFile(negDir, "firstError", xerrors = 3)
@@ -185,7 +186,7 @@ class tests extends CompilerTest {
    .filter(_.nonEmpty)
    .toList
 
-  @Test def compileStdLib = compileList("compileStdLib", stdlibFiles, "-migration" :: scala2mode)
+  @Test def compileStdLib = compileList("compileStdLib", stdlibFiles, "-migration" :: scala2mode)(allowDeepSubtypes)
   @Test def compileMixed = compileLine(
       """tests/pos/B.scala
         |./scala-scala/src/library/scala/collection/immutable/Seq.scala

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -176,6 +176,7 @@ class tests extends CompilerTest {
   @Test def neg_validateParsing = compileFile(negDir, "validate-parsing", xerrors = 7)
   @Test def neg_validateRefchecks = compileFile(negDir, "validate-refchecks", xerrors = 2)
   @Test def neg_skolemize = compileFile(negDir, "skolemize", xerrors = 2)
+  @Test def neg_nested_bounds = compileFile(negDir, "nested_bounds", xerrors = 1)
 
   @Test def run_all = runFiles(runDir)
 

--- a/tests/neg/bounds.scala
+++ b/tests/neg/bounds.scala
@@ -5,4 +5,8 @@ object Test {
     g("foo")
     new C("bar")
   }
+  def baz[X >: Y, Y <: String](x: X, y: Y) = (x, y)
+
+  baz[Int, String](1, "abc")
+
 }

--- a/tests/neg/nested_bounds.scala
+++ b/tests/neg/nested_bounds.scala
@@ -1,0 +1,5 @@
+class OnlyInt[T <: Int]
+
+object Test {
+  type T = List[OnlyInt[String]] // error: Type argument String does not conform to upper bound Int
+}

--- a/tests/neg/ski.scala
+++ b/tests/neg/ski.scala
@@ -1,0 +1,136 @@
+trait Term {
+  type ap[x <: Term] <: Term
+  type eval <: Term
+}
+
+// The S combinator
+trait S extends Term {
+  type ap[x <: Term] = S1[x]
+  type eval = S
+}
+trait S1[x <: Term] extends Term {
+  type ap[y <: Term] = S2[x, y]
+  type eval = S1[x]
+}
+trait S2[x <: Term, y <: Term] extends Term {
+  type ap[z <: Term] = S3[x, y, z]
+  type eval = S2[x, y]
+}
+trait S3[x <: Term, y <: Term, z <: Term] extends Term {
+  type ap[v <: Term] = eval#ap[v]
+  type eval = x#ap[z]#ap[y#ap[z]]#eval
+}
+
+// The K combinator
+trait K extends Term {
+  type ap[x <: Term] = K1[x]
+  type eval = K
+}
+trait K1[x <: Term] extends Term {
+  type ap[y <: Term] = K2[x, y]
+  type eval = K1[x]
+}
+trait K2[x <: Term, y <: Term] extends Term {
+  type ap[z <: Term] = eval#ap[z]
+  type eval = x#eval
+}
+
+// The I combinator
+trait I extends Term {
+  type ap[x <: Term] = I1[x]
+  type eval = I
+}
+trait I1[x <: Term] extends Term {
+  type ap[y <: Term] = eval#ap[y]
+  type eval = x#eval
+}
+
+// Constants
+
+trait c extends Term {
+  type ap[x <: Term] = c
+  type eval = c
+}
+trait d extends Term {
+  type ap[x <: Term] = d
+  type eval = d
+}
+trait e extends Term {
+  type ap[x <: Term] = e
+  type eval = e
+}
+
+case class Equals[A >: B <:B , B]()
+
+object Test {
+  type T1 = Equals[Int, Int]     // compiles fine
+  type T2 = Equals[String, Int]  // error
+  type T3 = Equals[I#ap[c]#eval, c]
+  type T3a = Equals[I#ap[c]#eval, d]// error
+
+  // Ic -> c
+  type T4 = Equals[I#ap[c]#eval, c]
+
+  // Kcd -> c
+  type T5 = Equals[K#ap[c]#ap[d]#eval, c]
+
+  // KKcde -> d
+  type T6 = Equals[K#ap[K]#ap[c]#ap[d]#ap[e]#eval, d]
+
+  // SIIIc -> Ic
+  type T7 = Equals[S#ap[I]#ap[I]#ap[I]#ap[c]#eval, c]
+
+  // SKKc -> Ic
+  type T8 = Equals[S#ap[K]#ap[K]#ap[c]#eval, c]
+
+  // SIIKc -> KKc
+  type T9 = Equals[S#ap[I]#ap[I]#ap[K]#ap[c]#eval, K#ap[K]#ap[c]#eval]
+
+  // SIKKc -> K(KK)c
+  type T10 = Equals[S#ap[I]#ap[K]#ap[K]#ap[c]#eval, K#ap[K#ap[K]]#ap[c]#eval]
+
+  // SIKIc -> KIc
+  type T11 = Equals[S#ap[I]#ap[K]#ap[I]#ap[c]#eval, K#ap[I]#ap[c]#eval]
+
+  // SKIc -> Ic
+  type T12 = Equals[S#ap[K]#ap[I]#ap[c]#eval, c]
+
+  // R = S(K(SI))K  (reverse)
+  type R = S#ap[K#ap[S#ap[I]]]#ap[K]
+  type T13 = Equals[R#ap[c]#ap[d]#eval, d#ap[c]#eval]
+
+  type b[a <: Term] = S#ap[K#ap[a]]#ap[S#ap[I]#ap[I]]
+
+  trait A0 extends Term {
+    type ap[x <: Term] = c
+    type eval = A0
+  }
+  trait A1 extends Term {
+    type ap[x <: Term] = x#ap[A0]#eval
+    type eval = A1
+  }
+  trait A2 extends Term {
+    type ap[x <: Term] = x#ap[A1]#eval
+    type eval = A2
+  }
+
+  type NN1 = b[R]#ap[b[R]]#ap[A0]
+  type T13a = Equals[NN1#eval, c]
+
+  // Double iteration
+  type NN2 = b[R]#ap[b[R]]#ap[A1]
+  type T14 = Equals[NN2#eval, c]
+
+  // Triple iteration
+  type NN3 = b[R]#ap[b[R]]#ap[A2]
+  type T15 = Equals[NN3#eval, c]
+
+  trait An extends Term {
+    type ap[x <: Term] = x#ap[An]#eval
+    type eval = An
+  }
+
+// Infinite iteration: Smashes scalac's stack
+  type NNn = b[R]#ap[b[R]]#ap[An]
+  // type X = Equals[NNn#eval, c]
+}

--- a/tests/neg/typedapply.scala
+++ b/tests/neg/typedapply.scala
@@ -2,16 +2,12 @@ object typedapply {
 
   def foo[X, Y](x: X, y: Y) = (x, y)
 
-  foo[Int](1, "abc")
+  foo[Int](1, "abc")  // error: wrong number of type parameters
 
-  foo[Int, String, String](1, "abc")
+  foo[Int, String, String](1, "abc") // error: wrong number of type parameters
 
   def bar(x: Int) = x
 
-  bar[Int](1)
-
-  def baz[X >: Y, Y <: String](x: X, y: Y) = (x, y)
-
-  baz[Int, String](1, "abc")
+  bar[Int](1) // error: does not take parameters
 
 }


### PR DESCRIPTION
This PR is based on #1012

Review by @odersky, I don't actually understand why `safeAnd` is safer than `&` but it seems to work well in practice, could you explain why it works so that I can add a comment?