### PR TITLE
Force the initialization of throwMethod in Definitions

### DIFF
--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -786,7 +786,7 @@ class Definitions {
     OpsPackageClass)
 
     /** Lists core methods that don't have underlying bytecode, but are synthesized on-the-fly in every reflection universe */
-    lazy val syntheticCoreMethods = AnyMethods ++ ObjectMethods ++ List(String_+)
+    lazy val syntheticCoreMethods = AnyMethods ++ ObjectMethods ++ List(String_+, throwMethod)
 
   private[this] var _isInitialized = false
   private def isInitialized = _isInitialized


### PR DESCRIPTION
This change will fix the problem with unpickling of throw expression from TASTY representation.