### PR TITLE
Error on value class with phantom value

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -464,6 +464,8 @@ object Checking {
           case List(param) =>
             if (param.is(Mutable))
               ctx.error("value class parameter must not be a var", param.pos)
+            if (param.info.isPhantom)
+              ctx.error("value class parameter must not be phantom", param.pos)
           case _ =>
             ctx.error("value class needs to have exactly one val parameter", clazz.pos)
         }


### PR DESCRIPTION
Previously there was an error emitted but the message was quite obscure. 