### PR TITLE
Fix #4160: Fix vscode-dotty build

### DIFF
--- a/vscode-dotty/package-lock.json
+++ b/vscode-dotty/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/mocha": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.0.0.tgz",
+      "integrity": "sha512-ZS0vBV7Jn5Z/Q4T3VXauEKMDCV8nWOtJJg90OsDylkYJiQwcWtKuLzohWzrthBkerUF7DLMmJcwOPEP0i/AOXw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@types/node": "^8.5.8",
+    "@types/mocha": "^5.0.0",
     "typescript": "^2.6.2",
     "vscode": "^1.1.10"
   }


### PR DESCRIPTION
Add missing dependency on typings for the test framework