### PR TITLE
Detect direct cycles of typerefs referring to themselves

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -111,7 +111,7 @@ object Config {
   /** If this flag is set, it is checked that TypeRefs don't refer directly
    *  to themselves.
    */
-  final val checkTypeRefCycles = true
+  final val checkTypeRefCycles = false
 
   /** The recursion depth for showing a summarized string */
   final val summarizeDepth = 2

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -108,6 +108,11 @@ object Config {
    */
   final val checkMethodTypes = false
 
+  /** If this flag is set, it is checked that TypeRefs don't refer directly
+   *  to themselves.
+   */
+  final val checkTypeRefCycles = true
+
   /** The recursion depth for showing a summarized string */
   final val summarizeDepth = 2
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1528,10 +1528,14 @@ object Types {
     /** Hook for adding debug check code when denotations are assigned */
     final def checkDenot()(implicit ctx: Context) =
       if (Config.checkTypeRefCycles)
-        lastDenotation.info match {
-          case TypeBounds(lo, hi) =>
-            assert(lo ne this)
-            assert(hi ne this)
+        lastDenotation match {
+          case d: SingleDenotation =>
+            d.infoOrCompleter match {
+              case TypeBounds(lo, hi) =>
+                assert(lo ne this)
+                assert(hi ne this)
+              case _ =>
+            }
           case _ =>
         }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1530,8 +1530,8 @@ object Types {
       if (Config.checkTypeRefCycles)
         lastDenotation.info match {
           case TypeBounds(lo, hi) =>
-            assert(lo.stripTypeVar.stripAnnots ne this)
-            assert(hi.stripTypeVar.stripAnnots ne this)
+            assert(lo ne this)
+            assert(hi ne this)
           case _ =>
         }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1532,8 +1532,8 @@ object Types {
           case d: SingleDenotation =>
             d.infoOrCompleter match {
               case TypeBounds(lo, hi) =>
-                assert(lo ne this)
-                assert(hi ne this)
+                assert(lo ne this, this)
+                assert(hi ne this, this)
               case _ =>
             }
           case _ =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1526,7 +1526,14 @@ object Types {
     }
 
     /** Hook for adding debug check code when denotations are assigned */
-    final def checkDenot()(implicit ctx: Context) = {}
+    final def checkDenot()(implicit ctx: Context) =
+      if (Config.checkTypeRefCycles)
+        lastDenotation.info match {
+          case TypeBounds(lo, hi) =>
+            assert(lo.stripTypeVar.stripAnnots ne this)
+            assert(hi.stripTypeVar.stripAnnots ne this)
+          case _ =>
+        }
 
     /** A second fallback to recompute the denotation if necessary */
     private def computeDenot(implicit ctx: Context): Denotation = {
@@ -1562,9 +1569,9 @@ object Types {
 
           // Don't use setDenot here; double binding checks can give spurious failures after erasure
           lastDenotation = d
-          checkDenot()
           lastSymbol = d.symbol
           checkedPeriod = ctx.period
+          checkDenot()
         }
         d
       }


### PR DESCRIPTION
Have a Config option that allows to flag as assertion errors
typerefs that refer directly to themselves in a bound or alias.
I am going to use this to track down isRef stackoverflows in the IDE; I believe
it is also useful to keep around in case similar errors appear later.