### PR TITLE
Modernize and clean up the build.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,167 +19,158 @@ object DottyBuild extends Build {
     // "-XX:+HeapDumpOnOutOfMemoryError", "-Xmx1g", "-Xss2m"
   )
 
-  val defaults = Defaults.coreDefaultSettings ++ Seq(
-    scalaVersion in Global := "2.11.5",
-    version in Global := "0.1-SNAPSHOT",
-    organization in Global := "org.scala-lang",
-    organizationName in Global := "LAMP/EPFL",
-    organizationHomepage in Global := Some(url("http://lamp.epfl.ch")),
-    homepage in Global := Some(url("https://github.com/lampepfl/dotty")),
+  override def settings: Seq[Setting[_]] = {
+    super.settings ++ Seq(
+      scalaVersion in Global := "2.11.5",
+      version in Global := "0.1-SNAPSHOT",
+      organization in Global := "org.scala-lang",
+      organizationName in Global := "LAMP/EPFL",
+      organizationHomepage in Global := Some(url("http://lamp.epfl.ch")),
+      homepage in Global := Some(url("https://github.com/lampepfl/dotty")),
 
-    // set sources to src/, tests to test/ and resources to resources/
-    scalaSource in Compile := baseDirectory.value / "src",
-    javaSource in Compile := baseDirectory.value / "src",
-    scalaSource in Test := baseDirectory.value / "test",
-    javaSource in Test := baseDirectory.value / "test",
-    resourceDirectory in Compile := baseDirectory.value / "resources",
-    unmanagedSourceDirectories in Compile := Seq((scalaSource in Compile).value),
-    unmanagedSourceDirectories in Test := Seq((scalaSource in Test).value),
+      // scalac options
+      scalacOptions in Global ++= Seq("-feature", "-deprecation", "-language:existentials,higherKinds,implicitConversions"),
 
-    // Generate compiler.properties, used by sbt
-    resourceGenerators in Compile += Def.task {
-      val file = (resourceManaged in Compile).value / "compiler.properties"
-      val contents = s"version.number=${version.value}"
-      IO.write(file, contents)
-      Seq(file)
-    }.taskValue,
+      javacOptions in Global ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
+    )
+  }
 
-    // include sources in eclipse (downloads source code for all dependencies)
-    //http://stackoverflow.com/questions/10472840/how-to-attach-sources-to-sbt-managed-dependencies-in-scala-ide#answer-11683728
-    com.typesafe.sbteclipse.plugin.EclipsePlugin.EclipseKeys.withSource := true,
+  lazy val dotty = project.in(file(".")).
+    settings(
+      // set sources to src/, tests to test/ and resources to resources/
+      scalaSource in Compile := baseDirectory.value / "src",
+      javaSource in Compile := baseDirectory.value / "src",
+      scalaSource in Test := baseDirectory.value / "test",
+      javaSource in Test := baseDirectory.value / "test",
+      resourceDirectory in Compile := baseDirectory.value / "resources",
+      unmanagedSourceDirectories in Compile := Seq((scalaSource in Compile).value),
+      unmanagedSourceDirectories in Test := Seq((scalaSource in Test).value),
 
-    // to get Scala 2.11
-    resolvers += Resolver.sonatypeRepo("releases"),
+      // Generate compiler.properties, used by sbt
+      resourceGenerators in Compile += Def.task {
+        val file = (resourceManaged in Compile).value / "compiler.properties"
+        val contents = s"version.number=${version.value}"
+        IO.write(file, contents)
+        Seq(file)
+      }.taskValue,
 
-    // get libraries onboard
-    partestDeps := Seq("me.d-d" % "scala-compiler" % "2.11.5-20151022-113908-7fb0e653fd",
-                      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-                      "org.scala-lang" % "scala-library" % scalaVersion.value % "test"),
-    libraryDependencies ++= partestDeps.value,
-    libraryDependencies ++= Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.1",
-                                "org.scala-lang.modules" %% "scala-partest" % "1.0.11" % "test",
-                                "com.novocode" % "junit-interface" % "0.11" % "test",
-                                "jline" % "jline" % "2.12"),
+      // include sources in eclipse (downloads source code for all dependencies)
+      //http://stackoverflow.com/questions/10472840/how-to-attach-sources-to-sbt-managed-dependencies-in-scala-ide#answer-11683728
+      com.typesafe.sbteclipse.plugin.EclipsePlugin.EclipseKeys.withSource := true,
 
-    // scalac options
-    scalacOptions in Global ++= Seq("-feature", "-deprecation", "-language:existentials,higherKinds,implicitConversions"),
+      // get libraries onboard
+      partestDeps := Seq("me.d-d" % "scala-compiler" % "2.11.5-20151022-113908-7fb0e653fd",
+                         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+                         "org.scala-lang" % "scala-library" % scalaVersion.value % "test"),
+      libraryDependencies ++= partestDeps.value,
+      libraryDependencies ++= Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.1",
+                                  "org.scala-lang.modules" %% "scala-partest" % "1.0.11" % "test",
+                                  "com.novocode" % "junit-interface" % "0.11" % "test",
+                                  "jline" % "jline" % "2.12"),
 
