### PR TITLE
Fix #3144: more aggressively check unreachability

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -510,10 +510,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     // convert top-level type shape into "conjunctive normal form"
     def cnf(tp: Type): Type = tp match {
       case AndType(OrType(l, r), tp)      =>
-        val tp1 = cnf(tp)
-        val l1  = cnf(l)
-        val r1  = cnf(r)
-        OrType(cnf(AndType(l1, tp1)), cnf(AndType(r1, tp1)))
+        OrType(cnf(AndType(l, tp)), cnf(AndType(r, tp)))
       case AndType(tp, o: OrType)         =>
         cnf(AndType(o, tp))
       case AndType(l, r)                  =>
@@ -533,9 +530,9 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         val tp1 = tp.derivedRefinedType(parent1, refinedName = tp.refinedName, refinedInfo = tp.refinedInfo)
 
         if (parent1.ne(tp.parent)) cnf(tp1) else tp1
-      case tp: TypeAlias =>
+      case tp: TypeAlias                  =>
         cnf(tp.alias)
-      case _                           =>
+      case _                              =>
         tp
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -575,9 +575,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
       case tp: RefinedType =>
         recur(tp.parent)
       case tp: TypeRef =>
-        recur(tp.prefix) &&
-        !(tp.classSymbol.is(Sealed) && tp.classSymbol.is(AbstractOrTrait) && tp.classSymbol.children.isEmpty) &&
-        !(tp.classSymbol.is(AbstractFinal))
+        recur(tp.prefix) && !(tp.classSymbol.is(AbstractFinal))
       case _ =>
         true
     }
