### PR TITLE
Fix compileStdLib test

### DIFF
--- a/compiler/test/dotc/scala-collections.blacklist
+++ b/compiler/test/dotc/scala-collections.blacklist
@@ -64,3 +64,20 @@
 #    |illegal redefinition of standard class AnyVal
 # (This is intended)
 
+../scala-scala/src/library/scala/collection/parallel/Tasks.scala
+# java.lang.StackOverflowError
+
+../scala-scala/src/library/scala/reflect/package.scala
+# 63 |  private[scala] def materializeClassTag[T](): ClassTag[T] = macro ???
+#    |                                                             ^^^^^
+#    |                                                             not found: macro
+
+../scala-scala/src/library/scala/StringContext.scala
+# 168 |  def f[A >: Any](args: A*): String = macro ???
+#     |                                      ^^^^^
+#     |                                      not found: macro
+
+../scala-scala/src/library/scala/util/control/Exception.scala
+# 51 |  implicit def throwableSubtypeToCatcher[Ex <: Throwable: ClassTag, T](pf: PartialFunction[Ex, T]) =
+#    |                                                                                                 ^
+#    |                                                                     cyclic reference involving method mkCatcher

--- a/compiler/test/dotc/scala-collections.whitelist
+++ b/compiler/test/dotc/scala-collections.whitelist
@@ -64,7 +64,7 @@
 ../scala-scala/src/library/scala/Serializable.scala
 ../scala-scala/src/library/scala/Specializable.scala
 ../scala-scala/src/library/scala/Symbol.scala
-../scala-scala/src/library/scala/StringContext.scala
+#../scala-scala/src/library/scala/StringContext.scala
 ../scala-scala/src/library/scala/UninitializedError.scala
 ../scala-scala/src/library/scala/UninitializedFieldError.scala
 ../scala-scala/src/library/scala/collection/IndexedSeqOptimized.scala
@@ -293,7 +293,7 @@
 
 ../scala-scala/src/library/scala/util/Try.scala
 
-../scala-scala/src/library/scala/util/control/Exception.scala
+#../scala-scala/src/library/scala/util/control/Exception.scala
 ../scala-scala/src/library/scala/util/control/Breaks.scala
 ../scala-scala/src/library/scala/util/control/ControlThrowable.scala
 ../scala-scala/src/library/scala/util/control/NonFatal.scala
@@ -445,7 +445,7 @@
 ../scala-scala/src/library/scala/reflect/NoManifest.scala
 ../scala-scala/src/library/scala/reflect/OptManifest.scala
 ../scala-scala/src/library/scala/reflect/NameTransformer.scala
-../scala-scala/src/library/scala/reflect/package.scala
+#../scala-scala/src/library/scala/reflect/package.scala
 
 ../scala-scala/src/library/scala/Responder.scala
 
@@ -508,7 +508,7 @@
 ../scala-scala/src/library/scala/collection/parallel/PreciseSplitter.scala
 ../scala-scala/src/library/scala/collection/parallel/Splitter.scala
 ../scala-scala/src/library/scala/collection/parallel/TaskSupport.scala
-../scala-scala/src/library/scala/collection/parallel/Tasks.scala
+#../scala-scala/src/library/scala/collection/parallel/Tasks.scala
 
 ../scala-scala/src/library/scala/Console.scala
 ../scala-scala/src/library/scala/Enumeration.scala

--- a/compiler/test/dotty/tools/dotc/CompilerTest.scala
+++ b/compiler/test/dotty/tools/dotc/CompilerTest.scala
@@ -228,8 +228,9 @@ abstract class CompilerTest {
     } else {
       val destDir = Directory(DPConfig.testRoot + JFile.separator + testName)
       files.foreach({ file =>
-        val jfile = new JFile(file)
-        recCopyFiles(jfile, destDir / jfile.getName)
+        val sourceFile = new JFile(file)
+        val destFile = destDir / (if (file.startsWith("../")) file.substring(3) else file)
+        recCopyFiles(sourceFile,  destFile)
       })
       compileDir(DPConfig.testRoot + JFile.separator, testName, args)
       destDir.deleteRecursively


### PR DESCRIPTION
The issue was that all the files stdlib files where copied in `partest-generated/pos/compileStdLib` directly (i.e. directories flattend). This implies that files with the same names would overwrite each other (like `package.scala` and `Set.scala`).