### PR TITLE
Cleanup transform phases

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TailRec.scala
@@ -70,7 +70,6 @@ class TailRec extends MiniPhaseTransform with DenotTransformer with FullParamete
   override def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation = ref
 
   override def phaseName: String = "tailrec"
-  override def treeTransformPhase = thisTransform // TODO Make sure tailrec runs at next phase.
 
   final val labelFlags = Flags.Synthetic | Flags.Label
 


### PR DESCRIPTION
 1. Run tailrec at phase + 1

    It was the only phase that overrode treeTransformPhase directly. Better to standardize on phase + 1.