### PR TITLE
[do not merge] Issues with TASTY - dotty pickling/unpickling

### DIFF
--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -47,6 +47,8 @@ class tests extends CompilerTest {
   val runDir        = testsDir + "run/"
   val newDir        = testsDir + "new/"
   val replDir       = testsDir + "repl/"
+  val tastyDir      = testsDir + "tasty/"
+  val tastyFailedDir = tastyDir + "failed/"
 
   val sourceDir = "./src/"
   val dottyDir  = sourceDir + "dotty/"
@@ -287,4 +289,34 @@ class tests extends CompilerTest {
   @Test def tasty_dotc_util = compileDir(dotcDir, "util", testPickling)
   @Test def tasty_tools_io = compileDir(toolsDir, "io", testPickling)
   @Test def tasty_tests = compileDir(testsDir, "tasty", testPickling)
+
+  //TODO - failed TASTY tests
+  @Test def tasty_runtime_vc = compileDir(s"${dottyDir}runtime/", "vc", testPickling)
+  @Test def tasty_fail1 = compileFile(tastyFailedDir, "Fail1", testPickling)
+
+  //issue with types in import, lazy val imports from Scala
+  @Test def tasty_fail_backend = compileFile(s"${backendDir}jvm/", "DottyBackendInterface", testPickling)
+
+  @Test def tasty_fail_sjs = compileDir(s"${backendDir}", "sjs", testPickling)
+
+  @Test def tasty_fail_types = compileFile(coreDir, "Types", testPickling)
+  @Test def tasty_fail2 = compileFile(tastyFailedDir, "Fail2", testPickling)
+  //TODO - Fail3.scala - problem with the compilation after unpickling
+
+  @Test def tasty_fail_parsers = compileFile(parsingDir, "Parsers", testPickling)
+  @Test def tasty_fail4 = compileFile(tastyFailedDir, "Fail4", testPickling)
+
+  @Test def tasty_fail_repl1 = compileFile(dotcDir + "repl/", "CompilingInterpreter", testPickling)
+  @Test def tasty_fail5 = compileFile(tastyFailedDir, "Fail5", testPickling)
+
+  //var param, issue with order
+  @Test def tasty_fail6 = compileFile(tastyFailedDir, "Fail6", testPickling)
+  //TODO - Fail7.scala - problem with unpickling - var param
+
+  @Test def tasty_fail_transform = compileFile(s"${dotcDir}transform/", "PatternMatcher", testPickling)
+  @Test def tasty_fail8 = compileFile(tastyFailedDir, "Fail8", testPickling)
+  @Test def tasty_fail9 = compileFile(tastyFailedDir, "Fail9", testPickling)
+
+  @Test def tasty_fail_typer = compileFile(typerDir, "Namer", testPickling)
+  @Test def tasty_fail10 = compileFile(tastyFailedDir, "Fail10", testPickling)
 }

--- a/tests/tasty/failed/Fail1.scala
+++ b/tests/tasty/failed/Fail1.scala
@@ -1,0 +1,8 @@
+class Test[T] {
+  def testMethod: Unit =
+    new Foo(this)
+}
+
+class Foo[T] {
+  def this(ct: Test[T]) = this()
+}

--- a/tests/tasty/failed/Fail10.scala
+++ b/tests/tasty/failed/Fail10.scala
@@ -1,0 +1,7 @@
+class Fail10 {
+  Nil foreach {
+    case cdef =>
+      Some(true)
+    case _ =>
+  }
+}

--- a/tests/tasty/failed/Fail2.scala
+++ b/tests/tasty/failed/Fail2.scala
@@ -1,0 +1,14 @@
+class Test() {
+  thisTest => //pickling representation is the same if remove self renaming
+
+  import Test._
+
+  val myStatus: Status = Unknown
+
+  def currentStatus: Status = myStatus
+}
+
+object Test {
+  private type Status = Byte
+  val Unknown: Status = 0
+}

--- a/tests/tasty/failed/Fail3.scala
+++ b/tests/tasty/failed/Fail3.scala
@@ -1,0 +1,9 @@
+//compilation fails after unpickling
+  class Test() {
+    import Test._
+
+    val myStatus = Unknown
+  }
+  object Test {
+    private val Unknown: Int = 0 // not yet computed
+  }

--- a/tests/tasty/failed/Fail4.scala
+++ b/tests/tasty/failed/Fail4.scala
@@ -1,0 +1,5 @@
+class Builder(parser: Parser)
+
+class Parser {
+  object concreteBuilder extends Builder(this)
+}

--- a/tests/tasty/failed/Fail5.scala
+++ b/tests/tasty/failed/Fail5.scala
@@ -1,0 +1,4 @@
+class Fail5 {
+  val someClass: Class[_] = ???
+  val resultMethod = someClass.getMethod("result")
+}

--- a/tests/tasty/failed/Fail6.scala
+++ b/tests/tasty/failed/Fail6.scala
@@ -1,0 +1,2 @@
+//different order of getter and setter of in
+abstract class Fail6(var in: Int, out: Double)

--- a/tests/tasty/failed/Fail7.scala
+++ b/tests/tasty/failed/Fail7.scala
@@ -1,0 +1,13 @@
+//Problem with unpickling
+//error: class Test needs to be abstract, since <accessor> var in_=: (x$1: Int)Unit is not defined
+//  (Note that an abstract var requires a setter in addition to the getter)
+//  one error found
+class Fail7(var in: Int)
+
+/*
+//This code fails while compiling with -Ycheck:all
+//Exception in thread "main" java.lang.AssertionError: assertion failed: method in_$eq is both Deferred and Private
+abstract class Fail7(private var in: Int, out: Double) {
+  val interpreter = 5
+}
+*/

--- a/tests/tasty/failed/Fail8.scala
+++ b/tests/tasty/failed/Fail8.scala
@@ -1,0 +1,6 @@
+trait Fail8 {
+  val ignoredSubPatBinders: Set[Int]
+  val storedBinders: Set[Int] =
+    (if (true) List.empty.toSet else Set.empty) ++ extraStoredBinders -- ignoredSubPatBinders
+  val extraStoredBinders: Set[Int]
+}

--- a/tests/tasty/failed/Fail9.scala
+++ b/tests/tasty/failed/Fail9.scala
@@ -1,0 +1,2 @@
+//def <init>$default$2(private[this] val param1: scala.Int)
+class Fail9(param1: Int)(param2: Boolean = true) //default value should be in second param list, and multiple parameter lists


### PR DESCRIPTION
After checking (pickling/unpickling) src/dotty:
- There are 10 files that have different trees representations after unpickling (string representation).
- For each case I added sample file representing issue in addition to original source file from Dotty (files Fail1.scala - Fail10.scala)
- I checked each sample file with FromTasty: **6 files** can be compiled and checked with -Ycheck:all, **4 files** have issues during compilation/checking.

#### **Compilation issues**:

**1)** Issue with private field access (`val Unknown` in `object Test`) from `class Test` (Fail3.scala):
```scala
class Test() {
  import Test._
  val myStatus = Unknown
}
object Test {
  private val Unknown: Int = 0
}
```
Unpickling with FromTasty results in:
```
assertion failed: private getter Unknown in object Test$ in null 
accessed from constructor Test in class Test in Simple(Fail3.scala)
```
Similar code is in: dotty/tools/dotc/core/Types.scala
<br>
**2)** Issue with var parameter in class (Fail7.scala): 
```scala
class Fail7(var in: Int)
```
Unpickling with FromTasty results in:
```
error: class Test needs to be abstract, since 
<accessor> var in_=: (x$1: Int)Unit is not defined
(Note that an abstract var requires a setter in addition to the getter)
```

