### PR TITLE
Cook comment on empty classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1536,7 +1536,7 @@ class Typer extends Namer
 
       // Expand comments and type usecases if `-Ycook-comments` is set.
       if (ctx.settings.YcookComments.value) {
-        cookComments(body1.map(_.symbol), self1.symbol)(ctx.localContext(cdef, cls).setNewScope)
+        cookComments(cls :: body1.map(_.symbol), self1.symbol)(ctx.localContext(cdef, cls).setNewScope)
       }
 
       checkNoDoubleDeclaration(cls)

--- a/doc-tool/test/SimpleComments.scala
+++ b/doc-tool/test/SimpleComments.scala
@@ -1,10 +1,34 @@
 package dotty.tools
 package dottydoc
 
+import model.internal._
+
 import org.junit.Test
 import org.junit.Assert._
 
 class TestSimpleComments extends DottyDocTest {
+
+  @Test def cookCommentEmptyClass = {
+    val source =
+      """
+      |package scala
+      |
+      |/**
+      | * An empty trait: $Variable
+      | *
+      | * @define Variable foobar
+      | */
+      |trait Test""".stripMargin
+
+    checkSource(source) { packages =>
+      packages("scala") match {
+        case PackageImpl(_, _, _, List(trt), _, _, _, _) =>
+          assert(trt.comment.isDefined, "Lost comment in transformations")
+          assert(trt.comment.get.body.contains("An empty trait: foobar"))
+          assert(trt.name == "Test", s"Incorrect name after transform: ${trt.name}")
+      }
+    }
+  }
 
   @Test def simpleComment = {
     val source =


### PR DESCRIPTION
A class with an empty body wouldn't see its own comment cooked.