### PR TITLE
Use symbolic names internally

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -62,7 +62,7 @@ object NameKinds {
   }
 
   /** The kind of SimpleNames */
-  object SimpleNameKind extends NameKind(UTF8) { self =>
+  val SimpleNameKind = new NameKind(UTF8) { self =>
     type ThisInfo = Info
     val info = new Info
     def mkString(underlying: TermName, info: ThisInfo) = unsupported("mkString")
@@ -311,7 +311,7 @@ object NameKinds {
   val PatMatSelectorName      = new UniqueNameKind("selector")
 
   /** The kind of names of default argument getters */
-  object DefaultGetterName extends NumberedNameKind(DEFAULTGETTER, "DefaultGetter") {
+  val DefaultGetterName = new NumberedNameKind(DEFAULTGETTER, "DefaultGetter") {
     def mkString(underlying: TermName, info: ThisInfo) = {
       val prefix = if (underlying.isConstructorName) nme.DEFAULT_GETTER_INIT else underlying
       prefix.toString + str.DEFAULT_GETTER + (info.num + 1)
@@ -330,14 +330,14 @@ object NameKinds {
   }
 
   /** The kind of names that also encode a variance: 0 for contravariance, 1 for covariance. */
-  object VariantName extends NumberedNameKind(VARIANT, "Variant") {
+  val VariantName = new NumberedNameKind(VARIANT, "Variant") {
     def mkString(underlying: TermName, info: ThisInfo) = "-+"(info.num).toString + underlying
   }
 
   /** Names of the form N_<outer>. Emitted by inliner, replaced by outer path
    *  in ExplicitOuter.
    */
-  object OuterSelectName extends NumberedNameKind(OUTERSELECT, "OuterSelect") {
+  val OuterSelectName = new NumberedNameKind(OUTERSELECT, "OuterSelect") {
     def mkString(underlying: TermName, info: ThisInfo) = {
       assert(underlying.isEmpty)
       info.num + "_<outer>"
@@ -359,7 +359,7 @@ object NameKinds {
   val ModuleClassName = new SuffixNameKind(OBJECTCLASS, "$", optInfoString = "ModuleClass")
 
   /** A name together with a signature. Used in Tasty trees. */
-  object SignedName extends NameKind(63) {
+  val SignedName = new NameKind(63) {
 
     case class SignedInfo(sig: Signature) extends Info {
       override def toString = s"$infoString $sig"

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -61,8 +61,7 @@ object NameKinds {
     def infoString: String
   }
 
-  /** The kind of SimpleNames */
-  val SimpleNameKind = new NameKind(UTF8) { self =>
+  object SimpleNameKind extends NameKind(UTF8) { self =>
     type ThisInfo = Info
     val info = new Info
     def mkString(underlying: TermName, info: ThisInfo) = unsupported("mkString")
@@ -359,7 +358,7 @@ object NameKinds {
   val ModuleClassName = new SuffixNameKind(OBJECTCLASS, "$", optInfoString = "ModuleClass")
 
   /** A name together with a signature. Used in Tasty trees. */
-  val SignedName = new NameKind(63) {
+  object SignedName extends NameKind(63) {
 
     case class SignedInfo(sig: Signature) extends Info {
       override def toString = s"$infoString $sig"

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -351,7 +351,9 @@ object NameKinds {
   val ProtectedSetterName = new PrefixNameKind(PROTECTEDSETTER, "protected$set") // dubious encoding, kept for Scala2 compatibility
   val AvoidClashName = new SuffixNameKind(AVOIDCLASH, "$_avoid_name_clash_$")
   val DirectMethodName = new SuffixNameKind(DIRECT, "$direct") { override def definesNewName = true }
-  val FieldName = new SuffixNameKind(FIELD, "$$local")
+  val FieldName = new SuffixNameKind(FIELD, "$$local") {
+      override def mkString(underlying: TermName, info: ThisInfo) = underlying.toString
+  }
   val ExtMethName = new SuffixNameKind(EXTMETH, "$extension")
   val ModuleVarName = new SuffixNameKind(OBJECTVAR, "$module")
   val ModuleClassName = new SuffixNameKind(OBJECTCLASS, "$", optInfoString = "ModuleClass")

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -247,7 +247,7 @@ object Names {
     }
 
     @sharable // because it's just a cache for performance
-    private[Names] var myMangledString: String = null
+    private[this] var myMangledString: String = null
 
     @sharable // because it's just a cache for performance
     private[this] var myMangled: Name = null

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2930,7 +2930,7 @@ object Types {
         case tycon: TypeRef if !tycon.symbol.isClass =>
         case _: TypeParamRef | _: ErrorType | _: WildcardType =>
         case _: TypeLambda =>
-          assert(args.exists(_.isInstanceOf[TypeBounds]), s"unreduced type apply: $this")
+          assert(!args.exists(_.isInstanceOf[TypeBounds]), s"unreduced type apply: $this")
         case tycon: AnnotatedType =>
           check(tycon.underlying)
         case _ =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -36,21 +36,21 @@ Macro-format:
                   EXPANDEDPREFIX    Length qualified_NameRef selector_NameRef
                   TRAITSETTER       Length qualified_NameRef selector_NameRef
                   UNIQUE            Length separator_NameRef uniqid_Nat underlying_NameRef?
-									DEFAULTGETTER     Length underlying_NameRef index_Nat
-									VARIANT           Length underlying_NameRef variance_Nat      // 0: Contravariant, 1: Covariant
-									OUTERSELECT       Length underlying_NameRef nhops_Nat         // a reference to `nhops` <outer> selections, followed by `underlying`
+                  DEFAULTGETTER     Length underlying_NameRef index_Nat
+                  VARIANT           Length underlying_NameRef variance_Nat      // 0: Contravariant, 1: Covariant
+                  OUTERSELECT       Length underlying_NameRef nhops_Nat         // a reference to `nhops` <outer> selections, followed by `underlying`
 
-									SUPERACCESSOR     Length underlying_NameRef
-									PROTECTEDACCESSOR Length underlying_NameRef
-									PROTECTEDSETTER   Length underlying_NameRef
-									INITIALIZER       Length underlying_NameRef
-									SHADOWED          Length underlying_NameRef
-									AVOIDCLASH        Length underlying_NameRef
-									DIRECT            Length underlying_NameRef
-									FIELD             Length underlying_NameRef
-									EXTMETH           Length underlying_NameRef
-									OBJECTVAR         Length underlying_NameRef
-									OBJECTCLASS       Length underlying_NameRef
+                  SUPERACCESSOR     Length underlying_NameRef
+                  PROTECTEDACCESSOR Length underlying_NameRef
+                  PROTECTEDSETTER   Length underlying_NameRef
+                  INITIALIZER       Length underlying_NameRef
+                  SHADOWED          Length underlying_NameRef
+                  AVOIDCLASH        Length underlying_NameRef
+                  DIRECT            Length underlying_NameRef
+                  FIELD             Length underlying_NameRef
+                  EXTMETH           Length underlying_NameRef
+                  OBJECTVAR         Length underlying_NameRef
+                  OBJECTCLASS       Length underlying_NameRef
                   SIGNED            Length original_NameRef resultSig_NameRef paramSig_NameRef*
 
   NameRef       = Nat                    // ordinal number of name in name table, starting from 1.

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -94,7 +94,7 @@ trait TypeAssigner {
               val refinableDecls = info.decls.filter(
                 sym => !(sym.is(TypeParamAccessor | Private) || sym.isConstructor))
               val fullType = (parentType /: refinableDecls)(addRefinement)
-              mapOver(fullType)
+              apply(fullType)
             case TypeBounds(lo, hi) if variance > 0 =>
               apply(hi)
             case _ =>

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -244,7 +244,7 @@ class CompilationTests extends ParallelTesting {
     }.map(_.checkCompile()).foreach(_.delete())
   }
 
-  /** Add a `z` so that hey run last. TODO: Only run them selectively? */
+  /** Add a `z` so that they run last. TODO: Only run them selectively? */
   @Test def zBytecodeIdempotency: Unit = {
     var failed = 0
     var total = 0

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -244,7 +244,8 @@ class CompilationTests extends ParallelTesting {
     }.map(_.checkCompile()).foreach(_.delete())
   }
 
-  @Test def bytecodeIdempotency: Unit = {
+  /** Add a `z` so that hey run last. TODO: Only run them selectively? */
+  @Test def zBytecodeIdempotency: Unit = {
     var failed = 0
     var total = 0
     val blacklisted = Set(

--- a/tests/pos/avoid.scala
+++ b/tests/pos/avoid.scala
@@ -8,3 +8,20 @@ object test {
   }
   val z: String = x.y
 }
+
+// A tricky case involving inner classes, exercised
+// in the large in dotty.tools.dotc.core.NameKinds.scala.
+object Test2 {
+
+  class NK {
+    class I
+    type T
+  }
+
+  val x = new NK { type T = I }
+
+  val y = {
+    class C extends NK { type T = I }
+    new C
+  }
+}

--- a/tests/run/paramForwarding.check
+++ b/tests/run/paramForwarding.check
@@ -1,16 +1,16 @@
 B:
-private final int B.theValue$$local
-private final int B.theValueInB$$local
+private final int B.theValue
+private final int B.theValueInB
 Bz:
-private final int Bz.theValue$$local
-private final int Bz.theValueInBz$$local
+private final int Bz.theValue
+private final int Bz.theValueInBz
 C:
 
 D:
-private final int D.other$$local
+private final int D.other
 NonVal:
 
 X:
-private final int X.theValue$$local
+private final int X.theValue
 Y:
 

--- a/tests/run/paramForwarding_separate.check
+++ b/tests/run/paramForwarding_separate.check
@@ -1,5 +1,5 @@
 # Fields in A:
-private final int A.member$$local
+private final int A.member
 # Fields in SubA:
 
 # Fields in B:

--- a/tests/run/paramForwarding_together.check
+++ b/tests/run/paramForwarding_together.check
@@ -1,5 +1,5 @@
 # Fields in A:
-private final int A.member$$local
+private final int A.member
 # Fields in SubA:
 
 # Fields in B:

--- a/tests/run/paramForwarding_together_b.check
+++ b/tests/run/paramForwarding_together_b.check
@@ -1,5 +1,5 @@
 # Fields in A:
-private final int A.member$$local
+private final int A.member
 # Fields in SubA:
 
 # Fields in B:

--- a/tests/run/statics.scala
+++ b/tests/run/statics.scala
@@ -2,18 +2,18 @@ import scala.annotation.static
 
 class Foo{
   class Bar {
-    def qwa = 
+    def qwa =
      Bar.field
          // 0: invokestatic  #31                 // Method Foo$Bar$.field:()I
          // 3: ireturn
   }
   object Bar {
-     @static 
+     @static
      val field = 1
    }
 }
 
-object Foo{ 
+object Foo{
  @static
  def method = 1
 
@@ -35,6 +35,6 @@ object Test {
 }
 
 class WithLazies{
-  @volatile lazy val s = 1 
+  @volatile lazy val s = 1
   //         98: getstatic     #30                 // Field WithLazies$.OFFSET$0:J
 }

--- a/tests/run/variable-pattern-access.check
+++ b/tests/run/variable-pattern-access.check
@@ -1,6 +1,6 @@
 # Fields of A:
-private final int A.a$$local
-private final int A.b$$local
+private final int A.a
+private final int A.b
 private final scala.Tuple2 A.$1$
 # Methods of A:
 public int A.a()


### PR DESCRIPTION
Change encoding to that symbolic operators are kept internally and are only emitted during the backend. The PR is based on #2128 of which it is the logical conclusion.

