### PR TITLE
New format of illegal start of statement error message (+tests)

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2496,7 +2496,7 @@ object Parsers {
           }
         else if (!isStatSep && (in.token != CASE)) {
           exitOnError = mustStartStat
-          syntaxErrorOrIncomplete(IllegalStartOfStatement(isModifier = isModifier))
+          syntaxErrorOrIncomplete(IllegalStartOfStatement(isModifier))
         }
         acceptStatSepUnlessAtEnd(CASE)
       }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2496,8 +2496,7 @@ object Parsers {
           }
         else if (!isStatSep && (in.token != CASE)) {
           exitOnError = mustStartStat
-          val addendum = if (isModifier) " (no modifiers allowed here)" else ""
-          syntaxErrorOrIncomplete("illegal start of statement" + addendum)
+          syntaxErrorOrIncomplete(IllegalStartOfStatement(isModifier = isModifier))
         }
         acceptStatSepUnlessAtEnd(CASE)
       }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -109,7 +109,8 @@ public enum ErrorMessageID {
     OnlyFunctionsCanBeFollowedByUnderscoreID,
     MissingEmptyArgumentListID,
     DuplicateNamedTypeParameterID,
-    UndefinedNamedTypeParameterID
+    UndefinedNamedTypeParameterID,
+    IllegalStartOfStatementID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1883,9 +1883,9 @@ object messages {
   case class IllegalStartOfStatement(isModifier: Boolean)(implicit ctx: Context) extends Message(IllegalStartOfStatementID) {
     val kind = "Syntax"
     val msg = {
-      val addendum = if(isModifier) "(no modifiers allowed here)" else ""
-      hl"Illegal start of statement $addendum"
+      val addendum = if (isModifier) ": no modifiers allowed here" else ""
+      s"Illegal start of statement" + addendum
     }
-    val explanation = hl"A statement is either an import, a definition or an expression."
+    val explanation = "A statement is either an import, a definition or an expression."
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1882,12 +1882,10 @@ object messages {
 
   case class IllegalStartOfStatement(isModifier: Boolean)(implicit ctx: Context) extends Message(IllegalStartOfStatementID) {
     val kind = "Syntax"
-    private val addendum = if(isModifier) "(no modifiers allowed here)" else ""
-    val msg = hl"Illegal start of statement $addendum"
-    val explanation = hl"""
-      | Expected an import, a statement or an expression at the start of a statement.
-      | For a detailed list of allowed statements, please consult the syntax of BlockStat at http://dotty.epfl.ch/docs/internals/syntax.html#expressions
-    """
-
+    val msg = {
+      val addendum = if(isModifier) "(no modifiers allowed here)" else ""
+      hl"Illegal start of statement $addendum"
+    }
+    val explanation = hl"A statement is either an import, a definition or an expression."
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1884,7 +1884,7 @@ object messages {
     val kind = "Syntax"
     val msg = {
       val addendum = if (isModifier) ": no modifiers allowed here" else ""
-      s"Illegal start of statement" + addendum
+      "Illegal start of statement" + addendum
     }
     val explanation = "A statement is either an import, a definition or an expression."
   }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1879,4 +1879,15 @@ object messages {
     val msg = hl"Type parameter $undefinedName is undefined. Expected one of ${definedNames.map(_.show).mkString(", ")}."
     val explanation = ""
   }
+
+  case class IllegalStartOfStatement(isModifier: Boolean)(implicit ctx: Context) extends Message(IllegalStartOfStatementID) {
+    val kind = "Syntax"
+    private val addendum = if(isModifier) "(no modifiers allowed here)" else ""
+    val msg = hl"Illegal start of statement $addendum"
+    val explanation = hl"""
+      | Expected an import, a statement or an expression at the start of a statement.
+      | For a detailed list of allowed statements, please consult the syntax of BlockStat at http://dotty.epfl.ch/docs/internals/syntax.html#expressions
+    """
+
+  }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1132,4 +1132,24 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals(tpParams, l2.map(_.show))
 
       }
+
+  @Test def illegalStartOfStatement =
+    checkMessagesAfter("frontend") {
+      """
+        |object Test {
+        |  { ) }
+        |  { private ) }
+        |}
+        |
+      """.stripMargin
+    }
+      .expect { (ictx, messages) =>
+        implicit val ctx: Context = ictx
+
+        assertMessageCount(2, messages)
+        val errWithModifier :: err :: Nil = messages
+
+        assertEquals(IllegalStartOfStatement(isModifier = false), err)
+        assertEquals(IllegalStartOfStatement(isModifier = true), errWithModifier)
+      }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1140,7 +1140,6 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |  { ) }
         |  { private ) }
         |}
-        |
       """.stripMargin
     }
       .expect { (ictx, messages) =>


### PR DESCRIPTION
Part of #1589.

Uses new format of error messages in Parsers.scala:2500

The new error is IllegalStartOfStatement