### PR TITLE
Some polishings to annotation handling

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -858,11 +858,11 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
      *
      *  works differently for type trees and term trees
      */
-    def annotated(annot: Tree)(implicit ctx: Context): Tree =
+    def annotated(annot: Annotation)(implicit ctx: Context): Tree =
       if (tree.isTerm)
-        Typed(tree, TypeTree(AnnotatedType(tree.tpe.widenIfUnstable, Annotation(annot))))
+        Typed(tree, TypeTree(AnnotatedType(tree.tpe.widenIfUnstable, annot)))
       else
-        Annotated(tree, annot)
+        Annotated(tree, annot.tree)
 
     /** A synthetic select with that will be turned into an outer path by ExplicitOuter.
      *  @param levels  How many outer levels to select

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -790,6 +790,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       else "some " ~ toText(denot.info)
   }
 
+  override def toText(annot: Annotation): Text = annotText(annot.tree)
+
   override def plain = new PlainPrinter(_ctx)
 
   private def withPos(txt: Text, pos: SourcePosition): Text = {

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -8,6 +8,7 @@ import MegaPhase._
 import SymUtils._
 import ast.untpd
 import ast.Trees._
+import Annotations._
 import dotty.tools.dotc.reporting.diagnostic.messages.TypeMismatch
 import dotty.tools.dotc.util.Positions.Position
 
@@ -88,7 +89,7 @@ class ExpandSAMs extends MiniPhase {
               Bind(defaultSym, Underscore(selectorTpe)),
               EmptyTree,
               defaultValue)
-          val unchecked = selector.annotated(New(ref(defn.UncheckedAnnotType)))
+          val unchecked = selector.annotated(Annotation(defn.UncheckedAnnot))
           cpy.Match(tree)(unchecked, cases :+ defaultCase)
             .subst(param.symbol :: Nil, pfParam :: Nil)
               // Needed because  a partial function can be written as:


### PR DESCRIPTION
 1. Some streamlining of `annotated`.
 2. Annotations now print their full trees.