### PR TITLE
Do not clean the sbt bridge cache on every bootstrapped compile

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -756,10 +756,12 @@ object Build {
       val sbtOrg = "org.scala-sbt"
       val bridgeDirectoryPattern = s"*${dottyVersion}*"
 
+      val log = streams.value.log
+      log.info("Cleaning the dotty-sbt-bridge cache")
       IO.delete((file(home) / ".ivy2" / "cache" / sbtOrg * bridgeDirectoryPattern).get)
       IO.delete((file(home) / ".sbt"  / "boot" * "scala-*" / sbtOrg / "sbt" * "*" * bridgeDirectoryPattern).get)
     },
-    packageSrc in Compile := (packageSrc in Compile).dependsOn(cleanSbtBridge).value,
+    compile in Compile := (compile in Compile).dependsOn(cleanSbtBridge).value,
     description := "sbt compiler bridge for Dotty",
     resolvers += Resolver.typesafeIvyRepo("releases"), // For org.scala-sbt:api
     libraryDependencies ++= Seq(


### PR DESCRIPTION
Previously, any compilation of a bootstrapped project removed the sbt
bridge cache which then had to be recompiled. This is too extreme: we
should only do it when the bridge needs to be recompiled.