### PR TITLE
Fix #2142: Skolemize arguments of dependent methods if necessary

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -107,10 +107,11 @@ object Types {
     final def isValueTypeOrLambda: Boolean = isValueType || this.isInstanceOf[TypeLambda]
 
     /** Does this type denote a stable reference (i.e. singleton type)? */
-    @tailrec final def isStable(implicit ctx: Context): Boolean = stripTypeVar match {
-      case tp: TermRef => tp.termSymbol.isStable && tp.prefix.isStable
+    final def isStable(implicit ctx: Context): Boolean = stripTypeVar match {
+      case tp: TermRef => tp.termSymbol.isStable && tp.prefix.isStable || tp.info.isStable
       case _: SingletonType | NoPrefix => true
       case tp: RefinedOrRecType => tp.parent.isStable
+      case tp: ExprType => tp.resultType.isStable
       case _ => false
     }
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -134,7 +134,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case tp: TypeType =>
         toTextRHS(tp)
       case tp: TermRef
-      if !tp.denotationIsCurrent && !homogenizedView || // always print underyling when testing picklers
+      if !tp.denotationIsCurrent && !homogenizedView || // always print underlying when testing picklers
          tp.symbol.is(Module) ||
          tp.symbol.name.isImportName =>
         toTextRef(tp) ~ ".type"
@@ -183,7 +183,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
           toTextGlobal(tp.resultType)
         }
       case tp: TypeParamRef =>
-        TypeParamRefNameString(tp) ~ lambdaHash(tp.binder)
+        ParamRefNameString(tp) ~ lambdaHash(tp.binder)
+      case tp: TermParamRef =>
+        ParamRefNameString(tp) ~ ".type"
       case AnnotatedType(tpe, annot) =>
         toTextLocal(tpe) ~ " " ~ toText(annot)
       case HKApply(tycon, args) =>
@@ -206,10 +208,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
     }
   }.close
 
-  protected def TypeParamRefNameString(name: TypeName): String = name.toString
+  protected def ParamRefNameString(name: Name): String = name.toString
 
-  protected def TypeParamRefNameString(param: TypeParamRef): String =
-    TypeParamRefNameString(param.binder.paramNames(param.paramNum))
+  protected def ParamRefNameString(param: ParamRef): String =
+    ParamRefNameString(param.binder.paramNames(param.paramNum))
 
   /** The name of the symbol without a unique id. Under refined printing,
    *  the decoded original name.

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -604,7 +604,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   def optText[T >: Untyped](tree: List[Tree[T]])(encl: Text => Text): Text =
     if (tree.exists(!_.isEmpty)) encl(blockText(tree)) else ""
 
-  override protected def TypeParamRefNameString(name: TypeName): String =
+  override protected def ParamRefNameString(name: Name): String =
     name.unexpandedName.toString
 
   override protected def treatAsTypeParam(sym: Symbol): Boolean = sym is TypeParam

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -395,9 +395,8 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
           def addTyped(arg: Arg, formal: Type): Type => Type = {
             addArg(typedArg(arg, formal), formal)
             if (methodType.isParamDependent)
-              _.substParam(methodType.newParamRef(n), typeOfArg(arg))
-            else
-              identity
+              substArgForParam(_, typeOfArg(arg), methodType.paramRefs(n))
+            else identity
           }
 
           def missingArg(n: Int): Unit = {

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -395,7 +395,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
           def addTyped(arg: Arg, formal: Type): Type => Type = {
             addArg(typedArg(arg, formal), formal)
             if (methodType.isParamDependent)
-              substArgForParam(_, typeOfArg(arg), methodType.paramRefs(n))
+              safeSubstParam(_, methodType.paramRefs(n), typeOfArg(arg))
             else identity
           }
 

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -315,10 +315,28 @@ trait TypeAssigner {
     }
   }
 
+  /** Substitute argument type `argType` for parameter `pref` in type `tp`,
+   *  skolemizing the argument type if it is not stable and `pref` occurs in `tp`.
+   */
+  def substArgForParam(tp: Type, argType: Type, pref: ParamRef)(implicit ctx: Context) = {
+    val tp1 = tp.substParam(pref, argType)
+    if ((tp1 eq tp) || argType.isStable) tp1
+    else tp.substParam(pref, SkolemType(argType.widen))
+  }
+
   def assignType(tree: untpd.Apply, fn: Tree, args: List[Tree])(implicit ctx: Context) = {
     val ownType = fn.tpe.widen match {
       case fntpe: MethodType =>
-        if (sameLength(fntpe.paramInfos, args) || ctx.phase.prev.relaxedTyping) fntpe.instantiate(args.tpes)
+        def substArgsForParams(tp: Type, args: List[Tree], params: List[ParamRef]): Type = params match {
+          case param :: params1 =>
+            val tp1 = substArgForParam(tp, args.head.tpe, param)
+            substArgsForParams(tp1, args.tail, params1)
+          case Nil =>
+            tp
+          }
+        if (sameLength(fntpe.paramInfos, args) || ctx.phase.prev.relaxedTyping)
+          if (fntpe.isDependent) substArgsForParams(fntpe.resultType, args, fntpe.paramRefs)
+          else fntpe.resultType
         else
           errorType(i"wrong number of arguments for $fntpe: ${fn.tpe}, expected: ${fntpe.paramInfos.length}, found: ${args.length}", tree.pos)
       case t =>

--- a/tests/neg/i2142.scala
+++ b/tests/neg/i2142.scala
@@ -1,0 +1,28 @@
+object Foo {
+
+class A
+val a1 = new A()
+val a2 = new A()
+
+def f(x: A, y: x.type) = ()
+f(a1, a1)           // ok
+f(a1, a2)           // error
+f(new A(), new A()) // error
+f(new A(), a1)      // error
+
+def g(x: A)(y: x.type) = ()
+g(a1)(a1)           // ok
+g(a1)(a2)           // error
+g(new A())(new A()) // error
+g(new A())(a1)      // error
+
+val x0 = g(new A()) _
+x0 (new A())          // error
+
+class C[T]
+
+def h(x: A): C[x.type] = ???
+val x = h(a1)
+val y = h(new A())
+
+}


### PR DESCRIPTION
This PR detects errors around unstable argument types to dependent methods that were
not reported before. 