### PR TITLE
Fix #2056: Backend crash when inlined method contains try

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -712,8 +712,11 @@ object Trees {
     override def toList: List[Tree[T]] = flatten(trees)
     override def toString = if (isEmpty) "EmptyTree" else "Thicket(" + trees.mkString(", ") + ")"
     override def withPos(pos: Position): this.type = {
-      val newTrees = trees.map(_.withPos(pos))
-      new Thicket[T](newTrees).asInstanceOf[this.type]
+      val newTrees = trees.mapConserve(_.withPos(pos))
+      if (trees eq newTrees)
+        this
+      else
+        new Thicket[T](newTrees).asInstanceOf[this.type]
     }
     override def pos = (NoPosition /: trees) ((pos, t) => pos union t.pos)
     override def foreachInThicket(op: Tree[T] => Unit): Unit =

--- a/tests/pos/i2056.scala
+++ b/tests/pos/i2056.scala
@@ -1,0 +1,13 @@
+object Test {
+  inline def crash() = {
+    try {
+      println("hi")
+    } catch {
+      case e: Exception =>
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    crash()
+  }
+}


### PR DESCRIPTION
In various places we do "case EmptyTree =>", since Tree#equals uses
reference equality this means that EmptyTree should never be copied,
otherwise some other code path will be taken.