### PR TITLE
Fix #1401: Make sure all references are forwarded

### DIFF
--- a/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -37,7 +37,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val usejavacp = BooleanSetting("-usejavacp", "Utilize the java.class.path in classpath resolution.")
   val verbose = BooleanSetting("-verbose", "Output messages about what the compiler is doing.")
   val version = BooleanSetting("-version", "Print product version and exit.")
-  val pageWidth = IntSetting("-pagewidth", "Set page width", 80)
+  val pageWidth = IntSetting("-pagewidth", "Set page width", 120)
 
   val jvmargs = PrefixSetting("-J<flag>", "-J", "Pass <flag> directly to the runtime system.")
   val defines = PrefixSetting("-Dproperty=value", "-D", "Pass -Dproperty=value directly to the runtime system.")

--- a/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/src/dotty/tools/dotc/core/TypeOps.scala
@@ -374,7 +374,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
               if (argSym is BaseTypeArg)
                 forwardRef(argSym, from, to, cls, decls)
           pref.info match {
-            case info: TempClassInfo => info.suspensions = (() => forward()) :: info.suspensions // !!! dotty deviation `forward` alone does not eta expand
+            case info: TempClassInfo => info.addSuspension(forward)
             case _ => forward()
           }
         }

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -3043,8 +3043,19 @@ object Types {
     override def toString = s"ClassInfo($prefix, $cls)"
   }
 
-  final class CachedClassInfo(prefix: Type, cls: ClassSymbol, classParents: List[TypeRef], decls: Scope, selfInfo: DotClass)
+  class CachedClassInfo(prefix: Type, cls: ClassSymbol, classParents: List[TypeRef], decls: Scope, selfInfo: DotClass)
     extends ClassInfo(prefix, cls, classParents, decls, selfInfo)
