### PR TITLE
Turn SymbolLoaders into an object

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -35,7 +35,7 @@ class JavaPlatform extends Platform {
       currentClassPath = Some(subst.getOrElse(cp, cp))
   }
 
-  def rootLoader(root: TermSymbol)(implicit ctx: Context): SymbolLoader = new ctx.base.loaders.PackageLoader(root, classPath)
+  def rootLoader(root: TermSymbol)(implicit ctx: Context): SymbolLoader = new SymbolLoaders.PackageLoader(root, classPath)
 
   /** Is the SAMType `cls` also a SAM under the rules of the JVM? */
   def isSam(cls: ClassSymbol)(implicit ctx: Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -551,9 +551,6 @@ object Contexts {
     /** The initial context */
     val initialCtx: Context = new InitialContext(this, settings)
 
-    /** The symbol loaders */
-    val loaders = new SymbolLoaders
-
     /** The platform, initialized by `initPlatform()`. */
     private[this] var _platform: Platform = _
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -377,7 +377,7 @@ object SymDenotations {
      *  Right now, the only usage is for the AnyRef alias in Definitions.
      */
     final private[core] def currentPackageDecls(implicit ctx: Context): MutableScope = myInfo match {
-      case pinfo: SymbolLoaders # PackageLoader => pinfo.currentDecls
+      case pinfo: SymbolLoaders.PackageLoader => pinfo.currentDecls
       case _ => unforcedDecls.openForMutations
     }
 

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -19,17 +19,14 @@ import parsing.Parsers.OutlineParser
 import reporting.trace
 
 object SymbolLoaders {
+  import ast.untpd._
+
   /** A marker trait for a completer that replaces the original
    *  Symbol loader for an unpickled root.
    */
   trait SecondCompleter
-}
 
-/** A base class for Symbol loaders with some overridable behavior  */
-class SymbolLoaders {
-  import ast.untpd._
-
-  protected def enterNew(
+  private def enterNew(
       owner: Symbol, member: Symbol,
       completer: SymbolLoader, scope: Scope = EmptyScope)(implicit ctx: Context): Symbol = {
     val comesFromScan =

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -703,7 +703,7 @@ class ClassfileParser(
     }
 
     def enterClassAndModule(entry: InnerClassEntry, file: AbstractFile, jflags: Int) = {
-      ctx.base.loaders.enterClassAndModule(
+      SymbolLoaders.enterClassAndModule(
           getOwner(jflags),
           entry.originalName,
           new ClassfileLoader(file),


### PR DESCRIPTION
The extra flexibility of a class isn't useful here and leads to worse
code being generated (e.g. it requires PackageLoader to carry an outer
accessor).