### PR TITLE
Improve usability of erased values

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -52,6 +52,8 @@ object CheckRealizable {
 
   def boundsRealizability(tp: Type)(implicit ctx: Context) =
     new CheckRealizable().boundsRealizability(tp)
+
+  private val LateInitialized = Lazy | Erased,
 }
 
 /** Compute realizability status */
@@ -66,7 +68,7 @@ class CheckRealizable(implicit ctx: Context) {
   /** Is symbol's definitition a lazy or erased val?
    *  (note we exclude modules here, because their realizability is ensured separately)
    */
-  private def isLateInitialized(sym: Symbol) = sym.is(Lazy | Erased, butNot = Module)
+  private def isLateInitialized(sym: Symbol) = sym.is(LateInitialized, butNot = Module)
 
   /** The realizability status of given type `tp`*/
   def realizability(tp: Type): Realizability = tp.dealias match {

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -63,10 +63,10 @@ class CheckRealizable(implicit ctx: Context) {
    */
   private val checkedFields: mutable.Set[Symbol] = mutable.LinkedHashSet[Symbol]()
 
-  /** Is symbol's definitition a lazy val?
+  /** Is symbol's definitition a lazy or erased val?
    *  (note we exclude modules here, because their realizability is ensured separately)
    */
-  private def isLateInitialized(sym: Symbol) = sym.is(Lazy, butNot = Module)
+  private def isLateInitialized(sym: Symbol) = sym.is(Lazy | Erased, butNot = Module)
 
   /** The realizability status of given type `tp`*/
   def realizability(tp: Type): Realizability = tp.dealias match {
@@ -156,10 +156,10 @@ class CheckRealizable(implicit ctx: Context) {
   private def memberRealizability(tp: Type) = {
     def checkField(sofar: Realizability, fld: SingleDenotation): Realizability =
       sofar andAlso {
-        if (checkedFields.contains(fld.symbol) || fld.symbol.is(Private | Mutable | Lazy))
+        if (checkedFields.contains(fld.symbol) || fld.symbol.is(Private | Mutable | Lazy | Erased))
           // if field is private it cannot be part of a visible path
           // if field is mutable it cannot be part of a path
-          // if field is lazy it does not need to be initialized when the owning object is
+          // if field is lazy or erased it does not need to be initialized when the owning object is
           // so in all cases the field does not influence realizability of the enclosing object.
           Realizable
         else {

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -597,7 +597,7 @@ object SymDenotations {
 
     /** Is this a denotation of a stable term (or an arbitrary type)? */
     final def isStable(implicit ctx: Context) =
-      isType || !is(Erased) && (is(Stable) || !(is(UnstableValue) || info.isInstanceOf[ExprType]))
+      isType || is(Stable) || !(is(UnstableValue) || info.isInstanceOf[ExprType])
 
     /** Is this a "real" method? A real method is a method which is:
      *  - not an accessor

--- a/compiler/src/dotty/tools/dotc/transform/ExpandPrivate.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandPrivate.scala
@@ -90,6 +90,7 @@ class ExpandPrivate extends MiniPhase with IdentityDenotTransformer { thisPhase 
       }
 
       assert(d.symbol.sourceFile != null &&
+             ctx.owner.sourceFile != null &&
              isSimilar(d.symbol.sourceFile.path, ctx.owner.sourceFile.path),
           s"private ${d.symbol.showLocated} in ${d.symbol.sourceFile} accessed from ${ctx.owner.showLocated} in ${ctx.owner.sourceFile}")
       d.ensureNotPrivate.installAfter(thisPhase)

--- a/tests/neg/erased-24.scala
+++ b/tests/neg/erased-24.scala
@@ -6,11 +6,11 @@ object Test {
     println(fun(new Bar))
   }
 
-  def fun(erased foo: Foo): foo.X = { // error
-    null.asInstanceOf[foo.X] // error
+  def fun(erased foo: Foo): foo.X = { // ok
+    null.asInstanceOf[foo.X] // ok
   }
 
-  def fun2(erased foo: Foo)(erased bar: foo.B): bar.X = { // error // error
+  def fun2(erased foo: Foo)(erased bar: foo.B): bar.X = { // error
     null.asInstanceOf[bar.X] // error
   }
 }

--- a/tests/neg/i4060.scala
+++ b/tests/neg/i4060.scala
@@ -1,5 +1,5 @@
 class X { type R }
-class T(erased val a: X)(val value: a.R) // error
+class T(erased val a: X)(val value: a.R)
 
 object App {
   def coerce[U, V](u: U): V = {
@@ -8,7 +8,7 @@ object App {
 
     class T[A <: X](erased val a: A)(val value: a.R) // error
 
-    object O { lazy val x : Y & X = ??? } // warning
+    object O { lazy val x : Y & X = ??? }
 
     val a = new T[Y & X](O.x)(u)
     a.value


### PR DESCRIPTION
Erased values were not very useful so far:

 - we could not instantiate them with anything interesting without triggering a warning.
 - we could not pull out a type from them without getting an error.

Both impediments are fixed in this PR. This is an alternate fix for #4060.
