### PR TITLE
Fix #4765, evaluate objects we inline from if not pure

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -420,7 +420,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
   /** The Inlined node representing the inlined call */
   def inlined(pt: Type) = {
     // make sure prefix is executed if it is impure
-    if (!isIdempotentExpr(prefix)) registerType(meth.owner.thisType)
+    if (!isPureExpr(prefix)) registerType(meth.owner.thisType)
 
     // Register types of all leaves of inlined body so that the `paramProxy` and `thisProxy` maps are defined.
     rhsToInline.foreachSubTree(registerLeaf)


### PR DESCRIPTION
Fix #4765: when inlining `A.x`, produce `A` and then `x`'s body.
Missing: tests — but first let's figure out if we want to do this change.

Here's the "repl-test" from #4765 — it turns `A.x` into `{ val A$_this: A.type(A) = A; { println("x init"); 1 } }` rather than `{ println("x init"); 1 }`.

```scala
sbt:dotty> repl -Xprint:frontend
[...]
[info] Running (fork) dotty.tools.repl.Main -classpath /Users/pgiarrusso/git/dotty/library/target/scala-2.12/dotty-library_2.12-0.9.0-bin-SNAPSHOT-nonbootstrapped.jar -Xprint:frontend
scala> object A {
     |   println("object init");
     |   inline def x: 1 = { println("x init") ; 1 } //`inline val` requires a val on the rhs
     | }
result of rs$line$1 after frontend:
package <empty> {
  final lazy module val rs$line$1: rs$line$1$ = new rs$line$1$()
  final module class rs$line$1$() extends Object() { this: rs$line$1.type =>
    final lazy module val A: A$ = new A$()
    final module class A$() extends Object() { this: A.type =>
      println("object init")
      inline def x: 1.type =
        {
          println("x init")
          1
        }
    }
  }
}
// defined object A

scala> object B {
     |            val y = A.x
     |          }
result of rs$line$2 after frontend:
package <empty> {
  final lazy module val rs$line$2: rs$line$2$ = new rs$line$2$()
  final module class rs$line$2$() extends Object() { this: rs$line$2.type =>
    final lazy module val B: B$ = new B$()
    final module class B$() extends Object() { this: B.type =>
      val y: Int =
        /* inlined from A.x*/
          {
            val A$_this: A.type(A) = A
            {
              println("x init")
              1
            }
          }
    }
  }
}
// defined object B
```
