### PR TITLE
Alternative fix for #2506 that does not force dirs

### DIFF
--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -149,7 +149,7 @@ final class FileZipArchive(file: JFile) extends ZipArchive(file) {
     override def sizeOption: Option[Int] = Some(zipEntry.getSize.toInt)
   }
 
-  val (root, allDirs) = {
+  @volatile lazy val (root, allDirs) = {
     val root = new DirEntry("/")
     val dirs = mutable.HashMap[String, DirEntry]("/" -> root)
     val zipFile = openZipFile()


### PR DESCRIPTION
As stated in #2506 `lazy` was droped to make it volatile.
It turns out that the dirs is not always used and epensive to compute.
In `implicit_cache.scala` only need dirs 1 out of 30 times.