### PR TITLE
Fix MatchError: InfixOp on TreeAccumulator

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1325,7 +1325,8 @@ object Trees {
             this(this(x, arg), annot)
           case Thicket(ts) =>
             this(x, ts)
-          case _ =>
+          case _ if ctx.reporter.errorsReported || ctx.mode.is(Mode.Interactive) =>
+            // In interactive mode, errors might come from previous runs.
             // In case of errors it may be that typed trees point to untyped ones.
             // The IDE can still traverse inside such trees, either in the run where errors
             // are reported, or in subsequent ones.

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1325,7 +1325,7 @@ object Trees {
             this(this(x, arg), annot)
           case Thicket(ts) =>
             this(x, ts)
-          case _ if ctx.mode.is(Mode.Interactive) =>
+          case _ =>
             // In case of errors it may be that typed trees point to untyped ones.
             // The IDE can still traverse inside such trees, either in the run where errors
             // are reported, or in subsequent ones.

--- a/tests/neg/i3487.scala
+++ b/tests/neg/i3487.scala
@@ -1,0 +1,4 @@
+object Test {
+  type &:[H, T] = Int
+  val a: F[Int] { type X = Int &: String } = ??? // error
+}


### PR DESCRIPTION
In case of errors it may be that typed trees point to untyped ones. I think it makes sense to avoid the MatchError in that case, not only in Interative mode.
