### PR TITLE
Fix #2188: Do cbn transform also on Selects

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
@@ -112,6 +112,9 @@ class ElimByName extends MiniPhaseTransform with InfoTransformer { thisTransform
   override def transformIdent(tree: Ident)(implicit ctx: Context, info: TransformerInfo): Tree =
     applyIfFunction(tree, tree)
 
+  override def transformSelect(tree: Select)(implicit ctx: Context, info: TransformerInfo): Tree =
+    applyIfFunction(tree, tree)
+
   override def transformTypeApply(tree: TypeApply)(implicit ctx: Context, info: TransformerInfo): Tree = tree match {
     case TypeApply(Select(_, nme.asInstanceOf_), arg :: Nil) =>
       // tree might be of form e.asInstanceOf[x.type] where x becomes a function.

--- a/tests/pos/i2188.scala
+++ b/tests/pos/i2188.scala
@@ -1,0 +1,5 @@
+class Fill(elem: => Int) {
+  class Iter {
+    def next(): Int = elem
+  }
+}


### PR DESCRIPTION
These can arise as a result of an explicit outer transform.