### PR TITLE
Fix #1369 Print a newline after interpreted commands

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -200,9 +200,11 @@ class ReplDriver(settings: Array[String],
   private def interpret(res: ParseResult)(implicit state: State): State =
     res match {
       case parsed: Parsed if parsed.trees.nonEmpty =>
-        compile(parsed)
+        val newState = compile(parsed)
           .withHistory(parsed.sourceCode :: state.history)
           .newRun(compiler, rootCtx)
+        out.println() // Prints newline after commands, also fixes #1369
+        newState
 
       case SyntaxErrors(src, errs, _) =>
         displayErrors(errs)

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -81,8 +81,8 @@ case class Completions(cursor: Int,
 
 /** Main REPL instance, orchestrating input, compilation and presentation */
 class ReplDriver(settings: Array[String],
-                 protected val out: PrintStream = Console.out,
-                 protected val classLoader: Option[ClassLoader] = None) extends Driver {
+                 out: PrintStream = Console.out,
+                 classLoader: Option[ClassLoader] = None) extends Driver {
 
   /** Overridden to `false` in order to not have to give sources on the
    *  commandline

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -197,14 +197,12 @@ class ReplDriver(settings: Array[String],
   private def extractImports(trees: List[untpd.Tree]): List[untpd.Import] =
     trees.collect { case imp: untpd.Import => imp }
 
-  private def interpret(res: ParseResult)(implicit state: State): State =
-    res match {
+  private def interpret(res: ParseResult)(implicit state: State): State = {
+    val newState = res match {
       case parsed: Parsed if parsed.trees.nonEmpty =>
-        val newState = compile(parsed)
+        compile(parsed)
           .withHistory(parsed.sourceCode :: state.history)
           .newRun(compiler, rootCtx)
-        out.println() // Prints newline after commands, also fixes #1369
-        newState
 
       case SyntaxErrors(src, errs, _) =>
         displayErrors(errs)
@@ -218,6 +216,9 @@ class ReplDriver(settings: Array[String],
       case _ => // new line, empty tree
         state
     }
+    out.println()
+    newState
+  }
 
   /** Compile `parsed` trees and evolve `state` in accordance */
   protected[this] final def compile(parsed: Parsed)(implicit state: State): State = {

--- a/compiler/test-resources/repl/i1369
+++ b/compiler/test-resources/repl/i1369
@@ -1,0 +1,4 @@
+scala> print("foo")
+foo
+scala> "Hello"
+val res0: String = Hello

--- a/compiler/test/dotty/tools/repl/ScriptedTests.scala
+++ b/compiler/test/dotty/tools/repl/ScriptedTests.scala
@@ -22,13 +22,13 @@ class ScriptedTests extends ReplTest with MessageRendering {
 
   private def testFile(f: JFile): Unit = {
     val prompt = "scala>"
-    val lines = Source.fromFile(f).getLines.buffered
+    val lines = Source.fromFile(f).getLines().buffered
+
+    assert(lines.head.startsWith(prompt),
+      s"""Each file has to start with the prompt: "$prompt"""")
 
     def extractInputs(prompt: String): List[String] = {
       val input = lines.next()
-
-      assert(input.startsWith(prompt),
-        s"""Each file has to start with the prompt: "$prompt"""")
 
       if (!input.startsWith(prompt)) extractInputs(prompt)
       else if (lines.hasNext) {
@@ -60,7 +60,7 @@ class ScriptedTests extends ReplTest with MessageRendering {
       }
 
     val expectedOutput =
-      Source.fromFile(f).getLines.flatMap(filterEmpties).mkString("\n")
+      Source.fromFile(f).getLines().flatMap(filterEmpties).mkString("\n")
     val actualOutput = {
       resetToInitial()
       init()


### PR DESCRIPTION
Keeping only one newline for Unit values if there are more of them in a command.