### PR TITLE
Fix #1754: Don't narrow GADTs to lower bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -556,6 +556,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
     val acc = new TreeAccumulator[List[Symbol]] {
       def apply(syms: List[Symbol], tree: Tree)(implicit ctx: Context) = tree match {
         case Bind(_, body) => apply(tree.symbol :: syms, body)
+        case Annotated(tree, id @ Ident(tpnme.BOUNDTYPE_ANNOT)) => apply(id.symbol :: syms, tree)
         case _ => foldOver(syms, tree)
       }
     }

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -143,6 +143,7 @@ object StdNames {
     val INITIALIZER_PREFIX: N         = "initial$"
     val COMPANION_MODULE_METHOD: N    = "companion$module"
     val COMPANION_CLASS_METHOD: N     = "companion$class"
+    val BOUNDTYPE_ANNOT: N            = "$boundType$"
     val QUOTE: N                      = "'"
     val TYPE_QUOTE: N                = "type_'"
     val TRAIT_SETTER_SEPARATOR: N     = str.TRAIT_SETTER_SEPARATOR

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -107,9 +107,18 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         assert(isSatisfiable, constraint.show)
   }
 
+  private[this] var approx: ApproxState = NoApprox
+  protected def approxState = approx
+
+  protected def isSubType(tp1: Type, tp2: Type, a: ApproxState): Boolean = {
+    val saved = approx
+    this.approx = a
+    try recur(tp1, tp2) finally this.approx = saved
+  }
+
   protected def isSubType(tp1: Type, tp2: Type): Boolean = isSubType(tp1, tp2, NoApprox)
 
