### PR TITLE
Fix #3623: Special case MethodType in PlainPrinter

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -342,6 +342,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
           else dclsText(trueDecls)
         tparamsText ~ " extends " ~ toTextParents(tp.parents) ~ "{" ~ selfText ~ declsText ~
           "} at " ~ preText
+      case mt: MethodType =>
+        toTextGlobal(mt)
       case tp =>
         ": " ~ toTextGlobal(tp)
     }


### PR DESCRIPTION
There is still an issue for method with no parameter list:
```scala
def bar: Int // printed as: def bar: => Int
```