### PR TITLE
Improve Tasty reflect modifiers api

### DIFF
--- a/library/src/scala/tasty/Tasty.scala
+++ b/library/src/scala/tasty/Tasty.scala
@@ -116,7 +116,9 @@ abstract class Tasty { tasty =>
 
   trait AbstractDefinition {
     def flags(implicit ctx: Context): FlagSet
-    def mods(implicit ctx: Context): List[Modifier]
+    def privateWithin(implicit ctx: Context): Option[Type]
+    def protectedWithin(implicit ctx: Context): Option[Type]
+    def annots(implicit ctx: Context): List[Term]
     def owner(implicit ctx: Context): Definition
     def localContext(implicit ctx: Context): Context
   }
@@ -679,38 +681,6 @@ abstract class Tasty { tasty =>
     }
 
   }
-
-  // ===== Modifiers ================================================
-
-  type Modifier
-
-  implicit def modifierClassTag: ClassTag[Modifier]
-
-  val Modifier: ModifierModule
-  abstract class ModifierModule {
-
-    val Annotation: AnnotationExtractor
-    abstract class AnnotationExtractor {
-      def unapply(x: Modifier)(implicit ctx: Context): Option[Term]
-    }
-
-    val Flags: FlagsExtractor
-    abstract class FlagsExtractor {
-      def unapply(x: Modifier)(implicit ctx: Context): Option[FlagSet]
-    }
-
-    val QualifiedPrivate: QualifiedPrivateExtractor
-    abstract class QualifiedPrivateExtractor {
-      def unapply(x: Modifier)(implicit ctx: Context): Option[Type]
-    }
-
-    val QualifiedProtected: QualifiedProtectedExtractor
-    abstract class QualifiedProtectedExtractor {
-      def unapply(x: Modifier)(implicit ctx: Context): Option[Type]
-    }
-
-  }
-
 
   // ===== Signature ================================================
 

--- a/library/src/scala/tasty/util/ShowExtractors.scala
+++ b/library/src/scala/tasty/util/ShowExtractors.scala
@@ -195,13 +195,6 @@ class ShowExtractors[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
         this += "NoPrefix()"
     }
 
-    def visitModifier(x: Modifier): Buffer = x match {
-      case Modifier.Flags(flags) => this += "Modifier.Flags(" += flags.toString += ")"
-      case Modifier.QualifiedPrivate(tp) => this += "Modifier.QualifiedPrivate(" += tp += ")"
-      case Modifier.QualifiedProtected(tp) => this += "Modifier.QualifiedProtected(" += tp += ")"
-      case Modifier.Annotation(tree) => this += "Modifier.Annotation(" += tree += ")"
-    }
-
     def visitId(x: Id): Buffer = {
       val Id(name) = x
       this += "Id(\"" += name += "\")"

--- a/tests/pos/tasty/definitions.scala
+++ b/tests/pos/tasty/definitions.scala
@@ -30,18 +30,30 @@ object definitions {
 
   // Does DefDef need a `def tpe: MethodType | PolyType`?
   case class ValDef(name: String, tpt: TypeTree, rhs: Option[Term]) extends Definition {
-    def mods: List[Modifier] = ???
+    def flags: FlagSet = ???
+    def privateWithin: Option[Type] = ???
+    def protectedWithin: Option[Type] = ???
+    def annots: List[Term] = ???
   }
   case class DefDef(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]],
                     returnTpt: TypeTree, rhs: Option[Term]) extends Definition {
-    def mods: List[Modifier] = ???
+    def flags: FlagSet = ???
+    def privateWithin: Option[Type] = ???
+    def protectedWithin: Option[Type] = ???
+    def annots: List[Term] = ???
   }
   case class TypeDef(name: String, rhs: TypeTree | TypeBoundsTree) extends Definition {
-    def mods: List[Modifier] = ???
+    def flags: FlagSet = ???
+    def privateWithin: Option[Type] = ???
+    def protectedWithin: Option[Type] = ???
+    def annots: List[Term] = ???
   }
   case class ClassDef(name: String, constructor: DefDef, parents: List[Term | TypeTree],
                       self: Option[ValDef], body: List[Statement]) extends Definition {
-    def mods: List[Modifier] = ???
+    def flags: FlagSet = ???
+    def privateWithin: Option[Type] = ???
+    def protectedWithin: Option[Type] = ???
+    def annots: List[Term] = ???
   }
   case class PackageDef(name: String, override val owner: PackageDef) extends Definition {
     def members: List[Statement] = ???


### PR DESCRIPTION
Previously it was awkward and hard to use. Replaced `def mods: List[Modifiers]` by `def privateWithin : Option[Type]`, `def protectedWithin : Option[Type]` and `def annots: List[Term]`; and `def flags: FlagSet` which was already implemented for the same reason. 