### PR TITLE
REPL: do not dealias before printing types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -357,8 +357,15 @@ class Definitions {
     def newGenericArrayMethod(implicit ctx: Context) = DottyArraysModule.requiredMethod("newGenericArray")
     def newArrayMethod(implicit ctx: Context) = DottyArraysModule.requiredMethod("newArray")
 
+  lazy val ListType = ctx.requiredClassRef("scala.collection.immutable.List")
+  def ListClass(implicit ctx: Context) = ListType.symbol.asClass
   lazy val NilModuleRef = ctx.requiredModuleRef("scala.collection.immutable.Nil")
   def NilModule(implicit ctx: Context) = NilModuleRef.symbol
+
+  lazy val immutableMapType = ctx.requiredClassRef("scala.collection.immutable.Map")
+  def immutableMapClass(implicit ctx: Context) = immutableMapType.symbol.asClass
+  lazy val immutableSetType = ctx.requiredClassRef("scala.collection.immutable.Set")
+  def immutableSetClass(implicit ctx: Context) = immutableSetType.symbol.asClass
 
   lazy val SingletonClass: ClassSymbol =
     // needed as a synthetic class because Scala 2.x refers to it in classfiles

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -194,6 +194,7 @@ class Definitions {
         else NoSymbol)
     cls
   }
+  lazy val ScalaPackageObjectRef = ctx.requiredModuleRef("scala.package")
   lazy val JavaPackageVal = ctx.requiredPackage("java")
   lazy val JavaLangPackageVal = ctx.requiredPackage("java.lang")
   // fundamental modules
@@ -357,15 +358,8 @@ class Definitions {
     def newGenericArrayMethod(implicit ctx: Context) = DottyArraysModule.requiredMethod("newGenericArray")
     def newArrayMethod(implicit ctx: Context) = DottyArraysModule.requiredMethod("newArray")
 
-  lazy val ListType = ctx.requiredClassRef("scala.collection.immutable.List")
-  def ListClass(implicit ctx: Context) = ListType.symbol.asClass
   lazy val NilModuleRef = ctx.requiredModuleRef("scala.collection.immutable.Nil")
   def NilModule(implicit ctx: Context) = NilModuleRef.symbol
-
-  lazy val immutableMapType = ctx.requiredClassRef("scala.collection.immutable.Map")
-  def immutableMapClass(implicit ctx: Context) = immutableMapType.symbol.asClass
-  lazy val immutableSetType = ctx.requiredClassRef("scala.collection.immutable.Set")
-  def immutableSetClass(implicit ctx: Context) = immutableSetType.symbol.asClass
 
   lazy val SingletonClass: ClassSymbol =
     // needed as a synthetic class because Scala 2.x refers to it in classfiles

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -700,6 +700,12 @@ object Types {
           (name, buf) => buf += member(name).asSingleDenotation)
     }
 
