### PR TITLE
increase command wait time to 1s

### DIFF
--- a/compiler/test/debug/Gen.scala
+++ b/compiler/test/debug/Gen.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable.ListBuffer
 
 object Gen {
   val MainObject = "Test"
-  val CommandWait = 0.5
+  val CommandWait = 1
 
   sealed trait Tree
 


### PR DESCRIPTION
This change helps to further reduce non-determinism in the auto debug test. The problem
can happen when two consecute commands interfere:

     [expect]                          [jdb]

      cmd1          ---->
      sleep 0.5                 <---    part 1 of rep1
      read & match buffer
      clear buffer

      cmd2          ---->
                                <---    part 2 of rep1

If we still have problems with the automation debug after this, it is fine to disable them for now. Review @felixmulder .