### PR TITLE
Fix #2939: Avoid duplicating symbols in default arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -311,9 +311,9 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   import tpd._
 
   /** The purity level of this statement.
-   *  @return   pure        if statement has no side effects
-   *            idempotent  if running the statement a second time has no side effects
-   *            impure      otherwise
+   *  @return   Pure        if statement has no side effects
+   *            Idempotent  if running the statement a second time has no side effects
+   *            Impure      otherwise
    */
   private def statPurity(tree: Tree)(implicit ctx: Context): PurityLevel = unsplice(tree) match {
     case EmptyTree
@@ -322,7 +322,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
        | DefDef(_, _, _, _, _) =>
       Pure
     case vdef @ ValDef(_, _, _) =>
-      if (vdef.symbol.flags is Mutable) Impure else exprPurity(vdef.rhs)
+      if (vdef.symbol.flags is Mutable) Impure else exprPurity(vdef.rhs) `min` Pure
     case _ =>
       Impure
       // TODO: It seem like this should be exprPurity(tree)
@@ -330,9 +330,10 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   }
 
   /** The purity level of this expression.
-   *  @return   pure        if expression has no side effects
-   *            idempotent  if running the expression a second time has no side effects
-   *            impure      otherwise
+   *  @return   PurePath    if expression has no side effects and cannot contain local definitions
+   *            Pure        if expression has no side effects
+   *            Idempotent  if running the expression a second time has no side effects
+   *            Impure      otherwise
    *
    *  Note that purity and idempotency are different. References to modules and lazy
    *  vals are impure (side-effecting) both because side-effecting code may be executed and because the first reference
@@ -345,7 +346,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
        | Super(_, _)
        | Literal(_)
        | Closure(_, _, _) =>
-      Pure
+      PurePath
     case Ident(_) =>
       refPurity(tree)
     case Select(qual, _) =>
@@ -366,7 +367,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
       if (args.isEmpty && fn.symbol.is(Stable)) exprPurity(fn)
       else if (tree.tpe.isInstanceOf[ConstantType] && isKnownPureOp(tree.symbol))
         // A constant expression with pure arguments is pure.
-        minOf(exprPurity(fn), args.map(exprPurity))
+        minOf(exprPurity(fn), args.map(exprPurity)) `min` Pure
       else Impure
     case Typed(expr, _) =>
       exprPurity(expr)
@@ -382,25 +383,26 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
 
   private def minOf(l0: PurityLevel, ls: List[PurityLevel]) = (l0 /: ls)(_ min _)
 
-  def isPureExpr(tree: Tree)(implicit ctx: Context) = exprPurity(tree) == Pure
+  def isPurePath(tree: Tree)(implicit ctx: Context) = exprPurity(tree) == PurePath
+  def isPureExpr(tree: Tree)(implicit ctx: Context) = exprPurity(tree) >= Pure
   def isIdempotentExpr(tree: Tree)(implicit ctx: Context) = exprPurity(tree) >= Idempotent
 
   /** The purity level of this reference.
    *  @return
-   *    pure        if reference is (nonlazy and stable) or to a parameterized function
-   *    idempotent  if reference is lazy and stable
-   *    impure      otherwise
+   *    PurePath    if reference is (nonlazy and stable) or to a parameterized function
+   *    Idempotent  if reference is lazy and stable
+   *    Impure      otherwise
    *  @DarkDimius: need to make sure that lazy accessor methods have Lazy and Stable
    *               flags set.
    */
   private def refPurity(tree: Tree)(implicit ctx: Context): PurityLevel =
-    if (!tree.tpe.widen.isParameterless) Pure
+    if (!tree.tpe.widen.isParameterless) PurePath
     else if (!tree.symbol.isStable) Impure
     else if (tree.symbol.is(Lazy)) Idempotent // TODO add Module flag, sinxce Module vals or not Lazy from the start.
-    else Pure
+    else PurePath
 
   def isPureRef(tree: Tree)(implicit ctx: Context) =
-    refPurity(tree) == Pure
+    refPurity(tree) == PurePath
   def isIdempotentRef(tree: Tree)(implicit ctx: Context) =
     refPurity(tree) >= Idempotent
 
@@ -724,6 +726,7 @@ object TreeInfo {
     def min(that: PurityLevel) = new PurityLevel(x min that.x)
   }
 
+  val PurePath = new PurityLevel(3)
   val Pure = new PurityLevel(2)
   val Idempotent = new PurityLevel(1)
   val Impure = new PurityLevel(0)

--- a/compiler/src/dotty/tools/dotc/transform/PhantomArgLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PhantomArgLift.scala
@@ -5,7 +5,7 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.NameKinds._
 import dotty.tools.dotc.core.Types._
 import dotty.tools.dotc.transform.MegaPhase.MiniPhase
-import dotty.tools.dotc.typer.EtaExpansion
+import dotty.tools.dotc.typer.LiftImpure
 
 import scala.collection.mutable.ListBuffer
 
