### PR TITLE
Fix #2299: Fix import into IDEs

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -150,6 +150,8 @@ object Build {
       crossPaths := false,
       // Do not depend on the Scala library
       autoScalaLibrary := false,
+      // Let the sbt eclipse plugin now that this is a Java-only project
+      EclipseKeys.projectFlavor := EclipseProjectFlavor.Java,
       //Remove javac invalid options in Compile doc
       javacOptions in (Compile, doc) --= Seq("-Xlint:unchecked", "-Xlint:deprecation")
     ).


### PR DESCRIPTION
Both IntelliJ and Eclipse fail horribly when trying to import a project
using `unmanagedSourceDirectories` containing files (and not
directories), but this is necessary for our build since we only want to
compile a subset of the backend folder. We workaround this by
linking (or copying on OS when symbolic links do not work) the files we
want to compile in sbt `managedSources`.
    
Make sure to run `sbt compile` at least once before running `sbt
eclipse` or importing the project in IntelliJ.