### PR TITLE
Fix #5372: Use `applyDynamic` in structural calls

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -737,6 +737,17 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
     case _ => This(ctx.owner.enclosingClass.asClass)
   }
 
+  /** Is this an application on a structural selection?
+   *
+   *  @see isStructuralTermSelect
+   */
+  def isStructuralTermApply(tree: Tree)(implicit ctx: Context): Boolean = tree match {
+    case Apply(fun, _) =>
+      isStructuralTermSelect(fun)
+    case _ =>
+      false
+  }
+
   /** Is this a selection of a member of a structural type that is not a member
    *  of an underlying class or trait?
    */

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -24,9 +24,6 @@ object Definitions {
    *  else without affecting the set of programs that can be compiled.
    */
   val MaxImplementedFunctionArity: Int = 22
-
-  /** The maximal arity of a function that can be accessed as member of a structural type */
-  val MaxStructuralMethodArity: Int = 7
 }
 
 /** A class defining symbols and types of standard definitions

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -501,7 +501,6 @@ object StdNames {
     val scala_ : N              = "scala"
     val scalaShadowing : N      = "scalaShadowing"
     val selectDynamic: N        = "selectDynamic"
-    val selectDynamicMethod: N  = "selectDynamicMethod"
     val selectOverloadedMethod: N = "selectOverloadedMethod"
     val selectTerm: N           = "selectTerm"
     val selectType: N           = "selectType"

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -490,7 +490,10 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
           }
 
           def tryDefault(n: Int, args1: List[Arg]): Unit = {
-            val getter = findDefaultGetter(n + numArgs(normalizedFun))
+            val getter =
+              // `methRef.symbol` doesn't exist for structural calls
+              if (methRef.symbol.exists) findDefaultGetter(n + numArgs(normalizedFun))
+              else EmptyTree
             if (getter.isEmpty) missingArg(n)
             else {
               val substParam = addTyped(

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2638,7 +2638,10 @@ class Typer extends Namer
             convertNewGenericArray(readapt(tree.appliedToTypeTrees(typeArgs)))
           }
         case wtp =>
-          if (isStructuralTermSelect(tree)) readaptSimplified(handleStructural(tree))
+          if (isStructuralTermApply(tree))
+            readaptSimplified(handleStructural(tree))
+          else if (isStructuralTermSelect(tree) && tree.tpe.widen.isValueType)
+            readaptSimplified(handleStructural(tree))
           else pt match {
             case pt: FunProto =>
               adaptToArgs(wtp, pt)

--- a/docs/docs/reference/changed/structural-types.md
+++ b/docs/docs/reference/changed/structural-types.md
@@ -69,11 +69,9 @@ differences.
   how to define reflective access operations. By contrast
   `Selectable` is a trait which declares the access operations.
 
-- One access operation, `selectDynamic` is shared between both
-  approaches, but the other access operations are
-  different. `Selectable` defines a `selectDynamicMethod`, which
-  takes class tags indicating the method's formal parameter types as
-  additional argument. `Dynamic` comes with `applyDynamic` and
-  `updateDynamic` methods, which take actual argument values.
+- Two access operations, `selectDynamic` and `applyDynamic` are shared
+  between both approches. In `Selectable`, `applyDynamic` also takes
+  `ClassTag` indicating the method's formal parameter types. `Dynamic`
+  comes with `updateDynamic`.
 
 [More details](structural-types-spec.html)

--- a/library/src/scala/Selectable.scala
+++ b/library/src/scala/Selectable.scala
@@ -3,6 +3,6 @@ import scala.reflect.ClassTag
 
 trait Selectable extends Any {
   def selectDynamic(name: String): Any
-  def selectDynamicMethod(name: String, paramClasses: ClassTag[_]*): Any =
-    new UnsupportedOperationException("selectDynamicMethod")
+  def applyDynamic(name: String, paramClasses: ClassTag[_]*)(args: Any*): Any =
+    new UnsupportedOperationException("applyDynamic")
 }

--- a/library/src/scala/reflect/Selectable.scala
+++ b/library/src/scala/reflect/Selectable.scala
@@ -10,60 +10,16 @@ class Selectable(val receiver: Any) extends AnyVal with scala.Selectable {
     }
     catch {
       case ex: NoSuchFieldException =>
-        selectDynamicMethod(name).asInstanceOf[() => Any]()
+        applyDynamic(name)()
     }
   }
 
-  override def selectDynamicMethod(name: String, paramTypes: ClassTag[_]*): Any = {
+  override def applyDynamic(name: String, paramTypes: ClassTag[_]*)(args: Any*): Any = {
     val rcls = receiver.getClass
     val paramClasses = paramTypes.map(_.runtimeClass)
     val mth = rcls.getMethod(name, paramClasses: _*)
     ensureAccessible(mth)
-    paramTypes.length match {
-      case 0 => () =>
-        mth.invoke(receiver)
-      case 1 => (x0: Any) =>
-        mth.invoke(receiver, x0.asInstanceOf[Object])
-      case 2 => (x0: Any, x1: Any) =>
-        mth.invoke(receiver,
-            x0.asInstanceOf[Object],
-            x1.asInstanceOf[Object])
-      case 3 => (x0: Any, x1: Any, x2: Any) =>
-        mth.invoke(receiver,
-            x0.asInstanceOf[Object],
-            x1.asInstanceOf[Object],
-            x2.asInstanceOf[Object])
-      case 4 => (x0: Any, x1: Any, x2: Any, x3: Any) =>
-        mth.invoke(receiver,
-            x0.asInstanceOf[Object],
-            x1.asInstanceOf[Object],
-            x2.asInstanceOf[Object],
-            x3.asInstanceOf[Object])
-      case 5 => (x0: Any, x1: Any, x2: Any, x3: Any, x4: Any) =>
-        mth.invoke(receiver,
-            x0.asInstanceOf[Object],
-            x1.asInstanceOf[Object],
-            x2.asInstanceOf[Object],
-            x3.asInstanceOf[Object],
-            x4.asInstanceOf[Object])
-      case 6 => (x0: Any, x1: Any, x2: Any, x3: Any, x4: Any, x5: Any) =>
-        mth.invoke(receiver,
-            x0.asInstanceOf[Object],
-            x1.asInstanceOf[Object],
-            x2.asInstanceOf[Object],
-            x3.asInstanceOf[Object],
-            x4.asInstanceOf[Object],
-            x5.asInstanceOf[Object])
-      case 7 => (x0: Any, x1: Any, x2: Any, x3: Any, x4: Any, x5: Any, x6: Any) =>
-        mth.invoke(receiver,
-            x0.asInstanceOf[Object],
-            x1.asInstanceOf[Object],
-            x2.asInstanceOf[Object],
-            x3.asInstanceOf[Object],
-            x4.asInstanceOf[Object],
-            x5.asInstanceOf[Object],
-            x6.asInstanceOf[Object])
-      }
+    mth.invoke(receiver, args.map(_.asInstanceOf[AnyRef]): _*)
   }
 }
 

--- a/tests/neg/structural.scala
+++ b/tests/neg/structural.scala
@@ -15,5 +15,9 @@ object Test3 {
 
   trait Entry { type Key; val key: Key }
   type D = { def foo(e: Entry, k: e.Key): Unit }
-  def i(x: D) = x.foo(???) // error: foo has dependent params
+  val e = new Entry { type Key = Int; val key = 0 }
+  def i(x: D) = x.foo(e, 1) // error: foo has dependent params
+
+  type G = { def foo(x: Int, y: Int): Unit }
+  def j(x: G) = x.foo(???) // error: missing argument
 }


### PR DESCRIPTION
This commit changes how `Selectable` works for calling methods: It used
to be called `selectMethodDynamic and to receive the name of the method
to call along with the class tags of the formal parameters.

This commit renames it to `applyDynamic`, and changes it so that it also
takes the actual arguments that are passed in the function call.

Fixes #5372