### PR TITLE
Change 'is abstract; cannot be instantiated' to Message

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -49,7 +49,9 @@ public enum ErrorMessageID {
     OverridesNothingButNameExistsID,
     ForwardReferenceExtendsOverDefinitionID,
     ExpectedTokenButFoundID,
-    MixedLeftAndRightAssociativeOpsID;
+    MixedLeftAndRightAssociativeOpsID,
+    CantInstantiateAbstractClassOrTraitID,
+    ;
 
     public int errorNumber() {
         return ordinal() - 2;

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1127,4 +1127,12 @@ object messages {
           |""".stripMargin
   }
 
+  case class CantInstantiateAbstractClassOrTrait(cls: Symbol, isTrait: Boolean)(implicit ctx: Context)
+  extends Message(CantInstantiateAbstractClassOrTraitID) {
+    val kind = "Usage"
+    private val traitOrAbstract = if (isTrait) hl"a trait" else hl"abstract"
+    val msg = hl"""${cls.name} is ${traitOrAbstract}; it cannot be instantiated"""
+    val explanation = ""
+  }
+
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1132,7 +1132,18 @@ object messages {
     val kind = "Usage"
     private val traitOrAbstract = if (isTrait) hl"a trait" else hl"abstract"
     val msg = hl"""${cls.name} is ${traitOrAbstract}; it cannot be instantiated"""
-    val explanation = ""
+    val explanation =
+      hl"""|Abstract classes and traits need to be extended by a concrete class or object
+           |to make their functionality accessible.
+           |
+           |You may want to create an anonymous class extending ${cls.name} with
+           |  ${s"class ${cls.name} { }"}
+           |  
+           |or add a companion object with
+           |  ${s"object ${cls.name} extends ${cls.name}"}
+           |
+           |You need to implement any abstract members in both cases.
+           |""".stripMargin
   }
 
 }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -29,6 +29,7 @@ import ErrorReporting.{err, errorType}
 import config.Printers.typr
 import collection.mutable
 import SymDenotations.NoCompleter
+import dotty.tools.dotc.reporting.diagnostic.messages.CantInstantiateAbstractClassOrTrait
 import dotty.tools.dotc.transform.ValueClasses._
 
 object Checking {
@@ -103,7 +104,7 @@ object Checking {
       case tref: TypeRef =>
         val cls = tref.symbol
         if (cls.is(AbstractOrTrait))
-          ctx.error(em"$cls is abstract; cannot be instantiated", pos)
+          ctx.error(CantInstantiateAbstractClassOrTrait(cls, isTrait = cls.is(Trait)), pos)
         if (!cls.is(Module)) {
           // Create a synthetic singleton type instance, and check whether
           // it conforms to the self type of the class as seen from that instance.

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -159,4 +159,43 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("+:", op2.show)
       assertFalse(op2LeftAssoc)
     }
+
+  @Test def cantInstantiateAbstract =
+    checkMessagesAfter("refchecks") {
+      """
+        |object Scope {
+        |  abstract class Concept
+        |  new Concept()
+        |}
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
+
+      assertMessageCount(1, messages)
+      val CantInstantiateAbstractClassOrTrait(cls, isTrait) :: Nil = messages
+      assertEquals("Concept", cls.name.show)
+      assertFalse("expected class", isTrait)
+    }
+
+  @Test def cantInstantiateTrait =
+    checkMessagesAfter("refchecks") {
+      """
+        |object Scope {
+        |  trait Concept
+        |  new Concept()
+        |}
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
+
+      assertMessageCount(1, messages)
+      val CantInstantiateAbstractClassOrTrait(cls, isTrait) :: Nil = messages
+      assertEquals("Concept", cls.name.show)
+      assertTrue("expected trait", isTrait)
+    }
+
 }


### PR DESCRIPTION
@felixmulder 
Next error to the case class scheme. Called its kind "Usage Error" - maybe the error kinds should be defined.