### PR TITLE
Fix #5008: forbid enums extending enums

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1575,6 +1575,15 @@ class Typer extends Namer
       if (!cls.is(AbstractOrTrait) && !ctx.isAfterTyper)
         checkRealizableBounds(cls, cdef.namePos)
       if (cls.is(Case) && cls.derivesFrom(defn.EnumClass)) checkEnum(cdef, cls)
+      if (seenParents.contains(defn.EnumClass)) {
+        // Since enums are classes and Namer checks that classes don't extend multiple classes, we only check the class
+        // parent.
+        val firstParent = parents1.head.tpe.dealias.typeSymbol
+        if (firstParent.derivesFrom(defn.EnumClass))
+          //Tricky to phrase; language taken from "case-to-case inheritance is prohibited".
+          ctx.error(s"Enum ${cls.name} has enum ancestor ${firstParent.name}, but enum-to-enum inheritance is prohibited", cdef.pos)
+      }
+
       val cdef1 = assignType(cpy.TypeDef(cdef)(name, impl1), cls)
       checkVariance(cdef1)
       if (ctx.phase.isTyper && cdef1.tpe.derivesFrom(defn.DynamicClass) && !ctx.dynamicsEnabled) {

--- a/tests/neg/i5008.scala
+++ b/tests/neg/i5008.scala
@@ -1,0 +1,5 @@
+enum Foo { case A }
+enum Bar { case A }
+enum Baz extends Foo { case Z } // error
+
+enum Quux extends Foo with Bar { case Z } // error

--- a/tests/pending/neg/i5008
+++ b/tests/pending/neg/i5008
@@ -1,2 +1,0 @@
-enum Foo {}
-enum Bar extends Foo {} // error


### PR DESCRIPTION
Check if we inherit from scala.Enum both directly (as a result of the
desugaring) and indirectly.