### PR TITLE
Fix #2778: Fix handling of named parameters

### DIFF
--- a/tests/neg/i2778.scala
+++ b/tests/neg/i2778.scala
@@ -1,0 +1,9 @@
+object Main {
+  def printName(first: String, last: String): Unit = {
+    println(first + " " + last)
+  }
+
+  def main(args: Array[String]): Unit = {
+    printName("John", first = "Smith") // error: parameter is already instantiated
+  }
+}


### PR DESCRIPTION
If a named parameter conflicts with a positional one, we should
report an error. We silently re-ordered parameters before.