### PR TITLE
Promote `WhileDo` loops to typed trees.

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -63,6 +63,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   type Throw           = tpd.Apply
   type Labeled         = tpd.Labeled
   type Return          = tpd.Return
+  type WhileDo         = tpd.WhileDo
   type Block           = tpd.Block
   type Typed           = tpd.Typed
   type Match           = tpd.Match
@@ -196,6 +197,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   implicit val ThrowTag: ClassTag[Throw] = ClassTag[Throw](classOf[Throw])
   implicit val LabeledTag: ClassTag[Labeled] = ClassTag[Labeled](classOf[Labeled])
   implicit val ReturnTag: ClassTag[Return] = ClassTag[Return](classOf[Return])
+  implicit val WhileDoTag: ClassTag[WhileDo] = ClassTag[WhileDo](classOf[WhileDo])
   implicit val LiteralTag: ClassTag[Literal] = ClassTag[Literal](classOf[Literal])
   implicit val BlockTag: ClassTag[Block] = ClassTag[Block](classOf[Block])
   implicit val TypedTag: ClassTag[Typed] = ClassTag[Typed](classOf[Typed])
@@ -1086,6 +1088,11 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   object Return extends ReturnDeconstructor {
     def _1: Tree = field.expr
     def _2: Symbol = if (field.from.symbol.isLabel) field.from.symbol else NoSymbol
+  }
+
+  object WhileDo extends WhileDoDeconstructor {
+    def _1: Tree = field.cond
+    def _2: Tree = field.body
   }
 
   object Ident extends IdentDeconstructor {

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -927,13 +927,6 @@ object desugar {
   /** Main desugaring method */
   def apply(tree: Tree)(implicit ctx: Context): Tree = {
 
-    /**    { label def lname(): Unit = rhs; call }
-     */
-    def labelDefAndCall(lname: TermName, rhs: Tree, call: Tree) = {
-      val ldef = DefDef(lname, Nil, ListOfNil, TypeTree(defn.UnitType), rhs).withFlags(Label | Synthetic)
-      Block(ldef, call)
-    }
-
     /** Create tree for for-comprehension `<for (enums) do body>` or
      *   `<for (enums) yield body>` where mapName and flatMapName are chosen
      *  corresponding to whether this is a for-do or a for-yield.
@@ -1158,16 +1151,10 @@ object desugar {
       case PrefixOp(op, t) =>
         val nspace = if (ctx.mode.is(Mode.Type)) tpnme else nme
         Select(t, nspace.UNARY_PREFIX ++ op.name)
-      case WhileDo(cond, body) =>
-        // { <label> def while$(): Unit = if (cond) { body; while$() } ; while$() }
-        val call = Apply(Ident(nme.WHILE_PREFIX), Nil).withPos(tree.pos)
-        val rhs = If(cond, Block(body, call), unitLiteral)
-        labelDefAndCall(nme.WHILE_PREFIX, rhs, call)
       case DoWhile(body, cond) =>
-        // { label def doWhile$(): Unit = { body; if (cond) doWhile$() } ; doWhile$() }
-        val call = Apply(Ident(nme.DO_WHILE_PREFIX), Nil).withPos(tree.pos)
-        val rhs = Block(body, If(cond, call, unitLiteral))
-        labelDefAndCall(nme.DO_WHILE_PREFIX, rhs, call)
+        // while ({ { body }; { cond } }) { () }
+        // the inner blocks are there to protect the scopes of body and cond from each other
+        WhileDo(Block(Block(Nil, body), Block(Nil, cond)), Literal(Constant(())))
       case ForDo(enums, body) =>
         makeFor(nme.foreach, nme.foreach, enums, body) orElse tree
       case ForYield(enums, body) =>

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -129,6 +129,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def Return(expr: Tree, from: Tree)(implicit ctx: Context): Return =
     ta.assignType(untpd.Return(expr, from))
 
+  def WhileDo(cond: Tree, body: Tree)(implicit ctx: Context): WhileDo =
+    ta.assignType(untpd.WhileDo(cond, body))
+
   def Try(block: Tree, cases: List[CaseDef], finalizer: Tree)(implicit ctx: Context): Try =
     ta.assignType(untpd.Try(block, cases, finalizer), block, cases)
 
@@ -608,6 +611,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
     override def Return(tree: Tree)(expr: Tree, from: Tree)(implicit ctx: Context): Return =
       ta.assignType(untpd.cpy.Return(tree)(expr, from))
+
+    override def WhileDo(tree: Tree)(cond: Tree, body: Tree)(implicit ctx: Context): WhileDo =
+      ta.assignType(untpd.cpy.WhileDo(tree)(cond, body))
 
     override def Try(tree: Tree)(expr: Tree, cases: List[CaseDef], finalizer: Tree)(implicit ctx: Context): Try = {
       val tree1 = untpd.cpy.Try(tree)(expr, cases, finalizer)

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -85,7 +85,6 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   }
   case class Throw(expr: Tree) extends TermTree
   case class Quote(expr: Tree) extends TermTree
-  case class WhileDo(cond: Tree, body: Tree) extends TermTree
   case class DoWhile(body: Tree, cond: Tree) extends TermTree
   case class ForYield(enums: List[Tree], expr: Tree) extends TermTree
   case class ForDo(enums: List[Tree], body: Tree) extends TermTree
@@ -280,6 +279,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def CaseDef(pat: Tree, guard: Tree, body: Tree): CaseDef = new CaseDef(pat, guard, body)
   def Labeled(bind: Bind, expr: Tree): Labeled = new Labeled(bind, expr)
   def Return(expr: Tree, from: Tree): Return = new Return(expr, from)
+  def WhileDo(cond: Tree, body: Tree): WhileDo = new WhileDo(cond, body)
   def Try(expr: Tree, cases: List[CaseDef], finalizer: Tree): Try = new Try(expr, cases, finalizer)
   def SeqLiteral(elems: List[Tree], elemtpt: Tree): SeqLiteral = new SeqLiteral(elems, elemtpt)
   def JavaSeqLiteral(elems: List[Tree], elemtpt: Tree): JavaSeqLiteral = new JavaSeqLiteral(elems, elemtpt)
@@ -470,10 +470,6 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       case tree: Quote if expr eq tree.expr => tree
       case _ => finalize(tree, untpd.Quote(expr))
     }
-    def WhileDo(tree: Tree)(cond: Tree, body: Tree) = tree match {
-      case tree: WhileDo if (cond eq tree.cond) && (body eq tree.body) => tree
-      case _ => finalize(tree, untpd.WhileDo(cond, body))
-    }
     def DoWhile(tree: Tree)(body: Tree, cond: Tree) = tree match {
       case tree: DoWhile if (body eq tree.body) && (cond eq tree.cond) => tree
       case _ => finalize(tree, untpd.DoWhile(body, cond))
@@ -534,8 +530,6 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
         cpy.Throw(tree)(transform(expr))
       case Quote(expr) =>
         cpy.Quote(tree)(transform(expr))
-      case WhileDo(cond, body) =>
-        cpy.WhileDo(tree)(transform(cond), transform(body))
       case DoWhile(body, cond) =>
         cpy.DoWhile(tree)(transform(body), transform(cond))
       case ForYield(enums, expr) =>
@@ -585,8 +579,6 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
         this(x, expr)
       case Quote(expr) =>
         this(x, expr)
-      case WhileDo(cond, body) =>
-        this(this(x, cond), body)
       case DoWhile(body, cond) =>
         this(this(x, body), cond)
       case ForYield(enums, expr) =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -91,6 +91,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   MATCH          Length sel_Term CaseDef*
                   TRY            Length expr_Term CaseDef* finalizer_Term?
                   RETURN         Length meth_ASTRef expr_Term?
+                  WHILE          Length cond_Term body_Term
                   REPEATED       Length elem_Type elem_Term*
                   SELECTouter    Length levels_Nat qual_Term underlying_Type
                   BIND           Length boundName_NameRef patType_Type pat_Term
@@ -245,7 +246,7 @@ Standard Section: "Comments" Comment*
 object TastyFormat {
 
   final val header = Array(0x5C, 0xA1, 0xAB, 0x1F)
-  val MajorVersion = 10
+  val MajorVersion = 11
   val MinorVersion = 0
 
   /** Tags used to serialize names */
@@ -392,48 +393,49 @@ object TastyFormat {
   final val LAMBDA = 142
   final val MATCH = 143
   final val RETURN = 144
-  final val TRY = 145
-  final val INLINED = 146
-  final val SELECTouter = 147
-  final val REPEATED = 148
-  final val BIND = 149
-  final val ALTERNATIVE = 150
-  final val UNAPPLY = 151
-  final val ANNOTATEDtype = 152
-  final val ANNOTATEDtpt = 153
-  final val CASEDEF = 154
-  final val TEMPLATE = 155
-  final val SUPER = 156
-  final val SUPERtype = 157
-  final val REFINEDtype = 158
-  final val REFINEDtpt = 159
-  final val APPLIEDtype = 160
-  final val APPLIEDtpt = 161
-  final val TYPEBOUNDS = 162
-  final val TYPEBOUNDStpt = 163
-  final val ANDtype = 164
-  final val ANDtpt = 165
-  final val ORtype = 166
-  final val ORtpt = 167
-  final val POLYtype = 168
-  final val TYPELAMBDAtype = 169
-  final val LAMBDAtpt = 170
-  final val PARAMtype = 171
-  final val ANNOTATION = 172
-  final val TERMREFin = 173
-  final val TYPEREFin = 174
-  final val OBJECTDEF = 175
+  final val WHILE = 145
+  final val TRY = 146
+  final val INLINED = 147
+  final val SELECTouter = 148
+  final val REPEATED = 149
+  final val BIND = 150
+  final val ALTERNATIVE = 151
+  final val UNAPPLY = 152
+  final val ANNOTATEDtype = 153
+  final val ANNOTATEDtpt = 154
+  final val CASEDEF = 155
+  final val TEMPLATE = 156
+  final val SUPER = 157
+  final val SUPERtype = 158
+  final val REFINEDtype = 159
+  final val REFINEDtpt = 160
+  final val APPLIEDtype = 161
+  final val APPLIEDtpt = 162
+  final val TYPEBOUNDS = 163
+  final val TYPEBOUNDStpt = 164
+  final val ANDtype = 165
+  final val ANDtpt = 166
+  final val ORtype = 167
+  final val ORtpt = 168
+  final val POLYtype = 169
+  final val TYPELAMBDAtype = 170
+  final val LAMBDAtpt = 171
+  final val PARAMtype = 172
+  final val ANNOTATION = 173
+  final val TERMREFin = 174
+  final val TYPEREFin = 175
+  final val OBJECTDEF = 176
 
-  // In binary: 101100EI
+  // In binary: 101101EI
   // I = implicit method type
   // E = erased method type
-  final val METHODtype = 176
-  final val IMPLICITMETHODtype = 177
-  final val ERASEDMETHODtype = 178
-  final val ERASEDIMPLICITMETHODtype = 179
+  final val METHODtype = 180
+  final val IMPLICITMETHODtype = 181
+  final val ERASEDMETHODtype = 182
+  final val ERASEDIMPLICITMETHODtype = 183
 
-  final val MATCHtype = 180
-  final val MATCHtpt = 181
+  final val MATCHtype = 190
+  final val MATCHtpt = 191
 
   final val UNTYPEDSPLICE = 199
 
@@ -607,6 +609,7 @@ object TastyFormat {
     case LAMBDA => "LAMBDA"
     case MATCH => "MATCH"
     case RETURN => "RETURN"
+    case WHILE => "WHILE"
     case INLINED => "INLINED"
     case SELECTouter => "SELECTouter"
     case TRY => "TRY"

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -436,6 +436,9 @@ class TreePickler(pickler: TastyPickler) {
         case Return(expr, from) =>
           writeByte(RETURN)
           withLength { pickleSymRef(from.symbol); pickleTreeUnlessEmpty(expr) }
+        case WhileDo(cond, body) =>
+          writeByte(WHILE)
+          withLength { pickleTree(cond); pickleTree(body) }
         case Try(block, cases, finalizer) =>
           writeByte(TRY)
           withLength { pickleTree(block); cases.foreach(pickleTree); pickleTreeUnlessEmpty(finalizer) }
@@ -796,6 +799,9 @@ class TreePickler(pickler: TastyPickler) {
       case Return(expr, from) =>
         writeByte(RETURN)
         withLength { pickleDummyRef(); pickleUnlessEmpty(expr) }
+      case WhileDo(cond, body) =>
+        writeByte(WHILE)
+        withLength { pickleUntyped(cond); pickleUntyped(body) }
       case Try(block, cases, finalizer) =>
         writeByte(TRY)
         withLength { pickleUntyped(block); cases.foreach(pickleUntyped); pickleUnlessEmpty(finalizer) }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1080,6 +1080,8 @@ class TreeUnpickler(reader: TastyReader,
               val from = readSymRef()
               val expr = ifBefore(end)(readTerm(), EmptyTree)
               Return(expr, Ident(from.termRef))
+            case WHILE =>
+              WhileDo(readTerm(), readTerm())
             case TRY =>
               Try(readTerm(), readCases(end), ifBefore(end)(readTerm(), EmptyTree))
             case SELECTouter =>
@@ -1331,6 +1333,8 @@ class TreeUnpickler(reader: TastyReader,
             readNat()
             val expr = ifBefore(end)(readUntyped(), untpd.EmptyTree)
             untpd.Return(expr, untpd.EmptyTree)
+          case WHILE =>
+            untpd.WhileDo(readUntyped(), readUntyped())
           case TRY =>
             untpd.Try(readUntyped(), readCases(end), ifBefore(end)(readUntyped(), untpd.EmptyTree))
           case BIND =>

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -381,6 +381,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           changePrec(GlobalPrec) { keywordStr("return[") ~ toText(sym.name) ~ keywordStr("]") ~ optText(expr)(" " ~ _) }
         else
           changePrec(GlobalPrec) { keywordStr("return") ~ optText(expr)(" " ~ _) }
+      case WhileDo(cond, body) =>
+        changePrec(GlobalPrec) { keywordStr("while ") ~ toText(cond) ~ keywordStr(" do ") ~ toText(body) }
       case Try(expr, cases, finalizer) =>
         changePrec(GlobalPrec) {
           keywordStr("try ") ~ toText(expr) ~ optText(cases)(keywordStr(" catch ") ~ _) ~ optText(finalizer)(keywordStr(" finally ") ~ _)
@@ -524,8 +526,6 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         "(" ~ toTextGlobal(t) ~ ")"
       case Tuple(ts) =>
         "(" ~ toTextGlobal(ts, ", ") ~ ")"
-      case WhileDo(cond, body) =>
-        changePrec(GlobalPrec) { keywordStr("while ") ~ toText(cond) ~ keywordStr(" do ") ~ toText(body) }
       case DoWhile(cond, body) =>
         changePrec(GlobalPrec) { keywordStr("do ") ~ toText(body) ~ keywordStr(" while ") ~ toText(cond) }
       case ForYield(enums, expr) =>

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TreeOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TreeOpsImpl.scala
@@ -378,14 +378,6 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with TastyCoreImpl with He
         case _ => None
       }
     }
-
-    object DoWhile extends DoWhileExtractor {
-      def unapply(x: Term)(implicit ctx: Context): Option[(Term, Term)] = x match {
-        case Trees.WhileDo(Trees.Block(Trees.Block(Nil, body) :: Nil, Trees.Block(Nil, cond)), Trees.Literal(Constants.Constant(()))) =>
-          Some((body, cond))
-        case _ => None
-      }
-    }
   }
 
   def termAsParent(term: Term): Parent = term

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -486,6 +486,9 @@ trait TypeAssigner {
   def assignType(tree: untpd.Return)(implicit ctx: Context) =
     tree.withType(defn.NothingType)
 
+  def assignType(tree: untpd.WhileDo)(implicit ctx: Context) =
+    tree.withType(defn.UnitType)
+
   def assignType(tree: untpd.Try, expr: Tree, cases: List[CaseDef])(implicit ctx: Context) =
     if (cases.isEmpty) tree.withType(expr.tpe)
     else tree.withType(ctx.typeComparer.lub(expr.tpe :: cases.tpes))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1137,6 +1137,12 @@ class Typer extends Namer
     assignType(cpy.Return(tree)(expr1, from))
   }
 
+  def typedWhileDo(tree: untpd.WhileDo)(implicit ctx: Context): Tree = track("typedWhileDo") {
+    val cond1 = typed(tree.cond, defn.BooleanType)
+    val body1 = typed(tree.body, defn.UnitType)
+    assignType(cpy.WhileDo(tree)(cond1, body1))
+  }
+
   def typedTry(tree: untpd.Try, pt: Type)(implicit ctx: Context): Try = track("typedTry") {
     val expr2 :: cases2x = harmonic(harmonize) {
       val expr1 = typed(tree.expr, pt.notApplied)
@@ -1889,6 +1895,7 @@ class Typer extends Namer
           case tree: untpd.Import => typedImport(tree, retrieveSym(tree))
           case tree: untpd.Match => typedMatch(tree, pt)
           case tree: untpd.Return => typedReturn(tree)
+          case tree: untpd.WhileDo => typedWhileDo(tree)
           case tree: untpd.Try => typedTry(tree, pt)
           case tree: untpd.Throw => typedThrow(tree)
           case tree: untpd.TypeApply => typedTypeApply(tree, pt)

--- a/library/src/scala/tasty/reflect/TreeOps.scala
+++ b/library/src/scala/tasty/reflect/TreeOps.scala
@@ -298,12 +298,6 @@ trait TreeOps extends TastyCore {
       /** Extractor for while loops. Matches `while (<cond>) <body>` and returns (<cond>, <body>) */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Term)]
     }
-
-    val DoWhile: DoWhileExtractor
-    abstract class DoWhileExtractor {
-      /** Extractor for do while loops. Matches `do <body> while (<cond>)` and returns (<body>, <cond>) */
-      def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Term)]
-    }
   }
 
   implicit def termAsParent(term: Term): Parent

--- a/library/src/scala/tasty/util/ShowExtractors.scala
+++ b/library/src/scala/tasty/util/ShowExtractors.scala
@@ -62,6 +62,8 @@ class ShowExtractors[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
         this += "Term.Match(" += selector += ", " ++= cases += ")"
       case Term.Return(expr) =>
         this += "Term.Return(" += expr += ")"
+      case Term.While(cond, body) =>
+        this += "Term.While(" += cond += ", " += body += ")"
       case Term.Try(block, handlers, finalizer) =>
         this += "Term.Try(" += block += ", " ++= handlers += ", " += finalizer += ")"
       case Term.Repeated(elems) =>

--- a/library/src/scala/tasty/util/ShowSourceCode.scala
+++ b/library/src/scala/tasty/util/ShowSourceCode.scala
@@ -227,15 +227,17 @@ class ShowSourceCode[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
             this
         }
 
-      case Term.DoWhile(body, cond) => // DoWhile must come before While
-        this += "do "
-        printTree(body) += " while "
-        inParens(printTree(cond))
-
       case Term.While(cond, body) =>
-        this += "while "
-        inParens(printTree(cond)) += " "
-        printTree(body)
+        (cond, body) match {
+          case (Term.Block(Term.Block(Nil, body1) :: Nil, Term.Block(Nil, cond1)), Term.Literal(Constant.Unit())) =>
+            this += "do "
+            printTree(body1) += " while "
+            inParens(printTree(cond1))
+          case _ =>
+            this += "while "
+            inParens(printTree(cond)) += " "
+            printTree(body)
+        }
 
       case IsDefDef(ddef @ DefDef(name, targs, argss, tpt, rhs)) =>
         printDefAnnotations(ddef)

--- a/library/src/scala/tasty/util/ShowSourceCode.scala
+++ b/library/src/scala/tasty/util/ShowSourceCode.scala
@@ -227,15 +227,15 @@ class ShowSourceCode[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
             this
         }
 
+      case Term.DoWhile(body, cond) => // DoWhile must come before While
+        this += "do "
+        printTree(body) += " while "
+        inParens(printTree(cond))
+
       case Term.While(cond, body) =>
         this += "while "
         inParens(printTree(cond)) += " "
         printTree(body)
-
-      case Term.DoWhile(body, cond) =>
-        this += "do "
-        printTree(body) += " while "
-        inParens(printTree(cond))
 
       case IsDefDef(ddef @ DefDef(name, targs, argss, tpt, rhs)) =>
         printDefAnnotations(ddef)

--- a/tests/run-with-compiler/quote-inline-function.check
+++ b/tests/run-with-compiler/quote-inline-function.check
@@ -7,11 +7,12 @@ Normal function
     f.apply(x$1)
     i = i.+(1)
   }
-  do {
+  while ({
     val x$2: scala.Int = i
     f.apply(x$2)
     i = i.+(1)
-  } while (i.<(j))
+    i.<(j)
+  }) ()
 }
 
 By name function
@@ -23,9 +24,10 @@ By name function
     scala.Predef.println(x$1)
     i = i.+(1)
   }
-  do {
+  while ({
     val x$2: scala.Int = i
     scala.Predef.println(x$2)
     i = i.+(1)
-  } while (i.<(j))
+    i.<(j)
+  }) ()
 }


### PR DESCRIPTION
They remain as such, without desugaring, until the back-end. We also use them to desugar `DoWhile` loops, instead of label-defs.

This is the second step towards getting rid of label-defs.