### PR TITLE
Prints new line when exiting the REPL

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -132,7 +132,10 @@ class ReplDriver(settings: Array[String],
   @tailrec final def runUntilQuit(state: State = initState): State = {
     val res = readLine()(state)
 
-    if (res == Quit) state
+    if (res == Quit) {
+      out.println()
+      state
+    }
     else {
       // readLine potentially destroys the run, so a new one is needed for the
       // rest of the interpretation:


### PR DESCRIPTION
In sbt:

Before:
```scala
> repl
scala> :quit
[success] Total time: 8 s, completed Oct 9, 2017 2:31:06 PM
> repl
scala> ctrl-d [success] Total time: 7 s, completed Oct 9, 2017 2:31:18 PM
```

Now:
```scala
> repl
scala> :quit

[success] Total time: 8 s, completed Oct 9, 2017 2:30:41 PM
> repl
scala> ctrl-d
[success] Total time: 4 s, completed Oct 9, 2017 2:30:48 PM
```
This aligns the behavior with what is currently done in scalac