### PR TITLE
Fix #5148: Rename class Aux to Aux_

### DIFF
--- a/tests/run/i4947c.scala
+++ b/tests/run/i4947c.scala
@@ -1,4 +1,4 @@
-object Aux {
+object Foo {
 
   inline def track[T](f: => T): T = {
     printStack("track")
@@ -12,7 +12,7 @@ object Aux {
 }
 
 object Test {
-  import Aux._
+  import Foo._
   def main(args: Array[String]): Unit = {
     track {
       printStack("main1")


### PR DESCRIPTION
Fixes #5148
Aux is the reserved file name on Windows so in order not to clash with it Aux class should be renamed