### PR TITLE
Fix #3847: Handle correctly splicing of (possibly) nested type parameters

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -64,7 +64,7 @@ object Build {
 
 
   val agentOptions = List(
-//     "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+    // "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
     // "-agentpath:/home/dark/opt/yjp-2013-build-13072/bin/linux-x86-64/libyjpagent.so"
     // "-agentpath:/Applications/YourKit_Java_Profiler_2015_build_15052.app/Contents/Resources/bin/mac/libyjpagent.jnilib",
     // "-XX:+HeapDumpOnOutOfMemoryError", "-Xmx1g", "-Xss2m"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -64,7 +64,7 @@ object Build {
 
 
   val agentOptions = List(
-    // "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+//     "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
     // "-agentpath:/home/dark/opt/yjp-2013-build-13072/bin/linux-x86-64/libyjpagent.so"
     // "-agentpath:/Applications/YourKit_Java_Profiler_2015_build_15052.app/Contents/Resources/bin/mac/libyjpagent.jnilib",
     // "-XX:+HeapDumpOnOutOfMemoryError", "-Xmx1g", "-Xss2m"

--- a/tests/run-with-compiler/i3847-b.check
+++ b/tests/run-with-compiler/i3847-b.check
@@ -1,3 +1,3 @@
 {
-  dotty.runtime.Arrays.newGenericArray[Int](3)(reflect.ClassTag.Int)
+  new Array[List[Int]](1)
 }

--- a/tests/run-with-compiler/i3847-b.check
+++ b/tests/run-with-compiler/i3847-b.check
@@ -1,0 +1,3 @@
+{
+  dotty.runtime.Arrays.newGenericArray[Int](3)(reflect.ClassTag.Int)
+}

--- a/tests/run-with-compiler/i3847-b.scala
+++ b/tests/run-with-compiler/i3847-b.scala
@@ -3,8 +3,8 @@ import scala.quoted._
 import scala.reflect.ClassTag
 
 object Arrays {
-  implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T], ct: Expr[ClassTag[T]]): Liftable[Array[List[T]]] = (arr: Array[List[T]]) => '{
-    new Array[List[~t]](3)
+  implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T]): Liftable[Array[List[T]]] = (arr: Array[List[T]]) => '{
+    new Array[List[~t]](~(arr.length: Expr[Int]))
     // TODO add elements
   }
 }

--- a/tests/run-with-compiler/i3847-b.scala
+++ b/tests/run-with-compiler/i3847-b.scala
@@ -4,7 +4,7 @@ import scala.reflect.ClassTag
 
 object Arrays {
   implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T]): Liftable[Array[List[T]]] = (arr: Array[List[T]]) => '{
-    new Array[List[~t]](~(arr.length: Expr[Int]))
+    new Array[List[~t]](~arr.length.toExpr)
     // TODO add elements
   }
 }
@@ -13,7 +13,7 @@ object Test {
   def main(args: Array[String]): Unit = {
     import Arrays._
     implicit val ct: Expr[ClassTag[Int]] = '(ClassTag.Int)
-    val arr: Expr[Array[List[Int]]] = Array[List[Int]](List(1, 2, 3))
+    val arr: Expr[Array[List[Int]]] = Array[List[Int]](List(1, 2, 3)).toExpr
     println(arr.show)
   }
 }

--- a/tests/run-with-compiler/i3847-b.scala
+++ b/tests/run-with-compiler/i3847-b.scala
@@ -1,0 +1,19 @@
+import dotty.tools.dotc.quoted.Toolbox._
+import scala.quoted._
+import scala.reflect.ClassTag
+
+object Arrays {
+  implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T], ct: Expr[ClassTag[T]]): Liftable[Array[List[T]]] = (arr: Array[List[T]]) => '{
+    new Array[List[~t]](3)
+    // TODO add elements
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    import Arrays._
+    implicit val ct: Expr[ClassTag[Int]] = '(ClassTag.Int)
+    val arr: Expr[Array[List[Int]]] = Array[List[Int]](List(1, 2, 3))
+    println(arr.show)
+  }
+}

