### PR TITLE
Decouple saving and running the worksheet

### DIFF
--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -40,6 +40,17 @@
         ]
       }
     ],
+    "configuration": {
+      "type": "object",
+      "title": "Dotty configuration",
+      "properties": {
+        "dotty.runWorksheetOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true, saving a worksheet will also run it."
+        }
+      }
+    },
     "commands": [
       {
         "command": "dotty.worksheet.run",


### PR DESCRIPTION
- Do not automatically save the worksheet when the run command is
  executed.
- Make it possible to save the worksheet without running it (by setting
  the configuration value dotty.runWorksheetOnSave to false)