### PR TITLE
Fix stdout redirect for REPL's println

### DIFF
--- a/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -94,6 +94,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val sourceReader = StringSetting("-Xsource-reader", "classname", "Specify a custom method for reading source files.", "")
   val XnoValueClasses = BooleanSetting("-Xno-value-classes", "Do not use value classes. Helps debugging.")
   val XreplLineWidth = IntSetting("-Xrepl-line-width", "Maximial number of columns per line for REPL output", 390)
+  val XreplNoColor = BooleanSetting("-Xrepl-no-color", "Removes syntax highlighting in REPL")
   val XoldPatmat = BooleanSetting("-Xoldpatmat", "Use the pre-2.10 pattern matcher. Otherwise, the 'virtualizing' pattern matcher is used in 2.10.")
   val XnoPatmatAnalysis = BooleanSetting("-Xno-patmat-analysis", "Don't perform exhaustivity/unreachability analysis. Also, ignore @switch annotation.")
   val XfullLubs = BooleanSetting("-Xfull-lubs", "Retains pre 2.10 behavior of less aggressive truncation of least upper bounds.")

--- a/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -28,7 +28,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val help = BooleanSetting("-help", "Print a synopsis of standard options")
   val nowarn = BooleanSetting("-nowarn", "Generate no warnings.")
   val print = BooleanSetting("-print", "Print program with Scala-specific features removed.")
-  val color = ChoiceSetting("-color", "mode", "Colored output", List("always", "never", "auto"), "auto")
+  val color = ChoiceSetting("-color", "mode", "Colored output", List("always", "never"/*, "auto"*/), "always"/* "auto"*/)
   val target = ChoiceSetting("-target", "target", "Target platform for object files. All JVM 1.5 targets are deprecated.",
     List("jvm-1.5", "jvm-1.5-fjbg", "jvm-1.5-asm", "jvm-1.6", "jvm-1.7", "jvm-1.8", "msil"),
     "jvm-1.8")

--- a/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -28,6 +28,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val help = BooleanSetting("-help", "Print a synopsis of standard options")
   val nowarn = BooleanSetting("-nowarn", "Generate no warnings.")
   val print = BooleanSetting("-print", "Print program with Scala-specific features removed.")
+  val color = ChoiceSetting("-color", "mode", "Colored output", List("always", "never", "auto"), "auto")
   val target = ChoiceSetting("-target", "target", "Target platform for object files. All JVM 1.5 targets are deprecated.",
     List("jvm-1.5", "jvm-1.5-fjbg", "jvm-1.5-asm", "jvm-1.6", "jvm-1.7", "jvm-1.8", "msil"),
     "jvm-1.8")
