### PR TITLE
Add an error message for incorrect sequence wildcard position Parsers.scala:1425 and Parsers.scala:1079

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1076,7 +1076,7 @@ object Parsers {
           val uscoreStart = in.skipToken()
           if (isIdent(nme.raw.STAR)) {
             in.nextToken()
-            if (in.token != RPAREN) syntaxError("`_*' can be used only for last argument", uscoreStart)
+            if (in.token != RPAREN) syntaxError(SeqWildcardPatternPos(), uscoreStart)
             Typed(t, atPos(uscoreStart) { Ident(tpnme.WILDCARD_STAR) })
           } else {
             syntaxErrorOrIncomplete(IncorrectRepeatedParameterSyntax())
@@ -1424,7 +1424,7 @@ object Parsers {
         // `x: _*' is parsed in `ascription'
         if (isIdent(nme.raw.STAR)) {
           in.nextToken()
-          if (in.token != RPAREN) syntaxError("`_*' can be used only for last argument", wildIndent.pos)
+          if (in.token != RPAREN) syntaxError(SeqWildcardPatternPos(), wildIndent.pos)
           atPos(wildIndent.pos) { Ident(tpnme.WILDCARD_STAR) }
         } else wildIndent
       case LPAREN =>

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -789,4 +789,27 @@ object messages {
     val msg = "unreachable code"
     val explanation = ""
   }
+
+  case class SeqWildcardPatternPos()(implicit ctx: Context) extends Message(31) {
+    val kind = "Syntax"
+    val msg = "`_*' can be used only for last argument"
+    val explanation = {
+      val code =
+        """def sumOfTheFirstTwo(list: List[Int]): Int = list match {
+          |  case List(first, second, x:_*) => first + second
+          |  case _ => 0
+          |}"""
+      hl"""|Sequence wildcard pattern is expected at the end of an argument list.
+           |This pattern matches any remaining elements in a sequence.
+           |Consider the following example:
+           |
+           |$code
+           |
+           |Calling:
+           |
+           |${"sumOfTheFirstTwo(List(1, 2, 10))"}
+           |
+           |would give 3 as a result"""
+    }
+  }
 }


### PR DESCRIPTION
This pull request is related to the following [issue](https://github.com/lampepfl/dotty/issues/1589).