### PR TITLE
Transform annotations only if defined in current run

### DIFF
--- a/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/src/dotty/tools/dotc/ast/Desugar.scala
@@ -46,7 +46,11 @@ object desugar {
      */
     override def ensureCompletions(implicit ctx: Context) =
       if (!(ctx.owner is Package))
-        if (ctx.owner is ModuleClass) ctx.owner.linkedClass.ensureCompleted()
+        if (ctx.owner.isClass) {
+          ctx.owner.ensureCompleted()
+          if (ctx.owner is ModuleClass)
+            ctx.owner.linkedClass.ensureCompleted()
+        }
         else ensureCompletions(ctx.outer)
 
     /** Return info of original symbol, where all references to siblings of the

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -179,7 +179,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     val ex = new BadSignature(
       sm"""error reading Scala signature of $classRoot from $source:
           |error occurred at position $readIndex: $msg""")
-    if (ctx.debug || true) original.getOrElse(ex).printStackTrace() // temporarilly enable printing of original failure signature to debug failing builds
+    if (ctx.debug || true) original.getOrElse(ex).printStackTrace() // temporarily enable printing of original failure signature to debug failing builds
     throw ex
   }
 

--- a/src/dotty/tools/dotc/transform/TreeTransform.scala
+++ b/src/dotty/tools/dotc/transform/TreeTransform.scala
@@ -185,12 +185,19 @@ object TreeTransforms {
 
       ref match {
         case ref: SymDenotation =>
-          val annotTrees = ref.annotations.map(_.tree)
-          val annotTrees1 = annotTrees.mapConserve(annotationTransformer.macroTransform)
-          val annots1 = if (annotTrees eq annotTrees1) ref.annotations else annotTrees1.map(new ConcreteAnnotation(_))
+          val annots1 =
+            if (!ref.symbol.isDefinedInCurrentRun) ref.annotations // leave annotations read from class files alone
+            else {
+              val annotTrees = ref.annotations.map(_.tree)
+              val annotTrees1 = annotTrees.mapConserve(annotationTransformer.macroTransform)
+              if (annotTrees eq annotTrees1) ref.annotations
+              else annotTrees1.map(new ConcreteAnnotation(_))
+            }
           if ((info1 eq ref.info) && (annots1 eq ref.annotations)) ref
           else ref.copySymDenotation(info = info1, annotations = annots1)
-        case _ => if (info1 eq ref.info) ref else ref.derivedSingleDenotation(ref.symbol, info1)
+        case _ =>
+          if (info1 eq ref.info) ref
+          else ref.derivedSingleDenotation(ref.symbol, info1)
       }
     }
   }

--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -925,7 +925,9 @@ trait Applications extends Compatibility { self: Typer =>
     /** Drop any implicit parameter section */
     def stripImplicit(tp: Type): Type = tp match {
       case mt: ImplicitMethodType if !mt.isDependent =>
-        mt.resultType // todo: make sure implicit method types are not dependent
+        mt.resultType
+          // todo: make sure implicit method types are not dependent?
+          // but check test case in /tests/pos/depmet_implicit_chaining_zw.scala
       case pt: PolyType =>
         pt.derivedPolyType(pt.paramNames, pt.paramBounds, stripImplicit(pt.resultType))
       case _ =>


### PR DESCRIPTION
There's no point transforming annotations that come from
classfiles. It's inefficient to do so and it's also risky
because it means we'd have to make sense of Scala-2 generated trees.

This should avoid the error in #1222.

Review by @DarkDimius 