### PR TITLE
Fix #3537: Don't add an implicit to qualifier of constructor

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1912,7 +1912,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
    */
   def tryInsertImplicitOnQualifier(tree: Tree, pt: Type)(implicit ctx: Context): Option[Tree] = trace(i"try insert impl on qualifier $tree $pt") {
     tree match {
-      case Select(qual, name) =>
+      case Select(qual, name) if name != nme.CONSTRUCTOR =>
         val qualProto = SelectionProto(name, pt, NoViewsAllowed, privateOK = false)
         tryEither { implicit ctx =>
           val qual1 = adaptInterpolated(qual, qualProto)

--- a/tests/neg/i3537.scala
+++ b/tests/neg/i3537.scala
@@ -1,0 +1,7 @@
+import dotty.Show._
+
+class Foo(x: Int)
+
+object Test {
+  val res0 = new Foo("Hello") // error
+}


### PR DESCRIPTION
When trying to insert an implicit on the qualifier of a method call,
make sure the call is not to a constructor, as this would lead to
illegal bytecode.