### PR TITLE
Upgrade backend to fix Java interop for inner classes

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,7 @@ object DottyBuild extends Build {
   val JENKINS_BUILD = "dotty.jenkins.build"
   val DRONE_MEM = "dotty.drone.mem"
 
-  val scalaCompiler = "me.d-d" % "scala-compiler" % "2.11.5-20160322-171045-e19b30b3cd"
+  val scalaCompiler = "me.d-d" % "scala-compiler" % "2.11.5-20170111-125332-40bdc7b65a"
 
   val agentOptions = List(
     // "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"

--- a/tests/pos-java-interop/innerClass/Test.java
+++ b/tests/pos-java-interop/innerClass/Test.java
@@ -3,7 +3,6 @@ public class Test {
     Outer outer = new Outer();
     Outer.InnerInClass innerInClass = outer.inner();
 
-    // Does not work yet, requires https://github.com/DarkDimius/scala/pull/4
-    // Outer.InnerInObject innerInObject = new Outer.InnerInObject();
+    Outer.InnerInObject innerInObject = new Outer.InnerInObject();
   }
 }


### PR DESCRIPTION
The upgraded backend contains a single new PR:
https://github.com/DarkDimius/scala/pull/4 which fixes Java interop with
Dotty-emitted inner classes in objects.

Review by @DarkDimius