### PR TITLE
Fix the reproduction script for testFromTasty tests

### DIFF
--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -1284,11 +1284,15 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     ) extends JointCompilationSource(name, Array(file), flags, outDir, fromTasty, decompilation) {
 
       override def buildInstructions(errors: Int, warnings: Int): String = {
+        val runOrPos = if (file.getPath.startsWith("tests/run/")) "run" else "pos"
+        val listName = if (fromTasty) "from-tasty" else "decompilation"
         s"""|
             |Test '$title' compiled with $errors error(s) and $warnings warning(s),
             |the test can be reproduced by running:
             |
             |  sbt "testFromTasty $file"
+            |
+            |This tests can be disabled by adding `${file.getName}` to `compiler/test/dotc/$runOrPos-$listName.blacklist`
             |
             |""".stripMargin
       }


### PR DESCRIPTION
For example a failure in a `testFromTasty` for `tests/run/eff-dependent.scala`  will output the following report:
```
================================================================================
Test Report
================================================================================

1 suites passed, 1 failed, 2 total
    tests/run/eff-dependent.scala failed


Test 'tests/run/eff-dependent.scala' compiled with 0 error(s) and 0 warning(s),
the test can be reproduced by running:

  sbt "testFromTasty tests/run/eff-dependent.scala"
```