### PR TITLE
Fix #1643: More robust untpd.New

### DIFF
--- a/src/dotty/tools/dotc/ast/untpd.scala
+++ b/src/dotty/tools/dotc/ast/untpd.scala
@@ -282,7 +282,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       case TypedSplice(AppliedTypeTree(tycon, targs)) =>
         (TypedSplice(tycon), targs map (TypedSplice(_)))
       case TypedSplice(tpt1: Tree) =>
-        val argTypes = tpt1.tpe.argTypes
+        val argTypes = tpt1.tpe.argTypesLo
         val tycon = tpt1.tpe.withoutArgs(argTypes)
         def wrap(tpe: Type) = TypeTree(tpe) withPos tpt.pos
         (wrap(tycon), argTypes map wrap)

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -241,7 +241,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
       /** Would import of kind `prec` be not shadowed by a nested higher-precedence definition? */
       def isPossibleImport(prec: Int)(implicit ctx: Context) =
-        !noImports && 
+        !noImports &&
         (prevPrec < prec || prevPrec == prec && (prevCtx.scope eq ctx.scope))
 
       @tailrec def loop(implicit ctx: Context): Type = {
@@ -446,6 +446,14 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
           case _ =>
         }
         checkClassType(tpt1.tpe, tpt1.pos, traitReq = false, stablePrefixReq = true)
+
+        tpt1 match {
+          case AppliedTypeTree(_, targs) =>
+            for (targ @ TypeBoundsTree(_, _) <- targs)
+              ctx.error("type argument must be fully defined", targ.pos)
+          case _ =>
+        }
+
         assignType(cpy.New(tree)(tpt1), tpt1)
         // todo in a later phase: checkInstantiatable(cls, tpt1.pos)
     }

--- a/tests/neg/i1643.scala
+++ b/tests/neg/i1643.scala
@@ -1,0 +1,19 @@
+trait T extends Array {
+  def t1(as: String*): Array[String] = { varargs1(as: _*) } // error
+  def t2(as: String*): Array[String] = { super.varargs1(as: _*) } // error
+}
+class C extends Base_1 { // error
+  def c1(as: String*): Array[String] = { varargs1(as: _*) } // error
+  def c2(as: String*): Array[String] = { super.varargs1(as: _*) } // error
+}
+object Test extends App {
+  val t = new T {}  // error
+  println(t.t1("a", "b").mkString(","))
+  println(t.t2("a", "b").mkString(","))
+  val c = new C {}
+  println(c.c1("a", "b").mkString(","))
+  println(c.c2("a", "b").mkString(","))
+
+  class CC[T]
+  val x = new CC[_]  // error
+}


### PR DESCRIPTION
Also, disallow wildcard arguments in new.

Review by @smarter.
