### PR TITLE
Update version number in sbt-dotty for 2.12.x compat

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -876,7 +876,7 @@ object Build {
 
 
       sbtPlugin := true,
-      version := "0.1.4",
+      version := "0.1.5",
       ScriptedPlugin.scriptedSettings,
       ScriptedPlugin.sbtTestDirectory := baseDirectory.value / "sbt-test",
       ScriptedPlugin.scriptedBufferLog := false,


### PR DESCRIPTION
We'd like to release this. We bumped the patch version, but we could just as well bump the minor version IMO...but it doesn't really break anything in the 0.1.x series though... your call :)