### PR TITLE
Fix #939. Allows IntMap and LongMap to compile

### DIFF
--- a/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -787,7 +787,8 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {thisTrans
         //  - Scala's arrays are invariant (so we don't drop type tests unsoundly)
         if (extractorArgTypeTest) mkDefault
         else expectedTp match {
-          case ThisType(tref) if tref.symbol.flags is Flags.Module            => and(mkEqualsTest(ref(tref.symbol)), mkTypeTest) // must use == to support e.g. List() == Nil
+          case ThisType(tref) if tref.symbol.flags is Flags.Module            =>
+            and(mkEqualsTest(ref(tref.symbol.companionModule)), mkTypeTest) // must use == to support e.g. List() == Nil
           case ConstantType(Constant(null)) if isAnyRef => mkEqTest(expTp(Literal(Constant(null))))
           case ConstantType(const)                      => mkEqualsTest(expTp(Literal(const)))
           case t:SingletonType                          => mkEqTest(singleton(expectedTp)) // SI-4577, SI-4897

--- a/test/dotc/scala-collections.whitelist
+++ b/test/dotc/scala-collections.whitelist
@@ -189,13 +189,11 @@
 ./scala-scala/src/library/scala/collection/immutable/HashMap.scala
 ./scala-scala/src/library/scala/collection/immutable/HashSet.scala
 
-# https://github.com/lampepfl/dotty/issues/939 -> @darkdimius
-#./scala-scala/src/library/scala/collection/immutable/IntMap.scala
+
+./scala-scala/src/library/scala/collection/immutable/IntMap.scala
 ./scala-scala/src/library/scala/collection/immutable/ListMap.scala
 ./scala-scala/src/library/scala/collection/immutable/ListSet.scala
-
-# https://github.com/lampepfl/dotty/issues/939 -> @darkdimius
-#./scala-scala/src/library/scala/collection/immutable/LongMap.scala
+./scala-scala/src/library/scala/collection/immutable/LongMap.scala
 
 ./scala-scala/src/library/scala/collection/immutable/Map.scala
 ./scala-scala/src/library/scala/collection/immutable/MapLike.scala

--- a/tests/pos/i939.scala
+++ b/tests/pos/i939.scala
@@ -1,0 +1,8 @@
+object IntMap {
+  private case object Nil {
+    override def equals(that : Any) = that match {
+      case _: this.type => true
+      case _            => super.equals(that)
+    }
+  }
+}


### PR DESCRIPTION
See also https://github.com/DarkDimius/scala/commit/69cf4238649c5faa91d29f5969f9d5abda30c783 for a small change in stdlib.