### PR TITLE
Add error message IdentifierExpected

### DIFF
--- a/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -21,6 +21,7 @@ import Symbols._
 import ast.Trees._
 import Decorators._
 import StdNames._
+import dotty.tools.dotc.reporting.diagnostic.messages.IdentifierExpected
 import dotty.tools.dotc.util.SourceFile
 import util.Positions._
 import annotation.switch
@@ -230,7 +231,7 @@ object JavaParsers {
         case AppliedTypeTree(_, _) | Select(_, _) =>
           tree
         case _ =>
-          syntaxError("identifier expected", tree.pos)
+          syntaxError(IdentifierExpected(tree.show), tree.pos)
           errorTypeTree
       }
     }

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -316,7 +316,7 @@ object Parsers {
       case id @ Select(qual, name) =>
         cpy.Select(id)(qual, name.toTypeName)
       case _ =>
-        syntaxError("identifier expected", tree.pos)
+        syntaxError(IdentifierExpected(tree.show), tree.pos)
         tree
     }
 

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -691,4 +691,28 @@ object messages {
                            |${s"trait A[${mods.flags} type $identifier]"}
                            |""".stripMargin
   }
+
+  case class IdentifierExpected(identifier: String)(implicit ctx: Context) extends Message(25) {
+    val kind = "Syntax"
+
+    val msg = "identifier expected"
+
+    val wrongIdentifier = s"def foo: $identifier = {...}"
+
+    val validIdentifier = s"def foo = {...}"
+
+    val explanation = {
+      hl"""|A valid identifier expected, but `$identifier` found.
+           |Let the compiler infer the type for you.
+           |For example, instead of:
+           |
+           |$wrongIdentifier
+           |
+           |Write your code like:
+           |
+           |$validIdentifier
+           |
+           |""".stripMargin
+    }
+  }
 }


### PR DESCRIPTION
This commit adds the semantic object fir the `identifier expected` error.
It is part of the https://github.com/lampepfl/dotty/issues/1589

I believe this PR fixes:
- parsing/JavaParsers.scala:233
- Parsers.scala:319
