### PR TITLE
Closes #1731 by fixing error message for overloaded method without re…

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -126,7 +126,7 @@ object Contexts {
     protected def sstate_=(sstate: SettingsState) = _sstate = sstate
     def sstate: SettingsState = _sstate
 
-    /** The current tree */
+    /** The current compilation unit */
     private[this] var _compilationUnit: CompilationUnit = _
     protected def compilationUnit_=(compilationUnit: CompilationUnit) = _compilationUnit = compilationUnit
     def compilationUnit: CompilationUnit = _compilationUnit

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1226,10 +1226,10 @@ object messages {
   object OverloadedOrRecursiveMethodNeedsResultType {
     def apply[T >: Trees.Untyped](tree: NameTree[T])(implicit ctx: Context)
     : OverloadedOrRecursiveMethodNeedsResultType =
-      OverloadedOrRecursiveMethodNeedsResultType(tree.show)(ctx)
+      OverloadedOrRecursiveMethodNeedsResultType(tree.name.show)(ctx)
     def apply(symbol: Symbol)(implicit ctx: Context)
     : OverloadedOrRecursiveMethodNeedsResultType =
-      OverloadedOrRecursiveMethodNeedsResultType(symbol.show)(ctx)
+      OverloadedOrRecursiveMethodNeedsResultType(symbol.name.show)(ctx)
   }
 
   case class RecursiveValueNeedsResultType(tree: Names.TermName)(implicit ctx: Context)

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1209,18 +1209,27 @@ object messages {
            |""".stripMargin
   }
 
-  case class OverloadedOrRecursiveMethodNeedsResultType(tree: Names.TermName)(implicit ctx: Context)
+  case class OverloadedOrRecursiveMethodNeedsResultType private (termName: String)(implicit ctx: Context)
   extends Message(OverloadedOrRecursiveMethodNeedsResultTypeID) {
     val kind = "Syntax"
-    val msg = hl"""overloaded or recursive method ${tree} needs return type"""
+    val msg = hl"""overloaded or recursive method $termName needs return type"""
     val explanation =
-      hl"""Case 1: ${tree} is overloaded
-          |If there are multiple methods named `${tree.name}` and at least one definition of
+      hl"""Case 1: $termName is overloaded
+          |If there are multiple methods named `$termName` and at least one definition of
           |it calls another, you need to specify the calling method's return type.
           |
-          |Case 2: ${tree} is recursive
-          |If `${tree.name}` calls itself on any path, you need to specify its return type.
+          |Case 2: $termName is recursive
+          |If `$termName` calls itself on any path, you need to specify its return type.
           |""".stripMargin
+  }
+
+  object OverloadedOrRecursiveMethodNeedsResultType {
+    @specialized def apply[T >: Trees.Untyped](tree: NameTree[T])(implicit ctx: Context)
+    : OverloadedOrRecursiveMethodNeedsResultType =
+      OverloadedOrRecursiveMethodNeedsResultType(tree.name.toString)(ctx)
+    def apply(symbol: Symbol)(implicit ctx: Context)
+    : OverloadedOrRecursiveMethodNeedsResultType =
+      OverloadedOrRecursiveMethodNeedsResultType(symbol.name.toString)(ctx)
   }
 
   case class RecursiveValueNeedsResultType(tree: Names.TermName)(implicit ctx: Context)
@@ -1320,7 +1329,8 @@ object messages {
            |"""
   }
 
-  case class MethodDoesNotTakeParameters(tree: tpd.Tree, methPartType: Types.Type)(err: typer.ErrorReporting.Errors)(implicit ctx: Context)
+  case class MethodDoesNotTakeParameters(tree: tpd.Tree, methPartType: Types.Type)
+  (err: typer.ErrorReporting.Errors)(implicit ctx: Context)
   extends Message(MethodDoesNotTakeParametersId) {
     private val more = tree match {
       case Apply(_, _) => " more"

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1224,12 +1224,12 @@ object messages {
   }
 
   object OverloadedOrRecursiveMethodNeedsResultType {
-    @specialized def apply[T >: Trees.Untyped](tree: NameTree[T])(implicit ctx: Context)
+    def apply[T >: Trees.Untyped](tree: NameTree[T])(implicit ctx: Context)
     : OverloadedOrRecursiveMethodNeedsResultType =
-      OverloadedOrRecursiveMethodNeedsResultType(tree.name.toString)(ctx)
+      OverloadedOrRecursiveMethodNeedsResultType(tree.show)(ctx)
     def apply(symbol: Symbol)(implicit ctx: Context)
     : OverloadedOrRecursiveMethodNeedsResultType =
-      OverloadedOrRecursiveMethodNeedsResultType(symbol.name.toString)(ctx)
+      OverloadedOrRecursiveMethodNeedsResultType(symbol.show)(ctx)
   }
 
   case class RecursiveValueNeedsResultType(tree: Names.TermName)(implicit ctx: Context)

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -32,7 +32,7 @@ object ErrorReporting {
       if (cx.mode is Mode.InferringReturnType) {
         cx.tree match {
           case tree: untpd.DefDef if !tree.tpt.typeOpt.exists =>
-            OverloadedOrRecursiveMethodNeedsResultType(tree.name)
+            OverloadedOrRecursiveMethodNeedsResultType(tree)
           case tree: untpd.ValDef if !tree.tpt.typeOpt.exists =>
             RecursiveValueNeedsResultType(tree.name)
           case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -48,7 +48,7 @@ object ProtoTypes {
 
     private def disregardProto(pt: Type)(implicit ctx: Context): Boolean = pt.dealias match {
       case _: OrType => true
-      case pt => pt.isRef(defn.UnitClass)
+      case ptd => ptd.isRef(defn.UnitClass)
     }
 
     /** Check that the result type of the current method

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -48,7 +48,7 @@ object ProtoTypes {
 
     private def disregardProto(pt: Type)(implicit ctx: Context): Boolean = pt.dealias match {
       case _: OrType => true
-      case ptd => ptd.isRef(defn.UnitClass)
+      case pt => pt.isRef(defn.UnitClass)
     }
 
     /** Check that the result type of the current method

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1872,6 +1872,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
    */
   def adaptInterpolated(tree: Tree, pt: Type, original: untpd.Tree)(implicit ctx: Context): Tree = {
 
+    assert(pt.exists)
+
     def methodStr = err.refStr(methPart(tree).tpe)
 
     def missingArgs(mt: MethodType) = {

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -218,20 +218,19 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("foo", treeName)
     }
 
-//The following test is disabled (may be running in an unsupported phase)
-//
-//    checkMessagesAfter("frontend") {
-//      """
-//        |case class Foo[T](x: T)
-//        |object Foo { def apply[T]() = Foo(null.asInstanceOf[T]) }
-//      """.stripMargin
-//    }.expect { (ictx, messages) =>
-//      implicit val ctx: Context = ictx
-//
-//      assertMessageCount(1, messages)
-//      val OverloadedOrRecursiveMethodNeedsResultType(treeName2) :: Nil = messages
-//      assertEquals("Foo", treeName2)
-//    }
+
+    checkMessagesAfter("frontend") {
+      """
+        |case class Foo[T](x: T)
+        |object Foo { def apply[T]() = Foo(null.asInstanceOf[T]) }
+      """.stripMargin
+    }.expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+      val OverloadedOrRecursiveMethodNeedsResultType(treeName2) :: Nil = messages
+      assertEquals("Foo", treeName2)
+    }
   }
 
   @Test def recursiveMethodNeedsReturnType =

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -200,7 +200,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertTrue("expected trait", isTrait)
     }
 
