### PR TITLE
Fix #5242: Don't run all Scala files as worksheets

### DIFF
--- a/vscode-dotty/src/features.ts
+++ b/vscode-dotty/src/features.ts
@@ -48,7 +48,7 @@ export class WorksheetRunFeature extends TextDocumentFeature<TextDocumentRegistr
       return
     }
 
-    const selector: DocumentSelector = documentSelector || [ { language: 'scala', pattern: '**/*.sc' } ]
+    const selector: DocumentSelector = [ { language: 'scala', pattern: '**/*.sc' } ]
     this.register(this.messages, {
       id: generateUuid(),
       registerOptions: { documentSelector: selector }


### PR DESCRIPTION
When initializing the `WorksheetRunFeature`, we were specifying that the
feature should apply to all files where the `document selector` matches
that of the Dotty plugin, or files in the Scala language whose name ends
in `.sc`. Unfortunately, this matches all `.scala` files, and these were
run as worksheets.

This commit changes the document selector for the `WorksheetRunFeature`
so that Scala files are not run as if they were worksheets.