### PR TITLE
Handle structural types with curried methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2640,9 +2640,8 @@ class Typer extends Namer
             convertNewGenericArray(readapt(tree.appliedToTypeTrees(typeArgs)))
           }
         case wtp =>
-          if (isStructuralTermApply(tree))
-            readaptSimplified(handleStructural(tree))
-          else if (isStructuralTermSelect(tree) && tree.tpe.widen.isValueType)
+          val isStructuralCall = wtp.isValueType && isStructuralTermSelectOrApply(tree)
+          if (isStructuralCall)
             readaptSimplified(handleStructural(tree))
           else pt match {
             case pt: FunProto =>

--- a/docs/docs/reference/changed/structural-types-spec.md
+++ b/docs/docs/reference/changed/structural-types-spec.md
@@ -47,17 +47,19 @@ consider three distinct cases:
   (v: Selectable).selectDynamic("a").asInstanceOf[U]
   ```
 
-- If `U` is a method type `(T1, ..., Tn) => R` with at most 7
-  parameters and it is not a dependent method type, we map `v.a` to
+- If `U` is a method type `(T11, ..., T1n)...(TN1, ..., TNn) => R` and it is not
+a dependent method type, we map `v.a(a11, ..., a1n)...(aN1, aNn)` to
   the  equivalent of:
   ```scala
   v.a(arg1, ..., argn)
      --->
-  (v: Selectable).applyDynamic("a", CT1, ..., CTn)(arg1, ..., argn).asInstanceOf[R]
+  (v: Selectable).applyDynamic("a", CT11, ..., CTn, ..., CTN1, ... CTNn)
+                              (a11, ..., a1n, ..., aN1, ..., aNn)
+                 .asInstanceOf[R]
   ```
 
 - If `U` is neither a value nor a method type, or a dependent method
-  type, or has more than 7 parameters, an error is emitted.
+  type, an error is emitted.
 
 We make sure that `r` conforms to type `Selectable`, potentially by
 introducing an implicit conversion, and then call either

--- a/library/src/scala/reflect/Selectable.scala
+++ b/library/src/scala/reflect/Selectable.scala
@@ -19,7 +19,7 @@ class Selectable(val receiver: Any) extends AnyVal with scala.Selectable {
     val paramClasses = paramTypes.map(_.runtimeClass)
     val mth = rcls.getMethod(name, paramClasses: _*)
     ensureAccessible(mth)
-    mth.invoke(receiver, args.map(_.asInstanceOf[AnyRef]): _*)
+    mth.invoke(receiver, args.asInstanceOf[Seq[AnyRef]]: _*)
   }
 }
 

--- a/tests/neg/structural.scala
+++ b/tests/neg/structural.scala
@@ -20,4 +20,20 @@ object Test3 {
 
   type G = { def foo(x: Int, y: Int): Unit }
   def j(x: G) = x.foo(???) // error: missing argument
+
+  class H { type S = String; type I }
+  class I extends H { type I = Int }
+  type Dep = {
+    def fun1(x: H, y: x.S): Int
+    def fun2(x: H, y: x.I): Int
+    def fun3(y: H): y.S
+    def fun4(y: H): y.I
+  }
+  def k(x: Dep) = {
+    val y = new I
+    x.fun1(y, "Hello")
+    x.fun2(y, 1) // error
+    x.fun3(y)
+    x.fun4(y) // error
+  }
 }

--- a/tests/run/structural.scala
+++ b/tests/run/structural.scala
@@ -1,0 +1,106 @@
+import scala.reflect.Selectable.reflectiveSelectable
+
+object Test {
+  class C { type S = String; type I }
+  class D extends C { type I = Int }
+
+  type Foo = {
+    def sel0: Int
+    def sel1: Int => Int
+    def fun0(x: Int): Int
+
+    def fun1(x: Int)(y: Int): Int
+    def fun2(x: Int): Int => Int
+    def fun3(a1: Int, a2: Int, a3: Int)
+            (a4: Int, a5: Int, a6: Int)
+            (a7: Int, a8: Int, a9: Int): Int
+
+    def fun4(implicit x: Int): Int
+    def fun5(x: Int)(implicit y: Int): Int
+
+    def fun6(x: C, y: x.S): Int
+    def fun7(x: C, y: x.I): Int
+    def fun8(y: C): y.S
+    def fun9(y: C): y.I
+  }
+
+  class FooI {
+    def sel0: Int = 1
+    def sel1: Int => Int = x => x
+    def fun0(x: Int): Int = x
+
+    def fun1(x: Int)(y: Int): Int = x + y
+    def fun2(x: Int): Int => Int = y => x * y
+    def fun3(a1: Int, a2: Int, a3: Int)
+            (a4: Int, a5: Int, a6: Int)
+            (a7: Int, a8: Int, a9: Int): Int = -1
+
+    def fun4(implicit x: Int): Int = x
+    def fun5(x: Int)(implicit y: Int): Int = x + y
+
+    def fun6(x: C, y: x.S): Int = 1
+    def fun7(x: C, y: x.I): Int = 2
+    def fun8(y: C): y.S = "Hello"
+    def fun9(y: C): y.I = 1.asInstanceOf[y.I]
+  }
+
+  def basic(x: Foo): Unit ={
+    assert(x.sel0 == 1)
+    assert(x.sel1(2) == 2)
+    assert(x.fun0(3) == 3)
+
+    val f = x.sel1
+    assert(f(3) == 3)
+  }
+
+  def currying(x: Foo): Unit = {
+    assert(x.fun1(1)(2) == 3)
+    assert(x.fun2(1)(2) == 2)
+    assert(x.fun3(1, 2, 3)(4, 5, 6)(7, 8, 9) == -1)
+  }
+
+  def etaExpansion(x: Foo): Unit = {
+    val f0 = x.fun0(_)
+    assert(f0(2) == 2)
+
+    val f1 = x.fun0 _
+    assert(f1(2) == 2)
+
+    val f2 = x.fun1(1)(_)
+    assert(f2(2) == 3)
+
+    val f3 = x.fun1(1) _
+    assert(f3(2) == 3)
+
+    val f4 = x.fun1(1)
+    assert(f4(2) == 3)
+  }
+
+  def implicits(x: Foo) = {
+    implicit val y = 2
+    assert(x.fun4 == 2)
+    assert(x.fun5(1) == 3)
+  }
+
+  // Limited support for dependant methods
+  def dependant(x: Foo) = {
+    val y = new D
+
+    assert(x.fun6(y, "Hello") == 1)
+    // assert(x.fun7(y, 1) == 2) // error: No ClassTag available for x.I
+
+    val s = x.fun8(y)
+    assert((s: String) == "Hello")
+
+    // val i = x.fun9(y) // error: rejected (blows up in pickler if not rejected)
+    // assert((i: String) == "Hello") // error: Type mismatch: found: y.S(i); required: String
+  }
+
+  def main(args: Array[String]): Unit = {
+    basic(new FooI)
+    currying(new FooI)
+    etaExpansion(new FooI)
+    implicits(new FooI)
+    dependant(new FooI)
+  }
+}


### PR DESCRIPTION
We desugar `x.foo(a1)(a2)` (where the type of `x` is a structural type) to:

```scala
(x:selectable).applyDynamic("a", CTa1, CTa2)(a1, a2)
```