### PR TITLE
-Yplain-printer: do not print positions by default

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -483,7 +483,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
           else
             Text()
 
-        nodeName ~ "(" ~ elems ~ tpSuffix ~ ")" ~ node.pos.toString
+        nodeName ~ "(" ~ elems ~ tpSuffix ~ ")" ~ (node.pos.toString provided ctx.settings.Yprintpos.value)
       case _ =>
         tree.fallbackToText(this)
     }


### PR DESCRIPTION
You can still have positions printed by explictly passing -Yprintpos