### PR TITLE
Remove class tags from Tasty reflect interface

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/TastyImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TastyImpl.scala
@@ -74,14 +74,14 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object IsPackageClause extends IsPackageClauseExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[PackageClause] = tree match {
-      case x: tpd.PackageDef @unchecked => Some(x)
+      case x: tpd.PackageDef => Some(x)
       case _ => None
     }
   }
 
   object PackageClause extends PackageClauseExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[Tree])] = tree match {
-      case x: tpd.PackageDef @unchecked => Some((x.pid, x.stats))
+      case x: tpd.PackageDef => Some((x.pid, x.stats))
       case _ => None
     }
   }
@@ -98,7 +98,7 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object Import extends ImportExtractor {
     def unapply(x: Tree)(implicit ctx: Context): Option[(Term, List[ImportSelector])] = x match {
-      case x: tpd.Import @unchecked => Some((x.expr, x.selectors))
+      case x: tpd.Import => Some((x.expr, x.selectors))
       case _ => None
     }
   }
@@ -181,14 +181,14 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object IsClassDef extends IsClassDefExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[ClassDef] = tree match {
-      case x: tpd.TypeDef @unchecked if x.isClassDef => Some(x)
+      case x: tpd.TypeDef if x.isClassDef => Some(x)
       case _ => None
     }
   }
 
   object ClassDef extends ClassDefExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, DefDef, List[Parent],  Option[ValDef], List[Statement])] = tree match {
-      case x: tpd.TypeDef @unchecked if x.isClassDef =>
+      case x: tpd.TypeDef if x.isClassDef =>
         val deco = ClassDefDeco(x)
         Some((x.name.toString, deco.constructor, deco.parents, deco.self, deco.body))
       case _ => None
@@ -209,14 +209,14 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object IsDefDef extends IsDefDefExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[DefDef] = tree match {
-      case x: tpd.DefDef @unchecked => Some(x)
+      case x: tpd.DefDef => Some(x)
       case _ => None
     }
   }
 
   object DefDef extends DefDefExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, List[TypeDef],  List[List[ValDef]], TypeTree, Option[Term])] = tree match {
-      case x: tpd.DefDef @unchecked =>
+      case x: tpd.DefDef =>
         Some((x.name.toString, x.tparams, x.vparamss, x.tpt, optional(x.rhs)))
       case _ => None
     }
@@ -235,14 +235,14 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object IsValDef extends IsValDefExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[ValDef] = tree match {
-      case x: tpd.ValDef @unchecked => Some(x)
+      case x: tpd.ValDef => Some(x)
       case _ => None
     }
   }
 
   object ValDef extends ValDefExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, TypeTree, Option[Term])] = tree match {
-      case x: tpd.ValDef @unchecked =>
+      case x: tpd.ValDef =>
         Some((x.name.toString, x.tpt, optional(x.rhs)))
       case _ => None
     }
@@ -259,14 +259,14 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object IsTypeDef extends IsTypeDefExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[TypeDef] = tree match {
-      case x: tpd.TypeDef @unchecked if !x.symbol.isClass => Some(x)
+      case x: tpd.TypeDef if !x.symbol.isClass => Some(x)
       case _ => None
     }
   }
 
   object TypeDef extends TypeDefExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, TypeOrBoundsTree /* TypeTree | TypeBoundsTree */)] = tree match {
-      case x: tpd.TypeDef @unchecked if !x.symbol.isClass => Some((x.name.toString, x.rhs))
+      case x: tpd.TypeDef if !x.symbol.isClass => Some((x.name.toString, x.rhs))
       case _ => None
     }
   }
@@ -359,14 +359,14 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
     object Ident extends IdentExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[String] = x match {
-        case x: tpd.Ident @unchecked if x.isTerm => Some(x.name.show)
+        case x: tpd.Ident if x.isTerm => Some(x.name.show)
         case _ => None
       }
     }
 
     object Select extends SelectExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, String, Option[Signature])] = x match {
-        case x: tpd.Select @unchecked if x.isTerm =>
+        case x: tpd.Select if x.isTerm =>
           val sig =
             if (x.symbol.signature == core.Signature.NotAMethod) None
             else Some(x.symbol.signature)
@@ -391,49 +391,49 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
     object New extends NewExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[TypeTree] = x match {
-        case x: tpd.New @unchecked => Some(x.tpt)
+        case x: tpd.New => Some(x.tpt)
         case _ => None
       }
     }
 
     object NamedArg extends NamedArgExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(String, Term)] = x match {
-        case x: tpd.NamedArg @unchecked if x.name.isInstanceOf[Names.TermName] => Some((x.name.toString, x.arg))
+        case x: tpd.NamedArg if x.name.isInstanceOf[Names.TermName] => Some((x.name.toString, x.arg))
         case _ => None
       }
     }
 
     object Apply extends ApplyExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[Term])] = x match {
-        case x: tpd.Apply @unchecked => Some((x.fun, x.args))
+        case x: tpd.Apply => Some((x.fun, x.args))
         case _ => None
       }
     }
 
     object TypeApply extends TypeApplyExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[TypeTree])] = x match {
-        case x: tpd.TypeApply @unchecked => Some((x.fun, x.args))
+        case x: tpd.TypeApply => Some((x.fun, x.args))
         case _ => None
       }
     }
 
     object Super extends SuperExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Option[Id])] = x match {
-        case x: tpd.Super @unchecked => Some((x.qual, if (x.mix.isEmpty) None else Some(x.mix)))
+        case x: tpd.Super => Some((x.qual, if (x.mix.isEmpty) None else Some(x.mix)))
         case _ => None
       }
     }
 
     object Typed extends TypedExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, TypeTree)] = x match {
-        case x: tpd.Typed @unchecked => Some((x.expr, x.tpt))
+        case x: tpd.Typed => Some((x.expr, x.tpt))
         case _ => None
       }
     }
 
     object Assign extends AssignExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Term)] = x match {
-        case x: tpd.Assign @unchecked => Some((x.lhs, x.rhs))
+        case x: tpd.Assign => Some((x.lhs, x.rhs))
         case _ => None
       }
     }
