### PR TITLE
Prune impossible types from exhaustivity checker

### DIFF
--- a/tests/patmat/i3574.scala
+++ b/tests/patmat/i3574.scala
@@ -1,0 +1,38 @@
+object PathVariantDefns {
+  sealed trait AtomBase {
+    sealed trait Atom
+    case class Zero(value: String) extends Atom
+  }
+
+  trait Atom1 extends AtomBase {
+    case class One(value: String) extends Atom
+  }
+
+  trait Atom2 extends AtomBase {
+    case class Two(value: String) extends Atom
+  }
+
+  object Atoms01 extends AtomBase with Atom1 {
+    def f = {
+      val a: Atom = null
+      a match {
+        case Zero(x) => ???
+        case One(x)  => ???
+        // match may not be exhaustive.
+        // It would fail on: PathVariantDefns.Atom2 & PathVariantDefns.Atoms01.type(PathVariantDefns.Atoms01).Two(_)
+      }
+    }
+  }
+
+  object Atoms02 extends AtomBase with Atom2 {
+    def f = {
+      val a: Atom = null
+      a match {
+        case Zero(x) => ???
+        case Two(x)  => ???
+        // match may not be exhaustive.
+        // It would fail on: PathVariantDefns.Atom1 & PathVariantDefns.Atoms02.type(PathVariantDefns.Atoms02).One(_)
+      }
+    }
+  }
+}


### PR DESCRIPTION
The exhaustivity checker sometimes looks for impossible types.

The test case added by this PR is an example taken from the shapeless test suite where a sealed trait is extended in two different scopes. The added case classes`One` and `Two` can only appear withing object `Atoms01` and  `Atoms02` respectively. On master the exhaustivity checker reports missing cases of the following form: `PathVariantDefns.Atom2 & PathVariantDefns.Atoms01.type(PathVariantDefns.Atoms01).Two(_)`. Given that `PathVariantDefns.Atoms01.type` is the type of an object, the intersection between this type and any unrelated type is always empty. This PR adds a check to `instantiate` that detect and remove these cases.

@liufengyun WDYT?