### PR TITLE
Remove Two Warts: Auto-Tupling and Multi-Parameter Infix Operations

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1216,7 +1216,7 @@ object desugar {
    */
   private object IdPattern {
     def unapply(tree: Tree)(implicit ctx: Context): Option[VarInfo] = tree match {
-      case id: Ident => Some(id, TypeTree())
+      case id: Ident => Some((id, TypeTree()))
       case Typed(id: Ident, tpt) => Some((id, tpt))
       case _ => None
     }

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -537,7 +537,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   object closure {
     def unapply(tree: Tree): Option[(List[Tree], Tree, Tree)] = tree match {
       case Block(_, expr) => unapply(expr)
-      case Closure(env, meth, tpt) => Some(env, meth, tpt)
+      case Closure(env, meth, tpt) => Some((env, meth, tpt))
       case Typed(expr, _)  => unapply(expr)
       case _ => None
     }

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1009,8 +1009,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   /** An extractor that pulls out type arguments */
   object MaybePoly {
     def unapply(tree: Tree): Option[(Tree, List[Tree])] = tree match {
-      case TypeApply(tree, targs) => Some(tree, targs)
-      case _ => Some(tree, Nil)
+      case TypeApply(tree, targs) => Some((tree, targs))
+      case _ => Some((tree, Nil))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -878,6 +878,10 @@ class Definitions {
       name.length > prefix.length &&
       name.drop(prefix.length).forall(_.isDigit))
 
+  // Currently unused:
+  /** If `cls` has name s"$prefix$digits" where $digits is a valid integer, that
+   *  that integer, otherwise -1.
+   */
   def arity(cls: Symbol, prefix: String): Int =
     scalaClassName(cls).applySimple(-1) { name =>
       if (name.startsWith(prefix)) {

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -553,7 +553,7 @@ object Denotations {
           val r = mergeDenot(this, that)
           if (r.exists) r else MultiDenotation(this, that)
         case that @ MultiDenotation(denot1, denot2) =>
-          this & (denot1, pre) & (denot2, pre)
+          this .& (denot1, pre) .& (denot2, pre)
       }
     }
 
@@ -634,11 +634,11 @@ object Denotations {
       else if (!that.exists) that
       else this match {
         case denot1 @ MultiDenotation(denot11, denot12) =>
-          denot1.derivedUnionDenotation(denot11 | (that, pre), denot12 | (that, pre))
+          denot1.derivedUnionDenotation(denot11 .| (that, pre), denot12 .| (that, pre))
         case denot1: SingleDenotation =>
           that match {
             case denot2 @ MultiDenotation(denot21, denot22) =>
-              denot2.derivedUnionDenotation(this | (denot21, pre), this | (denot22, pre))
+              denot2.derivedUnionDenotation(this .| (denot21, pre), this .| (denot22, pre))
             case denot2: SingleDenotation =>
               unionDenot(denot1, denot2)
           }
@@ -1180,7 +1180,7 @@ object Denotations {
   final case class DenotUnion(denot1: PreDenotation, denot2: PreDenotation) extends MultiPreDenotation {
     def exists = true
     def toDenot(pre: Type)(implicit ctx: Context) =
-      (denot1 toDenot pre) & (denot2 toDenot pre, pre)
+      (denot1 toDenot pre) .& (denot2 toDenot pre, pre)
     def containsSym(sym: Symbol) =
       (denot1 containsSym sym) || (denot2 containsSym sym)
     type AsSeenFromResult = PreDenotation
@@ -1218,8 +1218,8 @@ object Denotations {
     def hasAltWith(p: SingleDenotation => Boolean): Boolean =
       denot1.hasAltWith(p) || denot2.hasAltWith(p)
     def accessibleFrom(pre: Type, superAccess: Boolean)(implicit ctx: Context): Denotation = {
-      val d1 = denot1 accessibleFrom (pre, superAccess)
-      val d2 = denot2 accessibleFrom (pre, superAccess)
+      val d1 = denot1.accessibleFrom(pre, superAccess)
+      val d2 = denot2.accessibleFrom(pre, superAccess)
       if (!d1.exists) d2
       else if (!d2.exists) d1
       else derivedUnionDenotation(d1, d2)

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -58,6 +58,12 @@ object NameOps {
       case _ => false
     }
 
+    def applySimple[T](default: T)(f: SimpleName => T): T = name match {
+      case name: SimpleName => f(name)
+      case name: TypeName => name.toTermName.applySimple(default)(f)
+      case _ => default
+    }
+
     def likeSpaced(n: PreName): N =
       (if (name.isTermName) n.toTermName else n.toTypeName).asInstanceOf[N]
 
@@ -79,6 +85,11 @@ object NameOps {
           && (n != true_)
           && (n != null_))
       }
+    }
+
+    def isOpName = name match {
+      case name: SimpleName => NameTransformer.encode(name) != name
+      case _ => false
     }
 
     def isOpAssignmentName: Boolean = name match {

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -87,8 +87,10 @@ object NameOps {
       }
     }
 
-    def isOpName = name match {
-      case name: SimpleName => NameTransformer.encode(name) != name
+    /** Is name an operator name that does not start with a letter or `_` or `$`? */
+    def isSymbolic = name match {
+      case name: SimpleName =>
+        !Chars.isIdentifierStart(name.head) && NameTransformer.encode(name) != name
       case _ => false
     }
 

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -121,7 +121,7 @@ object NameOps {
 
     /** If flags is a ModuleClass but not a Package, add module class suffix */
     def adjustIfModuleClass(flags: Flags.FlagSet): N = likeSpaced {
-      if (flags is (ModuleClass, butNot = Package)) name.asTypeName.moduleClassName
+      if (flags.is(ModuleClass, butNot = Package)) name.asTypeName.moduleClassName
       else name.toTermName.exclude(AvoidClashName)
     }
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -190,7 +190,7 @@ object SymDenotations {
      *  in `butNot` are set?
      */
     final def is(fs: FlagSet, butNot: FlagSet)(implicit ctx: Context) =
-      (if (isCurrent(fs) && isCurrent(butNot)) myFlags else flags) is (fs, butNot)
+      (if (isCurrent(fs) && isCurrent(butNot)) myFlags else flags).is(fs, butNot)
 
     /** Has this denotation all of the flags in `fs` set? */
     final def is(fs: FlagConjunction)(implicit ctx: Context) =
@@ -200,7 +200,7 @@ object SymDenotations {
      *  in `butNot` are set?
      */
     final def is(fs: FlagConjunction, butNot: FlagSet)(implicit ctx: Context) =
-      (if (isCurrent(fs) && isCurrent(butNot)) myFlags else flags) is (fs, butNot)
+      (if (isCurrent(fs) && isCurrent(butNot)) myFlags else flags).is(fs, butNot)
 
     /** The type info.
      *  The info is an instance of TypeType iff this is a type denotation
@@ -457,13 +457,13 @@ object SymDenotations {
     /** Is symbol known to not exist, or potentially not completed yet? */
     final def unforcedIsAbsent(implicit ctx: Context): Boolean =
       myInfo == NoType ||
-      (this is (ModuleVal, butNot = Package)) && moduleClass.unforcedIsAbsent
+      (this.is(ModuleVal, butNot = Package)) && moduleClass.unforcedIsAbsent
 
     /** Is symbol known to not exist? */
     final def isAbsent(implicit ctx: Context): Boolean = {
       ensureCompleted()
       (myInfo `eq` NoType) ||
-      (this is (ModuleVal, butNot = Package)) && moduleClass.isAbsent
+      (this.is(ModuleVal, butNot = Package)) && moduleClass.isAbsent
     }
 
     /** Is this symbol the root class or its companion object? */
@@ -921,7 +921,7 @@ object SymDenotations {
      *  A local dummy owner is mapped to the primary constructor of the class.
      */
     final def enclosingMethod(implicit ctx: Context): Symbol =
-      if (this is (Method, butNot = Label)) symbol
+      if (this.is(Method, butNot = Label)) symbol
       else if (this.isClass) primaryConstructor
       else if (this.exists) owner.enclosingMethod
       else NoSymbol
@@ -1352,7 +1352,7 @@ object SymDenotations {
 
     // ----- denotation fields and accessors ------------------------------
 
-    if (initFlags is (Module, butNot = Package))
+    if (initFlags.is(Module, butNot = Package))
       assert(name.is(ModuleClassName), s"module naming inconsistency: ${name.debugString}")
 
     /** The symbol asserted to have type ClassSymbol */

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -17,7 +17,7 @@ import util.Property
 import collection.mutable
 import ast.tpd._
 import reporting.trace
-import reporting.diagnostic.Message
+import reporting.diagnostic.{Message, NoExplanation}
 
 trait TypeOps { this: Context => // TODO: Make standalone object.
 
@@ -313,10 +313,6 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
     hasImport(ctx.withPhase(ctx.typerPhase)) || hasOption
   }
 
-  /** Is auto-tupling enabled? */
-  def canAutoTuple =
-    !featureEnabled(defn.LanguageModuleClass, nme.noAutoTupling)
-
   def scala2Mode =
     featureEnabled(defn.LanguageModuleClass, nme.Scala2)
 
@@ -325,7 +321,8 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
 
   def testScala2Mode(msg: => Message, pos: Position, rewrite: => Unit = ()) = {
     if (scala2Mode) {
-      migrationWarning(msg, pos)
+      migrationWarning(
+        new NoExplanation(msg.msg ++ "\nThis can be fixed automatically using -rewrite"), pos)
       rewrite
     }
     scala2Mode

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -598,7 +598,7 @@ object Types {
             else pdenot.info recoverable_& rinfo
           pdenot.asSingleDenotation.derivedSingleDenotation(pdenot.symbol, jointInfo)
         } else {
-          pdenot & (
+          pdenot .& (
             new JointRefDenotation(NoSymbol, rinfo, Period.allInRun(ctx.runId)),
             pre,
             safeIntersection = ctx.pendingMemberSearches.contains(name))
@@ -643,7 +643,7 @@ object Types {
       }
 
       def goAnd(l: Type, r: Type) = {
-        go(l) & (go(r), pre, safeIntersection = ctx.pendingMemberSearches.contains(name))
+        go(l) .& (go(r), pre, safeIntersection = ctx.pendingMemberSearches.contains(name))
       }
 
       val recCount = ctx.findMemberCount
@@ -980,7 +980,7 @@ object Types {
           case res => res
         }
       case tp @ AndType(tp1, tp2) =>
-        tp derived_& (tp1.widenUnion, tp2.widenUnion)
+        tp.derived_&(tp1.widenUnion, tp2.widenUnion)
       case tp: RefinedType =>
         tp.derivedRefinedType(tp.parent.widenUnion, tp.refinedName, tp.refinedInfo)
       case tp: RecType =>

--- a/compiler/src/dotty/tools/dotc/reporting/UniqueMessagePositions.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/UniqueMessagePositions.scala
@@ -21,7 +21,7 @@ trait UniqueMessagePositions extends Reporter {
       m.pos.exists && {
         var shouldHide = false
         for (pos <- m.pos.start to m.pos.end) {
-          positions get (ctx.source, pos) match {
+          positions.get((ctx.source, pos)) match {
             case Some(level) if level >= m.level => shouldHide = true
             case _ => positions((ctx.source, pos)) = m.level
           }

--- a/compiler/src/dotty/tools/dotc/reporting/trace.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/trace.scala
@@ -9,40 +9,40 @@ import core.Mode
 
 object trace {
 
-  @inline
+  @`inline`
   def onDebug[TD](question: => String)(op: => TD)(implicit ctx: Context): TD =
     conditionally(ctx.settings.YdebugTrace.value, question, false)(op)
 
-  @inline
+  @`inline`
   def conditionally[TC](cond: Boolean, question: => String, show: Boolean)(op: => TC)(implicit ctx: Context): TC = {
     def op1 = op
     if (Config.tracingEnabled && cond) apply[TC](question, Printers.default, show)(op1)
     else op1
   }
 
-  @inline
+  @`inline`
   def apply[T](question: => String, printer: Printers.Printer, showOp: Any => String)(op: => T)(implicit ctx: Context): T = {
     def op1 = op
     if (!Config.tracingEnabled || printer.eq(config.Printers.noPrinter)) op1
     else doTrace[T](question, printer, showOp)(op1)
   }
 
-  @inline
+  @`inline`
   def apply[T](question: => String, printer: Printers.Printer, show: Boolean)(op: => T)(implicit ctx: Context): T = {
     def op1 = op
     if (!Config.tracingEnabled || printer.eq(config.Printers.noPrinter)) op1
     else doTrace[T](question, printer, if (show) showShowable(_) else alwaysToString)(op1)
   }
 
-  @inline
+  @`inline`
   def apply[T](question: => String, printer: Printers.Printer)(op: => T)(implicit ctx: Context): T =
     apply[T](question, printer, false)(op)
 
-  @inline
+  @`inline`
   def apply[T](question: => String, show: Boolean)(op: => T)(implicit ctx: Context): T =
     apply[T](question, Printers.default, show)(op)
 
-  @inline
+  @`inline`
   def apply[T](question: => String)(op: => T)(implicit ctx: Context): T =
     apply[T](question, Printers.default, false)(op)
 
@@ -59,7 +59,7 @@ object trace {
                         (op: => T)(implicit ctx: Context): T = {
     // Avoid evaluating question multiple time, since each evaluation
     // may cause some extra logging output.
-    lazy val q: String = question
+    @volatile lazy val q: String = question
     apply[T](s"==> $q?", (res: Any) => s"<== $q = ${showOp(res)}")(op)
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/trace.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/trace.scala
@@ -9,40 +9,40 @@ import core.Mode
 
 object trace {
 
-  @`inline`
+  @inline
   def onDebug[TD](question: => String)(op: => TD)(implicit ctx: Context): TD =
     conditionally(ctx.settings.YdebugTrace.value, question, false)(op)
 
-  @`inline`
+  @inline
   def conditionally[TC](cond: Boolean, question: => String, show: Boolean)(op: => TC)(implicit ctx: Context): TC = {
     def op1 = op
     if (Config.tracingEnabled && cond) apply[TC](question, Printers.default, show)(op1)
     else op1
   }
 
-  @`inline`
+  @inline
   def apply[T](question: => String, printer: Printers.Printer, showOp: Any => String)(op: => T)(implicit ctx: Context): T = {
     def op1 = op
     if (!Config.tracingEnabled || printer.eq(config.Printers.noPrinter)) op1
     else doTrace[T](question, printer, showOp)(op1)
   }
 
-  @`inline`
+  @inline
   def apply[T](question: => String, printer: Printers.Printer, show: Boolean)(op: => T)(implicit ctx: Context): T = {
     def op1 = op
     if (!Config.tracingEnabled || printer.eq(config.Printers.noPrinter)) op1
     else doTrace[T](question, printer, if (show) showShowable(_) else alwaysToString)(op1)
   }
 
-  @`inline`
+  @inline
   def apply[T](question: => String, printer: Printers.Printer)(op: => T)(implicit ctx: Context): T =
     apply[T](question, printer, false)(op)
 
-  @`inline`
+  @inline
   def apply[T](question: => String, show: Boolean)(op: => T)(implicit ctx: Context): T =
     apply[T](question, Printers.default, show)(op)
 
-  @`inline`
+  @inline
   def apply[T](question: => String)(op: => T)(implicit ctx: Context): T =
     apply[T](question, Printers.default, false)(op)
 
@@ -59,7 +59,7 @@ object trace {
                         (op: => T)(implicit ctx: Context): T = {
     // Avoid evaluating question multiple time, since each evaluation
     // may cause some extra logging output.
-    @volatile lazy val q: String = question
+    lazy val q: String = question
     apply[T](s"==> $q?", (res: Any) => s"<== $q = ${showOp(res)}")(op)
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -152,7 +152,7 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
       override def transform(tree: Tree)(implicit ctx: Context): Tree = tree match {
         case Ident(_) | Select(This(_), _) =>
           var sym = tree.symbol
-          if (sym is (ParamAccessor, butNot = Mutable)) sym = sym.subst(accessors, paramSyms)
+          if (sym.is(ParamAccessor, butNot = Mutable)) sym = sym.subst(accessors, paramSyms)
           if (sym.owner.isConstructor) ref(sym).withPos(tree.pos) else tree
         case Apply(fn, Nil) =>
           val fn1 = transform(fn)

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -481,7 +481,7 @@ object Erasure {
 	/** Besides normal typing, this method collects all arguments
 	 *  to a compacted function into a single argument of array type.
 	 */
-    override def typedApply(tree: untpd.Apply, pt: Type)(implicit ctx: Context): Tree = {
+    override def typedApply(tree: untpd.Apply, pt: Type, scala2InfixOp: Boolean)(implicit ctx: Context): Tree = {
       val Apply(fun, args) = tree
       if (fun.symbol == defn.cbnArg)
         typedUnadapted(args.head, pt)

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -48,7 +48,7 @@ class ParamForwarding(thisPhase: DenotTransformer) {
          * }
          */
         val candidate = sym.owner.asClass.superClass
-          .info.decl(sym.name).suchThat(_ is (ParamAccessor, butNot = Mutable)).symbol
+          .info.decl(sym.name).suchThat(_.is(ParamAccessor, butNot = Mutable)).symbol
         if (candidate.isAccessibleFrom(currentClass.thisType, superAccess = true)) candidate
         else if (candidate.exists) inheritedAccessor(candidate)
         else NoSymbol

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -123,7 +123,7 @@ class SuperAccessors(thisPhase: DenotTransformer) {
         // SI-4989 Check if an intermediate class between `clazz` and `sym.owner` redeclares the method as abstract.
         for (intermediateClass <- clazz.info.baseClasses.tail.takeWhile(_ != sym.owner)) {
           val overriding = sym.overridingSymbol(intermediateClass)
-          if ((overriding is (Deferred, butNot = AbsOverride)) && !(overriding.owner is Trait))
+          if (overriding.is(Deferred, butNot = AbsOverride) && !overriding.owner.is(Trait))
             ctx.error(
                 s"${sym.showLocated} cannot be directly accessed from ${clazz} because ${overriding.owner} redeclares it as abstract",
                 sel.pos)

--- a/compiler/src/dotty/tools/dotc/transform/TransformByNameApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TransformByNameApply.scala
@@ -26,7 +26,7 @@ abstract class TransformByNameApply extends MiniPhase { thisPhase: DenotTransfor
 
   /** If denotation had an ExprType before, it now gets a function type */
   protected def exprBecomesFunction(symd: SymDenotation)(implicit ctx: Context) =
-    (symd is Param) || (symd is (ParamAccessor, butNot = Method))
+    symd.is(Param) || symd.is(ParamAccessor, butNot = Method)
 
   protected def isByNameRef(tree: Tree)(implicit ctx: Context) = {
     val origDenot = originalDenotation(tree)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -980,10 +980,12 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
                 val (regularArgs, varArgs) = args.splitAt(argTypes.length - 1)
                 regularArgs :+ untpd.SeqLiteral(varArgs, untpd.TypeTree()).withPos(tree.pos)
             }
-          else if (argTypes.lengthCompare(1) == 0 && args.lengthCompare(1) > 0 && ctx.canAutoTuple)
-            untpd.Tuple(args) :: Nil
-          else
-            args
+          else argTypes match {
+            case argType :: Nil if args.lengthCompare(1) > 0 && supportsAutoTupling(argType, args) =>
+              untpd.Tuple(args) :: Nil
+            case _ =>
+              args
+          }
         if (argTypes.length != bunchedArgs.length) {
           ctx.error(UnapplyInvalidNumberOfArguments(qual, argTypes), tree.pos)
           argTypes = argTypes.take(args.length) ++

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -981,7 +981,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
                 regularArgs :+ untpd.SeqLiteral(varArgs, untpd.TypeTree()).withPos(tree.pos)
             }
           else argTypes match {
-            case argType :: Nil if args.lengthCompare(1) > 0 && supportsAutoTupling(argType, args) =>
+            case argType :: Nil if args.lengthCompare(1) > 0 && canAutoTuple(args) =>
               untpd.Tuple(args) :: Nil
             case _ =>
               args

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -564,13 +564,13 @@ class Inliner(call: tpd.Tree, rhs: tpd.Tree)(implicit ctx: Context) {
       }
     }
 
-    override def typedApply(tree: untpd.Apply, pt: Type)(implicit ctx: Context) =
+    override def typedApply(tree: untpd.Apply, pt: Type, scala2InfixOp: Boolean)(implicit ctx: Context) =
       tree.asInstanceOf[tpd.Tree] match {
         case Apply(Select(InlineableArg(closure(_, fn, _)), nme.apply), args) =>
           inlining.println(i"reducing $tree with closure $fn")
           typed(fn.appliedToArgs(args), pt)
         case _ =>
-          super.typedApply(tree, pt)
+          super.typedApply(tree, pt, scala2InfixOp)
       }
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1029,7 +1029,7 @@ class Namer { typer: Typer =>
   def moduleValSig(sym: Symbol)(implicit ctx: Context): Type = {
     val clsName = sym.name.moduleClassName
     val cls = ctx.denotNamed(clsName) suchThat (_ is ModuleClass)
-    ctx.owner.thisType select (clsName, cls)
+    ctx.owner.thisType.select(clsName, cls)
   }
 
   /** The type signature of a ValDef or DefDef

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -288,6 +288,11 @@ object ProtoTypes {
     def typeOfArg(arg: untpd.Tree)(implicit ctx: Context): Type =
       myTypedArg(arg).tpe
 
+    // `scala2InfixOp` and `tupled` only needed for Scala-2 compatibility and migration
+
+    /** FunProto applies to an infix operation under -language:Scala2 */
+    var scala2InfixOp = false
+
     private[this] var myTupled: Type = NoType
 
     /** The same proto-type but with all arguments combined in a single tuple */

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -151,7 +151,7 @@ class Typer extends Namer
     def qualifies(denot: Denotation): Boolean =
       reallyExists(denot) &&
         !(pt.isInstanceOf[UnapplySelectionProto] &&
-          (denot.symbol is (Method, butNot = Accessor))) &&
+          (denot.symbol.is(Method, butNot = Accessor))) &&
         !(denot.symbol is PackageClass)
 
     /** Find the denotation of enclosing `name` in given context `ctx`.

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1434,6 +1434,8 @@ class Typer extends Namer
       for (param <- tparams1 ::: vparamss1.flatten)
         checkRefsLegal(param, sym.owner, (name, sym) => sym.is(TypeParam), "secondary constructor")
 
+    checkSymbolicUnary(sym)
+
     assignType(cpy.DefDef(ddef)(name, tparams1, vparamss1, tpt1, rhs1), sym)
       //todo: make sure dependent method types do not depend on implicits or by-name params
   }

--- a/compiler/src/dotty/tools/dotc/util/SimpleIdentityMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/SimpleIdentityMap.scala
@@ -22,7 +22,7 @@ abstract class SimpleIdentityMap[K <: AnyRef, +V >: Null <: AnyRef] extends (K =
   def toList: List[(K, V)] = map2((k, v) => (k, v))
   override def toString = {
     def assocToString(key: K, value: V) = s"$key -> $value"
-    map2(assocToString) mkString ("(", ", ", ")")
+    map2(assocToString).mkString("(", ", ", ")")
   }
 }
 

--- a/compiler/src/dotty/tools/repl/terminal/filters/ReadlineFilters.scala
+++ b/compiler/src/dotty/tools/repl/terminal/filters/ReadlineFilters.scala
@@ -121,7 +121,7 @@ object ReadlineFilters {
     }
     def cutCharLeft(b: Vector[Char], c: Int) = {
       /* Do not edit current cut. Zsh(zle) & Bash(readline) do not edit the yank ring for Ctrl-h */
-      (b patch(from = c - 1, patch = Nil, replaced = 1), c - 1)
+      (b .patch(from = c - 1, patch = Nil, replaced = 1), c - 1)
     }
 
     def cutLineLeft(b: Vector[Char], c: Int) = {

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -180,7 +180,6 @@ class CompilationTests extends ParallelTesting {
     compileFilesInDir("tests/neg-custom-args/allow-double-bindings", allowDoubleBindings) +
     compileFile("tests/neg-custom-args/i3246.scala", scala2Mode) +
     compileFile("tests/neg-custom-args/overrideClass.scala", scala2Mode) +
-    compileFile("tests/neg-custom-args/autoTuplingTest.scala", defaultOptions.and("-language:noAutoTupling")) +
     compileFile("tests/neg-custom-args/i1050.scala", defaultOptions.and("-strict")) +
     compileFile("tests/neg-custom-args/nopredef.scala", defaultOptions.and("-Yno-predef")) +
     compileFile("tests/neg-custom-args/noimports.scala", defaultOptions.and("-Yno-imports")) +

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -331,7 +331,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
 
     protected def compile(files0: Array[JFile], flags0: TestFlags, suppressErrors: Boolean, targetDir: JFile): TestReporter = {
 
-      val flags = flags0 and ("-d", targetDir.getAbsolutePath)
+      val flags = flags0.and("-d", targetDir.getAbsolutePath)
 
       def flattenFiles(f: JFile): Array[JFile] =
         if (f.isDirectory) f.listFiles.flatMap(flattenFiles)
@@ -400,7 +400,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     protected def compileFromTasty(flags0: TestFlags, suppressErrors: Boolean, targetDir: JFile): TestReporter = {
       val tastyOutput = new JFile(targetDir.getPath + "_from-tasty")
       tastyOutput.mkdir()
-      val flags = flags0 and ("-d", tastyOutput.getAbsolutePath) and "-from-tasty"
+      val flags = flags0.and("-d", tastyOutput.getAbsolutePath).and("-from-tasty")
 
       def hasTastyFileToClassName(f: JFile): String =
         targetDir.toPath.relativize(f.toPath).toString.dropRight(".hasTasty".length).replace('/', '.')
@@ -427,8 +427,10 @@ trait ParallelTesting extends RunnerOrchestration { self =>
       val decompilationOutput = new JFile(targetDir.getPath)
       decompilationOutput.mkdir()
       val flags =
-        flags0 and ("-d", decompilationOutput.getAbsolutePath) and
-        "-decompile" and "-pagewidth" and "80"
+        flags0
+          .and("-d", decompilationOutput.getAbsolutePath)
+          .and("-decompile")
+          .and("-pagewidth", "80")
 
       def hasTastyFileToClassName(f: JFile): String =
         targetDir.toPath.relativize(f.toPath).toString.dropRight(".hasTasty".length).replace('/', '.')

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -49,18 +49,18 @@ object TestConfiguration {
 
   val basicDefaultOptions = checkOptions ++ noCheckOptions ++ yCheckOptions
   val defaultUnoptimised = TestFlags(classPath, runClassPath, basicDefaultOptions)
-  val defaultOptimised = defaultUnoptimised and "-optimise"
+  val defaultOptimised = defaultUnoptimised.and("-optimise")
   val defaultOptions = defaultUnoptimised
   val defaultRunWithCompilerOptions = defaultOptions.withRunClasspath(Jars.dottyRunWithCompiler.mkString(":"))
   val allowDeepSubtypes = defaultOptions without "-Yno-deep-subtypes"
   val allowDoubleBindings = defaultOptions without "-Yno-double-bindings"
-  val picklingOptions = defaultUnoptimised and (
+  val picklingOptions = defaultUnoptimised.and(
     "-Xprint-types",
     "-Ytest-pickler",
     "-Yprint-pos",
     "-Yprint-pos-syms"
   )
-  val scala2Mode = defaultOptions and "-language:Scala2"
-  val explicitUTF8 = defaultOptions and ("-encoding", "UTF8")
-  val explicitUTF16 = defaultOptions and ("-encoding", "UTF16")
+  val scala2Mode = defaultOptions.and("-language:Scala2")
+  val explicitUTF8 = defaultOptions.and("-encoding", "UTF8")
+  val explicitUTF16 = defaultOptions.and("-encoding", "UTF16")
 }

--- a/library/src/scalaShadowing/language.scala
+++ b/library/src/scalaShadowing/language.scala
@@ -29,7 +29,6 @@ package scalaShadowing
  *  and, for dotty:
  *
  *   - [[Scala2              `Scala2`]               backwards compatibility mode for Scala2
- *   - [[noAtoTupling        `noAutoTupling`]]       disable auto-tupling
  *
  *  @groupname production   Language Features
  *  @groupname experimental Experimental Language Features
@@ -192,9 +191,6 @@ object language {
 
   /** Where imported, a backwards compatibility mode for Scala2 is enabled */
   object Scala2
-
-  /** Where imported, auto-tupling is disabled */
-  object noAutoTupling
 
   /* Where imported loose equality using eqAny is disabled */
   object strictEquality

--- a/tests/neg-custom-args/autoTuplingTest.scala
+++ b/tests/neg-custom-args/autoTuplingTest.scala
@@ -1,9 +1,0 @@
-object autoTupling {
-
-  val x = Some(1, 2)                                  // error when running with -language:noAutoTupling
-
-  x match {
-    case Some(a, b) => a + b                          // error // error when running with -language:noAutoTupling
-    case None =>
-  }
-}

--- a/tests/neg/autoTuplingTest.scala
+++ b/tests/neg/autoTuplingTest.scala
@@ -1,11 +1,9 @@
-import language.noAutoTupling
-
 object autoTuplingNeg2 {
 
   val x = Some(1, 2) // error: too many arguments for method apply: (x: A)Some[A]
 
   x match {
-    case Some(a, b) => a + b // error: wrong number of argument patterns for Some // error: not found: b
+    case Some(a, b) => a + b // error: wrong number of argument patterns for Some // error: not found: a
     case None =>
   }
 }

--- a/tests/neg/i1286.scala
+++ b/tests/neg/i1286.scala
@@ -10,7 +10,6 @@ import scala.io.{ Idontexist4 => Foo } // error
 import scala.io.{ Idontexist5 => _ } // error
 
 import scala.language.dynamics
-import scala.language.noAutoTupling
 import scala.language.idontexist // error
 
 object Test

--- a/tests/neg/i2033.scala
+++ b/tests/neg/i2033.scala
@@ -4,10 +4,10 @@ object Test {
   def check(obj: AnyRef): Unit = {
     val bos = new ByteArrayOutputStream()
     val out = new ObjectOutputStream(println) // error
-    val arr = bos toByteArray ()
+    val arr = bos.toByteArray ()
     val in = (())
     val deser = ()
-    val lhs = mutable LinkedHashSet ()
+    val lhs = mutable.LinkedHashSet ()
     check(lhs)
   }
 }

--- a/tests/neg/t6920.scala
+++ b/tests/neg/t6920.scala
@@ -6,5 +6,5 @@ class DynTest extends Dynamic {
 
 class CompilerError {
   val test = new DynTest
-  test.crushTheCompiler(a = 1, b = 2) // error
+  test.crushTheCompiler(a = 1, b = 2) // error // error
 }

--- a/tests/pos-special/strawman-collections/CollectionStrawMan6.scala
+++ b/tests/pos-special/strawman-collections/CollectionStrawMan6.scala
@@ -651,7 +651,7 @@ object CollectionStrawMan6 extends LowPriority {
     }
 
     def fromIterator[B](it: Iterator[B]): LazyList[B] =
-      new LazyList(if (it.hasNext) Some(it.next(), fromIterator(it)) else None)
+      new LazyList(if (it.hasNext) Some((it.next(), fromIterator(it))) else None)
   }
 
   // ------------------ Decorators to add collection ops to existing types -----------------------

--- a/tests/pos/Map.scala
+++ b/tests/pos/Map.scala
@@ -176,7 +176,7 @@ object Map extends ImmutableMapFactory[Map] {
       else if (key == key2) new Map4(key1, value1, key2, value, key3, value3, key4, value4)
       else if (key == key3) new Map4(key1, value1, key2, value2, key3, value, key4, value4)
       else if (key == key4) new Map4(key1, value1, key2, value2, key3, value3, key4, value)
-      else new HashMap + ((key1, value1), (key2, value2), (key3, value3), (key4, value4), (key, value))
+      else HashMap((key1, value1), (key2, value2), (key3, value3), (key4, value4), (key, value))
     def + [B1 >: B](kv: (A, B1)): Map[A, B1] = updated(kv._1, kv._2)
     def - (key: A): Map[A, B] =
       if (key == key1)      new Map3(key2, value2, key3, value3, key4, value4)

--- a/tests/pos/autoTuplingTest.scala
+++ b/tests/pos/autoTuplingTest.scala
@@ -1,9 +1,0 @@
-object autoTupling {
-
-  val x = Some(1, 2)
-
-  x match {
-    case Some(a, b) => a + b
-    case None =>
-  }
-}

--- a/tests/pos/i1318.scala
+++ b/tests/pos/i1318.scala
@@ -3,7 +3,7 @@ object Foo {
   case class T(i: Int) extends S(i)
 
   object T {
-    def unapply(s: S): Option[(Int, Int)] = Some(5, 6)
+    def unapply(s: S): Option[(Int, Int)] = Some((5, 6))
     // def unapply(o: Object): Option[(Int, Int, Int)] = Some(5, 6, 7)
   }
 
@@ -22,7 +22,7 @@ object Bar {
   class S(i: Int) extends T(i)
 
   object T {
-    def unapply(s: S): Option[(Int, Int)] = Some(5, 6)
+    def unapply(s: S): Option[(Int, Int)] = Some((5, 6))
     // def unapply(o: Object): Option[(Int, Int, Int)] = Some(5, 6, 7)
   }
 

--- a/tests/pos/i903.scala
+++ b/tests/pos/i903.scala
@@ -17,7 +17,7 @@ object Test {
   }
 
   def test2 = {
-    val f = "".contains("", (_: Int)) // dotc:
+    val f = (x: Int) => "".contains(("", x)) // dotc:
     f.apply(0)
     // sandbox/eta.scala:18: error: apply is not a member of Boolean(f)
     //     f.apply(0)

--- a/tests/pos/t1133.scala
+++ b/tests/pos/t1133.scala
@@ -11,21 +11,21 @@ object Match
 
   object Extractor1 {
     def unapply(x: Any) = x match {
-        case x: String => Some(x, x + x, x + x+x, x+x, x)
+        case x: String => Some((x, x + x, x + x+x, x+x, x))
         case _ => None
     }
   }
 
   object Extractor2 {
     def unapply(x: Any) = x match {
-        case x: String => Some(x, x + x, x + x+x)
+        case x: String => Some((x, x + x, x + x+x))
         case _ => None
     }
   }
 
   object Extractor3 {
     def unapply(x: Any) = x match {
-        case x: String => Some(x, x, x)
+        case x: String => Some((x, x, x))
         case _ => None
     }
   }

--- a/tests/pos/t2913.scala
+++ b/tests/pos/t2913.scala
@@ -10,8 +10,6 @@ class RichA {
 }
 
 object TestNoAutoTupling {
-  import language.noAutoTupling // try with on and off
-
   implicit def AToRichA(a: A): RichA = new RichA
 
   val a = new A
@@ -52,25 +50,3 @@ object Main {
     ()
   }
 }
-
-object TestWithAutoTupling {
-
-  implicit def AToRichA(a: A): RichA = new RichA
-
-  val a = new A
-  a.foo()
-  a.foo(1)
-
-  a.foo("")       // Without implicits, a type error regarding invalid argument types is generated at `""`. This is
-                  // the same position as an argument, so the 'second try' typing with an Implicit View is tried,
-                  // and AToRichA(a).foo("") is found.
-                  //
-                  // My reading of the spec "7.3 Views" is that `a.foo` denotes a member of `a`, so the view should
-                  // not be triggered.
-                  //
-                  // But perhaps the implementation was changed to solve See https://lampsvn.epfl.ch/trac/scala/ticket/1756
-
-  a.foo("a", "b") // Without implicits, a type error regarding invalid arity is generated at `foo(<error>"", "")`.
-                  // Typers#tryTypedApply:3274 only checks if the error is as the same position as `foo`, `"a"`, or `"b"`.
-}
-

--- a/tests/run/collections.scala
+++ b/tests/run/collections.scala
@@ -18,7 +18,7 @@ object Test extends dotty.runtime.LegacyApp {
     println("***** "+msg+":")
     var s = s0
     s = s + 2
-    s = s + (3, 4000, 10000)
+    s = s.+(3, 4000, 10000)
     println("test1: "+sum(s))
     time {
       s = s ++ (List.range(0, iters) map (2*))
@@ -36,7 +36,7 @@ object Test extends dotty.runtime.LegacyApp {
     println("***** "+msg+":")
     var s = s0
     s = s + 2
-    s = s + (3, 4000, 10000)
+    s = s.+(3, 4000, 10000)
     println("test1: "+sum(s))
     time {
       s = s ++ (List.range(0, iters) map (2*))
@@ -54,7 +54,7 @@ object Test extends dotty.runtime.LegacyApp {
     println("***** "+msg+":")
     var s = s0
     s = s + (2 -> 2)
-    s = s + (3 -> 3, 4000 -> 4000, 10000 -> 10000)
+    s = s.+(3 -> 3, 4000 -> 4000, 10000 -> 10000)
     println("test1: "+sum(s map (_._2)))
     time {
       s = s ++ (List.range(0, iters) map (x => x * 2 -> x * 2))
@@ -89,7 +89,7 @@ object Test extends dotty.runtime.LegacyApp {
     println("***** "+msg+":")
     var s = s0
     s = s + (2 -> 2)
-    s = s + (3 -> 3, 4000 -> 4000, 10000 -> 10000)
+    s = s.+(3 -> 3, 4000 -> 4000, 10000 -> 10000)
     println("test1: "+sum(s map (_._2)))
     time {
       s = s ++ (List.range(0, iters) map (x => x * 2 -> x * 2))

--- a/tests/run/colltest1.scala
+++ b/tests/run/colltest1.scala
@@ -47,8 +47,8 @@ object Test extends dotty.runtime.LegacyApp {
     assert(vs1 == ten)
     assert((ten take 5) == firstFive)
     assert((ten drop 5) == secondFive)
-    assert(ten slice (3, 3) isEmpty)
-    assert((ten slice (3, 6)) == List(4, 5, 6), ten slice (3, 6))
+    assert(ten.slice(3, 3) isEmpty)
+    assert((ten.slice(3, 6)) == List(4, 5, 6), ten .slice (3, 6))
     assert((ten takeWhile (_ <= 5)) == firstFive)
     assert((ten dropWhile (_ <= 5)) == secondFive)
     assert((ten span (_ <= 5)) == (firstFive, secondFive))
@@ -139,7 +139,7 @@ object Test extends dotty.runtime.LegacyApp {
 
   def setTest(empty: => Set[String]): Unit = {
     var s = empty + "A" + "B" + "C"
-    s += ("D", "E", "F")
+    s = s.+("D", "E", "F")
     s ++= List("G", "H", "I")
     s ++= ('J' to 'Z') map (_.toString)
     assert(s forall (s contains))
@@ -156,8 +156,8 @@ object Test extends dotty.runtime.LegacyApp {
     assert(!s.isEmpty)
     val s1 = s intersect empty
     assert(s1 == empty, s1)
-    def abc = empty + ("a", "b", "c")
-    def bc = empty + ("b", "c")
+    def abc = empty.+("a", "b", "c")
+    def bc = empty.+("b", "c")
     assert(bc subsetOf abc)
   }
 
@@ -173,7 +173,7 @@ object Test extends dotty.runtime.LegacyApp {
 
   def mapTest(empty: => Map[String, String]) = {
     var m = empty + ("A" -> "A") + ("B" -> "B") + ("C" -> "C")
-    m += (("D" -> "D"), ("E" -> "E"), ("F" -> "F"))
+    m = m.+(("D" -> "D"), ("E" -> "E"), ("F" -> "F"))
     m ++= List(("G" -> "G"), ("H" -> "H"), ("I" -> "I"))
     m ++= ('J' to 'Z') map (x => (x.toString -> x.toString))
     println(m.toList.sorted)

--- a/tests/run/colltest6/CollectionStrawMan6_1.scala
+++ b/tests/run/colltest6/CollectionStrawMan6_1.scala
@@ -652,7 +652,7 @@ object CollectionStrawMan6 extends LowPriority {
     }
 
     def fromIterator[B](it: Iterator[B]): LazyList[B] =
-      new LazyList(if (it.hasNext) Some(it.next(), fromIterator(it)) else None)
+      new LazyList(if (it.hasNext) Some((it.next(), fromIterator(it))) else None)
   }
 
   // ------------------ Decorators to add collection ops to existing types -----------------------

--- a/tests/run/iterators.scala
+++ b/tests/run/iterators.scala
@@ -57,8 +57,8 @@ object Test {
   def check_drop: Int = {
     val it1 = Iterator.from(0)
     val it2 = it1 map { 2 * _ }
-    val n1 = it1 drop 2 next()
-    val n2 = it2 drop 2 next();
+    val n1 = (it1 drop 2) .next()
+    val n2 = (it2 drop 2) .next();
     n1 + n2
   }
 

--- a/tests/run/runtime.scala
+++ b/tests/run/runtime.scala
@@ -65,7 +65,7 @@ object Test1Test {
     // {System.out.print(12); java.lang}.System.out.println();
     // {System.out.print(13); java.lang.System}.out.println();
     {Console.print(14); Console}.println;
-    {Console.print(15); (() => Console.println):(() => Unit)} apply ();
+    {Console.print(15); (() => Console.println):(() => Unit)} .apply ();
     {Console.print(16); Console.println};
 
     {Console.print(20)}; test1.bar.System.out.println();
@@ -73,7 +73,7 @@ object Test1Test {
     // {System.out.print(22); test1.bar}.System.out.println();
     {Console.print(23); test1.bar.System}.out.println();
     {Console.print(24); test1.bar.System.out}.println();
-    {Console.print(25); test1.bar.System.out.println:(() => Unit)} apply ();
+    {Console.print(25); test1.bar.System.out.println:(() => Unit)} .apply ();
     {Console.print(26); test1.bar.System.out.println()};
   }
 

--- a/tests/run/t2544.scala
+++ b/tests/run/t2544.scala
@@ -11,10 +11,10 @@ object Test {
   )
 
   def main(args: Array[String]) = {
-    println(Foo indexWhere(_ >= 2,1))
-    println(Foo.toList indexWhere(_ >= 2,1))
-    println(Foo segmentLength(_ <= 3,1))
-    println(Foo.toList segmentLength(_ <= 3,1))
+    println(Foo .indexWhere(_ >= 2,1))
+    println(Foo.toList .indexWhere(_ >= 2,1))
+    println(Foo .segmentLength(_ <= 3,1))
+    println(Foo.toList .segmentLength(_ <= 3,1))
     lengthEquiv(Foo lengthCompare 7)
     lengthEquiv(Foo.toList lengthCompare 7)
     lengthEquiv(Foo lengthCompare 2)

--- a/tests/run/t4813.scala
+++ b/tests/run/t4813.scala
@@ -31,7 +31,7 @@ object Test extends dotty.runtime.LegacyApp {
   runTest(TreeSet(1,2,3))(_.clone) { buf => buf add 4 }
 
   // Maps
-  runTest(HashMap(1->1,2->2,3->3))(_.clone) { buf => buf put (4,4) }
-  runTest(WeakHashMap(1->1,2->2,3->3))(_.clone) { buf => buf put (4,4) }
+  runTest(HashMap(1->1,2->2,3->3))(_.clone) { buf => buf.put(4,4) }
+  runTest(WeakHashMap(1->1,2->2,3->3))(_.clone) { buf => buf.put(4,4) }
 }
 

--- a/tests/run/t5045.scala
+++ b/tests/run/t5045.scala
@@ -6,7 +6,7 @@ object Test extends dotty.runtime.LegacyApp {
  import scala.util.matching.{ Regex, UnanchoredRegex }
 
  val dateP1 = """(\d\d\d\d)-(\d\d)-(\d\d)""".r.unanchored
- val dateP2 = """(\d\d\d\d)-(\d\d)-(\d\d)""" r ("year", "month", "day") unanchored
+ val dateP2 = """(\d\d\d\d)-(\d\d)-(\d\d)""" .r ("year", "month", "day") unanchored
  val dateP3 =  new Regex("""(\d\d\d\d)-(\d\d)-(\d\d)""", "year", "month", "day") with UnanchoredRegex
 
  val yearStr = "2011"

--- a/tests/run/t6271.scala
+++ b/tests/run/t6271.scala
@@ -21,7 +21,7 @@ object Test extends dotty.runtime.LegacyApp {
   }
   def slicedIssue = {
     val viewed : Iterable[Iterable[Int]] = List(List(0).view).view
-    val filtered = viewed flatMap { x => List( x slice (2,3) ) }
+    val filtered = viewed flatMap { x => List( x.slice(2,3) ) }
     filtered.iterator.toIterable.flatten
   }
   filterIssue

--- a/tests/run/t6827.scala
+++ b/tests/run/t6827.scala
@@ -10,7 +10,7 @@ object Test extends App {
     } catch {
       case e: Exception => e.toString
     }
-    println("%s: %s" format (label, status))
+    println("%s: %s".format(label, status))
   }
 
   tryit("start at -5", -5, 10)

--- a/tests/run/t8610.scala
+++ b/tests/run/t8610.scala
@@ -3,7 +3,7 @@
 case class X(name: String) {
   def x = "Hi, $name"   // missing interp
   def f(p: (Int, Int)): Int = p._1 * p._2
-  def g = f(3, 4)       // adapted
+  def g = f((3, 4))       // adapted
   def u: Unit = ()      // unitarian universalist
 }
 

--- a/tests/run/unapply.scala
+++ b/tests/run/unapply.scala
@@ -33,7 +33,7 @@ object VarFoo {
 
 object Foo {
   def unapply(x: Any): Option[Product2[Int, String]] = x match {
-    case y: Bar => Some(y.size, y.name)
+    case y: Bar => Some((y.size, y.name))
     case _ => None
   }
   def doMatch1(b:Bar) = b match {
@@ -69,7 +69,7 @@ object Foo {
 object Mas {
   object Gaz {
     def unapply(x: Any): Option[Product2[Int, String]] = x match {
-      case y: Baz => Some(y.size, y.name)
+      case y: Baz => Some((y.size, y.name))
       case _ => None
     }
   }

--- a/tests/run/virtpatmat_unapply.scala
+++ b/tests/run/virtpatmat_unapply.scala
@@ -1,7 +1,7 @@
 class IntList(val hd: Int, val tl: IntList)
 object NilIL extends IntList(0, null)
 object IntList {
-  def unapply(il: IntList): Option[(Int, IntList)] = if(il eq NilIL) None else Some(il.hd, il.tl)
+  def unapply(il: IntList): Option[(Int, IntList)] = if(il eq NilIL) None else Some((il.hd, il.tl))
   def apply(x: Int, xs: IntList) = new IntList(x, xs)
 }
 


### PR DESCRIPTION
Prompted by the Scala contributors thread, this was initially an attempt to drop auto-tupling altogether. But it became quickly annoying. The main problem is that it's unnatural to add another pair of parentheses to infix operations. Compare:

    (x, y) == z
    z == ((x, y))    // !yuck

Same thing for cons:

    ((1, x)) :: ((2, y)) :: xs   // double yuck!

So at the very least we have to allow auto-tupling for arguments of infix operators. I went a little bit
further and also allowed auto-tupling if the expected type is already a (some kind of) product or tuple of the right arity. The result is this commit.

The language import `noAutoTupling` has been removed. The previous auto-tupling is still reported under Scala 2 mode, and there is -rewrite support to add the missing (...) automatically.