### PR TITLE
Stop crashes because we're out of memory by disabling t7880

### DIFF
--- a/tests/pending/run/t7880.scala
+++ b/tests/pending/run/t7880.scala
@@ -1,3 +1,4 @@
+// Do "git log" on this file to know why it's been moved to pending
 object Test extends dotty.runtime.LegacyApp {
   // This should terminate in one way or another, but it shouldn't loop forever.
   try {


### PR DESCRIPTION
All of our recent memory-related tests failures since
#1030 was merged seem to be caused
by t7880.scala. It tries to intentionally trigger an OutOfMemoryError,
however since we don't pass -Xmx to our run tests it's possible that
this we fill up the memory of our host before we reach the maximum heap
size of the JVM.

Ideally, we would specify a -Xmx for run tests (scalac uses 1 GB),
unfortunately in the version of partest we use this is tricky because we
need to set the system property "partest.java_opts". If we upgrade our
partest to the latest release, we can instead specify it by setting the
argument `javaOpts` of the constructor of `SuiteRunner`, see
scala/scala-partest@7c4659e

Review by @odersky or  @DarkDimius 