### PR TITLE
Fix #2512: Implicit keyword not allowed on return types

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -116,9 +116,9 @@ object Parsers {
     /** Issue an error at given offset if beyond last error offset
       *  and update lastErrorOffset.
       */
-    def syntaxError(msg: => Message, offset: Int = in.offset, name: Name = in.name): Unit =
+    def syntaxError(msg: => Message, offset: Int = in.offset): Unit =
       if (offset > lastErrorOffset) {
-        val length = if (name != null) name.show.length else 0
+        val length = if (in.name != null) in.name.show.length else 0
         syntaxError(msg, Position(offset, offset + length))
         lastErrorOffset = in.offset
       }
@@ -777,7 +777,7 @@ object Parsers {
         else infixType()
 
       if (isImplicit && !isImplicitFun && in.token != ARROW)
-        syntaxError("Types with implicit keyword can only be function types", start, nme.IMPLICITkw)
+        syntaxError("Types with implicit keyword can only be function types", Position(start, start + nme.IMPLICITkw.asSimpleName.length))
 
       in.token match {
         case ARROW => functionRest(t :: Nil)

--- a/tests/neg/i2512.scala
+++ b/tests/neg/i2512.scala
@@ -1,0 +1,10 @@
+
+object Test {
+
+  def foo0(): implicit Int => Int = ???
+  val foo01: implicit (String, Int) => Int = ???
+
+  def foo1(f: Int => implicit Int): Int = ??? // error
+  def foo2(): implicit Int = ??? // error
+  def foo3(): Int => implicit Int = ??? // error
+}


### PR DESCRIPTION
Update Parser to accommodate the new checks

Thanks @nicolasstucki for pair programming!