### PR TITLE
Fix #3273: Cook raw types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -24,7 +24,7 @@ object ClassfileParser {
     * be invalidated. */
   object NoEmbedded extends Embedded
 
-  /** Replace raw types with wildcad applications */
+  /** Replace raw types with wildcard applications */
   def cook(implicit ctx: Context) = new TypeMap {
     def apply(tp: Type): Type = tp match {
       case tp: TypeRef if tp.symbol.typeParams.nonEmpty =>

--- a/tests/pos/i3273/Foo_1.java
+++ b/tests/pos/i3273/Foo_1.java
@@ -1,0 +1,3 @@
+interface Foo_1 {
+  void foo(java.util.List list);
+}

--- a/tests/pos/i3273/Test_2.scala
+++ b/tests/pos/i3273/Test_2.scala
@@ -1,0 +1,3 @@
+class Test extends Foo_1 {
+  override def foo(list: java.util.List[_]): Unit = ???
+}


### PR DESCRIPTION
Replace Java raw types by existentials (wildcard applications).