### PR TITLE
Fix #1065 erasedLub for arrays of primitives.

### DIFF
--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -205,7 +205,9 @@ object TypeErasure {
   }
 
   /** The erased least upper bound is computed as follows
-   *  - if both argument are arrays, an array of the lub of the element types
+   *  - if both argument are arrays of objects, an array of the lub of the element types
+   *  - if both arguments are arrays of same primitives, an array of this primitive
+   *  - if one argument is array of primitives and the other is array of objects, Object
    *  - if one argument is an array, Object
    *  - otherwise a common superclass or trait S of the argument classes, with the
    *    following two properties:
@@ -217,8 +219,14 @@ object TypeErasure {
    */
   def erasedLub(tp1: Type, tp2: Type)(implicit ctx: Context): Type = tp1 match {
     case JavaArrayType(elem1) =>
+      import dotty.tools.dotc.transform.TypeUtils._
       tp2 match {
-        case JavaArrayType(elem2) => JavaArrayType(erasedLub(elem1, elem2))
+        case JavaArrayType(elem2) =>
+          if (elem1.isPrimitiveValueType || elem2.isPrimitiveValueType) {
+            if (elem1.classSymbol eq elem2.classSymbol) // same primitive
+              JavaArrayType(elem1)
+            else defn.ObjectType
+          } else JavaArrayType(erasedLub(elem1, elem2))
         case _ => defn.ObjectType
       }
     case _ =>

--- a/tests/pos/erasure-array.scala
+++ b/tests/pos/erasure-array.scala
@@ -1,0 +1,12 @@
+// https://github.com/lampepfl/dotty/issues/1065
+package hello
+
+object world {
+  def mkArray(atype: Int): Array[_ <: AnyVal] = {
+    (if (atype == 1) new Array[Int](10) else new Array[Float](10))
+  }
+
+  def main(args: Array[String]): Unit = {
+    println(mkArray(1))
+  }
+}


### PR DESCRIPTION
Unlike arrays of objects, that can be accessed as an array of a super type     of this object, int[] cannot be accessed as an array of primitives.
Review by @sjrd 