### PR TITLE
Revert <: Product requierment in pattern matching

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -10,7 +10,6 @@ import scala.collection.{ mutable, immutable }
 import PartialFunction._
 import collection.mutable
 import util.common.alwaysZero
-import typer.Applications
 
 object Definitions {
 
@@ -845,6 +844,9 @@ class Definitions {
   def tupleType(elems: List[Type]) = {
     TupleType(elems.size).appliedTo(elems)
   }
+
+  def isProductSubType(tp: Type)(implicit ctx: Context) =
+    tp.derivesFrom(ProductType.symbol)
 
   /** Is `tp` (an alias) of either a scala.FunctionN or a scala.ImplicitFunctionN? */
   def isFunctionType(tp: Type)(implicit ctx: Context) = {

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -1408,7 +1408,7 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
       protected def seqTree(binder: Symbol)                = tupleSel(binder)(firstIndexingBinder + 1)
       protected def tupleSel(binder: Symbol)(i: Int): Tree = {
         val accessors =
-          if (Applications.canProductMatch(binder.info))
+          if (defn.isProductSubType(binder.info))
             productSelectors(binder.info)
           else binder.caseAccessors
         val res =

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -48,9 +48,6 @@ object Applications {
     ref.info.widenExpr.dealias
   }
 
-  def canProductMatch(tp: Type)(implicit ctx: Context) =
-    extractorMemberType(tp, nme._1).exists
-
   /** Does `tp` fit the "product match" conditions as an unapply result type
    *  for a pattern with `numArgs` subpatterns?
    *  This is the case of `tp` has members `_1` to `_N` where `N == numArgs`.
@@ -72,7 +69,7 @@ object Applications {
   }
 
   def productArity(tp: Type)(implicit ctx: Context) =
-    if (canProductMatch(tp)) productSelectorTypes(tp).size else -1
+    if (defn.isProductSubType(tp)) productSelectorTypes(tp).size else -1
 
   def productSelectors(tp: Type)(implicit ctx: Context): List[Symbol] = {
     val sels = for (n <- Iterator.from(0)) yield tp.member(nme.selectorName(n)).symbol
@@ -114,7 +111,7 @@ object Applications {
         getUnapplySelectors(getTp, args, pos)
       else if (unapplyResult isRef defn.BooleanClass)
         Nil
-      else if (canProductMatch(unapplyResult))
+      else if (defn.isProductSubType(unapplyResult))
         productSelectorTypes(unapplyResult)
           // this will cause a "wrong number of arguments in pattern" error later on,
           // which is better than the message in `fail`.

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -759,7 +759,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       /** Is `formal` a product type which is elementwise compatible with `params`? */
       def ptIsCorrectProduct(formal: Type) = {
         isFullyDefined(formal, ForceDegree.noBottom) &&
-        Applications.canProductMatch(formal) &&
+        defn.isProductSubType(formal) &&
         Applications.productSelectorTypes(formal).corresponds(params) {
           (argType, param) =>
             param.tpt.isEmpty || argType <:< typedAheadType(param.tpt).tpe

--- a/tests/run/1938-2.scala
+++ b/tests/run/1938-2.scala
@@ -1,0 +1,37 @@
+object ProdNonEmpty {
+  def _1: Int = 0
+  def _2: String = "???" // Slight variation with scalac: this test passes
+                         // with ??? here. I think dotty behavior is fine
+                         // according to the spec given that methods involved
+                         // in pattern matching should be pure.
+  def isEmpty = false
+  def unapply(s: String): this.type = this
+  def get = this
+}
+
+object ProdEmpty {
+  def _1: Int = ???
+  def _2: String = ???
+  def isEmpty = true
+  def unapply(s: String): this.type = this
+  def get = this
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    "" match {
+      case ProdNonEmpty(0, _) => ()
+      case _ => ???
+    }
+
+    "" match {
+      case ProdNonEmpty(1, _) => ???
+      case _ => ()
+    }
+
+    "" match {
+      case ProdEmpty(_, _) => ???
+      case _ => ()
+    }
+  }
+}


### PR DESCRIPTION
The change in question broke the following pattern, commonly used in name based pattern matching:

```scala
object ProdEmpty {
  def _1: Int = ???
  def _2: String = ???
  def isEmpty = true
  def get = this
}
```

This type define both `_1` and `get` + `isEmpty` (but is not <: Product). After #1938, `ProdEmpty` became eligibles for both product and name based pattern. Because "in case of ambiguities, *Product Pattern* is preferred over *Name Based Pattern*", isEmpty wouldn't be used, breaking the scalac semantics.

Since this issue is blocker for cross compiling the back-end, I propose to first merge the revert, and discuss  possible alternatives later.