### PR TITLE
Fix #1797: Allow case class params with names _1, _2, ...

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -345,8 +345,9 @@ object desugar {
           DefDef(name, Nil, Nil, TypeTree(), rhs).withMods(synthetic)
         val isDefinedMeth = syntheticProperty(nme.isDefined, Literal(Constant(true)))
         val caseParams = constrVparamss.head.toArray
-        val productElemMeths = for (i <- 0 until arity) yield
-          syntheticProperty(nme.selectorName(i), Select(This(EmptyTypeIdent), caseParams(i).name))
+        val productElemMeths =
+          for (i <- 0 until arity if nme.selectorName(i) `ne` caseParams(i).name)
+          yield syntheticProperty(nme.selectorName(i), Select(This(EmptyTypeIdent), caseParams(i).name))
         def isRepeated(tree: Tree): Boolean = tree match {
           case PostfixOp(_, nme.raw.STAR) => true
           case ByNameTypeTree(tree1) => isRepeated(tree1)

--- a/tests/pos/i1797.scala
+++ b/tests/pos/i1797.scala
@@ -1,0 +1,1 @@
+case class Tuple1[T](_1: T)


### PR DESCRIPTION
This was not possible before because it clashed with the automatically
generated name of the accessor. We now allow it, by simply taking the
parameter(accessor) itself as the case class accessor if it already has
that name. But you still cannot write

    case class C(_2: Int, _1: String)

nor should you be able to do this.