### PR TITLE
Fix #2979: Allow for instantiated params when approximating

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -227,15 +227,15 @@ trait ConstraintHandling {
         }
       }
     }
-    if (constraint.contains(param)) {
-      val bound = if (fromBelow) constraint.fullLowerBound(param) else constraint.fullUpperBound(param)
-      val inst = avoidParam(bound)
-      typr.println(s"approx ${param.show}, from below = $fromBelow, bound = ${bound.show}, inst = ${inst.show}")
-      inst
-    }
-    else {
-      assert(ctx.mode.is(Mode.Interactive))
-      UnspecifiedErrorType
+    constraint.entry(param) match {
+      case _: TypeBounds =>
+        val bound = if (fromBelow) constraint.fullLowerBound(param) else constraint.fullUpperBound(param)
+        val inst = avoidParam(bound)
+        typr.println(s"approx ${param.show}, from below = $fromBelow, bound = ${bound.show}, inst = ${inst.show}")
+        inst
+      case inst =>
+        assert(inst.exists, i"param = $param\n constraint = $constraint")
+        inst
     }
   }
 

--- a/tests/neg/i2979.scala
+++ b/tests/neg/i2979.scala
@@ -1,0 +1,6 @@
+object Main {
+  Map(
+    "a" -> Unknown(), // error
+    "b" -> Unknown()  // error
+  )
+}


### PR DESCRIPTION
When approximating, some of the type parameters might already be instantiated
by earlier interpolations.