### PR TITLE
fix #1274: test for dotty bootstrap based on tasty

### DIFF
--- a/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/src/dotty/tools/dotc/config/PathResolver.scala
@@ -180,6 +180,7 @@ class PathResolver(implicit ctx: Context) {
     case "extdirs"            => settings.extdirs.value
     case "classpath" | "cp"   => settings.classpath.value
     case "sourcepath"         => settings.sourcepath.value
+    case "priorityclasspath"  => settings.priorityclasspath.value
   }
 
   /** Calculated values based on any given command line options, falling back on
@@ -193,6 +194,7 @@ class PathResolver(implicit ctx: Context) {
     def javaUserClassPath   = if (useJavaClassPath) Defaults.javaUserClassPath else ""
     def scalaBootClassPath  = cmdLineOrElse("bootclasspath", Defaults.scalaBootClassPath)
     def scalaExtDirs        = cmdLineOrElse("extdirs", Defaults.scalaExtDirs)
+    def priorityClassPath   = cmdLineOrElse("prioritypath", "")
     /** Scaladoc doesn't need any bootstrapping, otherwise will create errors such as:
      * [scaladoc] ../scala-trunk/src/reflect/scala/reflect/macros/Reifiers.scala:89: error: object api is not a member of package reflect
      * [scaladoc] case class ReificationException(val pos: reflect.api.PositionApi, val msg: String) extends Throwable(msg)
@@ -220,7 +222,9 @@ class PathResolver(implicit ctx: Context) {
     import context._
 
     // Assemble the elements!
+    // priority class path takes precedence
     def basis = List[Traversable[ClassPath]](
+      classesInExpandedPath(priorityClassPath),     // 0. The priority class path (for testing).
       classesInPath(javaBootClassPath),             // 1. The Java bootstrap class path.
       contentsOfDirsInPath(javaExtDirs),            // 2. The Java extension class path.
       classesInExpandedPath(javaUserClassPath),     // 3. The Java application class path.
@@ -235,6 +239,7 @@ class PathResolver(implicit ctx: Context) {
     override def toString = """
       |object Calculated {
       |  scalaHome            = %s
+      |  priorityClassPath    = %s
       |  javaBootClassPath    = %s
       |  javaExtDirs          = %s
       |  javaUserClassPath    = %s
@@ -244,7 +249,7 @@ class PathResolver(implicit ctx: Context) {
       |  userClassPath        = %s
       |  sourcePath           = %s
       |}""".trim.stripMargin.format(
-        scalaHome,
+        scalaHome, ppcp(priorityClassPath),
         ppcp(javaBootClassPath), ppcp(javaExtDirs), ppcp(javaUserClassPath),
         useJavaClassPath,
         ppcp(scalaBootClassPath), ppcp(scalaExtDirs), ppcp(userClassPath),

--- a/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -15,6 +15,10 @@ class ScalaSettings extends Settings.SettingGroup {
   val javabootclasspath = PathSetting("-javabootclasspath", "Override java boot classpath.", Defaults.javaBootClassPath)
   val javaextdirs = PathSetting("-javaextdirs", "Override java extdirs classpath.", Defaults.javaExtDirs)
   val sourcepath = PathSetting("-sourcepath", "Specify location(s) of source files.", "") // Defaults.scalaSourcePath
+  val argfiles = BooleanSetting("@<file>", "A text file containing compiler arguments (options and source files)")
+  val classpath = PathSetting("-classpath", "Specify where to find user class files.", defaultClasspath) withAbbreviation "-cp"
+  val d = StringSetting("-d", "directory|jar", "destination for generated classfiles.", ".")
+  val priorityclasspath = PathSetting("-priorityclasspath", "class path that takes precedence over all other paths (or testing only)", "")
 
   /** Other settings.
    */
@@ -46,9 +50,6 @@ class ScalaSettings extends Settings.SettingGroup {
   val nobootcp = BooleanSetting("-nobootcp", "Do not use the boot classpath for the scala jars.")
   val strict = BooleanSetting("-strict", "Use strict type rules, which means some formerly legal code does not typecheck anymore.")
 
-  val argfiles = BooleanSetting("@<file>", "A text file containing compiler arguments (options and source files)")
-  val classpath = PathSetting("-classpath", "Specify where to find user class files.", defaultClasspath) withAbbreviation "-cp"
-  val d = StringSetting("-d", "directory|jar", "destination for generated classfiles.", ".")
   val nospecialization = BooleanSetting("-no-specialization", "Ignore @specialize annotations.")
   val language = MultiStringSetting("-language", "feature", "Enable one or more language features.")
   val rewrite = OptionSetting[Rewrites]("-rewrite", "When used in conjunction with -language:Scala2 rewrites sources to migrate to new syntax")

--- a/src/dotty/tools/dotc/core/Contexts.scala
+++ b/src/dotty/tools/dotc/core/Contexts.scala
@@ -132,7 +132,7 @@ object Contexts {
     def compilationUnit: CompilationUnit = _compilationUnit
 
     /** The current tree */
-    private[this] var _tree: Tree[_ >: Untyped] = _
+    private[this] var _tree: Tree[_ >: Untyped]= _
     protected def tree_=(tree: Tree[_ >: Untyped]) = _tree = tree
     def tree: Tree[_ >: Untyped] = _tree
 


### PR DESCRIPTION
Fix #1274.

The real change is to make user-supplied `-classpath` take precedence over libraries from the compiler runtime.
