### PR TITLE
Fix #1366: constant adaptation

### DIFF
--- a/tests/pos/i1366.scala
+++ b/tests/pos/i1366.scala
@@ -1,0 +1,6 @@
+object Test {
+
+  val a: Char = 98
+  val c: (Char, Char) = ('a', 98)
+
+}


### PR DESCRIPTION
Fix #1366: Constant adaptation did not work if the
expected type was an as yet uninstantiated type variable.

Review by @nicolasstucki 