### PR TITLE
new format for "package name already defined" error (+tests)

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -113,6 +113,7 @@ public enum ErrorMessageID {
     IllegalStartOfStatementID,
     TraitIsExpectedID,
     TraitRedefinedFinalMethodFromAnyRefID,
+    PackageNameAlreadyDefinedID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1922,4 +1922,12 @@ object messages {
     val msg = hl"Traits cannot redefine final $method from ${"class AnyRef"}."
     val explanation = ""
   }
+
+  case class PackageNameAlreadyDefined(pkg: Symbol)(implicit ctx: Context) extends Message(PackageNameAlreadyDefinedID) {
+
+    override def msg: String = hl"${pkg} is already defined, cannot be a package"
+    override def kind: String = "Syntax"
+    override def explanation: String =
+      "An object cannot have the same name as an existing package. Rename ${pkg} or the package with the same name."
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1924,9 +1924,8 @@ object messages {
   }
 
   case class PackageNameAlreadyDefined(pkg: Symbol)(implicit ctx: Context) extends Message(PackageNameAlreadyDefinedID) {
-
     val msg = hl"${pkg} is already defined, cannot be a ${"package"}"
-    val kind = "Syntax"
+    val kind = "Naming"
     val explanation =
       hl"An ${"object"} cannot have the same name as an existing ${"package"}. Rename either one of them."
   }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1925,9 +1925,9 @@ object messages {
 
   case class PackageNameAlreadyDefined(pkg: Symbol)(implicit ctx: Context) extends Message(PackageNameAlreadyDefinedID) {
 
-    override def msg: String = hl"${pkg} is already defined, cannot be a package"
-    override def kind: String = "Syntax"
-    override def explanation: String =
-      "An object cannot have the same name as an existing package. Rename ${pkg} or the package with the same name."
+    val msg = hl"${pkg} is already defined, cannot be a ${"package"}"
+    val kind = "Syntax"
+    val explanation =
+      hl"An ${"object"} cannot have the same name as an existing ${"package"}. Rename either one of them."
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1522,7 +1522,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       val packageContext =
         if (pkg is Package) ctx.fresh.setOwner(pkg.moduleClass).setTree(tree)
         else {
-          ctx.error(em"$pkg is already defined, cannot be a package", tree.pos)
+          ctx.error(PackageNameAlreadyDefined(pkg), tree.pos)
           ctx
         }
       val stats1 = typedStats(tree.stats, pkg.moduleClass)(packageContext)

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1200,7 +1200,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
     }.expect { (ictx, messages) =>
       implicit val ctx: Context = ictx
 
-      assertMessageCount(1, messages)
-      assert(messages.head.isInstanceOf[PackageNameAlreadyDefined])
+      val PackageNameAlreadyDefined(pkg) = messages.head
+      assertEquals(pkg.show, "object bar")
     }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1189,4 +1189,18 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("method wait", method.show)
     }
 
+
+  @Test def packageNameAlreadyDefined =
+    checkMessagesAfter("frontend") {
+      """
+        |package bar { }
+        |object bar { }
+        |
+      """.stripMargin
+    }.expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+      assert(messages.head.isInstanceOf[PackageNameAlreadyDefined])
+    }
 }


### PR DESCRIPTION
PR from Scala.io 2017 FLOSS spree in Lyon.

For #1589 :

This PR creates a new format of error messages for `Typer.scala:1519`. The new `Message` class is `PackageNameAlreadyDefined`.