### PR TITLE
Support multi-project setups in the IDE tests

### DIFF
--- a/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
@@ -37,6 +37,20 @@ class DefinitionTest {
       .definition(m13 to m14, List(m3 to m4))
   }
 
+  @Test def classDefinitionDifferentWorkspace: Unit = {
+    val w0 = Workspace.withSources(
+      code"""class ${m1}Foo${m2}"""
+    )
+
+    val w1 = Workspace.dependingOn(w0).withSources(
+      code"""class Bar { new ${m3}Foo${m4} }"""
+    )
+
+    withWorkspaces(w0, w1)
+      .definition(m1 to m2, List(m1 to m2))
+      .definition(m3 to m4, List(m1 to m2))
+  }
+
   @Test def valDefinition0: Unit = {
     withSources(
       code"class Foo { val ${m1}x$m2 = 0; ${m3}x$m4 }",

--- a/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
@@ -46,9 +46,14 @@ class DefinitionTest {
       code"""class Bar { new ${m3}Foo${m4} }"""
     )
 
-    withWorkspaces(w0, w1)
+    val w2 = Workspace.dependingOn(w1).withSources(
+      code"""class Baz extends ${m5}Foo${m6}"""
+    )
+
+    withWorkspaces(w0, w1, w2)
       .definition(m1 to m2, List(m1 to m2))
       .definition(m3 to m4, List(m1 to m2))
+      .definition(m5 to m6, List(m1 to m2))
   }
 
   @Test def valDefinition0: Unit = {

--- a/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
@@ -37,20 +37,20 @@ class DefinitionTest {
       .definition(m13 to m14, List(m3 to m4))
   }
 
-  @Test def classDefinitionDifferentWorkspace: Unit = {
-    val w0 = Workspace.withSources(
+  @Test def classDefinitionDifferentProject: Unit = {
+    val p0 = Project.withSources(
       code"""class ${m1}Foo${m2}"""
     )
 
-    val w1 = Workspace.dependingOn(w0).withSources(
+    val p1 = Project.dependingOn(p0).withSources(
       code"""class Bar { new ${m3}Foo${m4} }"""
     )
 
-    val w2 = Workspace.dependingOn(w1).withSources(
+    val p2 = Project.dependingOn(p1).withSources(
       code"""class Baz extends ${m5}Foo${m6}"""
     )
 
-    withWorkspaces(w0, w1, w2)
+    withProjects(p0, p1, p2)
       .definition(m1 to m2, List(m1 to m2))
       .definition(m3 to m4, List(m1 to m2))
       .definition(m5 to m6, List(m1 to m2))

--- a/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
@@ -208,4 +208,15 @@ class DefinitionTest {
       .definition(m9 to m10, List(m3 to m4))
   }
 
+  @Test def definitionFromTasty: Unit = {
+    withSources(
+      tasty"""package mypackage
+              class ${m1}A${m2}""",
+      code"""package mypackage
+             object O {
+               new ${m3}A${m4}
+             }"""
+    ).definition(m3 to m4, List(m1 to m2))
+  }
+
 }

--- a/language-server/test/dotty/tools/languageserver/util/Code.scala
+++ b/language-server/test/dotty/tools/languageserver/util/Code.scala
@@ -60,6 +60,17 @@ object Code {
       WorksheetWithPositions(text, positions)
     }
 
+    /**
+     * An interpolator similar to `code`, but used for defining a source that will
+     * be unpickled from TASTY.
+     *
+     * @see code
+     */
+    def tasty(args: Embedded*): TastyWithPositions = {
+      val (text, positions) = textAndPositions(args: _*)
+      TastyWithPositions(text, positions)
+    }
+
     private def textAndPositions(args: Embedded*): (String, List[(CodeMarker, Int, Int)]) = {
       val pi = sc.parts.iterator
       val ai = args.iterator
@@ -107,7 +118,10 @@ object Code {
 
   sealed trait SourceWithPositions {
 
-     /** The code contained within the virtual source file. */
+    /** A name for this source given its index. */
+    def sourceName(index: Int): String
+
+    /** The code contained within the virtual source file. */
     def text: String
 
     /** The positions of the markers that have been set. */
@@ -124,7 +138,9 @@ object Code {
    * @param text      The code contained within the virtual source file.
    * @param positions The positions of the markers that have been set.
    */
-  case class ScalaSourceWithPositions(text: String, positions: List[(CodeMarker, Int, Int)]) extends SourceWithPositions
+  case class ScalaSourceWithPositions(text: String, positions: List[(CodeMarker, Int, Int)]) extends SourceWithPositions {
+    def sourceName(index: Int): String = s"Source$index.scala"
+  }
 
   /**
    * A virtual worksheet where several markers have been set.
@@ -132,7 +148,19 @@ object Code {
    * @param text      The code contained within the virtual source file.
    * @param positions The positions of the markers that have been set.
    */
-  case class WorksheetWithPositions(text: String, positions: List[(CodeMarker, Int, Int)]) extends SourceWithPositions
+  case class WorksheetWithPositions(text: String, positions: List[(CodeMarker, Int, Int)]) extends SourceWithPositions {
+    def sourceName(index: Int): String = s"Worksheet$index.sc"
+  }
+
+  /**
+   * A virtual source file that will not be opened in the IDE, but instead unpickled from TASTY.
+   *
+   * @param text      The code contained within the virtual source file.
+   * @param positions The positions of the markers that have been set.
+   */
+  case class TastyWithPositions(text: String, positions: List[(CodeMarker, Int, Int)]) extends SourceWithPositions {
+    def sourceName(index: Int): String = s"Source-from-tasty-$index.scala"
+  }
 
   /**
    * A group of sources belonging to the same project.

--- a/language-server/test/dotty/tools/languageserver/util/Code.scala
+++ b/language-server/test/dotty/tools/languageserver/util/Code.scala
@@ -110,11 +110,11 @@ object Code {
     }
   }
 
-  /** A new `CodeTester` working with a single workspace containing `sources`. */
-  def withSources(sources: SourceWithPositions*): CodeTester = withWorkspaces(Workspace(sources.toList))
+  /** A new `CodeTester` working with a single project containing `sources`. */
+  def withSources(sources: SourceWithPositions*): CodeTester = withProjects(Project(sources.toList))
 
-  /** A new `CodeTester` working with `workspaces`. */
-  def withWorkspaces(workspaces: Workspace*): CodeTester = new CodeTester(workspaces.toList)
+  /** A new `CodeTester` working with `projects`. */
+  def withProjects(projects: Project*): CodeTester = new CodeTester(projects.toList)
 
   sealed trait SourceWithPositions {
 
@@ -127,7 +127,7 @@ object Code {
     /** The positions of the markers that have been set. */
     def positions: List[(CodeMarker, Int, Int)]
 
-    /** A new `CodeTester` with only this source in the workspace. */
+    /** A new `CodeTester` with only this source in the project. */
     def withSource: CodeTester = withSources(this)
 
   }
@@ -165,40 +165,40 @@ object Code {
   /**
    * A group of sources belonging to the same project.
    *
-   * @param sources   The sources that this workspace holds.
-   * @param name      The name of this workspace
-   * @param dependsOn The other workspaces on which this workspace depend.
+   * @param sources   The sources that this project holds.
+   * @param name      The name of this project
+   * @param dependsOn The other projects on which this project depend.
    */
-  case class Workspace(sources: List[SourceWithPositions],
-                       name: String = Workspace.freshName,
-                       dependsOn: List[Workspace] = Nil) {
+  case class Project(sources: List[SourceWithPositions],
+                     name: String = Project.freshName,
+                     dependsOn: List[Project] = Nil) {
 
     /**
-     * Add `sources` to the sources of this workspace.
+     * Add `sources` to the sources of this project.
      */
-    def withSources(sources: SourceWithPositions*): Workspace = copy(sources = this.sources ::: sources.toList)
+    def withSources(sources: SourceWithPositions*): Project = copy(sources = this.sources ::: sources.toList)
 
   }
 
-  object Workspace {
+  object Project {
     private[this] val count = new java.util.concurrent.atomic.AtomicInteger()
-    private def freshName: String = s"workspace${count.incrementAndGet()}"
+    private def freshName: String = s"project${count.incrementAndGet()}"
 
     /**
-     * Creates a new workspace that depends on `workspaces`.
+     * Creates a new project that depends on `projects`.
      *
-     * @param workspaces The dependencies of the new workspace.
-     * @return An empty workspace with a dependency on the specified workspaces.
+     * @param projects The dependencies of the new project.
+     * @return An empty project with a dependency on the specified projects.
      */
-    def dependingOn(workspaces: Workspace*) = new Workspace(Nil, dependsOn = workspaces.toList)
+    def dependingOn(projects: Project*) = new Project(Nil, dependsOn = projects.toList)
 
     /**
-     * Create a new workspace with the given sources.
+     * Create a new project with the given sources.
      *
-     * @param sources The sources to add to this workspace.
-     * @return a new workspace containing the specified sources.
+     * @param sources The sources to add to this project.
+     * @return a new project containing the specified sources.
      */
-    def withSources(sources: SourceWithPositions*): Workspace = new Workspace(sources.toList)
+    def withSources(sources: SourceWithPositions*): Project = new Project(sources.toList)
   }
 
 }

--- a/language-server/test/dotty/tools/languageserver/util/CodeTester.scala
+++ b/language-server/test/dotty/tools/languageserver/util/CodeTester.scala
@@ -17,10 +17,13 @@ class CodeTester(workspaces: List[Workspace]) {
 
   private val sources = for { workspace <- workspaces
                               source <- workspace.sources } yield (workspace, source)
-  private val files = sources.zipWithIndex.map {
-    case ((workspace, ScalaSourceWithPositions(text, _)), i) => testServer.openCode(text, workspace, s"Source$i.scala")
-    case ((workspace, WorksheetWithPositions(text, _)), i) => testServer.openCode(text, workspace, s"Worksheet$i.sc")
-  }
+
+  private val files =
+    for { workspace <- workspaces
+          (source, id) <- workspace.sources.zipWithIndex } yield source match {
+      case ScalaSourceWithPositions(text, _) => testServer.openCode(text, workspace, s"Source$id.scala")
+      case WorksheetWithPositions(text, _) => testServer.openCode(text, workspace, s"Worksheet$id.sc")
+    }
 
   private val positions: PositionContext = getPositions(files)
 

--- a/language-server/test/dotty/tools/languageserver/util/CodeTester.scala
+++ b/language-server/test/dotty/tools/languageserver/util/CodeTester.scala
@@ -21,8 +21,8 @@ class CodeTester(workspaces: List[Workspace]) {
   private val files =
     for { workspace <- workspaces
           (source, id) <- workspace.sources.zipWithIndex } yield source match {
-      case ScalaSourceWithPositions(text, _) => testServer.openCode(text, workspace, s"Source$id.scala")
-      case WorksheetWithPositions(text, _) => testServer.openCode(text, workspace, s"Worksheet$id.sc")
+      case src @ TastyWithPositions(text, _) => testServer.openCode(text, workspace, src.sourceName(id), openInIDE = false)
+      case other => testServer.openCode(other.text, workspace, other.sourceName(id), openInIDE = true)
     }
 
   private val positions: PositionContext = getPositions(files)

--- a/language-server/test/dotty/tools/languageserver/util/CodeTester.scala
+++ b/language-server/test/dotty/tools/languageserver/util/CodeTester.scala
@@ -7,22 +7,22 @@ import dotty.tools.languageserver.util.server.{TestFile, TestServer}
 import org.eclipse.lsp4j.{CompletionItemKind, DocumentHighlightKind}
 
 /**
- * Simulates an LSP client for test in a workspace defined by `sources`.
+ * Simulates an LSP client for test in a project defined by `sources`.
  *
- * @param sources The list of sources in the workspace
+ * @param sources The list of sources in the project
  */
-class CodeTester(workspaces: List[Workspace]) {
+class CodeTester(projects: List[Project]) {
 
-  private val testServer = new TestServer(TestFile.testDir, workspaces)
+  private val testServer = new TestServer(TestFile.testDir, projects)
 
-  private val sources = for { workspace <- workspaces
-                              source <- workspace.sources } yield (workspace, source)
+  private val sources = for { project <- projects
+                              source <- project.sources } yield (project, source)
 
   private val files =
-    for { workspace <- workspaces
-          (source, id) <- workspace.sources.zipWithIndex } yield source match {
-      case src @ TastyWithPositions(text, _) => testServer.openCode(text, workspace, src.sourceName(id), openInIDE = false)
-      case other => testServer.openCode(other.text, workspace, other.sourceName(id), openInIDE = true)
+    for { project <- projects
+          (source, id) <- project.sources.zipWithIndex } yield source match {
+      case src @ TastyWithPositions(text, _) => testServer.openCode(text, project, src.sourceName(id), openInIDE = false)
+      case other => testServer.openCode(other.text, project, other.sourceName(id), openInIDE = true)
     }
 
   private val positions: PositionContext = getPositions(files)
@@ -165,8 +165,8 @@ class CodeTester(workspaces: List[Workspace]) {
       case ex: AssertionError =>
         val sourcesStr =
           sources.zip(files).map {
-            case ((workspace, source), file) =>
-              s"""// ${file.file} in workspace ${workspace.name}
+            case ((project, source), file) =>
+              s"""// ${file.file} in project ${project.name}
                  |${source.text}""".stripMargin
           }.mkString(System.lineSeparator)
 

--- a/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
+++ b/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
@@ -102,9 +102,12 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
     path.toAbsolutePath
   }
 
-  private def dependencyClasspath(workspace: Workspace) =
+  private def dependencyClasspath(workspace: Workspace): Seq[String] = {
     BuildInfo.ideTestsDependencyClasspath.map(_.getAbsolutePath) ++
-      workspace.dependsOn.map(w => classDirectory(w, wipe = false).toString)
+      workspace.dependsOn.flatMap { dep =>
+        classDirectory(dep, wipe = false).toString +: dependencyClasspath(dep)
+      }
+  }.distinct
 
   private def sourceDirectory(workspace: Workspace, wipe: Boolean): Path = {
     val path = TestFile.sourceDir.resolve(workspace.name).toAbsolutePath

--- a/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
+++ b/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
@@ -1,11 +1,14 @@
 package dotty.tools.languageserver.util.server
 
 import java.io.PrintWriter
-import java.io.File.{separator => sep}
+import java.io.File.{pathSeparator, separator}
 import java.net.URI
 import java.nio.file.{Files, Path}
 import java.util
 
+import dotty.tools.dotc.Main
+import dotty.tools.dotc.reporting.{Reporter, ThrowingReporter}
+import dotty.tools.io.Directory
 import dotty.tools.languageserver.DottyLanguageServer
 import dotty.tools.languageserver.util.Code.Workspace
 import org.eclipse.lsp4j.{ DidOpenTextDocumentParams, InitializeParams, InitializeResult, TextDocumentItem}
@@ -18,11 +21,21 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
   init()
 
   private[this] def init(): InitializeResult = {
+    var compiledWorkspaces: Set[Workspace] = Set.empty
+
+    /** Compile the dependencies of the given workspace, and then the workspace. */
+    def compileWorkspaceAndDependencies(workspace: Workspace): Unit =
+      if (!compiledWorkspaces.contains(workspace)) {
+        workspace.dependsOn.foreach(compileWorkspaceAndDependencies)
+        compileWorkspace(workspace)
+        compiledWorkspaces += workspace
+      }
+
     /**
      * Set up given workspace, return JSON config.
      *
-     * This creates the necessary directories to hold the classes and sources. Some values
-     * are passed via sbt-buildinfo, such as the classpath containing the scala and dotty libaries.
+     * If the workspace has dependencies, these dependencies are compiled. The classfiles of the
+     * dependent workspaces are put on the classpath of this workspace.
      *
      * @param workspace The workspace to configure.
      * @return A JSON object representing the configuration for this workspace.
@@ -33,29 +46,16 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
           .map(elem => '"' + elem.toString.replace('\\', '/') + '"')
           .mkString("[ ", ", ", " ]")
 
-      def classDirectory(workspace: Workspace): Path = {
-        val path = testFolder.resolve(workspace.name).resolve("out")
-        Files.createDirectories(path)
-        path.toAbsolutePath
-      }
-
-      val dependencyClasspath =
-        BuildInfo.ideTestsDependencyClasspath.map(_.getAbsolutePath) ++
-          workspace.dependsOn.map(w => classDirectory(w).toString)
-
-      val sourceDirectory: Path = {
-        val path = TestFile.sourceDir.resolve(workspace.name).toAbsolutePath
-        Files.createDirectories(path)
-        path
-      }
+      // Compile all the dependencies of this workspace
+      workspace.dependsOn.foreach(compileWorkspaceAndDependencies)
 
       s"""{
          |  "id" : "${workspace.name}",
          |  "compilerVersion" : "${BuildInfo.ideTestsCompilerVersion}",
          |  "compilerArguments" : ${showSeq(BuildInfo.ideTestsCompilerArguments)},
-         |  "sourceDirectories" : ${showSeq(sourceDirectory :: Nil)},
-         |  "dependencyClasspath" : ${showSeq(dependencyClasspath)},
-         |  "classDirectory" : "${classDirectory(workspace).toString.replace('\\','/')}"
+         |  "sourceDirectories" : ${showSeq(sourceDirectory(workspace, wipe = false) :: Nil)},
+         |  "dependencyClasspath" : ${showSeq(dependencyClasspath(workspace))},
+         |  "classDirectory" : "${classDirectory(workspace, wipe = false).toString.replace('\\','/')}"
          |}
          |""".stripMargin
     }
@@ -83,7 +83,7 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
    *  @return the file opened
    */
   def openCode(code: String, workspace: Workspace, fileName: String): TestFile = {
-    val testFile = new TestFile(workspace.name + sep + fileName)
+    val testFile = new TestFile(workspace.name + separator + fileName)
     val dotdp = new DidOpenTextDocumentParams()
     val tdi = new TextDocumentItem()
     tdi.setUri(testFile.uri)
@@ -91,6 +91,52 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
     dotdp.setTextDocument(tdi)
     server.didOpen(dotdp)
     testFile
+  }
+
+  private def classDirectory(workspace: Workspace, wipe: Boolean): Path = {
+    val path = testFolder.resolve(workspace.name).resolve("out")
+    if (wipe) {
+      Directory(path).deleteRecursively()
+      Files.createDirectories(path)
+    }
+    path.toAbsolutePath
+  }
+
+  private def dependencyClasspath(workspace: Workspace) =
+    BuildInfo.ideTestsDependencyClasspath.map(_.getAbsolutePath) ++
+      workspace.dependsOn.map(w => classDirectory(w, wipe = false).toString)
+
+  private def sourceDirectory(workspace: Workspace, wipe: Boolean): Path = {
+    val path = TestFile.sourceDir.resolve(workspace.name).toAbsolutePath
+    if (wipe) {
+      Directory(path).deleteRecursively()
+      Files.createDirectories(path)
+    }
+    path
+  }
+
+  /**
+   * Sets up the sources of the given workspace, creates the necessary directories
+   * and compile the sources.
+   *
+   * @param workspace The workspace to set up.
+   */
+  private def compileWorkspace(workspace: Workspace): Unit = {
+    val sourcesDir = sourceDirectory(workspace, wipe = true)
+    val sources = workspace.sources.zipWithIndex.map { case (src, id) =>
+      val path = sourcesDir.resolve(s"Source${id}.scala").toAbsolutePath
+      Files.write(path, src.text.getBytes("UTF-8"))
+      path.toString
+    }
+
+    val compileOptions =
+      sources.toArray ++
+        Array(
+          "-classpath", dependencyClasspath(workspace).mkString(pathSeparator),
+          "-d", classDirectory(workspace, wipe = true).toString
+        )
+    val reporter = new ThrowingReporter(Reporter.NoReporter)
+    Main.process(compileOptions, reporter)
   }
 
 }

--- a/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
+++ b/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
@@ -10,10 +10,10 @@ import dotty.tools.dotc.Main
 import dotty.tools.dotc.reporting.{Reporter, ThrowingReporter}
 import dotty.tools.io.Directory
 import dotty.tools.languageserver.DottyLanguageServer
-import dotty.tools.languageserver.util.Code.{TastyWithPositions, Workspace}
+import dotty.tools.languageserver.util.Code.{TastyWithPositions, Project}
 import org.eclipse.lsp4j.{ DidOpenTextDocumentParams, InitializeParams, InitializeResult, TextDocumentItem}
 
-class TestServer(testFolder: Path, workspaces: List[Workspace]) {
+class TestServer(testFolder: Path, projects: List[Project]) {
 
   val server = new DottyLanguageServer
   var client: TestClient = _
@@ -21,52 +21,52 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
   init()
 
   private[this] def init(): InitializeResult = {
-    var compiledWorkspaces: Set[Workspace] = Set.empty
+    var compiledProjects: Set[Project] = Set.empty
 
-    /** Compile the dependencies of the given workspace, and then the workspace. */
-    def compileWorkspaceAndDependencies(workspace: Workspace): Unit =
-      if (!compiledWorkspaces.contains(workspace)) {
-        workspace.dependsOn.foreach(compileWorkspaceAndDependencies)
-        compileWorkspace(workspace)
-        compiledWorkspaces += workspace
+    /** Compile the dependencies of the given project, and then the project. */
+    def compileProjectAndDependencies(project: Project): Unit =
+      if (!compiledProjects.contains(project)) {
+        project.dependsOn.foreach(compileProjectAndDependencies)
+        compileProject(project)
+        compiledProjects += project
       }
 
     /**
-     * Set up given workspace, return JSON config.
+     * Set up given project, return JSON config.
      *
-     * If the workspace has dependencies, these dependencies are compiled. The classfiles of the
-     * dependent workspaces are put on the classpath of this workspace.
+     * If the project has dependencies, these dependencies are compiled. The classfiles of the
+     * dependent projects are put on the classpath of this project.
      *
-     * @param workspace The workspace to configure.
-     * @return A JSON object representing the configuration for this workspace.
+     * @param project The project to configure.
+     * @return A JSON object representing the configuration for this project.
      */
-    def workspaceSetup(workspace: Workspace): String = {
+    def projectSetup(project: Project): String = {
       def showSeq[T](lst: Seq[T]): String =
         lst
           .map(elem => '"' + elem.toString.replace('\\', '/') + '"')
           .mkString("[ ", ", ", " ]")
 
-      if (workspace.sources.exists(_.isInstanceOf[TastyWithPositions])) {
-        compileWorkspaceAndDependencies(workspace)
+      if (project.sources.exists(_.isInstanceOf[TastyWithPositions])) {
+        compileProjectAndDependencies(project)
       } else {
-        // Compile all the dependencies of this workspace
-        workspace.dependsOn.foreach(compileWorkspaceAndDependencies)
+        // Compile all the dependencies of this project
+        project.dependsOn.foreach(compileProjectAndDependencies)
       }
 
       s"""{
-         |  "id" : "${workspace.name}",
+         |  "id" : "${project.name}",
          |  "compilerVersion" : "${BuildInfo.ideTestsCompilerVersion}",
          |  "compilerArguments" : ${showSeq(BuildInfo.ideTestsCompilerArguments)},
-         |  "sourceDirectories" : ${showSeq(sourceDirectory(workspace, wipe = false) :: Nil)},
-         |  "dependencyClasspath" : ${showSeq(dependencyClasspath(workspace))},
-         |  "classDirectory" : "${classDirectory(workspace, wipe = false).toString.replace('\\','/')}"
+         |  "sourceDirectories" : ${showSeq(sourceDirectory(project, wipe = false) :: Nil)},
+         |  "dependencyClasspath" : ${showSeq(dependencyClasspath(project))},
+         |  "classDirectory" : "${classDirectory(project, wipe = false).toString.replace('\\','/')}"
          |}
          |""".stripMargin
     }
 
     Files.createDirectories(testFolder)
     val configFile = testFolder.resolve(DottyLanguageServer.IDE_CONFIG_FILE)
-    val configuration = workspaces.map(workspaceSetup).mkString("[", ",", "]")
+    val configuration = projects.map(projectSetup).mkString("[", ",", "]")
 
     new PrintWriter(configFile.toString) {
       write(configuration)
@@ -87,8 +87,8 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
    *  @param openInIDE If true, send `textDocument/didOpen` to the server.
    *  @return the file opened
    */
-  def openCode(code: String, workspace: Workspace, fileName: String, openInIDE: Boolean): TestFile = {
-    val testFile = new TestFile(workspace.name + separator + fileName)
+  def openCode(code: String, project: Project, fileName: String, openInIDE: Boolean): TestFile = {
+    val testFile = new TestFile(project.name + separator + fileName)
     val tdi = new TextDocumentItem()
     tdi.setUri(testFile.uri)
     tdi.setText(code)
@@ -102,8 +102,8 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
     testFile
   }
 
-  private def classDirectory(workspace: Workspace, wipe: Boolean): Path = {
-    val path = testFolder.resolve(workspace.name).resolve("out")
+  private def classDirectory(project: Project, wipe: Boolean): Path = {
+    val path = testFolder.resolve(project.name).resolve("out")
     if (wipe) {
       Directory(path).deleteRecursively()
       Files.createDirectories(path)
@@ -111,15 +111,15 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
     path.toAbsolutePath
   }
 
-  private def dependencyClasspath(workspace: Workspace): Seq[String] = {
+  private def dependencyClasspath(project: Project): Seq[String] = {
     BuildInfo.ideTestsDependencyClasspath.map(_.getAbsolutePath) ++
-      workspace.dependsOn.flatMap { dep =>
+      project.dependsOn.flatMap { dep =>
         classDirectory(dep, wipe = false).toString +: dependencyClasspath(dep)
       }
   }.distinct
 
-  private def sourceDirectory(workspace: Workspace, wipe: Boolean): Path = {
-    val path = TestFile.sourceDir.resolve(workspace.name).toAbsolutePath
+  private def sourceDirectory(project: Project, wipe: Boolean): Path = {
+    val path = TestFile.sourceDir.resolve(project.name).toAbsolutePath
     if (wipe) {
       Directory(path).deleteRecursively()
       Files.createDirectories(path)
@@ -128,14 +128,14 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
   }
 
   /**
-   * Sets up the sources of the given workspace, creates the necessary directories
+   * Sets up the sources of the given project, creates the necessary directories
    * and compile the sources.
    *
-   * @param workspace The workspace to set up.
+   * @param project The project to set up.
    */
-  private def compileWorkspace(workspace: Workspace): Unit = {
-    val sourcesDir = sourceDirectory(workspace, wipe = true)
-    val sources = workspace.sources.zipWithIndex.map { case (src, id) =>
+  private def compileProject(project: Project): Unit = {
+    val sourcesDir = sourceDirectory(project, wipe = true)
+    val sources = project.sources.zipWithIndex.map { case (src, id) =>
       val path = sourcesDir.resolve(src.sourceName(id)).toAbsolutePath
       Files.write(path, src.text.getBytes("UTF-8"))
       path.toString
@@ -144,8 +144,8 @@ class TestServer(testFolder: Path, workspaces: List[Workspace]) {
     val compileOptions =
       sources.toArray ++
         Array(
-          "-classpath", dependencyClasspath(workspace).mkString(pathSeparator),
-          "-d", classDirectory(workspace, wipe = true).toString
+          "-classpath", dependencyClasspath(project).mkString(pathSeparator),
+          "-d", classDirectory(project, wipe = true).toString
         )
     val reporter = new ThrowingReporter(Reporter.NoReporter)
     Main.process(compileOptions, reporter)

--- a/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
+++ b/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
@@ -1,14 +1,16 @@
 package dotty.tools.languageserver.util.server
 
 import java.io.PrintWriter
+import java.io.File.{separator => sep}
 import java.net.URI
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 import java.util
 
 import dotty.tools.languageserver.DottyLanguageServer
+import dotty.tools.languageserver.util.Code.Workspace
 import org.eclipse.lsp4j.{ DidOpenTextDocumentParams, InitializeParams, InitializeResult, TextDocumentItem}
 
-class TestServer(testFolder: Path) {
+class TestServer(testFolder: Path, workspaces: List[Workspace]) {
 
   val server = new DottyLanguageServer
   var client: TestClient = _
@@ -16,28 +18,54 @@ class TestServer(testFolder: Path) {
   init()
 
   private[this] def init(): InitializeResult = {
-    // Fill the configuration with values populated by sbt
-    def showSeq[T](lst: Seq[T]): String =
-      lst
-        .map(elem => '"' + elem.toString.replace('\\', '/') + '"')
-        .mkString("[ ", ", ", " ]")
-    val dottyIdeJson: String =
-      s"""[ {
-         |  "id" : "dotty-ide-test",
+    /**
+     * Set up given workspace, return JSON config.
+     *
+     * This creates the necessary directories to hold the classes and sources. Some values
+     * are passed via sbt-buildinfo, such as the classpath containing the scala and dotty libaries.
+     *
+     * @param workspace The workspace to configure.
+     * @return A JSON object representing the configuration for this workspace.
+     */
+    def workspaceSetup(workspace: Workspace): String = {
+      def showSeq[T](lst: Seq[T]): String =
+        lst
+          .map(elem => '"' + elem.toString.replace('\\', '/') + '"')
+          .mkString("[ ", ", ", " ]")
+
+      def classDirectory(workspace: Workspace): Path = {
+        val path = testFolder.resolve(workspace.name).resolve("out")
+        Files.createDirectories(path)
+        path.toAbsolutePath
+      }
+
+      val dependencyClasspath =
+        BuildInfo.ideTestsDependencyClasspath.map(_.getAbsolutePath) ++
+          workspace.dependsOn.map(w => classDirectory(w).toString)
+
+      val sourceDirectory: Path = {
+        val path = TestFile.sourceDir.resolve(workspace.name).toAbsolutePath
+        Files.createDirectories(path)
+        path
+      }
+
+      s"""{
+         |  "id" : "${workspace.name}",
          |  "compilerVersion" : "${BuildInfo.ideTestsCompilerVersion}",
          |  "compilerArguments" : ${showSeq(BuildInfo.ideTestsCompilerArguments)},
-         |  "sourceDirectories" : ${showSeq(BuildInfo.ideTestsSourceDirectories)},
-         |  "dependencyClasspath" : ${showSeq(BuildInfo.ideTestsDependencyClasspath)},
-         |  "classDirectory" : "${BuildInfo.ideTestsClassDirectory.toString.replace('\\','/')}"
+         |  "sourceDirectories" : ${showSeq(sourceDirectory :: Nil)},
+         |  "dependencyClasspath" : ${showSeq(dependencyClasspath)},
+         |  "classDirectory" : "${classDirectory(workspace).toString.replace('\\','/')}"
          |}
-         |]""".stripMargin
+         |""".stripMargin
+    }
+
+    Files.createDirectories(testFolder)
     val configFile = testFolder.resolve(DottyLanguageServer.IDE_CONFIG_FILE)
-    testFolder.toFile.mkdirs()
-    testFolder.resolve("src").toFile.mkdirs()
-    testFolder.resolve("out").toFile.mkdirs()
+    val configuration = workspaces.map(workspaceSetup).mkString("[", ",", "]")
 
     new PrintWriter(configFile.toString) {
-      write(dottyIdeJson)
+      write(configuration)
       close()
     }
 
@@ -54,8 +82,8 @@ class TestServer(testFolder: Path) {
    *  @param fileName file path in the source directory
    *  @return the file opened
    */
-  def openCode(code: String, fileName: String): TestFile = {
-    val testFile = new TestFile(fileName)
+  def openCode(code: String, workspace: Workspace, fileName: String): TestFile = {
+    val testFile = new TestFile(workspace.name + sep + fileName)
     val dotdp = new DidOpenTextDocumentParams()
     val tdi = new TextDocumentItem()
     tdi.setUri(testFile.uri)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -103,9 +103,7 @@ object Build {
   // Settings used to configure the test language server
   lazy val ideTestsCompilerVersion = taskKey[String]("Compiler version to use in IDE tests")
   lazy val ideTestsCompilerArguments = taskKey[Seq[String]]("Compiler arguments to use in IDE tests")
-  lazy val ideTestsSourceDirectories = taskKey[Seq[File]]("Source directories to use in IDE tests")
   lazy val ideTestsDependencyClasspath = taskKey[Seq[File]]("Dependency classpath to use in IDE tests")
-  lazy val ideTestsClassDirectory = taskKey[File]("Class directory to use in IDE tests")
 
   // Settings shared by the build (scoped in ThisBuild). Used in build.sbt
   lazy val thisBuildSettings = Def.settings(
@@ -883,7 +881,6 @@ object Build {
     settings(
       ideTestsCompilerVersion := (version in `dotty-compiler`).value,
       ideTestsCompilerArguments := (scalacOptions in `dotty-compiler`).value,
-      ideTestsSourceDirectories := Seq((baseDirectory in ThisBuild).value / "out" / "ide-tests" / "src"),
       ideTestsDependencyClasspath := {
         val dottyLib = (classDirectory in `dotty-library-bootstrapped` in Compile).value
         val scalaLib =
@@ -894,13 +891,10 @@ object Build {
             .toList
         dottyLib :: scalaLib
       },
-      ideTestsClassDirectory := (baseDirectory in ThisBuild).value / "out" / "ide-tests" / "out",
       buildInfoKeys in Test := Seq[BuildInfoKey](
         ideTestsCompilerVersion,
         ideTestsCompilerArguments,
-        ideTestsSourceDirectories,
-        ideTestsDependencyClasspath,
-        ideTestsClassDirectory
+        ideTestsDependencyClasspath
       ),
       buildInfoPackage in Test := "dotty.tools.languageserver.util.server",
       BuildInfoPlugin.buildInfoScopedSettings(Test),


### PR DESCRIPTION
Because the IDE doesn't work with multi-project setup, I haven't included any test, but here's an example:

```scala
  @Test def classDefinition1: Unit = {
    val w0 = Workspace.withSources(
      code"""class ${m1}Foo${m2}""",
    )

    val w1 = Workspace.dependingOn(w0).withSources(
      code"""class Bar { new ${m3}Foo${m4} }"""
    )

    withWorkspaces(w0, w1)
      .definition(m1 to m2, List(m1 to m2))
      .definition(m3 to m4, List(m1 to m2))
  }
```