### PR TITLE
Remove ProductN parent on case classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -525,6 +525,8 @@ class Definitions {
     def Product_canEqual(implicit ctx: Context) = Product_canEqualR.symbol
     lazy val Product_productArityR = ProductClass.requiredMethodRef(nme.productArity)
     def Product_productArity(implicit ctx: Context) = Product_productArityR.symbol
+    lazy val Product_productElementR = ProductClass.requiredMethodRef(nme.productElement)
+    def Product_productElement(implicit ctx: Context) = Product_productElementR.symbol
     lazy val Product_productPrefixR = ProductClass.requiredMethodRef(nme.productPrefix)
     def Product_productPrefix(implicit ctx: Context) = Product_productPrefixR.symbol
   lazy val LanguageModuleRef = ctx.requiredModule("scala.language")

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -702,7 +702,6 @@ class Definitions {
   def FunctionClassPerRun = new PerRun[Array[Symbol]](implicit ctx => ImplementedFunctionType.map(_.symbol.asClass))
 
   lazy val TupleType = mkArityArray("scala.Tuple", MaxTupleArity, 2)
-  lazy val ProductNType = mkArityArray("scala.Product", MaxTupleArity, 0)
 
   def FunctionClass(n: Int, isImplicit: Boolean = false)(implicit ctx: Context) =
     if (isImplicit) ctx.requiredClass("scala.ImplicitFunction" + n.toString)
@@ -717,7 +716,6 @@ class Definitions {
     else FunctionClass(n, isImplicit).typeRef
 
   private lazy val TupleTypes: Set[TypeRef] = TupleType.toSet
-  private lazy val ProductTypes: Set[TypeRef] = ProductNType.toSet
 
   /** If `cls` is a class in the scala package, its name, otherwise EmptyTypeName */
   def scalaClassName(cls: Symbol)(implicit ctx: Context): TypeName =

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
@@ -116,9 +116,12 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
      */
     def productElementBody(arity: Int, index: Tree)(implicit ctx: Context): Tree = {
       val ioob = defn.IndexOutOfBoundsException.typeRef
-      // That's not ioob.typeSymbol.primaryConstructor, this is the other one
-      // that takes a String argument.
-      val constructor = ioob.typeSymbol.info.decls.toList.tail.head.asTerm
+      // Second constructor of ioob that takes a String argument
+      def filterStringConstructor(s: Symbol): Boolean = s.info match {
+        case m: MethodType if s.isConstructor => m.paramInfos == List(defn.StringType)
+        case _ => false
+      }
+      val constructor = ioob.typeSymbol.info.decls.find(filterStringConstructor _).asTerm
       val stringIndex = Apply(Select(index, nme.toString_), Nil)
       val error = Throw(New(ioob, constructor, List(stringIndex)))
 

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
@@ -17,6 +17,7 @@ import scala.language.postfixOps
 
 /** Synthetic method implementations for case classes, case objects,
  *  and value classes.
+ *
  *  Selectively added to case classes/objects, unless a non-default
  *  implementation already exists:
  *    def equals(other: Any): Boolean
@@ -26,12 +27,12 @@ import scala.language.postfixOps
  *    def productElement(i: Int): Any
  *    def productArity: Int
  *    def productPrefix: String
+ *
  *  Special handling:
  *    protected def readResolve(): AnyRef
  *
  *  Selectively added to value classes, unless a non-default
  *  implementation already exists:
- *
  *    def equals(other: Any): Boolean
  *    def hashCode(): Int
  */
@@ -51,8 +52,7 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
   def valueSymbols(implicit ctx: Context) = { initSymbols; myValueSymbols }
   def caseSymbols(implicit ctx: Context) = { initSymbols; myCaseSymbols }
 
-  /** The synthetic methods of the case or value class `clazz`.
-   */
+  /** The synthetic methods of the case or value class `clazz`. */
   def syntheticMethods(clazz: ClassSymbol)(implicit ctx: Context): List[Tree] = {
     val clazzType = clazz.typeRef
     lazy val accessors =
@@ -135,18 +135,22 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
 
     /** The class
      *
-     *      case class C(x: T, y: U)
+     *  ```
+     *  case class C(x: T, y: U)
+     *  ```
      *
-     *  gets the equals method:
+     *  gets the `equals` method:
      *
-     *      def equals(that: Any): Boolean =
-     *        (this eq that) || {
-     *          that match {
-     *            case x$0 @ (_: C) => this.x == this$0.x && this.y == x$0.y
-     *            case _ => false
-     *         }
+     *  ```
+     *  def equals(that: Any): Boolean =
+     *    (this eq that) || {
+     *      that match {
+     *        case x$0 @ (_: C) => this.x == this$0.x && this.y == x$0.y
+     *        case _ => false
+     *     }
+     *  ```
      *
-     *  If C is a value class the initial `eq` test is omitted.
+     *  If `C` is a value class the initial `eq` test is omitted.
      */
     def equalsBody(that: Tree)(implicit ctx: Context): Tree = {
       val thatAsClazz = ctx.newSymbol(ctx.owner, nme.x_0, Synthetic, clazzType, coord = ctx.owner.pos) // x$0
@@ -168,11 +172,15 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
 
     /** The class
      *
+     *  ```
      *  class C(x: T) extends AnyVal
+     *  ```
      *
-     *  gets the hashCode method:
+     *  gets the `hashCode` method:
      *
-     *    def hashCode: Int = x.hashCode()
+     *  ```
+     *  def hashCode: Int = x.hashCode()
+     *  ```
      */
     def valueHashCodeBody(implicit ctx: Context): Tree = {
       assert(accessors.length == 1)
@@ -181,17 +189,21 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
 
     /** The class
      *
-     *   package p
-     *    case class C(x: T, y: T)
+     *  ```
+     *  package p
+     *  case class C(x: T, y: T)
+     *  ```
      *
-     *  gets the hashCode method:
+     *  gets the `hashCode` method:
      *
-     *    def hashCode: Int = {
-     *      <synthetic> var acc: Int = "p.C".hashCode // constant folded
-     *      acc = Statics.mix(acc, x);
-     *      acc = Statics.mix(acc, Statics.this.anyHash(y));
-     *      Statics.finalizeHash(acc, 2)
-     *    }
+     *  ```
+     *  def hashCode: Int = {
+     *    <synthetic> var acc: Int = "p.C".hashCode // constant folded
+     *    acc = Statics.mix(acc, x);
+     *    acc = Statics.mix(acc, Statics.this.anyHash(y));
+     *    Statics.finalizeHash(acc, 2)
+     *  }
+     *  ```
      */
     def caseHashCodeBody(implicit ctx: Context): Tree = {
       val acc = ctx.newSymbol(ctx.owner, "acc".toTermName, Mutable | Synthetic, defn.IntType, coord = ctx.owner.pos)
@@ -202,7 +214,7 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
       Block(accDef :: mixes, finish)
     }
 
-    /** The hashCode implementation for given symbol `sym`. */
+    /** The `hashCode` implementation for given symbol `sym`. */
     def hashImpl(sym: Symbol)(implicit ctx: Context): Tree =
       defn.scalaClassName(sym.info.finalResultType) match {
         case tpnme.Unit | tpnme.Null               => Literal(Constant(0))
@@ -217,11 +229,15 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
 
     /** The class
      *
-     *    case class C(...)
+     *  ```
+     *  case class C(...)
+     *  ```
      *
-     *  gets the canEqual method
+     *  gets the `canEqual` method
      *
-     *    def canEqual(that: Any) = that.isInstanceOf[C]
+     *  ```
+     *  def canEqual(that: Any) = that.isInstanceOf[C]
+     *  ```
      */
     def canEqualBody(that: Tree): Tree = that.isInstance(clazzType)
 

--- a/tests/neg/t1843-variances.scala
+++ b/tests/neg/t1843-variances.scala
@@ -6,7 +6,7 @@
 
 object Crash {
   trait UpdateType[A]
-  case class StateUpdate[+A](updateType : UpdateType[A], value : A) // error
+  case class StateUpdate[+A](updateType : UpdateType[A], value : A) // error // error
   case object IntegerUpdateType extends UpdateType[Integer]
 
   //However this method will cause a crash

--- a/tests/run/i2314.scala
+++ b/tests/run/i2314.scala
@@ -1,0 +1,37 @@
+case class A(i: Int, s: String)
+
+case class B(i: Int, s: String) {
+  // No override, these methods will be added by SyntheticMethods only if
+  // there are not user defined.
+  def productArity = -1
+  def productElement(i: Int): Any = None
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val a = A(1, "s")
+    assert(a.productArity == 2)
+    assert(a.productElement(0) == 1)
+    assert(a.productElement(1) == "s")
+
+    try {
+      a.productElement(-1)
+      ???
+    } catch {
+      case e: IndexOutOfBoundsException =>
+        assert(e.getMessage == "-1")
+    }
+    try {
+      a.productElement(2)
+      ???
+    } catch {
+      case e: IndexOutOfBoundsException =>
+        assert(e.getMessage == "2")
+    }
+
+    val b = B(1, "s")
+    assert(b.productArity == -1)
+    assert(b.productElement(0) == None)
+    assert(b.productElement(1) == None)
+  }
+}


### PR DESCRIPTION
This means the compiler needs to systematically synthesise productElement and
productArity, which aligns with what scalac is doing.

This change gets rid of last reference to `scala.ProductN`! :tada:
