### PR TITLE
Better type inference in harmonizeUnion

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -35,15 +35,6 @@ trait ConstraintHandling {
   /** If the constraint is frozen we cannot add new bounds to the constraint. */
   protected var frozenConstraint = false
 
-  protected var alwaysFluid = false
-
-  /** Perform `op` in a mode where all attempts to set `frozen` to true are ignored */
-  def fluidly[T](op: => T): T = {
-    val saved = alwaysFluid
-    alwaysFluid = true
-    try op finally alwaysFluid = saved
-  }
-
   /** If set, align arguments `S1`, `S2`when taking the glb
    *  `T1 { X = S1 } & T2 { X = S2 }` of a constraint upper bound for some type parameter.
    *  Aligning means computing `S1 =:= S2` which may change the current constraint.
@@ -156,16 +147,24 @@ trait ConstraintHandling {
     up.forall(addOneBound(_, lo, isUpper = false))
   }
 
+
+  protected def isSubType(tp1: Type, tp2: Type, whenFrozen: Boolean): Boolean = {
+    if (whenFrozen)
+      isSubTypeWhenFrozen(tp1, tp2)
+    else
+      isSubType(tp1, tp2)
+  }
+
   final def isSubTypeWhenFrozen(tp1: Type, tp2: Type): Boolean = {
     val saved = frozenConstraint
-    frozenConstraint = !alwaysFluid
+    frozenConstraint = true
     try isSubType(tp1, tp2)
     finally frozenConstraint = saved
   }
 
   final def isSameTypeWhenFrozen(tp1: Type, tp2: Type): Boolean = {
     val saved = frozenConstraint
-    frozenConstraint = !alwaysFluid
+    frozenConstraint = true
     try isSameType(tp1, tp2)
     finally frozenConstraint = saved
   }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -282,7 +282,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
    */
   def harmonizeUnion(tp: Type): Type = tp match {
     case tp: OrType =>
-      joinIfScala2(typeComparer.fluidly(tp.tp1 | tp.tp2))
+      joinIfScala2(ctx.typeComparer.lub(harmonizeUnion(tp.tp1), harmonizeUnion(tp.tp2), canConstrain = true))
     case tp @ AndType(tp1, tp2) =>
       tp derived_& (harmonizeUnion(tp1), harmonizeUnion(tp2))
     case tp: RefinedType =>

--- a/tests/pos/constraining-lub.scala
+++ b/tests/pos/constraining-lub.scala
@@ -1,0 +1,34 @@
+class Inv[A](x: A)
+object Inv {
+  def empty[A]: Inv[A] = new Inv(???)
+}
+
+class Inv2[A](x: A)
+object Inv2 {
+  def empty[A]: Inv2[A] = new Inv2(???)
+}
+
+object Test {
+  def inv(cond: Boolean) =
+    if (cond)
+      new Inv(1)
+    else
+      Inv.empty
+
+  val x: Inv[Int] = inv(true)
+
+  def inv2(cond: Boolean) =
+    if (cond) {
+      if (cond)
+        new Inv(1)
+      else
+        Inv.empty
+    } else {
+      if (cond)
+        new Inv2(1)
+      else
+        Inv2.empty
+    }
+
+  val y: Inv[Int] | Inv2[Int] = inv2(true)
+}


### PR DESCRIPTION
NOTE: This PR depends on https://github.com/lampepfl/dotty/pull/2110 because the improved type inference revealed the bug fixed by https://github.com/lampepfl/dotty/pull/2110, only the last commit is new.

<hr>

Before this commit, the added testcase failed because the type of `inv`
was inferred to be `Inv[Any]` instead of `Inv[Int]`. The situation looks
like this:
```scala
def inv(cond: Boolean) =
    if (cond)
      new Inv(1) // : Inv[A] where A >: Int
    else
      Inv.empty // : Inv[A'] where A' unconstrained
    // : Inv[A] | Inv[A']
```
To get the type of `inv`, we call `harmonizeUnion` which will take the
lub of `Inv[A]` and `Inv[A']`, eventually this mean that we do:
```
  A' <:< A
```
But since `harmonizeUnion` uses `fluidly`, this does not result in `A'`
getting constrained to be a subtype of `A`, instead we constrain `A` to
the upper bound of `A'`:
```scala
  Any <:< A
```
We use `fluidly` to avoid creating OrTypes in `lub`, but it turns out
that there is a less aggressive solution: `lub` calls `mergeIfSuper`
which then calls `isSubTypeWhenFrozen`, if we just make these subtype
calls non-frozen, we can achieve what we want. This is what the new
method `fluidLub` does.