### PR TITLE
Fix Tasty positions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ build/
 
 # Ignore build-file
 .packages
+/.cache-main
+/.cache-tests

--- a/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/src/dotty/tools/dotc/ast/Positioned.scala
@@ -107,7 +107,7 @@ abstract class Positioned extends DotClass with Product {
 
   /** The initial, synthetic position. This is usually the union of all positioned children's positions.
    */
-  protected def initialPos: Position = {
+  def initialPos: Position = {
     var n = productArity
     var pos = NoPosition
     while (n > 0) {
@@ -139,7 +139,7 @@ abstract class Positioned extends DotClass with Product {
       (this.pos contains that.pos) && {
         var n = productArity
         var found = false
-        while (n > 0 && !found) {
+        while (!found && n > 0) {
           n -= 1
           found = isParent(productElement(n))
         }

--- a/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/src/dotty/tools/dotc/ast/Positioned.scala
@@ -24,7 +24,7 @@ abstract class Positioned extends DotClass with Product {
    *  positions in children.
    */
   protected def setPos(pos: Position): Unit = {
-    curPos = pos
+    setPosUnchecked(pos)
     if (pos.exists) setChildPositions(pos.toSynthetic)
   }
 

--- a/src/dotty/tools/dotc/ast/Trees.scala
+++ b/src/dotty/tools/dotc/ast/Trees.scala
@@ -502,7 +502,9 @@ object Trees {
 
   /** A tree representing inlined code.
    *
-   *  @param  call      The original call that was inlined
+   *  @param  call      Info about the original call that was inlined
+   *                    Until PostTyper, this is the full call, afterwards only
+   *                    a reference to the toplevel class from which the call was inlined.
    *  @param  bindings  Bindings for proxies to be used in the inlined code
    *  @param  expansion The inlined tree, minus bindings.
    *

--- a/src/dotty/tools/dotc/ast/Trees.scala
+++ b/src/dotty/tools/dotc/ast/Trees.scala
@@ -60,15 +60,19 @@ object Trees {
                                         with Cloneable {
 
     if (Stats.enabled) ntrees += 1
+    
+    private def nxId = {
+      nextId += 1
+      //assert(nextId != 199, this)
+      nextId      
+    }
 
     /** A unique identifier for this tree. Used for debugging, and potentially
      *  tracking presentation compiler interactions
      */
-    val uniqueId = {
-      nextId += 1
-      //assert(nextId != 214, this)
-      nextId
-    }
+    private var myUniqueId: Int = nxId
+    
+    def uniqueId = myUniqueId
 
     /** The type  constructor at the root of the tree */
     type ThisTree[T >: Untyped] <: Tree[T]
@@ -188,6 +192,12 @@ object Trees {
 
     override def hashCode(): Int = uniqueId // for debugging; was: System.identityHashCode(this)
     override def equals(that: Any) = this eq that.asInstanceOf[AnyRef]
+    
+    override def clone: Tree[T] = {
+      val tree = super.clone.asInstanceOf[Tree[T]]
+      tree.myUniqueId = nxId
+      tree
+    }
   }
 
   class UnAssignedTypeException[T >: Untyped](tree: Tree[T]) extends RuntimeException {

--- a/src/dotty/tools/dotc/ast/Trees.scala
+++ b/src/dotty/tools/dotc/ast/Trees.scala
@@ -520,13 +520,12 @@ object Trees {
   }
 
   /** A type tree that represents an existing or inferred type */
-  case class TypeTree[-T >: Untyped] private[ast] (original: Tree[T])
+  case class TypeTree[-T >: Untyped] ()
     extends DenotingTree[T] with TypTree[T] {
     type ThisTree[-T >: Untyped] = TypeTree[T]
-    override def initialPos = NoPosition
-    override def isEmpty = !hasType && original.isEmpty
+    override def isEmpty = !hasType
     override def toString =
-      s"TypeTree${if (hasType) s"[$typeOpt]" else s"($original)"}"
+      s"TypeTree${if (hasType) s"[$typeOpt]" else ""}"
   }
 
   /** ref.type */
@@ -960,10 +959,6 @@ object Trees {
         case tree: Inlined if (call eq tree.call) && (bindings eq tree.bindings) && (expansion eq tree.expansion) => tree
         case _ => finalize(tree, untpd.Inlined(call, bindings, expansion))
       }
-      def TypeTree(tree: Tree)(original: Tree): TypeTree = tree match {
-        case tree: TypeTree if original eq tree.original => tree
-        case _ => finalize(tree, untpd.TypeTree(original))
-      }
       def SingletonTypeTree(tree: Tree)(ref: Tree): SingletonTypeTree = tree match {
         case tree: SingletonTypeTree if ref eq tree.ref => tree
         case _ => finalize(tree, untpd.SingletonTypeTree(ref))
@@ -1106,7 +1101,7 @@ object Trees {
           cpy.SeqLiteral(tree)(transform(elems), transform(elemtpt))
         case Inlined(call, bindings, expansion) =>
           cpy.Inlined(tree)(call, transformSub(bindings), transform(expansion))
-        case TypeTree(original) =>
+        case TypeTree() =>
           tree
         case SingletonTypeTree(ref) =>
           cpy.SingletonTypeTree(tree)(transform(ref))
@@ -1210,7 +1205,7 @@ object Trees {
             this(this(x, elems), elemtpt)
           case Inlined(call, bindings, expansion) =>
             this(this(x, bindings), expansion)
-          case TypeTree(original) =>
+          case TypeTree() =>
             x
           case SingletonTypeTree(ref) =>
             this(x, ref)

--- a/src/dotty/tools/dotc/ast/tpd.scala
+++ b/src/dotty/tools/dotc/ast/tpd.scala
@@ -121,11 +121,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def Inlined(call: Tree, bindings: List[MemberDef], expansion: Tree)(implicit ctx: Context): Inlined =
     ta.assignType(untpd.Inlined(call, bindings, expansion), bindings, expansion)
 
-  def TypeTree(original: Tree)(implicit ctx: Context): TypeTree =
-    TypeTree(original.tpe, original)
-
-  def TypeTree(tp: Type, original: Tree = EmptyTree)(implicit ctx: Context): TypeTree =
-    untpd.TypeTree(original).withType(tp)
+  def TypeTree(tp: Type)(implicit ctx: Context): TypeTree =
+    untpd.TypeTree().withType(tp)
 
   def SingletonTypeTree(ref: Tree)(implicit ctx: Context): SingletonTypeTree =
     ta.assignType(untpd.SingletonTypeTree(ref), ref)

--- a/src/dotty/tools/dotc/ast/untpd.scala
+++ b/src/dotty/tools/dotc/ast/untpd.scala
@@ -144,7 +144,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   /** A type tree that gets its type from some other tree's symbol. Enters the
    *  type tree in the References attachment of the `from` tree as a side effect.
    */
-  abstract class DerivedTypeTree extends TypeTree(EmptyTree) {
+  abstract class DerivedTypeTree extends TypeTree {
 
     private var myWatched: Tree = EmptyTree
 
@@ -205,8 +205,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def SeqLiteral(elems: List[Tree], elemtpt: Tree): SeqLiteral = new SeqLiteral(elems, elemtpt)
   def JavaSeqLiteral(elems: List[Tree], elemtpt: Tree): JavaSeqLiteral = new JavaSeqLiteral(elems, elemtpt)
   def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree): Inlined = new Inlined(call, bindings, expansion)
-  def TypeTree(original: Tree): TypeTree = new TypeTree(original)
-  def TypeTree() = new TypeTree(EmptyTree)
+  def TypeTree() = new TypeTree()
   def SingletonTypeTree(ref: Tree): SingletonTypeTree = new SingletonTypeTree(ref)
   def AndTypeTree(left: Tree, right: Tree): AndTypeTree = new AndTypeTree(left, right)
   def OrTypeTree(left: Tree, right: Tree): OrTypeTree = new OrTypeTree(left, right)

--- a/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -59,7 +59,7 @@ class PositionPickler(pickler: TastyPickler, addrsOfTree: tpd.Tree => List[Addr]
         if (x.pos.exists /*&& x.pos.toSynthetic != x.initialPos.toSynthetic*/) {
           nextTreeAddr(x) match {
             case Some(addr) =>
-              //println(i"pickling $x ar $addr")
+              //println(i"pickling $x at $addr")
               pickleDeltas(addr.index, x.pos)
             case _ =>
               //println(i"no address for $x")
@@ -67,7 +67,7 @@ class PositionPickler(pickler: TastyPickler, addrsOfTree: tpd.Tree => List[Addr]
         }
         //else println(i"skipping $x")
         x match {
-          case x: MemberDef @unchecked => traverse(x.symbol.annotations)
+          case x: MemberDef @unchecked => traverse(x.symbol.annotations.map(_.tree))
           case _ =>
         }
         traverse(x.productIterator)

--- a/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -37,23 +37,27 @@ class PositionPickler(pickler: TastyPickler, addrOfTree: tpd.Tree => Option[Addr
       lastIndex = index
       lastPos = pos
     }
-    def traverse(x: Any, parentPos: Position): Unit = x match {
+    def traverse(x: Any): Unit = x match {
       case x: Tree @unchecked =>
-        if (x.pos.exists && x.pos.toSynthetic != parentPos.toSynthetic) {
+        if (x.pos.exists /*&& x.pos.toSynthetic != x.initialPos.toSynthetic*/) {
           addrOfTree(x) match {
-            case Some(addr) => pickleDeltas(addr.index, x.pos)
+            case Some(addr) =>
+              //println(i"pickling $x")
+              pickleDeltas(addr.index, x.pos)
             case _ =>
+              //println(i"no address for $x")
           }
         }
+        //else println(i"skipping $x")
         x match {
-          case x: MemberDef @unchecked => traverse(x.symbol.annotations, x.pos)
+          case x: MemberDef @unchecked => traverse(x.symbol.annotations)
           case _ =>
         }
-        traverse(x.productIterator, x.pos)
+        traverse(x.productIterator)
       case xs: TraversableOnce[_] =>
-        xs.foreach(traverse(_, parentPos))
+        xs.foreach(traverse)
       case _ =>
     }
-    traverse(roots, NoPosition)
+    traverse(roots)
   }
 }

--- a/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -79,7 +79,8 @@ class PositionPickler(pickler: TastyPickler, addrsOfTree: tpd.Tree => List[Addr]
         }
         //else if (x.pos.exists) println(i"skipping $x")
         x match {
-          case x: MemberDef @unchecked => traverse(x.symbol.annotations.map(_.tree))
+          case x: MemberDef @unchecked => 
+            for (ann <- x.symbol.annotations) traverse(ann.tree)
           case _ =>
         }
         traverse(x.productIterator)

--- a/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -61,6 +61,7 @@ class PositionPickler(pickler: TastyPickler, addrsOfTree: tpd.Tree => List[Addr]
     def alwaysNeedsPos(x: Positioned) = x match {
       case _: WithLazyField[_]            // initialPos is inaccurate for trees with lazy field
          | _: Trees.PackageDef[_] => true // package defs might be split into several Tasty files 
+      case x: Trees.Tree[_] => x.isType   // types are unpickled as TypeTrees, so child positions are not available
       case _ => false
     }
 

--- a/src/dotty/tools/dotc/core/tasty/PositionUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/PositionUnpickler.scala
@@ -19,14 +19,17 @@ class PositionUnpickler(reader: TastyReader) {
     var curEnd = 0
     while (!isAtEnd) {
       val header = readInt()
-      val addrDelta = header >> 2
-      val hasStart = (header & 2) != 0
-      val hasEnd = (header & 1) != 0
+      val addrDelta = header >> 3
+      val hasStart = (header & 4) != 0
+      val hasEnd = (header & 2) != 0
+      val hasPoint = (header & 1) != 0
       curIndex += addrDelta
       assert(curIndex >= 0)
       if (hasStart) curStart += readInt()
       if (hasEnd) curEnd += readInt()
-      positions(Addr(curIndex)) = Position(curStart, curEnd)
+      positions(Addr(curIndex)) = 
+        if (hasPoint) Position(curStart, curEnd, curStart + readInt())
+        else Position(curStart, curEnd)
     }
     positions
   }

--- a/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -57,7 +57,8 @@ Standard-Section: "ASTs" TopLevelStat*
                   TYPEDEF        Length NameRef (Type | Template) Modifier*
                   IMPORT         Length qual_Term Selector*
   Selector      = IMPORTED              name_NameRef
-                  RENAMED        Length from_NameRef to_NameRef
+                  RENAMED               to_NameRef
+
                                  // Imports are for scala.meta, they are not used in the backend
 
   TypeParam     = TYPEPARAM      Length NameRef Type Modifier*
@@ -264,6 +265,7 @@ object TastyFormat {
   final val DOUBLEconst = 76
   final val STRINGconst = 77
   final val IMPORTED = 78
+  final val RENAMED = 79
 
   final val THIS = 96
   final val CLASSconst = 97
@@ -291,10 +293,9 @@ object TastyFormat {
   final val TYPEPARAM = 133
   final val PARAMS = 134
   final val PARAM = 136
-  final val RENAMED = 138
+
   final val APPLY = 139
   final val TYPEAPPLY = 140
-
 
   final val TYPED = 143
   final val NAMEDARG = 144

--- a/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -139,12 +139,11 @@ Standard-Section: "ASTs" TopLevelStat*
                   BIND           Length boundName_NameRef bounds_Type
                                         // for type-variables defined in a type pattern
                   BYNAMEtype            underlying_Type
-                  LAMBDAtype     Length result_Type NamesTypes      // variance encoded in front of name: +/-/=
-                  POLYtype       Length result_Type NamesTypes      // needed for refinements
+                  POLYtype       Length result_Type NamesTypes      // variance encoded in front of name: +/-/=
                   METHODtype     Length result_Type NamesTypes      // needed for refinements
                   PARAMtype      Length binder_ASTref paramNum_Nat  // needed for refinements
                   SHARED                type_ASTRef
-  NamesTypes    = ParamType*
+  NamesTypes    = NameType*
   NameType      = paramName_NameRef typeOrBounds_ASTRef
 
   Modifier      = PRIVATE
@@ -325,9 +324,8 @@ object TastyFormat {
   final val ORtype = 172
   final val METHODtype = 174
   final val POLYtype = 175
-  final val LAMBDAtype = 176
-  final val PARAMtype = 177
-  final val ANNOTATION = 178
+  final val PARAMtype = 176
+  final val ANNOTATION = 177
 
   final val firstSimpleTreeTag = UNITconst
   final val firstNatTreeTag = SHARED
@@ -489,7 +487,7 @@ object TastyFormat {
     case PROTECTEDqualified => "PROTECTEDqualified"
   }
 
-  /** @return If non-negative, the number of leading references of a length/trees entry.
+  /** @return If non-negative, the number of leading references (represented as nats) of a length/trees entry.
    *          If negative, minus the number of leading non-reference trees.
    */
   def numRefs(tag: Int) = tag match {

--- a/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -79,6 +79,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   NAMEDARG       Length paramName_NameRef arg_Term
                   ASSIGN         Length lhs_Term rhs_Term
                   BLOCK          Length expr_Term Stat*
+                  INLINED        Length call_Term expr_Term Stat*
                   LAMBDA         Length meth_Term target_Type
                   IF             Length cond_Term then_Term else_Term
                   MATCH          Length sel_Term CaseDef*
@@ -306,6 +307,7 @@ object TastyFormat {
   final val MATCH = 149
   final val RETURN = 150
   final val TRY = 151
+  final val INLINED = 152
   final val REPEATED = 153
   final val BIND = 154
   final val ALTERNATIVE = 155
@@ -456,6 +458,7 @@ object TastyFormat {
     case LAMBDA => "LAMBDA"
     case MATCH => "MATCH"
     case RETURN => "RETURN"
+    case INLINED => "INLINED"
     case TRY => "TRY"
     case REPEATED => "REPEATED"
     case BIND => "BIND"

--- a/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
@@ -57,9 +57,11 @@ class TastyPickler {
   /**
    * Addresses in TASTY file of trees, stored by pickling.
    * Note that trees are checked for reference equality,
-   * so one can reliably use this function only directly after `pickler`
+   * so one can reliably use this function only directly after `pickler`.
+   * Note that a tree can have several addresses, if it is shared,
+   * i.e. accessible from different paths. Any such sharing is undone by pickling.
    */
-  var addrOfTree: tpd.Tree => Option[Addr] = (_ => None)
+  var addrsOfTree: tpd.Tree => List[Addr] = (_ => Nil)
 
   /**
    * Addresses in TASTY file of symbols, stored by pickling.

--- a/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
@@ -6,7 +6,7 @@ package tasty
 import util.Util.{bestFit, dble}
 import TastyBuffer.{Addr, AddrWidth}
 import config.Printers.pickling
-import ast.tpd.Tree
+import ast.untpd.Tree
 
 class TreeBuffer extends TastyBuffer(50000) {
 
@@ -18,6 +18,8 @@ class TreeBuffer extends TastyBuffer(50000) {
   private var numOffsets = 0
 
   private[tasty] val pickledTrees = new java.util.IdentityHashMap[Tree, Any] // Value type is really Addr, but that's not compatible with null
+
+  def registerTreeAddr(tree: Tree) = pickledTrees.put(tree, currentAddr)
 
   def addrOfTree(tree: Tree): Option[Addr] = pickledTrees.get(tree) match {
     case null => None

--- a/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
@@ -17,11 +17,11 @@ class TreeBuffer extends TastyBuffer(50000) {
   private var delta: Array[Int] = _
   private var numOffsets = 0
 
-  private[tasty] val pickledTrees = new java.util.IdentityHashMap[Tree, Any] // Value type is really Addr, but that's not compatible with null
+  private val treeAddr = new java.util.IdentityHashMap[Tree, Any] // Value type is really Addr, but that's not compatible with null
 
-  def registerTreeAddr(tree: Tree) = pickledTrees.put(tree, currentAddr)
+  def registerTreeAddr(tree: Tree) = treeAddr.put(tree, currentAddr)
 
-  def addrOfTree(tree: Tree): Option[Addr] = pickledTrees.get(tree) match {
+  def addrOfTree(tree: Tree): Option[Addr] = treeAddr.get(tree) match {
     case null => None
     case n => Some(n.asInstanceOf[Addr])
   }
@@ -149,11 +149,11 @@ class TreeBuffer extends TastyBuffer(50000) {
     wasted
   }
 
-  def adjustPickledTrees(): Unit = {
-    val it = pickledTrees.keySet.iterator
+  def adjustTreeAddrs(): Unit = {
+    val it = treeAddr.keySet.iterator
     while (it.hasNext) {
       val tree = it.next
-      pickledTrees.put(tree, adjusted(pickledTrees.get(tree).asInstanceOf[Addr]))
+      treeAddr.put(tree, adjusted(treeAddr.get(tree).asInstanceOf[Addr]))
     }
   }
 
@@ -174,7 +174,7 @@ class TreeBuffer extends TastyBuffer(50000) {
       pickling.println(s"adjusting deltas, saved = $saved")
     } while (saved > 0 && length / saved < 100)
     adjustOffsets()
-    adjustPickledTrees()
+    adjustTreeAddrs()
     val wasted = compress()
     pickling.println(s"original length: $origLength, compressed to: $length, wasted: $wasted") // DEBUG, for now.
   }

--- a/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -319,8 +319,8 @@ class TreePickler(pickler: TastyPickler) {
       pickleName(sym)
       pickleParams
       tpt match {
-        case tpt: TypeTree => pickleTpt(tpt)
         case templ: Template => pickleTree(tpt)
+        case _ if tpt.isType => pickleTpt(tpt)
       }
       pickleTreeUnlessEmpty(rhs)
       pickleModifiers(sym)
@@ -349,6 +349,8 @@ class TreePickler(pickler: TastyPickler) {
   def pickleTree(tree: Tree)(implicit ctx: Context): Unit = try {
     registerTreeAddr(tree)
     tree match {
+      case tree if tree.isType =>
+        pickleTpt(tree)
       case Ident(name) =>
         tree.tpe match {
           case tp: TermRef => pickleType(tp)
@@ -442,8 +444,6 @@ class TreePickler(pickler: TastyPickler) {
         writeByte(INLINED)
         bindings.foreach(preRegister)
         withLength { pickleTree(call); pickleTree(expansion); bindings.foreach(pickleTree) }
-      case TypeTree() =>
-        pickleTpt(tree)
       case Bind(name, body) =>
         registerDef(tree.symbol)
         writeByte(BIND)

--- a/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -262,7 +262,7 @@ class TreePickler(pickler: TastyPickler) {
       writeByte(BYNAMEtype)
       pickleType(tpe.underlying)
     case tpe: PolyType =>
-      writeByte(LAMBDAtype)
+      writeByte(POLYtype)
       val paramNames = tpe.typeParams.map(tparam =>
         varianceToPrefix(tparam.paramVariance) +: tparam.paramName)
       pickleMethodic(tpe.resultType, paramNames, tpe.paramBounds)

--- a/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -444,7 +444,7 @@ class TreePickler(pickler: TastyPickler) {
         // position information in the linker. We should come back to this
         // point once we know more what we would do with such information.
         pickleTree(Inliner.dropInlined(tree))
-      case TypeTree(original) =>
+      case TypeTree() =>
         pickleTpt(tree)
       case Bind(name, body) =>
         registerDef(tree.symbol)

--- a/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -49,6 +49,10 @@ class TreePickler(pickler: TastyPickler) {
       case None =>
     }
   }
+  
+  def rhs(tdef: TypeDef)(implicit ctx: Context) = 
+    if (tdef.symbol.isClass) tdef.rhs
+    else TypeTree(tdef.symbol.info).withPos(tdef.rhs.pos)
 
   private def pickleName(name: Name): Unit = writeNat(nameIndex(name).index)
   private def pickleName(name: TastyName): Unit = writeNat(nameIndex(name).index)
@@ -332,7 +336,7 @@ class TreePickler(pickler: TastyPickler) {
     tree match {
       case tree: ValDef => pickleDef(PARAM, tree.symbol, tree.tpt)
       case tree: DefDef => pickleDef(PARAM, tree.symbol, tree.tpt, tree.rhs)
-      case tree: TypeDef => pickleDef(TYPEPARAM, tree.symbol, tree.rhs)
+      case tree: TypeDef => pickleDef(TYPEPARAM, tree.symbol, rhs(tree))
     }
   }
 
@@ -474,7 +478,7 @@ class TreePickler(pickler: TastyPickler) {
         }
         pickleDef(DEFDEF, tree.symbol, tree.tpt, tree.rhs, pickleAllParams)
       case tree: TypeDef =>
-        pickleDef(TYPEDEF, tree.symbol, tree.rhs)
+        pickleDef(TYPEDEF, tree.symbol, rhs(tree))
       case tree: Template =>
         registerDef(tree.symbol)
         writeByte(TEMPLATE)

--- a/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -496,7 +496,7 @@ class TreePickler(pickler: TastyPickler) {
           if ((selfInfo ne NoType) || !tree.self.isEmpty) {
             writeByte(SELFDEF)
             pickleName(tree.self.name)
-            registerTreeAddr(tree.self)
+            if (!tree.self.isEmpty) registerTreeAddr(tree.self.tpt)
             pickleType {
               cinfo.selfInfo match {
                 case sym: Symbol => sym.info

--- a/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -438,15 +438,10 @@ class TreePickler(pickler: TastyPickler) {
       case SeqLiteral(elems, elemtpt) =>
         writeByte(REPEATED)
         withLength { pickleTree(elemtpt); elems.foreach(pickleTree) }
-      case tree: Inlined =>
-        // Why drop Inlined info when pickling?
-        // Since we never inline inside an inlined method, we know that
-        // any code that continas an Inlined tree is not inlined itself.
-        // So position information for inline expansion is no longer needed.
-        // The only reason to keep the inline info around would be to have fine-grained
-        // position information in the linker. We should come back to this
-        // point once we know more what we would do with such information.
-        pickleTree(Inliner.dropInlined(tree))
+      case Inlined(call, bindings, expansion) =>
+        writeByte(INLINED)
+        bindings.foreach(preRegister)
+        withLength { pickleTree(call); pickleTree(expansion); bindings.foreach(pickleTree) }
       case TypeTree() =>
         pickleTpt(tree)
       case Bind(name, body) =>

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -266,18 +266,11 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table, posUnpickle
               val sym = ctx.newSymbol(ctx.owner, readName().toTypeName, BindDefinedType, readType())
               registerSym(start, sym)
               TypeRef.withFixedSym(NoPrefix, sym.name, sym)
-            case LAMBDAtype =>
+            case POLYtype =>
               val (rawNames, paramReader) = readNamesSkipParams
               val (variances, paramNames) = rawNames
                 .map(name => (prefixToVariance(name.head), name.tail.toTypeName)).unzip
               val result = PolyType(paramNames, variances)(
-                pt => registeringType(pt, paramReader.readParamTypes[TypeBounds](end)),
-                pt => readType())
-              goto(end)
-              result
-            case POLYtype =>
-              val (names, paramReader) = readNamesSkipParams
-              val result = PolyType(names.map(_.toTypeName))(
                 pt => registeringType(pt, paramReader.readParamTypes[TypeBounds](end)),
                 pt => readType())
               goto(end)

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -626,7 +626,7 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table, posUnpickle
      *  or else read definition.
      */
     def readIndexedDef()(implicit ctx: Context): Tree = treeAtAddr.remove(currentAddr) match {
-      case Some(tree) => skipTree(); setPos(currentAddr, tree)
+      case Some(tree) => skipTree(); tree
       case none => readNewDef()
     }
 
@@ -1022,7 +1022,7 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table, posUnpickle
       if (ctx.mode.is(Mode.ReadPositions)) {
         posUnpicklerOpt match {
           case Some(posUnpickler) =>
-            //println(i"setPos $tree / ${tree.getClass} to ${posUnpickler.posAt(addr)}")
+            //println(i"setPos $tree / ${tree.getClass} at $addr to ${posUnpickler.posAt(addr)}")
             val pos = posUnpickler.posAt(addr)
             if (pos.exists) tree.setPosUnchecked(pos)
             tree

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -355,8 +355,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         else "/* inlined from " ~ toText(call) ~ "*/ " ~ blockText(bindings :+ body)
       case tpt: untpd.DerivedTypeTree =>
         "<derived typetree watching " ~ summarized(toText(tpt.watched)) ~ ">"
-      case TypeTree(orig) =>
-        if (tree.hasType) toText(tree.typeOpt) else toText(orig)
+      case TypeTree() =>
+        toText(tree.typeOpt)
       case SingletonTypeTree(ref) =>
         toTextLocal(ref) ~ ".type"
       case AndTypeTree(l, r) =>

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -351,8 +351,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case SeqLiteral(elems, elemtpt) =>
         "[" ~ toTextGlobal(elems, ",") ~ " : " ~ toText(elemtpt) ~ "]"
       case tree @ Inlined(call, bindings, body) =>
-        if (homogenizedView) toTextCore(Inliner.dropInlined(tree.asInstanceOf[tpd.Inlined]))
-        else "/* inlined from " ~ toText(call) ~ "*/ " ~ blockText(bindings :+ body)
+        (("/* inlined from " ~ toText(call) ~ "*/ ") provided !homogenizedView) ~ 
+        blockText(bindings :+ body)
       case tpt: untpd.DerivedTypeTree =>
         "<derived typetree watching " ~ summarized(toText(tpt.watched)) ~ ">"
       case TypeTree() =>
@@ -526,7 +526,9 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       else if (!tree.isDef) txt = ("<" ~ txt ~ ":" ~ toText(tp) ~ ">").close
     }
     if (ctx.settings.Yprintpos.value && !tree.isInstanceOf[WithoutTypeOrPos[_]]) {
-      val pos = if (homogenizedView) tree.pos.toSynthetic else tree.pos
+      val pos = 
+        if (homogenizedView && !tree.isInstanceOf[MemberDef]) tree.pos.toSynthetic 
+        else tree.pos
       txt = (txt ~ "@" ~ pos.toString /*~ tree.getClass.toString*/).close
     }
     tree match {

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -527,7 +527,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     }
     if (ctx.settings.Yprintpos.value && !tree.isInstanceOf[WithoutTypeOrPos[_]]) {
       val pos = if (homogenizedView) tree.pos.toSynthetic else tree.pos
-      txt = txt ~ "@" ~ pos.toString
+      txt = (txt ~ "@" ~ pos.toString).close
     }
     tree match {
       case Block(_, _) | Template(_, _, _, _) => txt

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -426,7 +426,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           case _ => toTextGlobal(sel)
         }
         val selectorsText: Text = selectors match {
-          case Ident(name) :: Nil => toText(name)
+          case id :: Nil => toText(id)
           case _ => "{" ~ Text(selectors map selectorText, ", ") ~ "}"
         }
         "import " ~ toTextLocal(expr) ~ "." ~ selectorsText
@@ -525,8 +525,10 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       if (tree.isType) txt = toText(tp)
       else if (!tree.isDef) txt = ("<" ~ txt ~ ":" ~ toText(tp) ~ ">").close
     }
-    if (ctx.settings.Yprintpos.value && !tree.isInstanceOf[WithoutTypeOrPos[_]])
-      txt = txt ~ "@" ~ tree.pos.toString
+    if (ctx.settings.Yprintpos.value && !tree.isInstanceOf[WithoutTypeOrPos[_]]) {
+      val pos = if (homogenizedView) tree.pos.toSynthetic else tree.pos
+      txt = txt ~ "@" ~ pos.toString
+    }
     tree match {
       case Block(_, _) | Template(_, _, _, _) => txt
       case _ => txt.close

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -525,11 +525,14 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       if (tree.isType) txt = toText(tp)
       else if (!tree.isDef) txt = ("<" ~ txt ~ ":" ~ toText(tp) ~ ">").close
     }
+    else if (homogenizedView && tree.isType) 
+      txt = toText(tree.typeOpt)
     if (ctx.settings.Yprintpos.value && !tree.isInstanceOf[WithoutTypeOrPos[_]]) {
       val pos = 
         if (homogenizedView && !tree.isInstanceOf[MemberDef]) tree.pos.toSynthetic 
         else tree.pos
-      txt = (txt ~ "@" ~ pos.toString /*~ tree.getClass.toString*/).close
+      val clsStr = "" // DEBUG: if (tree.isType) tree.getClass.toString else ""
+      txt = (txt ~ "@" ~ pos.toString ~ clsStr).close
     }
     tree match {
       case Block(_, _) | Template(_, _, _, _) => txt

--- a/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -527,7 +527,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     }
     if (ctx.settings.Yprintpos.value && !tree.isInstanceOf[WithoutTypeOrPos[_]]) {
       val pos = if (homogenizedView) tree.pos.toSynthetic else tree.pos
-      txt = (txt ~ "@" ~ pos.toString).close
+      txt = (txt ~ "@" ~ pos.toString /*~ tree.getClass.toString*/).close
     }
     tree match {
       case Block(_, _) | Template(_, _, _, _) => txt

--- a/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -146,7 +146,7 @@ class FirstTransform extends MiniPhaseTransform with InfoTransformer with Annota
   override def transformTemplate(impl: Template)(implicit ctx: Context, info: TransformerInfo): Tree = {
     cpy.Template(impl)(self = EmptyValDef)
   }
-
+  
   override def transformDefDef(ddef: DefDef)(implicit ctx: Context, info: TransformerInfo) = {
     if (ddef.symbol.hasAnnotation(defn.NativeAnnot)) {
       ddef.symbol.resetFlag(Deferred)
@@ -162,8 +162,14 @@ class FirstTransform extends MiniPhaseTransform with InfoTransformer with Annota
   override def transformOther(tree: Tree)(implicit ctx: Context, info: TransformerInfo) = tree match {
     case tree: Import => EmptyTree
     case tree: NamedArg => transform(tree.arg)
-    case tree => tree
+    case tree => if (tree.isType) TypeTree(tree.tpe).withPos(tree.pos) else tree
   }
+
+  override def transformIdent(tree: Ident)(implicit ctx: Context, info: TransformerInfo) =
+    if (tree.isType) TypeTree(tree.tpe).withPos(tree.pos) else tree
+
+  override def transformSelect(tree: Select)(implicit ctx: Context, info: TransformerInfo) =
+    if (tree.isType) TypeTree(tree.tpe).withPos(tree.pos) else tree
 
   // invariants: all modules have companion objects
   // all types are TypeTrees

--- a/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/src/dotty/tools/dotc/transform/Pickler.scala
@@ -66,7 +66,10 @@ class Pickler extends Phase {
   override def runOn(units: List[CompilationUnit])(implicit ctx: Context): List[CompilationUnit] = {
     val result = super.runOn(units)
     if (ctx.settings.YtestPickler.value)
-      testUnpickler(units)(ctx.fresh.setPeriod(Period(ctx.runId + 1, FirstPhaseId)))
+      testUnpickler(units)(
+          ctx.fresh
+            .setPeriod(Period(ctx.runId + 1, FirstPhaseId))
+            .addMode(Mode.ReadPositions))
     result
   }
 
@@ -81,7 +84,7 @@ class Pickler extends Phase {
       }
     pickling.println("************* entered toplevel ***********")
     for ((cls, unpickler) <- unpicklers) {
-      val unpickled = unpickler.body(ctx.addMode(Mode.ReadPositions))
+      val unpickled = unpickler.body
       testSame(i"$unpickled%\n%", beforePickling(cls), cls)
     }
   }

--- a/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/src/dotty/tools/dotc/transform/Pickler.scala
@@ -46,10 +46,10 @@ class Pickler extends Phase {
       val treePkl = pickler.treePkl
       treePkl.pickle(tree :: Nil)
       treePkl.compactify()
-      pickler.addrOfTree = treePkl.buf.addrOfTree
+      pickler.addrsOfTree = treePkl.buf.addrsOfTree
       pickler.addrOfSym = treePkl.addrOfSym
       if (tree.pos.exists)
-        new PositionPickler(pickler, treePkl.buf.addrOfTree).picklePositions(tree :: Nil)
+        new PositionPickler(pickler, treePkl.buf.addrsOfTree).picklePositions(tree :: Nil)
 
       def rawBytes = // not needed right now, but useful to print raw format.
         pickler.assembleParts().iterator.grouped(10).toList.zipWithIndex.map {

--- a/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -41,6 +41,9 @@ import Symbols._, TypeUtils._
  *
  *  (10) Adds Child annotations to all sealed classes
  *
+ *  (11) Minimizes `call` fields of `Inline` nodes to just point to the toplevel
+ *       class from which code was inlined.
+ *
  *  The reason for making this a macro transform is that some functions (in particular
  *  super and protected accessors and instantiation checks) are naturally top-down and
  *  don't lend themselves to the bottom-up approach of a mini phase. The other two functions

--- a/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -77,42 +77,11 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer  { thisTran
   }
 
   /** Check bounds of AppliedTypeTrees.
-   *  Replace constant expressions with Literal nodes.
-   *  Note: Demanding idempotency instead of purity in literalize is strictly speaking too loose.
-   *  Example
-   *
-   *    object O { final val x = 42; println("43") }
-   *    O.x
-   *
-   *  Strictly speaking we can't replace `O.x` with `42`.  But this would make
-   *  most expressions non-constant. Maybe we can change the spec to accept this
-   *  kind of eliding behavior. Or else enforce true purity in the compiler.
-   *  The choice will be affected by what we will do with `inline` and with
-   *  Singleton type bounds (see SIP 23). Presumably
-   *
-   *     object O1 { val x: Singleton = 42; println("43") }
-   *     object O2 { inline val x = 42; println("43") }
-   *
-   *  should behave differently.
-   *
-   *     O1.x  should have the same effect as   { println("43"); 42 }
-   *
-   *  whereas
-   *
-   *     O2.x = 42
-   *
-   *  Revisit this issue once we have implemented `inline`. Then we can demand
-   *  purity of the prefix unless the selection goes to an inline val.
    */
-  private def normalizeTree(tree: Tree)(implicit ctx: Context): Tree =
-    if (tree.isType) {
-      Checking.typeCheck(tree)
-      tree
-    } 
-    else tree.tpe.widenTermRefExpr match {
-      case ConstantType(value) if isIdempotentExpr(tree) => Literal(value)
-      case _ => tree
-    }
+  private def normalizeTree(tree: Tree)(implicit ctx: Context): Tree = {
+    if (tree.isType) Checking.typeCheck(tree)
+    tree
+  }
 
   /** If the type of `tree` is a TermRefWithSignature with an underdefined
    *  signature, narrow the type by re-computing the signature (which should
@@ -158,7 +127,11 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer  { thisTran
         case pkg: PackageClassDenotation if !tree.symbol.maybeOwner.is(Package) =>
           transformSelect(cpy.Select(tree)(qual select pkg.packageObj.symbol, tree.name), targs)
         case _ =>
-          superAcc.transformSelect(super.transform(tree), targs)
+          val tree1 = super.transform(tree)
+          constToLiteral(tree1) match {
+            case _: Literal => tree1
+            case _ => superAcc.transformSelect(tree1, targs)
+          }
       }
     }
 

--- a/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/src/dotty/tools/dotc/transform/TailRec.scala
@@ -350,7 +350,7 @@ class TailRec extends MiniPhaseTransform with DenotTransformer with FullParamete
           t // todo: could improve to handle DefDef's with a label flag calls to which are in tail position
 
         case ValDef(_, _, _) | EmptyTree | Super(_, _) | This(_) |
-             Literal(_) | TypeTree(_) | TypeDef(_, _) =>
+             Literal(_) | TypeTree() | TypeDef(_, _) =>
           tree
 
         case Return(expr, from) =>

--- a/src/dotty/tools/dotc/transform/TreeTransform.scala
+++ b/src/dotty/tools/dotc/transform/TreeTransform.scala
@@ -1122,10 +1122,7 @@ object TreeTransforms {
         case tree: TypeTree =>
           implicit val mutatedInfo: TransformerInfo = mutateTransformers(info, prepForTypeTree, info.nx.nxPrepTypeTree, tree, cur)
           if (mutatedInfo eq null) tree
-          else {
-            val original = transform(tree.original, mutatedInfo, cur)
-            goTypeTree(cpy.TypeTree(tree)(original), mutatedInfo.nx.nxTransTypeTree(cur))
-          }
+          else goTypeTree(tree, mutatedInfo.nx.nxTransTypeTree(cur))
         case tree: Alternative =>
           implicit val mutatedInfo: TransformerInfo = mutateTransformers(info, prepForAlternative, info.nx.nxPrepAlternative, tree, cur)
           if (mutatedInfo eq null) tree

--- a/src/dotty/tools/dotc/typer/Checking.scala
+++ b/src/dotty/tools/dotc/typer/Checking.scala
@@ -79,7 +79,12 @@ object Checking {
    */
   val typeChecker = new TreeTraverser {
     def traverse(tree: Tree)(implicit ctx: Context) = {
-      tree match {
+      typeCheck(tree)
+      traverseChildren(tree)
+    }
+  }
+  
+  def typeCheck(tree: Tree)(implicit ctx: Context) = tree match {
         case AppliedTypeTree(tycon, args) =>
           // If `args` is a list of named arguments, return corresponding type parameters,
           // otherwise return type parameters unchanged
@@ -103,10 +108,7 @@ object Checking {
           checkRealizable(ref.tpe, ref.pos.focus)
         case _ =>
       }
-      traverseChildren(tree)
-    }
-  }
-
+  
   /** Check that `tp` refers to a nonAbstract class
    *  and that the instance conforms to the self type of the created class.
    */

--- a/src/dotty/tools/dotc/typer/Checking.scala
+++ b/src/dotty/tools/dotc/typer/Checking.scala
@@ -55,59 +55,44 @@ object Checking {
   def checkBounds(args: List[tpd.Tree], poly: PolyType)(implicit ctx: Context): Unit =
     checkBounds(args, poly.paramBounds, _.substParams(poly, _))
 
-  /** If type is a higher-kinded application with wildcard arguments,
-   *  check that it or one of its supertypes can be reduced to a normal application.
-   *  Unreducible applications correspond to general existentials, and we
-   *  cannot handle those.
+  /** Check applied type trees for well-formedness. This means 
+   *   - all arguments are within their corresponding bounds 
+   *   - if type is a higher-kinded application with wildcard arguments,
+   *     check that it or one of its supertypes can be reduced to a normal application.
+   *     Unreducible applications correspond to general existentials, and we
+   *     cannot handle those.
    */
-  def checkWildcardHKApply(tp: Type, pos: Position)(implicit ctx: Context): Unit = tp match {
-    case tp @ HKApply(tycon, args) if args.exists(_.isInstanceOf[TypeBounds]) =>
-      tycon match {
-        case tycon: PolyType =>
-          ctx.errorOrMigrationWarning(
-            ex"unreducible application of higher-kinded type $tycon to wildcard arguments",
-            pos)
-        case _ =>
-          checkWildcardHKApply(tp.superType, pos)
-      }
-    case _ =>
-  }
+  def checkAppliedType(tree: AppliedTypeTree)(implicit ctx: Context) = {
+    val AppliedTypeTree(tycon, args) = tree
+    // If `args` is a list of named arguments, return corresponding type parameters,
+    // otherwise return type parameters unchanged
+    val tparams = tycon.tpe.typeParams
+    def argNamed(tparam: TypeParamInfo) = args.find {
+      case NamedArg(name, _) => name == tparam.paramName
+      case _ => false
+    }.getOrElse(TypeTree(tparam.paramRef))
+    val orderedArgs = if (hasNamedArg(args)) tparams.map(argNamed) else args
+    val bounds = tparams.map(_.paramBoundsAsSeenFrom(tycon.tpe))
+    def instantiate(bound: Type, args: List[Type]) =
+      bound.LambdaAbstract(tparams).appliedTo(args)
+    checkBounds(orderedArgs, bounds, instantiate)
 
-  /** Traverse type tree, performing the following checks:
-   *  1. All arguments of applied type trees must conform to their bounds.
-   *  2. Prefixes of type selections and singleton types must be realizable.
-   */
-  val typeChecker = new TreeTraverser {
-    def traverse(tree: Tree)(implicit ctx: Context) = {
-      typeCheck(tree)
-      traverseChildren(tree)
-    }
+    def checkWildcardHKApply(tp: Type, pos: Position): Unit = tp match {
+      case tp @ HKApply(tycon, args) if args.exists(_.isInstanceOf[TypeBounds]) =>
+        tycon match {
+          case tycon: PolyType =>
+            ctx.errorOrMigrationWarning(
+              ex"unreducible application of higher-kinded type $tycon to wildcard arguments",
+              pos)
+          case _ =>
+            checkWildcardHKApply(tp.superType, pos)
+        }
+      case _ =>
+    }    
+    def checkValidIfHKApply(implicit ctx: Context): Unit =
+      checkWildcardHKApply(tycon.tpe.appliedTo(args.map(_.tpe)), tree.pos)
+    checkValidIfHKApply(ctx.addMode(Mode.AllowLambdaWildcardApply))
   }
-  
-  def typeCheck(tree: Tree)(implicit ctx: Context) = tree match {
-        case AppliedTypeTree(tycon, args) =>
-          // If `args` is a list of named arguments, return corresponding type parameters,
-          // otherwise return type parameters unchanged
-          val tparams = tycon.tpe.typeParams
-          def argNamed(tparam: TypeParamInfo) = args.find {
-            case NamedArg(name, _) => name == tparam.paramName
-            case _ => false
-          }.getOrElse(TypeTree(tparam.paramRef))
-          val orderedArgs = if (hasNamedArg(args)) tparams.map(argNamed) else args
-          val bounds = tparams.map(_.paramBoundsAsSeenFrom(tycon.tpe))
-          def instantiate(bound: Type, args: List[Type]) =
-            bound.LambdaAbstract(tparams).appliedTo(args)
-          checkBounds(orderedArgs, bounds, instantiate)
-
-          def checkValidIfHKApply(implicit ctx: Context): Unit =
-            checkWildcardHKApply(tycon.tpe.appliedTo(args.map(_.tpe)), tree.pos)
-          checkValidIfHKApply(ctx.addMode(Mode.AllowLambdaWildcardApply))
-        case Select(qual, name) if name.isTypeName =>
-          checkRealizable(qual.tpe, qual.pos.focus)
-        case SingletonTypeTree(ref) =>
-          checkRealizable(ref.tpe, ref.pos.focus)
-        case _ =>
-      }
   
   /** Check that `tp` refers to a nonAbstract class
    *  and that the instance conforms to the self type of the created class.

--- a/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -138,7 +138,7 @@ object EtaExpansion {
       if (mt.paramTypes.length == xarity) mt.paramTypes map (_ => TypeTree())
       else mt.paramTypes map TypeTree
     val params = (mt.paramNames, paramTypes).zipped.map((name, tpe) =>
-      ValDef(name, TypeTree(tpe), EmptyTree).withFlags(Synthetic | Param).withPos(tree.pos))
+      ValDef(name, tpe, EmptyTree).withFlags(Synthetic | Param).withPos(tree.pos))
     var ids: List[Tree] = mt.paramNames map (name => Ident(name).withPos(tree.pos))
     if (mt.paramTypes.nonEmpty && mt.paramTypes.last.isRepeatedParam)
       ids = ids.init :+ repeated(ids.last)

--- a/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/src/dotty/tools/dotc/typer/Inliner.scala
@@ -244,8 +244,9 @@ object Inliner {
   /** Replace `Inlined` node by a block that contains its bindings and expansion */
   def dropInlined(inlined: tpd.Inlined)(implicit ctx: Context): Tree = {
     val reposition = new TreeMap {
-      override def transform(tree: Tree)(implicit ctx: Context): Tree =
-        tree.withPos(inlined.call.pos)
+      override def transform(tree: Tree)(implicit ctx: Context): Tree = {
+        super.transform(tree).withPos(inlined.call.pos)
+      }
     }
     tpd.seq(inlined.bindings, reposition.transform(inlined.expansion))
   }

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -927,7 +927,7 @@ class Namer { typer: Typer =>
     val tptProto = mdef.tpt match {
       case _: untpd.DerivedTypeTree =>
         WildcardType
-      case TypeTree(untpd.EmptyTree) =>
+      case TypeTree() =>
         inferredType
       case TypedSplice(tpt: TypeTree) if !isFullyDefined(tpt.tpe, ForceDegree.none) =>
         val rhsType = typedAheadExpr(mdef.rhs, tpt.tpe).tpe

--- a/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -851,15 +851,6 @@ class RefChecks extends MiniPhase { thisTransformer =>
         tree
     }
 
-    override def transformTypeTree(tree: TypeTree)(implicit ctx: Context, info: TransformerInfo) = {
-      if (!tree.original.isEmpty)
-        tree.tpe.foreachPart {
-          case tp: NamedType => checkUndesiredProperties(tp.symbol, tree.pos)
-          case _ =>
-        }
-      tree
-    }
-
     override def transformIdent(tree: Ident)(implicit ctx: Context, info: TransformerInfo) = {
       checkUndesiredProperties(tree.symbol, tree.pos)
       currentLevel.enterReference(tree.symbol, tree.pos)

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -961,28 +961,23 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   def typedTypeTree(tree: untpd.TypeTree, pt: Type)(implicit ctx: Context): TypeTree = track("typedTypeTree") {
-    if (tree.original.isEmpty)
-      tree match {
-        case tree: untpd.DerivedTypeTree =>
-          tree.ensureCompletions
-          try
-            TypeTree(tree.derivedType(tree.attachment(untpd.OriginalSymbol))) withPos tree.pos
-            // btw, no need to remove the attachment. The typed
-            // tree is different from the untyped one, so the
-            // untyped tree is no longer accessed after all
-            // accesses with typedTypeTree are done.
-          catch {
-            case ex: NoSuchElementException =>
-              println(s"missing OriginalSymbol for ${ctx.owner.ownersIterator.toList}")
-              throw ex
-          }
-        case _ =>
-          assert(isFullyDefined(pt, ForceDegree.none))
-          tree.withType(pt)
-      }
-    else {
-      val original1 = typed(tree.original)
-      cpy.TypeTree(tree)(original1).withType(original1.tpe)
+    tree match {
+      case tree: untpd.DerivedTypeTree =>
+        tree.ensureCompletions
+        try
+          TypeTree(tree.derivedType(tree.attachment(untpd.OriginalSymbol))) withPos tree.pos
+        // btw, no need to remove the attachment. The typed
+        // tree is different from the untyped one, so the
+        // untyped tree is no longer accessed after all
+        // accesses with typedTypeTree are done.
+        catch {
+          case ex: NoSuchElementException =>
+            println(s"missing OriginalSymbol for ${ctx.owner.ownersIterator.toList}")
+            throw ex
+        }
+      case _ =>
+        assert(isFullyDefined(pt, ForceDegree.none))
+        tree.withType(pt)
     }
   }
 

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -28,7 +28,7 @@ class tests extends CompilerTest {
       else List("-Ycheck:tailrec,resolveSuper,mixin,restoreScopes,labelDef")
     }
 
-  val testPickling = List("-Xprint-types", "-Ytest-pickler", "-Ystop-after:pickler")
+  val testPickling = List("-Xprint-types", "-Ytest-pickler", "-Ystop-after:pickler", "-Yprintpos")
 
   val twice = List("#runs", "2")
   val staleSymbolError: List[String] = List()
@@ -65,7 +65,7 @@ class tests extends CompilerTest {
     Directory(defaultOutputDir + "java").deleteRecursively()
   }
 
-  @Test def pickle_pickleOK = compileDir(testsDir, "pickling", "-Yprintpos" :: testPickling)
+  @Test def pickle_pickleOK = compileDir(testsDir, "pickling", testPickling)
 // This directory doesn't exist anymore
 // @Test def pickle_pickling = compileDir(coreDir, "pickling", testPickling)
   @Test def pickle_ast = compileDir(dotcDir, "ast", testPickling)

--- a/test/dotc/tests.scala
+++ b/test/dotc/tests.scala
@@ -65,7 +65,7 @@ class tests extends CompilerTest {
     Directory(defaultOutputDir + "java").deleteRecursively()
   }
 
-  @Test def pickle_pickleOK = compileDir(testsDir, "pickling", testPickling)
+  @Test def pickle_pickleOK = compileDir(testsDir, "pickling", "-Yprintpos" :: testPickling)
 // This directory doesn't exist anymore
 // @Test def pickle_pickling = compileDir(coreDir, "pickling", testPickling)
   @Test def pickle_ast = compileDir(dotcDir, "ast", testPickling)


### PR DESCRIPTION
Make Tasty positions read back exactly the way they were serialized.

The aim is to turn -Yprintpos on and to get exact correspondence between before-pickling and after-pickling.
