### PR TITLE
 Resolve SeqType based on the alias defined in scala package object

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -400,7 +400,15 @@ class Definitions {
       List(AnyClass.typeRef), EmptyScope)
   lazy val SingletonType: TypeRef = SingletonClass.typeRef
 
-  lazy val SeqType: TypeRef = ctx.requiredClassRef("scala.collection.Seq")
+  lazy val SeqType: TypeRef = {
+    // We load SeqType from the alias in scala package object
+    //  - in 2.12: scala.collection.Seq
+    //  - in 2.13: scala.collection.immutable.Seq
+    val alias = ctx.base.staticRef("scala.Seq".toTypeName).requiredSymbol(_.isAliasType)
+    alias.info.classSymbol.typeRef
+  }
+
+  // lazy val SeqType: TypeRef = ctx.requiredClassRef("scala.collection.Seq")
   def SeqClass(implicit ctx: Context) = SeqType.symbol.asClass
     lazy val Seq_applyR = SeqClass.requiredMethodRef(nme.apply)
     def Seq_apply(implicit ctx: Context) = Seq_applyR.symbol

--- a/tests/pos/repeatedArgs.scala
+++ b/tests/pos/repeatedArgs.scala
@@ -1,3 +1,15 @@
 object testRepeated {
- def foo = java.lang.System.out.format("%4$2s %3$2s %2$2s %1$2s", "a", "b", "c", "d")
+  def foo = java.lang.System.out.format("%4$2s %3$2s %2$2s %1$2s", "a", "b", "c", "d")
+
+  def bar(xs: Int*): Int = xs.length
+  def bat(xs: scala.Seq[Int]): Int = xs.length
+
+  def test(xs: List[Int]): Unit = {
+    bar(1, 2, 3)
+    bar(xs: _*)
+
+    val List(_, ys: _*) = xs
+    bar(ys: _*)
+    bat(ys)
+  }
 }


### PR DESCRIPTION
The goal of this PR is to be able to build the 2.13 standard library while still supporting scala 2.12