### PR TITLE
Fix typos in documentation: reference > enums

### DIFF
--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -83,7 +83,7 @@ object Option {
 Enumerations and ADTs have been presented as two different
 concepts. But since they share the same syntactic construct, they can
 be seen simply as two ends of a spectrum and it is perfectly possible
-to conctruct hybrids. For instance, the code below gives an
+to construct hybrids. For instance, the code below gives an
 implementation of `Color` either with three enum values or with a
 parameterized case that takes an RGB value.
 

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -8,7 +8,7 @@ Scala's other language features. As such, enums in Scala are
 convenient _syntactic sugar_, but they are not essential to understand
 Scala's core.
 
-We now explain the expansion of enums is explained in detail. First,
+We now explain the expansion of enums in detail. First,
 some terminology and notational conventions:
 
  - We use `E` as a name of an enum class, and `C` as a name of an enum case that appears in the companion object of `E`.
@@ -20,7 +20,7 @@ some terminology and notational conventions:
    - _Simple cases_ are cases of a non-generic enum class that have neither parameters nor an extends clause or body. That is, they consist of a name only.
    - _Value cases_ are all cases that do not have a parameter section but that do have a (possibly generated) extends clause and/or a body.
 
-  Simple cases and value cases are called collectively _singleton cases_.
+  Simple cases and value cases are collectively called _singleton cases_.
 
 The desugaring rules imply that class cases are mapped to case classes, and singleton cases are mapped to `val` definitions.
 

--- a/docs/docs/reference/enums/enums.md
+++ b/docs/docs/reference/enums/enums.md
@@ -117,7 +117,7 @@ trait Enum {
 }
 ```
 
-Enum values with `extends` clauses get expanded to anonymus class instances.
+Enum values with `extends` clauses get expanded to anonymous class instances.
 For instance, the `VENUS` value above would be defined like this:
 
 ```scala


### PR DESCRIPTION
Fixes some typos in the reference documentation for enums.