### PR TITLE
Docs: Unbreak link to proofs

### DIFF
--- a/docs/docs/reference/principled-meta-programming.md
+++ b/docs/docs/reference/principled-meta-programming.md
@@ -751,7 +751,7 @@ environments and terms.
                            Es |- 't: expr T
 
 The meta theory of a slightly simplified variant 2-stage variant of this calculus
-is studied [separatey](../simple-smp.md)
+is studied [separately](simple-smp.md).
 
 ## Going Further
 

--- a/docs/docs/reference/simple-smp.md
+++ b/docs/docs/reference/simple-smp.md
@@ -3,8 +3,6 @@ layout: doc-page
 title: "The Meta-theory of Symmetric Meta-programming"
 ---
 
-23.12.2017
-
 This note presents a simplified variant of
 [principled meta-programming](./principled-meta-programming.md)
 and sketches its soundness proof. The variant treats only dialogues

--- a/docs/docs/reference/simple-smp.md
+++ b/docs/docs/reference/simple-smp.md
@@ -3,8 +3,6 @@ layout: doc-page
 title: "The Meta-theory of Symmetric Meta-programming"
 ---
 
-# The Meta-theory of Symmetric Meta-programming
-
 23.12.2017
 
 This note presents a simplified variant of


### PR DESCRIPTION
The link currently 404s, fix that.