### PR TITLE
Fix #3352: Avoid widening method TermRefs in compatibility checks

### DIFF
--- a/tests/pending/neg/i3253.scala
+++ b/tests/pending/neg/i3253.scala
@@ -1,0 +1,5 @@
+import Test.test
+
+object Test {
+  def test = "  " * 10
+}

--- a/tests/pos/i3352.scala
+++ b/tests/pos/i3352.scala
@@ -1,0 +1,13 @@
+class Test {
+  class Foo {
+    def bar(x: String): Int = 1
+  }
+
+  implicit class FooOps(foo: Foo) {
+    def bar(x: Int, y: Int = 2): Int = 2 // compiles with no default argument
+  }
+
+  def test(foo: Foo): Unit = {
+    foo.bar(1)
+  }
+}


### PR DESCRIPTION
When normalizing for a compatibility check we should keep a method reference
instead of its widened method type as long as possible. This is because only
method references know about default arguments, once we widen to a method type
default arguments are no longer taken into account.

Supersedes #3357, from which it takes the essential solution idea.