### PR TITLE
Fix #2770: Tighten type compatibility checks for overrides

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -268,6 +268,19 @@ class TypeApplications(val self: Type) extends AnyVal {
     case _ => NoType
   }
 
+  /** Do self and other have the same kinds (not counting bounds and variances) */
+  def hasSameKindAs(other: Type)(implicit ctx: Context): Boolean = {
+    // println(i"check kind $self $other") // DEBUG
+    val selfResult = self.hkResult
+    val otherResult = other.hkResult
+    if (selfResult.exists)
+      otherResult.exists &&
+      selfResult.hasSameKindAs(otherResult) &&
+      self.typeParams.corresponds(other.typeParams)((sparam, oparam) =>
+        sparam.paramInfo.hasSameKindAs(oparam.paramInfo))
+    else !otherResult.exists
+  }
+
   /** Dealias type if it can be done without forcing the TypeRef's info */
   def safeDealias(implicit ctx: Context): Type = self match {
     case self: TypeRef if self.denot.exists && self.symbol.isAliasType =>

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -109,26 +109,9 @@ object Checking {
    *  types. Self application needs to be avoided since it can lead to stack overflows.
    *  Test cases are neg/i2771.scala and neg/i2771b.scala.
    */
-  def preCheckKind(arg: Tree, paramBounds: TypeBounds)(implicit ctx: Context): Tree = {
-    def result(tp: Type): Type = tp match {
-      case tp: HKTypeLambda => tp.resultType
-      case tp: TypeProxy => result(tp.superType)
-      case _ => defn.AnyType
-    }
-    def kindOK(argType: Type, boundType: Type): Boolean = {
-      // println(i"check kind rank2$arg $argType $boundType") // DEBUG
-      val argResult = argType.hkResult
-      val boundResult = argType.hkResult
-      if (argResult.exists)
-        boundResult.exists &&
-        kindOK(boundResult, argResult) &&
-        argType.typeParams.corresponds(boundType.typeParams)((ap, bp) =>
-          kindOK(ap.paramInfo, bp.paramInfo))
-      else !boundResult.exists
-    }
-    if (kindOK(arg.tpe, paramBounds.hi)) arg
-    else errorTree(arg, em"${arg.tpe} has wrong kind")
-  }
+  def preCheckKind(arg: Tree, paramBounds: TypeBounds)(implicit ctx: Context): Tree =
+    if (arg.tpe.hasSameKindAs(paramBounds.hi)) arg
+    else errorTree(arg, em"Type argument ${arg.tpe} has not the same kind as its bound $paramBounds")
 
   def preCheckKinds(args: List[Tree], paramBoundss: List[TypeBounds])(implicit ctx: Context): List[Tree] = {
     val args1 = args.zipWithConserve(paramBoundss)(preCheckKind)

--- a/tests/neg/i2770.scala
+++ b/tests/neg/i2770.scala
@@ -1,0 +1,14 @@
+trait A { type L }
+trait B extends A { type L[X] } // error: illegal override
+
+trait A2 { type L <: String }
+trait B2 extends A2 { type L[X] <: String } // error: illegal override
+trait C2 extends B2 { type L[X, Y] <: String } // error: illegal override
+
+trait D { type I }
+trait E extends D { type I <: String }
+trait F extends D { type I >: String }
+trait G extends E with F // ok
+
+trait H extends D { type I >: Int }
+trait H2 extends E with H // error: illegal override

--- a/tests/neg/i2771.scala
+++ b/tests/neg/i2771.scala
@@ -14,7 +14,7 @@ object Test {
   type LL[F[_]] <: LB[F] // ok
 
   def foo[X[_] <: Any]() = ()
-  foo[Int]()  // an error would be raised later, during PostTyper.
+  foo[Int]()  // error: Int has wrong kind
 
   def bar[X, Y]() = ()
   bar[List, Int]()   // error: List has wrong kind


### PR DESCRIPTION
 - We now require strict subtypes if owning classes are in
   a subclass relationship. Nonempty bounds good enough only
   if classes are unrelated.
 - We treat class types correctly by eta-expanding their types.
 - We do kind checking on types.

Previously, some illegal things slipped through because of the way Any works.
In fact a hk type like `[X] => Any` is a subtype of `Any` according to
TypeComparer. But kind checking should prevent us from making that
comparison in the first place.