### PR TITLE
Fix #4771: Relax overriding check for polymorphic methods

### DIFF
--- a/tests/neg/poly-override.scala
+++ b/tests/neg/poly-override.scala
@@ -1,0 +1,25 @@
+class Super {
+  def a[T] = {}
+  def b[T](x: String) = {}
+  def c[F[_ <: String]] = {}
+  def c1[F[_ >: String]] = {}
+  def d[F[_]] = {}
+
+  def m(x: String) = {}
+  def n[T](x: String) = {}
+}
+class Sub1 extends Super {
+  override def a[T <: String] = {} // error
+  override def b[T <: String](x: String) = {} // error
+  override def c[F[_]] = {} // error
+  override def c1[F[_]] = {} // error
+  override def d[F[+_]] = {} // error
+
+  override def m(x: Any) = {} // error
+  override def n[T](x: Any) = {} // error
+}
+
+class Sub2 extends Super {
+  override def a[T >: String] = {} // error
+  override def b[T >: String](x: String) = {} // error
+}

--- a/tests/pos/poly-override.scala
+++ b/tests/pos/poly-override.scala
@@ -1,0 +1,15 @@
+class Super {
+  def a[T <: String] = {}
+  def b[T <: String](x: String) = {}
+  def c[F[_]] = {}
+  def d[F[+_]] = {}
+}
+class Sub1 extends Super {
+  override def a[T <: AnyRef] = {}
+  override def b[T <: AnyRef](x: String) = {}
+  override def c[F[_ <: String]] = {}
+  override def d[F[_]] = {}
+}
+class Sub2 extends Super {
+  override def c[F[_ >: String]] = {}
+}


### PR DESCRIPTION
Just like in Scala 2, we now allow an override to widen the bounds of a
polymorphic type parameter (this is sound because parameters can vary
contravariantly). (And just like Scala 2, we continue not allowing an
overriding to widen the type of a term parameter).