### PR TITLE
Fix #4498: Go to definition in lifted expressions

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -49,8 +49,8 @@ abstract class Lifter {
       var liftedType = fullyDefinedType(expr.tpe.widen, "lifted expression", expr.pos)
       if (liftedFlags.is(Method)) liftedType = ExprType(liftedType)
       val lifted = ctx.newSymbol(ctx.owner, name, liftedFlags, liftedType, coord = positionCoord(expr.pos))
-      defs += liftedDef(lifted, expr).withPos(expr.pos.focus)
-      ref(lifted.termRef).withPos(expr.pos)
+      defs += liftedDef(lifted, expr).withPos(expr.pos)
+      ref(lifted.termRef).withPos(expr.pos.focus)
     }
 
   /** Lift out common part of lhs tree taking part in an operator assignment such as

--- a/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
@@ -36,4 +36,11 @@ class DefinitionTest {
       .definition(m5 to m6, List(m1 to m2))
   }
 
+  @Test def liftedExpression: Unit = {
+    withSources(
+      code"class ${m1}A${m2}",
+      code"object B { val lst = new ${m3}A${m4} :: Nil }"
+    ).definition(m3 to m4, List(m1 to m2))
+  }
+
 }


### PR DESCRIPTION
Consider the following snippet:

```scala
val lst = new A :: Nil
```

This is rewritten as:

```scala
val lst = {
  val x$0 = new A
  Nil.::(x$0)
}
```

During lifting, we need to assign positions to the trees. We were
assigning the position of `new A` in the original code to `x$0` in
`Nil.::(x$0)`, and the original position of `new A` to `val x$0 = new A`
with a zero-extent.

Still considering this snippet, this means that when trying to go to the
definition on `new A`, the IDE would think that the user tried to go to
the definition of `x$0`, because the IDE would look for the matching
tree by position.

This commit changes this so that the lifted definition
(`val x$0 = new A`) gets the position of the original expression, and
the reference gets a synthetic, zero-extent position. With this change,
the IDE correctly finds the right tree when selecting `new A` in the
original code.

Fixes #4498