### PR TITLE
Fix #4774: Skip TypeVars and skip if level is equal

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -567,8 +567,9 @@ class ReifyQuotes extends MacroTransformWithImplicits with InfoTransformer {
           case Quoted(quotedTree) =>
             quotation(quotedTree, tree)
           case tree: TypeTree if tree.tpe.typeSymbol.isSplice =>
-            val splicedType = tree.tpe.asInstanceOf[TypeRef].prefix.termSymbol
-            splice(ref(splicedType).select(tpnme.UNARY_~))
+            val splicedType = tree.tpe.stripTypeVar.asInstanceOf[TypeRef].prefix.termSymbol
+            if (levelOf.get(splicedType).contains(level)) tree
+            else splice(ref(splicedType).select(tpnme.UNARY_~))
           case tree: Select if tree.symbol.isSplice =>
             splice(tree)
           case tree: RefTree if isCaptured(tree.symbol, level) =>

--- a/tests/neg/i4774b.scala
+++ b/tests/neg/i4774b.scala
@@ -1,0 +1,11 @@
+
+import scala.quoted._
+
+object Test {
+  def loop[T](x: Expr[T])(implicit t: Type[T]): Expr[T] = '{
+    val y: ~t = ~x;
+    ~loop[~t]( // error
+      '(y)
+    )
+  }
+}

--- a/tests/pos/i4774.scala
+++ b/tests/pos/i4774.scala
@@ -1,0 +1,7 @@
+
+import scala.quoted._
+
+object Test {
+  def loop[T](x: Expr[T])(implicit t: Type[T]): Expr[T] =
+    '{ val y: ~t = ~x; ~loop('(y)) }
+}


### PR DESCRIPTION
If we have ~t for `t: Type[T]` used at the same level it is an alias for T.
We disallow it if it is explicit because of PCP but if it is infered it is fine.