### PR TITLE
Fix generic signatures of generic methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -240,8 +240,8 @@ object GenericSignatures {
 
         case mtpe: MethodType =>
           // phantom method parameters do not make it to the bytecode.
-          val params = mtpe.paramInfos.filterNot(_.isPhantom)
-          val restpe = mtpe.resultType
+          val params = mtpe.paramInfoss.flatten.filterNot(_.isPhantom)
+          val restpe = mtpe.finalResultType
           builder.append('(')
           // TODO: Update once we support varargs
           params.foreach { tp =>

--- a/tests/generic-java-signatures/i3411.check
+++ b/tests/generic-java-signatures/i3411.check
@@ -1,0 +1,1 @@
+public <U> float Foo$.foo(int,java.lang.String,long,boolean,U,java.lang.String,java.lang.Object)

--- a/tests/generic-java-signatures/i3411.scala
+++ b/tests/generic-java-signatures/i3411.scala
@@ -1,0 +1,10 @@
+object Foo {
+  def foo[U](i: Int, s: String, x: Long)(c: Boolean, a: U, d: String)(e: Object): Float = 0.0f
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val f1 = Foo.getClass.getMethods.find(_.getName.endsWith("foo")).get
+    println(f1.toGenericString)
+  }
+}


### PR DESCRIPTION
We ignored the case where a `MethodType` had another `MethodType` as
result type. This commit fixes the issue by collecting the parameters of
the result type if it is a `MethodType`, recursively.

Fixes #3411