### PR TITLE
Fix #1773: handle patterns in interpolated string

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -916,7 +916,11 @@ object desugar {
         val elems = segments flatMap {
           case ts: Thicket => ts.trees.tail
           case t => Nil
+        } map {
+          case Block(Nil, expr) => expr // important for interpolated string as patterns, see i1773.scala
+          case t => t
         }
+
         Apply(Select(Apply(Ident(nme.StringContext), strs), id), elems)
       case InfixOp(l, op, r) =>
         if (ctx.mode is Mode.Type)
@@ -1081,6 +1085,8 @@ object desugar {
         trees foreach collect
       case Thicket(trees) =>
         trees foreach collect
+      case Block(Nil, expr) =>
+        collect(expr)
       case _ =>
     }
     collect(tree)

--- a/tests/run/i1773.check
+++ b/tests/run/i1773.check
@@ -1,0 +1,2 @@
+class 
+ extends 

--- a/tests/run/i1773.scala
+++ b/tests/run/i1773.scala
@@ -1,0 +1,14 @@
+object Test {
+  implicit class Foo(sc: StringContext) {
+    object q {
+      def unapply(arg: Any): Option[(Any, Any)] =
+        Some((sc.parts(0), sc.parts(1)))
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    val q"class ${name: String} extends ${parent: String}" = new Object
+    println(name)
+    println(parent)
+  }
+}


### PR DESCRIPTION
Fix #1773: handle patterns in interpolated string

Now following patterns can be correctly desugared and type checked:

```Scala
val q"class ${name: String} extends ${parent: String}" = ...
```

Review @odersky 