### PR TITLE
Fix #1292: give position when failing to emit switch on annotated match

### DIFF
--- a/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -922,8 +922,8 @@ object Scanners {
           getFraction()
         }
       } else (ch: @switch) match {
-        case 'e' | 'E' | 'f' | 'F' | 'd' | 'D' if base == 10 =>
-          getFraction()
+        case 'e' | 'E' | 'f' | 'F' | 'd' | 'D' =>
+          if (base == 10) getFraction()
         case 'l' | 'L' =>
           nextChar()
           token = LONGLIT

--- a/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -89,8 +89,9 @@ object SyntaxHighlighting {
             append('<', { x => x == "<-" || x == "<:" || x == "<%" }, keyword)
           case '>'  =>
             append('>', { x => x == ">:" }, keyword)
-          case '#'  if prev != ' ' && prev != '.' =>
-            newBuf append keyword("#")
+          case '#'  =>
+            if (prev != ' ' && prev != '.') newBuf append keyword("#")
+            else newBuf += n
             prev = '#'
           case '@'  =>
             appendWhile('@', _ != ' ', annotation)
@@ -100,12 +101,14 @@ object SyntaxHighlighting {
             appendLiteral('\'')
           case '`'  =>
             appendTo('`', _ == '`', none)
-          case c if c.isUpper && keywordStart =>
-            appendWhile(c, !typeEnders.contains(_), typeDef)
-          case c if numberStart(c) =>
-            appendWhile(c, { x => x.isDigit || x == '.' || x == '\u0000'}, literal)
-          case c =>
-            newBuf += c; prev = c
+          case _    => {
+            if (n.isUpper && keywordStart)
+              appendWhile(n, !typeEnders.contains(_), typeDef)
+            else if (numberStart(n))
+              appendWhile(n, { x => x.isDigit || x == '.' || x == '\u0000'}, literal)
+            else
+              newBuf += n; prev = n
+          }
         }
       }
     }

--- a/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -434,7 +434,7 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {thisTrans
         }
       } else {
         if (dealiased hasAnnotation defn.SwitchAnnot)
-          ctx.warning("failed to emit switch for `@switch` annotated match")
+          ctx.warning("failed to emit switch for `@switch` annotated match", scrut.pos)
         None
       }
     }


### PR DESCRIPTION
This fix gives the position and refactors the code that gave off
warnings, but it also begs the question - should we be able to handle
emitting a switch for the following case:

```scala
(x: @switch) match {
  case 'a' if somePredicate(x) => // ...
  case 'b' => // ...
}
```

Currently if there is a guard, the patternmatcher will fail to emit
a switch. Scalac can handle these cases currently.

review: @DarkDimius