### PR TITLE
Fix colons in printer

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -164,10 +164,14 @@ class PlainPrinter(_ctx: Context) extends Printer {
         "<noprefix>"
       case tp: MethodType =>
         def paramText(name: TermName, tp: Type) = toText(name) ~ ": " ~ toText(tp)
+        def typeColon(resultType: Type): Text = resultType match {
+          case _: TypeRef => ": "
+          case _ => "" // eg. methods with implicit parameters go here in first pass
+        }
         changePrec(GlobalPrec) {
           (if (tp.isImplicit) "(implicit " else "(") ~
             Text((tp.paramNames, tp.paramTypes).zipped map paramText, ", ") ~
-          ")" ~ toText(tp.resultType)
+          ")" ~ typeColon(tp.resultType) ~ toText(tp.resultType)
         }
       case tp: ExprType =>
         changePrec(GlobalPrec) { "=> " ~ toText(tp.resultType) }

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -164,14 +164,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
         "<noprefix>"
       case tp: MethodType =>
         def paramText(name: TermName, tp: Type) = toText(name) ~ ": " ~ toText(tp)
-        def typeColon(resultType: Type): Text = resultType match {
-          case _: TypeRef => ": "
-          case _ => "" // eg. methods with implicit parameters go here in first pass
-        }
         changePrec(GlobalPrec) {
           (if (tp.isImplicit) "(implicit " else "(") ~
             Text((tp.paramNames, tp.paramTypes).zipped map paramText, ", ") ~
-          ")" ~ typeColon(tp.resultType) ~ toText(tp.resultType)
+          ")" ~ toText(tp.resultType)
         }
       case tp: ExprType =>
         changePrec(GlobalPrec) { "=> " ~ toText(tp.resultType) }

--- a/compiler/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
+++ b/compiler/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
@@ -685,7 +685,12 @@ class CompilingInterpreter(
         val varType = string2code(req.typeOf(varName))
         val fullPath = req.fullPath(varName)
 
-        s""" + "$prettyName: $varType = " + {
+        val varOrVal = statement match {
+          case v: ValDef if v.mods is Flags.Mutable => "var"
+          case _ => "val"
+        }
+
+        s""" + "$varOrVal $prettyName: $varType = " + {
            |  if ($fullPath.asInstanceOf[AnyRef] != null) {
            |    (if ($fullPath.toString().contains('\\n')) "\\n" else "") +
            |      $fullPath.toString() + "\\n"
@@ -736,7 +741,7 @@ class CompilingInterpreter(
 
       override def resultExtractionCode(req: Request, code: PrintWriter): Unit = {
         if (!defDef.mods.is(Flags.AccessFlags))
-          code.print("+\"" + string2code(defDef.name.toString) + ": " +
+          code.print("+\"def " + string2code(defDef.name.toString) +
             string2code(req.typeOf(defDef.name)) + "\\n\"")
       }
     }

--- a/tests/repl/def.check
+++ b/tests/repl/def.check
@@ -1,0 +1,9 @@
+scala> def foo = 5
+def foo: Int
+scala> def bar: String = "1"
+def bar: String
+scala> def baz() = 2
+def baz(): Int
+scala> def qux(): Int = 2
+def qux(): Int
+scala> :quit

--- a/tests/repl/import.check
+++ b/tests/repl/import.check
@@ -1,11 +1,11 @@
 scala> import collection.mutable._
 import collection.mutable._
 scala> val buf = new ListBuffer[Int]
-buf: scala.collection.mutable.ListBuffer[Int] = ListBuffer()
+val buf: scala.collection.mutable.ListBuffer[Int] = ListBuffer()
 scala> buf += 22
-res0: scala.collection.mutable.ListBuffer[Int] = ListBuffer(22)
+val res0: scala.collection.mutable.ListBuffer[Int] = ListBuffer(22)
 scala> buf ++= List(1, 2, 3)
-res1: scala.collection.mutable.ListBuffer[Int] = ListBuffer(22, 1, 2, 3)
+val res1: scala.collection.mutable.ListBuffer[Int] = ListBuffer(22, 1, 2, 3)
 scala> buf.toList
-res2: scala.collection.immutable.List[Int] = List(22, 1, 2, 3)
+val res2: scala.collection.immutable.List[Int] = List(22, 1, 2, 3)
 scala> :quit

--- a/tests/repl/imports.check
+++ b/tests/repl/imports.check
@@ -1,7 +1,7 @@
 scala> import scala.collection.mutable
 import scala.collection.mutable
 scala> val buf = mutable.ListBuffer[Int]()
-buf: scala.collection.mutable.ListBuffer[Int] = ListBuffer()
+val buf: scala.collection.mutable.ListBuffer[Int] = ListBuffer()
 scala> object o { val xs = List(1, 2, 3) }
 defined module o
 scala> import o._
@@ -14,7 +14,7 @@ scala> buf += xs
    |       required: String
    |       
 scala> buf ++= xs
-res1: scala.collection.mutable.ListBuffer[Int] = ListBuffer(1, 2, 3)
+val res1: scala.collection.mutable.ListBuffer[Int] = ListBuffer(1, 2, 3)
 scala> import util.foo
 -- Error: <console> ------------------------------------------------------------
 8 |import util.foo

--- a/tests/repl/onePlusOne.check
+++ b/tests/repl/onePlusOne.check
@@ -1,3 +1,3 @@
 scala> 1+1
-res0: Int = 2
+val res0: Int = 2
 scala> :quit

--- a/tests/repl/patdef.check
+++ b/tests/repl/patdef.check
@@ -1,10 +1,10 @@
-scala> val Const,x = 0
-Const: Int = 0
-x: Int = 0
+scala> val Const, x = 0
+val Const: Int = 0
+val x: Int = 0
 scala> val (Const, List(`x`, _, a), b) = (0, List(0, 1337, 1), 2)
-a: Int = 1
-b: Int = 2
+val a: Int = 1
+val b: Int = 2
 scala> val a@b = 0
-a: Int @unchecked = 0
-b: Int @unchecked = 0
+val a: Int @unchecked = 0
+val b: Int @unchecked = 0
 scala> :quit

--- a/tests/repl/toplevelTry.check
+++ b/tests/repl/toplevelTry.check
@@ -1,3 +1,3 @@
 scala> try { 0 } catch { _: Throwable => 1 }
-res0: Int = 0
+val res0: Int = 0
 scala> :quit

--- a/tests/repl/vars.check
+++ b/tests/repl/vars.check
@@ -1,8 +1,8 @@
 scala> var x = 0
-x: Int = 0
+var x: Int = 0
 scala> x = x + 1
 x: Int = 1
 scala> x *= 2
 scala> x
-res2: Int = 2
+val res2: Int = 2
 scala> :quit


### PR DESCRIPTION
This PR takes off where @rethab started and fixes defs not being properly printed when desugared to `TypeExpr`.

It does not fix the underlying issues with the REPL. The current strategy employed by the REPL is to gather all the types that were generated during a compilation and tie them to the correct names. This proves an issue though, because the types need to get printed using special hacks.

Ideally we would do an actual compile run and then just show the types without any distortion. But this I leave up to a later point in time when we're doing a more complete overhaul.

review: @OlivierBlanvillain 