### PR TITLE
Fix #2949: Change order of elaboration

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -909,9 +909,9 @@ class Namer { typer: Typer =>
       // the parent types are elaborated.
       index(constr)
       annotate(constr :: params)
-      symbolOfTree(constr).ensureCompleted()
 
       indexAndAnnotate(rest)(inClassContext(selfInfo))
+      symbolOfTree(constr).ensureCompleted()
 
       val parentTypes = ensureFirstIsClass(parents.map(checkedParentType(_)))
       val parentRefs = ctx.normalizeToClassRefs(parentTypes, cls, decls)

--- a/tests/pos/i2949.scala
+++ b/tests/pos/i2949.scala
@@ -1,0 +1,3 @@
+class Foo(a: Foo#A) {
+  type A = Int
+}


### PR DESCRIPTION
Swap the order in which the constructor or a class is elaborated
relative to indexing the class contents. The change indexes first,
which fixes #2949.