### PR TITLE
vscode-dotty display improvement and coursier update

### DIFF
--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -51,7 +51,7 @@
     "vscode:prepublish": "npm install && ./node_modules/.bin/tsc -p ./",
     "compile": "./node_modules/.bin/tsc -p ./",
     "test": "node ./node_modules/vscode/bin/test",
-    "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.0.3/coursier"
+    "postinstall": "node ./node_modules/vscode/bin/install && curl -L -o out/coursier https://github.com/coursier/coursier/raw/v1.1.0-M7/coursier"
   },
   "extensionDependencies": [
     "daltonjorge.scala"

--- a/vscode-dotty/src/extension.ts
+++ b/vscode-dotty/src/extension.ts
@@ -7,7 +7,8 @@ import * as cpp from 'child-process-promise';
 
 import { ExtensionContext } from 'vscode';
 import * as vscode from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, RevealOutputChannelOn,
+         ServerOptions } from 'vscode-languageclient';
 
 let extensionContext: ExtensionContext
 let outputChannel: vscode.OutputChannel
@@ -156,7 +157,8 @@ function run(serverOptions: ServerOptions) {
     ],
     synchronize: {
       configurationSection: 'dotty'
-    }
+    },
+    revealOutputChannelOn: RevealOutputChannelOn.Never
   }
 
   outputChannel.dispose()


### PR DESCRIPTION
Most of the time, the server can recover from errors, so displaying the
stack trace to the user will only confuse him.