### PR TITLE
Add `:doc` command in REPL to show documentation

### DIFF
--- a/compiler/src/dotty/tools/repl/ParseResult.scala
+++ b/compiler/src/dotty/tools/repl/ParseResult.scala
@@ -60,6 +60,15 @@ object TypeOf {
   val command = ":type"
 }
 
+/**
+ * A command that is used to display the documentation associated with
+ * the given expression.
+ */
+case class DocOf(expr: String) extends Command
+object DocOf {
+  val command = ":doc"
+}
+
 /** `:imports` lists the imports that have been explicitly imported during the
  *  session
  */
@@ -89,6 +98,7 @@ case object Help extends Command {
       |:load <path>             interpret lines in a file
       |:quit                    exit the interpreter
       |:type <expression>       evaluate the type of the given expression
+      |:doc <expression>        print the documentation for the given expresssion
       |:imports                 show import history
       |:reset                   reset the repl to its initial state, forgetting all session entries
     """.stripMargin
@@ -117,6 +127,7 @@ object ParseResult {
         case Imports.command => Imports
         case Load.command => Load(arg)
         case TypeOf.command => TypeOf(arg)
+        case DocOf.command => DocOf(arg)
         case _ => UnknownCommand(cmd)
       }
       case _ =>

--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -194,20 +194,17 @@ class ReplCompiler(val directory: AbstractFile) extends Compiler {
     }
 
     typeCheck(expr).map {
-      case v @ ValDef(_, _, Block(stats, _)) if stats.nonEmpty =>
+      case ValDef(_, _, Block(stats, _)) if stats.nonEmpty =>
         val stat = stats.last.asInstanceOf[tpd.Tree]
         if (stat.tpe.isError) stat.tpe.show
         else {
-          val doc =
-            ctx.docCtx.flatMap { docCtx =>
-              val symbols = extractSymbols(stat)
-              symbols.collectFirst {
-                case sym if docCtx.docstrings.contains(sym) =>
-                  docCtx.docstrings(sym).raw
-              }
-            }
-
-            doc.getOrElse(s"// No doc for `${expr}`")
+          val docCtx = ctx.docCtx.get
+          val symbols = extractSymbols(stat)
+          val doc = symbols.collectFirst {
+            case sym if docCtx.docstrings.contains(sym) =>
+              docCtx.docstrings(sym).raw
+          }
+          doc.getOrElse(s"// No doc for `${expr}`")
         }
 
       case _ =>

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -63,7 +63,7 @@ class ReplDriver(settings: Array[String],
 
   /** Create a fresh and initialized context with IDE mode enabled */
   private[this] def initialCtx = {
-    val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions).addMode(Mode.Interactive)
+    val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions).addMode(Mode.Interactive).addMode(Mode.ReadComments)
     val ictx = setup(settings, rootCtx)._2
     ictx.base.initialize()(ictx)
     ictx
@@ -333,6 +333,13 @@ class ReplDriver(settings: Array[String],
 
     case TypeOf(expr) =>
       compiler.typeOf(expr)(newRun(state)).fold(
+        displayErrors,
+        res => out.println(SyntaxHighlighting(res))
+      )
+      state
+
+    case DocOf(expr) =>
+      compiler.docOf(expr)(newRun(state)).fold(
         displayErrors,
         res => out.println(SyntaxHighlighting(res))
       )

--- a/compiler/test/dotty/tools/repl/DocTests.scala
+++ b/compiler/test/dotty/tools/repl/DocTests.scala
@@ -5,205 +5,154 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 
 class DocTests extends ReplTest {
+
   @Test def docOfDef =
-    fromInitialState { implicit s => run("/** doc */ def foo = 0") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval("/** doc */ def foo = 0").andThen { implicit s =>
+      assertEquals("/** doc */", doc("foo"))
     }
 
   @Test def docOfVal =
-    fromInitialState { implicit s => run("/** doc */ val foo = 0") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval("/** doc */ val foo = 0").andThen { implicit s =>
+      assertEquals("/** doc */", doc("foo"))
     }
 
   @Test def docOfObject =
-    fromInitialState { implicit s => run("/** doc */ object Foo") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc Foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval("/** doc */ object Foo").andThen { implicit s =>
+      assertEquals("/** doc */", doc("Foo"))
     }
 
   @Test def docOfClass =
-    fromInitialState { implicit s => run("/** doc */ class Foo") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc new Foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval("/** doc */ class Foo").andThen { implicit s =>
+      assertEquals("/** doc */", doc("new Foo"))
     }
 
   @Test def docOfTrait =
-    fromInitialState { implicit s => run("/** doc */ trait Foo") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc new Foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval("/** doc */ trait Foo").andThen { implicit s =>
+      assertEquals("/** doc */", doc("new Foo"))
     }
 
   @Test def docOfDefInObject =
-    fromInitialState { implicit s => run("object O { /** doc */ def foo = 0 }") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc O.foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval("object O { /** doc */ def foo = 0 }").andThen { implicit s =>
+      assertEquals("/** doc */", doc("O.foo"))
     }
 
   @Test def docOfValInObject =
-    fromInitialState { implicit s => run("object O { /** doc */ val foo = 0 }") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc O.foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval("object O { /** doc */ val foo = 0 }").andThen { implicit s =>
+      assertEquals("/** doc */", doc("O.foo"))
     }
 
   @Test def docOfObjectInObject =
-    fromInitialState { implicit s => run("object O { /** doc */ object Foo }") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc O.Foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval("object O { /** doc */ object Foo }").andThen { implicit s =>
+      assertEquals("/** doc */", doc("O.Foo"))
     }
 
   @Test def docOfClassInObject =
-    fromInitialState { implicit s => run("object O { /** doc */ class Foo }") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc new O.Foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval("object O { /** doc */ class Foo }").andThen { implicit s =>
+      assertEquals("/** doc */", doc("new O.Foo"))
     }
 
   @Test def docOfTraitInObject =
-    fromInitialState { implicit s => run("object O { /** doc */ trait Foo }") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc new O.Foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval("object O { /** doc */ trait Foo }").andThen { implicit s =>
+      assertEquals("/** doc */", doc("new O.Foo"))
     }
 
-  @Test def docOfDetInClass =
-    fromInitialState { implicit s => run("class C { /** doc */ def foo = 0 }") }
-    .andThen { implicit s => run("val c = new C") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc c.foo")
-      assertEquals("/** doc */", storedOutput().trim)
+  @Test def docOfDefInClass =
+    eval(
+      """class C { /** doc */ def foo = 0 }
+        |val c = new C
+      """.stripMargin).andThen { implicit s =>
+      assertEquals("/** doc */", doc("c.foo"))
     }
 
-  @Test def docOfVatInClass =
-    fromInitialState { implicit s => run("class C { /** doc */ val foo = 0 }") }
-    .andThen { implicit s => run("val c = new C") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc c.foo")
-      assertEquals("/** doc */", storedOutput().trim)
+  @Test def docOfValInClass =
+    eval(
+      """class C { /** doc */ val foo = 0 }
+        |val c = new C
+      """.stripMargin).andThen { implicit s =>
+      assertEquals("/** doc */", doc("c.foo"))
     }
 
   @Test def docOfObjectInClass =
-    fromInitialState { implicit s => run("class C { /** doc */ object Foo }") }
-    .andThen { implicit s => run("val c = new C") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc c.Foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval(
+      """class C { /** doc */ object Foo }
+        |val c = new C
+      """.stripMargin).andThen { implicit s =>
+      assertEquals("/** doc */", doc("c.Foo"))
     }
 
   @Test def docOfClassInClass =
-    fromInitialState { implicit s => run("class C { /** doc */ class Foo }") }
-    .andThen { implicit s => run("val c = new C") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc new c.Foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval(
+      """class C { /** doc */ class Foo }
+        |val c = new C
+      """.stripMargin).andThen { implicit s =>
+      assertEquals("/** doc */", doc("new c.Foo"))
     }
 
   @Test def docOfTraitInClass =
-    fromInitialState { implicit s => run("class C { /** doc */ trait Foo }") }
-    .andThen { implicit s => run("val c = new C") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc new c.Foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval(
+      """class C { /** doc */ trait Foo }
+        |val c = new C
+      """.stripMargin).andThen { implicit s =>
+      assertEquals("/** doc */", doc("new c.Foo"))
     }
 
   @Test def docOfOverloadedDef =
-    fromInitialState { implicit s =>
-      run("""object O {
-            |/** doc0 */ def foo(x: Int) = x
-            |/** doc1 */ def foo(x: String) = x
-            |}""".stripMargin)
-    }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc O.foo(_: Int)")
-      assertEquals("/** doc0 */", storedOutput().trim)
-      s
-    }
-    .andThen { implicit s =>
-      run(":doc O.foo(_: String)")
-      assertEquals("/** doc1 */", storedOutput().trim)
+    eval(
+      """object O {
+        |  /** doc0 */ def foo(x: Int) = x
+        |  /** doc1 */ def foo(x: String) = x
+        |}
+      """.stripMargin).andThen { implicit s =>
+      assertEquals("/** doc0 */", doc("O.foo(_: Int)"))
+      assertEquals("/** doc1 */", doc("O.foo(_: String)"))
     }
 
   @Test def docOfInherited =
-    fromInitialState { implicit s => run("class C { /** doc */ def foo = 0 }") }
-    .andThen { implicit s => run("object O extends C") }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc O.foo")
-      assertEquals("/** doc */", storedOutput().trim)
+    eval(
+      """class C { /** doc */ def foo = 0 }
+        |object O extends C
+      """.stripMargin).andThen { implicit s =>
+      assertEquals("/** doc */", doc("O.foo"))
     }
 
   @Test def docOfOverride =
-    fromInitialState { implicit s =>
-      run("""abstract class A {
-            |/** doc0 */ def foo(x: Int): Int = x + 1
-            |/** doc1 */ def foo(x: String): String = x + "foo"
-            |}""".stripMargin)
-    }
-    .andThen { implicit s =>
-      run("""object O extends A {
-            |  override def foo(x: Int): Int = x
-            |  /** overridden doc */ override def foo(x: String): String = x
-            |}""".stripMargin)
-    }
-    .andThen { implicit s =>
-      storedOutput()
-      run(":doc O.foo(_: Int)")
-      assertEquals("/** doc0 */", storedOutput().trim)
-      s
-    }
-    .andThen { implicit s =>
-      run(":doc O.foo(_: String)")
-      assertEquals("/** overridden doc */", storedOutput().trim)
+    eval(
+      """abstract class A {
+        |  /** doc0 */ def foo(x: Int): Int = x + 1
+        |  /** doc1 */ def foo(x: String): String = x + "foo"
+        |}
+        |object O extends A {
+        |  override def foo(x: Int): Int = x
+        |  /** overridden doc */ override def foo(x: String): String = x
+        |}
+      """.stripMargin).andThen { implicit s =>
+      assertEquals("/** doc0 */", doc("O.foo(_: Int)"))
+      assertEquals("/** overridden doc */", doc("O.foo(_: String)"))
     }
 
   @Test def docOfOverrideObject =
-    fromInitialState { implicit s =>
-      run("""abstract class A {
-            |  abstract class Companion { /** doc0 */ def bar: Int }
-            |  /** companion */ def foo: Companion
-            |}""".stripMargin)
-      .andThen { implicit s =>
-        run("""object O extends A {
-              |  override object foo extends Companion {
-              |    override def bar: Int = 0
-              |  }
-              |}""".stripMargin)
-      }
-      .andThen { implicit s =>
-        storedOutput()
-        run(":doc O.foo")
-        assertEquals("/** companion */", storedOutput().trim)
-        s
-      }
-      .andThen { implicit s =>
-        run(":doc O.foo.bar")
-        assertEquals("/** doc0 */", storedOutput().trim)
-      }
+    eval(
+      """abstract class A {
+        |  abstract class Companion { /** doc0 */ def bar: Int }
+        |  /** companion */ def foo: Companion
+        |}
+        |object O extends A {
+        |  override object foo extends Companion {
+        |    override def bar: Int = 0
+        |  }
+        |}
+      """.stripMargin).andThen { implicit s =>
+      assertEquals("/** companion */", doc("O.foo"))
+      assertEquals("/** doc0 */", doc("O.foo.bar"))
     }
+
+  private def eval(code: String): State =
+    fromInitialState { implicit s => run(code) }
+
+  private def doc(expr: String)(implicit s: State): String = {
+    storedOutput()
+    run(s":doc $expr")
+    storedOutput().trim
+  }
 
 }

--- a/compiler/test/dotty/tools/repl/DocTests.scala
+++ b/compiler/test/dotty/tools/repl/DocTests.scala
@@ -1,0 +1,160 @@
+package dotty.tools
+package repl
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class DocTests extends ReplTest {
+  @Test def docOfDef =
+    fromInitialState { implicit s => run("/** doc */ def foo = 0") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfVal =
+    fromInitialState { implicit s => run("/** doc */ val foo = 0") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfObject =
+    fromInitialState { implicit s => run("/** doc */ object Foo") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc Foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfClass =
+    fromInitialState { implicit s => run("/** doc */ class Foo") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc new Foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfTrait =
+    fromInitialState { implicit s => run("/** doc */ trait Foo") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc new Foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfDefInObject =
+    fromInitialState { implicit s => run("object O { /** doc */ def foo = 0 }") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc O.foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfValInObject =
+    fromInitialState { implicit s => run("object O { /** doc */ val foo = 0 }") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc O.foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfObjectInObject =
+    fromInitialState { implicit s => run("object O { /** doc */ object Foo }") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc O.Foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfClassInObject =
+    fromInitialState { implicit s => run("object O { /** doc */ class Foo }") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc new O.Foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfTraitInObject =
+    fromInitialState { implicit s => run("object O { /** doc */ trait Foo }") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc new O.Foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfDetInClass =
+    fromInitialState { implicit s => run("class C { /** doc */ def foo = 0 }") }
+    .andThen { implicit s => run("val c = new C") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc c.foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfVatInClass =
+    fromInitialState { implicit s => run("class C { /** doc */ val foo = 0 }") }
+    .andThen { implicit s => run("val c = new C") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc c.foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfObjectInClass =
+    fromInitialState { implicit s => run("class C { /** doc */ object Foo }") }
+    .andThen { implicit s => run("val c = new C") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc c.Foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfClassInClass =
+    fromInitialState { implicit s => run("class C { /** doc */ class Foo }") }
+    .andThen { implicit s => run("val c = new C") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc new c.Foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfTraitInClass =
+    fromInitialState { implicit s => run("class C { /** doc */ trait Foo }") }
+    .andThen { implicit s => run("val c = new C") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc new c.Foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+  @Test def docOfOverloadedDef =
+    fromInitialState { implicit s =>
+      run("""object O {
+            |/** doc0 */ def foo(x: Int) = x
+            |/** doc1 */ def foo(x: String) = x
+            |}""".stripMargin)
+    }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc O.foo(_: Int)")
+      assertEquals("/** doc0 */", storedOutput().trim)
+      s
+    }
+    .andThen { implicit s =>
+      run(":doc O.foo(_: String)")
+      assertEquals("/** doc1 */", storedOutput().trim)
+    }
+
+  @Test def docOfInherited =
+    fromInitialState { implicit s => run("class C { /** doc */ def foo = 0 }") }
+    .andThen { implicit s => run("object O extends C") }
+    .andThen { implicit s =>
+      storedOutput()
+      run(":doc O.foo")
+      assertEquals("/** doc */", storedOutput().trim)
+    }
+
+}


### PR DESCRIPTION
Depends on #4461 and #4648 

This command is used to display the documentation associated to the
given expression. For instance:

```scala
scala> /** A class */ class A
scala> /** An object */ object O { /** A def */ def foo = 0 }
scala> :doc new A
/** A class */
scala> :doc O
/** An object */
scala> :doc O.foo
/** A def */
```

(Only the last 2 commits are relevant for this PR)