### PR TITLE
Remove empty tree after erasure to pass -Ycheck:all

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -600,7 +600,7 @@ object Erasure extends TypeTestsCasts{
       val stats1 =
         if (takesBridges(ctx.owner)) new Bridges(ctx.owner.asClass).add(stats)
         else stats
-      super.typedStats(stats1, exprOwner)
+      super.typedStats(stats1, exprOwner).filter(!_.isEmpty)
     }
 
     override def adapt(tree: Tree, pt: Type, original: untpd.Tree)(implicit ctx: Context): Tree =

--- a/tests/pos/erased-typedef.scala
+++ b/tests/pos/erased-typedef.scala
@@ -1,0 +1,8 @@
+trait Monadless[Monad[_]] {
+
+  type M[T] = Monad[T]
+
+  def lift[T](body: T): Monad[T] =  ???
+
+  def unlift[T](m: M[T]): T = ???
+}


### PR DESCRIPTION
A simple fix to make sure that empty trees are removed after erasure. This avoids exception with `-Ycheck:all`.

This problem doesn't occur in the test set because we didn't enable `-Ycheck:erasure` and the empty trees are accidentally removed in the next phase.

@felixmulder Do you think it makes sense to `-Ycheck:erasure` on all tests?
