### PR TITLE
sbt-bridge: Fix #2092: Disable position information in the reporter

### DIFF
--- a/sbt-bridge/src/xsbt/DelegatingReporter.scala
+++ b/sbt-bridge/src/xsbt/DelegatingReporter.scala
@@ -28,7 +28,7 @@ final class DelegatingReporter(delegate: xsbti.Reporter) extends Reporter
       }
 
     val position =
-      if (cont.pos.exists) {
+      if (false && cont.pos.exists) { // Disabled because it duplicates the information printed by Dotty
         val pos = cont.pos
         val src = pos.source
         new Position {


### PR DESCRIPTION
This is temporary until someone figures out how to get sbt to not print
duplicated information when this is turned on. This might require
changes to sbt itself.

/cc @MasseGuillaume 