--- a/tests/run-with-compiler/i3847.check
+++ b/tests/run-with-compiler/i3847.check
@@ -1,0 +1,3 @@
+{
+  dotty.runtime.Arrays.newGenericArray[Int](3)(reflect.ClassTag.Int)
+}

--- a/tests/run-with-compiler/i3847.check
+++ b/tests/run-with-compiler/i3847.check
@@ -1,3 +1,1 @@
-{
-  dotty.runtime.Arrays.newGenericArray[Int](3)(reflect.ClassTag.Int)
-}
+dotty.runtime.Arrays.newGenericArray[Int](3)(reflect.ClassTag.Int)

--- a/tests/run-with-compiler/i3847.scala
+++ b/tests/run-with-compiler/i3847.scala
@@ -1,0 +1,19 @@
+import dotty.tools.dotc.quoted.Toolbox._
+import scala.quoted._
+import scala.reflect.ClassTag
+
+object Arrays {
+  implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T], ct: Expr[ClassTag[T]]): Liftable[Array[T]] = (arr: Array[T]) => '{
+    new Array[~t](~(arr.length: Expr[Int]))(~ct)
+    // TODO add elements
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    import Arrays._
+    implicit val ct: Expr[ClassTag[Int]] = '(ClassTag.Int)
+    val arr: Expr[Array[Int]] = Array[Int](1, 2, 3)
+    println(arr.show)
+  }
+}

--- a/tests/run-with-compiler/i3847.scala
+++ b/tests/run-with-compiler/i3847.scala
@@ -4,7 +4,7 @@ import scala.reflect.ClassTag
 
 object Arrays {
   implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T], ct: Expr[ClassTag[T]]): Liftable[Array[T]] = (arr: Array[T]) => '{
-    new Array[~t](~(arr.length: Expr[Int]))(~ct)
+    new Array[~t](~arr.length.toExpr)(~ct)
     // TODO add elements
   }
 }
@@ -13,7 +13,7 @@ object Test {
   def main(args: Array[String]): Unit = {
     import Arrays._
     implicit val ct: Expr[ClassTag[Int]] = '(ClassTag.Int)
-    val arr: Expr[Array[Int]] = Array[Int](1, 2, 3)
+    val arr: Expr[Array[Int]] = Array[Int](1, 2, 3).toExpr
     println(arr.show)
   }
 }

--- a/tests/run-with-compiler/quote-lib.scala
+++ b/tests/run-with-compiler/quote-lib.scala
@@ -118,7 +118,7 @@ package liftable {
 
     object Arrays {
       implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T], ct: Expr[ClassTag[T]]): Liftable[Array[T]] = (arr: Array[T]) => '{
-        new Array[~t](~(arr.length: Expr[Int]))(~ct)
+        new Array[~t](~arr.length.toExpr)(~ct)
       }
     }
 

--- a/tests/run-with-compiler/quote-lib.scala
+++ b/tests/run-with-compiler/quote-lib.scala
@@ -117,11 +117,9 @@ package liftable {
     }
 
     object Arrays {
-      // FIXME missing hole for ~t
-//      implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T], ct: Expr[ClassTag[T]]): Liftable[Array[T]] = (arr: Array[T]) => '{
-//        new Array[~t](~(arr.length: Expr[Int]))(~ct)
-//      }
-
+      implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T], ct: Expr[ClassTag[T]]): Liftable[Array[T]] = (arr: Array[T]) => '{
+        new Array[~t](~(arr.length: Expr[Int]))(~ct)
+      }
     }
 
   }


### PR DESCRIPTION
Based on #4081

The proposed fix handle the case when a type splice e.g., `~t` appears in possibly nested positions as a type parameter, e.g., `List[~t]` and `List[Array[~t]]`. If the code included just `List[T]` and `List[Array[T]]` the types are extracted and added as tags using implicit search in the phase of `tryHeal`. This commit collects and handles spliced types as well, using the same mechanism as before.
