### PR TITLE
Fix #4978: Complete imported symbol in REPL

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -167,7 +167,7 @@ class ReplDriver(settings: Array[String],
         unit.tpdTree = tree
         implicit val ctx = state.context.fresh.setCompilationUnit(unit)
         val srcPos = SourcePosition(file, Position(cursor))
-        val (_, completions) = Interactive.completions(srcPos)
+        val (_, completions) = Interactive.completions(srcPos, state.imports)
         completions.map(makeCandidate)
       }
       .getOrElse(Nil)

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -60,4 +60,14 @@ class TabcompleteTests extends ReplTest {
       val expected = List("comp1", "comp2", "comp3")
       assertEquals(expected, tabComplete("(new Foo).comp").sorted)
     }
+
+  @Test def tabCompleteImport =
+    fromInitialState { implicit state =>
+      val src = "import java.io.FileDescriptor"
+      run(src)
+    }
+    .andThen { implicit state =>
+      val expected = List("FileDescriptor")
+      assertEquals(expected, tabComplete("val foo: FileDesc"))
+    }
 }


### PR DESCRIPTION
The first scenario described in #4978 is fixed by this PR. Fixing the second case (completion of renamed imports) requires #4977.