### PR TITLE
Fix #3669: Treat java repeated arguments like scalac's

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -549,10 +549,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       val args = typedArgBuf.takeRight(n).toList
       typedArgBuf.trimEnd(n)
       val elemtpt = TypeTree(elemFormal)
-      val seqLit =
-        if (methodType.isJavaMethod) JavaSeqLiteral(args, elemtpt)
-        else SeqLiteral(args, elemtpt)
-      typedArgBuf += seqToRepeated(seqLit)
+      typedArgBuf += seqToRepeated(SeqLiteral(args, elemtpt))
     }
 
     def harmonizeArgs(args: List[TypedArg]) = harmonize(args)

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -44,7 +44,8 @@ object TestConfiguration {
     } mkString(":")
   }
 
-  val yCheckOptions = Array("-Ycheck:tailrec,resolveSuper,erasure,mixin,getClass,elimStaticThis,labelDef")
+  // Ideally should be Ycheck:all
+  val yCheckOptions = Array("-Ycheck:elimJavaPackages,refchecks,splitter,arrayConstructors,erasure,capturedVars,getClass,elimStaticThis,labelDef")
 
   val basicDefaultOptions = checkOptions ++ noCheckOptions ++ yCheckOptions
   val defaultUnoptimised = TestFlags(classPath, runClassPath, basicDefaultOptions)

--- a/tests/pos/i3669.scala
+++ b/tests/pos/i3669.scala
@@ -1,0 +1,10 @@
+import java.nio.file._
+
+class Test {
+  def test(xs: Array[String]) = {
+    val p1 = Paths.get("Hello")
+    val p2 = Paths.get("Hello", "World")
+    val p3 = Paths.get("Hello", "World", "!")
+    val p4 = Paths.get("Hello", xs: _*)
+  }
+}


### PR DESCRIPTION
Java repeated arguments are now treated as scala repeated arguments. They
are now replaced by a java array during ElimRepeated instead of Typer.

This change let us Ycheck one more MegaPhase. Previously java repeated
arguments would be replaced by a java array during typechecking which
prevented us from retypechecking the tree: Array[T] found, expected T*