-  protected def isSubType(tp1: Type, tp2: Type, approx: ApproxState): Boolean = trace(s"isSubType ${traceInfo(tp1, tp2)} $approx", subtyping) {
+  protected def recur(tp1: Type, tp2: Type): Boolean = trace(s"isSubType ${traceInfo(tp1, tp2)} $approx", subtyping) {
 
     def monitoredIsSubType = {
       if (pendingSubTypes == null) {
@@ -817,9 +826,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         false
       } else isSubType(tp1, tp2, approx.addLow)
 
-    def recur(tp1: Type, tp2: Type) = isSubType(tp1, tp2, approx)
-
-    // begin isSubType
+    // begin recur
     if (tp2 eq NoType) false
     else if (tp1 eq tp2) true
     else {

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -363,7 +363,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
               narrowGADTBounds(tp2, tp1, approx, isUpper = false)) &&
             GADTusage(tp2.symbol)
         }
-        isSubType(tp1, lo2, approx.addHigh) || compareGADT || fourthTry
+        isSubApproxHi(tp1, lo2) || compareGADT || fourthTry
 
       case _ =>
         val cls2 = tp2.symbol
@@ -750,7 +750,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
       *  @param   tyconLo   The type constructor's lower approximation.
       */
       def fallback(tyconLo: Type) =
-        either(fourthTry, isSubType(tp1, tyconLo.applyIfParameterized(args2), approx.addHigh))
+        either(fourthTry, isSubApproxHi(tp1, tyconLo.applyIfParameterized(args2)))
 
       /** Let `tycon2bounds` be the bounds of the RHS type constructor `tycon2`.
       *  Let `app2 = tp2` where the type constructor of `tp2` is replaced by
@@ -764,7 +764,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
       def compareLower(tycon2bounds: TypeBounds, tyconIsTypeRef: Boolean): Boolean =
         if (tycon2bounds.lo eq tycon2bounds.hi)
           if (tyconIsTypeRef) recur(tp1, tp2.superType)
-          else isSubType(tp1, tycon2bounds.lo.applyIfParameterized(args2), approx.addHigh)
+          else isSubApproxHi(tp1, tycon2bounds.lo.applyIfParameterized(args2))
         else
           fallback(tycon2bounds.lo)
 
@@ -825,6 +825,9 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         //println(s"useless subtype: $tp1 <:< $tp2")
         false
       } else isSubType(tp1, tp2, approx.addLow)
+
+    def isSubApproxHi(tp1: Type, tp2: Type): Boolean =
+      (tp2 ne NothingType) && isSubType(tp1, tp2, approx.addHigh)
 
     // begin recur
     if (tp2 eq NoType) false

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -25,6 +25,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
 
   private[this] var pendingSubTypes: mutable.Set[(Type, Type)] = null
   private[this] var recCount = 0
+  private[this] var monitored = false
 
   private[this] var needsGc = false
 
@@ -102,9 +103,11 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     if (tp2 eq NoType) return false
     if ((tp2 eq tp1) || (tp2 eq WildcardType)) return true
     try isSubType(tp1, tp2)
-    finally
+    finally {
+      monitored = false
       if (Config.checkConstraintsSatisfiable)
         assert(isSatisfiable, constraint.show)
+    }
   }
 
   private[this] var approx: ApproxState = NoApprox
@@ -284,6 +287,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
             if (recur(info1.alias, tp2)) return true
             if (tp1.prefix.isStable) return false
           case _ =>
+            if (tp1 eq NothingType) return tp1 == tp2.bottomType
         }
         thirdTry
       case tp1: TypeParamRef =>
@@ -837,9 +841,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
       val savedSuccessCount = successCount
       try {
         recCount = recCount + 1
-        val result =
-          if (recCount < Config.LogPendingSubTypesThreshold) firstTry
-          else monitoredIsSubType
+        if (recCount >= Config.LogPendingSubTypesThreshold) monitored = true
+        val result = if (monitored) monitoredIsSubType else firstTry
         recCount = recCount - 1
         if (!result) state.resetConstraintTo(saved)
         else if (recCount == 0 && needsGc) {

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -17,8 +17,7 @@ import reporting.trace
 /** Provides methods to compare types.
  */
 class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
-  import TypeComparer.show
-
+  import TypeComparer._
   implicit val ctx = initctx
 
   val state = ctx.typerState
@@ -26,14 +25,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
 
   private[this] var pendingSubTypes: mutable.Set[(Type, Type)] = null
   private[this] var recCount = 0
-  private[this] var monitored = false
 
   private[this] var needsGc = false
-
-  /** True iff a compared type `tp1` */
-  private[this] var loIsPrecise = true
-  private[this] var hiIsPrecise = true
-  val newScheme = true
 
   /** Is a subtype check in progress? In that case we may not
    *  permanently instantiate type variables, because the corresponding
@@ -109,16 +102,726 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     if (tp2 eq NoType) return false
     if ((tp2 eq tp1) || (tp2 eq WildcardType)) return true
     try isSubType(tp1, tp2)
-    finally {
-      monitored = false
+    finally
       if (Config.checkConstraintsSatisfiable)
         assert(isSatisfiable, constraint.show)
-    }
   }
 
-  protected def isSubType(tp1: Type, tp2: Type): Boolean = trace(s"isSubType ${traceInfo(tp1, tp2)} $loIsPrecise $hiIsPrecise", subtyping) {
-    //assert(s"isSubType ${traceInfo(tp1, tp2)} $loIsPrecise $hiIsPrecise" !=
-    //        "isSubType String <:< E false true")
+  protected def isSubType(tp1: Type, tp2: Type): Boolean = isSubType(tp1, tp2, Precise)
+
+  protected def isSubType(tp1: Type, tp2: Type, approx: ApproxState): Boolean = trace(s"isSubType ${traceInfo(tp1, tp2)} $approx", subtyping) {
+
+    def monitoredIsSubType = {
+      if (pendingSubTypes == null) {
+        pendingSubTypes = new mutable.HashSet[(Type, Type)]
+        ctx.log(s"!!! deep subtype recursion involving ${tp1.show} <:< ${tp2.show}, constraint = ${state.constraint.show}")
+        ctx.log(s"!!! constraint = ${constraint.show}")
+        //if (ctx.settings.YnoDeepSubtypes.value) {
+        //  new Error("deep subtype").printStackTrace()
+        //}
+        assert(!ctx.settings.YnoDeepSubtypes.value)
+        if (Config.traceDeepSubTypeRecursions && !this.isInstanceOf[ExplainingTypeComparer])
+          ctx.log(TypeComparer.explained(implicit ctx => ctx.typeComparer.isSubType(tp1, tp2, approx)))
+      }
+      // Eliminate LazyRefs before checking whether we have seen a type before
+      val normalize = new TypeMap {
+        val DerefLimit = 10
+        var derefCount = 0
+        def apply(t: Type) = t match {
+          case t: LazyRef =>
+            // Dereference a lazyref to detect underlying matching types, but
+            // be careful not to get into an infinite recursion. If recursion count
+            // exceeds `DerefLimit`, approximate with `NoType` instead.
+            derefCount += 1
+            if (derefCount >= DerefLimit) NoType
+            else try mapOver(t.ref) finally derefCount -= 1
+          case _ =>
+            mapOver(t)
+        }
+      }
+      val p = (normalize(tp1), normalize(tp2))
+      !pendingSubTypes(p) && {
+        try {
+          pendingSubTypes += p
+          firstTry
+        } finally {
+          pendingSubTypes -= p
+        }
+      }
+    }
+
+    def firstTry: Boolean = tp2 match {
+      case tp2: NamedType =>
+        def compareNamed(tp1: Type, tp2: NamedType): Boolean = {
+          implicit val ctx = this.ctx
+          tp2.info match {
+            case info2: TypeAlias => recur(tp1, info2.alias)
+            case _ => tp1 match {
+              case tp1: NamedType =>
+                tp1.info match {
+                  case info1: TypeAlias =>
+                    if (recur(info1.alias, tp2)) return true
+                    if (tp1.prefix.isStable) return false
+                      // If tp1.prefix is stable, the alias does contain all information about the original ref, so
+                      // there's no need to try something else. (This is important for performance).
+                      // To see why we cannot in general stop here, consider:
+                      //
+                      //     trait C { type A }
+                      //     trait D { type A = String }
+                      //     (C & D)#A <: C#A
+                      //
+                      // Following the alias leads to the judgment `String <: C#A` which is false.
+                      // However the original judgment should be true.
+                  case _ =>
+                }
+                val sym2 = tp2.symbol
+                var sym1 = tp1.symbol
+                if (sym1.is(ModuleClass) && sym2.is(ModuleVal))
+                  // For convenience we want X$ <:< X.type
+                  // This is safe because X$ self-type is X.type
+                  sym1 = sym1.companionModule
+                if ((sym1 ne NoSymbol) && (sym1 eq sym2))
+                  ctx.erasedTypes ||
+                  sym1.isStaticOwner ||
+                  isSubType(tp1.prefix, tp2.prefix) ||
+                  thirdTryNamed(tp2)
+                else
+                  (  (tp1.name eq tp2.name)
+                  && tp1.isMemberRef
+                  && tp2.isMemberRef
+                  && isSubType(tp1.prefix, tp2.prefix)
+                  && tp1.signature == tp2.signature
+                  && !(sym1.isClass && sym2.isClass)  // class types don't subtype each other
+                  ) ||
+                  thirdTryNamed(tp2)
+              case _ =>
+                secondTry
+            }
+          }
+        }
+        compareNamed(tp1, tp2)
+      case tp2: ProtoType =>
+        isMatchedByProto(tp2, tp1)
+      case tp2: BoundType =>
+        tp2 == tp1 || secondTry
+      case tp2: TypeVar =>
+        recur(tp1, tp2.underlying)
+      case tp2: WildcardType =>
+        def compareWild = tp2.optBounds match {
+          case TypeBounds(_, hi) => recur(tp1, hi)
+          case NoType => true
+        }
+        compareWild
+      case tp2: LazyRef =>
+        !tp2.evaluating && recur(tp1, tp2.ref)
+      case tp2: AnnotatedType =>
+        recur(tp1, tp2.tpe) // todo: refine?
+      case tp2: ThisType =>
+        def compareThis = {
+          val cls2 = tp2.cls
+          tp1 match {
+            case tp1: ThisType =>
+              // We treat two prefixes A.this, B.this as equivalent if
+              // A's selftype derives from B and B's selftype derives from A.
+              val cls1 = tp1.cls
+              cls1.classInfo.selfType.derivesFrom(cls2) &&
+              cls2.classInfo.selfType.derivesFrom(cls1)
+            case tp1: NamedType if cls2.is(Module) && cls2.eq(tp1.widen.typeSymbol) =>
+              cls2.isStaticOwner ||
+              recur(tp1.prefix, cls2.owner.thisType) ||
+              secondTry
+            case _ =>
+              secondTry
+          }
+        }
+        compareThis
+      case tp2: SuperType =>
+        def compareSuper = tp1 match {
+          case tp1: SuperType =>
+            isSubType(tp1.thistpe, tp2.thistpe) &&
+            isSameType(tp1.supertpe, tp2.supertpe)
+          case _ =>
+            secondTry
+        }
+        compareSuper
+      case AndType(tp21, tp22) =>
+        recur(tp1, tp21) && recur(tp1, tp22)
+      case OrType(tp21, tp22) =>
+        if (tp21.stripTypeVar eq tp22.stripTypeVar) recur(tp1, tp21)
+        else secondTry
+      case TypeErasure.ErasedValueType(tycon1, underlying2) =>
+        def compareErasedValueType = tp1 match {
+          case TypeErasure.ErasedValueType(tycon2, underlying1) =>
+            (tycon1.symbol eq tycon2.symbol) && isSameType(underlying1, underlying2)
+          case _ =>
+            secondTry
+        }
+        compareErasedValueType
+      case ConstantType(v2) =>
+        tp1 match {
+          case ConstantType(v1) => v1.value == v2.value
+          case _ => secondTry
+        }
+      case _: FlexType =>
+        true
+      case _ =>
+        secondTry
+    }
+
+    def secondTry: Boolean = tp1 match {
+      case tp1: NamedType =>
+        tp1.info match {
+          case info1: TypeAlias =>
+            if (recur(info1.alias, tp2)) return true
+            if (tp1.prefix.isStable) return false
+          case _ =>
+        }
+        thirdTry
+      case tp1: TypeParamRef =>
+        def flagNothingBound = {
+          if (!frozenConstraint && tp2.isRef(defn.NothingClass) && state.isGlobalCommittable) {
+            def msg = s"!!! instantiated to Nothing: $tp1, constraint = ${constraint.show}"
+            if (Config.failOnInstantiationToNothing) assert(false, msg)
+            else ctx.log(msg)
+          }
+          true
+        }
+        def compareTypeParamRef =
+          ctx.mode.is(Mode.TypevarsMissContext) ||
+          isSubTypeWhenFrozen(bounds(tp1).hi, tp2) || {
+            if (canConstrain(tp1) && (approx & HiApprox) == 0)
+              addConstraint(tp1, tp2, fromBelow = false) && flagNothingBound
+            else thirdTry
+          }
+        compareTypeParamRef
+      case tp1: ThisType =>
+        val cls1 = tp1.cls
+        tp2 match {
+          case tp2: TermRef if cls1.is(Module) && cls1.eq(tp2.widen.typeSymbol) =>
+            cls1.isStaticOwner ||
+            recur(cls1.owner.thisType, tp2.prefix) ||
+            thirdTry
+          case _ =>
+            thirdTry
+        }
+      case tp1: SkolemType =>
+        tp2 match {
+          case tp2: SkolemType if !ctx.phase.isTyper && isSubType(tp1.info, tp2.info) => true
+          case _ => thirdTry
+        }
+      case tp1: TypeVar =>
+        recur(tp1.underlying, tp2)
+      case tp1: WildcardType =>
+        def compareWild = tp1.optBounds match {
+          case TypeBounds(lo, _) => recur(lo, tp2)
+          case _ => true
+        }
+        compareWild
+      case tp1: LazyRef =>
+        // If `tp1` is in train of being evaluated, don't force it
+        // because that would cause an assertionError. Return false instead.
+        // See i859.scala for an example where we hit this case.
+        !tp1.evaluating && recur(tp1.ref, tp2)
+      case tp1: AnnotatedType =>
+        recur(tp1.tpe, tp2)
+      case AndType(tp11, tp12) =>
+        if (tp11.stripTypeVar eq tp12.stripTypeVar) recur(tp11, tp2)
+        else thirdTry
+      case tp1 @ OrType(tp11, tp12) =>
+        def joinOK = tp2.dealias match {
+          case tp2: AppliedType if !tp2.tycon.typeSymbol.isClass =>
+            // If we apply the default algorithm for `A[X] | B[Y] <: C[Z]` where `C` is a
+            // type parameter, we will instantiate `C` to `A` and then fail when comparing
+            // with `B[Y]`. To do the right thing, we need to instantiate `C` to the
+            // common superclass of `A` and `B`.
+            recur(tp1.join, tp2)
+          case _ =>
+            false
+        }
+        joinOK || recur(tp11, tp2) && recur(tp12, tp2)
+      case _: FlexType =>
+        true
+      case _ =>
+        thirdTry
+    }
+
+    def thirdTryNamed(tp2: NamedType): Boolean = tp2.info match {
+      case TypeBounds(lo2, _) =>
+        def compareGADT: Boolean = {
+          val gbounds2 = ctx.gadt.bounds(tp2.symbol)
+          (gbounds2 != null) &&
+            (isSubTypeWhenFrozen(tp1, gbounds2.lo) ||
+              narrowGADTBounds(tp2, tp1, approx, isUpper = false)) &&
+            GADTusage(tp2.symbol)
+        }
+        val tryLowerFirst = frozenConstraint || !isCappable(tp1)
+        if (tryLowerFirst) isSubType(tp1, lo2, approx | HiApprox) || compareGADT || fourthTry
+        else compareGADT || fourthTry || isSubType(tp1, lo2, approx | HiApprox)
+
+      case _ =>
+        val cls2 = tp2.symbol
+        if (cls2.isClass) {
+          if (cls2.typeParams.nonEmpty && tp1.isHK)
+            recur(tp1, EtaExpansion(cls2.typeRef))
+          else {
+            val base = tp1.baseType(cls2)
+            if (base.exists) {
+              if (cls2.is(JavaDefined))
+                // If `cls2` is parameterized, we are seeing a raw type, so we need to compare only the symbol
+                return base.typeSymbol == cls2
+              if (base ne tp1)
+                return isSubType(base, tp2, if (tp1.isRef(cls2)) approx else approx | LoApprox)
+            }
+            if (cls2 == defn.SingletonClass && tp1.isStable) return true
+          }
+        }
+        fourthTry
+    }
+
+    def thirdTry: Boolean = tp2 match {
+      case tp2 @ AppliedType(tycon2, args2) =>
+        compareAppliedType2(tp2, tycon2, args2)
+      case tp2: NamedType =>
+        thirdTryNamed(tp2)
+      case tp2: TypeParamRef =>
+        def compareTypeParamRef =
+          (ctx.mode is Mode.TypevarsMissContext) || {
+          val alwaysTrue =
+            // The following condition is carefully formulated to catch all cases
+            // where the subtype relation is true without needing to add a constraint
+            // It's tricky because we might need to either appriximate tp2 by its
+            // lower bound or else widen tp1 and check that the result is a subtype of tp2.
+            // So if the constraint is not yet frozen, we do the same comparison again
+            // with a frozen constraint, which means that we get a chance to do the
+            // widening in `fourthTry` before adding to the constraint.
+            if (frozenConstraint) isSubType(tp1, bounds(tp2).lo)
+            else isSubTypeWhenFrozen(tp1, tp2)
+          alwaysTrue || {
+            if (canConstrain(tp2) && (approx & LoApprox) == 0)
+              addConstraint(tp2, tp1.widenExpr, fromBelow = true)
+            else fourthTry
+          }
+        }
+        compareTypeParamRef
+      case tp2: RefinedType =>
+        def compareRefinedSlow: Boolean = {
+          val name2 = tp2.refinedName
+          recur(tp1, tp2.parent) &&
+            (name2 == nme.WILDCARD || hasMatchingMember(name2, tp1, tp2))
+        }
+        def compareRefined: Boolean = {
+          val tp1w = tp1.widen
+          val skipped2 = skipMatching(tp1w, tp2)
+          if ((skipped2 eq tp2) || !Config.fastPathForRefinedSubtype)
+            tp1 match {
+              case tp1: AndType =>
+                // Delay calling `compareRefinedSlow` because looking up a member
+                // of an `AndType` can lead to a cascade of subtyping checks
+                // This twist is needed to make collection/generic/ParFactory.scala compile
+                fourthTry || compareRefinedSlow
+              case tp1: HKTypeLambda =>
+                // HKTypeLambdas do not have members.
+                fourthTry
+              case _ =>
+                compareRefinedSlow || fourthTry
+            }
+          else // fast path, in particular for refinements resulting from parameterization.
+            isSubRefinements(tp1w.asInstanceOf[RefinedType], tp2, skipped2) &&
+            recur(tp1, skipped2)
+        }
+        compareRefined
+      case tp2: RecType =>
+        def compareRec = tp1.safeDealias match {
+          case tp1: RecType =>
+            val rthis1 = tp1.recThis
+            recur(tp1.parent, tp2.parent.substRecThis(tp2, rthis1))
+          case _ =>
+            val tp1stable = ensureStableSingleton(tp1)
+            recur(fixRecs(tp1stable, tp1stable.widenExpr), tp2.parent.substRecThis(tp2, tp1stable))
+        }
+        compareRec
+      case tp2: HKTypeLambda =>
+        def compareTypeLambda: Boolean = tp1.stripTypeVar match {
+          case tp1: HKTypeLambda =>
+            /* Don't compare bounds of lambdas under language:Scala2, or t2994 will fail.
+            * The issue is that, logically, bounds should compare contravariantly,
+            * but that would invalidate a pattern exploited in t2994:
+            *
+            *    [X0 <: Number] -> Number   <:<    [X0] -> Any
+            *
+            * Under the new scheme, `[X0] -> Any` is NOT a kind that subsumes
+            * all other bounds. You'd have to write `[X0 >: Any <: Nothing] -> Any` instead.
+            * This might look weird, but is the only logically correct way to do it.
+            *
+            * Note: it would be nice if this could trigger a migration warning, but I
+            * am not sure how, since the code is buried so deep in subtyping logic.
+            */
+            def boundsOK =
+              ctx.scala2Mode ||
+              tp1.typeParams.corresponds(tp2.typeParams)((tparam1, tparam2) =>
+                isSubType(tparam2.paramInfo.subst(tp2, tp1), tparam1.paramInfo))
+            val saved = comparedTypeLambdas
+            comparedTypeLambdas += tp1
+            comparedTypeLambdas += tp2
+            try
+              variancesConform(tp1.typeParams, tp2.typeParams) &&
+              boundsOK &&
+              isSubType(tp1.resType, tp2.resType.subst(tp2, tp1))
+            finally comparedTypeLambdas = saved
+          case _ =>
+            if (tp1.isHK) {
+              val tparams1 = tp1.typeParams
+              return recur(
+                HKTypeLambda.fromParams(tparams1, tp1.appliedTo(tparams1.map(_.paramRef))),
+                tp2
+              )
+            }
+            else tp2 match {
+              case EtaExpansion(tycon2) if tycon2.symbol.isClass =>
+                return recur(tp1, tycon2)
+              case _ =>
+            }
+            fourthTry
+        }
+        compareTypeLambda
+      case OrType(tp21, tp22) =>
+        val tp1a = tp1.widenDealias
+        if (tp1a ne tp1)
+          // Follow the alias; this might avoid truncating the search space in the either below
+          // Note that it's safe to widen here because singleton types cannot be part of `|`.
+          return recur(tp1a, tp2)
+
+        // Rewrite T1 <: (T211 & T212) | T22 to T1 <: (T211 | T22) and T1 <: (T212 | T22)
+        // and analogously for T1 <: T21 | (T221 & T222)
+        // `|' types to the right of <: are problematic, because
+        // we have to choose one constraint set or another, which might cut off
+        // solutions. The rewriting delays the point where we have to choose.
+        tp21 match {
+          case AndType(tp211, tp212) =>
+            return recur(tp1, OrType(tp211, tp22)) && recur(tp1, OrType(tp212, tp22))
+          case _ =>
+        }
+        tp22 match {
+          case AndType(tp221, tp222) =>
+            return recur(tp1, OrType(tp21, tp221)) && recur(tp1, OrType(tp21, tp222))
+          case _ =>
+        }
+        either(recur(tp1, tp21), recur(tp1, tp22)) || fourthTry
+      case tp2: MethodOrPoly =>
+        def compareMethod = tp1 match {
+          case tp1: MethodOrPoly =>
+            (tp1.signature consistentParams tp2.signature) &&
+              matchingParams(tp1, tp2) &&
+              (!tp2.isImplicitMethod || tp1.isImplicitMethod) &&
+              isSubType(tp1.resultType, tp2.resultType.subst(tp2, tp1))
+          case _ =>
+            false
+        }
+        compareMethod
+      case tp2 @ ExprType(restpe2) =>
+        def compareExpr = tp1 match {
+          // We allow ()T to be a subtype of => T.
+          // We need some subtype relationship between them so that e.g.
+          // def toString   and   def toString()   don't clash when seen
+          // as members of the same type. And it seems most logical to take
+          // ()T <:< => T, since everything one can do with a => T one can
+          // also do with a ()T by automatic () insertion.
+          case tp1 @ MethodType(Nil) => isSubType(tp1.resultType, restpe2)
+          case _ => isSubType(tp1.widenExpr, restpe2)
+        }
+        compareExpr
+      case tp2 @ TypeBounds(lo2, hi2) =>
+        def compareTypeBounds = tp1 match {
+          case tp1 @ TypeBounds(lo1, hi1) =>
+            ((lo2 eq NothingType) || isSubType(lo2, lo1)) &&
+            ((hi2 eq AnyType) || isSubType(hi1, hi2))
+          case tp1: ClassInfo =>
+            tp2 contains tp1
+          case _ =>
+            false
+        }
+        compareTypeBounds
+      case ClassInfo(pre2, cls2, _, _, _) =>
+        def compareClassInfo = tp1 match {
+          case ClassInfo(pre1, cls1, _, _, _) =>
+            (cls1 eq cls2) && isSubType(pre1, pre2)
+          case _ =>
+            false
+        }
+        compareClassInfo
+      case _ =>
+        fourthTry
+    }
+
+    def fourthTry: Boolean = tp1 match {
+      case tp1: TypeRef =>
+        tp1.info match {
+          case TypeBounds(_, hi1) =>
+            def compareGADT = {
+              val gbounds1 = ctx.gadt.bounds(tp1.symbol)
+              (gbounds1 != null) &&
+                (isSubTypeWhenFrozen(gbounds1.hi, tp2) ||
+                narrowGADTBounds(tp1, tp2, approx, isUpper = true)) &&
+                GADTusage(tp1.symbol)
+            }
+            isSubType(hi1, tp2, approx | LoApprox) || compareGADT
+          case _ =>
+            def isNullable(tp: Type): Boolean = tp.widenDealias match {
+              case tp: TypeRef => tp.symbol.isNullableClass
+              case tp: RefinedOrRecType => isNullable(tp.parent)
+              case tp: AppliedType => isNullable(tp.tycon)
+              case AndType(tp1, tp2) => isNullable(tp1) && isNullable(tp2)
+              case OrType(tp1, tp2) => isNullable(tp1) || isNullable(tp2)
+              case _ => false
+            }
+            val sym1 = tp1.symbol
+            (sym1 eq NothingClass) && tp2.isValueTypeOrLambda && !tp2.isPhantom ||
+            (sym1 eq NullClass) && isNullable(tp2) ||
+            (sym1 eq PhantomNothingClass) && tp1.topType == tp2.topType
+        }
+      case tp1 @ AppliedType(tycon1, args1) =>
+        compareAppliedType1(tp1, tycon1, args1)
+      case tp1: SingletonType =>
+        /** if `tp2 == p.type` and `p: q.type` then try `tp1 <:< q.type` as a last effort.*/
+        def comparePaths = tp2 match {
+          case tp2: TermRef =>
+            tp2.info.widenExpr.dealias match {
+              case tp2i: SingletonType =>
+                recur(tp1, tp2i)
+                  // see z1720.scala for a case where this can arise even in typer.
+                  // Also, i1753.scala, to show why the dealias above is necessary.
+              case _ => false
+            }
+          case _ =>
+            false
+        }
+        isNewSubType(tp1.underlying.widenExpr) || comparePaths
+      case tp1: RefinedType =>
+        isNewSubType(tp1.parent)
+      case tp1: RecType =>
+        isNewSubType(tp1.parent)
+      case tp1: HKTypeLambda =>
+        def compareHKLambda = tp1 match {
+          case EtaExpansion(tycon1) => recur(tycon1, tp2)
+          case _ => tp2 match {
+            case tp2: HKTypeLambda => false // this case was covered in thirdTry
+            case _ => tp2.isHK && isSubType(tp1.resultType, tp2.appliedTo(tp1.paramRefs))
+          }
+        }
+        compareHKLambda
+      case AndType(tp11, tp12) =>
+        val tp2a = tp2.dealias
+        if (tp2a ne tp2) // Follow the alias; this might avoid truncating the search space in the either below
+          return recur(tp1, tp2a)
+
+        // Rewrite (T111 | T112) & T12 <: T2 to (T111 & T12) <: T2 and (T112 | T12) <: T2
+        // and analogously for T11 & (T121 | T122) & T12 <: T2
+        // `&' types to the left of <: are problematic, because
+        // we have to choose one constraint set or another, which might cut off
+        // solutions. The rewriting delays the point where we have to choose.
+        tp11 match {
+          case OrType(tp111, tp112) =>
+            return recur(AndType(tp111, tp12), tp2) && recur(AndType(tp112, tp12), tp2)
+          case _ =>
+        }
+        tp12 match {
+          case OrType(tp121, tp122) =>
+            return recur(AndType(tp11, tp121), tp2) && recur(AndType(tp11, tp122), tp2)
+          case _ =>
+        }
+        either(recur(tp11, tp2), recur(tp12, tp2))
+      case JavaArrayType(elem1) =>
+        def compareJavaArray = tp2 match {
+          case JavaArrayType(elem2) => isSubType(elem1, elem2)
+          case _ => tp2 isRef ObjectClass
+        }
+        compareJavaArray
+      case tp1: ExprType if ctx.phase.id > ctx.gettersPhase.id =>
+        // getters might have converted T to => T, need to compensate.
+        recur(tp1.widenExpr, tp2)
+      case _ =>
+        false
+    }
+
+    /** Subtype test for the hk application `tp2 = tycon2[args2]`.
+    */
+    def compareAppliedType2(tp2: AppliedType, tycon2: Type, args2: List[Type]): Boolean = {
+      val tparams = tycon2.typeParams
+      if (tparams.isEmpty) return false // can happen for ill-typed programs, e.g. neg/tcpoly_overloaded.scala
+
+      /** True if `tp1` and `tp2` have compatible type constructors and their
+      *  corresponding arguments are subtypes relative to their variance (see `isSubArgs`).
+      */
+      def isMatchingApply(tp1: Type): Boolean = tp1 match {
+        case AppliedType(tycon1, args1) =>
+          tycon1.dealias match {
+            case tycon1: TypeParamRef =>
+              (tycon1 == tycon2 ||
+              canConstrain(tycon1) && tryInstantiate(tycon1, tycon2)) &&
+              isSubArgs(args1, args2, tp1, tparams)
+            case tycon1: TypeRef =>
+              tycon2.dealias match {
+                case tycon2: TypeRef if tycon1.symbol == tycon2.symbol =>
+                  isSubType(tycon1.prefix, tycon2.prefix) &&
+                  isSubArgs(args1, args2, tp1, tparams)
+                case _ =>
+                  false
+              }
+            case tycon1: TypeVar =>
+              isMatchingApply(tycon1.underlying)
+            case tycon1: AnnotatedType =>
+              isMatchingApply(tycon1.underlying)
+            case _ =>
+              false
+          }
+        case _ =>
+          false
+      }
+
+      /** `param2` can be instantiated to a type application prefix of the LHS
+      *  or to a type application prefix of one of the LHS base class instances
+      *  and the resulting type application is a supertype of `tp1`,
+      *  or fallback to fourthTry.
+      */
+      def canInstantiate(tycon2: TypeParamRef): Boolean = {
+
+        /** Let
+        *
+        *    `tparams_1, ..., tparams_k-1`    be the type parameters of the rhs
+        *    `tparams1_1, ..., tparams1_n-1`  be the type parameters of the constructor of the lhs
+        *    `args1_1, ..., args1_n-1`        be the type arguments of the lhs
+        *    `d  =  n - k`
+        *
+        *  Returns `true` iff `d >= 0` and `tycon2` can be instantiated to
+        *
+        *      [tparams1_d, ... tparams1_n-1] -> tycon1[args_1, ..., args_d-1, tparams_d, ... tparams_n-1]
+        *
+        *  such that the resulting type application is a supertype of `tp1`.
+        */
+        def appOK(tp1base: Type) = tp1base match {
+          case tp1base: AppliedType =>
+            var tycon1 = tp1base.tycon
+            val args1 = tp1base.args
+            val tparams1all = tycon1.typeParams
+            val lengthDiff = tparams1all.length - tparams.length
+            lengthDiff >= 0 && {
+              val tparams1 = tparams1all.drop(lengthDiff)
+              variancesConform(tparams1, tparams) && {
+                if (lengthDiff > 0)
+                  tycon1 = HKTypeLambda(tparams1.map(_.paramName))(
+                    tl => tparams1.map(tparam => tl.integrate(tparams, tparam.paramInfo).bounds),
+                    tl => tp1base.tycon.appliedTo(args1.take(lengthDiff) ++
+                            tparams1.indices.toList.map(tl.paramRefs(_))))
+                (ctx.mode.is(Mode.TypevarsMissContext) ||
+                  tryInstantiate(tycon2, tycon1.ensureHK)) &&
+                  recur(tp1, tycon1.appliedTo(args2))
+              }
+            }
+          case _ => false
+        }
+
+        tp1.widen match {
+          case tp1w: AppliedType => appOK(tp1w)
+          case tp1w =>
+            tp1w.typeSymbol.isClass && {
+              val classBounds = tycon2.classSymbols
+              def liftToBase(bcs: List[ClassSymbol]): Boolean = bcs match {
+                case bc :: bcs1 =>
+                  classBounds.exists(bc.derivesFrom) && appOK(tp1w.baseType(bc)) ||
+                  liftToBase(bcs1)
+                case _ =>
+                  false
+              }
+              liftToBase(tp1w.baseClasses)
+            } ||
+            fourthTry
+        }
+      }
+
+      /** Fall back to comparing either with `fourthTry` or against the lower
+      *  approximation of the rhs.
+      *  @param   tyconLo   The type constructor's lower approximation.
+      */
+      def fallback(tyconLo: Type) =
+        either(fourthTry, isSubType(tp1, tyconLo.applyIfParameterized(args2), approx | HiApprox))
+
+      /** Let `tycon2bounds` be the bounds of the RHS type constructor `tycon2`.
+      *  Let `app2 = tp2` where the type constructor of `tp2` is replaced by
+      *  `tycon2bounds.lo`.
+      *  If both bounds are the same, continue with `tp1 <:< app2`.
+      *  otherwise continue with either
+      *
+      *    tp1 <:< tp2    using fourthTry (this might instantiate params in tp1)
+      *    tp1 <:< app2   using isSubType (this might instantiate params in tp2)
+      */
+      def compareLower(tycon2bounds: TypeBounds, tyconIsTypeRef: Boolean): Boolean =
+        if (tycon2bounds.lo eq tycon2bounds.hi)
+          if (tyconIsTypeRef) recur(tp1, tp2.superType)
+          else isSubType(tp1, tycon2bounds.lo.applyIfParameterized(args2), approx | HiApprox)
+        else
+          fallback(tycon2bounds.lo)
+
+      tycon2 match {
+        case param2: TypeParamRef =>
+          isMatchingApply(tp1) ||
+          canConstrain(param2) && canInstantiate(param2) ||
+          compareLower(bounds(param2), tyconIsTypeRef = false)
+        case tycon2: TypeRef =>
+          isMatchingApply(tp1) || {
+            tycon2.info match {
+              case info2: TypeBounds =>
+                compareLower(info2, tyconIsTypeRef = true)
+              case info2: ClassInfo =>
+                val base = tp1.baseType(info2.cls)
+                if (base.exists && base.ne(tp1))
+                  isSubType(base, tp2, if (tp1.isRef(info2.cls)) approx else approx | LoApprox)
+                else fourthTry
+              case _ =>
+                fourthTry
+            }
+          }
+        case _: TypeVar | _: AnnotatedType =>
+          recur(tp1, tp2.superType)
+        case tycon2: AppliedType =>
+          fallback(tycon2.lowerBound)
+        case _ =>
+          false
+      }
+    }
+
+    /** Subtype test for the application `tp1 = tycon1[args1]`.
+    */
+    def compareAppliedType1(tp1: AppliedType, tycon1: Type, args1: List[Type]): Boolean =
+      tycon1 match {
+        case param1: TypeParamRef =>
+          def canInstantiate = tp2 match {
+            case AppliedType(tycon2, args2) =>
+              tryInstantiate(param1, tycon2.ensureHK) && isSubArgs(args1, args2, tp1, tycon2.typeParams)
+            case _ =>
+              false
+          }
+          canConstrain(param1) && canInstantiate ||
+            isSubType(bounds(param1).hi.applyIfParameterized(args1), tp2, approx | LoApprox)
+        case tycon1: TypeRef if tycon1.symbol.isClass =>
+          false
+        case tycon1: TypeProxy =>
+          recur(tp1.superType, tp2)
+        case _ =>
+          false
+      }
+
+    /** Like tp1 <:< tp2, but returns false immediately if we know that
+    *  the case was covered previously during subtyping.
+    */
+    def isNewSubType(tp1: Type): Boolean =
+      if (isCovered(tp1) && isCovered(tp2)) {
+        //println(s"useless subtype: $tp1 <:< $tp2")
+        false
+      } else isSubType(tp1, tp2, approx | LoApprox)
+
+    def recur(tp1: Type, tp2: Type) = isSubType(tp1, tp2, approx)
+
+    // begin isSubType
     if (tp2 eq NoType) false
     else if (tp1 eq tp2) true
     else {
@@ -126,8 +829,9 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
       val savedSuccessCount = successCount
       try {
         recCount = recCount + 1
-        if (recCount >= Config.LogPendingSubTypesThreshold) monitored = true
-        val result = if (monitored) monitoredIsSubType(tp1, tp2) else firstTry(tp1, tp2)
+        val result =
+          if (recCount < Config.LogPendingSubTypesThreshold) firstTry
+          else monitoredIsSubType
         recCount = recCount - 1
         if (!result) state.resetConstraintTo(saved)
         else if (recCount == 0 && needsGc) {
@@ -147,739 +851,9 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     }
   }
 
-  private def monitoredIsSubType(tp1: Type, tp2: Type) = {
-    if (pendingSubTypes == null) {
-      pendingSubTypes = new mutable.HashSet[(Type, Type)]
-      ctx.log(s"!!! deep subtype recursion involving ${tp1.show} <:< ${tp2.show}, constraint = ${state.constraint.show}")
-      ctx.log(s"!!! constraint = ${constraint.show}")
-      //if (ctx.settings.YnoDeepSubtypes.value) {
-      //  new Error("deep subtype").printStackTrace()
-      //}
-      assert(!ctx.settings.YnoDeepSubtypes.value)
-      if (Config.traceDeepSubTypeRecursions && !this.isInstanceOf[ExplainingTypeComparer])
-        ctx.log(TypeComparer.explained(implicit ctx => ctx.typeComparer.isSubType(tp1, tp2)))
-    }
-    // Eliminate LazyRefs before checking whether we have seen a type before
-    val normalize = new TypeMap {
-      val DerefLimit = 10
-      var derefCount = 0
-      def apply(t: Type) = t match {
-        case t: LazyRef =>
-          // Dereference a lazyref to detect underlying matching types, but
-          // be careful not to get into an infinite recursion. If recursion count
-          // exceeds `DerefLimit`, approximate with `NoType` instead.
-          derefCount += 1
-          if (derefCount >= DerefLimit) NoType
-          else try mapOver(t.ref) finally derefCount -= 1
-        case _ =>
-          mapOver(t)
-      }
-    }
-    val p = (normalize(tp1), normalize(tp2))
-    !pendingSubTypes(p) && {
-      try {
-        pendingSubTypes += p
-        firstTry(tp1, tp2)
-      } finally {
-        pendingSubTypes -= p
-      }
-    }
-  }
-
-  private def isSubApproxLo(tp1: Type, tp2: Type) = {
-    val saved = loIsPrecise
-    loIsPrecise = false
-    try isSubType(tp1, tp2) finally loIsPrecise = saved
-  }
-
-  private def isSubApproxHi(tp1: Type, tp2: Type) = {
-    val saved = hiIsPrecise
-    hiIsPrecise = false
-    try isSubType(tp1, tp2) finally hiIsPrecise = saved
-  }
-
-  private def isSubTypePart(tp1: Type, tp2: Type) = {
-    val savedHi = hiIsPrecise
-    val savedLo = loIsPrecise
-    hiIsPrecise = true
-    loIsPrecise = true
-    try isSubType(tp1, tp2) finally {
-      hiIsPrecise = savedHi
-      loIsPrecise = savedLo
-    }
-  }
-
-  private def firstTry(tp1: Type, tp2: Type): Boolean = tp2 match {
-    case tp2: NamedType =>
-      def compareNamed(tp1: Type, tp2: NamedType): Boolean = {
-        implicit val ctx = this.ctx
-        tp2.info match {
-          case info2: TypeAlias => isSubType(tp1, info2.alias)
-          case _ => tp1 match {
-            case tp1: NamedType =>
-              tp1.info match {
-                case info1: TypeAlias =>
-                  if (isSubType(info1.alias, tp2)) return true
-                  if (tp1.prefix.isStable) return false
-                    // If tp1.prefix is stable, the alias does contain all information about the original ref, so
-                    // there's no need to try something else. (This is important for performance).
-                    // To see why we cannot in general stop here, consider:
-                    //
-                    //     trait C { type A }
-                    //     trait D { type A = String }
-                    //     (C & D)#A <: C#A
-                    //
-                    // Following the alias leads to the judgment `String <: C#A` which is false.
-                    // However the original judgment should be true.
-                case _ =>
-              }
-              val sym2 = tp2.symbol
-              var sym1 = tp1.symbol
-              if (sym1.is(ModuleClass) && sym2.is(ModuleVal))
-                // For convenience we want X$ <:< X.type
-                // This is safe because X$ self-type is X.type
-                 sym1 = sym1.companionModule
-              if ((sym1 ne NoSymbol) && (sym1 eq sym2))
-                ctx.erasedTypes ||
-                sym1.isStaticOwner ||
-                isSubTypePart(tp1.prefix, tp2.prefix) ||
-                thirdTryNamed(tp1, tp2)
-              else
-                (  (tp1.name eq tp2.name)
-                && tp1.isMemberRef
-                && tp2.isMemberRef
-                && isSubTypePart(tp1.prefix, tp2.prefix)
-                && tp1.signature == tp2.signature
-                && !(sym1.isClass && sym2.isClass)  // class types don't subtype each other
-                ) ||
-                thirdTryNamed(tp1, tp2)
-            case _ =>
-              secondTry(tp1, tp2)
-          }
-        }
-      }
-      compareNamed(tp1, tp2)
-    case tp2: ProtoType =>
-      isMatchedByProto(tp2, tp1)
-    case tp2: BoundType =>
-      tp2 == tp1 || secondTry(tp1, tp2)
-    case tp2: TypeVar =>
-      isSubType(tp1, tp2.underlying)
-    case tp2: WildcardType =>
-      def compareWild = tp2.optBounds match {
-        case TypeBounds(_, hi) => isSubType(tp1, hi)
-        case NoType => true
-      }
-      compareWild
-    case tp2: LazyRef =>
-      !tp2.evaluating && isSubType(tp1, tp2.ref)
-    case tp2: AnnotatedType =>
-      isSubType(tp1, tp2.tpe) // todo: refine?
-    case tp2: ThisType =>
-      def compareThis = {
-        val cls2 = tp2.cls
-        tp1 match {
-          case tp1: ThisType =>
-            // We treat two prefixes A.this, B.this as equivalent if
-            // A's selftype derives from B and B's selftype derives from A.
-            val cls1 = tp1.cls
-            cls1.classInfo.selfType.derivesFrom(cls2) &&
-            cls2.classInfo.selfType.derivesFrom(cls1)
-          case tp1: NamedType if cls2.is(Module) && cls2.eq(tp1.widen.typeSymbol) =>
-            cls2.isStaticOwner ||
-            isSubType(tp1.prefix, cls2.owner.thisType) ||
-            secondTry(tp1, tp2)
-          case _ =>
-            secondTry(tp1, tp2)
-        }
-      }
-      compareThis
-    case tp2: SuperType =>
-      def compareSuper = tp1 match {
-        case tp1: SuperType =>
-          isSubType(tp1.thistpe, tp2.thistpe) &&
-          isSameType(tp1.supertpe, tp2.supertpe)
-        case _ =>
-          secondTry(tp1, tp2)
-      }
-      compareSuper
-    case AndType(tp21, tp22) =>
-      isSubType(tp1, tp21) && isSubType(tp1, tp22) // no isSubApprox, as the two calls together maintain all information
-    case OrType(tp21, tp22) =>
-      if (tp21.stripTypeVar eq tp22.stripTypeVar) isSubType(tp1, tp21)
-      else secondTry(tp1, tp2)
-    case TypeErasure.ErasedValueType(tycon1, underlying2) =>
-      def compareErasedValueType = tp1 match {
-        case TypeErasure.ErasedValueType(tycon2, underlying1) =>
-          (tycon1.symbol eq tycon2.symbol) && isSameType(underlying1, underlying2)
-        case _ =>
-          secondTry(tp1, tp2)
-      }
-      compareErasedValueType
-    case ConstantType(v2) =>
-      tp1 match {
-        case ConstantType(v1) => v1.value == v2.value
-        case _ => secondTry(tp1, tp2)
-      }
-    case _: FlexType =>
-      true
-    case _ =>
-      secondTry(tp1, tp2)
-  }
-
-  def testConstrain(tp1: Type, tp2: Type, isUpper: Boolean): Boolean =
-    !newScheme ||
-    (if (isUpper) hiIsPrecise else loIsPrecise) || {
-      println(i"missing constraint $tp1 with $tp2, isUpper = $isUpper")
-      false
-    }
-
-  private def secondTry(tp1: Type, tp2: Type): Boolean = tp1 match {
-    case tp1: NamedType =>
-      tp1.info match {
-        case info1: TypeAlias =>
-          if (isSubType(info1.alias, tp2)) return true
-          if (tp1.prefix.isStable) return false
-        case _ =>
-          if (tp1 eq NothingType) return tp1 == tp2.bottomType
-      }
-      thirdTry(tp1, tp2)
-    case tp1: TypeParamRef =>
-      def flagNothingBound = {
-        if (!frozenConstraint && tp2.isRef(defn.NothingClass) && state.isGlobalCommittable) {
-          def msg = s"!!! instantiated to Nothing: $tp1, constraint = ${constraint.show}"
-          if (Config.failOnInstantiationToNothing) assert(false, msg)
-          else ctx.log(msg)
-        }
-        true
-      }
-      def compareTypeParamRef =
-        ctx.mode.is(Mode.TypevarsMissContext) ||
-        isSubTypeWhenFrozen(bounds(tp1).hi, tp2) || {
-          if (canConstrain(tp1) && testConstrain(tp1, tp2, isUpper = true)) addConstraint(tp1, tp2, fromBelow = false) && flagNothingBound
-          else thirdTry(tp1, tp2)
-        }
-      compareTypeParamRef
-    case tp1: ThisType =>
-      val cls1 = tp1.cls
-      tp2 match {
-        case tp2: TermRef if cls1.is(Module) && cls1.eq(tp2.widen.typeSymbol) =>
-          cls1.isStaticOwner ||
-          isSubType(cls1.owner.thisType, tp2.prefix) ||
-          thirdTry(tp1, tp2)
-        case _ =>
-          thirdTry(tp1, tp2)
-      }
-    case tp1: SkolemType =>
-      tp2 match {
-        case tp2: SkolemType if !ctx.phase.isTyper && tp1.info <:< tp2.info => true
-        case _ => thirdTry(tp1, tp2)
-      }
-    case tp1: TypeVar =>
-      isSubType(tp1.underlying, tp2)
-    case tp1: WildcardType =>
-      def compareWild = tp1.optBounds match {
-        case TypeBounds(lo, _) => isSubType(lo, tp2)
-        case _ => true
-      }
-      compareWild
-    case tp1: LazyRef =>
-      // If `tp1` is in train of being evaluated, don't force it
-      // because that would cause an assertionError. Return false instead.
-      // See i859.scala for an example where we hit this case.
-      !tp1.evaluating && isSubType(tp1.ref, tp2)
-    case tp1: AnnotatedType =>
-      isSubType(tp1.tpe, tp2)
-    case AndType(tp11, tp12) =>
-      if (tp11.stripTypeVar eq tp12.stripTypeVar) isSubType(tp11, tp2)
-      else thirdTry(tp1, tp2)
-    case tp1 @ OrType(tp11, tp12) =>
-      def joinOK = tp2.dealias match {
-        case tp2: AppliedType if !tp2.tycon.typeSymbol.isClass =>
-          // If we apply the default algorithm for `A[X] | B[Y] <: C[Z]` where `C` is a
-          // type parameter, we will instantiate `C` to `A` and then fail when comparing
-          // with `B[Y]`. To do the right thing, we need to instantiate `C` to the
-          // common superclass of `A` and `B`.
-          isSubType(tp1.join, tp2)
-        case _ =>
-          false
-      }
-      joinOK || isSubType(tp11, tp2) && isSubType(tp12, tp2)
-    case _: FlexType =>
-      true
-    case _ =>
-      thirdTry(tp1, tp2)
-  }
-
-  private def thirdTryNamed(tp1: Type, tp2: NamedType): Boolean = tp2.info match {
-    case TypeBounds(lo2, _) =>
-      def compareGADT: Boolean = {
-        val gbounds2 = ctx.gadt.bounds(tp2.symbol)
-        (gbounds2 != null) &&
-          (isSubTypeWhenFrozen(tp1, gbounds2.lo) ||
-            narrowGADTBounds(tp2, tp1, isUpper = false)) &&
-          GADTusage(tp2.symbol)
-      }
-      val tryLowerFirst = frozenConstraint || !isCappable(tp1)
-      if (tryLowerFirst) isSubApproxHi(tp1, lo2) || compareGADT || fourthTry(tp1, tp2)
-      else compareGADT || fourthTry(tp1, tp2) || isSubApproxHi(tp1, lo2)
-
-    case _ =>
-      val cls2 = tp2.symbol
-      if (cls2.isClass) {
-        if (cls2.typeParams.nonEmpty && tp1.isHK)
-          isSubType(tp1, EtaExpansion(cls2.typeRef))
-        else {
-          val base = tp1.baseType(cls2)
-          if (base.exists) {
-            if (cls2.is(JavaDefined))
-              // If `cls2` is parameterized, we are seeing a raw type, so we need to compare only the symbol
-              return base.typeSymbol == cls2
-            if (base ne tp1)
-              return if (tp1.isRef(cls2)) isSubType(base, tp2) else isSubApproxLo(base, tp2)
-          }
-          if (cls2 == defn.SingletonClass && tp1.isStable) return true
-        }
-      }
-      fourthTry(tp1, tp2)
-  }
-
-  private def thirdTry(tp1: Type, tp2: Type): Boolean = tp2 match {
-    case tp2 @ AppliedType(tycon2, args2) =>
-      compareAppliedType2(tp1, tp2, tycon2, args2)
-    case tp2: NamedType =>
-      thirdTryNamed(tp1, tp2)
-    case tp2: TypeParamRef =>
-      def compareTypeParamRef =
-        (ctx.mode is Mode.TypevarsMissContext) || {
-        val alwaysTrue =
-          // The following condition is carefully formulated to catch all cases
-          // where the subtype relation is true without needing to add a constraint
-          // It's tricky because we might need to either appriximate tp2 by its
-          // lower bound or else widen tp1 and check that the result is a subtype of tp2.
-          // So if the constraint is not yet frozen, we do the same comparison again
-          // with a frozen constraint, which means that we get a chance to do the
-          // widening in `fourthTry` before adding to the constraint.
-          if (frozenConstraint) isSubType(tp1, bounds(tp2).lo)
-          else isSubTypeWhenFrozen(tp1, tp2)
-        alwaysTrue || {
-          if (canConstrain(tp2) && testConstrain(tp2, tp1.widenExpr, isUpper = false)) addConstraint(tp2, tp1.widenExpr, fromBelow = true)
-          else fourthTry(tp1, tp2)
-        }
-      }
-      compareTypeParamRef
-    case tp2: RefinedType =>
-      def compareRefinedSlow: Boolean = {
-        val name2 = tp2.refinedName
-        isSubType(tp1, tp2.parent) &&
-          (name2 == nme.WILDCARD || hasMatchingMember(name2, tp1, tp2))
-      }
-      def compareRefined: Boolean = {
-        val tp1w = tp1.widen
-        val skipped2 = skipMatching(tp1w, tp2)
-        if ((skipped2 eq tp2) || !Config.fastPathForRefinedSubtype)
-          tp1 match {
-            case tp1: AndType =>
-              // Delay calling `compareRefinedSlow` because looking up a member
-              // of an `AndType` can lead to a cascade of subtyping checks
-              // This twist is needed to make collection/generic/ParFactory.scala compile
-              fourthTry(tp1, tp2) || compareRefinedSlow
-            case tp1: HKTypeLambda =>
-              // HKTypeLambdas do not have members.
-              fourthTry(tp1, tp2)
-            case _ =>
-              compareRefinedSlow || fourthTry(tp1, tp2)
-          }
-        else // fast path, in particular for refinements resulting from parameterization.
-          isSubRefinements(tp1w.asInstanceOf[RefinedType], tp2, skipped2) &&
-          isSubType(tp1, skipped2)
-      }
-      compareRefined
-    case tp2: RecType =>
-      def compareRec = tp1.safeDealias match {
-        case tp1: RecType =>
-          val rthis1 = tp1.recThis
-          isSubType(tp1.parent, tp2.parent.substRecThis(tp2, rthis1))
-        case _ =>
-          val tp1stable = ensureStableSingleton(tp1)
-          isSubType(fixRecs(tp1stable, tp1stable.widenExpr), tp2.parent.substRecThis(tp2, tp1stable))
-      }
-      compareRec
-    case tp2: HKTypeLambda =>
-      def compareTypeLambda: Boolean = tp1.stripTypeVar match {
-        case tp1: HKTypeLambda =>
-          /* Don't compare bounds of lambdas under language:Scala2, or t2994 will fail.
-           * The issue is that, logically, bounds should compare contravariantly,
-           * but that would invalidate a pattern exploited in t2994:
-           *
-           *    [X0 <: Number] -> Number   <:<    [X0] -> Any
-           *
-           * Under the new scheme, `[X0] -> Any` is NOT a kind that subsumes
-           * all other bounds. You'd have to write `[X0 >: Any <: Nothing] -> Any` instead.
-           * This might look weird, but is the only logically correct way to do it.
-           *
-           * Note: it would be nice if this could trigger a migration warning, but I
-           * am not sure how, since the code is buried so deep in subtyping logic.
-           */
-          def boundsOK =
-            ctx.scala2Mode ||
-            tp1.typeParams.corresponds(tp2.typeParams)((tparam1, tparam2) =>
-              isSubTypePart(tparam2.paramInfo.subst(tp2, tp1), tparam1.paramInfo))
-          val saved = comparedTypeLambdas
-          comparedTypeLambdas += tp1
-          comparedTypeLambdas += tp2
-          try
-            variancesConform(tp1.typeParams, tp2.typeParams) &&
-            boundsOK &&
-            isSubTypePart(tp1.resType, tp2.resType.subst(tp2, tp1))
-          finally comparedTypeLambdas = saved
-        case _ =>
-          if (tp1.isHK) {
-            val tparams1 = tp1.typeParams
-            return isSubType(
-              HKTypeLambda.fromParams(tparams1, tp1.appliedTo(tparams1.map(_.paramRef))),
-              tp2
-            )
-          }
-          else tp2 match {
-            case EtaExpansion(tycon2) if tycon2.symbol.isClass =>
-              return isSubType(tp1, tycon2)
-            case _ =>
-          }
-          fourthTry(tp1, tp2)
-      }
-      compareTypeLambda
-    case OrType(tp21, tp22) =>
-      val tp1a = tp1.widenDealias
-      if (tp1a ne tp1)
-        // Follow the alias; this might avoid truncating the search space in the either below
-        // Note that it's safe to widen here because singleton types cannot be part of `|`.
-        return isSubType(tp1a, tp2)
-
-      // Rewrite T1 <: (T211 & T212) | T22 to T1 <: (T211 | T22) and T1 <: (T212 | T22)
-      // and analogously for T1 <: T21 | (T221 & T222)
-      // `|' types to the right of <: are problematic, because
-      // we have to choose one constraint set or another, which might cut off
-      // solutions. The rewriting delays the point where we have to choose.
-      tp21 match {
-        case AndType(tp211, tp212) =>
-          return isSubType(tp1, OrType(tp211, tp22)) && isSubType(tp1, OrType(tp212, tp22))
-        case _ =>
-      }
-      tp22 match {
-        case AndType(tp221, tp222) =>
-          return isSubType(tp1, OrType(tp21, tp221)) && isSubType(tp1, OrType(tp21, tp222))
-        case _ =>
-      }
-      either(isSubType(tp1, tp21), isSubType(tp1, tp22)) || fourthTry(tp1, tp2)
-    case tp2: MethodOrPoly =>
-      def compareMethod = tp1 match {
-        case tp1: MethodOrPoly =>
-          (tp1.signature consistentParams tp2.signature) &&
-            matchingParams(tp1, tp2) &&
-            (!tp2.isImplicitMethod || tp1.isImplicitMethod) &&
-            isSubTypePart(tp1.resultType, tp2.resultType.subst(tp2, tp1))
-        case _ =>
-          false
-      }
-      compareMethod
-    case tp2 @ ExprType(restpe2) =>
-      def compareExpr = tp1 match {
-        // We allow ()T to be a subtype of => T.
-        // We need some subtype relationship between them so that e.g.
-        // def toString   and   def toString()   don't clash when seen
-        // as members of the same type. And it seems most logical to take
-        // ()T <:< => T, since everything one can do with a => T one can
-        // also do with a ()T by automatic () insertion.
-        case tp1 @ MethodType(Nil) => isSubTypePart(tp1.resultType, restpe2)
-        case _ => isSubTypePart(tp1.widenExpr, restpe2)
-      }
-      compareExpr
-    case tp2 @ TypeBounds(lo2, hi2) =>
-      def compareTypeBounds = tp1 match {
-        case tp1 @ TypeBounds(lo1, hi1) =>
-          ((lo2 eq NothingType) || isSubTypePart(lo2, lo1)) &&
-          ((hi2 eq AnyType) || isSubTypePart(hi1, hi2))
-        case tp1: ClassInfo =>
-          tp2 contains tp1
-        case _ =>
-          false
-      }
-      compareTypeBounds
-    case ClassInfo(pre2, cls2, _, _, _) =>
-      def compareClassInfo = tp1 match {
-        case ClassInfo(pre1, cls1, _, _, _) =>
-          (cls1 eq cls2) && isSubTypePart(pre1, pre2)
-        case _ =>
-          false
-      }
-      compareClassInfo
-    case _ =>
-      fourthTry(tp1, tp2)
-  }
-
-  private def fourthTry(tp1: Type, tp2: Type): Boolean = tp1 match {
-    case tp1: TypeRef =>
-      tp1.info match {
-        case TypeBounds(_, hi1) =>
-          def compareGADT = {
-            val gbounds1 = ctx.gadt.bounds(tp1.symbol)
-            (gbounds1 != null) &&
-              (isSubTypeWhenFrozen(gbounds1.hi, tp2) ||
-               narrowGADTBounds(tp1, tp2, isUpper = true)) &&
-              GADTusage(tp1.symbol)
-          }
-          isSubApproxLo(hi1, tp2) || compareGADT
-        case _ =>
-          def isNullable(tp: Type): Boolean = tp.widenDealias match {
-            case tp: TypeRef => tp.symbol.isNullableClass
-            case tp: RefinedOrRecType => isNullable(tp.parent)
-            case tp: AppliedType => isNullable(tp.tycon)
-            case AndType(tp1, tp2) => isNullable(tp1) && isNullable(tp2)
-            case OrType(tp1, tp2) => isNullable(tp1) || isNullable(tp2)
-            case _ => false
-          }
-          val sym1 = tp1.symbol
-          (sym1 eq NothingClass) && tp2.isValueTypeOrLambda && !tp2.isPhantom ||
-          (sym1 eq NullClass) && isNullable(tp2) ||
-          (sym1 eq PhantomNothingClass) && tp1.topType == tp2.topType
-      }
-    case tp1 @ AppliedType(tycon1, args1) =>
-      compareAppliedType1(tp1, tycon1, args1, tp2)
-    case tp1: SingletonType =>
-      /** if `tp2 == p.type` and `p: q.type` then try `tp1 <:< q.type` as a last effort.*/
-      def comparePaths = tp2 match {
-        case tp2: TermRef =>
-          tp2.info.widenExpr.dealias match {
-            case tp2i: SingletonType =>
-              isSubType(tp1, tp2i)
-                // see z1720.scala for a case where this can arise even in typer.
-                // Also, i1753.scala, to show why the dealias above is necessary.
-            case _ => false
-          }
-        case _ =>
-          false
-      }
-      isNewSubType(tp1.underlying.widenExpr, tp2) || comparePaths
-    case tp1: RefinedType =>
-      isNewSubType(tp1.parent, tp2)
-    case tp1: RecType =>
-      isNewSubType(tp1.parent, tp2)
-    case tp1: HKTypeLambda =>
-      def compareHKLambda = tp1 match {
-        case EtaExpansion(tycon1) => isSubType(tycon1, tp2)
-        case _ => tp2 match {
-          case tp2: HKTypeLambda => false // this case was covered in thirdTry
-          case _ => tp2.isHK && isSubTypePart(tp1.resultType, tp2.appliedTo(tp1.paramRefs))
-        }
-      }
-      compareHKLambda
-    case AndType(tp11, tp12) =>
-      val tp2a = tp2.dealias
-      if (tp2a ne tp2) // Follow the alias; this might avoid truncating the search space in the either below
-        return isSubType(tp1, tp2a)
-
-      // Rewrite (T111 | T112) & T12 <: T2 to (T111 & T12) <: T2 and (T112 | T12) <: T2
-      // and analogously for T11 & (T121 | T122) & T12 <: T2
-      // `&' types to the left of <: are problematic, because
-      // we have to choose one constraint set or another, which might cut off
-      // solutions. The rewriting delays the point where we have to choose.
-      tp11 match {
-        case OrType(tp111, tp112) =>
-          return isSubType(AndType(tp111, tp12), tp2) && isSubType(AndType(tp112, tp12), tp2)
-        case _ =>
-      }
-      tp12 match {
-        case OrType(tp121, tp122) =>
-          return isSubType(AndType(tp11, tp121), tp2) && isSubType(AndType(tp11, tp122), tp2)
-        case _ =>
-      }
-      either(isSubType(tp11, tp2), isSubType(tp12, tp2))
-    case JavaArrayType(elem1) =>
-      def compareJavaArray = tp2 match {
-        case JavaArrayType(elem2) => isSubTypePart(elem1, elem2)
-        case _ => tp2 isRef ObjectClass
-      }
-      compareJavaArray
-    case tp1: ExprType if ctx.phase.id > ctx.gettersPhase.id =>
-      // getters might have converted T to => T, need to compensate.
-      isSubType(tp1.widenExpr, tp2)
-    case _ =>
-      false
-  }
-
-
-  /** Subtype test for the hk application `tp2 = tycon2[args2]`.
-   */
-  def compareAppliedType2(tp1: Type, tp2: AppliedType, tycon2: Type, args2: List[Type]): Boolean = {
-    val tparams = tycon2.typeParams
-    if (tparams.isEmpty) return false // can happen for ill-typed programs, e.g. neg/tcpoly_overloaded.scala
-
-    /** True if `tp1` and `tp2` have compatible type constructors and their
-     *  corresponding arguments are subtypes relative to their variance (see `isSubArgs`).
-     */
-    def isMatchingApply(tp1: Type): Boolean = tp1 match {
-      case AppliedType(tycon1, args1) =>
-        tycon1.dealias match {
-          case tycon1: TypeParamRef =>
-            (tycon1 == tycon2 ||
-             canConstrain(tycon1) && tryInstantiate(tycon1, tycon2)) &&
-            isSubArgs(args1, args2, tp1, tparams)
-          case tycon1: TypeRef =>
-            tycon2.dealias match {
-              case tycon2: TypeRef if tycon1.symbol == tycon2.symbol =>
-                isSubTypePart(tycon1.prefix, tycon2.prefix) &&
-                isSubArgs(args1, args2, tp1, tparams)
-              case _ =>
-                false
-            }
-          case tycon1: TypeVar =>
-            isMatchingApply(tycon1.underlying)
-          case tycon1: AnnotatedType =>
-            isMatchingApply(tycon1.underlying)
-          case _ =>
-            false
-        }
-      case _ =>
-        false
-    }
-
-    /** `param2` can be instantiated to a type application prefix of the LHS
-     *  or to a type application prefix of one of the LHS base class instances
-     *  and the resulting type application is a supertype of `tp1`,
-     *  or fallback to fourthTry.
-     */
-    def canInstantiate(tycon2: TypeParamRef): Boolean = {
-
-      /** Let
-       *
-       *    `tparams_1, ..., tparams_k-1`    be the type parameters of the rhs
-       *    `tparams1_1, ..., tparams1_n-1`  be the type parameters of the constructor of the lhs
-       *    `args1_1, ..., args1_n-1`        be the type arguments of the lhs
-       *    `d  =  n - k`
-       *
-       *  Returns `true` iff `d >= 0` and `tycon2` can be instantiated to
-       *
-       *      [tparams1_d, ... tparams1_n-1] -> tycon1[args_1, ..., args_d-1, tparams_d, ... tparams_n-1]
-       *
-       *  such that the resulting type application is a supertype of `tp1`.
-       */
-      def appOK(tp1base: Type) = tp1base match {
-        case tp1base: AppliedType =>
-          var tycon1 = tp1base.tycon
-          val args1 = tp1base.args
-          val tparams1all = tycon1.typeParams
-          val lengthDiff = tparams1all.length - tparams.length
-          lengthDiff >= 0 && {
-            val tparams1 = tparams1all.drop(lengthDiff)
-            variancesConform(tparams1, tparams) && {
-              if (lengthDiff > 0)
-                tycon1 = HKTypeLambda(tparams1.map(_.paramName))(
-                  tl => tparams1.map(tparam => tl.integrate(tparams, tparam.paramInfo).bounds),
-                  tl => tp1base.tycon.appliedTo(args1.take(lengthDiff) ++
-                          tparams1.indices.toList.map(tl.paramRefs(_))))
-              (ctx.mode.is(Mode.TypevarsMissContext) ||
-                tryInstantiate(tycon2, tycon1.ensureHK)) &&
-                isSubType(tp1, tycon1.appliedTo(args2))
-            }
-          }
-        case _ => false
-      }
-
-      tp1.widen match {
-        case tp1w: AppliedType => appOK(tp1w)
-        case tp1w =>
-          tp1w.typeSymbol.isClass && {
-            val classBounds = tycon2.classSymbols
-            def liftToBase(bcs: List[ClassSymbol]): Boolean = bcs match {
-              case bc :: bcs1 =>
-                classBounds.exists(bc.derivesFrom) && appOK(tp1w.baseType(bc)) ||
-                liftToBase(bcs1)
-              case _ =>
-                false
-            }
-            liftToBase(tp1w.baseClasses)
-          } ||
-          fourthTry(tp1, tp2)
-      }
-    }
-
-    /** Fall back to comparing either with `fourthTry` or against the lower
-     *  approximation of the rhs.
-     *  @param   tyconLo   The type constructor's lower approximation.
-     */
-    def fallback(tyconLo: Type) =
-      either(fourthTry(tp1, tp2), isSubApproxHi(tp1, tyconLo.applyIfParameterized(args2)))
-
-    /** Let `tycon2bounds` be the bounds of the RHS type constructor `tycon2`.
-     *  Let `app2 = tp2` where the type constructor of `tp2` is replaced by
-     *  `tycon2bounds.lo`.
-     *  If both bounds are the same, continue with `tp1 <:< app2`.
-     *  otherwise continue with either
-     *
-     *    tp1 <:< tp2    using fourthTry (this might instantiate params in tp1)
-     *    tp1 <:< app2   using isSubType (this might instantiate params in tp2)
-     */
-    def compareLower(tycon2bounds: TypeBounds, tyconIsTypeRef: Boolean): Boolean =
-      if (tycon2bounds.lo eq tycon2bounds.hi)
-        if (tyconIsTypeRef) isSubType(tp1, tp2.superType)
-        else isSubApproxHi(tp1, tycon2bounds.lo.applyIfParameterized(args2))
-      else
-        fallback(tycon2bounds.lo)
-
-    tycon2 match {
-      case param2: TypeParamRef =>
-        isMatchingApply(tp1) ||
-        canConstrain(param2) && canInstantiate(param2) ||
-        compareLower(bounds(param2), tyconIsTypeRef = false)
-      case tycon2: TypeRef =>
-        isMatchingApply(tp1) || {
-          tycon2.info match {
-            case info2: TypeBounds =>
-              compareLower(info2, tyconIsTypeRef = true)
-            case info2: ClassInfo =>
-              val base = tp1.baseType(info2.cls)
-              if (base.exists && base.ne(tp1))
-                if (tp1.isRef(info2.cls)) isSubType(base, tp2)
-                else isSubApproxLo(base, tp2)
-              else fourthTry(tp1, tp2)
-            case _ =>
-              fourthTry(tp1, tp2)
-          }
-        }
-      case _: TypeVar | _: AnnotatedType =>
-        isSubType(tp1, tp2.superType)
-      case tycon2: AppliedType =>
-        fallback(tycon2.lowerBound)
-      case _ =>
-        false
-    }
-  }
-
-  /** Subtype test for the application `tp1 = tycon1[args1]`.
-   */
-  def compareAppliedType1(tp1: AppliedType, tycon1: Type, args1: List[Type], tp2: Type): Boolean =
-    tycon1 match {
-      case param1: TypeParamRef =>
-        def canInstantiate = tp2 match {
-          case AppliedType(tycon2, args2) =>
-            tryInstantiate(param1, tycon2.ensureHK) && isSubArgs(args1, args2, tp1, tycon2.typeParams)
-          case _ =>
-            false
-        }
-        canConstrain(param1) && canInstantiate ||
-          isSubApproxLo(bounds(param1).hi.applyIfParameterized(args1), tp2)
-      case tycon1: TypeRef if tycon1.symbol.isClass =>
-        false
-      case tycon1: TypeProxy =>
-        isSubType(tp1.superType, tp2)
-      case _ =>
-        false
-    }
-
   /** Subtype test for corresponding arguments in `args1`, `args2` according to
-   *  variances in type parameters `tparams`.
-   */
+  *  variances in type parameters `tparams`.
+  */
   def isSubArgs(args1: List[Type], args2: List[Type], tp1: Type, tparams: List[ParamInfo]): Boolean =
     if (args1.isEmpty) args2.isEmpty
     else args2.nonEmpty && {
@@ -902,8 +876,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
             case arg1: TypeBounds =>
               compareCaptured(arg1, arg2)
             case _ =>
-              (v > 0 || isSubTypePart(arg2, arg1)) &&
-              (v < 0 || isSubTypePart(arg1, arg2))
+              (v > 0 || isSubType(arg2, arg1)) &&
+              (v < 0 || isSubType(arg1, arg2))
           }
       }
 
