### PR TITLE
Removed invalid javacOptions in (Compile, doc)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -45,7 +45,9 @@ object DottyBuild extends Build {
       // Do not append Scala versions to the generated artifacts
       crossPaths := false,
       // Do not depend on the Scala library
-      autoScalaLibrary := false
+      autoScalaLibrary := false,
+      //Remove javac invalid options in Compile doc
+      javacOptions in (Compile, doc) --= Seq("-Xlint:unchecked", "-Xlint:deprecation")
     )
 
   lazy val dotty = project.in(file(".")).


### PR DESCRIPTION
Targeting #1159 

this is the smallest fix that let publish, probably you should consider to add the javac options only on relevant Tasks.