### PR TITLE
Refine dependency extraction: Ignore packages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -49,9 +49,9 @@ pipeline:
     commands:
       - cp -R . /tmp/4/ && cd /tmp/4/
       - ./project/scripts/sbt sbt-dotty/scripted
-    when:
-      # sbt scripted tests are slow and only run on nightly or deployment
-      event: [ tag, deployment ]
+    # when:
+    #   # sbt scripted tests are slow and only run on nightly or deployment
+    #   event: [ tag, deployment ]
 
   # DOCUMENTATION:
   documentation:

--- a/.drone.yml
+++ b/.drone.yml
@@ -49,9 +49,9 @@ pipeline:
     commands:
       - cp -R . /tmp/4/ && cd /tmp/4/
       - ./project/scripts/sbt sbt-dotty/scripted
-    # when:
-    #   # sbt scripted tests are slow and only run on nightly or deployment
-    #   event: [ tag, deployment ]
+    when:
+      # sbt scripted tests are slow and only run on nightly or deployment
+      event: [ tag, deployment ]
 
   # DOCUMENTATION:
   documentation:

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -315,7 +315,7 @@ private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeT
     !sym.exists ||
     sym.unforcedIsAbsent || // ignore dependencies that have a symbol but do not exist.
                             // e.g. java.lang.Object companion object
-    sym.is(PackageClass) ||
+    sym.is(Package) ||
     sym.isEffectiveRoot ||
     sym.isAnonymousFunction ||
     sym.isAnonymousClass

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -297,7 +297,7 @@ private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeT
         assert(fromClass.isClass)
 
         addUsedName(fromClass, mangledName(sym), UseScope.Default)
-        // packages have class symbol. Only record them as used names but bot dependency
+        // packages have class symbol. Only record them as used names but not dependency
         if (!sym.is(Package)) {
           _dependencies += ClassDependency(fromClass, enclOrModuleClass, DependencyByMemberRef)
         }

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -295,8 +295,12 @@ private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeT
       val fromClass = resolveDependencySource
       if (fromClass.exists) { // can happen when visiting imports
         assert(fromClass.isClass)
-        _dependencies += ClassDependency(fromClass, enclOrModuleClass, DependencyByMemberRef)
+
         addUsedName(fromClass, mangledName(sym), UseScope.Default)
+        // packages have class symbol. Only record them as used names but bot dependency
+        if (!sym.is(Package)) {
+          _dependencies += ClassDependency(fromClass, enclOrModuleClass, DependencyByMemberRef)
+        }
       }
     }
 
@@ -315,7 +319,6 @@ private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeT
     !sym.exists ||
     sym.unforcedIsAbsent || // ignore dependencies that have a symbol but do not exist.
                             // e.g. java.lang.Object companion object
-    sym.is(Package) ||
     sym.isEffectiveRoot ||
     sym.isAnonymousFunction ||
     sym.isAnonymousClass

--- a/sbt-bridge/test/xsbt/DependencySpecification.scala
+++ b/sbt-bridge/test/xsbt/DependencySpecification.scala
@@ -145,6 +145,25 @@ class DependencySpecification {
     assertEquals(Set("abc.A"), deps("H"))
   }
 
+  @Test
+  def extractedClassDependenciesOnPackageObject = {
+    val srcA = "package object foo { def bar = 1 }"
+    val srcB =
+      """|package foo
+         |
+         |class Test {
+         |  bar
+         |}
+      """.stripMargin
+
+    val compilerForTesting = new ScalaCompilerForUnitTesting
+    val classDependencies =
+      compilerForTesting.extractDependenciesFromSrcs(srcA, srcB)
+
+    val memberRef = classDependencies.memberRef
+    assertEquals(Set("foo.package"), memberRef("foo.Test"))
+  }
+
   private def extractClassDependenciesPublic: ExtractedClassDependencies = {
     val srcA = "class A"
     val srcB = "class B extends D[A]"

--- a/sbt-bridge/test/xsbt/ExtractUsedNamesSpecification.scala
+++ b/sbt-bridge/test/xsbt/ExtractUsedNamesSpecification.scala
@@ -15,7 +15,7 @@ class ExtractUsedNamesSpecification {
                 |}""".stripMargin
     val compilerForTesting = new ScalaCompilerForUnitTesting
     val usedNames = compilerForTesting.extractUsedNamesFromSrc(src)
-    val expectedNames = standardNames ++ Set("a", "A", "A2", "b")
+    val expectedNames = standardNames ++ Set("A", "A2")
     // names used at top level are attributed to the first class defined in a compilation unit
 
     assertEquals(expectedNames, usedNames("a.A"))
@@ -43,7 +43,7 @@ class ExtractUsedNamesSpecification {
                   |}""".stripMargin
     val compilerForTesting = new ScalaCompilerForUnitTesting
     val usedNames = compilerForTesting.extractUsedNamesFromSrc(srcA, srcB)
-    val expectedNames = standardNames ++ Set("a", "c", "A", "B", "C", "D", "b", "BB")
+    val expectedNames = standardNames ++ Set("A", "B", "C", "D", "BB")
     assertEquals(expectedNames, usedNames("b.X"))
   }
 

