### PR TITLE
Show GADT bounds in type mismatch message

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -44,8 +44,6 @@ import reporting.diagnostic.messages.{NotAMember, SuperCallsNotAllowedInline}
  *  (11) Minimizes `call` fields of `Inline` nodes to just point to the toplevel
  *       class from which code was inlined.
  *
- *  (12) Converts GADT bounds into normal type bounds
- *
  *  The reason for making this a macro transform is that some functions (in particular
  *  super and protected accessors and instantiation checks) are naturally top-down and
  *  don't lend themselves to the bottom-up approach of a mini phase. The other two functions

--- a/tests/neg/gadt-eval.scala
+++ b/tests/neg/gadt-eval.scala
@@ -1,0 +1,33 @@
+sealed trait Exp[T]
+case class Lit(value: Int) extends Exp[Int]
+case class Pair[A, B](fst: Exp[A], snd: Exp[B]) extends Exp[(A, B)]
+
+object Test {
+  def eval[T](e: Exp[T]): T = e match {
+    case Lit(x) =>
+      x
+    case Pair(a, b) =>
+      (eval(a), eval(a)) // error:
+        // -- [E007] Type Mismatch Error: tests/neg/gadt-eval.scala:10:6 ------------------
+        // 10 |      (eval(a), eval(a))
+        // |      ^^^^^^^^^^^^^^^^^^
+        // |    found:    (_$1, _$1)
+        // |    required: T
+        // |
+        // |    where:    T is a type in method eval which is an alias of (_$1, _$2)
+  }
+
+  def eval2[T](e: Exp[T]): T = e match {
+    case e: Lit =>
+      e.value
+    case e: Pair[t1, t2] =>
+      (eval(e.fst), eval(e.fst)) // error:
+        //-- [E007] Type Mismatch Error: tests/neg/gadt-eval.scala:24:6 ------------------
+        //24 |      (eval(e.fst), eval(e.fst))
+        //   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+        //   |     found:    (t1, t1)
+        //   |     required: T
+        //   |
+        //   |     where:    T is a type in method eval2 which is an alias of (t1, t2)
+  }
+}

--- a/tests/pos/gadt-eval.scala
+++ b/tests/pos/gadt-eval.scala
@@ -1,0 +1,19 @@
+sealed trait Exp[T]
+case class Lit(value: Int) extends Exp[Int]
+case class Pair[A, B](fst: Exp[A], snd: Exp[B]) extends Exp[(A, B)]
+
+object Test {
+  def eval[T](e: Exp[T]): T = e match {
+    case Lit(x) =>
+      x
+    case Pair(a, b) =>
+      (eval(a), eval(b))
+  }
+
+  def eval2[T](e: Exp[T]): T = e match {
+    case e: Lit =>
+      e.value
+    case e: Pair[t1, t2] =>
+      (eval(e.fst), eval(e.snd))
+  }
+}


### PR DESCRIPTION
The inferred GADT bounds can be non-trivial so it makes sense to display
them.

This commit also showcases the now-improved GADT support in Dotty (both
tests/pos/gadt-eval.scala and tests/neg/gadt-eval.scala used to compile,
and both compile in Scala 2).