### PR TITLE
Fix #4390: Sort REPL autocomplete suggestions

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -219,7 +219,7 @@ object Interactive {
       case _  => getScopeCompletions(ctx)
     }
     interactiv.println(i"completion with pos = $pos, prefix = $prefix, termOnly = $termOnly, typeOnly = $typeOnly = ${completions.toList}%, %")
-    (completionPos, completions.toList)
+    (completionPos, completions.toList.sortBy(_.name.show))
   }
 
   /** Possible completions of members of `prefix` which are accessible when called inside `boundary` */

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -218,8 +218,10 @@ object Interactive {
       case (sel @ Select(qual, _)) :: _ => getMemberCompletions(qual)
       case _  => getScopeCompletions(ctx)
     }
-    interactiv.println(i"completion with pos = $pos, prefix = $prefix, termOnly = $termOnly, typeOnly = $typeOnly = ${completions.toList}%, %")
-    (completionPos, completions.toList.sortBy(_.name.toString))
+
+    val sortedCompletions = completions.toList.sortBy(_.name: Name)
+    interactiv.println(i"completion with pos = $pos, prefix = $prefix, termOnly = $termOnly, typeOnly = $typeOnly = $sortedCompletions%, %")
+    (completionPos, sortedCompletions)
   }
 
   /** Possible completions of members of `prefix` which are accessible when called inside `boundary` */

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -219,7 +219,7 @@ object Interactive {
       case _  => getScopeCompletions(ctx)
     }
     interactiv.println(i"completion with pos = $pos, prefix = $prefix, termOnly = $termOnly, typeOnly = $typeOnly = ${completions.toList}%, %")
-    (completionPos, completions.toList.sortBy(_.name.show))
+    (completionPos, completions.toList.sortBy(_.name.toString))
   }
 
   /** Possible completions of members of `prefix` which are accessible when called inside `boundary` */

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -68,11 +68,11 @@ class TabcompleteTests extends ReplTest {
 
   @Test def sortedCompletions: Unit =
     fromInitialState { implicit state  =>
-      val src = """class Foo { def comp1 = 1; def compa = 3; def compA = 4 }"""
+      val src = "class Foo { def comp3 = 3; def comp1 = 1; def comp2 = 2 }"
       compiler.compile(src).stateOrFail
     }
     .andThen { implicit state =>
-      val expected = List("comp1", "compA", "compa")
+      val expected = List("comp1", "comp2", "comp3")
       assertEquals(expected, tabComplete("(new Foo).comp").suggestions)
     }
 }

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -65,4 +65,14 @@ class TabcompleteTests extends ReplTest {
       List("\"", ")", "'", "¨", "£", ":", ",", ";", "@", "}", "[", "]")
         .foreach(src => assertTrue(tabComplete(src).suggestions.isEmpty))
     }
+
+  @Test def sortedCompletions: Unit =
+    fromInitialState { implicit state  =>
+      val src = """class Foo { def comp1 = 1; def compa = 3; def compA = 4 }"""
+      compiler.compile(src).stateOrFail
+    }
+    .andThen { implicit state =>
+      val expected = List("comp1", "compA", "compa")
+      assertEquals(expected, tabComplete("(new Foo).comp").suggestions)
+    }
 }


### PR DESCRIPTION
This seems to be a quick fix for https://github.com/lampepfl/dotty/issues/4390. Its my first PR to dotty so I might be missing something.