### PR TITLE
Fix #1905: Detect case where bridge would clash with the member

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -170,6 +170,12 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case tp: TypeRef =>
         if (tp.symbol.isAnonymousClass && !ctx.settings.uniqid.value)
           return toText(tp.info)
+        if (tp.symbol.is(Param))
+          tp.prefix match {
+            case pre: ThisType if pre.cls == tp.symbol.owner =>
+              return nameString(tp.symbol)
+            case _ =>
+          }
       case ExprType(result) =>
         return "=> " ~ toText(result)
       case ErasedValueType(tycon, underlying) =>
@@ -501,7 +507,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
             typeDefText(tparamsTxt, toText(rhs))
           case LambdaTypeTree(tparams, body) =>
             recur(body, tparamsText(tparams))
-          case rhs: TypeTree if rhs.tpe.isInstanceOf[TypeBounds] =>
+          case rhs: TypeTree if rhs.typeOpt.isInstanceOf[TypeBounds] =>
             typeDefText(tparamsTxt, toText(rhs))
           case rhs =>
             typeDefText(tparamsTxt, optText(rhs)(" = " ~ _))

--- a/tests/neg/i1905.scala
+++ b/tests/neg/i1905.scala
@@ -1,0 +1,17 @@
+class Arr[T](private val underlying: scala.Array[T]) extends AnyVal
+
+abstract class SeqMonoTransforms[+A, +Repr] {
+  protected[this] def fromIterableWithSameElemType(): Repr
+  def getFIWSET: Repr = fromIterableWithSameElemType()
+}
+
+class ArrOps[A](val xs: Arr[A]) extends SeqMonoTransforms[A, Arr[A]] {
+  def fromIterableWithSameElemType(): Arr[A] = xs // error: bridge clashes with member
+}
+
+object Test {
+  def main(args: Array[String]) = {
+    val t = new ArrOps(new Arr(Array(1, 2, 3)))
+    val t2 = t.getFIWSET
+  }
+}


### PR DESCRIPTION
With value classes it is possible that a bridge is needed because the semi erased
types of a member and its overridden method differ, yet the fully erased types
of the member and the bridge are the same. With this commit we flag this situation
as an error. Before it generated a ClassCastException at runtime instead.