### PR TITLE
Make benchmarks depend only on library classpath

### DIFF
--- a/bench/src/main/scala/Benchmarks.scala
+++ b/bench/src/main/scala/Benchmarks.scala
@@ -34,11 +34,9 @@ object Bench {
     }
     storeCompileOptions(args2)
 
-    val libs = System.getProperty("BENCH_CLASS_PATH")
-
     val opts = new OptionsBuilder()
                .shouldFailOnError(true)
-               .jvmArgsPrepend(s"-classpath $libs", "-Xms2G", "-Xmx2G")
+               .jvmArgs("-Xms2G", "-Xmx2G")
                .mode(Mode.AverageTime)
                .timeUnit(TimeUnit.MILLISECONDS)
                .warmupIterations(warmup)
@@ -55,9 +53,13 @@ object Bench {
   def removeCompileOptions: Unit = new File(COMPILE_OPTS_FILE).delete()
 
   def storeCompileOptions(args: Array[String]): Unit = {
+    val libs = System.getProperty("BENCH_CLASS_PATH")
+
     val file = new File(COMPILE_OPTS_FILE)
     val bw = new BufferedWriter(new FileWriter(file))
-    bw.write(args.mkString("\n"))
+    bw.write(args.mkString("", "\n", "\n"))
+    bw.write("-classpath\n")
+    bw.write(libs)
     bw.close()
   }
 

--- a/bench/src/main/scala/Benchmarks.scala
+++ b/bench/src/main/scala/Benchmarks.scala
@@ -37,6 +37,7 @@ object Bench {
     val libs = System.getProperty("BENCH_CLASS_PATH")
 
     val opts = new OptionsBuilder()
+               .shouldFailOnError(true)
                .jvmArgsPrepend(s"-classpath $libs", "-Xms2G", "-Xmx2G")
                .mode(Mode.AverageTime)
                .timeUnit(TimeUnit.MILLISECONDS)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -302,7 +302,7 @@ object Build {
   lazy val commonBenchmarkSettings = Seq(
     outputStrategy := Some(StdoutOutput),
     mainClass in (Jmh, run) := Some("dotty.tools.benchmarks.Bench"), // custom main for jmh:run
-    javaOptions += "-DBENCH_CLASS_PATH=" + Attributed.data((fullClasspath in (`dotty-library`, Compile)).value).mkString("", ":", "")
+    javaOptions += "-DBENCH_CLASS_PATH=" + Attributed.data((fullClasspath in (`dotty-library-bootstrapped`, Compile)).value).mkString("", ":", "")
   )
 
   // sbt >= 0.13.12 will automatically rewrite transitive dependencies on

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -302,7 +302,7 @@ object Build {
   lazy val commonBenchmarkSettings = Seq(
     outputStrategy := Some(StdoutOutput),
     mainClass in (Jmh, run) := Some("dotty.tools.benchmarks.Bench"), // custom main for jmh:run
-    javaOptions += "-DBENCH_CLASS_PATH=" + Attributed.data((fullClasspath in Compile).value).mkString("", ":", "")
+    javaOptions += "-DBENCH_CLASS_PATH=" + Attributed.data((fullClasspath in (`dotty-library`, Compile)).value).mkString("", ":", "")
   )
 
   // sbt >= 0.13.12 will automatically rewrite transitive dependencies on


### PR DESCRIPTION
Followup to #5020.

Testing that our benchmark program don't need to link against the compiler.
Warning: This might make performance incomparable with earlier (similarly to
other current changes.