### PR TITLE
Record syntactic information about modifiers

### DIFF
--- a/src/dotty/tools/dotc/ast/untpd.scala
+++ b/src/dotty/tools/dotc/ast/untpd.scala
@@ -94,9 +94,42 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   class InfixOpBlock(leftOperand: Tree, rightOp: Tree) extends Block(leftOperand :: Nil, rightOp)
 
   // ----- Modifiers -----------------------------------------------------
+  /** Mod is intended to record syntactic information about modifiers, it's
+    * NOT a replacement of flagsets.
+    *
+    * For any query about semantic information, check `flags` instead.
+    */
+  sealed trait Mod extends Positioned
 
- /** Modifiers and annotations for definitions
-   *  @param flags          The set flags
+  object Mod {
+    case class Private() extends Mod
+
+    case class Protected() extends Mod
+
+    case class Val() extends Mod
+
+    case class Var() extends Mod
+
+    case class Implicit() extends Mod
+
+    case class Final() extends Mod
+
+    case class Sealed() extends Mod
+
+    case class Override() extends Mod
+
+    case class Abstract() extends Mod
+
+    case class Lazy() extends Mod
+
+    case class Inline() extends Mod
+
+    case class Type() extends Mod
+  }
+
+  /** Modifiers and annotations for definitions
+    *
+    *  @param flags          The set flags
    *  @param privateWithin  If a private or protected has is followed by a
    *                        qualifier [q], the name q, "" as a typename otherwise.
    *  @param annotations    The annotations preceding the modifiers
@@ -104,7 +137,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   case class Modifiers (
     flags: FlagSet = EmptyFlags,
     privateWithin: TypeName = tpnme.EMPTY,
-    annotations: List[Tree] = Nil) extends Positioned with Cloneable {
+    annotations: List[Tree] = Nil,
+    mods: List[Mod] = Nil) extends Positioned with Cloneable {
 
     def is(fs: FlagSet): Boolean = flags is fs
     def is(fc: FlagConjunction): Boolean = flags is fc
@@ -120,7 +154,15 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       if (this.flags == flags) this
       else copy(flags = flags)
 
-    def withAddedAnnotation(annot: Tree): Modifiers =
+   def withAddedMod(mod: Mod): Modifiers =
+     if (mods.exists(_ eq mod)) this
+     else withMods(mods :+ mod)
+
+   def withMods(ms: List[Mod]): Modifiers =
+     if (mods eq ms) this
+     else copy(mods = ms)
+
+   def withAddedAnnotation(annot: Tree): Modifiers =
       if (annotations.exists(_ eq annot)) this
       else withAnnotations(annotations :+ annot)
 

--- a/src/dotty/tools/dotc/ast/untpd.scala
+++ b/src/dotty/tools/dotc/ast/untpd.scala
@@ -95,36 +95,36 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
   // ----- Modifiers -----------------------------------------------------
   /** Mod is intended to record syntactic information about modifiers, it's
-    * NOT a replacement of flagsets.
+    * NOT a replacement of FlagSet.
     *
     * For any query about semantic information, check `flags` instead.
     */
