### PR TITLE
Add timestamp to generated docs

### DIFF
--- a/doc-tool/resources/_layouts/main.html
+++ b/doc-tool/resources/_layouts/main.html
@@ -1,3 +1,4 @@
+<!-- This page was last generated on {{ page.date | date: "%b-%d-%Y" }} -->
 <!DOCTYPE html>
 <html lang="en">
     <head>

--- a/doc-tool/src/dotty/tools/dottydoc/staticsite/DefaultParams.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/staticsite/DefaultParams.scala
@@ -5,6 +5,8 @@ package staticsite
 import model.{ Entity, Package, NonEntity }
 
 import java.util.{ HashMap, List => JList, Map => JMap }
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import scala.collection.JavaConverters._
 
 case class DefaultParams(
@@ -58,7 +60,7 @@ case class DefaultParams(
   def withDate(d: String) = copy(page = PageInfo(page.url, d))
 }
 
-case class PageInfo(url: String, date: String = "") {
+case class PageInfo(url: String, date: String = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")).toString ) {
   val path: Array[String] = url.split('/').reverse.drop(1)
 }
 


### PR DESCRIPTION
Intended as a solution to #2115.
Contrary to what was proposed back in the issue, appending at the end of the file seemed to be an easier alternative than reading from the file and rewriting - I'm new here, so please correct me if I'm wrong.