### PR TITLE
Improve implicit search involving SelectProtos over dependent methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -97,8 +97,30 @@ object ProtoTypes {
   abstract case class SelectionProto(name: Name, memberProto: Type, compat: Compatibility, privateOK: Boolean)
   extends CachedProxyType with ProtoType with ValueTypeOrProto {
 
+    /** Is the set of members of this type unknown? This is the caes if:
+     *  1. The type has Nothing or Wildcard as a prefix or underlying type
+     *  2. The type has an uninstantiated TypeVar as a prefix or underlying type,
+     *  or as an upper bound of a prefix and underlying type.
+     */
+    private def hasUnknownMembers(tp: Type)(implicit ctx: Context): Boolean = tp match {
+      case tp: TypeVar => !tp.isInstantiated
+      case tp: WildcardType => true
+      case tp: TypeRef =>
+        val sym = tp.symbol
+        sym == defn.NothingClass ||
+        !sym.isStatic && {
+          hasUnknownMembers(tp.prefix) || {
+            val bound = tp.info.hiBound
+            bound.isProvisional && hasUnknownMembers(bound)
+          }
+        }
+      case tp: TypeProxy => hasUnknownMembers(tp.superType)
+      case _ => false
+    }
+
     override def isMatchedBy(tp1: Type)(implicit ctx: Context) = {
-      name == nme.WILDCARD || {
+      name == nme.WILDCARD || hasUnknownMembers(tp1) ||
+      {
         val mbr = if (privateOK) tp1.member(name) else tp1.nonPrivateMember(name)
         def qualifies(m: SingleDenotation) =
           memberProto.isRef(defn.UnitClass) ||

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -97,10 +97,10 @@ object ProtoTypes {
   abstract case class SelectionProto(name: Name, memberProto: Type, compat: Compatibility, privateOK: Boolean)
   extends CachedProxyType with ProtoType with ValueTypeOrProto {
 
-    /** Is the set of members of this type unknown? This is the caes if:
+    /** Is the set of members of this type unknown? This is the case if:
      *  1. The type has Nothing or Wildcard as a prefix or underlying type
      *  2. The type has an uninstantiated TypeVar as a prefix or underlying type,
-     *  or as an upper bound of a prefix and underlying type.
+     *  or as an upper bound of a prefix or underlying type.
      */
     private def hasUnknownMembers(tp: Type)(implicit ctx: Context): Boolean = tp match {
       case tp: TypeVar => !tp.isInstantiated

--- a/tests/pos/typeclass-encoding.scala
+++ b/tests/pos/typeclass-encoding.scala
@@ -1,0 +1,91 @@
+/** A possible type class encoding for
+
+      trait SemiGroup {
+        def add(that: This): This
+      }
+
+      trait Monoid extends SemiGroup {
+        static def unit: This
+      }
+
+      extend Int : Monoid {
+        def add(that: Int) = this + that
+        static def unit = 0
+      }
+
+      extend String : Monoid {
+        def add(that: Int) = this ++ that
+        static def unit = ""
+      }
+
+      def sum[T: Monoid](xs: List[T]): T =
+        (instance[T, Monoid].unit /: xs)(_ `add` _)
+
+*/
+object runtime {
+
+  trait TypeClass {
+    type This
+    type StaticPart[This]
+  }
+
+  trait Implementation[From] {
+    type This = From
+    type Implemented <: TypeClass
+    def inject(x: From): Implemented { type This = From }
+  }
+
+  class CompanionOf[T] { type StaticPart[_] }
+
+  def instance[From, To <: TypeClass](
+      implicit ev1: Implementation[From] { type Implemented = To },
+      ev2: CompanionOf[To]): Implementation[From] { type Implemented = To } & ev2.StaticPart[From] =
+    ev1.asInstanceOf  // can we avoid the cast?
+
+  implicit def inject[From](x: From)(
+      implicit ev1: Implementation[From]): ev1.Implemented { type This = From } =
+    ev1.inject(x)
+}
+
+object semiGroups {
+  import runtime._
+
+  trait SemiGroup extends TypeClass {
+    def add(that: This): This
+  }
+
+  trait Monoid extends SemiGroup {
+    type StaticPart[This] <: MonoidStatic[This]
+  }
+  abstract class MonoidStatic[This] { def unit: This }
+
+  implicit def companionOfMonoid: CompanionOf[Monoid] {
+    type StaticPart[X] = MonoidStatic[X]
+  } = new CompanionOf[Monoid] {
+    type StaticPart[X] = MonoidStatic[X]
+  }
+
+  implicit object extend_Int_Monoid extends MonoidStatic[Int] with Implementation[Int] {
+    type Implemented = Monoid
+    def unit: Int = 0
+    def inject($this: Int) = new Monoid {
+      type This = Int
+      def add(that: This): This = $this + that
+    }
+  }
+
+  implicit object extend_String_Monoid extends MonoidStatic[String] with Implementation[String] {
+    type Implemented = Monoid
+    def unit = ""
+    def inject($this: String): Monoid { type This = String } =
+      new Monoid {
+        type This = String
+        def add(that: This): This = $this ++ that
+      }
+  }
+
+  def sum[T](xs: List[T])(implicit $ev: Implementation[T] { type Implemented = Monoid } ) = {
+    (instance[T, Monoid].unit /: xs)((x, y) => inject(x) `add` y)
+    (instance[T, Monoid].unit /: xs)((x, y) => x `add` y)  // fails in scalac and previous dotc.
+  }
+}


### PR DESCRIPTION
Refine the isMatchedBy condition of SelectProto to take into account that sometimes we do not know yet what the members of a type could be. In these cases we now err on the side of generosity and assume that the type does match the selection.

This enables implicit searches for cases like

    a.f  ==>   implicitDeco(a).f

where `implicitDeco` is a dependent function, with a result type depending on `a` or an implicit argument of `implicitDeco`. So far neither dotty nor scalac supported this pattern.

Test case in typeclass-encoding.scala.