### PR TITLE
Remove date from landing page of Blogs

### DIFF
--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -1,20 +1,53 @@
 ---
-layout: blog-page
-title: "Blog"
+layout: main
+extraCSS:
+    - css/toolbar.css
+    - css/sidebar.css
+title: Blog
 ---
 
-<ul class="post-list">
-    {% for post in site.posts %}
-    <li>
-        <div>
-            <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
+{% include "toolbar" %}
+
+<div id="content-wrapper">
+    {% assign sidebarTop = "75px" %}
+    {% include "sidebar" %}
+
+    <div id="content-body" class="doc-page-body">
+        <div id="post-title">
+            <h1 id="main-title">{{ page.title }}</h1>
+            {% if page.subTitle %}
+            <h2 id="sub-title">{{ page.subTitle }}</h2>
+            {% endif %}
         </div>
-        <div class="date">
-            {{ post.date | date: '%B %d, %Y' }}
+
+        <div id="blog-post-container">
+            <ul class="post-list">
+                {% for post in site.posts %}
+                <li>
+                    <div>
+                        <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
+                    </div>
+                    <div class="date">
+                        {{ post.date | date: '%B %d, %Y' }}
+                    </div>
+                    <div class="excerpt">
+                        {{ post.excerpt }}
+                    </div>
+                </li>
+                {% endfor %}
+            </ul>
         </div>
-        <div class="excerpt">
-            {{ post.excerpt }}
+
+        {% if page.author %}
+        <div id="post-footer">
+            {% if page.authorImg %}
+            <img id="author-image" src="{{ site.baseurl }}/{{ page.authorImg }}">
+            {% endif %}
+            <span id="post-author">
+                {% if page.authorImg == null %}- {% endif %}{{ page.author }}
+            </span>
         </div>
-    </li>
-    {% endfor %}
-</ul>
+        {% endif %}
+
+    </div><!-- end content-body -->
+</div><!-- end content-wrapper -->


### PR DESCRIPTION
A dirty fix for #2818. There are two possibilities - Use js to hide the element in `index.html` but that'd go against "strict" templating and the other would be to modify `index.html` like this one. Would love to hear your views on this. CC @felixmulder