### PR TITLE
Add TypeOf (first step towards transparent methods)

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -605,16 +605,10 @@ object Trees {
    */
   class TypeVarBinder[-T >: Untyped] extends TypeTree[T]
 
-  /** ref.type */
+  /** ref.type  or  { ref } */
   case class SingletonTypeTree[-T >: Untyped] private[ast] (ref: Tree[T])
     extends DenotingTree[T] with TypTree[T] {
     type ThisTree[-T >: Untyped] = SingletonTypeTree[T]
-  }
-
-  /** { expr1 }, aka TypeOf type */
-  case class TypeOfTypeTree[-T >: Untyped] private[ast] (ref: Tree[T])
-    extends DenotingTree[T] with TypTree[T] {
-    type ThisTree[-T >: Untyped] = TypeOfTypeTree[T]
   }
 
   /** left & right */
@@ -894,7 +888,6 @@ object Trees {
     type Inlined = Trees.Inlined[T]
     type TypeTree = Trees.TypeTree[T]
     type SingletonTypeTree = Trees.SingletonTypeTree[T]
-    type TypeOfTypeTree = Trees.TypeOfTypeTree[T]
     type AndTypeTree = Trees.AndTypeTree[T]
     type OrTypeTree = Trees.OrTypeTree[T]
     type RefinedTypeTree = Trees.RefinedTypeTree[T]
@@ -1047,10 +1040,6 @@ object Trees {
       def SingletonTypeTree(tree: Tree)(ref: Tree): SingletonTypeTree = tree match {
         case tree: SingletonTypeTree if ref eq tree.ref => tree
         case _ => finalize(tree, untpd.SingletonTypeTree(ref))
-      }
-      def TypeOfTypeTree(tree: Tree)(ref: Tree): TypeOfTypeTree = tree match {
-        case tree: TypeOfTypeTree if ref eq tree.ref => tree
-        case _ => finalize(tree, untpd.TypeOfTypeTree(ref))
       }
       def AndTypeTree(tree: Tree)(left: Tree, right: Tree): AndTypeTree = tree match {
         case tree: AndTypeTree if (left eq tree.left) && (right eq tree.right) => tree
@@ -1211,8 +1200,6 @@ object Trees {
             tree
           case SingletonTypeTree(ref) =>
             cpy.SingletonTypeTree(tree)(transform(ref))
-          case TypeOfTypeTree(ref) =>
-            cpy.TypeOfTypeTree(tree)(transform(ref))
           case AndTypeTree(left, right) =>
             cpy.AndTypeTree(tree)(transform(left), transform(right))
           case OrTypeTree(left, right) =>
@@ -1327,8 +1314,6 @@ object Trees {
           case TypeTree() =>
             x
           case SingletonTypeTree(ref) =>
-            this(x, ref)
-          case TypeOfTypeTree(ref) =>
             this(x, ref)
           case AndTypeTree(left, right) =>
             this(this(x, left), right)

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -227,8 +227,9 @@ object Trees {
                 case y: List[_] => x.corresponds(y)(isSame)
                 case _ => false
               }
+            case x: Constant => x == y
             case _ =>
-              false
+              throw new AssertionError(s"Unexpected Tree in Tree comparison $x (comparing to $y)")
           }
         }
       this.getClass == that.getClass && {

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -611,6 +611,12 @@ object Trees {
     type ThisTree[-T >: Untyped] = SingletonTypeTree[T]
   }
 
+  /** { expr1 }, aka TypeOf type */
+  case class TypeOfTypeTree[-T >: Untyped] private[ast] (ref: Tree[T])
+    extends DenotingTree[T] with TypTree[T] {
+    type ThisTree[-T >: Untyped] = TypeOfTypeTree[T]
+  }
+
   /** left & right */
   case class AndTypeTree[-T >: Untyped] private[ast] (left: Tree[T], right: Tree[T])
     extends TypTree[T] {
@@ -888,6 +894,7 @@ object Trees {
     type Inlined = Trees.Inlined[T]
     type TypeTree = Trees.TypeTree[T]
     type SingletonTypeTree = Trees.SingletonTypeTree[T]
+    type TypeOfTypeTree = Trees.TypeOfTypeTree[T]
     type AndTypeTree = Trees.AndTypeTree[T]
     type OrTypeTree = Trees.OrTypeTree[T]
     type RefinedTypeTree = Trees.RefinedTypeTree[T]
@@ -1040,6 +1047,10 @@ object Trees {
       def SingletonTypeTree(tree: Tree)(ref: Tree): SingletonTypeTree = tree match {
         case tree: SingletonTypeTree if ref eq tree.ref => tree
         case _ => finalize(tree, untpd.SingletonTypeTree(ref))
+      }
+      def TypeOfTypeTree(tree: Tree)(ref: Tree): TypeOfTypeTree = tree match {
+        case tree: TypeOfTypeTree if ref eq tree.ref => tree
+        case _ => finalize(tree, untpd.TypeOfTypeTree(ref))
       }
       def AndTypeTree(tree: Tree)(left: Tree, right: Tree): AndTypeTree = tree match {
         case tree: AndTypeTree if (left eq tree.left) && (right eq tree.right) => tree
@@ -1200,6 +1211,8 @@ object Trees {
             tree
           case SingletonTypeTree(ref) =>
             cpy.SingletonTypeTree(tree)(transform(ref))
+          case TypeOfTypeTree(ref) =>
+            cpy.TypeOfTypeTree(tree)(transform(ref))
           case AndTypeTree(left, right) =>
             cpy.AndTypeTree(tree)(transform(left), transform(right))
           case OrTypeTree(left, right) =>
@@ -1314,6 +1327,8 @@ object Trees {
           case TypeTree() =>
             x
           case SingletonTypeTree(ref) =>
+            this(x, ref)
+          case TypeOfTypeTree(ref) =>
             this(x, ref)
           case AndTypeTree(left, right) =>
             this(this(x, left), right)

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -137,6 +137,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def SingletonTypeTree(ref: Tree)(implicit ctx: Context): SingletonTypeTree =
     ta.assignType(untpd.SingletonTypeTree(ref), ref)
 
+  def TypeOfTypeTree(ref: Tree)(implicit ctx: Context): TypeOfTypeTree =
+    ta.assignType(untpd.TypeOfTypeTree(ref), ref)
+
   def AndTypeTree(left: Tree, right: Tree)(implicit ctx: Context): AndTypeTree =
     ta.assignType(untpd.AndTypeTree(left, right), left, right)
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -137,9 +137,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def SingletonTypeTree(ref: Tree)(implicit ctx: Context): SingletonTypeTree =
     ta.assignType(untpd.SingletonTypeTree(ref), ref)
 
-  def TypeOfTypeTree(ref: Tree)(implicit ctx: Context): TypeOfTypeTree =
-    ta.assignType(untpd.TypeOfTypeTree(ref), ref)
-
   def AndTypeTree(left: Tree, right: Tree)(implicit ctx: Context): AndTypeTree =
     ta.assignType(untpd.AndTypeTree(left, right), left, right)
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -540,7 +540,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     override def If(tree: Tree)(cond: Tree, thenp: Tree, elsep: Tree)(implicit ctx: Context): If = {
       val tree1 = untpd.cpy.If(tree)(cond, thenp, elsep)
       tree match {
-        case tree: If if (thenp.tpe eq tree.thenp.tpe) && (elsep.tpe eq tree.elsep.tpe) => tree1.withTypeUnchecked(tree.tpe)
+        case tree: If if (cond.tpe eq tree.cond.tpe) && (thenp.tpe eq tree.thenp.tpe) && (elsep.tpe eq tree.elsep.tpe) => tree1.withTypeUnchecked(tree.tpe)
         case _ => ta.assignType(tree1, thenp, elsep)
       }
     }
@@ -557,7 +557,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     override def Match(tree: Tree)(selector: Tree, cases: List[CaseDef])(implicit ctx: Context): Match = {
       val tree1 = untpd.cpy.Match(tree)(selector, cases)
       tree match {
-        case tree: Match if sameTypes(cases, tree.cases) => tree1.withTypeUnchecked(tree.tpe)
+        case tree: Match if (selector.tpe eq tree.selector.tpe) && sameTypes(cases, tree.cases) => tree1.withTypeUnchecked(tree.tpe)
         case _ => ta.assignType(tree1, cases)
       }
     }

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -283,6 +283,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree): Inlined = new Inlined(call, bindings, expansion)
   def TypeTree() = new TypeTree()
   def SingletonTypeTree(ref: Tree): SingletonTypeTree = new SingletonTypeTree(ref)
+  def TypeOfTypeTree(ref: Tree): TypeOfTypeTree = new TypeOfTypeTree(ref)
   def AndTypeTree(left: Tree, right: Tree): AndTypeTree = new AndTypeTree(left, right)
   def OrTypeTree(left: Tree, right: Tree): OrTypeTree = new OrTypeTree(left, right)
   def RefinedTypeTree(tpt: Tree, refinements: List[Tree]): RefinedTypeTree = new RefinedTypeTree(tpt, refinements)

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -283,7 +283,6 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree): Inlined = new Inlined(call, bindings, expansion)
   def TypeTree() = new TypeTree()
   def SingletonTypeTree(ref: Tree): SingletonTypeTree = new SingletonTypeTree(ref)
-  def TypeOfTypeTree(ref: Tree): TypeOfTypeTree = new TypeOfTypeTree(ref)
   def AndTypeTree(left: Tree, right: Tree): AndTypeTree = new AndTypeTree(left, right)
   def OrTypeTree(left: Tree, right: Tree): OrTypeTree = new OrTypeTree(left, right)
   def RefinedTypeTree(tpt: Tree, refinements: List[Tree]): RefinedTypeTree = new RefinedTypeTree(tpt, refinements)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -752,6 +752,8 @@ class Definitions {
   def ThrowsAnnot(implicit ctx: Context) = ThrowsAnnotType.symbol.asClass
   lazy val TransientAnnotType                = ctx.requiredClassRef("scala.transient")
   def TransientAnnot(implicit ctx: Context) = TransientAnnotType.symbol.asClass
+  lazy val TypeOfAnnotType               = ctx.requiredClassRef("scala.annotation.internal.TypeOf")
+  def TypeOfAnnot(implicit ctx: Context) = TypeOfAnnotType.symbol.asClass
   lazy val UncheckedAnnotType = ctx.requiredClassRef("scala.unchecked")
   def UncheckedAnnot(implicit ctx: Context) = UncheckedAnnotType.symbol.asClass
   lazy val UncheckedStableAnnotType = ctx.requiredClassRef("scala.annotation.unchecked.uncheckedStable")

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -785,6 +785,10 @@ object SymDenotations {
     def isTransparentMethod(implicit ctx: Context): Boolean =
       is(TransparentMethod, butNot = Accessor)
 
+    /** Does this symbol have a transparent owner, itself included? */
+    def isTransitivelyTransparent(implicit ctx: Context): Boolean =
+      ownersIterator.exists(_.isTransparentMethod)
+
     def isInlineableMethod(implicit ctx: Context) = isInlinedMethod || isTransparentMethod
 
     /** ()T and => T types should be treated as equivalent for this symbol.

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -785,9 +785,14 @@ object SymDenotations {
     def isTransparentMethod(implicit ctx: Context): Boolean =
       is(TransparentMethod, butNot = Accessor)
 
-    /** Does this symbol have a transparent owner, itself included? */
-    def isTransitivelyTransparent(implicit ctx: Context): Boolean =
+    /** Are we in a transparent context?
+     *  Either  - this symbol has a transparent owner, itself included
+     *  Or      - we are inside a SingletonTypeTree
+     */
+    def isTransitivelyTransparent(implicit ctx: Context): Boolean = {
+      // Note: Should we use a mode instead?
       ownersIterator.exists(_.isTransparentMethod) || ctx.outersIterator.exists(_.tree.isInstanceOf[SingletonTypeTree[_]])
+    }
 
     def isInlineableMethod(implicit ctx: Context) = isInlinedMethod || isTransparentMethod
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -787,7 +787,7 @@ object SymDenotations {
 
     /** Does this symbol have a transparent owner, itself included? */
     def isTransitivelyTransparent(implicit ctx: Context): Boolean =
-      ownersIterator.exists(_.isTransparentMethod)
+      ownersIterator.exists(_.isTransparentMethod) || ctx.outersIterator.exists(_.tree.isInstanceOf[SingletonTypeTree[_]])
 
     def isInlineableMethod(implicit ctx: Context) = isInlinedMethod || isTransparentMethod
 

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -236,10 +236,10 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         compareWild
       case tp2: LazyRef =>
         !tp2.evaluating && recur(tp1, tp2.ref)
+      case tp2: TypeOf =>
+        tp2 == tp1 || secondTry
       case tp2: AnnotatedType if !tp2.isRefining =>
         recur(tp1, tp2.parent)
-      case tp2: TypeOf =>
-        tp1 == tp2 || secondTry
       case tp2: ThisType =>
         def compareThis = {
           val cls2 = tp2.cls

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -238,6 +238,8 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
         !tp2.evaluating && recur(tp1, tp2.ref)
       case tp2: AnnotatedType if !tp2.isRefining =>
         recur(tp1, tp2.parent)
+      case tp2: TypeOf =>
+        tp1 == tp2 || secondTry
       case tp2: ThisType =>
         def compareThis = {
           val cls2 = tp2.cls

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -569,7 +569,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
             false
         }
         compareTypeBounds
-      case tp2: AnnotatedType if tp2.isRefining =>
+      case tp2: AnnotatedType if tp2.isRefining && !tp2.isInstanceOf[TypeOf] =>
         (tp1.derivesAnnotWith(tp2.annot.sameAnnotation) || defn.isBottomType(tp1)) &&
         recur(tp1, tp2.parent)
       case ClassInfo(pre2, cls2, _, _, _) =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3989,6 +3989,16 @@ object Types {
         case _ => None
       }
     }
+
+    object Match {
+      def unapply(to: TypeOf): Option[(Type, List[Type])] = to.tree match {
+        case Trees.Match(cond, cases) =>
+          // TODO: We only look at .body.tpe for now, eventually we should
+          // also take the guard and the pattern into account.
+          Some((cond.tpe, cases.map(_.body.tpe)))
+        case _ => None
+      }
+    }
   }
 
   // ----- TypeMaps --------------------------------------------------------------------

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4099,6 +4099,14 @@ object Types {
               cpy.Apply(tree)(copyMapped(tree.fun), tree.args.mapConserve(copyMapped))
             case tree: If =>
               cpy.If(tree)(copyMapped(tree.cond), copyMapped(tree.thenp), copyMapped(tree.elsep))
+            case tree: Ident =>
+              copyMapped(tree)
+            case tree: Select =>
+              cpy.Select(tree)(copyMapped(tree.qualifier), tree.name)
+            case tree: Literal =>
+              copyMapped(tree)
+            case tree: Block =>
+              copyMapped(tree)
             case tree: Match =>
               ???
             case tree => throw new AssertionError(s"TypeOf shouldn't contain $tree as top-level node.")

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3944,6 +3944,15 @@ object Types {
       else TypeOf(tree, underlyingTp)
   }
 
+  object TypeOf {
+    /** To be used from type assigner. The assumption is that tree is currently
+     *  being type assigned, and will be typed by the time it reaches the
+     *  outside world.
+     */
+    private[dotc] def fromUntyped(tree: untpd.Tree, tpe: Type): TypeOf =
+      TypeOf(tree.asInstanceOf[Tree], tpe)
+  }
+
   // ----- TypeMaps --------------------------------------------------------------------
 
   /** Common base class of TypeMap and TypeAccumulator */

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3962,6 +3962,10 @@ object Types {
     def derivedTypeOf(tree: Tree, underlyingTp: Type)(implicit ctx: Context): TypeOf =
       if ((this.tree eq tree) && (this.underlyingTp eq underlyingTp)) this
       else TypeOf(tree, underlyingTp)
+
+    override def derivedAnnotatedType(parent: Type, annot: Annotation): AnnotatedType =
+      if ((parent eq this.parent) && (annot eq this.annot)) this
+      else TypeOf(annot.arguments.head, parent)
   }
 
   object TypeOf {

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -21,7 +21,7 @@ import util.Stats._
 import util.{DotClass, SimpleIdentitySet}
 import reporting.diagnostic.Message
 import ast.tpd._
-import ast.TreeTypeMap
+import ast.{Trees, TreeTypeMap}
 import printing.Texts._
 import ast.untpd
 import dotty.tools.dotc.transform.Erasure
@@ -3981,6 +3981,13 @@ object Types {
     private[dotc] def isLegalTopLevelTree(tree: Tree): Boolean = tree match {
       case _: TypeApply | _: Apply | _: If | _: Match => true
       case _ => false
+    }
+
+    object If {
+      def unapply(to: TypeOf): Option[(Type, Type, Type)] = to.tree match {
+        case Trees.If(cond, thenb, elseb) => Some((cond.tpe, thenb.tpe, elseb.tpe))
+        case _ => None
+      }
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4426,6 +4426,16 @@ object Types {
           if (underlying.isBottomType) underlying
           else tp.derivedAnnotatedType(underlying, annot)
       }
+
+    override protected def derivedTypeOf(tp: TypeOf, underlying: Type, tree: Tree) =
+      underlying match {
+        case Range(lo, hi) =>
+          range(tp.derivedTypeOf(lo, tree), tp.derivedTypeOf(hi, tree))
+        case _ =>
+          if (underlying.isBottomType) underlying
+          else tp.derivedTypeOf(underlying, tree)
+      }
+
     override protected def derivedWildcardType(tp: WildcardType, bounds: Type) = {
       tp.derivedWildcardType(rangeToBounds(bounds))
     }
@@ -4444,10 +4454,6 @@ object Types {
         case _ =>
           tp.derivedLambdaType(tp.paramNames, formals, restpe)
       }
-
-    // TODO: Implement derivedTypeOf in ApproximatingTypeMap
-//    override protected def derivedTypeOf(tp: TypeOf, tree: Tree, underlyingTp: Type): Type =
-//      tp.derivedTypeOf(tree, underlyingTp)
 
     protected def reapply(tp: Type): Type = apply(tp)
   }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3954,14 +3954,10 @@ object Types {
                 false
             }
           }
-          compareTree(this.tree, that.tree) && { assert(this.underlyingTp == that.underlyingTp, s"UTP:\n\t${this.underlyingTp}\n\t${that.underlyingTp}"); true }
+          compareTree(this.tree, that.tree)
         case _ => false
       }
     }
-
-    def derivedTypeOf(underlyingTp: Type, tree: Tree)(implicit ctx: Context): TypeOf =
-      if ((this.tree eq tree) && (this.underlyingTp eq underlyingTp)) this
-      else TypeOf(underlyingTp, tree)
 
     override def derivedAnnotatedType(parent: Type, annot: Annotation)(implicit ctx: Context): AnnotatedType =
       if ((parent eq this.parent) && (annot eq this.annot)) this
@@ -4059,8 +4055,6 @@ object Types {
     // note: currying needed  because Scala2 does not support param-dependencies
     protected def derivedLambdaType(tp: LambdaType)(formals: List[tp.PInfo], restpe: Type): Type =
       tp.derivedLambdaType(tp.paramNames, formals, restpe)
-    protected def derivedTypeOf(tp: TypeOf, underlyingTp: Type, tree: Tree): Type =
-      tp.derivedTypeOf(underlyingTp, tree)
 
     /** Map this function over given type */
     def mapOver(tp: Type): Type = {
@@ -4444,15 +4438,6 @@ object Types {
         case _ =>
           if (underlying.isBottomType) underlying
           else tp.derivedAnnotatedType(underlying, annot)
-      }
-
-    override protected def derivedTypeOf(tp: TypeOf, underlying: Type, tree: Tree) =
-      underlying match {
-        case Range(lo, hi) =>
-          range(tp.derivedTypeOf(lo, tree), tp.derivedTypeOf(hi, tree))
-        case _ =>
-          if (underlying.isBottomType) underlying
-          else tp.derivedTypeOf(underlying, tree)
       }
 
     override protected def derivedWildcardType(tp: WildcardType, bounds: Type) = {

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3981,13 +3981,6 @@ object Types {
     }
     def unapply(to: TypeOf): Option[(Type, Tree)] = Some((to.underlyingTp, to.tree))
 
-    /** To be used from type assigner. The assumption is that tree is currently
-     *  being type assigned, and will be typed by the time it reaches the
-     *  outside world.
-     */
-    private[dotc] def fromUntyped(tpe: Type, tree: untpd.Tree)(implicit ctx: Context): TypeOf =
-      TypeOf(tpe, tree)
-
     private[dotc] def isLegalTopLevelTree(tree: Tree): Boolean = tree match {
       case _: TypeApply | _: Apply | _: If | _: Match => true
       case _ => false

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -87,12 +87,12 @@ object Types {
 // ----- Tests -----------------------------------------------------
 
 //    // debug only: a unique identifier for a type
-    val uniqId = {
-      nextId = nextId + 1
+//    val uniqId = {
+//      nextId = nextId + 1
 //      if (nextId == 19555)
 //        println("foo")
-      nextId
-    }
+//      nextId
+//    }
 
     /** A cache indicating whether the type was still provisional, last time we checked */
     @sharable private var mightBeProvisional = true
@@ -3932,7 +3932,7 @@ object Types {
   // ----- TypeOf -------------------------------------------------------------------------
 
   /** */
-  class TypeOf(val underlyingTp: Type, val tree: Tree, annot: Annotation) extends AnnotatedType(underlyingTp, annot) {
+  class TypeOf private (val underlyingTp: Type, val tree: Tree, annot: Annotation) extends AnnotatedType(underlyingTp, annot) {
     assert(TypeOf.isLegalTopLevelTree(tree), s"Illegal top-level tree in TypeOf: $tree")
 
     override def equals(that: Any): Boolean = {
@@ -3967,7 +3967,7 @@ object Types {
       if ((parent eq this.parent) && (annot eq this.annot)) this
       else TypeOf(parent, annot.arguments.head)
 
-    override def toString(): String = s"TypeOf($underlyingTp, $tree)#$uniqId"
+    override def toString(): String = s"TypeOf($underlyingTp, $tree)"
   }
 
   object TypeOf {

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -87,12 +87,12 @@ object Types {
 // ----- Tests -----------------------------------------------------
 
 //    // debug only: a unique identifier for a type
-//    val uniqId = {
-//      nextId = nextId + 1
+    val uniqId = {
+      nextId = nextId + 1
 //      if (nextId == 19555)
 //        println("foo")
-//      nextId
-//    }
+      nextId
+    }
 
     /** A cache indicating whether the type was still provisional, last time we checked */
     @sharable private var mightBeProvisional = true
@@ -3931,8 +3931,11 @@ object Types {
 
   // ----- TypeOf -------------------------------------------------------------------------
 
+  // TODO: Move Annotation construction to TypeOf.apply(...)
   class TypeOf(val underlyingTp: Type, val tree: Tree)(implicit ctx: Context) extends AnnotatedType(underlyingTp, Annotation(defn.TypeOfAnnot, tree)) {
     assert(TypeOf.isLegalTopLevelTree(tree), i"Illegal top-level tree in TypeOf: $tree")
+    if (uniqId == 5705)
+      new Throwable().printStackTrace()
 
     override def equals(that: Any): Boolean = {
       that match {
@@ -3953,7 +3956,7 @@ object Types {
                 false
             }
           }
-          compareTree(this.tree, that.tree) && { assert(this.underlyingTp == that.underlyingTp); true }
+          compareTree(this.tree, that.tree) && { assert(this.underlyingTp == that.underlyingTp, s"UTP:\n\t${this.underlyingTp}\n\t${that.underlyingTp}"); true }
         case _ => false
       }
     }
@@ -3966,7 +3969,7 @@ object Types {
       if ((parent eq this.parent) && (annot eq this.annot)) this
       else TypeOf(parent, annot.arguments.head)
 
-    override def toString(): String = s"TypeOf($underlyingTp, $tree)"
+    override def toString(): String = s"TypeOf($underlyingTp, $tree)#$uniqId"
   }
 
   object TypeOf {

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3965,6 +3965,8 @@ object Types {
     override def derivedAnnotatedType(parent: Type, annot: Annotation): AnnotatedType =
       if ((parent eq this.parent) && (annot eq this.annot)) this
       else TypeOf(parent, annot.arguments.head)
+
+    override def toString(): String = s"TypeOf($underlyingTp, $tree)"
   }
 
   object TypeOf {

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3931,7 +3931,28 @@ object Types {
 
   // ----- TypeOf -------------------------------------------------------------------------
 
-  /** */
+  /** Type that represents the precise type of a given term.
+   *  Precision is only kept for Apply, TypeApply, If and Match trees.
+   *
+   *  The idea behind this type is to be able to compute more precise types
+   *  when more information is available.
+   *
+   *  TypeOfs are represented by an underlying type and a tree. The top level
+   *  node of the tree must be one of the nodes mentioned above, and is only
+   *  used as a "marker" node, meaning that we will never look at its type.
+   *
+   *  In a sense, TypeOf types are isomorphic to the following 4 types:
+   *
+   *  TypeOf(u, Apply(fun, args))       ~ SuspendedApply(u, fun, args)
+   *  TypeOf(u, TypeApply(fun, args))   ~ SuspendedTypeApply(u, fun, args)
+   *  TypeOf(u, If(cond, thenp, elsep)) ~ SuspendedIf(u, cond, thenp, elsep)
+   *  TypeOf(u, Match(selector, cases)) ~ SuspendedMatch(u, selector, cases)
+   *
+   *  Where u is the type that the tree would have had otherwise.
+   *
+   *  It should be the case that whenever two TypeOfs are equal, so are their
+   *  underlying types.
+   */
   class TypeOf private (val underlyingTp: Type, val tree: Tree, annot: Annotation) extends AnnotatedType(underlyingTp, annot) {
     assert(TypeOf.isLegalTopLevelTree(tree), s"Illegal top-level tree in TypeOf: $tree")
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3970,6 +3970,7 @@ object Types {
 
   object TypeOf {
     def apply(underlyingTp: Type, tree: Tree)(implicit ctx: Context): TypeOf = new TypeOf(underlyingTp, tree)
+    def unapply(to: TypeOf): Option[(Type, Tree)] = Some((to.underlyingTp, to.tree))
 
     /** To be used from type assigner. The assumption is that tree is currently
      *  being type assigned, and will be typed by the time it reaches the

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4181,15 +4181,6 @@ object Types {
               throw new AssertionError(s"TypeOf shouldn't contain $tree as top-level node.")
           }
           if (tp.tree ne tree1) {
-            // Here is an example showing what would go wrong if we don't re-assign types:
-            // Suppose we have
-            //   def f(x: Int) = x
-            //   def g(x: Int) = 2 * x
-            //   def h(f: Int => Int) = f(1)
-            //   h(g): { 2 * 1 }
-            // Given a type map substituting f for g in f(1), the underlying
-            // type should be substituted to the result type of g(1), that is,
-            // 2 * 1.
             assert(!tp.underlyingTp.exists || tree1.tpe.exists, i"Derived TypeOf's type became NoType")
             tree1.tpe
           } else {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -402,6 +402,7 @@ object TastyFormat {
   final val ANNOTATION = 172
   final val TERMREFin = 173
   final val TYPEREFin = 174
+  final val TYPEOF = 175
 
   // In binary: 101100EI
   // I = implicit method type
@@ -430,7 +431,7 @@ object TastyFormat {
     firstNatTreeTag <= tag && tag <= SYMBOLconst ||
     firstASTTreeTag <= tag && tag <= SINGLETONtpt ||
     firstNatASTTreeTag <= tag && tag <= NAMEDARG ||
-    firstLengthTreeTag <= tag && tag <= TYPEREFin ||
+    firstLengthTreeTag <= tag && tag <= ERASEDIMPLICITMETHODtype ||
     tag == HOLE
 
   def isParamTag(tag: Int) = tag == PARAM || tag == TYPEPARAM
@@ -595,6 +596,7 @@ object TastyFormat {
     case SUPERtype => "SUPERtype"
     case TERMREFin => "TERMREFin"
     case TYPEREFin => "TYPEREFin"
+    case TYPEOF => "TYPEOF"
 
     case REFINEDtype => "REFINEDtype"
     case REFINEDtpt => "REFINEDtpt"

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -74,6 +74,8 @@ class TastyPrinter(bytes: Array[Byte])(implicit ctx: Context) {
               until(end) { printName(); printTree() }
             case PARAMtype =>
               printNat(); printNat()
+            case TYPEOF =>
+              printTree(); printTree()
             case _ =>
               printTrees()
           }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -161,7 +161,7 @@ class TreePickler(pickler: TastyPickler) {
       pickleConstant(value)
     case tpe: TypeOf =>
       writeByte(TYPEOF)
-      withLength { pickleTree(tpe.tree); pickleType(tpe.underlyingTp, richTypes) }
+      withLength { pickleType(tpe.underlyingTp, richTypes); pickleTree(tpe.tree) }
     case tpe: NamedType =>
       val sym = tpe.symbol
       def pickleExternalRef(sym: Symbol) = {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -513,7 +513,6 @@ class TreePickler(pickler: TastyPickler) {
         case SingletonTypeTree(ref) =>
           writeByte(SINGLETONtpt)
           pickleTree(ref)
-        // TODO: case TypeOfTypeTree
         case RefinedTypeTree(parent, refinements) =>
           if (refinements.isEmpty) pickleTree(parent)
           else {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -513,6 +513,7 @@ class TreePickler(pickler: TastyPickler) {
         case SingletonTypeTree(ref) =>
           writeByte(SINGLETONtpt)
           pickleTree(ref)
+        // TODO: case TypeOfTypeTree
         case RefinedTypeTree(parent, refinements) =>
           if (refinements.isEmpty) pickleTree(parent)
           else {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -159,6 +159,9 @@ class TreePickler(pickler: TastyPickler) {
       withLength { pickleType(tycon); args.foreach(pickleType(_)) }
     case ConstantType(value) =>
       pickleConstant(value)
+    case tpe: TypeOf =>
+      writeByte(TYPEOF)
+      withLength { pickleTree(tpe.tree); pickleType(tpe.underlyingTp, richTypes) }
     case tpe: NamedType =>
       val sym = tpe.symbol
       def pickleExternalRef(sym: Symbol) = {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -324,6 +324,8 @@ class TreeUnpickler(reader: TastyReader,
               TypeBounds(readType(), readType())
             case ANNOTATEDtype =>
               AnnotatedType(readType(), Annotation(readTerm()))
+            case TYPEOF =>
+              TypeOf(readTerm(), readType())
             case ANDtype =>
               AndType(readType(), readType())
             case ORtype =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -325,7 +325,7 @@ class TreeUnpickler(reader: TastyReader,
             case ANNOTATEDtype =>
               AnnotatedType(readType(), Annotation(readTerm()))
             case TYPEOF =>
-              TypeOf(readTerm(), readType())
+              TypeOf(readType(), readTerm())
             case ANDtype =>
               AndType(readType(), readType())
             case ORtype =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1001,7 +1001,6 @@ class TreeUnpickler(reader: TastyReader,
           Throw(readTerm())
         case SINGLETONtpt =>
           SingletonTypeTree(readTerm())
-        // TODO: case TypeOfTypeTree =>
         case BYNAMEtpt =>
           ByNameTypeTree(readTpt())
         case NAMEDARG =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1001,6 +1001,7 @@ class TreeUnpickler(reader: TastyReader,
           Throw(readTerm())
         case SINGLETONtpt =>
           SingletonTypeTree(readTerm())
+        // TODO: case TypeOfTypeTree =>
         case BYNAMEtpt =>
           ByNameTypeTree(readTpt())
         case NAMEDARG =>

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -1198,8 +1198,6 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       case SINGLETONTYPEtree =>
         SingletonTypeTree(readTreeRef())
 
-      // TODO case TypeOfTypeTree =>
-
       case SELECTFROMTYPEtree =>
         val qualifier = readTreeRef()
         val selector = readTypeNameRef()

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -1198,6 +1198,8 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       case SINGLETONTYPEtree =>
         SingletonTypeTree(readTreeRef())
 
+      // TODO case TypeOfTypeTree =>
+
       case SELECTFROMTYPEtree =>
         val qualifier = readTreeRef()
         val selector = readTypeNameRef()

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -870,7 +870,7 @@ object Parsers {
           makeTupleOrParens(inParens(argTypes(namedOK = false, wildOK = true)))
         }
       else if (in.token == LBRACE)
-        atPos(in.offset) { RefinedTypeTree(EmptyTree, refinement()) }
+        atPos(in.offset) { inBraces(refinementOnEmptyOrTypeOf()) }
       else if (isSimpleLiteral) { SingletonTypeTree(literal()) }
       else if (in.token == USCORE) {
         val start = in.skipToken()
@@ -882,6 +882,12 @@ object Parsers {
         case r @ SingletonTypeTree(_) => r
         case r => convertToTypeId(r)
       }
+    }
+
+    /** A refinement on an empty tree or a TypeOf type tree. */
+    def refinementOnEmptyOrTypeOf(): Tree = {
+      if (!isStatSeqEnd && !isDclIntro) TypeOfTypeTree(expr1())
+      else RefinedTypeTree(EmptyTree, refineStatSeq())
     }
 
     val handleSingletonType: Tree => Tree = t =>

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -870,7 +870,7 @@ object Parsers {
           makeTupleOrParens(inParens(argTypes(namedOK = false, wildOK = true)))
         }
       else if (in.token == LBRACE)
-        atPos(in.offset) { inBraces(refinementOnEmptyOrTypeOf()) }
+        atPos(in.offset) { inBraces(refinementOnEmptyOrSingleton()) }
       else if (isSimpleLiteral) { SingletonTypeTree(literal()) }
       else if (in.token == USCORE) {
         val start = in.skipToken()
@@ -884,9 +884,9 @@ object Parsers {
       }
     }
 
-    /** A refinement on an empty tree or a TypeOf type tree. */
-    def refinementOnEmptyOrTypeOf(): Tree = {
-      if (!isStatSeqEnd && !isDclIntro) TypeOfTypeTree(expr1())
+    /** A refinement on an empty tree or a singleton type tree. */
+    def refinementOnEmptyOrSingleton(): Tree = {
+      if (!isStatSeqEnd && !isDclIntro) SingletonTypeTree(expr1())
       else RefinedTypeTree(EmptyTree, refineStatSeq())
     }
 

--- a/compiler/src/dotty/tools/dotc/printing/DecompilerPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/DecompilerPrinter.scala
@@ -76,6 +76,6 @@ class DecompilerPrinter(_ctx: Context) extends RefinedPrinter(_ctx) {
   override protected def typeApplyText[T >: Untyped](tree: TypeApply[T]): Text = {
     if (tree.symbol eq defn.QuotedExpr_apply) "'"
     else if (tree.symbol eq defn.QuotedType_apply) "'[" ~ toTextGlobal(tree.args, ", ") ~ "]"
-    else super.typeApplyText(tree)
+    else super.typeApplyText(tree.fun, tree.args)
   }
 }

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -141,8 +141,6 @@ class PlainPrinter(_ctx: Context) extends Printer {
         ParamRefNameString(tp) ~ ".type"
       case tp: TypeParamRef =>
         ParamRefNameString(tp) ~ lambdaHash(tp.binder)
-      case tp: TypeOf =>
-        "{ " ~ toTextLocal(tp.tree) ~ " }"
       case tp: SingletonType =>
         toTextLocal(tp.underlying) ~ "(" ~ toTextRef(tp) ~ ")"
       case AppliedType(tycon, args) =>
@@ -185,6 +183,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
           (Str(" => ") provided !tp.resultType.isInstanceOf[MethodType]) ~
           toTextGlobal(tp.resultType)
         }
+      case tp: TypeOf =>
+        "{ " ~ toTextLocal(tp.tree) ~ " }"
       case AnnotatedType(tpe, annot) =>
         toTextLocal(tpe) ~ " " ~ toText(annot)
       case tp: TypeVar =>

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -485,9 +485,12 @@ class PlainPrinter(_ctx: Context) extends Printer {
     val nodeName = tree.productPrefix
     val elems =
       Text(tree.productIterator.map(toTextElem).toList, ", ")
-    val tpSuffix =
+    val tpSuffix: Text =
       if (ctx.settings.XprintTypes.value && tree.hasType)
-        " | " ~ toText(tree.typeOpt)
+        tree.typeOpt match {
+          case tp: TypeOf if tp.tree.tpe eq tp => " | <idem>"
+          case tp => " | " ~ toText(tree.typeOpt)
+        }
       else
         Text()
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -141,6 +141,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
         ParamRefNameString(tp) ~ ".type"
       case tp: TypeParamRef =>
         ParamRefNameString(tp) ~ lambdaHash(tp.binder)
+      case tp: TypeOf =>
+        "{ " ~ toTextLocal(tp.tree) ~ " }"
       case tp: SingletonType =>
         toTextLocal(tp.underlying) ~ "(" ~ toTextRef(tp) ~ ")"
       case AppliedType(tycon, args) =>

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -149,7 +149,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case tp: TypeParamRef =>
         ParamRefNameString(tp) ~ lambdaHash(tp.binder)
       case tp: SingletonType =>
-        toTextLocal(tp.underlying) ~ "(" ~ toTextRef(tp) ~ ")"
+        if (isInTypeOf)
+          toTextRef(tp)
+        else
+          toTextLocal(tp.underlying) ~ "(" ~ toTextRef(tp) ~ ")"
       case AppliedType(tycon, args) =>
         (toTextLocal(tycon) ~ "[" ~ Text(args map argText, ", ") ~ "]").close
       case tp: RefinedType =>
@@ -190,11 +193,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
           (Str(" => ") provided !tp.resultType.isInstanceOf[MethodType]) ~
           toTextGlobal(tp.resultType)
         }
-      case tp @ TypeOf(underlyingTp, tree) =>
-        val underlying: Text =
-          if (ctx.settings.XprintTypes.value) " <: " ~ toText(underlyingTp)
-          else Text()
-        "{ " ~ inTypeOf { toTextLocal(tree) } ~ underlying ~ " }"
+      case TypeOf(underlyingTp, _) =>
+        "{ ... <: " ~ toText(underlyingTp) ~ " }"
       case AnnotatedType(tpe, annot) =>
         toTextLocal(tpe) ~ " " ~ toText(annot)
       case tp: TypeVar =>

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -498,7 +498,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
     val tpSuffix: Text =
       if (ctx.settings.XprintTypes.value && tree.hasType && !isInTypeOf)
         tree.typeOpt match {
-          case tp: TypeOf if tp.tree eq tree => " | <idem>"
+          case tp: TypeOf => " | <idem>"
           case tp => " | " ~ toText(tree.typeOpt)
         }
       else

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -18,11 +18,11 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected[this] implicit def ctx: Context = _ctx.addMode(Mode.Printing)
 
   private[this] var openRecs: List[RecType] = Nil
-  protected[this] var isInTypeOf: Boolean = true
+  protected[this] var isInTypeOf: Boolean = false
 
   protected final def inTypeOf(op: => Text): Text = {
     val saved = isInTypeOf
-    isInTypeOf = false
+    isInTypeOf = true
     try { op } finally { isInTypeOf = saved }
   }
 

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -372,8 +372,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case TypeTree() =>
         typeText(toText(tree.typeOpt))
       case SingletonTypeTree(ref) =>
-        toTextLocal(ref) ~ "." ~ keywordStr("type")
-      // TODO case TypeOfTypeTree =>
+        "{ " ~ toTextLocal(ref) ~ " }"
       case AndTypeTree(l, r) =>
         changePrec(AndPrec) { toText(l) ~ " & " ~ toText(r) }
       case OrTypeTree(l, r) =>

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -373,6 +373,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         typeText(toText(tree.typeOpt))
       case SingletonTypeTree(ref) =>
         toTextLocal(ref) ~ "." ~ keywordStr("type")
+      // TODO case TypeOfTypeTree =>
       case AndTypeTree(l, r) =>
         changePrec(AndPrec) { toText(l) ~ " & " ~ toText(r) }
       case OrTypeTree(l, r) =>

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -38,6 +38,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   /** A stack of enclosing DefDef, TypeDef, or ClassDef, or ModuleDefs nodes */
   private[this] var enclosingDef: untpd.Tree = untpd.EmptyTree
   private[this] var myCtx: Context = super.ctx
+  private[this] var printTypeOfTree: Boolean = true
   private[this] var printPos = ctx.settings.YprintPos.value
   private[this] val printLines = ctx.settings.printLines.value
 
@@ -552,7 +553,16 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
               ExprType(tp.widen)
             case _ => tp.widen
           })
-        case _: TypeOf => "<idem>"
+        case TypeOf(tpe, tree) =>
+          if (printTypeOfTree)
+            try {
+              // Only print 1 level of TypeOf; breaks the type→tree→type loop
+              printTypeOfTree = false
+              toText(tree)
+            } finally {
+              printTypeOfTree = true
+            }
+          else toText(tpe)
         case tp => toText(tp)
       }
       if (!suppressTypes)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -527,7 +527,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     var txt = toTextCore(tree)
 
     def suppressTypes =
-      tree.isType || tree.isDef || // don't print types of types or defs
+      tree.isType || isInTypeOf || tree.isDef || // don't print types of types or defs
       homogenizedView && ctx.mode.is(Mode.Pattern)
         // When comparing pickled info, disregard types of patterns.
         // The reason is that GADT matching can rewrite types of pattern trees
@@ -553,16 +553,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
               ExprType(tp.widen)
             case _ => tp.widen
           })
-        case TypeOf(tpe, tree) =>
-          if (printTypeOfTree)
-            try {
-              // Only print 1 level of TypeOf; breaks the type→tree→type loop
-              printTypeOfTree = false
-              toText(tree)
-            } finally {
-              printTypeOfTree = true
-            }
-          else toText(tpe)
+        case tp: TypeOf if tp.tree eq tree => "<idem>"
         case tp => toText(tp)
       }
       if (!suppressTypes)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -573,7 +573,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
               ExprType(tp.widen)
             case _ => tp.widen
           })
-        case tp: TypeOf if tp.tree eq tree => "<idem>"
+        case tp: TypeOf => "<idem>"
         case tp => toText(tp)
       }
       if (!suppressTypes)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -38,7 +38,6 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   /** A stack of enclosing DefDef, TypeDef, or ClassDef, or ModuleDefs nodes */
   private[this] var enclosingDef: untpd.Tree = untpd.EmptyTree
   private[this] var myCtx: Context = super.ctx
-  private[this] var printTypeOfTree: Boolean = true
   private[this] var printPos = ctx.settings.YprintPos.value
   private[this] val printLines = ctx.settings.printLines.value
 

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -273,7 +273,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
         case tree: TypeTree =>
           tree.withType(
             tree.tpe match {
-              case AnnotatedType(tpe, annot) => AnnotatedType(tpe, transformAnnot(annot))
+              case tpe: AnnotatedType => tpe.derivedAnnotatedType(tpe.parent, transformAnnot(tpe.annot))
               case tpe => tpe
             }
           )

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -499,6 +499,9 @@ object TreeChecker {
         case tp: TypeVar =>
           assert(tp.isInstantiated, s"Uninstantiated type variable: ${tp.show}, tree = ${tree.show}")
           apply(tp.underlying)
+        case tp: TypeOf =>
+          apply(tp.underlyingTp)
+          mapOver(tp)
         case _ =>
           mapOver(tp)
       }

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -500,7 +500,7 @@ object TreeChecker {
           assert(tp.isInstantiated, s"Uninstantiated type variable: ${tp.show}")
           apply(tp.underlying)
         case tp: TypeOf =>
-          assert(tp.tree.tpe eq NoType, s"A TypeOf's tree's type should point back to the TypeOf: $tp")
+          assert(tp.tree.tpe eq NoType, s"See note in TypeOf.apply")
           apply(tp.underlyingTp)
           mapOver(tp)
         case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -486,7 +486,7 @@ object TreeChecker {
   /** - Check that TypeParamRefs and MethodParams refer to an enclosing type.
    *  - Check that all type variables are instantiated.
    */
-  def checkNoOrphans(tp0: Type, tree: untpd.Tree = untpd.EmptyTree)(implicit ctx: Context) = new TypeMap() {
+  def checkNoOrphans(tp0: Type)(implicit ctx: Context) = new TypeMap() {
     val definedBinders = new java.util.IdentityHashMap[Type, Any]
     def apply(tp: Type): Type = {
       tp match {
@@ -495,11 +495,12 @@ object TreeChecker {
           mapOver(tp)
           definedBinders.remove(tp)
         case tp: ParamRef =>
-          assert(definedBinders.get(tp.binder) != null, s"orphan param: ${tp.show}, hash of binder = ${System.identityHashCode(tp.binder)}, tree = ${tree.show}, type = $tp0")
+          assert(definedBinders.get(tp.binder) != null, s"orphan param: ${tp.show}, hash of binder = ${System.identityHashCode(tp.binder)}, type = $tp0")
         case tp: TypeVar =>
-          assert(tp.isInstantiated, s"Uninstantiated type variable: ${tp.show}, tree = ${tree.show}")
+          assert(tp.isInstantiated, s"Uninstantiated type variable: ${tp.show}")
           apply(tp.underlying)
         case tp: TypeOf =>
+          assert(tp.tree.tpe eq tp, s"A TypeOf's tree's type should point back to the TypeOf: $tp\n\tshow: ${tp.show}")
           apply(tp.underlyingTp)
           mapOver(tp)
         case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -500,7 +500,7 @@ object TreeChecker {
           assert(tp.isInstantiated, s"Uninstantiated type variable: ${tp.show}")
           apply(tp.underlying)
         case tp: TypeOf =>
-          assert(tp.tree.tpe eq tp, s"A TypeOf's tree's type should point back to the TypeOf: $tp\n\tshow: ${tp.show}")
+          assert(tp.tree.tpe eq NoType, s"A TypeOf's tree's type should point back to the TypeOf: $tp")
           apply(tp.underlyingTp)
           mapOver(tp)
         case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -484,6 +484,12 @@ trait TypeAssigner {
   def assignType(tree: untpd.SingletonTypeTree, ref: Tree)(implicit ctx: Context) =
     tree.withType(ref.tpe)
 
+  def assignType(tree: untpd.TypeOfTypeTree, ref: Tree)(implicit ctx: Context) = {
+    val typeOf = TypeOf(ref, ref.tpe)
+    ref.withTypeUnchecked(typeOf)
+    tree.withType(typeOf)
+  }
+
   def assignType(tree: untpd.AndTypeTree, left: Tree, right: Tree)(implicit ctx: Context) =
     tree.withType(AndType(left.tpe, right.tpe))
 

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -459,8 +459,13 @@ trait TypeAssigner {
   def assignType(tree: untpd.Inlined, bindings: List[Tree], expansion: Tree)(implicit ctx: Context) =
     tree.withType(avoidingType(expansion, bindings))
 
-  def assignType(tree: untpd.If, thenp: Tree, elsep: Tree)(implicit ctx: Context) =
-    tree.withType(thenp.tpe | elsep.tpe)
+  def assignType(tree: untpd.If, thenp: Tree, elsep: Tree)(implicit ctx: Context) = {
+    val underlying = thenp.tpe | elsep.tpe
+    if (ctx.owner.isTransitivelyTransparent)
+      tree.withType(TypeOf.fromUntyped(tree, underlying))
+    else
+      tree.withType(underlying)
+  }
 
   def assignType(tree: untpd.Closure, meth: Tree, target: Tree)(implicit ctx: Context) =
     tree.withType(
@@ -470,8 +475,13 @@ trait TypeAssigner {
   def assignType(tree: untpd.CaseDef, body: Tree)(implicit ctx: Context) =
     tree.withType(body.tpe)
 
-  def assignType(tree: untpd.Match, cases: List[CaseDef])(implicit ctx: Context) =
-    tree.withType(ctx.typeComparer.lub(cases.tpes))
+  def assignType(tree: untpd.Match, cases: List[CaseDef])(implicit ctx: Context) = {
+    val underlying = ctx.typeComparer.lub(cases.tpes)
+    if (ctx.owner.isTransitivelyTransparent)
+      tree.withType(TypeOf.fromUntyped(tree, underlying))
+    else
+      tree.withType(underlying)
+  }
 
   def assignType(tree: untpd.Return)(implicit ctx: Context) =
     tree.withType(defn.NothingType)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -481,13 +481,13 @@ trait TypeAssigner {
     tree.withType(ownType)
   }
 
-  def assignType(tree: untpd.SingletonTypeTree, ref: Tree)(implicit ctx: Context) =
-    tree.withType(ref.tpe)
-
-  def assignType(tree: untpd.TypeOfTypeTree, ref: Tree)(implicit ctx: Context) = {
-    val typeOf = TypeOf(ref, ref.tpe)
-    ref.withTypeUnchecked(typeOf)
-    tree.withType(typeOf)
+  def assignType(tree: untpd.SingletonTypeTree, ref: Tree)(implicit ctx: Context) = {
+    val tp = ref match {
+      case _: TypeApply | _: Apply | _: If | _: Match => TypeOf(ref, ref.tpe)
+      case _: Literal | _: Ident | _: Select | _: Block => ref.tpe
+      case _ => throw new AssertionError(i"Tree $ref is not a valid reference for a singleton type tree.")
+    }
+    tree.withType(tp)
   }
 
   def assignType(tree: untpd.AndTypeTree, left: Tree, right: Tree)(implicit ctx: Context) =

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -490,9 +490,13 @@ trait TypeAssigner {
 
   def assignType(tree: untpd.SingletonTypeTree, ref: Tree)(implicit ctx: Context) = {
     val tp = ref match {
-      case _: TypeApply | _: Apply | _: If | _: Match => TypeOf(ref, ref.tpe)
       case _: Literal | _: Ident | _: Select | _: Block => ref.tpe
-      case _ => throw new AssertionError(i"Tree $ref is not a valid reference for a singleton type tree.")
+      case _ =>
+        if (TypeOf.isLegalTopLevelTree(ref))
+          if (ref.tpe.isInstanceOf[TypeOf]) ref.tpe
+          else TypeOf(ref, ref.tpe)
+        else
+          throw new AssertionError(i"Tree $ref is not a valid reference for a singleton type tree.")
     }
     tree.withType(tp)
   }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -368,7 +368,7 @@ trait TypeAssigner {
           val tpe =
             if (fntpe.isResultDependent) safeSubstParams(fntpe.resultType, fntpe.paramRefs, args.tpes)
             else fntpe.resultType
-          if (fn.symbol.isTransparentMethod) TypeOf.fromUntyped(tree, tpe)
+          if (fn.symbol.isTransparentMethod) TypeOf.fromUntyped(tpe, tree)
           else tpe
         } else
           errorType(i"wrong number of arguments at ${ctx.phase.prev} for $fntpe: ${fn.tpe}, expected: ${fntpe.paramInfos.length}, found: ${args.length}", tree.pos)
@@ -429,7 +429,7 @@ trait TypeAssigner {
           val argTypes = args.tpes
           if (sameLength(argTypes, paramNames)) {
             val tpe = pt.instantiate(argTypes)
-            if (fn.symbol.isTransparentMethod) TypeOf.fromUntyped(tree, tpe)
+            if (fn.symbol.isTransparentMethod) TypeOf.fromUntyped(tpe, tree)
             else tpe
           }
           else wrongNumberOfTypeArgs(fn.tpe, pt.typeParams, args, tree.pos)
@@ -462,7 +462,7 @@ trait TypeAssigner {
   def assignType(tree: untpd.If, thenp: Tree, elsep: Tree)(implicit ctx: Context) = {
     val underlying = thenp.tpe | elsep.tpe
     if (ctx.owner.isTransitivelyTransparent)
-      tree.withType(TypeOf.fromUntyped(tree, underlying))
+      tree.withType(TypeOf.fromUntyped(underlying, tree))
     else
       tree.withType(underlying)
   }
@@ -478,7 +478,7 @@ trait TypeAssigner {
   def assignType(tree: untpd.Match, cases: List[CaseDef])(implicit ctx: Context) = {
     val underlying = ctx.typeComparer.lub(cases.tpes)
     if (ctx.owner.isTransitivelyTransparent)
-      tree.withType(TypeOf.fromUntyped(tree, underlying))
+      tree.withType(TypeOf.fromUntyped(underlying, tree))
     else
       tree.withType(underlying)
   }
@@ -504,7 +504,7 @@ trait TypeAssigner {
       case _ =>
         if (TypeOf.isLegalTopLevelTree(ref))
           if (ref.tpe.isInstanceOf[TypeOf]) ref.tpe
-          else TypeOf(ref, ref.tpe)
+          else TypeOf(ref.tpe, ref)
         else
           throw new AssertionError(i"Tree $ref is not a valid reference for a singleton type tree.")
     }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -500,7 +500,7 @@ trait TypeAssigner {
 
   def assignType(tree: untpd.SingletonTypeTree, ref: Tree)(implicit ctx: Context) = {
     val tp = ref match {
-      case _: Literal | _: Ident | _: Select | _: Block => ref.tpe
+      case _: Literal | _: Ident | _: Select | _: Block | _: This | _: Super => ref.tpe
       case _ =>
         if (TypeOf.isLegalTopLevelTree(ref))
           if (ref.tpe.isInstanceOf[TypeOf])

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -368,7 +368,7 @@ trait TypeAssigner {
           val tpe =
             if (fntpe.isResultDependent) safeSubstParams(fntpe.resultType, fntpe.paramRefs, args.tpes)
             else fntpe.resultType
-          if (fn.symbol.isTransparentMethod) TypeOf.fromUntyped(tpe, tree)
+          if (fn.symbol.isTransparentMethod) TypeOf(tpe, tree)
           else tpe
         } else
           errorType(i"wrong number of arguments at ${ctx.phase.prev} for $fntpe: ${fn.tpe}, expected: ${fntpe.paramInfos.length}, found: ${args.length}", tree.pos)
@@ -429,7 +429,7 @@ trait TypeAssigner {
           val argTypes = args.tpes
           if (sameLength(argTypes, paramNames)) {
             val tpe = pt.instantiate(argTypes)
-            if (fn.symbol.isTransparentMethod) TypeOf.fromUntyped(tpe, tree)
+            if (fn.symbol.isTransparentMethod) TypeOf(tpe, tree)
             else tpe
           }
           else wrongNumberOfTypeArgs(fn.tpe, pt.typeParams, args, tree.pos)
@@ -462,7 +462,7 @@ trait TypeAssigner {
   def assignType(tree: untpd.If, thenp: Tree, elsep: Tree)(implicit ctx: Context) = {
     val underlying = thenp.tpe | elsep.tpe
     if (ctx.owner.isTransitivelyTransparent)
-      tree.withType(TypeOf.fromUntyped(underlying, tree))
+      tree.withType(TypeOf(underlying, tree))
     else
       tree.withType(underlying)
   }
@@ -478,7 +478,7 @@ trait TypeAssigner {
   def assignType(tree: untpd.Match, cases: List[CaseDef])(implicit ctx: Context) = {
     val underlying = ctx.typeComparer.lub(cases.tpes)
     if (ctx.owner.isTransitivelyTransparent)
-      tree.withType(TypeOf.fromUntyped(underlying, tree))
+      tree.withType(TypeOf(underlying, tree))
     else
       tree.withType(underlying)
   }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -503,8 +503,10 @@ trait TypeAssigner {
       case _: Literal | _: Ident | _: Select | _: Block => ref.tpe
       case _ =>
         if (TypeOf.isLegalTopLevelTree(ref))
-          if (ref.tpe.isInstanceOf[TypeOf]) ref.tpe
-          else TypeOf(ref.tpe, ref)
+          if (ref.tpe.isInstanceOf[TypeOf])
+            ref.tpe
+          else
+            errorType(i"Non-sensical singleton-type expression: $ref", ref.pos)
         else
           throw new AssertionError(i"Tree $ref is not a valid reference for a singleton type tree.")
     }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1175,6 +1175,18 @@ class Typer extends Namer
     assignType(cpy.SingletonTypeTree(tree)(ref1), ref1)
   }
 
+  def typedTypeOfTypeTree(tree: untpd.TypeOfTypeTree)(implicit ctx: Context): TypeOfTypeTree = track("typedTypeOfTypeTree") {
+    val ref1 = typedExpr(tree.ref)
+    ref1 match {
+      case _: Apply | _: If | _: Match | _: Block | _: Ident | _: Select | _: Literal =>
+        // Ident, Select & Literal are also available in the alternative syntax,
+        // that is a.type, a.b.type, 1. For now we treat them differently
+        // depending on the syntax.
+      case tree => ctx.error(s"$tree is not a valid singleton type.", ref1.pos)
+    }
+    assignType(cpy.TypeOfTypeTree(tree)(ref1), ref1)
+  }
+
   def typedAndTypeTree(tree: untpd.AndTypeTree)(implicit ctx: Context): AndTypeTree = track("typedAndTypeTree") {
     val left1 = checkSimpleKinded(typed(tree.left))
     val right1 = checkSimpleKinded(typed(tree.right))
@@ -1810,6 +1822,7 @@ class Typer extends Namer
           case tree: untpd.Inlined => typedInlined(tree, pt)
           case tree: untpd.TypeTree => typedTypeTree(tree, pt)
           case tree: untpd.SingletonTypeTree => typedSingletonTypeTree(tree)
+          case tree: untpd.TypeOfTypeTree => typedTypeOfTypeTree(tree)
           case tree: untpd.AndTypeTree => typedAndTypeTree(tree)
           case tree: untpd.OrTypeTree => typedOrTypeTree(tree)
           case tree: untpd.RefinedTypeTree => typedRefinedTypeTree(tree)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1171,20 +1171,9 @@ class Typer extends Namer
 
   def typedSingletonTypeTree(tree: untpd.SingletonTypeTree)(implicit ctx: Context): SingletonTypeTree = track("typedSingletonTypeTree") {
     val ref1 = typedExpr(tree.ref)
-    checkStable(ref1.tpe, tree.pos)
+    // TODO: Discuss stability requirements of singleton type trees and potentially reenable check
+    // checkStable(ref1.tpe, tree.pos)
     assignType(cpy.SingletonTypeTree(tree)(ref1), ref1)
-  }
-
-  def typedTypeOfTypeTree(tree: untpd.TypeOfTypeTree)(implicit ctx: Context): TypeOfTypeTree = track("typedTypeOfTypeTree") {
-    val ref1 = typedExpr(tree.ref)
-    ref1 match {
-      case _: Apply | _: If | _: Match | _: Block | _: Ident | _: Select | _: Literal =>
-        // Ident, Select & Literal are also available in the alternative syntax,
-        // that is a.type, a.b.type, 1. For now we treat them differently
-        // depending on the syntax.
-      case tree => ctx.error(s"$tree is not a valid singleton type.", ref1.pos)
-    }
-    assignType(cpy.TypeOfTypeTree(tree)(ref1), ref1)
   }
 
   def typedAndTypeTree(tree: untpd.AndTypeTree)(implicit ctx: Context): AndTypeTree = track("typedAndTypeTree") {
@@ -1822,7 +1811,6 @@ class Typer extends Namer
           case tree: untpd.Inlined => typedInlined(tree, pt)
           case tree: untpd.TypeTree => typedTypeTree(tree, pt)
           case tree: untpd.SingletonTypeTree => typedSingletonTypeTree(tree)
-          case tree: untpd.TypeOfTypeTree => typedTypeOfTypeTree(tree)
           case tree: untpd.AndTypeTree => typedAndTypeTree(tree)
           case tree: untpd.OrTypeTree => typedOrTypeTree(tree)
           case tree: untpd.RefinedTypeTree => typedRefinedTypeTree(tree)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -707,10 +707,16 @@ class Typer extends Namer
   }
 
   def typedIf(tree: untpd.If, pt: Type)(implicit ctx: Context): Tree = track("typedIf") {
-    val cond1 = typed(tree.cond, defn.BooleanType)
+    val (condProto, thenProto, elseProto) =
+      pt match {
+        case TypeOf.If(c, t ,e) => (c, t, e)
+        case _ => (defn.BooleanType, pt.notApplied, pt.notApplied)
+      }
+
+    val cond1 = typed(tree.cond, condProto)
     val thenp2 :: elsep2 :: Nil = harmonic(harmonize) {
-      val thenp1 = typed(tree.thenp, pt.notApplied)
-      val elsep1 = typed(tree.elsep orElse (untpd.unitLiteral withPos tree.pos), pt.notApplied)
+      val thenp1 = typed(tree.thenp, thenProto)
+      val elsep1 = typed(tree.elsep orElse (untpd.unitLiteral withPos tree.pos), elseProto)
       thenp1 :: elsep1 :: Nil
     }
     assignType(cpy.If(tree)(cond1, thenp2, elsep2), thenp2, elsep2)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1186,7 +1186,7 @@ class Typer extends Namer
   }
 
   def typedSingletonTypeTree(tree: untpd.SingletonTypeTree)(implicit ctx: Context): SingletonTypeTree = track("typedSingletonTypeTree") {
-    val ref1 = typedExpr(tree.ref)
+    val ref1 = typedExpr(tree.ref)(ctx.fresh.setTree(tree))
     // TODO: Discuss stability requirements of singleton type trees and potentially reenable check
     // checkStable(ref1.tpe, tree.pos)
     assignType(cpy.SingletonTypeTree(tree)(ref1), ref1)

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -14,7 +14,7 @@ import dotc.core.Contexts.Context
 import dotc.{ CompilationUnit, Run }
 import dotc.core.Mode
 import dotc.core.Flags._
-import dotc.core.Types._
+import dotc.core.Types.{TypeOf => _, _}
 import dotc.core.StdNames._
 import dotc.core.Names.Name
 import dotc.core.NameOps._

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -137,6 +137,7 @@ SimpleType        ::=  SimpleType TypeArgs                                      
                     |  ‘(’ ArgTypes ‘)’                                         Tuple(ts)
                     |  ‘_’ TypeBounds
                     |  Refinement                                               RefinedTypeTree(EmptyTree, refinement)
+                    |  TypeOf                                                   TypeOfTypeTree(expr)
                     |  SimpleLiteral                                            SingletonTypeTree(l)
 ArgTypes          ::=  Type {‘,’ Type}
                     |  NamedTypeArg {‘,’ NamedTypeArg}
@@ -148,6 +149,7 @@ TypeArgs          ::=  ‘[’ ArgTypes ‘]’                                 
 NamedTypeArg      ::=  id ‘=’ Type                                              NamedArg(id, t)
 NamedTypeArgs     ::=  ‘[’ NamedTypeArg {‘,’ NamedTypeArg} ‘]’                  nts
 Refinement        ::=  ‘{’ [RefineDcl] {semi [RefineDcl]} ‘}’                   ds
+TypeOf            ::=  ‘{’ Expr1 ‘}’                                            expr
 TypeBounds        ::=  [‘>:’ Type] [‘<:’ Type] | INT                            TypeBoundsTree(lo, hi)
 TypeParamBounds   ::=  TypeBounds {‘<%’ Type} {‘:’ Type}                        ContextBounds(typeBounds, tps)
 ```

--- a/library/src/scala/annotation/internal/TypeOf.scala
+++ b/library/src/scala/annotation/internal/TypeOf.scala
@@ -1,0 +1,9 @@
+package scala.annotation.internal
+
+import scala.annotation.RefiningAnnotation
+
+/** An annotation used with AnnotatedTypes to capture a term-level expression's
+ *  type precisely.
+ *  @param tree A typed Tree.
+ */
+final class TypeOf(tree: Any) extends RefiningAnnotation

--- a/tests/neg/transparent.scala
+++ b/tests/neg/transparent.scala
@@ -4,7 +4,7 @@ object Invalid {
   f(1): {0}  // error
 
   val y: Int = ???
-  type YPlusOne = {y + 1}  // error
+  type YPlusOne = {y + 1}  // error: Non-sensical singleton-type expression: ...
 }
 
 // object SimpleEqs {

--- a/tests/neg/transparent.scala
+++ b/tests/neg/transparent.scala
@@ -7,6 +7,15 @@ object Invalid {
   type YPlusOne = {y + 1}  // error: Non-sensical singleton-type expression: ...
 }
 
+object PrivateLeaks {
+  transparent def foo(x: Any): { x } = x
+  class A {
+    private transparent def bar(i: Int): Int = i + 1
+    val a: { foo(bar(1)) } = foo(bar(1)) // error: non-private value a refers to private method bar
+                                         // in its type signature { PrivateLeaks.foo({ A.this.bar(1) }) }
+  }
+}
+
 // object SimpleEqs {
 //   val x = 1
 //   val y: {x} = x

--- a/tests/neg/transparent.scala
+++ b/tests/neg/transparent.scala
@@ -2,6 +2,9 @@ object Invalid {
   transparent def f(x: Int) = x + 1
   f(1): String  // error
   f(1): {0}  // error
+
+  val y: Int = ???
+  type YPlusOne = {y + 1}  // error
 }
 
 // object SimpleEqs {

--- a/tests/neg/transparent.scala
+++ b/tests/neg/transparent.scala
@@ -1,0 +1,31 @@
+object Invalid {
+  transparent def f(x: Int) = x + 1
+  f(1): String  // error
+  f(1): {0}  // error
+}
+
+// object SimpleEqs {
+//   val x = 1
+//   val y: {x} = x
+//   implicitly[{x + 1} =:= {y}]  // errror
+//   implicitly[{x + 1} =:= {y + 2}]  // errror
+//   implicitly[{x + 1} =:= {1 + y}]  // errror: TypeComparer doesn't know about commutativity
+
+//   val b = true
+//   implicitly[{b} =:= {b}]
+//   implicitly[{!b} =:= {!b}]
+//   implicitly[{!b} =:= {b}]  // errror
+// }
+
+
+// object Stability {
+//   def f1(x: Int): Int = x
+//   def f2(x: Int): {x} = x
+
+//   val x = 1
+//   implicitly[{f1(x)} =:= {x}]  // errror: f1 is not considered stable  // errror: f1's result type is not precise enough
+//   implicitly[{f1(x)} =:= {f1(x)}]  // errror: f1 is not considered stable  // errror: f1 is not considered stable
+//   implicitly[{f2(x)} =:= {x}]
+//   implicitly[{f2(x)} =:= {f2(x)}]
+//   implicitly[{f1(x)} =:= {f2(x)}]  // errror: f1 is not considered stable  // errror: f1's result type is not precise enough
+// }

--- a/tests/pos/transparent.scala
+++ b/tests/pos/transparent.scala
@@ -50,6 +50,34 @@ object Applied {
   val a: { foo2(true) } = foo2(true)
 }
 
+object Approx1 {
+  transparent def foo(x: Any): { x } = x
+  class A {
+    transparent def bar(i: Int): Int = i + 1
+    val v: { bar(foo(1)) } = bar(foo(1))
+  }
+
+  val a = new A {}
+  val b: { a.bar(foo(1)) } = a.v
+
+  var c = new A {}
+  val d: { c.bar(foo(1)) } = c.v
+}
+
+object Approx2 {
+  transparent def foo(x: Any): { x } = x
+  class A {
+    transparent def bar(i: Int): Int = i + 1
+    val v: { foo(bar(1)) } = foo(bar(1))
+  }
+
+  val a = new A {}
+  val b: { foo(a.bar(1)) }= a.v
+
+  val c = new A {}
+  val d: { foo(c.bar(1)) }= c.v
+}
+
 // object AvoidLocalRefs {
 //   type Id[T] = T
 

--- a/tests/pos/transparent.scala
+++ b/tests/pos/transparent.scala
@@ -1,0 +1,121 @@
+object SimpleEqs {
+  val x = 1
+  val y: {x} = x
+  // val z: {y + 1} = y + 1
+
+  type YPlusOne = {y + 1}
+}
+
+object Call {
+  transparent def foo(x: Int) = 123
+  foo(1): { foo(1) }
+  foo(1): Int
+}
+
+object ITE {
+  transparent def foo1(b: Boolean) = {
+    val res = if (b)
+      1
+    else
+      2
+    identity[{ if (b) 1 else 2 }](res)
+    res
+  }
+
+  transparent def foo2(b: Boolean): { if (b) 1 else 2 } =
+    if (b) 1 else 2
+
+  // Postponed until we can beta reduce
+  // foo(true):  { if(true) 1 else 2 }
+  // foo(false): { if(false) 1 else 2 }
+  // var b: Boolean = true
+  // foo(b): { if(b) 1 else 2 }
+}
+
+object Match {
+  transparent def foo1(b: Boolean) = {
+    val res = b match {
+      case true => 1
+      case false => 2
+    }
+    identity[{ b match { case true => 1; case false => 2 } }](res)
+    res
+  }
+
+  transparent def foo(b: Boolean): { b match { case true => 1; case false => 2 } } =
+    b match { case true => 1; case false => 2 }
+}
+
+// object AvoidLocalRefs {
+//   type Id[T] = T
+
+//   val x = 1
+//   def y = { val a: {x} = x; val t: Id[{a + 1}] = a + 1; t }
+//   def z: {x + 1} = { val a: {x} = x; val t: Id[{a + 1}] = a + 1; t }
+
+//   { val a = 0; a + 1 }
+//   { val a = 0; 1 + a }
+// }
+
+
+// object Bounds {
+//   @annotation.implicitNotFound(msg = "Cannot prove that ${B} holds.")
+//   sealed abstract class P[B <: Boolean](val b: B)
+//   private[this] val prop_singleton = new P[true](true) {}
+//   object P {
+//     def assume(b: Boolean): P[b.type] = prop_singleton.asInstanceOf[P[b.type]]
+//   }
+
+//   def if_(cond: Boolean): (implicit (ev: P[cond.type]) => Unit) => Unit =
+//     thn => if (cond) thn(P.assume(cond))
+
+
+//   // Bounds-checked
+
+//   def index(k: Int)(implicit ev: P[{k >= 0}]): Int = k
+
+//   def run(i: Int) =
+//     if_(i >= 0) {
+//       index(i)
+//     }
+
+
+//   // Boxed value with a predicate
+
+//   class PredBox[T, B <: Boolean](val v: T)(val p: P[B])
+//   object PredBox {
+//     def apply[T, B <: Boolean](v: T)(implicit ev: P[B]) = new PredBox[T, B](v)(ev)
+//   }
+
+//   def run2(i: Int) =
+//     if_(i != 0) {
+//       PredBox[Int, {i != 0}](i)
+//     }
+// }
+
+
+// object ArithmeticIdentities {
+//   type SInt = Int & Singleton
+
+//   class DecomposeHelper[V <: SInt](val v: V) {
+//     import DecomposeHelper._
+//     def asSumOf[X <: SInt, Y <: SInt](x: X, y: Y)(implicit ev: {v} =:= {x + y}): SumOf[{x}, {y}] = SumOf(x, y)(ev(v))
+//   }
+
+//   object DecomposeHelper {
+//     /* Axioms */
+//     sealed trait Decomposition[V <: SInt]
+//     case class SumOf[X <: SInt, Y <: SInt](x: X, y: Y)(val v: {x + y}) extends Decomposition[{v}] {
+//       def commuted: SumOf[Y, X] = SumOf(y, x)(v.asInstanceOf[{y + x}])
+//     }
+//   }
+
+//   implicit def toDecomposeHelper[V <: Int](v: V): DecomposeHelper[v.type] = new DecomposeHelper(v)
+
+
+//   // Let's "show" that x + 1 == 1 + x
+
+//   val x = 123
+//   (x + 1).asSumOf(x, 1).v: {x + 1}
+//   (x + 1).asSumOf(x, 1).commuted.v: {1 + x}
+// }

--- a/tests/pos/transparent.scala
+++ b/tests/pos/transparent.scala
@@ -1,9 +1,9 @@
-object SimpleEqs {
+/*object SimpleEqs {
   val x = 1
   val y: {x} = x
   // val z: {y + 1} = y + 1
 
-  type YPlusOne = {y + 1}
+  // type YPlusOne = {y + 1}
 }
 
 object Call {
@@ -44,12 +44,13 @@ object Match {
 
   transparent def foo(b: Boolean): { b match { case true => 1; case false => 2 } } =
     b match { case true => 1; case false => 2 }
-}
+}*/
 
 object Applied {
   transparent def foo1(b: Boolean) = ???
-  transparent def foo2(b: Boolean): { foo1(b) } = foo1(b)
-  val a: { foo2(true) } = foo2(true)
+  // transparent def foo2(b: Boolean): { foo1(b) } = foo1(b)
+  transparent def foo2(b: Boolean) = foo1(b)
+  // val a: { foo2(true) } = foo2(true)
 }
 
 // object AvoidLocalRefs {

--- a/tests/pos/transparent.scala
+++ b/tests/pos/transparent.scala
@@ -46,6 +46,12 @@ object Match {
     b match { case true => 1; case false => 2 }
 }
 
+object Applied {
+  transparent def foo1(b: Boolean) = ???
+  transparent def foo2(b: Boolean): { foo1(b) } = foo1(b)
+  val a: { foo2(true) } = foo2(true)
+}
+
 // object AvoidLocalRefs {
 //   type Id[T] = T
 

--- a/tests/pos/transparent.scala
+++ b/tests/pos/transparent.scala
@@ -1,9 +1,7 @@
-/*object SimpleEqs {
+object SimpleEqs {
   val x = 1
   val y: {x} = x
   // val z: {y + 1} = y + 1
-
-  // type YPlusOne = {y + 1}
 }
 
 object Call {
@@ -44,13 +42,12 @@ object Match {
 
   transparent def foo(b: Boolean): { b match { case true => 1; case false => 2 } } =
     b match { case true => 1; case false => 2 }
-}*/
+}
 
 object Applied {
   transparent def foo1(b: Boolean) = ???
-  // transparent def foo2(b: Boolean): { foo1(b) } = foo1(b)
-  transparent def foo2(b: Boolean) = foo1(b)
-  // val a: { foo2(true) } = foo2(true)
+  transparent def foo2(b: Boolean): { foo1(b) } = foo1(b)
+  val a: { foo2(true) } = foo2(true)
 }
 
 // object AvoidLocalRefs {


### PR DESCRIPTION
We ended up working around several limitations of the `AnnotatedType` infrastructure:

* First and foremost, we discovered that a custom kind of equality is required to (type-) compare `TypeOf`s: After typing some trees may have been transformed, e.g. certain `Ident`s into `TypeTree`s, which in turn breaks the "naive" tree equality employed by AnnotatedType. Instead, we defined equality of `TypeOf` based on the top-level tree node: E.g., two `TypeOf`s with `if` as their top-level tree are equal if the types of their `cond`s, `thenb`s and `elseb`s are.

* Similarly, we discovered that special handling is required for `TypeOf` in `TypeMap`s. One crucial aspect is that `AnnotatedType` would map over the underlying type and the tree separately, potentially causing the two to go out of sync. As an example, consider the following:

```
Let a: Boolean, b: Int, c: Int

                     .substBy(c.type, b.type)

{ if (a) b else c } +-------------------------> { if (a) b else b }

         +                                               +
         |                                               |
         |  .underlying                                  |  .underlying
         |                                               |
         v           .substBy(c.type, b.type)            v

b.type | c.type     +------------X------------>  b.type | b.type
= Int | Int                (doesn't hold)        = b.type
= Int
```

In other words, we can't rely on the lower path, so we instead propose to always derive the underlying type from the `TypeOf`'s mapped-over tree (the top path).

* Similarly, without special handling, implementations of `TreeAccumulator` would actually ignore annotations. For instance, the dependency status of `TermLambda`s wouldn't take a `TypeOf`'s tree into account, thus skipping some of the necessary substitutions. This can be fixed, of course, by making TreeAccumulator (or all of its relevant implementations) aware of annotations. Either way, making `AnnotatedType` work out of the box would require some additional investigation.