### PR TITLE
Drop named type parameters in classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -253,9 +253,6 @@ trait ConstraintHandling {
     if (fromBelow && isOrType(inst) && isFullyDefined(inst) && !isOrType(upperBound))
       inst = ctx.harmonizeUnion(inst)
 
-    // 3. If instance is from below, and upper bound has open named parameters
-    //    make sure the instance has all named parameters of the bound.
-    if (fromBelow) inst = inst.widenToNamedTypeParams(param.namedTypeParams)
     inst
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -613,9 +613,6 @@ object Flags {
   /** A private parameter accessor */
   final val PrivateParamAccessor = allOf(Private, ParamAccessor)
 
-  /** A type parameter introduced with [type ... ] */
-  final val NamedTypeParam = allOf(TypeParam, ParamAccessor)
-
   /** A local parameter */
   final val ParamAndLocal = allOf(Param, Local)
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1086,9 +1086,6 @@ object SymDenotations {
     /** The type parameters of a class symbol, Nil for all other symbols */
     def typeParams(implicit ctx: Context): List[TypeSymbol] = Nil
 
-    /** The named type parameters declared or inherited by this symbol */
-    def namedTypeParams(implicit ctx: Context): Set[TypeSymbol] = Set()
-
     /** The type This(cls), where cls is this class, NoPrefix for all other symbols */
     def thisType(implicit ctx: Context): Type = NoPrefix
 
@@ -1226,11 +1223,9 @@ object SymDenotations {
     /** TODO: Document why caches are supposedly safe to use */
     private[this] var myTypeParams: List[TypeSymbol] = _
 
-    private[this] var myNamedTypeParams: Set[TypeSymbol] = _
-
     /** The type parameters in this class, in the order they appear in the current
      *  scope `decls`. This might be temporarily the incorrect order when
-     *  reading Scala2 pickled info. The problem is fixed by `updateTypeParams`
+     *  reading Scala2 pickled info. The problem is fixed by `ensureTypeParamsInCorrectOrder`,
      *  which is called once an unpickled symbol has been completed.
      */
     private def typeParamsFromDecls(implicit ctx: Context) =
@@ -1251,16 +1246,6 @@ object SymDenotations {
             }
           }
       myTypeParams
-    }
-
-    /** The named type parameters declared or inherited by this class */
-    override final def namedTypeParams(implicit ctx: Context): Set[TypeSymbol] = {
-      def computeNamedTypeParams: Set[TypeSymbol] =
-        if (ctx.erasedTypes || is(Module)) Set() // fast return for modules to avoid scanning package decls
-        else memberNames(abstractTypeNameFilter).map(name =>
-          info.member(name).symbol.asType).filter(_.is(TypeParam, butNot = ExpandedName)).toSet
-      if (myNamedTypeParams == null) myNamedTypeParams = computeNamedTypeParams
-      myNamedTypeParams
     }
 
     override protected[dotc] final def info_=(tp: Type) = {

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1264,22 +1264,10 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     }
   }
 
-  /** `op(tp1, tp2)` unless `tp1` and `tp2` are type-constructors with at least
-   *  some unnamed type parameters.
+  /** `op(tp1, tp2)` unless `tp1` and `tp2` are type-constructors.
    *  In the latter case, combine `tp1` and `tp2` under a type lambda like this:
    *
    *    [X1, ..., Xn] -> op(tp1[X1, ..., Xn], tp2[X1, ..., Xn])
-   *
-   *  Note: There is a tension between named and positional parameters here, which
-   *  is impossible to resolve completely. Say you have
-   *
-   *    C[type T], D[type U]
-   *
-   *  Then do you expand `C & D` to `[T] -> C[T] & D[T]` or not? Under the named
-   *  type parameter interpretation, this would be wrong whereas under the traditional
-   *  higher-kinded interpretation this would be required. The problem arises from
-   *  allowing both interpretations. A possible remedy is to be somehow stricter
-   *  in where we allow which interpretation.
    */
   private def liftIfHK(tp1: Type, tp2: Type, op: (Type, Type) => Type, original: (Type, Type) => Type) = {
     val tparams1 = tp1.typeParams

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -428,16 +428,10 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         case tp: TypeRef =>
           tp
         case tp @ RefinedType(tp1, name: TypeName, rinfo) =>
-          rinfo match {
-            case TypeAlias(TypeRef(pre, name1)) if name1 == name && (pre =:= cls.thisType) =>
-              // Don't record refinements of the form X = this.X (These can arise using named parameters).
-              typr.println(s"dropping refinement $tp")
-            case _ =>
-              val prevInfo = refinements(name)
-              refinements = refinements.updated(name,
-                if (prevInfo == null) tp.refinedInfo else prevInfo & tp.refinedInfo)
-              formals = formals.updated(name, tp1.typeParamNamed(name))
-          }
+          val prevInfo = refinements(name)
+          refinements = refinements.updated(name,
+            if (prevInfo == null) tp.refinedInfo else prevInfo & tp.refinedInfo)
+          formals = formals.updated(name, tp1.typeParamNamed(name))
           normalizeToRef(tp1)
         case _: ErrorType =>
           defn.AnyType

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -549,13 +549,7 @@ object Types {
 
       def goThis(tp: ThisType) = {
         val d = go(tp.underlying)
-        if (d.exists)
-          if ((pre eq tp) && d.symbol.is(NamedTypeParam) && (d.symbol.owner eq tp.cls))
-            // If we look for a named type parameter `P` in `C.this.P`, looking up
-            // the fully applied self type of `C` will give as an info the alias type
-            // `P = this.P`. We need to return a denotation with the underlying bounds instead.
-            d.symbol.denot
-          else d
+        if (d.exists) d
         else
           // There is a special case to handle:
           //   trait Super { this: Sub => private class Inner {} println(this.Inner) }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -32,7 +32,6 @@ public enum ErrorMessageID {
     ByNameParameterNotSupportedID,
     WrongNumberOfTypeArgsID,
     IllegalVariableInPatternAlternativeID,
-    TypeParamsTypeExpectedID,
     IdentifierExpectedID,
     AuxConstructorNeedsNonImplicitParameterID,
     IncorrectRepeatedParameterSyntaxID,

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -691,19 +691,6 @@ object messages {
     }
   }
 
-  case class TypeParamsTypeExpected(mods: untpd.Modifiers, identifier: TermName)(implicit ctx: Context)
-  extends Message(TypeParamsTypeExpectedID) {
-    val kind = "Syntax"
-    val msg = hl"""Expected ${"type"} keyword for type parameter $identifier"""
-    val explanation =
-      hl"""|This happens when you add modifiers like ${"private"} or ${"protected"}
-           |to your type parameter definition without adding the ${"type"} keyword.
-           |
-           |Add ${"type"} to your code, e.g.:
-           |${s"trait A[${mods.flags} type $identifier]"}
-           |"""
-  }
-
   case class IdentifierExpected(identifier: String)(implicit ctx: Context)
   extends Message(IdentifierExpectedID) {
     val kind = "Syntax"
@@ -1138,7 +1125,7 @@ object messages {
            |
            |You may want to create an anonymous class extending ${cls.name} with
            |  ${s"class ${cls.name} { }"}
-           |  
+           |
            |or add a companion object with
            |  ${s"object ${cls.name} extends ${cls.name}"}
            |

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -241,8 +241,6 @@ object RefChecks {
           isDefaultGetter(member.name) || // default getters are not checked for compatibility
           memberTp.overrides(otherTp)
 
-      def domain(sym: Symbol): Set[Name] = sym.info.namedTypeParams.map(_.name)
-
       //Console.println(infoString(member) + " overrides " + infoString(other) + " in " + clazz);//DEBUG
 
       // return if we already checked this combination elsewhere
@@ -344,9 +342,6 @@ object RefChecks {
         overrideError("cannot be used here - only term macros can override term macros")
       } else if (!compatibleTypes) {
         overrideError("has incompatible type" + err.whyNoMatchStr(memberTp, otherTp))
-      } else if (member.isType && domain(member) != domain(other)) {
-        overrideError("has different named type parameters: "+
-             i"[${domain(member).toList}%, %] instead of [${domain(other).toList}%, %]")
       } else {
         checkOverrideDeprecated()
       }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1064,23 +1064,21 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     }
     else {
       var args = tree.args
-      val args1 =
-        if (hasNamedArg(args)) typedNamedArgs(args)
-        else {
-          if (args.length != tparams.length) {
-            wrongNumberOfTypeArgs(tpt1.tpe, tparams, args, tree.pos)
-            args = args.take(tparams.length)
-          }
-          def typedArg(arg: untpd.Tree, tparam: TypeParamInfo) = {
-            val (desugaredArg, argPt) =
-              if (ctx.mode is Mode.Pattern)
-                (if (isVarPattern(arg)) desugar.patternVar(arg) else arg, tparam.paramBounds)
-              else
-                (arg, WildcardType)
-            typed(desugaredArg, argPt)
-          }
-          args.zipWithConserve(tparams)(typedArg(_, _)).asInstanceOf[List[Tree]]
+      val args1 = {
+        if (args.length != tparams.length) {
+          wrongNumberOfTypeArgs(tpt1.tpe, tparams, args, tree.pos)
+          args = args.take(tparams.length)
         }
+        def typedArg(arg: untpd.Tree, tparam: TypeParamInfo) = {
+          val (desugaredArg, argPt) =
+            if (ctx.mode is Mode.Pattern)
+              (if (isVarPattern(arg)) desugar.patternVar(arg) else arg, tparam.paramBounds)
+            else
+              (arg, WildcardType)
+          typed(desugaredArg, argPt)
+        }
+        args.zipWithConserve(tparams)(typedArg(_, _)).asInstanceOf[List[Tree]]
+      }
       // check that arguments conform to bounds is done in phase PostTyper
       assignType(cpy.AppliedTypeTree(tree)(tpt1, args1), tpt1, args1)
     }

--- a/compiler/test/dotty/tools/dotc/parsing/ModifiersParsingTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ModifiersParsingTest.scala
@@ -95,9 +95,6 @@ class ModifiersParsingTest {
 
     source = "class A[T]"
     assert(source.firstTypeParam.modifiers == List())
-
-    source = "class A[type T]"
-    assert(source.firstTypeParam.modifiers == List(Mod.Type()))
   }
 
   @Test def typeDef = {

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -126,7 +126,7 @@ InfixType         ::=  RefinedType {id [nl] RefinedType}                        
 RefinedType       ::=  WithType {[nl] Refinement}                               RefinedTypeTree(t, ds)
 WithType          ::=  AnnotType {‘with’ AnnotType}                             (deprecated)
 AnnotType         ::=  SimpleType {Annotation}                                  Annotated(t, annot)
-SimpleType        ::=  SimpleType (TypeArgs | NamedTypeArgs)                    AppliedTypeTree(t, args)
+SimpleType        ::=  SimpleType TypeArgs                                      AppliedTypeTree(t, args)
                     |  SimpleType ‘#’ id                                        Select(t, name)
                     |  StableId
                     |  Path ‘.’ ‘type’                                          SingletonTypeTree(p)
@@ -240,7 +240,7 @@ ArgumentPatterns  ::=  ‘(’ [Patterns] ‘)’                               
 ### Type and Value Parameters
 ```ebnf
 ClsTypeParamClause::=  ‘[’ ClsTypeParam {‘,’ ClsTypeParam} ‘]’
-ClsTypeParam      ::=  {Annotation} [{Modifier} type] [‘+’ | ‘-’]               TypeDef(Modifiers, name, tparams, bounds)
+ClsTypeParam      ::=  {Annotation} [‘+’ | ‘-’]                                   TypeDef(Modifiers, name, tparams, bounds)
                        id [HkTypeParamClause] TypeParamBounds                   Bound(below, above, context)
 
 DefTypeParamClause::=  ‘[’ DefTypeParam {‘,’ DefTypeParam} ‘]’

--- a/tests/neg/namedTypeParams.scala
+++ b/tests/neg/namedTypeParams.scala
@@ -1,0 +1,12 @@
+class C[T]
+class D[type T] // error: identifier expected, but `type` found
+
+object Test {
+
+  val x: C[T = Int] = // error:  ']' expected, but `=` found // error
+    new C[T = Int] // error:  ']' expected, but `=` found // error
+
+  class E extends C[T = Int] // error: ']' expected, but `=` found // error
+  class F extends C[T = Int]() // error: ']' expected, but `=` found // error
+
+}

--- a/tests/repl/errmsgs.check
+++ b/tests/repl/errmsgs.check
@@ -86,7 +86,7 @@ scala> val x: List[Int] = "foo" :: List(1)
   |                   required: Int
   |                   
 scala> { def f: Int = g; val x: Int = 1; def g: Int = 5; }
--- [E039] Reference Error: <console> -------------------------------------------
+-- [E038] Reference Error: <console> -------------------------------------------
 5 |{ def f: Int = g; val x: Int = 1; def g: Int = 5; }
   |               ^
   |           `g` is a forward reference extending over the definition of `x`

--- a/tests/repl/overrides.check
+++ b/tests/repl/overrides.check
@@ -1,5 +1,5 @@
 scala> class B { override def foo(i: Int): Unit = {}; }
--- [E037] Reference Error: <console> -------------------------------------------
+-- [E036] Reference Error: <console> -------------------------------------------
 4 |class B { override def foo(i: Int): Unit = {}; }
   |                       ^
   |                       method foo overrides nothing
@@ -8,7 +8,7 @@ longer explanation available when compiling with `-explain`
 scala> class A { def foo: Unit = {}; }
 defined class A
 scala> class B extends A { override def foo(i: Int): Unit = {}; }
--- [E038] Reference Error: <console> -------------------------------------------
+-- [E037] Reference Error: <console> -------------------------------------------
 5 |class B extends A { override def foo(i: Int): Unit = {}; }
   |                                 ^
   |      method foo has a different signature than the overridden declaration


### PR DESCRIPTION
Drop the [type T] syntax, and what's associated to make it work.

Motivation: It's an alternative way of doing things for which there seems
to be little need. The implementation was provisional and bitrotted during
the various iterations to introduce higher-kinded types. So in the end the
complxity-cost for language and compiler was not worth the added benefit
that [type T] parameters provide.

Note that we still accept _named arguments_ [A = T] in expressions; these are useful
for specifying some parameters and letting others be inferred.

Review by @smarter