### PR TITLE
Fix #3381: handle case of lub and glb of types with different kinds

### DIFF
--- a/tests/pos/i3381.scala
+++ b/tests/pos/i3381.scala
@@ -1,0 +1,8 @@
+case class Tuple2K[X, A[_], B[_]](a: A[X], b: B[X])
+
+object Test {
+  def f[X](x: Tuple2K[X, Option, [Y] => Tuple2K[Y, Option, Option]]): Any =
+    x match {
+      case Tuple2K(_, Tuple2K(_, _)) => ???
+    }
+}


### PR DESCRIPTION
When forming the lub and glb of two types with different numbers of type
parameters, this crashed provided neither parameter list was empty. We
now treat this analogous to the case where one of the types is a * type,
by applying both types to their parameter references.