### PR TITLE
Move only `case class` or `case object` allowed to new error format

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2382,7 +2382,7 @@ object Parsers {
           stats +++= tmplDef(in.offset, defAnnotsMods(modifierTokens))
         else if (!isStatSep) {
           if (in.token == CASE)
-            syntaxErrorOrIncomplete("only `case class` or `case object` allowed")
+            syntaxErrorOrIncomplete(OnlyCaseClassOrCaseObjectAllowed())
           else
             syntaxErrorOrIncomplete("expected class or object definition")
           if (mustStartStat) // do parse all definitions even if they are probably local (i.e. a "}" has been forgotten)

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -86,6 +86,7 @@ public enum ErrorMessageID {
     ValueClassesMayNotWrapItselfID,
     ValueClassParameterMayNotBeAVarID,
     ValueClassNeedsExactlyOneValParamID,
+    OnlyCaseClassOrCaseObjectAllowedID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1566,4 +1566,11 @@ object messages {
     val explanation = ""
   }
 
+  case class OnlyCaseClassOrCaseObjectAllowed()(implicit ctx: Context)
+    extends Message(OnlyCaseClassOrCaseObjectAllowedID) {
+    val msg = "only `case class` or `case object` allowed"
+    val kind = "Syntax"
+    val explanation = ""
+  }
+
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -781,4 +781,15 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals("class MyValue", valueClass.show)
       }
 
+  @Test def onlyCaseClassOrCaseObjectAllowed =
+    checkMessagesAfter("frontend") {
+      """case Foobar"""
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        assertMessageCount(1, messages)
+        val err :: Nil = messages
+        assertEquals(err, OnlyCaseClassOrCaseObjectAllowed())
+      }
+
 }


### PR DESCRIPTION
As part of #1589 this moves the error message 'only `case class` or
`case object` allowed' to the new error scheme.