### PR TITLE
Avoid exploring TyperState creations

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -49,7 +49,7 @@ class Run(comp: Compiler, ictx: Context) {
       .setOwner(defn.RootClass)
       .setTyper(new Typer)
       .addMode(Mode.ImplicitsEnabled)
-      .setTyperState(new MutableTyperState(ctx.typerState, ctx.typerState.reporter, isCommittable = true))
+      .setTyperState(new TyperState(ctx.typerState))
       .setFreshNames(new FreshNameCreator.Default)
     ctx.initialize()(start) // re-initialize the base context with start
     def addImport(ctx: Context, refFn: () => TermRef) =

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -455,9 +455,9 @@ object Contexts {
     def setCompilerCallback(callback: CompilerCallback): this.type = { this.compilerCallback = callback; this }
     def setSbtCallback(callback: AnalysisCallback): this.type = { this.sbtCallback = callback; this }
     def setTyperState(typerState: TyperState): this.type = { this.typerState = typerState; this }
-    def setReporter(reporter: Reporter): this.type = setTyperState(typerState.withReporter(reporter))
-    def setNewTyperState: this.type = setTyperState(typerState.fresh(isCommittable = true))
-    def setExploreTyperState: this.type = setTyperState(typerState.fresh(isCommittable = false))
+    def setReporter(reporter: Reporter): this.type = setTyperState(typerState.fresh().setReporter(reporter))
+    def setNewTyperState(): this.type = setTyperState(typerState.fresh().setCommittable(true))
+    def setExploreTyperState(): this.type = setTyperState(typerState.fresh().setCommittable(false))
     def setPrinterFn(printer: Context => Printer): this.type = { this.printerFn = printer; this }
     def setOwner(owner: Symbol): this.type = { assert(owner != NoSymbol); this.owner = owner; this }
     def setSettings(sstate: SettingsState): this.type = { this.sstate = sstate; this }
@@ -516,7 +516,7 @@ object Contexts {
     outer = NoContext
     period = InitialPeriod
     mode = Mode.None
-    typerState = new TyperState(new ConsoleReporter())
+    typerState = new TyperState(null)
     printerFn = new RefinedPrinter(_)
     owner = NoSymbol
     sstate = settings.defaultState

--- a/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
@@ -22,6 +22,8 @@ class StoreReporter(outer: Reporter) extends Reporter {
 
   private var infos: mutable.ListBuffer[MessageContainer] = null
 
+  def reset() = infos = null
+
   def doReport(m: MessageContainer)(implicit ctx: Context): Unit = {
     typr.println(s">>>> StoredError: ${m.message}") // !!! DEBUG
     if (infos == null) infos = new mutable.ListBuffer

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -847,7 +847,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
     def followTypeAlias(tree: untpd.Tree): untpd.Tree = {
       tree match {
         case tree: untpd.RefTree =>
-          val nestedCtx = ctx.fresh.setNewTyperState
+          val nestedCtx = ctx.fresh.setNewTyperState()
           val ttree =
             typedType(untpd.rename(tree, tree.name.toTypeName))(nestedCtx)
           ttree.tpe match {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -67,7 +67,7 @@ object Implicits {
           case mt: MethodType =>
             mt.isImplicit ||
             mt.paramInfos.length != 1 ||
-            !(argType relaxed_<:< mt.paramInfos.head)(ctx.fresh.setExploreTyperState)
+            !ctx.typerState.test(argType relaxed_<:< mt.paramInfos.head)
           case poly: PolyType =>
             // We do not need to call ProtoTypes#constrained on `poly` because
             // `refMatches` is always called with mode TypevarsMissContext enabled.
@@ -75,7 +75,7 @@ object Implicits {
               case mt: MethodType =>
                 mt.isImplicit ||
                 mt.paramInfos.length != 1 ||
-                !(argType relaxed_<:< wildApprox(mt.paramInfos.head, null, Set.empty)(ctx.fresh.setExploreTyperState))
+                !ctx.typerState.test(argType relaxed_<:< wildApprox(mt.paramInfos.head, null, Set.empty))
               case rtp =>
                 discardForView(wildApprox(rtp, null, Set.empty), argType)
             }
@@ -131,8 +131,12 @@ object Implicits {
       }
 
       if (refs.isEmpty) Nil
-      else refs.filter(refMatches(_)(ctx.fresh.addMode(Mode.TypevarsMissContext).setExploreTyperState)) // create a defensive copy of ctx to avoid constraint pollution
-               .map(Candidate(_, level))
+      else {
+        val nestedCtx = ctx.fresh.addMode(Mode.TypevarsMissContext)
+        refs
+          .filter(ref => nestedCtx.typerState.test(refMatches(ref)(nestedCtx)))
+          .map(Candidate(_, level))
+      }
     }
   }
 
@@ -507,6 +511,7 @@ trait Implicits { self: Typer =>
        || inferView(dummyTreeOfType(from), to)
             (ctx.fresh.addMode(Mode.ImplicitExploration).setExploreTyperState)
             .isInstanceOf[SearchSuccess]
+          // TODO: investigate why we can't TyperState#test here
        )
     )
 
@@ -578,7 +583,7 @@ trait Implicits { self: Typer =>
       formal.argTypes match {
         case args @ (arg1 :: arg2 :: Nil)
         if !ctx.featureEnabled(defn.LanguageModuleClass, nme.strictEquality) &&
-           validEqAnyArgs(arg1, arg2)(ctx.fresh.setExploreTyperState) =>
+           ctx.typerState.test(validEqAnyArgs(arg1, arg2)) =>
           ref(defn.Eq_eqAny).appliedToTypes(args).withPos(pos)
         case _ =>
           EmptyTree
@@ -822,7 +827,7 @@ trait Implicits { self: Typer =>
               if (ctx.mode.is(Mode.ImplicitExploration) || isCoherent) best :: Nil
               else {
                 val newPending = pending1.filter(cand1 =>
-                  isAsGood(cand1.ref, best.ref, cand1.level, best.level)(nestedContext.setExploreTyperState))
+                  ctx.typerState.test(isAsGood(cand1.ref, best.ref, cand1.level, best.level)(nestedContext)))
                 rankImplicits(newPending, best :: acc)
               }
           }
@@ -851,7 +856,8 @@ trait Implicits { self: Typer =>
       /** Convert a (possibly empty) list of search successes into a single search result */
       def condense(hits: List[SearchSuccess]): SearchResult = hits match {
         case best :: alts =>
-          alts find (alt => isAsGood(alt.ref, best.ref, alt.level, best.level)(ctx.fresh.setExploreTyperState)) match {
+          alts.find(alt =>
+            ctx.typerState.test(isAsGood(alt.ref, best.ref, alt.level, best.level))) match {
             case Some(alt) =>
               typr.println(i"ambiguous implicits for $pt: ${best.ref} @ ${best.level}, ${alt.ref} @ ${alt.level}")
             /* !!! DEBUG

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -509,7 +509,7 @@ trait Implicits { self: Typer =>
     && from.isValueType
     && (  from.isValueSubType(to)
        || inferView(dummyTreeOfType(from), to)
-            (ctx.fresh.addMode(Mode.ImplicitExploration).setExploreTyperState)
+            (ctx.fresh.addMode(Mode.ImplicitExploration).setExploreTyperState())
             .isInstanceOf[SearchSuccess]
           // TODO: investigate why we can't TyperState#test here
        )
@@ -787,7 +787,7 @@ trait Implicits { self: Typer =>
         val generated1 = adapt(generated, pt)
         lazy val shadowing =
           typed(untpd.Ident(ref.name) withPos pos.toSynthetic, funProto)(
-            nestedContext.addMode(Mode.ImplicitShadowing).setExploreTyperState)
+            nestedContext.addMode(Mode.ImplicitShadowing).setExploreTyperState())
         def refSameAs(shadowing: Tree): Boolean =
           ref.symbol == closureBody(shadowing).symbol || {
             shadowing match {
@@ -819,7 +819,7 @@ trait Implicits { self: Typer =>
           val history = ctx.searchHistory nest wildProto
           val result =
             if (history eq ctx.searchHistory) divergingImplicit(cand.ref)
-            else typedImplicit(cand)(nestedContext.setNewTyperState.setSearchHistory(history))
+            else typedImplicit(cand)(nestedContext.setNewTyperState().setSearchHistory(history))
           result match {
             case fail: SearchFailure =>
               rankImplicits(pending1, acc)

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -31,7 +31,7 @@ object Inferencing {
    *  Variables that are successfully minimized do not count as uninstantiated.
    */
   def isFullyDefined(tp: Type, force: ForceDegree.Value)(implicit ctx: Context): Boolean = {
-    val nestedCtx = ctx.fresh.setNewTyperState
+    val nestedCtx = ctx.fresh.setNewTyperState()
     val result = new IsFullyDefinedAccumulator(force)(nestedCtx).process(tp)
     if (result) nestedCtx.typerState.commit()
     result

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -39,11 +39,9 @@ object ProtoTypes {
       (tp.widenExpr relaxed_<:< pt.widenExpr) || viewExists(tp, pt)
 
     /** Test compatibility after normalization in a fresh typerstate. */
-    def normalizedCompatible(tp: Type, pt: Type)(implicit ctx: Context) = {
-      val nestedCtx = ctx.fresh.setExploreTyperState
-      val normTp = normalize(tp, pt)(nestedCtx)
-      isCompatible(normTp, pt)(nestedCtx) ||
-        pt.isRef(defn.UnitClass) && normTp.isParameterless
+    def normalizedCompatible(tp: Type, pt: Type)(implicit ctx: Context) = ctx.typerState.test {
+      val normTp = normalize(tp, pt)
+      isCompatible(normTp, pt) || pt.isRef(defn.UnitClass) && normTp.isParameterless
     }
 
     private def disregardProto(pt: Type)(implicit ctx: Context): Boolean = pt.dealias match {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1755,7 +1755,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     typed(tree, selType)(ctx addMode Mode.Pattern)
 
   def tryEither[T](op: Context => T)(fallBack: (T, TyperState) => T)(implicit ctx: Context) = {
-    val nestedCtx = ctx.fresh.setNewTyperState
+    val nestedCtx = ctx.fresh.setNewTyperState()
     val result = op(nestedCtx)
     if (nestedCtx.reporter.hasErrors)
       fallBack(result, nestedCtx.typerState)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1977,7 +1977,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       val constraint = ctx.typerState.constraint
       def inst(tp: Type): Type = tp match {
         case TypeBounds(lo, hi)
-        if (lo eq hi) || (hi <:< lo)(ctx.fresh.setExploreTyperState) =>
+        if (lo eq hi) || ctx.typerState.test(hi <:< lo) =>
           inst(lo)
         case tp: TypeParamRef =>
           constraint.typeVarOfParam(tp).orElse(tp)


### PR DESCRIPTION
Dotty bootstrap (from dotc directory) has 5924910 context creations.
This commit brings that number down to 4307795. It also reduces the
number of TyperStates created from 2'059'126 to 308'732.