### PR TITLE
Remove quoted.Liftable for Unit

### DIFF
--- a/library/src/scala/quoted/Liftable.scala
+++ b/library/src/scala/quoted/Liftable.scala
@@ -20,7 +20,6 @@ object Liftable {
     def toExpr(implicit liftable: Liftable[T]): Expr[T] = liftable.toExpr(x)
   }
 
-  implicit def UnitIsLiftable: Liftable[Unit] = (x: Unit) => new ValueExpr(x)
   implicit def BooleanIsLiftable: Liftable[Boolean] = (x: Boolean) => new ValueExpr(x)
   implicit def ByteLiftable: Liftable[Byte] = (x: Byte) => new ValueExpr(x)
   implicit def CharIsLiftable: Liftable[Char] = (x: Char) => new ValueExpr(x)

--- a/tests/pos/macro-with-type/Macro_1.scala
+++ b/tests/pos/macro-with-type/Macro_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
   inline def ff: Unit = ~impl('[Int])
-  def impl(t: Type[Int]): Expr[Unit] = ()
+  def impl(t: Type[Int]): Expr[Unit] = '()
 }

--- a/tests/pos/quote-liftable.scala
+++ b/tests/pos/quote-liftable.scala
@@ -33,7 +33,6 @@ object Test {
   (1.0f: Expr[Float])
   (1.0: Expr[Double])
   ("abc": Expr[String])
-  ((): Expr[Unit])
 
   val xs: Expr[List[Int]] = 1 :: 2 :: 3 :: Nil
 }

--- a/tests/run-with-compiler/i3946.scala
+++ b/tests/run-with-compiler/i3946.scala
@@ -2,7 +2,7 @@ import dotty.tools.dotc.quoted.Toolbox._
 import scala.quoted._
 object Test {
   def main(args: Array[String]): Unit = {
-    val u: Expr[Unit] = ()
+    val u: Expr[Unit] = '()
     println(u.show)
     println(u.run)
   }

--- a/tests/run-with-compiler/quote-show-blocks-raw.scala
+++ b/tests/run-with-compiler/quote-show-blocks-raw.scala
@@ -12,14 +12,14 @@ object Test {
       if (n == 0) x
       else a(n - 1, '{ println(~n.toExpr); ~x })
 
-    println(a(5, ()).show)
+    println(a(5, '()).show)
 
 
     def b(n: Int, x: Expr[Unit]): Expr[Unit] =
       if (n == 0) x
       else b(n - 1, '{ ~x; println(~n.toExpr) })
 
-    println(b(5, ()).show)
+    println(b(5, '()).show)
   }
 
 }

--- a/tests/run-with-compiler/quote-show-blocks.scala
+++ b/tests/run-with-compiler/quote-show-blocks.scala
@@ -11,14 +11,14 @@ object Test {
       if (n == 0) x
       else a(n - 1, '{ println(~n.toExpr); ~x })
 
-    println(a(5, ()).show)
+    println(a(5, '()).show)
 
 
     def b(n: Int, x: Expr[Unit]): Expr[Unit] =
       if (n == 0) x
       else b(n - 1, '{ ~x; println(~n.toExpr) })
 
-    println(b(5, ()).show)
+    println(b(5, '()).show)
   }
 
 }


### PR DESCRIPTION
To lift a unit we only need to write `'()` which will still
become a `ValueExpr` by some optimization in ReifyQuotes (see #4103).