### PR TITLE
sbt.ExtractAPI: Support TypeArgRef

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -147,6 +147,7 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
     new api.Annotated(tp, Array(marker))
   private def marker(name: String) =
     new api.Annotation(new api.Constant(Constants.emptyType, name), Array())
+  val typeArgRefMarker = marker("TypeArgRef")
   val orMarker = marker("Or")
   val byNameMarker = marker("ByName")
 
@@ -343,6 +344,12 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
     }
   }
 
+  // Hack to represent dotty types which don't have an equivalent in xsbti
+  def combineApiTypes(apiTps: api.Type*): api.Type = {
+    new api.Structure(strict2lzy(apiTps.toArray),
+      strict2lzy(Array()), strict2lzy(Array()))
+  }
+
   def apiType(tp: Type): api.Type = {
     typeCache.getOrElseUpdate(tp, computeType(tp))
   }
@@ -450,7 +457,7 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
         // TODO: Add a real representation for AndOrTypes in xsbti. The order of
         // types in an `AndOrType` does not change the API, so the API hash should
         // be symmetric.
-        val s = new api.Structure(strict2lzy(parents.toArray), strict2lzy(Array()), strict2lzy(Array()))
+        val s = combineApiTypes(apiType(tp.tp1), apiType(tp.tp2))
         if (tp.isAnd)
           s
         else
@@ -471,6 +478,9 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
         apiType(tp.ref)
       case tp: TypeVar =>
         apiType(tp.underlying)
+      case TypeArgRef(prefix, clsRef, idx) =>
+        val apiClsWithIdx = withMarker(apiType(clsRef), marker(idx.toString))
+        withMarker(combineApiTypes(apiType(prefix), apiClsWithIdx), typeArgRefMarker)
       case _ => {
         ctx.warning(i"sbt-api: Unhandled type ${tp.getClass} : $tp")
         Constants.emptyType

--- a/sbt-dotty/sbt-test/source-dependencies/typeargref/A.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/typeargref/A.scala
@@ -1,0 +1,10 @@
+import scala.collection.JavaConverters._
+import java.util.{ Map => JMap }
+
+class A {
+  // Inferred type for `param`: java.util.Map[Int, _ <: String]#<parameter V of trait Map>
+  def param = {
+    val opt: Option[JMap[Int, _ <: String]] = None
+    opt.getOrElse(Map.empty.asJava).get(42)
+  }
+}

--- a/sbt-dotty/sbt-test/source-dependencies/typeargref/B.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/typeargref/B.scala
@@ -1,0 +1,3 @@
+object B {
+  def foo(a: A): Int = a.param.length
+}

--- a/sbt-dotty/sbt-test/source-dependencies/typeargref/changes/A1.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/typeargref/changes/A1.scala
@@ -1,0 +1,10 @@
+import scala.collection.JavaConverters._
+import java.util.{ Map => JMap }
+
+class A {
+  // Inferred type for `param`: java.util.Map[Int, _ <: Int]#<parameter V of trait Map>
+  def param = {
+    val opt: Option[JMap[Int, _ <: Int]] = None
+    opt.getOrElse(Map.empty.asJava).get(42)
+  }
+}

--- a/sbt-dotty/sbt-test/source-dependencies/typeargref/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/typeargref/project/DottyInjectedPlugin.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion"),
+    scalacOptions += "-language:Scala2"
+  )
+}

--- a/sbt-dotty/sbt-test/source-dependencies/typeargref/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/source-dependencies/typeargref/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))

--- a/sbt-dotty/sbt-test/source-dependencies/typeargref/test
+++ b/sbt-dotty/sbt-test/source-dependencies/typeargref/test
@@ -1,0 +1,4 @@
+> compile
+$ copy-file changes/A1.scala A.scala
+# Compilation of B.scala should fail because the signature of A#param has changed
+-> compile


### PR DESCRIPTION
TypeArgRef can leak to method signatures, therefore it needs to be
handled in ExtractAPI for incremental compilation to work correctly.

@odersky :  See sbt-dotty/sbt-test/source-dependencies/typeargref/A.scala for an example where a TypeArgRef leaks to the signature. This example seems dubious to me since there's no reason we couldn't use the underlying type here, so let me know if you can come up with a more reasonable example.