### PR TITLE
Avoid closure creation in hot code

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -22,7 +22,8 @@ object Flags {
       else if (that.bits == 0) this
       else {
         val tbits = bits & that.bits & KINDFLAGS
-        assert(tbits != 0, s"illegal flagset combination: $this and $that")
+        if (tbits == 0)
+          assert(false, s"illegal flagset combination: $this and $that")
         FlagSet(tbits | ((this.bits | that.bits) & ~KINDFLAGS))
       }
 


### PR DESCRIPTION
Unfortunately the `inlining` solution of  #3267 fails here as the closure is impure an hence evaluated before the inlined block of code.