### PR TITLE
Fix #2099: Make param forwarders override the param they forward to

### DIFF
--- a/tests/pos/i2099/A_1.scala
+++ b/tests/pos/i2099/A_1.scala
@@ -1,0 +1,3 @@
+class A(val member: Int)
+
+class SubA(member: Int) extends A(member)

--- a/tests/pos/i2099/B_2.scala
+++ b/tests/pos/i2099/B_2.scala
@@ -1,0 +1,1 @@
+class B(member: Int) extends SubA(member)


### PR DESCRIPTION
Previously, in the following code:
```scala
class A(val member: Int)
class SubA(member: Int) extends A(member)
```
We created a forwarder in SubA like this:
```scala
  private[this] def member: Int = super.member
```
Since a private method cannot have the same name as an inherited
non-private one, we subsequently name-mangled the forwarder in
ExpandPrivate. However, this was only done in the TreeTransformer, not
in the DenotTransformer, this lead to separate compilation issues (see
added testcase).

Since we cannot detect that a ParamAccessor is a forwarder in a
DenotTransformer, we cannot fix the problem locally in ExpandPrivate.
Instead, we change ParamForwarding so that the forwarder now looks like:
```scala
  override def member: Int = super.member
```
To make this work we restrict ParamForwarding to only create forwarders
for non-final fields.