### PR TITLE
Fix #1716: avoid crash in type checking f[_]

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -368,7 +368,12 @@ trait TypeAssigner {
         }
         else {
           val argTypes = args.tpes
-          if (sameLength(argTypes, paramNames) || ctx.phase.prev.relaxedTyping) pt.instantiate(argTypes)
+          if (sameLength(argTypes, paramNames) || ctx.phase.prev.relaxedTyping) {
+            val index = argTypes.indexWhere(!_.isInstanceOf[TermType])
+            if (index != -1)
+              errorType(i"Incorrect type parameter `${args(index)}` for ${err.exprStr(fn)}", args(index).pos)
+            else pt.instantiate(argTypes)
+          }
           else wrongNumberOfTypeArgs(fn.tpe, pt.typeParams, args, tree.pos)
         }
       case _ =>

--- a/tests/neg/i1716.scala
+++ b/tests/neg/i1716.scala
@@ -1,0 +1,8 @@
+object Fail {
+  def f(m: Option[Int]): Unit = {
+     m match {
+      case x @ Some[_] =>       // error
+      case _       =>
+    }
+  }
+}

--- a/tests/neg/i1716b.scala
+++ b/tests/neg/i1716b.scala
@@ -1,0 +1,5 @@
+object Fail {
+  def f: Unit = {
+    Some[_]        // error
+  }
+}


### PR DESCRIPTION
Fix #1716: avoid crash in type checking `f[_]`.