### PR TITLE
Refine purity check

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1709,7 +1709,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         traverse(stats ++ rest)
       case stat :: rest =>
         val stat1 = typed(stat)(ctx.exprContext(stat, exprOwner))
-        if (!ctx.isAfterTyper && isPureExpr(stat1))
+        if (!ctx.isAfterTyper && isPureExpr(stat1) && !stat1.tpe.isRef(defn.UnitClass))
           ctx.warning(em"a pure expression does nothing in statement position", stat.pos)
         buf += stat1
         traverse(rest)

--- a/tests/neg/customArgs/xfatalWarnings.scala
+++ b/tests/neg/customArgs/xfatalWarnings.scala
@@ -4,4 +4,8 @@ object xfatalWarnings {
   opt match { // error when running with -Xfatal-warnings
     case None =>
   }
+
+  object Test {
+    while (true) {} // should be ok. no "pure expression does nothing in statement position" issued.
+  }
 }


### PR DESCRIPTION
Refine "a pure expression does nothing in statement position" warning.
It should not be issued if the expression has type Unit. Otherwise `()`
will trigger a warning.