### PR TITLE
Fix crash when compiling collection strawman.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -791,7 +791,7 @@ object SymDenotations {
      */
     /** The class implementing this module, NoSymbol if not applicable. */
     final def moduleClass(implicit ctx: Context): Symbol = {
-      def notFound = { println(s"missing module class for $name: $myInfo"); NoSymbol }
+      def notFound = { completions.println(s"missing module class for $name: $myInfo"); NoSymbol }
       if (this is ModuleVal)
         myInfo match {
           case info: TypeRef           => info.symbol

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -60,7 +60,6 @@ object Implicits {
 
     /** Return those references in `refs` that are compatible with type `pt`. */
     protected def filterMatching(pt: Type)(implicit ctx: Context): List[Candidate] = track("filterMatching") {
-      val ptNorm = normalize(pt, pt) // `pt` could be implicit function types, check i2749
 
       def refMatches(ref: TermRef)(implicit ctx: Context) = /*ctx.traceIndented(i"refMatches $ref $pt")*/ {
 
@@ -124,8 +123,10 @@ object Implicits {
             record("discarded eligible")
             false
           }
-          else
+          else {
+            val ptNorm = normalize(pt, pt) // `pt` could be implicit function types, check i2749
             NoViewsAllowed.isCompatible(normalize(ref, pt), ptNorm)
+          }
         }
       }
 


### PR DESCRIPTION
A computation of `ptNorm` was done too early, and failed
on NoContext.