### PR TITLE
Add error messages - Parsers.scala:626 and Parsers.scala:1492 

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -623,7 +623,7 @@ object Parsers {
                 if (inPattern) Block(Nil, inBraces(pattern()))
                 else expr()
               else {
-                syntaxErrorOrIncomplete("error in interpolated string: identifier or block expected")
+                ctx.error(InterpolatedStringError())
                 EmptyTree
               }
             })
@@ -1489,7 +1489,7 @@ object Parsers {
 
     private def addModifier(mods: Modifiers): Modifiers = {
       val flag = flagOfToken(in.token)
-      if (mods is flag) syntaxError("repeated modifier")
+      if (mods is flag) syntaxError(RepeatedModifier(flag.toString))
       val res = addFlag(mods, flag)
       in.nextToken()
       res

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -400,4 +400,51 @@ object messages {
            |  ((${nestedRepresentation}))""".stripMargin
     }
   }
+
+  case class RepeatedModifier(modifier: String)(implicit ctx:Context) extends Message(14) {
+    val kind = "Syntax"
+
+    val msg = hl"""repeated modifier $modifier"""
+
+    val code1 = hl"""private private val Origin = Point(0, 0)"""
+
+    val code2 = hl"""private final val Origin = Point(0, 0)"""
+
+    val explanation =
+      hl"""This happens when you accidentally specify the same modifier twice.
+           |
+           |Example:
+           |
+           |$code1
+           |
+           |instead of
+           |
+           |$code2
+           |
+           |""".stripMargin
+  }
+
+  case class InterpolatedStringError()(implicit ctx:Context) extends Message(15) {
+    val kind = "Syntax"
+
+    val msg = "error in interpolated string: identifier or block expected"
+
+    val code1 = "s\"$new Point(0, 0)\""
+
+    val code2 = "s\"${new Point(0, 0)}\""
+
+    val explanation =
+      hl"""
+         |This usually happens when you forget to place your expressions inside curly braces.
+         |
+         |$code1
+         |
+         |should be written as
+         |
+         |$code2
+         |
+         |""".stripMargin
+
+  }
+
 }


### PR DESCRIPTION
Error messages for Parsers.scala:626 and Parsers.scala:1492.

**Note**: I may have to bump the error message ids - depending on whether the other [PR](https://github.com/lampepfl/dotty/pull/1613) gets merged before this one.