### PR TITLE
Remove warnings from compliation of dotty.

### DIFF
--- a/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -22,7 +22,6 @@ import dotty.tools.dotc.ast.{untpd, tpd}
 import dotty.tools.dotc.core.Constants.Constant
 import dotty.tools.dotc.core.Types.MethodType
 import dotty.tools.dotc.core.Names.Name
-import dotty.runtime.LazyVals
 import scala.collection.mutable.ListBuffer
 import dotty.tools.dotc.core.Denotations.SingleDenotation
 import dotty.tools.dotc.core.SymDenotations.SymDenotation

--- a/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/src/dotty/tools/dotc/transform/TailRec.scala
@@ -338,14 +338,16 @@ class TailRec extends MiniPhaseTransform with DenotTransformer with FullParamete
           assert(false, "We should never have gotten inside a pattern")
           tree
 
+        case t @ DefDef(_, _, _, _, _) =>
+          t // todo: could improve to handle DefDef's with a label flag calls to which are in tail position
+
         case ValDef(_, _, _) | EmptyTree | Super(_, _) | This(_) |
-             Literal(_) | TypeTree(_) | DefDef(_, _, _, _, _) | TypeDef(_, _) =>
+             Literal(_) | TypeTree(_) | TypeDef(_, _) =>
           tree
 
         case Return(expr, from) =>
           tpd.cpy.Return(tree)(noTailTransform(expr), from)
-        case t: DefDef =>
-          t // todo: could improve to handle DefDef's with a label flag calls to which are in tail position
+
         case _ =>
           super.transform(tree)
       }

