### PR TITLE
[Do not merge] Aborted Experiment: Native AppliedType 

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -889,7 +889,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
           // to inner symbols of DefDef
           // todo: somehow handle.
 
-    def parents: List[Type] = tp.parents
+    def parents: List[Type] = tp.parentsNEW
   }
 
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -214,7 +214,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   def ClassDef(cls: ClassSymbol, constr: DefDef, body: List[Tree], superArgs: List[Tree] = Nil)(implicit ctx: Context): TypeDef = {
     val firstParentRef :: otherParentRefs = cls.info.parentRefs
-    val firstParent = cls.typeRef.baseTypeWithArgs(firstParentRef.symbol)
+    val firstParent = cls.appliedRef.baseTypeWithArgs(firstParentRef.symbol)
     val superRef =
       if (cls is Trait) TypeTree(firstParent)
       else {

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -213,7 +213,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     ta.assignType(untpd.TypeDef(sym.name, TypeTree(sym.info)), sym)
 
   def ClassDef(cls: ClassSymbol, constr: DefDef, body: List[Tree], superArgs: List[Tree] = Nil)(implicit ctx: Context): TypeDef = {
-    val firstParentRef :: otherParentRefs = cls.info.parents
+    val firstParentRef :: otherParentRefs = cls.info.parentRefs
     val firstParent = cls.typeRef.baseTypeWithArgs(firstParentRef.symbol)
     val superRef =
       if (cls is Trait) TypeTree(firstParent)
@@ -261,7 +261,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def AnonClass(parents: List[Type], fns: List[TermSymbol], methNames: List[TermName])(implicit ctx: Context): Block = {
     val owner = fns.head.owner
     val parents1 =
-      if (parents.head.classSymbol.is(Trait)) parents.head.parents.head :: parents
+      if (parents.head.classSymbol.is(Trait)) parents.head.parentRefs.head :: parents
       else parents
     val cls = ctx.newNormalizedClassSymbol(owner, tpnme.ANON_FUN, Synthetic, parents1,
         coord = fns.map(_.pos).reduceLeft(_ union _))

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -79,7 +79,7 @@ object Config {
   final val traceDeepSubTypeRecursions = false
 
   /** When explaining subtypes and this flag is set, also show the classes of the compared types. */
-  final val verboseExplainSubtype = false
+  final val verboseExplainSubtype = true
 
   /** If this flag is set, take the fast path when comparing same-named type-aliases and types */
   final val fastPathForRefinedSubtype = true
@@ -175,5 +175,5 @@ object Config {
   /** When in IDE, turn StaleSymbol errors into warnings instead of crashing */
   final val ignoreStaleInIDE = true
 
-  final val newScheme = false
+  final val newScheme = true
 }

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -174,4 +174,6 @@ object Config {
 
   /** When in IDE, turn StaleSymbol errors into warnings instead of crashing */
   final val ignoreStaleInIDE = true
+
+  final val newScheme = false
 }

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -175,5 +175,5 @@ object Config {
   /** When in IDE, turn StaleSymbol errors into warnings instead of crashing */
   final val ignoreStaleInIDE = true
 
-  final val newScheme = true
+  val newScheme = true
 }

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -202,8 +202,6 @@ trait ConstraintHandling {
             tp.derivedAppliedType(tycon,
               args.zipWithConserve(tycon.typeParams)(avoidInArg))
           case tp: RefinedType if param occursIn tp.refinedInfo =>
-            assert(fromBelow || variance <= 0,
-              "unsound approximation of $param with bounds ${constraint.fullUpperBound(param)}")
             tp.parent
           case tp: WildcardType =>
             val bounds = tp.optBounds.orElse(TypeBounds.empty).bounds

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -14,7 +14,6 @@ import NameOps._
 import Uniques._
 import SymDenotations._
 import Comments._
-import Flags.ParamAccessor
 import util.Positions._
 import ast.Trees._
 import ast.untpd
@@ -335,7 +334,9 @@ object Contexts {
      *    from constructor parameters to class parameter accessors.
      */
     def superCallContext: Context = {
-      val locals = newScopeWith(owner.asClass.paramAccessors: _*)
+      val locals = newScopeWith(
+        (if (Config.newScheme) owner.typeParams ++ owner.asClass.paramAccessors
+        else owner.asClass.paramAccessors): _*)
       superOrThisCallContext(owner.primaryConstructor, locals)
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -605,7 +605,7 @@ object Contexts {
     }
 
     /** A table for hash consing unique refined types */
-    private[dotc] val uniqueRefinedTypes = new RefinedUniques
+    private[dotc] val uniqueRefinedTypes = new RefinedUniques // @!!! replace with uniqueAppliedTypes
 
     /** A table for hash consing unique named types */
     private[core] val uniqueNamedTypes = new NamedTypeUniques

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -82,7 +82,7 @@ class Definitions {
           if (tpe.typeParams.nonEmpty) tpe.appliedTo(typeParam.typeRef)
           else tpe
         val parents = parentConstrs.toList map instantiate
-        val parentRefs: List[TypeRef] = ctx.normalizeToClassRefs(parents, cls, paramDecls)
+        val parentRefs = ctx.normalizeToClassRefs(parents, cls, paramDecls)
         denot.info = ClassInfo(ScalaPackageClass.thisType, cls, parentRefs, paramDecls)
       }
     }
@@ -721,7 +721,8 @@ class Definitions {
       if (ctx.erasedTypes) JavaArrayType(elem)
       else ArrayType.appliedTo(elem :: Nil)
     def unapply(tp: Type)(implicit ctx: Context): Option[Type] = tp.dealias match {
-      case at: RefinedType if (at isRef ArrayType.symbol) && at.argInfos.length == 1 => Some(at.argInfos.head)
+      case AppliedType(at, arg :: Nil) if at isRef ArrayType.symbol => Some(arg)
+      case at: RefinedType if (at isRef ArrayType.symbol) && at.argInfos.length == 1 => Some(at.argInfos.head) // @!!!
       case _ => None
     }
   }

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -644,6 +644,10 @@ object Denotations {
     // ------ Forming types -------------------------------------------
 
     /** The TypeRef representing this type denotation at its original location. */
+    def appliedRef(implicit ctx: Context): Type =
+      if (Config.newScheme) typeRef.appliedTo(symbol.typeParams.map(_.typeRef))
+      else typeRef
+
     def typeRef(implicit ctx: Context): TypeRef =
       TypeRef(symbol.owner.thisType, symbol.name.asTypeName, this)
 

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -250,7 +250,7 @@ object Flags {
    */
   final val ParamAccessor = commonFlag(14, "<paramaccessor>")
   final val TermParamAccessor = ParamAccessor.toTermFlags
-  final val TypeParamAccessor = ParamAccessor.toTypeFlags
+  final val TypeParamAccessor = ParamAccessor.toTypeFlags  // @!!!
 
     /** A value or class implementing a module */
   final val Module = commonFlag(15, "module")
@@ -306,7 +306,7 @@ object Flags {
 
   /** A binding for a type parameter of a base class or trait.
    */
-  final val BaseTypeArg = typeFlag(25, "<basetypearg>")
+  final val BaseTypeArg = typeFlag(25, "<basetypearg>")  // @!!!
 
   final val CaseAccessorOrBaseTypeArg = CaseAccessor.toCommonFlags
 

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -16,7 +16,7 @@ trait Substituters { this: Context =>
         else tp.derivedSelect(subst(tp.prefix, from, to, theMap))
       case _: ThisType | NoPrefix =>
         tp
-      case tp: RefinedType =>
+      case tp: RefinedType => // @!!! remove
         tp.derivedRefinedType(subst(tp.parent, from, to, theMap), tp.refinedName, subst(tp.refinedInfo, from, to, theMap))
       case tp: TypeAlias =>
         tp.derivedTypeAlias(subst(tp.alias, from, to, theMap))

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1379,6 +1379,14 @@ object SymDenotations {
         NoSymbol
     }
 
+    /** The explicitly given self type (self types of modules are assumed to be
+     *  explcitly given here).
+     */
+    def givenSelfType(implicit ctx: Context) = classInfo.selfInfo match {
+      case tp: Type => tp
+      case self: Symbol => self.info
+    }
+
    // ------ class-specific operations -----------------------------------
 
     private[this] var myThisType: Type = null

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1171,6 +1171,7 @@ object SymDenotations {
       case tp: TypeBounds => hasSkolems(tp.lo) || hasSkolems(tp.hi)
       case tp: TypeVar => hasSkolems(tp.inst)
       case tp: ExprType => hasSkolems(tp.resType)
+      case tp: AppliedType => hasSkolems(tp.tycon) || tp.args.exists(hasSkolems)
       case tp: HKApply => hasSkolems(tp.tycon) || tp.args.exists(hasSkolems)
       case tp: LambdaType => tp.paramInfos.exists(hasSkolems) || hasSkolems(tp.resType)
       case tp: AndOrType => hasSkolems(tp.tp1) || hasSkolems(tp.tp2)

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -699,7 +699,7 @@ object SymDenotations {
                | is not a subclass of ${owner.showLocated} where target is defined""")
         else if (
           !(  isType // allow accesses to types from arbitrary subclasses fixes #4737
-           || pre.baseTypeRef(cls).exists // ??? why not use derivesFrom ???
+           || pre.derivesFrom(cls)
            || isConstructor
            || (owner is ModuleClass) // don't perform this check for static members
            ))
@@ -1266,10 +1266,10 @@ object SymDenotations {
     private[this] var myMemberCache: LRUCache[Name, PreDenotation] = null
     private[this] var myMemberCachePeriod: Period = Nowhere
 
-    /** A cache from types T to baseTypeRef(T, C) */
-    type BaseTypeRefMap = java.util.HashMap[CachedType, Type]
-    private[this] var myBaseTypeRefCache: BaseTypeRefMap = null
-    private[this] var myBaseTypeRefCachePeriod: Period = Nowhere
+    /** A cache from types T to baseType(T, C) */
+    type BaseTypeMap = java.util.HashMap[CachedType, Type]
+    private[this] var myBaseTypeCache: BaseTypeMap = null
+    private[this] var myBaseTypeCachePeriod: Period = Nowhere
 
     private var baseDataCache: BaseData = BaseData.None
     private var memberNamesCache: MemberNames = MemberNames.None
@@ -1282,14 +1282,14 @@ object SymDenotations {
       myMemberCache
     }
 
-    private def baseTypeRefCache(implicit ctx: Context): BaseTypeRefMap = {
-      if (myBaseTypeRefCachePeriod != ctx.period &&
-          (myBaseTypeRefCachePeriod.runId != ctx.runId ||
-           ctx.phases(myBaseTypeRefCachePeriod.phaseId).sameParentsStartId != ctx.phase.sameParentsStartId)) {
-        myBaseTypeRefCache = new BaseTypeRefMap
-        myBaseTypeRefCachePeriod = ctx.period
+    private def baseTypeCache(implicit ctx: Context): BaseTypeMap = {
+      if (myBaseTypeCachePeriod != ctx.period &&
+          (myBaseTypeCachePeriod.runId != ctx.runId ||
+           ctx.phases(myBaseTypeCachePeriod.phaseId).sameParentsStartId != ctx.phase.sameParentsStartId)) {
+        myBaseTypeCache = new BaseTypeMap
+        myBaseTypeCachePeriod = ctx.period
       }
-      myBaseTypeRefCache
+      myBaseTypeCache
     }
 
     private def invalidateBaseDataCache() = {
@@ -1302,9 +1302,9 @@ object SymDenotations {
       memberNamesCache = MemberNames.None
     }
 
-    def invalidateBaseTypeRefCache() = {
-      myBaseTypeRefCache = null
-      myBaseTypeRefCachePeriod = Nowhere
+    def invalidateBaseTypeCache() = {
+      myBaseTypeCache = null
+      myBaseTypeCachePeriod = Nowhere
     }
 
     override def copyCaches(from: SymDenotation, phase: Phase)(implicit ctx: Context): this.type = {
@@ -1313,7 +1313,7 @@ object SymDenotations {
           if (from.memberNamesCache.isValidAt(phase)) memberNamesCache = from.memberNamesCache
           if (from.baseDataCache.isValidAt(phase)) {
             baseDataCache = from.baseDataCache
-            myBaseTypeRefCache = from.baseTypeRefCache
+            myBaseTypeCache = from.baseTypeCache
           }
         case _ =>
       }
@@ -1581,11 +1581,11 @@ object SymDenotations {
       raw.filterExcluded(excluded).asSeenFrom(pre).toDenot(pre)
     }
 
-    /** Compute tp.baseTypeRef(this) */
-    final def baseTypeRefOf(tp: Type)(implicit ctx: Context): Type = {
+    /** Compute tp.baseType(this) */
+    final def baseTypeOf(tp: Type)(implicit ctx: Context): Type = {
 
       def foldGlb(bt: Type, ps: List[Type]): Type = ps match {
-        case p :: ps1 => foldGlb(bt & baseTypeRefOf(p), ps1)
+        case p :: ps1 => foldGlb(bt & baseTypeOf(p), ps1)
         case _ => bt
       }
 
@@ -1597,7 +1597,7 @@ object SymDenotations {
        *    and this changes subtyping relations. As a shortcut, we do not
        *    cache ErasedValueType at all.
        */
-      def isCachable(tp: Type, btrCache: BaseTypeRefMap): Boolean = {
+      def isCachable(tp: Type, btrCache: BaseTypeMap): Boolean = {
         def inCache(tp: Type) = btrCache.containsKey(tp)
         tp match {
           case _: TypeErasure.ErasedValueType => false
@@ -1609,12 +1609,12 @@ object SymDenotations {
         }
       }
 
-      def computeBaseTypeRefOf(tp: Type): Type = {
+      def computeBaseTypeOf(tp: Type): Type = {
         Stats.record("computeBaseTypeOf")
-        if (symbol.isStatic && tp.derivesFrom(symbol))
+        if (symbol.isStatic && tp.derivesFrom(symbol) && symbol.typeParams.isEmpty)
           symbol.typeRef
         else tp match {
-          case tp: TypeRef =>
+          case tp: RefType =>
             val subcls = tp.symbol
             if (subcls eq symbol)
               tp
@@ -1623,14 +1623,14 @@ object SymDenotations {
                 if (cdenot.baseClassSet contains symbol) foldGlb(NoType, tp.parents)
                 else NoType
               case _ =>
-                baseTypeRefOf(tp.superType)
+                baseTypeOf(tp.superType)
             }
           case tp: TypeProxy =>
-            baseTypeRefOf(tp.superType)
+            baseTypeOf(tp.superType)
           case AndType(tp1, tp2) =>
-            baseTypeRefOf(tp1) & baseTypeRefOf(tp2)
+            baseTypeOf(tp1) & baseTypeOf(tp2)
           case OrType(tp1, tp2) =>
-            baseTypeRefOf(tp1) | baseTypeRefOf(tp2)
+            baseTypeOf(tp1) | baseTypeOf(tp2)
           case JavaArrayType(_) if symbol == defn.ObjectClass =>
             this.typeRef
           case _ =>
@@ -1638,16 +1638,16 @@ object SymDenotations {
         }
       }
 
-      /*>|>*/ ctx.debugTraceIndented(s"$tp.baseTypeRef($this)") /*<|<*/ {
+      /*>|>*/ ctx.debugTraceIndented(s"$tp.baseType($this)") /*<|<*/ {
         tp match {
           case tp: CachedType =>
-          val btrCache = baseTypeRefCache
+          val btrCache = baseTypeCache
             try {
               var basetp = btrCache get tp
               if (basetp == null) {
                 btrCache.put(tp, NoPrefix)
-                basetp = computeBaseTypeRefOf(tp)
-                if (isCachable(tp, baseTypeRefCache)) btrCache.put(tp, basetp)
+                basetp = computeBaseTypeOf(tp)
+                if (isCachable(tp, baseTypeCache)) btrCache.put(tp, basetp)
                 else btrCache.remove(tp)
               } else if (basetp == NoPrefix)
                 throw CyclicReference(this)
@@ -1659,7 +1659,7 @@ object SymDenotations {
                 throw ex
             }
           case _ =>
-            computeBaseTypeRefOf(tp)
+            computeBaseTypeOf(tp)
         }
       }
     }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1620,7 +1620,7 @@ object SymDenotations {
               tp
             else subcls.denot match {
               case cdenot: ClassDenotation =>
-                if (cdenot.baseClassSet contains symbol) foldGlb(NoType, tp.parents)
+                if (cdenot.baseClassSet contains symbol) foldGlb(NoType, tp.parentsNEW) // !!! change to parents
                 else NoType
               case _ =>
                 baseTypeOf(tp.superType)

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1728,11 +1728,11 @@ object SymDenotations {
       else constrNamed(nme.CONSTRUCTOR).orElse(constrNamed(nme.TRAIT_CONSTRUCTOR))
     }
 
-    /** The parameter accessors of this class. Term and type accessors,
-     *  getters and setters are all returned int his list
+    /** The term parameter accessors of this class.
+     *  Both getters and setters are returned in this list.
      */
     def paramAccessors(implicit ctx: Context): List[Symbol] =
-      unforcedDecls.filter(_ is ParamAccessor).toList
+      unforcedDecls.filter(_.is(ParamAccessor)).toList
 
     /** If this class has the same `decls` scope reference in `phase` and
      *  `phase.next`, install a new denotation with a cloned scope in `phase.next`.

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1424,7 +1424,14 @@ object SymDenotations {
         else ThisType.raw(TypeRef(pre, symbol.asType))
       }
 */
-    private[this] var myTypeRef: TypeRef = null
+    private[this] var myAppliedRef: Type = null // @!!!: Use classInfo.appliedRef instead?
+    private[this] var myTypeRef: TypeRef = null // @!!!: Use classInfo.appliedRef instead?
+
+    override def appliedRef(implicit ctx: Context): Type = {
+      if (myAppliedRef == null) myAppliedRef = super.appliedRef
+      if (ctx.erasedTypes) myAppliedRef.typeConstructor
+      else myAppliedRef
+    }
 
     override def typeRef(implicit ctx: Context): TypeRef = {
       if (myTypeRef == null) myTypeRef = super.typeRef
@@ -1632,7 +1639,7 @@ object SymDenotations {
       def computeBaseTypeOf(tp: Type): Type = {
         Stats.record("computeBaseTypeOf")
         if (symbol.isStatic && tp.derivesFrom(symbol) && symbol.typeParams.isEmpty)
-          symbol.typeRef
+          symbol.appliedRef
         else tp match {
           case tp: RefType =>
             val subcls = tp.symbol

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -46,8 +46,8 @@ trait SymDenotations { this: Context =>
     else {
       val initial = denot.initial
       val firstPhaseId = initial.validFor.firstPhaseId.max(ctx.typerPhase.id)
-     if ((initial ne denot) || ctx.phaseId != firstPhaseId) {
-       ctx.withPhase(firstPhaseId).stillValidInOwner(initial) ||
+      if ((initial ne denot) || ctx.phaseId != firstPhaseId) {
+        ctx.withPhase(firstPhaseId).stillValidInOwner(initial) ||
          // Workaround #1895: A symbol might not be entered into an owner
          // until the second phase where it exists
          (denot.validFor.containsPhaseId(firstPhaseId + 1)) &&
@@ -1220,7 +1220,7 @@ object SymDenotations {
       info2 match {
         case info2: ClassInfo =>
           info1 match {
-            case info1: ClassInfo => info1.classParents ne info2.classParents
+            case info1: ClassInfo => info1.classParentsNEW ne info2.classParentsNEW
             case _ => completersMatter
           }
         case _ => completersMatter
@@ -1366,13 +1366,24 @@ object SymDenotations {
     }
 
     /** The denotations of all parents in this class. */
-    def classParents(implicit ctx: Context): List[TypeRef] = info match {
-      case classInfo: ClassInfo => classInfo.classParents
+    def classParentRefs(implicit ctx: Context): List[TypeRef] = info match {
+      case classInfo: ClassInfo => classInfo.parentRefs
+      case _ => Nil
+    }
+
+    /** The denotations of all parents in this class. */
+    def classParentsWithArgs(implicit ctx: Context): List[Type] = info match {
+      case classInfo: ClassInfo => classInfo.parentsWithArgs
+      case _ => Nil
+    }
+
+    def classParentsNEW(implicit ctx: Context): List[Type] = info match {
+      case classInfo: ClassInfo => classInfo.parentsNEW
       case _ => Nil
     }
 
     /** The symbol of the superclass, NoSymbol if no superclass exists */
-    def superClass(implicit ctx: Context): Symbol = classParents match {
+    def superClass(implicit ctx: Context): Symbol = classParentsNEW match {
       case parent :: _ =>
         val cls = parent.classSymbol
         if (cls is Trait) NoSymbol else cls
@@ -1438,10 +1449,10 @@ object SymDenotations {
     def computeBaseData(implicit onBehalf: BaseData, ctx: Context): (List[ClassSymbol], BaseClassSet) = {
       def emptyParentsExpected =
         is(Package) || (symbol == defn.AnyClass) || ctx.erasedTypes && (symbol == defn.ObjectClass)
-      if (classParents.isEmpty && !emptyParentsExpected)
+      if (classParentsNEW.isEmpty && !emptyParentsExpected)
         onBehalf.signalProvisional()
       val builder = new BaseDataBuilder
-      for (p <- classParents) builder.addAll(p.symbol.asClass.baseClasses)
+      for (p <- classParentsNEW) builder.addAll(p.typeSymbol.asClass.baseClasses)
       (classSymbol :: builder.baseClasses, builder.baseClassSet)
     }
 
@@ -1567,10 +1578,10 @@ object SymDenotations {
       val ownDenots = info.decls.denotsNamed(name, selectNonPrivate)
       if (debugTrace) // DEBUG
         println(s"$this.member($name), ownDenots = $ownDenots")
-      def collect(denots: PreDenotation, parents: List[TypeRef]): PreDenotation = parents match {
+      def collect(denots: PreDenotation, parents: List[Type]): PreDenotation = parents match {
         case p :: ps =>
           val denots1 = collect(denots, ps)
-          p.symbol.denot match {
+          p.typeSymbol.denot match {
             case parentd: ClassDenotation =>
               denots1 union
                 parentd.nonPrivateMembersNamed(name, inherited = true)
@@ -1582,7 +1593,7 @@ object SymDenotations {
           denots
       }
       if (name.isConstructorName) ownDenots
-      else collect(ownDenots, classParents)
+      else collect(ownDenots, classParentsNEW)
     }
 
     override final def findMember(name: Name, pre: Type, excluded: FlagSet)(implicit ctx: Context): Denotation = {
@@ -1629,7 +1640,7 @@ object SymDenotations {
               tp
             else subcls.denot match {
               case cdenot: ClassDenotation =>
-                if (cdenot.baseClassSet contains symbol) foldGlb(NoType, tp.parentsNEW) // !!! change to parents
+                if (cdenot.baseClassSet contains symbol) foldGlb(NoType, tp.parentsNEW)
                 else NoType
               case _ =>
                 baseTypeOf(tp.superType)
@@ -1684,8 +1695,8 @@ object SymDenotations {
     def computeMemberNames(keepOnly: NameFilter)(implicit onBehalf: MemberNames, ctx: Context): Set[Name] = {
       var names = Set[Name]()
       def maybeAdd(name: Name) = if (keepOnly(thisType, name)) names += name
-      for (p <- classParents)
-        for (name <- p.symbol.asClass.memberNames(keepOnly))
+      for (p <- classParentsNEW)
+        for (name <- p.typeSymbol.asClass.memberNames(keepOnly))
           maybeAdd(name)
       val ownSyms =
         if (keepOnly eq implicitFilter)

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -123,7 +123,7 @@ trait Symbols { this: Context =>
       def complete(denot: SymDenotation)(implicit ctx: Context): Unit = {
         val cls = denot.asClass.classSymbol
         val decls = newScope
-        val parentRefs: List[TypeRef] = normalizeToClassRefs(parentTypes, cls, decls)
+        val parentRefs = normalizeToClassRefs(parentTypes, cls, decls)
         denot.info = ClassInfo(owner.thisType, cls, parentRefs, decls)
       }
     }

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -185,7 +185,7 @@ object TypeApplications {
           case arg =>
             arg
         }
-      case _: TypeBounds | _: HKApply =>
+      case _: TypeBounds | _: HKApply | _: AppliedType =>
         val saved = available
         available = Set()
         try mapOver(t)
@@ -453,7 +453,8 @@ class TypeApplications(val self: Type) extends AnyVal {
       case _ if typParams.isEmpty || typParams.head.isInstanceOf[LambdaParam] =>
         HKApply(self, args)
       case dealiased =>
-        matchParams(dealiased, typParams, args)
+        if (Config.newScheme) ???
+        else matchParams(dealiased, typParams, args)
     }
   }
 
@@ -593,6 +594,7 @@ class TypeApplications(val self: Type) extends AnyVal {
    */
   final def withoutArgs(typeArgs: List[Type]): Type = self match {
     case HKApply(tycon, args) => tycon
+    case AppliedType(tycon, args) => tycon
     case _ =>
       typeArgs match {
         case _ :: typeArgs1 =>

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -221,6 +221,8 @@ class TypeApplications(val self: Type) extends AnyVal {
         Nil
       case self: WildcardType =>
         self.optBounds.typeParams
+      case self: AppliedType =>
+        Nil
       case self: TypeProxy =>
         self.superType.typeParams
       case _ =>
@@ -292,7 +294,7 @@ class TypeApplications(val self: Type) extends AnyVal {
    */
   def EtaExpand(tparams: List[TypeSymbol])(implicit ctx: Context): Type = {
     val tparamsToUse = if (variancesConform(typeParams, tparams)) tparams else typeParamSymbols
-    HKTypeLambda.fromParams(tparamsToUse, self.appliedTo(tparams map (_.typeRef)))
+    HKTypeLambda.fromParams(tparamsToUse, self.appliedTo(tparams.map(_.typeRef)))
       //.ensuring(res => res.EtaReduce =:= self, s"res = $res, core = ${res.EtaReduce}, self = $self, hc = ${res.hashCode}")
   }
 
@@ -539,7 +541,7 @@ class TypeApplications(val self: Type) extends AnyVal {
       self.derivedExprType(tp.translateParameterized(from, to))
     case _ =>
       if (self.derivesFrom(from))
-        if (ctx.erasedTypes) to.typeRef
+        if (ctx.erasedTypes) to.typeRef // @!!! can be dropped; appliedTo does the right thing anyway
         else if (Config.newScheme) to.typeRef.appliedTo(self.baseType(from).argInfos)
         else RefinedType(to.typeRef, to.typeParams.head.name, self.member(from.typeParams.head.name).info)
       else self

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -443,7 +443,7 @@ class TypeApplications(val self: Type) extends AnyVal {
       case dealiased: TypeBounds =>
         dealiased.derivedTypeBounds(dealiased.lo.appliedTo(args), dealiased.hi.appliedTo(args))
       case dealiased: LazyRef =>
-        LazyRef(() => dealiased.ref.appliedTo(args))
+        LazyRef(c => dealiased.ref(c).appliedTo(args))
       case dealiased: WildcardType =>
         WildcardType(dealiased.optBounds.appliedTo(args).bounds)
       case dealiased: TypeRef if dealiased.symbol == defn.NothingClass =>

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -515,7 +515,7 @@ class TypeApplications(val self: Type) extends AnyVal {
           case TypeBounds(_, hi) => hi.baseTypeWithArgs(base)
           case _ => default
         }
-      case tp @ RefinedType(parent, name, _) if !isExpandedTypeParam(tp.member(name).symbol) =>
+      case tp @ RefinedType(parent, name, _) if !Config.newScheme && !isExpandedTypeParam(tp.member(name).symbol) =>
         tp.wrapIfMember(parent.baseTypeWithArgs(base))
       case tp: TermRef =>
         tp.underlying.baseTypeWithArgs(base)

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -160,10 +160,25 @@ object TypeApplications {
       p.binder == tycon && args(p.paramNum).isInstanceOf[TypeBounds]
     def canReduceWildcard(p: TypeParamRef) =
       !ctx.mode.is(Mode.AllowLambdaWildcardApply) || available.contains(p.paramNum)
-    def apply(t: Type) = t match {
-      case t @ TypeAlias(p: TypeParamRef) if hasWildcardArg(p) && canReduceWildcard(p) =>
+
+    // If this is a reference to a reducable type parameter corresponding to a
+    // wildcard argument, return the wildcard argument, otherwise apply recursively.
+    def applyArg(arg: Type): Type = arg match {
+      case p: TypeParamRef if hasWildcardArg(p) && canReduceWildcard(p) =>
         available -= p.paramNum
         args(p.paramNum)
+      case _ =>
+        apply(arg)
+    }
+    
+    def apply(t: Type) = t match {
+      case t @ TypeAlias(alias) =>
+        applyArg(alias) match {
+          case arg1: TypeBounds => arg1
+          case arg1 => t.derivedTypeAlias(arg1)
+        }
+      case t @ AppliedType(tycon, args1) if tycon.typeSymbol.isClass =>
+        t.derivedAppliedType(apply(tycon), args1.mapConserve(applyArg))
       case p: TypeParamRef if p.binder == tycon =>
         args(p.paramNum) match {
           case TypeBounds(lo, hi) =>

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -170,7 +170,7 @@ object TypeApplications {
       case _ =>
         apply(arg)
     }
-    
+
     def apply(t: Type) = t match {
       case t @ TypeAlias(alias) =>
         applyArg(alias) match {

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -407,14 +407,51 @@ class TypeApplications(val self: Type) extends AnyVal {
         }
       case nil => t
     }
+    val stripped = self.stripTypeVar
+    val dealiased = stripped.safeDealias
+
+    /** Normalize a TypeBounds argument. This involves (1) propagating bounds
+     *  from the type parameters into the argument, (2) possibly choosing the argument's
+     *  upper or lower bound according to variance.
+     *
+     *  Bounds propagation works as follows: If the dealiased type constructor is a TypeRef
+     *  `p.c`,
+     *    - take the type paramater bounds of `c` as seen from `p`,
+     *    - substitute concrete (non-bound) arguments for corresponding formal type parameters,
+     *    - interpolate, so that any (F-bounded) type parameters in the resulting bounds are avoided.
+     *  The resulting bounds are joined (via &) with corresponding type bound arguments.
+     */
     def normalizeWildcardArg(arg: Type, tparam: TypeParamInfo): Type = arg match {
       case TypeBounds(lo, hi) =>
         val v = tparam.paramVariance
-        if (v > 0) hi else if (v < 0) lo else arg
+        val avoidParams = new ApproximatingTypeMap {
+          variance = v
+          def apply(t: Type) = t match {
+            case t: TypeRef if typParams contains t.symbol =>
+              val bounds = apply(t.info).bounds
+              approx(bounds.lo, bounds.hi)
+            case _ => mapOver(t)
+          }
+        }
+        val pbounds = dealiased match {
+          case dealiased @ TypeRef(prefix, _) =>
+            val (concreteArgs, concreteParams) =
+              args.zip(typeParams.asInstanceOf[List[TypeSymbol]])
+                .filter(!_._1.isInstanceOf[TypeBounds])
+                .unzip
+            avoidParams(
+              tparam.paramInfo.asSeenFrom(prefix, dealiased.symbol.owner)
+                .subst(concreteParams, concreteArgs)).orElse(TypeBounds.empty)
+          case _ =>
+            TypeBounds.empty
+        }
+        //typr.println(i"normalize arg $arg for $tparam in $self app $args%, %, pbounds, = $pbounds")
+        if (v > 0) hi & pbounds.hiBound
+        else if (v < 0) lo | pbounds.loBound
+        else arg & pbounds
       case _ => arg
     }
-    val stripped = self.stripTypeVar
-    val dealiased = stripped.safeDealias
+
     if (args.isEmpty || ctx.erasedTypes) self
     else dealiased match {
       case dealiased: HKTypeLambda =>

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -342,6 +342,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
           // with `B[Y]`. To do the right thing, we need to instantiate `C` to the
           // common superclass of `A` and `B`.
           isSubType(tp1.join, tp2)
+        case tp2: AppliedType if !tp2.tycon.typeSymbol.isClass =>
+          isSubType(tp1.join, tp2)
         case _ =>
           false
       }
@@ -376,6 +378,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
   }
 
   private def thirdTry(tp1: Type, tp2: Type): Boolean = tp2 match {
+    case tp2 @ AppliedType(tycon2, args2) =>
+      compareAppliedType2(tp1, tp2, tycon2, args2)
     case tp2: NamedType =>
       thirdTryNamed(tp1, tp2)
     case tp2: TypeParamRef =>
@@ -566,6 +570,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
           (sym1 eq NullClass) && isNullable(tp2) ||
           (sym1 eq PhantomNothingClass) && tp1.topType == tp2.topType
       }
+    case tp1 @ AppliedType(tycon1, args1) =>
+      compareAppliedType1(tp1, tycon1, args1, tp2)
     case tp1: SingletonType =>
       /** if `tp2 == p.type` and `p: q.type` then try `tp1 <:< q.type` as a last effort.*/
       def comparePaths = tp2 match {
@@ -784,6 +790,172 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         false
     }
 
+  /** Subtype test for the hk application `tp2 = tycon2[args2]`.
+   */
+  def compareAppliedType2(tp1: Type, tp2: AppliedType, tycon2: Type, args2: List[Type]): Boolean = {
+    val tparams = tycon2.typeParams
+    if (tparams.isEmpty) return false // can happen for ill-typed programs, e.g. neg/tcpoly_overloaded.scala
+
+    /** True if `tp1` and `tp2` have compatible type constructors and their
+     *  corresponding arguments are subtypes relative to their variance (see `isSubArgs`).
+     */
+    def isMatchingApply(tp1: Type): Boolean = tp1 match {
+      case AppliedType(tycon1, args1) =>
+        tycon1.dealias match {
+          case tycon1: TypeParamRef =>
+            (tycon1 == tycon2 ||
+             canConstrain(tycon1) && tryInstantiate(tycon1, tycon2)) &&
+            isSubArgs(args1, args2, tparams)
+          case tycon1: TypeRef =>
+            tycon2.dealias match {
+              case tycon2: TypeRef if tycon1.symbol == tycon2.symbol =>
+                isSubType(tycon1.prefix, tycon2.prefix) &&
+                isSubArgs(args1, args2, tparams)
+              case _ =>
+                false
+            }
+          case tycon1: TypeVar =>
+            isMatchingApply(tycon1.underlying)
+          case tycon1: AnnotatedType =>
+            isMatchingApply(tycon1.underlying)
+          case _ =>
+            false
+        }
+      case _ =>
+        false
+    }
+
+    /** `param2` can be instantiated to a type application prefix of the LHS
+     *  or to a type application prefix of one of the LHS base class instances
+     *  and the resulting type application is a supertype of `tp1`,
+     *  or fallback to fourthTry.
+     */
+    def canInstantiate(tycon2: TypeParamRef): Boolean = {
+
+      /** Let
+       *
+       *    `tparams_1, ..., tparams_k-1`    be the type parameters of the rhs
+       *    `tparams1_1, ..., tparams1_n-1`  be the type parameters of the constructor of the lhs
+       *    `args1_1, ..., args1_n-1`        be the type arguments of the lhs
+       *    `d  =  n - k`
+       *
+       *  Returns `true` iff `d >= 0` and `tycon2` can be instantiated to
+       *
+       *      [tparams1_d, ... tparams1_n-1] -> tycon1a[args_1, ..., args_d-1, tparams_d, ... tparams_n-1]
+       *
+       *  such that the resulting type application is a supertype of `tp1`.
+       */
+      def tyconOK(tycon1a: Type, args1: List[Type]) = {
+        var tycon1b = tycon1a
+        val tparams1a = tycon1a.typeParams
+        val lengthDiff = tparams1a.length - tparams.length
+        lengthDiff >= 0 && {
+          val tparams1 = tparams1a.drop(lengthDiff)
+          variancesConform(tparams1, tparams) && {
+            if (lengthDiff > 0)
+              tycon1b = HKTypeLambda(tparams1.map(_.paramName))(
+                tl => tparams1.map(tparam => tl.integrate(tparams, tparam.paramInfo).bounds),
+                tl => tycon1a.appliedTo(args1.take(lengthDiff) ++
+                        tparams1.indices.toList.map(TypeParamRef(tl, _))))
+            (ctx.mode.is(Mode.TypevarsMissContext) ||
+              tryInstantiate(tycon2, tycon1b.ensureHK)) &&
+              isSubType(tp1, tycon1b.appliedTo(args2))
+          }
+        }
+      }
+
+      tp1.widen match {
+        case tp1w @ HKApply(tycon1, args1) =>
+          tyconOK(tycon1, args1)
+        case tp1w =>
+          tp1w.typeSymbol.isClass && {
+            val classBounds = tycon2.classSymbols
+            def liftToBase(bcs: List[ClassSymbol]): Boolean = bcs match {
+              case bc :: bcs1 =>
+                classBounds.exists(bc.derivesFrom) &&
+                tyconOK(tp1w.baseTypeTycon(bc), tp1w.baseArgInfos(bc)) ||
+                liftToBase(bcs1)
+              case _ =>
+                false
+            }
+            liftToBase(tp1w.baseClasses)
+          } ||
+          fourthTry(tp1, tp2)
+      }
+    }
+
+    /** Fall back to comparing either with `fourthTry` or against the lower
+     *  approximation of the rhs.
+     *  @param   tyconLo   The type constructor's lower approximation.
+     */
+    def fallback(tyconLo: Type) =
+      either(fourthTry(tp1, tp2), isSubType(tp1, tyconLo.applyIfParameterized(args2)))
+
+    /** Let `tycon2bounds` be the bounds of the RHS type constructor `tycon2`.
+     *  Let `app2 = tp2` where the type constructor of `tp2` is replaced by
+     *  `tycon2bounds.lo`.
+     *  If both bounds are the same, continue with `tp1 <:< app2`.
+     *  otherwise continue with either
+     *
+     *    tp1 <:< tp2    using fourthTry (this might instantiate params in tp1)
+     *    tp1 <:< app2   using isSubType (this might instantiate params in tp2)
+     */
+    def compareLower(tycon2bounds: TypeBounds, tyconIsTypeRef: Boolean): Boolean =
+      if (tycon2bounds.lo eq tycon2bounds.hi)
+        isSubType(tp1,
+            if (tyconIsTypeRef) tp2.superType
+            else tycon2bounds.lo.applyIfParameterized(args2))
+      else
+        fallback(tycon2bounds.lo)
+
+    tycon2 match {
+      case param2: TypeParamRef =>
+        isMatchingApply(tp1) ||
+        canConstrain(param2) && canInstantiate(param2) ||
+        compareLower(bounds(param2), tyconIsTypeRef = false)
+      case tycon2: TypeRef =>
+        isMatchingApply(tp1) || {
+          tycon2.info match {
+            case tycon2: TypeBounds =>
+              compareLower(tycon2, tyconIsTypeRef = true)
+            case tycon2: ClassInfo =>
+              val base = tp1.baseType(tycon2.cls)
+              if (base.exists && base.ne(tp1)) isSubType(base, tp2)
+              else fourthTry(tp1, tp2)
+            case _ =>
+              fourthTry(tp1, tp2)
+          }
+        }
+      case _: TypeVar | _: AnnotatedType =>
+        isSubType(tp1, tp2.superType)
+      case tycon2: AppliedType =>
+        fallback(tycon2.lowerBound)
+      case _ =>
+        false
+    }
+  }
+
+  /** Subtype test for the application `tp1 = tycon1[args1]`.
+   */
+  def compareAppliedType1(tp1: AppliedType, tycon1: Type, args1: List[Type], tp2: Type): Boolean =
+    tycon1 match {
+      case param1: TypeParamRef =>
+        def canInstantiate = tp2 match {
+          case AnyAppliedType(tycon2, args2) =>
+            tryInstantiate(param1, tycon2.ensureHK) && isSubArgs(args1, args2, tycon2.typeParams)
+          case _ =>
+            false
+        }
+        canConstrain(param1) && canInstantiate ||
+          isSubType(bounds(param1).hi.applyIfParameterized(args1), tp2)
+      case tycon1: TypeRef if tycon1.symbol.isClass =>
+        false
+      case tycon1: TypeProxy =>
+        isSubType(tp1.superType, tp2)
+      case _ =>
+        false
+    }
+
   /** Subtype test for corresponding arguments in `args1`, `args2` according to
    *  variances in type parameters `tparams`.
    */
@@ -983,10 +1155,11 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
 
   /** A type has been covered previously in subtype checking if it
    *  is some combination of TypeRefs that point to classes, where the
-   *  combiners are RefinedTypes, RecTypes, And/Or-Types or AnnotatedTypes.
+   *  combiners are AppliedTypes, RefinedTypes, RecTypes, And/Or-Types or AnnotatedTypes.
    */
    private def isCovered(tp: Type): Boolean = tp.dealias.stripTypeVar match {
     case tp: TypeRef => tp.symbol.isClass && tp.symbol != NothingClass && tp.symbol != NullClass
+    case tp: AppliedType => isCovered(tp.tycon)
     case tp: RefinedOrRecType => isCovered(tp.parent)
     case tp: AnnotatedType => isCovered(tp.underlying)
     case tp: AndOrType => isCovered(tp.tp1) && isCovered(tp.tp2)
@@ -1200,6 +1373,38 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
   final def lub(tps: List[Type]): Type =
     ((defn.NothingType: Type) /: tps)(lub(_,_, canConstrain = false))
 
+  def lubArgs(args1: List[Type], args2: List[Type], tparams: List[TypeParamInfo], canConstrain: Boolean = false): List[Type] =
+    tparams match {
+      case tparam :: tparamsRest =>
+        val arg1 :: args1Rest = args1
+        val arg2 :: args2Rest = args2
+        val v = tparam.paramVariance
+        val lubArg =
+          if (v > 0) lub(arg1.hiBound, arg2.hiBound, canConstrain)
+          else if (v < 0) glb(arg1.loBound, arg2.loBound)
+          else TypeBounds(glb(arg1.loBound, arg2.loBound),
+                          lub(arg1.hiBound, arg2.hiBound, canConstrain))
+        lubArg :: lubArgs(args1Rest, args2Rest, tparamsRest, canConstrain)
+      case nil =>
+        Nil
+    }
+
+  def glbArgs(args1: List[Type], args2: List[Type], tparams: List[TypeParamInfo]): List[Type] =
+    tparams match {
+      case tparam :: tparamsRest =>
+        val arg1 :: args1Rest = args1
+        val arg2 :: args2Rest = args2
+        val v = tparam.paramVariance
+        val glbArg =
+          if (v > 0) glb(arg1.hiBound, arg2.hiBound)
+          else if (v < 0) lub(arg1.loBound, arg2.loBound)
+          else TypeBounds(lub(arg1.loBound, arg2.loBound),
+                          glb(arg1.hiBound, arg2.hiBound))
+        glbArg :: glbArgs(args1Rest, args2Rest, tparamsRest)
+      case nil =>
+        Nil
+    }
+
   private def recombineAndOr(tp: AndOrType, tp1: Type, tp2: Type) =
     if (!tp1.exists) tp2
     else if (!tp2.exists) tp1
@@ -1339,6 +1544,13 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
    *  @pre !(tp1 <: tp2) && !(tp2 <:< tp1) -- these cases were handled before
    */
   private def distributeAnd(tp1: Type, tp2: Type): Type = tp1 match {
+    case tp1 @ AppliedType(tycon1, args1) =>
+      tp2 match {
+        case AppliedType(tycon2, args2) if tycon1.typeSymbol == tycon2.typeSymbol =>
+          (tycon1 & tycon2).appliedTo(glbArgs(args1, args2, tycon1.typeParams))
+        case _ =>
+          NoType
+      }
     // opportunistically merge same-named refinements
     // this does not change anything semantically (i.e. merging or not merging
     // gives =:= types), but it keeps the type smaller.
@@ -1553,17 +1765,17 @@ class ExplainingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
 
   override def copyIn(ctx: Context) = new ExplainingTypeComparer(ctx)
 
-  override def compareHkApply2(tp1: Type, tp2: HKApply, tycon2: Type, args2: List[Type]): Boolean = {
+  override def compareAppliedType2(tp1: Type, tp2: AppliedType, tycon2: Type, args2: List[Type]): Boolean = {
     def addendum = ""
-    traceIndented(i"compareHkApply2 $tp1, $tp2$addendum") {
-      super.compareHkApply2(tp1, tp2, tycon2, args2)
+    traceIndented(i"compareAppliedType2 $tp1, $tp2$addendum") {
+      super.compareAppliedType2(tp1, tp2, tycon2, args2)
     }
   }
 
-  override def compareHkApply1(tp1: HKApply, tycon1: Type, args1: List[Type], tp2: Type): Boolean = {
+  override def compareAppliedType1(tp1: AppliedType, tycon1: Type, args1: List[Type], tp2: Type): Boolean = {
     def addendum = ""
-    traceIndented(i"compareHkApply1 $tp1, $tp2$addendum") {
-      super.compareHkApply1(tp1, tycon1, args1, tp2)
+    traceIndented(i"compareAppliedType1 $tp1, $tp2$addendum") {
+      super.compareAppliedType1(tp1, tycon1, args1, tp2)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -368,7 +368,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     case _ =>
       val cls2 = tp2.symbol
       if (cls2.isClass) {
-        val base = tp1.baseTypeRef(cls2)
+        val base = tp1.baseType(cls2)
         if (base.exists && (base ne tp1)) return isSubType(base, tp2)
         if (cls2 == defn.SingletonClass && tp1.isStable) return true
       }
@@ -713,7 +713,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
             def liftToBase(bcs: List[ClassSymbol]): Boolean = bcs match {
               case bc :: bcs1 =>
                 classBounds.exists(bc.derivesFrom) &&
-                tyconOK(tp1w.baseTypeRef(bc), tp1w.baseArgInfos(bc)) ||
+                tyconOK(tp1w.baseTypeTycon(bc), tp1w.baseArgInfos(bc)) ||
                 liftToBase(bcs1)
               case _ =>
                 false
@@ -771,7 +771,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     tycon1 match {
       case param1: TypeParamRef =>
         def canInstantiate = tp2 match {
-          case AppliedType(tycon2, args2) =>
+          case AnyAppliedType(tycon2, args2) =>
             tryInstantiate(param1, tycon2.ensureHK) && isSubArgs(args1, args2, tycon2.typeParams)
           case _ =>
             false
@@ -810,7 +810,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     val classBounds = tp2.classSymbols
     def recur(bcs: List[ClassSymbol]): Boolean = bcs match {
       case bc :: bcs1 =>
-        val baseRef = tp1.baseTypeRef(bc)
+        val baseRef = tp1.baseTypeTycon(bc)
         (classBounds.exists(bc.derivesFrom) &&
          variancesConform(baseRef.typeParams, tparams) &&
          p(baseRef.appliedTo(tp1.baseArgInfos(bc)))

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -563,6 +563,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
           def isNullable(tp: Type): Boolean = tp.widenDealias match {
             case tp: TypeRef => tp.symbol.isNullableClass
             case tp: RefinedOrRecType => isNullable(tp.parent)
+            case tp: AppliedType => isNullable(tp.tycon)
             case AndType(tp1, tp2) => isNullable(tp1) && isNullable(tp2)
             case OrType(tp1, tp2) => isNullable(tp1) || isNullable(tp2)
             case _ => false

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -522,6 +522,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         case _ => isSubType(tp1.widenExpr, restpe2)
       }
       compareExpr
+    case tp2: TypeArgRef =>
+      isSubType(tp1, tp2.underlying.loBound) || fourthTry(tp1, tp2)
     case tp2 @ TypeBounds(lo2, hi2) =>
       def compareTypeBounds = tp1 match {
         case tp1 @ TypeBounds(lo1, hi1) =>
@@ -591,6 +593,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
       isNewSubType(tp1.parent, tp2)
     case tp1: RecType =>
       isNewSubType(tp1.parent, tp2)
+    case tp1: TypeArgRef =>
+      isSubType(tp1.underlying.hiBound, tp2)
     case tp1 @ HKApply(tycon1, args1) =>
       compareHkApply1(tp1, tycon1, args1, tp2)
     case tp1: HKTypeLambda =>
@@ -845,35 +849,36 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
        *
        *  such that the resulting type application is a supertype of `tp1`.
        */
-      def tyconOK(tycon1a: Type, args1: List[Type]) = {
-        var tycon1b = tycon1a
-        val tparams1a = tycon1a.typeParams
-        val lengthDiff = tparams1a.length - tparams.length
-        lengthDiff >= 0 && {
-          val tparams1 = tparams1a.drop(lengthDiff)
-          variancesConform(tparams1, tparams) && {
-            if (lengthDiff > 0)
-              tycon1b = HKTypeLambda(tparams1.map(_.paramName))(
-                tl => tparams1.map(tparam => tl.integrate(tparams, tparam.paramInfo).bounds),
-                tl => tycon1a.appliedTo(args1.take(lengthDiff) ++
-                        tparams1.indices.toList.map(TypeParamRef(tl, _))))
-            (ctx.mode.is(Mode.TypevarsMissContext) ||
-              tryInstantiate(tycon2, tycon1b.ensureHK)) &&
-              isSubType(tp1, tycon1b.appliedTo(args2))
+      def appOK(tp1base: Type) = tp1base match {
+        case tp1base: AppliedType =>
+          var tycon1 = tp1base.tycon
+          var args1 = tp1base.args
+          val tparams1all = tycon1.typeParams
+          val lengthDiff = tparams1all.length - tparams.length
+          lengthDiff >= 0 && {
+            val tparams1 = tparams1all.drop(lengthDiff)
+            variancesConform(tparams1, tparams) && {
+              if (lengthDiff > 0)
+                tycon1 = HKTypeLambda(tparams1.map(_.paramName))(
+                  tl => tparams1.map(tparam => tl.integrate(tparams, tparam.paramInfo).bounds),
+                  tl => tp1base.tycon.appliedTo(args1.take(lengthDiff) ++
+                          tparams1.indices.toList.map(TypeParamRef(tl, _))))
+              (ctx.mode.is(Mode.TypevarsMissContext) ||
+                tryInstantiate(tycon2, tycon1.ensureHK)) &&
+                isSubType(tp1, tycon1.appliedTo(args2))
+            }
           }
-        }
+        case _ => false
       }
 
       tp1.widen match {
-        case tp1w @ HKApply(tycon1, args1) =>
-          tyconOK(tycon1, args1)
+        case tp1w: AppliedType => appOK(tp1w)
         case tp1w =>
           tp1w.typeSymbol.isClass && {
             val classBounds = tycon2.classSymbols
             def liftToBase(bcs: List[ClassSymbol]): Boolean = bcs match {
               case bc :: bcs1 =>
-                classBounds.exists(bc.derivesFrom) &&
-                tyconOK(tp1w.baseTypeTycon(bc), tp1w.baseArgInfos(bc)) ||
+                classBounds.exists(bc.derivesFrom) && appOK(tp1w.baseType(bc)) ||
                 liftToBase(bcs1)
               case _ =>
                 false
@@ -982,12 +987,20 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     val classBounds = tp2.classSymbols
     def recur(bcs: List[ClassSymbol]): Boolean = bcs match {
       case bc :: bcs1 =>
-        val baseRef = tp1.baseTypeTycon(bc)
-        (classBounds.exists(bc.derivesFrom) &&
-         variancesConform(baseRef.typeParams, tparams) &&
-         p(baseRef.appliedTo(tp1.baseArgInfos(bc)))
-         ||
-         recur(bcs1))
+        if (Config.newScheme)
+          (classBounds.exists(bc.derivesFrom) &&
+           variancesConform(bc.typeParams, tparams) &&
+           p(tp1.baseType(bc))
+          ||
+          recur(bcs1))
+        else {
+          val baseRef = tp1.baseTypeTycon(bc)
+          (classBounds.exists(bc.derivesFrom) &&
+          variancesConform(baseRef.typeParams, tparams) &&
+          p(baseRef.appliedTo(tp1.baseArgInfos(bc)))
+          ||
+          recur(bcs1))
+        }
       case nil =>
         false
     }
@@ -1554,6 +1567,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     // opportunistically merge same-named refinements
     // this does not change anything semantically (i.e. merging or not merging
     // gives =:= types), but it keeps the type smaller.
+    // @!!! still needed?
     case tp1: RefinedType =>
       tp2 match {
         case tp2: RefinedType if tp1.refinedName == tp2.refinedName =>

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -66,7 +66,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
       else pre match {
         case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
         case _ =>
-          if (thiscls.derivesFrom(cls) && pre.baseTypeRef(thiscls).exists) {
+          if (thiscls.derivesFrom(cls) && pre.baseType(thiscls).exists) { // ??? why not derivesFrom ???
             if (theMap != null && theMap.currentVariance <= 0 && !isLegalPrefix(pre)) {
               ctx.base.unsafeNonvariant = ctx.runId
               pre match {
@@ -79,7 +79,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
           else if ((pre.termSymbol is Package) && !(thiscls is Package))
             toPrefix(pre.select(nme.PACKAGE), cls, thiscls)
           else
-            toPrefix(pre.baseTypeRef(cls).normalizedPrefix, cls.owner, thiscls)
+            toPrefix(pre.baseType(cls).normalizedPrefix, cls.owner, thiscls)
       }
     }
 
@@ -256,7 +256,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
               val doms = dominators(commonBaseClasses, Nil)
               def baseTp(cls: ClassSymbol): Type = {
                 val base =
-                  if (tp1.typeParams.nonEmpty) tp.baseTypeRef(cls)
+                  if (tp1.typeParams.nonEmpty) tp.baseTypeTycon(cls)
                   else tp.baseTypeWithArgs(cls)
                 base.mapReduceOr(identity)(mergeRefined)
               }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -123,17 +123,20 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
           if (sym.isStatic) tp
           else {
             val pre1 = asSeenFrom(tp.prefix, pre, cls, theMap)
-            if (Config.newScheme && sym.is(TypeParam)) argForParam(pre1, cls, sym)
-            else if (pre1.isUnsafeNonvariant) {
-              val safeCtx = ctx.withProperty(TypeOps.findMemberLimit, Some(()))
-              pre1.member(tp.name)(safeCtx).info match {
-                case TypeAlias(alias) =>
-                  // try to follow aliases of this will avoid skolemization.
-                  return alias
-                case _ =>
+            if (Config.newScheme && sym.is(TypeParam))
+              argForParam(pre1, cls, sym)
+            else {
+              if (pre1.isUnsafeNonvariant) {
+                val safeCtx = ctx.withProperty(TypeOps.findMemberLimit, Some(()))
+                pre1.member(tp.name)(safeCtx).info match {
+                  case TypeAlias(alias) =>
+                    // try to follow aliases of this will avoid skolemization.
+                    return alias
+                  case _ =>
+                }
               }
+              tp.derivedSelect(pre1)
             }
-            tp.derivedSelect(pre1)
           }
         case tp: ThisType =>
           toPrefix(pre, cls, tp.cls)

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -11,6 +11,7 @@ import NameKinds.DepParamName
 import Decorators._
 import StdNames._
 import Annotations._
+import annotation.tailrec
 import config.Config
 import util.{SimpleMap, Property}
 import collection.mutable
@@ -83,6 +84,18 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
       }
     }
 
+    @tailrec
+    def argForParam(pre: Type, cls: Symbol, pref: TypeParamRef, prefCls: ClassSymbol): Type =
+      if (cls.is(PackageClass)) pref
+      else {
+        val base = pre.baseType(cls)
+        if (cls eq prefCls) {
+          val AppliedType(_, args) = base
+          args(pref.paramNum)
+        }
+        else argForParam(base.normalizedPrefix, cls.owner.enclosingClass, pref, prefCls)
+      }
+
     /*>|>*/ ctx.conditionalTraceIndented(TypeOps.track, s"asSeen ${tp.show} from (${pre.show}, ${cls.show})", show = true) /*<|<*/ { // !!! DEBUG
       tp match {
         case tp: NamedType =>
@@ -103,6 +116,11 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
           }
         case tp: ThisType =>
           toPrefix(pre, cls, tp.cls)
+        case tp: TypeParamRef =>
+          tp.binder.resultType match {
+            case cinfo: ClassInfo => argForParam(pre, cls, tp, cinfo.cls)
+            case _ => tp
+          }
         case _: BoundType | NoPrefix =>
           tp
         case tp: RefinedType =>
@@ -163,7 +181,10 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         val bounds = ctx.typeComparer.bounds(tp)
         if (bounds.lo.isRef(defn.NothingClass)) bounds.hi else bounds.lo
       }
-      else typerState.constraint.typeVarOfParam(tp) orElse tp
+      else {
+        val tvar = typerState.constraint.typeVarOfParam(tp)
+        if (tvar.exists) tvar else tp
+      }
     case  _: ThisType | _: BoundType | NoPrefix =>
       tp
     case tp: RefinedType =>
@@ -213,14 +234,22 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         defn.ObjectClass :: Nil
     }
 
-    def mergeRefined(tp1: Type, tp2: Type): Type = {
+    def mergeRefinedOrApplied(tp1: Type, tp2: Type): Type = {
       def fail = throw new AssertionError(i"Failure to join alternatives $tp1 and $tp2")
       tp1 match {
         case tp1 @ RefinedType(parent1, name1, rinfo1) =>
           tp2 match {
             case RefinedType(parent2, `name1`, rinfo2) =>
               tp1.derivedRefinedType(
-                mergeRefined(parent1, parent2), name1, rinfo1 | rinfo2)
+                mergeRefinedOrApplied(parent1, parent2), name1, rinfo1 | rinfo2)
+            case _ => fail
+          }
+        case tp1 @ AppliedType(tycon1, args1) =>
+          tp2 match {
+            case AppliedType(tycon2, args2) =>
+              tp1.derivedAppliedType(
+                mergeRefinedOrApplied(tycon1, tycon2),
+                ctx.typeComparer.lubArgs(args1, args2, tycon1.typeParams))
             case _ => fail
           }
         case tp1 @ TypeRef(pre1, name1) =>
@@ -258,7 +287,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
                 val base =
                   if (tp1.typeParams.nonEmpty) tp.baseTypeTycon(cls)
                   else tp.baseTypeWithArgs(cls)
-                base.mapReduceOr(identity)(mergeRefined)
+                base.mapReduceOr(identity)(mergeRefinedOrApplied)
               }
               doms.map(baseTp).reduceLeft(AndType.apply)
           }
@@ -271,35 +300,6 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
       case _ =>
         tp
     }
-  }
-
-  /** Not currently needed:
-   *
-  def liftToRec(f: (Type, Type) => Type)(tp1: Type, tp2: Type)(implicit ctx: Context) = {
-    def f2(tp1: Type, tp2: Type): Type = tp2 match {
-      case tp2: RecType => tp2.rebind(f(tp1, tp2.parent))
-      case _ => f(tp1, tp2)
-    }
-    tp1 match {
-      case tp1: RecType => tp1.rebind(f2(tp1.parent, tp2))
-      case _ => f2(tp1, tp2)
-    }
-  }
-  */
-
-  private def enterArgBinding(formal: Symbol, info: Type, cls: ClassSymbol, decls: Scope) = {
-    val lazyInfo = new LazyType { // needed so we do not force `formal`.
-      def complete(denot: SymDenotation)(implicit ctx: Context): Unit = {
-        denot setFlag formal.flags & RetainedTypeArgFlags
-        denot.info = info
-      }
-    }
-    val sym = ctx.newSymbol(
-      cls, formal.name,
-      formal.flagsUNSAFE & RetainedTypeArgFlags | BaseTypeArg | Override,
-      lazyInfo,
-      coord = cls.coord)
-    cls.enter(sym, decls)
   }
 
   /** If `tpe` is of the form `p.x` where `p` refers to a package
@@ -322,6 +322,21 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         case pre: TermRef if pre.symbol is Package => tryInsert(pre.symbol.moduleClass)
         case _ => tpe
       }
+  }
+
+  private def enterArgBinding(formal: Symbol, info: Type, cls: ClassSymbol, decls: Scope) = {
+    val lazyInfo = new LazyType { // needed so we do not force `formal`.
+      def complete(denot: SymDenotation)(implicit ctx: Context): Unit = {
+        denot setFlag formal.flags & RetainedTypeArgFlags
+        denot.info = info
+      }
+    }
+    val sym = ctx.newSymbol(
+      cls, formal.name,
+      formal.flagsUNSAFE & RetainedTypeArgFlags | BaseTypeArg | Override,
+      lazyInfo,
+      coord = cls.coord)
+    cls.enter(sym, decls)
   }
 
   /** Normalize a list of parent types of class `cls` that may contain refinements

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -49,8 +49,10 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
    *  The scheme is efficient in particular because we expect that unsafe situations are rare;
    *  most compiles would contain none, so no scanning would be necessary.
    */
-  final def asSeenFrom(tp: Type, pre: Type, cls: Symbol): Type =
+  final def asSeenFrom(tp: Type, pre: Type, cls: Symbol): Type = {
+    //println(i"$tp.asSeenFrom($pre, $cls)")
     asSeenFrom(tp, pre, cls, null)
+  }
 
   /** Helper method, taking a map argument which is instantiated only for more
    *  complicated cases of asSeenFrom.
@@ -88,32 +90,32 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
       }
     }
 
-    @tailrec
-    def argForParam(pre: Type, cls: Symbol, tparam: Symbol): Type = {
-      def fail() = throw new TypeError(ex"$pre contains no matching argument for ${tparam.showLocated} ")
-      if ((pre eq NoType) || (pre eq NoPrefix) || (cls is PackageClass)) fail()
-      val base = pre.baseType(cls)
-      if (cls `eq` tparam.owner) {
-        var tparams = cls.typeParams
-        var args = base.argInfos
-        var idx = 0
-        while (tparams.nonEmpty && args.nonEmpty) {
-          if (tparams.head.eq(tparam))
-            return args.head match {
-              case bounds: TypeBounds =>
-                val v = currentVariance
-                if (v > 0) bounds.hi
-                else if (v < 0) bounds.lo
-                else TypeArgRef(pre, cls.typeRef, idx)
-              case arg => arg
-            }
-          tparams = tparams.tail
-          args = args.tail
-          idx += 1
-        }
-        fail()
+    def argForParam(pre: Type, tparam: Symbol): Type = {
+      val tparamCls = tparam.owner
+      pre.baseType(tparamCls) match {
+        case AppliedType(_, allArgs) =>
+          var tparams = tparamCls.typeParams
+          var args = allArgs
+          var idx = 0
+          while (tparams.nonEmpty && args.nonEmpty) {
+            if (tparams.head.eq(tparam))
+              return args.head match {
+                case bounds: TypeBounds =>
+                  val v = currentVariance
+                  if (v > 0) bounds.hi
+                  else if (v < 0) bounds.lo
+                  else TypeArgRef(pre, cls.typeRef, idx)
+                case arg => arg
+              }
+            tparams = tparams.tail
+            args = args.tail
+            idx += 1
+          }
+          throw new AssertionError(ex"$pre contains no matching argument for ${tparam.showLocated} ")
+        case OrType(tp1, tp2) => argForParam(tp1, cls) | argForParam(tp2, cls)
+        case AndType(tp1, tp2) => argForParam(tp1, cls) & argForParam(tp2, cls)
+        case _ => tp
       }
-      else argForParam(base.normalizedPrefix, cls.owner.enclosingClass, tparam)
     }
 
     /*>|>*/ ctx.conditionalTraceIndented(TypeOps.track, s"asSeen ${tp.show} from (${pre.show}, ${cls.show})", show = true) /*<|<*/ { // !!! DEBUG
@@ -124,7 +126,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
           else {
             val pre1 = asSeenFrom(tp.prefix, pre, cls, theMap)
             if (Config.newScheme && sym.is(TypeParam))
-              argForParam(pre1, cls, sym)
+              argForParam(pre1, sym)
             else {
               if (pre1.isUnsafeNonvariant) {
                 val safeCtx = ctx.withProperty(TypeOps.findMemberLimit, Some(()))

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3924,9 +3924,9 @@ object Types {
 
     protected var variance = 1
 
-    protected def applyToPrefix(x: T, tp: NamedType) = {
+    protected final def applyToPrefix(x: T, tp: NamedType) = {
       val saved = variance
-      variance = 0
+      variance = variance max 0 // see remark on NamedType case in TypeMap
       val result = this(x, tp.prefix)
       variance = saved
       result

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -566,6 +566,7 @@ object Types {
               try pdenot.info & rinfo
               catch {
                 case ex: CyclicReference =>
+                  // ??? can this still happen? ???
                   // happens for tests/pos/sets.scala. findMember is called from baseTypeRef.
                   // The & causes a subtype check which calls baseTypeRef again with the same
                   // superclass. In the observed case, the superclass was Any, and
@@ -826,12 +827,16 @@ object Types {
     /** The basetype TypeRef of this type with given class symbol,
      *  but without including any type arguments
      */
-    final def baseTypeRef(base: Symbol)(implicit ctx: Context): Type = /*ctx.traceIndented(s"$this baseTypeRef $base")*/ /*>|>*/ track("baseTypeRef") /*<|<*/ {
+    final def baseType(base: Symbol)(implicit ctx: Context): Type = /*ctx.traceIndented(s"$this baseType $base")*/ /*>|>*/ track("baseType") /*<|<*/ {
       base.denot match {
-        case classd: ClassDenotation => classd.baseTypeRefOf(this)
+        case classd: ClassDenotation => classd.baseTypeOf(this)
         case _ => NoType
       }
     }
+
+    /** Temporary replacement for baseTypeRef */
+    final def baseTypeTycon(base: Symbol)(implicit ctx: Context): Type =
+      baseType(base).typeConstructor
 
     def & (that: Type)(implicit ctx: Context): Type = track("&") {
       ctx.typeComparer.glb(this, that)
@@ -998,6 +1003,12 @@ object Types {
      */
     final def deconst(implicit ctx: Context): Type = stripTypeVar match {
       case tp: ConstantType => tp.value.tpe
+      case _ => this
+    }
+
+    /** The type constructor of an applied type, otherwise the type itself */
+    final def typeConstructor(implicit ctx: Context): Type = this match {
+      case AppliedType(tycon, _) => tycon
       case _ => this
     }
 
@@ -1435,6 +1446,11 @@ object Types {
   /** A marker trait for types that can be types of values or that are higher-kinded  */
   trait ValueType extends ValueTypeOrProto with ValueTypeOrWildcard
 
+  /** A common base trait of NamedType and AppliedType */
+  trait RefType extends CachedProxyType with ValueType {
+    def symbol(implicit ctx: Context): Symbol
+  }
+
   /** A marker trait for types that are guaranteed to contain only a
    *  single non-null value (they might contain null in addition).
    */
@@ -1466,7 +1482,7 @@ object Types {
 // --- NamedTypes ------------------------------------------------------------------
 
   /** A NamedType of the form Prefix # name */
-  abstract class NamedType extends CachedProxyType with ValueType {
+  abstract class NamedType extends CachedProxyType with RefType {
 
     val prefix: Type
     val name: Name
@@ -2990,6 +3006,91 @@ object Types {
     def paramVariance(implicit ctx: Context): Int = tl.paramNames(n).variance
     def toArg: Type = TypeParamRef(tl, n)
     def paramRef(implicit ctx: Context): Type = TypeParamRef(tl, n)
+  }
+
+  /** A type application `C[T_1, ..., T_n]` */
+  abstract case class AppliedType(tycon: Type, args: List[Type])
+  extends CachedProxyType with RefType {
+
+    private var validSuper: Period = Nowhere
+    private var cachedSuper: Type = _
+
+    override def underlying(implicit ctx: Context): Type = tycon
+
+    override def superType(implicit ctx: Context): Type = {
+      def reapply(tp: Type) = tp match {
+        case tp: TypeRef if tp.symbol.isClass => tp
+        case _ => tp.applyIfParameterized(args)
+      }
+      if (ctx.period != validSuper) {
+        validSuper = ctx.period
+        cachedSuper = tycon match {
+          case tp: HKTypeLambda => defn.AnyType
+          case tp: TypeVar if !tp.inst.exists =>
+            // supertype not stable, since underlying might change
+            validSuper = Nowhere
+            reapply(tp.underlying)
+          case tp: TypeProxy =>
+            if (tp.typeSymbol.is(Provisional)) validSuper = Nowhere
+            reapply(tp.superType)
+          case _ => defn.AnyType
+        }
+      }
+      cachedSuper
+    }
+
+    override def symbol(implicit ctx: Context) = tycon.typeSymbol
+
+    def lowerBound(implicit ctx: Context) = tycon.stripTypeVar match {
+      case tycon: TypeRef =>
+        tycon.info match {
+          case TypeBounds(lo, hi) =>
+            if (lo eq hi) superType // optimization, can profit from caching in this case
+            else lo.applyIfParameterized(args)
+          case _ => NoType
+        }
+      case _ =>
+        NoType
+    }
+
+    def typeParams(implicit ctx: Context): List[ParamInfo] = {
+      val tparams = tycon.typeParams
+      if (tparams.isEmpty) HKTypeLambda.any(args.length).typeParams else tparams
+    }
+
+    def derivedAppliedType(tycon: Type, args: List[Type])(implicit ctx: Context): Type =
+      if ((tycon eq this.tycon) && (args eq this.args)) this
+      else tycon.appliedTo(args)
+
+    override def computeHash = doHash(tycon, args)
+
+    protected def checkInst(implicit ctx: Context): this.type = {
+      def check(tycon: Type): Unit = tycon.stripTypeVar match {
+        case tycon: TypeRef =>
+        case _: TypeParamRef | _: ErrorType | _: WildcardType =>
+        case _: TypeLambda =>
+          assert(!args.exists(_.isInstanceOf[TypeBounds]), s"unreduced type apply: $this")
+        case tycon: AnnotatedType =>
+          check(tycon.underlying)
+        case _ =>
+          assert(false, s"illegal type constructor in $this")
+      }
+      if (Config.checkHKApplications) check(tycon)
+      this
+    }
+  }
+
+  final class CachedAppliedType(tycon: Type, args: List[Type]) extends AppliedType(tycon, args)
+
+  object AppliedType {
+    def apply(tycon: Type, args: List[Type])(implicit ctx: Context) =
+      unique(new CachedAppliedType(tycon, args)).checkInst
+  }
+
+  object ClassRef {
+    def unapply(tp: RefType)(implicit ctx: Context): Option[RefType] = { // after bootstrap, drop the Option
+      if (tp.symbol.isClass) Some(tp) else None
+    }
   }
 
   /** A higher kinded type application `C[T_1, ..., T_n]` */

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -591,6 +591,8 @@ object Types {
         case tl: HKTypeLambda =>
           go(tl.resType).mapInfo(info =>
             tl.derivedLambdaAbstraction(tl.paramNames, tl.paramInfos, info).appliedTo(tp.args))
+        case tc: TypeRef if tc.symbol.isClass =>
+          go(tc)
         case _ =>
           go(tp.superType)
       }
@@ -1188,7 +1190,10 @@ object Types {
 
     /** The full parent types, including (in new scheme) all type arguments */
     def parentsNEW(implicit ctx: Context): List[Type] = this match {
-      case tp: TypeProxy => tp.superType.parentsNEW
+      case tp @ AppliedType(tycon, args) if tycon.typeSymbol.isClass =>
+        tycon.parentsNEW.map(_.subst(tycon.typeSymbol.typeParams, args))
+      case tp: TypeProxy =>
+        tp.superType.parentsNEW
       case _ => Nil
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1206,14 +1206,6 @@ object Types {
       case _ => defn.AnyType
     }
 
-    /** the self type of the underlying classtype */
-    def givenSelfType(implicit ctx: Context): Type = this match {
-      case tp: RefinedType => tp.wrapIfMember(tp.parent.givenSelfType)
-      case tp: ThisType => tp.tref.givenSelfType
-      case tp: TypeProxy => tp.superType.givenSelfType
-      case _ => NoType
-    }
-
     /** The parameter types of a PolyType or MethodType, Empty list for others */
     final def paramInfoss(implicit ctx: Context): List[List[Type]] = stripPoly match {
       case mt: MethodType => mt.paramInfos :: mt.resultType.paramInfoss
@@ -1642,10 +1634,8 @@ object Types {
     }
 
     private def checkSymAssign(sym: Symbol)(implicit ctx: Context) = {
-      def selfTypeOf(sym: Symbol) = sym.owner.info match {
-        case info: ClassInfo => info.givenSelfType
-        case _ => NoType
-      }
+      def selfTypeOf(sym: Symbol) =
+        if (sym.isClass) sym.asClass.givenSelfType else NoType
       assert(
         (lastSymbol eq sym)
         ||
@@ -2242,7 +2232,7 @@ object Types {
       if ((parent eq this.parent) && (refinedName eq this.refinedName) && (refinedInfo eq this.refinedInfo)) this
       else RefinedType(parent, refinedName, refinedInfo)
 
-    /** Add this refinement to `parent`, provided If `refinedName` is a member of `parent`. */
+    /** Add this refinement to `parent`, provided `refinedName` is a member of `parent`. */
     def wrapIfMember(parent: Type)(implicit ctx: Context): Type =
       if (parent.member(refinedName).exists) derivedRefinedType(parent, refinedName, refinedInfo)
       else parent
@@ -3416,7 +3406,7 @@ object Types {
       if (selfTypeCache == null)
         selfTypeCache = {
           def fullRef = fullyAppliedRef
-          val given = givenSelfType
+          val given = cls.givenSelfType
           val raw =
             if (!given.exists) fullRef
             else if (cls is Module) given
@@ -3425,14 +3415,6 @@ object Types {
           raw//.asSeenFrom(prefix, cls.owner)
         }
       selfTypeCache
-    }
-
-    /** The explicitly given self type (self types of modules are assumed to be
-     *  explcitly given here).
-     */
-    override def givenSelfType(implicit ctx: Context): Type = selfInfo match {
-      case tp: Type => tp
-      case self: Symbol => self.info
     }
 
     private var selfTypeCache: Type = null
@@ -4284,7 +4266,7 @@ object Types {
   }
 
   private def otherReason(pre: Type)(implicit ctx: Context): String = pre match {
-    case pre: ThisType if pre.givenSelfType.exists =>
+    case pre: ThisType if pre.cls.givenSelfType.exists =>
       i"\nor the self type of $pre might not contain all transitive dependencies"
     case _ => ""
   }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -129,9 +129,10 @@ object Types {
           case TypeAlias(tp) =>
             assert((tp ne this) && (tp ne this1), s"$tp / $this")
             tp.isRef(sym)
-          case _ =>  this1.symbol eq sym
+          case _ => this1.symbol eq sym
         }
       case this1: RefinedOrRecType => this1.parent.isRef(sym)
+      case this1: AppliedType => this1.underlying.isRef(sym)
       case this1: HKApply => this1.superType.isRef(sym)
       case _ => false
     }
@@ -210,7 +211,7 @@ object Types {
       */
     private final def phantomLatticeType(implicit ctx: Context): Type = widen match {
       case tp: ClassInfo if defn.isPhantomTerminalClass(tp.classSymbol) => tp.prefix
-      case tp: TypeProxy if tp.superType ne this => tp.underlying.phantomLatticeType
+      case tp: TypeProxy if tp.superType ne this => tp.underlying.phantomLatticeType // ??? guard needed ???
       case tp: AndOrType => tp.tp1.phantomLatticeType
       case _ => NoType
     }
@@ -483,6 +484,8 @@ object Types {
           })
         case tp: TypeRef =>
           tp.denot.findMember(name, pre, excluded)
+        case tp: AppliedType =>
+          goApplied(tp)
         case tp: ThisType =>
           goThis(tp)
         case tp: RefinedType =>
@@ -494,7 +497,7 @@ object Types {
         case tp: SuperType =>
           goSuper(tp)
         case tp: HKApply =>
-          goApply(tp)
+          goHKApply(tp)
         case tp: TypeProxy =>
           go(tp.underlying)
         case tp: ClassInfo =>
@@ -584,7 +587,15 @@ object Types {
         }
       }
 
-      def goApply(tp: HKApply) = tp.tycon match {
+      def goApplied(tp: AppliedType) = tp.tycon match {
+        case tl: HKTypeLambda =>
+          go(tl.resType).mapInfo(info =>
+            tl.derivedLambdaAbstraction(tl.paramNames, tl.paramInfos, info).appliedTo(tp.args))
+        case _ =>
+          go(tp.superType)
+      }
+
+      def goHKApply(tp: HKApply) = tp.tycon match {
         case tl: HKTypeLambda =>
           go(tl.resType).mapInfo(info =>
             tl.derivedLambdaAbstraction(tl.paramNames, tl.paramInfos, info).appliedTo(tp.args))
@@ -963,6 +974,14 @@ object Types {
           case TypeAlias(tp) => tp.dealias(keepAnnots): @tailrec
           case _ => tp
         }
+      case app @ AppliedType(tycon, args) =>
+        val tycon1 = tycon.dealias(keepAnnots)
+        if (tycon1 ne tycon) app.superType.dealias(keepAnnots): @tailrec
+        else this
+      case app @ HKApply(tycon, args) =>
+        val tycon1 = tycon.dealias(keepAnnots)
+        if (tycon1 ne tycon) app.superType.dealias(keepAnnots): @tailrec
+        else this
       case tp: TypeVar =>
         val tp1 = tp.instanceOpt
         if (tp1.exists) tp1.dealias(keepAnnots): @tailrec else tp
@@ -971,10 +990,6 @@ object Types {
         if (keepAnnots) tp.derivedAnnotatedType(tp1, tp.annot) else tp1
       case tp: LazyRef =>
         tp.ref.dealias(keepAnnots): @tailrec
-      case app @ HKApply(tycon, args) =>
-        val tycon1 = tycon.dealias(keepAnnots)
-        if (tycon1 ne tycon) app.superType.dealias(keepAnnots): @tailrec
-        else this
       case _ => this
     }
 
@@ -1021,6 +1036,8 @@ object Types {
         if (tp.symbol.isClass) tp
         else if (tp.symbol.isAliasType) tp.underlying.underlyingClassRef(refinementOK)
         else NoType
+      case tp: AppliedType =>
+        tp.superType.underlyingClassRef(refinementOK)
       case tp: AnnotatedType =>
         tp.underlying.underlyingClassRef(refinementOK)
       case tp: RefinedType =>
@@ -1158,19 +1175,33 @@ object Types {
      *  Inherited by all type proxies. Empty for all other types.
      *  Overwritten in ClassInfo, where parents is cached.
      */
-    def parents(implicit ctx: Context): List[TypeRef] = this match {
-      case tp: TypeProxy => tp.underlying.parents
-      case _ => List()
+    def parentRefs(implicit ctx: Context): List[TypeRef] = this match {
+      case tp: TypeProxy => tp.underlying.parentRefs
+      case _ => Nil
     }
 
     /** The full parent types, including all type arguments */
     def parentsWithArgs(implicit ctx: Context): List[Type] = this match {
       case tp: TypeProxy => tp.superType.parentsWithArgs
-      case _ => List()
+      case _ => Nil
+    }
+
+    /** The full parent types, including (in new scheme) all type arguments */
+    def parentsNEW(implicit ctx: Context): List[Type] = this match {
+      case AppliedType(tycon: HKTypeLambda, args) => // TODO: can be eliminated once ClassInfo is changed, also: cache?
+        tycon.resType.parentsWithArgs.map(_.substParams(tycon, args))
+      case tp: TypeProxy => tp.superType.parentsNEW
+      case _ => Nil
     }
 
     /** The first parent of this type, AnyRef if list of parents is empty */
-    def firstParent(implicit ctx: Context): TypeRef = parents match {
+    def firstParentRef(implicit ctx: Context): TypeRef = parentRefs match {
+      case p :: _ => p
+      case _ => defn.AnyType
+    }
+
+    /** The first parent of this type, AnyRef if list of parents is empty */
+    def firstParentNEW(implicit ctx: Context): Type = parentsNEW match {
       case p :: _ => p
       case _ => defn.AnyType
     }
@@ -3018,10 +3049,6 @@ object Types {
     override def underlying(implicit ctx: Context): Type = tycon
 
     override def superType(implicit ctx: Context): Type = {
-      def reapply(tp: Type) = tp match {
-        case tp: TypeRef if tp.symbol.isClass => tp
-        case _ => tp.applyIfParameterized(args)
-      }
       if (ctx.period != validSuper) {
         validSuper = ctx.period
         cachedSuper = tycon match {
@@ -3029,10 +3056,10 @@ object Types {
           case tp: TypeVar if !tp.inst.exists =>
             // supertype not stable, since underlying might change
             validSuper = Nowhere
-            reapply(tp.underlying)
+            tp.underlying.applyIfParameterized(args)
           case tp: TypeProxy =>
             if (tp.typeSymbol.is(Provisional)) validSuper = Nowhere
-            reapply(tp.superType)
+            tp.superType.applyIfParameterized(args)
           case _ => defn.AnyType
         }
       }
@@ -3439,7 +3466,7 @@ object Types {
     private var parentsCache: List[TypeRef] = null
 
     /** The parent type refs as seen from the given prefix */
-    override def parents(implicit ctx: Context): List[TypeRef] = {
+    override def parentRefs(implicit ctx: Context): List[TypeRef] = {
       if (parentsCache == null)
         parentsCache = cls.classParents.mapConserve(_.asSeenFrom(prefix, cls.owner).asInstanceOf[TypeRef])
       parentsCache
@@ -3447,13 +3474,16 @@ object Types {
 
     /** The parent types with all type arguments */
     override def parentsWithArgs(implicit ctx: Context): List[Type] =
-      parents mapConserve { pref =>
+      parentRefs mapConserve { pref =>
         ((pref: Type) /: pref.classSymbol.typeParams) { (parent, tparam) =>
           val targSym = decls.lookup(tparam.name)
           if (targSym.exists) RefinedType(parent, targSym.name, targSym.info)
           else parent
         }
       }
+
+    override def parentsNEW(implicit ctx: Context): List[Type] =
+      parentRefs // !!! TODO: change
 
     def derivedClassInfo(prefix: Type)(implicit ctx: Context) =
       if (prefix eq this.prefix) this
@@ -3938,12 +3968,12 @@ object Types {
   abstract class DeepTypeMap(implicit ctx: Context) extends TypeMap {
     override def mapClassInfo(tp: ClassInfo) = {
       val prefix1 = this(tp.prefix)
-      val parents1 = (tp.parents mapConserve this).asInstanceOf[List[TypeRef]]
+      val parentRefs1 = (tp.parentRefs mapConserve this).asInstanceOf[List[TypeRef]]
       val selfInfo1 = tp.selfInfo match {
         case selfInfo: Type => this(selfInfo)
         case selfInfo => selfInfo
       }
-      tp.derivedClassInfo(prefix1, parents1, tp.decls, selfInfo1)
+      tp.derivedClassInfo(prefix1, parentRefs1, tp.decls, selfInfo1)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -462,7 +462,7 @@ object Types {
       // We need a valid prefix for `asSeenFrom`
       val pre = this match {
         case tp: ClassInfo =>
-          tp.typeRef
+          tp.typeRef // @!!! appliedRef
         case _ =>
           widenIfUnstable
       }
@@ -1248,7 +1248,7 @@ object Types {
     /** This type seen as a TypeBounds */
     final def bounds(implicit ctx: Context): TypeBounds = this match {
       case tp: TypeBounds => tp
-      case ci: ClassInfo => TypeAlias(ci.typeRef)
+      case ci: ClassInfo => TypeAlias(ci.appliedRef)
       case wc: WildcardType =>
         wc.optBounds match {
           case bounds: TypeBounds => bounds
@@ -2011,7 +2011,7 @@ object Types {
 
   // Those classes are non final as Linker extends them.
   class TermRefWithFixedSym(prefix: Type, name: TermName, val fixedSym: TermSymbol) extends TermRef(prefix, name) with WithFixedSym
-  class TypeRefWithFixedSym(prefix: Type, name: TypeName, val fixedSym: TypeSymbol) extends TypeRef(prefix, name) with WithFixedSym
+  class TypeRefWithFixedSym(prefix: Type, name: TypeName, val fixedSym: TypeSymbol) extends TypeRef(prefix, name) with WithFixedSym {
 
   /** Assert current phase does not have erasure semantics */
   private def assertUnerased()(implicit ctx: Context) =
@@ -3059,14 +3059,16 @@ object Types {
       if (ctx.period != validSuper) {
         validSuper = ctx.period
         cachedSuper = tycon match {
-          case tp: HKTypeLambda => defn.AnyType
-          case tp: TypeVar if !tp.inst.exists =>
+          case tycon: HKTypeLambda => defn.AnyType
+          case tycon: TypeVar if !tycon.inst.exists =>
             // supertype not stable, since underlying might change
             validSuper = Nowhere
-            tp.underlying.applyIfParameterized(args)
-          case tp: TypeProxy =>
-            if (tp.typeSymbol.is(Provisional)) validSuper = Nowhere
-            tp.superType.applyIfParameterized(args)
+            tycon.underlying.applyIfParameterized(args)
+          case tycon: TypeProxy =>
+            val sym = tycon.typeSymbol
+            if (sym.is(Provisional)) validSuper = Nowhere
+            if (sym.isClass) tycon
+            else tycon.superType.applyIfParameterized(args)
           case _ => defn.AnyType
         }
       }
@@ -3466,8 +3468,11 @@ object Types {
       }
 
     /** The class type with all type parameters */
-    def fullyAppliedRef(implicit ctx: Context): Type = fullyAppliedRef(cls.typeRef, cls.typeParams)
+    def fullyAppliedRef(implicit ctx: Context): Type =
+      if (Config.newScheme && false) cls.appliedRef
+      else fullyAppliedRef(cls.typeRef, cls.typeParams)
 
+    private var appliedRefCache: Type = null
     private var typeRefCache: TypeRef = null
 
     def typeRef(implicit ctx: Context): TypeRef = {
@@ -3477,6 +3482,19 @@ object Types {
           if ((cls is PackageClass) || cls.owner.isTerm) symbolicTypeRef
           else TypeRef(prefix, cls.name, clsDenot)
       typeRefCache
+    }
+
+    def appliedRef(implicit ctx: Context): Type = {
+      def clsDenot = if (prefix eq cls.owner.thisType) cls.denot else cls.denot.copySymDenotation(info = this)
+      if (appliedRefCache == null) {
+        val tref =
+          if ((cls is PackageClass) || cls.owner.isTerm) symbolicTypeRef
+          else TypeRef(prefix, cls.name, clsDenot)
+        appliedRefCache =
+          if (Config.newScheme) tref.appliedTo(cls.typeParams.map(_.typeRef))
+          else tref
+      }
+      appliedRefCache
     }
 
     def symbolicTypeRef(implicit ctx: Context): TypeRef = TypeRef(prefix, cls)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2011,7 +2011,7 @@ object Types {
 
   // Those classes are non final as Linker extends them.
   class TermRefWithFixedSym(prefix: Type, name: TermName, val fixedSym: TermSymbol) extends TermRef(prefix, name) with WithFixedSym
-  class TypeRefWithFixedSym(prefix: Type, name: TypeName, val fixedSym: TypeSymbol) extends TypeRef(prefix, name) with WithFixedSym {
+  class TypeRefWithFixedSym(prefix: Type, name: TypeName, val fixedSym: TypeSymbol) extends TypeRef(prefix, name) with WithFixedSym
 
   /** Assert current phase does not have erasure semantics */
   private def assertUnerased()(implicit ctx: Context) =
@@ -2695,7 +2695,7 @@ object Types {
      *    def f(x: C)(y: x.S)       // dependencyStatus = TrueDeps
      *    def f(x: C)(y: x.T)       // dependencyStatus = FalseDeps, i.e.
      *                              // dependency can be eliminated by dealiasing.
-     */
+      */
     private def dependencyStatus(implicit ctx: Context): DependencyStatus = {
       if (myDependencyStatus != Unknown) myDependencyStatus
       else {

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -329,11 +329,11 @@ class ClassfileParser(
                         case '*' => TypeBounds.empty
                       }
                       if (formals != null)
-                        tp1 = RefinedType(tp1, formals.head.name, bounds)
+                        tp1 = RefinedType(tp1, formals.head.name, bounds) // @!!!
                     case _ =>
                       val info = sig2type(tparams, skiptvs)
                       if (formals != null)
-                        tp1 = RefinedType(tp1, formals.head.name, TypeAlias(info))
+                        tp1 = RefinedType(tp1, formals.head.name, TypeAlias(info)) // @!!!
                   }
                   if (formals != null)
                     formals = formals.tail

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -424,7 +424,7 @@ class ClassfileParser(
       val start = index
       while (sig(index) != '>') {
         val tpname = subName(':'.==).toTypeName
-        val expname = if (owner.isClass) tpname.expandedName(owner) else tpname
+        val expname = if (owner.isClass && !config.Config.newScheme) tpname.expandedName(owner) else tpname
         val s = ctx.newSymbol(
           owner, expname, owner.typeParamCreationFlags,
           typeParamCompleter(index), coord = indexCoord(index))

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -164,6 +164,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   BIND           Length boundName_NameRef bounds_Type
                                         // for type-variables defined in a type pattern
                   BYNAMEtype            underlying_Type
+                  LAZYref               underlying_Type
                   POLYtype       Length result_Type NamesTypes
                   METHODtype     Length result_Type NamesTypes      // needed for refinements
                   TYPELAMBDAtype Length result_Type NamesTypes      // variance encoded in front of name: +/-/(nothing)
@@ -256,7 +257,7 @@ object TastyFormat {
   final val OBJECTCLASS = 40
 
   final val SIGNED = 63
-  
+
   final val firstInternalTag = 64
   final val IMPLMETH = 64
 
@@ -322,6 +323,7 @@ object TastyFormat {
   final val PROTECTEDqualified = 105
   final val RECtype = 106
   final val SINGLETONtpt = 107
+  final val LAZYref = 108
 
   final val IDENT = 112
   final val IDENTtpt = 113
@@ -512,6 +514,7 @@ object TastyFormat {
     case DOUBLEconst => "DOUBLEconst"
     case STRINGconst => "STRINGconst"
     case RECtype => "RECtype"
+    case LAZYref => "LAZYref"
 
     case IDENT => "IDENT"
     case IDENTtpt => "IDENTtpt"

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -164,11 +164,12 @@ Standard-Section: "ASTs" TopLevelStat*
                   BIND           Length boundName_NameRef bounds_Type
                                         // for type-variables defined in a type pattern
                   BYNAMEtype            underlying_Type
+                  PARAMtype      Length binder_ASTref paramNum_Nat
+                  TYPEARGtype    Length prefix_Type clsRef_Type idx_Nat
                   LAZYref               underlying_Type
                   POLYtype       Length result_Type NamesTypes
                   METHODtype     Length result_Type NamesTypes      // needed for refinements
                   TYPELAMBDAtype Length result_Type NamesTypes      // variance encoded in front of name: +/-/(nothing)
-                  PARAMtype      Length binder_ASTref paramNum_Nat  // needed for refinements
                   SHARED                type_ASTRef
   NamesTypes    = NameType*
   NameType      = paramName_NameRef typeOrBounds_ASTRef
@@ -382,6 +383,7 @@ object TastyFormat {
   final val LAMBDAtpt = 173
   final val PARAMtype = 174
   final val ANNOTATION = 175
+  final val TYPEARGtype = 176
 
   final val firstSimpleTreeTag = UNITconst
   final val firstNatTreeTag = SHARED
@@ -565,6 +567,7 @@ object TastyFormat {
     case ENUMconst => "ENUMconst"
     case SINGLETONtpt => "SINGLETONtpt"
     case SUPERtype => "SUPERtype"
+    case TYPEARGtype => "TYPEARGtype"
     case REFINEDtype => "REFINEDtype"
     case REFINEDtpt => "REFINEDtpt"
     case APPLIEDtype => "APPLIEDtype"

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -246,6 +246,7 @@ class TreePickler(pickler: TastyPickler) {
     case tpe: ParamRef =>
       assert(pickleParamRef(tpe), s"orphan parameter reference: $tpe")
     case tpe: LazyRef =>
+      writeByte(LAZYref)
       pickleType(tpe.ref)
   }
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -139,7 +139,7 @@ class TreePickler(pickler: TastyPickler) {
   }
 
   private def pickleNewType(tpe: Type, richTypes: Boolean)(implicit ctx: Context): Unit = tpe match {
-    case AppliedType(tycon, args) =>
+    case AnyAppliedType(tycon, args) =>
       writeByte(APPLIEDtype)
       withLength { pickleType(tycon); args.foreach(pickleType(_)) }
     case ConstantType(value) =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -197,7 +197,10 @@ class TreePickler(pickler: TastyPickler) {
       }
     case tpe: SuperType =>
       writeByte(SUPERtype)
-      withLength { pickleType(tpe.thistpe); pickleType(tpe.supertpe)}
+      withLength { pickleType(tpe.thistpe); pickleType(tpe.supertpe) }
+    case tpe: TypeArgRef =>
+      writeByte(TYPEARGtype)
+      withLength { pickleType(tpe.prefix); pickleType(tpe.clsRef); writeNat(tpe.idx) }
     case tpe: RecThis =>
       writeByte(RECthis)
       val binderAddr = pickledTypes.get(tpe.binder)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -295,9 +295,8 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
           RecThis(readTypeRef().asInstanceOf[RecType])
         case LAZYref =>
           val rdr = fork
-          def readUnderlying() = rdr.readType()
           skipTree()
-          LazyRef(readUnderlying)
+          LazyRef(implicit ctx => rdr.readType())
         case SHARED =>
           val ref = readAddr()
           typeAtAddr.getOrElseUpdate(ref, forkAt(ref).readType())

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -293,6 +293,11 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
           RecType(rt => registeringType(rt, readType()))
         case RECthis =>
           RecThis(readTypeRef().asInstanceOf[RecType])
+        case LAZYref =>
+          val rdr = fork
+          def readUnderlying() = rdr.readType()
+          skipTree()
+          LazyRef(readUnderlying)
         case SHARED =>
           val ref = readAddr()
           typeAtAddr.getOrElseUpdate(ref, forkAt(ref).readType())

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -219,8 +219,6 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
 
         val result =
           (tag: @switch) match {
-            case SUPERtype =>
-              SuperType(readType(), readType())
             case REFINEDtype =>
               var name: Name = readName()
               val parent = readType()
@@ -246,6 +244,10 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
               AndType(readType(), readType())
             case ORtype =>
               OrType(readType(), readType())
+            case SUPERtype =>
+              SuperType(readType(), readType())
+            case TYPEARGtype =>
+              TypeArgRef(readType(), readType().asInstanceOf[TypeRef], readNat())
             case BIND =>
               val sym = ctx.newSymbol(ctx.owner, readName().toTypeName, BindDefinedType, readType())
               registerSym(start, sym)
@@ -715,7 +717,7 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
     private def readTemplate(implicit ctx: Context): Template = {
       val start = currentAddr
       val cls = ctx.owner.asClass
-      def setClsInfo(parents: List[TypeRef], selfType: Type) =
+      def setClsInfo(parents: List[Type], selfType: Type) =
         cls.info = ClassInfo(cls.owner.thisType, cls, parents, cls.unforcedDecls, selfType)
       val assumedSelfType =
         if (cls.is(Module) && cls.owner.isClass)

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -486,7 +486,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         var name1 = name.asTypeName
         var flags1 = flags
         if (flags is TypeParam) {
-          name1 = name1.expandedName(owner)
+          if (!dotty.tools.dotc.config.Config.newScheme) name1 = name1.expandedName(owner)
           flags1 |= owner.typeParamCreationFlags
         }
         ctx.newSymbol(owner, name1, flags1, localMemberUnpickler, coord = start)

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -670,6 +670,14 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         }
         if (tycon1 ne tycon) elim(tycon1.appliedTo(args))
         else tp.derivedAppliedType(tycon, args.map(mapArg))
+      case tp @ AppliedType(tycon, args) =>
+        val tycon1 = tycon.safeDealias
+        def mapArg(arg: Type) = arg match {
+          case arg: TypeRef if isBound(arg) => arg.symbol.info
+          case _ => arg
+        }
+        if (tycon1 ne tycon) elim(tycon1.appliedTo(args))
+        else tp.derivedAppliedType(tycon, args.map(mapArg))
       case _ =>
         tp
     }

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -79,7 +79,7 @@ object Interactive {
         // those from the enclosing class
         boundary.enclosingClass match {
           case csym: ClassSymbol =>
-            val classRef = csym.classInfo.typeRef
+            val classRef = csym.classInfo.appliedRef
             completions(classRef, boundary)
           case _ =>
             Nil

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -4,7 +4,7 @@ package printing
 import core._
 import Texts._, Types._, Flags._, Names._, Symbols._, NameOps._, Constants._, Denotations._
 import Contexts.Context, Scopes.Scope, Denotations.Denotation, Annotations.Annotation
-import TypeApplications.AppliedType
+import TypeApplications.AnyAppliedType
 import StdNames.{nme, tpnme}
 import ast.Trees._, ast._
 import typer.Implicits._
@@ -123,7 +123,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
    */
   private def refinementChain(tp: Type): List[Type] =
     tp :: (tp match {
-      case AppliedType(_, _) => Nil
+      case AnyAppliedType(_, _) => Nil
       case tp: RefinedType => refinementChain(tp.parent.stripTypeVar)
       case _ => Nil
     })
@@ -142,7 +142,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
         toTextLocal(tp.underlying) ~ "(" ~ toTextRef(tp) ~ ")"
       case tp: TypeRef =>
         toTextPrefix(tp.prefix) ~ selectionString(tp)
-      case AppliedType(tycon, args) =>
+      case AnyAppliedType(tycon, args) =>
         (toTextLocal(tycon) ~ "[" ~ Text(args map argText, ", ") ~ "]").close
       case tp: RefinedType =>
         val parent :: (refined: List[RefinedType @unchecked]) =

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -61,6 +61,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
           homogenize(tp.info)
         case tp: LazyRef =>
           homogenize(tp.ref)
+        case AppliedType(tycon, args) =>
+          tycon.dealias.appliedTo(args)
         case HKApply(tycon, args) =>
           tycon.dealias.appliedTo(args)
         case _ =>
@@ -189,6 +191,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
         ParamRefNameString(tp) ~ ".type"
       case AnnotatedType(tpe, annot) =>
         toTextLocal(tpe) ~ " " ~ toText(annot)
+      case AppliedType(tycon, args) =>
+        toTextLocal(tycon) ~ "[" ~ Text(args.map(argText), ", ") ~ "]"
       case HKApply(tycon, args) =>
         toTextLocal(tycon) ~ "[" ~ Text(args.map(argText), ", ") ~ "]"
       case tp: TypeVar =>

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -125,7 +125,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
    */
   private def refinementChain(tp: Type): List[Type] =
     tp :: (tp match {
-      case AnyAppliedType(_, _) => Nil
+      case AnyAppliedType(_, _) => Nil // @!!!
       case tp: RefinedType => refinementChain(tp.parent.stripTypeVar)
       case _ => Nil
     })
@@ -156,6 +156,11 @@ class PlainPrinter(_ctx: Context) extends Printer {
           "{" ~ selfRecName(openRecs.length) ~ " => " ~ toTextGlobal(tp.parent) ~ "}"
         }
         finally openRecs = openRecs.tail
+      case TypeArgRef(prefix, clsRef, idx) =>
+        val cls = clsRef.symbol
+        val tparams = cls.typeParams
+        val paramName = if (tparams.length > idx) nameString(tparams(idx)) else "<unknown>"
+        toTextPrefix(prefix) ~ "<parameter $paramName of " ~ toText(cls) ~ ">"
       case AndType(tp1, tp2) =>
         changePrec(AndPrec) { toText(tp1) ~ " & " ~ toText(tp2) }
       case OrType(tp1, tp2) =>

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -323,7 +323,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
         val declsText =
           if (trueDecls.isEmpty || !ctx.settings.debug.value) Text()
           else dclsText(trueDecls)
-        tparamsText ~ " extends " ~ toTextParents(tp.parents) ~ "{" ~ selfText ~ declsText ~
+        tparamsText ~ " extends " ~ toTextParents(tp.parentsNEW) ~ "{" ~ selfText ~ declsText ~
           "} at " ~ preText
       case tp =>
         ": " ~ toTextGlobal(tp)
@@ -401,7 +401,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
   def toText(sym: Symbol): Text =
     (kindString(sym) ~~ {
-      if (sym.isAnonymousClass) toText(sym.info.parents, " with ") ~ "{...}"
+      if (sym.isAnonymousClass) toText(sym.info.parentsNEW, " with ") ~ "{...}"
       else if (hasMeaninglessName(sym)) simpleNameString(sym.owner) + idString(sym)
       else nameString(sym)
     }).close

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -64,7 +64,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
 
   override protected def simpleNameString(sym: Symbol): String = {
     val name = if (ctx.property(XprintMode).isEmpty) sym.originalName else sym.name
-    nameString(if (sym.is(TypeParam)) name.asTypeName.unexpandedName else name)
+    nameString(if (sym.is(TypeParam)) name.asTypeName.unexpandedName else name) // @!!!
   }
 
   override def fullNameString(sym: Symbol): String =

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -126,7 +126,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       }
 
     def isInfixType(tp: Type): Boolean = tp match {
-      case AppliedType(tycon, args) =>
+      case AnyAppliedType(tycon, args) =>
         args.length == 2 &&
           !Character.isUnicodeIdentifierStart(tycon.typeSymbol.name.toString.head)
           // TODO: Once we use the 2.12 stdlib, also check the @showAsInfix annotation
@@ -149,7 +149,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     homogenize(tp) match {
       case x: ConstantType if homogenizedView =>
         return toText(x.widen)
-      case AppliedType(tycon, args) =>
+      case AnyAppliedType(tycon, args) =>
         val cls = tycon.typeSymbol
         if (tycon.isRepeatedParam) return toTextLocal(args.head) ~ "*"
         if (defn.isFunctionClass(cls)) return toTextFunction(args, cls.name.isImplicitFunction)

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -23,6 +23,7 @@ import dotty.tools.dotc.ast.Trees
 import dotty.tools.dotc.ast.untpd.Modifiers
 import dotty.tools.dotc.core.Flags.{FlagSet, Mutable}
 import dotty.tools.dotc.core.SymDenotations.SymDenotation
+import scala.util.control.NonFatal
 
 object messages {
 
@@ -708,10 +709,15 @@ object messages {
 
     private val actualArgString = actual.map(_.show).mkString("[", ", ", "]")
 
-    private val prettyName = fntpe.termSymbol match {
-      case NoSymbol => fntpe.show
-      case symbol   => symbol.showFullName
-    }
+    private val prettyName =
+      try
+        fntpe.termSymbol match {
+          case NoSymbol => fntpe.show
+          case symbol   => symbol.showFullName
+        }
+      catch {
+        case NonFatal(ex) => fntpe.show
+      }
 
     val msg =
       hl"""|${NoColor(msgPrefix)} type arguments for $prettyName$expectedArgString

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1264,7 +1264,7 @@ object messages {
     val msg = hl"""|$qual does not name a parent of $cls"""
     val kind = "Reference"
 
-    private val parents: Seq[String] = (cls.info.parents map (_.name.show)).sorted
+    private val parents: Seq[String] = (cls.info.parentRefs map (_.name.show)).sorted
 
     val explanation =
       hl"""|When a qualifier ${"T"} is used in a ${"super"} prefix of the form ${"C.super[T]"},

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -179,7 +179,7 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
         else dt.Module
       } else dt.ClassDef
 
-    val selfType = apiType(sym.classInfo.givenSelfType)
+    val selfType = apiType(sym.givenSelfType)
 
     val name = if (sym.is(ModuleClass)) sym.fullName.sourceModuleName else sym.fullName
 

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -370,7 +370,7 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
         else
           tp.prefix
         new api.Projection(simpleType(prefix), sym.name.toString)
-      case TypeApplications.AppliedType(tycon, args) =>
+      case TypeApplications.AnyAppliedType(tycon, args) =>
         def processArg(arg: Type): api.Type = arg match {
           case arg @ TypeBounds(lo, hi) => // Handle wildcard parameters
             if (lo.isDirectRef(defn.NothingClass) && hi.isDirectRef(defn.AnyClass))

--- a/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
@@ -81,8 +81,8 @@ class CheckReentrant extends MiniPhaseTransform { thisTransformer =>
                 sym.info.widenExpr.classSymbols.foreach(addVars)
               }
             }
-        for (parent <- cls.classInfo.classParents)
-          addVars(parent.symbol.asClass)
+        for (parent <- cls.classInfo.classParentsNEW)
+          addVars(parent.typeSymbol.asClass)
       }
     }
   }

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -391,7 +391,7 @@ object Erasure {
             cpy.Super(qual)(thisQual, untpd.Ident(sym.owner.asClass.name))
               .withType(SuperType(thisType, sym.owner.typeRef))
           else
-            qual.withType(SuperType(thisType, thisType.firstParent))
+            qual.withType(SuperType(thisType, thisType.firstParentRef))
         case _ =>
           qual
       }

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -157,7 +157,7 @@ object ExplicitOuter {
 
   /** A new outer accessor or param accessor */
   private def newOuterSym(owner: ClassSymbol, cls: ClassSymbol, name: TermName, flags: FlagSet)(implicit ctx: Context) = {
-    val target = cls.owner.enclosingClass.typeRef
+    val target = cls.owner.enclosingClass.appliedRef
     val info = if (flags.is(Method)) ExprType(target) else target
     ctx.withPhaseNoEarlier(ctx.explicitOuterPhase.next) // outer accessors are entered at explicitOuter + 1, should not be defined before.
        .newSymbol(owner, name, Synthetic | flags, info, coord = cls.coord)

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -194,7 +194,7 @@ object ExplicitOuter {
     needsOuterIfReferenced(cls) &&
     (!hasLocalInstantiation(cls) || // needs outer because we might not know whether outer is referenced or not
      cls.mixins.exists(needsOuterIfReferenced) || // needs outer for parent traits
-     cls.classInfo.parents.exists(parent => // needs outer to potentially pass along to parent
+     cls.info.parentsNEW.exists(parent => // needs outer to potentially pass along to parent
        needsOuterIfReferenced(parent.classSymbol.asClass)))
 
   /** Class is always instantiated in the compilation unit where it is defined */

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -105,7 +105,7 @@ class ExplicitOuter extends MiniPhaseTransform with InfoTransformer { thisTransf
 
       for (parentTrait <- cls.mixins) {
         if (needsOuterIfReferenced(parentTrait)) {
-          val parentTp = cls.denot.thisType.baseTypeRef(parentTrait)
+          val parentTp = cls.denot.thisType.baseType(parentTrait)
           val outerAccImpl = newOuterAccessor(cls, parentTrait).enteredAfter(thisTransformer)
           newDefs += DefDef(outerAccImpl, singleton(fixThis(outerPrefix(parentTp))))
         }

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitSelf.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitSelf.scala
@@ -38,9 +38,8 @@ class ExplicitSelf extends MiniPhaseTransform { thisTransform =>
   override def transformSelect(tree: Select)(implicit ctx: Context, info: TransformerInfo): Tree = tree match {
     case Select(thiz: This, name) if name.isTermName =>
       val cls = thiz.symbol.asClass
-      val cinfo = cls.classInfo
-      if (cinfo.givenSelfType.exists && !cls.derivesFrom(tree.symbol.owner))
-        cpy.Select(tree)(thiz.asInstance(AndType(cinfo.selfType, thiz.tpe)), name)
+      if (cls.givenSelfType.exists && !cls.derivesFrom(tree.symbol.owner))
+        cpy.Select(tree)(thiz.asInstance(AndType(cls.classInfo.selfType, thiz.tpe)), name)
       else tree
     case _ => tree
   }

--- a/compiler/src/dotty/tools/dotc/transform/FunctionalInterfaces.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FunctionalInterfaces.scala
@@ -72,7 +72,7 @@ class FunctionalInterfaces extends MiniPhaseTransform {
           // symbols loaded from classpath aren't defined in periods earlier than when they where loaded
           val interface = ctx.withPhase(ctx.typerPhase).getClassIfDefined(functionPackage ++ interfaceName)
           if (interface.exists) {
-            val tpt = tpd.TypeTree(interface.asType.typeRef)
+            val tpt = tpd.TypeTree(interface.asType.appliedRef)
             tpd.Closure(tree.env, tree.meth, tpt)
           } else tree
         } else tree

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -35,7 +35,7 @@ object OverridingPairs {
      *  pair has already been treated in a parent class.
      *  This may be refined in subclasses. @see Bridges for a use case.
      */
-    protected def parents: Array[Symbol] = base.info.parents.toArray map (_.typeSymbol)
+    protected def parents: Array[Symbol] = base.info.parentsNEW.toArray map (_.typeSymbol)
 
     /** Does `sym1` match `sym2` so that it qualifies as overriding.
      *  Types always match. Term symbols match if their membertypes

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -236,7 +236,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer  { thisTran
 
             // Add Child annotation to sealed parents unless current class is anonymous
             if (!sym.isAnonymousClass) // ignore anonymous class
-              sym.asClass.classInfo.classParents.foreach { parent =>
+              sym.asClass.classParentsNEW.foreach { parent =>
                 val sym2 = if (sym.is(Module)) sym.sourceModule else sym
                 registerChild(sym2, parent)
               }

--- a/compiler/src/dotty/tools/dotc/transform/Splitter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splitter.scala
@@ -92,7 +92,7 @@ class Splitter extends MiniPhaseTransform { thisTransform =>
     else {
       def choose(qual: Tree, syms: List[Symbol]): Tree = {
         def testOrCast(which: Symbol, mbr: Symbol) =
-          qual.select(which).appliedToType(mbr.owner.typeRef)
+          qual.select(which).appliedToType(mbr.owner.appliedRef)
         def select(sym: Symbol) = {
           val qual1 =
             if (qual.tpe derivesFrom sym.owner) qual

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -297,7 +297,7 @@ class SuperAccessors(thisTransformer: DenotTransformer) {
       val clazz = currentClass
       val host = hostForAccessorOf(sym, clazz)
       def accessibleThroughSubclassing =
-        validCurrentClass && (clazz.classInfo.selfType <:< sym.owner.typeRef) && !clazz.is(Trait)
+        validCurrentClass && (clazz.classInfo.selfType <:< sym.owner.appliedRef) && !clazz.is(Trait)
 
       val isCandidate = (
            sym.is(Protected)
@@ -308,7 +308,7 @@ class SuperAccessors(thisTransformer: DenotTransformer) {
         && (sym.enclosingPackageClass == sym.accessBoundary(sym.enclosingPackageClass))
       )
       val hostSelfType = host.classInfo.selfType
-      def isSelfType = !(host.typeRef <:< hostSelfType) && {
+      def isSelfType = !(host.appliedRef <:< hostSelfType) && {
         if (hostSelfType.typeSymbol.is(JavaDefined))
           ctx.restrictionError(
             s"cannot accesses protected $sym from within $clazz with host self type $hostSelfType", pos)
@@ -332,7 +332,7 @@ class SuperAccessors(thisTransformer: DenotTransformer) {
      */
     private def hostForAccessorOf(sym: Symbol, referencingClass: ClassSymbol)(implicit ctx: Context): ClassSymbol =
       if (referencingClass.derivesFrom(sym.owner)
-          || referencingClass.classInfo.selfType <:< sym.owner.typeRef
+          || referencingClass.classInfo.selfType <:< sym.owner.appliedRef
           || referencingClass.enclosingPackageClass == sym.owner.enclosingPackageClass) {
         assert(referencingClass.isClass, referencingClass)
         referencingClass

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
@@ -54,7 +54,7 @@ class SyntheticMethods(thisTransformer: DenotTransformer) {
 
   /** The synthetic methods of the case or value class `clazz`. */
   def syntheticMethods(clazz: ClassSymbol)(implicit ctx: Context): List[Tree] = {
-    val clazzType = clazz.typeRef
+    val clazzType = clazz.appliedRef
     lazy val accessors =
       if (isDerivedValueClass(clazz))
         clazz.termParamAccessors

--- a/compiler/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TailRec.scala
@@ -244,7 +244,7 @@ class TailRec extends MiniPhaseTransform with DenotTransformer with FullParamete
 
         if (isRecursiveCall) {
           if (ctx.tailPos) {
-            val receiverIsSame = enclosingClass.typeRef.widenDealias =:= recvWiden
+            val receiverIsSame = enclosingClass.appliedRef.widenDealias =:= recvWiden
             val receiverIsThis = prefix.tpe =:= thisType || prefix.tpe.widen =:= thisType
 
             def rewriteTailCall(recv: Tree): Tree = {
@@ -282,7 +282,7 @@ class TailRec extends MiniPhaseTransform with DenotTransformer with FullParamete
           }
           else fail(defaultReason)
         } else {
-          val receiverIsSuper = (method.name eq sym) && enclosingClass.typeRef.widen <:< recvWiden
+          val receiverIsSuper = (method.name eq sym) && enclosingClass.appliedRef.widen <:< recvWiden
 
           if (receiverIsSuper) fail("it contains a recursive call targeting a supertype")
           else continue

--- a/compiler/src/dotty/tools/dotc/transform/localopt/InlineCaseIntrinsics.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/InlineCaseIntrinsics.scala
@@ -7,6 +7,7 @@ import core.StdNames._
 import core.Symbols._
 import core.Types._
 import core.Flags._
+import core.TypeApplications.noBounds
 import ast.Trees._
 import transform.SymUtils._
 import Simplify.desugarIdent
@@ -82,7 +83,7 @@ class InlineCaseIntrinsics(val simplifyPhase: Simplify) extends Optimisation {
         def some(e: Tree) = {
           val accessors = e.tpe.widenDealias.classSymbol.caseAccessors.filter(_.is(Method))
           val fields    = accessors.map(x => e.select(x).ensureApplied)
-          val tplType   = a.tpe.baseArgTypes(defn.OptionClass).head
+          val tplType   = noBounds(a.tpe.baseType(defn.OptionClass).argInfos.head)
           val someTpe   = a.tpe.translateParameterized(defn.OptionClass, defn.SomeClass)
 
           if (fields.tail.nonEmpty)

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -457,6 +457,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
   /* Erase a type binding according to erasure semantics in pattern matching */
   def erase(tp: Type): Type = {
     def doErase(tp: Type): Type = tp match {
+      case tp: AppliedType => erase(tp.superType)
       case tp: HKApply => erase(tp.superType)
       case tp: RefinedType => erase(tp.parent)
       case _ => tp
@@ -565,9 +566,13 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
    *
    *  If `tp1` is `path1.A`, `tp2` is `path2.B`, and `path1` is subtype of
    *  `path2`, then return `path1.B`.
+   *
+   *  (MO) I don't really understand what this does. Let's try to find a precise
+   *       definition!
    */
   def refine(tp1: Type, tp2: Type): Type = (tp1, tp2) match {
     case (tp1: RefinedType, _: TypeRef) => tp1.wrapIfMember(refine(tp1.parent, tp2))
+    case (tp1: AppliedType, _) => refine(tp1.superType, tp2)
     case (tp1: HKApply, _) => refine(tp1.superType, tp2)
     case (TypeRef(ref1: TypeProxy, _), tp2 @ TypeRef(ref2: TypeProxy, _)) =>
       if (ref1.underlying <:< ref2.underlying) tp2.derivedSelect(ref1) else tp2

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -94,7 +94,7 @@ object Applications {
     if (unapplyName == nme.unapplySeq) {
       if (unapplyResult derivesFrom defn.SeqClass) seqSelector :: Nil
       else if (isGetMatch(unapplyResult, pos)) {
-        val seqArg = boundsToHi(getTp.elemType)
+        val seqArg = getTp.elemType.hiBound
         if (seqArg.exists) args.map(Function.const(seqArg))
         else fail
       }

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -894,7 +894,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
     def isSubTypeOfParent(subtp: Type, tp: Type)(implicit ctx: Context): Boolean =
       if (subtp <:< tp) true
       else tp match {
-        case tp: TypeRef if tp.symbol.isClass => isSubTypeOfParent(subtp, tp.firstParent)
+        case tp: TypeRef if tp.symbol.isClass => isSubTypeOfParent(subtp, tp.firstParentNEW)
         case tp: TypeProxy => isSubTypeOfParent(subtp, tp.superType)
         case _ => false
       }

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -378,12 +378,12 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
           // default getters for class constructors are found in the companion object
           val cls = meth.owner
           val companion = cls.companionModule
-          receiver.tpe.baseTypeRef(cls) match {
-            case tp: TypeRef if companion.isTerm =>
-              selectGetter(ref(TermRef(tp.prefix, companion.asTerm)))
-            case _ =>
-              EmptyTree
+          if (companion.isTerm) {
+            val prefix = receiver.tpe.baseType(cls).normalizedPrefix
+            if (prefix.exists) selectGetter(ref(TermRef(prefix, companion.asTerm)))
+            else EmptyTree
           }
+          else EmptyTree
         }
       }
     }

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1075,7 +1075,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
         tp1.paramInfos.isEmpty && tp2.isInstanceOf[LambdaType]
       case tp1: PolyType => // (2)
         val tparams = ctx.newTypeParams(alt1.symbol, tp1.paramNames, EmptyFlags, tp1.instantiateBounds)
-        isAsSpecific(alt1, tp1.instantiate(tparams map (_.typeRef)), alt2, tp2)
+        isAsSpecific(alt1, tp1.instantiate(tparams.map(_.typeRef)), alt2, tp2)
       case _ => // (3)
         tp2 match {
           case tp2: MethodType => true // (3a)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -249,7 +249,7 @@ object Checking {
         } catch {
           case ex: CyclicReference =>
             ctx.debuglog(i"cycle detected for $tp, $nestedCycleOK, $cycleOK")
-            if (cycleOK) LazyRef(() => tp)
+            if (cycleOK) LazyRef(_ => tp)
             else if (reportErrors) throw ex
             else tp
         }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -133,7 +133,7 @@ object Checking {
           // Create a synthetic singleton type instance, and check whether
           // it conforms to the self type of the class as seen from that instance.
           val stp = SkolemType(tp)
-          val selfType = tref.givenSelfType.asSeenFrom(stp, cls)
+          val selfType = cls.asClass.givenSelfType.asSeenFrom(stp, cls)
           if (selfType.exists && !(stp <:< selfType))
             ctx.error(DoesNotConformToSelfTypeCantBeInstantiated(tp, selfType), pos)
         }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -454,7 +454,7 @@ object Checking {
         case tp: ClassInfo =>
           tp.derivedClassInfo(
             prefix = apply(tp.prefix),
-            classParents =
+            classParentsNEW =
               tp.parentsWithArgs.map { p =>
                 apply(p).underlyingClassRef(refinementOK = false) match {
                   case ref: TypeRef => ref
@@ -575,17 +575,26 @@ trait Checking {
    *  their lower bound conforms to their upper bound. If a type argument is
    *  infeasible, issue and error and continue with upper bound.
    */
-  def checkFeasible(tp: Type, pos: Position, where: => String = "")(implicit ctx: Context): Type = tp match {
-    case tp: RefinedType =>
-      tp.derivedRefinedType(tp.parent, tp.refinedName, checkFeasible(tp.refinedInfo, pos, where))
-    case tp: RecType =>
-      tp.rebind(tp.parent)
-    case tp @ TypeBounds(lo, hi) if !(lo <:< hi) =>
-      ctx.error(ex"no type exists between low bound $lo and high bound $hi$where", pos)
-      TypeAlias(hi)
-    case _ =>
-      tp
-  }
+  def checkFeasible(tp: Type, pos: Position, where: => String = "")(implicit ctx: Context): Type =
+    tp match {
+      case tp @ AppliedType(tycon, args) =>
+        def checkArg(arg: Type) = arg match {
+          case tp @ TypeBounds(lo, hi) if !(lo <:< hi) =>
+            ctx.error(ex"no type exists between low bound $lo and high bound $hi$where", pos)
+            hi
+          case _ => arg
+        }
+        tp.derivedAppliedType(tycon, args.mapConserve(checkArg))
+      case tp: RefinedType => // @!!!
+        tp.derivedRefinedType(tp.parent, tp.refinedName, checkFeasible(tp.refinedInfo, pos, where))
+      case tp: RecType => // @!!!
+        tp.rebind(tp.parent)
+      case tp @ TypeBounds(lo, hi) if !(lo <:< hi) => // @!!!
+        ctx.error(ex"no type exists between low bound $lo and high bound $hi$where", pos)
+        TypeAlias(hi)
+      case _ =>
+        tp
+    }
 
   /** Check that `tree` is a pure expression of constant type */
   def checkInlineConformant(tree: Tree, what: => String)(implicit ctx: Context): Unit =

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -385,6 +385,13 @@ trait ImplicitRunInfo { self: RunInfo =>
           (lead /: tp.classSymbols)(joinClass)
         case tp: TypeVar =>
           apply(tp.underlying)
+        case tp: AppliedType =>
+          def applyArg(arg: Type) = arg match {
+            case TypeBounds(lo, hi) => AndType.make(lo, hi)
+            case _: WildcardType => defn.AnyType
+            case _ => arg
+          }
+          (apply(tp.tycon) /: tp.args)((tc, arg) => AndType.make(tc, applyArg(arg)))
         case tp: HKApply =>
           def applyArg(arg: Type) = arg match {
             case TypeBounds(lo, hi) => AndType.make(lo, hi)

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -319,8 +319,6 @@ object Inferencing {
         case _ =>
           foldOver(vmap, t)
       }
-      override def applyToPrefix(vmap: VarianceMap, t: NamedType) =
-        apply(vmap, t.prefix)
     }
 
     /** Include in `vmap` type variables occurring in the constraints of type variables

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -922,7 +922,7 @@ class Namer { typer: Typer =>
       Checking.checkWellFormed(cls)
       if (isDerivedValueClass(cls)) cls.setFlag(Final)
       cls.info = avoidPrivateLeaks(cls, cls.pos)
-      cls.baseClasses.foreach(_.invalidateBaseTypeRefCache()) // we might have looked before and found nothing
+      cls.baseClasses.foreach(_.invalidateBaseTypeCache()) // we might have looked before and found nothing
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -336,7 +336,7 @@ class Namer { typer: Typer =>
     */
   def enterSymbol(sym: Symbol)(implicit ctx: Context) = {
     if (sym.exists) {
-      typr.println(s"entered: $sym in ${ctx.owner} and ${ctx.effectiveScope}")
+      typr.println(s"entered: $sym in ${ctx.owner}")
       ctx.enter(sym)
     }
     sym

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -92,7 +92,7 @@ trait NamerContextOps { this: Context =>
    *  type of the constructed instance is returned
    */
   def effectiveResultType(sym: Symbol, typeParams: List[Symbol], given: Type) =
-    if (sym.name == nme.CONSTRUCTOR) sym.owner.typeRef.appliedTo(typeParams map (_.typeRef))
+    if (sym.name == nme.CONSTRUCTOR) sym.owner.typeRef.appliedTo(typeParams.map(_.typeRef))
     else given
 
   /** if isConstructor, make sure it has one non-implicit parameter list */

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -915,7 +915,7 @@ class Namer { typer: Typer =>
 
       val parentTypes = ensureFirstIsClass(parents.map(checkedParentType(_)))
       val parentRefs = ctx.normalizeToClassRefs(parentTypes, cls, decls)
-      typr.println(s"completing $denot, parents = $parents, parentTypes = $parentTypes, parentRefs = $parentRefs")
+      typr.println(i"completing $denot, parents = $parents%, %, parentTypes = $parentTypes%, %, parentRefs = $parentRefs%, %")
 
       tempInfo.finalize(denot, parentRefs)
 

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -83,6 +83,7 @@ object ProtoTypes {
     def isMatchedBy(tp1: Type)(implicit ctx: Context) = true
     def map(tm: TypeMap)(implicit ctx: Context): ProtoType = this
     def fold[T](x: T, ta: TypeAccumulator[T])(implicit ctx: Context): T = x
+    override def toString = getClass.toString
   }
 
   /** A class marking ignored prototypes that can be revealed by `deepenProto` */

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -474,6 +474,11 @@ object ProtoTypes {
     case tp: NamedType => // default case, inlined for speed
       if (tp.symbol.isStatic) tp
       else tp.derivedSelect(wildApprox(tp.prefix, theMap, seen))
+    case tp @ AppliedType(tycon, args) =>
+      wildApprox(tycon, theMap, seen) match {
+        case _: WildcardType => WildcardType // this ensures we get a * type
+        case tycon1 => tp.derivedAppliedType(tycon1, args.mapConserve(wildApprox(_, theMap, seen)))
+      }
     case tp: RefinedType => // default case, inlined for speed
       tp.derivedRefinedType(
           wildApprox(tp.parent, theMap, seen),

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -94,16 +94,16 @@ object RefChecks {
    */
   private def checkParents(cls: Symbol)(implicit ctx: Context): Unit = cls.info match {
     case cinfo: ClassInfo =>
-      def checkSelfConforms(other: TypeRef, category: String, relation: String) = {
+      def checkSelfConforms(other: ClassSymbol, category: String, relation: String) = {
         val otherSelf = other.givenSelfType.asSeenFrom(cls.thisType, other.classSymbol)
         if (otherSelf.exists && !(cinfo.selfType <:< otherSelf))
           ctx.error(DoesNotConformToSelfType(category, cinfo.selfType, cls, otherSelf, relation, other.classSymbol),
             cls.pos)
       }
       for (parent <- cinfo.classParents)
-        checkSelfConforms(parent, "illegal inheritance", "parent")
-      for (reqd <- cinfo.givenSelfType.classSymbols)
-        checkSelfConforms(reqd.typeRef, "missing requirement", "required")
+        checkSelfConforms(parent.typeSymbol.asClass, "illegal inheritance", "parent")
+      for (reqd <- cinfo.cls.givenSelfType.classSymbols)
+        checkSelfConforms(reqd, "missing requirement", "required")
     case _ =>
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -100,7 +100,7 @@ object RefChecks {
           ctx.error(DoesNotConformToSelfType(category, cinfo.selfType, cls, otherSelf, relation, other.classSymbol),
             cls.pos)
       }
-      for (parent <- cinfo.classParents)
+      for (parent <- cinfo.classParentsNEW)
         checkSelfConforms(parent.typeSymbol.asClass, "illegal inheritance", "parent")
       for (reqd <- cinfo.cls.givenSelfType.classSymbols)
         checkSelfConforms(reqd, "missing requirement", "required")
@@ -251,7 +251,7 @@ object RefChecks {
       def compatibleTypes(memberTp: Type, otherTp: Type): Boolean =
         try
           if (member.isType) // intersection of bounds to refined types must be nonempty
-            member.is(BaseTypeArg) ||
+            member.is(BaseTypeArg) || // @!!!
             memberTp.bounds.hi.hasSameKindAs(otherTp.bounds.hi) &&
             ((memberTp frozen_<:< otherTp) ||
              !member.owner.derivesFrom(other.owner) && {

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -84,6 +84,7 @@ object RefChecks {
    */
   private def upwardsThisType(cls: Symbol)(implicit ctx: Context) = cls.info match {
     case ClassInfo(_, _, _, _, tp: Type) if (tp ne cls.typeRef) && !cls.is(ModuleOrFinal) =>
+    // @!!! case ClassInfo(_, _, _, _, selfTp: Type) if selfTp.exists && !cls.is(ModuleOrFinal) =>
       SkolemType(cls.typeRef).withName(nme.this_)
     case _ =>
       cls.thisType

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -285,7 +285,7 @@ object RefChecks {
           //Console.println(infoString(member) + " shadows1 " + infoString(other) " in " + clazz);//DEBUG
           return
         }
-        val parentSymbols = clazz.info.parents.map(_.typeSymbol)
+        val parentSymbols = clazz.info.parentsNEW.map(_.typeSymbol)
         if (parentSymbols exists (p => subOther(p) && subMember(p) && deferredCheck)) {
           //Console.println(infoString(member) + " shadows2 " + infoString(other) + " in " + clazz);//DEBUG
           return

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -304,7 +304,7 @@ trait TypeAssigner {
             errorType("ambiguous parent class qualifier", tree.pos)
         }
         val owntype =
-          if (mixinClass.exists) mixinClass.typeRef
+          if (mixinClass.exists) mixinClass.appliedRef
           else if (!mix.isEmpty) findMixinSuper(cls.info)
           else if (inConstrCall || ctx.erasedTypes) cls.info.firstParentRef
           else {

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -513,17 +513,15 @@ trait TypeAssigner {
 
   private def symbolicIfNeeded(sym: Symbol)(implicit ctx: Context) = {
     val owner = sym.owner
-    owner.infoOrCompleter match {
-      case info: ClassInfo if info.givenSelfType.exists =>
-        // In that case a simple typeRef/termWithWithSig could return a member of
-        // the self type, not the symbol itself. To avoid this, we make the reference
-        // symbolic. In general it seems to be faster to keep the non-symblic
-        // reference, since there is less pressure on the uniqueness tables that way
-        // and less work to update all the different references. That's why symbolic references
-        // are only used if necessary.
-        NamedType.withFixedSym(owner.thisType, sym)
-      case _ => NoType
-    }
+    if (owner.isClass && owner.isCompleted && owner.asClass.givenSelfType.exists)
+      // In that case a simple typeRef/termWithWithSig could return a member of
+      // the self type, not the symbol itself. To avoid this, we make the reference
+      // symbolic. In general it seems to be faster to keep the non-symblic
+      // reference, since there is less pressure on the uniqueness tables that way
+      // and less work to update all the different references. That's why symbolic references
+      // are only used if necessary.
+      NamedType.withFixedSym(owner.thisType, sym)
+    else NoType
   }
 
   def assertExists(tp: Type) = { assert(tp != NoType); tp }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -293,7 +293,7 @@ trait TypeAssigner {
       case err: ErrorType => untpd.cpy.Super(tree)(qual, mix).withType(err)
       case qtype @ ThisType(_) =>
         val cls = qtype.cls
-        def findMixinSuper(site: Type): Type = site.parents filter (_.name == mix.name) match {
+        def findMixinSuper(site: Type): Type = site.parentRefs filter (_.name == mix.name) match {
           case p :: Nil =>
             p
           case Nil =>
@@ -304,7 +304,7 @@ trait TypeAssigner {
         val owntype =
           if (mixinClass.exists) mixinClass.typeRef
           else if (!mix.isEmpty) findMixinSuper(cls.info)
-          else if (inConstrCall || ctx.erasedTypes) cls.info.firstParent
+          else if (inConstrCall || ctx.erasedTypes) cls.info.firstParentRef
           else {
             val ps = cls.classInfo.parentsWithArgs
             if (ps.isEmpty) defn.AnyType else ps.reduceLeft((x: Type, y: Type) => x & y)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -6,7 +6,7 @@ import core._
 import ast._
 import Scopes._, Contexts._, Constants._, Types._, Symbols._, Names._, Flags._, Decorators._
 import ErrorReporting._, Annotations._, Denotations._, SymDenotations._, StdNames._, TypeErasure._
-import TypeApplications.AppliedType
+import TypeApplications.AnyAppliedType
 import util.Positions._
 import config.Printers.typr
 import ast.Trees._
@@ -104,7 +104,7 @@ trait TypeAssigner {
           }
         case tp @ HKApply(tycon, args) if toAvoid(tycon) =>
           apply(tp.superType)
-        case tp @ AppliedType(tycon, args) if toAvoid(tycon) =>
+        case tp @ AnyAppliedType(tycon, args) if toAvoid(tycon) =>
           val base = apply(tycon)
           var args = tp.baseArgInfos(base.typeSymbol)
           if (base.typeParams.length != args.length)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -110,7 +110,7 @@ trait TypeAssigner {
           val base = apply(tycon)
           var args = tp.baseArgInfos(base.typeSymbol)
           if (base.typeParams.length != args.length)
-            args = base.typeParams.map(_.paramInfo)
+            args = base.typeParams.map(_.paramInfo) // TODO: not sure we need this
           apply(base.appliedTo(args))
         case tp @ RefinedType(parent, name, rinfo) if variance > 0 =>
           val parent1 = apply(tp.parent)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -102,6 +102,8 @@ trait TypeAssigner {
             case _ =>
               mapOver(tp)
           }
+        case tp @ AppliedType(tycon, args) if toAvoid(tycon) =>
+          apply(tp.superType)
         case tp @ HKApply(tycon, args) if toAvoid(tycon) =>
           apply(tp.superType)
         case tp @ AnyAppliedType(tycon, args) if toAvoid(tycon) =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -538,7 +538,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     if (untpd.isWildcardStarArg(tree))
       cases(
         ifPat = ascription(TypeTree(defn.RepeatedParamType.appliedTo(pt)), isWildcard = true),
-        ifExpr = seqToRepeated(typedExpr(tree.expr, defn.SeqType)),
+        ifExpr = seqToRepeated(typedExpr(tree.expr, defn.SeqType.appliedTo(defn.AnyType))),
         wildName = nme.WILDCARD_STAR)
     else {
       def typedTpt = checkSimpleKinded(typedType(tree.tpt))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1436,7 +1436,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       }
 
       // Check that phantom lattices are defined in a static object
-      if (cls.classParents.exists(_.classSymbol eq defn.PhantomClass) && !cls.isStaticOwner)
+      if (cls.classParentsNEW.exists(_.typeSymbol eq defn.PhantomClass) && !cls.isStaticOwner)
         ctx.error("only static objects can extend scala.Phantom", cdef.pos)
 
       // check value class constraints
@@ -1470,8 +1470,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     def realClassParent(cls: Symbol): ClassSymbol =
       if (!cls.isClass) defn.ObjectClass
       else if (!(cls is Trait)) cls.asClass
-      else cls.asClass.classParents match {
-        case parentRef :: _ => realClassParent(parentRef.symbol)
+      else cls.asClass.classParentsNEW match {
+        case parentRef :: _ => realClassParent(parentRef.typeSymbol)
         case nil => defn.ObjectClass
       }
     def improve(candidate: ClassSymbol, parent: Type): ClassSymbol = {
@@ -2042,13 +2042,14 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         // Follow proxies and approximate type paramrefs by their upper bound
         // in the current constraint in order to figure out robustly
         // whether an expected type is some sort of function type.
-        def underlyingRefined(tp: Type): Type = tp.stripTypeVar match {
+        def underlyingApplied(tp: Type): Type = tp.stripTypeVar match {
           case tp: RefinedType => tp
-          case tp: TypeParamRef => underlyingRefined(ctx.typeComparer.bounds(tp).hi)
-          case tp: TypeProxy => underlyingRefined(tp.superType)
+          case tp: AppliedType => tp
+          case tp: TypeParamRef => underlyingApplied(ctx.typeComparer.bounds(tp).hi)
+          case tp: TypeProxy => underlyingApplied(tp.superType)
           case _ => tp
         }
-        val ptNorm = underlyingRefined(pt)
+        val ptNorm = underlyingApplied(pt)
         val arity =
           if (defn.isFunctionType(ptNorm))
             if (!isFullyDefined(pt, ForceDegree.none) && isFullyDefined(wtp, ForceDegree.none))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1427,7 +1427,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       val impl1 = cpy.Template(impl)(constr1, parents1, self1, body1)
         .withType(dummy.nonMemberTermRef)
       checkVariance(impl1)
-      if (!cls.is(AbstractOrTrait) && !ctx.isAfterTyper) checkRealizableBounds(cls.typeRef, cdef.namePos)
+      if (!cls.is(AbstractOrTrait) && !ctx.isAfterTyper) checkRealizableBounds(cls.appliedRef, cdef.namePos)
       val cdef1 = assignType(cpy.TypeDef(cdef)(name, impl1), cls)
       if (ctx.phase.isTyper && cdef1.tpe.derivesFrom(defn.DynamicClass) && !ctx.dynamicsEnabled) {
         val isRequired = parents1.exists(_.tpe.isRef(defn.DynamicClass))

--- a/compiler/src/dotty/tools/dotc/typer/Variances.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Variances.scala
@@ -83,6 +83,17 @@ object Variances {
       flip(varianceInTypes(tp.paramInfos)(tparam)) & varianceInType(tp.resultType)(tparam)
     case ExprType(restpe) =>
       varianceInType(restpe)(tparam)
+    case tp @ AppliedType(tycon, args) =>
+      def varianceInArgs(v: Variance, args: List[Type], tparams: List[ParamInfo]): Variance =
+        args match {
+          case arg :: args1 =>
+            varianceInArgs(
+              v & compose(varianceInType(arg)(tparam), tparams.head.paramVariance),
+              args1, tparams.tail)
+          case nil =>
+            v
+        }
+      varianceInArgs(varianceInType(tycon)(tparam), args, tycon.typeParams)
     case tp @ HKApply(tycon, args) =>
       def varianceInArgs(v: Variance, args: List[Type], tparams: List[ParamInfo]): Variance =
         args match {

--- a/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
@@ -57,7 +57,7 @@ object factories {
     }
 
     def expandTpe(t: Type, params: List[Reference] = Nil): Reference = t match {
-      case AppliedType(tycon, args) => {
+      case AnyAppliedType(tycon, args) => {
         val cls = tycon.typeSymbol
 
         if (defn.isFunctionClass(cls))

--- a/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
@@ -198,7 +198,7 @@ object factories {
         case _ => false
       }
 
-      cd.classParents.collect {
+      cd.classParentRefs.collect {
         case t: TypeRef if !isJavaLangObject(t) && !isProductWithArity(t) =>
           UnsetLink(t.name.toString, path(t.symbol).mkString("."))
       }

--- a/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
@@ -176,7 +176,7 @@ object factories {
       paramLists(annot.tpe)
 
     case (_: TypeParamRef | _: RefinedType | _: TypeRef | _: ThisType |
-          _: ExprType  | _: OrType      | _: AndType | _: HKApply  |
+          _: ExprType  | _: OrType      | _: AndType | _: HKApply  | _: AppliedType |
           _: TermRef   | _: ConstantType) =>
       Nil // return types should not be in the paramlist
   }


### PR DESCRIPTION
A more developed version of #2898. 

In the end I did not go ahead with this. Here's a summary why:

First, there are other parts of the compiler that rely on the refinement encoding in interesting ways.  In particular, the way we compute findMember relies on the fact that the member type
of `x` in class `C` is a function of the member types of `x` in the parent classes of `C`. This is no longer true when we instantiate arguments immediately. To pick an example form collections: The type of `toCollection` has the form

     toCollection: (x: Repr)T

where `Repr` is a parameter to all collections. If we see that type from a specific 
collection `sc` we get `(x: sc.Repr)T`. The inherited types of `toCollection` are 
all of the form (x: P.this.Repr)T` where `P` is a parent class. The specific collection
type is obtained by joining the patent types with `&` after replacing `P.this` with `sc.type`.

But if we expand parameters with arguments we get `(x: P)T` for the parent types instead. instead.  And there is no safe operation which will allow us to recover `(x: SC)T` from that.

Second, there's the problem of bounds propagation (see `bounds-propagation.scala` test case).

Those two problems can be solved by having a mixed scheme where we keep type parameters as members, but make them private and have special types that refer to them instead. But that bring back part of the complexity of the refinement type scheme. 

The decisive reason to drop is elsewhere: The Linker relies on being able to refine any parameter bounds in a class or all its base classes retro-actively through refinements. If parameters are no longer instantiated through refinements, this will not work anymore. So if we want to keep the 
option of a fast and precise control-flow analysis, we need to keep parameters as refinements.


