### PR TITLE
Fix #1276: `_` binding in patternmatcher

### DIFF
--- a/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -1094,6 +1094,7 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {thisTrans
       */
     object WildcardPattern {
       def unapply(pat: Tree): Boolean = pat match {
+        case Typed(_, arg) if arg.tpe.isRepeatedParam => true
         case Bind(nme.WILDCARD, WildcardPattern()) => true // don't skip when binding an interesting symbol!
         case t if (tpd.isWildcardArg(t))            => true
         case x: Ident                              => isVarPattern(x)
@@ -1157,8 +1158,8 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {thisTrans
 
       object TypeBound {
         def unapply(tree: Tree): Option[Type] = tree match {
-          case Typed(_, _)  => Some(tree.typeOpt)
-          case _                                      => None
+          case Typed(_, arg) if !arg.tpe.isRepeatedParam => Some(tree.typeOpt)
+          case _                                         => None
         }
       }
 

--- a/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -23,6 +23,7 @@ import config.Printers
 class ReTyper extends Typer {
   import tpd._
 
+  /** Checks that the given tree has been typed */
   protected def promote(tree: untpd.Tree)(implicit ctx: Context): tree.ThisTree[Type] = {
     assert(tree.hasType, i"$tree ${tree.getClass} ${tree.uniqueId}")
     tree.withType(tree.typeOpt)

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -427,7 +427,6 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     }
     if (untpd.isWildcardStarArg(tree))
       cases(
-        //ifPat = ascription(TypeTree(defn.SeqType.appliedTo(pt :: Nil)), isWildcard = true),
         ifPat = ascription(TypeTree(defn.RepeatedParamType.appliedTo(pt)), isWildcard = true),
         ifExpr = seqToRepeated(typedExpr(tree.expr, defn.SeqType)),
         wildName = nme.WILDCARD_STAR)
@@ -976,7 +975,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
             typed(untpd.Bind(tree.name, arg).withPos(tree.pos), arg.tpe) :: Nil)
       case _ =>
         val flags = if (tree.isType) BindDefinedType else EmptyFlags
-        val sym = ctx.newSymbol(ctx.owner, tree.name, flags, body1.tpe, coord = tree.pos)
+        val sym = ctx.newSymbol(ctx.owner, tree.name, flags | Case, body1.tpe, coord = tree.pos)
         assignType(cpy.Bind(tree)(tree.name, body1), sym)
     }
   }

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -420,10 +420,15 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       case _ => ifExpr
     }
     def ascription(tpt: Tree, isWildcard: Boolean) = {
+      val underlyingTreeTpe =
+        if (isRepeatedParamType(tpt)) TypeTree(defn.SeqType.appliedTo(pt :: Nil))
+        else tpt
+
       val expr1 =
-        if (isWildcard) tree.expr.withType(tpt.tpe)
+        if (isRepeatedParamType(tpt)) tree.expr.withType(defn.SeqType.appliedTo(pt :: Nil))
+        else if (isWildcard) tree.expr.withType(tpt.tpe)
         else typed(tree.expr, tpt.tpe.widenSkolem)
-      assignType(cpy.Typed(tree)(expr1, tpt), tpt)
+      assignType(cpy.Typed(tree)(expr1, tpt), underlyingTreeTpe)
     }
     if (untpd.isWildcardStarArg(tree))
       cases(

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -427,7 +427,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     }
     if (untpd.isWildcardStarArg(tree))
       cases(
-        ifPat = ascription(TypeTree(defn.SeqType.appliedTo(pt :: Nil)), isWildcard = true),
+        //ifPat = ascription(TypeTree(defn.SeqType.appliedTo(pt :: Nil)), isWildcard = true),
+        ifPat = ascription(TypeTree(defn.RepeatedParamType.appliedTo(pt)), isWildcard = true),
         ifExpr = seqToRepeated(typedExpr(tree.expr, defn.SeqType)),
         wildName = nme.WILDCARD_STAR)
     else {

--- a/tests/disabled/pos/t3480.scala
+++ b/tests/disabled/pos/t3480.scala
@@ -1,4 +1,4 @@
 object Test {
   val List(_: _*) = List(1)
-    val Array( who, what : _* ) = "Eclipse plugin cannot not handle this" split (" ")
+  val Array(who, what: _*) = "Eclipse plugin cannot not handle this" split (" ")
 }

--- a/tests/pos/t9795.scala
+++ b/tests/pos/t9795.scala
@@ -1,0 +1,7 @@
+case class A(v: Int)
+class B(v: Int) extends A(v)
+
+object Test {
+  val a = new B(1)
+  a match { case A(_) => 1 }
+}

--- a/tests/pos/vararg-pattern.scala
+++ b/tests/pos/vararg-pattern.scala
@@ -1,12 +1,9 @@
 object Test {
-
   List(1, 2, 3, 4) match {
     case List(1, 2, xs: _*) =>
       val ys: Seq[Int] = xs
       println(ys)
   }
+
   val List(1, 2, x: _*) = List(1, 2, 3, 4)
-
 }
-
-

--- a/tests/run/correct-bind.check
+++ b/tests/run/correct-bind.check
@@ -1,0 +1,1 @@
+Vector(second, third)

--- a/tests/run/correct-bind.scala
+++ b/tests/run/correct-bind.scala
@@ -1,0 +1,4 @@
+object Test extends dotty.runtime.LegacyApp {
+  val Array(who, what: _*) = "first second third" split (" ")
+  println(what)
+}


### PR DESCRIPTION
This fix changes the typer to infer a `A*` instead of `Seq[A]` for repeated arguments. Subsequent parts of the patternmatcher and checking has been changed to accommodate this.

Related issue: #1276 