### PR TITLE
Fix #4600: method could be inside block in argument implicit resolution

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2258,7 +2258,7 @@ class Typer extends Namer
 
           // If method has default params, fall back to regular application
           // where all inferred implicits are passed as named args.
-          if (tree.symbol.hasDefaultParams && !propFail.isInstanceOf[AmbiguousImplicits]) {
+          if (methPart(tree).symbol.hasDefaultParams && !propFail.isInstanceOf[AmbiguousImplicits]) {
             val namedArgs = (wtp.paramNames, args).zipped.flatMap { (pname, arg) =>
               if (arg.tpe.isError) Nil else untpd.NamedArg(pname, untpd.TypedSplice(arg)) :: Nil
             }

--- a/tests/run/i4600.scala
+++ b/tests/run/i4600.scala
@@ -1,0 +1,37 @@
+import scala.language.dynamics
+
+class ImplicitExample() extends Dynamic {
+  def someMethod()(implicit s: String = "World"): String = s
+  def applyDynamic(name: String)(args: Any*)(implicit s: String = "World"): String = name + s
+}
+
+class ImplicitTest {
+  def t1() = {
+    new ImplicitExample().someMethod()
+  }
+
+  def t2() = {
+    implicit val s: String = "Hello"
+    new ImplicitExample().someMethod()
+  }
+
+  def t3() = {
+    new ImplicitExample().run()
+  }
+
+  def t4() = {
+    implicit val s: String = "Hello"
+    new ImplicitExample().run()
+  }
+}
+
+
+object Test {
+  def main(args: Array[String]) = {
+    val it = new ImplicitTest
+    assert(it.t1() == "World")
+    assert(it.t2() == "Hello")
+    assert(it.t3() == "runWorld")
+    assert(it.t4() == "runHello")
+  }
+}

--- a/tests/run/i4600b.scala
+++ b/tests/run/i4600b.scala
@@ -1,0 +1,15 @@
+class Foo(val config: String) {
+  case class Bar(val x: Int) {
+    def doThings: String = config //Do whatever here
+  }
+}
+
+
+object Test {
+  def test(foo: Foo)(bar: foo.Bar = foo.Bar(5))(implicit s: String = "ok") = s + foo.config + bar.x
+
+  def main(args: Array[String]) = {
+    val res = test(new Foo("port"))()
+    assert(res == "okport5")
+  }
+}


### PR DESCRIPTION
Fix #4600: method could be inside block in argument implicit resolution

Scalac incorrectly rejects `tests/pos/i4600b.scala`, with this fix Dotty accepts the code.