### PR TITLE
Fix IDE crash on @AfterClass

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -190,6 +190,12 @@ class InteractiveDriver(settings: List[String]) extends Driver {
         if (t.symbol.exists && t.hasType) {
           if (!t.symbol.isCompleted) t.symbol.info = UnspecifiedErrorType
           t.symbol.annotations.foreach { annot =>
+            /* In some cases annotations are are used on themself (possibly larger cycles).
+            *  This is the case with the java.lang.annotation.Target annotation, would end 
+            *  in an infinite loop while cleaning. The `seen` is added to ensure that those 
+            *  trees are not cleand twice.
+            *  TODO: Find a less expensive way to check for those cycles.
+            */
             if (!seen(annot.tree))
               cleanupTree(annot.tree)
           }


### PR DESCRIPTION
The TreeAccumulater was stuck in an infinite loop over the
synthetic constructor of java annotations. This could be reproduced
by opening the CompilationTests.scala in the IDE.