### PR TITLE
Make leak avoidance more robust

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -400,8 +400,14 @@ object Checking {
         case tp: ClassInfo =>
           tp.derivedClassInfo(
             prefix = apply(tp.prefix),
-            classParents = tp.parentsWithArgs.map(p =>
-              apply(p).underlyingClassRef(refinementOK = false).asInstanceOf[TypeRef]))
+            classParents =
+              tp.parentsWithArgs.map { p =>
+                apply(p).underlyingClassRef(refinementOK = false) match {
+                  case ref: TypeRef => ref
+                  case _ => defn.ObjectType // can happen if class files are missing
+                }
+              }
+            )
         case _ =>
           mapOver(tp)
       }


### PR DESCRIPTION
If class files are missing, finding an underlying class reference might give a NoType. This caused an asInstanceOf to fail. We now handle that case gracefully.

It's a small thing, and I found it too hard to reproduce in a test case. @smarter Since you are already current in `checkNoPrivateLeaks` do you want to take a quick look? 