### PR TITLE
Try to refine handling of SymDenotations V2

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/CollectEntryPoints.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CollectEntryPoints.scala
@@ -61,11 +61,11 @@ object CollectEntryPoints{
     val StringType = d.StringType
     // The given class has a main method.
     def hasJavaMainMethod(sym: Symbol): Boolean =
-      (toDenot(sym).info member nme.main).alternatives exists(x => isJavaMainMethod(x.symbol))
+      (sym.info member nme.main).alternatives exists(x => isJavaMainMethod(x.symbol))
 
     def fail(msg: String, pos: Position = sym.pos) = {
       ctx.warning(          sym.name +
-        s" has a main method with parameter type Array[String], but ${toDenot(sym).fullName} will not be a runnable program.\n  Reason: $msg",
+        s" has a main method with parameter type Array[String], but ${sym.fullName} will not be a runnable program.\n  Reason: $msg",
         sourcePos(sym.pos)
         // TODO: make this next claim true, if possible
         //   by generating valid main methods as static in module classes
@@ -77,7 +77,7 @@ object CollectEntryPoints{
     def failNoForwarder(msg: String) = {
       fail(s"$msg, which means no static forwarder can be generated.\n")
     }
-    val possibles = if (sym.flags is Flags.Module) (toDenot(sym).info nonPrivateMember nme.main).alternatives else Nil
+    val possibles = if (sym.flags is Flags.Module) (sym.info nonPrivateMember nme.main).alternatives else Nil
     val hasApproximate = possibles exists { m =>
       m.info match {
         case MethodTpe(_, p :: Nil, _) => p.typeSymbol == defn.ArrayClass
@@ -94,7 +94,7 @@ object CollectEntryPoints{
 
         if (hasJavaMainMethod(companion))
           failNoForwarder("companion contains its own main method")
-        else if (toDenot(companion).info.member(nme.main) != NoDenotation)
+        else if (companion.info.member(nme.main) != NoDenotation)
         // this is only because forwarders aren't smart enough yet
           failNoForwarder("companion contains its own main method (implementation restriction: no main is allowed, regardless of signature)")
         else if (companion.flags is Flags.Trait)
@@ -103,7 +103,7 @@ object CollectEntryPoints{
         // attempts to be java main methods.
         else (possibles exists(x=> isJavaMainMethod(x.symbol))) || {
           possibles exists { m =>
-            toDenot(m.symbol).info match {
+            m.symbol.info match {
               case t: PolyType =>
                 fail("main methods cannot be generic.")
               case MethodTpe(paramNames, paramTypes, resultType) =>

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -842,7 +842,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     def superInterfaces: List[Symbol] = {
       val directlyInheritedTraits = decorateSymbol(sym).directlyInheritedTraits
       val directlyInheritedTraitsSet = directlyInheritedTraits.toSet
-      val allBaseClasses = directlyInheritedTraits.iterator.flatMap(_.symbol.asClass.baseClasses.drop(1)).toSet
+      val allBaseClasses = directlyInheritedTraits.iterator.flatMap(_.asClass.baseClasses.drop(1)).toSet
       val superCalls = superCallsMap.getOrElse(sym, Set.empty)
       val additional = (superCalls -- directlyInheritedTraitsSet).filter(_.is(Flags.Trait))
 //      if (additional.nonEmpty)

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1094,9 +1094,9 @@ object desugar {
         Literal(Constant(scala.Symbol(str)))
       case Quote(expr) =>
         if (expr.isType)
-          TypeApply(ref(defn.QuotedType_applyR), List(expr))
+          TypeApply(ref(defn.QuotedType_apply.termRef), List(expr))
         else
-          Apply(ref(defn.QuotedExpr_applyR), expr)
+          Apply(ref(defn.QuotedExpr_apply.termRef), expr)
       case InterpolatedString(id, segments) =>
         val strs = segments map {
           case ts: Thicket => ts.trees.head

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -625,7 +625,7 @@ class Definitions {
     lazy val Product_productPrefixR = ProductClass.requiredMethodRef(nme.productPrefix)
     def Product_productPrefix(implicit ctx: Context) = Product_productPrefixR.symbol
   lazy val LanguageModuleRef = ctx.requiredModule("scala.language")
-  def LanguageModuleClass(implicit ctx: Context) = LanguageModuleRef.symbol.moduleClass.asClass
+  def LanguageModuleClass(implicit ctx: Context) = LanguageModuleRef.moduleClass.asClass
   lazy val NonLocalReturnControlType: TypeRef   = ctx.requiredClassRef("scala.runtime.NonLocalReturnControl")
   lazy val SelectableType: TypeRef              = ctx.requiredClassRef("scala.Selectable")
 
@@ -638,16 +638,12 @@ class Definitions {
 
   lazy val QuotedExprModuleType = ctx.requiredModuleRef("scala.quoted.Expr")
   def QuotedExprModule(implicit ctx: Context) = QuotedExprModuleType.symbol
-    lazy val QuotedExpr_applyR = QuotedExprModule.requiredMethodRef(nme.apply)
-    def QuotedExpr_apply(implicit ctx: Context) = QuotedExpr_applyR.symbol
-
-    lazy val QuotedExpr_spliceR = QuotedExprClass.requiredMethod(nme.UNARY_~)
-    def QuotedExpr_~(implicit ctx: Context) = QuotedExpr_spliceR.symbol
-    lazy val QuotedExpr_runR = QuotedExprClass.requiredMethodRef(nme.run)
-    def QuotedExpr_run(implicit ctx: Context) = QuotedExpr_runR.symbol
+    def QuotedExpr_apply(implicit ctx: Context) = QuotedExprModule.requiredMethod(nme.apply)
+    def QuotedExpr_~(implicit ctx: Context) = QuotedExprClass.requiredMethod(nme.UNARY_~)
+    def QuotedExpr_run(implicit ctx: Context) =QuotedExprClass.requiredMethodRef(nme.run)
 
   lazy val QuotedExprsModule = ctx.requiredModule("scala.quoted.Exprs")
-  def QuotedExprsClass(implicit ctx: Context) = QuotedExprsModule.symbol.asClass
+  def QuotedExprsClass(implicit ctx: Context) = QuotedExprsModule.asClass
 
   lazy val QuotedTypeType = ctx.requiredClassRef("scala.quoted.Type")
   def QuotedTypeClass(implicit ctx: Context) = QuotedTypeType.symbol.asClass

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -664,10 +664,9 @@ class Definitions {
   def Unpickler_unpickleType = ctx.requiredMethod("scala.runtime.quoted.Unpickler.unpickleType")
 
   lazy val TastyUniverseModule = ctx.requiredModule("scala.tasty.Universe")
-  def TastyUniverseModuleClass(implicit ctx: Context) = TastyUniverseModule.symbol.asClass
+  def TastyUniverseModuleClass(implicit ctx: Context) = TastyUniverseModule.moduleClass.asClass
 
-    lazy val TastyUniverse_compilationUniverseR = TastyUniverseModule.requiredMethod("compilationUniverse")
-    def TastyUniverse_compilationUniverse(implicit ctx: Context) = TastyUniverse_compilationUniverseR.symbol
+    lazy val TastyUniverse_compilationUniverse = TastyUniverseModule.requiredMethod("compilationUniverse")
 
   lazy val EqType = ctx.requiredClassRef("scala.Eq")
   def EqClass(implicit ctx: Context) = EqType.symbol.asClass

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -289,35 +289,6 @@ object Denotations {
           denot.symbol
       }
 
-    def requiredMethod(name: PreName)(implicit ctx: Context): TermSymbol =
-      info.member(name.toTermName).requiredSymbol(_ is Method).asTerm
-    def requiredMethodRef(name: PreName)(implicit ctx: Context): TermRef =
-      requiredMethod(name).termRef
-
-    def requiredMethod(name: PreName, argTypes: List[Type])(implicit ctx: Context): TermSymbol = {
-      info.member(name.toTermName).requiredSymbol { x =>
-        (x is Method) && {
-          x.info.paramInfoss match {
-            case paramInfos :: Nil => paramInfos.corresponds(argTypes)(_ =:= _)
-            case _ => false
-          }
-        }
-      }.asTerm
-    }
-    def requiredMethodRef(name: PreName, argTypes: List[Type])(implicit ctx: Context): TermRef =
-      requiredMethod(name, argTypes).termRef
-
-    def requiredValue(name: PreName)(implicit ctx: Context): TermSymbol =
-      info.member(name.toTermName).requiredSymbol(_.info.isParameterless).asTerm
-    def requiredValueRef(name: PreName)(implicit ctx: Context): TermRef =
-      requiredValue(name).termRef
-
-    def requiredClass(name: PreName)(implicit ctx: Context): ClassSymbol =
-      info.member(name.toTypeName).requiredSymbol(_.isClass).asClass
-
-    def requiredType(name: PreName)(implicit ctx: Context): TypeSymbol =
-      info.member(name.toTypeName).requiredSymbol(_.isType).asType
-
     /** The alternative of this denotation that has a type matching `targetType` when seen
      *  as a member of type `site`, `NoDenotation` if none exists.
      */

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -689,7 +689,7 @@ object Denotations {
     def validFor = myValidFor
     def validFor_=(p: Period) = {
       myValidFor = p
-      symbol.invalidateDenotCache()
+      symbol.updateValidForCache(this, p)
     }
 
     /** The next SingleDenotation in this run, with wrap-around from last to first.

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -689,7 +689,7 @@ object Denotations {
     def validFor = myValidFor
     def validFor_=(p: Period) = {
       myValidFor = p
-      symbol.updateValidForCache(this, p)
+      symbol.invalidateDenotCache()
     }
 
     /** The next SingleDenotation in this run, with wrap-around from last to first.

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -21,6 +21,7 @@ import printing.Printer
 import io.AbstractFile
 import config.Config
 import util.common._
+import util.Stats
 import collection.mutable.ListBuffer
 import Decorators.SymbolIteratorDecorator
 
@@ -174,6 +175,7 @@ object Denotations {
   abstract class Denotation(val symbol: Symbol) extends PreDenotation with printing.Showable {
 
     type AsSeenFromResult <: Denotation
+    Stats.record("Denotation")
 
     /** The type info of the denotation, exists only for non-overloaded denotations */
     def info(implicit ctx: Context): Type
@@ -1139,6 +1141,8 @@ object Denotations {
     def denot1: PreDenotation
     def denot2: PreDenotation
 
+    Stats.record("MultiPreDenotation")
+
     assert(denot1.exists && denot2.exists, s"Union of non-existing denotations ($denot1) and ($denot2)")
     def first = denot1.first
     def last = denot2.last
@@ -1290,7 +1294,7 @@ object Denotations {
 
   /** An exception for accessing symbols that are no longer valid in current run */
   class StaleSymbol(msg: => String) extends Exception {
-    util.Stats.record("stale symbol")
+    Stats.record("stale symbol")
     override def getMessage() = msg
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -160,8 +160,10 @@ object SymDenotations {
     private def adaptFlags(flags: FlagSet) = if (isType) flags.toTypeFlags else flags.toTermFlags
 
     /** Update the flag set */
-    final def flags_=(flags: FlagSet): Unit =
+    final def flags_=(flags: FlagSet): Unit = {
       myFlags = adaptFlags(flags)
+      symbol.updateFlagsCache(this, myFlags)
+    }
 
     /** Set given flags(s) of this denotation */
     final def setFlag(flags: FlagSet): Unit = { myFlags |= flags }
@@ -259,6 +261,7 @@ object SymDenotations {
         */
       if (Config.checkNoSkolemsInInfo) assertNoSkolems(tp)
       myInfo = tp
+      symbol.updateInfoCache(this, tp)
     }
 
     /** The name, except

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1191,11 +1191,15 @@ object SymDenotations {
       cachedRef
     }
 
-    override def typeRef(implicit ctx: Context): TypeRef =
-      namedRef.asInstanceOf[TypeRef]
+    override def typeRef(implicit ctx: Context): TypeRef = namedRef match {
+      case ref: TypeRef => ref
+      case _ => defn.AnyClass.typeRef // case arises when compiling parser-stabiility-1.scala
+    }
 
-    override def termRef(implicit ctx: Context): TermRef =
-      namedRef.asInstanceOf[TermRef]
+    override def termRef(implicit ctx: Context): TermRef = namedRef match {
+      case ref: TermRef => ref
+      case _ => defn.EmptyPackageVal.termRef
+    }
 
     /** The variance of this type parameter or type member as an Int, with
      *  +1 = Covariant, -1 = Contravariant, 0 = Nonvariant, or not a type parameter

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -166,10 +166,16 @@ object SymDenotations {
     }
 
     /** Set given flags(s) of this denotation */
-    final def setFlag(flags: FlagSet): Unit = { myFlags |= flags }
+    final def setFlag(flags: FlagSet): Unit = {
+      myFlags |= flags
+      symbol.updateFlagsCache(this, myFlags)
+    }
 
     /** Unset given flags(s) of this denotation */
-    final def resetFlag(flags: FlagSet): Unit = { myFlags &~= flags }
+    final def resetFlag(flags: FlagSet): Unit = {
+      myFlags &~= flags
+      symbol.updateFlagsCache(this, myFlags)
+    }
 
     /** Set applicable flags from `flags` which is a subset of {NoInits, PureInterface} */
     final def setNoInitsFlags(flags: FlagSet): Unit = {
@@ -228,7 +234,7 @@ object SymDenotations {
         indent += 1
 
         if (myFlags is Touched) throw CyclicReference(this)
-        myFlags |= Touched
+        setFlag(Touched)
 
         // completions.println(s"completing ${this.debugString}")
         try completer.complete(this)(ctx.withPhase(validFor.firstPhaseId))
@@ -244,7 +250,7 @@ object SymDenotations {
       }
       else {
         if (myFlags is Touched) throw CyclicReference(this)
-        myFlags |= Touched
+        setFlag(Touched)
         completer.complete(this)(ctx.withPhase(validFor.firstPhaseId))
       }
 
@@ -452,8 +458,10 @@ object SymDenotations {
     def isError: Boolean = false
 
     /** Make denotation not exist */
-    final def markAbsent(): Unit =
+    final def markAbsent(): Unit = {
       myInfo = NoType
+      symbol.updateInfoCache(this, NoType)
+    }
 
     /** Is symbol known to not exist, or potentially not completed yet? */
     final def unforcedIsAbsent(implicit ctx: Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -127,6 +127,8 @@ object SymDenotations {
 
     //assert(symbol.id != 4940, name)
 
+    Stats.record("SymDenotation")
+
     override def hasUniqueSym: Boolean = exists
 
     /** Debug only

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -580,13 +580,13 @@ object SymDenotations {
       myFlags.is(ModuleClass) && (myFlags.is(PackageClass) || isStatic)
 
     /** Is this denotation defined in the same scope and compilation unit as that symbol? */
-    final def isCoDefinedWith(that: Symbol)(implicit ctx: Context) =
-      (this.effectiveOwner == that.effectiveOwner) &&
+    final def isCoDefinedWith(other: Symbol)(implicit ctx: Context) =
+      (this.effectiveOwner == other.effectiveOwner) &&
       (  !(this.effectiveOwner is PackageClass)
-        || this.unforcedIsAbsent || that.unforcedIsAbsent
+        || this.unforcedIsAbsent || other.unforcedIsAbsent
         || { // check if they are defined in the same file(or a jar)
            val thisFile = this.symbol.associatedFile
-           val thatFile = that.symbol.associatedFile
+           val thatFile = other.associatedFile
            (  thisFile == null
            || thatFile == null
            || thisFile.path == thatFile.path // Cheap possibly wrong check, then expensive normalization

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -29,7 +29,7 @@ import Denotations.{ Denotation, SingleDenotation, MultiDenotation }
 import collection.mutable
 import io.AbstractFile
 import language.implicitConversions
-import util.{NoSource, DotClass, Property}
+import util.{NoSource, DotClass, Property, Stats}
 import scala.collection.JavaConverters._
 import config.Printers.typr
 
@@ -416,6 +416,8 @@ object Symbols {
 
     //assert(id != 723)
 
+    Stats.record("Symbol")
+
     def coord: Coord = myCoord
     /** Set the coordinate of this class, this is only useful when the coordinate is
      *  not known at symbol creation. This is the case for root symbols
@@ -442,12 +444,14 @@ object Symbols {
 
     /** The current denotation of this symbol */
     final def denot(implicit ctx: Context): SymDenotation = {
+      Stats.record("Symbol.denot")
       val lastd = lastDenot
       if (checkedPeriod == ctx.period) lastd
       else computeDenot(lastd)
     }
 
     private def computeDenot(lastd: SymDenotation)(implicit ctx: Context): SymDenotation = {
+      Stats.record("Symbol.computeDenot")
       val now = ctx.period
       checkedPeriod = now
       if (lastd.validFor contains now) lastd else recomputeDenot(lastd)
@@ -455,6 +459,7 @@ object Symbols {
 
     /** Overridden in NoSymbol */
     protected def recomputeDenot(lastd: SymDenotation)(implicit ctx: Context) = {
+      Stats.record("Symbol.recomputeDenot")
       val newd = lastd.current.asInstanceOf[SymDenotation]
       lastDenot = newd
       newd

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -564,13 +564,19 @@ object Symbols {
      *  Overridden in ClassSymbol
      */
     def associatedFile(implicit ctx: Context): AbstractFile =
-      if (lastDenot == null) null else lastDenot.topLevelClass.symbol.associatedFile
+      if (lastDenot == null) null else lastDenot.topLevelClass.associatedFile
 
     /** The class file from which this class was generated, null if not applicable. */
     final def binaryFile(implicit ctx: Context): AbstractFile = {
       val file = associatedFile
       if (file != null && file.extension == "class") file else null
     }
+
+    /** A trap to avoid calling x.symbol on something that is already a symbol.
+     *  This would be expanded to `toDenot(x).symbol` which is guaraneteed to be
+     *  the same as `x`
+     */
+    final def symbol: Nothing = unsupported("symbol")
 
     /** The source file from which this class was generated, null if not applicable. */
     final def sourceFile(implicit ctx: Context): AbstractFile = {

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -574,9 +574,11 @@ object Symbols {
 
     /** A trap to avoid calling x.symbol on something that is already a symbol.
      *  This would be expanded to `toDenot(x).symbol` which is guaraneteed to be
-     *  the same as `x`
+     *  the same as `x`.
+     *  With the given setup, all such calls will give implicit-not found errors
      */
-    final def symbol: Nothing = unsupported("symbol")
+    final def symbol(implicit ev: DontUseSymbolOnSymbol): Nothing = unsupported("symbol")
+    type DontUseSymbolOnSymbol
 
     /** The source file from which this class was generated, null if not applicable. */
     final def sourceFile(implicit ctx: Context): AbstractFile = {
@@ -803,5 +805,4 @@ object Symbols {
 
   @inline def newMutableSymbolMap[T]: MutableSymbolMap[T] =
     new MutableSymbolMap(new java.util.IdentityHashMap[Symbol, T]())
-
 }

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -434,11 +434,30 @@ object Symbols {
     private[this] var lastDenot: SymDenotation = _
     private[this] var checkedPeriod: Period = Nowhere
 
+    private[this] var cachedName: Name = _
+    private[this] var cachedOwner: Symbol = _
+    private[this] var cachedInfo: Type = _
+    private[this] var cachedFlags: FlagSet = _
+
     private[core] def invalidateDenotCache() = { checkedPeriod = Nowhere }
+
+    private[core] def updateInfoCache(d: SymDenotation, info: Type) =
+      if (lastDenot `eq` d) cachedInfo = info
+
+    private[core] def updateFlagsCache(d: SymDenotation, flags: FlagSet) =
+      if (lastDenot `eq` d) cachedFlags = flags
+
+    private[this] def setLastDenot(d: SymDenotation) = {
+      lastDenot = d
+      cachedName = d.name
+      cachedOwner = d.maybeOwner
+      cachedInfo = d.infoOrCompleter
+      cachedFlags = d.flagsUNSAFE
+    }
 
     /** Set the denotation of this symbol */
     private[core] def denot_=(d: SymDenotation) = {
-      lastDenot = d
+      setLastDenot(d)
       checkedPeriod = Nowhere
     }
 
@@ -461,7 +480,7 @@ object Symbols {
     protected def recomputeDenot(lastd: SymDenotation)(implicit ctx: Context) = {
       Stats.record("Symbol.recomputeDenot")
       val newd = lastd.current.asInstanceOf[SymDenotation]
-      lastDenot = newd
+      setLastDenot(newd)
       newd
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -434,12 +434,16 @@ object Symbols {
     private[this] var lastDenot: SymDenotation = _
     private[this] var checkedPeriod: Period = Nowhere
 
+    private[this] var cachedValidFor: Period = _
     private[this] var cachedName: Name = _
     private[this] var cachedOwner: Symbol = _
     private[this] var cachedInfo: Type = _
     private[this] var cachedFlags: FlagSet = _
 
-    private[core] def invalidateDenotCache() = { checkedPeriod = Nowhere }
+    private[core] def updateValidForCache(d: Denotation, validFor: Period) = {
+      if (lastDenot `eq` d) cachedValidFor = validFor
+      checkedPeriod = Nowhere  // this forces recomputeDenot() on next call to denot
+    }
 
     private[core] def updateInfoCache(d: SymDenotation, info: Type) =
       if (lastDenot `eq` d) cachedInfo = info
@@ -449,6 +453,7 @@ object Symbols {
 
     private[this] def setLastDenot(d: SymDenotation) = {
       lastDenot = d
+      cachedValidFor = d.validFor
       cachedName = d.name
       cachedOwner = d.maybeOwner
       cachedInfo = d.infoOrCompleter
@@ -464,22 +469,21 @@ object Symbols {
     /** The current denotation of this symbol */
     final def denot(implicit ctx: Context): SymDenotation = {
       Stats.record("Symbol.denot")
-      val lastd = lastDenot
-      if (checkedPeriod == ctx.period) lastd
-      else computeDenot(lastd)
+      if (checkedPeriod == ctx.period) lastDenot
+      else computeDenot()
     }
 
-    private def computeDenot(lastd: SymDenotation)(implicit ctx: Context): SymDenotation = {
+    private def computeDenot()(implicit ctx: Context): SymDenotation = {
       Stats.record("Symbol.computeDenot")
       val now = ctx.period
       checkedPeriod = now
-      if (lastd.validFor contains now) lastd else recomputeDenot(lastd)
+      if (cachedValidFor contains now) lastDenot else recomputeDenot()
     }
 
     /** Overridden in NoSymbol */
-    protected def recomputeDenot(lastd: SymDenotation)(implicit ctx: Context) = {
+    protected def recomputeDenot()(implicit ctx: Context) = {
       Stats.record("Symbol.recomputeDenot")
-      val newd = lastd.current.asInstanceOf[SymDenotation]
+      val newd = lastDenot.current.asInstanceOf[SymDenotation]
       setLastDenot(newd)
       newd
     }
@@ -638,7 +642,7 @@ object Symbols {
 // -------- Cached SymDenotation facades -----------------------------------------------
 
     private def ensureUpToDate()(implicit ctx: Context) =
-      if (checkedPeriod != ctx.period) computeDenot(lastDenot)
+      if (checkedPeriod != ctx.period) computeDenot()
 
     /** The current name of this symbol */
     final def name(implicit ctx: Context): ThisName = {
@@ -893,7 +897,7 @@ object Symbols {
   @sharable object NoSymbol extends Symbol(NoCoord, 0) {
     override def owner(implicit ctx: Context): Symbol = throw new AssertionError("NoSymbol.owner")
     override def associatedFile(implicit ctx: Context): AbstractFile = NoSource.file
-    override def recomputeDenot(lastd: SymDenotation)(implicit ctx: Context): SymDenotation = NoDenotation
+    override def recomputeDenot()(implicit ctx: Context): SymDenotation = NoDenotation
   }
 
   NoDenotation // force it in order to set `denot` field of NoSymbol

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -891,6 +891,7 @@ object Symbols {
   }
 
   @sharable object NoSymbol extends Symbol(NoCoord, 0) {
+    override def owner(implicit ctx: Context): Symbol = throw new AssertionError("NoSymbol.owner")
     override def associatedFile(implicit ctx: Context): AbstractFile = NoSource.file
     override def recomputeDenot(lastd: SymDenotation)(implicit ctx: Context): SymDenotation = NoDenotation
   }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1690,6 +1690,7 @@ object Types {
 
     /** The denotation currently denoted by this type */
     final def denot(implicit ctx: Context): Denotation = {
+      record("NamedType.denot")
       val now = ctx.period
       // Even if checkedPeriod == now we still need to recheck lastDenotation.validFor
       // as it may have been mutated by SymDenotation#installAfter

--- a/compiler/src/dotty/tools/dotc/core/Uniques.scala
+++ b/compiler/src/dotty/tools/dotc/core/Uniques.scala
@@ -66,7 +66,7 @@ object Uniques {
       designator match {
         case sym: Symbol =>
           val symd = sym.lastKnownDenotation
-          if (symd != null) {
+          if (symd != null && symd.exists) {
             val ref = symd.namedRef
             if (prefix `eq` ref.prefix) {
               record("namedRef reuse")

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -172,7 +172,7 @@ class ClassfileParser(
       setClassInfo(classRoot, classInfo)
       setClassInfo(moduleRoot, staticInfo)
     } else if (result == Some(NoEmbedded)) {
-      for (sym <- List(moduleRoot.sourceModule.symbol, moduleRoot.symbol, classRoot.symbol)) {
+      for (sym <- List(moduleRoot.sourceModule, moduleRoot.symbol, classRoot.symbol)) {
         classRoot.owner.asClass.delete(sym)
         if (classRoot.owner == defn.ScalaShadowingPackageClass) {
           // Symbols in scalaShadowing are also added to scala

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -351,7 +351,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       val owner = if (atEnd) loadingMirror.RootClass else readSymbolRef()
 
       def adjust(denot: Denotation) = {
-        val denot1 = denot.disambiguate(d => p(d.symbol))
+        val denot1 = denot.disambiguate(p)
         val sym = denot1.symbol
         if (denot.exists && !denot1.exists) { // !!!DEBUG
           val alts = denot.alternatives map (d => d + ":" + d.info + "/" + d.signature)

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -231,8 +231,8 @@ object Interactive {
         val boundaryCtx = ctx.withOwner(boundary)
         def exclude(sym: Symbol) = sym.isAbsent || sym.is(Synthetic) || sym.is(Artifact)
         def addMember(name: Name, buf: mutable.Buffer[SingleDenotation]): Unit =
-          buf ++= prefix.member(name).altsWith(d =>
-            !exclude(d) && d.symbol.isAccessibleFrom(prefix)(boundaryCtx))
+          buf ++= prefix.member(name).altsWith(sym =>
+            !exclude(sym) && sym.isAccessibleFrom(prefix)(boundaryCtx))
           prefix.memberDenots(completionsFilter, addMember).map(_.symbol).toList
       }
       else Nil

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -190,7 +190,7 @@ object LambdaLift {
       def traverse(tree: Tree)(implicit ctx: Context) = try { //debug
         val sym = tree.symbol
 
-        def enclosure = ctx.owner.enclosingMethod.symbol
+        def enclosure = ctx.owner.enclosingMethod
 
         def narrowTo(thisClass: ClassSymbol) = {
           val enclMethod = enclosure

--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -132,7 +132,7 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
             initName,
             Protected | Synthetic | Method,
             sym.info,
-            coord = sym.symbol.coord).enteredAfter(thisPhase))
+            coord = sym.coord).enteredAfter(thisPhase))
     }
   }.asTerm
 

--- a/compiler/src/dotty/tools/dotc/transform/TreeExtractors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeExtractors.scala
@@ -36,8 +36,8 @@ object TreeExtractors {
   object ValueClassUnbox {
     def unapply(t: Tree)(implicit ctx: Context): Option[Tree] = t match {
       case Apply(sel @ Select(ref, _), Nil) =>
-        val d = ref.tpe.widenDealias.typeSymbol.denot
-        if (isDerivedValueClass(d) && (sel.symbol eq valueClassUnbox(d.asClass))) {
+        val sym = ref.tpe.widenDealias.typeSymbol
+        if (isDerivedValueClass(sym) && (sel.symbol eq valueClassUnbox(sym.asClass))) {
           Some(ref)
         } else
           None

--- a/compiler/src/dotty/tools/dotc/transform/ValueClasses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ValueClasses.scala
@@ -4,7 +4,6 @@ package transform
 import core._
 import Types._
 import Symbols._
-import SymDenotations._
 import Contexts._
 import Flags._
 import StdNames._
@@ -13,7 +12,8 @@ import SymUtils._
 /** Methods that apply to user-defined value classes */
 object ValueClasses {
 
-  def isDerivedValueClass(d: SymDenotation)(implicit ctx: Context) = {
+  def isDerivedValueClass(sym: Symbol)(implicit ctx: Context): Boolean = {
+    val d = sym.denot
     !ctx.settings.XnoValueClasses.value &&
     !d.isRefinementClass &&
     d.isValueClass &&
@@ -33,27 +33,27 @@ object ValueClasses {
     }
 
   /** The member of a derived value class that unboxes it. */
-  def valueClassUnbox(d: ClassDenotation)(implicit ctx: Context): Symbol =
+  def valueClassUnbox(cls: ClassSymbol)(implicit ctx: Context): Symbol =
     // (info.decl(nme.unbox)).orElse(...)      uncomment once we accept unbox methods
-    d.classInfo.decls.find(_.is(ParamAccessor))
+    cls.classInfo.decls.find(_.is(ParamAccessor))
 
   /** For a value class `d`, this returns the synthetic cast from the underlying type to
    *  ErasedValueType defined in the companion module. This method is added to the module
    *  and further described in [[ExtensionMethods]].
    */
-  def u2evt(d: ClassDenotation)(implicit ctx: Context): Symbol =
-    d.linkedClass.info.decl(nme.U2EVT).symbol
+  def u2evt(cls: ClassSymbol)(implicit ctx: Context): Symbol =
+    cls.linkedClass.info.decl(nme.U2EVT).symbol
 
   /** For a value class `d`, this returns the synthetic cast from ErasedValueType to the
    *  underlying type defined in the companion module. This method is added to the module
    *  and further described in [[ExtensionMethods]].
    */
-  def evt2u(d: ClassDenotation)(implicit ctx: Context): Symbol =
-    d.linkedClass.info.decl(nme.EVT2U).symbol
+  def evt2u(cls: ClassSymbol)(implicit ctx: Context): Symbol =
+    cls.linkedClass.info.decl(nme.EVT2U).symbol
 
   /** The unboxed type that underlies a derived value class */
-  def underlyingOfValueClass(d: ClassDenotation)(implicit ctx: Context): Type =
-    valueClassUnbox(d).info.resultType
+  def underlyingOfValueClass(sym: ClassSymbol)(implicit ctx: Context): Type =
+    valueClassUnbox(sym).info.resultType
 
   /** Whether a value class wraps itself */
   def isCyclic(cls: ClassSymbol)(implicit ctx: Context): Boolean = {

--- a/compiler/src/dotty/tools/dotc/transform/localopt/InlineLocalObjects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/InlineLocalObjects.scala
@@ -92,7 +92,7 @@ class InlineLocalObjects(val simplifyPhase: Simplify) extends Optimisation {
       case t @ NewCaseClassValDef(fun, args) if newFieldsMapping.contains(t.symbol) =>
         val newFields     = newFieldsMapping(t.symbol).values.toList
         val newFieldsDefs = newFields.zip(args).map { case (nf, arg) =>
-          val rhs = arg.changeOwnerAfter(t.symbol, nf.symbol, simplifyPhase)
+          val rhs = arg.changeOwnerAfter(t.symbol, nf, simplifyPhase)
           ValDef(nf.asTerm, rhs)
         }
         val recreate      = cpy.ValDef(t)(rhs = fun.appliedToArgs(newFields.map(x => ref(x))))

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -279,7 +279,7 @@ object Inferencing {
       case tp: TypeRef =>
         val companion = tp.classSymbol.companionModule
         if (companion.exists)
-          companion.termRef.asSeenFrom(tp.prefix, companion.symbol.owner)
+          companion.termRef.asSeenFrom(tp.prefix, companion.owner)
         else NoType
       case _ => NoType
     }


### PR DESCRIPTION
It seems we get many cache misses when going from Symbols to their denotations. This is a very common operation: When compiling typer/*.scala, we generate ~80K symbols, ~125K SymDenotations, yet dereference .denot more than 15.8M times. Of these, 11.7M go to the symbol's initial denotation.

After closing #4504, this PR tries something else: Cache the hottests fields of denotations
in symbols, so that we can get at them without a dereference. 

We don't need to introduce forwarders in Symbols to do this (although it might be a good idea for other reasons), and we don't need to have Symbol inherit from SymDenotation (which has proven to be a bad idea).
