### PR TITLE
Fix #3348: use a new typeState in inferView

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2224,9 +2224,11 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         if (isFullyDefined(wtp, force = ForceDegree.all) &&
             ctx.typerState.constraint.ne(prevConstraint)) adapt(tree, pt)
         else err.typeMismatch(tree, pt, failure)
-      if (ctx.mode.is(Mode.ImplicitsEnabled))
-        inferView(tree, pt) match {
+      if (ctx.mode.is(Mode.ImplicitsEnabled)) {
+        val nestedCtx = ctx.fresh.setNewTyperState()
+        inferView(tree, pt)(nestedCtx) match {
           case SearchSuccess(inferred, _, _, _) =>
+            nestedCtx.typerState.commit()
             adapt(inferred, pt)(ctx.retractMode(Mode.ImplicitsEnabled))
           case failure: SearchFailure =>
             if (pt.isInstanceOf[ProtoType] && !failure.isInstanceOf[AmbiguousImplicits])
@@ -2236,6 +2238,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
               tree
             else recover(failure)
         }
+      }
       else recover(NoImplicitMatches)
     }
 

--- a/tests/neg/i3348.scala
+++ b/tests/neg/i3348.scala
@@ -1,0 +1,10 @@
+class Test {
+  import Test.test
+  "Hello".toto     // error
+}
+
+object Test {
+  def test = {
+    implicitly[collection.generic.CanBuildFrom[List[Int], Int, List[Int]]]
+  }
+}


### PR DESCRIPTION
Fix #3348

`inferImplicit` has a useful invariant that the constraint doesn't
change in the case of implicit resolution failure. However, this
invariant may not hold if completions are triggered during implicit resolution.
By create a new typeState for inferView, we ensure that the useful
invariant holds in such cases.