### PR TITLE
Add an error message class for the method's missing arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -105,6 +105,7 @@ public enum ErrorMessageID {
     ExpectedTypeBoundOrEqualsID,
     ClassAndCompanionNameClashID,
     TailrecNotApplicableID,
+    MissingEmptyArgumentListForMethodID,
     FailureToEliminateExistentialID,
     OnlyFunctionsCanBeFollowedByUnderscoreID
     ;

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1847,4 +1847,35 @@ object messages {
       hl"""The syntax ${"x _"} is no longer supported if ${"x"} is not a function.
           |To convert to a function value, you need to explicitly write ${"() => x"}"""
   }
+
+  case class MissingEmptyArgumentListForMethod(method: Symbol, methodStr: String)(implicit ctx: Context)
+    extends Message(MissingEmptyArgumentListForMethodID) {
+    val kind: String = "Syntax"
+    val msg: String = hl"$methodStr must be called with an empty argument list"
+    val explanation: String = {
+      val codeExample =
+        """
+          |def next(): T = ...
+          |next     // is expanded to next()
+        """
+      val errorMessage =
+        """
+          |next
+          |^^^^
+          |method next must be called with an empty argument list
+        """
+      hl"""
+          |Previously an empty argument list () was implicitly inserted when calling a nullary method without arguments. E.g.
+          |
+          |$codeExample
+          |
+          |In Dotty, this idiom is an error which leads to the following message:
+          |
+          |$errorMessage
+          |
+          |In Dotty, the application syntax has to follow exactly the parameter syntax.
+          |Excluded from this rule are methods that are defined in Java or that override methods defined in Java.
+        """
+    }
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1908,7 +1908,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     def methodStr = err.refStr(methPart(tree).tpe)
 
     def missingArgs(mt: MethodType) = {
-      ctx.error(em"missing arguments for $methodStr", tree.pos)
+      ctx.error(MissingEmptyArgumentListForMethod(methPart(tree).symbol, methodStr), tree.pos)
       tree.withType(mt.resultType)
     }
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1052,6 +1052,25 @@ class ErrorMessagesTests extends ErrorMessagesTest {
 
     }
 
+  @Test def missingEmptyArgumentListForMethod =
+    checkMessagesAfter("frontend") {
+      """
+        |class Test {
+        |  def greet(): String = "Hello"
+        |  def main(args: Array[String]): Unit = {
+        |    greet
+        |  }
+        |}
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+      val MissingEmptyArgumentListForMethod(method, _) :: Nil = messages
+      assertEquals("method greet", method.show)
+    }
+
   @Test def onlyFunctionsCanBeFollowedByUnderscore =
     checkMessagesAfter("frontend") {
       """


### PR DESCRIPTION
This PR is related to #1589. Specifically, it adds a new error message class for the following case `Typer.scala:1898 (def missingArgs)`