### PR TITLE
Fix #2081: Don't issue an $init$ method for NoInits traits

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -1171,7 +1171,9 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   object Template extends TemplateDeconstructor {
     def _1: List[Tree] = field.parents
     def _2: ValDef = field.self
-    def _3: List[Tree] = field.constr :: field.body
+    def _3: List[Tree] =
+      if (field.constr.rhs.isEmpty) field.body
+      else field.constr :: field.body
   }
 
   object Bind extends BindDeconstructor {

--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -179,7 +179,8 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
 
     def superCallOpt(baseCls: Symbol): List[Tree] = superCalls.get(baseCls) match {
       case Some(call) =>
-        if (defn.NotRuntimeClasses.contains(baseCls)) Nil else call :: Nil
+        if (defn.NotRuntimeClasses.contains(baseCls) || baseCls.is(NoInitsTrait)) Nil
+        else call :: Nil
       case None =>
         if (baseCls.is(NoInitsTrait) || defn.NoInitClasses.contains(baseCls)) Nil
         else {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1469,7 +1469,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
     } else {
       val dummy = localDummy(cls, impl)
       val body1 = typedStats(impl.body, dummy)(inClassContext(self1.symbol))
-      cls.setNoInitsFlags((NoInitsInterface /: body1) ((fs, stat) => fs & defKind(stat)))
+      if (!ctx.isAfterTyper)
+        cls.setNoInitsFlags((NoInitsInterface /: body1) ((fs, stat) => fs & defKind(stat)))
 
       // Expand comments and type usecases
       cookComments(body1.map(_.symbol), self1.symbol)(localContext(cdef, cls).setNewScope)

--- a/tests/run/junitForwarders/C_1.scala
+++ b/tests/run/junitForwarders/C_1.scala
@@ -1,6 +1,13 @@
 trait T {
   @org.junit.Test def foo = 0
+  println("hi")  // to force an $init method
 }
+
+trait U {
+  @org.junit.Test def bar = 0
+    // don't issue a $init method
+}
+
 
 class C extends T
 
@@ -12,4 +19,5 @@ object Test extends App {
   check(classOf[C], "foo - @org.junit.Test()")
   // TODO scala-dev#213: should `foo$` really carry the @Test annotation?
   check(classOf[T], "$init$ - ;foo - @org.junit.Test()")
+  check(classOf[U], "bar - @org.junit.Test()")
 }

--- a/tests/run/traitNoInit.scala
+++ b/tests/run/traitNoInit.scala
@@ -1,12 +1,29 @@
-trait Foo {
-  //println("hello")
+trait NoInit {
+  def meth(x: Int): Int
+}
+
+trait WithInit {
+  val i = 1
   def meth(x: Int): Int
 }
 
 trait Bar(x: Int)
 
-class C extends Foo() with Bar(1) {
+class NoInitClass extends NoInit() with Bar(1) {
   def meth(x: Int) = x
 }
 
-object Test extends C with App
+class WithInitClass extends WithInit() with Bar(1) {
+  def meth(x: Int) = x
+}
+
+object Test {
+  def hasInit(cls: Class[_]) = cls.getMethods.map(_.toString).exists(_.contains("$init$"))
+  def main(args: Array[String]): Unit = {
+    val noInit = new NoInitClass {}
+    val withInit = new WithInitClass {}
+
+    assert(!hasInit(noInit.getClass))
+    assert(hasInit(withInit.getClass))
+  }
+}

--- a/tests/run/traitNoInit.scala
+++ b/tests/run/traitNoInit.scala
@@ -1,0 +1,12 @@
+trait Foo {
+  //println("hello")
+  def meth(x: Int): Int
+}
+
+trait Bar(x: Int)
+
+class C extends Foo() with Bar(1) {
+  def meth(x: Int) = x
+}
+
+object Test extends C with App


### PR DESCRIPTION
 - Don't issue an initializer is a trait does not need initialization,
   as signalled by NoInits
 - Don't overwrite NoInits in erasure since that gives the wrong information
 - Don't issue supercalls in Mixin to NoInits traits