### PR TITLE
Fix #1639: Changes around implicits and apply methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -286,11 +286,16 @@ abstract class Reporter extends interfaces.ReporterResult {
   }
 
   /** Should this diagnostic not be reported at all? */
-  def isHidden(m: MessageContainer)(implicit ctx: Context): Boolean = ctx.mode.is(Mode.Printing)
+  def isHidden(m: MessageContainer)(implicit ctx: Context): Boolean =
+    ctx.mode.is(Mode.Printing)
 
   /** Does this reporter contain not yet reported errors or warnings? */
   def hasPending: Boolean = false
 
+  /** If this reporter buffers messages, remove and return all buffered messages. */
+  def removeBufferedMessages(implicit ctx: Context): List[MessageContainer] = Nil
+
   /** Issue all error messages in this reporter to next outer one, or make sure they are written. */
-  def flush()(implicit ctx: Context): Unit = {}
+  def flush()(implicit ctx: Context): Unit =
+    removeBufferedMessages.foreach(ctx.reporter.report)
 }

--- a/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
@@ -36,11 +36,9 @@ class StoreReporter(outer: Reporter) extends Reporter {
     }
   }
 
-  override def flush()(implicit ctx: Context) =
-    if (infos != null) {
-      infos.foreach(ctx.reporter.report(_))
-      infos = null
-    }
+  override def removeBufferedMessages(implicit ctx: Context): List[MessageContainer] =
+    if (infos != null) try infos.toList finally infos = null
+    else Nil
 
   override def errorsReported = hasErrors || outer.errorsReported
 }

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -73,8 +73,8 @@ class ReTyper extends Typer {
 
   override def index(trees: List[untpd.Tree])(implicit ctx: Context) = ctx
 
-  override def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType)(fallBack: (Tree, TyperState) => Tree)(implicit ctx: Context): Tree =
-    fallBack(tree, ctx.typerState)
+  override def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType)(fallBack: => Tree)(implicit ctx: Context): Tree =
+    fallBack
 
   override def completeAnnotations(mdef: untpd.MemberDef, sym: Symbol)(implicit ctx: Context): Unit = ()
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1585,17 +1585,33 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
    *  `fallBack`.
    *
    *  1st strategy: Try to insert `.apply` so that the result conforms to prototype `pt`.
+   *                This strategy is not tried if the prototype represents already
+   *                another `.apply` or `.apply()` selection.
    *  2nd strategy: If tree is a select `qual.name`, try to insert an implicit conversion
    *    around the qualifier part `qual` so that the result conforms to the expected type
    *    with wildcard result type.
    */
-  def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType)(fallBack: (Tree, TyperState) => Tree)(implicit ctx: Context): Tree =
-    tryEither { implicit ctx =>
+  def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType)(fallBack: => Tree)(implicit ctx: Context): Tree = {
+
+    /** Is `pt` a prototype of an `apply` selection, or a parameterless function yielding one? */
+    def isApplyProto(pt: Type): Boolean = pt match {
+      case pt: SelectionProto => pt.name == nme.apply
+      case pt: FunProto => pt.args.isEmpty && isApplyProto(pt.resultType)
+      case pt: IgnoredProto => isApplyProto(pt.ignored)
+      case _ => false
+    }
+
+    def tryApply(implicit ctx: Context) = {
       val sel = typedSelect(untpd.Select(untpd.TypedSplice(tree), nme.apply), pt)
       if (sel.tpe.isError) sel else adapt(sel, pt)
-    } { (failedTree, failedState) =>
-      tryInsertImplicitOnQualifier(tree, pt).getOrElse(fallBack(failedTree, failedState))
     }
+
+    def tryImplicit =
+      tryInsertImplicitOnQualifier(tree, pt).getOrElse(fallBack)
+
+    if (isApplyProto(pt)) tryImplicit
+    else tryEither(tryApply(_))((_, _) => tryImplicit) 
+  }
 
   /** If this tree is a select node `qual.name`, try to insert an implicit conversion
    *  `c` around `qual` so that `c(qual).name` conforms to `pt`.
@@ -1688,7 +1704,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
           def hasEmptyParams(denot: SingleDenotation) = denot.info.paramTypess == ListOfNil
           pt match {
             case pt: FunProto =>
-              tryInsertApplyOrImplicit(tree, pt)((_, _) => noMatches)
+              tryInsertApplyOrImplicit(tree, pt)(noMatches)
             case _ =>
               if (altDenots exists (_.info.paramTypess == ListOfNil))
                 typed(untpd.Apply(untpd.TypedSplice(tree), Nil), pt)
@@ -1727,7 +1743,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
           case Apply(_, _) => " more"
           case _ => ""
         }
-        (_, _) => errorTree(tree, em"$methodStr does not take$more parameters")
+        errorTree(tree, em"$methodStr does not take$more parameters")
       }
     }
 
@@ -1946,9 +1962,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
             case pt: FunProto =>
               adaptToArgs(wtp, pt)
             case pt: PolyProto =>
-              tryInsertApplyOrImplicit(tree, pt) {
-                (_, _) => tree // error will be reported in typedTypeApply
-              }
+              tryInsertApplyOrImplicit(tree, pt)(tree) // error will be reported in typedTypeApply
             case _ =>
               if (ctx.mode is Mode.Type) adaptType(tree.tpe)
               else adaptNoArgs(wtp)

--- a/tests/neg/i1639.scala
+++ b/tests/neg/i1639.scala
@@ -1,0 +1,10 @@
+class Bar {
+  implicit def f(implicit x: String): String = x
+
+  implicitly[String](f) // error: divergent (turn -explaintypes on to see it)
+}
+
+class Foo(implicit val bar: String) {
+  def this() = this("baz") // error: none of the alternatives match arguments
+}
+


### PR DESCRIPTION
While trying to fix #1639 I discovered two other areas where things could be improved. The PR contains:

 - Better error messages for nested implicits under -explaintypes
 - More efficient caching of implicit scopes
 - A fix for #1639 which avoids inserting apply methods until SO occurs.

Review by @smarter 