### PR TITLE
Fix #3775: Fix RefChecks#upwardsThisType

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -86,7 +86,7 @@ object RefChecks {
    */
   private def upwardsThisType(cls: Symbol)(implicit ctx: Context) = cls.info match {
     case ClassInfo(_, _, _, _, tp: Type) if (tp ne cls.typeRef) && !cls.is(ModuleOrFinal) =>
-      SkolemType(cls.typeRef).withName(nme.this_)
+      SkolemType(cls.appliedRef).withName(nme.this_)
     case _ =>
       cls.thisType
   }

--- a/tests/neg/i3775.scala
+++ b/tests/neg/i3775.scala
@@ -1,0 +1,8 @@
+trait Iterator[A] {
+  def next(): A
+}
+
+class IntMapIterator[T] extends Iterator[T] {
+  def next: T = ??? // error: overriding method next in trait Iterator of type (): IntMapIterator.this.T;
+                    // method next of type => IntMapIterator.this.T has incompatible type
+}


### PR DESCRIPTION
A non-applied class TypeRef is not a valid prefix for a TypeRef of a
class type parameter, it causes an assertion error in NamedType#argDenot
because args.nonEmpty ends up false.