### PR TITLE
Respect `-color:never` in REPL output

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -2,6 +2,8 @@ package dotty.tools
 package dotc
 package printing
 
+import dotty.tools.dotc.core.Contexts.Context
+
 import parsing.Tokens._
 import scala.annotation.switch
 import scala.collection.mutable.StringBuilder
@@ -45,7 +47,12 @@ object SyntaxHighlighting {
    '{'  :: '}' :: ')' :: '(' :: '[' :: ']' :: '=' :: ' ' :: ',' :: '.' :: '|' ::
    '&' :: '\n' :: Nil
 
-  def apply(chars: Iterable[Char]): Iterable[Char] = {
+  def apply(chars: Iterable[Char])(implicit ctx: Context): Iterable[Char] = {
+    if (ctx.settings.color.value != "never") highlight(chars)
+    else chars
+  }
+
+  def highlight(chars: Iterable[Char]): Iterable[Char] = {
     var prev: Char = 0
     var remaining  = chars.toStream
     val newBuf     = new StringBuilder

--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -22,9 +22,11 @@ final class JLineTerminal extends java.io.Closeable {
     .build()
   private val history = new DefaultHistory
 
-  private def blue(str: String) = Console.BLUE + str + Console.RESET
-  private val prompt        = blue("scala> ")
-  private val newLinePrompt = blue("     | ")
+  private def blue(str: String)(implicit ctx: Context) =
+    if (ctx.settings.color.value != "never") Console.BLUE + str + Console.RESET
+    else str
+  private def prompt(implicit ctx: Context)        = blue("scala> ")
+  private def newLinePrompt(implicit ctx: Context) = blue("     | ")
 
   /** Blockingly read line from `System.in`
    *
@@ -64,7 +66,7 @@ final class JLineTerminal extends java.io.Closeable {
   def close() = terminal.close()
 
   /** Provide syntax highlighting */
-  private class Highlighter extends reader.Highlighter {
+  private class Highlighter(implicit ctx: Context) extends reader.Highlighter {
     def highlight(reader: LineReader, buffer: String): AttributedString = {
       val highlighted = SyntaxHighlighting(buffer).mkString
       AttributedString.fromAnsi(highlighted)

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -339,14 +339,14 @@ class ReplDriver(settings: Array[String],
     case TypeOf(expr) =>
       compiler.typeOf(expr)(newRun(state)).fold(
         displayErrors,
-        res => out.println(SyntaxHighlighting(res))
+        res => out.println(SyntaxHighlighting(res)(state.context))
       )
       state
 
     case DocOf(expr) =>
       compiler.docOf(expr)(newRun(state)).fold(
         displayErrors,
-        res => out.println(SyntaxHighlighting(res))
+        res => out.println(SyntaxHighlighting(res)(state.context))
       )
       state
 

--- a/compiler/test/dotty/tools/dotc/printing/SyntaxHighlightingTests.scala
+++ b/compiler/test/dotty/tools/dotc/printing/SyntaxHighlightingTests.scala
@@ -9,7 +9,7 @@ class SyntaxHighlightingTests {
   import SyntaxHighlighting._
 
   private def test(source: String, expected: String): Unit = {
-    val highlighted = SyntaxHighlighting.apply(source)
+    val highlighted = SyntaxHighlighting.highlight(source)
       .mkString
       .replace(NoColor,         ">")
       .replace(CommentColor,    "<C|")


### PR DESCRIPTION
The (successful) result of the REPL was highlighted regardless of the
value of `-color`. This commit fixes this, so that the output of the
REPL is highlighted only if `-color` is not set to `never`.

The prompt and the code as being entered are still highlighted.