### PR TITLE
Fix dotd command after doc-tool dep update

### DIFF
--- a/dist/bin/dotd
+++ b/dist/bin/dotd
@@ -35,6 +35,7 @@ DOTTY_DOC_LIB=$(find_lib "*dotty-doc*")
 # Set flexmark deps:
 FLEXMARK_LIBS=""
 FLEXMARK_LIBS+=$(find_lib "*flexmark-0*")$PSEP
+FLEXMARK_LIBS+=$(find_lib "*flexmark-formatter*")$PSEP
 FLEXMARK_LIBS+=$(find_lib "*flexmark-ext-anchorlink*")$PSEP
 FLEXMARK_LIBS+=$(find_lib "*flexmark-ext-autolink*")$PSEP
 FLEXMARK_LIBS+=$(find_lib "*flexmark-ext-emoji*")$PSEP


### PR DESCRIPTION
The problem is the library flexmark gets refactored in the
updated version: a new jar `flexmark-formatter` needs to be
added to the path.