### PR TITLE
Fix #5008: forbid any class extending enums

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -132,7 +132,7 @@ public enum ErrorMessageID {
     ImportRenamedTwiceID,
     TypeTestAlwaysSucceedsID,
     TermMemberNeedsNeedsResultTypeForImplicitSearchID,
-    CaseClassCannotExtendEnumID,
+    ClassCannotExtendEnumID,
     ValueClassParameterMayNotBeCallByNameID,
     NotAnExtractorID,
     MemberWithSameNameAsStaticID,

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2128,7 +2128,7 @@ object messages {
 
   case class ClassCannotExtendEnum(cls: Symbol, parent: Symbol)(implicit ctx: Context) extends Message(ClassCannotExtendEnumID) {
     override def kind: String = "Syntax"
-    override def msg: String = hl"""Normal case class cannot extend an enum. case $cls in ${cls.owner} is extending enum ${parent.name}."""
+    override def msg: String = hl"""$cls in ${cls.owner} extends enum ${parent.name}, but extending enums is prohibited."""
     override def explanation: String = ""
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2126,7 +2126,7 @@ object messages {
            |""".stripMargin
   }
 
-  case class CaseClassCannotExtendEnum(cls: Symbol, parent: Symbol)(implicit ctx: Context) extends Message(CaseClassCannotExtendEnumID) {
+  case class ClassCannotExtendEnum(cls: Symbol, parent: Symbol)(implicit ctx: Context) extends Message(ClassCannotExtendEnumID) {
     override def kind: String = "Syntax"
     override def msg: String = hl"""Normal case class cannot extend an enum. case $cls in ${cls.owner} is extending enum ${parent.name}."""
     override def explanation: String = ""

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -908,7 +908,12 @@ trait Checking {
       cls.owner.isTerm &&
       (cls.owner.flagsUNSAFE.is(Case) || cls.owner.name == nme.DOLLAR_NEW)
     if (!cdef.mods.isEnumCase && !isEnumAnonCls) {
-      if (cls.is(Case))
+      // Since enums are classes and Namer checks that classes don't extend multiple classes, we only check the class
+      // parent.
+      //
+      // Unlike firstParent.derivesFrom(defn.EnumClass), this test allows inheriting from `Enum` by hand;
+      // see enum-List-control.scala.
+      if (cls.is(Case) || firstParent.is(Enum))
         ctx.error(ClassCannotExtendEnum(cls, firstParent), cdef.sourcePos)
     }
   }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -901,14 +901,16 @@ trait Checking {
     }
 
   /** Check that all case classes that extend `scala.Enum` are `enum` cases */
-  def checkEnum(cdef: untpd.TypeDef, cls: Symbol, parent: Symbol)(implicit ctx: Context): Unit = {
+  def checkEnum(cdef: untpd.TypeDef, cls: Symbol, firstParent: Symbol)(implicit ctx: Context): Unit = {
     import untpd.modsDeco
     def isEnumAnonCls =
       cls.isAnonymousClass &&
       cls.owner.isTerm &&
       (cls.owner.flagsUNSAFE.is(Case) || cls.owner.name == nme.DOLLAR_NEW)
-    if (!cdef.mods.isEnumCase && !isEnumAnonCls)
-      ctx.error(CaseClassCannotExtendEnum(cls, parent), cdef.sourcePos)
+    if (!cdef.mods.isEnumCase && !isEnumAnonCls) {
+      if (cls.is(Case))
+        ctx.error(ClassCannotExtendEnum(cls, firstParent), cdef.sourcePos)
+    }
   }
 
   /** Check that all references coming from enum cases in an enum companion object
@@ -975,7 +977,7 @@ trait Checking {
 
 trait ReChecking extends Checking {
   import tpd._
-  override def checkEnum(cdef: untpd.TypeDef, cls: Symbol, parent: Symbol)(implicit ctx: Context): Unit = ()
+  override def checkEnum(cdef: untpd.TypeDef, cls: Symbol, firstParent: Symbol)(implicit ctx: Context): Unit = ()
   override def checkRefsLegal(tree: tpd.Tree, badOwner: Symbol, allowed: (Name, Symbol) => Boolean, where: String)(implicit ctx: Context): Unit = ()
   override def checkEnumCaseRefsLegal(cdef: TypeDef, enumCtx: Context)(implicit ctx: Context): Unit = ()
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1651,7 +1651,7 @@ class Typer extends Namer
         .withType(dummy.termRef)
       if (!cls.is(AbstractOrTrait) && !ctx.isAfterTyper)
         checkRealizableBounds(cls, cdef.sourcePos.withSpan(cdef.nameSpan))
-      if (cls.is(Case) && cls.derivesFrom(defn.EnumClass)) {
+      if (cls.derivesFrom(defn.EnumClass)) {
         val firstParent = parents1.head.tpe.dealias.typeSymbol
         checkEnum(cdef, cls, firstParent)
       }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -30,7 +30,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         implicit val ctx: Context = ictx
         assertMessageCount(1, messages)
         val errorMsg = messages.head
-        val CaseClassCannotExtendEnum(cls, parent) :: Nil = messages
+        val ClassCannotExtendEnum(cls, parent) :: Nil = messages
         assertEquals("Bar", cls.name.show)
         assertEquals("Foo", parent.name.show)
         assertEquals("<empty>", cls.owner.name.show)

--- a/tests/neg/i5008.scala
+++ b/tests/neg/i5008.scala
@@ -1,0 +1,8 @@
+enum Foo { case A }
+enum Bar { case A }
+enum Baz extends Foo { case Z } // error
+
+enum Quux extends Foo with Bar { case Z } // error
+
+class Quuw extends Foo // error
+class Quuz extends Foo { val enumTag = 1 } // error

--- a/tests/pending/neg/i5008
+++ b/tests/pending/neg/i5008
@@ -1,2 +1,0 @@
-enum Foo {}
-enum Bar extends Foo {} // error


### PR DESCRIPTION
Forbid any class from extending enums. However, keep allowing to extend `Enum` by hand (per current testcase). Thanks to @allanrenucci for the suggesting how.

~Building on top of #5028, and alternative to it.~

~I'm not sure that's a good idea — there's a testcase from 2017 about this (from d3b2c37b9fb4211ade0660c3985f9f14a0ffa505, 0ee328187310b55ec088f21da66a163b005cc4b7), but it doesn't seem in the spirit of the current restricted enums.~

/cc @hrhino.