### PR TITLE
ClassfileParser: skip synthetic methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -211,7 +211,7 @@ class ClassfileParser(
       if (method) Flags.Method | methodTranslation.flags(jflags)
       else fieldTranslation.flags(jflags)
     val name = pool.getName(in.nextChar)
-    if (!(sflags is Flags.Private) || name == nme.CONSTRUCTOR) {
+    if (!(sflags is Flags.SyntheticOrPrivate) || name == nme.CONSTRUCTOR) {
       val member = ctx.newSymbol(
         getOwner(jflags), name, sflags, memberCompleter, coord = start)
       getScope(jflags).enter(member)


### PR DESCRIPTION
When compiling re2s, this reduces the number of symbols from 24663 to
24515 and the number of denotations from 216669 to 195374.