### PR TITLE
Fix #2089: Error when compiling ParSetLike, ParSet, SetLike, in this order

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1080,6 +1080,13 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
               (if (isVarPattern(arg)) desugar.patternVar(arg) else arg, tparam.paramBounds)
             else
               (arg, WildcardType)
+          if (tpt1.symbol.isClass)
+            tparam match {
+              case tparam: Symbol =>
+                // This is needed to get the test `compileParSetSubset` to work
+                tparam.ensureCompleted()
+              case _ =>
+            }
           typed(desugaredArg, argPt)
         }
         args.zipWithConserve(tparams)(typedArg(_, _)).asInstanceOf[List[Tree]]

--- a/compiler/test/dotc/tests.scala
+++ b/compiler/test/dotc/tests.scala
@@ -225,6 +225,10 @@ class tests extends CompilerTest {
         |../scala-scala/src/library/scala/collection/generic/GenSeqFactory.scala""".stripMargin)
   @Test def compileIndexedSeq = compileLine("../scala-scala/src/library/scala/collection/immutable/IndexedSeq.scala")
   @Test def compileParSetLike = compileLine("../scala-scala/src/library/scala/collection/parallel/mutable/ParSetLike.scala")
+  @Test def compileParSetSubset = compileLine(
+      """../scala-scala/src/library/scala/collection/parallel/mutable/ParSetLike.scala
+        |../scala-scala/src/library/scala/collection/parallel/mutable/ParSet.scala
+        |../scala-scala/src/library/scala/collection/mutable/SetLike.scala""".stripMargin)(scala2mode ++ defaultOptions)
 
   @Test def dotty = {
     dottyBootedLib


### PR DESCRIPTION
This fix is inspired by 6c91684, but I couldn't tell you why it works
exactly, it's just something I tried.