### PR TITLE
[WIP] #1579 Adapt the sbt bridge for the new error message

### DIFF
--- a/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
+++ b/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
@@ -2,15 +2,10 @@ package dotty.tools
 package dotc
 package reporting
 
-import scala.collection.mutable
 import util.SourcePosition
-import core.Contexts._, core.Decorators._
-import Reporter._
-import java.io.{ BufferedReader, IOException, PrintWriter }
-import scala.reflect.internal.util._
-import printing.SyntaxHighlighting._
-import printing.Highlighting._
-import diagnostic.{ Message, MessageContainer, NoExplanation }
+import core.Contexts._
+import java.io.{ BufferedReader, PrintWriter }
+import diagnostic.{ Message, MessageContainer }
 import diagnostic.messages._
 
 /**
@@ -19,7 +14,7 @@ import diagnostic.messages._
 class ConsoleReporter(
   reader: BufferedReader = Console.in,
   writer: PrintWriter = new PrintWriter(Console.err, true)
-) extends Reporter with UniqueMessagePositions with HideNonSensicalMessages {
+) extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with MessageRendering {
 
   import MessageContainer._
 
@@ -29,111 +24,26 @@ class ConsoleReporter(
   /** Prints the message. */
   def printMessage(msg: String): Unit = { writer.print(msg + "\n"); writer.flush() }
 
