### PR TITLE
Alternative fix for #1044: Properly constrain polymorphic implicit views

### DIFF
--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -52,7 +52,7 @@ object Implicits {
             mt.paramTypes.length != 1 ||
             !(argType relaxed_<:< mt.paramTypes.head)(ctx.fresh.setExploreTyperState)
           case poly: PolyType =>
-            poly.resultType match {
+            constrained(poly).resultType match {
               case mt: MethodType =>
                 mt.isImplicit ||
                 mt.paramTypes.length != 1 ||

--- a/tests/pos/i1044.scala
+++ b/tests/pos/i1044.scala
@@ -1,0 +1,3 @@
+object Test {
+  val x = ???.getClass.getMethods.head.getParameterTypes.mkString(",")
+}


### PR DESCRIPTION
Review by @odersky, this is an alternative to #1054
<hr>
When `wildApprox` encounters a PolyParam it approximates it by its
bounds in the current constraint set, this only makes sense if we have
added the PolyType corresponding to this PolyParam to the constrain set
using `ProtoTypes#constrained`, otherwise, we might get the bounds of
another use of this `PolyType`. This is exactly what happened in
i1044.scala: to compile, the implicit view `refArrayOps` needs to be
used twice with two different type parameters.

The fix is to always constrain polymorphic implicit views before
calling `wildApprox` on their result type.

This fix was inspired by the approach of #1054.