### PR TITLE
Make stubs generated by Java parser more robust.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -317,6 +317,8 @@ class Definitions {
     def Predef_conforms(implicit ctx: Context) = Predef_conformsR.symbol
     lazy val Predef_classOfR = ScalaPredefModule.requiredMethodRef("classOf")
     def Predef_classOf(implicit ctx: Context) = Predef_classOfR.symbol
+    lazy val Predef_undefinedR = ScalaPredefModule.requiredMethodRef("???")
+    def Predef_undefined(implicit ctx: Context) = Predef_undefinedR.symbol
 
   lazy val ScalaRuntimeModuleRef = ctx.requiredModuleRef("scala.runtime.ScalaRunTime")
   def ScalaRuntimeModule(implicit ctx: Context) = ScalaRuntimeModuleRef.symbol

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -107,7 +107,7 @@ object JavaParsers {
     def arrayOf(tpt: Tree) =
       AppliedTypeTree(Ident(nme.Array.toTypeName), List(tpt))
 
-    def unimplementedExpr = Ident("???".toTermName)
+    def unimplementedExpr(implicit ctx: Context) = ref(defn.Predef_undefinedR)
 
     def makeTemplate(parents: List[Tree], stats: List[Tree], tparams: List[TypeDef], needsDummyConstr: Boolean) = {
       def pullOutFirstConstr(stats: List[Tree]): (Tree, List[Tree]) = stats match {

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -107,7 +107,8 @@ object JavaParsers {
     def arrayOf(tpt: Tree) =
       AppliedTypeTree(Ident(nme.Array.toTypeName), List(tpt))
 
-    def unimplementedExpr(implicit ctx: Context) = ref(defn.Predef_undefinedR)
+    def unimplementedExpr(implicit ctx: Context) =
+      Select(Select(rootDot(nme.scala_), nme.Predef), nme.???)
 
     def makeTemplate(parents: List[Tree], stats: List[Tree], tparams: List[TypeDef], needsDummyConstr: Boolean) = {
       def pullOutFirstConstr(stats: List[Tree]): (Tree, List[Tree]) = stats match {


### PR DESCRIPTION
??? as an identifier won't cut it if Predef is not imported. We now generate a TypedSplice with a symbolic reference instead. 

Review by @julienrf?