### PR TITLE
Fix 1365: Fix bindings in patterns

### DIFF
--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -449,11 +449,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
               case _ =>
             }
           case _ =>
-            if (!ctx.isAfterTyper) {
-              val setBefore = ctx.mode is Mode.GADTflexible
-              tpt1.tpe.<:<(pt)(ctx.addMode(Mode.GADTflexible))
-              if (!setBefore) ctx.retractMode(Mode.GADTflexible)
-            }
+            if (!ctx.isAfterTyper) tpt1.tpe.<:<(pt)(ctx.addMode(Mode.GADTflexible))
         }
         ascription(tpt1, isWildcard = true)
       }

--- a/tests/pos/i1365.scala
+++ b/tests/pos/i1365.scala
@@ -1,0 +1,13 @@
+import scala.collection.mutable.ArrayBuffer
+
+trait Message[M]
+class Script[S] extends ArrayBuffer[Message[S]] with Message[S]
+
+class Test[A] {
+  def f(cmd: Message[A]): Unit = cmd match {
+    case s: Script[_] => s.iterator.foreach(x => f(x))
+  }
+  def g(cmd: Message[A]): Unit = cmd match {
+    case s: Script[z] => s.iterator.foreach(x => g(x))
+  }
+}


### PR DESCRIPTION
We need to compare pattern types with expected types in order
to derive knowledge about pattern-bound variables. This is done
using the mechanism of gadt bounds.

This is a subtle aspect of type inference that was so far missing from dotty. scalac does it 
differently, I would argue in a more ad-hoc way.

Review by @DarkDimius. 