### PR TITLE
Temporarily enable printing of original failure signature.

### DIFF
--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -180,7 +180,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     val ex = new BadSignature(
       sm"""error reading Scala signature of $classRoot from $source:
           |error occurred at position $readIndex: $msg""")
-    if (ctx.debug) original.getOrElse(ex).printStackTrace()
+    if (ctx.debug || true) original.getOrElse(ex).printStackTrace() // temporarilly enable printing of original failure signature to debug failing builds
     throw ex
   }
 


### PR DESCRIPTION
Temporarily enable printing of original failure signature to debug failing builds.