### PR TITLE
Deterministically randomises test compilation order

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -788,7 +788,7 @@ object Trees {
     def complete(implicit ctx: Context): T
   }
 
-  // ----- Generic Tree Instances, inherited from  `tpt` and `untpd`.
+  // ----- Generic Tree Instances, inherited from `tpt` and `untpd`.
 
   abstract class Instance[T >: Untyped <: Type] extends DotClass { inst =>
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1793,7 +1793,7 @@ object Types {
     override def newLikeThis(prefix: Type)(implicit ctx: Context): TermRef =
       fixDenot(TermRef.withSig(prefix, name, sig), prefix)
 
-    override def shadowed(implicit ctx: Context): NamedType = 
+    override def shadowed(implicit ctx: Context): NamedType =
       fixDenot(TermRef.withSig(prefix, name.shadowedName, sig), prefix)
 
     override def equals(that: Any) = that match {


### PR DESCRIPTION
The previous implementation would compile tests in different orders from machine to machine, depending on the order in which *.scala files are listed by the operating system.