### PR TITLE
vscode-dotty: Compile typescript with --strict

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -915,7 +915,7 @@ object Build {
         val coursier = baseDirectory.value / "out/coursier"
         val packageJson = baseDirectory.value / "package.json"
         if (!coursier.exists || packageJson.lastModified > coursier.lastModified)
-          runProcess(Seq("npm", "run", "update-all"), wait = true, directory = baseDirectory.value)
+          runProcess(Seq("npm", "install"), wait = true, directory = baseDirectory.value)
         val tsc = baseDirectory.value / "node_modules" / ".bin" / "tsc"
         runProcess(Seq(tsc.getAbsolutePath, "--pretty", "--project", baseDirectory.value.getAbsolutePath), wait = true)
 

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -49,8 +49,9 @@
     "tsc": "./node_modules/.bin/tsc",
     "vscode:prepublish": "npm run update-all && ./node_modules/.bin/tsc -p ./",
     "compile": "./node_modules/.bin/tsc -p ./",
-    "update-all": "npm install && node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.0.0/coursier",
-    "test": "node ./node_modules/vscode/bin/test"
+    "update-all": "npm install",
+    "test": "node ./node_modules/vscode/bin/test",
+    "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.0.0/coursier"
   },
   "extensionDependencies": [
     "daltonjorge.scala"

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -47,9 +47,8 @@
   },
   "scripts": {
     "tsc": "./node_modules/.bin/tsc",
-    "vscode:prepublish": "npm run update-all && ./node_modules/.bin/tsc -p ./",
+    "vscode:prepublish": "npm install && ./node_modules/.bin/tsc -p ./",
     "compile": "./node_modules/.bin/tsc -p ./",
-    "update-all": "npm install",
     "test": "node ./node_modules/vscode/bin/test",
     "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.0.0/coursier"
   },

--- a/vscode-dotty/src/extension.ts
+++ b/vscode-dotty/src/extension.ts
@@ -2,14 +2,12 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { spawn } from 'child_process';
 
 import * as cpp from 'child-process-promise';
 
-import { commands, workspace, Disposable, ExtensionContext, Uri } from 'vscode';
-import { Executable, LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind } from 'vscode-languageclient';
-import * as lc from 'vscode-languageclient';
+import { ExtensionContext } from 'vscode';
 import * as vscode from 'vscode';
+import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient';
 
 let extensionContext: ExtensionContext
 let outputChannel: vscode.OutputChannel
@@ -45,7 +43,7 @@ export function activate(context: ExtensionContext) {
   })
 }
 
-function fetchAndRun(artifact: String) {
+function fetchAndRun(artifact: string) {
   const coursierPath = path.join(extensionContext.extensionPath, './out/coursier');
 
   vscode.window.withProgress({
@@ -64,15 +62,15 @@ function fetchAndRun(artifact: String) {
 
     let classPath = ""
 
-    coursierProc.stdout.on('data', (data) => {
+    coursierProc.stdout.on('data', (data: Buffer) => {
       classPath += data.toString().trim()
     })
-    coursierProc.stderr.on('data', (data) => {
+    coursierProc.stderr.on('data', (data: Buffer) => {
       let msg = data.toString()
       outputChannel.append(msg)
     })
 
-    coursierProc.on('close', (code) => {
+    coursierProc.on('close', (code: number) => {
       if (code != 0) {
         let msg = "Fetching the language server failed."
         outputChannel.append(msg)

--- a/vscode-dotty/src/passthrough-server.ts
+++ b/vscode-dotty/src/passthrough-server.ts
@@ -1,17 +1,15 @@
 'use strict';
 
-import {
-	IPCMessageReader, IPCMessageWriter,
-	createConnection, IConnection, TextDocumentSyncKind,
-	TextDocuments, TextDocument, Diagnostic, DiagnosticSeverity,
-	InitializeParams, InitializeResult, TextDocumentPositionParams,
-	CompletionItem, CompletionItemKind
-} from 'vscode-languageserver';
-
 import * as net from 'net';
 
-let argv = process.argv.slice(2)
-let port = argv.shift()
+let argv: string[] = process.argv.slice(2)
+const firstArg: string | undefined = argv.shift()
+let port: string
+if (firstArg === undefined) {
+  throw new Error('Expected port as the first argument')
+} else {
+  port = firstArg
+}
 
 let client = new net.Socket()
 client.setEncoding('utf8')

--- a/vscode-dotty/src/types.d.ts
+++ b/vscode-dotty/src/types.d.ts
@@ -1,0 +1,14 @@
+declare module 'child-process-promise' {
+
+  import {ChildProcess} from "child_process";
+
+  interface ChildPromiseResult {
+    code: number;
+  }
+
+  interface ChildProcessPromise extends Promise<ChildPromiseResult> {
+    childProcess: ChildProcess;
+  }
+
+  function spawn(command: string, args: string[]): ChildProcessPromise;
+}

--- a/vscode-dotty/tsconfig.json
+++ b/vscode-dotty/tsconfig.json
@@ -7,7 +7,8 @@
             "es6"
         ],
         "sourceMap": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "strict": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Compiling typescript with the strict option is generally recommend to catch more type errors.

Also, I changed the update-all to a postinstall script, which will automatically execute after every `npm install`.