@@ -476,7 +476,7 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
     object Inlined extends InlinedExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Option[Term], List[Statement], Term)] = x match {
-        case x: tpd.Inlined @unchecked =>
+        case x: tpd.Inlined =>
           Some((optional(x.call), x.bindings, x.expansion))
         case _ => None
       }
@@ -484,49 +484,49 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
     object Lambda extends LambdaExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Option[TypeTree])] = x match {
-        case x: tpd.Closure @unchecked => Some((x.meth, optional(x.tpt)))
+        case x: tpd.Closure => Some((x.meth, optional(x.tpt)))
         case _ => None
       }
     }
 
     object If extends IfExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Term, Term)] = x match {
-        case x: tpd.If @unchecked => Some((x.cond, x.thenp, x.elsep))
+        case x: tpd.If => Some((x.cond, x.thenp, x.elsep))
         case _ => None
       }
     }
 
     object Match extends MatchExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[CaseDef])] = x match {
-        case x: tpd.Match @unchecked => Some((x.selector, x.cases))
+        case x: tpd.Match => Some((x.selector, x.cases))
         case _ => None
       }
     }
 
     object Try extends TryExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[CaseDef], Option[Term])] = x match {
-        case x: tpd.Try @unchecked => Some((x.expr, x.cases, optional(x.finalizer)))
+        case x: tpd.Try => Some((x.expr, x.cases, optional(x.finalizer)))
         case _ => None
       }
     }
 
     object Return extends ReturnExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[Term] = x match {
-        case x: tpd.Return @unchecked => Some(x.expr)
+        case x: tpd.Return => Some(x.expr)
         case _ => None
       }
     }
 
     object Repeated extends RepeatedExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[List[Term]] = x match {
-        case x: tpd.SeqLiteral @unchecked => Some(x.elems)
+        case x: tpd.SeqLiteral => Some(x.elems)
         case _ => None
       }
     }
 
     object SelectOuter extends SelectOuterExtractor {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Int, Type)] = x match {
-        case x: tpd.Select @unchecked =>
+        case x: tpd.Select =>
           x.name match {
             case NameKinds.OuterSelectName(_, levels) => Some((x.qualifier, levels, x.tpe.stripTypeVar))
             case _ => None
@@ -572,7 +572,7 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object CaseDef extends CaseDefExtractor {
     def unapply(x: CaseDef): Option[(Pattern, Option[Term], Term)] = x match {
-      case x: tpd.CaseDef @unchecked =>
+      case x: tpd.CaseDef =>
         Some(x.pat, optional(x.guard), x.body)
       case _ => None
     }
@@ -592,16 +592,16 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
     object Value extends ValueExtractor {
       def unapply(x: Pattern)(implicit ctx: Context): Option[Term] = x match {
-        case lit: tpd.Literal @unchecked => Some(lit)
-        case ref: tpd.RefTree @unchecked if ref.isTerm => Some(ref)
-        case ths: tpd.This @unchecked => Some(ths)
+        case lit: tpd.Literal => Some(lit)
+        case ref: tpd.RefTree if ref.isTerm => Some(ref)
+        case ths: tpd.This => Some(ths)
         case _ => None
       }
     }
 
     object Bind extends BindExtractor {
       def unapply(x: Pattern)(implicit ctx: Context): Option[(String, Pattern)] = x match {
-        case x: tpd.Bind @unchecked if x.name.isTermName => Some(x.name.toString, x.body)
+        case x: tpd.Bind if x.name.isTermName => Some(x.name.toString, x.body)
         case _ => None
       }
     }
@@ -620,7 +620,7 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
     object Alternative extends AlternativeExtractor {
       def unapply(x: Pattern)(implicit ctx: Context): Option[List[Pattern]] = x match {
-        case x: tpd.Alternative @unchecked => Some(x.trees)
+        case x: tpd.Alternative => Some(x.trees)
         case _ => None
       }
     }
@@ -672,70 +672,70 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
     object TypeIdent extends TypeIdentExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[String] = x match {
-        case x: tpd.Ident @unchecked if x.isType => Some(x.name.toString)
+        case x: tpd.Ident if x.isType => Some(x.name.toString)
         case _ => None
       }
     }
 
     object TermSelect extends TermSelectExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(Term, String)] = x match {
-        case x: tpd.Select @unchecked if x.isType && x.qualifier.isTerm => Some(x.qualifier, x.name.toString)
+        case x: tpd.Select if x.isType && x.qualifier.isTerm => Some(x.qualifier, x.name.toString)
         case _ => None
       }
     }
 
     object TypeSelect extends TypeSelectExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, String)] = x match {
-        case x: tpd.Select @unchecked if x.isType && x.qualifier.isType => Some(x.qualifier, x.name.toString)
+        case x: tpd.Select if x.isType && x.qualifier.isType => Some(x.qualifier, x.name.toString)
         case _ => None
       }
     }
 
     object Singleton extends SingletonExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[Term] = x match {
-        case x: tpd.SingletonTypeTree @unchecked => Some(x.ref)
+        case x: tpd.SingletonTypeTree => Some(x.ref)
         case _ => None
       }
     }
 
     object Refined extends RefinedExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, List[Definition])] = x match {
-        case x: tpd.RefinedTypeTree @unchecked => Some(x.tpt, x.refinements)
+        case x: tpd.RefinedTypeTree => Some(x.tpt, x.refinements)
         case _ => None
       }
     }
 
     object Applied extends AppliedExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, List[TypeOrBoundsTree])] = x match {
-        case x: tpd.AppliedTypeTree @unchecked => Some(x.tpt, x.args)
+        case x: tpd.AppliedTypeTree => Some(x.tpt, x.args)
         case _ => None
       }
     }
 
     object Annotated extends AnnotatedExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, Term)] = x match {
-        case x: tpd.Annotated @unchecked => Some(x.arg, x.annot)
+        case x: tpd.Annotated => Some(x.arg, x.annot)
         case _ => None
       }
     }
 
     object And extends AndExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)] = x match {
-        case x: tpd.AndTypeTree @unchecked => Some(x.left, x.right)
+        case x: tpd.AndTypeTree => Some(x.left, x.right)
         case _ => None
       }
     }
 
     object Or extends OrExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)] = x match {
-        case x: tpd.OrTypeTree @unchecked => Some(x.left, x.right)
+        case x: tpd.OrTypeTree => Some(x.left, x.right)
         case _ => None
       }
     }
 
     object ByName extends ByNameExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[TypeTree] = x match {
-        case x: tpd.ByNameTypeTree @unchecked => Some(x.result)
+        case x: tpd.ByNameTypeTree => Some(x.result)
         case _ => None
       }
     }
