### PR TITLE
Missing error messages: Parsers.scala: 2064

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2061,7 +2061,7 @@ object Parsers {
     def templateBody(): (ValDef, List[Tree]) = {
       val r = inDefScopeBraces { templateStatSeq() }
       if (in.token == WITH) {
-        syntaxError("early definitions are not supported; use trait parameters instead")
+        syntaxError(EarlyDefinitionsNotSupported())
         in.nextToken()
         template(emptyConstructor)
       }

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -274,4 +274,48 @@ object messages {
 
     val explanation = ""
   }
+ 
+  case class EarlyDefinitionsNotSupported()(implicit ctx:Context) extends Message(9) {
+    val kind = "Syntax"
+   
+    val msg = "early definitions are not supported; use trait parameters instead"
+
+    val code1 =
+      """|trait Logging {
+         |  val f: File
+         |  f.open()
+         |  onExit(f.close())
+         |  def log(msg: String) = f.write(msg)
+         |}
+         |
+         |class B extends Logging {
+         |  val f = new File("log.data") // triggers a null pointer exception
+         |}
+         |
+         |class C extends {
+         |  val f = new File("log.data") // early definition gets around the null pointer exception
+         |} with Logging""".stripMargin
+
+    val code2 =
+      """|trait Logging(f: File) {
+         |  f.open()
+         |  onExit(f.close())
+         |  def log(msg: String) = f.write(msg)
+         |}
+         |
+         |class C extends Logging(new File("log.data"))""".stripMargin
+
+    val explanation =
+      hl"""Earlier versions of Scala did not support trait parameters and "early definitions" (also known as "early initializers")
+        |were used as an alternative.
+        |
+        |Example of old syntax:
+        |
+        |$code1
+        |
+        |The above code can now be written as:
+        |
+        |$code2
+        |""".stripMargin
+  }
 }


### PR DESCRIPTION
Tackles [1589](https://github.com/lampepfl/dotty/issues/1589). More specifically, it provides a detailed explanation for the error message in Parsers.scala:2064 : "early definitions are not supported; use trait parameters instead".

The example code in the explanation message is taken from [this presentation](http://files.meetup.com/18712511/Scala2016.pdf) (page 17).

Let me know whether the explanation is too long or needs improvements :-) 


