### PR TITLE
[WIP] Travis CI for dotc/dotr on OSX and Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+branches:
+  only:
+  - master
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.3
+      language: java
+      env: PACK=dist
+    - os: osx
+      osx_image: xcode8.3
+      language: java
+      env: PACK=dist-bootstrapped
+    - os: linux
+      language: scala
+      jdk: oraclejdk8
+      env: PACK=dist
+    - os: linux
+      language: scala
+      jdk: oraclejdk8
+      env: PACK=dist-bootstrapped
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sbt ; fi
+script:
+  - sbt $PACK/pack
+  - $PACK/target/pack/bin/dotc tests/pos/HelloWorld.scala
+  - $PACK/target/pack/bin/dotr HelloWorld


### PR DESCRIPTION
Fix #2646 : Travis CI for test script on OSX and Linux

- [ ] Windows: https://github.com/marketplace/appveyor
- [x] Mac: travis
- [x] Linux: travis

Note: 

- Travis currently doesn't support Scala on OSX directly (https://github.com/travis-ci/travis-ci/issues/2316), thus a little hack is used.
- Enable this test on each PR will slow workflow and waste CPU cycles, thus we only enable on master branch changes. 