### PR TITLE
Fix #3012: Avoid swallowing multiple ()'s

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -62,8 +62,20 @@ object Typer {
     if (!tree.isEmpty && !tree.isInstanceOf[untpd.TypedSplice] && ctx.typerState.isGlobalCommittable)
       assert(tree.pos.exists, s"position not set for $tree # ${tree.uniqueId}")
 
+  /** A context property that indicates the owner of any expressions to be typed in the context
+   *  if that owner is different from the context's owner. Typically, a context with a class
+   *  as owner would have a local dummy as ExprOwner value.
+   */
   private val ExprOwner = new Property.Key[Symbol]
+
+  /** An attachment on a Select node with an `apply` field indicating that the `apply`
+   *  was inserted by the Typer.
+   */
   private val InsertedApply = new Property.Key[Unit]
+
+  /** An attachment on a tree `t` occurring as part of a `t()` where
+   *  the `()` was dropped by the Typer.
+   */
   private val DroppedEmptyArgs = new Property.Key[Unit]
 }
 

--- a/tests/neg/i3012/Fuzbar.java
+++ b/tests/neg/i3012/Fuzbar.java
@@ -1,0 +1,4 @@
+package fuz;
+public interface Fuzbar {
+  public String str();
+}

--- a/tests/neg/i3012/a.scala
+++ b/tests/neg/i3012/a.scala
@@ -1,0 +1,5 @@
+
+object a extends fuz.Fuzbar {
+  override def str = ""
+  str()()()()()()  // error: missing argument
+}

--- a/tests/neg/i3012/a.scala
+++ b/tests/neg/i3012/a.scala
@@ -2,4 +2,7 @@
 object a extends fuz.Fuzbar {
   override def str = ""
   str()()()()()()  // error: missing argument
+  str()() // error: missing argument
+  str() // ok
+  str // ok
 }


### PR DESCRIPTION
Allow dropping at most one () if a method is called that exists
in both ()T and => T forms.