### PR TITLE
Revert "Fix #3782: Fix type parameter inference with scala.Singleton"

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -272,10 +272,10 @@ trait ConstraintHandling {
 
     // Then, approximate by (1.) - (3.) and simplify as follows.
     // 1. If instance is from below and is a singleton type, yet upper bound is
-    // not a singleton type or a subtype of `scala.Singleton`, widen the
+    // not a singleton type or a reference to `scala.Singleton`, widen the
     // instance.
     if (fromBelow && isMultiSingleton(inst) && !isMultiSingleton(upperBound)
-        && !isSubTypeWhenFrozen(upperBound, defn.SingletonType))
+        && !upperBound.isRef(defn.SingletonClass))
       inst = inst.widen
 
     // 2. If instance is from below and is a fully-defined union type, yet upper bound

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -387,7 +387,6 @@ class Definitions {
     enterCompleteClassSymbol(
       ScalaPackageClass, tpnme.Singleton, PureInterfaceCreationFlags | Final,
       List(AnyClass.typeRef), EmptyScope)
-  lazy val SingletonType: TypeRef = SingletonClass.typeRef
 
   lazy val SeqType: TypeRef = ctx.requiredClassRef("scala.collection.Seq")
   def SeqClass(implicit ctx: Context) = SeqType.symbol.asClass

--- a/tests/pos/singletontrait.scala
+++ b/tests/pos/singletontrait.scala
@@ -1,7 +1,5 @@
 object Test {
   def foo[T <: Singleton](x: T): T = x
-  def bar[T <: Int with Singleton](x: T): T = x
 
   val a: 1 = foo(1)
-  val b: 1 = bar(1)
 }


### PR DESCRIPTION
This reverts commit 6a8c29a78e9eaeb9176fce75549133389324c443.