### PR TITLE
Fix #3349: Fix dottydoc filenames for Windows

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -190,7 +190,7 @@ object Names {
     private[this] var derivedNames: AnyRef /* immutable.Map[NameInfo, DerivedName] | j.u.HashMap */ =
       immutable.Map.empty[NameInfo, DerivedName]
 
-    private def getDerived(info: NameInfo): DerivedName /* | Null */= derivedNames match {
+    private def getDerived(info: NameInfo): DerivedName /* | Null */ = derivedNames match {
       case derivedNames: immutable.AbstractMap[NameInfo, DerivedName] @unchecked =>
         if (derivedNames.contains(info)) derivedNames(info) else null
       case derivedNames: HashMap[NameInfo, DerivedName] @unchecked =>

--- a/doc-tool/src/dotty/tools/dottydoc/core/DocASTPhase.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/core/DocASTPhase.scala
@@ -11,6 +11,7 @@ import dotc.core.Comments.ContextDocstrings
 import dotc.core.Types.{PolyType, NoType}
 import dotc.core.Phases.Phase
 import dotc.core.Symbols.{ Symbol, NoSymbol }
+import dotc.core.NameOps._
 
 class DocASTPhase extends Phase {
   import model._
@@ -108,9 +109,8 @@ class DocASTPhase extends Phase {
 
       /** objects, on the format "Object$" so drop the last letter */
       case o @ TypeDef(n, rhs) if o.symbol.is(Flags.Module) =>
-        val name = o.name.show
         //TODO: should not `collectMember` from `rhs` - instead: get from symbol, will get inherited members as well
-        ObjectImpl(o.symbol, annotations(o.symbol), name.dropRight(1), collectMembers(rhs),  flags(o), path(o.symbol).init :+ name, superTypes(o))
+        ObjectImpl(o.symbol, annotations(o.symbol), o.name.stripModuleClassSuffix.show, collectMembers(rhs),  flags(o), path(o.symbol), superTypes(o))
 
       /** class / case class */
       case c @ TypeDef(n, rhs) if c.symbol.isClass =>

--- a/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
@@ -13,6 +13,9 @@ import dotty.tools.dotc.core.SymDenotations._
 import dotty.tools.dotc.config.Printers.dottydoc
 import dotty.tools.dotc.core.Names.TypeName
 import dotc.ast.Trees._
+import dotc.core.StdNames._
+
+import scala.annotation.tailrec
 
 
 object factories {
@@ -29,9 +32,13 @@ object factories {
       .filter(_ != "interface")
       .filter(_ != "case")
 
-  def path(sym: Symbol)(implicit ctx: Context): List[String] = sym match {
-    case sym if sym.name.decode.toString == "<root>" => Nil
-    case sym => path(sym.owner) :+ sym.name.show
+  def path(sym: Symbol)(implicit ctx: Context): List[String] = {
+    @tailrec def go(sym: Symbol, acc: List[String]): List[String] =
+      if (sym.isRoot)
+        acc
+      else
+        go(sym.owner, sym.name.mangledString :: acc)
+    go(sym, Nil)
   }
 
   def annotations(sym: Symbol)(implicit ctx: Context): List[String] =


### PR DESCRIPTION
Many characters are forbidden in Windows filenames, mangled names are
used for classfiles so they should be safe.

Also make factories#path more efficient.