### PR TITLE
Fix deprecation messages missing a position

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -641,7 +641,7 @@ object RefChecks {
     // in either a deprecated member or a scala bridge method, issue a warning.
     if (sym.isDeprecated && !ctx.owner.ownersIterator.exists(_.isDeprecated)) {
       ctx.deprecationWarning("%s%s is deprecated%s".format(
-        sym, sym.showLocated, sym.deprecationMessage map (": " + _) getOrElse "", pos))
+        sym, sym.showLocated, sym.deprecationMessage map (": " + _) getOrElse ""), pos)
     }
     // Similar to deprecation: check if the symbol is marked with @migration
     // indicating it has changed semantics between versions.

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -640,8 +640,8 @@ object RefChecks {
     // If symbol is deprecated, and the point of reference is not enclosed
     // in either a deprecated member or a scala bridge method, issue a warning.
     if (sym.isDeprecated && !ctx.owner.ownersIterator.exists(_.isDeprecated)) {
-      ctx.deprecationWarning("%s%s is deprecated%s".format(
-        sym, sym.showLocated, sym.deprecationMessage map (": " + _) getOrElse ""), pos)
+      ctx.deprecationWarning("%s is deprecated%s".format(
+        sym.showLocated, sym.deprecationMessage map (": " + _) getOrElse ""), pos)
     }
     // Similar to deprecation: check if the symbol is marked with @migration
     // indicating it has changed semantics between versions.


### PR DESCRIPTION
`pos` was accidentally passed as a fourth argument to `format` and
ignored instead of as a second argument to `deprecationWarning`.