### PR TITLE
Reduce running time of testPickling

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -210,14 +210,14 @@ class CompilationTests extends ParallelTesting {
 
   @Test def testPickling: Unit = {
     implicit val testGroup: TestGroup = TestGroup("testPickling")
-    compileDir("../compiler/src/dotty/tools", picklingOptions) +
-    compileDir("../compiler/src/dotty/tools/dotc", picklingOptions) +
+    compileDir("../compiler/src/dotty/tools", picklingOptions, recursive = false) +
+    compileDir("../compiler/src/dotty/tools/dotc", picklingOptions, recursive = false) +
     compileFilesInDir("../tests/new", picklingOptions) +
     compileFilesInDir("../tests/pickling", picklingOptions) +
     compileDir("../library/src/dotty/runtime", picklingOptions) +
     compileDir("../compiler/src/dotty/tools/backend/jvm", picklingOptions) +
     compileDir("../compiler/src/dotty/tools/dotc/ast", picklingOptions) +
-    compileDir("../compiler/src/dotty/tools/dotc/core", picklingOptions) +
+    compileDir("../compiler/src/dotty/tools/dotc/core", picklingOptions, recursive = false) +
     compileDir("../compiler/src/dotty/tools/dotc/config", picklingOptions) +
     compileDir("../compiler/src/dotty/tools/dotc/parsing", picklingOptions) +
     compileDir("../compiler/src/dotty/tools/dotc/printing", picklingOptions) +

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -1113,13 +1113,16 @@ trait ParallelTesting extends RunnerOrchestration { self =>
    *  By default, files are compiled in alphabetical order. An optional seed
    *  can be used for randomization.
    */
-  def compileDir(f: String, flags: TestFlags, randomOrder: Option[Int] = None)(implicit testGroup: TestGroup): CompilationTest = {
+  def compileDir(f: String, flags: TestFlags, randomOrder: Option[Int] = None, recursive: Boolean = true)(implicit testGroup: TestGroup): CompilationTest = {
     val outDir = defaultOutputDir + testGroup + "/"
     val sourceDir = new JFile(f)
     checkRequirements(f, sourceDir, outDir)
 
     def flatten(f: JFile): Array[JFile] =
-      if (f.isDirectory) f.listFiles.flatMap(flatten)
+      if (f.isDirectory) {
+        val files = f.listFiles
+        if (recursive) files.flatMap(flatten) else files
+      }
       else Array(f)
 
     // Sort files either alphabetically or randomly using the provided seed:


### PR DESCRIPTION
testPickling pickled directories recursively. It seems this was unintentional
as it caused testPickling to test most files of the dotty compiler three times,
including two runs where basically the whole compiler was tested together. This
was very slow as pickling (and retaining pickled info) caused very high memory pressure.

We now compile root compiler directories non-recursively.