### PR TITLE
Fix erasure of Java Array[T]

### DIFF
--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -389,7 +389,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
     def arrayErasure(tpToErase: Type) =
       erasureFn(isJava, semiEraseVCs = false, isConstructor, wildcardOK)(tpToErase)
     if (elemtp derivesFrom defn.NullClass) JavaArrayType(defn.ObjectType)
-    else if (isUnboundedGeneric(elemtp)) defn.ObjectType
+    else if (isUnboundedGeneric(elemtp) && !isJava) defn.ObjectType
     else JavaArrayType(arrayErasure(elemtp))
   }
 

--- a/tests/run/i1387.scala
+++ b/tests/run/i1387.scala
@@ -1,0 +1,6 @@
+object Test {
+
+  def main(args: Array[String]): Unit =
+    classOf[java.nio.file.AccessMode].getEnumConstants
+
+}


### PR DESCRIPTION
Should be erased to Object[], not Object. Review by @smarter.