### PR TITLE
Let VSCode start the language server

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -980,14 +980,13 @@ object Build {
         val defaultIDEConfig = baseDirectory.value / "out" / "default-dotty-ide-config"
         IO.write(defaultIDEConfig, dottyVersion)
         val dottyPluginSbtFile = baseDirectory.value / "out" / "dotty-plugin.sbt"
-        IO.write(dottyPluginSbtFile, s"""addSbtPlugin("$dottyOrganization" % $sbtDottyName % "$sbtDottyVersion")""")
+        IO.write(dottyPluginSbtFile, s"""addSbtPlugin("$dottyOrganization" % "$sbtDottyName" % "$sbtDottyVersion")""")
         Seq(defaultIDEConfig, dottyPluginSbtFile)
       },
       compile in Compile := Def.task {
         val workingDir = baseDirectory.value
         val coursier = workingDir / "out" / "coursier"
         val packageJson = workingDir / "package.json"
-        // val _ = (managedResources in Compile).value
         if (!coursier.exists || packageJson.lastModified > coursier.lastModified)
           runProcess(Seq("npm", "install"), wait = true, directory = workingDir)
         val tsc = workingDir / "node_modules" / ".bin" / "tsc"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -53,6 +53,7 @@ object Build {
   }
   val dottyNonBootstrappedVersion = dottyVersion + "-nonbootstrapped"
 
+  val sbtDottyName = "sbt-dotty"
   val sbtDottyVersion = {
     val base = "0.2.3"
     if (isRelease) base else base + "-SNAPSHOT"
@@ -935,6 +936,7 @@ object Build {
   lazy val `sbt-dotty` = project.in(file("sbt-dotty")).
     settings(commonSettings).
     settings(
+      name := sbtDottyName,
       version := sbtDottyVersion,
       // Keep in sync with inject-sbt-dotty.sbt
       libraryDependencies ++= Seq(
@@ -975,9 +977,11 @@ object Build {
       includeFilter in unmanagedSources := NothingFilter | "*.ts" | "**.json",
       watchSources in Global ++= (unmanagedSources in Compile).value,
       resourceGenerators in Compile += Def.task {
-        val out = baseDirectory.value / "out" / "default-dotty-ide-config"
-        IO.writeLines(out, Seq(dottyVersion, sbtDottyVersion))
-        Seq(out)
+        val defaultIDEConfig = baseDirectory.value / "out" / "default-dotty-ide-config"
+        IO.write(defaultIDEConfig, dottyVersion)
+        val dottyPluginSbtFile = baseDirectory.value / "out" / "dotty-plugin.sbt"
+        IO.write(dottyPluginSbtFile, s"""addSbtPlugin("$dottyOrganization" % $sbtDottyName % "$sbtDottyVersion")""")
+        Seq(defaultIDEConfig, dottyPluginSbtFile)
       },
       compile in Compile := Def.task {
         val workingDir = baseDirectory.value

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -51,7 +51,7 @@
     "vscode:prepublish": "npm install && ./node_modules/.bin/tsc -p ./",
     "compile": "./node_modules/.bin/tsc -p ./",
     "test": "node ./node_modules/vscode/bin/test",
-    "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.0.3/coursier && curl -L -o out/load-plugin.jar https://oss.sonatype.org/content/repositories/releases/ch/epfl/scala/load-plugin_2.12/0.1.0+2-496ac670/load-plugin_2.12-0.1.0+2-496ac670.jar"
+    "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.0.3/coursier"
   },
   "extensionDependencies": [
     "daltonjorge.scala"

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -24,6 +24,7 @@
   ],
   "main": "./out/src/extension",
   "activationEvents": [
+    "onLanguage:scala",
     "workspaceContains:.dotty-ide.json"
   ],
   "languages": [
@@ -50,7 +51,7 @@
     "vscode:prepublish": "npm install && ./node_modules/.bin/tsc -p ./",
     "compile": "./node_modules/.bin/tsc -p ./",
     "test": "node ./node_modules/vscode/bin/test",
-    "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.0.3/coursier"
+    "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.0.3/coursier && curl -L -o out/load-plugin.jar https://github.com/scalacenter/load-plugin/releases/download/v0.1.0/load-plugin_2.12-0.1.0.jar"
   },
   "extensionDependencies": [
     "daltonjorge.scala"

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -51,7 +51,7 @@
     "vscode:prepublish": "npm install && ./node_modules/.bin/tsc -p ./",
     "compile": "./node_modules/.bin/tsc -p ./",
     "test": "node ./node_modules/vscode/bin/test",
-    "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.0.3/coursier && curl -L -o out/load-plugin.jar https://github.com/scalacenter/load-plugin/releases/download/v0.1.0/load-plugin_2.12-0.1.0.jar"
+    "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.0.3/coursier && curl -L -o out/load-plugin.jar https://oss.sonatype.org/content/repositories/releases/ch/epfl/scala/load-plugin_2.12/0.1.0+2-496ac670/load-plugin_2.12-0.1.0+2-496ac670.jar"
   },
   "extensionDependencies": [
     "daltonjorge.scala"

--- a/vscode-dotty/src/extension.ts
+++ b/vscode-dotty/src/extension.ts
@@ -16,7 +16,7 @@ export function activate(context: ExtensionContext) {
   extensionContext = context
   outputChannel = vscode.window.createOutputChannel('Dotty Language Client');
 
-  const sbtArtifact = "org.scala-sbt:sbt-launch:1.1.4"
+  const sbtArtifact = "org.scala-sbt:sbt-launch:1.1.5"
   const loadPluginArtifact = "ch.epfl.scala:load-plugin_2.12:0.1.0+2-496ac670"
   const languageServerArtifactFile = `${vscode.workspace.rootPath}/.dotty-ide-artifact`
   const languageServerDefaultConfigFile = path.join(extensionContext.extensionPath, './out/default-dotty-ide-config')

--- a/vscode-dotty/src/extension.ts
+++ b/vscode-dotty/src/extension.ts
@@ -39,16 +39,23 @@ export function activate(context: ExtensionContext) {
 
   } else {
     // Check whether `.dotty-ide-artifact` exists. If it does, start the language server,
-    // otherwise, try to auto-configure it if there's no build.sbt
+    // otherwise, try propose to start it if there's no build.sbt
     if (fs.existsSync(languageServerArtifactFile)) {
       runLanguageServer(coursierPath, languageServerArtifactFile)
     } else if (!fs.existsSync(buildSbtFile)) {
-      fs.readFile(languageServerDefaultConfigFile, (err, data) => {
-        if (err) throw err
-        else {
-          const [languageServerScalaVersion, sbtDottyVersion] = data.toString().trim().split(/\r?\n/)
-          fetchAndConfigure(coursierPath, sbtArtifact, languageServerScalaVersion, sbtDottyVersion, loadPluginArtifact).then(() => {
-            runLanguageServer(coursierPath, languageServerArtifactFile)
+      vscode.window.showInformationMessage(
+          "This looks like an unconfigured project. Would you like to start Dotty IDE?",
+          "Yes", "No"
+      ).then(choice => {
+        if (choice == "Yes") {
+          fs.readFile(languageServerDefaultConfigFile, (err, data) => {
+            if (err) throw err
+            else {
+              const [languageServerScalaVersion, sbtDottyVersion] = data.toString().trim().split(/\r?\n/)
+              fetchAndConfigure(coursierPath, sbtArtifact, languageServerScalaVersion, sbtDottyVersion, loadPluginArtifact).then(() => {
+                runLanguageServer(coursierPath, languageServerArtifactFile)
+              })
+            }
           })
         }
       })

--- a/vscode-dotty/src/extension.ts
+++ b/vscode-dotty/src/extension.ts
@@ -94,15 +94,21 @@ function configureIDE() {
     title: 'Configuring IDE...'
   }, (progress) => {
 
+      const applyLoadPlugin = "apply -cp " + loadPluginPath + " ch.epfl.scala.loadplugin.LoadPlugin"
+      const ifAbsentCommands = [
+        "if-absent dotty.tools.sbtplugin.DottyPlugin",
+        "\"set every scalaVersion := \\\"0.8.0-bin-SNAPSHOT\\\"\"",
+        "\"load-plugin ch.epfl.lamp:sbt-dotty:0.2.0-SNAPSHOT dotty.tools.sbtplugin.DottyPlugin\"",
+        "\"load-plugin ch.epfl.lamp:sbt-dotty:0.2.0-SNAPSHOT dotty.tools.sbtplugin.DottyIDEPlugin\""
+      ].join(" ")
+
     const sbtPromise =
       cpp.spawn("java", [
           "-jar", coursierPath,
           "launch",
           "org.scala-sbt:sbt-launch:1.1.2", "--",
-          "apply -cp " + loadPluginPath + " ch.epfl.scala.loadplugin.LoadPlugin",
-          "set every scalaVersion := \"0.8.0-bin-SNAPSHOT\"",
-          "load-plugin ch.epfl.lamp:sbt-dotty:0.2.0-SNAPSHOT dotty.tools.sbtplugin.DottyPlugin",
-          "load-plugin ch.epfl.lamp:sbt-dotty:0.2.0-SNAPSHOT dotty.tools.sbtplugin.DottyIDEPlugin",
+          applyLoadPlugin,
+          ifAbsentCommands,
           "configureIDE"
       ])
     const sbtProc = sbtPromise.childProcess


### PR DESCRIPTION
We used to start the language server with `launchIDE`. However, this
means that the language server is dependent of sbt being running and
configured, which is not a good user experience for newcomers.

For newcomers, we want the language server to start when they create a
new Scala file in an empty directory, for instance, which means that no
build is already configured.

~~This commits takes us closer to this experience by using [load-plugin](https://github.com/scalacenter/load-plugin)
to inject the Dotty plugin. This means that the Dotty plugin can now be
loaded even if there's no build configured, which happens if the user
opens VSCode in an empty directory, for instance.~~

We use the recently introduced `--addPluginSbtFile` to provide this experience.