### PR TITLE
homepage: Fix position of downward arrow to not overlap with text

### DIFF
--- a/docs/css/default.css
+++ b/docs/css/default.css
@@ -173,10 +173,6 @@ h1#dotty {
 div.centered-subtitle {
     text-align: center;
     font-family: 'Source Sans Pro', sans-serif;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
 }
 
 div.centered-subtitle > a {


### PR DESCRIPTION
Previously, the arrow overlapepd with the "Dotty Example Project" link in the Getting Started
section, making it difficult to click.