### PR TITLE
Fix typing of match expressions

### DIFF
--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -751,7 +751,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       if (subtp <:< tp) true
       else tp match {
         case tp: TypeRef if tp.symbol.isClass =>
-          tp.symbol.is(Trait) && isSubTypeOfParent(subtp, tp.parents.head)
+          tp.symbol.is(Trait) && isSubTypeOfParent(subtp, tp.firstParent)
         case tp: TypeProxy => isSubTypeOfParent(subtp, tp.superType)
         case _ => false
       }

--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -740,13 +740,19 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
 
     def fromScala2x = unapplyFn.symbol.exists && (unapplyFn.symbol.owner is Scala2x)
 
-    /** Can `subtp` be made to be a subtype of `tp`, possibly by dropping some
-     *  refinements in `tp`?
+    /** Is `subtp` a subtype of `tp` or of some generalization of `tp`?
+     *  The generalizations of a type T are the smallest set G such that
+     *
+     *   - T is in G
+     *   - If a typeref R in G represents a trait, R's superclass is in G.
+     *   - If a type proxy P is not a reference to a class, P's supertype is in G
      */
     def isSubTypeOfParent(subtp: Type, tp: Type)(implicit ctx: Context): Boolean =
       if (subtp <:< tp) true
       else tp match {
-        case tp: RefinedType => isSubTypeOfParent(subtp, tp.parent)
+        case tp: TypeRef if tp.symbol.isClass =>
+          tp.symbol.is(Trait) && isSubTypeOfParent(subtp, tp.parents.head)
+        case tp: TypeProxy => isSubTypeOfParent(subtp, tp.superType)
         case _ => false
       }
 
@@ -754,13 +760,11 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       case mt: MethodType if mt.paramTypes.length == 1 =>
         val unapplyArgType = mt.paramTypes.head
         unapp.println(i"unapp arg tpe = $unapplyArgType, pt = $selType")
-        def wpt = widenForMatchSelector(selType) // needed?
         val ownType =
           if (selType <:< unapplyArgType) {
-            //fullyDefinedType(unapplyArgType, "extractor argument", tree.pos)
             unapp.println(i"case 1 $unapplyArgType ${ctx.typerState.constraint}")
             selType
-          } else if (isSubTypeOfParent(unapplyArgType, wpt)(ctx.addMode(Mode.GADTflexible))) {
+          } else if (isSubTypeOfParent(unapplyArgType, selType)(ctx.addMode(Mode.GADTflexible))) {
             maximizeType(unapplyArgType) match {
               case Some(tvar) =>
                 def msg =
@@ -786,9 +790,9 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
             unapplyArgType
           } else {
             unapp.println("Neither sub nor super")
-            unapp.println(TypeComparer.explained(implicit ctx => unapplyArgType <:< wpt))
+            unapp.println(TypeComparer.explained(implicit ctx => unapplyArgType <:< selType))
             errorType(
-              d"Pattern type $unapplyArgType is neither a subtype nor a supertype of selector type $wpt",
+              d"Pattern type $unapplyArgType is neither a subtype nor a supertype of selector type $selType",
               tree.pos)
           }
 

--- a/tests/neg/i1212.scala
+++ b/tests/neg/i1212.scala
@@ -1,0 +1,1 @@
+@ann class ann extends scala.annotation.Annotation // error: cyclic reference

--- a/tests/neg/patmat.scala
+++ b/tests/neg/patmat.scala
@@ -1,0 +1,24 @@
+trait A
+trait B
+class C extends A with B
+case class D()
+object X {
+  def unapply(x: B): Boolean = false
+}
+
+object Test {
+  def main(args: Array[String]) = {
+    val ca: A = new C
+    ca match {
+      case x: B =>
+      case X() =>
+      case D() => // error: neither a subtype not a supertype
+    }
+    val cc = new C
+    cc match {
+      case x: B =>
+      case X() =>
+      case D() =>  // error: neither a subtype not a supertype
+    }
+  }
+}

--- a/tests/neg/patmat.scala
+++ b/tests/neg/patmat.scala
@@ -12,7 +12,7 @@ object Test {
     ca match {
       case x: B =>
       case X() =>
-      case D() => // error: neither a subtype not a supertype
+      case D() => // ok, but scalac disagrees
     }
     val cc = new C
     cc match {


### PR DESCRIPTION
Allow matches between unapply types and selector type where a possible
overlap might exist. Review by @liufengyun.