### PR TITLE
Fix #3208: Patterns gets the type of their scrutinee

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1344,11 +1344,12 @@ class Typer extends Namer
       case _ =>
         if (tree.name == nme.WILDCARD) body1
         else {
-          // for a singleton pattern like `x @ Nil`, `x` should get the type from the scrutinee
+          // For a pattern like `x @ P`, x gets the type of the scrutinee and pattern.
+          // For a singleton pattern like `x @ Nil`, `x` should get the type from the scrutinee,
           // see tests/neg/i3200b.scala and SI-1503
           val symTp =
             if (body1.tpe.isInstanceOf[TermRef]) pt1
-            else body1.tpe.underlyingIfRepeated(isJava = false)
+            else AndType.make(body1.tpe.underlyingIfRepeated(isJava = false), pt1)
           val sym = ctx.newPatternBoundSymbol(tree.name, symTp, tree.pos)
           if (pt == defn.ImplicitScrutineeTypeRef) sym.setFlag(Implicit)
           if (ctx.mode.is(Mode.InPatternAlternative))

--- a/tests/pos/i3208.scala
+++ b/tests/pos/i3208.scala
@@ -1,0 +1,20 @@
+trait X
+trait Y
+
+trait MyError
+
+class Test {
+  def test(xs: List[X]): List[X] = xs.collect { case y: Y => y }
+
+  def test2(x: X) = x match {
+    case y: Y =>
+      val b: X = y
+  }
+
+  def test3 =
+    try ???
+    catch {
+      case e: MyError =>
+        throw e
+    }
+}


### PR DESCRIPTION
For a pattern like `x @ P`, `x` gets the type of the scrutiny and pattern.
E.g:
```scala
(x: X) match case { y: Y => ... }
```
Above, `y` types to `X & Y`.