### PR TITLE
Quick-fix #2704, to get Olaf unblocked.

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -525,12 +525,16 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     def args: List[Tree] = List.empty // those arguments to scala-defined annotations. they are never emmited
   }
 
-  def assocsFromApply(tree: Tree) = {
+  def assocsFromApply(tree: Tree): List[(Name, Tree)] = {
     tree match {
+      case Block(_, expr) => assocsFromApply(expr)
       case Apply(fun, args) =>
         fun.tpe.widen match {
           case MethodType(names) =>
-            names zip args
+            (names zip args).filter {
+              case (_, t: tpd.Ident) if (t.tpe.normalizedPrefix eq NoPrefix) => false
+              case _ => true
+            }
         }
     }
   }


### PR DESCRIPTION
This is not a proper fix, it just fixes the crash.
We need to figure out why this happens and handle it correctly.