### PR TITLE
Harden IDE, 2nd attempt

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -167,5 +167,6 @@ object Config {
    */
   final val PendingFindMemberLimit = LogPendingFindMemberThreshold * 4
 
+  /** When in IDE, turn StaleSymbol errors into warnings instead of crashing */
   final val ignoreStaleInIDE = true
 }

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -72,6 +72,9 @@ object Config {
   /** Check positions for consistency after parsing */
   final val checkPositions = true
 
+  /** Check that typed trees don't point to untyped ones */
+  final val checkTreesConsistent = false
+
   /** Show subtype traces for all deep subtype recursions */
   final val traceDeepSubTypeRecursions = false
 
@@ -163,4 +166,6 @@ object Config {
    *  when findMemberLimit is set.
    */
   final val PendingFindMemberLimit = LogPendingFindMemberThreshold * 4
+
+  final val ignoreStaleInIDE = true
 }

--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -90,4 +90,7 @@ object Mode {
    *  In this case, identifiers should never be imported.
    */
   val InPackageClauseName = newMode(18, "InPackageClauseName")
+
+  /** We are in the IDE */
+  val Interactive = newMode(20, "Interactive")
 }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -102,11 +102,10 @@ trait SymDenotations { this: Context =>
 
   /** Configurable: Accept stale symbol with warning if in IDE */
   def acceptStale(denot: SingleDenotation): Boolean =
-    (mode.is(Mode.Interactive) && Config.ignoreStaleInIDE) && {
-      ctx.warning(denot.staleSymbolMsg)
+    mode.is(Mode.Interactive) && Config.ignoreStaleInIDE && {
+      ctx.echo(denot.staleSymbolMsg)
       true
     }
-
 }
 
 object SymDenotations {

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -99,6 +99,14 @@ trait SymDenotations { this: Context =>
         explain("denotation is not a SymDenotation")
     }
   }
+
+  /** Configurable: Accept stale symbol with warning if in IDE */
+  def acceptStale(denot: SingleDenotation): Boolean =
+    (mode.is(Mode.Interactive) && Config.ignoreStaleInIDE) && {
+      ctx.warning(denot.staleSymbolMsg)
+      true
+    }
+
 }
 
 object SymDenotations {

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveCompiler.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveCompiler.scala
@@ -15,7 +15,4 @@ class InteractiveCompiler extends Compiler {
   override def phases: List[List[Phase]] = List(
     List(new FrontEnd)
   )
-
-  override def rootContext(implicit ctx: Context) =
-    super.rootContext.fresh.addMode(Mode.Interactive)
 }

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveCompiler.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveCompiler.scala
@@ -5,6 +5,7 @@ package interactive
 import core._
 import Phases._
 import typer._
+import Contexts._
 
 class InteractiveCompiler extends Compiler {
   // TODO: Figure out what phases should be run in IDEs
@@ -14,4 +15,7 @@ class InteractiveCompiler extends Compiler {
   override def phases: List[List[Phase]] = List(
     List(new FrontEnd)
   )
+
+  override def rootContext(implicit ctx: Context) =
+    super.rootContext.fresh.addMode(Mode.Interactive)
 }

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -33,7 +33,7 @@ class InteractiveDriver(settings: List[String]) extends Driver {
   override def sourcesRequired = false
 
   private val myInitCtx: Context = {
-    val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions)
+    val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions).addMode(Mode.Interactive)
     rootCtx.setSetting(rootCtx.settings.YretainTrees, true)
     val ctx = setup(settings.toArray, rootCtx)._2
     ctx.initialize()(ctx)

--- a/compiler/src/dotty/tools/dotc/util/Positions.scala
+++ b/compiler/src/dotty/tools/dotc/util/Positions.scala
@@ -100,13 +100,18 @@ object Positions {
 
     /** A copy of this position with a different start */
     def withStart(start: Int) =
-      fromOffsets(start, this.end, if (isSynthetic) SyntheticPointDelta else this.point - start)
+      if (exists) fromOffsets(start, this.end, if (isSynthetic) SyntheticPointDelta else this.point - start)
+      else this
 
     /** A copy of this position with a different end */
-    def withEnd(end: Int) = fromOffsets(this.start, end, pointDelta)
+    def withEnd(end: Int) =
+      if (exists) fromOffsets(this.start, end, pointDelta)
+      else this
 
     /** A copy of this position with a different point */
-    def withPoint(point: Int) = fromOffsets(this.start, this.end, point - this.start)
+    def withPoint(point: Int) =
+      if (exists) fromOffsets(this.start, this.end, point - this.start)
+      else this
 
     /** A synthetic copy of this position */
     def toSynthetic = if (isSynthetic) this else Position(start, end)


### PR DESCRIPTION
On stale symbols: There are legitimate scenarios how they can arise in the IDE.

For instance, we define a class, refer to it, edit the class definition and introduce errors. The class symbol temporarily no longer exists until the errors are fixed. But typed trees elsewhere will refer to it. That's why StaleSymbol errors now give warnings by default. A config option can turn them back into exceptions, which is useful if we want to find the root cause of a particular warning.