### PR TITLE
Fix current working directory for building Dotty from cmdline wrappers

### DIFF
--- a/bin/common
+++ b/bin/common
@@ -17,7 +17,7 @@ new_files="$(find "$ROOT/compiler" \( -iname "*.scala" -o -iname "*.java" \) -ne
 
 if [ ! -f "$version" ] || [ ! -z "$new_files" ]; then
   echo "Building Dotty..."
-  sbt "dist-bootstrapped/pack"
+  (cd $ROOT && sbt "dist-bootstrapped/pack")
 fi
 
 eval "$target" "$@"


### PR DESCRIPTION
This fix running e.g. `dotc` in subdirectories of the dotty checkout when Dotty needs rebuilding. Most of `bin/common` accounts for being run in a subdirectory, but the call to sbt didn't.