### PR TITLE
Add dependent function types

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -560,6 +560,15 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       }
     }
 
+    override def Inlined(tree: Tree)(call: Tree, bindings: List[MemberDef], expansion: Tree)(implicit ctx: Context): Inlined = {
+      val tree1 = untpd.cpy.Inlined(tree)(call, bindings, expansion)
+      tree match {
+        case tree: Inlined if sameTypes(bindings, tree.bindings) && (expansion.tpe eq tree.expansion.tpe) =>
+          tree1.withTypeUnchecked(tree.tpe)
+        case _ => ta.assignType(tree1, bindings, expansion)
+      }
+    }
+
     override def SeqLiteral(tree: Tree)(elems: List[Tree], elemtpt: Tree)(implicit ctx: Context): SeqLiteral = {
       val tree1 = untpd.cpy.SeqLiteral(tree)(elems, elemtpt)
       tree match {

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -86,6 +86,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   case class GenAlias(pat: Tree, expr: Tree) extends Tree
   case class ContextBounds(bounds: TypeBoundsTree, cxBounds: List[Tree]) extends TypTree
   case class PatDef(mods: Modifiers, pats: List[Tree], tpt: Tree, rhs: Tree) extends DefTree
+  case class DependentTypeTree(tp: List[Symbol] => Type) extends Tree
 
   @sharable object EmptyTypeIdent extends Ident(tpnme.EMPTY) with WithoutTypeOrPos[Untyped] {
     override def isEmpty = true

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -915,17 +915,18 @@ class Definitions {
   def isProductSubType(tp: Type)(implicit ctx: Context) =
     tp.derivesFrom(ProductType.symbol)
 
-  /** Is `tp` (an alias) of either a scala.FunctionN or a scala.ImplicitFunctionN? */
-  def isFunctionType(tp: Type)(implicit ctx: Context) = {
+  /** Is `tp` (an alias) of either a scala.FunctionN or a scala.ImplicitFunctionN
+   *  instance?
+   */
+  def isNonDepFunctionType(tp: Type)(implicit ctx: Context) = {
     val arity = functionArity(tp)
     val sym = tp.dealias.typeSymbol
     arity >= 0 && isFunctionClass(sym) && tp.isRef(FunctionType(arity, sym.name.isImplicitFunction).typeSymbol)
   }
 
-  def isDependentFunctionType(tp: Type)(implicit ctx: Context) = tp.stripTypeVar match {
-    case RefinedType(parent, nme.apply, _) => isFunctionType(parent)
-    case _ => false
-  }
+  /** Is `tp` a representation of a (possibly depenent) function type or an alias of such? */
+  def isFunctionType(tp: Type)(implicit ctx: Context) =
+    isNonDepFunctionType(tp.dropDependentRefinement)
 
   // Specialized type parameters defined for scala.Function{0,1,2}.
   private lazy val Function1SpecializedParams: collection.Set[Type] =

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -702,7 +702,8 @@ class Definitions {
       val tsym = ft.typeSymbol
       if (isFunctionClass(tsym)) {
         val targs = ft.dealias.argInfos
-        Some(targs.init, targs.last, tsym.name.isImplicitFunction)
+        if (targs.isEmpty) None
+        else Some(targs.init, targs.last, tsym.name.isImplicitFunction)
       }
       else None
     }
@@ -919,6 +920,11 @@ class Definitions {
     val arity = functionArity(tp)
     val sym = tp.dealias.typeSymbol
     arity >= 0 && isFunctionClass(sym) && tp.isRef(FunctionType(arity, sym.name.isImplicitFunction).typeSymbol)
+  }
+
+  def isDependentFunctionType(tp: Type)(implicit ctx: Context) = tp.stripTypeVar match {
+    case RefinedType(parent, nme.apply, _) => isFunctionType(parent)
+    case _ => false
   }
 
   // Specialized type parameters defined for scala.Function{0,1,2}.

--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -48,12 +48,6 @@ object Mode {
   /** Allow GADTFlexType labelled types to have their bounds adjusted */
   val GADTflexible = newMode(8, "GADTflexible")
 
-  /** Allow dependent functions. This is currently necessary for unpickling, because
-   *  some dependent functions are passed through from the front end(s?), even though they
-   *  are technically speaking illegal.
-   */
-  val AllowDependentFunctions = newMode(9, "AllowDependentFunctions")
-
   /** We are currently printing something: avoid to produce more logs about
    *  the printing
    */

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -130,6 +130,9 @@ trait Symbols { this: Context =>
     newClassSymbol(owner, name, flags, completer, privateWithin, coord, assocFile)
   }
 
+  def newRefinedClassSymbol = newCompleteClassSymbol(
+    ctx.owner, tpnme.REFINE_CLASS, NonMember, parents = Nil)
+
   /** Create a module symbol with associated module class
    *  from its non-info fields and a function producing the info
    *  of the module class (this info may be lazy).

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1014,10 +1014,10 @@ object Types {
       case _ => this
     }
 
-    /** If this is a dependent function type, drop the `apply` refinement */
-    final def dropDependentRefinement(implicit ctx: Context): Type = stripTypeVar match {
+    /** Dealias, and if result is a dependent function type, drop the `apply` refinement. */
+    final def dropDependentRefinement(implicit ctx: Context): Type = dealias match {
       case RefinedType(parent, nme.apply, _) => parent
-      case _ => this
+      case tp => tp
     }
 
     /** The type constructor of an applied type, otherwise the type itself */

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1328,10 +1328,7 @@ object Types {
         val funType = defn.FunctionOf(
           formals1 mapConserve (_.underlyingIfRepeated(mt.isJavaMethod)),
           mt.nonDependentResultApprox, mt.isImplicitMethod && !ctx.erasedTypes)
-        if (mt.isDependent) {
-          assert(!mt.isImplicitMethod)
-          RefinedType(funType, nme.apply, mt)
-        }
+        if (mt.isDependent) RefinedType(funType, nme.apply, mt)
         else funType
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1328,7 +1328,7 @@ object Types {
         val funType = defn.FunctionOf(
           formals1 mapConserve (_.underlyingIfRepeated(mt.isJavaMethod)),
           mt.nonDependentResultApprox, mt.isImplicitMethod && !ctx.erasedTypes)
-        if (mt.isDependent) RefinedType(funType, nme.apply, mt)
+        if (mt.isDependent && !mt.isImplicitMethod) RefinedType(funType, nme.apply, mt)
         else funType
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1312,12 +1312,12 @@ object Types {
 // ----- misc -----------------------------------------------------------
 
     /** Turn type into a function type.
-     *  @pre this is a non-dependent method type.
+     *  @pre this is a method type without parameter dependencies.
      *  @param dropLast  The number of trailing parameters that should be dropped
      *                   when forming the function type.
      */
     def toFunctionType(dropLast: Int = 0)(implicit ctx: Context): Type = this match {
-      case mt: MethodType if !mt.isDependent || ctx.mode.is(Mode.AllowDependentFunctions) =>
+      case mt: MethodType if !mt.isDependent =>
         val formals1 = if (dropLast == 0) mt.paramInfos else mt.paramInfos dropRight dropLast
         defn.FunctionOf(
           formals1 mapConserve (_.underlyingIfRepeated(mt.isJavaMethod)), mt.resultType, mt.isImplicitMethod && !ctx.erasedTypes)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -74,7 +74,7 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
   /** The unpickled trees */
   def unpickle()(implicit ctx: Context): List[Tree] = {
     assert(roots != null, "unpickle without previous enterTopLevel")
-    new TreeReader(reader).readTopLevel()(ctx.addMode(Mode.AllowDependentFunctions))
+    new TreeReader(reader).readTopLevel()
   }
 
   class Completer(owner: Symbol, reader: TastyReader) extends LazyType {
@@ -1095,7 +1095,7 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
   class LazyReader[T <: AnyRef](reader: TreeReader, op: TreeReader => Context => T) extends Trees.Lazy[T] {
     def complete(implicit ctx: Context): T = {
       pickling.println(i"starting to read at ${reader.reader.currentAddr}")
-      op(reader)(ctx.addMode(Mode.AllowDependentFunctions).withPhaseNoLater(ctx.picklerPhase))
+      op(reader)(ctx.withPhaseNoLater(ctx.picklerPhase))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -999,8 +999,7 @@ class TreeUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName, posUnpi
               val argPats = until(end)(readTerm())
               UnApply(fn, implicitArgs, argPats, patType)
             case REFINEDtpt =>
-              val refineCls = ctx.newCompleteClassSymbol(
-                ctx.owner, tpnme.REFINE_CLASS, NonMember, parents = Nil)
+              val refineCls = ctx.newRefinedClassSymbol
               typeAtAddr(start) = refineCls.typeRef
               val parent = readTpt()
               val refinements = readStats(refineCls, end)(localContext(refineCls))

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -184,20 +184,17 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case NoPrefix =>
         "<noprefix>"
       case tp: MethodType =>
-        def paramText(name: TermName, tp: Type) = toText(name) ~ ": " ~ toText(tp)
         changePrec(GlobalPrec) {
-          (if (tp.isImplicitMethod) "(implicit " else "(") ~
-            Text((tp.paramNames, tp.paramInfos).zipped map paramText, ", ") ~
+          (if (tp.isImplicitMethod) "(implicit " else "(") ~ paramsText(tp) ~
           (if (tp.resultType.isInstanceOf[MethodType]) ")" else "): ") ~
           toText(tp.resultType)
         }
       case tp: ExprType =>
         changePrec(GlobalPrec) { "=> " ~ toText(tp.resultType) }
       case tp: TypeLambda =>
-        def paramText(name: Name, bounds: TypeBounds): Text = name.unexpandedName.toString ~ toText(bounds)
         changePrec(GlobalPrec) {
-          "[" ~ Text((tp.paramNames, tp.paramInfos).zipped.map(paramText), ", ") ~
-          "]" ~ lambdaHash(tp) ~ (" => " provided !tp.resultType.isInstanceOf[MethodType]) ~
+          "[" ~ paramsText(tp) ~ "]" ~ lambdaHash(tp) ~
+          (" => " provided !tp.resultType.isInstanceOf[MethodType]) ~
           toTextGlobal(tp.resultType)
         }
       case AnnotatedType(tpe, annot) =>
@@ -220,6 +217,11 @@ class PlainPrinter(_ctx: Context) extends Printer {
         tp.fallbackToText(this)
     }
   }.close
+
+  protected def paramsText(tp: LambdaType): Text = {
+    def paramText(name: Name, tp: Type) = toText(name) ~ toTextRHS(tp)
+    Text((tp.paramNames, tp.paramInfos).zipped.map(paramText), ", ")
+  }
 
   protected def ParamRefNameString(name: Name): String = name.toString
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -146,10 +146,14 @@ class PlainPrinter(_ctx: Context) extends Printer {
         toTextRef(tp) ~ ".type"
       case tp: TermRef if tp.denot.isOverloaded =>
         "<overloaded " ~ toTextRef(tp) ~ ">"
-      case tp: SingletonType =>
-        toTextLocal(tp.underlying) ~ "(" ~ toTextRef(tp) ~ ")"
       case tp: TypeRef =>
         toTextPrefix(tp.prefix) ~ selectionString(tp)
+      case tp: TermParamRef =>
+        ParamRefNameString(tp) ~ ".type"
+      case tp: TypeParamRef =>
+        ParamRefNameString(tp) ~ lambdaHash(tp.binder)
+      case tp: SingletonType =>
+        toTextLocal(tp.underlying) ~ "(" ~ toTextRef(tp) ~ ")"
       case AppliedType(tycon, args) =>
         (toTextLocal(tycon) ~ "[" ~ Text(args map argText, ", ") ~ "]").close
       case tp: RefinedType =>
@@ -196,10 +200,6 @@ class PlainPrinter(_ctx: Context) extends Printer {
           "]" ~ lambdaHash(tp) ~ (" => " provided !tp.resultType.isInstanceOf[MethodType]) ~
           toTextGlobal(tp.resultType)
         }
-      case tp: TypeParamRef =>
-        ParamRefNameString(tp) ~ lambdaHash(tp.binder)
-      case tp: TermParamRef =>
-        ParamRefNameString(tp) ~ ".type"
       case AnnotatedType(tpe, annot) =>
         toTextLocal(tpe) ~ " " ~ toText(annot)
       case tp: TypeVar =>

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -144,8 +144,8 @@ trait Dynamic { self: Typer with Applications =>
 
     tree.tpe.widen match {
       case tpe: MethodType =>
-        if (tpe.isDependent)
-          fail(i"has a dependent method type")
+        if (tpe.isParamDependent)
+          fail(i"has a method type with inter-parameter dependencies")
         else if (tpe.paramNames.length > Definitions.MaxStructuralMethodArity)
           fail(i"""takes too many parameters.
                   |Structural types only support methods taking up to ${Definitions.MaxStructuralMethodArity} arguments""")

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -54,7 +54,7 @@ object Inferencing {
    */
   def instantiateDependent(tp: Type, tparams: List[Symbol], vparamss: List[List[Symbol]])(implicit ctx: Context): Unit = {
     val dependentVars = new TypeAccumulator[Set[TypeVar]] {
-      lazy val params = (vparamss :\ tparams)( _ ::: _)
+      lazy val params = (tparams :: vparamss).flatten
       def apply(tvars: Set[TypeVar], tp: Type) = tp match {
         case tp: TypeVar
         if !tp.isInstantiated &&

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1150,12 +1150,8 @@ class Namer { typer: Typer =>
     vparamss foreach completeParams
     def typeParams = tparams map symbolOfTree
     val paramSymss = ctx.normalizeIfConstructor(vparamss.nestedMap(symbolOfTree), isConstructor)
-    def wrapMethType(restpe: Type): Type = {
-      val restpe1 = // try to make anonymous functions non-dependent, so that they can be used in closures
-        if (name == nme.ANON_FUN) avoid(restpe, paramSymss.flatten)
-        else restpe
-      ctx.methodType(tparams map symbolOfTree, paramSymss, restpe1, isJava = ddef.mods is JavaDefined)
-    }
+    def wrapMethType(restpe: Type): Type =
+      ctx.methodType(tparams map symbolOfTree, paramSymss, restpe, isJava = ddef.mods is JavaDefined)
     if (isConstructor) {
       // set result type tree to unit, but take the current class as result type of the symbol
       typedAheadType(ddef.tpt, defn.UnitType)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1096,6 +1096,8 @@ class Namer { typer: Typer =>
         WildcardType
       case TypeTree() =>
         inferredType
+      case DependentTypeTree(tpFun) =>
+        tpFun(paramss.head)
       case TypedSplice(tpt: TypeTree) if !isFullyDefined(tpt.tpe, ForceDegree.none) =>
         val rhsType = typedAheadExpr(mdef.rhs, tpt.tpe).tpe
         mdef match {

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -96,12 +96,12 @@ trait NamerContextOps { this: Context =>
     else given
 
   /** if isConstructor, make sure it has one non-implicit parameter list */
-  def normalizeIfConstructor(paramSymss: List[List[Symbol]], isConstructor: Boolean) =
+  def normalizeIfConstructor(termParamss: List[List[Symbol]], isConstructor: Boolean) =
     if (isConstructor &&
-      (paramSymss.isEmpty || paramSymss.head.nonEmpty && (paramSymss.head.head is Implicit)))
-      Nil :: paramSymss
+      (termParamss.isEmpty || termParamss.head.nonEmpty && (termParamss.head.head is Implicit)))
+      Nil :: termParamss
     else
-      paramSymss
+      termParamss
 
   /** The method type corresponding to given parameters and result type */
   def methodType(typeParams: List[Symbol], valueParamss: List[List[Symbol]], resultType: Type, isJava: Boolean = false)(implicit ctx: Context): Type = {
@@ -1149,15 +1149,17 @@ class Namer { typer: Typer =>
 
     vparamss foreach completeParams
     def typeParams = tparams map symbolOfTree
-    val paramSymss = ctx.normalizeIfConstructor(vparamss.nestedMap(symbolOfTree), isConstructor)
-    def wrapMethType(restpe: Type): Type =
-      ctx.methodType(tparams map symbolOfTree, paramSymss, restpe, isJava = ddef.mods is JavaDefined)
+    val termParamss = ctx.normalizeIfConstructor(vparamss.nestedMap(symbolOfTree), isConstructor)
+    def wrapMethType(restpe: Type): Type = {
+      instantiateDependent(restpe, typeParams, termParamss)
+      ctx.methodType(tparams map symbolOfTree, termParamss, restpe, isJava = ddef.mods is JavaDefined)
+    }
     if (isConstructor) {
       // set result type tree to unit, but take the current class as result type of the symbol
       typedAheadType(ddef.tpt, defn.UnitType)
       wrapMethType(ctx.effectiveResultType(sym, typeParams, NoType))
     }
-    else valOrDefDefSig(ddef, sym, typeParams, paramSymss, wrapMethType)
+    else valOrDefDefSig(ddef, sym, typeParams, termParamss, wrapMethType)
   }
 
   def typeDefSig(tdef: TypeDef, sym: Symbol, tparamSyms: List[TypeSymbol])(implicit ctx: Context): Type = {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -715,7 +715,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     }
     val funCls = defn.FunctionClass(args.length, isImplicit)
 
-    def typedDependent(params: List[ValDef])(implicit ctx: Context) = {
+    /** Typechecks dependent function type with given parameters `params` */
+    def typedDependent(params: List[ValDef])(implicit ctx: Context): Tree = {
       completeParams(params)
       val params1 = params.map(typedExpr(_).asInstanceOf[ValDef])
       val resultTpt = typed(body)
@@ -744,8 +745,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   def typedFunctionValue(tree: untpd.Function, pt: Type)(implicit ctx: Context) = {
-    val untpd.Function(args, body) = tree
-    val params = args.asInstanceOf[List[untpd.ValDef]]
+    val untpd.Function(params: List[untpd.ValDef], body) = tree
 
     pt match {
       case pt: TypeVar if untpd.isFunctionWithUnknownParamType(tree) =>
@@ -837,7 +837,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
           }
         case _ =>
       }
-      errorType(AnonymousFunctionMissingParamType(param, args, tree, pt), param.pos)
+      errorType(AnonymousFunctionMissingParamType(param, params, tree, pt), param.pos)
     }
 
     def protoFormal(i: Int): Type =
@@ -1721,7 +1721,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   protected def makeImplicitFunction(tree: untpd.Tree, pt: Type)(implicit ctx: Context): Tree = {
-    val defn.FunctionOf(formals, _, true) = pt.dealias.dropDependentRefinement
+    val defn.FunctionOf(formals, _, true) = pt.dropDependentRefinement
     val paramTypes = formals.map(fullyDefinedType(_, "implicit function parameter", tree.pos))
     val ifun = desugar.makeImplicitFunction(paramTypes, tree)
     typr.println(i"make implicit function $tree / $pt ---> $ifun")

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -719,10 +719,12 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       completeParams(params)
       val params1 = params.map(typedExpr(_).asInstanceOf[ValDef])
       val resultTpt = typed(body)
-      val companion = if (isImplicit) ImplicitMethodType else MethodType
-      val mt = companion.fromSymbols(params1.map(_.symbol), resultTpt.tpe)
+      val mt = MethodType.fromSymbols(params1.map(_.symbol), resultTpt.tpe)
       if (mt.isParamDependent)
-        ctx.error(i"$mt is an illegal function type because it has inter-parameter dependencies")
+        ctx.error(i"$mt is an illegal function type because it has inter-parameter dependencies", tree.pos)
+      if (isImplicit)
+        ctx.error(i"dependent function type $mt may not be implicit", tree.pos)
+
       val resTpt = TypeTree(mt.nonDependentResultApprox).withPos(body.pos)
       val typeArgs = params1.map(_.tpt) :+ resTpt
       val tycon = TypeTree(funCls.typeRef)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -684,7 +684,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   private def decomposeProtoFunction(pt: Type, defaultArity: Int)(implicit ctx: Context): (List[Type], Type) = pt match {
-    case _ if defn.isFunctionType(pt) =>
+    case _ if defn.isNonDepFunctionType(pt) =>
       // if expected parameter type(s) are wildcards, approximate from below.
       // if expected result type is a wildcard, approximate from above.
       // this can type the greatest set of admissible closures.
@@ -895,7 +895,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
           case mt: MethodType =>
             pt match {
               case SAMType(meth)
-              if !defn.isFunctionType(pt.dealias.dropDependentRefinement) && mt <:< meth.info =>
+              if !defn.isFunctionType(pt) && mt <:< meth.info =>
                 if (!isFullyDefined(pt, ForceDegree.all))
                   ctx.error(ex"result type of closure is an underspecified SAM type $pt", tree.pos)
                 TypeTree(pt)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -719,12 +719,10 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       completeParams(params)
       val params1 = params.map(typedExpr(_).asInstanceOf[ValDef])
       val resultTpt = typed(body)
-      val mt = MethodType.fromSymbols(params1.map(_.symbol), resultTpt.tpe)
+      val companion = if (isImplicit) ImplicitMethodType else MethodType
+      val mt = companion.fromSymbols(params1.map(_.symbol), resultTpt.tpe)
       if (mt.isParamDependent)
         ctx.error(i"$mt is an illegal function type because it has inter-parameter dependencies", tree.pos)
-      if (isImplicit)
-        ctx.error(i"dependent function type $mt may not be implicit", tree.pos)
-
       val resTpt = TypeTree(mt.nonDependentResultApprox).withPos(body.pos)
       val typeArgs = params1.map(_.tpt) :+ resTpt
       val tycon = TypeTree(funCls.typeRef)
@@ -1723,7 +1721,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
   }
 
   protected def makeImplicitFunction(tree: untpd.Tree, pt: Type)(implicit ctx: Context): Tree = {
-    val defn.FunctionOf(formals, resType, true) = pt.dealias
+    val defn.FunctionOf(formals, _, true) = pt.dealias.dropDependentRefinement
     val paramTypes = formals.map(fullyDefinedType(_, "implicit function parameter", tree.pos))
     val ifun = desugar.makeImplicitFunction(paramTypes, tree)
     typr.println(i"make implicit function $tree / $pt ---> $ifun")

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -122,6 +122,8 @@ Type              ::=  [‘implicit’] FunArgTypes ‘=>’ Type               
                     |  InfixType
 FunArgTypes       ::=  InfixType
                     |  ‘(’ [ FunArgType {‘,’ FunArgType } ] ‘)’
+                    |  '(' TypedFunParam {',' TypedFunParam } ')'
+TypedFunParam     ::=  id ':' Type
 InfixType         ::=  RefinedType {id [nl] RefinedType}                        InfixOp(t1, op, t2)
 RefinedType       ::=  WithType {[nl] Refinement}                               RefinedTypeTree(t, ds)
 WithType          ::=  AnnotType {‘with’ AnnotType}                             (deprecated)

--- a/library/src/dotty/DottyPredef.scala
+++ b/library/src/dotty/DottyPredef.scala
@@ -38,4 +38,5 @@ object DottyPredef {
   final def assertFail(): Unit = throw new java.lang.AssertionError("assertion failed")
   final def assertFail(message: => Any): Unit = throw new java.lang.AssertionError("assertion failed: " + message)
 
+  @inline final def implicitly[T](implicit ev: T): T = ev
 }

--- a/tests/neg/depfuns.scala
+++ b/tests/neg/depfuns.scala
@@ -1,5 +1,5 @@
 object Test {
 
-  type T = (x: Int) // error: `=>' expected
+  type T = (x: Int)
 
-}
+}  // error: `=>' expected

--- a/tests/neg/depfuns.scala
+++ b/tests/neg/depfuns.scala
@@ -1,0 +1,5 @@
+object Test {
+
+  type T = (x: Int) // error: `=>' expected
+
+}

--- a/tests/pos/depfuntype.scala
+++ b/tests/pos/depfuntype.scala
@@ -13,6 +13,6 @@ object Test {
   val depfun3: DF = depfun2
 
   val d: C = c
-  val z = depfun1(d)
+  val z = depfun3(d)
   val z1: d.M = z
 }

--- a/tests/pos/depfuntype.scala
+++ b/tests/pos/depfuntype.scala
@@ -1,0 +1,14 @@
+object Test {
+
+  trait C { type M; val m: M }
+
+  type DF = (x: C) => x.M
+  val depfun: DF = ??? // (x: C) => x.m
+  val c = new C { type M = Int; val m = 0 }
+  val y = depfun(c)
+  val y1: Int = y
+
+  val d: C = c
+  val z = depfun(d)
+  val z1: d.M = z
+}

--- a/tests/pos/depfuntype.scala
+++ b/tests/pos/depfuntype.scala
@@ -15,4 +15,21 @@ object Test {
   val d: C = c
   val z = depfun3(d)
   val z1: d.M = z
+
+  // Reproduced here because the one from DottyPredef is lacking a Tasty tree and
+  // therefore can't be inlined when testing non-bootstrapped.
+  // But inlining `implicitly` is vital to make the definition of `ifun` below work.
+  inline final def implicitly[T](implicit ev: T): T = ev
+
+  type IDF = implicit (x: C) => x.M
+
+  implicit val ic: C = ???
+
+  val ifun: IDF = implicitly[C].m
+
+  val u = ifun(c)
+  val u1: Int = u
+
+  val v = ifun(d)
+  val v1: d.M = v
 }

--- a/tests/pos/depfuntype.scala
+++ b/tests/pos/depfuntype.scala
@@ -3,12 +3,16 @@ object Test {
   trait C { type M; val m: M }
 
   type DF = (x: C) => x.M
-  val depfun: DF = ??? // (x: C) => x.m
+  val depfun1: DF = (x: C) => x.m
   val c = new C { type M = Int; val m = 0 }
-  val y = depfun(c)
+  val y = depfun1(c)
   val y1: Int = y
 
+  def depmeth(x: C) = x.m
+  val depfun2 = depmeth
+  val depfun3: DF = depfun2
+
   val d: C = c
-  val z = depfun(d)
+  val z = depfun1(d)
   val z1: d.M = z
 }

--- a/tests/run/eff-dependent.scala
+++ b/tests/run/eff-dependent.scala
@@ -1,0 +1,38 @@
+object Test extends App {
+
+  trait Effect
+
+  // Type X => Y
+  abstract class Fun[-X, +Y] {
+    type Eff <: Effect
+    def apply(x: X): implicit Eff => Y
+  }
+
+  class CanThrow extends Effect
+  class CanIO extends Effect
+
+  val i2s = new Fun[Int, String] { type Eff = CanThrow; def apply(x: Int) = x.toString }
+  val s2i = new Fun[String, Int] { type Eff = CanIO; def apply(x: String) = x.length }
+
+  implicit val ct: CanThrow = new CanThrow
+  implicit val ci: CanIO = new CanIO
+
+  // def map(f: A => B)(xs: List[A]): List[B]
+  def map[A, B](f: Fun[A, B])(xs: List[A]): implicit f.Eff => List[B] =
+    xs.map(f.apply)
+
+  // def mapFn[A, B]: (A => B) -> List[A] -> List[B]
+  def mapFn[A, B]: (f: Fun[A, B]) => List[A] => implicit f.Eff => List[B] =
+    f => xs => map(f)(xs)
+
+  // def compose(f: A => B)(g: B => C)(x: A): C
+  def compose[A, B, C](f: Fun[A, B])(g: Fun[B, C])(x: A): implicit f.Eff => implicit g.Eff => C = g(f(x))
+
+  // def composeFn: (A => B) -> (B => C) -> A -> C
+  def composeFn[A, B, C]: (f: Fun[A, B]) => (g: Fun[B, C]) => A => implicit f.Eff => implicit g.Eff => C =
+    f => g => x => compose(f)(g)(x)
+
+  assert(mapFn(i2s)(List(1, 2, 3)).mkString == "123")
+  assert(composeFn(i2s)(s2i)(22) == 2)
+
+}


### PR DESCRIPTION
We now support dependent function types as long as there are no inter-parameter dependencies. 
Assuming

    class C { type T }

a dependent function type is written like this:

     (x: C) => x.T

It gets represented as a normal function type that approximates the result type together with a refinement that adds an `apply` method with the precise type. E.g. the type above would be represented as

    Function1[C, C#T] { def apply(x: C): x.T }

~~For the moment, dependent function types cannot be implicit. Maybe we can lift that restriction in the future.~~

Dependent function types are important, because they are already in DOT, and they are probably a key feature to enable polymorphic effect systems.