### PR TITLE
Fix #2697: Align avoid and checkNoLeaks logic

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -56,8 +56,9 @@ trait TypeAssigner {
         // TODO: measure the cost of using `existsPart`, and if necessary replace it
         // by a `TypeAccumulator` where we have set `stopAtStatic = true`.
         tp existsPart {
-          case tp: NamedType => forbidden contains tp.symbol
-          case tp: ThisType => forbidden contains tp.cls
+          case tp: TermRef => forbidden.contains(tp.symbol) || toAvoid(tp.underlying)
+          case tp: TypeRef => forbidden.contains(tp.symbol)
+          case tp: ThisType => forbidden.contains(tp.cls)
           case _ => false
         }
       def apply(tp: Type): Type = tp match {

--- a/tests/pos/i2697.scala
+++ b/tests/pos/i2697.scala
@@ -1,0 +1,7 @@
+object Foo {
+  def bar = {
+    val data = Map.empty[String, String]
+    val list = List.empty[Map[String, String]]
+    list.map(_ ++ data)
+  }
+}


### PR DESCRIPTION
When checking for leaks we iterate over named parts which also
includes the underlying type of a TermRef. toAvoid needs to do
the same. We'd like to get a DRYer and less ad-hoc implementation
of avoid, but this does not look so easy. I tried several times
but failed so far.