### PR TITLE
Fix #3653: generic Java signature of FunctionXXL

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -127,6 +127,9 @@ object GenericSignatures {
         case ref @ TypeParamRef(_: PolyType, _) =>
           typeParamSig(ref.paramName.lastPart)
 
+        case RefOrAppliedType(sym, _, _) if defn.isXXLFunctionClass(sym) =>
+          jsig(defn.FunctionXXLType, toplevel, primitiveOK)
+
         case RefOrAppliedType(sym, pre, args) =>
           def argSig(tp: Type): Unit =
             tp match {

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -127,9 +127,6 @@ object GenericSignatures {
         case ref @ TypeParamRef(_: PolyType, _) =>
           typeParamSig(ref.paramName.lastPart)
 
-        case RefOrAppliedType(sym, _, _) if defn.isXXLFunctionClass(sym) =>
-          jsig(defn.FunctionXXLType, toplevel, primitiveOK)
-
         case RefOrAppliedType(sym, pre, args) =>
           def argSig(tp: Type): Unit =
             tp match {
@@ -215,6 +212,8 @@ object GenericSignatures {
             else
               jsig(unboxedSeen, toplevel, primitiveOK)
           }
+          else if (defn.isXXLFunctionClass(sym))
+            jsig(defn.FunctionXXLType, toplevel, primitiveOK)
           else if (sym.isClass)
             classSig
           else

--- a/tests/generic-java-signatures/i3653.check
+++ b/tests/generic-java-signatures/i3653.check
@@ -1,0 +1,1 @@
+public <T> scala.FunctionXXL Foo.bar()

--- a/tests/generic-java-signatures/i3653.scala
+++ b/tests/generic-java-signatures/i3653.scala
@@ -1,0 +1,13 @@
+class Foo {
+  def bar[T] =
+    (a0: T, a1: T, a2: T, a3: T, a4: T, a5: T, a6: T, a7: T, a8: T, a9: T,
+     b0: T, b1: T, b2: T, b3: T, b4: T, b5: T, b6: T, b7: T, b8: T, b9: T,
+     c0: T, c1: T, c2: T, c3: T, c4: T, c5: T, c6: T, c7: T, c8: T, c9: T) => 0
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val meth = classOf[Foo].getDeclaredMethod("bar")
+    println(meth.toGenericString)
+  }
+}


### PR DESCRIPTION
We were encoding the generic Java signature of `FunctionN`s' with more
than P parameters as `FunctionP<..params..>` (which doesn't exist), but
in the bytecode, FunctionXXL is used instead.

This commit fixes that, so that the generic signature matches
`FunctionXXL`.

Fixes #3653