### PR TITLE
Fix tasty hash

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyHash.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyHash.scala
@@ -1,0 +1,23 @@
+package dotty.tools.dotc.core.tasty
+
+object TastyHash {
+
+  /** Returns a non-cryptographic 64-bit hash of the array.
+   *
+   *  from https://en.wikipedia.org/wiki/PJW_hash_function#Algorithm
+   */
+  def pjwHash64(data: Array[Byte]): Long = {
+    var h = 0L
+    var i = 0
+    while (i < data.length) {
+      val d = data(i) & 0xFFL // Interpret byte as unsigned byte
+      h = (h << 8) + d
+      val high = h & 0xFF00000000000000L
+      h ^= high >> 48L
+      h &= ~high
+      i += 1
+    }
+    h
+  }
+
+}

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyHash.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyHash.scala
@@ -13,7 +13,7 @@ object TastyHash {
       val d = data(i) & 0xFFL // Interpret byte as unsigned byte
       h = (h << 8) + d
       val high = h & 0xFF00000000000000L
-      h ^= high >> 48L
+      h ^= high >>> 48L
       h &= ~high
       i += 1
     }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
@@ -26,8 +26,8 @@ class TastyPickler(val rootCls: ClassSymbol) {
     nameBuffer.assemble()
     sections.foreach(_._2.assemble())
 
-    val nameBufferHash = pjwHash64(nameBuffer.bytes)
-    val treeSectionHash +: otherSectionHashes = sections.map(x => pjwHash64(x._2.bytes))
+    val nameBufferHash = TastyHash.pjwHash64(nameBuffer.bytes)
+    val treeSectionHash +: otherSectionHashes = sections.map(x => TastyHash.pjwHash64(x._2.bytes))
 
     // Hash of name table and tree
     val uuidLow: Long = nameBufferHash ^ treeSectionHash
@@ -78,21 +78,4 @@ class TastyPickler(val rootCls: ClassSymbol) {
 
   val treePkl = new TreePickler(this)
 
-  /** Returns a non-cryptographic 64-bit hash of the array.
-   *
-   *  from https://en.wikipedia.org/wiki/PJW_hash_function#Algorithm
-   */
-  private def pjwHash64(data: Array[Byte]): Long = {
-    var h = 0L
-    var i = 0
-    while (i < data.length) {
-      val d = data(i) & 0xFFL // Interpret byte as unsigned byte
-      h = (h << 8) + d
-      val high = h & 0xFF00000000000000L
-      h ^= high >> 48L
-      h &= ~high
-      i += 1
-    }
-    h
-  }
 }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
@@ -89,10 +89,8 @@ class TastyPickler(val rootCls: ClassSymbol) {
       val d = data(i) & 0xFFL // Interpret byte as unsigned byte
       h = (h << 8) + d
       val high = h & 0xFF00000000000000L
-      if (high != 0) {
-        h ^= high >> 48L
-        h &= ~high
-      }
+      h ^= high >> 48L
+      h &= ~high
       i += 1
     }
     h

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
@@ -20,10 +20,11 @@ class TastyPickler(val rootCls: ClassSymbol) {
     sections += ((nameBuffer.nameIndex(name.toTermName), buf))
 
   def assembleParts(): Array[Byte] = {
-    def lengthWithLength(buf: TastyBuffer) = {
-      buf.assemble()
+    def lengthWithLength(buf: TastyBuffer) =
       buf.length + natSize(buf.length)
-    }
+
+    nameBuffer.assemble()
+    sections.foreach(_._2.assemble())
 
     val uuidLow: Long = pjwHash64(nameBuffer.bytes)
     val uuidHi: Long = sections.iterator.map(x => pjwHash64(x._2.bytes)).fold(0L)(_ ^ _)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
@@ -79,12 +79,12 @@ class TastyPickler(val rootCls: ClassSymbol) {
    */
   private def pjwHash64(data: Array[Byte]): Long = {
     var h = 0L
-    var high = 0L
     var i = 0
     while (i < data.length) {
       h = (h << 4) + data(i)
-      high = h & 0xF0000000L
-      h ^= high >> 24
+      val high = h & 0xF0000000L
+      if (high != 0)
+        h ^= high >> 24
       h &= ~high
       i += 1
     }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
@@ -75,18 +75,19 @@ class TastyPickler(val rootCls: ClassSymbol) {
 
   /** Returns a non-cryptographic 64-bit hash of the array.
    *
-   *  from https://en.wikipedia.org/wiki/PJW_hash_function#Implementation
+   *  from https://en.wikipedia.org/wiki/PJW_hash_function#Algorithm
    */
   private def pjwHash64(data: Array[Byte]): Long = {
     var h = 0L
     var i = 0
     while (i < data.length) {
       val d = data(i) & 0xFFL // Interpret byte as unsigned byte
-      h = (h << 4) + d
-      val high = h & 0xF0000000L
-      if (high != 0)
-        h ^= high >> 24
-      h &= ~high
+      h = (h << 8) + d
+      val high = h & 0xFF00000000000000L
+      if (high != 0) {
+        h ^= high >> 48L
+        h &= ~high
+      }
       i += 1
     }
     h

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
@@ -26,8 +26,13 @@ class TastyPickler(val rootCls: ClassSymbol) {
     nameBuffer.assemble()
     sections.foreach(_._2.assemble())
 
-    val uuidLow: Long = pjwHash64(nameBuffer.bytes)
-    val uuidHi: Long = sections.iterator.map(x => pjwHash64(x._2.bytes)).fold(0L)(_ ^ _)
+    val nameBufferHash = pjwHash64(nameBuffer.bytes)
+    val treeSectionHash +: otherSectionHashes = sections.map(x => pjwHash64(x._2.bytes))
+
+    // Hash of name table and tree
+    val uuidLow: Long = nameBufferHash ^ treeSectionHash
+    // Hash of positions, comments and any additional section
+    val uuidHi: Long = otherSectionHashes.fold(0L)(_ ^ _)
 
     val headerBuffer = {
       val buf = new TastyBuffer(header.length + 24)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
@@ -81,7 +81,8 @@ class TastyPickler(val rootCls: ClassSymbol) {
     var h = 0L
     var i = 0
     while (i < data.length) {
-      h = (h << 4) + data(i)
+      val d = data(i) & 0xFFL // Interpret byte as unsigned byte
+      h = (h << 4) + d
       val high = h & 0xF0000000L
       if (high != 0)
         h ^= high >> 24

--- a/compiler/test/dotty/tools/dotc/TastyHashTest.scala
+++ b/compiler/test/dotty/tools/dotc/TastyHashTest.scala
@@ -1,7 +1,11 @@
+package dotty.tools.dotc
+
+import org.junit.Test
+
 import dotty.tools.dotc.core.tasty.TastyHash.pjwHash64
 
-object Test {
-  def main(args: Array[String]): Unit = {
+class TastyHashTest {
+  @Test def pjwHash64Tests(): Unit = {
     testHash(0L, Array.empty)
     testHash(0L, Array(0))
     testHash(1L, Array(1))

--- a/compiler/test/dotty/tools/dotc/TastyHashTest.scala
+++ b/compiler/test/dotty/tools/dotc/TastyHashTest.scala
@@ -1,6 +1,7 @@
 package dotty.tools.dotc
 
 import org.junit.Test
+import org.junit.Assert.assertEquals
 
 import dotty.tools.dotc.core.tasty.TastyHash.pjwHash64
 
@@ -22,8 +23,7 @@ class TastyHashTest {
   }
 
   def testHash(expected: Long, arr: Array[Byte]): Unit = {
-    val res = pjwHash64(arr)
-    assert(res == expected, s"Exprected 0x${expected.toHexString}L but got 0X${res.toHexString}L")
+    assertEquals(s"0x${expected.toHexString}L", s"0x${pjwHash64(arr).toHexString}L")
   }
 
 }

--- a/tests/run-with-compiler/tasty-hash.scala
+++ b/tests/run-with-compiler/tasty-hash.scala
@@ -1,0 +1,25 @@
+import dotty.tools.dotc.core.tasty.TastyHash.pjwHash64
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    testHash(0L, Array.empty)
+    testHash(0L, Array(0))
+    testHash(1L, Array(1))
+    testHash(0x7fL, Array(Byte.MaxValue))
+    testHash(0x80L, Array(Byte.MinValue))
+    testHash(0x101L, Array(1, 1))
+    testHash(0X10101L, Array(1, 1, 1))
+    testHash(0X1010101L, Array(1, 1, 1, 1))
+    testHash(0X101010101L, Array(1, 1, 1, 1, 1))
+    testHash(0X202020202L, Array(2, 2, 2, 2, 2))
+    testHash(0X1010101L, Array.fill(1024)(1))
+    testHash(0X55aa01fe55ab54ffL, Array.tabulate(1024)(_.toByte))
+    testHash(0x34545c16020230L, "abcdefghijklmnopqrstuvwxyz1234567890".getBytes)
+  }
+
+  def testHash(expected: Long, arr: Array[Byte]): Unit = {
+    val res = pjwHash64(arr)
+    assert(res == expected, s"Exprected 0x${expected.toHexString}L but got 0X${res.toHexString}L")
+  }
+
+}

--- a/tests/run-with-compiler/tasty-hash.scala
+++ b/tests/run-with-compiler/tasty-hash.scala
@@ -13,7 +13,7 @@ object Test {
     testHash(0X101010101L, Array(1, 1, 1, 1, 1))
     testHash(0X202020202L, Array(2, 2, 2, 2, 2))
     testHash(0X1010101L, Array.fill(1024)(1))
-    testHash(0X55aa01fe55ab54ffL, Array.tabulate(1024)(_.toByte))
+    testHash(0xaafefeaaab54ffL, Array.tabulate(1024)(_.toByte))
     testHash(0x34545c16020230L, "abcdefghijklmnopqrstuvwxyz1234567890".getBytes)
   }
 


### PR DESCRIPTION
There were two bugs
* The hash of the `nameBuffer` was not computed
* The computed hash was 32-bit instead of 64-bit

The combination of the two bugs made the 128-bit UUID have `0`s in the first 96 bits.