### PR TITLE
Refactor "method does not take parameter" error message

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1371,27 +1371,25 @@ object messages {
            |"""
   }
 
-  case class MethodDoesNotTakeParameters(tree: tpd.Tree, methPartType: Types.Type)(err: typer.ErrorReporting.Errors)(implicit ctx: Context)
+  case class MethodDoesNotTakeParameters(tree: tpd.Tree)(implicit ctx: Context)
   extends Message(MethodDoesNotTakeParametersId) {
-    private val more = tree match {
-      case Apply(_, _) => " more"
-      case _ => ""
-    }
-
-    val msg = hl"${err.refStr(methPartType)} does not take$more parameters"
-
     val kind = "Reference"
 
-    private val noParameters = if (methPartType.widenSingleton.isInstanceOf[ExprType])
-      hl"""|As ${err.refStr(methPartType)} is defined without parenthesis, you may
-           |not use any at call-site, either.
-           |"""
-    else
-      ""
+    def methodSymbol = tpd.methPart(tree).symbol
 
-    val explanation =
-      s"""|You have specified more parameter lists as defined in the method definition(s).
-          |$noParameters""".stripMargin
+    val msg = {
+      val more = if (tree.isInstanceOf[tpd.Apply]) " more" else ""
+      hl"${methodSymbol.showLocated} does not take$more parameters"
+    }
+
+    val explanation = {
+      val isNullary = methodSymbol.info.isInstanceOf[ExprType]
+      val addendum =
+        if (isNullary) "\nNullary methods may not be called with parenthesis"
+        else ""
+
+      "You have specified more parameter lists as defined in the method definition(s)." + addendum
+    }
 
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2133,7 +2133,7 @@ class Typer extends Namer
           else
             tree
         case _ => tryInsertApplyOrImplicit(tree, pt, locked) {
-          errorTree(tree, MethodDoesNotTakeParameters(tree, methPart(tree).tpe)(err))
+          errorTree(tree, MethodDoesNotTakeParameters(tree))
         }
       }
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -347,10 +347,10 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
 
       assertMessageCount(1, messages)
-      val MethodDoesNotTakeParameters(tree, methodPart) :: Nil = messages
+      val msg @ MethodDoesNotTakeParameters(tree) = messages.head
 
       assertEquals("Scope.foo", tree.show)
-      assertEquals("=> Unit(Scope.foo)", methodPart.show)
+      assertEquals("method foo", msg.methodSymbol.show)
     }
 
   @Test def methodDoesNotTakeMorePrameters =
@@ -366,10 +366,10 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       implicit val ctx: Context = ictx
 
       assertMessageCount(1, messages)
-      val MethodDoesNotTakeParameters(tree, methodPart) :: Nil = messages
+      val msg @ MethodDoesNotTakeParameters(tree) = messages.head
 
       assertEquals("Scope.foo(1)", tree.show)
-      assertEquals("((a: Int): Unit)(Scope.foo)", methodPart.show)
+      assertEquals("method foo", msg.methodSymbol.show)
     }
 
   @Test def ambiugousOverloadWithWildcard =


### PR DESCRIPTION
A change I initially made as part of #4132. I decided to create a separate PR.

I changed the tests not to rely on pretty printing of singleton types and ended up refactoring the error message.