### PR TITLE
Fix #3873: Properly unpickle shared TypeTrees

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1054,8 +1054,12 @@ class TreeUnpickler(reader: TastyReader,
       setPos(start, tree)
     }
 
-    def readTpt()(implicit ctx: Context) =
-      if (nextByte == SHAREDterm || isTypeTreeTag(nextUnsharedTag)) readTerm()
+    def readTpt()(implicit ctx: Context): Tree =
+      if (nextByte == SHAREDterm) {
+        readByte()
+        forkAt(readAddr()).readTpt()
+      }
+      else if (isTypeTreeTag(nextByte)) readTerm()
       else {
         val start = currentAddr
         val tp = readType()

--- a/tests/pos/i3873.scala
+++ b/tests/pos/i3873.scala
@@ -1,0 +1,6 @@
+object Test {
+  inline def sum2(ys: List[Int]): Unit = {
+    ys.foldLeft(1)
+  }
+  val h1: ((List[Int]) => Unit) = sum2
+}


### PR DESCRIPTION
When a TypeTree is represented by a SHAREDterm, we need to follow the
SHAREDterm and call `readTpt()` again. We cannot rely on `readTerm()`
following the SHAREDterm for us because a TypeTree can be pickled as
just a type.