### PR TITLE
Restrict dotty-compiler to the jvm compact1 profile

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -691,7 +691,6 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     def hasPackageFlag: Boolean = sym is Flags.Package
     def isImplClass: Boolean = sym is Flags.ImplClass
     def isInterface: Boolean = (sym is Flags.PureInterface) || (sym is Flags.Trait)
-    def hasGetter: Boolean = false // used only for generaration of beaninfo todo: implement
     def isGetter: Boolean = toDenot(sym).isGetter
     def isSetter: Boolean = toDenot(sym).isSetter
     def isGetClass: Boolean = sym eq defn.Any_getClass

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -100,7 +100,6 @@ class GenBCodePipeline(val entryPoints: List[Symbol], val int: DottyBackendInter
 
     private[this] var bytecodeWriter  : BytecodeWriter   = null
     private[this] var mirrorCodeGen   : JMirrorBuilder   = null
-    private[this] var beanInfoCodeGen : JBeanInfoBuilder = null
 
     /* ---------------- q1 ---------------- */
 
@@ -126,7 +125,7 @@ class GenBCodePipeline(val entryPoints: List[Symbol], val int: DottyBackendInter
 
     /*
      *  An item of queue-3 (the last queue before serializing to disk) contains three of these
-     *  (one for each of mirror, plain, and bean classes).
+     *  (one for each of mirror and plain classes).
      *
      *  @param jclassName  internal name of the class
      *  @param jclassBytes bytecode emitted for the class SubItem3 represents
@@ -180,7 +179,7 @@ class GenBCodePipeline(val entryPoints: List[Symbol], val int: DottyBackendInter
 
       /*
        *  Checks for duplicate internal names case-insensitively,
-       *  builds ASM ClassNodes for mirror, plain, and bean classes;
+       *  builds ASM ClassNodes for mirror and plain classes;
        *  enqueues them in queue-2.
        *
        */
@@ -339,7 +338,6 @@ class GenBCodePipeline(val entryPoints: List[Symbol], val int: DottyBackendInter
       // initBytecodeWriter invokes fullName, thus we have to run it before the typer-dependent thread is activated.
       bytecodeWriter  = initBytecodeWriter(entryPoints)
       mirrorCodeGen   = new JMirrorBuilder
-      beanInfoCodeGen = new JBeanInfoBuilder
 
       val needsOutfileForSymbol = bytecodeWriter.isInstanceOf[ClassBytecodeWriter]
       buildAndSendToDisk(needsOutfileForSymbol)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -633,8 +633,6 @@ class Definitions {
   def MigrationAnnot(implicit ctx: Context) = MigrationAnnotType.symbol.asClass
   lazy val NativeAnnotType                   = ctx.requiredClassRef("scala.native")
   def NativeAnnot(implicit ctx: Context) = NativeAnnotType.symbol.asClass
-  lazy val RemoteAnnotType                   = ctx.requiredClassRef("scala.remote")
-  def RemoteAnnot(implicit ctx: Context) = RemoteAnnotType.symbol.asClass
   lazy val RepeatedAnnotType = ctx.requiredClassRef("scala.annotation.internal.Repeated")
   def RepeatedAnnot(implicit ctx: Context) = RepeatedAnnotType.symbol.asClass
   lazy val SourceFileAnnotType = ctx.requiredClassRef("scala.annotation.internal.SourceFile")


### PR DESCRIPTION
As verify by running `jdep -s -P` on the dotty-compiler jar. See
https://github.com/scala/bug/issues/10559 for why this is useful and
https://github.com/scala/scala/pull/6164 for how this was implemented in
scalac.