### PR TITLE
#1589 Move "implicit function type needs non-empty parameter list" error to a new errors format.

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -92,6 +92,7 @@ public enum ErrorMessageID {
     SuperCallsNotAllowedInlineID,
     ModifiersNotAllowedID,
     WildcardOnTypeArgumentNotAllowedOnNewID,
+    ImplicitFunctionTypeNeedsNonEmptyParameterListID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1663,4 +1663,23 @@ object messages {
         """
     }
   }
+
+  case class ImplicitFunctionTypeNeedsNonEmptyParameterList()(implicit ctx: Context)
+    extends Message(ImplicitFunctionTypeNeedsNonEmptyParameterListID) {
+    val kind = "Syntax"
+    val msg = "implicit function type needs non-empty parameter list"
+    val explanation = {
+      val code1 = "type Transactional[T] = implicit Transaction => T"
+      val code2 = "val cl: implicit A => B"
+      hl"""It is not allowed to leave implicit function parameter list empty.
+         |Possible ways to define implicit function type:
+         |
+         |$code1
+         |
+         |or
+         |
+         |$code2""".stripMargin
+    }
+  }
+
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -690,7 +690,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       val isImplicit = tree match {
         case _: untpd.ImplicitFunction =>
           if (args.length == 0) {
-            ctx.error(i"implicit function type needs non-empty parameter list", tree.pos)
+            ctx.error(ImplicitFunctionTypeNeedsNonEmptyParameterList(), tree.pos)
             false
           }
           else true

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -867,4 +867,20 @@ class ErrorMessagesTests extends ErrorMessagesTest {
 
         assertEquals(err, WildcardOnTypeArgumentNotAllowedOnNew())
       }
+
+  @Test def implicitFunctionTypeNeedsNonEmptyParameterList =
+    checkMessagesAfter("refchecks") {
+      """abstract class Foo {
+        |  type Contextual[T] = implicit () => T
+        |  val x: implicit () => Int
+        |}""".stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        val defn = ictx.definitions
+
+        assertMessageCount(2, messages)
+        messages.foreach(assertEquals(_, ImplicitFunctionTypeNeedsNonEmptyParameterList()))
+      }
+
 }


### PR DESCRIPTION
Hello. 
Here is PR for new schema for "implicit function type needs non-empty parameter list" error message. 