### PR TITLE
Make the output a list to be able to consume it twice

### DIFF
--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -537,7 +537,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
                     val output = Source.fromFile(outDir.getParent + "_decompiled" + JFile.separator + outDir.getName
                       + JFile.separator + "decompiled.scala").getLines().map {line =>
                       stripTrailingWhitespaces.unapplySeq(line).map(_.head).getOrElse(line)
-                    }
+                    }.toList
 
                     val check: String = Source.fromFile(checkFile).getLines().filter(!_.startsWith(ignoredFilePathLine))
                       .mkString("\n")


### PR DESCRIPTION
Some modifications to the code made it an iterator. The checks where performed
correctly but the output for the diff where empty.