### PR TITLE
Named type error messages to new format

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -108,7 +108,8 @@ public enum ErrorMessageID {
     FailureToEliminateExistentialID,
     OnlyFunctionsCanBeFollowedByUnderscoreID,
     MissingEmptyArgumentListID,
-    DuplicateNamedTypeArgumentID
+    DuplicateNamedTypeArgumentID,
+    UndefinedNamedTypeArgumentID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -107,7 +107,8 @@ public enum ErrorMessageID {
     TailrecNotApplicableID,
     FailureToEliminateExistentialID,
     OnlyFunctionsCanBeFollowedByUnderscoreID,
-    MissingEmptyArgumentListID
+    MissingEmptyArgumentListID,
+    DuplicateNamedTypeArgumentID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -108,8 +108,8 @@ public enum ErrorMessageID {
     FailureToEliminateExistentialID,
     OnlyFunctionsCanBeFollowedByUnderscoreID,
     MissingEmptyArgumentListID,
-    DuplicateNamedTypeArgumentID,
-    UndefinedNamedTypeArgumentID
+    DuplicateNamedTypeParameterID,
+    UndefinedNamedTypeParameterID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1872,4 +1872,11 @@ object messages {
     val msg = hl"Type parameter $name was defined multiple times."
     val explanation = ""
   }
+
+  case class UndefinedNamedTypeArgument(undefinedName: Name, definedNames: List[Name])(implicit ctx: Context)
+    extends Message(UndefinedNamedTypeArgumentID) {
+    val kind = "Syntax"
+    val msg = hl"The type parameter $undefinedName is undefined. Expected one of ${definedNames.mkString(",")}."
+    val explanation = ""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1876,7 +1876,7 @@ object messages {
   case class UndefinedNamedTypeArgument(undefinedName: Name, definedNames: List[Name])(implicit ctx: Context)
     extends Message(UndefinedNamedTypeArgumentID) {
     val kind = "Syntax"
-    val msg = hl"The type parameter $undefinedName is undefined. Expected one of ${definedNames.mkString(",")}."
+    val msg = hl"The type parameter $undefinedName is undefined. Expected one of ${definedNames.mkString(", ")}."
     val explanation = ""
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1876,7 +1876,7 @@ object messages {
   case class UndefinedNamedTypeArgument(undefinedName: Name, definedNames: List[Name])(implicit ctx: Context)
     extends Message(UndefinedNamedTypeArgumentID) {
     val kind = "Syntax"
-    val msg = hl"The type parameter $undefinedName is undefined. Expected one of ${definedNames.mkString(", ")}."
+    val msg = hl"Type parameter $undefinedName is undefined. Expected one of ${definedNames.mkString(", ")}."
     val explanation = ""
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1865,4 +1865,11 @@ object messages {
           |Excluded from this rule are methods that are defined in Java or that override methods defined in Java."""
     }
   }
+
+  case class DuplicateNamedTypeArgument(name: Name)(implicit ctx: Context)
+    extends Message(DuplicateNamedTypeArgumentID) {
+    val kind = "Syntax"
+    val msg = hl"Type parameter $name was defined multiple times."
+    val explanation = ""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1866,17 +1866,17 @@ object messages {
     }
   }
 
-  case class DuplicateNamedTypeArgument(name: Name)(implicit ctx: Context)
-    extends Message(DuplicateNamedTypeArgumentID) {
+  case class DuplicateNamedTypeParameter(name: Name)(implicit ctx: Context)
+    extends Message(DuplicateNamedTypeParameterID) {
     val kind = "Syntax"
     val msg = hl"Type parameter $name was defined multiple times."
     val explanation = ""
   }
 
-  case class UndefinedNamedTypeArgument(undefinedName: Name, definedNames: List[Name])(implicit ctx: Context)
-    extends Message(UndefinedNamedTypeArgumentID) {
+  case class UndefinedNamedTypeParameter(undefinedName: Name, definedNames: List[Name])(implicit ctx: Context)
+    extends Message(UndefinedNamedTypeParameterID) {
     val kind = "Syntax"
-    val msg = hl"Type parameter $undefinedName is undefined. Expected one of ${definedNames.mkString(", ")}."
+    val msg = hl"Type parameter $undefinedName is undefined. Expected one of ${definedNames.map(_.show).mkString(", ")}."
     val explanation = ""
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -371,7 +371,7 @@ trait TypeAssigner {
           val namedArgMap = new mutable.HashMap[Name, Type]
           for (NamedArg(name, arg) <- args)
             if (namedArgMap.contains(name))
-              ctx.error("duplicate name", arg.pos)
+              ctx.error(DuplicateNamedTypeArgument(name), arg.pos)
             else if (!paramNames.contains(name))
               ctx.error(s"undefined parameter name, required: ${paramNames.mkString(" or ")}", arg.pos)
             else

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -371,9 +371,9 @@ trait TypeAssigner {
           val namedArgMap = new mutable.HashMap[Name, Type]
           for (NamedArg(name, arg) <- args)
             if (namedArgMap.contains(name))
-              ctx.error(DuplicateNamedTypeArgument(name), arg.pos)
+              ctx.error(DuplicateNamedTypeParameter(name), arg.pos)
             else if (!paramNames.contains(name))
-              ctx.error(UndefinedNamedTypeArgument(name, paramNames), arg.pos)
+              ctx.error(UndefinedNamedTypeParameter(name, paramNames), arg.pos)
             else
               namedArgMap(name) = preCheckKind(arg, paramBoundsByName(name.asTypeName)).tpe
 

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -373,7 +373,7 @@ trait TypeAssigner {
             if (namedArgMap.contains(name))
               ctx.error(DuplicateNamedTypeArgument(name), arg.pos)
             else if (!paramNames.contains(name))
-              ctx.error(s"undefined parameter name, required: ${paramNames.mkString(" or ")}", arg.pos)
+              ctx.error(UndefinedNamedTypeArgument(name, paramNames), arg.pos)
             else
               namedArgMap(name) = preCheckKind(arg, paramBoundsByName(name.asTypeName)).tpe
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1088,4 +1088,24 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val MissingEmptyArgumentList(method) :: Nil = messages
       assertEquals("method greet", method.show)
     }
+
+  @Test def duplicateNamedTypeArgument =
+    checkMessagesAfter("frontend") {
+      """
+        |object Test {
+        |  def f[A, B]() = ???
+        |  f[A=Any, A=Any]()
+        |  f[B=Any, B=Any]()
+        |}
+        |
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(2, messages)
+      val DuplicateNamedTypeArgument(n2) :: DuplicateNamedTypeArgument(n1) :: Nil = messages
+      assertEquals("A", n1.show)
+      assertEquals("B", n2.show)
+    }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1089,7 +1089,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("method greet", method.show)
     }
 
-  @Test def duplicateNamedTypeArgument =
+  @Test def duplicateNamedTypeParameter =
     checkMessagesAfter("frontend") {
       """
         |object Test {
@@ -1104,12 +1104,12 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
 
       assertMessageCount(2, messages)
-      val DuplicateNamedTypeArgument(n2) :: DuplicateNamedTypeArgument(n1) :: Nil = messages
+      val DuplicateNamedTypeParameter(n2) :: DuplicateNamedTypeParameter(n1) :: Nil = messages
       assertEquals("A", n1.show)
       assertEquals("B", n2.show)
     }
 
-  @Test def undefinedNamedTypeArgument =
+  @Test def undefinedNamedTypeParameter =
     checkMessagesAfter("frontend") {
       """
         |object Test {
@@ -1124,11 +1124,12 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         implicit val ctx: Context = ictx
 
         assertMessageCount(2, messages)
-        val UndefinedNamedTypeArgument(n2, l2) :: UndefinedNamedTypeArgument(n1, l1) :: Nil = messages
+        val UndefinedNamedTypeParameter(n2, l2) :: UndefinedNamedTypeParameter(n1, l1) :: Nil = messages
+        val tpParams = List("A", "B")
         assertEquals("C", n1.show)
-        assertEquals("A"::"B"::Nil, l1.map(_.show))
+        assertEquals(tpParams, l1.map(_.show))
         assertEquals("C", n2.show)
-        assertEquals("A"::"B"::Nil, l2.map(_.show))
+        assertEquals(tpParams, l2.map(_.show))
 
       }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1108,4 +1108,27 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("A", n1.show)
       assertEquals("B", n2.show)
     }
+
+  @Test def undefinedNamedTypeArgument =
+    checkMessagesAfter("frontend") {
+      """
+        |object Test {
+        |  def f[A, B]() = ???
+        |  f[A=Any, C=Any]()
+        |  f[C=Any, B=Any]()
+        |}
+        |
+      """.stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+
+        assertMessageCount(2, messages)
+        val UndefinedNamedTypeArgument(n2, l2) :: UndefinedNamedTypeArgument(n1, l1) :: Nil = messages
+        assertEquals("C", n1.show)
+        assertEquals("A"::"B"::Nil, l1.map(_.show))
+        assertEquals("C", n2.show)
+        assertEquals("A"::"B"::Nil, l2.map(_.show))
+
+      }
 }


### PR DESCRIPTION
Part of #1589.

Changes error messages for named type parameters to use new format (with tests).