### PR TITLE
checkNoPrivateLeaks: Do not allow types to refer to leaky aliases

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -736,7 +736,9 @@ class TreeUnpickler(reader: TastyReader, tastyName: TastyName.Table, posUnpickle
         // no longer necessary.
       goto(end)
       setPos(start, tree)
-      sym.info = ta.avoidPrivateLeaks(sym, tree.pos)
+      if (!sym.isType) { // Only terms might have leaky aliases, see the documentation of `checkNoPrivateLeaks`
+        sym.info = ta.avoidPrivateLeaks(sym, tree.pos)
+      }
       tree
     }
 

--- a/tests/neg/leak-type.scala
+++ b/tests/neg/leak-type.scala
@@ -1,0 +1,13 @@
+trait A {
+  private type Foo = Int
+
+
+  class Inner[T <: Foo] { // error: non-private type T refers to private type Foo in its type signature
+    def get: T = ???
+  }
+}
+class B extends A {
+  def foo(x: Inner[_]): Unit = {
+    val a = x.get // error: cannot resolve reference to type B(B.this).Foo
+  }
+}

--- a/tests/pos/i1130.scala
+++ b/tests/pos/i1130.scala
@@ -3,4 +3,6 @@ trait A {
 
   def foo: Foo = 1
 }
-class B extends A
+class B extends A {
+  foo
+}

--- a/tests/pos/leak-inferred.scala
+++ b/tests/pos/leak-inferred.scala
@@ -1,0 +1,12 @@
+class A {
+  private val x = List(1,2)
+
+  val elem = x.head
+}
+
+class B extends A {
+  val a: Int = elem
+    // Without `checkNoPrivateLeaks`, we get:
+    // found:    B.this.x.scala$collection$immutable$List$$A(B.this.elem)
+    // required: Int
+}


### PR DESCRIPTION
`checkNoPrivateLeaks` can force a lot of things, this lead to
hard-to-reproduce issues in unpickling because we called
`checkNoPrivateLeaks` on the type parameters of a class before anything
in the class was indexed. We fix this by making sure that
`checkNoPrivateLeaks` never transforms type symbols, only term symbols,
therefore we can unpickle type parameters without forcing too many
things. `tests/neg/leak-type.scala` illustrates the new restriction that
this necessitates.

@OlivierBlanvillain Can you confirm that this fixes the issue for you too?