### PR TITLE
Revert #3059: which generates non-bootstrapped for bootstrapped

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,8 +8,7 @@ import java.util.Calendar
 
 import scala.reflect.io.Path
 import sbtassembly.AssemblyKeys.assembly
-import xerial.sbt.pack.PackPlugin._
-import autoImport._
+import xerial.sbt.Pack._
 
 import sbt.Package.ManifestAttributes
 
@@ -1128,7 +1127,6 @@ object Build {
   lazy val commonDistSettings = packSettings ++ Seq(
     packMain := Map(),
     publishArtifact := false,
-    packGenerateMakefile := false,
     packExpandedClasspath := true,
     packResourceDir += (baseDirectory.value / "bin" -> "bin"),
     packArchiveName := "dotty-" + dottyVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.9.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.8.2")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.24")
 


### PR DESCRIPTION
Revert #3059: which generates non-bootstrapped for bootstrapped.

There's some bug with the latest version of the sbt-pack plugin.