-  @Test def overloadedMethodNeedsReturnType =
+  @Test def overloadedMethodNeedsReturnType = {
     checkMessagesAfter("frontend") {
       """
         |class Scope() {
@@ -214,9 +214,25 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val defn = ictx.definitions
 
       assertMessageCount(1, messages)
-      val OverloadedOrRecursiveMethodNeedsResultType(tree) :: Nil = messages
-      assertEquals("foo", tree.show)
+      val OverloadedOrRecursiveMethodNeedsResultType(treeName) :: Nil = messages
+      assertEquals("foo", treeName)
     }
+
+//The following test is disabled (may be running in an unsupported phase)
+//
+//    checkMessagesAfter("frontend") {
+//      """
+//        |case class Foo[T](x: T)
+//        |object Foo { def apply[T]() = Foo(null.asInstanceOf[T]) }
+//      """.stripMargin
+//    }.expect { (ictx, messages) =>
+//      implicit val ctx: Context = ictx
+//
+//      assertMessageCount(1, messages)
+//      val OverloadedOrRecursiveMethodNeedsResultType(treeName2) :: Nil = messages
+//      assertEquals("Foo", treeName2)
+//    }
+  }
 
   @Test def recursiveMethodNeedsReturnType =
     checkMessagesAfter("frontend") {
@@ -231,8 +247,8 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val defn = ictx.definitions
 
       assertMessageCount(1, messages)
-      val OverloadedOrRecursiveMethodNeedsResultType(tree) :: Nil = messages
-      assertEquals("i", tree.show)
+      val OverloadedOrRecursiveMethodNeedsResultType(treeName) :: Nil = messages
+      assertEquals("i", treeName)
     }
 
   @Test def recursiveValueNeedsReturnType =


### PR DESCRIPTION
This was achieved by adding a more specific conditional to note the specific error and by overloading apply for the already existing `OverloadedOrRecursiveMethodNeedsResultType`. 

While this is an improvement, it is still not quite right, as the error message now behaves like:

```
scala> case class Foo[T](x: T); object Foo { def apply[T]() = Foo(null.asInstanceOf[T]) } 
-- [E043] Syntax Error: <console>:4:55 -----------------------------------------
4 |case class Foo[T](x: T); object Foo { def apply[T]() = Foo(null.asInstanceOf[T]) }
  |                                                       ^^^
  |                      overloaded or recursive method Foo needs return type
```

To improve beyond this, it seems we would need some way to walk up the tree to get to the LHS (not sure if possible), or, catch it higher up the tree in the first place.