### PR TITLE
Tailrec for derivesFrom/lookupRefined/classSymbol/classSymbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -607,7 +607,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
      *  owner to `to`, and continue until a non-weak owner is reached.
      */
     def changeOwner(from: Symbol, to: Symbol)(implicit ctx: Context): ThisTree = {
-      def loop(from: Symbol, froms: List[Symbol], tos: List[Symbol]): ThisTree = {
+      @tailrec def loop(from: Symbol, froms: List[Symbol], tos: List[Symbol]): ThisTree = {
         if (from.isWeakOwner && !from.owner.isClass)
           loop(from.owner, from :: froms, to :: tos)
         else {

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -6,6 +6,7 @@ import scala.util.{ Try, Success, Failure }
 import scala.reflect.internal.util.StringOps
 import reflect.ClassTag
 import core.Contexts._
+import scala.annotation.tailrec
 // import annotation.unchecked
   // Dotty deviation: Imports take precedence over definitions in enclosing package
   // (Note that @unchecked is in scala, not annotation, so annotation.unchecked gives
@@ -217,7 +218,7 @@ object Settings {
         case "--" :: args =>
           checkDependencies(stateWithArgs(skipped ++ args))
         case x :: _ if x startsWith "-" =>
-          def loop(settings: List[Setting[_]]): ArgsSummary = settings match {
+          @tailrec def loop(settings: List[Setting[_]]): ArgsSummary = settings match {
             case setting :: settings1 =>
               val state1 = setting.tryToSet(state)
               if (state1 ne state) processArguments(state1, processAll, skipped)

--- a/compiler/src/dotty/tools/dotc/core/Signature.scala
+++ b/compiler/src/dotty/tools/dotc/core/Signature.scala
@@ -4,6 +4,8 @@ package core
 import Names._, Types._, Contexts._, StdNames._
 import TypeErasure.sigName
 
+import scala.annotation.tailrec
+
 /** The signature of a denotation.
  *  Overloaded denotations with the same name are distinguished by
  *  their signatures. A signature of a method (of type PolyType,MethodType, or ExprType) is
@@ -41,7 +43,7 @@ case class Signature(paramsSig: List[TypeName], resSig: TypeName) {
    *  equal or on of them is tpnme.Uninstantiated.
    */
   final def consistentParams(that: Signature): Boolean = {
-    def loop(names1: List[TypeName], names2: List[TypeName]): Boolean =
+    @tailrec def loop(names1: List[TypeName], names2: List[TypeName]): Boolean =
       if (names1.isEmpty) names2.isEmpty
       else names2.nonEmpty && consistent(names1.head, names2.head) && loop(names1.tail, names2.tail)
     loop(this.paramsSig, that.paramsSig)

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1040,7 +1040,7 @@ object SymDenotations {
      *  pre: `this.owner` is in the base class sequence of `base`.
      */
     final def superSymbolIn(base: Symbol)(implicit ctx: Context): Symbol = {
-      def loop(bcs: List[ClassSymbol]): Symbol = bcs match {
+      @tailrec def loop(bcs: List[ClassSymbol]): Symbol = bcs match {
         case bc :: bcs1 =>
           val sym = matchingDecl(bcs.head, base.thisType)
             .suchThat(alt => !(alt is Deferred)).symbol
@@ -1056,7 +1056,7 @@ object SymDenotations {
      *  (2) it is abstract override and its super symbol in `base` is
      *      nonexistent or incomplete.
      */
-    final def isIncompleteIn(base: Symbol)(implicit ctx: Context): Boolean =
+    @tailrec final def isIncompleteIn(base: Symbol)(implicit ctx: Context): Boolean =
       (this is Deferred) ||
       (this is AbsOverride) && {
         val supersym = superSymbolIn(base)

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -10,6 +10,7 @@ import dotc.transform.ExplicitOuter._
 import dotc.transform.ValueClasses._
 import util.DotClass
 import Definitions.MaxImplementedFunctionArity
+import scala.annotation.tailrec
 
 /** Erased types are:
  *
@@ -244,7 +245,7 @@ object TypeErasure {
         case JavaArrayType(_) => defn.ObjectType
         case _ =>
           val cls2 = tp2.classSymbol
-          def loop(bcs: List[ClassSymbol], bestSoFar: ClassSymbol): ClassSymbol = bcs match {
+          @tailrec def loop(bcs: List[ClassSymbol], bestSoFar: ClassSymbol): ClassSymbol = bcs match {
             case bc :: bcs1 =>
               if (cls2.derivesFrom(bc))
                 if (!bc.is(Trait) && bc != defn.AnyClass) bc

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -153,16 +153,16 @@ object Types {
 
     /** Is this type an instance of a non-bottom subclass of the given class `cls`? */
     final def derivesFrom(cls: Symbol)(implicit ctx: Context): Boolean = {
-      def loop(tp: Type) = tp match {
+      def loop(tp: Type): Boolean = tp match {
         case tp: TypeRef =>
           val sym = tp.symbol
-          if (sym.isClass) sym.derivesFrom(cls) else tp.superType.derivesFrom(cls)
+          if (sym.isClass) sym.derivesFrom(cls) else loop(tp.superType): @tailrec
         case tp: TypeProxy =>
-          tp.underlying.derivesFrom(cls)
+          loop(tp.underlying): @tailrec
         case tp: AndType =>
-          tp.tp1.derivesFrom(cls) || tp.tp2.derivesFrom(cls)
+          loop(tp.tp1) || loop(tp.tp2): @tailrec
         case tp: OrType =>
-          tp.tp1.derivesFrom(cls) && tp.tp2.derivesFrom(cls)
+          loop(tp.tp1) && loop(tp.tp2): @tailrec
         case tp: JavaArrayType =>
           cls == defn.ObjectClass
         case _ =>
@@ -1011,7 +1011,7 @@ object Types {
           }
           else NoType
         case SkolemType(tp) =>
-          tp.lookupRefined(name)
+          loop(tp)
         case pre: WildcardType =>
           WildcardType
         case pre: TypeRef =>

--- a/compiler/src/dotty/tools/dotc/rewrite/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrite/Rewrites.scala
@@ -5,6 +5,7 @@ import util.{SourceFile, Positions}
 import Positions.Position
 import core.Contexts.{Context, FreshContext}
 import collection.mutable
+import scala.annotation.tailrec
 
 /** Handles rewriting of Scala2 files to Dotty */
 object Rewrites {
@@ -29,7 +30,7 @@ object Rewrites {
           p2
         }
       val ds = new Array[Char](cs.length + delta)
-      def loop(ps: List[Patch], inIdx: Int, outIdx: Int): Unit = {
+      @tailrec def loop(ps: List[Patch], inIdx: Int, outIdx: Int): Unit = {
         def copy(upTo: Int): Int = {
           val untouched = upTo - inIdx
           Array.copy(cs, inIdx, ds, outIdx, untouched)

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -16,7 +16,9 @@ import SymUtils._
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Phases.Phase
 import util.Property
+
 import collection.mutable
+import scala.annotation.tailrec
 
 /** This phase adds outer accessors to classes and traits that need them.
  *  Compared to Scala 2.x, it tries to minimize the set of classes
@@ -367,7 +369,7 @@ object ExplicitOuter {
     def path(start: Tree = This(ctx.owner.lexicallyEnclosingClass.asClass),
              toCls: Symbol = NoSymbol,
              count: Int = -1): Tree = try {
-      def loop(tree: Tree, count: Int): Tree = {
+      @tailrec def loop(tree: Tree, count: Int): Tree = {
         val treeCls = tree.tpe.widen.classSymbol
         val outerAccessorCtx = ctx.withPhaseNoLater(ctx.lambdaLiftPhase) // lambdalift mangles local class names, which means we cannot reliably find outer acessors anymore
         ctx.log(i"outer to $toCls of $tree: ${tree.tpe}, looking for ${outerAccName(treeCls.asClass)(outerAccessorCtx)} in $treeCls")

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -12,7 +12,9 @@ import StdNames._
 import NameOps._
 import Flags._
 import Annotations._
+
 import language.implicitConversions
+import scala.annotation.tailrec
 
 object SymUtils {
   implicit def decorateSymbol(sym: Symbol): SymUtils = new SymUtils(sym)
@@ -59,14 +61,14 @@ class SymUtils(val self: Symbol) extends AnyVal {
   }
 
   /** The closest enclosing method or class of this symbol */
-  final def enclosingMethodOrClass(implicit ctx: Context): Symbol =
+  @tailrec final def enclosingMethodOrClass(implicit ctx: Context): Symbol =
     if (self.is(Method, butNot = Label) || self.isClass) self
     else if (self.exists) self.owner.enclosingMethodOrClass
     else NoSymbol
 
   /** Apply symbol/symbol substitution to this symbol */
   def subst(from: List[Symbol], to: List[Symbol]): Symbol = {
-    def loop(from: List[Symbol], to: List[Symbol]): Symbol =
+    @tailrec def loop(from: List[Symbol], to: List[Symbol]): Symbol =
       if (from.isEmpty) self
       else if (self eq from.head) to.head
       else loop(from.tail, to.tail)

--- a/compiler/src/dotty/tools/io/Jar.scala
+++ b/compiler/src/dotty/tools/io/Jar.scala
@@ -12,6 +12,7 @@ import java.util.jar._
 import scala.collection.JavaConverters._
 import Attributes.Name
 import scala.language.{postfixOps, implicitConversions}
+import scala.annotation.tailrec
 
 // Attributes.Name instances:
 //
@@ -109,7 +110,7 @@ class JarWriter(val file: File, val manifest: Manifest) {
 
   private def transfer(in: InputStream, out: OutputStream) = {
     val buf = new Array[Byte](10240)
-    def loop(): Unit = in.read(buf, 0, buf.length) match {
+    @tailrec def loop(): Unit = in.read(buf, 0, buf.length) match {
       case -1 => in.close()
       case n  => out.write(buf, 0, n) ; loop
     }

--- a/compiler/src/strawman/collections/CollectionStrawMan6.scala
+++ b/compiler/src/strawman/collections/CollectionStrawMan6.scala
@@ -244,7 +244,7 @@ object CollectionStrawMan6 extends LowPriority {
      *  collection type.
      */
     override def drop(n: Int): C[A @uncheckedVariance] = { // sound bcs of VarianceNote
-      def loop(n: Int, s: Iterable[A]): C[A] =
+      @tailrec def loop(n: Int, s: Iterable[A]): C[A] =
         if (n <= 0) s.asInstanceOf[C[A]]
            // implicit contract to guarantee success of asInstanceOf:
            //   (1) coll is of type C[A]

--- a/compiler/test/dotty/tools/dotc/CompilerTest.scala
+++ b/compiler/test/dotty/tools/dotc/CompilerTest.scala
@@ -500,12 +500,12 @@ abstract class CompilerTest {
     * that aren't in extensionsToCopy. */
   private def recCopyFiles(sourceFile: Path, dest: Path): Unit = {
 
-    def copyfile(file: SFile, bytewise: Boolean): Unit = {
+    @tailrec def copyfile(file: SFile, bytewise: Boolean): Unit = {
       if (bytewise) {
         val in = file.inputStream()
         val out = SFile(dest).outputStream()
         val buffer = new Array[Byte](1024)
-        def loop(available: Int):Unit = {
+        @tailrec def loop(available: Int):Unit = {
           if (available < 0) {()}
           else {
             out.write(buffer, 0, available)


### PR DESCRIPTION
Fist two commits make changes to loops, the third only adds `@tailrec` annotations.