### PR TITLE
Split -print-tasty from -decompile

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -47,7 +47,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val fromTasty = BooleanSetting("-from-tasty", "Compile classes from tasty in classpath. The arguments are used as class names.")
 
   /** Decompiler settings */
-  val printTasty = BooleanSetting("-print-tasty", "Prints the raw tasty when decompiling.")
+  val printTasty = BooleanSetting("-print-tasty", "Prints the raw tasty.")
   val printLines = BooleanSetting("-print-lines", "Show source code line numbers.")
 
   /** Plugin-related setting */

--- a/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
@@ -39,14 +39,12 @@ class DecompilationPrinter extends Phase {
     val pageWidth = ctx.settings.pageWidth.value
     val printLines = ctx.settings.printLines.value
 
-    out.println(s"/** Decompiled from $unit */")
-    val printer = new DecompilerPrinter(ctx)
-    out.println(printer.toText(unit.tpdTree).mkString(pageWidth, printLines))
-
     if (ctx.settings.printTasty.value) {
-      out.println("/*")
       new TastyPrinter(unit.pickled.head._2).printContents()
-      out.println("*/")
+    } else {
+      out.println(s"/** Decompiled from $unit */")
+      val printer = new DecompilerPrinter(ctx)
+      out.println(printer.toText(unit.tpdTree).mkString(pageWidth, printLines))
     }
   }
 }

--- a/dist/bin/dotc
+++ b/dist/bin/dotc
@@ -85,6 +85,7 @@ case "$1" in
         -repl) PROG_NAME="$ReplMain" && shift ;;
      -compile) PROG_NAME="$CompilerMain" && shift ;;
    -decompile) PROG_NAME="$DecompilerMain" && shift ;;
+ -print-tasty) PROG_NAME="$DecompilerMain" && shift ;;
          -run) PROG_NAME="$ReplMain" && shift ;;
       -bootcp) bootcp=true && shift ;;
    -nobootcp) unset bootcp && shift ;;

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -658,18 +658,19 @@ object Build {
     val dottyCompiler = jars("dotty-compiler")
     val args0: List[String] = spaceDelimited("<arg>").parsed.toList
     val decompile = args0.contains("-decompile")
+    val printTasty = args0.contains("-print-tasty")
     val debugFromTasty = args0.contains("-Ythrough-tasty")
     val args = args0.filter(arg => arg != "-repl" && arg != "-decompile" &&
         arg != "-with-compiler" && arg != "-Ythrough-tasty")
 
     val main =
       if (repl) "dotty.tools.repl.Main"
-      else if (decompile) "dotty.tools.dotc.decompiler.Main"
+      else if (decompile || printTasty) "dotty.tools.dotc.decompiler.Main"
       else if (debugFromTasty) "dotty.tools.dotc.fromtasty.Debug"
       else "dotty.tools.dotc.Main"
 
     var extraClasspath = dottyLib
-    if (decompile && !args.contains("-classpath")) extraClasspath += ":."
+    if ((decompile || printTasty) && !args.contains("-classpath")) extraClasspath += ":."
     if (args0.contains("-with-compiler")) extraClasspath += s":$dottyCompiler"
 
     val fullArgs = main :: insertClasspathInArgs(args, extraClasspath)


### PR DESCRIPTION
For a class XYZ, now use:
* `dotc -decompile XYZ` to decompile
* `dotc -print-tasty XYZ` to print the raw contents of the tasty file