### PR TITLE
Change docker image to use lampepfl one

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 pipeline:
   test:
-    image: felixmulder/dotty:0.1
+    image: lampepfl/dotty:0.1
     pull: true
     commands:
       - ln -s /var/cache/drone/scala-scala scala-scala


### PR DESCRIPTION
Shouldn't be using things that are under my user, instead use the lampepfl organization for docker.