### PR TITLE
Remove dead code in CapturedVars

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
@@ -111,10 +111,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
       def boxMethod(name: TermName): Tree =
         ref(vble.info.classSymbol.companionModule.info.member(name).symbol)
       cpy.ValDef(vdef)(
-        rhs = vdef.rhs match {
-          case EmptyTree => boxMethod(nme.zero).appliedToNone.withPos(vdef.pos)
-          case arg => boxMethod(nme.create).appliedTo(arg)
-        },
+        rhs = boxMethod(nme.create).appliedTo(vdef.rhs),
         tpt = TypeTree(vble.info).withPos(vdef.tpt.pos))
     } else vdef
   }

--- a/tests/pos/capturedVars2.scala
+++ b/tests/pos/capturedVars2.scala
@@ -1,0 +1,14 @@
+abstract class Test {
+
+  var field: Int
+  val field2: Int
+
+  def foo() = {
+
+    var x: Int = 1
+
+    def inner() = {
+      x = x + 1 + field + field2
+    }
+  }
+}


### PR DESCRIPTION
Only field can have an empty rhs and they are not captured in this way