### PR TITLE
Fix #2117: bug in typechecking super prefix with invalid enclosing class

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -291,26 +291,28 @@ trait TypeAssigner {
 
   def assignType(tree: untpd.Super, qual: Tree, inConstrCall: Boolean, mixinClass: Symbol = NoSymbol)(implicit ctx: Context) = {
     val mix = tree.mix
-    val qtype @ ThisType(_) = qual.tpe
-    val cls = qtype.cls
-
-    def findMixinSuper(site: Type): Type = site.parents filter (_.name == mix.name) match {
-      case p :: Nil =>
-        p
-      case Nil =>
-        errorType(SuperQualMustBeParent(mix, cls), tree.pos)
-      case p :: q :: _ =>
-        errorType("ambiguous parent class qualifier", tree.pos)
+    qual.tpe match {
+      case err: ErrorType => untpd.cpy.Super(tree)(qual, mix).withType(err)
+      case qtype @ ThisType(_) =>
+        val cls = qtype.cls
+        def findMixinSuper(site: Type): Type = site.parents filter (_.name == mix.name) match {
+          case p :: Nil =>
+            p
+          case Nil =>
+            errorType(SuperQualMustBeParent(mix, cls), tree.pos)
+          case p :: q :: _ =>
+            errorType("ambiguous parent class qualifier", tree.pos)
+        }
+        val owntype =
+          if (mixinClass.exists) mixinClass.typeRef
+          else if (!mix.isEmpty) findMixinSuper(cls.info)
+          else if (inConstrCall || ctx.erasedTypes) cls.info.firstParent
+          else {
+            val ps = cls.classInfo.parentsWithArgs
+            if (ps.isEmpty) defn.AnyType else ps.reduceLeft((x: Type, y: Type) => x & y)
+          }
+        tree.withType(SuperType(cls.thisType, owntype))
     }
-    val owntype =
-      if (mixinClass.exists) mixinClass.typeRef
-      else if (!mix.isEmpty) findMixinSuper(cls.info)
-      else if (inConstrCall || ctx.erasedTypes) cls.info.firstParent
-      else {
-        val ps = cls.classInfo.parentsWithArgs
-        if (ps.isEmpty) defn.AnyType else ps.reduceLeft((x: Type, y: Type) => x & y)
-      }
-    tree.withType(SuperType(cls.thisType, owntype))
   }
 
   def assignType(tree: untpd.Apply, fn: Tree, args: List[Tree])(implicit ctx: Context) = {

--- a/tests/neg/i2117.scala
+++ b/tests/neg/i2117.scala
@@ -1,0 +1,3 @@
+class A {
+  C.super.foo() // error: C isn't an enclosing class
+}


### PR DESCRIPTION
When typechecking

`class A {
  C.super.foo()
}`

If C isn't an enclosing class, the compiler was throwing because of an
unguarded pattern match.

Fix the issue by checking for ErrorType.

Tested:
Verified that the example above no longer throws.