### PR TITLE
Add an error message class for a function underscore case

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -105,7 +105,8 @@ public enum ErrorMessageID {
     ExpectedTypeBoundOrEqualsID,
     ClassAndCompanionNameClashID,
     TailrecNotApplicableID,
-    FailureToEliminateExistentialID
+    FailureToEliminateExistentialID,
+    OnlyFunctionsCanBeFollowedByUnderscoreID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1838,4 +1838,11 @@ object messages {
           |type used instead: $tp2"""
     }
   }
+
+  case class OnlyFunctionsCanBeFollowedByUnderscore(pt: Type)(implicit ctx: Context)
+    extends Message(OnlyFunctionsCanBeFollowedByUnderscoreID) {
+    val kind = "Syntax"
+    val msg = hl"not a function: $pt; cannot be followed by `_'"
+    val explanation = ""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1842,7 +1842,9 @@ object messages {
   case class OnlyFunctionsCanBeFollowedByUnderscore(pt: Type)(implicit ctx: Context)
     extends Message(OnlyFunctionsCanBeFollowedByUnderscoreID) {
     val kind = "Syntax"
-    val msg = hl"not a function: $pt; cannot be followed by `_'"
-    val explanation = ""
+    val msg = hl"Not a function: $pt: cannot be followed by ${"_"}"
+    val explanation =
+      hl"""The syntax ${"x _"} is no longer supported if ${"x"} is not a function.
+          |To convert to a function value, you need to explicitly write ${"() => x"}"""
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1550,7 +1550,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     val pt1 = if (defn.isFunctionType(pt)) pt else AnyFunctionProto
     var res = typed(qual, pt1)
     if (pt1.eq(AnyFunctionProto) && !defn.isFunctionClass(res.tpe.classSymbol)) {
-      ctx.errorOrMigrationWarning(i"not a function: ${res.tpe}; cannot be followed by `_'", tree.pos)
+      ctx.errorOrMigrationWarning(OnlyFunctionsCanBeFollowedByUnderscore(res.tpe), tree.pos)
       if (ctx.scala2Mode) {
         // Under -rewrite, patch `x _` to `(() => x)`
         patch(Position(tree.pos.start), "(() => ")

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1066,9 +1066,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
 
       assertMessageCount(1, messages)
-
       val OnlyFunctionsCanBeFollowedByUnderscore(pt) :: Nil = messages
-
       assertEquals("String(n)", pt.show)
     }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1051,4 +1051,24 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("trait G", other.show)
 
     }
+
+  @Test def onlyFunctionsCanBeFollowedByUnderscore =
+    checkMessagesAfter("frontend") {
+      """
+        |class T {
+        |  def main(args: Array[String]): Unit = {
+        |   val n = "T"
+        |   val func = n _
+        |  }
+        |}
+      """.stripMargin
+    }.expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+
+      val OnlyFunctionsCanBeFollowedByUnderscore(pt) :: Nil = messages
+
+      assertEquals("String(n)", pt.show)
+    }
 }


### PR DESCRIPTION
This PR is related to #1589. Specifically, it adds a new error message class for the following case `Typer.scala:1555` (`ctx.errorOrMigrationWarning(i"not a function: ${res.tpe}; cannot be followed by _", tree.pos)`)