### PR TITLE
Fix #2391: Make child annotation lazy

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -829,8 +829,13 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     assert(tag == CHILDREN)
     val end = readNat() + readIndex
     val target = readSymbolRef()
-    while (readIndex != end)
-      target.addAnnotation(Annotation.makeChild(readSymbolRef()))
+    while (readIndex != end) {
+      val start = readIndex
+      readNat() // skip reference for now
+      target.addAnnotation(
+          Annotation.makeChild(implicit ctx =>
+              atReadPos(start, () => readSymbolRef())))
+    }
   }
 
   /* Read a reference to a pickled item */

--- a/tests/new/projection.scala
+++ b/tests/new/projection.scala
@@ -1,0 +1,4 @@
+class C { type T }
+object test {
+  def x: C#T = ???
+}

--- a/tests/pos/i2391/Containers.scala
+++ b/tests/pos/i2391/Containers.scala
@@ -1,0 +1,10 @@
+// Containers.scala
+package foo
+
+trait ParentContainer {
+  sealed trait Entry
+}
+
+class ChildContainer extends ParentContainer {
+  trait LazyEntry extends Entry
+}

--- a/tests/pos/i2391/User.scala
+++ b/tests/pos/i2391/User.scala
@@ -1,0 +1,6 @@
+// User.scala
+package foo
+
+trait User {
+  type Entry <: ChildContainer#Entry
+}


### PR DESCRIPTION
Make child annotations compute their symbols lazily when
unpickling from Scala2.
