### PR TITLE
Fix Symbol#sourceFile not working after Flatten

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -496,12 +496,15 @@ object Symbols {
     final def sourceFile(implicit ctx: Context): AbstractFile = {
       val file = associatedFile
       if (file != null && !file.path.endsWith("class")) file
-      else denot.topLevelClass.getAnnotation(defn.SourceFileAnnot) match {
-        case Some(sourceAnnot) => sourceAnnot.argumentConstant(0) match {
-          case Some(Constant(path: String)) => AbstractFile.getFile(path)
+      else {
+        val topLevelCls = denot.topLevelClass(ctx.withPhaseNoLater(ctx.flattenPhase))
+        topLevelCls.getAnnotation(defn.SourceFileAnnot) match {
+          case Some(sourceAnnot) => sourceAnnot.argumentConstant(0) match {
+            case Some(Constant(path: String)) => AbstractFile.getFile(path)
+            case none => null
+          }
           case none => null
         }
-        case none => null
       }
     }
 


### PR DESCRIPTION
The SourceFile annotation is only present on the non-flattened top-level
class.
