### PR TITLE
Fix #2929: REPL error for classes with a show method

### DIFF
--- a/compiler/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
+++ b/compiler/src/dotty/tools/dotc/repl/CompilingInterpreter.scala
@@ -724,7 +724,7 @@ class CompilingInterpreter(
            |  if ($fullPath.asInstanceOf[AnyRef] != null) {
            |    (if ($fullPath.toString().contains('\\n')) "\\n" else "") + {
            |      import dotty.Show._
-           |      $fullPath.show /*toString()*/ + "\\n"
+           |      (new ShowValue($fullPath)).show /*toString()*/ + "\\n"
            |    }
            |  } else {
            |    "null\\n"

--- a/tests/repl/showMethod.check
+++ b/tests/repl/showMethod.check
@@ -1,0 +1,9 @@
+scala> class A { def show = "hello"; override def toString = "A" }
+defined class A
+scala> new A
+val res0: A = A
+scala> class B { def show() = "hello"; override def toString = "B" }
+defined class B
+scala> new B
+val res1: B = B
+scala> :quit


### PR DESCRIPTION
Don't rely on implicit conversion to call the .show method