### PR TITLE
Fix #1214: PolyType return types may need wrapping with ExprType

### DIFF
--- a/src/dotty/tools/dotc/ast/tpd.scala
+++ b/src/dotty/tools/dotc/ast/tpd.scala
@@ -473,7 +473,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
         case tree: Select if qualifier.tpe eq tree.qualifier.tpe =>
           tree1.withTypeUnchecked(tree.tpe)
         case _ => tree.tpe match {
-          case tpe: NamedType => tree1.withType(tpe.derivedSelect(qualifier.tpe))
+          case tpe: NamedType => tree1.withType(tpe.derivedSelect(qualifier.tpe.widenIfUnstable))
           case _ => tree1.withTypeUnchecked(tree.tpe)
         }
       }

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -112,9 +112,13 @@ trait NamerContextOps { this: Context =>
             if (param.info.isDirectRef(defn.ObjectClass)) param.info = defn.AnyType
         make.fromSymbols(params, resultType)
       }
-    if (typeParams.nonEmpty) PolyType.fromSymbols(typeParams, monotpe)
-    else if (valueParamss.isEmpty) ExprType(monotpe)
-    else monotpe
+
+    val exprIfNeeded =
+      if (valueParamss.isEmpty) ExprType(monotpe)
+      else monotpe
+
+    if (typeParams.nonEmpty) PolyType.fromSymbols(typeParams, exprIfNeeded)
+    else exprIfNeeded
   }
 
   /** Find moduleClass/sourceModule in effective scope */

--- a/tests/pos/i1214.scala
+++ b/tests/pos/i1214.scala
@@ -1,0 +1,3 @@
+class Test {
+  def foo[T] = 5
+}


### PR DESCRIPTION
Namer.methodType is used to get type of method given types of arguments,
    type parameters and return type.
    It has a special case if method does not take arguments that wraps return
    type with ExprType.
    Such wrapping needs to be also performed in case method has type
    parameters.