### PR TITLE
Change 'overrides nothing' to report via Message (see #1965)

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1002,4 +1002,36 @@ object messages {
            |${typeCode}
            |"""
   }
+
+  case class OverridesNothing(member: Symbol)(implicit ctx: Context)
+  extends Message(37) {
+    val kind = "Reference"
+    val msg = hl"""${member} overrides nothing"""
+
+    val explanation =
+      hl"""|There must be a field or method with the name `${member.name}` in a super
+           |class of `${member.owner}` to override it. Did you misspell it?
+           |Are you extending the right classes?
+           |"""
+  }
+
+  case class OverridesNothingButNameExists(member: Symbol, existing: List[Denotations.SingleDenotation])(implicit ctx: Context)
+  extends Message(38) {
+    val kind = "Reference"
+    val msg = hl"""${member} has a different signature than the overridden declaration"""
+
+    val existingDecl = existing.map(_.showDcl).mkString("  \n")
+
+    val explanation =
+      hl"""|There must be a non-final field or method with the name `${member.name}` and the
+           |same parameter list in a super class of `${member.owner}` to override it.
+           |
+           |  ${member.showDcl}
+           |
+           |The super classes of `${member.owner}` contain the following members
+           |named `${member.name}`:
+           |  ${existingDecl}
+           |"""
+  }
+
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -57,10 +57,10 @@ class ErrorMessagesTests extends ErrorMessagesTest {
 
       assertMessageCount(1, messages)
       val OverridesNothing(member) :: Nil = messages
-      assertEquals("bar", member.name.toString)
+      assertEquals("bar", member.name.show)
     }
 
-  @Test def overridesNothingDifferntSignature =
+  @Test def overridesNothingDifferentSignature =
     checkMessagesAfter("refchecks") {
       """
         |class Bar {
@@ -80,9 +80,9 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertMessageCount(1, messages)
       val OverridesNothingButNameExists(member, sameName) :: Nil = messages
       // check expected context data
-      assertEquals("bar", member.name.toString)
+      assertEquals("bar", member.name.show)
       assertEquals(3, sameName.size)
-      assert(sameName.forall(_.symbol.name.toString == "bar"),
+      assert(sameName.forall(_.symbol.name.show == "bar"),
         "at least one method had an unexpected name")
     }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -42,4 +42,47 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       // is a type reference to `java.lang.String`
       assert(expected.dealias =:= defn.StringType, s"expected was: $expected")
     }
+
+  @Test def overridesNothing =
+    checkMessagesAfter("refchecks") {
+      """
+        |object Foo {
+        |  override def bar: Unit = {}
+        |}
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
+
+      assertMessageCount(1, messages)
+      val OverridesNothing(member) :: Nil = messages
+      assertEquals("bar", member.name.toString)
+    }
+
+  @Test def overridesNothingDifferntSignature =
+    checkMessagesAfter("refchecks") {
+      """
+        |class Bar {
+        |  def bar(s: String): Unit = {}
+        |  def bar(s: Int): Unit = {}
+        |  final def bar(s: Long): Unit = {}
+        |}
+        |object Foo extends Bar {
+        |  override def bar: Unit = {}
+        |}
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
+
+      assertMessageCount(1, messages)
+      val OverridesNothingButNameExists(member, sameName) :: Nil = messages
+      // check expected context data
+      assertEquals("bar", member.name.toString)
+      assertEquals(3, sameName.size)
+      assert(sameName.forall(_.symbol.name.toString == "bar"),
+        "at least one method had an unexpected name")
+    }
 }

--- a/tests/repl/overrides.check
+++ b/tests/repl/overrides.check
@@ -1,0 +1,17 @@
+scala> class B { override def foo(i: Int): Unit = {}; }
+-- [E037] Reference Error: <console> -------------------------------------------
+4 |class B { override def foo(i: Int): Unit = {}; }
+  |                       ^
+  |                       method foo overrides nothing
+
+longer explanation available when compiling with `-explain`
+scala> class A { def foo: Unit = {}; }
+defined class A
+scala> class B extends A { override def foo(i: Int): Unit = {}; }
+-- [E038] Reference Error: <console> -------------------------------------------
+5 |class B extends A { override def foo(i: Int): Unit = {}; }
+  |                                 ^
+  |      method foo has a different signature than the overridden declaration
+
+longer explanation available when compiling with `-explain`
+scala> :quit


### PR DESCRIPTION
'overrides nothing' is now reported as Message as descibed in #1589 (even though it is not listed in that issue.
I took the liberty to split the error into two different messages:
* overrides nothing - when name doesn't exist
* method foo has a different signature than the overridden declaration - when the name exists, but is not overriden by the declaration

Please review the explaining texts thoroughly as I'm not really sure what to call things properly.

I noticed `SingleDenotation.showDcl` creates non-valid code e.g. `def foo(i: Int)Unit` without the colon. Is there a better way to print declarations in the error messages? 