### PR TITLE
Fix #4758: Revert "New phase for entering annotations"

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -55,12 +55,6 @@ class FrontEnd extends Phase {
     typr.println("entered: " + unit.source)
   }
 
-  def enterAnnotations(implicit ctx: Context) = monitor("annotating") {
-    val unit = ctx.compilationUnit
-    ctx.typer.annotate(unit.untpdTree :: Nil)
-    typr.println("annotated: " + unit.source)
-  }
-
   def typeCheck(implicit ctx: Context) = monitor("typechecking") {
     val unit = ctx.compilationUnit
     unit.tpdTree = ctx.typer.typedExpr(unit.untpdTree)
@@ -91,7 +85,6 @@ class FrontEnd extends Phase {
       enterSyms(remaining.head)
       remaining = remaining.tail
     }
-    unitContexts.foreach(enterAnnotations(_))
     unitContexts.foreach(typeCheck(_))
     record("total trees after typer", ast.Trees.ntrees)
     unitContexts.map(_.compilationUnit).filterNot(discardAfterTyper)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -748,10 +748,7 @@ class Namer { typer: Typer =>
 
     protected def addAnnotations(sym: Symbol): Unit = original match {
       case original: untpd.MemberDef =>
-        var hasInlineAnnot = false
-        lazy val annotCtx =
-          if (sym.is(Param)) ctx.outersIterator.dropWhile(_.owner == sym.owner).next
-          else ctx
+        lazy val annotCtx = annotContext(original, sym)
         for (annotTree <- untpd.modsDeco(original).mods.annotations) {
           val cls = typedAheadAnnotationClass(annotTree)(annotCtx)
           val ann = Annotation.deferred(cls, implicit ctx => typedAnnotation(annotTree))

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -91,7 +91,6 @@ class ReTyper extends Typer with ReChecking {
   override def localTyper(sym: Symbol) = this
 
   override def index(trees: List[untpd.Tree])(implicit ctx: Context) = ctx
-  override def annotate(trees: List[untpd.Tree])(implicit ctx: Context) = ()
 
   override def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType, locked: TypeVars)(fallBack: => Tree)(implicit ctx: Context): Tree =
     fallBack

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -659,7 +659,7 @@ class Typer extends Namer
   }
 
   def typedBlockStats(stats: List[untpd.Tree])(implicit ctx: Context): (Context, List[tpd.Tree]) =
-    (indexAndAnnotate(stats), typedStats(stats, ctx.owner))
+    (index(stats), typedStats(stats, ctx.owner))
 
   def typedBlock(tree: untpd.Block, pt: Type)(implicit ctx: Context) = track("typedBlock") {
     val (exprCtx, stats1) = typedBlockStats(tree.stats)
@@ -1270,7 +1270,7 @@ class Typer extends Namer
 
   def typedLambdaTypeTree(tree: untpd.LambdaTypeTree)(implicit ctx: Context): Tree = track("typedLambdaTypeTree") {
     val LambdaTypeTree(tparams, body) = tree
-    indexAndAnnotate(tparams)
+    index(tparams)
     val tparams1 = tparams.mapconserve(typed(_).asInstanceOf[TypeDef])
     val body1 = typedType(tree.body)
     assignType(cpy.LambdaTypeTree(tree)(tparams1, body1), tparams1, body1)

--- a/compiler/src/dotty/tools/repl/ReplFrontEnd.scala
+++ b/compiler/src/dotty/tools/repl/ReplFrontEnd.scala
@@ -21,7 +21,6 @@ private[repl] class REPLFrontEnd extends FrontEnd {
 
     val unitContext = ctx.fresh.setCompilationUnit(units.head)
     enterSyms(unitContext)
-    enterAnnotations(unitContext)
     typeCheck(unitContext)
     List(unitContext.compilationUnit)
   }

--- a/tests/pos/i3702.scala
+++ b/tests/pos/i3702.scala
@@ -2,7 +2,7 @@ object test {
   class annot extends scala.annotation.Annotation
   def foo = {
     def bar(i: Int): Int = i
-    @annot class Silly {} // error: not found
+    @annot class Silly {} // used to be: not found, but now ok after backing out of 2b12868070be50fb70
     bar(5)
   }
 }

--- a/tests/pos/i4758/Test1.scala
+++ b/tests/pos/i4758/Test1.scala
@@ -1,0 +1,4 @@
+package foo.bar
+
+class Bar extends annotation.StaticAnnotation
+

--- a/tests/pos/i4758/Test2.scala
+++ b/tests/pos/i4758/Test2.scala
@@ -1,0 +1,7 @@
+package foo
+
+import foo.bar.Bar
+
+@Bar
+class Foo extends annotation.StaticAnnotation
+

--- a/tests/pos/i4758/Test3.scala
+++ b/tests/pos/i4758/Test3.scala
@@ -1,0 +1,3 @@
+package object foo {
+  @Foo class Hello
+}


### PR DESCRIPTION
This reverts commit 2b12868070be50fb70c687bcd8a415acbe398e3e.

Since we do not plan to run annotation macros during Namer, there's no need
to annotate before completing. This allows again to define an annotation in the
same scope as an annotated definition. So i3702.scala goes from neg to pos.