### PR TITLE
Fix build failure after last merge

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -615,7 +615,7 @@ object Symbols {
         assert(myTree.isEmpty)
         val body = unpickler.body(ctx.addMode(Mode.ReadPositions))
         myTree = body.headOption.getOrElse(tpd.EmptyTree)
-        if (!ctx.settings.tasty.value)
+        if (!ctx.settings.fromTasty.value)
           unpickler = null
       }
       myTree


### PR DESCRIPTION
tasty got renamed to fromTasty in
331245e444752eed1595c09e9fa3bda000c84def, but tasty was used in
51bc54a681ba243b545e72b114899562f60847c4 which was merged at the same
time.