### PR TITLE
Fix #1753: Better comparison of path types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -541,9 +541,11 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
       /** if `tp2 == p.type` and `p: q.type` then try `tp1 <:< q.type` as a last effort.*/
       def comparePaths = tp2 match {
         case tp2: TermRef =>
-          tp2.info.widenExpr match {
+          tp2.info.widenExpr.dealias match {
             case tp2i: SingletonType =>
-              isSubType(tp1, tp2i) // see z1720.scala for a case where this can arise even in typer.
+              isSubType(tp1, tp2i)
+                // see z1720.scala for a case where this can arise even in typer.
+                // Also, i1753.scala, to show why the dealias above is necessary.
             case _ => false
           }
         case _ =>

--- a/tests/pos/i1753.scala
+++ b/tests/pos/i1753.scala
@@ -1,0 +1,22 @@
+abstract class BackendInterface {
+  type Symbol >: Null
+  type ClassDef >: Null
+}
+
+class BTypesFromSymbols[I <: BackendInterface](val int: I) {
+  def isRemote(s: int.Symbol) = println("might've been remote")
+}
+
+trait BCodeIdiomatic {
+  val int: BackendInterface
+  final lazy val bTypes = new BTypesFromSymbols[int.type](int)
+}
+
+trait BCodeSkelBuilder extends BCodeIdiomatic {
+  import int._
+  import bTypes._
+  val b: BTypesFromSymbols[int.type] = bTypes
+  val x: int.type = bTypes.int
+  val y: bTypes.int.type = int
+  def getPlainClass(cd: ClassDef) = bTypes.isRemote(null: Symbol)
+}


### PR DESCRIPTION
In this case, a path went through a type parameter which was
aliased to a singleton type. Need to dealias to get to the
special case handling two paths.

Review by @felixmulder 