### PR TITLE
[WIP] consolidate entity serialization

### DIFF
--- a/doc-tool/src/dotty/tools/dottydoc/model/JavaConverters.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/model/JavaConverters.scala
@@ -4,12 +4,11 @@ package model
 import comment._
 import references._
 
-import _root_.java.util.HashMap
 import _root_.java.util.LinkedList
 
 object JavaConverters {
   import scala.collection.JavaConverters._
-  import _root_.java.util.{ Optional => JOptional, Map => JMap }
+  import _root_.java.util.{ Map => JMap }
 
   implicit class OptStr(val opt: Option[String]) extends AnyVal {
     def asJava = opt.getOrElse(null)
@@ -41,160 +40,6 @@ object JavaConverters {
       "groupNames"              -> cmt.groupNames.asJava,
       "groupPrio"               -> cmt.groupPrio.asJava,
       "hideImplicitConversions" -> cmt.hideImplicitConversions.asJava
-    ).asJava
-  }
-
-  implicit class JavaPackage(val ent: Package) extends AnyVal {
-    def asJava(extras: Map[String, _] = Map.empty): JMap[String, _] = (Map(
-      "kind"     -> ent.kind,
-      "annotations" -> ent.annotations.asJava,
-      "name"     -> ent.name,
-      "path"     -> ent.path.asJava,
-      "members"  -> ent.members.map(_.asJava()).asJava,
-      "children"  -> ent.children.map(_.asJava()).asJava,
-      "comment"  -> ent.comment.map(_.asJava).asJava,
-      "superTypes" -> ent.superTypes,
-      "hasVisibleMembers" -> ent.hasVisibleMembers,
-      "hasShortenedDocstring" -> ent.hasShortenedDocstring,
-      "signature" -> ent.signature
-    ) ++ extras).asJava
-  }
-
-  implicit class JavaCaseClass(val ent: CaseClass) extends AnyVal {
-    def asJava(extras: Map[String, _] = Map.empty): JMap[String, _] = (Map(
-      "kind" -> ent.kind,
-      "annotations" -> ent.annotations.asJava,
-      "name" -> ent.name,
-      "members" -> ent.members.map(_.asJava()).asJava,
-      "modifiers" -> ent.modifiers.asJava,
-      "path" -> ent.path.asJava,
-      "typeParams" -> ent.typeParams.asJava,
-      "superTypes" -> ent.superTypes.map(_.asJava).asJava,
-      "comment" -> ent.comment.map(_.asJava).asJava,
-      "constructors" -> ent.constructors.map(_.map(_.asJava).asJava).asJava,
-      "isPrivate" -> ent.isPrivate,
-      "isProtected" -> ent.isProtected,
-      "hasVisibleMembers" -> ent.hasVisibleMembers,
-      "hasShortenedDocstring" -> ent.hasShortenedDocstring,
-      "hasCompanion" -> ent.hasCompanion,
-      "companionPath" -> ent.companionPath.asJava,
-      "signature" -> ent.signature
-    ) ++ extras).asJava
-  }
-
-  implicit class JavaClass(val ent: Class) extends AnyVal {
-    def asJava(extras: Map[String, _] = Map.empty): JMap[String, _] = (Map(
-      "kind"       -> ent.kind,
-      "annotations" -> ent.annotations.asJava,
-      "name"       -> ent.name,
-      "members"    -> ent.members.map(_.asJava()).asJava,
-      "modifiers"  -> ent.modifiers.asJava,
-      "path"       -> ent.path.asJava,
-      "typeParams" -> ent.typeParams.asJava,
-      "superTypes" -> ent.superTypes.map(_.asJava).asJava,
-      "comment"    -> ent.comment.map(_.asJava).asJava,
-      "constructors" -> ent.constructors.map(_.map(_.asJava).asJava).asJava,
-      "isPrivate" -> ent.isPrivate,
-      "isProtected" -> ent.isProtected,
-      "hasVisibleMembers" -> ent.hasVisibleMembers,
-      "hasShortenedDocstring" -> ent.hasShortenedDocstring,
-      "hasCompanion" -> ent.hasCompanion,
-      "companionPath" -> ent.companionPath.asJava,
-      "signature" -> ent.signature
-    ) ++ extras).asJava
-  }
-
-  implicit class JavaTrait(val ent: Trait) extends AnyVal {
-    def asJava(extras: Map[String, _] = Map.empty): JMap[String, _] = (Map(
-      "kind"       -> ent.kind,
-      "annotations" -> ent.annotations.asJava,
-      "name"       -> ent.name,
-      "members"    -> ent.members.map(_.asJava()).asJava,
-      "modifiers"  -> ent.modifiers.asJava,
-      "path"       -> ent.path.asJava,
-      "typeParams" -> ent.typeParams.asJava,
-      "superTypes" -> ent.superTypes.map(_.asJava).asJava,
-      "comment"    -> ent.comment.map(_.asJava).asJava,
-      "isPrivate" -> ent.isPrivate,
-      "isProtected" -> ent.isProtected,
-      "hasVisibleMembers" -> ent.hasVisibleMembers,
-      "hasShortenedDocstring" -> ent.hasShortenedDocstring,
-      "hasCompanion" -> ent.hasCompanion,
-      "companionPath" -> ent.companionPath.asJava,
-      "signature" -> ent.signature
-    ) ++ extras).asJava
-  }
-
-  implicit class JavaObject(val ent: Object) extends AnyVal {
-    def asJava(extras: Map[String, _] = Map.empty): JMap[String, _] = (Map(
-      "kind"       -> ent.kind,
-      "annotations" -> ent.annotations.asJava,
-      "name"       -> ent.name,
-      "members"    -> ent.members.map(_.asJava()).asJava,
-      "modifiers"  -> ent.modifiers.asJava,
-      "path"       -> ent.path.asJava,
-      "superTypes" -> ent.superTypes.map(_.asJava).asJava,
-      "comment"    -> ent.comment.map(_.asJava).asJava,
-      "isPrivate" -> ent.isPrivate,
-      "isProtected" -> ent.isProtected,
-      "hasVisibleMembers" -> ent.hasVisibleMembers,
-      "hasShortenedDocstring" -> ent.hasShortenedDocstring,
-      "hasCompanion" -> ent.hasCompanion,
-      "companionPath" -> ent.companionPath.asJava,
-      "signature" -> ent.signature
-    ) ++ extras).asJava
-  }
-
-  implicit class JavaDef(val ent: Def) extends AnyVal {
-    def asJava: JMap[String, _] = Map(
-      "kind"                -> ent.kind,
-      "annotations" -> ent.annotations.asJava,
-      "name"                -> ent.name,
-      "modifiers"           -> ent.modifiers.asJava,
-      "path"                -> ent.path.asJava,
-      "returnValue"         -> ent.returnValue.asJava,
-      "typeParams"          -> ent.typeParams.asJava,
-      "paramLists"          -> ent.paramLists.map(_.asJava).asJava,
-      "comment"             -> ent.comment.map(_.asJava).asJava,
-      "implicitlyAddedFrom" -> ent.implicitlyAddedFrom.map(_.asJava).asJava,
-      "hasShortenedDocstring" -> ent.hasShortenedDocstring,
-      "isPrivate" -> ent.isPrivate,
-      "isProtected" -> ent.isProtected,
-      "signature" -> ent.signature
-    ).asJava
-  }
-
-  implicit class JavaVal(val ent: Val) extends AnyVal {
-    def asJava: JMap[String, _] = Map(
-      "kind" -> ent.kind,
-      "annotations" -> ent.annotations.asJava,
-      "name" -> ent.name,
-      "modifiers" -> ent.modifiers.asJava,
-      "path" -> ent.path.asJava,
-      "returnValue" -> ent.returnValue.asJava,
-      "comment" -> ent.comment.map(_.asJava).asJava,
-      "implicitlyAddedFrom" -> ent.implicitlyAddedFrom.map(_.asJava).asJava,
-      "hasShortenedDocstring" -> ent.hasShortenedDocstring,
-      "isPrivate" -> ent.isPrivate,
-      "isProtected" -> ent.isProtected,
-      "signature" -> ent.signature
-    ).asJava
-  }
-
-  implicit class JavaTypeAlias(val ent: TypeAlias) extends AnyVal {
-    def asJava: JMap[String, _] = Map(
-      "kind" -> ent.kind,
-      "annotations" -> ent.annotations.asJava,
-      "modifiers" -> ent.modifiers.asJava,
-      "name" -> ent.name,
-      "path" -> ent.path.asJava,
-      "alias" -> ent.alias.map(_.asJava).asJava,
-      "typeParams" -> ent.typeParams.asJava,
-      "comment" -> ent.comment.map(_.asJava).asJava,
-      "hasShortenedDocstring" -> ent.hasShortenedDocstring,
-      "isPrivate" -> ent.isPrivate,
-      "isProtected" -> ent.isProtected,
-      "signature" -> ent.signature
     ).asJava
   }
 
@@ -298,16 +143,88 @@ object JavaConverters {
     def asJava(extras: Map[String, _] = Map.empty): JMap[String, _] = parseEntity(ent, extras)
   }
 
-  private def parseEntity(ent: Entity, extras: Map[String, _]): JMap[String, _] = ent match {
-    case ent: Package   => ent.asJava(extras)
-    case ent: CaseClass => ent.asJava(extras)
-    case ent: Class     => ent.asJava(extras)
-    case ent: Trait     => ent.asJava(extras)
-    case ent: Object    => ent.asJava(extras)
-    case ent: Def       => ent.asJava
-    case ent: Val       => ent.asJava
-    case ent: TypeAlias => ent.asJava
-    case _              => Map.empty.asJava
+  private def parseEntity(ent: Entity, extras: Map[String, _]): JMap[String, _] = {
+    val entity = Map(
+      "kind"     -> ent.kind,
+      "annotations" -> ent.annotations.asJava,
+      "name"     -> ent.name,
+      "path"     -> ent.path.asJava,
+      "children"  -> ent.children.map(_.asJava()).asJava,
+      "comment"  -> ent.comment.map(_.asJava).asJava,
+      "hasShortenedDocstring" -> ent.hasShortenedDocstring,
+      "signature" -> ent.signature
+    )
+    val members = ent match {
+      case ent: Members => Map(
+        "members"  -> ent.members.map(_.asJava()).asJava,
+        "hasVisibleMembers" -> ent.hasVisibleMembers
+      )
+      case _ => Map.empty
+    }
+    val superTypes = ent match {
+      case ent: SuperTypes => Map(
+        "superTypes" -> ent.superTypes.map(_.asJava).asJava
+      )
+      case _ => Map.empty
+    }
+    val modifiers = ent match {
+      case ent: Modifiers => Map(
+        "modifiers" -> ent.modifiers.asJava,
+        "isPrivate" -> ent.isPrivate,
+        "isProtected" -> ent.isProtected
+      )
+      case _ => Map.empty
+    }
+    val typeParams = ent match {
+      case ent: TypeParams => Map(
+        "typeParams" -> ent.typeParams.asJava
+      )
+      case _ => Map.empty
+    }
+    val constructors = ent match {
+      case ent: Constructors => Map(
+        "constructors" -> ent.constructors.map(_.map(_.asJava).asJava).asJava
+      )
+      case _ => Map.empty
+    }
+    val companion = ent match {
+      case ent: Companion => Map(
+        "hasCompanion" -> ent.hasCompanion,
+        "companionPath" -> ent.companionPath.asJava
+      )
+      case _ => Map.empty
+    }
+    val returnValue = ent match {
+      case ent: ReturnValue => Map(
+        "returnValue"         -> ent.returnValue.asJava
+      )
+      case _ => Map.empty
+    }
+    val implicitlyAddedEntity = ent match {
+      case ent: ImplicitlyAddedEntity => Map(
+        "implicitlyAddedFrom" -> ent.implicitlyAddedFrom.map(_.asJava).asJava
+      )
+      case _ => Map.empty
+    }
+    val typeAlias : Map[String, _] = ent match {
+      case ent: TypeAlias => Map(
+        "alias" -> ent.alias.map(_.asJava).asJava
+      )
+      case _ => Map.empty
+    }
+    val trt = ent match {
+      case ent: Trait => Map(
+        "traitParams"          -> ent.traitParams.map(_.asJava).asJava
+      )
+      case _ => Map.empty
+    }
+    val df = ent match {
+      case ent: Def => Map(
+        "paramLists"          -> ent.paramLists.map(_.asJava).asJava
+      )
+      case _ => Map.empty
+    }
+      (entity ++ members ++ superTypes ++ modifiers ++ typeParams ++ constructors ++ companion ++ returnValue ++ implicitlyAddedEntity ++ typeAlias ++ trt ++ df).asJava
   }
 
   implicit class JavaMap(val map: collection.Map[String, Package]) extends AnyVal {

--- a/doc-tool/src/dotty/tools/dottydoc/model/JavaConverters.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/model/JavaConverters.scala
@@ -4,11 +4,11 @@ package model
 import comment._
 import references._
 
-import _root_.java.util.LinkedList
+import java.util.LinkedList
 
 object JavaConverters {
   import scala.collection.JavaConverters._
-  import _root_.java.util.{ Map => JMap }
+  import java.util.{ Map => JMap }
 
   implicit class OptStr(val opt: Option[String]) extends AnyVal {
     def asJava = opt.getOrElse(null)
@@ -20,32 +20,32 @@ object JavaConverters {
 
   implicit class JavaComment(val cmt: Comment) extends AnyVal {
     def asJava: JMap[String, _] = Map(
-      "body"                    -> cmt.body,
-      "short"                   -> cmt.short,
-      "authors"                 -> cmt.authors.asJava,
-      "see"                     -> cmt.see.asJava,
-      "result"                  -> cmt.result.asJava,
-      "throws"                  -> cmt.throws.asJava,
-      "valueParams"             -> cmt.valueParams.asJava,
-      "typeParams"              -> cmt.typeParams.asJava,
-      "version"                 -> cmt.version.asJava,
-      "since"                   -> cmt.since.asJava,
-      "todo"                    -> cmt.todo.asJava,
-      "deprecated"              -> cmt.deprecated.asJava,
-      "note"                    -> cmt.note.asJava,
-      "example"                 -> cmt.example.asJava,
-      "constructor"             -> cmt.constructor.asJava,
-      "group"                   -> cmt.group.asJava,
-      "groupDesc"               -> cmt.groupDesc.asJava,
-      "groupNames"              -> cmt.groupNames.asJava,
-      "groupPrio"               -> cmt.groupPrio.asJava,
+      "body" -> cmt.body,
+      "short" -> cmt.short,
+      "authors" -> cmt.authors.asJava,
+      "see" -> cmt.see.asJava,
+      "result" -> cmt.result.asJava,
+      "throws" -> cmt.throws.asJava,
+      "valueParams" -> cmt.valueParams.asJava,
+      "typeParams" -> cmt.typeParams.asJava,
+      "version" -> cmt.version.asJava,
+      "since" -> cmt.since.asJava,
+      "todo" -> cmt.todo.asJava,
+      "deprecated" -> cmt.deprecated.asJava,
+      "note" -> cmt.note.asJava,
+      "example" -> cmt.example.asJava,
+      "constructor" -> cmt.constructor.asJava,
+      "group" -> cmt.group.asJava,
+      "groupDesc" -> cmt.groupDesc.asJava,
+      "groupNames" -> cmt.groupNames.asJava,
+      "groupPrio" -> cmt.groupPrio.asJava,
       "hideImplicitConversions" -> cmt.hideImplicitConversions.asJava
     ).asJava
   }
 
   implicit class JavaParamList(val pl: ParamList) extends AnyVal {
     def asJava: JMap[String, _] = Map(
-      "list"       -> pl.list.map(_.asJava).asJava,
+      "list" -> pl.list.map(_.asJava).asJava,
       "isImplicit" -> pl.isImplicit
     ).asJava
   }
@@ -53,23 +53,23 @@ object JavaConverters {
   implicit class JavaReference(val ref: Reference) extends AnyVal {
     def asJava: JMap[String, _] = ref match {
       case TypeReference(title, tpeLink, paramLinks) => Map(
-        "kind"       -> "TypeReference",
-        "title"      -> title,
-        "tpeLink"    -> tpeLink.asJava,
+        "kind" -> "TypeReference",
+        "title" -> title,
+        "tpeLink" -> tpeLink.asJava,
         "paramLinks" -> paramLinks.map(_.asJava).asJava,
-        "scala"      -> ref
+        "scala" -> ref
       ).asJava
 
       case OrTypeReference(left, right) => Map(
-        "kind"  -> "OrTypeReference",
-        "left"  -> left.asJava,
+        "kind" -> "OrTypeReference",
+        "left" -> left.asJava,
         "right" -> right.asJava,
         "scala" -> ref
       ).asJava
 
       case AndTypeReference(left, right) => Map(
-        "kind"  -> "AndTypeReference",
-        "left"  -> left.asJava,
+        "kind" -> "AndTypeReference",
+        "left" -> left.asJava,
         "right" -> right.asJava,
         "scala" -> ref
       ).asJava
@@ -88,23 +88,23 @@ object JavaConverters {
       ).asJava
 
       case BoundsReference(low, high) => Map(
-        "kind"  -> "BoundsReference",
-        "low"   -> low.asJava,
+        "kind" -> "BoundsReference",
+        "low" -> low.asJava,
         "hight" -> high.asJava,
         "scala" -> ref
       ).asJava
 
       case NamedReference(title, ref, isByName, isRepeated) => Map(
-        "kind"       -> "NamedReference",
-        "title"      -> title,
-        "ref"        -> ref.asJava,
-        "isByName"   -> isByName,
+        "kind" -> "NamedReference",
+        "title" -> title,
+        "ref" -> ref.asJava,
+        "isByName" -> isByName,
         "isRepeated" -> isRepeated,
-        "scala"      -> ref
+        "scala" -> ref
       ).asJava
 
       case ConstantReference(title) => Map(
-        "kind"  -> "ConstantReference",
+        "kind" -> "ConstantReference",
         "title" -> title,
         "scala" -> ref
       ).asJava
@@ -117,22 +117,22 @@ object JavaConverters {
   implicit class JavaMaterializableLink(val link: MaterializableLink) extends AnyVal {
     def asJava: JMap[String, _] = link match {
       case UnsetLink(title, query) => Map(
-        "kind"  -> "UnsetLink",
+        "kind" -> "UnsetLink",
         "title" -> title,
         "query" -> query,
         "scala" -> link
       ).asJava
 
       case MaterializedLink(title, target) => Map(
-        "kind"   -> "MaterializedLink",
-        "title"  -> title,
+        "kind" -> "MaterializedLink",
+        "title" -> title,
         "target" -> target,
         "scala" -> link
       ).asJava
 
       case NoLink(title, target) => Map(
-        "kind"   -> "NoLink",
-        "title"  -> title,
+        "kind" -> "NoLink",
+        "title" -> title,
         "target" -> target,
         "scala" -> link
       ).asJava
@@ -140,23 +140,23 @@ object JavaConverters {
   }
 
   implicit class JavaEntity(val ent: Entity) extends AnyVal {
-    def asJava(extras: Map[String, _] = Map.empty): JMap[String, _] = parseEntity(ent, extras)
+    def asJava(): JMap[String, _] = parseEntity(ent)
   }
 
-  private def parseEntity(ent: Entity, extras: Map[String, _]): JMap[String, _] = {
+  private def parseEntity(ent: Entity): JMap[String, _] = {
     val entity = Map(
-      "kind"     -> ent.kind,
+      "kind" -> ent.kind,
       "annotations" -> ent.annotations.asJava,
-      "name"     -> ent.name,
-      "path"     -> ent.path.asJava,
-      "children"  -> ent.children.map(_.asJava()).asJava,
-      "comment"  -> ent.comment.map(_.asJava).asJava,
+      "name" -> ent.name,
+      "path" -> ent.path.asJava,
+      "children" -> ent.children.map(_.asJava()).asJava,
+      "comment" -> ent.comment.map(_.asJava).asJava,
       "hasShortenedDocstring" -> ent.hasShortenedDocstring,
       "signature" -> ent.signature
     )
     val members = ent match {
       case ent: Members => Map(
-        "members"  -> ent.members.map(_.asJava()).asJava,
+        "members" -> ent.members.map(_.asJava()).asJava,
         "hasVisibleMembers" -> ent.hasVisibleMembers
       )
       case _ => Map.empty
@@ -196,7 +196,7 @@ object JavaConverters {
     }
     val returnValue = ent match {
       case ent: ReturnValue => Map(
-        "returnValue"         -> ent.returnValue.asJava
+        "returnValue" -> ent.returnValue.asJava
       )
       case _ => Map.empty
     }
@@ -214,17 +214,31 @@ object JavaConverters {
     }
     val trt = ent match {
       case ent: Trait => Map(
-        "traitParams"          -> ent.traitParams.map(_.asJava).asJava
+        "traitParams" -> ent.traitParams.map(_.asJava).asJava
       )
       case _ => Map.empty
     }
     val df = ent match {
       case ent: Def => Map(
-        "paramLists"          -> ent.paramLists.map(_.asJava).asJava
+        "paramLists" -> ent.paramLists.map(_.asJava).asJava
       )
       case _ => Map.empty
     }
-      (entity ++ members ++ superTypes ++ modifiers ++ typeParams ++ constructors ++ companion ++ returnValue ++ implicitlyAddedEntity ++ typeAlias ++ trt ++ df).asJava
+
+    {
+      entity ++
+      members ++
+      superTypes ++
+      modifiers ++
+      typeParams ++
+      constructors ++
+      companion ++
+      returnValue ++
+      implicitlyAddedEntity ++
+      typeAlias ++
+      trt ++
+      df
+    }.asJava
   }
 
   implicit class JavaMap(val map: collection.Map[String, Package]) extends AnyVal {

--- a/doc-tool/test/JavaConverterTest.scala
+++ b/doc-tool/test/JavaConverterTest.scala
@@ -1,0 +1,111 @@
+package dotty.tools
+package dottydoc
+
+import org.junit.Test
+import org.junit.Assert._
+import model.{
+  Entity,
+  Members,
+  SuperTypes,
+  Modifiers,
+  TypeParams,
+  Constructors => MConstructors,
+  Companion,
+  ReturnValue,
+  ImplicitlyAddedEntity,
+  TypeAlias,
+  Trait,
+  Def,
+  NonEntity
+}
+import model.references.{ConstantReference, TypeReference, NoLink}
+import model.comment.Comment
+import dotty.tools.dotc.core.Symbols.NoSymbol
+import _root_.java.util.{Optional => JOptional, Map => JMap}
+
+class JavaConverterTest {
+  import model.JavaConverters._
+
+  @Test def entityConversions = {
+    trait TestEntity extends Entity {
+      def symbol = NoSymbol
+
+      def name = "test"
+
+      def kind = "ent"
+
+      def path = "path" :: "to" :: "test" :: Nil
+
+      def comment = Some(new Comment("", "", List(), List(), None, Map(), Map(), Map(), None, None, List(), None, List(), List(), None, None, Map(), Map(), Map(), List()))
+
+      def annotations = List("test")
+
+      def parent = NonEntity
+
+    }
+    trait TestMembers extends TestEntity with Members {
+      def members = new TestEntity{} :: Nil
+    }
+    trait TestSuperTypes extends TestEntity with SuperTypes {
+      def superTypes = new NoLink("title", "query") :: Nil
+    }
+    trait TestModifiers extends TestEntity with Modifiers {
+      def modifiers = "private" :: Nil
+    }
+    trait TestTypeParams extends TestEntity with TypeParams {
+      def typeParams = "String" :: "String" :: Nil
+    }
+    trait TestConstructors extends TestEntity with MConstructors {
+      def constructors = List(List())
+    }
+    trait TestCompanion extends TestEntity with Companion {
+      def companionPath = "path" :: "to" :: "companion" :: Nil
+      def companionPath_=(xs: List[String]) = Unit
+    }
+    trait TestReturnValue extends TestEntity with ReturnValue {
+      def returnValue =
+        new TypeReference("String", new NoLink("title", "target"), List())
+    }
+    trait TestImplicitlyAddedEntity
+        extends TestEntity
+        with ImplicitlyAddedEntity {
+      def implicitlyAddedFrom =
+        Some(
+          new TypeReference("String", new NoLink("title", "target"), List()))
+    }
+    trait TestTypeAlias extends TestTypeParams with TestModifiers with TypeAlias {
+      override val kind = "type"
+      def alias = None
+    }
+    trait TestDef extends TestModifiers with TestTypeParams with TestImplicitlyAddedEntity {
+      def paramLists = List()
+    }
+    trait TestTrait extends TestModifiers with TestTypeParams with TestSuperTypes with TestMembers with TestCompanion {
+      def traitParams = List()
+    }
+    val ent = new TestEntity {}
+    val members = new TestMembers {}
+    val superTypes = new TestSuperTypes {}
+    val modifiers = new TestModifiers {}
+    val typeParams = new TestTypeParams {}
+    val constructors = new TestConstructors {}
+    val companion = new TestCompanion {}
+    val returnValue = new TestReturnValue {}
+    val implicitlyAddedEntity = new TestImplicitlyAddedEntity {}
+    val typeAlias = new TestTypeAlias {}
+    val df = new TestDef {}
+    val trt = new TestTrait {}
+    val ent_serialized = ent.asJava()
+    val members_serialized = members.asJava()
+    val superTypes_serialized = superTypes.asJava()
+    val modifiers_serialized = modifiers.asJava()
+    val typeParams_serialized = typeParams.asJava()
+    val constructors_serialized = constructors.asJava()
+    val companion_serialized = companion.asJava()
+    val returnValue_serialized = returnValue.asJava()
+    val implicitlyAddedEntity_serialized = implicitlyAddedEntity.asJava()
+    val typeAlias_serialized = typeAlias.asJava()
+    val def_serialized = df.asJava()
+    val trait_serialized = trt.asJava()
+  }
+}

--- a/doc-tool/test/JavaConverterTest.scala
+++ b/doc-tool/test/JavaConverterTest.scala
@@ -3,109 +3,318 @@ package dottydoc
 
 import org.junit.Test
 import org.junit.Assert._
+
 import model.{
+  Val,
+  Object => EObject,
+  CaseClass,
   Entity,
   Members,
   SuperTypes,
   Modifiers,
   TypeParams,
-  Constructors => MConstructors,
+  Constructors => EConstructors,
+  Class,
   Companion,
   ReturnValue,
   ImplicitlyAddedEntity,
   TypeAlias,
   Trait,
+  Package,
   Def,
-  NonEntity
+  NonEntity,
+  ParamList
 }
-import model.references.{ConstantReference, TypeReference, NoLink}
+import model.references._
+import model.internal.{ParamListImpl}
 import model.comment.Comment
 import dotty.tools.dotc.core.Symbols.NoSymbol
-import _root_.java.util.{Optional => JOptional, Map => JMap}
+import java.util.{Optional => JOptional, Map => JMap, List => JList}
 
 class JavaConverterTest {
   import model.JavaConverters._
+  import scala.collection.JavaConverters._
 
   @Test def entityConversions = {
-    trait TestEntity extends Entity {
+    val paramList = new ParamListImpl(new NamedReference("x", new TypeReference("Int", new NoLink("title", "target"), List())) :: Nil, false)
+    val df = new Def {
       def symbol = NoSymbol
-
       def name = "test"
-
-      def kind = "ent"
-
-      def path = "path" :: "to" :: "test" :: Nil
-
-      def comment = Some(new Comment("", "", List(), List(), None, Map(), Map(), Map(), None, None, List(), None, List(), List(), None, None, Map(), Map(), Map(), List()))
-
+      def path = "path" :: "to" :: "def" :: Nil
+      def comment = None
       def annotations = List("test")
-
       def parent = NonEntity
-
-    }
-    trait TestMembers extends TestEntity with Members {
-      def members = new TestEntity{} :: Nil
-    }
-    trait TestSuperTypes extends TestEntity with SuperTypes {
-      def superTypes = new NoLink("title", "query") :: Nil
-    }
-    trait TestModifiers extends TestEntity with Modifiers {
       def modifiers = "private" :: Nil
-    }
-    trait TestTypeParams extends TestEntity with TypeParams {
       def typeParams = "String" :: "String" :: Nil
+      def implicitlyAddedFrom = Some(
+          new TypeReference("String", new NoLink("title", "target"), List()))
+      def returnValue = new TypeReference("String", new NoLink("title", "target"), List())
+      def paramLists = List(paramList)
     }
-    trait TestConstructors extends TestEntity with MConstructors {
-      def constructors = List(List())
-    }
-    trait TestCompanion extends TestEntity with Companion {
+    assertSerializedCorrectly(df, df.asJava())
+    val trt = new Trait {
+      def symbol = NoSymbol
+      def name = "someTrait"
+      def path = "path" :: "to" :: "trait" :: Nil
+      def comment = None
+      def annotations = List("test")
+      def parent = NonEntity
+      def modifiers = "protected" :: Nil
+      def typeParams = "String" :: "String" :: Nil
+      def superTypes = new NoLink("title", "query") :: Nil
+      def members = df :: Nil
+      def traitParams = List(paramList)
       def companionPath = "path" :: "to" :: "companion" :: Nil
       def companionPath_=(xs: List[String]) = Unit
     }
-    trait TestReturnValue extends TestEntity with ReturnValue {
-      def returnValue =
-        new TypeReference("String", new NoLink("title", "target"), List())
+    assertSerializedCorrectly(trt, trt.asJava())
+    val cls = new Class {
+      def symbol = NoSymbol
+      def name = "test"
+      def path = "path" :: "to" :: "test" :: Nil
+      def comment = None
+      def annotations = List("test")
+      def parent = NonEntity
+      def modifiers = "private" :: Nil
+      def typeParams = "String" :: "String" :: Nil
+      def superTypes = new NoLink("title", "query") :: Nil
+      def members = Nil
+      def companionPath = "path" :: "to" :: "companion" :: Nil
+      def companionPath_=(xs: List[String]) = Unit
+      def constructors = List(List(paramList))
     }
-    trait TestImplicitlyAddedEntity
-        extends TestEntity
-        with ImplicitlyAddedEntity {
-      def implicitlyAddedFrom =
-        Some(
-          new TypeReference("String", new NoLink("title", "target"), List()))
+    assertSerializedCorrectly(cls, cls.asJava())
+    val caseClass = new CaseClass {
+      def symbol = NoSymbol
+      def name = "test"
+      def path = "path" :: "to" :: "test" :: Nil
+      def comment = None
+      def annotations = List("test")
+      def parent = NonEntity
+      def modifiers = "private" :: Nil
+      def typeParams = "String" :: "String" :: Nil
+      def constructors = List(List(paramList))
+      def superTypes = new NoLink("title", "query") :: Nil
+      def members = Nil
+      def companionPath = "path" :: "to" :: "companion" :: Nil
+      def companionPath_=(xs: List[String]) = Unit
     }
-    trait TestTypeAlias extends TestTypeParams with TestModifiers with TypeAlias {
-      override val kind = "type"
-      def alias = None
+    assertSerializedCorrectly(caseClass, caseClass.asJava())
+    val obj = new EObject {
+      def symbol = NoSymbol
+      def name = "someObject"
+      def path = "path" :: "to" :: "object" :: Nil
+      def comment = None
+      def annotations = List("test")
+      def parent = NonEntity
+      def modifiers = "protected" :: Nil
+      def typeParams = "String" :: "String" :: Nil
+      def superTypes = new NoLink("title", "query") :: Nil
+      def members = df :: Nil
+      def companionPath = "path" :: "to" :: "companion" :: Nil
+      def companionPath_=(xs: List[String]) = Unit
     }
-    trait TestDef extends TestModifiers with TestTypeParams with TestImplicitlyAddedEntity {
-      def paramLists = List()
+    assertSerializedCorrectly(obj, obj.asJava())
+    val typeAlias = new TypeAlias {
+      def symbol = NoSymbol
+      def name = "typeAlias"
+      def path = "path" :: "to" :: "typeAlias" :: Nil
+      def comment = None
+      def annotations = List("test")
+      def parent = NonEntity
+      def modifiers = "private" :: Nil
+      def typeParams = "String" :: "String" :: Nil
+      def alias = Some(new TypeReference("String", new NoLink("title", "target"), List()))
     }
-    trait TestTrait extends TestModifiers with TestTypeParams with TestSuperTypes with TestMembers with TestCompanion {
-      def traitParams = List()
+    assertSerializedCorrectly(typeAlias, typeAlias.asJava())
+    val vl = new Val {
+      val kind = "val"
+      def symbol = NoSymbol
+      def name = "val"
+      def path = "path" :: "to" :: "val" :: Nil
+      def comment = None
+      def annotations = List("test")
+      def parent = NonEntity
+      def modifiers = "private" :: Nil
+      def returnValue = new TypeReference("String", new NoLink("title", "target"), List())
+      def implicitlyAddedFrom = Some(
+        new TypeReference("String", new NoLink("title", "target"), List()))
     }
-    val ent = new TestEntity {}
-    val members = new TestMembers {}
-    val superTypes = new TestSuperTypes {}
-    val modifiers = new TestModifiers {}
-    val typeParams = new TestTypeParams {}
-    val constructors = new TestConstructors {}
-    val companion = new TestCompanion {}
-    val returnValue = new TestReturnValue {}
-    val implicitlyAddedEntity = new TestImplicitlyAddedEntity {}
-    val typeAlias = new TestTypeAlias {}
-    val df = new TestDef {}
-    val trt = new TestTrait {}
-    val ent_serialized = ent.asJava()
-    val members_serialized = members.asJava()
-    val superTypes_serialized = superTypes.asJava()
-    val modifiers_serialized = modifiers.asJava()
-    val typeParams_serialized = typeParams.asJava()
-    val constructors_serialized = constructors.asJava()
-    val companion_serialized = companion.asJava()
-    val returnValue_serialized = returnValue.asJava()
-    val implicitlyAddedEntity_serialized = implicitlyAddedEntity.asJava()
-    val typeAlias_serialized = typeAlias.asJava()
-    val def_serialized = df.asJava()
-    val trait_serialized = trt.asJava()
+    assertSerializedCorrectly(vl, vl.asJava())
+    val pkg = new Package {
+      def symbol = NoSymbol
+      def name = "test"
+      def path = "path" :: "to" :: "test" :: Nil
+      def comment = None
+      def annotations = List("test")
+      def parent = NonEntity
+      def members = trt :: typeAlias :: Nil
+      def superTypes = new NoLink("title", "query") :: Nil
+    }
+    assertSerializedCorrectly(pkg, pkg.asJava())
+  }
+
+  def assertEach[E, C[E] <: Seq[E]](expected: C[E], serialized: Any)(pairwiseAssertion: (E, Any) => Unit) {
+    val actual = serialized.asInstanceOf[JList[_]].asScala.toList
+    assertEquals(expected.length, actual.length)
+    for ((exp, act) <- expected zip actual) {
+      pairwiseAssertion(exp, act)
+    }
+  }
+  def assertSameSeq[T, C[T] <: Seq[T]](expected: C[T], serialized: Any) = {
+    val actual = serialized.asInstanceOf[java.util.List[T]].asScala.toList
+    assertEquals(expected, actual);
+  }
+  def assertSerializedCorrectly(expected: ParamList, serialized: Any) {
+    val actual = serialized.asInstanceOf[JMap[String, _]]
+    assertEach(expected.list, actual.get("list")) {(exp, act) =>
+      assertSerializedCorrectly(exp, act)
+    }
+    assertEquals(expected.isImplicit, actual.get("isImplicit"))
+  }
+  def assertSerializedCorrectly(expected: Reference, serialized: Any) {
+    val actual = serialized.asInstanceOf[JMap[String, _]]
+    expected match {
+      case TypeReference(title, tpeLink, paramLinks) =>
+        assertEquals(title, actual.get("title"))
+        assertSerializedCorrectly(tpeLink, actual.get("tpeLink"))
+        assertEach(paramLinks, actual.get("paramLinks")) { (exp, act) =>
+          assertSerializedCorrectly(exp, act)
+        }
+      case OrTypeReference(left, right) =>
+        assertSerializedCorrectly(left, actual.get("left"))
+        assertSerializedCorrectly(right, actual.get("right"))
+      case AndTypeReference(left, right) =>
+        assertSerializedCorrectly(left, actual.get("left"))
+        assertSerializedCorrectly(right, actual.get("right"))
+      case FunctionReference(args, returnValue) =>
+        assertEach(args, actual.get("args")) { (exp, act) =>
+          assertSerializedCorrectly(exp, act)
+        }
+        assertSerializedCorrectly(returnValue, actual.get("returnValue"))
+      case TupleReference(args) =>
+        assertEach(args, actual.get("args")) { (exp, act) =>
+          assertSerializedCorrectly(exp, act)
+        }
+      case BoundsReference(low, high) =>
+        assertSerializedCorrectly(low, actual.get("low"))
+        assertSerializedCorrectly(high, actual.get("high"))
+      case NamedReference(title, ref, isByName, isRepeated) =>
+        assertEquals(title, actual.get("title"))
+        assertSerializedCorrectly(ref, actual.get("ref"))
+        assertEquals(isByName, actual.get("isByName"))
+        assertEquals(isRepeated, actual.get("isRepeated"))
+      case ConstantReference(title) =>
+        assertEquals(title, actual.get("title"))
+      case EmptyReference =>
+    }
+  }
+  def assertSerializedCorrectly(expected: MaterializableLink, serialized: Any) {
+    val actual = serialized.asInstanceOf[JMap[String, _]]
+    expected match {
+      case UnsetLink(title, query) =>
+        assertEquals(title, actual.get("title"))
+        assertEquals(query, actual.get("query"))
+      case MaterializedLink(title, target) =>
+        assertEquals(title, actual.get("title"))
+        assertEquals(target, actual.get("target"))
+      case NoLink(title, target) =>
+        assertEquals(title, actual.get("title"))
+        assertEquals(target, actual.get("target"))
+    }
+  }
+  def assertSerializedCorrectly(expected: Entity, serialized: Any) {
+    val actual = serialized.asInstanceOf[JMap[String, _]]
+    assertEquals(expected.name, actual.get("name"))
+    assertEquals(expected.kind, actual.get("kind"))
+    assertSameSeq(expected.annotations, actual.get("annotations"))
+    assertSameSeq(expected.path, actual.get("path"))
+    assertEquals(expected.hasShortenedDocstring, actual.get("hasShortenedDocstring"))
+    // Only test if a comment is present
+    expected.comment match {
+      case Some(c) => assertNotEquals(null, actual.get("comment"))
+      case _ =>
+    }
+    expected match {
+      case e: Members => {
+        assertEach(e.members, actual.get("members")) { (exp, act) =>
+          assertSerializedCorrectly(exp, act)
+        }
+      }
+      case _ =>
+    }
+    expected match {
+      case e: SuperTypes => {
+        assertEach(e.superTypes, actual.get("superTypes")) { (exp, act) =>
+          assertSerializedCorrectly(exp, act)
+        }
+      }
+      case _ =>
+    }
+    expected match {
+      case e: Modifiers => {
+        assertSameSeq(e.modifiers, actual.get("modifiers"))
+        assertEquals(e.isPrivate, actual.get("isPrivate"))
+        assertEquals(e.isProtected, actual.get("isProtected"))
+      }
+      case _ =>
+    }
+    expected match {
+      case e: TypeParams => {
+        assertSameSeq(e.typeParams, actual.get("typeParams"))
+      }
+      case _ =>
+    }
+    expected match {
+      case e: EConstructors => {
+        // constructors is of type List[List[ParamList]], so we need to apply assertEach twice
+        assertEach(e.constructors, actual.get("constructors")) { (exp, act) =>
+          assertEach(exp, act) { (exp, act) =>
+            assertSerializedCorrectly(exp, act)
+          }
+        }
+      }
+      case _ =>
+    }
+    expected match {
+      case e: Companion => {
+        assertSameSeq(e.companionPath, actual.get("companionPath"))
+      }
+      case _ =>
+    }
+    expected match {
+      case e: ReturnValue => {
+        assertSerializedCorrectly(e.returnValue, actual.get("returnValue"))
+      }
+      case _ =>
+    }
+    expected match {
+      case e: ImplicitlyAddedEntity => {
+        e.implicitlyAddedFrom.map(assertSerializedCorrectly(_, actual.get("implicitlyAddedFrom")))
+      }
+      case _ =>
+    }
+    expected match {
+      case e: TypeAlias => {
+        e.alias.map(assertSerializedCorrectly(_, actual.get("alias")))
+      }
+      case _ =>
+    }
+    expected match {
+      case e: Def => {
+        assertEach(e.paramLists, actual.get("paramLists")) { (exp, act) =>
+          assertSerializedCorrectly(exp, act)
+        }
+      }
+      case _ =>
+    }
+    expected match {
+      case e: Trait => {
+        assertEach(e.traitParams, actual.get("traitParams")) { (exp, act) =>
+          assertSerializedCorrectly(exp, act)
+        }
+      }
+      case _ =>
+    }
   }
 }


### PR DESCRIPTION
Related issue: #1950

Refactored the various implicit classes that handled serialization of entities into a single class. Entities are now serialized by unioning together the result of serializing their individual subtypes/inherited traits.

I also added a test to statically ensure that the implicit conversions work, and that the serializations are successful (but not whether the result is correct).

Review by @felixmulder 