### PR TITLE
Fix #2636: assert in Run.scala is inefficient

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -40,8 +40,8 @@ class Compiler {
    *   - after erasure, asSeenFrom is the identity, so every reference has a
    *     plain SymDenotation, as opposed to a UniqueRefDenotation.
    */
-  def phases: List[List[Phase]] =
-    List(
+  def phases: List[List[Phase]] = {
+    val allPhases = List(
       List(new FrontEnd),           // Compiler frontend: scanner, parser, namer, typer
       List(new sbt.ExtractDependencies), // Sends information on classes' dependencies to sbt via callbacks
       List(new PostTyper),          // Additional checks and cleanups after type checking
@@ -109,6 +109,9 @@ class Compiler {
            new LabelDefs),          // Converts calls to labels to jumps
       List(new GenBCode)            // Generate JVM bytecode
     )
+    assert(allPhases.last.last.id <= Periods.MaxPossiblePhaseId)
+    allPhases
+  }
 
   var runId = 1
   def nextRunId = {

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -24,7 +24,6 @@ import scala.util.control.NonFatal
 /** A compiler run. Exports various methods to compile source files */
 class Run(comp: Compiler)(implicit ctx: Context) {
 
-  assert(comp.phases.last.last.id <= Periods.MaxPossiblePhaseId)
   assert(ctx.runId <= Periods.MaxPossibleRunId)
 
   var units: List[CompilationUnit] = _


### PR DESCRIPTION
Move the assert after the declaration of the phases.

Tested:
Compiled one program and nothing blew up.