### PR TITLE
Fix #3333: adapt child instantiation

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -584,10 +584,9 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     // precondition: `tp1` should have the shape `path.Child`, thus `ThisType` is always covariant
     val thisTypeMap = new TypeMap {
       def apply(t: Type): Type = t match {
-        case tp @ ThisType(tref) if !tref.symbol.isStaticOwner && !tref.symbol.is(Module)  =>
-          // TODO: stackoverflow here
-          // newTypeVar(TypeBounds.upper(mapOver(tp.underlying)))
-          newTypeVar(TypeBounds.upper(mapOver(tref & tref.classSymbol.asClass.givenSelfType)))
+        case tp @ ThisType(tref) if !tref.symbol.isStaticOwner  =>
+          if (tref.symbol.is(Module)) mapOver(tref)
+          else newTypeVar(TypeBounds.upper(tp.underlying))
         case _ =>
           mapOver(t)
       }
@@ -633,7 +632,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     else {
       val protoTp2 = typeParamMap(tp2)
       if (protoTp1 <:< protoTp2) {
-        isFullyDefined(protoTp1 & protoTp2, force)
+        isFullyDefined(AndType(protoTp1, protoTp2), force)
         instUndetMap(protoTp1)
       }
       else {

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -626,14 +626,14 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     val protoTp1 = thisTypeMap(tp1.appliedTo(tvars))
 
     if (protoTp1 <:< tp2) {
-      isFullyDefined(protoTp1, force)
-      instUndetMap(protoTp1)
+      if (isFullyDefined(protoTp1, force)) protoTp1
+      else instUndetMap(protoTp1)
     }
     else {
       val protoTp2 = typeParamMap(tp2)
       if (protoTp1 <:< protoTp2) {
-        isFullyDefined(AndType(protoTp1, protoTp2), force)
-        instUndetMap(protoTp1)
+        if (isFullyDefined(AndType(protoTp1, protoTp2), force)) protoTp1
+        else instUndetMap(protoTp1)
       }
       else {
         debug.println(s"$protoTp1 <:< $protoTp2 = false")

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -596,7 +596,6 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     // replace type parameter references with bounds
     val typeParamMap = new TypeMap {
       def apply(t: Type): Type = t match {
-
         case tp: TypeRef if tp.symbol.is(TypeParam) && tp.underlying.isInstanceOf[TypeBounds] =>
           // See tests/patmat/gadt.scala  tests/patmat/exhausting.scala  tests/patmat/t9657.scala
           val exposed =
@@ -611,13 +610,32 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
       }
     }
 
+    // replace uninstantiated type vars with WildcardType, check tests/patmat/3333.scala
+    val instUndetMap = new TypeMap {
+      def apply(t: Type): Type = t match {
+        case tvar: TypeVar if !tvar.isInstantiated => WildcardType(tvar.origin.underlying.bounds)
+        case _ => mapOver(t)
+      }
+    }
+
+    val force = new ForceDegree.Value(
+      tvar => !(ctx.typerState.constraint.entry(tvar.origin) eq tvar.origin.underlying),
+      minimizeAll = false
+    )
+
     val tvars = tp1.typeParams.map { tparam => newTypeVar(tparam.paramInfo.bounds) }
     val protoTp1 = thisTypeMap(tp1.appliedTo(tvars))
 
-    if (protoTp1 <:< tp2 && isFullyDefined(protoTp1, ForceDegree.noBottom)) protoTp1
+    if (protoTp1 <:< tp2) {
+      isFullyDefined(protoTp1, force)
+      instUndetMap(protoTp1)
+    }
     else {
       val protoTp2 = typeParamMap(tp2)
-      if (protoTp1 <:< protoTp2 && isFullyDefined(protoTp1 & protoTp2, ForceDegree.noBottom)) protoTp1
+      if (protoTp1 <:< protoTp2) {
+        isFullyDefined(protoTp1 & protoTp2, force)
+        instUndetMap(protoTp1)
+      }
       else {
         debug.println(s"$protoTp1 <:< $protoTp2 = false")
         NoType

--- a/tests/patmat/3333.check
+++ b/tests/patmat/3333.check
@@ -1,0 +1,1 @@
+10: Pattern Match Exhaustivity: _: IntNumber, NotNaN

--- a/tests/patmat/3333.scala
+++ b/tests/patmat/3333.scala
@@ -1,0 +1,14 @@
+sealed trait IntegralNumber
+
+object IntegralNumber {
+  object NaN extends IntegralNumber
+  object NotNaN extends IntegralNumber
+
+  sealed abstract class FiniteNumberImpl[N](val value: N) extends IntegralNumber
+  sealed class IntNumber(value: Int) extends FiniteNumberImpl[Int](value)
+
+  def test(o: IntegralNumber) = o match {
+    case NaN => -1
+  }
+
+}

--- a/tests/patmat/3455.check
+++ b/tests/patmat/3455.check
@@ -1,0 +1,1 @@
+11: Pattern Match Exhaustivity: Decimal

--- a/tests/patmat/3455.scala
+++ b/tests/patmat/3455.scala
@@ -1,0 +1,14 @@
+trait AxisCompanion {
+   sealed trait Format
+   object Format {
+      case object Decimal extends Format
+      case object Integer extends Format
+   }
+}
+object Axis extends AxisCompanion
+class Axis {
+   import Axis._
+   def test( f: Format ) = f match {
+      case Format.Integer => "Int"
+   }
+}

--- a/tests/patmat/3469.scala
+++ b/tests/patmat/3469.scala
@@ -1,0 +1,9 @@
+object O {
+  sealed trait Trait[+A] { type T }
+  case class CaseClass[+A](a: A) extends Trait[A] { type T = Nothing }
+
+  def id[TT, A](v: Trait[A] { type T = TT }): Trait[A] { type T = TT } =
+    v match {
+      case CaseClass(a) => CaseClass(a)
+    }
+}


### PR DESCRIPTION
Fix #3333 #3455 #3469: adapt child instantiation

Structural types in #3333 is left open.

- If a child type parameter is not constrained, instantiate it to Wildcard
- In prefix inference, forget `ThisType` for modules.