### PR TITLE
Fix #2390: Use normal thisType as base for override checking

### DIFF
--- a/tests/pos/i2390.scala
+++ b/tests/pos/i2390.scala
@@ -1,0 +1,11 @@
+trait TestSuite {
+  trait NoArgTest
+}
+
+trait TestSuiteMixin { self: TestSuite =>
+  def foo(test: self.NoArgTest) = {}
+}
+
+trait CancelAfterFailure extends TestSuiteMixin { self: TestSuite =>
+  override def foo(test: self.NoArgTest) = {}
+}


### PR DESCRIPTION
Using upwardsThisType can cause MissingType errors. It's a hairy
problem which is still not quite understood (see comment on
upwardsThisType). We currently address this by trying either
normal thisType or upwardsThisType.