### PR TITLE
Add Constant and replace transparent parameters

### DIFF
--- a/bench/tests/power-macro/PowerMacro.scala
+++ b/bench/tests/power-macro/PowerMacro.scala
@@ -2,7 +2,7 @@ import scala.quoted.Expr
 
 object PowerMacro {
 
-  transparent def power(transparent n: Long, x: Double) = ~powerCode(n, '(x))
+  transparent def power(n: Long & Constant, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Long, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -410,6 +410,13 @@ class Definitions {
       List(AnyClass.typeRef), EmptyScope)
   lazy val SingletonType: TypeRef = SingletonClass.typeRef
 
+  lazy val ConstantClass: ClassSymbol =
+    // TODO needs to be synthetic as is SingletonClass?
+    enterCompleteClassSymbol(
+      ScalaPackageClass, tpnme.Constant, PureInterfaceCreationFlags | Final,
+      List(SingletonType), EmptyScope)
+  lazy val ConstantType: TypeRef = ConstantClass.typeRef
+
   lazy val SeqType: TypeRef =
     if (isNewCollections) ctx.requiredClassRef("scala.collection.immutable.Seq")
     else ctx.requiredClassRef("scala.collection.Seq")
@@ -1209,6 +1216,7 @@ class Definitions {
     NullClass,
     NothingClass,
     SingletonClass,
+    ConstantClass,
     EqualsPatternClass)
 
   lazy val syntheticCoreClasses = syntheticScalaClasses ++ List(

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -415,7 +415,6 @@ class Definitions {
     enterCompleteClassSymbol(
       ScalaPackageClass, tpnme.Constant, PureInterfaceCreationFlags | Final,
       List(SingletonType), EmptyScope)
-  lazy val ConstantType: TypeRef = ConstantClass.typeRef
 
   lazy val SeqType: TypeRef =
     if (isNewCollections) ctx.requiredClassRef("scala.collection.immutable.Seq")
@@ -741,8 +740,6 @@ class Definitions {
   def ImplicitNotFoundAnnot(implicit ctx: Context) = ImplicitNotFoundAnnotType.symbol.asClass
   lazy val ForceInlineAnnotType = ctx.requiredClassRef("scala.forceInline")
   def ForceInlineAnnot(implicit ctx: Context) = ForceInlineAnnotType.symbol.asClass
-  lazy val TransparentParamAnnotType = ctx.requiredClassRef("scala.annotation.internal.TransparentParam")
-  def TransparentParamAnnot(implicit ctx: Context) = TransparentParamAnnotType.symbol.asClass
   lazy val InvariantBetweenAnnotType = ctx.requiredClassRef("scala.annotation.internal.InvariantBetween")
   def InvariantBetweenAnnot(implicit ctx: Context) = InvariantBetweenAnnotType.symbol.asClass
   lazy val MigrationAnnotType = ctx.requiredClassRef("scala.annotation.migration")

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -563,9 +563,6 @@ object Flags {
   /** A transparent implicit method */
   final val TransparentImplicitMethod = allOf(Transparent, Implicit, Method)
 
-  /** A transparent parameter */
-  final val TransparentParam = allOf(Transparent, Param)
-
   /** An enum case */
   final val EnumCase = allOf(Enum, Case)
 

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -393,6 +393,7 @@ class TypeComparer(initctx: Context) extends DotClass with ConstraintHandling {
             if (base.exists && base.ne(tp1))
               return isSubType(base, tp2, if (tp1.isRef(cls2)) approx else approx.addLow)
             if (cls2 == defn.SingletonClass && tp1.isStable) return true
+            if (cls2 == defn.ConstantClass && tp1.isConstant) return true
           }
           else if (cls2.is(JavaDefined)) {
             // If `cls2` is parameterized, we are seeing a raw type, so we need to compare only the symbol

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -158,6 +158,14 @@ object Types {
       case _ => false
     }
 
+    /** Does this type denote a constant type */
+    final def isConstant(implicit ctx: Context): Boolean = stripTypeVar match {
+      case _: ConstantType => true
+      case tp: ExprType => tp.resultType.isConstant
+      case tp: AnnotatedType => tp.parent.isConstant
+      case _ => false
+    }
+
     /** Is this type a (possibly refined or applied or aliased) type reference
      *  to the given type symbol?
      *  @sym  The symbol to compare to. It must be a class symbol or abstract type.

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3016,15 +3016,8 @@ object Types {
      *   - add @inlineParam to transparent call-by-value parameters
      */
     def fromSymbols(params: List[Symbol], resultType: Type)(implicit ctx: Context) = {
-      def translateTransparent(tp: Type): Type = tp match {
-        case _: ExprType => tp
-        case _ => AnnotatedType(tp, Annotation(defn.TransparentParamAnnot))
-      }
-      def paramInfo(param: Symbol) = {
-        val paramType = param.info.annotatedToRepeated
-        if (param.is(Transparent)) translateTransparent(paramType) else paramType
-      }
-
+      def paramInfo(param: Symbol) =
+        param.info.annotatedToRepeated
       apply(params.map(_.name.asTermName))(
          tl => params.map(p => tl.integrate(params, paramInfo(p))),
          tl => tl.integrate(params, resultType))

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1913,12 +1913,12 @@ object Parsers {
     /** ClsParamClauses   ::=  {ClsParamClause} [[nl] `(' [FunArgMods] ClsParams `)']
      *  ClsParamClause    ::=  [nl] `(' [`erased'] [ClsParams] ')'
      *  ClsParams         ::=  ClsParam {`' ClsParam}
-     *  ClsParam          ::=  {Annotation} [{Modifier} (`val' | `var') | `inline'] Param
+     *  ClsParam          ::=  {Annotation} [{Modifier} (`val' | `var')] Param
      *  DefParamClauses   ::=  {DefParamClause} [[nl] `(' [FunArgMods] DefParams `)']
      *  DefParamClause    ::=  [nl] `(' [`erased'] [DefParams] ')'
      *  DefParams         ::=  DefParam {`,' DefParam}
-     *  DefParam          ::=  {Annotation} [`inline'] Param
-     *  Param             ::=  id `:' ParamType [`=' Expr]
+     *  DefParam          ::=  {Annotation} Param
+     *  Param             ::=  id :' ParamType [`=' Expr]
      */
     def paramClauses(owner: Name, ofCaseClass: Boolean = false): List[List[ValDef]] = {
       var imods: Modifiers = EmptyModifiers
@@ -1940,7 +1940,7 @@ object Parsers {
                 addMod(mods, mod)
               }
               else {
-                if (!(mods.flags &~ (ParamAccessor | Transparent)).isEmpty)
+                if (!(mods.flags &~ ParamAccessor).isEmpty)
                   syntaxError("`val' or `var' expected")
                 if (firstClauseOfCaseClass) mods
                 else mods | PrivateLocal
@@ -1948,7 +1948,6 @@ object Parsers {
             }
         }
         else {
-          if (in.token == TRANSPARENT) mods = addModifier(mods)
           mods = atPos(start) { mods | Param }
         }
         atPos(start, nameStart) {

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -254,6 +254,8 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
                   super.transform(_).asInstanceOf[Template]))
           }
         case tree: ValDef =>
+          if (tree.symbol.is(Param) && !tree.symbol.owner.is(Transparent) && tree.tpt.tpe.derivesFrom(defn.ConstantClass))
+            ctx.error("only parameters of transparent method can have Constant type", tree.pos)
           val tree1 = cpy.ValDef(tree)(rhs = normalizeErasedRhs(tree.rhs, tree.symbol))
           transformMemberDef(tree1)
           super.transform(tree1)

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -504,7 +504,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
       val captured = mutable.LinkedHashMap.empty[Symbol, Tree]
       val captured2 = capturer(captured)
 
-      outer.enteredSyms.foreach(sym => if (!sym.is(Transparent)) capturers.put(sym, captured2))
+      outer.enteredSyms.foreach(sym => if (!sym.info.derivesFrom(defn.ConstantClass)) capturers.put(sym, captured2))
 
       val tree2 = transform(tree)
       capturers --= outer.enteredSyms
@@ -550,7 +550,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
             splice(ref(splicedType).select(tpnme.UNARY_~).withPos(tree.pos))
           case tree: Select if tree.symbol.isSplice =>
             splice(tree)
-          case tree: RefTree if tree.symbol.is(Transparent) && tree.symbol.is(Param) =>
+          case tree: RefTree if tree.symbol.is(Param) && tree.tpe.derivesFrom(defn.ConstantClass) =>
             tree
           case tree: RefTree if isCaptured(tree.symbol, level) =>
             val t = capturers(tree.symbol).apply(tree)

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -240,9 +240,9 @@ object Splicer {
 
     def unexpectedTree(tree: tpd.Tree)(implicit env: Env): Boolean = {
       // Assuming that top-level splices can only be in transparent methods
-      // and splices are expanded at inline site, references to transparent values
+      // and splices are expanded at inline site, references to parameter wit constant type
       // will be know literal constant trees.
-      tree.symbol.is(Transparent)
+      tree.symbol.is(Param) && tree.tpe.derivesFrom(defn.ConstantClass)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -221,10 +221,9 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
                               bindingsBuf: mutable.ListBuffer[MemberDef]): MemberDef = {
     val argtpe = arg.tpe.dealiasKeepAnnots
     val isByName = paramtp.dealias.isInstanceOf[ExprType]
-    val inlineFlag = if (paramtp.hasAnnotation(defn.TransparentParamAnnot)) Transparent else EmptyFlags
     val (bindingFlags, bindingType) =
       if (isByName) (Method, ExprType(argtpe.widen))
-      else (inlineFlag, argtpe.widen)
+      else (EmptyFlags, argtpe.widen)
     val boundSym = newSym(name, bindingFlags, bindingType).asTerm
     val binding =
       if (isByName) DefDef(boundSym, arg.changeOwner(ctx.owner, boundSym))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2385,8 +2385,6 @@ class Typer extends Namer
         readaptSimplified(Inliner.inlineCall(tree, pt))
       }
       else if (tree.tpe <:< pt) {
-        if (pt.hasAnnotation(defn.TransparentParamAnnot))
-          checkTransparentConformant(tree, isFinal = false, "argument to transparent parameter")
         if (ctx.typeComparer.GADTused && pt.isValueType)
           // Insert an explicit cast, so that -Ycheck in later phases succeeds.
           // I suspect, but am not 100% sure that this might affect inferred types,

--- a/library/src/scala/annotation/internal/TransparentParam.scala
+++ b/library/src/scala/annotation/internal/TransparentParam.scala
@@ -1,6 +1,0 @@
-package scala.annotation.internal
-
-import scala.annotation.Annotation
-
-/** An annotation produced by Namer to indicate a transparent parameter */
-final class TransparentParam() extends Annotation

--- a/tests/neg/constant-types.scala
+++ b/tests/neg/constant-types.scala
@@ -1,0 +1,20 @@
+object Constants {
+
+  def f[C <: Constant](c: C): Unit = ()
+  val x = 1
+  f(x) // error
+
+  def fBool(c: Boolean & Constant): Unit = ()
+  val b = true
+  fBool(b) // error
+
+
+  def fInt(c: Int & Constant): Unit = ()
+  val i = 3
+  fInt(i) // error
+
+  def fChar(c: Char & Constant): Unit = ()
+  val c = 'c'
+  fChar(c) // error
+
+}

--- a/tests/neg/i4433.scala
+++ b/tests/neg/i4433.scala
@@ -1,6 +1,6 @@
 
 object Foo {
-  transparent def g(transparent p: Int => Boolean): Boolean = ~{ // error
+  transparent def g(p: (Int => Boolean) & Constant): Boolean = ~{ // error
     if(p(5)) '(true)
     else '(false)
   }

--- a/tests/neg/inlinevals-2.scala
+++ b/tests/neg/inlinevals-2.scala
@@ -1,0 +1,20 @@
+object Test {
+
+  def power0(x: Double, n: Int & Constant): Double = ???  // error
+
+  transparent def power(x: Double, n: Int & Constant): Double = ???  // ok
+
+  transparent val N = 10
+  def X = 20
+
+  class C(x: Int & Constant, private val y: Int & Constant) // error // error
+
+  transparent def foo(x: Int) = {
+
+    def f(xs: List[Int] & Constant) = xs // error
+
+    transparent val y = { println("hi"); 1 }  // ok
+    transparent val z = x // ok
+
+  }
+}

--- a/tests/neg/inlinevals.scala
+++ b/tests/neg/inlinevals.scala
@@ -1,35 +1,24 @@
 object Test {
 
-  def power0(x: Double, transparent n: Int): Double = ???  // error
-
-  transparent def power(x: Double, transparent n: Int): Double = ???  // ok
+  transparent def power(x: Double, n: Int & Constant): Double = ???  // ok
 
   transparent val N = 10
   def X = 20
 
   transparent transparent val twice = 30 // error: repeated modifier
 
-  class C(transparent x: Int, private transparent val y: Int) { // error // error
+  class C {
     transparent val foo: Int // error: abstract member may not be inline
     transparent def bar: Int // error: abstract member may not be inline
   }
 
-  power(2.0, N) // ok, since it's a by-name parameter
+  power(2.0, N) // ok, since parameter is inlined
   power(2.0, X) // error: argument to transparent parameter must be a constant expression
 
   transparent val M = X  // error: rhs must be constant expression
 
   transparent val xs = List(1, 2, 3) // error: must be a constant expression
 
-  transparent def foo(x: Int) = {
-
-    def f(transparent xs: List[Int]) = xs // error
-
-    transparent val y = { println("hi"); 1 }  // ok
-    transparent val z = x // ok
-
-  }
-
-  transparent def byname(transparent f: => String): Int = ??? // ok
+  transparent def byname(f: => String): Int = ??? // ok
 
 }

--- a/tests/neg/quote-error-2/Macro_1.scala
+++ b/tests/neg/quote-error-2/Macro_1.scala
@@ -1,7 +1,7 @@
 import quoted._
 
 object Macro_1 {
-  transparent def foo(transparent b: Boolean): Unit = ~fooImpl(b)
+  transparent def foo(b: Boolean & Constant): Unit = ~fooImpl(b)
   def fooImpl(b: Boolean): Expr[Unit] =
     '(println(~msg(b)))
 

--- a/tests/neg/quote-error/Macro_1.scala
+++ b/tests/neg/quote-error/Macro_1.scala
@@ -1,7 +1,7 @@
 import quoted._
 
 object Macro_1 {
-  transparent def foo(transparent b: Boolean): Unit = ~fooImpl(b)
+  transparent def foo(b: Boolean & Constant): Unit = ~fooImpl(b)
   def fooImpl(b: Boolean): Expr[Unit] =
     if (b) '(println("foo(true)"))
     else QuoteError("foo cannot be called with false")

--- a/tests/neg/quote-exception/Macro_1.scala
+++ b/tests/neg/quote-exception/Macro_1.scala
@@ -1,7 +1,7 @@
 import quoted._
 
 object Macro_1 {
-  transparent def foo(transparent b: Boolean): Unit = ~fooImpl(b)
+  transparent def foo(b: Boolean & Constant): Unit = ~fooImpl(b)
   def fooImpl(b: Boolean): Expr[Unit] =
     if (b) '(println("foo(true)"))
     else ???

--- a/tests/neg/quote-macro-complex-arg-0.scala
+++ b/tests/neg/quote-macro-complex-arg-0.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Macros {
-  transparent def foo(transparent i: Int, dummy: Int, j: Int): Int = ~bar(i + 1, '(j)) // error: i + 1 is not a parameter or field reference
+  transparent def foo(i: Int & Constant, dummy: Int, j: Int): Int = ~bar(i + 1, '(j)) // error: i + 1 is not a parameter or field reference
   def bar(x: Int, y: Expr[Int]): Expr[Int] = '{ ~x.toExpr + ~y }
 }

--- a/tests/neg/quote-splice-interpret-1.scala
+++ b/tests/neg/quote-splice-interpret-1.scala
@@ -2,7 +2,7 @@
 import scala.quoted._
 
 object Macros {
-  transparent def isZero(transparent n: Int): Boolean = ~{ // error
+  transparent def isZero(n: Int & Constant): Boolean = ~{ // error
     if (n == 0) '(true)
     else '(false)
   }

--- a/tests/pos/constant-types.scala
+++ b/tests/pos/constant-types.scala
@@ -1,0 +1,30 @@
+object Constants {
+
+  def f[C <: Constant](c: C): Unit = ()
+  f(true)
+  f(1)
+  f(2L)
+  f(1.2f)
+  f(1.2d)
+  f('a')
+  f("abc")
+
+  def fBool(c: Boolean & Constant): Unit = ()
+  fBool(true)
+  fBool(false)
+  transparent def bb: Boolean = true
+  fBool(bb)
+
+  def fInt(c: Int & Constant): Unit = ()
+  fInt(1)
+  fInt(2)
+  transparent def ii: Int = 4
+  fInt(ii)
+
+  def fChar(c: Char & Constant): Unit = ()
+  fChar('a')
+  fChar('b')
+  transparent def cc: Char = 'd'
+  fChar(cc)
+
+}

--- a/tests/pos/constant-types.scala
+++ b/tests/pos/constant-types.scala
@@ -1,6 +1,6 @@
 object Constants {
 
-  def f[C <: Constant](c: C): Unit = ()
+  transparent def f[C <: Constant](c: C): Unit = ()
   f(true)
   f(1)
   f(2L)
@@ -9,19 +9,19 @@ object Constants {
   f('a')
   f("abc")
 
-  def fBool(c: Boolean & Constant): Unit = ()
+  transparent def fBool(c: Boolean & Constant): Unit = ()
   fBool(true)
   fBool(false)
   transparent def bb: Boolean = true
   fBool(bb)
 
-  def fInt(c: Int & Constant): Unit = ()
+  transparent def fInt(c: Int & Constant): Unit = ()
   fInt(1)
   fInt(2)
   transparent def ii: Int = 4
   fInt(ii)
 
-  def fChar(c: Char & Constant): Unit = ()
+  transparent def fChar(c: Char & Constant): Unit = ()
   fChar('a')
   fChar('b')
   transparent def cc: Char = 'd'

--- a/tests/pos/i1570.decompiled
+++ b/tests/pos/i1570.decompiled
@@ -1,5 +1,5 @@
 /** Decompiled from out/posTestFromTasty/pos/i1570/Test.class */
 object Test {
-  transparent def foo(n: scala.Int): scala.Int = Test.bar(n)
-  transparent def bar(n: scala.Int): scala.Int = n
+  transparent def foo(n: scala.Int & scala.Constant): scala.Int & scala.Constant = Test.bar(n)
+  transparent def bar(n: scala.Int & scala.Constant): scala.Int & scala.Constant = n
 }

--- a/tests/pos/i1570.scala
+++ b/tests/pos/i1570.scala
@@ -1,4 +1,4 @@
 object Test {
-  transparent def foo(transparent n: Int) = bar(n)
-  transparent def bar(transparent n: Int) = n
+  transparent def foo(n: Int & Constant) = bar(n)
+  transparent def bar(n: Int & Constant) = n
 }

--- a/tests/pos/i3898b/quoted_1.scala
+++ b/tests/pos/i3898b/quoted_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  transparent def ff(x: Int, transparent y: Int): String = ~impl('(x))
+  transparent def ff(x: Int, y: Int & Constant): String = ~impl('(x))
   def impl(x: Expr[Int]): Expr[String] = '("")
 }

--- a/tests/pos/i3898c/quoted_1.scala
+++ b/tests/pos/i3898c/quoted_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  transparent def ff(x: Int, transparent y: Int): String = ~impl('(x))
+  transparent def ff(x: Int, y: Int & Constant): String = ~impl('(x))
   def impl(x: Expr[Int]): Expr[String] = '("")
 }

--- a/tests/pos/i4846.scala
+++ b/tests/pos/i4846.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Test {
-  transparent def foo(transparent x: Int): Int = ~fooImpl(x, '(x), '( '(x) ), '( '( '(x) ) ))
+  transparent def foo(x: Int & Constant): Int = ~fooImpl(x, '(x), '( '(x) ), '( '( '(x) ) ))
   def fooImpl(a: Int, b: Expr[Int], c: Expr[Expr[Int]], d: Expr[Expr[Expr[Int]]]): Expr[Int] = ???
 }

--- a/tests/pos/power-macro/Macro_1.scala
+++ b/tests/pos/power-macro/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted.Expr
 
 object PowerMacro {
 
-  transparent def power(transparent n: Long, x: Double) = ~powerCode(n, '(x))
+  transparent def power(n: Long & Constant, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Long, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/tests/pos/power-macro/PowerInlined-1_2.scala
+++ b/tests/pos/power-macro/PowerInlined-1_2.scala
@@ -1,5 +1,5 @@
 object PowerInlined1 {
   import PowerMacro._
 
-  power(1, 5.0) // 1 quotes to unpickle
+  power(1L, 5.0) // 1 quotes to unpickle
 }

--- a/tests/pos/quote-lift-inline-params-b.scala
+++ b/tests/pos/quote-lift-inline-params-b.scala
@@ -1,7 +1,7 @@
 import scala.quoted.Expr
 import quoted.Liftable.{IntIsLiftable => _}
 object Macro {
-  transparent def foo(transparent n: Int): Int = ~{
+  transparent def foo(n: Int & Constant): Int = ~{
     '(n)
   }
 }

--- a/tests/pos/quote-lift-inline-params/Macro_1.scala
+++ b/tests/pos/quote-lift-inline-params/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted.Expr
 object Macro {
   import quoted.Liftable.{IntIsLiftable => _}
-  transparent def foo(transparent n: Int): Int = ~{
+  transparent def foo(n: Int & Constant): Int = ~{
     '(n)
   }
 }

--- a/tests/pos/quote-nested-object/Macro_1.scala
+++ b/tests/pos/quote-nested-object/Macro_1.scala
@@ -6,7 +6,7 @@ object Macro {
 
   object Implementation {
 
-    transparent def plus(transparent n: Int, m: Int): Int = ~plus(n, '(m))
+    transparent def plus(n: Int & Constant, m: Int): Int = ~plus(n, '(m))
 
     def plus(n: Int, m: Expr[Int]): Expr[Int] =
       if (n == 0) m
@@ -14,7 +14,7 @@ object Macro {
 
     object Implementation2 {
 
-      transparent def plus(transparent n: Int, m: Int): Int = ~plus(n, '(m))
+      transparent def plus(n: Int & Constant, m: Int): Int = ~plus(n, '(m))
 
       def plus(n: Int, m: Expr[Int]): Expr[Int] =
         if (n == 0) m

--- a/tests/run/i1569.scala
+++ b/tests/run/i1569.scala
@@ -1,5 +1,5 @@
 object Test {
-  transparent def foo(transparent n: => Int) = n + n
+  transparent def foo(n: => Int & Constant) = n + n
 
   def main(args: Array[String]): Unit = foo({ println("foo"); 42 })
 }

--- a/tests/run/i4455/Macro_1.scala
+++ b/tests/run/i4455/Macro_1.scala
@@ -1,8 +1,8 @@
 import scala.quoted._
 object Macros {
-  transparent def foo(transparent i: Int): Int = ~bar('(i))
+  transparent def foo(i: Int & Constant): Int = ~bar('(i))
 
-  transparent def foo2(transparent i: Int): Int = ~bar('(i + 1))
+  transparent def foo2(i: Int & Constant): Int = ~bar('(i + 1))
 
   def bar(x: Expr[Int]): Expr[Int] = x
 }

--- a/tests/run/i4735/Macro_1.scala
+++ b/tests/run/i4735/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 
 object Macro {
 
-  transparent def unrolledForeach(transparent unrollSize: Int, seq: Array[Int], f: => Int => Unit): Unit = // or f: Int => Unit
+  transparent def unrolledForeach(unrollSize: Int & Constant, seq: Array[Int], f: => Int => Unit): Unit = // or f: Int => Unit
     ~unrolledForeachImpl(unrollSize, '(seq), '(f))
 
   private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{

--- a/tests/run/i4803/App_2.scala
+++ b/tests/run/i4803/App_2.scala
@@ -1,20 +1,20 @@
 
 class Num2(x: Double) {
-  transparent def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+  transparent def power(n: Long & Constant) = ~PowerMacro.powerCode('(x), n)
 }
 
 object Test {
   def main(args: Array[String]): Unit = {
     val n = new Num(1.5)
-    println(n.power(0))
-    println(n.power(1))
-    println(n.power(2))
-    println(n.power(5))
+    println(n.power(0L))
+    println(n.power(1L))
+    println(n.power(2L))
+    println(n.power(5L))
 
     val n2 = new Num2(1.5)
-    println(n.power(0))
-    println(n.power(1))
-    println(n.power(2))
-    println(n.power(5))
+    println(n.power(0L))
+    println(n.power(1L))
+    println(n.power(2L))
+    println(n.power(5L))
   }
 }

--- a/tests/run/i4803/Macro_1.scala
+++ b/tests/run/i4803/Macro_1.scala
@@ -8,5 +8,5 @@ object PowerMacro {
 }
 
 class Num(x: Double) {
-  transparent def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+  transparent def power(n: Long & Constant) = ~PowerMacro.powerCode('(x), n)
 }

--- a/tests/run/i4803b/App_2.scala
+++ b/tests/run/i4803b/App_2.scala
@@ -2,7 +2,7 @@
 
 class Nums {
   class Num(x: Double) {
-    transparent def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+    transparent def power(n: Long & Constant) = ~PowerMacro.powerCode('(x), n)
   }
 }
 
@@ -10,9 +10,9 @@ object Test {
   def main(args: Array[String]): Unit = {
     val nums = new Nums
     val n = new nums.Num(1.5)
-    println(n.power(0))
-    println(n.power(1))
-    println(n.power(2))
-    println(n.power(5))
+    println(n.power(0L))
+    println(n.power(1L))
+    println(n.power(2L))
+    println(n.power(5L))
   }
 }

--- a/tests/run/i4803c/App_2.scala
+++ b/tests/run/i4803c/App_2.scala
@@ -2,21 +2,21 @@
 object Test {
   def main(args: Array[String]): Unit = {
     class Num(x: Double) {
-      transparent def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+      transparent def power(n: Long & Constant) = ~PowerMacro.powerCode('(x), n)
     }
     val n = new Num(1.5)
-    println(n.power(0))
-    println(n.power(1))
-    println(n.power(2))
-    println(n.power(5))
+    println(n.power(0L))
+    println(n.power(1L))
+    println(n.power(2L))
+    println(n.power(5L))
 
-    transparent def power(x: Double, transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+    transparent def power(x: Double, n: Long & Constant) = ~PowerMacro.powerCode('(x), n)
 
     val x: Double = 1.5
 
-    println(power(x, 0))
-    println(power(x, 1))
-    println(power(x, 2))
-    println(power(x, 5))
+    println(power(x, 0L))
+    println(power(x, 1L))
+    println(power(x, 2L))
+    println(power(x, 5L))
   }
 }

--- a/tests/run/i4803d/App_2.scala
+++ b/tests/run/i4803d/App_2.scala
@@ -11,7 +11,7 @@ object Test {
   }
 
   transparent def power2(x: Double) = {
-    transparent def power(x: Double, transparent n: Long) = ~PowerMacro.powerCode('(x), n)
-    power(x, 2)
+    transparent def power(x: Double, n: Long & Constant) = ~PowerMacro.powerCode('(x), n)
+    power(x, 2L)
   }
 }

--- a/tests/run/lst/Lst.scala
+++ b/tests/run/lst/Lst.scala
@@ -37,7 +37,7 @@ class Lst[+T](val elems: Any) extends AnyVal { self =>
     }
   }
 
-  transparent def foreachReversed(transparent op: T => Unit): Unit = locally {
+  transparent def foreachReversed(op: => T => Unit): Unit = locally {
     def sharedOp(x: T) = op(x)
     elems match {
       case null =>

--- a/tests/run/quote-and-splice/Macros_1.scala
+++ b/tests/run/quote-and-splice/Macros_1.scala
@@ -5,7 +5,7 @@ object Macros {
   transparent def macro1 = ~ macro1Impl
   def macro1Impl = '(3)
 
-  transparent def macro2(transparent p: Boolean) = ~ macro2Impl(p)
+  transparent def macro2(p: Boolean & Constant) = ~ macro2Impl(p)
   def macro2Impl(p: Boolean) = if (p) '(3) else '(4)
 
   transparent def macro3(n: Int) = ~ macro3Impl('(n))
@@ -17,7 +17,7 @@ object Macros {
   transparent def macro5(i: Int, j: Int) = ~ macro5Impl(j = '(j), i = '(i))
   def macro5Impl(i: Expr[Int], j: Expr[Int]) = '{ ~i + ~j }
 
-  transparent def power(transparent n: Int, x: Double) = ~powerCode(n, '(x))
+  transparent def power(n: Int & Constant, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Int, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/tests/run/quote-simple-macro/quoted_1.scala
+++ b/tests/run/quote-simple-macro/quoted_1.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Macros {
-  transparent def foo(transparent i: Int, dummy: Int, j: Int): Int = ~bar(i, '(j))
+  transparent def foo(i: Int & Constant, dummy: Int, j: Int): Int = ~bar(i, '(j))
   def bar(x: Int, y: Expr[Int]): Expr[Int] = '{ ~x.toExpr + ~y }
 }

--- a/tests/run/quote-unrolled-foreach/quoted_1.scala
+++ b/tests/run/quote-unrolled-foreach/quoted_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 
 object Macro {
 
-  transparent def unrolledForeach(transparent unrollSize: Int, seq: Array[Int])(f: => Int => Unit): Unit = // or f: Int => Unit
+  transparent def unrolledForeach(unrollSize: Int & Constant, seq: Array[Int])(f: => Int => Unit): Unit = // or f: Int => Unit
     ~unrolledForeachImpl(unrollSize, '(seq), '(f))
 
   private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{

--- a/tests/run/typelevel-patmat.scala
+++ b/tests/run/typelevel-patmat.scala
@@ -21,7 +21,7 @@ object Test extends App {
   type HNil = HNil.type
   type Z = Z.type
 
-  transparent def ToNat(transparent n: Int): Typed[Nat] =
+  transparent def ToNat(n: Int & Constant): Typed[Nat] =
     if n == 0 then Typed(Z)
     else Typed(S(ToNat(n - 1).value))
 

--- a/tests/run/typelevel.scala
+++ b/tests/run/typelevel.scala
@@ -42,7 +42,7 @@ object Test extends App {
   type HNil = HNil.type
   type Z = Z.type
 
-  transparent def ToNat(transparent n: Int): ToNat[Nat] =
+  transparent def ToNat(n: Int & Constant): ToNat[Nat] =
     if n == 0 then new ToNat(Z)
     else {
       val n1 = ToNat(n - 1)
@@ -101,7 +101,7 @@ object Test extends App {
   transparent val l1 = xs.length
   val l1a: 2 = l1
 
-  transparent def index(xs: HList, transparent idx: Int): Any =
+  transparent def index(xs: HList, idx: Int & Constant): Any =
     if idx == 0 then xs.head
     else index(xs.tail, idx - 1)
 


### PR DESCRIPTION
Introduce the type `Constant` which is a subtype of `Singleton` but only allows constants (e.i. known values).

Use `Constant` to mark parameters of `transparent` methods that must be passed as constants or inlined constants.