### PR TITLE
Give more meaningful names to GADT type symbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -213,9 +213,13 @@ object NameKinds {
       safePrefix + info.num
     }
 
-    /** Generate fresh unique name of this kind with given prefix name */
+    /** Generate fresh unique term name of this kind with given prefix name */
     def fresh(prefix: TermName = EmptyTermName)(implicit ctx: Context): TermName =
       ctx.freshNames.newName(prefix, this)
+
+    /** Generate fresh unique type name of this kind with given prefix name */
+    def fresh(prefix: TypeName)(implicit ctx: Context): TypeName =
+      fresh(prefix.toTermName).toTypeName
 
     uniqueNameKinds(separator) = this
   }

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -9,7 +9,7 @@ import Trees._
 import Constants._
 import Scopes._
 import ProtoTypes._
-import NameKinds.WildcardParamName
+import NameKinds.UniqueName
 import annotation.unchecked
 import util.Positions._
 import util.{Stats, SimpleIdentityMap}
@@ -242,7 +242,7 @@ object Inferencing {
         if (bounds.hi <:< bounds.lo || bounds.hi.classSymbol.is(Final) || fromScala2x)
           tvar.instantiate(fromBelow = false)
         else {
-          val wildCard = ctx.newPatternBoundSymbol(WildcardParamName.fresh().toTypeName, bounds, pos)
+          val wildCard = ctx.newPatternBoundSymbol(UniqueName.fresh(tvar.origin.paramName), bounds, pos)
           tvar.instantiateWith(wildCard.typeRef)
           patternBound += wildCard
         }

--- a/tests/neg/gadt-eval.scala
+++ b/tests/neg/gadt-eval.scala
@@ -11,10 +11,10 @@ object Test {
         // -- [E007] Type Mismatch Error: tests/neg/gadt-eval.scala:10:6 ------------------
         // 10 |      (eval(a), eval(a))
         // |      ^^^^^^^^^^^^^^^^^^
-        // |    found:    (_$1, _$1)
+        // |    found:    (A$1, A$1)
         // |    required: T
         // |
-        // |    where:    T is a type in method eval which is an alias of (_$1, _$2)
+        // |    where:    T is a type in method eval which is an alias of (A$1, B$1)
   }
 
   def eval2[T](e: Exp[T]): T = e match {


### PR DESCRIPTION
Use the name of the corresponding class type parameter instead of `_` as
a prefix.