### PR TITLE
Fix incorrect ctx chain in TreeUnpickler

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -102,9 +102,10 @@ class TreeUnpickler(reader: TastyReader,
     }
   }
 
-  class Completer(owner: Symbol, reader: TastyReader) extends LazyType {
+  class Completer(owner: Symbol, reader: TastyReader)(implicit creationContext: Context) extends LazyType {
     import reader._
     def complete(denot: SymDenotation)(implicit ctx: Context): Unit = {
+      implicit val ctx = creationContext
       treeAtAddr(currentAddr) =
         new TreeReader(reader).readIndexedDef()(
           ctx.withPhaseNoLater(ctx.picklerPhase).withOwner(owner))


### PR DESCRIPTION
In this example:

```scala
object Test {
  def length(l: LIST): Boolean =
    l eq l

  sealed trait LIST
}
```

trait LIST used to have the context of method length as its outer context. After this PR TreeUnpickler follows the same pattern used in Namer.