### PR TITLE
Fix #2994

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1249,27 +1249,18 @@ object messages {
            |""".stripMargin
   }
 
-  case class OverloadedOrRecursiveMethodNeedsResultType private (termName: String)(implicit ctx: Context)
+  case class OverloadedOrRecursiveMethodNeedsResultType(tree: Names.TermName)(implicit ctx: Context)
   extends Message(OverloadedOrRecursiveMethodNeedsResultTypeID) {
     val kind = "Syntax"
-    val msg = hl"""overloaded or recursive method $termName needs return type"""
+    val msg = hl"""overloaded or recursive method ${tree} needs return type"""
     val explanation =
-      hl"""Case 1: $termName is overloaded
-          |If there are multiple methods named `$termName` and at least one definition of
+      hl"""Case 1: ${tree} is overloaded
+          |If there are multiple methods named `${tree.name}` and at least one definition of
           |it calls another, you need to specify the calling method's return type.
           |
-          |Case 2: $termName is recursive
-          |If `$termName` calls itself on any path, you need to specify its return type.
+          |Case 2: ${tree} is recursive
+          |If `${tree.name}` calls itself on any path, you need to specify its return type.
           |""".stripMargin
-  }
-
-  object OverloadedOrRecursiveMethodNeedsResultType {
-    def apply[T >: Trees.Untyped](tree: NameTree[T])(implicit ctx: Context)
-    : OverloadedOrRecursiveMethodNeedsResultType =
-      OverloadedOrRecursiveMethodNeedsResultType(tree.name.show)(ctx)
-    def apply(symbol: Symbol)(implicit ctx: Context)
-    : OverloadedOrRecursiveMethodNeedsResultType =
-      OverloadedOrRecursiveMethodNeedsResultType(symbol.name.show)(ctx)
   }
 
   case class RecursiveValueNeedsResultType(tree: Names.TermName)(implicit ctx: Context)
@@ -1369,8 +1360,7 @@ object messages {
            |"""
   }
 
-  case class MethodDoesNotTakeParameters(tree: tpd.Tree, methPartType: Types.Type)
-  (err: typer.ErrorReporting.Errors)(implicit ctx: Context)
+  case class MethodDoesNotTakeParameters(tree: tpd.Tree, methPartType: Types.Type)(err: typer.ErrorReporting.Errors)(implicit ctx: Context)
   extends Message(MethodDoesNotTakeParametersId) {
     private val more = tree match {
       case Apply(_, _) => " more"

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -32,7 +32,7 @@ object ErrorReporting {
       if (cx.mode is Mode.InferringReturnType) {
         cx.tree match {
           case tree: untpd.DefDef if !tree.tpt.typeOpt.exists =>
-            OverloadedOrRecursiveMethodNeedsResultType(tree)
+            OverloadedOrRecursiveMethodNeedsResultType(tree.name)
           case tree: untpd.ValDef if !tree.tpt.typeOpt.exists =>
             RecursiveValueNeedsResultType(tree.name)
           case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2032,13 +2032,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
         else
           tree
       case _ => tryInsertApplyOrImplicit(tree, pt) {
-        pt.resType match {
-          case IgnoredProto(WildcardType(optBounds))
-            if (optBounds == NoType) && (pt.args.size == tree.productArity) =>
-              errorTree(tree, OverloadedOrRecursiveMethodNeedsResultType(tree.symbol))
-          case resType =>
-            errorTree(tree, MethodDoesNotTakeParameters(tree, methPart(tree).tpe)(err))
-        }
+        errorTree(tree, MethodDoesNotTakeParameters(tree, methPart(tree).tpe)(err))
       }
     }
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -193,7 +193,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertTrue("expected trait", isTrait)
     }
 
-  @Test def overloadedMethodNeedsReturnType = {
+  @Test def overloadedMethodNeedsReturnType =
     checkMessagesAfter("frontend") {
       """
         |class Scope() {
@@ -206,24 +206,9 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
 
       assertMessageCount(1, messages)
-      val OverloadedOrRecursiveMethodNeedsResultType(treeName) :: Nil = messages
-      assertEquals("foo", treeName)
+      val OverloadedOrRecursiveMethodNeedsResultType(tree) :: Nil = messages
+      assertEquals("foo", tree.show)
     }
-
-
-    checkMessagesAfter("frontend") {
-      """
-        |case class Foo[T](x: T)
-        |object Foo { def apply[T]() = Foo(null.asInstanceOf[T]) }
-      """.stripMargin
-    }.expect { (ictx, messages) =>
-      implicit val ctx: Context = ictx
-
-      assertMessageCount(1, messages)
-      val OverloadedOrRecursiveMethodNeedsResultType(treeName2) :: Nil = messages
-      assertEquals("Foo", treeName2)
-    }
-  }
 
   @Test def recursiveMethodNeedsReturnType =
     checkMessagesAfter("frontend") {
@@ -237,8 +222,8 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
 
       assertMessageCount(1, messages)
-      val OverloadedOrRecursiveMethodNeedsResultType(treeName) :: Nil = messages
-      assertEquals("i", treeName)
+      val OverloadedOrRecursiveMethodNeedsResultType(tree) :: Nil = messages
+      assertEquals("i", tree.show)
     }
 
   @Test def recursiveValueNeedsReturnType =


### PR DESCRIPTION
This reverts #2823.

Compiling:
```scala
object Test {
  object Energy {
    private def parse(value: Any) = ???
    def apply = parse _
  }

  Energy("")
}
```
now emits:
```scala
-- [E050] Reference Error: tests/allan/Test.scala:7:2 --------------------------
7 |  Energy("")
  |  ^^^^^^
  |  object Energy in object Test does not take parameters
```
But now compiling:
```scala
 case class Foo[T](x: T)
 object Foo { def apply[T]() = Foo(???) }
```
emits:
```scala
-- [E050] Reference Error: tests/allan/Test.scala:11:31 ------------------------
11 | object Foo { def apply[T]() = Foo(???) }
   |                               ^^^
   |                               object Foo does not take parameters
```
instead of
```scala
-- [E044] Syntax Error: tests/allan/Test.scala:11:31 ---------------------------
11 | object Foo { def apply[T]() = Foo(???) }
   |                               ^^^
   |                    overloaded or recursive method Foo needs return type
```
ref #1731