### PR TITLE
Fix #3168: Don't insert apply if tree has method type

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1799,6 +1799,11 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
    */
   def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType)(fallBack: => Tree)(implicit ctx: Context): Tree = {
 
+    def isMethod(tree: Tree) = tree.tpe match {
+      case ref: TermRef => ref.denot.alternatives.forall(_.info.widen.isInstanceOf[MethodicType])
+      case _ => false
+    }
+
     def isSyntheticApply(tree: Tree): Boolean = tree match {
       case tree: Select => tree.getAttachment(InsertedApply).isDefined
       case Apply(fn, _) => fn.getAttachment(InsertedApply).isDefined
@@ -1821,7 +1826,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         pt.markAsDropped()
         tree
       case _ =>
-        if (isApplyProto(pt) || isSyntheticApply(tree)) tryImplicit
+        if (isApplyProto(pt) || isMethod(tree) || isSyntheticApply(tree)) tryImplicit
         else tryEither(tryApply(_))((_, _) => tryImplicit)
      }
   }

--- a/tests/neg/insertapply.scala
+++ b/tests/neg/insertapply.scala
@@ -1,0 +1,6 @@
+class C {
+  def apply: C
+}
+object Test {
+  (new C)(22) // error: does not take parameters
+}

--- a/tests/pos/i3168.scala
+++ b/tests/pos/i3168.scala
@@ -1,0 +1,14 @@
+object Test {
+  class C {
+    def foo(x: Int) = 1
+    def foo(x: Double) = 2
+  }
+
+  implicit class COps(val x: C) {
+    def foo(x: String) = 3
+  }
+
+  def test: Unit = {
+    (new C).foo("Hello")
+  }
+}

--- a/tests/pos/i3189.scala
+++ b/tests/pos/i3189.scala
@@ -1,3 +1,0 @@
-class Test[A](action: A => A) {
-  def this() = this(a => a)
-}

--- a/tests/pos/insertapply.scala
+++ b/tests/pos/insertapply.scala
@@ -1,0 +1,6 @@
+class C {
+  def apply: C
+}
+object Test {
+  (new C)(22)
+}

--- a/tests/pos/insertapply.scala
+++ b/tests/pos/insertapply.scala
@@ -1,6 +1,0 @@
-class C {
-  def apply: C
-}
-object Test {
-  (new C)(22)
-}

--- a/tests/run/i3189.scala
+++ b/tests/run/i3189.scala
@@ -1,0 +1,9 @@
+class Test[A](action: A => A) {
+  def this() = this(a => a)
+  def go(x: A) = action(x)
+}
+
+object Test extends App {
+  assert(new Test[Int]().go(3) == 3)
+}
+


### PR DESCRIPTION
It would be simply an eta-expansion followed by an application.
As #3168 shows, overloading resolution gets confused by this.