### PR TITLE
Check that we don't leak uninstantiated type variables

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -475,7 +475,9 @@ class TreeChecker extends Phase with SymTransformer {
 }
 
 object TreeChecker {
-  /** Check that TypeParamRefs and MethodParams refer to an enclosing type */
+  /** - Check that TypeParamRefs and MethodParams refer to an enclosing type.
+   *  - Check that all type variables are instantiated.
+   */
   def checkNoOrphans(tp0: Type, tree: untpd.Tree = untpd.EmptyTree)(implicit ctx: Context) = new TypeMap() {
     val definedBinders = new java.util.IdentityHashMap[Type, Any]
     def apply(tp: Type): Type = {
@@ -487,6 +489,7 @@ object TreeChecker {
         case tp: ParamRef =>
           assert(definedBinders.get(tp.binder) != null, s"orphan param: ${tp.show}, hash of binder = ${System.identityHashCode(tp.binder)}, tree = ${tree.show}, type = $tp0")
         case tp: TypeVar =>
+          assert(tp.isInstantiated, s"Uninstantiated type variable: ${tp.show}, tree = ${tree.show}")
           apply(tp.underlying)
         case _ =>
           mapOver(tp)


### PR DESCRIPTION
Type variable instantiation should only occur in Typer, TreeChecker and
during exhaustiveness checking, this means that no uninstantiated type
variable should exist outside of these phases. This was not enforced
until now, and was not always true before #4080.