### PR TITLE
Fix #1857: Interpolate type variables before implicit search

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1697,8 +1697,13 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
   def adapt(tree: Tree, pt: Type, original: untpd.Tree = untpd.EmptyTree)(implicit ctx: Context): Tree = /*>|>*/ track("adapt") /*<|<*/ {
     /*>|>*/ ctx.traceIndented(i"adapting $tree of type ${tree.tpe} to $pt", typr, show = true) /*<|<*/ {
+      def shouldInterpolate(tp: Type) = tp match {
+        case tp: PolyType => false
+        case tp: MethodType => tp.isImplicit
+        case _ => true
+      }
       if (tree.isDef) interpolateUndetVars(tree, tree.symbol)
-      else if (!tree.tpe.widen.isInstanceOf[MethodOrPoly]) interpolateUndetVars(tree, NoSymbol)
+      else if (shouldInterpolate(tree.tpe.widen)) interpolateUndetVars(tree, NoSymbol)
       tree.overwriteType(tree.tpe.simplified)
       adaptInterpolated(tree, pt, original)
     }

--- a/tests/pos/i1857.scala
+++ b/tests/pos/i1857.scala
@@ -1,0 +1,34 @@
+trait CommandeerDSL[Host] {
+  trait Operation[T]
+  type Op[T] <: Operation[T]
+}
+
+object CommandeerDSL {
+  def apply[Host, DSL <: CommandeerDSL[Host]](host: Host)(implicit dsl: DSL): DSL = dsl
+}
+
+trait Foo {
+  def bar(a: String, b: Int): Double
+}
+
+object Foo {
+  implicit val fooDSL: FooDSL = new FooDSL {}
+}
+
+trait FooDSL extends CommandeerDSL[Foo] {
+  sealed trait FooOperation[T] extends Operation[T]
+  type Op[T] = FooOperation[T]
+
+  case class Bar(a: String, b: Int) extends FooOperation[Double]
+}
+
+object RunMe {
+  def main(args: Array[String]): Unit = {
+    println("Hi Mum")
+
+    val kevin = CommandeerDSL(null.asInstanceOf[Foo])
+    println(s"Found DSL for Foo: $kevin")
+    val bar = kevin.Bar("bob", 3)
+    println(s"Made a bar: $bar")
+  }
+}

--- a/tests/pos/i1857a.scala
+++ b/tests/pos/i1857a.scala
@@ -1,0 +1,10 @@
+object Test {
+  def foo1[T](x: T)(implicit ev: T): Nothing = ???
+
+  def test1: Unit = {
+    implicit val ii: Int = 42
+    implicit val ss: String = "foo"
+
+    foo1(10) // ambiguous implicit because T=Any
+  }
+}


### PR DESCRIPTION
Interpolating type variables before resolving implicit parameters means that
more companion objects can become eligible for the implicit scope. An example
demonstrating this is i1857.scala. The spec mandates this behavior because it
says that type arguments are inferred before implicit parameter resolution takes place.

Review by @smarter?