### PR TITLE
 IDE: Support `textDocument/implementation`

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -519,4 +519,26 @@ object Interactive {
     }
   }
 
+  /**
+   * Return a predicate function that determines whether a given `NameTree` is an implementation of
+   * `sym`.
+   *
+   * @param sym The symbol whose implementations to find.
+   * @return A function that determines whether a `NameTree` is an implementation of `sym`.
+   */
+  def implementationFilter(sym: Symbol)(implicit ctx: Context): NameTree => Boolean = {
+    if (sym.isClass) {
+      case td: TypeDef =>
+        val treeSym = td.symbol
+        (treeSym != sym || !treeSym.is(AbstractOrTrait)) && treeSym.derivesFrom(sym)
+      case _ =>
+        false
+    } else {
+      case md: MemberDef =>
+        matchSymbol(md, sym, Include.overriding) && !md.symbol.is(Deferred)
+      case _ =>
+        false
+    }
+  }
+
 }

--- a/language-server/test/dotty/tools/languageserver/ImplementationTest.scala
+++ b/language-server/test/dotty/tools/languageserver/ImplementationTest.scala
@@ -1,0 +1,76 @@
+package dotty.tools.languageserver
+
+import dotty.tools.languageserver.util.Code._
+
+import org.junit.Test
+
+class ImplementationTest {
+
+  @Test def implMethodFromTrait: Unit = {
+    code"""trait A {
+             def ${m1}foo${m2}(x: Int): String
+           }
+           class B extends A {
+             override def ${m3}foo${m4}(x: Int): String = ""
+           }""".withSource
+      .implementation(m1 to m2, List(m3 to m4))
+      .implementation(m3 to m4, List(m3 to m4))
+  }
+
+  @Test def implMethodFromTrait0: Unit = {
+    code"""trait A {
+             def ${m1}foo${m2}(x: Int): String
+           }
+           class B extends A {
+             override def ${m3}foo${m4}(x: Int): String = ""
+           }
+           class C extends B {
+             override def ${m5}foo${m6}(x: Int): String = ""
+           }""".withSource
+      .implementation(m1 to m2, List(m3 to m4, m5 to m6))
+      .implementation(m3 to m4, List(m3 to m4, m5 to m6))
+      .implementation(m5 to m6, List(m5 to m6))
+  }
+
+  @Test def extendsTrait: Unit = {
+    code"""trait ${m1}A${m2}
+           class ${m3}B${m4} extends ${m5}A${m6}""".withSource
+      .implementation(m1 to m2, List(m3 to m4))
+      .implementation(m3 to m4, List(m3 to m4))
+      .implementation(m5 to m6, List(m3 to m4))
+  }
+
+  @Test def extendsClass: Unit = {
+    code"""class ${m1}A${m2}
+           class ${m3}B${m4} extends ${m5}A${m6}""".withSource
+      .implementation(m1 to m2, List(m1 to m2, m3 to m4))
+      .implementation(m3 to m4, List(m3 to m4))
+      .implementation(m5 to m6, List(m1 to m2, m3 to m4))
+  }
+
+  @Test def objExtendsTrait: Unit = {
+    code"""trait ${m1}A${m2}
+           object ${m3}B${m4} extends ${m5}A${m6}""".withSource
+      .implementation(m1 to m2, List(m3 to m4))
+      .implementation(m3 to m4, List(m3 to m4))
+      .implementation(m5 to m6, List(m3 to m4))
+  }
+
+  @Test def defineAbstractType: Unit = {
+    code"""trait A { type ${m1}T${m2} }
+           trait B extends A { type ${m3}T${m4} = Int }""".withSource
+      .implementation(m1 to m2, List(m3 to m4))
+      .implementation(m3 to m4, List(m3 to m4))
+  }
+
+  @Test def innerClass: Unit = {
+    code"""trait A { trait ${m1}AA${m2} }
+           class B extends A {
+             class ${m3}AB${m4} extends ${m5}AA${m6}
+           }""".withSource
+      .implementation(m1 to m2, List(m3 to m4))
+      .implementation(m3 to m4, List(m3 to m4))
+      .implementation(m5 to m6, List(m3 to m4))
+  }
+
+}

--- a/language-server/test/dotty/tools/languageserver/util/CodeTester.scala
+++ b/language-server/test/dotty/tools/languageserver/util/CodeTester.scala
@@ -158,6 +158,15 @@ class CodeTester(projects: List[Project]) {
   def cancelRun(marker: CodeMarker, afterMs: Long): this.type =
     doAction(new WorksheetCancel(marker, afterMs))
 
+  /**
+   * Find implementations of the symbol in `range`, compares that the results match `expected.
+   *
+   * @param range    The range of position over which to run `textDocument/implementation`.
+   * @param expected The expected result.
+   */
+  def implementation(range: CodeRange, expected: List[CodeRange]): this.type =
+    doAction(new Implementation(range, expected))
+
   private def doAction(action: Action): this.type = {
     try {
       action.execute()(testServer, testServer.client, positions)

--- a/language-server/test/dotty/tools/languageserver/util/actions/Implementation.scala
+++ b/language-server/test/dotty/tools/languageserver/util/actions/Implementation.scala
@@ -1,0 +1,36 @@
+package dotty.tools.languageserver.util.actions
+
+import dotty.tools.languageserver.util.embedded.CodeMarker
+import dotty.tools.languageserver.util.{CodeRange, PositionContext}
+
+import org.eclipse.lsp4j.Location
+
+import org.junit.Assert.assertEquals
+
+import scala.collection.JavaConverters._
+
+/**
+ * An action requesting the implementations of the symbol inside `range`.
+ * This action corresponds to the `textDocument/implementation` method of the Language Server
+ * Protocol.
+ *
+ * @param range    The range of position for which to request implementations.
+ * @param expected The expected results.
+ */
+class Implementation(override val range: CodeRange, expected: List[CodeRange]) extends ActionOnRange {
+
+  private implicit val LocationOrdering: Ordering[Location] = Ordering.by(_.toString)
+
+  override def onMarker(marker: CodeMarker): Exec[Unit] = {
+    val expectedLocations = expected.map(_.toLocation)
+    val results: Seq[org.eclipse.lsp4j.Location] = server.implementation(marker.toTextDocumentPositionParams).get().asScala
+
+    assertEquals(expectedLocations.length, results.length)
+    expectedLocations.sorted.zip(results.sorted).foreach {
+      assertEquals(_, _)
+    }
+  }
+
+  override def show: PositionContext.PosCtx[String] =
+    s"Implementation(${range.show}, $expected)"
+}


### PR DESCRIPTION
Works with `⌘F12` / `<ctrl>F12`, or `Go > Go to Implementation` 

Depends on #5209, only the last commit is new.