### PR TITLE
Fix #1386: Reduce double def errors

### DIFF
--- a/src/dotty/tools/dotc/core/Denotations.scala
+++ b/src/dotty/tools/dotc/core/Denotations.scala
@@ -292,24 +292,41 @@ object Denotations {
             val sym1 = denot1.symbol
             val sym2 = denot2.symbol
 
-            if (isDoubleDef(sym1, sym2)) doubleDefError(denot1, denot2, pre)
-
             val sym2Accessible = sym2.isAccessibleFrom(pre)
+
             /** Does `sym1` come before `sym2` in the linearization of `pre`? */
             def precedes(sym1: Symbol, sym2: Symbol) = {
               def precedesIn(bcs: List[ClassSymbol]): Boolean = bcs match {
                 case bc :: bcs1 => (sym1 eq bc) || !(sym2 eq bc) && precedesIn(bcs1)
                 case Nil => true
               }
-              sym1.derivesFrom(sym2) ||
-                !sym2.derivesFrom(sym1) && precedesIn(pre.baseClasses)
+              (sym1 ne sym2) &&
+              (sym1.derivesFrom(sym2) ||
+                !sym2.derivesFrom(sym1) && precedesIn(pre.baseClasses))
             }
 
-            /** Preference according to partial pre-order (isConcrete, precedes) */
+            /** Establish a partial order "preference" order between symbols.
+             *  Give preference to `sym1` over `sym2` if one of the following
+             *  conditions holds, in decreasing order of weight:
+             *   1. sym1 is concrete and sym2 is abstract
+             *   2. The owner of sym1 comes before the owner of sym2 in the linearization
+             *      of the type of the prefix `pre`.
+             *   3. The access boundary of sym2 is properly contained in the access
+             *      boundary of sym1. For protected access, we count the enclosing
+             *      package as access boundary.
+             *   4. sym1 a method but sym2 is not.
+             *  The aim of these criteria is to give some disambiguation on access which
+             *   - does not depend on textual order or other arbitrary choices
+             *   - minimizes raising of doubleDef errors
+             */
             def preferSym(sym1: Symbol, sym2: Symbol) =
               sym1.eq(sym2) ||
                 sym1.isAsConcrete(sym2) &&
-                (!sym2.isAsConcrete(sym1) || precedes(sym1.owner, sym2.owner))
+                (!sym2.isAsConcrete(sym1) ||
+                 precedes(sym1.owner, sym2.owner) ||
+                 sym2.accessBoundary(sym2.enclosingPackageClass)
+                   .isProperlyContainedIn(sym1.accessBoundary(sym1.enclosingPackageClass)) ||
+                 sym1.is(Method) && !sym2.is(Method))
 
             /** Sym preference provided types also override */
             def prefer(sym1: Symbol, sym2: Symbol, info1: Type, info2: Type) =
@@ -321,6 +338,7 @@ object Denotations {
               if (sym1Accessible && prefer(sym1, sym2, info1, info2)) denot1
               else if (sym1Accessible && sym2.exists && !sym2Accessible) denot1
               else if (sym2Accessible && sym1.exists && !sym1Accessible) denot2
+              else if (isDoubleDef(sym1, sym2)) doubleDefError(denot1, denot2, pre)
               else {
                 val sym =
                   if (!sym1.exists) sym2

--- a/src/dotty/tools/dotc/core/Denotations.scala
+++ b/src/dotty/tools/dotc/core/Denotations.scala
@@ -339,17 +339,18 @@ object Denotations {
             def prefer(sym1: Symbol, sym2: Symbol, info1: Type, info2: Type) =
               preferSym(sym1, sym2) && info1.overrides(info2)
 
+            def handleDoubleDef =
+              if (preferSym(sym1, sym2)) denot1
+              else if (preferSym(sym2, sym1)) denot2
+              else doubleDefError(denot1, denot2, pre)
+
             if (sym2Accessible && prefer(sym2, sym1, info2, info1)) denot2
             else {
               val sym1Accessible = sym1.isAccessibleFrom(pre)
               if (sym1Accessible && prefer(sym1, sym2, info1, info2)) denot1
               else if (sym1Accessible && sym2.exists && !sym2Accessible) denot1
               else if (sym2Accessible && sym1.exists && !sym1Accessible) denot2
-              else if (isDoubleDef(sym1, sym2)) {
-                if (preferSym(sym1, sym2)) denot1
-                else if (preferSym(sym2, sym1)) denot2
-                else doubleDefError(denot1, denot2, pre)
-              }
+              else if (isDoubleDef(sym1, sym2)) handleDoubleDef
               else {
                 val sym =
                   if (!sym1.exists) sym2

--- a/tests/run/i1386.scala
+++ b/tests/run/i1386.scala
@@ -1,0 +1,4 @@
+object Test {
+  def main(args: Array[String]) =
+   assert(new java.util.HashMap[Int, Int]().size == 0)
+}


### PR DESCRIPTION
Use additional disambiguation criteria before raising a double def error.
See for context: #1240.

Review by @DarkDimius