### PR TITLE
Fix #2363: better handle extractors in exhaustivity check

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -859,7 +859,7 @@ object desugar {
         case IdPattern(named, tpt) =>
           Function(derivedValDef(pat, named, tpt, EmptyTree, Modifiers(Param)) :: Nil, body)
         case _ =>
-          makeCaseLambda(CaseDef(pat, EmptyTree, body) :: Nil, unchecked = false)
+          makeCaseLambda(CaseDef(pat, EmptyTree, body) :: Nil)
       }
 
       /** If `pat` is not an Identifier, a Typed(Ident, _), or a Bind, wrap

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -351,15 +351,17 @@ class PatternMatcher extends MiniPhaseTransform with DenotTransformer {
       /* (Nil, body) means that `body` is the default case
        * It's a bit hacky but it simplifies manipulations.
        */
-      def extractSwitchCase(treeMakers: List[TreeMaker]): (List[Int], BodyTreeMaker) = treeMakers match {
+      def extractSwitchCase(treeMakers: List[TreeMaker]): (List[Int], BodyTreeMaker) = (treeMakers: @unchecked) match {
         // case 5 =>
         case List(IntEqualityTestTreeMaker(intValue), body: BodyTreeMaker) =>
           (List(intValue), body)
 
         // case 5 | 6 =>
         case List(AlternativesTreeMaker(_, alts, _), body: BodyTreeMaker) =>
-          val intValues = alts.map {
-            case List(IntEqualityTestTreeMaker(intValue)) => intValue
+          val intValues = alts.map { alt =>
+            (alt: @unchecked) match {
+              case List(IntEqualityTestTreeMaker(intValue)) => intValue
+            }
           }
           (intValues, body)
 

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -2,16 +2,17 @@ package dotty.tools.dotc
 package transform
 package patmat
 
-import core.Types._
-import core.Contexts._
-import core.Flags._
+import core._
+import Types._
+import Contexts._
+import Flags._
 import ast.Trees._
 import ast.tpd
-import core.Decorators._
-import core.Symbols._
-import core.StdNames._
-import core.NameOps._
-import core.Constants._
+import Decorators._
+import Symbols._
+import StdNames._
+import NameOps._
+import Constants._
 import reporting.diagnostic.messages._
 import config.Printers.{ exhaustivity => debug }
 
@@ -329,11 +330,11 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
   import SpaceEngine._
   import tpd._
 
-  private val scalaSomeClass       = ctx.requiredClass("scala.Some".toTypeName)
-  private val scalaSeqFactoryClass = ctx.requiredClass("scala.collection.generic.SeqFactory".toTypeName)
-  private val scalaListType        = ctx.requiredClassRef("scala.collection.immutable.List".toTypeName)
-  private val scalaNilType         = ctx.requiredModuleRef("scala.collection.immutable.Nil".toTermName)
-  private val scalaConsType        = ctx.requiredClassRef("scala.collection.immutable.::".toTypeName)
+  private val scalaSomeClass       = ctx.requiredClass("scala.Some")
+  private val scalaSeqFactoryClass = ctx.requiredClass("scala.collection.generic.SeqFactory")
+  private val scalaListType        = ctx.requiredClassRef("scala.collection.immutable.List")
+  private val scalaNilType         = ctx.requiredModuleRef("scala.collection.immutable.Nil")
+  private val scalaConsType        = ctx.requiredClassRef("scala.collection.immutable.::")
 
   /** Checks if it's possible to create a trait/class which is a subtype of `tp`.
    *

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -509,14 +509,14 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
           case space => List(space)
         }
       case OrType(tp1, tp2) => List(Typ(tp1, true), Typ(tp2, true))
-      case _ if tp =:= ctx.definitions.BooleanType =>
+      case tp if tp =:= ctx.definitions.BooleanType =>
         List(
           Typ(ConstantType(Constant(true)), true),
           Typ(ConstantType(Constant(false)), true)
         )
-      case _ if tp.classSymbol.is(Enum) =>
+      case tp if tp.classSymbol.is(Enum) =>
         children.map(sym => Typ(sym.termRef, true))
-      case _ =>
+      case tp =>
         val parts = children.map { sym =>
           if (sym.is(ModuleClass))
             refine(tp, sym.sourceModule.termRef)

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -323,7 +323,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
   import SpaceEngine._
   import tpd._
 
-  private val scalaOptionClass     = ctx.requiredClassRef("scala.Option".toTypeName).symbol.asClass
+  private val scalaSomeClass       = ctx.requiredClassRef("scala.Some".toTypeName).symbol.asClass
   private val scalaSeqFactoryClass = ctx.requiredClass("scala.collection.generic.SeqFactory".toTypeName)
   private val scalaListType        = ctx.requiredClassRef("scala.collection.immutable.List".toTypeName)
   private val scalaNilType         = ctx.requiredModuleRef("scala.collection.immutable.Nil".toTermName)
@@ -420,7 +420,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         Kon(pat.tpe.stripAnnots, pats.map(pat => project(pat)))
       else if (fun.symbol.owner == scalaSeqFactoryClass && fun.symbol.name == nme.unapplySeq)
         projectList(pats)
-      else if (!fun.symbol.info.finalResultType.isRef(scalaOptionClass))
+      else if (fun.symbol.info.finalResultType.isRef(scalaSomeClass))
         Kon(pat.tpe.stripAnnots, pats.map(pat => project(pat)))
       else
         Fun(pat.tpe.stripAnnots, fun.tpe, pats.map(pat => project(pat)))

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -417,14 +417,13 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     case Bind(_, pat) => project(pat)
     case UnApply(fun, _, pats) =>
       if (pat.tpe.classSymbol.is(CaseClass))
-        // FIXME: why dealias is needed here?
-        Kon(pat.tpe.stripAnnots.dealias, pats.map(pat => project(pat)))
+        Kon(pat.tpe.stripAnnots, pats.map(pat => project(pat)))
       else if (fun.symbol.owner == scalaSeqFactoryClass && fun.symbol.name == nme.unapplySeq)
         projectList(pats)
       else if (fun.symbol.info.resultType.isRef(scalaSomeClass))
-        Kon(pat.tpe.stripAnnots.dealias, pats.map(pat => project(pat)))
+        Kon(pat.tpe.stripAnnots, pats.map(pat => project(pat)))
       else
-        Fun(pat.tpe.stripAnnots.dealias, fun.tpe, pats.map(pat => project(pat)))
+        Fun(pat.tpe.stripAnnots, fun.tpe, pats.map(pat => project(pat)))
     case Typed(pat @ UnApply(_, _, _), _) => project(pat)
     case Typed(expr, _) => Typ(expr.tpe.stripAnnots, true)
     case _ =>
@@ -470,7 +469,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
   /** Is `tp1` a subtype of `tp2`?  */
   def isSubType(tp1: Type, tp2: Type): Boolean = {
     // check SI-9657 and tests/patmat/gadt.scala
-    val res = erase(tp1) <:< erase(tp2)
+    val res = tp1 <:< erase(tp2)
     debug.println(s"${tp1.show} <:< ${tp2.show} = $res")
     res
   }

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -323,7 +323,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
   import SpaceEngine._
   import tpd._
 
-  private val scalaSomeClass       = ctx.requiredClassRef("scala.Some".toTermName).symbol.asClass
+  private val scalaOptionClass     = ctx.requiredClassRef("scala.Option".toTypeName).symbol.asClass
   private val scalaSeqFactoryClass = ctx.requiredClass("scala.collection.generic.SeqFactory".toTypeName)
   private val scalaListType        = ctx.requiredClassRef("scala.collection.immutable.List".toTypeName)
   private val scalaNilType         = ctx.requiredModuleRef("scala.collection.immutable.Nil".toTermName)
@@ -420,7 +420,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         Kon(pat.tpe.stripAnnots, pats.map(pat => project(pat)))
       else if (fun.symbol.owner == scalaSeqFactoryClass && fun.symbol.name == nme.unapplySeq)
         projectList(pats)
-      else if (fun.symbol.info.resultType.isRef(scalaSomeClass))
+      else if (!fun.symbol.info.finalResultType.isRef(scalaOptionClass))
         Kon(pat.tpe.stripAnnots, pats.map(pat => project(pat)))
       else
         Fun(pat.tpe.stripAnnots, fun.tpe, pats.map(pat => project(pat)))

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -474,9 +474,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
   /** Is `tp1` a subtype of `tp2`?  */
   def isSubType(tp1: Type, tp2: Type): Boolean = {
-    // check SI-9657 and tests/patmat/gadt.scala
-    //
-    // `erase` is a walkaround to make the following code pass the check:
+    // `erase` is a workaround to make the following code pass the check:
     //
     //    def f(e: Either[Int, String]) = e match {
     //      case Left(i) => i

--- a/doc-tool/src/dotty/tools/dottydoc/model/comment/BodyEntities.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/model/comment/BodyEntities.scala
@@ -64,7 +64,7 @@ final case class Text(text: String) extends Inline
 abstract class EntityLink(val title: Inline) extends Inline { def link: LinkTo }
 object EntityLink {
   def apply(title: Inline, linkTo: LinkTo) = new EntityLink(title) { def link: LinkTo = linkTo }
-  def unapply(el: EntityLink): Option[(Inline, LinkTo)] = Some((el.title, el.link))
+  def unapply(el: EntityLink): Some[(Inline, LinkTo)] = Some((el.title, el.link))
 }
 final case class HtmlTag(data: String) extends Inline {
   private val Pattern = """(?ms)\A<(/?)(.*?)[\s>].*\z""".r

--- a/doc-tool/src/dotty/tools/dottydoc/staticsite/tags.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/staticsite/tags.scala
@@ -104,6 +104,10 @@ object tags {
         title
 
       case ConstantReference(title) => title
+
+      case _ =>  // EmptyReference
+        ctx.docbase.error(s"invalid reference: $ref")
+        null
     }
     override def render(tctx: TemplateContext, nodes: LNode*): AnyRef = nodes(0).render(tctx) match {
       case map: JMap[String, AnyRef] @unchecked =>

--- a/doc-tool/src/dotty/tools/dottydoc/util/MemberLookup.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/util/MemberLookup.scala
@@ -77,7 +77,8 @@ trait MemberLookup {
       case (x :: xs, _) =>
         if (xs.nonEmpty) globalLookup
         else lookup(entity, packages, "scala." + query)
-      case (Nil, _) => ??? // impossible as long as query is not empty
+      case (Nil, _) =>
+        throw new IllegalArgumentException("`query` cannot be empty")
     }
   }
 

--- a/doc-tool/src/dotty/tools/dottydoc/util/MemberLookup.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/util/MemberLookup.scala
@@ -77,6 +77,7 @@ trait MemberLookup {
       case (x :: xs, _) =>
         if (xs.nonEmpty) globalLookup
         else lookup(entity, packages, "scala." + query)
+      case (Nil, _) => ??? // impossible as long as query is not empty
     }
   }
 

--- a/tests/patmat/dotty-unreachable.scala
+++ b/tests/patmat/dotty-unreachable.scala
@@ -1,0 +1,17 @@
+object Types {
+  abstract case class TermRef(val prefix: String, name: String) {
+    type ThisType = TermRef
+
+    def alts: List[TermRef] = ???
+  }
+}
+
+class Test {
+  def foo(tp: Types.TermRef): Unit = {
+      tp.alts.filter(_.name == "apply") match {
+        case Nil =>
+        case alt :: Nil =>
+        case alt =>
+      }
+  }
+}

--- a/tests/patmat/dotty.scala
+++ b/tests/patmat/dotty.scala
@@ -1,0 +1,30 @@
+object IntEqualityTestTreeMaker {
+  def unapply(xs: Int): Option[Int] = ???
+}
+
+class Test {
+  def isBelow(n: Int, s: String): Boolean = false
+
+  def foo(xs: List[(Int, String)]): Unit = (xs filter (isBelow _).tupled) match {
+    case Nil =>
+    case matches =>
+  }
+
+  def linkCompanions(xs: List[(Int, Int)]): Unit = {
+    xs.groupBy(_._1).foreach {
+      case (_, List(x1, x2)) =>
+      case _ => ()
+    }
+  }
+
+  def bar(xs: List[(Int, String)]): Unit = xs match {
+    case (x, s) :: Nil =>
+    case Nil =>
+    case _ =>
+  }
+
+  def patmat(alts: List[List[Int]]): Unit = alts.forall {
+    case List(IntEqualityTestTreeMaker(_)) => false
+    case _ => true
+  }
+}

--- a/tests/patmat/exhausting.check
+++ b/tests/patmat/exhausting.check
@@ -1,6 +1,6 @@
 21: Pattern Match Exhaustivity: List(_), List(_, _, _)
 27: Pattern Match Exhaustivity: Nil
-32: Pattern Match Exhaustivity: List(_, _)
+32: Pattern Match Exhaustivity: List(_, _*)
 39: Pattern Match Exhaustivity: Bar3
 44: Pattern Match Exhaustivity: (Bar2, Bar2)
 53: Pattern Match Exhaustivity: (Bar2, Bar2), (Bar2, Bar1), (Bar1, Bar3), (Bar1, Bar2)

--- a/tests/patmat/for.scala
+++ b/tests/patmat/for.scala
@@ -2,4 +2,6 @@ object Test {
   def foo[A, B](l: List[(A, B)]): List[A] = {
     for ((a, b) <- l) yield a
   }
+
+  def bar(xs: List[(Int, List[Int])]): Unit = for ( (_, x :: y :: xs) <- xs) yield x
 }

--- a/tests/patmat/i2363.check
+++ b/tests/patmat/i2363.check
@@ -1,0 +1,2 @@
+15: Pattern Match Exhaustivity: List(_, _*)
+21: Pattern Match Exhaustivity: _: Expr

--- a/tests/patmat/i2363.scala
+++ b/tests/patmat/i2363.scala
@@ -1,0 +1,25 @@
+sealed trait Expr
+class IntExpr extends Expr
+class BooleanExpr extends Expr
+
+object IntExpr {
+  def unapply(expr: Expr): Option[IntExpr] = ???
+}
+
+object BooleanExpr {
+  def unapply(expr: Expr): Option[BooleanExpr] = ???
+}
+
+
+class Test {
+  def foo(x: List[Expr]): Int = x match {
+    case IntExpr(_) :: xs => 1
+    case BooleanExpr(_) :: xs => 1
+    case Nil => 2
+  }
+
+  def bar(x: Expr): Int = x match {
+    case IntExpr(_) => 1
+    case BooleanExpr(_) => 2
+  }
+}

--- a/tests/patmat/optionless.check
+++ b/tests/patmat/optionless.check
@@ -1,0 +1,1 @@
+28: Pattern Match Exhaustivity: _: Tree

--- a/tests/patmat/optionless.check
+++ b/tests/patmat/optionless.check
@@ -1,1 +1,3 @@
+20: Pattern Match Exhaustivity: _: Tree
+24: Pattern Match Exhaustivity: _: Tree
 28: Pattern Match Exhaustivity: _: Tree

--- a/tests/patmat/optionless.scala
+++ b/tests/patmat/optionless.scala
@@ -1,0 +1,32 @@
+sealed trait Tree
+case class Ident(name: String) extends Tree
+
+object Ident1 {
+  def unapply(tree: Tree): Ident = ???
+}
+
+trait Cap
+object Ident2 {
+  def unapply(tree: Tree)(implicit cap: Cap): Ident = ???
+}
+
+object Ident3 {
+  def unapply(tree: Tree)(implicit cap: Cap): Option[Ident] = ???
+}
+
+
+
+class Test {
+  def foo(t: Tree): Unit = t match {
+    case Ident1(t) =>
+  }
+
+  def bar(t: Tree)(implicit c: Cap): Unit = t match {
+    case Ident2(t) =>
+  }
+
+  def qux(t: Tree)(implicit c: Cap): Unit = t match {
+    case Ident3(t) =>
+  }
+
+}

--- a/tests/patmat/patmat-adt.check
+++ b/tests/patmat/patmat-adt.check
@@ -1,5 +1,5 @@
 7: Pattern Match Exhaustivity: Bad(Good(_)), Good(Bad(_))
 19: Pattern Match Exhaustivity: Some(_)
-24: Pattern Match Exhaustivity: (None, Some(_)), (_, Some(_))
+24: Pattern Match Exhaustivity: (_, Some(_))
 29: Pattern Match Exhaustivity: (None, None), (Some(_), Some(_))
 50: Pattern Match Exhaustivity: LetL(BooleanLit), LetL(IntLit)

--- a/tests/patmat/patmat-extractor.check
+++ b/tests/patmat/patmat-extractor.check
@@ -1,0 +1,2 @@
+13: Pattern Match Exhaustivity: _: Node
+15: Match case Unreachable

--- a/tests/patmat/patmatexhaust.check
+++ b/tests/patmat/patmatexhaust.check
@@ -2,6 +2,7 @@
 11: Pattern Match Exhaustivity: Bar(_)
 23: Pattern Match Exhaustivity: (Qult(), Qult()), (Kult(_), Kult(_))
 49: Pattern Match Exhaustivity: _: Gp
+59: Pattern Match Exhaustivity: Nil
 75: Pattern Match Exhaustivity: _: B
 100: Pattern Match Exhaustivity: _: C1
 114: Pattern Match Exhaustivity: D2(), D1

--- a/tests/patmat/t6420.check
+++ b/tests/patmat/t6420.check
@@ -1,1 +1,1 @@
-5: Pattern Match Exhaustivity: (Nil, _), (List(true, _), _), (List(false, _), _), (_, Nil), (_, List(true, _)), (_, List(false, _))
+5: Pattern Match Exhaustivity: (_: List, Nil), (_: List, List(true, _*)), (_: List, List(false, _*))

--- a/tests/patmat/t7020.check
+++ b/tests/patmat/t7020.check
@@ -1,4 +1,4 @@
-3: Pattern Match Exhaustivity: List(_, _)
-10: Pattern Match Exhaustivity: List(_, _)
-17: Pattern Match Exhaustivity: List(_, _)
-24: Pattern Match Exhaustivity: List(_, _)
+3: Pattern Match Exhaustivity: List(_, _*)
+10: Pattern Match Exhaustivity: List(_, _*)
+17: Pattern Match Exhaustivity: List(_, _*)
+24: Pattern Match Exhaustivity: List(_, _*)

--- a/tests/patmat/t7466.check
+++ b/tests/patmat/t7466.check
@@ -1,1 +1,1 @@
-8: Pattern Match Exhaustivity: (true, _), (false, _), (_, true), (_, false)
+8: Pattern Match Exhaustivity: (_, true), (_, false)

--- a/tests/patmat/t9129.check
+++ b/tests/patmat/t9129.check
@@ -1,1 +1,1 @@
-21: Pattern Match Exhaustivity: Two(B2, A2), Two(_, A2)
+21: Pattern Match Exhaustivity: Two(_, A2)

--- a/tests/patmat/t9232.check
+++ b/tests/patmat/t9232.check
@@ -1,1 +1,1 @@
-13: Pattern Match Exhaustivity: Node2()
+13: Pattern Match Exhaustivity: Node2(), Node1(Foo(_))

--- a/tests/patmat/t9351.check
+++ b/tests/patmat/t9351.check
@@ -1,3 +1,3 @@
 8: Pattern Match Exhaustivity: _: A
-17: Pattern Match Exhaustivity: (_, _), (_, None), (_, Some(_))
+17: Pattern Match Exhaustivity: (_, None), (_, Some(_))
 28: Pattern Match Exhaustivity: (_, _)


### PR DESCRIPTION
Fix #2363: better handle extractors in exhaustivity check

1. Better handle exactors
2. Translate the pattern `List(pat1, pat2, c:_*)` to space semantically
3. Deal with extractors that return `Some[_]` or option-less type
4. Reduce redundant counterexamples in the warning

Previously we approximate extractor either to the extracted type space or Empty,
which is too coarse, and it causes some false positives about unreachable case.
Introducing the concept extractor into the theory enables us to inspect the
patterns inside extractors and check more unreachable cases, which is not
supported by Scalac.

Scalac is silent with following code, but Dotty _correctly_ reports both unexhaustive and
unreachable warnings.

```Scala
    sealed trait Node
    case class NodeA(i: Int) extends Node
    case class NodeB(b: Boolean) extends Node
    case class NodeC(s: String) extends Node

    object Node {
      def unapply(node: Node): Option[(Node, Node)] = ???
    }

    object Test {
      def foo(x: Node): Boolean = x match { // unexhaustive
        case Node(NodeA(_), NodeB(_)) => true
        case Node(NodeA(4), NodeB(false)) => true // unreachable code
      }
    }
```