### PR TITLE
Do the implicit search shadowing check in the correct context

### DIFF
--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -491,8 +491,8 @@ trait Implicits { self: Typer =>
             pt)
         val generated1 = adapt(generated, pt)
         lazy val shadowing =
-          typed(untpd.Ident(ref.name) withPos pos.toSynthetic, funProto)
-               (nestedContext.addMode(Mode.ImplicitShadowing).setExploreTyperState)
+          typed(untpd.Ident(ref.name) withPos pos.toSynthetic, funProto)(
+            nestedContext.addMode(Mode.ImplicitShadowing).setExploreTyperState)
         def refMatches(shadowing: Tree): Boolean =
           ref.symbol == closureBody(shadowing).symbol || {
             shadowing match {

--- a/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -320,10 +320,8 @@ object ProtoTypes {
    */
   def constrained(pt: PolyType, owningTree: untpd.Tree)(implicit ctx: Context): (PolyType, List[TypeVar]) = {
     val state = ctx.typerState
-    def howmany = if (owningTree.isEmpty) "no" else "some"
-    def committable = if (ctx.typerState.isCommittable) "committable" else "uncommittable"
-    assert(owningTree.isEmpty != ctx.typerState.isCommittable,
-      s"inconsistent: $howmany typevars were added to $committable constraint ${state.constraint}")
+    assert(!(ctx.typerState.isCommittable && owningTree.isEmpty),
+      s"inconsistent: no typevars were added to committable constraint ${state.constraint}")
 
     def newTypeVars(pt: PolyType): List[TypeVar] =
       for (n <- (0 until pt.paramNames.length).toList)


### PR DESCRIPTION
This commit fixes a very sneaky bug, the following code:
```scala
lazy val shadowing =
  typed(untpd.Ident(ref.name) withPos pos.toSynthetic, funProto)
       (nestedContext.addMode(Mode.ImplicitShadowing).setExploreTyperState)
```
is parsed by scalac as:
```scala
lazy val shadowing =
  typed(untpd.Ident(ref.name) withPos pos.toSynthetic, funProto);
(nestedContext.addMode(Mode.ImplicitShadowing).setExploreTyperState);
```
So we don't actually use the nested context in `typed`, instead we end
up implicitly using `ctx`!

Review by @odersky 