### PR TITLE
Drop redundant extends clause in ADT docs

### DIFF
--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -64,7 +64,7 @@ As all other enums, ADTs can define methods. For instance, here is `Option` agai
 
 ```scala
 enum Option[+T] {
-  case Some(x: T) extends Option[T]
+  case Some(x: T)
   case None
 
   def isDefined: Boolean = this match {


### PR DESCRIPTION
Seeing as it's not necessary, it's confusing to include it in a section about defining methods.