### PR TITLE
Make sure basic enums work with REPL

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2151,7 +2151,7 @@ object Parsers {
     /** EnumCaseStats = EnumCaseStat {semi EnumCaseStat */
     def enumCaseStats(): List[DefTree] = {
       val cases = new ListBuffer[DefTree] += enumCaseStat()
-      while (in.token != RBRACE) {
+      while (in.token != RBRACE && in.token != EOF) {
         acceptStatSep()
         cases += enumCaseStat()
       }

--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -31,7 +31,7 @@ object SyntaxHighlighting {
   private val tripleQs = Console.RED_B + "???" + NoColor
 
   private val keywords: Seq[String] = for {
-    index <- IF to INLINE // All alpha keywords
+    index <- IF to ENUM // All alpha keywords
   } yield tokenString(index)
 
   private val interpolationPrefixes =


### PR DESCRIPTION
These changes make sure that

- enums are correctly highlighted in the REPL
- infinite loop does not occur when parsing: `enum Option[+T] {<EOF>`