### PR TITLE
Fix #3543: compare extractor with TermRef instead of MethodType

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -400,9 +400,9 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         if (fun.symbol.owner == scalaSeqFactoryClass)
           projectSeq(pats)
         else
-          Prod(pat.tpe.stripAnnots, fun.tpe.widen, fun.symbol, projectSeq(pats) :: Nil, irrefutable(fun))
+          Prod(pat.tpe.stripAnnots, fun.tpe, fun.symbol, projectSeq(pats) :: Nil, irrefutable(fun))
       else
-        Prod(pat.tpe.stripAnnots, fun.tpe.widen, fun.symbol, pats.map(project), irrefutable(fun))
+        Prod(pat.tpe.stripAnnots, fun.tpe, fun.symbol, pats.map(project), irrefutable(fun))
     case Typed(pat @ UnApply(_, _, _), _) => project(pat)
     case Typed(expr, tpt) =>
       Typ(erase(expr.tpe.stripAnnots), true)

--- a/tests/patmat/3543.scala
+++ b/tests/patmat/3543.scala
@@ -9,7 +9,7 @@ class Test {
 
     xs match {
       case Yes(x) :: ls => println("Yes")
-      case No(y) :: ls => println("No") // unreachable code
+      case No(y) :: ls => println("No")
       case _ =>
     }
   }
@@ -26,7 +26,7 @@ class Test2 {
 
     xs match {
       case No() :: ls => println("No")
-      case Yes() :: ls => println("Yes") // unreachable code
+      case Yes() :: ls => println("Yes")
       case _ =>
     }
   }

--- a/tests/patmat/3543.scala
+++ b/tests/patmat/3543.scala
@@ -1,0 +1,52 @@
+class Test {
+  class Foo {
+    def unapply(x: String): Option[String] = ???
+  }
+
+  def test(xs: List[String]): Unit = {
+    val Yes = new Foo
+    val No = new Foo
+
+    xs match {
+      case Yes(x) :: ls => println("Yes")
+      case No(y) :: ls => println("No") // unreachable code
+      case _ =>
+    }
+  }
+}
+
+class Test2 {
+  class Foo(x: Boolean) {
+    def unapply(y: String): Boolean = x
+  }
+
+  def test(xs: List[String]): Unit = {
+    val Yes = new Foo(true)
+    val No = new Foo(false)
+
+    xs match {
+      case No() :: ls => println("No")
+      case Yes() :: ls => println("Yes") // unreachable code
+      case _ =>
+    }
+  }
+}
+
+class Test3 {
+  import scala.util.matching.Regex
+
+  def main(args: Array[String]): Unit = {
+    foo("c" :: Nil, false)
+  }
+
+  def foo(remaining: List[String], inCodeBlock: Boolean): Unit = {
+    remaining match {
+      case CodeBlockEndRegex(before) :: ls =>
+      case SymbolTagRegex(name) :: ls if !inCodeBlock => println("OK")
+      case _ =>
+    }
+  }
+
+  val CodeBlockEndRegex = new Regex("(b)")
+  val SymbolTagRegex = new Regex("(c)")
+}


### PR DESCRIPTION
Fix #3543: compare extractor with TermRef instead of MethodType