### PR TITLE
Add an error message class for sealed classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -117,6 +117,7 @@ public enum ErrorMessageID {
     UnapplyInvalidNumberOfArgumentsID,
     StaticFieldsOnlyAllowedInObjectsID,
     CyclicInheritanceID,
+    UnableToExtendSealedClassID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1966,4 +1966,10 @@ object messages {
           |impossible to instantiate an object of this class"""
     }
   }
+
+  case class UnableToExtendSealedClass(pclazz: Symbol)(implicit ctx: Context) extends Message(UnableToExtendSealedClassID) {
+    val kind = "Syntax"
+    val msg = hl"Cannot extend ${"sealed"} $pclazz in a different source file"
+    val explanation = "A sealed class or trait can only be extended in the same file as its declaration"
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -877,7 +877,7 @@ class Namer { typer: Typer =>
             if (pclazz.is(Final))
               ctx.error(ExtendFinalClass(cls, pclazz), cls.pos)
             if (pclazz.is(Sealed) && pclazz.associatedFile != cls.associatedFile)
-              ctx.error(em"cannot extend sealed $pclazz in different compilation unit", cls.pos)
+              ctx.error(UnableToExtendSealedClass(pclazz), cls.pos)
             pt
           }
         }


### PR DESCRIPTION
This PR is related to #1589. Specifically, it adds a new error message class for the following case - `Namer.scala:880`. 

Unfortunately, this PR doesn't have a unit test because I wasn't able to find a way to trigger this particular behavior. It seems to me that it's impossible at the moment to check some code which is separated into two different compilation units inside a unit test. 

Maybe I'm simply missing something.