### PR TITLE
add readResolve to objects with serializable interface

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -551,6 +551,8 @@ class Definitions {
       case _ => false
     }).symbol.asTerm
   lazy val JavaSerializableClass     = ctx.requiredClass("java.io.Serializable")
+  def readResolve(cls: ClassSymbol, flags: FlagSet) = enterMethod(cls, nme.readResolve, MethodType(Nil, AnyRefType), flags)
+
   lazy val ComparableClass           = ctx.requiredClass("java.lang.Comparable")
 
   lazy val SystemClass               = ctx.requiredClass("java.lang.System")

--- a/tests/run/serialize.scala
+++ b/tests/run/serialize.scala
@@ -8,9 +8,23 @@ object Test {
     in.readObject.asInstanceOf[T]
   }
 
+  object Foo extends Serializable {}
+
+  object Baz extends Serializable {
+    private def readResolve(): AnyRef = {
+      this
+    }
+  }
+
   def main(args: Array[String]): Unit = {
     val x: PartialFunction[Int, Int] = { case x => x + 1 }
     val adder = serializeDeserialize(x)
     assert(adder(1) == 2)
+
+    val foo = serializeDeserialize(Foo)
+    assert(foo eq Foo)
+
+    val baz = serializeDeserialize(Baz)
+    assert(baz ne Baz)
   }
 }


### PR DESCRIPTION
If the object implements the serializable interface and not includes the
readResolve method then we add it. Since it's an object we reference it
to the objects singleton instance.

Resolves issue #4440