### PR TITLE
Fix parameterized typedefs with lambdas as rhs

### DIFF
--- a/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -223,12 +223,12 @@ class TypeApplications(val self: Type) extends AnyVal {
         self.parent.typeParams.filterNot(_.paramName == self.refinedName)
       case self: RecType =>
         self.parent.typeParams
-      case _: HKApply | _: SingletonType =>
+      case _: SingletonType =>
         Nil
       case self: WildcardType =>
         self.optBounds.typeParams
       case self: TypeProxy =>
-        self.underlying.typeParams
+        self.superType.typeParams
       case _ =>
         Nil
     }
@@ -312,14 +312,13 @@ class TypeApplications(val self: Type) extends AnyVal {
     case self: TypeRef => self.info.isHK
     case self: RefinedType => false
     case self: TypeLambda => true
-    case self: HKApply => false
     case self: SingletonType => false
     case self: TypeVar =>
       // Using `origin` instead of `underlying`, as is done for typeParams,
       // avoids having to set ephemeral in some cases.
       self.origin.isHK
     case self: WildcardType => self.optBounds.isHK
-    case self: TypeProxy => self.underlying.isHK
+    case self: TypeProxy => self.superType.isHK
     case _ => false
   }
 

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -2653,7 +2653,6 @@ object Types {
       cachedSuper
     }
 
-    /* (Not needed yet) */
     def lowerBound(implicit ctx: Context) = tycon.stripTypeVar match {
       case tycon: TypeRef =>
         tycon.info match {

--- a/tests/pos/nestedLambdas.scala
+++ b/tests/pos/nestedLambdas.scala
@@ -1,0 +1,9 @@
+class Test {
+
+  type T = [X] -> [Y] -> (X, Y)
+
+  type A[X] = [Y] -> (X, Y)
+
+  type B[X] = (X, X)
+
+}

--- a/tests/pos/nestedLambdas.scala
+++ b/tests/pos/nestedLambdas.scala
@@ -6,4 +6,16 @@ class Test {
 
   type B[X] = (X, X)
 
+  val x: T[Int][Boolean] = ???
+
+  val y: A[Int][Boolean] = x
+
+  def f[X <: T[Int]] = ???
+
+  f[A[Int]]
+
+  def g[X <: T] = ???
+
+  g[A]
+
 }


### PR DESCRIPTION
Previously the compiler crashed when faced with a parameterized typedef
that has a lambda as rhs. We fix this by refining the condition when
not to abstract in typeDefsig.

Review by @smarter 