### PR TITLE
Fix #3140: Generate better `equals` for case/value classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMethods.scala
@@ -164,11 +164,11 @@ class SyntheticMethods(thisPhase: DenotTransformer) {
       def wildcardAscription(tp: Type) = Typed(Underscore(tp), TypeTree(tp))
       val pattern = Bind(thatAsClazz, wildcardAscription(clazzType)) // x$0 @ (_: C)
       val comparisons = accessors map { accessor =>
-        This(clazz).select(accessor).select(defn.Any_==).appliedTo(ref(thatAsClazz).select(accessor)) }
+        This(clazz).select(accessor).equal(ref(thatAsClazz).select(accessor)) }
       val rhs = // this.x == this$0.x && this.y == x$0.y
         if (comparisons.isEmpty) Literal(Constant(true)) else comparisons.reduceLeft(_ and _)
       val matchingCase = CaseDef(pattern, EmptyTree, rhs) // case x$0 @ (_: C) => this.x == this$0.x && this.y == x$0.y
-      val defaultCase = CaseDef(wildcardAscription(defn.AnyType), EmptyTree, Literal(Constant(false))) // case _ => false
+      val defaultCase = CaseDef(Underscore(defn.AnyType), EmptyTree, Literal(Constant(false))) // case _ => false
       val matchExpr = Match(that, List(matchingCase, defaultCase))
       if (isDerivedValueClass(clazz)) matchExpr
       else {

--- a/compiler/src/dotty/tools/dotc/transform/VCElideAllocations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/VCElideAllocations.scala
@@ -29,7 +29,7 @@ class VCElideAllocations extends MiniPhase with IdentityDenotTransformer {
       case BinaryOp(NewWithArgs(tp1, List(u1)), op, NewWithArgs(tp2, List(u2)))
       if (tp1 eq tp2) && (op eq defn.Any_==) && isDerivedValueClass(tp1.typeSymbol) =>
         // == is overloaded in primitive classes
-        applyOverloaded(u1, nme.EQ, List(u2), Nil, defn.BooleanType)
+        u1.equal(u2)
 
       // (new V(u)).underlying() => u
       case ValueClassUnbox(NewWithArgs(_, List(u))) =>


### PR DESCRIPTION
- Do overloading resolution on `==` to avoid boxing primitives
- Use `case _` instead of `case _: Any` for the default case, the latter
  produces suboptimal code.
