### PR TITLE
Fix #2334: Require at least one digit after '.' in floating point literals

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -634,7 +634,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
         toDenot(sym)(shiftedContext).isStatic(shiftedContext)
       }
 
-    def isStaticConstructor: Boolean = (isStaticMember && isClassConstructor) || (sym.name eq core.Names.STATIC_CONSTRUCTOR)
+    def isStaticConstructor: Boolean = (isStaticMember && isClassConstructor) || (sym.name eq nme.STATIC_CONSTRUCTOR)
 
 
     // navigation

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -137,7 +137,7 @@ class Definitions {
   }
 
   private def newMethod(cls: ClassSymbol, name: TermName, info: Type, flags: FlagSet = EmptyFlags): TermSymbol =
-    newSymbol(cls, name.encode, flags | Method, info).asTerm
+    newSymbol(cls, name, flags | Method, info).asTerm
 
   private def enterMethod(cls: ClassSymbol, name: TermName, info: Type, flags: FlagSet = EmptyFlags): TermSymbol =
     newMethod(cls, name, info, flags).entered
@@ -301,7 +301,7 @@ class Definitions {
   lazy val ScalaPredefModuleRef = ctx.requiredModuleRef("scala.Predef")
   def ScalaPredefModule(implicit ctx: Context) = ScalaPredefModuleRef.symbol
 
-    lazy val Predef_ConformsR = ScalaPredefModule.requiredClass("$less$colon$less").typeRef
+    lazy val Predef_ConformsR = ScalaPredefModule.requiredClass("<:<").typeRef
     def Predef_Conforms(implicit ctx: Context) = Predef_ConformsR.symbol
     lazy val Predef_conformsR = ScalaPredefModule.requiredMethodRef("$conforms")
     def Predef_conforms(implicit ctx: Context) = Predef_conformsR.symbol

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1194,7 +1194,7 @@ object Denotations {
           select(recur(prefix), wrap(selector))
         case qn @ AnyQualifiedName(prefix, _) =>
           recur(prefix, n => wrap(qn.info.mkString(n).toTermName))
-        case path: SimpleTermName =>
+        case path: SimpleName =>
           def recurSimple(len: Int, wrap: TermName => Name): Denotation = {
             val point = path.lastIndexOf('.', len - 1)
             val selector = wrap(path.slice(point + 1, len).asTermName)

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -91,7 +91,7 @@ object NameKinds {
   class PrefixNameKind(tag: Int, prefix: String, optInfoString: String = "")
   extends ClassifiedNameKind(tag, if (optInfoString.isEmpty) s"Prefix $prefix" else optInfoString) {
     def mkString(underlying: TermName, info: ThisInfo) =
-      underlying.mapLast(n => termName(prefix + n.toString)).toString
+      underlying.mapLast(n => termName(prefix + str.sanitize(n.toString))).toString
     override def unmangle(name: SimpleName): TermName =
       if (name.startsWith(prefix)) apply(name.drop(prefix.length).asSimpleName)
       else name
@@ -100,7 +100,8 @@ object NameKinds {
   /** The kind of names that get formed by appending a suffix to an underlying name */
   class SuffixNameKind(tag: Int, suffix: String, optInfoString: String = "")
   extends ClassifiedNameKind(tag, if (optInfoString.isEmpty) s"Suffix $suffix" else optInfoString) {
-    def mkString(underlying: TermName, info: ThisInfo) = underlying.toString ++ suffix
+    def mkString(underlying: TermName, info: ThisInfo) =
+      underlying.mapLast(n => termName(str.sanitize(n.toString) + suffix)).toString
     override def unmangle(name: SimpleName): TermName =
       if (name.endsWith(suffix)) apply(name.take(name.length - suffix.length).asSimpleName)
       else name

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -254,7 +254,7 @@ object NameKinds {
       if (i > 0) {
         val index = name.drop(i).toString.toInt - 1
         var original = name.take(i - str.DEFAULT_GETTER.length).asTermName
-        if (original == nme.DEFAULT_GETTER_INIT) original = Names.CONSTRUCTOR
+        if (original == nme.DEFAULT_GETTER_INIT) original = nme.CONSTRUCTOR
         apply(original, index)
       }
       else name

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -91,7 +91,7 @@ object NameKinds {
   class PrefixNameKind(tag: Int, prefix: String, optInfoString: String = "")
   extends ClassifiedNameKind(tag, if (optInfoString.isEmpty) s"Prefix $prefix" else optInfoString) {
     def mkString(underlying: TermName, info: ThisInfo) =
-      underlying.mapLast(n => termName(prefix + str.sanitize(n.toString))).toString
+      underlying.qualToString(_.toString, n => prefix + n.toString)
     override def unmangle(name: SimpleName): TermName =
       if (name.startsWith(prefix)) apply(name.drop(prefix.length).asSimpleName)
       else name
@@ -101,7 +101,7 @@ object NameKinds {
   class SuffixNameKind(tag: Int, suffix: String, optInfoString: String = "")
   extends ClassifiedNameKind(tag, if (optInfoString.isEmpty) s"Suffix $suffix" else optInfoString) {
     def mkString(underlying: TermName, info: ThisInfo) =
-      underlying.mapLast(n => termName(str.sanitize(n.toString) + suffix)).toString
+      underlying.qualToString(_.toString, n => n.toString + suffix)
     override def unmangle(name: SimpleName): TermName =
       if (name.endsWith(suffix)) apply(name.take(name.length - suffix.length).asSimpleName)
       else name

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -228,7 +228,7 @@ object NameKinds {
       val i = skipSeparatorAndNum(name, separator)
       if (i > 0) {
         val index = name.drop(i).toString.toInt
-        var original = name.take(i - separator.length).asTermName
+        val original = name.take(i - separator.length).asTermName
         apply(original, index)
       }
       else name

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -206,7 +206,7 @@ object NameKinds {
     override def definesNewName = true
 
     def mkString(underlying: TermName, info: ThisInfo) = {
-      val safePrefix = str.sanitize(underlying.toString + separator)
+      val safePrefix = str.sanitize(underlying.toString) + separator
       safePrefix + info.num
     }
 

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -100,8 +100,10 @@ object NameOps {
      *  it is also called from the backend.
      */
     def stripModuleClassSuffix: N = likeSpaced {
-      val semName =
-        if (name.isSimple && name.endsWith("$")) name.unmangleClassName else name
+      val semName = name.toTermName match {
+        case name: SimpleTermName if name.endsWith("$") => name.unmangleClassName
+        case _ => name
+      }
       semName.exclude(ModuleClassName)
     }
 

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -128,15 +128,24 @@ object NameOps {
 
     def errorName: N = likeSpaced(name ++ nme.ERROR)
 
+    /** Map variance value -1, +1 to 0, 1 */
+    private def varianceToNat(v: Int) = (v + 1) / 2
+
+    /** Map 0, 1 to variance value -1, +1 */
+    private def natToVariance(n: Int) = n * 2 - 1
 
     /** Name with variance prefix: `+` for covariant, `-` for contravariant */
-    def withVariance(v: Int): N =
-      likeSpaced { VariantName(name.exclude(VariantName).toTermName, v) }
+    def withVariance(v: Int): N = {
+      val underlying = name.exclude(VariantName)
+      likeSpaced(
+          if (v == 0) underlying
+          else VariantName(underlying.toTermName, varianceToNat(v)))
+    }
 
     /** The variance as implied by the variance prefix, or 0 if there is
      *  no variance prefix.
      */
-    def variance = name.collect { case VariantName(_, n) => n }.getOrElse(0)
+    def variance = name.collect { case VariantName(_, n) => natToVariance(n) }.getOrElse(0)
 
     def freshened(implicit ctx: Context): N = likeSpaced {
       name.toTermName match {

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -52,8 +52,8 @@ object NameOps {
   implicit class NameDecorator[N <: Name](val name: N) extends AnyVal {
     import nme._
 
-    def testSimple(f: SimpleTermName => Boolean): Boolean = name match {
-      case name: SimpleTermName => f(name)
+    def testSimple(f: SimpleName => Boolean): Boolean = name match {
+      case name: SimpleName => f(name)
       case name: TypeName => name.toTermName.testSimple(f)
       case _ => false
     }
@@ -83,7 +83,7 @@ object NameOps {
     def isOpAssignmentName: Boolean = name match {
       case raw.NE | raw.LE | raw.GE | EMPTY =>
         false
-      case name: SimpleTermName =>
+      case name: SimpleName =>
         name.length > 0 && name.last == '=' && name.head != '=' && isOperatorPart(name.head)
       case _ =>
         false
@@ -101,7 +101,7 @@ object NameOps {
      */
     def stripModuleClassSuffix: N = likeSpaced {
       val semName = name.toTermName match {
-        case name: SimpleTermName if name.endsWith("$") => name.unmangleClassName
+        case name: SimpleName if name.endsWith("$") => name.unmangleClassName
         case _ => name
       }
       semName.exclude(ModuleClassName)
@@ -229,7 +229,7 @@ object NameOps {
     def compactified(implicit ctx: Context): TermName = termName(compactify(name.toString))
 
     def unmangleClassName: N = name.toTermName match {
-      case name: SimpleTermName
+      case name: SimpleName
       if name.endsWith(str.MODULE_SUFFIX) && !nme.falseModuleClassNames.contains(name) =>
         likeSpaced(name.dropRight(str.MODULE_SUFFIX.length).moduleClassName)
       case _ => name
@@ -237,11 +237,11 @@ object NameOps {
 
     def unmangle(kind: NameKind): N = likeSpaced {
       name rewrite {
-        case unmangled: SimpleTermName =>
+        case unmangled: SimpleName =>
           kind.unmangle(unmangled)
         case ExpandedName(prefix, last) =>
           kind.unmangle(last) rewrite {
-            case kernel: SimpleTermName =>
+            case kernel: SimpleName =>
               ExpandedName(prefix, kernel)
           }
       }

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -100,10 +100,10 @@ object Names {
     def toText(printer: Printer): Text = printer.toText(this)
 
     /** Replace \$op_name's by corresponding operator symbols. */
-    def decode: Name
+    def decode: ThisName
 
     /** Replace operator symbols by corresponding \$op_name's. */
-    def encode: Name
+    def encode: ThisName
 
     def firstPart: SimpleTermName
     def lastPart: SimpleTermName
@@ -382,8 +382,8 @@ object Names {
   case class DerivedTermName(override val underlying: TermName, override val info: NameInfo)
   extends TermName {
     def isEmpty = false
-    def encode: Name = underlying.encode.derived(info.map(_.encode))
-    def decode: Name = underlying.decode.derived(info.map(_.decode))
+    def encode: ThisName = underlying.encode.derived(info.map(_.encode))
+    def decode: ThisName = underlying.decode.derived(info.map(_.decode))
     def firstPart = underlying.firstPart
     def lastPart = info match {
       case qual: QualifiedInfo => qual.name

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -297,16 +297,16 @@ object Names {
             // because asserts are caught in exception handlers which might
             // cause other failures. In that case the first, important failure
             // is lost.
-            println("Backend should not call Name#toString, Name#mangledString should be used instead.")
-            new Error().printStackTrace()
+            System.err.println("Backend should not call Name#toString, Name#mangledString should be used instead.")
+            Thread.dumpStack()
             assert(false)
           }
         }
         new String(chrs, start, length)
       }
 
-    /** It's OK to take a toString if the stacktrace does not occur a method
-     *  in GenBCode or it also contains one of the whitelisted methods below.
+    /** It's OK to take a toString if the stacktrace does not contain a method
+     *  from GenBCode or it also contains one of the whitelisted methods below.
      */
     private def toStringOK = {
       val trace = Thread.currentThread.getStackTrace

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -82,13 +82,15 @@ object Names {
     def mangledString: String = mangled.toString
 
     /** Apply rewrite rule given by `f` to some part of this name, skipping and rewrapping
-     *  other decorators. Stops at first qualified name that's encountered.
+     *  other decorators.
+     *  Stops at derived names whose kind has `definesNewName = true`.
      *  If `f` does not apply to any part, return name unchanged.
      */
     def rewrite(f: PartialFunction[Name, Name]): ThisName
 
     /** If partial function `f` is defined for some part of this name, apply it
-     *  in a Some, otherwise None. Stops at first qualified name that's encountered.
+     *  in a Some, otherwise None.
+     *  Stops at derived names whose kind has `definesNewName = true`.
      */
     def collect[T](f: PartialFunction[Name, T]): Option[T]
 

--- a/compiler/src/dotty/tools/dotc/core/Signature.scala
+++ b/compiler/src/dotty/tools/dotc/core/Signature.scala
@@ -34,14 +34,6 @@ import scala.annotation.tailrec
 case class Signature(paramsSig: List[TypeName], resSig: TypeName) {
   import Signature._
 
-/* FIXME does not compile under dotty, we get a missing param error
-  def checkUnqual(name: TypeName) = name mapParts { part =>
-    assert(!part.contains('.'), name)
-    part
-  }
-  paramsSig.foreach(checkUnqual)
-  checkUnqual(resSig)
-*/
   /** Two names are consistent if they are the same or one of them is tpnme.Uninstantiated */
   private def consistent(name1: TypeName, name2: TypeName) =
     name1 == name2 || name1 == tpnme.Uninstantiated || name2 == tpnme.Uninstantiated

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -34,7 +34,7 @@ object StdNames {
     final val INTERPRETER_LINE_PREFIX    = "line"
     final val INTERPRETER_VAR_PREFIX     = "res"
     final val INTERPRETER_WRAPPER_SUFFIX = "$object"
-    final val MODULE_INSTANCE_FIELD      = NameTransformer.MODULE_INSTANCE_NAME  // "MODULE$"
+    final val MODULE_INSTANCE_FIELD      = "MODULE$"
 
     final val Function                   = "Function"
     final val ImplicitFunction           = "ImplicitFunction"
@@ -260,7 +260,6 @@ object StdNames {
     val REIFY_FREE_THIS_SUFFIX: N   = "$this"
     val REIFY_FREE_VALUE_SUFFIX: N  = "$value"
     val REIFY_SYMDEF_PREFIX: N      = "symdef$"
-    val MODULE_INSTANCE_FIELD: N    = "MODULE$"
     val OUTER: N                    = "$outer"
     val REFINE_CLASS: N             = "<refinement>"
     val ROOTPKG: N                  = "_root_"

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -24,7 +24,7 @@ object StdNames {
     final val SHADOWED_PREFIX          = "(shadowed)"
     final val AVOID_CLASH_SUFFIX       = "$_avoid_name_clash_$"
     final val MODULE_SUFFIX            = "$"
-    //final val NAME_JOIN                = "$"
+    final val NAME_JOIN                = "$"
     final val DEFAULT_GETTER           = "$default$"
     final val LOCALDUMMY_PREFIX        = "<local "       // owner of local blocks
     final val ANON_CLASS               = "$anon"

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -16,14 +16,15 @@ object StdNames {
 /** Base strings from which synthetic names are derived. */
 
   object str {
-    final val SETTER_SUFFIX            = "_$eq"
+    final val SETTER_SUFFIX            = "_="
     final val EXPAND_SEPARATOR         = "$$"
     final val TRAIT_SETTER_SEPARATOR   = "$_setter_$"
     final val SUPER_PREFIX             = "super$"
     final val INITIALIZER_PREFIX       = "initial$"
     final val SHADOWED_PREFIX          = "(shadowed)"
     final val AVOID_CLASH_SUFFIX       = "$_avoid_name_clash_$"
-    final val MODULE_SUFFIX            = NameTransformer.MODULE_SUFFIX_STRING
+    final val MODULE_SUFFIX            = "$"
+    //final val NAME_JOIN                = "$"
     final val DEFAULT_GETTER           = "$default$"
     final val LOCALDUMMY_PREFIX        = "<local "       // owner of local blocks
     final val ANON_CLASS               = "$anon"
@@ -131,8 +132,7 @@ object StdNames {
     val EXPAND_SEPARATOR: N           = str.EXPAND_SEPARATOR
     val IMPL_CLASS_SUFFIX: N          = "$class"
     val IMPORT: N                     = "<import>"
-    val MODULE_SUFFIX: N              = NameTransformer.MODULE_SUFFIX_STRING
-    val NAME_JOIN: N                  = NameTransformer.NAME_JOIN_STRING
+    val MODULE_SUFFIX: N              = str.MODULE_SUFFIX
     val OPS_PACKAGE: N                = "<special-ops>"
     val OVERLOADED: N                 = "<overloaded>"
     val PACKAGE: N                    = "package"
@@ -259,7 +259,7 @@ object StdNames {
     val REIFY_FREE_THIS_SUFFIX: N   = "$this"
     val REIFY_FREE_VALUE_SUFFIX: N  = "$value"
     val REIFY_SYMDEF_PREFIX: N      = "symdef$"
-    val MODULE_INSTANCE_FIELD: N    = NameTransformer.MODULE_INSTANCE_NAME  // "MODULE$"
+    val MODULE_INSTANCE_FIELD: N    = "MODULE$"
     val OUTER: N                    = "$outer"
     val REFINE_CLASS: N             = "<refinement>"
     val ROOTPKG: N                  = "_root_"
@@ -310,7 +310,7 @@ object StdNames {
     val _21 : N = "_21"
     val _22 : N = "_22"
 
-    val ??? = encode("???")
+    val ??? : N = "???"
 
     val genericWrapArray: N     = "genericWrapArray"
     def wrapRefArray: N         = "wrapRefArray"
@@ -595,36 +595,36 @@ object StdNames {
     def newLazyValSlowComputeName(lzyValName: N) = lzyValName ++ LAZY_SLOW_SUFFIX
 
     // ASCII names for operators
-    val ADD      = encode("+")
-    val AND      = encode("&")
-    val ASR      = encode(">>")
-    val DIV      = encode("/")
-    val EQ       = encode("==")
-    val EQL      = encode("=")
-    val GE       = encode(">=")
-    val GT       = encode(">")
-    val HASHHASH = encode("##")
-    val LE       = encode("<=")
-    val LSL      = encode("<<")
-    val LSR      = encode(">>>")
-    val LT       = encode("<")
-    val MINUS    = encode("-")
-    val MOD      = encode("%")
-    val MUL      = encode("*")
-    val NE       = encode("!=")
-    val OR       = encode("|")
+    val ADD      : N = "+"
+    val AND      : N = "&"
+    val ASR      : N = ">>"
+    val DIV      : N = "/"
+    val EQ       : N = "=="
+    val EQL      : N = "="
+    val GE       : N = ">="
+    val GT       : N = ">"
+    val HASHHASH : N = "##"
+    val LE       : N = "<="
+    val LSL      : N = "<<"
+    val LSR      : N = ">>>"
+    val LT       : N = "<"
+    val MINUS    : N = "-"
+    val MOD      : N = "%"
+    val MUL      : N = "*"
+    val NE       : N = "!="
+    val OR       : N = "|"
     val PLUS     = ADD    // technically redundant, but ADD looks funny with MINUS
     val SUB      = MINUS  // ... as does SUB with PLUS
-    val XOR      = encode("^")
-    val ZAND     = encode("&&")
-    val ZOR      = encode("||")
+    val XOR      : N = "^"
+    val ZAND     : N = "&&"
+    val ZOR      : N = "||"
 
     // unary operators
     val UNARY_PREFIX: N = "unary_"
-    val UNARY_~ = encode("unary_~")
-    val UNARY_+ = encode("unary_+")
-    val UNARY_- = encode("unary_-")
-    val UNARY_! = encode("unary_!")
+    val UNARY_~ : N = "unary_~"
+    val UNARY_+ : N = "unary_+"
+    val UNARY_- : N = "unary_-"
+    val UNARY_! : N = "unary_!"
 
     // Grouped here so Cleanup knows what tests to perform.
     val CommonOpNames   = Set[Name](OR, XOR, AND, EQ, NE)

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -127,7 +127,7 @@ object StdNames {
     val DOLLAR_VALUES: N              = "$values"
     val DOLLAR_NEW: N                 = "$new"
     val EMPTY: N                      = ""
-    val EMPTY_PACKAGE: N              = Names.EMPTY_PACKAGE.toString
+    val EMPTY_PACKAGE: N              = "<empty>"
     val EXCEPTION_RESULT_PREFIX: N    = "exceptionResult"
     val EXPAND_SEPARATOR: N           = str.EXPAND_SEPARATOR
     val IMPL_CLASS_SUFFIX: N          = "$class"
@@ -241,7 +241,8 @@ object StdNames {
 
     // Compiler-internal
     val ANYname: N                  = "<anyname>"
-    val CONSTRUCTOR: N              = Names.CONSTRUCTOR.toString
+    val CONSTRUCTOR: N              = "<init>"
+    val STATIC_CONSTRUCTOR: N       = "<clinit>"
     val DEFAULT_CASE: N             = "defaultCase$"
     val EVT2U: N                    = "evt2u$"
     val EQEQ_LOCAL_VAR: N           = "eqEqTemp$"

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -399,7 +399,7 @@ object SymDenotations {
           kind(prefix.toTermName, if (filler.isEmpty) n else termName(filler + n))
         val fn = name rewrite {
           case name: SimpleName => qualify(name)
-          case name @ AnyQualifiedName(_, _) => qualify(name.toSimpleName)
+          case name @ AnyQualifiedName(_, _) => qualify(name.mangled.toSimpleName)
         }
         if (isType) fn.toTypeName else fn.toTermName
       }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -397,7 +397,7 @@ object SymDenotations {
         var encl = owner
         while (!encl.isClass && !encl.isPackageObject) {
           encl = encl.owner
-          filler += "~"
+          filler += "_$"
         }
         var prefix = encl.fullNameSeparated(kind)
         if (kind.separator == "$")
@@ -499,7 +499,7 @@ object SymDenotations {
      *  step for creating Refinement types.
      */
     final def isRefinementClass(implicit ctx: Context): Boolean =
-      name.decode == tpnme.REFINE_CLASS
+      name == tpnme.REFINE_CLASS
 
     /** Is this symbol a package object or its module class? */
     def isPackageObject(implicit ctx: Context): Boolean = {

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -125,7 +125,6 @@ object SymDenotations {
 
     // ------ Getting and setting fields -----------------------------
 
-    private[this] var myName = initName
     private[this] var myFlags: FlagSet = adaptFlags(initFlags)
     private[this] var myInfo: Type = initInfo
     private[this] var myPrivateWithin: Symbol = initPrivateWithin

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -369,11 +369,7 @@ object SymDenotations {
     /** The expanded name of this denotation. */
     final def expandedName(implicit ctx: Context) =
       if (name.is(ExpandedName) || isConstructor) name
-      else {
-        def legalize(name: Name): Name = // JVM method names may not contain `<' or `>' characters
-          if (is(Method)) name.replace('<', '(').replace('>', ')') else name
-        legalize(name.expandedName(initial.owner))
-      }
+      else name.expandedName(initial.owner)
         // need to use initial owner to disambiguate, as multiple private symbols with the same name
         // might have been moved from different origins into the same class
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -402,10 +402,10 @@ object SymDenotations {
         if (kind.separator == "$")
           // duplicate scalac's behavior: don't write a double '$$' for module class members.
           prefix = prefix.exclude(ModuleClassName)
-        def qualify(n: SimpleTermName) =
+        def qualify(n: SimpleName) =
           kind(prefix.toTermName, if (filler.isEmpty) n else termName(filler + n))
         val fn = name rewrite {
-          case name: SimpleTermName => qualify(name)
+          case name: SimpleName => qualify(name)
           case name @ AnyQualifiedName(_, _) => qualify(name.toSimpleName)
         }
         if (isType) fn.toTypeName else fn.toTermName

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -107,7 +107,7 @@ object SymDenotations {
   class SymDenotation private[SymDenotations] (
     symbol: Symbol,
     ownerIfExists: Symbol,
-    initName: Name,
+    final val name: Name,
     initFlags: FlagSet,
     initInfo: Type,
     initPrivateWithin: Symbol = NoSymbol) extends SingleDenotation(symbol) {
@@ -130,12 +130,6 @@ object SymDenotations {
     private[this] var myInfo: Type = initInfo
     private[this] var myPrivateWithin: Symbol = initPrivateWithin
     private[this] var myAnnotations: List[Annotation] = Nil
-
-    /** The name of the symbol */
-    def name = myName
-
-    /** Update the name; only called when unpickling top-level classes */
-    def name_=(n: Name) = myName = n
 
     /** The owner of the symbol; overridden in NoDenotation */
     def owner: Symbol = ownerIfExists
@@ -1218,12 +1212,12 @@ object SymDenotations {
   class ClassDenotation private[SymDenotations] (
     symbol: Symbol,
     ownerIfExists: Symbol,
-    initName: Name,
+    name: Name,
     initFlags: FlagSet,
     initInfo: Type,
     initPrivateWithin: Symbol,
     initRunId: RunId)
-    extends SymDenotation(symbol, ownerIfExists, initName, initFlags, initInfo, initPrivateWithin) {
+    extends SymDenotation(symbol, ownerIfExists, name, initFlags, initInfo, initPrivateWithin) {
 
     import util.LRUCache
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -373,18 +373,11 @@ object SymDenotations {
         // might have been moved from different origins into the same class
 
     /** The name with which the denoting symbol was created */
-    final def originalName(implicit ctx: Context) =
-      initial.effectiveName
+    final def originalName(implicit ctx: Context) = initial.effectiveName
 
     /** The encoded full path name of this denotation, where outer names and inner names
-     *  are separated by `separator` strings.
-     *  Never translates expansions of operators back to operator symbol.
-     *  Drops package objects. Represents each term in the owner chain by a simple `~`.
-     *  (Note: scalac uses nothing to represent terms, which can cause name clashes
-     *   between same-named definitions in different enclosing methods. Before this commit
-     *   we used `$' but this can cause ambiguities with the class separator '$').
-     *  A separator "" means "flat name"; the real separator in this case is "$" and
-     *  enclosing packages do not form part of the name.
+     *  are separated by `separator` strings as indicated by the given name kind.
+     *  Drops package objects. Represents each term in the owner chain by a simple `_$`.
      */
     def fullNameSeparated(kind: QualifiedNameKind)(implicit ctx: Context): Name =
       if (symbol == NoSymbol ||

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -186,7 +186,7 @@ class SymbolLoaders {
 
     private[core] val currentDecls: MutableScope = new PackageScope()
 
-    def isFlatName(name: SimpleTermName) = name.lastIndexOf('$', name.length - 2) >= 0
+    def isFlatName(name: SimpleName) = name.lastIndexOf('$', name.length - 2) >= 0
 
     def isFlatName(classRep: ClassRepresentation) = {
       val idx = classRep.name.indexOf('$')

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -166,7 +166,13 @@ class SymbolLoaders {
       override def lookupEntry(name: Name)(implicit ctx: Context): ScopeEntry = {
         val mangled = name.mangled
         val e = super.lookupEntry(mangled)
-        if (e != null) e
+        if (e != null) {
+          // Eagerly update symbol's name to undecoded name to avpid the name
+          // spearding to types.
+          if (name.toSimpleName != mangled && e.sym.initialDenot.name == mangled)
+            e.sym.initialDenot.name = name
+          e
+        }
         else if (_sourceModule.initialDenot.name == nme.scala_ && _sourceModule == defn.ScalaPackageVal &&
                  name.isTypeName && name.isSyntheticFunction)
           newScopeEntry(defn.newFunctionNTrait(name.asTypeName))

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -536,7 +536,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
     }
   } catch {
     case ex: AssertionError =>
-      println(s"no sig for $tp")
+      println(s"no sig for $tp because of ${ex.printStackTrace()}")
       throw ex
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3444,7 +3444,7 @@ object Types {
   abstract class FlexType extends UncachedGroundType with ValueType
 
   class ErrorType(_msg: => Message) extends FlexType {
-    val msg = _msg
+    def msg = _msg
   }
 
   object UnspecifiedErrorType extends ErrorType("unspecified error")

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -39,7 +39,7 @@ class ClassfileParser(
   protected val staticScope: MutableScope = newScope       // the scope of all static definitions
   protected var pool: ConstantPool = _              // the classfile's constant pool
 
-  protected var currentClassName: SimpleTermName = _      // JVM name of the current class
+  protected var currentClassName: SimpleName = _      // JVM name of the current class
   protected var classTParams = Map[Name,Symbol]()
 
   classRoot.info = (new NoCompleter).withDecls(instanceScope)
@@ -47,7 +47,7 @@ class ClassfileParser(
 
   private def currentIsTopLevel(implicit ctx: Context) = classRoot.owner is Flags.PackageClass
 
-  private def mismatchError(className: SimpleTermName) =
+  private def mismatchError(className: SimpleName) =
     throw new IOException(s"class file '${in.file}' has location not matching its contents: contains class $className")
 
   def run()(implicit ctx: Context): Option[Embedded] = try {
@@ -254,14 +254,14 @@ class ClassfileParser(
   final def objToAny(tp: Type)(implicit ctx: Context) =
     if (tp.isDirectRef(defn.ObjectClass) && !ctx.phase.erasedTypes) defn.AnyType else tp
 
-  private def sigToType(sig: SimpleTermName, owner: Symbol = null)(implicit ctx: Context): Type = {
+  private def sigToType(sig: SimpleName, owner: Symbol = null)(implicit ctx: Context): Type = {
     var index = 0
     val end = sig.length
     def accept(ch: Char): Unit = {
       assert(sig(index) == ch, (sig(index), ch))
       index += 1
     }
-    def subName(isDelimiter: Char => Boolean): SimpleTermName = {
+    def subName(isDelimiter: Char => Boolean): SimpleName = {
       val start = index
       while (!isDelimiter(sig(index))) { index += 1 }
       sig.slice(start, index)
@@ -901,7 +901,7 @@ class ClassfileParser(
     private val len = in.nextChar
     private val starts = new Array[Int](len)
     private val values = new Array[AnyRef](len)
-    private val internalized = new Array[SimpleTermName](len)
+    private val internalized = new Array[SimpleName](len)
 
     { var i = 1
       while (i < starts.length) {
@@ -928,12 +928,12 @@ class ClassfileParser(
     }
 
     /** Return the name found at given index. */
-    def getName(index: Int): SimpleTermName = {
+    def getName(index: Int): SimpleName = {
       if (index <= 0 || len <= index)
         errorBadIndex(index)
 
       values(index) match {
-        case name: SimpleTermName => name
+        case name: SimpleName => name
         case null   =>
           val start = starts(index)
           if (in.buf(start).toInt != CONSTANT_UTF8) errorBadTag(start)
@@ -948,7 +948,7 @@ class ClassfileParser(
       new DataInputStream(new ByteArrayInputStream(bytes, offset, len)).readUTF
 
     /** Return the name found at given index in the constant pool, with '/' replaced by '.'. */
-    def getExternalName(index: Int): SimpleTermName = {
+    def getExternalName(index: Int): SimpleName = {
       if (index <= 0 || len <= index)
         errorBadIndex(index)
 
@@ -977,7 +977,7 @@ class ClassfileParser(
     /** Return the external name of the class info structure found at 'index'.
      *  Use 'getClassSymbol' if the class is sure to be a top-level class.
      */
-    def getClassName(index: Int): SimpleTermName = {
+    def getClassName(index: Int): SimpleName = {
       val start = starts(index)
       if (in.buf(start).toInt != CONSTANT_CLASS) errorBadTag(start)
       getExternalName(in.getChar(start + 1))

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -92,7 +92,9 @@ class ClassfileParser(
     val nameIdx      = in.nextChar
     currentClassName = pool.getClassName(nameIdx)
 
-    if (currentIsTopLevel && currentClassName != classRoot.fullName.toSimpleName)
+    if (currentIsTopLevel &&
+        currentClassName != classRoot.fullName.toSimpleName &&
+        currentClassName != classRoot.fullName.encode.toSimpleName)
       mismatchError(currentClassName)
 
     addEnclosingTParams()

--- a/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
@@ -4,7 +4,7 @@ package core
 package tasty
 
 import collection.mutable
-import Names.{Name, chrs, SimpleTermName, DerivedTermName}
+import Names.{Name, chrs, SimpleName, DerivedName}
 import NameOps.NameDecorator
 import NameKinds._
 import Decorators._
@@ -31,7 +31,7 @@ class NameBuffer extends TastyBuffer(10000) {
           case AnyUniqueName(original, separator, num) =>
             nameIndex(separator.toTermName)
             if (!original.isEmpty) nameIndex(original)
-          case DerivedTermName(original, _) =>
+          case DerivedName(original, _) =>
             nameIndex(original)
           case _ =>
         }
@@ -56,7 +56,7 @@ class NameBuffer extends TastyBuffer(10000) {
     val tag = name.toTermName.info.kind.tag
     writeByte(tag)
     name.toTermName match {
-      case name: SimpleTermName =>
+      case name: SimpleName =>
         val bytes =
           if (name.length == 0) new Array[Byte](0)
           else Codec.toUTF8(chrs, name.start, name.length)
@@ -78,7 +78,7 @@ class NameBuffer extends TastyBuffer(10000) {
         withLength(
           { writeNameRef(original); writeNameRef(result); params.foreach(writeNameRef) },
           if ((params.length + 2) * maxIndexWidth <= maxNumInByte) 1 else 2)
-      case DerivedTermName(original, _) =>
+      case DerivedName(original, _) =>
         withLength { writeNameRef(original) }
     }
   }

--- a/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
@@ -70,8 +70,6 @@ class NameBuffer extends TastyBuffer(10000) {
           writeNat(num)
           if (!original.isEmpty) writeNameRef(original)
         }
-      case VariantName(original, sign) =>
-        withLength { writeNameRef(original); writeNat(sign + 1) }
       case AnyNumberedName(original, num) =>
         withLength { writeNameRef(original); writeNat(num) }
       case SignedName(original, Signature(params, result)) =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -29,16 +29,29 @@ Macro-format:
   Section       = NameRef Length Bytes
   Length        = Nat                    // length of rest of entry in bytes
 
-  Name          = UTF8           Length UTF8-CodePoint*
-                  QUALIFIED      Length qualified_NameRef selector_NameRef
-                  SIGNED         Length original_NameRef resultSig_NameRef paramSig_NameRef*
-                  EXPANDED       Length original_NameRef
-                  UNIQUE         Length separator_NameRef num_Nat original_NameRef?
-                  OBJECTCLASS    Length module_NameRef
-                  SUPERACCESSOR  Length accessed_NameRef
-                  DEFAULTGETTER  Length method_NameRef paramNumber_Nat
-                  SHADOWED       Length original_NameRef
-                  ...
+  Name          = UTF8              Length UTF8-CodePoint*
+                  QUALIFIED         Length qualified_NameRef selector_NameRef
+                  FLATTENED         Length qualified_NameRef selector_NameRef
+                  EXPANDED          Length qualified_NameRef selector_NameRef
+                  EXPANDEDPREFIX    Length qualified_NameRef selector_NameRef
+                  TRAITSETTER       Length qualified_NameRef selector_NameRef
+                  UNIQUE            Length separator_NameRef uniqid_Nat underlying_NameRef?
+									DEFAULTGETTER     Length underlying_NameRef index_Nat
+									VARIANT           Length underlying_NameRef variance_Nat      // 0: Contravariant, 1: Covariant
+									OUTERSELECT       Length underlying_NameRef nhops_Nat         // a reference to `nhops` <outer> selections, followed by `underlying`
+
+									SUPERACCESSOR     Length underlying_NameRef
+									PROTECTEDACCESSOR Length underlying_NameRef
+									PROTECTEDSETTER   Length underlying_NameRef
+									INITIALIZER       Length underlying_NameRef
+									SHADOWED          Length underlying_NameRef
+									AVOIDCLASH        Length underlying_NameRef
+									DIRECT            Length underlying_NameRef
+									FIELD             Length underlying_NameRef
+									EXTMETH           Length underlying_NameRef
+									OBJECTVAR         Length underlying_NameRef
+									OBJECTCLASS       Length underlying_NameRef
+                  SIGNED            Length original_NameRef resultSig_NameRef paramSig_NameRef*
 
   NameRef       = Nat                    // ordinal number of name in name table, starting from 1.
 
@@ -238,8 +251,7 @@ object TastyFormat {
   final val AVOIDCLASH = 30
   final val DIRECT = 31
   final val FIELD = 32
-  final val SETTER = 33
-  final val EXTMETH = 34
+  final val EXTMETH = 33
   final val OBJECTVAR = 39
   final val OBJECTCLASS = 40
 
@@ -428,12 +440,26 @@ object TastyFormat {
     case QUALIFIED => "QUALIFIED"
     case FLATTENED => "FLATTENED"
     case EXPANDED => "EXPANDED"
-    case SIGNED => "SIGNED"
-    case OBJECTCLASS => "OBJECTCLASS"
-    case SUPERACCESSOR => "SUPERACCESSOR"
+    case EXPANDPREFIX => "EXPANDPREFIX"
+    case TRAITSETTER => "TRAITSETTER"
+    case UNIQUE => "UNIQUE"
     case DEFAULTGETTER => "DEFAULTGETTER"
-    case SHADOWED => "SHADOWED"
     case VARIANT => "VARIANT"
+    case OUTERSELECT => "OUTERSELECT"
+
+    case SUPERACCESSOR => "SUPERACCESSOR"
+    case PROTECTEDACCESSOR => "PROTECTEDACCESSOR"
+    case PROTECTEDSETTER => "PROTECTEDSETTER"
+    case INITIALIZER => "INITIALIZER"
+    case SHADOWED => "SHADOWED"
+    case AVOIDCLASH => "AVOIDCLASH"
+    case DIRECT => "DIRECT"
+    case FIELD => "FIELD"
+    case EXTMETH => "EXTMETH"
+    case OBJECTVAR => "OBJECTVAR"
+    case OBJECTCLASS => "OBJECTCLASS"
+
+    case SIGNED => "SIGNED"
   }
 
   def astTagToString(tag: Int): String = tag match {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -48,7 +48,7 @@ class TastyUnpickler(reader: TastyReader) {
     val result = tag match {
       case UTF8 =>
         goto(end)
-        termName(bytes, start.index, length).decode
+        termName(bytes, start.index, length)
       case QUALIFIED | FLATTENED | EXPANDED | EXPANDPREFIX =>
         qualifiedNameKindOfTag(tag)(readName(), readName().asSimpleName)
       case UNIQUE =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -48,7 +48,7 @@ class TastyUnpickler(reader: TastyReader) {
     val result = tag match {
       case UTF8 =>
         goto(end)
-        termName(bytes, start.index, length)
+        termName(bytes, start.index, length).decode
       case QUALIFIED | FLATTENED | EXPANDED | EXPANDPREFIX =>
         qualifiedNameKindOfTag(tag)(readName(), readName().asSimpleName)
       case UNIQUE =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -57,12 +57,8 @@ class TastyUnpickler(reader: TastyReader) {
         val originals = until(end)(readName())
         val original = if (originals.isEmpty) EmptyTermName else originals.head
         uniqueNameKindOfSeparator(separator)(original, num)
-      case DEFAULTGETTER =>
-        DefaultGetterName(readName(), readNat())
-      case VARIANT =>
-        VariantName(readName(), readNat() - 1)
-      case OUTERSELECT =>
-        OuterSelectName(readName(), readNat())
+      case DEFAULTGETTER | VARIANT | OUTERSELECT =>
+        numberedNameKindOfTag(tag)(readName(), readNat())
       case SIGNED =>
         val original = readName()
         val result = readName().toTypeName

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -436,7 +436,6 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
         roots.find(root => (root.owner eq ctx.owner) && root.name.mangled == mname) match {
           case Some(rootd) =>
             pickling.println(i"overwriting ${rootd.symbol} # ${rootd.hashCode}")
-            rootd.name = name
             rootd.info = adjustIfModule(
                 new Completer(ctx.owner, subReader(start, end)) with SymbolLoaders.SecondCompleter)
             rootd.flags = flags &~ Touched // allow one more completion

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -417,7 +417,6 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
       val end = readEnd()
       var name: Name = readName()
       if (tag == TYPEDEF || tag == TYPEPARAM) name = name.toTypeName
-      val mname = name.mangled
       skipParams()
       val ttag = nextUnsharedTag
       val isAbsType = isAbstractType(ttag)
@@ -433,7 +432,7 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
       def adjustIfModule(completer: LazyType) =
         if (flags is Module) ctx.adjustModuleCompleter(completer, name) else completer
       val sym =
-        roots.find(root => (root.owner eq ctx.owner) && root.name.mangled == mname) match {
+        roots.find(root => (root.owner eq ctx.owner) && root.name == name) match {
           case Some(rootd) =>
             pickling.println(i"overwriting ${rootd.symbol} # ${rootd.hashCode}")
             rootd.info = adjustIfModule(

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -227,7 +227,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     val major = readNat()
     val minor = readNat()
     if (major != MajorVersion || minor > MinorVersion)
-      throw new IOException("Scala signature " + classRoot.fullName.decode +
+      throw new IOException("Scala signature " + classRoot.fullName +
         " has wrong version\n expected: " +
         MajorVersion + "." + MinorVersion +
         "\n found: " + major + "." + minor +

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -338,7 +338,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     def atEnd = readIndex == end
 
     def readExtSymbol(): Symbol = {
-      val name = readNameRef()
+      val name = readNameRef().decode
       val owner = if (atEnd) loadingMirror.RootClass else readSymbolRef()
 
       def adjust(denot: Denotation) = {
@@ -401,7 +401,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
               // println(owner.info.decls.toList.map(_.debugString).mkString("\n  ")) // !!! DEBUG
               //              }
               // (5) Create a stub symbol to defer hard failure a little longer.
-              System.err.println(i"***** missing reference, looking for $name in $owner")
+              System.err.println(i"***** missing reference, looking for ${name.debugString} in $owner")
               System.err.println(i"decls = ${owner.info.decls}")
               owner.info.decls.checkConsistent()
               if (slowSearch(name).exists)
@@ -447,6 +447,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       name = name.asTermName.unmangle(SuperAccessorName)
       flags = flags &~ Scala2SuperAccessor
     }
+    name = name.mapLast(_.decode)
 
     val mname = name.mangled
     def nameMatches(rootName: Name) = mname == rootName.mangled

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -460,7 +460,6 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     //if (isModuleClassRoot) println(s"moduleClassRoot of $moduleClassRoot found at $readIndex, flags = $flags") // !!! DEBUG
 
     def completeRoot(denot: ClassDenotation, completer: LazyType): Symbol = {
-      denot.name = name
       denot.setFlag(flags)
       denot.resetFlag(Touched) // allow one more completion
       denot.info = completer

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -439,7 +439,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         if (name == nme.TRAIT_CONSTRUCTOR) nme.CONSTRUCTOR
         else name.asTermName.unmangle(Scala2MethodNameKinds)
     }
-    if ((flags is Scala2ExpandedName) && name.isSimple) {
+    if ((flags is Scala2ExpandedName)) {
       name = name.unmangle(ExpandedName)
       flags = flags &~ Scala2ExpandedName
     }

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -449,8 +449,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     }
     name = name.mapLast(_.decode)
 
-    val mname = name.mangled
-    def nameMatches(rootName: Name) = mname == rootName.mangled
+    def nameMatches(rootName: Name) = name == rootName
     def isClassRoot = nameMatches(classRoot.name) && (owner == classRoot.owner) && !(flags is ModuleClass)
     def isModuleClassRoot = nameMatches(moduleClassRoot.name) && (owner == moduleClassRoot.owner) && (flags is Module)
     def isModuleRoot = nameMatches(moduleClassRoot.name.sourceModuleName) && (owner == moduleClassRoot.owner) && (flags is Module)

--- a/compiler/src/dotty/tools/dotc/parsing/CharArrayReader.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/CharArrayReader.scala
@@ -120,7 +120,7 @@ abstract class CharArrayReader { self =>
   def isAtEnd = charOffset >= buf.length
 
   /** A new reader that takes off at the current character position */
-  def lookaheadReader = new CharArrayLookaheadReader
+  def lookaheadReader() = new CharArrayLookaheadReader
 
   class CharArrayLookaheadReader extends CharArrayReader {
     val buf = self.buf

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -111,7 +111,7 @@ object JavaParsers {
 
     def makeTemplate(parents: List[Tree], stats: List[Tree], tparams: List[TypeDef], needsDummyConstr: Boolean) = {
       def pullOutFirstConstr(stats: List[Tree]): (Tree, List[Tree]) = stats match {
-        case (meth: DefDef) :: rest if meth.name == CONSTRUCTOR => (meth, rest)
+        case (meth: DefDef) :: rest if meth.name == nme.CONSTRUCTOR => (meth, rest)
         case first :: rest =>
           val (constr, tail) = pullOutFirstConstr(rest)
           (constr, first :: tail)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -266,7 +266,7 @@ object Parsers {
     def accept(token: Int): Int = {
       val offset = in.offset
       if (in.token != token) {
-        syntaxErrorOrIncomplete(ExpectedTokenButFound(token, in.token, in.name))
+        syntaxErrorOrIncomplete(ExpectedTokenButFound(token, in.token))
       }
       if (in.token == token) in.nextToken()
       offset
@@ -477,7 +477,7 @@ object Parsers {
         in.nextToken()
         name
       } else {
-        syntaxErrorOrIncomplete(ExpectedTokenButFound(IDENTIFIER, in.token, in.name))
+        syntaxErrorOrIncomplete(ExpectedTokenButFound(IDENTIFIER, in.token))
         nme.ERROR
       }
 

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -7,6 +7,7 @@ import core.StdNames._, core.Comments._
 import util.SourceFile
 import java.lang.Character.isDigit
 import util.Chars._
+import util.NameTransformer.avoidIllegalChars
 import Tokens._
 import scala.annotation.{ switch, tailrec }
 import scala.collection.mutable
@@ -622,6 +623,7 @@ object Scanners {
       if (ch == '`') {
         nextChar()
         finishNamed(BACKQUOTED_IDENT)
+        name = avoidIllegalChars(name)
         if (name.length == 0)
           error("empty quoted identifier")
         else if (name == nme.WILDCARD)

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -180,7 +180,7 @@ object Scanners {
     private[this] var docstringMap: SortedMap[Int, Comment] = SortedMap.empty
 
     private[this] def addComment(comment: Comment): Unit = {
-      val lookahead = lookaheadReader
+      val lookahead = lookaheadReader()
       def nextPos: Int = (lookahead.getc(): @switch) match {
         case ' ' | '\t' => nextPos
         case CR | LF | FF =>
@@ -863,7 +863,7 @@ object Scanners {
         nextChar()
       }
       if (ch == 'e' || ch == 'E') {
-        val lookahead = lookaheadReader
+        val lookahead = lookaheadReader()
         lookahead.nextChar()
         if (lookahead.ch == '+' || lookahead.ch == '-') {
           lookahead.nextChar()
@@ -907,36 +907,10 @@ object Scanners {
       }
       token = INTLIT
       if (base == 10 && ch == '.') {
-        val isDefinitelyNumber = {
-          val lookahead = lookaheadReader
-          val c = lookahead.getc()
-          (c: @switch) match {
-            /** Another digit is a giveaway. */
-            case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
-              true
-
-            /** Backquoted idents like 22.`foo`. */
-            case '`' =>
-              false
-
-            /** These letters may be part of a literal, or a method invocation on an Int.
-             */
-            case 'd' | 'D' | 'f' | 'F' =>
-              !isIdentifierPart(lookahead.getc())
-
-            /** A little more special handling for e.g. 5e7 */
-            case 'e' | 'E' =>
-              val ch = lookahead.getc()
-              !isIdentifierPart(ch) || (isDigit(ch) || ch == '+' || ch == '-')
-
-            case x =>
-              !isIdentifierStart(x)
-          }
-        }
-        if (isDefinitelyNumber) {
-          putChar(ch)
-          nextChar()
-          getFraction()
+        val lookahead = lookaheadReader()
+        lookahead.nextChar()
+        if ('0' <= lookahead.ch && lookahead.ch <= '9') {
+          putChar('.'); nextChar(); getFraction()
         }
       } else (ch: @switch) match {
         case 'e' | 'E' | 'f' | 'F' | 'd' | 'D' =>

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -38,7 +38,7 @@ object Scanners {
     var lastOffset: Offset = 0
 
     /** the name of an identifier */
-    var name: SimpleTermName = null
+    var name: SimpleName = null
 
     /** the string value of a literal */
     var strVal: String = null

--- a/compiler/src/dotty/tools/dotc/parsing/SymbolicXMLBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/SymbolicXMLBuilder.scala
@@ -54,7 +54,7 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(implicit ctx: Cont
     val __Text: TermName    = "Text"
     val _buf: TermName      = "$buf"
     val _md: TermName       = "$md"
-    val _plus: TermName     = "$amp$plus"
+    val _plus: TermName     = "&+"
     val _tmpscope: TermName = "$tmpscope"
     val _xml: TermName      = "xml"
   }

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -208,9 +208,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected def ParamRefNameString(param: ParamRef): String =
     ParamRefNameString(param.binder.paramNames(param.paramNum))
 
-  /** The name of the symbol without a unique id. Under refined printing,
-   *  the decoded original name.
-   */
+  /** The name of the symbol without a unique id. */
   protected def simpleNameString(sym: Symbol): String = nameString(sym.name)
 
   /** If -uniqid is set, the hashcode of the lambda type, after a # */

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -60,7 +60,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   protected val PrintableFlags = (SourceModifierFlags | Label | Module | Local).toCommonFlags
 
   override def nameString(name: Name): String =
-    if (ctx.settings.debugNames.value) name.debugString else name.decode.toString
+    if (ctx.settings.debugNames.value) name.debugString else name.toString
 
   override protected def simpleNameString(sym: Symbol): String = {
     val name = if (ctx.property(XprintMode).isEmpty) sym.originalName else sym.name

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -157,7 +157,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         withoutPos(super.toText(tp))
       case tp: SelectionProto =>
         return "?{ " ~ toText(tp.name) ~
-           (" " provided !tp.name.toSimpleName.decode.last.isLetterOrDigit) ~
+           (" " provided !tp.name.toSimpleName.last.isLetterOrDigit) ~
            ": " ~ toText(tp.memberProto) ~ " }"
       case tp: ViewProto =>
         return toText(tp.argType) ~ " ?=>? " ~ toText(tp.resultType)

--- a/compiler/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
+++ b/compiler/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
@@ -742,7 +742,7 @@ class CompilingInterpreter(
       override def shouldShowResult(req: Request): Boolean =
         !statement.mods.is(Flags.AccessFlags) &&
           !(isGeneratedVarName(statement.name.toString) &&
-            req.typeOf(statement.name.encode) == "Unit")
+            req.typeOf(statement.name) == "Unit")
     }
 
 
@@ -812,7 +812,7 @@ class CompilingInterpreter(
       /** Print out lhs instead of the generated varName */
       override def resultExtractionCode(req: Request, code: PrintWriter): Unit = {
         code.print(" + \"" + lhs.show + ": " +
-          string2code(req.typeOf(helperName.encode)) +
+          string2code(req.typeOf(helperName)) +
           " = \" + " +
           string2code(req.fullPath(helperName))
           + " + \"\\n\"")

--- a/compiler/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
@@ -41,18 +41,25 @@ class ConsoleReporter(
   }
 
   /** Show prompt if `-Xprompt` is passed as a flag to the compiler */
-  def displayPrompt()(implicit ctx: Context): Unit = {
-    printMessage("\na)bort, s)tack, r)esume: ")
-    flush()
+  def displayPrompt(): Unit = {
+    writer.println()
+    writer.print("a)bort, s)tack, r)esume: ")
+    writer.flush()
     if (reader != null) {
-      val response = reader.read().asInstanceOf[Char].toLower
-      if (response == 'a' || response == 's') {
-        Thread.dumpStack()
-        if (response == 'a')
-          sys.exit(1)
+      def loop(): Unit = reader.read match {
+        case 'a' | 'A' =>
+          new Throwable().printStackTrace(writer)
+          System.exit(1)
+        case 's' | 'S' =>
+          new Throwable().printStackTrace(writer)
+          writer.println()
+          writer.flush()
+        case 'r' | 'R' =>
+          ()
+        case _ =>
+          loop()
       }
-      print("\n")
-      flush()
+      loop()
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1057,7 +1057,7 @@ object messages {
            |""".stripMargin
   }
 
-  case class ExpectedTokenButFound(expected: Token, found: Token, foundName: TermName)(implicit ctx: Context)
+  case class ExpectedTokenButFound(expected: Token, found: Token)(implicit ctx: Context)
   extends Message(ExpectedTokenButFoundID) {
     val kind = "Syntax"
 
@@ -1065,9 +1065,7 @@ object messages {
       if (Tokens.isIdentifier(expected)) "an identifier"
       else Tokens.showToken(expected)
 
-    private val foundText =
-      if (foundName != null) hl"`${foundName.show}`"
-      else Tokens.showToken(found)
+    private val foundText = Tokens.showToken(found)
 
     val msg = hl"""${expectedText} expected, but ${foundText} found"""
 
@@ -1077,10 +1075,7 @@ object messages {
            |If you necessarily want to use $foundText as identifier, you may put it in backticks.""".stripMargin
       else
         ""
-
-    val explanation =
-      s"""|The text ${foundText} may not occur at that position, the compiler expected ${expectedText}.$ifKeyword
-          |""".stripMargin
+    val explanation = s"$ifKeyword"
   }
 
   case class MixedLeftAndRightAssociativeOps(op1: Name, op2: Name, op2LeftAssoc: Boolean)(implicit ctx: Context)

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -334,7 +334,7 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
     private def newName(sym: Symbol)(implicit ctx: Context): Name =
       if (sym.isAnonymousFunction && sym.owner.is(Method, butNot = Label))
         sym.name.rewrite {
-          case name: SimpleTermName => ExpandPrefixName(sym.owner.name.asTermName, name)
+          case name: SimpleName => ExpandPrefixName(sym.owner.name.asTermName, name)
         }.freshened
       else sym.name.freshened
 

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -8,7 +8,7 @@ import core.Contexts._
 import core.Types._
 import core.Flags._
 import core.Decorators._
-import core.StdNames.nme
+import core.StdNames.{nme, str}
 import core.Names._
 import core.NameOps._
 import core.NameKinds.ExpandPrefixName

--- a/compiler/src/dotty/tools/dotc/transform/MoveStatics.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MoveStatics.scala
@@ -9,6 +9,7 @@ import dotty.tools.dotc.core.Decorators._
 import dotty.tools.dotc.core.NameOps._
 import dotty.tools.dotc.core.{Flags, Names}
 import dotty.tools.dotc.core.Names.Name
+import dotty.tools.dotc.core.StdNames.nme
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.core.Symbols._
 import dotty.tools.dotc.core.Types.MethodType
@@ -42,7 +43,7 @@ class MoveStatics extends MiniPhaseTransform with SymTransformer { thisTransform
         val newBodyWithStaticConstr =
           if (staticFields.nonEmpty) {
             /* do NOT put Flags.JavaStatic here. It breaks .enclosingClass */
-            val staticCostructor = ctx.newSymbol(orig.symbol, Names.STATIC_CONSTRUCTOR, Flags.Synthetic | Flags.Method | Flags.Private, MethodType(Nil, defn.UnitType))
+            val staticCostructor = ctx.newSymbol(orig.symbol, nme.STATIC_CONSTRUCTOR, Flags.Synthetic | Flags.Method | Flags.Private, MethodType(Nil, defn.UnitType))
             staticCostructor.addAnnotation(Annotation(defn.ScalaStaticAnnot))
             staticCostructor.entered
 

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -11,6 +11,7 @@ import Periods._
 import Phases._
 import Symbols._
 import Flags.Module
+import reporting.ThrowingReporter
 import collection.mutable
 
 /** This phase pickles trees */
@@ -77,6 +78,7 @@ class Pickler extends Phase {
       testUnpickler(
           ctx.fresh
             .setPeriod(Period(ctx.runId + 1, FirstPhaseId))
+            .setReporter(new ThrowingReporter(ctx.reporter))
             .addMode(Mode.ReadPositions))
     result
   }

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -265,7 +265,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer  { thisTran
         case Import(expr, selectors) =>
           val exprTpe = expr.tpe
           def checkIdent(ident: untpd.Ident): Unit = {
-            val name = ident.name.asTermName.encode
+            val name = ident.name.asTermName
             if (name != nme.WILDCARD && !exprTpe.member(name).exists && !exprTpe.member(name.toTypeName).exists)
               ctx.error(s"${ident.name} is not a member of ${expr.show}", ident.pos)
           }

--- a/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
@@ -19,7 +19,6 @@ import util.Positions._
 import Names._
 import collection.mutable
 import ResolveSuper._
-import config.Config
 
 /** This phase adds super accessors and method overrides where
  *  linearization differs from Java's rule for default methods in interfaces.
@@ -96,7 +95,7 @@ object ResolveSuper {
   def rebindSuper(base: Symbol, acc: Symbol)(implicit ctx: Context): Symbol = {
     var bcs = base.info.baseClasses.dropWhile(acc.owner != _).tail
     var sym: Symbol = NoSymbol
-    val SuperAccessorName(memberName) = acc.name.unexpandedName // dotty deviation: ": Name" needed otherwise pattern type is neither a subtype nor a supertype of selector type
+    val SuperAccessorName(memberName) = acc.name.unexpandedName
     ctx.debuglog(i"starting rebindsuper from $base of ${acc.showLocated}: ${acc.info} in $bcs, name = $memberName")
     while (bcs.nonEmpty && sym == NoSymbol) {
       val other = bcs.head.info.nonPrivateDecl(memberName)

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -107,7 +107,7 @@ class SuperAccessors(thisTransformer: DenotTransformer) {
         // ParamForwaders as installed ParamForwarding.scala do use super calls to vals
         ctx.error(s"super may be not be used on ${sym.underlyingSymbol}", sel.pos)
       else if (isDisallowed(sym))
-        ctx.error(s"super not allowed here: use this.${sel.name.decode} instead", sel.pos)
+        ctx.error(s"super not allowed here: use this.${sel.name} instead", sel.pos)
       else if (sym is Deferred) {
         val member = sym.overridingSymbol(clazz)
         if (!mix.name.isEmpty ||

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
@@ -82,7 +82,7 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
         ref(defn.runtimeMethodRef("_" + sym.name.toString)).appliedToArgs(This(clazz) :: vrefss.head)
 
       def ownName(vrefss: List[List[Tree]]): Tree =
-        Literal(Constant(clazz.name.stripModuleClassSuffix.decode.toString))
+        Literal(Constant(clazz.name.stripModuleClassSuffix.toString))
 
       def syntheticRHS(implicit ctx: Context): List[List[Tree]] => Tree = synthetic.name match {
         case nme.hashCode_ if isDerivedValueClass(clazz) => vrefss => valueHashCodeBody

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -384,7 +384,7 @@ class TreeChecker extends Phase with SymTransformer {
     override def typedDefDef(ddef: untpd.DefDef, sym: Symbol)(implicit ctx: Context) =
       withDefinedSyms(ddef.tparams) {
         withDefinedSymss(ddef.vparamss) {
-          if (!sym.isClassConstructor && !(sym.name eq Names.STATIC_CONSTRUCTOR))
+          if (!sym.isClassConstructor && !(sym.name eq nme.STATIC_CONSTRUCTOR))
             assert(isValidJVMMethodName(sym.name.encode), s"${sym.name.debugString} name is invalid on jvm")
 
           ddef.vparamss.foreach(_.foreach { vparam =>

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -25,6 +25,7 @@ import reporting.ThrowingReporter
 import ast.Trees._
 import ast.{tpd, untpd}
 import util.SourcePosition
+import util.Chars._
 import collection.mutable
 import ProtoTypes._
 import config.Printers
@@ -51,11 +52,9 @@ class TreeChecker extends Phase with SymTransformer {
   private val seenClasses = collection.mutable.HashMap[String, Symbol]()
   private val seenModuleVals = collection.mutable.HashMap[String, Symbol]()
 
-  def isValidJVMName(name: Name) =
-      !name.toString.exists(c => c == '.' || c == ';' || c =='[' || c == '/')
+  def isValidJVMName(name: Name) = name.toString.forall(isValidJVMChar)
 
-  def isValidJVMMethodName(name: Name) =
-      !name.toString.exists(c => c == '.' || c == ';' || c =='[' || c == '/' || c == '<' || c == '>')
+  def isValidJVMMethodName(name: Name) = name.toString.forall(isValidJVMMethodChar)
 
   def printError(str: String)(implicit ctx: Context) = {
     ctx.echo(Console.RED + "[error] " + Console.WHITE  + str)
@@ -149,7 +148,7 @@ class TreeChecker extends Phase with SymTransformer {
     def withDefinedSym[T](tree: untpd.Tree)(op: => T)(implicit ctx: Context): T = tree match {
       case tree: untpd.DefTree =>
         val sym = tree.symbol
-        assert(isValidJVMName(sym.name), s"${sym.fullName} name is invalid on jvm")
+        assert(isValidJVMName(sym.name.encode), s"${sym.name.debugString} name is invalid on jvm")
         everDefinedSyms.get(sym) match {
           case Some(t)  =>
             if (t ne tree)
@@ -386,7 +385,7 @@ class TreeChecker extends Phase with SymTransformer {
       withDefinedSyms(ddef.tparams) {
         withDefinedSymss(ddef.vparamss) {
           if (!sym.isClassConstructor && !(sym.name eq Names.STATIC_CONSTRUCTOR))
-            assert(isValidJVMMethodName(sym.name), s"${sym.name.debugString} name is invalid on jvm")
+            assert(isValidJVMMethodName(sym.name.encode), s"${sym.name.debugString} name is invalid on jvm")
 
           ddef.vparamss.foreach(_.foreach { vparam =>
             assert(vparam.symbol.is(Param),

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -566,8 +566,8 @@ class Namer { typer: Typer =>
 
     /** Create links between companion object and companion class */
     def createLinks(classTree: TypeDef, moduleTree: TypeDef)(implicit ctx: Context) = {
-      val claz = ctx.denotNamed(classTree.name).symbol
-      val modl = ctx.denotNamed(moduleTree.name).symbol
+      val claz = ctx.effectiveScope.lookup(classTree.name)
+      val modl = ctx.effectiveScope.lookup(moduleTree.name)
       ctx.synthesizeCompanionMethod(nme.COMPANION_CLASS_METHOD, claz, modl).entered
       ctx.synthesizeCompanionMethod(nme.COMPANION_MODULE_METHOD, modl, claz).entered
     }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -257,7 +257,7 @@ class Namer { typer: Typer =>
 
     /** Add moduleClass/sourceModule to completer if it is for a module val or class */
     def adjustIfModule(completer: LazyType, tree: MemberDef) =
-      if (tree.mods is Module) ctx.adjustModuleCompleter(completer, tree.name.encode)
+      if (tree.mods is Module) ctx.adjustModuleCompleter(completer, tree.name)
       else completer
 
     typr.println(i"creating symbol for $tree in ${ctx.mode}")
@@ -280,7 +280,7 @@ class Namer { typer: Typer =>
 
     tree match {
       case tree: TypeDef if tree.isClassDef =>
-        val name = checkNoConflict(tree.name.encode).toTypeName
+        val name = checkNoConflict(tree.name).asTypeName
         val flags = checkFlags(tree.mods.flags &~ Implicit)
         val cls = recordSym(ctx.newClassSymbol(
           ctx.owner, name, flags,
@@ -289,7 +289,7 @@ class Namer { typer: Typer =>
         cls.completer.asInstanceOf[ClassCompleter].init()
         cls
       case tree: MemberDef =>
-        val name = checkNoConflict(tree.name.encode)
+        val name = checkNoConflict(tree.name)
         val flags = checkFlags(tree.mods.flags)
         val isDeferred = lacksDefinition(tree)
         val deferred = if (isDeferred) Deferred else EmptyFlags
@@ -566,8 +566,8 @@ class Namer { typer: Typer =>
 
     /** Create links between companion object and companion class */
     def createLinks(classTree: TypeDef, moduleTree: TypeDef)(implicit ctx: Context) = {
-      val claz = ctx.effectiveScope.lookup(classTree.name.encode)
-      val modl = ctx.effectiveScope.lookup(moduleTree.name.encode)
+      val claz = ctx.denotNamed(classTree.name).symbol
+      val modl = ctx.denotNamed(moduleTree.name).symbol
       ctx.synthesizeCompanionMethod(nme.COMPANION_CLASS_METHOD, claz, modl).entered
       ctx.synthesizeCompanionMethod(nme.COMPANION_MODULE_METHOD, modl, claz).entered
     }
@@ -609,10 +609,10 @@ class Namer { typer: Typer =>
       // matters.
       if (ctx.owner.is(PackageClass)) {
         for (cdef @ TypeDef(moduleName, _) <- moduleDef.values) {
-          val moduleSym = ctx.effectiveScope.lookup(moduleName.encode)
+          val moduleSym = ctx.effectiveScope.lookup(moduleName)
           if (moduleSym.isDefinedInCurrentRun) {
             val className = moduleName.stripModuleClassSuffix.toTypeName
-            val classSym = ctx.effectiveScope.lookup(className.encode)
+            val classSym = ctx.effectiveScope.lookup(className)
             if (!classSym.isDefinedInCurrentRun) {
               val absentClassSymbol = ctx.newClassSymbol(ctx.owner, className, EmptyFlags, _ => NoType)
               enterSymbol(absentClassSymbol)

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -82,8 +82,6 @@ class ReTyper extends Typer {
   override def ensureConstrCall(cls: ClassSymbol, parents: List[Tree])(implicit ctx: Context): List[Tree] =
     parents
 
-  override def encodeName(tree: untpd.NameTree)(implicit ctx: Context) = tree
-
   override def handleUnexpectedFunType(tree: untpd.Apply, fun: Tree)(implicit ctx: Context): Tree = fun.tpe match {
     case mt: MethodType =>
       val args: List[Tree] = tree.args.zipWithConserve(mt.paramInfos)(typedExpr(_, _)).asInstanceOf[List[Tree]]

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -698,7 +698,7 @@ object RefChecks {
       if (!concrOvers.isEmpty)
         ctx.deprecationWarning(
           symbol.toString + " overrides concrete, non-deprecated symbol(s):" +
-            concrOvers.map(_.name.decode).mkString("    ", ", ", ""), tree.pos)
+            concrOvers.map(_.name).mkString("    ", ", ", ""), tree.pos)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -216,7 +216,7 @@ trait TypeAssigner {
     else if (site.derivesFrom(defn.DynamicClass) && !Dynamic.isDynamicMethod(name)) {
       TryDynamicCallType
     } else {
-      if (site.isErroneous) UnspecifiedErrorType
+      if (site.isErroneous || name.toTermName == nme.ERROR) UnspecifiedErrorType
       else {
         def kind = if (name.isTypeName) "type" else "value"
         def addendum =

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -197,7 +197,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
        *  from given `site` and `selectors`.
        */
       def namedImportRef(imp: ImportInfo)(implicit ctx: Context): Type = {
-        val Name = name.toTermName.decode
+        val Name = name.toTermName
         def recur(selectors: List[untpd.Tree]): Type = selectors match {
           case selector :: rest =>
             def checkUnambiguous(found: Type) = {
@@ -1572,14 +1572,11 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
             !ctx.isAfterTyper)
           makeImplicitFunction(xtree, pt)
         else xtree match {
-          case xtree: untpd.NameTree => typedNamed(encodeName(xtree), pt)
+          case xtree: untpd.NameTree => typedNamed(xtree, pt)
           case xtree => typedUnnamed(xtree)
         }
     }
   }
-
-  protected def encodeName(tree: untpd.NameTree)(implicit ctx: Context): untpd.NameTree =
-    untpd.rename(tree, tree.name.encode)
 
   protected def makeImplicitFunction(tree: untpd.Tree, pt: Type)(implicit ctx: Context): Tree = {
     val defn.FunctionOf(formals, resType, true) = pt.dealias

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -354,6 +354,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         // awaiting a better implicits based solution for library-supported xml
         return ref(defn.XMLTopScopeModuleRef)
       }
+      else if (name.toTermName == nme.ERROR)
+        UnspecifiedErrorType
       else
         errorType(new MissingIdent(tree, kind, name.show), tree.pos)
 

--- a/compiler/src/dotty/tools/dotc/util/Chars.scala
+++ b/compiler/src/dotty/tools/dotc/util/Chars.scala
@@ -77,6 +77,12 @@ object Chars {
     chtp == JCharacter.MATH_SYMBOL.toInt || chtp == JCharacter.OTHER_SYMBOL.toInt
   }
 
+  def isValidJVMChar(c: Char) =
+    !(c == '.' || c == ';' || c =='[' || c == '/')
+
+  def isValidJVMMethodChar(c: Char) =
+    !(c == '.' || c == ';' || c =='[' || c == '/' || c == '<' || c == '>')
+
   private final val otherLetters = Set[Char]('\u0024', '\u005F')  // '$' and '_'
   private final val letterGroups = {
     import JCharacter._

--- a/compiler/src/dotty/tools/dotc/util/FreshNameCreator.scala
+++ b/compiler/src/dotty/tools/dotc/util/FreshNameCreator.scala
@@ -22,10 +22,9 @@ object FreshNameCreator {
      * call to this function (provided the prefix does not end in a digit).
      */
     def newName(prefix: TermName, unique: UniqueNameKind): TermName = {
-      val key = str.sanitize(prefix.toString + unique.separator)
+      val key = str.sanitize(prefix.toString) + unique.separator
       counters(key) += 1
-      val counter = counters(key)
-      prefix.derived(unique.NumberedInfo(counter))
+      prefix.derived(unique.NumberedInfo(counters(key)))
     }
   }
 }

--- a/compiler/src/dotty/tools/dotc/util/NameTransformer.scala
+++ b/compiler/src/dotty/tools/dotc/util/NameTransformer.scala
@@ -44,7 +44,7 @@ object NameTransformer {
   /** Expand characters that are illegal as JVM method names by `$u`, followed
    *  by the character's unicode expansion.
    */
-  def avoidIllegalChars(name: SimpleTermName) = {
+  def avoidIllegalChars(name: SimpleName) = {
     var i = name.length - 1
     while (i >= 0 && isValidJVMMethodChar(name(i))) i -= 1
     if (i >= 0)
@@ -62,8 +62,8 @@ object NameTransformer {
    *  Operator symbols are only recognized if they make up the whole name, or
    *  if they make up the last part of the name which follows a `_`.
    */
-  def encode(name: SimpleTermName): SimpleTermName = {
-    def loop(len: Int, ops: List[String]): SimpleTermName = {
+  def encode(name: SimpleName): SimpleName = {
+    def loop(len: Int, ops: List[String]): SimpleName = {
       def convert =
         if (ops.isEmpty) name
         else {
@@ -89,8 +89,8 @@ object NameTransformer {
    *  Operator expansions are only recognized if they make up the whole name, or
    *  if they make up the last part of the name which follows a `_`.
    */
-  def decode(name: SimpleTermName): SimpleTermName = {
-    def loop(len: Int, ops: List[Char]): SimpleTermName = {
+  def decode(name: SimpleName): SimpleName = {
+    def loop(len: Int, ops: List[Char]): SimpleName = {
       def convert =
         if (ops.isEmpty) name
         else {

--- a/compiler/test/dotty/tools/dotc/ast/TreeInfoTest.scala
+++ b/compiler/test/dotty/tools/dotc/ast/TreeInfoTest.scala
@@ -4,6 +4,7 @@ package ast
 
 import org.junit.Test
 import core.Names._
+import core.StdNames.nme
 import core.Types._
 import core.Symbols._
 import org.junit.Assert._
@@ -19,7 +20,7 @@ class TreeInfoTest extends DottyTest {
       val xTree = tree.find(tree => tree.symbol.name == termName("x")).get
       val path = defPath(xTree.symbol, tree)
       assertEquals(List(
-        ("PackageDef", EMPTY_PACKAGE),
+        ("PackageDef", nme.EMPTY_PACKAGE),
         ("TypeDef", typeName("A")),
         ("Template", termName("<local A>")),
         ("DefDef", termName("bar")),

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -121,10 +121,9 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val defn = ictx.definitions
 
       assertMessageCount(1, messages)
-      val ExpectedTokenButFound(expected, found, foundName) :: Nil = messages
+      val ExpectedTokenButFound(expected, found) :: Nil = messages
       assertEquals(Tokens.IDENTIFIER, expected)
       assertEquals(Tokens.VAL, found)
-      assertEquals("val", foundName.show)
     }
 
   @Test def expectedToken =

--- a/sbt-bridge/test/xsbt/ExtractUsedNamesSpecification.scala
+++ b/sbt-bridge/test/xsbt/ExtractUsedNamesSpecification.scala
@@ -81,7 +81,7 @@ class ExtractUsedNamesSpecification extends Specification {
     // We could avoid this by checking if the untyped tree has a return type
     // but is it worth it? Revisit this after https://github.com/sbt/sbt/issues/1104
     // has landed.
-    val expectedNames = standardNames ++ Set("A", "a", "$eq", "Int")
+    val expectedNames = standardNames ++ Set("A", "a", "=", "Int")
     usedNames === expectedNames
   }
 
@@ -114,7 +114,7 @@ class ExtractUsedNamesSpecification extends Specification {
     val compilerForTesting = new ScalaCompilerForUnitTesting(nameHashing = true)
     val usedNames = compilerForTesting.extractUsedNamesFromSrc(src1, src2)
     val expectedNames = standardNames ++ Set("Test", "Test$", "B", "B$",
-      "Predef", "Predef$", "$qmark$qmark$qmark", "Nothing",
+      "Predef", "Predef$", "???", "Nothing",
       "lista", "List", "A",
       "at", "T", "X1", "X0",
       "as", "S", "Y",

--- a/tests/neg/floatlits.scala
+++ b/tests/neg/floatlits.scala
@@ -7,5 +7,5 @@ object Test {
   val a = 1.0e2
   val b = 1e-3
 
-  val x = 2. // error: identifier expected
-}
+  val x = 2.
+}  // error: identifier expected

--- a/tests/neg/floatlits.scala
+++ b/tests/neg/floatlits.scala
@@ -1,0 +1,11 @@
+object Test {
+
+  val y = .2 // ok
+
+  val z = 3.2 // ok
+
+  val a = 1.0e2
+  val b = 1e-3
+
+  val x = 2. // error: identifier expected
+}


### PR DESCRIPTION
…erals

This seemingly simple fix opened up a few other problems with error reporting. It's based on the symbolic names PR because we need that for avoiding `<error>` in error messages. The commits from e8860ee are new to this PR.