### PR TITLE
Add community build badge to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Dotty
 =====
 [![Build Status](http://dotty-ci.epfl.ch/api/badges/lampepfl/dotty/status.svg)](http://dotty-ci.epfl.ch/lampepfl/dotty)
+[![Community Build Status](https://travis-ci.org/lampepfl/dotty-community-build.svg?branch=master)](https://travis-ci.org/lampepfl/dotty-community-build)
 [![Join the chat at https://gitter.im/lampepfl/dotty](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/lampepfl/dotty?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 * [Homepage](http://dotty.epfl.ch)


### PR DESCRIPTION
The scalatest build is failing at the moment because of https://github.com/lampepfl/dotty/issues/2390 I recommend to subscribe for notifications here https://travis-ci.org/lampepfl/dotty-community-build in order to get email reminders if the the daily build fails.