### PR TITLE
Introduce scalaShadowing package

### DIFF
--- a/src/dotty/Pair.scala
+++ b/src/dotty/Pair.scala
@@ -1,5 +1,0 @@
-package dotty
-
-class Pair[T, U](x: T, y: U) {
-
-}

--- a/src/dotty/Singleton.scala
+++ b/src/dotty/Singleton.scala
@@ -1,5 +1,0 @@
-package dotty
-
-class Singleton {
-
-}

--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -420,8 +420,6 @@ class Definitions {
     lazy val StringAdd_plusR = StringAddClass.requiredMethodRef(nme.raw.PLUS)
     def StringAdd_+(implicit ctx: Context) = StringAdd_plusR.symbol
 
-  lazy val PairType: TypeRef                    = ctx.requiredClassRef("dotty.Pair")
-  def PairClass(implicit ctx: Context) = PairType.symbol.asClass
   lazy val PartialFunctionType: TypeRef         = ctx.requiredClassRef("scala.PartialFunction")
   def PartialFunctionClass(implicit ctx: Context) = PartialFunctionType.symbol.asClass
   lazy val AbstractPartialFunctionType: TypeRef = ctx.requiredClassRef("scala.runtime.AbstractPartialFunction")
@@ -460,17 +458,17 @@ class Definitions {
   def StaticAnnotationClass(implicit ctx: Context) = StaticAnnotationType.symbol.asClass
 
   // Annotation classes
-  lazy val AliasAnnotType = ctx.requiredClassRef("dotty.annotation.internal.Alias")
+  lazy val AliasAnnotType = ctx.requiredClassRef("scala.annotation.internal.Alias")
   def AliasAnnot(implicit ctx: Context) = AliasAnnotType.symbol.asClass
-  lazy val AnnotationDefaultAnnotType = ctx.requiredClassRef("dotty.annotation.internal.AnnotationDefault")
+  lazy val AnnotationDefaultAnnotType = ctx.requiredClassRef("scala.annotation.internal.AnnotationDefault")
   def AnnotationDefaultAnnot(implicit ctx: Context) = AnnotationDefaultAnnotType.symbol.asClass
-  lazy val BodyAnnotType = ctx.requiredClassRef("dotty.annotation.internal.Body")
+  lazy val BodyAnnotType = ctx.requiredClassRef("scala.annotation.internal.Body")
   def BodyAnnot(implicit ctx: Context) = BodyAnnotType.symbol.asClass
-  lazy val ChildAnnotType = ctx.requiredClassRef("dotty.annotation.internal.Child")
+  lazy val ChildAnnotType = ctx.requiredClassRef("scala.annotation.internal.Child")
   def ChildAnnot(implicit ctx: Context) = ChildAnnotType.symbol.asClass
-  lazy val CovariantBetweenAnnotType = ctx.requiredClassRef("dotty.annotation.internal.CovariantBetween")
+  lazy val CovariantBetweenAnnotType = ctx.requiredClassRef("scala.annotation.internal.CovariantBetween")
   def CovariantBetweenAnnot(implicit ctx: Context) = CovariantBetweenAnnotType.symbol.asClass
-  lazy val ContravariantBetweenAnnotType = ctx.requiredClassRef("dotty.annotation.internal.ContravariantBetween")
+  lazy val ContravariantBetweenAnnotType = ctx.requiredClassRef("scala.annotation.internal.ContravariantBetween")
   def ContravariantBetweenAnnot(implicit ctx: Context) = ContravariantBetweenAnnotType.symbol.asClass
   lazy val DeprecatedAnnotType = ctx.requiredClassRef("scala.deprecated")
   def DeprecatedAnnot(implicit ctx: Context) = DeprecatedAnnotType.symbol.asClass
@@ -478,9 +476,9 @@ class Definitions {
   def ImplicitNotFoundAnnot(implicit ctx: Context) = ImplicitNotFoundAnnotType.symbol.asClass
   lazy val InlineAnnotType = ctx.requiredClassRef("scala.inline")
   def InlineAnnot(implicit ctx: Context) = InlineAnnotType.symbol.asClass
-  lazy val InlineParamAnnotType = ctx.requiredClassRef("dotty.annotation.internal.InlineParam")
+  lazy val InlineParamAnnotType = ctx.requiredClassRef("scala.annotation.internal.InlineParam")
   def InlineParamAnnot(implicit ctx: Context) = InlineParamAnnotType.symbol.asClass
-  lazy val InvariantBetweenAnnotType = ctx.requiredClassRef("dotty.annotation.internal.InvariantBetween")
+  lazy val InvariantBetweenAnnotType = ctx.requiredClassRef("scala.annotation.internal.InvariantBetween")
   def InvariantBetweenAnnot(implicit ctx: Context) = InvariantBetweenAnnotType.symbol.asClass
   lazy val MigrationAnnotType = ctx.requiredClassRef("scala.annotation.migration")
   def MigrationAnnot(implicit ctx: Context) = MigrationAnnotType.symbol.asClass
@@ -488,9 +486,9 @@ class Definitions {
   def NativeAnnot(implicit ctx: Context) = NativeAnnotType.symbol.asClass
   lazy val RemoteAnnotType                   = ctx.requiredClassRef("scala.remote")
   def RemoteAnnot(implicit ctx: Context) = RemoteAnnotType.symbol.asClass
-  lazy val RepeatedAnnotType = ctx.requiredClassRef("dotty.annotation.internal.Repeated")
+  lazy val RepeatedAnnotType = ctx.requiredClassRef("scala.annotation.internal.Repeated")
   def RepeatedAnnot(implicit ctx: Context) = RepeatedAnnotType.symbol.asClass
-  lazy val SourceFileAnnotType = ctx.requiredClassRef("dotty.annotation.internal.SourceFile")
+  lazy val SourceFileAnnotType = ctx.requiredClassRef("scala.annotation.internal.SourceFile")
   def SourceFileAnnot(implicit ctx: Context) = SourceFileAnnotType.symbol.asClass
   lazy val ScalaSignatureAnnotType = ctx.requiredClassRef("scala.reflect.ScalaSignature")
   def ScalaSignatureAnnot(implicit ctx: Context) = ScalaSignatureAnnotType.symbol.asClass
@@ -520,7 +518,7 @@ class Definitions {
   def UncheckedStableAnnot(implicit ctx: Context) = UncheckedStableAnnotType.symbol.asClass
   lazy val UncheckedVarianceAnnotType = ctx.requiredClassRef("scala.annotation.unchecked.uncheckedVariance")
   def UncheckedVarianceAnnot(implicit ctx: Context) = UncheckedVarianceAnnotType.symbol.asClass
-  lazy val UnsafeNonvariantAnnotType = ctx.requiredClassRef("dotty.annotation.internal.UnsafeNonvariant")
+  lazy val UnsafeNonvariantAnnotType = ctx.requiredClassRef("scala.annotation.internal.UnsafeNonvariant")
   def UnsafeNonvariantAnnot(implicit ctx: Context) = UnsafeNonvariantAnnotType.symbol.asClass
   lazy val VolatileAnnotType = ctx.requiredClassRef("scala.volatile")
   def VolatileAnnot(implicit ctx: Context) = VolatileAnnotType.symbol.asClass

--- a/src/scala/annotation/internal/Alias.scala
+++ b/src/scala/annotation/internal/Alias.scala
@@ -1,10 +1,10 @@
-package dotty.annotation.internal
+package scala.annotation.internal
 
 import scala.annotation.Annotation
 
 /** An annotation to record a Scala2 pickled alias.
  *  @param aliased  A TermRef pointing to the aliased field.
  */
-class SourceFile(path: String) extends Annotation {
+class Alias(aliased: Any) extends Annotation {
 
 }

--- a/src/scala/annotation/internal/AnnotationDefault.scala
+++ b/src/scala/annotation/internal/AnnotationDefault.scala
@@ -1,4 +1,4 @@
-package dotty.annotation.internal
+package scala.annotation.internal
 
 import scala.annotation.Annotation
 

--- a/src/scala/annotation/internal/Body.scala
+++ b/src/scala/annotation/internal/Body.scala
@@ -1,4 +1,4 @@
-package dotty.annotation.internal
+package scala.annotation.internal
 
 import scala.annotation.Annotation
 

--- a/src/scala/annotation/internal/Child.scala
+++ b/src/scala/annotation/internal/Child.scala
@@ -1,4 +1,4 @@
-package dotty.annotation.internal
+package scala.annotation.internal
 
 import scala.annotation.Annotation
 
@@ -9,7 +9,7 @@ import scala.annotation.Annotation
  *    case class B() extends A
  *    case class C() extends A
  *
- *  Then the class symbol `A` would carry the annotations 
+ *  Then the class symbol `A` would carry the annotations
  *  `@Child[Bref] @Child[Cref]` where `Bref`, `Cref` are TypeRefs
  *  referring to the class symbols of `B` and `C`
  */

--- a/src/scala/annotation/internal/InlineParam.scala
+++ b/src/scala/annotation/internal/InlineParam.scala
@@ -1,4 +1,4 @@
-package dotty.annotation.internal
+package scala.annotation.internal
 
 import scala.annotation.Annotation
 

--- a/src/scala/annotation/internal/Repeated.scala
+++ b/src/scala/annotation/internal/Repeated.scala
@@ -1,4 +1,4 @@
-package dotty.annotation.internal
+package scala.annotation.internal
 
 import scala.annotation.Annotation
 

--- a/src/scala/annotation/internal/SourceFile.scala
+++ b/src/scala/annotation/internal/SourceFile.scala
@@ -1,10 +1,10 @@
-package dotty.annotation.internal
+package scala.annotation.internal
 
 import scala.annotation.Annotation
 
 /** An annotation to record a Scala2 pickled alias.
  *  @param aliased  A TermRef pointing to the aliased field.
  */
-class Alias(aliased: Any) extends Annotation {
+class SourceFile(path: String) extends Annotation {
 
 }

--- a/src/scala/annotation/internal/UnsafeNonvariant.scala
+++ b/src/scala/annotation/internal/UnsafeNonvariant.scala
@@ -1,4 +1,4 @@
-package dotty.annotation.internal
+package scala.annotation.internal
 
 import scala.annotation.Annotation
 

--- a/src/scalaShadowing/language.scala
+++ b/src/scalaShadowing/language.scala
@@ -1,0 +1,198 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2015, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+package scalaShadowing
+
+/**
+ *  The `scala.language` object controls the language features available to the programmer, as proposed in the
+ *  [[https://docs.google.com/document/d/1nlkvpoIRkx7at1qJEZafJwthZ3GeIklTFhqmXMvTX9Q/edit '''SIP-18 document''']].
+ *
+ *  Each of these features has to be explicitly imported into the current scope to become available:
+ *  {{{
+ *     import language.postfixOps // or language._
+ *     List(1, 2, 3) reverse
+ *  }}}
+ *
+ *  The language features are:
+ *   - [[dynamics            `dynamics`]]            enables defining calls rewriting using the [[scala.Dynamic `Dynamic`]] trait
+ *   - [[postfixOps          `postfixOps`]]          enables postfix operators
+ *   - [[reflectiveCalls     `reflectiveCalls`]]     enables using structural types
+ *   - [[implicitConversions `implicitConversions`]] enables defining implicit methods and members
+ *   - [[higherKinds         `higherKinds`]]         enables writing higher-kinded types
+ *   - [[existentials        `existentials`]]        enables writing existential types
+ *   - [[experimental        `experimental`]]        contains newer features that have not yet been tested in production
+ *   
+ *  and, for dotty:
+ *  
+ *   - [[Scala2              `Scala2`]               backwards compatibility mode for Scala2
+ *   - [[noAtoTupling        `noAutoTupling`]]       disable auto-tupling   
+ *
+ *  @groupname production   Language Features
+ *  @groupname experimental Experimental Language Features
+ *  @groupprio experimental 10
+ *  
+ *  Dotty-specific features come at the end.
+ *  
+ *  Note: Due to the more restricted language import mechanism in dotty (only
+ *  imports count, implicits are disregarded) we don't need the constructions
+ *  of the inherited language features. A simple object for each feature is
+ *  sufficient.
+ */
+object language {
+
+  import languageFeature._
+
+  /** Where enabled, direct or indirect subclasses of trait scala.Dynamic can
+   *  be defined. Unless dynamics is enabled, a definition of a class, trait,
+   *  or object that has Dynamic as a base trait is rejected. Dynamic member
+   *  selection of existing subclasses of trait Dynamic are unaffected;
+   *  they can be used anywhere.
+   *
+   *  '''Why introduce the feature?''' To enable flexible DSLs and convenient interfacing
+   *  with dynamic languages.
+   *
+   *  '''Why control it?''' Dynamic member selection can undermine static checkability
+   *  of programs. Furthermore, dynamic member selection often relies on reflection,
+   *  which is not available on all platforms.
+   *
+   *  @group production
+   */
+  @volatile implicit lazy val dynamics: dynamics = languageFeature.dynamics
+
+  /** Only where enabled, postfix operator notation `(expr op)` will be allowed.
+   *
+   *  '''Why keep the feature?''' Several DSLs written in Scala need the notation.
+   *
+   *  '''Why control it?''' Postfix operators interact poorly with semicolon inference.
+   *   Most programmers avoid them for this reason.
+   *
+   *  @group production
+   */
+  @volatile implicit lazy val postfixOps: postfixOps = languageFeature.postfixOps
+
+  /** Only where enabled, accesses to members of structural types that need
+   *  reflection are supported. Reminder: A structural type is a type of the form
+   *  `Parents { Decls }` where `Decls` contains declarations of new members that do
+   *  not override any member in `Parents`. To access one of these members, a
+   *  reflective call is needed.
+   *
+   *  '''Why keep the feature?''' Structural types provide great flexibility because
+   *  they avoid the need to define inheritance hierarchies a priori. Besides,
+   *  their definition falls out quite naturally from Scala’s concept of type refinement.
+   *
+   *  '''Why control it?''' Reflection is not available on all platforms. Popular tools
+   *  such as ProGuard have problems dealing with it. Even where reflection is available,
+   *  reflective dispatch can lead to surprising performance degradations.
+   *
+   *  @group production
+   */
+  @volatile implicit lazy val reflectiveCalls: reflectiveCalls = languageFeature.reflectiveCalls
+
+  /** Only where enabled, definitions of implicit conversions are allowed. An
+   *  implicit conversion is an implicit value of unary function type `A => B`,
+   *  or an implicit method that has in its first parameter section a single,
+   *  non-implicit parameter. Examples:
+   *
+   *  {{{
+   *     implicit def stringToInt(s: String): Int = s.length
+   *     implicit val conv = (s: String) => s.length
+   *     implicit def listToX(xs: List[T])(implicit f: T => X): X = ...
+   *  }}}
+   *
+   *  implicit values of other types are not affected, and neither are implicit
+   *  classes.
+   *
+   *  '''Why keep the feature?''' Implicit conversions are central to many aspects
+   *  of Scala’s core libraries.
+   *
+   *  '''Why control it?''' Implicit conversions are known to cause many pitfalls
+   *  if over-used. And there is a tendency to over-use them because they look
+   *  very powerful and their effects seem to be easy to understand. Also, in
+   *  most situations using implicit parameters leads to a better design than
+   *  implicit conversions.
+   *
+   *  @group production
+   */
+  @volatile implicit lazy val implicitConversions: implicitConversions = languageFeature.implicitConversions
+
+  /** Only where this flag is enabled, higher-kinded types can be written.
+   *
+   *  '''Why keep the feature?''' Higher-kinded types enable the definition of very general
+   *  abstractions such as functor, monad, or arrow. A significant set of advanced
+   *  libraries relies on them. Higher-kinded types are also at the core of the
+   *  scala-virtualized effort to produce high-performance parallel DSLs through staging.
+   *
+   *  '''Why control it?''' Higher kinded types in Scala lead to a Turing-complete
+   *  type system, where compiler termination is no longer guaranteed. They tend
+   *  to be useful mostly for type-level computation and for highly generic design
+   *  patterns. The level of abstraction implied by these design patterns is often
+   *  a barrier to understanding for newcomers to a Scala codebase. Some syntactic
+   *  aspects of higher-kinded types are hard to understand for the uninitiated and
+   *  type inference is less effective for them than for normal types. Because we are
+   *  not completely happy with them yet, it is possible that some aspects of
+   *  higher-kinded types will change in future versions of Scala. So an explicit
+   *  enabling also serves as a warning that code involving higher-kinded types
+   *  might have to be slightly revised in the future.
+   *
+   *  @group production
+   */
+  @volatile implicit lazy val higherKinds: higherKinds = languageFeature.higherKinds
+
+  /** Only where enabled, existential types that cannot be expressed as wildcard
+   *  types can be written and are allowed in inferred types of values or return
+   *  types of methods. Existential types with wildcard type syntax such as `List[_]`,
+   *  or `Map[String, _]` are not affected.
+   *
+   *  '''Why keep the feature?''' Existential types are needed to make sense of Java’s wildcard
+   *  types and raw types and the erased types of run-time values.
+   *
+   *  '''Why control it?''' Having complex existential types in a code base usually makes
+   *  application code very brittle, with a tendency to produce type errors with
+   *  obscure error messages. Therefore, going overboard with existential types
+   *  is generally perceived not to be a good idea. Also, complicated existential types
+   *  might be no longer supported in a future simplification of the language.
+   *
+   *  @group production
+   */
+  @volatile implicit lazy val existentials: existentials = languageFeature.existentials
+
+  /** The experimental object contains features that have been recently added but have not
+   *  been thoroughly tested in production yet.
+   *
+   *  Experimental features '''may undergo API changes''' in future releases, so production
+   *  code should not rely on them.
+   *
+   *  Programmers are encouraged to try out experimental features and
+   *  [[http://issues.scala-lang.org report any bugs or API inconsistencies]]
+   *  they encounter so they can be improved in future releases.
+   *
+   *  @group experimental
+   */
+  object experimental {
+
+    import languageFeature.experimental._
+
+    /** Where enabled, macro definitions are allowed. Macro implementations and
+     *  macro applications are unaffected; they can be used anywhere.
+     *
+     *  '''Why introduce the feature?''' Macros promise to make the language more regular,
+     *  replacing ad-hoc language constructs with a general powerful abstraction
+     *  capability that can express them. Macros are also a more disciplined and
+     *  powerful replacement for compiler plugins.
+     *
+     *  '''Why control it?''' For their very power, macros can lead to code that is hard
+     *  to debug and understand.
+     */
+    @volatile implicit lazy val macros: macros = languageFeature.experimental.macros
+  }
+  
+  /** Where imported, a backwards compatibility mode for Scala2 is enabled */
+  object Scala2
+  
+  /** Where imported, auto-tupling is disabled */
+  object noAutoTupling
+}


### PR DESCRIPTION
The `scalaShadowing` package is used to safely modify classes and
objects in scala so that they can be used from dotty. They will
be visible as members of the `scala` package, replacing any objects
or classes with the same name. But their binary artifacts are
in `scalaShadowing` so they don't clash with the same-named `scala`
members at runtime.

Review by @nicolasstucki 