### PR TITLE
Add error message - Parsers.scala:1180

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1177,7 +1177,7 @@ object Parsers {
         case _ =>
           if (isLiteral) literal()
           else {
-            syntaxErrorOrIncomplete("illegal start of simple expression")
+            syntaxErrorOrIncomplete(IllegalStartSimpleExpr(tokenString(in.token)))
             errorTermTree
           }
       }

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -482,4 +482,22 @@ object messages {
         |but an uninitialized var definition
         """.stripMargin
   }
+
+  case class IllegalStartSimpleExpr(illegalToken: String)(implicit ctx: Context) extends Message(17) {
+    val kind = "Syntax"
+    val msg = "illegal start of simple expression"
+    val explanation = {
+      hl"""|An expression yields a value. In the case of the simple expression, this error
+           |commonly occurs when there's a missing parenthesis or brace. The reason being
+           |that a simple expression is one of the following:
+           |
+           |- Block
+           |- Expression in parenthesis
+           |- Identifier
+           |- Object creation
+           |- Literal
+           |
+           |which cannot start with ${Red(illegalToken)}.""".stripMargin
+    }
+  }
 }


### PR DESCRIPTION
Part of #1589.
Explanation for the error on line Parsers.scala:1180.
Adds the sematic object for the error `illiegal start of simple expression`.
@felixmulder kindly review.