### PR TITLE
Fix #4948: final implicit class can be overridden

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -293,7 +293,7 @@ object desugar {
     val impl @ Template(constr0, parents, self, _) = cdef.rhs
     val mods = cdef.mods
     val companionMods = mods
-        .withFlags((mods.flags & AccessFlags).toCommonFlags)
+        .withFlags((mods.flags & (AccessFlags | Final)).toCommonFlags)
         .withMods(Nil)
 
     var defaultGetters: List[Tree] = Nil

--- a/tests/neg/overrideFinalImplicit.scala
+++ b/tests/neg/overrideFinalImplicit.scala
@@ -1,0 +1,7 @@
+class Implicits {
+  final implicit class FooExtender(foo: String)
+}
+
+class Test extends Implicits {
+  override implicit def FooExtender(foo: String) = super.FooExtender(foo) // error
+}


### PR DESCRIPTION
https://github.com/lampepfl/dotty/issues/4948