### PR TITLE
Fix handling of -print-tasty flag in dotc

### DIFF
--- a/dist/bin/dotc
+++ b/dist/bin/dotc
@@ -90,7 +90,7 @@ case "$1" in
         -repl) PROG_NAME="$ReplMain" && shift ;;
      -compile) PROG_NAME="$CompilerMain" && shift ;;
    -decompile) PROG_NAME="$DecompilerMain" && shift ;;
- -print-tasty) PROG_NAME="$DecompilerMain" && shift ;;
+ -print-tasty) PROG_NAME="$DecompilerMain" && addScala "-print-tasty" && shift ;;
          -run) PROG_NAME="$ReplMain" && shift ;;
       -bootcp) bootcp=true && shift ;;
    -nobootcp) unset bootcp && shift ;;


### PR DESCRIPTION
If the "-print-tasty" argument is passed to the dotc wrapper script, it should be propagated to the decompiler.