### PR TITLE
merge variances and Variances

### DIFF
--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -55,7 +55,7 @@ class tests extends CompilerTest {
   val dotcDir   = toolsDir + "dotc/"
   val coreDir   = dotcDir + "core/"
   val parsingDir = dotcDir + "parsing/"
-  val replDir   = dotcDir + "repl/"
+  val dottyReplDir   = dotcDir + "repl/"
   val typerDir  = dotcDir + "typer/"
 
   @Test def pickle_pickleOK = compileDir(testsDir, "pickling", testPickling)
@@ -254,7 +254,7 @@ class tests extends CompilerTest {
   @Test def tasty_dotc_repl = compileList("tasty_dotc_repl", List(
     "AbstractFileClassLoader.scala", "ConsoleWriter.scala", "InteractiveReader.scala",
     "Interpreter.scala", "Main.scala", "NewLinePrintWriter.scala", "REPL.scala", "SimpleReader.scala"
-  ) map (replDir + _), testPickling)
+  ) map (dottyReplDir + _), testPickling)
 
   //@Test def tasty_dotc_reporting = compileDir(dotcDir, "reporting", testPickling)
   @Test def tasty_dotc_rewrite = compileDir(dotcDir, "rewrite", testPickling)

--- a/tests/neg/variances.scala
+++ b/tests/neg/variances.scala
@@ -41,4 +41,19 @@ object Test2 extends App {
 }
 
 
+trait HasY { type Y }
+
+// These are neg-tests corresponding to the pos-test Variances.scala
+// where all the variance annotations have been inverted.
+trait Foo1[+X] { def bar[Y <: X](y: Y) = y } // error
+trait Foo2[+X] { def bar(x: HasY { type Y <: X })(y: x.Y) = y } // error
+trait Foo3[-X] { def bar[Y >: X](y: Y) = y } // error
+trait Foo4[-X] { def bar(x: HasY { type Y >: X })(y: x.Y) = y } // error
+
+// These are neg-tests corresponding to the pos-test Variances.scala
+// where all the bounds have been flipped.
+trait Foo5[-X] { def bar[Y >: X](y: Y) = y } // error
+trait Foo6[-X] { def bar(x: HasY { type Y >: X })(y: x.Y) = y } // error
+trait Foo7[+X] { def bar[Y <: X](y: Y) = y } // error
+trait Foo8[+X] { def bar(x: HasY { type Y <: X })(y: x.Y) = y } // error
 

--- a/tests/pos/variances.scala
+++ b/tests/pos/variances.scala
@@ -1,3 +1,18 @@
 trait C[+T <: C[T, U], -U <: C[T, U]] {
 
 }
+trait HasY { type Y }
+
+// This works in scalac.
+trait Foo1[-X] { def bar[Y <: X](y: Y) = y }
+
+// A variant of Foo1 using a dependent method type (doesn't work using
+// scalac)
+trait Foo2[-X] { def bar(x: HasY { type Y <: X })(y: x.Y) = y }
+
+// This works in scalac.
+trait Foo3[+X] { def bar[Y >: X](y: Y) = y }
+
+// A variant of Foo3 using a dependent method type (doesn't work
+// using scalac)
+trait Foo4[+X] { def bar(x: HasY { type Y >: X })(y: x.Y) = y }


### PR DESCRIPTION
We had variances.scala and Variances.scala in pos and neg. This messes up MacOS royally, to a point where a rebase gets stuck in an infinite loop. I merged the two pairs of tests. 