### PR TITLE
Support expecting compiler errors from all phases

### DIFF
--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTest.scala
@@ -57,8 +57,8 @@ trait ErrorMessagesTest extends DottyTest {
       }
   }
 
-  def checkMessages(source: String): Report = {
-    checkCompile("frontend", source) { (_,ictx) => () }
+  def checkMessagesAfter(checkAfterPhase: String)(source: String): Report = {
+    checkCompile(checkAfterPhase, source) { (_,ictx) => () }
     val rep = ctx.reporter.asInstanceOf[CapturingReporter].toReport
     ctx = freshReporter(ctx)
     rep

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -12,11 +12,11 @@ class ErrorMessagesTests extends ErrorMessagesTest {
   // In the case where there are no errors, we can do "expectNoErrors" in the
   // `Report`
   @Test def noErrors =
-    checkMessages("""class Foo""")
+    checkMessagesAfter("frontend")("""class Foo""")
     .expectNoErrors
 
   @Test def typeMismatch =
-    checkMessages {
+    checkMessagesAfter("frontend") {
       """
       |object Foo {
       |  def bar: String = 1


### PR DESCRIPTION
Improves @felixmulder's test tool for expecting error messages (see #1965) by adding which compiler phases to run before the error is expected.