### PR TITLE
Fix bug in erased lub of Java array types.

### DIFF
--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -218,8 +218,12 @@ object TypeErasure {
   def erasedLub(tp1: Type, tp2: Type)(implicit ctx: Context): Type = tp1 match {
     case JavaArrayType(elem1) =>
       tp2 match {
-        case JavaArrayType(elem2) => JavaArrayType(erasedLub(elem1, elem2))
-        case _ => defn.ObjectType
+        case JavaArrayType(elem2) =>
+          val lub = erasedLub(elem1, elem2)
+          if ((elem1 <:< lub) && (elem2 <:< lub)) JavaArrayType(lub)
+          else defn.ObjectType
+        case _ =>
+          defn.ObjectType
       }
     case _ =>
       tp2 match {

--- a/tests/run/i1065.scala
+++ b/tests/run/i1065.scala
@@ -1,0 +1,9 @@
+object Test {
+  def mkArray(atype: Int): Array[_ <: AnyVal] = {
+    (if (atype == 1) new Array[Int](10) else new Array[Float](10))
+  }
+
+  def main(args: Array[String]): Unit = {
+    assert(mkArray(1).length == 10)
+  }
+}


### PR DESCRIPTION
The lub of Int[] and Float[] is Object, not Object[].
Fixes #1065.

Review by @sjrd 