### PR TITLE
Make 'namePos' return a point position if name is 'nme.ERROR'

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -337,9 +337,11 @@ object Trees {
      *  a calling chain from `viewExists`), in that case the return position is NoPosition.
      */
     def namePos =
-      if (pos.exists)
-        if (rawMods.is(Synthetic) || name.toTermName == nme.ERROR) Position(pos.point, pos.point)
-        else Position(pos.point, pos.point + name.stripModuleClassSuffix.lastPart.length, pos.point)
+      if (pos.exists) {
+        val point = pos.point
+        if (rawMods.is(Synthetic) || name.toTermName == nme.ERROR) Position(point)
+        else Position(point, point + name.stripModuleClassSuffix.lastPart.length, point)
+      }
       else pos
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -338,7 +338,7 @@ object Trees {
      */
     def namePos =
       if (pos.exists)
-        if (rawMods.is(Synthetic)) Position(pos.point, pos.point)
+        if (rawMods.is(Synthetic) || name.toTermName == nme.ERROR) Position(pos.point, pos.point)
         else Position(pos.point, pos.point + name.stripModuleClassSuffix.lastPart.length, pos.point)
       else pos
   }

--- a/compiler/src/dotty/tools/dotc/interactive/SourceTree.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/SourceTree.scala
@@ -6,7 +6,7 @@ import scala.io.Codec
 
 import ast.tpd
 import core._, core.Decorators.{sourcePos => _, _}
-import Contexts._, NameOps._, Symbols._
+import Contexts._, NameOps._, Symbols._, StdNames._
 import util._, util.Positions._
 
 /** A typechecked named `tree` coming from `source` */
@@ -18,7 +18,7 @@ case class SourceTree(tree: tpd.NameTree, source: SourceFile) {
   def namePos(implicit ctx: Context): SourcePosition = {
     // FIXME: Merge with NameTree#namePos ?
     val treePos = tree.pos
-    if (treePos.isZeroExtent)
+    if (treePos.isZeroExtent || tree.name.toTermName == nme.ERROR)
       NoSourcePosition
     else {
       val nameLength = tree.name.stripModuleClassSuffix.show.toString.length


### PR DESCRIPTION
'namePos' used to return nonsensical position when the tree was
malformed (e.g. "case class").