### PR TITLE
Make warm compilation speed with sbt 2x faster

### DIFF
--- a/sbt-bridge/src/xsbt/CompilerClassLoader.scala
+++ b/sbt-bridge/src/xsbt/CompilerClassLoader.scala
@@ -80,8 +80,9 @@ object CompilerClassLoader {
    *  @param bridgeLoader  The classloader that sbt uses to load the compiler bridge
    *  @return A fixed classloader that works with dotty
    */
-  def fixBridgeLoader(bridgeLoader: ClassLoader): ClassLoader =
+  def fixBridgeLoader(bridgeLoader: ClassLoader): ClassLoader = synchronized {
     fixedLoaderCache.getOrElseUpdate(bridgeLoader, computeFixedLoader(bridgeLoader))
+  }
 
   private[this] def computeFixedLoader(bridgeLoader: ClassLoader) = bridgeLoader match {
     case bridgeLoader: URLClassLoader =>


### PR DESCRIPTION
Previously, every call to `compile` in sbt with dotty took about the
same time because we created a new ClassLoader everytime and thus
thrased the JIT code cache, by reusing ClassLoaders we can make
`compile` about 2x faster.

You can reproduce this by running:
```shell
> dotty-compiler-bootstrapped/compile
```
This takes ~50 seconds on my machine. Then clean using:
```shell
> ;dotty-compiler-bootstrapped/clean;dotty-compiler-update
```
And run `dotty-compiler-bootstrapped/compile` again, this takes ~25
seconds for me. I get very similar timings from scalac (replacing
`dotty-compiler-bootstrapped` by `dotty-compiler`).