<br>
#### **-Ycheck:all issues**

**3)** Code example (Fail1.scala):
```scala
class Test[T] {
  def testMethod: Unit =
    new Foo(this)
}
class Foo[T] {
  def this(ct: Test[T]) = this()
}
```
Differences (in `def testMethod`). Such expression before pickling:
```
<<new Foo:Foo>:([T](ct: Test[T])Foo[T])>[T]
```
after unpickling becomes:
```
<<new Foo:Foo>:([T = Foo @UnsafeNonvariant#T](ct: Test[Foo @UnsafeNonvariant#T])Foo[T])>[T]
```
Unpickling with FromTasty using `-Ycheck:all` results in:
```
*** error while checking Simple(Fail1.scala) after phase frontend ***
java.lang.AssertionError: assertion failed: error at Simple(Fail1.scala):2
type mismatch:
 found   : Test[T(in Test)](Test.this)
 required: Test[Foo @UnsafeNonvariant#T(in Foo)]
tree = This(Test)
```
Similar code is in: dotty/runtime/vc/VCPrototype.scala
<br>
**4)** Code example (Fail5.scala):
```scala
class Fail5 {
  val someClass: Class[_] = ???
  val resultMethod = someClass.getMethod("result")
}
```
Differences in types (in `val resultMethod`). Such expression before pickling:
```
    val resultMethod: Method = 
        this:Fail5.someClass.getMethod:((x$0: String, x$1: Class[_]*)Method)>(
            <"result":String>,
            <<[ : java.lang.Class[_]]:scala.Array[java.lang.Class[_]]>: ...
```
after unpickling becomes:
```
    val resultMethod: Method = 
        this:Fail5.someClass.getMethod:((x$0: String, x$1: Class[_]*).Method)>(
            <"result":String("result")>,
            <<[ : java.lang.Class[_]]:scala.collection.Seq[java.lang.Class[_]]>: ...
```

The difference is that the type for x$1 arg changes from **scala.Array** to **scala.collection.Seq**

Unpickling with FromTasty using `-Ycheck:all` results in:
```
*** error while checking Simple(Fail5.scala) after phase frontend ***
java.lang.AssertionError: assertion failed: error at Simple(Fail5.scala):2
type mismatch:
 found   : scala.collection.Seq[Class[_]]
 required: Array[Class[_]]
```
Similar code is in: dotty/tools/dotc/repl/CompilingInterpreter.scala