### PR TITLE
Fix owner of symbols created from TASTY LazyReaders

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/core/quoted/PickledQuotes.scala
@@ -51,7 +51,8 @@ object PickledQuotes {
     val tastyBytes = TastyString.unpickle(expr.tasty)
     val unpickled = unpickle(tastyBytes, expr.args)
     unpickled match {
-      case PackageDef(_, (vdef: ValDef) :: Nil) => vdef.rhs
+      case PackageDef(_, (vdef: ValDef) :: Nil) =>
+        vdef.rhs.changeOwner(vdef.symbol, ctx.owner)
     }
   }
 
@@ -62,6 +63,7 @@ object PickledQuotes {
     unpickled match {
       case PackageDef(_, (vdef: ValDef) :: Nil) =>
         vdef.rhs.asInstanceOf[TypeApply].args.head
+          .changeOwner(vdef.symbol, ctx.owner)
     }
   }
 

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -58,9 +58,6 @@ class FromTastyTests extends ParallelTesting {
         "spec-sparsearray-old.scala",
         "collections_1.scala",
 
-        // Anonymous method not defined
-        "i3067.scala",
-
         // Infinite compilation
         "t3612.scala",
       )


### PR DESCRIPTION
A LazyReader is completed using the current Context which may have a
different owner than the one that was in place when the LazyReader was
created, we compensate for this by explicitly recording and setting
`Context#owner` when completing the LazyReader.