### PR TITLE
Fixes to TastyUnpickler: correctly handle unpicking of trait setters.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -49,7 +49,7 @@ class TastyUnpickler(reader: TastyReader) {
       case UTF8 =>
         goto(end)
         termName(bytes, start.index, length)
-      case QUALIFIED | FLATTENED | EXPANDED | EXPANDPREFIX =>
+      case QUALIFIED | FLATTENED | EXPANDED | EXPANDPREFIX | TRAITSETTER =>
         qualifiedNameKindOfTag(tag)(readName(), readName().asSimpleName)
       case UNIQUE =>
         val separator = readName().toString


### PR DESCRIPTION
It was handled by wrong case before.