@@ -749,7 +749,7 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
     object Bind extends BindExtractor {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(String, TypeBoundsTree)] = x match {
-        case x: tpd.Bind @unchecked if x.name.isTypeName => Some((x.name.toString, x.body))
+        case x: tpd.Bind if x.name.isTypeName => Some((x.name.toString, x.body))
         case _ => None
       }
     }
@@ -767,14 +767,14 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object IsTypeBoundsTree extends IsTypeBoundsTreeExtractor {
     def unapply(x: TypeOrBoundsTree)(implicit ctx: Context): Option[TypeBoundsTree] = x match {
-      case x: tpd.TypeBoundsTree @unchecked => Some(x)
+      case x: tpd.TypeBoundsTree => Some(x)
       case _ => None
     }
   }
 
   object TypeBoundsTree extends TypeBoundsTreeExtractor {
     def unapply(x: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)] = x match {
-      case x: tpd.TypeBoundsTree @unchecked => Some(x.lo, x.hi)
+      case x: tpd.TypeBoundsTree => Some(x.lo, x.hi)
       case _ => None
     }
   }

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TastyImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TastyImpl.scala
@@ -133,11 +133,12 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   // ----- Definitions ----------------------------------------------
 
-  type Definition = tpd.Tree
+  type Definition = tpd.Tree /* tpd.MemberDef | PackageDefinition */
 
   object IsDefinition extends IsDefinitionExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[Definition] = tree match {
       case tree: tpd.MemberDef => Some(tree)
+      case tree: PackageDefinition => Some(tree)
       case _ => None
     }
   }

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TastyImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TastyImpl.scala
@@ -189,15 +189,14 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object ClassDef extends ClassDefExtractor {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, DefDef, List[Parent],  Option[ValDef], List[Statement])] = tree match {
-      case x: tpd.TypeDef if x.isClassDef =>
-        val deco = ClassDefDeco(x)
-        Some((x.name.toString, deco.constructor, deco.parents, deco.self, deco.body))
+      case Trees.TypeDef(name, impl: tpd.Template) =>
+        Some((name.toString, impl.constr, impl.parents, optional(impl.self), impl.body))
       case _ => None
     }
   }
 
   def ClassDefDeco(cdef: ClassDef): ClassDefAPI = new ClassDefAPI {
-    private[this] val rhs = cdef.rhs.asInstanceOf[tpd.Template]
+    private def rhs = cdef.rhs.asInstanceOf[tpd.Template]
     def constructor(implicit ctx: Context): DefDef = rhs.constr
     def parents(implicit ctx: Context): List[tpd.Tree] = rhs.parents
     def self(implicit ctx: Context): Option[tpd.ValDef] = optional(rhs.self)

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TastyImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TastyImpl.scala
@@ -62,7 +62,7 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object Id extends IdExtractor {
     def unapply(x: Id): Option[String] = x match {
-      case x: untpd.Ident => Some(x.name.toString) // TODO how to make sure it is not a Ident or TypeIdent? Check x.tpe?
+      case x: untpd.Ident => Some(x.name.toString)
       case _ => None
     }
   }
@@ -117,7 +117,7 @@ class TastyImpl(val rootContext: Contexts.Context) extends scala.tasty.Tasty wit
 
   object SimpleSelector extends SimpleSelectorExtractor {
     def unapply(x: ImportSelector)(implicit ctx: Context): Option[Id] = x match {
-      case x: untpd.Ident => Some(x) // TODO make sure it will not match other idents
+      case x: untpd.Ident => Some(x)
       case _ => None
     }
   }

--- a/library/src/scala/tasty/Tasty.scala
+++ b/library/src/scala/tasty/Tasty.scala
@@ -1,6 +1,5 @@
 package scala.tasty
 
-import scala.reflect.ClassTag
 import scala.tasty.reflect.StandardDefinitions
 import scala.tasty.util.Show
 
@@ -11,12 +10,12 @@ abstract class Tasty extends StandardDefinitions { tasty =>
   trait QuotedExprAPI {
     def toTasty(implicit ctx: Context): Term
   }
-  implicit def QuotedExprDeco[T](x: quoted.Expr[T]): QuotedExprAPI
+  implicit def QuotedExprDeco[T](expr: quoted.Expr[T]): QuotedExprAPI
 
   trait QuotedTypeAPI {
     def toTasty(implicit ctx: Context): TypeTree
   }
-  implicit def QuotedTypeDeco[T](x: quoted.Type[T]): QuotedTypeAPI
+  implicit def QuotedTypeDeco[T](tpe: quoted.Type[T]): QuotedTypeAPI
 
   // ===== Show =====================================================
 
@@ -52,11 +51,9 @@ abstract class Tasty extends StandardDefinitions { tasty =>
   }
   implicit def IdDeco(id: Id): IdAPI
 
-  implicit def idClassTag: ClassTag[Id]
-
   val Id: IdExtractor
   abstract class IdExtractor {
-    def unapply(x: Id): Option[String]
+    def unapply(id: Id): Option[String]
   }
 
   // ===== Trees ====================================================
@@ -70,11 +67,14 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type PackageClause <: Tree
 
-  implicit def packageClauseClassTag: ClassTag[PackageClause]
+  val IsPackageClause: IsPackageClauseExtractor
+  abstract class IsPackageClauseExtractor {
+    def unapply(tree: Tree)(implicit ctx: Context): Option[PackageClause]
+  }
 
   val PackageClause: PackageClauseExtractor
   abstract class PackageClauseExtractor {
-    def unapply(x: PackageClause)(implicit ctx: Context): Option[(Term, List[Tree])]
+    def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[Tree])]
   }
 
   trait PackageClauseAPI {
@@ -88,11 +88,9 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type Import <: Statement
 
-  implicit def importClassTag: ClassTag[Import]
-
   val Import: ImportExtractor
   abstract class ImportExtractor {
-    def unapply(x: Import)(implicit ctx: Context): Option[(Term, List[ImportSelector])]
+    def unapply(imp: Tree)(implicit ctx: Context): Option[(Term, List[ImportSelector])]
   }
 
   trait ImportAPI {
@@ -103,33 +101,29 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type ImportSelector
 
-  implicit def importSelectorClassTag: ClassTag[ImportSelector]
-
   val SimpleSelector: SimpleSelectorExtractor
   abstract class SimpleSelectorExtractor {
-    def unapply(x: ImportSelector)(implicit ctx: Context): Option[Id]
+    def unapply(importSelector: ImportSelector)(implicit ctx: Context): Option[Id]
   }
 
   val RenameSelector: RenameSelectorExtractor
   abstract class RenameSelectorExtractor {
-    def unapply(x: ImportSelector)(implicit ctx: Context): Option[(Id, Id)]
+    def unapply(importSelector: ImportSelector)(implicit ctx: Context): Option[(Id, Id)]
   }
 
   val OmitSelector: OmitSelectorExtractor
   abstract class OmitSelectorExtractor {
-    def unapply(x: ImportSelector)(implicit ctx: Context): Option[Id]
+    def unapply(importSelector: ImportSelector)(implicit ctx: Context): Option[Id]
   }
 
   // ----- Definitions ----------------------------------------------
 
   type Definition <: Statement
 
-  val Definition: DefinitionExtractor
-  abstract class DefinitionExtractor {
-    def unapply(x: Definition)(implicit ctx: Context): Boolean
+  val IsDefinition: IsDefinitionExtractor
+  abstract class IsDefinitionExtractor {
+    def unapply(tree: Tree)(implicit ctx: Context): Option[Definition]
   }
-
-  implicit def definitionClassTag: ClassTag[Definition]
 
   trait DefinitionAPI {
     def name(implicit ctx: Context): String
@@ -146,11 +140,14 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type ClassDef <: Definition
 
-  implicit def classDefClassTag: ClassTag[ClassDef]
+  val IsClassDef: IsClassDefExtractor
+  abstract class IsClassDefExtractor {
+    def unapply(tree: Tree)(implicit ctx: Context): Option[ClassDef]
+  }
 
   val ClassDef: ClassDefExtractor
   abstract class ClassDefExtractor {
-    def unapply(x: ClassDef)(implicit ctx: Context): Option[(String, DefDef, List[Parent], Option[ValDef], List[Statement])]
+    def unapply(tree: Tree)(implicit ctx: Context): Option[(String, DefDef, List[Parent], Option[ValDef], List[Statement])]
   }
 
   trait ClassDefAPI {
@@ -165,11 +162,14 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type DefDef <: Definition
 
-  implicit def defDefClassTag: ClassTag[DefDef]
+  val IsDefDef: IsDefDefExtractor
+  abstract class IsDefDefExtractor {
+    def unapply(tree: Tree)(implicit ctx: Context): Option[DefDef]
+  }
 
   val DefDef: DefDefExtractor
   abstract class DefDefExtractor {
-    def unapply(x: DefDef)(implicit ctx: Context): Option[(String, List[TypeDef],  List[List[ValDef]], TypeTree, Option[Term])]
+    def unapply(tree: Tree)(implicit ctx: Context): Option[(String, List[TypeDef],  List[List[ValDef]], TypeTree, Option[Term])]
   }
 
   trait DefDefAPI {
@@ -184,11 +184,14 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type ValDef <: Definition
 
-  implicit def valDefClassTag: ClassTag[ValDef]
+  val IsValDef: IsValDefExtractor
+  abstract class IsValDefExtractor {
+    def unapply(tree: Tree)(implicit ctx: Context): Option[ValDef]
+  }
 
   val ValDef: ValDefExtractor
   abstract class ValDefExtractor {
-    def unapply(x: ValDef)(implicit ctx: Context): Option[(String, TypeTree, Option[Term])]
+    def unapply(tree: Tree)(implicit ctx: Context): Option[(String, TypeTree, Option[Term])]
   }
 
   trait ValDefAPI {
@@ -201,11 +204,14 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type TypeDef <: Definition
 
-  implicit def typeDefClassTag: ClassTag[TypeDef]
+  val IsTypeDef: IsTypeDefExtractor
+  abstract class IsTypeDefExtractor {
+    def unapply(tree: Tree)(implicit ctx: Context): Option[TypeDef]
+  }
 
   val TypeDef: TypeDefExtractor
   abstract class TypeDefExtractor {
-    def unapply(x: TypeDef)(implicit ctx: Context): Option[(String, TypeOrBoundsTree /* TypeTree | TypeBoundsTree */)]
+    def unapply(tree: Tree)(implicit ctx: Context): Option[(String, TypeOrBoundsTree /* TypeTree | TypeBoundsTree */)]
   }
 
   trait TypeDefAPI {
@@ -217,17 +223,20 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type PackageDef <: Definition
 
+  val IsPackageDef: IsPackageDefExtractor
+  abstract class IsPackageDefExtractor {
+    def unapply(tree: Tree)(implicit ctx: Context): Option[PackageDef]
+  }
+
   trait PackageDefAPI {
     def owner(implicit ctx: Context): PackageDef
     def members(implicit ctx: Context): List[Statement]
   }
   implicit def PackageDefDeco(pdef: PackageDef): PackageDefAPI
 
-  implicit def packageDefClassTag: ClassTag[PackageDef]
-
   val PackageDef: PackageDefExtractor
   abstract class PackageDefExtractor {
-    def unapply(x: PackageDef)(implicit ctx: Context): Option[(String, PackageDef)]
+    def unapply(tree: Tree)(implicit ctx: Context): Option[(String, PackageDef)]
   }
 
   // ----- Parents --------------------------------------------------
@@ -243,164 +252,165 @@ abstract class Tasty extends StandardDefinitions { tasty =>
   }
   implicit def TermDeco(term: Term): TermAPI
 
-  implicit def termClassTag: ClassTag[Term]
+  val IsTerm: IsTermExtractor
+  abstract class IsTermExtractor {
+    /** Matches any term */
+    def unapply(tree: Tree)(implicit ctx: Context): Option[Term]
+    /** Matches any term */
+    def unapply(parent: Parent)(implicit ctx: Context, dummy: DummyImplicit): Option[Term]
+  }
 
   /** Scala term. Any tree that can go in expression position. */
   val Term: TermModule
   abstract class TermModule {
 
-    /** Matches any term */
-    def unapply(x: Term)(implicit ctx: Context): Boolean
-
     /** Scala term identifier */
     val Ident: IdentExtractor
     abstract class IdentExtractor {
       /** Matches a term identifier and returns its name */
-      def unapply(x: Term)(implicit ctx: Context): Option[String]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[String]
     }
 
     /** Scala term selection */
     val Select: SelectExtractor
     abstract class SelectExtractor {
       /** Matches `<qual: Term>.<name: String>: <sig: Signature>` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, String, Option[Signature])]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, String, Option[Signature])]
     }
 
     /** Scala literal constant */
     val Literal: LiteralExtractor
     abstract class LiteralExtractor {
-      def unapply(x: Term)(implicit ctx: Context): Option[Constant]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[Constant]
     }
 
     /** Scala `this` or `this[id]` */
     val This: ThisExtractor
     abstract class ThisExtractor {
       /** Matches new `this[<id: Option[Id]>` */
-      def unapply(x: Term)(implicit ctx: Context): Option[Option[Id]]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[Option[Id]]
     }
 
     /** Scala `new` */
     val New: NewExtractor
     abstract class NewExtractor {
       /** Matches new `new <tpt: TypeTree>` */
-      def unapply(x: Term)(implicit ctx: Context): Option[TypeTree]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[TypeTree]
     }
 
     /** Scala named argument `x = y` in argument position */
     val NamedArg: NamedArgExtractor
     abstract class NamedArgExtractor {
       /** Matches `<name: String> = <value: Term>` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(String, Term)]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(String, Term)]
     }
 
     /** Scala parameter application */
     val Apply: ApplyExtractor
     abstract class ApplyExtractor {
       /** Matches function application `<fun: Term>(<args: List[Term]>)` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[Term])]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[Term])]
     }
 
     /** Scala type parameter application */
     val TypeApply: TypeApplyExtractor
     abstract class TypeApplyExtractor {
       /** Matches function type application `<fun: Term>[<args: List[TypeTree]>]` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[TypeTree])]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[TypeTree])]
     }
 
     /** Scala `x.super` or `x.super[id]` */
     val Super: SuperExtractor
     abstract class SuperExtractor {
       /** Matches new `<qualifier: Term>.super[<id: Option[Id]>` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, Option[Id])]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Option[Id])]
     }
 
     /** Scala ascription `x: T` */
     val Typed: TypedExtractor
     abstract class TypedExtractor {
       /** Matches `<x: Term>: <tpt: Term>` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, TypeTree)]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, TypeTree)]
     }
 
     /** Scala assign `x = y` */
     val Assign: AssignExtractor
     abstract class AssignExtractor {
       /** Matches `<lhs: Term> = <rhs: Term>` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, Term)]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Term)]
     }
 
     /** Scala code block `{ stat0; ...; statN; expr }` term */
     val Block: BlockExtractor
     abstract class BlockExtractor {
       /** Matches `{ <statements: List[Statement]>; <expr: Term> }` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(List[Statement], Term)]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(List[Statement], Term)]
     }
 
     val Lambda: LambdaExtractor
     abstract class LambdaExtractor {
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, Option[TypeTree])]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Option[TypeTree])]
     }
 
     /** Scala `if`/`else` term */
     val If: IfExtractor
     abstract class IfExtractor {
       /** Matches `if (<cond: Term>) <thenp: Term> else <elsep: Term>` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, Term, Term)]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Term, Term)]
     }
 
     /** Scala `match` term */
     val Match: MatchExtractor
     abstract class MatchExtractor {
       /** Matches `<scrutinee: Trem> match { <cases: List[CaseDef]> }` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[CaseDef])]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[CaseDef])]
     }
 
     /** Scala `try`/`catch`/`finally` term */
     val Try: TryExtractor
     abstract class TryExtractor {
       /** Matches `try <body: Term> catch { <cases: List[CaseDef]> } finally <finalizer: Option[Term]>` */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[CaseDef], Option[Term])]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[CaseDef], Option[Term])]
     }
 
     /** Scala local `return` */
     val Return: ReturnExtractor
     abstract class ReturnExtractor {
       /** Matches `return <expr: Term>` */
-      def unapply(x: Term)(implicit ctx: Context): Option[Term]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[Term]
     }
 
     val Repeated: RepeatedExtractor
     abstract class RepeatedExtractor {
-      def unapply(x: Term)(implicit ctx: Context): Option[List[Term]]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[List[Term]]
     }
 
     val Inlined: InlinedExtractor
     abstract class InlinedExtractor {
-      def unapply(x: Term)(implicit ctx: Context): Option[(Option[Term], List[Definition], Term)]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Option[Term], List[Definition], Term)]
     }
 
     val SelectOuter: SelectOuterExtractor
     abstract class SelectOuterExtractor {
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, Int, Type)]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Int, Type)]
     }
 
     val While: WhileExtractor
     abstract class WhileExtractor {
       /** Extractor for while loops. Matches `while (<cond>) <body>` and returns (<cond>, <body>) */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, Term)]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Term)]
     }
 
     val DoWhile: DoWhileExtractor
     abstract class DoWhileExtractor {
       /** Extractor for do while loops. Matches `do <body> while (<cond>)` and returns (<body>, <cond>) */
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, Term)]
+      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Term)]
     }
   }
 
   // ----- CaseDef --------------------------------------------------
 
   type CaseDef
