### PR TITLE
Fix ParamForwarder under non-separate compilation 

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -32,7 +32,7 @@ class ParamForwarding(thisTransformer: DenotTransformer) {
           }
         case _ => (Nil, Nil)
       }
-      def inheritedAccessor(sym: Symbol): Symbol = {
+      def inheritedAccessor(sym: Symbol)(implicit ctx: Context): Symbol = {
         /**
          * Dmitry: having it have the same name is needed to maintain correctness in presence of subclassing
          * if you would use parent param-name `a` to implement param-field `b`
@@ -60,7 +60,7 @@ class ParamForwarding(thisTransformer: DenotTransformer) {
               // so avoid param forwarding if parameter is by name. See i1766.scala
               val idx = superArgs.indexWhere(_.symbol == sym)
               if (idx >= 0 && superParamNames(idx) == stat.name) { // supercall to like-named parameter
-                val alias = inheritedAccessor(sym)
+                val alias = inheritedAccessor(sym)(ctx.withPhase(thisTransformer.next))
                 if (alias.exists) {
                   def forwarder(implicit ctx: Context) = {
                     sym.copySymDenotation(initFlags = sym.flags | Method | Stable, info = sym.info.ensureMethodic)

--- a/tests/run/paramForwarding.check
+++ b/tests/run/paramForwarding.check
@@ -13,4 +13,4 @@ NonVal:
 X:
 private final int X.theValue$$local
 Y:
-private final int Y.theValue$$local
+

--- a/tests/run/paramForwarding.scala
+++ b/tests/run/paramForwarding.scala
@@ -36,8 +36,8 @@ class NonVal(theValue: Int) extends A(theValue) {
 // X.theValue() which overrides A.theValue()
 class X(override val theValue: Int) extends NonVal(0)
 
-// Y contains a field Y.theValue$$local accessible using the getter
-// Y.theValue() which overrides A.theValue()
+// Y does not contains a field Y.theValue$$local, it contains
+// a getter Y.theValue() which only calls super.theValue()
 class Y(override val theValue: Int) extends NonVal(theValue)
 
 

--- a/tests/run/paramForwarding_separate/A_1.scala
+++ b/tests/run/paramForwarding_separate/A_1.scala
@@ -1,3 +1,8 @@
-class A(val member: Int)
+class A(val member: Int) {
+  def getAMember = member
+}
 
-class SubA(member: Int) extends A(member)
+class SubA(member: Int) extends A(member) {
+  def getSubAMember = member
+}
+

--- a/tests/run/paramForwarding_separate/B_2.scala
+++ b/tests/run/paramForwarding_separate/B_2.scala
@@ -1,4 +1,6 @@
-class B(member: Int) extends SubA(member)
+class B(member: Int) extends SubA(member) {
+  def getMember = member
+}
 
 object Test {
   def printFields(cls: Class[_]) =

--- a/tests/run/paramForwarding_together.check
+++ b/tests/run/paramForwarding_together.check
@@ -1,0 +1,6 @@
+# Fields in A:
+private final int A.member$$local
+# Fields in SubA:
+
+# Fields in B:
+

--- a/tests/run/paramForwarding_together.scala
+++ b/tests/run/paramForwarding_together.scala
@@ -1,0 +1,29 @@
+class A(val member: Int) {
+  def getAMember = member
+}
+
+class SubA(member: Int) extends A(member) {
+  def getSubAMember = member
+}
+
+class B(member: Int) extends SubA(member) {
+  def getBMember = member
+}
+
+object Test {
+  def printFields(cls: Class[_]) =
+    println(cls.getDeclaredFields.map(_.toString).sorted.deep.mkString("\n"))
+
+  def main(args: Array[String]): Unit = {
+    val a = new A(10)
+    val subA = new SubA(11)
+    val b = new B(12)
+
+    println("# Fields in A:")
+    printFields(classOf[A])
+    println("# Fields in SubA:")
+    printFields(classOf[SubA])
+    println("# Fields in B:")
+    printFields(classOf[B])
+  }
+}

--- a/tests/run/paramForwarding_together_b.check
+++ b/tests/run/paramForwarding_together_b.check
@@ -1,0 +1,6 @@
+# Fields in A:
+private final int A.member$$local
+# Fields in SubA:
+
+# Fields in B:
+

--- a/tests/run/paramForwarding_together_b.scala
+++ b/tests/run/paramForwarding_together_b.scala
@@ -1,0 +1,30 @@
+class B(member: Int) extends SubA(member) {
+  def getBMember = member
+}
+
+class SubA(member: Int) extends A(member) {
+  def getSubAMember = member
+}
+
+class A(val member: Int) {
+  def getAMember = member
+}
+
+
+object Test {
+  def printFields(cls: Class[_]) =
+    println(cls.getDeclaredFields.map(_.toString).sorted.deep.mkString("\n"))
+
+  def main(args: Array[String]): Unit = {
+    val a = new A(10)
+    val subA = new SubA(11)
+    val b = new B(12)
+
+    println("# Fields in A:")
+    printFields(classOf[A])
+    println("# Fields in SubA:")
+    printFields(classOf[SubA])
+    println("# Fields in B:")
+    printFields(classOf[B])
+  }
+}


### PR DESCRIPTION
`inheritedAccessor` looks for a method in a superclass whose name
matches the param accessor name, but that method is created by
ParamForwarder itself, so this only succeeded under separate
compilation (as demonstrated by the existing `paramForwarding_separate`
test). We fix this by simply running `inheritedAccessor` at a phase
where `ParamForwarder` has already been run.