### PR TITLE
Fix #2514: Survive non-sensical trees in Typer

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -380,7 +380,7 @@ object desugar {
       def enumTagMeths = if (isEnumCase) enumTagMeth(CaseKind.Class)._1 :: Nil else Nil
       def copyMeths = {
         def isRepeated(tree: Tree): Boolean = tree match {
-          case PostfixOp(_, Ident(nme.raw.STAR)) => true
+          case PostfixOp(_, Ident(tpnme.raw.STAR)) => true
           case ByNameTypeTree(tree1) => isRepeated(tree1)
           case _ => false
         }
@@ -1051,7 +1051,7 @@ object desugar {
         else // l.op(r), or val x = r; l.op(x), plus handle named args specially
           makeBinop(l, op, r)
       case PostfixOp(t, op) =>
-        if ((ctx.mode is Mode.Type) && !op.isBackquoted && op.name == nme.raw.STAR) {
+        if ((ctx.mode is Mode.Type) && !op.isBackquoted && op.name == tpnme.raw.STAR) {
           val seqType = if (ctx.compilationUnit.isJava) defn.ArrayType else defn.SeqType
           Annotated(
             AppliedTypeTree(ref(seqType), t),

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -367,7 +367,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
    *  parameter, the reference will be a repeated argument.
    */
   def refOfDef(tree: MemberDef)(implicit ctx: Context) = tree match {
-    case ValDef(_, PostfixOp(_, Ident(nme.raw.STAR)), _) => repeated(Ident(tree.name))
+    case ValDef(_, PostfixOp(_, Ident(tpnme.raw.STAR)), _) => repeated(Ident(tree.name))
     case _ => Ident(tree.name)
   }
 

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -447,7 +447,7 @@ object JavaParsers {
       if (in.token == DOTDOTDOT) {
         in.nextToken()
         t = atPos(t.pos.start) {
-          PostfixOp(t, Ident(nme.raw.STAR))
+          PostfixOp(t, Ident(tpnme.raw.STAR))
         }
       }
       atPos(start, in.offset) {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -916,7 +916,7 @@ object Parsers {
       val t = toplevelTyp()
       if (isIdent(nme.raw.STAR)) {
         in.nextToken()
-        atPos(startOffset(t)) { PostfixOp(t, Ident(nme.raw.STAR)) }
+        atPos(startOffset(t)) { PostfixOp(t, Ident(tpnme.raw.STAR)) }
       } else t
     }
 
@@ -1322,7 +1322,7 @@ object Parsers {
      *                    |  `(' [ExprsInParens `,'] PostfixExpr `:' `_' `*' ')'
      *
      *  Special treatment for arguments of primary class constructor
-     *  annotations. All empty argument lists `(` `)` following the first 
+     *  annotations. All empty argument lists `(` `)` following the first
      *  get represented as `List(ParamNotArg)` instead of `Nil`, indicating that
      *  the token sequence should be interpreted as an empty parameter clause
      *  instead. `ParamNotArg` can also be produced when parsing the first
@@ -2047,7 +2047,7 @@ object Parsers {
 
     private def checkVarArgsRules(vparamss: List[List[untpd.ValDef]]): List[untpd.ValDef] = {
       def isVarArgs(tpt: Trees.Tree[Untyped]): Boolean = tpt match {
-        case PostfixOp(_, op) if op.name == nme.raw.STAR => true
+        case PostfixOp(_, op) if op.name == tpnme.raw.STAR => true
         case _ => false
       }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1056,8 +1056,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
             throw ex
         }
       case _ =>
-        assert(isFullyDefined(pt, ForceDegree.none))
-        tree.withType(pt)
+        tree.withType(
+          if (isFullyDefined(pt, ForceDegree.none)) pt else UnspecifiedErrorType)
     }
   }
 
@@ -1124,7 +1124,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
                 tparam.ensureCompleted()
               case _ =>
             }
-          typed(desugaredArg, argPt)
+          if (desugaredArg.isType) typed(desugaredArg, argPt)
+          else desugaredArg.withType(UnspecifiedErrorType)
         }
         args.zipWithConserve(tparams)(typedArg(_, _)).asInstanceOf[List[Tree]]
       }

--- a/tests/neg/i2514.scala
+++ b/tests/neg/i2514.scala
@@ -1,0 +1,10 @@
+object Foo {
+  def foo(): Int = {
+    val f: implicit Int => Int = (implicit x: Int) => 2 * x // error // error
+    f(2)
+  }
+
+  val f = (implicit x: Int) => x // error // error
+
+  ((implicit x: Int) => x): (implicit Int => Int) // error // error // error
+}

--- a/tests/pos/Result.scala
+++ b/tests/pos/Result.scala
@@ -1,0 +1,17 @@
+import scala.util.control.NonFatal
+object p {
+
+  enum Result[+T, +E] {
+    case OK [T](x: T) extends Result[T, Nothing]
+    case Err[E](e: E) extends Result[Nothing, E]
+  }
+
+  type Try[T] = Result[T, Throwable]
+  object Try {
+    def apply[T](x: => T): Try[T] =
+      try Result.OK(x)
+      catch {
+        case NonFatal(ex) => Result.Err(ex)
+      }
+  }
+}


### PR DESCRIPTION
Two problems here, because of previous parsing errors

 - We encounter a TypeTree() without expected type
 - We encounter a ValDef as an argument of an AppliedTypeTree