### PR TITLE
Fix #2198: Don't widen module singletons

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1043,9 +1043,11 @@ class Namer { typer: Typer =>
       def isInline = sym.is(FinalOrInline, butNot = Method | Mutable)
 
       // Widen rhs type and approximate `|' but keep ConstantTypes if
-      // definition is inline (i.e. final in Scala2).
+      // definition is inline (i.e. final in Scala2) and keep module singleton types
+      // instead of widening to the underlying module class types.
       def widenRhs(tp: Type): Type = tp.widenTermRefExpr match {
-        case tp: ConstantType if isInline => tp
+        case ctp: ConstantType if isInline => ctp
+        case ref: TypeRef if ref.symbol.is(ModuleClass) => tp
         case _ => ctx.harmonizeUnion(tp.widen)
       }
 

--- a/tests/pos/i2198.scala
+++ b/tests/pos/i2198.scala
@@ -1,0 +1,6 @@
+object Test {
+  val nil = scala.collection.immutable.Nil
+  def f(x: nil.type): Int = 3
+
+  f(scala.collection.immutable.Nil)
+}


### PR DESCRIPTION
Since module classes are a compiler-generated construct that's not directly
visible to programmers, it seems better not to automatically widen a module
singleton to its underlying class.

Fixes #2198.
