### PR TITLE
Fix #4999: allow pattern matching against by-name arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -116,7 +116,7 @@ object PatternMatcher {
     /** Widen type as far as necessary so that it does not refer to a pattern-
      *  generated variable.
      */
-    private def sanitize(tp: Type): Type = tp.widenExpr match {
+    private def sanitize(tp: Type): Type = tp.widenTermRefExpr match {
       case tp: TermRef if refersToInternal(false, tp) => sanitize(tp.underlying)
       case tp => tp
     }

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -116,7 +116,7 @@ object PatternMatcher {
     /** Widen type as far as necessary so that it does not refer to a pattern-
      *  generated variable.
      */
-    private def sanitize(tp: Type): Type = tp.widenTermRefExpr match {
+    private def sanitize(tp: Type): Type = tp.widenIfUnstable match {
       case tp: TermRef if refersToInternal(false, tp) => sanitize(tp.underlying)
       case tp => tp
     }

--- a/tests/pos/i4999.scala
+++ b/tests/pos/i4999.scala
@@ -1,0 +1,9 @@
+trait Foo
+final class Bar extends Foo
+
+class Test {
+  def test(xs: => Foo) = xs match {
+    case xs: Bar => 1
+    case _       => 2
+  }
+}


### PR DESCRIPTION
In this testcase `tp` is `TermRef(NoPrefix, xs)` so `widenExpr` does nothing, but
`widenTermRefExpr` is appropriate.