### PR TITLE
fix #1779: support $_ and $_id  in interpolated string

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -625,6 +625,10 @@ object Parsers {
             atPos(in.offset) {
               if (in.token == IDENTIFIER)
                 termIdent()
+              else if (in.token == USCORE) {
+                in.nextToken()
+                Ident(nme.WILDCARD)
+              }
               else if (in.token == THIS) {
                 in.nextToken()
                 This(EmptyTypeIdent)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -597,7 +597,7 @@ object Parsers {
       val isNegated = negOffset < in.offset
       atPos(negOffset) {
         if (in.token == SYMBOLLIT) atPos(in.skipToken()) { SymbolLit(in.strVal) }
-        else if (in.token == INTERPOLATIONID) interpolatedString()
+        else if (in.token == INTERPOLATIONID) interpolatedString(inPattern)
         else finish(in.token match {
           case CHARLIT                => in.charVal
           case INTLIT                 => in.intVal(isNegated).toInt
@@ -621,11 +621,11 @@ object Parsers {
       in.nextToken()
       while (in.token == STRINGPART) {
         segmentBuf += Thicket(
-            literal(),
+            literal(inPattern = inPattern),
             atPos(in.offset) {
               if (in.token == IDENTIFIER)
                 termIdent()
-              else if (in.token == USCORE) {
+              else if (in.token == USCORE && inPattern) {
                 in.nextToken()
                 Ident(nme.WILDCARD)
               }
@@ -637,12 +637,12 @@ object Parsers {
                 if (inPattern) Block(Nil, inBraces(pattern()))
                 else expr()
               else {
-                ctx.error(InterpolatedStringError())
+                ctx.error(InterpolatedStringError(), source atPos Position(in.offset))
                 EmptyTree
               }
             })
       }
-      if (in.token == STRINGLIT) segmentBuf += literal()
+      if (in.token == STRINGLIT) segmentBuf += literal(inPattern = inPattern)
       InterpolatedString(interpolator, segmentBuf.toList)
     }
 
@@ -1448,7 +1448,7 @@ object Parsers {
       case XMLSTART =>
         xmlLiteralPattern()
       case _ =>
-        if (isLiteral) literal()
+        if (isLiteral) literal(inPattern = true)
         else {
           syntaxErrorOrIncomplete(IllegalStartOfSimplePattern())
           errorTermTree

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -758,7 +758,7 @@ object Scanners {
           finishStringPart()
           nextRawChar()
           next.token = LBRACE
-        } else if (Character.isUnicodeIdentifierStart(ch)) {
+        } else if (Character.isUnicodeIdentifierStart(ch) || ch == '_') {
           finishStringPart()
           do {
             putChar(ch)

--- a/tests/neg/i1779.scala
+++ b/tests/neg/i1779.scala
@@ -1,0 +1,13 @@
+object Test {
+  implicit class Foo(sc: StringContext) {
+    object q {
+      def apply(arg: Any*): Int = 3
+    }
+  }
+
+  def f = {
+    val _parent = 3
+    q"val hello = $_parent"
+    q"class $_" // error // error
+  }
+}

--- a/tests/run/i1779.check
+++ b/tests/run/i1779.check
@@ -1,0 +1,1 @@
+ extends 

--- a/tests/run/i1779.scala
+++ b/tests/run/i1779.scala
@@ -1,0 +1,13 @@
+object Test {
+  implicit class Foo(sc: StringContext) {
+    object q {
+      def unapply(arg: Any): Option[(Any, Any)] =
+        Some((sc.parts(0), sc.parts(1)))
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    val q"class $_ extends $_parent" = new Object
+    println(_parent)
+  }
+}


### PR DESCRIPTION
Fix #1779: support $_ and $_id  in interpolated string.

Review @odersky .