### PR TITLE
Fix #2961: Scale logo size on home page with screen size

### DIFF
--- a/docs/css/default.css
+++ b/docs/css/default.css
@@ -143,11 +143,10 @@ div#header li.nav-item > a.nav-link {
 }
 
 div.scala-logo-container {
-    width: 232px;
-    height: calc(400px + 13em);
+    height: calc(100vh - 80px);
     margin: auto;
     position: absolute;
-    top: 0; right: 0; bottom: 0; left: 0;
+    top: 80px; right: 0; bottom: 0; left: 0;
 }
 
 div.scala-logo-container > p {
@@ -158,21 +157,25 @@ div.scala-logo-container > p {
 }
 
 div.scala-logo-container > p > img {
-    width: 100%;
-    height: auto;
+    max-width: 100%;
+    height: 60%;
+    display: block;
 }
 
 h1#dotty {
     font-family: 'Source Sans Pro', sans-serif;
     font-weight: 700;
     text-align: center;
-    font-size: 3.5em;
+    font-size: 10vh;
     margin-top: 20px;
 }
 
 div.centered-subtitle {
     text-align: center;
     font-family: 'Source Sans Pro', sans-serif;
+    position: absolute;
+    bottom: 0;
+    width: 100%;
 }
 
 div.centered-subtitle > a {
@@ -181,6 +184,10 @@ div.centered-subtitle > a {
 
 div.centered-subtitle > a > i#scroll-down-arrow {
     font-size: 3em;
+}
+
+div.centered-subtitle > p {
+    font-size: 3vh;
 }
 
 pre {
@@ -446,6 +453,10 @@ screen /* Most mobile devices  */
 and (max-device-width: 480px)
 and (orientation: portrait)
 ,
+screen /* Most mobile devices, landscape */
+and (max-device-height: 450px)
+and (orientation: landscape)
+,
 only screen /* iPhone 6 */
 and (max-device-width: 667px)
 and (-webkit-device-pixel-ratio: 2)
@@ -510,13 +521,12 @@ and (-webkit-device-pixel-ratio: 2)
     }
 
     div.scala-logo-container {
-        width: 40%;
         height: 84%;
         top: 70px;
     }
 
-    #content > div.page.red.exactly-one-page > div.scala-logo-container > div > p {
-        font-size: 0.8em;
+    div.scala-logo-container > p > img {
+        height: 50%;
     }
 
     /* Feature */


### PR DESCRIPTION
Changes the logo and slogan styling to scale based on screen height. This produces more suitable results on different screen sizes.

Also adds a height threshold to show mobile UI (previously, a wide but short window would not trigger the mobile UI, so the site wouldn't look very good viewing landscape on a phone).

1920x1200px (computer, high-res)
![dotty-1920x1200](https://user-images.githubusercontent.com/6363768/31697903-55cec136-b388-11e7-967c-7cfac961527e.PNG)

1280x800px (computer, low-res)
![dotty-1280x800](https://user-images.githubusercontent.com/6363768/31697901-55781be2-b388-11e7-9fd4-24739d3e27af.PNG)

360x640px (phone, portrait)
![dotty-360x640](https://user-images.githubusercontent.com/6363768/31697899-53d579d8-b388-11e7-8dbd-67d8098a5552.PNG)

640x360px (phone, landscape)
![dotty-640x360](https://user-images.githubusercontent.com/6363768/31697900-54f5bb8e-b388-11e7-9869-941a43f22971.PNG)

I've tested this change with many other different screen sizes within Chrome as well, with good results.