### PR TITLE
Error msg/stable identifiers

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.java
@@ -141,7 +141,8 @@ public enum ErrorMessageID {
     LazyStaticFieldID,
     StaticOverridingNonStaticMembersID,
     OverloadInRefinementID,
-    NoMatchingOverloadID
+    NoMatchingOverloadID,
+    StableIdentPatternID
     ;
 
     public int errorNumber() {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2191,4 +2191,12 @@ object messages {
     val kind: String = "Type Mismatch"
     val explanation: String = ""
   }
+  case class StableIdentPattern(tree: untpd.Tree, pt: Type)(implicit val ctx: Context)
+    extends Message(StableIdentPatternID) {
+    override def kind: String = "Syntax"
+    override def msg: String = {
+      hl"""|Stable identifier required, but ${tree.show} found"""
+    }
+    override def explanation: String = ""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2194,9 +2194,8 @@ object messages {
   case class StableIdentPattern(tree: untpd.Tree, pt: Type)(implicit val ctx: Context)
     extends Message(StableIdentPatternID) {
     override def kind: String = "Syntax"
-    override def msg: String = {
-      hl"""|Stable identifier required, but ${tree.show} found"""
-    }
+    override def msg: String =
+      hl"""Stable identifier required, but ${tree.show} found"""
     override def explanation: String = ""
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -414,7 +414,7 @@ class Typer extends Namer
         !pt.isInstanceOf[ApplyingProto] &&
         !tree.tpe.isStable &&
         !isWildcardArg(tree))
-      ctx.error(s"stable identifier required, but ${tree.show} found", tree.pos)
+      ctx.error(StableIdentPattern(tree, pt), tree.pos)
 
     tree
   }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1618,7 +1618,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         """.stripMargin
       }.expect { (_, messages) =>
         assertMessageCount(1, messages)
-        val message = message.head
+        val message = messages.head
         assertTrue(message.isInstanceOf[StableIdentPattern])
         assertEquals(
           "Stable identifier required, but `x` found",

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1605,4 +1605,23 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         message.msg
       )
     }
+
+    @Test def StableIdentifiers() =
+      checkMessagesAfter(FrontEnd.name) {
+        """
+          | object Test {
+          |   var x = 2
+          |   def test = 2 match {
+          |     case `x` => x + 1
+          |   }
+          | }
+        """.stripMargin
+      }.expect { (_, messages) =>
+        assertMessageCount(1, messages)
+        val message = message.head
+        assertTrue(message.isInstanceOf[StableIdentPattern])
+        assertEquals(
+          "Stable identifier required, but `x` found"
+        )
+      }
 }

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1621,7 +1621,8 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         val message = message.head
         assertTrue(message.isInstanceOf[StableIdentPattern])
         assertEquals(
-          "Stable identifier required, but `x` found"
+          "Stable identifier required, but `x` found",
+          message.msg
         )
       }
 }


### PR DESCRIPTION
Adds messages for checking stable identifiers.
Right now I'm considering this error will only show up in pattern matching, is that right?

Part of #1589 