### PR TITLE
Rename AbstractXYZ to XYZAPI in Tasty reflect

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/TastyImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TastyImpl.scala
@@ -19,11 +19,11 @@ object TastyImpl extends scala.tasty.Tasty {
 
   // ===== Quotes ===================================================
 
-  def QuotedExprDeco[T](x: quoted.Expr[T]): AbstractQuotedExpr = new AbstractQuotedExpr {
+  def QuotedExprDeco[T](x: quoted.Expr[T]): QuotedExprAPI = new QuotedExprAPI {
     def toTasty(implicit ctx: Context): Term = PickledQuotes.quotedExprToTree(x)
   }
 
-  def QuotedTypeDeco[T](x: quoted.Type[T]): AbstractQuotedType = new AbstractQuotedType {
+  def QuotedTypeDeco[T](x: quoted.Type[T]): QuotedTypeAPI = new QuotedTypeAPI {
     def toTasty(implicit ctx: Context): TypeTree = PickledQuotes.quotedTypeToTree(x)
   }
 
@@ -39,7 +39,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type Context = Contexts.Context
 
-  def ContextDeco(ctx: Context): AbstractContext = new AbstractContext {
+  def ContextDeco(ctx: Context): ContextAPI = new ContextAPI {
     def owner: Definition = FromSymbol.definition(ctx.owner)(ctx)
   }
 
@@ -47,7 +47,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type Id = untpd.Ident
 
-  def IdDeco(x: Id): AbstractId = new AbstractId {
+  def IdDeco(x: Id): IdAPI = new IdAPI {
     def pos(implicit ctx: Context): Position = x.pos
   }
 
@@ -64,7 +64,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type Tree = tpd.Tree
 
-  def TreeDeco(tree: Tree): AbstractTree = new AbstractTree {
+  def TreeDeco(tree: Tree): TreeAPI = new TreeAPI {
     def show(implicit ctx: Context, s: Show[TastyImpl.this.type]): String = s.showTree(tree)
     def pos(implicit ctx: Context): Position = tree.pos
   }
@@ -80,7 +80,7 @@ object TastyImpl extends scala.tasty.Tasty {
     }
   }
 
-  def PackageClauseDeco(x: PackageClause): AbstractPackageClause = new AbstractPackageClause {
+  def PackageClauseDeco(x: PackageClause): PackageClauseAPI = new PackageClauseAPI {
     def definition(implicit ctx: Context): Definition = FromSymbol.packageDef(x.symbol)
   }
 
@@ -133,7 +133,7 @@ object TastyImpl extends scala.tasty.Tasty {
       x.isInstanceOf[Trees.MemberDef[_]]
   }
 
-  def DefinitionDeco(x: Definition): AbstractDefinition = new AbstractDefinition {
+  def DefinitionDeco(x: Definition): DefinitionAPI = new DefinitionAPI {
 
     def owner(implicit ctx: Context): Definition = FromSymbol.definition(x.symbol.owner)
 
@@ -214,7 +214,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type PackageDef = PackageDefinition
 
-  def PackageDefDeco(t: PackageDef): AbstractPackageDef = new AbstractPackageDef {
+  def PackageDefDeco(t: PackageDef): PackageDefAPI = new PackageDefAPI {
     def members(implicit ctx: Context): List[Statement] = {
       if (t.symbol.is(core.Flags.JavaDefined)) Nil // FIXME should also support java packages
       else t.symbol.info.decls.iterator.map(FromSymbol.definition).toList
@@ -239,7 +239,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type Term = tpd.Tree
 
-  def TermDeco(tree: Term): AbstractTerm = new AbstractTerm {
+  def TermDeco(tree: Term): TermAPI = new TermAPI {
 
     def pos(implicit ctx: Context): Position = tree.pos
 
@@ -438,7 +438,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   def caseDefClassTag: ClassTag[CaseDef] = implicitly[ClassTag[CaseDef]]
 
-  def CaseDefDeco(caseDef: CaseDef): AbstractCaseDef = new AbstractCaseDef {
+  def CaseDefDeco(caseDef: CaseDef): CaseDefAPI = new CaseDefAPI {
     def show(implicit ctx: Context, s: Show[TastyImpl.this.type]): String = s.showCaseDef(caseDef)
   }
 
@@ -454,7 +454,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type Pattern = tpd.Tree
 
-  def PatternDeco(pattern: Pattern): AbstractPattern = new AbstractPattern {
+  def PatternDeco(pattern: Pattern): PatternAPI = new PatternAPI {
     def show(implicit ctx: Context, s: Show[TastyImpl.this.type]): String = s.showPattern(pattern)
     def pos(implicit ctx: Context): Position = pattern.pos
     def tpe(implicit ctx: Context): Types.Type = pattern.tpe.stripTypeVar
@@ -507,7 +507,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type TypeOrBoundsTree = tpd.Tree
 
-  def TypeOrBoundsTreeDeco(tpt: TypeOrBoundsTree): AbstractTypeOrBoundsTree = new AbstractTypeOrBoundsTree {
+  def TypeOrBoundsTreeDeco(tpt: TypeOrBoundsTree): TypeOrBoundsTreeAPI = new TypeOrBoundsTreeAPI {
     def show(implicit ctx: Context, s: Show[TastyImpl.this.type]): String = s.showTypeOrBoundsTree(tpt)
     def tpe(implicit ctx: Context): Type = tpt.tpe.stripTypeVar
   }
@@ -516,7 +516,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type TypeTree = tpd.Tree
 
-  def TypeTreeDeco(x: TypeTree): AbstractTypeTree = new AbstractTypeTree {
+  def TypeTreeDeco(x: TypeTree): TypeTreeAPI = new TypeTreeAPI {
     def pos(implicit ctx: Context): Position = x.pos
     def tpe(implicit ctx: Context): Types.Type = x.tpe.stripTypeVar
   }
@@ -603,7 +603,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type TypeBoundsTree = tpd.TypeBoundsTree
 
-  def TypeBoundsTreeDeco(x: TypeBoundsTree): AbstractTypeBoundsTree = new AbstractTypeBoundsTree {
+  def TypeBoundsTreeDeco(x: TypeBoundsTree): TypeBoundsTreeAPI = new TypeBoundsTreeAPI {
     def tpe(implicit ctx: Context): TypeBounds = x.tpe.bounds
   }
 
@@ -620,7 +620,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type TypeOrBounds = Types.Type
 
-  def TypeOrBoundsDeco(tpe: Types.Type): AbstractTypeOrBounds = new AbstractTypeOrBounds {
+  def TypeOrBoundsDeco(tpe: Types.Type): TypeOrBoundsAPI = new TypeOrBoundsAPI {
     def show(implicit ctx: Context, s: Show[TastyImpl.this.type]): String = s.showTypeOrBounds(tpe)
   }
 
@@ -639,7 +639,7 @@ object TastyImpl extends scala.tasty.Tasty {
   def polyTypeClassTag: ClassTag[PolyType] = implicitly[ClassTag[PolyType]]
   def typeLambdaClassTag: ClassTag[TypeLambda] = implicitly[ClassTag[TypeLambda]]
 
-  def MethodTypeDeco(x: MethodType): AbstractMethodType = new AbstractMethodType {
+  def MethodTypeDeco(x: MethodType): MethodTypeAPI = new MethodTypeAPI {
     def isErased: Boolean = x.isErasedMethod
     def isImplicit: Boolean = x.isImplicitMethod
   }
@@ -821,7 +821,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type Constant = Constants.Constant
 
-  def ConstantDeco(const: Constant): AbstractConstant = new AbstractConstant {
+  def ConstantDeco(const: Constant): ConstantAPI = new ConstantAPI {
     def show(implicit ctx: Context, s: Show[TastyImpl.this.type]): String = s.showConstant(const)
     def value: Any = const.value
   }
@@ -970,7 +970,7 @@ object TastyImpl extends scala.tasty.Tasty {
 
   type Position = SourcePosition
 
-  def PositionDeco(pos: Position): AbstractPosition = new AbstractPosition {
+  def PositionDeco(pos: Position): PositionAPI = new PositionAPI {
     def start = pos.start
     def end = pos.end
 

--- a/library/src/scala/tasty/Tasty.scala
+++ b/library/src/scala/tasty/Tasty.scala
@@ -7,15 +7,15 @@ abstract class Tasty { tasty =>
 
   // ===== Quotes ===================================================
 
-  trait AbstractQuotedExpr {
+  trait QuotedExprAPI {
     def toTasty(implicit ctx: Context): Term
   }
-  implicit def QuotedExprDeco[T](x: quoted.Expr[T]): AbstractQuotedExpr
+  implicit def QuotedExprDeco[T](x: quoted.Expr[T]): QuotedExprAPI
 
-  trait AbstractQuotedType {
+  trait QuotedTypeAPI {
     def toTasty(implicit ctx: Context): TypeTree
   }
-  implicit def QuotedTypeDeco[T](x: quoted.Type[T]): AbstractQuotedType
+  implicit def QuotedTypeDeco[T](x: quoted.Type[T]): QuotedTypeAPI
 
   // ===== Show =====================================================
 
@@ -29,17 +29,17 @@ abstract class Tasty { tasty =>
 
   type Context
 
-  trait AbstractContext {
+  trait ContextAPI {
     def owner: Definition
   }
-  implicit def ContextDeco(ctx: Context): AbstractContext
+  implicit def ContextDeco(ctx: Context): ContextAPI
 
   // ===== Id =======================================================
 
   type Id
 
-  trait AbstractId extends Positioned
-  implicit def IdDeco(x: Id): AbstractId
+  trait IdAPI extends Positioned
+  implicit def IdDeco(x: Id): IdAPI
 
   implicit def idClassTag: ClassTag[Id]
 
@@ -52,10 +52,10 @@ abstract class Tasty { tasty =>
 
   type Tree
 
-  trait AbstractTree extends Positioned {
+  trait TreeAPI extends Positioned {
     def show(implicit ctx: Context, s: Show[tasty.type]): String
   }
-  implicit def TreeDeco(tree: Tree): AbstractTree
+  implicit def TreeDeco(tree: Tree): TreeAPI
 
   type PackageClause <: Tree
 
@@ -66,10 +66,10 @@ abstract class Tasty { tasty =>
     def unapply(x: PackageClause)(implicit ctx: Context): Option[(Term, List[Tree])]
   }
 
-  trait AbstractPackageClause {
+  trait PackageClauseAPI {
     def definition(implicit ctx: Context): Definition
   }
-  implicit def PackageClauseDeco(x: PackageClause): AbstractPackageClause
+  implicit def PackageClauseDeco(x: PackageClause): PackageClauseAPI
 
   // ----- Statements -----------------------------------------------
 
@@ -114,13 +114,13 @@ abstract class Tasty { tasty =>
 
   implicit def definitionClassTag: ClassTag[Definition]
 
-  trait AbstractDefinition {
+  trait DefinitionAPI {
     def flags(implicit ctx: Context): FlagSet
     def mods(implicit ctx: Context): List[Modifier]
     def owner(implicit ctx: Context): Definition
     def localContext(implicit ctx: Context): Context
   }
-  implicit def DefinitionDeco(x: Definition): AbstractDefinition
+  implicit def DefinitionDeco(x: Definition): DefinitionAPI
 
   // ClassDef
 
@@ -170,10 +170,10 @@ abstract class Tasty { tasty =>
 
   type PackageDef <: Definition
 
-  trait AbstractPackageDef {
+  trait PackageDefAPI {
     def members(implicit ctx: Context): List[Statement]
   }
-  implicit def PackageDefDeco(t: PackageDef): AbstractPackageDef
+  implicit def PackageDefDeco(t: PackageDef): PackageDefAPI
 
   implicit def packageDefClassTag: ClassTag[PackageDef]
 
@@ -190,10 +190,10 @@ abstract class Tasty { tasty =>
 
   type Term <: Statement with Parent
 
-  trait AbstractTerm extends Typed with Positioned {
+  trait TermAPI extends Typed with Positioned {
     def toExpr[T: quoted.Type](implicit ctx: Context): quoted.Expr[T]
   }
-  implicit def TermDeco(t: Term): AbstractTerm
+  implicit def TermDeco(t: Term): TermAPI
 
   implicit def termClassTag: ClassTag[Term]
 
@@ -310,10 +310,10 @@ abstract class Tasty { tasty =>
 
   implicit def caseDefClassTag: ClassTag[CaseDef]
 
-  trait AbstractCaseDef {
+  trait CaseDefAPI {
     def show(implicit ctx: Context, s: Show[tasty.type]): String
   }
-  implicit def CaseDefDeco(caseDef: CaseDef): AbstractCaseDef
+  implicit def CaseDefDeco(caseDef: CaseDef): CaseDefAPI
 
   val CaseDef: CaseDefExtractor
   abstract class CaseDefExtractor {
@@ -324,10 +324,10 @@ abstract class Tasty { tasty =>
 
   type Pattern
 
-  trait AbstractPattern extends Typed with Positioned {
+  trait PatternAPI extends Typed with Positioned {
     def show(implicit ctx: Context, s: Show[tasty.type]): String
   }
-  implicit def PatternDeco(x: Pattern): AbstractPattern
+  implicit def PatternDeco(x: Pattern): PatternAPI
 
   implicit def patternClassTag: ClassTag[Pattern]
 
@@ -365,19 +365,19 @@ abstract class Tasty { tasty =>
 
   type TypeOrBoundsTree
 
-  trait AbstractTypeOrBoundsTree {
+  trait TypeOrBoundsTreeAPI {
     def show(implicit ctx: Context, s: Show[tasty.type]): String
     def tpe(implicit ctx: Context): TypeOrBounds
   }
-  implicit def TypeOrBoundsTreeDeco(tpt: TypeOrBoundsTree): AbstractTypeOrBoundsTree
+  implicit def TypeOrBoundsTreeDeco(tpt: TypeOrBoundsTree): TypeOrBoundsTreeAPI
 
 
   // ----- TypeTrees ------------------------------------------------
 
   type TypeTree <: TypeOrBoundsTree with Parent
 
-  trait AbstractTypeTree extends Typed with Positioned
-  implicit def TypeTreeDeco(x: TypeTree): AbstractTypeTree
+  trait TypeTreeAPI extends Typed with Positioned
+  implicit def TypeTreeDeco(x: TypeTree): TypeTreeAPI
 
   implicit def typeTreeClassTag: ClassTag[TypeTree]
 
@@ -442,10 +442,10 @@ abstract class Tasty { tasty =>
 
   type TypeBoundsTree <: TypeOrBoundsTree
 
-  trait AbstractTypeBoundsTree {
+  trait TypeBoundsTreeAPI {
     def tpe(implicit ctx: Context): TypeBounds
   }
-  implicit def TypeBoundsTreeDeco(x: TypeBoundsTree): AbstractTypeBoundsTree
+  implicit def TypeBoundsTreeDeco(x: TypeBoundsTree): TypeBoundsTreeAPI
 
   implicit def typeBoundsTreeClassTag: ClassTag[TypeBoundsTree]
 
@@ -462,10 +462,10 @@ abstract class Tasty { tasty =>
     def tpe(implicit ctx: Context): Type
   }
 
-  trait AbstractTypeOrBounds {
+  trait TypeOrBoundsAPI {
     def show(implicit ctx: Context, s: Show[tasty.type]): String
   }
-  implicit def TypeOrBoundsDeco(tpe: TypeOrBounds): AbstractTypeOrBounds
+  implicit def TypeOrBoundsDeco(tpe: TypeOrBounds): TypeOrBoundsAPI
 
   // ----- Types ----------------------------------------------------
 
@@ -484,11 +484,11 @@ abstract class Tasty { tasty =>
   implicit def typeLambdaClassTag: ClassTag[TypeLambda]
   implicit def recursiveTypeClassTag: ClassTag[RecursiveType]
 
-  trait AbstractMethodType {
+  trait MethodTypeAPI {
     def isImplicit: Boolean
     def isErased: Boolean
   }
-  implicit def MethodTypeDeco(x: MethodType): AbstractMethodType
+  implicit def MethodTypeDeco(x: MethodType): MethodTypeAPI
 
   val Type: TypeModule
   abstract class TypeModule {
@@ -612,11 +612,11 @@ abstract class Tasty { tasty =>
   // ===== Constants ================================================
 
   type Constant
-  trait AbstractConstant {
+  trait ConstantAPI {
     def show(implicit ctx: Context, s: Show[tasty.type]): String
     def value: Any
   }
-  implicit def ConstantDeco(const: Constant): AbstractConstant
+  implicit def ConstantDeco(const: Constant): ConstantAPI
 
   implicit def constantClassTag: ClassTag[Constant]
 
@@ -727,7 +727,7 @@ abstract class Tasty { tasty =>
 
   type Position
 
-  trait AbstractPosition {
+  trait PositionAPI {
     def start: Int
     def end: Int
 
@@ -738,7 +738,7 @@ abstract class Tasty { tasty =>
     def endLine: Int
     def endColumn: Int
   }
-  implicit def PositionDeco(pos: Position): AbstractPosition
+  implicit def PositionDeco(pos: Position): PositionAPI
 
   trait Positioned {
     def pos(implicit ctx: Context): Position

--- a/tests/pos/tasty/definitions.scala
+++ b/tests/pos/tasty/definitions.scala
@@ -271,31 +271,31 @@ object definitions {
 abstract class Tasty {
 
   type Type
-  trait AbstractType {
+  trait TypeAPI {
     // exported type fields
   }
-  implicit def TypeDeco(x: Type): AbstractType
+  implicit def TypeDeco(x: Type): TypeAPI
 
   type Symbol
-  trait AbstractSymbol {
+  trait SymbolAPI {
     // exported symbol fields
   }
-  implicit def SymbolDeco(s: Symbol): AbstractSymbol
+  implicit def SymbolDeco(s: Symbol): SymbolAPI
 
   type Context
-  trait AbstractContext {
+  trait ContextAPI {
     val owner: Symbol
     // more exported fields
   }
-  implicit def ContextDeco(x: Context): AbstractContext
+  implicit def ContextDeco(x: Context): ContextAPI
 
   type Position
-  trait AbstractPosition {
+  trait PositionAPI {
     val start: Int
     val end: Int
     // more fields
   }
-  implicit def PositionDeco(p: Position): AbstractPosition
+  implicit def PositionDeco(p: Position): PositionAPI
 
   trait TypedPositioned {
     val pos: Position
@@ -328,18 +328,18 @@ object TastyImpl extends Tasty {
   import util.{Positions}
 
   type Type = Types.Type
-  implicit class TypeDeco(x: Type) extends AbstractType {}
+  implicit class TypeDeco(x: Type) extends TypeAPI {}
 
   type Symbol = Symbols.Symbol
-  implicit class SymbolDeco(s: Symbol) extends AbstractSymbol {}
+  implicit class SymbolDeco(s: Symbol) extends SymbolAPI {}
 
   type Context = Contexts.Context
-  implicit class ContextDeco(c: Context) extends AbstractContext {
+  implicit class ContextDeco(c: Context) extends ContextAPI {
     val owner = c.owner
   }
 
   type Position = Positions.Position
-  implicit class PositionDeco(p: Position) extends AbstractPosition {
+  implicit class PositionDeco(p: Position) extends PositionAPI {
     val start = p.start
     val end = p.end
   }
@@ -382,8 +382,8 @@ object TastyImpl extends Tasty {
 */
 
 
-/* If the dotty implementations all inherit the ...Abstract traits,
-   and the Abstract traits inherit thmeselves from ProductN, we can
+/* If the dotty implementations all inherit the ...API traits,
+   and the API traits inherit thmeselves from ProductN, we can
    also do the following, faster implementation.
    This still does full information hiding, but should be almost
    as fast as native access.
@@ -419,7 +419,7 @@ object TastyImpl extends TastyAST {
   object CaseDef extends CaseDefExtractor {
     def apply(pat: Pattern, guard: Term, rhs: Term)(implicit ctx: Context): CaseDef =
       tpd.CaseDef(pat, guard, rhs)
-    def unapply(x: CaseDef): AbstractCaseDef = x
+    def unapply(x: CaseDef): CaseDefAPI = x
   }
 }
 


### PR DESCRIPTION
Those classes define all methods on XYZ, hence the name change.
It is also the same naming convention used in scala reflect.