### PR TITLE
Fix #2430: Make Erasure pass Ycheck

### DIFF
--- a/compiler/test/dotc/tests.scala
+++ b/compiler/test/dotc/tests.scala
@@ -68,7 +68,7 @@ class tests extends CompilerTest {
   }
 
   implicit val defaultOptions: List[String] = noCheckOptions ++ {
-    if (dotty.Properties.isRunByDrone) List("-Ycheck:tailrec,resolveSuper,mixin,getClass,restoreScopes,labelDef") // should be Ycheck:all, but #725
+    if (dotty.Properties.isRunByDrone) List("-Ycheck:tailrec,resolveSuper,erasure,mixin,getClass,restoreScopes,labelDef") // should be Ycheck:all, but #725
     else List("-Ycheck:tailrec,resolveSuper,mixin,restoreScopes,labelDef,simplify")
   } ++ checkOptions ++ classPath
 

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -50,7 +50,7 @@ object TestConfiguration {
     Array("-classpath", paths)
   }
 
-  private val yCheckOptions = Array("-Ycheck:tailrec,resolveSuper,mixin,getClass,restoreScopes,labelDef")
+  private val yCheckOptions = Array("-Ycheck:tailrec,resolveSuper,erasure,mixin,getClass,restoreScopes,labelDef")
 
   val defaultUnoptimised = noCheckOptions ++ checkOptions ++ yCheckOptions ++ classPath
   val defaultOptimised = defaultUnoptimised :+ "-optimise"


### PR DESCRIPTION
During Erasure, a value class A with underlying type U has its type
semi-erased to ErasedValueType(A, [semi-erasure of U]). To make Erasure
typecheck, special cast functions A.evt2u$ and A.u2evt$ are used to cast
between the underlying type and the class EVT type. Before this commit,
this conversion was not always correctly done for nested value classes,
this did not lead to problems in practice but broke -Ycheck:erasure.