### PR TITLE
Fix #4466: same ctx for tryInsertApplyOrImplicit

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1418,7 +1418,9 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
           if (isDetermined(alts2)) alts2
           else {
             pretypeArgs(alts2, pt)
-            narrowByTrees(alts2, pt.typedArgs, resultType)
+            val targs = pt.typedArgs
+            pt.getConstraints()
+            narrowByTrees(alts2, targs, resultType)
           }
         }
 

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -253,6 +253,14 @@ object ProtoTypes {
       myTypedArg.size == args.length
     }
 
+    def getConstraints()(implicit ctx: Context) = {
+      evalState.foreachBinding((_, tstateConstr) => {
+        val constr = tstateConstr._1.uncommittedAncestor.constraint
+        val tstate = ctx.typerState
+        if (tstate.constraint ne constr) tstate.constraint &= (constr, false)
+      })
+    }
+
     private def cacheTypedArg(arg: untpd.Tree, typerFn: untpd.Tree => Tree, force: Boolean)(implicit ctx: Context): Tree = {
       var targ = myTypedArg(arg)
       if (targ == null) {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -37,7 +37,7 @@ import config.Printers.{gadts, typr}
 import rewrite.Rewrites.patch
 import NavigateAST._
 import transform.SymUtils._
-import reporting.trace
+import reporting.{StoreReporter, trace}
 import config.Config
 
 import language.implicitConversions
@@ -1978,6 +1978,15 @@ class Typer extends Namer
   def typedPattern(tree: untpd.Tree, selType: Type = WildcardType)(implicit ctx: Context): Tree =
     typed(tree, selType)(ctx addMode Mode.Pattern)
 
+  def tryEitherWithSameContext[T](op: Context => T)(fallBack: T => T)(implicit ctx: Context) = {
+    val reporter = ctx.reporter
+    val reporter1 = new StoreReporter(reporter)
+    ctx.typerState.setReporter(reporter1)
+    val result = op(ctx)
+    ctx.typerState.setReporter(reporter)
+    if (reporter1.hasErrors) fallBack(result) else result
+  }
+
   def tryEither[T](op: Context => T)(fallBack: (T, TyperState) => T)(implicit ctx: Context) = {
     val nestedCtx = ctx.fresh.setNewTyperState()
     val result = op(nestedCtx)
@@ -2061,14 +2070,10 @@ class Typer extends Namer
         tree
       case _ =>
         if (isApplyProto(pt) || isMethod(tree) || isSyntheticApply(tree)) tryImplicit(fallBack)
-        else tryEither(tryApply(_)) { (app, appState) =>
+        else tryEitherWithSameContext(tryApply(_)) { app =>
           tryImplicit {
-            if (tree.tpe.member(nme.apply).exists) {
-              // issue the error about the apply, since it is likely more informative than the fallback
-              appState.commit()
-              app
-            }
-            else fallBack
+            // issue the error about the apply, since it is likely more informative than the fallback
+            if (tree.tpe.member(nme.apply).exists) app else fallBack
           }
         }
      }

--- a/tests/pos/i4466a.scala
+++ b/tests/pos/i4466a.scala
@@ -1,0 +1,11 @@
+class Foo {
+  def apply(bar: Bar[Int]): Unit = ()
+  def apply(i: Int): Unit = ()
+}
+
+class Bar[X](x: X)
+
+class Main {
+  val foo = new Foo
+  foo(new Bar(0))
+}

--- a/tests/pos/i4466b.scala
+++ b/tests/pos/i4466b.scala
@@ -1,0 +1,9 @@
+object Foo {
+  case class Bar(map: Map[String, String]) 
+
+  object Bar {
+    def apply(str: String): Bar = ???
+  }
+
+  Bar(Map("A" -> "B"))
+}


### PR DESCRIPTION
The below code generates the same error.
```scala
class Foo {
  def apply(bar: Bar[Int]): Unit = ()
  def apply(i: Int): Unit = ()
}

class Bar[X](x: X)

class Main {
  val foo = new Foo
  foo(new Bar(0)) // should be compiled, but fails
  foo.apply(new Bar(0)) // works
  foo(new Bar[Int](0)) // works
}
```
When `foo(new Bar(0))` is typed, since there is no method with name `foo`, `tryInsertApplyOrImplicit` is used to try `foo.apply(new Bar(0))`. In `tryInsertApplyOrImplicit`, `tryEither` is invoked, so that a new context with a new typer state is created. However, `pt` of `FunProto` type uses the original context. Therefore, the original typer state contains constraints about `X` but the new typer state does not. Finally, overloading resolution fails because neither `(Bar[Int])Unit` nor `(Int)Unit` is a proper candidate for `(Bar[X])_`. The last two lines work because `tryEither` is not used and `X` does not need to be inferred respectively.
To make the same typer state be used, I added `tryEitherWithSameContext`, which changes only `reporter`, and use it.