### PR TITLE
Fix nightly builds

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -64,9 +64,6 @@ object DottyBuild extends Build {
   lazy val dotty = project.in(file(".")).
     dependsOn(`dotty-interfaces`).
     settings(
-      // Disable scaladoc generation, makes publishLocal much faster
-      publishArtifact in packageDoc := false,
-
       overrideScalaVersionSetting,
 
       // set sources to src/, tests to test/ and resources to resources/


### PR DESCRIPTION
This commit removes the setting to not publish docs for the `dotty` project.

I suggest either adding a task-key that makes `publishLocal` faster, or simply overriding the setting when publishing locally instead of hardcoding it.