### PR TITLE
Add a DOTTY_SCALA_LIBRARY env variable to run the tests with Eclipse

### DIFF
--- a/compiler/test/dotty/Jars.scala
+++ b/compiler/test/dotty/Jars.scala
@@ -25,13 +25,14 @@ object Jars {
   val dottyTestDeps: List[String] =
     dottyLib :: dottyCompiler :: dottyInterfaces :: dottyExtras
 
+  def scalaLibrary: String = sys.env.get("DOTTY_SCALA_LIBRARY")
+    .getOrElse(findJarFromRuntime("scala-library-2."))
+
   /** Gets the scala 2.* library at runtime, note that doing this is unsafe
    *  unless you know that the library will be on the classpath of the running
    *  application. It is currently safe to call this function if the tests are
    *  run by sbt.
    */
-  def scalaLibraryFromRuntime: String = findJarFromRuntime("scala-library-2.")
-
   private def findJarFromRuntime(partialName: String) = {
     val urls = ClassLoader.getSystemClassLoader.asInstanceOf[java.net.URLClassLoader].getURLs.map(_.getFile.toString)
     urls.find(_.contains(partialName)).getOrElse {

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -343,7 +343,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
         val fullArgs = Array(
           "javac",
           "-classpath",
-          s".:${Jars.scalaLibraryFromRuntime}:${targetDir.getAbsolutePath}"
+          s".:${Jars.scalaLibrary}:${targetDir.getAbsolutePath}"
         ) ++ flags.takeRight(2) ++ fs
 
         Runtime.getRuntime.exec(fullArgs).waitFor() == 0

--- a/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
+++ b/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
@@ -153,7 +153,7 @@ trait RunnerOrchestration {
       val sep = sys.props("file.separator")
       val cp =
         classOf[ChildJVMMain].getProtectionDomain.getCodeSource.getLocation.getFile + ":" +
-        Jars.scalaLibraryFromRuntime
+        Jars.scalaLibrary
       val javaBin = sys.props("java.home") + sep + "bin" + sep + "java"
       new ProcessBuilder(javaBin, "-cp", cp, "dotty.tools.vulpix.ChildJVMMain")
         .redirectErrorStream(true)


### PR DESCRIPTION
The way we find scala-library is a giant hack that we should fix at some point.