### PR TITLE
Harden IDE some more

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1305,8 +1305,10 @@ object Trees {
             this(this(x, arg), annot)
           case Thicket(ts) =>
             this(x, ts)
-          case _ if ctx.reporter.errorsReported =>
+          case _ if ctx.mode.is(Mode.Interactive) =>
             // in case of errors it may be that typed trees point to untyped ones.
+            // The can still traverse inside such trees, either in the run where errors
+            // are reported, or in subsequent ones.
             x
         }
       }

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1306,8 +1306,8 @@ object Trees {
           case Thicket(ts) =>
             this(x, ts)
           case _ if ctx.mode.is(Mode.Interactive) =>
-            // in case of errors it may be that typed trees point to untyped ones.
-            // The can still traverse inside such trees, either in the run where errors
+            // In case of errors it may be that typed trees point to untyped ones.
+            // The IDE can still traverse inside such trees, either in the run where errors
             // are reported, or in subsequent ones.
             x
         }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1538,7 +1538,8 @@ object Types {
               else recomputeMember(d) // symbol could have been overridden, recompute membership
             else {
               val newd = loadDenot
-              if (newd.exists) newd else d.staleSymbolError
+              if (newd.exists || ctx.mode.is(Mode.Interactive)) newd
+              else d.staleSymbolError
             }
           case d =>
             if (d.validFor.runId != ctx.period.runId) loadDenot

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1538,7 +1538,8 @@ object Types {
               else recomputeMember(d) // symbol could have been overridden, recompute membership
             else {
               val newd = loadDenot
-              if (newd.exists || ctx.mode.is(Mode.Interactive)) newd
+              if (newd.exists) newd
+              else if (ctx.mode.is(Mode.Interactive)) d
               else d.staleSymbolError
             }
           case d =>


### PR DESCRIPTION
I came across two more sources of crashes when doing heavy editing on Types.scala

- tpd.TreeAccumulator hit again an untyped tree. I believe this is because the tree was left in because of an error in a previous run.  Because the error was in a previous run, we cannot take
`reporter.hasErrors` as a test to avoid the crash.

 - I got a StaleSymbolError through another path as before.
