### PR TITLE
Fix 2396b: Non-static synthetic case-objects should be initialized early.

### DIFF
--- a/tests/run/i2396b.scala
+++ b/tests/run/i2396b.scala
@@ -1,0 +1,14 @@
+class Bees {
+  def f: PartialFunction[Bee, Unit] = {  case Bee(_) => ""  }
+
+  f(new Bee("buzz"))
+
+  case class Bee(value: String)
+  //object Bee // With this it works
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    new Bees
+  }
+}


### PR DESCRIPTION
Lazy val implements non-static objects.
But if object is not user-defined we don't make it `real` lazy,
we instead make it eager as no-one will notice. This actually
saves resources as otherwise you'll still need to initialize
lazy-val related stuff in constructor instead and later initialize
actual objects.

Those objests, being eager, should be initialized early,
so that constructors can't see un-initialized values.