### PR TITLE
Fix the synthetic-companion scripted test

### DIFF
--- a/sbt-dotty/sbt-test/source-dependencies/synthetic-companion/B.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/synthetic-companion/B.scala
@@ -1,3 +1,4 @@
 object B {
-  A(0)
+  val f: Int => A = A
+  f(0)
 }

--- a/sbt-dotty/sbt-test/source-dependencies/synthetic-companion/dbg.sbt
+++ b/sbt-dotty/sbt-test/source-dependencies/synthetic-companion/dbg.sbt
@@ -1,2 +1,0 @@
-logLevel := Level.Debug
-incOptions ~= { _.copy(apiDebug = true, relationsDebug = true) }


### PR DESCRIPTION
As documented in `./test`, compilation should fail because `object A` is no
longer a subclass of `Int => A`, but `B.scala` did not actually check
that previously, so compilation always succeeded.