### PR TITLE
Ref #1589: Add error message for bad symbolic reference.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -19,7 +19,7 @@ import java.util.WeakHashMap
 import config.Config
 import config.Printers.{incremental, noPrinter}
 import reporting.diagnostic.Message
-import reporting.diagnostic.messages._
+import reporting.diagnostic.messages.BadSymbolicReference
 import reporting.trace
 
 trait SymDenotations { this: Context =>
@@ -1957,12 +1957,7 @@ object SymDenotations {
 
     def complete(denot: SymDenotation)(implicit ctx: Context): Unit = {
       val sym = denot.symbol
-      val file = sym.associatedFile
-      val (location, src) =
-        if (file != null) (s" in $file", file.toString)
-        else ("", "the signature")
-      val name = ctx.fresh.setSetting(ctx.settings.YdebugNames, true).nameString(denot.name)
-      val errMsg = BadSymbolicReference(location, name, denot.owner, src)
+      def errMsg = BadSymbolicReference(denot)
       ctx.error(errMsg, sym.pos)
       if (ctx.debug) throw new scala.Error()
       initializeToDefaults(denot, errMsg)

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -117,6 +117,7 @@ public enum ErrorMessageID {
     UnapplyInvalidNumberOfArgumentsID,
     StaticFieldsOnlyAllowedInObjectsID,
     CyclicInheritanceID,
+    BadSymbolicReferenceID,
     UnableToExtendSealedClassID,
     SymbolHasUnparsableVersionNumberID,
     SymbolChangedSemanticsInVersionID,

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1970,10 +1970,10 @@ object messages {
 
   case class BadSymbolicReference(denot: SymDenotation)(implicit ctx: Context) extends Message(BadSymbolicReferenceID) {
     val kind = "Reference"
-    private val denotationName = ctx.fresh.setSetting(ctx.settings.YdebugNames, true).nameString(denot.name)
 
     val msg = {
       val denotationOwner = denot.owner
+      val denotationName = ctx.fresh.setSetting(ctx.settings.YdebugNames, true).nameString(denot.name)
       val file = denot.symbol.associatedFile
       val (location, src) =
         if (file != null) (s" in $file", file.toString)
@@ -1985,10 +1985,7 @@ object messages {
           |the classpath might be incompatible with the version used when compiling $src."""
     }
 
-    val explanation =
-      hl"""A missing or invalid dependency was detected while loading class file '$denotationName'.
-          |Check your build definition for missing or conflicting dependencies.
-          |Re-run with ${"-Ylog-classpath"} to obtain the information about what classpath is being applied."""
+    val explanation = ""
   }
 
   case class UnableToExtendSealedClass(pclazz: Symbol)(implicit ctx: Context) extends Message(UnableToExtendSealedClassID) {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1970,20 +1970,23 @@ object messages {
 
   case class BadSymbolicReference(denot: SymDenotation)(implicit ctx: Context) extends Message(BadSymbolicReferenceID) {
     val kind = "Reference"
+    private val denotationName = ctx.fresh.setSetting(ctx.settings.YdebugNames, true).nameString(denot.name)
 
-    private val file = denot.symbol.associatedFile
-    private val (location, src) =
-      if (file != null) (s" in $file", file.toString)
-      else ("", "the signature")
-    private val name = ctx.fresh.setSetting(ctx.settings.YdebugNames, true).nameString(denot.name)
+    val msg = {
+      val denotationOwner = denot.owner
+      val file = denot.symbol.associatedFile
+      val (location, src) =
+        if (file != null) (s" in $file", file.toString)
+        else ("", "the signature")
 
-    val msg =
       hl"""Bad symbolic reference. A signature$location
-          |refers to $name in ${denot.owner.showKind} ${denot.owner.showFullName} which is not available.
+          |refers to $denotationName in ${denotationOwner.showKind} ${denotationOwner.showFullName} which is not available.
           |It may be completely missing from the current classpath, or the version on
           |the classpath might be incompatible with the version used when compiling $src."""
+    }
+
     val explanation =
-      hl"""A missing or invalid dependency was detected while loading class file '$name'.
+      hl"""A missing or invalid dependency was detected while loading class file '$denotationName'.
           |Check your build definition for missing or conflicting dependencies.
           |Re-run with ${"-Ylog-classpath"} to obtain the information about what classpath is being applied."""
   }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1968,16 +1968,18 @@ object messages {
     }
   }
 
-  case class BadSymbolicReference(
-    location: String,
-    name: String,
-    denotationOwner: Symbol,
-    src: String
-  )(implicit ctx: Context) extends Message(BadSymbolicReferenceID) {
+  case class BadSymbolicReference(denot: SymDenotation)(implicit ctx: Context) extends Message(BadSymbolicReferenceID) {
     val kind = "Reference"
+
+    private val file = denot.symbol.associatedFile
+    private val (location, src) =
+      if (file != null) (s" in $file", file.toString)
+      else ("", "the signature")
+    private val name = ctx.fresh.setSetting(ctx.settings.YdebugNames, true).nameString(denot.name)
+
     val msg =
       hl"""Bad symbolic reference. A signature$location
-          |refers to $name in ${denotationOwner.showKind} ${denotationOwner.showFullName} which is not available.
+          |refers to $name in ${denot.owner.showKind} ${denot.owner.showFullName} which is not available.
           |It may be completely missing from the current classpath, or the version on
           |the classpath might be incompatible with the version used when compiling $src."""
     val explanation =

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1968,6 +1968,24 @@ object messages {
     }
   }
 
+  case class BadSymbolicReference(
+    location: String,
+    name: String,
+    denotationOwner: Symbol,
+    src: String
+  )(implicit ctx: Context) extends Message(BadSymbolicReferenceID) {
+    val kind = "Reference"
+    val msg =
+      hl"""Bad symbolic reference. A signature$location
+          |refers to $name in ${denotationOwner.showKind} ${denotationOwner.showFullName} which is not available.
+          |It may be completely missing from the current classpath, or the version on
+          |the classpath might be incompatible with the version used when compiling $src."""
+    val explanation =
+      hl"""A missing or invalid dependency was detected while loading class file '$name'.
+          |Check your build definition for missing or conflicting dependencies.
+          |Re-run with ${"-Ylog-classpath"} to obtain the information about what classpath is being applied."""
+  }
+
   case class UnableToExtendSealedClass(pclazz: Symbol)(implicit ctx: Context) extends Message(UnableToExtendSealedClassID) {
     val kind = "Syntax"
     val msg = hl"Cannot extend ${"sealed"} $pclazz in a different source file"


### PR DESCRIPTION
Regarding #1589, this PR addresses the following error:
- "Bad symbolic reference. A signature..." - SymDenotations.scala:1964