### PR TITLE
Fix nightly build after eta-expansion changes

### DIFF
--- a/sbt-dotty/sbt-test/source-dependencies/implicit-params/B.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit-params/B.scala
@@ -1,4 +1,4 @@
 object B extends A
 {
-	val y = x(3)
+	val y: String = x(3)
 }


### PR DESCRIPTION
The nightly build runs the sbt incremental compilation tests (that can be
run by hand using sbt "sbt-dotty/scripted source-dependencies/*" but
take a while to complete). The implicit-params test started failing
after #2701 because B.scala contains:
  val y = x(3)
which was supposed to fail when the implicit is not present but now
succeeds with `y` getting the type `E => String`. We restore the failure
by adding a type annotation to `y`