### PR TITLE
Fix #2152: Instantiate dependent result type parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -209,7 +209,7 @@ object NameKinds {
   val InlineAccessorName      = new UniqueNameKind("$_inlineAccessor_$")
   val TempResultName          = new UniqueNameKind("ev$")
   val EvidenceParamName       = new UniqueNameKind("evidence$")
-  val DepParamName            = new UniqueNameKind("<param>")
+  val DepParamName            = new UniqueNameKind("(param)")
   val LazyImplicitName        = new UniqueNameKind("$_lazy_implicit_$")
   val LazyLocalName           = new UniqueNameKind("$lzy")
   val LazyLocalInitName       = new UniqueNameKind("$lzyINIT")

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -7,6 +7,7 @@ import SymDenotations._, Denotations.SingleDenotation
 import config.Printers.typr
 import util.Positions._
 import NameOps._
+import NameKinds.DepParamName
 import Decorators._
 import StdNames._
 import Annotations._
@@ -169,6 +170,9 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
       simplify(l, theMap) & simplify(r, theMap)
     case OrType(l, r) =>
       simplify(l, theMap) | simplify(r, theMap)
+    case tp: TypeVar if tp.origin.paramName.is(DepParamName) =>
+      val effectiveVariance = if (theMap == null) 1 else theMap.variance
+      tp.instanceOpt orElse tp.instantiate(fromBelow = effectiveVariance != -1)
     case _ =>
       (if (theMap != null) theMap else new SimplifyMap).mapOver(tp)
   }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3509,7 +3509,7 @@ object Types {
 
     def apply(tp: Type): Type
 
-    protected var variance = 1
+    protected[core] var variance = 1
 
     protected def derivedSelect(tp: NamedType, pre: Type): Type =
       tp.derivedSelect(pre)

--- a/tests/pos/i2152.scala
+++ b/tests/pos/i2152.scala
@@ -1,0 +1,7 @@
+class Contra[-D](task: AnyRef)
+object Test {
+  def narrow(task: AnyRef): Contra[task.type] = new Contra(task)
+  def ident[Before](elems: Contra[Before]): Contra[Before] = elems
+  val foo = null
+  ident(narrow(foo))
+}


### PR DESCRIPTION
#2152 shows that dependent result type parameters can end up in
the types of terms, so we have to eliminate them. If we don't we
get orphan parameters in pickling.

Based on #2128. Only one commit is new.