### PR TITLE
partest: run tests with -Xms64M -Xmx1024M instead of JVM defaults

### DIFF
--- a/test/dotty/partest/DPConfig.scala
+++ b/test/dotty/partest/DPConfig.scala
@@ -4,6 +4,8 @@ import scala.collection.JavaConversions._
 import scala.reflect.io.Path
 import java.io.File
 
+import scala.tools.partest.PartestDefaults
+
 
 /** Dotty Partest runs all tests in the provided testDirs located under
   * testRoot. There can be several directories with pos resp. neg tests, as
@@ -15,6 +17,12 @@ import java.io.File
   * otherwise pos/__defaultFlags.flags are used if the file exists).
   */
 object DPConfig {
+  /** Options used for _running_ the run tests.
+   *  Note that this is different from the options used when _compiling_ tests,
+   *  those are determined by the sbt configuration.
+   */
+  val runJVMOpts = s"-Xms64M -Xmx1024M ${PartestDefaults.javaOpts}"
+
   val testRoot = (Path(".") / Path("tests") / Path("partest-generated")).toString
   val genLog = Path(testRoot) / Path("gen.log")
 

--- a/test/dotty/partest/DPConsoleRunner.scala
+++ b/test/dotty/partest/DPConsoleRunner.scala
@@ -65,8 +65,9 @@ class DPSuiteRunner(testSourcePath: String, // relative path, like "files", or "
   consoleArgs: String,
   javaCmdPath: String = PartestDefaults.javaCmd,
   javacCmdPath: String = PartestDefaults.javacCmd,
-  scalacExtraArgs: Seq[String] = Seq.empty)
-extends SuiteRunner(testSourcePath, fileManager, updateCheck, failed, javaCmdPath, javacCmdPath, scalacExtraArgs) {
+  scalacExtraArgs: Seq[String] = Seq.empty,
+  javaOpts: String = DPConfig.runJVMOpts)
+extends SuiteRunner(testSourcePath, fileManager, updateCheck, failed, javaCmdPath, javacCmdPath, scalacExtraArgs, javaOpts) {
 
   if (!DPConfig.runTestsInParallel)
     sys.props("partest.threads") = "1"


### PR DESCRIPTION
This is the same settings that scalac uses, this should help use avoid
using too much memory (the default on 64 bits Linux seems to be
-Xms248M -Xmx3938M).

Review by @DarkDimius 