### PR TITLE
Fix #1576: Parameters of Java annotations should be public

### DIFF
--- a/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -131,7 +131,7 @@ object JavaParsers {
     def makeSyntheticParam(count: Int, tpt: Tree): ValDef =
       makeParam(nme.syntheticParamName(count), tpt)
     def makeParam(name: TermName, tpt: Tree): ValDef =
-      ValDef(name, tpt, EmptyTree).withMods(Modifiers(Flags.JavaDefined | Flags.PrivateLocalParamAccessor))
+      ValDef(name, tpt, EmptyTree).withMods(Modifiers(Flags.JavaDefined | Flags.ParamAccessor))
 
     def makeConstructor(formals: List[Tree], tparams: List[TypeDef], flags: FlagSet = Flags.JavaDefined) = {
       val vparams = mapWithIndex(formals)((p, i) => makeSyntheticParam(i + 1, p))

--- a/tests/pos/java-interop/1576/TagAnnotation.java
+++ b/tests/pos/java-interop/1576/TagAnnotation.java
@@ -1,0 +1,3 @@
+public @interface TagAnnotation {
+  public String value();
+}

--- a/tests/pos/java-interop/1576/Test.scala
+++ b/tests/pos/java-interop/1576/Test.scala
@@ -1,0 +1,5 @@
+object Test {
+  val v: TagAnnotation = null
+  println(v.value) // error: value value in class TagAnnotation cannot be accessed as a
+                   // member of TagAnnotation(Test.v) from module class Test$.
+}


### PR DESCRIPTION
Parameters of annotation classes parsed by the Java parser should
have public val parameters. Otherwise they cannot be accessed as fields.

Fixes #1576. Review by @OlivierBlanvillain 