-    javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation"),
+      // enable improved incremental compilation algorithm
+      incOptions := incOptions.value.withNameHashing(true),
 
-    // enable improved incremental compilation algorithm
-    incOptions := incOptions.value.withNameHashing(true),
+      // enable verbose exception messages for JUnit
+      testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "--run-listener=test.ContextEscapeDetector"),
+      testOptions in Test += Tests.Cleanup({ () => partestLockFile.delete }),
 
-    // enable verbose exception messages for JUnit
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "--run-listener=test.ContextEscapeDetector"),
-    testOptions in Test += Tests.Cleanup({ () => partestLockFile.delete }),
+      lockPartestFile := {
+        // When this file is present, running `test` generates the files for
+        // partest. Otherwise it just executes the tests directly.
+        val lockDir = partestLockFile.getParentFile
+        lockDir.mkdirs
+        // Cannot have concurrent partests as they write to the same directory.
+        if (lockDir.list.size > 0)
+          throw new RuntimeException("ERROR: sbt partest: another partest is already running, pid in lock file: " + lockDir.list.toList.mkString(" "))
+        partestLockFile.createNewFile
+        partestLockFile.deleteOnExit
+      },
+      runPartestRunner <<= Def.inputTaskDyn {
+        // Magic! This is both an input task and a dynamic task. Apparently
+        // command line arguments get passed to the last task in an aliased
+        // sequence (see partest alias below), so this works.
+        val args = Def.spaceDelimited("<arg>").parsed
+        val jars = Seq((packageBin in Compile).value.getAbsolutePath) ++
+            getJarPaths(partestDeps.value, ivyPaths.value.ivyHome)
+        val dottyJars  = "-dottyJars " + (jars.length + 1) + " dotty.jar" + " " + jars.mkString(" ")
+        // Provide the jars required on the classpath of run tests
+        runTask(Test, "dotty.partest.DPConsoleRunner", dottyJars + " " + args.mkString(" "))
+      },
 
-    lockPartestFile := {
-      // When this file is present, running `test` generates the files for
-      // partest. Otherwise it just executes the tests directly.
-      val lockDir = partestLockFile.getParentFile
-      lockDir.mkdirs
-      // Cannot have concurrent partests as they write to the same directory.
-      if (lockDir.list.size > 0)
-        throw new RuntimeException("ERROR: sbt partest: another partest is already running, pid in lock file: " + lockDir.list.toList.mkString(" "))
-      partestLockFile.createNewFile
-      partestLockFile.deleteOnExit
-    },
-    runPartestRunner <<= Def.inputTaskDyn {
-      // Magic! This is both an input task and a dynamic task. Apparently
-      // command line arguments get passed to the last task in an aliased
-      // sequence (see partest alias below), so this works.
-      val args = Def.spaceDelimited("<arg>").parsed
-      val jars = Seq((packageBin in Compile).value.getAbsolutePath) ++
-          getJarPaths(partestDeps.value, ivyPaths.value.ivyHome)
-      val dottyJars  = "-dottyJars " + (jars.length + 1) + " dotty.jar" + " " + jars.mkString(" ")
-      // Provide the jars required on the classpath of run tests
-      runTask(Test, "dotty.partest.DPConsoleRunner", dottyJars + " " + args.mkString(" "))
-    },
+      // Adjust classpath for running dotty
+      mainClass in (Compile, run) := Some("dotty.tools.dotc.Main"),
+      fork in run := true,
+      fork in Test := true,
+      parallelExecution in Test := false,
 
