### PR TITLE
Fix #3544: Better cache invalidation of uninstVars

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -548,7 +548,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
 
   /** The uninstantiated typevars of this constraint */
   def uninstVars: collection.Seq[TypeVar] = {
-    if (myUninstVars == null) {
+    if (myUninstVars == null || myUninstVars.exists(_.inst.exists)) {
       myUninstVars = new mutable.ArrayBuffer[TypeVar]
       boundsMap.foreachBinding { (poly, entries) =>
         for (i <- 0 until paramCount(entries)) {

--- a/tests/neg/i3470.scala
+++ b/tests/neg/i3470.scala
@@ -1,0 +1,6 @@
+object Main {
+    abstract class Factory[T <: Int] {
+      def size: T
+      def create: Array[T] = Array.ofDim(size) // error: No ClassTag available
+    }
+}

--- a/tests/pos/i3544.scala
+++ b/tests/pos/i3544.scala
@@ -1,0 +1,6 @@
+object Test {
+  case class Tuple2K[F[_], G[_], A](f: F[A], g: G[A])
+
+  val p0: Tuple2K[[X] => Int, [X] => String, Any] = Tuple2K(1, "s")
+  p0 == Tuple2K(List(1), Option("s"))
+}


### PR DESCRIPTION
Type variables can be instantiated without changing the underlying constraint.
We need to check that this has not happened before returning a previously
cached uninstVars.

Also fixes #3470.