### PR TITLE
Fix missing case TypedSplice in UntypedTreeMap

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -517,6 +517,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
         cpy.ContextBounds(tree)(transformSub(bounds), transform(cxBounds))
       case PatDef(mods, pats, tpt, rhs) =>
         cpy.PatDef(tree)(mods, transform(pats), transform(tpt), transform(rhs))
+      case TypedSplice(_) =>
+        tree
       case _ =>
         super.transform(tree)
     }


### PR DESCRIPTION
UntypedTreeMap misses a case for `TypedSplice`. I think `TypedSplice` should be a blackbox, thus it should not go into the typed tree inside it.

Review @odersky .