### PR TITLE
Improve compression of TastyString

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyString.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyString.scala
@@ -15,14 +15,7 @@ object TastyString {
   /** Encode TASTY bytes into an Seq of String */
   def pickle(bytes: Array[Byte]): Pickled = {
     val str = new String(Base64.getEncoder().encode(bytes), UTF_8)
-    def split(sliceEnd: Int, acc: List[String]): List[String] = {
-      if (sliceEnd == 0) acc
-      else {
-        val sliceStart = (sliceEnd - maxStringSize) max 0
-        split(sliceStart, str.substring(sliceStart, sliceEnd) :: acc)
-      }
-    }
-    split(str.length, Nil)
+    str.sliding(maxStringSize, maxStringSize).toList
   }
 
   /** Decode the TASTY String into TASTY bytes */


### PR DESCRIPTION
Improves #3877

`'{ { val y = ~x * ~x; ~powerCode(n / 2, '(y)) } }`
was reduced from 206 bytes to 172 bytes

`'{ ~x * ~powerCode(n - 1, x) }`
was reduced from 143 bytes to 128 bytes