### PR TITLE
Document how to clone dotty faster

### DIFF
--- a/docs/docs/contributing/getting-started.md
+++ b/docs/docs/contributing/getting-started.md
@@ -15,10 +15,11 @@ Compiling and Running
 Start by cloning the repository:
 
 ```bash
-$ git clone --recursive https://github.com/lampepfl/dotty.git
+$ git clone --recursive --single-branch https://github.com/lampepfl/dotty.git
 $ cd dotty
 $ sbt managedSources # Needed for IDE import to succeed
 ```
+Pass `--single-branch` to clone only the master branch, otherwise cloning will be *much* slower (details in [issue #3236](https://github.com/lampepfl/dotty/issues/3236)).
 
 Dotty provides a standard sbt build: compiling, running and starting a repl can
 all be done from within sbt:


### PR DESCRIPTION
Workaround for consequences of #3236, probably to revert when that issue is
fixed. Thanks to @allanrenucci for the initial report and suggesting the option.