### PR TITLE
Fix #4623: Don't check for repeated parents in refinement classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1491,7 +1491,8 @@ class Typer extends Namer
     def typedParent(tree: untpd.Tree): Tree = {
       var result = if (tree.isType) typedType(tree)(superCtx) else typedExpr(tree)(superCtx)
       val psym = result.tpe.typeSymbol
-      if (seenParents.contains(psym)) ctx.error(i"$psym is extended twice", tree.pos)
+      if (seenParents.contains(psym) && !cls.isRefinementClass)
+        ctx.error(i"$psym is extended twice", tree.pos)
       seenParents += psym
       if (tree.isType) {
         if (psym.is(Trait) && !cls.is(Trait) && !cls.superClass.isSubClass(psym))

--- a/tests/pos/i4623.scala
+++ b/tests/pos/i4623.scala
@@ -1,0 +1,7 @@
+trait Test {
+  type A <: Any { type T }
+  type B <: Any { type T }
+  type C <: A with B { type T }
+
+  type D <: List[A] with List[B] { type T }
+}


### PR DESCRIPTION
Refinement classes are just a temporary detour to get refinements. The restriction
that the same parent cannot be extended twice does not hold for them.