### PR TITLE
Rename Drone clone step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 # We override the default clone step to workaround a bug with GitHub (see #3415)
 clone:
-  custom:
+  clone:
     image: plugins/git
     commands:
       - sleep 5s


### PR DESCRIPTION
Rename Drone clone step from `custom` to `clone`. The name appears in
the web UI so it matters