### PR TITLE
Allow inter-parameter dependencies

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/CollectEntryPoints.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CollectEntryPoints.scala
@@ -49,7 +49,7 @@ class CollectEntryPoints extends MiniPhaseTransform {
 object CollectEntryPoints{
   def isJavaMainMethod(sym: Symbol)(implicit ctx: Context) = {
     (sym.name == nme.main) && (sym.info match {
-      case r@MethodType(_, List(defn.ArrayOf(t))) =>
+      case r@MethodTpe(_, List(defn.ArrayOf(t)), _) =>
         (t.widenDealias =:= defn.StringType) && (
         r.resultType.widenDealias =:= defn.UnitType)
       case _ => false
@@ -81,9 +81,8 @@ object CollectEntryPoints{
     val possibles = if (sym.flags is Flags.Module) (toDenot(sym).info nonPrivateMember nme.main).alternatives else Nil
     val hasApproximate = possibles exists { m =>
       m.info match {
-        case MethodType(_, p :: Nil) =>
-          p.typeSymbol == defn.ArrayClass
-        case _                       => false
+        case MethodTpe(_, p :: Nil, _) => p.typeSymbol == defn.ArrayClass
+        case _                         => false
       }
     }
     // At this point it's a module with a main-looking method, so either succeed or warn that it isn't.
@@ -108,8 +107,8 @@ object CollectEntryPoints{
             toDenot(m.symbol).info match {
               case t: PolyType =>
                 fail("main methods cannot be generic.")
-              case t@MethodType(paramNames, paramTypes) =>
-                if (t.resultType :: paramTypes exists (_.typeSymbol.isAbstractType))
+              case MethodTpe(paramNames, paramTypes, resultType) =>
+                if (resultType :: paramTypes exists (_.typeSymbol.isAbstractType))
                   fail("main methods cannot refer to type parameters or abstract types.", m.symbol.pos)
                 else
                   isJavaMainMethod(m.symbol) || fail("main method must have exact signature (Array[String])Unit", m.symbol.pos)

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -531,7 +531,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     tree match {
       case Apply(fun, args) =>
         fun.tpe.widen match {
-          case MethodType(names, _) =>
+          case MethodType(names) =>
             names zip args
         }
     }

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -185,12 +185,12 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     }
 
     def valueParamss(tp: Type): (List[List[TermSymbol]], Type) = tp match {
-      case tp @ MethodType(paramNames, paramTypes) =>
+      case tp: MethodType =>
         def valueParam(name: TermName, info: Type): TermSymbol = {
           val maybeImplicit = if (tp.isInstanceOf[ImplicitMethodType]) Implicit else EmptyFlags
           ctx.newSymbol(sym, name, TermParam | maybeImplicit, info)
         }
-        val params = (paramNames, paramTypes).zipped.map(valueParam)
+        val params = (tp.paramNames, tp.paramTypes).zipped.map(valueParam)
         val (paramss, rtp) = valueParamss(tp.instantiate(params map (_.termRef)))
         (params :: paramss, rtp)
       case tp => (Nil, tp.widenExpr)

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -88,6 +88,10 @@ object Config {
    */
   final val checkHKApplications = false
 
+  /** If this flag is set, method types are checked for valid parameter references
+   */
+  final val checkMethodTypes = false
+
   /** The recursion depth for showing a summarized string */
   final val summarizeDepth = 2
 

--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -23,7 +23,7 @@ class JavaPlatform extends Platform {
   // The given symbol is a method with the right name and signature to be a runnable java program.
   def isJavaMainMethod(sym: SymDenotation)(implicit ctx: Context) =
     (sym.name == nme.main) && (sym.info match {
-      case t@MethodType(_, defn.ArrayOf(el) :: Nil) => el =:= defn.StringType && (t.resultType isRef defn.UnitClass)
+      case MethodTpe(_, defn.ArrayOf(el) :: Nil, restpe) => el =:= defn.StringType && (restpe isRef defn.UnitClass)
       case _ => false
     })
 

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -308,13 +308,13 @@ object Denotations {
               case tp2: TypeBounds if tp2 contains tp1 => tp1
               case _ => mergeConflict(tp1, tp2)
             }
-          case tp1 @ MethodType(names1, formals1) if isTerm =>
+          case tp1: MethodType if isTerm =>
             tp2 match {
-              case tp2 @ MethodType(names2, formals2) if ctx.typeComparer.matchingParams(formals1, formals2, tp1.isJava, tp2.isJava) &&
+              case tp2: MethodType if ctx.typeComparer.matchingParams(tp1.paramTypes, tp2.paramTypes, tp1.isJava, tp2.isJava) &&
                 tp1.isImplicit == tp2.isImplicit =>
                 tp1.derivedMethodType(
-                  mergeNames(names1, names2, nme.syntheticParamName),
-                  formals1,
+                  mergeNames(tp1.paramNames, tp2.paramNames, nme.syntheticParamName),
+                  tp1.paramTypes,
                   infoMeet(tp1.resultType, tp2.resultType.subst(tp2, tp1)))
               case _ =>
                 mergeConflict(tp1, tp2)
@@ -471,14 +471,14 @@ object Denotations {
             case tp2: TypeBounds if tp2 contains tp1 => tp2
             case _ => mergeConflict(tp1, tp2)
           }
-        case tp1 @ MethodType(names1, formals1) =>
+        case tp1: MethodType =>
           tp2 match {
-            case tp2 @ MethodType(names2, formals2)
-            if ctx.typeComparer.matchingParams(formals1, formals2, tp1.isJava, tp2.isJava) &&
+            case tp2: MethodType
+            if ctx.typeComparer.matchingParams(tp1.paramTypes, tp2.paramTypes, tp1.isJava, tp2.isJava) &&
               tp1.isImplicit == tp2.isImplicit =>
               tp1.derivedMethodType(
-                mergeNames(names1, names2, nme.syntheticParamName),
-                formals1, tp1.resultType | tp2.resultType.subst(tp2, tp1))
+                mergeNames(tp1.paramNames, tp2.paramNames, nme.syntheticParamName),
+                tp1.paramTypes, tp1.resultType | tp2.resultType.subst(tp2, tp1))
             case _ =>
               mergeConflict(tp1, tp2)
           }

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -252,7 +252,7 @@ trait Symbols { this: Context =>
 
   /** Create a class constructor symbol for given class `cls`. */
   def newConstructor(cls: ClassSymbol, flags: FlagSet, paramNames: List[TermName], paramTypes: List[Type], privateWithin: Symbol = NoSymbol, coord: Coord = NoCoord) =
-    newSymbol(cls, nme.CONSTRUCTOR, flags | Method, MethodType(paramNames, paramTypes)(_ => cls.typeRef), privateWithin, coord)
+    newSymbol(cls, nme.CONSTRUCTOR, flags | Method, MethodType(paramNames, paramTypes, cls.typeRef), privateWithin, coord)
 
   /** Create an empty default constructor symbol for given class `cls`. */
   def newDefaultConstructor(cls: ClassSymbol) =

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -484,11 +484,11 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         case _ =>
       }
       either(isSubType(tp1, tp21), isSubType(tp1, tp22)) || fourthTry(tp1, tp2)
-    case tp2 @ MethodType(_, formals2) =>
+    case tp2: MethodType =>
       def compareMethod = tp1 match {
-        case tp1 @ MethodType(_, formals1) =>
+        case tp1: MethodType =>
           (tp1.signature consistentParams tp2.signature) &&
-            matchingParams(formals1, formals2, tp1.isJava, tp2.isJava) &&
+            matchingParams(tp1.paramTypes, tp2.paramTypes, tp1.isJava, tp2.isJava) &&
             (tp1.isImplicit == tp2.isImplicit) &&
             isSubType(tp1.resultType, tp2.resultType.subst(tp2, tp1))
         case _ =>
@@ -503,7 +503,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         // as members of the same type. And it seems most logical to take
         // ()T <:< => T, since everything one can do with a => T one can
         // also do with a ()T by automatic () insertion.
-        case tp1 @ MethodType(Nil, _) => isSubType(tp1.resultType, restpe2)
+        case tp1 @ MethodType(Nil) => isSubType(tp1.resultType, restpe2)
         case _ => isSubType(tp1.widenExpr, restpe2)
       }
       compareExpr

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2588,11 +2588,6 @@ object Types {
       case _ => false
     }
 
-    /** Is this polytype a higher-kinded type lambda as opposed to a polymorphic?
-     *  method type? Only type lambdas get created with variances, that's how we can tell.
-     */
-    def isTypeLambda: Boolean = variances.nonEmpty
-
     /** PolyParam references to all type parameters of this type */
     lazy val paramRefs: List[PolyParam] = paramNames.indices.toList.map(PolyParam(this, _))
 
@@ -2969,20 +2964,8 @@ object Types {
      *  instantiation can be a singleton type only if the upper bound
      *  is also a singleton type.
      */
-    def instantiate(fromBelow: Boolean)(implicit ctx: Context): Type = {
-      val inst = ctx.typeComparer.instanceType(origin, fromBelow)
-      if (ctx.typerState.isGlobalCommittable)
-        inst match {
-          case inst: PolyParam =>
-            assert(inst.binder.isTypeLambda, i"bad inst $this := $inst, constr = ${ctx.typerState.constraint}")
-              // If this fails, you might want to turn on Config.debugCheckConstraintsClosed
-              // to help find the root of the problem.
-              // Note: Parameters of type lambdas are excluded from the assertion because
-              // they might arise from ill-kinded code. See #1652
-          case _ =>
-        }
-      instantiateWith(inst)
-    }
+    def instantiate(fromBelow: Boolean)(implicit ctx: Context): Type =
+      instantiateWith(ctx.typeComparer.instanceType(origin, fromBelow))
 
     /** Unwrap to instance (if instantiated) or origin (if not), until result
      *  is no longer a TypeVar

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2470,12 +2470,10 @@ object Types {
 
   abstract class MethodTypeCompanion {
     def apply(paramNames: List[TermName])(paramTypesExp: MethodType => List[Type], resultTypeExp: MethodType => Type)(implicit ctx: Context): MethodType
-    def apply(paramNames: List[TermName], paramTypes: List[Type])(resultTypeExp: MethodType => Type)(implicit ctx: Context): MethodType =
-      apply(paramNames)(_ => paramTypes, resultTypeExp)
     def apply(paramNames: List[TermName], paramTypes: List[Type], resultType: Type)(implicit ctx: Context): MethodType =
-      apply(paramNames, paramTypes)(_ => resultType)
+      apply(paramNames)(_ => paramTypes, _ => resultType)
     def apply(paramTypes: List[Type])(resultTypeExp: MethodType => Type)(implicit ctx: Context): MethodType =
-      apply(nme.syntheticParamNames(paramTypes.length), paramTypes)(resultTypeExp)
+      apply(nme.syntheticParamNames(paramTypes.length))(_ => paramTypes, resultTypeExp)
     def apply(paramTypes: List[Type], resultType: Type)(implicit ctx: Context): MethodType =
       apply(nme.syntheticParamNames(paramTypes.length), paramTypes, resultType)
 

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -339,7 +339,7 @@ class ClassfileParser(
           }
           index += 1
           val restype = sig2type(tparams, skiptvs)
-          JavaMethodType(paramnames.toList, paramtypes.toList)(_ => restype)
+          JavaMethodType(paramnames.toList, paramtypes.toList, restype)
         case 'T' =>
           val n = subName(';'.==).toTypeName
           index += 1

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -198,8 +198,8 @@ class ClassfileParser(
          */
         def stripOuterParamFromConstructor() = innerClasses.get(currentClassName) match {
           case Some(entry) if !isStatic(entry.jflags) =>
-            val mt @ MethodType(paramnames, paramtypes) = denot.info
-            denot.info = mt.derivedMethodType(paramnames.tail, paramtypes.tail, mt.resultType)
+            val mt @ MethodTpe(paramNames, paramTypes, resultType) = denot.info
+            denot.info = mt.derivedMethodType(paramNames.tail, paramTypes.tail, resultType)
           case _ =>
         }
 
@@ -207,9 +207,9 @@ class ClassfileParser(
          *  and make constructor type polymorphic in the type parameters of the class
          */
         def normalizeConstructorInfo() = {
-          val mt @ MethodType(paramnames, paramtypes) = denot.info
+          val mt @ MethodType(paramNames) = denot.info
           val rt = classRoot.typeRef appliedTo (classRoot.typeParams map (_.typeRef))
-          denot.info = mt.derivedMethodType(paramnames, paramtypes, rt)
+          denot.info = mt.derivedMethodType(paramNames, mt.paramTypes, rt)
           addConstructorTypeParams(denot)
         }
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -278,7 +278,8 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table, posUnpickle
               result
             case METHODtype =>
               val (names, paramReader) = readNamesSkipParams
-              val result = MethodType(names.map(_.toTermName), paramReader.readParamTypes[Type](end))(
+              val result = MethodType(names.map(_.toTermName))(
+                mt => paramReader.readParamTypes[Type](end), // !!!
                 mt => registeringType(mt, readType()))
               goto(end)
               result

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -279,8 +279,8 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table, posUnpickle
             case METHODtype =>
               val (names, paramReader) = readNamesSkipParams
               val result = MethodType(names.map(_.toTermName))(
-                mt => paramReader.readParamTypes[Type](end), // !!!
-                mt => registeringType(mt, readType()))
+                mt => registeringType(mt, paramReader.readParamTypes[Type](end)),
+                mt => readType())
               goto(end)
               result
             case PARAMtype =>

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -55,8 +55,8 @@ object Scala2Unpickler {
    *  to `RepeatedParamClass` types.
    */
   def arrayToRepeated(tp: Type)(implicit ctx: Context): Type = tp match {
-    case tp @ MethodType(paramNames, paramTypes) =>
-      val lastArg = paramTypes.last
+    case tp: MethodType =>
+      val lastArg = tp.paramTypes.last
       assert(lastArg isRef defn.ArrayClass)
       val elemtp0 :: Nil = lastArg.baseArgInfos(defn.ArrayClass)
       val elemtp = elemtp0 match {
@@ -66,8 +66,8 @@ object Scala2Unpickler {
           elemtp0
       }
       tp.derivedMethodType(
-        paramNames,
-        paramTypes.init :+ defn.RepeatedParamType.appliedTo(elemtp),
+        tp.paramNames,
+        tp.paramTypes.init :+ defn.RepeatedParamType.appliedTo(elemtp),
         tp.resultType)
     case tp: PolyType =>
       tp.derivedPolyType(tp.paramNames, tp.paramBounds, arrayToRepeated(tp.resultType))

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -284,7 +284,7 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
       case pt: PolyType =>
         assert(start == 0)
         paramLists(pt.resultType)
-      case mt @ MethodType(pnames, ptypes) =>
+      case mt @ MethodTpe(pnames, ptypes, restpe) =>
         // TODO: We shouldn't have to work so hard to find the default parameters
         // of a method, Dotty should expose a convenience method for that, see #1143
         val defaults =
@@ -300,7 +300,7 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
         val params = (pnames, ptypes, defaults).zipped.map((pname, ptype, isDefault) =>
           new api.MethodParameter(pname.toString, apiType(ptype),
             isDefault, api.ParameterModifier.Plain))
-        new api.ParameterList(params.toArray, mt.isImplicit) :: paramLists(mt.resultType, params.length)
+        new api.ParameterList(params.toArray, mt.isImplicit) :: paramLists(restpe, params.length)
       case _ =>
         Nil
     }

--- a/compiler/src/dotty/tools/dotc/transform/CollectEntryPoints.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CollectEntryPoints.scala
@@ -64,7 +64,7 @@ class CollectEntryPoints extends MiniPhaseTransform {
     val hasApproximate = possibles exists {
       m =>
         m.info match {
-          case MethodType(_, p :: Nil) =>
+          case MethodTpe(_, p :: Nil, _) =>
             p.typeSymbol == defn.ArrayClass
           case _ => false
         }
@@ -87,8 +87,8 @@ class CollectEntryPoints extends MiniPhaseTransform {
             m.symbol.info match {
               case t: PolyType =>
                 fail("main methods cannot be generic.")
-              case t@MethodType(paramNames, paramTypes) =>
-                if (t.resultType :: paramTypes exists (_.typeSymbol.isAbstractType))
+              case t: MethodType =>
+                if (t.resultType :: t.paramTypes exists (_.typeSymbol.isAbstractType))
                   fail("main methods cannot refer to type parameters or abstract types.", m.symbol.pos)
                 else
                   javaPlatform.isJavaMainMethod(m.symbol) || fail("main method must have exact signature (Array[String])Unit", m.symbol.pos)

--- a/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
@@ -92,8 +92,8 @@ class ElimByName extends MiniPhaseTransform with InfoTransformer { thisTransform
         arg
     }
 
-    val MethodType(_, formals) = tree.fun.tpe.widen
-    val args1 = tree.args.zipWithConserve(formals)(transformArg)
+    val mt @ MethodType(_) = tree.fun.tpe.widen
+    val args1 = tree.args.zipWithConserve(mt.paramTypes)(transformArg)
     cpy.Apply(tree)(tree.fun, args1)
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -48,8 +48,8 @@ class ElimRepeated extends MiniPhaseTransform with InfoTransformer with Annotati
   private def overridesJava(sym: Symbol)(implicit ctx: Context) = sym.allOverriddenSymbols.exists(_ is JavaDefined)
 
   private def elimRepeated(tp: Type)(implicit ctx: Context): Type = tp.stripTypeVar match {
-    case tp @ MethodType(paramNames, paramTypes) =>
-      val resultType1 = elimRepeated(tp.resultType)
+    case tp @ MethodTpe(paramNames, paramTypes, resultType) =>
+      val resultType1 = elimRepeated(resultType)
       val paramTypes1 =
         if (paramTypes.nonEmpty && paramTypes.last.isRepeatedParam) {
           val last = paramTypes.last.underlyingIfRepeated(tp.isJava)

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -53,7 +53,7 @@ class ExpandSAMs extends MiniPhaseTransform { thisTransformer =>
     val applyRhs: Tree = applyDef.rhs
     val applyFn = applyDef.symbol.asTerm
 
-    val MethodType(paramNames, paramTypes) = applyFn.info
+    val MethodTpe(paramNames, paramTypes, _) = applyFn.info
     val isDefinedAtFn = applyFn.copy(
         name  = nme.isDefinedAt,
         flags = Synthetic | Method,

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -328,9 +328,9 @@ object ExplicitOuter {
     /** If `cls` has an outer parameter add one to the method type `tp`. */
     def addParam(cls: ClassSymbol, tp: Type): Type =
       if (hasOuterParam(cls)) {
-        val mt @ MethodType(pnames, ptypes) = tp
+        val mt @ MethodTpe(pnames, ptypes, restpe) = tp
         mt.derivedMethodType(
-          nme.OUTER :: pnames, cls.owner.enclosingClass.typeRef :: ptypes, mt.resultType)
+          nme.OUTER :: pnames, cls.owner.enclosingClass.typeRef :: ptypes, restpe)
       } else tp
 
     /** If function in an apply node is a constructor that needs to be passed an
@@ -389,7 +389,7 @@ object ExplicitOuter {
     /** The outer parameter definition of a constructor if it needs one */
     def paramDefs(constr: Symbol): List[ValDef] =
       if (constr.isConstructor && hasOuterParam(constr.owner.asClass)) {
-        val MethodType(outerName :: _, outerType :: _) = constr.info
+        val MethodTpe(outerName :: _, outerType :: _, _) = constr.info
         val outerSym = ctx.newSymbol(constr, outerName, Param, outerType)
         ValDef(outerSym) :: Nil
       }

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -29,7 +29,7 @@ import StdNames._
  *   - eliminates some kinds of trees: Imports, NamedArgs
  *   - stubs out native methods
  *   - eliminates self tree in Template and self symbol in ClassInfo
- *   - collapsess all type trees to trees of class TypeTree
+ *   - collapses all type trees to trees of class TypeTree
  *   - converts idempotent expressions with constant types
  */
 class FirstTransform extends MiniPhaseTransform with InfoTransformer with AnnotationTransformer { thisTransformer =>
@@ -148,7 +148,7 @@ class FirstTransform extends MiniPhaseTransform with InfoTransformer with Annota
   override def transformTemplate(impl: Template)(implicit ctx: Context, info: TransformerInfo): Tree = {
     cpy.Template(impl)(self = EmptyValDef)
   }
-  
+
   override def transformDefDef(ddef: DefDef)(implicit ctx: Context, info: TransformerInfo) = {
     if (ddef.symbol.hasAnnotation(defn.NativeAnnot)) {
       ddef.symbol.resetFlag(Deferred)
@@ -168,13 +168,13 @@ class FirstTransform extends MiniPhaseTransform with InfoTransformer with Annota
   }
 
   override def transformIdent(tree: Ident)(implicit ctx: Context, info: TransformerInfo) =
-    if (tree.isType) TypeTree(tree.tpe).withPos(tree.pos) 
+    if (tree.isType) TypeTree(tree.tpe).withPos(tree.pos)
     else constToLiteral(tree)
 
   override def transformSelect(tree: Select)(implicit ctx: Context, info: TransformerInfo) =
-    if (tree.isType) TypeTree(tree.tpe).withPos(tree.pos) 
+    if (tree.isType) TypeTree(tree.tpe).withPos(tree.pos)
     else constToLiteral(tree)
-    
+
   override def transformTypeApply(tree: TypeApply)(implicit ctx: Context, info: TransformerInfo) =
     constToLiteral(tree)
 
@@ -183,7 +183,7 @@ class FirstTransform extends MiniPhaseTransform with InfoTransformer with Annota
 
   override def transformTyped(tree: Typed)(implicit ctx: Context, info: TransformerInfo) =
     constToLiteral(tree)
-    
+
   override def transformBlock(tree: Block)(implicit ctx: Context, info: TransformerInfo) =
     constToLiteral(tree)
 

--- a/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -252,10 +252,10 @@ object FullParameterization {
   def memberSignature(info: Type)(implicit ctx: Context): Signature = info match {
     case info: PolyType =>
       memberSignature(info.resultType)
-    case info @ MethodType(nme.SELF :: Nil, _) =>
-      info.resultType.ensureMethodic.signature
-    case info @ MethodType(nme.SELF :: otherNames, thisType :: otherTypes) =>
-      info.derivedMethodType(otherNames, otherTypes, info.resultType).signature
+    case MethodTpe(nme.SELF :: Nil, _, restpe) =>
+      restpe.ensureMethodic.signature
+    case info @ MethodTpe(nme.SELF :: otherNames, thisType :: otherTypes, restpe) =>
+      info.derivedMethodType(otherNames, otherTypes, restpe).signature
     case _ =>
       Signature.NotAMethod
   }

--- a/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -105,8 +105,9 @@ trait FullParameterization {
     def resultType(mapClassParams: Type => Type) = {
       val thisParamType = mapClassParams(clazz.classInfo.selfType)
       val firstArgType = if (liftThisType) thisParamType & clazz.thisType else thisParamType
-      MethodType(nme.SELF :: Nil, firstArgType :: Nil)(mt =>
-        mapClassParams(origResult).substThisUnlessStatic(clazz, MethodParam(mt, 0)))
+      MethodType(nme.SELF :: Nil)(
+          mt => firstArgType :: Nil,
+          mt => mapClassParams(origResult).substThisUnlessStatic(clazz, MethodParam(mt, 0)))
     }
 
     /** Replace class type parameters by the added type parameters of the polytype `pt` */

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -352,12 +352,12 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
       }
 
     private def liftedInfo(local: Symbol)(implicit ctx: Context): Type = local.info match {
-      case mt @ MethodType(pnames, ptypes) =>
+      case MethodTpe(pnames, ptypes, restpe) =>
         val ps = proxies(local)
         MethodType(
           ps.map(_.name.asTermName) ++ pnames,
           ps.map(_.info) ++ ptypes,
-          mt.resultType)
+          restpe)
       case info => info
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -27,7 +27,7 @@ class ParamForwarding(thisTransformer: DenotTransformer) {
       val (superArgs, superParamNames) = impl.parents match {
         case superCall @ Apply(fn, args) :: _ =>
           fn.tpe.widen match {
-            case MethodType(paramNames, _) => (args, paramNames)
+            case MethodType(paramNames) => (args, paramNames)
             case _ => (Nil, Nil)
           }
         case _ => (Nil, Nil)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1263,7 +1263,8 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
 
         def sizeFits(alt: TermRef, tp: Type): Boolean = tp match {
           case tp: PolyType => sizeFits(alt, tp.resultType)
-          case MethodType(_, ptypes) =>
+          case tp: MethodType =>
+            val ptypes = tp.paramTypes
             val numParams = ptypes.length
             def isVarArgs = ptypes.nonEmpty && ptypes.last.isRepeatedParam
             def hasDefault = alt.symbol.hasDefaultParams

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -178,6 +178,8 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
      */
     protected def normalizedFun: Tree
 
+    protected def typeOfArg(arg: Arg): Type
+
     /** If constructing trees, pull out all parts of the function
      *  which are not idempotent into separate prefix definitions
      */
@@ -380,8 +382,16 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       if (success) formals match {
         case formal :: formals1 =>
 
-          def addTyped(arg: Arg, formal: Type) =
+          /** Add result of typing argument `arg` against parameter type `formal`.
+           *  @return  A type transformation to apply to all arguments following this one.
+           */
+          def addTyped(arg: Arg, formal: Type): Type => Type = {
             addArg(typedArg(arg, formal), formal)
+            if (methodType.isParamDependent)
+              _.substParam(MethodParam(methodType, n), typeOfArg(arg))
+            else
+              identity
+          }
 
           def missingArg(n: Int): Unit = {
             val pname = methodType.paramNames(n)
@@ -395,8 +405,10 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
             val getter = findDefaultGetter(n + numArgs(normalizedFun))
             if (getter.isEmpty) missingArg(n)
             else {
-              addTyped(treeToArg(spliceMeth(getter withPos normalizedFun.pos, normalizedFun)), formal)
-              matchArgs(args1, formals1, n + 1)
+              val substParam = addTyped(
+                  treeToArg(spliceMeth(getter withPos normalizedFun.pos, normalizedFun)),
+                  formal)
+              matchArgs(args1, formals1.mapconserve(substParam), n + 1)
             }
           }
 
@@ -420,8 +432,8 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
             case EmptyTree :: args1 =>
               tryDefault(n, args1)
             case arg :: args1 =>
-              addTyped(arg, formal)
-              matchArgs(args1, formals1, n + 1)
+              val substParam = addTyped(arg, formal)
+              matchArgs(args1, formals1.mapconserve(substParam), n + 1)
             case nil =>
               tryDefault(n, args)
           }
@@ -477,6 +489,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
     def argType(arg: Tree, formal: Type): Type = normalize(arg.tpe, formal)
     def treeToArg(arg: Tree): Tree = arg
     def isVarArg(arg: Tree): Boolean = tpd.isWildcardStarArg(arg)
+    def typeOfArg(arg: Tree): Type = arg.tpe
     def harmonizeArgs(args: List[Tree]) = harmonize(args)
   }
 
@@ -494,6 +507,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
     def argType(arg: Type, formal: Type): Type = arg
     def treeToArg(arg: Tree): Type = arg.tpe
     def isVarArg(arg: Type): Boolean = arg.isRepeatedParam
+    def typeOfArg(arg: Type): Type = arg
     def harmonizeArgs(args: List[Type]) = harmonizeTypes(args)
   }
 
@@ -592,6 +606,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
   extends TypedApply(app, fun, methRef, proto.args, resultType) {
     def typedArg(arg: untpd.Tree, formal: Type): TypedArg = proto.typedArg(arg, formal.widenExpr)
     def treeToArg(arg: Tree): untpd.Tree = untpd.TypedSplice(arg)
+    def typeOfArg(arg: untpd.Tree) = proto.typeOfArg(arg)
   }
 
   /** Subclass of Application for type checking an Apply node with typed arguments. */
@@ -603,6 +618,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       // not match the abstract method in Application and an abstract class error results.
     def typedArg(arg: tpd.Tree, formal: Type): TypedArg = arg
     def treeToArg(arg: Tree): Tree = arg
+    def typeOfArg(arg: Tree) = arg.tpe
   }
 
   /** If `app` is a `this(...)` constructor call, the this-call argument context,

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -59,8 +59,8 @@ object EtaExpansion {
    */
   def liftArgs(defs: mutable.ListBuffer[Tree], methRef: Type, args: List[Tree])(implicit ctx: Context) =
     methRef.widen match {
-      case MethodType(paramNames, paramTypes) =>
-        (args, paramNames, paramTypes).zipped map { (arg, name, tp) =>
+      case mt: MethodType =>
+        (args, mt.paramNames, mt.paramTypes).zipped map { (arg, name, tp) =>
           if (tp.isInstanceOf[ExprType]) arg
           else liftArg(defs, arg, if (name contains '$') "" else name.toString + "$")
         }

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -238,7 +238,7 @@ object ProtoTypes {
     }
 
     /** The type of the argument `arg`.
-     *  @pre `arg` ahs been typed before
+     *  @pre `arg` has been typed before
      */
     def typeOfArg(arg: untpd.Tree)(implicit ctx: Context): Type =
       myTypedArg(arg).tpe

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -237,6 +237,12 @@ object ProtoTypes {
       typer.adapt(targ, formal, arg)
     }
 
+    /** The type of the argument `arg`.
+     *  @pre `arg` ahs been typed before
+     */
+    def typeOfArg(arg: untpd.Tree)(implicit ctx: Context): Type =
+      myTypedArg(arg).tpe
+
     private var myTupled: Type = NoType
 
     /** The same proto-type but with all arguments combined in a single tuple */

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -85,8 +85,8 @@ class ReTyper extends Typer {
   override def encodeName(tree: untpd.NameTree)(implicit ctx: Context) = tree
 
   override def handleUnexpectedFunType(tree: untpd.Apply, fun: Tree)(implicit ctx: Context): Tree = fun.tpe match {
-    case mt @ MethodType(_, formals) =>
-      val args: List[Tree] = tree.args.zipWithConserve(formals)(typedExpr(_, _)).asInstanceOf[List[Tree]]
+    case mt: MethodType =>
+      val args: List[Tree] = tree.args.zipWithConserve(mt.paramTypes)(typedExpr(_, _)).asInstanceOf[List[Tree]]
       assignType(untpd.cpy.Apply(tree)(fun, args), fun, args)
     case _ =>
       super.handleUnexpectedFunType(tree, fun)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -315,10 +315,10 @@ trait TypeAssigner {
 
   def assignType(tree: untpd.Apply, fn: Tree, args: List[Tree])(implicit ctx: Context) = {
     val ownType = fn.tpe.widen match {
-      case fntpe @ MethodType(_, ptypes) =>
-        if (sameLength(ptypes, args) || ctx.phase.prev.relaxedTyping) fntpe.instantiate(args.tpes)
+      case fntpe: MethodType =>
+        if (sameLength(fntpe.paramTypes, args) || ctx.phase.prev.relaxedTyping) fntpe.instantiate(args.tpes)
         else
-          errorType(i"wrong number of arguments for $fntpe: ${fn.tpe}, expected: ${ptypes.length}, found: ${args.length}", tree.pos)
+          errorType(i"wrong number of arguments for $fntpe: ${fn.tpe}, expected: ${fntpe.paramTypes.length}, found: ${args.length}", tree.pos)
       case t =>
         errorType(i"${err.exprStr(fn)} does not take parameters", tree.pos)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1229,6 +1229,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     completeAnnotations(ddef, sym)
     val tparams1 = tparams mapconserve (typed(_).asInstanceOf[TypeDef])
     val vparamss1 = vparamss nestedMapconserve (typed(_).asInstanceOf[ValDef])
+    vparamss1.foreach(checkNoForwardDependencies)
     if (sym is Implicit) checkImplicitParamsNotSingletons(vparamss1)
     var tpt1 = checkSimpleKinded(typedType(tpt))
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -672,8 +672,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       // this can type the greatest set of admissible closures.
       (pt.dealias.argTypesLo.init, pt.dealias.argTypesHi.last)
     case SAMType(meth) =>
-      val mt @ MethodType(_, paramTypes) = meth.info
-      (paramTypes, mt.resultType)
+      val MethodTpe(_, formals, restpe) = meth.info
+      (formals, restpe)
     case _ =>
       (List.range(0, defaultArity) map alwaysWildcardType, WildcardType)
   }
@@ -1287,10 +1287,10 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     def maybeCall(ref: Tree, psym: Symbol, cinfo: Type): Tree = cinfo match {
       case cinfo: PolyType =>
         maybeCall(ref, psym, cinfo.resultType)
-      case cinfo @ MethodType(Nil, _) if cinfo.resultType.isInstanceOf[ImplicitMethodType] =>
+      case cinfo @ MethodType(Nil) if cinfo.resultType.isInstanceOf[ImplicitMethodType] =>
         val icall = New(ref).select(nme.CONSTRUCTOR).appliedToNone
         typedExpr(untpd.TypedSplice(icall))(superCtx)
-      case cinfo @ MethodType(Nil, _) if !cinfo.resultType.isInstanceOf[MethodType] =>
+      case cinfo @ MethodType(Nil) if !cinfo.resultType.isInstanceOf[MethodType] =>
         ref
       case cinfo: MethodType =>
         if (!ctx.erasedTypes) { // after constructors arguments are passed in super call.

--- a/compiler/src/dotty/tools/dotc/typer/Variances.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Variances.scala
@@ -79,8 +79,8 @@ object Variances {
       varianceInType(parent)(tparam) & varianceInType(rinfo)(tparam)
     case tp: RecType =>
       varianceInType(tp.parent)(tparam)
-    case tp @ MethodType(_, paramTypes) =>
-      flip(varianceInTypes(paramTypes)(tparam)) & varianceInType(tp.resultType)(tparam)
+    case tp: MethodType =>
+      flip(varianceInTypes(tp.paramTypes)(tparam)) & varianceInType(tp.resultType)(tparam)
     case ExprType(restpe) =>
       varianceInType(restpe)(tparam)
     case tp @ HKApply(tycon, args) =>

--- a/tests/neg/illegal-depmeth.scala
+++ b/tests/neg/illegal-depmeth.scala
@@ -1,0 +1,13 @@
+object Test {
+
+  class C { type T }
+
+  def f(x: C, y: x.T): x.T = y // ok
+
+  def g(y: x.T, x: C): x.T = y // error
+
+  def h(x: x.T) = ??? // error
+
+  def g(x: => C): x.T = ???  // error: x is not stable
+
+}

--- a/tests/pos/param-depmeth.scala
+++ b/tests/pos/param-depmeth.scala
@@ -1,0 +1,15 @@
+object Test {
+
+  class C { type T }
+
+  def f(x: C, y: x.T): x.T = y // ok
+
+  val c = new C { type T = String }
+  val c2 = c
+
+  f(c, "abc")
+  f(new C{ type T = String}, "abc")
+
+  val d: (C{ type T = String}) # T = "abc"
+
+}


### PR DESCRIPTION
Allow a later parameter's type to refer to an earlier parameter in the same parameter section. Previously, we allowed only references to parameters in preceding sections. This is simpler, but it
can force unnatural currying. The problem becomes urgent only if we want to add dependent types more broadly. It feels natural to write 

    def f(n: Int, v: Vec(n))

and being forced to curry this as `def fun(n: Int)(v: Vec(n))` is annoying. 

The changes in this PR have given me an idea for a much more sweeping change. We might be able to unify MethodTypes and PolyTypes, which would improve regularity of the language quite significantly and which would open up lots of new possibilities. But one thing after another.

Review by @gsps?


