### PR TITLE
 Build.scala: increase Jenkins max heap from 1.1G to 1.3G 

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object DottyBuild extends Build {
 
   // Currently, this cannot be increased without hitting the maximum amount of memory
   // available on the Jenkins VMs
-  val travisMemLimit = List("-Xmx1100m")
+  val jenkinsMemLimit = List("-Xmx1100m")
 
   val JENKINS_BUILD = "dotty.jenkins.build"
 
@@ -126,7 +126,7 @@ object DottyBuild extends Build {
 
         val travis_build = // propagate if this is a travis build
           if (sys.props.isDefinedAt(JENKINS_BUILD))
-            List(s"-D$JENKINS_BUILD=${sys.props(JENKINS_BUILD)}") ::: travisMemLimit
+            List(s"-D$JENKINS_BUILD=${sys.props(JENKINS_BUILD)}") ::: jenkinsMemLimit
           else
             List()
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,9 +6,7 @@ import scala.reflect.io.Path
 
 object DottyBuild extends Build {
 
-  // Currently, this cannot be increased without hitting the maximum amount of memory
-  // available on the Jenkins VMs
-  val jenkinsMemLimit = List("-Xmx1100m")
+  val jenkinsMemLimit = List("-Xmx1300m")
 
   val JENKINS_BUILD = "dotty.jenkins.build"
 


### PR DESCRIPTION
This should be safe now that run tests do not take so much memory
anymore (cf #1033 and  #1076).

It would be even better if we could figure out why we're using so much
memory, but that's less important than avoiding spurious test failures.

Review by @DarkDimius 