### PR TITLE
Fix `HoverTest` with error

### DIFF
--- a/language-server/test/dotty/tools/languageserver/HoverTest.scala
+++ b/language-server/test/dotty/tools/languageserver/HoverTest.scala
@@ -71,7 +71,7 @@ class HoverTest {
     code"""class Foo {
           |  ${m1}x$m2
           |}""".withSource
-      .hover(m1 to m2, hoverContent("<error not found: x>" ))
+      .hover(m1 to m2, None)
   }
 
   @Test def hoverFun0: Unit = {


### PR DESCRIPTION
We return `null` in `Hover` when the type of the symbol is erroneous,
but we used to show an error message.