### PR TITLE
Make testing more robust

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -661,7 +661,7 @@ class ClassfileParser(
     for (entry <- innerClasses.values) {
       // create a new class member for immediate inner classes
       if (entry.outerName == currentClassName) {
-        val file = ctx.platform.classPath.findSourceFile(entry.externalName.toString) getOrElse {
+        val file = ctx.platform.classPath.findBinaryFile(entry.externalName.toString) getOrElse {
           throw new AssertionError(entry.externalName)
         }
         enterClassAndModule(entry, file, entry.jflags)

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -852,9 +852,10 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
         // See the test for SI-7214 for motivation for dealias. Later `treeCondStrategy#outerTest`
         // generates an outer test based on `patType.prefix` with automatically dealises.
         expectedTp.dealias match {
-          case tref @ TypeRef(pre, name) =>
-            (pre ne NoPrefix) && tref.symbol.isClass &&
-            ExplicitOuter.needsOuterIfReferenced(tref.symbol.asClass)
+          case tref @ TypeRef(pre: SingletonType, name) =>
+            val s = tref
+            s.symbol.isClass &&
+            ExplicitOuter.needsOuterIfReferenced(s.symbol.asClass)
           case _ =>
             false
         }

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -848,10 +848,10 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
 
       val nextBinder = afterTest.asTerm
 
-      def needsOuterTest(patType: Type, selType: Type, currentOwner: Symbol): Boolean = {
+      def outerTestNeeded(implicit ctx: Context): Boolean = {
         // See the test for SI-7214 for motivation for dealias. Later `treeCondStrategy#outerTest`
         // generates an outer test based on `patType.prefix` with automatically dealises.
-        patType.dealias match {
+        expectedTp.dealias match {
           case tref @ TypeRef(pre, name) =>
             (pre ne NoPrefix) && tref.symbol.isClass &&
             ExplicitOuter.needsOuterIfReferenced(tref.symbol.asClass)
@@ -861,12 +861,6 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
       }
 
       override lazy val introducedRebindings = NoRebindings
-
-      def outerTestNeeded = {
-        /*val np = expectedTp.normalizedPrefix
-        val ts = np.termSymbol
-        (ts ne NoSymbol) && */needsOuterTest(expectedTp, testedBinder.info, ctx.owner)
-      }
 
       // the logic to generate the run-time test that follows from the fact that
       // a `prevBinder` is expected to have type `expectedTp`

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -863,9 +863,9 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
       override lazy val introducedRebindings = NoRebindings
 
       def outerTestNeeded = {
-        val np = expectedTp.normalizedPrefix
+        /*val np = expectedTp.normalizedPrefix
         val ts = np.termSymbol
-        (ts ne NoSymbol) && needsOuterTest(expectedTp, testedBinder.info, ctx.owner)
+        (ts ne NoSymbol) && */needsOuterTest(expectedTp, testedBinder.info, ctx.owner)
       }
 
       // the logic to generate the run-time test that follows from the fact that

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -242,8 +242,8 @@ abstract class ClassPath {
       case Some((pkg, rest)) =>
         val rep = packages find (_.name == pkg) flatMap (_ findClass rest)
         rep map {
-          case x: ClassRep  => x
-          case x            => throw new FatalError("Unexpected ClassRep '%s' found searching for name '%s'".format(x, name))
+          case x: AnyClassRep => x
+          case x              => throw new FatalError("Unexpected ClassRep '%s' found searching for name '%s'".format(x, name))
         }
       case _ =>
         classes find (_.name == name)
@@ -256,6 +256,7 @@ abstract class ClassPath {
     }
 
   def sortString = join(split(asClasspathString).sorted: _*)
+
   override def equals(that: Any) = that match {
     case x: ClassPath => this.sortString == x.sortString
     case _            => false

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -240,20 +240,13 @@ abstract class ClassPath {
   def findClass(name: String): Option[AnyClassRep] =
     name.splitWhere(_ == '.', doDropIndex = true) match {
       case Some((pkg, rest)) =>
-        val rep = packages find (_.name == pkg) flatMap (_ findClass rest)
-        rep map {
-          case x: AnyClassRep => x
-          case x              => throw new FatalError("Unexpected ClassRep '%s' found searching for name '%s'".format(x, name))
-        }
+        packages find (_.name == pkg) flatMap (_ findClass rest)
       case _ =>
         classes find (_.name == name)
     }
 
-  def findSourceFile(name: String): Option[AbstractFile] =
-    findClass(name) match {
-      case Some(ClassRep(Some(x: AbstractFile), _)) => Some(x)
-      case _                                        => None
-    }
+  def findBinaryFile(name: String): Option[AbstractFile] =
+    findClass(name).flatMap(_.binary)
 
   def sortString = join(split(asClasspathString).sorted: _*)
 

--- a/compiler/test/dotty/tools/dotc/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/dotc/ParallelTesting.scala
@@ -920,9 +920,8 @@ trait ParallelTesting { self =>
   private def compilationTargets(sourceDir: JFile): (List[JFile], List[JFile]) =
     sourceDir.listFiles.foldLeft((List.empty[JFile], List.empty[JFile])) { case ((dirs, files), f) =>
       if (f.isDirectory) (f :: dirs, files)
-      else if (f.getName.endsWith(".check")) (dirs, files)
-      else if (f.getName.endsWith(".flags")) (dirs, files)
-      else (dirs, f :: files)
+      else if (isSourceFile(f)) (dirs, f :: files)
+      else (dirs, files)
     }
 
   /** Gets the name of the calling method via reflection.

--- a/tests/run/i2156.scala
+++ b/tests/run/i2156.scala
@@ -1,0 +1,37 @@
+class Outer {
+
+  case class Inner()
+
+  val inner: Inner = new Inner
+
+  def checkInstance(o: Outer) =
+    o.inner.isInstanceOf[this.Inner]
+
+  def checkPattern1(i: Any) =
+    i match {
+      case _: Inner => true
+      case _ => false
+    }
+
+  def checkPattern2(i: Any) =
+    i match {
+      case Inner() => true
+      case _ => false
+    }
+
+  def checkEquals(o: Outer) =
+    o.inner == inner
+}
+
+object Test {
+
+  def main(args: Array[String]) = {
+    val o1 = new Outer
+    val o2 = new Outer
+    assert(o1.checkInstance(o2)) // ok
+    assert(!o1.checkPattern1(o2.inner)) // ok under scalac, fails for dotc-compiled code
+    assert(!o1.checkPattern2(o2.inner))  // ok under scalac, fails for dotc-compiled code
+    assert(!o1.checkEquals(o2))  // ok under scalac, fails for dotc-compiled code
+  }
+}
+


### PR DESCRIPTION
Emacs often produces temporary files in directories. These used to
cause NPEs in the new testing framework. We now fix this by only
compiling file names that designate source files.

Based on #2158. Only last commit is new.
