### PR TITLE
Fix #4373: reject wildcard types in syntactically invalid positions

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1130,9 +1130,7 @@ object desugar {
         Apply(Select(Apply(Ident(nme.StringContext), strs), id), elems)
       case InfixOp(l, op, r) =>
         if (ctx.mode is Mode.Type)
-          if (!op.isBackquoted && op.name == tpnme.raw.AMP) AndTypeTree(l, r)     // l & r
-          else if (!op.isBackquoted && op.name == tpnme.raw.BAR) OrTypeTree(l, r) // l | r
-          else AppliedTypeTree(op, l :: r :: Nil) // op[l, r]
+          AppliedTypeTree(op, l :: r :: Nil) // op[l, r]
         else {
           assert(ctx.mode is Mode.Pattern) // expressions are handled separately by `binop`
           Apply(op, l :: r :: Nil) // op(l, r)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2287,7 +2287,8 @@ object Parsers {
     /** ConstrApp         ::=  SimpleType {ParArgumentExprs}
      */
     val constrApp = () => {
-      val t = checkWildcard(annotType())
+      // Using Ident(nme.ERROR) to avoid causing cascade errors on non-user-written code
+      val t = checkWildcard(annotType(), fallbackTree = Ident(nme.ERROR))
       if (in.token == LPAREN) parArgumentExprss(wrapNew(t))
       else t
     }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -835,7 +835,7 @@ object Parsers {
         if (ctx.settings.strict.value)
           deprecationWarning(DeprecatedWithOperator())
         in.nextToken()
-        AndTypeTree(t, withType())
+        AndTypeTree(checkWildcard(t), checkWildcard(withType()))
       }
       else t
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -452,7 +452,7 @@ object Parsers {
       if (isLeftAssoc(op1) != op2LeftAssoc)
         syntaxError(MixedLeftAndRightAssociativeOps(op1, op2, op2LeftAssoc), offset)
 
-    def reduceStack(base: List[OpInfo], top: Tree, prec: Int, leftAssoc: Boolean, op2: Name): Tree = {
+    def reduceStack(base: List[OpInfo], top: Tree, prec: Int, leftAssoc: Boolean, op2: Name, isType: Boolean): Tree = {
       if (opStack != base && precedence(opStack.head.operator.name) == prec)
         checkAssoc(opStack.head.offset, opStack.head.operator.name, op2, leftAssoc)
       def recur(top: Tree): Tree = {
@@ -464,7 +464,15 @@ object Parsers {
             opStack = opStack.tail
             recur {
               atPos(opInfo.operator.pos union opInfo.operand.pos union top.pos) {
-                InfixOp(opInfo.operand, opInfo.operator, top)
+                val op = opInfo.operator
+                val l = opInfo.operand
+                val r = top
+                if (isType && !op.isBackquoted && op.name == tpnme.raw.BAR) {
+                  OrTypeTree(l, r)
+                } else if (isType && !op.isBackquoted && op.name == tpnme.raw.AMP) {
+                  AndTypeTree(l, r)
+                } else
+                  InfixOp(l, op, r)
               }
             }
           }
@@ -488,20 +496,20 @@ object Parsers {
       var top = first
       while (isIdent && isOperator) {
         val op = if (isType) typeIdent() else termIdent()
-        top = reduceStack(base, top, precedence(op.name), isLeftAssoc(op.name), op.name)
+        top = reduceStack(base, top, precedence(op.name), isLeftAssoc(op.name), op.name, isType)
         opStack = OpInfo(top, op, in.offset) :: opStack
         newLineOptWhenFollowing(canStartOperand)
         if (maybePostfix && !canStartOperand(in.token)) {
           val topInfo = opStack.head
           opStack = opStack.tail
-          val od = reduceStack(base, topInfo.operand, 0, true, in.name)
+          val od = reduceStack(base, topInfo.operand, 0, true, in.name, isType)
           return atPos(startOffset(od), topInfo.offset) {
             PostfixOp(od, topInfo.operator)
           }
         }
         top = operand()
       }
-      reduceStack(base, top, 0, true, in.name)
+      reduceStack(base, top, 0, true, in.name, isType)
     }
 
 /* -------- IDENTIFIERS AND LITERALS ------------------------------------------- */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -468,9 +468,9 @@ object Parsers {
                 val l = opInfo.operand
                 val r = top
                 if (isType && !op.isBackquoted && op.name == tpnme.raw.BAR) {
-                  OrTypeTree(l, r)
+                  OrTypeTree(checkWildcard(l), checkWildcard(r))
                 } else if (isType && !op.isBackquoted && op.name == tpnme.raw.AMP) {
-                  AndTypeTree(l, r)
+                  AndTypeTree(checkWildcard(l), checkWildcard(r))
                 } else
                   InfixOp(l, op, r)
               }
@@ -784,7 +784,7 @@ object Parsers {
           val start = in.offset
           val tparams = typeParamClause(ParamOwner.TypeParam)
           if (in.token == ARROW)
-            atPos(start, in.skipToken())(LambdaTypeTree(tparams, typ()))
+            atPos(start, in.skipToken())(LambdaTypeTree(tparams, toplevelTyp()))
           else { accept(ARROW); typ() }
         }
         else infixType()
@@ -822,7 +822,7 @@ object Parsers {
 
     def refinedTypeRest(t: Tree): Tree = {
       newLineOptWhenFollowedBy(LBRACE)
-      if (in.token == LBRACE) refinedTypeRest(atPos(startOffset(t)) { RefinedTypeTree(t, refinement()) })
+      if (in.token == LBRACE) refinedTypeRest(atPos(startOffset(t)) { RefinedTypeTree(checkWildcard(t), refinement()) })
       else t
     }
 
@@ -886,7 +886,7 @@ object Parsers {
     private def simpleTypeRest(t: Tree): Tree = in.token match {
       case HASH => simpleTypeRest(typeProjection(t))
       case LBRACKET => simpleTypeRest(atPos(startOffset(t)) {
-        AppliedTypeTree(t, typeArgs(namedOK = false, wildOK = true)) })
+        AppliedTypeTree(checkWildcard(t), typeArgs(namedOK = false, wildOK = true)) })
       case _ => t
     }
 
@@ -2159,7 +2159,7 @@ object Parsers {
         in.token match {
           case EQUALS =>
             in.nextToken()
-            TypeDef(name, lambdaAbstract(tparams, typ())).withMods(mods).setComment(in.getDocComment(start))
+            TypeDef(name, lambdaAbstract(tparams, toplevelTyp())).withMods(mods).setComment(in.getDocComment(start))
           case SUPERTYPE | SUBTYPE | SEMI | NEWLINE | NEWLINES | COMMA | RBRACE | EOF =>
             TypeDef(name, lambdaAbstract(tparams, typeBounds())).withMods(mods).setComment(in.getDocComment(start))
           case _ =>
@@ -2287,7 +2287,7 @@ object Parsers {
     /** ConstrApp         ::=  SimpleType {ParArgumentExprs}
      */
     val constrApp = () => {
-      val t = annotType()
+      val t = checkWildcard(annotType())
       if (in.token == LPAREN) parArgumentExprss(wrapNew(t))
       else t
     }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -768,9 +768,16 @@ object Parsers {
             accept(RPAREN)
             if (imods.is(Implicit) || isValParamList || in.token == ARROW) functionRest(ts)
             else {
-              for (t <- ts)
-                if (t.isInstanceOf[ByNameTypeTree])
-                  syntaxError(ByNameParameterNotSupported())
+              val ts1 =
+                for (t <- ts) yield {
+                  t match {
+                    case t@ByNameTypeTree(t1) =>
+                      syntaxError(ByNameParameterNotSupported(t), t.pos)
+                      t1
+                    case _ =>
+                      t
+                  }
+                }
               val tuple = atPos(start) { makeTupleOrParens(ts) }
               infixTypeRest(
                 refinedTypeRest(

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -696,10 +696,10 @@ object messages {
     }
   }
 
-  case class ByNameParameterNotSupported()(implicit ctx: Context)
+  case class ByNameParameterNotSupported(tpe: untpd.TypTree)(implicit ctx: Context)
   extends Message(ByNameParameterNotSupportedID) {
     val kind = "Syntax"
-    val msg = "By-name parameter type not allowed here."
+    val msg = hl"By-name parameter type ${tpe} not allowed here."
 
     val explanation =
       hl"""|By-name parameters act like functions that are only evaluated when referenced,

--- a/tests/neg/i4373.scala
+++ b/tests/neg/i4373.scala
@@ -1,0 +1,23 @@
+trait Base
+trait TypeConstr[X]
+
+class X1[A >: _ | X1[_]] // error
+class X2[A >: _ & X2[_]] // error
+class X3[A >: X3[_] | _] // error
+class X4[A >: X4[_] & _] // error
+
+class A1 extends _ // error
+class A2 extends _ with _ // error // error
+class A3 extends Base with _ // error
+class A4 extends _ with Base // error
+
+object Test {
+  type T1 = _ // error
+  type T2 = _[Int] // error
+  type T3 = _ { type S } // error
+  type T4 = [X] => _ // error
+
+  // Open questions:
+  type T5 = TypeConstr[_ { type S }] // error
+  type T5 = TypeConstr[_[Int]] // error
+}

--- a/tests/neg/i4373.scala
+++ b/tests/neg/i4373.scala
@@ -30,4 +30,22 @@ object Test {
   type T10 = (Int => Int) | (=> Int) // error
   type T11 = (Int => Int) & (=> Int) // error
   type T12 = (Int => Int) with (=> Int) // error
+
+  // annotations
+  type T13 = _ @ annotation.tailrec // error
+  type T14 = Int @ _ // error
+  type T15 = (_ | Int) @ annotation.tailrec // error
+  type T16 = (Int | _) @ annotation.tailrec // error
+  type T17 = Int @ (_ | annotation.tailrec) // error
+  type T18 = Int @ (annotation.tailrec | _) // error
+
+  type T19 = (_ with Int) @ annotation.tailrec // error
+  type T20 = (Int with _) @ annotation.tailrec // error
+  type T21 = Int @ (_ with annotation.tailrec) // error // error
+  type T22 = Int @ (annotation.tailrec with _) // error // error
+
+  type T23 = (_ & Int) @ annotation.tailrec // error
+  type T24 = (Int & _) @ annotation.tailrec // error
+  type T25 = Int @ (_ & annotation.tailrec) // error
+  type T26 = Int @ (annotation.tailrec & _) // error
 }

--- a/tests/neg/i4373.scala
+++ b/tests/neg/i4373.scala
@@ -21,5 +21,13 @@ object Test {
 
   // Open questions:
   type T5 = TypeConstr[_ { type S }] // error
-  type T5 = TypeConstr[_[Int]] // error
+  type T6 = TypeConstr[_[Int]] // error
+
+  // expression types
+  type T7 = (=> Int) | (Int => Int) // error
+  type T8 = (=> Int) & (Int => Int) // error
+  type T9 = (=> Int) with (Int => Int) // error
+  type T10 = (Int => Int) | (=> Int) // error
+  type T11 = (Int => Int) & (=> Int) // error
+  type T12 = (Int => Int) with (=> Int) // error
 }

--- a/tests/neg/i4373.scala
+++ b/tests/neg/i4373.scala
@@ -5,6 +5,8 @@ class X1[A >: _ | X1[_]] // error
 class X2[A >: _ & X2[_]] // error
 class X3[A >: X3[_] | _] // error
 class X4[A >: X4[_] & _] // error
+class X5[A >: _ with X5[_]] // error
+class X6[A >: X6[_] with _] // error
 
 class A1 extends _ // error
 class A2 extends _ with _ // error // error

--- a/tests/neg/i4373a.scala
+++ b/tests/neg/i4373a.scala
@@ -1,0 +1,3 @@
+// ==> 040fb47fbaf718cecb11a7d51ac5a48bf4f6a1fe.scala <==
+object x0 {
+  val x0 : _ with // error // error // error

--- a/tests/neg/i4373b.scala
+++ b/tests/neg/i4373b.scala
@@ -1,0 +1,4 @@
+// ==> 05bef7805687ba94da37177f7568e3ba7da1f91c.scala <==
+class x0 {
+  x1: // error
+      x0 | _ // error // error

--- a/tests/neg/i4373c.scala
+++ b/tests/neg/i4373c.scala
@@ -1,0 +1,3 @@
+// ==> 18b253a4a89a84c5674165c6fc3efafad535eee3.scala <==
+object x0 {
+  def x1[x2 <:_[ // error // error // error


### PR DESCRIPTION
The testcase is from examples in #4373, variations and tests for types with wildcards. I'm unsure for a couple cases.

The strategy I use comes from generalizing existing code.

A separate commit avoids cascade errors. That was the trickiest part of this PR, but pretty instructive. I now sometimes use `Ident(nme.ERROR)` instead of `scalaAny` to replace illegal wildcards in `extends` clauses.

Action items:
- [x] rebase
- [x] merge #4424 since it was approved
- [x] make `checkWildcard` private to Parsers again
- [x] go through #4389 and try all reported issues in Bugs.txt that contain a `_` somewhere.
- [x] test and fix `with` too (noticed from #4389)
- [x] add testcases with annotations