### PR TITLE
Fix #3633: Inline trees can be pure

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -372,6 +372,8 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
       exprPurity(expr)
     case Block(stats, expr) =>
       minOf(exprPurity(expr), stats.map(statPurity))
+    case Inlined(_, bindings, expr) =>
+      minOf(exprPurity(expr), bindings.map(statPurity))
     case NamedArg(_, expr) =>
       exprPurity(expr)
     case _ =>

--- a/tests/pos/i3633.scala
+++ b/tests/pos/i3633.scala
@@ -1,0 +1,4 @@
+class Test {
+  inline def foo = 1
+  def test = -foo
+}


### PR DESCRIPTION
Need to be handled like blocks for determining their purity.