### PR TITLE
New format for trait redefined final method from AnyRef error message…

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -112,6 +112,7 @@ public enum ErrorMessageID {
     UndefinedNamedTypeParameterID,
     IllegalStartOfStatementID,
     TraitIsExpectedID,
+    TraitRedefinedFinalMethodFromAnyRefID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1917,10 +1917,9 @@ object messages {
     }
   }
 
-  case class TraitRedefinedFinalMethodFromAnyRef()(implicit ctx: Context) extends Message(TraitRedefinedFinalMethodFromAnyRefID) {
+  case class TraitRedefinedFinalMethodFromAnyRef(method: Symbol)(implicit ctx: Context) extends Message(TraitRedefinedFinalMethodFromAnyRefID) {
     val kind = "Syntax"
-    val msg = "Trait cannot redefine final method from class AnyRef"
-    val explanation = hl"""A method was defined in a trait trying to redefine a method declared in class AnyRef.
-    All classes inherit from AnyRef and should not redefine its methods"""
+    val msg = hl"Traits cannot redefine final $method from ${"class AnyRef"}."
+    val explanation = ""
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1916,4 +1916,11 @@ object messages {
           |"""
     }
   }
+
+  case class TraitRedefinedFinalMethodFromAnyRef()(implicit ctx: Context) extends Message(TraitRedefinedFinalMethodFromAnyRefID) {
+    val kind = "Syntax"
+    val msg = "Trait cannot redefine final method from class AnyRef"
+    val explanation = hl"""A method was defined in a trait trying to redefine a method declared in class AnyRef.
+    All classes inherit from AnyRef and should not redefine its methods"""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -116,7 +116,7 @@ object RefChecks {
     if (!cls.owner.is(ModuleClass)) {
       def clashes(sym: Symbol) =
         sym.isClass &&
-        sym.name.stripModuleClassSuffix == cls.name.stripModuleClassSuffix        
+        sym.name.stripModuleClassSuffix == cls.name.stripModuleClassSuffix
 
       val others = cls.owner.linkedClass.info.decls.filter(clashes)
       others.foreach { other =>
@@ -606,7 +606,7 @@ object RefChecks {
         // override a concrete method in Object. The jvm, however, does not.
         val overridden = decl.matchingDecl(defn.ObjectClass, defn.ObjectType)
         if (overridden.is(Final))
-          ctx.error("trait cannot redefine final method from class AnyRef", decl.pos)
+          ctx.error(TraitRedefinedFinalMethodFromAnyRef(), decl.pos)
       }
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -606,7 +606,7 @@ object RefChecks {
         // override a concrete method in Object. The jvm, however, does not.
         val overridden = decl.matchingDecl(defn.ObjectClass, defn.ObjectType)
         if (overridden.is(Final))
-          ctx.error(TraitRedefinedFinalMethodFromAnyRef(), decl.pos)
+          ctx.error(TraitRedefinedFinalMethodFromAnyRef(overridden), decl.pos)
       }
     }
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1172,4 +1172,22 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val TraitIsExpected(symbol) :: Nil = messages
       assertEquals("class B", symbol.show)
     }
+
+  @Test def traitRedefinedFinalMethodFromAnyRef =
+    checkMessagesAfter("refchecks") {
+      """
+        |trait C {
+        |  def wait (): Unit
+        |}
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+      val err :: Nil = messages
+
+      assertEquals(TraitRedefinedFinalMethodFromAnyRef(), err)
+    }
+
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1185,9 +1185,8 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
 
       assertMessageCount(1, messages)
-      val err :: Nil = messages
-
-      assertEquals(TraitRedefinedFinalMethodFromAnyRef(), err)
+      val TraitRedefinedFinalMethodFromAnyRef(method) = messages.head
+      assertEquals("method wait", method.show)
     }
 
 }


### PR DESCRIPTION
Further enhancement : explanation could be enhanced by telling which method from AnyRef was redefined 