### PR TITLE
Fix #3675: don't unnecessarily wrap arrays when eliminating java varargs

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -9,6 +9,7 @@ import scala.collection.{ mutable, immutable }
 import PartialFunction._
 import collection.mutable
 import util.common.alwaysZero
+import dotty.tools.dotc.transform.TreeGen
 
 object Definitions {
 
@@ -338,6 +339,12 @@ class Definitions {
     def Predef_classOf(implicit ctx: Context) = Predef_classOfR.symbol
     lazy val Predef_undefinedR = ScalaPredefModule.requiredMethodRef("???")
     def Predef_undefined(implicit ctx: Context) = Predef_undefinedR.symbol
+    // The set of all wrap{X, Ref}Array methods, where X is a value type
+    lazy val Predef_wrapArrayR: Set[TermRef] = {
+      val methodNames = ScalaValueTypes.map(TreeGen.wrapArrayMethodName) + nme.wrapRefArray
+      methodNames.map(ScalaPredefModule.requiredMethodRef).toSet
+    }
+    def Predef_wrapArray(implicit ctx: Context): Set[Symbol] = Predef_wrapArrayR.map(_.symbol)
 
   lazy val ScalaRuntimeModuleRef = ctx.requiredModuleRef("scala.runtime.ScalaRunTime")
   def ScalaRuntimeModule(implicit ctx: Context) = ScalaRuntimeModuleRef.symbol

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -340,11 +340,10 @@ class Definitions {
     lazy val Predef_undefinedR = ScalaPredefModule.requiredMethodRef("???")
     def Predef_undefined(implicit ctx: Context) = Predef_undefinedR.symbol
     // The set of all wrap{X, Ref}Array methods, where X is a value type
-    lazy val Predef_wrapArrayR: collection.Set[TermRef] = {
+    val Predef_wrapArray = new PerRun[collection.Set[Symbol]]({ implicit ctx =>
       val methodNames = ScalaValueTypes.map(TreeGen.wrapArrayMethodName) + nme.wrapRefArray
-      methodNames.map(ScalaPredefModule.requiredMethodRef)
-    }
-    val Predef_wrapArray = new PerRun[collection.Set[Symbol]](implicit ctx => Predef_wrapArrayR.map(_.symbol))
+      methodNames.map(ScalaPredefModule.requiredMethodRef(_).symbol)
+    })
 
   lazy val ScalaRuntimeModuleRef = ctx.requiredModuleRef("scala.runtime.ScalaRunTime")
   def ScalaRuntimeModule(implicit ctx: Context) = ScalaRuntimeModuleRef.symbol

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -340,11 +340,11 @@ class Definitions {
     lazy val Predef_undefinedR = ScalaPredefModule.requiredMethodRef("???")
     def Predef_undefined(implicit ctx: Context) = Predef_undefinedR.symbol
     // The set of all wrap{X, Ref}Array methods, where X is a value type
-    lazy val Predef_wrapArrayR: Set[TermRef] = {
+    lazy val Predef_wrapArrayR: collection.Set[TermRef] = {
       val methodNames = ScalaValueTypes.map(TreeGen.wrapArrayMethodName) + nme.wrapRefArray
-      methodNames.map(ScalaPredefModule.requiredMethodRef).toSet
+      methodNames.map(ScalaPredefModule.requiredMethodRef)
     }
-    def Predef_wrapArray(implicit ctx: Context): Set[Symbol] = Predef_wrapArrayR.map(_.symbol)
+    val Predef_wrapArray = new PerRun[collection.Set[Symbol]](implicit ctx => Predef_wrapArrayR.map(_.symbol))
 
   lazy val ScalaRuntimeModuleRef = ctx.requiredModuleRef("scala.runtime.ScalaRunTime")
   def ScalaRuntimeModule(implicit ctx: Context) = ScalaRuntimeModuleRef.symbol

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -94,8 +94,8 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
   private def seqToArray(tree: Tree, pt: Type)(implicit ctx: Context): Tree = tree match {
     case SeqLiteral(elems, elemtpt) =>
       JavaSeqLiteral(elems, elemtpt)
-    case app@Apply(fun, args) if isWrappedArray(app) =>
-      args.head // There's only one argument: the wrapped array
+    case app@Apply(fun, args) if isWrappedArray(app) => // rewrite a call to `wrapXArray(arr)` to `arr`
+      args.head
     case _ =>
       val elemType = tree.tpe.elemType
       var elemClass = elemType.classSymbol
@@ -108,7 +108,7 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
           // Because of phantomclasses, the Java array's type might not conform to the return type
   }
 
-  /** Determines whether the given `tree` represents a wrapped array */
+  /** Determines whether `tree` is a method call to Predef.wrapXArray */
   private def isWrappedArray(tree: Apply)(implicit ctx: Context): Boolean = {
     val elemTpe = tree.tpe.elemType
     val wrapMethodName = TreeGen.wrapArrayMethodName(elemTpe)

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -94,7 +94,7 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
   private def seqToArray(tree: Tree, pt: Type)(implicit ctx: Context): Tree = tree match {
     case SeqLiteral(elems, elemtpt) =>
       JavaSeqLiteral(elems, elemtpt)
-    case app@Apply(fun, args) if defn.Predef_wrapArray.contains(fun.symbol) => // rewrite a call to `wrapXArray(arr)` to `arr`
+    case app@Apply(fun, args) if defn.Predef_wrapArray().contains(fun.symbol) => // rewrite a call to `wrapXArray(arr)` to `arr`
       args.head
     case _ =>
       val elemType = tree.tpe.elemType

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -187,4 +187,32 @@ class TestBCode extends DottyBytecodeTest {
         diffInstructions(instructions1, instructions2))
     }
   }
+
+  /** Verifies that arrays are not unnecessarily wrapped when passed to Java varargs methods */
+  @Test def dontWrapArraysInJavaVarargs = {
+    val source =
+      """
+        |import java.nio.file._
+        |class Test {
+        |  def test(xs: Array[String]) = {
+        |     val p4 = Paths.get("Hello", xs: _*)
+        |  }
+        |}
+      """.stripMargin
+
+    checkBCode(source) { dir =>
+      val moduleIn = dir.lookupName("Test.class", directory = false)
+      val moduleNode = loadClassNode(moduleIn.input)
+      val method = getMethod(moduleNode, "test")
+
+      val arrayWrapped = instructionsFromMethod(method).exists { instr: Instruction =>
+        instr match {
+          case inv: Invoke => inv.name.contains("wrapRefArray")
+          case _ => false
+        }
+      }
+
+      assert(!arrayWrapped, "Arrays should not be wrapped when passed to a Java varargs method\n")
+    }
+  }
 }

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -205,11 +205,9 @@ class TestBCode extends DottyBytecodeTest {
       val moduleNode = loadClassNode(moduleIn.input)
       val method = getMethod(moduleNode, "test")
 
-      val arrayWrapped = instructionsFromMethod(method).exists { instr: Instruction =>
-        instr match {
-          case inv: Invoke => inv.name.contains("wrapRefArray")
-          case _ => false
-        }
+      val arrayWrapped = instructionsFromMethod(method).exists {
+        case inv: Invoke => inv.name.contains("wrapRefArray")
+        case _ => false
       }
 
       assert(!arrayWrapped, "Arrays should not be wrapped when passed to a Java varargs method\n")


### PR DESCRIPTION
When eliminating varargs in a java method call, we need to convert Seqs
into Arrays. However, if the object we're passing is already a wrapped
array, we just need to unwrap it.

Testing
-------
Added a unit test that checks that
```
import java.nio.file._
class Test {
  def test(xs: Array[String]) = {
     val p4 = Paths.get("Hello", xs: _*)
  }
}
```
now gives

`val p4: java.nio.file.Path = java.nio.file.Paths.get("Hello", xs)` (i.e. there's no call to wrapXArray)