### PR TITLE
Added error message for Symbol is not a value #1589

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -124,7 +124,7 @@ public enum ErrorMessageID {
     SymbolChangedSemanticsInVersionID,
     UnableToEmitSwitchID,
     MissingCompanionForStaticID,
-    SymbolIsNotAValueID,
+    JavaSymbolIsNotAValueID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -124,6 +124,7 @@ public enum ErrorMessageID {
     SymbolChangedSemanticsInVersionID,
     UnableToEmitSwitchID,
     MissingCompanionForStaticID,
+    SymbolIsNotAValueID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2068,6 +2068,21 @@ object messages {
   case class JavaSymbolIsNotAValue(symbol: Symbol)(implicit ctx: Context) extends Message(JavaSymbolIsNotAValueID) {
     val msg = hl"$symbol is not a value"
     val kind = "Type Mismatch"
-    val explanation = hl"Java packages cannot be used as a value"
+    val explanation = {
+      val javaCodeExample = """class A {public static int a() {return 1;}}"""
+
+      val scalaCodeExample =
+        """val objectA = A     // This does not compile
+          |val aResult = A.a() // This does compile""".stripMargin
+
+      hl"""Java statics and packages cannot be used as a value.
+          |For Java statics consider the following Java example:
+          |
+          |$javaCodeExample
+          |
+          |When used from Scala:
+          |
+          |$scalaCodeExample"""
+    }
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -208,7 +208,7 @@ object messages {
 
   case class WildcardOnTypeArgumentNotAllowedOnNew()(implicit ctx: Context)
   extends Message(WildcardOnTypeArgumentNotAllowedOnNewID) {
-    val kind = "syntax"
+    val kind = "Syntax"
     val msg = "type argument must be fully defined"
 
     val code1 =
@@ -2063,5 +2063,12 @@ object messages {
     val kind = "Syntax"
     val explanation =
       hl"An object that contains ${"@static"} members must have a companion class."
+  }
+
+  case class SymbolIsNotAValue(symbol: Symbol)(implicit ctx: Context) extends Message(SymbolIsNotAValueID) {
+    val msg = hl"${symbol.show} is not a value"
+    val kind = "Type Mismatch"
+    val explanation =
+      hl"Scala or Java packages cannot be assigned to a value"
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2065,10 +2065,9 @@ object messages {
       hl"An object that contains ${"@static"} members must have a companion class."
   }
 
-  case class SymbolIsNotAValue(symbol: Symbol)(implicit ctx: Context) extends Message(SymbolIsNotAValueID) {
-    val msg = hl"${symbol.show} is not a value"
+  case class JavaSymbolIsNotAValue(symbol: Symbol)(implicit ctx: Context) extends Message(JavaSymbolIsNotAValueID) {
+    val msg = hl"$symbol is not a value"
     val kind = "Type Mismatch"
-    val explanation =
-      hl"Scala or Java packages cannot be assigned to a value"
+    val explanation = hl"Java packages cannot be used as a value"
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -523,7 +523,7 @@ trait Checking {
       val sym = tree.tpe.termSymbol
       // The check is avoided inside Java compilation units because it always fails
       // on the singleton type Module.type.
-      if ((sym is Package) || ((sym is JavaModule) && !ctx.compilationUnit.isJava)) ctx.error(em"$sym is not a value", tree.pos)
+      if ((sym is Package) || ((sym is JavaModule) && !ctx.compilationUnit.isJava)) ctx.error(SymbolIsNotAValue(sym), tree.pos)
     }
     tree
   }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -523,7 +523,7 @@ trait Checking {
       val sym = tree.tpe.termSymbol
       // The check is avoided inside Java compilation units because it always fails
       // on the singleton type Module.type.
-      if ((sym is Package) || ((sym is JavaModule) && !ctx.compilationUnit.isJava)) ctx.error(SymbolIsNotAValue(sym), tree.pos)
+      if ((sym is Package) || ((sym is JavaModule) && !ctx.compilationUnit.isJava)) ctx.error(JavaSymbolIsNotAValue(sym), tree.pos)
     }
     tree
   }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1277,4 +1277,18 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val MissingCompanionForStatic(member) = messages.head
       assertEquals(member.show, "method bar")
     }
+
+  @Test def symbolIsNotAValue =
+    checkMessagesAfter("checkStatic") {
+      """
+        |package p
+        |object O {
+        |  val v = p
+        |}
+      """.stripMargin
+    }.expect { (itcx, messages) =>
+      implicit val ctx: Context = itcx
+      val SymbolIsNotAValue(symbol) = messages.head
+      assertEquals(symbol.show, "package p")
+    }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1278,7 +1278,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals(member.show, "method bar")
     }
 
-  @Test def symbolIsNotAValue =
+  @Test def javaSymbolIsNotAValue =
     checkMessagesAfter("checkStatic") {
       """
         |package p
@@ -1288,7 +1288,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       """.stripMargin
     }.expect { (itcx, messages) =>
       implicit val ctx: Context = itcx
-      val SymbolIsNotAValue(symbol) = messages.head
+      val JavaSymbolIsNotAValue(symbol) = messages.head
       assertEquals(symbol.show, "package p")
     }
 }


### PR DESCRIPTION
1. Added SymbolIsNotAValue error Message class 
2. Substituted the original error message at Checking.scala:526 with the new class and added a test
3. Typo fix at Checking.scala:211
  