### PR TITLE
support debugging for dotc/dotr

### DIFF
--- a/dist/bin/common
+++ b/dist/bin/common
@@ -112,3 +112,6 @@ SCALA_ASM=$(find_lib "*scala-asm*")
 SCALA_LIB=$(find_lib "*scala-library*")
 SCALA_XML=$(find_lib "*scala-xml*")
 SBT_INTF=$(find_lib "*sbt-interface*")
+
+# debug
+DEBUG_STR=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005

--- a/dist/bin/dotc
+++ b/dist/bin/dotc
@@ -76,7 +76,7 @@ case "$1" in
            --) shift; for arg; do addResidual "$arg"; done; set -- ;;
      -h|-help) help=true && shift ;;
   -v|-verbose) verbose=true && shift ;;
-    -debug) debug=true && shift ;;
+       -debug) DEBUG="$DEBUG_STR" && shift ;;
     -q|-quiet) quiet=true && shift ;;
 
     # Optimize for short-running applications, see https://github.com/lampepfl/dotty/issues/222
@@ -103,6 +103,7 @@ classpathArgs
 
 eval exec "\"$JAVACMD\"" \
      ${JAVA_OPTS:-$default_java_opts} \
+     "$DEBUG" \
      "${java_args[@]}" \
      "$jvm_cp_args" \
      -Dscala.usejavacp=true \

--- a/dist/bin/dotr
+++ b/dist/bin/dotr
@@ -31,6 +31,11 @@ source "$PROG_HOME/bin/common"
 
 CLASS_PATH=".$PSEP$DOTTY_LIB$PSEP$SCALA_LIB"
 
+# -d must be the first option
+case "$1" in
+  -d) DEBUG="$DEBUG_STR" && shift ;;
+esac
+
 first_arg="$1"
 
 if [ -z "$1" ]; then
@@ -39,5 +44,5 @@ if [ -z "$1" ]; then
 elif [[ ${first_arg:0:1} == "-" ]]; then
     eval "$PROG_HOME/bin/dotc -repl $@"
 else
-  eval exec "\"$JAVACMD\"" "-classpath \"$CLASS_PATH\"" $@
+  eval exec "\"$JAVACMD\"" "$DEBUG" "-classpath \"$CLASS_PATH\"" $@
 fi


### PR DESCRIPTION
Support debugging option for `dotc/dotr`:

```bash
$ dotc -debug hello.scala
Listening for transport dt_socket at address: 5005

$ dotr -d Test
Listening for transport dt_socket at address: 5005
```

With this PR, we may consider remove the `bin/dotc` scripts:

- New scripts don't depend on source code
- New scripts support all features of old scripts
- New scripts is CI tested on Linux/Mac/Windows
- `sbt dist/pack` or `sbt dist-bootstrapped/pack` can be used for compiler development

The CI on Linux/Mac/Windows for this PR is here: https://github.com/liufengyun/packtest/pull/3

Note: `-d` is already used in the compiler for output directory, thus `dotc` has to use `-debug`.
