### PR TITLE
Fix #2186: Synchronize classpath handling with Scala 2.12

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,23 +1,28 @@
-The dotty compiler frontend has been developed since November 2012 by Martin Odersky. It is expected and hoped for 
+The dotty compiler frontend has been developed since November 2012 by Martin Odersky. It is expected and hoped for
 that the list of contributors to the codebase will grow quickly. Dotty draws inspiration and code from the original
-Scala compiler "nsc", which is developed at [scala/scala](https://github.com/scala/scala). 
+Scala compiler "nsc", which is developed at [scala/scala](https://github.com/scala/scala).
 
 The majority of the dotty codebase is new code, with the exception of the components mentioned below. We have for each component tried to come up with a list of the original authors in the  [scala/scala](https://github.com/scala/scala) codebase. Apologies if some major authors were omitted by oversight.
 
 `dotty.tools.dotc.ast`
 
-> The syntax tree handling is mostly new, but some elements, such as the idea of tree copiers and the `TreeInfo` module, 
-> were adopted from  [scala/scala](https://github.com/scala/scala). 
+> The syntax tree handling is mostly new, but some elements, such as the idea of tree copiers and the `TreeInfo` module,
+> were adopted from  [scala/scala](https://github.com/scala/scala).
 > The original authors of these parts include Martin Odersky, Paul Phillips, Adriaan Moors, and Matthias Zenger.
+
+`dotty.tools.dotc.classpath`
+
+> The classpath handling is taken mostly as is from [scala/scala](https://github.com/scala/scala).
+> The original authors were Grzegorz Kossakowski, Michał Pociecha, Lukas  Rytz, Jason Zaugg and others.
 
 `dotty.tools.dotc.config`
 
-> The configuration components were adapted and extended from  [scala/scala](https://github.com/scala/scala). 
+> The configuration components were adapted and extended from  [scala/scala](https://github.com/scala/scala).
 > The original sources were authored by Paul Phillips with contributions from Martin Odersky, Miguel Garcia and others.
-  
+
 `dotty.tools.dotc.core`
 
-> The core data structures and operations are mostly new. Some parts (e.g. those dealing with names) were adapted from  [scala/scala](https://github.com/scala/scala). 
+> The core data structures and operations are mostly new. Some parts (e.g. those dealing with names) were adapted from  [scala/scala](https://github.com/scala/scala).
 > These were originally authored by Martin Odersky, Adriaan Moors, Jason Zaugg, Paul Phillips, Eugene Burmako and others.
 
 `dotty.tools.dotc.core.pickling`
@@ -41,7 +46,7 @@ The majority of the dotty codebase is new code, with the exception of the compon
 
 > The utilities package is a mix of new and adapted components. The files in  [scala/scala](https://github.com/scala/scala) were originally authored by many people,
 > including Paul Phillips, Martin Odersky, Sean McDirmid, and others.
-  
+
 `dotty.tools.io`
 
 > The I/O support library was adapted from current Scala compiler. Original authors were Paul Phillips and others.
@@ -53,7 +58,7 @@ The majority of the dotty codebase is new code, with the exception of the compon
 > the needs of dotty. Original authors include: Adrian Moors, Lukas Rytz,
 > Grzegorz Kossakowski, Paul Phillips
 
-`dotty.tools.dotc.sbt and everything in bridge/`
+`dotty.tools.dotc.sbt and everything in sbt-bridge/`
 
 > The sbt compiler phases are based on
 > https://github.com/adriaanm/scala/tree/sbt-api-consolidate/src/compiler/scala/tools/sbt

--- a/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package dotty.tools.dotc.classpath
+
+import java.net.URL
+import scala.annotation.tailrec
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.internal.FatalError
+import scala.reflect.io.AbstractFile
+import dotty.tools.io.ClassPath
+import dotty.tools.io.ClassRepresentation
+
+/**
+ * A classpath unifying multiple class- and sourcepath entries.
+ * The Classpath can obtain entries for classes and sources independently
+ * so it tries to do operations quite optimally - iterating only these collections
+ * which are needed in the given moment and only as far as it's necessary.
+ *
+ * @param aggregates classpath instances containing entries which this class processes
+ */
+case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
+  override def findClassFile(className: String): Option[AbstractFile] = {
+    @tailrec
+    def find(aggregates: Seq[ClassPath]): Option[AbstractFile] =
+      if (aggregates.nonEmpty) {
+        val classFile = aggregates.head.findClassFile(className)
+        if (classFile.isDefined) classFile
+        else find(aggregates.tail)
+      } else None
+
+    find(aggregates)
+  }
+
+  override def findClass(className: String): Option[ClassRepresentation] = {
+    @tailrec
+    def findEntry(aggregates: Seq[ClassPath], isSource: Boolean): Option[ClassRepresentation] =
+      if (aggregates.nonEmpty) {
+        val entry = aggregates.head.findClass(className) match {
+          case s @ Some(_: SourceFileEntry) if isSource => s
+          case s @ Some(_: ClassFileEntry) if !isSource => s
+          case _ => None
+        }
+        if (entry.isDefined) entry
+        else findEntry(aggregates.tail, isSource)
+      } else None
+
+    val classEntry = findEntry(aggregates, isSource = false)
+    val sourceEntry = findEntry(aggregates, isSource = true)
+
+    (classEntry, sourceEntry) match {
+      case (Some(c: ClassFileEntry), Some(s: SourceFileEntry)) => Some(ClassAndSourceFilesEntry(c.file, s.file))
+      case (c @ Some(_), _) => c
+      case (_, s) => s
+    }
+  }
+
+  override def asURLs: Seq[URL] = aggregates.flatMap(_.asURLs)
+
+  override def asClassPathStrings: Seq[String] = aggregates.map(_.asClassPathString).distinct
+
+  override def asSourcePathString: String = ClassPath.join(aggregates map (_.asSourcePathString): _*)
+
+  override private[dotty] def packages(inPackage: String): Seq[PackageEntry] = {
+    val aggregatedPackages = aggregates.flatMap(_.packages(inPackage)).distinct
+    aggregatedPackages
+  }
+
+  override private[dotty] def classes(inPackage: String): Seq[ClassFileEntry] =
+    getDistinctEntries(_.classes(inPackage))
+
+  override private[dotty] def sources(inPackage: String): Seq[SourceFileEntry] =
+    getDistinctEntries(_.sources(inPackage))
+
+  override private[dotty] def list(inPackage: String): ClassPathEntries = {
+    val (packages, classesAndSources) = aggregates.map { cp =>
+      try {
+        cp.list(inPackage)
+      } catch {
+        case ex: java.io.IOException =>
+          val e = new FatalError(ex.getMessage)
+          e.initCause(ex)
+          throw e
+      }
+    }.unzip
+    val distinctPackages = packages.flatten.distinct
+    val distinctClassesAndSources = mergeClassesAndSources(classesAndSources: _*)
+    ClassPathEntries(distinctPackages, distinctClassesAndSources)
+  }
+
+  /**
+   * Returns only one entry for each name. If there's both a source and a class entry, it
+   * creates an entry containing both of them. If there would be more than one class or source
+   * entries for the same class it always would use the first entry of each type found on a classpath.
+   */
+  private def mergeClassesAndSources(entries: Seq[ClassRepresentation]*): Seq[ClassRepresentation] = {
+    // based on the implementation from MergedClassPath
+    var count = 0
+    val indices = collection.mutable.HashMap[String, Int]()
+    val mergedEntries = new ArrayBuffer[ClassRepresentation](1024)
+
+    for {
+      partOfEntries <- entries
+      entry <- partOfEntries
+    } {
+      val name = entry.name
+      if (indices contains name) {
+        val index = indices(name)
+        val existing = mergedEntries(index)
+
+        if (existing.binary.isEmpty && entry.binary.isDefined)
+          mergedEntries(index) = ClassAndSourceFilesEntry(entry.binary.get, existing.source.get)
+        if (existing.source.isEmpty && entry.source.isDefined)
+          mergedEntries(index) = ClassAndSourceFilesEntry(existing.binary.get, entry.source.get)
+      }
+      else {
+        indices(name) = count
+        mergedEntries += entry
+        count += 1
+      }
+    }
+    mergedEntries.toIndexedSeq
+  }
+
+  private def getDistinctEntries[EntryType <: ClassRepresentation](getEntries: ClassPath => Seq[EntryType]): Seq[EntryType] = {
+    val seenNames = collection.mutable.HashSet[String]()
+    val entriesBuffer = new ArrayBuffer[EntryType](1024)
+    for {
+      cp <- aggregates
+      entry <- getEntries(cp) if !seenNames.contains(entry.name)
+    } {
+      entriesBuffer += entry
+      seenNames += entry.name
+    }
+    entriesBuffer.toIndexedSeq
+  }
+}
+
+object AggregateClassPath {
+  def createAggregate(parts: ClassPath*): ClassPath = {
+    val elems = new ArrayBuffer[ClassPath]()
+    parts foreach {
+      case AggregateClassPath(ps) => elems ++= ps
+      case p => elems += p
+    }
+    if (elems.size == 1) elems.head
+    else AggregateClassPath(elems.toIndexedSeq)
+  }
+}

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package dotty.tools.dotc.classpath
+
+import scala.reflect.io.AbstractFile
+import dotty.tools.io.ClassRepresentation
+
+case class ClassPathEntries(packages: Seq[PackageEntry], classesAndSources: Seq[ClassRepresentation])
+
+object ClassPathEntries {
+  import scala.language.implicitConversions
+  // to have working unzip method
+  implicit def entry2Tuple(entry: ClassPathEntries): (Seq[PackageEntry], Seq[ClassRepresentation]) = (entry.packages, entry.classesAndSources)
+}
+
+trait ClassFileEntry extends ClassRepresentation {
+  def file: AbstractFile
+}
+
+trait SourceFileEntry extends ClassRepresentation {
+  def file: AbstractFile
+}
+
+trait PackageEntry {
+  def name: String
+}
+
+private[dotty] case class ClassFileEntryImpl(file: AbstractFile) extends ClassFileEntry {
+  override def name = FileUtils.stripClassExtension(file.name) // class name
+
+  override def binary: Option[AbstractFile] = Some(file)
+  override def source: Option[AbstractFile] = None
+}
+
+private[dotty] case class SourceFileEntryImpl(file: AbstractFile) extends SourceFileEntry {
+  override def name = FileUtils.stripSourceExtension(file.name)
+
+  override def binary: Option[AbstractFile] = None
+  override def source: Option[AbstractFile] = Some(file)
+}
+
+private[dotty] case class ClassAndSourceFilesEntry(classFile: AbstractFile, srcFile: AbstractFile) extends ClassRepresentation {
+  override def name = FileUtils.stripClassExtension(classFile.name)
+
+  override def binary: Option[AbstractFile] = Some(classFile)
+  override def source: Option[AbstractFile] = Some(srcFile)
+}
+
+private[dotty] case class PackageEntryImpl(name: String) extends PackageEntry
+
+private[dotty] trait NoSourcePaths {
+  def asSourcePathString: String = ""
+  private[dotty] def sources(inPackage: String): Seq[SourceFileEntry] = Seq.empty
+}
+
+private[dotty] trait NoClassPaths {
+  def findClassFile(className: String): Option[AbstractFile] = None
+  private[dotty] def classes(inPackage: String): Seq[ClassFileEntry] = Seq.empty
+}

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package dotty.tools.dotc.classpath
+
+import scala.reflect.io.{AbstractFile, VirtualDirectory}
+import scala.reflect.io.Path.string2path
+import dotty.tools.dotc.config.Settings
+import FileUtils.AbstractFileOps
+import dotty.tools.io.ClassPath
+import dotty.tools.dotc.core.Contexts.Context
+
+/**
+ * Provides factory methods for classpath. When creating classpath instances for a given path,
+ * it uses proper type of classpath depending on a types of particular files containing sources or classes.
+ */
+class ClassPathFactory {
+  /**
+    * Create a new classpath based on the abstract file.
+    */
+  def newClassPath(file: AbstractFile)(implicit ctx: Context): ClassPath = ClassPathFactory.newClassPath(file)
+
+  /**
+    * Creators for sub classpaths which preserve this context.
+    */
+  def sourcesInPath(path: String)(implicit ctx: Context): List[ClassPath] =
+    for {
+      file <- expandPath(path, expandStar = false)
+      dir <- Option(AbstractFile getDirectory file)
+    } yield createSourcePath(dir)
+
+
+  def expandPath(path: String, expandStar: Boolean = true): List[String] = dotty.tools.io.ClassPath.expandPath(path, expandStar)
+
+  def expandDir(extdir: String): List[String] = dotty.tools.io.ClassPath.expandDir(extdir)
+
+  def contentsOfDirsInPath(path: String)(implicit ctx: Context): List[ClassPath] =
+    for {
+      dir <- expandPath(path, expandStar = false)
+      name <- expandDir(dir)
+      entry <- Option(AbstractFile.getDirectory(name))
+    } yield newClassPath(entry)
+
+  def classesInExpandedPath(path: String)(implicit ctx: Context): IndexedSeq[ClassPath] =
+    classesInPathImpl(path, expand = true).toIndexedSeq
+
+  def classesInPath(path: String)(implicit ctx: Context) = classesInPathImpl(path, expand = false)
+
+  def classesInManifest(useManifestClassPath: Boolean)(implicit ctx: Context) =
+    if (useManifestClassPath) dotty.tools.io.ClassPath.manifests.map(url => newClassPath(AbstractFile getResources url))
+    else Nil
+
+  // Internal
+  protected def classesInPathImpl(path: String, expand: Boolean)(implicit ctx: Context) =
+    for {
+      file <- expandPath(path, expand)
+      dir <- {
+        def asImage = if (file.endsWith(".jimage")) Some(AbstractFile.getFile(file)) else None
+        Option(AbstractFile.getDirectory(file)).orElse(asImage)
+      }
+    } yield newClassPath(dir)
+
+  private def createSourcePath(file: AbstractFile)(implicit ctx: Context): ClassPath =
+    if (file.isJarOrZip)
+      ZipAndJarSourcePathFactory.create(file)
+    else if (file.isDirectory)
+      new DirectorySourcePath(file.file)
+    else
+      sys.error(s"Unsupported sourcepath element: $file")
+}
+
+object ClassPathFactory {
+  def newClassPath(file: AbstractFile)(implicit ctx: Context): ClassPath = file match {
+    case vd: VirtualDirectory => VirtualDirectoryClassPath(vd)
+    case _ =>
+      if (file.isJarOrZip)
+        ZipAndJarClassPathFactory.create(file)
+      else if (file.isDirectory)
+        new DirectoryClassPath(file.file)
+      else
+        sys.error(s"Unsupported classpath element: $file")
+  }
+}

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -99,21 +99,23 @@ trait JFileDirectoryLookup[FileEntryType <: ClassRepresentation] extends Directo
       case None => dir.listFiles()
     }
 
-    // Sort by file name for stable order of directory .class entries in package scope.
-    // This gives stable results ordering of base type sequences for unrelated classes
-    // with the same base type depth.
-    //
-    // Notably, this will stably infer`Product with Serializable`
-    // as the type of `case class C(); case class D(); List(C(), D()).head`, rather than the opposite order.
-    // On Mac, the HFS performs this sorting transparently, but on Linux the order is unspecified.
-    //
-    // Note this behaviour can be enabled in javac with `javac -XDsortfiles`, but that's only
-    // intended to improve determinism of the compiler for compiler hackers.
-    java.util.Arrays.sort(listing,
-      new java.util.Comparator[File] {
-        def compare(o1: File, o2: File) = o1.getName.compareTo(o2.getName)
-      })
-    listing
+    if (listing != null) {
+      // Sort by file name for stable order of directory .class entries in package scope.
+      // This gives stable results ordering of base type sequences for unrelated classes
+      // with the same base type depth.
+      //
+      // Notably, this will stably infer`Product with Serializable`
+      // as the type of `case class C(); case class D(); List(C(), D()).head`, rather than the opposite order.
+      // On Mac, the HFS performs this sorting transparently, but on Linux the order is unspecified.
+      //
+      // Note this behaviour can be enabled in javac with `javac -XDsortfiles`, but that's only
+      // intended to improve determinism of the compiler for compiler hackers.
+      java.util.Arrays.sort(listing,
+        new java.util.Comparator[File] {
+          def compare(o1: File, o2: File) = o1.getName.compareTo(o2.getName)
+        })
+      listing
+    } else Array()
   }
   protected def getName(f: File): String = f.getName
   protected def toAbstractFile(f: File): AbstractFile = new PlainFile(new scala.reflect.io.File(f))

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package dotty.tools.dotc.classpath
+
+import java.io.File
+import java.net.{URI, URL}
+import java.nio.file.{FileSystems, Files, SimpleFileVisitor}
+import java.util.function.IntFunction
+import java.util
+import java.util.Comparator
+
+import scala.reflect.io.{AbstractFile, PlainFile}
+import dotty.tools.io.{ClassPath, ClassRepresentation, PlainNioFile}
+import FileUtils._
+import scala.collection.JavaConverters._
+
+/**
+ * A trait allowing to look for classpath entries in directories. It provides common logic for
+ * classes handling class and source files.
+ * It makes use of the fact that in the case of nested directories it's easy to find a file
+ * when we have a name of a package.
+ * It abstracts over the file representation to work with both JFile and AbstractFile.
+ */
+trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
+  type F
+
+  val dir: F
+
+  protected def emptyFiles: Array[F] // avoids reifying ClassTag[F]
+  protected def getSubDir(dirName: String): Option[F]
+  protected def listChildren(dir: F, filter: Option[F => Boolean] = None): Array[F]
+  protected def getName(f: F): String
+  protected def toAbstractFile(f: F): AbstractFile
+  protected def isPackage(f: F): Boolean
+
+  protected def createFileEntry(file: AbstractFile): FileEntryType
+  protected def isMatchingFile(f: F): Boolean
+
+  private def getDirectory(forPackage: String): Option[F] = {
+    if (forPackage == ClassPath.RootPackage) {
+      Some(dir)
+    } else {
+      val packageDirName = FileUtils.dirPath(forPackage)
+      getSubDir(packageDirName)
+    }
+  }
+
+  private[dotty] def packages(inPackage: String): Seq[PackageEntry] = {
+    val dirForPackage = getDirectory(inPackage)
+    val nestedDirs: Array[F] = dirForPackage match {
+      case None => emptyFiles
+      case Some(directory) => listChildren(directory, Some(isPackage))
+    }
+    val prefix = PackageNameUtils.packagePrefix(inPackage)
+    nestedDirs.map(f => PackageEntryImpl(prefix + getName(f)))
+  }
+
+  protected def files(inPackage: String): Seq[FileEntryType] = {
+    val dirForPackage = getDirectory(inPackage)
+    val files: Array[F] = dirForPackage match {
+      case None => emptyFiles
+      case Some(directory) => listChildren(directory, Some(isMatchingFile))
+    }
+    files.map(f => createFileEntry(toAbstractFile(f)))
+  }
+
+  private[dotty] def list(inPackage: String): ClassPathEntries = {
+    val dirForPackage = getDirectory(inPackage)
+    val files: Array[F] = dirForPackage match {
+      case None => emptyFiles
+      case Some(directory) => listChildren(directory)
+    }
+    val packagePrefix = PackageNameUtils.packagePrefix(inPackage)
+    val packageBuf = collection.mutable.ArrayBuffer.empty[PackageEntry]
+    val fileBuf = collection.mutable.ArrayBuffer.empty[FileEntryType]
+    for (file <- files) {
+      if (isPackage(file))
+        packageBuf += PackageEntryImpl(packagePrefix + getName(file))
+      else if (isMatchingFile(file))
+        fileBuf += createFileEntry(toAbstractFile(file))
+    }
+    ClassPathEntries(packageBuf, fileBuf)
+  }
+}
+
+trait JFileDirectoryLookup[FileEntryType <: ClassRepresentation] extends DirectoryLookup[FileEntryType] {
+  type F = File
+
+  protected def emptyFiles: Array[File] = Array.empty
+  protected def getSubDir(packageDirName: String): Option[File] = {
+    val packageDir = new File(dir, packageDirName)
+    if (packageDir.exists && packageDir.isDirectory) Some(packageDir)
+    else None
+  }
+  protected def listChildren(dir: File, filter: Option[File => Boolean]): Array[File] = {
+    val listing = filter match {
+      case Some(f) => dir.listFiles(mkFileFilter(f))
+      case None => dir.listFiles()
+    }
+
+    // Sort by file name for stable order of directory .class entries in package scope.
+    // This gives stable results ordering of base type sequences for unrelated classes
+    // with the same base type depth.
+    //
+    // Notably, this will stably infer`Product with Serializable`
+    // as the type of `case class C(); case class D(); List(C(), D()).head`, rather than the opposite order.
+    // On Mac, the HFS performs this sorting transparently, but on Linux the order is unspecified.
+    //
+    // Note this behaviour can be enabled in javac with `javac -XDsortfiles`, but that's only
+    // intended to improve determinism of the compiler for compiler hackers.
+    java.util.Arrays.sort(listing,
+      new java.util.Comparator[File] {
+        def compare(o1: File, o2: File) = o1.getName.compareTo(o2.getName)
+      })
+    listing
+  }
+  protected def getName(f: File): String = f.getName
+  protected def toAbstractFile(f: File): AbstractFile = new PlainFile(new scala.reflect.io.File(f))
+  protected def isPackage(f: File): Boolean = f.isPackage
+
+  assert(dir != null, "Directory file in DirectoryFileLookup cannot be null")
+
+  def asURLs: Seq[URL] = Seq(dir.toURI.toURL)
+  def asClassPathStrings: Seq[String] = Seq(dir.getPath)
+}
+
+object JrtClassPath {
+  import java.nio.file._, java.net.URI
+  def apply(): Option[ClassPath] = {
+    try {
+      val fs = FileSystems.getFileSystem(URI.create("jrt:/"))
+      Some(new JrtClassPath(fs))
+    } catch {
+      case _: ProviderNotFoundException | _: FileSystemNotFoundException =>
+        None
+    }
+  }
+}
+
+/**
+  * Implementation `ClassPath` based on the JDK 9 encapsulated runtime modules (JEP-220)
+  *
+  * https://bugs.openjdk.java.net/browse/JDK-8066492 is the most up to date reference
+  * for the structure of the jrt:// filesystem.
+  *
+  * The implementation assumes that no classes exist in the empty package.
+  */
+final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with NoSourcePaths {
+  import java.nio.file.Path, java.nio.file._
+  type F = Path
+  private val dir: Path = fs.getPath("/packages")
+
+  // e.g. "java.lang" -> Seq("/modules/java.base")
+  private val packageToModuleBases: Map[String, Seq[Path]] = {
+    val ps = Files.newDirectoryStream(dir).iterator().asScala
+    def lookup(pack: Path): Seq[Path] = {
+      Files.list(pack).iterator().asScala.map(l => if (Files.isSymbolicLink(l)) Files.readSymbolicLink(l) else l).toList
+    }
+    ps.map(p => (p.toString.stripPrefix("/packages/"), lookup(p))).toMap
+  }
+
+  override private[dotty] def packages(inPackage: String): Seq[PackageEntry] = {
+    def matches(packageDottedName: String) =
+      if (packageDottedName.contains("."))
+        packageOf(packageDottedName) == inPackage
+      else inPackage == ""
+    packageToModuleBases.keysIterator.filter(matches).map(PackageEntryImpl(_)).toVector
+  }
+  private[dotty] def classes(inPackage: String): Seq[ClassFileEntry] = {
+    if (inPackage == "") Nil
+    else {
+      packageToModuleBases.getOrElse(inPackage, Nil).flatMap(x =>
+        Files.list(x.resolve(inPackage.replace('.', '/'))).iterator().asScala.filter(_.getFileName.toString.endsWith(".class"))).map(x =>
+        ClassFileEntryImpl(new PlainNioFile(x))).toVector
+    }
+  }
+
+  override private[dotty] def list(inPackage: String): ClassPathEntries =
+    if (inPackage == "") ClassPathEntries(packages(inPackage), Nil)
+    else ClassPathEntries(packages(inPackage), classes(inPackage))
+
+  def asURLs: Seq[URL] = Seq(dir.toUri.toURL)
+  // We don't yet have a scheme to represent the JDK modules in our `-classpath`.
+  // java models them as entries in the new "module path", we'll probably need to follow this.
+  def asClassPathStrings: Seq[String] = Nil
+
+  def findClassFile(className: String): Option[AbstractFile] = {
+    if (!className.contains(".")) None
+    else {
+      val inPackage = packageOf(className)
+      packageToModuleBases.getOrElse(inPackage, Nil).iterator.flatMap{x =>
+        val file = x.resolve(className.replace('.', '/') + ".class")
+        if (Files.exists(file)) new PlainNioFile(file) :: Nil else Nil
+      }.take(1).toList.headOption
+    }
+  }
+  private def packageOf(dottedClassName: String): String =
+    dottedClassName.substring(0, dottedClassName.lastIndexOf("."))
+}
+
+case class DirectoryClassPath(dir: File) extends JFileDirectoryLookup[ClassFileEntryImpl] with NoSourcePaths {
+  override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className) map ClassFileEntryImpl
+
+  def findClassFile(className: String): Option[AbstractFile] = {
+    val relativePath = FileUtils.dirPath(className)
+    val classFile = new File(s"$dir/$relativePath.class")
+    if (classFile.exists) {
+      val wrappedClassFile = new scala.reflect.io.File(classFile)
+      val abstractClassFile = new PlainFile(wrappedClassFile)
+      Some(abstractClassFile)
+    } else None
+  }
+
+  protected def createFileEntry(file: AbstractFile): ClassFileEntryImpl = ClassFileEntryImpl(file)
+  protected def isMatchingFile(f: File): Boolean = f.isClass
+
+  private[dotty] def classes(inPackage: String): Seq[ClassFileEntry] = files(inPackage)
+}
+
+case class DirectorySourcePath(dir: File) extends JFileDirectoryLookup[SourceFileEntryImpl] with NoClassPaths {
+  def asSourcePathString: String = asClassPathString
+
+  protected def createFileEntry(file: AbstractFile): SourceFileEntryImpl = SourceFileEntryImpl(file)
+  protected def isMatchingFile(f: File): Boolean = endsScalaOrJava(f.getName)
+
+  override def findClass(className: String): Option[ClassRepresentation] = findSourceFile(className) map SourceFileEntryImpl
+
+  private def findSourceFile(className: String): Option[AbstractFile] = {
+    val relativePath = FileUtils.dirPath(className)
+    val sourceFile = Stream("scala", "java")
+      .map(ext => new File(s"$dir/$relativePath.$ext"))
+      .collectFirst { case file if file.exists() => file }
+
+    sourceFile.map { file =>
+      val wrappedSourceFile = new scala.reflect.io.File(file)
+      val abstractSourceFile = new PlainFile(wrappedSourceFile)
+      abstractSourceFile
+    }
+  }
+
+  private[dotty] def sources(inPackage: String): Seq[SourceFileEntry] = files(inPackage)
+}

--- a/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package dotty.tools.dotc.classpath
+
+import java.io.{File => JFile, FileFilter}
+import java.net.URL
+import scala.reflect.internal.FatalError
+import scala.reflect.io.AbstractFile
+
+/**
+ * Common methods related to Java files and abstract files used in the context of classpath
+ */
+object FileUtils {
+  implicit class AbstractFileOps(val file: AbstractFile) extends AnyVal {
+    def isPackage: Boolean = file.isDirectory && mayBeValidPackage(file.name)
+
+    def isClass: Boolean = !file.isDirectory && file.hasExtension("class") && !file.name.endsWith("$class.class")
+      // FIXME: drop last condition when we stop being compatible with Scala 2.11
+
+    def isScalaOrJavaSource: Boolean = !file.isDirectory && (file.hasExtension("scala") || file.hasExtension("java"))
+
+    // TODO do we need to check also other files using ZipMagicNumber like in scala.tools.nsc.io.Jar.isJarOrZip?
+    def isJarOrZip: Boolean = file.hasExtension("jar") || file.hasExtension("zip")
+
+    /**
+     * Safe method returning a sequence containing one URL representing this file, when underlying file exists,
+     * and returning given default value in other case
+     */
+    def toURLs(default: => Seq[URL] = Seq.empty): Seq[URL] = if (file.file == null) default else Seq(file.toURL)
+  }
+
+  implicit class FileOps(val file: JFile) extends AnyVal {
+    def isPackage: Boolean = file.isDirectory && mayBeValidPackage(file.getName)
+
+    def isClass: Boolean = file.isFile && file.getName.endsWith(".class") && !file.getName.endsWith("$class.class")
+      // FIXME: drop last condition when we stop being compatible with Scala 2.11
+  }
+
+  def stripSourceExtension(fileName: String): String = {
+    if (endsScala(fileName)) stripClassExtension(fileName)
+    else if (endsJava(fileName)) stripJavaExtension(fileName)
+    else throw new FatalError("Unexpected source file ending: " + fileName)
+  }
+
+  def dirPath(forPackage: String) = forPackage.replace('.', '/')
+
+  def endsClass(fileName: String): Boolean =
+    fileName.length > 6 && fileName.substring(fileName.length - 6) == ".class"
+
+  def endsScalaOrJava(fileName: String): Boolean =
+    endsScala(fileName) || endsJava(fileName)
+
+  def endsJava(fileName: String): Boolean =
+    fileName.length > 5 && fileName.substring(fileName.length - 5) == ".java"
+
+  def endsScala(fileName: String): Boolean =
+    fileName.length > 6 && fileName.substring(fileName.length - 6) == ".scala"
+
+  def stripClassExtension(fileName: String): String =
+    fileName.substring(0, fileName.length - 6) // equivalent of fileName.length - ".class".length
+
+  def stripJavaExtension(fileName: String): String =
+    fileName.substring(0, fileName.length - 5)
+
+  // probably it should match a pattern like [a-z_]{1}[a-z0-9_]* but it cannot be changed
+  // because then some tests in partest don't pass
+  def mayBeValidPackage(dirName: String): Boolean =
+    (dirName != "META-INF") && (dirName != "") && (dirName.charAt(0) != '.')
+
+  def mkFileFilter(f: JFile => Boolean) = new FileFilter {
+    def accept(pathname: JFile): Boolean = f(pathname)
+  }
+}

--- a/compiler/src/dotty/tools/dotc/classpath/PackageNameUtils.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/PackageNameUtils.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package dotty.tools.dotc.classpath
+
+import dotty.tools.io.ClassPath.RootPackage
+
+/**
+ * Common methods related to package names represented as String
+ */
+object PackageNameUtils {
+
+  /**
+   * @param fullClassName full class name with package
+   * @return (package, simple class name)
+   */
+  def separatePkgAndClassNames(fullClassName: String): (String, String) = {
+    val lastDotIndex = fullClassName.lastIndexOf('.')
+    if (lastDotIndex == -1)
+      (RootPackage, fullClassName)
+    else
+      (fullClassName.substring(0, lastDotIndex), fullClassName.substring(lastDotIndex + 1))
+  }
+
+  def packagePrefix(inPackage: String): String = if (inPackage == RootPackage) "" else inPackage + "."
+}

--- a/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
@@ -1,0 +1,52 @@
+package dotty.tools.dotc.classpath
+
+import dotty.tools.io.ClassRepresentation
+import scala.reflect.io.{AbstractFile, Path, PlainFile, VirtualDirectory}
+import FileUtils._
+import java.net.URL
+
+import scala.reflect.internal.util.AbstractFileClassLoader
+import dotty.tools.io.ClassPath
+
+case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath with DirectoryLookup[ClassFileEntryImpl] with NoSourcePaths {
+  type F = AbstractFile
+
+  // From AbstractFileClassLoader
+  private final def lookupPath(base: AbstractFile)(pathParts: Seq[String], directory: Boolean): AbstractFile = {
+    var file: AbstractFile = base
+    for (dirPart <- pathParts.init) {
+      file = file.lookupName(dirPart, directory = true)
+      if (file == null)
+        return null
+    }
+
+    file.lookupName(pathParts.last, directory = directory)
+  }
+
+  protected def emptyFiles: Array[AbstractFile] = Array.empty
+  protected def getSubDir(packageDirName: String): Option[AbstractFile] =
+    Option(lookupPath(dir)(packageDirName.split('/'), directory = true))
+  protected def listChildren(dir: AbstractFile, filter: Option[AbstractFile => Boolean] = None): Array[F] = filter match {
+    case Some(f) => dir.iterator.filter(f).toArray
+    case _ => dir.toArray
+  }
+  def getName(f: AbstractFile): String = f.name
+  def toAbstractFile(f: AbstractFile): AbstractFile = f
+  def isPackage(f: AbstractFile): Boolean = f.isPackage
+
+  // mimic the behavior of the old nsc.util.DirectoryClassPath
+  def asURLs: Seq[URL] = Seq(new URL(dir.name))
+  def asClassPathStrings: Seq[String] = Seq(dir.path)
+
+  override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className) map ClassFileEntryImpl
+
+  def findClassFile(className: String): Option[AbstractFile] = {
+    val relativePath = FileUtils.dirPath(className) + ".class"
+    Option(lookupPath(dir)(relativePath split '/', directory = false))
+  }
+
+  private[dotty] def classes(inPackage: String): Seq[ClassFileEntry] = files(inPackage)
+
+  protected def createFileEntry(file: AbstractFile): ClassFileEntryImpl = ClassFileEntryImpl(file)
+  protected def isMatchingFile(f: AbstractFile): Boolean = f.isClass
+}

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package dotty.tools.dotc.classpath
+
+import java.io.File
+import java.net.URL
+import scala.annotation.tailrec
+import scala.reflect.io.{AbstractFile, FileZipArchive, ManifestResources}
+import dotty.tools.io.ClassPath
+import dotty.tools.dotc.config.Settings
+import dotty.tools.dotc.core.Contexts.Context
+import FileUtils._
+
+/**
+ * A trait providing an optional cache for classpath entries obtained from zip and jar files.
+ * It's possible to create such a cache assuming that entries in such files won't change (at
+ * least will be the same each time we'll load classpath during the lifetime of JVM process)
+ * - unlike class and source files in directories, which can be modified and recompiled.
+ * It allows us to e.g. reduce significantly memory used by PresentationCompilers in Scala IDE
+ * when there are a lot of projects having a lot of common dependencies.
+ */
+sealed trait ZipAndJarFileLookupFactory {
+  private val cache = collection.mutable.Map.empty[AbstractFile, ClassPath]
+
+  def create(zipFile: AbstractFile)(implicit ctx: Context): ClassPath = {
+    if (ctx.settings.YdisableFlatCpCaching.value) createForZipFile(zipFile)
+    else createUsingCache(zipFile)
+  }
+
+  protected def createForZipFile(zipFile: AbstractFile): ClassPath
+
+  private def createUsingCache(zipFile: AbstractFile)(implicit ctx: Context): ClassPath = cache.synchronized {
+    def newClassPathInstance = {
+      if (ctx.settings.verbose.value || ctx.settings.Ylogcp.value)
+        println(s"$zipFile is not yet in the classpath cache")
+      createForZipFile(zipFile)
+    }
+    cache.getOrElseUpdate(zipFile, newClassPathInstance)
+  }
+}
+
+/**
+ * Manages creation of classpath for class files placed in zip and jar files.
+ * It should be the only way of creating them as it provides caching.
+ */
+object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
+  private case class ZipArchiveClassPath(zipFile: File)
+    extends ZipArchiveFileLookup[ClassFileEntryImpl]
+    with NoSourcePaths {
+
+    override def findClassFile(className: String): Option[AbstractFile] = {
+      val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
+      classes(pkg).find(_.name == simpleClassName).map(_.file)
+    }
+
+    override private[dotty] def classes(inPackage: String): Seq[ClassFileEntry] = files(inPackage)
+
+    override protected def createFileEntry(file: FileZipArchive#Entry): ClassFileEntryImpl = ClassFileEntryImpl(file)
+    override protected def isRequiredFileType(file: AbstractFile): Boolean = file.isClass
+  }
+
+  /**
+   * This type of classpath is closely related to the support for JSR-223.
+   * Its usage can be observed e.g. when running:
+   * jrunscript -classpath scala-compiler.jar;scala-reflect.jar;scala-library.jar -l scala
+   * with a particularly prepared scala-library.jar. It should have all classes listed in the manifest like e.g. this entry:
+   * Name: scala/Function2$mcFJD$sp.class
+   */
+  private case class ManifestResourcesClassPath(file: ManifestResources) extends ClassPath with NoSourcePaths {
+    override def findClassFile(className: String): Option[AbstractFile] = {
+      val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
+      classes(pkg).find(_.name == simpleClassName).map(_.file)
+    }
+
+    override def asClassPathStrings: Seq[String] = Seq(file.path)
+
+    override def asURLs: Seq[URL] = file.toURLs()
+
+    import ManifestResourcesClassPath.PackageFileInfo
+    import ManifestResourcesClassPath.PackageInfo
+
+    /**
+     * A cache mapping package name to abstract file for package directory and subpackages of given package.
+     *
+     * ManifestResources can iterate through the collections of entries from e.g. remote jar file.
+     * We can't just specify the path to the concrete directory etc. so we can't just 'jump' into
+     * given package, when it's needed. On the other hand we can iterate over entries to get
+     * AbstractFiles, iterate over entries of these files etc.
+     *
+     * Instead of traversing a tree of AbstractFiles once and caching all entries or traversing each time,
+     * when we need subpackages of a given package or its classes, we traverse once and cache only packages.
+     * Classes for given package can be then easily loaded when they are needed.
+     */
+    private lazy val cachedPackages: collection.mutable.HashMap[String, PackageFileInfo] = {
+      val packages = collection.mutable.HashMap[String, PackageFileInfo]()
+
+      def getSubpackages(dir: AbstractFile): List[AbstractFile] =
+        (for (file <- dir if file.isPackage) yield file)(collection.breakOut)
+
+      @tailrec
+      def traverse(packagePrefix: String,
+                   filesForPrefix: List[AbstractFile],
+                   subpackagesQueue: collection.mutable.Queue[PackageInfo]): Unit = filesForPrefix match {
+        case pkgFile :: remainingFiles =>
+          val subpackages = getSubpackages(pkgFile)
+          val fullPkgName = packagePrefix + pkgFile.name
+          packages.put(fullPkgName, PackageFileInfo(pkgFile, subpackages))
+          val newPackagePrefix = fullPkgName + "."
+          subpackagesQueue.enqueue(PackageInfo(newPackagePrefix, subpackages))
+          traverse(packagePrefix, remainingFiles, subpackagesQueue)
+        case Nil if subpackagesQueue.nonEmpty =>
+          val PackageInfo(packagePrefix, filesForPrefix) = subpackagesQueue.dequeue()
+          traverse(packagePrefix, filesForPrefix, subpackagesQueue)
+        case _ =>
+      }
+
+      val subpackages = getSubpackages(file)
+      packages.put(ClassPath.RootPackage, PackageFileInfo(file, subpackages))
+      traverse(ClassPath.RootPackage, subpackages, collection.mutable.Queue())
+      packages
+    }
+
+    override private[dotty] def packages(inPackage: String): Seq[PackageEntry] = cachedPackages.get(inPackage) match {
+      case None => Seq.empty
+      case Some(PackageFileInfo(_, subpackages)) =>
+        val prefix = PackageNameUtils.packagePrefix(inPackage)
+        subpackages.map(packageFile => PackageEntryImpl(prefix + packageFile.name))
+    }
+
+    override private[dotty] def classes(inPackage: String): Seq[ClassFileEntry] = cachedPackages.get(inPackage) match {
+      case None => Seq.empty
+      case Some(PackageFileInfo(pkg, _)) =>
+        (for (file <- pkg if file.isClass) yield ClassFileEntryImpl(file))(collection.breakOut)
+    }
+
+    override private[dotty] def list(inPackage: String): ClassPathEntries = ClassPathEntries(packages(inPackage), classes(inPackage))
+  }
+
+  private object ManifestResourcesClassPath {
+    case class PackageFileInfo(packageFile: AbstractFile, subpackages: Seq[AbstractFile])
+    case class PackageInfo(packageName: String, subpackages: List[AbstractFile])
+  }
+
+  override protected def createForZipFile(zipFile: AbstractFile): ClassPath =
+    if (zipFile.file == null) createWithoutUnderlyingFile(zipFile)
+    else ZipArchiveClassPath(zipFile.file)
+
+  private def createWithoutUnderlyingFile(zipFile: AbstractFile) = zipFile match {
+    case manifestRes: ManifestResources =>
+      ManifestResourcesClassPath(manifestRes)
+    case _ =>
+      val errorMsg = s"Abstract files which don't have an underlying file and are not ManifestResources are not supported. There was $zipFile"
+      throw new IllegalArgumentException(errorMsg)
+  }
+}
+
+/**
+ * Manages creation of classpath for source files placed in zip and jar files.
+ * It should be the only way of creating them as it provides caching.
+ */
+object ZipAndJarSourcePathFactory extends ZipAndJarFileLookupFactory {
+  private case class ZipArchiveSourcePath(zipFile: File)
+    extends ZipArchiveFileLookup[SourceFileEntryImpl]
+    with NoClassPaths {
+
+    override def asSourcePathString: String = asClassPathString
+
+    override private[dotty] def sources(inPackage: String): Seq[SourceFileEntry] = files(inPackage)
+
+    override protected def createFileEntry(file: FileZipArchive#Entry): SourceFileEntryImpl = SourceFileEntryImpl(file)
+    override protected def isRequiredFileType(file: AbstractFile): Boolean = file.isScalaOrJavaSource
+  }
+
+  override protected def createForZipFile(zipFile: AbstractFile): ClassPath = ZipArchiveSourcePath(zipFile.file)
+}

--- a/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package dotty.tools.dotc.classpath
+
+import java.io.File
+import java.net.URL
+import scala.collection.Seq
+import scala.reflect.io.AbstractFile
+import scala.reflect.io.FileZipArchive
+import FileUtils.AbstractFileOps
+import dotty.tools.io.{ClassPath, ClassRepresentation}
+
+/**
+ * A trait allowing to look for classpath entries of given type in zip and jar files.
+ * It provides common logic for classes handling class and source files.
+ * It's aware of things like e.g. META-INF directory which is correctly skipped.
+ */
+trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
+  val zipFile: File
+
+  assert(zipFile != null, "Zip file in ZipArchiveFileLookup cannot be null")
+
+  override def asURLs: Seq[URL] = Seq(zipFile.toURI.toURL)
+  override def asClassPathStrings: Seq[String] = Seq(zipFile.getPath)
+
+  private val archive = new FileZipArchive(zipFile)
+
+  override private[dotty] def packages(inPackage: String): Seq[PackageEntry] = {
+    val prefix = PackageNameUtils.packagePrefix(inPackage)
+    for {
+      dirEntry <- findDirEntry(inPackage).toSeq
+      entry <- dirEntry.iterator if entry.isPackage
+    } yield PackageEntryImpl(prefix + entry.name)
+  }
+
+  protected def files(inPackage: String): Seq[FileEntryType] =
+    for {
+      dirEntry <- findDirEntry(inPackage).toSeq
+      entry <- dirEntry.iterator if isRequiredFileType(entry)
+    } yield createFileEntry(entry)
+
+  override private[dotty] def list(inPackage: String): ClassPathEntries = {
+    val foundDirEntry = findDirEntry(inPackage)
+
+    foundDirEntry map { dirEntry =>
+      val pkgBuf = collection.mutable.ArrayBuffer.empty[PackageEntry]
+      val fileBuf = collection.mutable.ArrayBuffer.empty[FileEntryType]
+      val prefix = PackageNameUtils.packagePrefix(inPackage)
+
+      for (entry <- dirEntry.iterator) {
+        if (entry.isPackage)
+          pkgBuf += PackageEntryImpl(prefix + entry.name)
+        else if (isRequiredFileType(entry))
+          fileBuf += createFileEntry(entry)
+      }
+      ClassPathEntries(pkgBuf, fileBuf)
+    } getOrElse ClassPathEntries(Seq.empty, Seq.empty)
+  }
+
+  private def findDirEntry(pkg: String): Option[archive.DirEntry] = {
+    val dirName = s"${FileUtils.dirPath(pkg)}/"
+    archive.allDirs.get(dirName)
+  }
+
+  protected def createFileEntry(file: FileZipArchive#Entry): FileEntryType
+  protected def isRequiredFileType(file: AbstractFile): Boolean
+}

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -73,6 +73,8 @@ class ScalaSettings extends Settings.SettingGroup {
   val log = PhasesSetting("-Ylog", "Log operations during")
   val emitTasty = BooleanSetting("-YemitTasty", "Generate tasty in separate *.tasty file.")
   val Ylogcp = BooleanSetting("-Ylog-classpath", "Output information about what classpath is being applied.")
+  val YdisableFlatCpCaching  = BooleanSetting("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
+
   val YnoImports = BooleanSetting("-Yno-imports", "Compile without importing scala.*, java.lang.*, or Predef.")
   val YnoPredef = BooleanSetting("-Yno-predef", "Compile without importing Predef.")
   val Yskip = PhasesSetting("-Yskip", "Skip")

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -665,7 +665,7 @@ class ClassfileParser(
     for (entry <- innerClasses.values) {
       // create a new class member for immediate inner classes
       if (entry.outerName == currentClassName) {
-        val file = ctx.platform.classPath.findBinaryFile(entry.externalName.toString) getOrElse {
+        val file = ctx.platform.classPath.findClassFile(entry.externalName.toString) getOrElse {
           throw new AssertionError(entry.externalName)
         }
         enterClassAndModule(entry, file, entry.jflags)

--- a/compiler/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
+++ b/compiler/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
@@ -138,7 +138,7 @@ class CompilingInterpreter(
   private val prevRequests = new ArrayBuffer[Request]()
 
   /** the compiler's classpath, as URL's */
-  val compilerClasspath: List[URL] = ictx.platform.classPath(ictx).asURLs
+  val compilerClasspath: Seq[URL] = ictx.platform.classPath(ictx).asURLs
 
   /* A single class loader is used for all commands interpreted by this Interpreter.
      It would also be possible to create a new class loader for each command

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -1,78 +1,95 @@
 /* NSC -- new Scala compiler
- * Copyright 2006-2012 LAMP/EPFL
+ * Copyright 2006-2013 LAMP/EPFL
  * @author  Martin Odersky
  */
+
 
 package dotty.tools
 package io
 
-import java.net.URL
-import scala.collection.{ mutable, immutable }
-import dotc.core.Decorators.StringDecorator
-import File.pathSeparator
 import java.net.MalformedURLException
-import Jar.isJarOrZip
-import ClassPath._
-import scala.Option.option2Iterable
-import scala.reflect.io.Path.string2path
-import language.postfixOps
+import java.net.URL
+import java.util.regex.PatternSyntaxException
 
-/** <p>
- *    This module provides star expansion of '-classpath' option arguments, behaves the same as
- *    java, see [http://java.sun.com/javase/6/docs/technotes/tools/windows/classpath.html]
- *  </p>
- *
- *  @author Stepan Koltsov
- */
+import File.pathSeparator
+import Jar.isJarOrZip
+
+/**
+  * A representation of the compiler's class- or sourcepath.
+  */
+trait ClassPath {
+  import dotty.tools.dotc.classpath._
+  def asURLs: Seq[URL]
+
+  /** Empty string represents root package */
+  private[dotty] def packages(inPackage: String): Seq[PackageEntry]
+  private[dotty] def classes(inPackage: String): Seq[ClassFileEntry]
+  private[dotty] def sources(inPackage: String): Seq[SourceFileEntry]
+
+  /** Allows to get entries for packages and classes merged with sources possibly in one pass. */
+  private[dotty] def list(inPackage: String): ClassPathEntries
+
+  /**
+    * It returns both classes from class file and source files (as our base ClassRepresentation).
+    * So note that it's not so strictly related to findClassFile.
+    */
+  def findClass(className: String): Option[ClassRepresentation] = {
+    // A default implementation which should be overridden, if we can create the more efficient
+    // solution for a given type of ClassPath
+    val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
+
+    val foundClassFromClassFiles = classes(pkg).find(_.name == simpleClassName)
+    def findClassInSources = sources(pkg).find(_.name == simpleClassName)
+
+    foundClassFromClassFiles orElse findClassInSources
+  }
+  def findClassFile(className: String): Option[AbstractFile]
+
+  def asClassPathStrings: Seq[String]
+
+  /** The whole classpath in the form of one String.
+    */
+  def asClassPathString: String = ClassPath.join(asClassPathStrings: _*)
+  // for compatibility purposes
+  @deprecated("use asClassPathString instead of this one", "2.11.5")
+  def asClasspathString: String = asClassPathString
+
+  /** The whole sourcepath in the form of one String.
+    */
+  def asSourcePathString: String
+}
+
 object ClassPath {
+  val RootPackage = ""
 
   /** Expand single path entry */
   private def expandS(pattern: String): List[String] = {
     val wildSuffix = File.separator + "*"
 
-    /** Get all subdirectories, jars, zips out of a directory. */
-    def lsDir(dir: Directory, filt: String => Boolean = _ => true) = {
-      val files = synchronized(dir.list)
-      files filter (x => filt(x.name) && (x.isDirectory || isJarOrZip(x))) map (_.path) toList
-    }
-
-    def basedir(s: String) =
-      if (s contains File.separator) s.substring(0, s.lastIndexOf(File.separator))
-      else "."
+    /* Get all subdirectories, jars, zips out of a directory. */
+    def lsDir(dir: Directory, filt: String => Boolean = _ => true) =
+      dir.list.filter(x => filt(x.name) && (x.isDirectory || isJarOrZip(x))).map(_.path).toList
 
     if (pattern == "*") lsDir(Directory("."))
     else if (pattern endsWith wildSuffix) lsDir(Directory(pattern dropRight 2))
     else if (pattern contains '*') {
-      val regexp = ("^%s$" format pattern.replaceAll("""\*""", """.*""")).r
-      lsDir(Directory(pattern).parent, regexp findFirstIn _ isDefined)
+      try {
+        val regexp = ("^" + pattern.replaceAllLiterally("""\*""", """.*""") + "$").r
+        lsDir(Directory(pattern).parent, regexp.findFirstIn(_).isDefined)
+      }
+      catch { case _: PatternSyntaxException => List(pattern) }
     }
     else List(pattern)
   }
 
   /** Split classpath using platform-dependent path separator */
-  def split(path: String): List[String] = (path split pathSeparator).toList filterNot (_ == "") distinct
+  def split(path: String): List[String] = (path split pathSeparator).toList.filterNot(_ == "").distinct
 
   /** Join classpath using platform-dependent path separator */
   def join(paths: String*): String  = paths filterNot (_ == "") mkString pathSeparator
 
   /** Split the classpath, apply a transformation function, and reassemble it. */
   def map(cp: String, f: String => String): String = join(split(cp) map f: _*)
-
-  /** Split the classpath, filter according to predicate, and reassemble. */
-  def filter(cp: String, p: String => Boolean): String = join(split(cp) filter p: _*)
-
-  /** Split the classpath and map them into Paths */
-  def toPaths(cp: String): List[Path] = split(cp) map (x => Path(x).toAbsolute)
-
-  /** Make all classpath components absolute. */
-  def makeAbsolute(cp: String): String = fromPaths(toPaths(cp): _*)
-
-  /** Join the paths as a classpath */
-  def fromPaths(paths: Path*): String = join(paths map (_.path): _*)
-  def fromURLs(urls: URL*): String = fromPaths(urls map (x => Path(x.getPath)) : _*)
-
-  /** Split the classpath and map them into URLs */
-  def toURLs(cp: String): List[URL] = toPaths(cp) map (_.toURL)
 
   /** Expand path and possibly expanding stars */
   def expandPath(path: String, expandStar: Boolean = true): List[String] =
@@ -83,9 +100,10 @@ object ClassPath {
   def expandDir(extdir: String): List[String] = {
     AbstractFile getDirectory extdir match {
       case null => Nil
-      case dir  => dir filter (_.isClassContainer) map (x => new java.io.File(dir.file, x.name) getPath) toList
+      case dir  => dir.filter(_.isClassContainer).map(x => new java.io.File(dir.file, x.name).getPath).toList
     }
   }
+
   /** Expand manifest jar classpath entries: these are either urls, or paths
    *  relative to the location of the jar.
    */
@@ -99,317 +117,34 @@ object ClassPath {
     )
   }
 
-  /** A useful name filter. */
-  def isTraitImplementation(name: String) = name endsWith "$class.class"
-
   def specToURL(spec: String): Option[URL] =
     try Some(new URL(spec))
     catch { case _: MalformedURLException => None }
 
-  /** A class modeling aspects of a ClassPath which should be
-   *  propagated to any classpaths it creates.
-   */
-  abstract class ClassPathContext {
-    /** A filter which can be used to exclude entities from the classpath
-     *  based on their name.
-     */
-    def isValidName(name: String): Boolean = true
-
-    /** From the representation to its identifier.
-     */
-    def toBinaryName(rep: AbstractFile): String
-
-    /** Create a new classpath based on the abstract file.
-     */
-    def newClassPath(file: AbstractFile): ClassPath
-
-    /** Creators for sub classpaths which preserve this context.
-     */
-    def sourcesInPath(path: String): List[ClassPath] =
-      for (file <- expandPath(path, false) ; dir <- Option(AbstractFile getDirectory file)) yield
-        new SourcePath(dir, this)
-
-    def contentsOfDirsInPath(path: String): List[ClassPath] =
-      for (dir <- expandPath(path, false) ; name <- expandDir(dir) ; entry <- Option(AbstractFile getDirectory name)) yield
-        newClassPath(entry)
-
-    def classesAtAllURLS(path: String): List[ClassPath] =
-      (path split " ").toList flatMap classesAtURL
-
-    def classesAtURL(spec: String) =
-      for (url <- specToURL(spec).toList ; location <- Option(AbstractFile getURL url)) yield
-        newClassPath(location)
-
-    def classesInExpandedPath(path: String): IndexedSeq[ClassPath] =
-      classesInPathImpl(path, true).toIndexedSeq
-
-    def classesInPath(path: String) = classesInPathImpl(path, false)
-
-    // Internal
-    private def classesInPathImpl(path: String, expand: Boolean) =
-      for (file <- expandPath(path, expand) ; dir <- Option(AbstractFile getDirectory file)) yield
-        newClassPath(dir)
+  def manifests: List[java.net.URL] = {
+    import scala.collection.JavaConverters._
+    val resources = Thread.currentThread().getContextClassLoader().getResources("META-INF/MANIFEST.MF")
+    resources.asScala.filter(_.getProtocol == "jar").toList
   }
 
-  class JavaContext extends ClassPathContext {
-    def toBinaryName(rep: AbstractFile) = {
-      val name = rep.name
-      assert(endsClass(name), name)
-      name.substring(0, name.length - 6)
-    }
-    def newClassPath(dir: AbstractFile) = new DirectoryClassPath(dir, this)
-  }
+  @deprecated("shim for sbt's compiler interface", since = "2.12.0")
+  sealed abstract class ClassPathContext
 
-  object DefaultJavaContext extends JavaContext {
-    override def isValidName(name: String) = !isTraitImplementation(name)
-  }
-
-  private def endsClass(s: String) = s.length > 6 && s.substring(s.length - 6) == ".class"
-  private def endsScala(s: String) = s.length > 6 && s.substring(s.length - 6) == ".scala"
-  private def endsJava(s: String)  = s.length > 5 && s.substring(s.length - 5) == ".java"
-
-  /** From the source file to its identifier.
-   */
-  def toSourceName(f: AbstractFile): String = {
-    val name = f.name
-
-    if (endsScala(name)) name.substring(0, name.length - 6)
-    else if (endsJava(name)) name.substring(0, name.length - 5)
-    else throw new FatalError("Unexpected source file ending: " + name)
-  }
+  @deprecated("shim for sbt's compiler interface", since = "2.12.0")
+  sealed abstract class JavaContext
 }
 
-/**
- * Represents a package which contains classes and other packages
- */
-abstract class ClassPath {
-  type AnyClassRep = ClassPath#ClassRep
-
-  /**
-   * The short name of the package (without prefix)
-   */
+trait ClassRepresentation {
   def name: String
-
-  /**
-   * A String representing the origin of this classpath element, if known.
-   * For example, the path of the directory or jar.
-   */
-  def origin: Option[String] = None
-
-  /** A list of URLs representing this classpath.
-   */
-  def asURLs: List[URL]
-
-  /** The whole classpath in the form of one String.
-   */
-  def asClasspathString: String
-
-  /** Info which should be propagated to any sub-classpaths.
-   */
-  def context: ClassPathContext
-
-  /** Lists of entities.
-   */
-  def classes: IndexedSeq[AnyClassRep]
-  def packages: IndexedSeq[ClassPath]
-  def sourcepaths: IndexedSeq[AbstractFile]
-
-  /**
-   * Represents classes which can be loaded with a ClassfileLoader
-   * and / or a SourcefileLoader.
-   */
-  case class ClassRep(binary: Option[AbstractFile], source: Option[AbstractFile]) {
-    def name: String = binary match {
-      case Some(x)  => context.toBinaryName(x)
-      case _        =>
-        assert(source.isDefined)
-        toSourceName(source.get)
-    }
-  }
-
-  /** Filters for assessing validity of various entities.
-   */
-  def validClassFile(name: String)  = endsClass(name) && context.isValidName(name)
-  def validPackage(name: String)    = (name != "META-INF") && (name != "") && (name.charAt(0) != '.')
-  def validSourceFile(name: String) = endsScala(name) || endsJava(name)
-
-  /**
-   * Find a ClassRep given a class name of the form "package.subpackage.ClassName".
-   * Does not support nested classes on .NET
-   */
-  def findClass(name: String): Option[AnyClassRep] =
-    name.splitWhere(_ == '.', doDropIndex = true) match {
-      case Some((pkg, rest)) =>
-        packages find (_.name == pkg) flatMap (_ findClass rest)
-      case _ =>
-        classes find (_.name == name)
-    }
-
-  def findBinaryFile(name: String): Option[AbstractFile] =
-    findClass(name).flatMap(_.binary)
-
-  def sortString = join(split(asClasspathString).sorted: _*)
-
-  override def equals(that: Any) = that match {
-    case x: ClassPath => this.sortString == x.sortString
-    case _            => false
-  }
-  override def hashCode = sortString.hashCode()
+  def binary: Option[AbstractFile]
+  def source: Option[AbstractFile]
 }
 
-/**
- * A Classpath containing source files
- */
-class SourcePath(dir: AbstractFile, val context: ClassPathContext) extends ClassPath {
-  def name = dir.name
-  override def origin = dir.underlyingSource map (_.path)
-  def asURLs = if (dir.file == null) Nil else List(dir.toURL)
-  def asClasspathString = dir.path
-  val sourcepaths: IndexedSeq[AbstractFile] = IndexedSeq(dir)
+@deprecated("shim for sbt's compiler interface", since = "2.12.0")
+sealed abstract class DirectoryClassPath
 
-  private def traverse() = {
-    val classBuf   = immutable.Vector.newBuilder[ClassRep]
-    val packageBuf = immutable.Vector.newBuilder[SourcePath]
-    dir foreach { f =>
-      if (!f.isDirectory && validSourceFile(f.name))
-        classBuf += ClassRep(None, Some(f))
-      else if (f.isDirectory && validPackage(f.name))
-        packageBuf += new SourcePath(f, context)
-    }
-    (packageBuf.result, classBuf.result)
-  }
+@deprecated("shim for sbt's compiler interface", since = "2.12.0")
+sealed abstract class MergedClassPath
 
-  lazy val (packages, classes) = traverse()
-  override def toString() = "sourcepath: " + dir.toString()
-}
-
-/**
- * A directory (or a .jar file) containing classfiles and packages
- */
-class DirectoryClassPath(val dir: AbstractFile, val context: ClassPathContext) extends ClassPath {
-  def name = dir.name
-  override def origin = dir.underlyingSource map (_.path)
-  def asURLs = if (dir.file == null) Nil else List(dir.toURL)
-  def asClasspathString = dir.path
-  val sourcepaths: IndexedSeq[AbstractFile] = IndexedSeq()
-
-  // calculates (packages, classes) in one traversal.
-  private def traverse() = {
-    val classBuf   = immutable.Vector.newBuilder[ClassRep]
-    val packageBuf = immutable.Vector.newBuilder[DirectoryClassPath]
-    dir foreach { f =>
-      if (!f.isDirectory && validClassFile(f.name))
-        classBuf += ClassRep(Some(f), None)
-      else if (f.isDirectory && validPackage(f.name))
-        packageBuf += new DirectoryClassPath(f, context)
-    }
-    (packageBuf.result, classBuf.result)
-  }
-
-  lazy val (packages, classes) = traverse()
-  override def toString() = "directory classpath: " + origin.getOrElse("?")
-}
-
-class DeltaClassPath(original: MergedClassPath, subst: Map[ClassPath, ClassPath])
-extends MergedClassPath(original.entries map (e => subst getOrElse (e, e)), original.context) {
-  // not sure we should require that here. Commented out for now.
-  // require(subst.keySet subsetOf original.entries.toSet)
-  // We might add specialized operations for computing classes packages here. Not sure it's worth it.
-}
-
-/**
- * A classpath unifying multiple class- and sourcepath entries.
- */
-class MergedClassPath(
-  val entries: IndexedSeq[ClassPath],
-  val context: ClassPathContext)
-extends ClassPath {
-  def this(entries: TraversableOnce[ClassPath], context: ClassPathContext) =
-    this(entries.toIndexedSeq, context)
-
-  def name = entries.head.name
-  def asURLs = (entries flatMap (_.asURLs)).toList
-  lazy val sourcepaths: IndexedSeq[AbstractFile] = entries flatMap (_.sourcepaths)
-
-  override def origin = Some(entries map (x => x.origin getOrElse x.name) mkString ("Merged(", ", ", ")"))
-  override def asClasspathString: String = join(entries map (_.asClasspathString) : _*)
-
-  lazy val classes: IndexedSeq[AnyClassRep] = {
-    var count   = 0
-    val indices = mutable.AnyRefMap[String, Int]()
-    val cls     = new mutable.ArrayBuffer[AnyClassRep](1024)
-
-    for (e <- entries; c <- e.classes) {
-      val name = c.name
-      if (indices contains name) {
-        val idx      = indices(name)
-        val existing = cls(idx)
-
-        if (existing.binary.isEmpty && c.binary.isDefined)
-          cls(idx) = existing.copy(binary = c.binary)
-        if (existing.source.isEmpty && c.source.isDefined)
-          cls(idx) = existing.copy(source = c.source)
-      }
-      else {
-        indices(name) = count
-        cls += c
-        count += 1
-      }
-    }
-    cls.toIndexedSeq
-  }
-
-  lazy val packages: IndexedSeq[ClassPath] = {
-    var count   = 0
-    val indices = mutable.AnyRefMap[String, Int]()
-    val pkg     = new mutable.ArrayBuffer[ClassPath](256)
-
-    for (e <- entries; p <- e.packages) {
-      val name = p.name
-      if (indices contains name) {
-        val idx  = indices(name)
-        pkg(idx) = addPackage(pkg(idx), p)
-      }
-      else {
-        indices(name) = count
-        pkg += p
-        count += 1
-      }
-    }
-    pkg.toIndexedSeq
-  }
-
-  private def addPackage(to: ClassPath, pkg: ClassPath) = {
-    val newEntries: IndexedSeq[ClassPath] = to match {
-      case cp: MergedClassPath => cp.entries :+ pkg
-      case _                   => IndexedSeq(to, pkg)
-    }
-    new MergedClassPath(newEntries, context)
-  }
-  def show(): Unit = {
-    println("ClassPath %s has %d entries and results in:\n".format(name, entries.size))
-    asClasspathString split ':' foreach (x => println("  " + x))
-  }
-  override def toString() = "merged classpath " + entries.mkString("(", "\n", ")")
-}
-
-/**
- * The classpath when compiling with target:jvm. Binary files (classfiles) are represented
- * as AbstractFile. nsc.io.ZipArchive is used to view zip/jar archives as directories.
- */
-class JavaClassPath(
-  containers: IndexedSeq[ClassPath],
-  context: JavaContext)
-extends MergedClassPath(containers, context) { }
-
-object JavaClassPath {
-  def fromURLs(urls: Seq[URL], context: JavaContext): JavaClassPath = {
-    val containers = {
-      for (url <- urls ; f = AbstractFile getURL url ; if f != null) yield
-        new DirectoryClassPath(f, context)
-    }
-    new JavaClassPath(containers.toIndexedSeq, context)
-  }
-  def fromURLs(urls: Seq[URL]): JavaClassPath =
-    fromURLs(urls, ClassPath.DefaultJavaContext)
-}
+@deprecated("shim for sbt's compiler interface", since = "2.12.0")
+sealed abstract class JavaClassPath

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -1,0 +1,170 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author  Martin Odersky
+ */
+
+package dotty.tools
+package io
+
+/** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
+class PlainDirectory(givenPath: Directory) extends PlainFile(givenPath) {
+  override def isDirectory = true
+  override def iterator = givenPath.list filter (_.exists) map (x => new PlainFile(x))
+  override def delete(): Unit = givenPath.deleteRecursively()
+}
+
+/** This class implements an abstract file backed by a File.
+ *
+ * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
+ */
+class PlainFile(val givenPath: Path) extends AbstractFile {
+  assert(path ne null)
+
+  val file = givenPath.jfile
+  override def underlyingSource = Some(this)
+
+  private val fpath = givenPath.toAbsolute
+
+  /** Returns the name of this abstract file. */
+  def name = givenPath.name
+
+  /** Returns the path of this abstract file. */
+  def path = givenPath.path
+
+  /** The absolute file. */
+  def absolute = new PlainFile(givenPath.toAbsolute)
+
+  override def container: AbstractFile = new PlainFile(givenPath.parent)
+  override def input = givenPath.toFile.inputStream()
+  override def output = givenPath.toFile.outputStream()
+  override def sizeOption = Some(givenPath.length.toInt)
+
+  override def hashCode(): Int = fpath.hashCode()
+  override def equals(that: Any): Boolean = that match {
+    case x: PlainFile => fpath == x.fpath
+    case _            => false
+  }
+
+  /** Is this abstract file a directory? */
+  def isDirectory: Boolean = givenPath.isDirectory
+
+  /** Returns the time that this abstract file was last modified. */
+  def lastModified: Long = givenPath.lastModified
+
+  /** Returns all abstract subfiles of this abstract directory. */
+  def iterator: Iterator[AbstractFile] = {
+    // Optimization: Assume that the file was not deleted and did not have permissions changed
+    // between the call to `list` and the iteration. This saves a call to `exists`.
+    def existsFast(path: Path) = path match {
+      case (_: Directory | _: io.File) => true
+      case _                           => path.exists
+    }
+    if (!isDirectory) Iterator.empty
+    else givenPath.toDirectory.list filter existsFast map (new PlainFile(_))
+  }
+
+  /**
+   * Returns the abstract file in this abstract directory with the
+   * specified name. If there is no such file, returns null. The
+   * argument "directory" tells whether to look for a directory or
+   * or a regular file.
+   */
+  def lookupName(name: String, directory: Boolean): AbstractFile = {
+    val child = givenPath / name
+    if ((child.isDirectory && directory) || (child.isFile && !directory)) new PlainFile(child)
+    else null
+  }
+
+  /** Does this abstract file denote an existing file? */
+  def create(): Unit = if (!exists) givenPath.createFile()
+
+  /** Delete the underlying file or directory (recursively). */
+  def delete(): Unit =
+    if (givenPath.isFile) givenPath.delete()
+    else if (givenPath.isDirectory) givenPath.toDirectory.deleteRecursively()
+
+  /** Returns a plain file with the given name. It does not
+   *  check that it exists.
+   */
+  def lookupNameUnchecked(name: String, directory: Boolean): AbstractFile =
+    new PlainFile(givenPath / name)
+}
+
+private[dotty] class PlainNioFile(nioPath: java.nio.file.Path) extends AbstractFile {
+  import java.nio.file._
+
+  assert(nioPath ne null)
+
+  /** Returns the underlying File if any and null otherwise. */
+  override def file: java.io.File = try {
+    nioPath.toFile
+  } catch {
+    case _: UnsupportedOperationException => null
+  }
+
+  override def underlyingSource  = Some(this)
+
+  private val fpath = nioPath.toAbsolutePath.toString
+
+  /** Returns the name of this abstract file. */
+  def name = nioPath.getFileName.toString
+
+  /** Returns the path of this abstract file. */
+  def path = nioPath.toString
+
+  /** The absolute file. */
+  def absolute = new PlainNioFile(nioPath.toAbsolutePath)
+
+  override def container: AbstractFile = new PlainNioFile(nioPath.getParent)
+  override def input = Files.newInputStream(nioPath)
+  override def output = Files.newOutputStream(nioPath)
+  override def sizeOption = Some(Files.size(nioPath).toInt)
+  override def hashCode(): Int = fpath.hashCode()
+  override def equals(that: Any): Boolean = that match {
+    case x: PlainNioFile => fpath == x.fpath
+    case _               => false
+  }
+
+  /** Is this abstract file a directory? */
+  def isDirectory: Boolean = Files.isDirectory(nioPath)
+
+  /** Returns the time that this abstract file was last modified. */
+  def lastModified: Long = Files.getLastModifiedTime(nioPath).toMillis
+
+  /** Returns all abstract subfiles of this abstract directory. */
+  def iterator: Iterator[AbstractFile] = {
+    try {
+      import scala.collection.JavaConverters._
+      val it = Files.newDirectoryStream(nioPath).iterator()
+      it.asScala.map(new PlainNioFile(_))
+    } catch {
+      case _: NotDirectoryException => Iterator.empty
+    }
+  }
+
+  /**
+    * Returns the abstract file in this abstract directory with the
+    * specified name. If there is no such file, returns null. The
+    * argument "directory" tells whether to look for a directory or
+    * or a regular file.
+    */
+  def lookupName(name: String, directory: Boolean): AbstractFile = {
+    val child = nioPath.resolve(name)
+    if ((Files.isDirectory(child) && directory) || (Files.isRegularFile(child) && !directory)) new PlainNioFile(child)
+    else null
+  }
+
+  /** Does this abstract file denote an existing file? */
+  def create(): Unit = if (!exists)  Files.createFile(nioPath)
+
+  /** Delete the underlying file or directory (recursively). */
+  def delete(): Unit =
+    if (Files.isRegularFile(nioPath)) Files.deleteIfExists(nioPath)
+    else if (Files.isDirectory(nioPath)) new Directory(nioPath.toFile).deleteRecursively()
+
+  /** Returns a plain file with the given name. It does not
+    *  check that it exists.
+    */
+  def lookupNameUnchecked(name: String, directory: Boolean): AbstractFile =
+    new PlainNioFile(nioPath.resolve(name))
+}

--- a/compiler/src/dotty/tools/io/package.scala
+++ b/compiler/src/dotty/tools/io/package.scala
@@ -20,8 +20,6 @@ package object io {
   val File = scala.reflect.io.File
   type Path = scala.reflect.io.Path
   val Path = scala.reflect.io.Path
-  type PlainFile = scala.reflect.io.PlainFile
-  //val PlainFile = scala.reflect.io.PlainFile
   val Streamable = scala.reflect.io.Streamable
   type VirtualDirectory = scala.reflect.io.VirtualDirectory
   type VirtualFile = scala.reflect.io.VirtualFile

--- a/sbt-bridge/test/xsbt/ScalaCompilerForUnitTesting.scala
+++ b/sbt-bridge/test/xsbt/ScalaCompilerForUnitTesting.scala
@@ -173,7 +173,7 @@ class ScalaCompilerForUnitTesting(nameHashing: Boolean, includeSynthToNameHashin
   private def prepareCompiler(outputDir: File, analysisCallback: AnalysisCallback, classpath: String = ".") = {
     val args = Array.empty[String]
 
-    import dotty.tools.dotc._
+    import dotty.tools.dotc.{Compiler, Driver}
     import dotty.tools.dotc.core.Contexts._
 
     val driver = new Driver {


### PR DESCRIPTION
This commit is a very crude port of the classpath handling as it exists
in the 2.12.x branch of scalac (hash: 232d95a198c94da0c6c8393624e83e9b9ac84e81),
this replaces the existing Classpath code that was adapted from scalac
years ago.

I'll update this commit with more details and proper attribution later,
for now I just want to run this on the CI.

@odersky I had to add a special case to `PackageLoader` to make sure that Scala2 impl classes (ending with `$class`) were not entered in scope, do you know how we avoided impl classes being in scope so far?