### PR TITLE
Eliminate AnnotationTransformer

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -268,7 +268,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
         }
       case t: SeqLiteral =>
         val arrAnnotV: AnnotationVisitor = av.visitArray(name)
-        for(arg <- t.elems) { emitArgument(arrAnnotV, null, arg, bcodeStore)(innerClasesStore) }
+        for (arg <- t.elems) { emitArgument(arrAnnotV, null, arg, bcodeStore)(innerClasesStore) }
         arrAnnotV.visitEnd()
 
       case Apply(fun, args) if fun.symbol == defn.ArrayClass.primaryConstructor ||
@@ -280,11 +280,15 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
           fun.asInstanceOf[Apply].args
         } else args
 
-        val flatArgs = actualArgs.flatMap {
-          case t: tpd.SeqLiteral => t.elems
-          case e => List(e)
+        val flatArgs = actualArgs.flatMap { arg =>
+          normalizeArgument(arg) match {
+            case t: tpd.SeqLiteral => t.elems
+            case e => List(e)
+          }
         }
-        for(arg <- flatArgs) { emitArgument(arrAnnotV, null, arg, bcodeStore)(innerClasesStore) }
+        for(arg <- flatArgs) {
+          emitArgument(arrAnnotV, null, arg, bcodeStore)(innerClasesStore)
+        }
         arrAnnotV.visitEnd()
 /*
       case sb @ ScalaSigBytes(bytes) =>

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -506,7 +506,7 @@ object Flags {
     Accessor | AbsOverride | Stable | Captured | Synchronized
 
   /** Flags that can apply to a module class */
-  final val RetainedModuleClassFlags: FlagSet = RetainedModuleValAndClassFlags | ImplClass
+  final val RetainedModuleClassFlags: FlagSet = RetainedModuleValAndClassFlags | ImplClass | Enum
 
   /** Packages and package classes always have these flags set */
   final val PackageCreationFlags =

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -601,7 +601,7 @@ object JavaParsers {
       atPos(cdef.pos) {
         assert(cdef.pos.exists)
         ModuleDef(cdef.name.toTermName,
-          makeTemplate(List(), statics, List(), false)).withMods((cdef.mods & (Flags.AccessFlags | Flags.JavaDefined)).toTermFlags)
+          makeTemplate(List(), statics, List(), false)).withMods((cdef.mods & Flags.RetainedModuleClassFlags).toTermFlags)
       }
 
     def importCompanionObject(cdef: TypeDef): Tree =

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -25,7 +25,7 @@ import TypeUtils._
 /** A transformer that removes repeated parameters (T*) from all types, replacing
  *  them with Seq types.
  */
-class ElimRepeated extends MiniPhaseTransform with InfoTransformer with AnnotationTransformer { thisTransformer =>
+class ElimRepeated extends MiniPhaseTransform with InfoTransformer { thisTransformer =>
   import ast.tpd._
 
   override def phaseName = "elimRepeated"
@@ -74,9 +74,12 @@ class ElimRepeated extends MiniPhaseTransform with InfoTransformer with Annotati
     transformTypeOfTree(tree)
 
   override def transformApply(tree: Apply)(implicit ctx: Context, info: TransformerInfo): Tree = {
-    val formals = (tree.fun.tpe.widen: @unchecked) match {
-      case mt: MethodType => mt.paramInfos
-    }
+    val formals =
+      ctx.atPhase(thisTransformer) { implicit ctx =>
+        (tree.fun.tpe.widen: @unchecked) match {
+          case mt: MethodType => mt.paramInfos
+        }
+      }
     val args1 = tree.args.zipWithConserve(formals) { (arg, formal) =>
       arg match {
         case arg: Typed if isWildcardStarArg(arg) =>
@@ -111,13 +114,13 @@ class ElimRepeated extends MiniPhaseTransform with InfoTransformer with Annotati
   /** If method overrides a Java varargs method, add a varargs bridge.
    *  Also transform trees inside method annotation
    */
-  override def transformDefDef(tree: DefDef)(implicit ctx: Context, info: TransformerInfo): Tree = {
-    assert(ctx.phase == thisTransformer)
-    if (tree.symbol.info.isVarArgsMethod && overridesJava(tree.symbol))
-      addVarArgsBridge(tree)
-    else
-      tree
-  }
+  override def transformDefDef(tree: DefDef)(implicit ctx: Context, info: TransformerInfo): Tree =
+    ctx.atPhase(thisTransformer) { implicit ctx =>
+      if (tree.symbol.info.isVarArgsMethod && overridesJava(tree.symbol))
+        addVarArgsBridge(tree)
+      else
+        tree
+    }
 
   /** Add a Java varargs bridge
    *  @param  ddef  the original method definition which is assumed to override

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -5,7 +5,7 @@ import core._
 import Names._
 import StdNames.nme
 import Types._
-import dotty.tools.dotc.transform.TreeTransforms.{AnnotationTransformer, TransformerInfo, MiniPhaseTransform, TreeTransformer}
+import dotty.tools.dotc.transform.TreeTransforms.{TransformerInfo, MiniPhaseTransform, TreeTransformer}
 import ast.Trees._
 import Flags._
 import Contexts.Context

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -76,9 +76,7 @@ class ElimRepeated extends MiniPhaseTransform with InfoTransformer { thisTransfo
   override def transformApply(tree: Apply)(implicit ctx: Context, info: TransformerInfo): Tree = {
     val formals =
       ctx.atPhase(thisTransformer) { implicit ctx =>
-        (tree.fun.tpe.widen: @unchecked) match {
-          case mt: MethodType => mt.paramInfos
-        }
+        tree.fun.tpe.widen.asInstanceOf[MethodType].paramInfos
       }
     val args1 = tree.args.zipWithConserve(formals) { (arg, formal) =>
       arg match {

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -35,7 +35,7 @@ import StdNames._
  *          if (true) A else B    ==> A
  *          if (false) A else B   ==> B
  */
-class FirstTransform extends MiniPhaseTransform with InfoTransformer with AnnotationTransformer { thisTransformer =>
+class FirstTransform extends MiniPhaseTransform with InfoTransformer { thisTransformer =>
   import ast.tpd._
 
   override def phaseName = "firstTransform"


### PR DESCRIPTION
AnnotationTransformers were introducing quite a bit of irregularities

 - they designated only a few phases, but not others to run over annotations
 - they were forcing these phases to run at phase itself instead of phase.next,
    as is the standard.
 - the phase skew was enforced even for the normal run of phases that transformed
    annotations, not just when they transformed some annotation tree.

In the end, the only reason to transform annotation trees at all is to eliminate a couple of
tree forms when annotations got emitted: The eliminated forms were NamedArgs and 
Typed trees representing _* arguments. 

I believe it's conceptually simpler never to transform annotation trees and to deal with
the two added tree forms in emitArguments.

That way all transformations now run at phase + 1. 