### PR TITLE
Make tests depend on environment variables for classpath jars

### DIFF
--- a/compiler/test/dotc/tests.scala
+++ b/compiler/test/dotc/tests.scala
@@ -1,5 +1,6 @@
 package dotc
 
+import dotty.Jars
 import dotty.tools.dotc.CompilerTest
 import org.junit.{Before, Test}
 
@@ -32,18 +33,28 @@ class tests extends CompilerTest {
   )
 
   val classPath = {
-    val paths = List(
-      "../library/target/scala-2.11/dotty-library_2.11-0.1-SNAPSHOT.jar",
-      "./target/scala-2.11/dotty-compiler_2.11-0.1-SNAPSHOT.jar",
-      "../interfaces/target/dotty-interfaces-0.1-SNAPSHOT.jar"
-    ).map { p =>
+    val paths = Jars.dottyTestDeps map { p =>
       val file = new JFile(p)
       assert(
         file.exists,
-        s"""File "$p" couldn't be found. Run `packageAll` from build tool before testing"""
+        s"""|File "$p" couldn't be found. Run `packageAll` from build tool before
+            |testing.
+            |
+            |If running without sbt, test paths need to be setup environment variables:
+            |
+            | - DOTTY_LIBRARY
+            | - DOTTY_COMPILER
+            | - DOTTY_INTERFACES
+            | - DOTTY_EXTRAS
+            |
+            |Where these all contain locations, except extras which is a comma
+            |separated list of jars.
+            |
+            |When compiling with eclipse, you need the sbt-interfaces jar, but
+            |it in extras."""
       )
       file.getAbsolutePath
-    }.mkString(":")
+    } mkString (":")
 
     List("-classpath", paths)
   }
