### PR TITLE
Fix #4590: Reintroduce old inline accessor scheme as a fallback

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -291,6 +291,7 @@ object NameKinds {
   val LiftedTreeName          = new UniqueNameKind("liftedTree")
   val SuperArgName            = new UniqueNameKind("$superArg$")
   val DocArtifactName         = new UniqueNameKind("$doc")
+  val UniqueInlineName        = new UniqueNameKind("$i")
 
   /** A kind of unique extension methods; Unlike other unique names, these can be
    *  unmangled.

--- a/tests/pos/i4590.scala
+++ b/tests/pos/i4590.scala
@@ -1,0 +1,19 @@
+package test
+
+class ArrayDeque {
+  inline def isResizeNecessary(len: Int) = len > ArrayDeque.StableSize
+}
+
+object ArrayDeque {
+  private val StableSize = 256
+}
+
+class List {
+  inline def foo(x: List.Cons): Unit = {
+    x.next = this
+  }
+}
+object List {
+  case class Cons(head: Int, private[List] var next: List)
+}
+

--- a/tests/run/inline.check
+++ b/tests/run/inline.check
@@ -7,3 +7,5 @@ Outer.f Inner
  Inner
 Outer.f
 Outer.f Inner
+(hi,1)
+(true,)

--- a/tests/run/inline/Test_2.scala
+++ b/tests/run/inline/Test_2.scala
@@ -10,12 +10,14 @@ object Test {
 
     val o = new Outer
     val i = new o.Inner
+    val p = new TestPassing
     println(i.m)
     println(i.g)
     println(i.h)
     println(o.inner.m)
     println(o.inner.g)
     println(o.inner.h)
+    println(p.foo("hi"))
+    println(p.bar(true))
   }
-
 }

--- a/tests/run/inline/inlines_1.scala
+++ b/tests/run/inline/inlines_1.scala
@@ -38,4 +38,22 @@ object inlines {
     }
     val inner = new Inner
   }
+
+  class C[T](private[inlines] val x: T) {
+    private[inlines] def next[U](y: U): (T, U) = (xx, y)
+    private[inlines] var xx: T =  _
+  }
+
+  class TestPassing {
+    inline def foo[A](x: A): (A, Int) = {
+      val c = new C[A](x)
+      c.xx = c.x
+      c.next(1)
+    }
+    inline def bar[A](x: A): (A, String) = {
+      val c = new C[A](x)
+      c.xx = c.x
+      c.next("")
+    }
+  }
 }


### PR DESCRIPTION
Turns out things are not so simple. Some inline accessors cannot be handled
in the same way as protected accessors because we cannot always place an accessor
method next to the accessed symbol.

We solve this by using an adapted version of the old inline accessor scheme as a fallback.