### PR TITLE
Ycheck all groups after FirstTransform, except Erasure

### DIFF
--- a/compiler/test/dotc/tests.scala
+++ b/compiler/test/dotc/tests.scala
@@ -68,7 +68,7 @@ class tests extends CompilerTest {
   }
 
   implicit val defaultOptions: List[String] = noCheckOptions ++ {
-    if (dotty.Properties.isRunByDrone) List("-Ycheck:tailrec,resolveSuper,mixin,restoreScopes,labelDef,simplify") // should be Ycheck:all, but #725
+    if (dotty.Properties.isRunByDrone) List("-Ycheck:tailrec,resolveSuper,mixin,getClass,restoreScopes,labelDef") // should be Ycheck:all, but #725
     else List("-Ycheck:tailrec,resolveSuper,mixin,restoreScopes,labelDef,simplify")
   } ++ checkOptions ++ classPath
 

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -50,7 +50,7 @@ object TestConfiguration {
     Array("-classpath", paths)
   }
 
-  private val yCheckOptions = Array("-Ycheck:tailrec,resolveSuper,mixin,arrayConstructors,labelDef")
+  private val yCheckOptions = Array("-Ycheck:tailrec,resolveSuper,mixin,getClass,restoreScopes,labelDef")
 
   val defaultUnoptimised = noCheckOptions ++ checkOptions ++ yCheckOptions ++ classPath
   val defaultOptimised = defaultUnoptimised :+ "-optimise"


### PR DESCRIPTION
Erasure does not pass Ycheck currently due to some issue with the value
class encoding, but everything else should pass.