### PR TITLE
Move ´parameterized type lack argument list´ to error case class

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -61,6 +61,7 @@ public enum ErrorMessageID {
     AmbiguousOverloadID,
     ReassignmentToValID,
     TypeDoesNotTakeParametersID,
+    ParameterizedTypeLacksArgumentsID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1326,4 +1326,14 @@ object messages {
          |declared to take any.
          |"""
   }
+
+  case class ParameterizedTypeLacksArguments(psym: Symbol)(implicit ctx: Context)
+    extends Message(ParameterizedTypeLacksArgumentsID) {
+    val msg = hl"parameterized $psym lacks argument list"
+    val kind = "Reference"
+    val explanation =
+      hl"""The $psym is declared with non-implicit parameters, you may not leave
+          |out the parameter list when extending it.
+          |"""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1286,7 +1286,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       case cinfo: MethodType =>
         if (!ctx.erasedTypes) { // after constructors arguments are passed in super call.
           typr.println(i"constr type: $cinfo")
-          ctx.error(em"parameterized $psym lacks argument list", ref.pos)
+          ctx.error(ParameterizedTypeLacksArguments(psym), ref.pos)
         }
         ref
       case _ =>

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -457,4 +457,20 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals("WithOutParams", tpe.show)
       }
 
+  @Test def parameterizedTypeLacksParameters =
+    checkMessagesAfter("frontend") {
+      """
+        |trait WithParams(s: String)
+        |class Extending extends WithParams
+      """.stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        val defn = ictx.definitions
+
+        assertMessageCount(1, messages)
+        val ParameterizedTypeLacksArguments(symbol) :: Nil = messages
+        assertEquals("trait WithParams", symbol.show)
+      }
+
 }


### PR DESCRIPTION
@felixmulder Another simple one. A bit shifting in the use of "arguments" and "parameters", though.