### PR TITLE
Change 'private, protected, or this expected' to Message

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2075,7 +2075,7 @@ object Parsers {
       val mods = modifiers(accessModifierTokens, annotsAsMods())
       if (mods.hasAnnotations && !mods.hasFlags)
         if (in.token == THIS) in.nextToken()
-        else syntaxError(AnnotatedPrimaryConstructorRequiresModifierOrThis(owner))
+        else syntaxError(AnnotatedPrimaryConstructorRequiresModifierOrThis(owner), mods.annotations.last.pos)
       mods
     }
 

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -51,6 +51,7 @@ public enum ErrorMessageID {
     ExpectedTokenButFoundID,
     MixedLeftAndRightAssociativeOpsID,
     CantInstantiateAbstractClassOrTraitID,
+    AnnotatedPrimaryConstructorRequiresModifierOrThisID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1146,4 +1146,18 @@ object messages {
            |""".stripMargin
   }
 
+  case class AnnotatedPrimaryConstructorRequiresModifierOrThis(cls: Name)(implicit ctx: Context)
+    extends Message(AnnotatedPrimaryConstructorRequiresModifierOrThisID) {
+    val kind = "Syntax"
+    val msg = hl"""${"private"}, ${"protected"}, or ${"this"} expected for annotated primary constructor"""
+    val explanation =
+      hl"""|When using annotations with a primary constructor of a class,
+           |the annotation must be followed by an access modifier
+           |(${"private"} or ${"protected"}) or ${"this"}.
+           |
+           |For example:
+           |  ${"class Sample @deprecated this(param: Parameter) { ..."}
+           |                           ^^^^
+           |""".stripMargin
+  }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -198,4 +198,18 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertTrue("expected trait", isTrait)
     }
 
+  @Test def constructorModifier =
+    checkMessagesAfter("frontend") {
+      """
+        |class AnotherClass @deprecated ()
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
+
+      assertMessageCount(1, messages)
+      val AnnotatedPrimaryConstructorRequiresModifierOrThis(cls) :: Nil = messages
+      assertEquals("AnotherClass", cls.show)
+    }
 }


### PR DESCRIPTION
@felixmulder 
Another error message with explanation. It captures the class name Symbol, but does not use it for now. 
I tried to get the error position indicator to move to the position where the keyword is missing, but did not manage to do so. Ideas?