### PR TITLE
Fix #1570: Allow inline parameters as inline args

### DIFF
--- a/src/dotty/tools/dotc/core/Flags.scala
+++ b/src/dotty/tools/dotc/core/Flags.scala
@@ -544,6 +544,9 @@ object Flags {
   /** An inline method */
   final val InlineMethod = allOf(Inline, Method)
 
+  /** An inline parameter */
+  final val InlineParam = allOf(Inline, Param)
+
   /** A parameter or parameter accessor */
   final val ParamOrAccessor = Param | ParamAccessor
 

--- a/src/dotty/tools/dotc/typer/Checking.scala
+++ b/src/dotty/tools/dotc/typer/Checking.scala
@@ -482,10 +482,13 @@ trait Checking {
 
   /** Check that `tree` is a pure expression of constant type */
   def checkInlineConformant(tree: Tree, what: => String)(implicit ctx: Context): Unit =
-    tree.tpe.widenTermRefExpr match {
-      case tp: ConstantType if isPureExpr(tree) => // ok
-      case tp if defn.isFunctionType(tp) && isPureExpr(tree) => // ok
-      case _ => ctx.error(em"$what must be a constant expression or a function", tree.pos)
+    tree.tpe match {
+      case tp: TermRef if tp.symbol.is(InlineParam) => // ok
+      case tp => tp.widenTermRefExpr match {
+        case tp: ConstantType if isPureExpr(tree) => // ok
+        case tp if defn.isFunctionType(tp) && isPureExpr(tree) => // ok
+        case _ => ctx.error(em"$what must be a constant expression or a function", tree.pos)
+      }
     }
 
   /** Check that class does not define same symbol twice */

--- a/tests/pos/i1570.scala
+++ b/tests/pos/i1570.scala
@@ -1,0 +1,4 @@
+object Test {
+  inline def foo(inline n: Int) = bar(n)
+  inline def bar(inline n: Int) = n
+}


### PR DESCRIPTION
Inline parameters can always be passed to other
inline parameters.

Fixes #1570. Review by @nicolasstucki 