### PR TITLE
Fix #3149: Fix pickling of child annotations to local classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -258,7 +258,7 @@ class ClassfileParser(
             ctx.warning(s"no linked class for java enum $sym in ${sym.owner}. A referencing class file might be missing an InnerClasses entry.")
           else {
             if (!(enumClass is Flags.Sealed)) enumClass.setFlag(Flags.AbstractSealed)
-            enumClass.addAnnotation(Annotation.makeChild(sym))
+            enumClass.addAnnotation(Annotation.Child(sym))
           }
         }
       } finally {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -705,7 +705,7 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
       if ((sym.isClass || sym.is(CaseVal)) && sym.isLocal)
         // Child annotations for local classes and enum values are not pickled, so
         // need to be re-established here.
-        sym.registerIfChild()
+        sym.registerIfChild(late = true)
       tree
     }
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -11,6 +11,7 @@ import util.Positions._
 import ast.{tpd, Trees, untpd}
 import Trees._
 import Decorators._
+import transform.SymUtils._
 import TastyUnpickler._, TastyBuffer._
 import scala.annotation.{tailrec, switch}
 import scala.collection.mutable.ListBuffer
@@ -663,7 +664,6 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
             def isCodefined =
               roots.contains(companion.denot) == seenRoots.contains(companion)
             if (companion.exists && isCodefined) {
-              import transform.SymUtils._
               if (sym is Flags.ModuleClass) sym.registerCompanionMethod(nme.COMPANION_CLASS_METHOD, companion)
               else sym.registerCompanionMethod(nme.COMPANION_MODULE_METHOD, companion)
             }
@@ -702,6 +702,10 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
       if (!sym.isType) { // Only terms might have leaky aliases, see the documentation of `checkNoPrivateLeaks`
         sym.info = ta.avoidPrivateLeaks(sym, tree.pos)
       }
+      if ((sym.isClass || sym.is(CaseVal)) && sym.isLocal)
+        // Child annotations for local classes and enum values are not pickled, so
+        // need to be re-established here.
+        sym.registerIfChild()
       tree
     }
 

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -838,7 +838,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       val start = readIndex
       readNat() // skip reference for now
       target.addAnnotation(
-          Annotation.makeChild(implicit ctx =>
+          Annotation.Child(implicit ctx =>
               atReadPos(start, () => readSymbolRef())))
     }
   }

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -14,7 +14,7 @@ import SymDenotations._, Symbols._, StdNames._, Annotations._, Trees._, Scopes._
 import util.Positions._
 import Decorators._
 import config.Printers.typr
