### PR TITLE
Fix #1216 Desugar: vals that are desugared PatDef may need setters.

### DIFF
--- a/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/src/dotty/tools/dotc/ast/Desugar.scala
@@ -634,8 +634,11 @@ object desugar {
   def makeAnnotated(cls: Symbol, tree: Tree)(implicit ctx: Context) =
     Annotated(untpd.New(untpd.TypeTree(cls.typeRef), Nil), tree)
 
-  private def derivedValDef(named: NameTree, tpt: Tree, rhs: Tree, mods: Modifiers) =
-    ValDef(named.name.asTermName, tpt, rhs).withMods(mods).withPos(named.pos)
+  private def derivedValDef(named: NameTree, tpt: Tree, rhs: Tree, mods: Modifiers)(implicit ctx: Context) = {
+    val vdef = ValDef(named.name.asTermName, tpt, rhs).withMods(mods).withPos(named.pos)
+    val mayNeedSetter = valDef(vdef)
+    mayNeedSetter
+   }
 
   private def derivedDefDef(named: NameTree, tpt: Tree, rhs: Tree, mods: Modifiers) =
     DefDef(named.name.asTermName, Nil, Nil, tpt, rhs).withMods(mods).withPos(named.pos)

--- a/tests/pos/i1216.scala
+++ b/tests/pos/i1216.scala
@@ -1,0 +1,11 @@
+object Main {
+  val MAX = 10
+  val s1, s2, target = new Array[Long](MAX)
+
+  var i, j = 0
+
+  while (i < MAX) {
+    target(i) = s1(i) + s2(i)
+    i+= 1
+  }
+}

--- a/tests/pos/i1216a.scala
+++ b/tests/pos/i1216a.scala
@@ -1,0 +1,11 @@
+object Main {
+  val MAX = 10
+  val s1, s2, target = new Array[Long](MAX)
+
+  var i = 0
+
+  while (i < MAX) {
+    target(i) = s1(i) + s2(i)
+    i+= 1
+  }
+}


### PR DESCRIPTION
Setters are normally synthesised in Desugar while expanding the ValDef. If
    the tree is a PatDef it is being desugared into several ValDefs that may
    need to be desugared once again.