### PR TITLE
Fix #4357: Avoid cyclic reference when parsing Java classfile

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -990,7 +990,7 @@ object SymDenotations {
      */
     private def companionNamed(name: TypeName)(implicit ctx: Context): Symbol =
       if (owner.isClass)
-        owner.info.decl(name).suchThat(_.isCoDefinedWith(symbol)).symbol
+        owner.unforcedDecls.lookup(name).suchThat(_.isCoDefinedWith(symbol)).symbol
       else if (!owner.exists || ctx.compilationUnit == null)
         NoSymbol
       else if (!ctx.compilationUnit.tpdTree.isEmpty)

--- a/tests/pos-java-interop/i4357/B_1.java
+++ b/tests/pos-java-interop/i4357/B_1.java
@@ -1,0 +1,4 @@
+public class B_1 extends A<B_1.C> {
+  public static class C {};
+}
+class A<T> {}

--- a/tests/pos-java-interop/i4357/Test_2.scala
+++ b/tests/pos-java-interop/i4357/Test_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  val b: B_1 = new B_1()
+}


### PR DESCRIPTION
We force all types appearing in the extends clause using `cook` before
completing the current class, in B_1.java this means we force `C` before
`B_1` is completed, ClassfileLoader#load ends up calling
`scalacLinkedClass` which before this commit forced the owner of `C`,
causing a cycle.