### PR TITLE
Small improvements to `workspace/symbol`

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -324,7 +324,10 @@ object Interactive {
 
   /** Find named trees with a non-empty position satisfying `treePredicate` in `trees`.
    *
-   *  @param includeReferences  If true, include references and not just definitions
+   *  @param trees         The trees to inspect.
+   *  @param include       Whether to include references, definitions, etc.
+   *  @param treePredicate An additional predicate that the trees must match.
+   *  @return The trees with a non-empty position satisfying `treePredicate`.
    */
   def namedTrees(trees: List[SourceTree],
                  include: Include.Set,

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -317,14 +317,6 @@ object Interactive {
     else
       namedTrees(trees, include, matchSymbol(_, sym, include))
 
-  /** Find named trees with a non-empty position whose name contains `nameSubstring` in `trees`.
-   */
-  def namedTrees(trees: List[SourceTree], nameSubstring: String)
-   (implicit ctx: Context): List[SourceTree] = {
-    val predicate: NameTree => Boolean = _.name.toString.contains(nameSubstring)
-    namedTrees(trees, Include.empty, predicate)
-  }
-
   /** Find named trees with a non-empty position satisfying `treePredicate` in `trees`.
    *
    *  @param includeReferences  If true, include references and not just definitions

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -338,6 +338,7 @@ object Interactive {
               val tree = utree.asInstanceOf[tpd.NameTree]
               if (tree.symbol.exists
                    && !tree.symbol.is(Synthetic)
+                   && !tree.symbol.isPrimaryConstructor
                    && tree.pos.exists
                    && !tree.pos.isZeroExtent
                    && (include.isReferences || isDefinition(tree))
@@ -373,8 +374,7 @@ object Interactive {
                        )(implicit ctx: Context): List[SourceTree] = {
     val linkedSym = symbol.linkedClass
     val fullPredicate: NameTree => Boolean = tree =>
-      (  !tree.symbol.isPrimaryConstructor
-      && (includes.isDefinitions || !Interactive.isDefinition(tree))
+      (  (includes.isDefinitions || !Interactive.isDefinition(tree))
       && (  Interactive.matchSymbol(tree, symbol, includes)
          || ( includes.isLinkedClass
             && linkedSym.exists

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -457,10 +457,7 @@ class DottyLanguageServer extends LanguageServer
     implicit val ctx = driver.currentCtx
 
     val uriTrees = driver.openedTrees(uri)
-    val predicate = (tree: NameTree) => {
-      val sym = tree.symbol
-      !sym.isLocal && !sym.isPrimaryConstructor
-    }
+    val predicate = (tree: NameTree) => !tree.symbol.isLocal
 
     val defs = Interactive.namedTrees(uriTrees, Include.empty, predicate)
     (for {
@@ -473,7 +470,7 @@ class DottyLanguageServer extends LanguageServer
     val query = params.getQuery
     def predicate(implicit ctx: Context): NameTree => Boolean = { tree =>
       val sym = tree.symbol
-      !sym.isLocal && !sym.isPrimaryConstructor && tree.name.toString.contains(query)
+      !sym.isLocal && tree.name.toString.contains(query)
     }
 
     drivers.values.toList.flatMap { driver =>

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -459,7 +459,7 @@ class DottyLanguageServer extends LanguageServer
     val uriTrees = driver.openedTrees(uri)
     val predicate = (tree: NameTree) => {
       val sym = tree.symbol
-      sym.exists && !sym.isLocal && !sym.isPrimaryConstructor && !sym.is(Synthetic)
+      !sym.isLocal && !sym.isPrimaryConstructor
     }
 
     val defs = Interactive.namedTrees(uriTrees, Include.empty, predicate)
@@ -471,8 +471,10 @@ class DottyLanguageServer extends LanguageServer
 
   override def symbol(params: WorkspaceSymbolParams) = computeAsync { cancelToken =>
     val query = params.getQuery
-    def predicate(implicit ctx: Context): NameTree => Boolean =
-      tree => tree.symbol.exists && !tree.symbol.isLocal && tree.name.toString.contains(query)
+    def predicate(implicit ctx: Context): NameTree => Boolean = { tree =>
+      val sym = tree.symbol
+      !sym.isLocal && !sym.isPrimaryConstructor && tree.name.toString.contains(query)
+    }
 
     drivers.values.toList.flatMap { driver =>
       implicit val ctx = driver.currentCtx

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -470,7 +470,7 @@ class DottyLanguageServer extends LanguageServer
     drivers.values.toList.flatMap { driver =>
       implicit val ctx = driver.currentCtx
 
-      val trees = driver.allTrees
+      val trees = driver.sourceTreesContaining(query)
       val defs = Interactive.namedTrees(trees, nameSubstring = query)
       defs.flatMap(d => symbolInfo(d.tree.symbol, d.namePos, positionMapperFor(d.source)))
     }.asJava

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -457,8 +457,12 @@ class DottyLanguageServer extends LanguageServer
     implicit val ctx = driver.currentCtx
 
     val uriTrees = driver.openedTrees(uri)
+    val predicate = (tree: NameTree) => {
+      val sym = tree.symbol
+      sym.exists && !sym.isLocal && !sym.isPrimaryConstructor && !sym.is(Synthetic)
+    }
 
-    val defs = Interactive.namedTrees(uriTrees, Include.empty, _ => true)
+    val defs = Interactive.namedTrees(uriTrees, Include.empty, predicate)
     (for {
       d <- defs if !isWorksheetWrapper(d)
       info <- symbolInfo(d.tree.symbol, d.namePos, positionMapperFor(d.source))
@@ -474,7 +478,7 @@ class DottyLanguageServer extends LanguageServer
       implicit val ctx = driver.currentCtx
 
       val trees = driver.sourceTreesContaining(query)
-      val defs = Interactive.namedTrees(trees, includeReferences = false, predicate)
+      val defs = Interactive.namedTrees(trees, Include.empty, predicate)
       defs.flatMap(d => symbolInfo(d.tree.symbol, d.namePos, positionMapperFor(d.source)))
     }.asJava
   }

--- a/language-server/test/dotty/tools/languageserver/DocumentSymbolTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DocumentSymbolTest.scala
@@ -38,4 +38,10 @@ class DocumentSymbolTest {
       .documentSymbol(m1, (m1 to m2).symInfo("Foo", SymbolKind.Module),
                           (m3 to m4).symInfo("Foo", SymbolKind.Class))
   }
+
+  @Test def documentSymbolSynthetic: Unit = {
+    code"""case class ${m1}Foo${m2}(${m3}x${m4}: Int)""".withSource
+      .documentSymbol(m1, (m1 to m2).symInfo("Foo", SymbolKind.Class),
+                          (m3 to m4).symInfo("x", SymbolKind.Field, "Foo"))
+  }
 }

--- a/language-server/test/dotty/tools/languageserver/ReferencesTest.scala
+++ b/language-server/test/dotty/tools/languageserver/ReferencesTest.scala
@@ -346,4 +346,14 @@ class ReferencesTest {
      .references(m11 to m12, List(m9 to m10, m11 to m12), withDecl = false)
   }
 
+  @Test def referenceInsideLocalMember: Unit = {
+    withSources(
+      code"""object A {
+            |  val ${m1}foo${m2} = 0
+            |  def fizz = println(${m3}foo${m4})
+            |}"""
+    ).references(m1 to m2, List(m1 to m2, m3 to m4), withDecl = true)
+     .references(m1 to m2, List(m3 to m4), withDecl = false)
+  }
+
 }

--- a/language-server/test/dotty/tools/languageserver/SymbolTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SymbolTest.scala
@@ -39,4 +39,19 @@ class SymbolTest {
       .symbol("Foo", (m1 to m2).symInfo("Foo", SymbolKind.Module),
                      (m3 to m4).symInfo("Foo", SymbolKind.Class))
   }
+
+  @Test def multipleProjects0: Unit = {
+    val p0 = Project.withSources(
+      code"""class ${m1}Foo${m2}"""
+    )
+
+    val p1 = Project.dependingOn(p0).withSources(
+      code"""class ${m3}Bar${m4} extends Foo"""
+    )
+
+    withProjects(p0, p1)
+      .symbol("Foo", (m1 to m2).symInfo("Foo", SymbolKind.Class))
+
+
+  }
 }

--- a/language-server/test/dotty/tools/languageserver/SymbolTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SymbolTest.scala
@@ -51,7 +51,14 @@ class SymbolTest {
 
     withProjects(p0, p1)
       .symbol("Foo", (m1 to m2).symInfo("Foo", SymbolKind.Class))
+  }
 
-
+  @Test def noLocalSymbols: Unit = {
+    code"""object O {
+             def foo = {
+               val hello = 0
+             }
+           }""".withSource
+      .symbol("hello")
   }
 }


### PR DESCRIPTION
 - Inspect only source trees
 - Exclude local symbols