### PR TITLE
Drop modifiers

### DIFF
--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -70,7 +70,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   type Bind            = tpd.Bind
   type New             = tpd.New
   type Super           = tpd.Super
-  type Modifiers       = tpd.Modifiers
+  type Modifiers       = Null
   type Annotation      = Annotations.Annotation
   type ArrayValue      = tpd.JavaSeqLiteral
   type ApplyDynamic    = Null
@@ -944,7 +944,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object ValDef extends ValDefDeconstructor {
-    def _1: Modifiers = tpd.Modifiers(field.symbol)
+    def _1: Modifiers = null
     def _2: Name = field.name
     def _3: Tree = field.tpt
     def _4: Tree = field.rhs
@@ -1055,7 +1055,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object DefDef extends DefDefDeconstructor {
-    def _1: Modifiers = tpd.Modifiers(field.symbol)
+    def _1: Modifiers = null
     def _2: Name = field.name
     def _3: List[TypeDef] = field.tparams
     def _4: List[List[ValDef]] = field.vparamss
@@ -1081,7 +1081,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object ClassDef extends ClassDefDeconstructor {
-    def _1: Modifiers = tpd.Modifiers(field.symbol)
+    def _1: Modifiers = null
     def _2: Name = field.name
     def _4: Template = field.rhs.asInstanceOf[Template]
     def _3: List[TypeDef] = Nil

--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -944,7 +944,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object ValDef extends ValDefDeconstructor {
-    def _1: Modifiers = field.mods
+    def _1: Modifiers = tpd.Modifiers(field.symbol)
     def _2: Name = field.name
     def _3: Tree = field.tpt
     def _4: Tree = field.rhs
@@ -1055,7 +1055,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object DefDef extends DefDefDeconstructor {
-    def _1: Modifiers = field.mods
+    def _1: Modifiers = tpd.Modifiers(field.symbol)
     def _2: Name = field.name
     def _3: List[TypeDef] = field.tparams
     def _4: List[List[ValDef]] = field.vparamss
@@ -1081,7 +1081,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object ClassDef extends ClassDefDeconstructor {
-    def _1: Modifiers = field.mods
+    def _1: Modifiers = tpd.Modifiers(field.symbol)
     def _2: Name = field.name
     def _4: Template = field.rhs.asInstanceOf[Template]
     def _3: List[TypeDef] = Nil

--- a/src/dotty/tools/dotc/ast/Trees.scala
+++ b/src/dotty/tools/dotc/ast/Trees.scala
@@ -297,6 +297,20 @@ object Trees {
     }
 
     protected def setMods(mods: untpd.Modifiers) = myMods = mods
+
+    /** The position of the name defined by this definition.
+     *  This is a point position if the definition is synthetic, or a range position
+     *  if the definition comes from source.
+     *  It might also be that the definition does not have a position (for instance when synthesized by
+     *  a calling chain from `viewExists`), in that case the return position is NoPosition.
+     */
+    def namePos =
+      if (pos.exists)
+        if (rawMods.is(Synthetic)) Position(pos.point, pos.point)
+        else Position(pos.point, pos.point + name.length, pos.point)
+      else pos
+
+
   }
 
   /** A ValDef or DefDef tree */

--- a/src/dotty/tools/dotc/ast/Trees.scala
+++ b/src/dotty/tools/dotc/ast/Trees.scala
@@ -322,7 +322,7 @@ object Trees {
 
     private[this] var myMods: Modifiers[T] = null
 
-    private[ast] def rawMods: Modifiers[T] =
+    private[dotc] def rawMods: Modifiers[T] =
       if (myMods == null) genericEmptyModifiers else myMods
 
     def rawComment: Option[Comment] = getAttachment(DocComment)
@@ -869,11 +869,6 @@ object Trees {
       case x :: Nil => x
       case ys => Thicket(ys)
     }
-
-    // ----- Accessing modifiers ----------------------------------------------------
-
-    abstract class ModsDeco { def mods: Modifiers }
-    implicit def modsDeco(mdef: MemberDef)(implicit ctx: Context): ModsDeco
 
     // ----- Helper classes for copying, transforming, accumulating -----------------
 

--- a/src/dotty/tools/dotc/ast/tpd.scala
+++ b/src/dotty/tools/dotc/ast/tpd.scala
@@ -446,10 +446,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       } else foldOver(sym, tree)
   }
 
-  implicit class modsDeco(mdef: MemberDef)(implicit ctx: Context) extends ModsDeco {
-    def mods = if (mdef.hasType) Modifiers(mdef.symbol) else mdef.rawMods
-  }
-
   override val cpy = new TypedTreeCopier
 
   class TypedTreeCopier extends TreeCopier {

--- a/src/dotty/tools/dotc/ast/tpd.scala
+++ b/src/dotty/tools/dotc/ast/tpd.scala
@@ -19,11 +19,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   private def ta(implicit ctx: Context) = ctx.typeAssigner
 
-  def Modifiers(sym: Symbol)(implicit ctx: Context): Modifiers = Modifiers(
-    sym.flags & (if (sym.isType) ModifierFlags | VarianceFlags else ModifierFlags),
-    if (sym.privateWithin.exists) sym.privateWithin.asType.name else tpnme.EMPTY,
-    sym.annotations map (_.tree))
-
   def Ident(tp: NamedType)(implicit ctx: Context): Ident =
     ta.assignType(untpd.Ident(tp.name), tp)
 

--- a/src/dotty/tools/dotc/ast/untpd.scala
+++ b/src/dotty/tools/dotc/ast/untpd.scala
@@ -264,22 +264,11 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   /** A repeated argument such as `arg: _*` */
   def repeated(arg: Tree)(implicit ctx: Context) = Typed(arg, Ident(tpnme.WILDCARD_STAR))
 
-// ------- Decorators -------------------------------------------------
+// ----- Accessing modifiers ----------------------------------------------------
 
-  implicit class UntypedTreeDecorator(val self: Tree) extends AnyVal {
-    def locateEnclosing(base: List[Tree], pos: Position): List[Tree] = {
-      def encloses(elem: Any) = elem match {
-        case t: Tree => t.pos contains pos
-        case _ => false
-      }
-      base.productIterator find encloses match {
-        case Some(tree: Tree) => locateEnclosing(tree :: base, pos)
-        case none => base
-      }
-    }
-  }
+  abstract class ModsDecorator { def mods: Modifiers }
 
-  implicit class modsDeco(val mdef: MemberDef)(implicit ctx: Context) extends ModsDeco {
+  implicit class modsDeco(val mdef: MemberDef)(implicit ctx: Context) {
     def mods = mdef.rawMods
   }
 

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -729,8 +729,8 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
           }
       }
       val mods =
-        if (sym.annotations.isEmpty) EmptyModifiers
-        else Modifiers(annotations = sym.annotations.map(_.tree))
+        if (sym.annotations.isEmpty) untpd.EmptyModifiers
+        else untpd.Modifiers(annotations = sym.annotations.map(_.tree))
       tree.withMods(mods) // record annotations in tree so that tree positions can be filled in.
       goto(end)
       setPos(start, tree)

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -731,7 +731,10 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
       val mods =
         if (sym.annotations.isEmpty) untpd.EmptyModifiers
         else untpd.Modifiers(annotations = sym.annotations.map(_.tree))
-      tree.withMods(mods) // record annotations in tree so that tree positions can be filled in.
+      tree.withMods(mods)
+        // record annotations in tree so that tree positions can be filled in.
+        // Note: Once the inline PR with its changes to positions is in, this should be
+        // no longer necessary.
       goto(end)
       setPos(start, tree)
     }

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -12,6 +12,7 @@ import StdNames._, Denotations._, NameOps._, Flags._, Constants._, Annotations._
 import dotty.tools.dotc.typer.ProtoTypes.{FunProtoTyped, FunProto}
 import util.Positions._
 import dotty.tools.dotc.ast.{tpd, Trees, untpd}, ast.tpd._
+import ast.untpd.Modifiers
 import printing.Texts._
 import printing.Printer
 import io.AbstractFile
@@ -1236,7 +1237,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     val pflags = (pflagsHi.toLong << 32) + pflagsLo
     val flags = unpickleScalaFlags(pflags, isType)
     val privateWithin = readNameRef().asTypeName
-    Trees.Modifiers[Type](flags, privateWithin, Nil)
+    Modifiers(flags, privateWithin, Nil)
   }
 
   protected def readTemplateRef()(implicit ctx: Context): Template =

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -161,8 +161,10 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     import untpd.{modsDeco => _, _}
 
     /** Print modifiers from symbols if tree has type, overriding the untpd behavior. */
-    implicit def modsDeco(mdef: untpd.MemberDef)(implicit ctx: Context): untpd.ModsDeco =
-      tpd.modsDeco(mdef.asInstanceOf[tpd.MemberDef]).asInstanceOf[untpd.ModsDeco]
+    implicit def modsDeco(mdef: untpd.MemberDef)(implicit ctx: Context): untpd.ModsDecorator =
+      new untpd.ModsDecorator {
+        def mods = if (mdef.hasType) tpd.Modifiers(mdef.symbol) else mdef.rawMods
+      }
 
     def isLocalThis(tree: Tree) = tree.typeOpt match {
       case tp: ThisType => tp.cls == ctx.owner.enclosingClass

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -163,8 +163,13 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     /** Print modifiers from symbols if tree has type, overriding the untpd behavior. */
     implicit def modsDeco(mdef: untpd.MemberDef)(implicit ctx: Context): untpd.ModsDecorator =
       new untpd.ModsDecorator {
-        def mods = if (mdef.hasType) tpd.Modifiers(mdef.symbol) else mdef.rawMods
+        def mods = if (mdef.hasType) Modifiers(mdef.symbol) else mdef.rawMods
       }
+
+    def Modifiers(sym: Symbol)(implicit ctx: Context): Modifiers = untpd.Modifiers(
+      sym.flags & (if (sym.isType) ModifierFlags | VarianceFlags else ModifierFlags),
+      if (sym.privateWithin.exists) sym.privateWithin.asType.name else tpnme.EMPTY,
+      sym.annotations map (_.tree))
 
     def isLocalThis(tree: Tree) = tree.typeOpt match {
       case tp: ThisType => tp.cls == ctx.owner.enclosingClass

--- a/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -210,7 +210,7 @@ class LazyVals extends MiniPhaseTransform with IdentityDenotTransformer {
     def transformMemberDefNonVolatile(x: ValOrDefDef)(implicit ctx: Context) = {
         val claz = x.symbol.owner.asClass
         val tpe = x.tpe.widen.resultType.widen
-        assert(!(x.mods is Flags.Mutable))
+        assert(!(x.symbol is Flags.Mutable))
         val containerName = ctx.freshName(x.name.asTermName.lazyLocalName).toTermName
         val containerSymbol = ctx.newSymbol(claz, containerName,
           x.symbol.flags &~ containerFlagsMask | containerFlags | Flags.Private,
@@ -331,7 +331,7 @@ class LazyVals extends MiniPhaseTransform with IdentityDenotTransformer {
     }
 
     def transformMemberDefVolatile(x: ValOrDefDef)(implicit ctx: Context) = {
-        assert(!(x.mods is Flags.Mutable))
+        assert(!(x.symbol is Flags.Mutable))
 
         val tpe = x.tpe.widen.resultType.widen
         val claz = x.symbol.owner.asClass
@@ -377,7 +377,7 @@ class LazyVals extends MiniPhaseTransform with IdentityDenotTransformer {
         }
 
         val containerName = ctx.freshName(x.name.asTermName.lazyLocalName).toTermName
-        val containerSymbol = ctx.newSymbol(claz, containerName, (x.mods &~ containerFlagsMask | containerFlags).flags, tpe, coord = x.symbol.coord).enteredAfter(this)
+        val containerSymbol = ctx.newSymbol(claz, containerName, x.symbol.flags &~ containerFlagsMask | containerFlags, tpe, coord = x.symbol.coord).enteredAfter(this)
 
         val containerTree = ValDef(containerSymbol, defaultValue(tpe))
 

--- a/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -164,7 +164,6 @@ class TreeChecker extends Phase with SymTransformer {
           tree match {
             case t: MemberDef =>
               if (t.name ne sym.name) ctx.warning(s"symbol ${sym.fullName} name doesn't correspond to AST: ${t}")
-              if (sym.flags != t.mods.flags) ctx.warning(s"symbol ${sym.fullName} flags ${sym.flags} doesn't match AST definition flags ${t.mods.flags}")
             // todo: compare trees inside annotations
             case _ =>
           }


### PR DESCRIPTION
The end goal of this PR is to get rid of the Modifiers structure and to represent each modifier as a tree of its own. This is more IDE friendly and simplifies treatment of trees. 

@DarkDimius can you comment on this? Also, have a look at my comments in BackendInterface which require action. 