### PR TITLE
Make Types#membersBasedOnFlags safer and faster

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -612,7 +612,7 @@ object Types {
     /** The set of members  of this type  having at least one of `requiredFlags` but none of  `excludedFlags` set */
     final def membersBasedOnFlags(requiredFlags: FlagSet, excludedFlags: FlagSet)(implicit ctx: Context): Seq[SingleDenotation] = track("implicitMembers") {
       memberDenots(takeAllFilter,
-        (name, buf) => buf ++= member(name).altsWith(x => x.is(requiredFlags, butNot = excludedFlags)))
+        (name, buf) => buf ++= memberExcluding(name, excludedFlags).altsWith(x => x.is(requiredFlags)))
     }
 
     /** The info of `sym`, seen as a member of this type. */


### PR DESCRIPTION
By filtering excluded flags earlier, we avoid forcing some denotations.

Review by @DarkDimius 