### PR TITLE
Fix reporter reuse in TyperState#test

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
@@ -20,9 +20,7 @@ import diagnostic.messages._
   */
 class StoreReporter(outer: Reporter) extends Reporter {
 
-  private[this] var infos: mutable.ListBuffer[MessageContainer] = null
-
-  def reset() = infos = null
+  protected[this] var infos: mutable.ListBuffer[MessageContainer] = null
 
   def doReport(m: MessageContainer)(implicit ctx: Context): Unit = {
     typr.println(s">>>> StoredError: ${m.message}") // !!! DEBUG


### PR DESCRIPTION
The previous logic was wrong: TyperState#test may be called by the
closure passed to TyperState#test, meaning that the testReporter may
already be in use at that point.