### PR TITLE
Fix #2104: Instantiate unapply result type variables

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -920,6 +920,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
         val ownType =
           if (selType <:< unapplyArgType) {
             unapp.println(i"case 1 $unapplyArgType ${ctx.typerState.constraint}")
+            fullyDefinedType(unapplyArgType, "pattern selector", tree.pos)
             selType
           } else if (isSubTypeOfParent(unapplyArgType, selType)(ctx.addMode(Mode.GADTflexible))) {
             maximizeType(unapplyArgType) match {
@@ -952,7 +953,6 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
               ex"Pattern type $unapplyArgType is neither a subtype nor a supertype of selector type $selType",
               tree.pos)
           }
-
         val dummyArg = dummyTreeOfType(ownType)
         val unapplyApp = typedExpr(untpd.TypedSplice(Apply(unapplyFn, dummyArg :: Nil)))
         val unapplyImplicits = unapplyApp match {

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -811,8 +811,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
     .expect { (ictx, messages) =>
       implicit val ctx: Context = ictx
 
-      assertMessageCount(1, messages)
-      val AnonymousFunctionMissingParamType(param, args, _, pt) :: Nil = messages
+      val AnonymousFunctionMissingParamType(param, args, _, pt) = messages.last
       assertEquals("x$1", param.show)
       assertEquals(s"List(ValDef(${param.show},TypeTree,EmptyTree))", args.toString)
       assertEquals("?", pt.show)

--- a/tests/pos/i2104.scala
+++ b/tests/pos/i2104.scala
@@ -1,0 +1,20 @@
+case class Pair[A, B](_1: A, _2: B)
+
+trait Cons[+H, +T]
+
+object Cons {
+  def apply[H, T](h: H, t: T): Cons[H, T] = ???
+  def unapply[H, T](t: Cons[H, T]): Option[Pair[H, T]] = ???
+}
+
+
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    Cons(Option(1), None) match {
+      case Cons(Some(i), None) =>
+        i: Int // error: found: Any(i), requires: Int
+        assert(i == 1)
+    }
+  }
+}


### PR DESCRIPTION
Type variables in an unapply result should be fully instantiated before nested
pattern matches. This is analogous to instantiating the scrutinee type of a match.