### PR TITLE
Document meaning of constant expressions

### DIFF
--- a/docs/docs/reference/inline.md
+++ b/docs/docs/reference/inline.md
@@ -29,7 +29,8 @@ inlined at the point of use. Example:
 The `Config` object contains a definition of an `inline` value
 `logging`. This means that `logging` is treated as a constant value,
 equivalent to its right-hand side `false`. The right-hand side of such
-an inline val must itself be a constant expression. Used in this way,
+an inline val must itself be a [constant
+expression](#the-definition-of-constant-expression). Used in this way,
 `inline` is equivalent to Java and Scala 2's `final`. `final` meaning
 "constant" is still supported in Dotty, but will be phased out.
 
@@ -124,6 +125,13 @@ it in backticks, i.e.
 
     @`inline` def ...
 
+### The definition of constant expression
+
+Right-hand sides of inline values and of arguments for inline parameters
+must be constant expressions in the sense defined by the [SLS §
+6.24](https://www.scala-lang.org/files/archive/spec/2.12/06-expressions.html#constant-expressions),
+including "platform-specific" extensions such as constant folding of
+pure numeric computations.
 
 ### Reference
 

--- a/docs/docs/reference/inline.md
+++ b/docs/docs/reference/inline.md
@@ -136,7 +136,4 @@ pure numeric computations.
 ### Reference
 
 For more info, see [PR #1492](https://github.com/lampepfl/dotty/pull/1492) and
-[Scala SIP 28](http://docs.scala-lang.org/sips/pending/inline-meta.html)
-
-
-
+[Scala SIP 28](http://docs.scala-lang.org/sips/pending/inline-meta.html).


### PR DESCRIPTION
Clarification following #4431.

The error checking's done by `Checking.checkInlineConformant(tree, isFinal =
false, "argument to inline parameter")`, and `checkInlineConformant` uses
`ConstantType` which characterizes constant expressions.

@tomasmikula opinions? (Since you asked what "constant expression" means).