### PR TITLE
Fix #3664: Run `test` in CI instead of `testAll`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ pipeline:
     image: lampepfl/dotty:2017-11-17
     commands:
       - cp -R . /tmp/1/ && cd /tmp/1/
-      - ./project/scripts/sbt ";compile ;testAll"
+      - ./project/scripts/sbt ";compile ;test"
       - ./project/scripts/sbtTests
 
   test_bootstrapped:
@@ -33,7 +33,7 @@ pipeline:
     image: lampepfl/dotty:2017-11-17
     commands:
       - cp -R . /tmp/2/ && cd /tmp/2/
-      - ./project/scripts/sbt ";dotty-bootstrapped/compile ;dotty-bootstrapped/testAll"
+      - ./project/scripts/sbt ";dotty-bootstrapped/compile ;dotty-bootstrapped/test"
       - ./project/scripts/sbtBootstrappedTests
 
   test_optimised:
@@ -41,7 +41,7 @@ pipeline:
     image: lampepfl/dotty:2017-11-17
     commands:
       - cp -R . /tmp/3/ && cd /tmp/3/
-      - ./project/scripts/sbt dotty-optimised/testAll
+      - ./project/scripts/sbt dotty-optimised/test
 
   test_sbt:
     group: test

--- a/library/src/dotty/Show.scala
+++ b/library/src/dotty/Show.scala
@@ -16,7 +16,7 @@ object Show extends LowPrioShow {
     * any `T`, we default to `T#toString`.
     */
   implicit class ShowValue[V](val v: V) extends AnyVal {
-    def show(implicit ev: Show[V] = defaultShow): String =
+    def show(implicit ev: Show[V]): String =
       ev.show(v)
   }
 
@@ -69,6 +69,10 @@ object Show extends LowPrioShow {
       case Some(t) => "Some("+ st.show(t) + ")"
       case none => "None"
     }
+  }
+
+  implicit def showSome[T](implicit st: Show[T]): Show[Some[T]] = new Show[Some[T]] {
+    def show(ot: Some[T]): String = "Some("+ st.show(ot.get) + ")"
   }
 
   implicit def showMap[K,V](implicit sk: Show[K], sv: Show[V]): Show[Map[K,V]] = new Show[Map[K,V]] {

--- a/library/test/dotty/ShowTests.scala
+++ b/library/test/dotty/ShowTests.scala
@@ -62,14 +62,13 @@ class ShowTests {
 
   @Test def withoutShow = {
     case class Car(model: String, manufacturer: String, year: Int)
-
     assertEquals("Car(Mustang,Ford,1967)", Car("Mustang", "Ford", 1967).show)
     assertEquals("Map()", Map[Nothing, Nothing]().show)
+    assertEquals("List()", List().show)
   }
 
   @Test def partialShow = {
     case object Foo
-
     assertEquals("Map(Foo -> \"Hello\")", Map(Foo -> "Hello").show)
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -72,11 +72,11 @@ object Build {
   lazy val packageAll =
     taskKey[Map[String, String]]("Package everything needed to run tests")
 
+  // Run tests with filter through vulpix test suite
+  lazy val testCompilation = inputKey[Unit]("runs integration test with the supplied filter")
+
   // Spawns a repl with the correct classpath
   lazy val repl = inputKey[Unit]("run the REPL with correct classpath")
-
-  // Run tests with filter through vulpix test suite
-  lazy val vulpix = inputKey[Unit]("runs integration test with the supplied filter")
 
   // Used to compile files similar to ./bin/dotc script
   lazy val dotc =
@@ -556,7 +556,7 @@ object Build {
         jars ::: tuning ::: agentOptions ::: ci_build ::: path.toList
       },
 
-      vulpix := Def.inputTaskDyn {
+      testCompilation := Def.inputTaskDyn {
         val args: Seq[String] = spaceDelimited("<arg>").parsed
         val cmd = " dotty.tools.dotc.CompilationTests -- --exclude-categories=dotty.SlowTests" + {
           if (args.nonEmpty) " -Ddotty.tests.filter=" + args.mkString(" ")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -78,9 +78,6 @@ object Build {
   // Run tests with filter through vulpix test suite
   lazy val vulpix = inputKey[Unit]("runs integration test with the supplied filter")
 
-  // Run all tests including tests marked with SlowTests
-  lazy val testAll = inputKey[Unit]("runs all tests including SlowTests")
-
   // Used to compile files similar to ./bin/dotc script
   lazy val dotc =
     inputKey[Unit]("run the compiler using the correct classpath, or the user supplied classpath")
@@ -124,7 +121,11 @@ object Build {
     // Override `runCode` from sbt-dotty to use the language-server and
     // vscode extension from the source repository of dotty instead of a
     // published version.
-    runCode := (run in `dotty-language-server`).toTask("").value
+    runCode := (run in `dotty-language-server`).toTask("").value,
+
+    // include sources in eclipse (downloads source code for all dependencies)
+    //http://stackoverflow.com/questions/10472840/how-to-attach-sources-to-sbt-managed-dependencies-in-scala-ide#answer-11683728
+    EclipseKeys.withSource := true
   )
 
   // Settings shared globally (scoped in Global). Used in build.sbt
@@ -180,7 +181,12 @@ object Build {
     resourceDirectory in Test       := baseDirectory.value / "test-resources",
 
     // Prevent sbt from rewriting our dependencies
-    ivyScala ~= (_ map (_ copy (overrideScalaVersion = false)))
+    ivyScala ~= (_ map (_ copy (overrideScalaVersion = false))),
+
+    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
+
+    // enable verbose exception messages for JUnit
+    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v")
   )
 
   // Settings used for projects compiled only with Scala 2
@@ -345,9 +351,6 @@ object Build {
     connectInput in run := true,
     outputStrategy := Some(StdoutOutput),
 
-    // enable verbose exception messages for JUnit
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
-
     javaOptions ++= (javaOptions in `dotty-compiler`).value,
     fork in run := true,
     fork in Test := true,
@@ -387,7 +390,6 @@ object Build {
     }.evaluated,
 
     libraryDependencies ++= Seq(
-      "com.novocode" % "junit-interface" % "0.11" % "test",
       "com.vladsch.flexmark" % "flexmark" % "0.11.1",
       "com.vladsch.flexmark" % "flexmark-ext-gfm-tasklist" % "0.11.1",
       "com.vladsch.flexmark" % "flexmark-ext-gfm-tables" % "0.11.1",
@@ -455,9 +457,6 @@ object Build {
         pairs.map(_._2)
       }.taskValue,
 
-      // Used by the backend
-      libraryDependencies += "org.scala-lang.modules" % "scala-asm" % "6.0.0-scala-1",
-
       // set system in/out for repl
       connectInput in run := true,
       outputStrategy := Some(StdoutOutput),
@@ -483,18 +482,13 @@ object Build {
         Seq(file)
       }.taskValue,
 
-      // include sources in eclipse (downloads source code for all dependencies)
-      //http://stackoverflow.com/questions/10472840/how-to-attach-sources-to-sbt-managed-dependencies-in-scala-ide#answer-11683728
-      com.typesafe.sbteclipse.plugin.EclipsePlugin.EclipseKeys.withSource := true,
-
       // get libraries onboard
-      libraryDependencies ++= Seq("com.typesafe.sbt" % "sbt-interface" % sbtVersion.value,
-                                  ("org.scala-lang.modules" %% "scala-xml" % "1.0.6").withDottyCompat(),
-                                  "com.novocode" % "junit-interface" % "0.11" % "test",
-                                  "org.scala-lang" % "scala-library" % scalacVersion % "test"),
-
-      // enable improved incremental compilation algorithm
-      incOptions := incOptions.value.withNameHashing(true),
+      libraryDependencies ++= Seq(
+        "org.scala-lang.modules" % "scala-asm" % "6.0.0-scala-1", // used by the backend
+        "com.typesafe.sbt" % "sbt-interface" % sbtVersion.value,
+        ("org.scala-lang.modules" %% "scala-xml" % "1.0.6").withDottyCompat(),
+        "org.scala-lang" % "scala-library" % scalacVersion % "test"
+      ),
 
       // For convenience, change the baseDirectory when running the compiler
       baseDirectory in (Compile, run) := baseDirectory.value / "..",
@@ -503,88 +497,12 @@ object Build {
 
       test in Test := {
         // Exclude legacy tests by default
-        (testOnly in Test).toTask(" -- --exclude-categories=dotty.LegacyTests,dotty.SlowTests").value
-      },
-
-      testAll in Test := {
-        // Exclude legacy tests by default
         (testOnly in Test).toTask(" -- --exclude-categories=dotty.LegacyTests").value
       },
 
-      vulpix := Def.inputTaskDyn {
-        val args: Seq[String] = spaceDelimited("<arg>").parsed
-        val cmd = " dotty.tools.dotc.CompilationTests -- --exclude-categories=dotty.SlowTests" + {
-          if (args.nonEmpty) " -Ddotty.tests.filter=" + args.mkString(" ")
-          else ""
-        }
-        (testOnly in Test).toTask(cmd)
-      }.evaluated,
-
-      // Override run to be able to run compiled classfiles
-      dotr := {
-        val args: List[String] = spaceDelimited("<arg>").parsed.toList
-        val java: String = Process("which" :: "java" :: Nil).!!
-        val attList = (dependencyClasspath in Runtime).value
-        val _ = packageAll.value
-        val scalaLib = attList
-          .map(_.data.getAbsolutePath)
-          .find(_.contains("scala-library"))
-          .toList.mkString(":")
-
-        if (args.isEmpty) {
-          println("Couldn't run `dotr` without args. Use `repl` to run the repl or add args to run the dotty application")
-        } else if (java == "") {
-          println("Couldn't find java executable on path, please install java to a default location")
-        } else if (scalaLib == "") {
-          println("Couldn't find scala-library on classpath, please run using script in bin dir instead")
-        } else {
-          val dottyLib = packageAll.value("dotty-library")
-          val fullArgs = insertClasspathInArgs(args, s".:$dottyLib:$scalaLib")
-          s"$java ${fullArgs.mkString(" ")}".!
-        }
-      },
-      run := dotc.evaluated,
-      dotc := runCompilerMain().evaluated,
-      repl := runCompilerMain(repl = true).evaluated,
-
-      // enable verbose exception messages for JUnit
       testOptions in Test += Tests.Argument(
-        TestFrameworks.JUnit, "-a", "-v",
-        "--run-listener=dotty.tools.ContextEscapeDetector"
+        TestFrameworks.JUnit, "--run-listener=dotty.tools.ContextEscapeDetector"
       ),
-
-      /* Add the sources of scalajs-ir.
-       * To guarantee that dotty can bootstrap without depending on a version
-       * of scalajs-ir built with a different Scala compiler, we add its
-       * sources instead of depending on the binaries.
-       */
-      //TODO: disabling until moved to separate project
-      //ivyConfigurations += config("sourcedeps").hide,
-      //libraryDependencies +=
-      //  "org.scala-js" %% "scalajs-ir" % scalaJSVersion % "sourcedeps",
-      //sourceGenerators in Compile += Def.task {
-      //  val s = streams.value
-      //  val cacheDir = s.cacheDirectory
-      //  val trgDir = (sourceManaged in Compile).value / "scalajs-ir-src"
-
-      //  val report = updateClassifiers.value
-      //  val scalaJSIRSourcesJar = report.select(
-      //      configuration = Set("sourcedeps"),
-      //      module = (_: ModuleID).name.startsWith("scalajs-ir_"),
-      //      artifact = artifactFilter(`type` = "src")).headOption.getOrElse {
-      //    sys.error(s"Could not fetch scalajs-ir sources")
-      //  }
-
-      //  FileFunction.cached(cacheDir / s"fetchScalaJSIRSource",
-      //      FilesInfo.lastModified, FilesInfo.exists) { dependencies =>
-      //    s.log.info(s"Unpacking scalajs-ir sources to $trgDir...")
-      //    if (trgDir.exists)
-      //      IO.delete(trgDir)
-      //    IO.createDirectory(trgDir)
-      //    IO.unzip(scalaJSIRSourcesJar, trgDir)
-      //    (trgDir ** "*.scala").get.toSet
-      //  } (Set(scalaJSIRSourcesJar)).toSeq
-      //}.taskValue,
 
       // Spawn new JVM in run and test
       fork in run := true,
@@ -636,7 +554,76 @@ object Build {
         )
 
         jars ::: tuning ::: agentOptions ::: ci_build ::: path.toList
-      }
+      },
+
+      vulpix := Def.inputTaskDyn {
+        val args: Seq[String] = spaceDelimited("<arg>").parsed
+        val cmd = " dotty.tools.dotc.CompilationTests -- --exclude-categories=dotty.SlowTests" + {
+          if (args.nonEmpty) " -Ddotty.tests.filter=" + args.mkString(" ")
+          else ""
+        }
+        (testOnly in Test).toTask(cmd)
+      }.evaluated,
+
+      // Override run to be able to run compiled classfiles
+      dotr := {
+        val args: List[String] = spaceDelimited("<arg>").parsed.toList
+        val java: String = Process("which" :: "java" :: Nil).!!
+        val attList = (dependencyClasspath in Runtime).value
+        val _ = packageAll.value
+        val scalaLib = attList
+          .map(_.data.getAbsolutePath)
+          .find(_.contains("scala-library"))
+          .toList.mkString(":")
+
+        if (args.isEmpty) {
+          println("Couldn't run `dotr` without args. Use `repl` to run the repl or add args to run the dotty application")
+        } else if (java == "") {
+          println("Couldn't find java executable on path, please install java to a default location")
+        } else if (scalaLib == "") {
+          println("Couldn't find scala-library on classpath, please run using script in bin dir instead")
+        } else {
+          val dottyLib = packageAll.value("dotty-library")
+          val fullArgs = insertClasspathInArgs(args, s".:$dottyLib:$scalaLib")
+          s"$java ${fullArgs.mkString(" ")}".!
+        }
+      },
+      run := dotc.evaluated,
+      dotc := runCompilerMain().evaluated,
+      repl := runCompilerMain(repl = true).evaluated
+
+      /* Add the sources of scalajs-ir.
+       * To guarantee that dotty can bootstrap without depending on a version
+       * of scalajs-ir built with a different Scala compiler, we add its
+       * sources instead of depending on the binaries.
+       */
+      //TODO: disabling until moved to separate project
+      //ivyConfigurations += config("sourcedeps").hide,
+      //libraryDependencies +=
+      //  "org.scala-js" %% "scalajs-ir" % scalaJSVersion % "sourcedeps",
+      //sourceGenerators in Compile += Def.task {
+      //  val s = streams.value
+      //  val cacheDir = s.cacheDirectory
+      //  val trgDir = (sourceManaged in Compile).value / "scalajs-ir-src"
+
+      //  val report = updateClassifiers.value
+      //  val scalaJSIRSourcesJar = report.select(
+      //      configuration = Set("sourcedeps"),
+      //      module = (_: ModuleID).name.startsWith("scalajs-ir_"),
+      //      artifact = artifactFilter(`type` = "src")).headOption.getOrElse {
+      //    sys.error(s"Could not fetch scalajs-ir sources")
+      //  }
+
+      //  FileFunction.cached(cacheDir / s"fetchScalaJSIRSource",
+      //      FilesInfo.lastModified, FilesInfo.exists) { dependencies =>
+      //    s.log.info(s"Unpacking scalajs-ir sources to $trgDir...")
+      //    if (trgDir.exists)
+      //      IO.delete(trgDir)
+      //    IO.createDirectory(trgDir)
+      //    IO.unzip(scalaJSIRSourcesJar, trgDir)
+      //    (trgDir ** "*.scala").get.toSet
+      //  } (Set(scalaJSIRSourcesJar)).toSeq
+      //}.taskValue
   )
 
   def runCompilerMain(repl: Boolean = false) = Def.inputTaskDyn {
@@ -678,7 +665,7 @@ object Build {
         "dotty-compiler" -> (packageBin in Compile).value,
         "dotty-library" -> (packageBin in (`dotty-library`, Compile)).value,
         "dotty-compiler-test" -> (packageBin in Test).value
-      ) map { case (k, v) => (k, v.getAbsolutePath) }
+      ).mapValues(_.getAbsolutePath)
     }
   )
 
@@ -706,10 +693,7 @@ object Build {
 
   // Settings shared between dotty-library and dotty-library-bootstrapped
   lazy val dottyLibrarySettings = Seq(
-      libraryDependencies ++= Seq(
-        "org.scala-lang" % "scala-library" % scalacVersion,
-        "com.novocode" % "junit-interface" % "0.11" % "test"
-      )
+      libraryDependencies += "org.scala-lang" % "scala-library" % scalacVersion
   )
 
   lazy val `dotty-library` = project.in(file("library")).asDottyLibrary(NonBootstrapped)


### PR DESCRIPTION
We remove `testAll` which is now equivalent to `test`. If one only want to run the compilation tests, he can use the `vulpix` command.

This commit also, clean the sbt build