### PR TITLE
Add debug string to assertion error message.

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -256,7 +256,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
           val evalue = t.symbol.name.mangledString // value the actual enumeration value.
           av.visitEnum(name, edesc, evalue)
         } else {
-          assert(toDenot(t.symbol).name.is(DefaultGetterName)) // this should be default getter. do not emmit.
+          assert(toDenot(t.symbol).name.is(DefaultGetterName), toDenot(t.symbol).name.debugString) // this should be default getter. do not emmit.
         }
       case t: SeqLiteral =>
         val arrAnnotV: AnnotationVisitor = av.visitArray(name)


### PR DESCRIPTION
This commit changes the assertion error messaage in #2797 from an empty
message to:
```
found:    Array[java.nio.file.FileVisitOption]
[error] required: java.nio.file.FileVisitOption
```