### PR TITLE
Fix `dotr` on Windows: use the right path separator.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -590,7 +590,8 @@ object Build {
         val dottyLib = jars("dotty-library")
 
         def run(args: List[String]): Unit = {
-          val fullArgs = insertClasspathInArgs(args, s".:$dottyLib:$scalaLib")
+          val sep = File.pathSeparator
+          val fullArgs = insertClasspathInArgs(args, s".$sep$dottyLib$sep$scalaLib")
           runProcess("java" :: fullArgs, wait = true)
         }
 


### PR DESCRIPTION
`dotr` introduces a custom classpath, which was hard-coded to use `:` as path separator. This commit uses `File.pathSeparator` instead, so that it also works on Windows.