### PR TITLE
better handling of overloaded extractors

### DIFF
--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -709,11 +709,11 @@ trait Applications extends Compatibility { self: Typer =>
       // try first for non-overloaded, then for overloaded ocurrences
       def tryWithName(name: TermName)(fallBack: Tree => Tree)(implicit ctx: Context): Tree =
         tryEither {
-          implicit ctx => typedExpr(untpd.Select(qual, name), genericProto)
+          implicit ctx => typedExpr(untpd.Select(qual, name), specificProto)
         } {
           (sel, _) =>
             tryEither {
-              implicit ctx => typedExpr(untpd.Select(qual, name), specificProto)
+              implicit ctx => typedExpr(untpd.Select(qual, name), genericProto)
             } {
               (_, _) => fallBack(sel)
             }

--- a/tests/pos/i1318.scala
+++ b/tests/pos/i1318.scala
@@ -1,0 +1,38 @@
+object Foo {
+  class S(i: Int)
+  case class T(i: Int) extends S(i)
+
+  object T {
+    def unapply(s: S): Option[(Int, Int)] = Some(5, 6)
+    // def unapply(o: Object): Option[(Int, Int, Int)] = Some(5, 6, 7)
+  }
+
+  val s = new S(5)
+
+  s match {
+    // case T(x, y, z) => println(x + y + z)
+    case T(x, y) => println(x + y)
+    case T(x) => println(x)
+    case _ => println("not match")
+  }
+}
+
+object Bar {
+  case class T(i: Int)
+  class S(i: Int) extends T(i)
+
+  object T {
+    def unapply(s: S): Option[(Int, Int)] = Some(5, 6)
+    // def unapply(o: Object): Option[(Int, Int, Int)] = Some(5, 6, 7)
+  }
+
+  val s = new S(5)
+
+  s match {
+    // case T(x, y, z) => println(x + y + z)
+    case T(x, y) => println(x + y)
+    case T(x) => println(x)
+    case _ => println("not match")
+  }
+}
+


### PR DESCRIPTION
Fix #1318 , review @DarkDimius 

This fix only works in limited cases. For example, if we remove the comments in the test `tests/pos/i1318.scala`, compilation still fails.

It seems that a more general and correct approach is to use a try and backtrack approach to find the first overloaded `unapply` that type checks. I'm not sure if it's good to follow that approach.
