### PR TITLE
Drop unused modifiers

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -112,8 +112,6 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
     case class Protected() extends Mod(Flags.Protected)
 
-    case class Val() extends Mod(Flags.EmptyFlags)
-
     case class Var() extends Mod(Flags.Mutable)
 
     case class Implicit() extends Mod(Flags.ImplicitCommon)
@@ -131,8 +129,6 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     case class Lazy() extends Mod(Flags.Lazy)
 
     case class Inline() extends Mod(Flags.Inline)
-
-    case class Type() extends Mod(Flags.EmptyFlags)
 
     case class Enum() extends Mod(Flags.EmptyFlags)
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1879,15 +1879,18 @@ object Parsers {
           mods =
             atPos(start, in.offset) {
               if (in.token == VAL) {
-                val mod = atPos(in.skipToken()) { Mod.Val() }
-                mods.withAddedMod(mod)
-              } else if (in.token == VAR) {
+                in.nextToken()
+                mods
+              }
+              else if (in.token == VAR) {
                 val mod = atPos(in.skipToken()) { Mod.Var() }
                 addMod(mods, mod)
-              } else {
+              }
+              else {
                 if (!(mods.flags &~ (ParamAccessor | Inline)).isEmpty)
                   syntaxError("`val' or `var' expected")
-                if (firstClauseOfCaseClass) mods else mods | PrivateLocal
+                if (firstClauseOfCaseClass) mods
+                else mods | PrivateLocal
               }
             }
         }
@@ -2038,9 +2041,8 @@ object Parsers {
      */
     def defOrDcl(start: Int, mods: Modifiers): Tree = in.token match {
       case VAL =>
-        val mod = atPos(in.skipToken()) { Mod.Val() }
-        val mods1 = mods.withAddedMod(mod)
-        patDefOrDcl(start, mods1)
+        in.nextToken()
+        patDefOrDcl(start, mods)
       case VAR =>
         val mod = atPos(in.skipToken()) { Mod.Var() }
         val mod1 = addMod(mods, mod)

--- a/compiler/test/dotty/tools/dotc/parsing/ModifiersParsingTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ModifiersParsingTest.scala
@@ -82,16 +82,16 @@ class ModifiersParsingTest {
     assert(source.firstConstrValDef.modifiers == List(Mod.Var()))
 
     source = "class A(val a: Int)"
-    assert(source.firstConstrValDef.modifiers == List(Mod.Val()))
+    assert(source.firstConstrValDef.modifiers == List())
 
     source = "class A(private val a: Int)"
-    assert(source.firstConstrValDef.modifiers == List(Mod.Private(), Mod.Val()))
+    assert(source.firstConstrValDef.modifiers == List(Mod.Private()))
 
     source = "class A(protected var a: Int)"
     assert(source.firstConstrValDef.modifiers == List(Mod.Protected(), Mod.Var()))
 
     source = "class A(protected implicit val a: Int)"
-    assert(source.firstConstrValDef.modifiers == List(Mod.Protected(), Mod.Implicit(), Mod.Val()))
+    assert(source.firstConstrValDef.modifiers == List(Mod.Protected(), Mod.Implicit()))
 
     source = "class A[T]"
     assert(source.firstTypeParam.modifiers == List())
@@ -125,8 +125,8 @@ class ModifiersParsingTest {
       """.stripMargin
 
     assert(source.field("a").modifiers == List(Mod.Lazy(), Mod.Var()))
-    assert(source.field("b").modifiers == List(Mod.Lazy(), Mod.Private(), Mod.Val()))
-    assert(source.field("c").modifiers == List(Mod.Final(), Mod.Val()))
+    assert(source.field("b").modifiers == List(Mod.Lazy(), Mod.Private()))
+    assert(source.field("c").modifiers == List(Mod.Final()))
     assert(source.field("f").modifiers == List(Mod.Abstract(), Mod.Override()))
     assert(source.field("g").modifiers == List(Mod.Inline()))
   }
@@ -146,7 +146,7 @@ class ModifiersParsingTest {
 
   @Test def blockDef = {
     var source: Tree = "implicit val x : A = ???"
-    assert(source.modifiers == List(Mod.Implicit(), Mod.Val()))
+    assert(source.modifiers == List(Mod.Implicit()))
 
     source = "implicit var x : A = ???"
     assert(source.modifiers == List(Mod.Implicit(), Mod.Var()))


### PR DESCRIPTION
Val and Type are not used anywhere; no need to generate them.