-import Symbols._, TypeUtils._
+import Symbols._, TypeUtils._, SymUtils._
 import reporting.diagnostic.messages.SuperCallsNotAllowedInline
 
 /** A macro transform that runs immediately after typer and that performs the following functions:
@@ -124,14 +124,9 @@ class PostTyper extends MacroTransform with SymTransformer  { thisTransformer =>
     private def transformAnnot(annot: Annotation)(implicit ctx: Context): Annotation =
       annot.derivedAnnotation(transformAnnot(annot.tree))
 
-    private def registerChild(sym: Symbol, tp: Type)(implicit ctx: Context) = {
-      val cls = tp.classSymbol
-      if (cls.is(Sealed)) cls.addAnnotation(Annotation.makeChild(sym))
-    }
-
     private def transformMemberDef(tree: MemberDef)(implicit ctx: Context): Unit = {
       val sym = tree.symbol
-      if (sym.is(CaseVal, butNot = Method | Module)) registerChild(sym, sym.info)
+      sym.registerIfChild()
       sym.transformAnnotations(transformAnnot)
     }
 
@@ -259,12 +254,7 @@ class PostTyper extends MacroTransform with SymTransformer  { thisTransformer =>
               sym.addAnnotation(Annotation.makeSourceFile(ctx.compilationUnit.source.file.path))
 
             // Add Child annotation to sealed parents unless current class is anonymous
-            if (!sym.isAnonymousClass) // ignore anonymous class
-              sym.asClass.classParents.foreach { parent =>
-                val sym2 = if (sym.is(Module)) sym.sourceModule else sym
-                registerChild(sym2, parent)
-              }
-
+            sym.registerIfChild()
             tree
           }
           super.transform(tree)

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -252,9 +252,6 @@ class PostTyper extends MacroTransform with SymTransformer  { thisTransformer =>
               ctx.compilationUnit.source.exists &&
               sym != defn.SourceFileAnnot)
               sym.addAnnotation(Annotation.makeSourceFile(ctx.compilationUnit.source.file.path))
-
-            // Add Child annotation to sealed parents unless current class is anonymous
-            sym.registerIfChild()
             tree
           }
           super.transform(tree)

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -134,4 +134,36 @@ class SymUtils(val self: Symbol) extends AnyVal {
       }
     }
   }
+
+  /** If this symbol is an enum value or a named class, register it as a child
+   *  in all direct parent classes which are sealed.
+   */
+  def registerIfChild()(implicit ctx: Context): Unit = {
+    def register(child: Symbol, parent: Type) = {
+      val cls = parent.classSymbol
+      if (cls.is(Sealed) && !cls.children.contains(child))
+        cls.addAnnotation(Annotation.Child(child))
+    }
+    if (self.isClass && !self.isAnonymousClass)
+      self.asClass.classParents.foreach { parent =>
+        val child = if (self.is(Module)) self.sourceModule else self
+        register(child, parent)
+      }
+    else if (self.is(CaseVal, butNot = Method | Module))
+      register(self, self.info)
+  }
+
+  /** If this is a sealed class, its known children */
+  def children(implicit ctx: Context): List[Symbol] =
+    self.annotations.collect {
+      case Annotation.Child(child) => child
+    }
+
+  /** Is symbol directly or indirectly owned by a term symbol? */
+  @tailrec def isLocal(implicit ctx: Context): Boolean = {
+    val owner = self.owner
+    if (owner.isTerm) true
+    else if (owner.is(Package)) false
+    else owner.isLocal
+  }
 }

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -514,12 +514,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
   /** Decompose a type into subspaces -- assume the type can be decomposed */
   def decompose(tp: Type): List[Space] = {
-    val children = tp.classSymbol.annotations.filter(_.symbol == ctx.definitions.ChildAnnot).map { annot =>
-      // refer to definition of Annotation.makeChild
-      annot.tree match {
-        case Apply(TypeApply(_, List(tpTree)), _) => tpTree.symbol
-      }
-    }
+    val children = tp.classSymbol.children
 
     debug.println(s"candidates for ${tp.show} : [${children.map(_.show).mkString(", ")}]")
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -470,7 +470,7 @@ class Namer { typer: Typer =>
     case vdef: ValDef if (isEnumConstant(vdef)) =>
       val enumClass = sym.owner.linkedClass
       if (!(enumClass is Flags.Sealed)) enumClass.setFlag(Flags.AbstractSealed)
-      enumClass.addAnnotation(Annotation.makeChild(sym))
+      enumClass.addAnnotation(Annotation.Child(sym))
     case _ =>
   }
 

--- a/tests/pickling/i3149.scala
+++ b/tests/pickling/i3149.scala
@@ -1,0 +1,7 @@
+sealed class Foo
+
+class Test {
+  def f = {
+    class Bar extends Foo
+  }
+}

--- a/tests/pos/i3149.scala
+++ b/tests/pos/i3149.scala
@@ -1,0 +1,14 @@
+sealed class Foo
+
+class Test {
+  def f = {
+    class Bar extends Foo
+  }
+  class C {
+    class Bar extends Foo
+  }
+  object O {
+    class Bar extends Foo
+  }
+}
+

--- a/tests/pos/i3149a.scala
+++ b/tests/pos/i3149a.scala
@@ -1,0 +1,14 @@
+sealed class Foo
+
+object Foo {
+  def f = {
+    class Bar extends Foo
+  }
+  class C {
+    class Bar extends Foo
+  }
+  object O {
+    class Bar extends Foo
+  }
+}
+


### PR DESCRIPTION
i3149.scala is an interesting test case: A sealed top-level class `Foo`
has a child which is a local (i.e., term-owned) definition in a different top-level class.
It is then impossible to establish a symbolic reference to the child class
from `Foo`, and it is also impossible to refer to `Foo` using a path. We deal with this
by avoiding pickling such child annotations and re-establishing the annotation
when the body of the child class is unpickled.