### PR TITLE
Fix #5021: Remove duplicate test

### DIFF
--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -43,8 +43,7 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
     compileDir("compiler/src/dotty/tools/dotc/reporting", withCompilerOptions) +
     compileDir("compiler/src/dotty/tools/dotc/typer", withCompilerOptions) +
     compileDir("compiler/src/dotty/tools/dotc/util", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/io", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/core", withCompilerOptions)
+    compileDir("compiler/src/dotty/tools/io", withCompilerOptions)
   }.checkCompile()
 
   @Test def posTwiceWithCompiler: Unit = {


### PR DESCRIPTION
These tests may be run in parallel in the same group, and compile the
same files at the same time which caused non deterministic issues.