### PR TITLE
Allow completion from source

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -135,7 +135,7 @@ class Compiler {
 
   def reset()(implicit ctx: Context): Unit = {
     ctx.base.reset()
-    ctx.runInfo.clear()
+    if (ctx.run != null) ctx.run.reset()
   }
 
   def newRun(implicit ctx: Context): Run = {

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -68,12 +68,8 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   private[this] var myUnits: List[CompilationUnit] = _
   private[this] var myUnitsCached: List[CompilationUnit] = _
   private[this] var myFiles: Set[AbstractFile] = _
-
-  /** Units that are added because of source completers but that are not
-   *  compiled in current run.
-   */
-  val lateUnits = mutable.ListBuffer[CompilationUnit]()
-  var lateFiles = mutable.Set[AbstractFile]()
+  private[this] val myLateUnits = mutable.ListBuffer[CompilationUnit]()
+  private[this] var myLateFiles = mutable.Set[AbstractFile]()
 
   /** The compilation units currently being compiled, this may return different
     *  results over time.
@@ -94,6 +90,12 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
     }
     myFiles
   }
+
+  /** Units that are added from source completers but that are not compiled in current run. */
+  def lateUnits: List[CompilationUnit] = myLateUnits.toList
+
+  /** The source files of all late units, as a set */
+  def lateFiles: collection.Set[AbstractFile] = myLateFiles
 
   def getSource(fileName: String): SourceFile = {
     val f = new PlainFile(io.Path(fileName))
@@ -184,8 +186,8 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   def enterRoots(file: AbstractFile)(implicit ctx: Context): Unit =
     if (!files.contains(file) && !lateFiles.contains(file)) {
       val unit = new CompilationUnit(getSource(file.path))
-      lateUnits += unit
-      lateFiles += file
+      myLateUnits += unit
+      myLateFiles += file
       enterRoots(unit)(runContext.fresh.setCompilationUnit(unit))
     }
 

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -88,7 +88,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
     myFiles
   }
 
-  private def getSource(fileName: String): SourceFile = {
+  def getSource(fileName: String): SourceFile = {
     val f = new PlainFile(io.Path(fileName))
     if (f.isDirectory) {
       ctx.error(s"expected file, received directory '$fileName'")
@@ -170,7 +170,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
     runPhases(runCtx)
     if (!ctx.reporter.hasErrors) Rewrites.writeBack()
   }
-  
+
   /** Enter top-level definitions of classes and objects contain in Scala source file `file`.
    *  The newly added symbols replace any previously entered symbols.
    */

--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -262,7 +262,7 @@ class PathResolver(implicit ctx: Context) {
   lazy val result: ClassPath = {
     val cp = AggregateClassPath(containers.toIndexedSeq)
 
-    if (settings.Ylogcp.value) {
+    if (settings.YlogClasspath.value) {
       Console.println("Classpath built from " + settings.toConciseString(ctx.settingsState))
       Console.println("Defaults: " + PathResolver.Defaults)
       Console.println("Calculated: " + Calculated)

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -16,7 +16,9 @@ class ScalaSettings extends Settings.SettingGroup {
   val extdirs = PathSetting("-extdirs", "Override location of installed extensions.", Defaults.scalaExtDirs)
   val javabootclasspath = PathSetting("-javabootclasspath", "Override java boot classpath.", Defaults.javaBootClassPath)
   val javaextdirs = PathSetting("-javaextdirs", "Override java extdirs classpath.", Defaults.javaExtDirs)
-  val sourcepath = PathSetting("-sourcepath", "Specify location(s) of source files.", "") // Defaults.scalaSourcePath
+  val sourcepath = PathSetting("-sourcepath", "Specify location(s) of source files.", Defaults.scalaSourcePath)
+  val scansource = BooleanSetting("-scansource", "Scan source files to locate classes for which class-name != file-name")
+
   val classpath = PathSetting("-classpath", "Specify where to find user class files.", defaultClasspath) withAbbreviation "-cp"
   val outputDir = PathSetting("-d", "directory|jar", "destination for generated classfiles.", ".")
   val priorityclasspath = PathSetting("-priorityclasspath", "class path that takes precedence over all other paths (or testing only)", "")
@@ -130,6 +132,7 @@ class ScalaSettings extends Settings.SettingGroup {
     "A directory containing static files from which to generate documentation",
     sys.props("user.dir")
   )
+
 
   val projectName = StringSetting (
     "-project",

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -80,7 +80,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val YtermConflict = ChoiceSetting("-Yresolve-term-conflict", "strategy", "Resolve term conflicts", List("package", "object", "error"), "error")
   val Ylog = PhasesSetting("-Ylog", "Log operations during")
   val YemitTasty = BooleanSetting("-Yemit-tasty", "Generate tasty in separate *.tasty file.")
-  val Ylogcp = BooleanSetting("-Ylog-classpath", "Output information about what classpath is being applied.")
+  val YlogClasspath = BooleanSetting("-Ylog-classpath", "Output information about what classpath is being applied.")
   val YdisableFlatCpCaching  = BooleanSetting("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
 
   val YnoImports = BooleanSetting("-Yno-imports", "Compile without importing scala.*, java.lang.*, or Predef.")

--- a/compiler/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
@@ -2,10 +2,9 @@ package dotty.tools.dotc
 package core
 
 import Contexts._
-import Run.RunInfo
 import config.Printers.typr
 
-trait ConstraintRunInfo { self: RunInfo =>
+trait ConstraintRunInfo { self: Run =>
   private[this] var maxSize = 0
   private[this] var maxConstraint: Constraint = _
   def recordConstraintSize(c: Constraint, size: Int) =
@@ -15,4 +14,6 @@ trait ConstraintRunInfo { self: RunInfo =>
     }
   def printMaxConstraint()(implicit ctx: Context) =
     if (maxSize > 0) typr.println(s"max constraint = ${maxConstraint.show}")
+
+  protected def reset() = maxConstraint = null
 }

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -14,7 +14,6 @@ import NameOps._
 import Uniques._
 import SymDenotations._
 import Comments._
-import Run.RunInfo
 import util.Positions._
 import ast.Trees._
 import ast.untpd
@@ -43,7 +42,7 @@ object Contexts {
   private val (settingsStateLoc,    store4) = store3.newLocation[SettingsState]()
   private val (freshNamesLoc,       store5) = store4.newLocation[FreshNameCreator](new FreshNameCreator.Default)
   private val (compilationUnitLoc,  store6) = store5.newLocation[CompilationUnit]()
-  private val (runInfoLoc,          store7) = store6.newLocation[RunInfo]()
+  private val (runLoc,              store7) = store6.newLocation[Run]()
   private val initialStore = store7
 
   /** A context is passed basically everywhere in dotc.
@@ -194,8 +193,8 @@ object Contexts {
     /** The current compilation unit */
     def compilationUnit: CompilationUnit = store(compilationUnitLoc)
 
-    /** The current compiler-run specific Info */
-    def runInfo: RunInfo = store(runInfoLoc)
+    /** The current compiler-run */
+    def run: Run = store(runLoc)
 
     /** The new implicit references that are introduced by this scope */
     protected var implicitsCache: ContextualImplicits = null
@@ -460,7 +459,7 @@ object Contexts {
     def setPrinterFn(printer: Context => Printer): this.type = updateStore(printerFnLoc, printer)
     def setSettings(settingsState: SettingsState): this.type = updateStore(settingsStateLoc, settingsState)
     def setCompilationUnit(compilationUnit: CompilationUnit): this.type = updateStore(compilationUnitLoc, compilationUnit)
-    def setRunInfo(runInfo: RunInfo): this.type = updateStore(runInfoLoc, runInfo)
+    def setRun(run: Run): this.type = updateStore(runLoc, run)
     def setFreshNames(freshNames: FreshNameCreator): this.type = updateStore(freshNamesLoc, freshNames)
 
     def setProperty[T](key: Key[T], value: T): this.type =
@@ -520,9 +519,7 @@ object Contexts {
     tree = untpd.EmptyTree
     typeAssigner = TypeAssigner
     moreProperties = Map.empty
-    store = initialStore
-              .updated(settingsStateLoc, settings.defaultState)
-              .updated(runInfoLoc, new RunInfo(this))
+    store = initialStore.updated(settingsStateLoc, settings.defaultState)
     typeComparer = new TypeComparer(this)
     searchHistory = new SearchHistory(0, Map())
     gadt = EmptyGADTMap

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -929,7 +929,7 @@ object Denotations {
         // printPeriods(current)
         this.validFor = Period(ctx.runId, targetId, current.validFor.lastPhaseId)
         if (current.validFor.firstPhaseId >= targetId)
-          insertInsteadOf(current)
+          current.replaceWith(this)
         else {
           current.validFor = Period(ctx.runId, current.validFor.firstPhaseId, targetId - 1)
           insertAfter(current)
@@ -950,7 +950,7 @@ object Denotations {
         val current1: SingleDenotation = f(current.asSymDenotation)
         if (current1 ne current) {
           current1.validFor = current.validFor
-          current1.insertInsteadOf(current)
+          current.replaceWith(current1)
         }
         hasNext = current1.nextInRun.validFor.code > current1.validFor.code
         current = current1.nextInRun
@@ -972,14 +972,14 @@ object Denotations {
      *  The code to achieve this is subtle in that it works correctly
      *  whether the replaced denotation is the only one in its cycle or not.
      */
-    private def insertInsteadOf(old: SingleDenotation): Unit = {
-      var prev = old
-      while (prev.nextInRun ne old) prev = prev.nextInRun
+    private[dotc] def replaceWith(newd: SingleDenotation): Unit = {
+      var prev = this
+      while (prev.nextInRun ne this) prev = prev.nextInRun
       // order of next two assignments is important!
-      prev.nextInRun = this
-      this.nextInRun = old.nextInRun
-      old.validFor = Nowhere
-      old.nextInRun = this
+      prev.nextInRun = newd
+      newd.nextInRun = nextInRun
+      validFor = Nowhere
+      nextInRun = newd
     }
 
     def staleSymbolError(implicit ctx: Context) =

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -26,7 +26,7 @@ object OrderingConstraint {
   private def newConstraint(boundsMap: ParamBounds, lowerMap: ParamOrdering, upperMap: ParamOrdering)(implicit ctx: Context) : OrderingConstraint = {
     val result = new OrderingConstraint(boundsMap, lowerMap, upperMap)
     if (Config.checkConstraintsNonCyclic) result.checkNonCyclic()
-    ctx.runInfo.recordConstraintSize(result, result.boundsMap.size)
+    ctx.run.recordConstraintSize(result, result.boundsMap.size)
     result
   }
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -275,7 +275,7 @@ object SymDenotations {
     final def privateWithin(implicit ctx: Context): Symbol = { ensureCompleted(); myPrivateWithin }
 
     /** Set privateWithin. */
-    protected[core] final def privateWithin_=(sym: Symbol): Unit =
+    protected[dotc] final def privateWithin_=(sym: Symbol): Unit =
       myPrivateWithin = sym
 
     /** The annotations of this denotation */

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package core
 
-import java.io.IOException
+import java.io.{IOException, File}
 import scala.compat.Platform.currentTime
 import dotty.tools.io.{ ClassPath, ClassRepresentation, AbstractFile }
 import classpath._
@@ -11,8 +11,10 @@ import StdNames._, NameOps._
 import Decorators.{PreNamedString, StringInterpolators}
 import classfile.ClassfileParser
 import util.Stats
+import Decorators._
 import scala.util.control.NonFatal
 import ast.Trees._
+import parsing.Parsers.OutlineParser
 import reporting.trace
 
 object SymbolLoaders {
@@ -24,11 +26,15 @@ object SymbolLoaders {
 
 /** A base class for Symbol loaders with some overridable behavior  */
 class SymbolLoaders {
+  import ast.untpd._
 
   protected def enterNew(
       owner: Symbol, member: Symbol,
       completer: SymbolLoader, scope: Scope = EmptyScope)(implicit ctx: Context): Symbol = {
-    assert(scope.lookup(member.name) == NoSymbol, s"${owner.fullName}.${member.name} already has a symbol")
+    val comesFromScan =
+      completer.isInstanceOf[SourcefileLoader] && ctx.settings.scansource.value
+    assert(comesFromScan || scope.lookup(member.name) == NoSymbol,
+           s"${owner.fullName}.${member.name} already has a symbol")
     owner.asClass.enter(member, scope)
     member
   }
@@ -98,16 +104,65 @@ class SymbolLoaders {
       scope = scope)
   }
 
-  /** In batch mode: Enter class and module with given `name` into scope of `owner`
-   *  and give them a source completer for given `src` as type.
-   *  In IDE mode: Find all toplevel definitions in `src` and enter then into scope of `owner`
-   *  with source completer for given `src` as type.
-   *  (overridden in interactive.Global).
+  /** If setting -scansource is set:
+   *    Enter all toplevel classes and objects in file `src` into package `owner`, provided
+   *    they are in the right package. Issue a warning if a class or object is in the wrong
+   *    package, i.e. if the file path differs from the declared package clause.
+   *  If -scansource is not set:
+   *    Enter class and module with given `name` into scope of `owner`.
+   *
+   *  All entered symbols are given a source completer of `src` as info.
    */
   def enterToplevelsFromSource(
       owner: Symbol, name: PreName, src: AbstractFile,
       scope: Scope = EmptyScope)(implicit ctx: Context): Unit = {
-    enterClassAndModule(owner, name, new SourcefileLoader(src), scope = scope)
+
+    val completer = new SourcefileLoader(src)
+    if (ctx.settings.scansource.value) {
+      if (src.exists && !src.isDirectory) {
+        val filePath = owner.ownersIterator.takeWhile(!_.isRoot).map(_.name.toTermName).toList
+
+        def addPrefix(pid: RefTree, path: List[TermName]): List[TermName] = pid match {
+          case Ident(name: TermName) => name :: path
+          case Select(qual: RefTree, name: TermName) => name :: addPrefix(qual, path)
+          case _ => path
+        }
+
+        def enterScanned(unit: CompilationUnit)(implicit ctx: Context) = {
+
+          def checkPathMatches(path: List[TermName], what: String, tree: MemberDef): Boolean = {
+            val ok = filePath == path
+            if (!ok)
+              ctx.warning(i"""$what ${tree.name} is in wrong directory.
+                              |It was declared to be in package ${path.reverse.mkString(".")}
+                              |But it is found in directory     ${filePath.reverse.mkString(File.separator)}""",
+                          tree.pos)
+            ok
+          }
+
+          def traverse(tree: Tree, path: List[TermName]): Unit = tree match {
+            case PackageDef(pid, body) =>
+              val path1 = addPrefix(pid, path)
+              for (stat <- body) traverse(stat, path1)
+            case tree: TypeDef if tree.isClassDef =>
+              if (checkPathMatches(path, "class", tree))
+                enterClassAndModule(owner, tree.name, completer, scope = scope)
+                  // It might be a case class or implicit class,
+                  // so enter class and module to be on the safe side
+            case tree: ModuleDef =>
+              if (checkPathMatches(path, "object", tree))
+                enterModule(owner, tree.name, completer, scope = scope)
+            case _ =>
+          }
+
+          traverse(new OutlineParser(unit.source).parse(), Nil)
+        }
+
+        val unit = new CompilationUnit(ctx.run.getSource(src.path))
+        enterScanned(unit)(ctx.run.runContext.fresh.setCompilationUnit(unit))
+      }
+    }
+    else enterClassAndModule(owner, name, completer, scope = scope)
   }
 
   /** The package objects of scala and scala.reflect should always

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -1,8 +1,3 @@
-/* NSC -- new Scala compiler
- * Copyright 2005-2012 LAMP/EPFL
- * @author  Martin Odersky
- */
-
 package dotty.tools
 package dotc
 package core
@@ -199,7 +194,7 @@ class SymbolLoaders {
         !root.unforcedDecls.lookup(classRep.name.toTypeName).exists
 
       if (!root.isRoot) {
-        val classReps = classPath.classes(packageName)
+        val classReps = classPath.list(packageName).classesAndSources
 
         for (classRep <- classReps)
           if (!maybeModuleClass(classRep) && isFlatName(classRep) == flat &&
@@ -343,5 +338,6 @@ class ClassfileLoader(val classfile: AbstractFile) extends SymbolLoader {
 class SourcefileLoader(val srcfile: AbstractFile) extends SymbolLoader {
   def description(implicit ctx: Context) = "source file " + srcfile.toString
   override def sourceFileOrNull = srcfile
-  def doComplete(root: SymDenotation)(implicit ctx: Context): Unit = unsupported("doComplete")
+  def doComplete(root: SymDenotation)(implicit ctx: Context): Unit =
+    ctx.run.enterRoots(srcfile)
 }

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -133,7 +133,7 @@ class SymbolLoaders {
           def checkPathMatches(path: List[TermName], what: String, tree: MemberDef): Boolean = {
             val ok = filePath == path
             if (!ok)
-              ctx.warning(i"""$what ${tree.name} is in wrong directory.
+              ctx.warning(i"""$what ${tree.name} is in the wrong directory.
                               |It was declared to be in package ${path.reverse.mkString(".")}
                               |But it is found in directory     ${filePath.reverse.mkString(File.separator)}""",
                           tree.pos)

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -449,7 +449,7 @@ object Symbols {
     final def isDefinedInCurrentRun(implicit ctx: Context): Boolean =
       pos.exists && defRunId == ctx.runId && {
         val file = associatedFile
-        file != null && ctx.runInfo.files.contains(file)
+        file != null && ctx.run.files.contains(file)
       }
 
     /** Is symbol valid in current run? */

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -191,8 +191,8 @@ class InteractiveDriver(settings: List[String]) extends Driver {
           if (!t.symbol.isCompleted) t.symbol.info = UnspecifiedErrorType
           t.symbol.annotations.foreach { annot =>
             /* In some cases annotations are are used on themself (possibly larger cycles).
-            *  This is the case with the java.lang.annotation.Target annotation, would end 
-            *  in an infinite loop while cleaning. The `seen` is added to ensure that those 
+            *  This is the case with the java.lang.annotation.Target annotation, would end
+            *  in an infinite loop while cleaning. The `seen` is added to ensure that those
             *  trees are not cleand twice.
             *  TODO: Find a less expensive way to check for those cycles.
             */
@@ -226,7 +226,7 @@ class InteractiveDriver(settings: List[String]) extends Driver {
 
       run.compileSources(List(source))
       run.printSummary()
-      val t = ctx.runInfo.units.head.tpdTree
+      val t = ctx.run.units.head.tpdTree
       cleanup(t)
       myOpenedTrees(uri) = topLevelClassTrees(t, source)
 

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -9,7 +9,6 @@ import util.Stats.{track, record, monitored}
 import printing.{Showable, Printer}
 import printing.Texts._
 import Contexts._
-import Run.RunInfo
 import Types._
 import Flags._
 import TypeErasure.{erasure, hasStableErasure}
@@ -372,7 +371,7 @@ object Implicits {
 import Implicits._
 
 /** Info relating to implicits that is kept for one run */
-trait ImplicitRunInfo { self: RunInfo =>
+trait ImplicitRunInfo { self: Run =>
 
   private val implicitScopeCache = mutable.AnyRefMap[Type, OfTypeImplicits]()
 
@@ -502,7 +501,7 @@ trait ImplicitRunInfo { self: RunInfo =>
     iscope(rootTp)
   }
 
-  def clear() = {
+  protected def reset() = {
     implicitScopeCache.clear()
   }
 }
@@ -1059,7 +1058,7 @@ trait Implicits { self: Typer =>
       }
     }
 
-    def implicitScope(tp: Type): OfTypeImplicits = ctx.runInfo.implicitScope(tp, ctx)
+    def implicitScope(tp: Type): OfTypeImplicits = ctx.run.implicitScope(tp, ctx)
   }
 }
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -60,6 +60,7 @@ class CompilationTests extends ParallelTesting {
     compileFile("../tests/pos-special/i3589-b.scala", defaultOptions.and("-Xfatal-warnings")) +
     compileFile("../tests/pos-special/completeFromSource/Test.scala", defaultOptions.and("-sourcepath", "../tests/pos-special")) +
     compileFile("../tests/pos-special/completeFromSource/Test2.scala", defaultOptions.and("-sourcepath", "../tests/pos-special")) +
+    compileFile("../tests/pos-special/completeFromSource/Test3.scala", defaultOptions.and("-sourcepath", "../tests/pos-special", "-scansource")) +
     compileList(
       "compileMixed",
       List(

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -58,6 +58,8 @@ class CompilationTests extends ParallelTesting {
     compileFile("../tests/pos-special/i3323.scala", defaultOptions.and("-Xfatal-warnings")) +
     compileFile("../tests/pos-special/i3323b.scala", defaultOptions.and("-Xfatal-warnings")) +
     compileFile("../tests/pos-special/i3589-b.scala", defaultOptions.and("-Xfatal-warnings")) +
+    compileFile("../tests/pos-special/completeFromSource/Test.scala", defaultOptions.and("-sourcepath", "../tests/pos-special")) +
+    compileFile("../tests/pos-special/completeFromSource/Test2.scala", defaultOptions.and("-sourcepath", "../tests/pos-special")) +
     compileList(
       "compileMixed",
       List(

--- a/tests/pos-special/completeFromSource/Test.scala
+++ b/tests/pos-special/completeFromSource/Test.scala
@@ -1,0 +1,13 @@
+package completeFromSource
+
+class Test extends nested.A(22) {
+
+  val y: Int = this.x
+
+  val a = nested.A(33)
+
+  println(a.x)
+
+}
+
+

--- a/tests/pos-special/completeFromSource/Test2.scala
+++ b/tests/pos-special/completeFromSource/Test2.scala
@@ -1,0 +1,16 @@
+package completeFromSource
+import nested._
+
+class Test2 extends A(22) {
+
+  val y: Int = this.x
+
+  val a = A(33)
+
+  println(a.x)
+
+}
+
+
+
+

--- a/tests/pos-special/completeFromSource/Test3.scala
+++ b/tests/pos-special/completeFromSource/Test3.scala
@@ -1,0 +1,16 @@
+package completeFromSource
+import nested._
+
+class Test3 {
+
+  val x = if (true) new B(1) else new C("xx")
+
+  x match {
+    case B(n) => println(s"B($n)")
+    case C(s) => println(s"C($s)")
+  }
+}
+
+
+
+

--- a/tests/pos-special/completeFromSource/nested/A.scala
+++ b/tests/pos-special/completeFromSource/nested/A.scala
@@ -1,0 +1,13 @@
+package completeFromSource.nested
+
+class A(y: Int) {
+
+  val x: Int = y
+
+}
+
+object A {
+
+  def apply(x: Int) = new A(22)
+
+}

--- a/tests/pos-special/completeFromSource/nested/BC.scala
+++ b/tests/pos-special/completeFromSource/nested/BC.scala
@@ -1,0 +1,6 @@
+package completeFromSource.nested
+
+
+case class B(x: Int) extends A(x)
+
+case class C(s: String) extends A(s.length)


### PR DESCRIPTION
If -sourcepath is set, we now allow completion from sources that are in the canonical place (i.e. fully qualified source name ~ path name of source file relative to source path). If both class and source file exist, the newer one is chosen.

To do: it would be nice to optionally scan all sources so that classes can be found even if their
fully qualified name does not correspond to the file name. Logically, this should be done in `ClassPath.scala`.
