### PR TITLE
VCArrayPrototype: replace override "def clone" by "def clone()"

### DIFF
--- a/src/dotty/runtime/vc/VCPrototype.scala
+++ b/src/dotty/runtime/vc/VCPrototype.scala
@@ -10,7 +10,7 @@ abstract class VCArrayPrototype[T <: VCPrototype] extends Object with Cloneable 
   def apply(idx: Int): Object
   def update(idx: Int, el: T): Unit
   def length: Int
-  override def clone: Object = super.clone()
+  override def clone(): Object = super.clone()
 }
 
 


### PR DESCRIPTION
This prevented Dotty from bootstrapping when the file arguments were
given in a certain order because of #1017. Regardless of what we do
regarding #1017, it makes sense to use "def clone()" here.

Review by @DarkDimius 