### PR TITLE
dotty-bot: don't ask people to set a reviewer

### DIFF
--- a/bot/src/dotty/tools/bot/PullRequestService.scala
+++ b/bot/src/dotty/tools/bot/PullRequestService.scala
@@ -245,9 +245,6 @@ trait PullRequestService {
     val body =
       s"""|Hello, and thank you for opening this PR! :tada:
           |
-          |If you haven't already, please request a review from one of our
-          |collaborators (have no fear, we don't bite)!
-          |
           |$cla
           |
           |$commitRules


### PR DESCRIPTION
- They can't set one (only contributors can)
- They would have no idea who to set it to anyway.