### PR TITLE
Fix #4929: Make TastyFileManager reusable

### DIFF
--- a/sbt-dotty/src/dotty/tools/sbtplugin/TastyFileManager.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/TastyFileManager.scala
@@ -48,6 +48,9 @@ final class TastyFileManager extends ClassFileManager {
       IO.deleteFilesEmptyDirs(generatedTastyFiles)
       for ((orig, tmp) <- movedTastyFiles) IO.move(tmp, orig)
     }
+
+    generatedTastyFiles.clear()
+    movedTastyFiles.clear()
     if (_tempDir != null) {
       IO.delete(tempDir)
       _tempDir = null


### PR DESCRIPTION
The external class file manager may be reused across multiple
compilation, so we need to make sure the instance is reusable once a
call to the `complete` callback has been made.