### PR TITLE
Fix #3200: bind var for singleton pattern get scrutinee type

### DIFF
--- a/tests/neg/i3200.scala
+++ b/tests/neg/i3200.scala
@@ -1,0 +1,6 @@
+object Test {
+  case object Bob { override def equals(other: Any) = true }
+  def main(args: Array[String]): Unit = {
+    val m : Bob.type = (5: Any) match { case x @ Bob => x }  // error
+  }
+}

--- a/tests/neg/i3200b.scala
+++ b/tests/neg/i3200b.scala
@@ -1,0 +1,5 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val a : Nil.type = (Vector(): Any) match { case n @ Nil => n } // error
+  }
+}


### PR DESCRIPTION
Fix #3200: bind var for singleton pattern get scrutinee type

Related issues:

https://issues.scala-lang.org/browse/SI-1503
https://github.com/lampepfl/dotty/issues/1463