### PR TITLE
Fix #5083: Fix field references in outer accessors

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -336,7 +336,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       case pre: ThisType =>
         tp.isType ||
         pre.cls.isStaticOwner ||
-        tp.symbol.isParamOrAccessor && !pre.cls.is(Trait) && ctx.owner.enclosingClass == pre.cls
+        tp.symbol.isParamOrAccessor && !tp.symbol.owner.is(Trait) && ctx.owner.enclosingClass == pre.cls
           // was ctx.owner.enclosingClass.derivesFrom(pre.cls) which was not tight enough
           // and was spuriously triggered in case inner class would inherit from outer one
           // eg anonymous TypeMap inside TypeMap.andThen

--- a/tests/pos/i5083.scala
+++ b/tests/pos/i5083.scala
@@ -1,0 +1,15 @@
+class A(a: Int) {
+  class X {
+    val x = a
+  }
+
+  trait Y {
+    val y = a
+  }
+
+  trait Z(val o: A) extends o.Y {
+    val z = a
+  }
+
+  class B extends X with Z(new A(4))
+}


### PR DESCRIPTION
i5083 provides an example where a field reference had NoPrefix as a parameter, which made
it fail for producing an outer path. It's not quite clear where this came from. The fix
addresses it for now. 