### PR TITLE
Don't report Dynamic inheritance warning on Dynamic itself

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1603,7 +1603,13 @@ class Typer extends Namer
       }
       val cdef1 = assignType(cpy.TypeDef(cdef)(name, impl1), cls)
       checkVariance(cdef1)
-      if (ctx.phase.isTyper && cdef1.tpe.derivesFrom(defn.DynamicClass) && !ctx.dynamicsEnabled) {
+
+      val reportDynamicInheritance =
+        ctx.phase.isTyper &&
+        cdef1.symbol.ne(defn.DynamicClass) &&
+        cdef1.tpe.derivesFrom(defn.DynamicClass) &&
+        !ctx.dynamicsEnabled
+      if (reportDynamicInheritance) {
         val isRequired = parents1.exists(_.tpe.isRef(defn.DynamicClass))
         ctx.featureWarning(nme.dynamics.toString, "extension of type scala.Dynamic", isScala2Feature = true,
           cls, isRequired, cdef.pos)

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -48,7 +48,7 @@ class CompilationTests extends ParallelTesting {
     compileFile("tests/pos-special/completeFromSource/Test2.scala", defaultOptions.and("-sourcepath", "tests/pos-special")) +
     compileFile("tests/pos-special/completeFromSource/Test3.scala", defaultOptions.and("-sourcepath", "tests/pos-special", "-scansource")) +
     compileFile("tests/pos-special/completeFromSource/nested/Test4.scala", defaultOptions.and("-sourcepath", "tests/pos-special", "-scansource")) +
-    compileFilesInDir("tests/pos-special/fatal-warnings", defaultOptions.and("-Xfatal-warnings")) +
+    compileFilesInDir("tests/pos-special/fatal-warnings", defaultOptions.and("-Xfatal-warnings", "-feature")) +
     compileList(
       "compileMixed",
       List(

--- a/tests/pos-special/fatal-warnings/Dynamic.scala
+++ b/tests/pos-special/fatal-warnings/Dynamic.scala
@@ -1,0 +1,3 @@
+package scala
+
+trait Dynamic extends Any


### PR DESCRIPTION
Compiling the standard library, we used to get this warning:
```scala
-- Feature Warning: Test.scala:3:6 ---------------------------------
3 |trait Dynamic extends Any
  |^^^^^^^^^^^^^^^^^^^^^^^^^
  |extension of type scala.Dynamic should be enabled
  |by making the implicit value scala.language.dynamics visible.
  |This can be achieved by adding the import clause 'import scala.language.dynamics'
  |or by setting the compiler option -language:dynamics.
  |See the Scala docs for value scala.language.dynamics for a discussion
  |why the feature should be explicitly enabled.
```