### PR TITLE
Fix #3412: Allow upper case identifiers to be bound with `@`.

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1557,10 +1557,10 @@ object Parsers {
       else p
     }
 
-    /**  Pattern2    ::=  [varid `@'] InfixPattern
+    /**  Pattern2    ::=  [id `@'] InfixPattern
      */
     val pattern2 = () => infixPattern() match {
-      case p @ Ident(name) if isVarPattern(p) && in.token == AT =>
+      case p @ Ident(name) if in.token == AT =>
         val offset = in.skipToken()
 
         // compatibility for Scala2 `x @ _*` syntax

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -220,7 +220,7 @@ CaseClause        ::=  ‘case’ (Pattern [Guard] ‘=>’ Block | INT)
 Pattern           ::=  Pattern1 { ‘|’ Pattern1 }                                Alternative(pats)
 Pattern1          ::=  PatVar ‘:’ RefinedType                                   Bind(name, Typed(Ident(wildcard), tpe))
                     |  Pattern2
-Pattern2          ::=  [varid ‘@’] InfixPattern                                 Bind(name, pat)
+Pattern2          ::=  [id ‘@’] InfixPattern                                    Bind(name, pat)
 InfixPattern      ::=  SimplePattern { id [nl] SimplePattern }                  InfixOp(pat, op, pat)
 SimplePattern     ::=  PatVar                                                   Ident(wildcard)
                     |  Literal                                                  Bind(name, Ident(wildcard))

--- a/tests/pos/i3412.scala
+++ b/tests/pos/i3412.scala
@@ -1,0 +1,5 @@
+class Test {
+  val A @ List() = List()
+  val B @ List(), C: List[Int] = List()
+  val D @ List(), E @ List() = List()
+}


### PR DESCRIPTION
According to

  https://www.scala-lang.org/files/archive/spec/2.11/13-syntax-summary.html

we require that an @-bound name is a variable name, i.e. lower-case only. But `scalac` supports
arbitrary identifiers and there's no good reason why we should restrict it that way. So I changed
the grammar and parser for Dotty to follow scalac's behavior.