--- a/src/scala/compat/java8/JFunction.java
+++ b/src/scala/compat/java8/JFunction.java
@@ -11,96 +11,183 @@ public final class JFunction {
     private JFunction() {}
     public static <R> scala.Function0<R> func(JFunction0<R> f) { return f; }
     public static scala.Function0<BoxedUnit> proc(JProcedure0 p) { return p; }
+    @SuppressWarnings("unchecked")
     public static scala.Function0<BoxedUnit> procSpecialized(JFunction0$mcV$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function0<Byte> funcSpecialized(JFunction0$mcB$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function0<Short> funcSpecialized(JFunction0$mcS$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function0<Integer> funcSpecialized(JFunction0$mcI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function0<Long> funcSpecialized(JFunction0$mcJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function0<Character> funcSpecialized(JFunction0$mcC$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function0<Float> funcSpecialized(JFunction0$mcF$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function0<Double> funcSpecialized(JFunction0$mcD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function0<Boolean> funcSpecialized(JFunction0$mcZ$sp f) { return f; }
     public static <T1, R> scala.Function1<T1, R> func(JFunction1<T1, R> f) { return f; }
     public static <T1> scala.Function1<T1, BoxedUnit> proc(JProcedure1<T1> p) { return p; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Integer, BoxedUnit> procSpecialized(JFunction1$mcVI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Integer, Boolean> funcSpecialized(JFunction1$mcZI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Integer, Integer> funcSpecialized(JFunction1$mcII$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Integer, Float> funcSpecialized(JFunction1$mcFI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Integer, Long> funcSpecialized(JFunction1$mcJI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Integer, Double> funcSpecialized(JFunction1$mcDI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Long, BoxedUnit> procSpecialized(JFunction1$mcVJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Long, Boolean> funcSpecialized(JFunction1$mcZJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Long, Integer> funcSpecialized(JFunction1$mcIJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Long, Float> funcSpecialized(JFunction1$mcFJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Long, Long> funcSpecialized(JFunction1$mcJJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Long, Double> funcSpecialized(JFunction1$mcDJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Float, BoxedUnit> procSpecialized(JFunction1$mcVF$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Float, Boolean> funcSpecialized(JFunction1$mcZF$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Float, Integer> funcSpecialized(JFunction1$mcIF$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Float, Float> funcSpecialized(JFunction1$mcFF$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Float, Long> funcSpecialized(JFunction1$mcJF$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Float, Double> funcSpecialized(JFunction1$mcDF$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Double, BoxedUnit> procSpecialized(JFunction1$mcVD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Double, Boolean> funcSpecialized(JFunction1$mcZD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Double, Integer> funcSpecialized(JFunction1$mcID$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Double, Float> funcSpecialized(JFunction1$mcFD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Double, Long> funcSpecialized(JFunction1$mcJD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function1<Double, Double> funcSpecialized(JFunction1$mcDD$sp f) { return f; }
     public static <T1, T2, R> scala.Function2<T1, T2, R> func(JFunction2<T1, T2, R> f) { return f; }
     public static <T1, T2> scala.Function2<T1, T2, BoxedUnit> proc(JProcedure2<T1, T2> p) { return p; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Integer, BoxedUnit> procSpecialized(JFunction2$mcVII$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Integer, Boolean> funcSpecialized(JFunction2$mcZII$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Integer, Integer> funcSpecialized(JFunction2$mcIII$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Integer, Float> funcSpecialized(JFunction2$mcFII$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Integer, Long> funcSpecialized(JFunction2$mcJII$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Integer, Double> funcSpecialized(JFunction2$mcDII$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Long, BoxedUnit> procSpecialized(JFunction2$mcVIJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Long, Boolean> funcSpecialized(JFunction2$mcZIJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Long, Integer> funcSpecialized(JFunction2$mcIIJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Long, Float> funcSpecialized(JFunction2$mcFIJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Long, Long> funcSpecialized(JFunction2$mcJIJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Long, Double> funcSpecialized(JFunction2$mcDIJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Double, BoxedUnit> procSpecialized(JFunction2$mcVID$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Double, Boolean> funcSpecialized(JFunction2$mcZID$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Double, Integer> funcSpecialized(JFunction2$mcIID$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Double, Float> funcSpecialized(JFunction2$mcFID$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Double, Long> funcSpecialized(JFunction2$mcJID$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Integer, Double, Double> funcSpecialized(JFunction2$mcDID$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Integer, BoxedUnit> procSpecialized(JFunction2$mcVJI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Integer, Boolean> funcSpecialized(JFunction2$mcZJI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Integer, Integer> funcSpecialized(JFunction2$mcIJI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Integer, Float> funcSpecialized(JFunction2$mcFJI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Integer, Long> funcSpecialized(JFunction2$mcJJI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Integer, Double> funcSpecialized(JFunction2$mcDJI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Long, BoxedUnit> procSpecialized(JFunction2$mcVJJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Long, Boolean> funcSpecialized(JFunction2$mcZJJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Long, Integer> funcSpecialized(JFunction2$mcIJJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Long, Float> funcSpecialized(JFunction2$mcFJJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Long, Long> funcSpecialized(JFunction2$mcJJJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Long, Double> funcSpecialized(JFunction2$mcDJJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Double, BoxedUnit> procSpecialized(JFunction2$mcVJD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Double, Boolean> funcSpecialized(JFunction2$mcZJD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Double, Integer> funcSpecialized(JFunction2$mcIJD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Double, Float> funcSpecialized(JFunction2$mcFJD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Double, Long> funcSpecialized(JFunction2$mcJJD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Long, Double, Double> funcSpecialized(JFunction2$mcDJD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Integer, BoxedUnit> procSpecialized(JFunction2$mcVDI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Integer, Boolean> funcSpecialized(JFunction2$mcZDI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Integer, Integer> funcSpecialized(JFunction2$mcIDI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Integer, Float> funcSpecialized(JFunction2$mcFDI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Integer, Long> funcSpecialized(JFunction2$mcJDI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Integer, Double> funcSpecialized(JFunction2$mcDDI$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Long, BoxedUnit> procSpecialized(JFunction2$mcVDJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Long, Boolean> funcSpecialized(JFunction2$mcZDJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Long, Integer> funcSpecialized(JFunction2$mcIDJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Long, Float> funcSpecialized(JFunction2$mcFDJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Long, Long> funcSpecialized(JFunction2$mcJDJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Long, Double> funcSpecialized(JFunction2$mcDDJ$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Double, BoxedUnit> procSpecialized(JFunction2$mcVDD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Double, Boolean> funcSpecialized(JFunction2$mcZDD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Double, Integer> funcSpecialized(JFunction2$mcIDD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Double, Float> funcSpecialized(JFunction2$mcFDD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Double, Long> funcSpecialized(JFunction2$mcJDD$sp f) { return f; }
+    @SuppressWarnings("unchecked")
     public static scala.Function2<Double, Double, Double> funcSpecialized(JFunction2$mcDDD$sp f) { return f; }
     public static <T1, T2, T3, R> scala.Function3<T1, T2, T3, R> func(JFunction3<T1, T2, T3, R> f) { return f; }
     public static <T1, T2, T3> scala.Function3<T1, T2, T3, BoxedUnit> proc(JProcedure3<T1, T2, T3> p) { return p; }

--- a/src/scala/compat/java8/JFunction1.java
+++ b/src/scala/compat/java8/JFunction1.java
@@ -11,229 +11,303 @@ public interface JFunction1<T1, R> extends scala.Function1<T1, R> {
     };
 
     @Override
+    @SuppressWarnings("unchecked")
     default <A> scala.Function1<T1, A> andThen(scala.Function1<R, A> g) {
         return scala.Function1$class.andThen(this, g);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     default <A> scala.Function1<A, R> compose(scala.Function1<A, T1> g) {
         return scala.Function1$class.compose(this, g);
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVI$sp(int v1) {
         apply((T1) ((Integer) v1));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZI$sp(int v1) {
         return (Boolean) apply((T1) ((Integer) v1));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcII$sp(int v1) {
         return (Integer) apply((T1) ((Integer) v1));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFI$sp(int v1) {
         return (Float) apply((T1) ((Integer) v1));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJI$sp(int v1) {
         return (Long) apply((T1) ((Integer) v1));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDI$sp(int v1) {
         return (Double) apply((T1) ((Integer) v1));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVJ$sp(long v1) {
         apply((T1) ((Long) v1));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZJ$sp(long v1) {
         return (Boolean) apply((T1) ((Long) v1));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIJ$sp(long v1) {
         return (Integer) apply((T1) ((Long) v1));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFJ$sp(long v1) {
         return (Float) apply((T1) ((Long) v1));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJJ$sp(long v1) {
         return (Long) apply((T1) ((Long) v1));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDJ$sp(long v1) {
         return (Double) apply((T1) ((Long) v1));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVF$sp(float v1) {
         apply((T1) ((Float) v1));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZF$sp(float v1) {
         return (Boolean) apply((T1) ((Float) v1));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIF$sp(float v1) {
         return (Integer) apply((T1) ((Float) v1));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFF$sp(float v1) {
         return (Float) apply((T1) ((Float) v1));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJF$sp(float v1) {
         return (Long) apply((T1) ((Float) v1));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDF$sp(float v1) {
         return (Double) apply((T1) ((Float) v1));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVD$sp(double v1) {
         apply((T1) ((Double) v1));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZD$sp(double v1) {
         return (Boolean) apply((T1) ((Double) v1));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcID$sp(double v1) {
         return (Integer) apply((T1) ((Double) v1));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFD$sp(double v1) {
         return (Float) apply((T1) ((Double) v1));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJD$sp(double v1) {
         return (Long) apply((T1) ((Double) v1));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDD$sp(double v1) {
         return (Double) apply((T1) ((Double) v1));
     }
-    
+
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcVI$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcZI$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcII$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcFI$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcJI$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcDI$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcVJ$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcZJ$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcIJ$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcFJ$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcJJ$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcDJ$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcVF$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcZF$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcIF$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcFF$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcJF$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcDF$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcVD$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcZD$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcID$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcFD$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcJD$sp(scala.Function1 g) {
         return compose(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 compose$mcDD$sp(scala.Function1 g) {
         return compose(g);
     }
     
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcVI$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcZI$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcII$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcFI$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcJI$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcDI$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcVJ$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcZJ$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcIJ$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcFJ$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcJJ$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcDJ$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcVF$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcZF$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcIF$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcFF$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcJF$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcDF$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcVD$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcZD$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcID$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcFD$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcJD$sp(scala.Function1 g) {
         return andThen(g);
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 andThen$mcDD$sp(scala.Function1 g) {
         return andThen(g);
     }

--- a/src/scala/compat/java8/JFunction10.java
+++ b/src/scala/compat/java8/JFunction10.java
@@ -10,10 +10,12 @@ public interface JFunction10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R> extends
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, R>>>>>>>>>> curried() {
       return scala.Function10$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, R> tupled() {
       return scala.Function10$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction11.java
+++ b/src/scala/compat/java8/JFunction11.java
@@ -10,10 +10,12 @@ public interface JFunction11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R> ex
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, R>>>>>>>>>>> curried() {
       return scala.Function11$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, R> tupled() {
       return scala.Function11$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction12.java
+++ b/src/scala/compat/java8/JFunction12.java
@@ -10,10 +10,12 @@ public interface JFunction12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, R>>>>>>>>>>>> curried() {
       return scala.Function12$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, R> tupled() {
       return scala.Function12$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction13.java
+++ b/src/scala/compat/java8/JFunction13.java
@@ -10,10 +10,12 @@ public interface JFunction13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, scala.Function1<T13, R>>>>>>>>>>>>> curried() {
       return scala.Function13$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, R> tupled() {
       return scala.Function13$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction14.java
+++ b/src/scala/compat/java8/JFunction14.java
@@ -10,10 +10,12 @@ public interface JFunction14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, scala.Function1<T13, scala.Function1<T14, R>>>>>>>>>>>>>> curried() {
       return scala.Function14$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, R> tupled() {
       return scala.Function14$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction15.java
+++ b/src/scala/compat/java8/JFunction15.java
@@ -10,10 +10,12 @@ public interface JFunction15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, scala.Function1<T13, scala.Function1<T14, scala.Function1<T15, R>>>>>>>>>>>>>>> curried() {
       return scala.Function15$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, R> tupled() {
       return scala.Function15$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction16.java
+++ b/src/scala/compat/java8/JFunction16.java
@@ -10,10 +10,12 @@ public interface JFunction16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, scala.Function1<T13, scala.Function1<T14, scala.Function1<T15, scala.Function1<T16, R>>>>>>>>>>>>>>>> curried() {
       return scala.Function16$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>, R> tupled() {
       return scala.Function16$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction17.java
+++ b/src/scala/compat/java8/JFunction17.java
@@ -10,10 +10,12 @@ public interface JFunction17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, scala.Function1<T13, scala.Function1<T14, scala.Function1<T15, scala.Function1<T16, scala.Function1<T17, R>>>>>>>>>>>>>>>>> curried() {
       return scala.Function17$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>, R> tupled() {
       return scala.Function17$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction18.java
+++ b/src/scala/compat/java8/JFunction18.java
@@ -10,10 +10,12 @@ public interface JFunction18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, scala.Function1<T13, scala.Function1<T14, scala.Function1<T15, scala.Function1<T16, scala.Function1<T17, scala.Function1<T18, R>>>>>>>>>>>>>>>>>> curried() {
       return scala.Function18$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>, R> tupled() {
       return scala.Function18$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction19.java
+++ b/src/scala/compat/java8/JFunction19.java
@@ -10,10 +10,12 @@ public interface JFunction19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, scala.Function1<T13, scala.Function1<T14, scala.Function1<T15, scala.Function1<T16, scala.Function1<T17, scala.Function1<T18, scala.Function1<T19, R>>>>>>>>>>>>>>>>>>> curried() {
       return scala.Function19$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>, R> tupled() {
       return scala.Function19$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction2.java
+++ b/src/scala/compat/java8/JFunction2.java
@@ -10,499 +10,663 @@ public interface JFunction2<T1, T2, R> extends scala.Function2<T1, T2, R> {
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, R>> curried() {
       return scala.Function2$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple2<T1, T2>, R> tupled() {
       return scala.Function2$class.tupled(this);
     }
 
+    @SuppressWarnings("unchecked")
     default void apply$mcVII$sp(int v1, int v2) {
         apply((T1) ((Integer) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZII$sp(int v1, int v2) {
         return (Boolean) apply((T1) ((Integer) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIII$sp(int v1, int v2) {
         return (Integer) apply((T1) ((Integer) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFII$sp(int v1, int v2) {
         return (Float) apply((T1) ((Integer) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJII$sp(int v1, int v2) {
         return (Long) apply((T1) ((Integer) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDII$sp(int v1, int v2) {
         return (Double) apply((T1) ((Integer) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVIJ$sp(int v1, long v2) {
         apply((T1) ((Integer) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZIJ$sp(int v1, long v2) {
         return (Boolean) apply((T1) ((Integer) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIIJ$sp(int v1, long v2) {
         return (Integer) apply((T1) ((Integer) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFIJ$sp(int v1, long v2) {
         return (Float) apply((T1) ((Integer) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJIJ$sp(int v1, long v2) {
         return (Long) apply((T1) ((Integer) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDIJ$sp(int v1, long v2) {
         return (Double) apply((T1) ((Integer) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVID$sp(int v1, double v2) {
         apply((T1) ((Integer) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZID$sp(int v1, double v2) {
         return (Boolean) apply((T1) ((Integer) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIID$sp(int v1, double v2) {
         return (Integer) apply((T1) ((Integer) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFID$sp(int v1, double v2) {
         return (Float) apply((T1) ((Integer) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJID$sp(int v1, double v2) {
         return (Long) apply((T1) ((Integer) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDID$sp(int v1, double v2) {
         return (Double) apply((T1) ((Integer) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVJI$sp(long v1, int v2) {
         apply((T1) ((Long) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZJI$sp(long v1, int v2) {
         return (Boolean) apply((T1) ((Long) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIJI$sp(long v1, int v2) {
         return (Integer) apply((T1) ((Long) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFJI$sp(long v1, int v2) {
         return (Float) apply((T1) ((Long) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJJI$sp(long v1, int v2) {
         return (Long) apply((T1) ((Long) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDJI$sp(long v1, int v2) {
         return (Double) apply((T1) ((Long) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVJJ$sp(long v1, long v2) {
         apply((T1) ((Long) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZJJ$sp(long v1, long v2) {
         return (Boolean) apply((T1) ((Long) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIJJ$sp(long v1, long v2) {
         return (Integer) apply((T1) ((Long) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFJJ$sp(long v1, long v2) {
         return (Float) apply((T1) ((Long) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJJJ$sp(long v1, long v2) {
         return (Long) apply((T1) ((Long) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDJJ$sp(long v1, long v2) {
         return (Double) apply((T1) ((Long) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVJD$sp(long v1, double v2) {
         apply((T1) ((Long) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZJD$sp(long v1, double v2) {
         return (Boolean) apply((T1) ((Long) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIJD$sp(long v1, double v2) {
         return (Integer) apply((T1) ((Long) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFJD$sp(long v1, double v2) {
         return (Float) apply((T1) ((Long) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJJD$sp(long v1, double v2) {
         return (Long) apply((T1) ((Long) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDJD$sp(long v1, double v2) {
         return (Double) apply((T1) ((Long) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVDI$sp(double v1, int v2) {
         apply((T1) ((Double) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZDI$sp(double v1, int v2) {
         return (Boolean) apply((T1) ((Double) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIDI$sp(double v1, int v2) {
         return (Integer) apply((T1) ((Double) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFDI$sp(double v1, int v2) {
         return (Float) apply((T1) ((Double) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJDI$sp(double v1, int v2) {
         return (Long) apply((T1) ((Double) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDDI$sp(double v1, int v2) {
         return (Double) apply((T1) ((Double) v1), (T2) ((Integer) v2));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVDJ$sp(double v1, long v2) {
         apply((T1) ((Double) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZDJ$sp(double v1, long v2) {
         return (Boolean) apply((T1) ((Double) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIDJ$sp(double v1, long v2) {
         return (Integer) apply((T1) ((Double) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFDJ$sp(double v1, long v2) {
         return (Float) apply((T1) ((Double) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJDJ$sp(double v1, long v2) {
         return (Long) apply((T1) ((Double) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDDJ$sp(double v1, long v2) {
         return (Double) apply((T1) ((Double) v1), (T2) ((Long) v2));
     }
+    @SuppressWarnings("unchecked")
     default void apply$mcVDD$sp(double v1, double v2) {
         apply((T1) ((Double) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default boolean apply$mcZDD$sp(double v1, double v2) {
         return (Boolean) apply((T1) ((Double) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default int apply$mcIDD$sp(double v1, double v2) {
         return (Integer) apply((T1) ((Double) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default float apply$mcFDD$sp(double v1, double v2) {
         return (Float) apply((T1) ((Double) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default long apply$mcJDD$sp(double v1, double v2) {
         return (Long) apply((T1) ((Double) v1), (T2) ((Double) v2));
     }
+    @SuppressWarnings("unchecked")
     default double apply$mcDDD$sp(double v1, double v2) {
         return (Double) apply((T1) ((Double) v1), (T2) ((Double) v2));
     }
     
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcVII$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcZII$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcIII$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcFII$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcJII$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcDII$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcVIJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcZIJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcIIJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcFIJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcJIJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcDIJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcVID$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcZID$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcIID$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcFID$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcJID$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcDID$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcVJI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcZJI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcIJI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcFJI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcJJI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcDJI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcVJJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcZJJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcIJJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcFJJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcJJJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcDJJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcVJD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcZJD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcIJD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcFJD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcJJD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcDJD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcVDI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcZDI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcIDI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcFDI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcJDI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcDDI$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcVDJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcZDJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcIDJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcFDJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcJDJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcDDJ$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcVDD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcZDD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcIDD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcFDD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcJDD$sp() {
         return curried();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 curried$mcDDD$sp() {
         return curried();
     }
     
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcVII$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcZII$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcIII$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcFII$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcJII$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcDII$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcVIJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcZIJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcIIJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcFIJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcJIJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcDIJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcVID$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcZID$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcIID$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcFID$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcJID$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcDID$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcVJI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcZJI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcIJI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcFJI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcJJI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcDJI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcVJJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcZJJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcIJJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcFJJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcJJJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcDJJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcVJD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcZJD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcIJD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcFJD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcJJD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcDJD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcVDI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcZDI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcIDI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcFDI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcJDI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcDDI$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcVDJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcZDJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcIDJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcFDJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcJDJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcDDJ$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcVDD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcZDD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcIDD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcFDD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcJDD$sp() {
         return tupled();
     }
+    @SuppressWarnings("unchecked")
     default scala.Function1 tupled$mcDDD$sp() {
         return tupled();
     }

--- a/src/scala/compat/java8/JFunction20.java
+++ b/src/scala/compat/java8/JFunction20.java
@@ -10,10 +10,12 @@ public interface JFunction20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, scala.Function1<T13, scala.Function1<T14, scala.Function1<T15, scala.Function1<T16, scala.Function1<T17, scala.Function1<T18, scala.Function1<T19, scala.Function1<T20, R>>>>>>>>>>>>>>>>>>>> curried() {
       return scala.Function20$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>, R> tupled() {
       return scala.Function20$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction21.java
+++ b/src/scala/compat/java8/JFunction21.java
@@ -10,10 +10,12 @@ public interface JFunction21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, scala.Function1<T13, scala.Function1<T14, scala.Function1<T15, scala.Function1<T16, scala.Function1<T17, scala.Function1<T18, scala.Function1<T19, scala.Function1<T20, scala.Function1<T21, R>>>>>>>>>>>>>>>>>>>>> curried() {
       return scala.Function21$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>, R> tupled() {
       return scala.Function21$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction22.java
+++ b/src/scala/compat/java8/JFunction22.java
@@ -10,10 +10,12 @@ public interface JFunction22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, scala.Function1<T10, scala.Function1<T11, scala.Function1<T12, scala.Function1<T13, scala.Function1<T14, scala.Function1<T15, scala.Function1<T16, scala.Function1<T17, scala.Function1<T18, scala.Function1<T19, scala.Function1<T20, scala.Function1<T21, scala.Function1<T22, R>>>>>>>>>>>>>>>>>>>>>> curried() {
       return scala.Function22$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>, R> tupled() {
       return scala.Function22$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction3.java
+++ b/src/scala/compat/java8/JFunction3.java
@@ -10,10 +10,12 @@ public interface JFunction3<T1, T2, T3, R> extends scala.Function3<T1, T2, T3, R
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, R>>> curried() {
       return scala.Function3$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple3<T1, T2, T3>, R> tupled() {
       return scala.Function3$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction4.java
+++ b/src/scala/compat/java8/JFunction4.java
@@ -10,10 +10,12 @@ public interface JFunction4<T1, T2, T3, T4, R> extends scala.Function4<T1, T2, T
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, R>>>> curried() {
       return scala.Function4$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple4<T1, T2, T3, T4>, R> tupled() {
       return scala.Function4$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction5.java
+++ b/src/scala/compat/java8/JFunction5.java
@@ -10,10 +10,12 @@ public interface JFunction5<T1, T2, T3, T4, T5, R> extends scala.Function5<T1, T
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, R>>>>> curried() {
       return scala.Function5$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple5<T1, T2, T3, T4, T5>, R> tupled() {
       return scala.Function5$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction6.java
+++ b/src/scala/compat/java8/JFunction6.java
@@ -10,10 +10,12 @@ public interface JFunction6<T1, T2, T3, T4, T5, T6, R> extends scala.Function6<T
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, R>>>>>> curried() {
       return scala.Function6$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple6<T1, T2, T3, T4, T5, T6>, R> tupled() {
       return scala.Function6$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction7.java
+++ b/src/scala/compat/java8/JFunction7.java
@@ -10,10 +10,12 @@ public interface JFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends scala.Functio
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, R>>>>>>> curried() {
       return scala.Function7$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled() {
       return scala.Function7$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction8.java
+++ b/src/scala/compat/java8/JFunction8.java
@@ -10,10 +10,12 @@ public interface JFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends scala.Fun
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, R>>>>>>>> curried() {
       return scala.Function8$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> tupled() {
       return scala.Function8$class.tupled(this);
     }

--- a/src/scala/compat/java8/JFunction9.java
+++ b/src/scala/compat/java8/JFunction9.java
@@ -10,10 +10,12 @@ public interface JFunction9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> extends scala
     default void $init$() {
     };
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<T1, scala.Function1<T2, scala.Function1<T3, scala.Function1<T4, scala.Function1<T5, scala.Function1<T6, scala.Function1<T7, scala.Function1<T8, scala.Function1<T9, R>>>>>>>>> curried() {
       return scala.Function9$class.curried(this);
     }
 
+    @SuppressWarnings("unchecked")
     default scala.Function1<scala.Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>, R> tupled() {
       return scala.Function9$class.tupled(this);
     }

--- a/test/dotc/build.scala
+++ b/test/dotc/build.scala
@@ -26,6 +26,5 @@ object build extends tests {
     dotty // build output dir
     val p = Runtime.getRuntime.exec(Array("jar", "cf", "dotty.jar", "-C", "out", "."))
     p.waitFor()
-    p
   }
 }


### PR DESCRIPTION
* Suppress warnings from the java Function caused by casts on erased specialized functions.
* Remove 1 dead code warning.
* Remove 1 import warning.

With this get from 372 warning each time dotty is compiled to 7 warnings.