### PR TITLE
Move 'reassignment to val' to error case class

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -57,6 +57,7 @@ public enum ErrorMessageID {
     CyclicReferenceInvolvingImplicitID,
     SuperQualMustBeParentID,
     AmbiguousImportID,
+    ReassignmentToValID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1253,4 +1253,18 @@ object messages {
            |"""
   }
 
+  case class ReassignmentToVal(name: Names.Name)(implicit ctx: Context)
+    extends Message(ReassignmentToValID) {
+    val kind = "Reference"
+    val msg = hl"""reassignment to val `$name`"""
+    val explanation =
+      hl"""|You can not assign a new value to `$name` as values can't be changed.
+           |Keep in mind that every statement has a value, so you may e.g. use
+           |  ${"val"} $name ${"= if (condition) 2 else 5"}
+           |In case you need a reassignable name, you can declare it as
+           |variable
+           |  ${"var"} $name ${"="} ...
+           |""".stripMargin
+  }
+
 }

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -15,6 +15,7 @@ import core.Symbols._
 import core.Definitions
 import Inferencing._
 import ErrorReporting._
+import dotty.tools.dotc.reporting.diagnostic.messages.ReassignmentToVal
 
 object Dynamic {
   def isDynamicMethod(name: Name): Boolean =
@@ -99,7 +100,7 @@ trait Dynamic { self: Typer with Applications =>
       case TypeApply(Select(qual, name), targs) if !isDynamicMethod(name) =>
         typedDynamicAssign(qual, name, targs)
       case _ =>
-        errorTree(tree, "reassignment to val")
+        errorTree(tree, ReassignmentToVal(tree.lhs.symbol.name))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -558,7 +558,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
         def reassignmentToVal =
           errorTree(cpy.Assign(tree)(lhsCore, typed(tree.rhs, lhs1.tpe.widen)),
-            "reassignment to val")
+            ReassignmentToVal(lhsCore.symbol.name))
 
         def canAssign(sym: Symbol) =
           sym.is(Mutable, butNot = Accessor) ||

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -358,4 +358,20 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals(namedImport, newPrec)
         assertEquals(namedImport, prevPrec)
       }
+
+  @Test def reassignmentToVal =
+    checkMessagesAfter("frontend") {
+      """
+        |class Context {
+        |  val value = 3
+        |  value = 4
+        |}
+      """.stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        assertMessageCount(1, messages)
+        val ReassignmentToVal(name) :: Nil = messages
+        assertEquals("value", name.show)
+      }
 }


### PR DESCRIPTION
An error message with explanation for ´reassignment to val´. It now includes the symbol's name.

@odersky `typer.Dynamic` reports this error as well, but I don't understand how a `Dynamic` can have `val`s,  the compiler reports a missing `updateDynamic` definition. I changed it anyway, though.