### PR TITLE
new line after rule heading

### DIFF
--- a/docs/docs/reference/erased-terms.md
+++ b/docs/docs/reference/erased-terms.md
@@ -147,11 +147,10 @@ object Test {
 Rules
 -----
 
-1) The `erased` modifier can appear:
-
-* At the start of a parameter block of a method, function or class
-* In a method definition
-* In a `val` definition (but not `lazy val` or `var`)
+1. The `erased` modifier can appear:
+   * At the start of a parameter block of a method, function or class
+   * In a method definition
+   * In a `val` definition (but not `lazy val` or `var`)
 
 ```scala
 erased val x = ...
@@ -166,43 +165,39 @@ class K(erased x: Int) { ... }
 ```
 
 
-2) A reference to an `erased` definition can only be used
+2. A reference to an `erased` definition can only be used
+   * Inside the expression of argument to an `erased` parameter
+   * Inside the body of an `erased` `val` or `def`
 
-* Inside the expression of argument to an `erased` parameter
-* Inside the body of an `erased` `val` or `def`
 
-
-3) Functions
-
-* `(erased x1: T1, x2: T2, ..., xN: TN) => y : (erased T1, T2, ..., TN) => R`
-* `(implicit erased x1: T1, x2: T2, ..., xN: TN) => y : (implicit erased T1, T2, ..., TN) => R`
-* `implicit erased T1 => R  <:<  erased T1 => R`
-* `(implicit erased T1, T2) => R  <:<  (erased T1, T2) => R`
-*  ...
+3. Functions
+   * `(erased x1: T1, x2: T2, ..., xN: TN) => y : (erased T1, T2, ..., TN) => R`
+   * `(implicit erased x1: T1, x2: T2, ..., xN: TN) => y : (implicit erased T1, T2, ..., TN) => R`
+   * `implicit erased T1 => R  <:<  erased T1 => R`
+   * `(implicit erased T1, T2) => R  <:<  (erased T1, T2) => R`
+   *  ...
 
 Note that there is no subtype relation between `erased T => R` and `T => R` (or `implicit erased T => R` and `implicit T => R`)
 
 
-4) Eta expansion
+4. Eta expansion
 
 if `def f(erased x: T): U` then `f: (erased T) => U`.
 
 
-5) Erasure Semantics
+5. Erasure Semantics
+   * All `erased` paramters are removed from the function
+   * All argument to `erased` paramters are not passed to the function
+   * All `erased` definitions are removed
+   * All `(erased T1, T2, ..., TN) => R` and `(implicit erased T1, T2, ..., TN) => R` become `() => R`
 
-* All `erased` paramters are removed from the function
-* All argument to `erased` paramters are not passed to the function
-* All `erased` definitions are removed
-* All `(erased T1, T2, ..., TN) => R` and `(implicit erased T1, T2, ..., TN) => R` become `() => R`
 
-
-6) Overloading
+6. Overloading
 
 Method with `erased` parameters will follow the normal overloading constraints after erasure.
 
 
-7) Overriding
-
-* Member definitions overidding each other must both be `erased` or not be `erased`
-* `def foo(x: T): U` cannot be overriden by `def foo(erased x: T): U` an viceversa
+7. Overriding
+   * Member definitions overidding each other must both be `erased` or not be `erased`
+   * `def foo(x: T): U` cannot be overriden by `def foo(erased x: T): U` an viceversa
 

--- a/docs/docs/reference/erased-terms.md
+++ b/docs/docs/reference/erased-terms.md
@@ -148,6 +148,7 @@ Rules
 -----
 
 1) The `erased` modifier can appear:
+
 * At the start of a parameter block of a method, function or class
 * In a method definition
 * In a `val` definition (but not `lazy val` or `var`)
@@ -164,11 +165,15 @@ def h(x: erased Int => Int) = ...
 class K(erased x: Int) { ... }
 ```
 
+
 2) A reference to an `erased` definition can only be used
+
 * Inside the expression of argument to an `erased` parameter
 * Inside the body of an `erased` `val` or `def`
 
+
 3) Functions
+
 * `(erased x1: T1, x2: T2, ..., xN: TN) => y : (erased T1, T2, ..., TN) => R`
 * `(implicit erased x1: T1, x2: T2, ..., xN: TN) => y : (implicit erased T1, T2, ..., TN) => R`
 * `implicit erased T1 => R  <:<  erased T1 => R`
@@ -177,20 +182,27 @@ class K(erased x: Int) { ... }
 
 Note that there is no subtype relation between `erased T => R` and `T => R` (or `implicit erased T => R` and `implicit T => R`)
 
+
 4) Eta expansion
+
 if `def f(erased x: T): U` then `f: (erased T) => U`.
 
 
 5) Erasure Semantics
+
 * All `erased` paramters are removed from the function
 * All argument to `erased` paramters are not passed to the function
 * All `erased` definitions are removed
 * All `(erased T1, T2, ..., TN) => R` and `(implicit erased T1, T2, ..., TN) => R` become `() => R`
 
+
 6) Overloading
+
 Method with `erased` parameters will follow the normal overloading constraints after erasure.
 
+
 7) Overriding
+
 * Member definitions overidding each other must both be `erased` or not be `erased`
 * `def foo(x: T): U` cannot be overriden by `def foo(erased x: T): U` an viceversa
 


### PR DESCRIPTION
The list is broken on http://dotty.epfl.ch/docs. I suppose it requires a new line after the rule heading (at least the list in workflow.md has a new line and this one is displayed correctly)