### PR TITLE
Fix reproduction steps for `JointCompilationSource`

### DIFF
--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -98,8 +98,8 @@ trait ParallelTesting extends RunnerOrchestration { self =>
       }
 
       self match {
-        case JointCompilationSource(_, files, _, _) => {
-          files.map(_.getAbsolutePath).foreach { path =>
+        case source: JointCompilationSource => {
+          source.sourceFiles.map(_.getAbsolutePath).foreach { path =>
             sb.append("\\\n        ")
             sb.append(path)
             sb += ' '


### PR DESCRIPTION
When a compilation test that used a `JointCompilationSource` would fail,
the test framework would generate reproduction instructions that could
potentially include files that were not source-files, thus preventing
people from simply copy-pasting the reproduction.