### PR TITLE
Upgrade to sbt-buildinfo 0.9.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,4 +15,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.10.1")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.2")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
To fix issues with multi-parameter infix notation.