### PR TITLE
Fix #2300: Try to heal subtype failures by instantiating type variables

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2191,8 +2191,11 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         val prevConstraint = localCtx.typerState.constraint
         if (isFullyDefined(wtp, force = ForceDegree.all)(localCtx) &&
             localCtx.typerState.constraint.ne(prevConstraint)) {
-          localCtx.typerState.commit()
-          return adapt(tree, pt, original)
+          val tree1 = adapt(tree, pt, original)(localCtx)
+          if (!localCtx.reporter.hasErrors) {
+            localCtx.typerState.commit()
+            return tree1
+          }
         }
       }
       // try an implicit conversion

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -383,8 +383,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
    *  prefix. If the result has another unsafe instantiation, raise an error.
    */
   private def healNonvariant[T <: Tree](tree: T, pt: Type)(implicit ctx: Context): T  =
-    if (ctx.unsafeNonvariant == ctx.runId && tree.tpe.widen.hasUnsafeNonvariant) {
-      println(i"HEAL $tree")
+    if (ctx.unsafeNonvariant == ctx.runId && tree.tpe.widen.hasUnsafeNonvariant)
       tree match {
         case tree @ Select(qual, _) if !qual.tpe.isStable =>
           val alt = typedSelect(tree, pt, Typed(qual, TypeTree(SkolemType(qual.tpe.widen))))
@@ -393,7 +392,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         case _ =>
           ctx.error(ex"unsafe instantiation of type ${tree.tpe}", tree.pos)
           tree
-      }}
+      }
     else tree
 
   def typedSelect(tree: untpd.Select, pt: Type)(implicit ctx: Context): Tree = track("typedSelect") {
@@ -2188,12 +2187,11 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         case _ =>
       }
       // try to fully instantiate type
-      {
-        val ictx = ctx.fresh.setNewTyperState
-        val constraint = ictx.typerState.constraint
-        if (isFullyDefined(wtp, force = ForceDegree.all)(ictx) &&
-            ictx.typerState.constraint.ne(constraint)) {
-          ictx.typerState.commit()
+      { val localCtx = ctx.fresh.setNewTyperState
+        val prevConstraint = localCtx.typerState.constraint
+        if (isFullyDefined(wtp, force = ForceDegree.all)(localCtx) &&
+            localCtx.typerState.constraint.ne(prevConstraint)) {
+          localCtx.typerState.commit()
           return adapt(tree, pt, original)
         }
       }

--- a/tests/neg/i1650.scala
+++ b/tests/neg/i1650.scala
@@ -1,5 +1,5 @@
 object Test {
-  test4(test4$default$1) // error
+  test4(test4$default$1)
   def test4[T[P]](x: T[T[List[T[X forSome { type X }]]]]) = ??? // error // error
   def test4$default$1[T[P]]: T[Int] = ???
 }

--- a/tests/pos/i2300.scala
+++ b/tests/pos/i2300.scala
@@ -1,0 +1,26 @@
+object hlists {
+  sealed abstract class HList {
+    type Merge[L <: HList] <: HList
+
+    def merge[L <: HList](l: L): Merge[L]
+  }
+  final case class HCons[H, T <: HList](head : H, tail : T) extends HList {
+    type Merge[L <: HList] = HCons[H, tail.Merge[L]]
+
+    def merge[L <: HList](l: L): Merge[L] = HCons(head, tail.merge(l))
+  }
+  sealed trait HNil extends HList {
+    type Merge[L <: HList] = L
+
+    def merge[L <: HList](l: L): Merge[L] = l
+  }
+  final val HNil: HNil = { case object HNil extends HNil; HNil }
+}
+
+object Test {
+  import hlists._
+
+  val merged: HCons[Int,HCons[String,HNil]] = {
+    HCons(42, HNil) merge HCons("foo", HNil)
+  }
+}

--- a/tests/repl/errmsgs.check
+++ b/tests/repl/errmsgs.check
@@ -31,10 +31,9 @@ scala> val a: Inv[String] = new Inv(new Inv(1))
 -- [E007] Type Mismatch Error: <console>:5:33 ----------------------------------
 5 |val a: Inv[String] = new Inv(new Inv(1))
   |                                 ^^^^^
-  |                  found:    Inv[T]
-  |                  required: String
-  |                  
-  |                  where:    T is a type variable with constraint >: Int(1)
+  |                                 found:    Inv[Int]
+  |                                 required: String
+  |                                 
 scala> val b: Inv[String] = new Inv(1)
 -- [E007] Type Mismatch Error: <console>:5:29 ----------------------------------
 5 |val b: Inv[String] = new Inv(1)


### PR DESCRIPTION
The idea is that if an adapt fails because an actual type A is not a
subtype of an expected type B, we try to instantiate all type variables
in A and, if that changes something, try again.

This mitigates the discrepancy that dotc is more lazy in instantiating type
variables than scalac.

Fixes #2300.