### PR TITLE
Move 'var/val parameter may not be call-by-name' to error case class

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1767,7 +1767,7 @@ object Parsers {
             } else {
               accept(COLON)
               if (in.token == ARROW && owner.isTypeName && !(mods is Local))
-                syntaxError(s"${if (mods is Mutable) "`var'" else "`val'"} parameters may not be call-by-name")
+                syntaxError(VarValParametersMayNotBeCallByName(name, mods is Mutable))
               paramType()
             }
           val default =

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -62,6 +62,7 @@ public enum ErrorMessageID {
     ReassignmentToValID,
     TypeDoesNotTakeParametersID,
     ParameterizedTypeLacksArgumentsID,
+    VarValParametersMayNotBeCallByNameID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1342,11 +1342,11 @@ object messages {
     val msg = s"${if (mutable) "`var'" else "`val'"} parameters may not be call-by-name"
     val kind = "Syntax"
     val explanation =
-      hl"""Parameters of classes and traits may no be call-by-name. In case you
-          |want the parameter to be evaluated on demand, consider using a function
-          |and a lazy value in the class such as
-          |  ${s"class MyClass(${name}Tick: () => String) {"}
-          |  ${s"  lazy val $name = ${name}Tick"}
+      hl"""${"var"} and ${"val"} parameters of classes and traits may no be call-by-name. In case you
+          |want the parameter to be evaluated on demand, consider making it just a parameter
+          |and a ${"def"} in the class such as
+          |  ${s"class MyClass(${name}Tick: => String) {"}
+          |  ${s"  def $name() = ${name}Tick"}
           |  ${"}"}
           |"""
   }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1336,4 +1336,18 @@ object messages {
           |out the parameter list when extending it.
           |"""
   }
+
+  case class VarValParametersMayNotBeCallByName(name: Names.TermName, mutable: Boolean)(implicit ctx: Context)
+    extends Message(VarValParametersMayNotBeCallByNameID) {
+    val msg = s"${if (mutable) "`var'" else "`val'"} parameters may not be call-by-name"
+    val kind = "Syntax"
+    val explanation =
+      hl"""Parameters of classes and traits may no be call-by-name. In case you
+          |want the parameter to be evaluated on demand, consider using a function
+          |and a lazy value in the class such as
+          |  ${s"class MyClass(${name}Tick: () => String) {"}
+          |  ${s"  lazy val $name = ${name}Tick"}
+          |  ${"}"}
+          |"""
+  }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -473,4 +473,15 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals("trait WithParams", symbol.show)
       }
 
+  @Test def varValParametersMayNotBeCallByName =
+    checkMessagesAfter("frontend") {
+      "trait Trait(val noNoNo: => String)"
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        assertMessageCount(1, messages)
+        val VarValParametersMayNotBeCallByName(name, false) :: Nil = messages
+        assertEquals("noNoNo", name.show)
+      }
+
 }


### PR DESCRIPTION
@felixmulder One more and I call it a day.