### PR TITLE
Fix #4720 and #4721: account for type inference being too smart

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -34,7 +34,7 @@ abstract class Positioned extends DotClass with Product {
    *  destructively and the item itself is returned.
    */
   def withPos(pos: Position): this.type = {
-    val newpd = (if (pos == curPos || curPos.isSynthetic) this else clone).asInstanceOf[Positioned]
+    val newpd = (if (pos == curPos || curPos.isSynthetic) this else clone.asInstanceOf[Positioned])
     newpd.setPos(pos)
     newpd.asInstanceOf[this.type]
   }

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -58,7 +58,7 @@ object Config {
   /** Type comparer will fail with an assert if the upper bound
    *  of a constrained parameter becomes Nothing. This should be turned
    *  on only for specific debugging as normally instantiation to Nothing
-   *  is not an error consdition.
+   *  is not an error condition.
    */
   final val failOnInstantiationToNothing = false
 

--- a/compiler/src/dotty/tools/dotc/core/Constraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constraint.scala
@@ -60,7 +60,7 @@ abstract class Constraint extends Showable {
    *  are not contained in the return bounds.
    *  @pre `param` is not part of the constraint domain.
    */
-  def nonParamBounds(param: TypeParamRef): TypeBounds
+  def nonParamBounds(param: TypeParamRef)(implicit ctx: Context): TypeBounds
 
   /** The lower bound of `param` including all known-to-be-smaller parameters */
   def fullLowerBound(param: TypeParamRef)(implicit ctx: Context): Type

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -345,8 +345,7 @@ trait ConstraintHandling {
     assert {
       checkPropagated(i"initialized $tl") {
         constraint = constraint.add(tl, tvars)
-        tl.paramNames.indices.forall { i =>
-          val param = tl.paramRefs(i)
+        tl.paramRefs.forall { param =>
           val bounds = constraint.nonParamBounds(param)
           val lower = constraint.lower(param)
           val upper = constraint.upper(param)

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -341,24 +341,22 @@ trait ConstraintHandling {
    *  and propagate all bounds.
    *  @param tvars   See Constraint#add
    */
-  def addToConstraint(tl: TypeLambda, tvars: List[TypeVar]): Unit =
-    assert {
-      checkPropagated(i"initialized $tl") {
-        constraint = constraint.add(tl, tvars)
-        tl.paramRefs.forall { param =>
-          constraint.entry(param) match {
-            case bounds: TypeBounds =>
-              val lower = constraint.lower(param)
-              val upper = constraint.upper(param)
-              if (lower.nonEmpty && !bounds.lo.isRef(defn.NothingClass) ||
-                upper.nonEmpty && !bounds.hi.isRef(defn.AnyClass)) constr.println(i"INIT*** $tl")
-              lower.forall(addOneBound(_, bounds.hi, isUpper = true)) &&
-                upper.forall(addOneBound(_, bounds.lo, isUpper = false))
-            case _ =>
-              // Happens if param was already solved while processing earlier params of the same TypeLambda.
-              // See #4720.
-              true
-          }
+  def addToConstraint(tl: TypeLambda, tvars: List[TypeVar]): Boolean =
+    checkPropagated(i"initialized $tl") {
+      constraint = constraint.add(tl, tvars)
+      tl.paramRefs.forall { param =>
+        constraint.entry(param) match {
+          case bounds: TypeBounds =>
+            val lower = constraint.lower(param)
+            val upper = constraint.upper(param)
+            if (lower.nonEmpty && !bounds.lo.isRef(defn.NothingClass) ||
+              upper.nonEmpty && !bounds.hi.isRef(defn.AnyClass)) constr.println(i"INIT*** $tl")
+            lower.forall(addOneBound(_, bounds.hi, isUpper = true)) &&
+              upper.forall(addOneBound(_, bounds.lo, isUpper = false))
+          case _ =>
+            // Happens if param was already solved while processing earlier params of the same TypeLambda.
+            // See #4720.
+            true
         }
       }
     }

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -191,8 +191,8 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
   def isLess(param1: TypeParamRef, param2: TypeParamRef): Boolean =
     upper(param1).contains(param2)
 
-  def nonParamBounds(param: TypeParamRef): TypeBounds =
-    entry(param).asInstanceOf[TypeBounds]
+  def nonParamBounds(param: TypeParamRef)(implicit ctx: Context): TypeBounds =
+    entry(param).bounds
 
   def fullLowerBound(param: TypeParamRef)(implicit ctx: Context): Type =
     (nonParamBounds(param).lo /: minLower(param))(_ | _)

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -457,10 +457,10 @@ object ProtoTypes {
       s"inconsistent: no typevars were added to committable constraint ${state.constraint}")
 
     def newTypeVars(tl: TypeLambda): List[TypeTree] =
-      for (n <- (0 until tl.paramNames.length).toList)
+      for (paramRef <- tl.paramRefs)
       yield {
         val tt = new TypeVarBinder().withPos(owningTree.pos)
-        val tvar = new TypeVar(tl.paramRefs(n), state)
+        val tvar = new TypeVar(paramRef, state)
         state.ownedVars += tvar
         tt.withType(tvar)
       }

--- a/tests/neg/i4721.scala
+++ b/tests/neg/i4721.scala
@@ -1,0 +1,4 @@
+object Test {
+  def main(args: Array[String]):Unit = m(1) // error
+  def m[Y<:String, Z>:Int, W>:Z<:Y](d:Y):Unit={}
+}

--- a/tests/neg/i4721a.scala
+++ b/tests/neg/i4721a.scala
@@ -1,0 +1,4 @@
+object Test {
+  def main(args: Array[String]):Unit = m("1") // error
+  def m[Y<:String, Z>:Int, W>:Z<:Y](d:Y):Unit={}
+}

--- a/tests/pos/i4720.scala
+++ b/tests/pos/i4720.scala
@@ -1,0 +1,4 @@
+object Test {
+  def main(args: Array[String]):Unit = m(1)
+  def m[Y<:Int, Z>:Int, W>:Z<:Y](d:Y):Unit={}
+}


### PR DESCRIPTION
Fix #4720 and #4721: account for @smarter type inference. Some type arguments can be solved right away by looking at their bounds alone, so handle them gracefully.
#4720 was introduced by eeb5965328a937ccac48d5b26e27f2e107c5e092, #4721 was earlier.