### PR TITLE
Generalize function symbol synthesis logic

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -108,7 +108,7 @@ class Definitions {
    *        def apply(implicit $x0: T0, ..., $x{N_1}: T{N-1}): R
    *      }
    */
-  def newFunctionNTrait(name: TypeName) = {
+  def newFunctionNTrait(name: TypeName): ClassSymbol = {
     val completer = new LazyType {
       def complete(denot: SymDenotation)(implicit ctx: Context): Unit = {
         val cls = denot.asClass.classSymbol
@@ -189,7 +189,14 @@ class Definitions {
 
   lazy val ScalaPackageVal = ctx.requiredPackage("scala")
   lazy val ScalaMathPackageVal = ctx.requiredPackage("scala.math")
-  lazy val ScalaPackageClass = ScalaPackageVal.moduleClass.asClass
+  lazy val ScalaPackageClass = {
+    val cls = ScalaPackageVal.moduleClass.asClass
+    cls.info.decls.openForMutations.useSynthesizer(
+      name => ctx =>
+        if (name.isTypeName && name.isSyntheticFunction) newFunctionNTrait(name.asTypeName)
+        else NoSymbol)
+    cls
+  }
   lazy val JavaPackageVal = ctx.requiredPackage("java")
   lazy val JavaLangPackageVal = ctx.requiredPackage("java.lang")
   // fundamental modules

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -167,9 +167,6 @@ class SymbolLoaders {
         val mangled = name.mangled
         val e = super.lookupEntry(mangled)
         if (e != null) e
-        else if (_sourceModule.initialDenot.name == nme.scala_ && _sourceModule == defn.ScalaPackageVal &&
-                 name.isTypeName && name.isSyntheticFunction)
-          newScopeEntry(defn.newFunctionNTrait(name.asTypeName))
         else if (isFlatName(mangled.toSimpleName) && enterFlatClasses.isDefined) {
           Stats.record("package scopes with flatnames entered")
           enterFlatClasses.get(ctx)


### PR DESCRIPTION
We will need other synthesized symbols down the road (e.g.
function types in phantom universes). With this commit one
can provide for that by installing a synthesizer in a
scope.