### PR TITLE
Fix #3956 -- Generic signature should box primitive type underlying refinement

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -276,7 +276,7 @@ object GenericSignatures {
         case _ =>
           val etp = erasure(tp)
           if (etp eq tp) throw new UnknownSig
-          else jsig(etp)
+          else jsig(etp, toplevel, primitiveOK)
       }
     }
     val throwsArgs = sym0.annotations flatMap ThrownException.unapply

--- a/tests/pos/i3956.scala
+++ b/tests/pos/i3956.scala
@@ -1,0 +1,4 @@
+object Foo {
+  type RInt = Int { val x: Int }
+  def f(xs: List[Int]): List[RInt] = ???
+}


### PR DESCRIPTION
Fix for #3956 