### PR TITLE
Fix #3067: Flag missing parent type of implicit object as error

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -282,6 +282,11 @@ object Contexts {
     /** The current reporter */
     def reporter: Reporter = typerState.reporter
 
+    /** Run `op` as if it was run in a fresh explore typer state, but possibly
+     *  optimized to re-use the current typer state.
+     */
+    final def test[T](op: Context => T): T = typerState.test(op)(this)
+
     /** Is this a context for the members of a class definition? */
     def isClassDefContext: Boolean =
       owner.isClass && (owner ne outer.owner)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -993,19 +993,19 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
    *  @param  resultType   The expected result type of the application
    */
   def isApplicable(methRef: TermRef, targs: List[Type], args: List[Tree], resultType: Type)(implicit ctx: Context): Boolean =
-    ctx.typerState.test(new ApplicableToTrees(methRef, targs, args, resultType).success)
+    ctx.test(implicit ctx => new ApplicableToTrees(methRef, targs, args, resultType).success)
 
   /** Is given method reference applicable to type arguments `targs` and argument trees `args` without inferring views?
     *  @param  resultType   The expected result type of the application
     */
   def isDirectlyApplicable(methRef: TermRef, targs: List[Type], args: List[Tree], resultType: Type)(implicit ctx: Context): Boolean =
-    ctx.typerState.test(new ApplicableToTreesDirectly(methRef, targs, args, resultType).success)
+    ctx.test(implicit ctx => new ApplicableToTreesDirectly(methRef, targs, args, resultType).success)
 
   /** Is given method reference applicable to argument types `args`?
    *  @param  resultType   The expected result type of the application
    */
   def isApplicable(methRef: TermRef, args: List[Type], resultType: Type)(implicit ctx: Context): Boolean =
-    ctx.typerState.test(new ApplicableToTypes(methRef, args, resultType).success)
+    ctx.test(implicit ctx => new ApplicableToTypes(methRef, args, resultType).success)
 
   /** Is given type applicable to type arguments `targs` and argument trees `args`,
    *  possibly after inserting an `apply`?
@@ -1110,7 +1110,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
           case tp2: MethodType => true // (3a)
           case tp2: PolyType if tp2.resultType.isInstanceOf[MethodType] => true // (3a)
           case tp2: PolyType => // (3b)
-            ctx.typerState.test(isAsSpecificValueType(tp1, constrained(tp2).resultType))
+            ctx.test(implicit ctx => isAsSpecificValueType(tp1, constrained(tp2).resultType))
           case _ => // (3b)
             isAsSpecificValueType(tp1, tp2)
         }
@@ -1262,9 +1262,9 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
      *  do they prune much, on average.
      */
     def adaptByResult(chosen: TermRef) = pt match {
-      case pt: FunProto if !ctx.typerState.test(resultConforms(chosen, pt.resultType)) =>
+      case pt: FunProto if !ctx.test(implicit ctx => resultConforms(chosen, pt.resultType)) =>
         val conformingAlts = alts.filter(alt =>
-          (alt ne chosen) && ctx.typerState.test(resultConforms(alt, pt.resultType)))
+          (alt ne chosen) && ctx.test(implicit ctx => resultConforms(alt, pt.resultType)))
         conformingAlts match {
           case Nil => chosen
           case alt2 :: Nil => alt2

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -80,7 +80,7 @@ object Implicits {
           case mt: MethodType =>
             mt.isImplicitMethod ||
             mt.paramInfos.length != 1 ||
-            !ctx.typerState.test(argType relaxed_<:< mt.paramInfos.head)
+            !ctx.test(implicit ctx => argType relaxed_<:< mt.paramInfos.head)
           case poly: PolyType =>
             // We do not need to call ProtoTypes#constrained on `poly` because
             // `refMatches` is always called with mode TypevarsMissContext enabled.
@@ -88,7 +88,7 @@ object Implicits {
               case mt: MethodType =>
                 mt.isImplicitMethod ||
                 mt.paramInfos.length != 1 ||
-                !ctx.typerState.test(argType relaxed_<:< wildApprox(mt.paramInfos.head, null, Set.empty))
+                !ctx.test(implicit ctx => argType relaxed_<:< wildApprox(mt.paramInfos.head, null, Set.empty))
               case rtp =>
                 discardForView(wildApprox(rtp, null, Set.empty), argType)
             }
@@ -148,7 +148,7 @@ object Implicits {
       else {
         val nestedCtx = ctx.fresh.addMode(Mode.TypevarsMissContext)
         refs
-          .filter(ref => nestedCtx.typerState.test(refMatches(ref.underlyingRef)(nestedCtx)))
+          .filter(ref => nestedCtx.test(implicit ctx => refMatches(ref.underlyingRef)))
           .map(Candidate(_, level))
       }
     }
@@ -591,7 +591,7 @@ trait Implicits { self: Typer =>
       formal.argTypes match {
         case args @ (arg1 :: arg2 :: Nil)
         if !ctx.featureEnabled(defn.LanguageModuleClass, nme.strictEquality) &&
-           ctx.typerState.test(validEqAnyArgs(arg1, arg2)) =>
+           ctx.test(implicit ctx => validEqAnyArgs(arg1, arg2)) =>
           ref(defn.Eq_eqAny).appliedToTypes(args).withPos(pos)
         case _ =>
           EmptyTree
@@ -787,7 +787,8 @@ trait Implicits { self: Typer =>
     assert(argument.isEmpty || argument.tpe.isValueType || argument.tpe.isInstanceOf[ExprType],
         em"found: $argument: ${argument.tpe}, expected: $pt")
 
-    private def nestedContext() = ctx.fresh.setMode(ctx.mode &~ Mode.ImplicitsEnabled)
+    private def nestedContext() =
+      ctx.fresh.setMode(ctx.mode &~ Mode.ImplicitsEnabled)
 
     private def implicitProto(resultType: Type, f: Type => Type) =
       if (argument.isEmpty) f(resultType) else ViewProto(f(argument.tpe.widen), f(resultType))
@@ -876,7 +877,7 @@ trait Implicits { self: Typer =>
        */
       def compareCandidate(prev: SearchSuccess, ref: TermRef, level: Int): Int =
         if (prev.ref eq ref) 0
-        else ctx.typerState.test(compare(prev.ref, ref, prev.level, level)(nestedContext()))
+        else nestedContext().test(implicit ctx => compare(prev.ref, ref, prev.level, level))
 
       /* Seems we don't need this anymore.
       def numericValueTieBreak(alt1: SearchSuccess, alt2: SearchSuccess) = {

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -730,6 +730,7 @@ class Namer { typer: Typer =>
 
     /** The context with which this completer was created */
     def creationContext = ctx
+    ctx.typerState.markShared()
 
     protected def typeSig(sym: Symbol): Type = original match {
       case original: ValDef =>
@@ -857,7 +858,7 @@ class Namer { typer: Typer =>
           val ptype = typedAheadType(tpt).tpe appliedTo targs1.tpes
           if (ptype.typeParams.isEmpty) ptype
           else {
-            if (denot.is(ModuleClass) && denot.sourceModule.is(Implicit)) 
+            if (denot.is(ModuleClass) && denot.sourceModule.is(Implicit))
               missingType(denot.symbol, "parent ")(creationContext)
             fullyDefinedType(typedAheadExpr(parent).tpe, "class parent", parent.pos)
           }

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -39,10 +39,11 @@ object ProtoTypes {
       (tp.widenExpr relaxed_<:< pt.widenExpr) || viewExists(tp, pt)
 
     /** Test compatibility after normalization in a fresh typerstate. */
-    def normalizedCompatible(tp: Type, pt: Type)(implicit ctx: Context) = ctx.typerState.test {
-      val normTp = normalize(tp, pt)
-      isCompatible(normTp, pt) || pt.isRef(defn.UnitClass) && normTp.isParameterless
-    }
+    def normalizedCompatible(tp: Type, pt: Type)(implicit ctx: Context) =
+      ctx.test { implicit ctx =>
+        val normTp = normalize(tp, pt)
+        isCompatible(normTp, pt) || pt.isRef(defn.UnitClass) && normTp.isParameterless
+      }
 
     private def disregardProto(pt: Type)(implicit ctx: Context): Boolean = pt.dealias match {
       case _: OrType => true

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2056,7 +2056,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
       val constraint = ctx.typerState.constraint
       def inst(tp: Type): Type = tp match {
         case TypeBounds(lo, hi)
-        if (lo eq hi) || ctx.typerState.test(hi <:< lo) =>
+        if (lo eq hi) || ctx.test(implicit ctx => hi <:< lo) =>
           inst(lo)
         case tp: TypeParamRef =>
           constraint.typeVarOfParam(tp).orElse(tp)

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -52,6 +52,7 @@ class FromTastyTests extends ParallelTesting {
         "t8023.scala",
         "tcpoly_ticket2096.scala",
         "t247.scala",
+        "i3067.scala",
       )
     )
     step1.checkCompile() // Compile all files to generate the class files with tasty

--- a/tests/neg/i1802.scala
+++ b/tests/neg/i1802.scala
@@ -17,5 +17,5 @@ object Exception {
   def mkThrowableCatcher[T](isDef: Throwable => Boolean, f: Throwable => T) = mkCatcher(isDef, f) // error: undetermined ClassTag
 
   implicit def throwableSubtypeToCatcher[Ex <: Throwable: ClassTag, T](pf: PartialFunction[Ex, T]) = // error: result type needs to be given
-    mkCatcher(pf.isDefinedAt _, pf.apply _)
+    mkCatcher(pf.isDefinedAt _, pf.apply _) // error: method needs return type
 }

--- a/tests/neg/i3067.scala
+++ b/tests/neg/i3067.scala
@@ -7,5 +7,5 @@ object o {
   implicit def y = "abc"   // error
 
   implicit object a extends Test(_ map identity)  // error
-  implicit object b extends Test(_ map identity)
+  implicit object b extends Test(_ map identity) // error // error: cyclic reference
 }

--- a/tests/neg/i3067.scala
+++ b/tests/neg/i3067.scala
@@ -1,0 +1,11 @@
+class Test[T](f: List[String] => T)
+
+object o {
+
+  implicit val x = 3  // error
+
+  implicit def y = "abc"   // error
+
+  implicit object a extends Test(_ map identity)  // error
+  implicit object b extends Test(_ map identity)
+}

--- a/tests/neg/i3067b.scala
+++ b/tests/neg/i3067b.scala
@@ -1,0 +1,11 @@
+import collection.generic.CanBuildFrom
+
+class Test[T](f: List[String] => T)
+
+object o {
+
+  implicitly[CanBuildFrom[String, Char, String]]
+
+  implicit object b extends Test(_ map identity)  // error: type needs to be given // error: cyclic reference
+
+}

--- a/tests/pos/i3067.scala
+++ b/tests/pos/i3067.scala
@@ -1,0 +1,6 @@
+class Test[T](f: List[String] => T)
+
+object o {
+  implicit object a extends Test[List[String]](_ map identity)
+  implicit object b extends Test[List[String]](_ map identity)
+}


### PR DESCRIPTION
Implicit objects should not allow parent types to be computed from argument
expressions of an application. This is analogous to demanding an explicit type
for implicit vals and defs.

This fix was straightfoward, however it exhibited another problem: Some errors issued
during completion were never reported because the completion happened inside a 
`TyperState#test` that reset the reporter subsequently. The fix for this one was a bit
more involved.
  
  