### PR TITLE
Fix #2637: Fix confusion between AppliedTypeTree and TypeApply

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -123,7 +123,7 @@ object Inferencing {
   def inferTypeParams(tree: Tree, pt: Type)(implicit ctx: Context): Tree = tree.tpe match {
     case tl: TypeLambda =>
       val (tl1, tvars) = constrained(tl, tree)
-      val tree1 = tree.withType(tl1).appliedToTypeTrees(tvars)
+      var tree1 = AppliedTypeTree(tree.withType(tl1), tvars)
       tree1.tpe <:< pt
       fullyDefinedType(tree1.tpe, "template parent", tree.pos)
       tree1

--- a/tests/pos/i2637.scala
+++ b/tests/pos/i2637.scala
@@ -1,0 +1,10 @@
+object Hello {
+  def main(args: Array[String]): Unit = {
+    sealed trait Wat[T]
+
+    implicit def intWat: Wat[Int] = ???
+    implicit def listWat[T](implicit tWat: Wat[T]): Wat[List[T]] = new Wat{}
+
+    def stuff[T](implicit implicitWat: => Wat[List[T]]): Unit = ???
+  }
+}


### PR DESCRIPTION
inferTypeParams should have generated an AppliedTypeTree, but it did
generate a TypeApply instead.