### PR TITLE
Fix #1372: Add handler for `PatDef`s to REPL

### DIFF
--- a/src/dotty/tools/dotc/ast/untpd.scala
+++ b/src/dotty/tools/dotc/ast/untpd.scala
@@ -447,6 +447,11 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     }
   }
 
+  /** Fold `f` over all tree nodes, in depth-first, prefix order */
+  class UntypedDeepFolder[X](f: (X, Tree) => X) extends UntypedTreeAccumulator[X] {
+    def apply(x: X, tree: Tree)(implicit ctx: Context): X = foldOver(f(x, tree), tree)
+  }
+
   override def rename(tree: NameTree, newName: Name)(implicit ctx: Context): tree.ThisTree[Untyped] = tree match {
     case t: PolyTypeDef =>
       cpy.PolyTypeDef(t)(newName.asTypeName, t.tparams, t.rhs).asInstanceOf[tree.ThisTree[Untyped]]

--- a/tests/repl/patdef.check
+++ b/tests/repl/patdef.check
@@ -1,0 +1,10 @@
+scala> val Const,x = 0
+Const: Int = 0
+x: Int = 0
+scala> val (Const, List(`x`, _, a), b) = (0, List(0, 1337, 1), 2)
+a: Int = 1
+b: Int = 2
+scala> val a@b = 0
+a: Int @unchecked = 0
+b: Int @unchecked = 0
+scala> :quit


### PR DESCRIPTION
Adds a new handler to `CompilingInterpreter` to extract variable definitions from `PatDef` statements, which allows multiple assignment syntax and pattern match assignments to work properly in the REPL.

Review by @odersky?