### PR TITLE
Unwrap `NamedType` in type mismatch error message

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -293,7 +293,12 @@ object messages {
         )
       }
 
-      ex"$selected `$name` is not a member of $site$closeMember"
+      val siteType = site match {
+        case tp: NamedType => tp.info
+        case tp => tp
+      }
+
+      ex"$selected `$name` is not a member of $siteType$closeMember"
     }
 
     val explanation = ""

--- a/tests/repl/errmsgs.check
+++ b/tests/repl/errmsgs.check
@@ -77,7 +77,7 @@ scala> class Foo() { def bar: Int = 1 }; val foo = new Foo(); foo.barr
 -- [E008] Member Not Found Error: <console>:4:59 -------------------------------
 4 |class Foo() { def bar: Int = 1 }; val foo = new Foo(); foo.barr
   |                                                       ^^^^^^^^
-  |        value `barr` is not a member of Foo(foo) - did you mean `foo.bar`?
+  |             value `barr` is not a member of Foo - did you mean `foo.bar`?
 scala> val x: List[Int] = "foo" :: List(1)
 -- [E007] Type Mismatch Error: <console>:4:19 ----------------------------------
 4 |val x: List[Int] = "foo" :: List(1)

--- a/tests/repl/imports.check
+++ b/tests/repl/imports.check
@@ -24,5 +24,5 @@ scala> import util.foo.bar
 -- [E008] Member Not Found Error: <console>:8:12 -------------------------------
 8 |import util.foo.bar
   |       ^^^^^^^^
-  |      value `foo` is not a member of util.type - did you mean `util.Left`?
+  |       value `foo` is not a member of util - did you mean `util.Left`?
 scala> :quit


### PR DESCRIPTION
Makes the error message print the actual type in most cases instead of scary internal
representation. E.g:

`Foo(Test.f)` => `Foo`