### PR TITLE
Add note of separate compilation unit in macro's code example

### DIFF
--- a/docs/docs/reference/principled-meta-programming.md
+++ b/docs/docs/reference/principled-meta-programming.md
@@ -322,9 +322,12 @@ program that calls `assert`.
         '{ if !(~expr) then throw new AssertionError(s"failed assertion: ${~expr}") }
     }
 
-    val program = {
-      val x = 1
-      Macros.assert(x != 0)
+    // has to be in a different compilation unit that depends on Macros
+    object App {
+      val program = {
+        val x = 1
+        Macros.assert(x != 0)
+      }
     }
 
 Inlining the `assert` function would give the following program:


### PR DESCRIPTION
Old docs (https://docs.scala-lang.org/overviews/macros/overview.html#a-complete-example) has a paragraph which says:

> An important aspect of macrology is separate compilation. To perform macro expansion, compiler needs a macro implementation in executable form. Thus macro implementations need to be compiled before the main compilation, otherwise you might see the following error:

However dotty throws unclear error so far so I opened and issue #4540 and submitted only simple note to code snippet as a remainder 