### PR TITLE
Fix #1975: Align valdefs and for expressions for patterns

### DIFF
--- a/tests/pos/i1975.scala
+++ b/tests/pos/i1975.scala
@@ -1,0 +1,5 @@
+object Test {
+  val X = Seq(1, 2)
+
+  for (X <- Seq(3, 4)) yield println(X)
+}


### PR DESCRIPTION
val definitions and for expressions both distinguish whether
something is a pattern or a variable binding. They no do it
the same way: `ident` or an `ident: type` is a variable binding,
everything else is a pattern. Previously, capitalized idents
were considered as bindings in valdefs but as pattern in fors.