### PR TITLE
Fix #3476: No generic signatures for synthetic syms

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -499,7 +499,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     // generic information could disappear as a consequence of a seemingly
     // unrelated change.
        ctx.base.settings.YnoGenericSig.value
-    || sym.is(Flags.Artifact)
+    || sym.is(Flags.Artifact | Flags.Synthetic)
     || sym.is(Flags.allOf(Flags.Method, Flags.Lifted))
     || sym.is(Flags.Bridge)
   )


### PR DESCRIPTION
Disable java generic signature generation for symbols that are marked
with the `Artifact` or `Synthetic` flags.

I'm not 100% sure about that. scalac only excludes symbols that have the `Artifact` flag, and doesn't care about `Synthetic`. I don't know if more symbols in dotc should be flagged as `Artifact`, or if we should just consider `Synthetic` here... 

However, I think it makes sense to not generate a signature for synthetic symbols. Since they are synthetic, we don't expect them to be inspected via reflection or in a debugger.

For reference, here are the definitions of `Artifact` and `Synthetic` in scalac and dotc:

### scalac
```scala
/** Flag used to distinguish programmatically generated definitions from user-written ones.
 *  @see ARTIFACT                                                                          
 */                                                                                        
val SYNTHETIC: FlagSet                                                                     

/** Flag used to distinguish platform-specific implementation details.                           
 *  Trees and symbols which are currently marked ARTIFACT by scalac:                             
 *    * $outer fields and accessors                                                              
 *    * super accessors                                                                          
 *    * protected accessors                                                                      
 *    * lazy local accessors                                                                     
 *    * bridge methods                                                                           
 *    * default argument getters                                                                 
 *    * evaluation-order preserving locals for right-associative and out-of-order named arguments
 *    * catch-expression storing vals                                                            
 *    * anything else which feels a setFlag(ARTIFACT)                                            
 *                                                                                               
 *  @see SYNTHETIC                                                                               
 */                                                                                              
val ARTIFACT: FlagSet                                                                            
```


### dotc
```scala
/** A compiler-generated symbol, which is visible for type-checking
 *  (compare with artifact)                                        
 */                                                                
final val Synthetic = commonFlag(18, "<synthetic>")       

/** Symbol should be ignored when typechecking; will be marked ACC_SYNTHETIC in bytecode */
final val Artifact = commonFlag(33, "<artifact>")                                          
```