### PR TITLE
Fix #2345: Handle case of overloaded local vars in assignment

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -567,7 +567,6 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       case lhs =>
         val lhsCore = typedUnadapted(lhs, AssignProto)
         def lhs1 = typed(untpd.TypedSplice(lhsCore))
-        lazy val lhsVal = lhsCore.asInstanceOf[TermRef].denot.suchThat(!_.is(Method))
 
         def reassignmentToVal =
           errorTree(cpy.Assign(tree)(lhsCore, typed(tree.rhs, lhs1.tpe.widen)),

--- a/tests/pos/i2345.scala
+++ b/tests/pos/i2345.scala
@@ -1,0 +1,6 @@
+import scala.collection.mutable
+
+abstract class Whatever[A] extends mutable.Set[A] {
+  private[this] var count = 0
+  count = 0
+}


### PR DESCRIPTION
Clean up logic of typedAssign, so that it now correctly handles the case
of an overloaded left-hand-side consisting of a provate[this] var
and one or more methods.