### PR TITLE
Evaluate annotations before completing tree of definitions

### DIFF
--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -670,6 +670,8 @@ class Namer { typer: Typer =>
         ok
       }
 
+      addAnnotations(denot)
+
       val selfInfo =
         if (self.isEmpty) NoType
         else if (cls.is(Module)) {
@@ -699,7 +701,6 @@ class Namer { typer: Typer =>
 
       index(rest)(inClassContext(selfInfo))
       denot.info = ClassInfo(cls.owner.thisType, cls, parentRefs, decls, selfInfo)
-      addAnnotations(denot)
       Checking.checkWellFormed(cls)
       if (isDerivedValueClass(cls)) cls.setFlag(Final)
       cls.setApplicableFlags(

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -562,8 +562,8 @@ class Namer { typer: Typer =>
      *  to pick up the context at the point where the completer was created.
      */
     def completeInCreationContext(denot: SymDenotation): Unit = {
-      denot.info = typeSig(denot.symbol)
       addAnnotations(denot)
+      denot.info = typeSig(denot.symbol)
       Checking.checkWellFormed(denot.symbol)
     }
   }

--- a/src/strawman/collections/CollectionStrawMan4.scala
+++ b/src/strawman/collections/CollectionStrawMan4.scala
@@ -12,6 +12,8 @@ import annotation.tailrec
  *  strengths and weaknesses of different collection architectures.
  *
  *  For a test file, see tests/run/CollectionTests.scala.
+ *
+ *  Strawman4 is like strawman1, but built over views instead of by-name iterators
  */
 object CollectionStrawMan4 {
 

--- a/src/strawman/collections/CollectionStrawMan5.scala
+++ b/src/strawman/collections/CollectionStrawMan5.scala
@@ -12,6 +12,15 @@ import annotation.tailrec
  *  strengths and weaknesses of different collection architectures.
  *
  *  For a test file, see tests/run/CollectionTests.scala.
+ *
+ *  Strawman5 is like strawman4, but using inheritance through ...Like traits
+ *  instead of decorators.
+ *
+ *   Advantage: Much easier to specialize. See partition for strict (buildable) collections
+ *   or drop for Lists.
+ *
+ *   Disadvantage: More "weird" types in base traits; some awkwardness with
+ *   @uncheckedVariance.
  */
 object CollectionStrawMan5 {
 


### PR DESCRIPTION
Motive: That way we can identify annotation macros without special
name resolution rules.

This was surprisingly easy.

Review by @xeno-by 