### PR TITLE
Make erased value type take a TypeRef instead of a ClassSymbol

### DIFF
--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -237,10 +237,10 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     case OrType(tp21, tp22) =>
       if (tp21.stripTypeVar eq tp22.stripTypeVar) isSubType(tp1, tp21)
       else secondTry(tp1, tp2)
-    case TypeErasure.ErasedValueType(cls2, underlying2) =>
+    case TypeErasure.ErasedValueType(tycon1, underlying2) =>
       def compareErasedValueType = tp1 match {
-        case TypeErasure.ErasedValueType(cls1, underlying1) =>
-          (cls1 eq cls2) && isSameType(underlying1, underlying2)
+        case TypeErasure.ErasedValueType(tycon2, underlying1) =>
+          (tycon1.symbol eq tycon2.symbol) && isSameType(underlying1, underlying2)
         case _ =>
           secondTry(tp1, tp2)
       }

--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -69,17 +69,17 @@ object TypeErasure {
    *  @param   cls               The value class symbol
    *  @param   erasedUnderlying  The erased type of the single field of the value class
    */
-  abstract case class ErasedValueType(cls: ClassSymbol, erasedUnderlying: Type)
+  abstract case class ErasedValueType(tycon: TypeRef, erasedUnderlying: Type)
   extends CachedGroundType with ValueType {
-    override def computeHash = doHash(cls, erasedUnderlying)
+    override def computeHash = doHash(tycon, erasedUnderlying)
   }
 
-  final class CachedErasedValueType(cls: ClassSymbol, erasedUnderlying: Type)
-    extends ErasedValueType(cls, erasedUnderlying)
+  final class CachedErasedValueType(tycon: TypeRef, erasedUnderlying: Type)
+    extends ErasedValueType(tycon, erasedUnderlying)
 
   object ErasedValueType {
-    def apply(cls: ClassSymbol, erasedUnderlying: Type)(implicit ctx: Context) = {
-      unique(new CachedErasedValueType(cls, erasedUnderlying))
+    def apply(tycon: TypeRef, erasedUnderlying: Type)(implicit ctx: Context) = {
+      unique(new CachedErasedValueType(tycon, erasedUnderlying))
     }
   }
 
@@ -411,7 +411,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
   private def eraseDerivedValueClassRef(tref: TypeRef)(implicit ctx: Context): Type = {
     val cls = tref.symbol.asClass
     val underlying = underlyingOfValueClass(cls)
-    if (underlying.exists) ErasedValueType(cls, valueErasure(underlying))
+    if (underlying.exists) ErasedValueType(tref, valueErasure(underlying))
     else NoType
   }
 

--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -66,7 +66,7 @@ object TypeErasure {
    *  Nothing. This is because this type is only useful for type adaptation (see
    *  [[Erasure.Boxing#adaptToType]]).
    *
-   *  @param   cls               The value class symbol
+   *  @param   tycon             A TypeRef referring to the value class symbol
    *  @param   erasedUnderlying  The erased type of the single field of the value class
    */
   abstract case class ErasedValueType(tycon: TypeRef, erasedUnderlying: Type)

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -157,8 +157,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           return toText(tp.info)
       case ExprType(result) =>
         return "=> " ~ toText(result)
-      case ErasedValueType(clazz, underlying) =>
-        return "ErasedValueType(" ~ toText(clazz.typeRef) ~ ", " ~ toText(underlying) ~ ")"
+      case ErasedValueType(tycon, underlying) =>
+        return "ErasedValueType(" ~ toText(tycon) ~ ", " ~ toText(underlying) ~ ")"
       case tp: ClassInfo =>
         return toTextParents(tp.parentsWithArgs) ~ "{...}"
       case JavaArrayType(elemtp) =>

--- a/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -70,7 +70,7 @@ class ExtensionMethods extends MiniPhaseTransform with DenotTransformer with Ful
             }
 
             val underlying = valueErasure(underlyingOfValueClass(valueClass))
-            val evt = ErasedValueType(valueClass, underlying)
+            val evt = ErasedValueType(valueClass.typeRef, underlying)
             val u2evtSym = ctx.newSymbol(moduleSym, nme.U2EVT, Synthetic | Method,
               MethodType(List(nme.x_0), List(underlying), evt))
             val evt2uSym = ctx.newSymbol(moduleSym, nme.EVT2U, Synthetic | Method,


### PR DESCRIPTION
To address #1198, we need to avoid putting symbols in ErasedValueTypes.
Fixes #1198.

Review by @VladimirNik.