### PR TITLE
Fix #5140: Ycheck failure in covariant java varargs

### DIFF
--- a/tests/pos/i5140/J.java
+++ b/tests/pos/i5140/J.java
@@ -1,0 +1,5 @@
+class Animal {}
+class Dog extends Animal {}
+class J {
+  void foo(Animal... animal) {}
+}

--- a/tests/pos/i5140/S.scala
+++ b/tests/pos/i5140/S.scala
@@ -1,0 +1,9 @@
+class S {
+  val j = new J()
+  val x: Array[Dog] = ???
+  // Check that the java varargs for `foo` gets typed as `Array[_ <: Animal]`.
+  // Otherwise, the call below would fail in -Ycheck:elimRepeated because arrays are invariant before erasure.
+  // This is unsound but allowed.
+  j.foo(x: _*)
+  j.foo(new Dog, new Dog)
+}


### PR DESCRIPTION
Allow passing `Array[Dog]` to a Java varargs that expects an
`Array[Animal]`. This types because Java vargs are represented as
`RepeatedParam[+T]`, which is covariant.

However, after `elimRepeated`, the `RP`s go away and the true type
(Array) is revealed, which was causing a Ycheck error because arrays are
invariant before erasure.

Fix the Ycheck error by casting `Array[Dog]` to `Array[Animal]`. This is
unsound but consistent with the typer behaviour and what scalac does.