### PR TITLE
Fix #2732: Allow wildcards in SAM types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3717,16 +3717,8 @@ object Types {
       case _ =>
         NoType
     }
-    def isInstantiatable(tp: Type)(implicit ctx: Context): Boolean = zeroParamClass(tp) match {
-      case cinfo: ClassInfo =>
-        val tref = tp.narrow
-        val selfType = cinfo.selfType.asSeenFrom(tref, cinfo.cls)
-        tref <:< selfType
-      case _ =>
-        false
-    }
     def unapply(tp: Type)(implicit ctx: Context): Option[SingleDenotation] =
-      if (isInstantiatable(tp)) {
+      if (zeroParamClass(tp).exists) {
         val absMems = tp.abstractTermMembers
         // println(s"absMems: ${absMems map (_.show) mkString ", "}")
         if (absMems.size == 1)

--- a/tests/pos/i2732.scala
+++ b/tests/pos/i2732.scala
@@ -1,0 +1,8 @@
+object Foo {
+  // Example 1
+  val fun: java.util.function.Function[String, _ <: String] = x => x
+
+  // Example 2
+  val map = new java.util.HashMap[String, String]
+  map.computeIfAbsent("hello", foo => "world")
+}


### PR DESCRIPTION
The `isInstantiable` test as written is incorrect:
Given tp = `java.util.function.Function[String, _ <: String]`, we will have:
    tref = skolem TermRef with underlying info `tp`
    selfType = `java.util.function.Function[String, tref#R]` (because of the `asSeenFrom`)
`tref <:< selfType` is false, because `tref.underlying` is
just `tp` and its return type parameter is a bounded wildcard, not a reference with
`tref` as a prefix.
In any case, I cannot think of a case where this function should return
false, and no test failed when I removed it. So I'm removing it until
someone can come up with a counter-example.