### PR TITLE
Fix #3945: Fix eta expansion for partially applied methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3286,7 +3286,7 @@ object Types {
    *  `owningTree` and `owner` are used to determine whether a type-variable can be instantiated
    *  at some given point. See `Inferencing#interpolateUndetVars`.
    */
-  final class TypeVar(val origin: TypeParamRef, creatorState: TyperState, val bindingTree: untpd.Tree, val owner: Symbol) extends CachedProxyType with ValueType {
+  final class TypeVar(val origin: TypeParamRef, creatorState: TyperState, var bindingTree: untpd.Tree, val owner: Symbol) extends CachedProxyType with ValueType {
 
     /** The permanent instance type of the variable, or NoType is none is given yet */
     private[this] var myInst: Type = NoType

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -192,6 +192,8 @@ object EtaExpansion extends LiftImpure {
    *  more options open.
    *
    *  In each case, the result is an untyped tree, with `es` and `expr` as typed splices.
+   *
+   *    F[V](x) ==> (x => F[X])
    */
   def etaExpand(tree: Tree, mt: MethodType, xarity: Int)(implicit ctx: Context): untpd.Tree = {
     import untpd._

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -394,6 +394,20 @@ trait Inferencing { this: Typer =>
     }
     if (constraint.uninstVars exists qualifies) interpolate()
   }
+
+  /** The uninstantiated type variables introduced somehwere in `tree` */
+  def uninstBoundVars(tree: Tree)(implicit ctx: Context): List[TypeVar] = {
+    val buf = new mutable.ListBuffer[TypeVar]
+    tree.foreachSubTree {
+      case arg: TypeTree =>
+        arg.tpe match {
+          case tv: TypeVar if !tv.isInstantiated && tree.contains(tv.bindingTree) => buf += tv
+          case _ =>
+        }
+      case _ =>
+    }
+    buf.toList
+  }
 }
 
 /** An enumeration controlling the degree of forcing in "is-dully-defined" checks. */

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -166,7 +166,7 @@ object Inferencing {
       case Apply(fn, _) => boundVars(fn, acc)
       case TypeApply(fn, targs) =>
         val tvars = targs.tpes.collect {
-          case tvar: TypeVar if !tvar.isInstantiated => tvar
+          case tvar: TypeVar if !tvar.isInstantiated && targs.contains(tvar.bindingTree) => tvar
         }
         boundVars(fn, acc ::: tvars)
       case Select(pre, _) => boundVars(pre, acc)
@@ -399,8 +399,8 @@ trait Inferencing { this: Typer =>
   def uninstBoundVars(tree: Tree)(implicit ctx: Context): List[TypeVar] = {
     val buf = new mutable.ListBuffer[TypeVar]
     tree.foreachSubTree {
-      case arg: TypeTree =>
-        arg.tpe match {
+      case TypeApply(_, args) =>
+        args.tpes.foreach {
           case tv: TypeVar if !tv.isInstantiated && tree.contains(tv.bindingTree) => buf += tv
           case _ =>
         }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1970,7 +1970,7 @@ class Typer extends Namer
       if (!tree.denot.isOverloaded) {
       	// for overloaded trees: resolve overloading before simplifying
         if (tree.isDef) interpolateUndetVars(tree, tree.symbol, pt)
-        else if (!tree.tpe.widen.isInstanceOf[LambdaType]) interpolateUndetVars(tree, NoSymbol, pt)
+        else if (!tree.tpe.widen.isInstanceOf[MethodOrPoly]) interpolateUndetVars(tree, NoSymbol, pt)
         tree.overwriteType(tree.tpe.simplified)
       }
       adaptInterpolated(tree, pt)
@@ -2106,8 +2106,10 @@ class Typer extends Namer
     def adaptNoArgsImplicitMethod(wtp: MethodType): Tree = {
       assert(wtp.isImplicitMethod)
       val tvarsToInstantiate = tvarsInParams(tree)
+      println(i"adaptNoArgsImpl $tvarsToInstantiate%, %, ${ctx.typerState.constraint}")
       wtp.paramInfos.foreach(instantiateSelected(_, tvarsToInstantiate))
       val constr = ctx.typerState.constraint
+      println(i"new constr = $constr")
 
       def dummyArg(tp: Type) = untpd.Ident(nme.???).withTypeUnchecked(tp)
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2227,8 +2227,18 @@ class Typer extends Namer
       if (arity >= 0 &&
           !tree.symbol.isConstructor &&
           !ctx.mode.is(Mode.Pattern) &&
-          !(isSyntheticApply(tree) && !isExpandableApply))
-        typed(etaExpand(tree, wtp, arity), pt)
+          !(isSyntheticApply(tree) && !isExpandableApply)) {
+        // Eta expansion interacts in tricky ways with type variable instantiation
+        // because it can extend the region where type variables are bound (and therefore may not
+        // be interpolated). To avoid premature interpolations, we need to extend the
+        // bindingTree of variables as we go along. Test case in pos/i3945.scala.
+        val boundtvs = uninstBoundVars(tree)
+        val uexpanded = etaExpand(tree, wtp, arity)
+        boundtvs.foreach(_.bindingTree = uexpanded) // make boundtvs point to uexpanded so that they are _not_ interpolated
+        val texpanded = typedUnadapted(uexpanded, pt)
+        boundtvs.foreach(_.bindingTree = texpanded) // make boundtvs point to texpanded so that they _can_ be interpolated
+        adapt(texpanded, pt)
+      }
       else if (wtp.paramInfos.isEmpty && isAutoApplied(tree.symbol))
         adaptInterpolated(tpd.Apply(tree, Nil), pt)
       else if (wtp.isImplicitMethod)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2106,10 +2106,8 @@ class Typer extends Namer
     def adaptNoArgsImplicitMethod(wtp: MethodType): Tree = {
       assert(wtp.isImplicitMethod)
       val tvarsToInstantiate = tvarsInParams(tree)
-      println(i"adaptNoArgsImpl $tvarsToInstantiate%, %, ${ctx.typerState.constraint}")
       wtp.paramInfos.foreach(instantiateSelected(_, tvarsToInstantiate))
       val constr = ctx.typerState.constraint
-      println(i"new constr = $constr")
 
       def dummyArg(tp: Type) = untpd.Ident(nme.???).withTypeUnchecked(tp)
 

--- a/tests/pos/i3945.scala
+++ b/tests/pos/i3945.scala
@@ -1,0 +1,11 @@
+object Test {
+  def int[A](k: String => A)(s: String)(x: Int): A = ???
+
+  // composing directly: ok in scalac, error in dotc
+  val c: (String => String) => (String) => (Int) => (Int) => String = (int[Int => String](_)).compose(int[String](_))
+
+  // unwrapping composition: ok in scalac, ok in dotc
+  val q: (String => Int => String) => (String) => (Int) => (Int => String) = int[Int => String]
+  val p: (String => String) => (String) => (Int) => String = int[String]
+  val c2: (String => String) => (String) => (Int) => (Int) => String = q.compose(p)
+}

--- a/tests/pos/i3945.scala
+++ b/tests/pos/i3945.scala
@@ -6,6 +6,6 @@ object Test {
 
   // unwrapping composition: ok in scalac, ok in dotc
   val q: (String => Int => String) => (String) => (Int) => (Int => String) = int[Int => String]
-  val p: (String => String) => (String) => (Int) => String = int[String]
+  val p: (String => String) => (String) => (Int) => String = int
   val c2: (String => String) => (String) => (Int) => (Int) => String = q.compose(p)
 }

--- a/tests/pos/i3945.scala
+++ b/tests/pos/i3945.scala
@@ -1,11 +1,19 @@
 object Test {
   def int[A](k: String => A)(s: String)(x: Int): A = ???
 
-  // composing directly: ok in scalac, error in dotc
+  // composing directly: ok in scalac, now also in dotc
   val c: (String => String) => (String) => (Int) => (Int) => String = (int[Int => String](_)).compose(int[String](_))
 
   // unwrapping composition: ok in scalac, ok in dotc
   val q: (String => Int => String) => (String) => (Int) => (Int => String) = int[Int => String]
   val p: (String => String) => (String) => (Int) => String = int
   val c2: (String => String) => (String) => (Int) => (Int) => String = q.compose(p)
+
+  class B
+  class C extends B
+  implicit def iC: C => Unit = ???
+
+  // making sure A is not instantiated before implicit search
+  def f[A](k: String => A)(s: String)(x: Int)(implicit y: A => Unit): A = ???
+  val r: (String => C) => (String) => (Int) => B = f
 }


### PR DESCRIPTION
This was a tricky one to fix.