### PR TITLE
Fix #3339: Disallow accesses to private package members from nested pkgs

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -674,10 +674,7 @@ object SymDenotations {
     final def isAccessibleFrom(pre: Type, superAccess: Boolean = false, whyNot: StringBuffer = null)(implicit ctx: Context): Boolean = {
 
       /** Are we inside definition of `boundary`? */
-      def accessWithin(boundary: Symbol) =
-        ctx.owner.isContainedIn(boundary) &&
-          (!(this is JavaDefined) || // disregard package nesting for Java
-             ctx.owner.enclosingPackageClass == boundary.enclosingPackageClass)
+      def accessWithin(boundary: Symbol) = ctx.owner.isContainedIn(boundary)
 
       /** Are we within definition of linked class of `boundary`? */
       def accessWithinLinked(boundary: Symbol) = {
@@ -733,7 +730,9 @@ object SymDenotations {
              (  !(this is Local)
              || (owner is ImplClass) // allow private local accesses to impl class members
              || isCorrectThisType(pre)
-             )
+             ) &&
+             (!(this.is(Private) && owner.is(Package)) ||
+              owner == ctx.owner.enclosingPackageClass)
         || (this is Protected) &&
              (  superAccess
              || pre.isInstanceOf[ThisType]

--- a/tests/neg/i3339.scala
+++ b/tests/neg/i3339.scala
@@ -1,0 +1,11 @@
+package outer {
+  private class A
+
+  package inner {
+    object Test {
+      def main(args: Array[String]): Unit = {
+        println(new A)  // error: cannot access
+      }
+    }
+  }
+}


### PR DESCRIPTION
Change of the accessibility rules: Disallow accesses to private package members from nested packages.

Such accesses were causing an access error at runtime before.