### PR TITLE
Refresh names inExpr.show

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/QuoteDecompiler.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuoteDecompiler.scala
@@ -8,6 +8,7 @@ import dotty.tools.dotc.core.Phases.Phase
 class QuoteDecompiler(output: tpd.Tree => Context => Unit) extends QuoteCompiler {
   override def phases: List[List[Phase]] = List(
     List(new QuotedFrontend(putInClass = false)), // Create class from Expr
+    List(new RefreshNames),
     List(new QuoteTreeOutput(output))
   )
 

--- a/compiler/src/dotty/tools/dotc/quoted/RefreshNames.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/RefreshNames.scala
@@ -1,0 +1,38 @@
+package dotty.tools.dotc.quoted
+
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.DenotTransformers.SymTransformer
+import dotty.tools.dotc.core.Flags._
+import dotty.tools.dotc.core.NameKinds.{NumberedInfo, UniqueName}
+import dotty.tools.dotc.core.SymDenotations.SymDenotation
+import dotty.tools.dotc.transform.MegaPhase.MiniPhase
+
+/** Refreshes local names starting from the second use of the name. Intended for readability of the pretty printed code. */
+class RefreshNames extends MiniPhase with SymTransformer {
+
+  def phaseName: String = "RefreshNames"
+
+  override def transformValDef(tree: tpd.ValDef)(implicit ctx: Context): tpd.Tree =
+    tpd.ValDef(tree.symbol.asTerm, tree.rhs)
+
+  override def transformDefDef(tree: tpd.DefDef)(implicit ctx: Context): tpd.Tree =
+    tpd.DefDef(tree.symbol.asTerm, tree.rhs)
+
+  override def transformTypeDef(tree: tpd.TypeDef)(implicit ctx: Context): tpd.Tree = {
+    val newTypeDef = tpd.TypeDef(tree.symbol.asType)
+    // keep rhs to keep `type T = ...` instead of `type T >: ... <: ...`
+    cpy.TypeDef(newTypeDef)(rhs = tree.rhs)
+  }
+
+  def transformSym(ref: SymDenotation)(implicit ctx: Context): SymDenotation = {
+    if (ref.is(Package) || ref.isClass || ref.owner != ctx.owner || ref.is(Label) || ref.is(Param)) ref
+    else {
+      val newName = UniqueName.fresh(ref.symbol.name.toTermName)
+      newName.info match {
+        case info: NumberedInfo if info.num == 1 => ref // Keep the first reference as is to avoid renaming if the code has no duplicated names
+        case _ => ref.copySymDenotation(name = if (ref.symbol.isType) newName.toTypeName else newName)
+      }
+    }
+  }
+}

--- a/tests/run-with-compiler/quote-run-2.check
+++ b/tests/run-with-compiler/quote-run-2.check
@@ -8,3 +8,14 @@
   val y: scala.Double = 5.0.*(5.0)
   y
 })
+{
+  val y: scala.Double = 5.0.*(5.0)
+  y.*({
+    val y$2: scala.Double = y.*(y)
+    y$2.*({
+      val y$3: scala.Double = y$2.*(y$2)
+      val y$4: scala.Double = y$3.*(y$3)
+      y$4
+    })
+  })
+}

--- a/tests/run-with-compiler/quote-run-2.scala
+++ b/tests/run-with-compiler/quote-run-2.scala
@@ -17,5 +17,6 @@ object Test {
     println(powerCode(1, '(5)).show)
     println(powerCode(2, '(5)).show)
     println(powerCode(3, '(5)).show)
+    println(powerCode(22, '(5)).show)
   }
 }


### PR DESCRIPTION
To print
```scala
val y$2: scala.Double = y.*(y)
y$2.*({
  val y$3: scala.Double = y$2.*(y$2)
  val y$4: scala.Double = y$3.*(y$3)
  ...
```

instead of

```scala
val y: scala.Double = y.*(y)
y.*({
  val y: scala.Double = y.*(y)
  val y: scala.Double = y.*(y)
  ...
```

This is useful in the presence of recursive quotes.