### PR TITLE
Mitigate #2924

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -112,9 +112,15 @@ object Decorators {
         else x1 :: xs1
       }
 
-    def foldRightBN[U](z: => U)(op: (T, => U) => U): U = xs match {
-      case Nil => z
-      case x :: xs1 => op(x, xs1.foldRightBN(z)(op))
+    def foldRightBN[U](z: => U)(op: (T, => U) => U): U =
+      xs.reverse.foldLeftBN(z)(op)
+
+    final def foldLeftBN[U](acc: => U)(op: (T, => U) => U): U = {
+      @tailrec def fold(xs: List[T], acc: => U): U = xs match {
+        case x :: xs1 => fold(xs1, op(x, acc))
+        case Nil => acc
+      }
+      fold(xs, acc)
     }
 
     final def hasSameLengthAs[U](ys: List[U]): Boolean = {

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -112,15 +112,12 @@ object Decorators {
         else x1 :: xs1
       }
 
-    def foldRightBN[U](z: => U)(op: (T, => U) => U): U =
-      xs.reverse.foldLeftBN(z)(op)
-
-    final def foldLeftBN[U](acc: => U)(op: (T, => U) => U): U = {
-      @tailrec def fold(xs: List[T], acc: => U): U = xs match {
-        case x :: xs1 => fold(xs1, op(x, acc))
+    def foldRightBN[U](z: => U)(op: (T, => U) => U): U = {
+      @tailrec def foldLeftBN(xs: List[T], acc: => U): U = xs match {
+        case x :: xs1 => foldLeftBN(xs1, op(x, acc))
         case Nil => acc
       }
-      fold(xs, acc)
+      foldLeftBN(xs.reverse, z)
     }
 
     final def hasSameLengthAs[U](ys: List[U]): Boolean = {


### PR DESCRIPTION
To make the stack shorter we implement foldRightBN with
a foldLeftBN which allocates only half of the closures.
By doing so we need to eagerly reverse the list which is
in most cases small or empty.