### PR TITLE
Fix #1263: Suppress super initializer call for val parameters of traits.

### DIFF
--- a/tests/run/i1263.scala
+++ b/tests/run/i1263.scala
@@ -1,0 +1,10 @@
+object Test {
+  trait Foo(val s: String)
+
+  val foo1 = new Foo("bar") {}
+  val foo2 = new Foo { override val s = "bar" }
+  def main(args: Array[String]): Unit = {
+    assert(foo1.s == "bar")
+    assert(foo2.s == "bar")
+  }
+}

--- a/tests/run/i1263.scala
+++ b/tests/run/i1263.scala
@@ -8,3 +8,27 @@ object Test {
     assert(foo2.s == "bar")
   }
 }
+object Test1 {
+  trait Foo(private val s0: String) {
+    def s = s0
+  }
+
+  val foo1 = new Foo("bar") {}
+  def main(args: Array[String]): Unit = {
+    assert(foo1.s == "bar")
+  }
+}
+object Test2 {
+  trait Foo(protected val s: String)
+
+  val foo1 = new Foo("bar") {}
+  val foo2 = new Foo { override val s = "bar" }
+}
+object Test3 {
+  trait Foo(final val s: String)
+
+  val foo1 = new Foo("bar") {}
+  def main(args: Array[String]): Unit = {
+    assert(foo1.s == "bar")
+  }
+}


### PR DESCRIPTION
Val-parameters of traits don't have an initializer, as other vals do. So
we cannot call the initializer in an initialization sequence of a subclass.

Fixes #1263. Review by @DarkDimius 