### PR TITLE
Ref #1589: Add error message for forward reference not allowed from self constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -118,6 +118,7 @@ public enum ErrorMessageID {
     StaticFieldsOnlyAllowedInObjectsID,
     CyclicInheritanceID,
     UnableToExtendSealedClassID,
+    ForwardReferenceNotAllowedFromSelfConstructorID,
     UnableToEmitSwitchID,
     ;
 

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1973,47 +1973,6 @@ object messages {
     val explanation = "A sealed class or trait can only be extended in the same file as its declaration"
   }
 
-  case class ForwardReferenceNotAllowedFromSelfConstructor()(implicit ctx: Context)
-  extends Message(ForwardReferenceNotAllowedFromSelfConstructorID){
-    val kind = "Reference"
-    val msg = "Forward reference not allowed from self constructor invocation"
-    val explanation = {
-
-      val errorCodeExample =
-        """class A(a: Any) {
-          |  def this() = {
-          |    this(b)                      // forward reference
-          |    def b = new {}
-          |  }
-          |
-          |  def this(x: Int) = {
-          |    this(b)                      // forward reference
-          |    lazy val b = new {}
-          |  }
-          |
-          |  def this(x: Int, y: Int) = {
-          |    this(b)                      // forward reference
-          |    val b = new {}
-          |  }
-          |
-          |  def this(x: Int, y: Int, z: Int) = {
-          |    this(b)                      // forward reference
-          |    println(".")
-          |    def b = new {}
-          |  }
-          |}""".stripMargin
-
-      hl"""
-          |Forward reference is not allowed from self constructors.
-          |
-          |$errorCodeExample
-          |
-          |The example above would fail as it contains a forward reference inside each self constructor.
-          |When not inside self constructors, a forward reference is allowed when:
-          |-The reference is not a variable definition
-          |-If it is a variable definition, it must be lazy
-        """.stripMargin
-
   case class UnableToEmitSwitch()(implicit ctx: Context)
   extends Message(UnableToEmitSwitchID) {
     val kind = "Syntax"
@@ -2040,7 +1999,6 @@ object messages {
           |- the matched value is not of type ${"Int"}, ${"Byte"}, ${"Short"} or ${"Char"}
           |- the matched value is not a constant literal
           |- there are less than three cases"""
-
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2001,4 +2001,47 @@ object messages {
           |- there are less than three cases"""
     }
   }
+
+  case class ForwardReferenceNotAllowedFromSelfConstructor()(implicit ctx: Context)
+  extends Message(ForwardReferenceNotAllowedFromSelfConstructorID){
+    val kind = "Reference"
+    val msg = "Forward reference not allowed from self constructor invocation"
+    val explanation = {
+
+      val errorCodeExample =
+        """class A(a: Any) {
+          |  def this() = {
+          |    this(b)                      // forward reference
+          |    def b = new {}
+          |  }
+          |
+          |  def this(x: Int) = {
+          |    this(b)                      // forward reference
+          |    lazy val b = new {}
+          |  }
+          |
+          |  def this(x: Int, y: Int) = {
+          |    this(b)                      // forward reference
+          |    val b = new {}
+          |  }
+          |
+          |  def this(x: Int, y: Int, z: Int) = {
+          |    this(b)                      // forward reference
+          |    println(".")
+          |    def b = new {}
+          |  }
+          |}""".stripMargin
+
+      hl"""
+          |Forward reference is not allowed from self constructors.
+          |
+          |$errorCodeExample
+          |
+          |The example above would fail as it contains a forward reference inside each self constructor.
+          |When not inside self constructors, a forward reference is allowed when:
+          |-The reference is not a variable definition
+          |-If it is a variable definition, it must be lazy
+        """.stripMargin
+    }
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -797,8 +797,7 @@ import RefChecks._
 class RefChecks extends MiniPhase { thisPhase =>
 
   import tpd._
-  import reporting.diagnostic.messages.ForwardReferenceExtendsOverDefinition
-  import dotty.tools.dotc.reporting.diagnostic.messages.UnboundPlaceholderParameter
+  import reporting.diagnostic.messages._ //ForwardReferenceExtendsOverDefinition, UnboundPlaceholderParameter
 
   override def phaseName: String = "refchecks"
 
@@ -871,7 +870,7 @@ class RefChecks extends MiniPhase { thisPhase =>
       if (level.maxIndex > 0) {
         // An implementation restriction to avoid VerifyErrors and lazyvals mishaps; see SI-4717
         ctx.debuglog("refsym = " + level.refSym)
-        ctx.error("forward reference not allowed from self constructor invocation", level.refPos)
+        ctx.error(ForwardReferenceNotAllowedFromSelfConstructor(), level.refPos)
       }
     }
     tree


### PR DESCRIPTION
Regarding #1589, this PR addresses:
- "Forward reference not allowed from self constructor invocation" (RefCheck:874).

Wasn't able to add a test for this error message as dotty seems to not have it ported from `scalac` yet. Evidence: https://scastie.scala-lang.org/lnrxIGq3SUCpoCXpUw3yGA

With scalac:
```
class A(a: Any) {
  def this() = {
    this(b)             //forward reference not allowed from self constructor invocation
    def b = new {}
  }
}
```

With dotty:
```
Starting dotty REPL...
scala> class A(a: Any) {
           def this() = {
             this(b)
             def b = new {}
           }
         }
3 |      this(b)
  |           ^
  |           not found: b
```

@smarter recommended to open an issue for this case. #3559