### PR TITLE
Pickle/unpickle SuperAccessor names

### DIFF
--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -383,7 +383,6 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
         case TastyName.SuperAccessor(_) => Flags.SuperAccessor
         case _ => EmptyFlags
       }
-      val superFlag = if (rawName.isInstanceOf)
       pickling.println(i"creating symbol $name at $start with flags $givenFlags")
       val flags = normalizeFlags(tag, givenFlags | nameFlags(rawName), name, isAbstractType, rhsIsEmpty)
       def adjustIfModule(completer: LazyType) =

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -78,7 +78,7 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
     case Shadowed(original) => toTermName(original).shadowedName
     case Expanded(prefix, original) => toTermName(original).expandedName(toTermName(prefix))
     case ModuleClass(original) => toTermName(original).moduleClassName.toTermName
-    case SuperAccessor(accessed) => ???
+    case SuperAccessor(accessed) => toTermName(accessed).superName
     case DefaultGetter(meth, num) => ???
   }
 
@@ -378,9 +378,14 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
       val rhsIsEmpty = noRhs(end)
       if (!rhsIsEmpty) skipTree()
       val (givenFlags, annots, privateWithin) = readModifiers(end)
-      val expandedFlag = if (rawName.isInstanceOf[TastyName.Expanded]) ExpandedName else EmptyFlags
+      def nameFlags(tname: TastyName): FlagSet = tname match {
+        case TastyName.Expanded(_, original) => ExpandedName | nameFlags(tastyName(original))
+        case TastyName.SuperAccessor(_) => Flags.SuperAccessor
+        case _ => EmptyFlags
+      }
+      val superFlag = if (rawName.isInstanceOf)
       pickling.println(i"creating symbol $name at $start with flags $givenFlags")
-      val flags = normalizeFlags(tag, givenFlags | expandedFlag, name, isAbstractType, rhsIsEmpty)
+      val flags = normalizeFlags(tag, givenFlags | nameFlags(rawName), name, isAbstractType, rhsIsEmpty)
       def adjustIfModule(completer: LazyType) =
         if (flags is Module) ctx.adjustModuleCompleter(completer, name) else completer
       val sym =

--- a/tests/run/i1144/AB_1.scala
+++ b/tests/run/i1144/AB_1.scala
@@ -1,0 +1,6 @@
+trait A {
+  def x = 3
+}
+trait B extends A {
+  override def x = super.x * 2
+}

--- a/tests/run/i1144/C_2.scala
+++ b/tests/run/i1144/C_2.scala
@@ -1,0 +1,3 @@
+object Test extends B {
+  def main(args: Array[String]) = assert(x == 6, x)
+}


### PR DESCRIPTION
Needed to restore the SuperAccessor flag in separate compilation.
Fixes #1144.