### PR TITLE
Fix #5149: Use function that closes the file stream

### DIFF
--- a/compiler/test/dotty/tools/dotc/core/tasty/CommentPicklingTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/tasty/CommentPicklingTest.scala
@@ -110,7 +110,7 @@ class CommentPicklingTest {
       implicit val (_, ctx: Context) = setup(args, initCtx)
       ctx.initialize()
       val trees = files.flatMap { f =>
-        val unpickler = new DottyUnpickler(f.bytes().toArray)
+        val unpickler = new DottyUnpickler(f.toByteArray())
         unpickler.enter(roots = Set.empty)
         unpickler.trees(ctx)
       }


### PR DESCRIPTION
Fixes #5149 
The real reason of the fail was that call ```f.bytes().toArray``` left stream open.