### PR TITLE
Mitigate #2387: Improve cloning logic

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,16 +1,17 @@
-# We override the default clone step to workaround a bug with GitHub (see #3415)
 clone:
+  git:
+    image: plugins/git
+    # We clone submodules ourselves
+    recursive: false
+
+pipeline:
+  # We add a custom clone step to workaround a bug with GitHub (see #3415)
+  # and speed up cloning submodules
   clone:
     image: plugins/git
     commands:
-      - sleep 5s
-      - git init
-      - git remote add origin $DRONE_REMOTE_URL
-      - git fetch --no-tags origin $DRONE_COMMIT_REF
-      - if [ $DRONE_BUILD_EVENT = "push" ]; then git reset --hard -q $DRONE_COMMIT_SHA; else git checkout -qf FETCH_HEAD; fi
-      - git submodule update --init --recursive
+      - ./project/scripts/ci-clone
 
-pipeline:
   # TESTS:
   # We run tests in parallel. Tests run in a copy of the working directory to avoid conflict
   test_legacy:

--- a/project/scripts/ci-clone
+++ b/project/scripts/ci-clone
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eux
+
+# if build is PR rebase on top of target branch
+if [ "$DRONE_BUILD_EVENT" = "pull_request" ]; then
+  git config user.email "allan.renucci@gmail.com"
+  git config user.name "Allan Renucci"
+  git pull --rebase "$DRONE_REMOTE_URL" "$DRONE_BRANCH"
+fi
+
+# clone submodules in parallel
+git submodule update --init --recursive --jobs 3


### PR DESCRIPTION
- Clone submodules in parallel
- Improve workaround to #3415. Don't rely on GitHub to perform the merge
  on PRs