### PR TITLE
Fix compilation of ParSetLike by itself

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -357,7 +357,7 @@ object Checking {
    */
   def checkNoPrivateLeaks(sym: Symbol, pos: Position)(implicit ctx: Context): Type = {
     class NotPrivate extends TypeMap {
-      var errors: List[String] = Nil
+      var errors: List[() => String] = Nil
 
       def accessBoundary(sym: Symbol): Symbol =
         if (sym.is(Private) || !sym.owner.isClass) sym.owner
@@ -384,7 +384,7 @@ object Checking {
           var tp1 =
             if (isLeaked(tp.symbol)) {
               errors =
-                em"non-private $sym refers to private ${tp.symbol}\n in its type signature ${sym.info}" :: errors
+                (() => em"non-private $sym refers to private ${tp.symbol}\n in its type signature ${sym.info}") :: errors
               tp
             }
             else mapOver(tp)
@@ -408,7 +408,7 @@ object Checking {
     }
     val notPrivate = new NotPrivate
     val info = notPrivate(sym.info)
-    notPrivate.errors.foreach(ctx.errorOrMigrationWarning(_, pos))
+    notPrivate.errors.foreach(error => ctx.errorOrMigrationWarning(error(), pos))
     info
   }
 

--- a/compiler/test/dotc/tests.scala
+++ b/compiler/test/dotc/tests.scala
@@ -224,6 +224,7 @@ class tests extends CompilerTest {
         |../scala-scala/src/library/scala/collection/SeqLike.scala
         |../scala-scala/src/library/scala/collection/generic/GenSeqFactory.scala""".stripMargin)
   @Test def compileIndexedSeq = compileLine("../scala-scala/src/library/scala/collection/immutable/IndexedSeq.scala")
+  @Test def compileParSetLike = compileLine("../scala-scala/src/library/scala/collection/parallel/mutable/ParSetLike.scala")
 
   @Test def dotty = {
     dottyBootedLib


### PR DESCRIPTION
Before this commit, ParSetLike compiled fine as part of compileStdLib
but crashed when compiled by itself because we tried to force a LazyRef
while forcing the same LazyRef. This commit fixes this by being slightly
more lazy where it matters.