### PR TITLE
Harden IDE

### DIFF
--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -328,7 +328,9 @@ class DottyLanguageServer extends LanguageServer
     if (sym == NoSymbol) Nil.asJava
     else {
       val refs = Interactive.namedTrees(uriTrees, Include.references | Include.overriding, sym)
-      refs.map(ref => new DocumentHighlight(range(ref.namePos), DocumentHighlightKind.Read)).asJava
+      ( for (ref <- refs if ref.namePos.exists)
+        yield new DocumentHighlight(range(ref.namePos), DocumentHighlightKind.Read)
+      ).asJava
     }
   }
 


### PR DESCRIPTION
I observed crashes when trying to compute the docstring of trees that did not have a position.
It happened for edited code with lots of syntax errors.