### PR TITLE
Fix bug where ambiguous references were not reported

### DIFF
--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -232,7 +232,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
           }
         }
         val curImport = ctx.importInfo
-        if (curImport != null && curImport.isRootImport && previous.exists) return previous
+        if (ctx.owner.is(Package) && curImport != null && curImport.isRootImport && previous.exists)
+          return previous // no more conflicts possible in this case
         // would import of kind `prec` be not shadowed by a nested higher-precedence definition?
         def isPossibleImport(prec: Int) =
           prevPrec < prec || prevPrec == prec && (prevCtx.scope eq ctx.scope)

--- a/tests/neg/i1145.scala
+++ b/tests/neg/i1145.scala
@@ -1,0 +1,11 @@
+object A {
+   def x = 3
+
+   def y = {
+     import B._
+     x  // error: ambiguous
+   }
+}
+object B {
+  def x = 3
+}


### PR DESCRIPTION
There was a mssing condition which meant Tyepr thought it was
at the outermost scope where but was mistaken.

Fixes #1145. Review by @smarter 