### PR TITLE
Fix build failure

### DIFF
--- a/tests/neg/i2292.scala
+++ b/tests/neg/i2292.scala
@@ -1,3 +1,3 @@
-package + // error
+package foo+ // error
 
 class Foo

--- a/tests/pos/i2292.scala
+++ b/tests/pos/i2292.scala
@@ -1,0 +1,3 @@
+package +
+
+class Foo


### PR DESCRIPTION
After the recent changes to semantic names, `package +` is a valid name,
just like with scalac.