### PR TITLE
Add tasty reflect members for definitions

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/package.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/package.scala
@@ -1,6 +1,7 @@
 package dotty.tools.dotc
 
 import dotty.tools.dotc.ast.Trees.{Tree, Untyped}
+import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.core.Types.Type
 
@@ -9,8 +10,9 @@ package object tastyreflect {
   type PackageDefinition = PackageDefinitionImpl[Type]
 
   /** Represents the symbol of a definition in tree form */
-  case class PackageDefinitionImpl[-T >: Untyped] private[tastyreflect] (symbol: Symbol) extends Tree[T] {
+  case class PackageDefinitionImpl[-T >: Untyped] private[tastyreflect] (sym: Symbol) extends Tree[T] {
     type ThisTree[-T >: Untyped] = PackageDefinitionImpl[T]
+    override def denot(implicit ctx: Context) = sym.denot
   }
 
 }

--- a/tests/pos/tasty/definitions.scala
+++ b/tests/pos/tasty/definitions.scala
@@ -25,6 +25,7 @@ object definitions {
 // ------ Definitions ---------------------------------
 
   trait Definition {
+    def name: String
     def owner: Definition = ???
   }
 


### PR DESCRIPTION
1.  Make the ADTs look like case classes by adding members as extension methods as abstract decorators

We can access members of 
```scala
val vdef: ValDef = ...
val ValDef(name, _, _) = vdef
println(name)
```
With this addition we can also do
```scala
val vdef: ValDef = ...
println(vdef.name)
```

2. Factor `optionally` for optional trees
3. Rename arguments of decorators to give them more meaning