### PR TITLE
Fix #3480: Fix expanded name

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -114,11 +114,12 @@ object NameOps {
       else name.toTermName.exclude(AvoidClashName)
     }
 
-    def expandedName(base: Symbol, kind: QualifiedNameKind = ExpandedName)(implicit ctx: Context): N = {
-      val prefix =
-        if (base.name.is(ExpandedName)) base.name else base.fullNameSeparated(ExpandPrefixName)
-      likeSpaced { kind(prefix.toTermName, name.toTermName) }
-    }
+    /** The expanded name.
+     *  This is the fully qualified name of `base` with `ExpandPrefixName` as separator,
+     *  followed by `kind` and the name.
+     */
+    def expandedName(base: Symbol, kind: QualifiedNameKind = ExpandedName)(implicit ctx: Context): N =
+      likeSpaced { base.fullNameSeparated(ExpandPrefixName, kind, name) }
 
     /** Revert the expanded name. */
     def unexpandedName: N = likeSpaced {

--- a/tests/pos/i3480.scala
+++ b/tests/pos/i3480.scala
@@ -1,0 +1,5 @@
+class Test {
+  def foo(x: PartialFunction[Int, Int]) = x(0)
+
+  foo({ case i => i})
+}

--- a/tests/run/i3006b.check
+++ b/tests/run/i3006b.check
@@ -1,3 +1,3 @@
-Foo$$init$$$bar$1
-Foo$$init$$$bar$2
-Bar$$init$$$bar$1
+Foo$$_$bar$1
+Foo$$_$bar$2
+Bar$$_$bar$1


### PR DESCRIPTION
Expanded name behaved different from what would be expected
by the fullNameSeparated conventions. This led to local
dummies creeping in the expanded names for local definitions
in templates.