### PR TITLE
Added error message for non object phantom extensions

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -125,6 +125,7 @@ public enum ErrorMessageID {
     UnableToEmitSwitchID,
     MissingCompanionForStaticID,
     PolymorphicMethodMissingTypeInParentID,
+    NonObjectPhantomTypeID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2074,4 +2074,11 @@ object messages {
           |$rsym does not override any method in $parentSym. Structural refinement does not allow for
           |polymorphic methods."""
   }
+
+  case class NonObjectPhantomType()(implicit ctx: Context)
+    extends Message(NonObjectPhantomTypeID) {
+    val kind = "Syntax"
+    val msg = hl"only static objects can extend scala.Phantom"
+    val explanation = ""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1504,7 +1504,7 @@ class Typer extends Namer with TypeAssigner with Applications with Implicits wit
 
       // Check that phantom lattices are defined in a static object
       if (cls.classParents.exists(_.typeSymbol eq defn.PhantomClass) && !cls.isStaticOwner)
-        ctx.error("only static objects can extend scala.Phantom", cdef.pos)
+        ctx.error(NonObjectPhantomType(), cdef.pos)
 
       // check value class constraints
       checkDerivedValueClass(cls, body1)

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1294,4 +1294,20 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("method get", rsym.show)
       assertEquals("class Object", parentSym.show)
     }
+
+    @Test def nonObjectPhantomType =
+      checkMessagesAfter("frontend") {
+        """
+          |class Boo1 extends Phantom
+          |trait Boo2 extends Phantom
+          |object Boo3 extends Phantom
+        """.stripMargin
+    }.expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+
+      val expectedErr = NonObjectPhantomType()
+      assertMessageCount(2, messages)
+      assertEquals(expectedErr, messages(0))
+      assertEquals(expectedErr, messages(1))
+    }
 }


### PR DESCRIPTION
Fixes `Typer.scala:1519` in https://github.com/lampepfl/dotty/issues/1589.