### PR TITLE
Try fix #1743: typing of ValDef with anonymous class

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -588,7 +588,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       else pt.notApplied
     val expr1 = typedExpr(tree.expr, ept)(exprCtx)
     ensureNoLocalRefs(
-        assignType(cpy.Block(tree)(stats1, expr1), stats1, expr1), pt, localSyms(stats1))
+        assignType(cpy.Block(tree)(stats1, expr1), stats1, expr1), pt, localSyms(stats1).filter(_.isTerm))
   }
 
   def escapingRefs(block: Tree, localSyms: => List[Symbol])(implicit ctx: Context): collection.Set[NamedType] = {

--- a/tests/pos/i1743.scala
+++ b/tests/pos/i1743.scala
@@ -1,0 +1,9 @@
+object DepBug {
+  val dep = new {
+    val a = 3
+    val b = 4
+  }
+
+  dep.a + dep.b
+}
+


### PR DESCRIPTION
In typing of blocks, it's fine to reference local type symbols. Fix #1743.