### PR TITLE
Fix #3248: Handle repeated arguments in results of unapply selectors

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -77,7 +77,10 @@ class Definitions {
         val cls = denot.asClass.classSymbol
         val paramDecls = newScope
         val typeParam = enterSyntheticTypeParam(cls, paramFlags, paramDecls)
-        val parents = parentConstrs.toList
+        def instantiate(tpe: Type) =
+          if (tpe.typeParams.nonEmpty) tpe.appliedTo(typeParam.typeRef)
+          else tpe
+        val parents = parentConstrs.toList map instantiate
         denot.info = ClassInfo(ScalaPackageClass.thisType, cls, parents, paramDecls)
       }
     }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1363,6 +1363,15 @@ object Types {
      */
     def signature(implicit ctx: Context): Signature = Signature.NotAMethod
 
+    def annotatedToRepeated(implicit ctx: Context): Type = this match {
+      case tp @ ExprType(tp1) => tp.derivedExprType(tp1.annotatedToRepeated)
+      case AnnotatedType(tp, annot) if annot matches defn.RepeatedAnnot =>
+        val typeSym = tp.typeSymbol.asClass
+        assert(typeSym == defn.SeqClass || typeSym == defn.ArrayClass)
+        tp.translateParameterized(typeSym, defn.RepeatedParamClass)
+      case _ => this
+    }
+
     /** Convert to text */
     def toText(printer: Printer): Text = printer.toText(this)
 
@@ -2860,21 +2869,12 @@ object Types {
      *   - add @inlineParam to inline call-by-value parameters
      */
     def fromSymbols(params: List[Symbol], resultType: Type)(implicit ctx: Context) = {
-      def translateRepeated(tp: Type): Type = tp match {
-        case tp @ ExprType(tp1) => tp.derivedExprType(translateRepeated(tp1))
-        case AnnotatedType(tp, annot) if annot matches defn.RepeatedAnnot =>
-          val typeSym = tp.typeSymbol.asClass
-          assert(typeSym == defn.SeqClass || typeSym == defn.ArrayClass)
-          tp.translateParameterized(typeSym, defn.RepeatedParamClass)
-        case tp =>
-          tp
-      }
       def translateInline(tp: Type): Type = tp match {
         case _: ExprType => tp
         case _ => AnnotatedType(tp, Annotation(defn.InlineParamAnnot))
       }
       def paramInfo(param: Symbol) = {
-        val paramType = translateRepeated(param.info)
+        val paramType = param.info.annotatedToRepeated
         if (param.is(Inline)) translateInline(paramType) else paramType
       }
 

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -351,6 +351,8 @@ object PatternMatcher {
           }
         case WildcardPattern() =>
           onSuccess
+        case SeqLiteral(pats, _) =>
+          matchElemsPlan(scrutinee, pats, exact = true, onSuccess)
         case _ =>
           TestPlan(EqualTest(tree), scrutinee, tree.pos, onSuccess, onFailure)
       }

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -395,6 +395,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
       Typ(pat.tpe.stripAnnots, false)
     case Alternative(trees) => Or(trees.map(project(_)))
     case Bind(_, pat) => project(pat)
+    case SeqLiteral(pats, _) => projectSeq(pats)
     case UnApply(fun, _, pats) =>
       if (fun.symbol.name == nme.unapplySeq)
         if (fun.symbol.owner == scalaSeqFactoryClass)
@@ -496,7 +497,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
     debug.println(s"signature of ${unappSym.showFullName} ----> ${sig.map(_.show).mkString(", ")}")
 
-    sig
+    sig.map(_.annotatedToRepeated)
   }
 
   /** Decompose a type into subspaces -- assume the type can be decomposed */

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1275,7 +1275,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       case _ =>
         if (tree.name == nme.WILDCARD) body1
         else {
-          val sym = newPatternBoundSym(tree.name, body1.tpe, tree.pos)
+          val sym = newPatternBoundSym(tree.name, body1.tpe.underlyingIfRepeated(isJava = false), tree.pos)
           if (ctx.mode.is(Mode.InPatternAlternative))
             ctx.error(i"Illegal variable ${sym.name} in pattern alternative", tree.pos)
           assignType(cpy.Bind(tree)(tree.name, body1), sym)

--- a/tests/neg/i3248.scala
+++ b/tests/neg/i3248.scala
@@ -1,0 +1,10 @@
+class Test {
+  class Foo(val name: String, val children: Int *)
+  object Foo {
+    def unapplySeq(f: Foo) = Some((f.name, f.children))
+  }
+
+  def foo(f: Foo) = f match {
+    case Foo(name, ns: _*) => 1 // error: not a valid unapply result type
+  }
+}

--- a/tests/patmat/t8178.scala
+++ b/tests/patmat/t8178.scala
@@ -4,7 +4,7 @@ case class FailsChild2(a: Seq[String]) extends Fails
 object FailsTest {
   def matchOnVarArgsFirstFails(f: Fails) = {
     f match {
-      case VarArgs1(_) => ???
+      case VarArgs1(_: _*) => ???
       // BUG: Without this line we should get a non-exhaustive match compiler error.
       //case FailsChild2(_) => ???
     }

--- a/tests/pos/i3248.scala
+++ b/tests/pos/i3248.scala
@@ -1,0 +1,13 @@
+object Test {
+  class Foo(val name: String, val children: Int *)
+  object Foo {
+    def unapply(f: Foo) = Some((f.name, f.children))
+  }
+
+  def foo(f: Foo) = f match {
+    case Foo(name, cs : _*) => name :: cs.reverse.toList.map(_.toString)
+  }
+  def main(args: Array[String]) = {
+    println(foo(new Foo("hi", 1, 2, 3)).mkString(" "))
+  }
+}

--- a/tests/run/i3248.scala
+++ b/tests/run/i3248.scala
@@ -13,6 +13,7 @@ object Test extends App {
 
   def bar(f: Any) = f match {
     case Bar(1, 2, 3) => 0
+    case Bar(a, b) => a + b
     case Bar(ns: _*) => ns.length
   }
 

--- a/tests/run/i3248.scala
+++ b/tests/run/i3248.scala
@@ -1,0 +1,22 @@
+object Test extends App {
+  class Foo(val name: String, val children: Int *)
+  object Foo {
+    def unapply(f: Foo) = Some((f.name, f.children))
+  }
+
+  def foo(f: Foo) = (f: Any) match {
+    case Foo(name, ns: _*) => ns.length
+    case List(ns: _*) => ns.length
+  }
+
+  case class Bar(val children: Int*)
+
+  def bar(f: Any) = f match {
+    case Bar(1, 2, 3) => 0
+    case Bar(ns: _*) => ns.length
+  }
+
+  assert(bar(new Bar(1, 2, 3)) == 0)
+  assert(bar(new Bar(3, 2, 1)) == 3)
+  assert(foo(new Foo("name", 1, 2, 3)) == 3)
+}


### PR DESCRIPTION
Normal unapply selectors can return results that have a repeated
argument as last element. This needs to be handled. This also subsumes
the previous way to express such arguments with `unapplySeq`.

In the long run, we should be able to do without `unapplySeq` altogether.
This is an intermediate step to get there.