### PR TITLE
fix #1748: desugaring with StringContext in PatDef

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1079,6 +1079,8 @@ object desugar {
         collect(tree)
       case Tuple(trees) =>
         trees foreach collect
+      case Thicket(trees) =>
+        trees foreach collect
       case _ =>
     }
     collect(tree)

--- a/tests/pos/i1784.scala
+++ b/tests/pos/i1784.scala
@@ -1,0 +1,14 @@
+object Test {
+  implicit class Foo(sc: StringContext) {
+    object q {
+      def unapply(args: Any*): Option[(Any, Any)] =
+        Some((sc.parts(0), sc.parts(1)))
+    }
+  }
+
+  def f(defn: Any): Any = {
+    val q"class $name extends $parent" =  defn
+    println(name)
+    println(parent)
+  }
+}

--- a/tests/run/i1748.check
+++ b/tests/run/i1748.check
@@ -1,0 +1,2 @@
+class 
+ extends 

--- a/tests/run/i1748.scala
+++ b/tests/run/i1748.scala
@@ -1,13 +1,13 @@
 object Test {
   implicit class Foo(sc: StringContext) {
     object q {
-      def unapply(args: Any*): Option[(Any, Any)] =
+      def unapply(arg: Any): Option[(Any, Any)] =
         Some((sc.parts(0), sc.parts(1)))
     }
   }
 
-  def f(defn: Any): Any = {
-    val q"class $name extends $parent" =  defn
+  def main(args: Array[String]): Unit = {
+    val q"class $name extends $parent" = new Object
     println(name)
     println(parent)
   }


### PR DESCRIPTION
Fix #1748: desugaring with StringContext in PatDef

The method `getVariables` forgets the case `Thicket`.

Review @felixmulder 
