### PR TITLE
Fix handling of && and || in TailRec

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TailRec.scala
@@ -276,7 +276,7 @@ class TailRec extends MiniPhase {
         case tree@Apply(fun, args) =>
           val meth = fun.symbol
           if (meth == defn.Boolean_|| || meth == defn.Boolean_&&)
-            tpd.cpy.Apply(tree)(fun, transform(args))
+            tpd.cpy.Apply(tree)(noTailTransform(fun), transform(args))
           else
             rewriteApply(tree)
 

--- a/tests/neg-tailcall/tailrec-and-or.scala
+++ b/tests/neg-tailcall/tailrec-and-or.scala
@@ -1,0 +1,21 @@
+import annotation.tailrec
+
+class Test  {
+  def cond: Boolean = ???
+
+  @tailrec final def tailCall1(x: Int): Boolean =
+    if (x < 0) tailCall1(0)
+    else tailCall1(x - 1) || cond // error
+
+  @tailrec final def tailCall2(x: Int): Boolean =
+    if (x < 0) tailCall2(0)
+    else tailCall2(x - 1) && cond // error
+
+  @tailrec final def tailCall3(x: Int): Boolean =
+    if (x < 0) tailCall3(0)
+    else cond || tailCall3(x - 1)
+
+  @tailrec final def tailCall4(x: Int): Boolean =
+    if (x < 0) tailCall4(0)
+    else cond && tailCall4(x - 1)
+}


### PR DESCRIPTION
`Apply::fun` should not be transformed in tail position