### PR TITLE
Fix #5351: Warn about implicit conversions using ImplicitConverter

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1414,6 +1414,7 @@ class Typer extends Namer
   def typedValDef(vdef: untpd.ValDef, sym: Symbol)(implicit ctx: Context): Tree = track("typedValDef") {
     val ValDef(name, tpt, _) = vdef
     completeAnnotations(vdef, sym)
+    if (sym is Implicit) checkImplicitConversionDefOK(sym)
     val tpt1 = checkSimpleKinded(typedType(tpt))
     val rhs1 = vdef.rhs match {
       case rhs @ Ident(nme.WILDCARD) => rhs withType tpt1.tpe

--- a/tests/neg-custom-args/impl-conv/A.scala
+++ b/tests/neg-custom-args/impl-conv/A.scala
@@ -3,6 +3,7 @@ package implConv
 object A {
 
   implicit def s2i(x: String): Int = Integer.parseInt(x) // error: feature
+  implicit val i2s: ImplicitConverter[Int, String] = _.toString // error: feature
 
   implicit class Foo(x: String) {
     def foo = x.length

--- a/tests/neg-custom-args/impl-conv/B.scala
+++ b/tests/neg-custom-args/impl-conv/B.scala
@@ -6,5 +6,6 @@ object B {
   "".foo
 
   val x: Int = ""  // error: feature
+  val y: String = 1 // error: feature
 
 }


### PR DESCRIPTION
As we do for implicit conversions, we now emit a warning when an
implicit conversion using `ImplicitConverter` is defined or used.

Fixes #5351