### PR TITLE
[Proof of concept] Polymorphic function types

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -90,6 +90,7 @@ class Compiler {
     List(new Erasure) ::             // Rewrite types to JVM model, erasing all type parameters, abstract types and refinements.
     List(new ElimErasedValueType,    // Expand erased value types to their underlying implmementation types
          new VCElideAllocations,     // Peep-hole optimization to eliminate unnecessary value class allocations
+         new ElimPolyFunction,       // Rewrite PolyFunction subclasses to FunctionN subclasses
          new TailRec,                // Rewrite tail recursion to loops
          new Mixin,                  // Expand trait fields and trait initializers
          new LazyVals,               // Expand lazy vals

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1430,22 +1430,35 @@ object desugar {
     }
 
     val desugared = tree match {
-      case PolyFunction(targs, body) if (ctx.mode.is(Mode.Type)) =>
-        // Desugar [T_1, ..., T_M] -> (P_1, ..., P_N) => R
-        // Into    scala.PolyFunction { def apply[T_1, ..., T_M](x$1: P_1, ..., x$N: P_N): R }
-        val Function(vargs, resType) = body
+      case PolyFunction(targs, body) =>
+        val Function(vargs, res) = body
         // TODO: Figure out if we need a `PolyFunctionWithMods` instead.
         val mods = body match {
           case body: FunctionWithMods => body.mods
           case _ => untpd.EmptyModifiers
         }
+        val polyFunctionTpt = ref(defn.PolyFunctionType)
         val applyTParams = targs.asInstanceOf[List[TypeDef]]
-        val applyVParams = vargs.zipWithIndex.map { case (p, n) =>
-          makeSyntheticParameter(n + 1, p).withAddedFlags(mods.flags)
+        if (ctx.mode.is(Mode.Type)) {
+          // Desugar [T_1, ..., T_M] -> (P_1, ..., P_N) => R
+          // Into    scala.PolyFunction { def apply[T_1, ..., T_M](x$1: P_1, ..., x$N: P_N): R }
+
+          val applyVParams = vargs.zipWithIndex.map { case (p, n) =>
+            makeSyntheticParameter(n + 1, p).withAddedFlags(mods.flags)
+          }
+          RefinedTypeTree(polyFunctionTpt, List(
+            DefDef(nme.apply, applyTParams, List(applyVParams), res, EmptyTree)
+          ))
+        } else {
+          // Desugar [T_1, ..., T_M] -> (x_1: P_1, ..., x_N: P_N) => body
+          // Into    new scala.PolyFunction { def apply[T_1, ..., T_M](x_1: P_1, ..., x_N: P_N) = body }
+
+          val applyVParams = vargs.asInstanceOf[List[ValDef]]
+            .map(varg => varg.withAddedFlags(mods.flags | Param))
+          New(Template(emptyConstructor, List(polyFunctionTpt), Nil, EmptyValDef,
+            List(DefDef(nme.apply, applyTParams, List(applyVParams), TypeTree(), res))
+          ))
         }
-        RefinedTypeTree(ref(defn.PolyFunctionType), List(
-          DefDef(nme.apply, applyTParams, List(applyVParams), resType, EmptyTree)
-        ))
       case SymbolLit(str) =>
         Literal(Constant(scala.Symbol(str)))
       case InterpolatedString(id, segments) =>

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1448,7 +1448,7 @@ object desugar {
               ))
         }
       case _ =>
-        EmptyTree //may happen for erroneous input
+        EmptyTree // may happen for erroneous input. An error will already have been reported.
     }
 
     // begin desugar

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1448,7 +1448,9 @@ object desugar {
               ))
         }
       case _ =>
-        EmptyTree // may happen for erroneous input. An error will already have been reported.
+        // may happen for erroneous input. An error will already have been reported.
+        assert(ctx.reporter.errorsReported)
+        EmptyTree
     }
 
     // begin desugar

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -331,6 +331,7 @@ object Trees {
     }
 
     def withFlags(flags: FlagSet): ThisTree[Untyped] = withMods(untpd.Modifiers(flags))
