### PR TITLE
Fix JUnit compilation of dotty by dotty

### DIFF
--- a/compiler/test/dotc/tests.scala
+++ b/compiler/test/dotc/tests.scala
@@ -98,6 +98,9 @@ class tests extends CompilerTest {
   val typerDir  = dotcDir + "typer/"
   val libDir = "../library/src/"
 
+  def dottyBootedLib = compileDir(libDir, ".", List("-deep", "-Ycheck-reentrant", "-strict") ::: defaultOptions)(allowDeepSubtypes) // note the -deep argument
+  def dottyDependsOnBootedLib = compileDir(dottyDir, ".", List("-deep", "-Ycheck-reentrant", "-strict") ::: defaultOptions)(allowDeepSubtypes) // note the -deep argument
+
   @Before def cleanup(): Unit = {
     // remove class files from stdlib and tests compilation
     Directory(defaultOutputDir + "scala").deleteRecursively()
@@ -252,12 +255,6 @@ class tests extends CompilerTest {
         |../scala-scala/src/library/scala/collection/SeqLike.scala
         |../scala-scala/src/library/scala/collection/generic/GenSeqFactory.scala""".stripMargin)
   @Test def compileIndexedSeq = compileLine("../scala-scala/src/library/scala/collection/immutable/IndexedSeq.scala")
-
-  // Not a junit test anymore since it is order dependent
-  def dottyBootedLib = compileDir(libDir, ".")(allowDeepSubtypes) // note the -deep argument
-
-  // Not a junit test anymore since it is order dependent
-  def dottyDependsOnBootedLib = compileDir(dottyDir, ".")(allowDeepSubtypes) // note the -deep argument
 
   @Test def dotc_ast = compileDir(dotcDir, "ast")
   @Test def dotc_config = compileDir(dotcDir, "config")

--- a/compiler/test/dotc/tests.scala
+++ b/compiler/test/dotc/tests.scala
@@ -256,6 +256,11 @@ class tests extends CompilerTest {
         |../scala-scala/src/library/scala/collection/generic/GenSeqFactory.scala""".stripMargin)
   @Test def compileIndexedSeq = compileLine("../scala-scala/src/library/scala/collection/immutable/IndexedSeq.scala")
 
+  @Test def dotty = {
+    dottyBootedLib
+    dottyDependsOnBootedLib
+  }
+
   @Test def dotc_ast = compileDir(dotcDir, "ast")
   @Test def dotc_config = compileDir(dotcDir, "config")
   @Test def dotc_core = compileDir(dotcDir, "core")(allowDeepSubtypes)// twice omitted to make tests run faster


### PR DESCRIPTION
This was broken in 06a3d47ea9fd1b67b3acba9d115a16d18549e377 when the
-deep argument was removed, meaning that dotty compiled with dotty was
not tested at all.