### PR TITLE
Rework type inference

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -573,6 +573,11 @@ object Trees {
       s"TypeTree${if (hasType) s"[$typeOpt]" else ""}"
   }
 
+  /** A type tree that defines a new type variable. Its type is always a TypeVar.
+   *  Every TypeVar is created as the type of one TypeVarBinder.
+   */
+  class TypeVarBinder[-T >: Untyped] extends TypeTree
+
   /** ref.type */
   case class SingletonTypeTree[-T >: Untyped] private[ast] (ref: Tree[T])
     extends DenotingTree[T] with TypTree[T] {

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -576,7 +576,7 @@ object Trees {
   /** A type tree that defines a new type variable. Its type is always a TypeVar.
    *  Every TypeVar is created as the type of one TypeVarBinder.
    */
-  class TypeVarBinder[-T >: Untyped] extends TypeTree
+  class TypeVarBinder[-T >: Untyped] extends TypeTree[T]
 
   /** ref.type */
   case class SingletonTypeTree[-T >: Untyped] private[ast] (ref: Tree[T])

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -87,6 +87,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val YdisableFlatCpCaching  = BooleanSetting("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
 
   val YnoImports = BooleanSetting("-Yno-imports", "Compile without importing scala.*, java.lang.*, or Predef.")
+  val YnoInline = BooleanSetting("-Yno-inline", "Suppress inlining.")
   val YnoGenericSig = BooleanSetting("-Yno-generic-signatures", "Suppress generation of generic signatures for Java.")
   val YnoPredef = BooleanSetting("-Yno-predef", "Compile without importing Predef.")
   val Yskip = PhasesSetting("-Yskip", "Skip")
@@ -126,7 +127,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val YexplainLowlevel = BooleanSetting("-Yexplain-lowlevel", "When explaining type errors, show types at a lower level.")
   val YnoDoubleBindings = BooleanSetting("-Yno-double-bindings", "Assert no namedtype is bound twice (should be enabled only if program is error-free).")
   val YshowVarBounds = BooleanSetting("-Yshow-var-bounds", "Print type variables with their bounds")
-  val YnoInline = BooleanSetting("-Yno-inline", "Suppress inlining.")
+  val YshowNoInline = BooleanSetting("-Yshow-no-inline", "Show inlined code without the 'inlined from' info")
 
   /** Linker specific flags */
   val optimise = BooleanSetting("-optimise", "Generates faster bytecode by applying local optimisations to the .program") withAbbreviation "-optimize"

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -86,6 +86,8 @@ trait ConstraintHandling {
     finally homogenizeArgs = saved
   }
 
+  private def location(implicit ctx: Context) = "" // i"in ${ctx.typerState.stateChainStr}" // use for debugging
+
   protected def addUpperBound(param: TypeParamRef, bound: Type): Boolean = {
     def description = i"constraint $param <: $bound to\n$constraint"
     if (bound.isRef(defn.NothingClass) && ctx.typerState.isGlobalCommittable) {
@@ -93,12 +95,12 @@ trait ConstraintHandling {
       if (Config.failOnInstantiationToNothing) assert(false, msg)
       else ctx.log(msg)
     }
-    constr.println(i"adding $description in ${ctx.typerState.hashesStr}")
+    constr.println(i"adding $description$location")
     val lower = constraint.lower(param)
     val res =
       addOneBound(param, bound, isUpper = true) &&
       lower.forall(addOneBound(_, bound, isUpper = true))
-    constr.println(i"added $description = $res in ${ctx.typerState.hashesStr}")
+    constr.println(i"added $description = $res$location")
     res
   }
 
@@ -109,7 +111,7 @@ trait ConstraintHandling {
     val res =
       addOneBound(param, bound, isUpper = false) &&
       upper.forall(addOneBound(_, bound, isUpper = false))
-    constr.println(i"added $description = $res in ${ctx.typerState.hashesStr}")
+    constr.println(i"added $description = $res$location")
     res
   }
 
@@ -122,12 +124,12 @@ trait ConstraintHandling {
         val up2 = p2 :: constraint.exclusiveUpper(p2, p1)
         val lo1 = constraint.nonParamBounds(p1).lo
         val hi2 = constraint.nonParamBounds(p2).hi
-        constr.println(i"adding $description down1 = $down1, up2 = $up2 ${ctx.typerState.hashesStr}")
+        constr.println(i"adding $description down1 = $down1, up2 = $up2$location")
         constraint = constraint.addLess(p1, p2)
         down1.forall(addOneBound(_, hi2, isUpper = true)) &&
         up2.forall(addOneBound(_, lo1, isUpper = false))
       }
-    constr.println(i"added $description = $res ${ctx.typerState.hashesStr}")
+    constr.println(i"added $description = $res$location")
     res
   }
 

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -254,6 +254,9 @@ trait ConstraintHandling {
       case tp: SingletonType => true
       case AndType(tp1, tp2) => isMultiSingleton(tp1) | isMultiSingleton(tp2)
       case OrType(tp1, tp2) => isMultiSingleton(tp1) & isMultiSingleton(tp2)
+      case tp: TypeRef => isMultiSingleton(tp.info.hiBound)
+      case tp: TypeVar => isMultiSingleton(tp.underlying)
+      case tp: TypeParamRef => isMultiSingleton(bounds(tp).hi)
       case _ => false
     }
     def isFullyDefined(tp: Type): Boolean = tp match {

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -130,7 +130,7 @@ object Denotations {
         if ((cachedPrefix ne pre) || ctx.period != validAsSeenFrom) {
           cachedAsSeenFrom = computeAsSeenFrom(pre)
           cachedPrefix = pre
-          validAsSeenFrom = ctx.period
+          validAsSeenFrom = if (pre.isProvisional) Nowhere else ctx.period
         }
         cachedAsSeenFrom
       } else computeAsSeenFrom(pre)

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -76,7 +76,7 @@ class TyperState(previous: TyperState /* | Null */) {
   /** The uninstantiated variables */
   def uninstVars = constraint.uninstVars
 
-  /** The set of uninstantiated type varibles which have this state as their owning state */
+  /** The set of uninstantiated type variables which have this state as their owning state */
   private[this] var myOwnedVars: TypeVars = SimpleIdentitySet.empty
   def ownedVars = myOwnedVars
   def ownedVars_=(vs: TypeVars): Unit = myOwnedVars = vs

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -42,19 +42,6 @@ class TyperState(previous: TyperState /* | Null */) extends DotClass with Showab
   private val previousConstraint =
     if (previous == null) constraint else previous.constraint
 
-  private[this] var myEphemeral: Boolean =
-    if (previous == null) false else previous.ephemeral
-
-  /** The ephemeral flag is set as a side effect if an operation accesses
-   *  the underlying type of a type variable. The reason we need this flag is
-   *  that any such operation is not referentially transparent; it might logically change
-   *  its value at the moment the type variable is instantiated. Caching code needs to
-   *  check the ephemeral flag; If the flag is set during an operation, the result
-   *  of that operation should not be cached.
-   */
-  def ephemeral = myEphemeral
-  def ephemeral_=(x: Boolean): Unit = { myEphemeral = x }
-
   private[this] var myIsCommittable = true
 
   def isCommittable = myIsCommittable
@@ -159,7 +146,6 @@ class TyperState(previous: TyperState /* | Null */) extends DotClass with Showab
     constraint foreachTypeVar { tvar =>
       if (tvar.owningState.get eq this) tvar.owningState = new WeakReference(targetState)
     }
-    targetState.ephemeral |= ephemeral
     targetState.gc()
     reporter.flush()
     isCommitted = true

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -12,8 +12,18 @@ import printing.Texts._
 import config.Config
 import collection.mutable
 import java.lang.ref.WeakReference
+import Decorators._
+
+object TyperState {
+  @sharable private var nextId: Int = 0
+}
 
 class TyperState(previous: TyperState /* | Null */) extends DotClass with Showable {
+
+  val id = TyperState.nextId
+  TyperState.nextId += 1
+
+  //assert(id != 146)
 
   private[this] var myReporter =
     if (previous == null) new ConsoleReporter() else previous.reporter
@@ -171,7 +181,7 @@ class TyperState(previous: TyperState /* | Null */) extends DotClass with Showab
       constraint = constraint.remove(poly)
   }
 
-  override def toText(printer: Printer): Text = constraint.toText(printer)
+  override def toText(printer: Printer): Text = s"TS[$id]"
 
   def hashesStr: String =
     if (previous == null) "" else hashCode.toString + " -> " + previous.hashesStr

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -18,12 +18,10 @@ object TyperState {
   @sharable private var nextId: Int = 0
 }
 
-class TyperState(previous: TyperState /* | Null */) extends DotClass with Showable {
+class TyperState(previous: TyperState /* | Null */) {
 
   val id = TyperState.nextId
   TyperState.nextId += 1
-
-  //assert(id != 146)
 
   private[this] var myReporter =
     if (previous == null) new ConsoleReporter() else previous.reporter
@@ -181,8 +179,7 @@ class TyperState(previous: TyperState /* | Null */) extends DotClass with Showab
       constraint = constraint.remove(poly)
   }
 
-  override def toText(printer: Printer): Text = s"TS[$id]"
+  override def toString: String = s"TS[$id]"
 
-  def hashesStr: String =
-    if (previous == null) "" else hashCode.toString + " -> " + previous.hashesStr
+  def stateChainStr: String = s"$this${if (previous == null) "" else previous.stateChainStr}"
 }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -18,7 +18,7 @@ import Denotations._
 import Periods._
 import util.Positions.{Position, NoPosition}
 import util.Stats._
-import util.DotClass
+import util.{DotClass, SimpleIdentitySet}
 import reporting.diagnostic.Message
 import reporting.diagnostic.messages.CyclicReferenceInvolving
 import ast.tpd._
@@ -3369,7 +3369,10 @@ object Types {
     private[core] def inst = myInst
     private[core] def inst_=(tp: Type) = {
       myInst = tp
-      if (tp.exists) owningState = null // no longer needed; null out to avoid a memory leak
+      if (tp.exists) {
+        owningState.get.ownedVars -= this
+        owningState = null // no longer needed; null out to avoid a memory leak
+      }
     }
 
     /** The state owning the variable. This is at first `creatorState`, but it can
@@ -3432,6 +3435,8 @@ object Types {
       s"TypeVar($origin$instStr)"
     }
   }
+
+  type TypeVars = SimpleIdentitySet[TypeVar]
 
   // ------ ClassInfo, Type Bounds ------------------------------------------------------------
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1691,7 +1691,7 @@ object Types {
      *  attempt in `denot` does not yield a denotation.
      */
     private def denotAt(lastd: Denotation, now: Period)(implicit ctx: Context): Denotation = {
-      if (lastd != null && (lastd.validFor contains now) && checkedPeriod != Nowhere) {
+      if (checkedPeriod != Nowhere && lastd.validFor.contains(now)) {
         checkedPeriod = now
         lastd
       }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3354,14 +3354,11 @@ object Types {
    *
    *  @param  origin        The parameter that's tracked by the type variable.
    *  @param  creatorState  The typer state in which the variable was created.
-   *  @param  bindingTree   The TypeTree which introduces the type variable, or EmptyTree
-   *                        if the type variable does not correspond to a source term.
-   *  @paran  owner         The current owner if the context where the variable was created.
    *
    *  `owningTree` and `owner` are used to determine whether a type-variable can be instantiated
    *  at some given point. See `Inferencing#interpolateUndetVars`.
    */
-  final class TypeVar(val origin: TypeParamRef, creatorState: TyperState, var bindingTree: untpd.Tree, val owner: Symbol) extends CachedProxyType with ValueType {
+  final class TypeVar(val origin: TypeParamRef, creatorState: TyperState) extends CachedProxyType with ValueType {
 
     /** The permanent instance type of the variable, or NoType is none is given yet */
     private[this] var myInst: Type = NoType

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -359,7 +359,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case SeqLiteral(elems, elemtpt) =>
         "[" ~ toTextGlobal(elems, ",") ~ " : " ~ toText(elemtpt) ~ "]"
       case tree @ Inlined(call, bindings, body) =>
-        (("/* inlined from " ~ toText(call) ~ "*/ ") provided !homogenizedView) ~
+        (("/* inlined from " ~ toText(call) ~ "*/ ") provided !homogenizedView && !ctx.settings.YshowNoInline.value) ~
         blockText(bindings :+ body)
       case tpt: untpd.DerivedTypeTree =>
         "<derived typetree watching " ~ summarized(toText(tpt.watched)) ~ ">"

--- a/compiler/src/dotty/tools/dotc/reporting/trace.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/trace.scala
@@ -28,8 +28,11 @@ object trace {
   }
 
   @inline
-  def apply[T](question: => String, printer: Printers.Printer, show: Boolean)(op: => T)(implicit ctx: Context): T =
-    apply[T](question, printer, if (show) showShowable(_) else alwaysToString)(op)
+  def apply[T](question: => String, printer: Printers.Printer, show: Boolean)(op: => T)(implicit ctx: Context): T = {
+    def op1 = op
+    if (!Config.tracingEnabled || printer.eq(config.Printers.noPrinter)) op1
+    else doTrace[T](question, printer, if (show) showShowable(_) else alwaysToString)(op1)
+  }
 
   @inline
   def apply[T](question: => String, printer: Printers.Printer)(op: => T)(implicit ctx: Context): T =

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -675,14 +675,16 @@ object Erasure {
       super.typedStats(stats1, exprOwner).filter(!_.isEmpty)
     }
 
-    override def adapt(tree: Tree, pt: Type)(implicit ctx: Context): Tree =
+    override def adapt(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): Tree =
       trace(i"adapting ${tree.showSummary}: ${tree.tpe} to $pt", show = true) {
-        assert(ctx.phase == ctx.erasurePhase.next, ctx.phase)
+        assert(ctx.phase == ctx.erasurePhase || ctx.phase == ctx.erasurePhase.next, ctx.phase)
         if (tree.isEmpty) tree
         else if (ctx.mode is Mode.Pattern) tree // TODO: replace with assertion once pattern matcher is active
         else adaptToType(tree, pt)
       }
-  }
+
+    override def simplify(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): tree.type = tree
+}
 
   def takesBridges(sym: Symbol)(implicit ctx: Context) =
     sym.isClass && !sym.is(Flags.Trait | Flags.Package)

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -259,14 +259,14 @@ class TreeChecker extends Phase with SymTransformer {
       tpdTree
     }
 
-    override def typedUnadapted(tree: untpd.Tree, pt: Type)(implicit ctx: Context): tpd.Tree = {
+    override def typedUnadapted(tree: untpd.Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): tpd.Tree = {
       val res = tree match {
         case _: untpd.TypedSplice | _: untpd.Thicket | _: EmptyValDef[_] =>
-          super.typedUnadapted(tree)
+          super.typedUnadapted(tree, pt, locked)
         case _ if tree.isType =>
           promote(tree)
         case _ =>
-          val tree1 = super.typedUnadapted(tree, pt)
+          val tree1 = super.typedUnadapted(tree, pt, locked)
           def isSubType(tp1: Type, tp2: Type) =
             (tp1 eq tp2) || // accept NoType / NoType
             (tp1 <:< tp2)
@@ -435,7 +435,7 @@ class TreeChecker extends Phase with SymTransformer {
     override def ensureNoLocalRefs(tree: Tree, pt: Type, localSyms: => List[Symbol])(implicit ctx: Context): Tree =
       tree
 
-    override def adapt(tree: Tree, pt: Type)(implicit ctx: Context) = {
+    override def adapt(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context) = {
       def isPrimaryConstructorReturn =
         ctx.owner.isPrimaryConstructor && pt.isRef(ctx.owner.owner) && tree.tpe.isRef(defn.UnitClass)
       if (ctx.mode.isExpr &&
@@ -449,6 +449,8 @@ class TreeChecker extends Phase with SymTransformer {
         })
       tree
     }
+
+    override def simplify(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): tree.type = tree
   }
 
   /**

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -120,9 +120,12 @@ object ErrorReporting {
       val found1 = dropJavaMethod(found)
       val expected1 = dropJavaMethod(expected)
       if ((found1 eq found) != (expected eq expected1) && (found1 <:< expected1))
-        "\n(Note that Scala's and Java's representation of this type differs)"
+        i"""
+           |(Note that Scala's and Java's representation of this type differs)"""
       else if (ctx.settings.explainTypes.value)
-        "\n" + ctx.typerState.show + "\n" + TypeComparer.explained((found <:< expected)(_))
+        i"""
+           |${ctx.typerState.constraint}
+           |${TypeComparer.explained((found <:< expected)(_))}"""
       else
         ""
     }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -224,14 +224,9 @@ object Implicits {
         }
         else if (ctx eq NoContext) Nil
         else {
-          val savedEphemeral = ctx.typerState.ephemeral
-          ctx.typerState.ephemeral = false
-          try {
-            val result = computeEligible(tp)
-            if (ctx.typerState.ephemeral) record("ephemeral cache miss: eligible")
-            else eligibleCache.put(tp, result)
-            result
-          } finally ctx.typerState.ephemeral |= savedEphemeral
+          val result = computeEligible(tp)
+          eligibleCache.put(tp, result)
+          result
         }
       }
     }
@@ -470,27 +465,20 @@ trait ImplicitRunInfo { self: Run =>
      *  @param isLifted    Type `tp` is the result of a `liftToClasses` application
      */
     def iscope(tp: Type, isLifted: Boolean = false): OfTypeImplicits = {
-      val canCache = Config.cacheImplicitScopes && tp.hash != NotCached
+      val canCache = Config.cacheImplicitScopes && tp.hash != NotCached && !tp.isProvisional
       def computeIScope() = {
-        val savedEphemeral = ctx.typerState.ephemeral
-        ctx.typerState.ephemeral = false
-        try {
-          val liftedTp = if (isLifted) tp else liftToClasses(tp)
-          val refs =
-            if (liftedTp ne tp)
-              iscope(liftedTp, isLifted = true).companionRefs
-            else
-              collectCompanions(tp)
-          val result = new OfTypeImplicits(tp, refs)(ctx)
-          if (ctx.typerState.ephemeral)
-            record("ephemeral cache miss: implicitScope")
-          else if (canCache &&
-                   ((tp eq rootTp) ||          // first type traversed is always cached
-                    !incomplete.contains(tp))) // other types are cached if they are not incomplete
-            implicitScopeCache(tp) = result
-          result
-        }
-        finally ctx.typerState.ephemeral |= savedEphemeral
+        val liftedTp = if (isLifted) tp else liftToClasses(tp)
+        val refs =
+          if (liftedTp ne tp)
+            iscope(liftedTp, isLifted = true).companionRefs
+          else
+            collectCompanions(tp)
+        val result = new OfTypeImplicits(tp, refs)(ctx)
+        if (canCache &&
+            ((tp eq rootTp) ||          // first type traversed is always cached
+             !incomplete.contains(tp))) // other types are cached if they are not incomplete
+          implicitScopeCache(tp) = result
+        result
       }
       if (canCache) implicitScopeCache.getOrElse(tp, computeIScope())
       else computeIScope()

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -166,10 +166,9 @@ object Inferencing {
     @tailrec def boundVars(tree: Tree, acc: List[TypeVar]): List[TypeVar] = tree match {
       case Apply(fn, _) => boundVars(fn, acc)
       case TypeApply(fn, targs) =>
-        val tvars = targs.tpes.collect {
+        val tvars = targs.filter(_.isInstanceOf[TypeVarBinder[_]]).tpes.collect {
           case tvar: TypeVar
           if !tvar.isInstantiated &&
-             targs.contains(tvar.bindingTree) &&
              ctx.typerState.ownedVars.contains(tvar) &&
              !locked.contains(tvar) => tvar
         }

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -341,7 +341,7 @@ trait Inferencing { this: Typer =>
    *      Y <: X
    *
    *  Then `Y` also occurs co-variantly in `T` because it needs to be minimized in order to constrain
-   *  `T` teh least. See `variances` for more detail.
+   *  `T` the least. See `variances` for more detail.
    */
   def interpolateTypeVars(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): tree.type = {
     val state = ctx.typerState

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -20,6 +20,7 @@ import config.Printers.{typr, constr}
 import annotation.tailrec
 import reporting._
 import collection.mutable
+import config.Config
 
 object Inferencing {
 
@@ -161,12 +162,16 @@ object Inferencing {
    *    - The prefix `p` of a selection `p.f`.
    *    - The result expression `e` of a block `{s1; .. sn; e}`.
    */
-  def tvarsInParams(tree: Tree)(implicit ctx: Context): List[TypeVar] = {
+  def tvarsInParams(tree: Tree, locked: TypeVars)(implicit ctx: Context): List[TypeVar] = {
     @tailrec def boundVars(tree: Tree, acc: List[TypeVar]): List[TypeVar] = tree match {
       case Apply(fn, _) => boundVars(fn, acc)
       case TypeApply(fn, targs) =>
         val tvars = targs.tpes.collect {
-          case tvar: TypeVar if !tvar.isInstantiated && targs.contains(tvar.bindingTree) => tvar
+          case tvar: TypeVar
+          if !tvar.isInstantiated &&
+             targs.contains(tvar.bindingTree) &&
+             ctx.typerState.ownedVars.contains(tvar) &&
+             !locked.contains(tvar) => tvar
         }
         boundVars(fn, acc ::: tvars)
       case Select(pre, _) => boundVars(pre, acc)
@@ -228,7 +233,7 @@ object Inferencing {
    *            to instantiate undetermined type variables that occur non-variantly
    */
   def maximizeType(tp: Type, pos: Position, fromScala2x: Boolean)(implicit ctx: Context): List[Symbol] = Stats.track("maximizeType") {
-    val vs = variances(tp, alwaysTrue)
+    val vs = variances(tp)
     val patternBound = new mutable.ListBuffer[Symbol]
     vs foreachBinding { (tvar, v) =>
       if (v == 1) tvar.instantiate(fromBelow = false)
@@ -265,14 +270,14 @@ object Inferencing {
    *
    *  we want to instantiate U to x.type right away. No need to wait further.
    */
-  private def variances(tp: Type, include: TypeVar => Boolean)(implicit ctx: Context): VarianceMap = Stats.track("variances") {
+  private def variances(tp: Type)(implicit ctx: Context): VarianceMap = Stats.track("variances") {
     val constraint = ctx.typerState.constraint
 
     object accu extends TypeAccumulator[VarianceMap] {
       def setVariance(v: Int) = variance = v
       def apply(vmap: VarianceMap, t: Type): VarianceMap = t match {
         case t: TypeVar
-        if !t.isInstantiated && (ctx.typerState.constraint contains t) && include(t) =>
+        if !t.isInstantiated && ctx.typerState.constraint.contains(t) =>
           val v = vmap(t)
           if (v == null) vmap.updated(t, variance)
           else if (v == variance || v == 0) vmap
@@ -313,71 +318,47 @@ object Inferencing {
 
     propagate(accu(SimpleIdentityMap.Empty, tp))
   }
-
-  private def varianceInContext(tvar: TypeVar)(implicit ctx: Context): FlagSet = {
-    object accu extends TypeAccumulator[FlagSet] {
-      def apply(fs: FlagSet, t: Type): FlagSet =
-        if (fs == EmptyFlags) fs
-        else if (t eq tvar)
-          if (variance > 0) fs &~ Contravariant
-          else if (variance < 0) fs &~ Covariant
-          else EmptyFlags
-        else foldOver(fs, t)
-    }
-    val constraint = ctx.typerState.constraint
-    val tparam = tvar.origin
-    (VarianceFlags /: constraint.uninstVars) { (fs, tv) =>
-      if ((tv `eq` tvar) || (fs == EmptyFlags)) fs
-      else {
-        val otherParam = tv.origin
-        val fs1 = if (constraint.isLess(tparam, otherParam)) fs &~ Covariant else fs
-        val fs2 = if (constraint.isLess(otherParam, tparam)) fs1 &~ Contravariant else fs1
-        accu(fs2, constraint.entry(otherParam))
-      }
-    }
-  }
 }
 
 trait Inferencing { this: Typer =>
   import Inferencing._
   import tpd._
 
-  /** Interpolate those undetermined type variables in the widened type of this tree
-   *  which are introduced by type application contained in the tree.
-   *  If such a variable appears covariantly in type `tp` or does not appear at all,
-   *  approximate it by its lower bound. Otherwise, if it appears contravariantly
-   *  in type `tp` approximate it by its upper bound.
-   *  @param ownedBy  if it is different from NoSymbol, all type variables owned by
-   *                  `ownedBy` qualify, independent of position.
-   *                  Without that second condition, it can be that certain variables escape
-   *                  interpolation, for instance when their tree was eta-lifted, so
-   *                  the typechecked tree is no longer the tree in which the variable
-   *                  was declared. A concrete example of this phenomenon can be
-   *                  observed when compiling core.TypeOps#asSeenFrom.
+  /** Interpolate undetermined type variables in the widened type of this tree.
+   *  @param tree    the tree whose type is interpolated
+   *  @param pt      the expected result type
+   *  @param locked  the set of type variables of the current typer state that cannot be interpolated
+   *                 at the present time
+   *  Eligible for interpolation are all type variables owned by the current typerstate
+   *  that are not in locked. Type variables occurring co- (respectively, contra-) variantly in the type
+   *  are minimized (respectvely, maximized). Non occurring type variables are minimized if they
+   *  have a lower bound different from Nothing, maximized otherwise. Type variables appearing
+   *  non-variantly in the type are left untouched.
+   *
+   *  Note that even type variables that do not appear directly in a type, can occur with
+   *  some variance in the type, because of the constraints. E.g if `X` occurs co-variantly in `T`
+   *  and we have a constraint
+   *
+   *      Y <: X
+   *
+   *  Then `Y` also occurs co-variantly in `T` because it needs to be minimized in order to constrain
+   *  `T` teh least. See `variances` for more detail.
    */
-  def interpolateUndetVars(tree: Tree, ownedBy: Symbol, pt: Type)(implicit ctx: Context): Unit = {
-    val constraint = ctx.typerState.constraint
-    val qualifies = (tvar: TypeVar) =>
-      (tree contains tvar.bindingTree) || ownedBy.exists && tvar.owner == ownedBy
-    def interpolate() = Stats.track("interpolateUndetVars") {
-      val tp = tree.tpe.widen
-      constr.println(s"interpolate undet vars in ${tp.show}, pos = ${tree.pos}, mode = ${ctx.mode}, undets = ${constraint.uninstVars map (tvar => s"${tvar.show}@${tvar.bindingTree.pos}")}")
-      constr.println(s"qualifying undet vars: ${constraint.uninstVars filter qualifies map (tvar => s"$tvar / ${tvar.show}")}, constraint: ${constraint.show}")
-
-      val vs = variances(tp, qualifies)
-      val hasUnreportedErrors = ctx.typerState.reporter match {
-        case r: StoreReporter if r.hasErrors => true
-        case _ => false
-      }
-
-      var isConstrained = tree.isInstanceOf[Apply] || tree.tpe.isInstanceOf[MethodOrPoly]
-
-      def ensureConstrained() = if (!isConstrained) {
-        isConstrained = true
+  def interpolateTypeVars(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): tree.type = {
+    val state = ctx.typerState
+    if (state.ownedVars.size > locked.size) {
+      val qualifying = state.ownedVars -- locked
+      typr.println(i"interpolate $tree: ${tree.tpe.widen} in $state, owned vars = ${state.ownedVars.toList}%, %, previous = ${locked.toList}%, % / ${state.constraint}")
+      val resultAlreadyConstrained =
+        tree.isInstanceOf[Apply] || tree.tpe.isInstanceOf[MethodOrPoly]
+      if (!resultAlreadyConstrained)
         constrainResult(tree.tpe, pt)
-      }
+          // This is needed because it could establish singleton type upper bounds. See i2998.scala.
 
-      // Avoid interpolating variables if typerstate has unreported errors.
+      val tp = tree.tpe.widen
+      val vs = variances(tp)
+
+      // Avoid interpolating variables occurring in tree's type if typerstate has unreported errors.
       // Reason: The errors might reflect unsatisfiable constraints. In that
       // case interpolating without taking account the constraints risks producing
       // nonsensical types that then in turn produce incomprehensible errors.
@@ -397,40 +378,29 @@ trait Inferencing { this: Typer =>
       //     found   : Int(1)
       //     required: String
       //     val y: List[List[String]] = List(List(1))
-      if (!hasUnreportedErrors)
-        vs foreachBinding { (tvar, v) =>
-          if (v != 0 && ctx.typerState.constraint.contains(tvar)) {
-            // previous interpolations could have already instantiated `tvar`
-            // through unification, that's why we have to check again whether `tvar`
-            // is contained in the current constraint.
-            typr.println(s"interpolate ${if (v == 1) "co" else "contra"}variant ${tvar.show} in ${tp.show}")
-            ensureConstrained()
-            tvar.instantiate(fromBelow = v == 1)
+      val hasUnreportedErrors = state.reporter match {
+        case r: StoreReporter if r.hasErrors => true
+        case _ => false
+      }
+      def constraint = state.constraint
+      for (tvar <- qualifying)
+        if (!tvar.isInstantiated && state.constraint.contains(tvar)) {
+          // Needs to be checked again, since previous interpolations could already have
+          // instantiated `tvar` through unification.
+          val v = vs(tvar)
+          if (v == null) {
+            typr.println(i"interpolate non-occurring $tvar in $state in $tree: $tp, fromBelow = ${tvar.hasLowerBound}, $constraint")
+            tvar.instantiate(fromBelow = tvar.hasLowerBound)
           }
-        }
-      for (tvar <- constraint.uninstVars)
-        if (!(vs contains tvar) && qualifies(tvar)) {
-          typr.println(s"instantiating non-occurring ${tvar.show} in ${tp.show} / $tp")
-          ensureConstrained()
-          tvar.instantiate(
-            fromBelow = tvar.hasLowerBound || !varianceInContext(tvar).is(Covariant))
+          else if (!hasUnreportedErrors)
+            if (v.intValue != 0) {
+              typr.println(i"interpolate $tvar in $state in $tree: $tp, fromBelow = ${v.intValue == 1}, $constraint")
+              tvar.instantiate(fromBelow = v.intValue == 1)
+            }
+            else typr.println(i"no interpolation for nonvariant $tvar in $state")
         }
     }
-    if (constraint.uninstVars exists qualifies) interpolate()
-  }
-
-  /** The uninstantiated type variables introduced somehwere in `tree` */
-  def uninstBoundVars(tree: Tree)(implicit ctx: Context): List[TypeVar] = {
-    val buf = new mutable.ListBuffer[TypeVar]
-    tree.foreachSubTree {
-      case TypeApply(_, args) =>
-        args.tpes.foreach {
-          case tv: TypeVar if !tv.isInstantiated && tree.contains(tv.bindingTree) => buf += tv
-          case _ =>
-        }
-      case _ =>
-    }
-    buf.toList
+    tree
   }
 }
 

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -394,8 +394,8 @@ object ProtoTypes {
     def newTypeVars(tl: TypeLambda): List[TypeTree] =
       for (n <- (0 until tl.paramNames.length).toList)
       yield {
-        val tt = new TypeTree().withPos(owningTree.pos)
-        val tvar = new TypeVar(tl.paramRefs(n), state, tt, ctx.owner)
+        val tt = new TypeVarBinder().withPos(owningTree.pos)
+        val tvar = new TypeVar(tl.paramRefs(n), state)
         state.ownedVars += tvar
         tt.withType(tvar)
       }

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -241,8 +241,9 @@ object ProtoTypes {
      *  used to avoid repeated typings of trees when backtracking.
      */
     def typedArg(arg: untpd.Tree, formal: Type)(implicit ctx: Context): Tree = {
-      val targ = cacheTypedArg(arg, typer.typedUnadapted(_, formal))
-      typer.adapt(targ, formal)
+      val locked = ctx.typerState.ownedVars
+      val targ = cacheTypedArg(arg, typer.typedUnadapted(_, formal, locked))
+      typer.adapt(targ, formal, locked)
     }
 
     /** The type of the argument `arg`.
@@ -394,7 +395,9 @@ object ProtoTypes {
       for (n <- (0 until tl.paramNames.length).toList)
       yield {
         val tt = new TypeTree().withPos(owningTree.pos)
-        tt.withType(new TypeVar(tl.paramRefs(n), state, tt, ctx.owner))
+        val tvar = new TypeVar(tl.paramRefs(n), state, tt, ctx.owner)
+        state.ownedVars += tvar
+        tt.withType(tvar)
       }
 
     /** Ensure that `tl` is not already in constraint, make a copy of necessary */

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -93,7 +93,7 @@ class ReTyper extends Typer with ReChecking {
   override def index(trees: List[untpd.Tree])(implicit ctx: Context) = ctx
   override def annotate(trees: List[untpd.Tree])(implicit ctx: Context) = ()
 
-  override def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType)(fallBack: => Tree)(implicit ctx: Context): Tree =
+  override def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType, locked: TypeVars)(fallBack: => Tree)(implicit ctx: Context): Tree =
     fallBack
 
   override def completeAnnotations(mdef: untpd.MemberDef, sym: Symbol)(implicit ctx: Context): Unit = ()
@@ -109,8 +109,8 @@ class ReTyper extends Typer with ReChecking {
       super.handleUnexpectedFunType(tree, fun)
   }
 
-  override def typedUnadapted(tree: untpd.Tree, pt: Type)(implicit ctx: Context) =
-    try super.typedUnadapted(tree, pt)
+  override def typedUnadapted(tree: untpd.Tree, pt: Type, locked: TypeVars)(implicit ctx: Context) =
+    try super.typedUnadapted(tree, pt, locked)
     catch {
       case NonFatal(ex) =>
         if (ctx.isAfterTyper)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1807,12 +1807,13 @@ class Typer extends Namer
 
   /** Interpolate and simplify the type of the given tree. */
   protected def simplify(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): tree.type = {
-    if (!tree.denot.isOverloaded) {
-      // for overloaded trees: resolve overloading before simplifying
-      if (tree.isDef || !tree.tpe.widen.isInstanceOf[MethodOrPoly])
+    if (!tree.denot.isOverloaded) // for overloaded trees: resolve overloading before simplifying
+      if (!tree.tpe.widen.isInstanceOf[MethodOrPoly] // wait with simplifying until method is fully applied
+          || tree.isDef)                             // ... unless tree is a definition
+      {
         interpolateTypeVars(tree, pt, locked)
-      tree.overwriteType(tree.tpe.simplified) // ??? can we move in?
-    }
+        tree.overwriteType(tree.tpe.simplified)
+      }
     tree
   }
 

--- a/compiler/src/dotty/tools/dotc/util/SimpleIdentityMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/SimpleIdentityMap.scala
@@ -2,6 +2,9 @@ package dotty.tools.dotc.util
 
 import collection.mutable.ListBuffer
 
+/** A simple linked map with `eq` as the key comparison, optimized for small maps.
+ *  It has linear complexity for `apply`, `updated`, and `remove`.
+ */
 abstract class SimpleIdentityMap[K <: AnyRef, +V >: Null <: AnyRef] extends (K => V) {
   def size: Int
   def apply(k: K): V

--- a/compiler/src/dotty/tools/dotc/util/SimpleIdentitySet.scala
+++ b/compiler/src/dotty/tools/dotc/util/SimpleIdentitySet.scala
@@ -1,0 +1,97 @@
+package dotty.tools.dotc.util
+
+import collection.mutable.ListBuffer
+
+/** A simple linked set with `eq` as the comparison, optimized for small sets.
+ *  It has linear complexity for `contains`, `+`, and `-`.
+ */
+abstract class SimpleIdentitySet[+Elem <: AnyRef] {
+  def size: Int
+  def + [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[E]
+  def - [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[Elem]
+  def contains[E >: Elem <: AnyRef](x: E): Boolean
+  def foreach(f: Elem => Unit): Unit
+  def toList: List[Elem] = {
+    val buf = new ListBuffer[Elem]
+    foreach(buf += _)
+    buf.toList
+  }
+  def ++ [E >: Elem <: AnyRef](that: SimpleIdentitySet[E]) =
+    ((this: SimpleIdentitySet[E]) /: that.toList)(_ + _)
+  def -- [E >: Elem <: AnyRef](that: SimpleIdentitySet[E]) =
+    (this /: that.toList)(_ - _)
+  override def toString = toList.mkString("(", ", ", ")")
+}
+
+object SimpleIdentitySet {
+  object empty extends SimpleIdentitySet[Nothing] {
+    def size = 0
+    def + [E <: AnyRef](x: E): SimpleIdentitySet[E] =
+      new Set1[E](x)
+    def - [E <: AnyRef](x: E): SimpleIdentitySet[Nothing] =
+      this
+    def contains[E <: AnyRef](x: E): Boolean = false
+    def foreach(f: Nothing => Unit): Unit = ()
+  }
+
+  private class Set1[+Elem <: AnyRef](x0: AnyRef) extends SimpleIdentitySet[Elem] {
+    def size = 1
+    def + [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[E] =
+      new Set2[E](x0, x)
+    def - [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[Elem] =
+      if (x `eq` x0) empty else this
+    def contains[E >: Elem <: AnyRef](x: E): Boolean = x `eq` x0
+    def foreach(f: Elem => Unit): Unit = f(x0.asInstanceOf[Elem])
+  }
+
+  private class Set2[+Elem <: AnyRef](x0: AnyRef, x1: AnyRef) extends SimpleIdentitySet[Elem] {
+    def size = 2
+    def + [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[E] = {
+      val xs = new Array[AnyRef](3)
+      xs(0) = x0
+      xs(1) = x1
+      xs(2) = x
+      new SetN[E](xs)
+    }
+    def - [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[Elem] =
+      if (x `eq` x0) new Set1(x1)
+      else if (x `eq` x1) new Set1(x0)
+      else this
+    def contains[E >: Elem <: AnyRef](x: E): Boolean = (x `eq` x0) || (x `eq` x1)
+    def foreach(f: Elem => Unit): Unit = { f(x0.asInstanceOf[Elem]); f(x1.asInstanceOf[Elem]) }
+  }
+
+  private class SetN[+Elem <: AnyRef](xs: Array[AnyRef]) extends SimpleIdentitySet[Elem] {
+    def size = xs.length
+    def + [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[E] = {
+      val xs1 = new Array[AnyRef](size + 1)
+      Array.copy(xs, 0, xs1, 0, size)
+      xs1(size) = x
+      new SetN[E](xs1)
+    }
+    def - [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[Elem] = {
+      var i = 0
+      while (i < size && (xs(i) `ne` x)) i += 1
+      if (i == size) this
+      else if (size == 3)
+        if (i == 0) new Set2(xs(1), xs(2))
+        else if (i == 1) new Set2(xs(0), xs(2))
+        else new Set2(xs(0), xs(1))
+      else {
+        val xs1 = new Array[AnyRef](size - 1)
+        Array.copy(xs, 0, xs1, 0, i)
+        Array.copy(xs, i + 1, xs1, i, size - (i + 1))
+        new SetN(xs1)
+      }
+    }
+    def contains[E >: Elem <: AnyRef](x: E): Boolean = {
+      var i = 0
+      while (i < size && (xs(i) `ne` x)) i += 1
+      i < size
+    }
+    def foreach(f: Elem => Unit): Unit = {
+      var i = 0
+      while (i < size) { f(xs(i).asInstanceOf[Elem]); i += 1 }
+    }
+  }
+}

--- a/compiler/src/dotty/tools/dotc/util/SimpleIdentitySet.scala
+++ b/compiler/src/dotty/tools/dotc/util/SimpleIdentitySet.scala
@@ -37,7 +37,7 @@ object SimpleIdentitySet {
   private class Set1[+Elem <: AnyRef](x0: AnyRef) extends SimpleIdentitySet[Elem] {
     def size = 1
     def + [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[E] =
-      new Set2[E](x0, x)
+      if (contains(x)) this else new Set2[E](x0, x)
     def - [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[Elem] =
       if (x `eq` x0) empty else this
     def contains[E >: Elem <: AnyRef](x: E): Boolean = x `eq` x0
@@ -46,19 +46,37 @@ object SimpleIdentitySet {
 
   private class Set2[+Elem <: AnyRef](x0: AnyRef, x1: AnyRef) extends SimpleIdentitySet[Elem] {
     def size = 2
-    def + [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[E] = {
-      val xs = new Array[AnyRef](3)
-      xs(0) = x0
-      xs(1) = x1
-      xs(2) = x
-      new SetN[E](xs)
-    }
+    def + [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[E] =
+      if (contains(x)) this else new Set3(x0, x1, x)
     def - [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[Elem] =
       if (x `eq` x0) new Set1(x1)
       else if (x `eq` x1) new Set1(x0)
       else this
     def contains[E >: Elem <: AnyRef](x: E): Boolean = (x `eq` x0) || (x `eq` x1)
     def foreach(f: Elem => Unit): Unit = { f(x0.asInstanceOf[Elem]); f(x1.asInstanceOf[Elem]) }
+  }
+
+  private class Set3[+Elem <: AnyRef](x0: AnyRef, x1: AnyRef, x2: AnyRef) extends SimpleIdentitySet[Elem] {
+    def size = 3
+    def + [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[E] =
+      if (contains(this)) this
+      else {
+        val xs = new Array[AnyRef](4)
+        xs(0) = x0
+        xs(1) = x1
+        xs(2) = x2
+        xs(3) = x
+        new SetN[E](xs)
+      }
+    def - [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[Elem] =
+      if (x `eq` x0) new Set2(x1, x2)
+      else if (x `eq` x1) new Set2(x0, x2)
+      else if (x `eq` x2) new Set2(x0, x1)
+      else this
+    def contains[E >: Elem <: AnyRef](x: E): Boolean = (x `eq` x0) || (x `eq` x1) || (x `eq` x2)
+    def foreach(f: Elem => Unit): Unit = {
+      f(x0.asInstanceOf[Elem]); f(x1.asInstanceOf[Elem]); f(x2.asInstanceOf[Elem])
+    }
   }
 
   private class SetN[+Elem <: AnyRef](xs: Array[AnyRef]) extends SimpleIdentitySet[Elem] {
@@ -73,10 +91,11 @@ object SimpleIdentitySet {
       var i = 0
       while (i < size && (xs(i) `ne` x)) i += 1
       if (i == size) this
-      else if (size == 3)
-        if (i == 0) new Set2(xs(1), xs(2))
-        else if (i == 1) new Set2(xs(0), xs(2))
-        else new Set2(xs(0), xs(1))
+      else if (size == 4)
+        if (i == 0) new Set3(xs(1), xs(2), xs(3))
+        else if (i == 1) new Set3(xs(0), xs(2), xs(3))
+        else if (i == 2) new Set3(xs(0), xs(1), xs(3))
+        else new Set3(xs(0), xs(1), xs(2))
       else {
         val xs1 = new Array[AnyRef](size - 1)
         Array.copy(xs, 0, xs1, 0, i)


### PR DESCRIPTION
This is an attempt to put type inference on a more solid basis. The main two commits are

### Drop Ephemeral 90a661b

Changing the interpolation scheme uncovered several cache invalidation problems with

 - the asSeenFrom cache in Denotations
 - the superType cache in AppliedType
 - the lastDenotation cache in NamedType

The new interpolation scheme performed essentially the same operations as the old one, but sometimes in a different order. I am still not quite sure how the differences made the cache invalidations fail. On the other hand, it is quite plausible (obvious even, in retrospect) that the previous invalidation schemes are incomplete. So this commit replaces them with a common algorithm that does not rely on the previous global state represented by `ephemeral`.

### New interpolation scheme 417f0c8

Variable interpolation "improves" types by instantiating type variables that do not appear in the result of a type derivation, or that appear only co- or only contra-variantly. This is convenient because it keeps the constraints small. It is also necessary since some operations have more or better solutions once type variables are instantiated. For instance, the members of a type
variable

    X >: T <: U

are the members of `U`. But assuming `X` is covariant once it is instantiated to `T` we get more members. Similarly for implicit searches. 

The major changes from the previous interpolation scheme are the following:

 - We explicitly keep track in typer of which variables should and
   which should not be interpolated. This replaces searching trees
   for embedded variable definitions, which is fragile e.g. in the
   presence of eta expansion.
 - We compute variances starting with all variables found in the type,
   not just the qualifying ones. The previous scheme caused some
   variance information to be missed, which caused some variables
   to be mis-classified as non-occurring. i4032.scala is a test case.
   Unfortunately, fixing this caused several other tricky inference
   failures because which were previously hidden because some variables
   were already instantiated prematurely. Examples were hmap.scala,
   hmap-covariant.scala, and i2300.scala. In all these cases there was another
   problem which was masked by the fact that some type variables had
   already been instantiated where they should not have been.
 - We interpolate at the end of `typedUnadapted` instead of at the
   beginning of `adapt`. Tracking instantiatable variables turned out
   to be easier this way.
