### PR TITLE
Fix #3343: Make baseType work properly with type lambdas

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1646,13 +1646,11 @@ object SymDenotations {
           case tp @ AppliedType(tycon, args) =>
             val subsym = tycon.typeSymbol
             if (subsym eq symbol) tp
-            else subsym.denot match {
-              case clsd: ClassDenotation =>
-                val tparams = clsd.typeParams
-                if (tparams.hasSameLengthAs(args)) baseTypeOf(tycon).subst(tparams, args)
-                else NoType
-              case _ =>
+            else tycon.typeParams match {
+              case LambdaParam(_, _) :: _ =>
                 baseTypeOf(tp.superType)
+              case tparams: List[Symbol @unchecked] =>
+                baseTypeOf(tycon).subst(tparams, args)
             }
           case tp: TypeProxy =>
             baseTypeOf(tp.superType)

--- a/tests/pos/i3343.scala
+++ b/tests/pos/i3343.scala
@@ -1,0 +1,5 @@
+object Test {
+  def foo[C[_]](implicit t: C[Char] => Traversable[Char]): C[Char] = ???
+
+  val a: List[Char] = foo
+}


### PR DESCRIPTION
Previously,
```scala
    `C[Char]`.baseTypeOf(`Traversable[Char]`)
    where C := `[X] => List[X]`
```
returned `Traversable[ParamRef(A)]` instead of `Traversable[Char]`,
because the substitution was done on the type parameters of the class
symbol instead of the type parameters of the type, these are different
when type lambdas are involved.