### PR TITLE
Changes to eta expansion

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -280,6 +280,13 @@ trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] 
     case _ => false
   }
 
+  /** Is tree a Function or Closure node, possibly preceded by definitions? (currently unused) */
+  def isClosure(tree: Tree)(implicit ctx: Context): Boolean = unsplice(tree) match {
+    case _: Function | _: Closure => true
+    case Block(_, expr) => isClosure(expr)
+    case _ => false
+  }
+
   /** Is `tree` an implicit function or closure, possibly nested in a block? */
   def isImplicitClosure(tree: Tree)(implicit ctx: Context): Boolean = unsplice(tree) match {
     case Function((param: untpd.ValDef) :: _, _) => param.mods.is(Implicit)
@@ -467,6 +474,12 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   /** Is tree a `this` node which belongs to `enclClass`? */
   def isSelf(tree: Tree, enclClass: Symbol)(implicit ctx: Context): Boolean = unsplice(tree) match {
     case This(_) => tree.symbol == enclClass
+    case _ => false
+  }
+
+  /** Is tree a compiler-generated `.apply` node? */
+  def isSyntheticApply(tree: Tree): Boolean = tree match {
+    case Select(qual, nme.apply) => tree.pos.end == qual.pos.end
     case _ => false
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -477,7 +477,9 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
     case _ => false
   }
 
-  /** Is tree a compiler-generated `.apply` node? */
+  /** Is tree a compiler-generated `.apply` node that refers to the
+   *  apply of a function class? (implicit functions are excluded)
+   */
   def isSyntheticApply(tree: Tree): Boolean = tree match {
     case Select(qual, nme.apply) => tree.pos.end == qual.pos.end
     case _ => false

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -471,7 +471,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   }
 
   /** Is tree a compiler-generated `.apply` node that refers to the
-   *  apply of a function class? (implicit functions are excluded)
+   *  apply of a function class?
    */
   def isSyntheticApply(tree: Tree): Boolean = tree match {
     case Select(qual, nme.apply) => tree.pos.end == qual.pos.end
@@ -710,7 +710,7 @@ object TreeInfo {
   /*
   def isAbsTypeDef(tree: Tree) = tree match {
     case TypeDef(_, _, _, TypeBoundsTree(_, _)) => true
-    case TypeDef(_, _, _, rhs) => rhs.tpe. isInstanceOf[TypeBounds]
+    case TypeDef(_, _, _, rhs) => rhs.tpe.isInstanceOf[TypeBounds]
     case _ => false
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -280,13 +280,6 @@ trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] 
     case _ => false
   }
 
-  /** Is tree a Function or Closure node, possibly preceded by definitions? (currently unused) */
-  def isClosure(tree: Tree)(implicit ctx: Context): Boolean = unsplice(tree) match {
-    case _: Function | _: Closure => true
-    case Block(_, expr) => isClosure(expr)
-    case _ => false
-  }
-
   /** Is `tree` an implicit function or closure, possibly nested in a block? */
   def isImplicitClosure(tree: Tree)(implicit ctx: Context): Boolean = unsplice(tree) match {
     case Function((param: untpd.ValDef) :: _, _) => param.mods.is(Implicit)
@@ -717,7 +710,7 @@ object TreeInfo {
   /*
   def isAbsTypeDef(tree: Tree) = tree match {
     case TypeDef(_, _, _, TypeBoundsTree(_, _)) => true
-    case TypeDef(_, _, _, rhs) => rhs.tpe.isInstanceOf[TypeBounds]
+    case TypeDef(_, _, _, rhs) => rhs.tpe. isInstanceOf[TypeBounds]
     case _ => false
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -809,8 +809,8 @@ class Definitions {
    */
   def erasedFunctionClass(cls: Symbol): Symbol = {
     val arity = scalaClassName(cls).functionArity
-    if (arity > 22) defn.FunctionXXLClass
-    else if (arity >= 0) defn.FunctionClass(arity)
+    if (arity > 22) FunctionXXLClass
+    else if (arity >= 0) FunctionClass(arity)
     else NoSymbol
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -668,8 +668,7 @@ object messages {
     private val msgPrefix = if (actualCount > expectedCount) "Too many" else "Not enough"
 
     //TODO add def simpleParamName to ParamInfo
-    private val expectedArgString = fntpe
-      .widen.typeParams
+    private val expectedArgString = expectedArgs
       .map(_.paramName.unexpandedName.show)
       .mkString("[", ", ", "]")
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2012,7 +2012,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
             else -1 // no eta expansion in this case
           }
 
-        if (arity >= 0 && !tree.symbol.isConstructor)
+        if (arity >= 0 && !tree.symbol.isConstructor && !ctx.mode.is(Mode.Pattern))
           typed(etaExpand(tree, wtp, arity), pt)
         else if (wtp.paramInfos.isEmpty)
           adaptInterpolated(tpd.Apply(tree, Nil), pt, EmptyTree)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2012,12 +2012,16 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
             else -1 // no eta expansion in this case
           }
 
-        if (arity >= 0 && !tree.symbol.isConstructor && !ctx.mode.is(Mode.Pattern))
+        if (wtp.isImplicit)
+          err.typeMismatch(tree, pt)
+        else if (arity >= 0 &&
+                 !tree.symbol.isConstructor &&
+                 !ctx.mode.is(Mode.Pattern) &&
+                 !isApplyProto(pt) &&
+                 !isSyntheticApply(tree))
           typed(etaExpand(tree, wtp, arity), pt)
         else if (wtp.paramInfos.isEmpty)
           adaptInterpolated(tpd.Apply(tree, Nil), pt, EmptyTree)
-        else if (wtp.isImplicit)
-          err.typeMismatch(tree, pt)
         else
           missingArgs
       case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2006,8 +2006,12 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
               // prioritize method parameter types as parameter types of the eta-expanded closure
               0
             else defn.functionArity(ptNorm)
-          else if (pt eq AnyFunctionProto) wtp.paramInfos.length
-          else -1
+          else {
+            val nparams = wtp.paramInfos.length
+            if (nparams > 0 || pt.eq(AnyFunctionProto)) nparams
+            else -1 // no eta expansion in this case
+          }
+
         if (arity >= 0 && !tree.symbol.isConstructor)
           typed(etaExpand(tree, wtp, arity), pt)
         else if (wtp.paramInfos.isEmpty)

--- a/tests/neg/i1503.scala
+++ b/tests/neg/i1503.scala
@@ -9,6 +9,6 @@ object Test {
 
   def main(args: Array[String]) = {
     (if (cond) foo1 else bar1)() // error: Unit does not take parameters
-    (if (cond) foo2 else bar2)(22) // error: missing arguments // error: missing arguments
+    (if (cond) foo2 else bar2)(22) // OK after changes to eta expansion
   }
 }

--- a/tests/neg/i1716.scala
+++ b/tests/neg/i1716.scala
@@ -1,9 +1,10 @@
 object Fail {
   def f(m: Option[Int]): Unit = {
      m match {
-      case x @ Some[_] =>       // error
+      case x @ Some[_] =>       // error: unbound wildcard type
       case _           =>
     }
   }
-  Some[_]  // error
+  Some[_]  // error: unbound wildcard type
+
 }

--- a/tests/neg/typedapply.scala
+++ b/tests/neg/typedapply.scala
@@ -6,8 +6,18 @@ object typedapply {
 
   foo[Int, String, String](1, "abc") // error: wrong number of type parameters
 
+  def fuz(x: Int, y: String) = (x, y)
+
+  val x1 = fuz.curried // OK
+  val x2: Int => String => (Int, String) = x1
+
   def bar(x: Int) = x
 
-  bar[Int](1) // error: does not take parameters
+  bar[Int](1) // error: does not take type parameters
+
+  bar.baz // error: baz is not a member of Int => Int
+
 
 }
+
+

--- a/tests/pos/i2570.scala
+++ b/tests/pos/i2570.scala
@@ -21,9 +21,18 @@ object Test {
   def sum2(x: Int, ys: Int*) = (x /: ys)(_ + _)
   val h1: ((Int, Seq[Int]) => Int) = sum2
 
-// Not yet:
-//  val h1 = repeat
-//  val h2: (String, Int, Int) = h1
-//  val h3 = sum
-//  val h4: (Int, => Int) = h3
+  val h3 = repeat
+  val h4: ((String, Int, Int) => String) = h3
+  val h5 = sum
+  val h6: ((Int, => Int) => Int) = h5
+
+  class A
+  class B
+  class C
+  implicit object b extends B
+
+  def foo(x: A)(implicit bla: B): C = ???
+
+  val h7 = foo
+  val h8: A => C = h7
 }


### PR DESCRIPTION
 - allow partial eta expansion
 - always eta expand if arity is >= 1

This implements the eta expansion parts of #2570, following the recommendations in my comment there:

After discussing this with @adriaanm, we are leaning towards the following compromise proposal for handling references to unapplied methods m:

 - If m has one or more parameters, we always eta expand

 - if m is nullary and the expected type is of the form () => T, we eta expand.

Based on #2691
