### PR TITLE
[WIP] avoid agressive eliding to make code re-typable

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -308,8 +308,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           // was ctx.owner.enclosingClass.derivesFrom(pre.cls) which was not tight enough
           // and was spuriously triggered in case inner class would inherit from outer one
           // eg anonymous TypeMap inside TypeMap.andThen
-      case pre: TermRef =>
-        pre.symbol.is(Module) && pre.symbol.isStatic
       case _ =>
         false
     }


### PR DESCRIPTION
Def macros require typed trees to be re-typable. Previously, the following untyped tree:

    Seq(2,1).sum

will be typed as follows:

     Seq(2, 1).sum(IntIsIntegral)

which cannot be typed again, as `IntIsIntegral` cannot be resolved. This commit
will make the tree typed as follows:

     Seq(2, 1).sum(scala.math.Numeric.IntIsIntegral)