### PR TITLE
Sort stdlib sources to make bug reproducible 

### DIFF
--- a/compiler/test/dotty/tools/StdLibSources.scala
+++ b/compiler/test/dotty/tools/StdLibSources.scala
@@ -17,14 +17,18 @@ object StdLibSources {
 
   def whitelisted: List[String] = {
     lazy val whitelistBasedOnBlacklist = all.diff(blacklisted)
-    if (!useExplicitWhiteList) {
-      whitelistBasedOnBlacklist
-    } else if (!new File(whitelistFile).exists()) {
-      genWhitelist(whitelistBasedOnBlacklist.map(_.replace(stdLibPath, "")))
-      whitelistBasedOnBlacklist
-    } else {
-      loadList(whitelistFile)
-    }
+    val files =
+      if (!useExplicitWhiteList) {
+        whitelistBasedOnBlacklist
+      } else if (!new File(whitelistFile).exists()) {
+        genWhitelist(whitelistBasedOnBlacklist.map(_.replace(stdLibPath, "")))
+        whitelistBasedOnBlacklist
+      } else {
+        loadList(whitelistFile)
+      }
+    // Sort the files so their compilation order is deterministic, and
+    // https://github.com/lampepfl/dotty/issues/2792 can be repro'ed.
+    files.sorted
   }
 
   def blacklisted: List[String] = loadList(blacklistFile)


### PR DESCRIPTION
A previous PR (https://github.com/lampepfl/dotty/pull/2193/files)
added sorting of input files to tests, so that the result is deterministic.

The compileDir function was sorting, but compileList was left out.
This was exposing failures while compiling the Predef.

Fix the symptoms (but not the cause of the failure) by sorting in compileList
as well.

Tested:
  Verified that compilePos passes in the system where it was previously failing.