### PR TITLE
Fix #2426: Use Scala-2 syntax for annotations of class constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -294,6 +294,41 @@ object Parsers {
       } finally inFunReturnType = saved
     }
 
+    /** A placeholder for dummy arguments that should be re-parsed as parameters */
+    val ParamNotArg = EmptyTree
+
+    /** A flag indicating we are parsing in the annotations of a primary
+     *  class constructor
+     */
+    private var inClassConstrAnnots = false
+
+    private def fromWithinClassConstr[T](body: => T): T = {
+      val saved = inClassConstrAnnots
+      try {
+        inClassConstrAnnots = true
+        body
+      } finally {
+        inClassConstrAnnots = saved
+        if (lookaheadTokens.nonEmpty) {
+          in.insertTokens(lookaheadTokens.toList)
+          lookaheadTokens.clear()
+        }
+      }
+    }
+
+    /** Lookahead tokens for the case of annotations in class constructors.
+     *  We store tokens in lookahead as long as they can form a valid prefix
+     *  of a class parameter clause.
+     */
+    private var lookaheadTokens = new ListBuffer[TokenData]
+
+    /** Copy current token to end of lookahead */
+    private def saveLookahead() = {
+      val lookahead = new TokenData{}
+      lookahead.copyFrom(in)
+      lookaheadTokens += lookahead
+    }
+
     def migrationWarningOrError(msg: String, offset: Int = in.offset) =
       if (in.isScala2Mode)
         ctx.migrationWarning(msg, source atPos Position(offset))
