### PR TITLE
Remove obsolete package members in new runs

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Scopes.scala
+++ b/compiler/src/dotty/tools/dotc/core/Scopes.scala
@@ -333,8 +333,12 @@ object Scopes {
     }
 
     /** remove symbol from this scope if it is present */
-    final def unlink(sym: Symbol)(implicit ctx: Context): Unit = {
-      var e = lookupEntry(sym.name)
+    final def unlink(sym: Symbol)(implicit ctx: Context): Unit =
+      unlink(sym, sym.name)
+
+    /** remove symbol from this scope if it is present under the given name */
+    final def unlink(sym: Symbol, name: Name)(implicit ctx: Context): Unit = {
+      var e = lookupEntry(name)
       while (e ne null) {
         if (e.sym == sym) unlink(e)
         e = lookupNextEntry(e)

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1853,6 +1853,17 @@ object SymDenotations {
       }
       true
     }
+
+    /** Unlink all package members defined in `file` in a previous run. */
+    def unlinkFromFile(file: AbstractFile)(implicit ctx: Context): Unit = {
+      val scope = unforcedDecls.openForMutations
+      for (sym <- scope.toList.iterator) {
+        // We need to be careful to not force the denotation of `sym` here,
+        // otherwise it will be brought forward to the current run.
+        if (sym.defRunId != ctx.runId && sym.isClass && sym.asClass.assocFile == file)
+          scope.unlink(sym, sym.lastKnownDenotation.name)
+      }
+    }
   }
 
   @sharable object NoDenotation

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -349,7 +349,16 @@ class Namer { typer: Typer =>
     }
     val existing = pkgOwner.info.decls.lookup(pid.name)
 
-    if ((existing is Package) && (pkgOwner eq existing.owner)) existing
+    if ((existing is Package) && (pkgOwner eq existing.owner)) {
+      existing.moduleClass.denot match {
+        case d: PackageClassDenotation =>
+          // Remove existing members coming from a previous compilation of this file,
+          // they are obsolete.
+          d.unlinkFromFile(ctx.source.file)
+        case _ =>
+      }
+      existing
+    }
     else {
       /** If there's already an existing type, then the package is a dup of this type */
       val existingType = pkgOwner.info.decls.lookup(pid.name.toTypeName)


### PR DESCRIPTION
Before this commit, typing and then deleting "class Foo" at the
top-level in the IDE resulted in the creation of symbols "F", "Fo" and
"Foo" that were never deleted. We fix this by always deleting package members
coming from a previous run of the current file when indexing a package.