### PR TITLE
Fix #2980: Crash when inlining HK type parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -98,6 +98,9 @@ final class TreeTypeMap(
             case ann => ann
           }
           res
+        case tdef @ LambdaTypeTree(tparams, body) =>
+          val (tmap1, tparams1) = transformDefs(tparams)
+          cpy.LambdaTypeTree(tdef)(tparams1, tmap1.transform(body))
         case blk @ Block(stats, expr) =>
           val (tmap1, stats1) = transformDefs(stats)
           val expr1 = tmap1.transform(expr)

--- a/tests/pos/i2980.scala
+++ b/tests/pos/i2980.scala
@@ -1,0 +1,13 @@
+trait Foo {
+  def apply[~>[_,_]](x: Int ~> Int): Int ~> Int
+}
+
+object Foo {
+  inline def foo: Foo = new Foo {
+    def apply[~>[_,_]](x: Int ~> Int): Int ~> Int = x
+  }
+
+  def main(args: Array[String]): Unit = {
+    val x = foo((x: Int) => x)
+  }
+}


### PR DESCRIPTION
When we inline we need to construct new trees with new symbols. This is
handled by TreeTypeMap which was missing a case for LambdaTypeTree (the
parameters of a type lambda are TypeDefs and thus have symbols that need
to be replaced). This caused a crash in pickling since we ended up
trying to pickle the same symbol twice.