### PR TITLE
Change '... expected but found ...' to Message

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -17,7 +17,7 @@ abstract class TokensCommon {
 
   def showToken(token: Int) = {
     val str = tokenString(token)
-    if (keywords contains token) s"'$str'" else str
+    if (isKeyword(token)) s"'$str'" else str
   }
 
   val tokenString, debugString = new Array[String](maxToken + 1)
@@ -113,6 +113,8 @@ abstract class TokensCommon {
   //final val VIEWBOUND = 84;        enter(VIEWBOUND, "<%") // TODO: deprecate
 
   val keywords: TokenSet
+
+  def isKeyword(token: Token): Boolean = keywords contains token
 
   /** parentheses */
   final val LPAREN = 90;           enter(LPAREN, "'('")

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/Message.scala
@@ -119,6 +119,8 @@ class ExtendMessage(_msg: () => Message)(f: String => String) { self =>
 class NoExplanation(val msg: String) extends Message(NoExplanation.ID) {
   val explanation = ""
   val kind = ""
+
+  override def toString(): String = s"NoExplanation($msg)"
 }
 
 /** The extractor for `NoExplanation` can be used to check whether any error

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTest.scala
@@ -65,7 +65,7 @@ trait ErrorMessagesTest extends DottyTest {
   }
 
   def assertMessageCount(expected: Int, messages: List[Message]): Unit =
-    assertEquals(
+    assertEquals(messages.mkString,
       expected,
       messages.length
     )

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -4,6 +4,7 @@ package reporting
 
 import core.Contexts.Context
 import diagnostic.messages._
+import dotty.tools.dotc.parsing.Tokens
 import org.junit.Assert._
 import org.junit.Test
 
@@ -107,4 +108,32 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals("value a", definition.show)
       }
 
+  @Test def unexpectedToken =
+    checkMessagesAfter("frontend") {
+      """
+        |object Forward {
+        |  def val = "ds"
+        |}
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
+
+      assertMessageCount(1, messages)
+      val ExpectedTokenButFound(expected, found, foundName) :: Nil = messages
+      assertEquals(Tokens.IDENTIFIER, expected)
+      assertEquals(Tokens.VAL, found)
+      assertEquals("val", foundName.show)
+    }
+
+  @Test def expectedToken =
+    checkMessagesAfter("frontend") {
+      """
+        |object Forward {
+        |  def `val` = "ds"
+        |}
+      """.stripMargin
+    }
+    .expectNoErrors
 }


### PR DESCRIPTION
@felixmulder 
The parser's accept token error is now reported via Message. I added the name of the current token, but did not see a better way than ` != null` to test if there is a name available.