### PR TITLE
Fix #1567: Widen private constructor in value class

### DIFF
--- a/tests/pos/1567/PosZInt_1.scala
+++ b/tests/pos/1567/PosZInt_1.scala
@@ -1,0 +1,6 @@
+final class PosZInt private (val value: Int) extends AnyVal
+
+object PosZInt {
+  def from(value: Int): Option[PosZInt] =
+    if (value >= 0) Some(new PosZInt(value)) else None
+}

--- a/tests/pos/1567/Test_2.scala
+++ b/tests/pos/1567/Test_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  scala.util.Try(PosZInt.from(1).get)
+}


### PR DESCRIPTION
Private or protected constructors of value classes need to be widenened
to public in order to enable boxing anywhere.

Technically we should also do something about qualified private constructors, but since we
want to get rid of them anyway it's urgent.

Review by @OlivierBlanvillain 