### PR TITLE
Don't print modifiers in the REPL

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -378,16 +378,16 @@ class PlainPrinter(_ctx: Context) extends Printer {
     else ""
   }
 
-  /** String representation of symbol's definition key word */
+  /** String representation of symbol's definition keyword */
   protected def keyString(sym: Symbol): String = {
     val flags = sym.flagsUNSAFE
     if (flags is JavaTrait) "interface"
     else if (flags is Trait) "trait"
+    else if (flags is Module) "object"
     else if (sym.isClass) "class"
     else if (sym.isType) "type"
     else if (flags is Mutable) "var"
     else if (flags is Package) "package"
-    else if (flags is Module) "object"
     else if (sym is Method) "def"
     else if (sym.isTerm && (!(flags is Param))) "val"
     else ""

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -779,6 +779,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       super.toText(sym)
   }
 
+  /** String representation of symbol's kind. */
   override def kindString(sym: Symbol): String = {
     val flags = sym.flagsUNSAFE
     if (flags is Package) "package"
@@ -789,16 +790,13 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     else super.kindString(sym)
   }
 
+  /** String representation of symbol's definition keyword */
   override protected def keyString(sym: Symbol): String = {
     val flags = sym.flagsUNSAFE
     if (sym.isType && sym.owner.isTerm) ""
     else if (sym.isPackageObject) "package object"
     else if (flags.is(Module) && flags.is(Case)) "case object"
     else if (sym.isClass && flags.is(Case)) "case class"
-    else if (flags is Module) "object"
-    else if (sym.isTerm && !flags.is(Param) && flags.is(Implicit) && (sym is Method)) "implicit def"
-    else if (sym.isTerm && !flags.is(Param) && flags.is(Implicit)) "implicit val"
-    else if (sym.isTerm && !flags.is(Param) && flags.is(Erased)) "erased val"
     else super.keyString(sym)
   }
 

--- a/compiler/test-resources/type-printer/definitions
+++ b/compiler/test-resources/type-printer/definitions
@@ -1,0 +1,23 @@
+scala> class A
+// defined class A
+
+scala> case class B()
+// defined case class B
+
+scala> object C
+// defined object C
+
+scala> case object D
+// defined case object D
+
+scala> case object D
+// defined case object D
+
+scala> trait E
+// defined trait E
+
+scala> implicit def x: Int = 1
+def x: Int
+
+scala> erased def y: Int = 1
+def y: Int


### PR DESCRIPTION
This also fixes the implementation of `RefinedPrinter::keyString` which
was not serving its original purpose anymore