### PR TITLE
Fix #2780: Fix generation of protected accessors

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -187,11 +187,11 @@ class SuperAccessors(thisTransformer: DenotTransformer) {
       }
       val protectedAccessor = clazz.info.decl(accName).suchThat(_.signature == accType.signature).symbol orElse {
         val newAcc = ctx.newSymbol(
-          clazz, accName, Artifact, accType, coord = sel.pos).enteredAfter(thisTransformer)
+          clazz, accName, Artifact | Method, accType, coord = sel.pos).enteredAfter(thisTransformer)
         val code = polyDefDef(newAcc, trefs => vrefss => {
           val (receiver :: _) :: tail = vrefss
           val base = receiver.select(sym).appliedToTypes(trefs)
-          (base /: vrefss)(Apply(_, _))
+          (base /: tail)(Apply(_, _))
         })
         ctx.debuglog("created protected accessor: " + code)
         accDefs(clazz) += code

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -300,9 +300,8 @@ class SuperAccessors(thisTransformer: DenotTransformer) {
     private def needsProtectedAccessor(sym: Symbol, pos: Position)(implicit ctx: Context): Boolean = {
       val clazz = currentClass
       val host = hostForAccessorOf(sym, clazz)
-      val selfType = host.classInfo.selfType
       def accessibleThroughSubclassing =
-        validCurrentClass && (selfType <:< sym.owner.typeRef) && !clazz.is(Trait)
+        validCurrentClass && (clazz.classInfo.selfType <:< sym.owner.typeRef) && !clazz.is(Trait)
 
       val isCandidate = (
            sym.is(Protected)
@@ -312,9 +311,11 @@ class SuperAccessors(thisTransformer: DenotTransformer) {
         && (sym.enclosingPackageClass != currentClass.enclosingPackageClass)
         && (sym.enclosingPackageClass == sym.accessBoundary(sym.enclosingPackageClass))
       )
-      def isSelfType = !(host.typeRef <:< selfType) && {
-        if (selfType.typeSymbol.is(JavaDefined))
-          ctx.restrictionError(s"cannot accesses protected $sym from within $clazz with self type $selfType", pos)
+      val hostSelfType = host.classInfo.selfType
+      def isSelfType = !(host.typeRef <:< hostSelfType) && {
+        if (hostSelfType.typeSymbol.is(JavaDefined))
+          ctx.restrictionError(
+            s"cannot accesses protected $sym from within $clazz with host self type $hostSelfType", pos)
         true
       }
       def isJavaProtected = host.is(Trait) && sym.is(JavaDefined) && {

--- a/tests/run/i2780/Base.java
+++ b/tests/run/i2780/Base.java
@@ -1,5 +1,6 @@
 package bla;
 
 public class Base {
-  protected String foo = "";
+  protected String foo() { return ""; }
+  protected String bar = "";
 }

--- a/tests/run/i2780/Base.java
+++ b/tests/run/i2780/Base.java
@@ -1,0 +1,5 @@
+package bla;
+
+public class Base {
+  protected String foo = "";
+}

--- a/tests/run/i2780/Test.scala
+++ b/tests/run/i2780/Test.scala
@@ -1,6 +1,7 @@
 class Foo extends bla.Base {
   class Inner {
-    println(foo)
+    println(foo())
+    println(bar)
   }
 }
 

--- a/tests/run/i2780/Test.scala
+++ b/tests/run/i2780/Test.scala
@@ -1,0 +1,12 @@
+class Foo extends bla.Base {
+  class Inner {
+    println(foo)
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val f = new Foo
+    new f.Inner
+  }
+}


### PR DESCRIPTION
It seems we never generated any. The condition to generate them was broken and once @smarter fixed that, the generated accessor was wrong.

