### PR TITLE
[WIP] bootstrap dotty with cbt

### DIFF
--- a/compiler-bootstrapped/build/build.scala
+++ b/compiler-bootstrapped/build/build.scala
@@ -1,0 +1,16 @@
+import cbt._
+class Build(val context: Context) extends Dotty{
+  def compilerDirectory = projectDirectory ++ "/../compiler"
+  override def dottyDependency = DirectoryDependency( compilerDirectory )
+  override def sources = Seq( compilerDirectory ++ "/src/dotty" )
+  def sbtV = "0.13.13"
+  override def dependencies: Seq[Dependency] =
+    Seq(
+      DirectoryDependency( projectDirectory ++ "/../library-bootstrapped" ),
+      DirectoryDependency( projectDirectory ++ "/../interfaces" )
+    ) ++
+    Resolver( mavenCentral ).bind(
+      "me.d-d" % "scala-compiler" % "2.11.5-20160322-171045-e19b30b3cd",
+      "com.typesafe.sbt" % "sbt-interface" % sbtV
+    )
+}

--- a/compiler/build/build.scala
+++ b/compiler/build/build.scala
@@ -1,0 +1,14 @@
+import cbt._
+class Build(val context: Context) extends BaseBuild{
+  override def sources = Seq(  projectDirectory ++ "/src/dotty" )
+  def sbtV = "0.13.13"
+  override def dependencies =
+    Seq(
+      DirectoryDependency( projectDirectory ++ "/../library" ),
+      DirectoryDependency( projectDirectory ++ "/../interfaces" )
+    ) ++
+    Resolver( mavenCentral ).bind(
+      "me.d-d" % "scala-compiler" % "2.11.5-20160322-171045-e19b30b3cd",
+      "com.typesafe.sbt" % "sbt-interface" % sbtV
+    )
+}

--- a/interfaces/build/build.scala
+++ b/interfaces/build/build.scala
@@ -1,0 +1,4 @@
+import cbt._
+class Build(val context: Context) extends BaseBuild{
+  override def sources = Seq(  projectDirectory ++ "/src/dotty" )
+}

--- a/library-bootstrapped/build/build.scala
+++ b/library-bootstrapped/build/build.scala
@@ -1,0 +1,13 @@
+import cbt._
+class Build(val context: Context) extends Dotty{
+  override def dottyDependency = DirectoryDependency( projectDirectory ++ "/../compiler" )
+  override def sources = Seq( "dotty", "scala", "scalaShadowing" ).map(
+    f => projectDirectory ++ ( "/../library/src/" + f )
+  )
+  def scalaV = "2.11.5"
+  override def dependencies =
+    Resolver( mavenCentral, sonatypeReleases ).bind(
+      "org.scala-lang" % "scala-reflect" % scalaV,
+      "org.scala-lang" % "scala-library" % scalaV
+    )
+}

--- a/library/build/build.scala
+++ b/library/build/build.scala
@@ -1,0 +1,12 @@
+import cbt._
+class Build(val context: Context) extends BaseBuild{
+  override def sources = Seq( "dotty", "scala", "scalaShadowing" ).map(
+    f => projectDirectory ++ ( "/src/" + f )
+  )
+  def scalaV = "2.11.5"
+  override def dependencies =
+    Resolver( mavenCentral, sonatypeReleases ).bind(
+      "org.scala-lang" % "scala-reflect" % scalaV,
+      "org.scala-lang" % "scala-library" % scalaV
+    )
+}


### PR DESCRIPTION
This bootstraps Dotty with cbt. It is not intended to be merged yet, but to serve as a platform for discussion of further steps. This does not run partest yet. I'll look into how to do that soon.

The structure is basically
```
library/  <- subproject building library with scalac
compiler/ <- subproject building Dotty with scalac
library-bootstrapped/  <- subproject building library with Dotty via dependency on project compiler
compiler-bootstrapped/ <- subproject building library with Dotty via dependency on project compiler and library
```

CBT requires java 8. Steps to bootstrap dotty are:
```
cd <directory where you want cbt>
git clone git@github.com:cvogt/cbt.git
git checkout c293f196d8555fa446b1276eb21857093a7ccefd # dev version of CBT required
cd <path to your dotty checkout>
git checkout cbt # cbt branch on dotty repo
cd compiler-bootstrapped
cbt direct compile
```

Dotty's bootstrapped class files will end up in `compiler-bootstrapped/target/dotty-0.1-20160926-ec28ea1-NIGHTLY/classes`.

The current setup uses CBT's "decentralized" multi-project build feature, which allows composing self-contained builds via `DirectoryDependency` on each other. A feature to do all of this in a single build/file is currently being reviewed and receiving final touches if you guys prefer that. It does reduce build file LOC overhead.