### PR TITLE
support `xs @ _*` and `_*` in Scala2 mode

### DIFF
--- a/tests/neg/i1059.scala
+++ b/tests/neg/i1059.scala
@@ -1,0 +1,10 @@
+object Repeated {
+  val list = List(1, 2, 3)
+
+  list match {
+    case List(_, _, _, _ @ _*)     =>   0  // error: only allowed in Scala2 mode
+    case List(_, _, _*)            =>   1  // error: only allowed in Scala2 mode
+    case List(_, _: _*)            =>   2
+    case Nil                       =>   3
+  }
+}

--- a/tests/pos-scala2/i1059.scala
+++ b/tests/pos-scala2/i1059.scala
@@ -1,0 +1,10 @@
+object Repeated {
+  val list = List(1, 2, 3)
+
+  list match {
+    case List(_, _, _, _ @ _*)     =>   0
+    case List(_, _, _*)            =>   1
+    case List(_, _: _*)            =>   2
+    case Nil                       =>   3
+  }
+}


### PR DESCRIPTION
Fix #1059 

The standard syntax in Dotty now is `xs : _*`. In Scala2 mode,
following code should be valid:

    list match {
      case List(_, _, _, _ @ _*)     =>   0
      case List(_, _, _*)            =>   1
      case List(_, _: _*)            =>   2
      case Nil                       =>   3
    }