### PR TITLE
Fix line splitting when point is first col

### DIFF
--- a/src/dotty/tools/dotc/core/Decorators.scala
+++ b/src/dotty/tools/dotc/core/Decorators.scala
@@ -179,7 +179,7 @@ object Decorators {
 
     /** Formatter that adds syntax highlighting to all interpolated values */
     def hl(args: Any*)(implicit ctx: Context): String =
-      new SyntaxFormatter(sc).assemble(args)
+      new SyntaxFormatter(sc).assemble(args).stripMargin
   }
 }
 

--- a/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -29,7 +29,7 @@ extends interfaces.SourcePosition {
     source.lineContent(source.lineToOffset(lineNumber))
 
   def beforeAndAfterPoint: (List[Int], List[Int]) =
-    lineOffsets.partition(_ < point)
+    lineOffsets.partition(_ <= point)
 
   /** The column of the position, starting at 0 */
   def column: Int = source.column(point)


### PR DESCRIPTION
Minor fixes to `SourcePosition` so that errors are reported on the correct line.