### PR TITLE
Make vals with constant rhs have constant types

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1115,15 +1115,11 @@ class Namer { typer: Typer =>
             WildcardType
       } getOrElse WildcardType
 
-      // println(s"final inherited for $sym: ${inherited.toString}") !!!
-      // println(s"owner = ${sym.owner}, decls = ${sym.owner.info.decls.show}")
-      def isInline = sym.is(FinalOrInlineOrTransparent, butNot = Method | Mutable)
-
       // Widen rhs type and eliminate `|' but keep ConstantTypes if
       // definition is inline (i.e. final in Scala2) and keep module singleton types
       // instead of widening to the underlying module class types.
       def widenRhs(tp: Type): Type = tp.widenTermRefExpr match {
-        case ctp: ConstantType if isInline => ctp
+        case ctp: ConstantType if !sym.is(Method | Mutable) => ctp
         case ref: TypeRef if ref.symbol.is(ModuleClass) => tp
         case _ => tp.widen.widenUnion
       }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1115,9 +1115,8 @@ class Namer { typer: Typer =>
             WildcardType
       } getOrElse WildcardType
 
-      // Widen rhs type and eliminate `|' but keep ConstantTypes if
-      // definition is inline (i.e. final in Scala2) and keep module singleton types
-      // instead of widening to the underlying module class types.
+      // Widen rhs type and eliminate `|' but keep ConstantTypes and module singleton
+      // types instead of widening to the underlying module class types.
       def widenRhs(tp: Type): Type = tp.widenTermRefExpr match {
         case ctp: ConstantType if !sym.is(Method | Mutable) => ctp
         case ref: TypeRef if ref.symbol.is(ModuleClass) => tp

--- a/tests/run/i4559.scala
+++ b/tests/run/i4559.scala
@@ -1,6 +1,6 @@
 trait A {
   println(s"super[A] init")
-  lazy val x = { println("super[A].x()"); 123 }
+  lazy val x: Int = { println("super[A].x()"); 123 }
 }
 
 class B extends A {


### PR DESCRIPTION
In Scala-2, val's get a constant type only if they are declared `final`. This is
a horrible wart, of which I was ashamed from the beginning. In Dotty, we definitely do not
want to continue with this tradition. So far, we keep the constant type if the `val` is
labeled `inline`. But `inline` clashes with `inline` annotations and its unclear whether
we want to keep it.

So I tried to see what breaks if we simply say that `val`'s without a declared
type and a constant rhs get a constant type. No additional modifier needed.
Turns out, a number of small tests break, but they all seem to test this
specific behavior. So it should be easy to change the tests.

The main benefit of the change is:

 - we do not have to introduce another modifier for inlined vals
 - it's shorter and clearer
 - we can always get back the old behavior using an explicit type annotation.

As a next step one could try to avoid widening all singleton types, not
just constant types as in this PR. I have not tried it, since it has no
relevance on the question how to retire final vals.

Note that the situations in Scala-2 and Dotty are different because Dotty
widens at different points. So it could well be that the change is not as
easy in Scala-2.