### PR TITLE
Fix #1367: Add ParsedTry case to UntypedTree{Copier,Map,Accumulator}

### DIFF
--- a/tests/repl/toplevelTry.check
+++ b/tests/repl/toplevelTry.check
@@ -1,0 +1,3 @@
+scala> try { 0 } catch { _: Throwable => 1 }
+res0: Int = 0
+scala> :quit


### PR DESCRIPTION
 A case for `ParsedTry` was missing from `UntypedTree{Copier,Map,Accumulator}`. Review by @odersky.