### PR TITLE
Fix exhaustivity check test after repo restructuring

### DIFF
--- a/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
@@ -9,9 +9,9 @@ import dotty.tools.dotc.Main
 import dotty.tools.dotc.reporting.TestReporter
 
 class PatmatExhaustivityTest {
-  val testsDir = "./tests/patmat"
+  val testsDir = "../tests/patmat"
   // stop-after: patmatexhaust-huge.scala crash compiler
-  val options = List("-color:never", "-Ystop-after:splitter", "-Ycheck-all-patmat")
+  val options = List("-color:never", "-Ystop-after:splitter", "-Ycheck-all-patmat") ++ (new dotc.tests).classPath
 
   private def compileFile(file: File) = {
     val stringBuffer = new StringWriter()


### PR DESCRIPTION
The exhaustivity check tests don't run after repo restructuring. Review @felixmulder . 