### PR TITLE
Fix #2397: Upgrade hasMatchingMember

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -1341,8 +1341,10 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
         tree match {
           case Typed(unapply, _) => apply(unapply, binder)
           case UnApply(unfun, implicits, args) =>
-            val castedBinder = ref(binder).ensureConforms(tree.tpe)
-            val synth = if (implicits.isEmpty) unfun.appliedTo(castedBinder) else unfun.appliedTo(castedBinder).appliedToArgs(implicits)
+            val mt @ MethodType(_) = unfun.tpe.widen
+            val castedBinder = ref(binder).ensureConforms(mt.paramInfos.head)
+            var synth = unfun.appliedTo(castedBinder)
+            if (implicits.nonEmpty) synth = synth.appliedToArgs(implicits)
             new ExtractorCallRegular(alignPatterns(tree, synth.tpe), synth, args, synth.tpe)
         }
       }

--- a/tests/neg/t5729.scala
+++ b/tests/neg/t5729.scala
@@ -1,0 +1,21 @@
+trait T[X]
+object Test {
+  def join(in: Seq[T[_]]): Int = ???
+  def join[S](in: Seq[T[S]]): String = ???
+  join(null: Seq[T[_]]) // error: ambiguous
+}
+
+object C {
+  def join(in: Seq[List[_]]): Int = error("TODO")
+  def join[S](in: Seq[List[S]]): String = error("TODO")
+
+  join(Seq[List[Int]]()) // error: ambiguous
+  //
+  // ./a.scala:13: error: ambiguous reference to overloaded definition,
+  // both method join in object C of type [S](in: Seq[List[S]])String
+  // and  method join in object C of type (in: Seq[List[_]])Int
+  // match argument types (Seq[List[Int]])
+  //   join(Seq[List[Int]]())
+  //   ^
+  // one error found
+}

--- a/tests/pos/i2397.scala
+++ b/tests/pos/i2397.scala
@@ -1,0 +1,9 @@
+class Foo[A]
+
+object Test {
+  def foo[T](x: Foo[T]) = x
+
+  foo((new Foo[Int]: Foo[_]))
+}
+
+

--- a/tests/pos/i2397.scala
+++ b/tests/pos/i2397.scala
@@ -6,4 +6,11 @@ object Test {
   foo((new Foo[Int]: Foo[_]))
 }
 
+import java.nio.file._
+import java.util.stream.Collectors
+
+object Foo {
+  Files.walk(Paths.get("")).collect(Collectors.toList[Path])
+}
+
 

--- a/tests/pos/t5729.scala
+++ b/tests/pos/t5729.scala
@@ -1,6 +1,0 @@
-trait T[X]
-object Test {
-  def join(in: Seq[T[_]]): Int = ???
-  def join[S](in: Seq[T[S]]): String = ???
-  join(null: Seq[T[_]])
-}


### PR DESCRIPTION
The previous "self-referential" special case needs to be generalized.
The fix caused some changes elsewhere.

 - `t5279` now fails with an overloading ambiguity, which is expected.

 - pattern matching code generation failed in 3 tests, had to be
   upgraded. The errors did not trigger before because instances of
   unapply type parameters were coarser.