### PR TITLE
Fix #2218: Add fullyDefinedType for class parent types

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -843,7 +843,7 @@ class Namer { typer: Typer =>
           val targs1 = targs map (typedAheadType(_))
           val ptype = typedAheadType(tpt).tpe appliedTo targs1.tpes
           if (ptype.typeParams.isEmpty) ptype
-          else typedAheadExpr(parent).tpe
+          else fullyDefinedType(typedAheadExpr(parent).tpe, "class parent", parent.pos)
         }
 
       /* Check parent type tree `parent` for the following well-formedness conditions:

--- a/tests/pos/i2218.scala
+++ b/tests/pos/i2218.scala
@@ -1,0 +1,9 @@
+trait Rule[In]
+
+class C {
+  def ruleWithName[In](f: In => Int): Rule[In] = {
+     new DefaultRule(f) {}
+  }
+
+  class DefaultRule[In](f: In => Int) extends Rule[In]
+}


### PR DESCRIPTION
If we do not do that, any type variables in the parent type get interpolated
later, when the whole primary constructor is typed. But by then we miss the
context of what their variance was.

Fixes #2218