### PR TITLE
Fix #4198: correctly enter pattern symbols in TreeChecker

### DIFF
--- a/tests/pos/i4198.scala
+++ b/tests/pos/i4198.scala
@@ -1,0 +1,15 @@
+class Foo {
+  def foo(x: Any): Unit = {
+    x match {
+      case y: Bar[_] =>
+        y.value match {
+          case value: Bar[_] => // here x is an instance of Bar[Bar[_]]
+          case _ =>
+        }
+    }
+  }
+}
+
+class Bar[T] {
+  def value: T = ???
+}


### PR DESCRIPTION
Fix #4198: correctly enter pattern symbols in TreeChecker

Previously `BOUNDTYPE_ANNOT` are ignored. `TreeInfo.patVars` already
handles all such cases, thus can be used for free.