### PR TITLE
Fix "Find all references" in the IDE with external projects

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/SourceTree.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/SourceTree.scala
@@ -39,7 +39,9 @@ case class SourceTree(tree: tpd.NameTree, source: SourceFile) {
 }
 object SourceTree {
   def fromSymbol(sym: ClassSymbol)(implicit ctx: Context): Option[SourceTree] = {
-    if (sym == defn.SourceFileAnnot) None // FIXME: No SourceFile annotation on SourceFile itself
+    if (sym == defn.SourceFileAnnot || // FIXME: No SourceFile annotation on SourceFile itself
+        sym.sourceFile == null) // FIXME: We cannot deal with external projects yet
+      None
     else {
       sym.tree match {
         case tree: tpd.TypeDef =>


### PR DESCRIPTION
"Find all references" worked on dotty itself because all its
dotty-compiled dependencies are internal, but in other projects it
failed when trying to construct a SourceTree for trees in the dotty
library, because sym.sourceFile returned null, because the SourceFile
annotation pointed to a path that does not exist on the user filesystem.

For now, we just discard these trees, but we need to find some way to
match them with source jars.