### PR TITLE
#1589 Move duplicate qualified modifier error to new format

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1700,7 +1700,7 @@ object Parsers {
     def accessQualifierOpt(mods: Modifiers): Modifiers =
       if (in.token == LBRACKET) {
         if ((mods is Local) || mods.hasPrivateWithin)
-          syntaxError("duplicate private/protected qualifier")
+          syntaxError(DuplicatePrivateProtectedQualifier())
         inBrackets {
           if (in.token == THIS) { in.nextToken(); mods | Local }
           else mods.withPrivateWithin(ident().toTypeName)

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -93,7 +93,8 @@ public enum ErrorMessageID {
     ModifiersNotAllowedID,
     WildcardOnTypeArgumentNotAllowedOnNewID,
     ImplicitFunctionTypeNeedsNonEmptyParameterListID,
-    WrongNumberOfParametersID
+    WrongNumberOfParametersID,
+    DuplicatePrivateProtectedQualifierID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1694,4 +1694,12 @@ object messages {
     val explanation = ""
   }
 
+  case class DuplicatePrivateProtectedQualifier()(implicit ctx: Context)
+    extends Message(DuplicatePrivateProtectedQualifierID) {
+    val kind = "Syntax"
+    val msg = "duplicate private/protected qualifier"
+    val explanation =
+      hl"It is not allowed to combine `private` and `protected` modifiers even if they are qualified to different scopes"
+  }
+
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -910,4 +910,20 @@ class ErrorMessagesTests extends ErrorMessagesTest {
 
       assertEquals(err, WrongNumberOfParameters(1))
     }
+
+  @Test def duplicatePrivateProtectedQualifier =
+    checkMessagesAfter("frontend") {
+      """class Test {
+        |   private[Test] protected[this] def foo(): Unit = ()
+        |} """.stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        val defn = ictx.definitions
+
+        assertMessageCount(1, messages)
+        val err :: Nil = messages
+
+        assertEquals(DuplicatePrivateProtectedQualifier(), err)
+      }
 }


### PR DESCRIPTION
This was a rather niched error message, since most of the time it is superseded by other errors.

This corresponds to the `Parsers:1703` index from the issue description.

P.S. I now realized that I will be leaving to areas with no internet soon... so hopefully all is well with the PR, otherwise I'll have to address it in a few days 😟