### PR TITLE
Fix #2671: Don't instantiate typevars before creating implicit closure

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1779,8 +1779,7 @@ class Typer extends Namer
 
   protected def makeImplicitFunction(tree: untpd.Tree, pt: Type)(implicit ctx: Context): Tree = {
     val defn.FunctionOf(formals, _, true) = pt.dropDependentRefinement
-    val paramTypes = formals.map(fullyDefinedType(_, "implicit function parameter", tree.pos))
-    val ifun = desugar.makeImplicitFunction(paramTypes, tree)
+    val ifun = desugar.makeImplicitFunction(formals, tree)
     typr.println(i"make implicit function $tree / $pt ---> $ifun")
     typed(ifun, pt)
   }

--- a/tests/pos/i2671.scala
+++ b/tests/pos/i2671.scala
@@ -1,0 +1,11 @@
+object Foo {
+
+  def map[E](f: implicit E => Int): (implicit E => Int) = ???
+
+  implicit def i: Int = ???
+
+  def f: implicit Int => Int = ???
+
+  val a: Int = map(f)
+
+}


### PR DESCRIPTION
We were a bit too conservative in instantiating all type variables before
creating an implicit closure. This causes unwanted instantiations, see #2671.