### PR TITLE
Improve migration message for Scala 2 procedures

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1732,7 +1732,7 @@ object Parsers {
      */
     def defDefOrDcl(mods: Modifiers): Tree = atPos(tokenRange) {
       def scala2ProcedureSyntax =
-        testScala2Mode("Procedure syntax no longer supported; `=' should be inserted here")
+        testScala2Mode("Procedure syntax no longer supported; `: Unit =' should be inserted here")
       if (in.token == THIS) {
         in.nextToken()
         val vparamss = paramClauses(nme.CONSTRUCTOR)


### PR DESCRIPTION
It's not correct to just add `=` you also need to specify the return
type to be `Unit` otherwise things may not work as expected, this is
especially important for a `main` method.

Review by @odersky 