### PR TITLE
Tree stats

### DIFF
--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -70,7 +70,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   type Bind            = tpd.Bind
   type New             = tpd.New
   type Super           = tpd.Super
-  type Modifiers       = tpd.Modifiers
+  type Modifiers       = Null
   type Annotation      = Annotations.Annotation
   type ArrayValue      = tpd.JavaSeqLiteral
   type ApplyDynamic    = Null
@@ -944,7 +944,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object ValDef extends ValDefDeconstructor {
-    def _1: Modifiers = tpd.Modifiers(field.symbol)
+    def _1: Modifiers = null
     def _2: Name = field.name
     def _3: Tree = field.tpt
     def _4: Tree = field.rhs
@@ -1055,7 +1055,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object DefDef extends DefDefDeconstructor {
-    def _1: Modifiers = tpd.Modifiers(field.symbol)
+    def _1: Modifiers = null
     def _2: Name = field.name
     def _3: List[TypeDef] = field.tparams
     def _4: List[List[ValDef]] = field.vparamss
@@ -1081,7 +1081,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object ClassDef extends ClassDefDeconstructor {
-    def _1: Modifiers = tpd.Modifiers(field.symbol)
+    def _1: Modifiers = null
     def _2: Name = field.name
     def _4: Template = field.rhs.asInstanceOf[Template]
     def _3: List[TypeDef] = Nil

--- a/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -944,7 +944,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object ValDef extends ValDefDeconstructor {
-    def _1: Modifiers = field.mods
+    def _1: Modifiers = tpd.Modifiers(field.symbol)
     def _2: Name = field.name
     def _3: Tree = field.tpt
     def _4: Tree = field.rhs
@@ -1055,7 +1055,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object DefDef extends DefDefDeconstructor {
-    def _1: Modifiers = field.mods
+    def _1: Modifiers = tpd.Modifiers(field.symbol)
     def _2: Name = field.name
     def _3: List[TypeDef] = field.tparams
     def _4: List[List[ValDef]] = field.vparamss
@@ -1081,7 +1081,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   object ClassDef extends ClassDefDeconstructor {
-    def _1: Modifiers = field.mods
+    def _1: Modifiers = tpd.Modifiers(field.symbol)
     def _2: Name = field.name
     def _4: Template = field.rhs.asInstanceOf[Template]
     def _3: List[TypeDef] = Nil

--- a/src/dotty/tools/dotc/Run.scala
+++ b/src/dotty/tools/dotc/Run.scala
@@ -73,6 +73,8 @@ class Run(comp: Compiler)(implicit ctx: Context) {
               printTree(lastPrintedTree)(ctx.fresh.setPhase(phase.next).setCompilationUnit(unit))
           }
         }
+        println(s"total trees after $phase: ${ast.Trees.ntrees}")
+        println(s"retained trees after $phase: ${Stats.nodesStat(units.map(_.tpdTree))}")
         ctx.informTime(s"$phase ", start)
       }
     if (!ctx.reporter.hasErrors) Rewrites.writeBack()

--- a/src/dotty/tools/dotc/ast/Trees.scala
+++ b/src/dotty/tools/dotc/ast/Trees.scala
@@ -322,7 +322,7 @@ object Trees {
 
     private[this] var myMods: Modifiers[T] = null
 
-    private[ast] def rawMods: Modifiers[T] =
+    private[dotc] def rawMods: Modifiers[T] =
       if (myMods == null) genericEmptyModifiers else myMods
 
     def rawComment: Option[Comment] = getAttachment(DocComment)
@@ -869,11 +869,6 @@ object Trees {
       case x :: Nil => x
       case ys => Thicket(ys)
     }
-
-    // ----- Accessing modifiers ----------------------------------------------------
-
-    abstract class ModsDeco { def mods: Modifiers }
-    implicit def modsDeco(mdef: MemberDef)(implicit ctx: Context): ModsDeco
 
     // ----- Helper classes for copying, transforming, accumulating -----------------
 

--- a/src/dotty/tools/dotc/ast/Trees.scala
+++ b/src/dotty/tools/dotc/ast/Trees.scala
@@ -116,7 +116,7 @@ object Trees {
 
     def withTypeUnchecked(tpe: Type): ThisTree[Type] = {
       val tree =
-        (if (myTpe == null ||
+        (if (//myTpe == null ||
           (myTpe.asInstanceOf[AnyRef] eq tpe.asInstanceOf[AnyRef])) this
          else clone).asInstanceOf[Tree[Type]]
       tree overwriteType tpe

--- a/src/dotty/tools/dotc/ast/tpd.scala
+++ b/src/dotty/tools/dotc/ast/tpd.scala
@@ -446,10 +446,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       } else foldOver(sym, tree)
   }
 
-  implicit class modsDeco(mdef: MemberDef)(implicit ctx: Context) extends ModsDeco {
-    def mods = if (mdef.hasType) Modifiers(mdef.symbol) else mdef.rawMods
-  }
-
   override val cpy = new TypedTreeCopier
 
   class TypedTreeCopier extends TreeCopier {

--- a/src/dotty/tools/dotc/ast/tpd.scala
+++ b/src/dotty/tools/dotc/ast/tpd.scala
@@ -19,11 +19,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   private def ta(implicit ctx: Context) = ctx.typeAssigner
 
-  def Modifiers(sym: Symbol)(implicit ctx: Context): Modifiers = Modifiers(
-    sym.flags & (if (sym.isType) ModifierFlags | VarianceFlags else ModifierFlags),
-    if (sym.privateWithin.exists) sym.privateWithin.asType.name else tpnme.EMPTY,
-    sym.annotations map (_.tree))
-
   def Ident(tp: NamedType)(implicit ctx: Context): Ident =
     ta.assignType(untpd.Ident(tp.name), tp)
 

--- a/src/dotty/tools/dotc/ast/untpd.scala
+++ b/src/dotty/tools/dotc/ast/untpd.scala
@@ -264,22 +264,11 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   /** A repeated argument such as `arg: _*` */
   def repeated(arg: Tree)(implicit ctx: Context) = Typed(arg, Ident(tpnme.WILDCARD_STAR))
 
-// ------- Decorators -------------------------------------------------
+// ----- Accessing modifiers ----------------------------------------------------
 
-  implicit class UntypedTreeDecorator(val self: Tree) extends AnyVal {
-    def locateEnclosing(base: List[Tree], pos: Position): List[Tree] = {
-      def encloses(elem: Any) = elem match {
-        case t: Tree => t.pos contains pos
-        case _ => false
-      }
-      base.productIterator find encloses match {
-        case Some(tree: Tree) => locateEnclosing(tree :: base, pos)
-        case none => base
-      }
-    }
-  }
+  abstract class ModsDecorator { def mods: Modifiers }
 
-  implicit class modsDeco(val mdef: MemberDef)(implicit ctx: Context) extends ModsDeco {
+  implicit class modsDeco(val mdef: MemberDef)(implicit ctx: Context) {
     def mods = mdef.rawMods
   }
 

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -729,8 +729,8 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table) {
           }
       }
       val mods =
-        if (sym.annotations.isEmpty) EmptyModifiers
-        else Modifiers(annotations = sym.annotations.map(_.tree))
+        if (sym.annotations.isEmpty) untpd.EmptyModifiers
+        else untpd.Modifiers(annotations = sym.annotations.map(_.tree))
       tree.withMods(mods) // record annotations in tree so that tree positions can be filled in.
       goto(end)
       setPos(start, tree)

--- a/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -12,6 +12,7 @@ import StdNames._, Denotations._, NameOps._, Flags._, Constants._, Annotations._
 import dotty.tools.dotc.typer.ProtoTypes.{FunProtoTyped, FunProto}
 import util.Positions._
 import dotty.tools.dotc.ast.{tpd, Trees, untpd}, ast.tpd._
+import ast.untpd.Modifiers
 import printing.Texts._
 import printing.Printer
 import io.AbstractFile
@@ -1236,7 +1237,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     val pflags = (pflagsHi.toLong << 32) + pflagsLo
     val flags = unpickleScalaFlags(pflags, isType)
     val privateWithin = readNameRef().asTypeName
-    Trees.Modifiers[Type](flags, privateWithin, Nil)
+    Modifiers(flags, privateWithin, Nil)
   }
 
   protected def readTemplateRef()(implicit ctx: Context): Template =

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -161,8 +161,10 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     import untpd.{modsDeco => _, _}
 
     /** Print modifiers from symbols if tree has type, overriding the untpd behavior. */
-    implicit def modsDeco(mdef: untpd.MemberDef)(implicit ctx: Context): untpd.ModsDeco =
-      tpd.modsDeco(mdef.asInstanceOf[tpd.MemberDef]).asInstanceOf[untpd.ModsDeco]
+    implicit def modsDeco(mdef: untpd.MemberDef)(implicit ctx: Context): untpd.ModsDecorator =
+      new untpd.ModsDecorator {
+        def mods = if (mdef.hasType) tpd.Modifiers(mdef.symbol) else mdef.rawMods
+      }
 
     def isLocalThis(tree: Tree) = tree.typeOpt match {
       case tp: ThisType => tp.cls == ctx.owner.enclosingClass

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -163,8 +163,13 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     /** Print modifiers from symbols if tree has type, overriding the untpd behavior. */
     implicit def modsDeco(mdef: untpd.MemberDef)(implicit ctx: Context): untpd.ModsDecorator =
       new untpd.ModsDecorator {
-        def mods = if (mdef.hasType) tpd.Modifiers(mdef.symbol) else mdef.rawMods
+        def mods = if (mdef.hasType) Modifiers(mdef.symbol) else mdef.rawMods
       }
+
+    def Modifiers(sym: Symbol)(implicit ctx: Context): Modifiers = untpd.Modifiers(
+      sym.flags & (if (sym.isType) ModifierFlags | VarianceFlags else ModifierFlags),
+      if (sym.privateWithin.exists) sym.privateWithin.asType.name else tpnme.EMPTY,
+      sym.annotations map (_.tree))
 
     def isLocalThis(tree: Tree) = tree.typeOpt match {
       case tp: ThisType => tp.cls == ctx.owner.enclosingClass

--- a/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -255,7 +255,6 @@ abstract class Reporter extends interfaces.ReporterResult {
   def incomplete(d: Diagnostic)(implicit ctx: Context): Unit =
     incompleteHandler(d)(ctx)
 
-
   /** Summary of warnings and errors */
   def summary: String = {
     val b = new mutable.ListBuffer[String]
@@ -272,6 +271,7 @@ abstract class Reporter extends interfaces.ReporterResult {
   def printSummary(implicit ctx: Context): Unit = {
     val s = summary
     if (s != "") ctx.echo(s)
+    println(s"total trees created: ${ast.Trees.ntrees}")
   }
 
   /** Returns a string meaning "n elements". */

--- a/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -210,7 +210,7 @@ class LazyVals extends MiniPhaseTransform with IdentityDenotTransformer {
     def transformMemberDefNonVolatile(x: ValOrDefDef)(implicit ctx: Context) = {
         val claz = x.symbol.owner.asClass
         val tpe = x.tpe.widen.resultType.widen
-        assert(!(x.mods is Flags.Mutable))
+        assert(!(x.symbol is Flags.Mutable))
         val containerName = ctx.freshName(x.name.asTermName.lazyLocalName).toTermName
         val containerSymbol = ctx.newSymbol(claz, containerName,
           x.symbol.flags &~ containerFlagsMask | containerFlags | Flags.Private,
@@ -331,7 +331,7 @@ class LazyVals extends MiniPhaseTransform with IdentityDenotTransformer {
     }
 
     def transformMemberDefVolatile(x: ValOrDefDef)(implicit ctx: Context) = {
-        assert(!(x.mods is Flags.Mutable))
+        assert(!(x.symbol is Flags.Mutable))
 
         val tpe = x.tpe.widen.resultType.widen
         val claz = x.symbol.owner.asClass
@@ -377,7 +377,7 @@ class LazyVals extends MiniPhaseTransform with IdentityDenotTransformer {
         }
 
         val containerName = ctx.freshName(x.name.asTermName.lazyLocalName).toTermName
-        val containerSymbol = ctx.newSymbol(claz, containerName, (x.mods &~ containerFlagsMask | containerFlags).flags, tpe, coord = x.symbol.coord).enteredAfter(this)
+        val containerSymbol = ctx.newSymbol(claz, containerName, x.symbol.flags &~ containerFlagsMask | containerFlags, tpe, coord = x.symbol.coord).enteredAfter(this)
 
         val containerTree = ValDef(containerSymbol, defaultValue(tpe))
 

--- a/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -164,7 +164,6 @@ class TreeChecker extends Phase with SymTransformer {
           tree match {
             case t: MemberDef =>
               if (t.name ne sym.name) ctx.warning(s"symbol ${sym.fullName} name doesn't correspond to AST: ${t}")
-              if (sym.flags != t.mods.flags) ctx.warning(s"symbol ${sym.fullName} flags ${sym.flags} doesn't match AST definition flags ${t.mods.flags}")
             // todo: compare trees inside annotations
             case _ =>
           }

--- a/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -67,9 +67,13 @@ class FrontEnd extends Phase {
     val unitContexts = for (unit <- units) yield
       ctx.fresh.setCompilationUnit(unit).setFreshNames(new FreshNameCreator.Default)
     unitContexts foreach (parse(_))
+    println(s"total trees created after parsing: ${ast.Trees.ntrees}")
     record("parsedTrees", ast.Trees.ntrees)
     unitContexts foreach (enterSyms(_))
     unitContexts foreach (typeCheck(_))
+    println(s"total trees created after typing: ${ast.Trees.ntrees}")
+    println(s"retained parse trees: ${nodesStat(unitContexts.map(ctx => ctx.compilationUnit.untpdTree))}")
+    println(s"retained typed trees: ${nodesStat(unitContexts.map(ctx => ctx.compilationUnit.tpdTree))}")
     record("totalTrees", ast.Trees.ntrees)
     unitContexts.map(_.compilationUnit).filterNot(discardAfterTyper)
   }

--- a/src/dotty/tools/dotc/util/Stats.scala
+++ b/src/dotty/tools/dotc/util/Stats.scala
@@ -68,4 +68,30 @@ import collection.mutable
       }
     } else op
   }
+
+  import ast.untpd
+
+  def countNodes(tree: untpd.Tree): (Int, Int) = {
+    val seen = mutable.Set[untpd.Tree]()
+    def count(x: Any): Int = {
+      def childNodes(p: ast.Positioned): Int = p.productIterator.map {
+        case pp: ast.Positioned => count(pp)
+        case xs: List[_] => xs.map(count).sum
+        case _ => 0
+      }.sum
+      x match {
+        case x: ast.Trees.WithoutTypeOrPos[_] => childNodes(x)
+        case x: untpd.Tree => seen += x; 1 + childNodes(x)
+        case x: ast.Positioned => childNodes(x)
+        case _ => 0
+      }
+    }
+    (count(tree), seen.size)
+  }
+
+  def nodesStat(ts: List[untpd.Tree]) = {
+    val retaineds = ts.map(t => Stats.countNodes(t)).unzip
+    s"${retaineds._1.sum} (${retaineds._2.sum} uniques)"
+  }
+
 }


### PR DESCRIPTION
Quick and dirty hack to get stats on created and retained nodes after each phase.

The results for bootstrapping dotty with itself are as given below. Total source size (using cloc) is `54351` lines. The part on he right after the "no COW" column is without the copy-on-write optimization in `Tree#withType`. The last two columns give the difference between no-COW numbers and COW numbers.

**Phase**|**total created**|**newly created**|**retained**|**no COW:**|**total created**|**newly created**|**retained**|**more created**|**more retained**
:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:
Parsing|334223|334223|264370| |334219|334219|264366|-4|-4
Typing|906635|572412|430462| |984172|649953|431643|77541|1181
PostTyper|1062563|155928|432280| |1140099|155927|432732|-1|452
FirstTransform|1092759|30196|419501| |1170295|30196|419953|0|452
RefChecks, extmethods, liftTre et al|1353637|260878|421521| |1431169|260874|421953|-4|432
Pattern matcher, explicitOuter, et al|1739140|385503|566543| |1816668|385499|566757|-4|214
ElimByName, resolveSuper et al|1863008|123868|615278| |1940536|123868|615489|0|211
Erasure|2480783|617775|663808| |2558307|617771|664005|-4|197
LazyVals, memoize, mixin, et al|2659164|178381|706704| |2736688|178381|706901|0|197
Lambda lift flatten, et al|2791031|131867|722189| |2868555|131867|722386|0|197
Expand private, labelDef et al|2878192|87161|691151| |2955716|87161|691348|0|197
GenBCode|3358082|479890|691151| |3435606|479890|691348|0|197