### PR TITLE
Fix GADT-related memory leak

### DIFF
--- a/compiler/src/dotty/tools/dotc/Bench.scala
+++ b/compiler/src/dotty/tools/dotc/Bench.scala
@@ -1,7 +1,3 @@
-/* NSC -- new Scala compiler
- * Copyright 2005-2013 LAMP/EPFL
- * @author  Martin Odersky
- */
 package dotty.tools
 package dotc
 
@@ -24,6 +20,11 @@ object Bench extends Driver {
       val start = System.nanoTime()
       val r = super.doCompile(compiler, fileNames)
       println(s"time elapsed: ${(System.nanoTime - start) / 1000000}ms")
+      if (ctx.settings.prompt.value) {
+        print("hit <return> to continue >")
+        System.in.read()
+        println()
+      }
       r
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -700,7 +700,8 @@ object Contexts {
       myBounds = myBounds.updated(sym, b)
     def bounds = myBounds
   }
-  object EmptyGADTMap extends GADTMap(SimpleMap.Empty) {
-    override def setBounds(sym: Symbol, b: TypeBounds) = unsupported("EmptyGADTMap.setBound")
+
+  @sharable object EmptyGADTMap extends GADTMap(SimpleMap.Empty) {
+    override def setBounds(sym: Symbol, b: TypeBounds) = unsupported("EmptyGADTMap.setBounds")
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -476,6 +476,7 @@ object Contexts {
     def setRunInfo(runInfo: RunInfo): this.type = { this.runInfo = runInfo; this }
     def setDiagnostics(diagnostics: Option[StringBuilder]): this.type = { this.diagnostics = diagnostics; this }
     def setGadt(gadt: GADTMap): this.type = { this.gadt = gadt; this }
+    def setFreshGADTBounds: this.type = setGadt(new GADTMap(gadt.bounds))
     def setTypeComparerFn(tcfn: Context => TypeComparer): this.type = { this.typeComparer = tcfn(this); this }
     def setSearchHistory(searchHistory: SearchHistory): this.type = { this.searchHistory = searchHistory; this }
     def setFreshNames(freshNames: FreshNameCreator): this.type = { this.freshNames = freshNames; this }
@@ -493,7 +494,6 @@ object Contexts {
     def setSetting[T](setting: Setting[T], value: T): this.type =
       setSettings(setting.updateIn(sstate, value))
 
-    def setFreshGADTBounds: this.type = { this.gadt = new GADTMap(gadt.bounds); this }
 
     def setDebug = setSetting(base.settings.debug, true)
   }
@@ -532,7 +532,7 @@ object Contexts {
     moreProperties = Map.empty
     typeComparer = new TypeComparer(this)
     searchHistory = new SearchHistory(0, Map())
-    gadt = new GADTMap(SimpleMap.Empty)
+    gadt = new GADTMap(SimpleMap.Empty) // EmptyGADTMap
   }
 
   @sharable object NoContext extends Context {
@@ -694,10 +694,13 @@ object Contexts {
     implicit val ctx: Context = initctx
   }
 
-  class GADTMap(initBounds: SimpleMap[Symbol, TypeBounds]) {
+  class GADTMap(initBounds: SimpleMap[Symbol, TypeBounds]) extends util.DotClass {
     private var myBounds = initBounds
     def setBounds(sym: Symbol, b: TypeBounds): Unit =
       myBounds = myBounds.updated(sym, b)
     def bounds = myBounds
+  }
+  object EmptyGADTMap extends GADTMap(SimpleMap.Empty) {
+    override def setBounds(sym: Symbol, b: TypeBounds) = unsupported("EmptyGADTMap.setBound")
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -532,7 +532,7 @@ object Contexts {
     moreProperties = Map.empty
     typeComparer = new TypeComparer(this)
     searchHistory = new SearchHistory(0, Map())
-    gadt = new GADTMap(SimpleMap.Empty) // EmptyGADTMap
+    gadt = EmptyGADTMap
   }
 
   @sharable object NoContext extends Context {

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -54,16 +54,8 @@ import reporting.diagnostic.messages.SuperCallsNotAllowedInline
  *  mini-phase or subfunction of a macro phase equally well. But taken by themselves
  *  they do not warrant their own group of miniphases before pickling.
  */
-class PostTyper extends MacroTransform with SymTransformer  { thisTransformer =>
-
-
+class PostTyper extends MacroTransform with IdentityDenotTransformer { thisTransformer =>
   import tpd._
-
-  def transformSym(ref: SymDenotation)(implicit ctx: Context): SymDenotation = {
-    if (ref.is(BindDefinedType) && ctx.gadt.bounds.contains(ref.symbol)) {
-      ref.copySymDenotation(info = ctx.gadt.bounds.apply(ref.symbol) & ref.info)
-    } else ref
-  }
 
   /** the following two members override abstract members in Transform */
   override def phaseName: String = "posttyper"
@@ -289,6 +281,8 @@ class PostTyper extends MacroTransform with SymTransformer  { thisTransformer =>
             case _                                  =>
           }
           super.transform(tree)
+        case Typed(Ident(nme.WILDCARD), _) =>
+          tree // skip checking pattern type
         case tree =>
           super.transform(tree)
       }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -68,7 +68,7 @@ object Checking {
    *     Unreducible applications correspond to general existentials, and we
    *     cannot handle those.
    */
-  def checkAppliedType(tree: AppliedTypeTree)(implicit ctx: Context) = {
+  def checkAppliedType(tree: AppliedTypeTree, boundsCheck: Boolean)(implicit ctx: Context) = {
     val AppliedTypeTree(tycon, args) = tree
     // If `args` is a list of named arguments, return corresponding type parameters,
     // otherwise return type parameters unchanged
@@ -81,7 +81,7 @@ object Checking {
     val bounds = tparams.map(_.paramInfoAsSeenFrom(tycon.tpe).bounds)
     def instantiate(bound: Type, args: List[Type]) =
       HKTypeLambda.fromParams(tparams, bound).appliedTo(args)
-    checkBounds(orderedArgs, bounds, instantiate)
+    if (boundsCheck) checkBounds(orderedArgs, bounds, instantiate)
 
     def checkWildcardApply(tp: Type, pos: Position): Unit = tp match {
       case tp @ AppliedType(tycon, args) if args.exists(_.isInstanceOf[TypeBounds]) =>

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -491,7 +491,10 @@ trait ImplicitRunInfo { self: RunInfo =>
     override def default(key: TermRef) = 0
   }
 
-  def clear() = implicitScopeCache.clear()
+  def clear() = {
+    implicitScopeCache.clear()
+    useCount.clear()
+  }
 }
 
 /** The implicit resolution part of type checking */


### PR DESCRIPTION
There was a confusion which led to the wrong gadt map being used
for pattern-bound variables if there was no other GADT variable
in the enclosing method.

This led to the outermost gadt map in the initial context being
populated with type bounds which never went away.