### PR TITLE
Use `scala-lang.scala` for syntax highlighting

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -992,10 +992,10 @@ object Build {
         val tsc = workingDir / "node_modules" / ".bin" / "tsc"
         runProcess(Seq(tsc.getAbsolutePath, "--pretty", "--project", workingDir.getAbsolutePath), wait = true)
 
-        // Currently, vscode-dotty depends on daltonjorge.scala for syntax highlighting,
+        // vscode-dotty depends on scala-lang.scala for syntax highlighting,
         // this is not automatically installed when starting the extension in development mode
         // (--extensionDevelopmentPath=...)
-        installCodeExtension(codeCommand.value, "daltonjorge.scala")
+        installCodeExtension(codeCommand.value, "scala-lang.scala")
 
         sbt.internal.inc.Analysis.Empty
       }.dependsOn(managedResources in Compile).value,

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -54,7 +54,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.1.0-M7/coursier"
   },
   "extensionDependencies": [
-    "daltonjorge.scala"
+    "scala-lang.scala"
   ],
   "dependencies": {
     "child-process-promise": "^2.2.1",


### PR DESCRIPTION
I don't know if there's something that prevents us from migrating; but I haven't seen any problem using that so far.