### PR TITLE
features.html: remove arrow pointing to nowhere

### DIFF
--- a/docs/_includes/features.html
+++ b/docs/_includes/features.html
@@ -80,12 +80,5 @@
         </div>
         <br/>
     </div>
-    <div class="centered-subtitle">
-        <a href="#why-dotty">
-            <i id="scroll-down-arrow" class="animated infinite pulse material-icons">
-                expand_more
-            </i>
-        </a>
-    </div>
 </div>
 


### PR DESCRIPTION
This arrow is useless after 5e325b049868351807d053255eb1d82ba5149bc8