### PR TITLE
Fix #2888: Avoid caching supertypes of hk apps with provisional infos

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -424,6 +424,9 @@ object Flags {
   /** A method that is known to have no default parameters */
   final val NoDefaultParams = termFlag(61, "<no-default-param>")
 
+  /** A type symbol with provisional empty bounds */
+  final val Provisional = typeFlag(61, "<provisional>")
+
   /** A denotation that is valid in all run-ids */
   final val Permanent = commonFlag(62, "<permanent>")
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3012,12 +3012,16 @@ object Types {
 
     override def superType(implicit ctx: Context): Type = {
       if (ctx.period != validSuper) {
+        var canCache = true
         cachedSuper = tycon match {
           case tp: HKTypeLambda => defn.AnyType
           case tp: TypeVar if !tp.inst.exists =>
             // supertype not stable, since underlying might change
-            return tp.underlying.applyIfParameterized(args)
-          case tp: TypeProxy => tp.superType.applyIfParameterized(args)
+            canCache = false
+            tp.underlying.applyIfParameterized(args)
+          case tp: TypeProxy =>
+            canCache = !tp.typeSymbol.is(Provisional)
+            tp.superType.applyIfParameterized(args)
           case _ => defn.AnyType
         }
         validSuper = ctx.period

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3024,7 +3024,7 @@ object Types {
             tp.superType.applyIfParameterized(args)
           case _ => defn.AnyType
         }
-        validSuper = ctx.period
+        if (canCache) validSuper = ctx.period
       }
       cachedSuper
     }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3012,19 +3012,18 @@ object Types {
 
     override def superType(implicit ctx: Context): Type = {
       if (ctx.period != validSuper) {
-        var canCache = true
+        validSuper = ctx.period
         cachedSuper = tycon match {
           case tp: HKTypeLambda => defn.AnyType
           case tp: TypeVar if !tp.inst.exists =>
             // supertype not stable, since underlying might change
-            canCache = false
+            validSuper = Nowhere
             tp.underlying.applyIfParameterized(args)
           case tp: TypeProxy =>
-            canCache = !tp.typeSymbol.is(Provisional)
+            if (tp.typeSymbol.is(Provisional)) validSuper = Nowhere
             tp.superType.applyIfParameterized(args)
           case _ => defn.AnyType
         }
-        if (canCache) validSuper = ctx.period
       }
       cachedSuper
     }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1159,6 +1159,7 @@ class Namer { typer: Typer =>
     def abstracted(tp: Type): Type = HKTypeLambda.fromParams(tparamSyms, tp)
     val dummyInfo = abstracted(TypeBounds.empty)
     sym.info = dummyInfo
+    sym.setFlag(Provisional)
       // Temporarily set info of defined type T to ` >: Nothing <: Any.
       // This is done to avoid cyclic reference errors for F-bounds.
       // This is subtle: `sym` has now an empty TypeBounds, but is not automatically

--- a/tests/pos/i2888.scala
+++ b/tests/pos/i2888.scala
@@ -1,0 +1,13 @@
+trait Foo[A, CC[X] <: Foo[X, CC, CC[X]], C <: CC[A]] {
+
+  def cc: CC[A]
+
+  def foo: Unit = ()
+
+  def bar: Unit = cc.foo
+
+}
+
+object Main {
+  def main(args: Array[String]): Unit = ()
+}


### PR DESCRIPTION
If the type constructor of a hk application has a provisional info (because
we are starting to initialize an F-bounded definition), we cannot cache its
supertype. We get an empty bound if we do.