### PR TITLE
Avoid creating NumericRange instances when not needed

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -111,21 +111,21 @@ class Definitions {
         val decls = newScope
         val arity = name.functionArity
         val paramNamePrefix = tpnme.scala_ ++ str.NAME_JOIN ++ name ++ str.EXPAND_SEPARATOR
-        val argParams =
-          for (i <- List.range(1, arity + 1)) yield
-            enterTypeParam(cls, paramNamePrefix ++ "T" ++ i.toString, Contravariant, decls)
+        val argParams = List.tabulate(arity) { i =>
+          enterTypeParam(cls, paramNamePrefix ++ "T" ++ (i + 1).toString, Contravariant, decls).typeRef
+        }
         val resParam = enterTypeParam(cls, paramNamePrefix ++ "R", Covariant, decls)
         val (methodType, parentTraits) =
           if (name.firstPart.startsWith(str.ImplicitFunction)) {
             val superTrait =
-              FunctionType(arity).appliedTo(argParams.map(_.typeRef) ::: resParam.typeRef :: Nil)
+              FunctionType(arity).appliedTo(argParams ::: resParam.typeRef :: Nil)
             (ImplicitMethodType, superTrait :: Nil)
           }
           else (MethodType, Nil)
         val applyMeth =
           decls.enter(
             newMethod(cls, nme.apply,
-              methodType(argParams.map(_.typeRef), resParam.typeRef), Deferred))
+              methodType(argParams, resParam.typeRef), Deferred))
         denot.info =
           ClassInfo(ScalaPackageClass.thisType, cls, ObjectType :: parentTraits, decls)
       }

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -111,21 +111,21 @@ class Definitions {
         val decls = newScope
         val arity = name.functionArity
         val paramNamePrefix = tpnme.scala_ ++ str.NAME_JOIN ++ name ++ str.EXPAND_SEPARATOR
-        val argParams = List.tabulate(arity) { i =>
+        val argParamRefs = List.tabulate(arity) { i =>
           enterTypeParam(cls, paramNamePrefix ++ "T" ++ (i + 1).toString, Contravariant, decls).typeRef
         }
         val resParam = enterTypeParam(cls, paramNamePrefix ++ "R", Covariant, decls)
         val (methodType, parentTraits) =
           if (name.firstPart.startsWith(str.ImplicitFunction)) {
             val superTrait =
-              FunctionType(arity).appliedTo(argParams ::: resParam.typeRef :: Nil)
+              FunctionType(arity).appliedTo(argParamRefs ::: resParam.typeRef :: Nil)
             (ImplicitMethodType, superTrait :: Nil)
           }
           else (MethodType, Nil)
         val applyMeth =
           decls.enter(
             newMethod(cls, nme.apply,
-              methodType(argParams, resParam.typeRef), Deferred))
+              methodType(argParamRefs, resParam.typeRef), Deferred))
         denot.info =
           ClassInfo(ScalaPackageClass.thisType, cls, ObjectType :: parentTraits, decls)
       }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -690,7 +690,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       val MethodTpe(_, formals, restpe) = meth.info
       (formals, restpe)
     case _ =>
-      (List.range(0, defaultArity) map alwaysWildcardType, WildcardType)
+      (List.tabulate(defaultArity)(alwaysWildcardType), WildcardType)
   }
 
   def typedFunction(tree: untpd.Function, pt: Type)(implicit ctx: Context) = track("typedFunction") {

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -28,9 +28,9 @@ extends interfaces.SourcePosition {
   /** The lines of the position */
   def lines: List[Int] = {
     val startOffset = source.offsetToLine(start)
-    val endOffest = source.offsetToLine(end + 1)
-    if (startOffset >= endOffest) line :: Nil
-    else List.tabulate(endOffest - startOffset)(i => i + startOffset)
+    val endOffset = source.offsetToLine(end + 1)
+    if (startOffset >= endOffset) line :: Nil
+    else List.tabulate(endOffset - startOffset)(i => i + startOffset)
   }
 
   def lineOffsets: List[Int] =

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -30,7 +30,7 @@ extends interfaces.SourcePosition {
     val startOffset = source.offsetToLine(start)
     val endOffset = source.offsetToLine(end + 1)
     if (startOffset >= endOffset) line :: Nil
-    else List.tabulate(endOffset - startOffset)(i => i + startOffset)
+    else (startOffset until endOffset).toList
   }
 
   def lineOffsets: List[Int] =

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -26,11 +26,12 @@ extends interfaces.SourcePosition {
     source.content.slice(source.startOfLine(start), source.nextLine(end))
 
   /** The lines of the position */
-  def lines: List[Int] =
-    List.range(source.offsetToLine(start), source.offsetToLine(end + 1)) match {
-      case Nil => line :: Nil
-      case xs => xs
-    }
+  def lines: List[Int] = {
+    val startOffset = source.offsetToLine(start)
+    val endOffest = source.offsetToLine(end + 1)
+    if (startOffset >= endOffest) line :: Nil
+    else List.tabulate(endOffest - startOffset)(i => i + startOffset)
+  }
 
   def lineOffsets: List[Int] =
     lines.map(source.lineToOffset(_))


### PR DESCRIPTION
Initializing NumericRange instances is expensive due to the implicit class tags used.