### PR TITLE
Fix misspelled words in comments and error messages

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -626,7 +626,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
 
     def symbol: Symbol = a.tree.symbol
 
-    def args: List[Tree] = List.empty // those arguments to scala-defined annotations. they are never emmited
+    def args: List[Tree] = List.empty // those arguments to scala-defined annotations. they are never emmitted
   }
 
   def assocsFromApply(tree: Tree): List[(Name, Tree)] = {
@@ -810,7 +810,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     def annotations: List[Annotation] = toDenot(sym).annotations
     def companionModuleMembers: List[Symbol] =  {
       // phase travel to exitingPickler: this makes sure that memberClassesOf only sees member classes,
-      // not local classes of the companion module (E in the exmaple) that were lifted by lambdalift.
+      // not local classes of the companion module (E in the example) that were lifted by lambdalift.
       if (linkedClass.isTopLevelModuleClass) /*exitingPickler*/ linkedClass.memberClasses
       else Nil
     }

--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -118,7 +118,7 @@ class Driver extends DotClass {
    *
    *  In most cases, you do not need a custom `Context` and should
    *  instead use one of the other overloads of `process`. However,
-   *  the other overloads cannot be overriden, instead you
+   *  the other overloads cannot be overridden, instead you
    *  should override this one which they call internally.
    *
    *  Usage example: [[https://github.com/lampepfl/dotty/tree/master/test/test/OtherEntryPointsTest.scala]]

--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -168,7 +168,7 @@ abstract class Positioned extends DotClass with Product {
     def check(p: Any): Unit = p match {
       case p: Positioned =>
         assert(pos contains p.pos,
-          s"""position error, parent position does not contain child positon
+          s"""position error, parent position does not contain child position
              |parent          = $this,
              |parent position = $pos,
              |child           = $p,

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1017,7 +1017,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
             lastParam.tpe match {
               case defn.ArrayOf(el2) if el2 <:< el =>
                 // we have a JavaSeqLiteral with a more precise type
-                // we cannot construct a tree as JavaSeqLiteral infered to precise type
+                // we cannot construct a tree as JavaSeqLiteral inferred to precise type
                 // if we add typed than it would be both type-correct and
                 // will pass Ycheck
                 prefix ::: List(tpd.Typed(lastParam, TypeTree(defn.ArrayOf(el))))

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -120,7 +120,7 @@ object Config {
 
   /** If this flag is set, it is checked that class type parameters are
    *  only references with NoPrefix or ThisTypes as prefixes. This option
-   *  is usally disabled, because there are still some legitimate cases where
+   *  is usually disabled, because there are still some legitimate cases where
    *  this can arise (e.g. for pos/Map.scala, in LambdaType.integrate).
    */
   final val checkTypeParamRefs = false

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1233,7 +1233,7 @@ class Definitions {
       // Temporary measure, as long as we do not read these classes from Tasty.
       // Scala-2 classes don't have NoInits set even if they are pure. We override this
       // for Product and Serializable so that case classes can be pure. A full solution
-      // requiers that we read all Scala code from Tasty.
+      // requires that we read all Scala code from Tasty.
       ProductClass.setFlag(NoInits)
       SerializableClass.setFlag(NoInits)
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1068,7 +1068,7 @@ object SymDenotations {
       if (!canMatchInheritedSymbols && (owner ne inClass)) NoSymbol
       else matchingDecl(inClass, owner.thisType)
 
-    /** All symbols overriden by this denotation. */
+    /** All symbols overridden by this denotation. */
     final def allOverriddenSymbols(implicit ctx: Context): Iterator[Symbol] =
       if (!canMatchInheritedSymbols) Iterator.empty
       else overriddenFromType(owner.info)

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -350,7 +350,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
    *   - For a refined type scala.Array+[T]:
    *      - if T is Nothing or Null, []Object
    *      - otherwise, if T <: Object, []|T|
-   *      - otherwise, if T is a type paramter coming from Java, []Object
+   *      - otherwise, if T is a type parameter coming from Java, []Object
    *      - otherwise, Object
    *   - For a term ref p.x, the type <noprefix> # x.
    *   - For a typeref scala.Any, scala.AnyVal or scala.Singleton: |java.lang.Object|

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -274,7 +274,7 @@ object TastyFormat {
 
     final val OBJECTCLASS = 23       // The name of an object class (or: module class) `<name>$`.
 
-    final val SIGNED = 63            // A pair of a name and a signature, used to idenitfy
+    final val SIGNED = 63            // A pair of a name and a signature, used to idenitify
                                      // possibly overloaded methods.
   }
   object NameTags extends NameTags

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -262,7 +262,7 @@ object Parsers {
     def deprecationWarning(msg: => Message, offset: Int = in.offset) =
       ctx.deprecationWarning(msg, source atPos Position(offset))
 
-    /** Issue an error at current offset taht input is incomplete */
+    /** Issue an error at current offset that input is incomplete */
     def incompleteInputError(msg: => Message) =
       ctx.incompleteInputError(msg, source atPos Position(in.offset))
 

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -244,7 +244,7 @@ object Formatting {
     * ```
     * found:    List[Int]
     * required: List[T]
-    * where:    T is a type in the initalizer of value s which is an alias of
+    * where:    T is a type in the initializer of value s which is an alias of
     *           String
     * ```
     *

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -435,7 +435,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
         else if (ownr.isAnonymousFunction) nextOuter("function")
         else if (isEmptyPrefix(ownr)) ""
         else if (ownr.isLocalDummy) showLocation(ownr.owner, "locally defined in")
-        else if (ownr.isTerm && !ownr.is(Module | Method)) showLocation(ownr, "in the initalizer of")
+        else if (ownr.isTerm && !ownr.is(Module | Method)) showLocation(ownr, "in the initializer of")
         else showLocation(ownr, "in")
       }
       recur(sym.owner, "")

--- a/compiler/src/dotty/tools/dotc/printing/Printer.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Printer.scala
@@ -34,7 +34,7 @@ abstract class Printer {
   def changePrec(prec: Precedence)(op: => Text): Text =
     if (prec < this.prec) atPrec(prec) ("(" ~ op ~ ")") else atPrec(prec)(op)
 
-  /** The name, possibley with with namespace suffix if debugNames is set:
+  /** The name, possibly with with namespace suffix if debugNames is set:
    *  /L for local names, /V for other term names, /T for type names
    */
   def nameString(name: Name): String

--- a/compiler/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
@@ -24,7 +24,7 @@ object AugmentScala2Traits {
 /** This phase augments Scala2 traits with implementation classes and with additional members
  *  needed for mixin composition.
  *  These symbols would have been added between Unpickling and Mixin in the Scala2 pipeline.
- *  Specifcally, it adds
+ *  Specifically, it adds
  *
  *   - an implementation class which defines a trait constructor and trait method implementations
  *   - trait setters for vals defined in traits

--- a/compiler/src/dotty/tools/dotc/transform/CheckStatic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckStatic.scala
@@ -12,7 +12,7 @@ import reporting.diagnostic.messages.{MissingCompanionForStatic, StaticFieldsOnl
 
 /** A transformer that check that requirements of Static fields\methods are implemented:
   *  1. Only objects can have members annotated with `@static`
-  *  2. The fields annotated with `@static` should preceed any non-`@static` fields.
+  *  2. The fields annotated with `@static` should precede any non-`@static` fields.
   *     This ensures that we do not introduce surprises for users in initialization order.
   *  3. If a member `foo` of an `object C` is annotated with `@static`,
   *     the companion class `C` is not allowed to define term members with name `foo`.
@@ -37,7 +37,7 @@ class CheckStatic extends MiniPhase {
         }
 
         if (defn.isInstanceOf[ValDef] && hadNonStaticField) {
-          ctx.error("@static fields should preceed non-static ones", defn.pos)
+          ctx.error("@static fields should precede non-static ones", defn.pos)
         }
 
         val companion = ctx.owner.companionClass

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -259,7 +259,7 @@ object Erasure {
           cast(ref(defn.runtimeMethodRef(nme.toObjectArray)).appliedTo(tree), pt)
 
         // When casting between two EVTs, we need to check which one underlies the other to determine
-        // wheter u2evt or evt2u should be used.
+        // whether u2evt or evt2u should be used.
         case (tp1 @ ErasedValueType(tycon1, underlying1), tp2 @ ErasedValueType(tycon2, underlying2)) =>
           if (tp1 <:< underlying2)
             // Cast EVT(tycon1, underlying1) to EVT(tycon2, EVT(tycon1, underlying1))

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -103,7 +103,7 @@ class FirstTransform extends MiniPhase with InfoTransformer { thisPhase =>
     reorder(stats, Nil)
   }
 
-  /** elimiate self in Template */
+  /** eliminate self in Template */
   override def transformTemplate(impl: Template)(implicit ctx: Context): Tree = {
     cpy.Template(impl)(self = EmptyValDef)
   }

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcherOld.scala.disabled
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcherOld.scala.disabled
@@ -169,7 +169,7 @@ class PatternMatcherOld extends MiniPhase with DenotTransformer {
   trait OptimizedCodegen extends CodegenCore {
     override def codegen: AbsCodegen = optimizedCodegen
 
-    // when we know we're targetting Option, do some inlining the optimizer won't do
+    // when we know we're targeting Option, do some inlining the optimizer won't do
     // for example, `o.flatMap(f)` becomes `if (o == None) None else f(o.get)`, similarly for orElse and guard
     //   this is a special instance of the advanced inlining optimization that takes a method call on
     //   an object of a type that only has two concrete subclasses, and inlines both bodies, guarded by an if to distinguish the two cases
@@ -504,7 +504,7 @@ class PatternMatcherOld extends MiniPhase with DenotTransformer {
      *     case d => <body>
      *   }
      *
-     * d inside <body> was to be substitued by x.
+     * d inside <body> was to be substituted by x.
      *
      * In dotty, SubstOnlyTreeMakers instead generate normal ValDef,
      *   and does not create a new substitution.

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1025,7 +1025,7 @@ trait Implicits { self: Typer =>
        *   - otherwise, if a previous search was also successful, handle the ambiguity
        *     in `disambiguate`,
        *   - otherwise, continue the search with all candidates that are not strictly
-       *     worse than the succesful candidate.
+       *     worse than the successful candidate.
        *  If a trial failed:
        *    - if the query term is a `Not[T]` treat it as a success,
        *    - otherwise, if the failure is an ambiguity, try to heal it (see @healAmbiguous)

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -626,7 +626,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
 
       val gadtSyms = typer.gadtSyms(scrutType)
 
-      /** Try to match pattern `pat` against scrutinee reference `scrut`. If succesful add
+      /** Try to match pattern `pat` against scrutinee reference `scrut`. If successful add
        *  bindings for variables bound in this pattern to `bindingsBuf`.
        */
       def reducePattern(bindingsBuf: mutable.ListBuffer[MemberDef], scrut: TermRef, pat: Tree): Boolean = {

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -152,7 +152,7 @@ object RefChecks {
    *  4. Check that every member with an `override` modifier
    *     overrides some other member.
    *  TODO check that classes are not overridden
-   *  TODO This still needs to be cleaned up; the current version is a staright port of what was there
+   *  TODO This still needs to be cleaned up; the current version is a straight port of what was there
    *       before, but it looks too complicated and method bodies are far too large.
    */
   private def checkAllOverrides(clazz: Symbol)(implicit ctx: Context): Unit = {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -954,7 +954,7 @@ class Typer extends Namer
                      |position = ${tree.pos}, raw type = ${mt.toString}""") // !!! DEBUG. Eventually, convert to an error?
                 }
                 else if ((tree.tpt `eq` untpd.ImplicitEmptyTree) && mt.paramNames.isEmpty)
-                  // Note implicitness of function in target type sicne there are no method parameters that indicate it.
+                  // Note implicitness of function in target type since there are no method parameters that indicate it.
                   TypeTree(defn.FunctionOf(Nil, mt.resType, isImplicit = true, isErased = false))
                 else
                   EmptyTree
@@ -2329,7 +2329,7 @@ class Typer extends Namer
       *
       *     val x: AnyRef = f
       *
-      *  That's intentional, we want to fail here, otherwise some unsuccesful implicit searches
+      *  That's intentional, we want to fail here, otherwise some unsuccessful implicit searches
       *  would go undetected.
       *
       *  Examples for these cases are found in run/implicitFuns.scala and neg/i2006.scala.

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -133,7 +133,7 @@ class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int, loadFactor: F
 
   /** Privileged access: Add entry `x` at the last position where an unsuccsessful
    *  `findEntryByHash` or `nextEntryByhash` operation returned. Needs to immediately
-   *  follow a `findEntryByhash` or `nextEntryByHash` operation that was unsucessful,
+   *  follow a `findEntryByhash` or `nextEntryByHash` operation that was unsuccessful,
    *  i.e. that returned `null`.
    */
   protected def addEntryAfterScan(x: T): T = addEntryAt(rover, x)

--- a/compiler/test-resources/repl/errmsgs
+++ b/compiler/test-resources/repl/errmsgs
@@ -42,13 +42,13 @@ scala> abstract class C { type T; val x: T; val s: Unit = { type T = String; var
   |required: T'
   |
   |where:    T  is a type in class C
-  |          T' is a type in the initalizer of value s which is an alias of String
+  |          T' is a type in the initializer of value s which is an alias of String
 1 | abstract class C { type T; val x: T; val s: Unit = { type T = String; var y: T = x; locally { def f() = { type T = Int; val z: T = y }; f() } }; }
   |                                                                                                                                    ^
   |found:    T(y)
   |required: T'
   |
-  |where:    T  is a type in the initalizer of value s which is an alias of String
+  |where:    T  is a type in the initializer of value s which is an alias of String
   |          T' is a type in method f which is an alias of Int
 scala> class Foo() { def bar: Int = 1 }; val foo = new Foo(); foo.barr
 1 | class Foo() { def bar: Int = 1 }; val foo = new Foo(); foo.barr

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -838,7 +838,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
    *  neg tests
    *  =========
    *  Neg tests are expected to generate a certain amount of errors - but not
-   *  crash the compiler. In each `.scala` file, you specifiy the line on which
+   *  crash the compiler. In each `.scala` file, you specify the line on which
    *  the error will be generated, e.g:
    *
    *  ```

--- a/compiler/test/dotty/tools/vulpix/TestGroup.scala
+++ b/compiler/test/dotty/tools/vulpix/TestGroup.scala
@@ -1,6 +1,6 @@
 package dotty.tools.vulpix
 
-/** Test groups are used to ensure that the ouput of tests do not overlap.
+/** Test groups are used to ensure that the output of tests do not overlap.
  *
  *  It can be used to disambiguate ouputs of tests that test the same file but with different options as shown in the following example.
  *    compileFilesInDir("tests/pos", defaultOptions)(TestGroup("compileStdLib")) // will output in ./out/compileStdLib/...

--- a/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
@@ -9,7 +9,7 @@ import TestConfiguration._
 
 /** Meta tests for the Vulpix test suite. This test follows the structure of
  *  CompilationTests.scala. It is meant to be called from bash to diff with
- *  output againts an expected result.
+ *  output against an expected result.
  */
 @Category(Array(classOf[dotty.VulpixMetaTests]))
 class VulpixMetaTests extends ParallelTesting {

--- a/doc-tool/src/dotty/tools/dottydoc/util/MemberLookup.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/util/MemberLookup.scala
@@ -16,7 +16,7 @@ import model._
 trait MemberLookup {
   /** Performs a lookup based on the provided (pruned) query string
    *
-   *  Will return a `Tooltip` if unsucessfull, otherwise a LinkToEntity or
+   *  Will return a `Tooltip` if unsucessful, otherwise a LinkToEntity or
    *  LinkToExternal
    */
   def lookup(entity: Entity, packages: Map[String, Package], query: String): Option[Entity] = {

--- a/docs/docs/internals/dotty-internals-1-notes.md
+++ b/docs/docs/internals/dotty-internals-1-notes.md
@@ -47,8 +47,8 @@ Typed trees contain not only the user-written code, but also semantic informatio
   * `Literal`: constants (e.g. integer constant 1)
   * `Typed`: type ascription (e.g. for widening, as in `(1: Any)`)
   * `NamedArg`: named arguments (can appear out-of-order in untyped trees, but will appear in-order in typed ones)
-  * `Assign`: assignment. The node has a `lhs` and a `rhs`, but the `lhs` can be arbitrarly complicated (e.g. `(new C).f = 0`).
-  * `If`: the condition in an if-expression can be arbitrarly complex (e.g. it can contain class definitions)
+  * `Assign`: assignment. The node has a `lhs` and a `rhs`, but the `lhs` can be arbitrarily complicated (e.g. `(new C).f = 0`).
+  * `If`: the condition in an if-expression can be arbitrarily complex (e.g. it can contain class definitions)
   * `Closure`: the free variables are stored in the `env` field, but are only accessible "around" the `LambdaLift` phase.
   * `Match` and `CaseDef`: pattern-matching trees. The `pat` field in `CaseDef` (the pattern) is, in turn, populated with a subset of trees like `Bind` and `Unapply`.
   * `Return`: return from a method. If the `from` field is empty, then we return from the closest enclosing method.

--- a/docs/docs/reference/changed/eta-expansion.md
+++ b/docs/docs/reference/changed/eta-expansion.md
@@ -28,7 +28,7 @@ Automatic eta expansion does not apply to "nullary" methods that take an empty p
     def next(): T
 
 , a simple reference to `next` does not auto-convert to a
-function. One has to write explicitely `() => next()` to achieve that
+function. One has to write explicitly `() => next()` to achieve that
 (it's better to write it this way rather than `next _` because the latter
 will be deprecated).
 

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -181,4 +181,4 @@ this object or its members via `this` or a simple identifier is also illegal. Th
 
 A normal case class which is not produced from an enum case is not allowed to extend
 `scala.Enum`. This ensures that the only cases of an enum are the ones that are
-explictly declared in it.
+explicitly declared in it.

--- a/docs/docs/reference/erased-terms.md
+++ b/docs/docs/reference/erased-terms.md
@@ -34,7 +34,7 @@ m.turnedOn.turnedOn // ERROR
 
 Note that in the code above the actual implicit arguments for `IsOff` are never used at runtime; they serve only to establish the right constraints at compile time.
 As these terms are never used at runtime there is not real need to have them around, but they still need to be
-present in some form in the generated code to be able to do separate compilation and retain binary compatiblity.
+present in some form in the generated code to be able to do separate compilation and retain binary compatibility.
 
 How to define erased terms?
 -------------------------------
@@ -186,8 +186,8 @@ Rules
 
 
 5. Erasure Semantics
-   * All `erased` paramters are removed from the function
-   * All argument to `erased` paramters are not passed to the function
+   * All `erased` parameters are removed from the function
+   * All argument to `erased` parameters are not passed to the function
    * All `erased` definitions are removed
    * All `(erased T1, T2, ..., TN) => R` and `(implicit erased T1, T2, ..., TN) => R` become `() => R`
 
@@ -199,5 +199,5 @@ Rules
 
 7. Overriding
    * Member definitions overidding each other must both be `erased` or not be `erased`
-   * `def foo(x: T): U` cannot be overriden by `def foo(erased x: T): U` an viceversa
+   * `def foo(x: T): U` cannot be overridden by `def foo(erased x: T): U` an viceversa
 

--- a/docs/docs/reference/overview.md
+++ b/docs/docs/reference/overview.md
@@ -72,7 +72,7 @@ Listed in this section are new language constructs that help precise, typechecke
  - Restrict Implicit Conversions
 
    ([Pending](https://github.com/lampepfl/dotty/pull/4229))
-   Implicit conversions are very easily mis-used, which makes them the cause of much suprising behavior.
+   Implicit conversions are very easily mis-used, which makes them the cause of much surprising behavior.
    We now require a language feature import not only when an implicit conversion is defined
    but also when it is applied. This protects users of libraries that define implicit conversions
    from being bitten by unanticipated feature interactions.

--- a/docs/docs/typelevel.md
+++ b/docs/docs/typelevel.md
@@ -332,7 +332,7 @@ transparent def concat(xs: Tuple, ys: Tuple): Tuple = {
 The transparent `concat` method makes use of two helper functions, `concatTyped` (described in the last section) and `concatImpl`. `concatTyped` is called as the right hand side of an `erased` value `r`. Since `r` is `erased`, no code is generated for its definition.
 `concatImpl` is a regular, non-transparent function that implements `concat` on generic tuples. It is not inlineable, and its result type is always `Tuple`. The actual code for `concat` calls `concatImpl` and casts its result to type `r.Type`, the computed result type of the concatenation. This gives the best of both worlds: Compact code and expressive types.
 
-One might criticize that this scheme involves code duplication. In the example above, the recursive `concat` algorithm had to be implemented twice, once as a regular function, the other time as a transparent function. However, in practice it is is quite likely that the regular function would use optimized data representatons and algortihms that do not lend themselves easily to a typelevel interpretation. In these cases a dual implementation is required anyway.
+One might criticize that this scheme involves code duplication. In the example above, the recursive `concat` algorithm had to be implemented twice, once as a regular function, the other time as a transparent function. However, in practice it is is quite likely that the regular function would use optimized data representatons and algorithms that do not lend themselves easily to a typelevel interpretation. In these cases a dual implementation is required anyway.
 
 ## Code Specialization
 

--- a/docs/docs/usage/ide-support.md
+++ b/docs/docs/usage/ide-support.md
@@ -51,7 +51,7 @@ Status
 - Once the IDE is started, source files that are not opened in the IDE
   should not be modified in some other editor, the IDE won't pick up
   these changes.
-- Not all compiler errors/warnings are displayed, just those occuring
+- Not all compiler errors/warnings are displayed, just those occurring
   during typechecking.
 
 

--- a/tests/disabled/existential/neg/literate_existentials.scala
+++ b/tests/disabled/existential/neg/literate_existentials.scala
@@ -187,7 +187,7 @@ object LiterateExistentials {
 //
 
   implicitly[Int <:< (M forSome { type M >: Nothing <: String })] // fails
-// The preceeding line causes the compiler to generate an error message.
+// The preceding line causes the compiler to generate an error message.
 
 
 

--- a/tests/disabled/existential/run/names-defaults.scala
+++ b/tests/disabled/existential/run/names-defaults.scala
@@ -239,7 +239,7 @@ object Test extends dotty.runtime.LegacyApp {
   // result type of default getters: parameter type, except if this one mentions any type
   // parameter, in which case the result type is inferred. examples:
 
-  // result type of default getter is "String => String". if it were infered, the compiler
+  // result type of default getter is "String => String". if it were inferred, the compiler
   // would put "Nothing => Nothing", which is useless
   def transform(s: String, f: String => String = identity _) = f(s)
   println(transform("my text"))

--- a/tests/disabled/reflect/run/t4729/S_2.scala
+++ b/tests/disabled/reflect/run/t4729/S_2.scala
@@ -21,7 +21,7 @@ object Test {
     (new ScalaVarArgs).method("1", "2")
     (new ScalaVarArgs: J_1).method("1", "2")
 
-    //[4] Not Ok -- error when assigning anonymous class to an explictly typed val
+    //[4] Not Ok -- error when assigning anonymous class to an explicitly typed val
     // Compiler error:  object creation impossible, since method method in trait VarArgs of type (s: <repeated...>[java.lang.String])Unit is not defined
     val tagged: J_1 = new J_1 {
       def method(s: String*) { println(s) }

--- a/tests/neg/validate.scala
+++ b/tests/neg/validate.scala
@@ -4,7 +4,7 @@ trait X {
   abstract def y: Y // error: abstract term
 }
 
-implicit object Z { // error: implict at toplevel
+implicit object Z { // error: implicit at toplevel
   implicit case class C() // error: implicit classes may not be case classes
   implicit type T = Int // error: implicit modifier cannot be used for types or traits
   implicit trait U // error: implicit modifier cannot be used for types or traits

--- a/tests/patmat/outer-ref-checks.scala
+++ b/tests/patmat/outer-ref-checks.scala
@@ -48,7 +48,7 @@ object O extends Outer {
   }
 
   def belongsOtherOuter4(a: Outer#Inner): Unit = a match {
-    case _: (Inner @unchecked) => // warning supressed
+    case _: (Inner @unchecked) => // warning suppressed
     case _ =>
   }
 

--- a/tests/patmat/t9926.scala
+++ b/tests/patmat/t9926.scala
@@ -19,5 +19,5 @@ object Model {
   // if T contains type parameter, get its dimension types.
   //
   // actively decompose its dimensions, and then do subtype checking to
-  // see if the type paramter can be instantiated.
+  // see if the type parameter can be instantiated.
 }

--- a/tests/pending/run/nullable-lazyvals.scala
+++ b/tests/pending/run/nullable-lazyvals.scala
@@ -24,7 +24,7 @@ object Test extends dotty.runtime.LegacyApp {
 
 	// test that try-finally does not generated a liftedTry
 	// helper. This would already fail the first part of the test,
-	// but this check will help diganose it (if the single access to a
+	// but this check will help diagnose it (if the single access to a
 	// private field does not happen directly in the lazy val, it won't
 	// be nulled).
 	for (f <- foo.getClass.getDeclaredMethods) {

--- a/tests/pos-with-compiler/tasty/definitions.scala
+++ b/tests/pos-with-compiler/tasty/definitions.scala
@@ -113,7 +113,7 @@ object definitions {
     def tpe: Type.TypeBounds = ???
   }
 
-  /** Trees denoting type infered bounds */
+  /** Trees denoting type inferred bounds */
   case class SyntheticBounds() extends Tree {
     def tpe: Type.TypeBounds = ???
   }

--- a/tests/pos/t2405.scala
+++ b/tests/pos/t2405.scala
@@ -6,14 +6,14 @@ object Test1 {
     implicitly[Int]
 }
 
-// Testing for the absense of shadowing #1.
+// Testing for the absence of shadowing #1.
 object Test2 {
     import A.{x => y}
     val x = 2
     implicitly[Int]
 }
 
-// Testing for the absense of shadowing #2.
+// Testing for the absence of shadowing #2.
 object Test3 {
     {
         import A.{x => y}

--- a/tests/pos/t5644/BoxesRunTime.java
+++ b/tests/pos/t5644/BoxesRunTime.java
@@ -236,7 +236,7 @@ public final class BoxesRunTime
      *  as yet have not.
      *
      *  Note: Among primitives, Float.NaN != Float.NaN, but the boxed
-     *  verisons are equal.  This still needs reconciliation.
+     *  versions are equal. This still needs reconciliation.
      */
     public static int hashFromLong(java.lang.Long n) {
         int iv = n.intValue();

--- a/tests/run/ReplacementMatching.scala
+++ b/tests/run/ReplacementMatching.scala
@@ -32,12 +32,12 @@ object Test {
 
   def groupsMatching: Unit = {
     val Date = """(\d+)/(\d+)/(\d+)""".r
-    for (Regex.Groups(a, b, c) <- Date findFirstMatchIn "1/1/2001 marks the start of the millenium. 31/12/2000 doesn't.") {
+    for (Regex.Groups(a, b, c) <- Date findFirstMatchIn "1/1/2001 marks the start of the millennium. 31/12/2000 doesn't.") {
       assert(a == "1")
       assert(b == "1")
       assert(c == "2001")
     }
-    for (Regex.Groups(a, b, c) <- (Date findAllIn "1/1/2001 marks the start of the millenium. 31/12/2000 doesn't.").matchData) {
+    for (Regex.Groups(a, b, c) <- (Date findAllIn "1/1/2001 marks the start of the millennium. 31/12/2000 doesn't.").matchData) {
       assert(a == "1" || a == "31")
       assert(b == "1" || b == "12")
       assert(c == "2001" || c == "2000")

--- a/tests/run/dynamicDynamicTests.scala
+++ b/tests/run/dynamicDynamicTests.scala
@@ -106,7 +106,7 @@ object Test {
   def runBarTests() = {
     val bar = new Bar("bar")
 
-    // dynamics combined with themselfs
+    // dynamics combined with themselves
     assertEquals("bar.selectDynamic(select1).selectDynamic(select2).selectDynamic(select3)",
         bar.select1.select2.select3)
     assertEquals("bar.applyDynamic(apply1)().applyDynamic(apply2)().applyDynamic(apply3)()",

--- a/tests/run/nothingTypeNoFramesNoDce.scala
+++ b/tests/run/nothingTypeNoFramesNoDce.scala
@@ -26,7 +26,7 @@ class C {
   }
 
   def f5(x: Boolean) = {
-    // stack heights need to be the smae. ??? looks to the jvm like returning a value of
+    // stack heights need to be the same. ??? looks to the jvm like returning a value of
     // type Nothing$, need to drop or throw it.
     println(
       if (x) { ???; 10 }

--- a/tests/run/nothingTypeNoOpt.scala
+++ b/tests/run/nothingTypeNoOpt.scala
@@ -26,7 +26,7 @@ class C {
   }
 
   def f5(x: Boolean) = {
-    // stack heights need to be the smae. ??? looks to the jvm like returning a value of
+    // stack heights need to be the same. ??? looks to the jvm like returning a value of
     // type Nothing$, need to drop or throw it.
     println(
       if (x) { ???; 10 }

--- a/tests/run/t1987b/cce_test.scala
+++ b/tests/run/t1987b/cce_test.scala
@@ -1,5 +1,5 @@
 package scales.xml
-//import scales.xml._ // using another pacakge and importing doesn't CCE
+//import scales.xml._ // using another package and importing doesn't CCE
 
 object CCE_Test {
   def main(args: Array[String]): Unit = {

--- a/tests/run/t5040.scala
+++ b/tests/run/t5040.scala
@@ -1,4 +1,4 @@
-import scala.language.dynamics // originaly used the flag -language:dynamics in t5040.flags, .flags are currently ignored
+import scala.language.dynamics // originally used the flag -language:dynamics in t5040.flags, .flags are currently ignored
 abstract class Prova2 extends Dynamic {
   def applyDynamic(m: String)(): Unit
   private def privateMethod() = println("private method")

--- a/tests/run/t6114.scala
+++ b/tests/run/t6114.scala
@@ -51,7 +51,7 @@ object Test extends dotty.runtime.LegacyApp {
     val next = list.asScala ++ List(4,5,6)
     assert(next != list.asScala)
 
-    // Note: Clone is hidden at this level, so no overriden cloning.
+    // Note: Clone is hidden at this level, so no overridden cloning.
   }
 
   testList

--- a/tests/run/t8010.scala
+++ b/tests/run/t8010.scala
@@ -5,7 +5,7 @@ trait Base {
   def bt(n: Int) = n
 }
 trait Derived extends Base {
-  // was: double defintion error
+  // was: double definition error
   override def t          = 1 + super.t
   override def t(n: Int)  = 1 + super.t(n)
   override def bt         = 1 + super.bt

--- a/tests/untried/neg/t5376.scala
+++ b/tests/untried/neg/t5376.scala
@@ -12,7 +12,7 @@ object Test {
     "a": Int
   }
 
-  // Import one implict and one non-implicit method with the
+  // Import one implicit and one non-implicit method with the
   // same name in the same scope.
   def m2 = {
     import O1._

--- a/tests/untried/pos/t3951/Coll_1.scala
+++ b/tests/untried/pos/t3951/Coll_1.scala
@@ -14,7 +14,7 @@ sealed trait DynamicDocument extends Document {
 
 class Coll extends StaticDocument
 
-// similiar issue with annotations
+// similar issue with annotations
 class ann[T] extends annotation.StaticAnnotation
 
 trait StatDoc extends Doc {

--- a/vscode-dotty/README.md
+++ b/vscode-dotty/README.md
@@ -11,7 +11,7 @@ is the default on all systems except Mac where you'll need to follow these
 instructions: https://code.visualstudio.com/docs/setup/mac#_command-line
 
 
-If this is the case and your project succesfully compiles with dotty, you can
+If this is the case and your project successfully compiles with dotty, you can
 simply use the `launchIDE` command provided by the sbt-dotty plugin:
 
 ```shell


### PR DESCRIPTION
This pull request fixes several minor typos found in comments and error messages.