### PR TITLE
<notype> pops up after pickling with tpd changes

### DIFF
--- a/after-pickling.txt
+++ b/after-pickling.txt
@@ -1,0 +1,1 @@
+[cannot display due to class dotty.tools.dotc.reporting.diagnostic.messages$Error at ?: value of type <notype> does not take parameters, raw string = dotty.tools.dotc.printing.Formatting$StringFormatter@6e950bcf]

--- a/before-pickling.txt
+++ b/before-pickling.txt
@@ -1,0 +1,14 @@
+package <empty>.type {
+  import dotty.tools.dotc.core.Decorators._
+  import dotty.tools.dotc.core.NameOps._
+  final lazy module val Test: Test = new Test()
+  @scala.annotation.internal.SourceFile("test.scala") final module class Test()
+     extends
+   java.lang.Object() { this: Test.type => 
+    dotty.tools.dotc.core.NameOps.NameDecorator[
+      dotty.tools.dotc.core.Names.TermName
+    ](dotty.tools.dotc.core.Decorators.PreNamedString("JFunction").toTermName).
+      specializedFor
+    (scala.Nil, scala.Predef.???, scala.Nil, scala.Nil)(scala.Predef.???)
+  }
+}

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1,3 +1,4 @@
+
 package dotty.tools
 package dotc
 package ast
@@ -479,8 +480,17 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       // the function type itself. A treetransform may keep the function type the
       // same but its widened type might change.
 
-    override def TypeApply(tree: Tree)(fun: Tree, args: List[Tree])(implicit ctx: Context): TypeApply =
-      ta.assignType(untpd.cpy.TypeApply(tree)(fun, args), fun, args)
+    override def TypeApply(tree: Tree)(fun: Tree, args: List[Tree])(implicit ctx: Context): TypeApply = {
+      println
+      println(tree.show)
+      println(tree.tpe.show)
+      val untyped = untpd.cpy.TypeApply(tree)(fun, args)
+      if (untyped.ne(tree)) // Set this to true and the test passes
+        ta.assignType(untyped, fun, args)
+      else
+        tree.asInstanceOf[TypeApply]
+
+    }
       // Same remark as for Apply
 
     override def Literal(tree: Tree)(const: Constant)(implicit ctx: Context): Literal =
@@ -950,4 +960,3 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     if (file != null && file.exists) new SourceFile(file, Codec(encoding)) else NoSource
   }
 }
-

--- a/test.scala
+++ b/test.scala
@@ -1,0 +1,6 @@
+import dotty.tools.dotc.core.Decorators._
+import dotty.tools.dotc.core.NameOps._
+
+object Test {
+  "JFunction".toTermName.specializedFor(Nil, ???, Nil, Nil)(???)
+}


### PR DESCRIPTION
Another issue caused by keeping the types coming out of typer: it seems that a `<notype>` pops up after pickling. I couldn't reproduce the bug with something else than a pickling test (I guess something later in the pipeline is healing that type?), here is a minimised test along with the changes in `tpd.scala` to reproduce the issue.

```
run -classpath library/target/scala-2.11/dotty-library_2.11-0.1.1-bin-SNAPSHOT-nonbootstrapped.jar:compiler/target/scala-2.11/dotty-compiler_2.11-0.1.1-bin-SNAPSHOT-nonbootstrapped.jar:interfaces/target/dotty-interfaces-0.1.1-bin-SNAPSHOT.jar -Ytest-pickler test.scala
```

@odersky Any idea where I should look?