### PR TITLE
Fixes to transparent functions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -560,6 +560,9 @@ object Flags {
   /** A transparent method */
   final val TransparentMethod = allOf(Transparent, Method)
 
+  /** A transparent implicit method */
+  final val TransparentImplicitMethod = allOf(Transparent, Implicit, Method)
+
   /** A transparent parameter */
   final val TransparentParam = allOf(Transparent, Param)
 

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -165,7 +165,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       val leftArg = if (isRightAssoc && isInfixType(l)) "(" ~ argText(l) ~ ")" else argText(l)
       val rightArg = if (!isRightAssoc && isInfixType(r)) "(" ~ argText(r) ~ ")" else argText(r)
 
-      leftArg ~ " " ~ toTextLocal(op) ~ " " ~ rightArg
+      leftArg ~ " " ~ simpleNameString(op.classSymbol) ~ " " ~ rightArg
     }
 
     homogenize(tp) match {

--- a/tests/run/Tuple.scala
+++ b/tests/run/Tuple.scala
@@ -1,0 +1,38 @@
+import annotation.showAsInfix
+
+sealed trait Tuple
+
+object Tuple {
+  object Empty extends Tuple
+
+  type Empty = Empty.type
+
+  @showAsInfix
+  final case class *: [H, T <: Tuple](hd: H, tl: T) extends Tuple
+
+  class HListDeco(val xs: Tuple) extends AnyVal {
+    transparent def *: [H] (x: H): Tuple = Tuple.*:.apply(x, xs)
+
+    transparent def size: Int = Tuple.size(xs)
+  }
+
+  transparent def size(xs: Tuple): Int = xs match {
+    case Empty => 0
+    case _ *: xs1 => size(xs1) + 1
+  }
+
+  transparent implicit def hlistDeco(xs: Tuple): HListDeco = new HListDeco(xs)
+
+  transparent def apply(): Tuple = Empty
+  transparent def apply(x1: Any): Tuple = x1 *: Empty
+  transparent def apply(x1: Any, x2: Any) = x1 *: x2 *: Empty
+
+  val xs0 = Tuple()
+  val xs1 = Tuple(2)
+  val xs2 = Tuple(2, "a")
+  val s0 = xs0.size
+  val s1 = xs1.size
+  val s2 = xs2.size
+}
+
+object Test extends App


### PR DESCRIPTION
The end-goal is to have a nice implementation of tuples/hlists. A start is in Tuple.scala. This stresses  transparent handling in interesting ways. 