### PR TITLE
Move all logic handling splices into `splice`

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -20,7 +20,6 @@ import dotty.tools.dotc.core.Constants.Constant
 import dotty.tools.dotc.tastyreflect.TastyImpl
 
 import scala.util.control.NonFatal
-import dotty.tools.dotc.util.Positions.Position
 import dotty.tools.dotc.util.SourcePosition
 
 import scala.reflect.ClassTag
@@ -35,7 +34,7 @@ object Splicer {
    *
    *  See: `ReifyQuotes`
    */
-  def splice(tree: Tree, pos: Position, classLoader: ClassLoader)(implicit ctx: Context): Tree = tree match {
+  def splice(tree: Tree, pos: SourcePosition, classLoader: ClassLoader)(implicit ctx: Context): Tree = tree match {
     case Quoted(quotedTree) => quotedTree
     case _ =>
       val interpreter = new Interpreter(pos, classLoader)
@@ -71,7 +70,7 @@ object Splicer {
   }
 
   /** Tree interpreter that evaluates the tree */
-  private class Interpreter(pos: Position, classLoader: ClassLoader)(implicit ctx: Context) extends AbstractInterpreter {
+  private class Interpreter(pos: SourcePosition, classLoader: ClassLoader)(implicit ctx: Context) extends AbstractInterpreter {
 
     type Result = Object
 
@@ -105,7 +104,7 @@ object Splicer {
 
     protected def interpretTastyContext()(implicit env: Env): Object =
       new TastyImpl(ctx) {
-        override def rootPosition: SourcePosition = SourcePosition(ctx.source, pos)
+        override def rootPosition: SourcePosition = pos
       }
 
     protected def interpretStaticMethodCall(fn: Tree, args: => List[Object])(implicit env: Env): Object = {
@@ -222,7 +221,7 @@ object Splicer {
     }
 
     /** Exception that stops interpretation if some issue is found */
-    private class StopInterpretation(val msg: String, val pos: Position) extends Exception
+    private class StopInterpretation(val msg: String, val pos: SourcePosition) extends Exception
 
   }
 

--- a/tests/neg/quote-exception/Macro_1.scala
+++ b/tests/neg/quote-exception/Macro_1.scala
@@ -4,5 +4,5 @@ object Macro_1 {
   transparent def foo(transparent b: Boolean): Unit = ~fooImpl(b)
   def fooImpl(b: Boolean): Expr[Unit] =
     if (b) '(println("foo(true)"))
-  else ???
+    else ???
 }

--- a/tests/neg/quote-macro-2-splices.scala
+++ b/tests/neg/quote-macro-2-splices.scala
@@ -1,0 +1,11 @@
+import scala.quoted._
+
+object Macro {
+
+  transparent def foo(b: Boolean): Int = { // error
+    if (b) ~bar(true)
+    else ~bar(false)
+  }
+
+  def bar(b: Boolean): Expr[Int] = if (b) '(1) else '(0)
+}

--- a/tests/neg/quote-pcp-in-arg.scala
+++ b/tests/neg/quote-pcp-in-arg.scala
@@ -1,0 +1,6 @@
+import scala.quoted._
+
+object Foo {
+  transparent def foo(x: Int): Int = ~bar('{ '(x); x }) // error
+  def bar(i: Expr[Int]): Expr[Int] = i
+}

--- a/tests/neg/splice-in-top-level-splice-1.scala
+++ b/tests/neg/splice-in-top-level-splice-1.scala
@@ -1,0 +1,7 @@
+import scala.quoted._
+
+object Foo {
+  transparent def foo(): Int = ~bar(~x) // error
+  def x: Expr[Int] = '(1)
+  def bar(i: Int): Expr[Int] = i.toExpr
+}

--- a/tests/neg/splice-in-top-level-splice-2.scala
+++ b/tests/neg/splice-in-top-level-splice-2.scala
@@ -1,0 +1,6 @@
+import scala.quoted._
+
+object Foo {
+  transparent def foo(): Int = ~(~x) // error
+  def x: Expr[Expr[Int]] = '( '(1) )
+}


### PR DESCRIPTION
THis is possible now that we have access to information
about the outer inlined tree nodes via enclosingInlineds.
In particular we can recover the position where the macro was inlined.