### PR TITLE
Fix #5247: Support type blocks and fix generic tuples

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -484,8 +484,10 @@ object Trees {
 
   /** { stats; expr } */
   case class Block[-T >: Untyped] private[ast] (stats: List[Tree[T]], expr: Tree[T])
-    extends TermTree[T] {
+    extends Tree[T] {
     type ThisTree[-T >: Untyped] = Block[T]
+    override def isTerm: Boolean = expr.isTerm
+    override def isType: Boolean = expr.isType
   }
 
   /** if cond then thenp else elsep */

--- a/compiler/src/dotty/tools/dotc/config/Printers.scala
+++ b/compiler/src/dotty/tools/dotc/config/Printers.scala
@@ -28,6 +28,7 @@ object Printers {
   val overload: Printer = noPrinter
   val patmatch: Printer = noPrinter
   val pickling: Printer = noPrinter
+  val quotePickling: Printer = noPrinter
   val plugins: Printer = noPrinter
   val simplify: Printer = noPrinter
   val subtyping: Printer = noPrinter

--- a/compiler/src/dotty/tools/dotc/core/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/core/quoted/PickledQuotes.scala
@@ -89,12 +89,12 @@ object PickledQuotes {
     if (tree.pos.exists)
       new PositionPickler(pickler, treePkl.buf.addrOfTree).picklePositions(tree :: Nil)
 
-    if (pickling ne noPrinter)
+    if (quotePickling ne noPrinter)
       println(i"**** pickling quote of \n${tree.show}")
 
     val pickled = pickler.assembleParts()
 
-    if (pickling ne noPrinter)
+    if (quotePickling ne noPrinter)
       new TastyPrinter(pickled).printContents()
 
     pickled
@@ -102,7 +102,7 @@ object PickledQuotes {
 
   /** Unpickle TASTY bytes into it's tree */
   private def unpickle(bytes: Array[Byte], splices: Seq[Any], isType: Boolean)(implicit ctx: Context): Tree = {
-    if (pickling ne noPrinter) {
+    if (quotePickling ne noPrinter) {
       println(i"**** unpickling quote from TASTY")
       new TastyPrinter(bytes).printContents()
     }
@@ -112,7 +112,7 @@ object PickledQuotes {
     unpickler.enter(Set.empty)
     val tree = unpickler.tree
 
-    if (pickling ne noPrinter)
+    if (quotePickling ne noPrinter)
       println(i"**** unpickle quote ${tree.show}")
 
     tree

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsTreesOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsTreesOpsImpl.scala
@@ -120,6 +120,13 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
         case _ => None
       }
     }
+
+    object Block extends BlockExtractor {
+      def unapply(x: TypeTree)(implicit ctx: Context): Option[(List[TypeDef], TypeTree)] = x match {
+        case x: tpd.Block => Some((x.stats.map { case alias: TypeDef => alias }, x.expr))
+        case _ => None
+      }
+    }
   }
 
   // ----- TypeBoundsTrees ------------------------------------------------

--- a/library/src-scala3/scala/StagedTuple.scala
+++ b/library/src-scala3/scala/StagedTuple.scala
@@ -208,7 +208,7 @@ object StagedTuple {
           that
         case Some(1) =>
           if (thatSize.contains(0)) self
-          else stagedCons(that, self.as[Tuple1[_]], thatSize)
+          else stagedCons(that, '((~self).asInstanceOf[Tuple1[_]]._1), thatSize)
         case Some(2) =>
           val self2 = self.as[Tuple2[_, _]]
           thatSize match {

--- a/library/src-scala3/scala/Tuple.scala
+++ b/library/src-scala3/scala/Tuple.scala
@@ -26,7 +26,7 @@ object Tuple {
   inline val $MaxSpecialized = 22
   inline private val XXL = $MaxSpecialized + 1
 
-  final val specialize = false
+  final val specialize = true
 
   type Head[+X <: NonEmptyTuple] = X match {
     case x *: _ => x

--- a/library/src/scala/tasty/reflect/TypeOrBoundsTreeOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsTreeOps.scala
@@ -91,6 +91,11 @@ trait TypeOrBoundsTreeOps extends TastyCore {
     abstract class BindExtractor{
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(String, TypeBoundsTree)]
     }
+
+    val Block: BlockExtractor
+    abstract class BlockExtractor{
+      def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(List[TypeDef], TypeTree)]
+    }
   }
 
   // ----- TypeBoundsTrees ------------------------------------------------

--- a/library/src/scala/tasty/util/ShowExtractors.scala
+++ b/library/src/scala/tasty/util/ShowExtractors.scala
@@ -116,9 +116,11 @@ class ShowExtractors[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
       case TypeTree.Annotated(arg, annot) =>
         this += "TypeTree.Annotated(" += arg += ", " += annot += ")"
       case TypeTree.TypeLambdaTree(tparams, body) =>
-        this += "LambdaTypeTree(" ++= tparams += ", " += body += ")"
+        this += "TypeTree.LambdaTypeTree(" ++= tparams += ", " += body += ")"
       case TypeTree.Bind(name, bounds) =>
-        this += "Bind(" += name += ", " += bounds += ")"
+        this += "TypeTree.Bind(" += name += ", " += bounds += ")"
+      case TypeTree.Block(aliases, tpt) =>
+        this += "TypeTree.Block(" ++= aliases += ", " += tpt += ")"
       case TypeBoundsTree(lo, hi) =>
         this += "TypeBoundsTree(" += lo += ", " += hi += ")"
       case SyntheticBounds() =>

--- a/library/src/scala/tasty/util/ShowSourceCode.scala
+++ b/library/src/scala/tasty/util/ShowSourceCode.scala
@@ -816,6 +816,12 @@ class ShowSourceCode[T <: Tasty with Singleton](tasty0: T) extends Show[T](tasty
       case TypeTree.Bind(name, _) =>
         this += highlightTypeDef(name, color)
 
+      case TypeTree.Block(aliases, tpt) =>
+        inBlock {
+          printTrees(aliases, lineBreak())
+          printTypeTree(tpt)
+        }
+
       case _ =>
         throw new MatchError(tree.show)
 

--- a/tests/run-with-compiler/i5247.check
+++ b/tests/run-with-compiler/i5247.check
@@ -1,0 +1,2 @@
+null.asInstanceOf[lang.Object]
+null.asInstanceOf[scala.List[lang.Object]]

--- a/tests/run-with-compiler/i5247.scala
+++ b/tests/run-with-compiler/i5247.scala
@@ -1,0 +1,16 @@
+import scala.quoted._
+object Test {
+  def main(args: Array[String]): Unit = {
+    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make
+    println(foo[Object].show)
+    println(bar[Object].show)
+  }
+  def foo[H : Type]: Expr[H] = {
+    val t = '[H]
+    '{ null.asInstanceOf[~t] }
+  }
+  def bar[H : Type]: Expr[List[H]] = {
+    val t = '[List[H]]
+    '{ null.asInstanceOf[~t] }
+  }
+}

--- a/tests/run-with-compiler/quote-owners-2.check
+++ b/tests/run-with-compiler/quote-owners-2.check
@@ -2,7 +2,7 @@
 {
   def ff: scala.Int = {
     val a: immutable.List[scala.Int] = {
-      type T = immutable.List[scala.Int]
+      type T = scala.List[scala.Int]
       val b: T = scala.Nil.::[scala.Int](3)
       (b: collection.immutable.List[scala.Int])
     }


### PR DESCRIPTION
Type block are represented with `Block` nodes where all statements
are `TypeDef`s and the expression is a `TypeTree`.

```scala
{
  type T1 = ...
  ...
  type Tn = ...
  T // Where T refers to T1, ..., Tn
}
```

We already had them but they were not properly handled.