### PR TITLE
Fix #2368: local variables must be initialized

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -490,7 +490,10 @@ object messages {
            |${"var a = _"}
            |
            |Note that this use of `_` is not placeholder syntax,
-           |but an uninitialized var definition"""
+           |but an uninitialized var definition.
+           |Only fields can be left uninitialized in this manner; local variables
+           |must be initialized.
+           |"""
   }
 
   case class IllegalStartSimpleExpr(illegalToken: String)(implicit ctx: Context)

--- a/tests/neg/t2368.scala
+++ b/tests/neg/t2368.scala
@@ -1,0 +1,5 @@
+class C {
+  def foo() = {
+    var x: String = _ // error: local variables can't be left uninitialized
+  }
+}

--- a/tests/pos/t2368.scala
+++ b/tests/pos/t2368.scala
@@ -1,0 +1,4 @@
+class C {
+  // A `var` field can be left uninitialized.
+  var x: String = _
+}


### PR DESCRIPTION
Disallow var declarations initialized to a placholder, if
the var declaration is local.

`var x: Foo = _` is still allowed in fields.

Testing
=======
Added tests for both invariants above.