### PR TITLE
Support Scala 2.12 Mixins

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -94,7 +94,7 @@ class Compiler {
            new FunctionalInterfaces, // Rewrites closures to implement @specialized types of Functions.
            new GetClass,            // Rewrites getClass calls on primitive types.
            new Simplify),           // Perform local optimizations, simplified versions of what linker does.
-      List(new LinkScala2ImplClasses, // Forward calls to the implementation classes of traits defined by Scala 2.11
+      List(new LinkScala2Impls,     // Redirect calls to trait methods defined by Scala 2.x, so that they now go to their implementations
            new LambdaLift,          // Lifts out nested functions to class scope, storing free variables in environments
                                        // Note: in this mini-phase block scopes are incorrect. No phases that rely on scopes should be here
            new ElimStaticThis,      // Replace `this` references to static objects by global identifiers

--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -75,7 +75,7 @@ class Compiler {
            new InterceptedMethods,  // Special handling of `==`, `|=`, `getClass` methods
            new Getters,             // Replace non-private vals and vars with getter defs (fields are added later)
            new ElimByName,          // Expand by-name parameter references
-           new AugmentScala2Traits, // Expand traits defined in Scala 2.11 to simulate old-style rewritings
+           new AugmentScala2Traits, // Expand traits defined in Scala 2.x to simulate old-style rewritings
            new ResolveSuper,        // Implement super accessors and add forwarders to trait methods
            new Simplify,            // Perform local optimizations, simplified versions of what linker does.
            new PrimitiveForwarders, // Add forwarders to trait methods that have a mismatch between generic and primitives
@@ -87,7 +87,6 @@ class Compiler {
            new Mixin,               // Expand trait fields and trait initializers
            new LazyVals,            // Expand lazy vals
            new Memoize,             // Add private fields to getters and setters
-           new LinkScala2ImplClasses, // Forward calls to the implementation classes of traits defined by Scala 2.11
            new NonLocalReturns,     // Expand non-local returns
            new CapturedVars,        // Represent vars captured by closures as heap objects
            new Constructors,        // Collect initialization code in primary constructors
@@ -95,7 +94,8 @@ class Compiler {
            new FunctionalInterfaces, // Rewrites closures to implement @specialized types of Functions.
            new GetClass,            // Rewrites getClass calls on primitive types.
            new Simplify),           // Perform local optimizations, simplified versions of what linker does.
-      List(new LambdaLift,          // Lifts out nested functions to class scope, storing free variables in environments
+      List(new LinkScala2ImplClasses, // Forward calls to the implementation classes of traits defined by Scala 2.11
+           new LambdaLift,          // Lifts out nested functions to class scope, storing free variables in environments
                                        // Note: in this mini-phase block scopes are incorrect. No phases that rely on scopes should be here
            new ElimStaticThis,      // Replace `this` references to static objects by global identifiers
            new Flatten,             // Lift all inner classes to package scope

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -734,7 +734,7 @@ object Denotations {
         this
       case _ =>
         if (coveredInterval.containsPhaseId(ctx.phaseId)) {
-          if (ctx.debug) ctx.traceInvalid(this)
+          if (ctx.debug || true) ctx.traceInvalid(this)
           staleSymbolError
         }
         else NoDenotation

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -734,7 +734,7 @@ object Denotations {
         this
       case _ =>
         if (coveredInterval.containsPhaseId(ctx.phaseId)) {
-          if (ctx.debug || true) ctx.traceInvalid(this)
+          if (ctx.debug) ctx.traceInvalid(this)
           staleSymbolError
         }
         else NoDenotation

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -400,13 +400,13 @@ object Flags {
   final val Scala2ModuleVar = termFlag(57, "<modulevar>")
 
   /** A Scala 2.12 trait that has been augmented with static members */
-  final val Scala_2_12_Augmented = typeFlag(57, "<scala12augmented")
+  final val Scala_2_12_Augmented = typeFlag(57, "<scala_2_12_augmented>")
 
   /** A definition that's initialized before the super call (Scala 2.x only) */
   final val Scala2PreSuper = termFlag(58, "<presuper>")
 
   /** A Scala 2.12 or higher trait */
-  final val Scala_2_12_Trait = typeFlag(58, "<scala12trait>")
+  final val Scala_2_12_Trait = typeFlag(58, "<scala_2_12_trait>")
 
   /** A macro (Scala 2.x only) */
   final val Macro = commonFlag(59, "<macro>")

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -402,6 +402,9 @@ object Flags {
   /** A definition that's initialized before the super call (Scala 2.x only) */
   final val Scala2PreSuper = termFlag(58, "<presuper>")
 
+  /** A Scala 2.12 or higher trait */
+  final val Scala_2_12_Trait = typeFlag(58, "<scala12trait>")
+
   /** A macro (Scala 2.x only) */
   final val Macro = commonFlag(59, "<macro>")
 

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -399,6 +399,9 @@ object Flags {
   /** A module variable (Scala 2.x only) */
   final val Scala2ModuleVar = termFlag(57, "<modulevar>")
 
+  /** A Scala 2.12 trait that has been augmented with static members */
+  final val Scala_2_12_Augmented = typeFlag(57, "<scala12augmented")
+
   /** A definition that's initialized before the super call (Scala 2.x only) */
   final val Scala2PreSuper = termFlag(58, "<presuper>")
 

--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -70,26 +70,29 @@ object Mode {
   /** We are currently unpickling Scala2 info */
   val Scala2Unpickling = newMode(13, "Scala2Unpickling")
 
+  /** We are currently unpickling from Java 8 or higher */
+  val Java8Unpickling = newMode(14, "Java8Unpickling")
+
   /** Use Scala2 scheme for overloading and implicit resolution */
-  val OldOverloadingResolution = newMode(14, "OldOverloadingResolution")
+  val OldOverloadingResolution = newMode(15, "OldOverloadingResolution")
 
   /** Allow hk applications of type lambdas to wildcard arguments;
    *  used for checking that such applications do not normally arise
    */
-  val AllowLambdaWildcardApply = newMode(15, "AllowHKApplyToWildcards")
+  val AllowLambdaWildcardApply = newMode(16, "AllowHKApplyToWildcards")
 
   /** Read original positions when unpickling from TASTY */
-  val ReadPositions = newMode(16, "ReadPositions")
+  val ReadPositions = newMode(17, "ReadPositions")
 
   /** Don't suppress exceptions thrown during show */
-  val PrintShowExceptions = newMode(17, "PrintShowExceptions")
+  val PrintShowExceptions = newMode(18, "PrintShowExceptions")
 
   val PatternOrType = Pattern | Type
 
   /** We are elaborating the fully qualified name of a package clause.
    *  In this case, identifiers should never be imported.
    */
-  val InPackageClauseName = newMode(18, "InPackageClauseName")
+  val InPackageClauseName = newMode(19, "InPackageClauseName")
 
   /** We are in the IDE */
   val Interactive = newMode(20, "Interactive")

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -359,6 +359,7 @@ object NameKinds {
   val ExtMethName = new SuffixNameKind(EXTMETH, "$extension")
   val ModuleVarName = new SuffixNameKind(OBJECTVAR, "$module")
   val ModuleClassName = new SuffixNameKind(OBJECTCLASS, "$", optInfoString = "ModuleClass")
+  val ImplMethName = new SuffixNameKind(IMPLMETH, "$")
 
   /** A name together with a signature. Used in Tasty trees. */
   object SignedName extends NameKind(63) {

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -71,7 +71,7 @@ trait SymDenotations { this: Context =>
 
   /** Explain why symbol is invalid; used for debugging only */
   def traceInvalid(denot: Denotation): Boolean = {
-    def show(d: Denotation) = s"$d#${d.symbol.id}/${denot.symbol.initialDenot.name.debugString}"
+    def show(d: Denotation) = s"$d#${d.symbol.id}"
     def explain(msg: String) = {
       println(s"${show(denot)} is invalid at ${this.period} because $msg")
       false

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -71,7 +71,7 @@ trait SymDenotations { this: Context =>
 
   /** Explain why symbol is invalid; used for debugging only */
   def traceInvalid(denot: Denotation): Boolean = {
-    def show(d: Denotation) = s"$d#${d.symbol.id}"
+    def show(d: Denotation) = s"$d#${d.symbol.id}/${denot.symbol.initialDenot.name.debugString}"
     def explain(msg: String) = {
       println(s"${show(denot)} is invalid at ${this.period} because $msg")
       false

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
@@ -10,6 +10,8 @@ object ClassfileConstants {
   final val JAVA_MAJOR_VERSION = 45
   final val JAVA_MINOR_VERSION = 3
 
+  final val JAVA8_MAJOR_VERSION = 52
+
   /** (see http://java.sun.com/docs/books/jvms/second_edition/jvms-clarify.html)
    *
    *  If the `ACC_INTERFACE` flag is set, the `ACC_ABSTRACT` flag must also

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -256,7 +256,9 @@ object TastyFormat {
   final val OBJECTCLASS = 40
 
   final val SIGNED = 63
+  
   final val firstInternalTag = 64
+  final val IMPLMETH = 64
 
   // AST tags
 

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -466,7 +466,11 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     }
 
     def finishSym(sym: Symbol): Symbol = {
-      if (sym.isClass) sym.setFlag(Scala2x)
+      if (sym.isClass) {
+        sym.setFlag(Scala2x)
+        if (flags.is(Trait) && ctx.mode.is(Mode.Java8Unpickling))
+          sym.setFlag(Scala_2_12_Trait)
+      }
       if (!(isRefinementClass(sym) || isUnpickleRoot(sym) || (sym is Scala2Existential))) {
         val owner = sym.owner
         if (owner.isClass)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -362,7 +362,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected def keyString(sym: Symbol): String = {
     val flags = sym.flagsUNSAFE
     if (flags is JavaTrait) "interface"
-    else if ((flags is Trait) && !(flags is ImplClass)) "trait"
+    else if (flags is Trait) "trait"
     else if (sym.isClass) "class"
     else if (sym.isType) "type"
     else if (flags is Mutable) "var"

--- a/compiler/src/dotty/tools/dotc/transform/LinkScala2Impls.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LinkScala2Impls.scala
@@ -46,7 +46,7 @@ class LinkScala2Impls extends MiniPhase with IdentityDenotTransformer { thisTran
     // that's why it is runsAfterGroupOf
 
   class Transform extends TreeTransform {
-    def phase = LinkScala2Impls
+    def phase = thisTransform
 
     /** Copy definitions from implementation class to trait itself */
     private def augmentScala_2_12_Trait(mixin: ClassSymbol)(implicit ctx: Context): Unit = {
@@ -55,7 +55,7 @@ class LinkScala2Impls extends MiniPhase with IdentityDenotTransformer { thisTran
         name = if (sym.isConstructor) sym.name else ImplMethName(sym.name)
       )
       for (sym <- mixin.implClass.info.decls)
-        newImpl(sym.asTerm).enteredAfter(LinkScala2Impls)
+        newImpl(sym.asTerm).enteredAfter(thisTransform)
     }
 
     override def prepareForTemplate(impl: Template)(implicit ctx: Context) = {
@@ -82,10 +82,10 @@ class LinkScala2Impls extends MiniPhase with IdentityDenotTransformer { thisTran
     }
 
     private def implMethod(meth: Symbol)(implicit ctx: Context): Symbol = {
-      val (implInfo, implName) = 
-        if (meth.owner.is(Scala_2_12_Trait)) 
+      val (implInfo, implName) =
+        if (meth.owner.is(Scala_2_12_Trait))
           (meth.owner.info, ImplMethName(meth.name.asTermName))
-        else 
+        else
           (meth.owner.implClass.info, meth.name)
       if (meth.isConstructor)
         implInfo.decl(nme.TRAIT_CONSTRUCTOR).symbol

--- a/compiler/src/dotty/tools/dotc/transform/LinkScala2Impls.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LinkScala2Impls.scala
@@ -34,7 +34,7 @@ import collection.mutable
  *
  *  where f is a static member of M.
  */
-class LinkScala2ImplClasses extends MiniPhase with IdentityDenotTransformer { thisTransform =>
+class LinkScala2Impls extends MiniPhase with IdentityDenotTransformer { thisTransform =>
   import ast.tpd._
 
   override def phaseName: String = "linkScala2ImplClasses"
@@ -46,7 +46,7 @@ class LinkScala2ImplClasses extends MiniPhase with IdentityDenotTransformer { th
     // that's why it is runsAfterGroupOf
 
   class Transform extends TreeTransform {
-    def phase = thisTransform
+    def phase = LinkScala2Impls
 
     /** Copy definitions from implementation class to trait itself */
     private def augmentScala_2_12_Trait(mixin: ClassSymbol)(implicit ctx: Context): Unit = {
@@ -55,7 +55,7 @@ class LinkScala2ImplClasses extends MiniPhase with IdentityDenotTransformer { th
         name = if (sym.isConstructor) sym.name else ImplMethName(sym.name)
       )
       for (sym <- mixin.implClass.info.decls)
-        newImpl(sym.asTerm).enteredAfter(thisTransform)
+        newImpl(sym.asTerm).enteredAfter(LinkScala2Impls)
     }
 
     override def prepareForTemplate(impl: Template)(implicit ctx: Context) = {

--- a/compiler/src/dotty/tools/dotc/transform/LinkScala2Impls.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LinkScala2Impls.scala
@@ -37,7 +37,7 @@ import collection.mutable
 class LinkScala2Impls extends MiniPhase with IdentityDenotTransformer { thisTransform =>
   import ast.tpd._
 
-  override def phaseName: String = "linkScala2ImplClasses"
+  override def phaseName: String = "linkScala2Impls"
   override def changesMembers = true
   val treeTransform = new Transform
 

--- a/compiler/test/dotc/tests.scala
+++ b/compiler/test/dotc/tests.scala
@@ -342,7 +342,7 @@ class tests extends CompilerTest {
     "ElimStaticThis.scala", "Erasure.scala", "ExpandPrivate.scala", "ExpandSAMs.scala",
     "ExplicitOuter.scala", "ExtensionMethods.scala", "FirstTransform.scala",
     "Flatten.scala", "FullParameterization.scala", "FunctionalInterfaces.scala", "GetClass.scala",
-    "Getters.scala", "InterceptedMethods.scala", "LambdaLift.scala", "LiftTry.scala", "LinkScala2ImplClasses.scala",
+    "Getters.scala", "InterceptedMethods.scala", "LambdaLift.scala", "LiftTry.scala", "LinkScala2Impls.scala",
     "MacroTransform.scala", "Memoize.scala", "Mixin.scala", "MixinOps.scala", "NonLocalReturns.scala",
     "NormalizeFlags.scala", "OverridingPairs.scala", "ParamForwarding.scala", "Pickler.scala", "PostTyper.scala",
     "ResolveSuper.scala", "RestoreScopes.scala", "SeqLiterals.scala", "Splitter.scala", "SuperAccessors.scala",

--- a/tests/run/mixins1/A_1.scala
+++ b/tests/run/mixins1/A_1.scala
@@ -1,0 +1,11 @@
+trait A {
+
+  var x = 3
+  println("hi")
+  val y = x * x
+
+  def f: Int = x + y
+
+  def f(z: Int): Int = f + z
+
+}

--- a/tests/run/mixins1/C_2.scala
+++ b/tests/run/mixins1/C_2.scala
@@ -1,0 +1,12 @@
+// Intended to be compiled with either 2.11 or 2.12
+class C extends A {
+  x = 4
+
+  override def f: Int = super.f
+
+  val z = x + f(x) + y
+}
+
+object Test extends App {
+  new C().f
+}


### PR DESCRIPTION
This PR is a first step to Scala 2.12 support from Dotty. It makes it possible for Dotty to extend traits compiled with Scala 2.12.
