### PR TITLE
Fix #2869: Have constructors run after group of Memoize

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -87,8 +87,8 @@ class Compiler {
            new LazyVals,            // Expand lazy vals
            new Memoize,             // Add private fields to getters and setters
            new NonLocalReturns,     // Expand non-local returns
-           new CapturedVars,        // Represent vars captured by closures as heap objects
-           new Constructors,        // Collect initialization code in primary constructors
+           new CapturedVars),       // Represent vars captured by closures as heap objects
+      List(new Constructors,        // Collect initialization code in primary constructors
                                     // Note: constructors changes decls in transformTemplate, no InfoTransformers should be added after it
            new FunctionalInterfaces, // Rewrites closures to implement @specialized types of Functions.
            new GetClass,            // Rewrites getClass calls on primitive types.

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -37,11 +37,7 @@ class Constructors extends MiniPhaseTransform with IdentityDenotTransformer { th
     // This test is done in the right-hand side of a value definition. If Memoize
     // was in the same group as Constructors, the test on the rhs ident would be
     // performed before the rhs undergoes the owner change. This would lead
-    // to more symbls being retained as parameters. Test case is
-    //
-    //     dotc tests/pos/captuing.scala -Xprint:constr
-    //
-    // `sf` should not be retained as a filed of class `MT`.
+    // to more symbols being retained as parameters. Test case in run/capturing.scala.
 
   /** The private vals that are known to be retained as class fields */
   private val retainedPrivateVals = mutable.Set[Symbol]()

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -66,7 +66,7 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
 
   override def relaxedTyping = true
 
-  override def runsAfter: Set[Class[_ <: Phase]] = Set(classOf[Constructors], classOf[HoistSuperArgs])
+  override def runsAfterGroupsOf: Set[Class[_ <: Phase]] = Set(classOf[Constructors], classOf[HoistSuperArgs])
     // Constructors has to happen before LambdaLift because the lambda lift logic
     // becomes simpler if it can assume that parameter accessors have already been
     // converted to parameters in super calls. Without this it is very hard to get

--- a/tests/run/capturing.check
+++ b/tests/run/capturing.check
@@ -1,0 +1,1 @@
+private final java.lang.String MT.s

--- a/tests/run/capturing.scala
+++ b/tests/run/capturing.scala
@@ -1,0 +1,9 @@
+class MT(sf: MT => String) {
+  // `s` is retained as a field, but `sf` should not be.
+  val s = sf(this)
+}
+object Test extends App {
+  def printFields(obj: Any) =
+    println(obj.getClass.getDeclaredFields.map(_.toString).sorted.deep.mkString("\n"))
+  printFields(new MT(_ => ""))
+}

--- a/tests/run/variable-pattern-access.check
+++ b/tests/run/variable-pattern-access.check
@@ -1,7 +1,6 @@
 # Fields of A:
 private final int A.a
 private final int A.b
-private final scala.Tuple2 A.$1$
 # Methods of A:
 public int A.a()
 public int A.b()


### PR DESCRIPTION
As explained in the code comment, the two get too entangled otherwise
which leads to parameters being stored as class fields when they should not.

This was the most obvious source of memory leaks in the IDE. Once this is fixed
we can check whether there are others.