### PR TITLE
Fix #2771: pre-check kinds at Typer

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2732,20 +2732,27 @@ object Types {
     protected def paramName(param: ParamInfo.Of[N])(implicit ctx: Context): N =
       param.paramName
 
+    protected def toPInfo(tp: Type)(implicit ctx: Context): PInfo
+
     def fromParams[PI <: ParamInfo.Of[N]](params: List[PI], resultType: Type)(implicit ctx: Context): Type =
       if (params.isEmpty) resultType
       else apply(params.map(paramName))(
-        tl => params.map(param => tl.integrate(params, param.paramInfo).asInstanceOf[PInfo]),
+        tl => params.map(param => toPInfo(tl.integrate(params, param.paramInfo))),
         tl => tl.integrate(params, resultType))
   }
 
   abstract class TermLambdaCompanion[LT <: TermLambda]
   extends LambdaTypeCompanion[TermName, Type, LT] {
+    def toPInfo(tp: Type)(implicit ctx: Context): Type = tp
     def syntheticParamName(n: Int) = nme.syntheticParamName(n)
   }
 
   abstract class TypeLambdaCompanion[LT <: TypeLambda]
   extends LambdaTypeCompanion[TypeName, TypeBounds, LT] {
+    def toPInfo(tp: Type)(implicit ctx: Context): TypeBounds = (tp: @unchecked) match {
+      case tp: TypeBounds => tp
+      case tp: ErrorType => TypeAlias(tp)
+    }
     def syntheticParamName(n: Int) = tpnme.syntheticTypeParamName(n)
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -100,6 +100,15 @@ object Checking {
     checkValidIfHKApply(ctx.addMode(Mode.AllowLambdaWildcardApply))
   }
 
+  def checkKind(arg: Tree, paramBounds: TypeBounds)(implicit ctx: Context): Tree =
+    if (arg.tpe.isHK && !paramBounds.isHK)
+      errorTree(arg, em"${arg.tpe} takes type parameters")
+    else
+      arg
+
+  def checkKinds(args: List[Tree], paramBoundss: List[TypeBounds])(implicit ctx: Context): List[Tree] =
+    args.zipWithConserve(paramBoundss)(checkKind)
+
   /** Check that `tp` refers to a nonAbstract class
    *  and that the instance conforms to the self type of the created class.
    */

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -110,9 +110,14 @@ object Checking {
    *  A test case is neg/i2771.scala.
    */
   def checkKindRank(arg: Tree, paramBounds: TypeBounds)(implicit ctx: Context): Tree = {
+    def result(tp: Type): Type = tp match {
+      case tp: HKTypeLambda => tp.resultType
+      case tp: TypeProxy => result(tp.superType)
+      case _ => defn.AnyType
+    }
     def kindOK(argType: Type, boundType: Type): Boolean =
       !argType.isHK ||
-        boundType.isHK && kindOK(argType.resultType, boundType.resultType)
+        boundType.isHK && kindOK(result(argType), result(boundType))
     if (kindOK(arg.tpe, paramBounds.hi)) arg
     else errorTree(arg, em"${arg.tpe} takes type parameters")
   }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -838,9 +838,9 @@ class Namer { typer: Typer =>
        * only if parent type contains uninstantiated type parameters.
        */
       def parentType(parent: untpd.Tree)(implicit ctx: Context): Type =
-        if (parent.isType) {
+        if (parent.isType)
           typedAheadType(parent, AnyTypeConstructorProto).tpe
-        } else {
+        else {
           val (core, targs) = stripApply(parent) match {
             case TypeApply(core, targs) => (core, targs)
             case core => (core, Nil)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -795,10 +795,16 @@ class Namer { typer: Typer =>
         nestedCtx = localContext(sym).setNewScope
         myTypeParams = {
           implicit val ctx = nestedCtx
-          val tparams = original.rhs match {
-            case LambdaTypeTree(tparams, _) => tparams
+          def typeParamTrees(tdef: Tree): List[TypeDef] = tdef match {
+            case TypeDef(_, original) =>
+              original match {
+                case LambdaTypeTree(tparams, _) => tparams
+                case original: DerivedFromParamTree => typeParamTrees(original.watched)
+                case _ => Nil
+              }
             case _ => Nil
           }
+          val tparams = typeParamTrees(original)
           completeParams(tparams)
           tparams.map(symbolOfTree(_).asType)
         }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -14,7 +14,7 @@ import NameOps._
 import collection.mutable
 import reporting.diagnostic.Message
 import reporting.diagnostic.messages._
-import Checking.{checkKind, checkKinds, checkNoPrivateLeaks}
+import Checking.{checkStarKind, checkStarKinds, checkNoPrivateLeaks}
 
 trait TypeAssigner {
   import tpd._
@@ -358,7 +358,7 @@ trait TypeAssigner {
             else if (!paramNames.contains(name))
               ctx.error(s"undefined parameter name, required: ${paramNames.mkString(" or ")}", arg.pos)
             else
-              namedArgMap(name) = checkKind(arg, paramBoundsByName(name.asTypeName)).tpe
+              namedArgMap(name) = checkStarKind(arg, paramBoundsByName(name.asTypeName)).tpe
 
           // Holds indexes of non-named typed arguments in paramNames
           val gapBuf = new mutable.ListBuffer[Int]
@@ -391,7 +391,7 @@ trait TypeAssigner {
           }
         }
         else {
-          val argTypes = checkKinds(args, pt.paramInfos).tpes
+          val argTypes = checkStarKinds(args, pt.paramInfos).tpes
           if (sameLength(argTypes, paramNames) || ctx.phase.prev.relaxedTyping) pt.instantiate(argTypes)
           else wrongNumberOfTypeArgs(fn.tpe, pt.typeParams, args, tree.pos)
         }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -14,7 +14,7 @@ import NameOps._
 import collection.mutable
 import reporting.diagnostic.Message
 import reporting.diagnostic.messages._
-import Checking.{checkStarKind, checkStarKinds, checkNoPrivateLeaks}
+import Checking.{checkKindRank, checkKindRanks, checkNoPrivateLeaks}
 
 trait TypeAssigner {
   import tpd._
@@ -358,7 +358,7 @@ trait TypeAssigner {
             else if (!paramNames.contains(name))
               ctx.error(s"undefined parameter name, required: ${paramNames.mkString(" or ")}", arg.pos)
             else
-              namedArgMap(name) = checkStarKind(arg, paramBoundsByName(name.asTypeName)).tpe
+              namedArgMap(name) = checkKindRank(arg, paramBoundsByName(name.asTypeName)).tpe
 
           // Holds indexes of non-named typed arguments in paramNames
           val gapBuf = new mutable.ListBuffer[Int]
@@ -391,7 +391,7 @@ trait TypeAssigner {
           }
         }
         else {
-          val argTypes = checkStarKinds(args, pt.paramInfos).tpes
+          val argTypes = checkKindRanks(args, pt.paramInfos).tpes
           if (sameLength(argTypes, paramNames) || ctx.phase.prev.relaxedTyping) pt.instantiate(argTypes)
           else wrongNumberOfTypeArgs(fn.tpe, pt.typeParams, args, tree.pos)
         }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -14,6 +14,7 @@ import NameOps._
 import collection.mutable
 import reporting.diagnostic.Message
 import reporting.diagnostic.messages._
+import Checking.{checkKind, checkKinds, checkNoPrivateLeaks}
 
 trait TypeAssigner {
   import tpd._
@@ -134,8 +135,7 @@ trait TypeAssigner {
     avoid(expr.tpe, localSyms(bindings).filter(_.isTerm))
 
   def avoidPrivateLeaks(sym: Symbol, pos: Position)(implicit ctx: Context): Type =
-    if (!sym.is(SyntheticOrPrivate) && sym.owner.isClass)
-      Checking.checkNoPrivateLeaks(sym, pos)
+    if (!sym.is(SyntheticOrPrivate) && sym.owner.isClass) checkNoPrivateLeaks(sym, pos)
     else sym.info
 
   def seqToRepeated(tree: Tree)(implicit ctx: Context): Tree =
@@ -348,6 +348,8 @@ trait TypeAssigner {
       case pt: TypeLambda =>
         val paramNames = pt.paramNames
         if (hasNamedArg(args)) {
+          val paramBoundsByName = paramNames.zip(pt.paramInfos).toMap
+
           // Type arguments which are specified by name (immutable after this first loop)
           val namedArgMap = new mutable.HashMap[Name, Type]
           for (NamedArg(name, arg) <- args)
@@ -356,7 +358,7 @@ trait TypeAssigner {
             else if (!paramNames.contains(name))
               ctx.error(s"undefined parameter name, required: ${paramNames.mkString(" or ")}", arg.pos)
             else
-              namedArgMap(name) = arg.tpe
+              namedArgMap(name) = checkKind(arg, paramBoundsByName(name.asTypeName)).tpe
 
           // Holds indexes of non-named typed arguments in paramNames
           val gapBuf = new mutable.ListBuffer[Int]
@@ -389,7 +391,7 @@ trait TypeAssigner {
           }
         }
         else {
-          val argTypes = args.tpes
+          val argTypes = checkKinds(args, pt.paramInfos).tpes
           if (sameLength(argTypes, paramNames) || ctx.phase.prev.relaxedTyping) pt.instantiate(argTypes)
           else wrongNumberOfTypeArgs(fn.tpe, pt.typeParams, args, tree.pos)
         }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -14,7 +14,7 @@ import NameOps._
 import collection.mutable
 import reporting.diagnostic.Message
 import reporting.diagnostic.messages._
-import Checking.{checkKindRank, checkKindRanks, checkNoPrivateLeaks}
+import Checking.{preCheckKind, preCheckKinds, checkNoPrivateLeaks}
 
 trait TypeAssigner {
   import tpd._
@@ -358,7 +358,7 @@ trait TypeAssigner {
             else if (!paramNames.contains(name))
               ctx.error(s"undefined parameter name, required: ${paramNames.mkString(" or ")}", arg.pos)
             else
-              namedArgMap(name) = checkKindRank(arg, paramBoundsByName(name.asTypeName)).tpe
+              namedArgMap(name) = preCheckKind(arg, paramBoundsByName(name.asTypeName)).tpe
 
           // Holds indexes of non-named typed arguments in paramNames
           val gapBuf = new mutable.ListBuffer[Int]
@@ -391,7 +391,7 @@ trait TypeAssigner {
           }
         }
         else {
-          val argTypes = checkKindRanks(args, pt.paramInfos).tpes
+          val argTypes = preCheckKinds(args, pt.paramInfos).tpes
           if (sameLength(argTypes, paramNames) || ctx.phase.prev.relaxedTyping) pt.instantiate(argTypes)
           else wrongNumberOfTypeArgs(fn.tpe, pt.typeParams, args, tree.pos)
         }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1140,7 +1140,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         }
         args.zipWithConserve(tparams)(typedArg(_, _)).asInstanceOf[List[Tree]]
       }
-      val args2 = checkStarKinds(args1, tparams.map(_.paramInfo.bounds))
+      val args2 = checkKindRanks(args1, tparams.map(_.paramInfo.bounds))
       // check that arguments conform to bounds is done in phase PostTyper
       assignType(cpy.AppliedTypeTree(tree)(tpt1, args2), tpt1, args2)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1140,7 +1140,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         }
         args.zipWithConserve(tparams)(typedArg(_, _)).asInstanceOf[List[Tree]]
       }
-      val args2 = checkKinds(args1, tparams.map(_.paramInfo.bounds))
+      val args2 = checkStarKinds(args1, tparams.map(_.paramInfo.bounds))
       // check that arguments conform to bounds is done in phase PostTyper
       assignType(cpy.AppliedTypeTree(tree)(tpt1, args2), tpt1, args2)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1140,7 +1140,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         }
         args.zipWithConserve(tparams)(typedArg(_, _)).asInstanceOf[List[Tree]]
       }
-      val args2 = checkKindRanks(args1, tparams.map(_.paramInfo.bounds))
+      val args2 = preCheckKinds(args1, tparams.map(_.paramInfo.bounds))
       // check that arguments conform to bounds is done in phase PostTyper
       assignType(cpy.AppliedTypeTree(tree)(tpt1, args2), tpt1, args2)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1140,8 +1140,9 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         }
         args.zipWithConserve(tparams)(typedArg(_, _)).asInstanceOf[List[Tree]]
       }
+      val args2 = checkKinds(args1, tparams.map(_.paramInfo.bounds))
       // check that arguments conform to bounds is done in phase PostTyper
-      assignType(cpy.AppliedTypeTree(tree)(tpt1, args1), tpt1, args1)
+      assignType(cpy.AppliedTypeTree(tree)(tpt1, args2), tpt1, args2)
     }
   }
 

--- a/tests/neg/i1652.scala
+++ b/tests/neg/i1652.scala
@@ -1,5 +1,5 @@
 object Test {
-  val v: Array[Array[Array]] = Array()    // error // error
+  val v: Array[Array[Array]] = Array()    // error: Array takes type parameters
   def f[T](w: Array[Array[T]]) = { for (r <- w) () }
-  f(v) // error
+  f(v)
 }

--- a/tests/neg/i2771.scala
+++ b/tests/neg/i2771.scala
@@ -6,8 +6,12 @@ trait D { type M >: B }
 object Test {
   def test(x: C with D): Unit = {
     def f(y: x.M)(z: y.L[y.L]) = z      // error: y.L takes type parameters
-    f(new B { type L[F[_]] = F[F] })(1)
+    f(new B { type L[F[_]] = F[F] })(1) // error: F takes type parameters (follow-on-error)
   }
+
+  type LB[F[_]]
+
+  type LL[F[_]] <: LB[F] // ok
 
   def foo[X[_] <: Any]() = ()
   foo[Int]()  // an error would be raised later, during PostTyper.
@@ -15,6 +19,6 @@ object Test {
   def bar[X, Y]() = ()
   bar[List, Int]()   // error: List takes type parameters
 
-  bar[Y = List, X = Int]  // error: List takes type parameters
+  bar[Y = List, X = Int]()  // error: List takes type parameters
 
 }

--- a/tests/neg/i2771.scala
+++ b/tests/neg/i2771.scala
@@ -1,0 +1,20 @@
+trait A { type L[X] }
+trait B { type L }
+trait C { type M <: A }
+trait D { type M >: B }
+
+object Test {
+  def test(x: C with D): Unit = {
+    def f(y: x.M)(z: y.L[y.L]) = z      // error: y.L takes type parameters
+    f(new B { type L[F[_]] = F[F] })(1) // error: F takes type parameters
+  }
+
+  def foo[X[_] <: Any]() = ()
+  foo[Int]()  // should be an error
+
+  def bar[X, Y]() = ()
+  bar[List, Int]()   // error: List takes type parameters
+
+  bar[Y = List, X = Int]  // error: List takes type parameters
+
+}

--- a/tests/neg/i2771.scala
+++ b/tests/neg/i2771.scala
@@ -6,11 +6,11 @@ trait D { type M >: B }
 object Test {
   def test(x: C with D): Unit = {
     def f(y: x.M)(z: y.L[y.L]) = z      // error: y.L takes type parameters
-    f(new B { type L[F[_]] = F[F] })(1) // error: F takes type parameters
+    f(new B { type L[F[_]] = F[F] })(1)
   }
 
   def foo[X[_] <: Any]() = ()
-  foo[Int]()  // should be an error
+  foo[Int]()  // an error would be raised later, during PostTyper.
 
   def bar[X, Y]() = ()
   bar[List, Int]()   // error: List takes type parameters

--- a/tests/neg/i2771.scala
+++ b/tests/neg/i2771.scala
@@ -5,8 +5,8 @@ trait D { type M >: B }
 
 object Test {
   def test(x: C with D): Unit = {
-    def f(y: x.M)(z: y.L[y.L]) = z      // error: y.L takes type parameters
-    f(new B { type L[F[_]] = F[F] })(1) // error: F takes type parameters (follow-on-error)
+    def f(y: x.M)(z: y.L[y.L]) = z      // error: y.L has wrong kind
+    f(new B { type L[F[_]] = F[F] })(1) // error: F has wrong kind
   }
 
   type LB[F[_]]
@@ -17,8 +17,8 @@ object Test {
   foo[Int]()  // an error would be raised later, during PostTyper.
 
   def bar[X, Y]() = ()
-  bar[List, Int]()   // error: List takes type parameters
+  bar[List, Int]()   // error: List has wrong kind
 
-  bar[Y = List, X = Int]()  // error: List takes type parameters
+  bar[Y = List, X = Int]()  // error: List has wrong kind
 
 }

--- a/tests/neg/i2771b.scala
+++ b/tests/neg/i2771b.scala
@@ -1,0 +1,11 @@
+trait A { type L[X[_]] }
+trait B { type L }
+trait C { type M <: A }
+trait D { type M >: B }
+
+object Test {
+  def test(x: C with D): Unit = {
+    def f(y: x.M)(z: y.L[y.L]) = z          // error: y.L takes type parameters
+    f(new B { type L[F[_[_]]] = F[F] })(1)  // error: F takes type parameters
+  }
+}

--- a/tests/neg/i2771b.scala
+++ b/tests/neg/i2771b.scala
@@ -5,7 +5,7 @@ trait D { type M >: B }
 
 object Test {
   def test(x: C with D): Unit = {
-    def f(y: x.M)(z: y.L[y.L]) = z          // error: y.L takes type parameters
-    f(new B { type L[F[_[_]]] = F[F] })(1)  // error: F takes type parameters
+    def f(y: x.M)(z: y.L[y.L]) = z          // error: y.L has wrong kind
+    f(new B { type L[F[_[_]]] = F[F] })(1)  // error: F has wrong kind
   }
 }

--- a/tests/neg/i2771c.scala
+++ b/tests/neg/i2771c.scala
@@ -1,0 +1,11 @@
+trait A { type L[X[_]] }
+trait B { type L }
+trait C { type M <: A }
+trait D { type M >: B }
+
+object Test {
+  def test(x: D with C): Unit = {
+    def f(y: x.M)(z: y.L[y.L]) = z    // error: y.L has wrong kind
+    new B { type L[F[_[_]]] = F[F] }  // error: F has wrong kind
+  }
+}


### PR DESCRIPTION
We normally do kind checking during PostTyper, together with bounds checking. 
However, this is not early enough, as #2771 shows. The problem is that we can 
use ill-kinded code to construct self applications of types, which leads to general
unhappiness in the typer. Prevent that by checking the outline of kinds of types
as soon as we create them.
