### PR TITLE
Fix #5419: explicit result types for _N in case classes

### DIFF
--- a/tests/neg/t1843-variances.scala
+++ b/tests/neg/t1843-variances.scala
@@ -6,7 +6,7 @@
 
 object Crash {
   trait UpdateType[A]
-  case class StateUpdate[+A](updateType : UpdateType[A], value : A) // error // error
+  case class StateUpdate[+A](updateType : UpdateType[A], value : A) // error
   case object IntegerUpdateType extends UpdateType[Integer]
 
   //However this method will cause a crash

--- a/tests/pos/case-getters.scala
+++ b/tests/pos/case-getters.scala
@@ -1,0 +1,8 @@
+case class Foo(x: 1, y: implicit Int => Int)
+object Test {
+  val f = Foo(1, implicit (i: Int) => i)
+  val fx1: 1 = f.x
+  val fx2: 1 = f._1
+  val fy1: Int = f.y(1)
+  val fy2: Int = f._2(1)
+}


### PR DESCRIPTION
In general this is necessary to avoid widening, but it's especially needed
when using an implicit function type as a case class parameter type.