### PR TITLE
Fix #5034:Attempt to throw proper error when enum is declared lazy instead of crash

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -206,6 +206,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
     def isEnumCase = isEnum && is(Case)
     def isEnumClass = isEnum && !is(Case)
+    def isLazyEnum = is(Lazy) && isEnum
   }
 
   @sharable val EmptyModifiers: Modifiers = new Modifiers()

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -132,7 +132,8 @@ public enum ErrorMessageID {
     ImportRenamedTwiceID,
     TypeTestAlwaysSucceedsID,
     TermMemberNeedsNeedsResultTypeForImplicitSearchID,
-    CaseClassCannotExtendEnumID
+    CaseClassCannotExtendEnumID,
+    EnumCannotBeLazyID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2126,4 +2126,10 @@ object messages {
     override def msg: String = hl"""normal case class cannot extend an enum. case $cls in ${cls.owner} is extending enum ${parent.name}."""
     override def explanation: String = ""
   }
+
+  case class EnumCannotBeLazy(enumCls: String)(implicit ctx: Context) extends Message(EnumCannotBeLazyID) {
+    override def kind: String = "Syntax"
+    override def msg: String = hl"""enum $enumCls cannot be declared lazy."""
+    override def explanation: String = ""
+  }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -36,6 +36,20 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals("<empty>", cls.owner.name.show)
       }
 
+  @Test def enumIsDeclaredLazy =
+    checkMessagesAfter(RefChecks.name) {
+      """
+        |lazy enum Foo
+      """.stripMargin
+    }
+      .expect { (ictx, messages) ⇒
+        implicit val ctx: Context = ictx
+        assertMessageCount(1, messages)
+        val errorMsg = messages.head
+        val EnumCannotBeLazy(enumName) :: Nil = messages
+        assertEquals("Foo", enumName)
+      }
+
   @Test def typeMismatch =
     checkMessagesAfter(FrontEnd.name) {
       """


### PR DESCRIPTION
I have attempted to provide a proper error when somebody declares `lazy enum Foo`. I think DesugarEnums.scala can be further improved so suggestions are welcome.