### PR TITLE
Drop requirement that implicit functions must be non-empty

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -869,7 +869,7 @@ object desugar {
 
   def makeImplicitFunction(formals: List[Type], body: Tree)(implicit ctx: Context): Tree = {
     val params = makeImplicitParameters(formals.map(TypeTree))
-    new NonEmptyFunction(params, body, Modifiers(Implicit))
+    new FunctionWithMods(params, body, Modifiers(Implicit))
   }
 
   /** Add annotation to tree:

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -819,12 +819,12 @@ object desugar {
    *
    *  If `inlineable` is true, tag $anonfun with an @inline annotation.
    */
-  def makeClosure(params: List[ValDef], body: Tree, tpt: Tree = TypeTree(), inlineable: Boolean)(implicit ctx: Context) = {
+  def makeClosure(params: List[ValDef], body: Tree, tpt: Tree = TypeTree(), isInlineable: Boolean, isImplicit: Boolean)(implicit ctx: Context) = {
     var mods = synthetic | Artifact
-    if (inlineable) mods |= Inline
+    if (isInlineable) mods |= Inline
     Block(
       DefDef(nme.ANON_FUN, Nil, params :: Nil, tpt, body).withMods(mods),
-      Closure(Nil, Ident(nme.ANON_FUN), EmptyTree))
+      Closure(Nil, Ident(nme.ANON_FUN), if (isImplicit) ImplicitEmptyTree else EmptyTree))
   }
 
   /** If `nparams` == 1, expand partial function

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -882,6 +882,7 @@ object Trees {
 
     @sharable val EmptyTree: Thicket = genericEmptyTree
     @sharable val EmptyValDef: ValDef = genericEmptyValDef
+    @sharable val ImplicitEmptyTree: Thicket = Thicket(Nil) // an empty tree marking an implicit closure
 
     // ----- Auxiliary creation methods ------------------
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -56,13 +56,15 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     override def isType = body.isType
   }
 
-  /** A function type that should have non empty args */
-  class NonEmptyFunction(args: List[Tree], body: Tree, val mods: Modifiers) extends Function(args, body)
+  /** A function type with `implicit` or `erased` modifiers */
+  class FunctionWithMods(args: List[Tree], body: Tree, val mods: Modifiers) extends Function(args, body)
 
   /** A function created from a wildcard expression
    *  @param  placeholderParams  a list of definitions of synthetic parameters.
    *  @param  body               the function body where wildcards are replaced by
    *                             references to synthetic parameters.
+   *  This is equivalent to Function, except that forms a special case for the overlapping
+   *  positions tests.
    */
   class WildcardFunction(placeholderParams: List[ValDef], body: Tree) extends Function(placeholderParams, body)
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -894,26 +894,23 @@ class Definitions {
   def isBottomType(tp: Type) =
     tp.derivesFrom(NothingClass) || tp.derivesFrom(NullClass)
 
-  /** Is a function class, i.e. on of
-   *   - FunctionN
-   *   - ImplicitFunctionN
-   *   - ErasedFunctionN
-   *   - ErasedImplicitFunctionN
-   *  for N >= 0
+  /** Is a function class.
+   *   - FunctionN for N >= 0
+   *   - ImplicitFunctionN for N >= 0
+   *   - ErasedFunctionN for N > 0
+   *   - ErasedImplicitFunctionN for N > 0
    */
   def isFunctionClass(cls: Symbol) = scalaClassName(cls).isFunction
 
   /** Is an implicit function class.
-   *   - ImplicitFunctionN
-   *   - ErasedImplicitFunctionN
-   *  for N >= 0
+   *   - ImplicitFunctionN for N >= 0
+   *   - ErasedImplicitFunctionN for N > 0
    */
   def isImplicitFunctionClass(cls: Symbol) = scalaClassName(cls).isImplicitFunction
 
   /** Is an erased function class.
-   *   - ErasedFunctionN
-   *   - ErasedImplicitFunctionN
-   *  for N >= 0
+   *   - ErasedFunctionN for N > 0
+   *   - ErasedImplicitFunctionN for N > 0
    */
   def isErasedFunctionClass(cls: Symbol) = scalaClassName(cls).isErasedFunction
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -855,22 +855,17 @@ class Definitions {
 
   lazy val TupleType = mkArityArray("scala.Tuple", MaxTupleArity, 2)
 
-  def FunctionClass(n: Int, isImplicit: Boolean = false, isErased: Boolean = false)(implicit ctx: Context) = {
-    if (isImplicit && isErased) {
-      require(n > 0)
+  def FunctionClass(n: Int, isImplicit: Boolean = false, isErased: Boolean = false)(implicit ctx: Context) =
+    if (isImplicit && isErased)
       ctx.requiredClass("scala.ErasedImplicitFunction" + n.toString)
-    }
-    else if (isImplicit) {
-      require(n > 0)
+    else if (isImplicit)
       ctx.requiredClass("scala.ImplicitFunction" + n.toString)
-    }
-    else if (isErased) {
-      require(n > 0)
+    else if (isErased)
       ctx.requiredClass("scala.ErasedFunction" + n.toString)
-    }
-    else if (n <= MaxImplementedFunctionArity) FunctionClassPerRun()(ctx)(n)
-    else ctx.requiredClass("scala.Function" + n.toString)
-  }
+    else if (n <= MaxImplementedFunctionArity)
+      FunctionClassPerRun()(ctx)(n)
+    else
+      ctx.requiredClass("scala.Function" + n.toString)
 
     lazy val Function0_applyR = ImplementedFunctionType(0).symbol.requiredMethodRef(nme.apply)
     def Function0_apply(implicit ctx: Context) = Function0_applyR.symbol
@@ -899,23 +894,26 @@ class Definitions {
   def isBottomType(tp: Type) =
     tp.derivesFrom(NothingClass) || tp.derivesFrom(NullClass)
 
-  /** Is a function class.
-   *   - FunctionN for N >= 0
-   *   - ImplicitFunctionN for N > 0
-   *   - ErasedFunctionN for N > 0
-   *   - ErasedImplicitFunctionN for N > 0
+  /** Is a function class, i.e. on of
+   *   - FunctionN
+   *   - ImplicitFunctionN
+   *   - ErasedFunctionN
+   *   - ErasedImplicitFunctionN
+   *  for N >= 0
    */
   def isFunctionClass(cls: Symbol) = scalaClassName(cls).isFunction
 
   /** Is an implicit function class.
-   *   - ImplicitFunctionN for N > 0
-   *   - ErasedImplicitFunctionN for N > 0
+   *   - ImplicitFunctionN
+   *   - ErasedImplicitFunctionN
+   *  for N >= 0
    */
   def isImplicitFunctionClass(cls: Symbol) = scalaClassName(cls).isImplicitFunction
 
   /** Is an erased function class.
-   *   - ErasedFunctionN for N > 0
-   *   - ErasedImplicitFunctionN for N > 0
+   *   - ErasedFunctionN
+   *   - ErasedImplicitFunctionN
+   *  for N >= 0
    */
   def isErasedFunctionClass(cls: Symbol) = scalaClassName(cls).isErasedFunction
 
@@ -942,7 +940,7 @@ class Definitions {
    *    - FunctionN for N > 22 becomes FunctionXXL
    *    - FunctionN for 22 > N >= 0 remains as FunctionN
    *    - ImplicitFunctionN for N > 22 becomes FunctionXXL
-   *    - ImplicitFunctionN for 22 > N >= 0 becomes FunctionN
+   *    - ImplicitFunctionN for N <= 22 becomes FunctionN
    *    - ErasedFunctionN becomes Function0
    *    - ImplicitErasedFunctionN becomes Function0
    *    - anything else becomes a NoSymbol
@@ -959,7 +957,7 @@ class Definitions {
    *    - FunctionN for N > 22 becomes FunctionXXL
    *    - FunctionN for 22 > N >= 0 remains as FunctionN
    *    - ImplicitFunctionN for N > 22 becomes FunctionXXL
-   *    - ImplicitFunctionN for 22 > N >= 0 becomes FunctionN
+   *    - ImplicitFunctionN for N <= 22 becomes FunctionN
    *    - ErasedFunctionN becomes Function0
    *    - ImplicitErasedFunctionN becomes Function0
    *    - anything else becomes a NoType

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -169,33 +169,36 @@ object NameOps {
 
     def functionArity: Int =
       functionArityFor(str.Function) max
-      functionArityFor(str.ImplicitFunction) max
-      functionArityFor(str.ErasedFunction) max
-      functionArityFor(str.ErasedImplicitFunction)
+      functionArityFor(str.ImplicitFunction) max {
+        val n =
+          functionArityFor(str.ErasedFunction) max
+          functionArityFor(str.ErasedImplicitFunction)
+        if (n == 0) -1 else n
+      }
 
-    /** Is a function name, i.e one of FunctionN, ImplicitFunctionN, ErasedFunctionN, ErasedImplicitFunctionN for N >= 0
+    /** Is a function name, i.e one of FunctionN, ImplicitFunctionN for N >= 0 or ErasedFunctionN, ErasedImplicitFunctionN for N > 0
      */
     def isFunction: Boolean = functionArity >= 0
 
-    /** Is an implicit function name, i.e one of ImplicitFunctionN, ErasedImplicitFunctionN for N >= 0
+    /** Is an implicit function name, i.e one of ImplicitFunctionN for N >= 0 or ErasedImplicitFunctionN for N > 0
      */
     def isImplicitFunction: Boolean = {
       functionArityFor(str.ImplicitFunction) >= 0 ||
-      functionArityFor(str.ErasedImplicitFunction) >= 0
+      functionArityFor(str.ErasedImplicitFunction) > 0
     }
 
-    /** Is an erased function name, i.e. one of ErasedFunctionN, ErasedImplicitFunctionN for N >= 0
+    /** Is an erased function name, i.e. one of ErasedFunctionN, ErasedImplicitFunctionN for N > 0
       */
     def isErasedFunction: Boolean = {
-      functionArityFor(str.ErasedFunction) >= 0 ||
-      functionArityFor(str.ErasedImplicitFunction) >= 0
+      functionArityFor(str.ErasedFunction) > 0 ||
+      functionArityFor(str.ErasedImplicitFunction) > 0
     }
 
     /** Is a synthetic function name, i.e. one of
      *    - FunctionN for N > 22
      *    - ImplicitFunctionN for N >= 0
-     *    - ErasedFunctionN for N >= 0
-     *    - ErasedImplicitFunctionN for N >= 0
+     *    - ErasedFunctionN for N > 0
+     *    - ErasedImplicitFunctionN for N > 0
      */
     def isSyntheticFunction: Boolean = {
       functionArityFor(str.Function) > MaxImplementedFunctionArity ||

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -167,59 +167,39 @@ object NameOps {
       }
     }
 
-    /** Is a synthetic function name
-     *    - N for FunctionN
-     *    - N for ImplicitFunctionN (N >= 1)
-      *   - (-1) otherwise
-     */
     def functionArity: Int =
-      functionArityFor(str.Function) max {
-        val n =
-          functionArityFor(str.ImplicitFunction) max
-          functionArityFor(str.ErasedFunction) max
-          functionArityFor(str.ErasedImplicitFunction)
-        if (n == 0) -1 else n
-      }
+      functionArityFor(str.Function) max
+      functionArityFor(str.ImplicitFunction) max
+      functionArityFor(str.ErasedFunction) max
+      functionArityFor(str.ErasedImplicitFunction)
 
-    /** Is a function name
-     *    - FunctionN for N >= 0
-     *    - ImplicitFunctionN for N >= 1
-     *    - ErasedFunctionN for N >= 1
-     *    - ErasedImplicitFunctionN for N >= 1
-     *    - false otherwise
+    /** Is a function name, i.e one of FunctionN, ImplicitFunctionN, ErasedFunctionN, ErasedImplicitFunctionN for N >= 0
      */
     def isFunction: Boolean = functionArity >= 0
 
-    /** Is a implicit function name
-     *    - ImplicitFunctionN for N >= 1
-     *    - ErasedImplicitFunctionN for N >= 1
-     *    - false otherwise
+    /** Is an implicit function name, i.e one of ImplicitFunctionN, ErasedImplicitFunctionN for N >= 0
      */
     def isImplicitFunction: Boolean = {
-      functionArityFor(str.ImplicitFunction) >= 1 ||
-      functionArityFor(str.ErasedImplicitFunction) >= 1
+      functionArityFor(str.ImplicitFunction) >= 0 ||
+      functionArityFor(str.ErasedImplicitFunction) >= 0
     }
 
-    /** Is a implicit function name
-      *    - ErasedFunctionN for N >= 1
-      *    - ErasedImplicitFunctionN for N >= 1
-      *    - false otherwise
+    /** Is an erased function name, i.e. one of ErasedFunctionN, ErasedImplicitFunctionN for N >= 0
       */
     def isErasedFunction: Boolean = {
-      functionArityFor(str.ErasedFunction) >= 1 ||
-      functionArityFor(str.ErasedImplicitFunction) >= 1
+      functionArityFor(str.ErasedFunction) >= 0 ||
+      functionArityFor(str.ErasedImplicitFunction) >= 0
     }
 
-    /** Is a synthetic function name
+    /** Is a synthetic function name, i.e. one of
      *    - FunctionN for N > 22
-     *    - ImplicitFunctionN for N >= 1
-     *    - ErasedFunctionN for N >= 1
-     *    - ErasedImplicitFunctionN for N >= 1
-     *    - false otherwise
+     *    - ImplicitFunctionN for N >= 0
+     *    - ErasedFunctionN for N >= 0
+     *    - ErasedImplicitFunctionN for N >= 0
      */
     def isSyntheticFunction: Boolean = {
       functionArityFor(str.Function) > MaxImplementedFunctionArity ||
-      functionArityFor(str.ImplicitFunction) >= 1 ||
+      functionArityFor(str.ImplicitFunction) >= 0 ||
       isErasedFunction
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2892,7 +2892,6 @@ object Types {
     final override def isImplicitMethod: Boolean = companion.eq(ImplicitMethodType) || companion.eq(ErasedImplicitMethodType)
     final override def isErasedMethod: Boolean = companion.eq(ErasedMethodType) || companion.eq(ErasedImplicitMethodType)
 
-
     def computeSignature(implicit ctx: Context): Signature = {
       val params = if (isErasedMethod) Nil else paramInfos
       resultSignature.prepend(params, isJavaMethod)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -732,7 +732,7 @@ object Parsers {
       def functionRest(params: List[Tree]): Tree =
         atPos(start, accept(ARROW)) {
           val t = typ()
-          if (imods.is(Implicit) || imods.is(Erased)) new NonEmptyFunction(params, t, imods)
+          if (imods.is(Implicit) || imods.is(Erased)) new FunctionWithMods(params, t, imods)
           else Function(params, t)
         }
       def funArgTypesRest(first: Tree, following: () => Tree) = {
@@ -800,7 +800,7 @@ object Parsers {
         case ARROW => functionRest(t :: Nil)
         case FORSOME => syntaxError(ExistentialTypesNoLongerSupported()); t
         case _ =>
-          if (imods.is(Implicit) && !t.isInstanceOf[NonEmptyFunction])
+          if (imods.is(Implicit) && !t.isInstanceOf[FunctionWithMods])
             syntaxError("Types with implicit keyword can only be function types", Position(start, start + nme.IMPLICITkw.asSimpleName.length))
           t
       }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1722,26 +1722,6 @@ object messages {
     }
   }
 
-  case class FunctionTypeNeedsNonEmptyParameterList(isImplicit: Boolean, isErased: Boolean)(implicit ctx: Context)
-    extends Message(FunctionTypeNeedsNonEmptyParameterListID) {
-    assert(isImplicit || isErased)
-    val kind = "Syntax"
-    val mods = ((isErased, "erased") :: (isImplicit, "implicit") :: Nil).collect { case (true, mod) => mod }.mkString(" ")
-    val msg = mods + " function type needs non-empty parameter list"
-    val explanation = {
-      val code1 = s"type Transactional[T] = $mods Transaction => T"
-      val code2 = "val cl: implicit A => B"
-      hl"""It is not allowed to leave $mods function parameter list empty.
-         |Possible ways to define $mods function type:
-         |
-         |$code1
-         |
-         |or
-         |
-         |$code2""".stripMargin
-    }
-  }
-
   case class WrongNumberOfParameters(expected: Int)(implicit ctx: Context)
     extends Message(WrongNumberOfParametersID) {
     val kind = "Syntax"

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -34,7 +34,7 @@ class ExpandSAMs extends MiniPhase {
     ctx.platform.isSam(cls)
 
   override def transformBlock(tree: Block)(implicit ctx: Context): Tree = tree match {
-    case Block(stats @ (fn: DefDef) :: Nil, cl @ Closure(_, fnRef, tpt)) if fnRef.symbol == fn.symbol =>
+    case Block(stats @ (fn: DefDef) :: Nil, Closure(_, fnRef, tpt)) if fnRef.symbol == fn.symbol =>
       tpt.tpe match {
         case NoType =>
           tree // it's a plain function

--- a/compiler/src/dotty/tools/dotc/transform/ShortcutImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ShortcutImplicits.scala
@@ -73,7 +73,7 @@ class ShortcutImplicits extends MiniPhase with IdentityDenotTransformer { thisPh
     ctx.fresh.updateStore(DirectMeth, newMutableSymbolMap[Symbol])
 
   /** Should `sym` get a ..$direct companion?
-    *  This is the case if (1) `sym` is a method with an implicit function type as final result type.
+    *  This is the case if `sym` is a method with a non-nullary implicit function type as final result type.
     *  However if `specializeMonoTargets` is false, we exclude symbols that are known
     *  to be only targets of monomorphic calls because they are effectively
     *  final and don't override anything.
@@ -81,6 +81,7 @@ class ShortcutImplicits extends MiniPhase with IdentityDenotTransformer { thisPh
   private def shouldBeSpecialized(sym: Symbol)(implicit ctx: Context) =
     sym.is(Method, butNot = Accessor) &&
     defn.isImplicitFunctionType(sym.info.finalResultType) &&
+    defn.functionArity(sym.info.finalResultType) > 0 &&
     !sym.isAnonymousFunction &&
     (specializeMonoTargets || !sym.isEffectivelyFinal || sym.allOverriddenSymbols.nonEmpty)
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -761,13 +761,8 @@ class Typer extends Namer
   def typedFunctionType(tree: untpd.Function, pt: Type)(implicit ctx: Context) = {
     val untpd.Function(args, body) = tree
     val (isImplicit, isErased) = tree match {
-      case tree: untpd.NonEmptyFunction =>
-        if (args.nonEmpty) (tree.mods.is(Implicit), tree.mods.is(Erased))
-        else {
-          ctx.error(FunctionTypeNeedsNonEmptyParameterList(tree.mods.is(Implicit), tree.mods.is(Erased)), tree.pos)
-          (false, false)
-        }
-      case _ => (false, false)
+      case tree: untpd.FunctionWithMods => (tree.mods.is(Implicit), tree.mods.is(Erased))
+     case _ => (false, false)
     }
     val funCls = defn.FunctionClass(args.length, isImplicit, isErased)
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -873,20 +873,6 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       assertEquals(err, WildcardOnTypeArgumentNotAllowedOnNew())
     }
 
-  @Test def implicitFunctionTypeNeedsNonEmptyParameterList =
-    checkMessagesAfter(RefChecks.name) {
-      """abstract class Foo {
-        |  type Contextual[T] = implicit () => T
-        |  val x: implicit () => Int
-        |}""".stripMargin
-    }
-    .expect { (ictx, messages) =>
-      implicit val ctx: Context = ictx
-
-      assertMessageCount(2, messages)
-      messages.foreach(assertEquals(_, FunctionTypeNeedsNonEmptyParameterList(isImplicit = true, isErased = false)))
-    }
-
   @Test def wrongNumberOfParameters =
     checkMessagesAfter(RefChecks.name) {
       """object NumberOfParams {
@@ -1309,48 +1295,6 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val DoubleDeclaration(symbol, previousSymbol) :: Nil = messages
       assertEquals(symbol.name.mangledString, "a")
   }
-
-  @Test def i4127a =
-    checkMessagesAfter(FrontEnd.name) {
-      """
-        |class Foo {
-        |  val x: implicit () => Int = () => 1
-        |}
-      """.stripMargin
-    }.expect { (ictx, messages) =>
-      implicit val ctx: Context = ictx
-      assertMessageCount(1, messages)
-      val (msg @ FunctionTypeNeedsNonEmptyParameterList(_, _)) :: Nil = messages
-      assertEquals(msg.mods, "implicit")
-    }
-
-  @Test def i4127b =
-    checkMessagesAfter(FrontEnd.name) {
-      """
-        |class Foo {
-        |  val x: erased () => Int = () => 1
-        |}
-      """.stripMargin
-    }.expect { (ictx, messages) =>
-      implicit val ctx: Context = ictx
-      assertMessageCount(1, messages)
-      val (msg @ FunctionTypeNeedsNonEmptyParameterList(_, _)) :: Nil = messages
-      assertEquals(msg.mods, "erased")
-    }
-
-  @Test def i4127c =
-    checkMessagesAfter(FrontEnd.name) {
-      """
-        |class Foo {
-        |  val x: erased implicit () => Int = () => 1
-        |}
-      """.stripMargin
-    }.expect { (ictx, messages) =>
-      implicit val ctx: Context = ictx
-      assertMessageCount(1, messages)
-      val (msg @ FunctionTypeNeedsNonEmptyParameterList(_, _)) :: Nil = messages
-      assertEquals(msg.mods, "erased implicit")
-    }
 
   @Test def renameImportTwice =
     checkMessagesAfter(PostTyper.name) {

--- a/tests/neg/i2642.scala
+++ b/tests/neg/i2642.scala
@@ -1,4 +1,10 @@
 object Foo {
-  type X = implicit () => Int // error: implicit function needs parameters
-  def ff: X = () // error: found: Unit, expected: X
+  type X = implicit () => Int // now ok, used to be: implicit function needs parameters
+  def ff: X = () // error: found: Unit, expected: Int
+
+  type Y = erased () => Int // error: empty function may not be erased
+  def gg: Y = () // error: found: Unit, expected: Y
+
+  type Z = erased implicit () => Int // error: empty function may not be erased
+  def hh: Z = () // error: found: Unit, expected: Int
 }

--- a/tests/run/i2642.scala
+++ b/tests/run/i2642.scala
@@ -1,0 +1,7 @@
+// Tests nullary implicit function types
+object Test extends App {
+  class I
+  type X = implicit () => Int
+  def ff: X = 2
+  assert(ff == 2)
+}


### PR DESCRIPTION
This removes an arbitrary restriction and is a first step towards unifying by-name types and implicit function types.

It's been trickier than anticipated since we needed a new mechanism to mark nullary implicit closures. Without parameters we cannot look at the parameter modifiers. Instead we produce an implicit function type as closure target type.