### PR TITLE
#3111: upgrade vscode engine requirement

### DIFF
--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -11,7 +11,7 @@
   },
   "icon": "images/dotty-logo.svg",
   "engines": {
-    "vscode": "^1.12.0"
+    "vscode": "^1.15.0"
   },
   "categories": [
     "Languages"


### PR DESCRIPTION
upgrades vscode engine requirement so `launchIDE` will work