### PR TITLE
Optimize scala2Mode

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -292,25 +292,17 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
    *  the prefix "dotty.language.".
    */
   def featureEnabled(owner: ClassSymbol, feature: TermName): Boolean = {
-    def toPrefix(sym: Symbol): String =
-      if (!sym.exists || (sym eq defn.LanguageModuleClass)) ""
-      else toPrefix(sym.owner) + sym.name + "."
-    def featureName = toPrefix(owner) + feature
-    def hasImport(implicit ctx: Context): Boolean = {
-      if (ctx.importInfo eq null) false
-      else {
-        val isImportOwner = ctx.importInfo.site.widen.typeSymbol eq owner
-        if (isImportOwner && ctx.importInfo.originals.contains(feature)) true
-        else if (isImportOwner && ctx.importInfo.excluded.contains(feature)) false
-        else {
-          var c = ctx.outer
-          while (c.importInfo eq ctx.importInfo) c = c.outer
-          hasImport(c)
-        }
-      }
+    val hasImport =
+      ctx.importInfo != null &&
+      ctx.importInfo.featureImported(owner, feature)(ctx.withPhase(ctx.typerPhase))
+    def hasOption = {
+      def toPrefix(sym: Symbol): String =
+        if (!sym.exists || (sym eq defn.LanguageModuleClass)) ""
+        else toPrefix(sym.owner) + sym.name + "."
+      val featureName = toPrefix(owner) + feature
+      ctx.base.settings.language.value exists (s => s == featureName || s == "_")
     }
-    def hasOption = ctx.base.settings.language.value exists (s => s == featureName || s == "_")
-    hasImport(ctx.withPhase(ctx.typerPhase)) || hasOption
+    hasImport || hasOption
   }
 
   /** Is auto-tupling enabled? */

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -79,7 +79,7 @@ object Implicits {
         def discardForView(tpw: Type, argType: Type): Boolean = tpw match {
           case mt: MethodType =>
             mt.isImplicitMethod ||
-            mt.paramInfos.length != 1 ||
+            mt.paramInfos.lengthCompare(1) != 0 ||
             !ctx.test(implicit ctx => argType relaxed_<:< mt.paramInfos.head)
           case poly: PolyType =>
             // We do not need to call ProtoTypes#constrained on `poly` because


### PR DESCRIPTION
Profile showed that `scala2Mode` takes about 1% of compute time when run on dotc/typer/*.scala.
We can reduce this by caching previously computed results.