### PR TITLE
Add error message for polymorphic methods in structured refinements

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -124,6 +124,7 @@ public enum ErrorMessageID {
     SymbolChangedSemanticsInVersionID,
     UnableToEmitSwitchID,
     MissingCompanionForStaticID,
+    PolymorphicMethodMissingTypeInParentID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2064,4 +2064,14 @@ object messages {
     val explanation =
       hl"An object that contains ${"@static"} members must have a companion class."
   }
+
+  case class PolymorphicMethodMissingTypeInParent(rsym: Symbol, parentTpt: tpd.Tree)(implicit ctx: Context)
+  extends Message(PolymorphicMethodMissingTypeInParentID) {
+    val kind = "Syntax"
+    val msg = hl"polymorphic refinement $rsym without matching type in parent $parentTpt is no longer allowed"
+    val explanation =
+      hl"""Polymorphic $rsym is not allowed in the structural refinement of $parentTpt because
+          |$rsym does not override any symbol in $parentTpt. Structural refinement does not allow for
+          |polymorphic methods."""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2065,13 +2065,13 @@ object messages {
       hl"An object that contains ${"@static"} members must have a companion class."
   }
 
-  case class PolymorphicMethodMissingTypeInParent(rsym: Symbol, parentTpt: tpd.Tree)(implicit ctx: Context)
+  case class PolymorphicMethodMissingTypeInParent(rsym: Symbol, parentSym: Symbol)(implicit ctx: Context)
   extends Message(PolymorphicMethodMissingTypeInParentID) {
     val kind = "Syntax"
-    val msg = hl"polymorphic refinement $rsym without matching type in parent $parentTpt is no longer allowed"
+    val msg = hl"polymorphic refinement $rsym without matching type in parent $parentSym is no longer allowed"
     val explanation =
-      hl"""Polymorphic $rsym is not allowed in the structural refinement of $parentTpt because
-          |$rsym does not override any symbol in $parentTpt. Structural refinement does not allow for
+      hl"""Polymorphic $rsym is not allowed in the structural refinement of $parentSym because
+          |$rsym does not override any method in $parentSym. Structural refinement does not allow for
           |polymorphic methods."""
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1169,7 +1169,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       checkRefinementNonCyclic(refinement, refineCls, seen)
       val rsym = refinement.symbol
       if (rsym.info.isInstanceOf[PolyType] && rsym.allOverriddenSymbols.isEmpty)
-        ctx.error(i"polymorphic refinement $rsym without matching type in parent $tpt1 is no longer allowed", refinement.pos)    }
+        ctx.error(PolymorphicMethodMissingTypeInParent(rsym, tpt1), refinement.pos)    }
     assignType(cpy.RefinedTypeTree(tree)(tpt1, refinements1), tpt1, refinements1, refineCls)
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1169,7 +1169,8 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       checkRefinementNonCyclic(refinement, refineCls, seen)
       val rsym = refinement.symbol
       if (rsym.info.isInstanceOf[PolyType] && rsym.allOverriddenSymbols.isEmpty)
-        ctx.error(PolymorphicMethodMissingTypeInParent(rsym, tpt1), refinement.pos)    }
+        ctx.error(PolymorphicMethodMissingTypeInParent(rsym, tpt1.symbol), refinement.pos)
+    }
     assignType(cpy.RefinedTypeTree(tree)(tpt1, refinements1), tpt1, refinements1, refineCls)
   }
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1277,4 +1277,21 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val MissingCompanionForStatic(member) = messages.head
       assertEquals(member.show, "method bar")
     }
+
+  @Test def polymorphicMethodMissingTypeInParent =
+    checkMessagesAfter("frontend") {
+      """
+        |object Test {
+        |  import scala.reflect.Selectable.reflectiveSelectable
+        |  def foo(x: { def get[T](a: T): Int }) = 5
+        |}
+      """.stripMargin
+    }.expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      assertMessageCount(1, messages)
+      val PolymorphicMethodMissingTypeInParent(rsym, parentTpt) = messages.head
+      assertEquals("method get", rsym.show)
+      assertEquals("Object", parentTpt.show)
+    }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1290,8 +1290,8 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
 
       assertMessageCount(1, messages)
-      val PolymorphicMethodMissingTypeInParent(rsym, parentTpt) = messages.head
+      val PolymorphicMethodMissingTypeInParent(rsym, parentSym) = messages.head
       assertEquals("method get", rsym.show)
-      assertEquals("Object", parentTpt.show)
+      assertEquals("class Object", parentSym.show)
     }
 }


### PR DESCRIPTION
Addresses `Typer.scala:1109` in https://github.com/lampepfl/dotty/issues/1589. Polymorphic methods are not allowed in structural refinements as explained here: https://github.com/lampepfl/dotty/blob/88d016c6f0d991698a42bfca2d593f8ec1ae608d/docs/docs/reference/changed/structural-types.md#notes