### PR TITLE
List pos and run tests that fail from tasty

### DIFF
--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -24,6 +24,34 @@ class FromTastyTests extends ParallelTesting {
     implicit val testGroup: TestGroup = TestGroup("posTestFromTasty")
     val (step1, step2) = {
       // compileTastyInDir("../tests/pos", defaultOptions) + // FIXME
+      // compileTasty("../tests/pos/t115.scala", defaultOptions) +
+      // compileTasty("../tests/pos/t2127.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i1570.scala", defaultOptions) +
+      // compileTasty("../tests/pos/t1279a.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i3129.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i2250.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i966.scala", defaultOptions) +
+      // compileTasty("../tests/pos/t0049.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i0306.scala", defaultOptions) +
+      // compileTasty("../tests/pos/t0055.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i2397.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i1365.scala", defaultOptions) +
+      // compileTasty("../tests/pos/t1957.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i1756.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i3130d.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i1990a.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i996.scala", defaultOptions) +
+      // compileTasty("../tests/pos/companions.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i1812.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i2944.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i2468.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i2300.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i1990.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i1812b.scala", defaultOptions) +
+      // compileTasty("../tests/pos/t2405.scala", defaultOptions) +
+      // compileTasty("../tests/pos/supercalls.scala", defaultOptions) +
+      // compileTasty("../tests/pos/hklub0.scala", defaultOptions) +
+      // compileTasty("../tests/pos/i3130a.scala", defaultOptions) +
       compileTastyInDir("../tests/pos-from-tasty", defaultOptions) +
       compileTasty("../tests/pos-from-tasty/simpleClass.scala", defaultOptions)
     }
@@ -36,6 +64,31 @@ class FromTastyTests extends ParallelTesting {
     implicit val testGroup: TestGroup = TestGroup("runTestFromTasty")
     val (step1, step2) = {
       // compileTastyInDir("../tests/run", defaultOptions) + // FIXME
+      // compileTasty("../tests/run/t3613.scala", defaultOptions) +
+      // compileTasty("../tests/run/i1569.scala", defaultOptions) +
+      // compileTasty("../tests/run/i2337.scala", defaultOptions) +
+      // compileTasty("../tests/run/t2127.scala", defaultOptions) +
+      // compileTasty("../tests/run/scala2trait-lazyval.scala", defaultOptions) +
+      // compileTasty("../tests/run/t6666a.scala", defaultOptions) +
+      // compileTasty("../tests/run/t3452f.scala", defaultOptions) +
+      // compileTasty("../tests/run/t6957.scala", defaultOptions) +
+      // compileTasty("../tests/run/inlinedAssign.scala", defaultOptions) +
+      // compileTasty("../tests/run/bridges.scala", defaultOptions) +
+      // compileTasty("../tests/run/t8002.scala", defaultOptions) +
+      // compileTasty("../tests/run/t6506.scala", defaultOptions) +
+      // compileTasty("../tests/run/enum-approx.scala", defaultOptions) +
+      // compileTasty("../tests/run/i2337b.scala", defaultOptions) +
+      // compileTasty("../tests/run/array-addition.scala", defaultOptions) +
+      // compileTasty("../tests/run/t1909c.scala", defaultOptions) +
+      // compileTasty("../tests/run/i2163.scala", defaultOptions) +
+      // compileTasty("../tests/run/t8395.scala", defaultOptions) +
+      // compileTasty("../tests/run/view-iterator-stream.scala", defaultOptions) +
+      // compileTasty("../tests/run/Course-2002-13.scala", defaultOptions) +
+      // compileTasty("../tests/run/NestedClasses.scala", defaultOptions) +
+      // compileTasty("../tests/run/inlineForeach.scala", defaultOptions) +
+      // compileTasty("../tests/run/i1990b.scala", defaultOptions) +
+      // compileTasty("../tests/run/t3048.scala", defaultOptions) +
+      // compileTasty("../tests/run/patmat-bind-typed.scala", defaultOptions) +
       compileTastyInDir("../tests/run-from-tasty", defaultOptions) +
       compileTasty("../tests/run/t493.scala", defaultOptions)
     }


### PR DESCRIPTION
Assuming the presence of #3525, this is the exhaustive list of `pos` and `run` tests that cannot be compiled from tasty.
