### PR TITLE
Fix #2957 single quote highlighting and refactor

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -254,18 +254,18 @@ object SyntaxHighlighting {
       prev = curr
     }
 
-    def appendSingleQuote(delim: Char) = remaining match {
-      case '\'' #:: chr #:: '\'' #:: _ => // single character
+    def appendSingleQuote(delim: Char) = remaining.take(3) match {
+      case chr #:: '\'' #:: _ => // single character
         newBuf append LiteralColor
         newBuf appendAll s"'$chr'"
         newBuf append NoColor
-        takeChars(3)
+        takeChars(2)
         prev = '\''
-      case '\'' #:: '\\' #:: chr #:: '\'' #:: _ => // escaped character
+      case '\\' #:: chr #:: '\'' #:: _ => // escaped character
         newBuf append LiteralColor
         newBuf appendAll s"'\\$chr'"
         newBuf append NoColor
-        takeChars(4)
+        takeChars(3)
         prev = '\''
       case _ => appendWhile(delim, !typeEnders.contains(_), literal)
     }

--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -6,7 +6,7 @@ import parsing.Tokens._
 import scala.annotation.switch
 import scala.collection.mutable.StringBuilder
 import core.Contexts.Context
-import util.Chars.{ LF, FF, CR, SU }
+import util.Chars
 import Highlighting.{Highlight, HighlightBuffer}
 
 /** This object provides functions for syntax highlighting in the REPL */
@@ -74,7 +74,7 @@ object SyntaxHighlighting {
           newBuf += n
           prev = n
           if (remaining.nonEmpty) takeChar() // drop 1 for appendLiteral
-          appendLiteral('"', next == "\"\"\"")
+          appendString('"', next == "\"\"\"")
         } else {
           if (n.isUpper && keywordStart) {
             appendWhile(n, !typeEnders.contains(_), typeDef)
@@ -115,9 +115,9 @@ object SyntaxHighlighting {
           case '@'  =>
             appendWhile('@', !typeEnders.contains(_), annotation)
           case '\"' =>
-            appendLiteral('\"', multiline = remaining.take(2).mkString == "\"\"")
+            appendString('\"', multiline = remaining.take(2).mkString == "\"\"")
           case '\'' =>
-            appendLiteral('\'')
+            appendSingleQuote('\'')
           case '`'  =>
             appendTo('`', _ == '`', none)
           case _    => {
@@ -169,16 +169,15 @@ object SyntaxHighlighting {
           if (curr == '*') open += 1
         }
 
-        (curr: @switch) match {
-          case LF | FF | CR | SU => newBuf append CommentColor
-          case _ => ()
+        if (Chars.isLineBreakChar(curr)) {
+          newBuf append CommentColor
         }
       }
       prev = curr
       newBuf append NoColor
     }
 
-    def appendLiteral(delim: Char, multiline: Boolean = false) = {
+    def appendString(delim: Char, multiline: Boolean = false) = {
       var curr: Char      = 0
       var continue        = true
       var closing         = 0
@@ -247,13 +246,30 @@ object SyntaxHighlighting {
           closing = 0
         }
 
-        (curr: @switch) match {
-          case LF | FF | CR | SU => newBuf append LiteralColor
-          case _ => ()
+        if (Chars.isLineBreakChar(curr)) {
+          newBuf append LiteralColor
         }
       }
       newBuf append NoColor
       prev = curr
+    }
+
+    def appendSingleQuote(delim: Char) = remaining match {
+      case '\'' #:: chr #:: '\'' #:: _ => // single character
+        newBuf append LiteralColor
+        newBuf appendAll s"'$chr'"
+        newBuf append NoColor
+        takeChars(3)
+        println(remaining.take(4))
+        prev = '\''
+      case '\'' #:: '\\' #:: chr #:: '\'' #:: _ => // escaped character
+        newBuf append LiteralColor
+        newBuf appendAll s"'\\$chr'"
+        newBuf append NoColor
+        takeChars(3)
+        println(remaining.take(4))
+        prev = '\''
+      case _ => appendWhile(delim, !typeEnders.contains(_), literal)
     }
 
     def append(c: Char, shouldHL: String => Boolean, highlight: String => String) = {

--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -260,14 +260,12 @@ object SyntaxHighlighting {
         newBuf appendAll s"'$chr'"
         newBuf append NoColor
         takeChars(3)
-        println(remaining.take(4))
         prev = '\''
       case '\'' #:: '\\' #:: chr #:: '\'' #:: _ => // escaped character
         newBuf append LiteralColor
         newBuf appendAll s"'\\$chr'"
         newBuf append NoColor
-        takeChars(3)
-        println(remaining.take(4))
+        takeChars(4)
         prev = '\''
       case _ => appendWhile(delim, !typeEnders.contains(_), literal)
     }


### PR DESCRIPTION
Hi all, this is my first PR so please let me know if I'm doing anything wrong. 

This fixes #2957, here's a picture of how things are highlighted now:

<img width="350" alt="screen shot 2017-08-18 at 9 16 31 am" src="https://user-images.githubusercontent.com/1261779/29467686-2e0ea268-83f6-11e7-8a4c-345f640db5bf.png">

And it does actually highlight as little as possible for characters:
<img width="160" alt="screen shot 2017-08-18 at 9 37 16 am" src="https://user-images.githubusercontent.com/1261779/29468393-e3c7dc80-83f8-11e7-993b-0f854f886686.png">


I also did a tiny refactor because `Chars.isLineBreakChar` did the same thing as some logic in the syntax highlighter.
