### PR TITLE
Back to the future: `rewrite` to `inline`

### DIFF
--- a/bench/tests/power-macro/PowerMacro.scala
+++ b/bench/tests/power-macro/PowerMacro.scala
@@ -2,7 +2,7 @@ import scala.quoted.Expr
 
 object PowerMacro {
 
-  rewrite def power(transparent n: Long, x: Double) = ~powerCode(n, '(x))
+  inline def power(transparent n: Long, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Long, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/bench/tests/power-macro/PowerMacro.scala
+++ b/bench/tests/power-macro/PowerMacro.scala
@@ -2,7 +2,7 @@ import scala.quoted.Expr
 
 object PowerMacro {
 
-  inline def power(transparent n: Long, x: Double) = ~powerCode(n, '(x))
+  inline def power(inline n: Long, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Long, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -464,11 +464,11 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
    *  Strictly speaking we can't replace `O.x` with `42`.  But this would make
    *  most expressions non-constant. Maybe we can change the spec to accept this
    *  kind of eliding behavior. Or else enforce true purity in the compiler.
-   *  The choice will be affected by what we will do with `transparent` and with
+   *  The choice will be affected by what we will do with `inline` and with
    *  Singleton type bounds (see SIP 23). Presumably
    *
    *     object O1 { val x: Singleton = 42; println("43") }
-   *     object O2 { transparent val x = 42; println("43") }
+   *     object O2 { inline val x = 42; println("43") }
    *
    *  should behave differently.
    *
@@ -478,8 +478,8 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
    *
    *     O2.x = 42
    *
-   *  Revisit this issue once we have standardized on `transparent`. Then we can demand
-   *  purity of the prefix unless the selection goes to a transparent val.
+   *  Revisit this issue once we have standardized on `inline`. Then we can demand
+   *  purity of the prefix unless the selection goes to a inline val.
    *
    *  Note: This method should be applied to all term tree nodes that are not literals,
    *        that can be idempotent, and that can have constant types. So far, only nodes

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -497,9 +497,9 @@ object Trees {
     extends TermTree[T] {
     type ThisTree[-T >: Untyped] = If[T]
   }
-  class RewriteIf[T >: Untyped] private[ast] (cond: Tree[T], thenp: Tree[T], elsep: Tree[T])
+  class InlineIf[T >: Untyped] private[ast] (cond: Tree[T], thenp: Tree[T], elsep: Tree[T])
     extends If(cond, thenp, elsep) {
-    override def toString = s"RewriteIf($cond, $thenp, $elsep)"
+    override def toString = s"InlineIf($cond, $thenp, $elsep)"
   }
 
   /** A closure with an environment and a reference to a method.
@@ -521,9 +521,9 @@ object Trees {
     extends TermTree[T] {
     type ThisTree[-T >: Untyped] = Match[T]
   }
-  class RewriteMatch[T >: Untyped] private[ast] (selector: Tree[T], cases: List[CaseDef[T]])
+  class InlineMatch[T >: Untyped] private[ast] (selector: Tree[T], cases: List[CaseDef[T]])
     extends Match(selector, cases) {
-    override def toString = s"RewriteMatch($selector, $cases)"
+    override def toString = s"InlineMatch($selector, $cases)"
   }
 
   /** case pat if guard => body; only appears as child of a Match */
@@ -904,10 +904,10 @@ object Trees {
     type Assign = Trees.Assign[T]
     type Block = Trees.Block[T]
     type If = Trees.If[T]
-    type RewriteIf = Trees.RewriteIf[T]
+    type InlineIf = Trees.InlineIf[T]
     type Closure = Trees.Closure[T]
     type Match = Trees.Match[T]
-    type RewriteMatch = Trees.RewriteMatch[T]
+    type InlineMatch = Trees.InlineMatch[T]
     type CaseDef = Trees.CaseDef[T]
     type Labeled = Trees.Labeled[T]
     type Return = Trees.Return[T]
@@ -1038,9 +1038,9 @@ object Trees {
         case _ => finalize(tree, untpd.Block(stats, expr))
       }
       def If(tree: Tree)(cond: Tree, thenp: Tree, elsep: Tree)(implicit ctx: Context): If = tree match {
-        case tree: RewriteIf =>
+        case tree: InlineIf =>
           if ((cond eq tree.cond) && (thenp eq tree.thenp) && (elsep eq tree.elsep)) tree
-          else finalize(tree, untpd.RewriteIf(cond, thenp, elsep))
+          else finalize(tree, untpd.InlineIf(cond, thenp, elsep))
         case tree: If if (cond eq tree.cond) && (thenp eq tree.thenp) && (elsep eq tree.elsep) => tree
         case _ => finalize(tree, untpd.If(cond, thenp, elsep))
       }
@@ -1049,9 +1049,9 @@ object Trees {
         case _ => finalize(tree, untpd.Closure(env, meth, tpt))
       }
       def Match(tree: Tree)(selector: Tree, cases: List[CaseDef])(implicit ctx: Context): Match = tree match {
-        case tree: RewriteMatch =>
+        case tree: InlineMatch =>
           if ((selector eq tree.selector) && (cases eq tree.cases)) tree
-          else finalize(tree, untpd.RewriteMatch(selector, cases))
+          else finalize(tree, untpd.InlineMatch(selector, cases))
         case tree: Match if (selector eq tree.selector) && (cases eq tree.cases) => tree
         case _ => finalize(tree, untpd.Match(selector, cases))
       }

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -134,8 +134,6 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
     case class Inline() extends Mod(Flags.Inline)
 
-    case class Transparent() extends Mod(Flags.Transparent)
-
     case class Enum() extends Mod(Flags.Enum)
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -132,7 +132,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
     case class Lazy() extends Mod(Flags.Lazy)
 
-    case class Rewrite() extends Mod(Flags.Rewrite)
+    case class Inline() extends Mod(Flags.Inline)
 
     case class Transparent() extends Mod(Flags.Transparent)
 
@@ -275,10 +275,10 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def Assign(lhs: Tree, rhs: Tree): Assign = new Assign(lhs, rhs)
   def Block(stats: List[Tree], expr: Tree): Block = new Block(stats, expr)
   def If(cond: Tree, thenp: Tree, elsep: Tree): If = new If(cond, thenp, elsep)
-  def RewriteIf(cond: Tree, thenp: Tree, elsep: Tree): If = new RewriteIf(cond, thenp, elsep)
+  def InlineIf(cond: Tree, thenp: Tree, elsep: Tree): If = new InlineIf(cond, thenp, elsep)
   def Closure(env: List[Tree], meth: Tree, tpt: Tree): Closure = new Closure(env, meth, tpt)
   def Match(selector: Tree, cases: List[CaseDef]): Match = new Match(selector, cases)
-  def RewriteMatch(selector: Tree, cases: List[CaseDef]): Match = new RewriteMatch(selector, cases)
+  def InlineMatch(selector: Tree, cases: List[CaseDef]): Match = new InlineMatch(selector, cases)
   def CaseDef(pat: Tree, guard: Tree, body: Tree): CaseDef = new CaseDef(pat, guard, body)
   def Labeled(bind: Bind, expr: Tree): Labeled = new Labeled(bind, expr)
   def Return(expr: Tree, from: Tree): Return = new Return(expr, from)

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -43,7 +43,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val pageWidth = IntSetting("-pagewidth", "Set page width", 80)
   val strict = BooleanSetting("-strict", "Use strict type rules, which means some formerly legal code does not typecheck anymore.")
   val language = MultiStringSetting("-language", "feature", "Enable one or more language features.")
-  val `rewrite` = OptionSetting[Rewrites]("-rewrite", "When used in conjunction with -language:Scala2 rewrites sources to migrate to new syntax")
+  val rewrite = OptionSetting[Rewrites]("-rewrite", "When used in conjunction with -language:Scala2 rewrites sources to migrate to new syntax")
   val silentWarnings = BooleanSetting("-nowarn", "Silence all warnings.")
   val fromTasty = BooleanSetting("-from-tasty", "Compile classes from tasty in classpath. The arguments are used as class names.")
 

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -57,7 +57,7 @@ object Annotations {
   }
 
   /** An annotation indicating the body of a right-hand side,
-   *  typically of an inline or transparent method. Treated specially in
+   *  typically of an inline method. Treated specially in
    *  pickling/unpickling and TypeTreeMaps
    */
   abstract class BodyAnnotation extends Annotation {

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -57,7 +57,7 @@ object Annotations {
   }
 
   /** An annotation indicating the body of a right-hand side,
-   *  typically of a rewrite or transparent method. Treated specially in
+   *  typically of an inline or transparent method. Treated specially in
    *  pickling/unpickling and TypeTreeMaps
    */
   abstract class BodyAnnotation extends Annotation {

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -764,8 +764,8 @@ class Definitions {
   def ImplicitNotFoundAnnot(implicit ctx: Context) = ImplicitNotFoundAnnotType.symbol.asClass
   lazy val ForceInlineAnnotType = ctx.requiredClassRef("scala.forceInline")
   def ForceInlineAnnot(implicit ctx: Context) = ForceInlineAnnotType.symbol.asClass
-  lazy val TransparentParamAnnotType = ctx.requiredClassRef("scala.annotation.internal.TransparentParam")
-  def TransparentParamAnnot(implicit ctx: Context) = TransparentParamAnnotType.symbol.asClass
+  lazy val InlineParamAnnotType = ctx.requiredClassRef("scala.annotation.internal.InlineParam")
+  def InlineParamAnnot(implicit ctx: Context) = InlineParamAnnotType.symbol.asClass
   lazy val InvariantBetweenAnnotType = ctx.requiredClassRef("scala.annotation.internal.InvariantBetween")
   def InvariantBetweenAnnot(implicit ctx: Context) = InvariantBetweenAnnotType.symbol.asClass
   lazy val MigrationAnnotType = ctx.requiredClassRef("scala.annotation.migration")

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -329,9 +329,6 @@ object Flags {
   /** A method that has default params */
   final val DefaultParameterized = termFlag(27, "<defaultparam>")
 
-  /** Labelled with `transparent` modifier */
-  final val Transparent = commonFlag(29, "transparent")
-
   /** Symbol is defined by a Java class */
   final val JavaDefined = commonFlag(30, "<java>")
 
@@ -436,7 +433,7 @@ object Flags {
 
   /** Flags representing source modifiers */
   final val SourceModifierFlags =
-    commonFlags(Private, Protected, Abstract, Final, Inline | Transparent,
+    commonFlags(Private, Protected, Abstract, Final, Inline,
      Sealed, Case, Implicit, Override, AbsOverride, Lazy, JavaStatic, Erased)
 
   /** Flags representing modifiers that can appear in trees */
@@ -457,7 +454,7 @@ object Flags {
     Scala2ExistentialCommon | Mutable.toCommonFlags | Touched | JavaStatic |
     CovariantOrOuter | ContravariantOrLabel | CaseAccessor.toCommonFlags |
     NonMember | ImplicitCommon | Permanent | Synthetic |
-    SuperAccessorOrScala2x | Inline | Transparent
+    SuperAccessorOrScala2x | Inline
 
   /** Flags that are not (re)set when completing the denotation, or, if symbol is
    *  a top-level class or object, when completing the denotation once the class
@@ -551,8 +548,8 @@ object Flags {
   /** Assumed to be pure */
   final val StableOrErased = Stable | Erased
 
-  /** Labeled `private`, `final`, `inline` or `transparent` */
-  final val EffectivelyFinal = Private | Final | Inline | Transparent
+  /** Labeled `private`, `final`, or `inline` */
+  final val EffectivelyFinal = Private | Final | Inline
 
   /** A private method */
   final val PrivateMethod = allOf(Private, Method)
@@ -560,17 +557,14 @@ object Flags {
   /** A private accessor */
   final val PrivateAccessor = allOf(Private, Accessor)
 
-  /** A transparent method */
-  final val TransparentMethod = allOf(Transparent, Method)
-
   /** An inline method */
   final val InlineMethod = allOf(Inline, Method)
 
   /** An implicit inline method */
   final val ImplicitInlineMethod = allOf(Inline, Implicit, Method)
 
-  /** A transparent parameter */
-  final val TransparentParam = allOf(Transparent, Param)
+  /** An inline parameter */
+  final val InlineParam = allOf(Inline, Param)
 
   /** An enum case */
   final val EnumCase = allOf(Enum, Case)
@@ -596,8 +590,8 @@ object Flags {
   /** A deferred type member or parameter (these don't have right hand sides) */
   final val DeferredOrTypeParam = Deferred | TypeParam
 
-  /** value that's final or transparent */
-  final val FinalOrTransparent = Final | Transparent
+  /** value that's final or inline */
+  final val FinalOrInline = Final | Inline
 
   /** A covariant type parameter instance */
   final val LocalCovariant = allOf(Local, Covariant)

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -283,8 +283,8 @@ object Flags {
    */
   final val Synthetic = commonFlag(18, "<synthetic>")
 
-  /** Labelled with `rewrite` modifier */
-  final val Rewrite = commonFlag(19, "rewrite")
+  /** Labelled with `inline` modifier */
+  final val Inline = commonFlag(19, "inline")
 
   /** A covariant type variable / an outer accessor */
   final val CovariantOrOuter = commonFlag(20, "")
@@ -436,7 +436,7 @@ object Flags {
 
   /** Flags representing source modifiers */
   final val SourceModifierFlags =
-    commonFlags(Private, Protected, Abstract, Final, Rewrite | Transparent,
+    commonFlags(Private, Protected, Abstract, Final, Inline | Transparent,
      Sealed, Case, Implicit, Override, AbsOverride, Lazy, JavaStatic, Erased)
 
   /** Flags representing modifiers that can appear in trees */
@@ -457,7 +457,7 @@ object Flags {
     Scala2ExistentialCommon | Mutable.toCommonFlags | Touched | JavaStatic |
     CovariantOrOuter | ContravariantOrLabel | CaseAccessor.toCommonFlags |
     NonMember | ImplicitCommon | Permanent | Synthetic |
-    SuperAccessorOrScala2x | Rewrite | Transparent
+    SuperAccessorOrScala2x | Inline | Transparent
 
   /** Flags that are not (re)set when completing the denotation, or, if symbol is
    *  a top-level class or object, when completing the denotation once the class
@@ -551,8 +551,8 @@ object Flags {
   /** Assumed to be pure */
   final val StableOrErased = Stable | Erased
 
-  /** Labeled `private`, `final`, `rewrite` or `transparent` */
-  final val EffectivelyFinal = Private | Final | Rewrite | Transparent
+  /** Labeled `private`, `final`, `inline` or `transparent` */
+  final val EffectivelyFinal = Private | Final | Inline | Transparent
 
   /** A private method */
   final val PrivateMethod = allOf(Private, Method)
@@ -563,11 +563,11 @@ object Flags {
   /** A transparent method */
   final val TransparentMethod = allOf(Transparent, Method)
 
-  /** A rewrite method */
-  final val RewriteMethod = allOf(Rewrite, Method)
+  /** An inline method */
+  final val InlineMethod = allOf(Inline, Method)
 
-  /** An implicit rewrite method */
-  final val ImplicitRewriteMethod = allOf(Rewrite, Implicit, Method)
+  /** An implicit inline method */
+  final val ImplicitInlineMethod = allOf(Inline, Implicit, Method)
 
   /** A transparent parameter */
   final val TransparentParam = allOf(Transparent, Param)

--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -95,7 +95,7 @@ object Mode {
   /** We are in the IDE */
   val Interactive = newMode(20, "Interactive")
 
-  /** We are typing the body of a transparent or rewrite method */
+  /** We are typing the body of a transparent or inline method */
   val InlineableBody = newMode(21, "InlineableBody")
 
   /** Read comments from definitions when unpickling from TASTY */

--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -95,7 +95,7 @@ object Mode {
   /** We are in the IDE */
   val Interactive = newMode(20, "Interactive")
 
-  /** We are typing the body of a transparent or inline method */
+  /** We are typing the body of an inline method */
   val InlineableBody = newMode(21, "InlineableBody")
 
   /** Read comments from definitions when unpickling from TASTY */

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -294,8 +294,8 @@ object NameKinds {
   val SuperArgName             = new UniqueNameKind("$superArg$")
   val DocArtifactName          = new UniqueNameKind("$doc")
   val UniqueInlineName         = new UniqueNameKind("$i")
-  val RewriteScrutineeName     = new UniqueNameKind("$scrutinee")
-  val RewriteBinderName        = new UniqueNameKind("$elem")
+  val InlineScrutineeName      = new UniqueNameKind("$scrutinee")
+  val InlineBinderName         = new UniqueNameKind("$elem")
 
   /** A kind of unique extension methods; Unlike other unique names, these can be
    *  unmangled.

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -782,14 +782,14 @@ object SymDenotations {
     def isTransparentMethod(implicit ctx: Context): Boolean =
       is(TransparentMethod, butNot = AccessorOrSynthetic)
 
-    def isRewriteMethod(implicit ctx: Context): Boolean =
-      is(RewriteMethod, butNot = AccessorOrSynthetic)
+    def isInlineMethod(implicit ctx: Context): Boolean =
+      is(InlineMethod, butNot = AccessorOrSynthetic)
 
-    /** A transparent or rewrite method */
+    /** A transparent or inline method */
     def isInlineable(implicit ctx: Context): Boolean =
-      is(TransparentMethod) || is(RewriteMethod)
+      is(TransparentMethod) || is(InlineMethod)
 
-    /** An erased value or a rewrite method, excluding @forceInline annotated methods.
+    /** An erased value or an inline method, excluding @forceInline annotated methods.
      *  The latter have to be kept around to get to parity with Scala.
      *  This is necessary at least until we have full bootstrap. Right now
      *  dotty-bootstrapped involves running the Dotty compiler compiled with Scala 2 with
@@ -799,7 +799,7 @@ object SymDenotations {
      */
     def isEffectivelyErased(implicit ctx: Context): Boolean =
       is(Erased) ||
-      isRewriteMethod && unforcedAnnotation(defn.ForceInlineAnnot).isEmpty
+      isInlineMethod && unforcedAnnotation(defn.ForceInlineAnnot).isEmpty
 
     /** ()T and => T types should be treated as equivalent for this symbol.
      *  Note: For the moment, we treat Scala-2 compiled symbols as loose matching,

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -779,15 +779,8 @@ object SymDenotations {
 
     def isSkolem: Boolean = name == nme.SKOLEM
 
-    def isTransparentMethod(implicit ctx: Context): Boolean =
-      is(TransparentMethod, butNot = AccessorOrSynthetic)
-
     def isInlineMethod(implicit ctx: Context): Boolean =
       is(InlineMethod, butNot = AccessorOrSynthetic)
-
-    /** A transparent or inline method */
-    def isInlineable(implicit ctx: Context): Boolean =
-      is(TransparentMethod) || is(InlineMethod)
 
     /** An erased value or an inline method, excluding @forceInline annotated methods.
      *  The latter have to be kept around to get to parity with Scala.

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -279,8 +279,8 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
     violations.toList
   }
 
-  /** Are we in a rewrite method body? */
-  def inRewriteMethod = owner.ownersIterator.exists(_.isRewriteMethod)
+  /** Are we in an inline method body? */
+  def inInlineMethod = owner.ownersIterator.exists(_.isInlineMethod)
 
   /** Is `feature` enabled in class `owner`?
    *  This is the case if one of the following two alternatives holds:

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3031,18 +3031,18 @@ object Types {
   abstract class MethodTypeCompanion extends TermLambdaCompanion[MethodType] { self =>
 
     /** Produce method type from parameter symbols, with special mappings for repeated
-     *  and transparent parameters:
+     *  and inline parameters:
      *   - replace @repeated annotations on Seq or Array types by <repeated> types
-     *   - add @inlineParam to transparent call-by-value parameters
+     *   - add @inlineParam to inline call-by-value parameters
      */
     def fromSymbols(params: List[Symbol], resultType: Type)(implicit ctx: Context) = {
-      def translateTransparent(tp: Type): Type = tp match {
+      def translateInline(tp: Type): Type = tp match {
         case _: ExprType => tp
-        case _ => AnnotatedType(tp, Annotation(defn.TransparentParamAnnot))
+        case _ => AnnotatedType(tp, Annotation(defn.InlineParamAnnot))
       }
       def paramInfo(param: Symbol) = {
         val paramType = param.info.annotatedToRepeated
-        if (param.is(Transparent)) translateTransparent(paramType) else paramType
+        if (param.is(Inline)) translateInline(paramType) else paramType
       }
 
       apply(params.map(_.name.asTermName))(

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -183,7 +183,6 @@ Standard-Section: "ASTs" TopLevelStat*
                   ERASED
                   LAZY
                   OVERRIDE
-                  TRANSPARENT
                   INLINE
                   MACRO                               // inline method containing toplevel splices
                   STATIC                              // mapped to static Java member
@@ -299,7 +298,7 @@ object TastyFormat {
   final val IMPLICIT = 13
   final val LAZY = 14
   final val OVERRIDE = 15
-  final val TRANSPARENT = 16
+
   final val INLINE = 17
   final val STATIC = 18
   final val OBJECT = 19
@@ -481,7 +480,6 @@ object TastyFormat {
        | ERASED
        | LAZY
        | OVERRIDE
-       | TRANSPARENT
        | INLINE
        | MACRO
        | STATIC
@@ -539,7 +537,6 @@ object TastyFormat {
     case ERASED => "ERASED"
     case LAZY => "LAZY"
     case OVERRIDE => "OVERRIDE"
-    case TRANSPARENT => "TRANSPARENT"
     case INLINE => "INLINE"
     case MACRO => "MACRO"
     case STATIC => "STATIC"

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -184,8 +184,8 @@ Standard-Section: "ASTs" TopLevelStat*
                   LAZY
                   OVERRIDE
                   TRANSPARENT
-                  REWRITE
-                  MACRO                               // rewrite method containing toplevel splices
+                  INLINE
+                  MACRO                               // inline method containing toplevel splices
                   STATIC                              // mapped to static Java member
                   OBJECT                              // an object or its class
                   TRAIT                               // a trait
@@ -300,7 +300,7 @@ object TastyFormat {
   final val LAZY = 14
   final val OVERRIDE = 15
   final val TRANSPARENT = 16
-  final val REWRITE = 17
+  final val INLINE = 17
   final val STATIC = 18
   final val OBJECT = 19
   final val TRAIT = 20
@@ -482,7 +482,7 @@ object TastyFormat {
        | LAZY
        | OVERRIDE
        | TRANSPARENT
-       | REWRITE
+       | INLINE
        | MACRO
        | STATIC
        | OBJECT
@@ -540,7 +540,7 @@ object TastyFormat {
     case LAZY => "LAZY"
     case OVERRIDE => "OVERRIDE"
     case TRANSPARENT => "TRANSPARENT"
-    case REWRITE => "REWRITE"
+    case INLINE => "INLINE"
     case MACRO => "MACRO"
     case STATIC => "STATIC"
     case OBJECT => "OBJECT"

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -617,7 +617,7 @@ class TreePickler(pickler: TastyPickler) {
     if (flags is Case) writeByte(CASE)
     if (flags is Override) writeByte(OVERRIDE)
     if (flags is Transparent) writeByte(TRANSPARENT)
-    if (flags is Rewrite) writeByte(REWRITE)
+    if (flags is Inline) writeByte(INLINE)
     if (flags is Macro) writeByte(MACRO)
     if (flags is JavaStatic) writeByte(STATIC)
     if (flags is Module) writeByte(OBJECT)
@@ -782,13 +782,13 @@ class TreePickler(pickler: TastyPickler) {
       case If(cond, thenp, elsep) =>
         writeByte(IF)
         withLength {
-          if (tree.isInstanceOf[untpd.RewriteIf]) writeByte(REWRITE)
+          if (tree.isInstanceOf[untpd.InlineIf]) writeByte(INLINE)
           pickleUntyped(cond); pickleUntyped(thenp); pickleUntyped(elsep)
         }
       case Match(selector, cases) =>
         writeByte(MATCH)
         withLength {
-          if (tree.isInstanceOf[untpd.RewriteMatch]) writeByte(REWRITE)
+          if (tree.isInstanceOf[untpd.InlineMatch]) writeByte(INLINE)
           pickleUntyped(selector); cases.foreach(pickleUntyped)
         }
       case CaseDef(pat, guard, rhs) =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -616,7 +616,6 @@ class TreePickler(pickler: TastyPickler) {
     if (flags.is(Final, butNot = Module)) writeByte(FINAL)
     if (flags is Case) writeByte(CASE)
     if (flags is Override) writeByte(OVERRIDE)
-    if (flags is Transparent) writeByte(TRANSPARENT)
     if (flags is Inline) writeByte(INLINE)
     if (flags is Macro) writeByte(MACRO)
     if (flags is JavaStatic) writeByte(STATIC)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -591,7 +591,6 @@ class TreeUnpickler(reader: TastyReader,
           case ERASED => addFlag(Erased)
           case LAZY => addFlag(Lazy)
           case OVERRIDE => addFlag(Override)
-          case TRANSPARENT => addFlag(Transparent)
           case INLINE => addFlag(Inline)
           case MACRO => addFlag(Macro)
           case STATIC => addFlag(JavaStatic)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -592,7 +592,7 @@ class TreeUnpickler(reader: TastyReader,
           case LAZY => addFlag(Lazy)
           case OVERRIDE => addFlag(Override)
           case TRANSPARENT => addFlag(Transparent)
-          case REWRITE => addFlag(Rewrite)
+          case INLINE => addFlag(Inline)
           case MACRO => addFlag(Macro)
           case STATIC => addFlag(JavaStatic)
           case OBJECT => addFlag(Module)
@@ -1315,12 +1315,12 @@ class TreeUnpickler(reader: TastyReader,
             val stats = until(end)(readUntyped())
             untpd.Block(stats, expr)
           case IF =>
-            val mkIf = if (nextByte == REWRITE) { readByte(); untpd.RewriteIf(_, _, _) }
+            val mkIf = if (nextByte == INLINE) { readByte(); untpd.InlineIf(_, _, _) }
               else untpd.If(_, _, _)
             mkIf(readUntyped(), readUntyped(), readUntyped())
           case MATCH =>
             val mkMatch =
-              if (nextByte == REWRITE) { readByte(); untpd.RewriteMatch(_, _) }
+              if (nextByte == INLINE) { readByte(); untpd.InlineMatch(_, _) }
               else untpd.Match(_, _)
             mkMatch(readUntyped(), readCases(end))
           case CASEDEF =>

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1778,7 +1778,6 @@ object Parsers {
       case FINAL       => Mod.Final()
       case IMPLICIT    => Mod.Implicit()
       case ERASED      => Mod.Erased()
-      case TRANSPARENT => Mod.Transparent()
       case LAZY        => Mod.Lazy()
       case OVERRIDE    => Mod.Override()
       case PRIVATE     => Mod.Private()
@@ -1988,7 +1987,7 @@ object Parsers {
                 addMod(mods, mod)
               }
               else {
-                if (!(mods.flags &~ (ParamAccessor | Transparent)).isEmpty)
+                if (!(mods.flags &~ (ParamAccessor | Inline)).isEmpty)
                   syntaxError("`val' or `var' expected")
                 if (firstClauseOfCaseClass) mods
                 else mods | PrivateLocal
@@ -1996,7 +1995,7 @@ object Parsers {
             }
         }
         else {
-          if (in.token == TRANSPARENT) mods = addModifier(mods)
+          if (isIdent(nme.INLINEkw)) mods = addModifier(mods)
           mods = atPos(start) { mods | Param }
         }
         atPos(start, nameStart) {

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -200,8 +200,7 @@ object Scanners {
     private def handleMigration(keyword: Token): Token =
       if (!isScala2Mode) keyword
       else if (  keyword == ENUM
-              || keyword == ERASED
-              || keyword == TRANSPARENT) treatAsIdent()
+              || keyword == ERASED) treatAsIdent()
       else keyword
 
 

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -91,9 +91,8 @@ abstract class TokensCommon {
   //final val LAZY = 59;             enter(LAZY, "lazy")
   //final val THEN = 60;             enter(THEN, "then")
   //final val FORSOME = 61;          enter(FORSOME, "forSome") // TODO: deprecate
-  //final val TRANSPARENT = 63;      enter(TRANSPARENT, "transparent")
-  //final val ENUM = 64;             enter(ENUM, "enum")
-  //final val ERASED = 65;           enter(ERASED, "erased")
+  //final val ENUM = 62;             enter(ENUM, "enum")
+  //final val ERASED = 63;           enter(ERASED, "erased")
 
   /** special symbols */
   final val COMMA = 70;            enter(COMMA, "','")
@@ -176,9 +175,8 @@ object Tokens extends TokensCommon {
   final val LAZY = 59;             enter(LAZY, "lazy")
   final val THEN = 60;             enter(THEN, "then")
   final val FORSOME = 61;          enter(FORSOME, "forSome") // TODO: deprecate
-  final val TRANSPARENT = 63;      enter(TRANSPARENT, "transparent")
-  final val ENUM = 64;             enter(ENUM, "enum")
-  final val ERASED = 65;           enter(ERASED, "erased")
+  final val ENUM = 62;             enter(ENUM, "enum")
+  final val ERASED = 63;           enter(ERASED, "erased")
 
   /** special symbols */
   final val NEWLINE = 78;          enter(NEWLINE, "end of statement", "new line")
@@ -227,7 +225,7 @@ object Tokens extends TokensCommon {
   final val defIntroTokens = templateIntroTokens | dclIntroTokens
 
   final val localModifierTokens = BitSet(
-    ABSTRACT, FINAL, SEALED, IMPLICIT, TRANSPARENT, LAZY, ERASED)
+    ABSTRACT, FINAL, SEALED, IMPLICIT, LAZY, ERASED)
 
   final val accessModifierTokens = BitSet(
     PRIVATE, PROTECTED)

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -91,7 +91,6 @@ abstract class TokensCommon {
   //final val LAZY = 59;             enter(LAZY, "lazy")
   //final val THEN = 60;             enter(THEN, "then")
   //final val FORSOME = 61;          enter(FORSOME, "forSome") // TODO: deprecate
-  //final val INLINE = 62;           enter(INLINE, "inline")
   //final val TRANSPARENT = 63;      enter(TRANSPARENT, "transparent")
   //final val ENUM = 64;             enter(ENUM, "enum")
   //final val ERASED = 65;           enter(ERASED, "erased")
@@ -177,7 +176,6 @@ object Tokens extends TokensCommon {
   final val LAZY = 59;             enter(LAZY, "lazy")
   final val THEN = 60;             enter(THEN, "then")
   final val FORSOME = 61;          enter(FORSOME, "forSome") // TODO: deprecate
-  final val INLINE = 62;           enter(INLINE, "inline")
   final val TRANSPARENT = 63;      enter(TRANSPARENT, "transparent")
   final val ENUM = 64;             enter(ENUM, "enum")
   final val ERASED = 65;           enter(ERASED, "erased")
@@ -215,7 +213,7 @@ object Tokens extends TokensCommon {
     USCORE, NULL, THIS, SUPER, TRUE, FALSE, RETURN, XMLSTART)
 
   final val canStartExpressionTokens = atomicExprTokens | BitSet(
-    LBRACE, LPAREN, QBRACE, QPAREN, IF, DO, WHILE, FOR, NEW, TRY, THROW, INLINE)
+    LBRACE, LPAREN, QBRACE, QPAREN, IF, DO, WHILE, FOR, NEW, TRY, THROW)
 
   final val canStartTypeTokens = literalTokens | identifierTokens | BitSet(
     THIS, SUPER, USCORE, LPAREN, AT)
@@ -229,7 +227,7 @@ object Tokens extends TokensCommon {
   final val defIntroTokens = templateIntroTokens | dclIntroTokens
 
   final val localModifierTokens = BitSet(
-    ABSTRACT, FINAL, SEALED, IMPLICIT, INLINE, TRANSPARENT, LAZY, ERASED)
+    ABSTRACT, FINAL, SEALED, IMPLICIT, TRANSPARENT, LAZY, ERASED)
 
   final val accessModifierTokens = BitSet(
     PRIVATE, PROTECTED)
@@ -240,8 +238,7 @@ object Tokens extends TokensCommon {
   final val modifierTokensOrCase = modifierTokens | BitSet(CASE)
 
   /** Is token only legal as start of statement (eof also included)? */
-  final val mustStartStatTokens = defIntroTokens | (modifierTokens - INLINE) | BitSet(
-    IMPORT, PACKAGE)
+  final val mustStartStatTokens = defIntroTokens | modifierTokens | BitSet(IMPORT, PACKAGE)
 
   final val canStartStatTokens = canStartExpressionTokens | mustStartStatTokens | BitSet(
     AT, CASE)

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -91,7 +91,7 @@ abstract class TokensCommon {
   //final val LAZY = 59;             enter(LAZY, "lazy")
   //final val THEN = 60;             enter(THEN, "then")
   //final val FORSOME = 61;          enter(FORSOME, "forSome") // TODO: deprecate
-  //final val REWRITE = 62;          enter(REWRITE, "rewrite")
+  //final val INLINE = 62;           enter(INLINE, "inline")
   //final val TRANSPARENT = 63;      enter(TRANSPARENT, "transparent")
   //final val ENUM = 64;             enter(ENUM, "enum")
   //final val ERASED = 65;           enter(ERASED, "erased")
@@ -177,7 +177,7 @@ object Tokens extends TokensCommon {
   final val LAZY = 59;             enter(LAZY, "lazy")
   final val THEN = 60;             enter(THEN, "then")
   final val FORSOME = 61;          enter(FORSOME, "forSome") // TODO: deprecate
-  final val REWRITE = 62;          enter(REWRITE, "rewrite")
+  final val INLINE = 62;           enter(INLINE, "inline")
   final val TRANSPARENT = 63;      enter(TRANSPARENT, "transparent")
   final val ENUM = 64;             enter(ENUM, "enum")
   final val ERASED = 65;           enter(ERASED, "erased")
@@ -215,7 +215,7 @@ object Tokens extends TokensCommon {
     USCORE, NULL, THIS, SUPER, TRUE, FALSE, RETURN, XMLSTART)
 
   final val canStartExpressionTokens = atomicExprTokens | BitSet(
-    LBRACE, LPAREN, QBRACE, QPAREN, IF, DO, WHILE, FOR, NEW, TRY, THROW, REWRITE)
+    LBRACE, LPAREN, QBRACE, QPAREN, IF, DO, WHILE, FOR, NEW, TRY, THROW, INLINE)
 
   final val canStartTypeTokens = literalTokens | identifierTokens | BitSet(
     THIS, SUPER, USCORE, LPAREN, AT)
@@ -229,7 +229,7 @@ object Tokens extends TokensCommon {
   final val defIntroTokens = templateIntroTokens | dclIntroTokens
 
   final val localModifierTokens = BitSet(
-    ABSTRACT, FINAL, SEALED, IMPLICIT, REWRITE, TRANSPARENT, LAZY, ERASED)
+    ABSTRACT, FINAL, SEALED, IMPLICIT, INLINE, TRANSPARENT, LAZY, ERASED)
 
   final val accessModifierTokens = BitSet(
     PRIVATE, PROTECTED)
@@ -240,7 +240,7 @@ object Tokens extends TokensCommon {
   final val modifierTokensOrCase = modifierTokens | BitSet(CASE)
 
   /** Is token only legal as start of statement (eof also included)? */
-  final val mustStartStatTokens = defIntroTokens | (modifierTokens - REWRITE) | BitSet(
+  final val mustStartStatTokens = defIntroTokens | (modifierTokens - INLINE) | BitSet(
     IMPORT, PACKAGE)
 
   final val canStartStatTokens = canStartExpressionTokens | mustStartStatTokens | BitSet(

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -125,7 +125,7 @@ public enum ErrorMessageID {
     UnableToEmitSwitchID,
     MissingCompanionForStaticID,
     PolymorphicMethodMissingTypeInParentID,
-    ParamsNoTransparentID,
+    ParamsNoInlineID,
     JavaSymbolIsNotAValueID,
     DoubleDeclarationID,
     MatchCaseOnlyNullWarningID,

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1736,7 +1736,7 @@ object messages {
     val kind = "Syntax"
     val msg = hl"no explicit ${"return"} allowed from inlineable $owner"
     val explanation =
-      hl"""Methods marked with ${"inline"} or  ${"transparent"} modifier may not use ${"return"} statements.
+      hl"""Methods marked with ${"inline"} modifier may not use ${"return"} statements.
           |Instead, you should rely on the last expression's value being
           |returned from a method.
           |"""
@@ -2042,10 +2042,10 @@ object messages {
           |polymorphic methods."""
   }
 
-  case class ParamsNoTransparent(owner: Symbol)(implicit ctx: Context)
-    extends Message(ParamsNoTransparentID) {
+  case class ParamsNoInline(owner: Symbol)(implicit ctx: Context)
+    extends Message(ParamsNoInlineID) {
     val kind = "Syntax"
-    val msg = hl"""${"transparent"} modifier can only be used for parameters of inline methods"""
+    val msg = hl"""${"inline"} modifier can only be used for parameters of inline methods"""
     val explanation = ""
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1736,7 +1736,7 @@ object messages {
     val kind = "Syntax"
     val msg = hl"no explicit ${"return"} allowed from inlineable $owner"
     val explanation =
-      hl"""Methods marked with ${"rewrite"} or  ${"transparent"} modifier may not use ${"return"} statements.
+      hl"""Methods marked with ${"inline"} or  ${"transparent"} modifier may not use ${"return"} statements.
           |Instead, you should rely on the last expression's value being
           |returned from a method.
           |"""
@@ -2045,7 +2045,7 @@ object messages {
   case class ParamsNoTransparent(owner: Symbol)(implicit ctx: Context)
     extends Message(ParamsNoTransparentID) {
     val kind = "Syntax"
-    val msg = hl"""${"transparent"} modifier can only be used for parameters of rewrite methods"""
+    val msg = hl"""${"transparent"} modifier can only be used for parameters of inline methods"""
     val explanation = ""
   }
 

--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -63,7 +63,7 @@ object Rewrites {
    *  given by `pos` in `source` by `replacement`
    */
   def patch(source: SourceFile, pos: Position, replacement: String)(implicit ctx: Context): Unit =
-    for (rewrites <- ctx.settings.`rewrite`.value)
+    for (rewrites <- ctx.settings.rewrite.value)
       rewrites.patched
         .getOrElseUpdate(source, new Patches(source))
         .addPatch(pos, replacement)
@@ -75,7 +75,7 @@ object Rewrites {
   /** If -rewrite is set, apply all patches and overwrite patched source files.
    */
   def writeBack()(implicit ctx: Context) =
-    for (rewrites <- ctx.settings.`rewrite`.value; source <- rewrites.patched.keys) {
+    for (rewrites <- ctx.settings.rewrite.value; source <- rewrites.patched.keys) {
       ctx.echo(s"[patched file ${source.file.path}]")
       rewrites.patched(source).writeBack()
     }

--- a/compiler/src/dotty/tools/dotc/tastyreflect/FlagSet.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/FlagSet.scala
@@ -15,7 +15,7 @@ class FlagSet(flags: Flags.FlagSet) extends scala.tasty.reflect.FlagSet {
   def isLazy: Boolean = flags.is(Lazy)
   def isOverride: Boolean = flags.is(Override)
   def isTransparent: Boolean = flags.is(Transparent)
-  def isRewrite: Boolean = flags.is(Rewrite)
+  def isInline: Boolean = flags.is(Inline)
   def isMacro: Boolean = flags.is(Macro)
   def isStatic: Boolean = flags.is(JavaStatic)
   def isObject: Boolean = flags.is(Module)
@@ -47,7 +47,7 @@ class FlagSet(flags: Flags.FlagSet) extends scala.tasty.reflect.FlagSet {
     if (isLazy) flags += "lazy"
     if (isOverride) flags += "override"
     if (isTransparent) flags += "transparent"
-    if (isRewrite) flags += "rewrite"
+    if (isInline) flags += "inline"
     if (isMacro) flags += "macro"
     if (isStatic) flags += "javaStatic"
     if (isObject) flags += "object"

--- a/compiler/src/dotty/tools/dotc/tastyreflect/FlagSet.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/FlagSet.scala
@@ -14,7 +14,6 @@ class FlagSet(flags: Flags.FlagSet) extends scala.tasty.reflect.FlagSet {
   def isErased: Boolean = flags.is(Erased)
   def isLazy: Boolean = flags.is(Lazy)
   def isOverride: Boolean = flags.is(Override)
-  def isTransparent: Boolean = flags.is(Transparent)
   def isInline: Boolean = flags.is(Inline)
   def isMacro: Boolean = flags.is(Macro)
   def isStatic: Boolean = flags.is(JavaStatic)
@@ -46,7 +45,6 @@ class FlagSet(flags: Flags.FlagSet) extends scala.tasty.reflect.FlagSet {
     if (isErased) flags += "erased"
     if (isLazy) flags += "lazy"
     if (isOverride) flags += "override"
-    if (isTransparent) flags += "transparent"
     if (isInline) flags += "inline"
     if (isMacro) flags += "macro"
     if (isStatic) flags += "javaStatic"

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -21,7 +21,7 @@ import Decorators._
 import SymUtils._
 
 /**
- * Perform Step 1 in the transparent classes SIP: Creates extension methods for all
+ * Perform Step 1 in the inline classes SIP: Creates extension methods for all
  * methods in a value class, except parameter or super accessors, or constructors.
  *
  * Additionally, for a value class V, let U be the underlying type after erasure. We add

--- a/compiler/src/dotty/tools/dotc/transform/Literalize.scala.disabled
+++ b/compiler/src/dotty/tools/dotc/transform/Literalize.scala.disabled
@@ -38,7 +38,7 @@ class Literalize extends MiniPhase { thisTransform =>
    *  Singleton type bounds (see SIP 23). Presumably
    *
    *     object O1 { val x: Singleton = 42; println("43") }
-   *     object O2 { transparent val x = 42; println("43") }
+   *     object O2 { inline val x = 42; println("43") }
    *
    *  should behave differently.
    *

--- a/compiler/src/dotty/tools/dotc/transform/Memoize.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Memoize.scala
@@ -105,7 +105,7 @@ class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
         cpy.installAfter(thisPhase)
       }
 
-    val NoFieldNeeded = Lazy | Deferred | JavaDefined | (if (ctx.settings.YnoInline.value) EmptyFlags else Transparent)
+    val NoFieldNeeded = Lazy | Deferred | JavaDefined | (if (ctx.settings.YnoInline.value) EmptyFlags else Inline)
 
     def erasedBottomTree(sym: Symbol) = {
       if (sym eq defn.NothingClass) Throw(Literal(Constant(null)))

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -156,7 +156,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
         }
     }
 
-    /** 1. If we are in a rewrite method but not in a nested quote, mark the rewrite method
+    /** 1. If we are in an inline method but not in a nested quote, mark the inline method
      *  as a macro.
      *
      *  2. If selection is a quote or splice node, record that fact in the current compilation unit.
@@ -165,7 +165,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
 
       def markAsMacro(c: Context): Unit =
         if (c.owner eq c.outer.owner) markAsMacro(c.outer)
-        else if (c.owner.isRewriteMethod) {
+        else if (c.owner.isInlineMethod) {
           c.owner.setFlag(Macro)
         }
         else if (!c.outer.owner.is(Package)) markAsMacro(c.outer)

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -230,7 +230,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
     }
 
     /** Does the level of `sym` match the current level?
-     *  An exception is made for transparent vals in macros. These are also OK if their level
+     *  An exception is made for inline vals in macros. These are also OK if their level
      *  is one higher than the current level, because on execution such values
      *  are constant expression trees and we can pull out the constant from the tree.
      */
@@ -439,7 +439,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
         splice
       }
       else { // level 0 inside an inline definition
-        ctx.error("Malformed macro call. The contents of the ~ must call a static method and arguments must be quoted or transparent.".stripMargin, splice.pos)
+        ctx.error("Malformed macro call. The contents of the ~ must call a static method and arguments must be quoted or inline.".stripMargin, splice.pos)
         splice
       }
     }
@@ -550,7 +550,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
             splice(ref(splicedType).select(tpnme.UNARY_~).withPos(tree.pos))
           case tree: Select if tree.symbol.isSplice =>
             splice(tree)
-          case tree: RefTree if tree.symbol.is(Transparent) && tree.symbol.is(Param) =>
+          case tree: RefTree if tree.symbol.is(Inline) && tree.symbol.is(Param) =>
             tree
           case tree: RefTree if isCaptured(tree.symbol, level) =>
             val t = capturers(tree.symbol).apply(tree)

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -76,7 +76,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
 
   override def checkPostCondition(tree: Tree)(implicit ctx: Context): Unit = {
     tree match {
-      case tree: RefTree if !ctx.inRewriteMethod =>
+      case tree: RefTree if !ctx.inInlineMethod =>
         assert(!tree.symbol.isQuote)
         // assert(!tree.symbol.isSplice) // TODO widen ~ type references at stage 0?
         assert(tree.symbol != defn.QuotedExpr_~)
@@ -117,7 +117,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
    *  @param  outer      the next outer reifier, null is this is the topmost transformer
    *  @param  level      the current level, where quotes add one and splices subtract one level.
    *                     The initial level is 0, a level `l` where `l > 0` implies code has been quoted `l` times
-   *                     and `l == -1` is code inside a top level splice (in a rewrite method).
+   *                     and `l == -1` is code inside a top level splice (in an inline method).
    *  @param  levels     a stacked map from symbols to the levels in which they were defined
    *  @param  embedded   a list of embedded quotes (if `inSplice = true`) or splices (if `inQuote = true`
    */
@@ -250,7 +250,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
     def tryHeal(tp: Type, pos: Position)(implicit ctx: Context): Option[String] = tp match {
       case tp: TypeRef =>
         if (level == -1) {
-          assert(ctx.inRewriteMethod)
+          assert(ctx.inInlineMethod)
           None
         } else {
           val reqType = defn.QuotedTypeType.appliedTo(tp)
@@ -281,7 +281,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
         else i"${sym.name}.this"
       if (!isThis && sym.maybeOwner.isType && !sym.is(Param))
         check(sym.owner, sym.owner.thisType, pos)
-      else if (level == 1 && sym.isType && sym.is(Param) && sym.owner.isRewriteMethod && !outer.isRoot)
+      else if (level == 1 && sym.isType && sym.is(Param) && sym.owner.isInlineMethod && !outer.isRoot)
         importedTags(sym.typeRef) = capturers(sym)(ref(sym))
       else if (sym.exists && !sym.isStaticOwner && !levelOK(sym))
         for (errMsg <- tryHeal(tp, pos))
@@ -372,9 +372,9 @@ class ReifyQuotes extends MacroTransformWithImplicits {
           capturers(body.symbol)(body)
         case _=>
           val (body1, splices) = nested(isQuote = true).split(body)
-          if (level == 0 && !ctx.inRewriteMethod) pickledQuote(body1, splices, body.tpe, isType).withPos(quote.pos)
+          if (level == 0 && !ctx.inInlineMethod) pickledQuote(body1, splices, body.tpe, isType).withPos(quote.pos)
           else {
-            // In top-level splice in a rewrite def. Keep the tree as it is, it will be transformed at inline site.
+            // In top-level splice in an inline def. Keep the tree as it is, it will be transformed at inline site.
             body
           }
       }
@@ -413,7 +413,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
 
     /** If inside a quote, split the body of the splice into a core and a list of embedded quotes
      *  and make a hole from these parts. Otherwise issue an error, unless we
-     *  are in the body of a rewrite method.
+     *  are in the body of an inline method.
      */
     private def splice(splice: Select)(implicit ctx: Context): Tree = {
       if (level > 1) {
@@ -430,15 +430,15 @@ class ReifyQuotes extends MacroTransformWithImplicits {
         val evaluatedSplice = Splicer.splice(splice.qualifier, pos, macroClassLoader)(spliceCtx).withPos(splice.pos)
         if (ctx.reporter.hasErrors) splice else transform(evaluatedSplice)
       }
-      else if (!ctx.owner.isRewriteMethod) { // level 0 outside a rewrite method
-        ctx.error(i"splice outside quotes or rewrite method", splice.pos)
+      else if (!ctx.owner.isInlineMethod) { // level 0 outside an inline method
+        ctx.error(i"splice outside quotes or inline method", splice.pos)
         splice
       }
-      else if (Splicer.canBeSpliced(splice.qualifier)) { // level 0 inside a rewrite definition
+      else if (Splicer.canBeSpliced(splice.qualifier)) { // level 0 inside an inline definition
         nested(isQuote = false).split(splice.qualifier) // Just check PCP
         splice
       }
-      else { // level 0 inside a rewrite definition
+      else { // level 0 inside an inline definition
         ctx.error("Malformed macro call. The contents of the ~ must call a static method and arguments must be quoted or transparent.".stripMargin, splice.pos)
         splice
       }
@@ -504,7 +504,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
       val captured = mutable.LinkedHashMap.empty[Symbol, Tree]
       val captured2 = capturer(captured)
 
-      outer.enteredSyms.foreach(sym => if (!sym.isRewriteMethod) capturers.put(sym, captured2))
+      outer.enteredSyms.foreach(sym => if (!sym.isInlineMethod) capturers.put(sym, captured2))
 
       val tree2 = transform(tree)
       capturers --= outer.enteredSyms
@@ -584,7 +584,7 @@ class ReifyQuotes extends MacroTransformWithImplicits {
                   """Malformed macro.
                     |
                     |Expected the ~ to be at the top of the RHS:
-                    |  rewrite def foo(x: X, ..., y: Y): Int = ~impl(x, ... '(y))
+                    |  inline def foo(x: X, ..., y: Y): Int = ~impl(x, ... '(y))
                     |
                     |The contents of the splice must call a static method. Arguments must be quoted or inlined.
                   """.stripMargin, tree.rhs.pos)

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -239,7 +239,7 @@ object Splicer {
     def interpretStaticMethodCall(fn: tpd.Tree, args: => List[Boolean])(implicit env: Env): Boolean = args.forall(identity)
 
     def unexpectedTree(tree: tpd.Tree)(implicit env: Env): Boolean = {
-      // Assuming that top-level splices can only be in rewrite methods
+      // Assuming that top-level splices can only be in inline methods
       // and splices are expanded at inline site, references to transparent values
       // will be known literal constant trees.
       tree.symbol.is(Transparent)

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -240,13 +240,13 @@ object Splicer {
 
     def unexpectedTree(tree: tpd.Tree)(implicit env: Env): Boolean = {
       // Assuming that top-level splices can only be in inline methods
-      // and splices are expanded at inline site, references to transparent values
+      // and splices are expanded at inline site, references to inline values
       // will be known literal constant trees.
-      tree.symbol.is(Transparent)
+      tree.symbol.is(Inline)
     }
   }
 
-  /** Abstract Tree interpreter that can interpret calls to static methods with quoted or transparent arguments */
+  /** Abstract Tree interpreter that can interpret calls to static methods with quoted or inline arguments */
   private abstract class AbstractInterpreter(implicit ctx: Context) {
     type Env = Map[Name, Result]
     type Result

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -967,8 +967,8 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       else trySelectUnapply(qual1)(_ => notAnExtractor(sel))
     }
 
-    if (unapplyFn.symbol.isRewriteMethod)
-      checkInRewriteContext("implementation restriction: call to rewrite unapply", tree.pos)
+    if (unapplyFn.symbol.isInlineMethod)
+      checkInInlineContext("implementation restriction: call to inline unapply", tree.pos)
 
     /** Add a `Bind` node for each `bound` symbol in a type application `unapp` */
     def addBinders(unapp: Tree, bound: List[Symbol]) = unapp match {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -621,14 +621,14 @@ trait Implicits { self: Typer =>
         val tag = bindFreeVars(arg)
         if (bindFreeVars.ok) ref(defn.QuotedType_apply).appliedToType(tag)
         else EmptyTree
-      case arg :: Nil if ctx.inRewriteMethod =>
+      case arg :: Nil if ctx.inInlineMethod =>
         ref(defn.QuotedType_apply).appliedToType(arg)
       case _ =>
         EmptyTree
     }
 
     def synthesizedTastyContext(formal: Type): Tree =
-      if (ctx.inRewriteMethod || enclosingInlineds.nonEmpty) ref(defn.TastyTasty_macroContext)
+      if (ctx.inInlineMethod || enclosingInlineds.nonEmpty) ref(defn.TastyTasty_macroContext)
       else EmptyTree
 
     /** If `formal` is of the form Eq[T, U], where no `Eq` instance exists for

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -760,7 +760,7 @@ class Namer { typer: Typer =>
     }
 
     private def addInlineInfo(sym: Symbol) = original match {
-      case original: untpd.DefDef if sym.isInlineable =>
+      case original: untpd.DefDef if sym.isInlineMethod =>
         PrepareInlineable.registerInlineInfo(
             sym,
             original.rhs,
@@ -1075,13 +1075,13 @@ class Namer { typer: Typer =>
 
       // println(s"final inherited for $sym: ${inherited.toString}") !!!
       // println(s"owner = ${sym.owner}, decls = ${sym.owner.info.decls.show}")
-      def isTransparentVal = sym.is(FinalOrTransparent, butNot = Method | Mutable)
+      def isInlineVal = sym.is(FinalOrInline, butNot = Method | Mutable)
 
       // Widen rhs type and eliminate `|' but keep ConstantTypes if
       // definition is inline (i.e. final in Scala2) and keep module singleton types
       // instead of widening to the underlying module class types.
       def widenRhs(tp: Type): Type = tp.widenTermRefExpr match {
-        case ctp: ConstantType if isTransparentVal => ctp
+        case ctp: ConstantType if isInlineVal => ctp
         case ref: TypeRef if ref.symbol.is(ModuleClass) => tp
         case _ => tp.widen.widenUnion
       }
@@ -1091,7 +1091,7 @@ class Namer { typer: Typer =>
       def dealiasIfUnit(tp: Type) = if (tp.isRef(defn.UnitClass)) defn.UnitType else tp
 
       var rhsCtx = ctx.addMode(Mode.InferringReturnType)
-      if (sym.isInlineable) rhsCtx = rhsCtx.addMode(Mode.InlineableBody)
+      if (sym.isInlineMethod) rhsCtx = rhsCtx.addMode(Mode.InlineableBody)
       def rhsType = typedAheadExpr(mdef.rhs, inherited orElse rhsProto)(rhsCtx).tpe
 
       // Approximate a type `tp` with a type that does not contain skolem types.
@@ -1111,7 +1111,7 @@ class Namer { typer: Typer =>
         if (sym.is(Final, butNot = Method)) {
           val tp = lhsType
           if (tp.isInstanceOf[ConstantType])
-            tp // keep constant types that fill in for a non-constant (to be revised when transparent has landed).
+            tp // keep constant types that fill in for a non-constant (to be revised when inline has landed).
           else inherited
         }
         else inherited

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -754,7 +754,7 @@ class Namer { typer: Typer =>
           val ann = Annotation.deferred(cls, implicit ctx => typedAnnotation(annotTree))
           sym.addAnnotation(ann)
           if (cls == defn.ForceInlineAnnot && sym.is(Method, butNot = Accessor))
-            sym.setFlag(Rewrite)
+            sym.setFlag(Inline)
         }
       case _ =>
     }

--- a/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
@@ -95,7 +95,7 @@ object PrepareInlineable {
       def preTransform(tree: Tree)(implicit ctx: Context): Tree = tree match {
         case tree: RefTree if needsAccessor(tree.symbol) =>
           if (tree.symbol.isConstructor) {
-            ctx.error("Implementation restriction: cannot use private constructors in transparent or inline methods", tree.pos)
+            ctx.error("Implementation restriction: cannot use private constructors in inlineinline methods", tree.pos)
             tree // TODO: create a proper accessor for the private constructor
           }
           else useAccessor(tree)

--- a/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
@@ -61,17 +61,17 @@ object PrepareInlineable {
 
       /** A definition needs an accessor if it is private, protected, or qualified private
        *  and it is not part of the tree that gets inlined. The latter test is implemented
-       *  by excluding all symbols properly contained in the inlined method.
+       *  by excluding all symbols properly contained in the inline method.
        *
        *  Constant vals don't need accessors since they are inlined in FirstTransform.
-       *  Rewrite methods don't need accessors since they are inlined in Typer.
+       *  Inline methods don't need accessors since they are inlined in Typer.
        */
       def needsAccessor(sym: Symbol)(implicit ctx: Context) =
         sym.isTerm &&
         (sym.is(AccessFlags) || sym.privateWithin.exists) &&
         !sym.isContainedIn(inlineSym) &&
         !(sym.isStable && sym.info.widenTermRefExpr.isInstanceOf[ConstantType]) &&
-        !sym.isRewriteMethod
+        !sym.isInlineMethod
 
       def preTransform(tree: Tree)(implicit ctx: Context): Tree
 
@@ -95,7 +95,7 @@ object PrepareInlineable {
       def preTransform(tree: Tree)(implicit ctx: Context): Tree = tree match {
         case tree: RefTree if needsAccessor(tree.symbol) =>
           if (tree.symbol.isConstructor) {
-            ctx.error("Implementation restriction: cannot use private constructors in transparent or rewrite methods", tree.pos)
+            ctx.error("Implementation restriction: cannot use private constructors in transparent or inline methods", tree.pos)
             tree // TODO: create a proper accessor for the private constructor
           }
           else useAccessor(tree)
@@ -106,7 +106,7 @@ object PrepareInlineable {
     }
 
     /** Fallback approach if the direct approach does not work: Place the accessor method
-     *  in the same class as the inlined method, and let it take the receiver as parameter.
+     *  in the same class as the inline method, and let it take the receiver as parameter.
      *  This is tricky, since we have to find a suitable type for the parameter, which might
      *  require additional type parameters for the inline accessor. An example is in the
      *  `TestPassing` class in test `run/inline/inlines_1`:
@@ -115,11 +115,11 @@ object PrepareInlineable {
      *      private[inlines] def next[U](y: U): (T, U) = (x, y)
      *    }
      *    class TestPassing {
-     *      rewrite def foo[A](x: A): (A, Int) = {
+     *      inline def foo[A](x: A): (A, Int) = {
      *      val c = new C[A](x)
      *      c.next(1)
      *    }
-     *    rewrite def bar[A](x: A): (A, String) = {
+     *    inline def bar[A](x: A): (A, String) = {
      *      val c = new C[A](x)
      *      c.next("")
      *    }
@@ -150,8 +150,8 @@ object PrepareInlineable {
           }
           val qualType = dealiasMap(qual.tpe.widen)
 
-          // The types that are local to the inlined method, and that therefore have
-          // to be abstracted out in the accessor, which is external to the inlined method
+          // The types that are local to the inline method, and that therefore have
+          // to be abstracted out in the accessor, which is external to the inline method
           val localRefs = qualType.namedPartsWith(ref =>
             ref.isType && ref.symbol.isContainedIn(inlineSym)).toList
 
@@ -227,7 +227,7 @@ object PrepareInlineable {
    *  @param treeExpr    A function that computes the tree to be inlined, given a context
    *                     This tree may still refer to non-public members.
    *  @param ctx         The context to use for evaluating `treeExpr`. It needs
-   *                     to have the inlined method as owner.
+   *                     to have the inline method as owner.
    */
   def registerInlineInfo(
       inlined: Symbol, originalBody: untpd.Tree, treeExpr: Context => Tree)(implicit ctx: Context): Unit = {
@@ -243,8 +243,8 @@ object PrepareInlineable {
             val typedBody =
               if (ctx.reporter.hasErrors) rawBody
               else ctx.compilationUnit.inlineAccessors.makeInlineable(rawBody)
-            if (inlined.isRewriteMethod)
-              checkRewriteMethod(inlined, typedBody)
+            if (inlined.isInlineMethod)
+              checkInlineMethod(inlined, typedBody)
             val inlineableBody = addReferences(inlined, originalBody, typedBody)
             inlining.println(i"Body to inline for $inlined: $inlineableBody")
             inlineableBody
@@ -253,12 +253,12 @@ object PrepareInlineable {
     }
   }
 
-  def checkRewriteMethod(inlined: Symbol, body: Tree)(implicit ctx: Context) = {
-    if (ctx.outer.inRewriteMethod)
-      ctx.error(ex"implementation restriction: nested rewrite methods are not supported", inlined.pos)
+  def checkInlineMethod(inlined: Symbol, body: Tree)(implicit ctx: Context) = {
+    if (ctx.outer.inInlineMethod)
+      ctx.error(ex"implementation restriction: nested inline methods are not supported", inlined.pos)
     if (inlined.name == nme.unapply && tupleArgs(body).isEmpty)
       ctx.warning(
-        em"rewrite unapply method can be rewritten only if its right hand side is a tuple (e1, ..., eN)",
+        em"inline unapply method can be rewritten only if its right hand side is a tuple (e1, ..., eN)",
         body.pos)
   }
 
@@ -418,12 +418,12 @@ object PrepareInlineable {
         val localImplicit = iref.symbol.asTerm.copy(
           owner = inlineMethod,
           name = UniqueInlineName.fresh(iref.symbol.name.asTermName),
-          flags = Implicit | Method | Stable | iref.symbol.flags & (Rewrite | Erased),
+          flags = Implicit | Method | Stable | iref.symbol.flags & (Inline | Erased),
           info = iref.tpe.widen.ensureMethodic,
           coord = inlineMethod.pos).asTerm
         val idef = polyDefDef(localImplicit, tps => vrefss =>
             iref.appliedToTypes(tps).appliedToArgss(vrefss))
-        if (localImplicit.is(Rewrite)) {
+        if (localImplicit.is(Inline)) {
           // produce a Body annotation for inlining
           def untype(tree: Tree): untpd.Tree = tree match {
             case Apply(fn, args) => untpd.cpy.Apply(tree)(untype(fn), args)

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -395,7 +395,7 @@ object RefChecks {
         overrideError("is erased, cannot override non-erased member")
       } else if (other.is(Erased) && !member.is(Erased)) { // (1.9)
         overrideError("is not erased, cannot override erased member")
-      } else if ((member.is(Inline) || member.is(Scala2Macro)) && other.is(Deferred) &&
+      } else if ((member.isInlineMethod || member.is(Scala2Macro)) && other.is(Deferred) &&
                  member.extendedOverriddenSymbols.forall(_.is(Deferred))) { // (1.10)
         overrideError("is an inline method, must override at least one concrete method")
       } else if (other.is(Scala2Macro) && !member.is(Scala2Macro)) { // (1.11)

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -158,7 +158,7 @@ object RefChecks {
    *    1.8.2  M is of type []S, O is of type ()T and S <: T, or
    *    1.8.3  M is of type ()S, O is of type []T and S <: T, or
    *    1.9    If M or O are erased, they must be both erased
-   *    1.10   If M is a rewrite or Scala-2 macro method, O cannot be deferred unless
+   *    1.10   If M is an inline or Scala-2 macro method, O cannot be deferred unless
    *           there's also a concrete method that M overrides.
    *    1.11.  If O is a Scala-2 macro, M must be a Scala-2 macro.
    *  2. Check that only abstract classes have deferred members
@@ -395,9 +395,9 @@ object RefChecks {
         overrideError("is erased, cannot override non-erased member")
       } else if (other.is(Erased) && !member.is(Erased)) { // (1.9)
         overrideError("is not erased, cannot override erased member")
-      } else if ((member.is(Rewrite) || member.is(Scala2Macro)) && other.is(Deferred) &&
+      } else if ((member.is(Inline) || member.is(Scala2Macro)) && other.is(Deferred) &&
                  member.extendedOverriddenSymbols.forall(_.is(Deferred))) { // (1.10)
-        overrideError("is a rewrite method, must override at least one concrete method")
+        overrideError("is an inline method, must override at least one concrete method")
       } else if (other.is(Scala2Macro) && !member.is(Scala2Macro)) { // (1.11)
         overrideError("cannot be used here - only Scala-2 macros can override Scala-2 macros")
       } else if (!compatibleTypes(memberTp(self), otherTp(self)) &&

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -379,7 +379,7 @@ class TestBCode extends DottyBytecodeTest {
   @Test def i4172 = {
     val source =
       """class Test {
-        |  rewrite def foo(first: Int*)(second: String = "") = {}
+        |  inline def foo(first: Int*)(second: String = "") = {}
         |
         |  def test = {
         |    foo(1)()

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -12,7 +12,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
   @Test def inlineUnit = {
     val source = """
                  |class Foo {
-                 |  rewrite def foo: Int = 1
+                 |  inline def foo: Int = 1
                  |  @forceInline def bar: Int = 1
                  |
                  |  def meth1: Unit = foo
@@ -44,7 +44,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
 
   @Test def i4947 = {
     val source = """class Foo {
-                   |  rewrite def track[T](f: => T): T = {
+                   |  inline def track[T](f: => T): T = {
                    |    foo("tracking") // line 3
                    |    f // line 4
                    |  }
@@ -103,11 +103,11 @@ class InlineBytecodeTests extends DottyBytecodeTest {
 
   @Test def i4947b = {
     val source = """class Foo {
-                   |  rewrite def track2[T](f: => T): T = {
+                   |  inline def track2[T](f: => T): T = {
                    |    foo("tracking2") // line 3
                    |    f // line 4
                    |  }
-                   |  rewrite def track[T](f: => T): T = {
+                   |  inline def track[T](f: => T): T = {
                    |    foo("tracking") // line 7
                    |    track2 { // line 8
                    |      f // line 9
@@ -163,11 +163,11 @@ class InlineBytecodeTests extends DottyBytecodeTest {
 
   @Test def i4947c = {
     val source = """class Foo {
-                   |  rewrite def track2[T](f: => T): T = {
+                   |  inline def track2[T](f: => T): T = {
                    |    foo("tracking2") // line 3
                    |    f // line 4
                    |  }
-                   |  rewrite def track[T](f: => T): T = {
+                   |  inline def track[T](f: => T): T = {
                    |    track2 { // line 7
                    |      foo("fgh") // line 8
                    |      f // line 9
@@ -223,11 +223,11 @@ class InlineBytecodeTests extends DottyBytecodeTest {
 
   @Test def i4947d = {
     val source = """class Foo {
-                   |  rewrite def track2[T](f: => T): T = {
+                   |  inline def track2[T](f: => T): T = {
                    |    foo("tracking2") // line 3
                    |    f // line 4
                    |  }
-                   |  rewrite def track[T](f: => T): T = {
+                   |  inline def track[T](f: => T): T = {
                    |    track2 { // line 7
                    |      track2 { // line 8
                    |        f // line 9
@@ -288,7 +288,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                    |  def test: Int = {
                    |    var a = 10
                    |
-                   |    rewrite def f() = {
+                   |    inline def f() = {
                    |      a += 1
                    |    }
                    |

--- a/compiler/test/dotty/tools/dotc/parsing/ModifiersParsingTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ModifiersParsingTest.scala
@@ -120,8 +120,7 @@ class ModifiersParsingTest {
         |   final val c = ???
         |
         |   abstract override def f: Boolean
-        |   transparent def g(n: Int) = ???
-        |   inline def h(n: Int) = ???
+        |   inline def g(n: Int) = ???
         | }
       """.stripMargin)
 
@@ -129,13 +128,12 @@ class ModifiersParsingTest {
     assert(source.field("b").modifiers == List(Mod.Lazy(), Mod.Private()))
     assert(source.field("c").modifiers == List(Mod.Final()))
     assert(source.field("f").modifiers == List(Mod.Abstract(), Mod.Override()))
-    assert(source.field("g").modifiers == List(Mod.Transparent()))
-    assert(source.field("h").modifiers == List(Mod.Inline()))
+    assert(source.field("g").modifiers == List(Mod.Inline()))
   }
 
   @Test def paramDef = {
-    var source: Tree = parse("def f(transparent a: Int) = ???")
-    assert(source.defParam(0).modifiers == List(Mod.Transparent()))
+    var source: Tree = parse("def f(inline a: Int) = ???")
+    assert(source.defParam(0).modifiers == List(Mod.Inline()))
 
     source = parse("def f(implicit a: Int, b: Int) = ???")
     assert(source.defParam(0).modifiers == List(Mod.Implicit()))

--- a/compiler/test/dotty/tools/dotc/parsing/ModifiersParsingTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ModifiersParsingTest.scala
@@ -121,7 +121,7 @@ class ModifiersParsingTest {
         |
         |   abstract override def f: Boolean
         |   transparent def g(n: Int) = ???
-        |   rewrite def h(n: Int) = ???
+        |   inline def h(n: Int) = ???
         | }
       """.stripMargin)
 
@@ -130,7 +130,7 @@ class ModifiersParsingTest {
     assert(source.field("c").modifiers == List(Mod.Final()))
     assert(source.field("f").modifiers == List(Mod.Abstract(), Mod.Override()))
     assert(source.field("g").modifiers == List(Mod.Transparent()))
-    assert(source.field("h").modifiers == List(Mod.Rewrite()))
+    assert(source.field("h").modifiers == List(Mod.Inline()))
   }
 
   @Test def paramDef = {

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -996,7 +996,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         |}
         |
         |class B extends A {
-        |  rewrite def bar(): Unit = super.foo()
+        |  inline def bar(): Unit = super.foo()
         |}
       """.stripMargin
     }
@@ -1105,7 +1105,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
   @Test def noReturnInInline =
     checkMessagesAfter(FrontEnd.name) {
       """class BadFunction {
-        |  rewrite def usesReturn: Int = { return 42 }
+        |  inline def usesReturn: Int = { return 42 }
         |}
       """.stripMargin
     }.expect { (ictx, messages) =>

--- a/docs/docs/internals/overall-structure.md
+++ b/docs/docs/internals/overall-structure.md
@@ -35,7 +35,7 @@ list of sub-packages and their focus.
 ├── printing            // Pretty-printing trees, types and other data
 ├── repl                // The interactive REPL
 ├── reporting           // Reporting of error messages, warnings and other info.
-├── rewrite             // Helpers for rewriting Scala 2's constructs into dotty's.
+├── rewrites            // Helpers for rewriting Scala 2's constructs into dotty's.
 ├── transform           // Miniphases and helpers for tree transformations.
 ├── typer               // Type-checking and other frontend phases
 └── util                // General purpose utility classes and modules.

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -163,9 +163,9 @@ BlockResult       ::=  [FunArgMods] FunParams ‘=>’ Block
 FunParams         ::=  Bindings
                     |  id
                     |  ‘_’
-Expr1             ::=  [‘rewrite’] ‘if’ ‘(’ Expr ‘)’ {nl}
+Expr1             ::=  [‘inline’] ‘if’ ‘(’ Expr ‘)’ {nl}
                        Expr [[semi] ‘else’ Expr]                                If(Parens(cond), thenp, elsep?)
-                    |  [‘rewrite’] ‘if’ Expr ‘then’ Expr [[semi] ‘else’ Expr]   If(cond, thenp, elsep?)
+                    |  [‘inline’] ‘if’ Expr ‘then’ Expr [[semi] ‘else’ Expr]    If(cond, thenp, elsep?)
                     |  ‘while’ ‘(’ Expr ‘)’ {nl} Expr                           WhileDo(Parens(cond), body)
                     |  ‘while’ Expr ‘do’ Expr                                   WhileDo(cond, body)
                     |  ‘do’ Expr [semi] ‘while’ Expr                            DoWhile(expr, cond)
@@ -177,7 +177,7 @@ Expr1             ::=  [‘rewrite’] ‘if’ ‘(’ Expr ‘)’ {nl}
                     |  [SimpleExpr ‘.’] id ‘=’ Expr                             Assign(expr, expr)
                     |  SimpleExpr1 ArgumentExprs ‘=’ Expr                       Assign(expr, expr)
                     |  PostfixExpr [Ascription]
-                    |  [‘rewrite’] PostfixExpr ‘match’ ‘{’ CaseClauses ‘}’      Match(expr, cases) -- point on match
+                    |  [‘inline’] PostfixExpr ‘match’ ‘{’ CaseClauses ‘}’       Match(expr, cases) -- point on match
                     |  ‘implicit’ ‘match’ ‘{’ ImplicitCaseClauses ‘}’
 Ascription        ::=  ‘:’ InfixType                                            Typed(expr, tp)
                     |  ‘:’ Annotation {Annotation}                              Typed(expr, Annotated(EmptyTree, annot)*)
@@ -295,7 +295,7 @@ LocalModifier     ::=  ‘abstract’
                     |  ‘implicit’
                     |  ‘lazy’
                     |  ‘transparent’
-                    |  ‘rewrite’
+                    |  ‘inline’
                     |  ‘erased’
 AccessModifier    ::=  (‘private’ | ‘protected’) [AccessQualifier]
 AccessQualifier   ::=  ‘[’ (id | ‘this’) ‘]’

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -271,7 +271,7 @@ ClsParamClauses   ::=  {ClsParamClause} [[nl] ‘(’ [FunArgMods] ClsParams ‘
 ClsParamClause    ::=  [nl] ‘(’ [ClsParams] ‘)’
 ClsParams         ::=  ClsParam {‘,’ ClsParam}
 ClsParam          ::=  {Annotation}                                             ValDef(mods, id, tpe, expr) -- point of mods on val/var
-                       [{Modifier} (‘val’ | ‘var’) | ‘transparent’] Param
+                       [{Modifier} (‘val’ | ‘var’) | ‘inline’] Param
 Param             ::=  id ‘:’ ParamType [‘=’ Expr]
                     |  INT
 

--- a/docs/docs/reference/dropped/weak-conformance.md
+++ b/docs/docs/reference/dropped/weak-conformance.md
@@ -66,7 +66,7 @@ assigning a type to a constant expression. The new rule is:
 
 __Examples:__
 
-    transparent val b = 33
+    inline val b = 33
     def f(): Int = b + 1
     List(b, 33, 'a')      : List[Int]
     List(b, 33, 'a', f()) : List[Int]

--- a/docs/docs/reference/inline.md
+++ b/docs/docs/reference/inline.md
@@ -1,13 +1,13 @@
 ---
 layout: doc-page
-title: Inline and Transparent
+title: Inline
 ---
 
 `inline` is a new modifier that guarantees that a definition will be
 inline at the point of use. Example:
 
     object Config {
-      transparent val logging = false
+      inline val logging = false
     }
 
     object Logger {
@@ -26,12 +26,12 @@ inline at the point of use. Example:
         else op
     }
 
-The `Config` object contains a definition of a `transparent` value
+The `Config` object contains a definition of a `inline` value
 `logging`. This means that `logging` is treated as a constant value,
 equivalent to its right-hand side `false`. The right-hand side of such
-a transparent val must itself be a [constant
+a inline val must itself be a [constant
 expression](#the-definition-of-constant-expression). Used in this way,
-`transparent` is equivalent to Java and Scala 2's `final`. `final` meaning
+`inline` is equivalent to Java and Scala 2's `final`. `final` meaning
 "constant" is still supported in Dotty, but will be phased out.
 
 The `Logger` object contains a definition of an `inline` method `log`.
@@ -89,7 +89,7 @@ overhead:
 
 By contrast, if `op` is a call-by-value parameter, it would be evaluated separately as a closure.
 
-Transparent methods can be recursive. For instance, when called with a constant
+Inline methods can be recursive. For instance, when called with a constant
 exponent `n`, the following method for `power` will be implemented by
 straight inline code without any loop or recursion.
 
@@ -110,7 +110,7 @@ straight inline code without any loop or recursion.
         //    val y3 = y2 * x  // ^5
         //    y3 * y3          // ^10
 
-Parameters of inline methods can be marked `transparent`. This means
+Parameters of inline methods can be marked `inline`. This means
 that actual arguments to these parameters must be constant expressions.
 
 ### Relationship to `@inline`.
@@ -129,7 +129,7 @@ for Scala 2 (i.e. `@forceInline @inline`).
 
 ### The definition of constant expression
 
-Right-hand sides of transparent values and of arguments for transparent parameters
+Right-hand sides of inline values and of arguments for inline parameters
 must be constant expressions in the sense defined by the [SLS §
 6.24](https://www.scala-lang.org/files/archive/spec/2.12/06-expressions.html#constant-expressions),
 including "platform-specific" extensions such as constant folding of

--- a/docs/docs/reference/principled-meta-programming.md
+++ b/docs/docs/reference/principled-meta-programming.md
@@ -303,7 +303,7 @@ Here’s an application of `map` and how it rewrites to optimized code:
       ys
     }
 
-### Relationship with Transparent and Macros
+### Relationship with Inline and Macros
 
 Seen by itself, principled meta-programming looks more like a
 framework for staging than one for compile-time meta programming with
@@ -372,13 +372,13 @@ they were in a quoted context. For instance, the definition of
 the call from `assert` to `assertImpl` phase-correct, even if we
 assume that both definitions are local.
 
-The `transparent` modifier is used to declare a `val` that is
+The `inline` modifier is used to declare a `val` that is
 either a constant or is a parameter that will be a constant when instantiated. This
 aspect is also important for macro expansion.  To illustrate this,
 consider an implementation of the `power` function that makes use of a
 statically known exponent:
 
-    inline def power(transparent n: Int, x: Double) = ~powerCode(n, '(x))
+    inline def power(inline n: Int, x: Double) = ~powerCode(n, '(x))
 
     private def powerCode(n: Int, x: Expr[Double]): Expr[Double] =
       if (n == 0) '(1.0)
@@ -390,13 +390,13 @@ The reference to `n` as an argument in `~powerCode(n, '(x))` is not
 phase-consistent, since `n` appears in a splice without an enclosing
 quote. Normally that would be a problem because it means that we need
 the _value_ of `n` at compile time, which is not available for general
-parameters. But since `n` is a transparent parameter of a macro, we know
+parameters. But since `n` is a inline parameter of a macro, we know
 that at the macro’s expansion point `n` will be instantiated to a
 constant, so the value of `n` will in fact be known at this
 point. To reflect this, we loosen the phase consistency requirements
 as follows:
 
- - If `x` is a transparent value (or a transparent parameter of an inline
+ - If `x` is a inline value (or a inline parameter of an inline
    function) of type Boolean, Byte, Short, Int, Long, Float, Double,
    Char or String, it can be accessed in all contexts where the number
    of splices minus the number of quotes between use and definition
@@ -437,7 +437,7 @@ we currently impose the following restrictions on the use of splices.
     into a macro)
 
  2. The splice must call a previously compiled
-    method passing quoted arguments, constant arguments or transparent arguments.
+    method passing quoted arguments, constant arguments or inline arguments.
 
  3. Splices inside splices (but no intervening quotes) are not allowed.
 
@@ -763,7 +763,7 @@ is studied [separately](simple-smp.md).
 The meta-programming framework as presented and currently implemented is quite restrictive
 in that it does not allow for the inspection of quoted expressions and
 types. It’s possible to work around this by providing all necessary
-information as normal, unquoted transparent parameters. But we would gain
+information as normal, unquoted inline parameters. But we would gain
 more flexibility by allowing for the inspection of quoted code with
 pattern matching. This opens new possibilities. For instance, here is a
 version of `power` that generates the multiplications directly if the

--- a/docs/docs/typelevel.md
+++ b/docs/docs/typelevel.md
@@ -491,20 +491,20 @@ the method is itself inlined, just like if it had been marked `rewrite`.
 
 ## Transparent Values
 
-Value definitions can also be marked `transparent`. Examples:
+Value definitions can also be marked `inline`. Examples:
 ```scala
-transparent val label      = "url"
-transparent val pi: Double = 3.14159265359
+inline val label      = "url"
+inline val pi: Double = 3.14159265359
 ```
-The right hand side of a  `transparent` value definition must be a pure expression of constant type. The type of the value is then the type of its right hand side, without any widenings. For instance, the type of `label` above is the singleton type `"url"` instead of `String` and the type of `pi` is `3.14159265359` instead of `Double`.
+The right hand side of a  `inline` value definition must be a pure expression of constant type. The type of the value is then the type of its right hand side, without any widenings. For instance, the type of `label` above is the singleton type `"url"` instead of `String` and the type of `pi` is `3.14159265359` instead of `Double`.
 
 Transparent values are effectively final; they may not be overridden. In Scala-2, constant values had to be expressed using `final`, which gave an unfortunate double meaning to the modifier. The `final` syntax is still supported in Scala 3 for a limited time to support cross-building.
 
-The `transparent` modifier can also be used for value parameters of `rewrite` methods. Example
+The `inline` modifier can also be used for value parameters of `rewrite` methods. Example
 ```scala
-rewrite def power(x: Double, transparent n: Int) = ...
+rewrite def power(x: Double, inline n: Int) = ...
 ```
-If a `transparent` modifier is given, corresponding arguments must be pure expressions of constant type.
+If a `inline` modifier is given, corresponding arguments must be pure expressions of constant type.
 
 However, the restrictions on right-hand sides or arguments mentioned in this section do not apply in code that is
 itself in a `rewrite` method. In other words, constantness checking is performed only when a `transparent` method

--- a/library/src-scala3/scala/Tuple.scala
+++ b/library/src-scala3/scala/Tuple.scala
@@ -5,7 +5,7 @@ import typelevel._
 sealed trait Tuple extends Any {
   import Tuple._
 
-  rewrite def toArray: Array[Object] = rewrite constValueOpt[BoundedSize[this.type]] match {
+  inline def toArray: Array[Object] = inline constValueOpt[BoundedSize[this.type]] match {
     case Some(0) =>
       $emptyArray
     case Some(1) =>
@@ -28,9 +28,9 @@ sealed trait Tuple extends Any {
       dynamicToArray(this)
   }
 
-  rewrite def *: [H] (x: H): H *: this.type = {
+  inline def *: [H] (x: H): H *: this.type = {
     type Result = H *: this.type
-    rewrite constValueOpt[BoundedSize[this.type]] match {
+    inline constValueOpt[BoundedSize[this.type]] match {
       case Some(0) =>
         Tuple1(x).asInstanceOf[Result]
       case Some(1) =>
@@ -51,9 +51,9 @@ sealed trait Tuple extends Any {
     }
   }
 
-  rewrite def ++(that: Tuple): Concat[this.type, that.type] = {
+  inline def ++(that: Tuple): Concat[this.type, that.type] = {
     type Result = Concat[this.type, that.type]
-    rewrite constValueOpt[BoundedSize[this.type]] match {
+    inline constValueOpt[BoundedSize[this.type]] match {
       case Some(0) =>
         that.asInstanceOf[Result]
       case Some(1) =>
@@ -61,7 +61,7 @@ sealed trait Tuple extends Any {
         else (asInstanceOf[Tuple1[_]]._1 *: that).asInstanceOf[Result]
       case Some(2) =>
         val t = asInstanceOf[Tuple2[_, _]]
-        rewrite constValue[BoundedSize[that.type]] match {
+        inline constValue[BoundedSize[that.type]] match {
           case 0 => this.asInstanceOf[Result]
           case 1 =>
             val u = that.asInstanceOf[Tuple1[_]]
@@ -74,7 +74,7 @@ sealed trait Tuple extends Any {
         }
       case Some(3) =>
         val t = asInstanceOf[Tuple3[_, _, _]]
-        rewrite constValue[BoundedSize[that.type]] match {
+        inline constValue[BoundedSize[that.type]] match {
           case 0 => this.asInstanceOf[Result]
           case 1 =>
             val u = that.asInstanceOf[Tuple1[_]]
@@ -90,12 +90,12 @@ sealed trait Tuple extends Any {
     }
   }
 
-  rewrite def genericConcat[T <: Tuple](xs: Tuple, ys: Tuple): Tuple =
+  inline def genericConcat[T <: Tuple](xs: Tuple, ys: Tuple): Tuple =
     fromArray[T](xs.toArray ++ ys.toArray)
 
-  rewrite def size: Size[this.type] = {
+  inline def size: Size[this.type] = {
     type Result = Size[this.type]
-    rewrite constValueOpt[BoundedSize[this.type]] match {
+    inline constValueOpt[BoundedSize[this.type]] match {
       case Some(n) => n.asInstanceOf[Result]
       case _ => dynamicSize(this).asInstanceOf[Result]
     }
@@ -163,8 +163,8 @@ object Tuple {
     elems1
   }
 
-  rewrite def fromArray[T <: Tuple](xs: Array[Object]): T =
-    rewrite constValue[BoundedSize[T]] match {
+  inline def fromArray[T <: Tuple](xs: Array[Object]): T =
+    inline constValue[BoundedSize[T]] match {
       case 0  => ().asInstanceOf[T]
       case 1  => Tuple1(xs(0)).asInstanceOf[T]
       case 2  => Tuple2(xs(0), xs(1)).asInstanceOf[T]
@@ -283,9 +283,9 @@ abstract sealed class NonEmptyTuple extends Tuple {
   import Tuple._
   import NonEmptyTuple._
 
-  rewrite def head: Head[this.type] = {
+  inline def head: Head[this.type] = {
     type Result = Head[this.type]
-    val resVal = rewrite constValueOpt[BoundedSize[this.type]] match {
+    val resVal = inline constValueOpt[BoundedSize[this.type]] match {
       case Some(1) =>
         val t = asInstanceOf[Tuple1[_]]
         t._1
@@ -309,9 +309,9 @@ abstract sealed class NonEmptyTuple extends Tuple {
     resVal.asInstanceOf[Result]
   }
 
-  rewrite def tail: Tail[this.type] = {
+  inline def tail: Tail[this.type] = {
     type Result = Tail[this.type]
-    rewrite constValueOpt[BoundedSize[this.type]]  match {
+    inline constValueOpt[BoundedSize[this.type]]  match {
       case Some(1) =>
         ().asInstanceOf[Result]
       case Some(2) =>
@@ -333,31 +333,31 @@ abstract sealed class NonEmptyTuple extends Tuple {
     }
   }
 
-  rewrite def fallbackApply(n: Int) =
-    rewrite constValueOpt[n.type] match {
+  inline def fallbackApply(n: Int) =
+    inline constValueOpt[n.type] match {
       case Some(n: Int) => error("index out of bounds", n)
       case None => dynamicApply[this.type](this, n)
     }
 
-  rewrite def apply(n: Int): Elem[this.type, n.type] = {
+  inline def apply(n: Int): Elem[this.type, n.type] = {
     type Result = Elem[this.type, n.type]
-    rewrite constValueOpt[Size[this.type]] match {
+    inline constValueOpt[Size[this.type]] match {
       case Some(1) =>
         val t = asInstanceOf[Tuple1[_]]
-        rewrite constValueOpt[n.type] match {
+        inline constValueOpt[n.type] match {
           case Some(0) => t._1.asInstanceOf[Result]
           case _ => fallbackApply(n).asInstanceOf[Result]
         }
       case Some(2) =>
         val t = asInstanceOf[Tuple2[_, _]]
-        rewrite constValueOpt[n.type] match {
+        inline constValueOpt[n.type] match {
           case Some(0) => t._1.asInstanceOf[Result]
           case Some(1) => t._2.asInstanceOf[Result]
           case _ => fallbackApply(n).asInstanceOf[Result]
         }
       case Some(3) =>
         val t = asInstanceOf[Tuple3[_, _, _]]
-        rewrite constValueOpt[n.type] match {
+        inline constValueOpt[n.type] match {
           case Some(0) => t._1.asInstanceOf[Result]
           case Some(1) => t._2.asInstanceOf[Result]
           case Some(2) => t._3.asInstanceOf[Result]
@@ -365,7 +365,7 @@ abstract sealed class NonEmptyTuple extends Tuple {
         }
       case Some(4) =>
         val t = asInstanceOf[Tuple4[_, _, _, _]]
-        rewrite constValueOpt[n.type] match {
+        inline constValueOpt[n.type] match {
           case Some(0) => t._1.asInstanceOf[Result]
           case Some(1) => t._2.asInstanceOf[Result]
           case Some(2) => t._3.asInstanceOf[Result]
@@ -374,13 +374,13 @@ abstract sealed class NonEmptyTuple extends Tuple {
         }
       case Some(s) if s > 4 && s <= $MaxSpecialized =>
         val t = asInstanceOf[Product]
-        rewrite constValueOpt[n.type] match {
+        inline constValueOpt[n.type] match {
           case Some(n) if n >= 0 && n < s => t.productElement(n).asInstanceOf[Result]
           case _ => fallbackApply(n).asInstanceOf[Result]
         }
       case Some(s) if s > $MaxSpecialized =>
         val t = asInstanceOf[TupleXXL]
-        rewrite constValueOpt[n.type] match {
+        inline constValueOpt[n.type] match {
           case Some(n) if n >= 0 && n < s => t.elems(n).asInstanceOf[Result]
           case _ => fallbackApply(n).asInstanceOf[Result]
         }
@@ -431,5 +431,5 @@ object NonEmptyTuple {
 sealed class *:[+H, +T <: Tuple] extends NonEmptyTuple
 
 object *: {
-  rewrite def unapply[H, T <: Tuple](x: H *: T) = (x.head, x.tail)
+  inline def unapply[H, T <: Tuple](x: H *: T) = (x.head, x.tail)
 }

--- a/library/src-scala3/scala/Tuple.scala
+++ b/library/src-scala3/scala/Tuple.scala
@@ -103,8 +103,8 @@ sealed trait Tuple extends Any {
 }
 
 object Tuple {
-  transparent val $MaxSpecialized = 22
-  transparent private val XXL = $MaxSpecialized + 1
+  inline val $MaxSpecialized = 22
+  inline private val XXL = $MaxSpecialized + 1
 
   type Head[+X <: NonEmptyTuple] = X match {
     case x *: _ => x

--- a/library/src-scala3/scala/typelevel/package.scala
+++ b/library/src-scala3/scala/typelevel/package.scala
@@ -6,11 +6,11 @@ package object typelevel {
 
   case class Typed[T](val value: T) { type Type = T }
 
-  rewrite def error(transparent msg: String, objs: Any*): Nothing = ???
+  inline def error(transparent msg: String, objs: Any*): Nothing = ???
 
-  rewrite def constValueOpt[T]: Option[T] = ???
+  inline def constValueOpt[T]: Option[T] = ???
 
-  rewrite def constValue[T]: T = ???
+  inline def constValue[T]: T = ???
 
   type S[X <: Int] <: Int
 }

--- a/library/src-scala3/scala/typelevel/package.scala
+++ b/library/src-scala3/scala/typelevel/package.scala
@@ -6,7 +6,7 @@ package object typelevel {
 
   case class Typed[T](val value: T) { type Type = T }
 
-  inline def error(transparent msg: String, objs: Any*): Nothing = ???
+  inline def error(inline msg: String, objs: Any*): Nothing = ???
 
   inline def constValueOpt[T]: Option[T] = ???
 

--- a/library/src/scala/annotation/internal/Body.scala
+++ b/library/src/scala/annotation/internal/Body.scala
@@ -3,6 +3,6 @@ package scala.annotation.internal
 import scala.annotation.Annotation
 
 /** The class associated with a `BodyAnnotation`, which indicates
- *  a transparent or inline method's right hand side
+ *  an inline method's right hand side
  */
 final class Body() extends Annotation

--- a/library/src/scala/annotation/internal/Body.scala
+++ b/library/src/scala/annotation/internal/Body.scala
@@ -3,6 +3,6 @@ package scala.annotation.internal
 import scala.annotation.Annotation
 
 /** The class associated with a `BodyAnnotation`, which indicates
- *  a transparent or rewrite method's right hand side
+ *  a transparent or inline method's right hand side
  */
 final class Body() extends Annotation

--- a/library/src/scala/annotation/internal/TransparentParam.scala
+++ b/library/src/scala/annotation/internal/TransparentParam.scala
@@ -2,5 +2,5 @@ package scala.annotation.internal
 
 import scala.annotation.Annotation
 
-/** An annotation produced by Namer to indicate a transparent parameter */
-final class TransparentParam() extends Annotation
+/** An annotation produced by Namer to indicate an inline parameter */
+final class InlineParam() extends Annotation

--- a/library/src/scala/forceInline.scala
+++ b/library/src/scala/forceInline.scala
@@ -1,6 +1,6 @@
 package scala
 
-/** An annotation on methods that is equivalent to Dotty `rewrite` modifier,
+/** An annotation on methods that is equivalent to Dotty `inline` modifier,
  *  except that it does not imply `erased`.
  *
  *  The annotation should be used instead of the `inline` modifier in code

--- a/library/src/scala/tasty/Tasty.scala
+++ b/library/src/scala/tasty/Tasty.scala
@@ -21,6 +21,6 @@ abstract class Tasty
     with TypeOrBoundsOps
 
 object Tasty {
-  /** Compiler tasty context available in a top level ~ of a transparent macro */
-  def macroContext: Tasty = throw new Exception("Not in transparent macro.")
+  /** Compiler tasty context available in a top level ~ of an inline macro */
+  def macroContext: Tasty = throw new Exception("Not in inline macro.")
 }

--- a/library/src/scala/tasty/reflect/FlagSet.scala
+++ b/library/src/scala/tasty/reflect/FlagSet.scala
@@ -11,8 +11,8 @@ trait FlagSet {
   def isLazy: Boolean
   def isOverride: Boolean
   def isTransparent: Boolean
-  def isRewrite: Boolean
-  def isMacro: Boolean                 // rewrite method containing toplevel splices
+  def isInline: Boolean
+  def isMacro: Boolean                 // inline method containing toplevel splices
   def isStatic: Boolean                // mapped to static Java member
   def isObject: Boolean                // an object or its class (used for a ValDef or a ClassDef extends Modifier respectively)
   def isTrait: Boolean                 // a trait (used for a ClassDef)

--- a/library/src/scala/tasty/reflect/FlagSet.scala
+++ b/library/src/scala/tasty/reflect/FlagSet.scala
@@ -10,7 +10,6 @@ trait FlagSet {
   def isErased: Boolean
   def isLazy: Boolean
   def isOverride: Boolean
-  def isTransparent: Boolean
   def isInline: Boolean
   def isMacro: Boolean                 // inline method containing toplevel splices
   def isStatic: Boolean                // mapped to static Java member

--- a/library/src/scala/tasty/util/ShowSourceCode.scala
+++ b/library/src/scala/tasty/util/ShowSourceCode.scala
@@ -244,7 +244,6 @@ class ShowSourceCode[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
 
         val flags = ddef.symbol.flags
         if (flags.isImplicit) this += "implicit "
-        if (flags.isTransparent) this += "transparent "
         if (flags.isInline) this += "inline "
         if (flags.isOverride) this += "override "
 

--- a/library/src/scala/tasty/util/ShowSourceCode.scala
+++ b/library/src/scala/tasty/util/ShowSourceCode.scala
@@ -245,7 +245,7 @@ class ShowSourceCode[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
         val flags = ddef.symbol.flags
         if (flags.isImplicit) this += "implicit "
         if (flags.isTransparent) this += "transparent "
-        if (flags.isRewrite) this += "rewrite "
+        if (flags.isInline) this += "inline "
         if (flags.isOverride) this += "override "
 
         printProtectedOrPrivate(ddef)

--- a/sbt-bridge/test/xsbt/DependencySpecification.scala
+++ b/sbt-bridge/test/xsbt/DependencySpecification.scala
@@ -92,7 +92,7 @@ class DependencySpecification {
       """object A {
         |   def foo = { B; () }
         |}""".stripMargin
-    val srcB = "object B { println("foo") }"
+    val srcB = """object B { println("foo") }"""
 
     val compilerForTesting = new ScalaCompilerForUnitTesting
     val classDependencies =

--- a/sbt-bridge/test/xsbt/DependencySpecification.scala
+++ b/sbt-bridge/test/xsbt/DependencySpecification.scala
@@ -92,7 +92,7 @@ class DependencySpecification {
       """object A {
         |   def foo = { B; () }
         |}""".stripMargin
-    val srcB = "object B"
+    val srcB = "object B { println("foo") }"
 
     val compilerForTesting = new ScalaCompilerForUnitTesting
     val classDependencies =

--- a/sbt-dotty/sbt-test/source-dependencies/inline/changes/B1.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/inline/changes/B1.scala
@@ -1,4 +1,4 @@
 object B {
-  rewrite def getInline: Int =
+  inline def getInline: Int =
     A.get
 }

--- a/sbt-dotty/sbt-test/source-dependencies/inline/changes/B2.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/inline/changes/B2.scala
@@ -1,4 +1,4 @@
 object B {
-  rewrite def getInline: String =
+  inline def getInline: String =
     A.get.toString
 }

--- a/sbt-dotty/sbt-test/source-dependencies/inline/changes/B3.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/inline/changes/B3.scala
@@ -1,4 +1,4 @@
 object B {
-  rewrite def getInline: Int =
+  inline def getInline: Int =
     sys.error("This is an expected failure when running C")
 }

--- a/tests/disabled/run/i4803d/App_2.scala
+++ b/tests/disabled/run/i4803d/App_2.scala
@@ -10,8 +10,8 @@ object Test {
     println(power2(x3))
   }
 
-  rewrite def power2(x: Double) = {
-    rewrite def power(x: Double, transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+  inline def power2(x: Double) = {
+    inline def power(x: Double, transparent n: Long) = ~PowerMacro.powerCode('(x), n)
     power(x, 2)
   }
 }

--- a/tests/disabled/run/i4803d/App_2.scala
+++ b/tests/disabled/run/i4803d/App_2.scala
@@ -11,7 +11,7 @@ object Test {
   }
 
   inline def power2(x: Double) = {
-    inline def power(x: Double, transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+    inline def power(x: Double, inline n: Long) = ~PowerMacro.powerCode('(x), n)
     power(x, 2)
   }
 }

--- a/tests/neg-with-compiler/quote-run-in-macro-1/quoted_1.scala
+++ b/tests/neg-with-compiler/quote-run-in-macro-1/quoted_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.Toolbox.Default._
 
 object Macros {
-  rewrite def foo(i: => Int): Int = ~fooImpl('(i))
+  inline def foo(i: => Int): Int = ~fooImpl('(i))
   def fooImpl(i: Expr[Int]): Expr[Int] = {
     val y: Int = i.run
     y.toExpr

--- a/tests/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
+++ b/tests/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.Toolbox.Default._
 
 object Macros {
-  rewrite def foo(i: => Int): Int = ~fooImpl('(i))
+  inline def foo(i: => Int): Int = ~fooImpl('(i))
   def fooImpl(i: Expr[Int]): Expr[Int] = {
     val y: Int = i.run
     y.toExpr

--- a/tests/neg/i1568.scala
+++ b/tests/neg/i1568.scala
@@ -1,3 +1,3 @@
 object Test {
-  rewrite def foo(n: Int) = foo(n) // error: cyclic reference
+  inline def foo(n: Int) = foo(n) // error: cyclic reference
 }

--- a/tests/neg/i1605.scala
+++ b/tests/neg/i1605.scala
@@ -1,5 +1,5 @@
 object Test {
   def foo = inlineMe
 
-  rewrite def inlineMe = 1 + x2233 // error
+  inline def inlineMe = 1 + x2233 // error
 }

--- a/tests/neg/i2006.scala
+++ b/tests/neg/i2006.scala
@@ -1,7 +1,7 @@
 object Test {
 
-  rewrite def foo(f: ImplicitFunction1[Int, Int]): AnyRef = f // error
-  rewrite def bar(f: ImplicitFunction1[Int, Int]) = f // error
+  inline def foo(f: ImplicitFunction1[Int, Int]): AnyRef = f // error
+  inline def bar(f: ImplicitFunction1[Int, Int]) = f // error
 
   def main(args: Array[String]) = {
     foo(implicit thisTransaction => 43)

--- a/tests/neg/i2421.scala
+++ b/tests/neg/i2421.scala
@@ -1,10 +1,10 @@
-rewrite object Foo // OK (error would be detected later, in PostTyper)
-rewrite class Bar // error: modifier(s) `rewrite' incompatible with type definition
-rewrite abstract class Baz // error: modifier(s) `rewrite' incompatible with type definition
-rewrite trait Qux // error: modifier(s) `rewrite' incompatible with type definition
+inline object Foo // OK (error would be detected later, in PostTyper)
+inline class Bar // error: modifier(s) `inline' incompatible with type definition
+inline abstract class Baz // error: modifier(s) `inline' incompatible with type definition
+inline trait Qux // error: modifier(s) `inline' incompatible with type definition
 
 object Quux {
-  rewrite type T // error: modifier(s) `rewrite' incompatible with type definition
-  rewrite var x: Int = 42 // error: modifier(s) `rewrite' incompatible with var definition
-  rewrite lazy val y: Int = 43 // error: modifier(s) `rewrite' incompatible with lazy val definition
+  inline type T // error: modifier(s) `inline' incompatible with type definition
+  inline var x: Int = 42 // error: modifier(s) `inline' incompatible with var definition
+  inline lazy val y: Int = 43 // error: modifier(s) `inline' incompatible with lazy val definition
 }

--- a/tests/neg/i2564.scala
+++ b/tests/neg/i2564.scala
@@ -1,4 +1,4 @@
 object Foo {
-  rewrite def bar = new Bar // error
+  inline def bar = new Bar // error
   class Bar private[Foo]()
 }

--- a/tests/neg/i2564b.scala
+++ b/tests/neg/i2564b.scala
@@ -1,3 +1,3 @@
 class Foo private() {
-  rewrite def foo = new Foo // error
+  inline def foo = new Foo // error
 }

--- a/tests/neg/i2901.scala
+++ b/tests/neg/i2901.scala
@@ -2,7 +2,7 @@ trait Foo {
   def foo = 4
 }
 object Bar extends Foo {
-  rewrite def bar = super[Foo].foo // error
+  inline def bar = super[Foo].foo // error
 }
 object Main {
   Bar.bar

--- a/tests/neg/i3900.scala
+++ b/tests/neg/i3900.scala
@@ -1,7 +1,7 @@
-class Foo(transparent val i: Int) // error
-case class Foo2(transparent val i: Int) // error
-class Foo3(transparent val i: Int) extends AnyVal // error
-trait Foo4(transparent val i: Int) // error
+class Foo(inline val i: Int) // error
+case class Foo2(inline val i: Int) // error
+class Foo3(inline val i: Int) extends AnyVal // error
+trait Foo4(inline val i: Int) // error
 class Foo5() {
-  def this(transparent x: Int) = this() // error
+  def this(inline x: Int) = this() // error
 }

--- a/tests/neg/i4433.scala
+++ b/tests/neg/i4433.scala
@@ -1,6 +1,6 @@
 
 object Foo {
-  rewrite def g(transparent p: Int => Boolean): Boolean = ~{ // error
+  inline def g(transparent p: Int => Boolean): Boolean = ~{ // error
     if(p(5)) '(true)
     else '(false)
   }

--- a/tests/neg/i4433.scala
+++ b/tests/neg/i4433.scala
@@ -1,6 +1,6 @@
 
 object Foo {
-  inline def g(transparent p: Int => Boolean): Boolean = ~{ // error
+  inline def g(inline p: Int => Boolean): Boolean = ~{ // error
     if(p(5)) '(true)
     else '(false)
   }

--- a/tests/neg/i4493-b.scala
+++ b/tests/neg/i4493-b.scala
@@ -1,6 +1,6 @@
 class Index[K]
 object Index {
-  rewrite def succ[K](x: K): Unit = ~{ // error
+  inline def succ[K](x: K): Unit = ~{ // error
     implicit val t: quoted.Type[K] = '[K]
     '(new Index[K])
   }

--- a/tests/neg/i4493.scala
+++ b/tests/neg/i4493.scala
@@ -1,6 +1,6 @@
 class Index[K]
 object Index {
-  rewrite def succ[K]: Unit = ~{ // error
+  inline def succ[K]: Unit = ~{ // error
     implicit val t: quoted.Type[K] = '[K]
     '(new Index[K])
   }

--- a/tests/neg/implicitMatch-ambiguous.scala
+++ b/tests/neg/implicitMatch-ambiguous.scala
@@ -4,7 +4,7 @@ object Test {
   implicit val a1: A = new A
   implicit val a2: A = new A
 
-  rewrite def f: Any = implicit match {
+  inline def f: Any = implicit match {
     case _: A => ???  // error: ambiguous implicits
   }
 

--- a/tests/neg/implicitMatch-syntax.scala
+++ b/tests/neg/implicitMatch-syntax.scala
@@ -2,28 +2,28 @@ object Test {
   import collection.immutable.TreeSet
   import collection.immutable.HashSet
 
-  rewrite def f1[T] = implicit implicit match { // error: repeated modifier // error: illegal modifier
+  inline def f1[T] = implicit implicit match { // error: repeated modifier // error: illegal modifier
     case ord: Ordered[T] => new TreeSet[T] // error: no implicit
     case _ => new HashSet[T]
 
   }
 
-  rewrite def f2[T] = implicit erased match { // error: illegal modifier
+  inline def f2[T] = implicit erased match { // error: illegal modifier
     case ord: Ordered[T] => new TreeSet[T] // error: no implicit
     case _ => new HashSet[T]
   }
 
-  rewrite def f3[T] = erased implicit match { // error: illegal modifier
+  inline def f3[T] = erased implicit match { // error: illegal modifier
     case ord: Ordered[T] => new TreeSet[T] // error: no implicit
     case _ => new HashSet[T]
   }
 
-  rewrite def f4() = implicit match {
+  inline def f4() = implicit match {
     case Nil => ???     // error: not a legal pattern
     case x :: xs => ??? // error: not a legal pattern
   }
 
-  rewrite def f5[T] = locally { implicit match { // Ok
+  inline def f5[T] = locally { implicit match { // Ok
     case _ => new HashSet[T]
   }}
 

--- a/tests/neg/inline-i1773.scala
+++ b/tests/neg/inline-i1773.scala
@@ -1,7 +1,7 @@
 object Test {
   implicit class Foo(sc: StringContext) {
     object q {
-      rewrite def unapply(arg: Any): Option[(Any, Any)] =
+      inline def unapply(arg: Any): Option[(Any, Any)] =
         Some((sc.parts(0), sc.parts(1)))
     }
   }

--- a/tests/neg/inline-position/A_1.scala
+++ b/tests/neg/inline-position/A_1.scala
@@ -1,5 +1,5 @@
 object A {
 
-  rewrite def f(x: => Object) = (x, x)
+  inline def f(x: => Object) = (x, x)
 
 }

--- a/tests/neg/inlineAccess/C_1.scala
+++ b/tests/neg/inlineAccess/C_1.scala
@@ -1,7 +1,7 @@
 package p
 private class D
 class C {
-  rewrite def inl(): Unit = {
+  inline def inl(): Unit = {
     val d = new D()     // error (when inlined): not accessible
   }
 }

--- a/tests/neg/inlinevals.scala
+++ b/tests/neg/inlinevals.scala
@@ -2,18 +2,18 @@ object Test {
 
   def power0(x: Double, transparent n: Int): Double = ???  // error
 
-  rewrite def power(x: Double, transparent n: Int): Double = ???  // ok
+  inline def power(x: Double, transparent n: Int): Double = ???  // ok
 
   transparent val N = 10
   def X = 20
 
   transparent transparent val twice = 30 // error: repeated modifier
 
-  rewrite transparent val twice = 30 // error: rewrite & transparent
+  inline transparent val twice = 30 // error: inline & transparent
 
   class C(transparent x: Int, private transparent val y: Int) { // error // error
     transparent val foo: Int // error: abstract member may not be inline
-    rewrite def bar: Int // error: abstract member may not be inline
+    inline def bar: Int // error: abstract member may not be inline
   }
 
   power(2.0, N) // ok, since it's a by-name parameter
@@ -23,7 +23,7 @@ object Test {
 
   transparent val xs = List(1, 2, 3) // error: must be a constant expression
 
-  rewrite def foo(x: Int) = {
+  inline def foo(x: Int) = {
 
     def f(transparent xs: List[Int]) = xs // error
 
@@ -32,6 +32,6 @@ object Test {
 
   }
 
-  rewrite def byname(transparent f: => String): Int = ??? // ok
+  inline def byname(transparent f: => String): Int = ??? // ok
 
 }

--- a/tests/neg/inlinevals.scala
+++ b/tests/neg/inlinevals.scala
@@ -7,7 +7,7 @@ object Test {
   inline val N = 10
   def X = 20
 
-  inline inline val twice = 30 // error: repeated modifier
+  inline inline val twice = 30 // error: repeated modifier // error: not found: inline
 
   class C(inline x: Int, private inline val y: Int) { // error // error
     inline val foo: Int // error: abstract member may not be inline

--- a/tests/neg/inlinevals.scala
+++ b/tests/neg/inlinevals.scala
@@ -1,37 +1,35 @@
 object Test {
 
-  def power0(x: Double, transparent n: Int): Double = ???  // error
+  def power0(x: Double, inline n: Int): Double = ???  // error
 
-  inline def power(x: Double, transparent n: Int): Double = ???  // ok
+  inline def power(x: Double, inline n: Int): Double = ???  // ok
 
-  transparent val N = 10
+  inline val N = 10
   def X = 20
 
-  transparent transparent val twice = 30 // error: repeated modifier
+  inline inline val twice = 30 // error: repeated modifier
 
-  inline transparent val twice = 30 // error: inline & transparent
-
-  class C(transparent x: Int, private transparent val y: Int) { // error // error
-    transparent val foo: Int // error: abstract member may not be inline
+  class C(inline x: Int, private inline val y: Int) { // error // error
+    inline val foo: Int // error: abstract member may not be inline
     inline def bar: Int // error: abstract member may not be inline
   }
 
   power(2.0, N) // ok, since it's a by-name parameter
-  power(2.0, X) // error: argument to transparent parameter must be a constant expression
+  power(2.0, X) // error: argument to inline parameter must be a constant expression
 
-  transparent val M = X  // error: rhs must be constant expression
+  inline val M = X  // error: rhs must be constant expression
 
-  transparent val xs = List(1, 2, 3) // error: must be a constant expression
+  inline val xs = List(1, 2, 3) // error: must be a constant expression
 
   inline def foo(x: Int) = {
 
-    def f(transparent xs: List[Int]) = xs // error
+    def f(inline xs: List[Int]) = xs // error
 
-    transparent val y = { println("hi"); 1 }  // ok
-    transparent val z = x // ok
+    inline val y = { println("hi"); 1 }  // ok
+    inline val z = x // ok
 
   }
 
-  inline def byname(transparent f: => String): Int = ??? // ok
+  inline def byname(inline f: => String): Int = ??? // ok
 
 }

--- a/tests/neg/nested-rewrites.scala
+++ b/tests/neg/nested-rewrites.scala
@@ -19,7 +19,7 @@ object Test0 {
       case 0 => 0
     }
     g(0)
-    transparent val Y = 0
+    inline val Y = 0
     g(Y)
 
     inline def h(x: Int) = inline x match {
@@ -39,7 +39,7 @@ object Test1 {
       case 0 => 0
     }
     g(0)
-    transparent val Y = 0
+    inline val Y = 0
     g(Y)
 
     inline def h(x: Int) = inline x match { // error: implementation restriction: nested inline methods are not supported

--- a/tests/neg/nested-rewrites.scala
+++ b/tests/neg/nested-rewrites.scala
@@ -1,13 +1,13 @@
 object Test {
 
-  rewrite def f1(x: Int) = {
-    rewrite def g(x: Int) = x // error: implementation restriction: nested rewrite methods are not supported
+  inline def f1(x: Int) = {
+    inline def g(x: Int) = x // error: implementation restriction: nested inline methods are not supported
     g(x)
   }
 
-  rewrite def f2(x: Int) = {
+  inline def f2(x: Int) = {
     object o {
-      rewrite def g(x: Int) = x // error: implementation restriction: nested rewrite methods are not supported
+      inline def g(x: Int) = x // error: implementation restriction: nested inline methods are not supported
     }
     o.g(x)
   }
@@ -15,14 +15,14 @@ object Test {
 object Test0 {
 
   def f(x: Int) = {
-    rewrite def g(x: Int) = rewrite x match {
+    inline def g(x: Int) = inline x match {
       case 0 => 0
     }
     g(0)
     transparent val Y = 0
     g(Y)
 
-    rewrite def h(x: Int) = rewrite x match {
+    inline def h(x: Int) = inline x match {
       case Y => 0
     }
     h(0)
@@ -34,15 +34,15 @@ object Test0 {
 
 object Test1 {
 
-  erased rewrite def f(x: Int) = {
-    erased rewrite def g(x: Int) = rewrite x match { // error: implementation restriction: nested rewrite methods are not supported
+  erased inline def f(x: Int) = {
+    erased inline def g(x: Int) = inline x match { // error: implementation restriction: nested inline methods are not supported
       case 0 => 0
     }
     g(0)
     transparent val Y = 0
     g(Y)
 
-    rewrite def h(x: Int) = rewrite x match { // error: implementation restriction: nested rewrite methods are not supported
+    inline def h(x: Int) = inline x match { // error: implementation restriction: nested inline methods are not supported
       case Y => 0
     }
     h(0)

--- a/tests/neg/power.scala
+++ b/tests/neg/power.scala
@@ -1,6 +1,6 @@
 object Test {
 
-  rewrite def power(x: Double, n: Int): Double =
+  inline def power(x: Double, n: Int): Double =
     if (n == 0) 1.0
     else if (n == 1) x
     else {

--- a/tests/neg/quote-MacroOverride.scala
+++ b/tests/neg/quote-MacroOverride.scala
@@ -2,11 +2,11 @@ object Test {
 
   abstract class A {
     def f(): Unit
-    rewrite def g(): Unit = ()
+    inline def g(): Unit = ()
   }
 
   object B extends A {
-    rewrite def f() = ~('())  // error: may not override
+    inline def f() = ~('())  // error: may not override
     override def g() = ()    // error: may not override
   }
 

--- a/tests/neg/quote-complex-top-splice.scala
+++ b/tests/neg/quote-complex-top-splice.scala
@@ -4,22 +4,22 @@ import scala.quoted._
 
 object Test {
 
-  rewrite def foo1: Unit = ~{ // error
+  inline def foo1: Unit = ~{ // error
     val x = 1
     impl(x)
   }
 
-  rewrite def foo2: Unit = ~impl({ // error
+  inline def foo2: Unit = ~impl({ // error
     val x = 1
     x
   })
 
-  rewrite def foo3: Unit = ~impl({ // error
+  inline def foo3: Unit = ~impl({ // error
     println("foo3")
     3
   })
 
-  rewrite def foo4: Unit = ~{ // error
+  inline def foo4: Unit = ~{ // error
     println("foo4")
     impl(1)
   }

--- a/tests/neg/quote-error-2/Macro_1.scala
+++ b/tests/neg/quote-error-2/Macro_1.scala
@@ -1,7 +1,7 @@
 import quoted._
 
 object Macro_1 {
-  rewrite def foo(transparent b: Boolean): Unit = ~fooImpl(b)
+  inline def foo(transparent b: Boolean): Unit = ~fooImpl(b)
   def fooImpl(b: Boolean): Expr[Unit] =
     '(println(~msg(b)))
 

--- a/tests/neg/quote-error-2/Macro_1.scala
+++ b/tests/neg/quote-error-2/Macro_1.scala
@@ -1,7 +1,7 @@
 import quoted._
 
 object Macro_1 {
-  inline def foo(transparent b: Boolean): Unit = ~fooImpl(b)
+  inline def foo(inline b: Boolean): Unit = ~fooImpl(b)
   def fooImpl(b: Boolean): Expr[Unit] =
     '(println(~msg(b)))
 

--- a/tests/neg/quote-error/Macro_1.scala
+++ b/tests/neg/quote-error/Macro_1.scala
@@ -1,7 +1,7 @@
 import quoted._
 
 object Macro_1 {
-  inline def foo(transparent b: Boolean): Unit = ~fooImpl(b)
+  inline def foo(inline b: Boolean): Unit = ~fooImpl(b)
   def fooImpl(b: Boolean): Expr[Unit] =
     if (b) '(println("foo(true)"))
     else QuoteError("foo cannot be called with false")

--- a/tests/neg/quote-error/Macro_1.scala
+++ b/tests/neg/quote-error/Macro_1.scala
@@ -1,7 +1,7 @@
 import quoted._
 
 object Macro_1 {
-  rewrite def foo(transparent b: Boolean): Unit = ~fooImpl(b)
+  inline def foo(transparent b: Boolean): Unit = ~fooImpl(b)
   def fooImpl(b: Boolean): Expr[Unit] =
     if (b) '(println("foo(true)"))
     else QuoteError("foo cannot be called with false")

--- a/tests/neg/quote-exception/Macro_1.scala
+++ b/tests/neg/quote-exception/Macro_1.scala
@@ -1,7 +1,7 @@
 import quoted._
 
 object Macro_1 {
-  rewrite def foo(transparent b: Boolean): Unit = ~fooImpl(b)
+  inline def foo(transparent b: Boolean): Unit = ~fooImpl(b)
   def fooImpl(b: Boolean): Expr[Unit] =
     if (b) '(println("foo(true)"))
     else ???

--- a/tests/neg/quote-exception/Macro_1.scala
+++ b/tests/neg/quote-exception/Macro_1.scala
@@ -1,7 +1,7 @@
 import quoted._
 
 object Macro_1 {
-  inline def foo(transparent b: Boolean): Unit = ~fooImpl(b)
+  inline def foo(inline b: Boolean): Unit = ~fooImpl(b)
   def fooImpl(b: Boolean): Expr[Unit] =
     if (b) '(println("foo(true)"))
     else ???

--- a/tests/neg/quote-interpolator-core-old.scala
+++ b/tests/neg/quote-interpolator-core-old.scala
@@ -5,9 +5,9 @@ import scala.quoted._
 object FInterpolation {
 
   implicit class FInterpolatorHelper(val sc: StringContext) extends AnyVal {
-    rewrite def ff(arg1: Any): String = ~fInterpolation(sc, Seq('(arg1))) // error: Inline macro method must be a static method
-    rewrite def ff(arg1: Any, arg2: Any): String = ~fInterpolation(sc, Seq('(arg1), '(arg2))) // error: Inline macro method must be a static method
-    rewrite def ff(arg1: Any, arg2: Any, arg3: Any): String = ~fInterpolation(sc, Seq('(arg1), '(arg2), '(arg3))) // error: Inline macro method must be a static method
+    inline def ff(arg1: Any): String = ~fInterpolation(sc, Seq('(arg1))) // error: Inline macro method must be a static method
+    inline def ff(arg1: Any, arg2: Any): String = ~fInterpolation(sc, Seq('(arg1), '(arg2))) // error: Inline macro method must be a static method
+    inline def ff(arg1: Any, arg2: Any, arg3: Any): String = ~fInterpolation(sc, Seq('(arg1), '(arg2), '(arg3))) // error: Inline macro method must be a static method
     // ...
   }
 

--- a/tests/neg/quote-macro-2-splices.scala
+++ b/tests/neg/quote-macro-2-splices.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object Macro {
 
-  rewrite def foo(b: Boolean): Int = { // error
+  inline def foo(b: Boolean): Int = { // error
     if (b) ~bar(true)
     else ~bar(false)
   }

--- a/tests/neg/quote-macro-complex-arg-0.scala
+++ b/tests/neg/quote-macro-complex-arg-0.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Macros {
-  inline def foo(transparent i: Int, dummy: Int, j: Int): Int = ~bar(i + 1, '(j)) // error: i + 1 is not a parameter or field reference
+  inline def foo(inline i: Int, dummy: Int, j: Int): Int = ~bar(i + 1, '(j)) // error: i + 1 is not a parameter or field reference
   def bar(x: Int, y: Expr[Int]): Expr[Int] = '{ ~x.toExpr + ~y }
 }

--- a/tests/neg/quote-macro-complex-arg-0.scala
+++ b/tests/neg/quote-macro-complex-arg-0.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Macros {
-  rewrite def foo(transparent i: Int, dummy: Int, j: Int): Int = ~bar(i + 1, '(j)) // error: i + 1 is not a parameter or field reference
+  inline def foo(transparent i: Int, dummy: Int, j: Int): Int = ~bar(i + 1, '(j)) // error: i + 1 is not a parameter or field reference
   def bar(x: Int, y: Expr[Int]): Expr[Int] = '{ ~x.toExpr + ~y }
 }

--- a/tests/neg/quote-macro-splice.scala
+++ b/tests/neg/quote-macro-splice.scala
@@ -2,22 +2,22 @@ import scala.quoted._
 
 object Test {
 
-  rewrite def foo1: Int = { // error
+  inline def foo1: Int = { // error
     println()
     ~impl(1.toExpr)
   }
 
-  rewrite def foo2: Int = { // error
+  inline def foo2: Int = { // error
     ~impl(1.toExpr)
     ~impl(2.toExpr)
   }
 
-  rewrite def foo3: Int = { // error
+  inline def foo3: Int = { // error
     val a = 1
     ~impl('(a))
   }
 
-  rewrite def foo4: Int = { // error
+  inline def foo4: Int = { // error
     ~impl('(1))
     1
   }

--- a/tests/neg/quote-pcp-in-arg.scala
+++ b/tests/neg/quote-pcp-in-arg.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Foo {
-  rewrite def foo(x: Int): Int = ~bar('{ '(x); x }) // error
+  inline def foo(x: Int): Int = ~bar('{ '(x); x }) // error
   def bar(i: Expr[Int]): Expr[Int] = i
 }

--- a/tests/neg/quote-splice-interpret-1.scala
+++ b/tests/neg/quote-splice-interpret-1.scala
@@ -2,7 +2,7 @@
 import scala.quoted._
 
 object Macros {
-  inline def isZero(transparent n: Int): Boolean = ~{ // error
+  inline def isZero(inline n: Int): Boolean = ~{ // error
     if (n == 0) '(true)
     else '(false)
   }

--- a/tests/neg/quote-splice-interpret-1.scala
+++ b/tests/neg/quote-splice-interpret-1.scala
@@ -2,7 +2,7 @@
 import scala.quoted._
 
 object Macros {
-  rewrite def isZero(transparent n: Int): Boolean = ~{ // error
+  inline def isZero(transparent n: Int): Boolean = ~{ // error
     if (n == 0) '(true)
     else '(false)
   }

--- a/tests/neg/splice-in-top-level-splice-1.scala
+++ b/tests/neg/splice-in-top-level-splice-1.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 
 object Foo {
-  rewrite def foo(): Int = ~bar(~x) // error
+  inline def foo(): Int = ~bar(~x) // error
   def x: Expr[Int] = '(1)
   def bar(i: Int): Expr[Int] = i.toExpr
 }

--- a/tests/neg/splice-in-top-level-splice-2.scala
+++ b/tests/neg/splice-in-top-level-splice-2.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Foo {
-  rewrite def foo(): Int = ~(~x) // error
+  inline def foo(): Int = ~(~x) // error
   def x: Expr[Expr[Int]] = '( '(1) )
 }

--- a/tests/neg/tasty-macro-assert/quoted_1.scala
+++ b/tests/neg/tasty-macro-assert/quoted_1.scala
@@ -11,7 +11,7 @@ object Asserts {
 
   object Ops
 
-  rewrite def macroAssert(cond: => Boolean): Unit =
+  inline def macroAssert(cond: => Boolean): Unit =
     ~impl('(cond))
 
   def impl(cond: Expr[Boolean])(implicit tasty: Tasty): Expr[Unit] = {

--- a/tests/neg/transparent-override/A_1.scala
+++ b/tests/neg/transparent-override/A_1.scala
@@ -1,6 +1,6 @@
 abstract class A {
    def f(x: Int): Int
-   rewrite def g(x: Int): Int = x
+   inline def g(x: Int): Int = x
 }
 
 

--- a/tests/neg/transparent-override/B_2.scala
+++ b/tests/neg/transparent-override/B_2.scala
@@ -1,5 +1,5 @@
 class B extends A {
-  rewrite def f(x: Int): Int = rewrite x match { // error
+  inline def f(x: Int): Int = inline x match { // error
     case 0 => 1
     case _ => x
   }

--- a/tests/neg/tuple-patterns2.scala
+++ b/tests/neg/tuple-patterns2.scala
@@ -1,5 +1,5 @@
 object Test {
   (1, 2) match {
-    case x *: xs =>  // error: call to rewrite unapply
+    case x *: xs =>  // error: call to inline unapply
   }
 }

--- a/tests/neg/typelevel-erased-leak.scala
+++ b/tests/neg/typelevel-erased-leak.scala
@@ -5,7 +5,7 @@ object typelevel {
 
 object Test {
 
-  rewrite def test[T] = rewrite typelevel.erasedValue[T] match {  // error
+  inline def test[T] = inline typelevel.erasedValue[T] match {  // error
     case b: Byte => b
     case c: Char => "A"
   }

--- a/tests/neg/typelevel-noeta.scala
+++ b/tests/neg/typelevel-noeta.scala
@@ -2,12 +2,12 @@
 object Test {
   def anyValue[T]: T = ???
 
-  rewrite def test(x: Int) = rewrite x match {
+  inline def test(x: Int) = inline x match {
     case _: Byte =>
     case _: Char =>
   }
 
-  rewrite def test2() = rewrite 1 match {
+  inline def test2() = inline 1 match {
     case _: Byte =>
     case _: Char =>
   }

--- a/tests/neg/typelevel-nomatch.scala
+++ b/tests/neg/typelevel-nomatch.scala
@@ -2,7 +2,7 @@
 object Test {
   def anyValue[T]: T = ???
 
-  rewrite def test[T] = rewrite anyValue[T] match {  // error
+  inline def test[T] = inline anyValue[T] match {  // error
     case _: Byte =>
     case _: Char =>
   }

--- a/tests/neg/typelevel.scala
+++ b/tests/neg/typelevel.scala
@@ -2,43 +2,43 @@ trait HList {
   def length: Int
   def head: Any
   def tail: HList
-  rewrite def isEmpty: Boolean =
+  inline def isEmpty: Boolean =
     length == 0
 }
 
 // ()
 case object HNil extends HList {
-  rewrite def length = 0
+  inline def length = 0
   def head: Nothing = ???
   def tail: Nothing = ???
 }
 
 // (H, T)
 case class HCons[H, T <: HList](hd: H, tl: T) extends HList {
-  rewrite def length = 1 + tl.length
+  inline def length = 1 + tl.length
   def head: H = this.hd
   def tail: T = this.tl
 }
 
 object Test {
-  rewrite def concat(xs: HList, ys: HList): HList =
+  inline def concat(xs: HList, ys: HList): HList =
     if xs.isEmpty then ys
     else HCons(xs.head, concat(xs.tail, ys))
 
   class Deco(private val as: HList) {
-    rewrite def ++ (bs: HList) = concat(as, bs)
+    inline def ++ (bs: HList) = concat(as, bs)
   }
 
   class Deco0(val as: HList) {
     println("HI")
-    rewrite def ++ (bs: HList) = concat(as, bs)
+    inline def ++ (bs: HList) = concat(as, bs)
   }
 
   class Eff {
     println("HI")
   }
   class Deco1(val as: HList) extends Eff {
-    rewrite def ++ (bs: HList) = concat(as, bs)
+    inline def ++ (bs: HList) = concat(as, bs)
   }
 
   // Test that selections from impure classes cannot be projected away
@@ -53,6 +53,6 @@ object Test {
   val rr1a: HCons[Int, HNil.type] = rr1   // error (type error because no inline)
 
   class Deco2(val as: HList) extends java.lang.Cloneable with java.lang.Comparable[Deco2] {
-    rewrite def ++ (bs: HList) = concat(as, bs)
+    inline def ++ (bs: HList) = concat(as, bs)
   }
 }

--- a/tests/pos-deep-subtype/tuples23.scala
+++ b/tests/pos-deep-subtype/tuples23.scala
@@ -14,7 +14,7 @@ object Test extends App {
     case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23) =>
       println(x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23)
   }
-  rewrite def decompose3 = rewrite x23 match { case x *: y *: xs => (x, y, xs) }
+  inline def decompose3 = inline x23 match { case x *: y *: xs => (x, y, xs) }
 
   { val (x, y, xs) = decompose3
     val xc: Int = x

--- a/tests/pos-with-compiler/quote-0.scala
+++ b/tests/pos-with-compiler/quote-0.scala
@@ -4,7 +4,7 @@ import scala.quoted.Toolbox.Default._
 
 object Macros {
 
-  rewrite def assert(expr: => Boolean): Unit =
+  inline def assert(expr: => Boolean): Unit =
     ~assertImpl('(expr))
 
   def assertImpl(expr: Expr[Boolean]) =
@@ -12,7 +12,7 @@ object Macros {
 
   def showExpr[T](expr: Expr[T]): Expr[String] = expr.toString.toExpr
 
-  rewrite def power(transparent n: Int, x: Double) = ~powerCode(n, '(x))
+  inline def power(transparent n: Int, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Int, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/tests/pos-with-compiler/quote-0.scala
+++ b/tests/pos-with-compiler/quote-0.scala
@@ -12,7 +12,7 @@ object Macros {
 
   def showExpr[T](expr: Expr[T]): Expr[String] = expr.toString.toExpr
 
-  inline def power(transparent n: Int, x: Double) = ~powerCode(n, '(x))
+  inline def power(inline n: Int, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Int, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/tests/pos-with-compiler/quote-assert/quoted_2.scala
+++ b/tests/pos-with-compiler/quote-assert/quoted_2.scala
@@ -4,7 +4,7 @@ import Macros._
 
 object Test {
 
-  rewrite def assert(expr: => Boolean): Unit =
+  inline def assert(expr: => Boolean): Unit =
     ~ assertImpl('(expr))
 
 

--- a/tests/pos-with-compiler/tasty/definitions.scala
+++ b/tests/pos-with-compiler/tasty/definitions.scala
@@ -236,7 +236,7 @@ object definitions {
     def isLazy: Boolean
     def isOverride: Boolean
     def isInline: Boolean
-    def isMacro: Boolean                 // rewrite method containing toplevel splices
+    def isMacro: Boolean                 // inline method containing toplevel splices
     def isStatic: Boolean                // mapped to static Java member
     def isObject: Boolean                // an object or its class (used for a ValDef or a ClassDef extends Modifier respectively)
     def isTrait: Boolean                 // a trait (used for a ClassDef)

--- a/tests/pos/SI-7060.scala
+++ b/tests/pos/SI-7060.scala
@@ -1,6 +1,6 @@
 object Test {
 
-  rewrite final def mbarray_apply_minibox(array: Any, tag: Byte): Long =
+  inline final def mbarray_apply_minibox(array: Any, tag: Byte): Long =
     if (tag == 0) {
       array.asInstanceOf[Array[Long]](0)
     } else

--- a/tests/pos/depfuntype.scala
+++ b/tests/pos/depfuntype.scala
@@ -19,7 +19,7 @@ object Test {
   // Reproduced here because the one from DottyPredef is lacking a Tasty tree and
   // therefore can't be inlined when testing non-bootstrapped.
   // But inlining `implicitly` is vital to make the definition of `ifun` below work.
-  rewrite final def implicitly[T](implicit ev: T): T = ev
+  inline final def implicitly[T](implicit ev: T): T = ev
 
   type IDF = implicit (x: C) => x.M
 

--- a/tests/pos/harmonize.scala
+++ b/tests/pos/harmonize.scala
@@ -3,7 +3,7 @@ object Test {
   def main(args: Array[String]) = {
     val x = true
     val n = 1
-    transparent val nn = 2
+    inline val nn = 2
     val y = if (x) 'A' else n
     val z: Int = y
 
@@ -41,7 +41,7 @@ object Test {
 
   }
 
-  transparent val b = 33
+  inline val b = 33
   def f(): Int = b + 1
   val a1 = Array(b, 33, 'a')
   val b1: Array[Int] = a1

--- a/tests/pos/i1570.decompiled
+++ b/tests/pos/i1570.decompiled
@@ -1,5 +1,5 @@
 /** Decompiled from out/posTestFromTasty/pos/i1570/Test.class */
 object Test {
-  rewrite def foo(n: scala.Int): scala.Int = Test.bar(n)
-  rewrite def bar(n: scala.Int): scala.Int = n
+  inline def foo(n: scala.Int): scala.Int = Test.bar(n)
+  inline def bar(n: scala.Int): scala.Int = n
 }

--- a/tests/pos/i1570.scala
+++ b/tests/pos/i1570.scala
@@ -1,4 +1,4 @@
 object Test {
-  inline def foo(transparent n: Int) = bar(n)
-  inline def bar(transparent n: Int) = n
+  inline def foo(inline n: Int) = bar(n)
+  inline def bar(inline n: Int) = n
 }

--- a/tests/pos/i1570.scala
+++ b/tests/pos/i1570.scala
@@ -1,4 +1,4 @@
 object Test {
-  rewrite def foo(transparent n: Int) = bar(n)
-  rewrite def bar(transparent n: Int) = n
+  inline def foo(transparent n: Int) = bar(n)
+  inline def bar(transparent n: Int) = n
 }

--- a/tests/pos/i1891.scala
+++ b/tests/pos/i1891.scala
@@ -4,7 +4,7 @@ object Test {
   type T2[A, B] = CC2[A, B]
 
   class ArrowAssoc[A](val self: A) {
-    rewrite def f[B](y: B): CC2[A, B] = new CC2(self, y)
+    inline def f[B](y: B): CC2[A, B] = new CC2(self, y)
   }
 
   def foo = (new ArrowAssoc(1)).f(2)

--- a/tests/pos/i1990.scala
+++ b/tests/pos/i1990.scala
@@ -1,6 +1,6 @@
 class A {
   class Foo {
-    rewrite def inlineMeth: Unit = {
+    inline def inlineMeth: Unit = {
       new Bar
     }
   }

--- a/tests/pos/i1990a.scala
+++ b/tests/pos/i1990a.scala
@@ -1,6 +1,6 @@
 class A { self =>
   class Foo {
-    rewrite def inlineMeth: Unit = {
+    inline def inlineMeth: Unit = {
       println(self)
     }
   }

--- a/tests/pos/i2056.scala
+++ b/tests/pos/i2056.scala
@@ -1,5 +1,5 @@
 object Test {
-  rewrite def crash() = {
+  inline def crash() = {
     try {
       println("hi")
     } catch {

--- a/tests/pos/i2166.scala
+++ b/tests/pos/i2166.scala
@@ -1,5 +1,5 @@
 object Test {
-  rewrite def f = rewrite "" match { case _ => false }
+  inline def f = inline "" match { case _ => false }
 
   def main(args: Array[String]): Unit = f
 }

--- a/tests/pos/i2980.scala
+++ b/tests/pos/i2980.scala
@@ -3,7 +3,7 @@ trait Foo {
 }
 
 object Foo {
-  rewrite def foo: Foo = new Foo {
+  inline def foo: Foo = new Foo {
     def apply[~>[_,_]](x: Int ~> Int): Int ~> Int = x
   }
 

--- a/tests/pos/i3050.scala
+++ b/tests/pos/i3050.scala
@@ -3,17 +3,17 @@ object Test {
   case object None extends Option[Nothing]
   case class Some[+T](x: T) extends Option[T]
 
-  rewrite def openImpl(): Int =
+  inline def openImpl(): Int =
     Some(42) match { case Some(i) => i }
 
   def open() = openImpl()
 
-  rewrite def openImpl1(): Int =
+  inline def openImpl1(): Int =
     new Some(42) match { case Some(i) => i }
 
   def open1() = openImpl1()
 
-  rewrite def openImpl2(): Int =
+  inline def openImpl2(): Int =
     None match { case None => 42 }
 
   def open2(): Int = openImpl2()
@@ -21,17 +21,17 @@ object Test {
 
 // Same as Test, with Scala2 case classes
 object Test2 {
-  rewrite def openImpl(): Int =
+  inline def openImpl(): Int =
     Some(42) match { case Some(i) => i }
 
   def open() = openImpl()
 
-  rewrite def openImpl1(): Int =
+  inline def openImpl1(): Int =
     new Some(42) match { case Some(i) => i }
 
   def open1() = openImpl1()
 
-  rewrite def openImpl2(): Int =
+  inline def openImpl2(): Int =
      None match { case None => 42 }
 
   def open2(): Int = openImpl2()

--- a/tests/pos/i3082.scala
+++ b/tests/pos/i3082.scala
@@ -1,6 +1,6 @@
 object Test {
   private def foo(arg1: Int): Int = {
-    rewrite def bar: Int = foo(0)
+    inline def bar: Int = foo(0)
     if (arg1 == 0) 0 else bar
   }
   assert(foo(11) == 0)

--- a/tests/pos/i3129.scala
+++ b/tests/pos/i3129.scala
@@ -1,5 +1,5 @@
 object companions2 {
-  rewrite def foo() = {
+  inline def foo() = {
     class C {
       println(C.p)
     }
@@ -15,7 +15,7 @@ class A {
 
   class B {
     private def getAncestor2(p: A): A = p
-    private rewrite def getAncestor(p: A): A = {
+    private inline def getAncestor(p: A): A = {
       p.b.getAncestor(p)
     }
   }

--- a/tests/pos/i3130a.scala
+++ b/tests/pos/i3130a.scala
@@ -5,6 +5,6 @@ object O {
  class D(val x: Int) {
   class DD()
   object DD {
-   rewrite def apply() = x // new DD()
+   inline def apply() = x // new DD()
   }
 }

--- a/tests/pos/i3130b.scala
+++ b/tests/pos/i3130b.scala
@@ -1,6 +1,6 @@
 class Outer {
   trait F { def f(): Int }
-  rewrite def inner: F = {
+  inline def inner: F = {
     class InnerClass(x: Int) extends F {
       def this() = this(3)
       def f() = x

--- a/tests/pos/i3130c.scala
+++ b/tests/pos/i3130c.scala
@@ -6,7 +6,7 @@ trait Test {
 
   trait TreeBuilder {
     val global: Global
-    rewrite def set(tree: global.Tree) = {}
+    inline def set(tree: global.Tree) = {}
   }
 
   val nsc: Global

--- a/tests/pos/i3130d.scala
+++ b/tests/pos/i3130d.scala
@@ -1,6 +1,6 @@
 class D(x: Int) {
   class DD {
-    rewrite def apply() = new DD()
+    inline def apply() = new DD()
   }
   val inner = new DD
 }

--- a/tests/pos/i3488.scala
+++ b/tests/pos/i3488.scala
@@ -4,7 +4,7 @@ class Sett[A] {
 
   def incl(elem: A): Sett[A] = ???
 
-  rewrite final def + (elem: A): Sett[A] = incl(elem)
+  inline final def + (elem: A): Sett[A] = incl(elem)
 }
 
 object Sett {

--- a/tests/pos/i3608.scala
+++ b/tests/pos/i3608.scala
@@ -1,6 +1,6 @@
 class A {
   class Foo {
-    rewrite def inlineMeth: Unit = new Bar
+    inline def inlineMeth: Unit = new Bar
   }
   class Bar
 }

--- a/tests/pos/i3633.scala
+++ b/tests/pos/i3633.scala
@@ -1,4 +1,4 @@
 class Test {
-  rewrite def foo = 1
+  inline def foo = 1
   def test = -foo
 }

--- a/tests/pos/i3636.scala
+++ b/tests/pos/i3636.scala
@@ -1,11 +1,11 @@
 trait Iterable[A] {
   def concat[B >: A](that: Iterable[B]): Iterable[B] = ???
-  rewrite final def ++ [B >: A](that: Iterable[B]): Iterable[B] = concat(that)
+  inline final def ++ [B >: A](that: Iterable[B]): Iterable[B] = concat(that)
 }
 
 class BitSet extends Iterable[Int] {
   def concat(that: Iterable[Int]): BitSet = ???
-  rewrite final def ++ (that: Iterable[Int]): BitSet = concat(that)
+  inline final def ++ (that: Iterable[Int]): BitSet = concat(that)
 }
 
 class Test {

--- a/tests/pos/i3873.scala
+++ b/tests/pos/i3873.scala
@@ -1,5 +1,5 @@
 object Test {
-  rewrite def sum2(ys: List[Int]): Unit = {
+  inline def sum2(ys: List[Int]): Unit = {
     ys.foldLeft(1)
   }
   val h1 = (xs: List[Int]) => sum2(xs)

--- a/tests/pos/i3898/quoted_1.scala
+++ b/tests/pos/i3898/quoted_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  rewrite def ff(args: Any*): String = ~impl('(args))
+  inline def ff(args: Any*): String = ~impl('(args))
   def impl(args: Expr[Seq[Any]]): Expr[String] = '("")
 }

--- a/tests/pos/i3898b/quoted_1.scala
+++ b/tests/pos/i3898b/quoted_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  inline def ff(x: Int, transparent y: Int): String = ~impl('(x))
+  inline def ff(x: Int, inline y: Int): String = ~impl('(x))
   def impl(x: Expr[Int]): Expr[String] = '("")
 }

--- a/tests/pos/i3898b/quoted_1.scala
+++ b/tests/pos/i3898b/quoted_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  rewrite def ff(x: Int, transparent y: Int): String = ~impl('(x))
+  inline def ff(x: Int, transparent y: Int): String = ~impl('(x))
   def impl(x: Expr[Int]): Expr[String] = '("")
 }

--- a/tests/pos/i3898c/quoted_1.scala
+++ b/tests/pos/i3898c/quoted_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  inline def ff(x: Int, transparent y: Int): String = ~impl('(x))
+  inline def ff(x: Int, inline y: Int): String = ~impl('(x))
   def impl(x: Expr[Int]): Expr[String] = '("")
 }

--- a/tests/pos/i3898c/quoted_1.scala
+++ b/tests/pos/i3898c/quoted_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  rewrite def ff(x: Int, transparent y: Int): String = ~impl('(x))
+  inline def ff(x: Int, transparent y: Int): String = ~impl('(x))
   def impl(x: Expr[Int]): Expr[String] = '("")
 }

--- a/tests/pos/i3912-1/i3912_1.scala
+++ b/tests/pos/i3912-1/i3912_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 
 object Macros {
-  rewrite def foo(): Int = { ~impl() }
+  inline def foo(): Int = { ~impl() }
 
   def impl(): Expr[Int] = '(1)
 }

--- a/tests/pos/i3912-2/i3912_1.scala
+++ b/tests/pos/i3912-2/i3912_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 
 object Macros {
-  rewrite def foo2(): Unit = ~impl()
+  inline def foo2(): Unit = ~impl()
 
   def impl(): Expr[Int] = '(1)
 }

--- a/tests/pos/i3912-3/i3912_1.scala
+++ b/tests/pos/i3912-3/i3912_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 
 object Macros {
-  rewrite def foo3(): Int = {
+  inline def foo3(): Int = {
     {
       ~impl()
     }

--- a/tests/pos/i4006.scala
+++ b/tests/pos/i4006.scala
@@ -1,4 +1,4 @@
 class Foo {
-  rewrite def foo: Int = try { 1 } finally println("Hello")
+  inline def foo: Int = try { 1 } finally println("Hello")
   foo
 }

--- a/tests/pos/i4006b.scala
+++ b/tests/pos/i4006b.scala
@@ -1,4 +1,4 @@
 class Foo {
-  rewrite def foo: Int = try { 1 } catch { case _ => 4 } finally println("Hello")
+  inline def foo: Int = try { 1 } catch { case _ => 4 } finally println("Hello")
   foo
 }

--- a/tests/pos/i4006c.scala
+++ b/tests/pos/i4006c.scala
@@ -1,4 +1,4 @@
 class Foo {
-  rewrite def foo: Int = try { 1 } catch { case _ => 4 }
+  inline def foo: Int = try { 1 } catch { case _ => 4 }
   foo
 }

--- a/tests/pos/i4023/Macro_1.scala
+++ b/tests/pos/i4023/Macro_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  rewrite def ff[T: Type](x: T): T = ~impl('(x))
+  inline def ff[T: Type](x: T): T = ~impl('(x))
   def impl[T](x: Expr[T]): Expr[T] = x
 }

--- a/tests/pos/i4023b/Macro_1.scala
+++ b/tests/pos/i4023b/Macro_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  rewrite def ff[T](implicit t: Type[T]): Int = ~impl[T]
+  inline def ff[T](implicit t: Type[T]): Int = ~impl[T]
   def impl[T]: Expr[Int] = '(4)
 }

--- a/tests/pos/i4023c/Macro_1.scala
+++ b/tests/pos/i4023c/Macro_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  rewrite def ff[T](x: T): T = ~impl('(x), '[T])
+  inline def ff[T](x: T): T = ~impl('(x), '[T])
   def impl[T](x: Expr[T], t: Type[T]): Expr[T] = '{ (~x): ~t }
 }

--- a/tests/pos/i4322.scala
+++ b/tests/pos/i4322.scala
@@ -3,12 +3,12 @@ object Foo {
 
   private def x(n: String): Int = n.toInt
 
-  rewrite def foo: Int = x + x + x("22")
+  inline def foo: Int = x + x + x("22")
 
-  rewrite def bar = {
+  inline def bar = {
     x += 1
     x += 1
   }
 
-  rewrite def baz = { x += x("11") }
+  inline def baz = { x += x("11") }
 }

--- a/tests/pos/i4493-c.scala
+++ b/tests/pos/i4493-c.scala
@@ -1,6 +1,6 @@
 class Index[K]
 object Index {
-  rewrite def succ[K]: Unit = ~{
+  inline def succ[K]: Unit = ~{
     '(new Index[K])
   }
 }

--- a/tests/pos/i4514.scala
+++ b/tests/pos/i4514.scala
@@ -1,4 +1,4 @@
 object Foo {
-  rewrite def foo[X](x: X): Unit = ~fooImpl('(x))
+  inline def foo[X](x: X): Unit = ~fooImpl('(x))
   def fooImpl[X: quoted.Type](x: X): quoted.Expr[Unit] = '()
 }

--- a/tests/pos/i4586.scala
+++ b/tests/pos/i4586.scala
@@ -1,4 +1,4 @@
 class Foo {
-  rewrite def foo1(f: => Int => Int): Int = f(7)
+  inline def foo1(f: => Int => Int): Int = f(7)
   def bar1 = foo1(x => x + 1)
 }

--- a/tests/pos/i4590.scala
+++ b/tests/pos/i4590.scala
@@ -1,7 +1,7 @@
 package test
 
 class ArrayDeque {
-  rewrite def isResizeNecessary(len: Int) = len > ArrayDeque.StableSize
+  inline def isResizeNecessary(len: Int) = len > ArrayDeque.StableSize
 }
 
 object ArrayDeque {
@@ -9,7 +9,7 @@ object ArrayDeque {
 }
 
 class List {
-  rewrite def foo(x: List.Cons): Unit = {
+  inline def foo(x: List.Cons): Unit = {
     x.next = this
   }
 }

--- a/tests/pos/i4734/Macro_1.scala
+++ b/tests/pos/i4734/Macro_1.scala
@@ -2,7 +2,7 @@ import scala.annotation.tailrec
 import scala.quoted._
 
 object Macros {
-  rewrite def unrolledForeach(f: Int => Int): Int =
+  inline def unrolledForeach(f: Int => Int): Int =
   ~unrolledForeachImpl('(f))
 
   def unrolledForeachImpl(f: Expr[Int => Int]): Expr[Int] = '{

--- a/tests/pos/i4773.scala
+++ b/tests/pos/i4773.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 
 object Foo {
-  rewrite def foo2(): Unit = ~foo2Impl()
+  inline def foo2(): Unit = ~foo2Impl()
   def foo2Impl(): Expr[Unit] = '()
-  rewrite def foo(): Unit = foo2()
+  inline def foo(): Unit = foo2()
 }

--- a/tests/pos/i4846.scala
+++ b/tests/pos/i4846.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Test {
-  inline def foo(transparent x: Int): Int = ~fooImpl(x, '(x), '( '(x) ), '( '( '(x) ) ))
+  inline def foo(inline x: Int): Int = ~fooImpl(x, '(x), '( '(x) ), '( '( '(x) ) ))
   def fooImpl(a: Int, b: Expr[Int], c: Expr[Expr[Int]], d: Expr[Expr[Expr[Int]]]): Expr[Int] = ???
 }

--- a/tests/pos/i4846.scala
+++ b/tests/pos/i4846.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Test {
-  rewrite def foo(transparent x: Int): Int = ~fooImpl(x, '(x), '( '(x) ), '( '( '(x) ) ))
+  inline def foo(transparent x: Int): Int = ~fooImpl(x, '(x), '( '(x) ), '( '( '(x) ) ))
   def fooImpl(a: Int, b: Expr[Int], c: Expr[Expr[Int]], d: Expr[Expr[Expr[Int]]]): Expr[Int] = ???
 }

--- a/tests/pos/inline-access-levels/A_1.scala
+++ b/tests/pos/inline-access-levels/A_1.scala
@@ -4,7 +4,7 @@ object A {
 
   private var x: Int = 0
 
-  rewrite def actOnX(f: Int => Int) = {
+  inline def actOnX(f: Int => Int) = {
     x = f(x)
   }
 }

--- a/tests/pos/inline-apply.scala
+++ b/tests/pos/inline-apply.scala
@@ -3,7 +3,7 @@ class Context
 object Test {
 
   def transform()(implicit ctx: Context) = {
-    rewrite def withLocalOwner[T](op: Context => T) = op(ctx)
+    inline def withLocalOwner[T](op: Context => T) = op(ctx)
 
     withLocalOwner { implicit ctx => }
 

--- a/tests/pos/inline-i2570.scala
+++ b/tests/pos/inline-i2570.scala
@@ -1,4 +1,4 @@
 object Test {
-  rewrite def sum2(ys: List[Int]): Int = (1 /: ys)(_ + _)
+  inline def sum2(ys: List[Int]): Int = (1 /: ys)(_ + _)
   val h1 = (xs:  List[Int]) => sum2(xs)
 }

--- a/tests/pos/inline-named-typeargs.scala
+++ b/tests/pos/inline-named-typeargs.scala
@@ -1,5 +1,5 @@
 object t1 {
-  rewrite def construct[Elem, Coll[_]](xs: List[Elem]): Coll[Elem] = ???
+  inline def construct[Elem, Coll[_]](xs: List[Elem]): Coll[Elem] = ???
 
   val xs3 = construct[Coll = List](List(1, 2, 3))
 }

--- a/tests/pos/inline-t2425.scala
+++ b/tests/pos/inline-t2425.scala
@@ -1,5 +1,5 @@
 object Test extends App {
-  rewrite def foo[T](bar: T) = {
+  inline def foo[T](bar: T) = {
     bar match {
       case _ => ()
     }

--- a/tests/pos/inlineAccesses.scala
+++ b/tests/pos/inlineAccesses.scala
@@ -6,12 +6,12 @@ class C {
   private type T = C
   private var x = 0
 
-  rewrite def f = {
+  inline def f = {
     x += 1
     x = x + 1
     x
   }
-  rewrite def dup = new T
+  inline def dup = new T
 }
 
 object Test {

--- a/tests/pos/inliner2.scala
+++ b/tests/pos/inliner2.scala
@@ -3,7 +3,7 @@
 // for inlining due to the bug.
 class A {
   private var debug = false
-  rewrite private def ifelse[T](cond: => Boolean, ifPart: => T, elsePart: => T): T =
+  inline private def ifelse[T](cond: => Boolean, ifPart: => T, elsePart: => T): T =
     if (cond) ifPart else elsePart
 
   final def bob1() = ifelse(debug, 1, 2)

--- a/tests/pos/macro-with-array/Macro_1.scala
+++ b/tests/pos/macro-with-array/Macro_1.scala
@@ -1,29 +1,29 @@
 
 object Macro {
 
-  rewrite def foo0(i: Int): Unit = ~{ '() }
-  rewrite def foo1(arr: Array[Boolean]): Unit = ~{ '() }
-  rewrite def foo2(arr: Array[Byte]): Unit = ~{ '() }
-  rewrite def foo3(arr: Array[Short]): Unit = ~{ '() }
-  rewrite def foo4(arr: Array[Int]): Unit = ~{ '() }
-  rewrite def foo5(arr: Array[Long]): Unit = ~{ '() }
-  rewrite def foo6(arr: Array[Float]): Unit = ~{ '() }
-  rewrite def foo7(arr: Array[Double]): Unit = ~{ '() }
-  rewrite def foo8(arr: Array[Char]): Unit = ~{ '() }
-  rewrite def foo9(arr: Array[Object]): Unit = ~{ '() }
-  rewrite def foo10(arr: Array[String]): Unit = ~{ '() }
-  rewrite def foo11[T](arr: Array[T]): Unit = ~{ '() }
-  rewrite def foo12(arr: Array[Array[Int]]): Unit = ~{ '() }
-  rewrite def foo13(arr: Array[Array[String]]): Unit = ~{ '() }
-  rewrite def foo14(arr: Array[Array[Array[Int]]]): Unit = ~{ '() }
-  rewrite def foo15(arr: Array[Any]): Unit = ~{ '() }
-  rewrite def foo16(arr: Array[AnyVal]): Unit = ~{ '() }
-  rewrite def foo17(arr: Array[AnyRef]): Unit = ~{ '() }
-  rewrite def foo18(arr: Array[Foo]): Unit = ~{ '() }
-  rewrite def foo19(arr: Array[Macro.type]): Unit = ~{ '() }
-  rewrite def foo20(arr: Array[Bar]): Unit = ~{ '() }
-  rewrite def foo21(arr: Array[Baz.type]): Unit = ~{ '() }
-  rewrite def foo22(arr: Array[Foo#A]): Unit = ~{ '() }
+  inline def foo0(i: Int): Unit = ~{ '() }
+  inline def foo1(arr: Array[Boolean]): Unit = ~{ '() }
+  inline def foo2(arr: Array[Byte]): Unit = ~{ '() }
+  inline def foo3(arr: Array[Short]): Unit = ~{ '() }
+  inline def foo4(arr: Array[Int]): Unit = ~{ '() }
+  inline def foo5(arr: Array[Long]): Unit = ~{ '() }
+  inline def foo6(arr: Array[Float]): Unit = ~{ '() }
+  inline def foo7(arr: Array[Double]): Unit = ~{ '() }
+  inline def foo8(arr: Array[Char]): Unit = ~{ '() }
+  inline def foo9(arr: Array[Object]): Unit = ~{ '() }
+  inline def foo10(arr: Array[String]): Unit = ~{ '() }
+  inline def foo11[T](arr: Array[T]): Unit = ~{ '() }
+  inline def foo12(arr: Array[Array[Int]]): Unit = ~{ '() }
+  inline def foo13(arr: Array[Array[String]]): Unit = ~{ '() }
+  inline def foo14(arr: Array[Array[Array[Int]]]): Unit = ~{ '() }
+  inline def foo15(arr: Array[Any]): Unit = ~{ '() }
+  inline def foo16(arr: Array[AnyVal]): Unit = ~{ '() }
+  inline def foo17(arr: Array[AnyRef]): Unit = ~{ '() }
+  inline def foo18(arr: Array[Foo]): Unit = ~{ '() }
+  inline def foo19(arr: Array[Macro.type]): Unit = ~{ '() }
+  inline def foo20(arr: Array[Bar]): Unit = ~{ '() }
+  inline def foo21(arr: Array[Baz.type]): Unit = ~{ '() }
+  inline def foo22(arr: Array[Foo#A]): Unit = ~{ '() }
 
   class Bar
   object Baz

--- a/tests/pos/macro-with-type/Macro_1.scala
+++ b/tests/pos/macro-with-type/Macro_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  rewrite def ff: Unit = ~impl('[Int])
+  inline def ff: Unit = ~impl('[Int])
   def impl(t: Type[Int]): Expr[Unit] = '()
 }

--- a/tests/pos/matchtype.scala
+++ b/tests/pos/matchtype.scala
@@ -17,13 +17,13 @@ object Test {
 
   erased val x2: 1 = erasedValue[T1]
 
-  rewrite def checkSub[T1, T2] =
-    rewrite typelevel.erasedValue[T1] match {
+  inline def checkSub[T1, T2] =
+    inline typelevel.erasedValue[T1] match {
       case _: T2 => // OK
       case _ => error("not a subtype T1/T2")
     }
 
-  rewrite def checkSame[T1, T2] = {
+  inline def checkSame[T1, T2] = {
     checkSub[T1, T2]
     checkSub[T2, T1]
   }
@@ -65,7 +65,7 @@ object Test {
   checkSame[Concat[(Boolean, Boolean), (String, Int)], Boolean *: Boolean *: (String, Int)]
   checkSub[(Boolean, Boolean, String, Int), Concat[(Boolean, Boolean), String *: Int *: Unit]]
 
-  rewrite def index[Xs <: NonEmptyTuple](xs: Xs, n: Int): Elem[Xs, n.type] = xs(n).asInstanceOf
+  inline def index[Xs <: NonEmptyTuple](xs: Xs, n: Int): Elem[Xs, n.type] = xs(n).asInstanceOf
 
   val test = (1, "hi", true, 2.0)
   index(test, 0): Int

--- a/tests/pos/pos_valueclasses/t5853.scala
+++ b/tests/pos/pos_valueclasses/t5853.scala
@@ -41,7 +41,7 @@ class Foo2 {
 
 object Arrow {
   implicit final class ArrowAssoc[A](val __leftOfArrow: A) extends AnyVal {
-    rewrite def ->>[B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
+    inline def ->>[B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
   }
 
   def foo = 1 ->> 2
@@ -50,7 +50,7 @@ object Arrow {
 
 object SpecArrow {
   implicit final class ArrowAssoc[A](val __leftOfArrow: A) extends AnyVal {
-    rewrite def ->> [@specialized(Int) B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
+    inline def ->> [@specialized(Int) B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
   }
 
   def foo = 1 ->> 2

--- a/tests/pos/power-macro/Macro_1.scala
+++ b/tests/pos/power-macro/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted.Expr
 
 object PowerMacro {
 
-  rewrite def power(transparent n: Long, x: Double) = ~powerCode(n, '(x))
+  inline def power(transparent n: Long, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Long, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/tests/pos/power-macro/Macro_1.scala
+++ b/tests/pos/power-macro/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted.Expr
 
 object PowerMacro {
 
-  inline def power(transparent n: Long, x: Double) = ~powerCode(n, '(x))
+  inline def power(inline n: Long, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Long, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/tests/pos/quote-lift-inline-params-b.scala
+++ b/tests/pos/quote-lift-inline-params-b.scala
@@ -1,7 +1,7 @@
 import scala.quoted.Expr
 import quoted.Liftable.{IntIsLiftable => _}
 object Macro {
-  rewrite def foo(transparent n: Int): Int = ~{
+  inline def foo(transparent n: Int): Int = ~{
     '(n)
   }
 }

--- a/tests/pos/quote-lift-inline-params-b.scala
+++ b/tests/pos/quote-lift-inline-params-b.scala
@@ -1,7 +1,7 @@
 import scala.quoted.Expr
 import quoted.Liftable.{IntIsLiftable => _}
 object Macro {
-  inline def foo(transparent n: Int): Int = ~{
+  inline def foo(inline n: Int): Int = ~{
     '(n)
   }
 }

--- a/tests/pos/quote-lift-inline-params/Macro_1.scala
+++ b/tests/pos/quote-lift-inline-params/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted.Expr
 object Macro {
   import quoted.Liftable.{IntIsLiftable => _}
-  rewrite def foo(transparent n: Int): Int = ~{
+  inline def foo(transparent n: Int): Int = ~{
     '(n)
   }
 }

--- a/tests/pos/quote-lift-inline-params/Macro_1.scala
+++ b/tests/pos/quote-lift-inline-params/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted.Expr
 object Macro {
   import quoted.Liftable.{IntIsLiftable => _}
-  inline def foo(transparent n: Int): Int = ~{
+  inline def foo(inline n: Int): Int = ~{
     '(n)
   }
 }

--- a/tests/pos/quote-nested-object/Macro_1.scala
+++ b/tests/pos/quote-nested-object/Macro_1.scala
@@ -6,7 +6,7 @@ object Macro {
 
   object Implementation {
 
-    inline def plus(transparent n: Int, m: Int): Int = ~plus(n, '(m))
+    inline def plus(inline n: Int, m: Int): Int = ~plus(n, '(m))
 
     def plus(n: Int, m: Expr[Int]): Expr[Int] =
       if (n == 0) m
@@ -14,7 +14,7 @@ object Macro {
 
     object Implementation2 {
 
-      inline def plus(transparent n: Int, m: Int): Int = ~plus(n, '(m))
+      inline def plus(inline n: Int, m: Int): Int = ~plus(n, '(m))
 
       def plus(n: Int, m: Expr[Int]): Expr[Int] =
         if (n == 0) m

--- a/tests/pos/quote-nested-object/Macro_1.scala
+++ b/tests/pos/quote-nested-object/Macro_1.scala
@@ -6,7 +6,7 @@ object Macro {
 
   object Implementation {
 
-    rewrite def plus(transparent n: Int, m: Int): Int = ~plus(n, '(m))
+    inline def plus(transparent n: Int, m: Int): Int = ~plus(n, '(m))
 
     def plus(n: Int, m: Expr[Int]): Expr[Int] =
       if (n == 0) m
@@ -14,7 +14,7 @@ object Macro {
 
     object Implementation2 {
 
-      rewrite def plus(transparent n: Int, m: Int): Int = ~plus(n, '(m))
+      inline def plus(transparent n: Int, m: Int): Int = ~plus(n, '(m))
 
       def plus(n: Int, m: Expr[Int]): Expr[Int] =
         if (n == 0) m

--- a/tests/pos/quote-non-static-macro.scala
+++ b/tests/pos/quote-non-static-macro.scala
@@ -1,18 +1,18 @@
 import scala.quoted._
 
 class Foo {
-  rewrite def foo: Unit = ~Foo.impl
+  inline def foo: Unit = ~Foo.impl
   object Bar {
-    rewrite def foo: Unit = ~Foo.impl
+    inline def foo: Unit = ~Foo.impl
   }
 }
 
 object Foo {
   class Baz {
-    rewrite def foo: Unit = ~impl
+    inline def foo: Unit = ~impl
   }
   object Quox {
-    rewrite def foo: Unit = ~Foo.impl
+    inline def foo: Unit = ~Foo.impl
   }
   def impl: Expr[Unit] = '()
 }

--- a/tests/pos/rbtree.scala
+++ b/tests/pos/rbtree.scala
@@ -457,11 +457,11 @@ object RedBlackTree {
   }
 
   object RedTree {
-    rewrite def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new RedTree(key, value, left, right)
+    inline def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new RedTree(key, value, left, right)
     def unapply[A, B](t: RedTree[A, B]) = Some((t.key, t.value, t.left, t.right))
   }
   object BlackTree {
-    rewrite def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new BlackTree(key, value, left, right)
+    inline def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new BlackTree(key, value, left, right)
     def unapply[A, B](t: BlackTree[A, B]) = Some((t.key, t.value, t.left, t.right))
   }
 

--- a/tests/pos/reference/inlines.scala
+++ b/tests/pos/reference/inlines.scala
@@ -8,7 +8,7 @@ object Logger {
 
   private var indent = 0
 
-  rewrite def log[T](msg: String)(op: => T): T =
+  inline def log[T](msg: String)(op: => T): T =
     if (Config.logging) {
       println(s"${"  " * indent}start $msg")
       indent += 1

--- a/tests/pos/reference/inlines.scala
+++ b/tests/pos/reference/inlines.scala
@@ -1,7 +1,7 @@
 package inlines
 
 object Config {
-  transparent val logging = false
+  inline val logging = false
 }
 
 object Logger {

--- a/tests/pos/sealed-final.scala
+++ b/tests/pos/sealed-final.scala
@@ -1,5 +1,5 @@
 sealed abstract class Foo {
-  rewrite def bar(x: Int) = x + 1
+  inline def bar(x: Int) = x + 1
 }
 object Foo {
   def mkFoo(): Foo = new Baz2

--- a/tests/pos/simpleInline.decompiled
+++ b/tests/pos/simpleInline.decompiled
@@ -1,6 +1,6 @@
 /** Decompiled from out/posTestFromTasty/pos/simpleInline/Foo.class */
 class Foo() {
-  rewrite def foo: scala.Int = 9
+  inline def foo: scala.Int = 9
   def bar: scala.Int = { // inlined
     9
   }

--- a/tests/pos/simpleInline.scala
+++ b/tests/pos/simpleInline.scala
@@ -1,4 +1,4 @@
 class Foo {
-  rewrite def foo: Int = 9
+  inline def foo: Int = 9
   def bar: Int = foo
 }

--- a/tests/pos/t6157.scala
+++ b/tests/pos/t6157.scala
@@ -12,7 +12,7 @@ import java.io.IOException
 
 object ErrorHandler {
 
-  rewrite def defaultIfIOException[T](default: => T)(closure: => T): T = {
+  inline def defaultIfIOException[T](default: => T)(closure: => T): T = {
     try {
       closure
     } catch {

--- a/tests/pos/t6562.scala
+++ b/tests/pos/t6562.scala
@@ -1,11 +1,11 @@
 class Test {
 
-  rewrite def foo: Unit = {
+  inline def foo: Unit = {
     def it = new {}
     (_: Any) => it
   }
 
-  rewrite private def bar: Unit = {
+  inline private def bar: Unit = {
     def it = new {}
     (_: Any) => it
   }

--- a/tests/pos/transparent-overload.scala
+++ b/tests/pos/transparent-overload.scala
@@ -4,8 +4,8 @@ object Test {
   def f(x: String): String = x
   def f(x: Any): Any = x
 
-  rewrite def g(x: Any) = f(x)
-  rewrite def h(x: Any) = this.f(x)
+  inline def g(x: Any) = f(x)
+  inline def h(x: Any) = this.f(x)
 
   locally {
     val x1 = g(1)

--- a/tests/pos/transparent.scala
+++ b/tests/pos/transparent.scala
@@ -1,5 +1,5 @@
 class Foo {
-  rewrite def foo() = {
+  inline def foo() = {
     abstract class C[T] extends Object {
       def x: T
       println(x)

--- a/tests/pos/typelevel-vector1.scala
+++ b/tests/pos/typelevel-vector1.scala
@@ -13,7 +13,7 @@ object Test {
   import typelevel._
   type Z = Z.type
 
-  rewrite def add(x: Nat, y: Nat): Nat = rewrite x match {
+  inline def add(x: Nat, y: Nat): Nat = inline x match {
     case Z => y
     case S(x1) => S(add(x1, y))
   }
@@ -22,7 +22,7 @@ object Test {
   val y = add(x, x)
   val z: S[S[S[S[Z]]]] = y
 
-  rewrite def concat[T, N1 <: Nat, N2 <: Nat](xs: Vec[T, N1], ys: Vec[T, N2]): Vec[T, _] = {
+  inline def concat[T, N1 <: Nat, N2 <: Nat](xs: Vec[T, N1], ys: Vec[T, N2]): Vec[T, _] = {
     val length = Typed(add(erasedValue[N1], erasedValue[N2]))
     Vec[T, length.Type](xs.elems ++ ys.elems)
   }

--- a/tests/run-with-compiler/i3876-d.scala
+++ b/tests/run-with-compiler/i3876-d.scala
@@ -13,5 +13,5 @@ object Test {
     println(f4(x).show)
   }
 
-  rewrite def inlineLambda: Int => Int = x => x + x
+  inline def inlineLambda: Int => Int = x => x + x
 }

--- a/tests/run-with-compiler/quote-impure-by-name/quoted_1.scala
+++ b/tests/run-with-compiler/quote-impure-by-name/quoted_1.scala
@@ -9,7 +9,7 @@ object Index {
 
   implicit def zero[K, T]: Index[K, (K, T)] = new Index("0")
 
-  implicit rewrite def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ~succImpl('(prev))('[K], '[H], '[T])
+  implicit inline def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ~succImpl('(prev))('[K], '[H], '[T])
 
   def succImpl[K, H, T](prev: Expr[Index[K, T]])(implicit k: Type[K], h: Type[H], t: Type[T]): Expr[Index[K, (H, T)]] = {
     val value = s"1 + {${prev.show}}"

--- a/tests/run-with-compiler/quote-inline-function/quoted_1.scala
+++ b/tests/run-with-compiler/quote-inline-function/quoted_1.scala
@@ -4,8 +4,8 @@ import scala.quoted.Toolbox.Default._
 
 object Macros {
 
-  rewrite def foreach1(start: Int, end: Int, f: Int => Unit): String = ~impl('(start), '(end), '(f))
-  rewrite def foreach2(start: Int, end: Int, f: => Int => Unit): String = ~impl('(start), '(end), '(f))
+  inline def foreach1(start: Int, end: Int, f: Int => Unit): String = ~impl('(start), '(end), '(f))
+  inline def foreach2(start: Int, end: Int, f: => Int => Unit): String = ~impl('(start), '(end), '(f))
 
   def impl(start: Expr[Int], end: Expr[Int], f: Expr[Int => Unit]): Expr[String] = {
     val res = '{

--- a/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
+++ b/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
@@ -6,7 +6,7 @@ import scala.tasty.util._
 
 object Macros {
 
-  rewrite def testMacro: Unit = ~impl
+  inline def testMacro: Unit = ~impl
 
   def impl(implicit tasty: Tasty): Expr[Unit] = {
     // 2 is a lifted constant

--- a/tests/run/Tuple.scala
+++ b/tests/run/Tuple.scala
@@ -16,32 +16,32 @@ object Tuple {
   type Empty = Empty.type
 
   class TupleOps(val xs: Tuple) extends AnyVal {
-    rewrite def *: [H] (x: H): Tuple = new *:(x, xs)
-    rewrite def size: Int = rewrite xs match {
+    inline def *: [H] (x: H): Tuple = new *:(x, xs)
+    inline def size: Int = inline xs match {
       case Empty => 0
       case _ *: xs1 => xs1.size + 1
     }
-    rewrite def apply(n: Int): Any = rewrite xs match {
+    inline def apply(n: Int): Any = inline xs match {
       case x *: _   if n == 0 => x
       case _ *: xs1 if n > 0  => xs1.apply(n - 1)
     }
-    rewrite def **: (ys: Tuple): Tuple = rewrite ys match {
+    inline def **: (ys: Tuple): Tuple = inline ys match {
       case Empty    => xs
       case y *: ys1 => y *: (ys1 **: xs)
     }
-    rewrite def head = rewrite xs match {
+    inline def head = inline xs match {
       case x *: _ => x
     }
-    rewrite def tail = rewrite xs match {
+    inline def tail = inline xs match {
       case _ *: xs => xs
     }
   }
 
   val emptyArray = Array[Object]()
 
-  rewrite def toObj(t: Any) = t.asInstanceOf[Object]
+  inline def toObj(t: Any) = t.asInstanceOf[Object]
 
-  rewrite def toArray(t: Tuple): Array[Object] = rewrite t.size match {
+  inline def toArray(t: Tuple): Array[Object] = inline t.size match {
     case 0 => emptyArray
     case 1 => Array(toObj(t(0)))
     case 2 => Array(toObj(t(0)), toObj(t(1)))
@@ -49,12 +49,12 @@ object Tuple {
     case 4 => Array(toObj(t(0)), toObj(t(1)), toObj(t(2)), toObj(t(3)))
   }
 
-  rewrite implicit def tupleDeco(xs: Tuple): TupleOps = new TupleOps(xs)
+  inline implicit def tupleDeco(xs: Tuple): TupleOps = new TupleOps(xs)
 
-  rewrite def apply(): Tuple = Empty
-  rewrite def apply(x1: Any): Tuple = x1 *: Empty
-  rewrite def apply(x1: Any, x2: Any) = x1 *: x2 *: Empty
-  rewrite def apply(x1: Any, x2: Any, x3: Any) = x1 *: x2 *: x3 *: Empty
+  inline def apply(): Tuple = Empty
+  inline def apply(x1: Any): Tuple = x1 *: Empty
+  inline def apply(x1: Any, x2: Any) = x1 *: x2 *: Empty
+  inline def apply(x1: Any, x2: Any, x3: Any) = x1 *: x2 *: x3 *: Empty
 
   val xs0 = Tuple()
   val xs1 = Tuple(2)

--- a/tests/run/Tuple.scala
+++ b/tests/run/Tuple.scala
@@ -60,10 +60,10 @@ object Tuple {
   val xs1 = Tuple(2)
   val xs2 = Tuple(2, "a")
   val xs3 = Tuple(true, 1, 2.0)
-  transparent val s0 = xs0.size; val s0c: 0 = s0
-  transparent val s1 = xs1.size; val s1c: 1 = s1
-  transparent val s2 = xs2.size; val s2c: 2 = s2
-  transparent val s3 = xs3.size; val s3c: 3 = s3
+  inline val s0 = xs0.size; val s0c: 0 = s0
+  inline val s1 = xs1.size; val s1c: 1 = s1
+  inline val s2 = xs2.size; val s2c: 2 = s2
+  inline val s3 = xs3.size; val s3c: 3 = s3
   val e0 = xs3(0); val e0c: Boolean = e0
   val e1 = xs3(1); val e1c: Int = e1
   val e2 = xs3(2); val e2c: Double = e2

--- a/tests/run/TupleAbstract.scala
+++ b/tests/run/TupleAbstract.scala
@@ -35,34 +35,34 @@ object Tuples {
 
   private final val MaxSpecialized = 7   // 22 in real life
 
-  private rewrite def _empty: Tuple = erasedValue[Empty]
-  private rewrite def _pair[H, T <: Tuple] (x: H, xs: T): Tuple = erasedValue[H *: T]
+  private inline def _empty: Tuple = erasedValue[Empty]
+  private inline def _pair[H, T <: Tuple] (x: H, xs: T): Tuple = erasedValue[H *: T]
 
-  private rewrite def _size(xs: Tuple): Int = rewrite xs match {
+  private inline def _size(xs: Tuple): Int = inline xs match {
     case _: Empty => 0
     case _: (_ *: xs1) => _size(erasedValue[xs1]) + 1
   }
 
-  private rewrite def _index(xs: Tuple, n: Int): Any = rewrite xs match {
+  private inline def _index(xs: Tuple, n: Int): Any = inline xs match {
     case _: (x *: _)   if n == 0 => erasedValue[x]
     case _: (_ *: xs1) if n > 0  => _index(erasedValue[xs1], n - 1)
   }
 
-  private rewrite def _head(xs: Tuple): Any = rewrite xs match {
+  private inline def _head(xs: Tuple): Any = inline xs match {
     case _: (x *: _) => erasedValue[x]
   }
 
-  private rewrite def _tail(xs: Tuple): Tuple = rewrite xs match {
+  private inline def _tail(xs: Tuple): Tuple = inline xs match {
     case _: (_ *: xs1) => erasedValue[xs1]
   }
 
-  private rewrite def _concat(xs: Tuple, ys: Tuple): Tuple = rewrite xs match {
+  private inline def _concat(xs: Tuple, ys: Tuple): Tuple = inline xs match {
     case _: Empty => ys
     case _: (x1 *: xs1) => _pair(erasedValue[x1], _concat(erasedValue[xs1], ys))
   }
 
-  rewrite def fromArray[T <: Tuple](xs: Array[Object]): T =
-    rewrite _size(erasedValue[T]) match {
+  inline def fromArray[T <: Tuple](xs: Array[Object]): T =
+    inline _size(erasedValue[T]) match {
       case 0 => ().asInstanceOf[T]
       case 1 => Tuple1(xs(0)).asInstanceOf[T]
       case 2 => Tuple2(xs(0), xs(1)).asInstanceOf[T]
@@ -76,11 +76,11 @@ object Tuples {
 
   val emptyArray = Array[Object]()
 
-  rewrite implicit def tupleDeco(xs: Tuple): TupleOps = new TupleOps(xs)
+  inline implicit def tupleDeco(xs: Tuple): TupleOps = new TupleOps(xs)
 
   class TupleOps(val xs: Tuple) extends AnyVal {
 
-    rewrite def toArray: Array[Object] = rewrite _size(xs) match {
+    inline def toArray: Array[Object] = inline _size(xs) match {
       case 0 =>
         emptyArray
       case 1 =>
@@ -108,9 +108,9 @@ object Tuples {
         xs.asInstanceOf[TupleXXL].elems
     }
 
-    rewrite def *: [H] (x: H): Tuple = {
+    inline def *: [H] (x: H): Tuple = {
       erased val resTpe = Typed(_pair(x, xs))
-      rewrite _size(xs) match {
+      inline _size(xs) match {
         case 0 =>
           Tuple1(x).asInstanceOf[resTpe.Type]
         case 1 =>
@@ -136,9 +136,9 @@ object Tuples {
       elems1
     }
 
-    rewrite def head: Any = {
+    inline def head: Any = {
       erased val resTpe = Typed(_head(xs))
-      val resVal = rewrite _size(xs) match {
+      val resVal = inline _size(xs) match {
         case 1 =>
           val t = xs.asInstanceOf[Tuple1[_]]
           t._1
@@ -160,9 +160,9 @@ object Tuples {
       resVal.asInstanceOf[resTpe.Type]
     }
 
-    rewrite def tail: Any = {
+    inline def tail: Any = {
       erased val resTpe = Typed(_tail(xs))
-      rewrite _size(xs) match {
+      inline _size(xs) match {
         case 1 =>
           unit
         case 2 =>
@@ -182,30 +182,30 @@ object Tuples {
       }
     }
 
-    rewrite def apply(n: Int): Any = {
+    inline def apply(n: Int): Any = {
       erased val resTpe = Typed(_index(xs, n))
-      rewrite _size(xs) match {
+      inline _size(xs) match {
         case 1 =>
           val t = xs.asInstanceOf[Tuple1[_]]
-          rewrite n match {
+          inline n match {
             case 0 => t._1.asInstanceOf[resTpe.Type]
           }
         case 2 =>
           val t = xs.asInstanceOf[Tuple2[_, _]]
-          rewrite n match {
+          inline n match {
             case 0 => t._1.asInstanceOf[resTpe.Type]
             case 1 => t._2.asInstanceOf[resTpe.Type]
           }
         case 3 =>
           val t = xs.asInstanceOf[Tuple3[_, _, _]]
-          rewrite n match {
+          inline n match {
             case 0 => t._1.asInstanceOf[resTpe.Type]
             case 1 => t._2.asInstanceOf[resTpe.Type]
             case 2 => t._3.asInstanceOf[resTpe.Type]
           }
         case 4 =>
           val t = xs.asInstanceOf[Tuple4[_, _, _, _]]
-          rewrite n match {
+          inline n match {
             case 0 => t._1.asInstanceOf[resTpe.Type]
             case 1 => t._2.asInstanceOf[resTpe.Type]
             case 2 => t._3.asInstanceOf[resTpe.Type]
@@ -218,16 +218,16 @@ object Tuples {
       }
     }
 
-    rewrite def ++(ys: Tuple): Tuple = {
+    inline def ++(ys: Tuple): Tuple = {
       erased val resTpe = Typed(_concat(xs, ys))
-      rewrite _size(xs) match {
+      inline _size(xs) match {
         case 0 => ys
         case 1 =>
           if (_size(ys) == 0) xs
           else xs.head *: ys
         case 2 =>
           val t = xs.asInstanceOf[Tuple2[_, _]]
-          rewrite _size(ys) match {
+          inline _size(ys) match {
             case 0 => xs
             case 1 =>
               val u = ys.asInstanceOf[Tuple1[_]]
@@ -240,7 +240,7 @@ object Tuples {
           }
         case 3 =>
           val t = xs.asInstanceOf[Tuple3[_, _, _]]
-          rewrite _size(ys) match {
+          inline _size(ys) match {
             case 0 => xs
             case 1 =>
               val u = ys.asInstanceOf[Tuple1[_]]
@@ -254,7 +254,7 @@ object Tuples {
       }
     }
 
-    rewrite def genericConcat[T <: Tuple](xs: Tuple, ys: Tuple): Tuple =
+    inline def genericConcat[T <: Tuple](xs: Tuple, ys: Tuple): Tuple =
       fromArray[T](xs.toArray ++ ys.toArray)
   }
 }

--- a/tests/run/dead-code-elimination.scala
+++ b/tests/run/dead-code-elimination.scala
@@ -18,7 +18,7 @@
 final class A {
   def f1 = true
   def f2 = true
-  rewrite def f3 = f1 || f2
+  inline def f3 = f1 || f2
   class B {
     def f() = 1 to 10 foreach (_ => f3)
   }

--- a/tests/run/generic-tuples.scala
+++ b/tests/run/generic-tuples.scala
@@ -7,7 +7,7 @@ class HNil extends Tuple
 case object HNil extends HNil
 
 trait Pair[H, T <: Tuple] {
-  erased rewrite def size = ???
+  erased inline def size = ???
 }
 }
 

--- a/tests/run/genericValueClass.scala
+++ b/tests/run/genericValueClass.scala
@@ -3,12 +3,12 @@ import scala.language.implicitConversions
 
 object Test extends dotty.runtime.LegacyApp {
   class ArrowAssocClass[A](val __leftOfArrow: A) extends AnyVal {
-    rewrite def -> [B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
+    inline def -> [B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
     def →[B](y: B): Tuple2[A, B] = ->(y)
   }
 
   {
-  rewrite implicit def ArrowAssoc[A](x: A): ArrowAssocClass[A] = new ArrowAssocClass(x)
+  inline implicit def ArrowAssoc[A](x: A): ArrowAssocClass[A] = new ArrowAssocClass(x)
   val x = 1 -> "abc"
   println(x)
   }

--- a/tests/run/i1569.scala
+++ b/tests/run/i1569.scala
@@ -1,5 +1,5 @@
 object Test {
-  rewrite def foo(transparent n: => Int) = n + n
+  inline def foo(transparent n: => Int) = n + n
 
   def main(args: Array[String]): Unit = foo({ println("foo"); 42 })
 }

--- a/tests/run/i1569.scala
+++ b/tests/run/i1569.scala
@@ -1,5 +1,5 @@
 object Test {
-  inline def foo(transparent n: => Int) = n + n
+  inline def foo(inline n: => Int) = n + n
 
   def main(args: Array[String]): Unit = foo({ println("foo"); 42 })
 }

--- a/tests/run/i1990b.scala
+++ b/tests/run/i1990b.scala
@@ -1,6 +1,6 @@
 trait A { self =>
   class Foo {
-    rewrite def inlineMeth: Unit = {
+    inline def inlineMeth: Unit = {
       println(self)
     }
   }

--- a/tests/run/i2077.scala
+++ b/tests/run/i2077.scala
@@ -1,5 +1,5 @@
 object Test {
-  transparent val x = true
+  inline val x = true
   val y = if (x) 1 else 2  // reduced to val y = 1
 
   def main(args: Array[String]): Unit  =

--- a/tests/run/i2360.scala
+++ b/tests/run/i2360.scala
@@ -7,7 +7,7 @@ object Test {
 }
 
 object Foo extends Bar {
-  rewrite def foo: Int = bar
+  inline def foo: Int = bar
 }
 
 class Bar {

--- a/tests/run/i2895a.scala
+++ b/tests/run/i2895a.scala
@@ -3,7 +3,7 @@ trait Foo[A <: Foo[A]] {
 
   def next: A
 
-  rewrite final def once: A = next
+  inline final def once: A = next
 
   def once1: A = once
 

--- a/tests/run/i4431/quoted_1.scala
+++ b/tests/run/i4431/quoted_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 
 object Macros {
-  rewrite def h(f: => Int => String): String = ~ '(f(42))
+  inline def h(f: => Int => String): String = ~ '(f(42))
 }

--- a/tests/run/i4455/Macro_1.scala
+++ b/tests/run/i4455/Macro_1.scala
@@ -1,8 +1,8 @@
 import scala.quoted._
 object Macros {
-  rewrite def foo(transparent i: Int): Int = ~bar('(i))
+  inline def foo(transparent i: Int): Int = ~bar('(i))
 
-  rewrite def foo2(transparent i: Int): Int = ~bar('(i + 1))
+  inline def foo2(transparent i: Int): Int = ~bar('(i + 1))
 
   def bar(x: Expr[Int]): Expr[Int] = x
 }

--- a/tests/run/i4455/Macro_1.scala
+++ b/tests/run/i4455/Macro_1.scala
@@ -1,8 +1,8 @@
 import scala.quoted._
 object Macros {
-  inline def foo(transparent i: Int): Int = ~bar('(i))
+  inline def foo(inline i: Int): Int = ~bar('(i))
 
-  inline def foo2(transparent i: Int): Int = ~bar('(i + 1))
+  inline def foo2(inline i: Int): Int = ~bar('(i + 1))
 
   def bar(x: Expr[Int]): Expr[Int] = x
 }

--- a/tests/run/i4492/quoted_1.scala
+++ b/tests/run/i4492/quoted_1.scala
@@ -2,5 +2,5 @@
 trait Index
 
 object Index {
-  rewrite def succ(prev: Index): Unit = ~{ '(println("Ok")) }
+  inline def succ(prev: Index): Unit = ~{ '(println("Ok")) }
 }

--- a/tests/run/i4496b.scala
+++ b/tests/run/i4496b.scala
@@ -24,7 +24,7 @@ object Test {
 
     // These accesses are also clearly well-typed
     def consume(v: T) = v.a
-    rewrite def consumeInl(v: T) = v.a
+    inline def consumeInl(v: T) = v.a
     def verify(v: T) = {
       assert(consume(v) == 10)
       assert(consumeInl(v) == 10)
@@ -58,7 +58,7 @@ object Test {
     def upcast2(v: Foo2): T = v
     def upcast3(v: Foo3): T = v
     def consume(v: T) = v.a
-    rewrite def consumeInl(v: T) = v.a
+    inline def consumeInl(v: T) = v.a
     def verify(v: T) = {
       assert(consume(v) == 10)
       assert(consumeInl(v) == 10)
@@ -88,7 +88,7 @@ object Test {
     type T = {val a: Int; def a_=(x: Int): Unit}
     def upcast3(v: Foo3): T = v
     def consume(v: T) = v.a
-    rewrite def consumeInl(v: T) = v.a
+    inline def consumeInl(v: T) = v.a
     def verify(v: T) = {
       assert(consume(v) == 10)
       assert(consumeInl(v) == 10)

--- a/tests/run/i4515/Macro_1.scala
+++ b/tests/run/i4515/Macro_1.scala
@@ -1,5 +1,5 @@
 
 object Macro {
-  rewrite def foo[X](x: X): Unit = ~fooImpl('(x))
+  inline def foo[X](x: X): Unit = ~fooImpl('(x))
   def fooImpl[X: quoted.Type](x: quoted.Expr[X]): quoted.Expr[Unit] = '()
 }

--- a/tests/run/i4515b/Macro_1.scala
+++ b/tests/run/i4515b/Macro_1.scala
@@ -1,6 +1,6 @@
 import scala.tasty.Tasty
 
 object Macro {
-  rewrite def foo: Unit = ~fooImpl
+  inline def foo: Unit = ~fooImpl
   def fooImpl(implicit tasty: Tasty): quoted.Expr[Unit] = '()
 }

--- a/tests/run/i4734/Macro_1.scala
+++ b/tests/run/i4734/Macro_1.scala
@@ -2,7 +2,7 @@ import scala.annotation.tailrec
 import scala.quoted._
 
 object Macros {
-  inline def unrolledForeach(seq: IndexedSeq[Int], f: => Int => Unit, transparent unrollSize: Int): Unit = // or f: Int => Unit
+  inline def unrolledForeach(seq: IndexedSeq[Int], f: => Int => Unit, inline unrollSize: Int): Unit = // or f: Int => Unit
     ~unrolledForeachImpl('(seq), '(f), unrollSize)
 
   def unrolledForeachImpl(seq: Expr[IndexedSeq[Int]], f: Expr[Int => Unit], unrollSize: Int): Expr[Unit] = '{

--- a/tests/run/i4734/Macro_1.scala
+++ b/tests/run/i4734/Macro_1.scala
@@ -2,7 +2,7 @@ import scala.annotation.tailrec
 import scala.quoted._
 
 object Macros {
-  rewrite def unrolledForeach(seq: IndexedSeq[Int], f: => Int => Unit, transparent unrollSize: Int): Unit = // or f: Int => Unit
+  inline def unrolledForeach(seq: IndexedSeq[Int], f: => Int => Unit, transparent unrollSize: Int): Unit = // or f: Int => Unit
     ~unrolledForeachImpl('(seq), '(f), unrollSize)
 
   def unrolledForeachImpl(seq: Expr[IndexedSeq[Int]], f: Expr[Int => Unit], unrollSize: Int): Expr[Unit] = '{

--- a/tests/run/i4735/App_2.scala
+++ b/tests/run/i4735/App_2.scala
@@ -10,5 +10,5 @@ object Test {
 }
 
 class Unrolled(arr: Array[Int]) extends AnyVal {
-  rewrite def foreach(f: => Int => Unit): Unit = Macro.unrolledForeach(3, arr, f)
+  inline def foreach(f: => Int => Unit): Unit = Macro.unrolledForeach(3, arr, f)
 }

--- a/tests/run/i4735/Macro_1.scala
+++ b/tests/run/i4735/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 
 object Macro {
 
-  inline def unrolledForeach(transparent unrollSize: Int, seq: Array[Int], f: => Int => Unit): Unit = // or f: Int => Unit
+  inline def unrolledForeach(inline unrollSize: Int, seq: Array[Int], f: => Int => Unit): Unit = // or f: Int => Unit
     ~unrolledForeachImpl(unrollSize, '(seq), '(f))
 
   private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{

--- a/tests/run/i4735/Macro_1.scala
+++ b/tests/run/i4735/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 
 object Macro {
 
-  rewrite def unrolledForeach(transparent unrollSize: Int, seq: Array[Int], f: => Int => Unit): Unit = // or f: Int => Unit
+  inline def unrolledForeach(transparent unrollSize: Int, seq: Array[Int], f: => Int => Unit): Unit = // or f: Int => Unit
     ~unrolledForeachImpl(unrollSize, '(seq), '(f))
 
   private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{

--- a/tests/run/i4754.scala
+++ b/tests/run/i4754.scala
@@ -6,7 +6,7 @@ object Foo {
 
 class Foo {
   import Foo._
-  rewrite def foo = x + Foo.x + y + Foo.y + z + Foo.z
+  inline def foo = x + Foo.x + y + Foo.y + z + Foo.z
 }
 
 object Test {

--- a/tests/run/i4803/App_2.scala
+++ b/tests/run/i4803/App_2.scala
@@ -1,6 +1,6 @@
 
 class Num2(x: Double) {
-  inline def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+  inline def power(inline n: Long) = ~PowerMacro.powerCode('(x), n)
 }
 
 object Test {

--- a/tests/run/i4803/App_2.scala
+++ b/tests/run/i4803/App_2.scala
@@ -1,6 +1,6 @@
 
 class Num2(x: Double) {
-  rewrite def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+  inline def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
 }
 
 object Test {

--- a/tests/run/i4803/Macro_1.scala
+++ b/tests/run/i4803/Macro_1.scala
@@ -8,5 +8,5 @@ object PowerMacro {
 }
 
 class Num(x: Double) {
-  inline def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+  inline def power(inline n: Long) = ~PowerMacro.powerCode('(x), n)
 }

--- a/tests/run/i4803/Macro_1.scala
+++ b/tests/run/i4803/Macro_1.scala
@@ -8,5 +8,5 @@ object PowerMacro {
 }
 
 class Num(x: Double) {
-  rewrite def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+  inline def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
 }

--- a/tests/run/i4803b/App_2.scala
+++ b/tests/run/i4803b/App_2.scala
@@ -2,7 +2,7 @@
 
 class Nums {
   class Num(x: Double) {
-    rewrite def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+    inline def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
   }
 }
 

--- a/tests/run/i4803b/App_2.scala
+++ b/tests/run/i4803b/App_2.scala
@@ -2,7 +2,7 @@
 
 class Nums {
   class Num(x: Double) {
-    inline def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+    inline def power(inline n: Long) = ~PowerMacro.powerCode('(x), n)
   }
 }
 

--- a/tests/run/i4803c/App_2.scala
+++ b/tests/run/i4803c/App_2.scala
@@ -2,7 +2,7 @@
 object Test {
   def main(args: Array[String]): Unit = {
     class Num(x: Double) {
-      inline def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+      inline def power(inline n: Long) = ~PowerMacro.powerCode('(x), n)
     }
     val n = new Num(1.5)
     println(n.power(0))
@@ -10,7 +10,7 @@ object Test {
     println(n.power(2))
     println(n.power(5))
 
-    inline def power(x: Double, transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+    inline def power(x: Double, inline n: Long) = ~PowerMacro.powerCode('(x), n)
 
     val x: Double = 1.5
 

--- a/tests/run/i4803c/App_2.scala
+++ b/tests/run/i4803c/App_2.scala
@@ -2,7 +2,7 @@
 object Test {
   def main(args: Array[String]): Unit = {
     class Num(x: Double) {
-      rewrite def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+      inline def power(transparent n: Long) = ~PowerMacro.powerCode('(x), n)
     }
     val n = new Num(1.5)
     println(n.power(0))
@@ -10,7 +10,7 @@ object Test {
     println(n.power(2))
     println(n.power(5))
 
-    rewrite def power(x: Double, transparent n: Long) = ~PowerMacro.powerCode('(x), n)
+    inline def power(x: Double, transparent n: Long) = ~PowerMacro.powerCode('(x), n)
 
     val x: Double = 1.5
 

--- a/tests/run/i4803e/App_2.scala
+++ b/tests/run/i4803e/App_2.scala
@@ -10,5 +10,5 @@ object Test {
     println(power2(x3))
   }
 
-  rewrite def power2(x: Double) = ~PowerMacro.power2('(x))
+  inline def power2(x: Double) = ~PowerMacro.power2('(x))
 }

--- a/tests/run/i4803e/Macro_1.scala
+++ b/tests/run/i4803e/Macro_1.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object PowerMacro {
   def power2(x: Expr[Double]) = '{
-    rewrite def power(x: Double, n: Long): Double =
+    inline def power(x: Double, n: Long): Double =
       if (n == 0) 1.0
       else if (n % 2 == 0) { val y = x * x; power(y, n / 2) }
       else x * power(x, n - 1)

--- a/tests/run/i4803f/App_2.scala
+++ b/tests/run/i4803f/App_2.scala
@@ -10,5 +10,5 @@ object Test {
     println(power2(x3))
   }
 
-  rewrite def power2(x: Double) = ~PowerMacro.power2('(x))
+  inline def power2(x: Double) = ~PowerMacro.power2('(x))
 }

--- a/tests/run/i4803f/Macro_1.scala
+++ b/tests/run/i4803f/Macro_1.scala
@@ -7,7 +7,7 @@ object PowerMacro {
     else '{ ~x * ~powerCode(x, n - 1) }
 
   def power2(x: Expr[Double]) = '{
-    rewrite def power(x: Double): Double = ~powerCode('(x), 2)
+    inline def power(x: Double): Double = ~powerCode('(x), 2)
     power(~x)
   }
 }

--- a/tests/run/i4947.scala
+++ b/tests/run/i4947.scala
@@ -1,6 +1,6 @@
 object Test {
 
-  rewrite def track[T](f: => T): T = {
+  inline def track[T](f: => T): T = {
     printStack("track")
     printStack("track")
     f

--- a/tests/run/i4947a.scala
+++ b/tests/run/i4947a.scala
@@ -1,6 +1,6 @@
 object Test {
 
-  rewrite def fact[T](transparent i: Int)(f: => T): Int = {
+  inline def fact[T](transparent i: Int)(f: => T): Int = {
     printStack("track", i)
     printStack("track", i)
     f

--- a/tests/run/i4947a.scala
+++ b/tests/run/i4947a.scala
@@ -1,6 +1,6 @@
 object Test {
 
-  inline def fact[T](transparent i: Int)(f: => T): Int = {
+  inline def fact[T](inline i: Int)(f: => T): Int = {
     printStack("track", i)
     printStack("track", i)
     f

--- a/tests/run/i4947b/Lib_1.scala
+++ b/tests/run/i4947b/Lib_1.scala
@@ -12,7 +12,7 @@ object Lib {
     println(s"$tag (i = $i): ${new Exception().getStackTrace().apply(1)}")
   }
 
-  inline def fact[T](transparent i: Int)(f: => T): Int = {
+  inline def fact[T](inline i: Int)(f: => T): Int = {
     printStack("track", i)
     printStack("track", i)
     track {

--- a/tests/run/i4947b/Lib_1.scala
+++ b/tests/run/i4947b/Lib_1.scala
@@ -1,5 +1,5 @@
 object Lib {
-  rewrite def track[T](f: => T): T = {
+  inline def track[T](f: => T): T = {
     printStack("track")
     printStack("track")
     f
@@ -12,7 +12,7 @@ object Lib {
     println(s"$tag (i = $i): ${new Exception().getStackTrace().apply(1)}")
   }
 
-  rewrite def fact[T](transparent i: Int)(f: => T): Int = {
+  inline def fact[T](transparent i: Int)(f: => T): Int = {
     printStack("track", i)
     printStack("track", i)
     track {

--- a/tests/run/i4947c.scala
+++ b/tests/run/i4947c.scala
@@ -1,6 +1,6 @@
 object Aux {
 
-  rewrite def track[T](f: => T): T = {
+  inline def track[T](f: => T): T = {
     printStack("track")
     printStack("track")
     f

--- a/tests/run/implicitMatch.scala
+++ b/tests/run/implicitMatch.scala
@@ -2,7 +2,7 @@ object Test extends App {
   import collection.immutable.TreeSet
   import collection.immutable.HashSet
 
-  rewrite def f[T]() = implicit match {
+  inline def f[T]() = implicit match {
     case ord: Ordering[T] => new TreeSet[T]
     case _ => new HashSet[T]
   }
@@ -11,7 +11,7 @@ object Test extends App {
   class B
   implicit val b: B = new B
 
-  rewrite def g = implicit match {
+  inline def g = implicit match {
     case _: A => println("A")
     case _: B => println("B")
   }

--- a/tests/run/lst/Lst.scala
+++ b/tests/run/lst/Lst.scala
@@ -15,7 +15,7 @@ import reflect.ClassTag
 class Lst[+T](val elems: Any) extends AnyVal { self =>
   import Lst._
 
-  rewrite def locally[T](body: => T): T = body
+  inline def locally[T](body: => T): T = body
 
   def length: Int = elems match {
     case null => 0
@@ -26,7 +26,7 @@ class Lst[+T](val elems: Any) extends AnyVal { self =>
   def isEmpty = elems == null
   def nonEmpty = elems != null
 
-  rewrite def foreach(op: => T => Unit): Unit = {
+  inline def foreach(op: => T => Unit): Unit = {
     def sharedOp(x: T) = op(x)
     elems match {
       case null =>
@@ -37,7 +37,7 @@ class Lst[+T](val elems: Any) extends AnyVal { self =>
     }
   }
 
-  rewrite def foreachReversed(transparent op: T => Unit): Unit = {
+  inline def foreachReversed(transparent op: T => Unit): Unit = {
     def sharedOp(x: T) = op(x)
     elems match {
       case null =>
@@ -51,7 +51,7 @@ class Lst[+T](val elems: Any) extends AnyVal { self =>
   /** Like `foreach`, but completely inlines `op`, at the price of generating the code twice.
    *  Should be used only of `op` is small
    */
-  rewrite def foreachInlined(op: => T => Unit): Unit = {
+  inline def foreachInlined(op: => T => Unit): Unit = {
     elems match {
       case null =>
       case elems: Arr => def elem(i: Int) = elems(i).asInstanceOf[T]
@@ -102,7 +102,7 @@ class Lst[+T](val elems: Any) extends AnyVal { self =>
   }
 
   /** `f` is pulled out, not duplicated */
-  rewrite def map[U](f: => T => U): Lst[U] = {
+  inline def map[U](f: => T => U): Lst[U] = {
     def op(x: T) = f(x)
     elems match {
       case null => Empty
@@ -194,7 +194,7 @@ class Lst[+T](val elems: Any) extends AnyVal { self =>
     buf.toLst
   }
 
-  rewrite def exists(p: => T => Boolean): Boolean = {
+  inline def exists(p: => T => Boolean): Boolean = {
     def op(x: T) = p(x)
     elems match {
       case null => false
@@ -207,7 +207,7 @@ class Lst[+T](val elems: Any) extends AnyVal { self =>
     }
   }
 
-  rewrite def forall(p: => T => Boolean): Boolean = {
+  inline def forall(p: => T => Boolean): Boolean = {
     def op(x: T) = p(x)
     elems match {
       case null => true
@@ -230,7 +230,7 @@ class Lst[+T](val elems: Any) extends AnyVal { self =>
       elem == x
   }
 
-  rewrite def foldLeft[U](z: U)(f: => (U, T) => U) = {
+  inline def foldLeft[U](z: U)(f: => (U, T) => U) = {
     def op(x: U, y: T) = f(x, y)
     elems match {
       case null => z
@@ -244,7 +244,7 @@ class Lst[+T](val elems: Any) extends AnyVal { self =>
     }
   }
 
-  rewrite def /: [U](z: U)(op: => (U, T) => U) = foldLeft(z)(op)
+  inline def /: [U](z: U)(op: => (U, T) => U) = foldLeft(z)(op)
 
   def reduceLeft[U >: T](op: (U, U) => U) = elems match {
     case null =>

--- a/tests/run/lst/Lst.scala
+++ b/tests/run/lst/Lst.scala
@@ -37,7 +37,7 @@ class Lst[+T](val elems: Any) extends AnyVal { self =>
     }
   }
 
-  inline def foreachReversed(transparent op: T => Unit): Unit = {
+  inline def foreachReversed(inline op: T => Unit): Unit = {
     def sharedOp(x: T) = op(x)
     elems match {
       case null =>

--- a/tests/run/nats.scala-deptypes
+++ b/tests/run/nats.scala-deptypes
@@ -11,11 +11,11 @@ object Nat {
   val Z = new Z
 }
 
-type NatOf(transparent x: Int where x >= 0) =
+type NatOf(inline x: Int where x >= 0) =
   if (x == 0) Z
   else S[NatOf(x - 1)]
 
-inline def natOf(transparent x: Int where x >= 0): NatOf(x) =
+inline def natOf(inline x: Int where x >= 0): NatOf(x) =
   if (x == 0) Z
   else S(natOf(x - 1))
 

--- a/tests/run/quote-and-splice/Macros_1.scala
+++ b/tests/run/quote-and-splice/Macros_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def macro1 = ~ macro1Impl
   def macro1Impl = '(3)
 
-  inline def macro2(transparent p: Boolean) = ~ macro2Impl(p)
+  inline def macro2(inline p: Boolean) = ~ macro2Impl(p)
   def macro2Impl(p: Boolean) = if (p) '(3) else '(4)
 
   inline def macro3(n: Int) = ~ macro3Impl('(n))
@@ -17,7 +17,7 @@ object Macros {
   inline def macro5(i: Int, j: Int) = ~ macro5Impl(j = '(j), i = '(i))
   def macro5Impl(i: Expr[Int], j: Expr[Int]) = '{ ~i + ~j }
 
-  inline def power(transparent n: Int, x: Double) = ~powerCode(n, '(x))
+  inline def power(inline n: Int, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Int, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/tests/run/quote-and-splice/Macros_1.scala
+++ b/tests/run/quote-and-splice/Macros_1.scala
@@ -2,22 +2,22 @@ import scala.quoted._
 
 object Macros {
 
-  rewrite def macro1 = ~ macro1Impl
+  inline def macro1 = ~ macro1Impl
   def macro1Impl = '(3)
 
-  rewrite def macro2(transparent p: Boolean) = ~ macro2Impl(p)
+  inline def macro2(transparent p: Boolean) = ~ macro2Impl(p)
   def macro2Impl(p: Boolean) = if (p) '(3) else '(4)
 
-  rewrite def macro3(n: Int) = ~ macro3Impl('(n))
+  inline def macro3(n: Int) = ~ macro3Impl('(n))
   def macro3Impl(p: Expr[Int]) = '{ 2 + ~p }
 
-  rewrite def macro4(i: Int)(j: Int) = ~ macro4Impl('(i))('(j))
+  inline def macro4(i: Int)(j: Int) = ~ macro4Impl('(i))('(j))
   def macro4Impl(i: Expr[Int])(j: Expr[Int]) = '{ ~i + ~j }
 
-  rewrite def macro5(i: Int, j: Int) = ~ macro5Impl(j = '(j), i = '(i))
+  inline def macro5(i: Int, j: Int) = ~ macro5Impl(j = '(j), i = '(i))
   def macro5Impl(i: Expr[Int], j: Expr[Int]) = '{ ~i + ~j }
 
-  rewrite def power(transparent n: Int, x: Double) = ~powerCode(n, '(x))
+  inline def power(transparent n: Int, x: Double) = ~powerCode(n, '(x))
 
   def powerCode(n: Int, x: Expr[Double]): Expr[Double] =
     if (n == 0) '(1.0)

--- a/tests/run/quote-force/quoted_1.scala
+++ b/tests/run/quote-force/quoted_1.scala
@@ -4,7 +4,7 @@ case class Location(owners: List[String])
 
 object Location {
 
-  implicit rewrite def location: Location = ~impl
+  implicit inline def location: Location = ~impl
 
   def impl: Expr[Location] = {
     val list = List("a", "b", "c", "d", "e", "f")

--- a/tests/run/quote-indexed-map-by-name/quoted_1.scala
+++ b/tests/run/quote-indexed-map-by-name/quoted_1.scala
@@ -5,7 +5,7 @@ object Index {
 
   implicit def zero[K, T]: Index[K, (K, T)] = new Index(0)
 
-  implicit rewrite def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ~succImpl('[K], '[H], '[T])
+  implicit inline def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ~succImpl('[K], '[H], '[T])
 
   def succImpl[K, H, T](implicit k: Type[K], h: Type[H], t: Type[T]): Expr[Index[K, (H, T)]] = {
     '(new Index(0))

--- a/tests/run/quote-sep-comp-2/Test_2.scala
+++ b/tests/run/quote-sep-comp-2/Test_2.scala
@@ -1,7 +1,7 @@
 
 object Test {
 
-  rewrite def assert2(expr: => Boolean): Unit =  ~Macros.assertImpl('(expr))
+  inline def assert2(expr: => Boolean): Unit =  ~Macros.assertImpl('(expr))
 
   def main(args: Array[String]): Unit = {
     val x = 1

--- a/tests/run/quote-sep-comp/Macro_1.scala
+++ b/tests/run/quote-sep-comp/Macro_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macros {
-  rewrite def assert2(expr: => Boolean): Unit =  ~ assertImpl('(expr))
+  inline def assert2(expr: => Boolean): Unit =  ~ assertImpl('(expr))
   def assertImpl(expr: Expr[Boolean]) = '{ println(~expr) }
 }

--- a/tests/run/quote-simple-macro/quoted_1.scala
+++ b/tests/run/quote-simple-macro/quoted_1.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Macros {
-  inline def foo(transparent i: Int, dummy: Int, j: Int): Int = ~bar(i, '(j))
+  inline def foo(inline i: Int, dummy: Int, j: Int): Int = ~bar(i, '(j))
   def bar(x: Int, y: Expr[Int]): Expr[Int] = '{ ~x.toExpr + ~y }
 }

--- a/tests/run/quote-simple-macro/quoted_1.scala
+++ b/tests/run/quote-simple-macro/quoted_1.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
 object Macros {
-  rewrite def foo(transparent i: Int, dummy: Int, j: Int): Int = ~bar(i, '(j))
+  inline def foo(transparent i: Int, dummy: Int, j: Int): Int = ~bar(i, '(j))
   def bar(x: Int, y: Expr[Int]): Expr[Int] = '{ ~x.toExpr + ~y }
 }

--- a/tests/run/quote-unrolled-foreach/quoted_1.scala
+++ b/tests/run/quote-unrolled-foreach/quoted_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 
 object Macro {
 
-  inline def unrolledForeach(transparent unrollSize: Int, seq: Array[Int])(f: => Int => Unit): Unit = // or f: Int => Unit
+  inline def unrolledForeach(inline unrollSize: Int, seq: Array[Int])(f: => Int => Unit): Unit = // or f: Int => Unit
     ~unrolledForeachImpl(unrollSize, '(seq), '(f))
 
   private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{

--- a/tests/run/quote-unrolled-foreach/quoted_1.scala
+++ b/tests/run/quote-unrolled-foreach/quoted_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 
 object Macro {
 
-  rewrite def unrolledForeach(transparent unrollSize: Int, seq: Array[Int])(f: => Int => Unit): Unit = // or f: Int => Unit
+  inline def unrolledForeach(transparent unrollSize: Int, seq: Array[Int])(f: => Int => Unit): Unit = // or f: Int => Unit
     ~unrolledForeachImpl(unrollSize, '(seq), '(f))
 
   private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{

--- a/tests/run/reduce-projections.scala
+++ b/tests/run/reduce-projections.scala
@@ -14,7 +14,7 @@ object Test {
   object O3a extends D(3)
   object O3b extends D(3)
 
-  rewrite def f(): Unit = {
+  inline def f(): Unit = {
     println(new C(
       { println(1); 1 },
       { println(2); 2 },

--- a/tests/run/tasty-custom-show/quoted_1.scala
+++ b/tests/run/tasty-custom-show/quoted_1.scala
@@ -5,7 +5,7 @@ import scala.tasty.util.{TreeTraverser, Show}
 
 object Macros {
 
-  implicit rewrite def printOwners[T](x: => T): Unit =
+  implicit inline def printOwners[T](x: => T): Unit =
     ~impl('(x))
 
   def impl[T](x: Expr[T])(implicit tasty: Tasty): Expr[Unit] = {

--- a/tests/run/tasty-definitions-1/quoted_1.scala
+++ b/tests/run/tasty-definitions-1/quoted_1.scala
@@ -5,7 +5,7 @@ import scala.tasty.util.TreeTraverser
 
 object Macros {
 
-  rewrite def testDefinitions(): Unit = ~testDefinitionsImpl
+  inline def testDefinitions(): Unit = ~testDefinitionsImpl
 
   def testDefinitionsImpl(implicit tasty: Tasty): Expr[Unit] = {
     import tasty._

--- a/tests/run/tasty-definitions-2/Macro_1.scala
+++ b/tests/run/tasty-definitions-2/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.tasty._
 
 object Foo {
 
-  rewrite def inspectBody(i: => Int): String =
+  inline def inspectBody(i: => Int): String =
     ~inspectBodyImpl('(i))
 
   def inspectBodyImpl(x: Expr[Int])(implicit tasty: Tasty): Expr[String] = {

--- a/tests/run/tasty-definitions-3/Macro_1.scala
+++ b/tests/run/tasty-definitions-3/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.tasty._
 
 object Foo {
 
-  rewrite def inspectBody(i: => Int): String =
+  inline def inspectBody(i: => Int): String =
     ~inspectBodyImpl('(i))
 
   def inspectBodyImpl(x: Expr[Int])(implicit tasty: Tasty): Expr[String] = {

--- a/tests/run/tasty-eval/quoted_1.scala
+++ b/tests/run/tasty-eval/quoted_1.scala
@@ -5,14 +5,14 @@ import scala.tasty.util.TreeTraverser
 
 object Macros {
 
-  implicit rewrite def foo(i: Int): String =
+  implicit inline def foo(i: Int): String =
     ~impl('(i))
 
   def impl(i: Expr[Int])(implicit tasty: Tasty): Expr[String] = {
     value(i).toString.toExpr
   }
 
-  rewrite implicit def value[X](e: Expr[X])(implicit tasty: Tasty, ev: Valuable[X]): Option[X] = ev.value(e)
+  inline implicit def value[X](e: Expr[X])(implicit tasty: Tasty, ev: Valuable[X]): Option[X] = ev.value(e)
 
   trait Valuable[X] {
     def value(e: Expr[X])(implicit tasty: Tasty): Option[X]

--- a/tests/run/tasty-extractors-1/quoted_1.scala
+++ b/tests/run/tasty-extractors-1/quoted_1.scala
@@ -4,7 +4,7 @@ import scala.tasty._
 
 object Macros {
 
-  implicit rewrite def printTree[T](x: => T): Unit =
+  implicit inline def printTree[T](x: => T): Unit =
     ~impl('(x))
 
   def impl[T](x: Expr[T])(implicit tasty: Tasty): Expr[Unit] = {

--- a/tests/run/tasty-extractors-2/quoted_1.scala
+++ b/tests/run/tasty-extractors-2/quoted_1.scala
@@ -4,7 +4,7 @@ import scala.tasty._
 
 object Macros {
 
-  implicit rewrite def printTree[T](x: => T): Unit =
+  implicit inline def printTree[T](x: => T): Unit =
     ~impl('(x))
 
   def impl[T](x: Expr[T])(implicit tasty: Tasty): Expr[Unit] = {

--- a/tests/run/tasty-extractors-3/quoted_1.scala
+++ b/tests/run/tasty-extractors-3/quoted_1.scala
@@ -5,7 +5,7 @@ import scala.tasty.util.TreeTraverser
 
 object Macros {
 
-  implicit rewrite def printTypes[T](x: => T): Unit =
+  implicit inline def printTypes[T](x: => T): Unit =
     ~impl('(x))
 
   def impl[T](x: Expr[T])(implicit tasty: Tasty): Expr[Unit] = {

--- a/tests/run/tasty-extractors-constants-1/quoted_1.scala
+++ b/tests/run/tasty-extractors-constants-1/quoted_1.scala
@@ -5,7 +5,7 @@ import scala.tasty.util._
 
 object Macros {
 
-  implicit rewrite def testMacro: Unit = ~impl
+  implicit inline def testMacro: Unit = ~impl
 
   def impl(implicit tasty: Tasty): Expr[Unit] = {
     import tasty._

--- a/tests/run/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run/tasty-extractors-owners/quoted_1.scala
@@ -5,7 +5,7 @@ import scala.tasty.util.TreeTraverser
 
 object Macros {
 
-  implicit rewrite def printOwners[T](x: => T): Unit =
+  implicit inline def printOwners[T](x: => T): Unit =
     ~impl('(x))
 
   def impl[T](x: Expr[T])(implicit tasty: Tasty): Expr[Unit] = {

--- a/tests/run/tasty-extractors-types/quoted_1.scala
+++ b/tests/run/tasty-extractors-types/quoted_1.scala
@@ -5,7 +5,7 @@ import scala.tasty.util.TreeTraverser
 
 object Macros {
 
-  implicit rewrite def printType[T]: Unit = ~impl('[T])
+  implicit inline def printType[T]: Unit = ~impl('[T])
 
   def impl[T](x: Type[T])(implicit tasty: Tasty): Expr[Unit] = {
     import tasty._

--- a/tests/run/tasty-getfile/Macro_1.scala
+++ b/tests/run/tasty-getfile/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.tasty.Tasty
 
 object SourceFiles {
 
-  implicit rewrite def getThisFile: String =
+  implicit inline def getThisFile: String =
     ~getThisFileImpl
 
   private def getThisFileImpl(implicit tasty: Tasty): Expr[String] = {

--- a/tests/run/tasty-indexed-map/quoted_1.scala
+++ b/tests/run/tasty-indexed-map/quoted_1.scala
@@ -24,7 +24,7 @@ object Index {
 
   implicit def zero[K, T]: Index[K, (K, T)] = new Index(0)
 
-  implicit rewrite def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ~succImpl[K, H, T]
+  implicit inline def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ~succImpl[K, H, T]
 
   def succImpl[K, H, T](implicit tasty: Tasty, k: Type[K], h: Type[H], t: Type[T]): Expr[Index[K, (H, T)]] = {
     import tasty._

--- a/tests/run/tasty-linenumber-2/quoted_1.scala
+++ b/tests/run/tasty-linenumber-2/quoted_1.scala
@@ -8,7 +8,7 @@ class LineNumber(val value: Int) {
 
 object LineNumber {
 
-  implicit rewrite def line: LineNumber = ~lineImpl
+  implicit inline def line: LineNumber = ~lineImpl
 
   def lineImpl(implicit tasty: Tasty): Expr[LineNumber] = {
     import tasty._

--- a/tests/run/tasty-linenumber/quoted_1.scala
+++ b/tests/run/tasty-linenumber/quoted_1.scala
@@ -8,7 +8,7 @@ class LineNumber(val value: Int) {
 
 object LineNumber {
 
-  implicit rewrite def line[T >: Unit <: Unit]: LineNumber =
+  implicit inline def line[T >: Unit <: Unit]: LineNumber =
     ~lineImpl('[T])
 
   def lineImpl(x: Type[Unit])(implicit tasty: Tasty): Expr[LineNumber] = {

--- a/tests/run/tasty-location/quoted_1.scala
+++ b/tests/run/tasty-location/quoted_1.scala
@@ -6,7 +6,7 @@ case class Location(owners: List[String])
 
 object Location {
 
-  implicit rewrite def location: Location = ~impl
+  implicit inline def location: Location = ~impl
 
   def impl(implicit tasty: Tasty): Expr[Location] = {
     import tasty._

--- a/tests/run/tasty-macro-assert/quoted_1.scala
+++ b/tests/run/tasty-macro-assert/quoted_1.scala
@@ -11,7 +11,7 @@ object Asserts {
 
   object Ops
 
-  rewrite def macroAssert(cond: => Boolean): Unit =
+  inline def macroAssert(cond: => Boolean): Unit =
     ~impl('(cond))
 
   def impl(cond: Expr[Boolean])(implicit tasty: Tasty): Expr[Unit] = {

--- a/tests/run/tasty-positioned/quoted_1.scala
+++ b/tests/run/tasty-positioned/quoted_1.scala
@@ -9,7 +9,7 @@ case class Positioned[T](value: T, position: Position)
 
 object Positioned {
 
-  implicit rewrite def apply[T](x: => T): Positioned[T] = ~impl('(x))
+  implicit inline def apply[T](x: => T): Positioned[T] = ~impl('(x))
 
   def impl[T](x: Expr[T])(implicit ev: Type[T], tasty: Tasty): Expr[Positioned[T]] = {
     import tasty.{Position => _, _}

--- a/tests/run/tasty-subtyping/quoted_1.scala
+++ b/tests/run/tasty-subtyping/quoted_1.scala
@@ -4,10 +4,10 @@ import scala.tasty._
 
 object Macros {
 
-  rewrite def isTypeEqual[T, U]: Boolean =
+  inline def isTypeEqual[T, U]: Boolean =
     ~isTypeEqualImpl('[T], '[U])
 
-  rewrite def isSubTypeOf[T, U]: Boolean =
+  inline def isSubTypeOf[T, U]: Boolean =
     ~isSubTypeOfImpl('[T], '[U])
 
   def isTypeEqualImpl[T, U](t: Type[T], u: Type[U])(implicit tasty: Tasty): Expr[Boolean] = {

--- a/tests/run/transparent-foreach.scala
+++ b/tests/run/transparent-foreach.scala
@@ -1,4 +1,4 @@
-// A demonstrator how `rewrite override` can be used to sepcialize inherited methods
+// A demonstrator how `inline override` can be used to sepcialize inherited methods
 trait Iterable[+A] {
   def foreach(f: A => Unit): Unit
 }
@@ -35,7 +35,7 @@ abstract class Range extends Iterable[Int]  {
 class UntilRange(val start: Int, val end: Int) extends Range {
   def step = 1
   def inclusive = false
-  rewrite override def foreach(f: Int => Unit): Unit = {
+  inline override def foreach(f: Int => Unit): Unit = {
     var idx = start
     while (idx < end) {
       f(idx)
@@ -54,13 +54,13 @@ object Test extends App {
     //    }
 
   class IntDeco(val x: Int) extends AnyVal {
-    rewrite def until(y: Int) = new UntilRange(x, y)
+    inline def until(y: Int) = new UntilRange(x, y)
   }
-  implicit rewrite def intDeco(x: Int): IntDeco = new IntDeco(x)
+  implicit inline def intDeco(x: Int): IntDeco = new IntDeco(x)
     // So far, the decorator has to be an explicit def, since
     // we can inline only methods defined in source. So an implicit class
     // will not work. We can make this work by making `Desugar` smarter
-    // and generate a rewrite method with pre-defined "BodyToInline" annotation.
+    // and generate an inline method with pre-defined "BodyToInline" annotation.
     // It's doable, just extra work.
 
   (1 until 10).foreach(x += _)

--- a/tests/run/transparent-implicits.scala
+++ b/tests/run/transparent-implicits.scala
@@ -11,7 +11,7 @@ object inlines {
   class C {
     implicit val x: X = new X()
 
-    rewrite
+    inline
     def f(): (X, Y) =
       (implicitly[X], implicitly[Y])
   }

--- a/tests/run/transparent-object.scala
+++ b/tests/run/transparent-object.scala
@@ -6,7 +6,7 @@ object Test {
 }
 
 object Foo extends Bar {
-  rewrite def foo: Unit = bar
+  inline def foo: Unit = bar
 }
 
 class Bar {

--- a/tests/run/transparent/inlines_1.scala
+++ b/tests/run/transparent/inlines_1.scala
@@ -4,7 +4,7 @@ import collection.mutable
 object transparents {
   final val monitored = false
 
-  rewrite def f(x: Int): Int = x * x
+  inline def f(x: Int): Int = x * x
 
   val hits = new mutable.HashMap[String, Int] {
     override def default(key: String): Int = 0
@@ -19,7 +19,7 @@ object transparents {
 
   @volatile private var stack: List[String] = Nil
 
-  rewrite def track[T](fn: String)(op: => T) =
+  inline def track[T](fn: String)(op: => T) =
     if (monitored) {
       stack = fn :: stack
       record(fn)
@@ -31,9 +31,9 @@ object transparents {
     def f = "Outer.f"
     class Inner {
       val msg = " Inner"
-      rewrite def m = msg
-      rewrite def g = f
-      rewrite def h = f ++ m
+      inline def m = msg
+      inline def g = f
+      inline def h = f ++ m
     }
     val inner = new Inner
   }
@@ -44,12 +44,12 @@ object transparents {
   }
 
   class TestPassing {
-    rewrite def foo[A](x: A): (A, Int) = {
+    inline def foo[A](x: A): (A, Int) = {
       val c = new C[A](x)
       c.xx = c.x
       c.next(1)
     }
-    rewrite def bar[A](x: A): (A, String) = {
+    inline def bar[A](x: A): (A, String) = {
       val c = new C[A](x)
       c.xx = c.x
       c.next("")

--- a/tests/run/transparentAccess/C_1.scala
+++ b/tests/run/transparentAccess/C_1.scala
@@ -2,6 +2,6 @@ package p {
 class C {
   protected def f(): Unit = ()
 
-  rewrite def inl() = f() // error (when inlined): not accessible
+  inline def inl() = f() // error (when inlined): not accessible
 }
 }

--- a/tests/run/transparentArrowAssoc.scala
+++ b/tests/run/transparentArrowAssoc.scala
@@ -10,7 +10,7 @@ object Test {
   )
 
   final implicit class ArrowAssoc[A](private val self: A) extends AnyVal {
-    rewrite def -> [B](y: B): Tuple2[A, B] = Tuple2(self, y)
+    inline def -> [B](y: B): Tuple2[A, B] = Tuple2(self, y)
     def →[B](y: B): Tuple2[A, B] = ->(y)
   }
 

--- a/tests/run/transparentAssign.scala
+++ b/tests/run/transparentAssign.scala
@@ -1,11 +1,11 @@
 object Test {
 
-  rewrite def swap[T](x: T, x_= : => T => Unit, y: T, y_= : => T => Unit) = {
+  inline def swap[T](x: T, x_= : => T => Unit, y: T, y_= : => T => Unit) = {
     x_=(y)
     y_=(x)
   }
 
-  rewrite def f(x: Int => Unit) = x
+  inline def f(x: Int => Unit) = x
 
   def main(args: Array[String]) = {
     var x = 1

--- a/tests/run/transparentAssign.scala
+++ b/tests/run/transparentAssign.scala
@@ -19,6 +19,6 @@ object Test {
     assert(x == 1 && y == 2)
 
 
-    val z = f(setX)  // tests case where transparent arg is not applied
+    val z = f(setX)  // tests case where inline arg is not applied
   }
 }

--- a/tests/run/transparentByName.scala
+++ b/tests/run/transparentByName.scala
@@ -1,7 +1,7 @@
 object Test {
 
   class Range(from: Int, end: Int) {
-    rewrite def foreach(op: => Int => Unit): Unit = {
+    inline def foreach(op: => Int => Unit): Unit = {
       var i = from
       while (i < end) {
         op(i)
@@ -9,11 +9,11 @@ object Test {
       }
     }
   }
-  rewrite def twice(op: => Int => Unit): Unit = {
+  inline def twice(op: => Int => Unit): Unit = {
     op(1)
     op(2)
   }
-  rewrite def thrice(op: => Unit): Unit = {
+  inline def thrice(op: => Unit): Unit = {
     op
     op
     op

--- a/tests/run/transparentForeach.scala
+++ b/tests/run/transparentForeach.scala
@@ -36,7 +36,7 @@ object Test {
   }
 
   implicit class intArrayOps(arr: Array[Int]) {
-    rewrite def foreach(op: => Int => Unit): Unit = {
+    inline def foreach(op: => Int => Unit): Unit = {
       var i = 0
       while (i < arr.length) {
         op(arr(i))

--- a/tests/run/transparentForeach.scala
+++ b/tests/run/transparentForeach.scala
@@ -2,7 +2,7 @@ object Test {
 
   class Range(from: Int, end: Int) {
 
-    transparent
+    inline
     def foreach(op: => Int => Unit): Unit = {
       var i = from
       while (i < end) {

--- a/tests/run/transparentPower/power_1.scala
+++ b/tests/run/transparentPower/power_1.scala
@@ -2,7 +2,7 @@ package p
 
 object pow {
 
-  rewrite def power(x: Double, n: Int): Double =
+  inline def power(x: Double, n: Int): Double =
     if (n == 0) 1.0
     else if (n == 1) x
     else {

--- a/tests/run/transparentPrivates.scala
+++ b/tests/run/transparentPrivates.scala
@@ -6,19 +6,19 @@ object Test {
 
     private var y: T = _
 
-    rewrite def get1 = x
-    rewrite def get2[U](c: C[U]) = c.x
+    inline def get1 = x
+    inline def get2[U](c: C[U]) = c.x
 
-    rewrite def foo1(x: Int) = foo(x)
-    rewrite def foo2[U](c: C[U]) = c.foo(x)
+    inline def foo1(x: Int) = foo(x)
+    inline def foo2[U](c: C[U]) = c.foo(x)
 
-    rewrite def set1(z: T) = { y = z; y }
-    rewrite def set2[U](c: C[U]) = { c.y = c.x; c.y }
+    inline def set1(z: T) = { y = z; y }
+    inline def set2[U](c: C[U]) = { c.y = c.x; c.y }
   }
 
   object CC {
     private val x = 3
-    rewrite def get1 = x
+    inline def get1 = x
   }
 
   def main(args: Array[String]) = {

--- a/tests/run/transparentProtected.scala
+++ b/tests/run/transparentProtected.scala
@@ -7,7 +7,7 @@ package P {
 package Q {
   class D extends P.C {
     class Inner {
-      rewrite def g() = f()
+      inline def g() = f()
     }
   }
 }

--- a/tests/run/tuples1.scala
+++ b/tests/run/tuples1.scala
@@ -34,8 +34,8 @@ object Test extends App {
   val c2_3 = x2 ++ x3; val c2_3c: (String, Int, Int, String, Int) = c2_3; println(s"c2_3 = $c2_3")
   val c3_3 = x3 ++ x3; val c3_3c: (Int, String, Int, Int, String, Int) = c3_3; println(s"c3_3 = $c3_3")
 
-  rewrite def decompose1 = rewrite x2 match { case x *: xs => (x, xs) }
-  rewrite def decompose2 = rewrite x2 match { case x *: y *: xs => (x, y, xs) }
+  inline def decompose1 = inline x2 match { case x *: xs => (x, xs) }
+  inline def decompose2 = inline x2 match { case x *: y *: xs => (x, y, xs) }
 
   { val (x, xs) = decompose1
     val xc: String = x

--- a/tests/run/typelevel-defaultValue.scala
+++ b/tests/run/typelevel-defaultValue.scala
@@ -5,7 +5,7 @@ object typelevel {
 
 object Test extends App {
 
-  rewrite def defaultValue[T]: Option[Any] = rewrite typelevel.erasedValue[T] match {
+  inline def defaultValue[T]: Option[Any] = inline typelevel.erasedValue[T] match {
     case _: Byte => Some(0: Byte)
     case c: Char => Some(0: Char)
     case d @ (_: Short) => Some(0: Short)

--- a/tests/run/typelevel-numeric.scala
+++ b/tests/run/typelevel-numeric.scala
@@ -7,7 +7,7 @@ abstract class MathLib[N : Numeric] {
 
 object MathLib {
 
-  rewrite def apply[N](implicit n: Numeric[N]) = new MathLib[N] {
+  inline def apply[N](implicit n: Numeric[N]) = new MathLib[N] {
     import n._
     def dotProduct(xs: Array[N], ys: Array[N]): N = {
       require(xs.length == ys.length)

--- a/tests/run/typelevel-overrides.scala
+++ b/tests/run/typelevel-overrides.scala
@@ -8,13 +8,13 @@ class A extends T {
   def f(x: Int) = x
 }
 class B extends A {
-  override rewrite def f(x: Int) = rewrite x match {
+  override inline def f(x: Int) = inline x match {
     case 0 => 0
     case x => x
   }
 }
 class C extends A with U {
-  override rewrite def f(x: Int) = rewrite x match {
+  override inline def f(x: Int) = inline x match {
     case 0 => 0
     case x => x
   }

--- a/tests/run/typelevel-patmat.scala
+++ b/tests/run/typelevel-patmat.scala
@@ -21,7 +21,7 @@ object Test extends App {
   type HNil = HNil.type
   type Z = Z.type
 
-  inline def ToNat(transparent n: Int): Typed[Nat] =
+  inline def ToNat(inline n: Int): Typed[Nat] =
     if n == 0 then Typed(Z)
     else Typed(S(ToNat(n - 1).value))
 
@@ -40,9 +40,9 @@ object Test extends App {
     case S(n1) => toInt(n1) + 1
   }
 
-  transparent val i0 = toInt(y0)
+  inline val i0 = toInt(y0)
   val j0: 0 = i0
-  transparent val i2 = toInt(y2)
+  inline val i2 = toInt(y2)
   val j2: 2 = i2
 
   inline def concat(xs: HList, ys: HList): HList = inline xs match {

--- a/tests/run/typelevel-patmat.scala
+++ b/tests/run/typelevel-patmat.scala
@@ -21,7 +21,7 @@ object Test extends App {
   type HNil = HNil.type
   type Z = Z.type
 
-  rewrite def ToNat(transparent n: Int): Typed[Nat] =
+  inline def ToNat(transparent n: Int): Typed[Nat] =
     if n == 0 then Typed(Z)
     else Typed(S(ToNat(n - 1).value))
 
@@ -35,7 +35,7 @@ object Test extends App {
   println(x1)
   println(x2)
 
-  rewrite def toInt(n: Nat): Int = rewrite n match {
+  inline def toInt(n: Nat): Int = inline n match {
     case Z => 0
     case S(n1) => toInt(n1) + 1
   }
@@ -45,7 +45,7 @@ object Test extends App {
   transparent val i2 = toInt(y2)
   val j2: 2 = i2
 
-  rewrite def concat(xs: HList, ys: HList): HList = rewrite xs match {
+  inline def concat(xs: HList, ys: HList): HList = inline xs match {
     case HNil => ys
     case HCons(x, xs1) => HCons(x, concat(xs1, ys))
   }
@@ -68,7 +68,7 @@ object Test extends App {
   val r6 = concat(HCons(1, HCons("a", HNil)), HCons(true, HCons(1.0, HNil)))
   val c6: HCons[Int, HCons[String, HCons[Boolean, HCons[Double, HNil]]]] = r6
 
-  rewrite def nth(xs: HList, n: Int): Any = rewrite xs match {
+  inline def nth(xs: HList, n: Int): Any = inline xs match {
     case HCons(x, _)   if n == 0 => x
     case HCons(_, xs1) if n > 0  => nth(xs1, n - 1)
   }
@@ -78,7 +78,7 @@ object Test extends App {
   val e1 = nth(r2, 1)
   val ce1: String = e1
 
-  rewrite def concatTyped(xs: HList, ys: HList): Typed[_ <: HList] = rewrite xs match {
+  inline def concatTyped(xs: HList, ys: HList): Typed[_ <: HList] = inline xs match {
     case HNil => Typed(ys)
     case HCons(x, xs1) => Typed(HCons(x, concatTyped(xs1, ys).value))
   }
@@ -88,7 +88,7 @@ object Test extends App {
     case HCons(x, xs1) => HCons(x, concatImpl(xs1, ys))
   }
 
-  rewrite def concatErased(xs: HList, ys: HList): HList = {
+  inline def concatErased(xs: HList, ys: HList): HList = {
     erased val r = concatTyped(xs, ys)
     concatImpl(xs, ys).asInstanceOf[r.Type]
   }

--- a/tests/run/typelevel.scala
+++ b/tests/run/typelevel.scala
@@ -4,24 +4,24 @@ trait Nat {
 }
 
 case object Z extends Nat {
-  rewrite override def toInt = 0
+  inline override def toInt = 0
 }
 
 case class S[N <: Nat](n: N) extends Nat {
-  rewrite override def toInt = n.toInt + 1
+  inline override def toInt = n.toInt + 1
 }
 
 trait HList {
   def length: Int = ???
   def head: Any
   def tail: HList
-  rewrite def isEmpty: Boolean =
+  inline def isEmpty: Boolean =
     length == 0
 }
 
 // ()
 case object HNil extends HList {
-  rewrite override def length = 0
+  inline override def length = 0
   def head: Nothing = ???
   def tail: Nothing = ???
 }
@@ -29,7 +29,7 @@ case object HNil extends HList {
 // (H, T)
 @annotation.showAsInfix(true)
 case class HCons [H, T <: HList](hd: H, tl: T) extends HList {
-  rewrite override def length = 1 + tl.length
+  inline override def length = 1 + tl.length
   def head: H = this.hd
   def tail: T = this.tl
 }
@@ -42,7 +42,7 @@ object Test extends App {
   type HNil = HNil.type
   type Z = Z.type
 
-  rewrite def ToNat(transparent n: Int): ToNat[Nat] =
+  inline def ToNat(transparent n: Int): ToNat[Nat] =
     if n == 0 then new ToNat(Z)
     else {
       val n1 = ToNat(n - 1)
@@ -67,10 +67,10 @@ object Test extends App {
   val j2: 2 = i2
 
   class HListDeco(private val as: HList) extends AnyVal {
-    rewrite def :: [H] (a: H) = HCons(a, as)
-    rewrite def ++ (bs: HList) = concat(as, bs)
+    inline def :: [H] (a: H) = HCons(a, as)
+    inline def ++ (bs: HList) = concat(as, bs)
   }
-  rewrite def concat(xs: HList, ys: HList): HList =
+  inline def concat(xs: HList, ys: HList): HList =
     if xs.isEmpty then ys
     else HCons(xs.head, concat(xs.tail, ys))
 
@@ -85,11 +85,11 @@ object Test extends App {
   val r5 = concat(HCons(1, HCons("a", HNil)) , HNil)
   val r6 = concat(HCons(1, HCons("a", HNil)), HCons(true, HCons(1.0, HNil)))
 
-  rewrite def size(xs: HList): Nat =
+  inline def size(xs: HList): Nat =
     if xs.isEmpty then Z
     else S(size(xs.tail))
 
-  rewrite def sizeDefensive(xs: HList): Nat = rewrite xs.isEmpty match {
+  inline def sizeDefensive(xs: HList): Nat = inline xs.isEmpty match {
     case true => Z
     case false => S(sizeDefensive(xs.tail))
   }
@@ -101,7 +101,7 @@ object Test extends App {
   transparent val l1 = xs.length
   val l1a: 2 = l1
 
-  rewrite def index(xs: HList, transparent idx: Int): Any =
+  inline def index(xs: HList, transparent idx: Int): Any =
     if idx == 0 then xs.head
     else index(xs.tail, idx - 1)
 
@@ -117,7 +117,7 @@ object Test extends App {
 
   //val ys = 1 :: "a" :: HNil
 
-  rewrite implicit def hlistDeco(xs: HList): HListDeco = new HListDeco(xs)
+  inline implicit def hlistDeco(xs: HList): HListDeco = new HListDeco(xs)
 
   val rr0 = new HListDeco(HNil).++(HNil)
   val rr1 = HNil ++ xs
@@ -125,7 +125,7 @@ object Test extends App {
   val rr3 = xs ++ xs
   val rr3a: HCons[Int, HCons[String, HCons[Int, HCons[String, HNil]]]] = rr3
 
-  rewrite def f(c: Boolean): Nat = {
+  inline def f(c: Boolean): Nat = {
     def g[X <: Nat](x: X): X = x
     g(if (c) Z else S(Z))
   }
@@ -133,8 +133,8 @@ object Test extends App {
   val f1: Z = f(true)
   val f2: S[Z] = f(false)
 
-  rewrite def mapHead[T, R](t: T)(implicit fh: T => R): R = fh(t)
-  rewrite def map(xs: HList): HList = {
+  inline def mapHead[T, R](t: T)(implicit fh: T => R): R = fh(t)
+  inline def map(xs: HList): HList = {
 
     if (xs.isEmpty) HNil
     else HCons(mapHead(xs.head), map(xs.tail))
@@ -148,12 +148,12 @@ object Test extends App {
   val res1: Boolean `HCons` (Int `HCons` (String `HCons` HNil)) = res
 
 /*
-  rewrite def toInt1[T]: Int = type T match {
+  inline def toInt1[T]: Int = type T match {
     case Z => 0
     case S[type N] => toInt[N] + 1
   }
 
-  rewrite def toInt1[T]: Nat = implicit match {
+  inline def toInt1[T]: Nat = implicit match {
     case C[type T, type U], T =:= U =>
     case T <:< S[type N] => toInt[N] + 1
   }

--- a/tests/run/typelevel.scala
+++ b/tests/run/typelevel.scala
@@ -42,7 +42,7 @@ object Test extends App {
   type HNil = HNil.type
   type Z = Z.type
 
-  inline def ToNat(transparent n: Int): ToNat[Nat] =
+  inline def ToNat(inline n: Int): ToNat[Nat] =
     if n == 0 then new ToNat(Z)
     else {
       val n1 = ToNat(n - 1)
@@ -61,9 +61,9 @@ object Test extends App {
   println(x0)
   println(x1)
   println(x2)
-  transparent val i0 = y0.toInt
+  inline val i0 = y0.toInt
   val j0: 0 = i0
-  transparent val i2 = y2.toInt
+  inline val i2 = y2.toInt
   val j2: 2 = i2
 
   class HListDeco(private val as: HList) extends AnyVal {
@@ -96,12 +96,12 @@ object Test extends App {
 
   val s0 = size(HNil)
   val s1 = size(xs)
-  transparent val l0 = HNil.length
+  inline val l0 = HNil.length
   val l0a: 0 = l0
-  transparent val l1 = xs.length
+  inline val l1 = xs.length
   val l1a: 2 = l1
 
-  inline def index(xs: HList, transparent idx: Int): Any =
+  inline def index(xs: HList, inline idx: Int): Any =
     if idx == 0 then xs.head
     else index(xs.tail, idx - 1)
 

--- a/tests/run/typelevel1.scala
+++ b/tests/run/typelevel1.scala
@@ -4,17 +4,17 @@ trait HList {
   def head: Any
   def tail: HList
 
-  rewrite def isEmpty: Boolean = length == 0
+  inline def isEmpty: Boolean = length == 0
 }
 
 case object HNil extends HList {
-  rewrite override def length = 0
+  inline override def length = 0
   def head: Nothing = ???
   def tail: Nothing = ???
 }
 
 case class :: [H, T <: HList] (hd: H, tl: T) extends HList {
-  rewrite override def length = 1 + tl.length
+  inline override def length = 1 + tl.length
   def head: H = this.hd
   def tail: T = this.tl
 }
@@ -23,14 +23,14 @@ object Test extends App {
   type HNil = HNil.type
 
   class HListDeco(val as: HList) extends AnyVal {
-    rewrite def :: [H] (a: H): HList = new :: (a, as)
-    rewrite def ++ (bs: HList): HList = concat(as, bs)
-    rewrite def apply(idx: Int): Any = index(as, idx)
+    inline def :: [H] (a: H): HList = new :: (a, as)
+    inline def ++ (bs: HList): HList = concat(as, bs)
+    inline def apply(idx: Int): Any = index(as, idx)
   }
 
-  rewrite implicit def hlistDeco(xs: HList): HListDeco = new HListDeco(xs)
+  inline implicit def hlistDeco(xs: HList): HListDeco = new HListDeco(xs)
 
-  rewrite def concat[T1, T2](xs: HList, ys: HList): HList =
+  inline def concat[T1, T2](xs: HList, ys: HList): HList =
     if xs.isEmpty then ys
     else new ::(xs.head, concat(xs.tail, ys))
 
@@ -40,7 +40,7 @@ object Test extends App {
 
   val control: Int :: String :: String :: Boolean :: Double :: HNil = zs
 
-  rewrite def index(xs: HList, idx: Int): Any =
+  inline def index(xs: HList, idx: Int): Any =
     if idx == 0 then xs.head
     else index(xs.tail, idx - 1)
 

--- a/tests/run/typelevel3.scala
+++ b/tests/run/typelevel3.scala
@@ -4,17 +4,17 @@ trait HList {
   def head: Any
   def tail: HList
 
-  rewrite def isEmpty: Boolean = length == 0
+  inline def isEmpty: Boolean = length == 0
 }
 
 case object HNil extends HList {
-  rewrite override def length = 0
+  inline override def length = 0
   def head: Nothing = ???
   def tail: Nothing = ???
 }
 
 case class HCons[H, T <: HList](hd: H, tl: T) extends HList {
-  rewrite override def length = 1 + tl.length
+  inline override def length = 1 + tl.length
   def head: H = this.hd
   def tail: T = this.tl
 }
@@ -24,7 +24,7 @@ case class Typed[T](val value: T) { type Type = T }
 object Test extends App {
   type HNil = HNil.type
 
-  rewrite def concat(xs: HList, ys: HList): Typed[_ <: HList] =
+  inline def concat(xs: HList, ys: HList): Typed[_ <: HList] =
     if xs.isEmpty then Typed(ys)
     else Typed(HCons(xs.head, concat(xs.tail, ys).value))
 
@@ -35,7 +35,7 @@ object Test extends App {
 
   val control: HCons[Int, HCons[String, HCons[String, HCons[Boolean, HCons[Double, HNil]]]]] = zs.value
 
-  rewrite def index(xs: HList, idx: Int): Typed[_] =
+  inline def index(xs: HList, idx: Int): Typed[_] =
     if idx == 0 then Typed(xs.head)
     else Typed(index(xs.tail, idx - 1).value)
 
@@ -51,7 +51,7 @@ object Test extends App {
     if xs.isEmpty then ys
     else HCons(xs.head, opaqueConcat(xs.tail, ys))
 
-  rewrite def compactConcat(xs: HList, ys: HList): HList = {
+  inline def compactConcat(xs: HList, ys: HList): HList = {
     erased val r = concat(xs, ys)
     opaqueConcat(xs, ys).asInstanceOf[r.Type]
   }

--- a/tests/run/xml-interpolation/XmlQuote_1.scala
+++ b/tests/run/xml-interpolation/XmlQuote_1.scala
@@ -6,13 +6,13 @@ import scala.language.implicitConversions
 case class Xml(parts: String, args: List[Any])
 
 // Ideally should be an implicit class but the implicit conversion
-// has to be a rewrite method
+// has to be a inline method
 class XmlQuote(ctx: => StringContext) {
-  rewrite def xml(args: => Any*): Xml = ~XmlQuote.impl('(ctx), '(args))
+  inline def xml(args: => Any*): Xml = ~XmlQuote.impl('(ctx), '(args))
 }
 
 object XmlQuote {
-  implicit rewrite def XmlQuote(ctx: => StringContext): XmlQuote = new XmlQuote(ctx)
+  implicit inline def XmlQuote(ctx: => StringContext): XmlQuote = new XmlQuote(ctx)
 
   def impl(ctx: Expr[StringContext], args: Expr[Seq[Any]])
           (implicit tasty: Tasty): Expr[Xml] = {


### PR DESCRIPTION
As a first step, rename all occurrences of `rewrite` to `inline`.

`inline` is now a soft keyword, so it can still be used as an annotation.