@@ -999,15 +973,6 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
     } || op2
   }
 
-  /** Like tp1 <:< tp2, but returns false immediately if we know that
-   *  the case was covered previously during subtyping.
-   */
-  private def isNewSubType(tp1: Type, tp2: Type): Boolean =
-    if (isCovered(tp1) && isCovered(tp2)) {
-      //println(s"useless subtype: $tp1 <:< $tp2")
-      false
-    } else isSubApproxLo(tp1, tp2)
-
   /** Does type `tp1` have a member with name `name` whose normalized type is a subtype of
    *  the normalized type of the refinement `tp2`?
    *  Normalization is as follows: If `tp2` contains a skolem to its refinement type,
@@ -1035,7 +1000,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
           tp2.refinedInfo match {
             case rinfo2: TypeBounds =>
               val ref1 = tp1.widenExpr.select(name)
-              isSubTypePart(rinfo2.lo, ref1) && isSubType(ref1, rinfo2.hi)
+              isSubType(rinfo2.lo, ref1) && isSubType(ref1, rinfo2.hi)
             case _ =>
               false
           }
@@ -1043,7 +1008,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
       }
 
       def qualifies(m: SingleDenotation) =
-        isSubTypePart(m.info, rinfo2) || matchAbstractTypeMember(m.info)
+        isSubType(m.info, rinfo2) || matchAbstractTypeMember(m.info)
 
       tp1.member(name) match { // inlined hasAltWith for performance
         case mbr: SingleDenotation => qualifies(mbr)
@@ -1083,7 +1048,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
    */
   private def isSubRefinements(tp1: RefinedType, tp2: RefinedType, limit: Type): Boolean = {
     def hasSubRefinement(tp1: RefinedType, refine2: Type): Boolean = {
-      isSubTypePart(tp1.refinedInfo, refine2) || {
+      isSubType(tp1.refinedInfo, refine2) || {
         // last effort: try to adapt variances of higher-kinded types if this is sound.
         // TODO: Move this to eta-expansion?
         val adapted2 = refine2.adaptHkVariances(tp1.parent.member(tp1.refinedName).symbol.info)
@@ -1133,8 +1098,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
    *  `bound` as an upper or lower bound (which depends on `isUpper`).
    *  Test that the resulting bounds are still satisfiable.
    */
-  private def narrowGADTBounds(tr: NamedType, bound: Type, isUpper: Boolean): Boolean = {
-    val boundIsPrecise = if (isUpper) hiIsPrecise else loIsPrecise
+  private def narrowGADTBounds(tr: NamedType, bound: Type, approx: ApproxState, isUpper: Boolean): Boolean = {
+    val boundIsPrecise = (approx & (if (isUpper) HiApprox else LoApprox)) == 0
     ctx.mode.is(Mode.GADTflexible) && !frozenConstraint && boundIsPrecise && {
       val tparam = tr.symbol
       gadts.println(i"narrow gadt bound of $tparam: ${tparam.info} from ${if (isUpper) "above" else "below"} to $bound ${bound.toString} ${bound.isRef(tparam)}")
@@ -1144,7 +1109,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         val newBounds =
           if (isUpper) TypeBounds(oldBounds.lo, oldBounds.hi & bound)
           else TypeBounds(oldBounds.lo | bound, oldBounds.hi)
-        isSubTypePart(newBounds.lo, newBounds.hi) &&
+        isSubType(newBounds.lo, newBounds.hi) &&
           { ctx.gadt.setBounds(tparam, newBounds); true }
       }
     }
@@ -1661,6 +1626,11 @@ object TypeComparer {
     case _ => String.valueOf(res)
   }
 
+  type ApproxState = Int
+  val Precise = 0
+  val LoApprox = 1
+  val HiApprox = 2
+
   /** Show trace of comparison operations when performing `op` as result string */
   def explained[T](op: Context => T)(implicit ctx: Context): String = {
     val nestedCtx = ctx.fresh.setTypeComparerFn(new ExplainingTypeComparer(_))
@@ -1671,7 +1641,7 @@ object TypeComparer {
 
 /** A type comparer that can record traces of subtype operations */
 class ExplainingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
-  import TypeComparer.show
+  import TypeComparer._
 
   private[this] var indent = 0
   private val b = new StringBuilder
@@ -1689,9 +1659,9 @@ class ExplainingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
       res
     }
 
-  override def isSubType(tp1: Type, tp2: Type) =
-    traceIndented(s"${show(tp1)} <:< ${show(tp2)}${if (Config.verboseExplainSubtype) s" ${tp1.getClass} ${tp2.getClass}" else ""}${if (frozenConstraint) " frozen" else ""}") {
-      super.isSubType(tp1, tp2)
+  override def isSubType(tp1: Type, tp2: Type, approx: ApproxState) =
+    traceIndented(s"${show(tp1)} <:< ${show(tp2)}${if (Config.verboseExplainSubtype) s" ${tp1.getClass} ${tp2.getClass}" else ""} $approx ${if (frozenConstraint) " frozen" else ""}") {
+      super.isSubType(tp1, tp2, approx)
     }
 
   override def hasMatchingMember(name: Name, tp1: Type, tp2: RefinedType): Boolean =
@@ -1715,20 +1685,6 @@ class ExplainingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
     }
 
   override def copyIn(ctx: Context) = new ExplainingTypeComparer(ctx)
-
-  override def compareAppliedType2(tp1: Type, tp2: AppliedType, tycon2: Type, args2: List[Type]): Boolean = {
-    def addendum = ""
-    traceIndented(i"compareAppliedType2 $tp1, $tp2$addendum") {
-      super.compareAppliedType2(tp1, tp2, tycon2, args2)
-    }
-  }
-
-  override def compareAppliedType1(tp1: AppliedType, tycon1: Type, args1: List[Type], tp2: Type): Boolean = {
-    def addendum = ""
-    traceIndented(i"compareAppliedType1 $tp1, $tp2$addendum") {
-      super.compareAppliedType1(tp1, tycon1, args1, tp2)
-    }
-  }
 
   override def toString = "Subtype trace:" + { try b.toString finally b.clear() }
 }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -127,9 +127,7 @@ object Types {
     def isRef(sym: Symbol)(implicit ctx: Context): Boolean = stripAnnots.stripTypeVar match {
       case this1: TypeRef =>
         this1.info match { // see comment in Namer#typeDefSig
-          case TypeAlias(tp) =>
-            assert((tp ne this) && (tp ne this1), s"$tp / $this")
-            tp.isRef(sym)
+          case TypeAlias(tp) => tp.isRef(sym)
           case _ => this1.symbol eq sym
         }
       case this1: RefinedOrRecType =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -226,7 +226,7 @@ Standard Section: "Positions" Assoc*
 object TastyFormat {
 
   final val header = Array(0x5C, 0xA1, 0xAB, 0x1F)
-  val MajorVersion = 3
+  val MajorVersion = 4
   val MinorVersion = 0
 
   /** Tags used to serialize names */
@@ -336,7 +336,6 @@ object TastyFormat {
   final val RECtype = 90
   final val TYPEALIAS = 91
   final val SINGLETONtpt = 92
-  final val NAMEDARG = 93
 
   // Cat. 4:    tag Nat AST
 
@@ -349,6 +348,7 @@ object TastyFormat {
   final val TYPEREFsymbol = 116
   final val TYPEREF = 117
   final val SELFDEF = 118
+  final val NAMEDARG = 119
 
   // Cat. 5:    tag Length ...
 
@@ -407,6 +407,15 @@ object TastyFormat {
   final val firstASTTreeTag = THIS
   final val firstNatASTTreeTag = IDENT
   final val firstLengthTreeTag = PACKAGE
+
+  /** Useful for debugging */
+  def isLegalTag(tag: Int) =
+    firstSimpleTreeTag <= tag && tag <= MACRO ||
+    firstNatTreeTag <= tag && tag <= SYMBOLconst ||
+    firstASTTreeTag <= tag && tag <= SINGLETONtpt ||
+    firstNatASTTreeTag <= tag && tag <= NAMEDARG ||
+    firstLengthTreeTag <= tag && tag <= TYPEREFin ||
+    tag == HOLE
 
   def isParamTag(tag: Int) = tag == PARAM || tag == TYPEPARAM
 

--- a/compiler/src/dotty/tools/dotc/transform/TryCatchPatterns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TryCatchPatterns.scala
@@ -71,7 +71,7 @@ class TryCatchPatterns extends MiniPhase {
     case _                                                               => isDefaultCase(cdef)
   }
 
-  private def isSimpleThrowable(tp: Type)(implicit ctx: Context): Boolean = tp match {
+  private def isSimpleThrowable(tp: Type)(implicit ctx: Context): Boolean = tp.stripAnnots match {
     case tp @ TypeRef(pre, _) =>
       (pre == NoPrefix || pre.widen.typeSymbol.isStatic) && // Does not require outer class check
       !tp.symbol.is(Flags.Trait) && // Traits not supported by JVM

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -108,12 +108,15 @@ object Checking {
    *  in order to prevent scenarios that lead to self application of
    *  types. Self application needs to be avoided since it can lead to stack overflows.
    *  Test cases are neg/i2771.scala and neg/i2771b.scala.
+   *  A NoType paramBounds is used as a sign that checking should be suppressed.
    */
-  def preCheckKind(arg: Tree, paramBounds: TypeBounds)(implicit ctx: Context): Tree =
-    if (arg.tpe.widen.isRef(defn.NothingClass) || arg.tpe.hasSameKindAs(paramBounds.hi)) arg
+  def preCheckKind(arg: Tree, paramBounds: Type)(implicit ctx: Context): Tree =
+    if (arg.tpe.widen.isRef(defn.NothingClass) ||
+        !paramBounds.exists ||
+        arg.tpe.hasSameKindAs(paramBounds.bounds.hi)) arg
     else errorTree(arg, em"Type argument ${arg.tpe} has not the same kind as its bound $paramBounds")
 
-  def preCheckKinds(args: List[Tree], paramBoundss: List[TypeBounds])(implicit ctx: Context): List[Tree] = {
+  def preCheckKinds(args: List[Tree], paramBoundss: List[Type])(implicit ctx: Context): List[Tree] = {
     val args1 = args.zipWithConserve(paramBoundss)(preCheckKind)
     args1 ++ args.drop(paramBoundss.length)
       // add any arguments that do not correspond to a parameter back,

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1254,7 +1254,7 @@ class Typer extends Namer
         case (tparam, TypeBoundsTree(EmptyTree, EmptyTree)) =>
           // if type argument is a wildcard, suppress kind checking since
           // there is no real argument.
-          TypeBounds.empty
+          NoType
         case (tparam, _) =>
           tparam.paramInfo.bounds
       }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -568,8 +568,8 @@ class Typer extends Namer
       def typedTpt = checkSimpleKinded(typedType(tree.tpt))
       def handlePattern: Tree = {
         val tpt1 = typedTpt
-        // special case for an abstract type that comes with a class tag
         if (!ctx.isAfterTyper) tpt1.tpe.<:<(pt)(ctx.addMode(Mode.GADTflexible))
+        // special case for an abstract type that comes with a class tag
         tryWithClassTag(ascription(tpt1, isWildcard = true), pt)
       }
       cases(
@@ -1012,37 +1012,29 @@ class Typer extends Namer
       if (!gadtCtx.gadt.bounds.contains(sym))
         gadtCtx.gadt.setBounds(sym, TypeBounds.empty)
 
-    /** - replace all references to symbols associated with wildcards by their GADT bounds
+    /** - strip all instantiated TypeVars from pattern types.
+     *    run/reducable.scala is a test case that shows stripping typevars is necessary.
      *  - enter all symbols introduced by a Bind in current scope
      */
     val indexPattern = new TreeMap {
-      val elimWildcardSym = new TypeMap {
-        def apply(t: Type) = t match {
-          case ref: TypeRef if ref.name == tpnme.WILDCARD && gadtCtx.gadt.bounds.contains(ref.symbol) =>
-            gadtCtx.gadt.bounds(ref.symbol)
-          case TypeAlias(ref: TypeRef) if ref.name == tpnme.WILDCARD && gadtCtx.gadt.bounds.contains(ref.symbol) =>
-            gadtCtx.gadt.bounds(ref.symbol)
-          case _ =>
-            mapOver(t)
-        }
+      val stripTypeVars = new TypeMap {
+        def apply(t: Type) = mapOver(t)
       }
       override def transform(trt: Tree)(implicit ctx: Context) =
-        super.transform(trt.withType(elimWildcardSym(trt.tpe))) match {
+        super.transform(trt.withType(stripTypeVars(trt.tpe))) match {
           case b: Bind =>
             val sym = b.symbol
-            if (sym.exists) {
+            if (sym.name != tpnme.WILDCARD)
               if (ctx.scope.lookup(b.name) == NoSymbol) ctx.enter(sym)
               else ctx.error(new DuplicateBind(b, tree), b.pos)
-              sym.info = elimWildcardSym(sym.info)
-              b
+            if (!ctx.isAfterTyper) {
+              val bounds = ctx.gadt.bounds(sym)
+              if (bounds != null) sym.info = bounds
             }
-            else {
-              assert(b.name == tpnme.WILDCARD)
-              b.body
-            }
+            b
           case t => t
         }
-    }
+      }
 
     def caseRest(pat: Tree)(implicit ctx: Context) = {
       val pat1 = indexPattern.transform(pat)
@@ -1277,7 +1269,7 @@ class Typer extends Namer
     assignType(cpy.ByNameTypeTree(tree)(result1), result1)
   }
 
-  def typedTypeBoundsTree(tree: untpd.TypeBoundsTree)(implicit ctx: Context): Tree = track("typedTypeBoundsTree") {
+  def typedTypeBoundsTree(tree: untpd.TypeBoundsTree, pt: Type)(implicit ctx: Context): Tree = track("typedTypeBoundsTree") {
     val TypeBoundsTree(lo, hi) = tree
     val lo1 = typed(lo)
     val hi1 = typed(hi)
@@ -1292,8 +1284,12 @@ class Typer extends Namer
       // with an expected type in typedTyped. The type symbol and the defining Bind node
       // are eliminated once the enclosing pattern has been typechecked; see `indexPattern`
       // in `typedCase`.
-      val wildcardSym = ctx.newPatternBoundSymbol(tpnme.WILDCARD, tree1.tpe, tree.pos)
-      untpd.Bind(tpnme.WILDCARD, tree1).withType(wildcardSym.typeRef)
+      //val ptt = if (lo.isEmpty && hi.isEmpty) pt else
+      if (ctx.isAfterTyper) tree1
+      else {
+        val wildcardSym = ctx.newPatternBoundSymbol(tpnme.WILDCARD, tree1.tpe & pt, tree.pos)
+        untpd.Bind(tpnme.WILDCARD, tree1).withType(wildcardSym.typeRef)
+      }
     }
     else tree1
   }
@@ -1762,7 +1758,7 @@ class Typer extends Namer
           case tree: untpd.AppliedTypeTree => typedAppliedTypeTree(tree)
           case tree: untpd.LambdaTypeTree => typedLambdaTypeTree(tree)(localContext(tree, NoSymbol).setNewScope)
           case tree: untpd.ByNameTypeTree => typedByNameTypeTree(tree)
-          case tree: untpd.TypeBoundsTree => typedTypeBoundsTree(tree)
+          case tree: untpd.TypeBoundsTree => typedTypeBoundsTree(tree, pt)
           case tree: untpd.Alternative => typedAlternative(tree, pt)
           case tree: untpd.PackageDef => typedPackageDef(tree)
           case tree: untpd.Annotated => typedAnnotated(tree, pt)

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -175,6 +175,7 @@ class CompilationTests extends ParallelTesting {
     compileFilesInDir("../tests/neg", defaultOptions) +
     compileFilesInDir("../tests/neg-tailcall", defaultOptions) +
     compileFilesInDir("../tests/neg-no-optimise", defaultOptions) +
+    compileFile("../tests/neg-custom-args/i1754.scala", allowDeepSubtypes) +
     compileFile("../tests/neg-custom-args/i3246.scala", scala2Mode) +
     compileFile("../tests/neg-custom-args/i3627.scala", allowDeepSubtypes) +
     compileFile("../tests/neg-custom-args/typers.scala", allowDoubleBindings) +

--- a/tests/neg-custom-args/i1754.scala
+++ b/tests/neg-custom-args/i1754.scala
@@ -1,0 +1,9 @@
+case class One[T](fst: T)
+
+object Test {
+  def bad[T](e: One[T]) = e match {
+    case foo: One[a] =>
+      val t: T = e.fst
+      val nok: Nothing = t // error
+  }
+}

--- a/tests/neg/boundspropagation.scala
+++ b/tests/neg/boundspropagation.scala
@@ -33,7 +33,7 @@ object test4 {
     class Tree[-S, -T >: Option[S]]
 
     def g(x: Any): Tree[_, _ <: Option[N]] = x match {
-      case y: Tree[_, _] => y                         // works now (because of capture conversion?)
+      case y: Tree[_, _] => y                         // error -- used to work (because of capture conversion?)
     }
   }
 }

--- a/tests/pos/boundspropagation.scala
+++ b/tests/pos/boundspropagation.scala
@@ -17,12 +17,15 @@ object test1 {
     }
   }
 }
+
+/** Does not work:
 object test2 {
   class Tree[S, T <: S]
 
   class Base {
     def g(x: Any): Tree[_, _ <: Int] = x match {
-      case y: Tree[Int @unchecked, _] => y
+      case y: Tree[Int @unchecked, t] => y
     }
   }
 }
+*/

--- a/tests/pos/i1754.scala
+++ b/tests/pos/i1754.scala
@@ -1,0 +1,24 @@
+object Test {
+  import java.util.{ concurrent => juc }
+  import scala.collection.concurrent
+  import scala.collection.convert.Wrappers._
+
+  /**
+   * Implicitly converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
+   * The returned Scala ConcurrentMap is backed by the provided Java
+   * ConcurrentMap and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java ConcurrentMap was previously obtained from an implicit or
+   * explicit call of `asConcurrentMap(scala.collection.mutable.ConcurrentMap)`
+   * then the original Scala ConcurrentMap will be returned.
+   *
+   * @param m The ConcurrentMap to be converted.
+   * @return A Scala mutable ConcurrentMap view of the argument.
+   */
+  implicit def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
+    case null                             => null
+    case cmw: ConcurrentMapWrapper[_, _]  => cmw.underlying
+    case _                                => new JConcurrentMapWrapper(m)
+  }
+}


### PR DESCRIPTION
neg/i1754.scala succeeded because a GADT bound for `A` in `A <: B`
was narrowed to the lower bound of `B` (which was `Nothing`) instead of
`B` itself. Fixing this uncovered several other problems that were
hidden by the overly aggressive narrowing "feature".

In the end the PR had to do a major cleanup so that now type bounds and type
variables in patterns are treated the same. I.e. it makes no difference whether
one writes a type pattern `C[_ >: L <: H]` or `C[t >: L <: H]` where `t` is otherwise
not used.

It also involved a major refactoring in TypeComparer to make it harder to accidentally narrow to bounds that are too tight.

Based on #3889.
