### PR TITLE
Fix desugaring of variable pattern leaking into API

### DIFF
--- a/tests/run/variable-pattern-access.check
+++ b/tests/run/variable-pattern-access.check
@@ -1,0 +1,7 @@
+# Fields of A:
+private final int A.a$$local
+private final int A.b$$local
+private final scala.Tuple2 A.$1$
+# Methods of A:
+public int A.a()
+public int A.b()

--- a/tests/run/variable-pattern-access.scala
+++ b/tests/run/variable-pattern-access.scala
@@ -1,0 +1,16 @@
+class A {
+  val (a, b) = (1, 2)
+}
+object Test {
+  def printFields(cls: Class[_]) =
+    println(cls.getDeclaredFields.map(_.toString).sorted.deep.mkString("\n"))
+  def printMethods(cls: Class[_]) =
+    println(cls.getDeclaredMethods.map(_.toString).sorted.deep.mkString("\n"))
+
+  def main(args: Array[String]): Unit = {
+    println("# Fields of A:")
+    printFields(classOf[A])
+    println("# Methods of A:")
+    printMethods(classOf[A])
+  }
+}


### PR DESCRIPTION
This was especially bad for incremental compilation since the temporary
variable name is unstable.