### PR TITLE
Fix file change detection in dotc & dotr scripts

### DIFF
--- a/bin/common
+++ b/bin/common
@@ -13,9 +13,9 @@ shift # Mutates $@ by deleting the first element ($1)
 version="$ROOT/dist-bootstrapped/target/pack/VERSION"
 
 # Create the target if absent or if file changed in ROOT/compiler
-new_files="$(find "$ROOT/compiler" \( -iname "*.scala" -o -iname "*.java" \) -newer "$version" >& /dev/null)"
+new_files="$(find "$ROOT/compiler" \( -iname "*.scala" -o -iname "*.java" \) -newer "$version" 2> /dev/null)"
 
-if [ ! -f "$target" ] || [ ! -z "$new_files" ]; then
+if [ ! -f "$version" ] || [ ! -z "$new_files" ]; then
   echo "Building Dotty..."
   sbt "dist-bootstrapped/pack"
 fi


### PR DESCRIPTION
This PR fixes the file change detection in the dotc & dotr scripts.

`>&` redirects both stdout and stderr, here we *need* `stdout` for the test below but don't care about `stderr`: when `dist-bootstrapped/target/pack/VERSION` doesn't exists, users don't should't see the error from find.

Also testing for the existance of `$target` to rebuild dotty is obviously a typo, we want to rebuild `$version` is not on disk.