### PR TITLE
Fix #5010: check type parents have type arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1593,6 +1593,7 @@ class Typer extends Namer
       }
       else seenParents += psym
       if (tree.isType) {
+        checkSimpleKinded(result) // Not needed for constructor calls, as type arguments will be inferred.
         if (psym.is(Trait) && !cls.is(Trait) && !cls.superClass.isSubClass(psym))
           result = maybeCall(result, psym, psym.primaryConstructor.info)
       }

--- a/tests/neg/i1643.scala
+++ b/tests/neg/i1643.scala
@@ -1,4 +1,4 @@
-trait T extends Array { // error
+trait T extends Array { // error // error
   def t1(as: String*): Array[String] = { varargs1(as: _*) } // error
   def t2(as: String*): Array[String] = { super.varargs1(as: _*) } // error
 }

--- a/tests/neg/i5010.scala
+++ b/tests/neg/i5010.scala
@@ -1,0 +1,1 @@
+class i0 extends Function0 // error

--- a/tests/neg/parser-stability-16.scala
+++ b/tests/neg/parser-stability-16.scala
@@ -1,6 +1,6 @@
 class x0[x0] {
   val x1 : x0
 }
-trait x3 extends x0 {
+trait x3 extends x0 { // error
 x1 = 0 object  // error
 // error

--- a/tests/neg/parser-stability-7.scala
+++ b/tests/neg/parser-stability-7.scala
@@ -1,7 +1,7 @@
 class x0[x1] {
 def x2: x1
 }
-trait x3 extends x0 {
+trait x3 extends x0 { // error
 class x2
 var x2 = 0     // error
 var x4 = x5 x2 // error

--- a/tests/run/t3613.scala
+++ b/tests/run/t3613.scala
@@ -2,7 +2,7 @@ class Boopy {
     private val s = new Schnuck
     def observer : PartialFunction[ Any, Unit ] = s.observer
 
-    private class Schnuck extends javax.swing.AbstractListModel {
+    private class Schnuck extends javax.swing.AbstractListModel[Nothing] {
         model =>
         val observer : PartialFunction[ Any, Unit ] = {
             case "Boopy" => fireIntervalAdded( model, 0, 1 )


### PR DESCRIPTION
We modify t3613 as it was written when AbstractListModel had no type parameter.

We could alternatively infer type arguments (see scala/bug#11111), as scalac
does, but that seems typically unhelpful. Instead, we only infer them for
constructor applications.