### PR TITLE
Split Compiler.phases into smaller logical groups

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -40,78 +40,93 @@ class Compiler {
    *     plain SymDenotation, as opposed to a UniqueRefDenotation.
    */
   def phases: List[List[Phase]] =
-    List(
-      List(new FrontEnd),           // Compiler frontend: scanner, parser, namer, typer
-      List(new sbt.ExtractDependencies), // Sends information on classes' dependencies to sbt via callbacks
-      List(new PostTyper),          // Additional checks and cleanups after type checking
-      List(new sbt.ExtractAPI),     // Sends a representation of the API of classes to sbt via callbacks
-      List(new Pickler),            // Generate TASTY info
-      List(new LinkAll),            // Reload compilation units from TASTY for library code (if needed)
-      List(new ReifyQuotes),        // Turn quoted trees into explicit run-time data structures
-      List(new FirstTransform,      // Some transformations to put trees into a canonical form
-           new CheckReentrant,      // Internal use only: Check that compiled program has no data races involving global vars
-           new ElimPackagePrefixes), // Eliminate references to package prefixes in Select nodes
-      List(new CheckStatic,         // Check restrictions that apply to @static members
-           new ElimRepeated,        // Rewrite vararg parameters and arguments
-           new NormalizeFlags,      // Rewrite some definition flags
-           new ExtensionMethods,    // Expand methods of value classes with extension methods
-           new ExpandSAMs,          // Expand single abstract method closures to anonymous classes
-           new TailRec,             // Rewrite tail recursion to loops
-           new ByNameClosures,      // Expand arguments to by-name parameters to closures
-           new LiftTry,             // Put try expressions that might execute on non-empty stacks into their own methods
-           new HoistSuperArgs,      // Hoist complex arguments of supercalls to enclosing scope
-           new ClassOf,             // Expand `Predef.classOf` calls.
-           new RefChecks),          // Various checks mostly related to abstract members and overriding
-      List(new TryCatchPatterns,    // Compile cases in try/catch
-           new PatternMatcher,      // Compile pattern matches
-           new ExplicitOuter,       // Add accessors to outer classes from nested ones.
-           new ExplicitSelf,        // Make references to non-trivial self types explicit as casts
-           new ShortcutImplicits,   // Allow implicit functions without creating closures
-           new CrossCastAnd,        // Normalize selections involving intersection types.
-           new Splitter),           // Expand selections involving union types into conditionals
-      List(new PhantomArgLift,      // Extracts the evaluation of phantom arguments placing them before the call.
-           new VCInlineMethods,     // Inlines calls to value class methods
-           new SeqLiterals,         // Express vararg arguments as arrays
-           new InterceptedMethods,  // Special handling of `==`, `|=`, `getClass` methods
-           new Getters,             // Replace non-private vals and vars with getter defs (fields are added later)
-           new ElimByName,          // Expand by-name parameter references
-           new ElimOuterSelect,     // Expand outer selections
-           new AugmentScala2Traits, // Expand traits defined in Scala 2.x to simulate old-style rewritings
-           new ResolveSuper,        // Implement super accessors and add forwarders to trait methods
-           new Simplify,            // Perform local optimizations, simplified versions of what linker does.
-           new PrimitiveForwarders, // Add forwarders to trait methods that have a mismatch between generic and primitives
-           new FunctionXXLForwarders, // Add forwarders for FunctionXXL apply method
-           new ArrayConstructors),  // Intercept creation of (non-generic) arrays and intrinsify.
-      List(new Erasure),            // Rewrite types to JVM model, erasing all type parameters, abstract types and refinements.
-      List(new ElimErasedValueType, // Expand erased value types to their underlying implmementation types
-           new VCElideAllocations,  // Peep-hole optimization to eliminate unnecessary value class allocations
-           new Mixin,               // Expand trait fields and trait initializers
-           new LazyVals,            // Expand lazy vals
-           new Memoize,             // Add private fields to getters and setters
-           new NonLocalReturns,     // Expand non-local returns
-           new CapturedVars),       // Represent vars captured by closures as heap objects
-      List(new Constructors,        // Collect initialization code in primary constructors
-                                    // Note: constructors changes decls in transformTemplate, no InfoTransformers should be added after it
-           new FunctionalInterfaces, // Rewrites closures to implement @specialized types of Functions.
-           new GetClass,            // Rewrites getClass calls on primitive types.
-           new Simplify),           // Perform local optimizations, simplified versions of what linker does.
-      List(new LinkScala2Impls,     // Redirect calls to trait methods defined by Scala 2.x, so that they now go to their implementations
-           new LambdaLift,          // Lifts out nested functions to class scope, storing free variables in environments
-                                       // Note: in this mini-phase block scopes are incorrect. No phases that rely on scopes should be here
-           new ElimStaticThis),     // Replace `this` references to static objects by global identifiers
-      List(new Flatten,             // Lift all inner classes to package scope
-           new RestoreScopes,       // Repair scopes rendered invalid by moving definitions in prior phases of the group
-           new RenameLifted,        // Renames lifted classes to local numbering scheme
-           new TransformWildcards,  // Replace wildcards with default values
-           new MoveStatics,         // Move static methods to companion classes
-           new ExpandPrivate,       // Widen private definitions accessed from nested classes
-           new SelectStatic,        // get rid of selects that would be compiled into GetStatic
-           new CollectEntryPoints,  // Find classes with main methods
-           new CollectSuperCalls,   // Find classes that are called with super
-           new DropInlined,         // Drop Inlined nodes, since backend has no use for them
-           new LabelDefs),          // Converts calls to labels to jumps
-      List(new GenBCode)            // Generate JVM bytecode
-    )
+    frontendPhases ::: picklerPhases ::: transformPhases ::: backendPhases
+
+  /** Phases dealing with the frontend up to trees ready for TASTY pickling */
+  protected def frontendPhases: List[List[Phase]] =
+    List(new FrontEnd) ::           // Compiler frontend: scanner, parser, namer, typer
+    List(new sbt.ExtractDependencies) :: // Sends information on classes' dependencies to sbt via callbacks
+    List(new PostTyper) ::          // Additional checks and cleanups after type checking
+    List(new sbt.ExtractAPI) ::     // Sends a representation of the API of classes to sbt via callbacks
+    Nil
+
+  /** Phases dealing with TASTY tree pickling and unpickling */
+  protected def picklerPhases: List[List[Phase]] =
+    List(new Pickler) ::            // Generate TASTY info
+    List(new LinkAll) ::            // Reload compilation units from TASTY for library code (if needed)
+    List(new ReifyQuotes) ::        // Turn quoted trees into explicit run-time data structures
+    Nil
+
+  /** Phases dealing with the transformation from pickled trees to backend trees */
+  protected def transformPhases: List[List[Phase]] =
+    List(new FirstTransform,         // Some transformations to put trees into a canonical form
+         new CheckReentrant,         // Internal use only: Check that compiled program has no data races involving global vars
+         new ElimPackagePrefixes) :: // Eliminate references to package prefixes in Select nodes
+    List(new CheckStatic,            // Check restrictions that apply to @static members
+         new ElimRepeated,           // Rewrite vararg parameters and arguments
+         new NormalizeFlags,         // Rewrite some definition flags
+         new ExtensionMethods,       // Expand methods of value classes with extension methods
+         new ExpandSAMs,             // Expand single abstract method closures to anonymous classes
+         new TailRec,                // Rewrite tail recursion to loops
+         new ByNameClosures,         // Expand arguments to by-name parameters to closures
+         new LiftTry,                // Put try expressions that might execute on non-empty stacks into their own methods
+         new HoistSuperArgs,         // Hoist complex arguments of supercalls to enclosing scope
+         new ClassOf,                // Expand `Predef.classOf` calls.
+         new RefChecks) ::           // Various checks mostly related to abstract members and overriding
+    List(new TryCatchPatterns,       // Compile cases in try/catch
+         new PatternMatcher,         // Compile pattern matches
+         new ExplicitOuter,          // Add accessors to outer classes from nested ones.
+         new ExplicitSelf,           // Make references to non-trivial self types explicit as casts
+         new ShortcutImplicits,      // Allow implicit functions without creating closures
+         new CrossCastAnd,           // Normalize selections involving intersection types.
+         new Splitter) ::            // Expand selections involving union types into conditionals
+    List(new PhantomArgLift,         // Extracts the evaluation of phantom arguments placing them before the call.
+         new VCInlineMethods,        // Inlines calls to value class methods
+         new SeqLiterals,            // Express vararg arguments as arrays
+         new InterceptedMethods,     // Special handling of `==`, `|=`, `getClass` methods
+         new Getters,                // Replace non-private vals and vars with getter defs (fields are added later)
+         new ElimByName,             // Expand by-name parameter references
+         new ElimOuterSelect,        // Expand outer selections
+         new AugmentScala2Traits,    // Expand traits defined in Scala 2.x to simulate old-style rewritings
+         new ResolveSuper,           // Implement super accessors and add forwarders to trait methods
+         new Simplify,               // Perform local optimizations, simplified versions of what linker does.
+         new PrimitiveForwarders,    // Add forwarders to trait methods that have a mismatch between generic and primitives
+         new FunctionXXLForwarders,  // Add forwarders for FunctionXXL apply method
+         new ArrayConstructors) ::   // Intercept creation of (non-generic) arrays and intrinsify.
+    List(new Erasure) ::             // Rewrite types to JVM model, erasing all type parameters, abstract types and refinements.
+    List(new ElimErasedValueType,    // Expand erased value types to their underlying implmementation types
+         new VCElideAllocations,     // Peep-hole optimization to eliminate unnecessary value class allocations
+         new Mixin,                   // Expand trait fields and trait initializers
+         new LazyVals,               // Expand lazy vals
+         new Memoize,                // Add private fields to getters and setters
+         new NonLocalReturns,        // Expand non-local returns
+         new CapturedVars) ::        // Represent vars captured by closures as heap objects
+    List(new Constructors,           // Collect initialization code in primary constructors
+                                        // Note: constructors changes decls in transformTemplate, no InfoTransformers should be added after it
+         new FunctionalInterfaces,   // Rewrites closures to implement @specialized types of Functions.
+         new GetClass,               // Rewrites getClass calls on primitive types.
+         new Simplify) ::            // Perform local optimizations, simplified versions of what linker does.
+    List(new LinkScala2Impls,        // Redirect calls to trait methods defined by Scala 2.x, so that they now go to their implementations
+         new LambdaLift,             // Lifts out nested functions to class scope, storing free variables in environments
+                                        // Note: in this mini-phase block scopes are incorrect. No phases that rely on scopes should be here
+         new ElimStaticThis) ::      // Replace `this` references to static objects by global identifiers
+    List(new Flatten,                // Lift all inner classes to package scope
+         new RestoreScopes,          // Repair scopes rendered invalid by moving definitions in prior phases of the group
+         new RenameLifted,           // Renames lifted classes to local numbering scheme
+         new TransformWildcards,     // Replace wildcards with default values
+         new MoveStatics,            // Move static methods to companion classes
+         new ExpandPrivate,          // Widen private definitions accessed from nested classes
+         new SelectStatic,           // get rid of selects that would be compiled into GetStatic
+         new CollectEntryPoints,     // Find classes with main methods
+         new CollectSuperCalls,      // Find classes that are called with super
+         new DropInlined,            // Drop Inlined nodes, since backend has no use for them
+         new LabelDefs) ::           // Converts calls to labels to jumps
+    Nil
+
+  /** Generate the output of the compilation */
+  protected def backendPhases: List[List[Phase]] =
+    List(new GenBCode) ::            // Generate JVM bytecode
+    Nil
 
   var runId = 1
   def nextRunId = {

--- a/compiler/src/dotty/tools/dotc/decompiler/TASTYDecompiler.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/TASTYDecompiler.scala
@@ -9,8 +9,15 @@ import dotty.tools.dotc.core.Phases.Phase
  * @author Nicolas Stucki
  */
 class TASTYDecompiler extends TASTYCompiler {
-  override def phases: List[List[Phase]] = List(
-    List(new ReadTastyTreesFromClasses), // Load classes from tasty
-    List(new DecompilationPrinter)       // Print all loaded classes
-  )
+
+  override protected def frontendPhases: List[List[Phase]] =
+    List(new ReadTastyTreesFromClasses) :: // Load classes from tasty
+    Nil
+
+  override protected def picklerPhases: List[List[Phase]] = Nil
+  override protected def transformPhases: List[List[Phase]] = Nil
+
+  override protected def backendPhases: List[List[Phase]] =
+    List(new DecompilationPrinter) ::  // Print all loaded classes
+    Nil
 }

--- a/compiler/src/dotty/tools/dotc/fromtasty/TASTYCompiler.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/TASTYCompiler.scala
@@ -5,17 +5,15 @@ package fromtasty
 import core._
 import Contexts._
 import Phases.Phase
-import dotty.tools.dotc.transform.Pickler
+import dotty.tools.dotc.transform._
 
 class TASTYCompiler extends Compiler {
 
-  override def phases: List[List[Phase]] = {
-    val backendPhases = super.phases.dropWhile {
-      case List(_: Pickler) => false
-      case _ => true
-    }.tail
-    List(new ReadTastyTreesFromClasses) :: backendPhases
-  }
+  override protected def frontendPhases: List[List[Phase]] =
+    List(new ReadTastyTreesFromClasses) :: Nil
+
+  override protected def picklerPhases: List[List[Phase]] =
+    super.picklerPhases.map(_.filterNot(_.isInstanceOf[Pickler])) // No need to repickle
 
   override def newRun(implicit ctx: Context): Run = {
     reset()

--- a/doc-tool/src/dotty/tools/dottydoc/DocCompiler.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/DocCompiler.scala
@@ -19,10 +19,16 @@ import dotc.Compiler
  *  3. Serialize to JS object
  */
 class DocCompiler extends Compiler {
-  override def phases: List[List[Phase]] = List(
-    List(new DocFrontEnd),
-    List(new DocImplicitsPhase),
-    List(new DocASTPhase),
+
+  override protected def frontendPhases: List[List[Phase]] =
+    List(new DocFrontEnd) :: Nil
+
+  override protected def picklerPhases: List[List[Phase]] =
+    Nil
+
+  override protected def transformPhases: List[List[Phase]] =
+    List(new DocImplicitsPhase) ::
+    List(new DocASTPhase) ::
     List(DocMiniTransformations(new UsecasePhase,
                                 new DocstringPhase,
                                 new PackageObjectsPhase,
@@ -32,8 +38,11 @@ class DocCompiler extends Compiler {
                                 new LinkSuperTypes,
                                 new LinkCompanions,
                                 new AlternateConstructors,
-                                new SortMembers)),
-    List(DocMiniTransformations(new RemoveEmptyPackages)),
-    List(new StatisticsPhase)
-  )
+                                new SortMembers)) ::
+    List(DocMiniTransformations(new RemoveEmptyPackages)) ::
+    Nil
+
+  override protected def backendPhases: List[List[Phase]] =
+    List(new StatisticsPhase) :: Nil
+
 }

--- a/doc-tool/test/DottyDocTest.scala
+++ b/doc-tool/test/DottyDocTest.scala
@@ -52,8 +52,8 @@ trait DottyDocTest extends MessageRendering {
           }
       }) :: Nil
 
-    override def phases =
-      super.phases ++ assertionPhase
+    override protected def backendPhases: List[List[Phase]] =
+      super.backendPhases ++ assertionPhase
   }
 
   private def callingMethod: String =


### PR DESCRIPTION
This change aims to simplify overriding of `phases` in classes that extend `Compiler`. It also splits the macro phases into groups that share a same logical purpose.