### PR TITLE
Fix #2437: Drop erroneous case in Pickler

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -81,10 +81,13 @@ object Mode {
   /** Read original positions when unpickling from TASTY */
   val ReadPositions = newMode(16, "ReadPositions")
 
+  /** Don't suppress exceptions thrown during show */
+  val PrintShowExceptions = newMode(17, "PrintShowExceptions")
+
   val PatternOrType = Pattern | Type
 
   /** We are elaborating the fully qualified name of a package clause.
    *  In this case, identifiers should never be imported.
    */
-  val InPackageClauseName = newMode(17, "InPackageClauseName")
+  val InPackageClauseName = newMode(18, "InPackageClauseName")
 }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -431,7 +431,8 @@ object TastyFormat {
        | ANNOTATEDtpt
        | ANDtpt
        | ORtpt
-       | BYNAMEtpt => true
+       | BYNAMEtpt
+       | BIND => true
     case _ => false
   }
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -249,6 +249,7 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
             case BIND =>
               val sym = ctx.newSymbol(ctx.owner, readName().toTypeName, BindDefinedType, readType())
               registerSym(start, sym)
+              if (currentAddr != end) readType()
               TypeRef.withFixedSym(NoPrefix, sym.name, sym)
             case POLYtype =>
               readMethodic(PolyType, _.toTypeName)

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -31,7 +31,8 @@ object Formatting {
       case arg: Showable =>
         try arg.show
         catch {
-          case NonFatal(ex) => s"[cannot display due to $ex, raw string = $toString]"
+          case NonFatal(ex) if !ctx.mode.is(Mode.PrintShowExceptions) =>
+            s"[cannot display due to $ex, raw string = $toString]"
         }
       case _ => arg.toString
     }

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -79,7 +79,8 @@ class Pickler extends Phase {
           ctx.fresh
             .setPeriod(Period(ctx.runId + 1, FirstPhaseId))
             .setReporter(new ThrowingReporter(ctx.reporter))
-            .addMode(Mode.ReadPositions))
+            .addMode(Mode.ReadPositions)
+            .addMode(Mode.PrintShowExceptions))
     result
   }
 

--- a/tests/pickling/i2437a.scala
+++ b/tests/pickling/i2437a.scala
@@ -1,0 +1,5 @@
+object Test {
+  def foo(arg: Any) = arg match {
+    case bla: List[t] =>
+  }
+}

--- a/tests/pickling/i2437b.scala
+++ b/tests/pickling/i2437b.scala
@@ -1,0 +1,6 @@
+class Foo[T]
+object Test {
+  def foo[T](arg: Foo[T]) = arg match {
+    case bla: Foo[_] =>
+  }
+}


### PR DESCRIPTION
The case was a left-over from when we did not pickle
types as trees. There was a special case to record the symbol
of a bound type variable. This is no longer needed as we now
pickle the full tree that defines the symbol.