### PR TITLE
Fix #5339: Use normal characters as delimiter for REPL output

### DIFF
--- a/language-server/src/dotty/tools/languageserver/worksheet/InputStreamConsumer.scala
+++ b/language-server/src/dotty/tools/languageserver/worksheet/InputStreamConsumer.scala
@@ -21,5 +21,5 @@ class InputStreamConsumer(in: InputStream) {
 }
 
 object InputStreamConsumer {
-  def delimiter = "\uE000" // withing private use area
+  def delimiter = "##!!##"
 }

--- a/language-server/src/dotty/tools/languageserver/worksheet/ReplProcess.scala
+++ b/language-server/src/dotty/tools/languageserver/worksheet/ReplProcess.scala
@@ -11,7 +11,8 @@ object ReplProcess {
     while (true) {
       val code = in.next() // blocking
       state = driver.run(code)(state)
-      print(InputStreamConsumer.delimiter) // needed to mark the end of REPL output
+      Console.print(InputStreamConsumer.delimiter) // needed to mark the end of REPL output
+      Console.flush()
     }
   }
 }


### PR DESCRIPTION
Using characters within the private use area was too fancy for Windows