### PR TITLE
set bench output to be stdout without prefix

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -239,6 +239,7 @@ object Build {
   )
 
   lazy val commonBenchmarkSettings = Seq(
+    outputStrategy := Some(StdoutOutput),
     mainClass in (Jmh, run) := Some("dotty.tools.benchmarks.Bench"), // custom main for jmh:run
     javaOptions += "-DBENCH_CLASS_PATH=" + Attributed.data((fullClasspath in Compile).value).mkString("", ":", "")
   )


### PR DESCRIPTION
The scripts have a hard time with prefixes
like "[info]" which has brackets in the string.

I tested locally, it indeed works.

Relevant sbt docs: http://www.scala-sbt.org/release/docs/Forking.html