### PR TITLE
Positioned#initialPos: Union the position of every children

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -123,6 +123,8 @@ abstract class Positioned extends DotClass with Product {
 
   private def unionPos(pos: Position, xs: List[_]): Position = xs match {
     case (p: Positioned) :: xs1 => unionPos(pos union p.pos, xs1)
+    case (xs0: List[_]) :: xs1 => unionPos(unionPos(pos, xs0), xs1)
+    case _ :: xs1 => unionPos(pos, xs1)
     case _ => pos
   }
 


### PR DESCRIPTION
Previously we missed some children, one consequence of this is that the
position of the typed tree corresponding to the lambda "z => 1" did not
contain the position of "z".

Review by @odersky 