### PR TITLE
Fix #2404: Fixes to make collections strawman compile, take 3

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -311,7 +311,8 @@ object Denotations {
           case tp1: MethodOrPoly =>
             tp2 match {
               case tp2: MethodOrPoly =>
-                // Two remedial strategies
+                // Two remedial strategies:
+                //
                 //  1. Prefer method types over poly types. This is necessary to handle
                 //     overloaded definitions like the following
                 //
@@ -319,6 +320,7 @@ object Denotations {
                 //        def ++ (xs: C[A]): D[A]
                 //
                 //     (Code like this is found in the collection strawman)
+                //
                 // 2. In the case of two method types or two polytypes with matching
                 //    parameters and implicit status, merge corresppnding parameter
                 //    and result types.

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -553,7 +553,7 @@ object Denotations {
       if (sd1.exists)
         if (sd2.exists)
           if (isDoubleDef(denot1.symbol, denot2.symbol)) doubleDefError(denot1, denot2)
-          else throw new TypeError(s"failure to disambiguate overloaded reference $this")
+          else throw new TypeError(i"failure to disambiguate overloaded reference at $this")
         else sd1
       else sd2
     }

--- a/compiler/src/dotty/tools/dotc/core/Signature.scala
+++ b/compiler/src/dotty/tools/dotc/core/Signature.scala
@@ -49,6 +49,13 @@ case class Signature(paramsSig: List[TypeName], resSig: TypeName) {
     loop(this.paramsSig, that.paramsSig)
   }
 
+  /** Is this siganture consistent with that signature?
+   *  This is the case if the signatures have consistent parameters
+   *  and result types.
+   */
+  final def consistentWith(that: Signature): Boolean =
+    consistentParams(that) && consistent(resSig, that.resSig)
+
   /** The degree to which this signature matches `that`.
    *  If parameter names are consistent and result types names match (i.e. they are the same
    *  or one is a wildcard), the result is `FullMatch`.

--- a/compiler/src/dotty/tools/dotc/core/Signature.scala
+++ b/compiler/src/dotty/tools/dotc/core/Signature.scala
@@ -1,7 +1,7 @@
 package dotty.tools.dotc
 package core
 
-import Names._, Types._, Contexts._, StdNames._
+import Names._, Types._, Contexts._, StdNames._, Decorators._
 import TypeErasure.sigName
 
 import scala.annotation.tailrec
@@ -49,12 +49,19 @@ case class Signature(paramsSig: List[TypeName], resSig: TypeName) {
     loop(this.paramsSig, that.paramsSig)
   }
 
-  /** Is this siganture consistent with that signature?
-   *  This is the case if the signatures have consistent parameters
-   *  and result types.
-   */
-  final def consistentWith(that: Signature): Boolean =
-    consistentParams(that) && consistent(resSig, that.resSig)
+  /** `that` signature, but keeping all corresponding parts of `this` signature. */
+  final def updateWith(that: Signature): Signature = {
+    def update(name1: TypeName, name2: TypeName): TypeName =
+      if (consistent(name1, name2)) name1 else name2
+    if (this == that) this
+    else if (!this.paramsSig.hasSameLengthAs(that.paramsSig)) that
+    else {
+      val mapped = Signature(
+          this.paramsSig.zipWithConserve(that.paramsSig)(update),
+          update(this.resSig, that.resSig))
+      if (mapped == this) this else mapped
+    }
+  }
 
   /** The degree to which this signature matches `that`.
    *  If parameter names are consistent and result types names match (i.e. they are the same

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1867,8 +1867,15 @@ object Types {
       }
       else candidate
 
-    override def newLikeThis(prefix: Type)(implicit ctx: Context): TermRef =
-      fixDenot(TermRef.withSig(prefix, name, sig), prefix)
+    override def newLikeThis(prefix: Type)(implicit ctx: Context): TermRef = {
+      // If symbol exists, the new signature is the symbol's signature as seen
+      // from the new prefix, modulo consistency
+      val symSig =
+        if (symbol.exists) symbol.info.asSeenFrom(prefix, symbol.owner).signature
+        else sig
+      val newSig = if (sig.consistentWith(symSig)) sig else symSig
+      fixDenot(TermRef.withSig(prefix, name, newSig), prefix)
+    }
 
     override def shadowed(implicit ctx: Context): NamedType =
       fixDenot(TermRef.withSig(prefix, name.derived(ShadowedName), sig), prefix)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1870,10 +1870,13 @@ object Types {
     override def newLikeThis(prefix: Type)(implicit ctx: Context): TermRef = {
       // If symbol exists, the new signature is the symbol's signature as seen
       // from the new prefix, modulo consistency
-      val symSig =
-        if (symbol.exists) symbol.info.asSeenFrom(prefix, symbol.owner).signature
-        else sig
-      val newSig = if (sig.consistentWith(symSig)) sig else symSig
+      val newSig =
+        if (sig == Signature.NotAMethod || !symbol.exists)
+          sig
+        else
+          sig.updateWith(symbol.info.asSeenFrom(prefix, symbol.owner).signature)
+      if (newSig ne sig)
+        core.println(i"sig change at ${ctx.phase} for $this, pre = $prefix, sig: $sig --> $newSig")
       fixDenot(TermRef.withSig(prefix, name, newSig), prefix)
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -96,6 +96,12 @@ object ErrorReporting {
 
     def exprStr(tree: Tree): String = refStr(tree.tpe)
 
+    def takesNoParamsStr(tree: Tree, kind: String) =
+      if (tree.tpe.widen.exists)
+        i"${exprStr(tree)} does not take ${kind}parameters"
+      else
+        i"undefined: $tree # ${tree.uniqueId}: ${tree.tpe.toString}"
+
     def patternConstrStr(tree: Tree): String = ???
 
     def typeMismatch(tree: Tree, pt: Type, implicitFailure: SearchFailure = NoImplicitMatches): Tree =

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -340,7 +340,7 @@ trait TypeAssigner {
         else
           errorType(i"wrong number of arguments for $fntpe: ${fn.tpe}, expected: ${fntpe.paramInfos.length}, found: ${args.length}", tree.pos)
       case t =>
-        errorType(i"${err.exprStr(fn)} does not take parameters", tree.pos)
+        errorType(err.takesNoParamsStr(fn, ""), tree.pos)
     }
     tree.withType(ownType)
   }
@@ -396,7 +396,7 @@ trait TypeAssigner {
           else wrongNumberOfTypeArgs(fn.tpe, pt.typeParams, args, tree.pos)
         }
       case _ =>
-        errorType(i"${err.exprStr(fn)} does not take type parameters", tree.pos)
+        errorType(err.takesNoParamsStr(fn, "type "), tree.pos)
     }
 
     tree.withType(ownType)


### PR DESCRIPTION
This one is needed to compile 

  https://github.com/scala/collection-strawman/pull/64.

It affects a core part of type handling: How to adapt signatures when copying 
TermRefWithSig trees. So far signatures were kept as before, which is incorrect if
the new prefix "sees" the symbol with different type as the old one. The problem
manifested itself by inlining failures.
