### PR TITLE
Selectable: catch correct exception when the field isn't found

### DIFF
--- a/library/src/scala/reflect/Selectable.scala
+++ b/library/src/scala/reflect/Selectable.scala
@@ -8,7 +8,7 @@ class Selectable(val receiver: Any) extends AnyVal with scala.Selectable {
       fld.get(receiver)
     }
     catch {
-      case ex: NoSuchFieldError =>
+      case ex: NoSuchFieldException =>
         selectDynamicMethod(name).asInstanceOf[() => Any]()
     }
   }

--- a/tests/run/i4496a.scala
+++ b/tests/run/i4496a.scala
@@ -1,0 +1,11 @@
+import scala.reflect.Selectable.reflectiveSelectable
+class Foo1 { val a: Int = 10 }
+class Foo2 { def a: Int = 10 }
+class Foo3 { var a: Int = 10 }
+object Test {
+  def main(args: Array[String]): Unit = {
+    assert((new Foo1 : {val a: Int}).a == 10)
+    assert((new Foo2 : {val a: Int}).a == 10)
+    assert((new Foo3 : {val a: Int}).a == 10)
+  }
+}


### PR DESCRIPTION
NoSuchFieldError doesn't happen when reflection fails but when class-loading
fails, so it isn't relevant here.

This is the first step towards #4496, IMHO pretty non-controversial, as it doesn't bypass any access control.