### PR TITLE
Constant-fold unary operations in Typer

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -169,8 +169,6 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     }
 
     homogenize(tp) match {
-      case x: ConstantType if homogenizedView =>
-        return toText(x.widen)
       case AppliedType(tycon, args) =>
         val cls = tycon.typeSymbol
         if (tycon.isRepeatedParam) return toTextLocal(args.head) ~ "*"

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -544,6 +544,15 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       // add type to term nodes; replace type nodes with their types unless -Yprint-pos is also set.
       def tp = tree.typeOpt match {
         case tp: TermRef if tree.isInstanceOf[RefTree] && !tp.denot.isOverloaded => tp.underlying
+        case tp: ConstantType if homogenizedView =>
+          // constant folded types are forgotten in Tasty, are reconstituted subsequently in FirstTransform.
+          // Therefore we have to gloss over this when comparing before/after pickling by widening to
+          // underlying type `T`, or, if expression is a unary primitive operation, to `=> T`.
+          tree match {
+            case Select(qual, _) if qual.typeOpt.widen.typeSymbol.isPrimitiveValueClass =>
+              ExprType(tp.widen)
+            case _ => tp.widen
+          }
         case tp => tp
       }
       if (!suppressTypes)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -437,7 +437,7 @@ class Typer extends Namer
       val qual1 = typedExpr(tree.qualifier, selectionProto(tree.name, pt, this))
       if (tree.name.isTypeName) checkStable(qual1.tpe, qual1.pos)
       val select = typedSelect(tree, pt, qual1)
-      if (select.tpe ne TryDynamicCallType) checkStableIdentPattern(select, pt)
+      if (select.tpe ne TryDynamicCallType) ConstFold(checkStableIdentPattern(select, pt))
       else if (pt.isInstanceOf[PolyProto] || pt.isInstanceOf[FunProto] || pt == AssignProto) select
       else typedDynamicSelect(tree, Nil, pt)
     }


### PR DESCRIPTION
This was previously forgotten, even though unary operations such as `!` and `~` were folded later
in FirstTransform. As a consequence, inlining simplifications involving constant expressions
using these operations were not done. This affected in particular the trace macro, which was always
expanded to an operation taking a closure argument.