### PR TITLE
Partially fix Java interop for emitted inner classes

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -560,7 +560,10 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     def javaBinaryName: Name = toDenot(sym).fullNameSeparated("/") // addModuleSuffix(fullNameInternal('/'))
     def javaClassName: String = toDenot(sym).fullName.toString// addModuleSuffix(fullNameInternal('.')).toString
     def name: Name = sym.name
-    def rawname: Name = sym.name // todo ????
+    def rawname: Name = {
+      val original = toDenot(sym).initial
+      sym.name(ctx.withPhase(original.validFor.phaseId))
+    }
 
     // types
     def info: Type = toDenot(sym).info

--- a/tests/pos-java-interop/innerClass/Outer.scala
+++ b/tests/pos-java-interop/innerClass/Outer.scala
@@ -1,0 +1,8 @@
+class Outer {
+  class InnerInClass
+
+  def inner() = new InnerInClass
+}
+object Outer {
+  class InnerInObject
+}

--- a/tests/pos-java-interop/innerClass/Test.java
+++ b/tests/pos-java-interop/innerClass/Test.java
@@ -1,0 +1,9 @@
+public class Test {
+  public static void test() {
+    Outer outer = new Outer();
+    Outer.InnerInClass innerInClass = outer.inner();
+
+    // Does not work yet, requires https://github.com/DarkDimius/scala/pull/4
+    // Outer.InnerInObject innerInObject = new Outer.InnerInObject();
+  }
+}


### PR DESCRIPTION
The backend uses `rawname` to define the "inner name" of an InnerClass
entry in a classfile, this should be the simple name of the class before
any mangling takes place but before this commit, we put the mangled name
after flatten there.

Fixing this allows Java code to reference dotty inner classes, except if
they're defined in objects which is still broken until
https://github.com/DarkDimius/scala/pull/4 is merged and a new backend
is published.

Review by @DarkDimius 