### PR TITLE
Tasty reflect load complete definition trees

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -836,7 +836,7 @@ class TreeUnpickler(reader: TastyReader,
           tree.setComment(comment)
         }
       }
-
+      tree.symbol.tree = tree // TODO only do it under some flag?
       tree
     }
 

--- a/compiler/src/dotty/tools/dotc/fromtasty/ReadTastyTreesFromClasses.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/ReadTastyTreesFromClasses.scala
@@ -41,9 +41,9 @@ class ReadTastyTreesFromClasses extends FrontEnd {
         case cls: ClassSymbol =>
           (cls.treeOrProvider: @unchecked) match {
             case unpickler: tasty.DottyUnpickler =>
-              if (cls.tree.isEmpty) None
+              if (cls.compilationUnitTree.isEmpty) None
               else {
-                val unit = mkCompilationUnit(cls, cls.tree, forceTrees = true)
+                val unit = mkCompilationUnit(cls, cls.compilationUnitTree, forceTrees = true)
                 unit.pickled += (cls -> unpickler.unpickler.bytes)
                 Some(unit)
               }

--- a/compiler/src/dotty/tools/dotc/tastyreflect/FromSymbol.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/FromSymbol.scala
@@ -10,6 +10,7 @@ import dotty.tools.dotc.core.Types._
 object FromSymbol {
 
   def definitionFromSym(sym: Symbol)(implicit ctx: Context): tpd.Tree = {
+    assert(sym.exists)
     if (sym.is(Package)) packageDefFromSym(sym)
     else if (sym.isClass) classDef(sym.asClass)
     else if (sym.isType) typeDefFromSym(sym.asType)
@@ -19,21 +20,34 @@ object FromSymbol {
 
   def packageDefFromSym(sym: Symbol)(implicit ctx: Context): PackageDefinition = PackageDefinitionImpl(sym)
 
-  def classDef(cls: ClassSymbol)(implicit ctx: Context): tpd.TypeDef = {
-    val constrSym = cls.unforcedDecls.find(_.isPrimaryConstructor).orElse(
-      // Dummy constructor for classes such as `<refinement>`
-      ctx.newSymbol(cls, nme.CONSTRUCTOR, EmptyFlags, NoType)
-    )
-    val constr = tpd.DefDef(constrSym.asTerm)
-    val parents = cls.classParents.map(tpd.TypeTree(_))
-    val body = cls.unforcedDecls.filter(!_.isPrimaryConstructor).map(s => definitionFromSym(s))
-    tpd.ClassDefWithParents(cls, constr, parents, body)
+  def classDef(cls: ClassSymbol)(implicit ctx: Context): tpd.TypeDef = cls.tree match {
+    case tree: tpd.TypeDef => tree
+    case tpd.EmptyTree =>
+      val constrSym = cls.unforcedDecls.find(_.isPrimaryConstructor).orElse(
+        // Dummy constructor for classes such as `<refinement>`
+        ctx.newSymbol(cls, nme.CONSTRUCTOR, EmptyFlags, NoType)
+      )
+      val constr = tpd.DefDef(constrSym.asTerm)
+      val parents = cls.classParents.map(tpd.TypeTree(_))
+      val body = cls.unforcedDecls.filter(!_.isPrimaryConstructor).map(s => definitionFromSym(s))
+      tpd.ClassDefWithParents(cls, constr, parents, body)
   }
 
-  def typeDefFromSym(sym: TypeSymbol)(implicit ctx: Context): tpd.TypeDef = tpd.TypeDef(sym)
+  // TODO: this logic could be moved inside sym.tree
 
-  def defDefFromSym(sym: TermSymbol)(implicit ctx: Context): tpd.DefDef = tpd.DefDef(sym)
+  def typeDefFromSym(sym: TypeSymbol)(implicit ctx: Context): tpd.TypeDef = sym.tree match {
+    case tree: tpd.TypeDef => tree
+    case tpd.EmptyTree => tpd.TypeDef(sym)
+  }
 
-  def valDefFromSym(sym: TermSymbol)(implicit ctx: Context): tpd.ValDef = tpd.ValDef(sym)
+  def defDefFromSym(sym: TermSymbol)(implicit ctx: Context): tpd.DefDef = sym.tree match {
+    case tree: tpd.DefDef => tree
+    case tpd.EmptyTree => tpd.DefDef(sym)
+  }
+
+  def valDefFromSym(sym: TermSymbol)(implicit ctx: Context): tpd.ValDef = sym.tree match {
+    case tree: tpd.ValDef => tree
+    case tpd.EmptyTree => tpd.ValDef(sym)
+  }
 
 }

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TreeOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TreeOpsImpl.scala
@@ -13,6 +13,9 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with TastyCoreImpl with He
 
   def TreeDeco(tree: Tree): TreeAPI = new TreeAPI {
     def pos(implicit ctx: Context): Position = tree.pos
+    def definition(implicit ctx: Context): Option[Definition] =
+      if (tree.symbol.exists) Some(definitionFromSym(tree.symbol))
+      else None
   }
 
   object IsPackageClause extends IsPackageClauseExtractor {
@@ -27,10 +30,6 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with TastyCoreImpl with He
       case x: tpd.PackageDef => Some((x.pid, x.stats))
       case _ => None
     }
-  }
-
-  def PackageClauseDeco(pack: PackageClause): PackageClauseAPI = new PackageClauseAPI {
-    def definition(implicit ctx: Context): Definition = packageDefFromSym(pack.symbol)
   }
 
   // ----- Statements -----------------------------------------------
@@ -342,7 +341,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with TastyCoreImpl with He
     }
 
     object Inlined extends InlinedExtractor {
-      def unapply(x: Term)(implicit ctx: Context): Option[(Option[Term], List[Statement], Term)] = x match {
+      def unapply(x: Term)(implicit ctx: Context): Option[(Option[Parent], List[Statement], Term)] = x match {
         case x: tpd.Inlined =>
           Some((optional(x.call), x.bindings, x.expansion))
         case _ => None

--- a/library/src/scala/tasty/reflect/TreeOps.scala
+++ b/library/src/scala/tasty/reflect/TreeOps.scala
@@ -5,6 +5,7 @@ trait TreeOps extends TastyCore {
 
   trait TreeAPI {
     def pos(implicit ctx: Context): Position
+    def definition(implicit ctx: Context): Option[Definition]
   }
   implicit def TreeDeco(tree: Tree): TreeAPI
 
@@ -17,11 +18,6 @@ trait TreeOps extends TastyCore {
   abstract class PackageClauseExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[Tree])]
   }
-
-  trait PackageClauseAPI {
-    def definition(implicit ctx: Context): Definition
-  }
-  implicit def PackageClauseDeco(pack: PackageClause): PackageClauseAPI
 
   // ----- Statements -----------------------------------------------
 
@@ -290,7 +286,7 @@ trait TreeOps extends TastyCore {
 
     val Inlined: InlinedExtractor
     abstract class InlinedExtractor {
-      def unapply(tree: Tree)(implicit ctx: Context): Option[(Option[Term], List[Definition], Term)]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Option[Parent], List[Definition], Term)]
     }
 
     val SelectOuter: SelectOuterExtractor

--- a/library/src/scala/tasty/util/ShowExtractors.scala
+++ b/library/src/scala/tasty/util/ShowExtractors.scala
@@ -67,7 +67,9 @@ class ShowExtractors[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
       case Term.Repeated(elems) =>
         this += "Term.Repeated(" ++= elems += ")"
       case Term.Inlined(call, bindings, expansion) =>
-        this += "Term.Inlined(" += call += ", " ++= bindings += ", " += expansion += ")"
+        this += "Term.Inlined("
+        visitOption(call, visitParent)
+        this += ", " ++= bindings += ", " += expansion += ")"
       case ValDef(name, tpt, rhs) =>
         this += "ValDef(\"" += name += "\", " += tpt += ", " += rhs += ")"
       case DefDef(name, typeParams, paramss, returnTpt, rhs) =>
@@ -76,10 +78,7 @@ class ShowExtractors[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
         this += "TypeDef(\"" += name += "\", " += rhs += ")"
       case ClassDef(name, constr, parents, self, body) =>
         this += "ClassDef(\"" += name += "\", " += constr += ", "
-        visitList[Parent](parents, {
-          case IsTerm(parent) => this += parent
-          case IsTypeTree(parent) => this += parent
-        })
+        visitList[Parent](parents, visitParent)
         this += ", " += self += ", " ++= body += ")"
       case PackageDef(name, owner) =>
         this += "PackageDef(\"" += name += "\", " += owner += ")"
@@ -138,6 +137,11 @@ class ShowExtractors[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
         this += "Pattern.Alternative(" ++= patterns += ")"
       case Pattern.TypeTest(tpt) =>
         this += "Pattern.TypeTest(" += tpt += ")"
+    }
+
+    def visitParent(x: Parent): Buffer = x match {
+      case IsTerm(parent) => this += parent
+      case IsTypeTree(parent) => this += parent
     }
 
     def visitConstant(x: Constant): Buffer = x match {

--- a/library/src/scala/tasty/util/TreeAccumulator.scala
+++ b/library/src/scala/tasty/util/TreeAccumulator.scala
@@ -74,7 +74,7 @@ abstract class TreeAccumulator[X, T <: Tasty with Singleton](val tasty: T) {
       case Import(expr, selectors) =>
         foldTree(x, expr)
       case IsPackageClause(clause @ PackageClause(pid, stats)) =>
-        foldTrees(foldTree(x, pid), stats)(localCtx(clause.definition))
+        foldTrees(foldTree(x, pid), stats)(localCtx(clause.definition.get))
     }
   }
 

--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -50,7 +50,7 @@ clear_out "$OUT"
 grep -qe "def main(args: scala.Array\[scala.Predef.String\]): scala.Unit =" "$tmp"
 
 echo "testing scala.quoted.Expr.run from sbt dotr"
-"$SBT" ";dotty-compiler-bootstrapped/dotc -with-compiler tests/run-with-compiler/quote-run.scala; dotty-compiler-bootstrapped/dotr -with-compiler Test" > "$tmp"
+"$SBT" ";dotty-compiler-bootstrapped/dotc tests/run-with-compiler/quote-run.scala; dotty-compiler-bootstrapped/dotr -with-compiler Test" > "$tmp"
 grep -qe "val a: scala.Int = 3" "$tmp"
 
 

--- a/tests/run/tasty-extractors-owners.check
+++ b/tests/run/tasty-extractors-owners.check
@@ -1,27 +1,27 @@
 foo
-DefDef("main", Nil, List(List(ValDef("args", TypeTree.Synthetic(), None))), TypeTree.Synthetic(), None)
+DefDef("main", Nil, List(List(ValDef("args", TypeTree.Applied(TypeTree.TypeIdent("Array"), List(TypeTree.TypeIdent("String"))), None))), TypeTree.TypeIdent("Unit"), Some(Term.Block(Nil, Term.Inlined(Some(TypeTree.TypeIdent("Macros$")), Nil, Term.Select(Term.Apply(Term.Apply(Term.TypeApply(Term.Ident("impl"), List(TypeTree.Synthetic())), List(Term.Apply(Term.TypeApply(Term.Ident("apply"), List(TypeTree.Synthetic())), List(Term.Inlined(None, Nil, Term.Block(List(DefDef("foo", Nil, Nil, TypeTree.Synthetic(), Some(Term.Block(List(DefDef("bar", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(1)))), ValDef("bar2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(2))))), Term.Typed(Term.Ident("bar"), TypeTree.Synthetic())))), ValDef("foo2", TypeTree.Synthetic(), Some(Term.Block(List(DefDef("baz", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(3)))), ValDef("baz2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(4))))), Term.Typed(Term.Ident("baz"), TypeTree.Synthetic())))), ClassDef("A", DefDef("<init>", Nil, List(Nil), TypeTree.Synthetic(), None), List(Term.Apply(Term.Select(Term.New(TypeTree.Synthetic()), "<init>", Some(Signature(Nil, java.lang.Object))), Nil)), None, List(TypeDef("B", TypeTree.TypeIdent("Int")), DefDef("b", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(5)))), ValDef("b2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(6))))))), Term.Literal(Constant.Unit()))))))), List(Term.Select(Term.Ident("TopLevelSplice"), "tastyContext", Some(Signature(Nil, scala.tasty.Tasty))))), "unary_~", Some(Signature(Nil, java.lang.Object)))))))
 
 bar
-DefDef("foo", Nil, Nil, TypeTree.Synthetic(), None)
+DefDef("foo", Nil, Nil, TypeTree.Synthetic(), Some(Term.Block(List(DefDef("bar", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(1)))), ValDef("bar2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(2))))), Term.Typed(Term.Ident("bar"), TypeTree.Synthetic()))))
 
 bar2
-DefDef("foo", Nil, Nil, TypeTree.Synthetic(), None)
+DefDef("foo", Nil, Nil, TypeTree.Synthetic(), Some(Term.Block(List(DefDef("bar", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(1)))), ValDef("bar2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(2))))), Term.Typed(Term.Ident("bar"), TypeTree.Synthetic()))))
 
 foo2
-DefDef("main", Nil, List(List(ValDef("args", TypeTree.Synthetic(), None))), TypeTree.Synthetic(), None)
+DefDef("main", Nil, List(List(ValDef("args", TypeTree.Applied(TypeTree.TypeIdent("Array"), List(TypeTree.TypeIdent("String"))), None))), TypeTree.TypeIdent("Unit"), Some(Term.Block(Nil, Term.Inlined(Some(TypeTree.TypeIdent("Macros$")), Nil, Term.Select(Term.Apply(Term.Apply(Term.TypeApply(Term.Ident("impl"), List(TypeTree.Synthetic())), List(Term.Apply(Term.TypeApply(Term.Ident("apply"), List(TypeTree.Synthetic())), List(Term.Inlined(None, Nil, Term.Block(List(DefDef("foo", Nil, Nil, TypeTree.Synthetic(), Some(Term.Block(List(DefDef("bar", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(1)))), ValDef("bar2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(2))))), Term.Typed(Term.Ident("bar"), TypeTree.Synthetic())))), ValDef("foo2", TypeTree.Synthetic(), Some(Term.Block(List(DefDef("baz", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(3)))), ValDef("baz2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(4))))), Term.Typed(Term.Ident("baz"), TypeTree.Synthetic())))), ClassDef("A", DefDef("<init>", Nil, List(Nil), TypeTree.Synthetic(), None), List(Term.Apply(Term.Select(Term.New(TypeTree.Synthetic()), "<init>", Some(Signature(Nil, java.lang.Object))), Nil)), None, List(TypeDef("B", TypeTree.TypeIdent("Int")), DefDef("b", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(5)))), ValDef("b2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(6))))))), Term.Literal(Constant.Unit()))))))), List(Term.Select(Term.Ident("TopLevelSplice"), "tastyContext", Some(Signature(Nil, scala.tasty.Tasty))))), "unary_~", Some(Signature(Nil, java.lang.Object)))))))
 
 baz
-ValDef("foo2", TypeTree.Synthetic(), None)
+ValDef("foo2", TypeTree.Synthetic(), Some(Term.Block(List(DefDef("baz", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(3)))), ValDef("baz2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(4))))), Term.Typed(Term.Ident("baz"), TypeTree.Synthetic()))))
 
 baz2
-ValDef("foo2", TypeTree.Synthetic(), None)
+ValDef("foo2", TypeTree.Synthetic(), Some(Term.Block(List(DefDef("baz", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(3)))), ValDef("baz2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(4))))), Term.Typed(Term.Ident("baz"), TypeTree.Synthetic()))))
 
 <init>
-ClassDef("A", DefDef("<init>", Nil, List(Nil), TypeTree.Synthetic(), None), List(TypeTree.Synthetic()), None, List(TypeDef("B", SyntheticBounds()), DefDef("b", Nil, Nil, TypeTree.Synthetic(), None), ValDef("b2", TypeTree.Synthetic(), None)))
+ClassDef("A", DefDef("<init>", Nil, List(Nil), TypeTree.Synthetic(), None), List(Term.Apply(Term.Select(Term.New(TypeTree.Synthetic()), "<init>", Some(Signature(Nil, java.lang.Object))), Nil)), None, List(TypeDef("B", TypeTree.TypeIdent("Int")), DefDef("b", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(5)))), ValDef("b2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(6))))))
 
 b
-ClassDef("A", DefDef("<init>", Nil, List(Nil), TypeTree.Synthetic(), None), List(TypeTree.Synthetic()), None, List(TypeDef("B", SyntheticBounds()), DefDef("b", Nil, Nil, TypeTree.Synthetic(), None), ValDef("b2", TypeTree.Synthetic(), None)))
+ClassDef("A", DefDef("<init>", Nil, List(Nil), TypeTree.Synthetic(), None), List(Term.Apply(Term.Select(Term.New(TypeTree.Synthetic()), "<init>", Some(Signature(Nil, java.lang.Object))), Nil)), None, List(TypeDef("B", TypeTree.TypeIdent("Int")), DefDef("b", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(5)))), ValDef("b2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(6))))))
 
 b2
-ClassDef("A", DefDef("<init>", Nil, List(Nil), TypeTree.Synthetic(), None), List(TypeTree.Synthetic()), None, List(TypeDef("B", SyntheticBounds()), DefDef("b", Nil, Nil, TypeTree.Synthetic(), None), ValDef("b2", TypeTree.Synthetic(), None)))
+ClassDef("A", DefDef("<init>", Nil, List(Nil), TypeTree.Synthetic(), None), List(Term.Apply(Term.Select(Term.New(TypeTree.Synthetic()), "<init>", Some(Signature(Nil, java.lang.Object))), Nil)), None, List(TypeDef("B", TypeTree.TypeIdent("Int")), DefDef("b", Nil, Nil, TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(5)))), ValDef("b2", TypeTree.Synthetic(), Some(Term.Literal(Constant.Int(6))))))
 

--- a/tests/run/tasty-load-tree-1.check
+++ b/tests/run/tasty-load-tree-1.check
@@ -1,0 +1,2 @@
+DefDef("foo", Nil, Nil, TypeTree.TypeIdent("Int"), Some(Term.Apply(Term.Select(Term.Literal(Constant.Int(1)), "+", Some(Signature(List(scala.Int), scala.Int))), List(Term.Literal(Constant.Int(2))))))
+ValDef("bar", TypeTree.TypeIdent("Int"), Some(Term.Apply(Term.Select(Term.Literal(Constant.Int(2)), "+", Some(Signature(List(scala.Int), scala.Int))), List(Term.Literal(Constant.Int(3))))))

--- a/tests/run/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run/tasty-load-tree-1/quoted_1.scala
@@ -1,0 +1,26 @@
+import scala.quoted._
+
+import scala.tasty._
+
+object Foo {
+
+  transparent def inspectBody(i: => Int): String =
+    ~inspectBodyImpl('(i))(TopLevelSplice.tastyContext) // FIXME infer TopLevelSplice.tastyContext within top level ~
+
+  def inspectBodyImpl(x: Expr[Int])(implicit tasty: Tasty): Expr[String] = {
+    import tasty._
+
+    def definitionString(tree: Tree): Expr[String] = tree.definition match {
+      case Some(definition) => definition.show.toExpr
+      case None => '("NO DEFINTION")
+    }
+
+    x.toTasty match {
+      case Term.Inlined(None, Nil, arg) => definitionString(arg)
+      case arg => definitionString(arg) // TODO should all by name parameters be in an inline node
+    }
+  }
+
+  def foo: Int = 1 + 2
+  val bar: Int = 2 + 3
+}

--- a/tests/run/tasty-load-tree-1/quoted_2.scala
+++ b/tests/run/tasty-load-tree-1/quoted_2.scala
@@ -1,0 +1,7 @@
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    println(Foo.inspectBody(Foo.foo))
+    println(Foo.inspectBody(Foo.bar))
+  }
+}

--- a/tests/run/tasty-load-tree-2.check
+++ b/tests/run/tasty-load-tree-2.check
@@ -1,0 +1,2 @@
+DefDef("foo", Nil, Nil, TypeTree.TypeIdent("Int"), Some(Term.Apply(Term.Select(Term.Literal(Constant.Int(1)), "+", Some(Signature(List(scala.Int), scala.Int))), List(Term.Literal(Constant.Int(2))))))
+ValDef("bar", TypeTree.TypeIdent("Int"), Some(Term.Apply(Term.Select(Term.Literal(Constant.Int(2)), "+", Some(Signature(List(scala.Int), scala.Int))), List(Term.Literal(Constant.Int(3))))))

--- a/tests/run/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run/tasty-load-tree-2/quoted_1.scala
@@ -1,0 +1,23 @@
+import scala.quoted._
+
+import scala.tasty._
+
+object Foo {
+
+  transparent def inspectBody(i: => Int): String =
+    ~inspectBodyImpl('(i))(TopLevelSplice.tastyContext) // FIXME infer TopLevelSplice.tastyContext within top level ~
+
+  def inspectBodyImpl(x: Expr[Int])(implicit tasty: Tasty): Expr[String] = {
+    import tasty._
+
+    def definitionString(tree: Tree): Expr[String] = tree.definition match {
+      case Some(definition) => definition.show.toExpr
+      case None => '("NO DEFINTION")
+    }
+
+    x.toTasty match {
+      case Term.Inlined(None, Nil, arg) => definitionString(arg)
+      case arg => definitionString(arg) // TODO should all by name parameters be in an inline node
+    }
+  }
+}

--- a/tests/run/tasty-load-tree-2/quoted_2.scala
+++ b/tests/run/tasty-load-tree-2/quoted_2.scala
@@ -1,0 +1,10 @@
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    println(Foo.inspectBody(foo))
+    println(Foo.inspectBody(bar))
+  }
+
+  def foo: Int = 1 + 2
+  val bar: Int = 2 + 3
+}


### PR DESCRIPTION
The goal is to have a way to load the tree from a symbol. 

The current scheme keeps any definition tree created while unpickling in the symbol directly. For symbols defined in classes that are being compiled are set during pickling.

Alternatively we could try to recover the tree by traversing the tree of the top level class, but this would not be performant. It could be implemented with some cache of some sort.

This is related to #2862