### PR TITLE
Fix typo in implicit conversion example

### DIFF
--- a/docs/docs/reference/changed/implicit-conversions.md
+++ b/docs/docs/reference/changed/implicit-conversions.md
@@ -33,7 +33,7 @@ In summary, previous code using implicit conversion parameters such as
 
     def useConversion(implicit f: A => B) = {
       val y: A = ...
-      val x: B = a    // error under Dotty
+      val x: B = y    // error under Dotty
     }
 
 is no longer legal and has to be rewritten to


### PR DESCRIPTION
In the following example:
```
def useConversion(implicit f: A => B) = {
      val y: A = ...
      val x: B = a    // error under Dotty
}
```
`x` should probably refer to `y`, but not to `a`