### PR TITLE
Implement value classes with phantom parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -503,7 +503,7 @@ object desugar {
         companionDefs(anyRef, companionMeths)
       else if (isValueClass) {
         constr0.vparamss match {
-          case List(_ :: Nil) => companionDefs(anyRef, Nil)
+          case (_ :: Nil) :: _ => companionDefs(anyRef, Nil)
           case _ => Nil // error will be emitted in typer
         }
       }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1620,9 +1620,9 @@ object messages {
           |"""
   }
 
-  case class ValueClassNeedsExactlyOneValParam(valueClass: Symbol)(implicit ctx: Context)
+  case class ValueClassNeedsOneValParam(valueClass: Symbol)(implicit ctx: Context)
     extends Message(ValueClassNeedsExactlyOneValParamID) {
-    val msg = hl"""value class needs to have exactly one ${"val"} parameter"""
+    val msg = hl"""value class needs one ${"val"} parameter"""
     val kind = "Syntax"
     val explanation = ""
   }

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -129,7 +129,7 @@ class Constructors extends MiniPhaseTransform with IdentityDenotTransformer { th
     // Produce aligned accessors and constructor parameters. We have to adjust
     // for any outer parameters, which are last in the sequence of original
     // parameter accessors but come first in the constructor parameter list.
-    val accessors = cls.paramAccessors.filterNot(_.isSetter)
+    val accessors = cls.paramAccessors.filterNot(x => x.isSetter || x.info.resultType.classSymbol == defn.ErasedPhantomClass)
     val vparamsWithOuterLast = vparams match {
       case vparam :: rest if vparam.name == nme.OUTER => rest ::: vparam :: Nil
       case _ => vparams

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -414,7 +414,8 @@ object Erasure {
         }
       }
 
-      if (tree.symbol eq defn.Phantom_assume) PhantomErasure.erasedAssume
+      if ((origSym eq defn.Phantom_assume) || (origSym.is(Flags.ParamAccessor) && wasPhantom(pt)))
+        PhantomErasure.erasedAssume
       else recur(typed(tree.qualifier, AnySelectionProto))
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -493,7 +493,7 @@ object Checking {
             if (param.is(Mutable))
               ctx.error(ValueClassParameterMayNotBeAVar(clazz, param), param.pos)
             if (param.info.isPhantom)
-              ctx.error("value class first parameter must not be phantom.", param.pos)
+              ctx.error("value class first parameter must not be phantom", param.pos)
             else {
               for (p <- params if !p.info.isPhantom)
                 ctx.error("value class can only have one non phantom parameter", p.pos)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -489,13 +489,17 @@ object Checking {
           param.isTerm && !param.is(Flags.Accessor)
         }
         clParamAccessors match {
-          case List(param) =>
+          case param :: params =>
             if (param.is(Mutable))
               ctx.error(ValueClassParameterMayNotBeAVar(clazz, param), param.pos)
             if (param.info.isPhantom)
-              ctx.error("value class parameter must not be phantom", param.pos)
-          case _ =>
-            ctx.error(ValueClassNeedsExactlyOneValParam(clazz), clazz.pos)
+              ctx.error("value class first parameter must not be phantom.", param.pos)
+            else {
+              for (p <- params if !p.info.isPhantom)
+                ctx.error("value class can only have one non phantom parameter", p.pos)
+            }
+          case Nil =>
+            ctx.error(ValueClassNeedsOneValParam(clazz), clazz.pos)
         }
       }
       stats.foreach(checkValueClassMember)

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -772,14 +772,14 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("variable i", param.show)
     }
 
-  @Test def valueClassNeedsExactlyOneVal =
+  @Test def valueClassNeedsOneVal =
     checkMessagesAfter("refchecks") {
-      """class MyValue(var i: Int, j: Int) extends AnyVal"""
+      """class MyValue() extends AnyVal"""
     }
     .expect { (ictx, messages) =>
       implicit val ctx: Context = ictx
       assertMessageCount(1, messages)
-      val ValueClassNeedsExactlyOneValParam(valueClass) :: Nil = messages
+      val ValueClassNeedsOneValParam(valueClass) :: Nil = messages
       assertEquals("class MyValue", valueClass.show)
     }
 

--- a/tests/neg/phantom-in-value-class.scala
+++ b/tests/neg/phantom-in-value-class.scala
@@ -1,0 +1,11 @@
+import MyPhantom._
+
+
+class Cursed1(val p: Boo) extends AnyVal // error
+
+class Cursed2(val n: Int)(val a: Int) extends AnyVal // error
+
+object MyPhantom extends Phantom {
+  type Boo <: super[MyPhantom].Any
+  def boo: Boo = assume
+}

--- a/tests/run/phantom-in-value-class.scala
+++ b/tests/run/phantom-in-value-class.scala
@@ -1,0 +1,22 @@
+import MyPhantom._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val cursed = new Cursed(7)(boo)
+    val cursed2 = new Cursed(7)(boo)
+    cursed.p
+    cursed2.p
+  }
+}
+
+
+class Cursed(val n: Int)(val p: Boo) extends AnyVal
+
+class Cursed2[B <: Boo](val n: Int)(val p: B) extends AnyVal
+
+class Cursed3[B <: Boo](val n: Int)(val p1: Boo, val p2: B) extends AnyVal
+
+object MyPhantom extends Phantom {
+  type Boo <: super[MyPhantom].Any
+  def boo: Boo = assume
+}


### PR DESCRIPTION
In this implementation the first parameter of the
value class must be a subtype of scala.Any. Every
other parameter must be phantom.