### PR TITLE
Fix #2030: Don't chain implicit conversions

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1375,7 +1375,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
                 else WildcardType)
               val commonFormal = defn.FunctionOf(commonParamTypes, WildcardType)
               overload.println(i"pretype arg $arg with expected type $commonFormal")
-              pt.typedArg(arg, commonFormal)
+              pt.typedArg(arg, commonFormal)(ctx.addMode(Mode.ImplicitsEnabled))
             }
           }
         }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -496,6 +496,7 @@ trait Implicits { self: Typer =>
         || (to isRef defn.UnitClass)
         || (from.tpe isRef defn.NothingClass)
         || (from.tpe isRef defn.NullClass)
+        || !(ctx.mode is Mode.ImplicitsEnabled)
         || (from.tpe eq NoPrefix)) NoImplicitMatches
     else
       try inferImplicit(to.stripTypeVar.widenExpr, from, from.pos)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2023,7 +2023,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       // try an implicit conversion
       inferView(tree, pt) match {
         case SearchSuccess(inferred, _, _, _) =>
-          adapt(inferred, pt)
+          adapt(inferred, pt)(ctx.retractMode(Mode.ImplicitsEnabled))
         case failure: SearchFailure =>
           if (pt.isInstanceOf[ProtoType] && !failure.isInstanceOf[AmbiguousImplicits]) tree
           else err.typeMismatch(tree, pt, failure)

--- a/tests/neg/i2030.scala
+++ b/tests/neg/i2030.scala
@@ -1,0 +1,5 @@
+// This used to take ~12s, the check should be that
+// it runs in reasonable time (i.e. instantaneous).
+object a {
+   val x: String | Int = 'a // error
+}

--- a/tests/run/builder.check
+++ b/tests/run/builder.check
@@ -1,1 +1,1 @@
-Table(Row(Cell(A1), Cell(B1)), Row(Cell(A2), Cell(B2)))
+Table(Row(Cell(top left), Cell(top right)), Row(Cell(botttom left), Cell(bottom right)))

--- a/tests/run/builder.scala
+++ b/tests/run/builder.scala
@@ -12,9 +12,7 @@ class Row {
   override def toString = cells.mkString("Row(", ", ", ")")
 }
 
-class Cell(elem: String) {
-  override def toString = s"Cell($elem)"
-}
+case class Cell(elem: String)
 
 object Test {
 
@@ -36,12 +34,12 @@ object Test {
   val data =
     table {
       row {
-        cell("A1")
-        cell("B1")
+        cell("top left")
+        cell("top right")
       }
       row {
-        cell("A2")
-        cell("B2")
+        cell("botttom left")
+        cell("bottom right")
       }
     }
 


### PR DESCRIPTION
When inferring a view, we are not allowed to use another
implicit conversion to adapt its result. Fixing this revealed
another problem where we have to re-enable implicit conversions
when pre-typing arguments in overloading resolution.