### PR TITLE
Fix #3171: Fix handling default getters in secondary constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -625,7 +625,7 @@ trait Checking {
           else doubleDefError(decl, other)
         }
         if ((decl is HasDefaultParams) && (other is HasDefaultParams)) {
-          ctx.error(em"two or more overloaded variants of $decl have default arguments")
+          ctx.error(em"two or more overloaded variants of $decl have default arguments", decl.pos)
           decl resetFlag HasDefaultParams
         }
       }

--- a/tests/neg/i3171.scala
+++ b/tests/neg/i3171.scala
@@ -1,0 +1,10 @@
+object Test {
+  class C(x: Int = 1, y: Int) {
+    def this(x: Int = 1)(y: String) = // error: two or more overloaded methods have default getters
+      this(x, y.toInt)
+  }
+
+  def test: Unit = {
+    new C()("1") // error: missing argument
+  }
+}

--- a/tests/pos/i3171.scala
+++ b/tests/pos/i3171.scala
@@ -1,0 +1,10 @@
+object Test {
+  class C(x: Int, y: Int) {
+    def this(x: Int = 1)(y: String) =
+      this(x, y.toInt)
+  }
+
+  def test: Unit = {
+    new C()("1")
+  }
+}


### PR DESCRIPTION
Previous logic would place them in the enclosing class instead of in
the companion object where they belong.

Also, define position for error that checks against multiple overloaded
alternatives with default arguments.