### PR TITLE
Fix #1269: Typing and pattern matching of nested subclasses

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -2993,10 +2993,6 @@ object Types {
     /** The class type with all type parameters */
     def fullyAppliedRef(implicit ctx: Context): Type = fullyAppliedRef(cls.typeRef, cls.typeParams)
 
-    def rebase(tp: Type)(implicit ctx: Context): Type =
-      if ((prefix eq cls.owner.thisType) || !cls.owner.isClass || ctx.erasedTypes) tp
-      else tp.substThis(cls.owner.asClass, prefix)
-
     private var typeRefCache: TypeRef = null
 
     def typeRef(implicit ctx: Context): TypeRef = {
@@ -3016,7 +3012,7 @@ object Types {
     /** The parent type refs as seen from the given prefix */
     override def parents(implicit ctx: Context): List[TypeRef] = {
       if (parentsCache == null)
-        parentsCache = cls.classParents.mapConserve(rebase(_).asInstanceOf[TypeRef])
+        parentsCache = cls.classParents.mapConserve(_.asSeenFrom(prefix, cls.owner).asInstanceOf[TypeRef])
       parentsCache
     }
 

--- a/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -763,9 +763,8 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {thisTrans
 
         def outerTest(testedBinder: Symbol, expectedTp: Type): Tree = {
           val expectedOuter = expectedTp.normalizedPrefix match {
-            //case ThisType(clazz) => This(clazz)
             //case NoType          => Literal(Constant(true)) // fallback for SI-6183 todo?
-            case pre             => ref(pre.termSymbol)
+            case pre: SingletonType => singleton(pre)
           }
 
           // ExplicitOuter replaces `Select(q, outerSym) OBJ_EQ expectedPrefix` by `Select(q, outerAccessor(outerSym.owner)) OBJ_EQ expectedPrefix`

--- a/tests/pos/i1269.scala
+++ b/tests/pos/i1269.scala
@@ -1,0 +1,16 @@
+trait Module {
+  sealed abstract class Tree
+
+  case class LetL() extends Tree
+
+  object O {
+    case class LetR() extends Tree
+  }
+}
+
+class Patmat(val module: Module) {
+  def patmat(tree: module.Tree) = tree match {
+    case module.LetL() =>
+    case module.O.LetR() =>
+  }
+}


### PR DESCRIPTION
Two problems, one in typing and one in pattern matching were fixed.

Review by @liufengyun or @DarkDimius.