### PR TITLE
Weaken assumption in mergeCompanionDefs

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -491,7 +491,8 @@ class Namer { typer: Typer =>
         if (cdef.isClassDef) {
           classDef(name) = cdef
           cdef.attachmentOrElse(ExpandedTree, cdef) match {
-            case Thicket(cls :: mval :: (mcls @ TypeDef(_, _: Template)) :: crest) =>
+            case Thicket(cls :: mval :: (mcls @ TypeDef(mname, _: Template)) :: crest)
+            if name.moduleClassName == mname =>
               moduleDef(name) = mcls
             case _ =>
           }
@@ -505,7 +506,8 @@ class Namer { typer: Typer =>
         classDef get name.toTypeName match {
           case Some(cdef) =>
             cdef.attachmentOrElse(ExpandedTree, cdef) match {
-              case Thicket(cls :: mval :: TypeDef(_, compimpl: Template) :: crest) =>
+              case Thicket(cls :: mval :: TypeDef(mname, compimpl: Template) :: crest)
+              if name.moduleClassName == mname =>
                 val mcls1 = cpy.TypeDef(mcls)(
                     rhs = cpy.Template(impl)(body = compimpl.body ++ impl.body))
                 mdef.putAttachment(ExpandedTree, Thicket(vdef :: mcls1 :: rest))


### PR DESCRIPTION
Previously `mergeCompanionDefs` assumes that if the attachment of class `Foo` is as follows:

    x :: y :: tdef @ TypeDef(_, templ)

Then `tdef` must be `Foo$`. When there are multiple pre-typer transforms,
this is not necessarily true. For example, an annotation macro expansion may
expand a non-case class `Foo` to `class Foo; object FooA`.

We need to check the name of `tdef` to be equal to `Foo$`.

Review @odersky .