### PR TITLE
Fix #2871: Recognize more types as structural selections

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -659,10 +659,8 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
           rname == tree.name || hasRefinement(parent)
         case tp: TypeProxy =>
           hasRefinement(tp.underlying)
-        case tp: OrType =>
+        case tp: AndOrType =>
           hasRefinement(tp.tp1) || hasRefinement(tp.tp2)
-        case tp: AndType =>
-          hasRefinement(tp.tp1) && hasRefinement(tp.tp2)
         case _ =>
           false
       }

--- a/tests/neg/i2871.scala
+++ b/tests/neg/i2871.scala
@@ -1,0 +1,5 @@
+class Cont[A0](x0: A0) { type A = A0; val x: A = x0 }
+object Test {
+  val c: { type A; val x: A } & { type A = Int } = new Cont(1)
+  println(c.x : Int) // error: not an instance of Selectable
+}


### PR DESCRIPTION
The previous condition was flawed because a type such as

    { val x: Int } && {}

should still be recognized as a structural selection of `x`. @LPTK, do you want to review?