### PR TITLE
isAsSpecific: restrict usage of fullyDefinedType

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1094,14 +1094,16 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
         {
           implicit val ctx = nestedCtx
 
-          // Fully define the type so that the types of the tparams created
-          // below never contain TypeRefs whose underling types contain
-          // uninstantiated TypeVars, this could lead to cycles in `isSubType`
-          // as a TypeVar might get constrained by a TypeRef it's part of.
-          val tp1a = fullyDefinedType(tp1, "alternative", alt1.symbol.pos).asInstanceOf[PolyType]
+          // Fully define the PolyType parameters so that the infos of the
+          // tparams created below never contain TypeRefs whose underling types
+          // contain uninstantiated TypeVars, this could lead to cycles in
+          // `isSubType` as a TypeVar might get constrained by a TypeRef it's
+          // part of.
+          val tp1Params = tp1.newLikeThis(tp1.paramNames, tp1.paramInfos, defn.AnyType)
+          fullyDefinedType(tp1Params, "type parameters of alternative", alt1.symbol.pos)
 
-          val tparams = ctx.newTypeParams(alt1.symbol, tp1.paramNames, EmptyFlags, tp1a.instantiateBounds)
-          isAsSpecific(alt1, tp1a.instantiate(tparams.map(_.typeRef)), alt2, tp2)
+          val tparams = ctx.newTypeParams(alt1.symbol, tp1.paramNames, EmptyFlags, tp1.instantiateBounds)
+          isAsSpecific(alt1, tp1.instantiate(tparams.map(_.typeRef)), alt2, tp2)
         }
       case _ => // (3)
         tp2 match {


### PR DESCRIPTION
We only need to fully define the bounds of the PolyType parameters, not the
whole PolyType.