-
-  implicit def caseDefClassTag: ClassTag[CaseDef]
 
   trait CaseDefAPI {
     def show(implicit ctx: Context, s: Show[tasty.type]): String
@@ -425,34 +435,32 @@ abstract class Tasty extends StandardDefinitions { tasty =>
   }
   implicit def PatternDeco(pattern: Pattern): PatternAPI
 
-  implicit def patternClassTag: ClassTag[Pattern]
-
   val Pattern: PatternModule
   abstract class PatternModule {
 
     val Value: ValueExtractor
     abstract class ValueExtractor {
-      def unapply(x: Pattern)(implicit ctx: Context): Option[Term]
+      def unapply(pattern: Pattern)(implicit ctx: Context): Option[Term]
     }
 
     val Bind: BindExtractor
     abstract class BindExtractor {
-      def unapply(x: Pattern)(implicit ctx: Context): Option[(String, Pattern)]
+      def unapply(pattern: Pattern)(implicit ctx: Context): Option[(String, Pattern)]
     }
 
     val Unapply: UnapplyExtractor
     abstract class UnapplyExtractor {
-      def unapply(x: Pattern)(implicit ctx: Context): Option[(Term, List[Term], List[Pattern])]
+      def unapply(pattern: Pattern)(implicit ctx: Context): Option[(Term, List[Term], List[Pattern])]
     }
 
     val Alternative: AlternativeExtractor
     abstract class AlternativeExtractor {
-      def unapply(x: Pattern)(implicit ctx: Context): Option[List[Pattern]]
+      def unapply(pattern: Pattern)(implicit ctx: Context): Option[List[Pattern]]
     }
 
     val TypeTest: TypeTestExtractor
     abstract class TypeTestExtractor {
-      def unapply(x: Pattern)(implicit ctx: Context): Option[TypeTree]
+      def unapply(pattern: Pattern)(implicit ctx: Context): Option[TypeTree]
     }
 
   }
@@ -470,83 +478,85 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   // ----- TypeTrees ------------------------------------------------
 
-  type TypeTree <: TypeOrBoundsTree with Parent
+  type TypeTree <: TypeOrBoundsTree
 
   trait TypeTreeAPI extends Typed with Positioned
   implicit def TypeTreeDeco(tpt: TypeTree): TypeTreeAPI
 
-  implicit def typeTreeClassTag: ClassTag[TypeTree]
+  val IsTypeTree: IsTypeTreeExtractor
+  abstract class IsTypeTreeExtractor {
+    def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[TypeTree]
+    def unapply(parent: Parent)(implicit ctx: Context, dummy: DummyImplicit): Option[TypeTree]
+  }
 
   val TypeTree: TypeTreeModule
   abstract class TypeTreeModule {
-
-    def unapply(x: TypeTree)(implicit ctx: Context): Boolean
 
     /** TypeTree containing an inferred type */
     val Synthetic: SyntheticExtractor
     abstract class SyntheticExtractor {
       /** Matches a TypeTree containing an inferred type */
-      def unapply(x: TypeTree)(implicit ctx: Context): Boolean
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Boolean
     }
 
     val TypeIdent: TypeIdentExtractor
     abstract class TypeIdentExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[String]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[String]
     }
 
     val TermSelect: TermSelectExtractor
     abstract class TermSelectExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[(Term, String)]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(Term, String)]
     }
 
     val TypeSelect: TypeSelectExtractor
     abstract class TypeSelectExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, String)]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, String)]
     }
 
     val Singleton: SingletonExtractor
     abstract class SingletonExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[Term]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[Term]
     }
 
     val Refined: RefinedExtractor
     abstract class RefinedExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, List[Definition])]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, List[Definition])]
     }
 
     val Applied: AppliedExtractor
     abstract class AppliedExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, List[TypeOrBoundsTree])]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, List[TypeOrBoundsTree])]
     }
 
     val Annotated: AnnotatedExtractor
     abstract class AnnotatedExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, Term)]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, Term)]
     }
 
     val And: AndExtractor
     abstract class AndExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)]
     }
 
     val Or: OrExtractor
     abstract class OrExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)]
     }
 
     val ByName: ByNameExtractor
     abstract class ByNameExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[TypeTree]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[TypeTree]
     }
 
     val TypeLambdaTree: TypeLambdaTreeExtractor
     abstract class TypeLambdaTreeExtractor {
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[(List[TypeDef], TypeOrBoundsTree)]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(List[TypeDef], TypeOrBoundsTree)]
     }
 
     val Bind: BindExtractor
     abstract class BindExtractor{
-      def unapply(x: TypeTree)(implicit ctx: Context): Option[(String, TypeBoundsTree)]
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(String, TypeBoundsTree)]
     }
   }
 
