### PR TITLE
Moving string error message to dedicated case class

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -88,7 +88,8 @@ public enum ErrorMessageID {
     ValueClassNeedsExactlyOneValParamID,
     OnlyCaseClassOrCaseObjectAllowedID,
     ExpectedClassOrObjectDefID,
-    AnonymousFunctionMissingParamTypeID
+    AnonymousFunctionMissingParamTypeID,
+    SuperCallsNotAllowedInlineID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1608,4 +1608,10 @@ object messages {
     val explanation = ""
   }
 
+  case class SuperCallsNotAllowedInline(symbol: Symbol)(implicit ctx: Context)
+    extends Message(SuperCallsNotAllowedInlineID) {
+    val kind = "Syntax"
+    val msg = s"super call not allowed in inline $symbol"
+    val explanation = "Method inlining prohibits calling superclass methods, as it may lead to confusion about which super is being called."
+  }
 }

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -15,6 +15,7 @@ import util.Positions._
 import Decorators._
 import config.Printers.typr
 import Symbols._, TypeUtils._
+import reporting.diagnostic.messages.SuperCallsNotAllowedInline
 
 /** A macro transform that runs immediately after typer and that performs the following functions:
  *
@@ -182,7 +183,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer  { thisTran
             transformSelect(paramFwd.adaptRef(fixSignature(tree)), Nil)
         case tree: Super =>
           if (ctx.owner.enclosingMethod.isInlineMethod)
-            ctx.error(em"super not allowed in inline ${ctx.owner}", tree.pos)
+            ctx.error(SuperCallsNotAllowedInline(ctx.owner), tree.pos)
           super.transform(tree)
         case tree: TypeApply =>
           val tree1 @ TypeApply(fn, args) = normalizeTypeArgs(tree)

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -820,4 +820,23 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals("?", pt.show)
       }
 
+  @Test def superCallsNotAllowedInline =
+  checkMessagesAfter("refchecks") {
+       """
+        |class A {
+        |  def foo(): Unit = ()
+        |}
+        |
+        |class B extends A {
+        |  inline def bar(): Unit = super.foo()
+        |}
+      """.stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        assertMessageCount(1, messages)
+        val err :: Nil = messages
+        val SuperCallsNotAllowedInline(symbol) = err
+        assertEquals("method bar", symbol.show)
+      }
 }


### PR DESCRIPTION
Error is related to super calls made from inline methods.