### PR TITLE
Fix #4430: Disallow access to Java bridge methods before erasure

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -160,7 +160,7 @@ object Config {
   final val showCompletions = false
 
   /** If set, enables tracing */
-  final val tracingEnabled = false
+  final val tracingEnabled = true
 
   /** Initial capacity of uniques HashMap.
    *  Note: This MUST BE a power of two to work with util.HashSet

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -160,7 +160,7 @@ object Config {
   final val showCompletions = false
 
   /** If set, enables tracing */
-  final val tracingEnabled = true
+  final val tracingEnabled = false
 
   /** Initial capacity of uniques HashMap.
    *  Note: This MUST BE a power of two to work with util.HashSet

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -488,6 +488,7 @@ object Denotations {
               (!sym2.isAsConcrete(sym1) ||
                 precedes(sym1.owner, sym2.owner) ||
                 accessBoundary(sym2).isProperlyContainedIn(accessBoundary(sym1)) ||
+                sym2.is(Bridge) && !sym1.is(Bridge) ||
                 sym1.is(Method) && !sym2.is(Method)) ||
               sym1.info.isErroneous)
 

--- a/tests/pickling/i4430.scala
+++ b/tests/pickling/i4430.scala
@@ -1,0 +1,7 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val sb = new java.lang.StringBuilder()
+    sb.append(Array[Char](), 0, 0)
+    sb.length
+  }
+}

--- a/tests/run/i4430.scala
+++ b/tests/run/i4430.scala
@@ -1,0 +1,7 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val sb = new java.lang.StringBuilder()
+    sb.append(Array[Char](), 0, 0)
+    sb.length
+  }
+}


### PR DESCRIPTION

Scala bridge methods only come to existence during erasure, so are not visible
before. But Java bridge methods come with their class files. It first I thought
we should get parity, so have to ignore Java bridge methods before erasure. But
that did not work, because unlike for Scala, some Java bridges are generated
to allow access to inherited methods. The situation can be described using
StringBuilder. It inherits a class AbstractStringBuilder which is not accessible
from Scala. Here's a minimized version highlighting the problem:

    private class AbstractStringBuilder {
      def length: Int = ...
      def append(xs: Array[Char]): AbstractStringBuilder = ...
    }
    class StringBuilder extends AbstractStringBuilder {
      override def append(xs: Array[Char]): StringBuilder = ...
      <bridge> def length: Int = super.length
      <bridge> def append(xs: Array[Char]): AbstractStringBuilder = this.append(xs)
    }

User code

    val sb = new StringBuilder
    sb.length      // needs to access bridge in StringBuilder
    sb.append(arr) // should not access bridge in StringBuilder

In the first case, `sb.length` needs to access the bridge method, as
the inherited method is inaccssible. So we cannot simply hide bridge
methods before erasure, as we do for Scala bridges. But in the second
case, we should not access the bridge append, because it refers to an
inaccessible class in its result type.

The fix is simple, but it took me a long time to find it: When merging denotations
with the same signature (which is the case for the two appends, since results are
ignored), always prefer a non-bridge over a bridge as the symbol of a JointRefDenotation.