### PR TITLE
Fix incorrect flatten of thicket inside interpolated string in UntpdTreeMap

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -476,7 +476,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       case SymbolLit(str) =>
         cpy.SymbolLit(tree)(str)
       case InterpolatedString(id, segments) =>
-        cpy.InterpolatedString(tree)(id, transform(segments))
+        cpy.InterpolatedString(tree)(id, segments.map(transform(_)))
       case Function(args, body) =>
         cpy.Function(tree)(transform(args), transform(body))
       case InfixOp(left, op, right) =>

--- a/compiler/test/dotty/tools/dotc/ast/UntypedTreeMapTest.scala
+++ b/compiler/test/dotty/tools/dotc/ast/UntypedTreeMapTest.scala
@@ -1,0 +1,32 @@
+package dotty.tools
+package dotc
+package ast
+
+import org.junit.Test
+import org.junit.Assert._
+
+import dotc.core.Contexts._
+import dotc.parsing.Parsers.Parser
+import dotc.util.SourceFile
+
+class UntpdTreeMapTest extends DottyTest {
+
+  import untpd._
+
+  def parse(code: String): Tree = {
+    val (_, stats) = new Parser(new SourceFile("<meta>", code.toCharArray)).templateStatSeq()
+    stats match { case List(stat) => stat; case stats => untpd.Thicket(stats) }
+  }
+
+  @Test
+  def testMapInterpolatedString = {
+    val tree = parse(""" q"hello ${2017}!" """)
+    val identity = new UntypedTreeMap {
+      override def transform(tree: Tree)(implicit ctx: Context): Tree = tree match {
+        case _ =>  super.transform(tree)
+      }
+    }
+
+    assertEquals(tree.toString, identity.transform(tree).toString)
+  }
+}


### PR DESCRIPTION
Previously, the thickets in `InterpolatedString` will be flattened during UntpdTreeMap. This commit addresses this problem.

Review @odersky .