### PR TITLE
Fix #856: Handle try/catch cases as catch cases if possible.

### DIFF
--- a/src/dotty/tools/dotc/Compiler.scala
+++ b/src/dotty/tools/dotc/Compiler.scala
@@ -57,7 +57,8 @@ class Compiler {
            new TailRec,             // Rewrite tail recursion to loops
            new LiftTry,             // Put try expressions that might execute on non-empty stacks into their own methods
            new ClassOf),            // Expand `Predef.classOf` calls.
-      List(new PatternMatcher,      // Compile pattern matches
+      List(new TryCatchPatterns,    // Compile cases in try/catch
+           new PatternMatcher,      // Compile pattern matches
            new ExplicitOuter,       // Add accessors to outer classes from nested ones.
            new ExplicitSelf,        // Make references to non-trivial self types explicit as casts
            new CrossCastAnd,        // Normalize selections involving intersection types.

--- a/src/dotty/tools/dotc/transform/TryCatchPatterns.scala
+++ b/src/dotty/tools/dotc/transform/TryCatchPatterns.scala
@@ -1,0 +1,99 @@
+package dotty.tools.dotc
+package transform
+
+import core.Symbols._
+import core.StdNames._
+import ast.Trees._
+import core.Types._
+import dotty.tools.dotc.core.Decorators._
+import dotty.tools.dotc.core.Flags
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.transform.TreeTransforms.{MiniPhaseTransform, TransformerInfo}
+import dotty.tools.dotc.util.Positions.Position
+
+/** Compiles the cases that can not be handled by primitive catch cases as a common pattern match.
+ *
+ *  The following code:
+ *    ```
+ *    try { <code> }
+ *    catch {
+ *      <tryCases> // Cases that can be handled by catch
+ *      <patternMatchCases> // Cases starting with first one that can't be handled by catch
+ *    }
+ *    ```
+ *  will become:
+ *    ```
+ *    try { <code> }
+ *    catch {
+ *      <tryCases>
+ *      case e => e match {
+ *        <patternMatchCases>
+ *      }
+ *    }
+ *    ```
+ *
+ *  Cases that are not supported include:
+ *   - Applies and unapplies
+ *   - Idents
+ *   - Alternatives
+ *   - `case _: T =>` where `T` is not `Throwable`
+ *
+ */
+class TryCatchPatterns extends MiniPhaseTransform {
+  import dotty.tools.dotc.ast.tpd._
+
+  def phaseName: String = "tryCatchPatterns"
+
+  override def runsAfter = Set(classOf[ElimRepeated])
+
+  override def checkPostCondition(tree: Tree)(implicit ctx: Context): Unit = tree match {
+    case Try(_, cases, _) =>
+      cases.foreach {
+        case CaseDef(Typed(_, _), guard, _) => assert(guard.isEmpty, "Try case should not contain a guard.")
+        case CaseDef(Bind(_, _), guard, _) => assert(guard.isEmpty, "Try case should not contain a guard.")
+        case c =>
+          assert(isDefaultCase(c), "Pattern in Try should be Bind, Typed or default case.")
+      }
+    case _ =>
+  }
+
+  override def transformTry(tree: Try)(implicit ctx: Context, info: TransformerInfo): Tree = {
+    val (tryCases, patternMatchCases) = tree.cases.span(isCatchCase)
+    val fallbackCase = mkFallbackPatterMatchCase(patternMatchCases, tree.pos)
+    cpy.Try(tree)(cases = tryCases ++ fallbackCase)
+  }
+
+  /** Is this pattern node a catch-all or type-test pattern? */
+  private def isCatchCase(cdef: CaseDef)(implicit ctx: Context): Boolean = cdef match {
+    case CaseDef(Typed(Ident(nme.WILDCARD), tpt), EmptyTree, _)          => isSimpleThrowable(tpt.tpe)
+    case CaseDef(Bind(_, Typed(Ident(nme.WILDCARD), tpt)), EmptyTree, _) => isSimpleThrowable(tpt.tpe)
+    case _                                                               => isDefaultCase(cdef)
+  }
+
+  private def isSimpleThrowable(tp: Type)(implicit ctx: Context): Boolean = tp match {
+    case tp @ TypeRef(pre, _) =>
+      (pre == NoPrefix || pre.widen.typeSymbol.isStatic) && // Does not require outer class check
+      !tp.symbol.is(Flags.Trait) && // Traits not supported by JVM
+      tp.derivesFrom(defn.ThrowableClass)
+    case _ =>
+      false
+  }
+
+  private def mkFallbackPatterMatchCase(patternMatchCases: List[CaseDef], pos: Position)(
+      implicit ctx: Context, info: TransformerInfo): Option[CaseDef] = {
+    if (patternMatchCases.isEmpty) None
+    else {
+      val exName = ctx.freshName("ex").toTermName
+      val fallbackSelector =
+        ctx.newSymbol(ctx.owner, exName, Flags.Synthetic | Flags.Case, defn.ThrowableType, coord = pos)
+      val sel = Ident(fallbackSelector.termRef).withPos(pos)
+      val rethrow = CaseDef(EmptyTree, EmptyTree, Throw(ref(fallbackSelector)))
+      Some(CaseDef(
+          Bind(fallbackSelector, Underscore(fallbackSelector.info).withPos(pos)),
+          EmptyTree,
+          transformFollowing(Match(sel, patternMatchCases ::: rethrow :: Nil)))
+      )
+    }
+  }
+
+}

--- a/tests/neg/tryPatternMatchError.scala
+++ b/tests/neg/tryPatternMatchError.scala
@@ -1,0 +1,35 @@
+import java.io.IOException
+import java.lang.NullPointerException
+import java.lang.IllegalArgumentException
+
+object IAE {
+  def unapply(e: Exception): Option[String] =
+    if (e.isInstanceOf[IllegalArgumentException]) Some(e.getMessage)
+    else None
+}
+
+object EX extends Exception
+
+trait ExceptionTrait extends Exception
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    var a: Int = 1
+    try {
+      throw new IllegalArgumentException()
+    } catch {
+      case e: IOException if e.getMessage == null =>
+      case e: NullPointerException =>
+      case e: IndexOutOfBoundsException =>
+      case _: NoSuchElementException =>
+      case _: ExceptionTrait =>
+      case _: NoSuchElementException if a <= 1 =>
+      case _: NullPointerException | _:IOException =>
+      case `a` => // This case should probably emmit an error
+      case e: Int => // error
+      case EX =>
+      case IAE(msg) =>
+      case e: IllegalArgumentException =>
+    }
+  }
+}

