### PR TITLE
Fix #4542: Enable Dotty LSP on `.scala` files only

### DIFF
--- a/vscode-dotty/src/extension.ts
+++ b/vscode-dotty/src/extension.ts
@@ -89,8 +89,8 @@ function fetchAndRun(artifact: string) {
 function run(serverOptions: ServerOptions) {
   const clientOptions: LanguageClientOptions = {
     documentSelector: [
-      { language: 'scala', scheme: 'file' },
-      { language: 'scala', scheme: 'untitled' }
+      { language: 'scala', scheme: 'file', pattern: '**/*.scala' },
+      { language: 'scala', scheme: 'untitled', pattern: '**/*.scala' }
     ],
     synchronize: {
       configurationSection: 'dotty'


### PR DESCRIPTION
Previously, the Dotty language server would try to provide services for
all `.scala` and `.sbt` files, because both are associated to the Scala
language . The association from filename to language is provided by the
extension `daltonjorge.scala`, which associates all `.scala` and `.sbt`
files to the Scala language.

This commit explicitly states that the Dotty LSP should only be used for
`.scala` files only.

Fixes #4542.