### PR TITLE
Fix #4449: PatternMatcher needs to split call nodes if arguments differ

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -698,13 +698,15 @@ object PatternMatcher {
               for ((rhs, _) <- seenVars if !seenAtLabel(plan.label).contains(rhs))
               yield (rhs, newVar(rhs.tree, Param))
           }
-          plan.args =
+          val newArgs =
             for {
               (rhs, actual) <- seenVars.toList
               formal <- paramsOfLabel(plan.label).get(rhs)
             }
             yield (formal -> actual)
-          plan
+          if (plan.args.isEmpty) { plan.args = newArgs; plan }
+          else if (newArgs == plan.args) plan
+          else CallPlan(plan.label, newArgs)
         }
       }
       (new Merge(Map()))(plan)

--- a/tests/pos/i4449.scala
+++ b/tests/pos/i4449.scala
@@ -1,0 +1,43 @@
+class TreeAccumulator2 {
+
+  def foo(tasty: Tasty2)(tree: Any): Unit = {
+    import tasty._
+    tree match {
+      case A() =>
+      case B() =>
+      case C() =>
+      case D() =>
+    }
+  }
+
+}
+
+abstract class Tasty2 {
+
+  type X
+  type Y
+
+  implicit def xct: scala.reflect.ClassTag[X]
+  implicit def yct: scala.reflect.ClassTag[Y]
+
+  val A: AExtractor
+  trait AExtractor {
+    def unapply(x: X): Boolean
+  }
+
+  val B: BExtractor
+  trait BExtractor {
+    def unapply(x: X): Boolean
+  }
+
+  val C: CExtractor
+  trait CExtractor {
+    def unapply(x: Y): Boolean // Note the type Y
+  }
+
+  val D: DExtractor
+  trait DExtractor {
+    def unapply(x: X): Boolean
+  }
+
+}


### PR DESCRIPTION
The merge phase of a pattern matcher needs to split a call node if it is used
in different places with different arguments.