### PR TITLE
Fix dottydoc exception caused by attempting to serialize NonEntity values

### DIFF
--- a/doc-tool/src/dotty/tools/dottydoc/staticsite/DefaultParams.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/staticsite/DefaultParams.scala
@@ -17,27 +17,34 @@ case class DefaultParams(
 ) {
   import model.JavaConverters._
 
-  def toMap: Map[String, AnyRef] = Map(
-    "docs" -> docs,
+  def toMap: Map[String, AnyRef] = {
+    val base = Map(
+      "docs" -> docs,
 
-    "originalDocs" -> originalDocs,
+      "originalDocs" -> originalDocs,
 
-    "page" -> Map(
-      "url" -> page.url,
-      "date" -> page.date,
-      "path" -> page.path
-    ),
+      "page" -> Map(
+        "url" -> page.url,
+        "date" -> page.date,
+        "path" -> page.path
+      ),
 
-    "site" -> Map(
-      "baseurl" -> site.baseurl,
-      "posts" -> site.posts.map(_.toMap),
-      "project" -> site.projectTitle
-    ).asJava,
+      "site" -> Map(
+        "baseurl" -> site.baseurl,
+        "posts" -> site.posts.map(_.toMap),
+        "project" -> site.projectTitle
+      ).asJava,
 
-    "sidebar" -> sidebar.titles.asJava,
-
-    "entity" -> entity.asJava()
-  )
+      "sidebar" -> sidebar.titles.asJava
+    )
+    val entityMap = entity match {
+      case NonEntity => Map.empty
+      case _ => Map(
+        "entity" -> entity.asJava
+      )
+    }
+    base ++ entityMap
+  }
 
   def withPosts(posts: Array[BlogPost]): DefaultParams =
     copy(site = SiteInfo(site.baseurl, site.projectTitle, posts))

--- a/doc-tool/test/JavaConverterTest.scala
+++ b/doc-tool/test/JavaConverterTest.scala
@@ -154,25 +154,25 @@ class JavaConverterTest {
     assertSerializedCorrectly(pkg, pkg.asJava())
   }
 
-  def assertEach[E, C[E] <: Seq[E]](expected: C[E], serialized: Any)(pairwiseAssertion: (E, Any) => Unit) {
+  def assertEach[E, C[E] <: Seq[E]](expected: C[E], serialized: Any)(pairwiseAssertion: (E, Any) => Unit): Unit = {
     val actual = serialized.asInstanceOf[JList[_]].asScala.toList
     assertEquals(expected.length, actual.length)
     for ((exp, act) <- expected zip actual) {
       pairwiseAssertion(exp, act)
     }
   }
-  def assertSameSeq[T, C[T] <: Seq[T]](expected: C[T], serialized: Any) = {
+  def assertSameSeq[T, C[T] <: Seq[T]](expected: C[T], serialized: Any): Unit = {
     val actual = serialized.asInstanceOf[java.util.List[T]].asScala.toList
     assertEquals(expected, actual);
   }
-  def assertSerializedCorrectly(expected: ParamList, serialized: Any) {
+  def assertSerializedCorrectly(expected: ParamList, serialized: Any): Unit = {
     val actual = serialized.asInstanceOf[JMap[String, _]]
     assertEach(expected.list, actual.get("list")) {(exp, act) =>
       assertSerializedCorrectly(exp, act)
     }
     assertEquals(expected.isImplicit, actual.get("isImplicit"))
   }
-  def assertSerializedCorrectly(expected: Reference, serialized: Any) {
+  def assertSerializedCorrectly(expected: Reference, serialized: Any): Unit = {
     val actual = serialized.asInstanceOf[JMap[String, _]]
     expected match {
       case TypeReference(title, tpeLink, paramLinks) =>
@@ -209,7 +209,7 @@ class JavaConverterTest {
       case EmptyReference =>
     }
   }
-  def assertSerializedCorrectly(expected: MaterializableLink, serialized: Any) {
+  def assertSerializedCorrectly(expected: MaterializableLink, serialized: Any): Unit = {
     val actual = serialized.asInstanceOf[JMap[String, _]]
     expected match {
       case UnsetLink(title, query) =>
@@ -223,7 +223,7 @@ class JavaConverterTest {
         assertEquals(target, actual.get("target"))
     }
   }
-  def assertSerializedCorrectly(expected: Entity, serialized: Any) {
+  def assertSerializedCorrectly(expected: Entity, serialized: Any): Unit = {
     val actual = serialized.asInstanceOf[JMap[String, _]]
     assertEquals(expected.name, actual.get("name"))
     assertEquals(expected.kind, actual.get("kind"))


### PR DESCRIPTION
Fixes an bug in dottydoc where NonEntity values were accidentally being serialized.

The changes in e7fe9df3c14df0e5ccd88440dbd49a9dce65d48f introduced an IllegalStateException during execution due to an attempt to serialize `NonEntity` values. Previously, NonEntities would incorrectly be serialized (without throwing an exception) as instances of Package (due to the pattern match at https://github.com/lampepfl/dotty/blob/5bb7c976712e8c86898b94d1abea1acedeed3562/doc-tool/src/dotty/tools/dottydoc/model/JavaConverters.scala#L302).

The source of the NonEntity values was the default value of `entity` in DefaultParams.scala (https://github.com/lampepfl/dotty/blob/3e65cff0caf4c671d3cf98da347792c85a4ac2de/doc-tool/src/dotty/tools/dottydoc/staticsite/DefaultParams.scala#L39)

This PR fixes this issue by explicitly checking whether `DefaultParams.entity` contains a `NonEntity`, and if so, omitting it from serialization. Also gets rid of procedure syntax used in JavaConverterTest.scala.

Review by @felixmulder

Style question: do you prefer both of these commits to be squashed into a single one for brevity, or keep them separate since they're independent changes?