### PR TITLE
Fix #4194: only enable research plugins on experimental compiler versions

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -56,7 +56,7 @@ trait PropertiesTrait {
   def scalaPropOrElse(name: String, alt: String): String = scalaProps.getProperty(name, alt)
   def scalaPropOrEmpty(name: String): String             = scalaPropOrElse(name, "")
   def scalaPropOrNone(name: String): Option[String]      = Option(scalaProps.getProperty(name))
-  
+
   /** Either the development or release version if known, otherwise
    *  the empty string.
    */
@@ -73,7 +73,15 @@ trait PropertiesTrait {
       } else ""
     }
   }
-  
+
+  /** Whether the current version of compiler is experimental
+   *
+   *  1. Snapshot and nightly releases are experimental.
+   *  2. Features supported by experimental versions of the compiler:
+   *     - research plugins
+   */
+  val experimental = versionString.contains("SNAPSHOT") || versionString.contains("NIGHTLY")
+
   val copyrightString       = scalaPropOrElse("copyright.string", "(c) 2002-2017 LAMP/EPFL")
 
   /** This is the encoding to use reading in source files, overridden with -encoding

--- a/compiler/src/dotty/tools/dotc/plugins/Plugin.scala
+++ b/compiler/src/dotty/tools/dotc/plugins/Plugin.scala
@@ -29,7 +29,7 @@ sealed trait Plugin {
    *  Research plugin receives a phase plan and return a new phase plan, while
    *  non-research plugin returns a list of phases to be inserted.
    */
-  def research: Boolean = isInstanceOf[ResearchPlugin]
+  def isResearch: Boolean = isInstanceOf[ResearchPlugin]
 
   /** A description of this plugin's options, suitable as a response
    *  to the -help command-line option.  Conventionally, the options

--- a/compiler/src/dotty/tools/dotc/plugins/Plugins.scala
+++ b/compiler/src/dotty/tools/dotc/plugins/Plugins.scala
@@ -3,7 +3,7 @@ package plugins
 
 import core._
 import Contexts._
-import config.PathResolver
+import config.{ PathResolver, Properties }
 import dotty.tools.io._
 import Phases._
 import config.Printers.plugins.{ println => debug }
@@ -128,7 +128,12 @@ trait Plugins {
     val updatedPlan = Plugins.schedule(plan, pluginPhases)
 
     // add research plugins
-    plugins.collect { case p: ResearchPlugin => p }.foldRight(updatedPlan) { (plug, plan) => plug.init(options(plug), plan) }
+    if (Properties.experimental)
+      plugins.collect { case p: ResearchPlugin => p }.foldRight(updatedPlan) {
+        (plug, plan) => plug.init(options(plug), plan)
+      }
+    else
+      updatedPlan
   }
 }
 


### PR DESCRIPTION
Fix #4194: only enable research plugins on experimental compiler versions