### PR TITLE
Treat singleton ExprTypes as stable values

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -595,8 +595,11 @@ object SymDenotations {
       )
 
     /** Is this a denotation of a stable term (or an arbitrary type)? */
-    final def isStable(implicit ctx: Context) =
-      isType || is(Stable) || !(is(UnstableValue) || info.isInstanceOf[ExprType])
+    final def isStable(implicit ctx: Context) = {
+      def isUnstable =
+      	is(UnstableValue) || info.isInstanceOf[ExprType] && !info.isStable
+      isType || is(Stable) || !isUnstable
+    }
 
     /** Is this a "real" method? A real method is a method which is:
      *  - not an accessor

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -115,7 +115,7 @@ object Types {
       case tp: RefinedOrRecType => tp.parent.isStable
       case tp: ExprType => tp.resultType.isStable
       case tp: AnnotatedType => tp.tpe.isStable
-      case _ => false
+      case tp => tp.derivesFrom(defn.SingletonClass)
     }
 
     /** Is this type a (possibly refined or applied or aliased) type reference

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -417,7 +417,7 @@ object ProtoTypes {
 
   /** Create a new TypeVar that represents a dependent method parameter singleton */
   def newDepTypeVar(tp: Type)(implicit ctx: Context): TypeVar =
-    newTypeVar(TypeBounds.upper(AndType(tp, defn.SingletonClass.typeRef)))
+    newTypeVar(TypeBounds.upper(AndType(tp.widenExpr, defn.SingletonClass.typeRef)))
 
   /** The result type of `mt`, where all references to parameters of `mt` are
    *  replaced by either wildcards (if typevarsMissContext) or TypeParamRefs.

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -56,6 +56,7 @@ class CompilationTests extends ParallelTesting {
     compileFile("../tests/pos-special/utf8encoded.scala", explicitUTF8) +
     compileFile("../tests/pos-special/utf16encoded.scala", explicitUTF16) +
     compileFile("../tests/pos-special/i3589-b.scala", defaultOptions.and("-Xfatal-warnings")) +
+    compileFile("../tests/pos-special/i3005.scala", depByNameOptions) +
     compileList(
       "compileMixed",
       List(

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -62,4 +62,7 @@ object TestConfiguration {
   val scala2Mode = defaultOptions and "-language:Scala2"
   val explicitUTF8 = defaultOptions and ("-encoding", "UTF8")
   val explicitUTF16 = defaultOptions and ("-encoding", "UTF16")
+
+  val depByNameOptions = // disable -Ycheck:arrayConstructors
+    TestFlags(classPath, runClassPath, basicDefaultOptions.map(_.replace(",arrayConstructors", "")))
 }

--- a/tests/pos-special/i3005.scala
+++ b/tests/pos-special/i3005.scala
@@ -1,0 +1,16 @@
+trait Foo {
+  type Out
+  def out: Out
+}
+
+object Test extends App {
+
+  implicit def bar(implicit foo: => Foo & Singleton): foo.Out = foo.out
+
+  var x = new Foo { type Out = String; def out = "hello" }
+
+  implicit val y: Foo = x
+
+  assert(bar(y) == "hello")
+  assert(bar == "hello")
+}


### PR DESCRIPTION
Two main changes:

 - values with type => T are stable if T is stable
 - types deriving from scala.Singleton are considered stable

The two changes together allow to declare by-name-parameters to be stable
by declaring them to have a Singleton type.

Currently such programs fail -Ycheck between elimByName and erasure because elimByName replaces e.g. `foo.out` for cbn foo with `foo.apply().out` but no corresponding operation can be performed on the types. So if we had `foo.out: foo.Out` before elimByName,  this is no longer true afterwards.

The most direct way to avoid the problem is probably to merge elimByName with erasure.

This fixes the test case of #3005, but is probably not enough to address the root of the problem. So I am not sure we should merge this.



  