### PR TITLE
Fix ownership of symbols unpickled inside Bind nodes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -144,10 +144,11 @@ class TreeUnpickler(reader: TastyReader,
             else {
               for (i <- 0 until nrefs) readNat()
               if (tag == BIND) {
-                buf += new OwnerTree(start, tag, fork, end)
-                goto(end)
+                // a Bind is never the owner of anything, so we set `end = start`
+                buf += new OwnerTree(start, tag, fork, end = start)
               }
-              else scanTrees(buf, end)
+
+              scanTrees(buf, end)
             }
           }
           else if (tag >= firstNatASTTreeTag) { readNat(); scanTree(buf) }

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -94,10 +94,6 @@ class FromTastyTests extends ParallelTesting {
          // Closure type miss match
          "eff-dependent.scala",
 
-         // Unpickling tree without owner
-         "patmat-bind-typed.scala",
-         "t8395.scala",
-
          // Issue unpickling universes
          "phantom-decls-1.scala",
          "phantom-decls-3.scala",


### PR DESCRIPTION
They should be owned by the Bind symbol owner, not by the Bind symbol
itself.