### PR TITLE
Implement f"" with quotes

### DIFF
--- a/compiler/src/dotty/tools/dotc/interpreter/Interpreter.scala
+++ b/compiler/src/dotty/tools/dotc/interpreter/Interpreter.scala
@@ -102,23 +102,6 @@ class Interpreter(implicit ctx: Context) {
       case tree: Ident if env.contains(tree.symbol) =>
         env(tree.symbol)
 
-      case tree: Apply =>
-        def prefixAndArgs(t: Tree, allArgs: List[Tree]): (Tree, List[Tree]) = t match {
-          case Apply(qual, args2) => prefixAndArgs(qual, args2 ::: allArgs)
-          case TypeApply(qual, _) => prefixAndArgs(qual, allArgs)
-          case Select(qual, _) => (qual, allArgs)
-        }
-        val (prefix, args) = prefixAndArgs(tree, Nil)
-
-        val evaluatedPrefix = interpretTreeImpl(prefix, env)
-
-        val clazz = evaluatedPrefix.getClass
-        val paramClasses = paramsSig(tree.symbol)
-        val interpretedArgs = args.map(arg => interpretTreeImpl(arg, env))
-
-        val method = getMethod(clazz, tree.symbol.name, paramClasses)
-        interpreted(method.invoke(evaluatedPrefix, interpretedArgs: _*))
-
       case Block(stats, expr) =>
         val env2 = stats.foldLeft(env)((acc, x) => interpretStat(x, acc))
         interpretTreeImpl(expr, env2)

--- a/compiler/src/dotty/tools/dotc/interpreter/Interpreter.scala
+++ b/compiler/src/dotty/tools/dotc/interpreter/Interpreter.scala
@@ -19,6 +19,7 @@ import java.net.URLClassLoader
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 
+
 /** Tree interpreter that can interpret
  *   * Literal constants
  *   * Calls to static methods

--- a/tests/run-with-compiler/f-interpolator.check
+++ b/tests/run-with-compiler/f-interpolator.check
@@ -1,0 +1,1 @@
+"StringContext(WrappedArray(abc, xyz))"

--- a/tests/run-with-compiler/f-interpolator.scala
+++ b/tests/run-with-compiler/f-interpolator.scala
@@ -1,0 +1,23 @@
+
+import dotty.tools.dotc.quoted.Runners._
+
+import scala.quoted._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+
+    val x: Expr[Int] = 5
+
+    println(fInterpolation(
+      new StringContext("abc", "xyz"),
+      '(Seq[Any](~x))
+    ).show)
+
+  }
+
+  def fInterpolation(sc: StringContext, args: Expr[Seq[Any]]): Expr[String] = {
+    assert(sc.parts.size - 1 == args.run.size)
+    sc.toString
+  }
+
+}

--- a/tests/run-with-compiler/f-interpolator.scala
+++ b/tests/run-with-compiler/f-interpolator.scala
@@ -10,13 +10,13 @@ object Test {
 
     println(fInterpolation(
       new StringContext("abc", "xyz"),
-      '(Seq[Any](~x))
+      Seq(x.asInstanceOf[Expr[Any]])
     ).show)
 
   }
 
-  def fInterpolation(sc: StringContext, args: Expr[Seq[Any]]): Expr[String] = {
-    assert(sc.parts.size - 1 == args.run.size)
+  def fInterpolation(sc: StringContext, args: Seq[Expr[Any]]): Expr[String] = {
+    assert(sc.parts.size - 1 == args.size)
     sc.toString
   }
 

--- a/tests/run/f-interpolator.check
+++ b/tests/run/f-interpolator.check
@@ -2,3 +2,29 @@ integer: 5
 string: l
 5, 6, hello
 5
+Bob is 1 years old
+Bob is  1 years old
+Bob will be 2 years old
+1+1 = 2
+Bob is 12 years old
+Bob is 12 years old
+Bob will be 13 years old
+12+1 = 13
+Bob is 123 years old
+Bob is 123 years old
+Bob will be 124 years old
+123+1 = 124
+Best price: 10.0
+Best price: 10.00
+10.0% discount included
+10.00% discount included
+Best price: 13.345
+Best price: 13.35
+13.345% discount included
+13.35% discount included
+
+0
+00
+
+0
+00

--- a/tests/run/f-interpolator.check
+++ b/tests/run/f-interpolator.check
@@ -1,3 +1,3 @@
-StringContext(List(List(abc, )))
-StringContext(List(List(abc, asf, )))
-StringContext(List(List(abc, , asf, )))
+integer: 5
+string: l
+5, 6, hello

--- a/tests/run/f-interpolator.check
+++ b/tests/run/f-interpolator.check
@@ -1,1 +1,3 @@
 StringContext(List(List(abc, )))
+StringContext(List(List(abc, asf, )))
+StringContext(List(List(abc, , asf, )))

--- a/tests/run/f-interpolator.check
+++ b/tests/run/f-interpolator.check
@@ -28,3 +28,31 @@ Best price: 13.35
 
 0
 00
+Bob is 1 years old
+Bob is  1 years old
+Bob will be 2 years old
+1+1 = 2
+Bob is 12 years old
+Bob is 12 years old
+Bob will be 13 years old
+12+1 = 13
+Bob is 123 years old
+Bob is 123 years old
+Bob will be 124 years old
+123+1 = 124
+Best price: 10.0
+Best price: 10.00
+10.0% discount included
+10.00% discount included
+Best price: 13.345
+Best price: 13.35
+13.345% discount included
+13.35% discount included
+Bob is 1 years old!
+Bob is 1%2d years old!
+===============
+Bob is 12 years old!
+Bob is 12%2d years old!
+===============
+Bob is 123 years old!
+Bob is 123%2d years old!

--- a/tests/run/f-interpolator.check
+++ b/tests/run/f-interpolator.check
@@ -1,3 +1,4 @@
 integer: 5
 string: l
 5, 6, hello
+5

--- a/tests/run/f-interpolator.check
+++ b/tests/run/f-interpolator.check
@@ -1,0 +1,1 @@
+StringContext(List(List(abc, )))

--- a/tests/run/f-interpolator/Interpolator_1.scala
+++ b/tests/run/f-interpolator/Interpolator_1.scala
@@ -10,9 +10,9 @@ object FInterpolation {
   @inline private def falsely(body: => Unit): Boolean = { body ; false }
 
   implicit class FInterpolatorHelper(val sc: StringContext) extends AnyVal {
-    inline def ff(arg1: Any): String = ~fInterpolation(sc, Seq('(arg1)))
-    inline def ff(arg1: Any, arg2: Any): String = ~fInterpolation(sc, Seq('(arg1), '(arg2)))
-    inline def ff(arg1: Any, arg2: Any, arg3: Any): String = ~fInterpolation(sc, Seq('(arg1), '(arg2), '(arg3)))
+    inline def ff(arg1: Any): String = ~interpolated(sc, Seq('(arg1)))
+    inline def ff(arg1: Any, arg2: Any): String = ~interpolated(sc, Seq('(arg1), '(arg2)))
+    inline def ff(arg1: Any, arg2: Any, arg3: Any): String = ~interpolated(sc, Seq('(arg1), '(arg2), '(arg3)))
     // ...
   }
 
@@ -47,7 +47,8 @@ object FInterpolation {
    *  7) "...${smth}[%illegalJavaConversion]" => error
    *  *Legal according to [[http://docs.oracle.com/javase/1.5.0/docs/api/java/util/Formatter.html]]
    */
-  def interpolated(parts: List[String], args: List[Expr[Any]]) = {
+  def interpolated(sc: StringContext, args: Seq[Expr[Any]]): Expr[String] = {
+    val parts = sc.parts
     val fstring  = new StringBuilder
     val argStack = Stack(args: _*)
 
@@ -149,7 +150,7 @@ object FInterpolation {
     }
 
     //q"{..$evals; new StringOps(${fstring.toString}).format(..$ids)}"
-    if (args.isEmpty && !fstring.contains("%")) fstring
+    if (args.isEmpty && !fstring.contains("%")) fstring.toString
     else {
       val format: Expr[String] = fstring.toString
       val args1: Expr[Seq[Any]] = liftSeq(args)

--- a/tests/run/f-interpolator/Interpolator_1.scala
+++ b/tests/run/f-interpolator/Interpolator_1.scala
@@ -9,7 +9,14 @@ object FInterpolation {
     // ...
   }
 
+  private def liftSeq(args: Seq[Expr[Any]]): Expr[Seq[Any]] = args match {
+    case x :: xs  => '{ (~x) +: ~(liftSeq(xs))  }
+    case Nil => '(Seq(): Seq[Any])
+  }
+
   def fInterpolation(sc: StringContext, args: Seq[Expr[Any]]): Expr[String] = {
-    sc.toString
+    val str: Expr[String] = sc.parts.mkString("")
+    val args1: Expr[Seq[Any]] = liftSeq(args)
+    '{  (~str).format(~args1: _*) }
   }
 }

--- a/tests/run/f-interpolator/Interpolator_1.scala
+++ b/tests/run/f-interpolator/Interpolator_1.scala
@@ -19,4 +19,350 @@ object FInterpolation {
     val args1: Expr[Seq[Any]] = liftSeq(args)
     '{  (~str).format(~args1: _*) }
   }
+
+  /** Every part except the first must begin with a conversion for
+   *  the arg that preceded it. If the conversion is missing, "%s"
+   *  is inserted.
+   *
+   *  In any other position, the only permissible conversions are
+   *  the literals (%% and %n) or an index reference (%1$ or %<).
+   *
+   *  A conversion specifier has the form:
+   *
+   *  [index$][flags][width][.precision]conversion
+   *
+   *  1) "...${smth}" => okay, equivalent to "...${smth}%s"
+   *  2) "...${smth}blahblah" => okay, equivalent to "...${smth}%sblahblah"
+   *  3) "...${smth}%" => error
+   *  4) "...${smth}%n" => okay, equivalent to "...${smth}%s%n"
+   *  5) "...${smth}%%" => okay, equivalent to "...${smth}%s%%"
+   *  6) "...${smth}[%legalJavaConversion]" => okay*
+   *  7) "...${smth}[%illegalJavaConversion]" => error
+   *  *Legal according to [[http://docs.oracle.com/javase/1.5.0/docs/api/java/util/Formatter.html]]
+   */
+  def interpolated(parts: List[Tree], args: List[Tree]) = {
+    val fstring  = new StringBuilder
+    val evals    = ListBuffer[ValDef]()
+    val ids      = ListBuffer[Ident]()
+    val argStack = Stack(args: _*)
+
+    // create a tmp val and add it to the ids passed to format
+    def defval(value: Tree, tpe: Type): Unit = {
+      val freshName = TermName(c.freshName("arg$"))
+      evals += ValDef(Modifiers(), freshName, TypeTree(tpe) setPos value.pos.focus, value) setPos value.pos
+      ids += Ident(freshName)
+    }
+    // Append the nth part to the string builder, possibly prepending an omitted %s first.
+    // Sanity-check the % fields in this part.
+    def copyPart(part: Tree, n: Int): Unit = {
+      import SpecifierGroups.{ Spec, Index }
+      val s0 = part match {
+        case Literal(Constant(x: String)) => x
+        case _ => throw new IllegalArgumentException("internal error: argument parts must be a list of string literals")
+      }
+      def escapeHatch: PartialFunction[Throwable, String] = {
+        // trailing backslash, octal escape, or other
+        case e: StringContext.InvalidEscapeException =>
+          def errPoint = part.pos withPoint (part.pos.point + e.index)
+          def octalOf(c: Char) = Character.digit(c, 8)
+          def alt = {
+            def altOf(i: Int) = i match {
+              case '\b' => "\\b"
+              case '\t' => "\\t"
+              case '\n' => "\\n"
+              case '\f' => "\\f"
+              case '\r' => "\\r"
+              case '\"' => "$" /* avoid lint warn */ +
+                "{'\"'} or a triple-quoted literal \"\"\"with embedded \" or \\u0022\"\"\""
+              case '\'' => "'"
+              case '\\' => """\\"""
+              case x    => "\\u%04x" format x
+            }
+            val suggest = {
+              val r = "([0-7]{1,3}).*".r
+              (s0 drop e.index + 1) match {
+                case r(n) => altOf { (0 /: n) { case (a, o) => (8 * a) + (o - '0') } }
+                case _    => ""
+              }
+            }
+            val txt =
+              if ("" == suggest) ""
+              else s", use $suggest instead"
+            txt
+          }
+          def badOctal = {
+            def msg(what: String) = s"Octal escape literals are $what$alt."
+            if (settings.future) {
+              c.error(errPoint, msg("unsupported"))
+              s0
+            } else {
+              currentRun.reporting.deprecationWarning(errPoint, msg("deprecated"), "2.11.0")
+              try StringContext.treatEscapes(s0) catch escapeHatch
+            }
+          }
+          if (e.index == s0.length - 1) {
+            c.error(errPoint, """Trailing '\' escapes nothing.""")
+            s0
+          } else if (octalOf(s0(e.index + 1)) >= 0) {
+            badOctal
+          } else {
+            c.error(errPoint, e.getMessage)
+            s0
+          }
+      }
+      val s  = try StringContext.processEscapes(s0) catch escapeHatch
+      val ms = fpat findAllMatchIn s
+
+      def errorLeading(op: Conversion) = op.errorAt(Spec, s"conversions must follow a splice; ${Conversion.literalHelp}")
+
+      def first = n == 0
+      // a conversion for the arg is required
+      if (!first) {
+        val arg = argStack.pop()
+        def s_%() = {
+          fstring append "%s"
+          defval(arg, AnyTpe)
+        }
+        def accept(op: Conversion) = {
+          if (!op.isLeading) errorLeading(op)
+          op.accepts(arg) match {
+            case Some(tpe) => defval(arg, tpe)
+            case None      =>
+          }
+        }
+        if (ms.hasNext) {
+          Conversion(ms.next, part.pos, args.size) match {
+            case Some(op) if op.isLiteral => s_%()
+            case Some(op) if op.indexed =>
+              if (op.index map (_ == n) getOrElse true) accept(op)
+              else {
+                // either some other arg num, or '<'
+                c.warning(op.groupPos(Index), "Index is not this arg")
+                s_%()
+              }
+            case Some(op) => accept(op)
+            case None     =>
+          }
+        } else s_%()
+      }
+      // any remaining conversions must be either literals or indexed
+      while (ms.hasNext) {
+        Conversion(ms.next, part.pos, args.size) match {
+          case Some(op) if first && op.hasFlag('<')   => op.badFlag('<', "No last arg")
+          case Some(op) if op.isLiteral || op.indexed => // OK
+          case Some(op) => errorLeading(op)
+          case None     =>
+        }
+      }
+      fstring append s
+    }
+
+    parts.zipWithIndex foreach {
+      case (part, n) => copyPart(part, n)
+    }
+
+    //q"{..$evals; new StringOps(${fstring.toString}).format(..$ids)}"
+    val format = fstring.toString
+    if (ids.isEmpty && !format.contains("%")) Literal(Constant(format))
+    else {
+      val scalaPackage = Select(Ident(nme.ROOTPKG), TermName("scala"))
+      val newStringOps = Select(
+        New(Select(Select(Select(scalaPackage,
+          TermName("collection")), TermName("immutable")), TypeName("StringOps"))),
+        termNames.CONSTRUCTOR
+      )
+      val expr =
+        Apply(
+          Select(
+            Apply(
+              newStringOps,
+              List(Literal(Constant(format)))),
+            TermName("format")),
+          ids.toList
+        )
+      val p = c.macroApplication.pos
+      Block(evals.toList, atPos(p.focus)(expr)) setPos p.makeTransparent
+    }
+  }
+
+  val fpat = """%(?:(\d+)\$)?([-#+ 0,(\<]+)?(\d+)?(\.\d+)?([tT]?[%a-zA-Z])?""".r
+  object SpecifierGroups extends Enumeration { val Spec, Index, Flags, Width, Precision, CC = Value }
+
+  val stdContextTags = new { val tc: c.type = c } with StdContextTags
+  import stdContextTags._
+  val tagOfFormattable = typeTag[Formattable]
+
+  /** A conversion specifier matched by `m` in the string part at `pos`,
+   *  with `argc` arguments to interpolate.
+   */
+  sealed trait Conversion {
+    def m: Match
+    def pos: Position
+    def argc: Int
+
+    import SpecifierGroups.{ Value => SpecGroup, _ }
+    private def maybeStr(g: SpecGroup) = Option(m group g.id)
+    private def maybeInt(g: SpecGroup) = maybeStr(g) map (_.toInt)
+    val index: Option[Int]     = maybeInt(Index)
+    val flags: Option[String]  = maybeStr(Flags)
+    val width: Option[Int]     = maybeInt(Width)
+    val precision: Option[Int] = maybeStr(Precision) map (_.drop(1).toInt)
+    val op: String             = maybeStr(CC) getOrElse ""
+
+    def cc: Char = if ("tT" contains op(0)) op(1) else op(0)
+
+    def indexed:   Boolean = index.nonEmpty || hasFlag('<')
+    def isLiteral: Boolean = false
+    def isLeading: Boolean = m.start(0) == 0
+    def verify:    Boolean = goodFlags && goodIndex
+    def accepts(arg: Tree): Option[Type]
+
+    val allFlags = "-#+ 0,(<"
+    def hasFlag(f: Char) = (flags getOrElse "") contains f
+    def hasAnyFlag(fs: String) = fs exists (hasFlag)
+
+    def badFlag(f: Char, msg: String) = {
+      val i = flags map (_.indexOf(f)) filter (_ >= 0) getOrElse 0
+      errorAtOffset(Flags, i, msg)
+    }
+    def groupPos(g: SpecGroup) = groupPosAt(g, 0)
+    def groupPosAt(g: SpecGroup, i: Int) = pos withPoint (pos.point + m.start(g.id) + i)
+    def errorAt(g: SpecGroup, msg: String) = c.error(groupPos(g), msg)
+    def errorAtOffset(g: SpecGroup, i: Int, msg: String) = c.error(groupPosAt(g, i), msg)
+
+    def noFlags = flags.isEmpty || falsely { errorAt(Flags, "flags not allowed") }
+    def noWidth = width.isEmpty || falsely { errorAt(Width, "width not allowed") }
+    def noPrecision = precision.isEmpty || falsely { errorAt(Precision, "precision not allowed") }
+    def only_-(msg: String) = {
+      val badFlags = (flags getOrElse "") filterNot { case '-' | '<' => true case _ => false }
+      badFlags.isEmpty || falsely { badFlag(badFlags(0), s"Only '-' allowed for $msg") }
+    }
+    protected def okFlags: String = allFlags
+    def goodFlags = {
+      val badFlags = flags map (_ filterNot (okFlags contains _))
+      for (bf <- badFlags; f <- bf) badFlag(f, s"Illegal flag '$f'")
+      badFlags.getOrElse("").isEmpty
+    }
+    def goodIndex = {
+      if (index.nonEmpty && hasFlag('<'))
+        c.warning(groupPos(Index), "Argument index ignored if '<' flag is present")
+      val okRange = index map (i => i > 0 && i <= argc) getOrElse true
+      okRange || hasFlag('<') || falsely { errorAt(Index, "Argument index out of range") }
+    }
+    /** Pick the type of an arg to format from among the variants
+     *  supported by a conversion.  This is the type of the temporary,
+     *  so failure results in an erroneous assignment to the first variant.
+     *  A more complete message would be nice.
+     */
+    def pickAcceptable(arg: Tree, variants: Type*): Option[Type] =
+      variants find (arg.tpe <:< _) orElse (
+        variants find (c.inferImplicitView(arg, arg.tpe, _) != EmptyTree)
+      ) orElse Some(variants(0))
+  }
+  object Conversion {
+    import SpecifierGroups.{ Spec, CC }
+    def apply(m: Match, p: Position, n: Int): Option[Conversion] = {
+      def badCC(msg: String) = {
+        val dk = new ErrorXn(m, p)
+        val at = if (dk.op.isEmpty) Spec else CC
+        dk.errorAt(at, msg)
+      }
+      def cv(cc: Char) = cc match {
+        case 'b' | 'B' | 'h' | 'H' | 's' | 'S' =>
+          new GeneralXn(m, p, n)
+        case 'c' | 'C' =>
+          new CharacterXn(m, p, n)
+        case 'd' | 'o' | 'x' | 'X' =>
+          new IntegralXn(m, p, n)
+        case 'e' | 'E' | 'f' | 'g' | 'G' | 'a' | 'A' =>
+          new FloatingPointXn(m, p, n)
+        case 't' | 'T' =>
+          new DateTimeXn(m, p, n)
+        case '%' | 'n' =>
+          new LiteralXn(m, p, n)
+        case _ =>
+          badCC(s"illegal conversion character '$cc'")
+          null
+      }
+      Option(m group CC.id) map (cc => cv(cc(0))) match {
+        case Some(x) => Option(x) filter (_.verify)
+        case None    =>
+          badCC(s"Missing conversion operator in '${m.matched}'; $literalHelp")
+          None
+      }
+    }
+    val literalHelp = "use %% for literal %, %n for newline"
+  }
+  class GeneralXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+    def accepts(arg: Tree) = cc match {
+      case 's' | 'S' if hasFlag('#') => pickAcceptable(arg, tagOfFormattable.tpe)
+      case 'b' | 'B' => if (arg.tpe <:< NullTpe) Some(NullTpe) else Some(BooleanTpe)
+      case _         => Some(AnyTpe)
+    }
+    override protected def okFlags = cc match {
+      case 's' | 'S' => "-#<"
+      case _         => "-<"
+    }
+  }
+  class LiteralXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+    import SpecifierGroups.Width
+    override val isLiteral = true
+    override def verify = op match {
+      case "%" => super.verify && noPrecision && truly(width foreach (_ => c.warning(groupPos(Width), "width ignored on literal")))
+      case "n" => noFlags && noWidth && noPrecision
+    }
+    override protected val okFlags = "-"
+    def accepts(arg: Tree) = None
+  }
+  class CharacterXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+    override def verify = super.verify && noPrecision && only_-("c conversion")
+    def accepts(arg: Tree) = pickAcceptable(arg, CharTpe, ByteTpe, ShortTpe, IntTpe)
+  }
+  class IntegralXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+    override def verify = {
+      def d_# = (cc == 'd' && hasFlag('#') &&
+        truly { badFlag('#', "# not allowed for d conversion") }
+      )
+      def x_comma = (cc != 'd' && hasFlag(',') &&
+        truly { badFlag(',', "',' only allowed for d conversion of integral types") }
+      )
+      super.verify && noPrecision && !d_# && !x_comma
+    }
+    override def accepts(arg: Tree) = {
+      def isBigInt = arg.tpe <:< tagOfBigInt.tpe
+      val maybeOK = "+ ("
+      def bad_+ = cond(cc) {
+        case 'o' | 'x' | 'X' if hasAnyFlag(maybeOK) && !isBigInt =>
+          maybeOK filter hasFlag foreach (badf =>
+            badFlag(badf, s"only use '$badf' for BigInt conversions to o, x, X"))
+          true
+      }
+      if (bad_+) None else pickAcceptable(arg, IntTpe, LongTpe, ByteTpe, ShortTpe, tagOfBigInt.tpe)
+    }
+  }
+  class FloatingPointXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+    override def verify = super.verify && (cc match {
+      case 'a' | 'A' =>
+        val badFlags = ",(" filter hasFlag
+        noPrecision && badFlags.isEmpty || falsely {
+          badFlags foreach (badf => badFlag(badf, s"'$badf' not allowed for a, A"))
+        }
+      case _ => true
+    })
+    def accepts(arg: Tree) = pickAcceptable(arg, DoubleTpe, FloatTpe, tagOfBigDecimal.tpe)
+  }
+  class DateTimeXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+    import SpecifierGroups.CC
+    def hasCC = (op.length == 2 ||
+      falsely { errorAt(CC, "Date/time conversion must have two characters") })
+    def goodCC = ("HIklMSLNpzZsQBbhAaCYyjmdeRTrDFc" contains cc) ||
+      falsely { errorAtOffset(CC, 1, s"'$cc' doesn't seem to be a date or time conversion") }
+    override def verify = super.verify && hasCC && goodCC && noPrecision && only_-("date/time conversions")
+    def accepts(arg: Tree) = pickAcceptable(arg, LongTpe, tagOfCalendar.tpe, tagOfDate.tpe)
+  }
+  class ErrorXn(val m: Match, val pos: Position) extends Conversion {
+    val argc = 0
+    override def verify = false
+    def accepts(arg: Tree) = None
+  }
 }

