### PR TITLE
Update CompilerTests to new jar

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilerTest.scala
+++ b/compiler/test/dotty/tools/dotc/CompilerTest.scala
@@ -77,7 +77,7 @@ abstract class CompilerTest {
     fs: Array[String],
     args: Array[String]
   )(implicit defaultOptions: List[String]): Boolean = {
-    val scalaLib = findJarFromRuntime("scala-library")
+    val scalaLib = dotty.Jars.scalaLibrary
     val fullArgs = Array(
       "javac",
       "-classpath",


### PR DESCRIPTION
I can't run the new CompilationTests for a number of reasons
under Eclipse. Updating CompilerTests to work under the new
build.