### PR TITLE
Fix #1908: give synthetic default params correct flags

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -190,7 +190,9 @@ object desugar {
             vparamss = takeUpTo(normalizedVparamss.nestedMap(toDefParam), n),
             tpt = TypeTree(),
             rhs = vparam.rhs
-          ).withMods(Modifiers(mods.flags & AccessFlags, mods.privateWithin))
+          )
+          .withMods(Modifiers(mods.flags & AccessFlags, mods.privateWithin))
+          .withFlags(Synthetic)
         val rest = defaultGetters(vparams :: vparamss1, n + 1)
         if (vparam.rhs.isEmpty) rest else defaultGetter :: rest
       case Nil :: vparamss1 =>

--- a/compiler/test/dotty/tools/dotc/ast/DesugarTests.scala
+++ b/compiler/test/dotty/tools/dotc/ast/DesugarTests.scala
@@ -1,0 +1,49 @@
+package dotty.tools
+package dotc
+package ast
+
+import core._
+import Names._, Types._ , Symbols._, StdNames._, Flags._, Contexts._
+
+import org.junit.Test
+import org.junit.Assert._
+
+class DesugarTests extends DottyTest {
+  import tpd._
+
+  private def validSym(sym: Symbol)(implicit ctx: Context): Unit = {
+      assert(
+        // remaining symbols must be either synthetic:
+        sym.is(Synthetic) ||
+        // or be a type argument from product:
+        (sym.isType && sym.is(BaseTypeArg)) ||
+        // or be a constructor:
+        sym.name == nme.CONSTRUCTOR,
+        s"found: $sym (${sym.flags})"
+      )
+  }
+
+  @Test def caseClassHasCorrectMembers =
+    checkCompile("frontend", "case class Foo(x: Int, y: String)") { (tree, context) =>
+      implicit val ctx = context
+      val ccTree = tree.find(tree => tree.symbol.name == typeName("Foo")).get
+      val List(_, foo) = defPath(ccTree.symbol, tree).map(_.symbol.info)
+
+      val x :: y :: rest = foo.decls.toList
+
+      // Make sure we extracted the correct values from foo:
+      assert(x.name == termName("x"))
+      assert(y.name == termName("y"))
+
+      rest.foreach(validSym)
+    }
+
+  @Test def caseClassCompanionHasCorrectMembers =
+    checkCompile("frontend", "case class Foo(x: Int, y: String)") { (tree, context) =>
+      implicit val ctx = context
+      val ccTree = tree.find(tree => tree.symbol.name == termName("Foo")).get
+      val List(_, foo) = defPath(ccTree.symbol, tree).map(_.symbol.info)
+
+      foo.decls.foreach(validSym)
+    }
+}


### PR DESCRIPTION
It turned out that it was only methods with default parameters that were missing the synthetic flag.