### PR TITLE
Fix #3452: Fix cycle with implicit by-name parameter

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -617,6 +617,7 @@ trait Implicits { self: Typer =>
      */
     val (formalValue, lazyImplicit, argCtx) = formal match {
       case ExprType(fv) =>
+        fullyDefinedType(fv, "implicit by-name parameter", pos)
         val lazyImplicit = ctx.newLazyImplicit(fv)
         (fv, lazyImplicit, lazyImplicitCtx(lazyImplicit))
       case _ => (formal, NoSymbol, ctx)

--- a/tests/neg/i3542.scala
+++ b/tests/neg/i3542.scala
@@ -1,0 +1,8 @@
+object Test {
+  trait TC[A]
+
+  implicit def case1[F[_]](implicit t: => TC[F[Any]]): TC[String] = ???
+  implicit def case2[G[_]](implicit r: TC[G[Any]]): TC[Int] = ???
+
+  implicitly[TC[Int]] // error: no implicit argument of type TC[Int] found
+}

--- a/tests/pos/i3542.scala
+++ b/tests/pos/i3542.scala
@@ -1,0 +1,7 @@
+class Foo[T]
+
+object Test {
+  implicit def foo[T](implicit rec: => Foo[T]): Foo[T] = ???
+
+  val bla: Foo[Int] = implicitly[Foo[Int]]
+}


### PR DESCRIPTION
When creating a lazy val to represent an implicit by-name parameter, we
need to fully define its type, otherwise cycles can arise in our
constraints.

This is similar to the issue fixed in eb2fdf273f7305e79196477347593f7417f19eb4