### PR TITLE
Fix #4564: Invalidate clashing case class methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -20,12 +20,18 @@ object desugar {
   /** Info of a variable in a pattern: The named tree and its type */
   private type VarInfo = (NameTree, Tree)
 
-  /** Names of methods that are added unconditionally to case classes */
-  def isDesugaredCaseClassMethodName(name: Name)(implicit ctx: Context): Boolean = name match {
+  /** Is `name` the name of a method that can be invalidated as a compiler-generated
+   *  case class method that clashes with a user-defined method?
+   */
+  def isRetractableCaseClassMethodName(name: Name)(implicit ctx: Context): Boolean = name match {
     case nme.apply | nme.unapply | nme.copy => true
     case DefaultGetterName(nme.copy, _) => true
-    case _ => name.isSelectorName
+    case _ => false
   }
+
+  /** Is `name` the name of a method that is added unconditionally to case classes? */
+  def isDesugaredCaseClassMethodName(name: Name)(implicit ctx: Context): Boolean =
+    isRetractableCaseClassMethodName(name) || name.isSelectorName
 
 // ----- DerivedTypeTrees -----------------------------------
 

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -21,8 +21,11 @@ object desugar {
   private type VarInfo = (NameTree, Tree)
 
   /** Names of methods that are added unconditionally to case classes */
-  def isDesugaredCaseClassMethodName(name: Name)(implicit ctx: Context): Boolean =
-    name == nme.copy || name.isSelectorName
+  def isDesugaredCaseClassMethodName(name: Name)(implicit ctx: Context): Boolean = name match {
+    case nme.apply | nme.unapply | nme.copy => true
+    case DefaultGetterName(nme.copy, _) => true
+    case _ => name.isSelectorName
+  }
 
 // ----- DerivedTypeTrees -----------------------------------
 
@@ -207,8 +210,7 @@ object desugar {
             tpt = TypeTree(),
             rhs = vparam.rhs
           )
-          .withMods(Modifiers(mods.flags & AccessFlags, mods.privateWithin))
-          .withFlags(Synthetic)
+          .withMods(Modifiers(mods.flags & (AccessFlags | Synthetic), mods.privateWithin))
         val rest = defaultGetters(vparams :: vparamss1, n + 1)
         if (vparam.rhs.isEmpty) rest else defaultGetter :: rest
       case Nil :: vparamss1 =>

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -780,7 +780,7 @@ class Namer { typer: Typer =>
         }
       val isClashingSynthetic =
         denot.is(Synthetic) &&
-        desugar.isDesugaredCaseClassMethodName(denot.name) &&
+        desugar.isRetractableCaseClassMethodName(denot.name) &&
         isCaseClass(denot.owner) &&
         denot.owner.info.decls.lookupAll(denot.name).exists(alt =>
           alt != denot.symbol && alt.info.matchesLoosely(denot.info))

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -768,6 +768,28 @@ class Namer { typer: Typer =>
       case _ =>
     }
 
+    /** Invalidate `denot` by overwriting its info with `NoType` if
+     *  `denot` is a compiler generated case class method that clashes
+     *  with a user-defined method in the same scope with a matching type.
+     */
+    private def invalidateIfClashingSynthetic(denot: SymDenotation): Unit = {
+      def isCaseClass(owner: Symbol) =
+        owner.isClass && {
+          if (owner.is(Module)) owner.linkedClass.is(CaseClass)
+          else owner.is(CaseClass)
+        }
+      val isClashingSynthetic =
+        denot.is(Synthetic) &&
+        desugar.isDesugaredCaseClassMethodName(denot.name) &&
+        isCaseClass(denot.owner) &&
+        denot.owner.info.decls.lookupAll(denot.name).exists(alt =>
+          alt != denot.symbol && alt.info.matchesLoosely(denot.info))
+      if (isClashingSynthetic) {
+        typr.println(i"invalidating clashing $denot in ${denot.owner}")
+        denot.info = NoType
+      }
+    }
+
     /** Intentionally left without `implicit ctx` parameter. We need
      *  to pick up the context at the point where the completer was created.
      */
@@ -776,6 +798,7 @@ class Namer { typer: Typer =>
       addAnnotations(sym)
       addInlineInfo(sym)
       denot.info = typeSig(sym)
+      invalidateIfClashingSynthetic(denot)
       Checking.checkWellFormed(sym)
       denot.info = avoidPrivateLeaks(sym, sym.pos)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1415,7 +1415,7 @@ class Typer extends Namer
 
   def typedDefDef(ddef: untpd.DefDef, sym: Symbol)(implicit ctx: Context): Tree = track("typedDefDef") {
     if (!sym.info.exists) { // it's a discarded synthetic case class method, drop it
-      assert(sym.is(Synthetic) && desugar.isDesugaredCaseClassMethodName(sym.name))
+      assert(sym.is(Synthetic) && desugar.isRetractableCaseClassMethodName(sym.name))
       sym.owner.info.decls.openForMutations.unlink(sym)
       return EmptyTree
     }

--- a/tests/neg/i4564.scala
+++ b/tests/neg/i4564.scala
@@ -1,0 +1,46 @@
+object ClashOverloadNoSig {
+
+  private def apply(x: Int) = if (x > 0) new ClashOverloadNoSig(x) else apply("") // error: overloaded method apply needs result type
+
+  def apply(x: String): ClashOverloadNoSig = ???
+}
+
+case class ClashOverloadNoSig private(x: Int)
+
+object ClashRecNoSig {
+  private def apply(x: Int) = if (x > 0) ClashRecNoSig(1) else ???    // error: recursive method apply needs result type
+}
+
+case class ClashRecNoSig private(x: Int)
+
+object NoClashNoSig {
+  private def apply(x: Boolean) = if (x) NoClashNoSig(1) else ???   // error: overloaded method apply needs result type
+}
+
+case class NoClashNoSig private(x: Int)
+
+object NoClashOverload {
+  private def apply(x: Boolean) = if (x) NoClashOverload(1) else apply("")   // error: overloaded method apply needs result type
+
+  def apply(x: String): NoClashOverload = ???
+}
+
+case class NoClashOverload private(x: Int)
+
+
+class BaseNCNSP[T] {
+  def apply(x: T) = if (???) NoClashNoSigPoly(1) else ???    // error: overloaded method apply needs result type
+}
+
+object NoClashNoSigPoly extends BaseNCNSP[Boolean]
+case class NoClashNoSigPoly private(x: Int)   // error: recursive method apply needs result type
+
+
+
+class BaseCNSP[T] {
+  def apply(x: T) = if (???) ClashNoSigPoly(1) else ???    // error: recursive method apply needs result type
+}
+
+object ClashNoSigPoly extends BaseCNSP[Int]
+// TODO: improve error message
+case class ClashNoSigPoly private(x: Int)  // error: found: ClashNoSigPoly required: Nothing

--- a/tests/neg/i4564.scala
+++ b/tests/neg/i4564.scala
@@ -20,7 +20,7 @@ object NoClashNoSig {
 case class NoClashNoSig private(x: Int)
 
 object NoClashOverload {
-  private def apply(x: Boolean) = if (x) NoClashOverload(1) else apply("")   // error: overloaded method apply needs result type
+  private def apply(x: Boolean) = if (x) NoClashOverload(1) else apply("")   // error // error: overloaded method apply needs result type (twice)
 
   def apply(x: String): NoClashOverload = ???
 }
@@ -33,7 +33,7 @@ class BaseNCNSP[T] {
 }
 
 object NoClashNoSigPoly extends BaseNCNSP[Boolean]
-case class NoClashNoSigPoly private(x: Int)   // error: recursive method apply needs result type
+case class NoClashNoSigPoly private(x: Int)   // ok, since `apply` is in base class
 
 
 

--- a/tests/pos/i4564.scala
+++ b/tests/pos/i4564.scala
@@ -14,7 +14,6 @@ object ClashNoSig { // ok
   }
 }
 case class ClashNoSig private (x: Int) {
-  def _1: Int = x
   def copy(y: Int) = ClashNoSig(y)
 }
 

--- a/tests/pos/i4564.scala
+++ b/tests/pos/i4564.scala
@@ -1,0 +1,63 @@
+case class A(x: Int) {
+  def copy(x: Int = x) = A(x)
+}
+
+// NOTE: the companion inherits a public apply method from Function1!
+case class NeedsCompanion private (x: Int)
+
+object ClashNoSig { // ok
+  private def apply(x: Int) = if (x > 0) new ClashNoSig(x) else ???
+  def unapply(x: ClashNoSig) = x
+
+  ClashNoSig(2) match {
+    case c @ ClashNoSig(y) => c.copy(y + c._1)
+  }
+}
+case class ClashNoSig private (x: Int) {
+  def _1: Int = x
+  def copy(y: Int) = ClashNoSig(y)
+}
+
+object Clash {
+  private def apply(x: Int) = if (x > 0) new Clash(x) else ???
+}
+case class Clash private (x: Int)
+
+object ClashSig {
+  private def apply(x: Int): ClashSig = if (x > 0) new ClashSig(x) else ???
+}
+case class ClashSig private (x: Int)
+
+object ClashOverload {
+  private def apply(x: Int): ClashOverload = if (x > 0) new ClashOverload(x) else apply("")
+  def apply(x: String): ClashOverload = ???
+}
+case class ClashOverload private (x: Int)
+
+object NoClashSig {
+  private def apply(x: Boolean): NoClashSig = if (x) NoClashSig(1) else ???
+}
+case class NoClashSig private (x: Int)
+
+object NoClashOverload {
+  // needs full sig
+  private def apply(x: Boolean): NoClashOverload = if (x) NoClashOverload(1) else apply("")
+  def apply(x: String): NoClashOverload = ???
+}
+case class NoClashOverload private (x: Int)
+
+class BaseNCP[T] {
+  // error: overloaded method apply needs result type
+  def apply(x: T): NoClashPoly = if (???) NoClashPoly(1) else ???
+}
+
+object NoClashPoly extends BaseNCP[Boolean]
+case class NoClashPoly private(x: Int)
+
+
+class BaseCP[T] {
+  // error: overloaded method apply needs result type
+  def apply(x: T): ClashPoly = if (???) ClashPoly(1) else ???
+}
+object ClashPoly extends BaseCP[Int]
+case class ClashPoly private(x: Int)

--- a/tests/pos/t5816-noclash.scala
+++ b/tests/pos/t5816-noclash.scala
@@ -1,0 +1,13 @@
+object Foo {
+  // spurious error if:
+  //   - this definition precedes that of apply (which is overloaded with the synthetic one derived from the case class)
+  //   - AND `Foo.apply` is explicitly applied to `[A]` (no error if `[A]` is inferred)
+  //
+  def referToPolyOverloadedApply[A]: Foo[A] = Foo.apply[A]("bla")
+  //                                                   ^
+  //  found   : String("bla")
+  //  required: Int
+
+  def apply[A](x: Int): Foo[A] = ???
+}
+case class Foo[A](x: String)


### PR DESCRIPTION
Invalidate a compiler generated case class method that clashes
with a user-defined method in the same scope with a matching type.

Invalidation is done by overwriting its info on completion with `NoType` and
eliminating the method altogether during type checking.

Methods potentially affected are `apply`, `unapply`, `copy`, and `copy`'s default getters.