### PR TITLE
Simplify output directory handling

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -41,13 +41,9 @@ class GenBCode extends Phase {
 
   private[this] var myOutput: AbstractFile = _
 
-  protected def outputDir(implicit ctx: Context): AbstractFile = {
-    if (myOutput eq null) {
-      val path = Directory(ctx.settings.outputDir.value)
-      myOutput =
-        if (path.extension == "jar") JarArchive.create(path)
-        else new PlainDirectory(path)
-    }
+  private def outputDir(implicit ctx: Context): AbstractFile = {
+    if (myOutput eq null)
+      myOutput = ctx.settings.outputDir.value
     myOutput
   }
 

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc
 package config
 
 import java.io.File
-import dotty.tools.io.{ Directory, Path }
+import dotty.tools.io.{ Directory, PlainDirectory }
 
 import PathResolver.Defaults
 import rewrite.Rewrites
@@ -20,7 +20,8 @@ class ScalaSettings extends Settings.SettingGroup {
   val scansource = BooleanSetting("-scansource", "Scan source files to locate classes for which class-name != file-name")
 
   val classpath = PathSetting("-classpath", "Specify where to find user class files.", defaultClasspath) withAbbreviation "-cp"
-  val outputDir = PathSetting("-d", "directory|jar", "destination for generated classfiles.", ".")
+  val outputDir = OutputSetting("-d", "directory|jar", "destination for generated classfiles.",
+    new PlainDirectory(Directory(".")))
   val priorityclasspath = PathSetting("-priorityclasspath", "class path that takes precedence over all other paths (or testing only)", "")
 
   /** Other settings */

--- a/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
@@ -19,13 +19,13 @@ class DecompilationPrinter extends Phase {
   override def phaseName: String = "decompilationPrinter"
 
   override def run(implicit ctx: Context): Unit = {
-    val outputDir = ctx.settings.outputDir.value
-    if (outputDir == ".") printToOutput(System.out)
+    if (ctx.settings.outputDir.isDefault) printToOutput(System.out)
     else {
+      val outputDir = ctx.settings.outputDir.value
       var os: OutputStream = null
       var ps: PrintStream = null
       try {
-        os = File(outputDir + "/decompiled.scala").outputStream(append = true)
+        os = File(outputDir.fileNamed("decompiled.scala").path).outputStream(append = true)
         ps = new PrintStream(os)
         printToOutput(ps)
       } finally {

--- a/compiler/src/dotty/tools/dotc/decompiler/Main.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/Main.scala
@@ -12,9 +12,8 @@ import dotty.tools.dotc.core.Contexts._
 object Main extends dotc.Driver {
   override protected def newCompiler(implicit ctx: Context): dotc.Compiler = {
     assert(ctx.settings.fromTasty.value)
-    val outputDir = ctx.settings.outputDir.value
-    if (outputDir != ".")
-      Files.deleteIfExists(Paths.get(outputDir + "/decompiled.scala"))
+    if (!ctx.settings.outputDir.isDefault)
+      Files.deleteIfExists(ctx.settings.outputDir.value.fileNamed("decompiled.scala").jpath)
     new TASTYDecompiler
   }
 

--- a/compiler/src/dotty/tools/dotc/quoted/QuoteCompiler.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuoteCompiler.scala
@@ -25,23 +25,14 @@ import scala.quoted.{Expr, Type}
 /** Compiler that takes the contents of a quoted expression `expr` and produces
  *  a class file with `class ' { def apply: Object = expr }`.
  */
-class QuoteCompiler(directory: AbstractFile) extends Compiler {
+class QuoteCompiler extends Compiler {
   import tpd._
-
-  /** A GenBCode phase that outputs to a virtual directory */
-  private class ExprGenBCode extends GenBCode {
-    override def phaseName = "genBCode"
-    override def outputDir(implicit ctx: Context) = directory
-  }
 
   override protected def frontendPhases: List[List[Phase]] =
     List(List(new QuotedFrontend(putInClass = true)))
 
   override protected def picklerPhases: List[List[Phase]] =
     List(List(new ReifyQuotes))
-
-  override protected def backendPhases: List[List[Phase]] =
-    List(List(new ExprGenBCode))
 
   override def newRun(implicit ctx: Context): ExprRun = {
     reset()

--- a/compiler/src/dotty/tools/dotc/quoted/QuoteDecompiler.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuoteDecompiler.scala
@@ -5,7 +5,7 @@ import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Phases.Phase
 
 /** Compiler that takes the contents of a quoted expression (or type) and outputs it's tree. */
-class QuoteDecompiler(output: tpd.Tree => Context => Unit) extends QuoteCompiler(null) {
+class QuoteDecompiler(output: tpd.Tree => Context => Unit) extends QuoteCompiler {
   override def phases: List[List[Phase]] = List(
     List(new QuotedFrontend(putInClass = false)), // Create class from Expr
     List(new QuoteTreeOutput(output))

--- a/compiler/src/dotty/tools/dotc/quoted/QuoteDriver.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuoteDriver.scala
@@ -17,18 +17,19 @@ class QuoteDriver extends Driver {
   private[this] val contextBase: ContextBase = new ContextBase
 
   def run[T](expr: Expr[T], settings: ToolboxSettings): T = {
-    val (_, ctx: Context) = setup(settings.compilerArgs.toArray :+ "dummy.scala", initCtx.fresh)
-
     val outDir: AbstractFile = settings.outDir match {
       case Some(out) =>
         val dir = Directory(out)
         dir.createDirectory()
         new PlainDirectory(Directory(out))
       case None =>
-        new VirtualDirectory("(memory)", None)
+        new VirtualDirectory("<quote compilation output>")
     }
 
-    val driver = new QuoteCompiler(outDir)
+    val (_, ctx0: Context) = setup(settings.compilerArgs.toArray :+ "dummy.scala", initCtx.fresh)
+    val ctx = ctx0.fresh.setSetting(ctx0.settings.outputDir, outDir)
+
+    val driver = new QuoteCompiler
     driver.newRun(ctx).compileExpr(expr)
 
     val classLoader = new AbstractFileClassLoader(outDir, this.getClass.getClassLoader)

--- a/compiler/src/dotty/tools/io/VirtualDirectory.scala
+++ b/compiler/src/dotty/tools/io/VirtualDirectory.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable
  *
  * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
-class VirtualDirectory(val name: String, maybeContainer: Option[VirtualDirectory])
+class VirtualDirectory(val name: String, maybeContainer: Option[VirtualDirectory] = None)
 extends AbstractFile {
   def path: String =
     maybeContainer match {

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -22,8 +22,7 @@ import dotc.core.StdNames.str
  *       `ReplDriver#resetToInitial` is called, the accompanying instance of
  *       `Rendering` is no longer valid.
  */
-private[repl] class Rendering(compiler: ReplCompiler,
-                              parentClassLoader: Option[ClassLoader] = None) {
+private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None) {
 
   private[this] var myClassLoader: ClassLoader = _
 
@@ -37,7 +36,7 @@ private[repl] class Rendering(compiler: ReplCompiler,
         new java.net.URLClassLoader(compilerClasspath.toArray, classOf[ReplDriver].getClassLoader)
       }
 
-      myClassLoader = new AbstractFileClassLoader(compiler.directory, parent)
+      myClassLoader = new AbstractFileClassLoader(ctx.settings.outputDir.value, parent)
       // Set the current Java "context" class loader to this rendering class loader
       Thread.currentThread.setContextClassLoader(myClassLoader)
       myClassLoader

--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -28,20 +28,9 @@ import scala.collection.mutable
  *  in conjunction with a specialized class loader in order to load virtual
  *  classfiles.
  */
-class ReplCompiler(val directory: AbstractFile) extends Compiler {
-
-
-  /** A GenBCode phase that outputs to a virtual directory */
-  private class REPLGenBCode extends GenBCode {
-    override def phaseName = "genBCode"
-    override def outputDir(implicit ctx: Context) = directory
-  }
-
+class ReplCompiler extends Compiler {
   override protected def frontendPhases: List[List[Phase]] =
     Phases.replace(classOf[FrontEnd], _ => new REPLFrontEnd :: Nil, super.frontendPhases)
-
-  override protected def backendPhases: List[List[Phase]] =
-    List(new REPLGenBCode) :: Nil
 
   def newRun(initCtx: Context, objectIndex: Int) = new Run(this, initCtx) {
     override protected[this] def rootContext(implicit ctx: Context) =

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -80,17 +80,11 @@ class ReplDriver(settings: Array[String],
    */
   protected[this] def resetToInitial(): Unit = {
     rootCtx = initialCtx
-    val outDir: AbstractFile = {
-      if (rootCtx.settings.outputDir.isDefault(rootCtx))
-        new VirtualDirectory("(memory)", None)
-      else {
-        val path = Directory(rootCtx.settings.outputDir.value(rootCtx))
-        assert(path.isDirectory)
-        new PlainDirectory(path)
-      }
-    }
-    compiler = new ReplCompiler(outDir)
-    rendering = new Rendering(compiler, classLoader)
+    if (rootCtx.settings.outputDir.isDefault(rootCtx))
+      rootCtx = rootCtx.fresh
+        .setSetting(rootCtx.settings.outputDir, new VirtualDirectory("<REPL compilation output>"))
+    compiler = new ReplCompiler
+    rendering = new Rendering(classLoader)
   }
 
   private[this] var rootCtx: Context = _

--- a/compiler/test/dotty/tools/dotc/SettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/SettingsTests.scala
@@ -14,7 +14,7 @@ class SettingsTests {
     val options = Array("-d", "not_here")
     val reporter = Main.process(options)
     assertEquals(1, reporter.errorCount)
-    assertEquals("'not_here' does not exist or is not a directory", reporter.allErrors.head.message)
+    assertEquals("'not_here' does not exist or is not a directory or .jar file", reporter.allErrors.head.message)
   }
 
   @Test def jarOutput: Unit = {

--- a/compiler/test/dotty/tools/dotc/SimplifyTests.scala
+++ b/compiler/test/dotty/tools/dotc/SimplifyTests.scala
@@ -11,13 +11,9 @@ class SimplifyPosTests extends SimplifyTests(optimise = true)
 class SimplifyNegTests extends SimplifyTests(optimise = false)
 
 abstract class SimplifyTests(val optimise: Boolean) extends DottyBytecodeTest {
-  override protected def initializeCtx(c: FreshContext): Unit = {
-    super.initializeCtx(c)
-    if (optimise) {
-      val flags = Array("-optimise") // :+ "-Xprint:simplify"
-      val summary = CompilerCommand.distill(flags)(c)
-      c.setSettings(summary.sstate)
-    }
+  override def initCtx = {
+    val ctx0 = super.initCtx
+    ctx0.setSetting(ctx0.settings.optimise, optimise)
   }
 
   def check(source: String, expected: String, shared: String = ""): Unit = {


### PR DESCRIPTION
Store the outputDir setting as an AbstractFile instead of a String, this
way we can use a virtual output directory in the REPL just by changing
the setting instead of having to subclass GenBCode.