### PR TITLE
Use inline flag instead of @inline annotation

### DIFF
--- a/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/src/dotty/tools/dotc/ast/Desugar.scala
@@ -615,8 +615,7 @@ object desugar {
    */
   def makeClosure(params: List[ValDef], body: Tree, tpt: Tree = TypeTree(), inlineable: Boolean)(implicit ctx: Context) = {
     var mods = synthetic
-    if (inlineable)
-      mods = mods.withAddedAnnotation(New(ref(defn.InlineAnnotType), Nil).withPos(body.pos))
+    if (inlineable) mods |= Inline
     Block(
       DefDef(nme.ANON_FUN, Nil, params :: Nil, tpt, body).withMods(mods),
       Closure(Nil, Ident(nme.ANON_FUN), EmptyTree))

--- a/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -751,10 +751,7 @@ object SymDenotations {
     //    def isOverridable: Boolean = !!! need to enforce that classes cannot be redefined
     def isSkolem: Boolean = name == nme.SKOLEM
 
-    def isInlineMethod(implicit ctx: Context): Boolean =
-      is(Method, butNot = Accessor) &&
-      !isCompleting &&   // don't force method type; recursive inlines are ignored anyway.
-      hasAnnotation(defn.InlineAnnot)
+    def isInlineMethod(implicit ctx: Context): Boolean = is(InlineMethod, butNot = Accessor) 
 
     // ------ access to related symbols ---------------------------------
 

--- a/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -474,7 +474,7 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table, posUnpickle
         sym.completer.withDecls(newScope)
         forkAt(templateStart).indexTemplateParams()(localContext(sym))
       }
-      else if (annots.exists(_.symbol == defn.InlineAnnot))
+      else if (sym.isInlineMethod)
         sym.addAnnotation(LazyBodyAnnotation { ctx0 =>
           implicit val ctx: Context = localContext(sym)(ctx0).addMode(Mode.ReadPositions)
             // avoids space leaks by not capturing the current context

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -521,7 +521,6 @@ class Namer { typer: Typer =>
     mergeCompanionDefs()
     val ctxWithStats = (ctx /: stats) ((ctx, stat) => indexExpanded(stat)(ctx))
     createCompanionLinks(ctxWithStats)
-    //stats foreach enterAnnotations
     ctxWithStats
   }
 

--- a/src/dotty/tools/dotc/typer/Namer.scala
+++ b/src/dotty/tools/dotc/typer/Namer.scala
@@ -570,13 +570,12 @@ class Namer { typer: Typer =>
           denot.addAnnotation(ann)
           if (cls == defn.InlineAnnot && denot.is(Method, butNot = Accessor))
             denot.setFlag(Inline)
-          if (denot.isInlineMethod) addInlineInfo(denot, original)
         }
       case _ =>
     }
 
-    private def addInlineInfo(denot: SymDenotation, original: untpd.Tree) = original match {
-      case original: untpd.DefDef =>
+    private def addInlineInfo(denot: SymDenotation) = original match {
+      case original: untpd.DefDef if denot.isInlineMethod =>
         Inliner.registerInlineInfo(
             denot,
             implicit ctx => typedAheadExpr(original).asInstanceOf[tpd.DefDef].rhs
@@ -589,6 +588,7 @@ class Namer { typer: Typer =>
      */
     def completeInCreationContext(denot: SymDenotation): Unit = {
       addAnnotations(denot)
+      addInlineInfo(denot)
       denot.info = typeSig(denot.symbol)
       Checking.checkWellFormed(denot.symbol)
     }

--- a/src/dotty/tools/dotc/typer/Typer.scala
+++ b/src/dotty/tools/dotc/typer/Typer.scala
@@ -1142,7 +1142,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     }
     val vdef1 = assignType(cpy.ValDef(vdef)(name, tpt1, rhs1), sym)
     if (sym.is(Inline, butNot = DeferredOrParamAccessor))
-      checkInlineConformant(rhs1, "right-hand side of inline value")
+      checkInlineConformant(rhs1, em"right-hand side of inline $sym")
     patchIfLazy(vdef1)
     vdef1
   }
@@ -1176,8 +1176,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     val rhs1 = typedExpr(ddef.rhs, tpt1.tpe)(rhsCtx)
 
     // Overwrite inline body to make sure it is not evaluated twice
-    if (sym.hasAnnotation(defn.InlineAnnot))
-      Inliner.registerInlineInfo(sym, _ => rhs1)
+    if (sym.isInlineMethod) Inliner.registerInlineInfo(sym, _ => rhs1)
 
     if (sym.isAnonymousFunction) {
       // If we define an anonymous function, make sure the return type does not


### PR DESCRIPTION
Convert `@inline` annotations to `inline` flags, not the
other way round as was done before.

This is the first step to fixing #1647, which requires a reorganization how
annotations are handled. 

I wanted to get the irregular treatement of inline annotations out of the way before trying this. 

Review by @smarter. Feel free to cherry-pick for getting the new repo structure to work.
