### PR TITLE
Fix #1490: type test of union types via type alias

### DIFF
--- a/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -100,7 +100,7 @@ trait TypeTestsCasts {
          *  The transform happens before erasure of `argType`, thus cannot be merged
          *  with `transformIsInstanceOf`, which depends on erased type of `argType`.
          */
-        def transformOrTypeTest(qual: Tree, argType: Type): Tree = argType match {
+        def transformOrTypeTest(qual: Tree, argType: Type): Tree = argType.dealias match {
           case OrType(tp1, tp2) =>
             evalOnce(qual) { fun =>
               transformOrTypeTest(fun, tp1)

--- a/tests/run/i1490.check
+++ b/tests/run/i1490.check
@@ -1,0 +1,3 @@
+true
+true
+false

--- a/tests/run/i1490.scala
+++ b/tests/run/i1490.scala
@@ -1,0 +1,13 @@
+class Base {
+  type T = Int | Boolean
+  def test(x: Object) = x.isInstanceOf[T]
+}
+
+object Test {
+  def main(args: Array[String]) = {
+    val b = new Base
+    println(b.test(Int.box(3)))
+    println(b.test(Boolean.box(false)))
+    println(b.test(Double.box(3.4)))
+  }
+}


### PR DESCRIPTION
Make type erasure accept one additional parameter:

- `eraseOrType`: Whether erase OrType to its lowest uppper bound