### PR TITLE
Fix initialization vulnerability in Scanner

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaTokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaTokens.scala
@@ -6,7 +6,7 @@ import collection.immutable.BitSet
 
 object JavaTokens extends TokensCommon {
   final val minToken = EMPTY
-  final val maxToken = DOUBLE
+  final def maxToken = DOUBLE
 
   final val javaOnlyKeywords = tokenRange(INSTANCEOF, ASSERT)
   final val sharedKeywords = BitSet( IF, FOR, ELSE, THIS, NULL, NEW, SUPER, ABSTRACT, FINAL, PRIVATE, PROTECTED,

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -6,7 +6,7 @@ import collection.immutable.BitSet
 import core.Decorators._
 
 abstract class TokensCommon {
-  val maxToken: Int
+  def maxToken: Int
 
   type Token = Int
   type TokenSet = BitSet
@@ -145,7 +145,7 @@ abstract class TokensCommon {
 
 object Tokens extends TokensCommon {
   final val minToken = EMPTY
-  final val maxToken = XMLSTART
+  final def maxToken = XMLSTART
 
   final val INTERPOLATIONID = 10;  enter(INTERPOLATIONID, "string interpolator")
   final val SYMBOLLIT = 11;        enter(SYMBOLLIT, "symbol literal") // TODO: deprecate


### PR DESCRIPTION
When bootstrapping with -Yno-inline, Tokens failied to initialize
because the length `maxToken` in `tokenString` was still 0. Changing
a `val` to a `def` fixes that. This is a nice demonstration that the
initialization rules are non-intuitive - we get bitten by them ourselves!