### PR TITLE
Fix overriding a Java method with varargs

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -48,9 +48,9 @@ class Compiler {
       List(new Pickler),            // Generate TASTY info
       List(new FirstTransform,      // Some transformations to put trees into a canonical form
            new CheckReentrant),     // Internal use only: Check that compiled program has no data races involving global vars
-      List(new RefChecks,           // Various checks mostly related to abstract members and overriding
-           new CheckStatic,         // Check restrictions that apply to @static members
+      List(new CheckStatic,         // Check restrictions that apply to @static members
            new ElimRepeated,        // Rewrite vararg parameters and arguments
+           new RefChecks,           // Various checks mostly related to abstract members and overriding
            new NormalizeFlags,      // Rewrite some definition flags
            new ExtensionMethods,    // Expand methods of value classes with extension methods
            new ExpandSAMs,          // Expand single abstract method closures to anonymous classes

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -95,8 +95,8 @@ class ElimRepeated extends MiniPhaseTransform with InfoTransformer with Annotati
     assert(ctx.phase == thisTransformer)
     def overridesJava = tree.symbol.allOverriddenSymbols.exists(_ is JavaDefined)
     if (tree.symbol.info.isVarArgsMethod && overridesJava)
-        addVarArgsBridge(tree)(ctx.withPhase(thisTransformer.next))
-     else
+      addVarArgsBridge(tree)
+    else
       tree
   }
 
@@ -120,6 +120,11 @@ class ElimRepeated extends MiniPhaseTransform with InfoTransformer with Annotati
         .appliedToArgs(vrefs :+ TreeGen.wrapArray(varArgRef, elemtp))
         .appliedToArgss(vrefss1)
     })
+
+    // Drop the override flag on the user-written method, only the added bridge
+    // is a real override.
+    original.copySymDenotation(initFlags = original.flags &~ Override).installAfter(thisTransformer)
+
     Thicket(ddef, bridgeDef)
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -32,7 +32,20 @@ class ElimRepeated extends MiniPhaseTransform with InfoTransformer with Annotati
   def transformInfo(tp: Type, sym: Symbol)(implicit ctx: Context): Type =
     elimRepeated(tp)
 
+
+  override def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation =
+    super.transform(ref) match {
+      case ref1: SymDenotation if (ref1 ne ref) && overridesJava(ref1.symbol) =>
+        // This method won't override the corresponding Java method at the end of this phase,
+        // only the bridge added by `addVarArgsBridge` will.
+        ref1.copySymDenotation(initFlags = ref1.flags &~ Override)
+      case ref1 =>
+        ref1
+    }
+
   override def mayChange(sym: Symbol)(implicit ctx: Context): Boolean = sym is Method
+
+  private def overridesJava(sym: Symbol)(implicit ctx: Context) = sym.allOverriddenSymbols.exists(_ is JavaDefined)
 
   private def elimRepeated(tp: Type)(implicit ctx: Context): Type = tp.stripTypeVar match {
     case tp @ MethodType(paramNames, paramTypes) =>
@@ -93,8 +106,7 @@ class ElimRepeated extends MiniPhaseTransform with InfoTransformer with Annotati
    */
   override def transformDefDef(tree: DefDef)(implicit ctx: Context, info: TransformerInfo): Tree = {
     assert(ctx.phase == thisTransformer)
-    def overridesJava = tree.symbol.allOverriddenSymbols.exists(_ is JavaDefined)
-    if (tree.symbol.info.isVarArgsMethod && overridesJava)
+    if (tree.symbol.info.isVarArgsMethod && overridesJava(tree.symbol))
       addVarArgsBridge(tree)
     else
       tree
@@ -120,10 +132,6 @@ class ElimRepeated extends MiniPhaseTransform with InfoTransformer with Annotati
         .appliedToArgs(vrefs :+ TreeGen.wrapArray(varArgRef, elemtp))
         .appliedToArgss(vrefss1)
     })
-
-    // Drop the override flag on the user-written method, only the added bridge
-    // is a real override.
-    original.copySymDenotation(initFlags = original.flags &~ Override).installAfter(thisTransformer)
 
     Thicket(ddef, bridgeDef)
   }

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -766,6 +766,9 @@ class RefChecks extends MiniPhase { thisTransformer =>
 
   override def phaseName: String = "refchecks"
 
+  // Needs to run after ElimRepeated for override checks involving varargs methods
+  override def runsAfter = Set(classOf[ElimRepeated])
+
   val treeTransform = new Transform(NoLevelInfo)
 
   class Transform(currentLevel: RefChecks.OptLevelInfo = RefChecks.NoLevelInfo) extends TreeTransform {

--- a/tests/pos-java-interop/varargsOverride/Base.java
+++ b/tests/pos-java-interop/varargsOverride/Base.java
@@ -1,0 +1,5 @@
+class Base {
+  public Object foo(Object... x) {
+    return x;
+  }
+}

--- a/tests/pos-java-interop/varargsOverride/Sub.scala
+++ b/tests/pos-java-interop/varargsOverride/Sub.scala
@@ -1,0 +1,3 @@
+class Sub extends Base {
+  override def foo(x: Object*): Object = x
+}


### PR DESCRIPTION
If A method like:
```scala
  override def foo(x: Object*)
```
overrides a Java method, it needs to be rewritten as:
```scala
  def foo(x: Seq[Object])
  override def foo(x: Array[Object]): Object = foo(Predef.wrapRefArray(x))
```

This should be handled by ElimRepeated but there were two bugs:
- `addVarArgsBridge` was called at phase `thisTransformer.next`, this is
too late to create the bridge since `T*` has already been rewritten as
`Seq[T]`
- The original method symbol needs to have the `override` flag dropped,
since it doesn't override anything.

Furthermore, RefChecks had to be moved after ElimRepeated, otherwise
the testcase would fail the overriding checks.

<hr>

@odersky I'm not sure if moving RefChecks is the best solution here. Alternatively we could teach TypeComparer about repeated params when we compare MethodTypes in a phase before ElimRepeated.