### PR TITLE
Fix #4109: Add dummy test for vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ compiler/after-pickling.txt
 *.dotty-ide-version
 
 *.decompiled.out
+
+# The vscode app for testing
+vscode-dotty/.vscode-test

--- a/vscode-dotty/test/extension.test.ts
+++ b/vscode-dotty/test/extension.test.ts
@@ -1,0 +1,21 @@
+//
+// Note: This example test is leveraging the Mocha test framework.
+// Please refer to their documentation on https://mochajs.org/ for help.
+//
+
+// The module 'assert' provides assertion methods from node
+import * as assert from 'assert';
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode';
+import * as dotty from '../src/extension';
+
+// Defines a Mocha test suite to group tests of similar kind together
+suite("vscode-dotty tests", function () {
+
+    // Defines a Mocha unit test
+    test("dummy test", function() {
+        assert.equal(1, 1)
+    });
+});

--- a/vscode-dotty/test/index.ts
+++ b/vscode-dotty/test/index.ts
@@ -1,0 +1,22 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+import * as testRunner from 'vscode/lib/testrunner';
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+});
+
+module.exports = testRunner;


### PR DESCRIPTION
The vscode test runner was crashing, because there was no test specified.