### PR TITLE
Fix #4272: make OrderingConstraint.&.mergeEntries symmetric

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -526,7 +526,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
         case (e1: TypeBounds, _) if e1 contains e2 => e2
         case (tv1: TypeVar, tv2: TypeVar) if tv1.instanceOpt eq tv2.instanceOpt => e1
         case _ =>
-          throw new AssertionError(i"cannot merge $this with $other")
+          throw new AssertionError(i"cannot merge $this with $other, mergeEntries($e1, $e2) failed")
       }
 
     val that = other.asInstanceOf[OrderingConstraint]

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -521,10 +521,10 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
 
     def mergeEntries(e1: Type, e2: Type): Type =
       (e1, e2) match {
+        case _ if e1 eq e2 => e1
         case (e1: TypeBounds, e2: TypeBounds) => e1 & e2
         case (e1: TypeBounds, _) if e1 contains e2 => e2
         case (tv1: TypeVar, tv2: TypeVar) if tv1.instanceOpt eq tv2.instanceOpt => e1
-        case _ if e1 eq e2 => e1
         case _ =>
           throw new AssertionError(i"cannot merge $this with $other")
       }

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -519,23 +519,15 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
     def mergeParams(ps1: List[TypeParamRef], ps2: List[TypeParamRef]) =
       (ps1 /: ps2)((ps1, p2) => if (ps1.contains(p2)) ps1 else p2 :: ps1)
 
-    def mergeEntries(e1: Type, e2: Type): Type = e1 match {
-        case e1: TypeBounds =>
-          e2 match {
-            case e2: TypeBounds => e1 & e2
-            case _ if e1 contains e2 => e2
-            case _ => mergeError
-          }
-        case tv1: TypeVar =>
-          e2 match {
-            case tv2: TypeVar if tv1.instanceOpt eq tv2.instanceOpt => e1
-            case _ => mergeError
-          }
+    def mergeEntries(e1: Type, e2: Type): Type =
+      (e1, e2) match {
+        case (e1: TypeBounds, e2: TypeBounds) => e1 & e2
+        case (e1: TypeBounds, _) if e1 contains e2 => e2
+        case (tv1: TypeVar, tv2: TypeVar) if tv1.instanceOpt eq tv2.instanceOpt => e1
         case _ if e1 eq e2 => e1
-        case _ => mergeError
-    }
-
-    def mergeError = throw new AssertionError(i"cannot merge $this with $other")
+        case _ =>
+          throw new AssertionError(i"cannot merge $this with $other")
+      }
 
     val that = other.asInstanceOf[OrderingConstraint]
     new OrderingConstraint(

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -519,11 +519,13 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
     def mergeParams(ps1: List[TypeParamRef], ps2: List[TypeParamRef]) =
       (ps1 /: ps2)((ps1, p2) => if (ps1.contains(p2)) ps1 else p2 :: ps1)
 
+    // Must be symmetric
     def mergeEntries(e1: Type, e2: Type): Type =
       (e1, e2) match {
         case _ if e1 eq e2 => e1
         case (e1: TypeBounds, e2: TypeBounds) => e1 & e2
         case (e1: TypeBounds, _) if e1 contains e2 => e2
+        case (_, e2: TypeBounds) if e2 contains e1 => e1
         case (tv1: TypeVar, tv2: TypeVar) if tv1.instanceOpt eq tv2.instanceOpt => e1
         case _ =>
           throw new AssertionError(i"cannot merge $this with $other, mergeEntries($e1, $e2) failed")

--- a/tests/neg/i4272.scala
+++ b/tests/neg/i4272.scala
@@ -1,0 +1,5 @@
+object Main {
+  def f(m: Map[String, Boolean]) = {}
+  println(f(Map('a' -> true)))  // error
+  println(this.f(Map('a' -> true)))  // error
+}


### PR DESCRIPTION
Fix #4272.
Debugging revealed that in the failing testcase `e2: TypeBounds` while `e1:
TypeRef`, and it's not clear why it should be otherwise.

Other fixes are possible, this one is easy to maintain but will repeat a few
checks.