### PR TITLE
Fix #1540: overloaded get and isDefined in option-less patmat

### DIFF
--- a/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -240,7 +240,7 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
           val isDefined = extractorMemberType(prev.tpe, nme.isDefined)
 
           if ((isDefined isRef defn.BooleanClass) && getTp.exists) {
-            // isDefined and get maybe overloaded
+            // isDefined and get may be overloaded
             val getDenot = prev.tpe.member(nme.get).suchThat(_.info.isParameterless)
             val isDefinedDenot = prev.tpe.member(nme.isDefined).suchThat(_.info.isParameterless)
 

--- a/tests/pos/i1540.scala
+++ b/tests/pos/i1540.scala
@@ -1,0 +1,14 @@
+class Casey1(val a: Int) {
+  def isDefined: Boolean = true
+  def isDefined(x: Int): Boolean = ???
+  def get: Int = a
+  def get(x: Int): String = ???
+}
+object Casey1 { def unapply(a: Casey1) = a }
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c @ Casey1(x) = new Casey1(0)
+    assert(x == c.get)
+  }
+}

--- a/tests/pos/i1540b.scala
+++ b/tests/pos/i1540b.scala
@@ -1,0 +1,14 @@
+class Casey1[T](val a: T) {
+  def isDefined: Boolean = true
+  def isDefined(x: T): Boolean = ???
+  def get: T = a
+  def get(x: T): String = ???
+}
+object Casey1 { def unapply[T](a: Casey1[T]) = a }
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c @ Casey1(x) = new Casey1(0)
+    assert(x == c.get)
+  }
+}


### PR DESCRIPTION
Fix #1540 .

When `isDefined` and `get` are overloaded, make sure the translated code use the correct version of the methods.