### PR TITLE
Fix warm bootstrapped compilation speed

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -430,7 +430,6 @@ object Build {
           s"""version.number=${version.value}
              |maven.version.number=${version.value}
              |git.hash=${VersionUtil.gitHash}
-             |osgi.version.number=${version.value}-v${dateFormat.format(Calendar.getInstance().getTime)}
              |copyright.string=Copyright 2002-${Calendar.getInstance().get(Calendar.YEAR)}, LAMP/EPFL
            """.stripMargin
 


### PR DESCRIPTION
14cdb8e2975bc8e2912e9811801333d6c1de99fb added a bunch of values to
compiler.properties, one of those is `osgi.version.number` which
contains a represention of the date including hours/minutes/seconds. This means that
this file needs to be constantly regenerated, which causes the
dotty-compiler jar to be recreated everytime we try to use it. This is
very bad because sbt will not cache classloaders when the files on the
corresponding classpath are modified. The result is that everytime we
call `dotty-compiler-bootstrapped/compile` a new classloader is created and
we do not benefit from reusing already jitted code. This commit fixes
this by simply removing the osgi.version.number property: it's not used
in dotty and even in Scala 2.12 it's no longer used, so this should be fine.

To reproduce the issue:
$ sbt
> dotty-compiler-bootstrapped/compile # takes about 50s on my machine
> ;dotty-compiler-bootstrapped/clean;dotty-compiler-bootstrapped/update
> dotty-compiler-bootstrapped/compile # takes about 25s on my machine after this patch

Before this commit, the second compile took about as long as the first.