### PR TITLE
Fix #3332: Disallow bound variables in pattern alternatives

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -8,7 +8,7 @@ case class Mode(val bits: Int) extends AnyVal {
   def &~ (that: Mode) = Mode(bits & ~that.bits)
   def is (that: Mode) = (bits & that.bits) == that.bits
 
-  def isExpr = (this & PatternOrType) == None
+  def isExpr = (this & PatternOrTypeBits) == None
 
   override def toString =
     (0 until 31).filter(i => (bits & (1 << i)) != 0).map(modeName).mkString("Mode(", ",", ")")
@@ -41,6 +41,9 @@ object Mode {
 
   /** We are looking at the arguments of a supercall */
   val InSuperCall = newMode(6, "InSuperCall")
+
+  /** We are in a pattern alternative */
+  val InPatternAlternative = newMode(7, "InPatternAlternative")
 
   /** Allow GADTFlexType labelled types to have their bounds adjusted */
   val GADTflexible = newMode(8, "GADTflexible")
@@ -87,7 +90,7 @@ object Mode {
   /** Don't suppress exceptions thrown during show */
   val PrintShowExceptions = newMode(18, "PrintShowExceptions")
 
-  val PatternOrType = Pattern | Type
+  val PatternOrTypeBits = Pattern | Type | InPatternAlternative
 
   /** We are elaborating the fully qualified name of a package clause.
    *  In this case, identifiers should never be imported.

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -936,10 +936,10 @@ class Namer { typer: Typer =>
   }
 
   def typedAheadType(tree: Tree, pt: Type = WildcardType)(implicit ctx: Context): tpd.Tree =
-    typedAheadImpl(tree, typer.typed(_, pt)(ctx retractMode Mode.PatternOrType addMode Mode.Type))
+    typedAheadImpl(tree, typer.typed(_, pt)(ctx retractMode Mode.PatternOrTypeBits addMode Mode.Type))
 
   def typedAheadExpr(tree: Tree, pt: Type = WildcardType)(implicit ctx: Context): tpd.Tree =
-    typedAheadImpl(tree, typer.typed(_, pt)(ctx retractMode Mode.PatternOrType))
+    typedAheadImpl(tree, typer.typed(_, pt)(ctx retractMode Mode.PatternOrTypeBits))
 
   def typedAheadAnnotation(tree: Tree)(implicit ctx: Context): Symbol = tree match {
     case Apply(fn, _) => typedAheadAnnotation(fn)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1210,9 +1210,13 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         tpd.cpy.UnApply(body1)(fn, Nil,
             typed(untpd.Bind(tree.name, untpd.TypedSplice(arg)).withPos(tree.pos), arg.tpe) :: Nil)
       case _ =>
-        val sym = newPatternBoundSym(tree.name, body1.tpe, tree.pos)
-        if (ctx.mode.is(Mode.InPatternAlternative)) ctx.error("Illegal variable in pattern alternative", tree.pos)
-        assignType(cpy.Bind(tree)(tree.name, body1), sym)
+        if (tree.name == nme.WILDCARD) body1
+        else {
+          val sym = newPatternBoundSym(tree.name, body1.tpe, tree.pos)
+          if (ctx.mode.is(Mode.InPatternAlternative))
+            ctx.error(i"Illegal variable ${sym.name} in pattern alternative", tree.pos)
+          assignType(cpy.Bind(tree)(tree.name, body1), sym)
+        }
     }
   }
 

--- a/tests/neg/i3332.scala
+++ b/tests/neg/i3332.scala
@@ -1,0 +1,9 @@
+object Main {
+  def main(args: Array[String]): Unit = {
+    (1: Any) match {
+      case x: String | Int => "OK"
+      case (_: String) | (_: Int) => "OK"
+      case (s: String) | _: Int => s   // error: Illegal variable in pattern alternative
+    }
+  }
+}

--- a/tests/neg/i3332.scala
+++ b/tests/neg/i3332.scala
@@ -1,7 +1,7 @@
 object Main {
   def main(args: Array[String]): Unit = {
     (1: Any) match {
-      case x: String | Int => "OK"
+      case x: String | Int => "OK"  // error: Illegal variable in pattern alternative
       case (_: String) | (_: Int) => "OK"
       case (s: String) | _: Int => s   // error: Illegal variable in pattern alternative
     }

--- a/tests/neg/i3332.scala
+++ b/tests/neg/i3332.scala
@@ -7,3 +7,11 @@ object Main {
     }
   }
 }
+
+// #1612
+object Test {
+  def g(p:(Int,Int)) = p match {
+    case (10,n) | (n,10) => println(n) // error // error (Illegal variable in pattern alternative)
+    case _ => println("nope")
+  }
+}

--- a/tests/neg/i3332.scala
+++ b/tests/neg/i3332.scala
@@ -10,8 +10,12 @@ object Main {
 
 // #1612
 object Test {
+  case class A()
   def g(p:(Int,Int)) = p match {
     case (10,n) | (n,10) => println(n) // error // error (Illegal variable in pattern alternative)
     case _ => println("nope")
+  }
+  def test(x: Any) = x match {
+    case _: String | _ @ A() => 1
   }
 }


### PR DESCRIPTION
Disallow bound variables where the binder appears as a pattern alternative.

Fixes #3332.

There's nothing we can do about the parsing. If we parsed

    case x: A | B 

as

    case x: (A | B)

then we would run into an error for

    case _: A | _: B

But the latter is a common idiom.

