### PR TITLE
Fix #3108: avoid generating useless scripts in distribution

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1126,6 +1126,7 @@ object Build {
   }
 
   lazy val commonDistSettings = packSettings ++ Seq(
+    packMain := Map(),
     publishArtifact := false,
     packGenerateMakefile := false,
     packExpandedClasspath := true,


### PR DESCRIPTION
Fix #3108: avoid generating useless scripts in distribution

The updated version of `sbt-pack` by default generates scripts for all main methods, thus an explicit setting is required.