### PR TITLE
PatMat: remove one more trace of doing several steps at a time

### DIFF
--- a/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -1543,7 +1543,7 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {thisTrans
         val spb = subPatBinders
         ExtractorTreeMaker(extractorApply, lengthGuard(binder), binder)(
           spb,
-          subPatRefs(binder, spb, binderTypeTested),
+          subPatRefs(binder, spb, resultType),
           aligner.isBool,
           checkedLength,
           patBinderOrCasted,

--- a/tests/run/patmat-option-named.scala
+++ b/tests/run/patmat-option-named.scala
@@ -1,0 +1,21 @@
+case class HasSingleField(f: HasSingleField)
+
+object Test {
+
+  def main(args: Array[String]) = {
+    val s: Object = HasSingleField(null)
+    s match {
+      case Matcher(self) => 
+        assert(self ne null)
+    }
+  }
+}
+
+object Matcher {
+ def unapply(x: Object): Option[HasSingleField] = {
+   if (x.isInstanceOf[HasSingleField]) 
+     Some(x.asInstanceOf[HasSingleField]) 
+   else 
+     None 
+  }
+}


### PR DESCRIPTION
When creating subPatRefs the consider returned type of accessor,
not the type of binder.

Fixes #1114