### PR TITLE
Fix #2367: Allow SAM conversion for overloaded functions

### DIFF
--- a/tests/pos/i2367.scala
+++ b/tests/pos/i2367.scala
@@ -1,0 +1,8 @@
+object Test {
+  new Thread(() => println("hi"))
+
+  def foo(x: Int => Int, y: Int): Int = 1
+  def foo(x: Int, y: Int): Int = 2
+  foo(1, 2)
+  foo(x => x, 2)
+}


### PR DESCRIPTION
If just one of a number of alternatives takes a SAM, allow a lambda argument,
just like we do for non-overloaded methods with SAM type parameters.