### PR TITLE
Topic/533 parse error

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -540,7 +540,7 @@ object Parsers {
       def handleThis(qual: Ident) = {
         in.nextToken()
         val t = atPos(start) { This(qual) }
-        if (!thisOK && in.token != DOT) syntaxError(DanglingThisInPath(), start)
+        if (!thisOK && in.token != DOT) syntaxError(DanglingThisInPath(), t.pos)
         dotSelectors(t, finish)
       }
       def handleSuper(qual: Ident) = {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -540,7 +540,7 @@ object Parsers {
       def handleThis(qual: Ident) = {
         in.nextToken()
         val t = atPos(start) { This(qual) }
-        if (!thisOK && in.token != DOT) syntaxError("`.' expected")
+        if (!thisOK && in.token != DOT) syntaxError(DanglingThisInPath(), start)
         dotSelectors(t, finish)
       }
       def handleSuper(qual: Ident) = {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -971,25 +971,34 @@ object messages {
     val kind = "Syntax"
     val msg = hl"""Expected an additional member selection after the keyword ${"this"}"""
 
+    val contextCode =
+      """  trait Outer {
+        |    val member: Int
+        |    type Member
+        |    trait Inner {
+        |      ...
+        |    }
+        |  }"""
+
     val importCode =
-      """import MyClass.this.member
-        |//                 ^^^^^^^
-      """
+      """  import Outer.this.member
+        |  //               ^^^^^^^"""
 
     val typeCode =
-      """type T = MyClass.this.Member
-        |//                   ^^^^^^^
-      """
+      """  type T = Outer.this.Member
+        |  //                 ^^^^^^^"""
 
     val explanation =
       hl"""|Paths of imports and type selections must not end with the keyword ${"this"}.
            |
-           |Maybe you forgot to select a member of ${"this"}?
+           |Maybe you forgot to select a member of ${"this"}? As an example, in the
+           |following context:
+           |${contextCode}
            |
-           |- Example for a valid import expression using a path
+           |- this is a valid import expression using a path
            |${importCode}
            |
-           |- Example for a valid type using a path
+           |- this is a valid type using a path
            |${typeCode}
            |"""
   }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -966,4 +966,31 @@ object messages {
            |    ${"val foo: Int = 3"}
            |"""
   }
+
+  case class DanglingThisInPath()(implicit ctx: Context) extends Message(36) {
+    val kind = "Syntax"
+    val msg = hl"""Expected an additional member selection after the keyword ${"this"}"""
+
+    val importCode =
+      """import MyClass.this.member
+        |//                 ^^^^^^^
+      """
+
+    val typeCode =
+      """type T = MyClass.this.Member
+        |//                   ^^^^^^^
+      """
+
+    val explanation =
+      hl"""|Paths of imports and type selections must not end with the keyword ${"this"}.
+           |
+           |Maybe you forgot to select a member of ${"this"}?
+           |
+           |- Example for a valid import expression using a path
+           |${importCode}
+           |
+           |- Example for a valid type using a path
+           |${typeCode}
+           |"""
+  }
 }

--- a/tests/neg/i1845.scala
+++ b/tests/neg/i1845.scala
@@ -1,3 +1,3 @@
 object Test {
   type X = FooBar22.this // error
-} // error
+}


### PR DESCRIPTION
This pull request deals with "Parsers.scala:533". It is part of #1589.

## Message Before

```
-- Error: examples/parser533.scala ---------------------------------------------
3 |} // error
  |^
  |`.' expected
-- [E025] Syntax Error: examples/parser533.scala -------------------------------
2 |  type X = FooBar22.this // error
  |           ^^^^^^^^^^^^^
  |           identifier expected

Explanation
===========
An identifier expected, but `FooBar22.this` found. This could be because
`FooBar22.this` is not a valid identifier. As a workaround, the compiler could
infer the type for you. For example, instead of:

def foo: FooBar22.this = {...}

Write your code like:

def foo = {...}



two errors found
```

## Message After
```
-- [E036] Syntax Error: examples/parser533.scala -------------------------------
2 |  type X = FooBar22.this // error
  |           ^^^^^^^^^^^^^
  |           Expected an additional member selection after the keyword this

Explanation
===========
Paths of imports and type selections must not end with the keyword this.

Maybe you forgot to select a member of this? As an example, in the
following context:
  trait Outer {
    val member: Int
    type Member
    trait Inner {
      ...
    }
  }

- this is a valid import expression using a path
  import Outer.this.member
  //               ^^^^^^^

- this is a valid type using a path
  type T = Outer.this.Member
  //                 ^^^^^^^


one error found
```


In addition to adding the required error message this pull request also fixes some inconsistencies with referring to identifier literals. While in the doc-comments one could find `Ident`, `ident`, `ident()`, `Id` and `id`, in the [spec](https://github.com/lampepfl/dotty/blob/master/docs/syntax-summary.txt) identifiers are always referred to as `id`. 