### PR TITLE
[WIP] Fix #3007: Added silencing of the output in initial and cleanup commands

### DIFF
--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -32,7 +32,7 @@ class ReplTest private (out: ByteArrayOutputStream) extends ReplDriver(
     storedOutput()
 
   def fromInitialState[A](op: State => A): A =
-    op(initState)
+    op(initialState)
 
   implicit class TestingState(state: State) {
     def andThen[A](op: State => A): A = op(state)

--- a/compiler/test/dotty/tools/repl/ScriptedTests.scala
+++ b/compiler/test/dotty/tools/repl/ScriptedTests.scala
@@ -65,7 +65,7 @@ class ScriptedTests extends ReplTest with MessageRendering {
       resetToInitial()
       val inputRes = extractInputs(prompt)
       val buf = new ArrayBuffer[String]
-      inputRes.foldLeft(initState) { (state, input) =>
+      inputRes.foldLeft(initialState) { (state, input) =>
         val (out, nstate) = evaluate(state, input, prompt)
         buf.append(out)
         nstate

--- a/sbt-bridge/src/xsbt/ConsoleInterface.scala
+++ b/sbt-bridge/src/xsbt/ConsoleInterface.scala
@@ -19,24 +19,6 @@ class ConsoleInterface {
   def run(args: Array[String],
           bootClasspathString: String,
           classpathString: String,
-          // TODO: initial commands needs to be run under some form of special
-          // "silent" mode in the REPL. I.e. the effects should be had without
-          // any visual output.
-          //
-          // To do this we can use the `run` interface to the `ReplDriver` and
-          // pass it a special instance of `ParseResult` like `Silently(res: ParseResult)`
-          // and then observe the effects without printing to `ReplDriver#out`
-          //
-          // This way, the REPL can offer feedback on invalid commands but
-          // still function without stringly logic.
-          //
-          // This same principle can be applied to `cleanupCommands` and
-          // `bindValues`
-          //
-          // Steps:
-          //
-          // 1. Introduce `case class Silent(res: ParseResult) extends ParseResult`
-          // 2. Perform all steps in `interpret` as usual without printing to `out`
           initialCommands: String,
           cleanupCommands: String,
           loader: ClassLoader,
@@ -51,6 +33,15 @@ class ConsoleInterface {
       } ++
       Array("-classpath", classpathString)
 
-    new ReplDriver(completeArgs, classLoader = Some(loader)).runUntilQuit()
+    val driver = new ReplDriver(completeArgs, classLoader = Some(loader))
+
+    val s0 = (bindNames, bindValues).zipped.foldLeft(driver.initialState) {
+      case (state, (name, value)) => driver.bind(name, value)(state)
+    }
+
+    val s1 = driver.run(initialCommands)(s0)
+    // TODO handle failure during initialisation
+    val s2 = driver.runUntilQuit(s1)
+    driver.run(cleanupCommands)(s2)
   }
 }


### PR DESCRIPTION
Implementing the feature requested in #3007 by dropping the output of the executed commands.