### PR TITLE
Fix #756: Generate efficient try cases for parameterized exceptions

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TryCatchPatterns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TryCatchPatterns.scala
@@ -76,6 +76,8 @@ class TryCatchPatterns extends MiniPhase {
       (pre == NoPrefix || pre.widen.typeSymbol.isStatic) && // Does not require outer class check
       !tp.symbol.is(Flags.Trait) && // Traits not supported by JVM
       tp.derivesFrom(defn.ThrowableClass)
+    case tp: AppliedType =>
+      isSimpleThrowable(tp.tycon)
     case _ =>
       false
   }

--- a/tests/pos/i756.scala
+++ b/tests/pos/i756.scala
@@ -1,0 +1,10 @@
+class Test[T] {
+
+  def f(x: Int) = try {
+    ???
+  }
+  catch {
+    case ex: scala.runtime.NonLocalReturnControl[T @scala.unchecked] =>
+      ???
+  }
+}


### PR DESCRIPTION
We were missing a case for AppliedType