-  def stripColor(str: String): String =
-    str.replaceAll("\u001B\\[[;\\d]*m", "")
-
-  def sourceLines(pos: SourcePosition)(implicit ctx: Context): (List[String], List[String], Int) = {
-    var maxLen = Int.MinValue
-    def render(xs: List[Int]) =
-      xs.map(pos.source.offsetToLine(_))
-      .map { lineNbr =>
-        val prefix = s"${lineNbr + 1} |"
-        maxLen = math.max(maxLen, prefix.length)
-        (prefix, pos.lineContent(lineNbr).stripLineEnd)
-      }
-      .map { case (prefix, line) =>
-        val lnum = Red(" " * math.max(0, maxLen - prefix.length) + prefix)
-        hl"$lnum$line"
-      }
-
-    val (before, after) = pos.beforeAndAfterPoint
-    (render(before), render(after), maxLen)
-  }
-
-  def columnMarker(pos: SourcePosition, offset: Int)(implicit ctx: Context) = {
-    val prefix = " " * (offset - 1)
-    val whitespace = " " * pos.startColumn
-    val carets = Red {
-      if (pos.startLine == pos.endLine)
-        "^" * math.max(1, pos.endColumn - pos.startColumn)
-      else "^"
-    }
-
-    s"$prefix|$whitespace${carets.show}"
-  }
-
-  def errorMsg(pos: SourcePosition, msg: String, offset: Int)(implicit ctx: Context) = {
-    val leastWhitespace = msg.lines.foldLeft(Int.MaxValue) { (minPad, line) =>
-      val lineLength = stripColor(line).length
-      val padding =
-        math.min(math.max(0, ctx.settings.pageWidth.value - offset - lineLength), offset + pos.startColumn)
-
-      if (padding < minPad) padding
-      else minPad
-    }
-
-    msg.lines
-      .map { line => " " * (offset - 1) + "|" + (" " * (leastWhitespace - offset)) + line }
-      .mkString(sys.props("line.separator"))
-  }
-
-  def posStr(pos: SourcePosition, diagnosticLevel: String, message: Message)(implicit ctx: Context) =
-    if (pos.exists) Blue({
-      val file = pos.source.file.toString
-      val errId =
-        if (message.errorId != NoExplanation.ID)
-          s"[E${"0" * (3 - message.errorId.toString.length) + message.errorId}] "
-        else ""
-      val kind =
-        if (message.kind == "") diagnosticLevel
-        else s"${message.kind} $diagnosticLevel"
-      val prefix = s"-- ${errId}${kind}: $file "
-
-      prefix +
-      ("-" * math.max(ctx.settings.pageWidth.value - stripColor(prefix).length, 0))
-    }).show else ""
-
   /** Prints the message with the given position indication. */
   def printMessageAndPos(msg: Message, pos: SourcePosition, diagnosticLevel: String)(implicit ctx: Context): Boolean = {
-    printMessage(posStr(pos, diagnosticLevel, msg))
-    if (pos.exists) {
-      val (srcBefore, srcAfter, offset) = sourceLines(pos)
-      val marker = columnMarker(pos, offset)
-      val err = errorMsg(pos, msg.msg, offset)
-
-      printMessage((srcBefore ::: marker :: err :: srcAfter).mkString("\n"))
-    } else printMessage(msg.msg)
+    printMessage(messageAndPos(msg, pos, diagnosticLevel))
     true
   }
 
   def printExplanation(m: Message)(implicit ctx: Context): Unit = {
-    printMessage(hl"""|
-                      |${Blue("Explanation")}
-                      |${Blue("===========")}""".stripMargin)
-    printMessage(m.explanation)
-    if (m.explanation.lastOption != Some('\n')) printMessage("")
+    printMessage(explanation(m))
   }
 
   override def doReport(m: MessageContainer)(implicit ctx: Context): Unit = {
     val didPrint = m match {
       case m: Error =>
-        val didPrint = printMessageAndPos(m.contained, m.pos, "Error")
+        val didPrint = printMessageAndPos(m.contained, m.pos, diagnosticLevel(m))
         if (ctx.settings.prompt.value) displayPrompt()
         didPrint
       case m: ConditionalWarning if !m.enablingOption.value =>
         false
-      case m: FeatureWarning =>
-        printMessageAndPos(m.contained, m.pos, "Feature Warning")
-      case m: DeprecationWarning =>
-        printMessageAndPos(m.contained, m.pos, "Deprecation Warning")
-      case m: UncheckedWarning =>
-        printMessageAndPos(m.contained, m.pos, "Unchecked Warning")
-      case m: MigrationWarning =>
-        printMessageAndPos(m.contained, m.pos, "Migration Warning")
-      case m: Warning =>
-        printMessageAndPos(m.contained, m.pos, "Warning")
-      case m: Info =>
-        printMessageAndPos(m.contained, m.pos, "Info")
+      case m =>
+        printMessageAndPos(m.contained, m.pos, diagnosticLevel(m))
     }
 
     if (didPrint && ctx.shouldExplain(m))

--- a/src/dotty/tools/dotc/reporting/MessageRendering.scala
+++ b/src/dotty/tools/dotc/reporting/MessageRendering.scala
@@ -1,0 +1,111 @@
+package dotty.tools
+package dotc
+package reporting
+
+import core.Contexts.Context
+import core.Decorators._
+import printing.Highlighting.{Blue, Red}
+import diagnostic.{Message, MessageContainer, NoExplanation}
+import diagnostic.messages._
+import util.SourcePosition
+
+import scala.collection.mutable
+
+trait MessageRendering {
+  def stripColor(str: String): String =
+    str.replaceAll("\u001B\\[[;\\d]*m", "")
+
+  def sourceLines(pos: SourcePosition)(implicit ctx: Context): (List[String], List[String], Int) = {
+    var maxLen = Int.MinValue
+    def render(xs: List[Int]) =
+      xs.map(pos.source.offsetToLine(_))
+        .map { lineNbr =>
+          val prefix = s"${lineNbr + 1} |"
+          maxLen = math.max(maxLen, prefix.length)
+          (prefix, pos.lineContent(lineNbr).stripLineEnd)
+        }
+        .map { case (prefix, line) =>
+          val lnum = Red(" " * math.max(0, maxLen - prefix.length) + prefix)
+          hl"$lnum$line"
+        }
+
+    val (before, after) = pos.beforeAndAfterPoint
+    (render(before), render(after), maxLen)
+  }
+
+  def columnMarker(pos: SourcePosition, offset: Int)(implicit ctx: Context): String = {
+    val prefix = " " * (offset - 1)
+    val whitespace = " " * pos.startColumn
+    val carets = Red {
+      if (pos.startLine == pos.endLine)
+        "^" * math.max(1, pos.endColumn - pos.startColumn)
+      else "^"
+    }
+
+    s"$prefix|$whitespace${carets.show}"
+  }
+
+  def errorMsg(pos: SourcePosition, msg: String, offset: Int)(implicit ctx: Context): String = {
+    val leastWhitespace = msg.lines.foldLeft(Int.MaxValue) { (minPad, line) =>
+      val lineLength = stripColor(line).length
+      val padding =
+        math.min(math.max(0, ctx.settings.pageWidth.value - offset - lineLength), offset + pos.startColumn)
+
+      if (padding < minPad) padding
+      else minPad
+    }
+
+    msg.lines
+      .map { line => " " * (offset - 1) + "|" + (" " * (leastWhitespace - offset)) + line }
+      .mkString(sys.props("line.separator"))
+  }
+
+  def posStr(pos: SourcePosition, diagnosticLevel: String, message: Message)(implicit ctx: Context): String =
+    if (pos.exists) Blue({
+      val file = pos.source.file.toString
+      val errId =
+        if (message.errorId != NoExplanation.ID)
+          s"[E${"0" * (3 - message.errorId.toString.length) + message.errorId}] "
+        else ""
+      val kind =
+        if (message.kind == "") diagnosticLevel
+        else s"${message.kind} $diagnosticLevel"
+      val prefix = s"-- ${errId}${kind}: $file "
+
+      prefix +
+        ("-" * math.max(ctx.settings.pageWidth.value - stripColor(prefix).length, 0))
+    }).show else ""
+
+  def explanation(m: Message)(implicit ctx: Context): String = {
+    val sb = new StringBuilder(hl"""|
+                                    |${Blue("Explanation")}
+                                    |${Blue("===========")}""".stripMargin)
+    sb.append('\n').append(m.explanation)
+    if (m.explanation.lastOption != Some('\n')) sb.append('\n')
+    sb.toString
+  }
+
+  def messageAndPos(msg: Message, pos: SourcePosition, diagnosticLevel: String)(implicit ctx: Context): String = {
+    val sb = mutable.StringBuilder.newBuilder
+    sb.append(posStr(pos, diagnosticLevel, msg)).append('\n')
+    if (pos.exists) {
+      val (srcBefore, srcAfter, offset) = sourceLines(pos)
+      val marker = columnMarker(pos, offset)
+      val err = errorMsg(pos, msg.msg, offset)
+      sb.append((srcBefore ::: marker :: err :: srcAfter).mkString("\n"))
+    } else sb.append(msg.msg)
+    sb.toString
+  }
+
+  def diagnosticLevel(cont: MessageContainer): String = {
+    cont match {
+      case m: Error => "Error"
+      case m: FeatureWarning => "Feature Warning"
+      case m: DeprecationWarning => "Deprecation Warning"
+      case m: UncheckedWarning => "Unchecked Warning"
+      case m: MigrationWarning => "Migration Warning"
+      case m: Warning => "Warning"
+      case m: Info => "Info"
+    }
+  }
+}


### PR DESCRIPTION
I started adaptation of sbt bridge.
Right now I have following output for next samples:
`case class Foo`
results in (with explain):
```
[error] /Users/dmitry/Projects/dotty-example-project/src/main/scala/Main.scala:10:
[error] case class Foo
[error]            ^^^
[error] A case class must have at least one parameter list
[error] Foo must have at least one parameter list, if you would rather
[error] have a singleton representation of Foo, use a "case object".
[error] Or, add an explicit `()' as a parameter list to Foo.
```
results in (without explain):
```
[error] /Users/dmitry/Projects/dotty-example-project/src/main/scala/Main.scala:10:
[error] case class Foo
[error]            ^^^
[error] A case class must have at least one parameter list
```


`println("msg", 123, None)`
results in (with explain):
```
[error] /Users/dmitry/Projects/dotty-example-project/src/main/scala/Main.scala:23:
[error]     println("msg", 123, None)
[error]     ^^^^^^^
[error] none of the overloaded alternatives of method println in object Predef with types
[error]  (x: Any)Unit
[error]  ()Unit
[error] match arguments (String("msg"), Int(123), None.type)
```
results in (without explain):
```
[error] /Users/dmitry/Projects/dotty-example-project/src/main/scala/Main.scala:23:
[error]     println("msg", 123, None)
[error]     ^^^^^^^
[error] none of the overloaded alternatives of method println in object Predef with types
[error]  (x: Any)Unit
[error]  ()Unit
[error] match arguments (String("msg"), Int(123), None.type)
```


```
case class Bar(s: String,
  i: Itn,
  b: Boolean)
```
results in (with explain):
```
[error] /Users/dmitry/Projects/dotty-example-project/src/main/scala/Main.scala:13:
[error]   i: Itn,
[error]      ^^^
[error] not found: type Itn
[error] An identifier for `type Itn` is missing. This means that something
[error] has either been misspelt or you're forgetting an import
```
results in (without explain):
```
[error] /Users/dmitry/Projects/dotty-example-project/src/main/scala/Main.scala:13:
[error]   i: Itn,
[error]      ^^^
[error] not found: type Itn
```

At this moment I would like to receive suggestions about errors output format:
should it be the same as used by dotty or proposed one is acceptable? (I opt for second because of sbt messages decoration)