### PR TITLE
Clarify "the new" in dependent function types

### DIFF
--- a/docs/docs/reference/dependent-function-types.md
+++ b/docs/docs/reference/dependent-function-types.md
@@ -6,7 +6,7 @@ title: "Dependent Function Types"
 A dependent function type describes functions where the result type may depend
 on the function's parameter values. Example:
 
-    class Entry { type Key; val key: Key }
+    trait Entry { type Key; val key: Key }
 
     def extractKey(e: Entry): e.Key = e.key          // a dependent method
     val extractor: (e: Entry) => e.Key = extractKey  // a dependent function value

--- a/docs/docs/reference/dependent-function-types.md
+++ b/docs/docs/reference/dependent-function-types.md
@@ -6,11 +6,14 @@ title: "Dependent Function Types"
 A dependent function type describes functions where the result type may depend
 on the function's parameter values. Example:
 
-    class Entry { type Key; key: Key }
+    class Entry { type Key; val key: Key }
 
     def extractKey(e: Entry): e.Key = e.key          // a dependent method
     val extractor: (e: Entry) => e.Key = extractKey  // a dependent function value
-
+    //            ║   ⇓ ⇓ ⇓ ⇓ ⇓ ⇓ ⇓   ║ 
+    //            ║     Dependent     ║  
+    //            ║   Function Type   ║  
+    //            ╚═══════════════════╝
 Scala already has _dependent methods_, i.e. methods where the result
 type refers to some of the parameters of the method. Method
 `extractKey` is an example. Its result type, `e.key` refers its


### PR DESCRIPTION
(also added missing `val`)
I was skimming over at this documentation and it actually took me a while to notice what is new.
So I added the comment to clarify. 
It is also possible to write `type EntryToKey = (e: Entry) => e.Key` and use it instead to clarify this is a dependent type