### PR TITLE
Allow multiple calls to `checkMessagesAfter` in ErrorMessagesTests

### DIFF
--- a/compiler/test/dotty/tools/DottyTest.scala
+++ b/compiler/test/dotty/tools/DottyTest.scala
@@ -18,7 +18,9 @@ trait DottyTest extends ContextEscapeDetection {
 
   dotc.parsing.Scanners // initialize keywords
 
-  implicit var ctx: Context = {
+  implicit var ctx: Context = initialCtx
+
+  protected def initialCtx: FreshContext = {
     val base = new ContextBase {}
     import base.settings._
     val ctx = base.initialCtx.fresh
@@ -55,18 +57,20 @@ trait DottyTest extends ContextEscapeDetection {
     }
   }
 
-  def checkCompile(checkAfterPhase: String, source: String)(assertion: (tpd.Tree, Context) => Unit): Unit = {
+  def checkCompile(checkAfterPhase: String, source: String)(assertion: (tpd.Tree, Context) => Unit): Context = {
     val c = compilerWithChecker(checkAfterPhase)(assertion)
     c.rootContext(ctx)
     val run = c.newRun
     run.compile(source)
+    run.runContext
   }
 
-  def checkCompile(checkAfterPhase: String, sources: List[String])(assertion: (tpd.Tree, Context) => Unit): Unit = {
+  def checkCompile(checkAfterPhase: String, sources: List[String])(assertion: (tpd.Tree, Context) => Unit): Context = {
     val c = compilerWithChecker(checkAfterPhase)(assertion)
     c.rootContext(ctx)
     val run = c.newRun
     run.compile(sources)
+    run.runContext
   }
 
   def methType(names: String*)(paramTypes: Type*)(resultType: Type = defn.UnitType) =

--- a/compiler/test/dotty/tools/dotc/ast/DesugarTests.scala
+++ b/compiler/test/dotty/tools/dotc/ast/DesugarTests.scala
@@ -23,7 +23,7 @@ class DesugarTests extends DottyTest {
       )
   }
 
-  @Test def caseClassHasCorrectMembers =
+  @Test def caseClassHasCorrectMembers: Unit =
     checkCompile("frontend", "case class Foo(x: Int, y: String)") { (tree, context) =>
       implicit val ctx = context
       val ccTree = tree.find(tree => tree.symbol.name == typeName("Foo")).get
@@ -38,7 +38,7 @@ class DesugarTests extends DottyTest {
       rest.foreach(validSym)
     }
 
-  @Test def caseClassCompanionHasCorrectMembers =
+  @Test def caseClassCompanionHasCorrectMembers: Unit =
     checkCompile("frontend", "case class Foo(x: Int, y: String)") { (tree, context) =>
       implicit val ctx = context
       val ccTree = tree.find(tree => tree.symbol.name == termName("Foo")).get

--- a/compiler/test/dotty/tools/dotc/ast/TreeInfoTest.scala
+++ b/compiler/test/dotty/tools/dotc/ast/TreeInfoTest.scala
@@ -14,7 +14,7 @@ class TreeInfoTest extends DottyTest {
   import tpd._
 
   @Test
-  def testDefPath = checkCompile("frontend", "class A { def bar = { val x = { val z = 0; 0} }} ") {
+  def testDefPath: Unit = checkCompile("frontend", "class A { def bar = { val x = { val z = 0; 0} }} ") {
     (tree, context) =>
       implicit val ctx = context
       val xTree = tree.find(tree => tree.symbol.name == termName("x")).get

--- a/compiler/test/dotty/tools/dotc/parsing/DocstringTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/DocstringTest.scala
@@ -25,7 +25,7 @@ trait DocstringTest extends DottyTest {
       assert(false, s"Couldn't match resulting AST to expected AST in: $x")
   }
 
-  def checkFrontend(source: String)(docAssert: PartialFunction[Tree[Untyped], Unit]) = {
+  def checkFrontend(source: String)(docAssert: PartialFunction[Tree[Untyped], Unit]): Unit = {
     checkCompile("frontend", source) { (_, ctx) =>
       implicit val c: Context = ctx
       (docAssert orElse defaultAssertion)(ctx.compilationUnit.untpdTree)

--- a/compiler/test/dotty/tools/dotc/parsing/DocstringTests.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/DocstringTests.scala
@@ -49,7 +49,7 @@ class DocstringTests extends DocstringTest {
         checkDocString(t.rawComment.map(_.raw), "/** Hello /* multiple open */ world! */")
     }
   }
-  @Test def multipleClassesInPackage = {
+  @Test def multipleClassesInPackage: Unit = {
     val source =
       """
       |package a

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -101,15 +101,15 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
       """.stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        val defn = ictx.definitions
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
 
-        assertMessageCount(1, messages)
-        val ForwardReferenceExtendsOverDefinition(value, definition) :: Nil = messages
-        assertEquals("value b", value.show)
-        assertEquals("value a", definition.show)
-      }
+      assertMessageCount(1, messages)
+      val ForwardReferenceExtendsOverDefinition(value, definition) :: Nil = messages
+      assertEquals("value b", value.show)
+      assertEquals("value a", definition.show)
+    }
 
   @Test def unexpectedToken =
     checkMessagesAfter("frontend") {
@@ -306,16 +306,16 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
       """.stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        val defn = ictx.definitions
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
 
-        assertMessageCount(1, messages)
-        val SuperQualMustBeParent(qual, cls) :: Nil = messages
+      assertMessageCount(1, messages)
+      val SuperQualMustBeParent(qual, cls) :: Nil = messages
 
-        assertEquals("B", qual.show)
-        assertEquals("class C", cls.show)
-      }
+      assertEquals("B", qual.show)
+      assertEquals("class C", cls.show)
+    }
 
   @Test def ambiguousImport =
     checkMessagesAfter("frontend") {
@@ -334,18 +334,18 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
       """.stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        val defn = ictx.definitions
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
 
-        import typer.Typer.BindingPrec._
+      import typer.Typer.BindingPrec._
 
-        assertMessageCount(1, messages)
-        val AmbiguousImport(name, newPrec, prevPrec, prevCtx) :: Nil = messages
-        assertEquals("ToBeImported", name.show)
-        assertEquals(namedImport, newPrec)
-        assertEquals(namedImport, prevPrec)
-      }
+      assertMessageCount(1, messages)
+      val AmbiguousImport(name, newPrec, prevPrec, prevCtx) :: Nil = messages
+      assertEquals("ToBeImported", name.show)
+      assertEquals(namedImport, newPrec)
+      assertEquals(namedImport, prevPrec)
+    }
 
   @Test def methodDoesNotTakePrameters =
     checkMessagesAfter("frontend") {
@@ -435,14 +435,14 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |class Extending extends WithOutParams[String]
       """.stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        val defn = ictx.definitions
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
 
-        assertMessageCount(1, messages)
-        val TypeDoesNotTakeParameters(tpe, params) :: Nil = messages
-        assertEquals("WithOutParams", tpe.show)
-      }
+      assertMessageCount(1, messages)
+      val TypeDoesNotTakeParameters(tpe, params) :: Nil = messages
+      assertEquals("WithOutParams", tpe.show)
+    }
 
   @Test def parameterizedTypeLacksParameters =
     checkMessagesAfter("frontend") {
@@ -451,25 +451,25 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |class Extending extends WithParams
       """.stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        val defn = ictx.definitions
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
 
-        assertMessageCount(1, messages)
-        val ParameterizedTypeLacksArguments(symbol) :: Nil = messages
-        assertEquals("trait WithParams", symbol.show)
-      }
+      assertMessageCount(1, messages)
+      val ParameterizedTypeLacksArguments(symbol) :: Nil = messages
+      assertEquals("trait WithParams", symbol.show)
+    }
 
   @Test def varValParametersMayNotBeCallByName =
     checkMessagesAfter("frontend") {
       "trait Trait(val noNoNo: => String)"
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val VarValParametersMayNotBeCallByName(name, false) :: Nil = messages
-        assertEquals("noNoNo", name.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val VarValParametersMayNotBeCallByName(name, false) :: Nil = messages
+      assertEquals("noNoNo", name.show)
+    }
 
   @Test def missingTypeParameter =
     checkMessagesAfter("frontend") {
@@ -477,12 +477,12 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |  val value: List = null
         |}""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val MissingTypeParameterFor(tpe) :: Nil = messages
-        assertEquals("List", tpe.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val MissingTypeParameterFor(tpe) :: Nil = messages
+      assertEquals("List", tpe.show)
+    }
 
   @Test def doesNotConformToBound =
     checkMessagesAfter("refchecks") {
@@ -491,14 +491,14 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |  val value: WithParam[Int] = null
         |}""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val DoesNotConformToBound(tpe, which, bound) :: Nil = messages
-        assertEquals("Int", tpe.show)
-        assertEquals("upper", which)
-        assertEquals("scala.collection.immutable.List[Int]", bound.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val DoesNotConformToBound(tpe, which, bound) :: Nil = messages
+      assertEquals("Int", tpe.show)
+      assertEquals("upper", which)
+      assertEquals("scala.collection.immutable.List[Int]", bound.show)
+    }
 
   @Test def doesNotConformToSelfType =
     checkMessagesAfter("refchecks") {
@@ -509,17 +509,17 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |class Blended extends BlendItIn
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val DoesNotConformToSelfType(category, selfType, cls, otherSelf, relation, other) :: Nil = messages
-        assertEquals("illegal inheritance", category)
-        assertEquals("Blended", selfType.show)
-        assertEquals("class Blended", cls.show)
-        assertEquals("Base", otherSelf.show)
-        assertEquals("parent", relation)
-        assertEquals("trait BlendItIn", other.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val DoesNotConformToSelfType(category, selfType, cls, otherSelf, relation, other) :: Nil = messages
+      assertEquals("illegal inheritance", category)
+      assertEquals("Blended", selfType.show)
+      assertEquals("class Blended", cls.show)
+      assertEquals("Base", otherSelf.show)
+      assertEquals("parent", relation)
+      assertEquals("trait BlendItIn", other.show)
+    }
 
   @Test def doesNotConformToSelfTypeCantBeInstantiated =
     checkMessagesAfter("refchecks") {
@@ -530,13 +530,13 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val DoesNotConformToSelfTypeCantBeInstantiated(tpe, selfType) :: Nil = messages
-        assertEquals("RequiresBase", tpe.show)
-        assertEquals("Base", selfType.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val DoesNotConformToSelfTypeCantBeInstantiated(tpe, selfType) :: Nil = messages
+      assertEquals("RequiresBase", tpe.show)
+      assertEquals("Base", selfType.show)
+    }
 
   @Test def abstractValueMayNotHaveFinalModifier =
     checkMessagesAfter("frontend") {
@@ -545,13 +545,13 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val AbstractMemberMayNotHaveModifier(symbol, flags) :: Nil = messages
-        assertEquals("value s", symbol.show)
-        assertEquals("final", flags.toString)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val AbstractMemberMayNotHaveModifier(symbol, flags) :: Nil = messages
+      assertEquals("value s", symbol.show)
+      assertEquals("final", flags.toString)
+    }
 
   @Test def topLevelCantBeImplicit =
     checkMessagesAfter("frontend") {
@@ -560,12 +560,12 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val TopLevelCantBeImplicit(symbol) :: Nil = messages
-        assertEquals("object S", symbol.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val TopLevelCantBeImplicit(symbol) :: Nil = messages
+      assertEquals("object S", symbol.show)
+    }
 
   @Test def typesAndTraitsCantBeImplicit =
     checkMessagesAfter("frontend") {
@@ -574,12 +574,12 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val TypesAndTraitsCantBeImplicit(symbol) :: Nil = messages
-        assertEquals("trait S", symbol.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val TypesAndTraitsCantBeImplicit(symbol) :: Nil = messages
+      assertEquals("trait S", symbol.show)
+    }
 
   @Test def onlyClassesCanBeAbstract =
     checkMessagesAfter("frontend") {
@@ -588,12 +588,12 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val OnlyClassesCanBeAbstract(symbol) :: Nil = messages
-        assertEquals("value s", symbol.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val OnlyClassesCanBeAbstract(symbol) :: Nil = messages
+      assertEquals("value s", symbol.show)
+    }
 
   @Test def abstractOverrideOnlyInTraits =
     checkMessagesAfter("frontend") {
@@ -602,23 +602,23 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val AbstractOverrideOnlyInTraits(symbol) :: Nil = messages
-        assertEquals("value s", symbol.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val AbstractOverrideOnlyInTraits(symbol) :: Nil = messages
+      assertEquals("value s", symbol.show)
+    }
 
   @Test def traitMayNotBeFinal =
     checkMessagesAfter("frontend") {
       """final trait Foo"""
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val TraitsMayNotBeFinal(symbol) :: Nil = messages
-        assertEquals("trait Foo", symbol.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val TraitsMayNotBeFinal(symbol) :: Nil = messages
+      assertEquals("trait Foo", symbol.show)
+    }
 
   @Test def nativeMemberMayNotHaveImplementation =
     checkMessagesAfter("frontend") {
@@ -627,12 +627,12 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
       """.stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val NativeMembersMayNotHaveImplementation(symbol) :: Nil = messages
-        assertEquals("method foo", symbol.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val NativeMembersMayNotHaveImplementation(symbol) :: Nil = messages
+      assertEquals("method foo", symbol.show)
+    }
 
   @Test def onlyClassesCanHaveDeclaredButUndefinedMembers =
     checkMessagesAfter("frontend") {
@@ -641,23 +641,23 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val OnlyClassesCanHaveDeclaredButUndefinedMembers(symbol) :: Nil = messages
-        assertEquals("method foo", symbol.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val OnlyClassesCanHaveDeclaredButUndefinedMembers(symbol) :: Nil = messages
+      assertEquals("method foo", symbol.show)
+    }
 
   @Test def cannotExtendAnyval =
     checkMessagesAfter("frontend") {
       """trait Foo extends AnyVal"""
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val CannotExtendAnyVal(symbol) :: Nil = messages
-        assertEquals("trait Foo", symbol.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val CannotExtendAnyVal(symbol) :: Nil = messages
+      assertEquals("trait Foo", symbol.show)
+    }
 
   @Test def cannotHaveSameNameAs =
     checkMessagesAfter("refchecks") {
@@ -668,13 +668,13 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |  class A
         |}""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val CannotHaveSameNameAs(symbol, cls, _) :: Nil = messages
-        assertEquals("class A", symbol.show)
-        assertEquals("class A", cls.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val CannotHaveSameNameAs(symbol, cls, _) :: Nil = messages
+      assertEquals("class A", symbol.show)
+      assertEquals("class A", cls.show)
+    }
 
   @Test def valueClassesMayNotDefineInner =
     checkMessagesAfter("refchecks") {
@@ -683,13 +683,13 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val ValueClassesMayNotDefineInner(valueClass, inner) :: Nil = messages
-        assertEquals("class MyValue", valueClass.show)
-        assertEquals("class Inner", inner.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val ValueClassesMayNotDefineInner(valueClass, inner) :: Nil = messages
+      assertEquals("class MyValue", valueClass.show)
+      assertEquals("class Inner", inner.show)
+    }
 
   @Test def valueClassesMayNotDefineNonParameterField =
     checkMessagesAfter("refchecks") {
@@ -698,13 +698,13 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val ValueClassesMayNotDefineNonParameterField(valueClass, field) :: Nil = messages
-        assertEquals("class MyValue", valueClass.show)
-        assertEquals("value illegal", field.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val ValueClassesMayNotDefineNonParameterField(valueClass, field) :: Nil = messages
+      assertEquals("class MyValue", valueClass.show)
+      assertEquals("value illegal", field.show)
+    }
 
   @Test def valueClassesMayNotDefineASecondaryConstructor =
     checkMessagesAfter("refchecks") {
@@ -713,13 +713,13 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val ValueClassesMayNotDefineASecondaryConstructor(valueClass, constuctor) :: Nil = messages
-        assertEquals("class MyValue", valueClass.show)
-        assertEquals("constructor MyValue", constuctor.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val ValueClassesMayNotDefineASecondaryConstructor(valueClass, constuctor) :: Nil = messages
+      assertEquals("class MyValue", valueClass.show)
+      assertEquals("constructor MyValue", constuctor.show)
+    }
 
   @Test def valueClassesMayNotContainInitalization =
     checkMessagesAfter("refchecks") {
@@ -728,12 +728,12 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val ValueClassesMayNotContainInitalization(valueClass) :: Nil = messages
-        assertEquals("class MyValue", valueClass.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val ValueClassesMayNotContainInitalization(valueClass) :: Nil = messages
+      assertEquals("class MyValue", valueClass.show)
+    }
 
   @Test def valueClassesMayNotBeContained =
     checkMessagesAfter("refchecks") {
@@ -742,68 +742,69 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val ValueClassesMayNotBeContainted(valueClass) :: Nil = messages
-        assertEquals("class MyValue", valueClass.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val ValueClassesMayNotBeContainted(valueClass) :: Nil = messages
+      assertEquals("class MyValue", valueClass.show)
+    }
 
   @Test def valueClassesMayNotWrapItself =
     checkMessagesAfter("refchecks") {
       """class MyValue(i: MyValue) extends AnyVal"""
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val ValueClassesMayNotWrapItself(valueClass) :: Nil = messages
-        assertEquals("class MyValue", valueClass.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val ValueClassesMayNotWrapItself(valueClass) :: Nil = messages
+      assertEquals("class MyValue", valueClass.show)
+    }
 
   @Test def valueClassParameterMayNotBeVar =
     checkMessagesAfter("refchecks") {
       """class MyValue(var i: Int) extends AnyVal"""
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val ValueClassParameterMayNotBeAVar(valueClass, param) :: Nil = messages
-        assertEquals("class MyValue", valueClass.show)
-        assertEquals("variable i", param.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val ValueClassParameterMayNotBeAVar(valueClass, param) :: Nil = messages
+      assertEquals("class MyValue", valueClass.show)
+      assertEquals("variable i", param.show)
+    }
 
   @Test def valueClassNeedsExactlyOneVal =
     checkMessagesAfter("refchecks") {
       """class MyValue(var i: Int, j: Int) extends AnyVal"""
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val ValueClassNeedsExactlyOneValParam(valueClass) :: Nil = messages
-        assertEquals("class MyValue", valueClass.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val ValueClassNeedsExactlyOneValParam(valueClass) :: Nil = messages
+      assertEquals("class MyValue", valueClass.show)
+    }
 
   @Test def onlyCaseClassOrCaseObjectAllowed =
     checkMessagesAfter("frontend") {
       """case Foobar"""
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val err :: Nil = messages
-        assertEquals(err, OnlyCaseClassOrCaseObjectAllowed())
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val err :: Nil = messages
+      assertEquals(err, OnlyCaseClassOrCaseObjectAllowed())
+    }
 
   @Test def expectedClassOrObjectDef =
     checkMessagesAfter("frontend") {
       """Foo"""
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val err :: Nil = messages
-        assertEquals(err, ExpectedClassOrObjectDef())
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val err :: Nil = messages
+      assertEquals(err, ExpectedClassOrObjectDef())
+    }
+
   @Test def anonymousFunctionMissingParamType =
     checkMessagesAfter("refchecks") {
       """
@@ -811,16 +812,16 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |  val f = { case l@List(1,2,3) => Some(l) }
         |}""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        val defn = ictx.definitions
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
 
-        assertMessageCount(1, messages)
-        val AnonymousFunctionMissingParamType(param, args, _, pt) :: Nil = messages
-        assertEquals("x$1", param.show)
-        assertEquals(s"List(ValDef(${param.show},TypeTree,EmptyTree))", args.toString)
-        assertEquals("?", pt.show)
-      }
+      assertMessageCount(1, messages)
+      val AnonymousFunctionMissingParamType(param, args, _, pt) :: Nil = messages
+      assertEquals("x$1", param.show)
+      assertEquals(s"List(ValDef(${param.show},TypeTree,EmptyTree))", args.toString)
+      assertEquals("?", pt.show)
+    }
 
   @Test def superCallsNotAllowedInline =
   checkMessagesAfter("refchecks") {
@@ -834,13 +835,13 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
       """.stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        assertMessageCount(1, messages)
-        val err :: Nil = messages
-        val SuperCallsNotAllowedInline(symbol) = err
-        assertEquals("method bar", symbol.show)
-      }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val err :: Nil = messages
+      val SuperCallsNotAllowedInline(symbol) = err
+      assertEquals("method bar", symbol.show)
+    }
 
   @Test def modifiersNotAllowed =
     verifyModifiersNotAllowed("lazy trait T", "lazy", Some("trait"))
@@ -868,15 +869,15 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |  val team = new Team[_]
         |}""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        val defn = ictx.definitions
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
 
-        assertMessageCount(1, messages)
-        val err :: Nil = messages
+      assertMessageCount(1, messages)
+      val err :: Nil = messages
 
-        assertEquals(err, WildcardOnTypeArgumentNotAllowedOnNew())
-      }
+      assertEquals(err, WildcardOnTypeArgumentNotAllowedOnNew())
+    }
 
   @Test def implicitFunctionTypeNeedsNonEmptyParameterList =
     checkMessagesAfter("refchecks") {
@@ -885,13 +886,13 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |  val x: implicit () => Int
         |}""".stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        val defn = ictx.definitions
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
 
-        assertMessageCount(2, messages)
-        messages.foreach(assertEquals(_, ImplicitFunctionTypeNeedsNonEmptyParameterList()))
-      }
+      assertMessageCount(2, messages)
+      messages.foreach(assertEquals(_, ImplicitFunctionTypeNeedsNonEmptyParameterList()))
+    }
 
   @Test def wrongNumberOfParameters =
     checkMessagesAfter("refchecks") {
@@ -900,14 +901,13 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |  unary((x, y) => ())
         |} """.stripMargin
     }
-      .expect { (ictx, messages) =>
-        implicit val ctx: Context = ictx
-        val defn = ictx.definitions
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
 
-        assertMessageCount(1, messages)
-        val err :: Nil = messages
+      assertMessageCount(1, messages)
+      val err :: Nil = messages
 
-        assertEquals(err, WrongNumberOfParameters(1))
-      }
-
+      assertEquals(err, WrongNumberOfParameters(1))
+    }
 }

--- a/compiler/test/dotty/tools/dotc/transform/TreeTransformerTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/TreeTransformerTest.scala
@@ -11,7 +11,7 @@ import core.Contexts.Context
 class TreeTransformerTest extends DottyTest {
 
   @Test
-  def shouldReturnSameTreeIfUnchanged = checkCompile("frontend", "class A{ val d = 1}") {
+  def shouldReturnSameTreeIfUnchanged: Unit = checkCompile("frontend", "class A{ val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       class EmptyTransform extends MiniPhaseTransform {
@@ -31,7 +31,7 @@ class TreeTransformerTest extends DottyTest {
   }
 
   // Disabled, awaiting resolution. @Test
-  def canReplaceConstant = checkCompile("frontend", "class A{ val d = 1}") {
+  def canReplaceConstant: Unit = checkCompile("frontend", "class A{ val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       class ConstantTransform extends MiniPhaseTransform {
@@ -53,7 +53,7 @@ class TreeTransformerTest extends DottyTest {
   }
 
   @Test
-  def canOverwrite = checkCompile("frontend", "class A{ val d = 1}") {
+  def canOverwrite: Unit = checkCompile("frontend", "class A{ val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       class Transformation extends MiniPhaseTransform {
@@ -84,7 +84,7 @@ class TreeTransformerTest extends DottyTest {
   }
 
   @Test
-  def transformationOrder = checkCompile("frontend", "class A{ val d = 1}") {
+  def transformationOrder: Unit = checkCompile("frontend", "class A{ val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       class Transformation1 extends MiniPhaseTransform {
@@ -130,7 +130,7 @@ class TreeTransformerTest extends DottyTest {
   }
 
   @Test
-  def invocationCount = checkCompile("frontend", "class A{ val d = 1}") {
+  def invocationCount: Unit = checkCompile("frontend", "class A{ val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       var transformed1 = 0


### PR DESCRIPTION
This solves the issue @bbarker was having with regards to runs.

Second commit simply cleans up formatting of ErrorMessagesTests file.