### PR TITLE
Fix typos in documentation: reference > new types

### DIFF
--- a/docs/docs/reference/implicit-function-types.md
+++ b/docs/docs/reference/implicit-function-types.md
@@ -10,7 +10,7 @@ An implicit function type describes functions with implicit parameters. Example:
 A value of implicit function type is applied to implicit arguments, in
 the same way a method with implicit parameters is applied. For instance:
 
-    implicit ctx: Context = ...
+    implicit val ctx: Context = ...
 
     def f(x: Int): Contextual[Int] = ...
 
@@ -93,7 +93,7 @@ With that setup, the table construction code above compiles and expands to:
         cell("top right")($r)
       }($t)
       row { implicit $r: Row =>
-        cell("botttom left")($r)
+        cell("bottom left")($r)
         cell("bottom right")($r)
       }($t)
     }

--- a/docs/docs/reference/phantom-types.md
+++ b/docs/docs/reference/phantom-types.md
@@ -16,7 +16,7 @@ When saying that they have no effect on the runtime we do not only mean side eff
 like IO, field mutation, exceptions and so on. We also imply that if a function receives 
 a phantom its result will not be affected by this argument.
 
-As phantom do not live at runtime they cannot be subtypes of `scala.Any`, which defines 
+As phantoms do not live at runtime they cannot be subtypes of `scala.Any`, which defines 
 methods such as `hashCode`, `equals`, `getClass`, `asInstanceOf` and `isInstanceOf`. 
 All these operations cannot exist on phantoms as there will not be an underlying object 
 instance at runtime. At first glance this could look like a limitation, but in fact not 
@@ -49,13 +49,13 @@ In fact we allow multiple phantom universes to exist.
          +---------+                +-------------------+       +------------------------+
 ```
 
-Inside a universe it types support the full Dotty type system. But we cannot mix types from 
-different universes with `&`, `|` or in type bounds. Each type must be fully defined one universe.
+Inside a universe the full Dotty type system is supported. But we cannot mix types from 
+different universes with `&`, `|` or in type bounds. Each type must be fully defined in a single universe.
 
 
 Implement your own phantom type
 -------------------------------
-Phantom types are definded by an `object` extending `scala.Phantom`. This object will represent 
+Phantom types are defined by an `object` extending `scala.Phantom`. This object will represent 
 a universe of phantom types that is completely separated from types in `scala.Any` or other 
 phantom universes. We can define our phantom universe `MyPhantoms`.
 
@@ -78,7 +78,7 @@ of the phantom types in `MyPhantoms`, these bounds are `protected` and can not b
 from outside `MyPhantoms` unless an alias is defined for them.
 
 New phantom types can be defined using `type XYZ <: OtherPhantom` (where `>: MyPhantom.Nothing` 
-will be inferred), this would be the equivalent of `class XYZ extends OtherClass` on a types 
+will be inferred), this would be the equivalent of `class XYZ extends OtherClass` on types 
 only (no runtime definitions). Or aliased with `type MyAny = OtherPhantom`. Within `MyPhantoms` 
 it is possible to refer to `MyPhantoms.Any` and `MyPhantoms.Nothing` with `this.Any` and 
 `this.Nothing` (or just `Any` and `Nothing` but not recommended). Using this we will define
@@ -94,7 +94,7 @@ object MyPhantoms extends Phantom {
 ```
 
 Values of phantom type can be created using the `protected def assume`. This value can be 
-used as a value of this phantom type as it's type is `this.Nothing` (or `MyPhantoms.Nothing`). 
+used as a value of this phantom type as its type is `this.Nothing` (or `MyPhantoms.Nothing`). 
 Usually this value will be used to define a `implicit def` that returns the phantom with a more 
 precise type. In our example we will only create values of type `Pinky` and `Clyde`
 
@@ -136,8 +136,8 @@ What happens with Phantoms at runtime?
 
 Disclaimer: Most of phantom erasure is implemented, but not all of is has been merged in `dotty/master` yet.
 
-As phantom have no effect on the result of a method invocation we just remove them for the call an definition. 
-The evaluation of the phantom parameter is still be done unless it can be optimized away. 
+As phantoms have no effect on the result of a method invocation we just remove them for the call and definition. 
+The evaluation of the phantom parameter is still done unless it can be optimized away. 
 By removing them we also restrict overloading as `def f()` and `def f(x: MyPhantom)` will 
 have the same signature in the bytecode, just use different names to avoid this.
 

--- a/docs/docs/reference/singleton-types.md
+++ b/docs/docs/reference/singleton-types.md
@@ -3,7 +3,7 @@ layout: doc-page
 title: "Literal Singleton Types"
 ---
 
-Literal Singleton Types allows primitive literals to be used as types. For example:
+Literal Singleton Types allow primitive literals to be used as types. For example:
 
 ```scala
 val t: 42 = 42

--- a/docs/docs/reference/union-types.md
+++ b/docs/docs/reference/union-types.md
@@ -26,10 +26,9 @@ Union types are dual of intersection types. Values of type `A | B` are
 all values of type `A` and all values of type `B`. `|` is _commutative_:
 `A | B` is the same type as `B | A`.
 
-The compiler will assign an expression a union type only if such a
+The compiler will assign a union type to an expression only if such a
 type is explicitly given.
-This can be seen in the folling REPL
-transcript:
+This can be seen in the following REPL transcript:
 
 ```scala
 scala> val password = Password(123)
@@ -45,7 +44,7 @@ val either: Password | UserName = UserName(Eve)
 The type of `res2` is `Object & Product`, which is a supertype of
 `UserName` and `Product`, but not the least supertype `Password |
 UserName`.  If we want the least supertype, we have to give it
-explicitely, as is done for the type of `either`. More precisely, the
+explicitly, as is done for the type of `either`. More precisely, the
 typechecker will _widen_ a union type to a non-union type when
 inferring the type of `val` or `var`, or the result type of a `def`,
 or the argument to pass for a type parameter.  The widened type of `A


### PR DESCRIPTION
As I was reading through the documentation for new types, I fixed some typos.