### PR TITLE
Fix #4225: always do reachability check

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -429,7 +429,6 @@ object desugar {
         }
         val hasRepeatedParam = constrVparamss.exists(_.exists {
           case ValDef(_, tpt, _) => isRepeated(tpt)
-          case _ => false
         })
         if (mods.is(Abstract) || hasRepeatedParam) Nil  // cannot have default arguments for repeated parameters, hence copy method is not issued
         else {

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -490,8 +490,6 @@ class PlainPrinter(_ctx: Context) extends Printer {
             Text()
 
         nodeName ~ "(" ~ elems ~ tpSuffix ~ ")" ~ (Str(node.pos.toString) provided ctx.settings.YprintPos.value)
-      case _ =>
-        tree.fallbackToText(this)
     }
   }.close // todo: override in refined printer
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -473,24 +473,21 @@ class PlainPrinter(_ctx: Context) extends Printer {
     ("Scope{" ~ dclsText(sc.toList) ~ "}").close
 
   def toText[T >: Untyped](tree: Tree[T]): Text = {
-    tree match {
-      case node: Positioned =>
-        def toTextElem(elem: Any): Text = elem match {
-          case elem: Showable => elem.toText(this)
-          case elem: List[_] => "List(" ~ Text(elem map toTextElem, ",") ~ ")"
-          case elem => elem.toString
-        }
-        val nodeName = node.productPrefix
-        val elems =
-          Text(node.productIterator.map(toTextElem).toList, ", ")
-        val tpSuffix =
-          if (ctx.settings.XprintTypes.value && tree.hasType)
-            " | " ~ toText(tree.typeOpt)
-          else
-            Text()
-
-        nodeName ~ "(" ~ elems ~ tpSuffix ~ ")" ~ (Str(node.pos.toString) provided ctx.settings.YprintPos.value)
+    def toTextElem(elem: Any): Text = elem match {
+      case elem: Showable => elem.toText(this)
+      case elem: List[_] => "List(" ~ Text(elem map toTextElem, ",") ~ ")"
+      case elem => elem.toString
     }
+    val nodeName = tree.productPrefix
+    val elems =
+      Text(tree.productIterator.map(toTextElem).toList, ", ")
+    val tpSuffix =
+      if (ctx.settings.XprintTypes.value && tree.hasType)
+        " | " ~ toText(tree.typeOpt)
+      else
+        Text()
+
+    nodeName ~ "(" ~ elems ~ tpSuffix ~ ")" ~ (Str(tree.pos.toString) provided ctx.settings.YprintPos.value)
   }.close // todo: override in refined printer
 
   def toText(result: SearchResult): Text = result match {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -128,6 +128,7 @@ public enum ErrorMessageID {
     ParamsNoInlineID,
     JavaSymbolIsNotAValueID,
     DoubleDeclarationID,
+    MatchCaseOnlyNullWarningID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -909,8 +909,15 @@ object messages {
 
   case class MatchCaseUnreachable()(implicit ctx: Context)
   extends Message(MatchCaseUnreachableID) {
-    val kind = s"""Match ${hl"case"} Unreachable"""
+    val kind = s"""Match case Unreachable"""
     val msg = "unreachable code"
+    val explanation = ""
+  }
+
+  case class MatchCaseOnlyNullWarning()(implicit ctx: Context)
+  extends Message(MatchCaseOnlyNullWarningID) {
+    val kind = s"""Only null matched"""
+    val msg = s"Only ${hl"null"} is matched. Consider use `case null =>` instead."
     val explanation = ""
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -909,15 +909,15 @@ object messages {
 
   case class MatchCaseUnreachable()(implicit ctx: Context)
   extends Message(MatchCaseUnreachableID) {
-    val kind = s"""Match case Unreachable"""
+    val kind = "Match case Unreachable"
     val msg = "unreachable code"
     val explanation = ""
   }
 
   case class MatchCaseOnlyNullWarning()(implicit ctx: Context)
   extends Message(MatchCaseOnlyNullWarningID) {
-    val kind = s"""Only null matched"""
-    val msg = s"Only ${hl"null"} is matched. Consider use `case null =>` instead."
+    val kind = "Only null matched"
+    val msg = s"Only ${hl"null"} is matched. Consider using `case null =>` instead."
     val explanation = ""
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -910,7 +910,7 @@ object messages {
   case class MatchCaseUnreachable()(implicit ctx: Context)
   extends Message(MatchCaseUnreachableID) {
     val kind = "Match case Unreachable"
-    val msg = "unreachable code"
+    val msg = "unreachable case"
     val explanation = ""
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -33,11 +33,8 @@ class PatternMatcher extends MiniPhase {
 
     // check exhaustivity and unreachability
     val engine = new patmat.SpaceEngine
-
-    if (engine.checkable(tree)) {
-      engine.checkExhaustivity(tree)
-      engine.checkRedundancy(tree)
-    }
+    engine.checkExhaustivity(tree)
+    engine.checkRedundancy(tree)
 
     translated.ensureConforms(tree.tpe)
   }

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -86,7 +86,6 @@ object Splicer {
          """.stripMargin
         ctx.error(msg, pos)
         None
-      case ex: Throwable => throw ex
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -921,6 +921,11 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         else Empty
       }.reduce((a, b) => Or(List(a, b)))
 
+    def isNull(tree: Tree): Boolean = tree match {
+      case Literal(Constant(null)) => true
+      case _ => false
+    }
+
     (1 until cases.length).foreach { i =>
       val prevs = projectPrevCases(cases.take(i))
 
@@ -944,7 +949,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         }
 
         // if last case is `_` and only matches `null`, produce a warning
-        if (i == cases.length - 1) {
+        if (i == cases.length - 1 && !isNull(pat) ) {
           simplify(minus(covered, prevs)) match {
             case Typ(ConstantType(Constant(null)), _) =>
               ctx.warning(MatchCaseOnlyNullWarning(), pat.pos)

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -951,7 +951,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         // if last case is `_` and only matches `null`, produce a warning
         if (i == cases.length - 1 && !isNull(pat) ) {
           simplify(minus(covered, prevs)) match {
-            case Typ(ConstantType(Constant(null)), _) =>
+            case Typ(`nullType`, _) =>
               ctx.warning(MatchCaseOnlyNullWarning(), pat.pos)
             case _ =>
           }

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -379,7 +379,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
   /** Is `tp1` a subtype of `tp2`?  */
   def isSubType(tp1: Type, tp2: Type): Boolean = {
-    val res = tp1 <:< tp2 && (tp1 != nullType || tp2 == nullType)
+    val res = (tp1 != nullType || tp2 == nullType) && tp1 <:< tp2
     debug.println(s"${tp1.show} <:< ${tp2.show} = $res")
     res
   }

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -299,7 +299,10 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
     debug.println(s"atomic intersection: ${and.show} = ${res}")
 
-    if (res) Typ(and, true) else Empty
+    if (!res) Empty
+    else if (tp1.isSingleton) Typ(tp1, true)
+    else if (tp2.isSingleton) Typ(tp2, true)
+    else Typ(and, true)
   }
 
   /** Whether the extractor is irrefutable */

--- a/tests/patmat/andtype-opentype-interaction.check
+++ b/tests/patmat/andtype-opentype-interaction.check
@@ -2,6 +2,5 @@
 27: Pattern Match Exhaustivity: _: SealedAbstractClass & OpenTrait & OpenTrait2, _: SealedClass & OpenTrait & OpenTrait2, _: SealedTrait & OpenTrait & OpenTrait2, _: AbstractClass & OpenTrait & OpenTrait2, _: Clazz & OpenTrait & OpenTrait2, _: Trait & OpenTrait & OpenTrait2
 31: Pattern Match Exhaustivity: _: SealedTrait & OpenClass, _: Trait & OpenClass
 35: Pattern Match Exhaustivity: _: SealedTrait & OpenTrait & OpenClass, _: Trait & OpenTrait & OpenClass
-40: Match case Unreachable
 43: Pattern Match Exhaustivity: _: SealedTrait & OpenAbstractClass, _: Trait & OpenAbstractClass
 47: Pattern Match Exhaustivity: _: SealedTrait & OpenClass & OpenTrait & OpenClassSubclass, _: Trait & OpenClass & OpenTrait & OpenClassSubclass

--- a/tests/patmat/andtype-refinedtype-interaction.check
+++ b/tests/patmat/andtype-refinedtype-interaction.check
@@ -1,9 +1,6 @@
 32: Pattern Match Exhaustivity: _: Trait & C1{x: Int}
-37: Match case Unreachable
-43: Match case Unreachable
 48: Pattern Match Exhaustivity: _: Clazz & (C1 | C2 | T1){x: Int} & (C3 | C4 | T2){x: Int}, _: Trait & (C1 | C2 | T1){x: Int} & (C3 | C4 | T2){x: Int}
 54: Pattern Match Exhaustivity: _: Trait & (C1 | C2 | T1){x: Int} & C3{x: Int}
-60: Match case Unreachable
 65: Pattern Match Exhaustivity: _: Trait & (C1 | C2){x: Int} & (C3 | SubC1){x: Int}
 72: Pattern Match Exhaustivity: _: Trait & (T1 & (C1 | SubC2)){x: Int} & (T2 & (C2 | C3 | SubC1)){x: Int} &
   SubSubC1{x: Int}

--- a/tests/patmat/byte.check
+++ b/tests/patmat/byte.check
@@ -1,0 +1,1 @@
+5: Match case Unreachable

--- a/tests/patmat/byte.scala
+++ b/tests/patmat/byte.scala
@@ -1,0 +1,7 @@
+class Test {
+  def foo(x: Byte) = x match {
+    case 23 =>
+    case 33 =>
+    case _  =>
+  }
+}

--- a/tests/patmat/byte.scala
+++ b/tests/patmat/byte.scala
@@ -2,6 +2,7 @@ class Test {
   def foo(x: Byte) = x match {
     case 23 =>
     case 33 =>
+    case 33 =>
     case _  =>
   }
 }

--- a/tests/patmat/file.scala
+++ b/tests/patmat/file.scala
@@ -1,0 +1,15 @@
+abstract class AbstractFile
+class PlainFile(path: String) extends AbstractFile
+class VirtualFile(name: String) extends AbstractFile
+abstract class ZipArchive(path: String) extends AbstractFile {
+  sealed abstract class Entry(name: String) extends VirtualFile(name)
+  class DirEntry(path: String) extends Entry(path)
+}
+
+object Test {
+  def foo(file: AbstractFile) =  file match {
+    case ze: ZipArchive#Entry =>
+    case pf: PlainFile =>
+    case _ =>
+  }
+}

--- a/tests/patmat/i2253.check
+++ b/tests/patmat/i2253.check
@@ -1,5 +1,3 @@
 28: Pattern Match Exhaustivity: HasIntXIntM, HasIntXStringM
 29: Pattern Match Exhaustivity: HasIntXIntM
-29: Match case Unreachable
 30: Pattern Match Exhaustivity: HasIntXIntM
-30: Match case Unreachable

--- a/tests/patmat/i4225.check
+++ b/tests/patmat/i4225.check
@@ -1,0 +1,1 @@
+10: Match case Unreachable

--- a/tests/patmat/i4225.scala
+++ b/tests/patmat/i4225.scala
@@ -1,0 +1,12 @@
+object Bar {
+  def unapply(x: Int): Some[Int] =
+    Some(0)
+}
+
+object Test {
+  def test(x: Int) =
+    x match {
+      case Bar(a) => a
+      case _ => x // should be unreachable
+    }
+}

--- a/tests/patmat/i4225b.check
+++ b/tests/patmat/i4225b.check
@@ -1,0 +1,1 @@
+10: Only null matched

--- a/tests/patmat/i4225b.scala
+++ b/tests/patmat/i4225b.scala
@@ -1,0 +1,12 @@
+object Bar {
+  def unapply(x: String): Some[Int] =
+    Some(0)
+}
+
+object Test {
+  def test(x: String) =
+    x match {
+      case Bar(a) => a
+      case _ => x // this case is reachable, i.e. test(null)
+    }
+}

--- a/tests/patmat/i4225c.scala
+++ b/tests/patmat/i4225c.scala
@@ -1,0 +1,12 @@
+object Bar {
+  def unapply(x: String): Some[Int] =
+    Some(0)
+}
+
+object Test {
+  def test(x: String) =
+    x match {
+      case Bar(a) => a
+      case null => x
+    }
+}

--- a/tests/patmat/identifier.scala
+++ b/tests/patmat/identifier.scala
@@ -1,0 +1,11 @@
+trait Type
+case class TermParamRef(binder: Type, index: Int) extends Type
+case class TypeRef(prefix: Type, name: String) extends Type
+
+class LambdaType extends Type { thisLambdaType =>
+  def foo(tp: Type): Unit = tp match {
+    case TermParamRef(`thisLambdaType`, _) =>
+    case tp: TypeRef =>
+    case _ =>
+  }
+}

--- a/tests/patmat/null.check
+++ b/tests/patmat/null.check
@@ -1,2 +1,4 @@
 6: Match case Unreachable
+13: Only null matched
 18: Match case Unreachable
+20: Only null matched

--- a/tests/patmat/null.check
+++ b/tests/patmat/null.check
@@ -1,0 +1,2 @@
+6: Match case Unreachable
+18: Match case Unreachable

--- a/tests/patmat/null.scala
+++ b/tests/patmat/null.scala
@@ -1,0 +1,22 @@
+class Test {
+  def foo(x: Option[Int]) = x match {
+    case Some(x) =>
+    case None    =>
+    case null    =>     // don't produce warning here
+    case _       =>
+  }
+
+  def bar(x: Option[String]) = x match {
+    case Some(a: String)        =>
+    case Some(null)     =>
+    case None           =>
+    case y              =>
+  }
+
+  def quux(x: Option[String]) = x match {
+    case Some(a)        =>
+    case Some(null)     =>
+    case None           =>
+    case y              =>
+  }
+}

--- a/tests/patmat/reader.check
+++ b/tests/patmat/reader.check
@@ -1,0 +1,1 @@
+8: Match case Unreachable

--- a/tests/patmat/reader.scala
+++ b/tests/patmat/reader.scala
@@ -5,6 +5,7 @@ class Test {
     case 'a' | 'A' =>
     case 's' | 'S' =>
     case 'r' | 'R' =>
+    case 'r' =>
     case _ =>
   }
 }

--- a/tests/patmat/reader.scala
+++ b/tests/patmat/reader.scala
@@ -1,0 +1,10 @@
+import java.io.BufferedReader
+
+class Test {
+  def loop(reader: BufferedReader): Unit = reader.read match {
+    case 'a' | 'A' =>
+    case 's' | 'S' =>
+    case 'r' | 'R' =>
+    case _ =>
+  }
+}

--- a/tests/patmat/try2.scala
+++ b/tests/patmat/try2.scala
@@ -1,0 +1,7 @@
+import scala.util.control.NonFatal
+
+object Test {
+  try 2/0 catch {
+    case NonFatal(ex) =>
+  }
+}

--- a/tests/pos-special/isInstanceOf/3324d.scala
+++ b/tests/pos-special/isInstanceOf/3324d.scala
@@ -3,6 +3,6 @@ class Test {
 
   x match {
     case _: List[Int @unchecked] => 5
-    case _: List[Int] @unchecked => 5
+    case _: Option[Int] @unchecked => 5
   }
 }

--- a/tests/pos-special/isInstanceOf/3324h.scala
+++ b/tests/pos-special/isInstanceOf/3324h.scala
@@ -2,7 +2,7 @@ object Test {
   trait Marker
   def foo[T](x: T) = x match {
     case _: (T & Marker)       => // no warning
-    case _: T with Marker      => // scalac emits a warning
+    case _: T with String      => // scalac emits a warning
     case _ =>
   }
 }


### PR DESCRIPTION
Fix #4225 

- always do reachability check
- handle null in patterns

Note that we only handle null in reachability check, while ignore null in exhaustivity check. Otherwise, the following pattern match will report a warning about `null`, which is annoying:

```Scala
    (Some(3): Option[Int]) match {
       case Some(x) =>
       case None    =>
    }
```