### PR TITLE
SI-4700 Types with symbolic names print in infix by default

### DIFF
--- a/tests/repl/infix-types.check
+++ b/tests/repl/infix-types.check
@@ -1,0 +1,19 @@
+scala> class &&[T,U]
+defined class &&
+scala> def foo: Int && Boolean = ???
+def foo: Int && Boolean
+scala> def foo: Int && Boolean && String = ???
+def foo: Int && Boolean && String
+scala> def foo: Int && (Boolean && String) = ???
+def foo: Int && (Boolean && String)
+scala> class &:[L, R]
+defined class &:
+scala> def foo: Int &: String = ???
+def foo: Int &: String
+scala> def foo: Int &: Boolean &: String = ???
+def foo: Int &: Boolean &: String
+scala> def foo: (Int && String) &: Boolean = ???
+def foo: (Int && String) &: Boolean
+scala> def foo: Int && (Boolean &: String) = ???
+def foo: Int && (Boolean &: String)
+scala> :quit


### PR DESCRIPTION
This a partial port of https://github.com/scala/scala/pull/5589 to
dotty: when pretty-printing an applied type, if its type constructor has
a symbolic name, then always print it in infix form. The PR in scalac
also adds an `@showAsInfix` annotation to control this behavior, but we
cannot do the same in dotty since we still rely on the standard library
from Scala 2.11 and the annotation only exists in 2.12 and up.