### PR TITLE
Change isCompanionNeeded

### DIFF
--- a/src/dotty/tools/dotc/Run.scala
+++ b/src/dotty/tools/dotc/Run.scala
@@ -56,12 +56,13 @@ class Run(comp: Compiler)(implicit ctx: Context) {
     ctx.usePhases(phases)
     for (phase <- ctx.allPhases)
       if (!ctx.reporter.hasErrors) {
-        if (ctx.settings.verbose.value) ctx.println(s"[$phase]")
+        val start = System.currentTimeMillis
         units = phase.runOn(units)
         def foreachUnit(op: Context => Unit)(implicit ctx: Context): Unit =
           for (unit <- units) op(ctx.fresh.setPhase(phase.next).setCompilationUnit(unit))
         if (ctx.settings.Xprint.value.containsPhase(phase))
           foreachUnit(printTree)
+        ctx.informTime(s"$phase ", start)
       }
   }
 

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -609,7 +609,7 @@ object Types {
         (name, buf) => buf ++= member(name).altsWith(x => !x.is(Method)))
     }
 
-    /** The set of members  of this type  having at least one of `requiredFlags` but none of  `excludedFlags` set */
+    /** The set of members of this type having at least one of `requiredFlags` but none of `excludedFlags` set */
     final def membersBasedOnFlags(requiredFlags: FlagSet, excludedFlags: FlagSet)(implicit ctx: Context): Seq[SingleDenotation] = track("implicitMembers") {
       memberDenots(takeAllFilter,
         (name, buf) => buf ++= member(name).altsWith(x => x.is(requiredFlags, butNot = excludedFlags)))

--- a/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -48,7 +48,7 @@ class LazyVals extends MiniPhaseTransform with IdentityDenotTransformer with Nee
   override def runsAfter = Set(classOf[Mixin])
 
   def isCompanionNeeded(cls: ClassSymbol)(implicit ctx: Context): Boolean = {
-    def hasLazyVal(x: ClassSymbol) = x.classInfo.membersBasedOnFlags(Flags.Lazy, excludedFlags = Flags.EmptyFlags).nonEmpty
+    def hasLazyVal(cls: ClassSymbol) = cls.info.decls.exists(_.is(Flags.Lazy))
     hasLazyVal(cls) || cls.mixins.exists(hasLazyVal)
   }
 


### PR DESCRIPTION
Fix an inefficiency when compiling stdlib. The fix brings compilation time down from 185s to 44s.
But I seem to remember we used to compile stdlib in ~25s. We should investigate what else
could have slowed it down.

Review by @darkdimius.