### PR TITLE
Fix printing of classes with companion objects in the decompiler (#4526)

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/DecompilerPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/DecompilerPrinter.scala
@@ -38,7 +38,7 @@ class DecompilerPrinter(_ctx: Context) extends RefinedPrinter(_ctx) {
     }
     val statsText = stats match {
       case (pdef: PackageDef) :: Nil => toText(pdef)
-      case _ => toTextGlobal(stats, "\n")
+      case _ => Fluid(toTextGlobal(stats, "\n") :: Nil)
     }
     val bodyText =
       if (tree.pid.symbol.isEmptyPackage) statsText

--- a/tests/pos/classWithCompObj.decompiled
+++ b/tests/pos/classWithCompObj.decompiled
@@ -1,0 +1,3 @@
+/** Decompiled from out/posTestFromTasty/pos/classWithCompObj/Foo.class */
+class Foo() {}
+object Foo {}

--- a/tests/pos/classWithCompObj.scala
+++ b/tests/pos/classWithCompObj.scala
@@ -1,0 +1,2 @@
+class Foo
+object Foo


### PR DESCRIPTION
This fixes printing of classes with companion objects so that they don't appear on the same line as described in #4526.

Example case:

```scala
class Foo
object Foo
```

will be decompiled into

```scala
class Foo() {}
object Foo {}
```

whereas before they would be printed on the same line, failing compilation.

Thanks to @nicolasstucki for mentoring this during the Scala Spree in Berlin!