### PR TITLE
Fix #3422: Add missing case to TypeComparer

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -369,14 +369,18 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     case _ =>
       val cls2 = tp2.symbol
       if (cls2.isClass) {
-        val base = tp1.baseType(cls2)
-        if (base.exists) {
-          if (cls2.is(JavaDefined))
-            // If `cls2` is parameterized, we are seeing a raw type, so we need to compare only the symbol
-            return base.typeSymbol == cls2
-          if (base ne tp1) return isSubType(base, tp2)
+        if (cls2.typeParams.nonEmpty && tp1.isHK)
+          isSubType(tp1, EtaExpansion(cls2.typeRef))
+        else {
+          val base = tp1.baseType(cls2)
+          if (base.exists) {
+            if (cls2.is(JavaDefined))
+              // If `cls2` is parameterized, we are seeing a raw type, so we need to compare only the symbol
+              return base.typeSymbol == cls2
+            if (base ne tp1) return isSubType(base, tp2)
+          }
+          if (cls2 == defn.SingletonClass && tp1.isStable) return true
         }
-        if (cls2 == defn.SingletonClass && tp1.isStable) return true
       }
       fourthTry(tp1, tp2)
   }

--- a/tests/pos/i3422/a_1.scala
+++ b/tests/pos/i3422/a_1.scala
@@ -1,0 +1,9 @@
+trait Fun[L[_]]
+
+object O1 {
+  trait N[X]
+}
+
+object O2 {
+  def bar: Fun[O1.N] = ???
+}

--- a/tests/pos/i3422/b_2.scala
+++ b/tests/pos/i3422/b_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  def c: Fun[O1.N] = O2.bar
+}


### PR DESCRIPTION
We missed the case where we compare two hk tpes A <: B, where both A and B refer to
classes with type parameters. It seems this case usually does not arise when we compile
from source because A or B or both are eta expanded. But it can arise after unpickling.