### PR TITLE
Fix #1443: Replace toplevel TypeBounds with Any

### DIFF
--- a/src/dotty/tools/dotc/ast/untpd.scala
+++ b/src/dotty/tools/dotc/ast/untpd.scala
@@ -205,6 +205,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def rootDot(name: Name) = Select(Ident(nme.ROOTPKG), name)
   def scalaDot(name: Name) = Select(rootDot(nme.scala_), name)
   def scalaUnit = scalaDot(tpnme.Unit)
+  def scalaAny = scalaDot(tpnme.Any)
 
   def makeConstructor(tparams: List[TypeDef], vparamss: List[List[ValDef]], rhs: Tree = EmptyTree)(implicit ctx: Context): DefDef =
     DefDef(nme.CONSTRUCTOR, tparams, vparamss, TypeTree(), rhs)

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -648,12 +648,17 @@ object Parsers {
     }
 
 /* ------------- TYPES ------------------------------------------------------ */
-    /** Same as [[typ]], but emits a syntax error if it returns a wildcard.
+    /** Same as [[typ]], but if this results in a wildcard it emits a syntax error and
+     *  returns a tree for type `Any` instead.
      */
     def toplevelTyp(): Tree = {
       val t = typ()
-      for (wildcardPos <- findWildcardType(t)) syntaxError("unbound wildcard type", wildcardPos)
-      t
+      findWildcardType(t) match {
+        case Some(wildcardPos) =>
+          syntaxError("unbound wildcard type", wildcardPos)
+          scalaAny
+        case None => t
+      }
     }
 
     /** Type        ::=  FunArgTypes `=>' Type

--- a/tests/neg/unboundWildcard.scala
+++ b/tests/neg/unboundWildcard.scala
@@ -1,6 +1,5 @@
 object unboundWildcard {
 
-  // TODO: move this to tests/neg once it doesn't crash the compiler anymore
   val wildcardVal: _ = 0  // error: unbound wildcard type
 
   val annotated: _ @unchecked = 0  // error: unbound wildcard type


### PR DESCRIPTION
Is there a way to give a full path for "Any" that cannot be shadowed? I've not actually managed to come up with a situation where this would matter, but my current solution still seems inadequate.
Review by @smarter.