### PR TITLE
Only allow access to inline args at level 1

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -124,7 +124,7 @@ object Inliner {
         if needsAccessor(tree.symbol) && tree.isTerm && !tree.symbol.isConstructor =>
           val (refPart, targs, argss) = decomposeCall(tree)
           val qual = qualifier(refPart)
-          println(i"adding receiver passing inline accessor for $tree/$refPart -> (${qual.tpe}, $refPart: ${refPart.getClass}, [$targs%, %], ($argss%, %))")
+          inlining.println(i"adding receiver passing inline accessor for $tree/$refPart -> (${qual.tpe}, $refPart: ${refPart.getClass}, [$targs%, %], ($argss%, %))")
 
           // Need to dealias in order to cagtch all possible references to abstracted over types in
           // substitutions

--- a/docs/docs/reference/principled-meta-programming.md
+++ b/docs/docs/reference/principled-meta-programming.md
@@ -400,7 +400,7 @@ as follows:
    function) of type Boolean, Byte, Short, Int, Long, Float, Double,
    Char or String, it can be accessed in all contexts where the number
    of splices minus the number of quotes between use and definition
-   is 0.
+   is 1.
 
 ### Relationship with Staging
 

--- a/docs/docs/reference/principled-meta-programming.md
+++ b/docs/docs/reference/principled-meta-programming.md
@@ -400,7 +400,7 @@ as follows:
    function) of type Boolean, Byte, Short, Int, Long, Float, Double,
    Char or String, it can be accessed in all contexts where the number
    of splices minus the number of quotes between use and definition
-   is either 0 or 1.
+   is 0.
 
 ### Relationship with Staging
 

--- a/tests/neg/quote-macro-inline-args.scala
+++ b/tests/neg/quote-macro-inline-args.scala
@@ -1,0 +1,9 @@
+object Test {
+
+  inline def foo(inline x: Int): Int = ~{
+    if (x == 1) '(3)
+    else '(x) // error
+  }
+
+}
+

--- a/tests/run/i4455/Macro_1.scala
+++ b/tests/run/i4455/Macro_1.scala
@@ -1,8 +1,8 @@
 import scala.quoted._
 object Macros {
-  inline def foo(inline i: Int): Int = ~bar('(i))
+  inline def foo(inline i: Int): Int = ~bar(i.toExpr)
 
-  inline def foo2(inline i: Int): Int = ~bar('(i + 1))
+  inline def foo2(inline i: Int): Int = ~bar((i + 1).toExpr)
 
   def bar(x: Expr[Int]): Expr[Int] = x
 }


### PR DESCRIPTION
If it is needed at level 1 it can be explicitly lifted.
This simplifies the rules that users need to know and
the implementation of the phase.