### PR TITLE
Give position to symbols when unpickling

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -196,7 +196,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       case tp: MethodType =>
         def valueParam(name: TermName, info: Type): TermSymbol = {
           val maybeImplicit = if (tp.isImplicitMethod) Implicit else EmptyFlags
-          ctx.newSymbol(sym, name, TermParam | maybeImplicit, info)
+          ctx.newSymbol(sym, name, TermParam | maybeImplicit, info, coord = sym.coord)
         }
         val params = (tp.paramNames, tp.paramInfos).zipped.map(valueParam)
         val (paramss, rtp) = valueParamss(tp.instantiate(params map (_.termRef)))

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -262,7 +262,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     val parents1 =
       if (parents.head.classSymbol.is(Trait)) parents.head.parents.head :: parents
       else parents
-    val cls = ctx.newNormalizedClassSymbol(owner, tpnme.ANON_FUN, Synthetic, parents1,
+    val cls = ctx.newNormalizedClassSymbol(owner, tpnme.ANON_CLASS, Synthetic, parents1,
         coord = fns.map(_.pos).reduceLeft(_ union _))
     val constr = ctx.newConstructor(cls, Synthetic, Nil, Nil).entered
     def forwarder(fn: TermSymbol, name: TermName) = {

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -96,6 +96,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val YdetailedStats = BooleanSetting("-Ydetailed-stats", "show detailed internal compiler stats (needs Stats.enabled to be set to true).")
   val Yheartbeat = BooleanSetting("-Ydetailed-stats", "show heartbeat stack trace of compiler operations (needs Stats.enabled to be set to true).")
   val YprintPos = BooleanSetting("-Yprint-pos", "show tree positions.")
+  val YprintPosSyms = BooleanSetting("-Yprint-pos-syms", "show symbol definitions positions.")
   val YnoDeepSubtypes = BooleanSetting("-Yno-deep-subtypes", "throw an exception on deep subtyping call stacks.")
   val YnoPatmatOpt = BooleanSetting("-Yno-patmat-opt", "disable all pattern matching optimizations.")
   val YplainPrinter = BooleanSetting("-Yplain-printer", "Pretty-print using a plain printer.")

--- a/compiler/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
@@ -2,6 +2,7 @@ package dotty.tools.dotc
 package core
 
 import Contexts._
+import Run.RunInfo
 import config.Printers.typr
 
 trait ConstraintRunInfo { self: RunInfo =>

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -14,11 +14,12 @@ import NameOps._
 import Uniques._
 import SymDenotations._
 import Comments._
+import Run.RunInfo
 import util.Positions._
 import ast.Trees._
 import ast.untpd
 import util.{FreshNameCreator, SimpleIdentityMap, SourceFile, NoSource}
-import typer.{Implicits, ImplicitRunInfo, ImportInfo, Inliner, NamerContextOps, SearchHistory, TypeAssigner, Typer}
+import typer.{Implicits, ImportInfo, Inliner, NamerContextOps, SearchHistory, TypeAssigner, Typer}
 import Implicits.ContextualImplicits
 import config.Settings._
 import config.Config
@@ -673,11 +674,6 @@ object Contexts {
     implicit def toBase(ctx: Context): ContextBase = ctx.base
 
     // @sharable val theBase = new ContextBase // !!! DEBUG, so that we can use a minimal context for reporting even in code that normally cannot access a context
-  }
-
-  /** Info that changes on each compiler run */
-  class RunInfo(initctx: Context) extends ImplicitRunInfo with ConstraintRunInfo {
-    implicit val ctx: Context = initctx
   }
 
   class GADTMap(initBounds: SimpleIdentityMap[Symbol, TypeBounds]) extends util.DotClass {

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -288,7 +288,7 @@ trait Symbols { this: Context =>
     val tparamBuf = new mutable.ListBuffer[TypeSymbol]
     val trefBuf = new mutable.ListBuffer[TypeRef]
     for (name <- names) {
-      val tparam = newNakedSymbol[TypeName](NoCoord)
+      val tparam = newNakedSymbol[TypeName](owner.coord)
       tparamBuf += tparam
       trefBuf += TypeRef(owner.thisType, tparam)
     }

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -443,10 +443,11 @@ object Symbols {
       if (lastDenot == null) NoRunId else lastDenot.validFor.runId
 
     /** Does this symbol come from a currently compiled source file? */
-    final def isDefinedInCurrentRun(implicit ctx: Context): Boolean = {
-      // FIXME: broken now now that symbols unpickled from TASTY have a position
-      pos.exists && defRunId == ctx.runId
-    }
+    final def isDefinedInCurrentRun(implicit ctx: Context): Boolean =
+      pos.exists && defRunId == ctx.runId && {
+        val file = associatedFile
+        file != null && ctx.runInfo.files.contains(file)
+      }
 
     /** Is symbol valid in current run? */
     final def isValidInCurrentRun(implicit ctx: Context): Boolean =
@@ -540,7 +541,7 @@ object Symbols {
      *  Overridden in ClassSymbol
      */
     def associatedFile(implicit ctx: Context): AbstractFile =
-      denot.topLevelClass.symbol.associatedFile
+      if (lastDenot == null) null else lastDenot.topLevelClass.symbol.associatedFile
 
     /** The class file from which this class was generated, null if not applicable. */
     final def binaryFile(implicit ctx: Context): AbstractFile = {

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -130,8 +130,8 @@ trait Symbols { this: Context =>
     newClassSymbol(owner, name, flags, completer, privateWithin, coord, assocFile)
   }
 
-  def newRefinedClassSymbol = newCompleteClassSymbol(
-    ctx.owner, tpnme.REFINE_CLASS, NonMember, parents = Nil)
+  def newRefinedClassSymbol(coord: Coord = NoCoord) =
+    newCompleteClassSymbol(ctx.owner, tpnme.REFINE_CLASS, NonMember, parents = Nil, coord = coord)
 
   /** Create a module symbol with associated module class
    *  from its non-info fields and a function producing the info
@@ -444,6 +444,7 @@ object Symbols {
 
     /** Does this symbol come from a currently compiled source file? */
     final def isDefinedInCurrentRun(implicit ctx: Context): Boolean = {
+      // FIXME: broken now now that symbols unpickled from TASTY have a position
       pos.exists && defRunId == ctx.runId
     }
 
@@ -563,8 +564,12 @@ object Symbols {
       }
     }
 
-    /** The position of this symbol, or NoPosition is symbol was not loaded
-     *  from source.
+    /** The position of this symbol, or NoPosition if the symbol was not loaded
+     *  from source or from TASTY. This is always a zero-extent position.
+     *
+     *  NOTE: If the symbol was not loaded from the current compilation unit,
+     *  the implicit conversion `sourcePos` will return the wrong result, careful!
+     *  TODO: Consider changing this method return type to `SourcePosition`.
      */
     def pos: Position = if (coord.isPosition) coord.toPosition else NoPosition
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -41,11 +41,21 @@ class PositionPickler(pickler: TastyPickler, addrOfTree: tpd.Tree => Option[Addr
       lastPos = pos
     }
 
-    /** True if x's position cannot be reconstructed automatically from its initialPos
+    /** True if x's position shouldn't be reconstructed automatically from its initialPos
      */
     def alwaysNeedsPos(x: Positioned) = x match {
-      case _: WithLazyField[_]            // initialPos is inaccurate for trees with lazy field
-         | _: Trees.PackageDef[_] => true // package defs might be split into several Tasty files
+      case
+          // initialPos is inaccurate for trees with lazy field
+          _: WithLazyField[_]
+
+          // A symbol is created before the corresponding tree is unpickled,
+          // and its position cannot be changed afterwards.
+          // so we cannot use the tree initialPos to set the symbol position.
+          // Instead, we always pickle the position of definitions.
+          | _: Trees.DefTree[_]
+
+          // package defs might be split into several Tasty files
+          | _: Trees.PackageDef[_] => true
       case _ => false
     }
 

--- a/compiler/src/dotty/tools/dotc/fromtasty/TASTYRun.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/TASTYRun.scala
@@ -6,7 +6,7 @@ import core.Contexts._
 
 class TASTYRun(comp: Compiler, ictx: Context) extends Run(comp, ictx) {
   override def compile(classNames: List[String]) = {
-    units = classNames.map(new TASTYCompilationUnit(_))
-    compileUnits()
+    val units = classNames.map(new TASTYCompilationUnit(_))
+    compileUnits(units)
   }
 }

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -226,7 +226,7 @@ class InteractiveDriver(settings: List[String]) extends Driver {
 
       run.compileSources(List(source))
       run.printSummary()
-      val t = run.units.head.tpdTree
+      val t = ctx.runInfo.units.head.tpdTree
       cleanup(t)
       myOpenedTrees(uri) = topLevelClassTrees(t, source)
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1181,7 +1181,8 @@ object Parsers {
         t
     }
 
-    def ascription(t: Tree, location: Location.Value) = atPos(startOffset(t), in.skipToken()) {
+    def ascription(t: Tree, location: Location.Value) = atPos(startOffset(t)) {
+      in.skipToken()
       in.token match {
         case USCORE =>
           val uscoreStart = in.skipToken()

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -13,6 +13,7 @@ import Trees._
 import TypeApplications._
 import Decorators._
 import config.Config
+import util.Positions._
 import transform.SymUtils._
 import scala.annotation.switch
 import language.implicitConversions
@@ -630,14 +631,18 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       else if (tree.isType && !homogenizedView)
         txt = toText(tp)
     }
-    if (printPos && !suppressPositions) {
-      // add positions
-      val pos =
-        if (homogenizedView && !tree.isInstanceOf[MemberDef]) tree.pos.toSynthetic
-        else tree.pos
-      val clsStr = ""//if (tree.isType) tree.getClass.toString else ""
-      txt = (txt ~ "@" ~ pos.toString ~ clsStr).close
-    }
+    if (!suppressPositions) {
+      if (printPos) {
+        val pos =
+          if (homogenizedView && !tree.isInstanceOf[MemberDef]) tree.pos.toSynthetic
+          else tree.pos
+        val clsStr = ""//if (tree.isType) tree.getClass.toString else ""
+        txt = (txt ~ "@" ~ pos.toString ~ clsStr).close
+      }
+      if (ctx.settings.YprintPosSyms.value && tree.isDef)
+        txt = (txt ~
+          s"@@(${tree.symbol.name}=" ~ tree.symbol.pos.toString ~ ")").close
+   }
     if (ctx.settings.YshowTreeIds.value)
       txt = (txt ~ "#" ~ tree.uniqueId.toString).close
     tree match {

--- a/compiler/src/dotty/tools/dotc/transform/ExpandPrivate.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandPrivate.scala
@@ -90,8 +90,8 @@ class ExpandPrivate extends MiniPhase with IdentityDenotTransformer { thisPhase 
       }
 
       assert(d.symbol.sourceFile != null &&
-             isSimilar(d.symbol.sourceFile.path, ctx.source.file.path),
-          s"private ${d.symbol.showLocated} in ${d.symbol.sourceFile} accessed from ${ctx.owner.showLocated} in ${ctx.source.file}")
+             isSimilar(d.symbol.sourceFile.path, ctx.owner.sourceFile.path),
+          s"private ${d.symbol.showLocated} in ${d.symbol.sourceFile} accessed from ${ctx.owner.showLocated} in ${ctx.owner.sourceFile}")
       d.ensureNotPrivate.installAfter(thisPhase)
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -70,7 +70,7 @@ class ParamForwarding(thisPhase: DenotTransformer) {
                     val superAcc =
                       Super(This(currentClass), tpnme.EMPTY, inConstrCall = false).select(alias)
                     typr.println(i"adding param forwarder $superAcc")
-                    DefDef(sym, superAcc.ensureConforms(sym.info.widen))
+                    DefDef(sym, superAcc.ensureConforms(sym.info.widen)).withPos(stat.pos)
                   }
                   return forwarder(ctx.withPhase(thisPhase.next))
                 }

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
@@ -99,7 +99,7 @@ class SyntheticMethods(thisPhase: DenotTransformer) {
         case nme.productElement => vrefss => productElementBody(accessors.length, vrefss.head.head)
       }
       ctx.log(s"adding $synthetic to $clazz at ${ctx.phase}")
-      DefDef(synthetic, syntheticRHS(ctx.withOwner(synthetic)))
+      DefDef(synthetic, syntheticRHS(ctx.withOwner(synthetic))).withPos(ctx.owner.pos.focus)
     }
 
     /** The class

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -28,8 +28,8 @@ object EtaExpansion {
       val name = UniqueName.fresh(prefix)
       val liftedType = fullyDefinedType(expr.tpe.widen, "lifted expression", expr.pos)
       val sym = ctx.newSymbol(ctx.owner, name, EmptyFlags, liftedType, coord = positionCoord(expr.pos))
-      defs += ValDef(sym, expr)
-      ref(sym.termRef)
+      defs += ValDef(sym, expr).withPos(expr.pos.focus)
+      ref(sym.termRef).withPos(expr.pos)
     }
 
   /** Lift out common part of lhs tree taking part in an operator assignment such as

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -9,6 +9,7 @@ import util.Stats.{track, record, monitored}
 import printing.{Showable, Printer}
 import printing.Texts._
 import Contexts._
+import Run.RunInfo
 import Types._
 import Flags._
 import TypeErasure.{erasure, hasStableErasure}

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -98,8 +98,8 @@ object Inliner {
             val accessorType = accessedType.ensureMethodic
             val accessor = accessorSymbol(tree, accessorType).asTerm
             val accessorDef = polyDefDef(accessor, tps => argss =>
-              rhs(refPart, tps, argss))
-            val accessorRef = ref(accessor).appliedToTypeTrees(targs).appliedToArgss(argss)
+              rhs(refPart, tps, argss).withPos(tree.pos.focus))
+            val accessorRef = ref(accessor).appliedToTypeTrees(targs).appliedToArgss(argss).withPos(tree.pos)
             (accessorDef, accessorRef)
           } else {
             // Hard case: Reference needs to go via a dynamic prefix
@@ -135,11 +135,14 @@ object Inliner {
             val accessor = accessorSymbol(tree, accessorType).asTerm
 
             val accessorDef = polyDefDef(accessor, tps => argss =>
-              rhs(argss.head.head.select(refPart.symbol), tps.drop(localRefs.length), argss.tail))
+              rhs(argss.head.head.select(refPart.symbol), tps.drop(localRefs.length), argss.tail)
+              .withPos(tree.pos.focus)
+            )
 
             val accessorRef = ref(accessor)
               .appliedToTypeTrees(localRefs.map(TypeTree(_)) ++ targs)
               .appliedToArgss((qual :: Nil) :: argss)
+              .withPos(tree.pos)
             (accessorDef, accessorRef)
           }
         accessors += accessorDef
@@ -168,8 +171,8 @@ object Inliner {
               // Draft code (incomplete):
               //
               //  val accessor = accessorSymbol(tree, TypeAlias(tree.tpe)).asType
-              //  myAccessors += TypeDef(accessor)
-              //  ref(accessor)
+              //  myAccessors += TypeDef(accessor).withPos(tree.pos.focus)
+              //  ref(accessor).withPos(tree.pos)
               //
               tree
             }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -759,7 +759,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     args match {
       case ValDef(_, _, _) :: _ =>
         typedDependent(args.asInstanceOf[List[ValDef]])(
-          ctx.fresh.setOwner(ctx.newRefinedClassSymbol).setNewScope)
+          ctx.fresh.setOwner(ctx.newRefinedClassSymbol(tree.pos)).setNewScope)
       case _ =>
         typed(cpy.AppliedTypeTree(tree)(untpd.TypeTree(funCls.typeRef), args :+ body), pt)
     }

--- a/compiler/test/dotc/tests.scala
+++ b/compiler/test/dotc/tests.scala
@@ -73,7 +73,7 @@ class tests extends CompilerTest {
     else List("-Ycheck:tailrec,resolveSuper,mixin,elimStaticThis,labelDef,simplify")
   } ++ checkOptions ++ classPath
 
-  val testPickling = List("-Xprint-types", "-Ytest-pickler", "-Ystop-after:pickler", "-Yprint-pos")
+  val testPickling = List("-Xprint-types", "-Ytest-pickler", "-Ystop-after:pickler", "-Yprint-pos", "-Yprint-pos-syms")
 
   val twice = List("#runs", "2")
   val staleSymbolError: List[String] = List()

--- a/compiler/test/dotty/tools/dotc/CompilerTest.scala
+++ b/compiler/test/dotty/tools/dotc/CompilerTest.scala
@@ -104,7 +104,7 @@ abstract class CompilerTest {
           else (fp, jfp)
         }
       val expErrors = expectedErrors(filePaths.toList)
-      (filePaths, javaFilePaths, normArgs, expErrors)
+      (filePaths.sorted, javaFilePaths.sorted, normArgs, expErrors)
     }
     if (runTest)
       log(s"WARNING: run tests can only be run by partest, JUnit just verifies compilation: $prefix$dirName")

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -151,7 +151,8 @@ trait ParallelTesting extends RunnerOrchestration { self =>
   ) extends TestSource {
 
     /** Get the files grouped by `_X` as a list of groups, files missing this
-     *  suffix will be put into the same group
+     *  suffix will be put into the same group.
+     *  Files in each group are sorted alphabetically.
      *
      *  Filters out all none source files
      */
@@ -170,7 +171,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
         .toOption
         .getOrElse("")
       }
-      .toList.sortBy(_._1).map(_._2.filter(isSourceFile))
+      .toList.sortBy(_._1).map(_._2.filter(isSourceFile).sorted)
   }
 
   /** Each `Test` takes the `testSources` and performs the compilation and assertions

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -54,7 +54,8 @@ object TestConfiguration {
   val picklingOptions = defaultUnoptimised and (
     "-Xprint-types",
     "-Ytest-pickler",
-    "-Yprint-pos"
+    "-Yprint-pos",
+    "-Yprint-pos-syms"
   )
   val scala2Mode = defaultOptions and "-language:Scala2"
   val explicitUTF8 = defaultOptions and ("-encoding", "UTF8")

--- a/tests/neg/checkNoConflict/A1.scala
+++ b/tests/neg/checkNoConflict/A1.scala
@@ -1,0 +1,2 @@
+package foo
+class A

--- a/tests/neg/checkNoConflict/A2.scala
+++ b/tests/neg/checkNoConflict/A2.scala
@@ -1,0 +1,2 @@
+package foo
+class A // error: class A in package foo has already been compiled once during this run

--- a/tests/pos-from-tasty/anonBridge.scala
+++ b/tests/pos-from-tasty/anonBridge.scala
@@ -1,0 +1,3 @@
+class Test {
+  val x: PartialFunction[Int, Int] = { case x: Int => x }
+}


### PR DESCRIPTION
I started working on this to fix a crash when compiling the collection-strawman contrib tests. I minimized it to `anonBridge.scala` (in the collection-strawman, unpickling happened because of `inline def`, here the test is in `from-tasty` so it will be compiled from an unpickled tree). Eventually, I would also like to use the unpickled symbol positions in the IDE, but this will require more work. (Right now, going from an arbitrary Position to a SourcePosition is annoying, it requires creating a SourceFile which requires converting the source file content to an array of bytes).