### PR TITLE
Fix #4217: display warnings in repl

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -235,8 +235,8 @@ class ReplDriver(settings: Array[String],
             val newImports = newState.imports ++ extractImports(parsed.trees)
             val newStateWithImports = newState.copy(imports = newImports)
 
-            implicit val ctx: Context = newState.run.runContext
-            displayErrors(newState.run.runContext.flushBufferedMessages())
+            // display warnings
+            displayErrors(newState.run.runContext.flushBufferedMessages())(newState)
 
             displayDefinitions(unit.tpdTree, newestWrapper)(newStateWithImports)
           }

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -235,6 +235,9 @@ class ReplDriver(settings: Array[String],
             val newImports = newState.imports ++ extractImports(parsed.trees)
             val newStateWithImports = newState.copy(imports = newImports)
 
+            implicit val ctx: Context = newState.run.runContext
+            displayErrors(newState.run.runContext.flushBufferedMessages())
+
             displayDefinitions(unit.tpdTree, newestWrapper)(newStateWithImports)
           }
         }

--- a/compiler/test-resources/repl/i4217
+++ b/compiler/test-resources/repl/i4217
@@ -1,0 +1,7 @@
+scala> def foo(x: Option[Int]) = x match { case None => }
+1 | def foo(x: Option[Int]) = x match { case None => }
+  |                           ^
+  |                           match may not be exhaustive.
+  |
+  |                           It would fail on pattern case: Some(_)
+def foo(x: Option[Int]): Unit


### PR DESCRIPTION
Fix #4217: display warnings in repl
