### PR TITLE
Remove arbitrary use case of enum from documentation

### DIFF
--- a/docs/docs/reference/enums/enums.md
+++ b/docs/docs/reference/enums/enums.md
@@ -89,35 +89,6 @@ object Planet {
   }
 }
 ```
-### A specific use case of enum
-
-Two enums can be combined into a different type as shown below:
- 
-```scala
-
-trait Animal
-object Animal {
-  def enumValues: Iterable[Animal] = Dog.enumValues ++ Cat.enumValues
-  def enumValueNamed = Dog.enumValueNamed ++ Cat.enumValueNamed
-}
-
-enum Dog extends Animal {
-  case GermanShepherd, Labrador, Boxer
-}
-
-enum Cat extends Animal {
-  case PersianCat, Ragdoll, ScottishFold
-}
-
-object Main {
-  def main(args: Array[String]): Unit = {
-    val values: Iterable[Animal] = Animal.enumValues
-    val boxer_dog: Animal = Animal.enumValueNamed("Boxer")
-    val ragdoll_cat: Animal = Animal.enumValueNamed("Ragdoll")
-  }
-}
-
-```
 
 ### Implementation
 

--- a/tests/run/i4961.scala
+++ b/tests/run/i4961.scala
@@ -1,0 +1,33 @@
+trait Animal
+object Animal {
+  def enumValues: Iterable[Animal] = Dog.enumValues ++ Cat.enumValues
+  def enumValueNamed = Dog.enumValueNamed ++ Cat.enumValueNamed
+}
+
+enum Dog extends Animal {
+  case GermanShepherd, Labrador, Boxer
+}
+
+enum Cat extends Animal {
+  case PersianCat, Ragdoll, ScottishFold
+}
+
+object Test {
+  import Dog._
+  import Cat._
+
+  def main(args: Array[String]): Unit = {
+    val values = List(
+      GermanShepherd,
+      Labrador,
+      Boxer,
+      PersianCat,
+      Ragdoll,
+      ScottishFold
+    )
+
+    assert(Animal.enumValues == values)
+    assert(Animal.enumValueNamed("Boxer") == Boxer)
+    assert(Animal.enumValueNamed("Ragdoll") == Ragdoll)
+  }
+}


### PR DESCRIPTION
I don't think we should start adding arbitrary use cases to the documentation. It makes a good test case though