### PR TITLE
Fixes `@unchecked` warnings

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -477,7 +477,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       case SymbolLit(str) =>
         cpy.SymbolLit(tree)(str)
       case InterpolatedString(id, segments) =>
-        cpy.InterpolatedString(tree)(id, segments.map(transform(_)))
+        cpy.InterpolatedString(tree)(id, segments.mapConserve(transform))
       case Function(args, body) =>
         cpy.Function(tree)(transform(args), transform(body))
       case InfixOp(left, op, right) =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
@@ -159,7 +159,7 @@ class TreeBuffer extends TastyBuffer(50000) {
       val tree = it.next
       treeAddrs.get(tree) match {
         case addr: Addr => treeAddrs.put(tree, adjusted(addr))
-        case addrs: List[Addr] => treeAddrs.put(tree, addrs.map(adjusted))
+        case addrs: List[Addr @unchecked] => treeAddrs.put(tree, addrs.map(adjusted))
       }
     }
   }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
@@ -159,7 +159,6 @@ class TreeBuffer extends TastyBuffer(50000) {
       val tree = it.next
       treeAddrs.get(tree) match {
         case addr: Addr => treeAddrs.put(tree, adjusted(addr))
-        case addrs: List[Addr @unchecked] => treeAddrs.put(tree, addrs.map(adjusted))
       }
     }
   }

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc
 package transform
 
 import dotty.tools.dotc.transform.TreeTransforms.{TransformerInfo, TreeTransform, TreeTransformer}
-import dotty.tools.dotc.ast.{Trees, tpd}
+import dotty.tools.dotc.ast.{Trees, tpd, untpd}
 import scala.collection.{ mutable, immutable }
 import ValueClasses._
 import scala.annotation.tailrec
@@ -258,15 +258,15 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer  { thisTran
           )
         case Import(expr, selectors) =>
           val exprTpe = expr.tpe
-          def checkIdent(ident: Ident): Unit = {
+          def checkIdent(ident: untpd.Ident): Unit = {
             val name = ident.name.asTermName.encode
             if (name != nme.WILDCARD && !exprTpe.member(name).exists && !exprTpe.member(name.toTypeName).exists)
               ctx.error(s"${ident.name} is not a member of ${expr.show}", ident.pos)
           }
           selectors.foreach {
-            case ident @ Ident(_)                 => checkIdent(ident)
-            case Thicket((ident @ Ident(_)) :: _) => checkIdent(ident)
-            case _                                =>
+            case ident: untpd.Ident                 => checkIdent(ident)
+            case Thicket((ident: untpd.Ident) :: _) => checkIdent(ident)
+            case _                                  =>
           }
           super.transform(tree)
         case tree =>

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -264,9 +264,9 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer  { thisTran
               ctx.error(s"${ident.name} is not a member of ${expr.show}", ident.pos)
           }
           selectors.foreach {
-            case ident: Ident                 => checkIdent(ident)
-            case Thicket((ident: Ident) :: _) => checkIdent(ident)
-            case _                            =>
+            case ident @ Ident(_)                 => checkIdent(ident)
+            case Thicket((ident @ Ident(_)) :: _) => checkIdent(ident)
+            case _                                =>
           }
           super.transform(tree)
         case tree =>

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -139,13 +139,13 @@ class TreeChecker extends Phase with SymTransformer {
   class Checker(phasesToCheck: Seq[Phase]) extends ReTyper with Checking {
 
     val nowDefinedSyms = new mutable.HashSet[Symbol]
-    val everDefinedSyms = new mutable.HashMap[Symbol, Tree]
+    val everDefinedSyms = new mutable.HashMap[Symbol, untpd.Tree]
 
     // don't check value classes after typer, as the constraint about constructors doesn't hold after transform
     override def checkDerivedValueClass(clazz: Symbol, stats: List[Tree])(implicit ctx: Context) = ()
 
     def withDefinedSym[T](tree: untpd.Tree)(op: => T)(implicit ctx: Context): T = tree match {
-      case tree: DefTree @unchecked =>
+      case tree: untpd.DefTree =>
         val sym = tree.symbol
         assert(isValidJVMName(sym.name), s"${sym.fullName} name is invalid on jvm")
         everDefinedSyms.get(sym) match {
@@ -160,7 +160,7 @@ class TreeChecker extends Phase with SymTransformer {
 
         if (ctx.settings.YcheckMods.value) {
           tree match {
-            case t: MemberDef =>
+            case t: untpd.MemberDef =>
               if (t.name ne sym.name) ctx.warning(s"symbol ${sym.fullName} name doesn't correspond to AST: ${t}")
             // todo: compare trees inside annotations
             case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -145,7 +145,7 @@ class TreeChecker extends Phase with SymTransformer {
     override def checkDerivedValueClass(clazz: Symbol, stats: List[Tree])(implicit ctx: Context) = ()
 
     def withDefinedSym[T](tree: untpd.Tree)(op: => T)(implicit ctx: Context): T = tree match {
-      case tree: DefTree =>
+      case tree: DefTree @unchecked =>
         val sym = tree.symbol
         assert(isValidJVMName(sym.name), s"${sym.fullName} name is invalid on jvm")
         everDefinedSyms.get(sym) match {

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -539,7 +539,7 @@ object ProtoTypes {
   /** Dummy tree to be used as an argument of a FunProto or ViewProto type */
   object dummyTreeOfType {
     def apply(tp: Type): Tree = untpd.Literal(Constant(null)) withTypeUnchecked tp
-    def unapply(tree: Tree): Option[Type] = tree match {
+    def unapply(tree: Tree @unchecked): Option[Type] = tree match {
       case Literal(Constant(null)) => Some(tree.typeOpt)
       case _ => None
     }

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -539,7 +539,7 @@ object ProtoTypes {
   /** Dummy tree to be used as an argument of a FunProto or ViewProto type */
   object dummyTreeOfType {
     def apply(tp: Type): Tree = untpd.Literal(Constant(null)) withTypeUnchecked tp
-    def unapply(tree: Tree @unchecked): Option[Type] = tree match {
+    def unapply(tree: untpd.Tree): Option[Type] = tree match {
       case Literal(Constant(null)) => Some(tree.typeOpt)
       case _ => None
     }


### PR DESCRIPTION
- Fixe the few `@unchecked` warnings emitted when compiling dotty.
- Replace a `map` by `mapConserve` in `UntypedTreeMap`

dotty fails to compile the files I modified. Not sure if this reveals a bug or if it is a known incompatibility between scalac and dotty
```scala
-- Error: dotty/compiler/../compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala 
542 |    def unapply(tree: Tree @unchecked): Option[Type] = tree match {
    |                           ^^^^^^^^^^
    |                      annotation.unchecked does not have a constructor
-- [E007] Type Mismatch Error: dotty/compiler/../compiler/src/dotty/tools/dotc/transform/PostTyper.scala 
267 |            case ident @ Ident(_)                 => checkIdent(ident)
    |                                                                ^^^^^
    |found:    dotty.tools.dotc.ast.Trees.Ident[dotty.tools.dotc.ast.Trees.Untyped](ident)
    |required: dotty.tools.dotc.ast.tpd.Ident
```