-    // Adjust classpath for running dotty
-    mainClass in (Compile, run) := Some("dotty.tools.dotc.Main"),
-    fork in run := true,
-    fork in Test := true,
-    parallelExecution in Test := false,
+      // http://grokbase.com/t/gg/simple-build-tool/135ke5y90p/sbt-setting-jvm-boot-paramaters-for-scala
+      javaOptions <++= (managedClasspath in Runtime, packageBin in Compile) map { (attList, bin) =>
+        // put the Scala {library, reflect} in the classpath
+        val path = for {
+          file <- attList.map(_.data)
+          path = file.getAbsolutePath
+        } yield "-Xbootclasspath/p:" + path
+        // dotty itself needs to be in the bootclasspath
+        val fullpath = ("-Xbootclasspath/a:" + bin) :: path.toList
+        // System.err.println("BOOTPATH: " + fullpath)
 
-    // http://grokbase.com/t/gg/simple-build-tool/135ke5y90p/sbt-setting-jvm-boot-paramaters-for-scala
-    javaOptions <++= (managedClasspath in Runtime, packageBin in Compile) map { (attList, bin) =>
-      // put the Scala {library, reflect} in the classpath
-      val path = for {
-        file <- attList.map(_.data)
-        path = file.getAbsolutePath
-      } yield "-Xbootclasspath/p:" + path
-      // dotty itself needs to be in the bootclasspath
-      val fullpath = ("-Xbootclasspath/a:" + bin) :: path.toList
-      // System.err.println("BOOTPATH: " + fullpath)
+        val travis_build = // propagate if this is a travis build
+          if (sys.props.isDefinedAt(JENKINS_BUILD))
+            List(s"-D$JENKINS_BUILD=${sys.props(JENKINS_BUILD)}") ::: travisMemLimit
+          else
+            List()
 
-      val travis_build = // propagate if this is a travis build
-        if (sys.props.isDefinedAt(JENKINS_BUILD))
-          List(s"-D$JENKINS_BUILD=${sys.props(JENKINS_BUILD)}") ::: travisMemLimit
-        else
-          List()
+        val tuning =
+          if (sys.props.isDefinedAt("Oshort"))
+            // Optimize for short-running applications, see https://github.com/lampepfl/dotty/issues/222
+            List("-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1")
+          else
+            List()
 
-      val tuning =
-        if (sys.props.isDefinedAt("Oshort"))
-          // Optimize for short-running applications, see https://github.com/lampepfl/dotty/issues/222
-          List("-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1")
-        else
-          List()
+        ("-DpartestParentID=" + pid) :: tuning ::: agentOptions ::: travis_build ::: fullpath
+      }
+    ).
+    settings(
+      addCommandAlias("partest",                   ";test:package;package;test:runMain dotc.build;lockPartestFile;test:test;runPartestRunner") ++
+      addCommandAlias("partest-only",              ";test:package;package;test:runMain dotc.build;lockPartestFile;test:test-only dotc.tests;runPartestRunner") ++
+      addCommandAlias("partest-only-no-bootstrap", ";test:package;package;                        lockPartestFile;test:test-only dotc.tests;runPartestRunner")
+    )
 
