### PR TITLE
Fix #1648: don't define companion object for java.lang.Object

### DIFF
--- a/src/dotty/tools/dotc/core/Definitions.scala
+++ b/src/dotty/tools/dotc/core/Definitions.scala
@@ -194,6 +194,13 @@ class Definitions {
     val cls = ctx.requiredClass("java.lang.Object")
     assert(!cls.isCompleted, "race for completing java.lang.Object")
     cls.info = ClassInfo(cls.owner.thisType, cls, AnyClass.typeRef :: Nil, newScope)
+
+    // The companion object doesn't really exist, `NoType` is the general
+    // technique to do that. Here we need to set it before completing
+    // attempt to load Object's classfile, which causes issue #1648.
+    val companion = JavaLangPackageVal.info.decl(nme.Object).symbol
+    companion.info = NoType // to indicate that it does not really exist
+
     completeClass(cls)
   }
   def ObjectType = ObjectClass.typeRef

--- a/tests/neg/i1648.scala
+++ b/tests/neg/i1648.scala
@@ -1,0 +1,1 @@
+class Foo { Object[A] } // error // error


### PR DESCRIPTION
Fix #1648: `java.lang.Object` has no static methods, there's no need to define module object for it.