### PR TITLE
Only recreate dotty-compiler jar if it changed

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -275,7 +275,11 @@ object Build {
       resourceGenerators in Compile += Def.task {
         val file = (resourceManaged in Compile).value / "compiler.properties"
         val contents = s"version.number=${version.value}"
-        IO.write(file, contents)
+
+        if (!(file.exists && IO.read(file) == contents)) {
+          IO.write(file, contents)
+        }
+
         Seq(file)
       }.taskValue,
 


### PR DESCRIPTION
Previously `dotty-compiler/packageBin` always recreated the jar because
we overwrote the compiler.properties ressource file.