### PR TITLE
Fix #2064: Avoid illegal types in OrDominator

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -239,7 +239,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         case tp1: RecType =>
           tp1.rebind(approximateOr(tp1.parent, tp2))
         case tp1: TypeProxy if !isClassRef(tp1) =>
-          orDominator(tp1.superType.bounds.hi | tp2)
+          orDominator(tp1.superType | tp2)
         case _ =>
           tp2 match {
             case tp2: RecType =>

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -239,7 +239,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         case tp1: RecType =>
           tp1.rebind(approximateOr(tp1.parent, tp2))
         case tp1: TypeProxy if !isClassRef(tp1) =>
-          orDominator(tp1.superType | tp2)
+          orDominator(tp1.superType.bounds.hi | tp2)
         case _ =>
           tp2 match {
             case tp2: RecType =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1273,8 +1273,9 @@ object Types {
     def underlying(implicit ctx: Context): Type
 
     /** The closest supertype of this type. This is the same as `underlying`,
-     *  except for TypeRefs where the upper bound is returned, and HKApplys,
-     *  where the upper bound of the constructor is re-applied to the arguments.
+     *  except that
+     *    - instead of a TyperBounds type it returns its upper bound, and
+     *    - for HKApplys it returns the upper bound of the constructor re-applied to the arguments.
      */
     def superType(implicit ctx: Context): Type = underlying match {
       case TypeBounds(_, hi) => hi

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1276,7 +1276,10 @@ object Types {
      *  except for TypeRefs where the upper bound is returned, and HKApplys,
      *  where the upper bound of the constructor is re-applied to the arguments.
      */
-    def superType(implicit ctx: Context): Type = underlying
+    def superType(implicit ctx: Context): Type = underlying match {
+      case TypeBounds(_, hi) => hi
+      case st => st
+    }
   }
 
   // Every type has to inherit one of the following four abstract type classes.,
@@ -1762,11 +1765,6 @@ object Types {
     type ThisType = TypeRef
 
     override def underlying(implicit ctx: Context): Type = info
-
-    override def superType(implicit ctx: Context): Type = info match {
-      case TypeBounds(_, hi) => hi
-      case _ => info
-    }
   }
 
   final class TermRefWithSignature(prefix: Type, name: TermName, override val sig: Signature) extends TermRef(prefix, name) {

--- a/tests/pos/i2064.scala
+++ b/tests/pos/i2064.scala
@@ -1,0 +1,15 @@
+object p {
+
+class Foo[T] {
+  // Crashes:
+  def f(): Foo[T] = (if (true) this else this).bar
+
+  // Works:
+  // def f(): Foo[T] = new Bar(if (true) this else this).bar
+}
+
+implicit class Bar[A](val self: A) {
+  def bar(): A = self
+}
+
+}


### PR DESCRIPTION
Need to skip type bounds in `underlying` chain, since
TypeBounds is not a legal operand type for OrType.

Fixes #2064 