### PR TITLE
Fix #1531: Ignore private members when looking for abstract ones

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -615,13 +615,13 @@ object Types {
     /** The set of abstract term members of this type. */
     final def abstractTermMembers(implicit ctx: Context): Seq[SingleDenotation] = track("abstractTermMembers") {
       memberDenots(abstractTermNameFilter,
-          (name, buf) => buf ++= member(name).altsWith(_ is Deferred))
+          (name, buf) => buf ++= nonPrivateMember(name).altsWith(_ is Deferred))
     }
 
     /** The set of abstract type members of this type. */
     final def abstractTypeMembers(implicit ctx: Context): Seq[SingleDenotation] = track("abstractTypeMembers") {
       memberDenots(abstractTypeNameFilter,
-          (name, buf) => buf += member(name).asSingleDenotation)
+          (name, buf) => buf += nonPrivateMember(name).asSingleDenotation)
     }
 
     /** The set of abstract type members of this type. */
@@ -3756,7 +3756,7 @@ object Types {
   object abstractTypeNameFilter extends NameFilter {
     def apply(pre: Type, name: Name)(implicit ctx: Context): Boolean =
       name.isTypeName && {
-        val mbr = pre.member(name)
+        val mbr = pre.nonPrivateMember(name)
         (mbr.symbol is Deferred) && mbr.info.isInstanceOf[RealTypeBounds]
       }
   }
@@ -3773,7 +3773,7 @@ object Types {
   /** A filter for names of deferred term definitions of a given type */
   object abstractTermNameFilter extends NameFilter {
     def apply(pre: Type, name: Name)(implicit ctx: Context): Boolean =
-      name.isTermName && (pre member name).hasAltWith(_.symbol is Deferred)
+      name.isTermName && pre.nonPrivateMember(name).hasAltWith(_.symbol is Deferred)
   }
 
   object typeNameFilter extends NameFilter {

--- a/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -487,7 +487,7 @@ object RefChecks {
             // abstract method, and a cursory examination of the difference reveals
             // something obvious to us, let's make it more obvious to them.
             val abstractParams = underlying.info.firstParamTypes
-            val matchingName = clazz.info.member(underlying.name).alternatives
+            val matchingName = clazz.info.nonPrivateMember(underlying.name).alternatives
             val matchingArity = matchingName filter { m =>
               !m.symbol.is(Deferred) &&
                 m.info.firstParamTypes.length == abstractParams.length

--- a/tests/neg/i1531.scala
+++ b/tests/neg/i1531.scala
@@ -1,0 +1,6 @@
+trait T {
+  def f: Int
+}
+
+class A(f: Int) extends T // error: class A needs to be abstract
+


### PR DESCRIPTION
Private members do not override abstract ones. So when looking for
abstract members we need to search with `nonPrivateMember`, not
`member`.

Fixes #1531. Review by @smarter.