### PR TITLE
WIP #4721 try improving errors

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1478,10 +1478,10 @@ object messages {
     val explanation = ""
   }
 
-  case class DoesNotConformToBound(tpe: Type, which: String, bound: Type)(
+  case class DoesNotConformToBound(tpe: Type, which: String, bound: Type, inferred: Boolean)(
     err: typer.ErrorReporting.Errors)(implicit ctx: Context)
     extends Message(DoesNotConformToBoundID) {
-    val msg = hl"Type argument ${tpe} does not conform to $which bound $bound ${err.whyNoMatchStr(tpe, bound)}"
+    val msg = hl"${if (inferred) "Inferred type" else "Type"} argument $tpe does not conform to $which bound $bound ${err.whyNoMatchStr(tpe, bound)}"
     val kind = "Type Mismatch"
     val explanation = ""
   }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -44,10 +44,14 @@ object Checking {
         ctx.error(ex"missing type parameter(s) for $arg", arg.pos)
       }
     }
-    for ((arg, which, bound) <- ctx.boundsViolations(args, boundss, instantiate))
-      ctx.error(
+    for ((arg, which, bound) <- ctx.boundsViolations(args, boundss, instantiate)) {
+      if (arg.pos.isZeroExtent)
+        ctx.error(
           DoesNotConformToBound(arg.tpe, which, bound)(err),
           arg.pos.focus)
+      else
+        ctx.error(hl"inferred type ${arg.tpe} violates $which bound $bound", arg.pos.focus)
+    }
   }
 
   /** Check that type arguments `args` conform to corresponding bounds in `tl`

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -45,12 +45,10 @@ object Checking {
       }
     }
     for ((arg, which, bound) <- ctx.boundsViolations(args, boundss, instantiate)) {
-      if (arg.pos.isZeroExtent)
-        ctx.error(
-          DoesNotConformToBound(arg.tpe, which, bound)(err),
-          arg.pos.focus)
-      else
-        ctx.error(hl"inferred type ${arg.tpe} violates $which bound $bound", arg.pos.focus)
+      println(s"arg.pos ${arg.pos}, ${arg.pos.isSynthetic}")
+      ctx.error(
+        DoesNotConformToBound(arg.tpe, which, bound, arg.pos.isZeroExtent)(err),
+        arg.pos.focus)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -480,7 +480,12 @@ object ProtoTypes {
       else tl
     val added = ensureFresh(tl)
     val tvars = if (addTypeVars) newTypeVars(added) else Nil
-    ctx.typeComparer.addToConstraint(added, tvars.tpes.asInstanceOf[List[TypeVar]])
+    // addToConstraint can return false if the constraints have no solution, but it seems easier to detect and report
+    // any resulting bound violations later in PostTyper (see #4946). We still give a warning because the subsequent
+    // errors might be misleading.
+    if (!ctx.typeComparer.addToConstraint(added, tvars.tpes.asInstanceOf[List[TypeVar]]))
+      ctx.warning(s"Unsatisfiable type parameter constraints in polymorphic application", owningTree.pos)
+
     (added, tvars)
   }
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -629,10 +629,11 @@ class ErrorMessagesTests extends ErrorMessagesTest {
     .expect { (ictx, messages) =>
       implicit val ctx: Context = ictx
       assertMessageCount(1, messages)
-      val DoesNotConformToBound(tpe, which, bound) :: Nil = messages
+      val DoesNotConformToBound(tpe, which, bound, inferred) :: Nil = messages
       assertEquals("Int", tpe.show)
       assertEquals("upper", which)
       assertEquals("List[Int]", bound.show)
+      assertEquals(true, inferred)
     }
 
   @Test def doesNotConformToSelfType =


### PR DESCRIPTION
When a type argument violates its bounds, we give the same errors whether the argument is specified by the user or inferred by the compiler. This PR is an (incomplete) attempt to detect and fix that. However, I failed to distinguish reliably inferred and synthesized type arguments, even following https://github.com/lampepfl/dotty/pull/4946#issuecomment-413785742

This PR builds on #4946 to try improving the resulting error output. Sadly, the position of inferred arguments fails both `isSynthetic` and `isZeroExtent` (`arg.pos [53..54], false`).

```
sbt:dotty> dotc -d out tests/neg/i4721a.scala
[info] Compiling 1 Scala source to /Users/pgiarrusso/git/dotty/compiler/target/scala-2.12/classes ...
[info] Done compiling.
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
[info] Packaging /Users/pgiarrusso/git/dotty/compiler/target/scala-2.12/dotty-compiler_2.12-0.10.0-bin-SNAPSHOT-nonbootstrapped.jar ...
[info] Done packaging.
[info] Running (fork) dotty.tools.dotc.Main -classpath /Users/pgiarrusso/git/dotty/library/../out/bootstrap/dotty-library-bootstrapped/scala-0.10/dotty-library_0.10-0.10.0-bin-SNAPSHOT.jar -d out tests/neg/i4721a.scala
-- Warning: tests/neg/i4721a.scala:2:39 ----------------------------------------
2 |  def main(args: Array[String]):Unit = m("1") // error
  |                                       ^
  |       Unsatisfiable type parameter constraints in polymorphic application
arg.pos [53..54], false
-- [E057] Type Mismatch Error: tests/neg/i4721a.scala:2:39 ---------------------
2 |  def main(args: Array[String]):Unit = m("1") // error
  |                                       ^
  |                 Type argument Int does not conform to upper bound String
one warning found
one error found
```