### PR TITLE
Fix #4225: always check redundant cases except for @unchecked

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -33,11 +33,8 @@ class PatternMatcher extends MiniPhase {
 
     // check exhaustivity and unreachability
     val engine = new patmat.SpaceEngine
-
-    if (engine.checkable(tree)) {
-      engine.checkExhaustivity(tree)
-      engine.checkRedundancy(tree)
-    }
+    engine.checkExhaustivity(tree)
+    engine.checkRedundancy(tree)
 
     translated.ensureConforms(tree.tpe)
   }

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -839,7 +839,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     flatten(s).map(doShow(_, false)).distinct.mkString(", ")
   }
 
-  def checkable(tree: Match): Boolean = {
+  private def exhaustivityCheckable(sel: Tree): Boolean = {
     // Possible to check everything, but be compatible with scalac by default
     def isCheckable(tp: Type): Boolean =
       !tp.hasAnnotation(defn.UncheckedAnnot) && {
@@ -857,9 +857,8 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         (defn.isTupleType(tpw) && tpw.argInfos.exists(isCheckable(_)))
       }
 
-    val Match(sel, cases) = tree
     val res = isCheckable(sel.tpe)
-    debug.println(s"checkable: ${sel.show} = $res")
+    debug.println(s"exhaustivity checkable: ${sel.show} = $res")
     res
   }
 
@@ -877,6 +876,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     val Match(sel, cases) = _match
     val selTyp = sel.tpe.widen.dealias
 
+    if (!exhaustivityCheckable(sel)) return
 
     val patternSpace = cases.map({ x =>
       val space = project(x.pat)
@@ -894,10 +894,14 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
       ctx.warning(PatternMatchExhaustivity(show(Or(uncovered))), sel.pos)
   }
 
+  private def redundancyCheckable(sel: Tree): Boolean =
+    !sel.tpe.hasAnnotation(defn.UncheckedAnnot)
+
   def checkRedundancy(_match: Match): Unit = {
     val Match(sel, cases) = _match
-    // ignore selector type for now
     val selTyp = sel.tpe.widen.dealias
+
+    if (!redundancyCheckable(sel)) return
 
     (0 until cases.length).foreach { i =>
       // in redundancy check, take guard as false in order to soundly approximate

--- a/tests/patmat/i4225.check
+++ b/tests/patmat/i4225.check
@@ -1,0 +1,1 @@
+10: Match case Unreachable

--- a/tests/patmat/i4225.scala
+++ b/tests/patmat/i4225.scala
@@ -1,0 +1,12 @@
+object Bar {
+  def unapply(x: Int): Some[Int] =
+    Some(0)
+}
+
+object Test {
+  def test(x: Int) =
+    x match {
+      case Bar(a) => a
+      case _ => x // should be unreachable
+    }
+}


### PR DESCRIPTION
Fix #4225: always check redundant cases except for @unchecked