### PR TITLE
Add error messages for CheckStatic

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -136,7 +136,10 @@ public enum ErrorMessageID {
     ValueClassParameterMayNotBeCallByNameID,
     NotAnExtractorID,
     MemberWithSameNameAsStaticID,
-    PureExpressionInStatementPositionID
+    PureExpressionInStatementPositionID,
+    TraitCompanionWithMutableStaticID,
+    LazyStaticFieldID,
+    StaticOverridingNonStaticMembersID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2149,4 +2149,25 @@ object messages {
       hl"""The pure expression `$stat` doesn't have any side effect and its result is not assigned elsewhere.
           |It can be removed without changing the semantics of the program. This may indicate an error.""".stripMargin
   }
+
+  case class TraitCompanionWithMutableStatic()(implicit val ctx: Context)
+    extends Message(TraitCompanionWithMutableStaticID) {
+    override def msg: String = hl"Companion of traits cannot define mutable @static fields"
+    override def kind: String = "Syntax"
+    override def explanation: String = ""
+  }
+
+  case class LazyStaticField()(implicit val ctx: Context)
+    extends Message(LazyStaticFieldID) {
+    override def msg: String = hl"Lazy @static fields are not supported"
+    override def kind: String = "Syntax"
+    override def explanation: String = ""
+  }
+
+  case class StaticOverridingNonStaticMembers()(implicit val ctx: Context)
+    extends Message(StaticOverridingNonStaticMembersID) {
+    override def msg: String = hl"@static members cannot override or implement non-static ones"
+    override def kind: String = "Syntax"
+    override def explanation: String = ""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/transform/CheckStatic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckStatic.scala
@@ -8,7 +8,7 @@ import Contexts.Context
 import Symbols._
 import dotty.tools.dotc.ast.tpd
 import Decorators._
-import reporting.diagnostic.messages.{MemberWithSameNameAsStatic, MissingCompanionForStatic, StaticFieldsOnlyAllowedInObjects}
+import reporting.diagnostic.messages._
 
 /** A transformer that check that requirements of Static fields\methods are implemented:
   *  1. Only objects can have members annotated with `@static`
@@ -48,11 +48,11 @@ class CheckStatic extends MiniPhase {
         } else if (clashes.exists) {
           ctx.error(MemberWithSameNameAsStatic(), defn.pos)
          } else if (defn.symbol.is(Flags.Mutable) && companion.is(Flags.Trait)) {
-          ctx.error("Companions of traits cannot define mutable @static fields", defn.pos)
+          ctx.error(TraitCompanionWithMutableStatic(), defn.pos)
         } else if (defn.symbol.is(Flags.Lazy)) {
-          ctx.error("Lazy @static fields are not supported", defn.pos)
+          ctx.error(LazyStaticField(), defn.pos)
         } else if (defn.symbol.allOverriddenSymbols.nonEmpty) {
-          ctx.error("@static members cannot override or implement non-static ones", defn.pos)
+          ctx.error(StaticOverridingNonStaticMembers(), defn.pos)
         }
       } else hadNonStaticField = hadNonStaticField || defn.isInstanceOf[ValDef]
 


### PR DESCRIPTION
Adds messages for checking of companions and @static fields
- Static overriding non static member
- Lazy static field
- Trait's companion defining mutable static field

Part of #1589