### PR TITLE
Convert "method has return statement; needs result type" to new error format with MissingReturnTypeWithReturnStatement

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -96,6 +96,7 @@ public enum ErrorMessageID {
     WrongNumberOfParametersID,
     DuplicatePrivateProtectedQualifierID,
     ExpectedStartOfTopLevelDefinitionID,
+    MissingReturnTypeWithReturnStatementID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -598,6 +598,21 @@ object messages {
            |}"""
   }
 
+  case class MissingReturnTypeWithReturnStatement(method: Symbol)(implicit ctx: Context)
+  extends Message(MissingReturnTypeWithReturnStatementID) {
+    val kind = "Syntax"
+    val msg = hl"$method has a return statement; it needs a result type"
+    val explanation =
+      hl"""|If a method contains a ${"return"} statement, it must have a return
+           |type explicitly given to it. For example:
+           |
+           |${"def bad() = { return \"fail\" }"}
+           |
+           |This is illegal because bad does not have a return type given
+           |to it. Giving bad a return type of ${"String"} will resolve
+           |this error."""
+  }
+
   case class YieldOrDoExpectedInForComprehension()(implicit ctx: Context)
   extends Message(YieldOrDoExpectedInForComprehensionID) {
     val kind = "Syntax"

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -603,14 +603,10 @@ object messages {
     val kind = "Syntax"
     val msg = hl"$method has a return statement; it needs a result type"
     val explanation =
-      hl"""|If a method contains a ${"return"} statement, it must have a return
-           |type explicitly given to it. For example:
+      hl"""|If a method contains a ${"return"} statement, it must have an
+           |explicit return type. For example:
            |
-           |${"def bad() = { return \"fail\" }"}
-           |
-           |This is illegal because bad does not have a return type given
-           |to it. Giving bad a return type of ${"String"} will resolve
-           |this error."""
+           |${"def good: Int /* explicit return type */ = return 1"}"""
   }
 
   case class YieldOrDoExpectedInForComprehension()(implicit ctx: Context)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -987,7 +987,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         if (owner.isInlineMethod)
           (EmptyTree, errorType(em"no explicit return allowed from inline $owner", tree.pos))
         else if (!owner.isCompleted)
-          (EmptyTree, errorType(em"$owner has return statement; needs result type", tree.pos))
+          (EmptyTree, errorType(MissingReturnTypeWithReturnStatement(owner), tree.pos))
         else {
           val from = Ident(TermRef(NoPrefix, owner.asTerm))
           val proto = returnProto(owner, cx.scope)

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -963,9 +963,11 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
       """.stripMargin
     }.expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
       assertMessageCount(1, messages)
 
       val MissingReturnTypeWithReturnStatement(method) :: Nil = messages
-      assertEquals(method.show, "bad")
+      assertEquals(method.name.show, "bad")
     }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -963,13 +963,9 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
       """.stripMargin
     }.expect { (ictx, messages) =>
-      implicit val ctx: Context = ictx
-      val defn = ictx.definitions
-
       assertMessageCount(1, messages)
 
       val MissingReturnTypeWithReturnStatement(method) :: Nil = messages
-
-      assertEquals(method.name.toString, "bad")
+      assertEquals(method.show, "bad")
     }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -955,4 +955,21 @@ class ErrorMessagesTests extends ErrorMessagesTest {
 
         assertEquals(ExpectedStartOfTopLevelDefinition(), err)
       }
+
+  @Test def missingReturnTypeWithReturnStatement =
+    checkMessagesAfter("frontend") {
+      """class BadFunction {
+        |  def bad() = { return "fail" }
+        |}
+      """.stripMargin
+    }.expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      val defn = ictx.definitions
+
+      assertMessageCount(1, messages)
+
+      val MissingReturnTypeWithReturnStatement(method) :: Nil = messages
+
+      assertEquals(method.name.toString, "bad")
+    }
 }


### PR DESCRIPTION
Convert "method has return statement; needs result type" to new error format with MissingReturnTypeWithReturnStatement