### PR TITLE
Support for multi-project `find all references`

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -490,4 +490,32 @@ object Interactive {
     }
   }
 
+  /**
+   * Given `sym`, originating from `sourceDriver`, find its representation in
+   * `targetDriver`.
+   *
+   * @param symbol The symbol to expression in the new driver.
+   * @param sourceDriver The driver from which `symbol` originates.
+   * @param targetDriver The driver in which we want to get a representation of `symbol`.
+   * @return A representation of `symbol` in `targetDriver`.
+   */
+  def localize(symbol: Symbol, sourceDriver: InteractiveDriver, targetDriver: InteractiveDriver): Symbol = {
+
+    def in[T](driver: InteractiveDriver)(fn: Context => T): T =
+      fn(driver.currentCtx)
+
+    if (sourceDriver == targetDriver) symbol
+    else {
+      val owners = in(sourceDriver) { implicit ctx =>
+        symbol.ownersIterator.toList.reverse.map(_.name)
+      }
+      in(targetDriver) { implicit ctx =>
+        val base: Symbol = ctx.definitions.RootClass
+        owners.tail.foldLeft(base) { (prefix, symbolName) =>
+          prefix.info.member(symbolName).symbol
+        }
+      }
+    }
+  }
+
 }

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -512,7 +512,8 @@ object Interactive {
       in(targetDriver) { implicit ctx =>
         val base: Symbol = ctx.definitions.RootClass
         owners.tail.foldLeft(base) { (prefix, symbolName) =>
-          prefix.info.member(symbolName).symbol
+          if (prefix.exists) prefix.info.member(symbolName).symbol
+          else NoSymbol
         }
       }
     }

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -299,15 +299,17 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
   }
 
   /**
-   * Initialize this driver and compiler by "compiling" a fake, empty source file.
+   * Initialize this driver and compiler.
    *
    * This is necessary because an `InteractiveDriver` can be put to work without having
    * compiled anything (for instance, resolving a symbol coming from a different compiler in
-   * this compiler). In those cases, an un-initialized compiler will crash.
+   * this compiler). In those cases, an un-initialized compiler may crash (for instance if
+   * late-compilation is needed).
    */
   private[this] def initialize(): Unit = {
-    val fakeSource = new File("fake.scala")
-    run(fakeSource.toURI, "")
+    val run = compiler.newRun(myInitCtx.fresh)
+    myCtx = run.runContext
+    run.compileUnits(Nil, myCtx)
   }
 
 }

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -86,6 +86,8 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
     names
   }
 
+  initialize()
+
   /**
    * The trees for all the source files in this project.
    *
@@ -296,6 +298,18 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
     writer.write(sourceCode)
     writer.close()
     new SourceFile(virtualFile, Codec.UTF8)
+  }
+
+  /**
+   * Initialize this driver and compiler by "compiling" a fake, empty source file.
+   *
+   * This is necessary because an `InteractiveDriver` can be put to work without having
+   * compiled anything (for instance, resolving a symbol coming from a different compiler in
+   * this compiler). In those cases, an un-initialized compiler will crash.
+   */
+  private[this] def initialize(): Unit = {
+    val fakeSource = new File("fake.scala")
+    run(fakeSource.toURI, "")
   }
 
 }

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -134,7 +134,7 @@ class DottyLanguageServer extends LanguageServer
       val allProjects = drivers.keySet
 
       def transitiveDependencies(config: ProjectConfig): Set[ProjectConfig] = {
-        val dependencies = config.dependencies.map(idToConfig).toSet
+        val dependencies = config.projectDependencies.map(idToConfig).toSet
         dependencies ++ dependencies.flatMap(transitiveDependencies)
       }
 

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -342,7 +342,7 @@ class DottyLanguageServer extends LanguageServer
         (remoteDriver, ctx, definition)
       }
 
