### PR TITLE
Fix crash when `showMessageRequest` is discarded

### DIFF
--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -594,10 +594,11 @@ class DottyLanguageServer extends LanguageServer
     request.setMessage(message)
     request.setType(tpe)
 
-    client.showMessageRequest(request).thenApply { (answer: MessageActionItem) =>
-      choices.find(_._1 == answer.getTitle).map {
-        case (_, action) => action()
-      }
+    client.showMessageRequest(request).thenApply { (message: MessageActionItem) =>
+      for {
+        answer <- Option(message)
+        (_, action) <- choices.find(_._1 == answer.getTitle)
+      } yield action()
     }
   }
 }


### PR DESCRIPTION
When the client discards a `showMessageRequest`, it replies with `null`,
which caused a crash of the language server.