### PR TITLE
Fix #4375: Properly erase SeqLiteral

### DIFF
--- a/tests/pos/i4375.scala
+++ b/tests/pos/i4375.scala
@@ -1,0 +1,13 @@
+object Test {
+  type Id[A] >: A
+  def test: Unit = {
+    val a: Array[_ >: Id[Int]] = Array(1, 2)
+    val b = a(0)
+  }
+
+  class VC(i: String) extends AnyVal
+  def test2: Unit = {
+    val c: Array[_ >: Id[VC]] = Array(new VC(""))
+    val d = c(0)
+  }
+}


### PR DESCRIPTION
Before this commit, the `SeqLiteral#elems` were typed based on the
SeqLiteral prototype, which means that nothing ensured that the elems
types conformed to the type of `SeqLiteral#elemtpt`. In i4375.scala this
means that erasing `SeqLiteral([1, 2], Object)` did not box each element
because the expected element type was `WildcardType`.

To prevent this sort of issue, we now use the type of SeqLiteral#elemtpt
if it exists as the expected type of each element in the sequence.