### PR TITLE
Add console to bridge

### DIFF
--- a/bridge/src/main/scala/xsbt/ConsoleInterface.scala
+++ b/bridge/src/main/scala/xsbt/ConsoleInterface.scala
@@ -1,0 +1,68 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2008, 2009 Mark Harrah
+ */
+package xsbt
+
+import xsbti.Logger
+import scala.tools.nsc.{ GenericRunnerCommand, Interpreter, InterpreterLoop, ObjectRunner, Settings }
+import scala.tools.nsc.interpreter.InteractiveReader
+import scala.tools.nsc.reporters.Reporter
+import scala.tools.nsc.util.ClassPath
+
+import dotty.tools.dotc.repl.REPL
+import dotty.tools.dotc.repl.REPL.Config
+
+class ConsoleInterface {
+  def commandArguments(
+    args: Array[String],
+    bootClasspathString: String,
+    classpathString: String,
+    log: Logger
+  ): Array[String] = args
+
+  def run(args: Array[String],
+          bootClasspathString: String,
+          classpathString: String,
+          initialCommands: String,
+          cleanupCommands: String,
+          loader: ClassLoader,
+          bindNames: Array[String],
+          bindValues: Array[Any],
+          log: Logger
+  ): Unit = {
+    val completeArgs =
+      args                                    :+
+      "-bootclasspath" :+ bootClasspathString :+
+      "-classpath"     :+ classpathString
+
+    println("Starting dotty interpreter...")
+    val repl = ConsoleInterface.customRepl(
+      initialCommands :: Nil,
+      cleanupCommands :: Nil,
+      bindNames zip bindValues
+    )
+    repl.process(completeArgs)
+  }
+}
+
+object ConsoleInterface {
+  def customConfig(
+    initCmds: List[String],
+    cleanupCmds: List[String],
+    boundVals: Array[(String, Any)]
+  ) = new Config {
+    override val initialCommands: List[String] = initCmds
+    override val cleanupCommands: List[String] = cleanupCmds
+    override val boundValues: Array[(String, Any)] = boundVals
+  }
+
+  def customRepl(cfg: Config): REPL = new REPL {
+    override lazy val config = cfg
+  }
+
+  def customRepl(
+    initCmds: List[String],
+    cleanupCmds: List[String],
+    boundVals: Array[(String, Any)]
+  ): REPL = customRepl(customConfig(initCmds, cleanupCmds, boundVals))
+}

--- a/bridge/src/main/scala/xsbt/ConsoleInterface.scala
+++ b/bridge/src/main/scala/xsbt/ConsoleInterface.scala
@@ -9,6 +9,7 @@ import scala.tools.nsc.interpreter.InteractiveReader
 import scala.tools.nsc.reporters.Reporter
 import scala.tools.nsc.util.ClassPath
 
+import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.repl.REPL
 import dotty.tools.dotc.repl.REPL.Config
 
@@ -39,7 +40,8 @@ class ConsoleInterface {
     val repl = ConsoleInterface.customRepl(
       initialCommands :: Nil,
       cleanupCommands :: Nil,
-      bindNames zip bindValues
+      bindNames zip bindValues,
+      loader
     )
     repl.process(completeArgs)
   }
