### PR TITLE
Vulpix should catch and report all exceptions during compilation of test cases

### DIFF
--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -324,7 +324,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
         if (!isInteractive) realStdout.println(testing)
         op
       } catch {
-        case NonFatal(e) => {
+        case e: Throwable => {
           // if an exception is thrown during compilation, the complete test
           // run should fail
           failTestSource(testSource)


### PR DESCRIPTION
Vulpix currently only catches `NonFatal` exceptions in `tryCompile`, silently omitting exceptions such as those for stack overflows. Worse yet, such exceptions are then caught somewhere higher up in vulpix, but `registerCompletion(1)` is never called for the respective failing test cases, causing vulpix to hang in an idle state.

Vulpix should arguably catch all sorts of exceptions and also report the respective stack traces. I'd be grateful if someone also pointed out where such fatal exceptions were currently caught, perhaps that exception handler higher up should actually abort testing.