### PR TITLE
move 'Only static object can extend Phantom' to error class

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -99,6 +99,7 @@ public enum ErrorMessageID {
     MissingReturnTypeWithReturnStatementID,
     NoReturnFromInlineID,
     ReturnOutsideMethodDefinitionID,
+    OnlyStaticObjectCanExtendPhantomID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1758,4 +1758,17 @@ object messages {
           |"""
   }
 
+  case class OnlyStaticObjectCanExtendPhantom()(implicit ctx: Context)
+    extends Message(OnlyStaticObjectCanExtendPhantomID) {
+    val kind = "Inheritance"
+    val msg = hl"only static ${"object"}s can extend ${"scala.Phantom"}"
+    val explanation =
+      hl"""To declare a phantom type, you need to declare a static object
+          |extending ${"scala.Phantom"}. Being "static" means, the object
+          |must be top-level or member of an object.
+          |
+          |See ${Blue("http://dotty.epfl.ch/docs/reference/phantom-types.html")}
+          |"""
+  }
+
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1423,7 +1423,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
       // Check that phantom lattices are defined in a static object
       if (cls.classParents.exists(_.typeSymbol eq defn.PhantomClass) && !cls.isStaticOwner)
-        ctx.error("only static objects can extend scala.Phantom", cdef.pos)
+        ctx.error(OnlyStaticObjectCanExtendPhantom(), cdef.pos)
 
       // check value class constraints
       checkDerivedValueClass(cls, body1)

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -998,4 +998,16 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val ReturnOutsideMethodDefinition(owner) :: Nil = messages
       assertEquals("object A", owner.show)
     }
+
+  @Test def onlyStaticObjectCanExtendPhantom =
+    checkMessagesAfter("frontend") {
+      "class Dont extends scala.Phantom"
+    }.expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+
+      val OnlyStaticObjectCanExtendPhantom() :: Nil = messages
+    }
+
 }


### PR DESCRIPTION
@allanrenucci Is there a better suited wording to explain "static". 
I reckon most people using Phantom types know about this basic stuff, right?