@@ -338,9 +349,15 @@ class tests extends CompilerTest {
   @Test def tasty_tests = compileDir(testsDir, "tasty", testPickling)
 
   @Test def tasty_bootstrap = {
+    val f = new JFile(getClass.getProtectionDomain.getCodeSource.getLocation.getPath)
+    println(f)
+    println(System.getProperty("java.class.path"))
+
+
     val opt = List("-priorityclasspath", defaultOutputDir, "-Ylog-classpath")
     // first compile dotty
     compileDir(dottyDir, ".", List("-deep", "-Ycheck-reentrant", "-strict"))(allowDeepSubtypes)
+
 
     compileDir(dottyDir, "tools", opt)
     compileDir(toolsDir, "dotc", opt)

--- a/compiler/test/dotty/Jars.scala
+++ b/compiler/test/dotty/Jars.scala
@@ -1,0 +1,22 @@
+package dotty
+
+/** Jars used when compiling test, defaults to sbt locations */
+object Jars {
+  val dottyLib: String = sys.env.get("DOTTY_LIB") getOrElse {
+    "../library/target/scala-2.11/dotty-library_2.11-0.1-SNAPSHOT.jar"
+  }
+
+  val dottyCompiler: String = sys.env.get("DOTTY_COMPILER") getOrElse {
+    "./target/scala-2.11/dotty-compiler_2.11-0.1-SNAPSHOT.jar"
+  }
+
+  val dottyInterfaces: String = sys.env.get("DOTTY_INTERFACE") getOrElse {
+    "../interfaces/target/dotty-interfaces-0.1-SNAPSHOT.jar"
+  }
+
+  val dottyExtras: List[String] = sys.env.get("DOTTY_EXTRAS")
+    .map(_.split(",").toList).getOrElse(Nil)
+
+  val dottyTestDeps: List[String] =
+    dottyLib :: dottyCompiler :: dottyInterfaces :: dottyExtras
+}

--- a/compiler/test/dotty/tools/DottyTest.scala
+++ b/compiler/test/dotty/tools/DottyTest.scala
@@ -23,10 +23,7 @@ class DottyTest extends ContextEscapeDetection{
     import base.settings._
     val ctx = base.initialCtx.fresh
     ctx.setSetting(ctx.settings.encoding, "UTF8")
-    ctx.setSetting(
-      ctx.settings.classpath,
-      "../library/target/scala-2.11/dotty-library_2.11-0.1-SNAPSHOT.jar"
-    )
+    ctx.setSetting(ctx.settings.classpath, Jars.dottyLib)
     // when classpath is changed in ctx, we need to re-initialize to get the
     // correct classpath from PathResolver
     base.initialize()(ctx)

--- a/compiler/test/dotty/tools/ShowClassTests.scala
+++ b/compiler/test/dotty/tools/ShowClassTests.scala
@@ -1,4 +1,5 @@
-package dotty.tools
+package dotty
+package tools
 
 import dotc.core._
 import dotc.core.Contexts._
@@ -18,8 +19,7 @@ class ShowClassTests extends DottyTest {
     ctx.setSetting(ctx.settings.encoding, "UTF8")
     ctx.setSetting(
       ctx.settings.classpath,
-      "../library/target/scala-2.11/dotty-library_2.11-0.1-SNAPSHOT.jar" +
-      ":../interfaces/target/dotty-interfaces-0.1-SNAPSHOT.jar"
+      Jars.dottyLib + ":" + Jars.dottyInterfaces
     )
     base.initialize()(ctx)
     ctx

--- a/compiler/test/dotty/tools/dotc/EntryPointsTest.scala
+++ b/compiler/test/dotty/tools/dotc/EntryPointsTest.scala
@@ -1,4 +1,5 @@
-package dotty.tools
+package dotty
+package tools
 package dotc
 
 import org.junit.Test
@@ -20,9 +21,9 @@ class EntryPointsTest {
   private val sources =
     List("../tests/pos/HelloWorld.scala").map(p => new java.io.File(p).getPath())
   private val dottyInterfaces =
-    new java.io.File("../interfaces/dotty-interfaces-0.1-SNAPSHOT.jar").getPath
+    new java.io.File(Jars.dottyInterfaces).getPath
   private val dottyLibrary =
-    new java.io.File("../library/target/scala-2.11/dotty-library_2.11-0.1-SNAPSHOT.jar").getPath
+    new java.io.File(Jars.dottyLib).getPath
   private val args =
     sources ++
     List("-d", "../out/") ++

--- a/compiler/test/dotty/tools/dotc/EntryPointsTest.scala
+++ b/compiler/test/dotty/tools/dotc/EntryPointsTest.scala
@@ -20,14 +20,7 @@ import scala.collection.mutable.ListBuffer
 class EntryPointsTest {
   private val sources =
     List("../tests/pos/HelloWorld.scala").map(p => new java.io.File(p).getPath())
-  private val dottyInterfaces =
-    new java.io.File(Jars.dottyInterfaces).getPath
-  private val dottyLibrary =
-    new java.io.File(Jars.dottyLib).getPath
-  private val args =
-    sources ++
-    List("-d", "../out/") ++
-    List("-classpath", dottyInterfaces + ":" + dottyLibrary)
+  private val args = sources ++ List("-d", "../out/", "-usejavacp")
 
   @Test def runCompiler = {
     val reporter = new CustomReporter

--- a/compiler/test/dotty/tools/dotc/InterfaceEntryPointTest.scala
+++ b/compiler/test/dotty/tools/dotc/InterfaceEntryPointTest.scala
@@ -21,15 +21,7 @@ class InterfaceEntryPointTest {
   @Test def runCompilerFromInterface = {
     val sources =
       List("../tests/pos/HelloWorld.scala").map(p => new java.io.File(p).getPath())
-    val dottyInterfaces =
-      new java.io.File(Jars.dottyInterfaces).getPath
-    val dottyLibrary =
-      new java.io.File(Jars.dottyLib).getPath
-
-    val args =
-      sources ++
-      List("-d", "../out/") ++
-      List("-classpath", dottyInterfaces + ":" + dottyLibrary)
+    val args = sources ++ List("-d", "../out/", "-usejavacp")
 
     val mainClass = Class.forName("dotty.tools.dotc.Main")
     val process = mainClass.getMethod("process",

--- a/compiler/test/dotty/tools/dotc/InterfaceEntryPointTest.scala
+++ b/compiler/test/dotty/tools/dotc/InterfaceEntryPointTest.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc
+package dotty
+package tools.dotc
 
 import org.junit.Test
 import org.junit.Assert._
@@ -21,9 +22,9 @@ class InterfaceEntryPointTest {
     val sources =
       List("../tests/pos/HelloWorld.scala").map(p => new java.io.File(p).getPath())
     val dottyInterfaces =
-      new java.io.File("../interfaces/dotty-interfaces-0.1-SNAPSHOT.jar").getPath
+      new java.io.File(Jars.dottyInterfaces).getPath
     val dottyLibrary =
-      new java.io.File("../library/target/scala-2.11/dotty-library_2.11-0.1-SNAPSHOT.jar").getPath
+      new java.io.File(Jars.dottyLib).getPath
 
     val args =
       sources ++

--- a/compiler/test/dotty/tools/dotc/repl/TestREPL.scala
+++ b/compiler/test/dotty/tools/dotc/repl/TestREPL.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc
+package dotty
+package tools.dotc
 package repl
 
 import core.Contexts.Context
@@ -23,10 +24,7 @@ class TestREPL(script: String) extends REPL {
     override def context(ctx: Context) = {
       val fresh = ctx.fresh
       fresh.setSetting(ctx.settings.color, "never")
-      fresh.setSetting(
-        ctx.settings.classpath,
-        "../library/target/scala-2.11/dotty-library_2.11-0.1-SNAPSHOT.jar"
-      )
+      fresh.setSetting(ctx.settings.classpath, Jars.dottyLib)
       fresh.initialize()(fresh)
       fresh
     }


### PR DESCRIPTION
sbt adds the correct jars to classpath and the tests depend on
`packageAll` which creates these. When using something else, however,
these together with `sbt-interfaces` do not get propagated from the
build.

To remedy this and make the testing a bit more flexible, we now
take these from `sys.props` instead, see `tests/dotty/Jars.scala`.

If the props aren't defined we fall back to the ones default to sbt.

review by: @odersky