### PR TITLE
Rework publishing and simplify build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -72,9 +72,7 @@ pipeline:
       - NIGHTLYBUILD=yes
     commands:
       - ./project/scripts/sbtPublish ";dotty-bootstrapped/publishSigned ;sonatypeRelease"
-    volumes:
-      - /home/drone/keys:/keys
-    secrets: [ sonatype_user, sonatype_pw, pgp_pw ]
+    secrets: [ sonatype_user, sonatype_pw, pgp_pw, pgp_secret ]
     when:
       event: deployment
       environment: nightly
@@ -87,9 +85,7 @@ pipeline:
       # Produces dotty-version.{tar.gz, zip}
       - ./project/scripts/sbt dist-bootstrapped/packArchive
       - ./project/scripts/sbtPublish ";dotty-bootstrapped/publishSigned ;sonatypeRelease"
-    volumes:
-      - /home/drone/keys:/keys
-    secrets: [ sonatype_user, sonatype_pw, pgp_pw ]
+    secrets: [ sonatype_user, sonatype_pw, pgp_pw, pgp_secret ]
     when:
       event: tag
 
@@ -111,9 +107,7 @@ pipeline:
       - RELEASEBUILD=yes
     commands:
       - ./project/scripts/sbtPublish ";sbt-dotty/publishSigned ;sonatypeRelease"
-    volumes:
-      - /home/drone/keys:/keys
-    secrets: [ sonatype_user, sonatype_pw, pgp_pw ]
+    secrets: [ sonatype_user, sonatype_pw, pgp_pw, pgp_secret ]
     when:
       event: deployment
       environment: sbt_release

--- a/build.sbt
+++ b/build.sbt
@@ -31,3 +31,4 @@ val `sbt-dotty` = Build.`sbt-dotty`
 val `vscode-dotty` = Build.`vscode-dotty`
 
 inThisBuild(Build.thisBuildSettings)
+inScope(Global)(Build.globalSettings)

--- a/project/scripts/sbt
+++ b/project/scripts/sbt
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
+set -e
 
 # Usage:
 # ./sbt <cmd>
 
-CMD="$1"
-
-if [ -z "$CMD" ]; then
-  echo "Error: missing sbt command"
-  exit 1
-fi
+CMD="${1:?Missing sbt command}"
 
 # run sbt with the supplied arg
 sbt -J-Xmx4096m \

--- a/project/scripts/sbtPublish
+++ b/project/scripts/sbtPublish
@@ -1,34 +1,27 @@
 #!/usr/bin/env bash
-
-# Usage:
-# SONATYPE_USER=<sonatype user> SONATYPE_PW=<sonatype pw> PGP_PW=<pgp pw> ./sbtPublish <publish cmd>
-
 set -e
 
-# Release command:
-RELEASE_CMD="$1"
+# Usage:
+# SONATYPE_USER=<sonatype user> SONATYPE_PW=<sonatype pw> PGP_PW=<pgp pw> PGP_SECRET=<pgp secret> ./sbtPublish <publish cmd>
 
-if [ -z "$SONATYPE_USER" ] || [ -z "$SONATYPE_PW" ] || [ -z "$PGP_PW" ]; then
-    echo "Error: SONATYPE_USER, SONATYPE_PW or PGP_PW env unset"
-    exit 1
-fi
+# Release command:
+RELEASE_CMD="${1:?Missing publish command}"
+
+# Make sure required environment variable are set
+: "${SONATYPE_USER:?not set}"
+: "${SONATYPE_PW:?not set}"
+: "${PGP_PW:?not set}"
+: "${PGP_SECRET:?is not set}"
 
 if [ ! "$NIGHTLYBUILD" = "yes" ] && [ ! "$RELEASEBUILD" = "yes" ]; then
     echo "Neither NIGHTLYBUILD nor RELEASEBUILD env var set to \"yes\""
     exit 1
 fi
 
-if [ -z "$RELEASE_CMD" ]; then
-  echo "Error: missing publish command"
-  exit 1
-fi
-
-CMD="     ;set credentials in ThisBuild := Seq(Credentials(\"Sonatype Nexus Repository Manager\", \"oss.sonatype.org\", \"$SONATYPE_USER\", \"$SONATYPE_PW\"))"
-CMD="$CMD ;set pgpPassphrase := Some(\"\"\"$PGP_PW\"\"\".toCharArray)"
-CMD="$CMD ;set pgpSecretRing := file(\"/keys/secring.asc\")"
-CMD="$CMD ;set pgpPublicRing := file(\"/keys/pubring.asc\")"
-CMD="$CMD $RELEASE_CMD"
+# Write down PGP secret key to the location expected by sbt-pgp
+mkdir -p "$HOME/.sbt/gpg"
+echo "$PGP_SECRET" > "$HOME/.sbt/gpg/secring.asc"
 
 # run sbt with the supplied arg
 SBT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/sbt"
-"$SBT" "$CMD"
+"$SBT" "$RELEASE_CMD"


### PR DESCRIPTION
- The gpg key used to release to sonatype is now passed as a secret in
  Drone instead of storing it in a file on the server.
- Aggregate Global and ThisBuild settings together. This has the
  advantage of evaluating them once instead of for every project they
  are shared with.