### PR TITLE
Fix build breakage

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -486,8 +486,8 @@ object Trees {
   case class Block[-T >: Untyped] private[ast] (stats: List[Tree[T]], expr: Tree[T])
     extends Tree[T] {
     type ThisTree[-T >: Untyped] = Block[T]
-    override def isTerm: Boolean = expr.isTerm
     override def isType: Boolean = expr.isType
+    override def isTerm: Boolean = !isType // this will classify empty trees as terms, which is necessary
   }
 
   /** if cond then thenp else elsep */

--- a/tests/neg/implicit-shadowing.scala
+++ b/tests/neg/implicit-shadowing.scala
@@ -25,6 +25,5 @@ object Test {
       implicitly[C1[T]]    // OK: no shadowing for evidence parameters
       implicitly[C2[U]]
     }
-    ()
   }
 }

--- a/tests/neg/implicit-shadowing.scala
+++ b/tests/neg/implicit-shadowing.scala
@@ -25,5 +25,6 @@ object Test {
       implicitly[C1[T]]    // OK: no shadowing for evidence parameters
       implicitly[C2[U]]
     }
+    ()
   }
 }


### PR DESCRIPTION
It was an interaction of a new test on implicit shadowing with the recently added classification of blocks as types or terms.

The classification needs to be refined.
