### PR TITLE
Fix #2009: Fix placeholder params logic for lambdas

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1001,7 +1001,7 @@ object Parsers {
 
         val t = expr1(location)
         if (in.token == ARROW) {
-          placeholderParams = Nil // don't interprete `_' to the left of `=>` as a placeholder
+          placeholderParams = Nil // don't interpret `_' to the left of `=>` as placeholder
           wrapPlaceholders(closureRest(start, location, convertToParams(t)))
         }
         else if (isWildcard(t)) {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1001,7 +1001,7 @@ object Parsers {
 
         val t = expr1(location)
         if (in.token == ARROW) {
-          placeholderParams = Nil
+          placeholderParams = Nil // don't interprete `_' to the left of `=>` as a placeholder
           wrapPlaceholders(closureRest(start, location, convertToParams(t)))
         }
         else if (isWildcard(t)) {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -993,20 +993,22 @@ object Parsers {
       else {
         val saved = placeholderParams
         placeholderParams = Nil
+
+        def wrapPlaceholders(t: Tree) = try
+          if (placeholderParams.isEmpty) t
+          else new WildcardFunction(placeholderParams.reverse, t)
+        finally placeholderParams = saved
+
         val t = expr1(location)
         if (in.token == ARROW) {
-          placeholderParams = saved
-          closureRest(start, location, convertToParams(t))
+          placeholderParams = Nil
+          wrapPlaceholders(closureRest(start, location, convertToParams(t)))
         }
         else if (isWildcard(t)) {
           placeholderParams = placeholderParams ::: saved
           t
         }
-        else
-          try
-            if (placeholderParams.isEmpty) t
-            else new WildcardFunction(placeholderParams.reverse, t)
-          finally placeholderParams = saved
+        else wrapPlaceholders(t)
       }
     }
 

--- a/tests/pos/i2009.scala
+++ b/tests/pos/i2009.scala
@@ -1,0 +1,9 @@
+object Test {
+
+  trait Gen[T] {
+    def map[U](f: T => U): Gen[U] = ???
+  }
+
+  def f[T](implicit g: Gen[T]): Gen[() => T] =
+    g map ( () => _ )
+}


### PR DESCRIPTION
Logic was missing placeholders in rhs of lambdas. 
