### PR TITLE
Fix #2071: handle HKApply in SAMType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3328,6 +3328,8 @@ object Types {
         zeroParamClass(tp.underlying)
       case tp: TypeVar =>
         zeroParamClass(tp.underlying)
+      case tp: HKApply =>
+        zeroParamClass(tp.superType)
       case _ =>
         NoType
     }

--- a/tests/pos/i2071.scala
+++ b/tests/pos/i2071.scala
@@ -1,0 +1,7 @@
+object Test {
+  type PF[A, B] = PartialFunction[A, B]
+
+  val f: PF[Int, String] = {
+    case i => "bar"
+  }
+}


### PR DESCRIPTION
 Fix #2071: handle HKApply in SAMType

Previously, the logic in `SAMType` does not take into consideration type constructors.