### PR TITLE
Fix #2833: Fixes to harmonize

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -557,7 +557,8 @@ trait Checking {
       case tp => tp.widenTermRefExpr match {
         case tp: ConstantType if isPureExpr(tree) => // ok
         case tp if defn.isFunctionType(tp) && isPureExpr(tree) => // ok
-        case _ => ctx.error(em"$what must be a constant expression or a function", tree.pos)
+        case _ =>
+          if (!ctx.erasedTypes) ctx.error(em"$what must be a constant expression or a function", tree.pos)
       }
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2098,8 +2098,11 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
             case _: RefTree | _: Literal
             if !isVarPattern(tree) &&
                !(tree.tpe <:< pt)(ctx.addMode(Mode.GADTflexible)) =>
-              val tp1 :: tp2 :: Nil = harmonizeTypes(pt :: wtp :: Nil)
-              checkCanEqual(tp1, tp2, tree.pos)(ctx.retractMode(Mode.Pattern))
+              val cmp =
+                untpd.Apply(
+                  untpd.Select(untpd.TypedSplice(tree), nme.EQ),
+                  untpd.TypedSplice(dummyTreeOfType(pt)))
+              typedExpr(cmp, defn.BooleanType)(ctx.retractMode(Mode.Pattern))
             case _ =>
           }
           tree

--- a/docs/docs/reference/dropped/weak-conformance.md
+++ b/docs/docs/reference/dropped/weak-conformance.md
@@ -3,7 +3,7 @@ layout: doc-page
 title: Dropped: Weak Conformance
 ---
 
-In some situations, Scala used a {\em weak conformance} relation when
+In some situations, Scala used a _weak conformance_ relation when
 testing type compatibility or computing the least upper bound of a set
 of types.  The principal motivation behind weak conformance was to
 make as expression like this have type `List[Double]`:
@@ -24,12 +24,12 @@ A less obvious example is the following one, which was also typed as a
     List(n, c, d) // used to be: List[Double], now: List[AnyVal]
 
 Here, it is less clear why the type should be widened to
-`List[Double]`, a `List[AnyVal` seems to be an equally valid -- and
+`List[Double]`, a `List[AnyVal]` seems to be an equally valid -- and
 more principled -- choice.
 
 To simplify the underlying type theory, Dotty drops the notion of weak
 conformance altogether. Instead, it provides more flexibility when
-assigning a type to a constant expression. The rule is:
+assigning a type to a constant expression. The new rule is:
 
  - If a list of expressions `Es` appears as one of
 

--- a/docs/docs/reference/dropped/weak-conformance.md
+++ b/docs/docs/reference/dropped/weak-conformance.md
@@ -1,0 +1,78 @@
+---
+layout: doc-page
+title: Dropped: Weak Conformance
+---
+
+In some situations, Scala used a {\em weak conformance} relation when
+testing type compatibility or computing the least upper bound of a set
+of types.  The principal motivation behind weak conformance was to
+make as expression like this have type `List[Double]`:
+
+    List(1.0, math.sqrt(3.0), 0, -3.3) // : List[Double]
+
+It's "obvious" that this should be a `List[Double]`. However, without
+some special provision, the least upper bound of the lists's element
+types `(Double, Double, Int, Double)` would be `AnyVal`, hence the list
+expression would be given type `List[AnyVal]`.
+
+A less obvious example is the following one, which was also typed as a
+`List[Double]`, using the weak conformance relation.
+
+    val n: Int = 3
+    val c: Char = 'X'
+    val n: Double = math.sqrt(3.0)
+    List(n, c, d) // used to be: List[Double], now: List[AnyVal]
+
+Here, it is less clear why the type should be widened to
+`List[Double]`, a `List[AnyVal` seems to be an equally valid -- and
+more principled -- choice.
+
+To simplify the underlying type theory, Dotty drops the notion of weak
+conformance altogether. Instead, it provides more flexibility when
+assigning a type to a constant expression. The rule is:
+
+ - If a list of expressions `Es` appears as one of
+
+     - the elements of a vararg parameter, or
+     - the alternatives of an if-then-else or match expression, or
+     - the body and catch results of a try expression,
+
+   and all expressions have primitive numeric types, but they do not
+   all have the same type, then the following is attempted: Every
+   constant expression `E` in `Es` is widened to the least primitive
+   numeric value type above the types of all expressions in `Es`. Here
+   _above_ and _least_ are interpreted according to the ordering given
+   below.
+
+
+                  Double
+                 /      \
+               Long    Float
+                 \     /
+                   Int
+                 /    \
+              Short   Char
+                |
+              Byte
+
+    If these widenings lead to all expressions `Es` having the same type,
+    we use the transformed list of expressions instead of `Es`, otherwise
+    we use `Es` unchanged.
+
+__Examples:__
+
+    inline val b: Byte = 3
+    inline val s: Short = 33
+    def f(): Int = b + s
+    List(b, s, 'a')     : List[Int]
+    List(b, s, 'a', f()): List[Int]
+    List(1.0f, 'a', 0)  : List[Float]
+    List(1.0f, 1L)      : List[Double]
+    List(1.0f, 1L, f()) : List[AnyVal]
+
+The expression on the last line has type `List[AnyVal]`, since widenings
+only affect constants. Hence, `1.0f` and `1L` are widened to `Double`,
+but `f()` still has type `Int`. The elements don't agree on a type after
+widening, hence the expressions are left unchanged.
+
+

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -95,6 +95,8 @@ sidebar:
               url: docs/reference/dropped/xml.html
             - title: Auto-Application
               url: docs/reference/dropped/auto-apply.html
