### PR TITLE
Fix #2246: Ensure ScalaTest compiles again

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -95,8 +95,9 @@ class Erasure extends Phase with DenotTransformer { thisTransformer =>
     assertErased(tree)
     tree match {
       case res: tpd.This =>
-        assert(!ExplicitOuter.referencesOuter(ctx.owner.lexicallyEnclosingClass, res),
-          i"Reference to $res from ${ctx.owner.showLocated}")
+        assert(
+          !ExplicitOuter.referencesOuter(ctx.owner.lexicallyEnclosingClass, res),
+          i"Reference to $res from ${ctx.owner} in ${ctx.owner.ownersIterator.toList}%, %")
       case ret: tpd.Return =>
         // checked only after erasure, as checking before erasure is complicated
         // due presence of type params in returned types

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -257,7 +257,9 @@ object ExplicitOuter {
       case _ => false
     }
     tree match {
-      case _: This | _: Ident => isOuterRef(tree.tpe)
+      case _: This | _: Ident =>
+        tree.symbol.is(InSuperCall) || // symbol in supercalls are lifted to the next outer class
+        isOuterRef(tree.tpe)
       case nw: New =>
         val newCls = nw.tpe.classSymbol
         isOuterSym(newCls.owner.enclosingClass) ||

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -11,18 +11,17 @@ import core.Decorators._
 import core.StdNames.nme
 import core.Names._
 import core.NameOps._
+import core.NameKinds.ExpandPrefixName
 import core.Phases._
 import ast.Trees._
 import SymUtils._
 import ExplicitOuter.outer
 import util.Attachment
-import util.NameTransformer
 import util.Positions._
 import collection.{ mutable, immutable }
 import collection.mutable.{ HashMap, HashSet, LinkedHashMap, LinkedHashSet, TreeSet }
 
 object LambdaLift {
-  private val NJ = NameTransformer.NAME_JOIN_STRING
   private class NoPath extends Exception
 }
 
@@ -338,7 +337,9 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
 
     private def newName(sym: Symbol)(implicit ctx: Context): Name =
       if (sym.isAnonymousFunction && sym.owner.is(Method, butNot = Label))
-        (sym.name ++ NJ ++ sym.owner.name).freshened
+        sym.name.rewrite {
+          case name: SimpleTermName => ExpandPrefixName(sym.owner.name.asTermName, name)
+        }.freshened
       else sym.name.freshened
 
     private def generateProxies()(implicit ctx: Context): Unit =

--- a/tests/pending/pos/t0055.scala
+++ b/tests/pending/pos/t0055.scala
@@ -4,3 +4,10 @@ class W {
   trait Y { def y = () }
 }
 class Z(r : Any) { def this() = this(null) }
+
+object Test {
+  def main(args: Array[String]) = {
+    val w = new W
+  }
+
+}

--- a/tests/pos/lambdalift.scala
+++ b/tests/pos/lambdalift.scala
@@ -22,4 +22,21 @@ object test {
     fun("abc")
 
   }
+
+  class D(f: Int => Int) { self =>
+    assert(f(0) == 3)
+    def foo = 2
+
+    def g(xxx: Int) = {
+
+      class E extends D(y => xxx + y) {
+       // println(self.foo)
+      }
+
+      new E
+    }
+    g(3)
+  }
+
+  new D(y => 3)
 }

--- a/tests/pos/lambdalift.scala
+++ b/tests/pos/lambdalift.scala
@@ -25,12 +25,10 @@ object test {
 
   class D(f: Int => Int) { self =>
     assert(f(0) == 3)
-    def foo = 2
 
     def g(xxx: Int) = {
 
       class E extends D(y => xxx + y) {
-       // println(self.foo)
       }
 
       new E


### PR DESCRIPTION
Several problems. The first had to do with name mangling. The second concerned handling of symbols in super calls, augmenting #2216. Finally, the third problem concerned interaction between
symbols in super calls and outer accessor generation. 