--- a/sbt-bridge/test/xsbt/ExtractUsedNamesSpecification.scala
+++ b/sbt-bridge/test/xsbt/ExtractUsedNamesSpecification.scala
@@ -275,6 +275,20 @@ class ExtractUsedNamesSpecification {
     assertEquals(Set(), findPatMatUsages(notUsedInPatternMatch))
   }
 
+  @Test
+  def extractedNamesInImport = {
+    val src =
+      """|import java.util.List
+         |
+         |class Test
+      """.stripMargin
+
+    val compilerForTesting = new ScalaCompilerForUnitTesting
+    val usedNames = compilerForTesting.extractUsedNamesFromSrc(src)
+
+    assertEquals(standardNames + "List", usedNames("Test"))
+  }
+
   /**
    * Standard names that appear in every compilation unit that has any class
    * definition.

--- a/sbt-bridge/test/xsbt/ExtractUsedNamesSpecification.scala
+++ b/sbt-bridge/test/xsbt/ExtractUsedNamesSpecification.scala
@@ -15,7 +15,7 @@ class ExtractUsedNamesSpecification {
                 |}""".stripMargin
     val compilerForTesting = new ScalaCompilerForUnitTesting
     val usedNames = compilerForTesting.extractUsedNamesFromSrc(src)
-    val expectedNames = standardNames ++ Set("A", "A2")
+    val expectedNames = standardNames ++ Set("a", "A", "A2", "b")
     // names used at top level are attributed to the first class defined in a compilation unit
 
     assertEquals(expectedNames, usedNames("a.A"))
@@ -43,7 +43,7 @@ class ExtractUsedNamesSpecification {
                   |}""".stripMargin
     val compilerForTesting = new ScalaCompilerForUnitTesting
     val usedNames = compilerForTesting.extractUsedNamesFromSrc(srcA, srcB)
-    val expectedNames = standardNames ++ Set("A", "B", "C", "D", "BB")
+    val expectedNames = standardNames ++ Set("a", "c", "A", "B", "C", "D", "b", "BB")
     assertEquals(expectedNames, usedNames("b.X"))
   }
 
@@ -286,7 +286,8 @@ class ExtractUsedNamesSpecification {
     val compilerForTesting = new ScalaCompilerForUnitTesting
     val usedNames = compilerForTesting.extractUsedNamesFromSrc(src)
 
-    assertEquals(standardNames + "List", usedNames("Test"))
+    val expectedNames = standardNames ++ Set("java", "util", "List")
+    assertEquals(expectedNames, usedNames("Test"))
   }
 
   /**

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/Test.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/Test.scala
@@ -1,0 +1,6 @@
+package foo
+
+object Test {
+  def test(implicit x: Int = 1): String = x.toString
+  def main(args: Array[String]): Unit = test
+}

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/changes/package.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/changes/package.scala
@@ -1,0 +1,3 @@
+package object foo {
+  implicit val x: Int = ???
+}

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/pending
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/pending
@@ -1,0 +1,7 @@
+> run
+
+$ copy-file changes/package.scala package.scala
+
+# New implicit in scope from package object that makes run throws
+# clean run fails correctly
+-> run

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/project/DottyInjectedPlugin.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion"),
+    scalacOptions += "-language:Scala2"
+  )
+}

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))


### PR DESCRIPTION
We can ignore packages when collecting dependencies for incremental
compilation. We make sure not to ignore dependencies on package object.