### PR TITLE
Fix dummy scala-library

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -555,11 +555,15 @@ object DottyInjectedPlugin extends AutoPlugin {
       }
     )
 
-   lazy val `scala-library` = project
-    .settings(
-      libraryDependencies += "org.scala-lang" % "scala-library" % scalaVersion.value
-    )
-    .settings(publishing)
+
+  // Dummy scala-library artefact. This is useful because sbt projects
+  // automatically depend on scalaOrganization.value % "scala-library" % scalaVersion.value
+  lazy val `scala-library` = project.
+    dependsOn(`dotty-library`).
+    settings(
+      crossPaths := false
+    ).
+    settings(publishing)
 
    lazy val publishing = Seq(
      publishMavenStyle := true,


### PR DESCRIPTION
To be useful, the dummy scala-library:
- needs to be published with crossPaths off (the "_2.11" path of the
artefact name), like the real scala-library
- should depend on dotty-library and not just scala-library, since this
is what is needed to compile dotty programs

Review by @felixmulder 