### PR TITLE
Add error message for unbound wildcard type. Parsers.scala:664

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -676,7 +676,7 @@ object Parsers {
       val t = typ()
       findWildcardType(t) match {
         case Some(wildcardPos) =>
-          syntaxError("unbound wildcard type", wildcardPos)
+          syntaxError(UnboundWildcardType(), wildcardPos)
           scalaAny
         case None => t
       }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -923,4 +923,47 @@ object messages {
            |"""
   }
 
+  case class UnboundWildcardType()(implicit ctx: Context) extends Message(35) {
+    val kind = "Syntax"
+    val msg = "Unbound wildcard type"
+    val explanation =
+      hl"""|The wildcard type syntax (`_`) was used where it could not be bound.
+           |Replace `_` with a non-wildcard type. If the type doesn't matter,
+           |try replacing `_` with ${"Any"}.
+           |
+           |Examples:
+           |
+           |- Parameter lists
+           |
+           |  Instead of:
+           |    ${"def foo(x: _) = ..."}
+           |
+           |  Use ${"Any"} if the type doesn't matter:
+           |    ${"def foo(x: Any) = ..."}
+           |
+           |- Type arguments
+           |
+           |  Instead of:
+           |    ${"val foo = List[_](1, 2)"}
+           |
+           |  Use:
+           |    ${"val foo = List[Int](1, 2)"}
+           |
+           |- Type bounds
+           |
+           |  Instead of:
+           |    ${"def foo[T <: _](x: T) = ..."}
+           |
+           |  Remove the bounds if the type doesn't matter:
+           |    ${"def foo[T](x: T) = ..."}
+           |
+           |- ${"val"} and ${"def"} types
+           |
+           |  Instead of:
+           |    ${"val foo: _ = 3"}
+           |
+           |  Use:
+           |    ${"val foo: Int = 3"}
+           |"""
+  }
 }


### PR DESCRIPTION
Regarding #1589, this PR addresses "unbound wildcard type" (Parsers.scala:664). Please let me know if the examples in my explanation are not complete/useful. :)