### PR TITLE
Fixes #3860 REPL pretty-printed output for by-name parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -326,6 +326,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
           "} at " ~ preText
       case mt: MethodType =>
         toTextGlobal(mt)
+      case tp: ExprType =>
+        ": => " ~ toTextGlobal(tp.widenExpr)
       case tp =>
         ": " ~ toTextGlobal(tp)
     }

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -120,4 +120,9 @@ class ReplCompilerTests extends ReplTest {
     compile("(x: Int) => println(x)")
     assertTrue(storedOutput().startsWith("val res0: Int => Unit ="))
   }
+
+  @Test def byNameParam: Unit = fromInitialState { implicit state =>
+    compile("def f(g: => Int): Int = g")
+    assertTrue(storedOutput().startsWith("def f(g: => Int): Int"))
+  }
 }


### PR DESCRIPTION
Fix #3860.