### PR TITLE
Add an error message for a cyclic inheritance case

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -116,6 +116,7 @@ public enum ErrorMessageID {
     PackageNameAlreadyDefinedID,
     UnapplyInvalidNumberOfArgumentsID,
     StaticFieldsOnlyAllowedInObjectsID,
+    CyclicInheritanceID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1949,4 +1949,21 @@ object messages {
     val explanation =
       hl"${"@static"} members are only allowed inside objects."
   }
+
+  case class CyclicInheritance(symbol: Symbol, addendum: String)(implicit ctx: Context) extends Message(CyclicInheritanceID) {
+    val kind = "Syntax"
+    val msg = hl"Cyclic inheritance: $symbol extends itself$addendum"
+    val explanation = {
+      val codeExample = "class A extends A"
+
+      hl"""Cyclic inheritance is prohibited in Dotty.
+          |Consider the following example:
+          |
+          |$codeExample
+          |
+          |The example mentioned above would fail because this type of inheritance hierarchy
+          |creates a "cycle" where a not yet defined class A extends itself which makes
+          |impossible to instantiate an object of this class"""
+    }
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -869,7 +869,7 @@ class Namer { typer: Typer =>
                 "\n(Note that inheriting a class of the same name is no longer allowed)"
               case _ => ""
             }
-            ctx.error(i"cyclic inheritance: $cls extends itself$addendum", parent.pos)
+            ctx.error(CyclicInheritance(cls, addendum), parent.pos)
             defn.ObjectType
           }
           else {

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1225,7 +1225,6 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals("(class Int, class String)", argTypes.map(_.typeSymbol).mkString("(", ", ", ")"))
       }
 
-
   @Test def staticOnlyAllowedInsideObjects =
     checkMessagesAfter("checkStatic") {
       """
@@ -1237,5 +1236,17 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
       val StaticFieldsOnlyAllowedInObjects(field) = messages.head
       assertEquals(field.show, "method bar")
+    }
+
+  @Test def cyclicInheritance =
+    checkMessagesAfter("frontend") {
+      "class A extends A"
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+      val CyclicInheritance(symbol, _) :: Nil = messages
+      assertEquals("class A", symbol.show)
     }
 }


### PR DESCRIPTION
This PR is related to #1589. Specifically, it adds a new error message class for a cyclic inheritance case - `Namer.scala:872`. I decided not to include an explanation in this particular message because it's pretty self-explanatory.