### PR TITLE
Fix #3909: Allow ~ as a standalone type identifier

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -432,8 +432,12 @@ object Parsers {
 
     def commaSeparated[T](part: () => T): List[T] = tokenSeparated(COMMA, part)
 
-    def lookaheadIn(tokens: Token*): Boolean =
-      tokens.contains(in.lookaheadScanner.nextToken())
+    /** Is the token following the current one in `tokens`? */
+    def lookaheadIn(tokens: Token*): Boolean = {
+      val lookahead = in.lookaheadScanner
+      lookahead.nextToken()
+      tokens.contains(lookahead.token)
+    }
 
 /* --------- OPERAND/OPERATOR STACK --------------------------------------- */
 

--- a/tests/pos/i3909.scala
+++ b/tests/pos/i3909.scala
@@ -1,0 +1,8 @@
+class ~(x: Int)
+object Test {
+  new ~(1)   // Syntax error
+  new `~`(1) // Syntax error
+
+  def ~(x: Int) = 1
+  ~(1) // OK
+}


### PR DESCRIPTION
We previously always parsed as a prefix operator.

Another change is that we now accept only ~ as type prefix operator. That's in
preparation of giving this a special syntax and not allowing it as a user-defined
operator.