### PR TITLE
Fix incredibly minor typo in union types doc.

### DIFF
--- a/docs/docs/reference/union-types.md
+++ b/docs/docs/reference/union-types.md
@@ -42,7 +42,7 @@ scala> val either: Password | UserName = if (true) name else password
 val either: Password | UserName = UserName(Eve)
 ```
 
-The type of `res2` is `Object | Product`, which is a supertype of
+The type of `res2` is `Object & Product`, which is a supertype of
 `UserName` and `Product`, but not the least supertype `Password |
 UserName`.  If we want the least supertype, we have to give it
 explicitely, as is done for the type of `Either`. More precisely, the


### PR DESCRIPTION
`if (true) name else password` is an `Object & Product`, not an `Object | Product`.