### PR TITLE
Add an error message class for a case where a trait is expected

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -110,7 +110,8 @@ public enum ErrorMessageID {
     MissingEmptyArgumentListID,
     DuplicateNamedTypeParameterID,
     UndefinedNamedTypeParameterID,
-    IllegalStartOfStatementID
+    IllegalStartOfStatementID,
+    TraitIsExpectedID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -111,7 +111,7 @@ public enum ErrorMessageID {
     DuplicateNamedTypeParameterID,
     UndefinedNamedTypeParameterID,
     IllegalStartOfStatementID,
-    TraitIsExpectedID
+    TraitIsExpectedID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1888,4 +1888,32 @@ object messages {
     }
     val explanation = "A statement is either an import, a definition or an expression."
   }
+
+  case class TraitIsExpected(tref: TypeRef)(implicit ctx: Context) extends Message(TraitIsExpectedID) {
+    val kind = "Syntax"
+    val msg = hl"$tref is not a trait"
+    val explanation = {
+      val errorCodeExample =
+        """class A
+          |class B
+          |
+          |val a = new A with B // will fail with a compile error - B is not a trait"""
+      val codeExample =
+        """class A
+          |trait B
+          |
+          |val a = new A with B // compiles normally"""
+
+      hl"""Only traits can be mixed into classes using a ${"with"} keyword.
+          |Consider the following example:
+          |
+          |$errorCodeExample
+          |
+          |The example mentioned above would fail because B is not a trait.
+          |But if you make B a trait it will be compiled without any errors:
+          |
+          |$codeExample
+          |"""
+    }
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1889,20 +1889,20 @@ object messages {
     val explanation = "A statement is either an import, a definition or an expression."
   }
 
-  case class TraitIsExpected(tref: TypeRef)(implicit ctx: Context) extends Message(TraitIsExpectedID) {
+  case class TraitIsExpected(symbol: Symbol)(implicit ctx: Context) extends Message(TraitIsExpectedID) {
     val kind = "Syntax"
-    val msg = hl"$tref is not a trait"
+    val msg = hl"$symbol is not a trait"
     val explanation = {
       val errorCodeExample =
         """class A
           |class B
           |
-          |val a = new A with B // will fail with a compile error - B is not a trait"""
+          |val a = new A with B // will fail with a compile error - class B is not a trait""".stripMargin
       val codeExample =
         """class A
           |trait B
           |
-          |val a = new A with B // compiles normally"""
+          |val a = new A with B // compiles normally""".stripMargin
 
       hl"""Only traits can be mixed into classes using a ${"with"} keyword.
           |Consider the following example:

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -548,7 +548,7 @@ trait Checking {
   def checkClassType(tp: Type, pos: Position, traitReq: Boolean, stablePrefixReq: Boolean)(implicit ctx: Context): Type =
     tp.underlyingClassRef(refinementOK = false) match {
       case tref: TypeRef =>
-        if (traitReq && !(tref.symbol is Trait)) ctx.error(ex"$tref is not a trait", pos)
+        if (traitReq && !(tref.symbol is Trait)) ctx.error(TraitIsExpected(tref), pos)
         if (stablePrefixReq && ctx.phase <= ctx.refchecksPhase) checkStable(tref.prefix, pos)
         tp
       case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -548,7 +548,7 @@ trait Checking {
   def checkClassType(tp: Type, pos: Position, traitReq: Boolean, stablePrefixReq: Boolean)(implicit ctx: Context): Type =
     tp.underlyingClassRef(refinementOK = false) match {
       case tref: TypeRef =>
-        if (traitReq && !(tref.symbol is Trait)) ctx.error(TraitIsExpected(tref), pos)
+        if (traitReq && !(tref.symbol is Trait)) ctx.error(TraitIsExpected(tref.symbol), pos)
         if (stablePrefixReq && ctx.phase <= ctx.refchecksPhase) checkStable(tref.prefix, pos)
         tp
       case _ =>

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1151,4 +1151,25 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals(IllegalStartOfStatement(isModifier = false), err)
         assertEquals(IllegalStartOfStatement(isModifier = true), errWithModifier)
       }
+
+  @Test def traitIsExpected =
+    checkMessagesAfter("frontend") {
+      """
+        |class A
+        |class B
+        |
+        |object Test {
+        |  def main(args: Array[String]): Unit = {
+        |    val a = new A with B
+        |  }
+        |}
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+      val TraitIsExpected(tref) :: Nil = messages
+      assertEquals("B", tref.show)
+    }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1169,7 +1169,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
 
       assertMessageCount(1, messages)
-      val TraitIsExpected(tref) :: Nil = messages
-      assertEquals("B", tref.show)
+      val TraitIsExpected(symbol) :: Nil = messages
+      assertEquals("class B", symbol.show)
     }
 }


### PR DESCRIPTION
This PR is related to #1589. Specifically, it adds a new error message class for the following case - `Checking.scala:551`