### PR TITLE
Harden IDE: Avoid ClassCastException in ThisType.cls

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2177,7 +2177,11 @@ object Types {
    *  do not survive runs whereas typerefs do.
    */
   abstract case class ThisType(tref: TypeRef) extends CachedProxyType with SingletonType {
-    def cls(implicit ctx: Context): ClassSymbol = tref.stableInRunSymbol.asClass
+    def cls(implicit ctx: Context): ClassSymbol = tref.stableInRunSymbol match {
+      case cls: ClassSymbol => cls
+      case _ if ctx.mode.is(Mode.Interactive) => defn.AnyClass // was observed to happen in IDE mode
+    }
+
     override def underlying(implicit ctx: Context): Type =
       if (ctx.erasedTypes) tref
       else cls.info match {


### PR DESCRIPTION
This was observed repeatedly as a PC crash.