### PR TITLE
More IDE work

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -61,7 +61,7 @@ object Annotations {
     def tree(implicit ctx: Context) = body
   }
 
-  case class LazyBodyAnnotation(bodyExpr: Context => Tree) extends BodyAnnotation {
+  case class LazyBodyAnnotation(private var bodyExpr: Context => Tree) extends BodyAnnotation {
     private var evaluated = false
     private var myBody: Tree = _
     def tree(implicit ctx: Context) = {
@@ -69,6 +69,7 @@ object Annotations {
       else {
         evaluated = true
         myBody = bodyExpr(ctx)
+        bodyExpr = null
       }
       myBody
     }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2156,16 +2156,14 @@ object Types {
     }
   }
 
-  case class LazyRef(refFn: () => Type) extends UncachedProxyType with ValueType {
-    private var myRefFn: () => Type = refFn
+  case class LazyRef(private var refFn: () => Type) extends UncachedProxyType with ValueType {
     private var myRef: Type = null
     private var computed = false
     def ref = {
       if (computed) assert(myRef != null)
       else {
         computed = true
-        myRef = myRefFn()
-        myRefFn = null // null out to avoid memory leak
+        myRef = refFn()
       }
       myRef
     }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2157,13 +2157,15 @@ object Types {
   }
 
   case class LazyRef(refFn: () => Type) extends UncachedProxyType with ValueType {
+    private var myRefFn: () => Type = refFn
     private var myRef: Type = null
     private var computed = false
     def ref = {
       if (computed) assert(myRef != null)
       else {
         computed = true
-        myRef = refFn()
+        myRef = myRefFn()
+        myRefFn = null // null out to avoid memory leak
       }
       myRef
     }

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -62,8 +62,8 @@ object Interactive {
       sourceSymbol(sym.owner)
     else sym
 
-  private def safely[T](default: T)(op: => T) =
-    try op catch { case ex: TypeError => default }
+  private def safely[T](op: => List[T]): List[T] =
+    try op catch { case ex: TypeError => Nil }
 
   /** Possible completions at position `pos` */
   def completions(trees: List[SourceTree], pos: SourcePosition)(implicit ctx: Context): List[Symbol] = {
@@ -89,7 +89,7 @@ object Interactive {
 
   /** Possible completions of members of `prefix` which are accessible when called inside `boundary` */
   def completions(prefix: Type, boundary: Symbol)(implicit ctx: Context): List[Symbol] =
-    safely(Nil) {
+    safely {
       val boundaryCtx = ctx.withOwner(boundary)
       prefix.memberDenots(completionsFilter, (name, buf) =>
         buf ++= prefix.member(name).altsWith(d => !d.isAbsent && d.symbol.isAccessibleFrom(prefix)(boundaryCtx))
@@ -131,7 +131,7 @@ object Interactive {
    *  @param includeReferences  If true, include references and not just definitions
    */
   def namedTrees(trees: List[SourceTree], includeReferences: Boolean, treePredicate: NameTree => Boolean)
-    (implicit ctx: Context): List[SourceTree] = safely(Nil) {
+    (implicit ctx: Context): List[SourceTree] = safely {
     val buf = new mutable.ListBuffer[SourceTree]
 
     trees foreach { case SourceTree(topTree, source) =>

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -204,7 +204,7 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
           if (enclosure.is(PackageClass)) enclosure
           else if (enclosure.isConstructor) markFree(sym, enclosure.owner.enclosure)
           else markFree(sym, enclosure.enclosure)
-        narrowLiftedOwner(enclosure, intermediate orElse sym.enclosingClass)
+        if (intermediate.exists) narrowLiftedOwner(enclosure, intermediate)
         if (!intermediate.isRealClass || enclosure.isConstructor) {
           // Constructors and methods nested inside traits get the free variables
           // of the enclosing trait or class.
@@ -384,7 +384,7 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisTransform
         local.copySymDenotation(
           owner = newOwner,
           name = newName(local),
-          initFlags = local.flags &~ Module | Private | maybeStatic,
+          initFlags = local.flags &~ Module &~ Final | Private | maybeStatic,
             // drop Module because class is no longer a singleton in the lifted context.
           info = liftedInfo(local)).installAfter(thisTransform)
       }


### PR DESCRIPTION
 - Make NamedTrees survive TypeErrors
    (Same principle as for completions applies).
 - Null out closures in LazyRef and LazyBodyAnnotation once they are evaluated.