### PR TITLE
Port part of scala/scala#5293

### DIFF
--- a/compiler/test/dotty/tools/backend/jvm/AsmConverters.scala
+++ b/compiler/test/dotty/tools/backend/jvm/AsmConverters.scala
@@ -96,7 +96,7 @@ object ASMConverters {
   case class FrameEntry   (`type`: Int, local: List[Any], stack: List[Any])                                   extends Instruction { def opcode: Int = -1 }
   case class LineNumber   (line: Int, start: Label)                                                           extends Instruction { def opcode: Int = -1 }
 
-  case class MethodHandle(tag: Int, owner: String, name: String, desc: String)
+  case class MethodHandle(tag: Int, owner: String, name: String, desc: String, itf: Boolean)
 
   case class ExceptionHandler(start: Label, end: Label, handler: Label, desc: Option[String])
   case class LocalVariable(name: String, desc: String, signature: Option[String], start: Label, end: Label, index: Int)
@@ -149,7 +149,7 @@ object ASMConverters {
       case _ => a // can be: Class, method Type, primitive constant
     })(collection.breakOut)
 
-    private def convertMethodHandle(h: asm.Handle): MethodHandle = MethodHandle(h.getTag, h.getOwner, h.getName, h.getDesc)
+    private def convertMethodHandle(h: asm.Handle): MethodHandle = MethodHandle(h.getTag, h.getOwner, h.getName, h.getDesc, h.isInterface)
 
     private def convertHandlers(method: t.MethodNode): List[ExceptionHandler] = {
       method.tryCatchBlocks.asScala.map(h => ExceptionHandler(applyLabel(h.start), applyLabel(h.end), applyLabel(h.handler), Option(h.`type`)))(collection.breakOut)
@@ -229,7 +229,7 @@ object ASMConverters {
     case x => x.asInstanceOf[Object]
   }
 
-  def unconvertMethodHandle(h: MethodHandle): asm.Handle = new asm.Handle(h.tag, h.owner, h.name, h.desc)
+  def unconvertMethodHandle(h: MethodHandle): asm.Handle = new asm.Handle(h.tag, h.owner, h.name, h.desc, h.itf)
   def unconvertBsmArgs(a: List[Object]): Array[Object] = a.map({
     case h: MethodHandle => unconvertMethodHandle(h)
     case o => o


### PR DESCRIPTION
Original commit from Irytz: https://github.com/scala/scala/commit/e619b033350a3378d650db4c3e5b1bfc83b73d81

Upgrade asm to 5.1

The constructor of scala.tools.asm.Handle now takes an additional
boolean parameter to denote whether the owner is an interface.