### PR TITLE
Fix test log folder location

### DIFF
--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -87,7 +87,7 @@ object TestReporter {
     val date = new Date
     val df0 = new SimpleDateFormat("yyyy-MM-dd")
     val df1 = new SimpleDateFormat("yyyy-MM-dd-HH:mm:ss")
-    val folder = s"../testlogs/tests-${df0.format(date)}"
+    val folder = s"testlogs/tests-${df0.format(date)}"
     new JFile(folder).mkdirs()
     outFile = new JFile(s"$folder/tests-${df1.format(date)}.log")
     logWriter = new PrintWriter(new FileOutputStream(outFile, true))


### PR DESCRIPTION
After #3926, test logs were outputted to the dotty project parent folder