### PR TITLE
Add annotations phase

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -32,7 +32,7 @@ object Trees {
   /** Property key for trees with documentation strings attached */
   val DocComment = new Property.Key[Comment]
 
-   @sharable private var nextId = 0 // for debugging
+  @sharable private var nextId = 0 // for debugging
 
   type LazyTree = AnyRef     /* really: Tree | Lazy[Tree] */
   type LazyTreeList = AnyRef /* really: List[Tree] | Lazy[List[Tree]] */

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -422,6 +422,13 @@ object Contexts {
     final def withOwner(owner: Symbol): Context =
       if (owner ne this.owner) fresh.setOwner(owner) else this
 
+    final def withProperty[T](key: Key[T], value: Option[T]): Context =
+      if (property(key) == value) this
+      else value match {
+        case Some(v) => fresh.setProperty(key, v)
+        case None => fresh.dropProperty(key)
+      }
+
     override def toString = {
       def iinfo(implicit ctx: Context) = if (ctx.importInfo == null) "" else i"${ctx.importInfo.selectors}%, %"
       "Context(\n" +
@@ -469,6 +476,9 @@ object Contexts {
 
     def setProperty[T](key: Key[T], value: T): this.type =
       setMoreProperties(moreProperties.updated(key, value))
+
+    def dropProperty(key: Key[_]): this.type =
+      setMoreProperties(moreProperties - key)
 
     def setPhase(pid: PhaseId): this.type = setPeriod(Period(runId, pid))
     def setPhase(phase: Phase): this.type = setPeriod(Period(runId, phase.start, phase.end))

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -422,9 +422,11 @@ object Contexts {
     final def withOwner(owner: Symbol): Context =
       if (owner ne this.owner) fresh.setOwner(owner) else this
 
-    override def toString =
+    override def toString = {
+      def iinfo(implicit ctx: Context) = if (ctx.importInfo == null) "" else i"${ctx.importInfo.selectors}%, %"
       "Context(\n" +
-      (outersIterator map ( ctx => s"  owner = ${ctx.owner}, scope = ${ctx.scope}") mkString "\n")
+      (outersIterator map ( ctx => s"  owner = ${ctx.owner}, scope = ${ctx.scope}, import = ${iinfo(ctx)}") mkString "\n")
+    }
   }
 
   /** A condensed context provides only a small memory footprint over

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -216,8 +216,8 @@ object Contexts {
             else if (isNonEmptyScopeContext) scope.implicitDecls
             else Nil
           val outerImplicits =
-            if (isImportContext && importInfo.hiddenRoot.exists)
-              outer.implicits exclude importInfo.hiddenRoot
+            if (isImportContext && importInfo.unimported.exists)
+              outer.implicits exclude importInfo.unimported
             else
               outer.implicits
           if (implicitRefs.isEmpty) outerImplicits

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -650,6 +650,13 @@ class Definitions {
   def isTupleClass(cls: Symbol) = isVarArityClass(cls, tpnme.Tuple)
   def isProductClass(cls: Symbol) = isVarArityClass(cls, tpnme.Product)
 
+  val predefClassNames: Set[Name] =
+    Set("Predef$", "DeprecatedPredef", "LowPriorityImplicits").map(_.toTypeName)
+
+  /** Is `cls` the predef module class, or a class inherited by Predef? */
+  def isPredefClass(cls: Symbol) =
+    (cls.owner eq ScalaPackageClass) && predefClassNames.contains(cls.name)
+
   val StaticRootImportFns = List[() => TermRef](
     () => JavaLangPackageVal.termRef,
     () => ScalaPackageVal.termRef

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -26,7 +26,10 @@ trait Phases {
 
   def phasesStack: List[Phase] =
     if ((this eq NoContext) || !phase.exists) Nil
-    else phase :: outersIterator.dropWhile(_.phase == phase).next.phasesStack
+    else {
+      val rest = outersIterator.dropWhile(_.phase == phase)
+      phase :: (if (rest.hasNext) rest.next.phasesStack else Nil)
+    }
 
   /** Execute `op` at given phase */
   def atPhase[T](phase: Phase)(op: Context => T): T =

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -614,14 +614,12 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       (sym.allOverriddenSymbols exists (_ is TypeParam))
 
   override def toText(sym: Symbol): Text = {
-    if (sym.isImport) {
-      def importString(tree: untpd.Tree) = s"import ${tree.show}"
+    if (sym.isImport)
       sym.infoOrCompleter match {
-        case info: Namer#Completer => return importString(info.original)
-        case info: ImportType => return importString(info.expr)
+        case info: Namer#Completer => return info.original.show
+        case info: ImportType => return s"import $info.expr.show"
         case _ =>
       }
-    }
     if (sym.is(ModuleClass))
       kindString(sym) ~~ (nameString(sym.name.stripModuleClassSuffix) + idString(sym))
     else

--- a/compiler/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
+++ b/compiler/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
@@ -6,7 +6,7 @@ import java.io.{
   File, PrintWriter, PrintStream, StringWriter, Writer, OutputStream,
   ByteArrayOutputStream => ByteOutputStream
 }
-import java.lang.{Class, ClassLoader}
+import java.lang.{Class, ClassLoader, Thread, System, StringBuffer}
 import java.net.{URL, URLClassLoader}
 
 import scala.collection.immutable.ListSet

--- a/compiler/src/dotty/tools/dotc/repl/InterpreterLoop.scala
+++ b/compiler/src/dotty/tools/dotc/repl/InterpreterLoop.scala
@@ -4,7 +4,7 @@ package repl
 
 import java.io.{BufferedReader, File, FileReader, PrintWriter}
 import java.io.IOException
-import java.lang.{ClassLoader, System}
+import java.lang.{ClassLoader, System, Thread}
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.Duration
 import reporting.Reporter

--- a/compiler/src/dotty/tools/dotc/transform/CollectEntryPoints.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CollectEntryPoints.scala
@@ -9,7 +9,6 @@ import dotty.tools.dotc.core.Symbols.NoSymbol
 import scala.annotation.tailrec
 import dotty.tools.dotc.core._
 import Symbols._
-import scala.Some
 import dotty.tools.dotc.transform.TreeTransforms.{NXTransformations, TransformerInfo, TreeTransform, TreeTransformer}
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Contexts.Context

--- a/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -44,6 +44,12 @@ class FrontEnd extends Phase {
     typr.println("entered: " + unit.source)
   }
 
+  def enterAnnotations(implicit ctx: Context) = monitor("annotating") {
+    val unit = ctx.compilationUnit
+    ctx.typer.annotate(unit.untpdTree :: Nil)
+    typr.println("annotated: " + unit.source)
+  }
+
   def typeCheck(implicit ctx: Context) = monitor("typechecking") {
     val unit = ctx.compilationUnit
     unit.tpdTree = ctx.typer.typedExpr(unit.untpdTree)
@@ -69,8 +75,9 @@ class FrontEnd extends Phase {
     }
     unitContexts foreach (parse(_))
     record("parsedTrees", ast.Trees.ntrees)
-    unitContexts foreach (enterSyms(_))
-    unitContexts foreach (typeCheck(_))
+    unitContexts.foreach(enterSyms(_))
+    unitContexts.foreach(enterAnnotations(_))
+    unitContexts.foreach(typeCheck(_))
     record("total trees after typer", ast.Trees.ntrees)
     unitContexts.map(_.compilationUnit).filterNot(discardAfterTyper)
   }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -570,10 +570,10 @@ class Namer { typer: Typer =>
    *  that are already added to the symbol.
    */
   def addAnnotations(sym: Symbol, stat: MemberDef)(implicit ctx: Context) = {
-    // (1) The context in which an annotation of a top-evel class or module is evaluated
+    // (1) The context in which an annotation of a top-level class or module is evaluated
     // is the closest enclosing context which has the enclosing package as owner.
     // (2) The context in which an annotation for any other symbol is evaluated is the
-    // closest enclosing context which has the owner of the class enclpsing the symbol as owner.
+    // closest enclosing context which has the owner of the class enclosing the symbol as owner.
     // E.g in
     //
     //     package p

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -72,6 +72,7 @@ class ReTyper extends Typer {
   override def localTyper(sym: Symbol) = this
 
   override def index(trees: List[untpd.Tree])(implicit ctx: Context) = ctx
+  override def annotate(trees: List[untpd.Tree])(implicit ctx: Context) = ()
 
   override def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType)(fallBack: (Tree, TyperState) => Tree)(implicit ctx: Context): Tree =
     fallBack(tree, ctx.typerState)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -192,12 +192,12 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
             }
 
             def selection(name: Name) =
-              if (unimported.contains(imp.site.termSymbol))
-                NoType
-              else if (imp.sym.isCompleting) {
+              if (imp.sym.isCompleting) {
                 ctx.warning(i"cyclic ${imp.sym}, ignored", tree.pos)
                 NoType
               }
+              else if (unimported.nonEmpty && unimported.contains(imp.site.termSymbol))
+                NoType
               else {
                 // Pass refctx so that any errors are reported in the context of the
                 // reference instead of the
@@ -588,7 +588,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   def typedBlockStats(stats: List[untpd.Tree])(implicit ctx: Context): (Context, List[tpd.Tree]) =
-    (index(stats), typedStats(stats, ctx.owner))
+    (indexAndAnnotate(stats), typedStats(stats, ctx.owner))
 
   def typedBlock(tree: untpd.Block, pt: Type)(implicit ctx: Context) = track("typedBlock") {
     val (exprCtx, stats1) = typedBlockStats(tree.stats)
@@ -1070,7 +1070,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
   def typedPolyTypeTree(tree: untpd.PolyTypeTree)(implicit ctx: Context): Tree = track("typedPolyTypeTree") {
     val PolyTypeTree(tparams, body) = tree
-    index(tparams)
+    indexAndAnnotate(tparams)
     val tparams1 = tparams.mapconserve(typed(_).asInstanceOf[TypeDef])
     val body1 = typedType(tree.body)
     assignType(cpy.PolyTypeTree(tree)(tparams1, body1), tparams1, body1)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1138,7 +1138,11 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     lazy val annotCtx = {
       val c = ctx.outersIterator.dropWhile(_.owner == sym).next
       c.property(ExprOwner) match {
-        case Some(exprOwner) if c.owner.isClass => c.exprContext(mdef, exprOwner)
+        case Some(exprOwner) if c.owner.isClass =>
+          // We need to evaluate annotation arguments in an expression context, since
+          // classes defined in a such arguments should not be entered into the
+          // enclosing class.
+          c.exprContext(mdef, exprOwner)
         case None => c
       }
     }

--- a/compiler/src/dotty/tools/dotc/util/Chars.scala
+++ b/compiler/src/dotty/tools/dotc/util/Chars.scala
@@ -6,7 +6,6 @@ package dotty.tools.dotc
 package util
 
 import scala.annotation.switch
-import java.lang.{ Character => JCharacter }
 import java.lang.{Character => JCharacter}
 import java.lang.Character.LETTER_NUMBER
 import java.lang.Character.LOWERCASE_LETTER
@@ -66,16 +65,16 @@ object Chars {
 
   /** Can character start an alphanumeric Scala identifier? */
   def isIdentifierStart(c: Char): Boolean =
-    (c == '_') || (c == '$') || Character.isUnicodeIdentifierStart(c)
+    (c == '_') || (c == '$') || JCharacter.isUnicodeIdentifierStart(c)
 
   /** Can character form part of an alphanumeric Scala identifier? */
   def isIdentifierPart(c: Char) =
-    (c == '$') || Character.isUnicodeIdentifierPart(c)
+    (c == '$') || JCharacter.isUnicodeIdentifierPart(c)
 
   /** Is character a math or other symbol in Unicode?  */
   def isSpecial(c: Char) = {
-    val chtp = Character.getType(c)
-    chtp == Character.MATH_SYMBOL.toInt || chtp == Character.OTHER_SYMBOL.toInt
+    val chtp = JCharacter.getType(c)
+    chtp == JCharacter.MATH_SYMBOL.toInt || chtp == JCharacter.OTHER_SYMBOL.toInt
   }
 
   private final val otherLetters = Set[Char]('\u0024', '\u005F')  // '$' and '_'

--- a/tests/neg/i1647.scala
+++ b/tests/neg/i1647.scala
@@ -1,0 +1,4 @@
+class ann {
+  @ann({ def baz })  // error: missing return type
+  def foo(): Unit
+}

--- a/tests/neg/i1649.scala
+++ b/tests/neg/i1649.scala
@@ -1,0 +1,2 @@
+class Two[@A A] // error
+

--- a/tests/neg/nopredef.scala
+++ b/tests/neg/nopredef.scala
@@ -1,0 +1,5 @@
+import Predef.{assert => _}
+
+object Test {
+  assert("asdf" == "asdf") // error: not found assert
+}


### PR DESCRIPTION
New phase for entering annotations

If we want to do annotation macros right, we need to add
annotations before completing definitions. This commit achieves
that by adding a new "phase" between index and typecheck.

Also: Fixes #1647 be tweaking the context in which we evaluate annotation argumnents

Review by @liufengyun or @olafurpg 