@@ -1280,10 +1315,43 @@ object Parsers {
       if (in.token == RPAREN) Nil else commaSeparated(exprInParens)
 
     /** ParArgumentExprs ::= `(' [ExprsInParens] `)'
-     *                    |  `(' [ExprsInParens `,'] PostfixExpr `:' `_' `*' ')' \
+     *                    |  `(' [ExprsInParens `,'] PostfixExpr `:' `_' `*' ')'
+     *
+     *  Special treatment for arguments of primary class constructor
+     *  annotations. Empty argument lists `(` `)` get represented
+     *  as `List(ParamNotArg)` instead of `Nil`, indicating that the
+     *  token sequence should be interpreted as an empty parameter clause
+     *  instead. `ParamNotArg` can also be produced when parsing the first
+     *  argument (see `classConstrAnnotExpr`).
+     *
+     *  The method affects `lookaheadTokens` as a side effect.
+     *  If the argument list parses as `List(ParamNotArg)`, `lookaheadTokens`
+     *  contains the tokens that need to be replayed to parse the parameter clause.
+     *  Otherwise, `lookaheadTokens` is empty.
      */
-    def parArgumentExprs(): List[Tree] =
-      inParens(if (in.token == RPAREN) Nil else commaSeparated(argumentExpr))
+    def parArgumentExprs(): List[Tree] = {
+      if (inClassConstrAnnots) {
+        assert(lookaheadTokens.isEmpty)
+        saveLookahead()
+        accept(LPAREN)
+        val args =
+          if (in.token == RPAREN) ParamNotArg :: Nil
+          else {
+            openParens.change(LPAREN, +1)
+            try commaSeparated(argumentExpr)
+            finally openParens.change(LPAREN, -1)
+          }
+        if (args == ParamNotArg :: Nil) in.adjustSepRegions(RPAREN) // simulate `)` without requiring it
+        else {
+          lookaheadTokens.clear()
+          accept(RPAREN)
+        }
+        args
+      }
+      else
+        inParens(if (in.token == RPAREN) Nil else commaSeparated(argumentExpr))
+
+    }
 
     /** ArgumentExprs ::= ParArgumentExprs
      *                 |  [nl] BlockExpr
@@ -1291,9 +1359,33 @@ object Parsers {
     def argumentExprs(): List[Tree] =
       if (in.token == LBRACE) blockExpr() :: Nil else parArgumentExprs()
 
-    val argumentExpr = () => exprInParens() match {
-      case a @ Assign(Ident(id), rhs) => cpy.NamedArg(a)(id, rhs)
-      case e => e
+    val argumentExpr = () => {
+      val arg =
+        if (inClassConstrAnnots && lookaheadTokens.nonEmpty) classConstrAnnotExpr()
+        else exprInParens()
+      arg match {
+        case arg @ Assign(Ident(id), rhs) => cpy.NamedArg(arg)(id, rhs)
+        case arg => arg
+      }
+    }
+
+    /** Handle first argument of an argument list to an annotation of
+     *  a primary class constructor. If the current token either cannot
+     *  start an expression or is an identifier and is followed by `:`,
+     *  stop parsing the rest of the expression and return `EmptyTree`,
+     *  indicating that we should re-parse the expression as a parameter clause.
+     *  Otherwise clear the lookahead buffer and parse as normal.
+     */
+    def classConstrAnnotExpr() = {
+      saveLookahead()
+      if (in.token == IDENTIFIER) {
+        postfixExpr() match {
+          case Ident(_) if in.token == COLON => ParamNotArg
+          case t => expr1Rest(t, Location.InParens)
+        }
+      }
+      else if (isExprIntro) exprInParens()
+      else ParamNotArg
     }
 
     /** ArgumentExprss ::= {ArgumentExprs}
@@ -1305,9 +1397,17 @@ object Parsers {
     }
 
     /** ParArgumentExprss ::= {ParArgumentExprs}
+     *
+     *  Special treatment for arguments of primary class constructor
+     *  annotations. If an argument list returns `List(ParamNotArg)`
+     *  ignore it, and return prefix parsed before that list instead.
      */
     def parArgumentExprss(fn: Tree): Tree =
-      if (in.token == LPAREN) parArgumentExprss(Apply(fn, parArgumentExprs()))
+      if (in.token == LPAREN) {
+        val first = parArgumentExprs()
+        if (inClassConstrAnnots && first == ParamNotArg :: Nil) fn
+        else parArgumentExprss(Apply(fn, first))
+      }
       else fn
 
     /** BlockExpr ::= `{' (CaseClauses | Block) `}'
@@ -2094,21 +2194,15 @@ object Parsers {
      */
     def classConstr(owner: Name, isCaseClass: Boolean = false): DefDef = atPos(in.lastOffset) {
       val tparams = typeParamClauseOpt(ParamOwner.Class)
-      val cmods = constrModsOpt(owner)
+      val cmods = fromWithinClassConstr(constrModsOpt(owner))
       val vparamss = paramClauses(owner, isCaseClass)
       makeConstructor(tparams, vparamss).withMods(cmods)
     }
 
-    /** ConstrMods        ::=  AccessModifier
-     *                      |  Annotation {Annotation} (AccessModifier | `this')
+    /** ConstrMods        ::=  {Annotation} [AccessModifier]
      */
-    def constrModsOpt(owner: Name): Modifiers = {
-      val mods = modifiers(accessModifierTokens, annotsAsMods())
-      if (mods.hasAnnotations && !mods.hasFlags)
-        if (in.token == THIS) in.nextToken()
-        else syntaxError(AnnotatedPrimaryConstructorRequiresModifierOrThis(owner), mods.annotations.last.pos)
-      mods
-    }
+    def constrModsOpt(owner: Name): Modifiers =
+      modifiers(accessModifierTokens, annotsAsMods())
 
     /** ObjectDef       ::= id TemplateOpt
      */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1318,7 +1318,7 @@ object Parsers {
      *                    |  `(' [ExprsInParens `,'] PostfixExpr `:' `_' `*' ')'
      *
      *  Special treatment for arguments of primary class constructor
-     *  annotations. All empty argument lists `(` `)` follwoing the first 
+     *  annotations. All empty argument lists `(` `)` following the first 
      *  get represented as `List(ParamNotArg)` instead of `Nil`, indicating that
      *  the token sequence should be interpreted as an empty parameter clause
      *  instead. `ParamNotArg` can also be produced when parsing the first

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1351,7 +1351,6 @@ object Parsers {
       }
       else
         inParens(if (in.token == RPAREN) Nil else commaSeparated(argumentExpr))
-
     }
 
     /** ArgumentExprs ::= ParArgumentExprs

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1341,7 +1341,8 @@ object Parsers {
             try commaSeparated(argumentExpr)
             finally openParens.change(LPAREN, -1)
           }
-        if (args == ParamNotArg :: Nil) in.adjustSepRegions(RPAREN) // simulate `)` without requiring it
+        if (args == ParamNotArg :: Nil)
+          in.adjustSepRegions(RPAREN) // simulate `)` without requiring it
         else {
           lookaheadTokens.clear()
           accept(RPAREN)
@@ -1374,7 +1375,7 @@ object Parsers {
      *  start an expression or is an identifier and is followed by `:`,
      *  stop parsing the rest of the expression and return `EmptyTree`,
      *  indicating that we should re-parse the expression as a parameter clause.
-     *  Otherwise clear the lookahead buffer and parse as normal.
+     *  Otherwise parse as normal.
      */
     def classConstrAnnotExpr() = {
       saveLookahead()

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -233,10 +233,10 @@ object Scanners {
       following = copy :: following
     }
 
-    /** If following is empty, invalidate token data `td` by setting 
+    /** If following is empty, invalidate token data `td` by setting
      *  `td.token` to `EMPTY`. Otherwise pop head of `following` into `td`.
      */
-    private def popCopy(td: TokenData) = {
+    private def popCopy(td: TokenData) =
       if (following.isEmpty) td.token = EMPTY
       else {
         td.copyFrom(following.head)

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -50,7 +50,7 @@ public enum ErrorMessageID {
     ExpectedTokenButFoundID,
     MixedLeftAndRightAssociativeOpsID,
     CantInstantiateAbstractClassOrTraitID,
-    AnnotatedPrimaryConstructorRequiresModifierOrThisID,
+    DUMMY_AVAILABLE_1,
     OverloadedOrRecursiveMethodNeedsResultTypeID,
     RecursiveValueNeedsResultTypeID,
     CyclicReferenceInvolvingID,

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1135,21 +1135,6 @@ object messages {
            |""".stripMargin
   }
 
-  case class AnnotatedPrimaryConstructorRequiresModifierOrThis(cls: Name)(implicit ctx: Context)
-  extends Message(AnnotatedPrimaryConstructorRequiresModifierOrThisID) {
-    val kind = "Syntax"
-    val msg = hl"""${"private"}, ${"protected"}, or ${"this"} expected for annotated primary constructor"""
-    val explanation =
-      hl"""|When using annotations with a primary constructor of a class,
-           |the annotation must be followed by an access modifier
-           |(${"private"} or ${"protected"}) or ${"this"}.
-           |
-           |For example:
-           |  ${"class Sample @deprecated this(param: Parameter) { ..."}
-           |                           ^^^^
-           |""".stripMargin
-  }
-
   case class OverloadedOrRecursiveMethodNeedsResultType(tree: Names.TermName)(implicit ctx: Context)
   extends Message(OverloadedOrRecursiveMethodNeedsResultTypeID) {
     val kind = "Syntax"
@@ -1277,7 +1262,7 @@ object messages {
           |$noParameters""".stripMargin
 
   }
-                        
+
   case class AmbiguousOverload(tree: tpd.Tree, alts: List[SingleDenotation], pt: Type)(
     err: typer.ErrorReporting.Errors)(
     implicit ctx: Context)
@@ -1296,7 +1281,7 @@ object messages {
            |- adding a type ascription as in `${"instance.myMethod: String => Int"}`
            |"""
   }
-                        
+
   case class ReassignmentToVal(name: Names.Name)(implicit ctx: Context)
     extends Message(ReassignmentToValID) {
     val kind = "Reference"

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -198,21 +198,6 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertTrue("expected trait", isTrait)
     }
 
-  @Test def constructorModifier =
-    checkMessagesAfter("frontend") {
-      """
-        |class AnotherClass @deprecated ()
-      """.stripMargin
-    }
-    .expect { (ictx, messages) =>
-      implicit val ctx: Context = ictx
-      val defn = ictx.definitions
-
-      assertMessageCount(1, messages)
-      val AnnotatedPrimaryConstructorRequiresModifierOrThis(cls) :: Nil = messages
-      assertEquals("AnotherClass", cls.show)
-    }
-
   @Test def overloadedMethodNeedsReturnType =
     checkMessagesAfter("frontend") {
       """
@@ -399,7 +384,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("Scope.foo(1)", tree.show)
       assertEquals("((a: Int)Unit)(Scope.foo)", methodPart.show)
     }
-  
+
   @Test def ambiugousOverloadWithWildcard =
     checkMessagesAfter("frontend") {
       """object Context {

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -335,8 +335,7 @@ TmplDef           ::=  ([‘case’ | `enum'] ‘class’ | trait’) ClassDef
                     |  `enum' EnumDef
 ClassDef          ::=  id ClassConstr TemplateOpt                               ClassDef(mods, name, tparams, templ)
 ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses         with DefDef(_, <init>, Nil, vparamss, EmptyTree, EmptyTree) as first stat
-ConstrMods        ::=  AccessModifier
-                    |  Annotation {Annotation} (AccessModifier | ‘this’)
+ConstrMods        ::=  {Annotation} [AccessModifier]
 ObjectDef         ::=  id TemplateOpt                                           ModuleDef(mods, name, template)  // no constructor
 EnumDef           ::=  id ClassConstr [`extends' [ConstrApps]]                  EnumDef(mods, name, tparams, template)
                        [nl] ‘{’ EnumCaseStat {semi EnumCaseStat} ‘}’

--- a/tests/pos/i2426.scala
+++ b/tests/pos/i2426.scala
@@ -2,7 +2,18 @@ class Foo @deprecated("foo", "2.11.0") (x: Int)
 
 class Bar @deprecated(x: Int)
 
-class Baz @deprecated()
+class Baz1 @deprecated(implicit c: C)
+class Baz2 @deprecated()(implicit c: C)
+class Baz3 @deprecated()()(implicit c: C)
+
+object Test {
+  implicit val c: C = obj
+  new Baz1
+  new Baz2
+  new Baz3()
+}
+
+class D(implicit x: C)
 
 class C
 object obj extends C

--- a/tests/pos/i2426.scala
+++ b/tests/pos/i2426.scala
@@ -1,0 +1,13 @@
+class Foo @deprecated("foo", "2.11.0") (x: Int)
+
+class Bar @deprecated(x: Int)
+
+class Baz @deprecated()
+
+class C
+object obj extends C
+
+class ann(x: C)(y: C, s: String) extends scala.annotation.Annotation
+
+class Bam @ann(obj)(obj, "h")(n: String)
+


### PR DESCRIPTION
Use Scala-2 compatible syntax for annotations of primary class constructors.
In fact, we can drop Scala 2's restriction that such annotations may only
have one parameter list.