### PR TITLE
Fix #1619: Reduce collision rate in NameTable

### DIFF
--- a/src/dotty/tools/dotc/core/Names.scala
+++ b/src/dotty/tools/dotc/core/Names.scala
@@ -221,13 +221,15 @@ object Names {
   private var size = 1
 
   /** The hash of a name made of from characters cs[offset..offset+len-1].  */
-  private def hashValue(cs: Array[Char], offset: Int, len: Int): Int =
-    if (len > 0)
-      (len * (41 * 41 * 41) +
-        cs(offset) * (41 * 41) +
-        cs(offset + len - 1) * 41 +
-        cs(offset + (len >> 1)))
-    else 0
+  private def hashValue(cs: Array[Char], offset: Int, len: Int): Int = {
+    var i = offset
+    var hash = 0
+    while (i < len) {
+      hash = 31 * hash + cs(i)
+      i += 1
+    }
+    hash
+  }
 
   /** Is (the ASCII representation of) name at given index equal to
    *  cs[offset..offset+len-1]?


### PR DESCRIPTION
The fix is consistent with Scalac: https://github.com/scala/scala/pull/5474/files.