### PR TITLE
Fix #1590: Eliminate wildcards when approximating a type

### DIFF
--- a/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -162,7 +162,8 @@ trait ConstraintHandling {
   /** Solve constraint set for given type parameter `param`.
    *  If `fromBelow` is true the parameter is approximated by its lower bound,
    *  otherwise it is approximated by its upper bound. However, any occurrences
-   *  of the parameter in a refinement somewhere in the bound are removed.
+   *  of the parameter in a refinement somewhere in the bound are removed. Also
+   *  wildcard types in bounds are approximated by their upper or lower bounds.
    *  (Such occurrences can arise for F-bounded types).
    *  The constraint is left unchanged.
    *  @return the instantiating type
@@ -174,6 +175,9 @@ trait ConstraintHandling {
       def apply(tp: Type) = mapOver {
         tp match {
           case tp: RefinedType if param occursIn tp.refinedInfo => tp.parent
+          case tp: WildcardType =>
+            val bounds = tp.optBounds.orElse(TypeBounds.empty).bounds
+            if (fromBelow == (variance >= 0)) bounds.lo else bounds.hi
           case _ => tp
         }
       }

--- a/tests/pos/i1590.scala
+++ b/tests/pos/i1590.scala
@@ -1,0 +1,1 @@
+case class W[T](seq: Option[Option[T]] = Option.empty)

--- a/tests/pos/i1590.scala
+++ b/tests/pos/i1590.scala
@@ -1,1 +1,10 @@
 case class W[T](seq: Option[Option[T]] = Option.empty)
+object W {
+  def apply[T] = new W[T]()
+}
+
+case class V[T](vv: W[W[T]] = W.apply)
+object Test {
+  W[Int]()
+  // V[Int]()    fails in scalac and dotty: both instantiate the vv-default to W[Nothing]
+}


### PR DESCRIPTION
Fixes #1590. Type variables should never be instantiated to types
containing wildcards. 

Review by @smarter