-      ("-DpartestParentID=" + pid) :: tuning ::: agentOptions ::: travis_build ::: fullpath
-    }
-  ) ++ addCommandAlias("partest", ";test:package;package;test:runMain dotc.build;lockPartestFile;test:test;runPartestRunner") ++
-       addCommandAlias("partest-only",             ";test:package;package;test:runMain dotc.build;lockPartestFile;test:test-only dotc.tests;runPartestRunner") ++
-       addCommandAlias("partest-only-no-bootstrap", ";test:package;package;                        lockPartestFile;test:test-only dotc.tests;runPartestRunner")
+  lazy val `dotty-bench` = project.in(file("bench")).
+    dependsOn(dotty % "compile->test").
+    settings(
+      baseDirectory in (Test,run) := (baseDirectory in dotty).value,
 
-  lazy val dotty = Project(id = "dotty", base = file("."), settings = defaults)
+      libraryDependencies ++= Seq("com.storm-enroute" %% "scalameter" % "0.6" % Test,
+        "com.novocode" % "junit-interface" % "0.11"),
+      testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
 
-  lazy val benchmarkSettings = Defaults.coreDefaultSettings ++ Seq(
+      fork in Test := true,
+      parallelExecution in Test := false,
 
-    // to get Scala 2.11
-    resolvers += Resolver.sonatypeRepo("releases"),
+      // http://grokbase.com/t/gg/simple-build-tool/135ke5y90p/sbt-setting-jvm-boot-paramaters-for-scala
+      javaOptions <++= (dependencyClasspath in Runtime, packageBin in Compile) map { (attList, bin) =>
+        // put the Scala {library, reflect, compiler} in the classpath
+        val path = for {
+          file <- attList.map(_.data)
+          path = file.getAbsolutePath
+          prefix = if (path.endsWith(".jar")) "p" else "a"
+        } yield "-Xbootclasspath/" + prefix + ":" + path
+        // dotty itself needs to be in the bootclasspath
+        val fullpath = ("-Xbootclasspath/a:" + bin) :: path.toList
+        // System.err.println("BOOTPATH: " + fullpath)
 
-    baseDirectory in (Test,run) := (baseDirectory in dotty).value,
-
-
-    libraryDependencies ++= Seq("com.storm-enroute" %% "scalameter" % "0.6" % Test,
-      "com.novocode" % "junit-interface" % "0.11"),
-    testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
-
-    // scalac options
-    scalacOptions in Global ++= Seq("-feature", "-deprecation", "-language:existentials,higherKinds,implicitConversions"),
-
-    javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation"),
-
-    fork in Test := true,
-    parallelExecution in Test := false,
-
-    // http://grokbase.com/t/gg/simple-build-tool/135ke5y90p/sbt-setting-jvm-boot-paramaters-for-scala
-    javaOptions <++= (dependencyClasspath in Runtime, packageBin in Compile) map { (attList, bin) =>
-      // put the Scala {library, reflect, compiler} in the classpath
-      val path = for {
-        file <- attList.map(_.data)
-        path = file.getAbsolutePath
-        prefix = if (path.endsWith(".jar")) "p" else "a"
-      } yield "-Xbootclasspath/" + prefix + ":" + path
-      // dotty itself needs to be in the bootclasspath
-      val fullpath = ("-Xbootclasspath/a:" + bin) :: path.toList
-      // System.err.println("BOOTPATH: " + fullpath)
-
-      val travis_build = // propagate if this is a travis build
-        if (sys.props.isDefinedAt(JENKINS_BUILD))
-          List(s"-D$JENKINS_BUILD=${sys.props(JENKINS_BUILD)}")
-        else
-          List()
-      val res = agentOptions ::: travis_build ::: fullpath
-      println("Running with javaOptions: " + res)
-      res
-    }
-  )
-
-
-  lazy val benchmarks = Project(id = "dotty-bench", settings = benchmarkSettings,
-    base = file("bench")) dependsOn(dotty % "compile->test")
+        val travis_build = // propagate if this is a travis build
+          if (sys.props.isDefinedAt(JENKINS_BUILD))
+            List(s"-D$JENKINS_BUILD=${sys.props(JENKINS_BUILD)}")
+          else
+            List()
+        val res = agentOptions ::: travis_build ::: fullpath
+        println("Running with javaOptions: " + res)
+        res
+      }
+    )
 
   // Partest tasks
   lazy val lockPartestFile = TaskKey[Unit]("lockPartestFile", "Creates the lock file at ./tests/locks/partest-<pid>.lock")


### PR DESCRIPTION
Settings `in Global` are moved to Build.settings. Otherwise they
are added *twice* in every project.

Project definitions use the `project` macro rather than the
`Project()` factory, as is the customary notation since sbt
0.13. The `Defaults.coreDefaultSettings` is therefore dropped.

The coding style of project definitions is adapted to the style
shown in sbt documentations.