### PR TITLE
Fix issues with `enterBlock` for comment parsing

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1879,7 +1879,7 @@ object Parsers {
             in.nextToken()
             TypeDef(name, tparams, typ()).withMods(mods).setComment(docstring)
           case SUPERTYPE | SUBTYPE | SEMI | NEWLINE | NEWLINES | COMMA | RBRACE | EOF =>
-            TypeDef(name, tparams, typeBounds()).withMods(mods)
+            TypeDef(name, tparams, typeBounds()).withMods(mods).setComment(docstring)
           case _ =>
             syntaxErrorOrIncomplete("`=', `>:', or `<:' expected")
             EmptyTree

--- a/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -180,15 +180,15 @@ object Scanners {
     /** All doc comments as encountered, each list contains doc comments from
      *  the same block level. Starting with the deepest level and going upward
      */
-    private[this] var docsPerBlockStack: List[List[Comment]] = List(List())
+    private[this] var docsPerBlockStack: List[List[Comment]] = List(Nil)
 
     /** Adds level of nesting to docstrings */
     def enterBlock(): Unit =
-      docsPerBlockStack = Nil ::: docsPerBlockStack
+      docsPerBlockStack = List(Nil) ::: docsPerBlockStack
 
     /** Removes level of nesting for docstrings */
     def exitBlock(): Unit = docsPerBlockStack = docsPerBlockStack match {
-      case x :: xs => List(List())
+      case x :: Nil => List(Nil)
       case _ => docsPerBlockStack.tail
     }
 

--- a/test/test/DottyDocParsingTests.scala
+++ b/test/test/DottyDocParsingTests.scala
@@ -456,4 +456,34 @@ class DottyDocParsingTests extends DottyDocTest {
         }
     }
   }
+
+  @Test def withExtends = {
+    val source =
+      """
+      |trait Trait1
+      |/** Class1 */
+      |class Class1 extends Trait1
+      """.stripMargin
+
+    import dotty.tools.dotc.ast.untpd._
+    checkFrontend(source) {
+      case p @ PackageDef(_, Seq(_, c: TypeDef)) =>
+        checkDocString(c.rawComment, "/** Class1 */")
+    }
+  }
+
+  @Test def withAnnotation = {
+    val source =
+      """
+      |/** Class1 */
+      |@SerialVersionUID(1)
+      |class Class1
+      """.stripMargin
+
+    import dotty.tools.dotc.ast.untpd._
+    checkFrontend(source) {
+      case p @ PackageDef(_, Seq(c: TypeDef)) =>
+        checkDocString(c.rawComment, "/** Class1 */")
+    }
+  }
 } /* End class */


### PR DESCRIPTION
There was a small error in my code where `enterBlock` would not add an empty list to the beginning of the `docsPerBlockStack` but instead add the elements from the empty list to the current list of lists.

review: @DarkDimius 