### PR TITLE
Fix #1812, Symbols.mapSymbols shouldn't replace denotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -328,6 +328,7 @@ trait Symbols { this: Context =>
                                // Note that this is a hack, but hack commonly used in Dotty
                                // The same thing is done by other completers all the time
             denot.info = ttmap1.mapType(oinfo)
+            denot.annotations = odenot.annotations.mapConserve(ttmap1.apply)
           }
         }
 
@@ -337,7 +338,7 @@ trait Symbols { this: Context =>
           initFlags = odenot.flags &~ (Frozen | Touched) | Fresh,
           info = completer,
           privateWithin = ttmap1.mapOwner(odenot.privateWithin), // since this refers to outer symbols, need not include copies (from->to) in ownermap here.
-          annotations = odenot.annotations.mapConserve(ttmap1.apply))
+          annotations = odenot.annotations)
 
       }
 

--- a/tests/pos/i1812.scala
+++ b/tests/pos/i1812.scala
@@ -1,0 +1,12 @@
+class FF[R] {
+  def compose(): R = ???
+}
+
+class Test(x: Int) extends AnyVal {
+  def method: Unit = {
+    class Bla
+    class Foo extends FF[Bla] {
+      override def compose() = super[FF].compose()
+    }
+  }
+}

--- a/tests/pos/i1812b.scala
+++ b/tests/pos/i1812b.scala
@@ -1,0 +1,11 @@
+class FF[R] {
+  def compose(): R = ???
+}
+
+class Test(x: Int) extends AnyVal {
+  def method: Unit = {
+    class Bla{ def bar:a.S = ???}
+    trait TRT{ type S}
+    val a: TRT = ???
+  }
+}


### PR DESCRIPTION
It will use lazy types instead. The current version transforms a type, with
    a context that has denotations that may be forcefully replaced by
    mapSymbols. Types created during this transformation may cache denots, that
    are-to-be replaced. This is very problematic as this method is called from
    TreeTypeMap.withMappedSyms in a fixed-point cycle, creating new symbols on
    every iteration. Those cached denotations could make types keep symbols
    from previous iterations indefinitely.

The changed version does not transform the types eagerly, and instead makes
    them lazy. Assuming there are no cycles, this should ensure correct
    ordering. Unfortunatelly, at this point in the compiler we basically always
    touch everything, and we can't even transform the info of denotation
    without this denotations info. We basically have a chicked&egg problem
    here. To solve it, I use the same trick as used by other lazy types by
    assigning an approximation of future type first. This allows to pass the
    tests and makes dotty more robust, but I suspect this isn't a complete fix
    and new similar bugs may arrive.