### PR TITLE
fix #1354: improve type test of union types

### DIFF
--- a/tests/run/i1354.check
+++ b/tests/run/i1354.check
@@ -1,0 +1,6 @@
+0
+false
+5
+1
+true
+true

--- a/tests/run/i1354.scala
+++ b/tests/run/i1354.scala
@@ -1,0 +1,27 @@
+object Test {
+  def foo(a: Int | Double) = a match {
+    case a: (Float | Boolean) => 1
+    case _ => 0
+  }
+
+  def typeTest(a: Int | Double) = a.isInstanceOf[Float | Boolean] // false
+
+  def typeCast(a: Int | Double) = a.asInstanceOf[Float | Boolean] // no error
+
+  def main(args: Array[String]): Unit = {
+    println(foo(4))
+
+    println(typeTest(4))
+
+    println(typeCast(5))
+
+    Boolean.box(true) match {
+     case a: (Float | Boolean) => println(1)
+     case _ => println(0)
+    }
+
+    println(Boolean.box(true).isInstanceOf[Float | Boolean])
+
+    println(Boolean.box(true).asInstanceOf[Float | Boolean])
+  }
+}


### PR DESCRIPTION
Perform following transform before erasure:

```
expr.isInstanceOf[A | B]  ~~>  expr.isInstanceOf[A] | expr.isInstanceOf[B]
```