### PR TITLE
Fix #2560: Regression in #2465: blog pages get wrong date

### DIFF
--- a/doc-tool/resources/_layouts/main.html
+++ b/doc-tool/resources/_layouts/main.html
@@ -1,4 +1,4 @@
-<!-- This page was last generated on {{ page.date | date: "%b-%d-%Y" }} -->
+<!-- This page was last generated on {{ page.date | date: "%Y-%B-%d %H:%M" }} -->
 <!DOCTYPE html>
 <html lang="en">
     <head>

--- a/docs/blog/_posts/2015-10-23-dotty-compiler-bootstraps.md
+++ b/docs/blog/_posts/2015-10-23-dotty-compiler-bootstraps.md
@@ -4,7 +4,7 @@ author: Martin Odersky and Dmitry Petrashko
 title: "We got liftoff!"
 subTitle: The Dotty compiler for Scala bootstraps.
 excerpt_separator: <!--more-->
-date: 2015-10-23
+date: 2015-10-23 00:00:00
 ---
 
 The [Dotty project](https://github.com/lampepfl/dotty)

--- a/docs/blog/_posts/2016-01-02-new-year-resolutions.md
+++ b/docs/blog/_posts/2016-01-02-new-year-resolutions.md
@@ -3,7 +3,7 @@ layout: blog-page
 title: New Year Resolutions
 author: Martin Odersky
 authorImg: /images/martin.jpg
-date: 2016-01-02
+date: 2016-01-02 00:00:00
 ---
 
 For most of us, the change of the year is an occasion for thinking
@@ -60,7 +60,3 @@ simpler: The language, its foundations, its libraries. I hope you
 will join me in that venture.
 
 With that thought, I wish you a happy new year 2016.
-
-
-
-

--- a/docs/blog/_posts/2016-02-03-essence-of-scala.md
+++ b/docs/blog/_posts/2016-02-03-essence-of-scala.md
@@ -3,7 +3,7 @@ layout: blog-page
 title: The Essence of Scala
 author: Martin Odersky
 authorImg: /images/martin.jpg
-date: 2016-02-03
+date: 2016-02-03 00:00:00
 ---
 
 What do you get if you boil Scala on a slow flame and wait until all
@@ -143,4 +143,3 @@ project are important.
     either to increase our confidence that they are indeed sound, or
     to show that they are unsound. In my next blog I will
     present some of the issues we have discovered through that exercise.
-

--- a/docs/blog/_posts/2016-02-17-scaling-dot-soundness.md
+++ b/docs/blog/_posts/2016-02-17-scaling-dot-soundness.md
@@ -3,7 +3,7 @@ layout: blog-page
 title: Scaling DOT to Scala - Soundness
 author: Martin Odersky
 authorImg: /images/martin.jpg
-date: 2016-02-17
+date: 2016-02-17 00:00:00
 ---
 
 In my [last
@@ -150,10 +150,3 @@ should make sure not to back-slide. And if the experience of the past
 10 years has taught us one thing, it is that the meta theory of type
 systems has many more surprises in store than one might think. That's
 why mechanical proofs are essential.
-
-
-
-
-
-
-

--- a/docs/blog/_posts/2016-05-05-multiversal-equality.md
+++ b/docs/blog/_posts/2016-05-05-multiversal-equality.md
@@ -3,7 +3,7 @@ layout: blog-page
 title: Multiversal Equality for Scala
 author: Martin Odersky
 authorImg: /images/martin.jpg
-date: 2016-05-05
+date: 2016-05-05 00:00:00
 ---
 
 I have been working recently on making equality tests using `==` and `!=` safer in Scala. This has led to a [Language Enhancement Proposal](https://github.com/lampepfl/dotty/issues/1247) which I summarize in this blog.

--- a/docs/blog/_posts/2016-12-05-implicit-function-types.md
+++ b/docs/blog/_posts/2016-12-05-implicit-function-types.md
@@ -3,7 +3,7 @@ layout: blog-page
 title: Implicit Function Types
 author: Martin Odersky
 authorImg: /images/martin.jpg
-date: 2016-12-05
+date: 2016-12-05 00:00:00
 ---
 
 I just made the [first pull request](https://github.com/lampepfl/dotty/pull/1775) to add _implicit function types_ to

--- a/docs/blog/_posts/2017-05-31-first-dotty-milestone-release.md
+++ b/docs/blog/_posts/2017-05-31-first-dotty-milestone-release.md
@@ -3,7 +3,7 @@ layout: blog-page
 title: Announcing Dotty 0.1.2-RC1, a major step towards Scala 3
 author: Dmytro Petrashko
 authorImg: /images/petrashko.jpg
-date: 2017-05-31
+date: 2017-05-31 00:00:00
 ---
 
 Today, we are excited to release Dotty version 0.1.2-RC1.  This release


### PR DESCRIPTION
Intended as a fix for #2560. CC: @felixmulder @nicolasstucki 
P.S - removed some empty lines at the end of the file