### PR TITLE
Fix #5333: Invalid entries in the baseType cache

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1631,7 +1631,10 @@ object SymDenotations {
           Stats.record("basetype cache entries")
           if (!baseTp.exists) Stats.record("basetype cache NoTypes")
         }
-        btrCache.put(tp, baseTp)
+        if (!tp.isProvisional)
+          btrCache.put(tp, baseTp)
+        else
+          btrCache.remove(tp) // Remove any potential sentinel value
       }
 
       def ensureAcyclic(baseTp: Type) = {
@@ -1717,8 +1720,6 @@ object SymDenotations {
               val baseTp = recur(superTp)
               tp match {
                 case tp: CachedType if baseTp.exists && inCache(superTp) =>
-                  // Note: This also works for TypeVars: If they are not instantiated, their supertype
-                  // is a TypeParamRef, which is never cached. So uninstantiated TypeVars are not cached either.
                   record(tp, baseTp)
                 case _ =>
               }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1685,8 +1685,8 @@ object SymDenotations {
                 case _ =>
                   val superTp = tp.superType
                   val baseTp = recur(superTp)
-                  if (inCache(superTp) && tp.symbol.maybeOwner.isType)
-                    record(tp, baseTp)   // typeref cannot be a GADT, so cache is stable
+                  if (inCache(superTp))
+                    record(tp, baseTp)
                   else
                     btrCache.remove(tp)
                   baseTp

--- a/tests/pos/seqtype-cycle/Test2.scala
+++ b/tests/pos/seqtype-cycle/Test2.scala
@@ -2,6 +2,8 @@ package object scala {
   // needed for some reasons
   type Throwable = java.lang.Throwable
   type IndexOutOfBoundsException = java.lang.IndexOutOfBoundsException
+  type List[+A] = scala.collection.immutable.List[A]
+  type Iterable[+A] = scala.collection.Iterable[A]
 
   type Seq[A] = scala.collection.Seq[A]
   val Seq = scala.collection.Seq


### PR DESCRIPTION
Provisional types should not have their baseType cached, it may change
as type variables get refined and instantiated.

The seqtype-cycle test had to be adjusted to avoid some missing
reference errors, probably due to the completion order changing.