### PR TITLE
Reenable tests disabled/dropped in #4833

### DIFF
--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -45,7 +45,7 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
     compileDir("compiler/src/dotty/tools/dotc/util", defaultOptions) +
     compileDir("compiler/src/dotty/tools/io", defaultOptions) +
     compileDir("compiler/src/dotty/tools/dotc/core", TestFlags(classPath, noCheckOptions))
-  }
+  }.checkCompile()
 
   @Test def posTwiceWithCompiler: Unit = {
     implicit val testGroup: TestGroup = TestGroup("posTwiceWithCompiler")

--- a/docs/docs/contributing/testing.md
+++ b/docs/docs/contributing/testing.md
@@ -58,7 +58,7 @@ You can also run all paths of classes of a certain name:
 These tests are Scala source files expected to compile with Dotty (pos tests),
 along with their expected output (run tests) or errors (neg tests).
 
-All of these tests are contained in the `./tests/*` directories and can be run with the `testCompilation` command.
+All of these tests are contained in the `./tests/*` directories and can be run with the `testCompilation` command. Tests in folders named `with-compiler` are an exception, see next section.
 
 Currently to run these tests you need to invoke from sbt:
 
@@ -79,3 +79,10 @@ $ sbt
 This will run both the test `./tests/pos/companions.scala` and
 `./tests/neg/companions.scala` since both of these match the given string.
 This also means that you could run `testCompilation` with no arguments to run all integration tests.
+
+### Bootstrapped-only tests
+
+To run `testCompilation` on a bootstrapped Dotty compiler, use
+`dotty-compiler-bootstrapped/testCompilation` (with the same syntax as above).
+Some tests can only be run in bootstrapped compilers; that includes all tests
+with `with-compiler` in their name.

--- a/tests/pos-with-compiler/lazyValsSepComp.scala
+++ b/tests/pos-with-compiler/lazyValsSepComp.scala
@@ -1,0 +1,16 @@
+package dotty.tools
+package io
+
+import java.io.{ InputStream }
+import java.util.jar.JarEntry
+import dotty.tools.dotc.core.Definitions
+import language.postfixOps
+import dotty.tools.dotc.core.Contexts._
+
+
+ /** A test to trigger issue with separate compilation between Dotty and Scalac and lazy vals */
+object Foo {
+  val definitions: Definitions = null
+  def defn = definitions
+  def go = defn.FunctionClassPerRun
+}


### PR DESCRIPTION
`lazyValsSepComp` was dropped in c9f1754ab1c9cb37af400eb71626dd9a8e975e73
without motivation.

After readding it, `dotty-compiler-bootstrapped/testCompilation lazyValsSep`
didn't find it; adding the forgotten `checkCompile` call fixed this as well.