### PR TITLE
Extend exhaustivity checks to and-types

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -74,6 +74,15 @@ trait SpaceLogic {
   /** Is `tp1` the same type as `tp2`? */
   def isEqualType(tp1: Type, tp2: Type): Boolean
 
+  /** Can `tp` be arbitrarily subtyped by any other open type? */
+  def isOpen(tp: Type): Boolean
+
+  /** Construct a space which contains values from both `tp1` and `tp2`.
+   *
+   * Both types are expected to be open in the [[isOpen]] sense.
+   */
+  def commonOpenTypeSpace(tp1: Type, tp2: Type): Space
+
   /** Is the type `tp` decomposable? i.e. all values of the type can be covered
    *  by its decomposed types.
    *
@@ -171,6 +180,7 @@ trait SpaceLogic {
         else if (isSubType(tp2, tp1)) b
         else if (canDecompose(tp1)) tryDecompose1(tp1)
         else if (canDecompose(tp2)) tryDecompose2(tp2)
+        else if (isOpen(tp1) && isOpen(tp2)) commonOpenTypeSpace(tp1, tp2)
         else Empty
       case (Typ(tp1, _), Kon(tp2, ss)) =>
         if (isSubType(tp2, tp1)) b
@@ -242,6 +252,11 @@ trait SpaceLogic {
 /** Scala implementation of space logic */
 class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
   import tpd._
+
+  override def isOpen(tp: Type) =
+    !tp.classSymbol.is(Sealed | Final) && !tp.termSymbol.is(Module)
+
+  override def commonOpenTypeSpace(tp1: Type, tp2: Type) = Typ(AndType(tp1, tp2), true)
 
   /** Return the space that represents the pattern `pat`
    *

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -476,11 +476,12 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
   /** Abstract sealed types, or-types, Boolean and Java enums can be decomposed */
   def canDecompose(tp: Type): Boolean = {
+    val dealiasedTp = tp.dealias
     val res = tp.classSymbol.is(allOf(Abstract, Sealed)) ||
       tp.classSymbol.is(allOf(Trait, Sealed)) ||
-      tp.dealias.isInstanceOf[OrType] ||
-      (tp.isInstanceOf[AndType] && {
-        val and = tp.asInstanceOf[AndType]
+      dealiasedTp.isInstanceOf[OrType] ||
+      (dealiasedTp.isInstanceOf[AndType] && {
+        val and = dealiasedTp.asInstanceOf[AndType]
         canDecompose(and.tp1) || canDecompose(and.tp2)
       }) ||
       tp =:= ctx.definitions.BooleanType ||

--- a/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
@@ -28,11 +28,11 @@ class PatmatExhaustivityTest {
         e.printStackTrace()
     }
 
-    val actual = stringBuffer.toString.trim
+    val actual = stringBuffer.toString.trim.replaceAll("\\s+\n", "\n")
     val checkFilePath = file.getAbsolutePath.stripSuffix(".scala") + ".check"
     val checkContent =
       if (new File(checkFilePath).exists)
-        fromFile(checkFilePath).getLines.mkString("\n").trim
+        fromFile(checkFilePath).getLines.map(_.replaceAll("\\s+$", "")).mkString("\n").trim
       else ""
 
     (file, checkContent, actual)
@@ -55,11 +55,11 @@ class PatmatExhaustivityTest {
         e.printStackTrace()
     }
 
-    val actual = stringBuffer.toString.trim
+    val actual = stringBuffer.toString.trim.replaceAll("\\s+\n", "\n")
     val checkFilePath = file.getPath + File.separator + "expected.check"
     val checkContent =
       if (new File(checkFilePath).exists)
-        fromFile(checkFilePath).getLines.mkString("\n").trim
+        fromFile(checkFilePath).getLines.map(_.replaceAll("\\s+$", "")).mkString("\n").trim
       else ""
 
     (file, checkContent, actual)

--- a/tests/patmat/aliasing.check
+++ b/tests/patmat/aliasing.check
@@ -1,0 +1,3 @@
+14: Pattern Match Exhaustivity: _: Clazz & Test.Alias1, _: Trait & Test.Alias1
+19: Pattern Match Exhaustivity: _: Trait & Test.Alias2
+23: Pattern Match Exhaustivity: _: Trait & (Test.Alias2 & OpenTrait2){x: Int}

--- a/tests/patmat/aliasing.scala
+++ b/tests/patmat/aliasing.scala
@@ -1,0 +1,26 @@
+sealed trait T
+trait Trait extends T
+class Clazz extends T
+object Obj extends T
+
+trait OpenTrait
+trait OpenTrait2
+class OpenClass
+
+trait Unrelated
+
+object Test {
+  type Alias1 = OpenTrait
+  def traitAndClass(s: T & Alias1) = s match {
+    case _: Unrelated => ;
+  }
+
+  type Alias2 = OpenTrait & OpenClass
+  def classOnly(s: T & Alias2) = s match {
+    case _: Unrelated => ;
+  }
+
+  def classOnlyRefined(s: T & (Alias2 & OpenTrait2) { val x: Int }) = s match {
+    case _: Unrelated => ;
+  }
+}

--- a/tests/patmat/andtype-opentype-interaction.check
+++ b/tests/patmat/andtype-opentype-interaction.check
@@ -1,3 +1,3 @@
 19: Pattern Match Exhaustivity: _: AbstractClass & OpenTrait, _: Clazz & OpenTrait, _: Trait & OpenTrait
-23: Pattern Match Exhaustivity: _: AbstractClass & OpenClass, _: Clazz & OpenClass, _: Trait & OpenClass
-27: Pattern Match Exhaustivity: _: AbstractClass & OpenAbstractClass, _: Clazz & OpenAbstractClass, _: Trait & OpenAbstractClass
+23: Pattern Match Exhaustivity: _: Trait & OpenClass
+27: Pattern Match Exhaustivity: _: Trait & OpenAbstractClass

--- a/tests/patmat/andtype-opentype-interaction.check
+++ b/tests/patmat/andtype-opentype-interaction.check
@@ -1,0 +1,3 @@
+19: Pattern Match Exhaustivity: _: AbstractClass & OpenTrait, _: Clazz & OpenTrait, _: Trait & OpenTrait
+23: Pattern Match Exhaustivity: _: AbstractClass & OpenClass, _: Clazz & OpenClass, _: Trait & OpenClass
+27: Pattern Match Exhaustivity: _: AbstractClass & OpenAbstractClass, _: Clazz & OpenAbstractClass, _: Trait & OpenAbstractClass

--- a/tests/patmat/andtype-opentype-interaction.check
+++ b/tests/patmat/andtype-opentype-interaction.check
@@ -1,5 +1,5 @@
-23: Pattern Match Exhaustivity: _: AbstractClass & OpenTrait, _: Clazz & OpenTrait, _: Trait & OpenTrait
-27: Pattern Match Exhaustivity: _: AbstractClass & OpenTrait & OpenTrait2, _: Clazz & OpenTrait & OpenTrait2, _: Trait & OpenTrait & OpenTrait2
+23: Pattern Match Exhaustivity: _: SealedClass & OpenTrait, _: AbstractClass & OpenTrait, _: Clazz & OpenTrait, _: Trait & OpenTrait
+27: Pattern Match Exhaustivity: _: SealedClass & OpenTrait & OpenTrait2, _: AbstractClass & OpenTrait & OpenTrait2, _: Clazz & OpenTrait & OpenTrait2, _: Trait & OpenTrait & OpenTrait2
 31: Pattern Match Exhaustivity: _: Trait & OpenClass
 35: Pattern Match Exhaustivity: _: Trait & OpenTrait & OpenClass
 43: Pattern Match Exhaustivity: _: Trait & OpenAbstractClass

--- a/tests/patmat/andtype-opentype-interaction.check
+++ b/tests/patmat/andtype-opentype-interaction.check
@@ -1,3 +1,6 @@
-19: Pattern Match Exhaustivity: _: AbstractClass & OpenTrait, _: Clazz & OpenTrait, _: Trait & OpenTrait
-23: Pattern Match Exhaustivity: _: Trait & OpenClass
-27: Pattern Match Exhaustivity: _: Trait & OpenAbstractClass
+23: Pattern Match Exhaustivity: _: AbstractClass & OpenTrait, _: Clazz & OpenTrait, _: Trait & OpenTrait
+27: Pattern Match Exhaustivity: _: AbstractClass & OpenTrait & OpenTrait2, _: Clazz & OpenTrait & OpenTrait2, _: Trait & OpenTrait & OpenTrait2
+31: Pattern Match Exhaustivity: _: Trait & OpenClass
+35: Pattern Match Exhaustivity: _: Trait & OpenTrait & OpenClass
+43: Pattern Match Exhaustivity: _: Trait & OpenAbstractClass
+47: Pattern Match Exhaustivity: _: Trait & OpenTrait & OpenClassSubclass

--- a/tests/patmat/andtype-opentype-interaction.scala
+++ b/tests/patmat/andtype-opentype-interaction.scala
@@ -11,12 +11,20 @@ object Obj extends T
 
 trait OpenTrait
 class OpenClass
+class OpenClassSubclass extends OpenClass
 abstract class OpenAbstractClass
 
 trait Unrelated
 
+trait OpenTrait2
+class OpenClass2
+
 object Test {
-  def m1(s: T & OpenTrait) = s match {
+  def m1a(s: T & OpenTrait) = s match {
+    case _: Unrelated => ;
+  }
+
+  def m1b(s: T & OpenTrait & OpenTrait2) = s match {
     case _: Unrelated => ;
   }
 
@@ -24,7 +32,19 @@ object Test {
     case _: Unrelated => ;
   }
 
+  def m2b(s: T & OpenTrait & OpenClass) = s match {
+    case _: Unrelated => ;
+  }
+
+  def m2c(s: (T & OpenClass) & (OpenTrait & OpenClass2)) = s match {
+    case _: Unrelated => ;
+  }
+
   def m3(s: T & OpenAbstractClass) = s match {
+    case _: Unrelated => ;
+  }
+
+  def m4(s: (T & OpenClass) & (OpenTrait & OpenClassSubclass)) = s match {
     case _: Unrelated => ;
   }
 }

--- a/tests/patmat/andtype-opentype-interaction.scala
+++ b/tests/patmat/andtype-opentype-interaction.scala
@@ -1,0 +1,30 @@
+sealed trait T
+trait Trait extends T
+class Clazz extends T
+abstract class AbstractClass extends T
+// none of the below can be extended
+sealed trait SealedTrait extends T
+final class FinalClass extends T
+sealed class SealedClass extends T
+sealed abstract class SealedAbstractClass extends T
+object Obj extends T
+
+trait OpenTrait
+class OpenClass
+abstract class OpenAbstractClass
+
+trait Unrelated
+
+object Test {
+  def m1(s: T & OpenTrait) = s match {
+    case _: Unrelated => ;
+  }
+
+  def m2(s: T & OpenClass) = s match {
+    case _: Unrelated => ;
+  }
+
+  def m3(s: T & OpenAbstractClass) = s match {
+    case _: Unrelated => ;
+  }
+}

--- a/tests/patmat/andtype-refinedtype-interaction.check
+++ b/tests/patmat/andtype-refinedtype-interaction.check
@@ -1,0 +1,10 @@
+32: Pattern Match Exhaustivity: _: Trait & C1{x: Int}
+48: Pattern Match Exhaustivity: _: Clazz & (C1 | C2 | T1){x: Int} & (C3 | C4 | T2){x: Int}, _: Trait & (C1 | C2 | T1){x: Int} & (C3 | C4 | T2){x: Int}
+54: Pattern Match Exhaustivity: _: Trait & (C1 | C2 | T1){x: Int} & C3{x: Int}
+65: Pattern Match Exhaustivity: _: Trait & (C1 | C2){x: Int} & (C3 | SubC1){x: Int}
+72: Pattern Match Exhaustivity: _: Trait & (T1 & C1 | T1 & SubC2){x: Int} &
+  (T2 & C2 | T2 & C3 | T2 & SubC1){x: Int}
+ & SubSubC1{x: Int}
+79: Pattern Match Exhaustivity: _: Trait & (T1 & C1 | T1 & SubC2){x: Int} &
+  (T2 & C2 | T2 & C3 | T2 & SubC1){x: Int}
+ & SubSubC2{x: Int}

--- a/tests/patmat/andtype-refinedtype-interaction.scala
+++ b/tests/patmat/andtype-refinedtype-interaction.scala
@@ -1,0 +1,82 @@
+sealed trait S
+trait Trait extends S
+class Clazz extends S
+object Obj extends S
+
+trait T1
+trait T2
+
+class C1
+class C2
+class C3
+class C4
+
+class SubC1 extends C1
+class SubSubC1 extends SubC1
+class SubC2 extends C2
+class SubSubC2 extends SubC2
+
+trait Unrelated
+
+object Test {
+  /*
+  Note: error message on this suggests Obj to be unmatched as well.
+  This isn't a bug in atomic type intersection, but a consequence
+  of approximating all types to be a subtype of a structural type.
+
+  def basic1(s: S & { val x: Int }) = s match {
+    case _: Unrelated => ;
+  }
+  */
+
+  def basic2(s: S & C1 { val x: Int }) = s match {
+    case _: Unrelated => ;
+  }
+
+  def doubleInheritance1(s: S & C1 { val x: Int } & C2) = s match {
+    case _: Unrelated => ;
+  }
+
+  def doubleInheritance2(s: S & C1 { val x: Int }
+                              & C2 { val x: Int }) =
+    s match {
+      case _: Unrelated => ;
+    }
+
+  def classOrTrait(s: S & (C1 | (C2 | T1)) { val x: Int }
+                        & (C3 | (C4 | T2)) { val x: Int }) =
+    s match {
+      case _: Unrelated => ;
+    }
+
+  def traitOnly(s: S & (C1 | (C2 | T1)) { val x: Int }
+                     & C3 { val x: Int }) =
+    s match {
+      case _: Unrelated => ;
+    }
+
+  def nestedDoubleInheritance(s: S & (C1 & C2) { val x: Int }) =
+    s match {
+      case _: Unrelated => ;
+    }
+
+  def subclassingA(s: S & (C1 | C2) { val x: Int }
+                        & (C3 | SubC1) { val x: Int }) =
+    s match {
+      case _: Unrelated => ;
+    }
+
+  def subclassingB(s: S & (T1 & (C1 | SubC2)) { val x: Int }
+                        & (T2 & (C2 | C3 | SubC1)) { val x: Int }
+                        & SubSubC1 { val x: Int }) =
+    s match {
+      case _: Unrelated => ;
+    }
+
+  def subclassingC(s: S & (T1 & (C1 | SubC2)) { val x: Int }
+                        & (T2 & (C2 | C3 | SubC1)) { val x: Int }
+                        & SubSubC2 { val x: Int }) =
+    s match {
+      case _: Unrelated => ;
+    }
+}

--- a/tests/patmat/andtype.check
+++ b/tests/patmat/andtype.check
@@ -1,0 +1,3 @@
+9: Pattern Match Exhaustivity: _: B
+13: Pattern Match Exhaustivity: _: B
+17: Pattern Match Exhaustivity: _: B

--- a/tests/patmat/andtype.scala
+++ b/tests/patmat/andtype.scala
@@ -1,0 +1,20 @@
+object Test {
+  trait Marker
+
+  sealed trait T
+  trait A extends T with Marker
+  trait B extends T with Marker
+  case object C extends T
+
+  def m1(s: T & Marker) = s match {
+    case _: A => ;
+  }
+
+  def m2(s: Marker & T) = s match {
+    case _: A => ;
+  }
+
+  def m3(s: (A | B) & Marker) = s match {
+    case _: A => ;
+  }
+}

--- a/tests/patmat/nontrivial-andtype.check
+++ b/tests/patmat/nontrivial-andtype.check
@@ -1,0 +1,1 @@
+16: Pattern Match Exhaustivity: D, _: C, B(), _: A

--- a/tests/patmat/nontrivial-andtype.scala
+++ b/tests/patmat/nontrivial-andtype.scala
@@ -1,0 +1,19 @@
+object Test {
+  sealed trait Marker
+  trait M1 extends Marker
+  sealed trait Marker2 extends Marker
+  sealed trait M2 extends Marker2
+
+  sealed trait T
+  trait A extends T with M2
+  sealed trait T2 extends T
+  case class B() extends T2 with Marker
+  class C extends T2 with M1
+  case object D extends T2 with Marker
+
+  trait Unrelated
+
+  def m1(s: T & Marker) = s match {
+    case _: Unrelated => ;
+  }
+}


### PR DESCRIPTION
As discussed on [gitter](https://gitter.im/lampepfl/dotty?at=58d7b495b52518ed4dab1c95), this PR extends exhaustivity checks to and-types. It's possible to check exhaustivity of pattern matching on them in case of "marker" types like this:
```scala
trait Marker
sealed type T
case object A extends T with Marker
case object B extends T with Marker
case object C extends T
def m(s: T & Marker) = s match { case A => ; }
// current behaviour without -YcheckAllPatmat:
//     no warning, since and-types aren't considered checkable
// with -YcheckAllPatmat:
//     warns that _: T & Marker would fail - T & Marker isn't decomposed into A | B
```

I've defined and-types as checkable if either type is checkable, decomposable if either type is decomposable and used space intersection for decomposition. However, this gives wrong results for this case:
```scala
sealed trait T
trait T1 extends T
trait T2 extends T
trait T3
def m(s: T & T3) = s match { case _: T1 => ; }
```
The underlying issue is that the intersection of two open types was previously approximated to be empty. I've added a check to `intersect` to see if it's possible to have a value of both types and return a type space of the and-type if that's the case. This changes slightly how space subtraction behaves - it's now possible to get "degenerate" unions from subtracting two constructor spaces ("degenerate" in the sense that one of the spaces is exactly the left-hand-side of the subtraction). This doesn't change the final result of exhaustivity check, though, so I'm not sure if it's an issue.

I'm also not completely sure if I got the `isOpen` implementation right - I'm not really familiar with how symbols work, so it's entirely possible there's a mistake there.

I'm also aware that `commonOpenTypeSpace` may sometimes return a space that can't be inhabited, since for instance the types are classes with conflicting methods, but I don't think it's an issue, since a) such and-types should be rare and b) we will at most emit a warning that the match may not be exhaustive.

/cc @liufengyun 