### PR TITLE
Fix #1442: add new phase, SelectStatic

### DIFF
--- a/src/dotty/tools/dotc/Compiler.scala
+++ b/src/dotty/tools/dotc/Compiler.scala
@@ -91,6 +91,7 @@ class Compiler {
            new Flatten,             // Lift all inner classes to package scope
            new RestoreScopes),      // Repair scopes rendered invalid by moving definitions in prior phases of the group
       List(new ExpandPrivate,       // Widen private definitions accessed from nested classes
+           new SelectStatic,        // get rid of selects that would be compiled into GetStatic
            new CollectEntryPoints,  // Find classes with main methods
            new CollectSuperCalls,   // Find classes that are called with super
            new MoveStatics,         // Move static methods to companion classes

--- a/src/dotty/tools/dotc/transform/SelectStatic.scala
+++ b/src/dotty/tools/dotc/transform/SelectStatic.scala
@@ -32,7 +32,7 @@ class SelectStatic extends MiniPhaseTransform with IdentityDenotTransformer { th
             sym.hasAnnotation(ctx.definitions.ScalaStaticAnnot)
           )
       )
-        if (!tree.qualifier.symbol.is(JavaModule))
+        if (!tree.qualifier.symbol.is(JavaModule) && !tree.qualifier.isType)
           Block(List(tree.qualifier), ref(sym))
         else tree
       else tree

