### PR TITLE
Remove dead code in Bridges

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -104,15 +104,13 @@ class Bridges(root: ClassSymbol)(implicit ctx: Context) {
   /** Add all necessary bridges to template statements `stats`, and remove at the same
    *  time deferred methods in `stats` that are replaced by a bridge with the same signature.
    */
-  def add(stats: List[untpd.Tree]): List[untpd.Tree] =
-    if (root.is(Trait)) stats
-    else {
-      val opc = new BridgesCursor()(preErasureCtx)
-      while (opc.hasNext) {
-        if (!opc.overriding.is(Deferred)) addBridgeIfNeeded(opc.overriding, opc.overridden)
-        opc.next()
-      }
-      if (bridges.isEmpty) stats
-      else stats.filterNot(stat => toBeRemoved contains stat.symbol) ::: bridges.toList
+  def add(stats: List[untpd.Tree]): List[untpd.Tree] = {
+    val opc = new BridgesCursor()(preErasureCtx)
+    while (opc.hasNext) {
+      if (!opc.overriding.is(Deferred)) addBridgeIfNeeded(opc.overriding, opc.overridden)
+      opc.next()
     }
+    if (bridges.isEmpty) stats
+    else stats.filterNot(stat => toBeRemoved contains stat.symbol) ::: bridges.toList
+  }
 }

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -665,7 +665,7 @@ object Erasure {
       }
     }
 
-    override def typedTypeDef(tdef: untpd.TypeDef, sym: Symbol)(implicit ctx: Context) =
+    override def typedTypeDef(tdef: untpd.TypeDef, sym: Symbol)(implicit ctx: Context): Tree =
       EmptyTree
 
     override def typedStats(stats: List[untpd.Tree], exprOwner: Symbol)(implicit ctx: Context): List[Tree] = {
@@ -684,8 +684,8 @@ object Erasure {
       }
 
     override def simplify(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): tree.type = tree
-}
+  }
 
-  def takesBridges(sym: Symbol)(implicit ctx: Context) =
+  private def takesBridges(sym: Symbol)(implicit ctx: Context): Boolean =
     sym.isClass && !sym.is(Flags.Trait | Flags.Package)
 }


### PR DESCRIPTION
We never call `add` on traits as ensured by `takesBridges`