@@ -94,7 +95,6 @@ class ScalaSettings extends Settings.SettingGroup {
   val sourceReader = StringSetting("-Xsource-reader", "classname", "Specify a custom method for reading source files.", "")
   val XnoValueClasses = BooleanSetting("-Xno-value-classes", "Do not use value classes. Helps debugging.")
   val XreplLineWidth = IntSetting("-Xrepl-line-width", "Maximial number of columns per line for REPL output", 390)
-  val XreplNoColor = BooleanSetting("-Xrepl-no-color", "Removes syntax highlighting in REPL")
   val XoldPatmat = BooleanSetting("-Xoldpatmat", "Use the pre-2.10 pattern matcher. Otherwise, the 'virtualizing' pattern matcher is used in 2.10.")
   val XnoPatmatAnalysis = BooleanSetting("-Xno-patmat-analysis", "Don't perform exhaustivity/unreachability analysis. Also, ignore @switch annotation.")
   val XfullLubs = BooleanSetting("-Xfull-lubs", "Retains pre 2.10 behavior of less aggressive truncation of least upper bounds.")

--- a/src/dotty/tools/dotc/core/Contexts.scala
+++ b/src/dotty/tools/dotc/core/Contexts.scala
@@ -370,6 +370,10 @@ object Contexts {
     /** Is the verbose option set? */
     def verbose: Boolean = base.settings.verbose.value
 
+    /** Should use colors when printing? */
+    def useColors: Boolean =
+      List("auto", "always") contains base.settings.color.value
+
     /** A condensed context containing essential information of this but
      *  no outer contexts except the initial context.
     private var _condensed: CondensedContext = null

--- a/src/dotty/tools/dotc/core/Contexts.scala
+++ b/src/dotty/tools/dotc/core/Contexts.scala
@@ -372,7 +372,7 @@ object Contexts {
 
     /** Should use colors when printing? */
     def useColors: Boolean =
-      List("auto", "always") contains base.settings.color.value
+      base.settings.color.value == "always"
 
     /** A condensed context containing essential information of this but
      *  no outer contexts except the initial context.

--- a/src/dotty/tools/dotc/repl/AmmoniteReader.scala
+++ b/src/dotty/tools/dotc/repl/AmmoniteReader.scala
@@ -58,8 +58,7 @@ class AmmoniteReader(val interpreter: Interpreter)(implicit ctx: Context) extend
       allFilters,
       displayTransform = (buffer, cursor) => {
         val coloredBuffer =
-          if (List("auto", "always").contains(ctx.settings.color.value))
-            SyntaxHighlighting(buffer)
+          if (ctx.useColors) SyntaxHighlighting(buffer)
           else buffer
 
         val ansiBuffer = Ansi.Str.parse(coloredBuffer)

--- a/src/dotty/tools/dotc/repl/AmmoniteReader.scala
+++ b/src/dotty/tools/dotc/repl/AmmoniteReader.scala
@@ -57,7 +57,10 @@ class AmmoniteReader(val interpreter: Interpreter)(implicit ctx: Context) extend
       writer,
       allFilters,
       displayTransform = (buffer, cursor) => {
-        val ansiBuffer = Ansi.Str.parse(SyntaxHighlighting(buffer))
+        val coloredBuffer =
+          if (!ctx.settings.XreplNoColor.value) SyntaxHighlighting(buffer)
+          else buffer
+        val ansiBuffer = Ansi.Str.parse(coloredBuffer)
         val (newBuffer, cursorOffset) = SelectionFilter.mangleBuffer(
           selectionFilter, ansiBuffer, cursor, Ansi.Reversed.On
         )

--- a/src/dotty/tools/dotc/repl/AmmoniteReader.scala
+++ b/src/dotty/tools/dotc/repl/AmmoniteReader.scala
@@ -58,8 +58,10 @@ class AmmoniteReader(val interpreter: Interpreter)(implicit ctx: Context) extend
       allFilters,
       displayTransform = (buffer, cursor) => {
         val coloredBuffer =
-          if (!ctx.settings.XreplNoColor.value) SyntaxHighlighting(buffer)
+          if (List("auto", "always").contains(ctx.settings.color.value))
+            SyntaxHighlighting(buffer)
           else buffer
+
         val ansiBuffer = Ansi.Str.parse(coloredBuffer)
         val (newBuffer, cursorOffset) = SelectionFilter.mangleBuffer(
           selectionFilter, ansiBuffer, cursor, Ansi.Reversed.On

--- a/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
+++ b/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
@@ -406,7 +406,7 @@ class CompilingInterpreter(out: PrintWriter, ictx: Context) extends Compiler wit
     }
 
     /** load and run the code using reflection.
-     *  @return  A pair consisting of the run's result as a string, and
+     *  @return  A pair consisting of the run's result as a `List[String]`, and
      *           a boolean indicating whether the run succeeded without throwing
      *           an exception.
      */
@@ -417,12 +417,11 @@ class CompilingInterpreter(out: PrintWriter, ictx: Context) extends Compiler wit
         interpreterResultObject.getMethod("result")
       try {
         withOutput(new ByteOutputStream) { ps =>
-          val rawRes    = valMethodRes.invoke(interpreterResultObject).toString
-          val res       =
-            if (List("auto", "always").contains(ictx.settings.color.value))
-              new String(SyntaxHighlighting(rawRes).toArray)
+          val rawRes = valMethodRes.invoke(interpreterResultObject).toString
+          val res =
+            if (ictx.useColors) new String(SyntaxHighlighting(rawRes).toArray)
             else rawRes
-          val prints    = ps.toString("utf-8")
+          val prints = ps.toString("utf-8")
           val printList = if (prints != "") prints :: Nil else Nil
 
           if (!delayOutput) out.print(prints)

--- a/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
+++ b/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
@@ -418,11 +418,12 @@ class CompilingInterpreter(out: PrintWriter, ictx: Context) extends Compiler wit
       try {
         withOutput(new ByteOutputStream) { ps =>
           val rawRes    = valMethodRes.invoke(interpreterResultObject).toString
-          val res       = new String(SyntaxHighlighting(rawRes).toArray)
+          val res       =
+            if (!ictx.settings.XreplNoColor.value)
+              new String(SyntaxHighlighting(rawRes).toArray)
+            else rawRes
           val prints    = ps.toString("utf-8")
-          val printList =
-            if (prints == "") Nil
-            else prints :: Nil
+          val printList = if (prints != "") prints :: Nil else Nil
 
           if (!delayOutput) out.print(prints)
 

--- a/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
+++ b/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
@@ -419,7 +419,7 @@ class CompilingInterpreter(out: PrintWriter, ictx: Context) extends Compiler wit
         withOutput(new ByteOutputStream) { ps =>
           val rawRes    = valMethodRes.invoke(interpreterResultObject).toString
           val res       =
-            if (!ictx.settings.XreplNoColor.value)
+            if (List("auto", "always").contains(ictx.settings.color.value))
               new String(SyntaxHighlighting(rawRes).toArray)
             else rawRes
           val prints    = ps.toString("utf-8")

--- a/src/dotty/tools/dotc/repl/REPL.scala
+++ b/src/dotty/tools/dotc/repl/REPL.scala
@@ -25,6 +25,11 @@ class REPL extends Driver {
 
   lazy val config = new REPL.Config
 
+  override def setup(args: Array[String], rootCtx: Context): (List[String], Context) = {
+    val (strs, ctx) = super.setup(args, rootCtx)
+    (strs, config.context(ctx))
+  }
+
   override def newCompiler(implicit ctx: Context): Compiler =
     new repl.CompilingInterpreter(config.output, ctx)
 
@@ -44,6 +49,8 @@ object REPL {
     val prompt             = "scala> "
     val continuationPrompt = "     | "
     val version            = ".next (pre-alpha)"
+
+    def context(ctx: Context): Context = ctx
 
     /** The default input reader */
     def input(in: Interpreter)(implicit ctx: Context): InteractiveReader = {

--- a/test/test/TestREPL.scala
+++ b/test/test/TestREPL.scala
@@ -21,7 +21,7 @@ class TestREPL(script: String) extends REPL {
     override val output = new NewLinePrintWriter(out)
 
     override def context(ctx: Context) =
-      ctx.fresh.setSetting(ctx.settings.XreplNoColor, true)
+      ctx.fresh.setSetting(ctx.settings.color, "never")
 
     override def input(in: Interpreter)(implicit ctx: Context) = new InteractiveReader {
       val lines = script.lines

--- a/test/test/TestREPL.scala
+++ b/test/test/TestREPL.scala
@@ -38,7 +38,8 @@ class TestREPL(script: String) extends REPL {
     out.close()
     val printed = out.toString
     val transcript = printed.drop(printed.indexOf(config.prompt))
-    if (transcript.toString != script) {
+    val transcriptNoColors = transcript.toString.replaceAll("\u001B\\[[;\\d]*m", "")
+    if (transcriptNoColors != script) {
       println("input differs from transcript:")
       println(transcript)
       assert(false)

--- a/test/test/TestREPL.scala
+++ b/test/test/TestREPL.scala
@@ -20,6 +20,9 @@ class TestREPL(script: String) extends REPL {
   override lazy val config = new REPL.Config {
     override val output = new NewLinePrintWriter(out)
 
+    override def context(ctx: Context) =
+      ctx.fresh.setSetting(ctx.settings.XreplNoColor, true)
+
     override def input(in: Interpreter)(implicit ctx: Context) = new InteractiveReader {
       val lines = script.lines
       def readLine(prompt: String): String = {
@@ -38,8 +41,7 @@ class TestREPL(script: String) extends REPL {
     out.close()
     val printed = out.toString
     val transcript = printed.drop(printed.indexOf(config.prompt))
-    val transcriptNoColors = transcript.toString.replaceAll("\u001B\\[[;\\d]*m", "")
-    if (transcriptNoColors != script) {
+    if (transcript.toString != script) {
       println("input differs from transcript:")
       println(transcript)
       assert(false)


### PR DESCRIPTION
When printing in the REPL via `println`, the output would end up on the
same line, since stdout had not been redirected. This commit remedies
that.

It also adds syntax highlighting to result types.

Review: @smarter 