--- a/tests/run/f-interpolator/Interpolator_1.scala
+++ b/tests/run/f-interpolator/Interpolator_1.scala
@@ -10,6 +10,7 @@ object FInterpolation {
   @inline private def falsely(body: => Unit): Boolean = { body ; false }
 
   implicit class FInterpolatorHelper(val sc: StringContext) extends AnyVal {
+    inline def ff(): String = ~interpolated(sc, Seq())
     inline def ff(arg1: Any): String = ~interpolated(sc, Seq('(arg1)))
     inline def ff(arg1: Any, arg2: Any): String = ~interpolated(sc, Seq('(arg1), '(arg2)))
     inline def ff(arg1: Any, arg2: Any, arg3: Any): String = ~interpolated(sc, Seq('(arg1), '(arg2), '(arg3)))

--- a/tests/run/f-interpolator/Interpolator_1.scala
+++ b/tests/run/f-interpolator/Interpolator_1.scala
@@ -1,0 +1,12 @@
+import scala.quoted._
+
+object FInterpolation {
+
+  implicit class FInterpolatorHelper(val sc: StringContext) extends AnyVal {
+    inline def ff(args: Any*): String = ~fInterpolation(sc, '(args))
+  }
+
+  def fInterpolation(sc: StringContext, args: Expr[Seq[Any]]): Expr[String] = {
+    sc.toString
+  }
+}

--- a/tests/run/f-interpolator/Interpolator_1.scala
+++ b/tests/run/f-interpolator/Interpolator_1.scala
@@ -1,6 +1,13 @@
 import scala.quoted._
 
+import scala.collection.mutable.{ ListBuffer, Stack }
+import scala.PartialFunction.cond
+import scala.util.matching.Regex.Match
+
 object FInterpolation {
+
+  @inline private def truly(body: => Unit): Boolean = { body ; true }
+  @inline private def falsely(body: => Unit): Boolean = { body ; false }
 
   implicit class FInterpolatorHelper(val sc: StringContext) extends AnyVal {
     inline def ff(arg1: Any): String = ~fInterpolation(sc, Seq('(arg1)))
@@ -40,30 +47,19 @@ object FInterpolation {
    *  7) "...${smth}[%illegalJavaConversion]" => error
    *  *Legal according to [[http://docs.oracle.com/javase/1.5.0/docs/api/java/util/Formatter.html]]
    */
-  def interpolated(parts: List[Tree], args: List[Tree]) = {
+  def interpolated(parts: List[String], args: List[Expr[Any]]) = {
     val fstring  = new StringBuilder
-    val evals    = ListBuffer[ValDef]()
-    val ids      = ListBuffer[Ident]()
     val argStack = Stack(args: _*)
 
-    // create a tmp val and add it to the ids passed to format
-    def defval(value: Tree, tpe: Type): Unit = {
-      val freshName = TermName(c.freshName("arg$"))
-      evals += ValDef(Modifiers(), freshName, TypeTree(tpe) setPos value.pos.focus, value) setPos value.pos
-      ids += Ident(freshName)
-    }
     // Append the nth part to the string builder, possibly prepending an omitted %s first.
     // Sanity-check the % fields in this part.
-    def copyPart(part: Tree, n: Int): Unit = {
+    def copyPart(part: String, n: Int): Unit = {
       import SpecifierGroups.{ Spec, Index }
-      val s0 = part match {
-        case Literal(Constant(x: String)) => x
-        case _ => throw new IllegalArgumentException("internal error: argument parts must be a list of string literals")
-      }
       def escapeHatch: PartialFunction[Throwable, String] = {
         // trailing backslash, octal escape, or other
         case e: StringContext.InvalidEscapeException =>
-          def errPoint = part.pos withPoint (part.pos.point + e.index)
+          // TODO
+          // def errPoint = part.pos withPoint (part.pos.point + e.index)
           def octalOf(c: Char) = Character.digit(c, 8)
           def alt = {
             def altOf(i: Int) = i match {
@@ -80,7 +76,7 @@ object FInterpolation {
             }
             val suggest = {
               val r = "([0-7]{1,3}).*".r
-              (s0 drop e.index + 1) match {
+              (part drop e.index + 1) match {
                 case r(n) => altOf { (0 /: n) { case (a, o) => (8 * a) + (o - '0') } }
                 case _    => ""
               }
@@ -90,27 +86,22 @@ object FInterpolation {
               else s", use $suggest instead"
             txt
           }
-          def badOctal = {
-            def msg(what: String) = s"Octal escape literals are $what$alt."
-            if (settings.future) {
-              c.error(errPoint, msg("unsupported"))
-              s0
-            } else {
-              currentRun.reporting.deprecationWarning(errPoint, msg("deprecated"), "2.11.0")
-              try StringContext.treatEscapes(s0) catch escapeHatch
-            }
-          }
-          if (e.index == s0.length - 1) {
-            c.error(errPoint, """Trailing '\' escapes nothing.""")
-            s0
-          } else if (octalOf(s0(e.index + 1)) >= 0) {
-            badOctal
+
+          if (e.index == part.length - 1) {
+            // TODO
+            // c.error(errPoint, """Trailing '\' escapes nothing.""")
+            part
+          } else if (octalOf(part(e.index + 1)) >= 0) {
+            // TODO
+            // c.error(errPoint, msg("unsupported"))
+            throw new Exception("unsupported")
           } else {
-            c.error(errPoint, e.getMessage)
-            s0
+            // TODO
+            // c.error(errPoint, e.getMessage)
+            part
           }
       }
-      val s  = try StringContext.processEscapes(s0) catch escapeHatch
+      val s  = try StringContext.processEscapes(part) catch escapeHatch
       val ms = fpat findAllMatchIn s
 
       def errorLeading(op: Conversion) = op.errorAt(Spec, s"conversions must follow a splice; ${Conversion.literalHelp}")
@@ -121,23 +112,19 @@ object FInterpolation {
         val arg = argStack.pop()
         def s_%() = {
           fstring append "%s"
-          defval(arg, AnyTpe)
         }
         def accept(op: Conversion) = {
           if (!op.isLeading) errorLeading(op)
-          op.accepts(arg) match {
-            case Some(tpe) => defval(arg, tpe)
-            case None      =>
-          }
         }
         if (ms.hasNext) {
-          Conversion(ms.next, part.pos, args.size) match {
+          Conversion(ms.next, /* part.pos, */ args.size) match {
             case Some(op) if op.isLiteral => s_%()
             case Some(op) if op.indexed =>
               if (op.index map (_ == n) getOrElse true) accept(op)
               else {
                 // either some other arg num, or '<'
-                c.warning(op.groupPos(Index), "Index is not this arg")
+                // TODO
+                // c.warning(op.groupPos(Index), "Index is not this arg")
                 s_%()
               }
             case Some(op) => accept(op)
@@ -147,7 +134,7 @@ object FInterpolation {
       }
       // any remaining conversions must be either literals or indexed
       while (ms.hasNext) {
-        Conversion(ms.next, part.pos, args.size) match {
+        Conversion(ms.next, /* part.pos, */ args.size) match {
           case Some(op) if first && op.hasFlag('<')   => op.badFlag('<', "No last arg")
           case Some(op) if op.isLiteral || op.indexed => // OK
           case Some(op) => errorLeading(op)
@@ -162,42 +149,27 @@ object FInterpolation {
     }
 
     //q"{..$evals; new StringOps(${fstring.toString}).format(..$ids)}"
-    val format = fstring.toString
-    if (ids.isEmpty && !format.contains("%")) Literal(Constant(format))
+    if (args.isEmpty && !fstring.contains("%")) fstring
     else {
-      val scalaPackage = Select(Ident(nme.ROOTPKG), TermName("scala"))
-      val newStringOps = Select(
-        New(Select(Select(Select(scalaPackage,
-          TermName("collection")), TermName("immutable")), TypeName("StringOps"))),
-        termNames.CONSTRUCTOR
-      )
-      val expr =
-        Apply(
-          Select(
-            Apply(
-              newStringOps,
-              List(Literal(Constant(format)))),
-            TermName("format")),
-          ids.toList
-        )
-      val p = c.macroApplication.pos
-      Block(evals.toList, atPos(p.focus)(expr)) setPos p.makeTransparent
+      val format: Expr[String] = fstring.toString
+      val args1: Expr[Seq[Any]] = liftSeq(args)
+      '{  (~format).format(~args1: _*) }
     }
   }
 
   val fpat = """%(?:(\d+)\$)?([-#+ 0,(\<]+)?(\d+)?(\.\d+)?([tT]?[%a-zA-Z])?""".r
   object SpecifierGroups extends Enumeration { val Spec, Index, Flags, Width, Precision, CC = Value }
 
-  val stdContextTags = new { val tc: c.type = c } with StdContextTags
-  import stdContextTags._
-  val tagOfFormattable = typeTag[Formattable]
+  // val stdContextTags = new { val tc: c.type = c } with StdContextTags
+  // import stdContextTags._
+  // val tagOfFormattable = typeTag[Formattable]
 
   /** A conversion specifier matched by `m` in the string part at `pos`,
    *  with `argc` arguments to interpolate.
    */
   sealed trait Conversion {
     def m: Match
-    def pos: Position
+    // def pos: Position
     def argc: Int
 
     import SpecifierGroups.{ Value => SpecGroup, _ }
@@ -215,7 +187,8 @@ object FInterpolation {
     def isLiteral: Boolean = false
     def isLeading: Boolean = m.start(0) == 0
     def verify:    Boolean = goodFlags && goodIndex
-    def accepts(arg: Tree): Option[Type]
+    // TODO
+    // def accepts(arg: Tree): Option[Type]
 
     val allFlags = "-#+ 0,(<"
     def hasFlag(f: Char) = (flags getOrElse "") contains f
@@ -223,12 +196,15 @@ object FInterpolation {
 
     def badFlag(f: Char, msg: String) = {
       val i = flags map (_.indexOf(f)) filter (_ >= 0) getOrElse 0
-      errorAtOffset(Flags, i, msg)
+      // TODO
+      // errorAtOffset(Flags, i, msg)
     }
-    def groupPos(g: SpecGroup) = groupPosAt(g, 0)
-    def groupPosAt(g: SpecGroup, i: Int) = pos withPoint (pos.point + m.start(g.id) + i)
-    def errorAt(g: SpecGroup, msg: String) = c.error(groupPos(g), msg)
-    def errorAtOffset(g: SpecGroup, i: Int, msg: String) = c.error(groupPosAt(g, i), msg)
+
+    // TODO
+    // def groupPos(g: SpecGroup) = groupPosAt(g, 0)
+    // def groupPosAt(g: SpecGroup, i: Int) = pos withPoint (pos.point + m.start(g.id) + i)
+    def errorAt(g: SpecGroup, msg: String) = () // c.error(groupPos(g), msg) // TODO
+    def errorAtOffset(g: SpecGroup, i: Int, msg: String) = () // c.error(groupPosAt(g, i), msg) // TODO
 
     def noFlags = flags.isEmpty || falsely { errorAt(Flags, "flags not allowed") }
     def noWidth = width.isEmpty || falsely { errorAt(Width, "width not allowed") }
@@ -244,8 +220,9 @@ object FInterpolation {
       badFlags.getOrElse("").isEmpty
     }
     def goodIndex = {
-      if (index.nonEmpty && hasFlag('<'))
-        c.warning(groupPos(Index), "Argument index ignored if '<' flag is present")
+      // TODO
+      // if (index.nonEmpty && hasFlag('<'))
+      //  c.warning(groupPos(Index), "Argument index ignored if '<' flag is present")
       val okRange = index map (i => i > 0 && i <= argc) getOrElse true
       okRange || hasFlag('<') || falsely { errorAt(Index, "Argument index out of range") }
     }
@@ -254,32 +231,33 @@ object FInterpolation {
      *  so failure results in an erroneous assignment to the first variant.
      *  A more complete message would be nice.
      */
-    def pickAcceptable(arg: Tree, variants: Type*): Option[Type] =
-      variants find (arg.tpe <:< _) orElse (
-        variants find (c.inferImplicitView(arg, arg.tpe, _) != EmptyTree)
-      ) orElse Some(variants(0))
+    // TODO
+    // def pickAcceptable(arg: Tree, variants: Type*): Option[Type] =
+    //   variants find (arg.tpe <:< _) orElse (
+    //     variants find (c.inferImplicitView(arg, arg.tpe, _) != EmptyTree)
+    //   ) orElse Some(variants(0))
   }
   object Conversion {
     import SpecifierGroups.{ Spec, CC }
-    def apply(m: Match, p: Position, n: Int): Option[Conversion] = {
+    def apply(m: Match, /* p: Position, */ n: Int): Option[Conversion] = {
       def badCC(msg: String) = {
-        val dk = new ErrorXn(m, p)
+        val dk = new ErrorXn(m /* , p */)
         val at = if (dk.op.isEmpty) Spec else CC
         dk.errorAt(at, msg)
       }
       def cv(cc: Char) = cc match {
         case 'b' | 'B' | 'h' | 'H' | 's' | 'S' =>
-          new GeneralXn(m, p, n)
+          new GeneralXn(m, /* p, */ n)
         case 'c' | 'C' =>
-          new CharacterXn(m, p, n)
+          new CharacterXn(m, /* p, */ n)
         case 'd' | 'o' | 'x' | 'X' =>
-          new IntegralXn(m, p, n)
+          new IntegralXn(m, /* p, */ n)
         case 'e' | 'E' | 'f' | 'g' | 'G' | 'a' | 'A' =>
-          new FloatingPointXn(m, p, n)
+          new FloatingPointXn(m, /* p, */ n)
         case 't' | 'T' =>
-          new DateTimeXn(m, p, n)
+          new DateTimeXn(m, /* p, */ n)
         case '%' | 'n' =>
-          new LiteralXn(m, p, n)
+          new LiteralXn(m, /* p, */ n)
         case _ =>
           badCC(s"illegal conversion character '$cc'")
           null
@@ -293,32 +271,32 @@ object FInterpolation {
     }
     val literalHelp = "use %% for literal %, %n for newline"
   }
-  class GeneralXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
-    def accepts(arg: Tree) = cc match {
-      case 's' | 'S' if hasFlag('#') => pickAcceptable(arg, tagOfFormattable.tpe)
-      case 'b' | 'B' => if (arg.tpe <:< NullTpe) Some(NullTpe) else Some(BooleanTpe)
-      case _         => Some(AnyTpe)
-    }
+  class GeneralXn(val m: Match, /* val pos: Position, */ val argc: Int) extends Conversion {
+    // def accepts(arg: Tree) = cc match {
+    //   case 's' | 'S' if hasFlag('#') => pickAcceptable(arg, tagOfFormattable.tpe)
+    //   case 'b' | 'B' => if (arg.tpe <:< NullTpe) Some(NullTpe) else Some(BooleanTpe)
+    //   case _         => Some(AnyTpe)
+    // }
     override protected def okFlags = cc match {
       case 's' | 'S' => "-#<"
       case _         => "-<"
     }
   }
-  class LiteralXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+  class LiteralXn(val m: Match, /* val pos: Position, */ val argc: Int) extends Conversion {
     import SpecifierGroups.Width
     override val isLiteral = true
     override def verify = op match {
-      case "%" => super.verify && noPrecision && truly(width foreach (_ => c.warning(groupPos(Width), "width ignored on literal")))
+      case "%" => super.verify && noPrecision && truly(width foreach (_ => () /* c.warning(groupPos(Width), "width ignored on literal") */ ))
       case "n" => noFlags && noWidth && noPrecision
     }
     override protected val okFlags = "-"
-    def accepts(arg: Tree) = None
+    // def accepts(arg: Tree) = None
   }
-  class CharacterXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+  class CharacterXn(val m: Match, /* val pos: Position, */ val argc: Int) extends Conversion {
     override def verify = super.verify && noPrecision && only_-("c conversion")
-    def accepts(arg: Tree) = pickAcceptable(arg, CharTpe, ByteTpe, ShortTpe, IntTpe)
+    // def accepts(arg: Tree) = pickAcceptable(arg, CharTpe, ByteTpe, ShortTpe, IntTpe)
   }
-  class IntegralXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+  class IntegralXn(val m: Match, /* val pos: Position, */ val argc: Int) extends Conversion {
     override def verify = {
       def d_# = (cc == 'd' && hasFlag('#') &&
         truly { badFlag('#', "# not allowed for d conversion") }
@@ -328,19 +306,19 @@ object FInterpolation {
       )
       super.verify && noPrecision && !d_# && !x_comma
     }
-    override def accepts(arg: Tree) = {
-      def isBigInt = arg.tpe <:< tagOfBigInt.tpe
-      val maybeOK = "+ ("
-      def bad_+ = cond(cc) {
-        case 'o' | 'x' | 'X' if hasAnyFlag(maybeOK) && !isBigInt =>
-          maybeOK filter hasFlag foreach (badf =>
-            badFlag(badf, s"only use '$badf' for BigInt conversions to o, x, X"))
-          true
-      }
-      if (bad_+) None else pickAcceptable(arg, IntTpe, LongTpe, ByteTpe, ShortTpe, tagOfBigInt.tpe)
-    }
+    // override def accepts(arg: Tree) = {
+    //   def isBigInt = arg.tpe <:< tagOfBigInt.tpe
+    //   val maybeOK = "+ ("
+    //   def bad_+ = cond(cc) {
+    //     case 'o' | 'x' | 'X' if hasAnyFlag(maybeOK) && !isBigInt =>
+    //       maybeOK filter hasFlag foreach (badf =>
+    //         badFlag(badf, s"only use '$badf' for BigInt conversions to o, x, X"))
+    //       true
+    //   }
+    //   if (bad_+) None else pickAcceptable(arg, IntTpe, LongTpe, ByteTpe, ShortTpe, tagOfBigInt.tpe)
+    // }
   }
-  class FloatingPointXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+  class FloatingPointXn(val m: Match, /* val pos: Position, */ val argc: Int) extends Conversion {
     override def verify = super.verify && (cc match {
       case 'a' | 'A' =>
         val badFlags = ",(" filter hasFlag
@@ -349,20 +327,20 @@ object FInterpolation {
         }
       case _ => true
     })
-    def accepts(arg: Tree) = pickAcceptable(arg, DoubleTpe, FloatTpe, tagOfBigDecimal.tpe)
+    // def accepts(arg: Tree) = pickAcceptable(arg, DoubleTpe, FloatTpe, tagOfBigDecimal.tpe)
   }
-  class DateTimeXn(val m: Match, val pos: Position, val argc: Int) extends Conversion {
+  class DateTimeXn(val m: Match, /* val pos: Position, */ val argc: Int) extends Conversion {
     import SpecifierGroups.CC
     def hasCC = (op.length == 2 ||
       falsely { errorAt(CC, "Date/time conversion must have two characters") })
     def goodCC = ("HIklMSLNpzZsQBbhAaCYyjmdeRTrDFc" contains cc) ||
       falsely { errorAtOffset(CC, 1, s"'$cc' doesn't seem to be a date or time conversion") }
     override def verify = super.verify && hasCC && goodCC && noPrecision && only_-("date/time conversions")
-    def accepts(arg: Tree) = pickAcceptable(arg, LongTpe, tagOfCalendar.tpe, tagOfDate.tpe)
+    // def accepts(arg: Tree) = pickAcceptable(arg, LongTpe, tagOfCalendar.tpe, tagOfDate.tpe)
   }
-  class ErrorXn(val m: Match, val pos: Position) extends Conversion {
+  class ErrorXn(val m: Match /* , val pos: Position */) extends Conversion {
     val argc = 0
     override def verify = false
-    def accepts(arg: Tree) = None
+    // def accepts(arg: Tree) = None
   }
 }

--- a/tests/run/f-interpolator/Interpolator_1.scala
+++ b/tests/run/f-interpolator/Interpolator_1.scala
@@ -3,13 +3,13 @@ import scala.quoted._
 object FInterpolation {
 
   implicit class FInterpolatorHelper(val sc: StringContext) extends AnyVal {
-    inline def ff(arg1: Any): String = ~fInterpolation(sc, '(Seq(arg1)))
-    inline def ff(arg1: Any, arg2: Any): String = ~fInterpolation(sc, '(Seq(arg1, arg2)))
-    inline def ff(arg1: Any, arg2: Any, arg3: Any): String = ~fInterpolation(sc, '(Seq(arg1, arg2, arg3)))
+    inline def ff(arg1: Any): String = ~fInterpolation(sc, Seq('(arg1)))
+    inline def ff(arg1: Any, arg2: Any): String = ~fInterpolation(sc, Seq('(arg1), '(arg2)))
+    inline def ff(arg1: Any, arg2: Any, arg3: Any): String = ~fInterpolation(sc, Seq('(arg1), '(arg2), '(arg3)))
     // ...
   }
 
-  def fInterpolation(sc: StringContext, args: Expr[Seq[Any]]): Expr[String] = {
+  def fInterpolation(sc: StringContext, args: Seq[Expr[Any]]): Expr[String] = {
     sc.toString
   }
 }

--- a/tests/run/f-interpolator/Interpolator_1.scala
+++ b/tests/run/f-interpolator/Interpolator_1.scala
@@ -3,7 +3,10 @@ import scala.quoted._
 object FInterpolation {
 
   implicit class FInterpolatorHelper(val sc: StringContext) extends AnyVal {
-    inline def ff(args: Any*): String = ~fInterpolation(sc, '(args))
+    inline def ff(arg1: Any): String = ~fInterpolation(sc, '(Seq(arg1)))
+    inline def ff(arg1: Any, arg2: Any): String = ~fInterpolation(sc, '(Seq(arg1, arg2)))
+    inline def ff(arg1: Any, arg2: Any, arg3: Any): String = ~fInterpolation(sc, '(Seq(arg1, arg2, arg3)))
+    // ...
   }
 
   def fInterpolation(sc: StringContext, args: Expr[Seq[Any]]): Expr[String] = {

--- a/tests/run/f-interpolator/Test_2.scala
+++ b/tests/run/f-interpolator/Test_2.scala
@@ -1,0 +1,8 @@
+
+import FInterpolation._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    println(ff"abc${5}")
+  }
+}

--- a/tests/run/f-interpolator/Test_2.scala
+++ b/tests/run/f-interpolator/Test_2.scala
@@ -2,32 +2,24 @@
 import FInterpolation._
 
 object Test {
-  def test1(n: Int) = {
-    println(s"Bob is $n years old")
-    println(ff"Bob is $n%2d years old")
-    println(s"Bob will be ${n+1} years old")
-    // println(ff"Bob will be ${n+1}%2d years old")
-    println(s"$n+1 = ${n+1}")
-    // println(ff"$n%d+1 = ${n+1}%d")
-  }
+  // interpolation.scala
+  def testA = {
+    def test1(n: Int) = {
+      println(s"Bob is $n years old")
+      println(ff"Bob is $n%2d years old")
+      println(s"Bob will be ${n+1} years old")
+      // println(ff"Bob will be ${n+1}%2d years old")
+      println(s"$n+1 = ${n+1}")
+      // println(ff"$n%d+1 = ${n+1}%d")
+    }
 
-  def test2(f: Float) = {
-    println(s"Best price: $f")
-    println(ff"Best price: $f%.2f")
-    println(s"$f% discount included")
-    println(ff"$f%3.2f%% discount included")
-  }
+    def test2(f: Float) = {
+      println(s"Best price: $f")
+      println(ff"Best price: $f%.2f")
+      println(s"$f% discount included")
+      println(ff"$f%3.2f%% discount included")
+    }
 
-  def main(args: Array[String]): Unit = {
-    println(ff"integer: ${5}%d")
-    println(ff"string: ${"l"}%s")
-    println(ff"${5}%s, ${6}%d, ${"hello"}%s")
-
-    val x = 5
-    println(ff"$x%d")
-    // println(ff"${x + 1}%d")
-
-    // ported from scalac
     test1(1)
     test1(12)
     test1(123)
@@ -41,5 +33,68 @@ object Test {
     println(ff"")
     println(ff"${0}")
     println(ff"${0}${0}")
+  }
+
+  // interpolationMultiline1.scala
+  def testB = {
+    def test1(n: Int) = {
+      println(s"""Bob is $n years old""")
+      println(ff"""Bob is $n%2d years old""")
+      println(s"""Bob will be ${n+1} years old""")
+      // println(ff"""Bob will be ${n+1}%2d years old""")
+      println(s"""$n+1 = ${n+1}""")
+      // println(ff"""$n%d+1 = ${n+1}%d""")
+    }
+
+    def test2(f: Float) = {
+      println(s"""Best price: $f""")
+      println(ff"""Best price: $f%.2f""")
+      println(s"""$f% discount included""")
+      println(ff"""$f%3.2f%% discount included""")
+    }
+
+    test1(1)
+    test1(12)
+    test1(123)
+
+    test2(10.0f)
+    test2(13.345f)
+  }
+
+  // interpolationMultiline2.scala
+  def testC = {
+    def test1(n: Int) = {
+      val old = "old"
+      val catcher: PartialFunction[Throwable, Unit] = { case e => println(e) }
+      try { println(s"""Bob is ${s"$n"} years ${s"$old"}!""") } catch catcher
+      // try { println(s"""Bob is ${ff"$n"} years ${s"$old"}!""") } catch catcher
+      // try { println(ff"""Bob is ${s"$n"} years ${s"$old"}!""") } catch catcher
+      // try { println(ff"""Bob is ${ff"$n"} years ${s"$old"}!""") } catch catcher
+      // try { println(ff"""Bob is ${ff"$n%2d"} years ${s"$old"}!""") } catch catcher
+      // try { println(ff"""Bob is ${s"$n%2d"} years ${s"$old"}!""") } catch catcher
+      // try { println(s"""Bob is ${ff"$n%2d"} years ${s"$old"}!""") } catch catcher
+      try { println(s"""Bob is ${s"$n%2d"} years ${s"$old"}!""") } catch catcher
+    }
+
+    test1(1)
+    println("===============")
+    test1(12)
+    println("===============")
+    test1(123)
+  }
+
+  def main(args: Array[String]): Unit = {
+    println(ff"integer: ${5}%d")
+    println(ff"string: ${"l"}%s")
+    println(ff"${5}%s, ${6}%d, ${"hello"}%s")
+
+    val x = 5
+    println(ff"$x%d")
+    // println(ff"${x + 1}%d")
+
+    // ported from scalac
+    testA
+    testB
+    testC
   }
 }

--- a/tests/run/f-interpolator/Test_2.scala
+++ b/tests/run/f-interpolator/Test_2.scala
@@ -6,5 +6,8 @@ object Test {
     println(ff"integer: ${5}%d")
     println(ff"string: ${"l"}%s")
     println(ff"${5}%s, ${6}%d, ${"hello"}%s")
+
+    val x = 5
+    println(ff"$x%d")
   }
 }

--- a/tests/run/f-interpolator/Test_2.scala
+++ b/tests/run/f-interpolator/Test_2.scala
@@ -2,6 +2,22 @@
 import FInterpolation._
 
 object Test {
+  def test1(n: Int) = {
+    println(s"Bob is $n years old")
+    println(ff"Bob is $n%2d years old")
+    println(s"Bob will be ${n+1} years old")
+    // println(ff"Bob will be ${n+1}%2d years old")
+    println(s"$n+1 = ${n+1}")
+    // println(ff"$n%d+1 = ${n+1}%d")
+  }
+
+  def test2(f: Float) = {
+    println(s"Best price: $f")
+    println(ff"Best price: $f%.2f")
+    println(s"$f% discount included")
+    println(ff"$f%3.2f%% discount included")
+  }
+
   def main(args: Array[String]): Unit = {
     println(ff"integer: ${5}%d")
     println(ff"string: ${"l"}%s")
@@ -9,5 +25,21 @@ object Test {
 
     val x = 5
     println(ff"$x%d")
+    // println(ff"${x + 1}%d")
+
+    // ported from scalac
+    test1(1)
+    test1(12)
+    test1(123)
+
+    test2(10.0f)
+    test2(13.345f)
+
+    println(s"")
+    println(s"${0}")
+    println(s"${0}${0}")
+    println(ff"")
+    println(ff"${0}")
+    println(ff"${0}${0}")
   }
 }

--- a/tests/run/f-interpolator/Test_2.scala
+++ b/tests/run/f-interpolator/Test_2.scala
@@ -3,8 +3,8 @@ import FInterpolation._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    println(ff"abc${5}")
-    println(ff"abc${5}asf${"l"}")
-    println(ff"abc${5}${6}asf${8}")
+    println(ff"integer: ${5}%d")
+    println(ff"string: ${"l"}%s")
+    println(ff"${5}%s, ${6}%d, ${"hello"}%s")
   }
 }

--- a/tests/run/f-interpolator/Test_2.scala
+++ b/tests/run/f-interpolator/Test_2.scala
@@ -4,5 +4,7 @@ import FInterpolation._
 object Test {
   def main(args: Array[String]): Unit = {
     println(ff"abc${5}")
+    println(ff"abc${5}asf${"l"}")
+    println(ff"abc${5}${6}asf${8}")
   }
 }


### PR DESCRIPTION
Todo list

- [x] support basic feature to print
- [ ] type checking
- [ ] error message & positions
- [x] port tests from scalac

Requirements

- error reporting facility
- get position of trees
- get type of tree
- subtype checking
- infer implicit

Problem Found

- cannot select in macro body (`sc.parts`), need to move to implementation
- cannot interpreter correctly with explicit call `new Interpolation.Helper(sc)`.
- `Seq` works, but not `List` in the API
- doesn't support `f"${x + 1}%d"`: phase error