### PR TITLE
Remove debug code for stdlib whitelist

### DIFF
--- a/compiler/test/dotty/tools/StdLibSources.scala
+++ b/compiler/test/dotty/tools/StdLibSources.scala
@@ -7,47 +7,11 @@ import org.junit.Assert._
 
 object StdLibSources {
 
-  /* For debug only */
-  private val useExplicitWhiteList = false
-
   private final val stdLibPath = "scala2-library/src/library/"
 
   def blacklistFile: String = "compiler/test/dotc/scala-collections.blacklist"
-  private def whitelistFile: String = "compiler/test/dotc/scala-collections.whitelist"
-
-  def whitelisted: List[String] = {
-    lazy val whitelistBasedOnBlacklist = all.diff(blacklisted)
-    if (!useExplicitWhiteList) {
-      whitelistBasedOnBlacklist
-    } else if (!new File(whitelistFile).exists()) {
-      genWhitelist(whitelistBasedOnBlacklist.map(_.replace(stdLibPath, "")))
-      whitelistBasedOnBlacklist
-    } else {
-      loadList(whitelistFile)
-    }
-  }
 
   def blacklisted: List[String] = loadList(blacklistFile)
-
-  def all: List[String] = {
-    def collectAllFilesInDir(dir: File, acc: List[String]): List[String] = {
-      val files = dir.listFiles()
-      val acc2 = files.foldLeft(acc)((acc1, file) => if (file.isFile && file.getPath.endsWith(".scala")) file.getPath :: acc1 else acc1)
-      files.foldLeft(acc2)((acc3, file) => if (file.isDirectory) collectAllFilesInDir(file, acc3) else acc3)
-    }
-    collectAllFilesInDir(new File(stdLibPath), Nil)
-  }
-
-  private def genWhitelist(list: List[String]): Unit = {
-    println(s"Generating $whitelistFile based on $blacklistFile")
-    val whitelist = new File(whitelistFile)
-    val p = new java.io.PrintWriter(whitelist)
-    try {
-      list.foreach(p.println)
-    } finally {
-      p.close()
-    }
-  }
 
   private def loadList(path: String): List[String] = Source.fromFile(path, "UTF8").getLines()
     .map(_.trim) // allow identation
@@ -57,18 +21,4 @@ object StdLibSources {
     .map(stdLibPath + _)
     .toList
 
-}
-
-class StdLibSources {
-  @Test def checkWBLists = {
-    val stdlibFilesBlackListed = StdLibSources.blacklisted
-
-    val duplicates = stdlibFilesBlackListed.groupBy(x => x).filter(_._2.size > 1).filter(_._2.size > 1)
-    val msg = duplicates.map(x => s"'${x._1}' appears ${x._2.size} times").mkString(s"Duplicate entries in ${StdLibSources.blacklistFile}:\n", "\n", "\n")
-    assertTrue(msg, duplicates.isEmpty)
-
-    val filesNotInStdLib = stdlibFilesBlackListed.toSet -- StdLibSources.all
-    val msg2 = filesNotInStdLib.map(x => s"'$x'").mkString(s"Entries in ${StdLibSources.blacklistFile} where not found:\n", "\n", "\n")
-    assertTrue(msg2, filesNotInStdLib.isEmpty)
-  }
 }

--- a/compiler/test/dotty/tools/StdLibSources.scala
+++ b/compiler/test/dotty/tools/StdLibSources.scala
@@ -11,7 +11,17 @@ object StdLibSources {
 
   def blacklistFile: String = "compiler/test/dotc/scala-collections.blacklist"
 
+  def whitelisted: List[String] = all.diff(blacklisted)
   def blacklisted: List[String] = loadList(blacklistFile)
+
+  def all: List[String] = {
+    def collectAllFilesInDir(dir: File, acc: List[String]): List[String] = {
+      val files = dir.listFiles()
+      val acc2 = files.foldLeft(acc)((acc1, file) => if (file.isFile && file.getPath.endsWith(".scala")) file.getPath :: acc1 else acc1)
+      files.foldLeft(acc2)((acc3, file) => if (file.isDirectory) collectAllFilesInDir(file, acc3) else acc3)
+    }
+    collectAllFilesInDir(new File(stdLibPath), Nil)
+  }
 
   private def loadList(path: String): List[String] = Source.fromFile(path, "UTF8").getLines()
     .map(_.trim) // allow identation


### PR DESCRIPTION
Now that our blacklist is a single file this code does not serve any purpose.
It was added back when the whitelist was the main file as a way to copy files
from the blacklist to the whitelist.