### PR TITLE
Fix bug in erasedLub leading to incorrect signatures

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -246,10 +246,14 @@ object TypeErasure {
           val cls2 = tp2.classSymbol
           def loop(bcs: List[ClassSymbol], bestSoFar: ClassSymbol): ClassSymbol = bcs match {
             case bc :: bcs1 =>
-              if (cls2.derivesFrom(bc))
-                if (!bc.is(Trait) && bc != defn.AnyClass) bc
-                else loop(bcs1, if (bestSoFar.derivesFrom(bc)) bestSoFar else bc)
-              else
+              if (cls2.derivesFrom(bc)) {
+                val newBest = if (bestSoFar.derivesFrom(bc)) bestSoFar else bc
+
+                if (!bc.is(Trait) && bc != defn.AnyClass)
+                  newBest
+                else
+                  loop(bcs1, newBest)
+              } else
                 loop(bcs1, bestSoFar)
             case nil =>
               bestSoFar

--- a/tests/pos/erased-lub-2.scala
+++ b/tests/pos/erased-lub-2.scala
@@ -1,0 +1,15 @@
+trait Foo
+
+trait PF[A, +B] {
+  def apply(x: A): B
+}
+
+object Test {
+  def orElse2[A1, B1 >: Foo](that: PF[A1, B1]): PF[A1, B1] = ???
+
+  def identity[E]: PF[E, E] = ???
+
+  def foo: PF[Foo, Foo] = ???
+
+  def bla(foo: Foo) = orElse2(identity).apply(foo)
+}


### PR DESCRIPTION
Before this commit, the added testcase failed in a strange way:
```scala
14 |  def bla(foo: Foo) = orElse2(identity).apply(foo)
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |value of type <nonsensical><notype></nonsensical> does not take parameters
```
This happened because the TermRef for the apply method had an incorrect
signature (with a result type of `Object` instead of `Foo`), therefore its underlying type was NoType.

According to the documentation of `erasedLub`, the erasure should be:
> a common superclass or trait S of the argument classes, with the
    following two properties:
> - S is minimal: no other common superclass or trait derives from S]
> - S is last   : in the linearization of the first argument type `tp1`
                    there are no minimal common superclasses or traits that
                    come after S.
  (the reason to pick last is that we prefer classes over traits that way).

I'm not convinced that the implementation satisfies either of these two
properties, but this commit at least makes S closer to being minimal by
making sure that it does not derive from the last seen best candidate never derives from it.