### PR TITLE
Create dummy companions for classes without a real one

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -606,11 +606,11 @@ class Namer { typer: Typer =>
         }
       }
 
-      // If a top-level object has no companion class in the current run, we
-      // enter a dummy companion class symbol (`denot.isAbsent` returns true) in
-      // scope. This ensures that we never use a companion from a previous run
-      // or from the classpath. See tests/pos/false-companion for an
-      // example where this matters.
+      // If a top-level object or class has no companion in the current run, we
+      // enter a dummy companion (`denot.isAbsent` returns true) in scope. This
+      // ensures that we never use a companion from a previous run or from the
+      // classpath. See tests/pos/false-companion for an example where this
+      // matters.
       if (ctx.owner.is(PackageClass)) {
         for (cdef @ TypeDef(moduleName, _) <- moduleDef.values) {
           val moduleSym = ctx.effectiveScope.lookup(moduleName.encode)
@@ -620,6 +620,17 @@ class Namer { typer: Typer =>
             if (!classSym.isDefinedInCurrentRun) {
               val absentClassSymbol = ctx.newClassSymbol(ctx.owner, className, EmptyFlags, _ => NoType)
               enterSymbol(absentClassSymbol)
+            }
+          }
+        }
+        for (cdef @ TypeDef(className, _) <- classDef.values) {
+          val classSym = ctx.effectiveScope.lookup(className.encode)
+          if (classSym.isDefinedInCurrentRun) {
+            val moduleName = className.toTermName
+            val moduleSym = ctx.effectiveScope.lookup(moduleName.encode)
+            if (!moduleSym.isDefinedInCurrentRun) {
+              val absentModuleSymbol = ctx.newModuleSymbol(ctx.owner, moduleName, EmptyFlags, EmptyFlags, (_, _) => NoType)
+              enterSymbol(absentModuleSymbol)
             }
           }
         }


### PR DESCRIPTION
In #2139 I added code to create dummy companions for companion-less
objects, but not for companion-less classes because I thought it wasn't
needed. But it turns out that even if the classpath only has `Foo.class`
and not `Foo$.class`, a module for `Foo` is entered by
`initializeFromClassPath` when it calls `enterClassAndModule`, so we
have to add dummy companions to classes. I don't have a test to
illustrate this issue, but note that it fixes the incremental
compilation bug demonstrated by
https://github.com/dotty-staging/dotty/commits/incremental-compilation-bug.

Note: I verified that adding a dummy companion to "class Foo" did not
cause the backend to emit a Foo$.class, so this should have no visible
impact.