### PR TITLE
sbt-dotty: fix extension upgrade on Windows, release 0.2.6

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -37,14 +37,14 @@ object Build {
   val scalacVersion = "2.12.7"
 
   val baseVersion = "0.11.0"
-  val baseSbtDottyVersion = "0.2.6"
+  val baseSbtDottyVersion = "0.2.7"
 
   // Versions used by the vscode extension to create a new project
   // This should be the latest published releases.
   // TODO: Have the vscode extension fetch these numbers from the Internet
   // instead of hardcoding them ?
   val publishedDottyVersion = "0.11.0-bin-20181031-5a465af-NIGHTLY" // Using a nightly for now to get worksheet support
-  val publishedSbtDottyVersion = "0.2.5"
+  val publishedSbtDottyVersion = "0.2.6"
 
 
   val dottyOrganization = "ch.epfl.lamp"

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyIDEPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyIDEPlugin.scala
@@ -197,7 +197,7 @@ object DottyIDEPlugin extends AutoPlugin {
    */
   def installCodeExtension(codeCmd: Seq[String], name: String): Unit = {
     try {
-      runProcess(codeCmd ++ Seq("--install-extension", name), wait = true)
+      runProcess(codeCmd ++ Seq("--force", "--install-extension", name), wait = true)
     } catch {
       case e: Exception =>
         var alreadyInstalled: Boolean = false


### PR DESCRIPTION
When using --install-extension and an upgraded version of the extension
exists online, the user normally gets a prompt to accept or reject the
upgrade. Using --force we bypass this prompt and we also fix an issue
with Windows where the prompt does not appear and we get the error
"Unknown stdin file type" instead.