### PR TITLE
Handle case where typevar instance is fully determined

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -611,7 +611,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
   override def toString: String = {
     def entryText(tp: Type): String = tp match {
       case tp: TypeBounds => tp.toString
-      case _ =>" := " + tp
+      case _ => " := " + tp
     }
     val constrainedText =
       " constrained types = " + domainLambdas.mkString("\n")

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -250,7 +250,10 @@ object Inferencing {
       //     val y: List[List[String]] = List(List(1))
       if (!hasUnreportedErrors)
         vs foreachBinding { (tvar, v) =>
-          if (v != 0) {
+          if (v != 0 && ctx.typerState.constraint.contains(tvar)) {
+            // previous interpolations could have already instantiated `tvar`
+            // through unification, that's why we have to check again whether `tvar`
+            // is contained in the current constraint.
             typr.println(s"interpolate ${if (v == 1) "co" else "contra"}variant ${tvar.show} in ${tp.show}")
             tvar.instantiate(fromBelow = v == 1)
           }

--- a/tests/pos/strawman-i79.scala
+++ b/tests/pos/strawman-i79.scala
@@ -1,0 +1,22 @@
+object Empty
+  extends App {
+
+  trait Iterable[+A]
+      extends IterableOnce[A]
+
+  trait IterableOps[+A, +CC[X], +C] {
+    def ++[B >: A](xs: IterableOnce[B]): CC[B] = ???
+  }
+
+  trait IterableOnce[+A]
+
+  class LazyList[+A]()
+      extends IterableOps[A, LazyList, LazyList[A]]
+      with Iterable[A]
+
+  object LazyList {
+    def empty[A <: Any]: LazyList[A] = new LazyList[A]()
+  }
+
+  LazyList.empty ++ LazyList.empty
+}


### PR DESCRIPTION
It's possible that a type parameter in a constraint gets instantiated via
a unification operation. In that case, the type parameter does not have
a TypeBounds instance associated with it, so is not considered to be
contained in the constraint. But it must still be possible to instantiate
a type variable corresponding to this parameter.

Test case in collection strawman: `List.empty ++ List.empty`.