### PR TITLE
Mitigate #2387: Improve cloning logic

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,12 +3,10 @@ clone:
   clone:
     image: plugins/git
     commands:
-      - sleep 5s
-      - git init
-      - git remote add origin $DRONE_REMOTE_URL
-      - git fetch --no-tags origin $DRONE_COMMIT_REF
-      - if [ $DRONE_BUILD_EVENT = "push" ]; then git reset --hard -q $DRONE_COMMIT_SHA; else git checkout -qf FETCH_HEAD; fi
-      - git submodule update --init --recursive
+      - git clone -b "$DRONE_BRANCH" "$DRONE_REMOTE_URL" .
+      - git fetch origin "$DRONE_COMMIT_REF"
+      - if [ "$DRONE_BUILD_EVENT" = "pull_request" ]; then git merge "$DRONE_COMMIT_SHA"; else git checkout -qf "$DRONE_COMMIT_SHA"; fi
+      - git submodule update --init --recursive --jobs 3
 
 pipeline:
   # TESTS:

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,9 @@ clone:
   clone:
     image: plugins/git
     commands:
-      - git clone -b "$DRONE_BRANCH" "$DRONE_REMOTE_URL" .
+      - git init
+      - git remote add origin "$DRONE_REMOTE_URL"
+      - git pull origin "$DRONE_BRANCH"
       - git fetch origin "$DRONE_COMMIT_REF"
       - if [ "$DRONE_BUILD_EVENT" = "pull_request" ]; then git merge "$DRONE_COMMIT_SHA"; else git checkout -qf "$DRONE_COMMIT_SHA"; fi
       - git submodule update --init --recursive --jobs 3


### PR DESCRIPTION
- Clone submodules in parallel
- Improve workaround to #3415. Don't rely on GitHub to perform the merge
  on PRs