### PR TITLE
Fix #4023: Ignore healed implicit tag at level 0

### DIFF
--- a/compiler/src/dotty/tools/dotc/interpreter/Interpreter.scala
+++ b/compiler/src/dotty/tools/dotc/interpreter/Interpreter.scala
@@ -69,7 +69,7 @@ class Interpreter(implicit ctx: Context) {
 
     tree match {
       case Quoted(quotedTree) =>
-        if (tree.isTerm) new scala.quoted.Exprs.TreeExpr(quotedTree)
+        if (quotedTree.isTerm) new scala.quoted.Exprs.TreeExpr(quotedTree)
         else new scala.quoted.Types.TreeType(quotedTree)
 
       case Literal(Constant(c)) => c.asInstanceOf[Object]

--- a/compiler/src/dotty/tools/dotc/interpreter/Interpreter.scala
+++ b/compiler/src/dotty/tools/dotc/interpreter/Interpreter.scala
@@ -63,11 +63,7 @@ class Interpreter(implicit ctx: Context) {
    *  If some error is encountered while interpreting a ctx.error is emitted and a StopInterpretation is thrown.
    */
   private def interpretTreeImpl(tree: Tree, env: Env): Object = {
-    ctx.debuglog(
-      s"""Interpreting:
-        |${tree.show}
-        |$env
-      """.stripMargin)
+    // println(s"Interpreting:\n${tree.show}\n$env\n")
 
     implicit val pos: Position = tree.pos
 
@@ -113,6 +109,9 @@ class Interpreter(implicit ctx: Context) {
       case Inlined(_, bindings, expansion) =>
         val env2 = bindings.foldLeft(env)((acc, x) => interpretStat(x, acc))
         interpretTreeImpl(expansion, env2)
+
+      case TypeApply(fn, _) =>
+        interpretTreeImpl(fn, env)
 
       case Typed(expr, _) =>
         interpretTreeImpl(expr, env)

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -77,6 +77,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
    */
   private class Reifier(inQuote: Boolean, val outer: Reifier, val level: Int, levels: LevelInfo) extends ImplicitsTransformer {
     import levels._
+    assert(level >= 0)
 
     /** A nested reifier for a quote (if `isQuote = true`) or a splice (if not) */
     def nested(isQuote: Boolean): Reifier =
@@ -169,7 +170,8 @@ class ReifyQuotes extends MacroTransformWithImplicits {
                     | The access would be accepted with the right type tag, but
                     | ${ctx.typer.missingArgMsg(tag, reqType, "")}""")
           case _ =>
-            importedTags(tp) = nested(isQuote = false).transform(tag)
+            if (level > 0) // TODO do we need to find the tag for level 0?
+              importedTags(tp) = nested(isQuote = false).transform(tag)
             None
         }
       case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -16,10 +16,7 @@ object Splicer {
    */
   def splice(tree: Tree)(implicit ctx: Context): Tree = tree match {
     case Quoted(quotedTree) => quotedTree
-    case tree: RefTree => reflectiveSplice(tree)
-    case tree: Apply => reflectiveSplice(tree)
-    case tree: Inlined => reflectiveSplice(tree)
-    case tree: Block => reflectiveSplice(tree)
+    case _ => reflectiveSplice(tree)
   }
 
   /** Splice the Tree for a Quoted expression which is constructed via a reflective call to the given method */

--- a/tests/pos/i4023/Macro_1.scala
+++ b/tests/pos/i4023/Macro_1.scala
@@ -1,0 +1,5 @@
+import scala.quoted._
+object Macro {
+  inline def ff[T: Type](x: T): T = ~impl('(x))
+  def impl[T](x: Expr[T]): Expr[T] = x
+}

--- a/tests/pos/i4023/Test_2.scala
+++ b/tests/pos/i4023/Test_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  Macro.ff(3)
+}

--- a/tests/pos/i4023b/Macro_1.scala
+++ b/tests/pos/i4023b/Macro_1.scala
@@ -1,0 +1,5 @@
+import scala.quoted._
+object Macro {
+  inline def ff[T](implicit t: Type[T]): Int = ~impl[T]
+  def impl[T]: Expr[Int] = 4
+}

--- a/tests/pos/i4023b/Test_2.scala
+++ b/tests/pos/i4023b/Test_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  Macro.ff[Int]
+}

--- a/tests/pos/i4023c/Macro_1.scala
+++ b/tests/pos/i4023c/Macro_1.scala
@@ -1,0 +1,5 @@
+import scala.quoted._
+object Macro {
+  inline def ff[T](x: T): T = ~impl('(x), '[T])
+  def impl[T](x: Expr[T], t: Type[T]): Expr[T] = '{ (~x): ~t }
+}

--- a/tests/pos/i4023c/Test_2.scala
+++ b/tests/pos/i4023c/Test_2.scala
@@ -1,0 +1,7 @@
+object Test {
+  Macro.ff(3)
+
+  def f[T](x: T) = {
+    Macro.ff(x)
+  }
+}

--- a/tests/pos/macro-with-type/Macro_1.scala
+++ b/tests/pos/macro-with-type/Macro_1.scala
@@ -1,0 +1,5 @@
+import scala.quoted._
+object Macro {
+  inline def ff: Unit = ~impl('[Int])
+  def impl(t: Type[Int]): Expr[Unit] = ()
+}

--- a/tests/pos/macro-with-type/Test_2.scala
+++ b/tests/pos/macro-with-type/Test_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  Macro.ff
+}


### PR DESCRIPTION
Fixes #4023 by making phase inconsistent types references in level 0 (of a macro) phase consistent without. This type will be phase consistent at the inline site.