### PR TITLE
Clean up config.Printers imports

### DIFF
--- a/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/src/dotty/tools/dotc/ast/Desugar.scala
@@ -9,7 +9,6 @@ import Decorators._
 import language.higherKinds
 import collection.mutable.ListBuffer
 import util.Attachment
-import config.Printers._
 
 object desugar {
 

--- a/src/dotty/tools/dotc/ast/tpd.scala
+++ b/src/dotty/tools/dotc/ast/tpd.scala
@@ -9,7 +9,6 @@ import core._
 import util.Positions._, Types._, Contexts._, Constants._, Names._, Flags._
 import SymDenotations._, Symbols._, StdNames._, Annotations._, Trees._, Symbols._
 import Denotations._, Decorators._, DenotTransformers._
-import config.Printers._
 import collection.mutable
 import typer.ErrorReporting._
 

--- a/src/dotty/tools/dotc/config/Printers.scala
+++ b/src/dotty/tools/dotc/config/Printers.scala
@@ -4,12 +4,10 @@ object Printers {
 
   class Printer {
     def println(msg: => String): Unit = System.out.println(msg)
-    def echo[T](msg: => String, value: T): T = { println(msg + value); value }
   }
 
   object noPrinter extends Printer {
     override def println(msg: => String): Unit = ()
-    override def echo[T](msg: => String, value: T): T = value
   }
 
   val default: Printer = new Printer

--- a/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -4,7 +4,6 @@ package core
 
 import Contexts._, Types._, Symbols._, Names._, Flags._, Scopes._
 import SymDenotations._, Denotations.SingleDenotation
-import config.Printers._
 import util.Positions._
 import Decorators._
 import StdNames._

--- a/src/dotty/tools/dotc/core/Constraint.scala
+++ b/src/dotty/tools/dotc/core/Constraint.scala
@@ -8,7 +8,7 @@ import collection.mutable
 import printing.{Printer, Showable}
 import printing.Texts._
 import config.Config
-import config.Printers._
+import config.Printers.constr
 
 /** Constraint over undetermined type parameters. Constraints are built
  *  over values of the following types:

--- a/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -5,7 +5,7 @@ package core
 import Types._, Contexts._, Symbols._
 import Decorators._
 import config.Config
-import config.Printers._
+import config.Printers.{constr, typr}
 import TypeApplications.EtaExpansion
 import collection.mutable
 

--- a/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
+++ b/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
@@ -1,7 +1,8 @@
 package dotty.tools.dotc
 package core
 
-import Contexts._, config.Printers._
+import Contexts._
+import config.Printers.typr
 
 trait ConstraintRunInfo { self: RunInfo =>
   private var maxSize = 0

--- a/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -8,7 +8,6 @@ import collection.mutable
 import printing.{Printer, Showable}
 import printing.Texts._
 import config.Config
-import config.Printers._
 import collection.immutable.BitSet
 import reflect.ClassTag
 import annotation.tailrec

--- a/src/dotty/tools/dotc/core/Phases.scala
+++ b/src/dotty/tools/dotc/core/Phases.scala
@@ -9,7 +9,7 @@ import util.DotClass
 import DenotTransformers._
 import Denotations._
 import Decorators._
-import config.Printers._
+import config.Printers.config
 import scala.collection.mutable.{ListBuffer, ArrayBuffer}
 import dotty.tools.dotc.transform.TreeTransforms.{TreeTransformer, MiniPhase, TreeTransform}
 import dotty.tools.dotc.transform._

--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -16,7 +16,7 @@ import CheckRealizable._
 import util.SimpleMap
 import util.Stats
 import config.Config
-import config.Printers._
+import config.Printers.{completions, incremental, noPrinter}
 
 trait SymDenotations { this: Context =>
   import SymDenotations._

--- a/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -13,7 +13,7 @@ import NameOps._
 import Flags._
 import StdNames.tpnme
 import util.Positions.Position
-import config.Printers._
+import config.Printers.core
 import collection.mutable
 import dotty.tools.dotc.config.Config
 import java.util.NoSuchElementException

--- a/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -8,7 +8,7 @@ import StdNames.{nme, tpnme}
 import collection.mutable
 import util.{Stats, DotClass, SimpleMap}
 import config.Config
-import config.Printers._
+import config.Printers.{typr, constr, subtyping}
 import TypeErasure.{erasedLub, erasedGlb}
 import TypeApplications._
 import scala.util.control.NonFatal

--- a/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/src/dotty/tools/dotc/core/TypeOps.scala
@@ -4,7 +4,7 @@ package core
 
 import Contexts._, Types._, Symbols._, Names._, Flags._, Scopes._
 import SymDenotations._, Denotations.SingleDenotation
-import config.Printers._
+import config.Printers.typr
 import util.Positions._
 import NameOps._
 import Decorators._

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -28,11 +28,11 @@ import Hashable._
 import Uniques._
 import collection.{mutable, Seq, breakOut}
 import config.Config
-import config.Printers._
 import annotation.tailrec
 import Flags.FlagSet
 import language.implicitConversions
 import scala.util.hashing.{ MurmurHash3 => hashing }
+import config.Printers.{core, typr, cyclicErrors}
 
 object Types {
 

--- a/src/dotty/tools/dotc/reporting/StoreReporter.scala
+++ b/src/dotty/tools/dotc/reporting/StoreReporter.scala
@@ -5,7 +5,7 @@ package reporting
 import core.Contexts.Context
 import collection.mutable
 import Reporter.{Error, Warning}
-import config.Printers._
+import config.Printers.typr
 
 /**
  * This class implements a Reporter that stores all messages

--- a/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -13,7 +13,7 @@ import Types._, Contexts._, Constants._, Names._, NameOps._, Flags._, DenotTrans
 import SymDenotations._, Symbols._, StdNames._, Annotations._, Trees._, Scopes._, Denotations._
 import util.Positions._
 import Decorators._
-import config.Printers._
+import config.Printers.typr
 import Symbols._, TypeUtils._
 
 /** A macro transform that runs immediately after typer and that performs the following functions:

--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -24,7 +24,7 @@ import ProtoTypes._
 import EtaExpansion._
 import Inferencing._
 import collection.mutable
-import config.Printers._
+import config.Printers.{typr, unapp, overload}
 import TypeApplications._
 import language.implicitConversions
 

--- a/src/dotty/tools/dotc/typer/Checking.scala
+++ b/src/dotty/tools/dotc/typer/Checking.scala
@@ -26,7 +26,7 @@ import transform.SymUtils._
 import Decorators._
 import Uniques._
 import ErrorReporting.{err, errorType}
-import config.Printers._
+import config.Printers.typr
 import collection.mutable
 import SymDenotations.NoCompleter
 

--- a/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -7,7 +7,7 @@ import Contexts._
 import Symbols._
 import dotty.tools.dotc.parsing.JavaParsers.JavaParser
 import parsing.Parsers.Parser
-import config.Printers._
+import config.Printers.{typr, default}
 import util.Stats._
 import scala.util.control.NonFatal
 import ast.Trees._

--- a/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/src/dotty/tools/dotc/typer/Implicits.scala
@@ -28,7 +28,7 @@ import Inferencing.fullyDefinedType
 import Trees._
 import Hashable._
 import config.Config
-import config.Printers._
+import config.Printers.{implicits, implicitsDetailed}
 import collection.mutable
 
 /** Implicit resolution */

--- a/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -15,7 +15,7 @@ import util.{Stats, SimpleMap}
 import util.common._
 import Decorators._
 import Uniques._
-import config.Printers._
+import config.Printers.{typr, constr}
 import annotation.tailrec
 import reporting._
 import collection.mutable

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -15,7 +15,7 @@ import annotation.tailrec
 import ErrorReporting._
 import tpd.ListOfTreeDecorator
 import config.Config
-import config.Printers._
+import config.Printers.{typr, completions, noPrinter}
 import Annotations._
 import Inferencing._
 import transform.ValueClasses._

--- a/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -15,7 +15,7 @@ import util.common._
 import Decorators._
 import Uniques._
 import ErrorReporting.errorType
-import config.Printers._
+import config.Printers.typr
 import collection.mutable
 
 object ProtoTypes {

--- a/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -8,7 +8,7 @@ import Scopes._, Contexts._, Constants._, Types._, Symbols._, Names._, Flags._, 
 import ErrorReporting._, Annotations._, Denotations._, SymDenotations._, StdNames._, TypeErasure._
 import TypeApplications.AppliedType
 import util.Positions._
-import config.Printers._
+import config.Printers.typr
 import ast.Trees._
 import NameOps._
 import collection.mutable
@@ -81,10 +81,11 @@ trait TypeAssigner {
                   parentType.findMember(decl.name, info.cls.thisType, Private)
                     .suchThat(decl.matches(_))
                 val inheritedInfo = inherited.info
-                if (inheritedInfo.exists && decl.info <:< inheritedInfo && !(inheritedInfo <:< decl.info))
-                  typr.echo(
-                    i"add ref $parent $decl --> ",
-                    RefinedType(parent, decl.name, decl.info))
+                if (inheritedInfo.exists && decl.info <:< inheritedInfo && !(inheritedInfo <:< decl.info)) {
+                  val r = RefinedType(parent, decl.name, decl.info)
+                  typr.println(i"add ref $parent $decl --> " + r)
+                  r
+                }
                 else
                   parent
               }

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -31,7 +31,7 @@ import collection.mutable
 import annotation.tailrec
 import Implicits._
 import util.Stats.{track, record}
-import config.Printers._
+import config.Printers.{typr, gadts}
 import rewrite.Rewrites.patch
 import NavigateAST._
 import transform.SymUtils._


### PR DESCRIPTION
This PR cleans up `config.Printers` imports to make them more grep-able. These changes go in pair with the following updates on https://github.com/lampepfl/dotty/wiki/Workflow:

---

## Compiling files with dotc

From sbt:
```
run <OPTIONS> <FILE>
```

From terminal:

```
$ ./bin/dotc <OPTIONS> <FILE>
```

Here are some useful debugging <OPTIONS>:

* `-Xprint:PHASE1,PHASE2,...` or `-Xprint:all`: prints the `AST` after each specified phase. Phase names can be found by searching `src/dotty/tools/dotc/transform/` for `phaseName`.

* `-Ylog:PHASE1,PHASE2,...` or `-Ylog:all`: enables `ctx.log("")` logging for the specified phase.

* `-Ycheck:all` verifies the consistency of `AST` nodes between phases, in particular checks that types do not change (option enabled in tests)

Additional logging information can be obtained by changes some `noPrinter` to `new Printer` in `src/dotty/tools/dotc/config/Printers.scala`. This enables the `subtyping.println("")` and `ctx.traceIndented("", subtyping)` style logging.

## Running tests

From sbt:

```
partest --show-diff --verbose
```

## Type Stealer

There is no power mode for the repl yet, but you can inspect types with the type stealer:
```
$ ./bin/dotc -repl
scala> import test.DottyTypeStealer._; import dotty.tools.dotc.core._; import Contexts._,Types._;
```

Now, you can define types and access their representation. For example:
```
scala> val s = stealType("class O { type X }", "O#X")
scala> implicit val ctx: Context = s._1
scala> val t = s._2(0)
t: dotty.tools.dotc.core.Types.Type = TypeRef(TypeRef(ThisType(TypeRef(NoPrefix,<empty>)),O),X)
scala> val u = t.asInstanceOf[TypeRef].underlying
u: dotty.tools.dotc.core.Types.Type = TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Nothing), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any))
```

# Pretty-printing

Many objects in the dotc compiler implement a `Showable` trait (e.g. `Tree`, `Symbol`, `Type`). These objects may be prettyprinted using the `.show` method

