### PR TITLE
Fix 2551: shortcut staticRef for packages to avoid cycles

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1186,11 +1186,11 @@ object Denotations {
      *  or a MissingRef or NoQualifyingRef instance, if it does not exist.
      *  if generateStubs is set, generates stubs for missing top-level symbols
      */
-    def staticRef(path: Name, generateStubs: Boolean = true)(implicit ctx: Context): Denotation = {
+    def staticRef(path: Name, generateStubs: Boolean = true, isPackage: Boolean = false)(implicit ctx: Context): Denotation = {
       def select(prefix: Denotation, selector: Name): Denotation = {
         val owner = prefix.disambiguate(_.info.isParameterless)
         if (owner.exists) {
-          val result = owner.info.member(selector)
+          val result = if (isPackage) owner.info.decl(selector) else owner.info.member(selector)
           if (result.exists) result
           else {
             val alt =

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -357,7 +357,7 @@ trait Symbols { this: Context =>
 // ----- Locating predefined symbols ----------------------------------------
 
   def requiredPackage(path: PreName): TermSymbol =
-    base.staticRef(path.toTermName).requiredSymbol(_ is Package).asTerm
+    base.staticRef(path.toTermName, isPackage = true).requiredSymbol(_ is Package).asTerm
 
   def requiredPackageRef(path: PreName): TermRef = requiredPackage(path).termRef
 

--- a/tests/pos/i2551/library_1.scala
+++ b/tests/pos/i2551/library_1.scala
@@ -1,0 +1,14 @@
+package scala {
+  package meta {
+    package config {
+      case class Version()
+
+      trait Aliases {
+        type Version = scala.meta.config.Version
+        val Version = scala.meta.config.Version
+      }
+    }
+  }
+
+  package object meta extends scala.meta.config.Aliases
+}

--- a/tests/pos/i2551/test_2.scala
+++ b/tests/pos/i2551/test_2.scala
@@ -1,0 +1,5 @@
+import scala.meta._
+
+object Test {
+  val v = Version()
+}


### PR DESCRIPTION
Attempt to fix #2551: shortcut staticRef for packages to avoid cycles