### PR TITLE
Keep package structure in `rootTreeOrProvider`

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -52,6 +52,7 @@ class Compiler {
     List(new FirstTransform,         // Some transformations to put trees into a canonical form
          new CheckReentrant,         // Internal use only: Check that compiled program has no data races involving global vars
          new ElimPackagePrefixes,    // Eliminate references to package prefixes in Select nodes
+         new SetRootTree,            // Set the `rootTreeOrProvider` on class symbols
          new CookComments) ::        // Cook the comments: expand variables, doc, etc.
     List(new CheckStatic,            // Check restrictions that apply to @static members
          new ElimRepeated,           // Rewrite vararg parameters and arguments

--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -39,6 +39,7 @@ class Compiler {
     List(new sbt.ExtractDependencies) :: // Sends information on classes' dependencies to sbt via callbacks
     List(new PostTyper) ::          // Additional checks and cleanups after type checking
     List(new sbt.ExtractAPI) ::     // Sends a representation of the API of classes to sbt via callbacks
+    List(new SetRootTree) ::        // Set the `rootTreeOrProvider` on class symbols
     Nil
 
   /** Phases dealing with TASTY tree pickling and unpickling */
@@ -52,7 +53,6 @@ class Compiler {
     List(new FirstTransform,         // Some transformations to put trees into a canonical form
          new CheckReentrant,         // Internal use only: Check that compiled program has no data races involving global vars
          new ElimPackagePrefixes,    // Eliminate references to package prefixes in Select nodes
-         new SetRootTree,            // Set the `rootTreeOrProvider` on class symbols
          new CookComments) ::        // Cook the comments: expand variables, doc, etc.
     List(new CheckStatic,            // Check restrictions that apply to @static members
          new ElimRepeated,           // Rewrite vararg parameters and arguments

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -215,7 +215,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
         def processUnit() = {
           unit.tpdTree = ctx.typer.typedExpr(unit.untpdTree)
           val phase = new transform.SetRootTree()
-          phase.runOn(unit)
+          phase.run
         }
         if (typeCheck)
           if (compiling) finalizeActions += (() => processUnit()) else processUnit()

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -200,7 +200,8 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
 
   /** Enter top-level definitions of classes and objects contain in Scala source file `file`.
    *  The newly added symbols replace any previously entered symbols.
-   *  If `typeCheck = true`, also run typer on the compilation unit.
+   *  If `typeCheck = true`, also run typer on the compilation unit, and set
+   *  `rootTreeOrProvider`.
    */
   def lateCompile(file: AbstractFile, typeCheck: Boolean)(implicit ctx: Context): Unit =
     if (!files.contains(file) && !lateFiles.contains(file)) {
@@ -211,9 +212,13 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
           if (unit.isJava) new JavaParser(unit.source).parse()
           else new Parser(unit.source).parse()
         ctx.typer.lateEnter(unit.untpdTree)
-        def typeCheckUnit() = unit.tpdTree = ctx.typer.typedExpr(unit.untpdTree)
+        def processUnit() = {
+          unit.tpdTree = ctx.typer.typedExpr(unit.untpdTree)
+          val phase = new transform.SetRootTree()
+          phase.runOn(unit)
+        }
         if (typeCheck)
-          if (compiling) finalizeActions += (() => typeCheckUnit()) else typeCheckUnit()
+          if (compiling) finalizeActions += (() => processUnit()) else processUnit()
       }
       process()(runContext.fresh.setCompilationUnit(unit))
     }

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveCompiler.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveCompiler.scala
@@ -13,6 +13,7 @@ class InteractiveCompiler extends Compiler {
   // after each phase group instead of waiting for the pipeline to finish.
   override def phases: List[List[Phase]] = List(
     List(new FrontEnd),
+    List(new transform.SetRootTree),
     List(new transform.CookComments)
   )
 }

--- a/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
@@ -32,9 +32,6 @@ class SetRootTree extends Phase {
                 sym.rootTreeOrProvider = td
             }
           }
-          traverseChildren(td)
-        case tpl: tpd.Template =>
-          traverseChildren(tpl)
         case _ =>
           ()
       }

--- a/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
@@ -1,0 +1,45 @@
+package dotty.tools.dotc.transform
+
+import dotty.tools.dotc.CompilationUnit
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.transform.MegaPhase.MiniPhase
+
+/** Set the `rootTreeOrProvider` property of class symbols. */
+class SetRootTree extends MiniPhase {
+
+  override val phaseName: String = SetRootTree.name
+  override def isRunnable(implicit ctx: Context) =
+    super.isRunnable && ctx.settings.YretainTrees.value
+
+  def runOn(unit: CompilationUnit)(implicit ctx: Context) = {
+    val runCtx = ctx.fresh.setCompilationUnit(unit)
+    traverser.traverse(unit.tpdTree)(runCtx)
+  }
+
+  override def transformTypeDef(tree: tpd.TypeDef)(implicit ctx: Context): tpd.Tree = {
+    if (tree.symbol.isClass) {
+      val sym = tree.symbol.asClass
+      tpd.sliceTopLevel(ctx.compilationUnit.tpdTree, sym) match {
+        case (pkg: tpd.PackageDef) :: Nil =>
+          sym.rootTreeOrProvider = pkg
+        case _ =>
+          sym.rootTreeOrProvider = tree
+      }
+    }
+    tree
+  }
+
+  private def traverser = new tpd.TreeTraverser {
+    override def traverse(tree: tpd.Tree)(implicit ctx: Context): Unit = tree match {
+      case typeDef: tpd.TypeDef => transformTypeDef(typeDef)
+      case other => traverseChildren(other)
+    }
+  }
+
+
+}
+
+object SetRootTree {
+  val name: String = "SetRootTree"
+}

--- a/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
@@ -19,16 +19,25 @@ class SetRootTree extends Phase {
 
   private def traverser = new tpd.TreeTraverser {
     override def traverse(tree: tpd.Tree)(implicit ctx: Context): Unit = {
-      if (tree.isInstanceOf[tpd.TypeDef] && tree.symbol.isClass) {
-        val sym = tree.symbol.asClass
-        tpd.sliceTopLevel(ctx.compilationUnit.tpdTree, sym) match {
-          case (pkg: tpd.PackageDef) :: Nil =>
-            sym.rootTreeOrProvider = pkg
-          case _ =>
-            sym.rootTreeOrProvider = tree
-        }
+      tree match {
+        case pkg: tpd.PackageDef =>
+          traverseChildren(pkg)
+        case td: tpd.TypeDef =>
+          if (td.symbol.isClass) {
+            val sym = td.symbol.asClass
+            tpd.sliceTopLevel(ctx.compilationUnit.tpdTree, sym) match {
+              case (pkg: tpd.PackageDef) :: Nil =>
+                sym.rootTreeOrProvider = pkg
+              case _ =>
+                sym.rootTreeOrProvider = td
+            }
+          }
+          traverseChildren(td)
+        case tpl: tpd.Template =>
+          traverseChildren(tpl)
+        case _ =>
+          ()
       }
-      traverseChildren(tree)
     }
   }
 }

--- a/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
@@ -3,41 +3,34 @@ package dotty.tools.dotc.transform
 import dotty.tools.dotc.CompilationUnit
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.transform.MegaPhase.MiniPhase
+import dotty.tools.dotc.core.Phases.Phase
 
 /** Set the `rootTreeOrProvider` property of class symbols. */
-class SetRootTree extends MiniPhase {
+class SetRootTree extends Phase {
 
   override val phaseName: String = SetRootTree.name
   override def isRunnable(implicit ctx: Context) =
     super.isRunnable && ctx.settings.YretainTrees.value
 
-  def runOn(unit: CompilationUnit)(implicit ctx: Context) = {
-    val runCtx = ctx.fresh.setCompilationUnit(unit)
-    traverser.traverse(unit.tpdTree)(runCtx)
-  }
-
-  override def transformTypeDef(tree: tpd.TypeDef)(implicit ctx: Context): tpd.Tree = {
-    if (tree.symbol.isClass) {
-      val sym = tree.symbol.asClass
-      tpd.sliceTopLevel(ctx.compilationUnit.tpdTree, sym) match {
-        case (pkg: tpd.PackageDef) :: Nil =>
-          sym.rootTreeOrProvider = pkg
-        case _ =>
-          sym.rootTreeOrProvider = tree
-      }
-    }
-    tree
+  override def run(implicit ctx: Context): Unit = {
+    val tree = ctx.compilationUnit.tpdTree
+    traverser.traverse(tree)
   }
 
   private def traverser = new tpd.TreeTraverser {
-    override def traverse(tree: tpd.Tree)(implicit ctx: Context): Unit = tree match {
-      case typeDef: tpd.TypeDef => transformTypeDef(typeDef)
-      case other => traverseChildren(other)
+    override def traverse(tree: tpd.Tree)(implicit ctx: Context): Unit = {
+      if (tree.isInstanceOf[tpd.TypeDef] && tree.symbol.isClass) {
+        val sym = tree.symbol.asClass
+        tpd.sliceTopLevel(ctx.compilationUnit.tpdTree, sym) match {
+          case (pkg: tpd.PackageDef) :: Nil =>
+            sym.rootTreeOrProvider = pkg
+          case _ =>
+            sym.rootTreeOrProvider = tree
+        }
+      }
+      traverseChildren(tree)
     }
   }
-
-
 }
 
 object SetRootTree {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1642,6 +1642,12 @@ class Typer extends Namer
       // check value class constraints
       checkDerivedValueClass(cls, body1)
 
+
+      // Temporarily set the typed class def as root tree so that we have at least some
+      // information in the IDE in case we never reach `SetRootTree`.
+      if (ctx.mode.is(Mode.Interactive) && ctx.settings.YretainTrees.value)
+        cls.rootTreeOrProvider = cdef1
+
       cdef1
 
       // todo later: check that

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1642,8 +1642,6 @@ class Typer extends Namer
       // check value class constraints
       checkDerivedValueClass(cls, body1)
 
-      if (ctx.settings.YretainTrees.value) cls.rootTreeOrProvider = cdef1
-
       cdef1
 
       // todo later: check that

--- a/language-server/test/dotty/tools/languageserver/RenameTest.scala
+++ b/language-server/test/dotty/tools/languageserver/RenameTest.scala
@@ -236,6 +236,19 @@ class RenameTest {
 
   }
 
+  @Test def renameImportFromTasty: Unit = {
+    // Note that everything here is in the empty package; this ensures that we will
+    // use the sourcefile loader to load `class Bar`.
+    def testRename(m: CodeMarker) = {
+      withSources(
+        code"""object O { class ${m1}Foo${m2} }""",
+        tasty"""import O.${m3}Foo${m4}
+                class Bar extends ${m5}Foo${m6}"""
+      ).rename(m, "NewName", Set(m1 to m2, m3 to m4, m5 to m6))
+    }
 
+    testRename(m1)
+    testRename(m2)
+  }
 
 }


### PR DESCRIPTION
`rootTreeOrProvider` is a property of `ClassSymbol`, and contain the
tree that defines this symbol (or a mean to get that tree).

When the tree came from unpickled TASTY files, we were able to see the
nested packages from which the tree comes, along with the imports.
However, when the symbol has been loaded from source, we were filling
the `rootTreeOrProvider` only with the `TypeDef` that introduced this
symbol.

This commit moves the assignment of `rootTreeOrProvider` out of the
typer and into its own phase. Before assigning, we recreate the package
structure so that the information that we get out of
`rootTreeOrProvider` is the same regardless of whether the symbol has
been loaded from source or unpickled from TASTY.