### PR TITLE
Fix #2143: remove widenForMatchSelector in typing patmat

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -354,6 +354,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     case Bind(_, pat) => project(pat)
     case UnApply(_, _, pats) =>
       if (pat.tpe.classSymbol.is(CaseClass))
+        // FIXME: why dealias is needed here?
         Kon(pat.tpe.stripAnnots.dealias, pats.map(pat => project(pat, roundUp)))
       else if (roundUp) Typ(pat.tpe.stripAnnots, false)
       else Empty

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -354,7 +354,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     case Bind(_, pat) => project(pat)
     case UnApply(_, _, pats) =>
       if (pat.tpe.classSymbol.is(CaseClass))
-        Kon(pat.tpe.stripAnnots, pats.map(pat => project(pat, roundUp)))
+        Kon(pat.tpe.stripAnnots.dealias, pats.map(pat => project(pat, roundUp)))
       else if (roundUp) Typ(pat.tpe.stripAnnots, false)
       else Empty
     case Typed(pat @ UnApply(_, _, _), _) => project(pat)

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -187,17 +187,6 @@ object Inferencing {
     approxAbove - approxBelow
   }
 
-  /** Recursively widen and also follow type declarations and type aliases. */
-  def widenForMatchSelector(tp: Type)(implicit ctx: Context): Type = tp.widen match {
-    case tp: TypeRef if !tp.symbol.isClass =>
-      widenForMatchSelector(tp.superType)
-    case tp: HKApply =>
-      widenForMatchSelector(tp.superType)
-    case tp: AnnotatedType =>
-      tp.derivedAnnotatedType(widenForMatchSelector(tp.tpe), tp.annot)
-    case tp => tp
-  }
-
   /** Following type aliases and stripping refinements and annotations, if one arrives at a
    *  class type reference where the class has a companion module, a reference to
    *  that companion module. Otherwise NoType

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -834,8 +834,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         typed(desugar.makeCaseLambda(tree.cases, protoFormals.length, unchecked) withPos tree.pos, pt)
       case _ =>
         val sel1 = typedExpr(tree.selector)
-        val selType = widenForMatchSelector(
-            fullyDefinedType(sel1.tpe, "pattern selector", tree.pos))
+        val selType = fullyDefinedType(sel1.tpe, "pattern selector", tree.pos).widen
 
         val cases1 = typedCases(tree.cases, selType, pt.notApplied)
         val cases2 = harmonize(cases1).asInstanceOf[List[CaseDef]]

--- a/tests/pos/i2378.scala
+++ b/tests/pos/i2378.scala
@@ -1,0 +1,29 @@
+trait Cap
+
+trait Toolbox {
+  type Tree
+
+  val tpd: TypedTrees
+  trait TypedTrees {
+    type Tree
+  }
+
+  val Apply: ApplyImpl
+  trait ApplyImpl {
+    def unapply(tree: Tree): Option[(Tree, Seq[Tree])]
+    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, Seq[tpd.Tree])]
+  }
+}
+
+class Test(val tb: Toolbox) {
+  import tb._
+  implicit val cap: Cap = null
+
+  def foo(tree: Tree): Int = tree match {
+    case Apply(fun, args) => 3
+  }
+
+  def bar(tree: tpd.Tree): Int = tree match {
+    case Apply(fun, args) => 3
+  }
+}


### PR DESCRIPTION
Fix #2143: remove `widenForMatchSelector` in typing pattern matches.