### PR TITLE
 Add error message for missing () argument list

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -17,6 +17,7 @@ import util.Property
 import collection.mutable
 import ast.tpd._
 import reporting.trace
+import reporting.diagnostic.Message
 
 trait TypeOps { this: Context => // TODO: Make standalone object.
 
@@ -315,7 +316,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
   def dynamicsEnabled =
     featureEnabled(defn.LanguageModuleClass, nme.dynamics)
 
-  def testScala2Mode(msg: => String, pos: Position, rewrite: => Unit = ()) = {
+  def testScala2Mode(msg: => Message, pos: Position, rewrite: => Unit = ()) = {
     if (scala2Mode) {
       migrationWarning(msg, pos)
       rewrite

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -107,7 +107,7 @@ public enum ErrorMessageID {
     TailrecNotApplicableID,
     FailureToEliminateExistentialID,
     OnlyFunctionsCanBeFollowedByUnderscoreID,
-    MissingArgumentsForMethodID
+    MissingEmptyArgumentListID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -106,7 +106,8 @@ public enum ErrorMessageID {
     ClassAndCompanionNameClashID,
     TailrecNotApplicableID,
     FailureToEliminateExistentialID,
-    OnlyFunctionsCanBeFollowedByUnderscoreID
+    OnlyFunctionsCanBeFollowedByUnderscoreID,
+    MissingArgumentsForMethodID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1848,34 +1848,21 @@ object messages {
           |To convert to a function value, you need to explicitly write ${"() => x"}"""
   }
 
-  case class MissingEmptyArgumentListForMethod(method: Symbol, methodStr: String)(implicit ctx: Context)
-    extends Message(MissingArgumentsForMethodID) {
-    val kind: String = "Syntax"
-    val msg: String = hl"$methodStr must be called with an empty argument list"
-    val explanation: String = {
+  case class MissingEmptyArgumentList(method: Symbol)(implicit ctx: Context)
+    extends Message(MissingEmptyArgumentListID) {
+    val kind = "Syntax"
+    val msg = hl"$method must be called with ${"()"} argument"
+    val explanation = {
       val codeExample =
-        """
-          |def next(): T = ...
-          |next     // is expanded to next()
-        """
-      val errorMessage =
-        """
-          |next
-          |^^^^
-          |method next must be called with an empty argument list
-        """
-      hl"""
-          |Previously an empty argument list () was implicitly inserted when calling a nullary method without arguments. E.g.
+        """def next(): T = ...
+          |next     // is expanded to next()"""
+
+      hl"""Previously an empty argument list () was implicitly inserted when calling a nullary method without arguments. E.g.
           |
           |$codeExample
           |
-          |In Dotty, this idiom is an error which leads to the following message:
-          |
-          |$errorMessage
-          |
-          |In Dotty, the application syntax has to follow exactly the parameter syntax.
-          |Excluded from this rule are methods that are defined in Java or that override methods defined in Java.
-        """
+          |In Dotty, this idiom is an error. The application syntax has to follow exactly the parameter syntax.
+          |Excluded from this rule are methods that are defined in Java or that override methods defined in Java."""
     }
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1847,4 +1847,35 @@ object messages {
       hl"""The syntax ${"x _"} is no longer supported if ${"x"} is not a function.
           |To convert to a function value, you need to explicitly write ${"() => x"}"""
   }
+
+  case class MissingEmptyArgumentListForMethod(method: Symbol, methodStr: String)(implicit ctx: Context)
+    extends Message(MissingArgumentsForMethodID) {
+    val kind: String = "Syntax"
+    val msg: String = hl"$methodStr must be called with an empty argument list"
+    val explanation: String = {
+      val codeExample =
+        """
+          |def next(): T = ...
+          |next     // is expanded to next()
+        """
+      val errorMessage =
+        """
+          |next
+          |^^^^
+          |method next must be called with an empty argument list
+        """
+      hl"""
+          |Previously an empty argument list () was implicitly inserted when calling a nullary method without arguments. E.g.
+          |
+          |$codeExample
+          |
+          |In Dotty, this idiom is an error which leads to the following message:
+          |
+          |$errorMessage
+          |
+          |In Dotty, the application syntax has to follow exactly the parameter syntax.
+          |Excluded from this rule are methods that are defined in Java or that override methods defined in Java.
+        """
+    }
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1908,7 +1908,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     def methodStr = err.refStr(methPart(tree).tpe)
 
     def missingArgs(mt: MethodType) = {
-      ctx.error(em"missing arguments for $methodStr", tree.pos)
+      ctx.error(MissingEmptyArgumentListForMethod(methPart(tree).symbol, methodStr), tree.pos)
       tree.withType(mt.resultType)
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1908,7 +1908,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     def methodStr = err.refStr(methPart(tree).tpe)
 
     def missingArgs(mt: MethodType) = {
-      ctx.error(MissingEmptyArgumentListForMethod(methPart(tree).symbol, methodStr), tree.pos)
+      ctx.error(MissingEmptyArgumentList(methPart(tree).symbol), tree.pos)
       tree.withType(mt.resultType)
     }
 
@@ -2076,7 +2076,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       def isAutoApplied(sym: Symbol): Boolean = {
         sym.isConstructor ||
         sym.matchNullaryLoosely ||
-        ctx.testScala2Mode(em"${sym.showLocated} requires () argument", tree.pos,
+        ctx.testScala2Mode(MissingEmptyArgumentList(sym), tree.pos,
             patch(tree.pos.endPos, "()"))
       }
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1070,7 +1070,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("String(n)", pt.show)
     }
 
-  @Test def missingEmptyArgumentListForMethod =
+  @Test def missingEmptyArgumentList =
     checkMessagesAfter("frontend") {
       """
         |class Test {
@@ -1085,9 +1085,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
 
       assertMessageCount(1, messages)
-
-      val MissingEmptyArgumentListForMethod(method, _) :: Nil = messages
-
+      val MissingEmptyArgumentList(method) :: Nil = messages
       assertEquals("method greet", method.show)
     }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1069,4 +1069,25 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val OnlyFunctionsCanBeFollowedByUnderscore(pt) :: Nil = messages
       assertEquals("String(n)", pt.show)
     }
+
+  @Test def missingEmptyArgumentListForMethod =
+    checkMessagesAfter("frontend") {
+      """
+        |class Test {
+        |  def greet(): String = "Hello"
+        |  def main(args: Array[String]): Unit = {
+        |    greet
+        |  }
+        |}
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+
+      val MissingEmptyArgumentListForMethod(method, _) :: Nil = messages
+
+      assertEquals("method greet", method.show)
+    }
 }


### PR DESCRIPTION
@maseev I added some stuff on top of your work. This error message could also be emitted at `Typer:2079`