### PR TITLE
Fix position of implicit conversions for IDEs

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -773,7 +773,7 @@ trait Implicits { self: Typer =>
       def typedImplicit(cand: Candidate)(implicit ctx: Context): SearchResult = track("typedImplicit") { ctx.traceIndented(i"typed implicit ${cand.ref}, pt = $pt, implicitsEnabled == ${ctx.mode is ImplicitsEnabled}", implicits, show = true) {
         assert(constr eq ctx.typerState.constraint)
         val ref = cand.ref
-        var generated: Tree = tpd.ref(ref).withPos(pos)
+        var generated: Tree = tpd.ref(ref).withPos(pos.startPos)
         if (!argument.isEmpty)
           generated = typedUnadapted(
             untpd.Apply(untpd.TypedSplice(generated), untpd.TypedSplice(argument) :: Nil),


### PR DESCRIPTION
In f24190d5c60c4e019fba97425b6f3b10167a039d the position was changed to
be zero-extent so that hover-on-type and other IDE features would work
correctly for expressions that get implicitly converted.
In 8a60a204589f16eede777c257559806f9a477d30 this got reverted without
explanation, I assume that this was an error so I'm now restoring it.