### PR TITLE
Make sbt scripted tests use the right ivy HOME

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -877,6 +877,8 @@ object Build {
       ScriptedPlugin.scriptedBufferLog := false,
       ScriptedPlugin.scriptedLaunchOpts += "-Dplugin.version=" + version.value,
       ScriptedPlugin.scriptedLaunchOpts += "-Dplugin.scalaVersion=" + dottyVersion,
+     // By default scripted tests use $HOME/.ivy2 for the ivy cache. We need to override this value for the CI.
+      ScriptedPlugin.scriptedLaunchOpts ++= ivyPaths.value.ivyHome.map("-Dsbt.ivy.home=" + _.getAbsolutePath).toList,
       ScriptedPlugin.scripted := ScriptedPlugin.scripted.dependsOn(Def.task {
         val x0 = (publishLocal in `dotty-sbt-bridge-bootstrapped`).value
         val x1 = (publishLocal in `dotty-interfaces`).value

--- a/project/scripts/sbt
+++ b/project/scripts/sbt
@@ -10,12 +10,10 @@ if [ -z "$CMD" ]; then
   exit 1
 fi
 
-# get the ivy2 cache
-ln -s /var/cache/drone/ivy2 "$HOME/.ivy2"
-
 # run sbt with the supplied arg
 sbt -J-Xmx4096m \
     -J-XX:ReservedCodeCacheSize=512m \
     -J-XX:MaxMetaspaceSize=1024m \
     -Ddotty.drone.mem=4096m \
+    -Dsbt.ivy.home=/var/cache/drone/ivy2 \
     "$CMD"


### PR DESCRIPTION
When running the CI, ivy HOME is not the default one but sbt scripted
tests used to use the default one anyway