### PR TITLE
Fix #1447: Make X$ <:< X.type when X is an object

### DIFF
--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -165,7 +165,13 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
                     // However the original judgment should be true.
                 case _ =>
               }
-              val sym1 = tp1.symbol
+              val sym1 =
+                if (tp1.symbol.is(ModuleClass) && tp2.symbol.is(ModuleVal))
+                  // For convenience we want X$ <:< X.type
+                  // This is safe because X$ self-type is X.type
+                  tp1.symbol.companionModule
+                else
+                  tp1.symbol
               if ((sym1 ne NoSymbol) && (sym1 eq tp2.symbol))
                 ctx.erasedTypes ||
                 sym1.isStaticOwner ||

--- a/tests/pos/i1447.scala
+++ b/tests/pos/i1447.scala
@@ -1,0 +1,10 @@
+case object X
+
+object Test {
+  val Alias = X
+
+  val x: X.type = Alias
+
+  type Alias = X.type
+  val a: Alias = Alias
+}


### PR DESCRIPTION
This allows objects to be easily aliased.

Review by @odersky 