### PR TITLE
Fix #4753: Direct method should keep `Override` if overriden nonempty

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ShortcutImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ShortcutImplicits.scala
@@ -181,11 +181,14 @@ object ShortcutImplicits {
   }
 
   /** A new `m$direct` method to accompany the given method `m` */
-  private def newShortcutMethod(sym: Symbol)(implicit ctx: Context): Symbol =
-    sym.copy(
+  private def newShortcutMethod(sym: Symbol)(implicit ctx: Context): Symbol = {
+    val direct = sym.copy(
       name = DirectMethodName(sym.name.asTermName).asInstanceOf[sym.ThisName],
-      flags = sym.flags &~ Override | Synthetic,
+      flags = sym.flags | Synthetic,
       info = directInfo(sym.info))
+    if (direct.allOverriddenSymbols.isEmpty) direct.resetFlag(Override)
+    direct
+  }
 
   def shortcutMethod(sym: Symbol, phase: DenotTransformer)(implicit ctx: Context) =
     sym.owner.info.decl(DirectMethodName(sym.name.asTermName))

--- a/tests/pos/i4753b.scala
+++ b/tests/pos/i4753b.scala
@@ -1,0 +1,7 @@
+class Foo1 {
+  def foo: implicit String => Int = 1
+}
+
+class Foo2 extends Foo1 {
+  override def foo: implicit String => Int = 2
+}


### PR DESCRIPTION
Fix #4753: Direct method should keep `Override` if overriden nonempty.

It is the case if the overriden symbol is in the same compilation unit.