### PR TITLE
Properly report errors when cli flags are malformed

### DIFF
--- a/src/dotty/tools/dotc/Driver.scala
+++ b/src/dotty/tools/dotc/Driver.scala
@@ -31,7 +31,7 @@ abstract class Driver extends DotClass {
           ctx.error(ex.getMessage) // signals that we should fail compilation.
           ctx.reporter
       }
-    else emptyReporter
+    else ctx.reporter
 
   protected def initCtx = (new ContextBase).initialCtx
 

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -119,6 +119,9 @@ class tests extends CompilerTest {
   @Test def neg_typedIdents() = compileDir(negDir, "typedIdents")
 
   val negCustomArgs = negDir + "customArgs/"
+
+  @Test def neg_cli_error = compileFile(negCustomArgs, "cliError", List("-thisOptionDoesNotExist"))
+
   @Test def neg_typers() = compileFile(negCustomArgs, "typers")(allowDoubleBindings)
   @Test def neg_overrideClass = compileFile(negCustomArgs, "overrideClass", scala2mode)
   @Test def neg_autoTupling = compileFile(negCustomArgs, "autoTuplingTest", args = "-language:noAutoTupling" :: Nil)

--- a/tests/neg/customArgs/cliError.scala
+++ b/tests/neg/customArgs/cliError.scala
@@ -1,0 +1,2 @@
+// nopos-error
+object Test


### PR DESCRIPTION
Previously we returned an empty Reporter with no errors so partest
reported the test as a success.

Review by @DarkDimius 