### PR TITLE
Make vulpix diff readable

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/DiffUtil.scala
+++ b/compiler/src/dotty/tools/dotc/util/DiffUtil.scala
@@ -82,13 +82,6 @@ object DiffUtil {
         case Deleted(_) => ""
       }.mkString
 
-      val expectedDiffSize = diff.collect {
-        case Unmodified(str) => str.length
-        case Inserted(str) => str.length
-        case Modified(_, str) => str.length
-        case Deleted(_) => 0
-      }.sum
-
       val actualDiff = diff.collect {
         case Unmodified(str) => str
         case Inserted(_) => ""
@@ -98,7 +91,7 @@ object DiffUtil {
           DELETION_COLOR + str + ANSI_DEFAULT
       }.mkString
 
-      expectedDiff + (" " * (60 - expectedDiffSize).max(0)) + "|   " + actualDiff
+      expectedDiff + (" " * (60 - expected.length).max(0)) + "|   " + actualDiff
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/util/DiffUtil.scala
+++ b/compiler/src/dotty/tools/dotc/util/DiffUtil.scala
@@ -61,7 +61,7 @@ object DiffUtil {
     (fnd, exp, totalChange.toDouble / (expected.length + found.length))
   }
 
-  def mkColoredLineDiff(expected: String, actual: String): String = {
+  def mkColoredLineDiff(expected: String, actual: String, expectedSize: Int): String = {
     lazy val diff = {
       val tokens = splitTokens(expected, Nil).toArray
       val lastTokens = splitTokens(actual, Nil).toArray
@@ -90,9 +90,9 @@ object DiffUtil {
           DELETION_COLOR + str + ANSI_DEFAULT
       }.mkString
 
-    val pad = " " * (60 - expected.length).max(0)
+    val pad = " " * 0.max(expectedSize - expected.length)
 
-    expectedDiff + pad + "| " + actualDiff
+    expectedDiff + pad + "  |  " + actualDiff
   }
 
   def mkColoredCodeDiff(code: String, lastCode: String, printDiffDel: Boolean): String = {

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -511,7 +511,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
 
           if (outputLines.length != checkLines.length || !linesMatch) {
             // Print diff to files and summary:
-            val expectedSize = DiffUtil.EOF.length max outputLines.map(_.length).max
+            val expectedSize = DiffUtil.EOF.length max checkLines.map(_.length).max
             val diff = outputLines.padTo(checkLines.length, "").zip(checkLines.padTo(outputLines.length, "")).map { case (act, exp) =>
               DiffUtil.mkColoredLineDiff(exp, act, expectedSize)
             }.mkString("\n")

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -500,8 +500,8 @@ trait ParallelTesting extends RunnerOrchestration { self =>
       else runMain(testSource.runClassPath) match {
         case Success(_) if !checkFile.isDefined || !checkFile.get.exists => // success!
         case Success(output) => {
-          val outputLines = output.lines.toArray
-          val checkLines: Array[String] = Source.fromFile(checkFile.get).getLines().toArray
+          val outputLines = output.lines.toArray :+ DiffUtil.EOF
+          val checkLines: Array[String] = Source.fromFile(checkFile.get).getLines().toArray :+ DiffUtil.EOF
           val sourceTitle = testSource.title
 
           def linesMatch =
@@ -512,7 +512,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
           if (outputLines.length != checkLines.length || !linesMatch) {
             // Print diff to files and summary:
             val expectedSize = DiffUtil.EOF.length max outputLines.map(_.length).max
-            val diff = (outputLines :+ DiffUtil.EOF).zip(checkLines :+ DiffUtil.EOF).map { case (act, exp) =>
+            val diff = outputLines.padTo(checkLines.length, "").zip(checkLines.padTo(outputLines.length, "")).map { case (act, exp) =>
               DiffUtil.mkColoredLineDiff(exp, act, expectedSize)
             }.mkString("\n")
 

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -511,8 +511,9 @@ trait ParallelTesting extends RunnerOrchestration { self =>
 
           if (outputLines.length != checkLines.length || !linesMatch) {
             // Print diff to files and summary:
+            val expectedSize = DiffUtil.EOF.length max outputLines.map(_.length).max
             val diff = (outputLines :+ DiffUtil.EOF).zip(checkLines :+ DiffUtil.EOF).map { case (act, exp) =>
-              DiffUtil.mkColoredLineDiff(exp, act)
+              DiffUtil.mkColoredLineDiff(exp, act, expectedSize)
             }.mkString("\n")
 
             val msg =

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -511,13 +511,14 @@ trait ParallelTesting extends RunnerOrchestration { self =>
 
           if (outputLines.length != checkLines.length || !linesMatch) {
             // Print diff to files and summary:
-            val diff = outputLines.zip(checkLines).map { case (act, exp) =>
-              DiffUtil.mkColoredLineDiff(exp, act)
+            import DiffUtil._
+            val diff = (outputLines :+ NO_NEW_LINE).zip(checkLines :+ NO_NEW_LINE).map { case (act, exp) =>
+              mkColoredLineDiff(exp, act)
             }.mkString("\n")
 
             val msg =
               s"""|Output from '$sourceTitle' did not match check file.
-                  |Diff ('e' is expected, 'a' is actual):
+                  |Diff (expected on the left, actual right):
                   |""".stripMargin + diff + "\n"
             echo(msg)
             addFailureInstruction(msg)

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -511,9 +511,8 @@ trait ParallelTesting extends RunnerOrchestration { self =>
 
           if (outputLines.length != checkLines.length || !linesMatch) {
             // Print diff to files and summary:
-            import DiffUtil._
-            val diff = (outputLines :+ NO_NEW_LINE).zip(checkLines :+ NO_NEW_LINE).map { case (act, exp) =>
-              mkColoredLineDiff(exp, act)
+            val diff = (outputLines :+ DiffUtil.EOF).zip(checkLines :+ DiffUtil.EOF).map { case (act, exp) =>
+              DiffUtil.mkColoredLineDiff(exp, act)
             }.mkString("\n")
 
             val msg =


### PR DESCRIPTION
This will print the diff of the vulpix outputs in two colored columns starting at the beginning and ending at the first `EOF` found.