### PR TITLE
fix #2166: unpickling of shared CaseDef

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1062,7 +1062,13 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table, posUnpickle
       }
 
     def readCases(end: Addr)(implicit ctx: Context): List[CaseDef] =
-      collectWhile(nextByte == CASEDEF && currentAddr != end) { readCase()(ctx.fresh.setNewScope) }
+      collectWhile((nextByte == CASEDEF || nextByte == SHARED) && currentAddr != end) {
+        if (nextByte == SHARED) {
+          readByte()
+          forkAt(readAddr()).readCase()(ctx.fresh.setNewScope)
+        }
+        else readCase()(ctx.fresh.setNewScope)
+      }
 
     def readCase()(implicit ctx: Context): CaseDef = {
       val start = currentAddr

--- a/tests/pickling/i2166.scala
+++ b/tests/pickling/i2166.scala
@@ -1,0 +1,5 @@
+object Test {
+  @inline def f = "" match { case _ => false }
+
+  def main(args: Array[String]): Unit = f
+}


### PR DESCRIPTION
Fix #2166: the unpickling of CaseDef should take care of SHARED trees.