@@ -49,11 +51,13 @@ object ConsoleInterface {
   def customConfig(
     initCmds: List[String],
     cleanupCmds: List[String],
-    boundVals: Array[(String, Any)]
+    boundVals: Array[(String, Any)],
+    loader: ClassLoader
   ) = new Config {
     override val initialCommands: List[String] = initCmds
     override val cleanupCommands: List[String] = cleanupCmds
     override val boundValues: Array[(String, Any)] = boundVals
+    override val classLoader: Option[ClassLoader] = Option(loader)
   }
 
   def customRepl(cfg: Config): REPL = new REPL {
@@ -63,6 +67,7 @@ object ConsoleInterface {
   def customRepl(
     initCmds: List[String],
     cleanupCmds: List[String],
-    boundVals: Array[(String, Any)]
-  ): REPL = customRepl(customConfig(initCmds, cleanupCmds, boundVals))
+    boundVals: Array[(String, Any)],
+    loader: ClassLoader
+  ): REPL = customRepl(customConfig(initCmds, cleanupCmds, boundVals, loader))
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -347,11 +347,47 @@ object DottyInjectedPlugin extends AutoPlugin {
      },
      publishArtifact in Test := false,
      homepage := Some(url("https://github.com/lampepfl/dotty")),
+     licenses += ("BSD New",
+       url("https://github.com/lampepfl/dotty/blob/master/LICENSE.md")),
      scmInfo := Some(
        ScmInfo(
          url("https://github.com/lampepfl/dotty"),
          "scm:git:git@github.com:lampepfl/dotty.git"
        )
+     ),
+     pomExtra := (
+       <developers>
+         <developer>
+           <id>odersky</id>
+           <name>Martin Odersky</name>
+           <email>martin.odersky@epfl.ch</email>
+           <url>https://github.com/odersky</url>
+         </developer>
+         <developer>
+           <id>DarkDimius</id>
+           <name>Dmitry Petrashko</name>
+           <email>me@d-d.me</email>
+           <url>https://d-d.me</url>
+         </developer>
+         <developer>
+           <id>smarter</id>
+           <name>Guillaume Martres</name>
+           <email>smarter@ubuntu.com</email>
+           <url>http://guillaume.martres.me</url>
+         </developer>
+         <developer>
+           <id>felixmulder</id>
+           <name>Felix Mulder</name>
+           <email>felix.mulder@gmail.com</email>
+           <url>http://felixmulder.com</url>
+         </developer>
+         <developer>
+           <id>liufengyun</id>
+           <name>Liu Fengyun</name>
+           <email>liufengyun@chaos-lab.com</email>
+           <url>http://chaos-lab.com</url>
+         </developer>
+       </developers>
      )
    )
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -211,9 +211,12 @@ object DottyBuild extends Build {
       ),
       version :=
         "0.1.1-SNAPSHOT-" + VersionUtil.commitDate + "-" + VersionUtil.gitHash,
-      // The sources should be published with crossPaths := false, the binaries
-      // are unused so it doesn't matter.
+      // The sources should be published with crossPaths := false since they
+      // need to be compiled by the project using the bridge.
       crossPaths := false,
+
+      // Don't publish any binaries for the bridge because of the above
+      publishArtifact in (Compile, packageBin) := false,
 
       fork in Test := true,
       parallelExecution in Test := false

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -50,7 +50,8 @@ object DottyBuild extends Build {
       autoScalaLibrary := false,
       //Remove javac invalid options in Compile doc
       javacOptions in (Compile, doc) --= Seq("-Xlint:unchecked", "-Xlint:deprecation")
-    )
+    ).
+    settings(publishing)
 
   lazy val dotty = project.in(file(".")).
     dependsOn(`dotty-interfaces`).
