### PR TITLE
Add missing case to TypeComparer

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1065,7 +1065,7 @@ object desugar {
             AppliedTypeTree(ref(seqType), t),
             New(ref(defn.RepeatedAnnotType), Nil :: Nil))
         } else {
-          assert(ctx.mode.isExpr || ctx.reporter.hasErrors, ctx.mode)
+          assert(ctx.mode.isExpr || ctx.reporter.hasErrors || ctx.mode.is(Mode.Interactive), ctx.mode)
           Select(t, op.name)
         }
       case PrefixOp(op, t) =>

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -475,12 +475,17 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
             isSubType(tp1.resType, tp2.resType.subst(tp2, tp1))
           finally comparedTypeLambdas = saved
         case _ =>
-          if (!tp1.isHK) {
-            tp2 match {
-              case EtaExpansion(tycon2) if tycon2.symbol.isClass =>
-                return isSubType(tp1, tycon2)
-              case _ =>
-            }
+          if (tp1.isHK) {
+            val tparams1 = tp1.typeParams
+            return isSubType(
+              HKTypeLambda.fromParams(tparams1, tp1.appliedTo(tparams1.map(_.paramRef))),
+              tp2
+            )
+          }
+          else tp2 match {
+            case EtaExpansion(tycon2) if tycon2.symbol.isClass =>
+              return isSubType(tp1, tycon2)
+            case _ =>
           }
           fourthTry(tp1, tp2)
       }

--- a/tests/pos/i2989.scala
+++ b/tests/pos/i2989.scala
@@ -1,0 +1,12 @@
+class Foo[+X[_]] {
+  // OK
+  def foo1[Y[_]](right: Foo[Y]): Foo[Y] = right
+  // OK
+  def foo2[Y[_]](right: Foo[[T] => Y[T]]): Foo[Y] = right
+  // OK
+  def foo3[Y[_]](right: Foo[[T] => Y[T]]): Foo[[T] => Y[T]] = right
+  // Error:
+  //   found:    Foo[Y](right)
+  //   required: Foo[Y]
+  def foo4[Y[_]](right: Foo[Y]): Foo[[T] => Y[T]] = right
+}

--- a/tests/pos/i3658.scala
+++ b/tests/pos/i3658.scala
@@ -1,0 +1,15 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    trait ModuleSig {
+      type F[_]
+      type Type = F
+
+      def subst[F[_[_]]](fa: F[List]): F[Type]
+    }
+    val Module: ModuleSig = new ModuleSig {
+      type F[+A] = List[A]
+
+      def subst[FF[_[_]]](fa: FF[List]): FF[Type] = fa
+    }
+  }
+}


### PR DESCRIPTION
The missing case was for

    hk-type ref <:< hk type lambda

E.g.

    type Y[X]
    Foo[Y] <:< Foo[[T] => Y[T]]