### PR TITLE
Fix #2051: allow override T with => T or ()T

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -727,8 +727,8 @@ object Types {
 
     /** Is this type a legal type for a member that overrides another
      *  member of type `that`? This is the same as `<:<`, except that
-     *  the types ()T and => T are identified, and T is seen as overriding
-     *  either type.
+     *  the types `()T`, `=> T` and `T` are seen as overriding
+     *  each other.
      */
     final def overrides(that: Type)(implicit ctx: Context) = {
       def result(tp: Type): Type = tp match {
@@ -737,7 +737,8 @@ object Types {
       }
       (this frozen_<:< that) || {
         val rthat = result(that)
-        (rthat ne that) && (result(this) frozen_<:< rthat)
+        val rthis = result(this)
+        (rthat.ne(that) || rthis.ne(this)) && (rthis frozen_<:< rthat)
       }
     }
 

--- a/tests/neg/i2051.scala
+++ b/tests/neg/i2051.scala
@@ -1,0 +1,2 @@
+abstract class C { val x: Int }
+class D extends C { def x = 1 } // error: method x of type => Int needs to be a stable, immutable value

--- a/tests/pos/i2051.scala
+++ b/tests/pos/i2051.scala
@@ -1,2 +1,9 @@
 class A[T](val x:T)
 class B[T](override val x:T) extends A[T](x)
+
+class C[T](val x:T, val y: Int, val z: Boolean)
+class D[T](override val x:T, y: Int, z: Boolean) extends C[T](x, y, z)
+
+trait X(val x: Int, y: Int, z: Int)
+trait Y(override val x: Int, y: Int, z: Int) extends X
+class Z(override val x: Int, y: Int, z: Int) extends Y(x, y, z) with X(x, y, z)

--- a/tests/pos/i2051.scala
+++ b/tests/pos/i2051.scala
@@ -1,0 +1,2 @@
+class A[T](val x:T)
+class B[T](override val x:T) extends A[T](x)


### PR DESCRIPTION
Fix #2051: allow override `T` with `=> T` or `()T`.

I'm not sure if this is the right fix. Could you please advise @DarkDimius ?