### PR TITLE
Add error message for companion and class/module name clash

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -103,6 +103,7 @@ public enum ErrorMessageID {
     ExtendFinalClassID,
     EnumCaseDefinitionInNonEnumOwnerID,
     ExpectedTypeBoundOrEqualsID,
+    ClassAndCompanionNameClashID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1804,4 +1804,14 @@ object messages {
            |refers to a subtype of type ${"A"}.
            |"""
   }
+
+  case class ClassAndCompanionNameClash(cls: Symbol)(implicit ctx: Context)
+    extends Message(ClassAndCompanionNameClashID) {
+    val kind = "Syntax"
+    val msg = hl"Naming clash, ${cls.owner} and it's companion object defines $cls"
+    val explanation =
+      s"""It is not allowed to define a class or module with the same
+        |name inside a class and companion object.
+      """
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1805,13 +1805,16 @@ object messages {
            |"""
   }
 
-  case class ClassAndCompanionNameClash(cls: Symbol)(implicit ctx: Context)
+  case class ClassAndCompanionNameClash(cls: Symbol, other: Symbol)(implicit ctx: Context)
     extends Message(ClassAndCompanionNameClashID) {
-    val kind = "Syntax"
-    val msg = hl"Naming clash, ${cls.owner} and it's companion object defines $cls"
-    val explanation =
-      s"""It is not allowed to define a class or module with the same
-        |name inside a class and companion object.
-      """
+    val kind = "Naming"
+    val msg = hl"Name clash: both ${cls.owner} and its companion object defines ${cls.name}"
+    val explanation = {
+      val kind = if (cls.owner.is(Flags.Trait)) "trait" else "class"
+
+      hl"""|A $kind and its companion object cannot both define a ${"class"}, ${"trait"} or ${"object"} with the same name:
+           |  - ${cls.owner} defines ${cls}
+           |  - ${other.owner} defines ${other}"""
+      }
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -113,9 +113,9 @@ object RefChecks {
    */
   private def checkCompanionNameClashes(cls: Symbol)(implicit ctx: Context): Unit =
     if (!(cls.owner is ModuleClass)) {
-      val other = cls.owner.linkedClass.info.decl(cls.name)
-      if (other.symbol.isClass)
-        ctx.error(ClassAndCompanionNameClash(cls))
+      val other = cls.owner.linkedClass.info.decl(cls.name).symbol
+      if (other.isClass)
+        ctx.error(ClassAndCompanionNameClash(cls, other), cls.pos)
     }
 
   // Override checking ------------------------------------------------------------

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -115,9 +115,7 @@ object RefChecks {
     if (!(cls.owner is ModuleClass)) {
       val other = cls.owner.linkedClass.info.decl(cls.name)
       if (other.symbol.isClass)
-        ctx.error(s"name clash: ${cls.owner} defines $cls" + "\n" +
-          s"and its companion ${cls.owner.companionModule} also defines $other",
-          cls.pos)
+        ctx.error(ClassAndCompanionNameClash(cls))
     }
 
   // Override checking ------------------------------------------------------------

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1043,19 +1043,21 @@ class ErrorMessagesTests extends ErrorMessagesTest {
     checkMessagesAfter("refchecks") {
       """
         |class T {
-        |  class G {}
+        |  trait G
         |}
         |object T {
-        |  class G {}
+        |  trait G
         |}
       """.stripMargin
     }.expect { (ictx, messages) =>
       implicit val ctx: Context = ictx
 
       assertMessageCount(1, messages)
-      val ClassAndCompanionNameClash(symbol) :: Nil = messages
+      val ClassAndCompanionNameClash(cls, other) :: Nil = messages
 
-      assertEquals("class T", symbol.owner.show)
-      assertEquals("class G", symbol.show)
+      assertEquals("trait G", cls.show)
+      assertEquals("trait G", other.show)
+      assertEquals("class T", cls.owner.show)
+      assertEquals("object T", other.owner.show)
     }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1038,4 +1038,24 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         val ExpectedTypeBoundOrEquals(found) :: Nil = messages
         assertEquals(Tokens.IDENTIFIER, found)
       }
+
+  @Test def classAndCompanionNameClash =
+    checkMessagesAfter("refchecks") {
+      """
+        |class T {
+        |  class G {}
+        |}
+        |object T {
+        |  class G {}
+        |}
+      """.stripMargin
+    }.expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+      val ClassAndCompanionNameClash(symbol) :: Nil = messages
+
+      assertEquals("class T", symbol.owner.show)
+      assertEquals("class G", symbol.show)
+    }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1043,7 +1043,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
     checkMessagesAfter("refchecks") {
       """
         |class T {
-        |  trait G
+        |  class G
         |}
         |object T {
         |  trait G
@@ -1055,9 +1055,10 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertMessageCount(1, messages)
       val ClassAndCompanionNameClash(cls, other) :: Nil = messages
 
-      assertEquals("trait G", cls.show)
-      assertEquals("trait G", other.show)
       assertEquals("class T", cls.owner.show)
+      assertEquals("class G", cls.show)
       assertEquals("object T", other.owner.show)
+      assertEquals("trait G", other.show)
+
     }
 }


### PR DESCRIPTION
Add error message inside `RefChecks.scala` for companion and class or module naming clash.
This is related to #1589

@felixmulder please review