### PR TITLE
Rename isDependent

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1362,7 +1362,7 @@ object Types {
         val funType = defn.FunctionOf(
           formals1 mapConserve (_.underlyingIfRepeated(mt.isJavaMethod)),
           mt.nonDependentResultApprox, isImplicit, isUnused)
-        if (mt.isDependent) RefinedType(funType, nme.apply, mt)
+        if (mt.isResultDependent) RefinedType(funType, nme.apply, mt)
         else funType
     }
 
@@ -2668,7 +2668,7 @@ object Types {
 
     override def resultType(implicit ctx: Context) = resType
 
-    def isDependent(implicit ctx: Context): Boolean
+    def isResultDependent(implicit ctx: Context): Boolean
     def isParamDependent(implicit ctx: Context): Boolean
 
     final def isTermLambda = isInstanceOf[TermLambda]
@@ -2683,7 +2683,7 @@ object Types {
     }
 
     final def instantiate(argTypes: => List[Type])(implicit ctx: Context): Type =
-      if (isDependent) resultType.substParams(this, argTypes)
+      if (isResultDependent) resultType.substParams(this, argTypes)
       else resultType
 
     def companion: LambdaTypeCompanion[ThisName, PInfo, This]
@@ -2845,7 +2845,7 @@ object Types {
     /** Does result type contain references to parameters of this method type,
      *  which cannot be eliminated by de-aliasing?
      */
-    def isDependent(implicit ctx: Context): Boolean = dependencyStatus == TrueDeps
+    def isResultDependent(implicit ctx: Context): Boolean = dependencyStatus == TrueDeps
 
     /** Does one of the parameter types contain references to earlier parameters
      *  of this method type which cannot be eliminated by de-aliasing?
@@ -2856,7 +2856,7 @@ object Types {
 
     /** The least supertype of `resultType` that does not contain parameter dependencies */
     def nonDependentResultApprox(implicit ctx: Context): Type =
-      if (isDependent) {
+      if (isResultDependent) {
         val dropDependencies = new ApproximatingTypeMap {
           def apply(tp: Type) = tp match {
             case tp @ TermParamRef(thisLambdaType, _) =>
@@ -3007,7 +3007,7 @@ object Types {
     type This <: TypeLambda
     type ParamRefType = TypeParamRef
 
-    def isDependent(implicit ctx: Context): Boolean = true
+    def isResultDependent(implicit ctx: Context): Boolean = true
     def isParamDependent(implicit ctx: Context): Boolean = true
 
     def newParamRef(n: Int) = new TypeParamRef(this, n) {}

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -435,7 +435,7 @@ object ProtoTypes {
    *  replaced by either wildcards (if typevarsMissContext) or TypeParamRefs.
    */
   def resultTypeApprox(mt: MethodType)(implicit ctx: Context): Type =
-    if (mt.isDependent) {
+    if (mt.isResultDependent) {
       def replacement(tp: Type) =
         if (ctx.mode.is(Mode.TypevarsMissContext)) WildcardType else newDepTypeVar(tp)
       mt.resultType.substParams(mt, mt.paramInfos.map(replacement))
@@ -464,7 +464,7 @@ object ProtoTypes {
         normalize(constrained(poly).resultType, pt)
       case mt: MethodType =>
         if (mt.isImplicitMethod) normalize(resultTypeApprox(mt), pt)
-        else if (mt.isDependent) tp
+        else if (mt.isResultDependent) tp
         else {
           val rt = normalize(mt.resultType, pt)
           pt match {

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -362,7 +362,7 @@ trait TypeAssigner {
     val ownType = fn.tpe.widen match {
       case fntpe: MethodType =>
         if (sameLength(fntpe.paramInfos, args) || ctx.phase.prev.relaxedTyping)
-          if (fntpe.isDependent) safeSubstParams(fntpe.resultType, fntpe.paramRefs, args.tpes)
+          if (fntpe.isResultDependent) safeSubstParams(fntpe.resultType, fntpe.paramRefs, args.tpes)
           else fntpe.resultType
         else
           errorType(i"wrong number of arguments at ${ctx.phase.prev} for $fntpe: ${fn.tpe}, expected: ${fntpe.paramInfos.length}, found: ${args.length}", tree.pos)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -741,7 +741,7 @@ class Typer extends Namer
       case SAMType(meth) =>
         val mt @ MethodTpe(_, formals, restpe) = meth.info
         (formals,
-         if (mt.isDependent)
+         if (mt.isResultDependent)
            untpd.DependentTypeTree(syms => restpe.substParams(mt, syms.map(_.termRef)))
          else
            typeTree(restpe))


### PR DESCRIPTION
    isDependent -> isResultDependent

so that `isDependent` now is implemented as

    isResultDependent || isParamDependent

We got bitten by this when trying to fix #4031.