### PR TITLE
Move 'invalid super qualifier' error to new error format.

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -55,6 +55,7 @@ public enum ErrorMessageID {
     RecursiveValueNeedsResultTypeID,
     CyclicReferenceInvolvingID,
     CyclicReferenceInvolvingImplicitID,
+    SuperQualMustBeParentID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1192,4 +1192,21 @@ object messages {
            |""".stripMargin
   }
 
+  case class SuperQualMustBeParent(qual: untpd.Ident, cls: Symbols.ClassSymbol)(implicit ctx: Context)
+  extends Message(SuperQualMustBeParentID) {
+
+    val msg = hl"""|$qual does not name a parent of $cls"""
+
+    val kind = "Reference"
+
+    private val parents: Seq[String] = (cls.info.parents map (_.name.show)).sorted
+
+    val explanation =
+      hl"""|When a qualifier ${"T"} is used in a ${"super"} prefix of the form ${"C.super[T]"},
+           |${"T"} must be a parent type of ${"C"}.
+           |
+           |In this case, the parents of $cls are:
+           |${parents.mkString("  - ", "\n  - ", "")}
+           |""".stripMargin
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -298,7 +298,7 @@ trait TypeAssigner {
       case p :: Nil =>
         p
       case Nil =>
-        errorType(em"$mix does not name a parent class of $cls", tree.pos)
+        errorType(SuperQualMustBeParent(mix, cls), tree.pos)
       case p :: q :: _ =>
         errorType("ambiguous parent class qualifier", tree.pos)
     }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -304,5 +304,29 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("x", tree.name.show)
     }
 
+  @Test def superQualMustBeParent =
+    checkMessagesAfter("frontend") {
+      """
+        |class A {
+        |  def foo(): Unit = ()
+        |}
+        |
+        |class B {
+        |}
+        |
+        |class C extends A {
+        |  super[B].foo
+        |}
+      """.stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        val defn = ictx.definitions
 
+        assertMessageCount(1, messages)
+        val SuperQualMustBeParent(qual, cls) :: Nil = messages
+
+        assertEquals("B", qual.show)
+        assertEquals("class C", cls.show)
+      }
 }


### PR DESCRIPTION
As part of https://github.com/lampepfl/dotty/issues/1589, use the new error message for static super references where the qualifier isn't a parent of the class.

Tested:
  Added unit test.