### PR TITLE
Fix 1375: Infinite loop in interpreter

### DIFF
--- a/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -77,10 +77,15 @@ object SyntaxHighlighting {
         (n: @switch) match {
           case '/'  =>
             if (remaining.nonEmpty) {
-              takeChar() match {
-                case '/' => eolComment()
-                case '*' => blockComment()
-                case x => newBuf += '/'; remaining = x #:: remaining
+              remaining.head match {
+                case '/' =>
+                  takeChar()
+                  eolComment()
+                case '*' =>
+                  takeChar()
+                  blockComment()
+                case x =>
+                  newBuf += '/'
               }
             } else newBuf += '/'
           case '='  =>


### PR DESCRIPTION
The code example in #1375 caused the REPL to get in an infinite loop, and eventually terminate in an out of memory error.

The cause of this was the way the `/` character was handled, or more precisely, the character following a `/`. Instead of peeking the next character, it was polled, and in case of a no match, was put back using the lazy stream cons, which doesn't play nicely with expressions of the form `stream = n #:: stream` (or I should say it can be surprising).