### PR TITLE
Add explicit return type to some methods

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/CollectEntryPoints.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CollectEntryPoints.scala
@@ -46,7 +46,7 @@ class CollectEntryPoints extends MiniPhase {
 }
 
 object CollectEntryPoints{
-  def isJavaMainMethod(sym: Symbol)(implicit ctx: Context) = {
+  def isJavaMainMethod(sym: Symbol)(implicit ctx: Context): Boolean = {
     (sym.name == nme.main) && (sym.info match {
       case r@MethodTpe(_, List(defn.ArrayOf(t)), _) =>
         (t.widenDealias =:= defn.StringType) && (
@@ -63,7 +63,7 @@ object CollectEntryPoints{
     def hasJavaMainMethod(sym: Symbol): Boolean =
       (toDenot(sym).info member nme.main).alternatives exists(x => isJavaMainMethod(x.symbol))
 
-    def fail(msg: String, pos: Position = sym.pos) = {
+    def fail(msg: String, pos: Position = sym.pos): Boolean = {
       ctx.warning(          sym.name +
         s" has a main method with parameter type Array[String], but ${toDenot(sym).fullName} will not be a runnable program.\n  Reason: $msg",
         sourcePos(sym.pos)
@@ -74,7 +74,7 @@ object CollectEntryPoints{
       )
       false
     }
-    def failNoForwarder(msg: String) = {
+    def failNoForwarder(msg: String): Boolean = {
       fail(s"$msg, which means no static forwarder can be generated.\n")
     }
     val possibles = if (sym.flags is Flags.Module) (toDenot(sym).info nonPrivateMember nme.main).alternatives else Nil

--- a/compiler/src/dotty/tools/backend/jvm/CollectSuperCalls.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CollectSuperCalls.scala
@@ -32,7 +32,7 @@ class CollectSuperCalls extends MiniPhase {
     tree
   }
 
-  private def registerSuperCall(sym: ClassSymbol, calls: ClassSymbol)(implicit ctx: Context) = {
+  private def registerSuperCall(sym: ClassSymbol, calls: ClassSymbol)(implicit ctx: Context): Unit = {
     ctx.genBCodePhase match {
       case genBCodePhase: GenBCode =>
         genBCodePhase.registerSuperCall(sym, calls)

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -313,7 +313,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   override def emitAnnotations(cw: asm.ClassVisitor, annotations: List[Annotation], bcodeStore: BCodeHelpers)
-                              (innerClasesStore: bcodeStore.BCInnerClassGen) = {
+                              (innerClasesStore: bcodeStore.BCInnerClassGen): Unit = {
     for(annot <- annotations; if shouldEmitAnnotation(annot)) {
       val typ = annot.atp
       val assocs = annot.assocs
@@ -323,14 +323,14 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   private def emitAssocs(av: asm.AnnotationVisitor, assocs: List[(Name, Object)], bcodeStore: BCodeHelpers)
-                        (innerClasesStore: bcodeStore.BCInnerClassGen) = {
+                        (innerClasesStore: bcodeStore.BCInnerClassGen): Unit = {
     for ((name, value) <- assocs)
       emitArgument(av, name.mangledString, value.asInstanceOf[Tree], bcodeStore)(innerClasesStore)
     av.visitEnd()
   }
 
   override def emitAnnotations(mw: asm.MethodVisitor, annotations: List[Annotation], bcodeStore: BCodeHelpers)
-                              (innerClasesStore: bcodeStore.BCInnerClassGen) = {
+                              (innerClasesStore: bcodeStore.BCInnerClassGen): Unit = {
     for(annot <- annotations; if shouldEmitAnnotation(annot)) {
       val typ = annot.atp
       val assocs = annot.assocs
@@ -340,7 +340,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   override def emitAnnotations(fw: asm.FieldVisitor, annotations: List[Annotation], bcodeStore: BCodeHelpers)
-                              (innerClasesStore: bcodeStore.BCInnerClassGen) = {
+                              (innerClasesStore: bcodeStore.BCInnerClassGen): Unit = {
     for(annot <- annotations; if shouldEmitAnnotation(annot)) {
       val typ = annot.atp
       val assocs = annot.assocs

--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -108,7 +108,7 @@ object DesugarEnums {
    *     $values.register(this)
    *   }
    */
-  private def enumValueCreator(implicit ctx: Context) = {
+  private def enumValueCreator(implicit ctx: Context): Tree = {
     def param(name: TermName, typ: Type) =
       ValDef(name, TypeTree(typ), EmptyTree).withFlags(Param)
     val enumTagDef =
@@ -178,7 +178,7 @@ object DesugarEnums {
     val (count, seenKind) = ctx.tree.removeAttachment(EnumCaseCount).getOrElse((0, CaseKind.Class))
     val minKind = if (kind < seenKind) kind else seenKind
     ctx.tree.pushAttachment(EnumCaseCount, (count + 1, minKind))
-    val scaffolding =
+    val scaffolding: List[Tree] =
       if (enumClass.typeParams.nonEmpty || kind >= seenKind) Nil
       else if (kind == CaseKind.Object) enumScaffolding
       else if (seenKind == CaseKind.Object) enumValueCreator :: Nil

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -26,7 +26,7 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
     case _ => false
   }
 
-  def isOpAssign(tree: Tree) = unsplice(tree) match {
+  def isOpAssign(tree: Tree): Boolean = unsplice(tree) match {
     case Apply(fn, _ :: _) =>
       unsplice(fn) match {
         case Select(_, name) if name.isOpAssignmentName => true
@@ -510,7 +510,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   /** Is tree a reference to a mutable variable, or to a potential getter
    *  that has a setter in the same class?
    */
-  def isVariableOrGetter(tree: Tree)(implicit ctx: Context) = {
+  def isVariableOrGetter(tree: Tree)(implicit ctx: Context): Boolean = {
     def sym = tree.symbol
     def isVar    = sym is Mutable
     def isGetter =

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -325,7 +325,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   // ------ Making references ------------------------------------------------------
 
-  def prefixIsElidable(tp: NamedType)(implicit ctx: Context) = {
+  def prefixIsElidable(tp: NamedType)(implicit ctx: Context): Boolean = {
     val typeIsElidable = tp.prefix match {
       case pre: ThisType =>
         tp.isType ||
@@ -470,7 +470,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   /** A `_' with given type */
   def Underscore(tp: Type)(implicit ctx: Context) = untpd.Ident(nme.WILDCARD).withType(tp)
 
-  def defaultValue(tpe: Types.Type)(implicit ctx: Context) = {
+  def defaultValue(tpe: Types.Type)(implicit ctx: Context): Tree = {
     val tpw = tpe.widen
 
     if (tpw isRef defn.IntClass) Literal(Constant(0))
@@ -1008,7 +1008,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       .select(TermRef(receiver.tpe, selected.termSymbol.asTerm))
       .appliedToTypes(targs)
 
-    def adaptLastArg(lastParam: Tree, expectedType: Type) = {
+    def adaptLastArg(lastParam: Tree, expectedType: Type): List[Tree] = {
       if (isAnnotConstructor && !(lastParam.tpe <:< expectedType)) {
         val defn = ctx.definitions
         val prefix = args.take(selected.widen.paramInfoss.head.size - 1)
@@ -1055,7 +1055,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    *
    *     ~within('tree)
    */
-  def letBindUnless(level: TreeInfo.PurityLevel, tree: Tree)(within: Tree => Tree)(implicit ctx: Context) = {
+  def letBindUnless(level: TreeInfo.PurityLevel, tree: Tree)(within: Tree => Tree)(implicit ctx: Context): Tree = {
     if (exprPurity(tree) >= level) within(tree)
     else {
       val vdef = SyntheticValDef(TempResultName.fresh(), tree)


### PR DESCRIPTION
I think the code is more readable if a return type of a method is not omitted generally