### PR TITLE
Fix #2948: Use symbol's info when mapping inherited denotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -362,13 +362,11 @@ trait ConstraintHandling {
       def pruneLambdaParams(tp: Type) =
         if (comparedTypeLambdas.nonEmpty) {
           val approx = new ApproximatingTypeMap {
+            if (fromBelow) variance = -1
             def apply(t: Type): Type = t match {
               case t @ TypeParamRef(tl: TypeLambda, n) if comparedTypeLambdas contains tl =>
-                val effectiveVariance = if (fromBelow) -variance else variance
                 val bounds = tl.paramInfos(n)
-                if (effectiveVariance > 0) bounds.lo
-                else if (effectiveVariance < 0) bounds.hi
-                else NoType
+                range(bounds.lo, bounds.hi)
               case _ =>
                 mapOver(t)
             }

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -657,8 +657,6 @@ class Definitions {
   def UncheckedStableAnnot(implicit ctx: Context) = UncheckedStableAnnotType.symbol.asClass
   lazy val UncheckedVarianceAnnotType = ctx.requiredClassRef("scala.annotation.unchecked.uncheckedVariance")
   def UncheckedVarianceAnnot(implicit ctx: Context) = UncheckedVarianceAnnotType.symbol.asClass
-  lazy val UnsafeNonvariantAnnotType = ctx.requiredClassRef("scala.annotation.internal.UnsafeNonvariant")
-  def UnsafeNonvariantAnnot(implicit ctx: Context) = UnsafeNonvariantAnnotType.symbol.asClass
   lazy val VolatileAnnotType = ctx.requiredClassRef("scala.volatile")
   def VolatileAnnot(implicit ctx: Context) = VolatileAnnotType.symbol.asClass
   lazy val FieldMetaAnnotType = ctx.requiredClassRef("scala.annotation.meta.field")

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1005,7 +1005,7 @@ object Denotations {
         case _ => if (symbol.exists) symbol.owner else NoSymbol
       }
       if (!owner.membersNeedAsSeenFrom(pre)) this
-      else derivedSingleDenotation(symbol, info.asSeenFrom(pre, owner))
+      else derivedSingleDenotation(symbol, symbol.info.asSeenFrom(pre, owner))
     }
 
     private def overlaps(fs: FlagSet)(implicit ctx: Context): Boolean = this match {

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1537,22 +1537,22 @@ object SymDenotations {
      *  have existing symbols.
      *  @param inherited  The method is called on a parent class from computeNPMembersNamed
      */
-    final def nonPrivateMembersNamed(name: Name, inherited: Boolean = false)(implicit ctx: Context): PreDenotation = {
+    final def nonPrivateMembersNamed(name: Name)(implicit ctx: Context): PreDenotation = {
       Stats.record("nonPrivateMembersNamed")
       if (Config.cacheMembersNamed) {
         var denots: PreDenotation = memberCache lookup name
         if (denots == null) {
-          denots = computeNPMembersNamed(name, inherited)
+          denots = computeNPMembersNamed(name)
           memberCache.enter(name, denots)
         } else if (Config.checkCacheMembersNamed) {
-          val denots1 = computeNPMembersNamed(name, inherited)
+          val denots1 = computeNPMembersNamed(name)
           assert(denots.exists == denots1.exists, s"cache inconsistency: cached: $denots, computed $denots1, name = $name, owner = $this")
         }
         denots
-      } else computeNPMembersNamed(name, inherited)
+      } else computeNPMembersNamed(name)
     }
 
-    private[core] def computeNPMembersNamed(name: Name, inherited: Boolean)(implicit ctx: Context): PreDenotation = /*>|>*/ Stats.track("computeNPMembersNamed") /*<|<*/ {
+    private[core] def computeNPMembersNamed(name: Name)(implicit ctx: Context): PreDenotation = /*>|>*/ Stats.track("computeNPMembersNamed") /*<|<*/ {
       Stats.record("computeNPMembersNamed after fingerprint")
       ensureCompleted()
       val ownDenots = info.decls.denotsNamed(name, selectNonPrivate)
@@ -1564,7 +1564,7 @@ object SymDenotations {
           p.symbol.denot match {
             case parentd: ClassDenotation =>
               denots1 union
-                parentd.nonPrivateMembersNamed(name, inherited = true)
+                parentd.nonPrivateMembersNamed(name)
                 .mapInherited(ownDenots, denots1, thisType)
             case _ =>
               denots1
@@ -1768,19 +1768,19 @@ object SymDenotations {
      *  object that hides a class or object in the scala package of the same name, because
      *  the behavior would then be unintuitive for such members.
      */
-    override def computeNPMembersNamed(name: Name, inherited: Boolean)(implicit ctx: Context): PreDenotation =
+    override def computeNPMembersNamed(name: Name)(implicit ctx: Context): PreDenotation =
       packageObj.moduleClass.denot match {
         case pcls: ClassDenotation if !pcls.isCompleting =>
           if (symbol eq defn.ScalaPackageClass) {
-            val denots = super.computeNPMembersNamed(name, inherited)
-            if (denots.exists) denots else pcls.computeNPMembersNamed(name, inherited)
+            val denots = super.computeNPMembersNamed(name)
+            if (denots.exists) denots else pcls.computeNPMembersNamed(name)
           }
           else {
-            val denots = pcls.computeNPMembersNamed(name, inherited)
-            if (denots.exists) denots else super.computeNPMembersNamed(name, inherited)
+            val denots = pcls.computeNPMembersNamed(name)
+            if (denots.exists) denots else super.computeNPMembersNamed(name)
           }
         case _ =>
-          super.computeNPMembersNamed(name, inherited)
+          super.computeNPMembersNamed(name)
       }
 
     /** The union of the member names of the package and the package object */

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -132,18 +132,9 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
 
   /** Approximate a type `tp` with a type that does not contain skolem types. */
   object deskolemize extends ApproximatingTypeMap {
-    private var seen: Set[SkolemType] = Set()
     def apply(tp: Type) = tp match {
-      case tp: SkolemType =>
-        if (seen contains tp) NoType
-        else {
-          val saved = seen
-          seen += tp
-          try approx(hi = tp.info)
-          finally seen = saved
-        }
-      case _ =>
-        mapOver(tp)
+      case tp: SkolemType => range(hi = apply(tp.info))
+      case _ => mapOver(tp)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -132,9 +132,11 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
 
   /** Approximate a type `tp` with a type that does not contain skolem types. */
   object deskolemize extends ApproximatingTypeMap {
-    def apply(tp: Type) = tp match {
-      case tp: SkolemType => range(hi = apply(tp.info))
-      case _ => mapOver(tp)
+    def apply(tp: Type) = /*ctx.traceIndented(i"deskolemize($tp) at $variance", show = true)*/ {
+      tp match {
+        case tp: SkolemType => range(hi = atVariance(1)(apply(tp.info)))
+        case _ => mapOver(tp)
+      }
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -19,122 +19,81 @@ import ast.tpd._
 trait TypeOps { this: Context => // TODO: Make standalone object.
 
   /** The type `tp` as seen from prefix `pre` and owner `cls`. See the spec
-   *  for what this means. Called very often, so the code is optimized heavily.
-   *
-   *  A tricky aspect is what to do with unstable prefixes. E.g. say we have a class
-   *
-   *    class C { type T; def f(x: T): T }
-   *
-   *  and an expression `e` of type `C`. Then computing the type of `e.f` leads
-   *  to the query asSeenFrom(`C`, `(x: T)T`). What should its result be? The
-   *  naive answer `(x: C#T)C#T` is incorrect given that we treat `C#T` as the existential
-   *  `exists(c: C)c.T`. What we need to do instead is to skolemize the existential. So
-   *  the answer would be `(x: c.T)c.T` for some (unknown) value `c` of type `C`.
-   *  `c.T` is expressed in the compiler as a skolem type `Skolem(C)`.
-   *
-   *  Now, skolemization is messy and expensive, so we want to do it only if we absolutely
-   *  must. Also, skolemizing immediately would mean that asSeenFrom was no longer
-   *  idempotent - each call would return a type with a different skolem.
-   *  Instead we produce an annotated type that marks the prefix as unsafe:
-   *
-   *     (x: (C @ UnsafeNonvariant)#T)C#T
-   *
-   *  We also set a global state flag `unsafeNonvariant` to the current run.
-   *  When typing a Select node, typer will check that flag, and if it
-   *  points to the current run will scan the result type of the select for
-   *  @UnsafeNonvariant annotations. If it finds any, it will introduce a skolem
-   *  constant for the prefix and try again.
-   *
-   *  The scheme is efficient in particular because we expect that unsafe situations are rare;
-   *  most compiles would contain none, so no scanning would be necessary.
+   *  for what this means.
    */
   final def asSeenFrom(tp: Type, pre: Type, cls: Symbol): Type =
-    asSeenFrom(tp, pre, cls, null)
+    new AsSeenFromMap(pre, cls).apply(tp)
 
-  /** Helper method, taking a map argument which is instantiated only for more
-   *  complicated cases of asSeenFrom.
-   */
-  private def asSeenFrom(tp: Type, pre: Type, cls: Symbol, theMap: AsSeenFromMap): Type = {
+  /** The TypeMap handling the asSeenFrom */
+  class AsSeenFromMap(pre: Type, cls: Symbol) extends ApproximatingTypeMap {
 
-    /** Map a `C.this` type to the right prefix. If the prefix is unstable and
-     *  the `C.this` occurs in nonvariant or contravariant position, mark the map
-     *  to be unstable.
-     */
-    def toPrefix(pre: Type, cls: Symbol, thiscls: ClassSymbol): Type = /*>|>*/ ctx.conditionalTraceIndented(TypeOps.track, s"toPrefix($pre, $cls, $thiscls)") /*<|<*/ {
-      if ((pre eq NoType) || (pre eq NoPrefix) || (cls is PackageClass))
-        tp
-      else pre match {
-        case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
-        case _ =>
-          if (thiscls.derivesFrom(cls) && pre.baseTypeRef(thiscls).exists) {
-            if (theMap != null && theMap.currentVariance <= 0 && !isLegalPrefix(pre)) {
-              ctx.base.unsafeNonvariant = ctx.runId
-              pre match {
-                case AnnotatedType(_, ann) if ann.symbol == defn.UnsafeNonvariantAnnot => pre
-                case _ => AnnotatedType(pre, Annotation(defn.UnsafeNonvariantAnnot, Nil))
-              }
-            }
-            else pre
-          }
-          else if ((pre.termSymbol is Package) && !(thiscls is Package))
-            toPrefix(pre.select(nme.PACKAGE), cls, thiscls)
-          else
-            toPrefix(pre.baseTypeRef(cls).normalizedPrefix, cls.owner, thiscls)
-      }
-    }
+    def apply(tp: Type): Type = {
 
-    /*>|>*/ ctx.conditionalTraceIndented(TypeOps.track, s"asSeen ${tp.show} from (${pre.show}, ${cls.show})", show = true) /*<|<*/ { // !!! DEBUG
-      tp match {
-        case tp: NamedType =>
-          val sym = tp.symbol
-          if (sym.isStatic) tp
-          else {
-            val pre1 = asSeenFrom(tp.prefix, pre, cls, theMap)
-            if (pre1.isUnsafeNonvariant) {
-              val safeCtx = ctx.withProperty(TypeOps.findMemberLimit, Some(()))
-              pre1.member(tp.name)(safeCtx).info match {
-                case TypeAlias(alias) =>
-                  // try to follow aliases of this will avoid skolemization.
-                  return alias
-                case _ =>
-              }
-            }
-            tp.derivedSelect(pre1)
-          }
-        case tp: ThisType =>
-          toPrefix(pre, cls, tp.cls)
-        case _: BoundType | NoPrefix =>
+      /** Map a `C.this` type to the right prefix. If the prefix is unstable and
+      *  the `C.this` occurs in nonvariant or contravariant position, mark the map
+      *  to be unstable.
+      */
+      def toPrefix(pre: Type, cls: Symbol, thiscls: ClassSymbol): Type = /*>|>*/ ctx.conditionalTraceIndented(TypeOps.track, s"toPrefix($pre, $cls, $thiscls)") /*<|<*/ {
+        if ((pre eq NoType) || (pre eq NoPrefix) || (cls is PackageClass))
           tp
-        case tp: RefinedType =>
-          tp.derivedRefinedType(
-            asSeenFrom(tp.parent, pre, cls, theMap),
-            tp.refinedName,
-            asSeenFrom(tp.refinedInfo, pre, cls, theMap))
-        case tp: TypeAlias if tp.variance == 1 => // if variance != 1, need to do the variance calculation
-          tp.derivedTypeAlias(asSeenFrom(tp.alias, pre, cls, theMap))
-        case _ =>
-          (if (theMap != null) theMap else new AsSeenFromMap(pre, cls))
-            .mapOver(tp)
+        else pre match {
+          case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
+          case _ =>
+            if (thiscls.derivesFrom(cls) && pre.baseTypeRef(thiscls).exists)
+              if (variance <= 0 && !isLegalPrefix(pre)) Range(pre.bottomType, pre)
+              else pre
+            else if ((pre.termSymbol is Package) && !(thiscls is Package))
+              toPrefix(pre.select(nme.PACKAGE), cls, thiscls)
+            else
+              toPrefix(pre.baseTypeRef(cls).normalizedPrefix, cls.owner, thiscls)
+        }
+      }
+
+      /*>|>*/ ctx.conditionalTraceIndented(TypeOps.track, s"asSeen ${tp.show} from (${pre.show}, ${cls.show})", show = true) /*<|<*/ { // !!! DEBUG
+        tp match {
+          case tp: NamedType =>
+            val sym = tp.symbol
+            if (sym.isStatic) tp
+            else {
+              val pre1 = apply(tp.prefix)
+              if (pre1.isUnsafeNonvariant) {
+                val safeCtx = ctx.withProperty(TypeOps.findMemberLimit, Some(()))
+                pre1.member(tp.name)(safeCtx).info match {
+                  case TypeAlias(alias) =>
+                    // try to follow aliases of this will avoid skolemization.
+                    return alias
+                  case _ =>
+                }
+              }
+              derivedSelect(tp, pre1)
+            }
+          case tp: ThisType =>
+            toPrefix(pre, cls, tp.cls)
+          case _: BoundType | NoPrefix =>
+            tp
+          case tp: RefinedType =>
+            derivedRefinedType(tp, apply(tp.parent), apply(tp.refinedInfo))
+          case tp: TypeAlias if tp.variance == 1 => // if variance != 1, need to do the variance calculation
+            derivedTypeAlias(tp, apply(tp.alias))
+          case _ =>
+            mapOver(tp)
+        }
       }
     }
+
+    override def reapply(tp: Type) =
+      // derives infos have already been subjected to asSeenFrom, hence to need to apply the map again.
+      tp
   }
 
   private def isLegalPrefix(pre: Type)(implicit ctx: Context) =
     pre.isStable || !ctx.phase.isTyper
 
-  /** The TypeMap handling the asSeenFrom in more complicated cases */
-  class AsSeenFromMap(pre: Type, cls: Symbol) extends TypeMap {
-    def apply(tp: Type) = asSeenFrom(tp, pre, cls, this)
-
-    /** A method to export the current variance of the map */
-    def currentVariance = variance
-  }
-
   /** Approximate a type `tp` with a type that does not contain skolem types. */
   object deskolemize extends ApproximatingTypeMap {
     def apply(tp: Type) = /*ctx.traceIndented(i"deskolemize($tp) at $variance", show = true)*/ {
       tp match {
-        case tp: SkolemType => range(hi = atVariance(1)(apply(tp.info)))
+        case tp: SkolemType => range(tp.bottomType, atVariance(1)(apply(tp.info)))
         case _ => mapOver(tp)
       }
     }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -40,7 +40,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
           case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
           case _ =>
             if (thiscls.derivesFrom(cls) && pre.baseTypeRef(thiscls).exists)
-              if (variance <= 0 && !isLegalPrefix(pre)) Range(pre.bottomType, pre)
+              if (variance <= 0 && !isLegalPrefix(pre)) range(pre.bottomType, pre)
               else pre
             else if ((pre.termSymbol is Package) && !(thiscls is Package))
               toPrefix(pre.select(nme.PACKAGE), cls, thiscls)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -136,6 +136,12 @@ object Types {
       case _ => false
     }
 
+    /** Is this type exactly Nothing (no vars, aliases, refinements etc allowed)? */
+    def isBottomType(implicit ctx: Context): Boolean = this match {
+      case tp: TypeRef => tp.symbol eq defn.NothingClass
+      case _ => false
+    }
+
     /** Is this type a (neither aliased nor applied) reference to class `sym`? */
     def isDirectRef(sym: Symbol)(implicit ctx: Context): Boolean = stripTypeVar match {
       case this1: TypeRef =>
@@ -275,7 +281,10 @@ object Types {
     }
 
     /** Is this an alias TypeBounds? */
-    def isAlias: Boolean = this.isInstanceOf[TypeAlias]
+    final def isAlias: Boolean = this.isInstanceOf[TypeAlias]
+
+    /** Is this a non-alias TypeBounds? */
+    final def isRealTypeBounds = this.isInstanceOf[TypeBounds] && !isAlias
 
 // ----- Higher-order combinators -----------------------------------
 
@@ -1220,6 +1229,18 @@ object Types {
       case _ => TypeAlias(this)
     }
 
+    /** The lower bound of a TypeBounds type, the type itself otherwise */
+    def loBound = this match {
+      case tp: TypeBounds => tp.lo
+      case _ => this
+    }
+
+    /** The upper bound of a TypeBounds type, the type itself otherwise */
+    def hiBound = this match {
+      case tp: TypeBounds => tp.hi
+      case _ => this
+    }
+
     /** The type parameter with given `name`. This tries first `decls`
      *  in order not to provoke a cycle by forcing the info. If that yields
      *  no symbol it tries `member` as an alternative.
@@ -1766,6 +1787,7 @@ object Types {
      */
     def derivedSelect(prefix: Type)(implicit ctx: Context): Type =
       if (prefix eq this.prefix) this
+      else if (prefix.isBottomType) prefix
       else if (isType) {
         val res = prefix.lookupRefined(name)
         if (res.exists) res
@@ -3722,6 +3744,18 @@ object Types {
               // of `p`'s upper bound.
             val prefix1 = this(tp.prefix)
             variance = saved
+            /* was:
+            val prefix1 = tp.info match {
+              case info: TypeBounds if !info.isAlias =>
+                // prefix of an abstract type selection is non-variant, since a path
+                // cannot be legally widened to its underlying type, or any supertype.
+                val saved = variance
+                variance = 0
+                try this(tp.prefix) finally variance = saved
+              case _ =>
+                this(tp.prefix)
+            }
+			*/
             derivedSelect(tp, prefix1)
           }
         case _: ThisType
@@ -3851,63 +3885,139 @@ object Types {
     def apply(tp: Type) = tp
   }
 
-  /** A type map that approximates NoTypes by upper or lower known bounds depending on
+  case class Range(lo: Type, hi: Type) extends UncachedGroundType {
+    assert(!lo.isInstanceOf[Range])
+    assert(!hi.isInstanceOf[Range])
+  }
+
+  /** A type map that approximates TypeBounds types depending on
    *  variance.
    *
    *  if variance > 0 : approximate by upper bound
    *     variance < 0 : approximate by lower bound
-   *     variance = 0 : propagate NoType to next outer level
+   *     variance = 0 : propagate bounds to next outer level
    */
   abstract class ApproximatingTypeMap(implicit ctx: Context) extends TypeMap { thisMap =>
-    def approx(lo: Type = defn.NothingType, hi: Type = defn.AnyType) =
-      if (variance == 0) NoType
-      else apply(if (variance < 0) lo else hi)
+
+    def range(lo: Type = defn.NothingType, hi: Type = defn.AnyType) =
+      if (variance > 0) hi
+      else if (variance < 0) lo
+      else Range(loBound(lo), hiBound(hi))
+
+    def isRange(tp: Type) = tp.isInstanceOf[Range]
+
+    def loBound(tp: Type) = tp match {
+      case tp: Range => tp.lo
+      case _ => tp
+    }
+
+    /** The upper bound of a TypeBounds type, the type itself otherwise */
+    def hiBound(tp: Type) = tp match {
+      case tp: Range => tp.hi
+      case _ => tp
+    }
+
+    def rangeToBounds(tp: Type) = tp match {
+      case Range(lo, hi) => TypeBounds(lo, hi)
+      case _ => tp
+    }
 
     override protected def derivedSelect(tp: NamedType, pre: Type) =
       if (pre eq tp.prefix) tp
-      else tp.info match {
-        case TypeAlias(alias) => apply(alias) // try to heal by following aliases
+      else pre match {
+        case Range(preLo, preHi) =>
+          tp.info match {
+            case TypeAlias(alias) => apply(alias)
+            case TypeBounds(lo, hi) => range(apply(lo), apply(hi))
+            case _ => range(tp.derivedSelect(preLo), tp.derivedSelect(preHi))
+          }
+        case _ => tp.derivedSelect(pre)
+      }
+
+    override protected def derivedRefinedType(tp: RefinedType, parent: Type, info: Type) =
+      parent match {
+        case Range(parentLo, parentHi) =>
+          range(derivedRefinedType(tp, parentLo, info), derivedRefinedType(tp, parentHi, info))
         case _ =>
-          if (pre.exists && !pre.isRef(defn.NothingClass) && variance > 0) tp.derivedSelect(pre)
-          else tp.info match {
-            case TypeBounds(lo, hi) => approx(lo, hi)
-            case _ => approx()
+          if (parent.isBottomType) parent
+          else info match {
+            case Range(infoLo, infoHi) if tp.refinedName.isTermName || variance <= 0 =>
+              range(derivedRefinedType(tp, parent, infoLo), derivedRefinedType(tp, parent, infoHi))
+            case _ =>
+              tp.derivedRefinedType(parent, tp.refinedName, rangeToBounds(info))
           }
       }
-    override protected def derivedRefinedType(tp: RefinedType, parent: Type, info: Type) =
-      if (parent.exists && info.exists) tp.derivedRefinedType(parent, tp.refinedName, info)
-      else approx(hi = parent)
     override protected def derivedRecType(tp: RecType, parent: Type) =
-      if (parent.exists) tp.rebind(parent)
-      else approx()
+      parent match {
+        case Range(lo, hi) => range(tp.rebind(lo), tp.rebind(hi))
+        case _ => tp.rebind(parent)
+      }
     override protected def derivedTypeAlias(tp: TypeAlias, alias: Type) =
-      if (alias.exists) tp.derivedTypeAlias(alias)
-      else approx(NoType, TypeBounds.empty)
+      alias match {
+        case Range(lo, hi) =>
+          if (variance > 0) TypeBounds(lo, hi)
+          else range(TypeAlias(lo), TypeAlias(hi))
+        case _ => tp.derivedTypeAlias(alias)
+      }
     override protected def derivedTypeBounds(tp: TypeBounds, lo: Type, hi: Type) =
-      if (lo.exists && hi.exists) tp.derivedTypeBounds(lo, hi)
-      else approx(NoType,
-        if (lo.exists) TypeBounds.lower(lo)
-        else if (hi.exists) TypeBounds.upper(hi)
-        else TypeBounds.empty)
+      if (isRange(lo) || isRange(hi))
+        if (variance > 0) TypeBounds(loBound(lo), hiBound(hi))
+        else range(TypeBounds(hiBound(lo), loBound(hi)), TypeBounds(loBound(lo), hiBound(hi)))
+      else tp.derivedTypeBounds(lo, hi)
     override protected def derivedSuperType(tp: SuperType, thistp: Type, supertp: Type) =
-      if (thistp.exists && supertp.exists) tp.derivedSuperType(thistp, supertp)
-      else NoType
+      if (isRange(thistp) || isRange(supertp)) range()
+      else tp.derivedSuperType(thistp, supertp)
+
     override protected def derivedAppliedType(tp: HKApply, tycon: Type, args: List[Type]): Type =
-      if (tycon.exists && args.forall(_.exists)) tp.derivedAppliedType(tycon, args)
-      else approx() // This is rather coarse, but to do better is a bit complicated
+      tycon match {
+        case Range(tyconLo, tyconHi) =>
+          range(derivedAppliedType(tp, tyconLo, args), derivedAppliedType(tp, tyconHi, args))
+        case _ =>
+          if (args.exists(isRange))
+            if (variance > 0) tp.derivedAppliedType(tycon, args.map(rangeToBounds))
+            else {
+              val loBuf, hiBuf = new mutable.ListBuffer[Type]
+              def distributeArgs(args: List[Type], tparams: List[ParamInfo]): Boolean = args match {
+                case Range(lo, hi) :: args1 =>
+                  val v = tparams.head.paramVariance
+                  if (v == 0) false
+                  else if (v > 0) { loBuf += lo; hiBuf += hi }
+                  else { loBuf += hi; hiBuf += lo }
+                  distributeArgs(args1, tparams.tail)
+                case arg :: args1 =>
+                  loBuf += arg; hiBuf += arg
+                  distributeArgs(args1, tparams.tail)
+                case nil =>
+                  true
+              }
+              if (distributeArgs(args, tp.typeParams))
+                range(tp.derivedAppliedType(tycon, loBuf.toList),
+                      tp.derivedAppliedType(tycon, hiBuf.toList))
+              else range()
+            }
+          else tp.derivedAppliedType(tycon, args)
+      }
+
     override protected def derivedAndOrType(tp: AndOrType, tp1: Type, tp2: Type) =
-      if (tp1.exists && tp2.exists) tp.derivedAndOrType(tp1, tp2)
-      else if (tp.isAnd) approx(hi = tp1 & tp2)  // if one of tp1d, tp2d exists, it is the result of tp1d & tp2d
-      else approx(lo = tp1 & tp2)
+      if (tp1.isInstanceOf[Range] || tp2.isInstanceOf[Range])
+        if (tp.isAnd) range(loBound(tp1) & loBound(tp2), hiBound(tp1) & hiBound(tp2))
+        else range(loBound(tp1) | loBound(tp2), hiBound(tp1) | hiBound(tp2))
+      else tp.derivedAndOrType(tp1, tp2)
     override protected def derivedAnnotatedType(tp: AnnotatedType, underlying: Type, annot: Annotation) =
-      if (underlying.exists) tp.derivedAnnotatedType(underlying, annot)
-      else NoType
-    override protected def derivedWildcardType(tp: WildcardType, bounds: Type) =
-      if (bounds.exists) tp.derivedWildcardType(bounds)
-      else WildcardType
-    override protected def derivedClassInfo(tp: ClassInfo, pre: Type): Type =
-      if (pre.exists) tp.derivedClassInfo(pre)
-      else NoType
+      underlying match {
+        case Range(lo, hi) =>
+          range(tp.derivedAnnotatedType(lo, annot), tp.derivedAnnotatedType(hi, annot))
+        case _ =>
+          if (underlying.isBottomType) underlying
+          else tp.derivedAnnotatedType(underlying, annot)
+      }
+    override protected def derivedWildcardType(tp: WildcardType, bounds: Type) = {
+      tp.derivedWildcardType(rangeToBounds(bounds))
+    }
+    override protected def derivedClassInfo(tp: ClassInfo, pre: Type): Type = {
+      assert(!pre.isInstanceOf[Range])
+      tp.derivedClassInfo(pre)
+    }
   }
 
   // ----- TypeAccumulators ----------------------------------------------------

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3924,7 +3924,8 @@ object Types {
       }
 
     override protected def derivedRefinedType(tp: RefinedType, parent: Type, info: Type) =
-      parent match {
+      if ((parent eq tp.parent) && (info eq tp.refinedInfo)) tp
+      else parent match {
         case Range(parentLo, parentHi) =>
           range(derivedRefinedType(tp, parentLo, info), derivedRefinedType(tp, parentHi, info))
         case _ =>
@@ -3948,13 +3949,15 @@ object Types {
         }
 
     override protected def derivedRecType(tp: RecType, parent: Type) =
-      parent match {
+      if (parent eq tp.parent) tp
+      else parent match {
         case Range(lo, hi) => range(tp.rebind(lo), tp.rebind(hi))
         case _ => tp.rebind(parent)
       }
 
     override protected def derivedTypeAlias(tp: TypeAlias, alias: Type) =
-      alias match {
+      if (alias eq tp.alias) tp
+      else alias match {
         case Range(lo, hi) =>
           if (variance > 0) TypeBounds(lo, hi)
           else range(TypeAlias(lo), TypeAlias(hi))
@@ -3962,7 +3965,8 @@ object Types {
       }
 
     override protected def derivedTypeBounds(tp: TypeBounds, lo: Type, hi: Type) =
-      if (isRange(lo) || isRange(hi))
+      if ((lo eq tp.lo) && (hi eq tp.hi)) tp
+      else if (isRange(lo) || isRange(hi))
         if (variance > 0) TypeBounds(lower(lo), upper(hi))
         else range(TypeBounds(upper(lo), lower(hi)), TypeBounds(lower(lo), upper(hi)))
       else tp.derivedTypeBounds(lo, hi)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3915,7 +3915,9 @@ object Types {
               // hence we can replace with U under all variances
               reapply(alias)
             case TypeBounds(lo, hi) =>
-              range(atVariance(-1)(reapply(lo)), atVariance(1)(reapply(hi)))
+              // If H#T = _ >: S <: U, then for any x in L..H, S <: x.T <: U,
+              // hence we can replace with S..U under all variances
+              range(atVariance(-variance)(reapply(lo)), reapply(hi))
             case info: SingletonType =>
               // if H#x: y.type, then for any x in L..H, x.type =:= y.type,
               // hence we can replace with y.type under all variances

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -255,16 +255,6 @@ object Types {
     def isRepeatedParam(implicit ctx: Context): Boolean =
       typeSymbol eq defn.RepeatedParamClass
 
-    /** Does this type carry an UnsafeNonvariant annotation? */
-    final def isUnsafeNonvariant(implicit ctx: Context): Boolean = this match {
-      case AnnotatedType(_, annot) => annot.symbol == defn.UnsafeNonvariantAnnot
-      case _ => false
-    }
-
-    /** Does this type have an UnsafeNonvariant annotation on one of its parts? */
-    final def hasUnsafeNonvariant(implicit ctx: Context): Boolean =
-      new HasUnsafeNonAccumulator().apply(false, this)
-
     /** Is this the type of a method that has a repeated parameter type as
      *  last parameter type?
      */
@@ -4173,10 +4163,6 @@ object Types {
 
   class ForeachAccumulator(p: Type => Unit, override val stopAtStatic: Boolean)(implicit ctx: Context) extends TypeAccumulator[Unit] {
     def apply(x: Unit, tp: Type): Unit = foldOver(p(tp), tp)
-  }
-
-  class HasUnsafeNonAccumulator(implicit ctx: Context) extends TypeAccumulator[Boolean] {
-    def apply(x: Boolean, tp: Type) = x || tp.isUnsafeNonvariant || foldOver(x, tp)
   }
 
   class NamedPartsAccumulator(p: NamedType => Boolean, excludeLowerBounds: Boolean = false)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -68,6 +68,15 @@ class PlainPrinter(_ctx: Context) extends Printer {
       }
     else tp
 
+  private def sameBound(lo: Type, hi: Type): Boolean =
+    try lo =:= hi
+    catch { case ex: Throwable => false }
+
+  private def homogenizeArg(tp: Type) = tp match {
+    case TypeBounds(lo, hi) if sameBound(lo, hi) => homogenize(hi)
+    case _ => tp
+  }
+
   private def selfRecName(n: Int) = s"z$n"
 
   /** Render elements alternating with `sep` string */
@@ -113,9 +122,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected def toTextRefinement(rt: RefinedType) =
     (refinementNameString(rt) ~ toTextRHS(rt.refinedInfo)).close
 
-  protected def argText(arg: Type): Text = arg match {
+  protected def argText(arg: Type): Text = homogenizeArg(arg) match {
     case arg: TypeBounds => "_" ~ toTextGlobal(arg)
-    case _ => toTextGlobal(arg)
+    case arg => toTextGlobal(arg)
   }
 
   /** The longest sequence of refinement types, starting at given type

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -64,9 +64,19 @@ trait TypeAssigner {
   }
 
   /** An upper approximation of the given type `tp` that does not refer to any symbol in `symsToAvoid`.
+   *  We need to approximate with ranges:
+   *
+   *    term references to symbols in `symsToAvoid`,
+   *    term references that have a widened type of which some part refers
+   *    to a symbol in `symsToAvoid`,
+   *    type references to symbols in `symsToAvoid`,
+   *    this types of classes in `symsToAvoid`.
+   *
+   *  Type variables that would be interpolated to a type that
+   *  needs to be widened are replaced by the widened interpolation instance.
    */
   def avoid(tp: Type, symsToAvoid: => List[Symbol])(implicit ctx: Context): Type = {
-    val wmap = new ApproximatingTypeMap {
+    val widenMap = new ApproximatingTypeMap {
       lazy val forbidden = symsToAvoid.toSet
       def toAvoid(sym: Symbol) = !sym.isStatic && forbidden.contains(sym)
       def partsToAvoid = new NamedPartsAccumulator(tp => toAvoid(tp.symbol))
@@ -92,23 +102,18 @@ trait TypeAssigner {
         case tp: ThisType if toAvoid(tp.cls) =>
           range(tp.bottomType, apply(classBound(tp.cls.classInfo)))
         case tp: TypeVar if ctx.typerState.constraint.contains(tp) =>
-          val lo = ctx.typeComparer.instanceType(tp.origin, fromBelow = true)
+          val lo = ctx.typeComparer.instanceType(tp.origin, fromBelow = variance >= 0)
           val lo1 = apply(lo)
-          //println(i"INST $tp --> $lo --> $lo1")
           if (lo1 ne lo) lo1 else tp
-        case tp: TermRef if false =>
-          val saved = variance
-          variance = 0
-          val prefix1 = this(tp.prefix)
-          variance = saved
-          if (isRange(prefix1)) range(tp.bottomType, apply(tp.info.widenExpr))
-          else derivedSelect(tp, prefix1)
         case _ =>
           mapOver(tp)
       }
 
-      /** Needs to handle the case where the prefix type does not have a member
-       *  named `tp.name` anymmore.
+      /** Two deviations from standard derivedSelect:
+       *   1. The teh approximation result is a singleton references C#x.type, we
+       *      replace by the widened type, which is usually more natural.
+       *   2. We need to handle the case where the prefix type does not have a member
+       *      named `tp.name` anymmore.
        */
       override def derivedSelect(tp: NamedType, pre: Type) =
         if (pre eq tp.prefix) tp
@@ -117,87 +122,8 @@ trait TypeAssigner {
         else if (upper(pre).member(tp.name).exists) super.derivedSelect(tp, pre)
         else range(tp.bottomType, tp.topType)
     }
-    val widenMap = new TypeMap {
-      lazy val forbidden = symsToAvoid.toSet
-      def toAvoid(tp: Type): Boolean =
-        // TODO: measure the cost of using `existsPart`, and if necessary replace it
-        // by a `TypeAccumulator` where we have set `stopAtStatic = true`.
-        tp existsPart {
-          case tp: TermRef => forbidden.contains(tp.symbol) || toAvoid(tp.underlying)
-          case tp: TypeRef => forbidden.contains(tp.symbol)
-          case tp: ThisType => forbidden.contains(tp.cls)
-          case _ => false
-        }
-      def apply(tp: Type): Type = tp match {
-        case tp: TermRef
-        if toAvoid(tp) && (variance > 0 || tp.info.widenExpr <:< tp) =>
-          // Can happen if `x: y.type`, then `x.type =:= y.type`, hence we can widen `x.type`
-          // to y.type in all contexts, not just covariant ones.
-          apply(tp.info.widenExpr)
-        case tp: TypeRef if toAvoid(tp) =>
-          tp.info match {
-            case TypeAlias(ref) =>
-              apply(ref)
-            case info: ClassInfo if variance > 0 =>
-              if (!(forbidden contains tp.symbol)) {
-                val prefix = apply(tp.prefix)
-                val tp1 = tp.derivedSelect(prefix)
-                if (tp1.typeSymbol.exists)
-                  return tp1
-              }
-              val parentType = info.parentsWithArgs.reduceLeft(ctx.typeComparer.andType(_, _))
-              def addRefinement(parent: Type, decl: Symbol) = {
-                val inherited =
-                  parentType.findMember(decl.name, info.cls.thisType, Private)
-                    .suchThat(decl.matches(_))
-                val inheritedInfo = inherited.info
-                if (inheritedInfo.exists && decl.info <:< inheritedInfo && !(inheritedInfo <:< decl.info)) {
-                  val r = RefinedType(parent, decl.name, decl.info)
-                  typr.println(i"add ref $parent $decl --> " + r)
-                  r
-                }
-                else
-                  parent
-              }
-              val refinableDecls = info.decls.filter(
-                sym => !(sym.is(TypeParamAccessor | Private) || sym.isConstructor))
-              val fullType = (parentType /: refinableDecls)(addRefinement)
-              apply(fullType)
-            case TypeBounds(lo, hi) if variance > 0 =>
-              apply(hi)
-            case _ =>
-              mapOver(tp)
-          }
-        case tp @ HKApply(tycon, args) if toAvoid(tycon) =>
-          apply(tp.superType)
-        case tp @ AppliedType(tycon, args) if toAvoid(tycon) =>
-          val base = apply(tycon)
-          var args = tp.baseArgInfos(base.typeSymbol)
-          if (base.typeParams.length != args.length)
-            args = base.typeParams.map(_.paramInfo)
-          apply(base.appliedTo(args))
-        case tp @ RefinedType(parent, name, rinfo) if variance > 0 =>
-          val parent1 = apply(tp.parent)
-          val refinedInfo1 = apply(rinfo)
-          if (toAvoid(refinedInfo1)) {
-            typr.println(s"dropping refinement from $tp")
-            if (name.isTypeName) tp.derivedRefinedType(parent1, name, TypeBounds.empty)
-            else parent1
-          } else {
-            tp.derivedRefinedType(parent1, name, refinedInfo1)
-          }
-        case tp: TypeVar if ctx.typerState.constraint.contains(tp) =>
-          val lo = ctx.typerState.constraint.fullLowerBound(tp.origin)
-          val lo1 = avoid(lo, symsToAvoid)
-          if (lo1 ne lo) lo1 else tp
-        case _ =>
-          mapOver(tp)
-      }
-    }
-    //val was = widenMap(tp)
-    val now = wmap(tp)
-    //if (was.show != now.show) println(i"difference for avoid $tp, ${tp.toString}, forbidden = $symsToAvoid%, %, was: $was, now: $now")
-    now
+
+    widenMap(tp)
   }
 
   def avoidingType(expr: Tree, bindings: List[Tree])(implicit ctx: Context): Type =

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1427,7 +1427,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       val impl1 = cpy.Template(impl)(constr1, parents1, self1, body1)
         .withType(dummy.nonMemberTermRef)
       checkVariance(impl1)
-      if (!cls.is(AbstractOrTrait) && !ctx.isAfterTyper) checkRealizableBounds(cls.typeRef, cdef.namePos)
+      if (!cls.is(AbstractOrTrait) && !ctx.isAfterTyper) checkRealizableBounds(cls.thisType, cdef.namePos)
       val cdef1 = assignType(cpy.TypeDef(cdef)(name, impl1), cls)
       if (ctx.phase.isTyper && cdef1.tpe.derivesFrom(defn.DynamicClass) && !ctx.dynamicsEnabled) {
         val isRequired = parents1.exists(_.tpe.isRef(defn.DynamicClass))

--- a/library/src/scala/annotation/internal/UnsafeNonvariant.scala
+++ b/library/src/scala/annotation/internal/UnsafeNonvariant.scala
@@ -1,8 +1,0 @@
-package scala.annotation.internal
-
-import scala.annotation.Annotation
-
-/** This annotation is used as a marker for unsafe
- *  instantiations in asSeenFrom. See TypeOps.asSeenfrom for an explanation.
- */
-class UnsafeNonvariant extends Annotation

--- a/tests/neg/i1662.scala
+++ b/tests/neg/i1662.scala
@@ -2,5 +2,5 @@ class Lift {
   def apply(f: F0) // error
   class F0
   object F0 { implicit def f2f0(String): F0 = ??? } // error
-  (new Lift)("")
+  (new Lift)("") // error after switch to approximating asSeenFrom
 }

--- a/tests/pos/dependent-extractors.scala
+++ b/tests/pos/dependent-extractors.scala
@@ -10,5 +10,5 @@ object Test {
   val y1: Int = y
 
   val z = (c: Any)  match { case X(y) => y }
-  val z1: C#T = z
+  // val z1: C#T = z  // error: z has type Any TODO: find out why
 }

--- a/tests/pos/dependent-extractors.scala
+++ b/tests/pos/dependent-extractors.scala
@@ -10,5 +10,5 @@ object Test {
   val y1: Int = y
 
   val z = (c: Any)  match { case X(y) => y }
-  val z1: C#T = z  // error: z has type Any TODO: find out why
+  val z1: C#T = z
 }

--- a/tests/pos/dependent-extractors.scala
+++ b/tests/pos/dependent-extractors.scala
@@ -10,5 +10,5 @@ object Test {
   val y1: Int = y
 
   val z = (c: Any)  match { case X(y) => y }
-  // val z1: C#T = z  // error: z has type Any TODO: find out why
+  val z1: C#T = z  // error: z has type Any TODO: find out why
 }

--- a/tests/pos/i2948.scala
+++ b/tests/pos/i2948.scala
@@ -1,0 +1,5 @@
+import scala.collection.mutable.ListBuffer
+class Foo {
+  val zipped: ListBuffer[(String, Int)] = null
+  val unzipped:  (ListBuffer[String], ListBuffer[Int]) = zipped.unzip
+}

--- a/tests/pos/t2435.scala
+++ b/tests/pos/t2435.scala
@@ -23,5 +23,6 @@ object Test {
   val a2 = a1.chain("a")
 
   println("\nDoesn't compile:")
-  val a = FNil.chain("a").chain("a").chain("a")
+  val a3 = FNil.chain("a").chain("a").chain("a")
+  val a4: FConstant[_ <: FConstant[_ <: FConstant[FNil.type]]] = a3
 }


### PR DESCRIPTION
The test case shows that it is inadmissible to combine the infos of inherited denotations
into a new denotation. The problem here is that a type parameter CC was instantiated in
an inherited denotation to Traversable, yet the parameter was afterwards instantiated to
ListBuffer. This shows that infos from inherited denotations are useless; instead we have
to go back to the inherited symbol's infos and map them with an asSeenFrom.

This fix also shows that one of the reasons for abandoning #2947 was wrong. We cannot form
denotations from parent denotations in any case, so instantiating early should be fine with
the change in this commit.

Based on #2945