### PR TITLE
Fix incremental overcompilation due to instabilities

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -350,7 +350,7 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
       case tp: NamedType =>
         val sym = tp.symbol
         // Normalize package prefix to avoid instability of representation
-        val prefix = if (sym.isClass && sym.owner.is(Package))
+        val prefix = if (sym.owner.is(Package))
           sym.owner.thisType
         else
           tp.prefix
@@ -358,7 +358,7 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
       case TypeApplications.AppliedType(tycon, args) =>
         def processArg(arg: Type): api.Type = arg match {
           case arg @ TypeBounds(lo, hi) => // Handle wildcard parameters
-            if (lo.eq(defn.NothingType) && hi.eq(defn.AnyType))
+            if (lo.isDirectRef(defn.NothingClass) && hi.isDirectRef(defn.AnyClass))
               Constants.emptyType
             else {
               val name = "_"


### PR DESCRIPTION
The output of ExtractAPI should be stable, otherwise sbt might
incorrectly conclude that some API changed because its hash is
different, even though the source hasn't changed. This commit fixes two
cases where this might happen:
- package prefixes in NamedTypes are unstable, we already worked around this by
  normalizing them, but only for classes, we now always do it.
- We use a simplified representation for `_ >: Nothing <: Any`, this is
  now checked using `isDirectRef` instead of referential equality on types
  since there is more than one way to represent `Nothing` and `Any`.