### PR TITLE
Parse Function arity without throwing exceptions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -190,10 +190,13 @@ object NameOps {
 
     /** Parsed function arity for function with some specific prefix */
     private def functionArityFor(prefix: String): Int = {
-      if (name.startsWith(prefix))
-        try name.toString.substring(prefix.length).toInt
-        catch { case _: NumberFormatException => -1 }
-      else -1
+      if (name.startsWith(prefix)) {
+        val suffix = name.toString.substring(prefix.length)
+        if (suffix.matches("\\d+"))
+          suffix.toInt
+        else
+          -1
+      } else -1
     }
 
     /** The name of the generic runtime operation corresponding to an array operation */


### PR DESCRIPTION
Using NumberFormatException in the normal control flow of the program
makes it harder to debug the compiler by stopping on all instances of
RuntimeException.