### PR TITLE
Fix position of desugared tree wrapped in parentheses

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1017,7 +1017,17 @@ object desugar {
     }
 
     // begin desugar
+
+    // Special case for `Parens` desugaring: unlike all the desugarings below,
+    // its output is not a new tree but an existing one whose position should
+    // be preserved, so we shouldn't call `withPos` on it.
     tree match {
+      case Parens(t) =>
+        return t
+      case _ =>
+    }
+
+    val desugared = tree match {
       case SymbolLit(str) =>
         Apply(
           ref(defn.SymbolClass.companionModule.termRef),
@@ -1057,8 +1067,6 @@ object desugar {
         }
       case PrefixOp(op, t) =>
         Select(t, nme.UNARY_PREFIX ++ op.name)
-      case Parens(t) =>
-        t
       case Tuple(ts) =>
         val arity = ts.length
         def tupleTypeRef = defn.TupleType(arity)
@@ -1096,7 +1104,8 @@ object desugar {
               finalizer)
         }
     }
-  }.withPos(tree.pos)
+    desugared.withPos(tree.pos)
+  }
 
   /** Create a class definition with the same info as the refined type given by `parent`
    *  and `refinements`.

--- a/compiler/test-resources/repl/errmsgs
+++ b/compiler/test-resources/repl/errmsgs
@@ -64,3 +64,7 @@ scala> { def f: Int = g; val x: Int = 1; def g: Int = 5; }
 1 | { def f: Int = g; val x: Int = 1; def g: Int = 5; }
   |                ^
   |           `g` is a forward reference extending over the definition of `x`
+scala> while (((  foo ))) {}
+1 | while (((  foo ))) {}
+  |            ^^^
+  |            not found: foo


### PR DESCRIPTION
Before this commit, the added testcase produced the following result:
```scala
scala> while ((( foo ))) {}
1 |while ((( foo ))) {}
  |      ^^^^^^^^^^^
  |      not found: foo
```