### PR TITLE
some fixes for windows test failures

### DIFF
--- a/test/test/CompilerTest.scala
+++ b/test/test/CompilerTest.scala
@@ -452,8 +452,7 @@ abstract class CompilerTest {
     processFileDir(sourceFile, { sf =>
       if (extensionsToCopy.contains(sf.extension)) {
         dest.parent.jfile.mkdirs
-        dest.toFile.writeAll("/* !!!!! WARNING: DO NOT MODIFY. Original is at: $sf !!!!! */",
-          sf.slurp())
+        dest.toFile.writeAll(s"/* !!!!! WARNING: DO NOT MODIFY. Original is at: $sf !!!!! */", sf.slurp)
       } else {
         log(s"WARNING: ignoring $sf")
       }

--- a/test/test/InterfaceEntryPointTest.scala
+++ b/test/test/InterfaceEntryPointTest.scala
@@ -18,7 +18,7 @@ import scala.collection.mutable.ListBuffer
  */
 class InterfaceEntryPointTest {
   @Test def runCompilerFromInterface = {
-    val sources = List("./tests/pos/HelloWorld.scala")
+    val sources = List("./tests/pos/HelloWorld.scala").map(p => new java.io.File(p).getPath())
     val args = sources ++ List("-d", "./out/")
 
     val mainClass = Class.forName("dotty.tools.dotc.Main")

--- a/test/test/OtherEntryPointsTest.scala
+++ b/test/test/OtherEntryPointsTest.scala
@@ -17,7 +17,7 @@ import scala.collection.mutable.ListBuffer
  */
 class OtherEntryPointsTest {
   @Test def runCompiler = {
-    val sources = List("./tests/pos/HelloWorld.scala")
+    val sources = List("./tests/pos/HelloWorld.scala").map(p => new java.io.File(p).getPath())
     val args = sources ++ List("-d", "./out/")
 
     val reporter = new CustomReporter
@@ -31,7 +31,7 @@ class OtherEntryPointsTest {
   }
 
   @Test def runCompilerWithContext = {
-    val sources = List("./tests/pos/HelloWorld.scala")
+    val sources = List("./tests/pos/HelloWorld.scala").map(p => new java.io.File(p).getPath())
     val args = sources ++ List("-d", "./out/")
 
     val reporter = new CustomReporter

--- a/test/test/TestREPL.scala
+++ b/test/test/TestREPL.scala
@@ -34,7 +34,7 @@ class TestREPL(script: String) extends REPL {
           while (lines.hasNext && lines.head.startsWith(continuationPrompt)) {
             val continued = lines.next
             output.println(continued)
-            buf append "\n"
+            buf append System.lineSeparator()
             buf append continued.drop(continuationPrompt.length)
           }
           buf.toString
@@ -49,7 +49,7 @@ class TestREPL(script: String) extends REPL {
     out.close()
     val printed = out.toString
     val transcript = printed.drop(printed.indexOf(config.prompt))
-    if (transcript.toString != script) {
+    if (transcript.toString.lines.toList != script.lines.toList) {
       println("input differs from transcript:")
       println(transcript)
       assert(false)


### PR DESCRIPTION
* normalize paths
* ignore REPL transscript line ending differences
* missing string interpolator in processFileDir