### PR TITLE
Fix #1444: Pass implicits to parameterless traits if needed

### DIFF
--- a/tests/neg/i1263.scala
+++ b/tests/neg/i1263.scala
@@ -2,8 +2,10 @@ object Test {
   trait Foo(val s: String)
 
   val foo1 = new Foo("bar") {}
+  val foo2 = new Foo { override val s = "bar" } // error: parameterized trait lacks argument list
   def main(args: Array[String]): Unit = {
     assert(foo1.s == "bar")
+    assert(foo2.s == "bar")
   }
 }
 object Test1 {

--- a/tests/neg/traitParamsMixin.scala
+++ b/tests/neg/traitParamsMixin.scala
@@ -2,8 +2,6 @@ trait T(x: Int) {
   def f = x
 }
 
-class C extends T  // error
-
 trait U extends T
 
 class D extends U {  // error

--- a/tests/neg/traitParamsTyper.scala
+++ b/tests/neg/traitParamsTyper.scala
@@ -2,7 +2,7 @@ trait T(x: Int) {
   def f = x
 }
 
-class C extends T // error
+class C0 extends T // error
 
 class C(x: Int) extends T() // error
 

--- a/tests/neg/traitParamsTyper.scala
+++ b/tests/neg/traitParamsTyper.scala
@@ -2,6 +2,8 @@ trait T(x: Int) {
   def f = x
 }
 
+class C extends T // error
+
 class C(x: Int) extends T() // error
 
 trait U extends C with T

--- a/tests/pos/i1444.scala
+++ b/tests/pos/i1444.scala
@@ -1,0 +1,14 @@
+object Test {
+
+class Cls(implicit x:X)
+class ClsImpl extends Cls //this works
+
+trait Tr1(implicit x:X)
+class TrtImpl extends Tr1 //Compiler: Error: parameterized trait Tr1 lacks argument list
+
+trait Tr2()(implicit x:X)
+class Tr2Impl extends Tr2() //this works
+
+trait X
+implicit object AnX extends X
+}


### PR DESCRIPTION
Fixes #1444. Review by @smarter. 

Based on #1434.
