### PR TITLE
Fix access of lazy vals in traits compiled by 2.12

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -132,6 +132,12 @@ object NameOps {
 
     def implClassName: N = likeSpaced(name ++ tpnme.IMPL_CLASS_SUFFIX)
 
+    def traitOfImplClassName: N = {
+      val suffix = tpnme.IMPL_CLASS_SUFFIX.toString
+      assert(name.endsWith(suffix), name)
+      likeSpaced(name.mapLast(_.dropRight(suffix.length)))
+    }
+
     def errorName: N = likeSpaced(name ++ nme.ERROR)
 
     /** Map variance value -1, +1 to 0, 1 */

--- a/compiler/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
@@ -55,7 +55,7 @@ class AugmentScala2Traits extends MiniPhaseTransform with IdentityDenotTransform
       val implClass = ctx.newCompleteClassSymbol(
         owner = mixin.owner,
         name = mixin.name.implClassName,
-        flags = Abstract | Scala2x,
+        flags = Abstract | Scala2x | ImplClass,
         parents = defn.ObjectType :: Nil,
         assocFile = mixin.assocFile).enteredAfter(thisTransform)
 

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -115,6 +115,9 @@ class SymUtils(val self: Symbol) extends AnyVal {
   def implClass(implicit ctx: Context): Symbol =
     self.owner.info.decl(self.name.implClassName).symbol
 
+  def traitOfImplClass(implicit ctx: Context): Symbol =
+    self.owner.info.decl(self.name.traitOfImplClassName).symbol
+
   def annotationsCarrying(meta: ClassSymbol)(implicit ctx: Context): List[Annotation] =
     self.annotations.filter(_.symbol.hasAnnotation(meta))
 

--- a/tests/run/scala2trait-lazyval.scala
+++ b/tests/run/scala2trait-lazyval.scala
@@ -1,0 +1,17 @@
+class Foo extends scala.collection.SeqView[Int, List[Int]] {
+  def iterator: Iterator[Int] = null
+  def apply(idx: Int): Int = idx
+  def length: Int = 0
+  protected def underlying = null
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val f: scala.collection.TraversableViewLike[Int, List[Int], _] = new Foo
+    new f.Transformed[Int] {
+      def foreach[U](f: Int => U): Unit = ()
+      // underlying is a lazy val
+      assert(underlying == null)
+    }
+  }
+}


### PR DESCRIPTION
This was a case we did not consider before. Accessing a lazy val defined
in a Scala 2.12 trait accessed an implementation class which did not exist.
We need special treatment to avoid this.

P.S. It might be preferable to change lazy vals to not generate implementation class
references in the first place. I don't know enough about its internals to be able
to say whether that's feasible.