### PR TITLE
Move "type argument must be fully defined" message to case class scheme

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -91,6 +91,7 @@ public enum ErrorMessageID {
     AnonymousFunctionMissingParamTypeID,
     SuperCallsNotAllowedInlineID,
     ModifiersNotAllowedID,
+    WildcardOnTypeArgumentNotAllowedOnNewID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -91,7 +91,7 @@ public enum ErrorMessageID {
     AnonymousFunctionMissingParamTypeID,
     SuperCallsNotAllowedInlineID,
     ModifiersNotAllowedID,
-    WildcardOnTypeArgumentNotAllowedOnNewID
+    WildcardOnTypeArgumentNotAllowedOnNewID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -205,6 +205,39 @@ object messages {
            |${"val f: Seq[Int] => Option[List[Int]] = { case xs @ List(1, 2, 3) => Some(xs) }"} """
   }
 
+  case class WildcardOnTypeArgumentNotAllowedOnNew()(implicit ctx: Context)
+  extends Message(WildcardOnTypeArgumentNotAllowedOnNewID) {
+    val kind = "syntax"
+    val msg = "type argument must be fully defined"
+
+    val code1 =
+      """
+        |object TyperDemo {
+        |  class Team[A]
+        |  val team = new Team[_]
+        |}
+      """.stripMargin
+
+    val code2 =
+      """
+        |object TyperDemo {
+        |  class Team[A]
+        |  val team = new Team[Int]
+        |}
+      """.stripMargin
+
+    val explanation =
+      hl"""|Wildcard on arguments is not allowed when declaring a new type.
+           |
+           |Given the following example:
+           |
+           |$code1
+           |
+           |You must complete all the type parameters, for instance:
+           |
+           |$code2 """
+  }
+
 
   // Type Errors ------------------------------------------------------------ //
   case class DuplicateBind(bind: untpd.Bind, tree: untpd.CaseDef)(implicit ctx: Context)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -479,7 +479,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         tpt1 match {
           case AppliedTypeTree(_, targs) =>
             for (targ @ TypeBoundsTree(_, _) <- targs)
-              ctx.error("type argument must be fully defined", targ.pos)
+              ctx.error(WildcardOnTypeArgumentNotAllowedOnNew(), targ.pos)
           case _ =>
         }
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -849,4 +849,22 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals("lazy", flags.toString)
         assertEquals("trait", sort)
       }
+
+  @Test def wildcardOnTypeArgumentNotAllowedOnNew =
+    checkMessagesAfter("refchecks") {
+      """
+        |object TyperDemo {
+        |  class Team[A]
+        |  val team = new Team[_]
+        |}""".stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        val defn = ictx.definitions
+
+        assertMessageCount(1, messages)
+        val err :: Nil = messages
+
+        assertEquals(err, WildcardOnTypeArgumentNotAllowedOnNew())
+      }
 }


### PR DESCRIPTION
Move "type argument must be fully defined" message to new error message scheme using WilcardOnTypeArgumentNotAllowedOnNew.