--- a/tests/run/tryPatternMatch.check
+++ b/tests/run/tryPatternMatch.check
@@ -1,0 +1,20 @@
+success 1
+success 2
+success 3
+success 4
+success 5
+success 6
+success 7
+success 8
+success 9.1
+success 9.2
+IllegalArgumentException: abc
+IllegalArgumentException
+NullPointerException | IOException
+NoSuchElementException
+EX
+InnerException
+NullPointerException
+ExceptionTrait
+ClassCastException
+TimeoutException escaped

--- a/tests/run/tryPatternMatch.scala
+++ b/tests/run/tryPatternMatch.scala
@@ -1,0 +1,139 @@
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+
+object IAE {
+  def unapply(e: Exception): Option[String] =
+    if (e.isInstanceOf[IllegalArgumentException] && e.getMessage != null) Some(e.getMessage)
+    else None
+}
+
+object EX extends Exception {
+  val msg = "a"
+  class InnerException extends Exception(msg)
+}
+
+trait ExceptionTrait extends Exception
+
+trait TestTrait {
+  type ExceptionType <: Exception
+
+  def traitTest(): Unit = {
+    try {
+      throw new IOException
+    } catch {
+      case _: ExceptionType => println("success 9.2")
+      case _                => println("failed 9.2")
+    }
+  }
+}
+
+object Test extends TestTrait {
+  type ExceptionType = IOException
+
+  def main(args: Array[String]): Unit = {
+    var a: Int = 1
+
+    try {
+      throw new Exception("abc")
+    } catch {
+      case _: Exception => println("success 1")
+      case _            => println("failed 1")
+    }
+
+    try {
+      throw new Exception("abc")
+    } catch {
+      case e: Exception => println("success 2")
+      case _            => println("failed 2")
+    }
+
+    try {
+      throw new Exception("abc")
+    } catch {
+      case e: Exception if e.getMessage == "abc" => println("success 3")
+      case _                                     => println("failed 3")
+    }
+
+    try {
+      throw new Exception("abc")
+    } catch {
+      case e: Exception if e.getMessage == "" => println("failed 4")
+      case _                                  => println("success 4")
+    }
+
+    try {
+      throw EX
+    } catch {
+      case EX => println("success 5")
+      case _  => println("failed 5")
+    }
+
+    try {
+      throw new EX.InnerException
+    } catch {
+      case _: EX.InnerException => println("success 6")
+      case _                    => println("failed 6")
+    }
+
+    try {
+      throw new NullPointerException
+    } catch {
+      case _: NullPointerException | _:IOException => println("success 7")
+      case _                                       => println("failed 7")
+    }
+
+    try {
+      throw new ExceptionTrait {}
+    } catch {
+      case _: ExceptionTrait => println("success 8")
+      case _                 => println("failed 8")
+    }
+
+    try {
+      throw new IOException
+    } catch {
+      case _: ExceptionType => println("success 9.1")
+      case _                => println("failed 9.1")
+    }
+
+    traitTest() // test 9.2
+
+    def testThrow(throwIt: => Unit): Unit = {
+      try {
+        throwIt
+      } catch {
+        // These cases will be compiled as catch cases
+        case e: NullPointerException                 => println("NullPointerException")
+        case e: IndexOutOfBoundsException            => println("IndexOutOfBoundsException")
+        case _: NoSuchElementException               => println("NoSuchElementException")
+        case _: EX.InnerException                    => println("InnerException")
+        // All the following will be compiled as a match
+        case IAE(msg)                                => println("IllegalArgumentException: " + msg)
+        case _: ExceptionTrait                       => println("ExceptionTrait")
+        case e: IOException if e.getMessage == null  => println("IOException")
+        case _: NullPointerException | _:IOException => println("NullPointerException | IOException")
+        case `a`                                     => println("`a`")
+        case EX                                      => println("EX")
+        case e: IllegalArgumentException             => println("IllegalArgumentException")
+        case _: ClassCastException                   => println("ClassCastException")
+      }
+    }
+
+    testThrow(throw new IllegalArgumentException("abc"))
+    testThrow(throw new IllegalArgumentException())
+    testThrow(throw new IOException("abc"))
+    testThrow(throw new NoSuchElementException())
+    testThrow(throw EX)
+    testThrow(throw new EX.InnerException)
+    testThrow(throw new NullPointerException())
+    testThrow(throw new ExceptionTrait {})
+    testThrow(throw a.asInstanceOf[Throwable])
+    try {
+      testThrow(throw new TimeoutException)
+      println("TimeoutException did not escape")
+    } catch {
+      case _: TimeoutException => println("TimeoutException escaped")
+    }
+  }
+
+}


### PR DESCRIPTION
Previously they were all lifted into a match with the came cases.
Now the first cases are handled directly by by the catch. If one
of the cases can not be handled the old scheme is applied to to it
and all subsequent cases.