@@ -706,8 +704,10 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
   /** Abstract sealed types, or-types, Boolean and Java enums can be decomposed */
   def canDecompose(tp: Type): Boolean = {
     val dealiasedTp = tp.dealias
-    val res = tp.classSymbol.is(allOf(Abstract, Sealed)) ||
-      tp.classSymbol.is(allOf(Trait, Sealed)) ||
+    val res =
+      (tp.classSymbol.is(Sealed) &&
+        tp.classSymbol.is(AbstractOrTrait) &&
+        tp.classSymbol.children.nonEmpty ) ||
       dealiasedTp.isInstanceOf[OrType] ||
       (dealiasedTp.isInstanceOf[AndType] && {
         val and = dealiasedTp.asInstanceOf[AndType]

--- a/tests/patmat/3144.check
+++ b/tests/patmat/3144.check
@@ -1,0 +1,1 @@
+7: Match case Unreachable

--- a/tests/patmat/3144.check
+++ b/tests/patmat/3144.check
@@ -1,1 +1,1 @@
-7: Match case Unreachable
+6: Pattern Match Exhaustivity: _: Foo

--- a/tests/patmat/3144c.check
+++ b/tests/patmat/3144c.check
@@ -1,0 +1,1 @@
+7: Match case Unreachable

--- a/tests/patmat/3144c.check
+++ b/tests/patmat/3144c.check
@@ -1,1 +1,1 @@
-7: Match case Unreachable
+6: Pattern Match Exhaustivity: _: Foo

--- a/tests/patmat/3144c.scala
+++ b/tests/patmat/3144c.scala
@@ -1,0 +1,9 @@
+sealed trait Foo
+case class Bar(s: String)
+
+object Test {
+  def shouldError(foo: Foo): String =
+    foo match {
+      case bar: Bar => bar.s
+    }
+}

--- a/tests/patmat/3145.scala
+++ b/tests/patmat/3145.scala
@@ -1,0 +1,43 @@
+object Test {
+  sealed trait Foo
+  class Bar(val s: String) extends Foo
+  sealed abstract class Baz(val s: String) extends Foo
+
+  val f: Foo => String = {
+    case bar: Bar => bar.s
+    case baz: Baz => baz.s
+  }
+}
+
+object Test2 {
+  sealed trait Foo
+  class Bar extends Foo
+  sealed trait Baz extends Foo
+
+  def f(x: Foo) = x match {
+    case bar: Bar => 1
+    case baz: Baz => 2
+  }
+}
+
+object Test3 {
+  sealed trait Foo
+  class Bar extends Foo
+  sealed trait Baz extends Foo
+
+  def foo = {
+    val x: Foo = new Baz {}
+    x match {
+      case bar: Bar => 1
+      case baz: Baz => 2
+    }
+  }
+
+  def bar = {
+    val x: Baz  = new Baz {}
+    x match {
+      case bar: Bar => 1
+      case baz: Baz => 2
+    }
+  }
+}

--- a/tests/patmat/andtype-opentype-interaction.check
+++ b/tests/patmat/andtype-opentype-interaction.check
@@ -2,5 +2,6 @@
 27: Pattern Match Exhaustivity: _: SealedClass & OpenTrait & OpenTrait2, _: AbstractClass & OpenTrait & OpenTrait2, _: Clazz & OpenTrait & OpenTrait2, _: Trait & OpenTrait & OpenTrait2
 31: Pattern Match Exhaustivity: _: Trait & OpenClass
 35: Pattern Match Exhaustivity: _: Trait & OpenTrait & OpenClass
+40: Match case Unreachable
 43: Pattern Match Exhaustivity: _: Trait & OpenAbstractClass
 47: Pattern Match Exhaustivity: _: Trait & OpenClass & OpenTrait & OpenClassSubclass

--- a/tests/patmat/andtype-opentype-interaction.check
+++ b/tests/patmat/andtype-opentype-interaction.check
@@ -1,7 +1,7 @@
-23: Pattern Match Exhaustivity: _: SealedClass & OpenTrait, _: AbstractClass & OpenTrait, _: Clazz & OpenTrait, _: Trait & OpenTrait
-27: Pattern Match Exhaustivity: _: SealedClass & OpenTrait & OpenTrait2, _: AbstractClass & OpenTrait & OpenTrait2, _: Clazz & OpenTrait & OpenTrait2, _: Trait & OpenTrait & OpenTrait2
-31: Pattern Match Exhaustivity: _: Trait & OpenClass
-35: Pattern Match Exhaustivity: _: Trait & OpenTrait & OpenClass
+23: Pattern Match Exhaustivity: _: SealedAbstractClass & OpenTrait, _: SealedClass & OpenTrait, _: SealedTrait & OpenTrait, _: AbstractClass & OpenTrait, _: Clazz & OpenTrait, _: Trait & OpenTrait
+27: Pattern Match Exhaustivity: _: SealedAbstractClass & OpenTrait & OpenTrait2, _: SealedClass & OpenTrait & OpenTrait2, _: SealedTrait & OpenTrait & OpenTrait2, _: AbstractClass & OpenTrait & OpenTrait2, _: Clazz & OpenTrait & OpenTrait2, _: Trait & OpenTrait & OpenTrait2
+31: Pattern Match Exhaustivity: _: SealedTrait & OpenClass, _: Trait & OpenClass
+35: Pattern Match Exhaustivity: _: SealedTrait & OpenTrait & OpenClass, _: Trait & OpenTrait & OpenClass
 40: Match case Unreachable
-43: Pattern Match Exhaustivity: _: Trait & OpenAbstractClass
-47: Pattern Match Exhaustivity: _: Trait & OpenClass & OpenTrait & OpenClassSubclass
+43: Pattern Match Exhaustivity: _: SealedTrait & OpenAbstractClass, _: Trait & OpenAbstractClass
+47: Pattern Match Exhaustivity: _: SealedTrait & OpenClass & OpenTrait & OpenClassSubclass, _: Trait & OpenClass & OpenTrait & OpenClassSubclass

--- a/tests/patmat/andtype-refinedtype-interaction.check
+++ b/tests/patmat/andtype-refinedtype-interaction.check
@@ -1,6 +1,9 @@
 32: Pattern Match Exhaustivity: _: Trait & C1{x: Int}
+37: Match case Unreachable
+43: Match case Unreachable
 48: Pattern Match Exhaustivity: _: Clazz & (C1 | C2 | T1){x: Int} & (C3 | C4 | T2){x: Int}, _: Trait & (C1 | C2 | T1){x: Int} & (C3 | C4 | T2){x: Int}
 54: Pattern Match Exhaustivity: _: Trait & (C1 | C2 | T1){x: Int} & C3{x: Int}
+60: Match case Unreachable
 65: Pattern Match Exhaustivity: _: Trait & (C1 | C2){x: Int} & (C3 | SubC1){x: Int}
 72: Pattern Match Exhaustivity: _: Trait & (T1 & (C1 | SubC2)){x: Int} & (T2 & (C2 | C3 | SubC1)){x: Int} &
   SubSubC1{x: Int}

--- a/tests/patmat/i2253.check
+++ b/tests/patmat/i2253.check
@@ -1,3 +1,5 @@
-27: Pattern Match Exhaustivity: HasIntXIntM, HasIntXStringM
-28: Pattern Match Exhaustivity: HasIntXIntM
+28: Pattern Match Exhaustivity: HasIntXIntM, HasIntXStringM
 29: Pattern Match Exhaustivity: HasIntXIntM
+29: Match case Unreachable
+30: Pattern Match Exhaustivity: HasIntXIntM
+30: Match case Unreachable

--- a/tests/patmat/i2253.scala
+++ b/tests/patmat/i2253.scala
@@ -22,6 +22,7 @@ object HasIntXIntM extends S {
 }
 
 trait T
+case class TA(val x: Int) extends T with S
 
 class Test {
   def onlyIntX(s: S { val x: Int }) = s match { case _: T => ; }

--- a/tests/patmat/patmatexhaust.check
+++ b/tests/patmat/patmatexhaust.check
@@ -4,6 +4,7 @@
 49: Pattern Match Exhaustivity: _: Gp
 59: Pattern Match Exhaustivity: Nil
 75: Pattern Match Exhaustivity: _: B
+87: Pattern Match Exhaustivity: _: C1
 100: Pattern Match Exhaustivity: _: C1
 114: Pattern Match Exhaustivity: D2(), D1
 126: Pattern Match Exhaustivity: _: C1

--- a/tests/patmat/patmatexhaust.scala
+++ b/tests/patmat/patmatexhaust.scala
@@ -84,7 +84,7 @@ class TestSealedExhaustive { // compile only
     case class C3() extends C
     case object C4 extends C
 
-    def ma10(x: C) = x match {  // exhaustive: abstract sealed C1 is dead end.
+    def ma10(x: C) = x match {  // treat abstract sealed C1 is as inhabited.
       case C3()     => true
       case C2 | C4  => true
     }

--- a/tests/patmat/t6450.scala
+++ b/tests/patmat/t6450.scala
@@ -1,5 +1,5 @@
 sealed abstract class FoundNode[T]
-// case class A[T](x: T) extends FoundNode[T]
+case class A[T](x: T) extends FoundNode[T]
 
 object Foo {
   val v: (Some[_], FoundNode[_]) = (???, ???)

--- a/tests/patmat/t8511.check
+++ b/tests/patmat/t8511.check
@@ -1,1 +1,1 @@
-18: Pattern Match Exhaustivity: Baz(), Bar(_)
+18: Pattern Match Exhaustivity: EatsExhaustiveWarning(_), Baz(), Bar(_)

--- a/tests/patmat/t9677.check
+++ b/tests/patmat/t9677.check
@@ -1,1 +1,0 @@
-20: Match case Unreachable

--- a/tests/patmat/virtpatmat_reach_sealed_unsealed.check
+++ b/tests/patmat/virtpatmat_reach_sealed_unsealed.check
@@ -1,3 +1,4 @@
 16: Pattern Match Exhaustivity: false
 18: Match case Unreachable
 19: Match case Unreachable
+20: Match case Unreachable


### PR DESCRIPTION
Fix #3144: more aggressively check unreachability.

Previously, we optimise by (1) skipping the check for the first clause; (2) don't intersect with the scrutinee type.

Based on #3888.