### PR TITLE
Fix #1169: Fix strange type formatting in error message

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -56,7 +56,13 @@ class Bridges(root: ClassSymbol)(implicit ctx: Context) {
       bridgesScope.lookupAll(member.name).exists(bridge =>
         bridgeTarget(bridge) == member && bridge.signature == other.signature)
     def info(sym: Symbol)(implicit ctx: Context) = sym.info
-    def desc(sym: Symbol)= i"$sym${info(sym)(preErasureCtx)} in ${sym.owner}"
+    def desc(sym: Symbol)= {
+      val infoStr = info(sym)(preErasureCtx) match {
+        case ExprType(info) => i": $info"
+        case info => info.show
+      }
+      i"$sym$infoStr in ${sym.owner}"
+    }
     if (member.signature == other.signature) {
       if (!member.info.matches(other.info))
         ctx.error(em"""bridge generated for member ${desc(member)}

--- a/tests/neg/i1169.scala
+++ b/tests/neg/i1169.scala
@@ -1,0 +1,9 @@
+class X(val underlying: Object) extends AnyVal
+
+trait Producer[T] {
+  def produce: T
+}
+
+class XProducer extends Producer[X] {
+  def produce = new X(null) // error
+}


### PR DESCRIPTION
We already generate an error message for i1169.scala, but it looked weird:

    |bridge generated for member method produce=> X in class XProducer
    |which overrides method produce=> T in trait Producer
    |clashes with definition of the member itself; both have erased type (): Object.

The fix changes how ExprTypes in method signatures are handled. We now get:

    |bridge generated for member method produce: X in class XProducer
    |which overrides method produce: T in trait Producer
    |clashes with definition of the member itself; both have erased type (): Object."