@@ -561,18 +571,21 @@ abstract class Tasty extends StandardDefinitions { tasty =>
   }
   implicit def TypeBoundsTreeDeco(tpt: TypeBoundsTree): TypeBoundsTreeAPI
 
-  implicit def typeBoundsTreeClassTag: ClassTag[TypeBoundsTree]
+  val IsTypeBoundsTree: IsTypeBoundsTreeExtractor
+  abstract class IsTypeBoundsTreeExtractor {
+    def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[TypeBoundsTree]
+  }
 
   val TypeBoundsTree: TypeBoundsTreeExtractor
   abstract class TypeBoundsTreeExtractor {
-    def unapply(x: TypeBoundsTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)]
+    def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)]
   }
 
   /** TypeBoundsTree containing an inferred type bounds */
   val SyntheticBounds: SyntheticBoundsExtractor
   abstract class SyntheticBoundsExtractor {
     /** Matches a TypeBoundsTree containing inferred type bounds */
-    def unapply(x: TypeBoundsTree)(implicit ctx: Context): Boolean
+    def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Boolean
   }
 
   // ===== Types ====================================================
@@ -605,12 +618,6 @@ abstract class Tasty extends StandardDefinitions { tasty =>
   type PolyType <: LambdaType[TypeBounds]
   type TypeLambda <: LambdaType[TypeBounds]
 
-  implicit def typeClassTag: ClassTag[Type]
-  implicit def methodTypeClassTag: ClassTag[MethodType]
-  implicit def polyTypeClassTag: ClassTag[PolyType]
-  implicit def typeLambdaClassTag: ClassTag[TypeLambda]
-  implicit def recursiveTypeClassTag: ClassTag[RecursiveType]
-
   trait MethodTypeAPI {
     def isImplicit: Boolean
     def isErased: Boolean
@@ -634,99 +641,102 @@ abstract class Tasty extends StandardDefinitions { tasty =>
   }
   implicit def TypeLambdaDeco(tpt: TypeLambda): TypeLambdaAPI
 
+  val IsType: IsTypeExtractor
+  abstract class IsTypeExtractor {
+    def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[Type]
+  }
+
   val Type: TypeModule
   abstract class TypeModule {
 
-    def unapply(x: Type)(implicit ctx: Context): Boolean
-
     val ConstantType: ConstantTypeExtractor
     abstract class ConstantTypeExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[Constant]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[Constant]
     }
 
     val SymRef: SymRefExtractor
     abstract class SymRefExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[(Definition, TypeOrBounds /* Type | NoPrefix */)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Definition, TypeOrBounds /* Type | NoPrefix */)]
     }
 
     val TermRef: TermRefExtractor
     abstract class TermRefExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)]
     }
 
     val TypeRef: TypeRefExtractor
     abstract class TypeRefExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)]
     }
 
     val SuperType: SuperTypeExtractor
     abstract class SuperTypeExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[(Type, Type)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)]
     }
 
     val Refinement: RefinementExtractor
     abstract class RefinementExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[(Type, String, TypeOrBounds /* Type | TypeBounds */)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, String, TypeOrBounds /* Type | TypeBounds */)]
     }
 
     val AppliedType: AppliedTypeExtractor
     abstract class AppliedTypeExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[(Type, List[TypeOrBounds /* Type | TypeBounds */])]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, List[TypeOrBounds /* Type | TypeBounds */])]
     }
 
     val AnnotatedType: AnnotatedTypeExtractor
     abstract class AnnotatedTypeExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[(Type, Term)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Term)]
     }
 
     val AndType: AndTypeExtractor
     abstract class AndTypeExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[(Type, Type)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)]
     }
 
     val OrType: OrTypeExtractor
     abstract class OrTypeExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[(Type, Type)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)]
     }
 
     val ByNameType: ByNameTypeExtractor
     abstract class ByNameTypeExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[Type]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[Type]
     }
 
     val ParamRef: ParamRefExtractor
     abstract class ParamRefExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[(LambdaType[TypeOrBounds], Int)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(LambdaType[TypeOrBounds], Int)]
     }
 
     val ThisType: ThisTypeExtractor
     abstract class ThisTypeExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[Type]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[Type]
     }
 
     val RecursiveThis: RecursiveThisExtractor
     abstract class RecursiveThisExtractor {
-      def unapply(x: Type)(implicit ctx: Context): Option[RecursiveType]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[RecursiveType]
     }
 
     val RecursiveType: RecursiveTypeExtractor
     abstract class RecursiveTypeExtractor {
-      def unapply(x: RecursiveType)(implicit ctx: Context): Option[Type]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[Type]
     }
 
     val MethodType: MethodTypeExtractor
     abstract class MethodTypeExtractor {
-      def unapply(x: MethodType)(implicit ctx: Context): Option[(List[String], List[Type], Type)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(List[String], List[Type], Type)]
     }
 
     val PolyType: PolyTypeExtractor
     abstract class PolyTypeExtractor {
-      def unapply(x: PolyType)(implicit ctx: Context): Option[(List[String], List[TypeBounds], Type)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(List[String], List[TypeBounds], Type)]
     }
 
     val TypeLambda: TypeLambdaExtractor
     abstract class TypeLambdaExtractor {
-      def unapply(x: TypeLambda)(implicit ctx: Context): Option[(List[String], List[TypeBounds], Type)]
+      def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(List[String], List[TypeBounds], Type)]
     }
 
   }
