### PR TITLE
Reenable terminal tests on CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -42,9 +42,9 @@ pipeline:
     commands:
       - cp -R . /tmp/4/ && cd /tmp/4/
       - ./project/scripts/sbt sbt-dotty/scripted
-    when:
-      # sbt scripted tests are slow and only run on nightly or deployment
-      event: [ tag, deployment ]
+    # when:
+    #   # sbt scripted tests are slow and only run on nightly or deployment
+    #   event: [ tag, deployment ]
 
   # DOCUMENTATION:
   documentation:

--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -18,7 +18,6 @@ final class JLineTerminal extends java.io.Closeable {
   // Logger.getLogger("org.jline").setLevel(Level.FINEST)
 
   private val terminal = TerminalBuilder.builder()
-    .dumb(false) // fail early if not able to create a terminal
     .build()
   private val history = new DefaultHistory
 

--- a/sbt-dotty/sbt-test/sbt-dotty/example-project/test
+++ b/sbt-dotty/sbt-test/sbt-dotty/example-project/test
@@ -1,4 +1,4 @@
 > run
 > 'set initialCommands := "1 + 1" '
 # FIXME: does not work on the CI
-#> console
+> console

--- a/sbt-dotty/sbt-test/sbt-dotty/example-project/test
+++ b/sbt-dotty/sbt-test/sbt-dotty/example-project/test
@@ -1,4 +1,3 @@
 > run
 > 'set initialCommands := "1 + 1" '
-# FIXME: does not work on the CI
 > console


### PR DESCRIPTION
The issue is discussed at https://github.com/lampepfl/dotty/pull/4952#discussion_r212562619:
`console` tries to open a terminal, on CI we can only open dumb ones, but we configured JLine to fail then. If we don't, the tests pass.

Since opening dumb terminals is necessary in real usecases where the terminal emulator is limited, this might be good to go; otherwise we can only enable dumb terminals in CI.

/cc @SzymonPajzert: is this fix sufficient for your testing goals? We aren't doing that much testing yet...