### PR TITLE
#1589: Add error message for not emitting @switch.

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -118,6 +118,7 @@ public enum ErrorMessageID {
     StaticFieldsOnlyAllowedInObjectsID,
     CyclicInheritanceID,
     UnableToExtendSealedClassID,
+    UnableToEmitSwitchID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1972,4 +1972,36 @@ object messages {
     val msg = hl"Cannot extend ${"sealed"} $pclazz in a different source file"
     val explanation = "A sealed class or trait can only be extended in the same file as its declaration"
   }
+
+  case class UnableToEmitSwitch()(implicit ctx: Context)
+  extends Message(UnableToEmitSwitchID) {
+    val kind = "Syntax"
+    val msg = hl"""Could not emit switch for ${"@switch"} annotated match"""
+    val explanation = {
+      val errorCodeExample =
+        """val middle = 'm'
+          |val last   = 'z'
+          |
+          |val number   = (middle: @switch) match {
+          |  case 'a'  => 1
+          |  case 'm'  => 13
+          |  case last => 26  //a non-literal may prevent switch generation: this would not compile.
+          |  case _    => 0
+          |}""".stripMargin
+
+      hl"""The compiler verifies that the match has been compiled to a tableswitch or lookupswitch.
+          |An error will be issued in case it compiles into a series of conditional expressions.
+          |
+          |Consider the following example:
+          |
+          |$errorCodeExample
+          |
+          |The example above would fail as it matches a non-literal value.
+          |The compiler will apply the tableswitch optimization when:
+          |-The matched value is a known integer or types implicitly convertible to integer.
+          |-The matched expression only matches literal values, without type checks, if statements, or extractors.
+          |-The expression have its value available at compile time.
+          |-There are more than two case statements."""
+    }
+  }
 }

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -14,6 +14,7 @@ import Decorators._
 import patmat.Space
 import NameKinds.{UniqueNameKind, PatMatStdBinderName, PatMatCaseName}
 import config.Printers.patmatch
+import reporting.diagnostic.messages._
 
 /** The pattern matching transform.
  *  After this phase, the only Match nodes remaining in the code are simple switches
@@ -908,7 +909,7 @@ object PatternMatcher {
           tpes.toSet.size: Int // without the type ascription, testPickling fails because of #2840.
         }
         if (numConsts(resultCases) < numConsts(original.cases))
-          ctx.warning(i"could not emit switch for @switch annotated match", original.pos)
+          ctx.warning(UnableToEmitSwitch(), original.pos)
       case _ =>
     }
 


### PR DESCRIPTION
Regarding #1589, this PR addresses "could not emit switch" (PatternMatcher.911).

Noticed that `ctx.warning` does not propagate the error messages. 

@smarter Suggested to refactor `checkMessagesAfter` in a way that errors and warning messages are reported.

Would be something like:

```
  def checkMessagesAfter(checkAfterPhase: String)(source: String): Report = {
    ctx = newContext
    val runCtx = checkCompile(checkAfterPhase, source) { (_, _) => () }

    if (!runCtx.reporter.hasErrors && !runCtx.reporter.hasWarnings) new EmptyReport  // adding && !runCtx.reporter.hasWarnings
    else {
      val rep = runCtx.reporter.asInstanceOf[StoreReporter]
      val msgs = rep.removeBufferedMessages(runCtx).map(_.contained()).reverse
      new Report(msgs, runCtx)
    }
  }
```
