### PR TITLE
Fix #3624: Lazily evaluate static module accessors

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -62,8 +62,8 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
   def transformLazyVal(tree: ValOrDefDef)(implicit ctx: Context): Tree = {
     val sym = tree.symbol
     if (!(sym is Flags.Lazy) ||
-        sym.owner.is(Flags.Trait) ||
-        (sym.isStatic && sym.is(Flags.Module, butNot = Flags.Method)))
+        sym.owner.is(Flags.Trait) || // val is accessor, lazy field will be implemented in subclass
+        (sym.isStatic && sym.is(Flags.Module, butNot = Flags.Method))) // static module vals are implemented in the JVM by lazy loading
       tree
     else {
       val isField = sym.owner.isClass

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -36,7 +36,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
   class OffsetInfo(var defs: List[Tree], var ord:Int)
   val appendOffsetDefs = mutable.Map.empty[Symbol, OffsetInfo]
 
-  override def phaseName: String = "LazyVals"
+  override def phaseName: String = "lazyVals"
 
   /** List of names of phases that should have finished processing of tree
     * before this phase starts processing same tree */
@@ -61,7 +61,10 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
 
   def transformLazyVal(tree: ValOrDefDef)(implicit ctx: Context): Tree = {
     val sym = tree.symbol
-    if (!(sym is Flags.Lazy) || sym.owner.is(Flags.Trait) || (sym.isStatic && sym.is(Flags.Module))) tree
+    if (!(sym is Flags.Lazy) ||
+        sym.owner.is(Flags.Trait) ||
+        (sym.isStatic && sym.is(Flags.Module, butNot = Flags.Method)))
+      tree
     else {
       val isField = sym.owner.isClass
       if (isField) {

--- a/tests/pending/run/implicits-numeric.scala
+++ b/tests/pending/run/implicits-numeric.scala
@@ -1,0 +1,7 @@
+object Test extends App {
+
+  implicit def _1: Long = 1L
+  implicit def _2: Int = 0
+
+  println(implicitly[AnyVal])
+}

--- a/tests/run/i3624.scala
+++ b/tests/run/i3624.scala
@@ -3,9 +3,11 @@ trait T {
 }
 
 object Bar extends T
+object Baz extends T
 
 object Test {
   def main(args: Array[String]): Unit = {
-    assert(Bar.Foo == Bar.Foo) // false
+    assert(Bar.Foo eq Bar.Foo)
+    assert(Bar.Foo ne Baz.Foo)
   }
 }

--- a/tests/run/i3634.scala
+++ b/tests/run/i3634.scala
@@ -1,0 +1,11 @@
+trait T {
+  case object Foo
+}
+
+object Bar extends T
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    assert(Bar.Foo == Bar.Foo) // false
+  }
+}


### PR DESCRIPTION
We did not use lazy evaluation for static objects, because these are usually evauated
lazily by the backend. But that does not hold if the static module is an (accessor) def
instead of a val.