### PR TITLE
Actually fill the TyperState#testReporter cache

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -95,12 +95,14 @@ class TyperState(previous: TyperState /* | Null */) extends DotClass with Showab
     val savedCommittable = myIsCommittable
     val savedCommitted = isCommitted
     myIsCommittable = false
-    myReporter =
-      if (testReporter == null) new StoreReporter(reporter)
-      else {
+    myReporter = {
+      if (testReporter == null) {
+        testReporter = new StoreReporter(reporter)
+      } else {
         testReporter.reset()
-        testReporter
       }
+      testReporter
+    }
     try op
     finally {
       myReporter = savedReporter


### PR DESCRIPTION
This cache was never set before, only read from.