### PR TITLE
ProtoTypes#wildApprox: fix LazyRef approximation

### DIFF
--- a/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -420,6 +420,8 @@ object ProtoTypes {
         WildcardType(tp1a.bounds | tp2a.bounds)
       else
         tp.derivedOrType(tp1a, tp2a)
+    case tp: LazyRef =>
+      WildcardType
     case tp: SelectionProto =>
       tp.derivedSelectionProto(tp.name, wildApprox(tp.memberProto), NoViewsAllowed)
     case tp: ViewProto =>

--- a/tests/pos/i1103.scala
+++ b/tests/pos/i1103.scala
@@ -1,0 +1,5 @@
+class Sys[S]
+class Foo[T <: Sys[T]] {
+  val t: T = ???
+  def foo[A <: Sys[A]](x: A = t) = x
+}


### PR DESCRIPTION
Before this commit, the output of `wildApprox(A)` where `A <: Sys[LazyRef(A)]` was
`? <: Sys[LazyRef(() => wildApprox(A))]`. This lead to infinite
subtyping checks.

This is fixed by always approximating a LazyRef by an unbounded
wildcard. Since we only create LazyRefs when we encounter a cycle, this
should be safe.

Fix #1103.

 Review by @odersky 