### PR TITLE
FullParametrization: allow to have $this of ThisType.

### DIFF
--- a/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -91,7 +91,7 @@ trait FullParameterization {
    *
    *  @param abstractOverClass  if true, include the type parameters of the class in the method's list of type parameters.
    *  @param liftThisType       if true, require created $this to be $this: (Foo[A] & Foo,this).
-   *                            This is needed of created member stays inside scope of Foo(as in tailrec)
+   *                            This is needed if created member stays inside scope of Foo(as in tailrec)
    */
   def fullyParameterizedType(info: Type, clazz: ClassSymbol, abstractOverClass: Boolean = true, liftThisType: Boolean = false)(implicit ctx: Context): Type = {
     val (mtparamCount, origResult) = info match {
@@ -225,7 +225,7 @@ trait FullParameterization {
    */
   def forwarder(derived: TermSymbol, originalDef: DefDef, abstractOverClass: Boolean = true, liftThisType: Boolean = false)(implicit ctx: Context): Tree = {
     val fun =
-    ref(derived.termRef)
+      ref(derived.termRef)
         .appliedToTypes(allInstanceTypeParams(originalDef, abstractOverClass).map(_.typeRef))
         .appliedTo(This(originalDef.symbol.enclosingClass.asClass))
 

--- a/tests/neg/tailcall/t6574.scala
+++ b/tests/neg/tailcall/t6574.scala
@@ -4,7 +4,7 @@ class Bad[X, Y](val v: Int) extends AnyVal {
     println("tail")
   }
 
-  @annotation.tailrec final def differentTypeArgs : Unit = {
-    {(); new Bad[String, Unit](0)}.differentTypeArgs
+  @annotation.tailrec final def differentTypeArgs : Unit = { // error
+    {(); new Bad[String, Unit](0)}.differentTypeArgs // error
   }
 }

--- a/tests/pos/tailcall/i1089.scala
+++ b/tests/pos/tailcall/i1089.scala
@@ -1,0 +1,26 @@
+package hello
+
+import scala.annotation.tailrec
+
+class Enclosing {
+  class SomeData(val x: Int)
+
+  def localDef(): Unit = {
+    def foo(data: SomeData): Int = data.x
+
+    @tailrec
+    def test(i: Int, data: SomeData): Unit = {
+      if (i != 0) {
+        println(foo(data))
+        test(i - 1, data)
+      }
+    }
+
+    test(3, new SomeData(42))
+  }
+}
+
+object world extends App {
+  println("hello dotty!")
+  new Enclosing().localDef()
+}


### PR DESCRIPTION
TailRec methods remain members of enclosing class,
it means that they can refer to methods that require this.type.
It means that tailrec, unlike value classes is not allowed to widen
type of $this to it's full self type.

Fixes #1089