### PR TITLE
Fix #2219: Fix type applications on WildcardType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -429,7 +429,7 @@ class TypeApplications(val self: Type) extends AnyVal {
       case dealiased: LazyRef =>
         LazyRef(() => dealiased.ref.appliedTo(args))
       case dealiased: WildcardType =>
-        dealiased
+        WildcardType(dealiased.optBounds.appliedTo(args).bounds)
       case dealiased: TypeRef if dealiased.symbol == defn.NothingClass =>
         dealiased
       case _ if typParams.isEmpty || typParams.head.isInstanceOf[LambdaParam] =>

--- a/tests/pos/i2219.scala
+++ b/tests/pos/i2219.scala
@@ -1,0 +1,7 @@
+object Test {
+  type Inv[T[_]] = T[_]
+
+  class Hi[T[_]](x: Inv[T]) {
+    def foo[T[_]](value: Inv[T] = x) = {}
+  }
+}


### PR DESCRIPTION
Previously we just returned the unapplied WildcardType which is
incorrect if the WildcardType is bounded. The proper thing to do is to
do the type application on the bounds of the WildcardType and wrap the
result in a WildcardType.