### PR TITLE
Fix wrong word usage. Replace 'constructors' with 'constructs'.

### DIFF
--- a/docs/_includes/faq.html
+++ b/docs/_includes/faq.html
@@ -6,7 +6,7 @@
             technologies for Scala. The focus is mainly on simplification. We
             remove extraneous syntax (e.g. no XML literals), and try to boil
             down Scala’s types into a smaller set of more fundamental
-            constructors. The theory behind these constructors is researched in
+            constructs. The theory behind these constructs is researched in
             <a href="https://infoscience.epfl.ch/record/215280">DOT</a>, a
             calculus for dependent object types.
         </p>

--- a/docs/blog/_posts/2017-09-07-third-dotty-milestone-release.md
+++ b/docs/blog/_posts/2017-09-07-third-dotty-milestone-release.md
@@ -13,7 +13,7 @@ and the compiler supporting them.
 If you’re not familiar with Dotty, it's a platform to try out new language concepts and compiler
 technologies for Scala. The focus is mainly on simplification. We remove extraneous syntax
 (e.g. no XML literals), and try to boil down Scala’s types into a smaller set of more fundamental
-constructors. The theory behind these constructors is researched in
+constructs. The theory behind these constructs is researched in
 [DOT](https://infoscience.epfl.ch/record/215280), a calculus for dependent object types.
 You can learn more about Dotty on our [website](http://dotty.epfl.ch).
 

--- a/docs/blog/_posts/2017-10-16-fourth-dotty-milestone-release.md
+++ b/docs/blog/_posts/2017-10-16-fourth-dotty-milestone-release.md
@@ -13,7 +13,7 @@ and the compiler supporting them.
 If you’re not familiar with Dotty, it's a platform to try out new language concepts and compiler
 technologies for Scala. The focus is mainly on simplification. We remove extraneous syntax
 (e.g. no XML literals), and try to boil down Scala’s types into a smaller set of more fundamental
-constructors. The theory behind these constructors is researched in
+constructs. The theory behind these constructs is researched in
 [DOT](https://infoscience.epfl.ch/record/215280), a calculus for dependent object types.
 You can learn more about Dotty on our [website](http://dotty.epfl.ch).
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -5,8 +5,8 @@ title: "Dotty Documentation"
 
 Dotty is a platform to try out new language concepts and compiler technologies for Scala.
 The focus is mainly on simplification. We remove extraneous syntax (e.g. no XML literals),
-and try to boil down Scala’s types into a smaller set of more fundamental constructors.
-The theory behind these constructors is researched in DOT, a calculus for dependent object types.
+and try to boil down Scala’s types into a smaller set of more fundamental constructs.
+The theory behind these constructs is researched in DOT, a calculus for dependent object types.
 
 In this documentation you will find information on how to use the Dotty compiler on your machine, navigate through
 the code, setup Dotty with your favorite IDE and more!


### PR DESCRIPTION
Discovered this problem while discussing Dotty with @sarkologist.
Discussion: https://gitter.im/lampepfl/dotty?at=59f6b1e7210ac2692049565c