### PR TITLE
-Xverify-signatures: emit errors, not warnings

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -522,8 +522,8 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
       }
     }
 
-    if(!valid) {
-      ctx.warning(
+    if (!valid) {
+      ctx.error(
         i"""|compiler bug: created invalid generic signature for $sym in ${sym.denot.owner.showFullName}
             |signature: $sig
             |if this is reproducible, please report bug at https://github.com/lampepfl/dotty/issues


### PR DESCRIPTION
Otherwise the tests will still succeed.