### PR TITLE
Error on TypedefOrDcl

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2156,7 +2156,7 @@ object Parsers {
           case SUPERTYPE | SUBTYPE | SEMI | NEWLINE | NEWLINES | COMMA | RBRACE | EOF =>
             TypeDef(name, lambdaAbstract(tparams, typeBounds())).withMods(mods).setComment(in.getDocComment(start))
           case _ =>
-            syntaxErrorOrIncomplete("`=', `>:', or `<:' expected")
+            syntaxErrorOrIncomplete(ExpectedTypeBoundOrEquals())
             EmptyTree
         }
       }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2156,7 +2156,7 @@ object Parsers {
           case SUPERTYPE | SUBTYPE | SEMI | NEWLINE | NEWLINES | COMMA | RBRACE | EOF =>
             TypeDef(name, lambdaAbstract(tparams, typeBounds())).withMods(mods).setComment(in.getDocComment(start))
           case _ =>
-            syntaxErrorOrIncomplete(ExpectedTypeBoundOrEquals())
+            syntaxErrorOrIncomplete(ExpectedTypeBoundOrEquals(in.token))
             EmptyTree
         }
       }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -102,6 +102,7 @@ public enum ErrorMessageID {
     UncheckedTypePatternID,
     ExtendFinalClassID,
     EnumCaseDefinitionInNonEnumOwnerID,
+    ExpectedTypeBoundOrEqualsID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1787,22 +1787,21 @@ object messages {
             |and has the ${"enum"} keyword."""
   }
 
-  case class ExpectedTypeBoundOrEquals()(implicit ctx: Context)
+  case class ExpectedTypeBoundOrEquals(found: Token)(implicit ctx: Context)
     extends Message(ExpectedTypeBoundOrEqualsID) {
     val kind = "Syntax"
-    val msg =
-        hl"""`=', `>:', or `<:' expected"""
+    val msg = hl"${"="}, ${">:"}, or ${"<:"} expected, but ${Tokens.showToken(found)} found"
 
     val explanation =
-      hl"""|In Scala, type parameters and abstract types may be constrained by a type bound.
+      hl"""Type parameters and abstract types may be constrained by a type bound.
            |Such type bounds limit the concrete values of the type variables and possibly
            |reveal more information about the members of such types.
            |
-           |A lower type bound `B >: A` expresses that the type variable `B`
-           |refers to a supertype of type `A`.
+           |A lower type bound ${"B >: A"} expresses that the type variable ${"B"}
+           |refers to a supertype of type ${"A"}.
            |
-           |An upper type bound `T <: A` declares that type variable `T`
-           |refers to a subtype of type `A`.
+           |An upper type bound ${"T <: A"} declares that type variable ${"T"}
+           |refers to a subtype of type ${"A"}.
            |"""
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1770,7 +1770,7 @@ object messages {
           |"""
   }
 
-  case class ExtendFinalClass(clazz:Symbol, finalClazz: Symbol)(implicit ctx: Context) 
+  case class ExtendFinalClass(clazz:Symbol, finalClazz: Symbol)(implicit ctx: Context)
     extends Message(ExtendFinalClassID) {
     val kind = "Syntax"
     val msg = hl"$clazz cannot extend ${"final"} $finalClazz"
@@ -1785,5 +1785,24 @@ object messages {
         hl"""${"enum"} cases are only allowed within the companion ${"object"} of an ${"enum class"}.
             |If you want to create an ${"enum"} case, make sure the corresponding ${"enum class"} exists
             |and has the ${"enum"} keyword."""
+  }
+
+  case class ExpectedTypeBoundOrEquals()(implicit ctx: Context)
+    extends Message(ExpectedTypeBoundOrEqualsID) {
+    val kind = "Syntax"
+    val msg =
+        hl"""`=', `>:', or `<:' expected"""
+
+    val explanation =
+      hl"""|In Scala, type parameters and abstract types may be constrained by a type bound.
+           |Such type bounds limit the concrete values of the type variables and possibly
+           |reveal more information about the members of such types.
+           |
+           |A lower type bound `B >: A` expresses that the type variable `B`
+           |refers to a supertype of type `A`.
+           |
+           |An upper type bound `T <: A` declares that type variable `T`
+           |refers to a subtype of type `A`.
+           |"""
   }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1024,4 +1024,19 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val EnumCaseDefinitionInNonEnumOwner(owner) :: Nil = messages
       assertEquals("object Qux", owner.show)
     }
+
+    @Test def expectedTypeBoundOrEquals =
+      checkMessagesAfter("frontend") {
+        """object typedef {
+          |  type asd > Seq
+          |}
+        """.stripMargin
+      }.expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+        val defn = ictx.definitions
+
+        assertMessageCount(1, messages)
+        val ExpectedTypeBoundOrEquals(found) :: Nil = messages
+        assertEquals(Tokens.IDENTIFIER, found)
+      }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1033,7 +1033,6 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         """.stripMargin
       }.expect { (ictx, messages) =>
         implicit val ctx: Context = ictx
-        val defn = ictx.definitions
 
         assertMessageCount(1, messages)
         val ExpectedTypeBoundOrEquals(found) :: Nil = messages


### PR DESCRIPTION
Tackles #1589. More specifically, it provides a detailed explanation for the error message in Parsers.scala:2150 : "`=', `>:', or `<:' expected".