### PR TITLE
Fix #2895: Two fixes for inlining

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -39,7 +39,6 @@ class Bridges(root: ClassSymbol)(implicit ctx: Context) {
    *  before erasure, if the following conditions are satisfied.
    *
    *   - `member` and other have different signatures
-   *   - `member` is not inline
    *   - there is not yet a bridge with the same name and signature in `root`
    *
    *  The bridge has the erased info of `other` and forwards to `member`.
@@ -48,7 +47,7 @@ class Bridges(root: ClassSymbol)(implicit ctx: Context) {
     def bridgeExists =
       bridgesScope.lookupAll(member.name).exists(bridge =>
         bridgeTarget(bridge) == member && bridge.signature == other.signature)
-    if (!(member.is(Inline) || member.signature == other.signature || bridgeExists))
+    if (!(member.signature == other.signature || bridgeExists))
       addBridge(member, other)
   }
 

--- a/tests/run/i2895.scala
+++ b/tests/run/i2895.scala
@@ -1,0 +1,17 @@
+object Foo extends (Int => Int) {
+  inline def apply(x: Int): Int = impl(x)
+  def impl(x: Int): Int = x + 1
+}
+
+object Test {
+
+  def test(foo: Foo.type): Int = foo(41)
+
+  def test2(f: Int => Int): Int = f(41)
+
+  def main(args: Array[String]): Unit = {
+    assert(test(Foo) == 42)
+    assert(test2(Foo) == 42)
+  }
+
+}

--- a/tests/run/i2895a.scala
+++ b/tests/run/i2895a.scala
@@ -1,0 +1,26 @@
+
+trait Foo[A <: Foo[A]] {
+
+  def next: A
+
+  inline final def once: A = next
+
+  def once1: A = once
+
+  def twice: A = once.once
+}
+
+trait Bar extends Foo[Bar]
+
+case object Bar0 extends Bar { def next = Bar1 }
+case object Bar1 extends Bar { def next = Bar2 }
+case object Bar2 extends Bar { def next = this }
+
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    assert(Bar0.once.once.toString == "Bar2")
+    assert(Bar0.twice.toString == "Bar2")
+  }
+}
+


### PR DESCRIPTION
Two fixes:

 1. Generate bridges for inline methods 

   There was a test before that explicitly suppressed bridge generation
   for inline methods. I am not sure why. @DarkDimius, does the one ring a bell?

 2. Sharpen condition when to elide a `this` binding. 
