### PR TITLE
Improve doc readability

### DIFF
--- a/doc-tool/resources/css/sidebar.css
+++ b/doc-tool/resources/css/sidebar.css
@@ -8,7 +8,7 @@ div#content-wrapper div.index-wrapper {
     overflow-y: auto;
     overflow-x: hidden;
     font-family: "Titillium Web", sans-serif;
-    font-weight: 200;
+    font-weight: 300;
     padding-left: 14px;
     padding-bottom: 75px;
 }

--- a/doc-tool/resources/css/toolbar.css
+++ b/doc-tool/resources/css/toolbar.css
@@ -3,7 +3,7 @@
 div#toolbar {
   height: 75px;
   width: 100%;
-  background-color: #4c5264;
+  background-color: #414551;
   position: fixed;
   top: 0; left: 0;
   z-index: 2;


### PR DESCRIPTION
This is attempting to address some readability issues, by modifying the CSS files in the doc-tool resources in just 2 places:

- increase sidebar font size
- make toolbar darker (to increase contrast with the light title text)