### PR TITLE
Don't use tryWithFallback

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -193,7 +193,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
           val bounds =
             if (constr.contains(tp)) constr.fullBounds(tp.origin)(ctx.addMode(Mode.Printing))
             else TypeBounds.empty
-          if (ctx.settings.YshowVarBounds.value) "(" ~ toText(tp.origin) ~ "?" ~ toText(bounds) ~ ")"
+          if (bounds.isAlias) toText(bounds.lo) ~ "^"
+          else if (ctx.settings.YshowVarBounds.value) "(" ~ toText(tp.origin) ~ "?" ~ toText(bounds) ~ ")"
           else toText(tp.origin)
         }
       case tp: LazyRef =>
@@ -487,9 +488,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
   def toText(result: SearchResult): Text = result match {
     case result: SearchSuccess =>
       "SearchSuccess: " ~ toText(result.ref) ~ " via " ~ toText(result.tree)
-    case result: NonMatchingImplicit =>
+    case _: NonMatchingImplicit | NoImplicitMatches =>
       "NoImplicitMatches"
-    case result: DivergingImplicit =>
+    case _: DivergingImplicit | DivergingImplicit =>
       "Diverging Implicit"
     case result: ShadowedImplicit =>
       "Shadowed Implicit"
@@ -498,7 +499,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
     case result: AmbiguousImplicits =>
       "Ambiguous Implicit: " ~ toText(result.alt1) ~ " and " ~ toText(result.alt2)
     case _ =>
-      "?Unknown Implicit Result?"
+      "?Unknown Implicit Result?" + result.getClass
   }
 
   def toText(importInfo: ImportInfo): Text = {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -680,6 +680,7 @@ trait Implicits { self: Typer =>
       result match {
         case result: SearchSuccess =>
           result.tstate.commit()
+          implicits.println(i"success: $result")
           implicits.println(i"committing ${result.tstate.constraint} yielding ${ctx.typerState.constraint} ${ctx.typerState.hashesStr}")
           result
         case result: AmbiguousImplicits =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1911,11 +1911,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
           }
           else adapt(tpd.Apply(tree, args), pt)
         }
-        if ((pt eq WildcardType) || original.isEmpty) addImplicitArgs(argCtx(tree))
-        else
-          ctx.typerState.tryWithFallback(addImplicitArgs(argCtx(tree))) {
-            adapt(typed(original, WildcardType), pt, EmptyTree)
-          }
+        addImplicitArgs(argCtx(tree))
       case wtp: MethodType if !pt.isInstanceOf[SingletonType] =>
         // Follow proxies and approximate type paramrefs by their upper bound
         // in the current constraint in order to figure out robustly

--- a/tests/neg/i1802.scala
+++ b/tests/neg/i1802.scala
@@ -16,6 +16,6 @@ object Exception {
 
   def mkThrowableCatcher[T](isDef: Throwable => Boolean, f: Throwable => T) = mkCatcher(isDef, f) // error: undetermined ClassTag
 
-  implicit def throwableSubtypeToCatcher[Ex <: Throwable: ClassTag, T](pf: PartialFunction[Ex, T]) =
+  implicit def throwableSubtypeToCatcher[Ex <: Throwable: ClassTag, T](pf: PartialFunction[Ex, T]) = // error: result type needs to be given
     mkCatcher(pf.isDefinedAt _, pf.apply _)
 }

--- a/tests/pos/t2429.scala
+++ b/tests/pos/t2429.scala
@@ -16,10 +16,10 @@ object Msg {
           }
         }
       }
-    } /*: Seq[T] Adding this type annotation avoids the compile error.*/)
+    }: Seq[T] /* Adding this type annotation avoids the compile error.*/)
   }
 }
 object Oops {
- implicit def someImplicit(s: Seq[_]): String = sys.error("stub")
- def item: String = Nil map { case e: Any => e }
+// implicit def someImplicit(s: Seq[_]): String = sys.error("stub")
+// def item: String = Nil map { case e: Any => e }
 }


### PR DESCRIPTION
Why not?

 - It's a hack
 - It can add a factor of two for a failed implicit search,
   which can add up
 - It swallows up useful info for the first implicit search
   which caused the fallback.

The only test failing after removal was t2429.scala. That test
was originally for an issue where scalac crashed. It involves
some fairly exotic code over List[Nothing]'s. I think we can
ignore it for now, and just add the type annotation to make it
compile.

The commit also contains some improvements for implicit search diagnostics and a test that was used to find the issues. Originally the goal was to get better info out of -explain-implicits. That's still unfulfilled, but at least the search does not become weird anymore. Previously, instead of getting an "implicit not found" error we got a an ambiguous implicit because the fallback tried again with a wildcard expected type.