### PR TITLE
[Experiment, PR for benchmarking] Try to reduce cache misses

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -800,12 +800,14 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
      */
     def memberClasses: List[Symbol] = definedClasses(ctx.lambdaLiftPhase)
 
-    private def definedClasses(phase: Phase) =
-      if (sym.isDefinedInCurrentRun)
-        ctx.atPhase(phase) { implicit ctx =>
-          toDenot(sym).info.decls.filter(_.isClass)
-        }
+    private def definedClasses(phase: Phase) = {
+      val outerCtx = ctx
+      if (sym.isDefinedInCurrentRun) {
+        implicit val ctx = outerCtx.withPhase(phase)
+        toDenot(sym).info.decls.filter(_.isClass)
+      }
       else Nil
+    }
 
     def annotations: List[Annotation] = toDenot(sym).annotations
     def companionModuleMembers: List[Symbol] =  {

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -106,6 +106,8 @@ object Names {
      */
     def derived(info: NameInfo): ThisName
 
+    def derivedUnique(info: NameInfo): ThisName
+
     /** A derived name consisting of this name and the info of `kind` */
     def derived(kind: ClassifiedNameKind): ThisName = derived(kind.info)
 
@@ -229,6 +231,17 @@ object Names {
       val thatKind = info.kind
       if (thisKind.tag < thatKind.tag || thatKind.definesNewName) add(info)
       else if (thisKind.tag > thatKind.tag) rewrap(underlying.derived(info))
+      else {
+        assert(info == this.info)
+        this
+      }
+    }
+
+    override def derivedUnique(info: NameInfo): TermName = {
+      val thisKind = this.info.kind
+      val thatKind = info.kind
+      if (thisKind.tag < thatKind.tag || thatKind.definesNewName) new DerivedName(this, info)
+      else if (thisKind.tag > thatKind.tag) rewrap(underlying.derivedUnique(info))
       else {
         assert(info == this.info)
         this
@@ -453,6 +466,7 @@ object Names {
     override def likeSpaced(name: Name): TypeName = name.toTypeName
 
     override def derived(info: NameInfo): TypeName = toTermName.derived(info).toTypeName
+    override def derivedUnique(info: NameInfo): TypeName = toTermName.derivedUnique(info).toTypeName
     override def exclude(kind: NameKind): TypeName = toTermName.exclude(kind).toTypeName
     override def is(kind: NameKind) = toTermName.is(kind)
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -525,7 +525,7 @@ object SymDenotations {
     /** Is this symbol a package object or its module class? */
     def isPackageObject(implicit ctx: Context): Boolean = {
       val nameMatches =
-        if (isType) name == tpnme.PACKAGE.moduleClassName
+        if (isType) name.exclude(ModuleClassName) == tpnme.PACKAGE
         else name == nme.PACKAGE
       nameMatches && (owner is Package) && (this is Module)
     }

--- a/compiler/src/dotty/tools/dotc/util/FreshNameCreator.scala
+++ b/compiler/src/dotty/tools/dotc/util/FreshNameCreator.scala
@@ -24,7 +24,7 @@ object FreshNameCreator {
     def newName(prefix: TermName, unique: UniqueNameKind): TermName = {
       val key = str.sanitize(prefix.toString) + unique.separator
       counters(key) += 1
-      prefix.derived(unique.NumberedInfo(counters(key)))
+      prefix.derivedUnique(unique.NumberedInfo(counters(key)))
     }
   }
 }


### PR DESCRIPTION
- Name#derived is costly because it involves getting and setting value
  in a Map for caching, we don't need this caching for fresh names.
- NameOps#moduleClassName is costly because it calls Name#derived
- Tree#denot was megamorphic