### PR TITLE
VsCode: create local output channel even if tracing is disabled

### DIFF
--- a/vscode-dotty/src/tracer.ts
+++ b/vscode-dotty/src/tracer.ts
@@ -84,17 +84,15 @@ export class Tracer {
 
     run(): vscode.OutputChannel | undefined {
         const consentCommandDisposable = vscode.commands.registerCommand(consentCommandName, () => this.askForTracingConsent())
-        if (this.isTracingEnabled) {
-            if (this.tracingConsent.get() === 'no-answer') this.askForTracingConsent()
-            this.initializeAsyncWorkspaceDump()
+        if (this.isTracingEnabled && this.tracingConsent.get() === 'no-answer') this.askForTracingConsent()
+        this.initializeAsyncWorkspaceDump()
 
-            const lspOutputChannel = this.createLspOutputChannel()
-            const statusBarItem = this.createStatusBarItem()
-            for (const disposable of [consentCommandDisposable, lspOutputChannel, statusBarItem]) {
-                if (disposable) this.ctx.extensionContext.subscriptions.push(disposable)
-            }
-            return lspOutputChannel
+        const lspOutputChannel = this.createLspOutputChannel()
+        const statusBarItem = this.createStatusBarItem()
+        for (const disposable of [consentCommandDisposable, lspOutputChannel, statusBarItem]) {
+            if (disposable) this.ctx.extensionContext.subscriptions.push(disposable)
         }
+        return lspOutputChannel
     }
 
     private askForTracingConsent(): void {
@@ -111,7 +109,7 @@ export class Tracer {
 
     private initializeAsyncWorkspaceDump() {
         const url = this.remoteWorkspaceDumpUrl
-        if (url === undefined) return
+        if (!url) return
 
         const doInitialize = () => {
             try {


### PR DESCRIPTION
We should still create a local output channel if remote tracing is disabled,  BUT `dotty.trace.server` is set to be consistent with how other plugins implement the functionality.

I broke the check at the beginning of `initializeAsyncWorkspaceDump` when I set the default value of workspace dump URL to empty string in `package.json`. Note that checking if the url is falsey is morally fine, since all falsey strings are invalid (absolute) URLs. This is already done by `isTracingEnabled`.