### PR TITLE
Resolve SeqType based on the alias defined in scala package object

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -401,7 +401,14 @@ class Definitions {
       List(AnyClass.typeRef), EmptyScope)
   lazy val SingletonType: TypeRef = SingletonClass.typeRef
 
-  lazy val SeqType: TypeRef = ctx.requiredClassRef("scala.collection.Seq")
+  lazy val SeqType: TypeRef = {
+    // We load SeqType from the alias in scala package object
+    //  - in 2.12: scala.collection.Seq
+    //  - in 2.13: scala.collection.immutable.Seq
+    val alias = ctx.base.staticRef("scala.Seq".toTypeName).requiredSymbol(_.isAliasType)
+    alias.info.classSymbol.typeRef
+  }
+
   def SeqClass(implicit ctx: Context) = SeqType.symbol.asClass
     lazy val Seq_applyR = SeqClass.requiredMethodRef(nme.apply)
     def Seq_apply(implicit ctx: Context) = Seq_applyR.symbol

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -405,8 +405,21 @@ class Definitions {
     // We load SeqType from the alias in scala package object
     //  - in 2.12: scala.collection.Seq
     //  - in 2.13: scala.collection.immutable.Seq
-    val alias = ctx.base.staticRef("scala.Seq".toTypeName).requiredSymbol(_.isAliasType)
-    alias.info.classSymbol.typeRef
+
+    // force to avoid cycles
+    // ctx.requiredClassRef("scala.collection.Seq").symbol.ensureCompleted()
+    // ctx.requiredClassRef("scala.collection.immutable.Seq").symbol.ensureCompleted()
+
+    // // Using type Seq[+A] = ...
+    // val alias = ctx.base.staticRef("scala.Seq".toTypeName).requiredSymbol(_.isAliasType)
+    // alias.info.classSymbol.typeRef
+
+    // Using val Seq = ...
+    val scalaSeq = ctx.base.staticRef("scala.Seq".toTermName)
+    val seqName = scalaSeq.info.resultType.termSymbol.fullName
+    ctx.requiredClassRef(seqName.toTypeName)
+
+    // ctx.requiredClassRef("scala.collection.Seq")
   }
 
   def SeqClass(implicit ctx: Context) = SeqType.symbol.asClass

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -71,7 +71,7 @@ object Implicits {
     /** The implicit references */
     def refs: List[ImplicitRef]
 
-    private var SingletonClass: ClassSymbol = null
+    private[this] var SingletonClass: ClassSymbol = null
 
     /** Widen type so that it is neither a singleton type nor a type that inherits from scala.Singleton. */
     private def widenSingleton(tp: Type)(implicit ctx: Context): Type = {

--- a/tests/pos/repeatedArgs.scala
+++ b/tests/pos/repeatedArgs.scala
@@ -1,3 +1,15 @@
 object testRepeated {
- def foo = java.lang.System.out.format("%4$2s %3$2s %2$2s %1$2s", "a", "b", "c", "d")
+  def foo = java.lang.System.out.format("%4$2s %3$2s %2$2s %1$2s", "a", "b", "c", "d")
+
+  def bar(xs: Int*): Int = xs.length
+  def bat(xs: scala.Seq[Int]): Int = xs.length
+
+  def test(xs: List[Int]): Unit = {
+    bar(1, 2, 3)
+    bar(xs: _*)
+
+    val List(_, ys: _*) = xs
+    bar(ys: _*)
+    bat(ys)
+  }
 }

--- a/tests/pos/seqtype-cycle/Test1.scala
+++ b/tests/pos/seqtype-cycle/Test1.scala
@@ -1,0 +1,3 @@
+class Test {
+  def bar = Array(1) // call to Array(_: Repeated)
+}

--- a/tests/pos/seqtype-cycle/Test2.scala
+++ b/tests/pos/seqtype-cycle/Test2.scala
@@ -1,5 +1,6 @@
 package object scala {
   type Throwable = java.lang.Throwable // needed for some reasons
 
-  type Seq[+A] = scala.Seq[A]
+  type Seq[+A] = scala.collection.Seq[A]
+  val Seq = scala.collection.Seq
 }

--- a/tests/pos/seqtype-cycle/Test2.scala
+++ b/tests/pos/seqtype-cycle/Test2.scala
@@ -1,0 +1,5 @@
+package object scala {
+  type Throwable = java.lang.Throwable // needed for some reasons
+
+  type Seq[+A] = scala.Seq[A]
+}

--- a/tests/pos/seqtype-cycle/Test3.scala
+++ b/tests/pos/seqtype-cycle/Test3.scala
@@ -1,0 +1,5 @@
+package scala
+
+trait Seq[@specialized(1, 2) A]
+
+class specialized(types: Int*) extends scala.annotation.StaticAnnotation

--- a/tests/pos/seqtype-cycle/Test3.scala
+++ b/tests/pos/seqtype-cycle/Test3.scala
@@ -1,5 +1,12 @@
 package scala
 
-trait Seq[@specialized(1, 2) A]
-
 class specialized(types: Int*) extends scala.annotation.StaticAnnotation
+
+package collection {
+  class Foo[@specialized(1, 2) A]
+
+  trait Seq[A] extends Foo[A]
+  object Seq extends SeqFactory[Seq]
+
+  trait SeqFactory[CC[X] <: Seq[X]]
+}


### PR DESCRIPTION
The goal of this PR is to be able to build the 2.13 standard library while still supporting scala 2.12