--- a/src/dotty/tools/dotc/transform/SelectStatic.scala
+++ b/src/dotty/tools/dotc/transform/SelectStatic.scala
@@ -23,11 +23,11 @@ class SelectStatic extends MiniPhaseTransform with IdentityDenotTransformer { th
 
   override def transformSelect(tree: tpd.Select)(implicit ctx: Context, info: TransformerInfo): tpd.Tree = {
     val sym = tree.symbol
-    if (!sym.is(isPackage) && !sym.owner.is(isPackage) &&
+    if (!sym.is(isPackage) && !sym.maybeOwner.is(isPackage) &&
       (
-         ((sym is Flags.Module) && sym.owner.isStaticOwner) ||
+         ((sym is Flags.Module) && sym.maybeOwner.isStaticOwner) ||
          (sym is Flags.JavaStatic) ||
-         (sym.owner is Flags.ImplClass) ||
+         (sym.maybeOwner is Flags.ImplClass) ||
          sym.hasAnnotation(ctx.definitions.ScalaStaticAnnot)
         )
     )

--- a/src/dotty/tools/dotc/transform/SelectStatic.scala
+++ b/src/dotty/tools/dotc/transform/SelectStatic.scala
@@ -1,0 +1,37 @@
+package dotty.tools.dotc
+package transform
+
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.DenotTransformers.IdentityDenotTransformer
+import dotty.tools.dotc.core.Flags._
+import dotty.tools.dotc.core.Symbols._
+import dotty.tools.dotc.core._
+import dotty.tools.dotc.transform.TreeTransforms._
+
+/** Removes selects that would be compiled into GetStatic
+ * otherwise backend needs to be aware that some qualifiers need to be dropped.
+ * Similar transformation seems to be performed by flatten in nsc
+ *
+ * @author Dmytro Petrashko
+ */
+class SelectStatic extends MiniPhaseTransform with IdentityDenotTransformer { thisTransform =>
+  import ast.tpd._
+
+  override def phaseName: String = "selectStatic"
+  private val isPackage = FlagConjunction(PackageCreationFlags.bits)
+
+  override def transformSelect(tree: tpd.Select)(implicit ctx: Context, info: TransformerInfo): tpd.Tree = {
+    val sym = tree.symbol
+    if (!sym.is(isPackage) && !sym.owner.is(isPackage) &&
+      (
+         ((sym is Flags.Module) && sym.owner.isStaticOwner) ||
+         (sym is Flags.JavaStatic) ||
+         (sym.owner is Flags.ImplClass) ||
+         sym.hasAnnotation(ctx.definitions.ScalaStaticAnnot)
+        )
+    )
+      Block(List(tree.qualifier), ref(sym))
+    else tree
+  }
+}

--- a/src/dotty/tools/dotc/transform/SelectStatic.scala
+++ b/src/dotty/tools/dotc/transform/SelectStatic.scala
@@ -13,7 +13,6 @@ import dotty.tools.dotc.transform.TreeTransforms._
 /** Removes selects that would be compiled into GetStatic
  * otherwise backend needs to be aware that some qualifiers need to be dropped.
  * Similar transformation seems to be performed by flatten in nsc
- *
  * @author Dmytro Petrashko
  */
 class SelectStatic extends MiniPhaseTransform with IdentityDenotTransformer { thisTransform =>
@@ -43,7 +42,7 @@ class SelectStatic extends MiniPhaseTransform with IdentityDenotTransformer { th
 
   private def normalize(t: Tree)(implicit ctx: Context) = t match {
     case Select(Block(stats, qual), nm) =>
-      Block(stats, Select(qual, nm))
+      Block(stats, cpy.Select(t)(qual, nm))
     case Apply(Block(stats, qual), nm) =>
       Block(stats, Apply(qual, nm))
     case TypeApply(Block(stats, qual), nm) =>

--- a/src/dotty/tools/dotc/transform/SelectStatic.scala
+++ b/src/dotty/tools/dotc/transform/SelectStatic.scala
@@ -31,7 +31,9 @@ class SelectStatic extends MiniPhaseTransform with IdentityDenotTransformer { th
          sym.hasAnnotation(ctx.definitions.ScalaStaticAnnot)
         )
     )
-      Block(List(tree.qualifier), ref(sym))
+      if (!tree.qualifier.symbol.is(JavaModule))
+        Block(List(tree.qualifier), ref(sym))
+      else tree
     else tree
   }
 }

--- a/src/dotty/tools/dotc/transform/SelectStatic.scala
+++ b/src/dotty/tools/dotc/transform/SelectStatic.scala
@@ -46,10 +46,16 @@ class SelectStatic extends MiniPhaseTransform with IdentityDenotTransformer { th
       Block(stats, Select(qual, nm))
     case Apply(Block(stats, qual), nm) =>
       Block(stats, Apply(qual, nm))
+    case TypeApply(Block(stats, qual), nm) =>
+      Block(stats, TypeApply(qual, nm))
     case _ => t
   }
 
   override def transformApply(tree: tpd.Apply)(implicit ctx: Context, info: TransformerInfo): tpd.Tree = {
+    normalize(tree)
+  }
+
+  override def transformTypeApply(tree: tpd.TypeApply)(implicit ctx: Context, info: TransformerInfo): tpd.Tree = {
     normalize(tree)
   }
 }

--- a/tests/pos/i1442.scala
+++ b/tests/pos/i1442.scala
@@ -1,0 +1,24 @@
+object Test1442 {
+  final def sumMinimized[B](num: Numeric[B]): Int = {
+       var cse: scala.math.Numeric.type = null.asInstanceOf[scala.math.Numeric.type]
+       ({cse = scala.math.Numeric; num eq cse.IntIsIntegral} ||
+               (num eq cse.DoubleAsIfIntegral))
+      2
+  } 
+
+  final def sum[B](implicit num: Numeric[B]): B = {
+           // arithmetic series formula  can be used for regular addition
+       var cse: scala.math.Numeric.type = null.asInstanceOf[scala.math.Numeric.type]   
+       if ({cse = scala.math.Numeric; num eq cse.IntIsIntegral}||
+               (num eq cse.BigIntIsIntegral)||
+               (num eq cse.ShortIsIntegral)||
+               (num eq cse.ByteIsIntegral)||
+               (num eq cse.CharIsIntegral)||
+               (num eq cse.LongIsIntegral)||
+               (num eq cse.FloatAsIfIntegral)||
+               (num eq cse.BigDecimalIsFractional)||
+               (num eq cse.DoubleAsIfIntegral)) {     
+        null.asInstanceOf[B]
+      } else null.asInstanceOf[B]
+  } 
+}

--- a/tests/run/t4859.check
+++ b/tests/run/t4859.check
@@ -1,7 +1,7 @@
+Outer
 Inner
 Inner.i
 About to reference Inner.i
-Outer
 Inner.i
 About to reference O.N
 About to reference O.N


### PR DESCRIPTION
GenBCode has an implicit assumption that I wasn't aware of:
GetStatic should not be emitted against a non-trivial selector. 
If it is, GenBCode messes up the stack by not pop-ing the selector.

Surprisingly, this transformation is perfumed in nsc by flatten.