### PR TITLE
Remove compilation units for classes that have already been loaded

### DIFF
--- a/compiler/src/dotty/tools/dotc/fromtasty/ReadTastyTreesFromClasses.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/ReadTastyTreesFromClasses.scala
@@ -28,9 +28,12 @@ class ReadTastyTreesFromClasses extends FrontEnd {
             else {
               val unit = CompilationUnit.mkCompilationUnit(clsd, unpickled, forceTrees = true)
               val cls = clsd.symbol.asClass
-              unit.pickled += (cls -> cls.unpickler.unpickler.bytes)
-              cls.unpickler = null
-              Some(unit)
+              if (cls.unpickler == null) None // Has already been loaded by some other compilation unit
+              else {
+                unit.pickled += (cls -> cls.unpickler.unpickler.bytes)
+                cls.unpickler = null
+                Some(unit)
+              }
             }
         }
       }

--- a/compiler/src/dotty/tools/dotc/fromtasty/ReadTastyTreesFromClasses.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/ReadTastyTreesFromClasses.scala
@@ -28,7 +28,10 @@ class ReadTastyTreesFromClasses extends FrontEnd {
             else {
               val unit = CompilationUnit.mkCompilationUnit(clsd, unpickled, forceTrees = true)
               val cls = clsd.symbol.asClass
-              if (cls.unpickler == null) None // Has already been loaded by some other compilation unit
+              if (cls.unpickler == null) {
+                ctx.error(s"Error: Already loaded ${cls.showFullName}")
+                None
+              }
               else {
                 unit.pickled += (cls -> cls.unpickler.unpickler.bytes)
                 cls.unpickler = null


### PR DESCRIPTION
If not, we would create two compilation units that try to load the same class.