### PR TITLE
Reduce type lambdas even if variance changes

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -64,6 +64,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val Ycheck = PhasesSetting("-Ycheck", "Check the tree at the end of")
   val YcheckMods = BooleanSetting("-Ycheck-mods", "Check that symbols and their defining trees have modifiers in sync")
   val debug = BooleanSetting("-Ydebug", "Increase the quantity of debugging output.")
+  val debugAlias = BooleanSetting("-Ydebug-alias", "Never follow alias when printing types")
   val debugNames = BooleanSetting("-YdebugNames", "Show name-space indicators when printing names")
   val debugTrace = BooleanSetting("-Ydebug-trace", "Trace core operations")
   val debugFlags = BooleanSetting("-Ydebug-flags", "Print all flags of definitions")

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc
+package dotty.tools
+package dotc
 package core
 
 import Types._
@@ -412,8 +413,8 @@ class TypeApplications(val self: Type) extends AnyVal {
             val followAlias = Config.simplifyApplications && {
               dealiased.resType match {
                 case AppliedType(tyconBody, _) =>
-                  variancesConform(typParams, tyconBody.typeParams)
-                    // Reducing is safe for type inference, as kind of type constructor does not change
+                  sameLength(dealiased.typeParams, tyconBody.typeParams)
+                    // Reducing is safe for type inference, as kind arity of type constructor does not change
                 case _ => false
               }
             }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -130,7 +130,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         if (defn.isTupleClass(cls)) return toTextTuple(args)
         return (toTextLocal(tycon) ~ "[" ~ Text(args map argText, ", ") ~ "]").close
       case tp: TypeRef =>
-        val hideType = tp.symbol is AliasPreferred
+        val hideType = !ctx.settings.debugAlias.value && (tp.symbol is AliasPreferred)
         if (hideType && !ctx.phase.erasedTypes && !tp.symbol.isCompleting) {
           tp.info match {
             case TypeAlias(alias) => return toText(alias)

--- a/tests/pos/hk-reduce-variance.scala
+++ b/tests/pos/hk-reduce-variance.scala
@@ -1,0 +1,3 @@
+class Cov[+A](a: A) {
+  def foo = Seq(a)
+}


### PR DESCRIPTION
Previously, the added testcase failed with (when running with -Ydebug-alias):
```scala
2 |  def foo = Seq(a)
  |      ^
  |covariant type A occurs in invariant position in type => Seq.CC[Cov.this.A] of method foo
```

Because the type parameter of `CC` is invariant.

Of course, this is fine because `CC[A]` can be reduced to `Seq[A]`, but
before this commit, `TypeApplications#appliedTo` used to disallow
reductions that replaced an invariant type parameter with a variant one.
I believe that for type inference, only preserving the arity is
important, so I removed this restriction.