### PR TITLE
Give point position to synthetic class parent

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1675,7 +1675,7 @@ class Typer extends Namer
   /** Ensure that first parent tree refers to a real class. */
   def ensureFirstTreeIsClass(parents: List[Tree], pos: Position)(implicit ctx: Context): List[Tree] = parents match {
     case p :: ps if p.tpe.classSymbol.isRealClass => parents
-    case _ => TypeTree(ensureFirstIsClass(parents.tpes, pos).head).withPos(pos) :: parents
+    case _ => TypeTree(ensureFirstIsClass(parents.tpes, pos).head).withPos(pos.focus) :: parents
   }
 
   /** If this is a real class, make sure its first parent is a

--- a/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
@@ -219,4 +219,34 @@ class DefinitionTest {
     ).definition(m3 to m4, List(m1 to m2))
   }
 
+  @Test def definitionAnonClassTrait: Unit = {
+    code"""trait ${m1}Foo${m2} { val x = 0 }
+           class C {
+             def foo = new ${m3}Foo${m4} {}
+           }""".withSource
+      .definition(m1 to m2, List(m1 to m2))
+      .definition(m3 to m4, List(m1 to m2))
+  }
+
+  @Test def definitionAnonClassClass: Unit = {
+    code"""abstract class ${m1}Foo${m2} { val x = 0 }
+           class C {
+             def foo = new ${m3}Foo${m4} {}
+           }""".withSource
+      .definition(m1 to m2, List(m1 to m2))
+      .definition(m3 to m4, List(m1 to m2))
+  }
+
+  @Test def definitionAnonClassClassTrait: Unit = {
+    code"""abstract class ${m1}Foo${m2}
+           trait ${m3}Bar${m4}
+           class C {
+             def foo = new ${m5}Foo${m6} with ${m7}Bar${m8} {}
+           }""".withSource
+      .definition(m1 to m2, List(m1 to m2))
+      .definition(m3 to m4, List(m3 to m4))
+      .definition(m5 to m6, List(m1 to m2))
+      .definition(m7 to m8, List(m3 to m4))
+  }
+
 }

--- a/language-server/test/dotty/tools/languageserver/ReferencesTest.scala
+++ b/language-server/test/dotty/tools/languageserver/ReferencesTest.scala
@@ -48,4 +48,15 @@ class ReferencesTest {
       .references(m7 to m8, List(m7 to m8), withDecl = false)
   }
 
+  @Test def anonClassTrait: Unit = {
+    code"""trait ${m1}Foo${m2}
+           object O {
+             val foo = new ${m3}Foo${m4} {}
+           }""".withSource
+      .references(m1 to m2, List(m1 to m2, m3 to m4), withDecl = true)
+      .references(m1 to m2, List(m3 to m4), withDecl = false)
+      .references(m3 to m4, List(m1 to m2, m3 to m4), withDecl = true)
+      .references(m3 to m4, List(m3 to m4), withDecl = false)
+  }
+
 }


### PR DESCRIPTION
Classes that extend only traits are given a synthetic parent class. The
position that is given to this parent is now synthetic.

This prevents the `extends <parent>` to be selected by mistake by the
IDE.