### PR TITLE
Avoid calling unsupported computeHash in some situations

### DIFF
--- a/src/dotty/tools/dotc/core/Hashable.scala
+++ b/src/dotty/tools/dotc/core/Hashable.scala
@@ -31,9 +31,9 @@ trait Hashable {
   protected def hashSeed: Int = getClass.hashCode
 
   protected final def finishHash(hashCode: Int, arity: Int): Int =
-    avoidNotCached(hashing.finalizeHash(hashCode, arity))
+    avoidSpecialHashes(hashing.finalizeHash(hashCode, arity))
 
-  final def identityHash = avoidNotCached(System.identityHashCode(this))
+  final def identityHash = avoidSpecialHashes(System.identityHashCode(this))
 
   protected def finishHash(seed: Int, arity: Int, tp: Type): Int = {
     val elemHash = tp.hash
@@ -94,7 +94,10 @@ trait Hashable {
 
   protected final def addDelta(elemHash: Int, delta: Int) =
     if (elemHash == NotCached) NotCached
-    else avoidNotCached(elemHash + delta)
+    else avoidSpecialHashes(elemHash + delta)
 
-  private def avoidNotCached(h: Int) = if (h == NotCached) NotCachedAlt else h
+  private def avoidSpecialHashes(h: Int) =
+    if (h == NotCached) NotCachedAlt
+    else if (h == HashUnknown) HashUnknownAlt
+    else h
 }

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -1278,7 +1278,7 @@ object Types {
     final def hash = {
       if (myHash == HashUnknown) {
         myHash = computeHash
-        if (myHash == HashUnknown) myHash = HashUnknownAlt
+        assert(myHash != HashUnknown)
       }
       myHash
     }
@@ -1293,7 +1293,7 @@ object Types {
     final def hash = {
       if (myHash == HashUnknown) {
         myHash = computeHash
-        if (myHash == HashUnknown) myHash = HashUnknownAlt
+        assert(myHash != HashUnknown)
       }
       myHash
     }


### PR DESCRIPTION
Some types do not implement `computeHash`, instead they override
`myHash` directly. This works fine as long as `myHash` is not equal to
`HashUnknown` but this was not guaranteed before this commit, if
`myHash` is equal to `HashUnknown` then `computeHash` is called by
`CachedGroundType#hash` or `CachedProxyType#hash` causing an exception:
https://gist.github.com/smarter/6b642db0495e995d8f3c26d614cf54d6

This commit fixes this by making sure we never compute a hash equal to
`HashUnknown`, instead `HashUnknownAlt` should be used.

Review by @odersky 
