### PR TITLE
Fix #2020: Only the first parameters of a case class are caseaccessors

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -469,7 +469,13 @@ object desugar {
       val originalVparams = constr1.vparamss.toIterator.flatten
       val tparamAccessors = derivedTparams.map(_.withMods(originalTparams.next.mods))
       val caseAccessor = if (isCaseClass) CaseAccessor else EmptyFlags
-      val vparamAccessors = derivedVparamss.flatten.map(_.withMods(originalVparams.next.mods | caseAccessor))
+      val vparamAccessors = derivedVparamss match {
+        case first :: rest =>
+          first.map(_.withMods(originalVparams.next.mods | caseAccessor)) ++
+          rest.flatten.map(_.withMods(originalVparams.next.mods))
+        case _ =>
+          Nil
+      }
       cpy.TypeDef(cdef)(
         name = className,
         rhs = cpy.Template(impl)(constr, parents1, self1,

--- a/tests/run/i2020.scala
+++ b/tests/run/i2020.scala
@@ -1,0 +1,8 @@
+object Test {
+
+  case class Foo(x: Int)(y: Int)
+
+  def main(args: Array[String]) =
+    assert(Foo(1)(1) == Foo(1)(2))
+
+}


### PR DESCRIPTION
Only the parameters in the first parameter list of a case class should get
the `CaseAccessor` flag. Fixes #2020.