### PR TITLE
Do not create multiple SymDenotation chains for the same symbol

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3481,10 +3481,9 @@ object Types {
     }
 
     def appliedRef(implicit ctx: Context): Type = {
-      def clsDenot = if (prefix eq cls.owner.thisType) cls.denot else cls.denot.copySymDenotation(info = this)
       if (appliedRefCache == null)
         appliedRefCache =
-          TypeRef(prefix, cls.name, clsDenot).appliedTo(cls.typeParams.map(_.typeRef))
+          TypeRef(prefix, cls).appliedTo(cls.typeParams.map(_.typeRef))
       appliedRefCache
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -65,7 +65,7 @@ class TreeChecker extends Phase with SymTransformer {
   def testDuplicate(sym: Symbol, registry: mutable.Map[String, Symbol], typ: String)(implicit ctx: Context) = {
     val name = sym.fullName.mangledString
     if (this.flatClasses && registry.contains(name))
-        printError(s"$typ defined twice $sym ${sym.id} ${registry(name).id}")
+        assert(false, s"$typ defined twice $sym ${sym.id} ${registry(name).id}")
     registry(name) = sym
   }
 


### PR DESCRIPTION
This allows us to turn the TreeChecker duplicate error message into a
fatal error.