### PR TITLE
#1589 Move Parsers:2177 err to new format

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2174,7 +2174,7 @@ object Parsers {
           if (in.token == CLASS) tmplDef(start, addMod(mods, enumMod))
           else enumDef(start, mods, enumMod)
         case _ =>
-          syntaxErrorOrIncomplete("expected start of definition")
+          syntaxErrorOrIncomplete(ExpectedStartOfTopLevelDefinition())
           EmptyTree
       }
     }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -95,6 +95,7 @@ public enum ErrorMessageID {
     ImplicitFunctionTypeNeedsNonEmptyParameterListID,
     WrongNumberOfParametersID,
     DuplicatePrivateProtectedQualifierID,
+    ExpectedStartOfTopLevelDefinitionID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1702,4 +1702,12 @@ object messages {
       hl"It is not allowed to combine `private` and `protected` modifiers even if they are qualified to different scopes"
   }
 
+  case class ExpectedStartOfTopLevelDefinition()(implicit ctx: Context)
+    extends Message(ExpectedStartOfTopLevelDefinitionID) {
+    val kind = "Syntax"
+    val msg = "expected start of definition"
+    val explanation =
+      hl"you have to provide either ${"class"}, ${"trait"}, ${"object"}, or ${"enum"} definitions after qualifiers"
+  }
+
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -926,4 +926,18 @@ class ErrorMessagesTests extends ErrorMessagesTest {
 
         assertEquals(DuplicatePrivateProtectedQualifier(), err)
       }
+
+  @Test def expectedStartOfTopLevelDefinition =
+    checkMessagesAfter("frontend") {
+      """private Test {}"""
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        val defn = ictx.definitions
+
+        assertMessageCount(1, messages)
+        val err :: Nil = messages
+
+        assertEquals(ExpectedStartOfTopLevelDefinition(), err)
+      }
 }


### PR DESCRIPTION
Move error for `Parsers:2177` to new format.

Actual line numbers have started getting out of sync with the description in issue #1589. But it should be quite straightforward to see that this was also necessary.