### PR TITLE
Fix #4032: Fix direction of instantiation.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Constraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constraint.scala
@@ -128,12 +128,11 @@ abstract class Constraint extends Showable {
   /** Check whether predicate holds for all parameters in constraint */
   def forallParams(p: TypeParamRef => Boolean): Boolean
 
-  /** Perform operation `op` on all typevars, or only on uninstantiated
-   *  typevars, depending on whether `uninstOnly` is set or not.
-   */
+  /** Perform operation `op` on all typevars that do not have their `inst` field set. */
   def foreachTypeVar(op: TypeVar => Unit): Unit
 
-  /** The uninstantiated typevars of this constraint */
+  /** The uninstantiated typevars of this constraint, which still have a bounds constraint
+   */
   def uninstVars: collection.Seq[TypeVar]
 
   /** The weakest constraint that subsumes both this constraint and `other` */

--- a/tests/pos/i4032.scala
+++ b/tests/pos/i4032.scala
@@ -1,0 +1,19 @@
+import scala.concurrent.Future
+
+class Gen[+T] {
+  def map[U](f: T => U): Gen[U] = ???
+}
+
+object Gen {
+  def oneOf[T](t0: T, t1: T): Gen[T] = ??? // Compile with this line commented
+  def oneOf[T](g0: Gen[T], g1: Gen[T]): Gen[T] = ???
+}
+
+class Arbitrary[T]
+
+object Arbitrary {
+  def arbitrary[T]: Gen[T] = ???
+
+  def arbFuture[X]: Gen[Future[X]] =
+    Gen.oneOf(arbitrary[Future[X]], arbitrary[Throwable].map(Future.failed))
+}


### PR DESCRIPTION
Interpolation is a pretty delicate scenario. It's difficult to even say what is right and what
is wrong. In #4032 there's an unconstrained type variable that should be interpolated and it's a coin
flip whether we instantiate it to the lower or upper bound. A completely unrelated change in
#3981 meant that we instantiated the variable to the upper instead of the lower bound which
caused the program to fail. The failure was because the type variable appeared covariantly
in the lower bound of some other type variable. So maximizing the first type variable
overconstrained the second. We avoid this problem now by computing the variance of the type
variable that's eliminated in the rest of the constraint. We take this into account to
instantiate the variable so that it narrows the overall constraint the least, defaulting
again to lower bound if there is not best direction. Since the test is expensive (linear
in the constraint size), we do this only if the variable's lower bound is unconstrained.
We could do it for all non-occurring type variables, but have to see how that would affect
performance.
