### PR TITLE
Added error message for Symbol is not a value #1589

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -126,6 +126,7 @@ public enum ErrorMessageID {
     MissingCompanionForStaticID,
     PolymorphicMethodMissingTypeInParentID,
     ParamsNoInlineID,
+    JavaSymbolIsNotAValueID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -21,7 +21,7 @@ import ErrorMessageID._
 import Denotations.SingleDenotation
 import dotty.tools.dotc.ast.Trees
 import dotty.tools.dotc.config.ScalaVersion
-import dotty.tools.dotc.core.Flags.{FlagSet, Mutable}
+import dotty.tools.dotc.core.Flags._
 import dotty.tools.dotc.core.SymDenotations.SymDenotation
 import scala.util.control.NonFatal
 
@@ -203,11 +203,11 @@ object messages {
     val explanation =
       hl"""|Anonymous functions must define a type. For example, if you define a function like this one:
            |
-           |${"val f = { case xs @ List(1, 2, 3) => Some(xs) }"}
+           |${"val f = { case x: Int => x + 1 }"}
            |
            |Make sure you give it a type of what you expect to match and help the type inference system:
            |
-           |${"val f: Seq[Int] => Option[List[Int]] = { case xs @ List(1, 2, 3) => Some(xs) }"} """
+           |${"val f: Any => Int = { case x: Int => x + 1 }"} """
   }
 
   case class WildcardOnTypeArgumentNotAllowedOnNew()(implicit ctx: Context)
@@ -2078,23 +2078,14 @@ object messages {
   }
 
   case class JavaSymbolIsNotAValue(symbol: Symbol)(implicit ctx: Context) extends Message(JavaSymbolIsNotAValueID) {
-    val msg = hl"$symbol is not a value"
     val kind = "Type Mismatch"
-    val explanation = {
-      val javaCodeExample = """class A {public static int a() {return 1;}}"""
+    val msg = {
+      val kind =
+        if (symbol is Package) hl"$symbol"
+        else hl"Java defined ${"class " + symbol.name}"
 
-      val scalaCodeExample =
-        """val objectA = A     // This does not compile
-          |val aResult = A.a() // This does compile""".stripMargin
-
-      hl"""Java statics and packages cannot be used as a value.
-          |For Java statics consider the following Java example:
-          |
-          |$javaCodeExample
-          |
-          |When used from Scala:
-          |
-          |$scalaCodeExample"""
+      s"$kind is not a value"
     }
+    val explanation = ""
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2076,4 +2076,25 @@ object messages {
     val msg = hl"""${"inline"} modifier cannot be used for a ${owner.showKind} parameter"""
     val explanation = ""
   }
+
+  case class JavaSymbolIsNotAValue(symbol: Symbol)(implicit ctx: Context) extends Message(JavaSymbolIsNotAValueID) {
+    val msg = hl"$symbol is not a value"
+    val kind = "Type Mismatch"
+    val explanation = {
+      val javaCodeExample = """class A {public static int a() {return 1;}}"""
+
+      val scalaCodeExample =
+        """val objectA = A     // This does not compile
+          |val aResult = A.a() // This does compile""".stripMargin
+
+      hl"""Java statics and packages cannot be used as a value.
+          |For Java statics consider the following Java example:
+          |
+          |$javaCodeExample
+          |
+          |When used from Scala:
+          |
+          |$scalaCodeExample"""
+    }
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -526,7 +526,7 @@ trait Checking {
       val sym = tree.tpe.termSymbol
       // The check is avoided inside Java compilation units because it always fails
       // on the singleton type Module.type.
-      if ((sym is Package) || ((sym is JavaModule) && !ctx.compilationUnit.isJava)) ctx.error(em"$sym is not a value", tree.pos)
+      if ((sym is Package) || ((sym is JavaModule) && !ctx.compilationUnit.isJava)) ctx.error(JavaSymbolIsNotAValue(sym), tree.pos)
     }
     tree
   }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1278,4 +1278,18 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals("method get", rsym.show)
       assertEquals("class Object", parentSym.show)
     }
+
+  @Test def javaSymbolIsNotAValue =
+    checkMessagesAfter("checkStatic") {
+      """
+        |package p
+        |object O {
+        |  val v = p
+        |}
+      """.stripMargin
+    }.expect { (itcx, messages) =>
+      implicit val ctx: Context = itcx
+      val JavaSymbolIsNotAValue(symbol) = messages.head
+      assertEquals(symbol.show, "package p")
+    }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -805,15 +805,15 @@ class ErrorMessagesTests extends ErrorMessagesTest {
     checkMessagesAfter("refchecks") {
       """
         |object AnonymousF {
-        |  val f = { case l@List(1,2,3) => Some(l) }
+        |  val f = { case x: Int => x + 1 }
         |}""".stripMargin
     }
     .expect { (ictx, messages) =>
       implicit val ctx: Context = ictx
 
-      val AnonymousFunctionMissingParamType(param, args, _, pt) = messages.last
+      assertMessageCount(1, messages)
+      val AnonymousFunctionMissingParamType(param, args, _, pt) = messages.head
       assertEquals("x$1", param.show)
-      assertEquals(s"List(ValDef(${param.show},TypeTree,EmptyTree))", args.toString)
       assertEquals("?", pt.show)
     }
 
@@ -1289,6 +1289,8 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       """.stripMargin
     }.expect { (itcx, messages) =>
       implicit val ctx: Context = itcx
+
+      assertMessageCount(1, messages)
       val JavaSymbolIsNotAValue(symbol) = messages.head
       assertEquals(symbol.show, "package p")
     }


### PR DESCRIPTION
1. Added SymbolIsNotAValue error Message class
2. Substituted the original error message at Checking.scala:526 with the new class and added a test
3. Typo fix at Checking.scala:211

In place of this [pr](https://github.com/lampepfl/dotty/pull/3746).