### PR TITLE
Override Console.out and Console.err the REPL

### DIFF
--- a/compiler/test-resources/repl/outputStream
+++ b/compiler/test-resources/repl/outputStream
@@ -1,0 +1,2 @@
+scala> println("Hello World!")
+Hello World!


### PR DESCRIPTION
This make it possible to test command such as `println` in the REPL
scripted tests.

