### PR TITLE
Closes #4300 adds better worded pattern match unreachability warning

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -130,6 +130,7 @@ public enum ErrorMessageID {
     DoubleDeclarationID,
     MatchCaseOnlyNullWarningID,
     ImportRenamedTwiceID,
+    PatternMatchAlwaysSucceedsID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -130,7 +130,7 @@ public enum ErrorMessageID {
     DoubleDeclarationID,
     MatchCaseOnlyNullWarningID,
     ImportRenamedTwiceID,
-    PatternMatchAlwaysSucceedsID,
+    TypeTestAlwaysSucceedsID,
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2117,38 +2117,10 @@ object messages {
     val explanation: String = ""
   }
 
-  case class PatternMatchAlwaysSucceeds(foundCls: Symbol, testCls: Symbol)(implicit ctx: Context) extends Message(PatternMatchAlwaysSucceedsID) {
+  case class TypeTestAlwaysSucceeds(foundCls: Symbol, testCls: Symbol)(implicit ctx: Context) extends Message(TypeTestAlwaysSucceedsID) {
     val kind = "Syntax"
-    val msg: String =
-      hl"""
-         |The type check in the highlighted part of the pattern match case statement will always succeed,
-         |since `$foundCls` is a subclass of `$testCls`.
-       """
-    val codeExampleValidWarning = "def foo(a: Int) = a match { case x: Int => x }"
-    val codeExampleDisregardWarning =
-      hl"""
-        |object Foo {
-        |  def unapply(x: Int): Option[Int] = if (x % 2 == 0) Some(x) else None
-        |}
-        |
-        |class Test {
-        |  def foo(a: Int) = a match { case Foo(x: Int) => x }
-        |}
-      """
-    val explanation: String =
-      hl"""
-          |The highlighted typecheck will always match.
-          |For example:
-          |
-          |$codeExampleValidWarning
-          |
-          |The type of the scrutinee 'a' will always be 'Int', so a the 'case x: Int'
-          |match will always be successful. Maybe a guard clause was forgotten.
-          |
-          |In the following counter-example, because of the unapply method, the
-          |whole match will not be always successful, only the type check.
-          |$codeExampleDisregardWarning
-          |
-        """
+    val msg =
+      s"The highlighted type test will always succeed since the scrutinee type ($foundCls) is a subtype of ${testCls}"
+    val explanation = ""
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2119,8 +2119,7 @@ object messages {
 
   case class TypeTestAlwaysSucceeds(foundCls: Symbol, testCls: Symbol)(implicit ctx: Context) extends Message(TypeTestAlwaysSucceedsID) {
     val kind = "Syntax"
-    val msg =
-      s"The highlighted type test will always succeed since the scrutinee type ($foundCls) is a subtype of ${testCls}"
+    val msg = s"The highlighted type test will always succeed since the scrutinee type ($foundCls) is a subtype of ${testCls}"
     val explanation = ""
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2117,4 +2117,38 @@ object messages {
     val explanation: String = ""
   }
 
+  case class PatternMatchAlwaysSucceeds(foundCls: Symbol, testCls: Symbol)(implicit ctx: Context) extends Message(PatternMatchAlwaysSucceedsID) {
+    val kind = "Syntax"
+    val msg: String =
+      hl"""
+         |The type check in the highlighted part of the pattern match case statement will always succeed,
+         |since `$foundCls` is a subclass of `$testCls`.
+       """
+    val codeExampleValidWarning = "def foo(a: Int) = a match { case x: Int => x }"
+    val codeExampleDisregardWarning =
+      hl"""
+        |object Foo {
+        |  def unapply(x: Int): Option[Int] = if (x % 2 == 0) Some(x) else None
+        |}
+        |
+        |class Test {
+        |  def foo(a: Int) = a match { case Foo(x: Int) => x }
+        |}
+      """
+    val explanation: String =
+      hl"""
+          |The highlighted typecheck will always match.
+          |For example:
+          |
+          |$codeExampleValidWarning
+          |
+          |The type of the scrutinee 'a' will always be 'Int', so a the 'case x: Int'
+          |match will always be successful. Maybe a guard clause was forgotten.
+          |
+          |In the following counter-example, because of the unapply method, the
+          |whole match will not be always successful, only the type check.
+          |$codeExampleDisregardWarning
+          |
+        """
+  }
 }

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -10,7 +10,7 @@ import ValueClasses._
 import SymUtils._
 import core.Flags._
 import util.Positions._
-import reporting.diagnostic.messages.PatternMatchAlwaysSucceeds
+import reporting.diagnostic.messages.TypeTestAlwaysSucceeds
 import reporting.trace
 
 
@@ -91,12 +91,7 @@ object TypeTestsCasts {
 
           if (expr.tpe <:< testType)
             if (expr.tpe.isNotNull) {
-              if (inMatch)
-                ctx.warning(PatternMatchAlwaysSucceeds(foundCls, testCls), tree.pos)
-              else
-                ctx.warning(
-                  em"this will always yield true, since `$foundCls` is a subclass of `$testCls`",
-                  expr.pos)
+              ctx.warning(TypeTestAlwaysSucceeds(foundCls, testCls), tree.pos)
               constant(expr, Literal(Constant(true)))
             }
             else expr.testNotNull

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -10,6 +10,7 @@ import ValueClasses._
 import SymUtils._
 import core.Flags._
 import util.Positions._
+import reporting.diagnostic.messages.PatternMatchAlwaysSucceeds
 import reporting.trace
 
 
@@ -91,10 +92,7 @@ object TypeTestsCasts {
           if (expr.tpe <:< testType)
             if (expr.tpe.isNotNull) {
               if (inMatch)
-                ctx.warning(
-                  em"the type check in the highlighted part of the pattern match case statement " +
-                    em"will always succeed, since `$foundCls` is a subclass of `$testCls`",
-                  tree.pos)
+                ctx.warning(PatternMatchAlwaysSucceeds(foundCls, testCls), tree.pos)
               else
                 ctx.warning(
                   em"this will always yield true, since `$foundCls` is a subclass of `$testCls`",

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -92,7 +92,8 @@ object TypeTestsCasts {
             if (expr.tpe.isNotNull) {
               if (inMatch)
                 ctx.warning(
-                  em"the highlighted part of the pattern match case statement will always succeed, since `$foundCls` is a subclass of `$testCls`",
+                  em"the type check in the highlighted part of the pattern match case statement " +
+                    em"will always succeed, since `$foundCls` is a subclass of `$testCls`",
                   tree.pos)
               else
                 ctx.warning(

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -92,7 +92,7 @@ object TypeTestsCasts {
             if (expr.tpe.isNotNull) {
               if (inMatch)
                 ctx.warning(
-                  em"this case will always be taken because the scrutinee has type `$testType`",
+                  em"the highlighted part of the pattern match case statement will always succeed, since `$foundCls` is a subclass of `$testCls`",
                   tree.pos)
               else
                 ctx.warning(

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -90,9 +90,14 @@ object TypeTestsCasts {
 
           if (expr.tpe <:< testType)
             if (expr.tpe.isNotNull) {
-              ctx.warning(
-                em"this will always yield true, since `$foundCls` is a subclass of `$testCls`",
-                expr.pos)
+              if (inMatch)
+                ctx.warning(
+                  em"this case will always be taken because the scrutinee has type `$testType`",
+                  tree.pos)
+              else
+                ctx.warning(
+                  em"this will always yield true, since `$foundCls` is a subclass of `$testCls`",
+                  expr.pos)
               constant(expr, Literal(Constant(true)))
             }
             else expr.testNotNull


### PR DESCRIPTION
  - Used when isInstanceOf is called inside a match case
  - The new message is "this case will always be taken because the scrutinee has type `<type>`"
  - Highlights the position of `x: Int` instead of `x`