### PR TITLE
Add unbound placeholder parameter message.

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -334,7 +334,7 @@ object Parsers {
       try op
       finally {
         placeholderParams match {
-          case vd :: _ => syntaxError("unbound placeholder parameter", vd.pos)
+          case vd :: _ => syntaxError(UnboundPlaceholderParameter(), vd.pos)
           case _ =>
         }
         placeholderParams = savedPlaceholderParams

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -447,4 +447,39 @@ object messages {
 
   }
 
+  case class UnboundPlaceholderParameter()(implicit ctx:Context)
+    extends Message(16) {
+    val kind = "Syntax"
+
+    val msg = hl"unbound placeholder parameter; incorrect use of `_`"
+
+    val explanation =
+      hl"""The `_` placeholder syntax was used where it could not be bound.
+        |Consider explicitly writing the variable binding.
+        |
+        |This can be done by replacing `_` with a variable (eg. `x`)
+        |and adding ${"x =>"} where applicable.
+        |
+        |Example before:
+        |
+        |${"{ _ }"}
+        |
+        |Example after:
+        |
+        |${"x => { x }"}
+        |
+        |Another common occurrence for this error is defining a val with `_`:
+        |
+        |${"val a = _"}
+        |
+        |But this val definition isn't very useful, it can never be assigned
+        |another value. And thus will always remain uninitialized.
+        |Consider replacing the ${"val"} with ${"var"}:
+        |
+        |${"var a = _"}
+        |
+        |Note that this use of `_` is not placeholder syntax,
+        |but an uninitialized var definition
+        """.stripMargin
+  }
 }


### PR DESCRIPTION
Part of #1589 
Addition of message for the 'unbound placeholder parameter' error message (Parsers.scala 337).
I tried to check what is available in the vd ValDef in checkNoEscapingPlaceholders (Parsers.scala 330), but I couldn't really find anything which could be used to enhance the error message.