### PR TITLE
enclosingInlineds: Clarify invariants

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -574,8 +574,9 @@ object Trees {
 
   /** A tree representing inlined code.
    *
-   *  @param  call      Info about the original call that was inlined
-   *                    Until PostTyper, this is the full call, afterwards only
+   *  @param  call      Tree representing the original call that was inlined.
+   *                    If EmptyTree: this represents an argument actual tree.
+   *                    Otherwise: Until PostTyper, this is the full call, afterwards only
    *                    a reference to the toplevel class from which the call was inlined.
    *  @param  bindings  Bindings for proxies to be used in the inlined code
    *  @param  expansion The inlined tree, minus bindings.
@@ -587,6 +588,8 @@ object Trees {
    *  The reason to keep `bindings` separate is because they are typed in a
    *  different context: `bindings` represent the arguments to the inlined
    *  call, whereas `expansion` represents the body of the inlined function.
+   *  Call argument trees (whether kept in `bindings` or inlined in the body)
+   *  are typed in the caller's context.
    */
   case class Inlined[-T >: Untyped] private[ast] (call: tpd.Tree, bindings: List[MemberDef[T]], expansion: Tree[T])
     extends Tree[T] {

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -385,8 +385,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case SeqLiteral(elems, elemtpt) =>
         "[" ~ toTextGlobal(elems, ",") ~ " : " ~ toText(elemtpt) ~ "]"
       case tree @ Inlined(call, bindings, body) =>
-        (("/* inlined from " ~ toText(call) ~ " */ ") `provided`
-          !call.isEmpty && !homogenizedView && !ctx.settings.YshowNoInline.value) ~
+        ((if (!call.isEmpty) "/* inlined from " ~ toText(call) ~ " */ " else "/* inline arg */ ": Text) `provided`
+          !homogenizedView && !ctx.settings.YshowNoInline.value) ~
         blockText(bindings :+ body)
       case tpt: untpd.DerivedTypeTree =>
         "<derived typetree watching " ~ summarized(toText(tpt.watched)) ~ ">"


### PR DESCRIPTION
WIP, followup to #4990 and #4949.

I also tried ensuring parameters are always nested in calls and boy is that false - we forget using inlineContext often enough, which could be a trap if we use implicit conversion `sourcePos`.