### PR TITLE
Fix #2234: Dealias before type erasing

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -355,7 +355,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
    *   - For NoType or NoPrefix, the type itself.
    *   - For any other type, exception.
    */
-  private def apply(tp: Type)(implicit ctx: Context): Type = tp match {
+  private def apply(tp: Type)(implicit ctx: Context): Type = tp.dealias match {
     case _: ErasedValueType =>
       tp
     case tp: TypeRef =>
@@ -487,7 +487,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
    *  Need to ensure correspondence with erasure!
    */
   private def sigName(tp: Type)(implicit ctx: Context): TypeName = try {
-    tp match {
+    tp.dealias match {
       case ErasedValueType(_, underlying) =>
         sigName(underlying)
       case tp: TypeRef =>

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -355,7 +355,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
    *   - For NoType or NoPrefix, the type itself.
    *   - For any other type, exception.
    */
-  private def apply(tp: Type)(implicit ctx: Context): Type = tp.dealias match {
+  private def apply(tp: Type)(implicit ctx: Context): Type = tp match {
     case _: ErasedValueType =>
       tp
     case tp: TypeRef =>
@@ -377,6 +377,8 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
       defn.FunctionType(0)
     case AndType(tp1, tp2) =>
       erasedGlb(this(tp1), this(tp2), isJava)
+    case tp: HKApply =>
+      apply(tp.superType)
     case OrType(tp1, tp2) =>
       ctx.typeComparer.orType(this(tp1), this(tp2), erased = true)
     case tp: MethodType =>
@@ -487,7 +489,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
    *  Need to ensure correspondence with erasure!
    */
   private def sigName(tp: Type)(implicit ctx: Context): TypeName = try {
-    tp.dealias match {
+    tp match {
       case ErasedValueType(_, underlying) =>
         sigName(underlying)
       case tp: TypeRef =>
@@ -508,6 +510,8 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
           normalizeClass(sym.asClass).fullName.asTypeName
       case defn.ArrayOf(elem) =>
         sigName(this(tp))
+      case tp: HKApply =>
+        sigName(tp.superType)
       case JavaArrayType(elem) =>
         sigName(elem) ++ "[]"
       case tp: TermRef =>

--- a/tests/pos/i2234.scala
+++ b/tests/pos/i2234.scala
@@ -1,0 +1,13 @@
+object Test {
+  type Dummy[A] = A
+
+  def a(d: Dummy[String]) = ()
+  def a(d: Dummy[Int]) = ()
+
+  implicit def dummy[A]: Dummy[A] = null.asInstanceOf[A]
+  def m(x: List[String])(implicit d: Dummy[String]) = "string"
+  def m(x: List[Int])(implicit d: Dummy[Int]) = "int"
+
+  m(List(1, 2, 3))
+  m(List("a"))
+}


### PR DESCRIPTION
... and likewise for taking a signature. The previous case worked
in all cases except when faced with an alias like `type Id[T] = T`.
In that case, it would disregard the argument and erase to Object.

Fixes #2234.
