### PR TITLE
Fix #4066 `./bin/dotr -language:Scala2` fails

### DIFF
--- a/dist/bin/dotc
+++ b/dist/bin/dotc
@@ -92,8 +92,8 @@ case "$1" in
    -no-colors) unset colors && shift ;;
   -with-compiler) jvm_cp_args="$PSEP$DOTTY_COMP" && shift ;;
 
-          # break out -D and -J options and add them to JAVA_OPTS as well
-          # so they reach the JVM in time to do some good. The -D options
+          # break out -D and -J options and add them to java_args so
+          # they reach the JVM in time to do some good. The -D options
           # will be available as system properties.
           -D*) addJava "$1" && shift ;;
           -J*) addJava "${1:2}" && shift ;;

--- a/dist/bin/dotc
+++ b/dist/bin/dotc
@@ -95,8 +95,8 @@ case "$1" in
           # break out -D and -J options and add them to JAVA_OPTS as well
           # so they reach the JVM in time to do some good. The -D options
           # will be available as system properties.
-          -D*) addJava "$1" && addScala "$1" && shift ;;
-          -J*) addJava "${1:2}" && addScala "$1" && shift ;;
+          -D*) addJava "$1" && shift ;;
+          -J*) addJava "${1:2}" && shift ;;
             *) addResidual "$1" && shift ;;
   esac
 done

--- a/dist/bin/dotr
+++ b/dist/bin/dotr
@@ -31,6 +31,10 @@ addJvmOptions () {
   jvm_options+=("$1")
 }
 
+addRawJvmOptions () {
+  java_options+=("$1")
+}
+
 source "$PROG_HOME/bin/common"
 
 declare -a residual_args
@@ -39,6 +43,11 @@ execute_run=false
 with_compiler=false
 class_path_count=0
 CLASS_PATH=""
+
+# Little hack to check if all arguments are options
+all_params="$*"
+truncated_params="${*#-}"
+not_only_options=$(( ${#all_params} - ${#truncated_params} - $# ))
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -65,7 +74,8 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     -J*)
-      addJvmOptions "-${1:2}"
+      addJvmOptions "${1:2}"
+      addRawJvmOptions "${1}"
       shift ;;
     *)
       residual_args+=("$1")
@@ -74,13 +84,12 @@ while [[ $# -gt 0 ]]; do
 
   esac
 done
-
-if [ $execute_repl == true ] || ([ $execute_run == false ] && [ ${#residual_args[@]} -eq 0 ]); then
+if [ $execute_repl == true ] || ([ $execute_run == false ] && [ $not_only_options == 0 ]); then
   if [ "$CLASS_PATH" ]; then
     cp_arg="-classpath \"$CLASS_PATH\""
   fi
   echo "Starting dotty REPL..."
-  eval "\"$PROG_HOME/bin/dotc\" $cp_arg -repl ${residual_args[@]}"
+  eval "\"$PROG_HOME/bin/dotc\" $cp_arg ${java_options[@]} -repl ${residual_args[@]}"
 elif [ $execute_repl == true ] || [ ${#residual_args[@]} -ne 0 ]; then
   cp_arg="$DOTTY_LIB$PSEP$SCALA_LIB"
   if [ -z "$CLASS_PATH" ]; then

--- a/dist/bin/dotr
+++ b/dist/bin/dotr
@@ -31,7 +31,7 @@ addJvmOptions () {
   jvm_options+=("$1")
 }
 
-addRawJvmOptions () {
+addDotcOptions () {
   java_options+=("$1")
 }
 
@@ -47,7 +47,8 @@ CLASS_PATH=""
 # Little hack to check if all arguments are options
 all_params="$*"
 truncated_params="${*#-}"
-not_only_options=$(( ${#all_params} - ${#truncated_params} - $# ))
+# options_indicator != 0 if at least one parameter is not an option
+options_indicator=$(( ${#all_params} - ${#truncated_params} - $# ))
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -75,7 +76,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     -J*)
       addJvmOptions "${1:2}"
-      addRawJvmOptions "${1}"
+      addDotcOptions "${1}"
       shift ;;
     *)
       residual_args+=("$1")
@@ -84,7 +85,7 @@ while [[ $# -gt 0 ]]; do
 
   esac
 done
-if [ $execute_repl == true ] || ([ $execute_run == false ] && [ $not_only_options == 0 ]); then
+if [ $execute_repl == true ] || ([ $execute_run == false ] && [ $options_indicator == 0 ]); then
   if [ "$CLASS_PATH" ]; then
     cp_arg="-classpath \"$CLASS_PATH\""
   fi


### PR DESCRIPTION
- allow to pass compilation option to ./bin/dotr 
- restore standard notation for java options (using -J-Xmx512m instead of -JXmx512m introduce with https://github.com/lampepfl/dotty/issues/3509)
- allow to pass java options to ./bin/dotr -repl
- allow to pass java options to ./bin/dotc

I was a bit surprise to find dotr and dotc in such bad shape.
The code was and still is a bit fishy but as far as I can see now work in every situation.