### PR TITLE
Add Term.toExpr in Tasty

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/Toolbox.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/Toolbox.scala
@@ -1,7 +1,9 @@
 package dotty.tools.dotc.quoted
 
 import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Constants._
+import dotty.tools.dotc.core.quoted.PickledQuotes
 import dotty.tools.dotc.printing.RefinedPrinter
 
 import scala.quoted.Expr

--- a/library/src/scala/tasty/Tasty.scala
+++ b/library/src/scala/tasty/Tasty.scala
@@ -180,7 +180,9 @@ abstract class Tasty { tasty =>
 
   type Term <: Statement with Parent
 
-  trait AbstractTerm extends Typed with Positioned
+  trait AbstractTerm extends Typed with Positioned {
+    def toExpr[T: quoted.Type](implicit ctx: Context): quoted.Expr[T]
+  }
   implicit def TermDeco(t: Term): AbstractTerm
 
   implicit def termClassTag: ClassTag[Term]

--- a/library/src/scala/tasty/TastyTypecheckError.scala
+++ b/library/src/scala/tasty/TastyTypecheckError.scala
@@ -1,0 +1,3 @@
+package scala.tasty
+
+class TastyTypecheckError(msg: String) extends Throwable

--- a/tests/neg/tasty-macro-assert/quoted_1.scala
+++ b/tests/neg/tasty-macro-assert/quoted_1.scala
@@ -35,10 +35,7 @@ object Asserts {
 
     tree match {
       case Term.Apply(Term.Select(OpsTree(left), op, _), right :: Nil) =>
-        op match {
-          case "===" => '(assertEquals(~left.toExpr[Any], ~right.toExpr[Any]))
-          case "!==" => '(assertNotEquals(~left.toExpr[Any], ~right.toExpr[Any]))
-        }
+        '(assertTrue(~left.toExpr[Boolean])) // Buggy code. To generate the errors
       case _ =>
         '(assertTrue(~cond))
     }

--- a/tests/neg/tasty-macro-assert/quoted_2.scala
+++ b/tests/neg/tasty-macro-assert/quoted_2.scala
@@ -1,0 +1,12 @@
+
+import Asserts._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    macroAssert(true === "cde")
+    macroAssert("acb" === "cde") // error
+    macroAssert(false !== "acb")
+    macroAssert("acb" !== "acb") // error
+  }
+
+}

--- a/tests/run/tasty-macro-assert.check
+++ b/tests/run/tasty-macro-assert.check
@@ -1,7 +1,7 @@
 Condition was false
 Error left did not equal right:
-  left  = Term.Literal(Constant.String("acb"))
-  right = Term.Literal(Constant.String("cde"))
+  left  = acb
+  right = cde
 Error left was equal to right:
-  left  = Term.Literal(Constant.String("acb"))
-  right = Term.Literal(Constant.String("acb"))
+  left  = acb
+  right = acb


### PR DESCRIPTION
Add a transformation from a `Tasty.Term` to an `Expr[T]`. A type tag `quoted.Type[T]` is required as type evidence.