### PR TITLE
Fix #2982: Avoid instantiating to Nothing in some situations

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3327,6 +3327,10 @@ object Types {
     def instantiate(fromBelow: Boolean)(implicit ctx: Context): Type =
       instantiateWith(ctx.typeComparer.instanceType(origin, fromBelow))
 
+    /** For uninstantiated type variables: Is the lower bound different from Nothing? */
+    def hasLowerBound(implicit ctx: Context) =
+      !ctx.typerState.constraint.entry(origin).loBound.isBottomType
+
     /** Unwrap to instance (if instantiated) or origin (if not), until result
      *  is no longer a TypeVar
      */

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -389,7 +389,7 @@ trait Inferencing { this: Typer =>
         if (!(vs contains tvar) && qualifies(tvar)) {
           typr.println(s"instantiating non-occurring ${tvar.show} in ${tp.show} / $tp")
           ensureConstrained()
-          tvar.instantiate(fromBelow = true)
+          tvar.instantiate(fromBelow = tvar.hasLowerBound)
         }
     }
     if (constraint.uninstVars exists qualifies) interpolate()

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -113,7 +113,8 @@ trait TypeAssigner {
         case tp: SkolemType if partsToAvoid(mutable.Set.empty, tp.info).nonEmpty =>
           range(tp.info.bottomType, apply(tp.info))
         case tp: TypeVar if ctx.typerState.constraint.contains(tp) =>
-          val lo = ctx.typeComparer.instanceType(tp.origin, fromBelow = variance >= 0)
+          val lo = ctx.typeComparer.instanceType(
+            tp.origin, fromBelow = variance > 0 || variance == 0 && tp.hasLowerBound)
           val lo1 = apply(lo)
           if (lo1 ne lo) lo1 else tp
         case _ =>

--- a/tests/neg-tailcall/tailrec.scala
+++ b/tests/neg-tailcall/tailrec.scala
@@ -56,7 +56,7 @@ class Failures {
   }
 
   // unsafe
-  @tailrec final def fail3[T](x: Int): Int = fail3(x - 1)
+  @tailrec final def fail3[T](x: Int): Int = fail3(x - 1) // error // error: recursive application has different type arguments
 
   // unsafe
   class Tom[T](x: Int) {

--- a/tests/pos/i2982.scala
+++ b/tests/pos/i2982.scala
@@ -1,8 +1,6 @@
-object A {
-  def fun[E >: B](a: A[E]): E => Unit = ???
-  val x = fun(new A[C])
-}
-class B extends C
-class C
 
-class A[-X >: B]
+object A {
+  def fun[E](a: A[E]): Unit = ()
+  fun(new A[Int])
+}
+class A[-X]


### PR DESCRIPTION
If variance == 0, we have to choice whether to instantiate a type variable
to its lower or upper bound. We used to always pick the lower bound, but now
we pick the upper bound if the lower bound is Nothing.