### PR TITLE
Fix #3352: defaults parameters require named type in compatibility check

### DIFF
--- a/tests/pos/i3352.scala
+++ b/tests/pos/i3352.scala
@@ -1,0 +1,13 @@
+class Test {
+  class Foo {
+    def bar(x: String): Int = 1
+  }
+
+  implicit class FooOps(foo: Foo) {
+    def bar(x: Int, y: Int = 2): Int = 2 // compiles with no default argument
+  }
+
+  def test(foo: Foo): Unit = {
+    foo.bar(1)
+  }
+}


### PR DESCRIPTION
Fix #3352: defaults parameters require named type in compatibility check
