### PR TITLE
Fix #4318: Ignore java.lang.Object companion object

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -313,6 +313,8 @@ private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeT
 
   private def ignoreDependency(sym: Symbol)(implicit ctx: Context) =
     !sym.exists ||
+    sym.unforcedIsAbsent || // ignore dependencies that have a symbol but do not exist.
+                            // e.g. java.lang.Object companion object
     sym.is(PackageClass) ||
     sym.isEffectiveRoot ||
     sym.isAnonymousFunction ||

--- a/tests/pos/i4318.scala
+++ b/tests/pos/i4318.scala
@@ -1,0 +1,1 @@
+import java.lang.Object


### PR DESCRIPTION
java.lang.Object companion object does not exist but has a companion
object. We used to record a dependency on it for incremental compilation
when `java.lang.Object` was imported.