### PR TITLE
Fix reading of jar resource files for dottydoc

### DIFF
--- a/doc-tool/src/dotty/tools/dottydoc/staticsite/ResourceFinder.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/staticsite/ResourceFinder.scala
@@ -9,8 +9,8 @@ trait ResourceFinder {
   final case class ResourceNotFoundException(message: String) extends Exception(message)
 
   protected def getResource(r: String): String =
-    Option(getClass.getResourceAsStream(r)).map(scala.io.Source.fromInputStream)
+    Option(getClass.getResourceAsStream(r))
+      .map(scala.io.Source.fromInputStream(_)(scala.io.Codec.UTF8))
       .map(_.mkString)
       .getOrElse(throw ResourceNotFoundException(r))
-
 }


### PR DESCRIPTION
This was the bug that didn't work with the released version. Since the codec was not specified, it assumed ISO-8859-1 :(

Now it is correctly UTF8 (master race)