### PR TITLE
fix #2254: dealias types in decomposition of spaces

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -324,7 +324,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
     debug.println(s"candidates for ${tp.show} : [${children.map(_.show).mkString(", ")}]")
 
-    tp match {
+    tp.dealias match {
       case OrType(tp1, tp2) => List(Typ(tp1, true), Typ(tp2, true))
       case _ if tp =:= ctx.definitions.BooleanType =>
         List(
@@ -379,7 +379,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
   def canDecompose(tp: Type): Boolean = {
     val res = tp.classSymbol.is(allOf(Abstract, Sealed)) ||
       tp.classSymbol.is(allOf(Trait, Sealed)) ||
-      tp.isInstanceOf[OrType] ||
+      tp.dealias.isInstanceOf[OrType] ||
       tp =:= ctx.definitions.BooleanType ||
       tp.classSymbol.is(allOf(Enum, Sealed))  // Enum value doesn't have Sealed flag
 

--- a/tests/patmat/i2254.scala
+++ b/tests/patmat/i2254.scala
@@ -1,0 +1,6 @@
+object Test {
+  type OrAlias = Int | Float
+
+  def m(s: OrAlias | String) = s match {
+    case _: Int => ; case _: Float => ; case _: String => ; }
+}


### PR DESCRIPTION
Fix #2254: In the decomposition of type spaces, we need to dealias types.