@@ -735,11 +745,14 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type TypeBounds <: TypeOrBounds
 
-  implicit def typeBoundsClassTag: ClassTag[TypeBounds]
+  val IsTypeBounds: IsTypeBoundsExtractor
+  abstract class IsTypeBoundsExtractor {
+    def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[TypeBounds]
+  }
 
   val TypeBounds: TypeBoundsExtractor
   abstract class TypeBoundsExtractor {
-    def unapply(x: TypeBounds)(implicit ctx: Context): Option[(Type, Type)]
+    def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)]
   }
 
   trait TypeBoundsAPI {
@@ -752,11 +765,9 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type NoPrefix <: TypeOrBounds
 
-  implicit def noPrefixClassTag: ClassTag[NoPrefix]
-
   val NoPrefix: NoPrefixExtractor
   abstract class NoPrefixExtractor {
-    def unapply(x: NoPrefix)(implicit ctx: Context): Boolean
+    def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Boolean
   }
 
   // ===== Constants ================================================
@@ -768,76 +779,74 @@ abstract class Tasty extends StandardDefinitions { tasty =>
   }
   implicit def ConstantDeco(const: Constant): ConstantAPI
 
-  implicit def constantClassTag: ClassTag[Constant]
-
   val Constant: ConstantModule
   abstract class ConstantModule {
 
     val Unit: UnitExtractor
     abstract class UnitExtractor {
-      def unapply(x: Constant): Boolean
+      def unapply(constant: Constant): Boolean
     }
 
     val Null: NullExtractor
     abstract class NullExtractor {
-      def unapply(x: Constant): Boolean
+      def unapply(constant: Constant): Boolean
     }
 
     val Boolean: BooleanExtractor
     abstract class BooleanExtractor {
-      def unapply(x: Constant): Option[Boolean]
+      def unapply(constant: Constant): Option[Boolean]
     }
 
     val Byte: ByteExtractor
     abstract class ByteExtractor {
-      def unapply(x: Constant): Option[Byte]
+      def unapply(constant: Constant): Option[Byte]
     }
 
     val Short: ShortExtractor
     abstract class ShortExtractor {
-      def unapply(x: Constant): Option[Short]
+      def unapply(constant: Constant): Option[Short]
     }
 
     val Char: CharExtractor
     abstract class CharExtractor {
-      def unapply(x: Constant): Option[Char]
+      def unapply(constant: Constant): Option[Char]
     }
 
     val Int: IntExtractor
     abstract class IntExtractor {
-      def unapply(x: Constant): Option[Int]
+      def unapply(constant: Constant): Option[Int]
     }
 
     val Long: LongExtractor
     abstract class LongExtractor {
-      def unapply(x: Constant): Option[Long]
+      def unapply(constant: Constant): Option[Long]
     }
 
     val Float: FloatExtractor
     abstract class FloatExtractor {
-      def unapply(x: Constant): Option[Float]
+      def unapply(constant: Constant): Option[Float]
     }
 
     val Double: DoubleExtractor
     abstract class DoubleExtractor {
-      def unapply(x: Constant): Option[Double]
+      def unapply(constant: Constant): Option[Double]
     }
 
     val String: StringExtractor
     abstract class StringExtractor {
-      def unapply(x: Constant): Option[String]
+      def unapply(constant: Constant): Option[String]
     }
 
     val ClassTag: ClassTagExtractor
     abstract class ClassTagExtractor {
-      def unapply(x: Constant): Option[Type]
+      def unapply(constant: Constant): Option[Type]
     }
 
     /** Extractor for scala.Symbol literals */
     val Symbol: SymbolExtractor
     /** Extractor for scala.Symbol literals */
     abstract class SymbolExtractor {
-      def unapply(x: Constant): Option[scala.Symbol]
+      def unapply(constant: Constant): Option[scala.Symbol]
     }
   }
 
@@ -845,11 +854,9 @@ abstract class Tasty extends StandardDefinitions { tasty =>
 
   type Signature
 
-  implicit def signatureClassTag: ClassTag[Signature]
-
   val Signature: SignatureExtractor
   abstract class SignatureExtractor {
-    def unapply(x: Signature)(implicit ctx: Context): Option[(List[String], String)]
+    def unapply(sig: Signature)(implicit ctx: Context): Option[(List[String], String)]
   }
 
   trait SignatureAPI {

--- a/library/src/scala/tasty/util/ShowExtractors.scala
+++ b/library/src/scala/tasty/util/ShowExtractors.scala
@@ -77,8 +77,8 @@ class ShowExtractors[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
       case ClassDef(name, constr, parents, self, body) =>
         this += "ClassDef(\"" += name += "\", " += constr += ", "
         visitList[Parent](parents, {
-          case parent @ Term() => this += parent
-          case parent @ TypeTree() => this += parent
+          case IsTerm(parent) => this += parent
+          case IsTypeTree(parent) => this += parent
         })
         this += ", " += self += ", " ++= body += ")"
       case PackageDef(name, owner) =>

--- a/library/src/scala/tasty/util/TreeAccumulator.scala
+++ b/library/src/scala/tasty/util/TreeAccumulator.scala
@@ -59,21 +59,21 @@ abstract class TreeAccumulator[X, T <: Tasty with Singleton](val tasty: T) {
         foldTrees(x, elems)
       case Term.Inlined(call, bindings, expansion) =>
         foldTree(foldTrees(x, bindings), expansion)
-      case vdef @ ValDef(_, tpt, rhs) =>
+      case IsDefinition(vdef @ ValDef(_, tpt, rhs)) =>
         implicit val ctx = localCtx(vdef)
         foldTrees(foldTypeTree(x, tpt), rhs)
-      case ddef @ DefDef(_, tparams, vparamss, tpt, rhs) =>
+      case IsDefinition(ddef @ DefDef(_, tparams, vparamss, tpt, rhs)) =>
         implicit val ctx = localCtx(ddef)
         foldTrees(foldTypeTree((foldTrees(x, tparams) /: vparamss)(foldTrees), tpt), rhs)
-      case tdef @ TypeDef(_, rhs) =>
+      case IsDefinition(tdef @ TypeDef(_, rhs)) =>
         implicit val ctx = localCtx(tdef)
         foldTypeTree(x, rhs)
-      case cdef @ ClassDef(_, constr, parents, self, body) =>
+      case IsDefinition(cdef @ ClassDef(_, constr, parents, self, body)) =>
         implicit val ctx = localCtx(cdef)
         foldTrees(foldTrees(foldParents(foldTree(x, constr), parents), self), body)
       case Import(expr, selectors) =>
         foldTree(x, expr)
-      case clause @ PackageClause(pid, stats) =>
+      case IsPackageClause(clause @ PackageClause(pid, stats)) =>
         foldTrees(foldTree(x, pid), stats)(localCtx(clause.definition))
     }
   }
@@ -106,8 +106,8 @@ abstract class TreeAccumulator[X, T <: Tasty with Singleton](val tasty: T) {
   }
 
   private def foldOverParent(x: X, tree: Parent)(implicit ctx: Context): X = tree match {
-    case tree @ Term() => foldOverTree(x, tree)
-    case tree @ TypeTree() => foldOverTypeTree(x, tree)
+    case IsTerm(tree) => foldOverTree(x, tree)
+    case IsTypeTree(tree) => foldOverTypeTree(x, tree)
   }
 
 }

--- a/tests/run/tasty-custom-show/quoted_1.scala
+++ b/tests/run/tasty-custom-show/quoted_1.scala
@@ -19,12 +19,12 @@ object Macros {
         // Use custom Show[_] here
         implicit val printer = new DummyShow(tasty)
         tree match {
-          case tree @ DefDef(name, _, _, _, _) =>
+          case IsDefinition(tree @ DefDef(name, _, _, _, _)) =>
             buff.append(name)
             buff.append("\n")
             buff.append(tree.owner.show)
             buff.append("\n\n")
-          case tree @ ValDef(name, _, _) =>
+          case IsDefinition(tree @ ValDef(name, _, _)) =>
             buff.append(name)
             buff.append("\n")
             buff.append(tree.owner.show)

--- a/tests/run/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run/tasty-extractors-owners/quoted_1.scala
@@ -16,12 +16,12 @@ object Macros {
     val output = new TreeTraverser(tasty) {
       override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = {
         tree match {
-          case tree @ DefDef(name, _, _, _, _) =>
+          case IsDefinition(tree @ DefDef(name, _, _, _, _)) =>
             buff.append(name)
             buff.append("\n")
             buff.append(tree.owner.show)
             buff.append("\n\n")
-          case tree @ ValDef(name, _, _) =>
+          case IsDefinition(tree @ ValDef(name, _, _)) =>
             buff.append(name)
             buff.append("\n")
             buff.append(tree.owner.show)


### PR DESCRIPTION
We found that when the implementation of those class tags
uses the same class tags, type matches are unsound.
Instead, we replace the more precise scrutinee by equivalent
extractors. In the future, we intend to  language support
for abstract type pattern matching where the scrutinee
can get a more precise type.