### PR TITLE
Fix #3460: Fix semicolon insertion confusion after enum case

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2055,6 +2055,7 @@ object Parsers {
         typeDefOrDcl(start, posMods(start, mods))
       case CASE =>
         enumCase(start, mods)
+          .reporting(t => i"case $t, current = ${in.show} / ${in.sepRegions}%, %")
       case _ =>
         tmplDef(start, mods)
     }
@@ -2313,6 +2314,11 @@ object Parsers {
     def enumCase(start: Offset, mods: Modifiers): DefTree = {
       val mods1 = mods.withAddedMod(atPos(in.offset)(Mod.EnumCase())) | Case
       accept(CASE)
+
+      in.adjustSepRegions(ARROW)
+        // Scanner thinks it is in a pattern match after seeing the `case`.
+        // We need to get it out of that mode by telling it we are past the `=>`
+
       atPos(start, nameStart) {
         val id = termIdent()
         if (in.token == LBRACKET || in.token == LPAREN)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2055,7 +2055,6 @@ object Parsers {
         typeDefOrDcl(start, posMods(start, mods))
       case CASE =>
         enumCase(start, mods)
-          .reporting(t => i"case $t, current = ${in.show} / ${in.sepRegions}%, %")
       case _ =>
         tmplDef(start, mods)
     }

--- a/tests/pos/i2906.scala
+++ b/tests/pos/i2906.scala
@@ -1,0 +1,6 @@
+enum Foo {
+  case A
+  private case B
+  @deprecated("Will be removed") case C
+  @deprecated("Will be removed") private case D
+}

--- a/tests/pos/i3460.scala
+++ b/tests/pos/i3460.scala
@@ -1,0 +1,7 @@
+enum class Ducks
+
+object Ducks {
+  case Dewey
+
+  def wooohoo: Int = 1
+}


### PR DESCRIPTION
After seeing an enum case, the Scanner thought it is in a pattern, and
therefore does not do semicolon insertion on newlines. We now get it
out of that mode by pretending to be passed the `=>`.