### PR TITLE
Allow partial eta expansion

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1044,7 +1044,13 @@ object Types {
       case _ => NoType
     }
 
-  	/** If this is a FunProto or PolyProto, WildcardType, otherwise this. */
+    /** If this is a repeated type, its element type, otherwise the type itself */
+    def repeatedToSingle(implicit ctx: Context): Type = this match {
+      case tp @ ExprType(tp1) => tp.derivedExprType(tp1.repeatedToSingle)
+      case _                  => if (isRepeatedParam) this.argTypesHi.head else this
+    }
+
+    /** If this is a FunProto or PolyProto, WildcardType, otherwise this. */
     def notApplied: Type = this
 
     // ----- Normalizing typerefs over refined types ----------------------------

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1056,12 +1056,8 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
      */
     def isAsSpecific(alt1: TermRef, tp1: Type, alt2: TermRef, tp2: Type): Boolean = ctx.traceIndented(i"isAsSpecific $tp1 $tp2", overload) { tp1 match {
       case tp1: MethodType => // (1)
-        def repeatedToSingle(tp: Type): Type = tp match {
-          case tp @ ExprType(tp1) => tp.derivedExprType(repeatedToSingle(tp1))
-          case _ => if (tp.isRepeatedParam) tp.argTypesHi.head else tp
-        }
         val formals1 =
-          if (tp1.isVarArgsMethod && tp2.isVarArgsMethod) tp1.paramInfos map repeatedToSingle
+          if (tp1.isVarArgsMethod && tp2.isVarArgsMethod) tp1.paramInfos.map(_.repeatedToSingle)
           else tp1.paramInfos
         isApplicable(alt2, formals1, WildcardType) ||
         tp1.paramInfos.isEmpty && tp2.isInstanceOf[LambdaType]

--- a/tests/pos/i2570.scala
+++ b/tests/pos/i2570.scala
@@ -1,0 +1,29 @@
+object Test {
+
+  def repeat(s: String, i: Int, j: Int = 22) = s * i
+
+  val f1 = repeat("abc", _)
+  val f2: Int => String = f1
+  val f3 = repeat(_, 3)
+  val f4: String => String = f3
+  val f5 = repeat("abc", _, _)
+  val f6: (Int, Int) => String = f5
+  val f7 = repeat(_, 11, _)
+  val f8: (String, Int) => String = f7
+
+  def sum(x: Int, y: => Int) = x + y
+
+  val g1 = sum(2, _)
+  val g2: (=> Int) => Int = g1
+
+  val h0: ((Int, => Int) => Int) = sum
+
+  def sum2(x: Int, ys: Int*) = (x /: ys)(_ + _)
+  val h1: ((Int, Seq[Int]) => Int) = sum2
+
+// Not yet:
+//  val h1 = repeat
+//  val h2: (String, Int, Int) = h1
+//  val h3 = sum
+//  val h4: (Int, => Int) = h3
+}


### PR DESCRIPTION
Allow partial eta expansion using the following rule:

Assume we have an application

    (x_1, ..., x_m) => f(<arg_1, ..., arg_n>)

where every `x_i` occurs exactly once as argument to `f`, and typing `f` with `(?, ..., ?) => ?`
as expected type (where there are n occurrences of `?` in the argument list)
yields a method type `(T_1, ..., T_n)R`. Let `p` be the mapping from `1..m` to `1..n`
which maps every parameter `x_i` to the position where it occurs in `<arg_1, ..., arg_n>`.

In this case, if one of the parameter types `x_i` is not given and not inferred from the
expected type, assume `T_p(i)` as the type of `x_i`, provided `T_p(i)` is fully defined
and not a repeated type `T*` or `=>T*`.

The reason for excluding repeated types `T*` is that `T*` is not a valid type for a
lambda parameter.

Fixes one part of #2570.