-      perProjectInfo.par.flatMap { (remoteDriver, ctx, definition) =>
+      perProjectInfo.flatMap { (remoteDriver, ctx, definition) =>
         val trees = remoteDriver.sourceTreesContaining(symbolName)(ctx)
         Interactive.findTreesMatching(trees, includes, definition)(ctx)
       }

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -332,18 +332,23 @@ class DottyLanguageServer extends LanguageServer
 
     val originalSymbol = Interactive.enclosingSourceSymbol(path)
     val symbolName = originalSymbol.name.sourceModuleName.toString
-    val references =
-      for { config <- projectsToInspect.toList
-            remoteDriver = drivers(config)
-            ctx = remoteDriver.currentCtx
-            remoteDefinition = Interactive.localize(originalSymbol, driver, remoteDriver)
-            trees = remoteDriver.sourceTreesContaining(symbolName)(ctx)
-            reference <- Interactive.findTreesMatching(trees, includes, remoteDefinition)(ctx)
-          } yield {
-        reference
+    val references = {
+      // Collect the information necessary to look into each project separately: representation of
+      // `originalSymbol` in this project, the context and correct Driver.
+      val perProjectInfo = projectsToInspect.toList.map { config =>
+        val remoteDriver = drivers(config)
+        val ctx = remoteDriver.currentCtx
+        val definition = Interactive.localize(originalSymbol, driver, remoteDriver)
+        (remoteDriver, ctx, definition)
       }
 
-      references.flatMap(ref => location(ref.namePos, positionMapperFor(ref.source))).asJava
+      perProjectInfo.par.flatMap { (remoteDriver, ctx, definition) =>
+        val trees = remoteDriver.sourceTreesContaining(symbolName)(ctx)
+        Interactive.findTreesMatching(trees, includes, definition)(ctx)
+      }
+    }.toList
+
+    references.flatMap(ref => location(ref.namePos, positionMapperFor(ref.source))).asJava
   }
 
   override def rename(params: RenameParams) = computeAsync { cancelToken =>

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -80,6 +80,7 @@ class DottyLanguageServer extends LanguageServer
         val settings =
           defaultFlags ++
           config.compilerArguments.toList
+            .update("-d", config.classDirectory.getAbsolutePath)
             .update("-classpath", (config.classDirectory +: config.dependencyClasspath).mkString(File.pathSeparator))
             .update("-sourcepath", config.sourceDirectories.mkString(File.pathSeparator)) :+
           "-scansource"
@@ -106,19 +107,35 @@ class DottyLanguageServer extends LanguageServer
   private def checkMemory() =
     if (Memory.isCritical()) CompletableFutures.computeAsync { _ => restart() }
 
-  /** The driver instance responsible for compiling `uri` */
-  def driverFor(uri: URI): InteractiveDriver = thisServer.synchronized {
-    val matchingConfig =
+  /** The configuration of the project that owns `uri`. */
+  def configFor(uri: URI): ProjectConfig = thisServer.synchronized {
+    val config =
       drivers.keys.find(config => config.sourceDirectories.exists(sourceDir =>
         new File(uri.getPath).getCanonicalPath.startsWith(sourceDir.getCanonicalPath)))
-    matchingConfig match {
-      case Some(config) =>
-        drivers(config)
-      case None =>
-        val config = drivers.keys.head
-        // println(s"No configuration contains $uri as a source file, arbitrarily choosing ${config.id}")
-        drivers(config)
+
+    config.getOrElse {
+      val config = drivers.keys.head
+      // println(s"No configuration contains $uri as a source file, arbitrarily choosing ${config.id}")
+      config
     }
+  }
+
+  /** The driver instance responsible for compiling `uri` */
+  def driverFor(uri: URI): InteractiveDriver = {
+    drivers(configFor(uri))
+  }
+
+  /** The set of projects that transitively depend on `config` */
+  def transitivelyDependentProjects(config: ProjectConfig): immutable.Set[ProjectConfig] = {
+    val allProjects = drivers.keySet.toSet
+    allProjects.filter(transitiveDependencies(_).contains(config))
+  }
+
+  /** The set of transitive dependencies of `config`. */
+  def transitiveDependencies(config: ProjectConfig): immutable.Set[ProjectConfig] = {
+    val idToConfig = drivers.keys.map(k => k.id -> k).toMap
+    val dependencies = config.dependencies.map(idToConfig).toSet
+    dependencies ++ dependencies.flatMap(transitiveDependencies)
   }
 
   def connect(client: WorksheetClient): Unit = {
@@ -281,22 +298,43 @@ class DottyLanguageServer extends LanguageServer
     val driver = driverFor(uri)
     implicit val ctx = driver.currentCtx
 
-    val pos = sourcePosition(driver, uri, params.getPosition)
-    val sym = Interactive.enclosingSourceSymbol(driver.openedTrees(uri), pos)
-
-    if (sym == NoSymbol) Nil.asJava
-    else {
-      // FIXME: this will search for references in all trees on the classpath, but we really
-      // only need to look for trees in the target directory if the symbol is defined in the
-      // current project
-      val trees = driver.allTreesContaining(sym.name.sourceModuleName.toString)
+    val includes = {
       val includeDeclaration = params.getContext.isIncludeDeclaration
-      val includes =
-        Include.references | Include.overriding | (if (includeDeclaration) Include.definitions else 0)
-      val refs = Interactive.findTreesMatching(trees, includes, sym)
-
-      refs.flatMap(ref => location(ref.namePos, positionMapperFor(ref.source))).asJava
+      Include.references | Include.overriding | (if (includeDeclaration) Include.definitions else 0)
     }
+
+    val pos = sourcePosition(driver, uri, params.getPosition)
+    val path = Interactive.pathTo(driver.openedTrees(uri), pos)
+
+    // Find definitions of the symbol under the cursor, so that we can determine
+    // what projects are worth exploring
+    val definitions = Interactive.findDefinitions(path, driver)
+    val projectsToInspect =
+      if (definitions.isEmpty) {
+        drivers.keySet
+      } else {
+        for {
+          definition <- definitions
+          uri <- toUriOption(definition.pos.source).toSet
+          config = configFor(uri)
+          project <- transitivelyDependentProjects(config) + config
+        } yield project
+      }
+
+    val originalSymbol = Interactive.enclosingSourceSymbol(path)
+    val symbolName = originalSymbol.name.sourceModuleName.toString
+    val references =
+      for { config <- projectsToInspect.toList
+            remoteDriver = drivers(config)
+            ctx = remoteDriver.currentCtx
+            remoteDefinition = Interactive.localize(originalSymbol, driver, remoteDriver)
+            trees = remoteDriver.sourceTreesContaining(symbolName)(ctx)
+            reference <- Interactive.findTreesMatching(trees, includes, remoteDefinition)(ctx)
+          } yield {
+        reference
+      }
+
+      references.flatMap(ref => location(ref.namePos, positionMapperFor(ref.source))).asJava
   }
 
   override def rename(params: RenameParams) = computeAsync { cancelToken =>

--- a/language-server/src/dotty/tools/languageserver/config/ProjectConfig.java
+++ b/language-server/src/dotty/tools/languageserver/config/ProjectConfig.java
@@ -11,6 +11,7 @@ public class ProjectConfig {
   public final File[] sourceDirectories;
   public final File[] dependencyClasspath;
   public final File classDirectory;
+  public final String[] dependencies;
 
   @JsonCreator
   public ProjectConfig(
@@ -19,12 +20,14 @@ public class ProjectConfig {
       @JsonProperty("compilerArguments") String[] compilerArguments,
       @JsonProperty("sourceDirectories") File[] sourceDirectories,
       @JsonProperty("dependencyClasspath") File[] dependencyClasspath,
-      @JsonProperty("classDirectory") File classDirectory) {
+      @JsonProperty("classDirectory") File classDirectory,
+      @JsonProperty("dependencies") String[] dependencies) {
      this.id = id;
      this.compilerVersion = compilerVersion;
      this.compilerArguments = compilerArguments;
      this.sourceDirectories = sourceDirectories;
      this.dependencyClasspath = dependencyClasspath;
-     this.classDirectory =classDirectory;
+     this.classDirectory = classDirectory;
+     this.dependencies = dependencies;
   }
 }

--- a/language-server/src/dotty/tools/languageserver/config/ProjectConfig.java
+++ b/language-server/src/dotty/tools/languageserver/config/ProjectConfig.java
@@ -11,7 +11,7 @@ public class ProjectConfig {
   public final File[] sourceDirectories;
   public final File[] dependencyClasspath;
   public final File classDirectory;
-  public final String[] dependencies;
+  public final String[] projectDependencies;
 
   @JsonCreator
   public ProjectConfig(
@@ -21,13 +21,13 @@ public class ProjectConfig {
       @JsonProperty("sourceDirectories") File[] sourceDirectories,
       @JsonProperty("dependencyClasspath") File[] dependencyClasspath,
       @JsonProperty("classDirectory") File classDirectory,
-      @JsonProperty("dependencies") String[] dependencies) {
+      @JsonProperty("projectDependencies") String[] projectDependencies) {
      this.id = id;
      this.compilerVersion = compilerVersion;
      this.compilerArguments = compilerArguments;
      this.sourceDirectories = sourceDirectories;
      this.dependencyClasspath = dependencyClasspath;
      this.classDirectory = classDirectory;
-     this.dependencies = dependencies;
+     this.projectDependencies = projectDependencies;
   }
 }

--- a/language-server/test/dotty/tools/languageserver/ReferencesTest.scala
+++ b/language-server/test/dotty/tools/languageserver/ReferencesTest.scala
@@ -59,4 +59,162 @@ class ReferencesTest {
       .references(m3 to m4, List(m3 to m4), withDecl = false)
   }
 
+  @Test def valReferencesInDifferentProject: Unit = {
+    val p0 = Project.withSources(
+      code"""object A { val ${m1}x${m2} = 1 }"""
+    )
+
+    val p1 = Project.dependingOn(p0).withSources(
+      code"""object B { A.${m3}x${m4} }"""
+    )
+
+    val p2 = Project.dependingOn(p0).withSources(
+      code"""object C { A.${m5}x${m6} }"""
+    )
+
+    withProjects(p0, p1, p2)
+      .references(m1 to m2, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m1 to m2, List(m3 to m4, m5 to m6), withDecl = false)
+      .references(m3 to m4, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m3 to m4, List(m3 to m4, m5 to m6), withDecl = false)
+      .references(m5 to m6, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m5 to m6, List(m3 to m4, m5 to m6), withDecl = false)
+  }
+
+  @Test def valReferencesInDifferentProjectNoDef: Unit = {
+    val p0 = Project.withSources(
+      code"""object A { new java.util.${m1}ArrayList${m2}[Int] }"""
+    )
+
+    val p1 = Project.withSources(
+      code"""object B { new java.util.${m3}ArrayList${m4}[Int] }"""
+    )
+
+    val p2 = Project.withSources(
+      code"""object C { new java.util.${m5}ArrayList${m6}[Int] }"""
+    )
+
+    withProjects(p0, p1, p2)
+      .references(m1 to m2, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m1 to m2, List(m1 to m2, m3 to m4, m5 to m6), withDecl = false)
+      .references(m3 to m4, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m3 to m4, List(m1 to m2, m3 to m4, m5 to m6), withDecl = false)
+      .references(m5 to m6, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m5 to m6, List(m1 to m2, m3 to m4, m5 to m6), withDecl = false)
+  }
+
+  @Test def moduleReferencesInDifferentProject: Unit = {
+    val p0 = Project.withSources(
+      code"""object ${m1}A${m2}"""
+    )
+
+    val p1 = Project.dependingOn(p0).withSources(
+      code"""class B { ${m3}A${m4} }"""
+    )
+
+    withProjects(p0, p1)
+      .references(m1 to m2, List(m1 to m2, m3 to m4), withDecl = true)
+      .references(m1 to m2, List(m3 to m4), withDecl = false)
+      .references(m3 to m4, List(m1 to m2, m3 to m4), withDecl = true)
+      .references(m3 to m4, List(m3 to m4), withDecl = false)
+  }
+
+  @Test def classReferencesInDifferentProject: Unit = {
+    val p0 = Project.withSources(
+      code"""class ${m1}A${m2}"""
+    )
+
+    val p1 = Project.dependingOn(p0).withSources(
+      code"""class B extends ${m3}A${m4}"""
+    )
+
+    val p2 = Project.dependingOn(p0).withSources(
+      code"""class C { new ${m5}A${m6} }"""
+    )
+
+    withProjects(p0, p1, p2)
+      .references(m1 to m2, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m1 to m2, List(m3 to m4, m5 to m6), withDecl = false)
+      .references(m3 to m4, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m3 to m4, List(m3 to m4, m5 to m6), withDecl = false)
+      .references(m5 to m6, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m5 to m6, List(m3 to m4, m5 to m6), withDecl = false)
+  }
+
+  @Test def defReferencesInDifferentProject: Unit = {
+    val p0 = Project.withSources(
+      code"""object A { def ${m1}x${m2} = 1 }"""
+    )
+
+    val p1 = Project.dependingOn(p0).withSources(
+      code"""object B { A.${m3}x${m4} }"""
+    )
+
+    val p2 = Project.dependingOn(p0).withSources(
+      code"""object C { A.${m5}x${m6} }"""
+    )
+
+    withProjects(p0, p1, p2)
+      .references(m1 to m2, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m1 to m2, List(m3 to m4, m5 to m6), withDecl = false)
+      .references(m3 to m4, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m3 to m4, List(m3 to m4, m5 to m6), withDecl = false)
+      .references(m5 to m6, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m5 to m6, List(m3 to m4, m5 to m6), withDecl = false)
+  }
+
+  @Test def deeplyNestedValReferencesInDifferentProject: Unit = {
+    val p0 = Project.withSources(
+      code"""class A { class Z { class Y { class X { val ${m1}x${m2} = 1 } } } }"""
+    )
+
+    val p1 = Project.dependingOn(p0).withSources(
+      code"""class B {
+               val a = new A()
+               val z = new a.Z()
+               val y = new z.Y()
+               val x = new y.X()
+               x.${m3}x${m4}
+             }"""
+    )
+
+    withProjects(p0, p1)
+      .references(m1 to m2, List(m1 to m2, m3 to m4), withDecl = true)
+      .references(m1 to m2, List(m3 to m4), withDecl = false)
+      .references(m3 to m4, List(m1 to m2, m3 to m4), withDecl = true)
+      .references(m3 to m4, List(m3 to m4), withDecl = false)
+  }
+
+  @Test def deeplyNestedStaticValReferencesInDifferentProject: Unit = {
+    val p0 = Project.withSources(
+      code"""object A { object Z { object Y { object X { val ${m1}x${m2} = 1 } } } }"""
+    )
+
+    val p1 = Project.dependingOn(p0).withSources(
+      code"""object B { A.Z.Y.X.${m3}x${m4} }"""
+    )
+
+    withProjects(p0, p1)
+      .references(m1 to m2, List(m1 to m2, m3 to m4), withDecl = true)
+      .references(m1 to m2, List(m3 to m4), withDecl = false)
+      .references(m3 to m4, List(m1 to m2, m3 to m4), withDecl = true)
+      .references(m3 to m4, List(m3 to m4), withDecl = false)
+  }
+
+  @Test def findReferencesInUntouchedProject: Unit = {
+    val p0 = Project.withSources(
+      code"""package hello
+             object A { def ${m1}foo${m2} = 1 }"""
+    )
+
+    val p1 = Project.dependingOn(p0).withSources(
+      tasty"""package hello
+              object B { def bar = A.${m3}foo${m4} }"""
+    )
+
+    withProjects(p0, p1)
+      .references(m1 to m2, List(m1 to m2, m3 to m4), withDecl = true)
+      .references(m1 to m2, List(m3 to m4), withDecl = false)
+  }
+
 }

--- a/language-server/test/dotty/tools/languageserver/util/actions/CodeReferences.scala
+++ b/language-server/test/dotty/tools/languageserver/util/actions/CodeReferences.scala
@@ -5,6 +5,8 @@ import dotty.tools.languageserver.util.{CodeRange, PositionContext}
 
 import org.junit.Assert.assertEquals
 
+import org.eclipse.lsp4j.Location
+
 import scala.collection.JavaConverters._
 
 /**
@@ -19,9 +21,11 @@ class CodeReferences(override val range: CodeRange,
                      expected: List[CodeRange],
                      withDecl: Boolean) extends ActionOnRange {
 
+  private implicit val LocationOrdering: Ordering[Location] = Ordering.by(_.toString)
+
   override def onMarker(marker: CodeMarker): Exec[Unit] = {
-    val expectedLocations = expected.map(_.toLocation)
-    val results = server.references(marker.toReferenceParams(withDecl)).get().asScala
+    val expectedLocations = expected.map(_.toLocation).sorted
+    val results = server.references(marker.toReferenceParams(withDecl)).get().asScala.sorted
 
     assertEquals(expectedLocations, results)
   }

--- a/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
+++ b/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
@@ -60,7 +60,7 @@ class TestServer(testFolder: Path, projects: List[Project]) {
          |  "sourceDirectories" : ${showSeq(sourceDirectory(project, wipe = false) :: Nil)},
          |  "dependencyClasspath" : ${showSeq(dependencyClasspath(project))},
          |  "classDirectory" : "${classDirectory(project, wipe = false).toString.replace('\\','/')}",
-         |  "dependencies": ${showSeq(project.dependsOn.map(_.name))}
+         |  "projectDependencies": ${showSeq(project.dependsOn.map(_.name))}
          |}
          |""".stripMargin
     }

--- a/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
+++ b/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
@@ -107,8 +107,8 @@ class TestServer(testFolder: Path, projects: List[Project]) {
     val path = testFolder.resolve(project.name).resolve("out")
     if (wipe) {
       Directory(path).deleteRecursively()
-      Files.createDirectories(path)
     }
+    Files.createDirectories(path)
     path.toAbsolutePath
   }
 

--- a/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
+++ b/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
@@ -59,7 +59,8 @@ class TestServer(testFolder: Path, projects: List[Project]) {
          |  "compilerArguments" : ${showSeq(BuildInfo.ideTestsCompilerArguments)},
          |  "sourceDirectories" : ${showSeq(sourceDirectory(project, wipe = false) :: Nil)},
          |  "dependencyClasspath" : ${showSeq(dependencyClasspath(project))},
-         |  "classDirectory" : "${classDirectory(project, wipe = false).toString.replace('\\','/')}"
+         |  "classDirectory" : "${classDirectory(project, wipe = false).toString.replace('\\','/')}",
+         |  "dependencies": ${showSeq(project.dependsOn.map(_.name))}
          |}
          |""".stripMargin
     }

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyIDEPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyIDEPlugin.scala
@@ -374,16 +374,16 @@ object DottyIDEPlugin extends AutoPlugin {
   /**
    * Detect the eligible configuration dependencies from a given configuration.
    *
-   * A configuration is elibile if the project defines it and `bloopGenerate`
+   * A configuration is eligible if the project defines it and `compile`
    * exists for it. Otherwise, the configuration dependency is ignored.
    *
    * This is required to prevent transitive configurations like `Runtime` from
-   * generating useless bloop configuration files and possibly incorrect project
+   * generating useless IDE configuration files and possibly incorrect project
    * dependencies. For example, if we didn't do this then the dependencies of
-   * `IntegrationTest` would be `projectName-runtime` and `projectName-compile`,
+   * `IntegrationTest` would be `projectName/runtime` and `projectName/compile`,
    * whereas the following logic will return only the configuration `Compile`
    * so that the use site of this function can create the project dep
-   * `projectName-compile`.
+   * `projectName/compile`.
    */
   private def eligibleDepsFromConfig(config: Configuration): Def.Initialize[Task[List[Configuration]]] = {
     Def.task {

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyIDEPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyIDEPlugin.scala
@@ -269,14 +269,21 @@ object DottyIDEPlugin extends AutoPlugin {
     Command.process("runCode", state1)
   }
 
+  private def makeId(name: String, config: String): String = s"$name/$config"
+
   private def projectConfigTask(config: Configuration): Initialize[Task[Option[ProjectConfig]]] = Def.taskDyn {
     val depClasspath = Attributed.data((dependencyClasspath in config).value)
+    val projectName = name.value
 
     // Try to detect if this is a real Scala project or not. This is pretty
     // fragile because sbt simply does not keep track of this information. We
     // could check if at least one source file ends with ".scala" but that
     // doesn't work for empty projects.
-    val isScalaProject = depClasspath.exists(_.getAbsolutePath.contains("dotty-library")) && depClasspath.exists(_.getAbsolutePath.contains("scala-library"))
+    val isScalaProject = (
+          // Our `dotty-library` project is a Scala project
+          (projectName.startsWith("dotty-library") || depClasspath.exists(_.getAbsolutePath.contains("dotty-library")))
+       && depClasspath.exists(_.getAbsolutePath.contains("scala-library"))
+    )
 
     if (!isScalaProject) Def.task { None }
     else Def.task {
@@ -285,11 +292,30 @@ object DottyIDEPlugin extends AutoPlugin {
       // step.
       val _ = (compile in config).value
 
-      val id = s"${thisProject.value.id}/${config.name}"
+      val project = thisProject.value
+      val id = makeId(project.id, config.name)
       val compilerVersion = (scalaVersion in config).value
       val compilerArguments = (scalacOptions in config).value
       val sourceDirectories = (unmanagedSourceDirectories in config).value ++ (managedSourceDirectories in config).value
       val classDir = (classDirectory in config).value
+      val extracted = Project.extract(state.value)
+      val settings = extracted.structure.data
+
+      val dependencies = {
+        val logger = streams.value.log
+        // Project dependencies come from classpath deps and also inter-project config deps
+        // We filter out dependencies that do not compile using Dotty
+        val classpathProjectDependencies =
+          project.dependencies.filter { d =>
+            val version = scalaVersion.in(d.project).get(settings).get
+            isDottyVersion(version)
+          }.map(d => projectDependencyName(d, config, project, logger))
+        val configDependencies =
+          eligibleDepsFromConfig(config).value.map(c => makeId(project.id, c.name))
+
+       // The distinct here is important to make sure that there are no repeated project deps
+       (classpathProjectDependencies ++ configDependencies).distinct.toList
+      }
 
       Some(new ProjectConfig(
         id,
@@ -297,7 +323,8 @@ object DottyIDEPlugin extends AutoPlugin {
         compilerArguments.toArray,
         sourceDirectories.toArray,
         depClasspath.toArray,
-        classDir
+        classDir,
+        dependencies.toArray
       ))
     }
   }
@@ -338,4 +365,106 @@ object DottyIDEPlugin extends AutoPlugin {
     }
 
   ) ++ addCommandAlias("launchIDE", ";configureIDE;runCode")
+
+  // Ported from Bloop
+  /**
+   * Detect the eligible configuration dependencies from a given configuration.
+   *
+   * A configuration is elibile if the project defines it and `bloopGenerate`
+   * exists for it. Otherwise, the configuration dependency is ignored.
+   *
+   * This is required to prevent transitive configurations like `Runtime` from
+   * generating useless bloop configuration files and possibly incorrect project
+   * dependencies. For example, if we didn't do this then the dependencies of
+   * `IntegrationTest` would be `projectName-runtime` and `projectName-compile`,
+   * whereas the following logic will return only the configuration `Compile`
+   * so that the use site of this function can create the project dep
+   * `projectName-compile`.
+   */
+  private def eligibleDepsFromConfig(config: Configuration): Def.Initialize[Task[List[Configuration]]] = {
+    Def.task {
+      def depsFromConfig(configuration: Configuration): List[Configuration] = {
+        configuration.extendsConfigs.toList match {
+          case config :: Nil if config.extendsConfigs.isEmpty => config :: Nil
+          case config :: Nil => config :: depsFromConfig(config)
+          case Nil => Nil
+        }
+      }
+
+      val configs = depsFromConfig(config)
+      val activeProjectConfigs = thisProject.value.configurations.toSet
+
+      val data = settingsData.value
+      val thisProjectRef = Keys.thisProjectRef.value
+
+      val eligibleConfigs = activeProjectConfigs.filter { c =>
+        val configKey = ConfigKey.configurationToKey(c)
+        // Consider only configurations where the `compile` key is defined
+        val eligibleKey = compile in (thisProjectRef, configKey)
+        eligibleKey.get(data) match {
+          case Some(t) =>
+            // Sbt seems to return tasks for the extended configurations (looks like a big bug)
+            t.info.get(taskDefinitionKey) match {
+              // So we now make sure that the returned config key matches the original one
+              case Some(taskDef) => taskDef.scope.config.toOption.toList.contains(configKey)
+              case None => true
+            }
+          case None => false
+        }
+      }
+
+      configs.filter(c => eligibleConfigs.contains(c))
+    }
+  }
+
+  /**
+   * Creates a project name from a classpath dependency and its configuration.
+   *
+   * This function uses internal sbt utils (`sbt.Classpaths`) to parse configuration
+   * dependencies like sbt does and extract them. This parsing only supports compile
+   * and test, any kind of other dependency will be assumed to be test and will be
+   * reported to the user.
+   *
+   * Ref https://www.scala-sbt.org/1.x/docs/Library-Management.html#Configurations.
+   */
+  private def projectDependencyName(
+      dep: ClasspathDep[ProjectRef],
+      configuration: Configuration,
+      project: ResolvedProject,
+      logger: Logger
+  ): String = {
+    val ref = dep.project
+    dep.configuration match {
+      case Some(_) =>
+        val mapping = sbt.Classpaths.mapped(
+          dep.configuration,
+          List("compile", "test"),
+          List("compile", "test"),
+          "compile",
+          "*->compile"
+        )
+
+        mapping(configuration.name) match {
+          case Nil =>
+            makeId(ref.project, configuration.name)
+          case List(conf) if Compile.name == conf =>
+            makeId(ref.project, Compile.name)
+          case List(conf) if Test.name == conf =>
+            makeId(ref.project, Test.name)
+          case List(conf1, conf2) if Test.name == conf1 && Compile.name == conf2 =>
+            makeId(ref.project, Test.name)
+          case List(conf1, conf2) if Compile.name == conf1 && Test.name == conf2 =>
+            makeId(ref.project, Test.name)
+          case unknown =>
+            val msg =
+              s"Unsupported dependency '${project.id}' -> '${ref.project}:${unknown.mkString(", ")}' is understood as '${ref.project}:test'."
+            logger.warn(msg)
+            makeId(ref.project, Test.name)
+        }
+      case None =>
+        // If no configuration, default is `Compile` dependency (see scripted tests `cross-compile-test-configuration`)
+        makeId(ref.project, Compile.name)
+    }
+  }
+
 }

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyIDEPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyIDEPlugin.scala
@@ -317,6 +317,10 @@ object DottyIDEPlugin extends AutoPlugin {
        (classpathProjectDependencies ++ configDependencies).distinct.toList
       }
 
+      // For projects without sources, we need to create it. Otherwise `InteractiveDriver`
+      // complains that the target directory doesn't exist.
+      if (!classDir.exists) IO.createDirectory(classDir)
+
       Some(new ProjectConfig(
         id,
         compilerVersion,


### PR DESCRIPTION
This commit adapts the `find all references` feature so that it is able
to find references to given symbols across projects. For symbols that
come from the classpath, all the projects in the build will be
inspected. If we're able to find a source for the symbol, only the
projects that depend on the projects where we found the definition need
to be inspected.