### PR TITLE
Fix #5386: Generate a synthetic val def and then apply the unary operator

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -46,16 +46,14 @@ class InterceptedMethods extends MiniPhase {
       ctx.log(s"$phaseName rewrote $tree to $rewritten")
       rewritten
     }
-    else if (tree.name.startsWith(nme.UNARY_PREFIX.toString) && tree.qualifier.symbol.isAbsent) {
+    else if (!tree.qualifier.symbol.exists && tree.name.startsWith(nme.UNARY_PREFIX.toString)) {
       tree.qualifier match {
-        case refTree: RefTree => tree
-        case _ => {
+        case _ =>
           val tempDef = SyntheticValDef(UniqueName.fresh().toTermName, tree.qualifier)
           val rewritten = Block(tempDef :: Nil, ref(tempDef.symbol).select(tree.name))
           ctx.log(s"$phaseName rewrote $tree to $rewritten")
 
           rewritten
-        }
       }
     }
     else tree

--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -53,8 +53,6 @@ class InterceptedMethods extends MiniPhase {
           val tempDef = SyntheticValDef(UniqueName.fresh().toTermName, tree.qualifier)
           val rewritten = Block(tempDef :: Nil, ref(tempDef.symbol).select(tree.name))
           ctx.log(s"$phaseName rewrote $tree to $rewritten")
-          println("### " + tree.tpe + " " + tree.tpe.show)
-          println("### " + tree.qualifier.symbol)
 
           rewritten
         }

--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -51,14 +51,11 @@ class InterceptedMethods extends MiniPhase {
     // in case a unary operator is applied to a block (potentially containing impure expressions)
     // we create a synthetic variable and then apply the operator
     else if (!tree.qualifier.symbol.exists && tree.name.startsWith(nme.UNARY_PREFIX.toString)) {
-      tree.qualifier match {
-        case _ =>
-          val tempDef = SyntheticValDef(UniqueName.fresh().toTermName, tree.qualifier)
-          val rewritten = Block(tempDef :: Nil, ref(tempDef.symbol).select(tree.name))
-          ctx.log(s"$phaseName rewrote $tree to $rewritten")
+      val tempDef = SyntheticValDef(UniqueName.fresh().toTermName, tree.qualifier)
+      val rewritten = Block(tempDef :: Nil, ref(tempDef.symbol).select(tree.name))
+      ctx.log(s"$phaseName rewrote $tree to $rewritten")
 
-          rewritten
-      }
+      rewritten
     }
     else tree
   }

--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -9,6 +9,7 @@ import dotty.tools.dotc.core.Names.TermName
 import dotty.tools.dotc.core.StdNames._
 import dotty.tools.dotc.core.Symbols._
 import dotty.tools.dotc.core.Types._
+import dotty.tools.dotc.core.NameKinds._
 import dotty.tools.dotc.transform.MegaPhase.MiniPhase
 
 object InterceptedMethods {
@@ -44,6 +45,17 @@ class InterceptedMethods extends MiniPhase {
       val rewritten = poundPoundValue(qual)
       ctx.log(s"$phaseName rewrote $tree to $rewritten")
       rewritten
+    }
+    else if (tree.name.startsWith(nme.UNARY_PREFIX.toString)) {
+      tree.qualifier match {
+        case refTree: RefTree => tree
+        case _ => {
+          val tempDef = SyntheticValDef(UniqueName.fresh().toTermName, tree.qualifier)
+          val rewritten = Block(tempDef :: Nil, ref(tempDef.symbol).select(tree.name))
+          ctx.log(s"$phaseName rewrote $tree to $rewritten")
+          rewritten
+        }
+      }
     }
     else tree
   }

--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -46,13 +46,16 @@ class InterceptedMethods extends MiniPhase {
       ctx.log(s"$phaseName rewrote $tree to $rewritten")
       rewritten
     }
-    else if (tree.name.startsWith(nme.UNARY_PREFIX.toString)) {
+    else if (tree.name.startsWith(nme.UNARY_PREFIX.toString) && tree.qualifier.symbol.isAbsent) {
       tree.qualifier match {
         case refTree: RefTree => tree
         case _ => {
           val tempDef = SyntheticValDef(UniqueName.fresh().toTermName, tree.qualifier)
           val rewritten = Block(tempDef :: Nil, ref(tempDef.symbol).select(tree.name))
           ctx.log(s"$phaseName rewrote $tree to $rewritten")
+          println("### " + tree.tpe + " " + tree.tpe.show)
+          println("### " + tree.qualifier.symbol)
+
           rewritten
         }
       }

--- a/tests/pos/i5386.scala
+++ b/tests/pos/i5386.scala
@@ -1,0 +1,23 @@
+object Test {
+  ~{
+    println("!")
+    1
+  }
+
+  +{
+    println("!")
+    1
+  }
+
+  -{
+    println("!")
+    1
+  }
+
+  !{
+    println("!")
+    true
+  }
+
+  !(try true finally{()})
+}


### PR DESCRIPTION
I added the logic that lifts a block with a side-effectful operation at the `InterceptedMethods` phase. Is this the most appropriate place for that?

What happens is essentially:

```scala
~{
    println("!")
    1
}
```
is rewritten to ->
```scala
val temp = {
    println("!")
    1
}
!temp
```
