### PR TITLE
Avoid fishy reference equality on strings

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -157,7 +157,7 @@ object Decorators {
         names exists { name =>
           name == "all" || {
             val strippedName = name.stripSuffix("+")
-            val logNextPhase = name ne strippedName
+            val logNextPhase = name != strippedName
             phase.phaseName.startsWith(strippedName) ||
               (logNextPhase && phase.prev.phaseName.startsWith(strippedName))
           }


### PR DESCRIPTION
While the code looks correct (because strippedName comes from stripSuffix and because of stripSuffix's contract and implementation), this is subtle enough that we should either add a test or use !=.

Since `String.equals` happens to be O(1) in this case, changing the code looks simpler. `String.equals` is O(1) here because it will either succeed by testing pointer equality or fail by noticing a length mismatch, so it will never look at the actual contents!