### PR TITLE
Fix #1640: Avoid applications with untyped function parts

### DIFF
--- a/src/dotty/tools/dotc/typer/Applications.scala
+++ b/src/dotty/tools/dotc/typer/Applications.scala
@@ -591,7 +591,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
         }
 
       fun1.tpe match {
-        case ErrorType => tree.withType(ErrorType)
+        case ErrorType => untpd.cpy.Apply(tree)(fun1, tree.args).withType(ErrorType)
         case TryDynamicCallType => typedDynamicApply(tree, pt)
         case _ =>
           tryEither {

--- a/tests/neg/i1640.scala
+++ b/tests/neg/i1640.scala
@@ -1,0 +1,4 @@
+object Test extends App {
+  List(1, 2, 3) map (_ match { case x => x + 1 })
+  List((1, 2)) x (_ match { case (x, z) => x + z }) // error
+}

--- a/tests/neg/i1641.scala
+++ b/tests/neg/i1641.scala
@@ -1,0 +1,8 @@
+package bar { object bippy extends (Double => String) { def apply(x: Double): String = "Double" } }
+package object println { def bippy(x: Int, y: Int, z: Int) = "(Int, Int, Int)" }
+object Test {
+  def main(args: Array[String]): Unit = {
+    println(bar.bippy(5.5))
+    println(bar.bippy(1, 2, 3)) // error
+  }
+}


### PR DESCRIPTION
Avoid applications with untyped function parts even if program is erroneous.
Taking the symbol fails for these applications, which can cause crashes.

Fixes #1640. Review by @felixmulder.