### PR TITLE
Fix erasure of "def foo[T]: Unit", do not box the return type

### DIFF
--- a/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -417,7 +417,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
         // See doc comment for ElimByName for speculation how we could improve this.
       else MethodType(Nil, Nil, eraseResult(rt))
     case tp: PolyType =>
-      this(tp.resultType) match {
+      eraseResult(tp.resultType) match {
         case rt: MethodType => rt
         case rt => MethodType(Nil, Nil, rt)
       }

--- a/tests/run/unit_erasure.scala
+++ b/tests/run/unit_erasure.scala
@@ -1,0 +1,16 @@
+class A {
+  def foo1[T]: Unit = {}
+  def foo2[T](): Unit = {}
+  def foo3[T]()(): Unit = {}
+  def foo4: Unit = {}
+  def foo5(): Unit = {}
+  def foo6()(): Unit = {}
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    classOf[A].getMethods.toList.filter(_.getName.startsWith("foo")).foreach { m =>
+      assert(m.getGenericReturnType == Void.TYPE, s"Method does not return void: `${m}`")
+    }
+  }
+}


### PR DESCRIPTION
Review by @odersky 