### PR TITLE
Moved error message to case class scheme

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -88,6 +88,7 @@ public enum ErrorMessageID {
     ValueClassNeedsExactlyOneValParamID,
     OnlyCaseClassOrCaseObjectAllowedID,
     ExpectedClassOrObjectDefID,
+    AnonymousFunctionMissingParamTypeID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -176,6 +176,34 @@ object messages {
            |Or, add an explicit `()' as a parameter list to ${cdef.name}."""
   }
 
+  case class AnonymousFunctionMissingParamType(param: untpd.ValDef,
+                                               args: List[untpd.Tree],
+                                               tree: untpd.Function,
+                                               pt: Type)
+                                              (implicit ctx: Context)
+  extends Message(AnonymousFunctionMissingParamTypeID) {
+    val kind = "Syntax"
+
+    val msg = {
+      val ofFun =
+        if (MethodType.syntheticParamNames(args.length + 1) contains param.name)
+          i" of expanded function $tree"
+        else
+          ""
+
+      i"missing parameter type for parameter ${param.name}$ofFun, expected = $pt"
+    }
+
+    val explanation =
+      hl"""|Anonymous functions must define a type. For example, if you define a function like this one:
+           |
+           |${"val f = { case xs @ List(1, 2, 3) => Some(xs) }"}
+           |
+           |Make sure you give it a type of what you expect to match and help the type inference system:
+           |
+           |${"val f: Seq[Int] => Option[List[Int]] = { case xs @ List(1, 2, 3) => Some(xs) }"} """
+  }
+
 
   // Type Errors ------------------------------------------------------------ //
   case class DuplicateBind(bind: untpd.Bind, tree: untpd.CaseDef)(implicit ctx: Context)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -762,12 +762,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
             }
           case _ =>
         }
-        val ofFun =
-          if (MethodType.syntheticParamNames(args.length + 1) contains param.name)
-            i" of expanded function $tree"
-          else
-            ""
-        errorType(i"missing parameter type for parameter ${param.name}$ofFun, expected = $pt", param.pos)
+        errorType(AnonymousFunctionMissingParamType(param, args, tree, pt), param.pos)
       }
 
       def protoFormal(i: Int): Type =

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -802,5 +802,22 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         val err :: Nil = messages
         assertEquals(err, ExpectedClassOrObjectDef())
       }
+  @Test def anonymousFunctionMissingParamType =
+    checkMessagesAfter("refchecks") {
+      """
+        |object AnonymousF {
+        |  val f = { case l@List(1,2,3) => Some(l) }
+        |}""".stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        val defn = ictx.definitions
+
+        assertMessageCount(1, messages)
+        val AnonymousFunctionMissingParamType(param, args, _, pt) :: Nil = messages
+        assertEquals("x$1", param.show)
+        assertEquals(s"List(ValDef(${param.show},TypeTree,EmptyTree))", args.toString)
+        assertEquals("?", pt.show)
+      }
 
 }


### PR DESCRIPTION
Moved anonymous function missing parameter type error message to case class scheme.

Corresponds to Typer.scala:770 listed on the main issue: #1589 