### PR TITLE
Fix #4922: unapplySeq mustn't allow arrays

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -101,7 +101,7 @@ object Applications {
 
     if (unapplyName == nme.unapplySeq) {
       if (unapplyResult derivesFrom defn.SeqClass) seqSelector :: Nil
-      else if (isGetMatch(unapplyResult, pos)) {
+      else if (isGetMatch(unapplyResult, pos) && getTp.derivesFrom(defn.SeqClass)) {
         val seqArg = getTp.elemType.hiBound
         if (seqArg.exists) args.map(Function.const(seqArg))
         else fail

--- a/tests/neg/i4922.scala
+++ b/tests/neg/i4922.scala
@@ -1,0 +1,15 @@
+class SQ {
+  val isEmpty = false
+  val get = Array(1)
+}
+object A {
+  def unapplySeq(a: Int): SQ = new SQ
+}
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val seq: Seq[Int] = 2 match {
+      case A(xs: _*) => xs // error // error
+    }
+  }
+}


### PR DESCRIPTION
Fix #4922 with the "obvious" fix.

If this triggers cyclic errors, the extra check could be moved to PostTyper.

The error message could be improved, since it doesn't mention the specific reason why `SQ` isn't a valid result type.
```
12 |      case A(xs: _*) => xs
   |           ^^^^^^^^^
   | SQ is not a valid result type of an unapplySeq method of an extractor()
12 |      case A(xs: _*) => xs
   |                        ^^
   |                        not found: xs

```

Beware this was a 5-minute job, so haven't thought hard about it.