### PR TITLE
Drop stray statement

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1467,7 +1467,6 @@ object SymDenotations {
       for (p <- classParents) {
         if (p.typeSymbol.isClass) builder.addAll(p.typeSymbol.asClass.baseClasses)
         else assert(ctx.mode.is(Mode.Interactive), s"$this has non-class parent: $p")
-        builder.addAll(p.typeSymbol.asClass.baseClasses)
       }
       (classSymbol :: builder.baseClasses, builder.baseClassSet)
     }


### PR DESCRIPTION
This should have been dropped before, as it was a duplicate from a statement
that is now under its proper condition.