+
+  /** A class for temporary class infos where `parents` are not yet known. */
+  final class TempClassInfo(prefix: Type, cls: ClassSymbol, decls: Scope, selfInfo: DotClass)
+  extends CachedClassInfo(prefix, cls, Nil, decls, selfInfo) {
+  
+    /** A list of actions that were because they rely on the class info of `cls` to
+     *  be no longer temporary. These actions will be performed once `cls` gets a real
+     *  ClassInfo.
+     */
+    var suspensions: List[() => Unit] = Nil
+  }
 
   object ClassInfo {
     def apply(prefix: Type, cls: ClassSymbol, classParents: List[TypeRef], decls: Scope, selfInfo: DotClass = NoType)(implicit ctx: Context) =

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -106,7 +106,8 @@ object Scala2Unpickler {
         // `denot.sourceModule.exists` provision i859.scala crashes in the backend.
         denot.owner.thisType select denot.sourceModule
       else selfInfo
-    denot.info = new TempClassInfo(denot.owner.thisType, denot.classSymbol, decls, ost) // first rough info to avoid CyclicReferences
+    val tempInfo = new TempClassInfo(denot.owner.thisType, denot.classSymbol, decls, ost)
+    denot.info = tempInfo // first rough info to avoid CyclicReferences
     var parentRefs = ctx.normalizeToClassRefs(parents, cls, decls)
     if (parentRefs.isEmpty) parentRefs = defn.ObjectType :: Nil
     for (tparam <- tparams) {
@@ -132,8 +133,7 @@ object Scala2Unpickler {
       registerCompanionPair(scalacCompanion, denot.classSymbol)
     }
 
-    denot.info = ClassInfo( // final info, except possibly for typeparams ordering
-      denot.owner.thisType, denot.classSymbol, parentRefs, decls, ost)
+    tempInfo.finalize(denot, parentRefs) // install final info, except possibly for typeparams ordering
     denot.ensureTypeParamsInCorrectOrder()
   }
 }

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -106,7 +106,7 @@ object Scala2Unpickler {
         // `denot.sourceModule.exists` provision i859.scala crashes in the backend.
         denot.owner.thisType select denot.sourceModule
       else selfInfo
-    denot.info = ClassInfo(denot.owner.thisType, denot.classSymbol, Nil, decls, ost) // first rough info to avoid CyclicReferences
+    denot.info = new TempClassInfo(denot.owner.thisType, denot.classSymbol, decls, ost) // first rough info to avoid CyclicReferences
     var parentRefs = ctx.normalizeToClassRefs(parents, cls, decls)
     if (parentRefs.isEmpty) parentRefs = defn.ObjectType :: Nil
     for (tparam <- tparams) {

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -403,7 +403,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           case impl: Template =>
             modText(tree.mods, if ((tree).mods is Trait) "trait" else "class") ~~
             nameIdText(tree) ~ withEnclosingDef(tree) { toTextTemplate(impl) } ~
-            (if (tree.hasType && ctx.settings.verbose.value) s"[decls = ${tree.symbol.info.decls}]" else "")
+            (if (tree.hasType && ctx.settings.verbose.value) i"[decls = ${tree.symbol.info.decls}]" else "")
           case rhs: TypeBoundsTree =>
             typeDefText(toText(rhs))
           case _ =>

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -688,7 +688,8 @@ class Namer { typer: Typer =>
         else createSymbol(self)
 
       // pre-set info, so that parent types can refer to type params
-      denot.info = ClassInfo(cls.owner.thisType, cls, Nil, decls, selfInfo)
+      val tempClassInfo = new TempClassInfo(cls.owner.thisType, cls, decls, selfInfo)
+      denot.info = tempClassInfo
 
       // Ensure constructor is completed so that any parameter accessors
       // which have type trees deriving from its parameters can be
@@ -705,6 +706,8 @@ class Namer { typer: Typer =>
 
       index(rest)(inClassContext(selfInfo))
       denot.info = ClassInfo(cls.owner.thisType, cls, parentRefs, decls, selfInfo)
+      tempClassInfo.suspensions.foreach(_())
+
       Checking.checkWellFormed(cls)
       if (isDerivedValueClass(cls)) cls.setFlag(Final)
       cls.setApplicableFlags(

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -688,8 +688,8 @@ class Namer { typer: Typer =>
         else createSymbol(self)
 
       // pre-set info, so that parent types can refer to type params
-      val tempClassInfo = new TempClassInfo(cls.owner.thisType, cls, decls, selfInfo)
-      denot.info = tempClassInfo
+      val tempInfo = new TempClassInfo(cls.owner.thisType, cls, decls, selfInfo)
+      denot.info = tempInfo
 
       // Ensure constructor is completed so that any parameter accessors
       // which have type trees deriving from its parameters can be
@@ -705,8 +705,7 @@ class Namer { typer: Typer =>
       typr.println(s"completing $denot, parents = $parents, parentTypes = $parentTypes, parentRefs = $parentRefs")
 
       index(rest)(inClassContext(selfInfo))
-      denot.info = ClassInfo(cls.owner.thisType, cls, parentRefs, decls, selfInfo)
-      tempClassInfo.suspensions.foreach(_())
+      tempInfo.finalize(denot, parentRefs)
 
       Checking.checkWellFormed(cls)
       if (isDerivedValueClass(cls)) cls.setFlag(Final)

--- a/test/dotc/scala-collections.whitelist
+++ b/test/dotc/scala-collections.whitelist
@@ -83,7 +83,7 @@
 ./scala-scala/src/library/scala/collection/immutable/Seq.scala
 ./scala-scala/src/library/scala/collection/mutable/IndexedSeq.scala
 ./scala-scala/src/library/scala/collection/mutable/ListBuffer.scala
-#./scala-scala/src/library/scala/collection/mutable/BufferLike.scala // works under junit, fails under partest, but can't see more info on the cause
+./scala-scala/src/library/scala/collection/mutable/BufferLike.scala
 
 ./scala-scala/src/library/scala/collection/mutable/ArrayBuilder.scala
 

--- a/tests/pos/i1401.scala
+++ b/tests/pos/i1401.scala
@@ -1,0 +1,25 @@
+package i1401
+
+trait Subtractable[A, +Repr <: Subtractable[A, Repr]] {
+  def -(elem: A): Repr
+}
+
+trait BufferLike[BA, +This <: BufferLike[BA, This] with Buffer[BA]]
+                extends Subtractable[BA, This]
+{ self : This =>
+
+  /* Without fix-#1401:
+   *
+     error: overriding method - in trait Subtractable of type (elem: A)This & i1401.Buffer[A];
+     method - of type (elem: BA)This has incompatible type
+     def -(elem: BA): This
+         ^
+     one error found
+  */
+  def -(elem: BA): This
+}
+
+trait Buffer[A] extends BufferLike[A, Buffer[A]]
+
+
+


### PR DESCRIPTION
I minimized the problem to i1401.scala. If we swap Buffer and BufferLike, the test already succeeds without this PR. The difference between the two orders is that we are lacking some parameter forwarders in the error scenario. This PR fixes that.
