### PR TITLE
Don't check positions in `findTreesMatching`

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -321,8 +321,7 @@ object Interactive {
     val includeDeclaration = (includes & Include.definitions) != 0
     val includeLinkedClass = (includes & Include.linkedClass) != 0
     val predicate: NameTree => Boolean = tree =>
-      (  tree.pos.isSourceDerived
-      && !tree.symbol.isPrimaryConstructor
+      (  !tree.symbol.isPrimaryConstructor
       && (includeDeclaration || !Interactive.isDefinition(tree))
       && (  Interactive.matchSymbol(tree, symbol, includes)
          || (  includeDeclaration


### PR DESCRIPTION
We used to check the positions in `findTreesMatching` and exclude trees
where the position is not source-derived. It turns out that this is
wrong, because this will exclude all trees that have been unpickled.

The correct test, checking whether the position has a zero extent, is
already done in `namedTrees`.