### PR TITLE
Fix #2943: Insert LazyRefs automatically upon Unpickling

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -164,7 +164,6 @@ Standard-Section: "ASTs" TopLevelStat*
                   BIND           Length boundName_NameRef bounds_Type
                                         // for type-variables defined in a type pattern
                   BYNAMEtype            underlying_Type
-                  LAZYref               underlying_Type
                   POLYtype       Length result_Type NamesTypes
                   METHODtype     Length result_Type NamesTypes      // needed for refinements
                   TYPELAMBDAtype Length result_Type NamesTypes      // variance encoded in front of name: +/-/(nothing)
@@ -323,7 +322,6 @@ object TastyFormat {
   final val PROTECTEDqualified = 105
   final val RECtype = 106
   final val SINGLETONtpt = 107
-  final val LAZYref = 108
 
   final val IDENT = 112
   final val IDENTtpt = 113
@@ -514,7 +512,6 @@ object TastyFormat {
     case DOUBLEconst => "DOUBLEconst"
     case STRINGconst => "STRINGconst"
     case RECtype => "RECtype"
-    case LAZYref => "LAZYref"
 
     case IDENT => "IDENT"
     case IDENTtpt => "IDENTtpt"

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -246,7 +246,6 @@ class TreePickler(pickler: TastyPickler) {
     case tpe: ParamRef =>
       assert(pickleParamRef(tpe), s"orphan parameter reference: $tpe")
     case tpe: LazyRef =>
-      writeByte(LAZYref)
       pickleType(tpe.ref)
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -239,7 +239,8 @@ object Checking {
           }
           if (isInteresting(pre)) {
             val pre1 = this(pre, false, false)
-            if (locked.contains(tp)) throw CyclicReference(tp.symbol)
+            if (locked.contains(tp) || tp.symbol.infoOrCompleter == NoCompleter)
+              throw CyclicReference(tp.symbol)
             locked += tp
             try checkInfo(tp.info)
             finally locked -= tp


### PR DESCRIPTION
This relieves Tasty producers from having to insert LazyRefs
themselves. Fixes #2943.