### PR TITLE
Fix incremental compilation dependency tracking

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -8,7 +8,7 @@ import Names._, NameOps._, StdNames._
 
 import scala.collection.{Set, mutable}
 
-import dotty.tools.io.{AbstractFile, Path, PlainFile, ZipArchive}
+import dotty.tools.io.{AbstractFile, Path, ZipArchive}
 import java.io.File
 
 import java.util.{Arrays, Comparator}
@@ -101,7 +101,7 @@ class ExtractDependencies extends Phase {
               val classSegments = Path(ze.path).segments
               binaryDependency(zipFile, className(classSegments))
             }
-          case pf: PlainFile =>
+          case pf: scala.reflect.io.PlainFile =>
             val packages = dep.ownersIterator
               .filter(x => x.is(PackageClass) && !x.isEffectiveRoot).length
             // We can recover the fully qualified name of a classfile from
@@ -109,6 +109,7 @@ class ExtractDependencies extends Phase {
             val classSegments = pf.givenPath.segments.takeRight(packages + 1)
             binaryDependency(pf.file, className(classSegments))
           case _ =>
+            ctx.warning(s"sbt-deps: Ignoring dependency $depFile of class ${depFile.getClass}")
         }
       } else if (depFile.file != currentSourceFile) {
         ctx.sbtCallback.sourceDependency(depFile.file, currentSourceFile, context)


### PR DESCRIPTION
Since #2191, `dotty.tools.dotc.io.PlainFile` is no longer an alias
for  `scala.reflect.io.PlainFile` but its own class. However, the
backend still uses PlainFile from scala.reflect. This mess should soon
be fixed by getting rid of scala-reflect (#2271). Meanwhile, this commit
fixes ExtractDependencies to pattern match on the correct class, and
thus avoid missing dependencies.