### PR TITLE
Fix #1793: allow multiversal comparisons between Null and X

### DIFF
--- a/compiler/test/dotc/scala-collections.blacklist
+++ b/compiler/test/dotc/scala-collections.blacklist
@@ -164,11 +164,6 @@
 #     |                ^^^
 #     |                not found: msg
 
-../scala-scala/src/library/scala/ref/WeakReference.scala
-# 33 |    if (x != null) Some(x) else None
-#    |       ^^^^^^^^^^^
-#    |       Values of types wr.underlying.java$lang$ref$WeakReference$$T and Null cannot be compared with == or !=
-
 ../scala-scala/src/library/scala/reflect/ClassManifestDeprecatedApis.scala
 # 51 |      import Manifest._
 #    |             ^^^^^^^^

--- a/compiler/test/dotc/scala-collections.whitelist
+++ b/compiler/test/dotc/scala-collections.whitelist
@@ -422,6 +422,7 @@
 ../scala-scala/src/library/scala/ref/ReferenceQueue.scala
 ../scala-scala/src/library/scala/ref/ReferenceWrapper.scala
 ../scala-scala/src/library/scala/ref/SoftReference.scala
+../scala-scala/src/library/scala/ref/WeakReference.scala
 
 ../scala-scala/src/library/scala/reflect/macros/internal/macroImpl.scala
 ../scala-scala/src/library/scala/reflect/NoManifest.scala

--- a/tests/neg/i1793.scala
+++ b/tests/neg/i1793.scala
@@ -1,0 +1,7 @@
+object Test {
+  import scala.ref.WeakReference
+  def unapply[T <: AnyVal](wr: WeakReference[T]): Option[T] = {
+    val x = wr.underlying.get
+    if (x != null) Some(x) else None // error
+  }
+}

--- a/tests/pos/i1793.scala
+++ b/tests/pos/i1793.scala
@@ -1,0 +1,7 @@
+object Test {
+  import scala.ref.WeakReference
+  def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = {
+    val x = wr.underlying.get
+    if (x != null) Some(x) else None
+  }
+}


### PR DESCRIPTION
`Eq[Null, X]` and `Eq[X, Null]` should not force `X` to have an `Eq`-instance, it should be enough that `X` is not a subtype of AnyVal.

This PR amends this and adds the failing `WeakReference` sourcefile to the whitelist.