### PR TITLE
Drop navigation arrows from homepage

### DIFF
--- a/docs/_includes/getting-started.html
+++ b/docs/_includes/getting-started.html
@@ -25,11 +25,4 @@
 
         <p>For documentation see the <a href="https://github.com/lampepfl/dotty-example-project">Dotty Example Project</a>.</p>
     </div>
-    <div class="centered-subtitle">
-        <a href="#so-features">
-            <i id="scroll-down-arrow" class="animated infinite pulse material-icons">
-                expand_more
-            </i>
-        </a>
-    </div>
 </div>

--- a/docs/_includes/logo-page.html
+++ b/docs/_includes/logo-page.html
@@ -75,11 +75,6 @@
         <div class="centered-subtitle">
             <h1 id="dotty">Dotty</h1>
             <p>A next generation compiler for Scala</p>
-            <a href="#getting-started">
-                <i id="scroll-down-arrow" class="animated infinite pulse material-icons">
-                    expand_more
-                </i>
-            </a>
         </div>
     </div>
 </div>

--- a/docs/css/default.css
+++ b/docs/css/default.css
@@ -182,10 +182,6 @@ div.centered-subtitle > a {
     color: #fff;
 }
 
-div.centered-subtitle > a > i#scroll-down-arrow {
-    font-size: 3em;
-}
-
 div.centered-subtitle > p {
     font-size: 3vh;
 }


### PR DESCRIPTION
Fix #3952 by simplifying the layout, in particular by dropping navigation arrows
as suggested in
https://github.com/lampepfl/dotty/issues/3952#issuecomment-361996836.