### PR TITLE
Fix #1638: Don't import when typing a package clause

### DIFF
--- a/src/dotty/tools/dotc/core/Mode.scala
+++ b/src/dotty/tools/dotc/core/Mode.scala
@@ -93,4 +93,9 @@ object Mode {
   val ReadPositions = newMode(16, "ReadPositions")
 
   val PatternOrType = Pattern | Type
+  
+  /** We are elaborating the fully qualified name of a package clause.
+   *  In this case, identifiers should never be imported.
+   */
+  val InPackageClauseName = newMode(17, "InPackageClauseName")
 }

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -95,6 +95,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   def typedIdent(tree: untpd.Ident, pt: Type)(implicit ctx: Context): Tree = track("typedIdent") {
     val refctx = ctx
     val name = tree.name
+    val noImports = ctx.mode.is(Mode.InPackageClauseName)
 
     /** Method is necessary because error messages need to bind to
      *  to typedIdent's context which is lost in nested calls to findRef
@@ -240,7 +241,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
       /** Would import of kind `prec` be not shadowed by a nested higher-precedence definition? */
       def isPossibleImport(prec: Int)(implicit ctx: Context) =
-        prevPrec < prec || prevPrec == prec && (prevCtx.scope eq ctx.scope)
+        !noImports && 
+        (prevPrec < prec || prevPrec == prec && (prevCtx.scope eq ctx.scope))
 
       @tailrec def loop(implicit ctx: Context): Type = {
         if (ctx.scope == null) previous
@@ -1335,7 +1337,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   def typedPackageDef(tree: untpd.PackageDef)(implicit ctx: Context): Tree = track("typedPackageDef") {
-    val pid1 = typedExpr(tree.pid, AnySelectionProto)
+    val pid1 = typedExpr(tree.pid, AnySelectionProto)(ctx.addMode(Mode.InPackageClauseName))
     val pkg = pid1.symbol
     val packageContext =
       if (pkg is Package) ctx.fresh.setOwner(pkg.moduleClass).setTree(tree)

--- a/tests/pos/i1638.scala
+++ b/tests/pos/i1638.scala
@@ -1,0 +1,3 @@
+package util.util
+
+class C


### PR DESCRIPTION
When typing the first identifier of a package clause, disable
imports, as package clauses are never imported.

Fixes #1638. Review by @felixmulder or @smarter?