### PR TITLE
Fix #2292: Discard trees with errors early in Frontend

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -75,7 +75,7 @@ class FrontEnd extends Phase {
   }
 
   protected def discardAfterTyper(unit: CompilationUnit)(implicit ctx: Context) =
-    unit.isJava || firstTopLevelDef(unit.tpdTree :: Nil).isPrimitiveValueClass
+    ctx.reporter.hasErrors || unit.isJava || firstTopLevelDef(unit.tpdTree :: Nil).isPrimitiveValueClass
 
   override def runOn(units: List[CompilationUnit])(implicit ctx: Context): List[CompilationUnit] = {
     val unitContexts = for (unit <- units) yield {

--- a/tests/neg/i2292.scala
+++ b/tests/neg/i2292.scala
@@ -1,0 +1,3 @@
+package + // error
+
+class Foo


### PR DESCRIPTION
Previously, we called `firstTopLevelDef(unit.tpdTree)` but this can
crash with an `UnAssignedTypeException` if a top-level class is
contained in a package which got an error type. Since we will always
discard trees with errors, we can just make sure that this is done
before the call to `firstTopLevelDef`