### PR TITLE
Upgrade sbt to 0.13.11 and scalastyle-sbt-plugin to 0.8.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,8 +5,4 @@
 // Scala IDE project file generator
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")
 
-// See https://github.com/scalastyle/scalastyle/issues/156#issuecomment-137229733
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0" excludeAll(
-  ExclusionRule(organization = "com.danieltrinh")))
-
-libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.7"
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")


### PR DESCRIPTION
Upgrading sbt will allow us to experiment with bootstrapping
using sbt since 0.13.11 is the first release that supports building
with dotty (see https://github.com/smarter/dotty-bridge).

Upgrading scalastyle-sbt-plugin allows us to remove the workaround for
https://github.com/scalastyle/scalastyle/issues/156

Review by @DarkDimius 