### PR TITLE
Improve diagnostics for bad Tasty files

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -54,7 +54,7 @@ class ClassfileParser(
   private def currentIsTopLevel(implicit ctx: Context) = classRoot.owner is Flags.PackageClass
 
   private def mismatchError(className: SimpleName) =
-    throw new IOException(s"class file '${in.file}' has location not matching its contents: contains class $className")
+    throw new IOException(s"class file '${in.file.file.getAbsolutePath}' has location not matching its contents: contains class $className")
 
   def run()(implicit ctx: Context): Option[Embedded] = try {
     ctx.debuglog("[class] >> " + classRoot.fullName)
@@ -65,7 +65,7 @@ class ClassfileParser(
     case e: RuntimeException =>
       if (ctx.debug) e.printStackTrace()
       throw new IOException(
-        i"""class file $classfile is broken, reading aborted with ${e.getClass}
+        i"""class file ${classfile.file.getAbsolutePath} is broken, reading aborted with ${e.getClass}
            |${Option(e.getMessage).getOrElse("")}""")
   }
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -10,7 +10,7 @@ import NameKinds._
 import java.util.UUID
 
 object TastyUnpickler {
-  class UnpickleException(msg: String) extends Exception(msg)
+  class UnpickleException(msg: String) extends RuntimeException(msg)
 
   abstract class SectionUnpickler[R](val name: String) {
     def unpickle(reader: TastyReader, nameAtRef: NameTable): R


### PR DESCRIPTION
 - always give absolute paths when reporting about bad class files
 - turn UnpickleException into a runtime error, so that additional
   file info is printed.

I used this change to figure out why launchIDE failed.