### PR TITLE
Fix #1664: Refine isOuterRef condition

### DIFF
--- a/tests/pos/i1664.scala
+++ b/tests/pos/i1664.scala
@@ -1,0 +1,12 @@
+object test {
+  def f[a](x: a) = {
+    def print = x
+    class A {
+      def f() = {
+        class B { def h = print }
+        new B
+      }
+      f()
+    }
+  }
+}


### PR DESCRIPTION
We forgot the case where a hoistable method can still
refer to free variables that have to be passed using
outer pointers.

Fixes #1664. Review by @DarkDimius ?