### PR TITLE
Reduce size of generated code for lazy fields

### DIFF
--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -546,4 +546,23 @@ class TestBCode extends DottyBytecodeTest {
       assertFalse(doBox)
     }
   }
+
+  /** Test that the size of lazy field accesors is under a certain threshold
+   *
+   *  - Changed from 19 to 14
+   */
+  @Test def lazyFields = {
+    val source =
+      """class Test {
+        |  lazy val test = 1
+        |}
+      """.stripMargin
+
+    checkBCode(source) { dir =>
+      val clsIn   = dir.lookupName("Test.class", directory = false).input
+      val clsNode = loadClassNode(clsIn)
+      val method  = getMethod(clsNode, "test")
+      assertEquals(14, instructionsFromMethod(method).size)
+    }
+  }
 }


### PR DESCRIPTION
For `lazy val x = <RHS>`:

Before:
```scala
def x() =
  if (flag) target
  else {
    target = <RHS>
    flag = true
    target
  }
```

After:
```scala
def x() = {
  if (!flag) {
    target = <RHS>
    flag = true
  }
  target
}
```