### PR TITLE
Fix #2375: Memoize should not generate static fields.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Memoize.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Memoize.scala
@@ -69,6 +69,7 @@ import Decorators._
     val sym = tree.symbol
 
     def newField = {
+      assert(!sym.hasAnnotation(defn.ScalaStaticAnnot))
       val fieldType =
         if (sym.isGetter) sym.info.resultType
         else /*sym.isSetter*/ sym.info.firstParamTypes.head

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -98,10 +98,10 @@ class SymUtils(val self: Symbol) extends AnyVal {
     else accessorNamed(self.asTerm.name.setterName)
 
   def field(implicit ctx: Context): Symbol = {
-    val fieldName = if (self.hasAnnotation(defn.ScalaStaticAnnot)) {
-      self.name.asTermName.getterName
-    } else self.asTerm.name.fieldName
-    
+    val thisName = self.name.asTermName
+    val fieldName =
+      if (self.hasAnnotation(defn.ScalaStaticAnnot)) thisName.getterName
+      else thisName.fieldName
     self.owner.info.decl(fieldName).suchThat(!_.is(Method)).symbol
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -97,8 +97,13 @@ class SymUtils(val self: Symbol) extends AnyVal {
     if (self.isSetter) self
     else accessorNamed(self.asTerm.name.setterName)
 
-  def field(implicit ctx: Context): Symbol =
-    self.owner.info.decl(self.asTerm.name.fieldName).suchThat(!_.is(Method)).symbol
+  def field(implicit ctx: Context): Symbol = {
+    val fieldName = if (self.hasAnnotation(defn.ScalaStaticAnnot)) {
+      self.name.asTermName.getterName
+    } else self.asTerm.name.fieldName
+    
+    self.owner.info.decl(fieldName).suchThat(!_.is(Method)).symbol
+  }
 
   def isField(implicit ctx: Context): Boolean =
     self.isTerm && !self.is(Method)


### PR DESCRIPTION
They are not transformed by Getters phase,
they keep the original name and never renamed.