### PR TITLE
Restrict visibility of copy and apply

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -658,8 +658,6 @@ object desugar {
     flatTree(cdef1 :: companions ::: implicitWrappers)
   }
 
-  val AccessOrSynthetic: FlagSet = AccessFlags | Synthetic
-
   /** Expand
    *
    *    object name extends parents { self => body }

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -469,7 +469,7 @@ object desugar {
           val copyRestParamss = derivedVparamss.tail.nestedMap(vparam =>
             cpy.ValDef(vparam)(rhs = EmptyTree))
           DefDef(nme.copy, derivedTparams, copyFirstParams :: copyRestParamss, TypeTree(), creatorExpr)
-            .withMods(synthetic) :: Nil
+            .withFlags(Synthetic | constr1.mods.flags & AccessFlags) :: Nil
         }
       }
 
@@ -574,7 +574,7 @@ object desugar {
           if (mods is Abstract) Nil
           else
             DefDef(nme.apply, derivedTparams, derivedVparamss, applyResultTpt, widenedCreatorExpr)
-              .withFlags(Synthetic | (constr1.mods.flags & DefaultParameterized)) :: widenDefs
+              .withFlags(Synthetic | constr1.mods.flags & (DefaultParameterized | AccessFlags)) :: widenDefs
         val unapplyMeth = {
           val unapplyParam = makeSyntheticParameter(tpt = classTypeRef)
           val unapplyRHS = if (arity == 0) Literal(Constant(true)) else Ident(unapplyParam.name)

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -327,6 +327,11 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
     }
     scala2Mode
   }
+
+  /** Is option -language:Scala2 set?
+   *  This test is used when we are too early in the pipeline to consider imports.
+   */
+  def scala2Setting = ctx.settings.language.value.contains(nme.Scala2.toString)
 }
 
 object TypeOps {

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -22,7 +22,7 @@ object Interactive {
   import ast.tpd._
 
   object Include {
-    case class Set private (val bits: Int) extends AnyVal {
+    case class Set private[Include] (val bits: Int) extends AnyVal {
       def | (that: Set): Set = Set(bits | that.bits)
       def except(that: Set): Set = Set(bits & ~that.bits)
 

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -242,7 +242,7 @@ object Scanners {
 
 // Scala 2 compatibility
 
-    val isScala2Mode: Boolean = ctx.settings.language.value.contains(nme.Scala2.toString)
+    val isScala2Mode: Boolean = ctx.scala2Setting
 
     /** Cannot use ctx.featureEnabled because accessing the context would force too much */
     def testScala2Mode(msg: String, pos: Position = Position(offset)): Boolean = {

--- a/tests/neg/private-case-class-constr.scala
+++ b/tests/neg/private-case-class-constr.scala
@@ -1,0 +1,10 @@
+case class Nat private (value: Int)
+object Nat {
+  def apply(value: Int, disable: Boolean): Option[Nat] =
+    if (value < 0 || disable) None else Some(new Nat(value))
+}
+object Test {
+  val n1o = Nat(2) // error
+  val n2o = Nat(2, false) // ok
+  for (n <- n2o) yield n.copy() // error
+}

--- a/tests/pos/i4564.scala
+++ b/tests/pos/i4564.scala
@@ -51,7 +51,7 @@ class BaseNCP[T] {
 }
 
 object NoClashPoly extends BaseNCP[Boolean]
-case class NoClashPoly private(x: Int)
+case class NoClashPoly (x: Int)
 
 
 class BaseCP[T] {


### PR DESCRIPTION
Make the synthesized copy and apply methods of a case class have the
same visibility as its private constructor.

I believe it would make sense to spec it that way.
