### PR TITLE
Changes to wildApprox

### DIFF
--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -56,9 +56,9 @@ object Implicits {
               case mt: MethodType =>
                 mt.isImplicit ||
                 mt.paramTypes.length != 1 ||
-                !(argType relaxed_<:< wildApprox(mt.paramTypes.head)(ctx.fresh.setExploreTyperState))
+                !(argType relaxed_<:< wildApprox(mt.paramTypes.head, poly)(ctx.fresh.setExploreTyperState))
               case rtp =>
-                discardForView(wildApprox(rtp), argType)
+                discardForView(wildApprox(rtp, poly), argType)
             }
           case tpw: TermRef =>
             false // can't discard overloaded refs

--- a/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -379,19 +379,6 @@ object ProtoTypes {
     }
   }
 
-  /** Like wildApprox, but assume that all parameters of `disregarded` are not
-   *  bound in current constraint. This is necessary because an instance of
-   *  the type of a polymorphic function might already be part of the current
-   *  constraint when we try to check another occurrence of the same polymorphic
-   *  function for eligibility. An example is in i1044.scala where one expression
-   *  requires two implicit calls of the same refArrayOps method. When approximating
-   *  the parameter types of such a method we should always ignore type parameters of
-   *  the method itself, even though some of these parameters might still be
-   *  bound in the constraint.
-   */
-  final def wildApprox(tp: Type, disregarded: PolyType)(implicit ctx: Context): Type =
-    wildApprox(tp, new WildApproxMap(disregarded))
-
   /** Approximate occurrences of parameter types and uninstantiated typevars
    *  by wildcard types.
    */
@@ -441,6 +428,19 @@ object ProtoTypes {
     case _ =>
       (if (theMap != null) theMap else new WildApproxMap).mapOver(tp)
   }
+
+  /** Like unary wildApprox, but assume that all parameters of `disregarded` are not
+   *  bound in current constraint. This is necessary because an instance of
+   *  the type of a polymorphic function might already be part of the current
+   *  constraint when we try to check another occurrence of the same polymorphic
+   *  function for eligibility. An example is in i1044.scala where one expression
+   *  requires two implicit calls of the same refArrayOps method. When approximating
+   *  the parameter types of such a method we should always map the type parameters of
+   *  the method itself to wildcards, even though some of these parameters might still be
+   *  bound in the constraint.
+   */
+  final def wildApprox(tp: Type, disregarded: PolyType)(implicit ctx: Context): Type =
+    wildApprox(tp, new WildApproxMap(disregarded))
 
   private[ProtoTypes] class WildApproxMap(val disregarded: Type = NoType)(implicit ctx: Context) extends TypeMap {
     def apply(tp: Type) = wildApprox(tp, this)

--- a/tests/pos/i1044.scala
+++ b/tests/pos/i1044.scala
@@ -1,0 +1,3 @@
+object Test {
+  val x = ???.getClass.getMethods.head.getParameterTypes.mkString(",")
+}


### PR DESCRIPTION
See comment in new overloaded variant of wildApprox for an explanation.
Fixes #1044.

Review by @smarter.