-  sealed trait Mod extends Positioned
+  sealed abstract class Mod(val flags: FlagSet) extends Positioned
 
   object Mod {
-    case class Private() extends Mod
+    case class Private() extends Mod(Flags.Private)
 
-    case class Protected() extends Mod
+    case class Protected() extends Mod(Flags.Protected)
 
-    case class Val() extends Mod
+    case class Val() extends Mod(Flags.EmptyFlags)
 
-    case class Var() extends Mod
+    case class Var() extends Mod(Flags.Mutable)
 
-    case class Implicit() extends Mod
+    case class Implicit(flag: FlagSet = Flags.ImplicitCommon) extends Mod(flag)
 
-    case class Final() extends Mod
+    case class Final() extends Mod(Flags.Final)
 
-    case class Sealed() extends Mod
+    case class Sealed() extends Mod(Flags.Sealed)
 
-    case class Override() extends Mod
+    case class Override() extends Mod(Flags.Override)
 
-    case class Abstract() extends Mod
+    case class Abstract() extends Mod(Flags.Abstract)
 
-    case class Lazy() extends Mod
+    case class Lazy() extends Mod(Flags.Lazy)
 
-    case class Inline() extends Mod
+    case class Inline() extends Mod(Flags.Inline)
 
-    case class Type() extends Mod
+    case class Type() extends Mod(Flags.EmptyFlags)
   }
 
   /** Modifiers and annotations for definitions

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1827,12 +1827,12 @@ object Parsers {
     def defOrDcl(start: Int, mods: Modifiers): Tree = in.token match {
       case VAL =>
         val mod = atPos(in.skipToken()) { Mod.Val() }
-        val modPos = atPos(start) { mods.withAddedMod(mod) }
-        patDefOrDcl(start, modPos, in.getDocComment(start))
+        val mods1 = mods.withAddedMod(mod)
+        patDefOrDcl(start, mods1, in.getDocComment(start))
       case VAR =>
         val mod = atPos(in.skipToken()) { Mod.Var() }
-        val modPos = atPos(start) { addMod(mods, mod) }
-        patDefOrDcl(start, modPos, in.getDocComment(start))
+        val mod1 = addMod(mods, mod)
+        patDefOrDcl(start, mod1, in.getDocComment(start))
       case DEF =>
         defDefOrDcl(start, posMods(start, mods), in.getDocComment(start))
       case TYPE =>

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1492,7 +1492,7 @@ object Parsers {
       val tok = in.token
       val mod = atPos(in.skipToken()) { modOfToken(tok) }
 
-      if (mods is mod.flags) syntaxError(RepeatedModifier(flag.toString))
+      if (mods is mod.flags) syntaxError(RepeatedModifier(mod.flags.toString))
       addMod(mods, mod)
     }
 

--- a/test/test/ModifiersParsingTest.scala
+++ b/test/test/ModifiersParsingTest.scala
@@ -1,0 +1,160 @@
+package test
+
+import org.junit.Test
+import org.junit.Assert._
+
+import dotty.tools.dotc.ast.untpd.modsDeco
+import dotty.tools.dotc.ast.untpd._
+import dotty.tools.dotc.ast.{ Trees => d }
+import dotty.tools.dotc.parsing.Parsers.Parser
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.dotc.core.Contexts.ContextBase
+
+object ModifiersParsingTest {
+  implicit val ctx = (new ContextBase).initialCtx
+
+  implicit def parse(code: String): Tree = {
+    val (_, stats) = new Parser(new SourceFile("<meta>", code.toCharArray)).templateStatSeq()
+    stats match { case List(stat) => stat; case stats => Thicket(stats) }
+  }
+
+  implicit class TreeDeco(val code: Tree) extends AnyVal {
+    def firstConstrValDef: ValDef = code match {
+      case d.TypeDef(_, d.Template(constr, _, _, _)) =>
+        constr.vparamss.head.head
+    }
+
+    def firstTypeParam: TypeDef = code match {
+      case d.TypeDef(_, d.Template(constr, _, _, _)) =>
+        constr.tparams.head
+    }
+
+    def defParam(i: Int): ValDef = code match {
+      case d.DefDef(_, _, vparamss, _, _) =>
+        vparamss.head.toArray.apply(i)
+    }
+
+    def defParam(i: Int, j: Int): ValDef = code match {
+      case d.DefDef(_, _, vparamss, _, _) =>
+        vparamss.toArray.apply(i).toArray.apply(j)
+    }
+
+    def funParam(i: Int): Tree = code match {
+      case Function(params, _) =>
+        params.toArray.apply(i)
+    }
+
+    def field(i: Int): Tree = code match {
+      case d.TypeDef(_, t: Template) =>
+        t.body.toArray.apply(i)
+    }
+
+    def field(name: String): Tree = code match {
+      case d.TypeDef(_, t: Template) =>
+        t.body.find({
+          case m: MemberDef => m.name.show == name
+          case _ => false
+        }).get
+    }
+
+    def stat(i: Int): Tree = code match {
+      case d.Block(stats, expr) =>
+        if (i < stats.length) stats.toArray.apply(i)
+        else expr
+    }
+
+    def modifiers: List[Mod] = code match {
+      case t: MemberDef => t.mods.mods
+    }
+  }
+}
+
+
+class ModifiersParsingTest {
+  import ModifiersParsingTest._
+
+
+  @Test def valDef = {
+    var source: Tree = "class A(var a: Int)"
+    assert(source.firstConstrValDef.modifiers == List(Mod.Var()))
+
+    source = "class A(val a: Int)"
+    assert(source.firstConstrValDef.modifiers == List(Mod.Val()))
+
+    source = "class A(private val a: Int)"
+    assert(source.firstConstrValDef.modifiers == List(Mod.Private(), Mod.Val()))
+
+    source = "class A(protected var a: Int)"
+    assert(source.firstConstrValDef.modifiers == List(Mod.Protected(), Mod.Var()))
+
+    source = "class A(protected implicit val a: Int)"
+    assert(source.firstConstrValDef.modifiers == List(Mod.Protected(), Mod.Implicit(), Mod.Val()))
+
+    source = "class A[T]"
+    assert(source.firstTypeParam.modifiers == List())
+
+    source = "class A[type T]"
+    assert(source.firstTypeParam.modifiers == List(Mod.Type()))
+  }
+
+  @Test def typeDef = {
+    var source: Tree = "class A"
+    assert(source.modifiers == List())
+
+    source = "sealed class A"
+    assert(source.modifiers == List(Mod.Sealed()))
+
+    source = "implicit class A"
+    assert(source.modifiers == List(Mod.Implicit()))
+
+    source = "abstract sealed class A"
+    assert(source.modifiers == List(Mod.Abstract(), Mod.Sealed()))
+  }
+
+  @Test def fieldDef = {
+    val source: Tree =
+      """
+        | class A {
+        |   lazy var a = ???
+        |   lazy private val b = ???
+        |   final val c = ???
+        |
+        |   abstract override def f: Boolean
+        |   inline def g(n: Int) = ???
+        | }
+      """.stripMargin
+
+    assert(source.field("a").modifiers == List(Mod.Lazy(), Mod.Var()))
+    assert(source.field("b").modifiers == List(Mod.Lazy(), Mod.Private(), Mod.Val()))
+    assert(source.field("c").modifiers == List(Mod.Final(), Mod.Val()))
+    assert(source.field("f").modifiers == List(Mod.Abstract(), Mod.Override()))
+    assert(source.field("g").modifiers == List(Mod.Inline()))
+  }
+
+  @Test def paramDef = {
+    var source: Tree = "def f(inline a: Int) = ???"
+    assert(source.defParam(0).modifiers == List(Mod.Inline()))
+
+    source = "def f(implicit a: Int, b: Int) = ???"
+    assert(source.defParam(0).modifiers == List(Mod.Implicit()))
+    assert(source.defParam(1).modifiers == List(Mod.Implicit()))
+
+    source = "def f(x: Int, y: Int)(implicit a: Int, b: Int) = ???"
+    assert(source.defParam(0, 0).modifiers == List())
+    assert(source.defParam(1, 0).modifiers == List(Mod.Implicit()))
+  }
+
+  @Test def blockDef = {
+    var source: Tree = "implicit val x : A = ???"
+    assert(source.modifiers == List(Mod.Implicit(), Mod.Val()))
+
+    source = "implicit var x : A = ???"
+    assert(source.modifiers == List(Mod.Implicit(), Mod.Var()))
+
+    source = "{ implicit var x : A = ??? }"
+    assert(source.stat(0).modifiers == List(Mod.Implicit(), Mod.Var()))
+
+    source = "{ implicit x => x * x }"
+    assert(source.stat(0).funParam(0).modifiers == List(Mod.Implicit()))
+  }
+}

--- a/test/test/ModifiersParsingTest.scala
+++ b/test/test/ModifiersParsingTest.scala
@@ -9,6 +9,7 @@ import dotty.tools.dotc.ast.{ Trees => d }
 import dotty.tools.dotc.parsing.Parsers.Parser
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.core.Contexts.ContextBase
+import dotty.tools.dotc.core.Flags
 
 object ModifiersParsingTest {
   implicit val ctx = (new ContextBase).initialCtx
@@ -136,12 +137,13 @@ class ModifiersParsingTest {
     assert(source.defParam(0).modifiers == List(Mod.Inline()))
 
     source = "def f(implicit a: Int, b: Int) = ???"
-    assert(source.defParam(0).modifiers == List(Mod.Implicit()))
-    assert(source.defParam(1).modifiers == List(Mod.Implicit()))
+    println(source.defParam(0).modifiers)
+    assert(source.defParam(0).modifiers == List(Mod.Implicit(Flags.Implicit)))
+    assert(source.defParam(1).modifiers == List(Mod.Implicit(Flags.Implicit)))
 
     source = "def f(x: Int, y: Int)(implicit a: Int, b: Int) = ???"
     assert(source.defParam(0, 0).modifiers == List())
-    assert(source.defParam(1, 0).modifiers == List(Mod.Implicit()))
+    assert(source.defParam(1, 0).modifiers == List(Mod.Implicit(Flags.Implicit)))
   }
 
   @Test def blockDef = {


### PR DESCRIPTION
This PR defines `trait Mod` to record source information about modifiers.

Note that `privateWithin` is already present in `Modifiers`, thus it's not repeated in Mod definitions. 

Review @odersky .