### PR TITLE
Reenable fix for type parameter inference with scala.Singleton

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -272,10 +272,10 @@ trait ConstraintHandling {
 
     // Then, approximate by (1.) - (3.) and simplify as follows.
     // 1. If instance is from below and is a singleton type, yet upper bound is
-    // not a singleton type or a reference to `scala.Singleton`, widen the
+    // not a singleton type or a subtype of `scala.Singleton`, widen the
     // instance.
     if (fromBelow && isMultiSingleton(inst) && !isMultiSingleton(upperBound)
-        && !upperBound.isRef(defn.SingletonClass))
+        && !isSubTypeWhenFrozen(upperBound, defn.SingletonType))
       inst = inst.widen
 
     // 2. If instance is from below and is a fully-defined union type, yet upper bound

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -387,6 +387,7 @@ class Definitions {
     enterCompleteClassSymbol(
       ScalaPackageClass, tpnme.Singleton, PureInterfaceCreationFlags | Final,
       List(AnyClass.typeRef), EmptyScope)
+  lazy val SingletonType: TypeRef = SingletonClass.typeRef
 
   lazy val SeqType: TypeRef = ctx.requiredClassRef("scala.collection.Seq")
   def SeqClass(implicit ctx: Context) = SeqType.symbol.asClass

--- a/tests/neg/i2997.scala
+++ b/tests/neg/i2997.scala
@@ -1,9 +1,0 @@
-case class Foo[T <: Int with Singleton](t : T)
-
-object Test {
-  val one = 1
-  final val final_one = 1
-  val a : 1 = Foo(1).t
-  val b : Int = Foo(one).t // error: does not conform to upper bound Int & Singleton
-  val c : 1 = Foo(final_one).t
-}

--- a/tests/pos/i2997.scala
+++ b/tests/pos/i2997.scala
@@ -4,5 +4,6 @@ object Test {
   val one = 1
   final val final_one = 1
   val a : 1 = Foo(1).t
+  val b : one.type = Foo(one).t
   val c : 1 = Foo(final_one).t
 }

--- a/tests/pos/singletontrait.scala
+++ b/tests/pos/singletontrait.scala
@@ -1,5 +1,7 @@
 object Test {
   def foo[T <: Singleton](x: T): T = x
+  def bar[T <: Int with Singleton](x: T): T = x
 
   val a: 1 = foo(1)
+  val b: 1 = bar(1)
 }


### PR DESCRIPTION
6a8c29a78e9eaeb9176fce75549133389324c443 was reverted because of a
neg test now compiling. The test should compile in fact, so this commit
reverts the revert and fix the test.