### PR TITLE
Add include for rendering sidebar in docs

### DIFF
--- a/doc-tool/resources/_includes/sidebar.html
+++ b/doc-tool/resources/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <div class="index-wrapper" style="top: {{ sidebarTop }};">
     <ul class="toc">
         {% assign parent = page.path | first %}
-        {% for title in sidebar %}
+        {% for title in sidebar.titles %}
         <li>{% renderTitle title, parent %}</li>
         {% endfor %}
     </ul>

--- a/doc-tool/src/dotty/tools/dottydoc/staticsite/tags.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/staticsite/tags.scala
@@ -184,8 +184,10 @@ object tags {
 
     override def render(ctx: TemplateContext, nodes: LNode*): AnyRef =
       (nodes(0).render(ctx), nodes(1).render(ctx)) match {
-        case (t: Title, parent: String) => renderTitle(t, parent)
-        case (t: Title, _) => renderTitle(t, "./") // file is in top dir
+        case (map: JMap[String, AnyRef] @unchecked, parent: String) =>
+          Title(map).map(renderTitle(_, parent)).getOrElse(null)
+        case (map: JMap[String, AnyRef] @unchecked, _) =>
+          Title(map).map(renderTitle(_, "./")).getOrElse(null) // file is in top dir
         case _ => null
       }
   }

--- a/docs/_includes/table-of-contents.html
+++ b/docs/_includes/table-of-contents.html
@@ -1,0 +1,15 @@
+<ul>
+{% for item in titles %}
+<li>
+{% if item.url %}
+<a href="{{ site.baseurl }}/{{ item.url }}">{{ item.title }}</a>
+{% else %}
+{{ item.title }}
+{% endif %}
+{% if item.subsection %}
+{% assign titles = item.subsection %}
+{% include "table-of-contents" %}
+{% endif %}
+</li>
+{% endfor %}
+</ul>

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,10 +3,15 @@ layout: doc-page
 title: "Dotty Documentation"
 ---
 
-Dotty is a platform to try out new language concepts and compiler technologies for Scala. 
-The focus is mainly on simplification. We remove extraneous syntax (e.g. no XML literals), 
-and try to boil down Scala’s types into a smaller set of more fundamental constructors. 
+Dotty is a platform to try out new language concepts and compiler technologies for Scala.
+The focus is mainly on simplification. We remove extraneous syntax (e.g. no XML literals),
+and try to boil down Scala’s types into a smaller set of more fundamental constructors.
 The theory behind these constructors is researched in DOT, a calculus for dependent object types.
 
 In this documentation you will find information on how to use the Dotty compiler on your machine, navigate through
 the code, setup Dotty with your favorite IDE and more!
+
+Table of Contents
+=================
+{% assign titles = sidebar.titles %}
+{% include "table-of-contents" %}

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -1,6 +1,18 @@
 sidebar:
     - title: Blog
       url: blog/index.html
+    - title: Usage
+      subsection:
+        - title: sbt-projects
+          url: docs/usage/sbt-projects.html
+        - title: IDE support for Dotty
+          url: docs/usage/ide-support.html
+        - title: cbt-projects
+          url: docs/usage/cbt-projects.html
+        - title: Dottydoc
+          url: docs/usage/dottydoc.html
+        - title: Migrating
+          url: docs/usage/migrating.html
     - title: Reference
       subsection:
         - title: New Types
@@ -71,18 +83,6 @@ sidebar:
               url: docs/reference/dropped/limit22.html
             - title: XML literals
               url: docs/reference/dropped/xml.html
-    - title: Usage
-      subsection:
-        - title: sbt-projects
-          url: docs/usage/sbt-projects.html
-        - title: IDE support for Dotty
-          url: docs/usage/ide-support.html
-        - title: cbt-projects
-          url: docs/usage/cbt-projects.html
-        - title: Dottydoc
-          url: docs/usage/dottydoc.html
-        - title: Migrating
-          url: docs/usage/migrating.html
     - title: Contributing
       subsection:
         - title: Getting Started


### PR DESCRIPTION
This fix mirrors the sidebar in `docs/index.md` by include. Maybe we should consider renaming `sidebar.yml => toc.yml` or something similar. But later PR.

I was rebooked to 15:30 :(

So still hacking, but boarding is starting...