### PR TITLE
Fix #1732: Special treatment for bottom type by-name args

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
@@ -71,7 +71,8 @@ class ElimByName extends MiniPhaseTransform with InfoTransformer { thisTransform
 
     def transformArg(arg: Tree, formal: Type): Tree = formal.dealias match {
       case formalExpr: ExprType =>
-        val argType = arg.tpe.widenIfUnstable
+        var argType = arg.tpe.widenIfUnstable
+        if (defn.isBottomType(argType)) argType = formal.widenExpr
         val argFun = arg match {
           case Apply(Select(qual, nme.apply), Nil)
           if qual.tpe.derivesFrom(defn.FunctionClass(0)) && isPureExpr(qual) =>

--- a/tests/run/i1732.scala
+++ b/tests/run/i1732.scala
@@ -1,0 +1,15 @@
+object Test {
+  import scala.util.control.Breaks
+
+  def brk(f: () => Unit): Unit = try {
+    f()
+  } catch {
+    case ex: NotImplementedError =>
+  }
+  def main(args: Array[String]): Unit = {
+    brk { () => ??? }
+    Breaks.breakable {
+      Breaks.break
+    }
+  }
+}


### PR DESCRIPTION
If a by-name arg has a bottom type, we need to create a closure with the
result type of the formal parameter, or else specialization with
FunctionalInterfaces will fail.

Review by @nicolasstucki ?