### PR TITLE
Try to refine handling of SymDenotations

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/CollectEntryPoints.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CollectEntryPoints.scala
@@ -61,11 +61,11 @@ object CollectEntryPoints{
     val StringType = d.StringType
     // The given class has a main method.
     def hasJavaMainMethod(sym: Symbol): Boolean =
-      (toDenot(sym).info member nme.main).alternatives exists(x => isJavaMainMethod(x.symbol))
+      (sym.info member nme.main).alternatives exists(x => isJavaMainMethod(x.symbol))
 
     def fail(msg: String, pos: Position = sym.pos) = {
       ctx.warning(          sym.name +
-        s" has a main method with parameter type Array[String], but ${toDenot(sym).fullName} will not be a runnable program.\n  Reason: $msg",
+        s" has a main method with parameter type Array[String], but ${sym.fullName} will not be a runnable program.\n  Reason: $msg",
         sourcePos(sym.pos)
         // TODO: make this next claim true, if possible
         //   by generating valid main methods as static in module classes
@@ -77,7 +77,7 @@ object CollectEntryPoints{
     def failNoForwarder(msg: String) = {
       fail(s"$msg, which means no static forwarder can be generated.\n")
     }
-    val possibles = if (sym.flags is Flags.Module) (toDenot(sym).info nonPrivateMember nme.main).alternatives else Nil
+    val possibles = if (sym.flags is Flags.Module) (sym.info nonPrivateMember nme.main).alternatives else Nil
     val hasApproximate = possibles exists { m =>
       m.info match {
         case MethodTpe(_, p :: Nil, _) => p.typeSymbol == defn.ArrayClass
@@ -94,7 +94,7 @@ object CollectEntryPoints{
 
         if (hasJavaMainMethod(companion))
           failNoForwarder("companion contains its own main method")
-        else if (toDenot(companion).info.member(nme.main) != NoDenotation)
+        else if (companion.info.member(nme.main) != NoDenotation)
         // this is only because forwarders aren't smart enough yet
           failNoForwarder("companion contains its own main method (implementation restriction: no main is allowed, regardless of signature)")
         else if (companion.flags is Flags.Trait)
@@ -103,7 +103,7 @@ object CollectEntryPoints{
         // attempts to be java main methods.
         else (possibles exists(x=> isJavaMainMethod(x.symbol))) || {
           possibles exists { m =>
-            toDenot(m.symbol).info match {
+            m.symbol.info match {
               case t: PolyType =>
                 fail("main methods cannot be generic.")
               case MethodTpe(paramNames, paramTypes, resultType) =>

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -697,7 +697,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
               val sym = tree.symbol
               val prevDenot = sym.denot(ctx.withPhase(trans))
               if (prevDenot.effectiveOwner == from.skipWeakOwner) {
-                val d = sym.copySymDenotation(owner = to)
+                val d = sym.denot.copySymDenotation(owner = to)
                 d.installAfter(trans)
                 d.transformAfter(trans, d => if (d.owner eq from) d.copySymDenotation(owner = to) else d)
               }

--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -21,7 +21,7 @@ class JavaPlatform extends Platform {
   }
 
   // The given symbol is a method with the right name and signature to be a runnable java program.
-  def isMainMethod(sym: SymDenotation)(implicit ctx: Context) =
+  def isMainMethod(sym: Symbol)(implicit ctx: Context) =
     (sym.name == nme.main) && (sym.info match {
       case MethodTpe(_, defn.ArrayOf(el) :: Nil, restpe) => el =:= defn.StringType && (restpe isRef defn.UnitClass)
       case _ => false

--- a/compiler/src/dotty/tools/dotc/config/Platform.scala
+++ b/compiler/src/dotty/tools/dotc/config/Platform.scala
@@ -39,13 +39,10 @@ abstract class Platform {
   def newClassLoader(bin: AbstractFile)(implicit ctx: Context): SymbolLoader
 
   /** The given symbol is a method with the right name and signature to be a runnable program. */
-  def isMainMethod(sym: SymDenotation)(implicit ctx: Context): Boolean
+  def isMainMethod(sym: Symbol)(implicit ctx: Context): Boolean
 
   /** The given class has a main method. */
   final def hasMainMethod(sym: Symbol)(implicit ctx: Context): Boolean =
-    sym.info.member(nme.main).hasAltWith {
-      case x: SymDenotation => isMainMethod(x)
-      case _ => false
-    }
+    sym.info.member(nme.main).hasAltWith(d => isMainMethod(d.symbol))
 }
 

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -148,7 +148,7 @@ object Annotations {
 
     def makeAlias(sym: TermSymbol)(implicit ctx: Context) =
       apply(defn.AliasAnnot, List(
-        ref(TermRef(sym.owner.thisType, sym.name, sym))))
+        ref(TermRef(sym.owner.thisType, sym.name, sym.denot))))
 
     /** Extractor for child annotations */
     object Child {
@@ -157,7 +157,7 @@ object Annotations {
       def apply(delayedSym: Context => Symbol)(implicit ctx: Context): Annotation = {
         def makeChildLater(implicit ctx: Context) = {
           val sym = delayedSym(ctx)
-          New(defn.ChildAnnotType.appliedTo(sym.owner.thisType.select(sym.name, sym)), Nil)
+          New(defn.ChildAnnotType.appliedTo(sym.owner.thisType.select(sym.name, sym.denot)), Nil)
         }
         deferred(defn.ChildAnnot, implicit ctx => makeChildLater(ctx))
       }

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -625,7 +625,7 @@ class Definitions {
     lazy val Product_productPrefixR = ProductClass.requiredMethodRef(nme.productPrefix)
     def Product_productPrefix(implicit ctx: Context) = Product_productPrefixR.symbol
   lazy val LanguageModuleRef = ctx.requiredModule("scala.language")
-  def LanguageModuleClass(implicit ctx: Context) = LanguageModuleRef.symbol.moduleClass.asClass
+  def LanguageModuleClass(implicit ctx: Context) = LanguageModuleRef.moduleClass.asClass
   lazy val NonLocalReturnControlType: TypeRef   = ctx.requiredClassRef("scala.runtime.NonLocalReturnControl")
   lazy val SelectableType: TypeRef              = ctx.requiredClassRef("scala.Selectable")
 
@@ -642,12 +642,12 @@ class Definitions {
     def QuotedExpr_apply(implicit ctx: Context) = QuotedExpr_applyR.symbol
 
     lazy val QuotedExpr_spliceR = QuotedExprClass.requiredMethod(nme.UNARY_~)
-    def QuotedExpr_~(implicit ctx: Context) = QuotedExpr_spliceR.symbol
+    def QuotedExpr_~(implicit ctx: Context) = QuotedExpr_spliceR
     lazy val QuotedExpr_runR = QuotedExprClass.requiredMethodRef(nme.run)
     def QuotedExpr_run(implicit ctx: Context) = QuotedExpr_runR.symbol
 
   lazy val QuotedExprsModule = ctx.requiredModule("scala.quoted.Exprs")
-  def QuotedExprsClass(implicit ctx: Context) = QuotedExprsModule.symbol.asClass
+  def QuotedExprsClass(implicit ctx: Context) = QuotedExprsModule.asClass
 
   lazy val QuotedTypeType = ctx.requiredClassRef("scala.quoted.Type")
   def QuotedTypeClass(implicit ctx: Context) = QuotedTypeType.symbol.asClass

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -287,35 +287,6 @@ object Denotations {
           denot.symbol
       }
 
-    final def requiredMethod(name: PreName)(implicit ctx: Context): TermSymbol =
-      info.member(name.toTermName).requiredSymbol(_ is Method).asTerm
-    final def requiredMethodRef(name: PreName)(implicit ctx: Context): TermRef =
-      requiredMethod(name).termRef
-
-    final def requiredMethod(name: PreName, argTypes: List[Type])(implicit ctx: Context): TermSymbol = {
-      info.member(name.toTermName).requiredSymbol { x =>
-        (x is Method) && {
-          x.info.paramInfoss match {
-            case paramInfos :: Nil => paramInfos.corresponds(argTypes)(_ =:= _)
-            case _ => false
-          }
-        }
-      }.asTerm
-    }
-    final def requiredMethodRef(name: PreName, argTypes: List[Type])(implicit ctx: Context): TermRef =
-      requiredMethod(name, argTypes).termRef
-
-    final def requiredValue(name: PreName)(implicit ctx: Context): TermSymbol =
-      info.member(name.toTermName).requiredSymbol(_.info.isParameterless).asTerm
-    final def requiredValueRef(name: PreName)(implicit ctx: Context): TermRef =
-      requiredValue(name).termRef
-
-    final def requiredClass(name: PreName)(implicit ctx: Context): ClassSymbol =
-      info.member(name.toTypeName).requiredSymbol(_.isClass).asClass
-
-    final def requiredType(name: PreName)(implicit ctx: Context): TypeSymbol =
-      info.member(name.toTypeName).requiredSymbol(_.isType).asType
-
     /** The alternative of this denotation that has a type matching `targetType` when seen
      *  as a member of type `site`, `NoDenotation` if none exists.
      */

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -131,7 +131,7 @@ object SymDenotations {
 
     //assert(symbol.id != 4940, name)
 
-    override def hasUniqueSym: Boolean = exists
+    override protected def hasUniqueSym: Boolean = exists
 
     /** Debug only
     override def validFor_=(p: Period) = {
@@ -268,7 +268,7 @@ object SymDenotations {
      *   - if this is a companion object with a clash-avoiding name, strip the
      *     "avoid clash" suffix
      */
-    def effectiveName(implicit ctx: Context) =
+    def effectiveName(implicit ctx: Context): Name =
       if (this is ModuleClass) name.stripModuleClassSuffix
       else name.exclude(AvoidClashName)
 
@@ -492,7 +492,7 @@ object SymDenotations {
      *  and used in SymDenotations#companionClass and
      *  SymDenotations#companionModule .
      */
-    final def isCompanionMethod(implicit ctx: Context) =
+    final def isCompanionMethod(implicit ctx: Context): Boolean =
       name.toTermName == nme.COMPANION_CLASS_METHOD ||
       name.toTermName == nme.COMPANION_MODULE_METHOD
 
@@ -500,20 +500,21 @@ object SymDenotations {
       *  These methods are generated in ExtensionMethods
       *  and used in ElimErasedValueType.
       */
-    final def isValueClassConvertMethod(implicit ctx: Context) =
+    final def isValueClassConvertMethod(implicit ctx: Context): Boolean =
       name.toTermName == nme.U2EVT ||
       name.toTermName == nme.EVT2U
 
     /** Is symbol a primitive value class? */
-    def isPrimitiveValueClass(implicit ctx: Context) =
+    def isPrimitiveValueClass(implicit ctx: Context): Boolean =
       maybeOwner == defn.ScalaPackageClass && defn.ScalaValueClasses().contains(symbol)
 
     /** Is symbol a primitive numeric value class? */
-    def isNumericValueClass(implicit ctx: Context) =
+    def isNumericValueClass(implicit ctx: Context): Boolean =
       maybeOwner == defn.ScalaPackageClass && defn.ScalaNumericValueClasses().contains(symbol)
 
     /** Is symbol a class for which no runtime representation exists? */
-    def isNotRuntimeClass(implicit ctx: Context) = defn.NotRuntimeClasses contains symbol
+    def isNotRuntimeClass(implicit ctx: Context): Boolean =
+      defn.NotRuntimeClasses contains symbol
 
     /** Is this symbol a class representing a refinement? These classes
      *  are used only temporarily in Typer and Unpickler as an intermediate
@@ -531,16 +532,16 @@ object SymDenotations {
     }
 
     /** Is this symbol an abstract type? */
-    final def isAbstractType(implicit ctx: Context) = this is DeferredType
+    final def isAbstractType(implicit ctx: Context): Boolean = this is DeferredType
 
     /** Is this symbol an alias type? */
-    final def isAliasType(implicit ctx: Context) = isAbstractOrAliasType && !(this is Deferred)
+    final def isAliasType(implicit ctx: Context): Boolean = isAbstractOrAliasType && !(this is Deferred)
 
     /** Is this symbol an abstract or alias type? */
-    final def isAbstractOrAliasType = isType & !isClass
+    final def isAbstractOrAliasType: Boolean = isType & !isClass
 
     /** Is this symbol an abstract type or type parameter? */
-    final def isAbstractOrParamType(implicit ctx: Context) = this is DeferredOrTypeParam
+    final def isAbstractOrParamType(implicit ctx: Context): Boolean = this is DeferredOrTypeParam
 
     /** Is this the denotation of a self symbol of some class?
      *  This is the case if one of two conditions holds:
@@ -552,7 +553,7 @@ object SymDenotations {
      *  TODO: Find a more robust way to characterize self symbols, maybe by
      *       spending a Flag on them?
      */
-    final def isSelfSym(implicit ctx: Context) = owner.infoOrCompleter match {
+    final def isSelfSym(implicit ctx: Context): Boolean = owner.infoOrCompleter match {
       case ClassInfo(_, _, _, _, selfInfo) =>
         selfInfo == symbol ||
           selfInfo.isInstanceOf[Type] && name == nme.WILDCARD
@@ -575,7 +576,7 @@ object SymDenotations {
       symbol != boundary && isContainedIn(boundary)
 
     /** Is this denotation static (i.e. with no outer instance)? */
-    final def isStatic(implicit ctx: Context) =
+    final def isStatic(implicit ctx: Context): Boolean =
       (if (maybeOwner eq NoSymbol) isRoot else maybeOwner.originDenotation.isStaticOwner) ||
         myFlags.is(JavaStatic)
 
@@ -584,13 +585,13 @@ object SymDenotations {
       myFlags.is(ModuleClass) && (myFlags.is(PackageClass) || isStatic)
 
     /** Is this denotation defined in the same scope and compilation unit as that symbol? */
-    final def isCoDefinedWith(that: Symbol)(implicit ctx: Context) =
+    final def isCoDefinedWith(that: Symbol)(implicit ctx: Context): Boolean =
       (this.effectiveOwner == that.effectiveOwner) &&
       (  !(this.effectiveOwner is PackageClass)
         || this.unforcedIsAbsent || that.unforcedIsAbsent
         || { // check if they are defined in the same file(or a jar)
            val thisFile = this.symbol.associatedFile
-           val thatFile = that.symbol.associatedFile
+           val thatFile = that.associatedFile
            (  thisFile == null
            || thatFile == null
            || thisFile.path == thatFile.path // Cheap possibly wrong check, then expensive normalization
@@ -600,7 +601,7 @@ object SymDenotations {
       )
 
     /** Is this a denotation of a stable term (or an arbitrary type)? */
-    final def isStable(implicit ctx: Context) =
+    final def isStable(implicit ctx: Context): Boolean =
       isType || !is(Erased) && (is(Stable) || !(is(UnstableValue) || info.isInstanceOf[ExprType]))
 
     /** Is this a "real" method? A real method is a method which is:
@@ -609,53 +610,53 @@ object SymDenotations {
      *  - not an anonymous function
      *  - not a companion method
      */
-    final def isRealMethod(implicit ctx: Context) =
+    final def isRealMethod(implicit ctx: Context): Boolean =
       this.is(Method, butNot = AccessorOrLabel) &&
         !isAnonymousFunction &&
         !isCompanionMethod
 
     /** Is this a getter? */
-    final def isGetter(implicit ctx: Context) =
+    final def isGetter(implicit ctx: Context): Boolean =
       (this is Accessor) && !originalName.isSetterName && !originalName.isScala2LocalSuffix
 
     /** Is this a setter? */
-    final def isSetter(implicit ctx: Context) =
+    final def isSetter(implicit ctx: Context): Boolean =
       (this is Accessor) &&
       originalName.isSetterName &&
       (!isCompleted || info.firstParamTypes.nonEmpty) // to avoid being fooled by   var x_= : Unit = ...
 
     /** is this a symbol representing an import? */
-    final def isImport = name == nme.IMPORT
+    final def isImport: Boolean = name == nme.IMPORT
 
     /** is this the constructor of a class? */
-    final def isClassConstructor = name == nme.CONSTRUCTOR
+    final def isClassConstructor: Boolean = name == nme.CONSTRUCTOR
 
     /** Is this the constructor of a trait? */
-    final def isImplClassConstructor = name == nme.TRAIT_CONSTRUCTOR
+    final def isImplClassConstructor: Boolean = name == nme.TRAIT_CONSTRUCTOR
 
     /** Is this the constructor of a trait or a class */
-    final def isConstructor = name.isConstructorName
+    final def isConstructor: Boolean = name.isConstructorName
 
     /** Is this a local template dummmy? */
     final def isLocalDummy: Boolean = name.isLocalDummyName
 
     /** Does this symbol denote the primary constructor of its enclosing class? */
-    final def isPrimaryConstructor(implicit ctx: Context) =
+    final def isPrimaryConstructor(implicit ctx: Context): Boolean =
       isConstructor && owner.primaryConstructor == symbol
 
     /** Does this symbol denote the static constructor of its enclosing class? */
-    final def isStaticConstructor(implicit ctx: Context) =
+    final def isStaticConstructor(implicit ctx: Context): Boolean =
       name.isStaticConstructorName
 
     /** Is this a subclass of the given class `base`? */
-    def isSubClass(base: Symbol)(implicit ctx: Context) = false
+    def isSubClass(base: Symbol)(implicit ctx: Context): Boolean = false
 
     /** Is this a subclass of `base`,
      *  and is the denoting symbol also different from `Null` or `Nothing`?
      *  @note  erroneous classes are assumed to derive from all other classes
      *         and all classes derive from them.
      */
-    def derivesFrom(base: Symbol)(implicit ctx: Context) = false
+    def derivesFrom(base: Symbol)(implicit ctx: Context): Boolean = false
 
     /** Is this symbol a class that extends `AnyVal`? */
     final def isValueClass(implicit ctx: Context): Boolean = {
@@ -751,7 +752,7 @@ object SymDenotations {
     /** Do members of this symbol need translation via asSeenFrom when
      *  accessed via prefix `pre`?
      */
-    def membersNeedAsSeenFrom(pre: Type)(implicit ctx: Context) =
+    def membersNeedAsSeenFrom(pre: Type)(implicit ctx: Context): Boolean =
       !(  this.isTerm
        || this.isStaticOwner
        || ctx.erasedTypes
@@ -846,7 +847,7 @@ object SymDenotations {
     }
 
     /** The field accessed by this getter or setter, or if it does not exist, the getter */
-    def accessedFieldOrGetter(implicit ctx: Context): Symbol = {
+    final def accessedFieldOrGetter(implicit ctx: Context): Symbol = {
       val fieldName = if (isSetter) name.asTermName.getterName else name
       val d = owner.info.decl(fieldName)
       val field = d.suchThat(!_.is(Method)).symbol
@@ -858,7 +859,7 @@ object SymDenotations {
      *  if it does not exists, the getter of a setter, or
      *  if that does not exist the symbol itself.
      */
-    def underlyingSymbol(implicit ctx: Context): Symbol =
+    final def underlyingSymbol(implicit ctx: Context): Symbol =
       if (is(Accessor)) accessedFieldOrGetter orElse symbol else symbol
 
     /** The chain of owners of this denotation, starting with the denoting symbol itself */
@@ -930,9 +931,9 @@ object SymDenotations {
      *  except for a toplevel module, where its module class is returned.
      */
     final def topLevelClass(implicit ctx: Context): Symbol = {
-      @tailrec def topLevel(d: SymDenotation): Symbol = {
+      @tailrec def topLevel(d: SymDenotation): Symbol = { // TODO: rewrite to take Symbols?
         if (d.isTopLevelClass) d.symbol
-        else topLevel(d.owner)
+        else topLevel(d.owner.denot)
       }
 
       val sym = topLevel(this)
@@ -1115,7 +1116,7 @@ object SymDenotations {
       (this is Deferred) ||
       (this is AbsOverride) && {
         val supersym = superSymbolIn(base)
-        supersym == NoSymbol || supersym.isIncompleteIn(base)
+        supersym == NoSymbol || supersym.denot.isIncompleteIn(base)
       }
 
     /** The class or term symbol up to which this symbol is accessible,
@@ -1139,7 +1140,7 @@ object SymDenotations {
     /** The current declaration in this symbol's class owner that has the same name
      *  as this one, and, if there are several, also has the same signature.
      */
-    def currentSymbol(implicit ctx: Context): Symbol = {
+    final def currentSymbol(implicit ctx: Context): Symbol = {
       val candidates = owner.info.decls.lookupAll(name)
       def test(sym: Symbol): Symbol =
         if (sym == symbol || sym.signature == signature) sym
@@ -1358,7 +1359,7 @@ object SymDenotations {
     def classSymbol: ClassSymbol = symbol.asInstanceOf[ClassSymbol]
 
     /** The info asserted to have type ClassInfo */
-    def classInfo(implicit ctx: Context): ClassInfo = info.asInstanceOf[ClassInfo]
+    final def classInfo(implicit ctx: Context): ClassInfo = info.asInstanceOf[ClassInfo]
 
     /** The type parameters in this class, in the order they appear in the current
      *  scope `decls`. This might be temporarily the incorrect order when
@@ -1393,13 +1394,13 @@ object SymDenotations {
       super.info_=(tp)
     }
 
-    def classParents(implicit ctx: Context): List[Type] = info match {
+    final def classParents(implicit ctx: Context): List[Type] = info match {
       case classInfo: ClassInfo => classInfo.parents
       case _ => Nil
     }
 
     /** The symbol of the superclass, NoSymbol if no superclass exists */
-    def superClass(implicit ctx: Context): Symbol = classParents match {
+    final def superClass(implicit ctx: Context): Symbol = classParents match {
       case parent :: _ =>
         val cls = parent.classSymbol
         if (cls is Trait) NoSymbol else cls
@@ -1410,7 +1411,7 @@ object SymDenotations {
     /** The explicitly given self type (self types of modules are assumed to be
      *  explcitly given here).
      */
-    def givenSelfType(implicit ctx: Context) = classInfo.selfInfo match {
+    final def givenSelfType(implicit ctx: Context) = classInfo.selfInfo match {
       case tp: Type => tp
       case self: Symbol => self.info
     }
@@ -1424,7 +1425,7 @@ object SymDenotations {
      *  - for a module class `m`: A term ref to m's source module.
      *  - for all other classes `c` with owner `o`: ThisType(TypeRef(o.thisType, c))
      */
-    override def thisType(implicit ctx: Context): Type = {
+    final override def thisType(implicit ctx: Context): Type = {
       if (myThisType == null) myThisType = computeThisType
       myThisType
     }
@@ -1437,12 +1438,12 @@ object SymDenotations {
 
     private[this] var myTypeRef: TypeRef = null
 
-    override def typeRef(implicit ctx: Context): TypeRef = {
+    final override def typeRef(implicit ctx: Context): TypeRef = {
       if (myTypeRef == null) myTypeRef = super.typeRef
       myTypeRef
     }
 
-    override def appliedRef(implicit ctx: Context): Type = classInfo.appliedRef
+    final override def appliedRef(implicit ctx: Context): Type = classInfo.appliedRef
 
     private def baseData(implicit onBehalf: BaseData, ctx: Context): (List[ClassSymbol], BaseClassSet) = {
       if (!baseDataCache.isValid) baseDataCache = BaseData.newCache()
@@ -1452,14 +1453,14 @@ object SymDenotations {
     /** The base classes of this class in linearization order,
      *  with the class itself as first element.
      */
-    def baseClasses(implicit onBehalf: BaseData, ctx: Context): List[ClassSymbol] =
+    final def baseClasses(implicit onBehalf: BaseData, ctx: Context): List[ClassSymbol] =
       baseData._1
 
     /** A bitset that contains the superId's of all base classes */
     private def baseClassSet(implicit onBehalf: BaseData, ctx: Context): BaseClassSet =
       baseData._2
 
-    def computeBaseData(implicit onBehalf: BaseData, ctx: Context): (List[ClassSymbol], BaseClassSet) = {
+    final def computeBaseData(implicit onBehalf: BaseData, ctx: Context): (List[ClassSymbol], BaseClassSet) = {
       def emptyParentsExpected =
         is(Package) || (symbol == defn.AnyClass) || ctx.erasedTypes && (symbol == defn.ObjectClass)
       if (classParents.isEmpty && !emptyParentsExpected)
@@ -1497,7 +1498,7 @@ object SymDenotations {
      *  @param scope   The scope in which symbol should be entered.
      *                 If this is EmptyScope, the scope is `decls`.
      */
-    def enter(sym: Symbol, scope: Scope = EmptyScope)(implicit ctx: Context): Unit = {
+    final def enter(sym: Symbol, scope: Scope = EmptyScope)(implicit ctx: Context): Unit = {
       val mscope = scope match {
         case scope: MutableScope =>
           // if enter gets a scope as an argument,
@@ -1520,7 +1521,7 @@ object SymDenotations {
     }
 
     /** Enter a symbol in given `scope` without potentially replacing the old copy. */
-    def enterNoReplace(sym: Symbol, scope: MutableScope)(implicit ctx: Context): Unit = {
+    final def enterNoReplace(sym: Symbol, scope: MutableScope)(implicit ctx: Context): Unit = {
       scope.enter(sym)
       if (myMemberCache != null) myMemberCache.invalidate(sym.name)
       if (!sym.flagsUNSAFE.is(Private)) invalidateMemberNamesCache()
@@ -1530,7 +1531,7 @@ object SymDenotations {
      *  If `prev` is not defined in current class, do nothing.
      *  @pre `prev` and `replacement` have the same name.
      */
-    def replace(prev: Symbol, replacement: Symbol)(implicit ctx: Context): Unit = {
+    final def replace(prev: Symbol, replacement: Symbol)(implicit ctx: Context): Unit = {
       unforcedDecls.openForMutations.replace(prev, replacement)
       if (myMemberCache != null) myMemberCache.invalidate(replacement.name)
     }
@@ -1539,7 +1540,7 @@ object SymDenotations {
      *  Note: We require that this does not happen after the first time
      *  someone does a findMember on a subclass.
      */
-    def delete(sym: Symbol)(implicit ctx: Context) = {
+    final def delete(sym: Symbol)(implicit ctx: Context) = {
       info.decls.openForMutations.unlink(sym)
       if (myMemberCache != null) myMemberCache.invalidate(sym.name)
       if (!sym.flagsUNSAFE.is(Private)) invalidateMemberNamesCache()
@@ -1548,7 +1549,7 @@ object SymDenotations {
     /** Make sure the type parameters of this class appear in the order given
      *  by `typeParams` in the scope of the class. Reorder definitions in scope if necessary.
      */
-    def ensureTypeParamsInCorrectOrder()(implicit ctx: Context): Unit = {
+    final def ensureTypeParamsInCorrectOrder()(implicit ctx: Context): Unit = {
       val tparams = typeParams
       if (!ctx.erasedTypes && !typeParamsFromDecls.corresponds(tparams)(_.name == _.name)) {
         val decls = info.decls
@@ -1743,7 +1744,7 @@ object SymDenotations {
         memberNamesCache(keepOnly, this)
       }
 
-    def computeMemberNames(keepOnly: NameFilter)(implicit onBehalf: MemberNames, ctx: Context): Set[Name] = {
+    final def computeMemberNames(keepOnly: NameFilter)(implicit onBehalf: MemberNames, ctx: Context): Set[Name] = {
       var names = Set[Name]()
       def maybeAdd(name: Name) = if (keepOnly(thisType, name)) names += name
       for (p <- classParents)
@@ -1758,7 +1759,7 @@ object SymDenotations {
       names
     }
 
-    override final def fullNameSeparated(kind: QualifiedNameKind)(implicit ctx: Context): Name = {
+    final override def fullNameSeparated(kind: QualifiedNameKind)(implicit ctx: Context): Name = {
       val cached = fullNameCache(kind)
       if (cached != null) cached
       else {
@@ -1769,9 +1770,9 @@ object SymDenotations {
     }
 
     // to avoid overloading ambiguities
-    override def fullName(implicit ctx: Context): Name = super.fullName
+    final override def fullName(implicit ctx: Context): Name = super.fullName
 
-    override def primaryConstructor(implicit ctx: Context): Symbol = {
+    final override def primaryConstructor(implicit ctx: Context): Symbol = {
       def constrNamed(cname: TermName) = info.decls.denotsNamed(cname).last.symbol
         // denotsNamed returns Symbols in reverse order of occurrence
       if (this.is(ImplClass)) constrNamed(nme.TRAIT_CONSTRUCTOR) // ignore normal constructor
@@ -1782,13 +1783,13 @@ object SymDenotations {
     /** The term parameter accessors of this class.
      *  Both getters and setters are returned in this list.
      */
-    def paramAccessors(implicit ctx: Context): List[Symbol] =
+    final def paramAccessors(implicit ctx: Context): List[Symbol] =
       unforcedDecls.filter(_.is(ParamAccessor))
 
     /** If this class has the same `decls` scope reference in `phase` and
      *  `phase.next`, install a new denotation with a cloned scope in `phase.next`.
      */
-    def ensureFreshScopeAfter(phase: DenotTransformer)(implicit ctx: Context): Unit =
+    final def ensureFreshScopeAfter(phase: DenotTransformer)(implicit ctx: Context): Unit =
       if (ctx.phaseId != phase.next.id) ensureFreshScopeAfter(phase)(ctx.withPhase(phase.next))
       else {
         val prevCtx = ctx.withPhase(phase)

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -129,6 +129,8 @@ object SymDenotations {
     initInfo: Type,
     initPrivateWithin: Symbol = NoSymbol) extends SingleDenotation(symbol) {
 
+    Stats.record("SymDenotation")
+
     //assert(symbol.id != 4940, name)
 
     override protected def hasUniqueSym: Boolean = exists
@@ -991,7 +993,7 @@ object SymDenotations {
      */
     private def companionNamed(name: TypeName)(implicit ctx: Context): Symbol =
       if (owner.isClass)
-        owner.unforcedDecls.lookup(name).suchThat(_.isCoDefinedWith(symbol)).symbol
+        owner.unforcedDecls.lookup(name).ensuring(_.isCoDefinedWith(symbol))
       else if (!owner.exists || ctx.compilationUnit == null)
         NoSymbol
       else if (!ctx.compilationUnit.tpdTree.isEmpty)
@@ -1098,8 +1100,7 @@ object SymDenotations {
     final def superSymbolIn(base: Symbol)(implicit ctx: Context): Symbol = {
       @tailrec def loop(bcs: List[ClassSymbol]): Symbol = bcs match {
         case bc :: bcs1 =>
-          val sym = matchingDecl(bcs.head, base.thisType)
-            .suchThat(alt => !(alt is Deferred)).symbol
+          val sym = matchingDecl(bcs.head, base.thisType).ensuring(!_.is(Deferred))
           if (sym.exists) sym else loop(bcs.tail)
         case _ =>
           NoSymbol
@@ -1289,6 +1290,8 @@ object SymDenotations {
     extends SymDenotation(symbol, maybeOwner, name, initFlags, initInfo, initPrivateWithin) {
 
     import util.LRUCache
+
+    Stats.record("ClassDenotation")
 
     // ----- caches -------------------------------------------------------
 

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -268,7 +268,7 @@ class SymbolLoaders {
       val pre = root.owner.thisType
       root.info = ClassInfo(pre, root.symbol.asClass, Nil, currentDecls, pre select sourceModule)
       if (!sourceModule.isCompleted)
-        sourceModule.completer.complete(sourceModule)
+        sourceModule.completer.complete(sourceModule.denot)
 
       val packageName = if (root.isEffectiveRoot) "" else root.fullName.mangledString
 

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -230,8 +230,8 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
       tpe
     else
       tpe.prefix match {
-        case pre: ThisType if pre.cls is Package => tryInsert(pre.cls)
-        case pre: TermRef if pre.symbol is Package => tryInsert(pre.symbol.moduleClass)
+        case pre: ThisType if pre.cls is Package => tryInsert(pre.cls.denot)
+        case pre: TermRef if pre.symbol is Package => tryInsert(pre.symbol.moduleClass.denot)
         case _ => tpe
       }
   }

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -157,7 +157,7 @@ class ClassfileParser(
       moduleRoot.setFlag(Flags.JavaDefined | Flags.ModuleClassCreationFlags)
       setPrivateWithin(classRoot, jflags)
       setPrivateWithin(moduleRoot, jflags)
-      setPrivateWithin(moduleRoot.sourceModule, jflags)
+      setPrivateWithin(moduleRoot.sourceModule.denot, jflags)
 
       for (i <- 0 until in.nextChar) parseMember(method = false)
       for (i <- 0 until in.nextChar) parseMember(method = true)
@@ -172,7 +172,7 @@ class ClassfileParser(
       setClassInfo(classRoot, classInfo)
       setClassInfo(moduleRoot, staticInfo)
     } else if (result == Some(NoEmbedded)) {
-      for (sym <- List(moduleRoot.sourceModule.symbol, moduleRoot.symbol, classRoot.symbol)) {
+      for (sym <- List(moduleRoot.sourceModule, moduleRoot.symbol, classRoot.symbol)) {
         classRoot.owner.asClass.delete(sym)
         if (classRoot.owner == defn.ScalaShadowingPackageClass) {
           // Symbols in scalaShadowing are also added to scala
@@ -758,7 +758,7 @@ class ClassfileParser(
 
       def unpickleTASTY(bytes: Array[Byte]): Some[Embedded]  = {
         val unpickler = new tasty.DottyUnpickler(bytes)
-        unpickler.enter(roots = Set(classRoot, moduleRoot, moduleRoot.sourceModule))
+        unpickler.enter(roots = Set(classRoot, moduleRoot, moduleRoot.sourceModule.denot))
         Some(unpickler)
       }
 

--- a/compiler/src/dotty/tools/dotc/core/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/core/quoted/PickledQuotes.scala
@@ -116,7 +116,7 @@ object PickledQuotes {
   /** Unpickle TASTY bytes into it's tree */
   private def unpickle(bytes: Array[Byte], splices: Seq[Any])(implicit ctx: Context): Tree = {
     val unpickler = new TastyUnpickler(bytes, splices)
-    unpickler.enter(roots = Set(defn.RootPackage))
+    unpickler.enter(roots = Set(defn.RootPackage.denot))
     val tree = unpickler.tree
     if (pickling ne noPrinter) {
       println(i"**** unpickled quote for \n${tree.show}")

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -260,7 +260,7 @@ class TreeUnpickler(reader: TastyReader,
               val prefix = readType()
               val space = readType()
               space.decl(name) match {
-                case symd: SymDenotation if prefix.isArgPrefixOf(symd.symbol) => TypeRef(prefix, symd.symbol)
+                case symd: SymDenotation if prefix.isArgPrefixOf(symd) => TypeRef(prefix, symd.symbol)
                 case _ => TypeRef(prefix, name, space.decl(name).asSeenFrom(prefix))
               }
             case REFINEDtype =>

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -513,8 +513,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
             val unpickler = new ClassUnpickler(infoRef) withDecls symScope(cls)
             if (flags is ModuleClass)
               unpickler withSourceModule (implicit ctx =>
-                cls.owner.info.decls.lookup(cls.name.sourceModuleName)
-                  .suchThat(_ is Module).symbol)
+                cls.owner.info.decls.lookup(cls.name.sourceModuleName).ensuring(_ is Module))
             else unpickler
           }
           ctx.newClassSymbol(owner, name.asTypeName, flags, completer, coord = start)
@@ -527,8 +526,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
           moduleRoot.symbol
         } else ctx.newSymbol(owner, name.asTermName, flags,
           new LocalUnpickler() withModuleClass(implicit ctx =>
-            owner.info.decls.lookup(name.moduleClassName)
-              .suchThat(_ is Module).symbol)
+            owner.info.decls.lookup(name.moduleClassName).ensuring(_ is Module))
           , coord = start)
       case _ =>
         errorBadSignature("bad symbol tag: " + tag)

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -88,7 +88,7 @@ object Scala2Unpickler {
   def ensureConstructor(cls: ClassSymbol, scope: Scope)(implicit ctx: Context) =
     if (scope.lookup(nme.CONSTRUCTOR) == NoSymbol) {
       val constr = ctx.newDefaultConstructor(cls)
-      addConstructorTypeParams(constr)
+      addConstructorTypeParams(constr.denot)
       cls.enter(constr, scope)
     }
 
@@ -351,7 +351,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       val owner = if (atEnd) loadingMirror.RootClass else readSymbolRef()
 
       def adjust(denot: Denotation) = {
-        val denot1 = denot.disambiguate(d => p(d.symbol))
+        val denot1 = denot.disambiguate(p)
         val sym = denot1.symbol
         if (denot.exists && !denot1.exists) { // !!!DEBUG
           val alts = denot.alternatives map (d => d + ":" + d.info + "/" + d.signature)
@@ -406,7 +406,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
           // (3) Try as a nested object symbol.
           nestedObjectSymbol orElse {
             // (4) Call the mirror's "missing" hook.
-            adjust(ctx.base.missingHook(owner, name)) orElse {
+            adjust(ctx.base.missingHook(owner, name).denot) orElse {
               // println(owner.info.decls.toList.map(_.debugString).mkString("\n  ")) // !!! DEBUG
               //              }
               // (5) Create a stub symbol to defer hard failure a little longer.

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -231,8 +231,8 @@ object Interactive {
         val boundaryCtx = ctx.withOwner(boundary)
         def exclude(sym: Symbol) = sym.isAbsent || sym.is(Synthetic) || sym.is(Artifact)
         def addMember(name: Name, buf: mutable.Buffer[SingleDenotation]): Unit =
-          buf ++= prefix.member(name).altsWith(d =>
-            !exclude(d) && d.symbol.isAccessibleFrom(prefix)(boundaryCtx))
+          buf ++= prefix.member(name).altsWith(sym =>
+            !exclude(sym) && sym.isAccessibleFrom(prefix)(boundaryCtx))
           prefix.memberDenots(completionsFilter, addMember).map(_.symbol).toList
       }
       else Nil

--- a/compiler/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
@@ -66,7 +66,7 @@ class AugmentScala2Traits extends MiniPhase with IdentityDenotTransformer with F
       def implMethod(meth: TermSymbol): Symbol = {
         val mold =
           if (meth.isConstructor)
-            meth.copySymDenotation(
+            meth.denot.copySymDenotation(
               name = nme.TRAIT_CONSTRUCTOR,
               info = MethodType(Nil, defn.UnitType))
           else meth.ensureNotPrivate

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -204,7 +204,7 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
             }
             else if (!stat.rhs.isEmpty) {
               dropped += sym
-              sym.copySymDenotation(
+              sym.denot.copySymDenotation(
                 initFlags = sym.flags &~ Private,
                 owner = constr.symbol).installAfter(thisPhase)
               constrStats += intoConstr(stat, sym)

--- a/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
@@ -71,7 +71,7 @@ class ElimByName extends TransformByNameApply with InfoTransformer {
 
   override def transformValDef(tree: ValDef)(implicit ctx: Context): Tree =
     ctx.atPhase(next) { implicit ctx =>
-      if (exprBecomesFunction(tree.symbol))
+      if (exprBecomesFunction(tree.symbol.denot))
         cpy.ValDef(tree)(tpt = tree.tpt.withType(tree.symbol.info))
       else tree
     }
@@ -81,7 +81,7 @@ class ElimByName extends TransformByNameApply with InfoTransformer {
     case _ => tp
   }
 
-  override def mayChange(sym: Symbol)(implicit ctx: Context): Boolean = sym.isTerm && exprBecomesFunction(sym)
+  override def mayChange(sym: Symbol)(implicit ctx: Context): Boolean = sym.isTerm && exprBecomesFunction(sym.denot)
 }
 
 object ElimByName {

--- a/compiler/src/dotty/tools/dotc/transform/ExpandPrivate.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandPrivate.scala
@@ -96,12 +96,12 @@ class ExpandPrivate extends MiniPhase with IdentityDenotTransformer { thisPhase 
     }
 
   override def transformIdent(tree: Ident)(implicit ctx: Context) = {
-    ensurePrivateAccessible(tree.symbol)
+    ensurePrivateAccessible(tree.symbol.denot)
     tree
   }
 
   override def transformSelect(tree: Select)(implicit ctx: Context) = {
-    ensurePrivateAccessible(tree.symbol)
+    ensurePrivateAccessible(tree.symbol.denot)
     tree
   }
 
@@ -112,7 +112,7 @@ class ExpandPrivate extends MiniPhase with IdentityDenotTransformer { thisPhase 
       if sym.is(PrivateParamAccessor) && sel.symbol.is(ParamAccessor) && sym.name == sel.symbol.name =>
         sym.ensureNotPrivate.installAfter(thisPhase)
       case _ =>
-        if (isVCPrivateParamAccessor(sym))
+        if (isVCPrivateParamAccessor(sym.denot))
           sym.ensureNotPrivate.installAfter(thisPhase)
     }
     tree

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -165,7 +165,7 @@ class ExtensionMethods extends MiniPhase with DenotTransformer with FullParamete
       val origMeth = tree.symbol
       val origClass = ctx.owner.asClass
       val staticClass = origClass.linkedClass
-      assert(staticClass.exists, s"$origClass lacks companion, ${origClass.owner.definedPeriodsString} ${origClass.owner.info.decls} ${origClass.owner.info.decls}")
+      assert(staticClass.exists, s"$origClass lacks companion, ${origClass.owner.denot.definedPeriodsString} ${origClass.owner.info.decls} ${origClass.owner.info.decls}")
       val extensionMeth = extensionMethod(origMeth)
       ctx.log(s"Value class $origClass spawns extension method.\n  Old: ${origMeth.showDcl}\n  New: ${extensionMeth.showDcl}")
       val store: ListBuffer[Tree] = extensionDefs.get(staticClass) match {

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -190,7 +190,7 @@ object LambdaLift {
       def traverse(tree: Tree)(implicit ctx: Context) = try { //debug
         val sym = tree.symbol
 
-        def enclosure = ctx.owner.enclosingMethod.symbol
+        def enclosure = ctx.owner.enclosingMethod
 
         def narrowTo(thisClass: ClassSymbol) = {
           val enclMethod = enclosure
@@ -338,7 +338,7 @@ object LambdaLift {
             else (topClass, JavaStatic)
           }
           else (lOwner, EmptyFlags)
-        local.copySymDenotation(
+        local.denot.copySymDenotation(
           owner = newOwner,
           name = newName(local),
           initFlags = local.flags &~ Module &~ Final | Private | Lifted | maybeStatic,
@@ -347,7 +347,7 @@ object LambdaLift {
       }
       for (local <- free.keys)
         if (!liftedOwner.contains(local))
-          local.copySymDenotation(info = liftedInfo(local)).installAfter(thisPhase)
+          local.denot.copySymDenotation(info = liftedInfo(local)).installAfter(thisPhase)
     }
 
     // initialization

--- a/compiler/src/dotty/tools/dotc/transform/Memoize.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Memoize.scala
@@ -98,9 +98,9 @@ class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
         case _ => ()
       }
 
-    def removeAnnotations(denot: SymDenotation): Unit =
+    def removeAnnotations(): Unit =
       if (sym.annotations.nonEmpty) {
-        val cpy = sym.copySymDenotation()
+        val cpy = sym.denot.copySymDenotation()
         cpy.annotations = Nil
         cpy.installAfter(thisPhase)
       }
@@ -136,7 +136,7 @@ class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
           else transformFollowingDeep(ref(field))(ctx.withOwner(sym))
         val getterDef = cpy.DefDef(tree)(rhs = getterRhs)
         addAnnotations(fieldDef.denot)
-        removeAnnotations(sym)
+        removeAnnotations()
         Thicket(fieldDef, getterDef)
       } else if (sym.isSetter) {
         if (!sym.is(ParamAccessor)) { val Literal(Constant(())) = tree.rhs } // This is intended as an assertion
@@ -145,7 +145,7 @@ class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
         else {
           val initializer = Assign(ref(field), adaptToField(ref(tree.vparamss.head.head.symbol)))
           val setterDef = cpy.DefDef(tree)(rhs = transformFollowingDeep(initializer)(ctx.withOwner(sym)))
-          removeAnnotations(sym)
+          removeAnnotations()
           setterDef
         }
       }

--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -132,7 +132,7 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
             initName,
             Protected | Synthetic | Method,
             sym.info,
-            coord = sym.symbol.coord).enteredAfter(thisPhase))
+            coord = sym.coord).enteredAfter(thisPhase))
     }
   }.asTerm
 

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -65,7 +65,7 @@ class ParamForwarding(thisPhase: DenotTransformer) {
                 val alias = inheritedAccessor(sym)
                 if (alias.exists) {
                   def forwarder(implicit ctx: Context) = {
-                    sym.copySymDenotation(initFlags = sym.flags | Method | Stable, info = sym.info.ensureMethodic)
+                    sym.denot.copySymDenotation(initFlags = sym.flags | Method | Stable, info = sym.info.ensureMethodic)
                       .installAfter(thisPhase)
                     val superAcc =
                       Super(This(currentClass), tpnme.EMPTY, inConstrCall = false).select(alias)

--- a/compiler/src/dotty/tools/dotc/transform/RestoreScopes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/RestoreScopes.scala
@@ -58,7 +58,7 @@ class RestoreScopes extends MiniPhase with IdentityDenotTransformer { thisPhase 
 
       pkg.enter(cls)
       val cinfo = cls.classInfo
-      tree.symbol.copySymDenotation(
+      tree.symbol.denot.copySymDenotation(
         info = cinfo.derivedClassInfo( // Dotty deviation: Cannot expand cinfo inline without a type error
           decls = restoredDecls: Scope)).installAfter(thisPhase)
       tree

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -125,7 +125,7 @@ class SymUtils(val self: Symbol) extends AnyVal {
 
   def registerCompanionMethod(name: Name, target: Symbol)(implicit ctx: Context) = {
     if (!self.unforcedDecls.lookup(name).exists) {
-      val companionMethod = ctx.synthesizeCompanionMethod(name, target, self)
+      val companionMethod = ctx.synthesizeCompanionMethod(name, target.denot, self.denot)
       if (companionMethod.exists) {
         companionMethod.entered
       }

--- a/compiler/src/dotty/tools/dotc/transform/TreeExtractors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeExtractors.scala
@@ -36,8 +36,8 @@ object TreeExtractors {
   object ValueClassUnbox {
     def unapply(t: Tree)(implicit ctx: Context): Option[Tree] = t match {
       case Apply(sel @ Select(ref, _), Nil) =>
-        val d = ref.tpe.widenDealias.typeSymbol.denot
-        if (isDerivedValueClass(d) && (sel.symbol eq valueClassUnbox(d.asClass))) {
+        val sym = ref.tpe.widenDealias.typeSymbol
+        if (isDerivedValueClass(sym) && (sel.symbol eq valueClassUnbox(sym.asClass))) {
           Some(ref)
         } else
           None

--- a/compiler/src/dotty/tools/dotc/transform/ValueClasses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ValueClasses.scala
@@ -4,7 +4,6 @@ package transform
 import core._
 import Types._
 import Symbols._
-import SymDenotations._
 import Contexts._
 import Flags._
 import StdNames._
@@ -13,15 +12,14 @@ import SymUtils._
 /** Methods that apply to user-defined value classes */
 object ValueClasses {
 
-  def isDerivedValueClass(d: SymDenotation)(implicit ctx: Context): Boolean = {
+  def isDerivedValueClass(sym: Symbol)(implicit ctx: Context): Boolean = {
+    val d = sym.denot
     !ctx.settings.XnoValueClasses.value &&
     !d.isRefinementClass &&
     d.isValueClass &&
     (d.initial.symbol ne defn.AnyValClass) && // Compare the initial symbol because AnyVal does not exist after erasure
     !d.isPrimitiveValueClass
   }
-  def isDerivedValueClass(sym: Symbol)(implicit ctx: Context): Boolean =
-    isDerivedValueClass(sym.denot)
 
   def isMethodWithExtension(sym: Symbol)(implicit ctx: Context) =
     ctx.atPhaseNotLaterThan(ctx.extensionMethodsPhase) { implicit ctx =>
@@ -35,12 +33,9 @@ object ValueClasses {
     }
 
   /** The member of a derived value class that unboxes it. */
-  def valueClassUnbox(d: ClassDenotation)(implicit ctx: Context): Symbol =
-    // (info.decl(nme.unbox)).orElse(...)      uncomment once we accept unbox methods
-    d.classInfo.decls.find(_.is(ParamAccessor))
-
   def valueClassUnbox(cls: ClassSymbol)(implicit ctx: Context): Symbol =
-    valueClassUnbox(cls.classDenot)
+    // (info.decl(nme.unbox)).orElse(...)      uncomment once we accept unbox methods
+    cls.classInfo.decls.find(_.is(ParamAccessor))
 
   /** For a value class `d`, this returns the synthetic cast from the underlying type to
    *  ErasedValueType defined in the companion module. This method is added to the module
@@ -57,10 +52,8 @@ object ValueClasses {
     d.linkedClass.info.decl(nme.EVT2U).symbol
 
   /** The unboxed type that underlies a derived value class */
-  def underlyingOfValueClass(d: ClassDenotation)(implicit ctx: Context): Type =
-    valueClassUnbox(d).info.resultType
   def underlyingOfValueClass(sym: ClassSymbol)(implicit ctx: Context): Type =
-    underlyingOfValueClass(sym.classDenot)
+    valueClassUnbox(sym).info.resultType
 
   /** Whether a value class wraps itself */
   def isCyclic(cls: ClassSymbol)(implicit ctx: Context): Boolean = {

--- a/compiler/src/dotty/tools/dotc/transform/localopt/DropNoEffects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/DropNoEffects.scala
@@ -116,7 +116,7 @@ class DropNoEffects(val simplifyPhase: Simplify) extends Optimisation {
           case et: ExprType =>
             et.derivedExprType(defn.UnitType)
         }
-        val newD = app.symbol.asSymDenotation.copySymDenotation(info = newLabelType)
+        val newD = app.symbol.denot.copySymDenotation(info = newLabelType)
         newD.installAfter(simplifyPhase)
       }
 

--- a/compiler/src/dotty/tools/dotc/transform/localopt/InlineLocalObjects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/InlineLocalObjects.scala
@@ -92,7 +92,7 @@ class InlineLocalObjects(val simplifyPhase: Simplify) extends Optimisation {
       case t @ NewCaseClassValDef(fun, args) if newFieldsMapping.contains(t.symbol) =>
         val newFields     = newFieldsMapping(t.symbol).values.toList
         val newFieldsDefs = newFields.zip(args).map { case (nf, arg) =>
-          val rhs = arg.changeOwnerAfter(t.symbol, nf.symbol, simplifyPhase)
+          val rhs = arg.changeOwnerAfter(t.symbol, nf, simplifyPhase)
           ValDef(nf.asTerm, rhs)
         }
         val recreate      = cpy.ValDef(t)(rhs = fun.appliedToArgs(newFields.map(x => ref(x))))

--- a/compiler/src/dotty/tools/dotc/transform/localopt/InlineLocalObjects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/InlineLocalObjects.scala
@@ -51,11 +51,11 @@ class InlineLocalObjects(val simplifyPhase: Simplify) extends Optimisation {
     if (newFieldsMapping == null) {
       newFieldsMapping = candidates.intersect(gettersCalled).map { refVal =>
         val accessors = refVal.info.classSymbol.caseAccessors.filter(_.isGetter)
-        val newLocals = accessors.map { x =>
+        val newLocals = accessors.map { accessor =>
           val owner: Symbol  = refVal.owner
           val name:  Name    = LocalOptInlineLocalObj.fresh()
           val flags: FlagSet = Synthetic
-          val info:  Type    = x.asSeenFrom(refVal.info).info.finalResultType.widenDealias
+          val info:  Type    = accessor.denot.asSeenFrom(refVal.info).info.finalResultType.widenDealias
           ctx.newSymbol(owner, name, flags, info)
         }
         (refVal, LinkedHashMap[Symbol, Symbol](accessors.zip(newLocals): _*))

--- a/compiler/src/dotty/tools/dotc/transform/localopt/Valify.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/Valify.scala
@@ -78,7 +78,7 @@ class Valify(val simplifyPhase: Simplify) extends Optimisation {
         case x: ValDef if valsToDrop.contains(x) => EmptyTree
         case t: Assign => assignsToReplace.get(t) match {
           case Some(vd) =>
-            val newD = vd.symbol.asSymDenotation.copySymDenotation(initFlags = vd.symbol.flags.&~(Mutable))
+            val newD = vd.symbol.denot.copySymDenotation(initFlags = vd.symbol.flags.&~(Mutable))
             newD.installAfter(simplifyPhase)
             ValDef(vd.symbol.asTerm, t.rhs)
           case None => t

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -823,7 +823,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
     /** does the companion object of the given symbol have custom unapply */
     def hasCustomUnapply(sym: Symbol): Boolean = {
-      val companion = sym.companionModule
+      val companion = sym.companionModule.denot
       companion.findMember(nme.unapply, NoPrefix, excluded = Synthetic).exists ||
         companion.findMember(nme.unapplySeq, NoPrefix, excluded = Synthetic).exists
     }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -662,7 +662,7 @@ trait Checking {
     def checkDecl(decl: Symbol): Unit = {
       for (other <- seen(decl.name)) {
         typr.println(i"conflict? $decl $other")
-        if (decl.matches(other.denot)) {
+        if (decl.denot.matches(other.denot)) {
           def doubleDefError(decl: Symbol, other: Symbol): Unit =
             if (!decl.info.isErroneous && !other.info.isErroneous)
               ctx.error(DoubleDeclaration(decl, other), decl.pos)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -662,7 +662,7 @@ trait Checking {
     def checkDecl(decl: Symbol): Unit = {
       for (other <- seen(decl.name)) {
         typr.println(i"conflict? $decl $other")
-        if (decl.matches(other)) {
+        if (decl.matches(other.denot)) {
           def doubleDefError(decl: Symbol, other: Symbol): Unit =
             if (!decl.info.isErroneous && !other.info.isErroneous)
               ctx.error(DoubleDeclaration(decl, other), decl.pos)

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -279,7 +279,7 @@ object Inferencing {
       case tp: TypeRef =>
         val companion = tp.classSymbol.companionModule
         if (companion.exists)
-          companion.termRef.asSeenFrom(tp.prefix, companion.symbol.owner)
+          companion.termRef.asSeenFrom(tp.prefix, companion.owner)
         else NoType
       case _ => NoType
     }

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -206,7 +206,7 @@ object Inliner {
    *                     to have the inlined method as owner.
    */
   def registerInlineInfo(
-      sym: SymDenotation, treeExpr: Context => Tree)(implicit ctx: Context): Unit = {
+      sym: Symbol, treeExpr: Context => Tree)(implicit ctx: Context): Unit = {
     sym.unforcedAnnotation(defn.BodyAnnot) match {
       case Some(ann: ConcreteBodyAnnotation) =>
       case Some(ann: LazyBodyAnnotation) if ann.isEvaluated =>
@@ -225,10 +225,10 @@ object Inliner {
   /** `sym` has an inline method with a known body to inline (note: definitions coming
    *  from Scala2x class files might be `@inline`, but still lack that body.
    */
-  def hasBodyToInline(sym: SymDenotation)(implicit ctx: Context): Boolean =
+  def hasBodyToInline(sym: Symbol)(implicit ctx: Context): Boolean =
     sym.isInlineMethod && sym.hasAnnotation(defn.BodyAnnot)
 
-  private def bodyAndAccessors(sym: SymDenotation)(implicit ctx: Context): (Tree, List[MemberDef]) =
+  private def bodyAndAccessors(sym: Symbol)(implicit ctx: Context): (Tree, List[MemberDef]) =
     sym.unforcedAnnotation(defn.BodyAnnot).get.tree match {
       case Thicket(body :: accessors) => (body, accessors.asInstanceOf[List[MemberDef]])
       case body => (body, Nil)
@@ -237,14 +237,14 @@ object Inliner {
   /** The body to inline for method `sym`.
    *  @pre  hasBodyToInline(sym)
    */
-  def bodyToInline(sym: SymDenotation)(implicit ctx: Context): Tree =
+  def bodyToInline(sym: Symbol)(implicit ctx: Context): Tree =
     bodyAndAccessors(sym)._1
 
  /** The accessors to non-public members needed by the inlinable body of `sym`.
    * These accessors are dropped as a side effect of calling this method.
    * @pre  hasBodyToInline(sym)
    */
-  def removeInlineAccessors(sym: SymDenotation)(implicit ctx: Context): List[MemberDef] = {
+  def removeInlineAccessors(sym: Symbol)(implicit ctx: Context): List[MemberDef] = {
     val (body, accessors) = bodyAndAccessors(sym)
     if (accessors.nonEmpty) sym.updateAnnotation(ConcreteBodyAnnotation(body))
     accessors

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -56,7 +56,7 @@ trait NamerContextOps { this: Context =>
         owner.thisType.member(name)
       }
       else // we are in the outermost context belonging to a class; self is invisible here. See inClassContext.
-        owner.findMember(name, owner.thisType, EmptyFlags)
+        owner.denot.findMember(name, owner.thisType, EmptyFlags)
     else
       scope.denotsNamed(name).toDenot(NoPrefix)
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -611,8 +611,8 @@ class Namer { typer: Typer =>
 
     /** Create links between companion object and companion class */
     def createLinks(classTree: TypeDef, moduleTree: TypeDef)(implicit ctx: Context) = {
-      val claz = ctx.effectiveScope.lookup(classTree.name)
-      val modl = ctx.effectiveScope.lookup(moduleTree.name)
+      val claz = ctx.effectiveScope.lookup(classTree.name).denot
+      val modl = ctx.effectiveScope.lookup(moduleTree.name).denot
       if (claz.isClass && modl.isClass) {
         ctx.synthesizeCompanionMethod(nme.COMPANION_CLASS_METHOD, claz, modl).entered
         ctx.synthesizeCompanionMethod(nme.COMPANION_MODULE_METHOD, modl, claz).entered
@@ -821,12 +821,12 @@ class Namer { typer: Typer =>
       else completeInCreationContext(denot)
     }
 
-    private def addInlineInfo(denot: SymDenotation) = original match {
-      case original: untpd.DefDef if denot.isInlineMethod =>
+    private def addInlineInfo(sym: Symbol) = original match {
+      case original: untpd.DefDef if sym.isInlineMethod =>
         Inliner.registerInlineInfo(
-            denot,
+            sym,
             implicit ctx => typedAheadExpr(original).asInstanceOf[tpd.DefDef].rhs
-          )(localContext(denot.symbol))
+          )(localContext(sym))
       case _ =>
     }
 
@@ -839,7 +839,7 @@ class Namer { typer: Typer =>
         case original: MemberDef => addAnnotations(sym, original)
         case _ =>
       }
-      addInlineInfo(denot)
+      addInlineInfo(sym)
       denot.info = typeSig(sym)
       Checking.checkWellFormed(sym)
       denot.info = avoidPrivateLeaks(sym, sym.pos)
@@ -990,7 +990,7 @@ class Namer { typer: Typer =>
       Checking.checkWellFormed(cls)
       if (isDerivedValueClass(cls)) cls.setFlag(Final)
       cls.info = avoidPrivateLeaks(cls, cls.pos)
-      cls.baseClasses.foreach(_.invalidateBaseTypeCache()) // we might have looked before and found nothing
+      cls.baseClasses.foreach(_.classDenot.invalidateBaseTypeCache()) // we might have looked before and found nothing
     }
   }
 
@@ -1033,7 +1033,7 @@ class Namer { typer: Typer =>
   def moduleValSig(sym: Symbol)(implicit ctx: Context): Type = {
     val clsName = sym.name.moduleClassName
     val cls = ctx.denotNamed(clsName).suchThat(_ is ModuleClass)
-      .orElse(ctx.newStubSymbol(ctx.owner, clsName).assertingErrorsReported)
+      .orElse(ctx.newStubSymbol(ctx.owner, clsName).assertingErrorsReported.denot)
     ctx.owner.thisType.select(clsName, cls)
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -49,12 +49,13 @@ trait TypeAssigner {
     val parentType = info.parents.reduceLeft(ctx.typeComparer.andType(_, _))
 
     def addRefinement(parent: Type, decl: Symbol) = {
+      val decld = decl.denot
       val inherited =
-        parentType.findMember(decl.name, cls.thisType, excluded = Private)
-          .suchThat(sym => decl.matches(sym.denot))
+        parentType.findMember(decld.name, cls.thisType, excluded = Private)
+          .suchThat(sym => decld.matches(sym.denot))
       val inheritedInfo = inherited.info
-      if (inheritedInfo.exists && decl.info <:< inheritedInfo && !(inheritedInfo <:< decl.info)) {
-        val r = RefinedType(parent, decl.name, decl.info)
+      if (inheritedInfo.exists && decld.info <:< inheritedInfo && !(inheritedInfo <:< decld.info)) {
+        val r = RefinedType(parent, decld.name, decld.info)
         typr.println(i"add ref $parent $decl --> " + r)
         r
       }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -51,7 +51,7 @@ trait TypeAssigner {
     def addRefinement(parent: Type, decl: Symbol) = {
       val inherited =
         parentType.findMember(decl.name, cls.thisType, excluded = Private)
-          .suchThat(decl.matches(_))
+          .suchThat(sym => decl.matches(sym.denot))
       val inheritedInfo = inherited.info
       if (inheritedInfo.exists && decl.info <:< inheritedInfo && !(inheritedInfo <:< decl.info)) {
         val r = RefinedType(parent, decl.name, decl.info)


### PR DESCRIPTION
It seems we get many cache misses when going from Symbols to their denotations. This is a very common operation: When compiling typer/*.scala, we generate ~80K symbols, ~125K SymDenotations, yet dereference .denot more than 15.8M times. Of these, 11.7M go to the symbol's initial denotation. 

So one thing I'd like to try is to store the initial denotation of a symbol in the symbol itself, by making Symbol inherit from SymDenotation. To get there, several obstacles need to be put out of the way first:

 - ClassDenotation needs to be a trait.
 - Eliminate the implicit conversions from Symbol to SymDenotation, replacing them with
   forwarders in Symbol.
 - Rename all SymDenotation methods so that they are different from Symbol methods (otherwise we'd get accidental overrides). 
