### PR TITLE
 Fix #5083: Disallow using trait parameters as prefix for its parents

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -93,7 +93,7 @@ object RefChecks {
   /** Check that self type of this class conforms to self types of parents.
    *  and required classes.
    */
-  private def checkParents(cls: Symbol, tmpl: Template)(implicit ctx: Context): Unit = cls.info match {
+  private def checkParents(cls: Symbol)(implicit ctx: Context): Unit = cls.info match {
     case cinfo: ClassInfo =>
       def checkSelfConforms(other: ClassSymbol, category: String, relation: String) = {
         val otherSelf = other.givenSelfType.asSeenFrom(cls.thisType, other.classSymbol)
@@ -101,10 +101,8 @@ object RefChecks {
           ctx.error(DoesNotConformToSelfType(category, cinfo.selfType, cls, otherSelf, relation, other.classSymbol),
             cls.pos)
       }
-      for (parent <- tmpl.parents) {
-        checkSelfConforms(parent.tpe.classSymbol.asClass, "illegal inheritance", "parent")
-        checkParentPrefix(cls, parent)
-      }
+      for (parent <- cinfo.classParents)
+        checkSelfConforms(parent.classSymbol.asClass, "illegal inheritance", "parent")
       for (reqd <- cinfo.cls.givenSelfType.classSymbols)
         checkSelfConforms(reqd, "missing requirement", "required")
     case _ =>
@@ -119,7 +117,7 @@ object RefChecks {
     parent.tpe.typeConstructor match {
       case TypeRef(ref: TermRef, _) =>
         val paramRefs = ref.namedPartsWith(ntp => ntp.symbol.enclosingClass == cls)
-        if (paramRefs.nonEmpty && cls.is(Trait))
+        if (paramRefs.nonEmpty)
           ctx.error("trait parameters cannot be used as parent prefixes", parent.pos)
       case _ =>
     }
@@ -976,7 +974,8 @@ class RefChecks extends MiniPhase { thisPhase =>
   override def transformTemplate(tree: Template)(implicit ctx: Context) = try {
     val cls = ctx.owner
     checkOverloadedRestrictions(cls)
-    checkParents(cls, tree)
+    checkParents(cls)
+    if (cls.is(Trait)) tree.parents.foreach(checkParentPrefix(cls, _))
     checkCompanionNameClashes(cls)
     checkAllOverrides(cls)
     tree

--- a/tests/neg/i5083.scala
+++ b/tests/neg/i5083.scala
@@ -1,0 +1,25 @@
+class A(a: Int) {
+  abstract class X {
+    def f: Int
+    val x = a + f      // NPE: the outer for `Y` is not yet set
+  }
+
+  trait Y {
+    val y = a
+    def f: Int = A.this.a      // NPE: the outer for `Y` is not yet set
+  }
+
+  trait Z(val o: A) extends o.Y {  // error
+    val z = a
+  }
+
+  class B extends X with Z(new A(4))
+}
+
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val a = new A(3)
+    new a.B
+  }
+}

--- a/tests/neg/i5083b.scala
+++ b/tests/neg/i5083b.scala
@@ -1,0 +1,15 @@
+class A(a: Int) {
+  class X {
+    val x = a
+  }
+
+  trait Y {
+    val y = a
+  }
+
+  val z: Z = ???
+
+  trait Z(val o: A) extends z.o.Y   // error: cyclic reference `z`
+
+  class B extends X with Z(new A(4))
+}

--- a/tests/neg/i5083c.scala
+++ b/tests/neg/i5083c.scala
@@ -1,0 +1,25 @@
+class A(a: Int) {
+  trait X {
+    def f: Int
+    val x = a + f      // NPE: the outer for `Y` is not yet set
+  }
+
+  trait Y {
+    val y = a
+    def f: Int = A.this.a      // NPE: the outer for `Y` is not yet set
+  }
+
+  class Z(o: A) extends m.Y {  // error
+    val m = o
+  }
+
+  class B extends Z(new A(4))
+}
+
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val a = new A(3)
+    new a.B
+  }
+}


### PR DESCRIPTION
 Fix #5083: Disallow using trait parameters as prefix for its parents

The rationale is to ensure outer-related NPE never happen in Scala.
Otherwise, outer NPE may happen, see tests/neg/i5083.scala
