### PR TITLE
Simplify Enums

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -33,11 +33,15 @@ object desugar {
 // ----- DerivedTypeTrees -----------------------------------
 
   class SetterParamTree extends DerivedTypeTree {
-    def derivedType(sym: Symbol)(implicit ctx: Context) = sym.info.resultType
+    def derivedTree(sym: Symbol)(implicit ctx: Context) = tpd.TypeTree(sym.info.resultType)
   }
 
   class TypeRefTree extends DerivedTypeTree {
-    def derivedType(sym: Symbol)(implicit ctx: Context) = sym.typeRef
+    def derivedTree(sym: Symbol)(implicit ctx: Context) = tpd.TypeTree(sym.typeRef)
+  }
+
+  class TermRefTree extends DerivedTypeTree {
+    def derivedTree(sym: Symbol)(implicit ctx: Context) = tpd.ref(sym)
   }
 
   /** A type tree that computes its type from an existing parameter.
@@ -73,7 +77,7 @@ object desugar {
      *
      *       parameter name  ==  reference name ++ suffix
      */
-    def derivedType(sym: Symbol)(implicit ctx: Context) = {
+    def derivedTree(sym: Symbol)(implicit ctx: Context) = {
       val relocate = new TypeMap {
         val originalOwner = sym.owner
         def apply(tp: Type) = tp match {
@@ -91,7 +95,7 @@ object desugar {
             mapOver(tp)
         }
       }
-      relocate(sym.info)
+      tpd.TypeTree(relocate(sym.info))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -305,14 +305,19 @@ object desugar {
     val isCaseObject = mods.is(Case) && mods.is(Module)
     val isImplicit = mods.is(Implicit)
     val isEnum = mods.hasMod[Mod.Enum] && !mods.is(Module)
-    val isEnumCase = isLegalEnumCase(cdef)
+    val isEnumCase = mods.hasMod[Mod.EnumCase]
     val isValueClass = parents.nonEmpty && isAnyVal(parents.head)
-    // This is not watertight, but `extends AnyVal` will be replaced by `inline` later.
-
+      // This is not watertight, but `extends AnyVal` will be replaced by `inline` later.
 
     val originalTparams = constr1.tparams
     val originalVparamss = constr1.vparamss
-    val constrTparams = originalTparams.map(toDefParam)
+    lazy val derivedEnumParams = enumClass.typeParams.map(derivedTypeParam)
+    val impliedTparams =
+      if (isEnumCase && originalTparams.isEmpty)
+        derivedEnumParams.map(tdef => tdef.withFlags(tdef.mods.flags | PrivateLocal))
+      else
+        originalTparams
+    val constrTparams = impliedTparams.map(toDefParam)
     val constrVparamss =
       if (originalVparamss.isEmpty) { // ensure parameter list is non-empty
         if (isCaseClass) ctx.error(CaseClassMissingParamList(cdef), cdef.namePos)
@@ -321,18 +326,34 @@ object desugar {
       else originalVparamss.nestedMap(toDefParam)
     val constr = cpy.DefDef(constr1)(tparams = constrTparams, vparamss = constrVparamss)
 
-    // Add constructor type parameters and evidence implicit parameters
-    // to auxiliary constructors
-    val normalizedBody = impl.body map {
-      case ddef: DefDef if ddef.name.isConstructorName =>
-        decompose(
-          defDef(
-            addEvidenceParams(
-              cpy.DefDef(ddef)(tparams = constrTparams),
-              evidenceParams(constr1).map(toDefParam))))
-      case stat =>
-        stat
+    val (normalizedBody, enumCases, enumCompanionRef) = {
+      // Add constructor type parameters and evidence implicit parameters
+      // to auxiliary constructors; set defaultGetters as a side effect.
+      def expandConstructor(tree: Tree) = tree match {
+        case ddef: DefDef if ddef.name.isConstructorName =>
+          decompose(
+            defDef(
+              addEvidenceParams(
+                cpy.DefDef(ddef)(tparams = constrTparams),
+                evidenceParams(constr1).map(toDefParam))))
+        case stat =>
+          stat
+      }
+      // The Identifiers defined by a case
+      def caseIds(tree: Tree) = tree match {
+        case tree: MemberDef => Ident(tree.name.toTermName) :: Nil
+        case PatDef(_, ids, _, _) => ids
+      }
+      val stats = impl.body.map(expandConstructor)
+      if (isEnum) {
+        val (enumCases, enumStats) = stats.partition(DesugarEnums.isEnumCase)
+        val enumCompanionRef = new TermRefTree()
+        val enumImport = Import(enumCompanionRef, enumCases.flatMap(caseIds))
+        (enumImport :: enumStats, enumCases, enumCompanionRef)
+      }
+      else (stats, Nil, EmptyTree)
     }
+
     def anyRef = ref(defn.AnyRefAlias.typeRef)
 
     val derivedTparams = constrTparams.map(derivedTypeParam(_))
@@ -365,20 +386,16 @@ object desugar {
     val classTypeRef = appliedRef(classTycon)
 
     // a reference to `enumClass`, with type parameters coming from the case constructor
-    lazy val enumClassTypeRef = enumClass.primaryConstructor.info match {
-      case info: PolyType =>
-        if (constrTparams.isEmpty)
-          interpolatedEnumParent(cdef.pos.startPos)
-        else if ((constrTparams.corresponds(info.paramNames))((param, name) => param.name == name))
-          appliedRef(enumClassRef)
-        else {
-          ctx.error(i"explicit extends clause needed because type parameters of case and enum class differ"
-              , cdef.pos.startPos)
-          appliedTypeTree(enumClassRef, constrTparams map (_ => anyRef))
-        }
-      case _ =>
+    lazy val enumClassTypeRef =
+      if (enumClass.typeParams.isEmpty)
         enumClassRef
-    }
+      else if (originalTparams.isEmpty)
+        appliedRef(enumClassRef)
+      else {
+        ctx.error(i"explicit extends clause needed because both enum case and enum class have type parameters"
+            , cdef.pos.startPos)
+        appliedTypeTree(enumClassRef, constrTparams map (_ => anyRef))
+      }
 
     // new C[Ts](paramss)
     lazy val creatorExpr = New(classTypeRef, constrVparamss nestedMap refOfDef)
@@ -432,6 +449,7 @@ object desugar {
     }
 
     // Case classes and case objects get Product parents
+    // Enum cases get an inferred parent if no parents are given
     var parents1 = parents
     if (isEnumCase && parents.isEmpty)
       parents1 = enumClassTypeRef :: Nil
@@ -477,7 +495,7 @@ object desugar {
             .withMods(companionMods | Synthetic))
       .withPos(cdef.pos).toList
 
-    val companionMeths = defaultGetters ::: eqInstances
+    val companionMembers = defaultGetters ::: eqInstances ::: enumCases
 
     // The companion object definitions, if a companion is needed, Nil otherwise.
     // companion definitions include:
@@ -490,18 +508,17 @@ object desugar {
     // For all other classes, the parent is AnyRef.
     val companions =
       if (isCaseClass) {
-        // The return type of the `apply` method
+        // The return type of the `apply` method, and an (empty or singleton) list
+        // of widening coercions
         val (applyResultTpt, widenDefs) =
           if (!isEnumCase)
             (TypeTree(), Nil)
           else if (parents.isEmpty || enumClass.typeParams.isEmpty)
             (enumClassTypeRef, Nil)
-          else {
-            val tparams = enumClass.typeParams.map(derivedTypeParam)
-            enumApplyResult(cdef, parents, tparams, appliedRef(enumClassRef, tparams))
-          }
+          else
+            enumApplyResult(cdef, parents, derivedEnumParams, appliedRef(enumClassRef, derivedEnumParams))
 
-        val parent =
+        val companionParent =
           if (constrTparams.nonEmpty ||
               constrVparamss.length > 1 ||
               mods.is(Abstract) ||
@@ -523,10 +540,10 @@ object desugar {
           DefDef(nme.unapply, derivedTparams, (unapplyParam :: Nil) :: Nil, TypeTree(), unapplyRHS)
             .withMods(synthetic)
         }
-        companionDefs(parent, applyMeths ::: unapplyMeth :: companionMeths)
+        companionDefs(companionParent, applyMeths ::: unapplyMeth :: companionMembers)
       }
-      else if (companionMeths.nonEmpty)
-        companionDefs(anyRef, companionMeths)
+      else if (companionMembers.nonEmpty)
+        companionDefs(anyRef, companionMembers)
       else if (isValueClass) {
         constr0.vparamss match {
           case (_ :: Nil) :: _ => companionDefs(anyRef, Nil)
@@ -534,6 +551,13 @@ object desugar {
         }
       }
       else Nil
+
+    enumCompanionRef match {
+      case ref: TermRefTree => // have the enum import watch the companion object
+        val (modVal: ValDef) :: _ = companions
+        ref.watching(modVal)
+      case _ =>
+    }
 
     // For an implicit class C[Ts](p11: T11, ..., p1N: T1N) ... (pM1: TM1, .., pMN: TMN), the method
     //     synthetic implicit C[Ts](p11: T11, ..., p1N: T1N) ... (pM1: TM1, ..., pMN: TMN): C[Ts] =
@@ -567,7 +591,7 @@ object desugar {
     }
 
     val cdef1 = addEnumFlags {
-      val originalTparamsIt = originalTparams.toIterator
+      val originalTparamsIt = impliedTparams.toIterator
       val originalVparamsIt = originalVparamss.toIterator.flatten
       val tparamAccessors = derivedTparams.map(_.withMods(originalTparamsIt.next().mods))
       val caseAccessor = if (isCaseClass) CaseAccessor else EmptyFlags
@@ -607,7 +631,7 @@ object desugar {
     val moduleName = checkNotReservedName(mdef).asTermName
     val impl = mdef.impl
     val mods = mdef.mods
-    lazy val isEnumCase = isLegalEnumCase(mdef)
+    lazy val isEnumCase = mods.hasMod[Mod.EnumCase]
     if (mods is Package)
       PackageDef(Ident(moduleName), cpy.ModuleDef(mdef)(nme.PACKAGE, impl).withMods(mods &~ Package) :: Nil)
     else if (isEnumCase)
@@ -654,7 +678,7 @@ object desugar {
    */
   def patDef(pdef: PatDef)(implicit ctx: Context): Tree = flatTree {
     val PatDef(mods, pats, tpt, rhs) = pdef
-    if (mods.hasMod[Mod.EnumCase] && enumCaseIsLegal(pdef))
+    if (mods.hasMod[Mod.EnumCase])
       pats map {
         case id: Ident =>
           expandSimpleEnumCase(id.name.asTermName, mods,

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -320,7 +320,8 @@ object desugar {
     val constrTparams = impliedTparams.map(toDefParam)
     val constrVparamss =
       if (originalVparamss.isEmpty) { // ensure parameter list is non-empty
-        if (isCaseClass) ctx.error(CaseClassMissingParamList(cdef), cdef.namePos)
+        if (isCaseClass && originalTparams.isEmpty)
+          ctx.error(CaseClassMissingParamList(cdef), cdef.namePos)
         ListOfNil
       }
       else originalVparamss.nestedMap(toDefParam)

--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -68,8 +68,8 @@ object DesugarEnums {
 
   /** Add implied flags to an enum class or an enum case */
   def addEnumFlags(cdef: TypeDef)(implicit ctx: Context) =
-    if (cdef.mods.hasMod[Mod.Enum]) cdef.withFlags(cdef.mods.flags | Abstract | Sealed)
-    else if (isEnumCase(cdef)) cdef.withFlags(cdef.mods.flags | Final)
+    if (cdef.mods.hasMod[Mod.Enum]) cdef.withMods(cdef.mods.withFlags(cdef.mods.flags | Abstract | Sealed))
+    else if (isEnumCase(cdef)) cdef.withMods(cdef.mods.withFlags(cdef.mods.flags | Final))
     else cdef
 
   private def valuesDot(name: String) = Select(Ident(nme.DOLLAR_VALUES), name.toTermName)

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -309,6 +309,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       case NoPrefix =>
         true
       case pre: ThisType =>
+        tp.isType ||
         pre.cls.isStaticOwner ||
           tp.symbol.isParamOrAccessor && !pre.cls.is(Trait) && ctx.owner.enclosingClass == pre.cls
           // was ctx.owner.enclosingClass.derivesFrom(pre.cls) which was not tight enough

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -228,8 +228,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
      */
     def ensureCompletions(implicit ctx: Context): Unit = ()
 
-    /** The method that computes the type of this tree */
-    def derivedType(originalSym: Symbol)(implicit ctx: Context): Type
+    /** The method that computes the tree with the derived type */
+    def derivedTree(originalSym: Symbol)(implicit ctx: Context): tpd.Tree
   }
 
     /** Property key containing TypeTrees whose type is computed

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2239,7 +2239,7 @@ object Parsers {
             }
             else
               ModuleDef(id.name.toTermName, caseTemplate(emptyConstructor))
-          caseDef.withMods(mods).setComment(in.getDocComment(start))
+          caseDef.withMods(mods1).setComment(in.getDocComment(start))
         }
       }
     }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -308,12 +308,19 @@ object Parsers {
      *  class constructor
      */
     private[this] var inClassConstrAnnots = false
-
     private def fromWithinClassConstr[T](body: => T): T = {
       val saved = inClassConstrAnnots
       inClassConstrAnnots = true
       try body
       finally inClassConstrAnnots = saved
+    }
+
+    private[this] var inEnum = false
+    private def withinEnum[T](isEnum: Boolean)(body: => T): T = {
+      val saved = inEnum
+      inEnum = isEnum
+      try body
+      finally inEnum = saved
     }
 
     def migrationWarningOrError(msg: String, offset: Int = in.offset) =
@@ -1975,7 +1982,7 @@ object Parsers {
      *             | var ValDcl
      *             | def DefDcl
      *             | type {nl} TypeDcl
-     *  EnumCase ::= `case' (EnumClassDef | ObjectDef)
+     *  EnumCase ::= `case' (id ClassConstr [`extends' ConstrApps]] | ids)
      */
     def defOrDcl(start: Int, mods: Modifiers): Tree = in.token match {
       case VAL =>
@@ -1990,7 +1997,7 @@ object Parsers {
         defDefOrDcl(start, posMods(start, mods))
       case TYPE =>
         typeDefOrDcl(start, posMods(start, mods))
-      case CASE =>
+      case CASE if inEnum =>
         enumCase(start, mods)
       case _ =>
         tmplDef(start, mods)
@@ -2135,7 +2142,7 @@ object Parsers {
       }
     }
 
-    /** TmplDef ::=  ([`case' | `enum]'] ‘class’ | trait’) ClassDef
+    /** TmplDef ::=  ([`case'] ‘class’ | trait’) ClassDef
      *            |  [`case'] `object' ObjectDef
      *            |  `enum' EnumDef
      */
@@ -2152,9 +2159,7 @@ object Parsers {
         case CASEOBJECT =>
           objectDef(start, posMods(start, mods | Case | Module))
         case ENUM =>
-          val enumMod = atPos(in.skipToken()) { Mod.Enum() }
-          if (in.token == CLASS) tmplDef(start, addMod(mods, enumMod))
-          else enumDef(start, mods, enumMod)
+          enumDef(start, mods, atPos(in.skipToken()) { Mod.Enum() })
         case _ =>
           syntaxErrorOrIncomplete(ExpectedStartOfTopLevelDefinition())
           EmptyTree
@@ -2198,55 +2203,18 @@ object Parsers {
       ModuleDef(name, template).withMods(mods).setComment(in.getDocComment(start))
     }
 
-    /**  id ClassConstr [`extends' [ConstrApps]]
-     *   [nl] ‘{’ EnumCaseStats ‘}’
+    /**  EnumDef ::=  id ClassConstr [`extends' [ConstrApps]] EnumBody
      */
-    def enumDef(start: Offset, mods: Modifiers, enumMod: Mod): Thicket = {
-      val point = nameStart
+    def enumDef(start: Offset, mods: Modifiers, enumMod: Mod): TypeDef = atPos(start, nameStart) {
       val modName = ident()
       val clsName = modName.toTypeName
       val constr = classConstr(clsName)
-      val parents =
-        if (in.token == EXTENDS) {
-          in.nextToken();
-          newLineOptWhenFollowedBy(LBRACE)
-          if (in.token == LBRACE) Nil else tokenSeparated(WITH, constrApp)
-        }
-        else Nil
-      val clsDef = atPos(start, point) {
-        TypeDef(clsName, Template(constr, parents, EmptyValDef, Nil))
-          .withMods(addMod(mods, enumMod)).setComment(in.getDocComment(start))
-      }
-      newLineOptWhenFollowedBy(LBRACE)
-      val modDef = atPos(in.offset) {
-        val body = inBraces(enumCaseStats())
-        ModuleDef(modName, Template(emptyConstructor, Nil, EmptyValDef, body))
-          .withMods(mods)
-      }
-      Thicket(clsDef :: modDef :: Nil)
+      val impl = templateOpt(constr, isEnum = true)
+      TypeDef(clsName, impl).withMods(addMod(mods, enumMod)).setComment(in.getDocComment(start))
     }
 
-    /** EnumCaseStats = EnumCaseStat {semi EnumCaseStat} */
-    def enumCaseStats(): List[DefTree] = {
-      val cases = new ListBuffer[DefTree] += enumCaseStat()
-      var exitOnError = false
-      while (!isStatSeqEnd && !exitOnError) {
-        acceptStatSep()
-        if (isCaseIntro)
-          cases += enumCaseStat()
-        else if (!isStatSep) {
-          exitOnError = mustStartStat
-          syntaxErrorOrIncomplete("illegal start of case")
-        }
-      }
-      cases.toList
-    }
-
-    /** EnumCaseStat = {Annotation [nl]} {Modifier} EnumCase */
-    def enumCaseStat(): DefTree =
-      enumCase(in.offset, defAnnotsMods(modifierTokens))
-
-    /** EnumCase = `case' (EnumClassDef | ObjectDef) */
+    /** EnumCase = `case' (id ClassConstr [`extends' ConstrApps] | ids)
+     */
     def enumCase(start: Offset, mods: Modifiers): DefTree = {
       val mods1 = mods.withAddedMod(atPos(in.offset)(Mod.EnumCase())) | Case
       accept(CASE)
@@ -2257,16 +2225,34 @@ object Parsers {
 
       atPos(start, nameStart) {
         val id = termIdent()
-        if (in.token == LBRACKET || in.token == LPAREN)
-          classDefRest(start, mods1, id.name.toTypeName)
-        else if (in.token == COMMA) {
+        if (in.token == COMMA) {
           in.nextToken()
           val ids = commaSeparated(() => termIdent())
           PatDef(mods1, id :: ids, TypeTree(), EmptyTree)
         }
-        else
-          objectDefRest(start, mods1, id.name.asTermName)
+        else {
+          val caseDef =
+            if (in.token == LBRACKET || in.token == LPAREN || in.token == AT || isModifier) {
+              val clsName = id.name.toTypeName
+              val constr = classConstr(clsName, isCaseClass = true)
+              TypeDef(clsName, caseTemplate(constr))
+            }
+            else
+              ModuleDef(id.name.toTermName, caseTemplate(emptyConstructor))
+          caseDef.withMods(mods).setComment(in.getDocComment(start))
+        }
       }
+    }
+
+    /** [`extends' ConstrApps] */
+    def caseTemplate(constr: DefDef): Template = {
+      val parents =
+        if (in.token == EXTENDS) {
+          in.nextToken()
+          tokenSeparated(WITH, constrApp)
+        }
+        else Nil
+      Template(constr, parents, EmptyValDef, Nil)
     }
 
 /* -------- TEMPLATES ------------------------------------------- */
@@ -2285,32 +2271,34 @@ object Parsers {
      *  @return  a pair consisting of the template, and a boolean which indicates
      *           whether the template misses a body (i.e. no {...} part).
      */
-    def template(constr: DefDef): (Template, Boolean) = {
+    def template(constr: DefDef, isEnum: Boolean = false): (Template, Boolean) = {
       newLineOptWhenFollowedBy(LBRACE)
-      if (in.token == LBRACE) (templateBodyOpt(constr, Nil), false)
+      if (in.token == LBRACE) (templateBodyOpt(constr, Nil, isEnum), false)
       else {
         val parents = tokenSeparated(WITH, constrApp)
         newLineOptWhenFollowedBy(LBRACE)
+        if (isEnum && in.token != LBRACE)
+          syntaxErrorOrIncomplete(ExpectedTokenButFound(LBRACE, in.token))
         val missingBody = in.token != LBRACE
-        (templateBodyOpt(constr, parents), missingBody)
+        (templateBodyOpt(constr, parents, isEnum), missingBody)
       }
     }
 
     /** TemplateOpt = [`extends' Template | TemplateBody]
      */
-    def templateOpt(constr: DefDef): Template =
-      if (in.token == EXTENDS) { in.nextToken(); template(constr)._1 }
+    def templateOpt(constr: DefDef, isEnum: Boolean = false): Template =
+      if (in.token == EXTENDS) { in.nextToken(); template(constr, isEnum)._1 }
       else {
         newLineOptWhenFollowedBy(LBRACE)
-        if (in.token == LBRACE) template(constr)._1
+        if (in.token == LBRACE) template(constr, isEnum)._1
         else Template(constr, Nil, EmptyValDef, Nil)
       }
 
     /** TemplateBody ::= [nl] `{' TemplateStatSeq `}'
      */
-    def templateBodyOpt(constr: DefDef, parents: List[Tree]) = {
+    def templateBodyOpt(constr: DefDef, parents: List[Tree], isEnum: Boolean) = {
       val (self, stats) =
-        if (in.token == LBRACE) templateBody() else (EmptyValDef, Nil)
+        if (in.token == LBRACE) withinEnum(isEnum)(templateBody()) else (EmptyValDef, Nil)
       Template(constr, parents, self, stats)
     }
 
@@ -2378,9 +2366,10 @@ object Parsers {
      *  TemplateStat     ::= Import
      *                     | Annotations Modifiers Def
      *                     | Annotations Modifiers Dcl
-     *                     | EnumCaseStat
      *                     | Expr1
      *                     |
+     *  EnumStat         ::= TemplateStat
+     *                     | Annotations Modifiers EnumCase
      */
     def templateStatSeq(): (ValDef, List[Tree]) = checkNoEscapingPlaceholders {
       var self: ValDef = EmptyValDef

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1783,16 +1783,6 @@ object messages {
       hl"""A class marked with the ${"final"} keyword cannot be extended"""
   }
 
-  case class EnumCaseDefinitionInNonEnumOwner(owner: Symbol)(implicit ctx: Context)
-    extends Message(EnumCaseDefinitionInNonEnumOwnerID) {
-      val kind = "Syntax"
-      val msg = em"case not allowed here, since owner ${owner} is not an ${"enum"} object"
-      val explanation =
-        hl"""${"enum"} cases are only allowed within the companion ${"object"} of an ${"enum class"}.
-            |If you want to create an ${"enum"} case, make sure the corresponding ${"enum class"} exists
-            |and has the ${"enum"} keyword."""
-  }
-
   case class ExpectedTypeBoundOrEquals(found: Token)(implicit ctx: Context)
     extends Message(ExpectedTypeBoundOrEqualsID) {
     val kind = "Syntax"

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -830,7 +830,9 @@ trait Checking {
           case _: ValDef | _: TypeDef => stat.symbol.is(Case)
           case _ => false
         }
-        val cases = for (stat <- impl.body if isCase(stat)) yield untpd.Ident(stat.symbol.name)
+        val cases =
+          for (stat <- impl.body if isCase(stat))
+          yield untpd.Ident(stat.symbol.name.toTermName)
         val caseImport: Import = Import(ref(cdef.symbol), cases)
         val caseCtx = enumCtx.importContext(caseImport, caseImport.symbol)
         for (stat <- impl.body) checkCaseOrDefault(stat, caseCtx)

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -22,7 +22,7 @@ import config.Printers.typr
  *
  *  Otherwise, everything is as in Typer.
  */
-class ReTyper extends Typer {
+class ReTyper extends Typer with ReChecking {
   import tpd._
 
   private def assertTyped(tree: untpd.Tree)(implicit ctx: Context): Unit =

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1405,6 +1405,10 @@ class Typer extends Namer
     // Overwrite inline body to make sure it is not evaluated twice
     if (sym.isInlineMethod) Inliner.registerInlineInfo(sym, _ => rhs1)
 
+    if (sym.isConstructor && !sym.isPrimaryConstructor)
+      for (param <- tparams1 ::: vparamss1.flatten)
+        checkRefsLegal(param, sym.owner, (name, sym) => sym.is(TypeParam), "secondary constructor")
+
     assignType(cpy.DefDef(ddef)(name, tparams1, vparamss1, tpt1, rhs1), sym)
       //todo: make sure dependent method types do not depend on implicits or by-name params
   }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1406,7 +1406,7 @@ class Typer extends Namer
     if (sym.isInlineMethod) Inliner.registerInlineInfo(sym, _ => rhs1)
 
     assignType(cpy.DefDef(ddef)(name, tparams1, vparamss1, tpt1, rhs1), sym)
-    //todo: make sure dependent method types do not depend on implicits or by-name params
+      //todo: make sure dependent method types do not depend on implicits or by-name params
   }
 
   def typedTypeDef(tdef: untpd.TypeDef, sym: Symbol)(implicit ctx: Context): Tree = track("typedTypeDef") {
@@ -1506,6 +1506,7 @@ class Typer extends Namer
       checkVariance(impl1)
       if (!cls.is(AbstractOrTrait) && !ctx.isAfterTyper)
         checkRealizableBounds(cls, cdef.namePos)
+      if (cls.is(Case) && cls.derivesFrom(defn.EnumClass)) checkEnum(cdef, cls)
       val cdef1 = assignType(cpy.TypeDef(cdef)(name, impl1), cls)
       if (ctx.phase.isTyper && cdef1.tpe.derivesFrom(defn.DynamicClass) && !ctx.dynamicsEnabled) {
         val isRequired = parents1.exists(_.tpe.isRef(defn.DynamicClass))
@@ -1813,6 +1814,8 @@ class Typer extends Namer
 
   def typedStats(stats: List[untpd.Tree], exprOwner: Symbol)(implicit ctx: Context): List[tpd.Tree] = {
     val buf = new mutable.ListBuffer[Tree]
+    val enumContexts = new mutable.HashMap[Symbol, Context]
+      // A map from `enum` symbols to the contexts enclosing their definitions
     @tailrec def traverse(stats: List[untpd.Tree])(implicit ctx: Context): List[Tree] = stats match {
       case (imp: untpd.Import) :: rest =>
         val imp1 = typed(imp)
@@ -1827,6 +1830,12 @@ class Typer extends Namer
               case mdef1: DefDef if Inliner.hasBodyToInline(mdef1.symbol) =>
                 buf ++= inlineExpansion(mdef1)
               case mdef1 =>
+                import untpd.modsDeco
+                mdef match {
+                  case mdef: untpd.TypeDef if mdef.mods.hasMod[untpd.Mod.Enum] =>
+                    enumContexts(mdef1.symbol) = ctx
+                  case _ =>
+                }
                 buf += mdef1
             }
             traverse(rest)
@@ -1846,7 +1855,7 @@ class Typer extends Namer
       val exprOwnerOpt = if (exprOwner == ctx.owner) None else Some(exprOwner)
       ctx.withProperty(ExprOwner, exprOwnerOpt)
     }
-    traverse(stats)(localCtx)
+    checkEnumCompanions(traverse(stats)(localCtx), enumContexts)
   }
 
   /** Given an inline method `mdef`, the method rewritten so that its body

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1152,7 +1152,7 @@ class Typer extends Namer
         tree.ensureCompletions
         tree.getAttachment(untpd.OriginalSymbol) match {
           case Some(origSym) =>
-            TypeTree(tree.derivedType(origSym)).withPos(tree.pos)
+            tree.derivedTree(origSym).withPos(tree.pos)
             // btw, no need to remove the attachment. The typed
             // tree is different from the untyped one, so the
             // untyped tree is no longer accessed after all

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -986,19 +986,6 @@ class ErrorMessagesTests extends ErrorMessagesTest {
     assertEquals(parent.show, "class A")
   }
 
-  @Test def enumCaseDefinitionInNonEnumOwner =
-    checkMessagesAfter("frontend") {
-      """object Qux {
-        |  case Foo
-        |}
-      """.stripMargin
-    }.expect { (ictx, messages) =>
-      implicit val ctx: Context = ictx
-      assertMessageCount(1, messages)
-      val EnumCaseDefinitionInNonEnumOwner(owner) :: Nil = messages
-      assertEquals("object Qux", owner.show)
-    }
-
   @Test def tailrecNotApplicableNeitherPrivateNorFinal =
     checkMessagesAfter("tailrec") {
     """

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -290,16 +290,6 @@ AccessQualifier   ::=  ‘[’ (id | ‘this’) ‘]’
 
 Annotation        ::=  ‘@’ SimpleType {ParArgumentExprs}                        Apply(tpe, args)
 
-TemplateBody      ::=  [nl] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’ (self, stats)
-TemplateStat      ::=  Import
-                    |  {Annotation [nl]} {Modifier} Def
-                    |  {Annotation [nl]} {Modifier} Dcl
-                    |  EnumCaseStat
-                    |  Expr1
-                    |
-SelfType          ::=  id [‘:’ InfixType] ‘=>’                                  ValDef(_, name, tpt, _)
-                    |  ‘this’ ‘:’ InfixType ‘=>’
-
 Import            ::=  ‘import’ ImportExpr {‘,’ ImportExpr}
 ImportExpr        ::=  StableId ‘.’ (id | ‘_’ | ImportSelectors)                Import(expr, sels)
 ImportSelectors   ::=  ‘{’ {ImportSelector ‘,’} (ImportSelector | ‘_’) ‘}’
@@ -335,19 +325,14 @@ DefDef            ::=  DefSig [‘:’ Type] ‘=’ Expr                       
                     |  ‘this’ DefParamClause DefParamClauses                    DefDef(_, <init>, Nil, vparamss, EmptyTree, expr | Block)
                        (‘=’ ConstrExpr | [nl] ConstrBlock)
 
-TmplDef           ::=  ([‘case’ | `enum'] ‘class’ | trait’) ClassDef
+TmplDef           ::=  ([‘case’] ‘class’ | trait’) ClassDef
                     |  [‘case’] ‘object’ ObjectDef
                     |  `enum' EnumDef
 ClassDef          ::=  id ClassConstr TemplateOpt                               ClassDef(mods, name, tparams, templ)
 ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses         with DefDef(_, <init>, Nil, vparamss, EmptyTree, EmptyTree) as first stat
 ConstrMods        ::=  {Annotation} [AccessModifier]
 ObjectDef         ::=  id TemplateOpt                                           ModuleDef(mods, name, template)  // no constructor
-EnumDef           ::=  id ClassConstr [`extends' [ConstrApps]]                  EnumDef(mods, name, tparams, template)
-                       [nl] ‘{’ EnumCaseStat {semi EnumCaseStat} ‘}’
-EnumCaseStat      ::=  {Annotation [nl]} {Modifier} EnumCase
-EnumCase          ::=  `case' (EnumClassDef | ObjectDef | ids)
-EnumClassDef      ::=  id [ClsTpeParamClause | ClsParamClause]                  ClassDef(mods, name, tparams, templ)
-                       ClsParamClauses TemplateOpt
+EnumDef           ::=  id ClassConstr [`extends' [ConstrApps]] EnumBody         EnumDef(mods, name, tparams, template)
 TemplateOpt       ::=  [‘extends’ Template | [nl] TemplateBody]
 Template          ::=  ConstrApps [TemplateBody] | TemplateBody                 Template(constr, parents, self, stats)
 ConstrApps        ::=  ConstrApp {‘with’ ConstrApp}
@@ -356,6 +341,20 @@ ConstrExpr        ::=  SelfInvocation
                     |  ConstrBlock
 SelfInvocation    ::=  ‘this’ ArgumentExprs {ArgumentExprs}
 ConstrBlock       ::=  ‘{’ SelfInvocation {semi BlockStat} ‘}’
+
+TemplateBody      ::=  [nl] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’ (self, stats)
+TemplateStat      ::=  Import
+                    |  {Annotation [nl]} {Modifier} Def
+                    |  {Annotation [nl]} {Modifier} Dcl
+                    |  Expr1
+                    |
+SelfType          ::=  id [‘:’ InfixType] ‘=>’                                  ValDef(_, name, tpt, _)
+                    |  ‘this’ ‘:’ InfixType ‘=>’
+
+EnumBody          ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
+EnumStat          ::=  TemplateStat
+                    |  {Annotation [nl]} {Modifier} EnumCase
+EnumCase          ::=  `case' (id [ClsTpeParamClause] {ClsParamClause} | ids)
 
 TopStatSeq        ::=  TopStat {semi TopStat}
 TopStat           ::=  {Annotation [nl]} {Modifier} TmplDef

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -354,7 +354,7 @@ SelfType          ::=  id [‘:’ InfixType] ‘=>’                          
 EnumBody          ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
 EnumStat          ::=  TemplateStat
                     |  {Annotation [nl]} {Modifier} EnumCase
-EnumCase          ::=  `case' (id [ClsTpeParamClause] {ClsParamClause} | ids)
+EnumCase          ::=  `case' (id ClassConstr [`extends' ConstrApps]] | ids)
 
 TopStatSeq        ::=  TopStat {semi TopStat}
 TopStat           ::=  {Annotation [nl]} {Modifier} TmplDef

--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -10,28 +10,28 @@ how an `Option` type can be represented as an ADT:
 
 ```scala
 enum Option[+T] {
-  case Some[+T](x: T)
+  case Some(x: T)
   case None
 }
 ```
 
-This example introduces `Option` enum class with a covariant type
-parameter `T`, together with two cases, `Some` and `None`. `Some` is
-parameterized with a type parameter `T` and a value parameter `x`. It
-is a shorthand for writing a case class that extends `Option`. Since
-`None` is not parameterized it is treated as a normal enum value.
+This example introduces an `Option` enum with a covariant type
+parameter `T` consisting of two cases, `Some` and `None`. `Some` is
+parameterized with a value parameter `x`. It is a shorthand for writing a
+case class that extends `Option`. Since `None` is not parameterized, it
+is treated as a normal enum value.
 
 The `extends` clauses that were omitted in the example above can also
 be given explicitly:
 
 ```scala
 enum Option[+T] {
-  case Some[+T](x: T) extends Option[T]
-  case None           extends Option[Nothing]
+  case Some(x: T) extends Option[T]
+  case None       extends Option[Nothing]
 }
 ```
 
-Note that the parent type of `None` is inferred as
+Note that the parent type of the `None` value is inferred as
 `Option[Nothing]`. Generally, all covariant type parameters of the enum
 class are minimized in a compiler-generated extends clause whereas all
 contravariant type parameters are maximized. If `Option` was non-variant,
@@ -59,24 +59,22 @@ scala> new Option.Some(2)
 val res3: t2.Option.Some[Int] = Some(2)
 ```
 
-As all other enums, ADTs can have methods on both the enum class and
-its companion object. For instance, here is `Option` again, with an
-`isDefined` method and an `Option(...)` constructor.
+As all other enums, ADTs can define methods. For instance, here is `Option` again, with an
+`isDefined` method and an `Option(...)` constructor in its companion object.
 
 ```scala
-enum class Option[+T] {
-   def isDefined: Boolean
+enum Option[+T] {
+  case Some(x: T) extends Option[T]
+  case None
+
+  def isDefined: Boolean = this match {
+    case None => false
+    case some => true
+  }
 }
 object Option {
   def apply[T >: Null](x: T): Option[T] =
     if (x == null) None else Some(x)
-
-  case Some[+T](x: T) {
-     def isDefined = true
-  }
-  case None {
-     def isDefined = false
-  }
 }
 ```
 
@@ -98,23 +96,20 @@ enum Color(val rgb: Int) {
 
 ### Syntax of Enums
 
-Changes to the syntax fall in two categories: enum classes and cases inside enums.
+Changes to the syntax fall in two categories: enum definitions and cases inside enums.
 The changes are specified below as deltas with respect to the Scala syntax given [here](http://dotty.epfl.ch/docs/internals/syntax.html)
 
- 1. Enum definitions and enum classes are defined as follows:
+ 1. Enum definitions are defined as follows:
 
-        TmplDef ::=  `enum' `class’ ClassDef
-                 |   `enum' EnumDef
-        EnumDef ::=  id ClassConstr [`extends' [ConstrApps]]
-                     [nl] `{’ EnumCaseStat {semi EnumCaseStat} `}’
+        TmplDef   ::=  `enum' EnumDef
+        EnumDef   ::=  id ClassConstr [`extends' [ConstrApps]] EnumBody
+        EnumBody  ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
+        EnumStat  ::=  TemplateStat
+                    |  {Annotation [nl]} {Modifier} EnumCase
 
  2. Cases of enums are defined as follows:
 
-        EnumCaseStat  ::=  {Annotation [nl]} {Modifier} EnumCase
-        EnumCase      ::=  `case' (EnumClassDef | ObjectDef | ids)
-        EnumClassDef  ::=  id [ClsTpeParamClause | ClsParamClause]
-                           ClsParamClauses TemplateOpt
-        TemplateStat  ::=  ... | EnumCaseStat
+        EnumCase  ::=  `case' (id [ClsTpeParamClause] {ClsParamClause} | ids)
 
 ### Reference
 

--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -109,7 +109,7 @@ The changes are specified below as deltas with respect to the Scala syntax given
 
  2. Cases of enums are defined as follows:
 
-        EnumCase  ::=  `case' (id [ClsTpeParamClause] {ClsParamClause} | ids)
+        EnumCase  ::=  `case' (id ClassConstr [`extends' ConstrApps]] | ids)
 
 ### Reference
 

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -93,8 +93,7 @@ map into case classes or vals.
 
    This result is then further rewritten with rule (8).
 
-6. If `E` is an enum with type parameters `Ts`, a class case with neither type parameters nor
-   an extends clause
+6. If `E` is an enum with type parameters `Ts`, a class case with neither type parameters nor an extends clause
 
         case C <value-params>
 
@@ -102,8 +101,7 @@ map into case classes or vals.
 
         case C[Ts] <value-params> extends E[Ts]
 
-   This result is then further rewritten with rule (8). For class cases that have type parameters
-   themselves, an extends clause needs to be given explicitly.
+   This result is then further rewritten with rule (8). For class cases that have type parameters themselves, an extends clause needs to be given explicitly.
 
 7. A value case
 
@@ -159,7 +157,7 @@ the following additional members.
    - A method `enumValues` which returns an `Iterable[E]` of all singleton case
      values in `E`, in the order of their definitions.
 
-Companion objects that contain at least one simple case define in addition:
+Companion objects of enumerations that contain at least one simple case define in addition:
 
    - A private method `$new` which defines a new simple case value with given
      ordinal number and name. This method can be thought as being defined as
@@ -182,5 +180,5 @@ this object or its members via `this` or a simple identifier is also illegal. Th
 ### Other Rules
 
 A normal case class which is not produced from an enum case is not allowed to extend
-`scala.Enum`. This ensures that the only cases of an anum are the ones that are
+`scala.Enum`. This ensures that the only cases of an enum are the ones that are
 explictly declared in it.

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -173,14 +173,11 @@ Companion objects that contain at least one simple case define in addition:
 
 ### Scopes for Enum Cases
 
-A case in an `enum` is treated similarly to a secondary constructor. It cannot access
-with simple identifiers value parameters or instance members of the enclosing `enum`.
+A case in an `enum` is treated similarly to a secondary constructor. It can access neither the enclosing `enum` using `this`, nor its value parameters or instance members using simple
+identifiers.
 
-Even though translated enum cases are located in the enum's companion object, they
-cannot access with simple identifiers any members defined locally in the enclosing
-object either. The compiler is free to typecheck enum cases in the scope of the
-enclosing companion object but it must then flag any illegal accesses to the object's
-members.
+Even though translated enum cases are located in the enum's companion object, referencing
+this object or its members via `this` or a simple identifier is also illegal. The compiler typechecks enum cases in the scope of the enclosing companion object but flags any such illegal accesses as errors.
 
 ### Other Rules
 

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -38,8 +38,8 @@ map into case classes or vals.
     an associated companion object that contains the defined cases, expanded according
     to rules (2 - 8).
 
-       sealed abstract class E ... extends <parents> with scala.Enum { <defs> }
-       object E { <cases> }
+        sealed abstract class E ... extends <parents> with scala.Enum { <defs> }
+        object E { <cases> }
 
 2. A simple case consisting of a comma-separated list of enum names
 
@@ -79,13 +79,13 @@ map into case classes or vals.
    rewritten with rule (7). Simple cases of enums with non-variant type
    parameters are not permitted.
 
-5.  A class case without an extends clause
+5. A class case without an extends clause
 
-       case C <type-params> <value-params>
+        case C <type-params> <value-params>
 
    of an enum `E` that does not take type parameters expands to
 
-       case C <type-params> <value-params> extends E
+        case C <type-params> <value-params> extends E
 
    This result is then further rewritten with rule (8).
 

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -136,7 +136,6 @@ map into case classes or vals.
    where `n` is the ordinal number of the case in the companion object,
    starting from 0.
 
-
 ### Equality
 
 An `enum` type contains a `scala.Eq` instance that restricts values of the `enum` type to
@@ -171,3 +170,20 @@ Companion objects that contain at least one simple case define in addition:
            def toString = name
            $values.register(this)   // register enum value so that `valueOf` and `values` can return it.
          }
+
+### Scopes for Enum Cases
+
+A case in an `enum` is treated similarly to a secondary constructor. It cannot access
+with simple identifiers value parameters or instance members of the enclosing `enum`.
+
+Even though translated enum cases are located in the enum's companion object, they
+cannot access with simple identifiers any members defined locally in the enclosing
+object either. The compiler is free to typecheck enum cases in the scope of the
+enclosing companion object but it must then flag any illegal accesses to the object's
+members.
+
+### Other Rules
+
+A normal case class which is not produced from an enum case is not allowed to extend
+`scala.Enum`. This ensures that the only cases of an anum are the ones that are
+explictly declared in it.

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -36,9 +36,13 @@ map into case classes or vals.
 
     expands to a `sealed` `abstract` class that extends the `scala.Enum` trait and
     an associated companion object that contains the defined cases, expanded according
-    to rules (2 - 8).
+    to rules (2 - 8). The enum trait starts with a compiler-generated import that imports
+    the names `<caseIds>` of all cases so that they can be used without prefix in the trait.
 
-        sealed abstract class E ... extends <parents> with scala.Enum { <defs> }
+        sealed abstract class E ... extends <parents> with scala.Enum {
+          import E.{ <caseIds> }
+          <defs>
+        }
         object E { <cases> }
 
 2. A simple case consisting of a comma-separated list of enum names

--- a/docs/docs/reference/enums/enums.md
+++ b/docs/docs/reference/enums/enums.md
@@ -13,22 +13,11 @@ enum Color {
 
 This defines a new `sealed` class, `Color`, with three values, `Color.Red`,
 `Color.Green`, `Color.Blue`.  The color values are members of `Color`s
-companion object. The `Color` definition above is equivalent to the
-following more explicit definition of an _enum class_ and a companion
-object:
-
-```scala
-enum class Color
-object Color {
-  case Red
-  case Green
-  case Blue
-}
-```
+companion object.
 
 ### Parameterized enums
 
-Enum classes can be parameterized.
+Enums can be parameterized.
 
 ```scala
 enum Color(val rgb: Int) {
@@ -53,7 +42,7 @@ scala> red.enumTag
 val res0: Int = 0
 ```
 
-The companion object of an enum class also defines three utility methods.
+The companion object of an enum also defines three utility methods.
 The `enumValue` and `enumValueNamed` methods obtain an enum value
 by its tag or its name. The `enumValues` method returns all enum values
 defined in an enumeration in an `Iterable`.
@@ -69,20 +58,14 @@ val res3: collection.Iterable[Color] = MapLike(Red, Green, Blue)
 
 ### User-defined members of enums
 
-It is possible to add your own definitions to an enum class or its
-companion object.  To make clear what goes where you need to use the
-longer syntax which defines an enum class alongside its companion
-object explicitly. In the following example, we define some methods in
-class `Planet` and a `main` method in its companion object.
+It is possible to add your own definitions to an enum. Example:
 
 ```scala
-enum class Planet(mass: Double, radius: Double) {
+enum Planet(mass: Double, radius: Double) {
   private final val G = 6.67300E-11
   def surfaceGravity = G * mass / (radius * radius)
   def surfaceWeight(otherMass: Double) =  otherMass * surfaceGravity
-}
 
-object Planet {
   case MERCURY extends Planet(3.303e+23, 2.4397e6)
   case VENUS   extends Planet(4.869e+24, 6.0518e6)
   case EARTH   extends Planet(5.976e+24, 6.37814e6)
@@ -91,7 +74,13 @@ object Planet {
   case SATURN  extends Planet(5.688e+26, 6.0268e7)
   case URANUS  extends Planet(8.686e+25, 2.5559e7)
   case NEPTUNE extends Planet(1.024e+26, 2.4746e7)
+}
+```
 
+It is also possible to define an explicit companion object for an enum:
+
+```scala
+object Planet {
   def main(args: Array[String]) = {
     val earthWeight = args(0).toDouble
     val mass = earthWeight/EARTH.surfaceGravity
@@ -103,7 +92,7 @@ object Planet {
 
 ### Implementation
 
-Enum classes are represented as `sealed` classes that extend the `scala.Enum` trait.
+Enums are represented as `sealed` classes that extend the `scala.Enum` trait.
 This trait defines a single method, `enumTag`:
 
 ```scala

--- a/docs/docs/reference/enums/enums.md
+++ b/docs/docs/reference/enums/enums.md
@@ -129,4 +129,5 @@ val Red: Color = $new(0, "Red")
 
 ### Reference
 
-For more info, see [Issue #1970](https://github.com/lampepfl/dotty/issues/1970).
+For more info, see [Issue #1970](https://github.com/lampepfl/dotty/issues/1970) and
+[PR #4003](https://github.com/lampepfl/dotty/pull/4003).

--- a/tests/neg/constrParams.scala
+++ b/tests/neg/constrParams.scala
@@ -1,0 +1,8 @@
+
+
+class C {
+  type INT = Int
+  class I
+  def this(x: INT) = this() // error: illegal access
+  def this(x: I) = this() // error: illegal access
+}

--- a/tests/neg/enum-List3.scala
+++ b/tests/neg/enum-List3.scala
@@ -1,5 +1,5 @@
 enum List[+T] {
-  case Cons[T](x: T, xs: List[T])
+  case Cons[T](x: T, xs: List[T]) // error: missing extends
   case Nil extends List[Nothing]
 }
 object Test {

--- a/tests/neg/enums.scala
+++ b/tests/neg/enums.scala
@@ -1,12 +1,8 @@
 package enums
 
 enum List[+T] {
-  case Cons[T](x: T, xs: List[T]) // ok
-  case Snoc[U](xs: List[U], x: U) // error: different type parameters
-}
-
-enum class X {
-  case Y // error: case not allowed here
+  case Cons[T](x: T, xs: List[T]) // error: missing extends
+  case Snoc[U](xs: List[U], x: U) // error: missing extends
 }
 
 enum E1[T] {
@@ -22,7 +18,7 @@ enum E3[-T <: Ordered[T]] {
 }
 
 enum Option[+T] {
-  case Some[T](x: T)
+  case Some(x: T)
   case None
 }
 

--- a/tests/neg/enums.scala
+++ b/tests/neg/enums.scala
@@ -17,6 +17,13 @@ enum E3[-T <: Ordered[T]] {
   case C // error: cannot determine type argument
 }
 
+enum E4 {
+  case C
+}
+
+case class C4() extends E4 // error: cannot extend enum
+case object O4 extends E4 // error: cannot extend enum
+
 enum Option[+T] {
   case Some(x: T)
   case None

--- a/tests/neg/enumsAccess.scala
+++ b/tests/neg/enumsAccess.scala
@@ -1,0 +1,86 @@
+package enums
+
+object test1 {
+
+  enum E4 {
+    case C1(x: INT) // error: illegal reference
+    case C2(x: Int = defaultX) // error: illegal reference
+    case C3[T <: INT] // error: illegal reference
+  }
+
+  object E4 {
+    type INT = Integer
+    val defaultX = 2
+  }
+}
+
+object test2 {
+  import E5._
+  object E5 {
+    type INT = Integer
+    val defaultX = 2
+  }
+
+  enum E5 {
+    case C1(x: INT) // ok
+    case C2(x: Int = defaultX) // ok
+    case C3[T <: INT] // ok
+  }
+}
+
+object test3 {
+  object E5 {
+    type INT = Integer
+    val defaultX = 2
+  }
+
+  import E5._
+
+  enum E5 {
+    case C1(x: INT) // ok
+    case C2(x: Int = defaultX)// ok
+    case C3[T <: INT] // ok
+  }
+}
+
+object test4 {
+
+  enum E5 {
+    case C1(x: INT) // error: illegal reference
+    case C2(x: Int = defaultX) // error: illegal reference
+    case C3[T <: INT] // error: illegal reference
+  }
+
+  import E5._
+
+  object E5 {
+    type INT = Integer
+    val defaultX = 2
+  }
+}
+
+object test5 {
+  enum E5[T](x: T) {
+    case C3() extends E5[INT](defaultX)// error: illegal reference  // error: illegal reference
+    case C4 extends E5[INT](defaultX) // error: illegal reference  // error: illegal reference
+    case C5 extends E5[E5[_]](E5.this) // error: type mismatch
+  }
+
+  object E5 {
+    type INT = Integer
+    val defaultX = 2
+  }
+}
+
+object test6 {
+  import E5._
+  enum E5[T](x: T) {
+    case C3() extends E5[INT](defaultX) // ok
+    case C4 extends E5[INT](defaultX) // ok
+  }
+
+  object E5 {
+    type INT = Integer
+    val defaultX = 2
+  }
+}

--- a/tests/neg/enumsAccess.scala
+++ b/tests/neg/enumsAccess.scala
@@ -84,3 +84,13 @@ object test6 {
     val defaultX = 2
   }
 }
+
+object test7 {
+
+  trait Arg
+
+  enum E(x: Arg) {
+    case C extends E(this) // error: illegal reference to `this`
+  }
+  object E extends Arg
+}

--- a/tests/patmat/enum-Tree.scala
+++ b/tests/patmat/enum-Tree.scala
@@ -5,7 +5,7 @@ enum Tree[T] {
   case Succ(n: Tree[Int]) extends Tree[Int]
   case Pred(n: Tree[Int]) extends Tree[Int]
   case IsZero(n: Tree[Int]) extends Tree[Boolean]
-  case If[T](cond: Tree[Boolean], thenp: Tree[T], elsep: Tree[T])
+  case If(cond: Tree[Boolean], thenp: Tree[T], elsep: Tree[T])
 }
 
 object Test {

--- a/tests/patmat/enum-Tree.scala
+++ b/tests/patmat/enum-Tree.scala
@@ -5,7 +5,7 @@ enum Tree[T] {
   case Succ(n: Tree[Int]) extends Tree[Int]
   case Pred(n: Tree[Int]) extends Tree[Int]
   case IsZero(n: Tree[Int]) extends Tree[Boolean]
-  case If(cond: Tree[Boolean], thenp: Tree[T], elsep: Tree[T])
+  case If(cond: Tree[Boolean], thenp: Tree[T], elsep: Tree[T]) extends Tree[T]
 }
 
 object Test {

--- a/tests/patmat/enum-Tree.scala
+++ b/tests/patmat/enum-Tree.scala
@@ -5,7 +5,7 @@ enum Tree[T] {
   case Succ(n: Tree[Int]) extends Tree[Int]
   case Pred(n: Tree[Int]) extends Tree[Int]
   case IsZero(n: Tree[Int]) extends Tree[Boolean]
-  case If(cond: Tree[Boolean], thenp: Tree[T], elsep: Tree[T]) extends Tree[T]
+  case If[X](cond: Tree[Boolean], thenp: Tree[X], elsep: Tree[X]) extends Tree[X]
 }
 
 object Test {

--- a/tests/patmat/planets.scala
+++ b/tests/patmat/planets.scala
@@ -1,9 +1,8 @@
-enum class Planet(mass: Double, radius: Double) {
+enum Planet(mass: Double, radius: Double) {
   private final val G = 6.67300E-11
   def surfaceGravity = G * mass / (radius * radius)
   def surfaceWeight(otherMass: Double) =  otherMass * surfaceGravity
-}
-object Planet {
+
   case MERCURY extends Planet(3.303e+23, 2.4397e6)
   case VENUS   extends Planet(4.869e+24, 6.0518e6)
   case EARTH   extends Planet(5.976e+24, 6.37814e6)

--- a/tests/pos/enum-List-control.scala
+++ b/tests/pos/enum-List-control.scala
@@ -1,10 +1,16 @@
 abstract sealed class List[T] extends Enum
 object List {
-  final case class Cons[T](x: T, xs: List[T]) extends List[T] {
+  final class Cons[T](x: T, xs: List[T]) extends List[T] {
     def enumTag = 0
   }
-  final case class Nil[T]() extends List[T] {
+  object Cons {
+    def apply[T](x: T, xs: List[T]): List[T] = new Cons(x, xs)
+  }
+  final class Nil[T]() extends List[T] {
     def enumTag = 1
+  }
+  object Nil {
+    def apply[T](): List[T] = new Nil()
   }
 }
 object Test {

--- a/tests/pos/i3460.scala
+++ b/tests/pos/i3460.scala
@@ -1,7 +1,7 @@
-enum class Ducks
+enum Ducks {
+  case Dewey
+}
 
 object Ducks {
-  case Dewey
-
   def wooohoo: Int = 1
 }

--- a/tests/pos/objXfun.scala
+++ b/tests/pos/objXfun.scala
@@ -2,7 +2,6 @@ object Foo extends (Int => Int) { // OK
   def apply(x: Int) = x
 }
 
-enum class E(x: Int)  // used to generate Int => new E(x) as the parent of object E --> crash
-object E {
+enum E(x: Int) { // used to generate Int => new E(x) as the parent of object E --> crash
   case C(x: Int) extends E(x)
 }

--- a/tests/pos/patmat.scala
+++ b/tests/pos/patmat.scala
@@ -1,5 +1,4 @@
 object Test {
-
   val xs = List(1, 2, 3)
 
   xs match {
@@ -36,7 +35,7 @@ object Test {
   }
 
   enum Option[+T] {
-    case Some[+T](value: T)
+    case Some(value: T)
     case None
   }
   import Option._

--- a/tests/pos/reference/adts.scala
+++ b/tests/pos/reference/adts.scala
@@ -2,7 +2,7 @@ package adts
 object t1 {
 
 enum Option[+T] {
-  case Some[T](x: T)
+  case Some(x: T)
   case None
 }
 
@@ -11,8 +11,8 @@ enum Option[+T] {
 object t2 {
 
 enum Option[+T] {
-  case Some[T](x: T) extends Option[T]
-  case None          extends Option[Nothing]
+  case Some(x: T) extends Option[T]
+  case None       extends Option[Nothing]
 }
 
 
@@ -27,19 +27,18 @@ enum Color(val rgb: Int) {
 
 object t3 {
 
-enum class Option[+T] {
-   def isDefined: Boolean
+enum Option[+T] {
+  case Some(x: T) extends Option[T]
+  case None
+
+  def isDefined: Boolean = this match {
+    case None => false
+    case some => true
+  }
 }
 object Option {
   def apply[T >: Null](x: T): Option[T] =
     if (x == null) None else Some(x)
-
-  case Some[+T](x: T) {
-     def isDefined = true
-  }
-  case None {
-     def isDefined = false
-  }
 }
 
 }

--- a/tests/pos/reference/enums.scala
+++ b/tests/pos/reference/enums.scala
@@ -10,43 +10,29 @@ enum Color {
 
 object t2 {
 
-enum class Color
-object Color {
+enum Color {
   case Red
   case Green
   case Blue
 }
-
 }
 
 object t3 {
-
-enum class Color(val rgb: Int)
-object Color {
-  case Red   extends Color(0xFF0000)
-  case Green extends Color(0x00FF00)
-  case Blue  extends Color(0x0000FF)
-}
-
-}
-
-object t4 {
 
 enum Color(val rgb: Int) {
   case Red   extends Color(0xFF0000)
   case Green extends Color(0x00FF00)
   case Blue  extends Color(0x0000FF)
 }
+
 }
 
 
-enum class Planet(mass: Double, radius: Double) {
+enum Planet(mass: Double, radius: Double) {
   private final val G = 6.67300E-11
   def surfaceGravity = G * mass / (radius * radius)
   def surfaceWeight(otherMass: Double) =  otherMass * surfaceGravity
-}
 
-object Planet {
   case MERCURY extends Planet(3.303e+23, 2.4397e6)
   case VENUS   extends Planet(4.869e+24, 6.0518e6)
   case EARTH   extends Planet(5.976e+24, 6.37814e6)
@@ -55,7 +41,9 @@ object Planet {
   case SATURN  extends Planet(5.688e+26, 6.0268e7)
   case URANUS  extends Planet(8.686e+25, 2.5559e7)
   case NEPTUNE extends Planet(1.024e+26, 2.4746e7)
+}
 
+object Planet {
   def main(args: Array[String]) = {
     val earthWeight = args(0).toDouble
     val mass = earthWeight/EARTH.surfaceGravity

--- a/tests/run/enum-Color.scala
+++ b/tests/run/enum-Color.scala
@@ -1,5 +1,6 @@
 enum Color {
   case Red, Green, Blue
+  class Color  // Just to throw a spanner in the works
 }
 
 object Test {

--- a/tests/run/enum-List1.scala
+++ b/tests/run/enum-List1.scala
@@ -1,7 +1,6 @@
-enum class List[T]
-object List {
-  case Cons[T](x: T, xs: List[T])
-  case Nil[T]()
+enum List[T] {
+  case Cons(x: T, xs: List[T])
+  case Nil()
 }
 object Test {
   import List._

--- a/tests/run/enum-List2.scala
+++ b/tests/run/enum-List2.scala
@@ -1,7 +1,6 @@
-enum class List[+T]
-object List {
-  case Cons[+T](x: T, xs: List[T])
-  case Nil extends List[Nothing]
+enum List[+T] {
+  case Cons(x: T, xs: List[T])
+  case Nil
 }
 object Test {
   import List._

--- a/tests/run/enum-List2a.scala
+++ b/tests/run/enum-List2a.scala
@@ -1,6 +1,5 @@
-enum class List[+T]
-object List {
-  case Cons[+T](x: T, xs: List[T])
+enum List[+T] {
+  case Cons(x: T, xs: List[T])
   case Nil
 }
 object Test {

--- a/tests/run/enum-List3.check
+++ b/tests/run/enum-List3.check
@@ -1,1 +1,0 @@
-Cons(1,Cons(2,Cons(3,Nil)))

--- a/tests/run/enum-List3.scala
+++ b/tests/run/enum-List3.scala
@@ -1,6 +1,6 @@
 enum List[+T] {
   case Cons[T](x: T, xs: List[T])
-  case Nil
+  case Nil extends List[Nothing]
 }
 object Test {
   import List._

--- a/tests/run/enum-Option.scala
+++ b/tests/run/enum-Option.scala
@@ -1,4 +1,4 @@
-enum Option[+T >: Null] extends Serializable {
+enum Option[+T] extends Serializable {
   case Some(x: T)
   case None
 
@@ -12,6 +12,7 @@ object Option {
 }
 
 object Test {
+  import Option._
   def main(args: Array[String]) = {
     assert(Some(None).isDefined)
     Option("22") match { case Option.Some(x) => assert(x == "22") }

--- a/tests/run/enum-Option.scala
+++ b/tests/run/enum-Option.scala
@@ -1,15 +1,14 @@
-enum class Option[+T >: Null] extends Serializable {
-   def isDefined: Boolean
+enum Option[+T >: Null] extends Serializable {
+  case Some(x: T)
+  case None
+
+  def isDefined: Boolean = this match {
+    case None => false
+    case some => true
+  }
 }
 object Option {
   def apply[T >: Null](x: T): Option[T] = if (x == null) None else Some(x)
-
-  case Some[+T >: Null](x: T) {
-     def isDefined = true
-  }
-  case None {
-     def isDefined = false
-  }
 }
 
 object Test {

--- a/tests/run/enum-Option1.scala
+++ b/tests/run/enum-Option1.scala
@@ -1,0 +1,21 @@
+enum Option1[+T] extends Serializable {
+  case Some1(x: T)
+  case None1
+
+  def isDefined: Boolean = this match {
+    case None1 => false
+    case some => true
+  }
+}
+object Option1 {
+  def apply[T >: Null](x: T): Option1[T] = if (x == null) None1 else Some1(x)
+}
+
+object Test {
+  import Option1._
+  def main(args: Array[String]) = {
+    assert(Some1(None1).isDefined)
+    Option1("22") match { case Option1.Some1(x) => assert(x == "22") }
+    assert(Some1(None1) != None1)
+  }
+}

--- a/tests/run/enum-Tree.scala
+++ b/tests/run/enum-Tree.scala
@@ -5,7 +5,7 @@ enum Tree[T] {
   case Succ(n: Tree[Int]) extends Tree[Int]
   case Pred(n: Tree[Int]) extends Tree[Int]
   case IsZero(n: Tree[Int]) extends Tree[Boolean]
-  case If[T](cond: Tree[Boolean], thenp: Tree[T], elsep: Tree[T])
+  case If(cond: Tree[Boolean], thenp: Tree[T], elsep: Tree[T])
 }
 
 object Test {

--- a/tests/run/enum-approx.scala
+++ b/tests/run/enum-approx.scala
@@ -1,14 +1,14 @@
-enum class Fun[-T, +U >: Null] {
-  def f: T => U = null
-}
-object Fun {
-  case Identity[T, U >: Null](override val f: T => U) extends Fun[T, U]
-  case ConstNull {
-    override def f = x => null
+enum Fun[-T, +U >: Null] {
+  def f: T => U = this match {
+    case Identity(g) => g
+    case ConstNull => (_ => null)
+    case ConstNullClass() => (_ => null)
+    case ConstNullSimple => null
   }
-  case ConstNullClass() {
-    override def f = x => null
-  }
+
+  case Identity[T, U >: Null](g: T => U) extends Fun[T, U]
+  case ConstNull
+  case ConstNullClass()
   case ConstNullSimple
 }
 

--- a/tests/run/enums.scala
+++ b/tests/run/enums.scala
@@ -100,6 +100,14 @@ object Test5 {
   }
 }
 
+object Test6 {
+  enum Color(val x: Int) {
+    case Green  extends Color(3)
+    case Red    extends Color(2)
+    case Violet extends Color(Green.x + Red.x)
+  }
+}
+
 object SerializationTest {
   object Types extends Enumeration { val X, Y = Value }
   class A extends java.io.Serializable { val types = Types.values }

--- a/tests/run/generic/Enum.scala
+++ b/tests/run/generic/Enum.scala
@@ -1,0 +1,25 @@
+package generic
+
+trait Enum {
+  def enumTag: Int
+}
+
+object runtime {
+  class EnumValues[E <: Enum] {
+    private[this] var myMap: Map[Int, E] = Map()
+    private[this] var fromNameCache: Map[String, E] = null
+
+    def register(v: E) = {
+      require(!myMap.contains(v.enumTag))
+      myMap = myMap.updated(v.enumTag, v)
+      fromNameCache = null
+    }
+
+    def fromInt: Map[Int, E] = myMap
+    def fromName: Map[String, E] = {
+      if (fromNameCache == null) fromNameCache = myMap.values.map(v => v.toString -> v).toMap
+      fromNameCache
+    }
+    def values: Iterable[E] = myMap.values
+  }
+}

--- a/tests/run/planets.scala
+++ b/tests/run/planets.scala
@@ -1,9 +1,8 @@
-enum class Planet(mass: Double, radius: Double) {
+enum Planet(mass: Double, radius: Double) {
   private final val G = 6.67300E-11
   def surfaceGravity = G * mass / (radius * radius)
   def surfaceWeight(otherMass: Double) =  otherMass * surfaceGravity
-}
-object Planet {
+
   case MERCURY extends Planet(3.303e+23, 2.4397e6)
   case VENUS   extends Planet(4.869e+24, 6.0518e6)
   case EARTH   extends Planet(5.976e+24, 6.37814e6)


### PR DESCRIPTION
I had a lingering unease that the rules for enums were too complex, and the syntax too cumbersome. I now think I have found a way to simplify things considerably. The key was to take away one capability: that cases can have bodies which can define members. Arguably, if we choose an ADT decomposition of a problem it's good style to write all methods using pattern matching instead of overriding individual cases. So this removes an unnecessary choice. What's more, once we have eliminated case bodies we also have eliminated scope confusion. All that remains are the case parameters and extends clause. Extends clauses of cases can be handled like super-calls in constructors: I.e. the enclosing enum class is not visible for them.

This means we can treat enums unequivocally as classes. They can have methods and other statements just like other classes can. Cases in enums are seen as a form of constructors. We do not need a distinction between enum class and enum object anymore. Enums can have companion objects just like normal classes can, of course.

This also means that type parameters of enums scope naturally over cases, just like they scope
over secondary constructors. We do not need to repeat them in cases anymore, which is a huge relief.

~~This first commit changes the syntax, docs and tests. It still needs to be implemented.
So tests should fail right now.~~