### PR TITLE
Rename AllFlags to AnyFlags

### DIFF
--- a/src/dotty/tools/dotc/core/Flags.scala
+++ b/src/dotty/tools/dotc/core/Flags.scala
@@ -508,7 +508,7 @@ object Flags {
   /** These flags are pickled */
   final val PickledFlags = flagRange(FirstFlag, FirstNotPickledFlag)
 
-  final val AllFlags = flagRange(FirstFlag, MaxFlag)
+  final val AnyFlags = flagRange(FirstFlag, MaxFlag)
 
   /** An abstract class or a trait */
   final val AbstractOrTrait = Abstract | Trait

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -256,7 +256,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     def modText(mods: untpd.Modifiers, kw: String): Text = { // DD
       val suppressKw = if (enclDefIsClass) mods is ParamAndLocal else mods is Param
       var flagMask =
-        if (ctx.settings.debugFlags.value) AllFlags
+        if (ctx.settings.debugFlags.value) AnyFlags
         else if (suppressKw) PrintableFlags &~ Private
         else PrintableFlags
       if (homogenizedView && mods.flags.isTypeFlags) flagMask &~= Implicit // drop implicit from classes


### PR DESCRIPTION
`membersBasedOnFlags(requiredFlags = AnyFlags, excludedFlags = ...)` is
easier to understand than
`membersBasedOnFlags(requiredFlags = AllFlags, excludedFlags = ...)`

Review by @DarkDimius 