### PR TITLE
Fix #2663: More refined handling of enum case apply results

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -460,7 +460,7 @@ object desugar {
         val (applyResultTpt, widenDefs) =
           if (!isEnumCase)
             (TypeTree(), Nil)
-          else if (parents.isEmpty || derivedTparams.isEmpty || enumClass.typeParams.isEmpty)
+          else if (parents.isEmpty || enumClass.typeParams.isEmpty)
             (enumClassTypeRef, Nil)
           else
             enumApplyResult(cdef, parents, derivedTparams, appliedRef(enumClassRef, derivedTparams))

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -92,6 +92,10 @@ object desugar {
     cpy.TypeDef(tdef)(
       rhs = new DerivedFromParamTree() withPos tdef.rhs.pos watching tdef)
 
+  /** A derived type definition watching `sym` */
+  def derivedTypeParam(sym: TypeSymbol)(implicit ctx: Context): TypeDef =
+    TypeDef(sym.name, new DerivedFromParamTree().watching(sym)).withFlags(TypeParam)
+
   /** A value definition copied from `vdef` with a tpt typetree derived from it */
   def derivedTermParam(vdef: ValDef) =
     cpy.ValDef(vdef)(
@@ -462,8 +466,10 @@ object desugar {
             (TypeTree(), Nil)
           else if (parents.isEmpty || enumClass.typeParams.isEmpty)
             (enumClassTypeRef, Nil)
-          else
-            enumApplyResult(cdef, parents, derivedTparams, appliedRef(enumClassRef, derivedTparams))
+          else {
+            val tparams = enumClass.typeParams.map(derivedTypeParam)
+            enumApplyResult(cdef, parents, tparams, appliedRef(enumClassRef, tparams))
+          }
 
         val parent =
           if (constrTparams.nonEmpty ||

--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -120,6 +120,52 @@ object DesugarEnums {
         TypeTree(), creator)
   }
 
+  /** The return type of an enum case apply method and any widening methods in which
+   *  the apply's right hand side will be wrapped. For parents of the form
+   *
+   *      extends E(args) with T1(args1) with ... TN(argsN)
+   *
+   *  and type parameters `tparams` the generated widen method is
+   *
+   *      def C$to$E[tparams](x$1: E[tparams] with T1 with ... TN) = x$1
+   *
+   *  @param cdef            The case definition
+   *  @param parents         The declared parents of the enum case
+   *  @param tparams         The type parameters of the enum case
+   *  @param appliedEnumRef  The enum class applied to `tparams`.
+   */
+  def enumApplyResult(
+      cdef: TypeDef,
+      parents: List[Tree],
+      tparams: List[TypeDef],
+      appliedEnumRef: Tree)(implicit ctx: Context): (Tree, List[DefDef]) = {
+
+    def extractType(t: Tree): Tree = t match {
+      case Apply(t1, _) => extractType(t1)
+      case TypeApply(t1, ts) => AppliedTypeTree(extractType(t1), ts)
+      case Select(t1, nme.CONSTRUCTOR) => extractType(t1)
+      case New(t1) => t1
+      case t1 => t1
+    }
+
+    val parentTypes = parents.map(extractType)
+    parentTypes.head match {
+      case parent: RefTree if parent.name == enumClass.name =>
+        // need a widen method to compute correct type parameters for enum base class
+        val widenParamType = (appliedEnumRef /: parentTypes.tail)(AndTypeTree)
+        val widenParam = makeSyntheticParameter(tpt = widenParamType)
+        val widenDef = DefDef(
+          name = s"${cdef.name}$$to$$${enumClass.name}".toTermName,
+          tparams = tparams,
+          vparamss = (widenParam :: Nil) :: Nil,
+          tpt = TypeTree(),
+          rhs = Ident(widenParam.name))
+        (TypeTree(), widenDef :: Nil)
+      case _ =>
+        (parentTypes.reduceLeft(AndTypeTree), Nil)
+    }
+  }
+
   /** A pair consisting of
    *   - the next enum tag
    *   - scaffolding containing the necessary definitions for singleton enum cases

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -227,6 +227,12 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       this
     }
 
+    /** Install the derived type tree as a dependency on `sym` */
+    def watching(sym: Symbol): this.type = {
+      pushAttachment(OriginalSymbol, sym)
+      this
+    }
+
     /** A hook to ensure that all necessary symbols are completed so that
      *  OriginalSymbol attachments are propagated to this tree
      */
@@ -240,7 +246,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
    *  from the symbol in this type. These type trees have marker trees
    *  TypeRefOfSym or InfoOfSym as their originals.
    */
-  val References = new Property.Key[List[Tree]]
+  val References = new Property.Key[List[DerivedTypeTree]]
 
   /** Property key for TypeTrees marked with TypeRefOfSym or InfoOfSym
    *  which contains the symbol of the original tree from which this

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -228,11 +228,7 @@ class Namer { typer: Typer =>
 
   /** Record `sym` as the symbol defined by `tree` */
   def recordSym(sym: Symbol, tree: Tree)(implicit ctx: Context): Symbol = {
-    val refs = tree.attachmentOrElse(References, Nil)
-    if (refs.nonEmpty) {
-      tree.removeAttachment(References)
-      refs foreach (_.pushAttachment(OriginalSymbol, sym))
-    }
+    for (refs <- tree.removeAttachment(References); ref <- refs) ref.watching(sym)
     tree.pushAttachment(SymOfTree, sym)
     sym
   }

--- a/tests/pos/i2663.scala
+++ b/tests/pos/i2663.scala
@@ -3,12 +3,14 @@ enum Foo[T](x: T) {
   case Bar[T](y: T) extends Foo(y)
   case Bas[T](y: Int) extends Foo(y)
   case Bam[T](y: String) extends Foo(y) with Tr
+  case Baz[S, T](y: String) extends Foo(y) with Tr
 }
 object Test {
   import Foo._
   val bar: Foo[Boolean] = Bar(true)
   val bas: Foo[Int] = Bas(1)
   val bam: Foo[String] & Tr = Bam("")
+  val baz: Foo[String] & Tr = Baz("")
 }
 
 

--- a/tests/pos/i2663.scala
+++ b/tests/pos/i2663.scala
@@ -1,0 +1,14 @@
+trait Tr
+enum Foo[T](x: T) {
+  case Bar[T](y: T) extends Foo(y)
+  case Bas[T](y: Int) extends Foo(y)
+  case Bam[T](y: String) extends Foo(y) with Tr
+}
+object Test {
+  import Foo._
+  val bar: Foo[Boolean] = Bar(true)
+  val bas: Foo[Int] = Bas(1)
+  val bam: Foo[String] & Tr = Bam("")
+}
+
+

--- a/tests/pos/i2663.scala
+++ b/tests/pos/i2663.scala
@@ -13,4 +13,18 @@ object Test {
   val baz: Foo[String] & Tr = Baz("")
 }
 
+enum Foo2[S <: T, T](x1: S, x2: T) {
+  case Bar[T](y: T) extends Foo2(y, y)
+  case Bas[T](y: Int) extends Foo2(y, y)
+  case Bam[T](y: String) extends Foo2(y, y) with Tr
+  case Baz[S, T](y: String) extends Foo2(y, y) with Tr
+}
+object Test2 {
+  import Foo2._
+  val bar: Foo2[Boolean, Boolean] = Bar(true)
+  val bas: Foo2[Int, Int] = Bas(1)
+  val bam: Foo2[String, String] & Tr = Bam("")
+  val baz: Foo2[String, String] & Tr = Baz("")
+}
+
 


### PR DESCRIPTION
i2663 demonstrates that we do not always have a complete result type
for the `apply` method of an enum case. In that case our only recourse
is to add a generic widening method that upcasts the enum case class to the
enum base class.