### PR TITLE
Fix #1771: Harden namer in the presence of double definitions

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -590,8 +590,10 @@ class Namer { typer: Typer =>
     def createLinks(classTree: TypeDef, moduleTree: TypeDef)(implicit ctx: Context) = {
       val claz = ctx.effectiveScope.lookup(classTree.name)
       val modl = ctx.effectiveScope.lookup(moduleTree.name)
-      ctx.synthesizeCompanionMethod(nme.COMPANION_CLASS_METHOD, claz, modl).entered
-      ctx.synthesizeCompanionMethod(nme.COMPANION_MODULE_METHOD, modl, claz).entered
+      if (claz.isClass && modl.isClass) {
+        ctx.synthesizeCompanionMethod(nme.COMPANION_CLASS_METHOD, claz, modl).entered
+        ctx.synthesizeCompanionMethod(nme.COMPANION_MODULE_METHOD, modl, claz).entered
+      }
     }
 
     def createCompanionLinks(implicit ctx: Context): Unit = {

--- a/tests/neg/i1771.scala
+++ b/tests/neg/i1771.scala
@@ -1,4 +1,4 @@
 class GBTree[B] {
   class Tree[A, B]; class Node[A, B](value: Node[A, B]) extends Tree[A, B]
-  case class B[A, B]() extends Tree[A, B]
+  case class B[A, B]() extends Tree[A, B]  // error: double definition
 }

--- a/tests/pos/i1771.scala
+++ b/tests/pos/i1771.scala
@@ -1,0 +1,4 @@
+class GBTree[B] {
+  class Tree[A, B]; class Node[A, B](value: Node[A, B]) extends Tree[A, B]
+  case class B[A, B]() extends Tree[A, B]
+}


### PR DESCRIPTION
i1771.scala exhibits a case where an inner class is a double definition of a type parameter.
The inner class then gets renamed, but this caused problems for the generation of companion
links.

Companion links are fixed in Namer. There is also a change in Typer, where a missing
OriginalSymbol caused a crash. It turned out this was caused by the companion link generation
so once the latter was fixed, the crash did not happen anymore. Nevertheless I feel it's more
prudent to turn the crash into a "this should not happen" error, because we might have overlooked
other error paths that also lead to missing OriginalSymbols.