### PR TITLE
Fix #4493 and #4514

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -145,7 +145,7 @@ class ReifyQuotes extends MacroTransformWithImplicits with InfoTransformer {
     def inSplice = outer != null && !inQuote
 
     /** We are not in a `~(...)` or a `'(...)` */
-    def isRoot = outer != null
+    def isRoot = outer == null
 
     /** A map from type ref T to expressions of type `quoted.Type[T]`".
      *  These will be turned into splices using `addTags` and represent type variables
@@ -294,7 +294,7 @@ class ReifyQuotes extends MacroTransformWithImplicits with InfoTransformer {
         else i"${sym.name}.this"
       if (!isThis && sym.maybeOwner.isType && !sym.is(Param))
         check(sym.owner, sym.owner.thisType, pos)
-      else if (level == 1 && sym.isType && sym.is(Param) && sym.owner.is(Macro) && outer.isRoot)
+      else if (level == 1 && sym.isType && sym.is(Param) && sym.owner.is(Macro) && !outer.isRoot)
         importedTags(sym.typeRef) = capturers(sym)(ref(sym))
       else if (sym.exists && !sym.isStaticOwner && !levelOK(sym))
         for (errMsg <- tryHeal(tp, pos))

--- a/tests/pos/i4493-b.scala
+++ b/tests/pos/i4493-b.scala
@@ -1,0 +1,7 @@
+class Index[K]
+object Index {
+  inline def succ[K](x: K): Unit = ~{
+    implicit val t: quoted.Type[K] = '[K]
+    '(new Index[K])
+  }
+}

--- a/tests/pos/i4493-c.scala
+++ b/tests/pos/i4493-c.scala
@@ -1,0 +1,6 @@
+class Index[K]
+object Index {
+  inline def succ[K]: Unit = ~{
+    '(new Index[K])
+  }
+}

--- a/tests/pos/i4493.scala
+++ b/tests/pos/i4493.scala
@@ -1,0 +1,7 @@
+class Index[K]
+object Index {
+  inline def succ[K]: Unit = ~{
+    implicit val t: quoted.Type[K] = '[K]
+    '(new Index[K])
+  }
+}

--- a/tests/pos/i4514.scala
+++ b/tests/pos/i4514.scala
@@ -1,0 +1,4 @@
+object Foo {
+  inline def foo[X](x: X): Unit = ~fooImpl('(x))
+  def fooImpl[X: quoted.Type](x: X): quoted.Expr[Unit] = '()
+}


### PR DESCRIPTION
Use captured type tags for macro type parameters. Before this change we just kept the type and failed when we tied to pickle it.