### PR TITLE
Fix #2201: Less aggressive type application reduction for better inference

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -391,9 +391,12 @@ class TypeApplications(val self: Type) extends AnyVal {
           if (!args.exists(_.isInstanceOf[TypeBounds])) {
             val followAlias = Config.simplifyApplications && {
               dealiased.resType match {
-                case AppliedType(tyconBody, _) =>
-                  sameLength(dealiased.typeParams, tyconBody.typeParams)
-                    // Reducing is safe for type inference, as kind arity of type constructor does not change
+                case AppliedType(tyconBody, dealiasedArgs) =>
+                  // Reduction should not affect type inference when it's
+                  // just eta-reduction (ignoring variance annotations).
+                  // See i2201*.scala for examples where more aggressive
+                  // reduction would break type inference.
+                  dealiased.paramRefs == dealiasedArgs
                 case _ => false
               }
             }

--- a/tests/pos/i2201a.scala
+++ b/tests/pos/i2201a.scala
@@ -1,0 +1,8 @@
+class Foo[T]
+
+class Fix[F[_]](unfix: F[Fix[F]])
+object DocTree {
+  type Const[T] = Foo[Int]
+  type FixConst = Fix[Const]
+  def docTree(s: Const[FixConst]): FixConst = new Fix(s)
+}

--- a/tests/pos/i2201b.scala
+++ b/tests/pos/i2201b.scala
@@ -1,0 +1,14 @@
+trait X
+trait Y
+
+object Test {
+  type One[A <: X, B <: Y]
+
+  type Two[TA <: Y, TB <: X] = One[TB, TA]
+
+  def foo[M[_ <: Y, _ <: X]](x: M[_ <: Y, _ <: X]) = x
+
+  val a: Two[Y, X] = ???
+
+  foo(a)
+}

--- a/tests/pos/i2201c.scala
+++ b/tests/pos/i2201c.scala
@@ -1,0 +1,11 @@
+object Test {
+  implicit val theAnswer: Int = 42
+
+  type Swap[A, B] = (B, A)
+
+  def foo[M[_, _], T, S](x: M[T, S])(implicit ev: T) = ev
+
+  val a: Swap[Int, String] = ("hi", 1)
+
+  foo(a)
+}


### PR DESCRIPTION
Previously we believed that reducing type applications did not affect
type inference as long as the reduced type constructor had the same
arity as the unreduced one, for example reducing `Foo[X, Y]` is fine
when `Foo` is defined as:
```scala
type Foo[A, B] = Bar[A, B]
```
but not when it's defined as:
```scala
type Foo[A] = Bar[A, A]
```
But this is not a sufficient condition: the bounds of the type
constructor arguments also matter for type inference, so we need to be
more strict and disallow reductions in cases like:
```scala
type Foo[A, B] = Bar[B, A]
```
and:
```scala
type Foo[A, B] = Bar[A, Int]
```