### PR TITLE
Fix #1751: Make dominator work after erasure

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -197,6 +197,9 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
       case c :: rest =>
         val accu1 = if (accu exists (_ derivesFrom c)) accu else c :: accu
         if (cs == c.baseClasses) accu1 else dominators(rest, accu1)
+      case Nil => // this case can happen because after erasure we do not have a top class anymore
+        assert(ctx.erasedTypes)
+        defn.ObjectClass :: Nil
     }
 
     def mergeRefined(tp1: Type, tp2: Type): Type = {

--- a/tests/pos/i1751.scala
+++ b/tests/pos/i1751.scala
@@ -1,0 +1,17 @@
+trait Break { protected val break: Int; }
+case class BreakImpl(protected val break: Int) extends Break {}
+object Test {
+  def f2(x: Break) = x match {
+    case BreakImpl(x) => BreakImpl
+    case _ => -1
+  }
+  def f4(x: Any) = x match {
+    case BreakImpl(x) => x
+    case _ => -1
+  }
+  def main(args: Array[String]): Unit = {
+    val break = BreakImpl(22)
+    assert(f2(break) == 22)
+    assert(f4(break) == 22)
+  }
+}


### PR DESCRIPTION
i1751.scala shows a case where we need to compute the approximation
of an or-type during erasure. This can lead to an empty set of common
classes because Any does not exist anymore after erasure.

Review by @liufengyun ?