### PR TITLE
Fix #3965: Make higher-kinded equality correct and efficient

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -306,8 +306,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   def prefixIsElidable(tp: NamedType)(implicit ctx: Context) = {
     val typeIsElidable = tp.prefix match {
-      case NoPrefix =>
-        true
       case pre: ThisType =>
         pre.cls.isStaticOwner ||
           tp.symbol.isParamOrAccessor && !pre.cls.is(Trait) && ctx.owner.enclosingClass == pre.cls
@@ -316,8 +314,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           // eg anonymous TypeMap inside TypeMap.andThen
       case pre: TermRef =>
         pre.symbol.is(Module) && pre.symbol.isStatic
-      case _ =>
-        false
+      case pre =>
+        pre `eq` NoPrefix
     }
     typeIsElidable ||
     tp.symbol.is(JavaStatic) ||

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -617,7 +617,8 @@ object Contexts {
         "uniqueNamedTypes" -> uniqueNamedTypes)
 
     /** A map that associates label and size of all uniques sets */
-    def uniquesSizes: Map[String, Int] = uniqueSets.mapValues(_.size)
+    def uniquesSizes: Map[String, (Int, Int, Int)] =
+      uniqueSets.mapValues(s => (s.size, s.accesses, s.misses))
 
     /** Number of findMember calls on stack */
     private[core] var findMemberCount: Int = 0

--- a/compiler/src/dotty/tools/dotc/core/Hashable.scala
+++ b/compiler/src/dotty/tools/dotc/core/Hashable.scala
@@ -6,6 +6,8 @@ import scala.util.hashing.{ MurmurHash3 => hashing }
 
 object Hashable {
 
+  type Binders = Array[BindingType]
+
   /** A hash value indicating that the underlying type is not
    *  cached in uniques.
    */
@@ -33,26 +35,29 @@ trait Hashable {
   protected final def finishHash(hashCode: Int, arity: Int): Int =
     avoidSpecialHashes(hashing.finalizeHash(hashCode, arity))
 
-  final def identityHash = avoidSpecialHashes(System.identityHashCode(this))
+  final def typeHash(bs: Binders, tp: Type) =
+    if (bs == null) tp.hash else tp.computeHash(bs)
 
-  protected def finishHash(seed: Int, arity: Int, tp: Type): Int = {
-    val elemHash = tp.hash
+  def identityHash(bs: Binders) = avoidSpecialHashes(System.identityHashCode(this))
+
+  protected def finishHash(bs: Binders, seed: Int, arity: Int, tp: Type): Int = {
+    val elemHash = typeHash(bs, tp)
     if (elemHash == NotCached) return NotCached
     finishHash(hashing.mix(seed, elemHash), arity + 1)
   }
 
-  protected def finishHash(seed: Int, arity: Int, tp1: Type, tp2: Type): Int = {
-    val elemHash = tp1.hash
+  protected def finishHash(bs: Binders, seed: Int, arity: Int, tp1: Type, tp2: Type): Int = {
+    val elemHash = typeHash(bs, tp1)
     if (elemHash == NotCached) return NotCached
-    finishHash(hashing.mix(seed, elemHash), arity + 1, tp2)
+    finishHash(bs, hashing.mix(seed, elemHash), arity + 1, tp2)
   }
 
-  protected def finishHash(seed: Int, arity: Int, tps: List[Type]): Int = {
+  protected def finishHash(bs: Binders, seed: Int, arity: Int, tps: List[Type]): Int = {
     var h = seed
     var xs = tps
     var len = arity
     while (xs.nonEmpty) {
-      val elemHash = xs.head.hash
+      val elemHash = typeHash(bs, xs.head)
       if (elemHash == NotCached) return NotCached
       h = hashing.mix(h, elemHash)
       xs = xs.tail
@@ -61,35 +66,35 @@ trait Hashable {
     finishHash(h, len)
   }
 
-  protected def finishHash(seed: Int, arity: Int, tp: Type, tps: List[Type]): Int = {
-    val elemHash = tp.hash
+  protected def finishHash(bs: Binders, seed: Int, arity: Int, tp: Type, tps: List[Type]): Int = {
+    val elemHash = typeHash(bs, tp)
     if (elemHash == NotCached) return NotCached
-    finishHash(hashing.mix(seed, elemHash), arity + 1, tps)
+    finishHash(bs, hashing.mix(seed, elemHash), arity + 1, tps)
   }
 
   protected final def doHash(x: Any): Int =
     finishHash(hashing.mix(hashSeed, x.hashCode), 1)
 
-  protected final def doHash(tp: Type): Int =
-    finishHash(hashSeed, 0, tp)
+  protected final def doHash(bs: Binders, tp: Type): Int =
+    finishHash(bs, hashSeed, 0, tp)
 
-  protected final def doHash(x1: Any, tp2: Type): Int =
-    finishHash(hashing.mix(hashSeed, x1.hashCode), 1, tp2)
+  protected final def doHash(bs: Binders, x1: Any, tp2: Type): Int =
+    finishHash(bs, hashing.mix(hashSeed, x1.hashCode), 1, tp2)
 
-  protected final def doHash(tp1: Type, tp2: Type): Int =
-    finishHash(hashSeed, 0, tp1, tp2)
+  protected final def doHash(bs: Binders, tp1: Type, tp2: Type): Int =
+    finishHash(bs, hashSeed, 0, tp1, tp2)
 
-  protected final def doHash(x1: Any, tp2: Type, tp3: Type): Int =
-    finishHash(hashing.mix(hashSeed, x1.hashCode), 1, tp2, tp3)
+  protected final def doHash(bs: Binders, x1: Any, tp2: Type, tp3: Type): Int =
+    finishHash(bs, hashing.mix(hashSeed, x1.hashCode), 1, tp2, tp3)
 
-  protected final def doHash(tp1: Type, tps2: List[Type]): Int =
-    finishHash(hashSeed, 0, tp1, tps2)
+  protected final def doHash(bs: Binders, tp1: Type, tps2: List[Type]): Int =
+    finishHash(bs, hashSeed, 0, tp1, tps2)
 
-  protected final def doHash(x1: Any, tp2: Type, tps3: List[Type]): Int =
-    finishHash(hashing.mix(hashSeed, x1.hashCode), 1, tp2, tps3)
+  protected final def doHash(bs: Binders, x1: Any, tp2: Type, tps3: List[Type]): Int =
+    finishHash(bs, hashing.mix(hashSeed, x1.hashCode), 1, tp2, tps3)
 
 
-  protected final def doHash(x1: Int, x2: Int): Int =
+  protected final def doHash(bs: Binders, x1: Int, x2: Int): Int =
     finishHash(hashing.mix(hashing.mix(hashSeed, x1), x2), 1)
 
   protected final def addDelta(elemHash: Int, delta: Int) =

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -12,9 +12,9 @@ trait Substituters { this: Context =>
       case tp: BoundType =>
         if (tp.binder eq from) tp.copyBoundType(to.asInstanceOf[tp.BT]) else tp
       case tp: NamedType =>
-        if (tp.currentSymbol.isStatic) tp
+        if (tp.currentSymbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
         else tp.derivedSelect(subst(tp.prefix, from, to, theMap))
-      case _: ThisType | NoPrefix =>
+      case _: ThisType =>
         tp
       case _ =>
         (if (theMap != null) theMap else new SubstBindingMap(from, to))
@@ -26,9 +26,9 @@ trait Substituters { this: Context =>
       case tp: NamedType =>
         val sym = tp.symbol
         if (sym eq from) return to
-        if (sym.isStatic && !from.isStatic) tp
+        if (sym.isStatic && !from.isStatic || (tp.prefix `eq` NoPrefix)) tp
         else tp.derivedSelect(subst1(tp.prefix, from, to, theMap))
-      case _: ThisType | _: BoundType | NoPrefix =>
+      case _: ThisType | _: BoundType =>
         tp
       case _ =>
         (if (theMap != null) theMap else new Subst1Map(from, to))
@@ -42,9 +42,9 @@ trait Substituters { this: Context =>
         val sym = tp.symbol
         if (sym eq from1) return to1
         if (sym eq from2) return to2
-        if (sym.isStatic && !from1.isStatic && !from2.isStatic) tp
+        if (sym.isStatic && !from1.isStatic && !from2.isStatic || (tp.prefix `eq` NoPrefix)) tp
         else tp.derivedSelect(subst2(tp.prefix, from1, to1, from2, to2, theMap))
-      case _: ThisType | _: BoundType | NoPrefix =>
+      case _: ThisType | _: BoundType =>
         tp
       case _ =>
         (if (theMap != null) theMap else new Subst2Map(from1, to1, from2, to2))
@@ -63,9 +63,9 @@ trait Substituters { this: Context =>
           fs = fs.tail
           ts = ts.tail
         }
-        if (sym.isStatic && !existsStatic(from)) tp
+        if (sym.isStatic && !existsStatic(from) || (tp.prefix `eq` NoPrefix)) tp
         else tp.derivedSelect(subst(tp.prefix, from, to, theMap))
-      case _: ThisType | _: BoundType | NoPrefix =>
+      case _: ThisType | _: BoundType =>
         tp
       case _ =>
         (if (theMap != null) theMap else new SubstMap(from, to))
@@ -84,7 +84,7 @@ trait Substituters { this: Context =>
           fs = fs.tail
           ts = ts.tail
         }
-        if (sym.isStatic && !existsStatic(from)) tp
+        if (sym.isStatic && !existsStatic(from) || (tp.prefix `eq` NoPrefix)) tp
         else {
           tp.info match {
             case TypeAlias(alias) =>
@@ -94,7 +94,7 @@ trait Substituters { this: Context =>
           }
           tp.derivedSelect(substDealias(tp.prefix, from, to, theMap))
         }
-      case _: ThisType | _: BoundType | NoPrefix =>
+      case _: ThisType | _: BoundType =>
         tp
       case _ =>
         (if (theMap != null) theMap else new SubstDealiasMap(from, to))
@@ -114,7 +114,7 @@ trait Substituters { this: Context =>
           fs = fs.tail
           ts = ts.tail
         }
-        if (sym.isStatic && !existsStatic(from)) tp
+        if (sym.isStatic && !existsStatic(from) || (tp.prefix `eq` NoPrefix)) tp
         else tp.derivedSelect(substSym(tp.prefix, from, to, theMap))
       case tp: ThisType =>
         val sym = tp.cls
@@ -126,7 +126,7 @@ trait Substituters { this: Context =>
           ts = ts.tail
         }
         tp
-      case _: ThisType | _: BoundType | NoPrefix =>
+      case _: ThisType | _: BoundType =>
         tp
       case _ =>
         (if (theMap != null) theMap else new SubstSymMap(from, to))
@@ -138,9 +138,9 @@ trait Substituters { this: Context =>
       case tp: ThisType =>
         if (tp.cls eq from) to else tp
       case tp: NamedType =>
-        if (tp.currentSymbol.isStaticOwner) tp
+        if (tp.currentSymbol.isStaticOwner || (tp.prefix `eq` NoPrefix)) tp
         else tp.derivedSelect(substThis(tp.prefix, from, to, theMap))
-      case _: BoundType | NoPrefix =>
+      case _: BoundType =>
         tp
       case _ =>
         (if (theMap != null) theMap else new SubstThisMap(from, to))
@@ -152,9 +152,9 @@ trait Substituters { this: Context =>
       case tp @ RecThis(binder) =>
         if (binder eq from) to else tp
       case tp: NamedType =>
-        if (tp.currentSymbol.isStatic) tp
+        if (tp.currentSymbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
         else tp.derivedSelect(substRecThis(tp.prefix, from, to, theMap))
-      case _: ThisType | _: BoundType | NoPrefix =>
+      case _: ThisType | _: BoundType =>
         tp
       case _ =>
         (if (theMap != null) theMap else new SubstRecThisMap(from, to))
@@ -166,9 +166,9 @@ trait Substituters { this: Context =>
       case tp: BoundType =>
         if (tp == from) to else tp
       case tp: NamedType =>
-        if (tp.currentSymbol.isStatic) tp
+        if (tp.currentSymbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
         else tp.derivedSelect(substParam(tp.prefix, from, to, theMap))
-      case _: ThisType | NoPrefix =>
+      case _: ThisType =>
         tp
       case _ =>
         (if (theMap != null) theMap else new SubstParamMap(from, to))
@@ -180,9 +180,9 @@ trait Substituters { this: Context =>
       case tp: ParamRef =>
         if (tp.binder == from) to(tp.paramNum) else tp
       case tp: NamedType =>
-        if (tp.currentSymbol.isStatic) tp
+        if (tp.currentSymbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
         else tp.derivedSelect(substParams(tp.prefix, from, to, theMap))
-      case _: ThisType | NoPrefix =>
+      case _: ThisType =>
         tp
       case _ =>
         (if (theMap != null) theMap else new SubstParamsMap(from, to))

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -461,7 +461,7 @@ object SymDenotations {
     /** Is symbol known to not exist? */
     final def isAbsent(implicit ctx: Context): Boolean = {
       ensureCompleted()
-      myInfo == NoType ||
+      (myInfo `eq` NoType) ||
       (this is (ModuleVal, butNot = Package)) && moduleClass.isAbsent
     }
 
@@ -1296,7 +1296,7 @@ object SymDenotations {
     private[this] var myMemberCachePeriod: Period = Nowhere
 
     /** A cache from types T to baseType(T, C) */
-    type BaseTypeMap = java.util.HashMap[CachedType, Type]
+    type BaseTypeMap = java.util.IdentityHashMap[CachedType, Type]
     private[this] var myBaseTypeCache: BaseTypeMap = null
     private[this] var myBaseTypeCachePeriod: Period = Nowhere
 
@@ -1720,7 +1720,7 @@ object SymDenotations {
                   btrCache.put(tp, basetp)
                 }
                 else btrCache.remove(tp)
-              } else if (basetp == NoPrefix)
+              } else if (basetp `eq` NoPrefix)
                 throw CyclicReference(this)
               basetp
             }

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -78,7 +78,7 @@ object TypeErasure {
    */
   abstract case class ErasedValueType(tycon: TypeRef, erasedUnderlying: Type)
   extends CachedGroundType with ValueType {
-    override def computeHash = doHash(tycon, erasedUnderlying)
+    override def computeHash(bs: Hashable.Binders) = doHash(bs, tycon, erasedUnderlying)
   }
 
   final class CachedErasedValueType(tycon: TypeRef, erasedUnderlying: Type)

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -429,9 +429,11 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
         tp.derivedClassInfo(NoPrefix, erasedParents, erasedDecls, erasedRef(tp.selfType))
           // can't replace selftype by NoType because this would lose the sourceModule link
       }
-    case NoType | NoPrefix | _: ErrorType | JavaArrayType(_) =>
+    case _: ErrorType | JavaArrayType(_) =>
       tp
     case tp: WildcardType if wildcardOK =>
+      tp
+    case tp if (tp `eq` NoType) || (tp `eq` NoPrefix) =>
       tp
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -57,11 +57,11 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         tp match {
           case tp: NamedType =>
             val sym = tp.symbol
-            if (sym.isStatic) tp
+            if (sym.isStatic || (tp.prefix `eq` NoPrefix)) tp
             else derivedSelect(tp, atVariance(variance max 0)(this(tp.prefix)))
           case tp: ThisType =>
             toPrefix(pre, cls, tp.cls)
-          case _: BoundType | NoPrefix =>
+          case _: BoundType =>
             tp
           case _ =>
             mapOver(tp)
@@ -80,7 +80,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
   /** Implementation of Types#simplified */
   final def simplify(tp: Type, theMap: SimplifyMap): Type = tp match {
     case tp: NamedType =>
-      if (tp.symbol.isStatic) tp
+      if (tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
       else tp.derivedSelect(simplify(tp.prefix, theMap)) match {
         case tp1: NamedType if tp1.denotationIsCurrent =>
           val tp2 = tp1.reduceProjection
@@ -97,7 +97,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         val tvar = typerState.constraint.typeVarOfParam(tp)
         if (tvar.exists) tvar else tp
       }
-    case  _: ThisType | _: BoundType | NoPrefix =>
+    case  _: ThisType | _: BoundType =>
       tp
     case tp: TypeAlias =>
       tp.derivedTypeAlias(simplify(tp.alias, theMap))

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1401,7 +1401,7 @@ object Types {
 
     /** Equality used for hash-consing; uses `eq` on all recursive invocations.
      */
-    def eql(that: Type): Boolean = this.equals(that)
+    def eql(that: Type): Boolean = this.iso(that, null)
 
     /** customized hash code of this type.
      *  NotCached for uncached types. Cached types
@@ -3782,7 +3782,7 @@ object Types {
       implicit val ctx = this.ctx
       tp match {
         case tp: NamedType =>
-          if (stopAtStatic && tp.symbol.isStatic) tp
+          if (stopAtStatic && tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
           else {
             val prefix1 = atVariance(variance max 0)(this(tp.prefix))
               // A prefix is never contravariant. Even if say `p.A` is used in a contravariant
@@ -4171,7 +4171,7 @@ object Types {
       record(s"foldOver total")
       tp match {
       case tp: TypeRef =>
-        if (stopAtStatic && tp.symbol.isStatic) x
+        if (stopAtStatic && tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) x
         else {
           val tp1 = tp.prefix.lookupRefined(tp.name)
           if (tp1.exists) this(x, tp1) else applyToPrefix(x, tp)
@@ -4201,10 +4201,8 @@ object Types {
         variance = -variance
         this(y, tp.resultType)
 
-      case NoPrefix => x
-
       case tp: TermRef =>
-        if (stopAtStatic && tp.currentSymbol.isStatic) x
+        if (stopAtStatic && tp.currentSymbol.isStatic || (tp.prefix `eq` NoPrefix)) x
         else applyToPrefix(x, tp)
 
       case tp: TypeVar =>
@@ -4284,11 +4282,14 @@ object Types {
     (implicit ctx: Context) extends TypeAccumulator[mutable.Set[NamedType]] {
     override def stopAtStatic = false
     def maybeAdd(x: mutable.Set[NamedType], tp: NamedType) = if (p(tp)) x += tp else x
-    val seen: mutable.Set[Type] = mutable.Set()
+    val seen = new util.HashSet[Type](7) {
+      override def hash(x: Type): Int = x.hash
+      override def isEqual(x: Type, y: Type) = x.eq(y)
+    }
     def apply(x: mutable.Set[NamedType], tp: Type): mutable.Set[NamedType] =
       if (seen contains tp) x
       else {
-        seen += tp
+        seen.addEntry(tp)
         tp match {
           case tp: TypeRef =>
             foldOver(maybeAdd(x, tp), tp)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1401,7 +1401,7 @@ object Types {
 
     /** Equality used for hash-consing; uses `eq` on all recursive invocations.
      */
-    def eql(that: Type): Boolean = this.iso(that, null)
+    def eql(that: Type): Boolean = this.equals(that)
 
     /** customized hash code of this type.
      *  NotCached for uncached types. Cached types
@@ -4282,8 +4282,8 @@ object Types {
     (implicit ctx: Context) extends TypeAccumulator[mutable.Set[NamedType]] {
     override def stopAtStatic = false
     def maybeAdd(x: mutable.Set[NamedType], tp: NamedType) = if (p(tp)) x += tp else x
-    val seen = new util.HashSet[Type](7) {
-      override def hash(x: Type): Int = x.hash
+    val seen = new util.HashSet[Type](64) {
+      override def hash(x: Type): Int = System.identityHashCode(x)
       override def isEqual(x: Type, y: Type) = x.eq(y)
     }
     def apply(x: mutable.Set[NamedType], tp: Type): mutable.Set[NamedType] =

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2734,11 +2734,10 @@ object Types {
 
   abstract class MethodOrPoly extends UncachedGroundType with LambdaType with MethodicType {
     final override def hashCode = System.identityHashCode(this)
-    final override def equals(other: Any) = this `eq` other.asInstanceOf[AnyRef]
 
     final override def equals(that: Any) = equals(that, null)
 
-    // No definition of `eql` --> fall back on equals, which calls iso
+    // No definition of `eql` --> fall back on equals, which is `eq`
 
     final override def iso(that: Any, bs: BinderPairs) = that match {
       case that: MethodOrPoly =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2663,6 +2663,7 @@ object Types {
     final def isHigherKinded = isInstanceOf[TypeProxy]
 
     private[this] var myParamRefs: List[ParamRefType] = null
+    private[this] var myStableHash: Byte = 0
 
     def paramRefs: List[ParamRefType] = {
       if (myParamRefs == null) myParamRefs = paramNames.indices.toList.map(newParamRef)
@@ -2695,24 +2696,20 @@ object Types {
           x => paramInfos.mapConserve(_.subst(this, x).asInstanceOf[PInfo]),
           x => resType.subst(this, x))
 
-    protected def prefixString: String
-    final override def toString = s"$prefixString($paramNames, $paramInfos, $resType)"
-  }
-
-  abstract class HKLambda extends CachedProxyType with LambdaType {
-    final override def underlying(implicit ctx: Context) = resType
-
     override def computeHash(bs: Binders) =
       doHash(new Binders(this, bs), paramNames, resType, paramInfos)
 
-    override def stableHash = resType.stableHash && paramInfos.stableHash
+    override def stableHash = {
+      if (myStableHash == 0) myStableHash = if (resType.stableHash && paramInfos.stableHash) 1 else -1
+      myStableHash > 0
+    }
 
     final override def equals(that: Any) = equals(that, null)
 
     // No definition of `eql` --> fall back on equals, which calls iso
 
     final override def iso(that: Any, bs: BinderPairs) = that match {
-      case that: HKLambda =>
+      case that: LambdaType =>
         paramNames.eqElements(that.paramNames) &&
         companion.eq(that.companion) && {
           val bs1 = new BinderPairs(this, that, bs)
@@ -2722,12 +2719,16 @@ object Types {
       case _ =>
         false
     }
+
+    protected def prefixString: String
+    final override def toString = s"$prefixString($paramNames, $paramInfos, $resType)"
   }
 
-  abstract class MethodOrPoly extends UncachedGroundType with LambdaType with MethodicType {
-    final override def hashCode = System.identityHashCode(this)
-    final override def equals(other: Any) = this `eq` other.asInstanceOf[AnyRef]
+  abstract class HKLambda extends CachedProxyType with LambdaType {
+    final override def underlying(implicit ctx: Context) = resType
   }
+
+  abstract class MethodOrPoly extends CachedGroundType with LambdaType with MethodicType
 
   trait TermLambda extends LambdaType { thisLambdaType =>
     import DepStatus._

--- a/compiler/src/dotty/tools/dotc/core/Uniques.scala
+++ b/compiler/src/dotty/tools/dotc/core/Uniques.scala
@@ -54,7 +54,7 @@ object Uniques {
     }
 
     def enterIfNew(prefix: Type, designator: Designator, isTerm: Boolean)(implicit ctx: Context): NamedType = {
-      val h = doHash(designator, prefix)
+      val h = doHash(null, designator, prefix)
       if (monitored) recordCaching(h, classOf[NamedType])
       def newType =
         if (isTerm) new CachedTermRef(prefix, designator, h)
@@ -80,7 +80,7 @@ object Uniques {
     }
 
     def enterIfNew(tycon: Type, args: List[Type]): AppliedType = {
-      val h = doHash(tycon, args)
+      val h = doHash(null, tycon, args)
       def newType = new CachedAppliedType(tycon, args, h)
       if (monitored) recordCaching(h, classOf[CachedAppliedType])
       if (h == NotCached) newType

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -480,7 +480,7 @@ object ProtoTypes {
    */
   final def wildApprox(tp: Type, theMap: WildApproxMap, seen: Set[TypeParamRef])(implicit ctx: Context): Type = tp match {
     case tp: NamedType => // default case, inlined for speed
-      if (tp.symbol.isStatic) tp
+      if (tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
       else tp.derivedSelect(wildApprox(tp.prefix, theMap, seen))
     case tp @ AppliedType(tycon, args) =>
       wildApprox(tycon, theMap, seen) match {
@@ -540,7 +540,7 @@ object ProtoTypes {
       tp.derivedViewProto(
           wildApprox(tp.argType, theMap, seen),
           wildApprox(tp.resultType, theMap, seen))
-    case  _: ThisType | _: BoundType | NoPrefix => // default case, inlined for speed
+    case  _: ThisType | _: BoundType => // default case, inlined for speed
       tp
     case _ =>
       (if (theMap != null && seen.eq(theMap.seen)) theMap else new WildApproxMap(seen))

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -402,7 +402,7 @@ object ProtoTypes {
       if (state.constraint contains tl) {
       	var paramInfos = tl.paramInfos
       	if (tl.isInstanceOf[HKLambda]) {
-      	  // HKLambdas care hash-consed, need to create an artificial difference by adding
+      	  // HKLambdas are hash-consed, need to create an artificial difference by adding
       	  // a LazyRef to a bound.
           val TypeBounds(lo, hi) :: pinfos1 = tl.paramInfos
           paramInfos = TypeBounds(lo, LazyRef(_ => hi)) :: pinfos1

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -130,9 +130,9 @@ object ProtoTypes {
 
     override def deepenProto(implicit ctx: Context) = derivedSelectionProto(name, memberProto.deepenProto, compat)
 
-    override def computeHash = {
+    override def computeHash(bs: Hashable.Binders) = {
       val delta = (if (compat eq NoViewsAllowed) 1 else 0) | (if (privateOK) 2 else 0)
-      addDelta(doHash(name, memberProto), delta)
+      addDelta(doHash(bs, name, memberProto), delta)
     }
   }
 
@@ -326,7 +326,7 @@ object ProtoTypes {
   }
 
   class CachedViewProto(argType: Type, resultType: Type) extends ViewProto(argType, resultType) {
-    override def computeHash = doHash(argType, resultType)
+    override def computeHash(bs: Hashable.Binders) = doHash(bs, argType, resultType)
   }
 
   object ViewProto {

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -400,14 +400,11 @@ object ProtoTypes {
     /** Ensure that `tl` is not already in constraint, make a copy of necessary */
     def ensureFresh(tl: TypeLambda): TypeLambda =
       if (state.constraint contains tl) {
-      	var paramInfos = tl.paramInfos
-      	if (tl.isInstanceOf[HKLambda]) {
-      	  // HKLambdas care hash-consed, need to create an artificial difference by adding
-      	  // a LazyRef to a bound.
-          val TypeBounds(lo, hi) :: pinfos1 = tl.paramInfos
-          paramInfos = TypeBounds(lo, LazyRef(_ => hi)) :: pinfos1
-        }
-        ensureFresh(tl.newLikeThis(tl.paramNames, paramInfos, tl.resultType))
+      	// Type lambdas are hash-consed, need to create an artificial difference by adding
+      	// a LazyRef to a bound.
+        val TypeBounds(lo, hi) :: pinfos1 = tl.paramInfos
+        val newParamInfos = TypeBounds(lo, LazyRef(_ => hi)) :: pinfos1
+        ensureFresh(tl.newLikeThis(tl.paramNames, newParamInfos, tl.resultType))
       }
       else tl
     val added = ensureFresh(tl)

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -400,11 +400,14 @@ object ProtoTypes {
     /** Ensure that `tl` is not already in constraint, make a copy of necessary */
     def ensureFresh(tl: TypeLambda): TypeLambda =
       if (state.constraint contains tl) {
-      	// Type lambdas are hash-consed, need to create an artificial difference by adding
-      	// a LazyRef to a bound.
-        val TypeBounds(lo, hi) :: pinfos1 = tl.paramInfos
-        val newParamInfos = TypeBounds(lo, LazyRef(_ => hi)) :: pinfos1
-        ensureFresh(tl.newLikeThis(tl.paramNames, newParamInfos, tl.resultType))
+      	var paramInfos = tl.paramInfos
+      	if (tl.isInstanceOf[HKLambda]) {
+      	  // HKLambdas care hash-consed, need to create an artificial difference by adding
+      	  // a LazyRef to a bound.
+          val TypeBounds(lo, hi) :: pinfos1 = tl.paramInfos
+          paramInfos = TypeBounds(lo, LazyRef(_ => hi)) :: pinfos1
+        }
+        ensureFresh(tl.newLikeThis(tl.paramNames, paramInfos, tl.resultType))
       }
       else tl
     val added = ensureFresh(tl)

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -9,6 +9,10 @@ class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int, loadFactor: F
 
   protected def isEqual(x: T, y: T): Boolean = x.equals(y)
 
+  // Counters for Stats
+  var accesses = 0
+  var misses = 0
+
   clear()
 
   /** The number of elements in the set */
@@ -37,10 +41,12 @@ class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int, loadFactor: F
    *  If not, enter `x` in set and return `x`.
    */
   def findEntryOrUpdate(x: T): T = {
+    if (Stats.enabled) accesses += 1
     var h = index(hash(x))
     var entry = entryAt(h)
     while (entry ne null) {
       if (isEqual(x, entry)) return entry
+      if (Stats.enabled) misses += 1
       h = index(h + 1)
       entry = entryAt(h)
     }
@@ -57,9 +63,11 @@ class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int, loadFactor: F
 
   /** The entry in the set such that `isEqual(x, entry)`, or else `null`. */
   def findEntry(x: T): T = {
+    if (Stats.enabled) accesses += 1
     var h = index(hash(x))
     var entry = entryAt(h)
     while ((entry ne null) && !isEqual(x, entry)) {
+      if (Stats.enabled) misses += 1
       h = index(h + 1)
       entry = entryAt(h)
     }
@@ -70,10 +78,12 @@ class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int, loadFactor: F
 
   /** Add entry `x` to set */
   def addEntry(x: T): Unit = {
+    if (Stats.enabled) accesses += 1
     var h = index(hash(x))
     var entry = entryAt(h)
     while (entry ne null) {
       if (isEqual(x, entry)) return
+      if (Stats.enabled) misses += 1
       h = index(h + 1)
       entry = entryAt(h)
     }
@@ -109,10 +119,12 @@ class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int, loadFactor: F
    *  follow a `findEntryByhash` or `nextEntryByHash` operation.
    */
   protected def nextEntryByHash(hashCode: Int): T = {
+    if (Stats.enabled) accesses += 1
     var entry = table(rover)
     while (entry ne null) {
       rover = index(rover + 1)
       if (hash(entry.asInstanceOf[T]) == hashCode) return entry.asInstanceOf[T]
+      if (Stats.enabled) misses += 1
       entry = table(rover)
     }
     null

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -83,7 +83,7 @@ import collection.mutable
         hb.continue = false
         println()
         println(hits.toList.sortBy(_._2).map{ case (x, y) => s"$x -> $y" } mkString "\n")
-        println(s"uniqieInfo (size, accesses, collisions): ${ctx.base.uniquesSizes}")
+        println(s"uniqueInfo (size, accesses, collisions): ${ctx.base.uniquesSizes}")
       }
     } else op
   }

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -83,7 +83,7 @@ import collection.mutable
         hb.continue = false
         println()
         println(hits.toList.sortBy(_._2).map{ case (x, y) => s"$x -> $y" } mkString "\n")
-        println(s"sizes: ${ctx.base.uniquesSizes}")
+        println(s"uniqieInfo (size, accesses, collisions): ${ctx.base.uniquesSizes}")
       }
     } else op
   }

--- a/tests/pos/i3965.scala
+++ b/tests/pos/i3965.scala
@@ -1,0 +1,19 @@
+trait Iterable[+A] extends  IterableOps[A, Iterable, Iterable[A]]
+trait IterableOps[+A, +CCop[_], +C]
+
+trait SortedSet[A] extends Iterable[A] with SortedSetOps[A, SortedSet, SortedSet[A]]
+
+trait SortedSetOps[A, +CCss[X] <: SortedSet[X], +C <: SortedSetOps[A, CCss, C]]
+
+class TreeSet[A]
+  extends SortedSet[A]
+    with SortedSetOps[A, TreeSet, TreeSet[A]]
+
+class Test {
+  def optionSequence1[CCos[X] <: IterableOps[X, CCos, _], A](xs: CCos[Option[A]]): Option[CCos[A]] = ???
+  def optionSequence1[CC[X] <: SortedSet[X] with SortedSetOps[X, CC, CC[X]], A : Ordering](xs: CC[Option[A]]): Option[CC[A]] = ???
+
+  def test(xs2: TreeSet[Option[String]]) = {
+    optionSequence1(xs2)
+  }
+}

--- a/tests/pos/i3965a.scala
+++ b/tests/pos/i3965a.scala
@@ -1,0 +1,15 @@
+trait SortedSet[A] extends SortedSetOps[A, SortedSet, SortedSet[A]]
+
+trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+
+class TreeSet[A]
+  extends SortedSet[A]
+    with SortedSetOps[A, TreeSet, TreeSet[A]]
+
+class Test {
+  def optionSequence1[CC[X] <: SortedSet[X] with SortedSetOps[X, CC, CC[X]], A : Ordering](xs: CC[A]): Unit = ()
+
+  def test(xs2: TreeSet[String]) = {
+    optionSequence1(xs2)
+  }
+}


### PR DESCRIPTION
#3970 fixed equality for higher-kinded types but came at a steep performance penalty. This PR is trying to avoid the penalty. 

Investigation showed that the main culprit was that equality reverted to `eq` for some ProtoType case classes that inherit from type. Since the multiple copies of these case class instances all had the same hashcode, hashtables saw a significant drop in performance. This shows the danger of redefining equality without also redefining hashcode at the same time. We now dropped the shortcut of having a global `equals` in Type, preferring to overwrite `equals` in each subclass where necessary.

To make detection of such issues easier in the future e9388bc adds the numbers of hash-cons table accesses and collisions in the statistics output.