+    /** The set of type alias members of this type */
+    final def typeAliasMembers(implicit ctx: Context): Seq[SingleDenotation] = track("typeAlias") {
+      memberDenots(typeAliasNameFilter,
+          (name, buf) => buf += member(name).asSingleDenotation)
+    }
+
     /** The set of type members of this type */
     final def typeMembers(implicit ctx: Context): Seq[SingleDenotation] = track("typeMembers") {
       memberDenots(typeNameFilter,
@@ -4409,6 +4415,15 @@ object Types {
   object abstractTermNameFilter extends NameFilter {
     def apply(pre: Type, name: Name)(implicit ctx: Context): Boolean =
       name.isTermName && pre.nonPrivateMember(name).hasAltWith(_.symbol is Deferred)
+  }
+
+  /** A filter for names of type aliases of a given type */
+  object typeAliasNameFilter extends NameFilter {
+    def apply(pre: Type, name: Name)(implicit ctx: Context): Boolean =
+      name.isTypeName && {
+        val mbr = pre.nonPrivateMember(name)
+        mbr.symbol.isAliasType
+      }
   }
 
   object typeNameFilter extends NameFilter {

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -136,10 +136,12 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case _ => Nil
     })
 
-  // Direct references to these symbols are printed without their prefix for convenience,
-  // they are either aliased in scala.Predef or in the scala package object.
+  /** Direct references to these symbols are printed without their prefix for convenience.
+   *  They are either aliased in scala.Predef or in the scala package object.
+   */
   private[this] lazy val printWithoutPrefix: Set[Symbol] =
-    Set(defn.ListClass, defn.immutableMapClass, defn.immutableSetClass, defn.SeqClass)
+    (defn.ScalaPredefModuleRef.typeAliasMembers
+      ++ defn.ScalaPackageObjectRef.typeAliasMembers).map(_.info.classSymbol).toSet
 
   def toText(tp: Type): Text = controlled {
     homogenize(tp) match {
@@ -152,12 +154,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case tp: TermRef if tp.denot.isOverloaded =>
         "<overloaded " ~ toTextRef(tp) ~ ">"
       case tp: TypeRef =>
-        printWithoutPrefix.find(sym => tp.isDirectRef(sym)) match {
-          case Some(sym) =>
-            toText(sym.name)
-          case _ =>
-            toTextPrefix(tp.prefix) ~ selectionString(tp)
-        }
+        if (printWithoutPrefix.contains(tp.symbol))
+          toText(tp.name)
+        else
+          toTextPrefix(tp.prefix) ~ selectionString(tp)
       case tp: TermParamRef =>
         ParamRefNameString(tp) ~ ".type"
       case tp: TypeParamRef =>

--- a/compiler/test-resources/repl/importFromObj
+++ b/compiler/test-resources/repl/importFromObj
@@ -7,7 +7,7 @@ scala> import o._
 scala> buf += xs
 1 | buf += xs
   |        ^^
-  |        found:    scala.collection.immutable.List[Int](o.xs)
+  |        found:    List[Int](o.xs)
   |        required: Int
   |
 scala> buf ++= xs

--- a/compiler/test-resources/type-printer/hkAlias
+++ b/compiler/test-resources/type-printer/hkAlias
@@ -1,0 +1,6 @@
+scala> type Identity[T] = T
+// defined alias type Identity = [T] => T
+scala> def foo[T](x: T): Identity[T] = x
+def foo[T](x: T): Identity[T]
+scala> foo(1)
+val res0: Identity[Int] = 1

--- a/compiler/test-resources/type-printer/prefixless
+++ b/compiler/test-resources/type-printer/prefixless
@@ -1,0 +1,8 @@
+scala> List(1,2,3)
+val res0: List[Int] = List(1, 2, 3)
+scala> Map("foo" -> 1)
+val res1: Map[String, Int] = Map("foo" -> 1)
+scala> Seq('a','b')
+val res2: Seq[Char] = List(a, b)
+scala> Set(4, 5)
+val res3: Set[Int] = Set(4, 5)

--- a/compiler/test-resources/type-printer/prefixless
+++ b/compiler/test-resources/type-printer/prefixless
@@ -6,3 +6,5 @@ scala> Seq('a','b')
 val res2: Seq[Char] = List(a, b)
 scala> Set(4, 5)
 val res3: Set[Int] = Set(4, 5)
+scala> Iterator(1)
+val res4: Iterator[Int] = non-empty iterator

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -493,7 +493,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val DoesNotConformToBound(tpe, which, bound) :: Nil = messages
       assertEquals("Int", tpe.show)
       assertEquals("upper", which)
-      assertEquals("scala.collection.immutable.List[Int]", bound.show)
+      assertEquals("List[Int]", bound.show)
     }
 
   @Test def doesNotConformToSelfType =


### PR DESCRIPTION
Also simplify the mechanism used to avoid printing prefixes. This is now
handled in the PlainPrinter and limited to List, Map, Set, Seq.