### PR TITLE
Fix #3279

### DIFF
--- a/sbt-dotty/sbt-test/sbt-dotty/example-project/test
+++ b/sbt-dotty/sbt-test/sbt-dotty/example-project/test
@@ -1,1 +1,3 @@
 > run
+> 'set initialCommands := "1 + 1" '
+> console


### PR DESCRIPTION
When using the repl through "sbt console", we used to use the class
loader sbt give us. But we need a class loader that has the output
directory of the compiler on the classpath