### PR TITLE
Third try for a fix for #1044: handle TypevarsMissContext mode in wildApprox

### DIFF
--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -52,6 +52,8 @@ object Implicits {
             mt.paramTypes.length != 1 ||
             !(argType relaxed_<:< mt.paramTypes.head)(ctx.fresh.setExploreTyperState)
           case poly: PolyType =>
+            // We do not need to call ProtoTypes#constrained on `poly` because
+            // `refMatches` is always called with mode TypevarsMissContext enabled.
             poly.resultType match {
               case mt: MethodType =>
                 mt.isImplicit ||

--- a/tests/pos/i1044.scala
+++ b/tests/pos/i1044.scala
@@ -1,0 +1,3 @@
+object Test {
+  val x = ???.getClass.getMethods.head.getParameterTypes.mkString(",")
+}


### PR DESCRIPTION
Review by @odersky, this is an alternative to #1054
<hr>
When `wildApprox` encounters a PolyParam it approximates it by its
bounds in the current constraint set, but this is incorrect if
`TypevarsMissContext` is set, we might get the bounds of another use of
this `PolyType`. This is exactly what happened in i1044.scala where the
implicit view `refArrayOps` needs to be used twice with two different
type parameters.

The fix is to approximate a PolyParam by its original bounds in its
PolyType if `TypevarsMissContext` is set.

This fix was inspired by the approach of #1054.