### PR TITLE
Update periods-related comments

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Periods.scala
+++ b/compiler/src/dotty/tools/dotc/core/Periods.scala
@@ -46,9 +46,9 @@ object Periods {
    *  It is coded as follows:
    *
    *     sign, always 0        1 bit
-   *     runid                19 bits
-   *     last phase id:        6 bits
-   *     #phases before last:  6 bits
+   *     runid                17 bits
+   *     last phase id:        7 bits
+   *     #phases before last:  7 bits
    *
    *     // Dmitry: sign == 0 isn't actually always true, in some cases phaseId == -1 is used for shifts, that easily creates code < 0
    */
@@ -108,6 +108,7 @@ object Periods {
       else
         Nowhere
 
+    /** The smallest period containing two periods */
     def | (that: Period): Period =
       Period(this.runId,
           this.firstPhaseId min that.firstPhaseId,


### PR DESCRIPTION
The phase width in a period was bumped from 6 to 7 in
https://github.com/lampepfl/dotty/commit/16671a00371df2bdbaf6ae7f51b0ec7191ce94f3
but the comment wasn't updated.

Update the comment (and another unrelated comment).

Tested:
No