### PR TITLE
Correct the position of root symbols unpickled from TASTY

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -409,11 +409,23 @@ object Symbols {
    *  @param coord  The coordinates of the symbol (a position or an index)
    *  @param id     A unique identifier of the symbol (unique per ContextBase)
    */
-  class Symbol private[Symbols] (val coord: Coord, val id: Int) extends Designator with ParamInfo with printing.Showable {
+  class Symbol private[Symbols] (private[this] var myCoord: Coord, val id: Int) extends Designator with ParamInfo with printing.Showable {
 
     type ThisName <: Name
 
     //assert(id != 723)
+
+    def coord: Coord = myCoord
+    /** Set the coordinate of this class, this is only useful when the coordinate is
+     *  not known at symbol creation. This is the case for root symbols
+     *  unpickled from TASTY.
+     *
+     *  @pre coord == NoCoord
+     */
+    private[core] def coord_=(c: Coord) = {
+      assert(myCoord == NoCoord)
+      myCoord = c
+    }
 
     /** The last denotation of this symbol */
     private[this] var lastDenot: SymDenotation = _
@@ -628,7 +640,7 @@ object Symbols {
 
     /** If this is either:
       *   - a top-level class and `-Yretain-trees` is set
-     *    - a top-level class loaded from TASTY and `-tasty` or `-Xlink` is set
+      *   - a top-level class loaded from TASTY and `-tasty` or `-Xlink` is set
       * then return the TypeDef tree (possibly wrapped inside PackageDefs) for this class, otherwise EmptyTree.
       * This will force the info of the class.
       */

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -492,10 +492,12 @@ class TreeUnpickler(reader: TastyReader,
       val flags = normalizeFlags(tag, givenFlags, name, isAbsType, rhsIsEmpty)
       def adjustIfModule(completer: LazyType) =
         if (flags is Module) ctx.adjustModuleCompleter(completer, name) else completer
+      val coord = coordAt(start)
       val sym =
         roots.find(root => (root.owner eq ctx.owner) && root.name == name) match {
           case Some(rootd) =>
             pickling.println(i"overwriting ${rootd.symbol} # ${rootd.hashCode}")
+            rootd.symbol.coord = coord
             rootd.info = adjustIfModule(
                 new Completer(ctx.owner, subReader(start, end)) with SymbolLoaders.SecondCompleter)
             rootd.flags = flags &~ Touched // allow one more completion
@@ -504,8 +506,6 @@ class TreeUnpickler(reader: TastyReader,
             rootd.symbol
           case _ =>
             val completer = adjustIfModule(new Completer(ctx.owner, subReader(start, end)))
-
-            val coord = coordAt(start)
 
             if (isClass)
               ctx.newClassSymbol(ctx.owner, name.asTypeName, flags, completer, privateWithin, coord)


### PR DESCRIPTION
This require mutating Symbol#coord since the position is not known when
the symbol is created. This is needed to get `-Ythrough-tasty
tests/pos/t247.scala` to compile because the position of bridge
definitions is sometimes set using the position of the enclosing class.