### PR TITLE
Tweaks to ExplicitOuter and TreeTypeMap

### DIFF
--- a/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -82,9 +82,11 @@ final class TreeTypeMap(
           constr = tmap.transformSub(constr),
           parents = parents mapconserve transform,
           self = tmap.transformSub(self),
-          body = impl.body mapconserve tmap.transform
+          body = impl.body mapconserve
+            (tmap.transform(_)(ctx.withOwner(mapOwner(impl.symbol.owner))))
         ).withType(tmap.mapType(impl.tpe))
     case tree1 =>
+      println(i"tree type map $tree1, owner = ${ctx.owner}")
       tree1.withType(mapType(tree1.tpe)) match {
         case id: Ident if tpd.needsSelect(id.tpe) =>
           ref(id.tpe.asInstanceOf[TermRef]).withPos(id.pos)

--- a/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -86,7 +86,6 @@ final class TreeTypeMap(
             (tmap.transform(_)(ctx.withOwner(mapOwner(impl.symbol.owner))))
         ).withType(tmap.mapType(impl.tpe))
     case tree1 =>
-      println(i"tree type map $tree1, owner = ${ctx.owner}")
       tree1.withType(mapType(tree1.tpe)) match {
         case id: Ident if tpd.needsSelect(id.tpe) =>
           ref(id.tpe.asInstanceOf[TermRef]).withPos(id.pos)

--- a/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/src/dotty/tools/dotc/transform/Constructors.scala
@@ -26,7 +26,7 @@ import collection.mutable
  *   - also moves private fields that are accessed only from constructor
  *     into the constructor if possible.
  */
-class Constructors extends MiniPhaseTransform with SymTransformer { thisTransform =>
+class Constructors extends MiniPhaseTransform with IdentityDenotTransformer { thisTransform =>
   import tpd._
 
   override def phaseName: String = "constructors"
@@ -97,18 +97,6 @@ class Constructors extends MiniPhaseTransform with SymTransformer { thisTransfor
         assert(!tree.rhs.isEmpty, i"unimplemented: $tree")
       case _ =>
     }
-  }
-
-  /** Symbols that are owned by either <local dummy> or a class field move into the
-   *  primary constructor.
-   */
-  override def transformSym(sym: SymDenotation)(implicit ctx: Context): SymDenotation = {
-    def ownerBecomesConstructor(owner: Symbol): Boolean =
-      (owner.isLocalDummy || owner.isTerm && !owner.is(MethodOrLazy)) &&
-      owner.owner.isClass
-    if (ownerBecomesConstructor(sym.owner))
-      sym.copySymDenotation(owner = sym.owner.enclosingClass.primaryConstructor)
-    else sym
   }
 
   /** @return true  if after ExplicitOuter, all references from this tree go via an

--- a/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/src/dotty/tools/dotc/transform/Mixin.scala
@@ -134,8 +134,8 @@ class Mixin extends MiniPhaseTransform with SymTransformer { thisTransform =>
           val vsym = stat.symbol
           val isym = initializer(vsym)
           val rhs = Block(
-            initBuf.toList.map(_.changeOwner(impl.symbol, isym)),
-            stat.rhs.changeOwner(vsym, isym).wildcardToDefault)
+            initBuf.toList.map(_.changeOwnerAfter(impl.symbol, isym, thisTransform)),
+            stat.rhs.changeOwnerAfter(vsym, isym, thisTransform).wildcardToDefault)
           initBuf.clear()
           cpy.DefDef(stat)(rhs = EmptyTree) :: DefDef(isym, rhs) :: Nil
         case stat: DefDef if stat.symbol.isSetter =>

--- a/tests/pos/i1131.scala
+++ b/tests/pos/i1131.scala
@@ -1,0 +1,14 @@
+class Outer {
+  class Inner
+}
+
+trait MustBeATrait {
+  val o = new Outer
+  val inner = {
+    class C {
+      new o.Inner
+    }
+    new C
+  }
+  val inner2 = new o.Inner {}
+}


### PR DESCRIPTION
Fixes #1131.

The test shows interesting behavior where we have to copy local classes using a TreeTypeMap. Since
this happens after erasure (in phase Mixin), we need at the same time be prepared to issue explicit outer paths. There were two problems encountered with this, which are fixed in this PR.