### PR TITLE
Fixes to CLI and version reporting.

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -115,6 +115,9 @@ object CompilerCommand extends DotClass {
     else if (settings.version.value) {
       ctx.echo(versionMsg)
       Nil
+    } else if (!Properties.isJavaAtLeast("1.8")) {
+      ctx.error("Dotty requires Java 8 or newer to run")
+      Nil
     }
     else if (shouldStopWithInfo) {
       ctx.echo(infoMessage)

--- a/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -116,7 +116,7 @@ object CompilerCommand extends DotClass {
       ctx.echo(versionMsg)
       Nil
     } else if (!Properties.isJavaAtLeast("1.8")) {
-      ctx.error("Dotty requires Java 8 or newer to run")
+      ctx.error("Dotty requires Java 8 to run")
       Nil
     }
     else if (shouldStopWithInfo) {

--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -7,7 +7,7 @@ import java.util.jar.Attributes.{ Name => AttributeName }
 
 /** Loads `library.properties` from the jar. */
 object Properties extends PropertiesTrait {
-  protected def propCategory    = "library"
+  protected def propCategory    = "compiler"
   protected def pickJarBasedOn  = classOf[Option[_]]
 
   /** Scala manifest attributes.

--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -128,9 +128,10 @@ trait PropertiesTrait {
    */
   def isJavaAtLeast(version: String) = {
     val okVersions = version match {
-      case "1.5"    => List("1.5", "1.6", "1.7")
-      case "1.6"    => List("1.6", "1.7")
-      case "1.7"    => List("1.7")
+      case "1.5"    => List("1.5", "1.6", "1.7", "1.8")
+      case "1.6"    => List("1.6", "1.7", "1.8")
+      case "1.7"    => List("1.7", "1.8")
+      case "1.8"    => List("1.8")
       case _        => Nil
     }
     okVersions exists (javaVersion startsWith _)

--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -135,10 +135,4 @@ trait PropertiesTrait {
     }
     okVersions exists (javaVersion startsWith _)
   }
-
-  // provide a main method so version info can be obtained by running this
-  def main(args: Array[String]): Unit = {
-    val writer = new PrintWriter(Console.err, true)
-    writer println versionMsg
-  }
 }

--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -119,8 +119,8 @@ trait PropertiesTrait {
   def jdkHome              = envOrElse("JDK_HOME", envOrElse("JAVA_HOME", javaHome))
 
   def versionMsg            = "Scala %s %s -- %s".format(propCategory, versionString, copyrightString)
-  def scalaCmd              = if (isWin) "scala.bat" else "scala"
-  def scalacCmd             = if (isWin) "scalac.bat" else "scalac"
+  def scalaCmd              = if (isWin) "dotr.bat" else "dotr"
+  def scalacCmd             = if (isWin) "dotc.bat" else "dotc"
 
   /** Can the java version be determined to be at least as high as the argument?
    *  Hard to properly future proof this but at the rate 1.7 is going we can leave

--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -56,36 +56,7 @@ trait PropertiesTrait {
   def scalaPropOrElse(name: String, alt: String): String = scalaProps.getProperty(name, alt)
   def scalaPropOrEmpty(name: String): String             = scalaPropOrElse(name, "")
   def scalaPropOrNone(name: String): Option[String]      = Option(scalaProps.getProperty(name))
-
-  /** The numeric portion of the runtime Scala version, if this is a final
-   *  release.  If for instance the versionString says "version 2.9.0.final",
-   *  this would return Some("2.9.0").
-   *
-   *  @return Some(version) if this is a final release build, None if
-   *  it is an RC, Beta, etc. or was built from source, or if the version
-   *  cannot be read.
-   */
-  val releaseVersion =
-    for {
-      v <- scalaPropOrNone("maven.version.number")
-      if !(v endsWith "-SNAPSHOT")
-    } yield v
-
-  /** The development Scala version, if this is not a final release.
-   *  The precise contents are not guaranteed, but it aims to provide a
-   *  unique repository identifier (currently the svn revision) in the
-   *  fourth dotted segment if the running version was built from source.
-   *
-   *  @return Some(version) if this is a non-final version, None if this
-   *  is a final release or the version cannot be read.
-   */
-  val developmentVersion =
-    for {
-      v <- scalaPropOrNone("maven.version.number")
-      if v endsWith "-SNAPSHOT"
-      ov <- scalaPropOrNone("version.number")
-    } yield ov
-
+  
   /** Either the development or release version if known, otherwise
    *  the empty string.
    */
@@ -94,8 +65,16 @@ trait PropertiesTrait {
   /** The version number of the jar this was loaded from plus "version " prefix,
    *  or "version (unknown)" if it cannot be determined.
    */
-  val versionString         = "version " + "0.01" //scalaPropOrElse("version.number", "(unknown)")" +
-  val copyrightString       = "(c) 2013 LAMP/EPFL" // scalaPropOrElse("copyright.string", "(c) 2002-2011 LAMP/EPFL")
+  val versionString = {
+    val v = scalaPropOrElse("version.number", "(unknown)")
+    "version " + scalaPropOrElse("version.number", "(unknown)") + {
+      if (v.contains("SNAPSHOT") || v.contains("NIGHTLY")) {
+        "-git-" + scalaPropOrElse("git.hash", "(unknown)")
+      } else ""
+    }
+  }
+  
+  val copyrightString       = scalaPropOrElse("copyright.string", "(c) 2002-2017 LAMP/EPFL")
 
   /** This is the encoding to use reading in source files, overridden with -encoding
    *  Note that it uses "prop" i.e. looks in the scala jar, not the system properties.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,9 +1,11 @@
 import sbt.Keys._
 import sbt._
 import complete.DefaultParsers._
-import java.io.{ RandomAccessFile, File }
+import java.io.{File, RandomAccessFile}
 import java.nio.channels.FileLock
 import java.nio.file.Files
+import java.util.Calendar
+
 import scala.reflect.io.Path
 import sbtassembly.AssemblyKeys.assembly
 
@@ -405,8 +407,18 @@ object Build {
 
       // Generate compiler.properties, used by sbt
       resourceGenerators in Compile += Def.task {
+        import java.util._
+        import java.text._
         val file = (resourceManaged in Compile).value / "compiler.properties"
-        val contents = s"version.number=${version.value}"
+        val dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmss")
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"))
+        val contents =                //2.11.11.v20170413-090219-8a413ba7cc
+          s"""version.number=${version.value}
+             |maven.version.number=${version.value}
+             |git.hash=${VersionUtil.gitHash}
+             |osgi.version.number=${version.value}-v${dateFormat.format(Calendar.getInstance().getTime)v}
+             |copyright.string=Copyright 2002-${Calendar.getInstance().get(Calendar.YEAR)}, LAMP/EPFL
+           """.stripMargin
 
         if (!(file.exists && IO.read(file) == contents)) {
           IO.write(file, contents)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -416,7 +416,7 @@ object Build {
           s"""version.number=${version.value}
              |maven.version.number=${version.value}
              |git.hash=${VersionUtil.gitHash}
-             |osgi.version.number=${version.value}-v${dateFormat.format(Calendar.getInstance().getTime)v}
+             |osgi.version.number=${version.value}-v${dateFormat.format(Calendar.getInstance().getTime)}
              |copyright.string=Copyright 2002-${Calendar.getInstance().get(Calendar.YEAR)}, LAMP/EPFL
            """.stripMargin
 


### PR DESCRIPTION
We used to report a hardcoded 0.0.1 version in one place and 2.11 in other places.
Now, we report consistently the version that was used in sbt.

Additionaly, if version countains SNAPSHOT or NIGHTLY it will also report git sha.