### PR TITLE
Fix #1378: Propagate more knowledge of result type into applications

### DIFF
--- a/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -280,7 +280,7 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
 trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] =>
   import TreeInfo._
 
-  def isFunctionWithImplicitParamType(tree: Tree) = tree match {
+  def isFunctionWithUnknownParamType(tree: Tree) = tree match {
     case untpd.Function(args, _) =>
       args.exists {
         case ValDef(_, tpt, _) => tpt.isEmpty

--- a/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -278,7 +278,18 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
 }
 
 trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] =>
-  // todo: fill with methods from TreeInfo that only apply to untpd.Tree's
+  import TreeInfo._
+
+  def isFunctionWithImplicitParamType(tree: Tree) = tree match {
+    case untpd.Function(args, _) =>
+      args.exists {
+        case ValDef(_, tpt, _) => tpt.isEmpty
+        case _ => false
+      }
+    case _ => false
+  }
+
+  // todo: fill with other methods from TreeInfo that only apply to untpd.Tree's
 }
 
 trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>

--- a/src/dotty/tools/dotc/core/Constants.scala
+++ b/src/dotty/tools/dotc/core/Constants.scala
@@ -173,8 +173,8 @@ object Constants {
           ctx.typerState.constraint.entry(param) match {
             case TypeBounds(lo, hi) =>
               if (hi.classSymbol.isPrimitiveValueClass) hi //constrain further with high bound
-              else lo
-            case NoType => param.binder.paramBounds(param.paramNum).lo
+              else classBound(lo)
+            case NoType => classBound(param.binder.paramBounds(param.paramNum).lo)
             case inst => classBound(inst)
           }
         case pt => pt

--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -554,12 +554,11 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       if (proto.isTupled) proto = proto.tupled
 
       // If some of the application's arguments are function literals without explicitly declared
-      // parameter types, and the expected type is a value type, relate the
-      // normalized result type of the application with the expected type through `<:<`.
-      // This can add more constraints which help sharpen the inferred parameter
-      // types for the argument function literal(s).
-      // This tweak is needed to make i1348 compile.
-      if (tree.args.exists(untpd.isFunctionWithImplicitParamType(_)))
+      // parameter types, relate the normalized result type of the application with the
+      // expected type through `constrainResult`. This can add more constraints which
+      // help sharpen the inferred parameter types for the argument function literal(s).
+      // This tweak is needed to make i1378 compile.
+      if (tree.args.exists(untpd.isFunctionWithUnknownParamType(_)))
         if (!constrainResult(fun1.tpe.widen, proto.derivedFunProto(resultType = pt)))
           typr.println(i"result failure for $tree with type ${fun1.tpe.widen}, expected = $pt")
 

--- a/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -175,7 +175,7 @@ object ProtoTypes {
     def isMatchedBy(tp: Type)(implicit ctx: Context) =
       typer.isApplicable(tp, Nil, typedArgs, resultType)
 
-    def derivedFunProto(args: List[untpd.Tree], resultType: Type, typer: Typer) =
+    def derivedFunProto(args: List[untpd.Tree] = this.args, resultType: Type, typer: Typer = this.typer) =
       if ((args eq this.args) && (resultType eq this.resultType) && (typer eq this.typer)) this
       else new FunProto(args, resultType, typer)
 

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -597,6 +597,13 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         untpd.TypeTree(defn.FunctionClass(args.length).typeRef), args :+ body), pt)
     else {
       val params = args.asInstanceOf[List[untpd.ValDef]]
+
+      pt match {
+        case pt: TypeVar if untpd.isFunctionWithImplicitParamType(tree) =>
+          isFullyDefined(pt, ForceDegree.noBottom)
+        case _ =>
+      }
+
       val (protoFormals, protoResult) = decomposeProtoFunction(pt, params.length)
 
       def refersTo(arg: untpd.Tree, param: untpd.ValDef): Boolean = arg match {

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -599,7 +599,10 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       val params = args.asInstanceOf[List[untpd.ValDef]]
 
       pt match {
-        case pt: TypeVar if untpd.isFunctionWithImplicitParamType(tree) =>
+        case pt: TypeVar if untpd.isFunctionWithUnknownParamType(tree) =>
+          // try to instantiate `pt` if this is possible. If it does not
+          // work the error will be reported later in `inferredParam`,
+          // when we try to infer the parameter type.
           isFullyDefined(pt, ForceDegree.noBottom)
         case _ =>
       }

--- a/test/dotc/scala-collections.whitelist
+++ b/test/dotc/scala-collections.whitelist
@@ -83,7 +83,7 @@
 ./scala-scala/src/library/scala/collection/immutable/Seq.scala
 ./scala-scala/src/library/scala/collection/mutable/IndexedSeq.scala
 ./scala-scala/src/library/scala/collection/mutable/ListBuffer.scala
-./scala-scala/src/library/scala/collection/mutable/BufferLike.scala
+#./scala-scala/src/library/scala/collection/mutable/BufferLike.scala // works under junit, fails under partest, but can't see more info on the cause
 
 ./scala-scala/src/library/scala/collection/mutable/ArrayBuilder.scala
 

--- a/test/dotc/scala-collections.whitelist
+++ b/test/dotc/scala-collections.whitelist
@@ -83,6 +83,7 @@
 ./scala-scala/src/library/scala/collection/immutable/Seq.scala
 ./scala-scala/src/library/scala/collection/mutable/IndexedSeq.scala
 ./scala-scala/src/library/scala/collection/mutable/ListBuffer.scala
+./scala-scala/src/library/scala/collection/mutable/BufferLike.scala
 
 ./scala-scala/src/library/scala/collection/mutable/ArrayBuilder.scala
 

--- a/tests/pos/i1378.scala
+++ b/tests/pos/i1378.scala
@@ -1,0 +1,3 @@
+object Test {
+  (1, x => 2): (Int, Int => Int)
+}


### PR DESCRIPTION
In the presence of implicits, this a delicate dance. On the one hand, we need to propagate
knowledge of result types into applications in order to infer parameters as shown in i1378.scala.
On the other hand, we might go down a wrong path with this, if for instance we really meant to insert an implicit on the result type. 

Review by @nicolasstucki or @smarter.