### PR TITLE
Fix #2324: Check contexts in right order when looking for idents

### DIFF
--- a/tests/neg/i1641.scala
+++ b/tests/neg/i1641.scala
@@ -2,7 +2,7 @@ package bar { object bippy extends (Double => String) { def apply(x: Double): St
 package object println { def bippy(x: Int, y: Int, z: Int) = "(Int, Int, Int)" }
 object Test {
   def main(args: Array[String]): Unit = {
-    println(bar.bippy(5.5))
+    println(bar.bippy(5.5)) // error
     println(bar.bippy(1, 2, 3)) // error
   }
 }

--- a/tests/pos/i2324.scala
+++ b/tests/pos/i2324.scala
@@ -1,0 +1,16 @@
+object A {
+  def foo: Int = 1
+}
+object B {
+  def foo: Int = 2
+}
+class C {
+  import A._
+  import B._
+
+  def bar: Int = 4
+
+  def foo: Int = 3
+
+  println(foo)
+}


### PR DESCRIPTION
The previous logic would look for members of a class in the outermost scope
where the class is owner. But it should be the innermost scope.
