### PR TITLE
Fix #2292: Do not crash when a top-level class is untyped

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -233,7 +233,7 @@ object Trees {
   /** Tree's denotation can be derived from its type */
   abstract class DenotingTree[-T >: Untyped] extends Tree[T] {
     type ThisTree[-T >: Untyped] <: DenotingTree[T]
-    override def denot(implicit ctx: Context) = tpe match {
+    override def denot(implicit ctx: Context) = typeOpt match {
       case tpe: NamedType => tpe.denot
       case tpe: ThisType => tpe.cls.denot
       case tpe: AnnotatedType => tpe.stripAnnots match {
@@ -363,7 +363,7 @@ object Trees {
     type ThisTree[-T >: Untyped] = This[T]
     // Denotation of a This tree is always the underlying class; needs correction for modules.
     override def denot(implicit ctx: Context): Denotation = {
-      tpe match {
+      typeOpt match {
         case tpe @ TermRef(pre, _) if tpe.symbol is Module =>
           tpe.symbol.moduleClass.denot.asSeenFrom(pre)
         case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -70,7 +70,7 @@ class FrontEnd extends Phase {
   private def firstTopLevelDef(trees: List[tpd.Tree])(implicit ctx: Context): Symbol = trees match {
     case PackageDef(_, defs) :: _    => firstTopLevelDef(defs)
     case Import(_, _) :: defs        => firstTopLevelDef(defs)
-    case (tree @ TypeDef(_, _)) :: _ => tree.symbol
+    case (tree @ TypeDef(_, _)) :: _ => if (tree.hasType) tree.symbol else NoSymbol
     case _ => NoSymbol
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -70,7 +70,7 @@ class FrontEnd extends Phase {
   private def firstTopLevelDef(trees: List[tpd.Tree])(implicit ctx: Context): Symbol = trees match {
     case PackageDef(_, defs) :: _    => firstTopLevelDef(defs)
     case Import(_, _) :: defs        => firstTopLevelDef(defs)
-    case (tree @ TypeDef(_, _)) :: _ => if (tree.hasType) tree.symbol else NoSymbol
+    case (tree @ TypeDef(_, _)) :: _ => tree.symbol
     case _ => NoSymbol
   }
 

--- a/tests/neg/i2292.scala
+++ b/tests/neg/i2292.scala
@@ -1,0 +1,3 @@
+package + // error
+
+class Foo


### PR DESCRIPTION
This can happen when the class is in a package that got an error type.