### PR TITLE
Fix #1605: don't inline methods that have errors

### DIFF
--- a/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -167,6 +167,22 @@ trait Reporting { this: Context =>
         throw ex
     }
   }
+
+  /** Implements a fold that applies the function `f` to the result of `op` if
+    * there are no new errors in the reporter
+    *
+    * @param op operation checked for errors
+    * @param f  function applied to result of op
+    * @return   either the result of `op` if it had errors or the result of `f`
+    *           applied to it
+    */
+  def withNoError[A, B >: A](op: => A)(f: A => B): B = {
+    val before = reporter.errorCount
+    val op0 = op
+
+    if (reporter.errorCount > before) op0
+    else f(op0)
+  }
 }
 
 /**

--- a/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/src/dotty/tools/dotc/typer/Inliner.scala
@@ -146,7 +146,7 @@ object Inliner {
               addAccessor(tree, methPart, targs, argss,
                   accessedType = methPart.tpe.widen,
                   rhs = (qual, tps, argss) => qual.appliedToTypes(tps).appliedToArgss(argss))
-           } else {
+            } else {
               // TODO: Handle references to non-public types.
               // This is quite tricky, as such types can appear anywhere, including as parts
               // of types of other things. For the moment we do nothing and complain
@@ -191,7 +191,9 @@ object Inliner {
           sym.updateAnnotation(LazyBodyAnnotation { _ =>
             implicit val ctx: Context = inlineCtx
             val tree1 = treeExpr(ctx)
-            makeInlineable(tree1)
+            if (tree1.hasType && !tree1.tpe.isError)
+              makeInlineable(tree1)
+            else tree1
           })
         }
     }

--- a/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/src/dotty/tools/dotc/typer/Inliner.scala
@@ -190,10 +190,7 @@ object Inliner {
           val inlineCtx = ctx
           sym.updateAnnotation(LazyBodyAnnotation { _ =>
             implicit val ctx: Context = inlineCtx
-            val tree1 = treeExpr(ctx)
-            if (tree1.hasType && !tree1.tpe.isError)
-              makeInlineable(tree1)
-            else tree1
+            ctx.withNoError(treeExpr(ctx))(makeInlineable)
           })
         }
     }

--- a/tests/neg/i1605.scala
+++ b/tests/neg/i1605.scala
@@ -1,0 +1,5 @@
+object Test {
+  def foo = inlineMe
+
+  inline def inlineMe = 1 + x // error
+}


### PR DESCRIPTION
Review: @smarter 
