### PR TITLE
Two fixes to TermRefWithSignature.newLikeThis

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -1743,7 +1743,7 @@ object Types {
       if (symbol.exists && !candidate.symbol.exists) { // recompute from previous symbol
         val ownSym = symbol
         val newd = asMemberOf(prefix)
-        candidate.withDenot(asMemberOf(prefix).suchThat(_ eq ownSym))
+        candidate.withDenot(newd.suchThat(_ eq ownSym))
       }
       else candidate
     }

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -1743,7 +1743,7 @@ object Types {
       if (symbol.exists && !candidate.symbol.exists) { // recompute from previous symbol
         val ownSym = symbol
         val newd = asMemberOf(prefix)
-        candidate.withDenot(newd.suchThat(_ eq ownSym))
+        candidate.withDenot(newd.suchThat(_.signature == ownSym.signature))
       }
       else candidate
     }


### PR DESCRIPTION
Used to compute `asMemberOf(prefix)` twice and assume that symbol does not change.

@odersky please review