### PR TITLE
Default getters accessibility fix

### DIFF
--- a/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/src/dotty/tools/dotc/ast/Desugar.scala
@@ -186,7 +186,7 @@ object desugar {
             vparamss = takeUpTo(normalizedVparamss, n),
             tpt = TypeTree(),
             rhs = vparam.rhs
-          ).withMods(vparam.mods & AccessFlags)
+          ).withMods(mods & AccessFlags)
         val rest = defaultGetters(vparams :: vparamss1, n + 1)
         if (vparam.rhs.isEmpty) rest else defaultGetter :: rest
       case Nil :: vparamss1 =>

--- a/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/src/dotty/tools/dotc/ast/Desugar.scala
@@ -186,7 +186,7 @@ object desugar {
             vparamss = takeUpTo(normalizedVparamss, n),
             tpt = TypeTree(),
             rhs = vparam.rhs
-          ).withMods(mods & AccessFlags)
+          ).withMods(Modifiers(mods.flags & AccessFlags, mods.privateWithin))
         val rest = defaultGetters(vparams :: vparamss1, n + 1)
         if (vparam.rhs.isEmpty) rest else defaultGetter :: rest
       case Nil :: vparamss1 =>


### PR DESCRIPTION
Default getters should have same accessibility as the method they belong to.
Previously, it was the accessibility of the parameter, which makes no sense.
Fixes #1116.

Review by @DarkDimius 