### PR TITLE
Fix #1750: Alternative fix for cyclic references due to illegal class overrides

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -338,6 +338,11 @@ object Checking {
     checkNoConflict(Final, Sealed)
     checkNoConflict(Private, Protected)
     checkNoConflict(Abstract, Override)
+    if (sym.isType && !sym.is(Deferred))
+      for (cls <- sym.allOverriddenSymbols.filter(_.isClass)) {
+        fail(i"$sym cannot have the same name as ${cls.showLocated} -- class definitions cannot be overridden")
+        sym.setFlag(Private) // break the overriding relationship by making sym Private
+      }
   }
 
   /** Check the type signature of the symbol `M` defined by `tree` does not refer

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -289,6 +289,8 @@ object RefChecks {
       if (!isOverrideAccessOK) {
         overrideAccessError()
       } else if (other.isClass) {
+        // direct overrides were already checked on completion (see Checking.chckWellFormed)
+        // the test here catches indirect overriddes between two inherited base types.
         overrideError("cannot be used here - class definitions cannot be overridden")
       } else if (!other.is(Deferred) && member.isClass) {
         overrideError("cannot be used here - classes can only override abstract types")

--- a/tests/neg/customArgs/overrideClass.scala
+++ b/tests/neg/customArgs/overrideClass.scala
@@ -8,8 +8,7 @@
   }
   trait FooB extends FooA {
     type A <: Ax;
-    trait Ax extends super.Ax { def xxx : Int; } // error: cyclic inheritance: trait Ax extends itself
-                                                 // (Note that inheriting a class of the same name is no longer allowed)
+    trait Ax extends super.Ax { def xxx : Int; } // error: cyclic inheritance: trait Ax extends itself) // error: class definitions cannot be overridden
     abstract class InnerB extends InnerA {
       // type B <: A;
       val a : A = doB;

--- a/tests/neg/i1750.scala
+++ b/tests/neg/i1750.scala
@@ -1,0 +1,12 @@
+trait Lang1 {
+  trait Exp
+  trait Visitor { def f(left: Exp): Unit }
+  class Eval1 extends Visitor { self =>
+    def f(left: Exp) = ()
+  }
+}
+trait Lang2 extends Lang1 {
+  class Visitor extends Eval1 { Visitor => // error: classes cannot be overridden
+  }
+}
+

--- a/tests/neg/i1750a.scala
+++ b/tests/neg/i1750a.scala
@@ -1,0 +1,13 @@
+trait Lang1 {
+  trait Exp
+  trait Visitor { def f(left: Exp): Unit }
+  class Eval1 extends Visitor { self =>
+    def f(left: Exp) = ()
+  }
+}
+trait Lang3 { self: Lang1 =>
+  class Visitor extends Eval1 { Visitor => // error: classes cannot be overridden
+  }
+}
+trait Lang4 extends Lang1 with Lang3
+

--- a/tests/neg/i1806.scala
+++ b/tests/neg/i1806.scala
@@ -2,6 +2,6 @@ trait A {
   class Inner
  }
 trait B extends A {
-  class Inner extends super.Inner // error
+  class Inner extends super.Inner // error // error
 }
 

--- a/tests/neg/overrides.scala
+++ b/tests/neg/overrides.scala
@@ -34,11 +34,6 @@ package p2 { // all being in the same package compiles fine
     }
   }
 
-  abstract class T3 extends T2 {
-    class A {   // error: classes cannot be overridden
-      bug()
-    }
-  }
 }
 
 class A[T] {

--- a/tests/neg/t7278.scala
+++ b/tests/neg/t7278.scala
@@ -1,5 +1,5 @@
 class A { class E }
-class B extends A { class E }
+class B extends A { class EB }
 trait C { type E = Int }
 trait D { type E = String }
 trait EC { type E }


### PR DESCRIPTION
Illegal class overrides are fundamentally at odds with the way dotty
represents types and therefore can cause lots of low-level problems.

Two measures in this commit:

First, we detect direct illegal class overrides on completion instead of
during RefChecks. Break the override by making the previously
overriding type private.

This fixes i1750.scala, but still fails for indirect overrides between
two unrelated outer traits/classes that are inherited by the same class or trait.
We fix this by catching the previously thrown ClassCastException
in both ExtractAPI and RefChecks.

Test case for indirect overrides is in i1750a.scala.

Review by @liufengyun 