### PR TITLE
Fix #1568 - avoid transforming error trees

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -573,6 +573,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       Try(tree: Tree)(expr, cases, finalizer)
   }
 
+  override def skipTransform(tree: Tree)(implicit ctx: Context) = tree.tpe.isError
+
   implicit class TreeOps[ThisTree <: tpd.Tree](val tree: ThisTree) extends AnyVal {
 
     def isValue(implicit ctx: Context): Boolean =

--- a/tests/neg/i1568.scala
+++ b/tests/neg/i1568.scala
@@ -1,0 +1,3 @@
+object Test {
+  inline def foo(n: Int) = foo(n) // error: cyclic reference
+}


### PR DESCRIPTION
If a tree has type error, subtrees may not have an assigned type.
Therefore we should avoid transforming such trees.