### PR TITLE
Adopt scala's scheme for root import hiding

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -747,6 +747,7 @@ class Definitions {
     else if (ctx.settings.YnoPredef.value) StaticRootImportFns
     else StaticRootImportFns ++ PredefImportFns
 
+  lazy val ShadowableImportNames = Set("Predef", "DottyPredef").map(_.toTermName)
   lazy val RootImportTypes = RootImportFns.map(_())
 
   /** Modules whose members are in the default namespace and their module classes */

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -373,8 +373,13 @@ class Namer { typer: Typer =>
   }
 
   /** A new context that summarizes an import statement */
-  def importContext(sym: Symbol, selectors: List[Tree])(implicit ctx: Context) =
-    ctx.fresh.setImportInfo(new ImportInfo(sym, selectors))
+  def importContext(imp: Import, sym: Symbol)(implicit ctx: Context) = {
+    val impNameOpt = imp.expr match {
+      case ref: RefTree => Some(ref.name.asTermName)
+      case _            => None
+    }
+    ctx.fresh.setImportInfo(new ImportInfo(sym, imp.selectors, impNameOpt))
+  }
 
   /** A new context for the interior of a class */
   def inClassContext(selfInfo: DotClass /* Should be Type | Symbol*/)(implicit ctx: Context): Context = {
@@ -423,7 +428,7 @@ class Namer { typer: Typer =>
         setDocstring(pkg, stat)
         ctx
       case imp: Import =>
-        importContext(createSymbol(imp), imp.selectors)
+        importContext(imp, createSymbol(imp))
       case mdef: DefTree =>
         val sym = enterSymbol(createSymbol(mdef))
         setDocstring(sym, origStat)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1588,7 +1588,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       case (imp: untpd.Import) :: rest =>
         val imp1 = typed(imp)
         buf += imp1
-        traverse(rest)(importContext(imp1.symbol, imp.selectors))
+        traverse(rest)(importContext(imp, imp1.symbol))
       case (mdef: untpd.DefTree) :: rest =>
         mdef.removeAttachment(ExpandedTree) match {
           case Some(xtree) =>


### PR DESCRIPTION
scalac hides a root import from Predef if there is an explicit Predef import.
We now do the same (previously we did this only if the overriding import undefined
something, using a `x => _` syntax). To avoid cycles and races one had to be very careful
not to force import symbols too early, so we now compare the name before the symbol proper.

All this is likely temporary - the comment of ImportInfo#unimported points to a different,
more systematic solution.

Note: The difference in semantics showed up and caused problems for the current collection strawman.
