### PR TITLE
Fix #4781: Add neg test

### DIFF
--- a/tests/neg/i4781.scala
+++ b/tests/neg/i4781.scala
@@ -1,0 +1,9 @@
+class A
+class B extends A
+
+class Map[T] { def foo(x: T): A = new A }
+
+class AnyRefMap[T <: AnyRef] extends Map[T] {
+  // This is an overload in Scala 2 but an override in Dotty
+  def foo(y: T with AnyRef): B = new B // error: missing override modifier
+}


### PR DESCRIPTION
This hack relies on a Scala 2 bug (see scala/scala-dev#530). This won't
be supported in Dotty