### PR TITLE
Fix #1806: Define outer accessors at the right phase

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -24,7 +24,6 @@ object desugar {
 
   /** Names of methods that are added unconditionally to case classes */
   def isDesugaredCaseClassMethodName(name: Name)(implicit ctx: Context): Boolean =
-    name == nme.isDefined ||
     name == nme.copy ||
     name == nme.productArity ||
     name.isSelectorName
@@ -343,7 +342,6 @@ object desugar {
       if (isCaseClass) {
         def syntheticProperty(name: TermName, rhs: Tree) =
           DefDef(name, Nil, Nil, TypeTree(), rhs).withMods(synthetic)
-        val isDefinedMeth = syntheticProperty(nme.isDefined, Literal(Constant(true)))
         val caseParams = constrVparamss.head.toArray
         val productElemMeths = for (i <- 0 until arity) yield
           syntheticProperty(nme.selectorName(i), Select(This(EmptyTypeIdent), caseParams(i).name))
@@ -369,7 +367,7 @@ object desugar {
             DefDef(nme.copy, derivedTparams, copyFirstParams :: copyRestParamss, TypeTree(), creatorExpr)
               .withMods(synthetic) :: Nil
           }
-        copyMeths ::: isDefinedMeth :: productElemMeths.toList
+        copyMeths ::: productElemMeths.toList
       }
       else Nil
 

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -262,6 +262,9 @@ object Contexts {
     final def withPhaseNoLater(phase: Phase) =
       if (phase.exists && ctx.phase.id > phase.id) withPhase(phase) else ctx
 
+    final def withPhaseNoEarlier(phase: Phase) =
+      if (phase.exists && ctx.phase.id < phase.id) withPhase(phase) else ctx
+
     /** If -Ydebug is on, the top of the stack trace where this context
      *  was created, otherwise `null`.
      */

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -675,7 +675,7 @@ class Definitions {
 
   private def isVarArityClass(cls: Symbol, prefix: Name) = {
     val name = scalaClassName(cls)
-    name.startsWith(prefix) && 
+    name.startsWith(prefix) &&
     name.length > prefix.length &&
     name.drop(prefix.length).forall(_.isDigit)
   }
@@ -736,6 +736,14 @@ class Definitions {
 
   def isProductSubType(tp: Type)(implicit ctx: Context) =
     (tp derivesFrom ProductType.symbol) && tp.baseClasses.exists(isProductClass)
+
+  def productArity(tp: Type)(implicit ctx: Context) =
+    if (tp derivesFrom ProductType.symbol)
+      tp.baseClasses.find(isProductClass) match {
+        case Some(prod) => prod.typeParams.length
+        case None => -1
+      }
+    else -1
 
   def isFunctionType(tp: Type)(implicit ctx: Context) =
     isFunctionClass(tp.dealias.typeSymbol) && {

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -675,7 +675,9 @@ class Definitions {
 
   private def isVarArityClass(cls: Symbol, prefix: Name) = {
     val name = scalaClassName(cls)
-    name.startsWith(prefix) && name.drop(prefix.length).forall(_.isDigit)
+    name.startsWith(prefix) && 
+    name.length > prefix.length &&
+    name.drop(prefix.length).forall(_.isDigit)
   }
 
   def isBottomClass(cls: Symbol) =

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -424,7 +424,6 @@ object StdNames {
     val info: N                 = "info"
     val inlinedEquals: N        = "inlinedEquals"
     val isArray: N              = "isArray"
-    val isDefined: N            = "isDefined"
     val isDefinedAt: N          = "isDefinedAt"
     val isDefinedAtImpl: N      = "$isDefinedAt"
     val isEmpty: N              = "isEmpty"

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -147,7 +147,8 @@ object ExplicitOuter {
   private def newOuterSym(owner: ClassSymbol, cls: ClassSymbol, name: TermName, flags: FlagSet)(implicit ctx: Context) = {
     val target = cls.owner.enclosingClass.typeRef
     val info = if (flags.is(Method)) ExprType(target) else target
-    ctx.newSymbol(owner, name, Synthetic | flags, info, coord = cls.coord)
+    ctx.withPhaseNoEarlier(ctx.explicitOuterPhase.next) // outer accessors are entered at explicitOuter + 1, should not be defined before.
+       .newSymbol(owner, name, Synthetic | flags, info, coord = cls.coord)
   }
 
   /** A new param accessor for the outer field in class `cls` */

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -235,7 +235,8 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
         // next: MatchMonad[U]
         // returns MatchMonad[U]
         def flatMap(prev: Tree, b: Symbol, next: Tree): Tree = {
-          if (isProductMatch(prev.tpe)) {
+          val resultArity = defn.productArity(b.info)
+          if (isProductMatch(prev.tpe, resultArity)) {
             val nullCheck: Tree = prev.select(defn.Object_ne).appliedTo(Literal(Constant(null)))
             ifThenElseZero(
               nullCheck,
@@ -1429,7 +1430,7 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
 
       def resultInMonad  =
         if (aligner.isBool) defn.UnitType
-        else if (isProductMatch(resultType)) resultType
+        else if (isProductMatch(resultType, aligner.prodArity)) resultType
         else if (isGetMatch(resultType)) extractorMemberType(resultType, nme.get)
         else resultType
 
@@ -1630,7 +1631,7 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
           ref(binder) :: Nil
         }
         else if ((aligner.isSingle && aligner.extractor.prodArity == 1) &&
-                 !isProductMatch(binderTypeTested) && isGetMatch(binderTypeTested))
+                 !isProductMatch(binderTypeTested, aligner.prodArity) && isGetMatch(binderTypeTested))
           List(ref(binder))
         else
           subPatRefs(binder)
@@ -1885,7 +1886,7 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
           else if (result.classSymbol is Flags.CaseClass) result.decls.filter(x => x.is(Flags.CaseAccessor) && x.is(Flags.Method)).map(_.info).toList
           else result.select(nme.get) :: Nil
           )*/
-          if (isProductMatch(resultType)) productSelectorTypes(resultType)
+          if (isProductMatch(resultType, args.length)) productSelectorTypes(resultType)
           else if (isGetMatch(resultType)) getUnapplySelectors(resultOfGet, args)
           else if (resultType isRef defn.BooleanClass) Nil
           else {

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -235,14 +235,20 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
         // next: MatchMonad[U]
         // returns MatchMonad[U]
         def flatMap(prev: Tree, b: Symbol, next: Tree): Tree = {
-
-          val getTp = extractorMemberType(prev.tpe, nme.get)
-          val isDefined = extractorMemberType(prev.tpe, nme.isDefined)
-
-          if ((isDefined isRef defn.BooleanClass) && getTp.exists) {
-            // isDefined and get may be overloaded
-            val getDenot = prev.tpe.member(nme.get).suchThat(_.info.isParameterless)
-            val isDefinedDenot = prev.tpe.member(nme.isDefined).suchThat(_.info.isParameterless)
+          if (isProductMatch(prev.tpe)) {
+            val nullCheck: Tree = prev.select(defn.Object_ne).appliedTo(Literal(Constant(null)))
+            ifThenElseZero(
+              nullCheck,
+              Block(
+                List(ValDef(b.asTerm, prev)),
+                next //Substitution(b, ref(prevSym))(next)
+              )
+            )
+          }
+          else {
+            val getDenot = extractorMember(prev.tpe, nme.get)
+            val isEmptyDenot = extractorMember(prev.tpe, nme.isEmpty)
+            assert(getDenot.exists && isEmptyDenot.exists, i"${prev.tpe}")
 
             val tmpSym = freshSym(prev.pos, prev.tpe, "o")
             val prevValue = ref(tmpSym).select(getDenot.symbol).ensureApplied
@@ -251,18 +257,8 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
               List(ValDef(tmpSym, prev)),
               // must be isEmpty and get as we don't control the target of the call (prev is an extractor call)
               ifThenElseZero(
-                ref(tmpSym).select(isDefinedDenot.symbol),
+                ref(tmpSym).select(isEmptyDenot.symbol).select(defn.Boolean_!),
                 Block(List(ValDef(b.asTerm, prevValue)), next)
-              )
-            )
-          } else {
-            assert(defn.isProductSubType(prev.tpe))
-            val nullCheck: Tree = prev.select(defn.Object_ne).appliedTo(Literal(Constant(null)))
-            ifThenElseZero(
-              nullCheck,
-              Block(
-                List(ValDef(b.asTerm, prev)),
-                next //Substitution(b, ref(prevSym))(next)
               )
             )
           }
@@ -1431,12 +1427,12 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
         case _        => or
       }
 
-      def resultInMonad  = if (aligner.isBool) defn.UnitType else {
-        val getTp = extractorMemberType(resultType, nme.get)
-        if ((extractorMemberType(resultType, nme.isDefined) isRef defn.BooleanClass) && getTp.exists)
-          getTp
+      def resultInMonad  =
+        if (aligner.isBool) defn.UnitType
+        else if (isProductMatch(resultType)) resultType
+        else if (isGetMatch(resultType)) extractorMemberType(resultType, nme.get)
         else resultType
-      }
+
       def resultType: Type
 
       /** Create the TreeMaker that embodies this extractor call
@@ -1632,13 +1628,12 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
           //val spr = subPatRefs(binder)
           assert(go && go1)
           ref(binder) :: Nil
-        } else {
-          lazy val getTp = extractorMemberType(binderTypeTested, nme.get)
-          if ((aligner.isSingle && aligner.extractor.prodArity == 1) && ((extractorMemberType(binderTypeTested, nme.isDefined) isRef defn.BooleanClass) && getTp.exists))
-            List(ref(binder))
-          else
-            subPatRefs(binder)
         }
+        else if ((aligner.isSingle && aligner.extractor.prodArity == 1) &&
+                 !isProductMatch(binderTypeTested) && isGetMatch(binderTypeTested))
+          List(ref(binder))
+        else
+          subPatRefs(binder)
       }
 
       /*protected def spliceApply(binder: Symbol): Tree = {
@@ -1890,9 +1885,8 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
           else if (result.classSymbol is Flags.CaseClass) result.decls.filter(x => x.is(Flags.CaseAccessor) && x.is(Flags.Method)).map(_.info).toList
           else result.select(nme.get) :: Nil
           )*/
-          if ((extractorMemberType(resultType, nme.isDefined) isRef defn.BooleanClass) && resultOfGet.exists)
-            getUnapplySelectors(resultOfGet, args)
-          else if (defn.isProductSubType(resultType)) productSelectorTypes(resultType)
+          if (isProductMatch(resultType)) productSelectorTypes(resultType)
+          else if (isGetMatch(resultType)) getUnapplySelectors(resultOfGet, args)
           else if (resultType isRef defn.BooleanClass) Nil
           else {
             ctx.error(i"invalid return type in Unapply node: $resultType")

--- a/compiler/test/dotc/scala-collections.whitelist
+++ b/compiler/test/dotc/scala-collections.whitelist
@@ -280,3 +280,5 @@
 ../scala-scala/src/library/scala/collection/generic/Subtractable.scala
 ../scala-scala/src/library/scala/collection/generic/TraversableFactory.scala
 ../scala-scala/src/library/scala/collection/generic/package.scala
+
+../scala-scala/src/library/scala/util/Try.scala

--- a/tests/neg/i1806.scala
+++ b/tests/neg/i1806.scala
@@ -1,0 +1,7 @@
+trait A {
+  class Inner
+ }
+trait B extends A {
+  class Inner extends super.Inner // error
+}
+

--- a/tests/pos/Patterns.scala
+++ b/tests/pos/Patterns.scala
@@ -108,3 +108,31 @@ object NestedPattern {
   val xss: List[List[String]] = ???
   val List(List(x)) = xss
 }
+
+// Tricky case (exercised by Scala parser combinators) where we use
+// both get/isEmpty and product-based pattern matching in different
+// matches on the same types.
+object ProductAndGet {
+
+  trait Result[+T]
+  case class Success[+T](in: String, x: T) extends Result[T] {
+    def isEmpty = false
+    def get: T = x
+  }
+  case class Failure[+T](in: String, msg: String) extends Result[T] {
+    def isEmpty = false
+    def get: String = msg
+  }
+
+  val r: Result[Int] = ???
+
+  r match {
+    case Success(in, x) => x
+    case Failure(in, msg) => -1
+  }
+
+  r match {
+    case Success(x) => x
+    case Failure(msg) => -1
+  }
+}

--- a/tests/pos/i1540.scala
+++ b/tests/pos/i1540.scala
@@ -1,6 +1,6 @@
 class Casey1(val a: Int) {
-  def isDefined: Boolean = true
-  def isDefined(x: Int): Boolean = ???
+  def isEmpty: Boolean = false
+  def isEmpty(x: Int): Boolean = ???
   def get: Int = a
   def get(x: Int): String = ???
 }

--- a/tests/pos/i1540b.scala
+++ b/tests/pos/i1540b.scala
@@ -1,6 +1,6 @@
 class Casey1[T](val a: T) {
-  def isDefined: Boolean = true
-  def isDefined(x: T): Boolean = ???
+  def isEmpty: Boolean = false
+  def isEmpty(x: T): Boolean = ???
   def get: T = a
   def get(x: T): String = ???
 }

--- a/tests/pos/i1790.scala
+++ b/tests/pos/i1790.scala
@@ -1,0 +1,15 @@
+import scala.util.control.NonFatal
+
+class Try[+T] {
+  def transform[U](s: T => Try[U], f: Throwable => Try[U]): Try[U] =
+    try this match {
+      case Success(v) => s(v)
+      case Failure(e) => f(e)
+    } catch {
+      case NonFatal(e) => Failure(e)
+    }
+}
+final case class Success[+T](value: T) extends Try[T]
+final case class Failure[+T](exception: Throwable) extends Try[T] {
+  def get: T = throw exception
+}

--- a/tests/pos/pos_valueclasses/optmatch.scala
+++ b/tests/pos/pos_valueclasses/optmatch.scala
@@ -7,7 +7,7 @@ package optmatch
 
 class NonZeroLong(val value: Long) extends AnyVal {
   def get: Long = value
-  def isDefined: Boolean = get != 0l
+  def isEmpty: Boolean = get == 0l
 }
 object NonZeroLong {
   def unapply(value: Long): NonZeroLong = new NonZeroLong(value)

--- a/tests/repl/innerClasses.check
+++ b/tests/repl/innerClasses.check
@@ -1,0 +1,5 @@
+scala> class A { class Inner }
+defined class A
+scala> class B extends A { class Inner2 extends super.Inner }
+defined class B
+scala> :quit


### PR DESCRIPTION

Some outer accessors were defined at phase explicitOuter,
but were entered into the scope of their enclosing class only
at phase explicitOuter + 1. This turned them to stale symbols
when trying to access them at a later run, because at their
initially valid phase they were not found as members of
their owner.

Fixes #1806. Review by @nicolasstucki 
