### PR TITLE
Fix #2633: Cyclic reference when compiling Predef and deprecated

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -829,7 +829,7 @@ class Definitions {
   }
 
   val predefClassNames: Set[Name] =
-    Set("Predef$", "DeprecatedPredef", "LowPriorityImplicits").map(_.toTypeName)
+    Set("Predef$", "DeprecatedPredef", "LowPriorityImplicits").map(_.toTypeName.unmangleClassName)
 
   /** Is `cls` the predef module class, or a class inherited by Predef? */
   def isPredefClass(cls: Symbol) =

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -72,6 +72,16 @@ class CompilationTests extends ParallelTesting {
       ),
       scala2Mode
     ) +
+    // FIXME: This fails with .times(2), see #2799
+    compileList(
+      "testPredefDeprecatedNonCyclic",
+      List(
+        "../scala2-library/src/library/scala/io/Position.scala",
+        "../scala2-library/src/library/scala/Predef.scala",
+        "../scala2-library/src/library/scala/deprecated.scala"
+      ),
+      scala2Mode
+    ) +
     compileFilesInDir("../tests/new", defaultOptions) +
     compileFilesInDir("../tests/pos-scala2", scala2Mode) +
     compileFilesInDir("../tests/pos", defaultOptions) +


### PR DESCRIPTION
`Namer#annotate` special cases `Predef` annotations to avoid cycles, but
`isPredefClass` was broken after the semantic name PR, this commit fixes that.