### PR TITLE
Update error message at Parsers.scala:1901

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1898,7 +1898,7 @@ object Parsers {
             else EmptyTree
           }
           else {
-            if (!isExprIntro) syntaxError("missing return type", in.lastOffset)
+            if (!isExprIntro) syntaxError(MissingReturnType(), in.lastOffset)
             accept(EQUALS)
             expr()
           }

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -275,10 +275,10 @@ object messages {
 
     val explanation = ""
   }
- 
+
   case class EarlyDefinitionsNotSupported()(implicit ctx:Context) extends Message(9) {
     val kind = "Syntax"
-   
+
     val msg = "early definitions are not supported; use trait parameters instead"
 
     val code1 =
@@ -500,4 +500,16 @@ object messages {
            |which cannot start with ${Red(illegalToken)}.""".stripMargin
     }
   }
+
+  case class MissingReturnType()(implicit ctx:Context) extends Message(18) {
+    val kind = "Syntax"
+    val msg = "missing return type"
+    val explanation =
+      hl"""An abstract declaration must have a return type. For example:
+        |
+        |trait Shape {
+        |  def area: Double // abstract declaration returning a ${"Double"}
+        |}""".stripMargin
+  }
+
 }


### PR DESCRIPTION
This one is about a 'missing return type' when we can't infer a type. I used tests/neg/i871.scala to verify the change