### PR TITLE
Fix #3930: Handle multiple type arguments in overloading resolution

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1388,8 +1388,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
           }
         }
 
-      case pt @ PolyProto(targs1, pt1) =>
-        assert(targs.isEmpty)
+      case pt @ PolyProto(targs1, pt1) if targs.isEmpty =>
         val alts1 = alts filter pt.isMatchedBy
         resolveOverloaded(alts1, pt1, targs1)
 

--- a/tests/neg/i3930.scala
+++ b/tests/neg/i3930.scala
@@ -1,0 +1,7 @@
+object A {
+  def a[F](x: Int) = 0
+  def a[F](x: String) = 0
+}
+object Test extends App {
+  A.a[String][Int](3) == 1 // error: ambiguous
+}

--- a/tests/run/i3930.scala
+++ b/tests/run/i3930.scala
@@ -1,0 +1,8 @@
+class Apply { def apply[A](x: Int) = 1 }
+object A {
+  def a[F] = new Apply
+  def a[F](x: String) = 0
+}
+object Test extends App {
+  assert(A.a[String][Int](3) == 1)
+}


### PR DESCRIPTION
The error message for the neg case is a bit weird, (it complains about an
ambiguity error), but improving it would require considerable complications,
which I don't think are worth it at the present time.