### PR TITLE
Fix `bin/dotc` checkjar of wrong project

### DIFF
--- a/bin/dotc
+++ b/bin/dotc
@@ -75,7 +75,7 @@ function checkjar {
   fi
 }
 
-checkjar $INTERFACES_JAR interfaces/package interfaces
+checkjar $INTERFACES_JAR dotty-interfaces/package interfaces
 checkjar $MAIN_JAR package src
 checkjar $TEST_JAR test:package test
 


### PR DESCRIPTION
Noticed that `bin/dotc` wasn't working for the "Getting Started" instructions anymore. The failing line was:

```bash
checkjar $INTERFACES_JAR interfaces/package interfaces
````

Which generated the error:

```
[Projects/dotty master] ./bin/dotc tests/pos/HelloWorld.scala
The script is going to build the required jar file /Users/fixel/Projects/dotty/bin/../interfaces/target/dotty-interfaces-0.1-SNAPSHOT.jar by running "sbt interfaces/package"
[info] Loading global plugins from /Users/fixel/.sbt/0.13/plugins
[info] Loading project definition from /Users/fixel/Projects/dotty/project
[info] Set current project to dotty (in build file:/Users/fixel/Projects/dotty/)
[error] Expected ID character
[error] Not a valid command: interfaces
[error] Expected project ID
[error] Expected configuration
[error] Expected ':' (if selecting a configuration)
[error] Expected key
[error] Not a valid key: interfaces (similar: signedArtifacts, signed-artifacts)
[error] interfaces/package
[error]           ^
/Users/fixel/Projects/dotty
The required jar file has not been built by sbt. Please run "sbt interfaces/package"
```

review: @smarter 