### PR TITLE
Fix #1379: Add regression test

### DIFF
--- a/compiler/test-resources/repl/1379
+++ b/compiler/test-resources/repl/1379
@@ -1,0 +1,4 @@
+scala>  object Foo { val bar = new Object { def baz = 1 }; bar.baz }
+1 |  object Foo { val bar = new Object { def baz = 1 }; bar.baz }
+  |                                                     ^^^^^^^
+  |            value `baz` is not a member of Object - did you mean `bar.eq`?


### PR DESCRIPTION
Add error message test to make sure the `repl` internals do not leak.