### PR TITLE
Don't zip workspace if tracing is disabled

### DIFF
--- a/vscode-dotty/src/tracer.ts
+++ b/vscode-dotty/src/tracer.ts
@@ -75,15 +75,17 @@ export class Tracer {
 
     run(): vscode.OutputChannel | undefined {
         const consentCommandDisposable = vscode.commands.registerCommand(consentCommandName, () => this.askForTracingConsent())
-        if (this.isTracingEnabled && this.tracingConsent.get() === 'no-answer') this.askForTracingConsent()
-        this.initializeAsyncWorkspaceDump()
+        if (this.isTracingEnabled) {
+            if (this.tracingConsent.get() === 'no-answer') this.askForTracingConsent()
+            this.initializeAsyncWorkspaceDump()
 
-        const lspOutputChannel = this.createLspOutputChannel()
-        const statusBarItem = this.createStatusBarItem()
-        for (const disposable of [consentCommandDisposable, lspOutputChannel, statusBarItem]) {
-            if (disposable) this.ctx.extensionContext.subscriptions.push(disposable)
+            const lspOutputChannel = this.createLspOutputChannel()
+            const statusBarItem = this.createStatusBarItem()
+            for (const disposable of [consentCommandDisposable, lspOutputChannel, statusBarItem]) {
+                if (disposable) this.ctx.extensionContext.subscriptions.push(disposable)
+            }
+            return lspOutputChannel
         }
-        return lspOutputChannel
     }
 
     private askForTracingConsent(): void {


### PR DESCRIPTION
I've noticed that on my machine, VSCode always tries to zip my workspace. On my machine, it looks like `this.tracingConsent.get() === 'Allow'`, but the URLs are unset.
