### PR TITLE
Fix #3383: Don't fail on unreported errors

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -112,9 +112,9 @@ object Trees {
      *  type. (Overridden by empty trees)
      */
     def withType(tpe: Type)(implicit ctx: Context): ThisTree[Type] = {
-      if (Config.checkUnreportedErrors)
-        if (tpe.isInstanceOf[ErrorType]) assert(ctx.reporter.errorsReported)
-      if (Config.checkTreesConsistent)
+      if (tpe.isInstanceOf[ErrorType])
+        assert(!Config.checkUnreportedErrors || ctx.reporter.errorsReported)
+      else if (Config.checkTreesConsistent)
         checkChildrenTyped(productIterator)
       withTypeUnchecked(tpe)
     }

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -112,9 +112,9 @@ object Trees {
      *  type. (Overridden by empty trees)
      */
     def withType(tpe: Type)(implicit ctx: Context): ThisTree[Type] = {
-      if (tpe.isInstanceOf[ErrorType])
-        assert(ctx.mode.is(Mode.Interactive) || ctx.reporter.errorsReported)
-      else if (Config.checkTreesConsistent)
+      if (Config.checkUnreportedErrors)
+        if (tpe.isInstanceOf[ErrorType]) assert(ctx.reporter.errorsReported)
+      if (Config.checkTreesConsistent)
         checkChildrenTyped(productIterator)
       withTypeUnchecked(tpe)
     }

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -106,6 +106,18 @@ object Config {
    */
   final val checkTypeRefCycles = false
 
+  /** If this flag is set, we check that types assigned to trees are error types only
+   *  if some error was already reported. There are complicicated scenarios where this
+   *  is not true. An example is TestNonCyclic in posTwice. If we remove the
+   *  first (unused) import `import dotty.tools.dotc.core.Types.Type` in `CompilationUnit`,
+   *  we end up assigning a CyclicReference error type to an import expression `annotation`
+   *  before the cyclic reference is reported. What happens is that the error was reported
+   *  as a result of a completion in a not-yet committed typerstate. So we cannot enforce
+   *  this in all circumstances. But since it is almost always true it is useful to
+   *  keep the Config option for debugging.
+   */
+  final val checkUnreportedErrors = false
+
   /** If this flag is set, it is checked that class type parameters are
    *  only references with NoPrefix or ThisTypes as prefixes. This option
    *  is usally disabled, because there are still some legitimate cases where


### PR DESCRIPTION
#3383 shows that there are valid cases where an error type is assigned to a tree
before the error is reported. The error will then be reported later in `adapt`.