### PR TITLE
Fix #2137: Create dummy companions for top-level objects without a real one

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -175,7 +175,7 @@ private class ExtractDependenciesCollector(implicit val ctx: Context) extends tp
   override def traverse(tree: Tree)(implicit ctx: Context): Unit = {
     tree match {
       case Import(expr, selectors) =>
-        def lookupImported(name: Name) = expr.tpe.select(name).typeSymbol
+        def lookupImported(name: Name) = expr.tpe.member(name).symbol
         def addImported(name: Name) = {
           // importing a name means importing both a term and a type (if they exist)
           addDependency(lookupImported(name.toTermName))

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -570,8 +570,8 @@ class Namer { typer: Typer =>
 
     /** Create links between companion object and companion class */
     def createLinks(classTree: TypeDef, moduleTree: TypeDef)(implicit ctx: Context) = {
-      val claz = ctx.denotNamed(classTree.name.encode).symbol
-      val modl = ctx.denotNamed(moduleTree.name.encode).symbol
+      val claz = ctx.effectiveScope.lookup(classTree.name.encode)
+      val modl = ctx.effectiveScope.lookup(moduleTree.name.encode)
       ctx.synthesizeCompanionMethod(nme.COMPANION_CLASS_METHOD, claz, modl).entered
       ctx.synthesizeCompanionMethod(nme.COMPANION_MODULE_METHOD, modl, claz).entered
     }
@@ -613,10 +613,10 @@ class Namer { typer: Typer =>
       // example where this matters.
       if (ctx.owner.is(PackageClass)) {
         for (cdef @ TypeDef(moduleName, _) <- moduleDef.values) {
-          val moduleSym = ctx.denotNamed(moduleName.encode).symbol
+          val moduleSym = ctx.effectiveScope.lookup(moduleName.encode)
           if (moduleSym.isDefinedInCurrentRun) {
             val className = moduleName.stripModuleClassSuffix.toTypeName
-            val classSym = ctx.denotNamed(className.encode).symbol
+            val classSym = ctx.effectiveScope.lookup(className.encode)
             if (!classSym.isDefinedInCurrentRun) {
               val absentClassSymbol = ctx.newClassSymbol(ctx.owner, className, EmptyFlags, _ => NoType)
               enterSymbol(absentClassSymbol)

--- a/tests/pending/pos/false-companion/00_outerinnerTest_2.scala
+++ b/tests/pending/pos/false-companion/00_outerinnerTest_2.scala
@@ -1,0 +1,5 @@
+package outer
+package inner
+object Test {
+  val x: Foo = new Foo
+}

--- a/tests/pending/pos/false-companion/01_outerinnerFoo_2.scala
+++ b/tests/pending/pos/false-companion/01_outerinnerFoo_2.scala
@@ -1,0 +1,5 @@
+package outer
+package inner
+object Foo {
+  // val a: Int = 1
+}

--- a/tests/pending/pos/false-companion/outerFoo_1.scala
+++ b/tests/pending/pos/false-companion/outerFoo_1.scala
@@ -1,0 +1,2 @@
+package outer
+class Foo

--- a/tests/pending/pos/false-companion/outerinnerFoo_1.scala
+++ b/tests/pending/pos/false-companion/outerinnerFoo_1.scala
@@ -1,0 +1,5 @@
+package outer
+package inner
+object Foo {
+  val a: Int = 1
+}


### PR DESCRIPTION
Previously, we sometimes ended up forcing a companion class symbol from
a previous run or from the classpath which lead to weird issues like in
`tests/pos-special/false-companion`. Even if we end up not forcing such
a symbol, its presence can still lead to issue: before this commit
incremental compilation of `dotty-compiler-bootstrapped` was broken
because we recorded a false dependency on the non-bootstrapped
`dotty-compiler` jar.