### PR TITLE
Fix dealias of aliased TypeLambdas

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -862,6 +862,7 @@ object Types {
         val tycon1 = tycon.dealias
         if (tycon1 ne tycon) app.superType.dealias
         else this
+      case TypeAlias(tp) => tp.dealias
       case _ => this
     }
 


### PR DESCRIPTION
In dottydoc I collect implicitly added defs by:

```scala
val defs = sym.info.widenDealias.membersBasedOnFlags(Flags.Method, Flags.Synthetic | Flags.Private).map { meth =>
  // ...
}.toList
```

When rebasing against master after the new HK scheme, this would break the following assertion when encountering an aliased `TypeLambda`:

```
[error] Exception in thread "main" java.lang.AssertionError: assertion failed: invalid prefix TypeAlias(TypeLambda(List(1), List(X0), List(TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Nothing), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any))), RefinedType(TypeRef(ThisType(TypeRef(NoPrefix,collection)),Iterable), scala$collection$Iterable$$A, TypeAlias(PolyParam(X0), 1))), 0)
[error] 	at scala.Predef$.assert(Predef.scala:170)
[error] 	at dotty.tools.dotc.core.Types$NamedType.<init>(Types.scala:1365)
[error] 	at dotty.tools.dotc.core.Types$TypeRef.<init>(Types.scala:1741)
```

This PR fixes the issue in the dottydoc code.