### PR TITLE
Fix #3540: Implicit class with two arguments does not fail compilation

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -20,6 +20,7 @@ public enum ErrorMessageID {
     EarlyDefinitionsNotSupportedID,
     TopLevelImplicitClassID,
     ImplicitCaseClassID,
+    ImplicitClassPrimaryConstructorArityID,
     ObjectMayNotHaveSelfTypeID,
     TupleTooLongID,
     RepeatedModifierID,

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -455,7 +455,7 @@ object messages {
   case class ImplicitClassPrimaryConstructorArity()(implicit ctx: Context)
   extends Message(ImplicitClassPrimaryConstructorArityID){
     val kind = "Syntax"
-    val msg = hl"Implicit classes must accept exactly one primary constructor parameter"
+    val msg = "Implicit classes must accept exactly one primary constructor parameter"
     val explanation = {
       val example = "implicit class RichDate(date: java.util.Date)"
       hl"""Implicit classes may only take one non-implicit argument in their constructor. For example:

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -20,7 +20,6 @@ import printing.Formatting
 import ErrorMessageID._
 import Denotations.SingleDenotation
 import dotty.tools.dotc.ast.Trees
-import dotty.tools.dotc.ast.untpd.Modifiers
 import dotty.tools.dotc.config.ScalaVersion
 import dotty.tools.dotc.core.Flags.{FlagSet, Mutable}
 import dotty.tools.dotc.core.SymDenotations.SymDenotation
@@ -451,6 +450,22 @@ object messages {
            |implicit class ${cdef.name}...
            |
            |""" + implicitClassRestrictionsText
+  }
+
+  case class ImplicitClassPrimaryConstructorArity()(implicit ctx: Context)
+  extends Message(ImplicitClassPrimaryConstructorArityID){
+    val kind = "Syntax"
+    val msg = hl"Implicit classes must accept exactly one primary constructor parameter"
+    val explanation = {
+      val example = "implicit class RichDate(date: java.util.Date)"
+      hl"""Implicit classes may only take one non-implicit argument in their constructor. For example:
+          |
+          | $example
+          |
+          |While it’s possible to create an implicit class with more than one non-implicit argument,
+          |such classes aren’t used during implicit lookup.
+          |""" + implicitClassRestrictionsText
+    }
   }
 
   case class ObjectMayNotHaveSelfType(mdef: untpd.ModuleDef)(implicit ctx: Context)

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -801,6 +801,21 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals(err, ExpectedClassOrObjectDef())
     }
 
+  @Test def implicitClassPrimaryConstructorArity =
+    checkMessagesAfter("frontend") {
+      """
+        |object Test {
+        |  implicit class Foo(i: Int, s: String)
+        |}
+      """.stripMargin
+    }
+    .expect { (itcx, messages) =>
+      implicit val ctx: Context = itcx
+      assertMessageCount(1, messages)
+      val err :: Nil = messages
+      assertEquals(err, ImplicitClassPrimaryConstructorArity())
+    }
+
   @Test def anonymousFunctionMissingParamType =
     checkMessagesAfter("refchecks") {
       """

--- a/tests/neg/i2464.scala
+++ b/tests/neg/i2464.scala
@@ -1,0 +1,4 @@
+object Foo {
+  object Bar
+  implicit class Bar // error: Implicit classes must accept exactly one primary constructor parameter
+}

--- a/tests/neg/i3540.scala
+++ b/tests/neg/i3540.scala
@@ -1,0 +1,9 @@
+object Test {
+  implicit class Foo(i: Int, s: String) // error: Implicit classes must accept exactly one primary constructor parameter
+  implicit class Foo0                   // error: Implicit classes must accept exactly one primary constructor parameter
+  implicit class Foo1()                 // error: Implicit classes must accept exactly one primary constructor parameter
+  implicit class Foo2()(x: Int)         // error: Implicit classes must accept exactly one primary constructor parameter
+  implicit case class Bar0              // error: A case class must have at least one parameter list
+  implicit case class Bar1()            // error: A case class may not be defined as implicit
+  implicit case class Bar2()(x: Int)    // error: A case class may not be defined as implicit
+}

--- a/tests/pos/i3540.scala
+++ b/tests/pos/i3540.scala
@@ -1,0 +1,5 @@
+object Test {
+  implicit class Foo(x: Int)(implicit y: Int)
+  implicit class Foo0(x: Int)(y: Int)(implicit z: Int) // OK but not used during implicit lookup
+  implicit class Foo1(x: Int)(y: Int)                  // OK but not used during implicit lookup
+}


### PR DESCRIPTION
This PR aims #3540 and #2464.

Where:

```
object Test {
  implicit class Foo(i: Int, s: String)
}
```

And

```
object Foo {
  object Bar
  implicit class Bar
}
```

Compilation must fail providing `Implicit classes must accept exactly one primary constructor parameter` error message and further explanation.