### PR TITLE
Introduce CaseClassCannotExtendsEnum message to replace error string from Checking

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -131,7 +131,8 @@ public enum ErrorMessageID {
     MatchCaseOnlyNullWarningID,
     ImportRenamedTwiceID,
     TypeTestAlwaysSucceedsID,
-    TermMemberNeedsNeedsResultTypeForImplicitSearchID
+    TermMemberNeedsNeedsResultTypeForImplicitSearchID,
+    CaseClassCannotExtendEnumID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2120,4 +2120,10 @@ object messages {
            |To avoid this error, give `$cycleSym` an explicit type.
            |""".stripMargin
   }
+
+  case class CaseClassCannotExtendEnum(cls: Symbol)(implicit ctx: Context) extends Message(CaseClassCannotExtendEnumID) {
+    override def kind: String = "Syntax"
+    override def msg: String = hl"""normal case $cls in ${cls.owner} cannot extend an enum"""
+    override def explanation: String = ""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -853,7 +853,7 @@ trait Checking {
       cls.owner.isTerm &&
       (cls.owner.flagsUNSAFE.is(Case) || cls.owner.name == nme.DOLLAR_NEW)
     if (!cdef.mods.isEnumCase && !isEnumAnonCls)
-      ctx.error(em"normal case $cls in ${cls.owner} cannot extend an enum", cdef.pos)
+      ctx.error(CaseClassCannotExtendEnum(cls), cdef.pos)
   }
 
   /** Check that all references coming from enum cases in an enum companion object

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -30,7 +30,9 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         implicit val ctx: Context = ictx
         assertMessageCount(1, messages)
         val errorMsg = messages.head
-        assertEquals("normal case class Bar in package <empty> cannot extend an enum", errorMsg.msg)
+        val CaseClassCannotExtendEnum(cls) :: Nil = messages
+        assertEquals("Bar", cls.name.show)
+        assertEquals("<empty>", cls.owner.name.show)
       }
 
   @Test def typeMismatch =


### PR DESCRIPTION
I have attempted to create an error message for case class extending enums. 

Also in Checking.scala I could see approx 18 error messages as strings. So are these good to be picked up and massaged similar to `CaseClassCannotExtendEnum` in this PR ? 