### PR TITLE
[DO NOT MERGE] Scala 2 style lazy field implementation

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -86,11 +86,11 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
            !sym.is(Flags.Synthetic))
             // module class is user-defined.
             // Should be threadsafe, to mimic safety guaranteed by global object
-          transformMemberDefVolatile(tree)
+          transformMemberDefScala2Compat(tree)
         else if (sym.is(Flags.Module)) // synthetic module
           transformSyntheticModule(tree)
         else
-          transformMemberDefNonVolatile(tree)
+          transformMemberDefScala2Compat(tree)
       }
       else transformLocalDef(tree)
     }


### PR DESCRIPTION
Desugar a lazy field `lazy val x: Int = <RHS>` into:

```scala
private var container: Int = _
@volatile private var flag: Boolean = _

private def x$lzycompute(): Int = this.synchronized {
  if (!flag) {
    container = <RHS>
    flag = true
    nullable = null
  }
  container
}

def x(): Int = if (flag) container else x$lzycompute()
```