### PR TITLE
Fix #1652: Make assertion more robust

### DIFF
--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -2528,6 +2528,9 @@ object Types {
       case _ => false
     }
     
+    /** Is this polytype a higher-kinded type lambda as opposed to a polymorphic?
+     *  method type? Only type lambdas get created with variances, that's how we can tell.
+     */
     def isTypeLambda: Boolean = variances.nonEmpty
 
     /** PolyParam references to all type parameters of this type */

--- a/tests/neg/i1652.scala
+++ b/tests/neg/i1652.scala
@@ -1,0 +1,5 @@
+object Test {
+  val v: Array[Array[Array]] = Array()    // error // error
+  def f[T](w: Array[Array[T]]) = { for (r <- w) () }
+  f(v) // error
+}

--- a/tests/pos/i1652.scala
+++ b/tests/pos/i1652.scala
@@ -1,0 +1,5 @@
+object Test {
+  val v: Array[Array[Array]] = Array()    // happens because of the kindedness error here.
+  def f[T](w: Array[Array[T]]) = { for (r <- w) () }
+  f(v)
+}

--- a/tests/pos/i1652.scala
+++ b/tests/pos/i1652.scala
@@ -1,5 +1,0 @@
-object Test {
-  val v: Array[Array[Array]] = Array()    // happens because of the kindedness error here.
-  def f[T](w: Array[Array[T]]) = { for (r <- w) () }
-  f(v)
-}


### PR DESCRIPTION
An assertion fired giving a false negative after a fuzzing
test which introduced an ill-kinded type argument.

Fixes #1652. Review by @felixmulder?