### PR TITLE
Splitter: Avoid unnecessary allocations (20% fewer Apply nodes)

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Splitter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splitter.scala
@@ -23,11 +23,22 @@ class Splitter extends MiniPhase {
     recur(tree.fun)
   }
 
+  private def needsDistribution(fun: Tree) = fun match {
+    case _: Block | _: If => true
+    case _ => false
+  }
+
   override def transformTypeApply(tree: TypeApply)(implicit ctx: Context) =
-    distribute(tree, typeApply)
+    if (needsDistribution(tree.fun))
+      distribute(tree, typeApply)
+    else
+      tree
 
   override def transformApply(tree: Apply)(implicit ctx: Context) =
-    distribute(tree, apply)
+    if (needsDistribution(tree.fun))
+      distribute(tree, apply)
+    else
+      tree
 
   private val typeApply = (fn: Tree, args: List[Tree]) => (ctx: Context) => TypeApply(fn, args)(ctx)
   private val apply     = (fn: Tree, args: List[Tree]) => (ctx: Context) => Apply(fn, args)(ctx)


### PR DESCRIPTION
When compiling dotty-compiler, this reduces the total number of
allocated Apply nodes from 649879 to 506536, and the total number of
allocated TypeApply nodes from 111097 to 95094