### PR TITLE
[DO NOT MERGE] 	Illustrate issue with TreeTypeMap and miniphases

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
@@ -80,7 +80,9 @@ class ElimByName extends MiniPhaseTransform with InfoTransformer { thisTransform
             val inSuper = if (ctx.mode.is(Mode.InSuperCall)) InSuperCall else EmptyFlags
             val meth = ctx.newSymbol(
                 ctx.owner, nme.ANON_FUN, Synthetic | Method | inSuper, MethodType(Nil, Nil, argType))
-            Closure(meth, _ => arg.changeOwner(ctx.owner, meth))
+            atGroupEnd { implicit ctx: Context =>
+              Closure(meth, _ => arg.changeOwner(ctx.owner, meth))
+            }
         }
         ref(defn.dummyApply).appliedToType(argType).appliedTo(argFun)
       case _ =>

--- a/tests/pos/treetypemap-miniphase.scala
+++ b/tests/pos/treetypemap-miniphase.scala
@@ -1,0 +1,38 @@
+class Test {
+  def byName(param: => Any) = {}
+
+  def test: Unit = {
+
+    // 1. In ResolveSuper#transformTemplate we add "def <(that: Int): Boolean =
+    //    Foo.super[Ordered].<(that)", etc to Foo, these methods are inserted
+    //    into a new decls scope using enteredAfter in MixinOps#implementation
+
+    // 2. In ElimByName#transformApply we call `changeOwner` on the tree
+    //    containing Foo, which will use a TreeTypeMap
+
+    // 3. In TreeTypeMap#withMappedSyms we call `cls.info.decls` on every mapped
+    //    class to map its symbols, one of these mapped class is Foo, but at
+    //    this point we are before the ResolveSuper phase, therefore the decls
+    //    scope does not contain the methods added in ResolveSuper like `<`, so
+    //    we never map them and their owner is still the old symbol for Foo,
+    //    this is wrong! But the compiler will not realize this until much later
+
+    // 4. In LinkScala2ImplClasses we replace:
+    //      def <(that: Int): Boolean = Foo.super[Ordered].<(that)
+    //    by:
+    //      def <(that: Int): Boolean = scala.math.Ordered$class#<(this, scala.Int.box(that))
+    //    This is fine, except that the owner of `<` is incorrect since 3., so the `this` tree
+    //    gets an incorrect symbol
+
+    // 5. In the backend, the compiler finally realizes that something has gone very wrong:
+    //    assertion failed: Trying to access the this of another class:
+    //    tree.symbol = class Test$~Foo#4444,
+    //    class symbol = class Test$Foo$1#6723
+
+    byName({
+      class Foo extends Ordered[Int] {
+        def compare(that: Int): Int = 0
+      }
+    })
+  }
+}


### PR DESCRIPTION
Ping @DarkDimius @odersky, I'm not sure how to proceed from here.

The first commit illustrates the issue:
> When running TreeTypeMap in a miniphase, the tree we're transforming has
already been transformed by all the miniphases in the same group, but
the symbols we're looking at might be older than the trees, this means
that we can miss transforming some symbols as illustrated in details by
the added testcase which currently fails.

The second commit contains a hack to show that my diagnostic of the issue above is correct, but I don't know how to fix this properly:
> With this commit, tests/pos/treetypemap-miniphase.scala now compiles,
but this is only a hack: there are other instances of TreeTypeMap in the
compiler and they would all need to be run with "atGroupEnd", this is
tricky since we are not always calling TreeTypeMap in a context where we
have access to the current TreeTransformer (for example when we create a
TreeTypeMap inside TypeMap to deal with annotations), ideas and
alternative fixes welcome.