### PR TITLE
Fix #4785: change typing rule for _* args

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -345,11 +345,6 @@ class Definitions {
     def Predef_classOf(implicit ctx: Context) = Predef_classOfR.symbol
     lazy val Predef_undefinedR = ScalaPredefModule.requiredMethodRef("???")
     def Predef_undefined(implicit ctx: Context) = Predef_undefinedR.symbol
-    // The set of all wrap{X, Ref}Array methods, where X is a value type
-    val Predef_wrapArray = new PerRun[collection.Set[Symbol]]({ implicit ctx =>
-      val methodNames = ScalaValueTypes.map(TreeGen.wrapArrayMethodName) + nme.wrapRefArray
-      methodNames.map(ScalaPredefModule.requiredMethodRef(_).symbol)
-    })
 
   lazy val ScalaRuntimeModuleRef = ctx.requiredModuleRef("scala.runtime.ScalaRunTime")
   def ScalaRuntimeModule(implicit ctx: Context) = ScalaRuntimeModuleRef.symbol

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -492,7 +492,7 @@ class TypeApplications(val self: Type) extends AnyVal {
   }
 
   /** The element type of a sequence or array */
-  def elemType(implicit ctx: Context): Type = self match {
+  def elemType(implicit ctx: Context): Type = self.widenDealias match {
     case defn.ArrayOf(elemtp) => elemtp
     case JavaArrayType(elemtp) => elemtp
     case _ => self.baseType(defn.SeqClass).argInfos.headOption.getOrElse(NoType)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -153,8 +153,12 @@ trait TypeAssigner {
     if (!sym.is(SyntheticOrPrivate) && sym.owner.isClass) checkNoPrivateLeaks(sym, pos)
     else sym.info
 
-  def seqToRepeated(tree: Tree)(implicit ctx: Context): Tree =
-    Typed(tree, TypeTree(tree.tpe.widen.translateParameterized(defn.SeqClass, defn.RepeatedParamClass)))
+  private def toRepeated(tree: Tree, from: ClassSymbol)(implicit ctx: Context): Tree =
+    Typed(tree, TypeTree(tree.tpe.widen.translateParameterized(from, defn.RepeatedParamClass)))
+
+  def seqToRepeated(tree: Tree)(implicit ctx: Context): Tree = toRepeated(tree, defn.SeqClass)
+
+  def arrayToRepeated(tree: Tree)(implicit ctx: Context): Tree = toRepeated(tree, defn.ArrayClass)
 
   /** A denotation exists really if it exists and does not point to a stale symbol. */
   final def reallyExists(denot: Denotation)(implicit ctx: Context): Boolean = try

--- a/tests/pos/repeatedArgs.scala
+++ b/tests/pos/repeatedArgs.scala
@@ -1,3 +1,22 @@
-object testRepeated {
- def foo = java.lang.System.out.format("%4$2s %3$2s %2$2s %1$2s", "a", "b", "c", "d")
+import scala.collection.{immutable, mutable}
+import java.nio.file.Paths
+
+class repeatedArgs {
+  def bar(xs: String*): Int = xs.length
+
+  def test(xs: immutable.Seq[String], ys: collection.Seq[String], zs: Array[String]): Unit = {
+    bar("a", "b", "c")
+    bar(xs: _*)
+    bar(ys: _*) // error in 2.13
+    bar(zs: _*)
+
+    Paths.get("Hello", "World")
+    Paths.get("Hello", xs: _*)
+    Paths.get("Hello", ys: _*) // error in 2.13
+    Paths.get("Hello", zs: _*)
+
+    val List(_, others: _*) = xs.toList // toList should not be needed, see #4790
+    val x: collection.Seq[String] = others
+    // val y: immutable.Seq[String] = others // ok in 2.13
+  }
 }


### PR DESCRIPTION
In expression position, if a tree is of the form `expr: _*`, try to type
`expr` as an `Array` and as a `Seq` if there are errors