### PR TITLE
Resync copy of the type diagram in docs

### DIFF
--- a/docs/docs/internals/type-system.md
+++ b/docs/docs/internals/type-system.md
@@ -13,6 +13,8 @@ A type which inherits `TypeProxy` is a proxy for another type accessible using
 the `underlying` method, other types are called _ground_ types and inherit
 `CachedGroundType` or `UncachedGroundType`.
 
+Here's a diagram, copied from [dotty/tools/dotc/core/Types.scala][1]:
+
 ```
 Type -+- ProxyType --+- NamedType ----+--- TypeRef
       |              |                 \
@@ -22,19 +24,22 @@ Type -+- ProxyType --+- NamedType ----+--- TypeRef
       |              |                +--- SuperType
       |              |                +--- ConstantType
       |              |                +--- MethodParam
-      |              |                +--- RefinedThis
+      |              |                +----RecThis
+      |              |                +--- SkolemType
       |              +- PolyParam
-      |              +- RefinedType
+      |              +- RefinedOrRecType -+-- RefinedType
+      |              |                   -+-- RecType
+      |              +- HKApply
       |              +- TypeBounds
       |              +- ExprType
       |              +- AnnotatedType
       |              +- TypeVar
+      |              +- PolyType
       |
       +- GroundType -+- AndType
                      +- OrType
                      +- MethodType -----+- ImplicitMethodType
                      |                  +- JavaMethodType
-                     +- PolyType
                      +- ClassInfo
                      |
                      +- NoType

--- a/src/dotty/tools/dotc/core/Types.scala
+++ b/src/dotty/tools/dotc/core/Types.scala
@@ -73,6 +73,8 @@ object Types {
    *                       +- NoPrefix
    *                       +- ErrorType
    *                       +- WildcardType
+   *
+   *  Note: please keep in sync with copy in `docs/docs/internals/type-system.md`.
    */
   abstract class Type extends DotClass with Hashable with printing.Showable {
 


### PR DESCRIPTION
Also add a note that the two diagrams should be kept in sync, both ways,
so there's a chance that the copies are kept in sync.

Alternatively one could drop a copy.