### PR TITLE
Fix #1776: Avoid interaction between parameter forwarding and elimByName

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -55,7 +55,9 @@ class ParamForwarding(thisTransformer: DenotTransformer) {
         stat match {
           case stat: ValDef =>
             val sym = stat.symbol.asTerm
-            if (sym is (ParamAccessor, butNot = Mutable)) {
+            if (sym.is(ParamAccessor, butNot = Mutable) && !sym.info.isInstanceOf[ExprType]) {
+              // ElimByName gets confused with methods returning an ExprType,
+              // so avoid param forwarding if parameter is by name. See i1766.scala
               val idx = superArgs.indexWhere(_.symbol == sym)
               if (idx >= 0 && superParamNames(idx) == stat.name) { // supercall to like-named parameter
                 val alias = inheritedAccessor(sym)

--- a/tests/pos/i1776.scala
+++ b/tests/pos/i1776.scala
@@ -1,0 +1,3 @@
+class X(val y: String)
+class Y(y: => String) extends X(y)
+class Z(z: => String) extends X(z)


### PR DESCRIPTION
Parameter forwarding is not geared to handle parameters of by-name types correctly
and consequently elimByName generates wrong code. Since it's a corner case it's
easiest not applying the parameter forwarding optimization to by-name parameters.