### PR TITLE
Fix #3443: adapt child compatibility check

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -405,35 +405,22 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         Prod(pat.tpe.stripAnnots, fun.tpe.widen, fun.symbol, pats.map(project), irrefutable(fun))
     case Typed(pat @ UnApply(_, _, _), _) => project(pat)
     case Typed(expr, tpt) =>
-      val unchecked = expr.tpe.hasAnnotation(ctx.definitions.UncheckedAnnot)
-      def warn(msg: String): Unit = if (!unchecked) ctx.warning(UncheckedTypePattern(msg), tpt.pos)
-      Typ(erase(expr.tpe.stripAnnots)(warn), true)
+      Typ(erase(expr.tpe.stripAnnots), true)
     case _ =>
       debug.println(s"unknown pattern: $pat")
       Empty
   }
 
   /* Erase a type binding according to erasure semantics in pattern matching */
-  def erase(tp: Type)(implicit warn: String => Unit): Type = tp match {
+  def erase(tp: Type): Type = tp match {
     case tp @ AppliedType(tycon, args) =>
       if (tycon.isRef(defn.ArrayClass)) tp.derivedAppliedType(tycon, args.map(erase))
-      else {
-        val ignoreWarning = args.forall { p =>
-          p.typeSymbol.is(BindDefinedType) ||
-            p.hasAnnotation(defn.UncheckedAnnot) ||
-            p.isInstanceOf[TypeBounds]
-        }
-        if (!ignoreWarning)
-          warn("type arguments are not checked since they are eliminated by erasure")
-
-        tp.derivedAppliedType(tycon, args.map(t => WildcardType))
-      }
+      else tp.derivedAppliedType(tycon, args.map(t => WildcardType))
     case OrType(tp1, tp2) =>
       OrType(erase(tp1), erase(tp2))
     case AndType(tp1, tp2) =>
       AndType(erase(tp1), erase(tp2))
     case tp: RefinedType =>
-      warn("type refinement is not checked since it is eliminated by erasure")
       tp.derivedRefinedType(erase(tp.parent), tp.refinedName, WildcardType)
     case _ => tp
   }

--- a/tests/patmat/3144.check
+++ b/tests/patmat/3144.check
@@ -1,2 +1,0 @@
-2: Pattern Match Exhaustivity
-7: Pattern Match Exhaustivity

--- a/tests/patmat/3144b.check
+++ b/tests/patmat/3144b.check
@@ -1,2 +1,0 @@
-4: Pattern Match Exhaustivity
-10: Pattern Match Exhaustivity

--- a/tests/patmat/enum-HList.check
+++ b/tests/patmat/enum-HList.check
@@ -1,1 +1,0 @@
-2: Pattern Match Exhaustivity

--- a/tests/patmat/enum-Tree.check
+++ b/tests/patmat/enum-Tree.check
@@ -1,1 +1,0 @@
-8: Pattern Match Exhaustivity

--- a/tests/patmat/i3443.scala
+++ b/tests/patmat/i3443.scala
@@ -1,0 +1,19 @@
+object Test {
+  // shapeless.Coproduct
+  sealed trait Coproduct extends Product with Serializable
+  sealed trait :+:[+H, +T <: Coproduct] extends Coproduct
+  final case class Inl[+H, +T <: Coproduct](head : H) extends :+:[H, T]
+  final case class Inr[+H, +T <: Coproduct](tail : T) extends :+:[H, T]
+  sealed trait CNil extends Coproduct
+
+  // Note that this only appears when T is a type parameter. Replaying T with
+  // a concrete type (CNil or another :+:) leads to accurate warnnings
+  def f[T <: Coproduct](fa: Int :+: T) =
+    fa match {
+      case Inl(x) => 1
+      case Inr(x) => 2 // Dotty thinks this unreachable, but it is!
+    }
+
+  def main(args: Array[String]): Unit =
+    assert(f(Inr(Inl(-1))) == 2) // Example of reachability
+}

--- a/tests/patmat/t3683.check
+++ b/tests/patmat/t3683.check
@@ -1,1 +1,0 @@
-7: Pattern Match Exhaustivity

--- a/tests/patmat/t3683a.check
+++ b/tests/patmat/t3683a.check
@@ -1,2 +1,1 @@
-8: Pattern Match Exhaustivity
 14: Pattern Match Exhaustivity: XX()


### PR DESCRIPTION
Fix #3443

Previously, the child compatibility check will result in a check like `CNil <: TVar(Nothing..Coproduct)`, which failed. Now we expose type param according to its variance. We only resort to `TVar` if the variance is 0.

This PR also removes the `@unchecked` check, as agreed with @allanrenucci the check should be somewhere else and handle more complex cases.