### PR TITLE
Generalize Approximating Type Maps

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -362,13 +362,11 @@ trait ConstraintHandling {
       def pruneLambdaParams(tp: Type) =
         if (comparedTypeLambdas.nonEmpty) {
           val approx = new ApproximatingTypeMap {
+            if (fromBelow) variance = -1
             def apply(t: Type): Type = t match {
               case t @ TypeParamRef(tl: TypeLambda, n) if comparedTypeLambdas contains tl =>
-                val effectiveVariance = if (fromBelow) -variance else variance
                 val bounds = tl.paramInfos(n)
-                if (effectiveVariance > 0) bounds.lo
-                else if (effectiveVariance < 0) bounds.hi
-                else NoType
+                range(bounds.lo, bounds.hi)
               case _ =>
                 mapOver(t)
             }

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -657,8 +657,6 @@ class Definitions {
   def UncheckedStableAnnot(implicit ctx: Context) = UncheckedStableAnnotType.symbol.asClass
   lazy val UncheckedVarianceAnnotType = ctx.requiredClassRef("scala.annotation.unchecked.uncheckedVariance")
   def UncheckedVarianceAnnot(implicit ctx: Context) = UncheckedVarianceAnnotType.symbol.asClass
-  lazy val UnsafeNonvariantAnnotType = ctx.requiredClassRef("scala.annotation.internal.UnsafeNonvariant")
-  def UnsafeNonvariantAnnot(implicit ctx: Context) = UnsafeNonvariantAnnotType.symbol.asClass
   lazy val VolatileAnnotType = ctx.requiredClassRef("scala.volatile")
   def VolatileAnnot(implicit ctx: Context) = VolatileAnnotType.symbol.asClass
   lazy val FieldMetaAnnotType = ctx.requiredClassRef("scala.annotation.meta.field")

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -132,18 +132,9 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
 
   /** Approximate a type `tp` with a type that does not contain skolem types. */
   object deskolemize extends ApproximatingTypeMap {
-    private var seen: Set[SkolemType] = Set()
     def apply(tp: Type) = tp match {
-      case tp: SkolemType =>
-        if (seen contains tp) NoType
-        else {
-          val saved = seen
-          seen += tp
-          try approx(hi = tp.info)
-          finally seen = saved
-        }
-      case _ =>
-        mapOver(tp)
+      case tp: SkolemType => range(hi = apply(tp.info))
+      case _ => mapOver(tp)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -132,9 +132,11 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
 
   /** Approximate a type `tp` with a type that does not contain skolem types. */
   object deskolemize extends ApproximatingTypeMap {
-    def apply(tp: Type) = tp match {
-      case tp: SkolemType => range(hi = apply(tp.info))
-      case _ => mapOver(tp)
+    def apply(tp: Type) = /*ctx.traceIndented(i"deskolemize($tp) at $variance", show = true)*/ {
+      tp match {
+        case tp: SkolemType => range(hi = atVariance(1)(apply(tp.info)))
+        case _ => mapOver(tp)
+      }
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -19,122 +19,81 @@ import ast.tpd._
 trait TypeOps { this: Context => // TODO: Make standalone object.
 
   /** The type `tp` as seen from prefix `pre` and owner `cls`. See the spec
-   *  for what this means. Called very often, so the code is optimized heavily.
-   *
-   *  A tricky aspect is what to do with unstable prefixes. E.g. say we have a class
-   *
-   *    class C { type T; def f(x: T): T }
-   *
-   *  and an expression `e` of type `C`. Then computing the type of `e.f` leads
-   *  to the query asSeenFrom(`C`, `(x: T)T`). What should its result be? The
-   *  naive answer `(x: C#T)C#T` is incorrect given that we treat `C#T` as the existential
-   *  `exists(c: C)c.T`. What we need to do instead is to skolemize the existential. So
-   *  the answer would be `(x: c.T)c.T` for some (unknown) value `c` of type `C`.
-   *  `c.T` is expressed in the compiler as a skolem type `Skolem(C)`.
-   *
-   *  Now, skolemization is messy and expensive, so we want to do it only if we absolutely
-   *  must. Also, skolemizing immediately would mean that asSeenFrom was no longer
-   *  idempotent - each call would return a type with a different skolem.
-   *  Instead we produce an annotated type that marks the prefix as unsafe:
-   *
-   *     (x: (C @ UnsafeNonvariant)#T)C#T
-   *
-   *  We also set a global state flag `unsafeNonvariant` to the current run.
-   *  When typing a Select node, typer will check that flag, and if it
-   *  points to the current run will scan the result type of the select for
-   *  @UnsafeNonvariant annotations. If it finds any, it will introduce a skolem
-   *  constant for the prefix and try again.
-   *
-   *  The scheme is efficient in particular because we expect that unsafe situations are rare;
-   *  most compiles would contain none, so no scanning would be necessary.
+   *  for what this means.
    */
   final def asSeenFrom(tp: Type, pre: Type, cls: Symbol): Type =
-    asSeenFrom(tp, pre, cls, null)
+    new AsSeenFromMap(pre, cls).apply(tp)
 
-  /** Helper method, taking a map argument which is instantiated only for more
-   *  complicated cases of asSeenFrom.
-   */
-  private def asSeenFrom(tp: Type, pre: Type, cls: Symbol, theMap: AsSeenFromMap): Type = {
+  /** The TypeMap handling the asSeenFrom */
+  class AsSeenFromMap(pre: Type, cls: Symbol) extends ApproximatingTypeMap {
 
-    /** Map a `C.this` type to the right prefix. If the prefix is unstable and
-     *  the `C.this` occurs in nonvariant or contravariant position, mark the map
-     *  to be unstable.
-     */
-    def toPrefix(pre: Type, cls: Symbol, thiscls: ClassSymbol): Type = /*>|>*/ ctx.conditionalTraceIndented(TypeOps.track, s"toPrefix($pre, $cls, $thiscls)") /*<|<*/ {
-      if ((pre eq NoType) || (pre eq NoPrefix) || (cls is PackageClass))
-        tp
-      else pre match {
-        case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
-        case _ =>
-          if (thiscls.derivesFrom(cls) && pre.baseTypeRef(thiscls).exists) {
-            if (theMap != null && theMap.currentVariance <= 0 && !isLegalPrefix(pre)) {
-              ctx.base.unsafeNonvariant = ctx.runId
-              pre match {
-                case AnnotatedType(_, ann) if ann.symbol == defn.UnsafeNonvariantAnnot => pre
-                case _ => AnnotatedType(pre, Annotation(defn.UnsafeNonvariantAnnot, Nil))
-              }
-            }
-            else pre
-          }
-          else if ((pre.termSymbol is Package) && !(thiscls is Package))
-            toPrefix(pre.select(nme.PACKAGE), cls, thiscls)
-          else
-            toPrefix(pre.baseTypeRef(cls).normalizedPrefix, cls.owner, thiscls)
-      }
-    }
+    def apply(tp: Type): Type = {
 
-    /*>|>*/ ctx.conditionalTraceIndented(TypeOps.track, s"asSeen ${tp.show} from (${pre.show}, ${cls.show})", show = true) /*<|<*/ { // !!! DEBUG
-      tp match {
-        case tp: NamedType =>
-          val sym = tp.symbol
-          if (sym.isStatic) tp
-          else {
-            val pre1 = asSeenFrom(tp.prefix, pre, cls, theMap)
-            if (pre1.isUnsafeNonvariant) {
-              val safeCtx = ctx.withProperty(TypeOps.findMemberLimit, Some(()))
-              pre1.member(tp.name)(safeCtx).info match {
-                case TypeAlias(alias) =>
-                  // try to follow aliases of this will avoid skolemization.
-                  return alias
-                case _ =>
-              }
-            }
-            tp.derivedSelect(pre1)
-          }
-        case tp: ThisType =>
-          toPrefix(pre, cls, tp.cls)
-        case _: BoundType | NoPrefix =>
+      /** Map a `C.this` type to the right prefix. If the prefix is unstable and
+      *  the `C.this` occurs in nonvariant or contravariant position, mark the map
+      *  to be unstable.
+      */
+      def toPrefix(pre: Type, cls: Symbol, thiscls: ClassSymbol): Type = /*>|>*/ ctx.conditionalTraceIndented(TypeOps.track, s"toPrefix($pre, $cls, $thiscls)") /*<|<*/ {
+        if ((pre eq NoType) || (pre eq NoPrefix) || (cls is PackageClass))
           tp
-        case tp: RefinedType =>
-          tp.derivedRefinedType(
-            asSeenFrom(tp.parent, pre, cls, theMap),
-            tp.refinedName,
-            asSeenFrom(tp.refinedInfo, pre, cls, theMap))
-        case tp: TypeAlias if tp.variance == 1 => // if variance != 1, need to do the variance calculation
-          tp.derivedTypeAlias(asSeenFrom(tp.alias, pre, cls, theMap))
-        case _ =>
-          (if (theMap != null) theMap else new AsSeenFromMap(pre, cls))
-            .mapOver(tp)
+        else pre match {
+          case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
+          case _ =>
+            if (thiscls.derivesFrom(cls) && pre.baseTypeRef(thiscls).exists)
+              if (variance <= 0 && !isLegalPrefix(pre)) Range(pre.bottomType, pre)
+              else pre
+            else if ((pre.termSymbol is Package) && !(thiscls is Package))
+              toPrefix(pre.select(nme.PACKAGE), cls, thiscls)
+            else
+              toPrefix(pre.baseTypeRef(cls).normalizedPrefix, cls.owner, thiscls)
+        }
+      }
+
+      /*>|>*/ ctx.conditionalTraceIndented(TypeOps.track, s"asSeen ${tp.show} from (${pre.show}, ${cls.show})", show = true) /*<|<*/ { // !!! DEBUG
+        tp match {
+          case tp: NamedType =>
+            val sym = tp.symbol
+            if (sym.isStatic) tp
+            else {
+              val pre1 = apply(tp.prefix)
+              if (pre1.isUnsafeNonvariant) {
+                val safeCtx = ctx.withProperty(TypeOps.findMemberLimit, Some(()))
+                pre1.member(tp.name)(safeCtx).info match {
+                  case TypeAlias(alias) =>
+                    // try to follow aliases of this will avoid skolemization.
+                    return alias
+                  case _ =>
+                }
+              }
+              derivedSelect(tp, pre1)
+            }
+          case tp: ThisType =>
+            toPrefix(pre, cls, tp.cls)
+          case _: BoundType | NoPrefix =>
+            tp
+          case tp: RefinedType =>
+            derivedRefinedType(tp, apply(tp.parent), apply(tp.refinedInfo))
+          case tp: TypeAlias if tp.variance == 1 => // if variance != 1, need to do the variance calculation
+            derivedTypeAlias(tp, apply(tp.alias))
+          case _ =>
+            mapOver(tp)
+        }
       }
     }
+
+    override def reapply(tp: Type) =
+      // derives infos have already been subjected to asSeenFrom, hence to need to apply the map again.
+      tp
   }
 
   private def isLegalPrefix(pre: Type)(implicit ctx: Context) =
     pre.isStable || !ctx.phase.isTyper
 
-  /** The TypeMap handling the asSeenFrom in more complicated cases */
-  class AsSeenFromMap(pre: Type, cls: Symbol) extends TypeMap {
-    def apply(tp: Type) = asSeenFrom(tp, pre, cls, this)
-
-    /** A method to export the current variance of the map */
-    def currentVariance = variance
-  }
-
   /** Approximate a type `tp` with a type that does not contain skolem types. */
   object deskolemize extends ApproximatingTypeMap {
     def apply(tp: Type) = /*ctx.traceIndented(i"deskolemize($tp) at $variance", show = true)*/ {
       tp match {
-        case tp: SkolemType => range(hi = atVariance(1)(apply(tp.info)))
+        case tp: SkolemType => range(tp.bottomType, atVariance(1)(apply(tp.info)))
         case _ => mapOver(tp)
       }
     }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -40,7 +40,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
           case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
           case _ =>
             if (thiscls.derivesFrom(cls) && pre.baseTypeRef(thiscls).exists)
-              if (variance <= 0 && !isLegalPrefix(pre)) Range(pre.bottomType, pre)
+              if (variance <= 0 && !isLegalPrefix(pre)) range(pre.bottomType, pre)
               else pre
             else if ((pre.termSymbol is Package) && !(thiscls is Package))
               toPrefix(pre.select(nme.PACKAGE), cls, thiscls)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -136,6 +136,12 @@ object Types {
       case _ => false
     }
 
+    /** Is this type exactly Nothing (no vars, aliases, refinements etc allowed)? */
+    def isBottomType(implicit ctx: Context): Boolean = this match {
+      case tp: TypeRef => tp.symbol eq defn.NothingClass
+      case _ => false
+    }
+
     /** Is this type a (neither aliased nor applied) reference to class `sym`? */
     def isDirectRef(sym: Symbol)(implicit ctx: Context): Boolean = stripTypeVar match {
       case this1: TypeRef =>
@@ -275,7 +281,10 @@ object Types {
     }
 
     /** Is this an alias TypeBounds? */
-    def isAlias: Boolean = this.isInstanceOf[TypeAlias]
+    final def isAlias: Boolean = this.isInstanceOf[TypeAlias]
+
+    /** Is this a non-alias TypeBounds? */
+    final def isRealTypeBounds = this.isInstanceOf[TypeBounds] && !isAlias
 
 // ----- Higher-order combinators -----------------------------------
 
@@ -1220,6 +1229,18 @@ object Types {
       case _ => TypeAlias(this)
     }
 
+    /** The lower bound of a TypeBounds type, the type itself otherwise */
+    def loBound = this match {
+      case tp: TypeBounds => tp.lo
+      case _ => this
+    }
+
+    /** The upper bound of a TypeBounds type, the type itself otherwise */
+    def hiBound = this match {
+      case tp: TypeBounds => tp.hi
+      case _ => this
+    }
+
     /** The type parameter with given `name`. This tries first `decls`
      *  in order not to provoke a cycle by forcing the info. If that yields
      *  no symbol it tries `member` as an alternative.
@@ -1766,6 +1787,7 @@ object Types {
      */
     def derivedSelect(prefix: Type)(implicit ctx: Context): Type =
       if (prefix eq this.prefix) this
+      else if (prefix.isBottomType) prefix
       else if (isType) {
         val res = prefix.lookupRefined(name)
         if (res.exists) res
@@ -3722,6 +3744,18 @@ object Types {
               // of `p`'s upper bound.
             val prefix1 = this(tp.prefix)
             variance = saved
+            /* was:
+            val prefix1 = tp.info match {
+              case info: TypeBounds if !info.isAlias =>
+                // prefix of an abstract type selection is non-variant, since a path
+                // cannot be legally widened to its underlying type, or any supertype.
+                val saved = variance
+                variance = 0
+                try this(tp.prefix) finally variance = saved
+              case _ =>
+                this(tp.prefix)
+            }
+			*/
             derivedSelect(tp, prefix1)
           }
         case _: ThisType
@@ -3851,63 +3885,139 @@ object Types {
     def apply(tp: Type) = tp
   }
 
-  /** A type map that approximates NoTypes by upper or lower known bounds depending on
+  case class Range(lo: Type, hi: Type) extends UncachedGroundType {
+    assert(!lo.isInstanceOf[Range])
+    assert(!hi.isInstanceOf[Range])
+  }
+
+  /** A type map that approximates TypeBounds types depending on
    *  variance.
    *
    *  if variance > 0 : approximate by upper bound
    *     variance < 0 : approximate by lower bound
-   *     variance = 0 : propagate NoType to next outer level
+   *     variance = 0 : propagate bounds to next outer level
    */
   abstract class ApproximatingTypeMap(implicit ctx: Context) extends TypeMap { thisMap =>
-    def approx(lo: Type = defn.NothingType, hi: Type = defn.AnyType) =
-      if (variance == 0) NoType
-      else apply(if (variance < 0) lo else hi)
+
+    def range(lo: Type = defn.NothingType, hi: Type = defn.AnyType) =
+      if (variance > 0) hi
+      else if (variance < 0) lo
+      else Range(loBound(lo), hiBound(hi))
+
+    def isRange(tp: Type) = tp.isInstanceOf[Range]
+
+    def loBound(tp: Type) = tp match {
+      case tp: Range => tp.lo
+      case _ => tp
+    }
+
+    /** The upper bound of a TypeBounds type, the type itself otherwise */
+    def hiBound(tp: Type) = tp match {
+      case tp: Range => tp.hi
+      case _ => tp
+    }
+
+    def rangeToBounds(tp: Type) = tp match {
+      case Range(lo, hi) => TypeBounds(lo, hi)
+      case _ => tp
+    }
 
     override protected def derivedSelect(tp: NamedType, pre: Type) =
       if (pre eq tp.prefix) tp
-      else tp.info match {
-        case TypeAlias(alias) => apply(alias) // try to heal by following aliases
+      else pre match {
+        case Range(preLo, preHi) =>
+          tp.info match {
+            case TypeAlias(alias) => apply(alias)
+            case TypeBounds(lo, hi) => range(apply(lo), apply(hi))
+            case _ => range(tp.derivedSelect(preLo), tp.derivedSelect(preHi))
+          }
+        case _ => tp.derivedSelect(pre)
+      }
+
+    override protected def derivedRefinedType(tp: RefinedType, parent: Type, info: Type) =
+      parent match {
+        case Range(parentLo, parentHi) =>
+          range(derivedRefinedType(tp, parentLo, info), derivedRefinedType(tp, parentHi, info))
         case _ =>
-          if (pre.exists && !pre.isRef(defn.NothingClass) && variance > 0) tp.derivedSelect(pre)
-          else tp.info match {
-            case TypeBounds(lo, hi) => approx(lo, hi)
-            case _ => approx()
+          if (parent.isBottomType) parent
+          else info match {
+            case Range(infoLo, infoHi) if tp.refinedName.isTermName || variance <= 0 =>
+              range(derivedRefinedType(tp, parent, infoLo), derivedRefinedType(tp, parent, infoHi))
+            case _ =>
+              tp.derivedRefinedType(parent, tp.refinedName, rangeToBounds(info))
           }
       }
-    override protected def derivedRefinedType(tp: RefinedType, parent: Type, info: Type) =
-      if (parent.exists && info.exists) tp.derivedRefinedType(parent, tp.refinedName, info)
-      else approx(hi = parent)
     override protected def derivedRecType(tp: RecType, parent: Type) =
-      if (parent.exists) tp.rebind(parent)
-      else approx()
+      parent match {
+        case Range(lo, hi) => range(tp.rebind(lo), tp.rebind(hi))
+        case _ => tp.rebind(parent)
+      }
     override protected def derivedTypeAlias(tp: TypeAlias, alias: Type) =
-      if (alias.exists) tp.derivedTypeAlias(alias)
-      else approx(NoType, TypeBounds.empty)
+      alias match {
+        case Range(lo, hi) =>
+          if (variance > 0) TypeBounds(lo, hi)
+          else range(TypeAlias(lo), TypeAlias(hi))
+        case _ => tp.derivedTypeAlias(alias)
+      }
     override protected def derivedTypeBounds(tp: TypeBounds, lo: Type, hi: Type) =
-      if (lo.exists && hi.exists) tp.derivedTypeBounds(lo, hi)
-      else approx(NoType,
-        if (lo.exists) TypeBounds.lower(lo)
-        else if (hi.exists) TypeBounds.upper(hi)
-        else TypeBounds.empty)
+      if (isRange(lo) || isRange(hi))
+        if (variance > 0) TypeBounds(loBound(lo), hiBound(hi))
+        else range(TypeBounds(hiBound(lo), loBound(hi)), TypeBounds(loBound(lo), hiBound(hi)))
+      else tp.derivedTypeBounds(lo, hi)
     override protected def derivedSuperType(tp: SuperType, thistp: Type, supertp: Type) =
-      if (thistp.exists && supertp.exists) tp.derivedSuperType(thistp, supertp)
-      else NoType
+      if (isRange(thistp) || isRange(supertp)) range()
+      else tp.derivedSuperType(thistp, supertp)
+
     override protected def derivedAppliedType(tp: HKApply, tycon: Type, args: List[Type]): Type =
-      if (tycon.exists && args.forall(_.exists)) tp.derivedAppliedType(tycon, args)
-      else approx() // This is rather coarse, but to do better is a bit complicated
+      tycon match {
+        case Range(tyconLo, tyconHi) =>
+          range(derivedAppliedType(tp, tyconLo, args), derivedAppliedType(tp, tyconHi, args))
+        case _ =>
+          if (args.exists(isRange))
+            if (variance > 0) tp.derivedAppliedType(tycon, args.map(rangeToBounds))
+            else {
+              val loBuf, hiBuf = new mutable.ListBuffer[Type]
+              def distributeArgs(args: List[Type], tparams: List[ParamInfo]): Boolean = args match {
+                case Range(lo, hi) :: args1 =>
+                  val v = tparams.head.paramVariance
+                  if (v == 0) false
+                  else if (v > 0) { loBuf += lo; hiBuf += hi }
+                  else { loBuf += hi; hiBuf += lo }
+                  distributeArgs(args1, tparams.tail)
+                case arg :: args1 =>
+                  loBuf += arg; hiBuf += arg
+                  distributeArgs(args1, tparams.tail)
+                case nil =>
+                  true
+              }
+              if (distributeArgs(args, tp.typeParams))
+                range(tp.derivedAppliedType(tycon, loBuf.toList),
+                      tp.derivedAppliedType(tycon, hiBuf.toList))
+              else range()
+            }
+          else tp.derivedAppliedType(tycon, args)
+      }
+
     override protected def derivedAndOrType(tp: AndOrType, tp1: Type, tp2: Type) =
-      if (tp1.exists && tp2.exists) tp.derivedAndOrType(tp1, tp2)
-      else if (tp.isAnd) approx(hi = tp1 & tp2)  // if one of tp1d, tp2d exists, it is the result of tp1d & tp2d
-      else approx(lo = tp1 & tp2)
+      if (tp1.isInstanceOf[Range] || tp2.isInstanceOf[Range])
+        if (tp.isAnd) range(loBound(tp1) & loBound(tp2), hiBound(tp1) & hiBound(tp2))
+        else range(loBound(tp1) | loBound(tp2), hiBound(tp1) | hiBound(tp2))
+      else tp.derivedAndOrType(tp1, tp2)
     override protected def derivedAnnotatedType(tp: AnnotatedType, underlying: Type, annot: Annotation) =
-      if (underlying.exists) tp.derivedAnnotatedType(underlying, annot)
-      else NoType
-    override protected def derivedWildcardType(tp: WildcardType, bounds: Type) =
-      if (bounds.exists) tp.derivedWildcardType(bounds)
-      else WildcardType
-    override protected def derivedClassInfo(tp: ClassInfo, pre: Type): Type =
-      if (pre.exists) tp.derivedClassInfo(pre)
-      else NoType
+      underlying match {
+        case Range(lo, hi) =>
+          range(tp.derivedAnnotatedType(lo, annot), tp.derivedAnnotatedType(hi, annot))
+        case _ =>
+          if (underlying.isBottomType) underlying
+          else tp.derivedAnnotatedType(underlying, annot)
+      }
+    override protected def derivedWildcardType(tp: WildcardType, bounds: Type) = {
+      tp.derivedWildcardType(rangeToBounds(bounds))
+    }
+    override protected def derivedClassInfo(tp: ClassInfo, pre: Type): Type = {
+      assert(!pre.isInstanceOf[Range])
+      tp.derivedClassInfo(pre)
+    }
   }
 
   // ----- TypeAccumulators ----------------------------------------------------

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3915,7 +3915,9 @@ object Types {
               // hence we can replace with U under all variances
               reapply(alias)
             case TypeBounds(lo, hi) =>
-              range(atVariance(-1)(reapply(lo)), atVariance(1)(reapply(hi)))
+              // If H#T = _ >: S <: U, then for any x in L..H, S <: x.T <: U,
+              // hence we can replace with S..U under all variances
+              range(atVariance(-variance)(reapply(lo)), reapply(hi))
             case info: SingletonType =>
               // if H#x: y.type, then for any x in L..H, x.type =:= y.type,
               // hence we can replace with y.type under all variances

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -255,16 +255,6 @@ object Types {
     def isRepeatedParam(implicit ctx: Context): Boolean =
       typeSymbol eq defn.RepeatedParamClass
 
-    /** Does this type carry an UnsafeNonvariant annotation? */
-    final def isUnsafeNonvariant(implicit ctx: Context): Boolean = this match {
-      case AnnotatedType(_, annot) => annot.symbol == defn.UnsafeNonvariantAnnot
-      case _ => false
-    }
-
-    /** Does this type have an UnsafeNonvariant annotation on one of its parts? */
-    final def hasUnsafeNonvariant(implicit ctx: Context): Boolean =
-      new HasUnsafeNonAccumulator().apply(false, this)
-
     /** Is this the type of a method that has a repeated parameter type as
      *  last parameter type?
      */
@@ -4173,10 +4163,6 @@ object Types {
 
   class ForeachAccumulator(p: Type => Unit, override val stopAtStatic: Boolean)(implicit ctx: Context) extends TypeAccumulator[Unit] {
     def apply(x: Unit, tp: Type): Unit = foldOver(p(tp), tp)
-  }
-
-  class HasUnsafeNonAccumulator(implicit ctx: Context) extends TypeAccumulator[Boolean] {
-    def apply(x: Boolean, tp: Type) = x || tp.isUnsafeNonvariant || foldOver(x, tp)
   }
 
   class NamedPartsAccumulator(p: NamedType => Boolean, excludeLowerBounds: Boolean = false)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3982,6 +3982,13 @@ object Types {
             if (variance > 0) tp.derivedAppliedType(tycon, args.map(rangeToBounds))
             else {
               val loBuf, hiBuf = new mutable.ListBuffer[Type]
+              // Given `C[A1, ..., An]` where sone A's are ranges, try to find
+              // non-range arguments L1, ..., Ln and H1, ..., Hn such that
+              // C[L1, ..., Ln] <: C[H1, ..., Hn] by taking the right limits of
+              // ranges that appear in as co- or contravariant arguments.
+              // Fail for non-variant argument ranges.
+              // If successful, the L-arguments are in loBut, the H-arguments in hiBuf.
+              // @return  operation succeeded for all arguments.
               def distributeArgs(args: List[Type], tparams: List[ParamInfo]): Boolean = args match {
                 case Range(lo, hi) :: args1 =>
                   val v = tparams.head.paramVariance

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3923,20 +3923,27 @@ object Types {
         case Range(parentLo, parentHi) =>
           range(derivedRefinedType(tp, parentLo, info), derivedRefinedType(tp, parentHi, info))
         case _ =>
+          def propagate(lo: Type, hi: Type) =
+            range(derivedRefinedType(tp, parent, lo), derivedRefinedType(tp, parent, hi))
           if (parent.isBottomType) parent
           else info match {
+            case Range(infoLo: TypeBounds, infoHi: TypeBounds) =>
+              assert(variance == 0)
+              val v1 = infoLo.variance
+              val v2 = infoHi.variance
+              // There's some weirdness coming from the way aliases can have variance
+              // If infoLo and infoHi are both aliases with the same non-zero variance
+              // we can propagate to a range of the refined types. If they are both
+              // non-alias ranges we know that infoLo <:< infoHi and therefore we can
+              // propagate to refined types with infoLo and infoHi as bounds.
+              // In all other cases, Nothing..Any is the only interval that contains
+              // the range. i966.scala is a test case.
+              if (v1 > 0 && v2 > 0) propagate(infoLo, infoHi)
+              else if (v1 < 0 && v2 < 0) propagate(infoHi, infoLo)
+              else if (!infoLo.isAlias && !infoHi.isAlias) propagate(infoLo, infoHi)
+              else range(tp.bottomType, tp.topType)
             case Range(infoLo, infoHi) =>
-              def propagate(lo: Type, hi: Type) =
-                range(derivedRefinedType(tp, parent, lo), derivedRefinedType(tp, parent, hi))
-              tp.refinedInfo match {
-                case rinfo: TypeBounds =>
-                  val v = if (rinfo.isAlias) rinfo.variance * variance else variance
-                  if (v > 0) tp.derivedRefinedType(parent, tp.refinedName, rangeToBounds(info))
-                  else if (v < 0) propagate(infoHi, infoLo)
-                  else range(tp.bottomType, tp.topType)
-                case _ =>
-                  propagate(infoLo, infoHi)
-              }
+              propagate(infoLo, infoHi)
             case _ =>
               tp.derivedRefinedType(parent, tp.refinedName, info)
           }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4014,7 +4014,7 @@ object Types {
       }
 
     override protected def derivedAndOrType(tp: AndOrType, tp1: Type, tp2: Type) =
-      if (tp1.isInstanceOf[Range] || tp2.isInstanceOf[Range])
+      if (isRange(tp1) || isRange(tp2))
         if (tp.isAnd) range(lower(tp1) & lower(tp2), upper(tp1) & upper(tp2))
         else range(lower(tp1) | lower(tp2), upper(tp1) | upper(tp2))
       else tp.derivedAndOrType(tp1, tp2)
@@ -4032,7 +4032,9 @@ object Types {
     }
 
     override protected def derivedClassInfo(tp: ClassInfo, pre: Type): Type = {
-      assert(!pre.isInstanceOf[Range])
+      assert(!isRange(pre))
+        // we don't know what to do here; this case has to be handled in subclasses
+        // (typically by handling ClassInfo's specially, in case they can be encountered).
       tp.derivedClassInfo(pre)
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3676,13 +3676,25 @@ object Types {
 
   // ----- TypeMaps --------------------------------------------------------------------
 
-  abstract class TypeMap(implicit protected val ctx: Context) extends (Type => Type) { thisMap =>
+  /** Common base class of TypeMap and TypeAccumulator */
+  abstract class VariantTraversal {
+    protected[core] var variance = 1
+
+    @inline protected def atVariance[T](v: Int)(op: => T): T = {
+      val saved = variance
+      variance = v
+      val res = op
+      variance = saved
+      res
+    }
+  }
+
+  abstract class TypeMap(implicit protected val ctx: Context)
+  extends VariantTraversal with (Type => Type) { thisMap =>
 
     protected def stopAtStatic = true
 
     def apply(tp: Type): Type
-
-    protected[core] var variance = 1
 
     protected def derivedSelect(tp: NamedType, pre: Type): Type =
       tp.derivedSelect(pre)
@@ -3721,16 +3733,13 @@ object Types {
         case tp: NamedType =>
           if (stopAtStatic && tp.symbol.isStatic) tp
           else {
-            val saved = variance
-            variance = variance max 0
+            val prefix1 = atVariance(variance max 0)(this(tp.prefix))
               // A prefix is never contravariant. Even if say `p.A` is used in a contravariant
               // context, we cannot assume contravariance for `p` because `p`'s lower
               // bound might not have a binding for `A` (e.g. the lower bound could be `Nothing`).
               // By contrast, covariance does translate to the prefix, since we have that
               // if `p <: q` then `p.A <: q.A`, and well-formedness requires that `A` is a member
               // of `p`'s upper bound.
-            val prefix1 = this(tp.prefix)
-            variance = saved
             derivedSelect(tp, prefix1)
           }
         case _: ThisType
@@ -3741,11 +3750,7 @@ object Types {
           derivedRefinedType(tp, this(tp.parent), this(tp.refinedInfo))
 
         case tp: TypeAlias =>
-          val saved = variance
-          variance *= tp.variance
-          val alias1 = this(tp.alias)
-          variance = saved
-          derivedTypeAlias(tp, alias1)
+          derivedTypeAlias(tp, atVariance(variance * tp.variance)(this(tp.alias)))
 
         case tp: TypeBounds =>
           variance = -variance
@@ -3761,12 +3766,8 @@ object Types {
           if (inst.exists) apply(inst) else tp
 
         case tp: HKApply =>
-          def mapArg(arg: Type, tparam: ParamInfo): Type = {
-            val saved = variance
-            variance *= tparam.paramVariance
-            try this(arg)
-            finally variance = saved
-          }
+          def mapArg(arg: Type, tparam: ParamInfo): Type =
+            atVariance(variance * tparam.paramVariance)(this(arg))
           derivedAppliedType(tp, this(tp.tycon),
               tp.args.zipWithConserve(tp.typeParams)(mapArg))
 
@@ -3889,12 +3890,6 @@ object Types {
     protected def rangeToBounds(tp: Type) = tp match {
       case Range(lo, hi) => TypeBounds(lo, hi)
       case _ => tp
-    }
-
-    protected def atVariance[T](v: Int)(op: => T): T = {
-      val saved = variance
-      variance = v
-      try op finally variance = saved
     }
 
     /** Derived selection.
@@ -4051,7 +4046,8 @@ object Types {
 
   // ----- TypeAccumulators ----------------------------------------------------
 
-  abstract class TypeAccumulator[T](implicit protected val ctx: Context) extends ((T, Type) => T) {
+  abstract class TypeAccumulator[T](implicit protected val ctx: Context)
+  extends VariantTraversal with ((T, Type) => T) {
 
     protected def stopAtStatic = true
 
@@ -4059,15 +4055,8 @@ object Types {
 
     protected def applyToAnnot(x: T, annot: Annotation): T = x // don't go into annotations
 
-    protected var variance = 1
-
-    protected final def applyToPrefix(x: T, tp: NamedType) = {
-      val saved = variance
-      variance = variance max 0 // see remark on NamedType case in TypeMap
-      val result = this(x, tp.prefix)
-      variance = saved
-      result
-    }
+    protected final def applyToPrefix(x: T, tp: NamedType) =
+      atVariance(variance max 0)(this(x, tp.prefix)) // see remark on NamedType case in TypeMap
 
     def foldOver(x: T, tp: Type): T = tp match {
       case tp: TypeRef =>
@@ -4088,13 +4077,7 @@ object Types {
         this(this(x, tp.parent), tp.refinedInfo)
 
       case bounds @ TypeBounds(lo, hi) =>
-        if (lo eq hi) {
-          val saved = variance
-          variance = variance * bounds.variance
-          val result = this(x, lo)
-          variance = saved
-          result
-        }
+        if (lo eq hi) atVariance(variance * bounds.variance)(this(x, lo))
         else {
           variance = -variance
           val y = this(x, lo)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -12,6 +12,7 @@ import typer.ImportInfo
 import config.Config
 import java.lang.Integer.toOctalString
 import config.Config.summarizeDepth
+import scala.util.control.NonFatal
 import scala.annotation.switch
 
 class PlainPrinter(_ctx: Context) extends Printer {
@@ -69,11 +70,11 @@ class PlainPrinter(_ctx: Context) extends Printer {
     else tp
 
   private def sameBound(lo: Type, hi: Type): Boolean =
-    try lo =:= hi
-    catch { case ex: Throwable => false }
+    try ctx.typeComparer.isSameTypeWhenFrozen(lo, hi)
+    catch { case NonFatal(ex) => false }
 
   private def homogenizeArg(tp: Type) = tp match {
-    case TypeBounds(lo, hi) if sameBound(lo, hi) => homogenize(hi)
+    case TypeBounds(lo, hi) if homogenizedView && sameBound(lo, hi) => homogenize(hi)
     case _ => tp
   }
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -68,6 +68,15 @@ class PlainPrinter(_ctx: Context) extends Printer {
       }
     else tp
 
+  private def sameBound(lo: Type, hi: Type): Boolean =
+    try lo =:= hi
+    catch { case ex: Throwable => false }
+
+  private def homogenizeArg(tp: Type) = tp match {
+    case TypeBounds(lo, hi) if sameBound(lo, hi) => homogenize(hi)
+    case _ => tp
+  }
+
   private def selfRecName(n: Int) = s"z$n"
 
   /** Render elements alternating with `sep` string */
@@ -113,9 +122,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected def toTextRefinement(rt: RefinedType) =
     (refinementNameString(rt) ~ toTextRHS(rt.refinedInfo)).close
 
-  protected def argText(arg: Type): Text = arg match {
+  protected def argText(arg: Type): Text = homogenizeArg(arg) match {
     case arg: TypeBounds => "_" ~ toTextGlobal(arg)
-    case _ => toTextGlobal(arg)
+    case arg => toTextGlobal(arg)
   }
 
   /** The longest sequence of refinement types, starting at given type

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1427,7 +1427,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       val impl1 = cpy.Template(impl)(constr1, parents1, self1, body1)
         .withType(dummy.nonMemberTermRef)
       checkVariance(impl1)
-      if (!cls.is(AbstractOrTrait) && !ctx.isAfterTyper) checkRealizableBounds(cls.typeRef, cdef.namePos)
+      if (!cls.is(AbstractOrTrait) && !ctx.isAfterTyper) checkRealizableBounds(cls.thisType, cdef.namePos)
       val cdef1 = assignType(cpy.TypeDef(cdef)(name, impl1), cls)
       if (ctx.phase.isTyper && cdef1.tpe.derivesFrom(defn.DynamicClass) && !ctx.dynamicsEnabled) {
         val isRequired = parents1.exists(_.tpe.isRef(defn.DynamicClass))

--- a/library/src/scala/annotation/internal/UnsafeNonvariant.scala
+++ b/library/src/scala/annotation/internal/UnsafeNonvariant.scala
@@ -1,8 +1,0 @@
-package scala.annotation.internal
-
-import scala.annotation.Annotation
-
-/** This annotation is used as a marker for unsafe
- *  instantiations in asSeenFrom. See TypeOps.asSeenfrom for an explanation.
- */
-class UnsafeNonvariant extends Annotation

--- a/tests/neg/i1662.scala
+++ b/tests/neg/i1662.scala
@@ -2,5 +2,5 @@ class Lift {
   def apply(f: F0) // error
   class F0
   object F0 { implicit def f2f0(String): F0 = ??? } // error
-  (new Lift)("")
+  (new Lift)("") // error after switch to approximating asSeenFrom
 }

--- a/tests/pos/dependent-extractors.scala
+++ b/tests/pos/dependent-extractors.scala
@@ -10,5 +10,5 @@ object Test {
   val y1: Int = y
 
   val z = (c: Any)  match { case X(y) => y }
-  val z1: C#T = z
+  // val z1: C#T = z  // error: z has type Any TODO: find out why
 }

--- a/tests/pos/dependent-extractors.scala
+++ b/tests/pos/dependent-extractors.scala
@@ -10,5 +10,5 @@ object Test {
   val y1: Int = y
 
   val z = (c: Any)  match { case X(y) => y }
-  val z1: C#T = z  // error: z has type Any TODO: find out why
+  val z1: C#T = z
 }

--- a/tests/pos/dependent-extractors.scala
+++ b/tests/pos/dependent-extractors.scala
@@ -10,5 +10,5 @@ object Test {
   val y1: Int = y
 
   val z = (c: Any)  match { case X(y) => y }
-  // val z1: C#T = z  // error: z has type Any TODO: find out why
+  val z1: C#T = z  // error: z has type Any TODO: find out why
 }

--- a/tests/pos/t2435.scala
+++ b/tests/pos/t2435.scala
@@ -23,5 +23,6 @@ object Test {
   val a2 = a1.chain("a")
 
   println("\nDoesn't compile:")
-  val a = FNil.chain("a").chain("a").chain("a")
+  val a3 = FNil.chain("a").chain("a").chain("a")
+  val a4: FConstant[_ <: FConstant[_ <: FConstant[FNil.type]]] = a3
 }


### PR DESCRIPTION
Approximating type maps now work with bounds instead of NoTypes. This
gives more precision (in particular for type applications), and also
makes it possible to combine approximation with other mappings.

The biggest win here is that we can now express AsSeenFrom soundly in terms of ApproximatingTypeMaps. We can therefore remove the UnsafeNonVariant annotations and 
retroactive skolemizations which felt kludgey.

