### PR TITLE
Hide stack traces behind -Ydebug

### DIFF
--- a/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -151,6 +151,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val Yheartbeat = BooleanSetting("-Yheartbeat", "show heartbeat stack trace of compiler operations.")
   val Yprintpos = BooleanSetting("-Yprintpos", "show tree positions.")
   val YnoDeepSubtypes = BooleanSetting("-Yno-deep-subtypes", "throw an exception on deep subtyping call stacks.")
+  val YplainPrinter = BooleanSetting("-Yplain-printer", "Pretty-print using a plain printer.")
   val YprintSyms = BooleanSetting("-Yprint-syms", "when printing trees print info in symbols instead of corresponding info in trees.")
   val YtestPickler = BooleanSetting("-Ytest-pickler", "self-test for pickling functionality; should be used with -Ystop-after:pickler")
   val YcheckReentrant = BooleanSetting("-Ycheck-reentrant", "check that compiled program does not contain vars that can be accessed from a global root.")

--- a/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -146,6 +146,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val etaExpandKeepsStar = BooleanSetting("-Yeta-expand-keeps-star", "Eta-expand varargs methods to T* rather than Seq[T].  This is a temporary option to ease transition.")
   val Yinvalidate = StringSetting("-Yinvalidate", "classpath-entry", "Invalidate classpath entry before run", "")
   val noSelfCheck = BooleanSetting("-Yno-self-type-checks", "Suppress check for self-type conformance among inherited members.")
+  val YtraceContextCreation = BooleanSetting("-Ytrace-context-creation", "Store stack trace of context creations.")
   val YshowSuppressedErrors = BooleanSetting("-Yshow-suppressed-errors", "Also show follow-on errors and warnings that are normally supressed.")
   val Yheartbeat = BooleanSetting("-Yheartbeat", "show heartbeat stack trace of compiler operations.")
   val Yprintpos = BooleanSetting("-Yprintpos", "show tree positions.")

--- a/src/dotty/tools/dotc/core/Contexts.scala
+++ b/src/dotty/tools/dotc/core/Contexts.scala
@@ -255,7 +255,7 @@ object Contexts {
     private var creationTrace: Array[StackTraceElement] = _
 
     private def setCreationTrace() =
-      if (this.settings.debug.value)
+      if (this.settings.YtraceContextCreation.value)
         creationTrace = (new Throwable).getStackTrace().take(20)
 
     /** Print all enclosing context's creation stacktraces */

--- a/src/dotty/tools/dotc/core/Denotations.scala
+++ b/src/dotty/tools/dotc/core/Denotations.scala
@@ -465,7 +465,7 @@ object Denotations {
           try info.signature
           catch { // !!! DEBUG
             case scala.util.control.NonFatal(ex) =>
-              println(s"cannot take signature of ${info.show}")
+              ctx.println(s"cannot take signature of ${info.show}")
               throw ex
           }
         case _ => Signature.NotAMethod

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -3386,7 +3386,7 @@ object Types {
   class MissingType(pre: Type, name: Name)(implicit ctx: Context) extends TypeError(
     i"""cannot resolve reference to type $pre.$name
        |the classfile defining the type might be missing from the classpath${otherReason(pre)}""".stripMargin) {
-    printStackTrace()
+    if (ctx.debug) printStackTrace()
   }
 
   private def otherReason(pre: Type)(implicit ctx: Context): String = pre match {

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -186,7 +186,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     val ex = new BadSignature(
       sm"""error reading Scala signature of $classRoot from $source:
           |error occurred at position $readIndex: $msg""")
-    /*if (debug)*/ original.getOrElse(ex).printStackTrace() // !!! DEBUG
+    if (ctx.debug) original.getOrElse(ex).printStackTrace()
     throw ex
   }
 
@@ -423,7 +423,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
               owner.info.decls.checkConsistent()
               if (slowSearch(name).exists)
                 System.err.println(i"**** slow search found: ${slowSearch(name)}")
-              new Exception().printStackTrace()
+              if (ctx.debug) Thread.dumpStack()
               ctx.newStubSymbol(owner, name, source)
             }
           }

--- a/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -32,7 +32,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
   protected def recursionLimitExceeded() = {
     ctx.warning("Exceeded recursion depth attempting to print.")
-    (new Throwable).printStackTrace
+    if (ctx.debug) Thread.dumpStack()
   }
 
   /** If true, tweak output so it is the same before and after pickling */

--- a/src/dotty/tools/dotc/printing/Printers.scala
+++ b/src/dotty/tools/dotc/printing/Printers.scala
@@ -8,7 +8,7 @@ trait Printers { this: Context =>
   /** A function creating a printer */
   def printer = {
     val pr = printerFn(this)
-    if (this.debug) pr.plain else pr
+    if (this.settings.YplainPrinter.value) pr.plain else pr
   }
 }
 

--- a/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
+++ b/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
@@ -63,7 +63,7 @@ class ConsoleReporter(
     if (reader != null) {
       val response = reader.read().asInstanceOf[Char].toLower
       if (response == 'a' || response == 's') {
-        (new Exception).printStackTrace()
+        Thread.dumpStack()
         if (response == 'a')
           sys.exit(1)
       }

--- a/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -327,7 +327,7 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {thisTrans
       private[TreeMakers] def incorporateOuterRebinding(outerSubst: Rebindings): Unit = {
         if (currSub ne null) {
           ctx.debuglog("BUG: incorporateOuterRebinding called more than once for " + ((this, currSub, outerSubst)))
-          Thread.dumpStack()
+          if (ctx.debug) Thread.dumpStack()
         }
         else currSub = outerSubst >> rebindings
       }


### PR DESCRIPTION
They're not very useful for end users and some tests like
tests/neg/selfreq.scala always print these exceptions which makes it
harder to read the test logs,

Also use Thread.dumpStack() instead of creating an Exception and calling
printStackTrace() on it.

Review by @odersky  or @DarkDimius 