### PR TITLE
More aggressive valification

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -313,6 +313,7 @@ object NameKinds {
   val PatMatSelectorName      = new UniqueNameKind("selector")
 
   val LocalOptInlineLocalObj  = new UniqueNameKind("ilo")
+  val LocalOptValifyName      = new UniqueNameKind("valify")
 
   /** The kind of names of default argument getters */
   val DefaultGetterName = new NumberedNameKind(DEFAULTGETTER, "DefaultGetter") {

--- a/compiler/src/dotty/tools/dotc/transform/localopt/Valify.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/Valify.scala
@@ -58,7 +58,7 @@ class Valify(val simplifyPhase: Simplify) extends Optimisation {
           else new TreeMap() {
               override def transform(tree: Tree)(implicit ctx: Context): Tree = {
                 // abort valification in captures
-                if (tree.isDef && tree.symbol.exists) tree
+                if (tree.isDef && tree.symbol.exists && tree.symbol.is(Method)) tree
                 else super.transform(tree)(ctx) match {
                   case id: Ident if valified.contains(id.symbol) => 
                     replaced = true

--- a/compiler/test/dotty/tools/dotc/SimplifyTests.scala
+++ b/compiler/test/dotty/tools/dotc/SimplifyTests.scala
@@ -201,6 +201,17 @@ abstract class SimplifyTests(val optimise: Boolean) extends DottyBytecodeTest {
         |print(i)
       """)
 
+  @Test def valifyValVar =
+    check(
+      """
+        |var i = 7
+        |val cst = i
+        |print(cst)
+      """,
+      """
+        |print(7)
+      """)
+
   // check for incorrecly eliminated statements with side effects 
   @Test def valifySideEffects =
     checkNotEquals(


### PR DESCRIPTION
Valify optimization pass rewritten to be a lot more aggressive.
This implementation replaces every `var` assignation by a `val` def then replaces every (unconditional) access to the mutable variable by an access to it's valified counterpart. If not all accesses can be valified the assignation is kept, otherwise it is discarded.
