### PR TITLE
Fix #1765: Context bounds and denotation handling

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Periods.scala
+++ b/compiler/src/dotty/tools/dotc/core/Periods.scala
@@ -153,7 +153,7 @@ object Periods {
   final val FirstPhaseId = 1
 
   /** The number of bits needed to encode a phase identifier. */
-  final val PhaseWidth = 6
+  final val PhaseWidth = 7
   final val PhaseMask = (1 << PhaseWidth) - 1
   final val MaxPossiblePhaseId = PhaseMask
 }

--- a/compiler/src/dotty/tools/dotc/transform/Memoize.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Memoize.scala
@@ -47,7 +47,9 @@ import Decorators._
     }
     tree match {
       case ddef: DefDef
-        if !ddef.symbol.is(Deferred) && ddef.rhs == EmptyTree =>
+        if !ddef.symbol.is(Deferred) &&
+           !ddef.symbol.isConstructor && // constructors bodies are added later at phase Constructors
+           ddef.rhs == EmptyTree =>
           errorLackImplementation(ddef)
       case tdef: TypeDef
         if tdef.symbol.isClass && !tdef.symbol.is(Deferred) && tdef.rhs == EmptyTree =>
@@ -89,10 +91,10 @@ import Decorators._
     }
 
     lazy val field = sym.field.orElse(newField).asTerm
-    
+
     def adaptToField(tree: Tree) =
       if (tree.isEmpty) tree else tree.ensureConforms(field.info.widen)
-      
+
     if (sym.is(Accessor, butNot = NoFieldNeeded))
       if (sym.isGetter) {
         def skipBlocks(t: Tree): Tree = t match {

--- a/tests/pos/i1765.scala
+++ b/tests/pos/i1765.scala
@@ -1,0 +1,21 @@
+trait T[X]
+
+trait U[X]
+
+trait TC[M[_]] {
+  def foo[M[_]: TC, A](ma: U[A]) = ()
+  implicit val TCofT: TC[T] = new TC[T] {}
+  implicit def any2T[A](a: A): T[A] = new T[A] {}
+  implicit def any2U[A](a: A): U[A] = new U[A] {}
+  val x = foo[T, Int](1)
+  val y = ()
+}
+
+// Minimized version exhibiting an assertion violation in Denotation#current at phase lambdalift:
+trait TC2 {
+//  implicit val TCofT: TC2[T] = new TC2[T] {}
+  val TCofT: Object = {
+    class C extends TC2
+    new Object
+  }
+}


### PR DESCRIPTION
This is the first time a fuzzing test has revealed two unrelated errors. The first error had to do with the desugaring of context bounds for higher-kinded types. It was straightforward to diagnose and fix. 

The other error was much harder to diagnose. Replacing denotations via `installAfter` did not what it claimed to do.

Fixes #1765

Review by @DarkDimius 