### PR TITLE
Move LiftExprOps to quoted package

### DIFF
--- a/library/src/scala/quoted/Liftable.scala
+++ b/library/src/scala/quoted/Liftable.scala
@@ -15,11 +15,6 @@ abstract class Liftable[T] {
  *  gives an alternative implementation using just the basic staging system.
  */
 object Liftable {
-
-  implicit class LiftExprOps[T](val x: T) extends AnyVal {
-    def toExpr(implicit liftable: Liftable[T]): Expr[T] = liftable.toExpr(x)
-  }
-
   implicit def BooleanIsLiftable: Liftable[Boolean] = (x: Boolean) => new ValueExpr(x)
   implicit def ByteLiftable: Liftable[Byte] = (x: Byte) => new ValueExpr(x)
   implicit def CharIsLiftable: Liftable[Char] = (x: Char) => new ValueExpr(x)

--- a/library/src/scala/quoted/package.scala
+++ b/library/src/scala/quoted/package.scala
@@ -1,0 +1,9 @@
+package scala
+
+package object quoted {
+
+  implicit class LiftExprOps[T](val x: T) extends AnyVal {
+    def toExpr(implicit ev: Liftable[T]): Expr[T] = ev.toExpr(x)
+  }
+
+}

--- a/tests/run-with-compiler/quote-lib.scala
+++ b/tests/run-with-compiler/quote-lib.scala
@@ -42,7 +42,6 @@ object Test {
 
 package liftable {
   import scala.quoted.Liftable
-  import scala.quoted.Liftable._
   import scala.reflect.ClassTag
 
   object Exprs {

--- a/tests/run-with-compiler/quote-show-blocks-raw.scala
+++ b/tests/run-with-compiler/quote-show-blocks-raw.scala
@@ -2,7 +2,6 @@
 import dotty.tools.dotc.quoted.Toolbox._
 
 import scala.quoted._
-import scala.quoted.Liftable._
 
 object Test {
   def main(args: Array[String]): Unit = {

--- a/tests/run-with-compiler/quote-show-blocks.scala
+++ b/tests/run-with-compiler/quote-show-blocks.scala
@@ -2,7 +2,6 @@
 import dotty.tools.dotc.quoted.Toolbox._
 
 import scala.quoted._
-import scala.quoted.Liftable._
 
 object Test {
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
To use `import scala.quotes._` to import `toExpr` extension