### PR TITLE
TastyFormat: Don't use final vals for MajorVersion/MinorVersion

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -230,8 +230,8 @@ Standard Section: "Positions" Assoc*
 object TastyFormat {
 
   final val header = Array(0x5C, 0xA1, 0xAB, 0x1F)
-  final val MajorVersion = 1
-  final val MinorVersion = 0
+  val MajorVersion = 1
+  val MinorVersion = 0
 
   // Name tags
 


### PR DESCRIPTION
Because sbt incremental compilation for scalac is broken for final vals,
so the dotty-library-bootstrapped compiled by the non-bootstrapped
dotty-compiler may have an old MajorVersion/MinorVersion unless you do
`clean` first.