### PR TITLE
fix #1750: check problematic owner first to avoid cyclic reference

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -44,13 +44,13 @@ class Compiler {
       List(new FrontEnd),           // Compiler frontend: scanner, parser, namer, typer
       List(new sbt.ExtractDependencies), // Sends information on classes' dependencies to sbt via callbacks
       List(new PostTyper),          // Additional checks and cleanups after type checking
+      List(new RefChecks,           // Various checks mostly related to abstract members and overriding
+           new CheckStatic),        // Check restrictions that apply to @static members
       List(new sbt.ExtractAPI),     // Sends a representation of the API of classes to sbt via callbacks
       List(new Pickler),            // Generate TASTY info
       List(new FirstTransform,      // Some transformations to put trees into a canonical form
            new CheckReentrant),     // Internal use only: Check that compiled program has no data races involving global vars
-      List(new RefChecks,           // Various checks mostly related to abstract members and overriding
-           new CheckStatic,         // Check restrictions that apply to @static members
-           new ElimRepeated,        // Rewrite vararg parameters and arguments
+      List(new ElimRepeated,        // Rewrite vararg parameters and arguments
            new NormalizeFlags,      // Rewrite some definition flags
            new ExtensionMethods,    // Expand methods of value classes with extension methods
            new ExpandSAMs,          // Expand single abstract method closures to anonymous classes

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -813,9 +813,10 @@ class RefChecks extends MiniPhase { thisTransformer =>
       // If owner is possibly problematic, check owner first.
       // If there are overriding errors with owner, stop checking current to avoid cyclic reference.
       // See neg/i1750.scala.
+      val errors = ctx.reporter.errorCount
       if (ownerPossibleProblematic(cls)) checkAllOverrides(cls.owner)
+      if (ctx.reporter.errorCount == errors) checkAllOverrides(cls)
 
-      if (!ctx.reporter.hasErrors) checkAllOverrides(cls)
       tree
     } catch {
       case ex: MergeError =>

--- a/tests/neg/i1750.scala
+++ b/tests/neg/i1750.scala
@@ -1,0 +1,12 @@
+trait Lang1 {
+  trait Exp
+  trait Visitor { def f(left: Exp): Unit }
+  class Eval1 extends Visitor { self =>
+    def f(left: Exp) = ()
+  }
+}
+
+trait Lang2 extends Lang1 {
+  class Visitor extends Eval1 { Visitor => // error: overidding class definitions
+  }
+}


### PR DESCRIPTION
Fix #1750: check problematic owner first to avoid cyclic reference.

I'm not sure if this is the right fix, could you please advise @odersky ?
