### PR TITLE
Add error message for illegal literals - Parser.scala:602

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -599,7 +599,7 @@ object Parsers {
           case FALSE                  => false
           case NULL                   => null
           case _                      =>
-            syntaxErrorOrIncomplete("illegal literal")
+            syntaxErrorOrIncomplete(IllegalLiteral())
             null
         })
       }

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -754,4 +754,18 @@ object messages {
            |${"square(ints: _*)          // res1: List[Int] = List(4, 9, 16)"}
            |""".stripMargin
   }
+
+  case class IllegalLiteral()(implicit ctx: Context) extends Message(28) {
+    val kind = "Syntax"
+    val msg = "illegal literal"
+    val explanation =
+      hl"""|Available literals can be divided into the several groups:
+           | - Integer literals: 0, 21, 0xFFFFFFFF, -42L
+           | - Floating Point Literals: 0.0, 1e30f, 3.14159f, 1.0e-100, .1
+           | - Boolean Literals: true, false
+           | - Character Literals: 'a', '\u0041', '\n'
+           | - String Literals: "Hello, World!"
+           | - null
+           |"""
+  }
 }


### PR DESCRIPTION
This pull request is related to the following [issue](https://github.com/lampepfl/dotty/issues/1589)