### PR TITLE
Avoid creating most trees in GenBCode

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -128,11 +128,11 @@ class Run(comp: Compiler, ictx: Context) {
           }
         }
         ctx.informTime(s"$phase ", start)
+        Stats.record(s"total trees at end of $phase", ast.Trees.ntrees)
+        for (unit <- units)
+          Stats.record(s"retained typed trees at end of $phase", unit.tpdTree.treeSize)
       }
     if (!ctx.reporter.hasErrors) Rewrites.writeBack()
-    for (unit <- units)
-      Stats.record("retained typed trees at end", unit.tpdTree.treeSize)
-    Stats.record("total trees at end", ast.Trees.ntrees)
   }
 
   private sealed trait PrintedTree


### PR DESCRIPTION
GenBCode generates trees when it desugars Idents based on their type.
We now cache the generated tree, avoiding generating the same tree several times.

In the Dotty bootstrap, this reduced generated trees in backend from 606K (about 20%
of total) to 49K.