### PR TITLE
Fix #1756: Use lexically enclosing class as start of outer path.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -82,7 +82,7 @@ class Erasure extends Phase with DenotTransformer { thisTransformer =>
     assertErased(tree)
     tree match {
       case res: tpd.This =>
-        assert(!ExplicitOuter.referencesOuter(ctx.owner.enclosingClass, res),
+        assert(!ExplicitOuter.referencesOuter(ctx.owner.lexicallyEnclosingClass, res),
           i"Reference to $res from ${ctx.owner.showLocated}")
       case ret: tpd.Return =>
         // checked only after erasure, as checking before erasure is complicated
@@ -389,7 +389,7 @@ object Erasure extends TypeTestsCasts{
     }
 
     override def typedThis(tree: untpd.This)(implicit ctx: Context): Tree =
-      if (tree.symbol == ctx.owner.enclosingClass || tree.symbol.isStaticOwner) promote(tree)
+      if (tree.symbol == ctx.owner.lexicallyEnclosingClass || tree.symbol.isStaticOwner) promote(tree)
       else {
         ctx.log(i"computing outer path from ${ctx.owner.ownersIterator.toList}%, % to ${tree.symbol}, encl class = ${ctx.owner.enclosingClass}")
         outer.path(tree.symbol)

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -330,7 +330,7 @@ object ExplicitOuter {
     /** The path of outer accessors that references `toCls.this` starting from
      *  the context owner's this node.
      */
-    def path(toCls: Symbol, start: Tree = This(ctx.owner.enclosingClass.asClass)): Tree = try {
+    def path(toCls: Symbol, start: Tree = This(ctx.owner.lexicallyEnclosingClass.asClass)): Tree = try {
       def loop(tree: Tree): Tree = {
         val treeCls = tree.tpe.widen.classSymbol
         val outerAccessorCtx = ctx.withPhaseNoLater(ctx.lambdaLiftPhase) // lambdalift mangles local class names, which means we cannot reliably find outer acessors anymore

--- a/tests/pos/i1756.scala
+++ b/tests/pos/i1756.scala
@@ -1,5 +1,4 @@
-/*
- * class A { { val x = this } }
+class A { { val x = this } }
 class B(x: Int) {
   class C(x: Int)
       extends B({
@@ -13,7 +12,7 @@ class B(x: Int) {
     }
   }
 }
-*/
+
 // Minimized version
 class D(x: Int) {
   class E(x: Int) extends D({val test = D.this; x})

--- a/tests/pos/i1756.scala
+++ b/tests/pos/i1756.scala
@@ -1,0 +1,21 @@
+/*
+ * class A { { val x = this } }
+class B(x: Int) {
+  class C(x: Int)
+      extends B({
+        val test = this
+        x
+      }) {
+    def this() = {
+      this({
+        1
+      })
+    }
+  }
+}
+*/
+// Minimized version
+class D(x: Int) {
+  class E(x: Int) extends D({val test = D.this; x})
+}
+


### PR DESCRIPTION
We confused the enclosing class (which skips the current class in super
call contexts) and the lexically enclosing class in three locations
that all had to do with the start of an outer path.

Review by @DarkDimius ?