### PR TITLE
Fix #4846: Allow transparent parameters at any stage 

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -364,7 +364,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
           capturers(body.symbol)(body)
         case _=>
           val (body1, splices) = nested(isQuote = true).split(body)
-          if (level == 0 && !ctx.owner.ownersIterator.exists(_.isTransparentMethod)) pickledQuote(body1, splices, body.tpe, isType).withPos(quote.pos)
+          if (level == 0 && !ctx.inTransparentMethod) pickledQuote(body1, splices, body.tpe, isType).withPos(quote.pos)
           else {
             // In top-level splice in an transparent def. Keep the tree as it is, it will be transformed at inline site.
             body

--- a/tests/pos/i4846.scala
+++ b/tests/pos/i4846.scala
@@ -1,0 +1,6 @@
+import scala.quoted._
+
+object Test {
+  transparent def foo(transparent x: Int): Int = ~fooImpl(x, '(x), '( '(x) ), '( '( '(x) ) ))
+  def fooImpl(a: Int, b: Expr[Int], c: Expr[Expr[Int]], d: Expr[Expr[Expr[Int]]]): Expr[Int] = ???
+}


### PR DESCRIPTION
Based on #4823

* Stop checking and using capture transformation for transparent parameters
* Keep transparent parameters as they are. Allow them to be inlined and replaced directly.