### PR TITLE
fix version check in Cygwin

### DIFF
--- a/dist/bin/common
+++ b/dist/bin/common
@@ -62,7 +62,7 @@ if [ ! -x "$JAVACMD" ] ; then
 fi
 
 # parses 1.7, 1.8, 9, etc out of java version "1.8.0_91"
-JAVA_VERSION=$("$JAVACMD" -version 2>&1 | grep ' version "' | sed 's/.*version "\([0-9]*\)\(\.[0-9]*\)\{0,1\}\(.*\)*"/\1\2/; 1q')
+JAVA_VERSION=$("$JAVACMD" -version 2>&1 | grep ' version "' | tr '\r' '\n' | sed 's/.*version "\([0-9]*\)\(\.[0-9]*\)\{0,1\}\(.*\)*"/\1\2/; 1q')
 
 if [ "$JAVA_VERSION" != "1.8" ] ; then
   echo "Error: Java 8 is required, actual $JAVA_VERSION"


### PR DESCRIPTION
Fix version check in Cygwin

Note: I've tried following code as well, which doesn't work either on Cygwin:

``` shell
JAVA_VERSION=$(echo $JAVA_VERSION | xargs)
# or
JAVA_VERSION=$(echo $JAVA_VERSION)
```

I've tried compare `$JAVA_VERSION == "1.8 "`, which is false as well. I guess Cygwin has inserted some invisible characters somewhere.