### PR TITLE
Fix #3213: Make PolyTypes generative

### DIFF
--- a/tests/pos/i2981.scala
+++ b/tests/pos/i2981.scala
@@ -1,0 +1,16 @@
+trait HList
+trait HNil extends HList
+
+trait FromTraversable[Out <: HList]
+object FromTraversable {
+  implicit def hnilFromTraversable[T]: FromTraversable[HNil] =
+    new FromTraversable[HNil]{}
+}
+
+object Filter {
+  def apply[A <: HList, O <: HList]()(implicit ftA: FromTraversable[A],
+                                      ftO: FromTraversable[O]): Unit = ()
+}
+object Main {
+  def main = Filter[HNil, HNil]()
+}


### PR DESCRIPTION
Because PolyTypes are used as carriers of constrained parameter references,
we must make sure that we can duplicate them so that the duplicate is
different from the original. Hence, it's useless to cache PolyTypes.