### PR TITLE
Handle "missing args" case when expected type is a singleton type.

### DIFF
--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -1343,6 +1343,10 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
     def methodStr = err.refStr(methPart(tree).tpe)
 
+    def missingArgs = errorTree(tree,
+      d"""missing arguments for $methodStr
+         |follow this method with `_' if you want to treat it as a partially applied function""".stripMargin)
+
     def adaptOverloaded(ref: TermRef) = {
       val altDenots = ref.denot.alternatives
       typr.println(i"adapt overloaded $ref with alternatives ${altDenots map (_.info)}%, %")
@@ -1475,12 +1479,11 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         else if (wtp.isImplicit)
           err.typeMismatch(tree, pt)
         else
-          errorTree(tree,
-            d"""missing arguments for $methodStr
-               |follow this method with `_' if you want to treat it as a partially applied function""".stripMargin)
+          missingArgs
       case _ =>
         if (tree.tpe <:< pt) tree
         else if (ctx.mode is Mode.Pattern) tree // no subtype check for pattern
+        else if (wtp.isInstanceOf[MethodType]) missingArgs
         else {
           typr.println(i"adapt to subtype ${tree.tpe} !<:< $pt")
           //typr.println(TypeComparer.explained(implicit ctx => tree.tpe <:< pt))

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -157,6 +157,7 @@ class tests extends CompilerTest {
   @Test def neg_i941 = compileFile(negDir, "i941", xerrors = 3)
   @Test def neg_finalSealed = compileFile(negDir, "final-sealed", xerrors = 2)
   @Test def neg_i705 = compileFile(negDir, "i705-inner-value-class", xerrors = 7)
+  @Test def neg_i803 = compileFile(negDir, "i803", xerrors = 2)
   @Test def neg_i866 = compileFile(negDir, "i866", xerrors = 2)
   @Test def neg_i974 = compileFile(negDir, "i974", xerrors = 2)
   @Test def neg_moduleSubtyping = compileFile(negDir, "moduleSubtyping", xerrors = 4)

--- a/tests/neg/i803.scala
+++ b/tests/neg/i803.scala
@@ -1,0 +1,11 @@
+class Foo{
+  val default = this
+  def foo(a: Int)(b: Foo = default): b.type = b
+
+  def bar(b: Foo = default): b.type = b
+  val x: Foo = bar() // ok
+  val x2: Foo = foo(1)() // ok
+
+  val s: Foo = foo(1) // error
+  val s2: default.type = foo(1) // error
+}


### PR DESCRIPTION
Fixes #803. Review by @DarkDimius 