### PR TITLE
Clarify error for unbound identifiers and add/fix a few comments

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -151,7 +151,7 @@ object Parsers {
 /* ------------- ERROR HANDLING ------------------------------------------- */
 
     /** The offset of the last time when a statement on a new line was definitely
-     *  encountered in the current scope or an outer scope\
+     *  encountered in the current scope or an outer scope.
      */
     private var lastStatOffset = -1
 
@@ -505,7 +505,7 @@ object Parsers {
       if (t1 ne t) t1 else dotSelectors(selector(t), finish)
     }
 
-    /** Dotelectors ::= { `.' ident()
+    /** DotSelectors ::= { `.' ident()
      *
      *  Accept `.' separated identifiers acting as a selectors on given tree `t`.
      *  @param finish   An alternative parse in case the token following a `.' is not an identifier.
@@ -521,7 +521,7 @@ object Parsers {
      *              |  [Ident `.'] this
      *
      *  @param thisOK   If true, [Ident `.'] this is acceptable as the path.
-     *                  If false, another selection is required aftre the `this`.
+     *                  If false, another selection is required after the `this`.
      *  @param finish   An alternative parse in case the token following a `.' is not an identifier.
      *                  If the alternative does not apply, its tree argument is returned unchanged.
      */

--- a/src/dotty/tools/dotc/reporting/diagnostic/Message.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/Message.scala
@@ -31,7 +31,7 @@ abstract class Message(val errorId: Int) { self =>
     * > expected: String
     * > found:    Int
     *
-    * This message wil be placed underneath the position given by the enclosing
+    * This message will be placed underneath the position given by the enclosing
     * `MessageContainer`
     */
   def msg: String

--- a/src/dotty/tools/dotc/reporting/diagnostic/Message.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/Message.scala
@@ -18,7 +18,8 @@ object Message {
 /** A `Message` contains all semantic information necessary to easily
   * comprehend what caused the message to be logged. Each message can be turned
   * into a `MessageContainer` which contains the log level and can later be
-  * consumed by a subclass of `Reporter`.
+  * consumed by a subclass of `Reporter`. However, the error position is only
+  * part of `MessageContainer`, not `Message`.
   *
   * @param errorId a unique number identifying the message, this will later be
   *                used to reference documentation online

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -194,12 +194,14 @@ object messages {
 
   case class MissingIdent(tree: untpd.Ident, treeKind: String, name: String)(implicit ctx: Context)
   extends Message(6) {
-    val kind = "Missing Identifier"
+    val kind = "Unbound Identifier"
     val msg = em"not found: $treeKind$name"
 
     val explanation = {
-      hl"""|An identifier for `$treeKind$name` is missing. This means that something
-           |has either been misspelt or you're forgetting an import"""
+      hl"""|The identifier for `$treeKind$name` is not bound, that is,
+           |no declaration for this identifier can be found.
+           |That can happen for instance if $name or its declaration has either been
+           |misspelt, or if you're forgetting an import"""
     }
   }
 

--- a/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -184,7 +184,7 @@ object messages {
 
       val caseDef = s"case $pat$guard => $body"
 
-      hl"""|For each ${"case"} bound variable names  have to be unique. In:
+      hl"""|For each ${"case"} bound variable names have to be unique. In:
            |
            |$caseDef
            |


### PR DESCRIPTION
I think "Missing identifier" is not a good error, @odersky agreed and suggested "No definition for `a` was found." (https://github.com/lampepfl/dotty/issues/1683#issuecomment-259480649), and I replaced "definition" with "declaration".

I also tried improving the explanation.

Also a few other minor issues in separate commits (I'd PR them separately but IIUC that'd be noise to you).