### PR TITLE
Don't inline when errors are detected

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -171,22 +171,6 @@ trait Reporting { this: Context =>
         throw ex
     }
   }
-
-  /** Implements a fold that applies the function `f` to the result of `op` if
-    * there are no new errors in the reporter
-    *
-    * @param op operation checked for errors
-    * @param f  function applied to result of op
-    * @return   either the result of `op` if it had errors or the result of `f`
-    *           applied to it
-    */
-  def withNoError[A, B >: A](op: => A)(f: A => B): B = {
-    val before = reporter.errorCount
-    val op0 = op
-
-    if (reporter.errorCount > before) op0
-    else f(op0)
-  }
 }
 
 /**

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1964,7 +1964,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
           if (Inliner.hasBodyToInline(tree.symbol) &&
               !ctx.owner.ownersIterator.exists(_.isInlineMethod) &&
               !ctx.settings.YnoInline.value &&
-              !ctx.isAfterTyper)
+              !ctx.isAfterTyper &&
+              !ctx.reporter.hasErrors)
             adapt(Inliner.inlineCall(tree, pt), pt)
           else if (ctx.typeComparer.GADTused && pt.isValueType)
             // Insert an explicit cast, so that -Ycheck in later phases succeeds.

--- a/tests/neg/i2006.scala
+++ b/tests/neg/i2006.scala
@@ -1,0 +1,10 @@
+object Test {
+
+  inline def foo(f: ImplicitFunction1[Int, Int]): AnyRef = f // error
+  inline def bar(f: ImplicitFunction1[Int, Int]) = f // error
+
+  def main(args: Array[String]) = {
+    foo(implicit thisTransaction => 43)
+    bar(implicit thisTransaction => 44)
+  }
+}


### PR DESCRIPTION
Inlining is only well-defined if the body to inline does not
have any errors. We therefore check for errors before we
perform any transformation of trees related to inlining.
The error check is global, i.e. we stop on any error
not just on errors in the code to be inlined. This is a safe
approximation, of course.

Fixes #2006.
