### PR TITLE
replaced 'none' with 'None' and 'nil' with 'Nil' when pattern matching

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1406,7 +1406,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     case Some(sym) =>
       sym.ensureCompleted()
       sym
-    case none =>
+    case None =>
       NoSymbol
   }
 
@@ -1426,7 +1426,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     val xtree = expanded(initTree)
     xtree.removeAttachment(TypedAhead) match {
       case Some(ttree) => ttree
-      case none =>
+      case None =>
 
         def typedNamed(tree: untpd.NameTree, pt: Type)(implicit ctx: Context): Tree = {
           val sym = retrieveSym(xtree)
@@ -1523,7 +1523,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         mdef.removeAttachment(ExpandedTree) match {
           case Some(xtree) =>
             traverse(xtree :: rest)
-          case none =>
+          case None =>
             typed(mdef) match {
               case mdef1: DefDef if Inliner.hasBodyToInline(mdef1.symbol) =>
                 buf ++= inlineExpansion(mdef1)
@@ -1537,7 +1537,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       case stat :: rest =>
         buf += typed(stat)(ctx.exprContext(stat, exprOwner))
         traverse(rest)
-      case nil =>
+      case Nil =>
         buf.toList
     }
     traverse(stats)


### PR DESCRIPTION
small cleanup.