### PR TITLE
Fix #4951: Increase stack size before bootstrap to reduce tests flakyness

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -718,6 +718,9 @@ object Build {
       TestFrameworks.JUnit,
       "--exclude-categories=dotty.BootstrappedOnlyTests",
     ),
+    // increase stack size for non-bootstrapped compiler, because some code
+    // is only tail-recursive after bootstrap
+    javaOptions in Test += "-Xss2m"
   )
 
   lazy val bootstrapedDottyCompilerSettings = commonDottyCompilerSettings ++ Seq(


### PR DESCRIPTION
To test, use `testCompilation inductive-implicits-bench` before and after,
locally. I get a failure before and a pass after.

We consume more stack before bootstrap because many typer methods are only tail-recursive if `track` or such are inlined (via `@forceInline`), and we don't plan to fix that. Viceversa, if this test stack overflows *after* bootstrap, we probably want to take a look.