### PR TITLE
Unpickle quotes with the destination context

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -147,7 +147,9 @@ object StdNames {
     val COMPANION_CLASS_METHOD: N     = "companion$class"
     val BOUNDTYPE_ANNOT: N            = "$boundType$"
     val QUOTE: N                      = "'"
-    val TYPE_QUOTE: N                = "type_'"
+    val TYPE_QUOTE: N                 = "type_'"
+    val PICKLED_QUOTE: N              = "$quote"
+    val PICKLED_TYPE_QUOTE: N         = "$typeQuote"
     val TRAIT_SETTER_SEPARATOR: N     = str.TRAIT_SETTER_SEPARATOR
 
     // value types (and AnyRef) are all used as terms as well

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -709,9 +709,12 @@ class TreeUnpickler(reader: TastyReader,
         if (noRhs(end)) EmptyTree
         else readLater(end, rdr => ctx => rdr.readTerm()(ctx))
 
-      def ValDef(tpt: Tree) =
-        ta.assignType(untpd.ValDef(sym.name.asTermName, tpt, readRhs(localCtx)), sym)
-
+      def ValDef(tpt: Tree) = {
+        val ctx2 =
+          if (sym.name != nme.PICKLED_QUOTE && sym.name != nme.PICKLED_TYPE_QUOTE) localCtx
+          else ctx.outer // Unpickle rhs with quote destination context. See PickledQuotes.{unpickleExpr|unpickleType}
+        ta.assignType(untpd.ValDef(sym.name.asTermName, tpt, readRhs(ctx2)), sym)
+      }
       def DefDef(tparams: List[TypeDef], vparamss: List[List[ValDef]], tpt: Tree) =
          ta.assignType(
             untpd.DefDef(sym.name.asTermName, tparams, vparamss, tpt, readRhs(localCtx)),

--- a/tests/run-with-compiler/quote-owners-2.check
+++ b/tests/run-with-compiler/quote-owners-2.check
@@ -1,0 +1,14 @@
+3
+{
+  def ff: Int = 
+    {
+      val a: List[Int] = 
+        {
+          type T = List[Int]
+          val b: T = Nil.::[Int](3)
+          b: List[Int]
+        }
+      a.head: Int
+    }
+  ff: Int
+}

--- a/tests/run-with-compiler/quote-owners-2.scala
+++ b/tests/run-with-compiler/quote-owners-2.scala
@@ -1,0 +1,24 @@
+import quoted._
+import dotty.tools.dotc.quoted.Toolbox._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val q = f(g(Type.IntTag))
+    println(q.run)
+    println(q.show)
+  }
+
+  def f(t: Type[List[Int]]): Expr[Int] = '{
+    def ff: Int = {
+      val a: ~t = {
+        type T = ~t
+        val b: T = 3 :: Nil
+        b
+      }
+      a.head
+    }
+    ff
+  }
+
+  def g[T](a: Type[T]): Type[List[T]] = '[List[~a]]
+}

--- a/tests/run-with-compiler/quote-owners.check
+++ b/tests/run-with-compiler/quote-owners.check
@@ -1,0 +1,9 @@
+9
+{
+  def ff: Int = 
+    {
+      val a: Int = 9
+      a.+(0)
+    }
+  ff: Int
+}

--- a/tests/run-with-compiler/quote-owners.scala
+++ b/tests/run-with-compiler/quote-owners.scala
@@ -1,0 +1,22 @@
+import quoted._
+import dotty.tools.dotc.quoted.Toolbox._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val q = f
+    println(q.run)
+    println(q.show)
+  }
+
+  def f: Expr[Int] = '{
+    def ff: Int = {
+      ~g
+    }
+    ff
+  }
+
+  def g: Expr[Int] = '{
+    val a = 9
+    a + 0
+  }
+}


### PR DESCRIPTION
This avoids exponential traversal of the tree due to owner changes
of the dummy valdefs for the contents of quote.