### PR TITLE
Fix #4837: use dealiased type for parent symbol 

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1501,7 +1501,7 @@ class Typer extends Namer
      */
     def maybeCall(ref: Tree, psym: Symbol, cinfo: Type): Tree = cinfo.stripPoly match {
       case cinfo @ MethodType(Nil) if cinfo.resultType.isImplicitMethod =>
-        typedExpr(untpd.New(ref, Nil))(superCtx)
+        typedExpr(untpd.New(untpd.TypedSplice(ref)(superCtx), Nil))(superCtx)
       case cinfo @ MethodType(Nil) if !cinfo.resultType.isInstanceOf[MethodType] =>
         ref
       case cinfo: MethodType =>
@@ -1518,7 +1518,7 @@ class Typer extends Namer
 
     def typedParent(tree: untpd.Tree): Tree = {
       var result = if (tree.isType) typedType(tree)(superCtx) else typedExpr(tree)(superCtx)
-      val psym = result.tpe.typeSymbol
+      val psym = result.tpe.dealias.typeSymbol
       if (seenParents.contains(psym) && !cls.isRefinementClass)
         ctx.error(i"$psym is extended twice", tree.pos)
       seenParents += psym

--- a/tests/neg/i4837.scala
+++ b/tests/neg/i4837.scala
@@ -1,0 +1,6 @@
+trait T(x: Int)
+
+class C {
+  type Foo[X] = T
+  class D extends Foo[Unit] // error
+}

--- a/tests/pos/i4837.scala
+++ b/tests/pos/i4837.scala
@@ -1,0 +1,11 @@
+trait T[X: Numeric]
+
+class C {
+  type S[X] = T[X]
+  type Foo[X, Y] = T[X]
+  type Bar[X, Y] = Foo[X, Y]
+
+  class D[X: Numeric] extends S[X]
+  class E[X: Numeric] extends Foo[X, Unit]
+  class F[X: Numeric] extends Bar[X, Unit]
+}


### PR DESCRIPTION
This PR is based on PR #4798. I'll rebase it after #4798 is merged to the master branch.