### PR TITLE
Fix FatalError's constructor to forward `msg` to super.

### DIFF
--- a/src/dotty/tools/dotc/Driver.scala
+++ b/src/dotty/tools/dotc/Driver.scala
@@ -1,5 +1,6 @@
 package dotty.tools.dotc
 
+import dotty.tools.FatalError
 import config.CompilerCommand
 import core.Contexts.{Context, ContextBase}
 import util.DotClass
@@ -101,6 +102,3 @@ abstract class Driver extends DotClass {
     sys.exit(if (process(args).hasErrors) 1 else 0)
   }
 }
-
-class FatalError(msg: String) extends Exception(msg)
-

--- a/src/dotty/tools/dotc/Driver.scala
+++ b/src/dotty/tools/dotc/Driver.scala
@@ -102,5 +102,5 @@ abstract class Driver extends DotClass {
   }
 }
 
-class FatalError(msg: String) extends Exception
+class FatalError(msg: String) extends Exception(msg)
 


### PR DESCRIPTION
Previously, `getMessage()` always returned `null`, causing NPEs when trying to report a `FatalError`.