### PR TITLE
Print Lists consistently in exhaustivity warnings

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -661,7 +661,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         else if (scalaListType.isRef(sym))
           if (mergeList) "_*" else "_: List"
         else if (scalaConsType.isRef(sym))
-          if (mergeList) "_" else "List(_)"
+          if (mergeList) "_, _*"  else "List(_, _*)"
         else if (tp.classSymbol.is(CaseClass) && !hasCustomUnapply(tp.classSymbol))
         // use constructor syntax for case class
           showType(tp) + signature(tp).map(_ => "_").mkString("(", ", ", ")")

--- a/tests/patmat/exhausting.check
+++ b/tests/patmat/exhausting.check
@@ -1,4 +1,4 @@
-21: Pattern Match Exhaustivity: List(_), List(_, _, _)
+21: Pattern Match Exhaustivity: List(_), List(_, _, _, _*)
 27: Pattern Match Exhaustivity: Nil
 32: Pattern Match Exhaustivity: List(_, _*)
 39: Pattern Match Exhaustivity: Bar3

--- a/tests/patmat/t4408.check
+++ b/tests/patmat/t4408.check
@@ -1,1 +1,1 @@
-2: Pattern Match Exhaustivity: List(_, _, _)
+2: Pattern Match Exhaustivity: List(_, _, _, _*)

--- a/tests/patmat/t5440.check
+++ b/tests/patmat/t5440.check
@@ -1,1 +1,1 @@
-2: Pattern Match Exhaustivity: (Nil, List(_)), (List(_), Nil)
+2: Pattern Match Exhaustivity: (Nil, List(_, _*)), (List(_, _*), Nil)


### PR DESCRIPTION
First off - I wasn't too sure if I should open an issue for this, since it's so trivial. I apologise if I should.

This PR adjusts how `List`s are printed in error messages. Previously, depending on the specific pattern match in question, an unmatched `::` would print differently depending on whether we ended up with a `Typ` space or `Kon` space. For the simplest example, `Typ(::)` was printed as `List(_)`, but `Kon(::, Int, List[Int])` was printed as `List(_, _*)`. The error messages were also slightly confusing, since to me `List(_)` suggests that the list has only one member, whereas a `::` can have one-or-more members. After adjustments, `List` now prints consistently as though we had ended up with the `Kon` space. Note that the code is equivalent to showing `Kon(tp, signature(tp).map(Typ(_, false)))`.

/cc @liufengyun