### PR TITLE
fix #1626: inconsistent names in prettyprint

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -15,6 +15,7 @@ import reporting.Reporter
 import transform.TreeChecker
 import rewrite.Rewrites
 import java.io.{BufferedWriter, OutputStreamWriter}
+import printing.XprintMode
 
 import scala.annotation.tailrec
 import scala.reflect.io.VirtualFile
@@ -95,7 +96,7 @@ class Run(comp: Compiler)(implicit ctx: Context) {
     val unit = ctx.compilationUnit
     val prevPhase = ctx.phase.prev // can be a mini-phase
     val squashedPhase = ctx.squashed(prevPhase)
-    val treeString = unit.tpdTree.show
+    val treeString = unit.tpdTree.show(ctx.withProperty(XprintMode, Some(())))
 
     ctx.echo(s"result of $unit after $squashedPhase:")
 

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -61,7 +61,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   override def nameString(name: Name): String = name.decode.toString
 
   override protected def simpleNameString(sym: Symbol): String = {
-    val name = sym.originalName
+    val name = if (ctx.property(XprintMode).isEmpty) sym.originalName else sym.name
     nameString(if (sym is ExpandedTypeParam) name.asTypeName.unexpandedName else name)
   }
 

--- a/compiler/src/dotty/tools/dotc/printing/package.scala
+++ b/compiler/src/dotty/tools/dotc/printing/package.scala
@@ -2,6 +2,7 @@ package dotty.tools.dotc
 
 import core.StdNames.nme
 import parsing.{precedence, minPrec, maxPrec, minInfixPrec}
+import util.Property.Key
 
 package object printing {
 
@@ -14,4 +15,9 @@ package object printing {
   val GlobalPrec    = parsing.minPrec
   val TopLevelPrec  = parsing.minPrec - 1
 
+  /** A property to indicate whether the compiler is currently doing -Xprint
+   *
+   *  -Xprint will print `sym.name` instead of `sym.originalName`
+   */
+  val XprintMode = new Key[Unit]
 }


### PR DESCRIPTION
I'm not sure if `sym.originalName` is intended here. Change it to `sym.name` fixes #1626 .
