### PR TITLE
Don't clone entire scala/scala commit history for submodules

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1158,7 +1158,7 @@ object Build {
       sLog.value.log(Level.Error,
         s"""Missing some of the submodules
            |You can initialize the modules with:
-           |  > git submodule update --init
+           |  > git submodule update --init --depth 50
         """.stripMargin)
     }
     state


### PR DESCRIPTION
Makes cloning a new repo substantially faster