### PR TITLE
 Fix #4138: Do not emit forwarders for methods with expanded names

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -33,7 +33,7 @@ import tpd._
 import scala.tools.asm
 import StdNames.{nme, str}
 import NameOps._
-import NameKinds.DefaultGetterName
+import NameKinds.{DefaultGetterName, ExpandedName}
 import dotty.tools.dotc.core
 import dotty.tools.dotc.core.Names.TypeName
 
@@ -677,6 +677,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     def isType: Boolean = sym.isType
     def isAnonymousClass: Boolean = toDenot(sym).isAnonymousClass
     def isConstructor: Boolean = toDenot(sym).isConstructor
+    def isExpanded: Boolean = sym.name.is(ExpandedName)
     def isAnonymousFunction: Boolean = toDenot(sym).isAnonymousFunction
     def isMethod: Boolean = sym is Flags.Method
     def isPublic: Boolean =  sym.flags.is(Flags.EmptyFlags, Flags.Private | Flags.Protected)

--- a/tests/run/forwarder.check
+++ b/tests/run/forwarder.check
@@ -1,0 +1,1 @@
+public static int Foo.hi()

--- a/tests/run/forwarder.scala
+++ b/tests/run/forwarder.scala
@@ -1,0 +1,20 @@
+class Foo
+object Foo extends Bar
+
+trait Bar {
+  def hi: Int = 1
+  private def foo: Int = 1
+
+  class Inner {
+    val a = foo // Force foo to be expanded by ExpandPrivate
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    println(
+      classOf[Foo].getMethods
+        .filter(m => (m.getModifiers & java.lang.reflect.Modifier.STATIC) != 0)
+        .mkString("\n"))
+  }
+}


### PR DESCRIPTION
This was accidentally broken in 21ab9a1
when the ExpandedName symbol flag was replaced by a name kind.