### PR TITLE
Avoid spurious "double-def" error message involving erroneous definition

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -624,9 +624,9 @@ trait Checking {
       for (other <- seen(decl.name)) {
         typr.println(i"conflict? $decl $other")
         if (decl.matches(other)) {
-          def doubleDefError(decl: Symbol, other: Symbol): Unit = {
-            ctx.error(DoubleDeclaration(decl, other), decl.pos)
-          }
+          def doubleDefError(decl: Symbol, other: Symbol): Unit =
+            if (!decl.info.isErroneous && !other.info.isErroneous)
+              ctx.error(DoubleDeclaration(decl, other), decl.pos)
           if (decl is Synthetic) doubleDefError(other, decl)
           else doubleDefError(decl, other)
         }


### PR DESCRIPTION
Looks like this fixes master's failure.