### PR TITLE
Harden IDE: Catch NoSuchFileException

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -148,20 +148,24 @@ class InteractiveDriver(settings: List[String]) extends Driver {
     val names = new mutable.ListBuffer[String]
     dirClassPaths.foreach { dirCp =>
       val root = dirCp.dir.toPath
-      Files.walkFileTree(root, new SimpleFileVisitor[Path] {
-        override def visitFile(path: Path, attrs: BasicFileAttributes) = {
-          if (!attrs.isDirectory) {
-            val name = path.getFileName.toString
-            for {
-              tastySuffix <- tastySuffixes
-              if name.endsWith(tastySuffix)
-            } {
-              names += root.relativize(path).toString.replace("/", ".").stripSuffix(tastySuffix)
+      try
+        Files.walkFileTree(root, new SimpleFileVisitor[Path] {
+          override def visitFile(path: Path, attrs: BasicFileAttributes) = {
+            if (!attrs.isDirectory) {
+              val name = path.getFileName.toString
+              for {
+                tastySuffix <- tastySuffixes
+                if name.endsWith(tastySuffix)
+              } {
+                names += root.relativize(path).toString.replace("/", ".").stripSuffix(tastySuffix)
+              }
             }
+            FileVisitResult.CONTINUE
           }
-          FileVisitResult.CONTINUE
-        }
-      })
+        })
+      catch {
+        case _: NoSuchFileException =>
+      }
     }
     names.toList
   }


### PR DESCRIPTION
A NoSuchFileException was observed for a non-existing directory on the classpath:

    /Users/odersky/workspace/dotty/compiler/../out/bootstrap/dotty-compiler-bootstrapped/scala-0.7/classes

It was after a dotty-bootstrapped/clean. I believe this should be ignored, or maybe handled with
an error message. But certainly not a crash.