+            - title: Weak Conformance
+              url: docs/reference/dropped/weak-conformance.html
     - title: Contributing
       subsection:
         - title: Getting Started

--- a/tests/pos/harmonize.scala
+++ b/tests/pos/harmonize.scala
@@ -3,25 +3,40 @@ object Test {
   def main(args: Array[String]) = {
     val x = true
     val n = 1
+    inline val nn = 2
     val y = if (x) 'A' else n
     val z: Int = y
 
-    val yy = n match {
+    val yy1 = n match {
       case 1 => 'A'
       case 2 => n
       case 3 => 1.0
     }
-    val zz: Double = yy
+    val zz1: AnyVal = yy1 // no widening
+
+    val yy2 = n match {
+      case 1 => 'A'
+      case 2 => nn
+      case 3 => 1.0f
+    }
+    val zz2: Float = yy2 // widening to Float
+
+    val yy3 = n match {
+      case 1 => 'A'
+      case 2 => 3L
+      case 3 => 1.0f
+    }
+    val zz3: Double = yy3 // widening to Double
 
     val a = try {
       'A'
     } catch {
-      case ex: Exception => n
+      case ex: Exception => nn
       case ex: Error => 3L
     }
     val b: Long = a
 
-    val xs = List(1.0, n, 'c')
+    val xs = List(1.0, nn, 'c')
     val ys: List[Double] = xs
   }
 

--- a/tests/pos/harmonize.scala
+++ b/tests/pos/harmonize.scala
@@ -38,6 +38,21 @@ object Test {
 
     val xs = List(1.0, nn, 'c')
     val ys: List[Double] = xs
+
   }
 
+  inline val b = 33
+  def f(): Int = b + 1
+  val a1 = Array(b, 33, 'a')
+  val b1: Array[Int] = a1
+  val a2 = Array(b, 33, 'a', f())
+  val b2: Array[Int] = a2
+  val a3 = Array(1.0f, 'a', 0)
+  val b3: Array[Float] = a3
+  val a4 = Array(1.0f, 1L)
+  val b4: Array[Double] = a4
+  val a5 = Array(1.0f, 1L, f())
+  val b5: Array[AnyVal] = a5
+  val a6 = Array(1.0f, 1234567890)
+  val b6: Array[AnyVal] = a6
 }

--- a/tests/pos/i2833.scala
+++ b/tests/pos/i2833.scala
@@ -1,0 +1,9 @@
+object a {
+  val x: scala.Any =
+    if (true)
+      0L
+    else if (false)
+      (0: Int)
+    else
+      null
+}


### PR DESCRIPTION
We try to replace harmonize with something weaker that only applies to constants. 

As a first step: make pattern matching typecheck more principled

When checking a pattern `p` against a selector `s` we should check
that `p == s` is typeable. So far we did this in a roundabout way
by calling harmonizeType and canCheckEquals directly. But that
is correct only if there are no user-defined definitions of `==`.

The new algorithm for harmonize is described a new section of the language reference.
