### PR TITLE
Clean up kindedness tests

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -212,7 +212,10 @@ class TypeApplications(val self: Type) extends AnyVal {
 
   /** Is self type of kind != "*"? */
   def hasHigherKind(implicit ctx: Context): Boolean =
-    typeParams.nonEmpty || self.isRef(defn.AnyKindClass)
+    typeParams.nonEmpty || self.hasAnyKind
+
+  /** Is self type of kind "*"? */
+  def hasFirstKind(implicit ctx: Context): Boolean = !hasHigherKind
 
   /** If self type is higher-kinded, its result type, otherwise NoType.
    *  Note: The hkResult of an any-kinded type is again AnyKind.

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -210,12 +210,9 @@ class TypeApplications(val self: Type) extends AnyVal {
   /** Is self type bounded by a type lambda or AnyKind? */
   def isLambdaSub(implicit ctx: Context): Boolean = hkResult.exists
 
-  /** Is self type of kind != "*"? */
-  def hasHigherKind(implicit ctx: Context): Boolean =
-    typeParams.nonEmpty || self.hasAnyKind
-
   /** Is self type of kind "*"? */
-  def hasFirstKind(implicit ctx: Context): Boolean = !hasHigherKind
+  def hasSimpleKind(implicit ctx: Context): Boolean =
+    typeParams.isEmpty && !self.hasAnyKind
 
   /** If self type is higher-kinded, its result type, otherwise NoType.
    *  Note: The hkResult of an any-kinded type is again AnyKind.

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -248,6 +248,20 @@ object Types {
     /** Is this type a (possibly aliased) singleton type? */
     def isSingleton(implicit ctx: Context) = dealias.isInstanceOf[SingletonType]
 
+    /** Is this type of kind `AnyKind`? */
+    def hasAnyKind(implicit ctx: Context): Boolean = {
+      @tailrec def loop(tp: Type): Boolean = tp match {
+        case tp: TypeRef =>
+          val sym = tp.symbol
+          if (sym.isClass) sym == defn.AnyKindClass else loop(tp.superType)
+        case tp: TypeProxy =>
+          loop(tp.underlying)
+        case _ =>
+          false
+      }
+      loop(this)
+    }
+
     /** Is this type guaranteed not to have `null` as a value? */
     final def isNotNull(implicit ctx: Context): Boolean = this match {
       case tp: ConstantType => tp.value.value != null

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -213,7 +213,10 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
           }
         case tree: TypeApply =>
           val tree1 @ TypeApply(fn, args) = normalizeTypeArgs(tree)
-          Checking.checkBounds(args, fn.tpe.widen.asInstanceOf[PolyType])
+          if (fn.symbol != defn.ChildAnnot.primaryConstructor) {
+            // Make an exception for ChildAnnot, which should really have AnyKind bounds
+            Checking.checkBounds(args, fn.tpe.widen.asInstanceOf[PolyType])
+          }
           fn match {
             case sel: Select =>
               val args1 = transform(args)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -46,9 +46,14 @@ object Checking {
    */
   def checkBounds(args: List[tpd.Tree], boundss: List[TypeBounds], instantiate: (Type, List[Type]) => Type)(implicit ctx: Context): Unit = {
     (args, boundss).zipped.foreach { (arg, bound) =>
-      if (!bound.isLambdaSub && arg.tpe.isLambdaSub)
+      if (!bound.isLambdaSub && arg.tpe.hasHigherKind) {
         // see MissingTypeParameterFor
+        if (!arg.tpe.isLambdaSub) { // FIXME: Provisional, remove
+          println(i"different for checkBounds $arg vs $bound at ${ctx.phase} in ${ctx.owner.ownersIterator.toList}")
+          throw new AssertionError("")
+        }
         ctx.error(ex"missing type parameter(s) for $arg", arg.pos)
+      }
     }
     for ((arg, which, bound) <- ctx.boundsViolations(args, boundss, instantiate))
       ctx.error(

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -704,7 +704,7 @@ trait Checking {
 
   /** Check that `tpt` does not define a higher-kinded type */
   def checkSimpleKinded(tpt: Tree)(implicit ctx: Context): Tree =
-    if (tpt.tpe.isLambdaSub && !ctx.compilationUnit.isJava) {
+    if (tpt.tpe.hasHigherKind && !ctx.compilationUnit.isJava) {
         // be more lenient with missing type params in Java,
         // needed to make pos/java-interop/t1196 work.
       errorTree(tpt, MissingTypeParameterFor(tpt.tpe))

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -46,12 +46,8 @@ object Checking {
    */
   def checkBounds(args: List[tpd.Tree], boundss: List[TypeBounds], instantiate: (Type, List[Type]) => Type)(implicit ctx: Context): Unit = {
     (args, boundss).zipped.foreach { (arg, bound) =>
-      if (!bound.isLambdaSub && arg.tpe.hasHigherKind) {
+      if (!bound.isLambdaSub && !arg.tpe.hasSimpleKind) {
         // see MissingTypeParameterFor
-        if (!arg.tpe.isLambdaSub) { // FIXME: Provisional, remove
-          println(i"different for checkBounds $arg vs $bound at ${ctx.phase} in ${ctx.owner.ownersIterator.toList}")
-          throw new AssertionError("")
-        }
         ctx.error(ex"missing type parameter(s) for $arg", arg.pos)
       }
     }
@@ -709,7 +705,7 @@ trait Checking {
 
   /** Check that `tpt` does not define a higher-kinded type */
   def checkSimpleKinded(tpt: Tree)(implicit ctx: Context): Tree =
-    if (tpt.tpe.hasHigherKind && !ctx.compilationUnit.isJava) {
+    if (!tpt.tpe.hasSimpleKind && !ctx.compilationUnit.isJava) {
         // be more lenient with missing type params in Java,
         // needed to make pos/java-interop/t1196 work.
       errorTree(tpt, MissingTypeParameterFor(tpt.tpe))

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -255,7 +255,7 @@ trait TypeAssigner {
    */
   def accessibleSelectionType(tree: untpd.RefTree, qual1: Tree)(implicit ctx: Context): Type = {
     var qualType = qual1.tpe.widenIfUnstable
-    if (qualType.hasHigherKind && tree.name != nme.CONSTRUCTOR)
+    if (!qualType.hasSimpleKind && tree.name != nme.CONSTRUCTOR)
       // constructors are selected on typeconstructor, type arguments are passed afterwards
       qualType = errorType(em"$qualType takes type parameters", qual1.pos)
     else if (!qualType.isInstanceOf[TermType]) qualType = errorType(em"$qualType is illegal as a selection prefix", qual1.pos)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -255,7 +255,9 @@ trait TypeAssigner {
    */
   def accessibleSelectionType(tree: untpd.RefTree, qual1: Tree)(implicit ctx: Context): Type = {
     var qualType = qual1.tpe.widenIfUnstable
-    if (qualType.isLambdaSub) qualType = errorType(em"$qualType takes type parameters", qual1.pos)
+    if (qualType.hasHigherKind && tree.name != nme.CONSTRUCTOR)
+      // constructors are selected on typeconstructor, type arguments are passed afterwards
+      qualType = errorType(em"$qualType takes type parameters", qual1.pos)
     else if (!qualType.isInstanceOf[TermType]) qualType = errorType(em"$qualType is illegal as a selection prefix", qual1.pos)
     val ownType = selectionType(qualType, tree.name, tree.pos)
     ensureAccessible(ownType, qual1.isInstanceOf[Super], tree.pos)

--- a/library/src/scala/annotation/internal/Child.scala
+++ b/library/src/scala/annotation/internal/Child.scala
@@ -12,5 +12,6 @@ import scala.annotation.Annotation
  *  Then the class symbol `A` would carry the annotations
  *  `@Child[Bref] @Child[Cref]` where `Bref`, `Cref` are TypeRefs
  *  referring to the class symbols of `B` and `C`
+ *  TODO: This should be `Child[T <: AnyKind]`
  */
 class Child[T] extends Annotation


### PR DESCRIPTION
We currently mostly use isLambdaSub which detects unapplied
abstract and alias types but not unapplied generic classes.
We should use `hasHigherKind` more often, which includes
unapplied classes.

The first commit fixes a problem with `hasHigherKind` where
abstract types upper bounded by `AnyKind` where not classified
as higher-kinded.

It also changes checkSimpleKinded to use hasHigherKind instead
if isLambdaSub.

I thought it would be good to get this in before I proceed with effects, since
effects effectively introduce another kind.
 