### PR TITLE
fix parameter name in general example description

### DIFF
--- a/docs/docs/reference/dependent-function-types.md
+++ b/docs/docs/reference/dependent-function-types.md
@@ -48,6 +48,6 @@ translates to
     }
 
 where the result type parameter `R'` is an upper approximation of the
-true result type `R` that does not mention any of the parameters `e1, ..., eN`.
+true result type `R` that does not mention any of the parameters `x1, ..., xN`.
 
 


### PR DESCRIPTION
I suppose it should be `x1` and `xN` instead of `e1` and `eN` but maybe I misunderstand something because I don't see why only an upper approximation is possible.