### PR TITLE
Fix bot rate limits

### DIFF
--- a/bot/src/dotty/tools/bot/Main.scala
+++ b/bot/src/dotty/tools/bot/Main.scala
@@ -7,10 +7,12 @@ import scalaz.concurrent.Task
 
 object Main extends ServerApp with PullRequestService {
 
-  val githubUser  = sys.env("GITHUB_USER")
-  val githubToken = sys.env("GITHUB_TOKEN")
-  val droneToken  = sys.env("DRONE_TOKEN")
-  val port        = sys.env("PORT").toInt
+  val githubUser         = sys.env("GITHUB_USER")
+  val githubToken        = sys.env("GITHUB_TOKEN")
+  val githubClientId     = sys.env("GITHUB_CLIENT_ID")
+  val githubClientSecret = sys.env("GITHUB_CLIENT_SECRET")
+  val droneToken         = sys.env("DRONE_TOKEN")
+  val port               = sys.env("PORT").toInt
 
   /** Services mounted to the server */
   final val services = prService

--- a/bot/src/dotty/tools/bot/PullRequestService.scala
+++ b/bot/src/dotty/tools/bot/PullRequestService.scala
@@ -34,6 +34,12 @@ trait PullRequestService {
   /** OAuth token for drone, needed to cancel builds */
   def droneToken: String
 
+  /** OAuthed application's "client_id" */
+  def githubClientId: String
+
+  /** OAuthed application's "client_secret" */
+  def githubClientSecret: String
+
   /** Pull Request HTTP service */
   val prService = HttpService {
     case request @ POST -> Root =>
@@ -68,21 +74,23 @@ trait PullRequestService {
   )
 
   private[this] val githubUrl = "https://api.github.com"
+  private[this] def withGithubSecret(url: String, extras: String*): String =
+    s"$url?client_id=$githubClientId&client_secret=$githubClientSecret" + extras.mkString("&", "&", "")
 
   def claUrl(userName: String): String =
    s"https://www.lightbend.com/contribute/cla/scala/check/$userName"
 
   def commitsUrl(prNumber: Int): String =
-    s"$githubUrl/repos/lampepfl/dotty/pulls/$prNumber/commits?per_page=100"
+    withGithubSecret(s"$githubUrl/repos/lampepfl/dotty/pulls/$prNumber/commits", "per_page=100")
 
   def statusUrl(sha: String): String =
-    s"$githubUrl/repos/lampepfl/dotty/statuses/$sha"
+    withGithubSecret(s"$githubUrl/repos/lampepfl/dotty/statuses/$sha")
 
   def issueCommentsUrl(issueNbr: Int): String =
-    s"$githubUrl/repos/lampepfl/dotty/issues/$issueNbr/comments"
+    withGithubSecret(s"$githubUrl/repos/lampepfl/dotty/issues/$issueNbr/comments")
 
   def reviewUrl(issueNbr: Int): String =
-    s"$githubUrl/repos/lampepfl/dotty/pulls/$issueNbr/reviews"
+    withGithubSecret(s"$githubUrl/repos/lampepfl/dotty/pulls/$issueNbr/reviews")
 
   sealed trait CommitStatus {
     def commit: Commit

--- a/bot/test/PRServiceTests.scala
+++ b/bot/test/PRServiceTests.scala
@@ -15,9 +15,11 @@ import org.http4s.client.Client
 import scalaz.concurrent.Task
 
 class PRServiceTests extends PullRequestService {
-  val githubUser  = sys.env("GITHUB_USER")
-  val githubToken = sys.env("GITHUB_TOKEN")
-  val droneToken  = sys.env("DRONE_TOKEN")
+  val githubUser         = sys.env("GITHUB_USER")
+  val githubToken        = sys.env("GITHUB_TOKEN")
+  val droneToken         = sys.env("DRONE_TOKEN")
+  val githubClientId     = sys.env("GITHUB_CLIENT_ID")
+  val githubClientSecret = sys.env("GITHUB_CLIENT_SECRET")
 
   private def withClient[A](f: Client => Task[A]): A = {
     val httpClient = PooledHttp1Client()


### PR DESCRIPTION
Github doesn't allow more than 60 requests per hour unless you attach `?client_id=x&client_secret=y` to all requests.

This PR fixes just that.