### PR TITLE
Remove AndOrType

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -679,7 +679,9 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
           rname == tree.name || hasRefinement(parent)
         case tp: TypeProxy =>
           hasRefinement(tp.underlying)
-        case tp: AndOrType =>
+        case tp: AndType =>
+          hasRefinement(tp.tp1) || hasRefinement(tp.tp2)
+        case tp: OrType =>
           hasRefinement(tp.tp1) || hasRefinement(tp.tp2)
         case _ =>
           false

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -88,7 +88,8 @@ class CheckRealizable(implicit ctx: Context) {
       def isConcrete(tp: Type): Boolean = tp.dealias match {
         case tp: TypeRef => tp.symbol.isClass
         case tp: TypeProxy => isConcrete(tp.underlying)
-        case tp: AndOrType => isConcrete(tp.tp1) && isConcrete(tp.tp2)
+        case tp: AndType => isConcrete(tp.tp1) && isConcrete(tp.tp2)
+        case tp: OrType  => isConcrete(tp.tp1) && isConcrete(tp.tp2)
         case _ => false
       }
       if (!isConcrete(tp)) NotConcrete

--- a/compiler/src/dotty/tools/dotc/core/Constants.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constants.scala
@@ -23,27 +23,9 @@ object Constants {
   final val EnumTag    = 13
   final val ScalaSymbolTag = 14
 
-  case class Constant(value: Any) extends printing.Showable {
+  class Constant(val value: Any, val tag: Int) extends printing.Showable with Product1[Any] {
     import java.lang.Double.doubleToRawLongBits
     import java.lang.Float.floatToRawIntBits
-
-    val tag: Int = value match {
-      case null            => NullTag
-      case x: Unit         => UnitTag
-      case x: Boolean      => BooleanTag
-      case x: Byte         => ByteTag
-      case x: Short        => ShortTag
-      case x: Int          => IntTag
-      case x: Long         => LongTag
-      case x: Float        => FloatTag
-      case x: Double       => DoubleTag
-      case x: String       => StringTag
-      case x: Char         => CharTag
-      case x: Type         => ClazzTag
-      case x: Symbol       => EnumTag
-      case x: scala.Symbol => ScalaSymbolTag
-      case _               => throw new Error("bad constant value: " + value + " of class " + value.getClass)
-    }
 
     def isByteRange: Boolean  = isIntRange && Byte.MinValue <= intValue && intValue <= Byte.MaxValue
     def isShortRange: Boolean = isIntRange && Short.MinValue <= intValue && intValue <= Short.MaxValue
@@ -235,5 +217,49 @@ object Constants {
       h = mix(h, equalHashValue.##)
       finalizeHash(h, length = 2)
     }
+
+    override def toString = s"Constant($value)"
+    def canEqual(x: Any) = true
+    def get     = value
+    def isEmpty = false
+    def _1      = value
+  }
+
+  object Constant {
+    def apply(x: Null)         = new Constant(x, NullTag)
+    def apply(x: Unit)         = new Constant(x, UnitTag)
+    def apply(x: Boolean)      = new Constant(x, BooleanTag)
+    def apply(x: Byte)         = new Constant(x, ByteTag)
+    def apply(x: Short)        = new Constant(x, ShortTag)
+    def apply(x: Int)          = new Constant(x, IntTag)
+    def apply(x: Long)         = new Constant(x, LongTag)
+    def apply(x: Float)        = new Constant(x, FloatTag)
+    def apply(x: Double)       = new Constant(x, DoubleTag)
+    def apply(x: String)       = new Constant(x, StringTag)
+    def apply(x: Char)         = new Constant(x, CharTag)
+    def apply(x: Type)         = new Constant(x, ClazzTag)
+    def apply(x: Symbol)       = new Constant(x, EnumTag)
+    def apply(x: scala.Symbol) = new Constant(x, ScalaSymbolTag)
+    def apply(value: Any)      =
+      new Constant(value,
+        value match {
+          case null            => NullTag
+          case x: Unit         => UnitTag
+          case x: Boolean      => BooleanTag
+          case x: Byte         => ByteTag
+          case x: Short        => ShortTag
+          case x: Int          => IntTag
+          case x: Long         => LongTag
+          case x: Float        => FloatTag
+          case x: Double       => DoubleTag
+          case x: String       => StringTag
+          case x: Char         => CharTag
+          case x: Type         => ClazzTag
+          case x: Symbol       => EnumTag
+          case x: scala.Symbol => ScalaSymbolTag
+        }
+      )
+
+    def unapply(c: Constant) = c
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1202,7 +1202,8 @@ object SymDenotations {
       case tp: ExprType => hasSkolems(tp.resType)
       case tp: AppliedType => hasSkolems(tp.tycon) || tp.args.exists(hasSkolems)
       case tp: LambdaType => tp.paramInfos.exists(hasSkolems) || hasSkolems(tp.resType)
-      case tp: AndOrType => hasSkolems(tp.tp1) || hasSkolems(tp.tp2)
+      case tp: AndType => hasSkolems(tp.tp1) || hasSkolems(tp.tp2)
+      case tp: OrType  => hasSkolems(tp.tp1) || hasSkolems(tp.tp2)
       case tp: AnnotatedType => hasSkolems(tp.tpe)
       case _ => false
     }
@@ -1641,9 +1642,9 @@ object SymDenotations {
           case tp: TypeRef if tp.symbol.isClass => true
           case tp: TypeVar => tp.inst.exists && inCache(tp.inst)
           //case tp: TypeProxy => inCache(tp.underlying) // disabled, can re-enable insyead of last two lines for performance testing
-          //case tp: AndOrType => inCache(tp.tp1) && inCache(tp.tp2)
           case tp: TypeProxy => isCachable(tp.underlying, btrCache)
-          case tp: AndOrType => isCachable(tp.tp1, btrCache) && isCachable(tp.tp2, btrCache)
+          case tp: AndType => isCachable(tp.tp1, btrCache) && isCachable(tp.tp2, btrCache)
+          case tp: OrType  => isCachable(tp.tp1, btrCache) && isCachable(tp.tp2, btrCache)
           case _ => true
         }
       }

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -374,8 +374,10 @@ class TypeApplications(val self: Type) extends AnyVal {
         tryReduce
       case dealiased: PolyType =>
         dealiased.instantiate(args)
-      case dealiased: AndOrType =>
-        dealiased.derivedAndOrType(dealiased.tp1.appliedTo(args), dealiased.tp2.appliedTo(args))
+      case dealiased: AndType =>
+        dealiased.derivedAndType(dealiased.tp1.appliedTo(args), dealiased.tp2.appliedTo(args))
+      case dealiased: OrType =>
+        dealiased.derivedOrType(dealiased.tp1.appliedTo(args), dealiased.tp2.appliedTo(args))
       case dealiased: TypeAlias =>
         dealiased.derivedTypeAlias(dealiased.alias.appliedTo(args))
       case dealiased: TypeBounds =>

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -322,7 +322,8 @@ object TypeErasure {
     case tp: TypeParamRef => false
     case tp: TypeBounds => false
     case tp: TypeProxy => hasStableErasure(tp.superType)
-    case tp: AndOrType => hasStableErasure(tp.tp1) && hasStableErasure(tp.tp2)
+    case tp: AndType => hasStableErasure(tp.tp1) && hasStableErasure(tp.tp2)
+    case tp: OrType  => hasStableErasure(tp.tp1) && hasStableErasure(tp.tp2)
     case _ => false
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -237,8 +237,11 @@ class TreePickler(pickler: TastyPickler) {
     case tpe: AnnotatedType =>
       writeByte(ANNOTATEDtype)
       withLength { pickleType(tpe.tpe, richTypes); pickleTree(tpe.annot.tree) }
-    case tpe: AndOrType =>
-      writeByte(if (tpe.isAnd) ANDtype else ORtype)
+    case tpe: AndType =>
+      writeByte(ANDtype)
+      withLength { pickleType(tpe.tp1, richTypes); pickleType(tpe.tp2, richTypes) }
+    case tpe: OrType =>
+      writeByte(ORtype)
       withLength { pickleType(tpe.tp1, richTypes); pickleType(tpe.tp2, richTypes) }
     case tpe: ExprType =>
       writeByte(BYNAMEtype)

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/PickleBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/PickleBuffer.scala
@@ -252,13 +252,22 @@ object PickleBuffer {
     // Convert map so that it maps chunks of ChunkBits size at once
     // instead of single bits.
     def chunkMap(xs: Array[Long]): FlagMap = {
-      val chunked = Array.ofDim[Long](
-        (xs.length + ChunkBits - 1) / ChunkBits, ChunkSize)
-      for (i <- 0 until chunked.length)
-        for (j <- 0 until ChunkSize)
-          for (k <- 0 until ChunkBits)
+      val size = (xs.length + ChunkBits - 1) / ChunkBits
+      val chunked = Array.ofDim[Long](size, ChunkSize)
+      var i = 0
+      while (i < size) {
+        var j = 0
+        while (j < ChunkSize) {
+          var k = 0
+          while (k < ChunkBits) {
             if ((j & (1 << k)) != 0)
               chunked(i)(j) |= xs(i * ChunkBits + k)
+            k += 1
+          }
+          j += 1
+        }
+        i += 1
+      }
       chunked
     }
 

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -450,17 +450,11 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
         // `recType` would lead to an infinite recursion, we avoid this by
         //  computing the representation of `recType` lazily.
         apiLazy(recType)
-      case tp: AndOrType =>
-        val parents = List(apiType(tp.tp1), apiType(tp.tp2))
-
-        // TODO: Add a real representation for AndOrTypes in xsbti. The order of
-        // types in an `AndOrType` does not change the API, so the API hash should
-        // be symmetric.
+      case tp: AndType =>
+        combineApiTypes(apiType(tp.tp1), apiType(tp.tp2))
+      case tp: OrType =>
         val s = combineApiTypes(apiType(tp.tp1), apiType(tp.tp2))
-        if (tp.isAnd)
-          s
-        else
-          withMarker(s, orMarker)
+        withMarker(s, orMarker)
       case ExprType(resultType) =>
         withMarker(apiType(resultType), byNameMarker)
       case ConstantType(constant) =>

--- a/compiler/src/dotty/tools/dotc/typer/Variances.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Variances.scala
@@ -96,8 +96,10 @@ object Variances {
       varianceInArgs(varianceInType(tycon)(tparam), args, tycon.typeParams)
     case AnnotatedType(tp, annot) =>
       varianceInType(tp)(tparam) & varianceInAnnot(annot)(tparam)
-    case tp: AndOrType =>
-      varianceInType(tp.tp1)(tparam) & varianceInType(tp.tp2)(tparam)
+    case AndType(tp1, tp2) =>
+      varianceInType(tp1)(tparam) & varianceInType(tp2)(tparam)
+    case OrType(tp1, tp2) =>
+      varianceInType(tp1)(tparam) & varianceInType(tp2)(tparam)
     case _ =>
       Bivariant
   }


### PR DESCRIPTION
This PR remove AndOrType to help the JVM's inliner (+2 other small cleanups based on the same data).

The pattern implemented by `AndOrType` is very problematic for the inliner as the type profiles would be around 50/50 between AndType and OrType, meaning that there is no way to inline further. IIUC, if the ratio goes above 95/5, there the JVM will inline for the common 95% cases and deopt in the other 5% cases.

To get that info from the VM I bootstrapped Dotty with `-XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining`, then grepped for `not inlineable`. [Here is the full log](https://gist.github.com/OlivierBlanvillain/a0b82a8f98ac28ff4a7699b408b403de). Note that each of these are on the hot path, so there should be some performance to be gained in each of them. All the `_1` & `_2` on types look like other low hanging fruits.