### PR TITLE
Fix #3979: Completion for renamed imports

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -146,8 +146,8 @@ class ReplDriver(settings: Array[String],
 
   /** Extract possible completions at the index of `cursor` in `expr` */
   protected[this] final def completions(cursor: Int, expr: String, state0: State): List[Candidate] = {
-    def makeCandidate(completion: Symbol)(implicit ctx: Context) = {
-      val displ = completion.name.toString
+    def makeCandidate(name: Name)(implicit ctx: Context) = {
+      val displ = name.toString
       new Candidate(
         /* value    = */ displ,
         /* displ    = */ displ, // displayed value
@@ -168,7 +168,7 @@ class ReplDriver(settings: Array[String],
         implicit val ctx = state.context.fresh.setCompilationUnit(unit)
         val srcPos = SourcePosition(file, Position(cursor))
         val (_, completions) = Interactive.completions(srcPos)
-        completions.map(makeCandidate)
+        completions.map(c => makeCandidate(c._2))
       }
       .getOrElse(Nil)
   }

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -234,7 +234,7 @@ class DottyLanguageServer extends LanguageServer
     }
 
     JEither.forRight(new CompletionList(
-      /*isIncomplete = */ false, items.map(completionItem).asJava))
+      /*isIncomplete = */ false, items.map(completionItem.tupled).asJava))
   }
 
   /** If cursor is on a reference, show its definition and all overriding definitions in
@@ -441,7 +441,7 @@ object DottyLanguageServer {
     }
 
   /** Create an lsp4j.CompletionItem from a Symbol */
-  def completionItem(sym: Symbol)(implicit ctx: Context): lsp4j.CompletionItem = {
+  def completionItem(sym: Symbol, name: Name)(implicit ctx: Context): lsp4j.CompletionItem = {
     def completionItemKind(sym: Symbol)(implicit ctx: Context): lsp4j.CompletionItemKind = {
       import lsp4j.{CompletionItemKind => CIK}
 
@@ -459,7 +459,7 @@ object DottyLanguageServer {
         CIK.Field
     }
 
-    val label = sym.name.show
+    val label = name.show
     val item = new lsp4j.CompletionItem(label)
     item.setDetail(sym.info.widenTermRefExpr.show)
     item.setKind(completionItemKind(sym))

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -11,4 +11,25 @@ class CompletionTest {
     code"class Foo { val xyz: Int = 0; def y: Int = xy$m1 }".withSource
       .completion(m1, Set(("xyz", CompletionItemKind.Field, "Int")))
   }
+
+  @Test def completionOnImport: Unit = {
+    code"""import java.io.FileDescriptor
+           trait Foo { val x: FileDesc$m1 }""".withSource
+      .completion(m1, Set(("FileDescriptor", CompletionItemKind.Class, "Object{...}")))
+  }
+
+  @Test def completionOnRenamedImport: Unit = {
+    code"""import java.io.{FileDescriptor => AwesomeStuff}
+           trait Foo { val x: Awesom$m1 }""".withSource
+      .completion(m1, Set(("AwesomeStuff", CompletionItemKind.Class, "Object{...}")))
+  }
+
+  @Test def completionOnRenamedImport2: Unit = {
+    code"""import java.util.{HashMap => MyImportedSymbol}
+           trait Foo {
+             import java.io.{FileDescriptor => MyImportedSymbol}
+             val x: MyImp$m1
+           }""".withSource
+      .completion(m1, Set(("MyImportedSymbol", CompletionItemKind.Class, "Object{...}")))
+  }
 }


### PR DESCRIPTION
We introduce a new `RenameAwareScope` that tracks the name associated
with a symbol in the scope. Calling `toListWithNames` returns the list
of symbols in this scope along with the name that should be used to
refer to the symbol in this scope.

Fixes #3979