### PR TITLE
Update error msg for Parsers.scala:1738 and 1739

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1742,8 +1742,8 @@ object Parsers {
       if (owner == nme.CONSTRUCTOR && (result.isEmpty || (result.head take 1 exists (_.mods is Implicit)))) {
         in.token match {
           case LBRACKET   => syntaxError("no type parameters allowed here")
-          case EOF        => incompleteInputError("auxiliary constructor needs non-implicit parameter list")
-          case _          => syntaxError("auxiliary constructor needs non-implicit parameter list", start)
+          case EOF        => incompleteInputError(AuxConstructorNeedsNonImplicitParameter())
+          case _          => syntaxError(AuxConstructorNeedsNonImplicitParameter(), start)
         }
       }
       result

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -715,4 +715,21 @@ object messages {
            |""".stripMargin
     }
   }
+
+  case class AuxConstructorNeedsNonImplicitParameter()(implicit ctx:Context) extends Message(26) {
+    val kind = "Syntax"
+    val msg = "auxiliary constructor needs non-implicit parameter list"
+    val explanation =
+      hl"""Only the primary constructor is allowed an ${"implicit"} parameter list;
+        |auxiliary constructors need a non-implicit parameter list. When a primary
+        |constructor has an implicit argslist, auxiliary constructors that call the
+        |primary constructor must specify the implicit value.
+        |
+        |To resolve this issue check for:
+        | - forgotten parenthesis on ${"this"} (${"def this() = // ..."})
+        | - auxiliary constructors specify the implicit value
+        |""".stripMargin
+  }
+
+
 }


### PR DESCRIPTION
These error messages are for aux ctors needing non-implicit params. I'm testing the error messages with this code

```
class Square(val len: Int) {
  // typical cases:
  //  (1) this() parens are forgotten, (2) argument set as implicit
  def this(implicit width: Double) = this(0)
  def this = { this(4) }
}

class MyList(val s: String) {
  def this
```
