### PR TITLE
Alternative fix for #1857: Consider tvars in bounds of uninstantiated tvars

### DIFF
--- a/tests/pos/i1857a.scala
+++ b/tests/pos/i1857a.scala
@@ -1,0 +1,39 @@
+class Wrapper[Host]
+
+
+class SubWrapper extends Wrapper[Foo]
+
+class Foo
+object Foo {
+  implicit val fooWrapper: SubWrapper = new SubWrapper
+}
+
+class Inv[A, B]
+
+object RunMe {
+  def main(args: Array[String]): Unit = {
+    def wrap1a[A, W <: Wrapper[Foo]](host: A)(implicit w: W): W = ???
+    def wrap1b[A, W <: Wrapper[Foo]](host: A)(implicit w: W): A = ???
+    def wrap1c[A, W <: Wrapper[Foo]](host: A)(implicit w: W): Inv[W, A] = ???
+    def wrap1d[A, W <: Wrapper[Foo]](host: A)(implicit w: W): Nothing = ???
+
+    def wrap2a[A, W <: Wrapper[A]](host: A)(implicit w: W): W = ???
+    def wrap2b[A, W <: Wrapper[A]](host: A)(implicit w: W): A = ???
+    def wrap2c[A, W <: Wrapper[A]](host: A)(implicit w: W): Inv[W, A] = ???
+    def wrap2d[A, W <: Wrapper[A]](host: A)(implicit w: W): Nothing = ???
+
+    val f: Foo = new Foo
+
+    // work with master
+    wrap1a(f)
+    wrap1b(f)
+    wrap1c(f)
+    wrap1d(f)
+
+    // do not work with master
+    wrap2a(f)
+    wrap2b(f)
+    wrap2c(f)
+    wrap2d(f)
+  }
+}

--- a/tests/pos/tparam_inf.scala
+++ b/tests/pos/tparam_inf.scala
@@ -23,6 +23,14 @@ object Test {
     foo2(10)
   }
 
+  def test1b: Unit = {
+    implicit val ii: Int = 42
+    implicit val ss: String = "foo"
+
+    foo1(10)
+    foo2(10)
+  }
+
   def hf[T]: HasFoo[T] = ???
   def test2: Unit = {
     implicit val ii: Int = 42


### PR DESCRIPTION
This is an alternative to https://github.com/lampepfl/dotty/pull/1859, review by @odersky

<hr>

Given:
```scala
  val f: Foo = new Foo
  def wrap2a[A, W <: Wrapper[A]](host: A)(implicit w: W): W = ???
  wrap2a(f)
```

We need to instantiate `A` before doing the implicit search for `w`
because the type of `w` indirectly depends on `A` and `A` was constrained by the first parameter list. This was not
done before because we did not traverse the constraint bounds of an
uninstantiated type variable.