### PR TITLE
Make rarely updated context fields elements of the store

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -170,7 +170,7 @@ object Config {
    *  dotty itself only causes small pending names lists to be generated (we measured
    *  at max 6 elements) and these lists are never searched with contains.
    */
-  final val LogPendingFindMemberThreshold = 10
+  final val LogPendingFindMemberThreshold = 9
 
   /** Maximal number of outstanding recursive calls to findMember before backing out
    *  when findMemberLimit is set.

--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -263,7 +263,7 @@ class PathResolver(implicit ctx: Context) {
     val cp = AggregateClassPath(containers.toIndexedSeq)
 
     if (settings.Ylogcp.value) {
-      Console.println("Classpath built from " + settings.toConciseString(ctx.sstate))
+      Console.println("Classpath built from " + settings.toConciseString(ctx.settingsState))
       Console.println("Defaults: " + PathResolver.Defaults)
       Console.println("Calculated: " + Calculated)
 

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -180,9 +180,9 @@ object Settings {
 
   object Setting {
     implicit class SettingDecorator[T](val setting: Setting[T]) extends AnyVal {
-      def value(implicit ctx: Context): T = setting.valueIn(ctx.sstate)
-      def update(x: T)(implicit ctx: Context): SettingsState = setting.updateIn(ctx.sstate, x)
-      def isDefault(implicit ctx: Context): Boolean = setting.isDefaultIn(ctx.sstate)
+      def value(implicit ctx: Context): T = setting.valueIn(ctx.settingsState)
+      def update(x: T)(implicit ctx: Context): SettingsState = setting.updateIn(ctx.settingsState, x)
+      def isDefault(implicit ctx: Context): Boolean = setting.isDefaultIn(ctx.settingsState)
     }
   }
 
@@ -248,7 +248,7 @@ object Settings {
     }
 
     def processArguments(arguments: List[String], processAll: Boolean)(implicit ctx: Context): ArgsSummary =
-      processArguments(ArgsSummary(ctx.sstate, arguments, Nil, Nil), processAll, Nil)
+      processArguments(ArgsSummary(ctx.settingsState, arguments, Nil, Nil), processAll, Nil)
 
     def publish[T](settingf: Int => Setting[T]): Setting[T] = {
       val setting = settingf(_allSettings.length)

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -328,7 +328,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
 object TypeOps {
   @sharable var track = false // !!!DEBUG
 
-  /** When a property with this key is set in a context, it limit the number
+  /** When a property with this key is set in a context, it limits the number
    *  of recursive member searches. If the limit is reached, findMember returns
    *  NoDenotation.
    */

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -632,16 +632,14 @@ object Types {
         go(l) & (go(r), pre, safeIntersection = ctx.pendingMemberSearches.contains(name))
       }
 
-      { val recCount = ctx.findMemberCount + 1
-        ctx.findMemberCount = recCount
-        if (recCount >= Config.LogPendingFindMemberThreshold) {
-          ctx.pendingMemberSearches = name :: ctx.pendingMemberSearches
-          if (ctx.property(TypeOps.findMemberLimit).isDefined &&
-              ctx.findMemberCount > Config.PendingFindMemberLimit)
-            return NoDenotation
-        }
+      val recCount = ctx.findMemberCount
+      if (recCount >= Config.LogPendingFindMemberThreshold) {
+        if (ctx.property(TypeOps.findMemberLimit).isDefined &&
+            ctx.findMemberCount > Config.PendingFindMemberLimit)
+          return NoDenotation
+        ctx.pendingMemberSearches = name :: ctx.pendingMemberSearches
       }
-
+      ctx.findMemberCount = recCount + 1
       //assert(ctx.findMemberCount < 20)
       try go(this)
       catch {
@@ -650,10 +648,9 @@ object Types {
           throw ex // DEBUG
       }
       finally {
-        val recCount = ctx.findMemberCount
         if (recCount >= Config.LogPendingFindMemberThreshold)
           ctx.pendingMemberSearches = ctx.pendingMemberSearches.tail
-        ctx.findMemberCount = recCount - 1
+        ctx.findMemberCount = recCount
       }
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -15,7 +15,6 @@ import ast.Trees._
 import SymUtils._
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Phases.Phase
-import util.Property
 
 import collection.mutable
 import scala.annotation.tailrec
@@ -37,8 +36,6 @@ import scala.annotation.tailrec
 class ExplicitOuter extends MiniPhase with InfoTransformer { thisPhase =>
   import ExplicitOuter._
   import ast.tpd._
-
-  val Outer = new Property.Key[Tree]
 
   override def phaseName: String = "explicitOuter"
 


### PR DESCRIPTION
This avoids copying them with the rest of the context, so it should save space.

Based on #3366