### PR TITLE
Fixes to lambdalift that prevent memory leaks.

### DIFF
--- a/src/dotty/tools/dotc/transform/ElimStaticThis.scala
+++ b/src/dotty/tools/dotc/transform/ElimStaticThis.scala
@@ -27,9 +27,11 @@ class ElimStaticThis extends MiniPhaseTransform {
   override def transformIdent(tree: tpd.Ident)(implicit ctx: Context, info: TransformerInfo): tpd.Tree = {
     if (ctx.owner.enclosingMethod.is(JavaStatic)) {
       tree.tpe match {
-        case TermRef(thiz: ThisType, _) =>
-          assert(thiz.underlying.typeSymbol.is(ModuleClass))
+        case TermRef(thiz: ThisType, _) if thiz.underlying.typeSymbol.is(ModuleClass) =>
           ref(thiz.underlying.typeSymbol.sourceModule).select(tree.symbol)
+        case TermRef(thiz: ThisType, _) =>
+          assert(tree.symbol.is(Flags.JavaStatic))
+          tree
         case _ => tree
       }
     }

--- a/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -251,8 +251,8 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
             }
             def captureImplicitThis(x: Type): Unit = {
               x match {
-                case TermRef(x, _) => captureImplicitThis(x)
-                case x: ThisType => narrowTo(x.tref.typeSymbol.asClass)
+                case tr@TermRef(x, _) if (!tr.termSymbol.isStatic) => captureImplicitThis(x)
+                case x: ThisType if (!x.tref.typeSymbol.isStaticOwner) => narrowTo(x.tref.typeSymbol.asClass)
                 case _ =>
               }
             }

--- a/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -369,8 +369,9 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
                // though the second condition seems weird, it's not true for symbols which are defined in some
                // weird combinations of super calls.
               (encClass, EmptyFlags)
-            } else
-              (topClass, JavaStatic)
+            } else if (encClass.is(ModuleClass, butNot = Package) && encClass.isStatic) // needed to not cause deadlocks in classloader. see t5375.scala
+              (encClass, EmptyFlags)
+            else (topClass, JavaStatic)
           }
           else (lOwner, EmptyFlags)
         local.copySymDenotation(

--- a/tests/run/t5375.scala
+++ b/tests/run/t5375.scala
@@ -1,3 +1,14 @@
+/** Hello fellow compiler developer.
+    if you are wondering why does test suite hang on this test
+    then it's likely that the lambda inside map has been compiled into static method
+    unfotrunatelly, as it is executed inside static object initializer,
+    it is executed inside class-loader, in a synchronized block that is not source defined.
+    
+    If the lambda will be static Test$#foo, calling it through a different thread would require grabbing the
+    lock inside classloader. Unlike if it not static and is called through This(Test).foo, no lock is grabbed.
+    
+    @DarkDimius  
+*/  
 object Test extends dotty.runtime.LegacyApp {
   val foos = (1 to 1000).toSeq
   try


### PR DESCRIPTION
CollectDependencies had incorrect handling of `Ident`s. If it had ever met
    an `Ident` to a symbol defined outside of current owner-chain(e.g.
    Predef.println) it would issue narrowTo(enclosingClass).

This is very conservative and leads to memory leaks even in trivial lambdas.