### PR TITLE
Fix nested implicit functions

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ShortcutImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ShortcutImplicits.scala
@@ -133,6 +133,7 @@ class ShortcutImplicits extends MiniPhase with IdentityDenotTransformer { thisTr
       if (shouldBeSpecialized(original)) {
         val direct = directMethod(original)
 
+        // TODO also adapt this code to account for nested implicits
         def splitClosure(tree: Tree): (List[Type] => List[List[Tree]] => Tree, Tree) = tree match {
           case Block(Nil, expr) => splitClosure(expr)
           case Block((meth @ DefDef(nme.ANON_FUN, Nil, clparams :: Nil, _, _)) :: Nil, cl: Closure) =>
@@ -150,6 +151,9 @@ class ShortcutImplicits extends MiniPhase with IdentityDenotTransformer { thisTr
               .appliedToArgss(vparamSymss.map(_.map(ref(_))) :+ clparamSyms.map(ref(_)))
             val fwdClosure = cpy.Block(tree)(cpy.DefDef(meth)(rhs = forwarder) :: Nil, cl)
             (remappedCore, fwdClosure)
+
+          // for nested implicits give up for now!
+          case b @ Block(defs, cl: Closure) => (_ => _ => b, b)
           case EmptyTree =>
             (_ => _ => EmptyTree, EmptyTree)
         }

--- a/tests/neg/t2146a.scala
+++ b/tests/neg/t2146a.scala
@@ -1,0 +1,13 @@
+object nestedImplicits {
+
+  trait A
+  trait B
+
+  def foo: implicit A => implicit B => Int = { implicit b: B =>
+    implicitly[A]
+    implicitly[B]
+    42
+  }
+
+  foo(new A{})(new B{})
+}

--- a/tests/pos/t2146a.scala
+++ b/tests/pos/t2146a.scala
@@ -1,0 +1,13 @@
+object nestedImplicits {
+
+  trait A
+  trait B
+
+  def foo: implicit A => implicit B => Int = {
+    implicitly[A]
+    implicitly[B]
+    42
+  }
+
+  foo(new A{})(new B{})
+}

--- a/tests/pos/t2146b.scala
+++ b/tests/pos/t2146b.scala
@@ -1,0 +1,13 @@
+object nestedImplicits {
+
+  trait A
+  trait B
+
+  def foo: implicit A => implicit B => Int = { implicit a: A =>
+    implicitly[A]
+    implicitly[B]
+    42
+  }
+
+  foo(new A{})(new B{})
+}

--- a/tests/pos/t2146c.scala
+++ b/tests/pos/t2146c.scala
@@ -1,0 +1,13 @@
+object nestedImplicits {
+
+  trait A
+  trait B
+
+  def foo: implicit A => implicit B => Int = { implicit a: A => implicit b: B =>
+    implicitly[A]
+    implicitly[B]
+    42
+  }
+
+  foo(new A{})(new B{})
+}


### PR DESCRIPTION
Currently nested implicit function types (#1775) are not successfully eta-expanded. That is the following is not valid:

```scala
def foo: implicit A => implicit B => Int = {
  42
}
```

While this PR drafts a solution, for now it should only serve for **discussion purposes**.

@smarter @odersky Is there a reason why automatic eta expansion of nested implicit function types is not implemented?