### PR TITLE
Put -bin- in dotty version number

### DIFF
--- a/compiler/test/dotc/tests.scala
+++ b/compiler/test/dotc/tests.scala
@@ -250,7 +250,7 @@ class tests extends CompilerTest {
 
   @Test def dotc_typer = compileDir(dotcDir, "typer")// twice omitted to make tests run faster
     // error: error while loading Checking$$anon$2$,
-    // class file 'target/scala-2.11/dotty_2.11-0.1.1-SNAPSHOT.jar(dotty/tools/dotc/typer/Checking$$anon$2.class)'
+    // class file 'target/scala-2.11/dotty_2.11-0.1.1-bin-SNAPSHOT.jar(dotty/tools/dotc/typer/Checking$$anon$2.class)'
     // has location not matching its contents: contains class $anon
 
   @Test def dotc_util = compileDir(dotcDir, "util") // twice omitted to make tests run faster

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,9 +21,9 @@ object Build {
     val baseVersion = "0.1.1"
     val isNightly = sys.env.get("NIGHTLYBUILD") == Some("yes")
     if (isNightly)
-      baseVersion + "-" + VersionUtil.commitDate + "-" + VersionUtil.gitHash + "-NIGHTLY"
+      baseVersion + "-bin-" + VersionUtil.commitDate + "-" + VersionUtil.gitHash + "-NIGHTLY"
     else
-      baseVersion + "-SNAPSHOT"
+      baseVersion + "-bin-SNAPSHOT"
   }
 
   val jenkinsMemLimit = List("-Xmx1500m")
@@ -573,7 +573,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/compilerReporter/simple/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/compilerReporter/simple/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/discovery/test-discovery/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/discovery/test-discovery/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/abstract-override/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/abstract-override/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/abstract-type-override/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/abstract-type-override/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/abstract-type/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/abstract-type/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/added/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/added/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/as-seen-from-a/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/as-seen-from-a/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/as-seen-from-b/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/as-seen-from-b/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/backtick-quoted-names/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/backtick-quoted-names/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/binary/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/binary/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/by-name/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/by-name/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/canon/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/canon/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/compactify/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/compactify/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/constants/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/constants/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/default-params/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/default-params/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/dup-class/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/dup-class/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/empty-a/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/empty-a/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/empty-package/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/empty-package/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/erasure/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/erasure/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/export-jars/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/export-jars/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/ext/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/ext/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/false-error/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/false-error/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/fbounded-existentials/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/fbounded-existentials/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/implicit-params/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/implicit-params/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/implicit-search-companion-scope/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/implicit-search-companion-scope/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/implicit-search/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/implicit-search/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/implicit/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/implicit/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/import-class/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/import-class/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/import-package/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/import-package/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/inherited-deps-java/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/inherited-deps-java/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/inherited_type_params/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/inherited_type_params/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/inline/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/inline/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/intermediate-error/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/intermediate-error/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/java-analysis-serialization-error/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/java-analysis-serialization-error/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/java-basic/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/java-basic/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/java-generic-workaround/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/java-generic-workaround/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/java-mixed/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/java-mixed/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/java-static/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/java-static/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/lazy-val/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/lazy-val/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/less-inter-inv-java/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/less-inter-inv-java/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/less-inter-inv/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/less-inter-inv/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/linearization/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/linearization/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/named/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/named/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/nested-case-class/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/nested-case-class/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/new-cyclic/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/new-cyclic/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/new-pkg-dep/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/new-pkg-dep/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/override/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/override/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/parent-change/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/parent-change/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/parent-member-change/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/parent-member-change/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/pkg-self/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/pkg-self/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/qualified-access/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/qualified-access/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/relative-source-error/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/relative-source-error/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/remove-test-a/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/remove-test-a/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/remove-test-b/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/remove-test-b/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/repeated-parameters/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/repeated-parameters/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/replace-test-a/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/replace-test-a/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/resident-java/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/resident-java/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/resident-package-object/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/resident-package-object/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/restore-classes/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/restore-classes/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/same-file-used-names/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/same-file-used-names/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/sealed/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/sealed/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/signature-change/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/signature-change/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/specialized/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/specialized/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/stability-change/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/stability-change/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/synthetic-companion/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/synthetic-companion/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/trait-member-modified/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/trait-member-modified/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/trait-private-object/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/trait-private-object/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/trait-private-var/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/trait-private-var/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/trait-super/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/trait-super/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/transitive-a/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/transitive-a/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/transitive-b/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/transitive-b/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/transitive-inherit-java/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/transitive-inherit-java/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/transitive-inherit/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/transitive-inherit/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/transitive-memberRef/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/transitive-memberRef/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/type-alias/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/type-alias/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/type-parameter/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/type-parameter/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/typeref-only/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/typeref-only/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/typeref-return/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/typeref-return/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/types-in-used-names-a/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/types-in-used-names-a/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/types-in-used-names-b/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/types-in-used-names-b/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/value-class/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/value-class/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/var/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/var/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",

--- a/sbt-bridge/sbt-test/source-dependencies/variance/project/DottyInjectedPlugin.scala
+++ b/sbt-bridge/sbt-test/source-dependencies/variance/project/DottyInjectedPlugin.scala
@@ -6,7 +6,7 @@ object DottyInjectedPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override val projectSettings = Seq(
-    scalaVersion := "0.1.1-SNAPSHOT",
+    scalaVersion := "0.1.1-bin-SNAPSHOT",
     scalaOrganization := "ch.epfl.lamp",
     scalacOptions += "-language:Scala2",
     scalaBinaryVersion  := "2.11",


### PR DESCRIPTION
We need to put "-bin" between the actual version number (0.1.X) and
-SNAPSHOT or -XXX-NIGHTLY if we want sbt's scalaBinaryVersion to return
0.1. Unfortunately this is not enough: sbt will still return the full
version number for versions less than 2.10, fixing this will require
patching sbt, but it's good if we get the version number right already.