### PR TITLE
Change nested typer creation to allow creation of derived typers

### DIFF
--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -508,7 +508,7 @@ class Namer { typer: Typer =>
         if (sym is Module) moduleValSig(sym)
         else valOrDefDefSig(original, sym, Nil, Nil, identity)(localContext(sym).setNewScope)
       case original: DefDef =>
-        val typer1 = new Typer
+        val typer1 = ctx.typer.newLikeThis
         nestedTyper(sym) = typer1
         typer1.defDefSig(original, sym)(localContext(sym).setTyper(typer1))
       case original: TypeDef =>

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -68,6 +68,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
    */
   private var importedFromRoot: Set[Symbol] = Set()
 
+  def newLikeThis: Typer = new Typer
+
   /** Attribute an identifier consisting of a simple name or wildcard
    *
    *  @param tree      The tree representing the identifier.


### PR DESCRIPTION
When the symbol completer runs, it may create a new Typer instance. But if the current typer is a derived typer the completer won't create an instance of the derived type. This change adds a method "newLikeThis" to the Typer class that can be overridden by derived typers.