+    def withAddedFlags(flags: FlagSet): ThisTree[Untyped] = withMods(rawMods | flags)
 
     def setComment(comment: Option[Comment]): this.type = {
       comment.map(putAttachment(DocComment, _))

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -72,6 +72,12 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   class FunctionWithMods(args: List[Tree], body: Tree, val mods: Modifiers)(implicit @constructorOnly src: SourceFile)
     extends Function(args, body)
 
+  /** A polymorphic function type */
+  case class PolyFunction(targs: List[Tree], body: Tree)(implicit @constructorOnly src: SourceFile) extends Tree {
+    override def isTerm = body.isTerm
+    override def isType = body.isType
+  }
+
   /** A function created from a wildcard expression
    *  @param  placeholderParams  a list of definitions of synthetic parameters.
    *  @param  body               the function body where wildcards are replaced by
@@ -491,6 +497,10 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       case tree: Function if (args eq tree.args) && (body eq tree.body) => tree
       case _ => finalize(tree, untpd.Function(args, body)(tree.source))
     }
+    def PolyFunction(tree: Tree)(targs: List[Tree], body: Tree)(implicit ctx: Context): Tree = tree match {
+      case tree: PolyFunction if (targs eq tree.targs) && (body eq tree.body) => tree
+      case _ => finalize(tree, untpd.PolyFunction(targs, body)(tree.source))
+    }
     def InfixOp(tree: Tree)(left: Tree, op: Ident, right: Tree)(implicit ctx: Context): Tree = tree match {
       case tree: InfixOp if (left eq tree.left) && (op eq tree.op) && (right eq tree.right) => tree
       case _ => finalize(tree, untpd.InfixOp(left, op, right)(tree.source))
@@ -579,6 +589,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
         cpy.InterpolatedString(tree)(id, segments.mapConserve(transform))
       case Function(args, body) =>
         cpy.Function(tree)(transform(args), transform(body))
+      case PolyFunction(targs, body) =>
+        cpy.PolyFunction(tree)(transform(targs), transform(body))
       case InfixOp(left, op, right) =>
         cpy.InfixOp(tree)(transform(left), op, transform(right))
       case PostfixOp(od, op) =>
@@ -634,6 +646,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
         this(x, segments)
       case Function(args, body) =>
         this(this(x, args), body)
+      case PolyFunction(targs, body) =>
+        this(this(x, targs), body)
       case InfixOp(left, op, right) =>
         this(this(this(x, left), op), right)
       case PostfixOp(od, op) =>

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1038,8 +1038,6 @@ class Definitions {
   lazy val PolyFunctionClass = ctx.requiredClass("scala.PolyFunction")
   def PolyFunctionType = PolyFunctionClass.typeRef
 
-  private lazy val TupleTypes: Set[TypeRef] = TupleType.toSet
-
   /** If `cls` is a class in the scala package, its name, otherwise EmptyTypeName */
   def scalaClassName(cls: Symbol)(implicit ctx: Context): TypeName =
     if (cls.isClass && cls.owner == ScalaPackageClass) cls.asClass.name else EmptyTypeName

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1035,6 +1035,11 @@ class Definitions {
     if (n <= MaxImplementedFunctionArity && (!isContextual || ctx.erasedTypes) && !isErased) ImplementedFunctionType(n)
     else FunctionClass(n, isContextual, isErased).typeRef
 
+  lazy val PolyFunctionClass = ctx.requiredClass("scala.PolyFunction")
+  def PolyFunctionType = PolyFunctionClass.typeRef
+
+  private lazy val TupleTypes: Set[TypeRef] = TupleType.toSet
+
   /** If `cls` is a class in the scala package, its name, otherwise EmptyTypeName */
   def scalaClassName(cls: Symbol)(implicit ctx: Context): TypeName =
     if (cls.isClass && cls.owner == ScalaPackageClass) cls.asClass.name else EmptyTypeName

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -383,6 +383,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
    *      - otherwise, if T is a type parameter coming from Java, []Object
    *      - otherwise, Object
    *   - For a term ref p.x, the type <noprefix> # x.
+   *   - For a refined type scala.PolyFunction { def apply[...](x_1, ..., x_N): R }, scala.FunctionN
    *   - For a typeref scala.Any, scala.AnyVal, scala.Singleton, scala.Tuple, or scala.*: : |java.lang.Object|
    *   - For a typeref scala.Unit, |scala.runtime.BoxedUnit|.
    *   - For a typeref scala.FunctionN, where N > MaxImplementedFunctionArity, scala.FunctionXXL
@@ -429,6 +430,12 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
       SuperType(this(thistpe), this(supertpe))
     case ExprType(rt) =>
       defn.FunctionType(0)
+    case RefinedType(parent, nme.apply, refinedInfo) if parent.typeSymbol eq defn.PolyFunctionClass =>
+      assert(refinedInfo.isInstanceOf[PolyType])
+      val res = refinedInfo.resultType
+      val paramss = res.paramNamess
+      assert(paramss.length == 1)
+      this(defn.FunctionType(paramss.head.length, isContextual = res.isImplicitMethod, isErased = res.isErasedMethod))
     case tp: TypeProxy =>
       this(tp.underlying)
     case AndType(tp1, tp2) =>

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -605,6 +605,8 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
       case tp: TypeVar =>
         val inst = tp.instanceOpt
         if (inst.exists) sigName(inst) else tpnme.Uninstantiated
+      case RefinedType(parent, nme.apply, refinedInfo) if parent.typeSymbol eq defn.PolyFunctionClass =>
+        sigName(defn.FunctionType(refinedInfo.resultType.paramNamess.head.length))
       case tp: TypeProxy =>
         sigName(tp.underlying)
       case _: ErrorType | WildcardType | NoType =>

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -605,8 +605,11 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
       case tp: TypeVar =>
         val inst = tp.instanceOpt
         if (inst.exists) sigName(inst) else tpnme.Uninstantiated
-      case RefinedType(parent, nme.apply, refinedInfo) if parent.typeSymbol eq defn.PolyFunctionClass =>
-        sigName(defn.FunctionType(refinedInfo.resultType.paramNamess.head.length))
+      case tp @ RefinedType(parent, nme.apply, _) if parent.typeSymbol eq defn.PolyFunctionClass => 
+        // we need this case rather than falling through to the default
+        // because RefinedTypes <: TypeProxy and it would be caught by
+        // the case immediately below
+        sigName(this(tp))
       case tp: TypeProxy =>
         sigName(tp.underlying)
       case _: ErrorType | WildcardType | NoType =>

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -209,10 +209,13 @@ object TypeErasure {
           einfo
       case einfo =>
         // Erase the parameters of `apply` in subclasses of PolyFunction
+        // Preserve PolyFunction argument types to support PolyFunctions with
+        // PolyFunction arguments
         if (sym.is(TermParam) && sym.owner.name == nme.apply
-            && sym.owner.owner.derivesFrom(defn.PolyFunctionClass))
+            && sym.owner.owner.derivesFrom(defn.PolyFunctionClass)
+            && !(tp <:< defn.PolyFunctionType)) {
           defn.ObjectType
-        else
+        } else
           einfo
     }
   }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3196,15 +3196,7 @@ object Types {
 
 
     def computeSignature(implicit ctx: Context): Signature = {
-      def polyFunctionSignature(tp: Type): Type = tp match {
-        case RefinedType(parent, nme.apply, refinedInfo) if parent.typeSymbol eq defn.PolyFunctionClass =>
-          val res = refinedInfo.resultType
-          val paramss = res.paramNamess
-          defn.FunctionType(paramss.head.length)
-        case _ => tp
-      }
-
-      val params = if (isErasedMethod) Nil else paramInfos.mapConserve(polyFunctionSignature)
+      val params = if (isErasedMethod) Nil else paramInfos
       resultSignature.prepend(params, isJavaMethod)
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3194,8 +3194,17 @@ object Types {
       companion.eq(ContextualMethodType) ||
       companion.eq(ErasedContextualMethodType)
 
+
     def computeSignature(implicit ctx: Context): Signature = {
-      val params = if (isErasedMethod) Nil else paramInfos
+      def polyFunctionSignature(tp: Type): Type = tp match {
+        case RefinedType(parent, nme.apply, refinedInfo) if parent.typeSymbol eq defn.PolyFunctionClass =>
+          val res = refinedInfo.resultType
+          val paramss = res.paramNamess
+          defn.FunctionType(paramss.head.length)
+        case _ => tp
+      }
+
+      val params = if (isErasedMethod) Nil else paramInfos.mapConserve(polyFunctionSignature)
       resultSignature.prepend(params, isJavaMethod)
     }
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -850,9 +850,13 @@ object Parsers {
      */
     def toplevelTyp(): Tree = rejectWildcardType(typ())
 
-    /** Type        ::=  FunTypeMods FunArgTypes `=>' Type
-     *                |  HkTypeParamClause `=>>' Type
+    /** Type        ::=  FunType
+     *                |  HkTypeParamClause ‘=>>’ Type
+     *                |  MatchType
      *                |  InfixType
+     *  FunType     ::=  { 'erased' | 'given' } (MonoFunType | PolyFunType)
+     *  MonoFunType ::=  FunArgTypes ‘=>’ Type
+     *  PolyFunType ::=  HKTypeParamClause '=>' Type
      *  FunArgTypes ::=  InfixType
      *                |  `(' [ FunArgType {`,' FunArgType } ] `)'
      *                |  '(' TypedFunParam {',' TypedFunParam } ')'
@@ -1234,6 +1238,7 @@ object Parsers {
      *                      |  `throw' Expr
      *                      |  `return' [Expr]
      *                      |  ForExpr
+     *                      |  HkTypeParamClause ‘=>’ Expr
      *                      |  [SimpleExpr `.'] id `=' Expr
      *                      |  SimpleExpr1 ArgumentExprs `=' Expr
      *                      |  Expr2

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1325,6 +1325,11 @@ object Parsers {
         atSpan(in.skipToken()) { Return(if (isExprIntro) expr() else EmptyTree, EmptyTree) }
       case FOR =>
         forExpr()
+      case LBRACKET =>
+        val start = in.offset
+        val tparams = typeParamClause(ParamOwner.TypeParam)
+        assert(isIdent && in.name.toString == "->", "Expected `->`")
+        atSpan(start, in.skipToken())(PolyFunction(tparams, expr()))
       case _ =>
         if (isIdent(nme.inline) && !in.inModifierPosition() && in.lookaheadIn(canStartExpressionTokens)) {
           val start = in.skipToken()

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -924,6 +924,8 @@ object Parsers {
           val tparams = typeParamClause(ParamOwner.TypeParam)
           if (in.token == TLARROW)
             atSpan(start, in.skipToken())(LambdaTypeTree(tparams, toplevelTyp()))
+          else if (isIdent && in.name.toString == "->")
+            atSpan(start, in.skipToken())(PolyFunction(tparams, toplevelTyp()))
           else { accept(TLARROW); typ() }
         }
         else infixType()

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -558,6 +558,11 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
 		  (keywordText("erased ") provided isErased) ~
           argsText ~ " => " ~ toText(body)
         }
+      case PolyFunction(targs, body) =>
+        val targsText = "[" ~ Text(targs.map((arg: Tree) => toText(arg)), ", ") ~ "]"
+        changePrec(GlobalPrec) {
+          targsText ~ " -> " ~ toText(body)
+        }
       case InfixOp(l, op, r) =>
         val opPrec = parsing.precedence(op.name)
         changePrec(opPrec) { toText(l) ~ " " ~ toText(op) ~ " " ~ toText(r) }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -561,7 +561,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case PolyFunction(targs, body) =>
         val targsText = "[" ~ Text(targs.map((arg: Tree) => toText(arg)), ", ") ~ "]"
         changePrec(GlobalPrec) {
-          targsText ~ " -> " ~ toText(body)
+          targsText ~ " => " ~ toText(body)
         }
       case InfixOp(l, op, r) =>
         val opPrec = parsing.precedence(op.name)

--- a/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
@@ -83,14 +83,19 @@ class ElimErasedValueType extends MiniPhase with InfoTransformer { thisPhase =>
       override def matches(sym1: Symbol, sym2: Symbol) =
         sym1.signature == sym2.signature
     }
+
     def checkNoConflict(sym1: Symbol, sym2: Symbol, info: Type)(implicit ctx: Context): Unit = {
       val site = root.thisType
       val info1 = site.memberInfo(sym1)
       val info2 = site.memberInfo(sym2)
-      if (!info1.matchesLoosely(info2) &&
-          !(sym1.name == nme.apply &&
-            (sym1.owner.derivesFrom(defn.PolyFunctionClass) ||
-             sym2.owner.derivesFrom(defn.PolyFunctionClass))))
+      // PolyFunction apply methods will be eliminated later during
+      // ElimPolyFunction, so we let them pass here.
+      def bothPolyApply =
+        sym1.name == nme.apply &&
+        (sym1.owner.derivesFrom(defn.PolyFunctionClass) ||
+         sym2.owner.derivesFrom(defn.PolyFunctionClass))
+
+      if (!info1.matchesLoosely(info2) && !bothPolyApply)
         ctx.error(DoubleDefinition(sym1, sym2, root), root.sourcePos)
     }
     val earlyCtx = ctx.withPhase(ctx.elimRepeatedPhase.next)

--- a/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
@@ -87,7 +87,10 @@ class ElimErasedValueType extends MiniPhase with InfoTransformer { thisPhase =>
       val site = root.thisType
       val info1 = site.memberInfo(sym1)
       val info2 = site.memberInfo(sym2)
-      if (!info1.matchesLoosely(info2))
+      if (!info1.matchesLoosely(info2) &&
+          !(sym1.name == nme.apply &&
+            (sym1.owner.derivesFrom(defn.PolyFunctionClass) ||
+             sym2.owner.derivesFrom(defn.PolyFunctionClass))))
         ctx.error(DoubleDefinition(sym1, sym2, root), root.sourcePos)
     }
     val earlyCtx = ctx.withPhase(ctx.elimRepeatedPhase.next)

--- a/compiler/src/dotty/tools/dotc/transform/ElimPolyFunction.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimPolyFunction.scala
@@ -1,0 +1,68 @@
+package dotty.tools.dotc
+package transform
+
+import ast.{Trees, tpd}
+import core._, core.Decorators._
+import MegaPhase._, Phases.Phase
+import Types._, Contexts._, Constants._, Names._, NameOps._, Flags._, DenotTransformers._
+import SymDenotations._, Symbols._, StdNames._, Annotations._, Trees._, Scopes._, Denotations._
+import TypeErasure.ErasedValueType, ValueClasses._
+
+/** This phase rewrite PolyFunction subclasses to FunctionN subclasses
+ *
+ *      class Foo extends PolyFunction {
+ *          def apply(x_1: P_1, ..., x_N: P_N): R = rhs
+ *      }
+ *   becomes:
+ *      class Foo extends FunctionN {
+ *          def apply(x_1: P_1, ..., x_N: P_N): R = rhs
+ *      }
+ */
+class ElimPolyFunction extends MiniPhase with DenotTransformer {
+
+  import tpd._
+
+  override def phaseName: String = ElimPolyFunction.name
+
+  override def runsAfter = Set(Erasure.name)
+
+  override def changesParents: Boolean = true // Replaces PolyFunction by FunctionN
+
+  override def transform(ref: SingleDenotation)(implicit ctx: Context) = ref match {
+    case ref: ClassDenotation if ref.symbol != defn.PolyFunctionClass && ref.derivesFrom(defn.PolyFunctionClass) =>
+      val cinfo = ref.classInfo
+      val newParent = functionTypeOfPoly(cinfo)
+      val newParents = cinfo.classParents.map(parent =>
+        if (parent.typeSymbol == defn.PolyFunctionClass)
+          newParent
+        else
+          parent
+      )
+      ref.copySymDenotation(info = cinfo.derivedClassInfo(classParents = newParents))
+    case _ =>
+      ref
+  }
+
+  def functionTypeOfPoly(cinfo: ClassInfo)(implicit ctx: Context): Type = {
+    val applyMeth = cinfo.decls.lookup(nme.apply).info
+    val arity = applyMeth.paramNamess.head.length
+    defn.FunctionType(arity)
+  }
+
+  override def transformTemplate(tree: Template)(implicit ctx: Context): Tree = {
+    val newParents = tree.parents.mapconserve(parent =>
+      if (parent.tpe.typeSymbol == defn.PolyFunctionClass) {
+        val cinfo = tree.symbol.owner.asClass.classInfo
+        tpd.TypeTree(functionTypeOfPoly(cinfo))
+      }
+      else
+        parent
+    )
+    cpy.Template(tree)(parents = newParents)
+  }
+}
+
+object ElimPolyFunction {
+  val name = "elimPolyFunction"
+}
+

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -54,7 +54,8 @@ trait TypeAssigner {
           required = EmptyFlagConjunction, excluded = Private)
           .suchThat(decl.matches(_))
       val inheritedInfo = inherited.info
-      if (inheritedInfo.exists &&
+      val isPolyFunctionApply = decl.name == nme.apply && (parent <:< defn.PolyFunctionType)
+      if (isPolyFunctionApply || inheritedInfo.exists &&
           decl.info.widenExpr <:< inheritedInfo.widenExpr &&
           !(inheritedInfo.widenExpr <:< decl.info.widenExpr)) {
         val r = RefinedType(parent, decl.name, decl.info)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1271,7 +1271,9 @@ class Typer extends Namer
       typr.println(s"adding refinement $refinement")
       checkRefinementNonCyclic(refinement, refineCls, seen)
       val rsym = refinement.symbol
-      if (rsym.info.isInstanceOf[PolyType] && rsym.allOverriddenSymbols.isEmpty)
+      val polymorphicRefinementAllowed =
+        tpt1.tpe.typeSymbol == defn.PolyFunctionClass && rsym.name == nme.apply
+      if (!polymorphicRefinementAllowed && rsym.info.isInstanceOf[PolyType] && rsym.allOverriddenSymbols.isEmpty)
         ctx.error(PolymorphicMethodMissingTypeInParent(rsym, tpt1.symbol), refinement.sourcePos)
 
       val member = refineCls.info.member(rsym.name)

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -139,10 +139,13 @@ ClassQualifier    ::=  ‘[’ id ‘]’
 
 ### Types
 ```ebnf
-Type              ::=  { ‘erased’ | ‘given’} FunArgTypes ‘=>’ Type              Function(ts, t)
-                    |  HkTypeParamClause ‘=>>’ Type                              TypeLambda(ps, t)
+Type              ::=  FunType
+                    |  HkTypeParamClause ‘=>>’ Type                             TypeLambda(ps, t)
                     |  MatchType
                     |  InfixType
+FunType           ::=  { 'erased' | 'given' } (MonoFunType | PolyFunType)
+MonoFunType       ::=  FunArgTypes ‘=>’ Type                                    Function(ts, t)
+PolyFunType       :: = HKTypeParamClause '=>' Type                              PolyFunction(ps, t)
 FunArgTypes       ::=  InfixType
                     |  ‘(’ [ FunArgType {‘,’ FunArgType } ] ‘)’
                     |  ‘(’ TypedFunParam {‘,’ TypedFunParam } ‘)’
@@ -195,6 +198,7 @@ Expr1             ::=  ‘if’ ‘(’ Expr ‘)’ {nl}
                     |  ‘throw’ Expr                                             Throw(expr)
                     |  ‘return’ [Expr]                                          Return(expr?)
                     |  ForExpr
+                    |  HkTypeParamClause ‘=>’ Expr                              PolyFunction(ts, expr)
                     |  [SimpleExpr ‘.’] id ‘=’ Expr                             Assign(expr, expr)
                     |  SimpleExpr1 ArgumentExprs ‘=’ Expr                       Assign(expr, expr)
                     |  Expr2

--- a/library/src/scala/PolyFunction.scala
+++ b/library/src/scala/PolyFunction.scala
@@ -1,0 +1,10 @@
+package scala
+
+/** Marker trait for polymorphic function types.
+ *
+ *  This is the only trait that can be refined with a polymorphic method,
+ *  as long as that method is called `apply`, e.g.:
+ *      PolyFunction { def apply[T_1, ..., T_M](x_1: P_1, ..., x_N: P_N): R }
+ *  This type will be erased to FunctionN.
+ */
+trait PolyFunction

--- a/tests/neg/bad-selftype.scala
+++ b/tests/neg/bad-selftype.scala
@@ -2,5 +2,5 @@ trait x0[T] { self: x0 => }           // error
 
 trait x1[T] { self: (=> String) => }  // error
 
-trait x2[T] { self: ([X] => X) => }   // error
+trait x2[T] { self: ([X] =>> X) => }   // error
 

--- a/tests/neg/i4373.scala
+++ b/tests/neg/i4373.scala
@@ -17,7 +17,7 @@ object Test {
   type T1 = _ // error
   type T2 = _[Int] // error
   type T3 = _ { type S } // error
-  type T4 = [X] => _ // error
+  type T4 = [X] =>> _ // error
 
   // Open questions:
   type T5 = TypeConstr[_ { type S }] // error

--- a/tests/neg/i6385a.scala
+++ b/tests/neg/i6385a.scala
@@ -7,5 +7,5 @@ object Test {
   def f[F[_]](x: Box[F]) = ???
   def db: Box[D] = ???
   def cb: Box[C] = db  // error
-  f[[X] => C[X]](db)   // error
+  f[[X] =>> C[X]](db)   // error
 }

--- a/tests/neg/polymorphic-functions.scala
+++ b/tests/neg/polymorphic-functions.scala
@@ -1,0 +1,5 @@
+object Test {
+  val pv0: [T] => List[T] = ???        // error
+  val pv1: Any = [T] => Nil            // error
+  val pv2: [T] => List[T] = [T] => Nil // error // error
+}

--- a/tests/run/polymorphic-functions.scala
+++ b/tests/run/polymorphic-functions.scala
@@ -4,9 +4,7 @@ object Test {
   }
 
   def main(args: Array[String]): Unit = {
-    val fun = new PolyFunction {
-      def apply[T <: AnyVal](x: List[T]): List[(T, T)] = x.map(e => (e, e))
-    }
+    val fun = [T <: AnyVal] -> (x: List[T]) => x.map(e => (e, e))
 
     assert(test1(fun) == List((1, 1), (2, 2), (3, 3)))
   }

--- a/tests/run/polymorphic-functions.scala
+++ b/tests/run/polymorphic-functions.scala
@@ -1,11 +1,14 @@
-object Test {
-  def test1(f: [T <: AnyVal] -> List[T] => List[(T, T)]) = {
-    f(List(1, 2, 3))
-  }
+object Test extends App {
+  // Types
+  type F0 = [T] => List[T] => Option[T]
+  type F1 = [F[_], G[_], T] => (F[T], F[T] => G[T]) => G[T]
 
-  def main(args: Array[String]): Unit = {
-    val fun = [T <: AnyVal] -> (x: List[T]) => x.map(e => (e, e))
+  // Terms
+  val t0 = [T] => (ts: List[T]) => ts.headOption
+  val t0a: F0 = t0
+  assert(t0(List(1, 2, 3)) == Some(1))
 
-    assert(test1(fun) == List((1, 1), (2, 2), (3, 3)))
-  }
+  val t1 = [F[_], G[_], T] => (ft: F[T], f: F[T] => G[T]) => f(ft)
+  val t1a: F1 = t1
+  assert(t1(List(1, 2, 3), (ts: List[Int]) => ts.headOption) == Some(1))
 }

--- a/tests/run/polymorphic-functions.scala
+++ b/tests/run/polymorphic-functions.scala
@@ -2,6 +2,8 @@ object Test extends App {
   // Types
   type F0 = [T] => List[T] => Option[T]
   type F1 = [F[_], G[_], T] => (F[T], F[T] => G[T]) => G[T]
+  type F11 = [F[_[_]], G[_[_]], T[_]] => (F[T], [U[_]] => F[U] => G[U]) => G[T]
+  type F2 = [T, U] => (T, U) => Either[T, U]
 
   // Terms
   val t0 = [T] => (ts: List[T]) => ts.headOption
@@ -11,4 +13,81 @@ object Test extends App {
   val t1 = [F[_], G[_], T] => (ft: F[T], f: F[T] => G[T]) => f(ft)
   val t1a: F1 = t1
   assert(t1(List(1, 2, 3), (ts: List[Int]) => ts.headOption) == Some(1))
+
+  val t11 = [F[_[_]], G[_[_]], T[_]] => (fl: F[T], f: [U[_]] => F[U] => G[U]) => f(fl)
+  val t11a: F11 = t11
+  case class C11[F[_]](is: F[Int])
+  case class D11[F[_]](is: F[Int])
+  assert(t11[F = C11](C11(List(1, 2, 3)), [U[_]] => (c: C11[U]) => D11(c.is)) == D11(List(1, 2, 3)))
+
+  val t2 = [T, U] => (t: T, u: U) => Left(t)
+  val t2a: F2 = t2
+  assert(t2(23, "foo") == Left(23))
+
+  // Polymorphic idenity
+  val pid = [T] => (t: T) => t
+
+  // Method with poly function argument
+  def m[T](f: [U] => U => U, t: T) = f(t)
+  val m0 = m(pid, 23)
+
+  // Constructor with poly function argument
+  class C[T](f: [U] => U => U, t: T) { val v: T = f(t) }
+  val c0 = new C(pid, 23)
+
+  // Function with poly function argument
+  val mf = (f: [U] => U => U, t: Int) => f(t)
+  val mf0 = mf(pid, 23)
+
+  // Poly function with poly function argument
+  val pf = [T] => (f: [U] => U => U, t: T) => f(t)
+  val pf0 = pf(pid, 23)
+
+  // Poly function with AnyVal arguments
+  val pf2 = [T] => (f: [U] => U => U, t: Int) => f(t)
+  val pf20 = pf2(pid, 23)
+
+  // Implment/override
+  val phd = [T] => (ts: List[T]) => ts.headOption
+
+  trait A {
+    val is: List[Int]
+    def m1(f: [T] => List[T] => Option[T]): Option[Int]
+    def m2(f: [T] => List[T] => Option[T]): Option[Int] = f(is)
+  }
+
+  class B(val is: List[Int]) extends A {
+    def m1(f: [T] => List[T] => Option[T]): Option[Int] = f(is)
+    override def m2(f: [T] => List[T] => Option[T]): Option[Int] = f(is)
+  }
+
+  assert(new B(List(1, 2, 3)).m1(phd) == Some(1))
+  assert(new B(List(1, 2, 3)).m2(phd) == Some(1))
+
+  // Overload
+  class O(is: List[Int]) {
+    def m(f: [T] => List[T] => Option[T]): (Option[Int], Boolean) = (f(is), true)
+    def m(f: [T] => (List[T], T) => Option[T]): (Option[Int], Boolean) = (is.headOption.flatMap(f(is, _)), false)
+  }
+
+  assert(new O(List(1, 2, 3)).m(phd) == (Some(1), true))
+  assert(new O(List(1, 2, 3)).m([T] => (ts: List[T], t: T) => Some(t)) == (Some(1), false))
+
+  // Dependent
+  trait Entry[V] { type Key; val key: Key ; val value: V }
+  def extractKey[V](e: Entry[V]): e.Key = e.key
+  val md = [V] => (e: Entry[V]) => extractKey(e)
+  val eis = new Entry[Int] { type Key = String ; val key = "foo" ; val value = 23 }
+  val v0 = md(eis)
+  val v0a: String = v0
+  assert(v0 == "foo")
+
+  // Contextual
+  trait Show[T] { def show(t: T): String }
+  implicit val si: Show[Int] =
+    new Show[Int] {
+      def show(t: Int): String = t.toString
+    }
+  val s = [T] => (t: T) => given (st: Show[T]) => st.show(t)
+  assert(s(23) == "23")
 }

--- a/tests/run/polymorphic-functions.scala
+++ b/tests/run/polymorphic-functions.scala
@@ -1,5 +1,5 @@
 object Test {
-  def test1(f: PolyFunction { def apply[T <: AnyVal](x: List[T]): List[(T, T)] }) = {
+  def test1(f: [T <: AnyVal] -> List[T] => List[(T, T)]) = {
     f(List(1, 2, 3))
   }
 

--- a/tests/run/polymorphic-functions.scala
+++ b/tests/run/polymorphic-functions.scala
@@ -1,0 +1,9 @@
+object Test {
+  def test1(f: PolyFunction { def apply[T <: AnyVal](x: List[T]): List[(T, T)] }) = {
+    f(List(1, 2, 3))
+  }
+
+  def main(args: Array[String]): Unit = {
+    //test1(...)
+  }
+}

--- a/tests/run/polymorphic-functions.scala
+++ b/tests/run/polymorphic-functions.scala
@@ -4,6 +4,10 @@ object Test {
   }
 
   def main(args: Array[String]): Unit = {
-    //test1(...)
+    val fun = new PolyFunction {
+      def apply[T <: AnyVal](x: List[T]): List[(T, T)] = x.map(e => (e, e))
+    }
+
+    assert(test1(fun) == List((1, 1), (2, 2), (3, 3)))
   }
 }


### PR DESCRIPTION
This is a sketch of how polymorphic function types could be implemented in Dotty, this PR adds types that look like:
```scala
[T <: AnyVal] -> List[T] => List[(T, T)]
```
and a way of writing values of these types:
```scala
val f = [T <: AnyVal] -> (x: List[T]) => x.map(e => (e, e))
```
Just like `P => R` has a method `def apply(x: A): B`, `[T] => P => R` has a method `def apply[T](x: P): R` (in fact, it doesn't have any other method). Behind the scene, this is erased to a regular `scala.FunctionN`, see the commit messages for more details.

This PR isn't complete, this is just a quick experiment done in a few hours. In particular, I haven't tried to work out how this interact with implicit/erased/dependent function types and SAM types. I also haven't tried to implement polymorphic eta-expansion yet, e.g. given:
```scala
def foo(x: [T] -> T => Option[T]): Unit
```
we'd like to be able to write:
```scala
foo(Some)
```
but for now you'll have to write:
```scala
foo([T] -> (x: T) => Some(x))
```