### PR TITLE
Change backend name handling

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -535,11 +535,8 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     }
   }
 
-
   implicit def nameHelper(n: Name): NameHelper = new NameHelper {
-    def toTypeName: Name = n.toTypeName
     def isTypeName: Boolean = n.isTypeName
-    def toTermName: Name = n.toTermName
     def isTermName: Boolean = n.isTermName
     def startsWith(s: String): Boolean = n.startsWith(s)
   }

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -409,11 +409,10 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     def newSet[K](): mutable.Set[K] = new mutable.HashSet[K]
   }
 
-
-
   val MODULE_INSTANCE_FIELD: String = nme.MODULE_INSTANCE_FIELD.toString
 
-  def internalNameString(offset: Int, length: Int): String = new String(Names.chrs, offset, length)
+  def dropModule(str: String) =
+    if (!str.isEmpty && str.last == '$') str.take(str.length - 1) else str
 
   def newTermName(prefix: String): Name = prefix.toTermName
 
@@ -423,7 +422,6 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
       Flags.Specialized | Flags.Lifted | Flags.Protected | Flags.JavaStatic |
       Flags.Bridge | Flags.VBridge | Flags.Private | Flags.Macro
   }.bits
-
 
   def isQualifierSafeToElide(qual: Tree): Boolean = tpd.isIdempotentExpr(qual)
   def desugarIdent(i: Ident): Option[tpd.Select] = {
@@ -557,7 +555,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     def fullName: String = sym.showFullName
     def simpleName: Name = sym.name
     def javaSimpleName: Name = toDenot(sym).name // addModuleSuffix(simpleName.dropLocal)
-    def javaBinaryName: Name = javaClassName.replace('.', '/').toTypeName // TODO: can we make this a string? addModuleSuffix(fullNameInternal('/'))
+    def javaBinaryName: String = javaClassName.replace('.', '/') // TODO: can we make this a string? addModuleSuffix(fullNameInternal('/'))
     def javaClassName: String = toDenot(sym).fullName.toString// addModuleSuffix(fullNameInternal('.')).toString
     def name: Name = sym.name
     def rawname: Name = {

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -404,7 +404,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     def newAnyRefMap[K <: AnyRef, V](): mutable.AnyRefMap[K, V] = new mutable.AnyRefMap[K, V]()
     def newWeakMap[K, V](): mutable.WeakHashMap[K, V] = new mutable.WeakHashMap[K, V]()
     def recordCache[T <: Clearable](cache: T): T = cache
-    def newWeakSet[K <: AnyRef](): WeakHashSet[K] = new WeakHashSet[K]()
+    def newWeakSet[K >: Null <: AnyRef](): WeakHashSet[K] = new WeakHashSet[K]()
     def newMap[K, V](): mutable.HashMap[K, V] = new mutable.HashMap[K, V]()
     def newSet[K](): mutable.Set[K] = new mutable.HashSet[K]
   }
@@ -540,14 +540,9 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     def toTypeName: Name = n.toTypeName
     def isTypeName: Boolean = n.isTypeName
     def toTermName: Name = n.toTermName
-    def dropModule: Name = n.stripModuleClassSuffix
-
-    def len: Int = n.toSimpleName.length
-    def offset: Int = n.toSimpleName.start
     def isTermName: Boolean = n.isTermName
     def startsWith(s: String): Boolean = n.startsWith(s)
   }
