### PR TITLE
Fail jhm on error and fix benchmarks

### DIFF
--- a/bench/src/main/scala/Benchmarks.scala
+++ b/bench/src/main/scala/Benchmarks.scala
@@ -53,13 +53,20 @@ object Bench {
   def removeCompileOptions: Unit = new File(COMPILE_OPTS_FILE).delete()
 
   def storeCompileOptions(args: Array[String]): Unit = {
-    val libs = System.getProperty("BENCH_CLASS_PATH")
+    val standard_libs = System.getProperty("BENCH_CLASS_PATH")
+    val compiler_libs = System.getProperty("BENCH_COMPILER_CLASS_PATH")
+
+    val libs = if (args.contains("-with-compiler")) compiler_libs else standard_libs
+    var argsNorm = args.filter(_ != "-with-compiler")
+
+    var cpIndex = argsNorm.indexOf("-classpath")
+    if (cpIndex == -1) cpIndex = argsNorm.indexOf("-cp")
+    if (cpIndex != -1) argsNorm(cpIndex + 1) = argsNorm(cpIndex + 1) + ":" + libs
+    else argsNorm = argsNorm :+ "-classpath" :+ libs
 
     val file = new File(COMPILE_OPTS_FILE)
     val bw = new BufferedWriter(new FileWriter(file))
-    bw.write(args.mkString("", "\n", "\n"))
-    bw.write("-classpath\n")
-    bw.write(libs)
+    bw.write(argsNorm.mkString("", "\n", "\n"))
     bw.close()
   }
 

--- a/bench/src/main/scala/Benchmarks.scala
+++ b/bench/src/main/scala/Benchmarks.scala
@@ -34,11 +34,9 @@ object Bench {
     }
     storeCompileOptions(args2)
 
-    val libs = System.getProperty("BENCH_CLASS_PATH")
-
     val opts = new OptionsBuilder()
                .shouldFailOnError(true)
-               .jvmArgsPrepend(s"-classpath $libs", "-Xms2G", "-Xmx2G")
+               .jvmArgs("-Xms2G", "-Xmx2G")
                .mode(Mode.AverageTime)
                .timeUnit(TimeUnit.MILLISECONDS)
                .warmupIterations(warmup)
@@ -55,9 +53,13 @@ object Bench {
   def removeCompileOptions: Unit = new File(COMPILE_OPTS_FILE).delete()
 
   def storeCompileOptions(args: Array[String]): Unit = {
+    val libs = System.getProperty("BENCH_CLASS_PATH")
+
     val file = new File(COMPILE_OPTS_FILE)
     val bw = new BufferedWriter(new FileWriter(file))
-    bw.write(args.mkString("\n"))
+    bw.write(args.mkString("", "\n", "\n"))
+    bw.write("-classpath\n")
+    bw.write(libs)
     bw.close()
   }
 

--- a/bench/src/main/scala/Benchmarks.scala
+++ b/bench/src/main/scala/Benchmarks.scala
@@ -37,6 +37,7 @@ object Bench {
     val libs = System.getProperty("BENCH_CLASS_PATH")
 
     val opts = new OptionsBuilder()
+               .shouldFailOnError(true)
                .jvmArgsPrepend(s"-classpath $libs", "-Xms2G", "-Xmx2G")
                .mode(Mode.AverageTime)
                .timeUnit(TimeUnit.MILLISECONDS)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -302,7 +302,8 @@ object Build {
   lazy val commonBenchmarkSettings = Seq(
     outputStrategy := Some(StdoutOutput),
     mainClass in (Jmh, run) := Some("dotty.tools.benchmarks.Bench"), // custom main for jmh:run
-    javaOptions += "-DBENCH_CLASS_PATH=" + Attributed.data((fullClasspath in Compile).value).mkString("", ":", "")
+    javaOptions += "-DBENCH_COMPILER_CLASS_PATH=" + Attributed.data((fullClasspath in (`dotty-bootstrapped`, Compile)).value).mkString("", ":", ""),
+    javaOptions += "-DBENCH_CLASS_PATH=" + Attributed.data((fullClasspath in (`dotty-library-bootstrapped`, Compile)).value).mkString("", ":", "")
   )
 
   // sbt >= 0.13.12 will automatically rewrite transitive dependencies on

--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -12,6 +12,7 @@ EXPECTED_OUTPUT="hello world"
 # check that benchmarks can run
 "$SBT" "dotty-bench/jmh:run 1 1 tests/pos/alias.scala"
 "$SBT" "dotty-bench-bootstrapped/jmh:run 1 1 tests/pos/alias.scala"
+"$SBT" "dotty-bench-bootstrapped/jmh:run 1 1 -with-compiler compiler/src/dotty/tools/dotc/core/Types.scala"
 
 OUT=$(mktemp -d)
 OUT1=$(mktemp -d)


### PR DESCRIPTION
#3138 breaks the benchmarks, but it's not catched by the CI due to a missing setting for JMH.

This PR shows the problem and proposes a fix (in the 2nd commit).