### PR TITLE
Fix position of Inline#expansion

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -280,7 +280,14 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def Try(expr: Tree, cases: List[CaseDef], finalizer: Tree): Try = new Try(expr, cases, finalizer)
   def SeqLiteral(elems: List[Tree], elemtpt: Tree): SeqLiteral = new SeqLiteral(elems, elemtpt)
   def JavaSeqLiteral(elems: List[Tree], elemtpt: Tree): JavaSeqLiteral = new JavaSeqLiteral(elems, elemtpt)
-  def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree): Inlined = new Inlined(call, bindings, expansion)
+  def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree): Inlined = {
+    val tree = new Inlined(call, bindings, expansion)
+    // `expansion.pos` is a position inside the file in which the inline method
+    // is defined (see `TreeCopier#inlineContext` and `Decorators#sourcePos`),
+    // so it must not be taken into account when setting a position for the
+    // Inlined tree.
+    tree.withPos(call.pos)
+  }
   def TypeTree() = new TypeTree()
   def SingletonTypeTree(ref: Tree): SingletonTypeTree = new SingletonTypeTree(ref)
   def AndTypeTree(left: Tree, right: Tree): AndTypeTree = new AndTypeTree(left, right)

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -495,7 +495,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
     // the owner from the inlined method to the current owner.
     val inliner = new TreeTypeMap(typeMap, treeMap, meth :: Nil, ctx.owner :: Nil)(inlineCtx)
 
-    val expansion = inliner(rhsToInline.withPos(call.pos))
+    val expansion = inliner(rhsToInline)
     trace(i"inlining $call\n, BINDINGS =\n${bindingsBuf.toList}%\n%\nEXPANSION =\n$expansion", inlining, show = true) {
 
       // The final expansion runs a typing pass over the inlined tree. See InlineTyper for details.


### PR DESCRIPTION
Using `call.pos` here is very wrong since the positions of nodes insides
Inline#expansion should be positions inside the file in which the inline
method is defined, but `call.pos` is a position inside the file where
the inline method is called. See `TreeCopier#inlineContext`.