### PR TITLE
Add colon after method type in printer

### DIFF
--- a/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -159,10 +159,14 @@ class PlainPrinter(_ctx: Context) extends Printer {
         "<noprefix>"
       case tp: MethodType =>
         def paramText(name: TermName, tp: Type) = toText(name) ~ ": " ~ toText(tp)
+        def typeColon(resultType: Type): Text = resultType match {
+          case _: TypeRef => ": "
+          case _ => "" // eg. methods with implicit parameters go here in first pass
+        }
         changePrec(GlobalPrec) {
           (if (tp.isImplicit) "(implicit " else "(") ~
             Text((tp.paramNames, tp.paramTypes).zipped map paramText, ", ") ~
-          ")" ~ toText(tp.resultType)
+          ")" ~ typeColon(tp.resultType) ~ toText(tp.resultType)
         }
       case tp: ExprType =>
         changePrec(GlobalPrec) { "=> " ~ toText(tp.resultType) }

--- a/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
+++ b/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
@@ -685,7 +685,12 @@ class CompilingInterpreter(
         val varType = string2code(req.typeOf(varName))
         val fullPath = req.fullPath(varName)
 
-        s""" + "$prettyName: $varType = " + {
+        val varOrVal = statement match {
+          case v: ValDef if v.mods is Flags.Mutable => "var"
+          case _ => "val"
+        }
+
+        s""" + "$varOrVal $prettyName: $varType = " + {
            |  if ($fullPath.asInstanceOf[AnyRef] != null) {
            |    (if ($fullPath.toString().contains('\\n')) "\\n" else "") +
            |      $fullPath.toString() + "\\n"
@@ -736,7 +741,7 @@ class CompilingInterpreter(
 
       override def resultExtractionCode(req: Request, code: PrintWriter): Unit = {
         if (!defDef.mods.is(Flags.AccessFlags))
-          code.print("+\"" + string2code(defDef.name.toString) + ": " +
+          code.print("+\"def " + string2code(defDef.name.toString) +
             string2code(req.typeOf(defDef.name)) + "\\n\"")
       }
     }


### PR DESCRIPTION
Changes
```scala
scala> def id(x: 4): 4 = x
id: (x: Int(4))Int(4)
```
to
```scala
scala> def id(x: 4): 4 = x
id: (x: Int(4)): Int(4)
```

Contrary to the github markdown, the REPL would not highlight the method type w/o this change.