### PR TITLE
Fix missing argument in spec's pseudocode

### DIFF
--- a/docs/docs/reference/changed/lazy-vals-spec.md
+++ b/docs/docs/reference/changed/lazy-vals-spec.md
@@ -40,7 +40,7 @@ class Foo {
       flag = LazyVals.get(this, bitmap_offset)
       LazyVals.STATE(flag, <field-id>) match {
         case <state-0> =>
-          if (LazyVals.CAS(this, bitmap_offset, flag, <state-1>)) {
+          if (LazyVals.CAS(this, bitmap_offset, flag, <state-1>, <field-id>)) {
             try result = <RHS>
             catch {
               case ex =>


### PR DESCRIPTION
Reading the code is tricky enough without such issues (`LazyVals.scala` could use docs on parameter names).