### PR TITLE
 HK reduction: Remove special-case for typerefs 

### DIFF
--- a/src/dotty/tools/dotc/config/Config.scala
+++ b/src/dotty/tools/dotc/config/Config.scala
@@ -98,9 +98,8 @@ object Config {
   final val splitProjections = false
 
   /** If this flag is on, always rewrite an application `S[Ts]` where `S` is an alias for
-   *  `[Xs] -> U` to `[Xs := Ts]U`. If this flag is off, the rewriting is only done if `S` is a
-   *  reference to an instantiated parameter. Turning this flag on was observed to
-   *  give a ~6% speedup on the JUnit test suite.
+   *  `[Xs] -> U` to `[Xs := Ts]U`.
+   *  Turning this flag on was observed to give a ~6% speedup on the JUnit test suite.
    */
   final val simplifyApplications = true
 

--- a/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -470,18 +470,13 @@ class TypeApplications(val self: Type) extends AnyVal {
       case dealiased: TypeLambda =>
         def tryReduce =
           if (!args.exists(_.isInstanceOf[TypeBounds])) {
-            val followAlias = stripped match {
-              case stripped: TypeRef =>
-                stripped.symbol.is(BaseTypeArg)
-              case _ =>
-                Config.simplifyApplications && {
-                  dealiased.resType match {
-                    case AppliedType(tyconBody, _) =>
-                      variancesConform(typParams, tyconBody.typeParams)
-                        // Reducing is safe for type inference, as kind of type constructor does not change
-                    case _ => false
-                  }
-                }
+            val followAlias = Config.simplifyApplications && {
+              dealiased.resType match {
+                case AppliedType(tyconBody, _) =>
+                  variancesConform(typParams, tyconBody.typeParams)
+                    // Reducing is safe for type inference, as kind of type constructor does not change
+                case _ => false
+              }
             }
             if ((dealiased eq stripped) || followAlias) dealiased.instantiate(args)
             else HKApply(self, args)

--- a/tests/pos/i1181b.scala
+++ b/tests/pos/i1181b.scala
@@ -1,0 +1,11 @@
+class Foo[A]
+
+object Test {
+  def foo[M[_,_]](x: M[Int,Int]) = x
+
+  type Alias[X,Y] = Foo[X]
+  val x: Alias[Int,Int] = new Foo[Int]
+
+  foo[Alias](x) // ok
+  foo(x)
+}

--- a/tests/pos/i1181c.scala
+++ b/tests/pos/i1181c.scala
@@ -1,0 +1,11 @@
+class Foo[A]
+
+trait Bar[DD[_,_]] {
+  val x: DD[Int, Int]
+}
+
+trait Baz extends Bar[[X,Y] -> Foo[X]] {
+  def foo[M[_,_]](x: M[Int, Int]) = x
+
+  foo(x)
+}


### PR DESCRIPTION
The special case:
```scala
  case stripped: TypeRef =>
    stripped.symbol.is(BaseTypeArg)
```
is wrong because you might still want to reduce applications involving
TypeRefs which are not base class parameters, like in:
```scala
  class Foo[A]
  type Alias[X] = Foo[X]
  val x: Alias[Int] = ???
```
`Alias` is a TypeRef so before this commit `Alias[Int]` was never reduced
to `Foo[Int]`. It should have been:
```scala
  case stripped: TypeRef if stripped.symbol.is(BaseTypeArg) =>
    true
```
But even this is incorrect: it assumes that we can always safely reduce HK
applications involving base class parameters, this is not the case when
the parameter kind is different from the rhs kind as illustrated by
`i1181c.scala`. We fix this by simply dropping the special case.

Review by @odersky 