### PR TITLE
Fix #3548: set outer select type to be the type enclosing the expected type

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -771,7 +771,7 @@ object PatternMatcher {
             val expectedClass = expectedTp.dealias.classSymbol.asClass
             ExplicitOuter.ensureOuterAccessors(expectedClass)
             scrutinee.ensureConforms(expectedTp)
-              .outerSelect(1, expectedOuter.tpe.widen)
+              .outerSelect(1, expectedClass.owner.typeRef)
               .select(defn.Object_eq)
               .appliedTo(expectedOuter)
           }

--- a/tests/run/i3548.scala
+++ b/tests/run/i3548.scala
@@ -9,11 +9,12 @@ object Test {
 
     val data = O2.Data("test")
 
-    // Runtime error: java.lang.ClassCastException: O2$ cannot be cast to O1$
-    data match {
-        case O1.Data(s) => println("O1 data")
-        case O2.Data(s) => println("O2 data")
-        case _ => println("Unknown")
+    val result = data match {
+      case O1.Data(s) => 1
+      case O2.Data(s) => 2
+      case _ => 3
     }
+
+    assert(result == 2)
   }
 }

--- a/tests/run/i3548.scala
+++ b/tests/run/i3548.scala
@@ -1,0 +1,19 @@
+trait Common {
+  case class Data(a: String)
+}
+object O1 extends Common
+object O2 extends Common
+
+object Test {
+  def main(args: Array[String]): Unit = {
+
+    val data = O2.Data("test")
+
+    // Runtime error: java.lang.ClassCastException: O2$ cannot be cast to O1$
+    data match {
+        case O1.Data(s) => println("O1 data")
+        case O2.Data(s) => println("O2 data")
+        case _ => println("Unknown")
+    }
+  }
+}


### PR DESCRIPTION
Fix #3548: set outer select type to be the type enclosing the expected type.

Otherwise, `ElimOuterSelect` will insert `ensureConforms(tp)` in outer test, which causes run-time exception.