### PR TITLE
Resugar Varargs

### DIFF
--- a/compiler/test/dotc/pos-recompilation.whitelist
+++ b/compiler/test/dotc/pos-recompilation.whitelist
@@ -38,3 +38,5 @@ t116
 t3869
 t6225b
 t704
+varargs
+varargs-position

--- a/tests/pos/varargs-position.decompiled
+++ b/tests/pos/varargs-position.decompiled
@@ -1,0 +1,12 @@
+object varargspos {
+  def g(a: scala.Int, x: scala.Int*): scala.Int = a.+(x.length)
+  varargspos.g(1, 2, 3, 4)
+  val xs: collection.immutable.List[scala.Int] = scala.Nil.::[scala.Int](2).::[scala.Int](1)
+  val a: scala.Int = 8
+  val b: scala.Int = 7
+  varargspos.g(5, varargspos.xs: _*)
+  varargspos.g(3, scala.Nil: _*)
+  varargspos.g(varargspos.a, varargspos.xs: _*)
+  varargspos.g(varargspos.a, varargspos.b, 2, 3)
+  varargspos.g(1)
+}

--- a/tests/pos/varargs-position.scala
+++ b/tests/pos/varargs-position.scala
@@ -1,0 +1,12 @@
+object varargspos {
+  def g(a: Int, x: Int*) = a + x.length
+  g(1, 2, 3, 4)
+  val xs = 1 :: 2 :: Nil
+  val a = 8
+  val b = 7
+  g(5, xs: _*)
+  g(3, Nil: _*)
+  g(a, xs: _*)
+  g(a, b, 2, 3)
+  g(1)
+}


### PR DESCRIPTION
Function Declaration:
- type of parameter resugared from `Seq[T] @scala.annotation.internal.Repeated()` to `T*`

Function Call:
- when necessary explicity type parameter as `_*`