-
 
   implicit def symHelper(sym: Symbol): SymbolHelper = new SymbolHelper {
     // names

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -50,8 +50,11 @@ class GenBCode extends Phase {
     new PlainDirectory(new Directory(new JFile(ctx.settings.d.value)))
 
   def run(implicit ctx: Context): Unit = {
-    new GenBCodePipeline(entryPoints.toList,
-        new DottyBackendInterface(outputDir, superCallsMap.toMap)(ctx))(ctx).run(ctx.compilationUnit.tpdTree)
+    val saved = Names.useMangled
+    Names.useMangled = true
+    try new GenBCodePipeline(entryPoints.toList,
+          new DottyBackendInterface(outputDir, superCallsMap.toMap)(ctx))(ctx).run(ctx.compilationUnit.tpdTree)
+    finally Names.useMangled = saved
     entryPoints.clear()
   }
 }

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -50,11 +50,8 @@ class GenBCode extends Phase {
     new PlainDirectory(new Directory(new JFile(ctx.settings.d.value)))
 
   def run(implicit ctx: Context): Unit = {
-    val saved = Names.useMangled
-    Names.useMangled = true
-    try new GenBCodePipeline(entryPoints.toList,
-          new DottyBackendInterface(outputDir, superCallsMap.toMap)(ctx))(ctx).run(ctx.compilationUnit.tpdTree)
-    finally Names.useMangled = saved
+    new GenBCodePipeline(entryPoints.toList,
+        new DottyBackendInterface(outputDir, superCallsMap.toMap)(ctx))(ctx).run(ctx.compilationUnit.tpdTree)
     entryPoints.clear()
   }
 }
@@ -205,7 +202,7 @@ class GenBCodePipeline(val entryPoints: List[Symbol], val int: DottyBackendInter
 
         if (claszSymbol.isClass) // @DarkDimius is this test needed here?
           for (binary <- ctx.compilationUnit.pickled.get(claszSymbol.asClass)) {
-            val dataAttr = new CustomAttr(nme.TASTYATTR.toString, binary)
+            val dataAttr = new CustomAttr(nme.TASTYATTR.mangledString, binary)
             val store = if (mirrorC ne null) mirrorC else plainC
             store.visitAttribute(dataAttr)
             if (ctx.settings.emitTasty.value) {

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -49,6 +49,13 @@ object Config {
    */
   final val checkNoSkolemsInInfo = false
 
+  /** Check that Name#toString is not called directly from backend by analyzing
+   *  the stack trace of each toString call on names. This is very expensive,
+   *  so not suitable for continuous testing. But it can be used to find a problem
+   *  when running a specific test.
+   */
+  final val checkBackendNames = false
+
   /** Type comparer will fail with an assert if the upper bound
    *  of a constrained parameter becomes Nothing. This should be turned
    *  on only for specific debugging as normally instantiation to Nothing

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -582,7 +582,7 @@ object Denotations {
     def hasUniqueSym: Boolean
     protected def newLikeThis(symbol: Symbol, info: Type): SingleDenotation
 
-    final def signature(implicit ctx: Context): Signature = {
+    final def signature(implicit ctx: Context): Signature =
       if (isType) Signature.NotAMethod // don't force info if this is a type SymDenotation
       else info match {
         case info: MethodicType =>
@@ -594,7 +594,6 @@ object Denotations {
           }
         case _ => Signature.NotAMethod
       }
-    }
 
     def derivedSingleDenotation(symbol: Symbol, info: Type)(implicit ctx: Context): SingleDenotation =
       if ((symbol eq this.symbol) && (info eq this.info)) this

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -293,6 +293,10 @@ object Names {
       else {
         if (Config.checkBackendNames) {
           if (!toStringOK) {
+            // We print the stacktrace instead of doing an assert directly,
+            // because asserts are caught in exception handlers which might
+            // cause other failures. In that case the first, important failure
+            // is lost.
             println("Backend should not call Name#toString, Name#mangledString should be used instead.")
             new Error().printStackTrace()
             assert(false)
@@ -301,6 +305,9 @@ object Names {
         new String(chrs, start, length)
       }
 
+    /** It's OK to take a toString if the stacktrace does not occur a method
+     *  in GenBCode or it also contains one of the whitelisted methods below.
+     */
     private def toStringOK = {
       val trace = Thread.currentThread.getStackTrace
       !trace.exists(_.getClassName.endsWith("GenBCode")) ||

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -21,11 +21,6 @@ import java.util.HashMap
 object Names {
   import NameKinds._
 
-  // Gross hack because the backend uses toString on arbitrary names, which means
-  // that the NameHelper abstraction is leaky. As long as cannot get rid of this,
-  // parallel compilation is impossible.
-  @sharable var useMangled: Boolean = false
-
   /** A common class for things that can be turned into names.
    *  Instances are both names and strings, the latter via a decorator.
    */
@@ -72,6 +67,7 @@ object Names {
     def asSimpleName: SimpleTermName
     def toSimpleName: SimpleTermName
     def mangled: Name
+    def mangledString: String = mangled.toString
 
     def rewrite(f: PartialFunction[Name, Name]): ThisName
     def collect[T](f: PartialFunction[Name, T]): Option[T]
@@ -293,10 +289,7 @@ object Names {
 
     override def toString =
       if (length == 0) ""
-      else {
-        val n = if (useMangled) mangled.asSimpleName else this
-        new String(chrs, n.start, n.length)
-      }
+      else new String(chrs, start, length)
 
     def debugString: String = toString
   }

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -21,6 +21,11 @@ import java.util.HashMap
 object Names {
   import NameKinds._
 
+  // Gross hack because the backend uses toString on arbitrary names, which means
+  // that the NameHelper abstraction is leaky. As long as cannot get rid of this,
+  // parallel compilation is impossible.
+  @sharable var useMangled: Boolean = false
+
   /** A common class for things that can be turned into names.
    *  Instances are both names and strings, the latter via a decorator.
    */
@@ -287,7 +292,11 @@ object Names {
     override def hashCode: Int = start
 
     override def toString =
-      if (length == 0) "" else new String(chrs, start, length)
+      if (length == 0) ""
+      else {
+        val n = if (useMangled) mangled.asSimpleName else this
+        new String(chrs, n.start, n.length)
+      }
 
     def debugString: String = toString
   }

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -33,6 +33,7 @@ object StdNames {
     final val INTERPRETER_LINE_PREFIX    = "line"
     final val INTERPRETER_VAR_PREFIX     = "res"
     final val INTERPRETER_WRAPPER_SUFFIX = "$object"
+    final val MODULE_INSTANCE_FIELD      = NameTransformer.MODULE_INSTANCE_NAME  // "MODULE$"
 
     final val Function                   = "Function"
     final val ImplicitFunction           = "ImplicitFunction"

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -220,7 +220,7 @@ class SymbolLoaders {
       if (!sourceModule.isCompleted)
         sourceModule.completer.complete(sourceModule)
 
-      val packageName = if (root.isEffectiveRoot) "" else root.fullName.toString
+      val packageName = if (root.isEffectiveRoot) "" else root.fullName.mangledString
 
       enterFlatClasses = Some { ctx =>
         enterFlatClasses = None

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -677,7 +677,7 @@ class ClassfileParser(
     for (entry <- innerClasses.values) {
       // create a new class member for immediate inner classes
       if (entry.outerName == currentClassName) {
-        val file = ctx.platform.classPath.findClassFile(entry.externalName.toString) getOrElse {
+        val file = ctx.platform.classPath.findClassFile(entry.externalName.mangledString) getOrElse {
           throw new AssertionError(entry.externalName)
         }
         enterClassAndModule(entry, file, entry.jflags)

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -63,7 +63,7 @@ class TreeChecker extends Phase with SymTransformer {
   val NoSuperClass = Trait | Package
 
   def testDuplicate(sym: Symbol, registry: mutable.Map[String, Symbol], typ: String)(implicit ctx: Context) = {
-    val name = sym.fullName.toString
+    val name = sym.fullName.mangledString
     if (this.flatClasses && registry.contains(name))
         printError(s"$typ defined twice $sym ${sym.id} ${registry(name).id}")
     registry(name) = sym


### PR DESCRIPTION
Change backend name handling to support symbolic names. The idea is to
narrow the interface to names in the backend interface and avoid direct calls
to toString on names.
