### PR TITLE
Fix #1959: infix type operators in the REPL

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -526,11 +526,11 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       case Function(args, body) =>
         this(this(x, args), body)
       case InfixOp(left, op, right) =>
-        this(this(x, left), right)
+        this(this(this(x, left), op), right)
       case PostfixOp(od, op) =>
-        this(x, od)
+        this(this(x, od), op)
       case PrefixOp(op, od) =>
-        this(x, od)
+        this(this(x, op), od)
       case Parens(t) =>
         this(x, t)
       case Tuple(trees) =>

--- a/tests/repl/infixTypeOp.check
+++ b/tests/repl/infixTypeOp.check
@@ -1,0 +1,5 @@
+scala> trait +[A, B]
+defined trait +
+scala> type IntAndString = Int + String
+defined type alias IntAndString
+scala> :quit


### PR DESCRIPTION
Infix type operators were broken in the REPL.
The REPL uses fold methods from the untpd package,
but those were skipping the operator subtree when folding
over an InfixOp.

Fix the issue by taking the operator into account.

Tested:
1) Verified that only the REPL code uses the modified
fold method.
2) The following interaction now works in the REPL
(used to fail with a 'can't find +' error):

scala> class +[A, B](a: A, B: B)
defined class +
scala> type IntAndString = Int + String
defined type alias IntAndString
scala> new IntAndString(42, "hello world")
val res0: +[Int, String] = $plus@6a472554