### PR TITLE
Replace isAsGood with ternary operator

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1046,17 +1046,25 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
    *   - The nesting levels of A1 and A2 are the same, and A1's owner derives from A2's owner
    *   - A1's type is more specific than A2's type.
    */
-  def isAsGood(alt1: TermRef, alt2: TermRef, nesting1: Int = 0, nesting2: Int = 0)(implicit ctx: Context): Boolean = track("isAsGood") { trace(i"isAsGood($alt1, $alt2)", overload) {
+  def compare(alt1: TermRef, alt2: TermRef, nesting1: Int = 0, nesting2: Int = 0)(implicit ctx: Context): Int = track("compare") { trace(i"compare($alt1, $alt2)", overload) {
 
     assert(alt1 ne alt2)
 
-    /** Is class or module class `sym1` derived from class or module class `sym2`?
+    /** Compare owner inheritance level.
+     *  @param    sym1 The first owner
+     *  @param    sym2 The second owner
+     *  @return    1   if `sym1` properly derives from `sym2`
+     *            -1   if `sym2` properly derives from `sym1`
+     *             0   otherwise
      *  Module classes also inherit the relationship from their companions.
      */
-    def isDerived(sym1: Symbol, sym2: Symbol): Boolean =
-      if (sym1 isSubClass sym2) true
-      else if (sym2 is Module) isDerived(sym1, sym2.companionClass)
-      else (sym1 is Module) && isDerived(sym1.companionClass, sym2)
+    def compareOwner(sym1: Symbol, sym2: Symbol): Int =
+      if (sym1 == sym2) 0
+      else if (sym1 isSubClass sym2) 1
+      else if (sym2 isSubClass sym1) -1
+      else if (sym2 is Module) compareOwner(sym1, sym2.companionClass)
+      else if (sym1 is Module) compareOwner(sym1.companionClass, sym2)
+      else 0
 
     /** Is alternative `alt1` with type `tp1` as specific as alternative
      *  `alt2` with type `tp2` ?
@@ -1165,55 +1173,59 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
 
     val owner1 = if (alt1.symbol.exists) alt1.symbol.owner else NoSymbol
     val owner2 = if (alt2.symbol.exists) alt2.symbol.owner else NoSymbol
+    val ownerScore =
+      if (nesting1 > nesting2) 1
+      else if (nesting1 < nesting2) -1
+      else compareOwner(owner1, owner2)
+
     val tp1 = stripImplicit(alt1.widen)
     val tp2 = stripImplicit(alt2.widen)
-
-    def winsOwner1 =
-      nesting1 > nesting2 || nesting1 == nesting2 && isDerived(owner1, owner2)
     def winsType1  = isAsSpecific(alt1, tp1, alt2, tp2)
-    def winsOwner2 =
-      nesting2 > nesting1 || nesting1 == nesting2 && isDerived(owner2, owner1)
     def winsType2  = isAsSpecific(alt2, tp2, alt1, tp1)
 
-    overload.println(i"isAsGood($alt1, $alt2)? $tp1 $tp2 $winsOwner1 $winsType1 $winsOwner2 $winsType2")
+    overload.println(i"compare($alt1, $alt2)? $tp1 $tp2 $ownerScore $winsType1 $winsType2")
 
-    // Assume the following probabilities:
-    //
-    // P(winsOwnerX) = 2/3
-    // P(winsTypeX) = 1/3
-    //
-    // Then the call probabilities of the 4 basic operations are as follows:
-    //
-    // winsOwner1: 1/1
-    // winsOwner2: 1/1
-    // winsType1 : 7/9
-    // winsType2 : 4/9
-
-    if (winsOwner1) /* 6/9 */ !winsOwner2 || /* 4/9 */ winsType1 || /* 8/27 */ !winsType2
-    else if (winsOwner2) /* 2/9 */ winsType1 && /* 2/27 */ !winsType2
-    else /* 1/9 */ winsType1 || /* 2/27 */ !winsType2
+    if (ownerScore == 1)
+      if (winsType1 || !winsType2) 1 else 0
+    else if (ownerScore == -1)
+      if (winsType2 || !winsType1) -1 else 0
+    else if (winsType1)
+      if (winsType2) 0 else 1
+    else
+      if (winsType2) -1 else 0
   }}
+
+  def isAsGood(alt1: TermRef, alt2: TermRef, nesting1: Int = 0, nesting2: Int = 0)(implicit ctx: Context): Boolean =
+    compare(alt1, alt2, nesting1, nesting2) >= 0
 
   def narrowMostSpecific(alts: List[TermRef])(implicit ctx: Context): List[TermRef] = track("narrowMostSpecific") {
     alts match {
       case Nil => alts
       case _ :: Nil => alts
-      case alt :: alts1 =>
-        def winner(bestSoFar: TermRef, alts: List[TermRef]): TermRef = alts match {
-          case alt :: alts1 =>
-            winner(if (isAsGood(alt, bestSoFar)) alt else bestSoFar, alts1)
-          case nil =>
-            bestSoFar
+      case alt1 :: alt2 :: Nil =>
+        compare(alt1, alt2) match {
+          case  1 => alt1 :: Nil
+          case -1 => alt2 :: Nil
+          case  0 => alts
         }
-        val best = winner(alt, alts1)
+      case alt :: alts1 =>
+        def survivors(previous: List[TermRef], alts: List[TermRef]): List[TermRef] = alts match {
+          case alt :: alts1 =>
+            compare(previous.head, alt) match {
+              case  1 => survivors(previous, alts1)
+              case -1 => survivors(alt :: previous.tail, alts1)
+              case  0 => survivors(alt :: previous, alts1)
+            }
+          case Nil => previous
+        }
+        val best :: rest = survivors(alt :: Nil, alts1)
         def asGood(alts: List[TermRef]): List[TermRef] = alts match {
           case alt :: alts1 =>
-            if ((alt eq best) || !isAsGood(alt, best)) asGood(alts1)
-            else alt :: asGood(alts1)
+            if (compare(alt, best) < 0) asGood(alts1) else alt :: asGood(alts1)
           case nil =>
             Nil
         }
-        best :: asGood(alts)
+        best :: asGood(rest)
     }
   }
 


### PR DESCRIPTION
The aim is to have ultimately fewer comparisons. The downside is
that some of the comparisons are now more expensive, because types
have to be compared where they previously weren't.

This should be integrated in the implicits PR. It is broken out here so that performance can
be tested separately.