### PR TITLE
Erasure: reuse TypeTrees when possible

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -535,9 +535,12 @@ object Erasure {
       }
     }
 
+    private def resultTpt(defTree: untpd.ValOrDefDef, resultTpe: Type)(implicit ctx: Context): TypeTree =
+      defTree.tpt.asInstanceOf[TypeTree].withType(resultTpe)
+
     override def typedValDef(vdef: untpd.ValDef, sym: Symbol)(implicit ctx: Context): ValDef =
       super.typedValDef(untpd.cpy.ValDef(vdef)(
-        tpt = untpd.TypedSplice(TypeTree(sym.info).withPos(vdef.tpt.pos))), sym)
+        tpt = untpd.TypedSplice(resultTpt(vdef, sym.info))), sym)
 
     /** Besides normal typing, this function also compacts anonymous functions
      *  with more than `MaxImplementedFunctionArity` parameters to ise a single
@@ -572,7 +575,7 @@ object Erasure {
       val ddef1 = untpd.cpy.DefDef(ddef)(
         tparams = Nil,
         vparamss = vparamss1,
-        tpt = untpd.TypedSplice(TypeTree(restpe).withPos(ddef.tpt.pos)),
+        tpt = untpd.TypedSplice(resultTpt(ddef, restpe)),
         rhs = rhs1)
       super.typedDefDef(ddef1, sym)
     }


### PR DESCRIPTION
If the erased type is equal to the unerased type, we can reuse
TypeTrees.
When compiling re2s, this reduces the number of allocated TypeTrees from
34870 to 34477. It should be possible to do better if unerased types
used TermRef less often, for example:
```scala
TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),module scala),class Boolean)
```
gets erased to:
```scala
TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Boolean)
```
but the latter type could also have been used pre-erasure.