### PR TITLE
Harden IDE: Cleanup trees after typechecking them in IDE

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1056,7 +1056,10 @@ object SymDenotations {
       else overriddenFromType(owner.asClass.classInfo.selfType)
 
     private def overriddenFromType(tp: Type)(implicit ctx: Context): Iterator[Symbol] =
-      tp.baseClasses.tail.iterator map overriddenSymbol filter (_.exists)
+      tp.baseClasses match {
+        case _ :: inherited => inherited.iterator map overriddenSymbol filter (_.exists)
+        case Nil => Iterator.empty
+      }
 
     /** The symbol overriding this symbol in given subclass `ofclazz`.
      *

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -179,6 +179,11 @@ class InteractiveDriver(settings: List[String]) extends Driver {
 
   private val compiler: Compiler = new InteractiveCompiler
 
+  /** Remove attachments and error out completers. The goal is to avoid
+   *  having a completer hanging in a typed tree which can capture the context
+   *  of a previous run. Note that typed trees can have untyped or partially
+   *  typed children if the source contains errors.
+   */
   private def cleanup(tree: tpd.Tree)(implicit ctx: Context): Unit = tree.foreachSubTree { t =>
     if (t.hasType) {
       if (t.symbol.exists) {

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -181,8 +181,10 @@ class InteractiveDriver(settings: List[String]) extends Driver {
 
   private def cleanup(tree: tpd.Tree)(implicit ctx: Context): Unit = tree.foreachSubTree { t =>
     if (t.hasType) {
-      if (t.symbol.exists && !t.symbol.isCompleted)
-        t.symbol.info = UnspecifiedErrorType
+      if (t.symbol.exists) {
+        if (!t.symbol.isCompleted) t.symbol.info = UnspecifiedErrorType
+        t.symbol.annotations.foreach(annot => cleanup(annot.tree))
+      }
     }
     t.removeAllAttachments()
   }

--- a/compiler/src/dotty/tools/dotc/util/Attachment.scala
+++ b/compiler/src/dotty/tools/dotc/util/Attachment.scala
@@ -92,5 +92,8 @@ object Attachment {
       assert(!getAttachment(key).isDefined, s"duplicate attachment for key $key")
       next = new Link(key, value, next)
     }
+
+    final def removeAllAttachments() =
+      next = null
   }
 }


### PR DESCRIPTION
I decided in the end it is simpler and more modular to sanitize trees in the IDE, after type checking them. That way we can separate concerns and need not burden the general tree handling.

Sanitization involves removing all attachments and symbol completers.
