### PR TITLE
Fix handling of special implicit searches for ClassTag, quoted.Type, Eq

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1674,12 +1674,12 @@ object SymDenotations {
                       else NoType
                     else
                       recur(clsd.typeRef).asSeenFrom(prefix, clsd.owner)
-                  if (baseTp.exists) record(tp, baseTp) else btrCache.remove(tp)
+                  record(tp, baseTp)
                   baseTp
                 case _ =>
                   val superTp = tp.superType
                   val baseTp = recur(superTp)
-                  if (baseTp.exists && inCache(superTp) && tp.symbol.maybeOwner.isType)
+                  if (inCache(superTp) && tp.symbol.maybeOwner.isType)
                     record(tp, baseTp)   // typeref cannot be a GADT, so cache is stable
                   else
                     btrCache.remove(tp)
@@ -1700,7 +1700,7 @@ object SymDenotations {
                   case tparams: List[Symbol @unchecked] =>
                     recur(tycon).subst(tparams, args)
                 }
-              if (baseTp.exists) record(tp, baseTp) else btrCache.remove(tp)
+              record(tp, baseTp)
               baseTp
             }
             computeApplied

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2438,7 +2438,14 @@ object Types {
 
   // --- AndType/OrType ---------------------------------------------------------------
 
-  abstract case class AndType(tp1: Type, tp2: Type) extends CachedGroundType with ValueType {
+  abstract class AndOrType extends CachedGroundType with ValueType {
+    def isAnd: Boolean
+    def tp1: Type
+    def tp2: Type
+  }
+
+  abstract case class AndType(tp1: Type, tp2: Type) extends AndOrType {
+    def isAnd = true
     private[this] var myBaseClassesPeriod: Period = Nowhere
     private[this] var myBaseClasses: List[ClassSymbol] = _
     /** Base classes of are the merge of the operand base classes. */
@@ -2502,7 +2509,8 @@ object Types {
         if (checkValid) apply(tp1, tp2) else unchecked(tp1, tp2)
   }
 
-  abstract case class OrType(tp1: Type, tp2: Type) extends CachedGroundType with ValueType {
+  abstract case class OrType(tp1: Type, tp2: Type) extends AndOrType {
+    def isAnd = false
     private[this] var myBaseClassesPeriod: Period = Nowhere
     private[this] var myBaseClasses: List[ClassSymbol] = _
     /** Base classes of are the intersection of the operand base classes. */

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -863,30 +863,6 @@ object Types {
       }
     }
 
-    /** Like basetype, but follow context bounds */
-    final def contextualBaseType(cls: ClassSymbol)(implicit ctx: Context): Type = {
-      def loop(tp: Type): Type = tp match {
-        case tp: TypeRef =>
-          val sym = tp.symbol
-          if (sym.isClass) tp.baseType(cls) else loop(tp.superType): @tailrec
-        case tp: AppliedType =>
-          tp.baseType(cls)
-        case tp: TypeParamRef =>
-          loop(ctx.typeComparer.bounds(tp).hi): @tailrec
-        case tp: TypeProxy =>
-          loop(tp.superType): @tailrec
-        case tp: AndType =>
-          loop(tp.tp1) & loop(tp.tp2): @tailrec
-        case tp: OrType =>
-          loop(tp.tp1) | loop(tp.tp2): @tailrec
-        case tp: JavaArrayType =>
-          if (cls == defn.ObjectClass) cls.typeRef else NoType
-        case _ =>
-          NoType
-      }
-      loop(this)
-    }
-
     def & (that: Type)(implicit ctx: Context): Type = track("&") {
       ctx.typeComparer.glb(this, that)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -652,7 +652,7 @@ trait Implicits { self: Typer =>
           arg
       case fail @ SearchFailure(failed) =>
         def trySpecialCase(cls: ClassSymbol, handler: Type => Tree, ifNot: => Tree) = {
-          val base = formalValue.contextualBaseType(cls)
+          val base = formalValue.baseType(cls)
           if (base <:< formalValue) {
             // With the subtype test we enforce that the searched type `formalValue` is of the right form
             handler(base).orElse(ifNot)

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -650,17 +650,20 @@ trait Implicits { self: Typer =>
             ref(lazyImplicit))
         else
           arg
-      case fail @ SearchFailure(tree) =>
-        if (fail.isAmbiguous)
-          tree
-        else if (formalValue.isRef(defn.ClassTagClass))
-          synthesizedClassTag(formalValue).orElse(tree)
-        else if (formalValue.isRef(defn.QuotedTypeClass))
-          synthesizedTypeTag(formalValue).orElse(tree)
-        else if (formalValue.isRef(defn.EqClass))
-          synthesizedEq(formalValue).orElse(tree)
+      case fail @ SearchFailure(failed) =>
+        def trySpecialCase(cls: ClassSymbol, handler: Type => Tree, ifNot: => Tree) = {
+          val base = formalValue.contextualBaseType(cls)
+          if (base <:< formalValue) {
+            // With the subtype test we enforce that the searched type `formalValue` is of the right form
+            handler(base).orElse(ifNot)
+          }
+          else ifNot
+        }
+        if (fail.isAmbiguous) failed
         else
-          tree
+          trySpecialCase(defn.ClassTagClass, synthesizedClassTag,
+            trySpecialCase(defn.QuotedTypeClass, synthesizedTypeTag,
+              trySpecialCase(defn.EqClass, synthesizedEq, failed)))
     }
   }
 

--- a/tests/run/inlineForeach.scala
+++ b/tests/run/inlineForeach.scala
@@ -35,6 +35,22 @@ object Test {
     zs
   }
 
+  implicit class intArrayOps(arr: Array[Int]) {
+    inline def foreach(inline op: Int => Unit): Unit = {
+      var i = 0
+      while (i < arr.length) {
+        op(arr(i))
+        i += 1
+      }
+    }
+  }
+
+  def sum(ints: Array[Int]): Int = {
+    var t = 0
+    for (n <- ints) t += n
+    t
+  }
+
   def main(args: Array[String]) = {
     1.until(10).foreach(i => println(i))
     1.until(10).foreach(println(_))
@@ -44,5 +60,8 @@ object Test {
     for (k1 <- 1 to 10)
       for (k2 <- 1 to 10)
         println(s"$k1")
+
+    val xs = Array(1, 2, 3, 4)
+    assert(sum(xs) == 10, sum(xs))
   }
 }

--- a/tests/run/patmatch-classtag.scala
+++ b/tests/run/patmatch-classtag.scala
@@ -18,7 +18,7 @@ object dotc {
 object Impl extends API {
   type CaseDef = dotc.CaseDef
 
-  val tagForCaseDef: ClassTag[dotc.CaseDef] = implicitly[ClassTag[dotc.CaseDef]]
+  val tagForCaseDef: ClassTag[dotc.CaseDef] = implicitly
 
   object CaseDef extends CaseDefCompanion {
     def apply(str: String): CaseDef = dotc.CaseDef(str)


### PR DESCRIPTION
They did not work if the searched-for type was an uninstantiated TypeVar that
had the class as an upper bound. Getting them to work is surprisingly subtle.