### PR TITLE
Implement AppliedTermRef (singleton types for term-level applications)

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -699,6 +699,15 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
             false
         }
         compareTypeBounds
+      case tp2: AppliedTermRef =>
+        // TODO(gsps): Check whether rule or position thereof should change
+        def compareAppliedTerm = tp1 match {
+          case tp1: AppliedTermRef =>
+            sameLength(tp1.args, tp2.args) && isSubType(tp1.fn, tp2.fn) &&
+              tp1.args.zip(tp2.args).forall((arg1, arg2) => isSubType(arg1, arg2))
+          case _ => fourthTry
+        }
+        compareAppliedTerm
       case tp2: AnnotatedType if tp2.isRefining =>
         (tp1.derivesAnnotWith(tp2.annot.sameAnnotation) || defn.isBottomType(tp1)) &&
         recur(tp1, tp2.parent)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -91,6 +91,9 @@ class TastyPrinter(bytes: Array[Byte])(implicit ctx: Context) {
                  POLYtype | TYPELAMBDAtype =>
               printTree()
               until(end) { printName(); printTree() }
+            case APPLIEDTERMREF =>
+              printTree()
+              until(end) { printTree() }
             case PARAMtype =>
               printNat(); printNat()
             case _ =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -167,6 +167,9 @@ class TreePickler(pickler: TastyPickler) {
     case AppliedType(tycon, args) =>
       writeByte(APPLIEDtype)
       withLength { pickleType(tycon); args.foreach(pickleType(_)) }
+    case AppliedTermRef(fn, args) =>
+      writeByte(APPLIEDTERMREF)
+      withLength { pickleType(fn); args.foreach(pickleType(_)) }
     case ConstantType(value) =>
       pickleConstant(value)
     case tpe: NamedType =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -344,6 +344,8 @@ class TreeUnpickler(reader: TastyReader,
                 // Eta expansion of the latter puts readType() out of the expression.
             case APPLIEDtype =>
               readType().appliedTo(until(end)(readType()))
+            case APPLIEDTERMREF =>
+              AppliedTermRef(readType().asInstanceOf[SingletonType], until(end)(readType()))
             case TYPEBOUNDS =>
               val lo = readType()
               if nothingButMods(end) then

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -142,6 +142,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
         toTextRef(tp) ~ ".type"
       case tp: TermRef if tp.denot.isOverloaded =>
         "<overloaded " ~ toTextRef(tp) ~ ">"
+      case tp: AppliedTermRef =>
+        "{" ~ toTextRef(tp) ~ "}"
       case tp: TypeRef =>
         if (printWithoutPrefix.contains(tp.symbol))
           toText(tp.name)
@@ -291,8 +293,11 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case tp: TermRef =>
         toTextPrefix(tp.prefix) ~ selectionString(tp)
       case AppliedTermRef(fn, args) =>
-        // TODO(gsps): Print AppliedTermRef as in surface syntax (using curly braces)
-        (toTextRef(fn) ~ "(" ~ Text(args map argText, ", ") ~ ")").close
+        val argTexts = args.map {
+          case arg: SingletonType => toTextRef(arg)
+          case arg => argText(arg)
+        }
+        (toTextRef(fn) ~ "(" ~ Text(argTexts, ", ") ~ ")").close
       case tp: ThisType =>
         nameString(tp.cls) + ".this"
       case SuperType(thistpe: SingletonType, _) =>

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -65,7 +65,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
           if (defn.isCompiletimeAppliedType(tycon.typeSymbol)) tp.tryCompiletimeConstantFold
           else tycon.dealias.appliedTo(args)
         case tp @ AppliedTermRef(fn, args) =>
-          tp.derivedAppliedTermRef(homogenize(tp), args.mapConserve(homogenize))
+          tp.derivedAppliedTermRef(homogenize(fn), args.mapConserve(homogenize))
         case _ =>
           tp
       }

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -64,6 +64,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
         case tp @ AppliedType(tycon, args) =>
           if (defn.isCompiletimeAppliedType(tycon.typeSymbol)) tp.tryCompiletimeConstantFold
           else tycon.dealias.appliedTo(args)
+        case tp @ AppliedTermRef(fn, args) =>
+          tp.derivedAppliedTermRef(homogenize(tp), args.mapConserve(homogenize))
         case _ =>
           tp
       }
@@ -288,6 +290,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
     tp match {
       case tp: TermRef =>
         toTextPrefix(tp.prefix) ~ selectionString(tp)
+      case AppliedTermRef(fn, args) =>
+        // TODO(gsps): Print AppliedTermRef as in surface syntax (using curly braces)
+        (toTextRef(fn) ~ "(" ~ Text(args map argText, ", ") ~ ")").close
       case tp: ThisType =>
         nameString(tp.cls) + ".this"
       case SuperType(thistpe: SingletonType, _) =>

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -514,13 +514,14 @@ object Erasure {
       ref(meth).appliedToArgs(args.toList ++ followingArgs)
     }
 
-    private def protoArgs(pt: Type, methTp: Type): List[untpd.Tree] = (pt, methTp) match {
-      case (pt: FunProto, methTp: MethodType) if methTp.isErasedMethod =>
-        protoArgs(pt.resType, methTp.resType)
-      case (pt: FunProto, methTp: MethodType) =>
-        pt.args ++ protoArgs(pt.resType, methTp.resType)
-      case _ => Nil
-    }
+    private def protoArgs(pt: Type, methTp: Type)(implicit ctx: Context): List[untpd.Tree] =
+      (pt, methTp.stripPoly) match {
+        case (pt: FunProto, methTp: MethodType) if methTp.isErasedMethod =>
+          protoArgs(pt.resType, methTp.resType)
+        case (pt: FunProto, methTp: MethodType) =>
+          pt.args ++ protoArgs(pt.resType, methTp.resType)
+        case _ => Nil
+      }
 
     override def typedTypeApply(tree: untpd.TypeApply, pt: Type)(implicit ctx: Context): Tree = {
       val ntree = interceptTypeApply(tree.asInstanceOf[TypeApply])(ctx.withPhase(ctx.erasurePhase)).withSpan(tree.span)

--- a/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -231,7 +231,7 @@ trait FullParameterization {
     else {
       // this type could have changed on forwarding. Need to insert a cast.
       originalDef.vparamss.foldLeft(fun)((acc, vparams) => {
-        val meth = acc.tpe.asInstanceOf[MethodType]
+        val meth = acc.tpe.stripPoly.asInstanceOf[MethodType]
         val paramTypes = meth.instantiateParamInfos(vparams.map(_.tpe))
         acc.appliedToArgs(
           vparams.lazyZip(paramTypes).map((vparam, paramType) => {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -869,6 +869,7 @@ trait Implicits { self: Typer =>
               success(Literal(Constant(())))
             case n: TermRef =>
               success(ref(n))
+            // TODO(gsps): Handle AppliedTermRef
             case tp =>
               EmptyTree
           }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -424,13 +424,9 @@ trait TypeAssigner {
     val fnTpe = fn.tpe
     val ownType = fnTpe.widen match {
       case methTp: MethodType =>
-        if (sameLength(methTp.paramInfos, args) || ctx.phase.prev.relaxedTyping) {
-          val argTpes = args.tpes
-          if (!ctx.erasedTypes && fnTpe.isStable && argTpes.forall(_.isStable))
-            AppliedTermRef(fnTpe, argTpes)
-          else
-            applicationResultType(methTp, argTpes)
-        } else
+        if (sameLength(methTp.paramInfos, args) || ctx.phase.prev.relaxedTyping)
+          AppliedTermRef.make(fnTpe, args.tpes)
+        else
           errorType(i"wrong number of arguments at ${ctx.phase.prev} for $methTp: $fnTpe, expected: ${methTp.paramInfos.length}, found: ${args.length}", tree.sourcePos)
       case t =>
         if (ctx.settings.Ydebug.value) new FatalError("").printStackTrace()

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -160,6 +160,7 @@ SimpleType        ::=  SimpleType TypeArgs                                      
                     |  ‘(’ ArgTypes ‘)’                                         Tuple(ts)
                     |  ‘?’ SubtypeBounds
                     |  Refinement                                               RefinedTypeTree(EmptyTree, refinement)
+                    |  `{` PostfixExpr `}`                                      SingletonTypeTree(expr)
                     |  SimpleLiteral                                            SingletonTypeTree(l)
                     |  ‘$’ ‘{’ Block ‘}’
 ArgTypes          ::=  Type {‘,’ Type}

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -126,6 +126,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   THIS                  clsRef_Type                                -- cls.this
                   RECthis               recType_ASTRef                             -- The `this` in a recursive refined type `recType`.
                   SHAREDtype            path_ASTRef                                -- link to previously serialized path
+                  APPLIEDTERMREF Length fn_Type arg_Type*                          -- The stable result of `fn` applied to `arg`s
 
   Constant      = UNITconst                                                        -- ()
                   FALSEconst                                                       -- false
@@ -254,7 +255,7 @@ object TastyFormat {
 
   final val header: Array[Int] = Array(0x5C, 0xA1, 0xAB, 0x1F)
   val MajorVersion: Int = 20
-  val MinorVersion: Int = 0
+  val MinorVersion: Int = 1
 
   /** Tags used to serialize names, should update [[nameTagToString]] if a new constant is added */
   class NameTags {
@@ -453,6 +454,7 @@ object TastyFormat {
   final val ANNOTATION = 173
   final val TERMREFin = 174
   final val TYPEREFin = 175
+  final val APPLIEDTERMREF = 176
 
   final val METHODtype = 180
   final val ERASEDMETHODtype = 181
@@ -660,6 +662,7 @@ object TastyFormat {
     case SUPERtype => "SUPERtype"
     case TERMREFin => "TERMREFin"
     case TYPEREFin => "TYPEREFin"
+    case APPLIEDTERMREF => "APPLIEDTERMREF"
 
     case REFINEDtype => "REFINEDtype"
     case REFINEDtpt => "REFINEDtpt"

--- a/tests/init/neg/private.scala
+++ b/tests/init/neg/private.scala
@@ -1,5 +1,5 @@
 class A(a: Int) {
-  a + 3
+  val _ = a + 3
   def foo() = a * 2
 }
 

--- a/tests/neg/appliedTerm.scala
+++ b/tests/neg/appliedTerm.scala
@@ -1,0 +1,25 @@
+object SimpleEqs {
+  val x = 1
+  val y: {x} = x
+  implicitly[{x + 1} =:= {y}]  // error
+  implicitly[{x + 1} =:= {y + 2}]  // error
+  implicitly[{x + 1} =:= {1 + y}]  // error: TypeComparer doesn't know about commutativity
+
+  val b = true
+  implicitly[{b} =:= {b}]
+  implicitly[{!b} =:= {!b}]
+  implicitly[{!b} =:= {b}]  // error
+}
+
+
+object Stability {
+  def f1(x: Int): Int = x
+  def f2(x: Int): {x} = x
+
+  val x = 1
+  implicitly[{f1(x)} =:= {x}]  // error: f1 is not considered stable  // error: f1's result type is not precise enough
+  implicitly[{f1(x)} =:= {f1(x)}]  // error: f1 is not considered stable  // error: f1 is not considered stable
+  implicitly[{f2(x)} =:= {x}]
+  implicitly[{f2(x)} =:= {f2(x)}]
+  implicitly[{f1(x)} =:= {f2(x)}]  // error: f1 is not considered stable  // error: f1's result type is not precise enough
+}

--- a/tests/pos/appliedTerm.scala
+++ b/tests/pos/appliedTerm.scala
@@ -1,0 +1,100 @@
+object SimpleEqs {
+  val x = 1
+  val y: {x} = x
+
+  type YPlusOne = {y + 1}
+
+  implicitly[{x + 1} =:= {y + 1}]
+  implicitly[{x + 1} =:= YPlusOne]
+}
+
+
+object AvoidLocalRefs {
+  type Id[T] = T
+
+  val x = 1
+  def y = { val a: {x} = x; val t: Id[{a + 1}] = a + 1; t }
+  def z: {x + 1} = { val a: {x} = x; val t: Id[{a + 1}] = a + 1; t }
+
+  val _ = { val a = 0; a + 1 }
+  val _ = { val a = 0; 1 + a }
+}
+
+
+object Bounds {
+  @annotation.implicitNotFound(msg = "Cannot prove that ${B} holds.")
+  sealed abstract class P[B <: Boolean](val b: B)
+  private[this] val prop_singleton = new P[true](true) {}
+  object P {
+    def assume(b: Boolean): P[b.type] = prop_singleton.asInstanceOf[P[b.type]]
+  }
+
+  def if_(cond: Boolean): (P[cond.type] ?=> Unit) => Unit =
+    thn => if (cond) thn(using P.assume(cond))
+
+
+  // Bounds-checked
+
+  def index(k: Int)(implicit ev: P[{k >= 0}]): Int = k
+
+  def run(i: Int) =
+    if_(i >= 0) {
+      index(i)
+    }
+
+
+  // Boxed value with a predicate
+
+  class PredBox[T, B <: Boolean](val v: T)(val p: P[B])
+  object PredBox {
+    def apply[T, B <: Boolean](v: T)(implicit ev: P[B]) = new PredBox[T, B](v)(ev)
+  }
+
+  def run2(i: Int) =
+    if_(i != 0) {
+      PredBox[Int, {i != 0}](i)
+    }
+}
+
+
+object ArithmeticIdentities {
+  type SInt = Int & Singleton
+
+  class DecomposeHelper[V <: SInt](val v: V) {
+    import DecomposeHelper._
+    def asSumOf[X <: SInt, Y <: SInt](x: X, y: Y)(implicit ev: {v} =:= {x + y}): SumOf[{x}, {y}] = SumOf(x, y)(ev(v))
+  }
+
+  object DecomposeHelper {
+    /* Axioms */
+    sealed trait Decomposition[V <: SInt]
+    case class SumOf[X <: SInt, Y <: SInt](x: X, y: Y)(val v: {x + y}) extends Decomposition[{v}] {
+      def commuted: SumOf[Y, X] = SumOf(y, x)(v.asInstanceOf[{y + x}])
+    }
+  }
+
+  implicit def toDecomposeHelper[V <: Int](v: V): DecomposeHelper[v.type] = new DecomposeHelper(v)
+
+
+  // Let's "show" that x + 1 == 1 + x
+
+  val x = 123
+  (x + 1).asSumOf(x, 1).v: {x + 1}
+  (x + 1).asSumOf(x, 1).commuted.v: {1 + x}
+}
+
+
+object Matrices {
+  type SInt = Int & Singleton
+
+  case class Matrix[M <: SInt, N <: SInt](m: M, n: N) {
+    val size: {m * n} = m * n
+  }
+
+  val a: 123 = 123
+  val b: Int = ???
+  val mat = Matrix(a, b)
+  val _ = mat.m: 123
+  val _ = mat.n: b.type
+  val _ = mat.size: {123 * b}
+}


### PR DESCRIPTION
This PR implements `AppliedTermRef`, a singleton type representing a term-level application precisely. `AppliedTermRef`s are currently only introduced when they are stable, that is, when both the function and the arguments are.

The PR includes several additional changes to allow interaction and testing of `AppliedTermRef`s:

- Previously no methods were marked stable, making it impossible to take advantage of the new singletons. As a starting point, we now mark methods on primitive value classes stable. Until an effect system capable of proving purity has landed, it might make sense to allow users to assume purity for user-defined methods (e.g. using an annotation).
- Similarly to other precise types `AppliedTermRef`s are widened away unless specifically expected on declaration sites. This prompts the need for an explicit syntax of singleton types more complex than `p.a.t.h.type`. For this purpose we add an alternative syntax for singleton types: a type tree of the form `{ expr }` is translated to the singleton type `T` of `expr`, provided that `T` is stable.

A simple example:
```scala
val x = 1
val y: {x} = x
implicitly[{x + 1} =:= {y + 1}]  // works
```

To Dos:

- [x] ~~Bug: Missing denotation / NoType upon accessing underlying type of inter-parameter dependency.~~ _Deferred. I suggest tackling this as a separate issue -- I think the problem lies in how parameter types are integrated into `MethodType`s and existed before this PR, but afaict could not be exercised previously._
- [ ] Implement translation of `AppliedTermRef` for sbt API extraction. _Not sure how to proceed with this. Can we map `AppliedTermRef`s to existing `xsbti.api.Tree`s, or do we need a new subclass?_