### PR TITLE
Fix ambiguous implicit for Show[Nothing]

### DIFF
--- a/compiler/test-resources/repl/renderNothing
+++ b/compiler/test-resources/repl/renderNothing
@@ -1,0 +1,6 @@
+scala> List()
+val res0: List[Nothing] = List()
+scala> Option.empty
+val res1: Option[Nothing] = None
+scala> Map()
+val res2: Map[Nothing, Nothing] = Map()

--- a/library/src/dotty/Show.scala
+++ b/library/src/dotty/Show.scala
@@ -1,21 +1,16 @@
 package dotty
 
-import scala.annotation.implicitNotFound
-
-@implicitNotFound("No member of type class Show could be found for ${T}")
-trait Show[-T] {
+trait Show[T] {
   def show(t: T): String
 }
 
-/** Ideally show would only contain `defaultShow` and the pimped generic class,
-  * but since we can't change the current stdlib, we're stuck with providing
-  * default instances in this object
-  */
-object Show {
-  private[this] val defaultShow: Show[Any] = new Show[Any] {
-    def show(x: Any) = x.toString
+trait LowPrioShow {
+  implicit def defaultShow[T]: Show[T] = new Show[T] {
+    def show(x: T) = x.toString
   }
+}
 
+object Show extends LowPrioShow {
   /** This class implements pimping of all types to provide a show method.
     * Currently it is quite permissive, if there's no instance of `Show[T]` for
     * any `T`, we default to `T#toString`.
@@ -46,16 +41,8 @@ object Show {
     }
   }
 
-  implicit val intShow: Show[Int] = new Show[Int] {
-    def show(i: Int) = i.toString
-  }
-
   implicit val floatShow: Show[Float] = new Show[Float] {
     def show(f: Float) = f + "f"
-  }
-
-  implicit val doubleShow: Show[Double] = new Show[Double] {
-    def show(d: Double) = d.toString
   }
 
   implicit val charShow: Show[Char] = new Show[Char] {
@@ -77,10 +64,6 @@ object Show {
       else "List(" + xs.map(_.show).mkString(", ") + ")"
   }
 
-  implicit val showNil: Show[Nil.type] = new Show[Nil.type] {
-    def show(xs: Nil.type) = "List()"
-  }
-
   implicit def showOption[T](implicit st: Show[T]): Show[Option[T]] = new Show[Option[T]] {
     def show(ot: Option[T]): String = ot match {
       case Some(t) => "Some("+ st.show(t) + ")"
@@ -88,16 +71,8 @@ object Show {
     }
   }
 
-  implicit val showNone: Show[None.type] = new Show[None.type] {
-    def show(n: None.type) = "None"
-  }
-
   implicit def showMap[K,V](implicit sk: Show[K], sv: Show[V]): Show[Map[K,V]] = new Show[Map[K,V]] {
     def show(m: Map[K, V]) =
       "Map(" + m.map { case (k, v) => sk.show(k) + " -> " + sv.show(v) } .mkString (", ") + ")"
-  }
-
-  implicit def showMapOfNothing: Show[Map[Nothing,Nothing]] = new Show[Map[Nothing,Nothing]] {
-    def show(m: Map[Nothing, Nothing]) = m.toString
   }
 }

--- a/library/test/dotty/ShowTests.scala
+++ b/library/test/dotty/ShowTests.scala
@@ -66,4 +66,10 @@ class ShowTests {
     assertEquals("Car(Mustang,Ford,1967)", Car("Mustang", "Ford", 1967).show)
     assertEquals("Map()", Map().show)
   }
+
+  @Test def partialShow = {
+    case object Foo
+
+    assertEquals("Map(Foo -> \"Hello\")", Map(Foo -> "Hello").show)
+  }
 }


### PR DESCRIPTION
PR #3421 changed implicit search:
In the old scheme, a method with an implicit argument and a default
value would give you the default value if called with an ambiguous
implicit argument. The new scheme emits an error.

We now provide an implicit instance of `Show[Nothing]` in order to avoid
ambiguous implicit error in the REPL for expressions like:
```scala
scala> List()
val res0: List[Nothing] = List()
scala> Option.empty
val res1: Option[Nothing] = None
scala> Map()
val res2: Map[Nothing, Nothing] = Map()
```