### PR TITLE
Fix unescaping of escape sequences by jline in REPL

### DIFF
--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -62,6 +62,7 @@ final class JLineTerminal(needsTerminal: Boolean) extends java.io.Closeable {
       .variable(BLINK_MATCHING_PAREN, 0L)       // Don't blink the opening paren after typing a closing paren.
       .option(INSERT_TAB, true)                 // At the beginning of the line, insert tab instead of completing.
       .option(AUTO_FRESH_LINE, true)            // if not at start of line before prompt, move to new line.
+      .option(DISABLE_EVENT_EXPANSION, true)    // don't process escape sequences in input
       .build()
 
     lineReader.readLine(prompt)


### PR DESCRIPTION
Fixes #5294

Output
```scala
scala> "\\A"
val res0: String = \A

scala> "\A"
1 |"\A"
  |  ^
  |  invalid escape character

scala>
```