### PR TITLE
Refine decomposeCall

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -560,14 +560,16 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
    *
    *  Note: targ and vargss may be empty
    */
-  def decomposeCall(tree: Tree): (Tree, List[Tree], List[List[Tree]]) = {
-    @tailrec
+  def decomposeCall(tree: Tree)(implicit ctx: Context): (Tree, List[Tree], List[List[Tree]]) = {
     def loop(tree: Tree, targss: List[Tree], argss: List[List[Tree]]): (Tree, List[Tree], List[List[Tree]]) =
       tree match {
         case Apply(fn, args) =>
           loop(fn, targss, args :: argss)
         case TypeApply(fn, targs) =>
           loop(fn, targs ::: targss, argss)
+        case Block(stats, expr) =>
+          val (fn, targss2, argss2) = loop(expr, targss, argss)
+          (Block(stats, fn), targss2, argss2)
         case _ =>
           (tree, targss, argss)
       }


### PR DESCRIPTION
The following code

```Scala
class Test {
  def foo(x: Int = 5)(implicit y: Int): Int =
    if (x > 0) y * y
    else y + y

  implicit val m: Int = 7

  (new Test).foo()
}
```

produces a tree with a block as function after typer:

```Scala
  class Test() extends Object() {
    def foo(x: Int)(implicit y: Int): Int = if x.>(0) then y.*(y) else y.+(y)
    def foo$default$1: Int = 5
    implicit val m: Int = 7
    {
      val $1$: Test = new Test()
      $1$.foo($1$.foo$default$1)
    }(this.m)
  }
```