### PR TITLE
Fix #2253 edge cases: recurse into refined type

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -537,7 +537,12 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
               tp.refinedName,
               tpb.derivedTypeBounds(follow(lo, false), follow(hi, true))
             )
-          case tp => tp
+          case _ =>
+            tp.derivedRefinedType(
+              expose(tp.parent),
+              tp.refinedName,
+              tp.refinedInfo
+            )
         }
       case _ => tp
     }

--- a/tests/patmat/i2253.check
+++ b/tests/patmat/i2253.check
@@ -1,0 +1,3 @@
+27: Pattern Match Exhaustivity: HasIntXIntM, HasIntXStringM
+28: Pattern Match Exhaustivity: HasIntXIntM
+29: Pattern Match Exhaustivity: HasIntXIntM

--- a/tests/patmat/i2253.scala
+++ b/tests/patmat/i2253.scala
@@ -1,7 +1,30 @@
 sealed trait S
-object O extends S
+
+object BodylessObject extends S
+
+object HasIntM extends S {
+  type M = Int
+}
+
+object HasStringXStringM extends S {
+  type M = String
+  val x: String = ""
+}
+
+object HasIntXStringM extends S {
+  type M = String
+  val x: Int = 0
+}
+
+object HasIntXIntM extends S {
+  type M = Int
+  val x: Int = 0
+}
+
 trait T
 
 class Test {
-  def m(s: S { val x: Int }) = s match { case _: T => ; }
+  def onlyIntX(s: S { val x: Int }) = s match { case _: T => ; }
+  def exposeAlias1[I <: Int](s: S { type M = I; val x: Int }) = s match { case _: T => ; }
+  def exposeAlias2[I <: Int](s: S { val x: Int; type M = I }) = s match { case _: T => ; }
 }


### PR DESCRIPTION
I managed to get some interesting results after #2257:
```scala
scala> trait T1; trait T2; sealed trait S; object O extends S with T2; object O2
defined trait T1
defined trait T2
defined trait S
defined module O
defined module O2
scala> def m(s: S { val x: T2 }) = s match { case _: T1 => ; }
-- [E028] Pattern Match Exhaustivity Warning: <console> ------------------------
7 |def m(s: S { val x: T2 }) = s match { case _: T1 => ; }
  |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |                            match may not be exhaustive.
  |
  |                            It would fail on: O
```

This should hopefully fix such cases. @liufengyun could you please review?