### PR TITLE
Fix import which produces flakey test results on Eclipse

### DIFF
--- a/compiler/test/dotty/tools/dotc/EntryPointsTest.scala.disabled
+++ b/compiler/test/dotty/tools/dotc/EntryPointsTest.scala.disabled
@@ -4,7 +4,7 @@ package dotc
 
 import org.junit.Test
 import org.junit.Assert._
-import dotty.tools.dotc.interfaces.{CompilerCallback, SourceFile}
+import interfaces.{CompilerCallback, SourceFile}
 import reporting._
 import reporting.diagnostic.MessageContainer
 import core.Contexts._


### PR DESCRIPTION
Previous import gave test errors under eclipse. Probably
due to some stray directory on the classpath.
