### PR TITLE
Prevent position errors on Ident(nme.ERROR)

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1975,24 +1975,20 @@ object Parsers {
     /** ImportSelector ::= id [`=>' id | `=>' `_']
      */
     def importSelector(): Tree = {
-      val start = in.offset
       val from = termIdentOrWildcard()
       if (from.name != nme.WILDCARD && in.token == ARROW)
         atPos(startOffset(from), in.skipToken()) {
-          val start2 = in.offset
+          val start = in.offset
           val to = termIdentOrWildcard()
           val toWithPos =
             if (to.name == nme.ERROR)
               // error identifiers don't consume any characters, so atPos(start)(id) wouldn't set a position.
               // Some testcases would then fail in Positioned.checkPos. Set a position anyway!
-              atPos(start2, start2, in.lastOffset)(to)
+              atPos(start, start, in.lastOffset)(to)
             else
               to
           Thicket(from, toWithPos)
         }
-      else if (from.name == nme.ERROR) {
-        atPos(start, start, in.lastOffset)(from)
-      }
       else from
     }
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -518,16 +518,8 @@ object Parsers {
       }
 
     /** Accept identifier and return Ident with its name as a term name. */
-    def termIdent(): Ident = {
-      val start = in.offset
-      val id = makeIdent(in.token, ident())
-      if (id.name != nme.ERROR) {
-        atPos(start)(id)
-      } else {
-        // error identifiers don't consume any characters, so atPos(start)(id) wouldn't set a position.
-        // Some testcases would then fail in Positioned.checkPos. Set a position anyway!
-        atPos(start, start, in.lastOffset)(id)
-      }
+    def termIdent(): Ident = atPos(in.offset) {
+      makeIdent(in.token, ident())
     }
 
     /** Accept identifier and return Ident with its name as a type name. */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -518,8 +518,16 @@ object Parsers {
       }
 
     /** Accept identifier and return Ident with its name as a term name. */
-    def termIdent(): Ident = atPos(in.offset) {
-      makeIdent(in.token, ident())
+    def termIdent(): Ident = {
+      val start = in.offset
+      val id = makeIdent(in.token, ident())
+      if (id.name != nme.ERROR) {
+        atPos(start)(id)
+      } else {
+        // error identifiers don't consume any characters, so atPos(start)(id) wouldn't set a position.
+        // Some testcases would then fail in Positioned.checkPos. Set a position anyway!
+        atPos(start, start, in.lastOffset)(id)
+      }
     }
 
     /** Accept identifier and return Ident with its name as a type name. */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1975,11 +1975,24 @@ object Parsers {
     /** ImportSelector ::= id [`=>' id | `=>' `_']
      */
     def importSelector(): Tree = {
+      val start = in.offset
       val from = termIdentOrWildcard()
       if (from.name != nme.WILDCARD && in.token == ARROW)
         atPos(startOffset(from), in.skipToken()) {
-          Thicket(from, termIdentOrWildcard())
+          val start2 = in.offset
+          val to = termIdentOrWildcard()
+          val toWithPos =
+            if (to.name == nme.ERROR)
+              // error identifiers don't consume any characters, so atPos(start)(id) wouldn't set a position.
+              // Some testcases would then fail in Positioned.checkPos. Set a position anyway!
+              atPos(start2, start2, in.lastOffset)(to)
+            else
+              to
+          Thicket(from, toWithPos)
         }
+      else if (from.name == nme.ERROR) {
+        atPos(start, start, in.lastOffset)(from)
+      }
       else from
     }
 

--- a/tests/neg/parser-stability-23.scala
+++ b/tests/neg/parser-stability-23.scala
@@ -1,0 +1,3 @@
+object i0 {
+  import Ordering.{ implicitly => } (true: Boolean) match { case _: i1 => true } // error // error
+}


### PR DESCRIPTION
Stop-gap fix for
```
Exception in thread "main" java.lang.AssertionError: assertion failed: position error: position not set for Ident(<error>) # 24
	at dotty.DottyPredef$.assertFail(DottyPredef.scala:36)
	at dotty.tools.dotc.ast.Positioned.check$1(Positioned.scala:178)
	at dotty.tools.dotc.ast.Positioned.check$5$$anonfun$4(Positioned.scala:203)
```

which comes up often on the unminimized @alexknvl errors.

This fix looks wrong, and I've seen the comment in `atPos` on the logic I'm fighting against, but I don't yet understand the logic enough for a proper fix.