### PR TITLE
Ennru forward reference error

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1034,4 +1034,23 @@ object messages {
            |"""
   }
 
+  case class ForwardReferenceExtendsOverDefinition(value: Symbol, definition: Symbol)(implicit ctx: Context)
+  extends Message(39) {
+    val kind = "Reference"
+    val msg = hl"`${definition.name}` is a forward reference extending over the definition of `${value.name}`"
+
+    val explanation =
+      hl"""|`${definition.name}` is used before you define it, and the definition of `${value.name}`
+           |appears between that use and the definition of `${definition.name}`.
+           |
+           |Forward references are allowed only, if there are no value definitions between
+           |the reference and the referred method definition.
+           |
+           |Define `${definition.name}` before it is used,
+           |or move the definition of `${value.name}` so it does not appear between
+           |the declartion of `${definition.name}` and its use,
+           |or define `${value.name}` as lazy.
+           |""".stripMargin
+  }
+
 }

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -789,8 +789,7 @@ class RefChecks extends MiniPhase { thisTransformer =>
       if (sym.exists && sym.owner.isTerm && !sym.is(Lazy))
         currentLevel.levelAndIndex.get(sym) match {
           case Some((level, symIdx)) if symIdx < level.maxIndex =>
-            ctx.debuglog("refsym = " + level.refSym)
-            ctx.error(s"forward reference extends over definition of $sym", level.refPos)
+            ctx.error(ForwardReferenceExtendsOverDefinition(sym, level.refSym), level.refPos)
           case _ =>
         }
       tree

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -767,6 +767,7 @@ import RefChecks._
 class RefChecks extends MiniPhase { thisTransformer =>
 
   import tpd._
+  import reporting.diagnostic.messages.ForwardReferenceExtendsOverDefinition
 
   override def phaseName: String = "refchecks"
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -4,7 +4,6 @@ package reporting
 
 import core.Contexts.Context
 import diagnostic.messages._
-
 import org.junit.Assert._
 import org.junit.Test
 
@@ -85,4 +84,25 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assert(sameName.forall(_.symbol.name.show == "bar"),
         "at least one method had an unexpected name")
     }
+
+  @Test def forwardReference =
+    checkMessagesAfter("refchecks") {
+      """
+        |object Forward {
+        |  a.toInt
+        |  val b = 2
+        |  val a = BigDecimal("4")
+        |}
+      """.stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        val defn = ictx.definitions
+
+        assertMessageCount(1, messages)
+        val ForwardReferenceExtendsOverDefinition(value, definition) :: Nil = messages
+        assertEquals("value b", value.show)
+        assertEquals("value a", definition.show)
+      }
+
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -89,9 +89,11 @@ class ErrorMessagesTests extends ErrorMessagesTest {
     checkMessagesAfter("refchecks") {
       """
         |object Forward {
-        |  a.toInt
-        |  val b = 2
-        |  val a = BigDecimal("4")
+        |  def block = {
+        |    a.toInt
+        |    val b = 2
+        |    val a = BigDecimal("4")
+        |  }
         |}
       """.stripMargin
     }

--- a/tests/repl/errmsgs.check
+++ b/tests/repl/errmsgs.check
@@ -85,4 +85,11 @@ scala> val x: List[Int] = "foo" :: List(1)
   |                   found:    String($1$)
   |                   required: Int
   |                   
+scala> { def f: Int = g; val x: Int = 1; def g: Int = 5; }
+-- [E039] Reference Error: <console> -------------------------------------------
+5 |{ def f: Int = g; val x: Int = 1; def g: Int = 5; }
+  |               ^
+  |           `g` is a forward reference extending over the definition of `x`
+
+longer explanation available when compiling with `-explain`
 scala> :quit


### PR DESCRIPTION
@felixmulder
Another awsome error message giving more relevant context. 

There seem to be other checks for this error around that expect the old message, but I did not find out how to run those tests.

I removed the `ctx.debuglog` as that symbol is now included in the message.
