### PR TITLE
Add allocation recording

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -9,16 +9,19 @@ import Phases._
 import Decorators._
 import dotty.tools.dotc.transform.TreeTransforms.TreeTransformer
 import io.PlainFile
+
 import scala.io.Codec
 import util._
-import reporting.Reporter
+import reporting.{AllocationStats, Reporter}
 import transform.TreeChecker
 import rewrite.Rewrites
 import java.io.{BufferedWriter, OutputStreamWriter}
+
 import printing.XprintMode
 
 import scala.annotation.tailrec
 import dotty.tools.io.VirtualFile
+
 import scala.util.control.NonFatal
 
 /** A compiler run. Exports various methods to compile source files */
@@ -92,6 +95,8 @@ class Run(comp: Compiler)(implicit ctx: Context) {
     for (unit <- units)
       Stats.record("retained typed trees at end", unit.tpdTree.treeSize)
     Stats.record("total trees at end", ast.Trees.ntrees)
+    if (AllocationStats.collect)
+      ctx.echo(AllocationStats.report())
   }
 
   private sealed trait PrintedTree

--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -71,7 +71,7 @@ object DesugarEnums {
     else if (isLegalEnumCase(cdef)) cdef.withFlags(cdef.mods.flags | Final)
     else cdef
 
-  private def valuesDot(name: String) = Select(Ident(nme.DOLLAR_VALUES), name.toTermName)
+  private def valuesDot(name: String)(implicit ctx: Context) = Select(Ident(nme.DOLLAR_VALUES), name.toTermName)
   private def registerCall(implicit ctx: Context): List[Tree] =
     if (enumClass.typeParams.nonEmpty) Nil
     else Apply(valuesDot("register"), This(EmptyTypeIdent) :: Nil) :: Nil

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -2,17 +2,31 @@ package dotty.tools
 package dotc
 package ast
 
-import dotty.tools.dotc.transform.{ExplicitOuter, Erasure}
+import dotty.tools.dotc.transform.{Erasure, ExplicitOuter}
 import dotty.tools.dotc.typer.ProtoTypes.FunProtoTyped
 import transform.SymUtils._
 import core._
-import util.Positions._, Types._, Contexts._, Constants._, Names._, Flags._
-import SymDenotations._, Symbols._, StdNames._, Annotations._, Trees._, Symbols._
-import Denotations._, Decorators._, DenotTransformers._
+import util.Positions._
+import Types._
+import Contexts._
+import Constants._
+import Names._
+import Flags._
+import SymDenotations._
+import Symbols._
+import StdNames._
+import Annotations._
+import Trees._
+import Symbols._
+import Denotations._
+import Decorators._
+import DenotTransformers._
+
 import collection.mutable
-import util.{Property, SourceFile, NoSource}
+import util.{NoSource, Property, SourceFile}
 import typer.ErrorReporting._
 import NameKinds.TempResultName
+import dotty.tools.dotc.reporting.AllocationStats
 
 import scala.annotation.tailrec
 import scala.io.Codec
@@ -120,7 +134,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     ta.assignType(untpd.SeqLiteral(elems, elemtpt), elems, elemtpt)
 
   def JavaSeqLiteral(elems: List[Tree], elemtpt: Tree)(implicit ctx: Context): JavaSeqLiteral =
-    ta.assignType(new untpd.JavaSeqLiteral(elems, elemtpt), elems, elemtpt).asInstanceOf[JavaSeqLiteral]
+    ta.assignType(AllocationStats.registerAllocation(new untpd.JavaSeqLiteral(elems, elemtpt)), elems, elemtpt).asInstanceOf[JavaSeqLiteral]
 
   def Inlined(call: Tree, bindings: List[MemberDef], expansion: Tree)(implicit ctx: Context): Inlined =
     ta.assignType(untpd.Inlined(call, bindings, expansion), bindings, expansion)
@@ -866,7 +880,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   def applyOverloaded(receiver: Tree, method: TermName, args: List[Tree], targs: List[Type], expectedType: Type, isAnnotConstructor: Boolean = false)(implicit ctx: Context): Tree = {
     val typer = ctx.typer
-    val proto = new FunProtoTyped(args, expectedType, typer)
+    val proto = AllocationStats.registerAllocation(new FunProtoTyped(args, expectedType, typer))
     val denot = receiver.tpe.member(method)
     assert(denot.exists, i"no member $receiver . $method, members = ${receiver.tpe.decls}")
     val selected =

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -3,10 +3,23 @@ package dotc
 package ast
 
 import core._
-import util.Positions._, Types._, Contexts._, Constants._, Names._, NameOps._, Flags._
-import Denotations._, SymDenotations._, Symbols._, StdNames._, Annotations._, Trees._
+import util.Positions._
+import Types._
+import Contexts._
+import Constants._
+import Names._
+import NameOps._
+import Flags._
+import Denotations._
+import SymDenotations._
+import Symbols._
+import StdNames._
+import Annotations._
+import Trees._
 import Decorators._
+import dotty.tools.dotc.reporting.AllocationStats
 import util.Property
+
 import language.higherKinds
 import collection.mutable.ListBuffer
 import reflect.ClassTag
@@ -241,48 +254,258 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
   // ------ Creation methods for untyped only -----------------
 
-  def Ident(name: Name): Ident = new Ident(name)
-  def BackquotedIdent(name: Name): BackquotedIdent = new BackquotedIdent(name)
-  def Select(qualifier: Tree, name: Name): Select = new Select(qualifier, name)
-  def SelectWithSig(qualifier: Tree, name: Name, sig: Signature): Select = new SelectWithSig(qualifier, name, sig)
-  def This(qual: Ident): This = new This(qual)
-  def Super(qual: Tree, mix: Ident): Super = new Super(qual, mix)
-  def Apply(fun: Tree, args: List[Tree]): Apply = new Apply(fun, args)
-  def TypeApply(fun: Tree, args: List[Tree]): TypeApply = new TypeApply(fun, args)
-  def Literal(const: Constant): Literal = new Literal(const)
-  def New(tpt: Tree): New = new New(tpt)
-  def Typed(expr: Tree, tpt: Tree): Typed = new Typed(expr, tpt)
-  def NamedArg(name: Name, arg: Tree): NamedArg = new NamedArg(name, arg)
-  def Assign(lhs: Tree, rhs: Tree): Assign = new Assign(lhs, rhs)
-  def Block(stats: List[Tree], expr: Tree): Block = new Block(stats, expr)
-  def If(cond: Tree, thenp: Tree, elsep: Tree): If = new If(cond, thenp, elsep)
-  def Closure(env: List[Tree], meth: Tree, tpt: Tree): Closure = new Closure(env, meth, tpt)
-  def Match(selector: Tree, cases: List[CaseDef]): Match = new Match(selector, cases)
-  def CaseDef(pat: Tree, guard: Tree, body: Tree): CaseDef = new CaseDef(pat, guard, body)
-  def Return(expr: Tree, from: Tree): Return = new Return(expr, from)
-  def Try(expr: Tree, cases: List[CaseDef], finalizer: Tree): Try = new Try(expr, cases, finalizer)
-  def SeqLiteral(elems: List[Tree], elemtpt: Tree): SeqLiteral = new SeqLiteral(elems, elemtpt)
-  def JavaSeqLiteral(elems: List[Tree], elemtpt: Tree): JavaSeqLiteral = new JavaSeqLiteral(elems, elemtpt)
-  def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree): Inlined = new Inlined(call, bindings, expansion)
-  def TypeTree() = new TypeTree()
-  def SingletonTypeTree(ref: Tree): SingletonTypeTree = new SingletonTypeTree(ref)
-  def AndTypeTree(left: Tree, right: Tree): AndTypeTree = new AndTypeTree(left, right)
-  def OrTypeTree(left: Tree, right: Tree): OrTypeTree = new OrTypeTree(left, right)
-  def RefinedTypeTree(tpt: Tree, refinements: List[Tree]): RefinedTypeTree = new RefinedTypeTree(tpt, refinements)
-  def AppliedTypeTree(tpt: Tree, args: List[Tree]): AppliedTypeTree = new AppliedTypeTree(tpt, args)
-  def LambdaTypeTree(tparams: List[TypeDef], body: Tree): LambdaTypeTree = new LambdaTypeTree(tparams, body)
-  def ByNameTypeTree(result: Tree): ByNameTypeTree = new ByNameTypeTree(result)
-  def TypeBoundsTree(lo: Tree, hi: Tree): TypeBoundsTree = new TypeBoundsTree(lo, hi)
-  def Bind(name: Name, body: Tree): Bind = new Bind(name, body)
-  def Alternative(trees: List[Tree]): Alternative = new Alternative(trees)
-  def UnApply(fun: Tree, implicits: List[Tree], patterns: List[Tree]): UnApply = new UnApply(fun, implicits, patterns)
-  def ValDef(name: TermName, tpt: Tree, rhs: LazyTree): ValDef = new ValDef(name, tpt, rhs)
-  def DefDef(name: TermName, tparams: List[TypeDef], vparamss: List[List[ValDef]], tpt: Tree, rhs: LazyTree): DefDef = new DefDef(name, tparams, vparamss, tpt, rhs)
-  def TypeDef(name: TypeName, rhs: Tree): TypeDef = new TypeDef(name, rhs)
-  def Template(constr: DefDef, parents: List[Tree], self: ValDef, body: LazyTreeList): Template = new Template(constr, parents, self, body)
-  def Import(expr: Tree, selectors: List[untpd.Tree]): Import = new Import(expr, selectors)
-  def PackageDef(pid: RefTree, stats: List[Tree]): PackageDef = new PackageDef(pid, stats)
-  def Annotated(arg: Tree, annot: Tree): Annotated = new Annotated(arg, annot)
+  def Ident(name: Name)(implicit ctx: Context): Ident = {
+    val r = new Ident(name)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def BackquotedIdent(name: Name)(implicit ctx: Context): BackquotedIdent = {
+    val r = new BackquotedIdent(name)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Select(qualifier: Tree, name: Name)(implicit ctx: Context): Select = {
+    val r = new Select(qualifier, name)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def SelectWithSig(qualifier: Tree, name: Name, sig: Signature)(implicit ctx: Context): Select = {
+    val r = new SelectWithSig(qualifier, name, sig)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def This(qual: Ident)(implicit ctx: Context): This = {
+    val r = new This(qual)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Super(qual: Tree, mix: Ident)(implicit ctx: Context): Super = {
+    val r = new Super(qual, mix)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Apply(fun: Tree, args: List[Tree])(implicit ctx: Context): Apply = {
+    val r = new Apply(fun, args)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def TypeApply(fun: Tree, args: List[Tree])(implicit ctx: Context): TypeApply = {
+    val r = new TypeApply(fun, args)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Literal(const: Constant)(implicit ctx: Context): Literal = {
+    val r = new Literal(const)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def New(tpt: Tree)(implicit ctx: Context): New = {
+    val r = new New(tpt)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Typed(expr: Tree, tpt: Tree)(implicit ctx: Context): Typed = {
+    val r = new Typed(expr, tpt)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def NamedArg(name: Name, arg: Tree)(implicit ctx: Context): NamedArg = {
+    val r = new NamedArg(name, arg)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Assign(lhs: Tree, rhs: Tree)(implicit ctx: Context): Assign = {
+    val r = new Assign(lhs, rhs)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Block(stats: List[Tree], expr: Tree)(implicit ctx: Context): Block = {
+    val r = new Block(stats, expr)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def If(cond: Tree, thenp: Tree, elsep: Tree)(implicit ctx: Context): If = {
+    val r = new If(cond, thenp, elsep)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Closure(env: List[Tree], meth: Tree, tpt: Tree)(implicit ctx: Context): Closure = {
+    val r = new Closure(env, meth, tpt)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Match(selector: Tree, cases: List[CaseDef])(implicit ctx: Context): Match = {
+    val r = new Match(selector, cases)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def CaseDef(pat: Tree, guard: Tree, body: Tree)(implicit ctx: Context): CaseDef = {
+    val r = new CaseDef(pat, guard, body)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Return(expr: Tree, from: Tree)(implicit ctx: Context): Return = {
+    val r = new Return(expr, from)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Try(expr: Tree, cases: List[CaseDef], finalizer: Tree)(implicit ctx: Context): Try = {
+    val r = new Try(expr, cases, finalizer)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def SeqLiteral(elems: List[Tree], elemtpt: Tree)(implicit ctx: Context): SeqLiteral = {
+    val r = new SeqLiteral(elems, elemtpt)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def JavaSeqLiteral(elems: List[Tree], elemtpt: Tree)(implicit ctx: Context): JavaSeqLiteral = {
+    val r = new JavaSeqLiteral(elems, elemtpt)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree)(implicit ctx: Context): Inlined = {
+    val r = new Inlined(call, bindings, expansion)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def TypeTree()(implicit ctx: Context): TypeTree = {
+    val r = new TypeTree()
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def SingletonTypeTree(ref: Tree)(implicit ctx: Context): SingletonTypeTree = {
+    val r = new SingletonTypeTree(ref)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def AndTypeTree(left: Tree, right: Tree)(implicit ctx: Context): AndTypeTree = {
+    val r = new AndTypeTree(left, right)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def OrTypeTree(left: Tree, right: Tree)(implicit ctx: Context): OrTypeTree = {
+    val r = new OrTypeTree(left, right)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def RefinedTypeTree(tpt: Tree, refinements: List[Tree])(implicit ctx: Context): RefinedTypeTree = {
+    val r = new RefinedTypeTree(tpt, refinements)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def AppliedTypeTree(tpt: Tree, args: List[Tree])(implicit ctx: Context): AppliedTypeTree = {
+    val r = new AppliedTypeTree(tpt, args)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def LambdaTypeTree(tparams: List[TypeDef], body: Tree)(implicit ctx: Context): LambdaTypeTree = {
+    val r = new LambdaTypeTree(tparams, body)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def ByNameTypeTree(result: Tree)(implicit ctx: Context): ByNameTypeTree = {
+    val r = new ByNameTypeTree(result)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def TypeBoundsTree(lo: Tree, hi: Tree)(implicit ctx: Context): TypeBoundsTree = {
+    val r = new TypeBoundsTree(lo, hi)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Bind(name: Name, body: Tree)(implicit ctx: Context): Bind = {
+    val r = new Bind(name, body)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Alternative(trees: List[Tree])(implicit ctx: Context): Alternative = {
+    val r = new Alternative(trees)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def UnApply(fun: Tree, implicits: List[Tree], patterns: List[Tree])(implicit ctx: Context): UnApply = {
+    val r = new UnApply(fun, implicits, patterns)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def ValDef(name: TermName, tpt: Tree, rhs: LazyTree)(implicit ctx: Context): ValDef = {
+    val r = new ValDef(name, tpt, rhs)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def DefDef(name: TermName, tparams: List[TypeDef], vparamss: List[List[ValDef]], tpt: Tree, rhs: LazyTree)(implicit ctx: Context): DefDef = {
+    val r = new DefDef(name, tparams, vparamss, tpt, rhs)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def TypeDef(name: TypeName, rhs: Tree)(implicit ctx: Context): TypeDef = {
+    val r = new TypeDef(name, rhs)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Template(constr: DefDef, parents: List[Tree], self: ValDef, body: LazyTreeList)(implicit ctx: Context): Template = {
+    val r = new Template(constr, parents, self, body)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Import(expr: Tree, selectors: List[untpd.Tree])(implicit ctx: Context): Import = {
+    val r = new Import(expr, selectors)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def PackageDef(pid: RefTree, stats: List[Tree])(implicit ctx: Context): PackageDef = {
+    val r = new PackageDef(pid, stats)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
+  def Annotated(arg: Tree, annot: Tree)(implicit ctx: Context): Annotated = {
+    val r = new Annotated(arg, annot)
+    if (AllocationStats.collect)
+      AllocationStats.registerAllocation(r)
+    r
+  }
 
   // ------ Additional creation methods for untyped only -----------------
 
@@ -309,31 +532,31 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     ensureApplied((prefix /: argss)(Apply(_, _)))
   }
 
-  def Block(stat: Tree, expr: Tree): Block =
+  def Block(stat: Tree, expr: Tree)(implicit ctx: Context): Block =
     Block(stat :: Nil, expr)
 
-  def Apply(fn: Tree, arg: Tree): Apply =
+  def Apply(fn: Tree, arg: Tree)(implicit ctx: Context): Apply =
     Apply(fn, arg :: Nil)
 
-  def ensureApplied(tpt: Tree) = tpt match {
+  def ensureApplied(tpt: Tree)(implicit ctx: Context) = tpt match {
     case _: Apply => tpt
     case _ => Apply(tpt, Nil)
   }
 
-  def AppliedTypeTree(tpt: Tree, arg: Tree): AppliedTypeTree =
+  def AppliedTypeTree(tpt: Tree, arg: Tree)(implicit ctx: Context): AppliedTypeTree =
     AppliedTypeTree(tpt, arg :: Nil)
 
   def TypeTree(tpe: Type)(implicit ctx: Context): TypedSplice = TypedSplice(TypeTree().withTypeUnchecked(tpe))
 
-  def unitLiteral = Literal(Constant(()))
+  def unitLiteral(implicit ctx: Context) = Literal(Constant(()))
 
   def ref(tp: NamedType)(implicit ctx: Context): Tree =
     TypedSplice(tpd.ref(tp))
 
-  def rootDot(name: Name) = Select(Ident(nme.ROOTPKG), name)
-  def scalaDot(name: Name) = Select(rootDot(nme.scala_), name)
-  def scalaUnit = scalaDot(tpnme.Unit)
-  def scalaAny = scalaDot(tpnme.Any)
+  def rootDot(name: Name)(implicit ctx: Context) = Select(Ident(nme.ROOTPKG), name)
+  def scalaDot(name: Name)(implicit ctx: Context) = Select(rootDot(nme.scala_), name)
+  def scalaUnit(implicit ctx: Context) = scalaDot(tpnme.Unit)
+  def scalaAny(implicit ctx: Context) = scalaDot(tpnme.Any)
 
   def makeConstructor(tparams: List[TypeDef], vparamss: List[List[ValDef]], rhs: Tree = EmptyTree)(implicit ctx: Context): DefDef =
     DefDef(nme.CONSTRUCTOR, tparams, vparamss, TypeTree(), rhs)
@@ -357,8 +580,9 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def makeParameter(pname: TermName, tpe: Tree, mods: Modifiers = EmptyModifiers)(implicit ctx: Context): ValDef =
     ValDef(pname, tpe, EmptyTree).withMods(mods | Param)
 
-  def makeSyntheticParameter(n: Int = 1, tpt: Tree = TypeTree())(implicit ctx: Context): ValDef =
-    ValDef(nme.syntheticParamName(n), tpt, EmptyTree).withFlags(SyntheticTermParam)
+  def makeSyntheticParameter(n: Int = 1, tpt: Tree = null)(implicit ctx: Context): ValDef =
+    ValDef(nme.syntheticParamName(n), if (tpt eq null) TypeTree() else tpt, EmptyTree).withFlags(SyntheticTermParam)
+  
 
   def lambdaAbstract(tparams: List[TypeDef], tpt: Tree)(implicit ctx: Context) =
     if (tparams.isEmpty) tpt else LambdaTypeTree(tparams, tpt)

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -501,7 +501,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     r
   }
   def Annotated(arg: Tree, annot: Tree)(implicit ctx: Context): Annotated = {
-    val r = new Annotated(arg, annot)
+    val r = Annotated(arg, annot)
     if (AllocationStats.collect)
       AllocationStats.registerAllocation(r)
     r

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -501,7 +501,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     r
   }
   def Annotated(arg: Tree, annot: Tree)(implicit ctx: Context): Annotated = {
-    val r = Annotated(arg, annot)
+    val r = new Annotated(arg, annot)
     if (AllocationStats.collect)
       AllocationStats.registerAllocation(r)
     r

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -418,7 +418,9 @@ object Contexts {
     }
 
     /** A fresh clone of this context. */
-    def fresh: FreshContext = clone.asInstanceOf[FreshContext].init(this)
+    def fresh: FreshContext = {
+      AllocationStats.registerAllocation(clone()).asInstanceOf[FreshContext].init(this)
+    }
 
     final def withOwner(owner: Symbol): Context =
       if (owner ne this.owner) fresh.setOwner(owner) else this

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -707,6 +707,8 @@ object Denotations {
     def history: List[SingleDenotation] = {
       val b = new ListBuffer[SingleDenotation]
       var current = initial
+      if ((this.validFor == Nowhere) && (this.nextInRun.initial ne current))
+        throw new UnsupportedOperationException("history is not supported on invalid denotations") // will go into infinite loop
       do {
         b += (current)
         current = current.nextInRun

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2,22 +2,40 @@ package dotty.tools
 package dotc
 package core
 
-import Periods._, Contexts._, Symbols._, Denotations._, Names._, NameOps._, Annotations._
-import Types._, Flags._, Decorators._, DenotTransformers._, StdNames._, Scopes._, Comments._
-import NameOps._, NameKinds._, Phases._
+import Periods._
+import Contexts._
+import Symbols._
+import Denotations._
+import Names._
+import NameOps._
+import Annotations._
+import Types._
+import Flags._
+import Decorators._
+import DenotTransformers._
+import StdNames._
+import Scopes._
+import Comments._
+import NameOps._
+import NameKinds._
+import Phases._
 import Scopes.Scope
+
 import collection.mutable
 import collection.BitSet
 import dotty.tools.io.AbstractFile
 import Decorators.SymbolIteratorDecorator
 import ast._
+
 import annotation.tailrec
 import CheckRealizable._
 import util.SimpleMap
 import util.Stats
 import java.util.WeakHashMap
+
 import config.Config
 import config.Printers.{completions, incremental, noPrinter}
+import dotty.tools.dotc.reporting.AllocationStats
 
 trait SymDenotations { this: Context =>
   import SymDenotations._
@@ -34,9 +52,9 @@ trait SymDenotations { this: Context =>
     initPrivateWithin: Symbol = NoSymbol)(implicit ctx: Context): SymDenotation = {
     val result =
       if (symbol.isClass)
-        if (initFlags is Package) new PackageClassDenotation(symbol, owner, name, initFlags, initInfo, initPrivateWithin, ctx.runId)
-        else new ClassDenotation(symbol, owner, name, initFlags, initInfo, initPrivateWithin, ctx.runId)
-      else new SymDenotation(symbol, owner, name, initFlags, initInfo, initPrivateWithin)
+        if (initFlags is Package) AllocationStats.registerAllocation(new PackageClassDenotation(symbol, owner, name, initFlags, initInfo, initPrivateWithin, ctx.runId))
+        else AllocationStats.registerAllocation(new ClassDenotation(symbol, owner, name, initFlags, initInfo, initPrivateWithin, ctx.runId))
+      else AllocationStats.registerAllocation(new SymDenotation(symbol, owner, name, initFlags, initInfo, initPrivateWithin))
     result.validFor = stablePeriod
     result
   }
@@ -1164,7 +1182,7 @@ object SymDenotations {
 
     // ----- copies and transforms  ----------------------------------------
 
-    protected def newLikeThis(s: Symbol, i: Type): SingleDenotation = new UniqueRefDenotation(s, i, validFor)
+    protected def newLikeThis(s: Symbol, i: Type): SingleDenotation = AllocationStats.registerAllocation(new UniqueRefDenotation(s, i, validFor))(null)
 
     /** Copy this denotation, overriding selective fields */
     final def copySymDenotation(
@@ -1845,9 +1863,9 @@ object SymDenotations {
     /** A proxy to this lazy type that keeps the complete operation
      *  but provides fresh slots for scope/sourceModule/moduleClass
      */
-    def proxy: LazyType = new LazyType {
+    def proxy: LazyType = AllocationStats.registerAllocation(new LazyType {
       override def complete(denot: SymDenotation)(implicit ctx: Context) = self.complete(denot)
-    }
+    })(null)
 
     def decls: Scope = myDecls
     def sourceModule(implicit ctx: Context): Symbol = mySourceModuleFn(ctx)

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -270,7 +270,7 @@ abstract class SymbolLoader extends LazyType {
         }
       else
         doComplete(root)
-      ctx.informTime("loaded " + description, start)
+      //ctx.informTime("loaded " + description, start)
     } catch {
       case ex: IOException =>
         signalError(ex)

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -2,7 +2,13 @@ package dotty.tools
 package dotc
 package core
 
-import Symbols._, Types._, Contexts._, Flags._, Names._, StdNames._, Decorators._
+import Symbols._
+import Types._
+import Contexts._
+import Flags._
+import Names._
+import StdNames._
+import Decorators._
 import Flags.JavaDefined
 import NameOps._
 import Uniques.unique
@@ -10,6 +16,8 @@ import dotc.transform.ExplicitOuter._
 import dotc.transform.ValueClasses._
 import util.DotClass
 import Definitions.MaxImplementedFunctionArity
+import dotty.tools.dotc.reporting.AllocationStats
+
 import scala.annotation.tailrec
 
 /** Erased types are:
@@ -86,7 +94,7 @@ object TypeErasure {
 
   object ErasedValueType {
     def apply(tycon: TypeRef, erasedUnderlying: Type)(implicit ctx: Context) = {
-      unique(new CachedErasedValueType(tycon, erasedUnderlying))
+      unique(AllocationStats.registerAllocation(new CachedErasedValueType(tycon, erasedUnderlying)))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6,7 +6,8 @@ import util.common._
 import Symbols._
 import Flags._
 import Names._
-import StdNames._, NameOps._
+import StdNames._
+import NameOps._
 import NameKinds.{ShadowedName, SkolemName}
 import Scopes._
 import Constants._
@@ -16,7 +17,7 @@ import SymDenotations._
 import Decorators._
 import Denotations._
 import Periods._
-import util.Positions.{Position, NoPosition}
+import util.Positions.{NoPosition, Position}
 import util.Stats._
 import util.{DotClass, SimpleMap}
 import reporting.diagnostic.Message
@@ -29,13 +30,17 @@ import dotty.tools.dotc.transform.Erasure
 import printing.Printer
 import Hashable._
 import Uniques._
-import collection.{mutable, Seq, breakOut}
+
+import collection.{Seq, breakOut, mutable}
 import config.Config
+
 import annotation.tailrec
 import Flags.FlagSet
+
 import language.implicitConversions
-import scala.util.hashing.{ MurmurHash3 => hashing }
-import config.Printers.{core, typr, cyclicErrors}
+import scala.util.hashing.{MurmurHash3 => hashing}
+import config.Printers.{core, cyclicErrors, typr}
+import dotty.tools.dotc.reporting.AllocationStats
 
 object Types {
 
@@ -1999,7 +2004,7 @@ object Types {
      *  with given prefix, name, and signature
      */
     def withFixedSym(prefix: Type, name: TermName, sym: TermSymbol)(implicit ctx: Context): TermRef =
-      unique(new TermRefWithFixedSym(prefix, name, sym))
+      unique(AllocationStats.registerAllocation(new TermRefWithFixedSym(prefix, name, sym)))
 
     /** Create a term ref referring to given symbol with given name, taking the signature
      *  from the symbol if it is completed, or creating a term ref without
@@ -2029,7 +2034,7 @@ object Types {
 
     /** Create a term ref with given prefix, name and signature */
     def withSig(prefix: Type, name: TermName, sig: Signature)(implicit ctx: Context): TermRef =
-      unique(new TermRefWithSignature(prefix, name, sig))
+      unique(AllocationStats.registerAllocation(new TermRefWithSignature(prefix, name, sig)))
 
     /** Create a term ref with given prefix, name, signature, and initial denotation */
     def withSigAndDenot(prefix: Type, name: TermName, sig: Signature, denot: Denotation)(implicit ctx: Context): TermRef = {
@@ -2053,7 +2058,7 @@ object Types {
      *  with given prefix, name, and symbol.
      */
     def withFixedSym(prefix: Type, name: TypeName, sym: TypeSymbol)(implicit ctx: Context): TypeRef =
-      unique(new TypeRefWithFixedSym(prefix, name, sym))
+      unique(AllocationStats.registerAllocation(new TypeRefWithFixedSym(prefix, name, sym)))
 
     /** Create a type ref referring to given symbol with given name.
      *  This is very similar to TypeRef(Type, Symbol),
@@ -2091,7 +2096,7 @@ object Types {
   object ThisType {
     /** Normally one should use ClassSymbol#thisType instead */
     def raw(tref: TypeRef)(implicit ctx: Context) =
-      unique(new CachedThisType(tref))
+      unique(AllocationStats.registerAllocation(new CachedThisType(tref)))
   }
 
   /** The type of a super reference cls.super where
@@ -2111,7 +2116,7 @@ object Types {
   object SuperType {
     def apply(thistpe: Type, supertpe: Type)(implicit ctx: Context): Type = {
       assert(thistpe != NoPrefix)
-      unique(new CachedSuperType(thistpe, supertpe))
+      unique(AllocationStats.registerAllocation(new CachedSuperType(thistpe, supertpe)))
     }
   }
 
@@ -2126,7 +2131,7 @@ object Types {
   object ConstantType {
     def apply(value: Constant)(implicit ctx: Context) = {
       assertUnerased()
-      unique(new CachedConstantType(value))
+      unique(AllocationStats.registerAllocation(new CachedConstantType(value)))
     }
   }
 
@@ -2268,7 +2273,7 @@ object Types {
      *         of length > 1
      */
     def apply(parentExp: RecType => Type)(implicit ctx: Context): RecType = {
-      val rt = new RecType(parentExp)
+      val rt = AllocationStats.registerAllocation(new RecType(parentExp))
       def normalize(tp: Type): Type = tp.stripTypeVar match {
         case tp: RecType =>
           normalize(tp.parent.substRecThis(tp, RecThis(rt)))
@@ -2327,7 +2332,7 @@ object Types {
 
     def unchecked(tp1: Type, tp2: Type)(implicit ctx: Context): AndType = {
       assertUnerased()
-      unique(new CachedAndType(tp1, tp2))
+      unique(AllocationStats.registerAllocation(new CachedAndType(tp1, tp2)))
     }
 
     /** Make an AndType using `op` unless clearly unnecessary (i.e. without
@@ -2377,7 +2382,7 @@ object Types {
   object OrType {
     def apply(tp1: Type, tp2: Type)(implicit ctx: Context) = {
       assertUnerased()
-      unique(new CachedOrType(tp1, tp2))
+      unique(AllocationStats.registerAllocation(new CachedOrType(tp1, tp2)))
     }
     def make(tp1: Type, tp2: Type)(implicit ctx: Context): Type =
       if (tp1 eq tp2) tp1
@@ -2435,7 +2440,7 @@ object Types {
   object ExprType {
     def apply(resultType: Type)(implicit ctx: Context) = {
       assertUnerased()
-      unique(new CachedExprType(resultType))
+      unique(AllocationStats.registerAllocation(new CachedExprType(resultType)))
     }
   }
 
@@ -2748,17 +2753,17 @@ object Types {
 
   object MethodType extends MethodTypeCompanion {
     def apply(paramNames: List[TermName])(paramInfosExp: MethodType => List[Type], resultTypeExp: MethodType => Type)(implicit ctx: Context): MethodType =
-      checkValid(unique(new CachedMethodType(paramNames)(paramInfosExp, resultTypeExp)))
+      checkValid(unique(AllocationStats.registerAllocation(new CachedMethodType(paramNames)(paramInfosExp, resultTypeExp))))
   }
 
   object JavaMethodType extends MethodTypeCompanion {
     def apply(paramNames: List[TermName])(paramInfosExp: MethodType => List[Type], resultTypeExp: MethodType => Type)(implicit ctx: Context): MethodType =
-      unique(new JavaMethodType(paramNames)(paramInfosExp, resultTypeExp))
+      unique(AllocationStats.registerAllocation(new JavaMethodType(paramNames)(paramInfosExp, resultTypeExp)))
   }
 
   object ImplicitMethodType extends MethodTypeCompanion {
     def apply(paramNames: List[TermName])(paramInfosExp: MethodType => List[Type], resultTypeExp: MethodType => Type)(implicit ctx: Context): MethodType =
-      checkValid(unique(new ImplicitMethodType(paramNames)(paramInfosExp, resultTypeExp)))
+      checkValid(unique(AllocationStats.registerAllocation(new ImplicitMethodType(paramNames)(paramInfosExp, resultTypeExp))))
   }
 
   /** A ternary extractor for MethodType */
@@ -2777,8 +2782,14 @@ object Types {
 
     def newParamRef(n: Int) = TypeParamRef(this, n)
 
-    lazy val typeParams: List[LambdaParam] =
-      paramNames.indices.toList.map(new LambdaParam(this, _))
+    def typeParams(implicit ctx: Context): List[LambdaParam] = {
+      if (myTypeParams eq null) {
+        myTypeParams = paramNames.indices.toList.map(x => AllocationStats.registerAllocation(new LambdaParam(this, x)))
+      }
+      myTypeParams
+    }
+
+    private var myTypeParams: List[LambdaParam] = null
 
     /** Instantiate parameter bounds by substituting parameters with given arguments */
     final def instantiateBounds(argTypes: List[Type])(implicit ctx: Context): List[Type] =
@@ -2864,10 +2875,10 @@ object Types {
     def apply(paramNames: List[TypeName])(
         paramInfosExp: HKTypeLambda => List[TypeBounds],
         resultTypeExp: HKTypeLambda => Type)(implicit ctx: Context): HKTypeLambda = {
-      unique(new HKTypeLambda(paramNames)(paramInfosExp, resultTypeExp))
+      unique(AllocationStats.registerAllocation(new HKTypeLambda(paramNames)(paramInfosExp, resultTypeExp)))
     }
 
-    def unapply(tl: HKTypeLambda): Some[(List[LambdaParam], Type)] =
+    def unapply(tl: HKTypeLambda)(implicit ctx: Context): Some[(List[LambdaParam], Type)] =
       Some((tl.typeParams, tl.resType))
 
     def any(n: Int)(implicit ctx: Context) =
@@ -2901,10 +2912,10 @@ object Types {
     def apply(paramNames: List[TypeName])(
         paramInfosExp: PolyType => List[TypeBounds],
         resultTypeExp: PolyType => Type)(implicit ctx: Context): PolyType = {
-      unique(new PolyType(paramNames)(paramInfosExp, resultTypeExp))
+      unique(AllocationStats.registerAllocation(new PolyType(paramNames)(paramInfosExp, resultTypeExp)))
     }
 
-    def unapply(tl: PolyType): Some[(List[LambdaParam], Type)] =
+    def unapply(tl: PolyType)(implicit ctx: Context): Some[(List[LambdaParam], Type)] =
       Some((tl.typeParams, tl.resType))
 
     def any(n: Int)(implicit ctx: Context) =
@@ -3004,7 +3015,7 @@ object Types {
 
   object HKApply {
     def apply(tycon: Type, args: List[Type])(implicit ctx: Context) =
-      unique(new CachedHKApply(tycon, args)).checkInst
+      unique(AllocationStats.registerAllocation(new CachedHKApply(tycon, args))).checkInst
   }
 
   // ----- BoundTypes: ParamRef, RecThis ----------------------------------------
@@ -3328,7 +3339,7 @@ object Types {
 
   object ClassInfo {
     def apply(prefix: Type, cls: ClassSymbol, classParents: List[TypeRef], decls: Scope, selfInfo: DotClass = NoType)(implicit ctx: Context) =
-      unique(new CachedClassInfo(prefix, cls, classParents, decls, selfInfo))
+      unique(AllocationStats.registerAllocation(new CachedClassInfo(prefix, cls, classParents, decls, selfInfo)))
   }
 
   /** Type bounds >: lo <: hi */
@@ -3437,7 +3448,7 @@ object Types {
 
   object TypeBounds {
     def apply(lo: Type, hi: Type)(implicit ctx: Context): TypeBounds =
-      unique(new RealTypeBounds(lo, hi))
+      unique(AllocationStats.registerAllocation(new RealTypeBounds(lo, hi)))
     def empty(implicit ctx: Context) = apply(defn.NothingType, defn.AnyType)
     def upper(hi: Type)(implicit ctx: Context) = apply(defn.NothingType, hi)
     def lower(lo: Type)(implicit ctx: Context) = apply(lo, defn.AnyType)
@@ -3480,7 +3491,7 @@ object Types {
   }
   final class CachedJavaArrayType(elemType: Type) extends JavaArrayType(elemType)
   object JavaArrayType {
-    def apply(elemType: Type)(implicit ctx: Context) = unique(new CachedJavaArrayType(elemType))
+    def apply(elemType: Type)(implicit ctx: Context) = unique(AllocationStats.registerAllocation(new CachedJavaArrayType(elemType)))
   }
 
   /** The type of an import clause tree */
@@ -3523,7 +3534,7 @@ object Types {
   final class CachedWildcardType(optBounds: Type) extends WildcardType(optBounds)
 
   @sharable object WildcardType extends WildcardType(NoType) {
-    def apply(bounds: TypeBounds)(implicit ctx: Context) = unique(new CachedWildcardType(bounds))
+    def apply(bounds: TypeBounds)(implicit ctx: Context) = unique(AllocationStats.registerAllocation(new CachedWildcardType(bounds)))
   }
 
   /** An extractor for single abstract method types.

--- a/compiler/src/dotty/tools/dotc/parsing/MarkupParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/MarkupParsers.scala
@@ -3,7 +3,7 @@ package dotc
 package parsing
 
 import scala.collection.mutable
-import mutable.{ Buffer, ArrayBuffer, ListBuffer }
+import mutable.{ArrayBuffer, Buffer, ListBuffer}
 import scala.util.control.ControlThrowable
 import util.Chars.SU
 import Parsers._
@@ -11,6 +11,7 @@ import util.Positions._
 import core._
 import Constants._
 import Utility._
+import dotty.tools.dotc.core.Contexts.Context
 
 
 // XXX/Note: many/most of the functions in here are almost direct cut and pastes
@@ -45,7 +46,7 @@ object MarkupParsers {
     override def getMessage = "input ended while parsing XML"
   }
 
-  class MarkupParser(parser: Parser, final val preserveWS: Boolean) extends MarkupParserCommon {
+  class MarkupParser(parser: Parser, final val preserveWS: Boolean)(implicit ctx: Context) extends MarkupParserCommon {
 
     import Tokens.{ LBRACE, RBRACE }
 

--- a/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
@@ -59,9 +59,13 @@ object AllocationStats {
     val data = counts.readOnlySnapshot()
     clear()
     val longestNameLength = data.keys.map(x => x._2.getName.length).max
+    val total = data.groupBy( x => x._1._2).map(x => (x._1, x._2.map(_._2).sum))
     val byPhase = data.groupBy(x => x._1._1).map(x => (x._1, x._2.map(x => (x._1._2, x._2)))).toSeq.sortBy(x => -x._2.map(_._2).sum)
 
-    "Class allocations by phase:\n" + byPhase.map { x =>
+    "Total allocations:\n" + total.map{ x =>
+         "   " + x._1.getName + " -> " + x._2
+    }.mkString("\n") +
+      "Class allocations by phase:\n" + byPhase.map { x =>
       val phaseName = x._1.getSimpleName
       val subtrees = x._2.toSeq.sortBy(-_._2).map(x => s"${x._1.getName.padTo(longestNameLength, " ").mkString} -> ${x._2}").mkString("\n   ", "\n   ","\n")
       phaseName ++ subtrees

--- a/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
@@ -1,0 +1,91 @@
+package dotty.tools.dotc.reporting
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Phases.Phase
+import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReferenceArray}
+
+import dotty.tools.dotc.typer.FrontEnd
+
+
+/** Collect collection allocation statistics in the entire compiler.
+ * Threads safe but makes compiler slow
+ * @author Dmitry Petrahsko
+ */
+object AllocationStats {
+  final val collect = true
+
+  private val counts = collection.concurrent.TrieMap[(Class[_], Class[_]), Int]()
+  private val lastPhase = new ThreadLocal[Class[_]]()
+
+  def fixPhase(x: Class[_]): Class[_] = {
+    if (x eq null) {
+      val r = lastPhase.get()
+      if (r ne null) r
+      else classOf[FrontEnd]
+    } else {
+      lastPhase.set(x)
+      x
+    }
+  }
+
+  def registerAllocation[T](obj: T)(implicit ctx: Context): T  = {
+    if (collect)
+      registerAllocation(fixPhase(if (ctx eq null) null else ctx.phase.getClass), obj)
+
+    obj
+  }
+
+
+  private def registerAllocation[T](p: Class[_], obj: T): T = {
+    //markReported(obj)
+    val key = (if (p eq null) null else p, obj.getClass)
+
+    counts.putIfAbsent(key, 0)
+    var repeat = true
+    while (repeat) {
+      val old = counts(key)
+      repeat = !counts.replace(key, old, old + 1)
+    }
+
+    obj
+  }
+
+  def clear() = {
+    counts.clear()
+  }
+
+  def report(): String = {
+    val data = counts.readOnlySnapshot()
+    clear()
+    val longestNameLength = data.keys.map(x => x._2.getName.length).max
+    val byPhase = data.groupBy(x => x._1._1).map(x => (x._1, x._2.map(x => (x._1._2, x._2))))
+    "Class allocations by phase:\n" + byPhase.map { x =>
+      val phaseName = x._1.getSimpleName
+      val subtrees = x._2.map(x => s"${x._1.getName.padTo(longestNameLength, " ").mkString} -> ${x._2}").mkString("\n   ", "\n   ","\n")
+      phaseName ++ subtrees
+    }.mkString("\n")
+  }
+
+  /*
+  final val historySize = 1024
+  private val last = new AtomicReferenceArray[WeakReference[Any]](historySize)
+  private val rec = new AtomicInteger(0)
+
+  def checkReported(obj: Object): Unit = {
+    var i = 0
+    while (i < historySize) {
+      val s = last.get(i)
+      if ((s ne null) && s.get() == obj) return;
+      i = i + 1
+    }
+    throw new RuntimeException(s"object not registered in allocation statistics: ${obj.getClass}")
+  }
+
+  def markReported(obj: Any): Unit = {
+    val my = rec.getAndAdd(1)
+    val idx = ((my % historySize) + historySize) % historySize
+    last.set(idx, new WeakReference[Any](obj))
+  }*/
+
+}

--- a/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
@@ -31,14 +31,16 @@ object AllocationStats {
   }
 
   def registerAllocation[T](obj: T)(implicit ctx: Context): T  = {
+    // this method should be kept very small
     if (collect)
-      registerAllocation(fixPhase(if (ctx eq null) null else ctx.phase.getClass), obj)
+      registerAllocation(ctx, obj)
 
     obj
   }
 
 
-  private def registerAllocation[T](p: Class[_], obj: T): T = {
+  private def registerAllocation[T](ctx: Context, obj: T): T = {
+    val p: Class[_] = fixPhase(if (ctx eq null) null else ctx.phase.getClass)
     //markReported(obj)
     val key = (if (p eq null) null else p, obj.getClass)
 

--- a/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicReferenceArray}
 
 import dotty.tools.dotc.core.Denotations.{Denotation, MultiDenotation, SingleDenotation}
 import dotty.tools.dotc.core.Periods
+import dotty.tools.dotc.core.Periods.Period
 import dotty.tools.dotc.typer.FrontEnd
 import dotty.tools.sharable
 
@@ -18,11 +19,11 @@ import scala.collection.concurrent.TrieMap
  * @author Dmitry Petrahsko
  */
 object AllocationStats {
-  final val collect = false
+  final val collect = true
 
   @sharable private val counts = collection.concurrent.TrieMap[(Class[_], Class[_]), Int]()
   @sharable private val lastPhase = new ThreadLocal[Class[_]]()
-  private val denotations = new TrieMap[SingleDenotation, SingleDenotation]()
+  @sharable private val denotations = new TrieMap[SingleDenotation, SingleDenotation]()
 
   def fixPhase(x: Class[_]): Class[_] = {
     if (x eq null) {

--- a/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
@@ -90,7 +90,7 @@ object AllocationStats {
     }.mkString("\n") + {
       "\n\n\nDenotation length distribution:\n" + denotationsByLength.map {
         x => s"${pad(x._1.toString)} -> ${x._2.size}\n"
-      }
+      }.mkString("\n")
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
@@ -6,6 +6,7 @@ import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReferenceArray}
 
 import dotty.tools.dotc.core.Denotations.{Denotation, MultiDenotation, SingleDenotation}
+import dotty.tools.dotc.core.Periods
 import dotty.tools.dotc.typer.FrontEnd
 import dotty.tools.sharable
 
@@ -72,9 +73,9 @@ object AllocationStats {
     val data = counts.readOnlySnapshot()
     clear()
     val longestNameLength = data.keys.map(x => x._2.getName.length).max
-    val total = data.groupBy( x => x._1._2).map(x => (x._1, x._2.map(_._2).sum)).toSeq.sortBy(-_._2)
+    val total = data.groupBy( x => x._1._2).map(x => (x._1, x._2.values.sum)).toSeq.sortBy(-_._2)
     val byPhase = data.groupBy(x => x._1._1).map(x => (x._1, x._2.map(x => (x._1._2, x._2)))).toSeq.sortBy(x => -x._2.map(_._2).sum)
-    val denotationsByLength = denotations.keysIterator.map(_.initial).toSeq.distinct.groupBy(x => x.history.length).toSeq.sortBy(x => -x._1)
+    val denotationsByLength = denotations.keySet.map(_.initial).filter(x => x.validFor != Periods.Nowhere).toSeq.groupBy(x => x.history.length).toSeq.sortBy(x => -x._1)
 
     def pad(o: AnyRef) =
       o.toString.padTo(longestNameLength, " ").mkString

--- a/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/AllocationStats.scala
@@ -63,8 +63,9 @@ object AllocationStats {
     val total = data.groupBy( x => x._1._2).map(x => (x._1, x._2.map(_._2).sum)).toSeq.sortBy(-_._2)
     val byPhase = data.groupBy(x => x._1._1).map(x => (x._1, x._2.map(x => (x._1._2, x._2)))).toSeq.sortBy(x => -x._2.map(_._2).sum)
 
+
     "Total allocations:\n" + total.map{ x =>
-         "   " + x._1.getName + " -> " + x._2
+         "   " + x._1.getName.padTo(longestNameLength, " ").mkString + " -> " + x._2
     }.mkString("\n") +
       "\n\n\nClass allocations by phase:\n" + byPhase.map { x =>
       val phaseName = x._1.getSimpleName

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -3,7 +3,7 @@ package dotc
 package typer
 
 import core._
-import ast.{Trees, untpd, tpd, TreeInfo}
+import ast.{TreeInfo, Trees, tpd, untpd}
 import util.Positions._
 import util.Stats.track
 import Trees.Untyped
@@ -24,9 +24,12 @@ import NameKinds.DefaultGetterName
 import ProtoTypes._
 import EtaExpansion._
 import Inferencing._
+
 import collection.mutable
-import config.Printers.{typr, unapp, overload}
+import config.Printers.{overload, typr, unapp}
 import TypeApplications._
+import dotty.tools.dotc.reporting.AllocationStats
+
 import language.implicitConversions
 import reporting.diagnostic.Message
 
@@ -639,7 +642,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
   def typedApply(tree: untpd.Apply, pt: Type)(implicit ctx: Context): Tree = {
 
     def realApply(implicit ctx: Context): Tree = track("realApply") {
-      val originalProto = new FunProto(tree.args, IgnoredProto(pt), this)(argCtx(tree))
+      val originalProto = AllocationStats.registerAllocation(new FunProto(tree.args, IgnoredProto(pt), this)(argCtx(tree)))
       val fun1 = typedExpr(tree.fun, originalProto)
 
       // Warning: The following lines are dirty and fragile. We record that auto-tupling was demanded as
@@ -844,12 +847,12 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       // try first for non-overloaded, then for overloaded ocurrences
       def tryWithName(name: TermName)(fallBack: Tree => Tree)(implicit ctx: Context): Tree =
         tryEither { implicit ctx =>
-          val specificProto = new UnapplyFunProto(selType, this)
+          val specificProto = AllocationStats.registerAllocation(new UnapplyFunProto(selType, this))
           typedExpr(untpd.Select(qual, name), specificProto)
         } {
           (sel, _) =>
             tryEither { implicit ctx =>
-              val genericProto = new UnapplyFunProto(WildcardType, this)
+              val genericProto = AllocationStats.registerAllocation(new UnapplyFunProto(WildcardType, this))
               typedExpr(untpd.Select(qual, name), genericProto)
             } {
               (_, _) => fallBack(sel)


### PR DESCRIPTION
Add a compile-time flat that enables recording of allocations.
Allocations are recoreder per-phase and per-allocated class.