@@ -46,7 +46,7 @@ class PhantomArgLift extends MiniPhase {
       if (!hasImpurePhantomArgs(tree)) tree
       else {
         val buffer = ListBuffer.empty[Tree]
-        val app = EtaExpansion.liftApp(buffer, tree)
+        val app = LiftImpure.liftApp(buffer, tree)
         if (buffer.isEmpty) app
         else Block(buffer.result(), app)
       }

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -22,7 +22,6 @@ import Names._
 import StdNames._
 import NameKinds.DefaultGetterName
 import ProtoTypes._
-import EtaExpansion._
 import Inferencing._
 
 import collection.mutable
@@ -426,7 +425,8 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
           }
 
           def tryDefault(n: Int, args1: List[Arg]): Unit = {
-            if (!isJavaAnnotConstr(methRef.symbol)) liftFun()
+            if (!isJavaAnnotConstr(methRef.symbol))
+              liftFun()
             val getter = findDefaultGetter(n + numArgs(normalizedFun))
             if (getter.isEmpty) missingArg(n)
             else {
@@ -571,10 +571,13 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
 
     def normalizedFun = myNormalizedFun
 
+    private def lifter(implicit ctx: Context) =
+      if (methRef.symbol.hasDefaultParams) LiftComplex else LiftImpure
+
     override def liftFun(): Unit =
       if (liftedDefs == null) {
         liftedDefs = new mutable.ListBuffer[Tree]
-        myNormalizedFun = liftApp(liftedDefs, myNormalizedFun)
+        myNormalizedFun = lifter.liftApp(liftedDefs, myNormalizedFun)
       }
 
     /** The index of the first difference between lists of trees `xs` and `ys`
@@ -608,13 +611,13 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
 
             // lift arguments in the definition order
             val argDefBuf = mutable.ListBuffer.empty[Tree]
-            typedArgs = liftArgs(argDefBuf, methType, typedArgs)
+            typedArgs = lifter.liftArgs(argDefBuf, methType, typedArgs)
 
             // Lifted arguments ordered based on the original order of typedArgBuf and
             // with all non-explicit default parameters at the end in declaration order.
             val orderedArgDefs = {
               // List of original arguments that are lifted by liftArgs
-              val impureArgs = typedArgBuf.filterNot(isPureExpr)
+              val impureArgs = typedArgBuf.filterNot(lifter.noLift)
               // Assuming stable sorting all non-explicit default parameters will remain in the end with the same order
               val defaultParamIndex = args.size
               // Mapping of index of each `liftable` into original args ordering
@@ -746,7 +749,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       val Apply(Select(lhs, name), rhss) = tree
       val lhs1 = typedExpr(lhs)
       val liftedDefs = new mutable.ListBuffer[Tree]
-      val lhs2 = untpd.TypedSplice(liftAssigned(liftedDefs, lhs1))
+      val lhs2 = untpd.TypedSplice(LiftComplex.liftAssigned(liftedDefs, lhs1))
       val assign = untpd.Assign(lhs2,
           untpd.Apply(untpd.Select(lhs2, name.asSimpleName.dropRight(1)), rhss))
       wrapDefs(liftedDefs, typed(assign))

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -46,7 +46,8 @@ abstract class Lifter {
     if (noLift(expr)) expr
     else {
       val name = UniqueName.fresh(prefix)
-      val liftedType = fullyDefinedType(expr.tpe.widen, "lifted expression", expr.pos)
+      var liftedType = fullyDefinedType(expr.tpe.widen, "lifted expression", expr.pos)
+      if (liftedFlags.is(Method)) liftedType = ExprType(liftedType)
       val lifted = ctx.newSymbol(ctx.owner, name, liftedFlags, liftedType, coord = positionCoord(expr.pos))
       defs += liftedDef(lifted, expr).withPos(expr.pos.focus)
       ref(lifted.termRef).withPos(expr.pos)

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -33,7 +33,7 @@ abstract class Lifter {
   /** Test indicating `expr` does not need lifting */
   def noLift(expr: Tree)(implicit ctx: Context): Boolean
 
-  /** The corresponding lifter for paam-by-name arguments */
+  /** The corresponding lifter for pass-by-name arguments */
   protected def exprLifter: Lifter = NoLift
 
   /** The flags of a lifted definition */
@@ -144,7 +144,7 @@ object LiftImpure extends LiftImpure
 
 /** Lift all impure or complex arguments */
 class LiftComplex extends Lifter {
-  def noLift(expr: tpd.Tree)(implicit ctx: Context) = tpd.isPurePath(expr)
+  def noLift(expr: tpd.Tree)(implicit ctx: Context) = tpd.isSimplyPure(expr)
   override def exprLifter = LiftToDefs
 }
 object LiftComplex extends LiftComplex

--- a/tests/run/i2939.scala
+++ b/tests/run/i2939.scala
@@ -1,0 +1,33 @@
+import scala.collection.mutable._
+
+class Tag(val name: String, val buffer: Buffer[Tag] = ArrayBuffer()) {
+	def space(n: Int = 0): String = {
+	    s"${" " * n}<$name>\n" +
+	        (if(buffer.isEmpty) "" else buffer.map(_.space(n + 4)).mkString("", "\n", "\n")) +
+	    s"${" " * n}</$name>"
+	}
+
+	def apply[U](f: implicit Tag => U)(implicit tag: Tag = null): this.type = {
+		f(this)
+		if(tag != null) tag.buffer += this
+		this
+	}
+
+	override def toString(): String = space(0)
+}
+
+object Tag {
+	implicit def toTag(symbol: Symbol): Tag = new Tag(symbol.name)
+
+	def main(args: Array[String]): Unit = {
+	}
+}
+
+
+object Test {
+  def foo(x: Int => Int)(y: Int = 0) = {}
+
+  def main(args: Array[String]): Unit = {
+    foo(x => x)()
+  }
+}

--- a/tests/run/i2939.scala
+++ b/tests/run/i2939.scala
@@ -26,8 +26,10 @@ object Tag {
 
 object Test {
   def foo(x: Int => Int)(y: Int = 0) = {}
+  def bar(x: => Int)(y: Int = 0) = {}
 
   def main(args: Array[String]): Unit = {
     foo(x => x)()
+    bar(args.length)()
   }
 }


### PR DESCRIPTION
Previously a method argument could be duplicated because it was passed
to the method as well as to its default argument methods. This was fatal
if the argument contained local definitions or was a closure.

We now unconditionally lift such arguments if the method has default
parameters.