### PR TITLE
Fix #3984: SAM closures returning Unit may need adaptation

### DIFF
--- a/tests/run/lambda-unit.scala
+++ b/tests/run/lambda-unit.scala
@@ -2,13 +2,19 @@ trait SAMUnit {
   def foo(a: Object): Unit
 }
 
+trait GenericSAM[R] {
+  def foo(a: Object): R
+}
+
 object Test {
   val fun: Object => Unit = a => assert(a == "")
   val sam: SAMUnit = a => assert(a == "")
+  val genericSam: GenericSAM[Unit] = a => assert(a == "")
 
   def main(args: Array[String]): Unit = {
     fun("")
     (fun: Object => Any)("")
     sam.foo("")
+    genericSam.foo("")
   }
 }


### PR DESCRIPTION
If the abstract method in a SAM trait has a generic result type that is
instantiated to Unit, we need to adapt closures implementing this trait
to return BoxedUnit. This isn't necessary for
Unit-returning closures without an explicit SAM type because in the backend they're implemented
using the `JProcedure*` SAMs (see DottyBackendInterface#Closure) that
already handle adapting to BoxedUnit.