### PR TITLE
Fix compilation of dotty sbt scripted tests

### DIFF
--- a/sbt-dotty/sbt-test/source-dependencies/inherited_type_params/A.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/inherited_type_params/A.scala
@@ -3,5 +3,5 @@ trait Equal[-A] {
   def equal(a1: A, a2: A): Boolean
 }
 object Test {
-  implicit def TraversableEqual[CC[X] <: collection.TraversableLike[X, CC[X]] with Traversable[X], A: Equal]: Equal[CC[A]] = error("")
+  implicit def TraversableEqual[CC[X] <: collection.TraversableLike[X, CC[X]] with Traversable[X], A: Equal]: Equal[CC[A]] = sys.error("")
 }


### PR DESCRIPTION
Adds missing `sys.` prefix in call to `error`