### PR TITLE
Fix #3206: make sure partial function has `@unchecked`

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2251,7 +2251,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
      *  tree that went unreported. A scenario where this happens is i1802.scala.
      */
     def ensureReported(tp: Type) = tp match {
-      case err: ErrorType if !ctx.reporter.hasErrors => ctx.error(err.msg, tree.pos)
+      case err: ErrorType if !ctx.reporter.errorsReported => ctx.error(err.msg, tree.pos)
       case _ =>
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -878,7 +878,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     tree.selector match {
       case EmptyTree =>
         val (protoFormals, _) = decomposeProtoFunction(pt, 1)
-        val unchecked = pt <:< defn.PartialFunctionType
+        val unchecked = pt.isRef(defn.PartialFunctionClass)
         typed(desugar.makeCaseLambda(tree.cases, protoFormals.length, unchecked) withPos tree.pos, pt)
       case _ =>
         val sel1 = typedExpr(tree.selector)

--- a/tests/neg/ensureReported.scala
+++ b/tests/neg/ensureReported.scala
@@ -1,0 +1,6 @@
+object AnonymousF {
+  val f = {
+    case l @ List(1) => // error: missing parameter type // error: Ambiguous overload
+      Some(l)
+  }
+}

--- a/tests/patmat/i3206.scala
+++ b/tests/patmat/i3206.scala
@@ -1,0 +1,5 @@
+object Test {
+  val foo: PartialFunction[Option[Int], Int] = {
+    case Some(x) => x
+  }
+}

--- a/tests/patmat/partial-function.check
+++ b/tests/patmat/partial-function.check
@@ -1,1 +1,0 @@
-10: Pattern Match Exhaustivity: CC(_, B2)


### PR DESCRIPTION
Fix #3206: make sure partial function has `@unchecked`.

Review @smarter .