### PR TITLE
Simplify REPL

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
@@ -140,7 +140,8 @@ trait MessageRendering {
   /** The whole message rendered from `msg` */
   def messageAndPos(msg: Message, pos: SourcePosition, diagnosticLevel: String)(implicit ctx: Context): String = {
     val sb = mutable.StringBuilder.newBuilder
-    sb.append(posStr(pos, diagnosticLevel, msg)).append('\n')
+    val posString = posStr(pos, diagnosticLevel, msg)
+    if (posString.nonEmpty) sb.append(posString).append('\n')
     if (pos.exists) {
       val (srcBefore, srcAfter, offset) = sourceLines(pos)
       val marker = columnMarker(pos, offset)

--- a/compiler/src/dotty/tools/repl/ReplFrontEnd.scala
+++ b/compiler/src/dotty/tools/repl/ReplFrontEnd.scala
@@ -12,19 +12,17 @@ import dotc.core.Contexts.Context
  *  compiler pipeline.
  */
 private[repl] class REPLFrontEnd extends FrontEnd {
-  override def phaseName = "replFrontEnd"
+  override def phaseName = "frontend"
 
   override def isRunnable(implicit ctx: Context) = true
 
   override def runOn(units: List[CompilationUnit])(implicit ctx: Context) = {
-    val unitContexts = for (unit <- units) yield ctx.fresh.setCompilationUnit(unit)
-    var remaining = unitContexts
-    while (remaining.nonEmpty) {
-      enterSyms(remaining.head)
-      remaining = remaining.tail
-    }
-    unitContexts.foreach(enterAnnotations(_))
-    unitContexts.foreach(typeCheck(_))
-    unitContexts.map(_.compilationUnit).filterNot(discardAfterTyper)
+    assert(units.size == 1) // REPl runs one compilation unit at a time
+
+    val unitContext = ctx.fresh.setCompilationUnit(units.head)
+    enterSyms(unitContext)
+    enterAnnotations(unitContext)
+    typeCheck(unitContext)
+    List(unitContext.compilationUnit)
   }
 }

--- a/compiler/test-resources/repl/patdef
+++ b/compiler/test-resources/repl/patdef
@@ -22,5 +22,5 @@ val x: Int = 1
 scala> val List(_ @ List(x)) = List(List(2))
 val x: Int = 2
 scala> val B @ List(), C: List[Int] = List()
-val B: List[Int] = Nil
-val C: List[Int] = Nil
+val B: List[Int] = List()
+val C: List[Int] = List()

--- a/dist/bin/dotr
+++ b/dist/bin/dotr
@@ -60,7 +60,7 @@ if [ $run_repl == true ] || [ ${#residual_args[@]} -eq 0 ]; then
   if [ "$CLASS_PATH" ]; then
     cp_arg="-classpath $CLASS_PATH"
   fi
-  echo "Starting dotty REPL"
+  echo "Starting dotty REPL..."
   eval "$PROG_HOME/bin/dotc $cp_arg -repl ${residual_args[@]}"
 else
   cp_arg="-classpath $DOTTY_LIB$PSEP$SCALA_LIB"

--- a/library/src/dotty/Show.scala
+++ b/library/src/dotty/Show.scala
@@ -28,21 +28,22 @@ object Show {
   implicit val stringShow: Show[String] = new Show[String] {
     // From 2.12 spec, `charEscapeSeq`:
     // ‘\‘ (‘b‘ | ‘t‘ | ‘n‘ | ‘f‘ | ‘r‘ | ‘"‘ | ‘'‘ | ‘\‘)
-    def show(str: String) =
-      "\"" + {
-        val sb = new StringBuilder
-        str.foreach {
-          case '\b' => sb.append("\\b")
-          case '\t' => sb.append("\\t")
-          case '\n' => sb.append("\\n")
-          case '\f' => sb.append("\\f")
-          case '\r' => sb.append("\\r")
-          case '\'' => sb.append("\\'")
-          case '\"' => sb.append("\\\"")
-          case c => sb.append(c)
-        }
-        sb.toString
-      } + "\""
+    def show(str: String) = {
+      val sb = new StringBuilder
+      sb.append("\"")
+      str.foreach {
+        case '\b' => sb.append("\\b")
+        case '\t' => sb.append("\\t")
+        case '\n' => sb.append("\\n")
+        case '\f' => sb.append("\\f")
+        case '\r' => sb.append("\\r")
+        case '\'' => sb.append("\\'")
+        case '\"' => sb.append("\\\"")
+        case c => sb.append(c)
+      }
+      sb.append("\"")
+      sb.toString
+    }
   }
 
   implicit val intShow: Show[Int] = new Show[Int] {
@@ -72,12 +73,12 @@ object Show {
 
   implicit def showList[T](implicit st: Show[T]): Show[List[T]] = new Show[List[T]] {
     def show(xs: List[T]) =
-      if (xs.isEmpty) "Nil"
+      if (xs.isEmpty) "List()"
       else "List(" + xs.map(_.show).mkString(", ") + ")"
   }
 
   implicit val showNil: Show[Nil.type] = new Show[Nil.type] {
-    def show(xs: Nil.type) = "Nil"
+    def show(xs: Nil.type) = "List()"
   }
 
   implicit def showOption[T](implicit st: Show[T]): Show[Option[T]] = new Show[Option[T]] {


### PR DESCRIPTION
- Remove monadic API when not needed: methods returning `Result[T]` now return `T` if failure is not possible
- Other minor polishing