### PR TITLE
Do not allow named self in objects

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -645,7 +645,7 @@ object desugar {
         .withPos(mdef.pos.startPos)
       val ValDef(selfName, selfTpt, _) = impl.self
       val selfMods = impl.self.mods
-      if (!selfTpt.isEmpty) ctx.error(ObjectMayNotHaveSelfType(mdef), impl.self.pos)
+      if (!selfTpt.isEmpty || selfName != nme.WILDCARD) ctx.error(ObjectMayNotHaveSelfType(mdef), impl.self.pos)
       val clsSelf = ValDef(selfName, SingletonTypeTree(Ident(moduleName)), impl.self.rhs)
         .withMods(selfMods)
         .withPos(impl.self.pos orElse impl.pos.startPos)

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -63,7 +63,7 @@ object NameKinds {
     def infoString: String
   }
 
-  object SimpleNameKind extends NameKind(UTF8) { self =>
+  object SimpleNameKind extends NameKind(UTF8) {
     type ThisInfo = Info
     val info = new Info
     def mkString(underlying: TermName, info: ThisInfo) = unsupported("mkString")

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -954,13 +954,7 @@ class Namer { typer: Typer =>
 
       val selfInfo =
         if (self.isEmpty) NoType
-        else if (cls.is(Module)) {
-          val moduleType = cls.owner.thisType select sourceModule
-          if (self.name == nme.WILDCARD) moduleType
-          else recordSym(
-            ctx.newSymbol(cls, self.name, self.mods.flags, moduleType, coord = self.pos),
-            self)
-        }
+        else if (cls.is(Module)) cls.owner.thisType.select(sourceModule)
         else createSymbol(self)
 
       // pre-set info, so that parent types can refer to type params

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -56,9 +56,6 @@ class FromTastyTests extends ParallelTesting {
         "spec-super.scala",
         "spec-sparsearray-old.scala",
         "collections_1.scala",
-
-        // Infinite compilation
-        "t3612.scala",
       )
     )
     step1.checkCompile() // Compile all files to generate the class files with tasty

--- a/tests/neg/i831.scala
+++ b/tests/neg/i831.scala
@@ -1,0 +1,4 @@
+object Test { self => // error: objects must not have a self type
+  def a = 5
+  self.a // error: not found: self
+}

--- a/tests/pickling/desugar.scala
+++ b/tests/pickling/desugar.scala
@@ -11,7 +11,7 @@ object desugar {
   def foo1(first: Int, second: Int = 2)(third: Int = 3) = first + second
   def foo2(first: Int)(second: Int = 2)(third: Int = 3) = first + second
 
-  object caseClasses { self =>
+  object caseClasses {
     trait List[+T] {
       def head: T
       def tail: List[T]

--- a/tests/pos/desugar.scala
+++ b/tests/pos/desugar.scala
@@ -11,7 +11,7 @@ object desugar {
   def foo1(first: Int, second: Int = 2)(third: Int = 3) = first + second
   def foo2(first: Int)(second: Int = 2)(third: Int = 3) = first + second
 
-  object caseClasses { self =>
+  object caseClasses {
     trait List[+T] {
       def head: T
       def tail: List[T]

--- a/tests/pos/i831.scala
+++ b/tests/pos/i831.scala
@@ -1,4 +1,0 @@
-object Test { self =>
-  def a = 5
-  self.a
-}

--- a/tests/pos/t3612.scala
+++ b/tests/pos/t3612.scala
@@ -1,6 +1,0 @@
-trait C
-
-class Outer {
-  object O0 extends C {}
-  object O extends C { self => }
-}


### PR DESCRIPTION
`object A { foo: Bla => }` was already prohibited, we extend this
restriction to `object A { foo => }`, the latter is not really useful
and it currently causes a MatchError in SymDenotation#sourceModule when
unpickling.