### PR TITLE
Fix #5422: prefer type tp1 in Typ(tp1) - Prod(tp2, ...)

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -243,7 +243,7 @@ trait SpaceLogic {
         else a
       case (Typ(tp1, _), Prod(tp2, fun, sym, ss, true)) =>
         // rationale: every instance of `tp1` is covered by `tp2(_)`
-        if (isSubType(tp1, tp2)) minus(Prod(tp2, fun, sym, signature(fun, sym, ss.length).map(Typ(_, false)), true), b)
+        if (isSubType(tp1, tp2)) minus(Prod(tp1, fun, sym, signature(fun, sym, ss.length).map(Typ(_, false)), true), b)
         else if (canDecompose(tp1)) tryDecompose1(tp1)
         else a
       case (_, Or(ss)) =>

--- a/tests/patmat/i5422.scala
+++ b/tests/patmat/i5422.scala
@@ -1,0 +1,21 @@
+import scala.language.higherKinds
+
+object Test {
+
+  trait X
+  case object Y extends X
+
+  sealed trait Foo[F[_], O] {
+    def bar: Foo[F, O] = this match {
+      case Qux(fa, f) => qux(fa) {
+        case Left(Y) => ???
+        case x => ???
+      }
+    }
+  }
+
+  case class Qux[F[_], A, O](fa: F[A], f: Either[X, A] => Int) extends Foo[F, O]
+
+  def qux[F[_], A, O](fa: F[A])(f: Either[X, A] => Int): Foo[F, O] =
+    Qux(fa, f)
+}


### PR DESCRIPTION
Fix #5422: prefer type tp1 in Typ(tp1) - Prod(tp2, ...)

In `Typ(tp1) - Prod(tp2, ...)` with `tp1 <: tp2`, we rewrite
`Typ(tp1)` to `Prod(tpx, Nil)`. We should prefer `tp1` over
`tp2`, as the latter is usually a bigger space, due to the
erasure of pattern bound symbol references during
pattern-space projection.