### PR TITLE
Add time travelling copies

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -605,7 +605,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
     override def Closure(tree: Tree)(env: List[Tree], meth: Tree, tpt: Tree)(implicit ctx: Context): Closure =
       ta.assignType(untpd.cpy.Closure(tree)(env, meth, tpt), meth, tpt)
-      // Same remark as for Apply
+
+    override def Closure(tree: Closure)(env: List[Tree] = tree.env, meth: Tree = tree.meth, tpt: Tree = tree.tpt)(implicit ctx: Context): Closure =
+      Closure(tree: Tree)(env, meth, tpt)
   }
 
   override def skipTransform(tree: Tree)(implicit ctx: Context) = tree.tpe.isError

--- a/compiler/src/dotty/tools/dotc/transform/MacroTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroTransform.scala
@@ -30,7 +30,7 @@ abstract class MacroTransform extends Phase {
    */
   protected def transformPhase(implicit ctx: Context): Phase = this
 
-  class Transformer extends TreeMap {
+  class Transformer extends TreeMap(cpy = cpyBetweenPhases) {
 
     protected def localCtx(tree: Tree)(implicit ctx: Context) = {
       val sym = tree.symbol

--- a/compiler/src/dotty/tools/dotc/transform/TreeTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeTransform.scala
@@ -62,6 +62,8 @@ object TreeTransforms {
 
     def treeTransformPhase: Phase = phase.next
 
+    val cpy = cpyBetweenPhases
+
     def prepareForIdent(tree: Ident)(implicit ctx: Context) = this
     def prepareForSelect(tree: Select)(implicit ctx: Context) = this
     def prepareForThis(tree: This)(implicit ctx: Context) = this

--- a/tests/pickling/A.scala
+++ b/tests/pickling/A.scala
@@ -1,0 +1,6 @@
+import dotty.tools.dotc.core.Decorators._
+import dotty.tools.dotc.core.NameOps._
+
+object Test {
+  "JFunction".toTermName.specializedFor(Nil, ???, Nil, Nil)(???)
+}

--- a/tests/pickling/B.scala
+++ b/tests/pickling/B.scala
@@ -1,0 +1,6 @@
+import dotty.tools.dotc.core.Contexts.Context
+
+object Formatting {
+  def rainbows(implicit ctx: Context): String =
+    ctx.settings.color.value.toString
+}


### PR DESCRIPTION
Make Apply and TypeApply copy only if function or argument types have changed.