### PR TITLE
Alternative fix for #2099: avoid loading a private member when recomputing a NamedType denot

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1482,7 +1482,7 @@ object Types {
 
     /** A member of `prefix` (disambiguated by `d.signature`) or, if none was found, `d.current`. */
     private def recomputeMember(d: SymDenotation)(implicit ctx: Context): Denotation =
-      asMemberOf(prefix) match {
+      asMemberOf(prefix, allowPrivate = d.is(Private)) match {
         case NoDenotation => d.current
         case newd: SingleDenotation => newd
         case newd =>
@@ -1573,7 +1573,7 @@ object Types {
       TermRef.withSig(prefix, name.asTermName, sig)
 
     protected def loadDenot(implicit ctx: Context): Denotation = {
-      val d = asMemberOf(prefix)
+      val d = asMemberOf(prefix, allowPrivate = true)
       if (d.exists || ctx.phaseId == FirstPhaseId || !lastDenotation.isInstanceOf[SymDenotation])
         d
       else { // name has changed; try load in earlier phase and make current
@@ -1583,15 +1583,10 @@ object Types {
       }
     }
 
-    protected def asMemberOf(prefix: Type)(implicit ctx: Context): Denotation =
+    protected def asMemberOf(prefix: Type, allowPrivate: Boolean)(implicit ctx: Context): Denotation =
       if (name.isShadowedName) prefix.nonPrivateMember(name.revertShadowed)
-      else lastDenotation match {
-        case d: SymDenotation if !d.is(Private) =>
-          // We shouldn't go from a non-private denotation to a private one
-          prefix.nonPrivateMember(name)
-        case _ =>
-          prefix.member(name)
-      }
+      else if (!allowPrivate) prefix.nonPrivateMember(name)
+      else prefix.member(name)
 
     /** (1) Reduce a type-ref `W # X` or `W { ... } # U`, where `W` is a wildcard type
      *  to an (unbounded) wildcard type.
@@ -1791,7 +1786,7 @@ object Types {
       val candidate = TermRef.withSig(prefix, name, sig)
       if (symbol.exists && !candidate.symbol.exists) { // recompute from previous symbol
         val ownSym = symbol
-        val newd = asMemberOf(prefix)
+        val newd = asMemberOf(prefix, allowPrivate = ownSym.is(Private))
         candidate.withDenot(newd.suchThat(_.signature == ownSym.signature))
       }
       else candidate

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1585,8 +1585,12 @@ object Types {
 
     protected def asMemberOf(prefix: Type)(implicit ctx: Context): Denotation =
       if (name.isShadowedName) prefix.nonPrivateMember(name.revertShadowed)
-      else prefix.member(name)
-
+      else {
+        val d = lastDenotation
+        // Never go from a non-private denotation to a private one
+        if (d == null || d.symbol.is(Private)) prefix.member(name)
+        else prefix.nonPrivateMember(name)
+      }
 
     /** (1) Reduce a type-ref `W # X` or `W { ... } # U`, where `W` is a wildcard type
      *  to an (unbounded) wildcard type.

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1585,11 +1585,12 @@ object Types {
 
     protected def asMemberOf(prefix: Type)(implicit ctx: Context): Denotation =
       if (name.isShadowedName) prefix.nonPrivateMember(name.revertShadowed)
-      else {
-        val d = lastDenotation
-        // Never go from a non-private denotation to a private one
-        if (d == null || d.symbol.is(Private)) prefix.member(name)
-        else prefix.nonPrivateMember(name)
+      else lastDenotation match {
+        case d: SymDenotation if !d.is(Private) =>
+          // We shouldn't go from a non-private denotation to a private one
+          prefix.nonPrivateMember(name)
+        case _ =>
+          prefix.member(name)
       }
 
     /** (1) Reduce a type-ref `W # X` or `W { ... } # U`, where `W` is a wildcard type

--- a/tests/run/paramForwarding_separate.check
+++ b/tests/run/paramForwarding_separate.check
@@ -1,0 +1,6 @@
+# Fields in A:
+private final int A.member$$local
+# Fields in SubA:
+
+# Fields in B:
+

--- a/tests/run/paramForwarding_separate/A_1.scala
+++ b/tests/run/paramForwarding_separate/A_1.scala
@@ -1,0 +1,3 @@
+class A(val member: Int)
+
+class SubA(member: Int) extends A(member)

--- a/tests/run/paramForwarding_separate/B_2.scala
+++ b/tests/run/paramForwarding_separate/B_2.scala
@@ -1,0 +1,19 @@
+class B(member: Int) extends SubA(member)
+
+object Test {
+  def printFields(cls: Class[_]) =
+    println(cls.getDeclaredFields.map(_.toString).sorted.deep.mkString("\n"))
+
+  def main(args: Array[String]): Unit = {
+    val a = new A(10)
+    val subA = new SubA(11)
+    val b = new B(12)
+
+    println("# Fields in A:")
+    printFields(classOf[A])
+    println("# Fields in SubA:")
+    printFields(classOf[SubA])
+    println("# Fields in B:")
+    printFields(classOf[B])
+  }
+}


### PR DESCRIPTION
ParamForwarding creates the following forwarder in B:
```scala
  private[this] def member: Int = super.member
```
Where the type for `super.member` is `TermRef(SubA, member)` and the
  symbol is the `val member` in `A`.
So far this is correct, but in later phases we might call `loadDenot` on
this `TermRef` which will end up calling `asMemberOf`, which before this
commit just did:
```scala
  prefix.member(name)
```
This is incorrect in our case because `SubA` also happens to have a
private `def member`, which means that our forwarder in B now forwards
to a private method in a superclass, this subsequently crashes in
`ExpandPrivate`.
(Note: in the bytecode, a private method cannot have the same name as an
overriden method, but this is already worked around in EnsurePrivate.)

The fix is simple: when we recompute a member, we should only look at
private members if the previous denotation was private.