### PR TITLE
Fix #3024: repl alias in sbt and `dist/bin/dotr` not working

### DIFF
--- a/dist/bin/dotc
+++ b/dist/bin/dotc
@@ -32,7 +32,7 @@ bootcp=true
 
 CompilerMain=dotty.tools.dotc.Main
 FromTasty=dotty.tools.dotc.FromTasty
-ReplMain=dotty.tools.dotc.repl.Main
+ReplMain=dotty.tools.repl.Main
 
 PROG_NAME=$CompilerMain
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -391,8 +391,6 @@ object Build {
         )
       }.evaluated,
 
-      repl := run.evaluated,
-
       javaOptions ++= (javaOptions in `dotty-compiler`).value,
       fork in run := true,
       fork in Test := true,
@@ -580,6 +578,20 @@ object Build {
         )
       }.evaluated,
       dotc := run.evaluated,
+
+      repl := Def.inputTaskDyn {
+        val dottyLib = packageAll.value("dotty-library")
+        val args: Seq[String] = spaceDelimited("<arg>").parsed
+
+        val fullArgs = args.span(_ != "-classpath") match {
+          case (beforeCp, Nil) => beforeCp ++ ("-classpath" :: dottyLib :: Nil)
+          case (beforeCp, rest) => beforeCp ++ rest
+        }
+
+        (runMain in Compile).toTask(
+          s" dotty.tools.repl.Main " + fullArgs.mkString(" ")
+        )
+      }.evaluated,
 
       // enable verbose exception messages for JUnit
       testOptions in Test += Tests.Argument(


### PR DESCRIPTION
We should also decide if we should ditch the old ./bin scripts in favor of the `./dist/bin` scripts. Keeping both up to date feels tedious.