### PR TITLE
Avoid classcast exception in IDE

### DIFF
--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -257,9 +257,12 @@ class DottyLanguageServer extends LanguageServer
         if (enclTree.isInstanceOf[MemberDef])
           (driver.allTreesContaining(sym.name.sourceModuleName.toString),
            Include.overriding | Include.overridden)
-        else
-          (SourceTree.fromSymbol(sym.topLevelClass.asClass).toList,
-           Include.overriding)
+        else sym.topLevelClass match {
+          case cls: ClassSymbol =>
+            (SourceTree.fromSymbol(cls).toList, Include.overriding)
+          case _ =>
+            (Nil, Include.overriding)
+        }
       val defs = Interactive.namedTrees(trees, include, sym)
       defs.map(d => location(d.namePos)).asJava
     }


### PR DESCRIPTION
We assumed that the toplevel class is always a ClassSymbol, but that assumption was wrong
in some code I was editing, which caused a crash at the point where the fix is done.