@@ -244,7 +245,8 @@ object DottyInjectedPlugin extends AutoPlugin {
 """)
       }
       */
-    )
+    ).
+    settings(publishing)
 
 
   /** A sandbox to play with the Scala.js back-end of dotty.
@@ -348,6 +350,13 @@ object DottyInjectedPlugin extends AutoPlugin {
        )
      )
    )
+
+   lazy val `dotty-core` = project
+     .dependsOn(`dotty-interfaces`)
+     .dependsOn(dotty)
+     .dependsOn(`dotty-bridge`)
+     .settings(publishing)
+     .aggregate(dotty, `dotty-interfaces`, `dotty-bridge`)
 
   // Partest tasks
   lazy val lockPartestFile = TaskKey[Unit]("lockPartestFile", "Creates the lock file at ./tests/locks/partest-<pid>.lock")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -338,6 +338,7 @@ object DottyInjectedPlugin extends AutoPlugin {
    lazy val publishing = Seq(
      publishMavenStyle := true,
      publishArtifact := true,
+     isSnapshot := version.value.contains("SNAPSHOT"),
      publishTo := {
        val nexus = "https://oss.sonatype.org/"
        if (isSnapshot.value)
@@ -390,13 +391,6 @@ object DottyInjectedPlugin extends AutoPlugin {
        </developers>
      )
    )
-
-   lazy val `dotty-core` = project
-     .dependsOn(`dotty-interfaces`)
-     .dependsOn(dotty)
-     .dependsOn(`dotty-bridge`)
-     .settings(publishing)
-     .aggregate(dotty, `dotty-interfaces`, `dotty-bridge`)
 
   // Partest tasks
   lazy val lockPartestFile = TaskKey[Unit]("lockPartestFile", "Creates the lock file at ./tests/locks/partest-<pid>.lock")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,7 +26,7 @@ object DottyBuild extends Build {
     super.settings ++ Seq(
       scalaVersion in Global := "2.11.5",
       version in Global :=
-        "0.1-SNAPSHOT-" + VersionUtil.commitDate + "-" + VersionUtil.gitHash,
+        "0.1-" + VersionUtil.commitDate + "-" + VersionUtil.gitHash + "-SNAPSHOT",
       organization in Global := "ch.epfl.lamp",
       organizationName in Global := "LAMP/EPFL",
       organizationHomepage in Global := Some(url("http://lamp.epfl.ch")),
@@ -210,7 +210,7 @@ object DottyBuild extends Build {
         "org.specs2" %% "specs2" % "2.3.11" % "test"
       ),
       version :=
-        "0.1.1-SNAPSHOT-" + VersionUtil.commitDate + "-" + VersionUtil.gitHash,
+        "0.1.1-" + VersionUtil.commitDate + "-" + VersionUtil.gitHash + "-SNAPSHOT",
       // The sources should be published with crossPaths := false since they
       // need to be compiled by the project using the bridge.
       crossPaths := false,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -332,7 +332,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
    lazy val publishing = Seq(
      publishMavenStyle := true,
-     publishMavenStyle := true,
      publishArtifact := true,
      publishTo := {
        val nexus = "https://oss.sonatype.org/"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,7 +25,8 @@ object DottyBuild extends Build {
   override def settings: Seq[Setting[_]] = {
     super.settings ++ Seq(
       scalaVersion in Global := "2.11.5",
-      version in Global := "0.1-SNAPSHOT",
+      version in Global :=
+        "0.1-SNAPSHOT-" + VersionUtil.commitDate + "-" + VersionUtil.gitHash,
       organization in Global := "ch.epfl.lamp",
       organizationName in Global := "LAMP/EPFL",
       organizationHomepage in Global := Some(url("http://lamp.epfl.ch")),
@@ -208,7 +209,8 @@ object DottyBuild extends Build {
         "org.scala-sbt" % "api" % sbtVersion.value % "test",
         "org.specs2" %% "specs2" % "2.3.11" % "test"
       ),
-      version := "0.1.1-SNAPSHOT",
+      version :=
+        "0.1.1-SNAPSHOT-" + VersionUtil.commitDate + "-" + VersionUtil.gitHash,
       // The sources should be published with crossPaths := false, the binaries
       // are unused so it doesn't matter.
       crossPaths := false,

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -1,0 +1,18 @@
+import scala.sys.process.Process
+
+object VersionUtil {
+  def executeScript(scriptName: String) = {
+    val cmd =
+      if (System.getProperty("os.name").toLowerCase.contains("windows"))
+        s"cmd.exe /c scripts\\build\\$scriptName.bat -p"
+      else s"scripts/build/$scriptName"
+    Process(cmd).lines.head.trim
+  }
+
+  /** Seven letters of the SHA hash is considered enough to uniquely identify a
+   *  commit, albeit extremely large projects - such as the Linux kernel - need
+   *  more letters to stay unique
+   */
+  def gitHash = executeScript("get-scala-commit-sha").substring(0, 7)
+  def commitDate = executeScript("get-scala-commit-date")
+}

--- a/scripts/build/get-scala-commit-date
+++ b/scripts/build/get-scala-commit-date
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Usage: get-scala-commit-date [dir]
+# Figures out current commit date of a git clone.
+# If no dir is given, current working dir is used.
+#
+# Example build version string:
+#   20120312
+#
+
+[[ $# -eq 0 ]] || cd "$1"
+
+lastcommitdate=$(git log --format="%ci" HEAD | head -n 1 | cut -d ' ' -f 1)
+
+# 20120324
+echo "${lastcommitdate//-/}"

--- a/scripts/build/get-scala-commit-date.bat
+++ b/scripts/build/get-scala-commit-date.bat
@@ -1,0 +1,9 @@
+@echo off
+for %%X in (bash.exe) do (set FOUND=%%~$PATH:X)
+if defined FOUND (
+  bash "%~dp0\get-scala-commit-date" 2>NUL
+) else (
+  rem echo this script does not work with cmd.exe. please, install bash
+  echo unknown
+  exit 1
+)

--- a/scripts/build/get-scala-commit-sha
+++ b/scripts/build/get-scala-commit-sha
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Usage: get-scala-commit-sha [dir]
+# Figures out current commit sha of a git clone.
+# If no dir is given, current working dir is used.
+#
+# Example build version string:
+#   6f1c486d0ba
+#
+
+[[ $# -eq 0 ]] || cd "$1"
+
+# printf %016s is not portable for 0-padding, has to be a digit.
+# so we're stuck disassembling it.
+hash=$(git log -1 --format="%H" HEAD)
+hash=${hash#g}
+hash=${hash:0:10}
+echo "$hash"

--- a/scripts/build/get-scala-commit-sha.bat
+++ b/scripts/build/get-scala-commit-sha.bat
@@ -1,0 +1,9 @@
+@echo off
+for %%X in (bash.exe) do (set FOUND=%%~$PATH:X)
+if defined FOUND (
+  bash "%~dp0\get-scala-commit-sha" 2>NUL
+) else (
+  rem echo this script does not work with cmd.exe. please, install bash
+  echo unknown
+  exit 1
+)

--- a/src/dotty/tools/dotc/repl/REPL.scala
+++ b/src/dotty/tools/dotc/repl/REPL.scala
@@ -4,7 +4,10 @@ package repl
 
 import core.Contexts.Context
 import reporting.Reporter
-import java.io.{BufferedReader, File, FileReader, PrintWriter}
+import io.{AbstractFile, PlainFile, VirtualDirectory}
+import scala.reflect.io.{PlainDirectory, Directory}
+import java.io.{BufferedReader, File => JFile, FileReader, PrintWriter}
+import java.net.{URL, URLClassLoader}
 
 /** A compiler which stays resident between runs.
  *  Usage:
@@ -31,7 +34,7 @@ class REPL extends Driver {
   }
 
   override def newCompiler(implicit ctx: Context): Compiler =
-    new repl.CompilingInterpreter(config.output, ctx)
+    new repl.CompilingInterpreter(config.output, ctx, config.classLoader)
 
   override def sourcesRequired = false
 
@@ -79,6 +82,9 @@ object REPL {
      *  inspect.
      */
     val boundValues: Array[(String, Any)] = Array.empty[(String, Any)]
+
+    /** To pass a custom ClassLoader to the Dotty REPL, overwride this value */
+    val classLoader: Option[ClassLoader] = None
 
     /** The default input reader */
     def input(in: Interpreter)(implicit ctx: Context): InteractiveReader = {


### PR DESCRIPTION
This PR does two things:

1. Adds the ability to use `console` from within an sbt-session that is using the dotty-bridge
1. Creates an aggregated subproject in the build file so that we may publish the correct snapshot artifacts using `sbt dotty-core/publishLocal` or to deploy real snapshots: `sbt dotty-core/publish`