### PR TITLE
Rename reflect/reify and make them plain methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/QuotedOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/QuotedOpsImpl.scala
@@ -8,16 +8,16 @@ import dotty.tools.dotc.reporting.diagnostic.MessageContainer
 trait QuotedOpsImpl extends scala.tasty.reflect.QuotedOps with CoreImpl {
 
   def QuotedExprDeco[T](x: scala.quoted.Expr[T]): QuotedExprAPI = new QuotedExprAPI {
-    def reflect(implicit ctx: Context): Term = PickledQuotes.quotedExprToTree(x)
+    def unseal(implicit ctx: Context): Term = PickledQuotes.quotedExprToTree(x)
   }
 
   def QuotedTypeDeco[T](x: scala.quoted.Type[T]): QuotedTypeAPI = new QuotedTypeAPI {
-    def reflect(implicit ctx: Context): TypeTree = PickledQuotes.quotedTypeToTree(x)
+    def unseal(implicit ctx: Context): TypeTree = PickledQuotes.quotedTypeToTree(x)
   }
 
   def TermToQuoteDeco(term: Term): TermToQuotedAPI = new TermToQuotedAPI {
 
-    def reify[T: scala.quoted.Type](implicit ctx: Context): scala.quoted.Expr[T] = {
+    def seal[T: scala.quoted.Type](implicit ctx: Context): scala.quoted.Expr[T] = {
       typecheck(ctx)
       new scala.quoted.Exprs.TastyTreeExpr(term).asInstanceOf[scala.quoted.Expr[T]]
     }
@@ -28,7 +28,7 @@ trait QuotedOpsImpl extends scala.tasty.reflect.QuotedOps with CoreImpl {
       ctx0.typerState.setReporter(new Reporter {
         def doReport(m: MessageContainer)(implicit ctx: Context): Unit = ()
       })
-      val tp = QuotedTypeDeco(implicitly[scala.quoted.Type[T]]).reflect
+      val tp = QuotedTypeDeco(implicitly[scala.quoted.Type[T]]).unseal
       ctx0.typer.typed(term, tp.tpe)
       if (ctx0.reporter.hasErrors) {
         val stack = new Exception().getStackTrace

--- a/docs/docs/reference/tasty-reflect.md
+++ b/docs/docs/reference/tasty-reflect.md
@@ -1,13 +1,13 @@
 ---
 layout: doc-page
-title: "TASTy reflect"
+title: "TASTy Reflect"
 ---
 
 TASTy Reflect enables inspection and construction of Typed Abstract Syntax Trees (TAST).
 It may be used on quoted expressions (`quoted.Expr`) and quoted types (`quoted.Type`) from [Principled Meta-programming](./principled-meta-programming.html)
 or on full TASTy files.
 
-If you are writing macros, please first read [Principled Meta-programming](./principled-meta-programming.html). 
+If you are writing macros, please first read [Principled Meta-programming](./principled-meta-programming.html).
 You may find all you need without using TASTy Reflect.
 
 
@@ -32,13 +32,13 @@ def natConstImpl(x: Expr[Int])(implicit reflection: Reflection): Expr[Int] = {
 }
 ```
 
-`import reflection._` will provide a `reflect` extension method on `quoted.Expr` and `quoted.Type` which return a `reflection.Term` and `reflection.TypeTree` respectively.
+`import reflection._` will provide a `unseal` extension method on `quoted.Expr` and `quoted.Type` which return a `reflection.Term` and `reflection.TypeTree` respectively.
 It will also import all extractors and methods on TASTy Reflect trees. For example the `Term.Literal(_)` extractor used below.
 
 ```scala
 def natConstImpl(x: Expr[Int])(implicit reflection: Reflection): Expr[Int] = {
   import reflection._
-  val xTree: Term = x.reflect
+  val xTree: Term = x.unseal
   xTree match {
     case Term.Literal(Constant.Int(n)) =>
       if (n <= 0)
@@ -53,9 +53,10 @@ def natConstImpl(x: Expr[Int])(implicit reflection: Reflection): Expr[Int] = {
 To easily know which extractors are needed, the `reflection.Term.show` method returns the string representation of the extractors.
 
 The method `reflection.Term.reify[T]` provides a way to to go back to a `quoted.Expr`.
-Note that the type must be set explicitly and that if it does not conform to it an exception will be thrown. 
+Note that the type must be set explicitly and that if it does not conform to it an exception will be thrown.
 In the code above we could have replaced `n.toExpr` by `xTree.reify[Int]`.
- 
+
+
 ## Inspect a TASTy file
 
 To inspect the TASTy Reflect trees of a TASTy file a consumer can be defined in the following way.
@@ -78,7 +79,7 @@ object Test {
   }
 }
 ```
- 
+
 ## TASTy Reflect API
 
 TASTy Reflect provides the following types:

--- a/library/src/scala/tasty/reflect/QuotedOps.scala
+++ b/library/src/scala/tasty/reflect/QuotedOps.scala
@@ -5,19 +5,19 @@ trait QuotedOps extends Core {
 
   trait QuotedExprAPI {
     /** View this expression `Expr[T]` as a `Term` */
-    def reflect(implicit ctx: Context): Term
+    def unseal(implicit ctx: Context): Term
   }
   implicit def QuotedExprDeco[T](expr: quoted.Expr[T]): QuotedExprAPI
 
   trait QuotedTypeAPI {
     /** View this expression `Type[T]` as a `TypeTree` */
-    def reflect(implicit ctx: Context): TypeTree
+    def unseal(implicit ctx: Context): TypeTree
   }
   implicit def QuotedTypeDeco[T](tpe: quoted.Type[T]): QuotedTypeAPI
 
   trait TermToQuotedAPI {
     /** Convert `Term` to an `Expr[T]` and check that it conforms to `T` */
-    def reify[T: scala.quoted.Type](implicit ctx: Context): scala.quoted.Expr[T]
+    def seal[T: scala.quoted.Type](implicit ctx: Context): scala.quoted.Expr[T]
   }
   implicit def TermToQuoteDeco(term: Term): TermToQuotedAPI
 

--- a/library/src/scala/tasty/util/ConstantExtractor.scala
+++ b/library/src/scala/tasty/util/ConstantExtractor.scala
@@ -25,6 +25,6 @@ class ConstantExtractor[R <: Reflection with Singleton](val reflect: Reflection)
       case Term.Inlined(_, Nil, e) => const(e)
       case _  => None
     }
-    const(expr.reflect)
+    const(expr.unseal)
   }
 }

--- a/tests/neg/tasty-macro-assert/quoted_1.scala
+++ b/tests/neg/tasty-macro-assert/quoted_1.scala
@@ -17,7 +17,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(implicit reflect: Reflection): Expr[Unit] = {
     import reflect._
 
-    val tree = cond.reflect
+    val tree = cond.unseal
 
     def isOps(tpe: TypeOrBounds): Boolean = tpe match {
       case Type.SymRef(IsDefSymbol(sym), _) => sym.name == "Ops" // TODO check that the parent is Asserts
@@ -34,7 +34,7 @@ object Asserts {
 
     tree match {
       case Term.Inlined(_, Nil, Term.Apply(Term.Select(OpsTree(left), op, _), right :: Nil)) =>
-        '(assertTrue(~left.reify[Boolean])) // Buggy code. To generate the errors
+        '(assertTrue(~left.seal[Boolean])) // Buggy code. To generate the errors
       case _ =>
         '(assertTrue(~cond))
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -13,7 +13,7 @@ object Foo {
       case IsValSymbol(sym) => sym.tree.show.toExpr
       case IsBindSymbol(sym) => sym.tree.show.toExpr
     }
-    x.reflect match {
+    x.unseal match {
       case Term.Inlined(None, Nil, arg) => definitionString(arg)
       case arg => definitionString(arg) // TODO should all by name parameters be in an inline node?
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -13,7 +13,7 @@ object Foo {
       case IsValSymbol(sym) => sym.tree.show.toExpr
       case IsBindSymbol(sym) => sym.tree.show.toExpr
     }
-    x.reflect match {
+    x.unseal match {
       case Term.Inlined(None, Nil, arg) => definitionString(arg)
       case arg => definitionString(arg) // TODO should all by name parameters be in an inline node?
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -40,7 +40,7 @@ object Macros {
       }
     }
 
-    val tree = x.reflect
+    val tree = x.unseal
     output.traverseTree(tree)
     '(print(~buff.result().toExpr))
   }

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
@@ -17,7 +17,7 @@ object Foo {
       case _ => '("NO DEFINTION")
     }
 
-    x.reflect match {
+    x.unseal match {
       case Term.Inlined(None, Nil, arg) => definitionString(arg)
       case arg => definitionString(arg) // TODO should all by name parameters be in an inline node
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
@@ -17,7 +17,7 @@ object Foo {
       case _ => '("NO DEFINTION")
     }
 
-    x.reflect match {
+    x.unseal match {
       case Term.Inlined(None, Nil, arg) => definitionString(arg)
       case arg => definitionString(arg) // TODO should all by name parameters be in an inline node
     }

--- a/tests/run-separate-compilation/gestalt-type-toolbox-reflect/Macro_1.scala
+++ b/tests/run-separate-compilation/gestalt-type-toolbox-reflect/Macro_1.scala
@@ -9,7 +9,7 @@ object TypeToolbox {
   inline def =:=[A, B]: Boolean = ~tpEqImpl('[A], '[B])
   private def tpEqImpl[A, B](a: Type[A], b: Type[B])(implicit reflect: Reflection): Expr[Boolean] = {
     import reflect._
-    val res = a.reflect.tpe =:= b.reflect.tpe
+    val res = a.unseal.tpe =:= b.unseal.tpe
     res.toExpr
   }
 
@@ -17,7 +17,7 @@ object TypeToolbox {
   inline def <:<[A, B]: Boolean = ~tpLEqImpl('[A], '[B])
   private def tpLEqImpl[A, B](a: Type[A], b: Type[B])(implicit reflect: Reflection): Expr[Boolean] = {
     import reflect._
-    val res = a.reflect.tpe <:< b.reflect.tpe
+    val res = a.unseal.tpe <:< b.unseal.tpe
     res.toExpr
   }
 
@@ -25,7 +25,7 @@ object TypeToolbox {
   inline def typeOf[T, Expected](a: T): Boolean = ~typeOfImpl('(a), '[Expected])
   private def typeOfImpl(a: Expr[_], expected: Type[_])(implicit reflect: Reflection): Expr[Boolean] = {
     import reflect._
-    val res = a.reflect.tpe =:= expected.reflect.tpe
+    val res = a.unseal.tpe =:= expected.unseal.tpe
     res.toExpr
   }
 
@@ -33,7 +33,7 @@ object TypeToolbox {
   inline def isCaseClass[A]: Boolean = ~isCaseClassImpl('[A])
   private def isCaseClassImpl(tp: Type[_])(implicit reflect: Reflection): Expr[Boolean] = {
     import reflect._
-    val res = tp.reflect.symbol match {
+    val res = tp.unseal.symbol match {
       case IsClassSymbol(sym) => sym.flags.isCase
       case _ => false
     }
@@ -44,66 +44,66 @@ object TypeToolbox {
   inline def caseFields[T]: List[String] = ~caseFieldsImpl('[T])
   private def caseFieldsImpl(tp: Type[_])(implicit reflect: Reflection): Expr[List[String]] = {
     import reflect._
-    val fields = tp.reflect.symbol.asClass.caseFields.map(_.name)
+    val fields = tp.unseal.symbol.asClass.caseFields.map(_.name)
     fields.toExpr
   }
 
   inline def fieldIn[T](inline mem: String): String = ~fieldInImpl('[T], mem)
   private def fieldInImpl(t: Type[_], mem: String)(implicit reflect: Reflection): Expr[String] = {
     import reflect._
-    val field = t.reflect.symbol.asClass.field(mem)
+    val field = t.unseal.symbol.asClass.field(mem)
     field.map(_.name).getOrElse("").toExpr
   }
 
   inline def fieldsIn[T]: Seq[String] = ~fieldsInImpl('[T])
   private def fieldsInImpl(t: Type[_])(implicit reflect: Reflection): Expr[Seq[String]] = {
     import reflect._
-    val fields = t.reflect.symbol.asClass.fields
+    val fields = t.unseal.symbol.asClass.fields
     fields.map(_.name).toList.toExpr
   }
 
   inline def methodIn[T](inline mem: String): Seq[String] = ~methodInImpl('[T], mem)
   private def methodInImpl(t: Type[_], mem: String)(implicit reflect: Reflection): Expr[Seq[String]] = {
     import reflect._
-    t.reflect.symbol.asClass.classMethod(mem).map(_.name).toExpr
+    t.unseal.symbol.asClass.classMethod(mem).map(_.name).toExpr
   }
 
   inline def methodsIn[T]: Seq[String] = ~methodsInImpl('[T])
   private def methodsInImpl(t: Type[_])(implicit reflect: Reflection): Expr[Seq[String]] = {
     import reflect._
-    t.reflect.symbol.asClass.classMethods.map(_.name).toExpr
+    t.unseal.symbol.asClass.classMethods.map(_.name).toExpr
   }
 
   inline def method[T](inline mem: String): Seq[String] = ~methodImpl('[T], mem)
   private def methodImpl(t: Type[_], mem: String)(implicit reflect: Reflection): Expr[Seq[String]] = {
     import reflect._
-    t.reflect.symbol.asClass.method(mem).map(_.name).toExpr
+    t.unseal.symbol.asClass.method(mem).map(_.name).toExpr
   }
 
   inline def methods[T]: Seq[String] = ~methodsImpl('[T])
   private def methodsImpl(t: Type[_])(implicit reflect: Reflection): Expr[Seq[String]] = {
     import reflect._
-    t.reflect.symbol.asClass.methods.map(_.name).toExpr
+    t.unseal.symbol.asClass.methods.map(_.name).toExpr
   }
 
   inline def typeTag[T](x: T): String = ~typeTagImpl('[T])
   private def typeTagImpl(tp: Type[_])(implicit reflect: Reflection): Expr[String] = {
     import reflect._
-    val res = tp.reflect.tpe.showCode
+    val res = tp.unseal.tpe.showCode
     res.toExpr
   }
 
   inline def companion[T1, T2]: Boolean = ~companionImpl('[T1], '[T2])
   private def companionImpl(t1: Type[_], t2: Type[_])(implicit reflect: Reflection): Expr[Boolean] = {
     import reflect._
-    val res = t1.reflect.symbol.asClass.companionModule.contains(t2.reflect.symbol)
+    val res = t1.unseal.symbol.asClass.companionModule.contains(t2.unseal.symbol)
     res.toExpr
   }
 
   inline def companionName[T1]: String = ~companionNameImpl('[T1])
   private def companionNameImpl(tp: Type[_])(implicit reflect: Reflection): Expr[String] = {
     import reflect._
-    val companionClassOpt = tp.reflect.symbol match {
+    val companionClassOpt = tp.unseal.symbol match {
       case IsClassSymbol(sym) => sym.companionClass
       case IsValSymbol(sym) => sym.companionClass
       case _ => None

--- a/tests/run-separate-compilation/i5119/Macro_1.scala
+++ b/tests/run-separate-compilation/i5119/Macro_1.scala
@@ -8,6 +8,6 @@ object Macro {
   implicit inline def XmlQuote(sc: => StringContext): StringContextOps = new StringContextOps(sc)
   def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(implicit reflect: Reflection): Expr[String] = {
     import reflect._
-    (sc.reflect.underlyingArgument.show + "\n" + args.reflect.underlyingArgument.show).toExpr
+    (sc.unseal.underlyingArgument.show + "\n" + args.unseal.underlyingArgument.show).toExpr
   }
 }

--- a/tests/run-separate-compilation/i5119b/Macro_1.scala
+++ b/tests/run-separate-compilation/i5119b/Macro_1.scala
@@ -7,7 +7,7 @@ object Macro {
 
   def impl(arg1: Expr[Any], arg2: Expr[Any])(implicit reflect: Reflection): Expr[String] = {
     import reflect._
-    (arg1.reflect.underlyingArgument.show + "\n" + arg2.reflect.underlyingArgument.show).toExpr
+    (arg1.unseal.underlyingArgument.show + "\n" + arg2.unseal.underlyingArgument.show).toExpr
   }
 
 }

--- a/tests/run-separate-compilation/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-argument-tree-1/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
 
   def impl[T](x: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
     import reflect._
-    val tree = x.reflect
+    val tree = x.unseal
     '{
       println()
       println("tree: " + ~tree.show.toExpr)

--- a/tests/run-separate-compilation/tasty-custom-show/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-custom-show/quoted_1.scala
@@ -33,7 +33,7 @@ object Macros {
       }
     }
 
-    val tree = x.reflect
+    val tree = x.unseal
     output.traverseTree(tree)
     '(print(~buff.result().toExpr))
   }

--- a/tests/run-separate-compilation/tasty-eval/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-eval/quoted_1.scala
@@ -21,7 +21,7 @@ object Macros {
     override def value(e: Expr[Int])(implicit reflect: Reflection): Option[Int] = {
       import reflect._
 
-      e.reflect.tpe match {
+      e.unseal.tpe match {
         case Type.SymRef(IsValSymbol(sym), pre) =>
           sym.tree.tpt.tpe match {
             case Type.ConstantType(Constant.Int(i)) => Some(i)

--- a/tests/run-separate-compilation/tasty-extractors-1/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-extractors-1/quoted_1.scala
@@ -10,7 +10,7 @@ object Macros {
   def impl[T](x: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
     import reflect._
 
-    val tree = x.reflect
+    val tree = x.unseal
     val treeStr = tree.show
     val treeTpeStr = tree.tpe.show
 

--- a/tests/run-separate-compilation/tasty-extractors-2/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-extractors-2/quoted_1.scala
@@ -10,7 +10,7 @@ object Macros {
   def impl[T](x: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
     import reflect._
 
-    val tree = x.reflect
+    val tree = x.unseal
 
     val treeStr = tree.show
     val treeTpeStr = tree.tpe.show

--- a/tests/run-separate-compilation/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-extractors-3/quoted_1.scala
@@ -19,7 +19,7 @@ object Macros {
       }
     }
 
-    val tree = x.reflect
+    val tree = x.unseal
     traverser.traverseTree(tree)
     '(print(~buff.result().toExpr))
   }

--- a/tests/run-separate-compilation/tasty-extractors-types/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-extractors-types/quoted_1.scala
@@ -9,7 +9,7 @@ object Macros {
   def impl[T](x: Type[T])(implicit reflect: Reflection): Expr[Unit] = {
     import reflect._
 
-    val tree = x.reflect
+    val tree = x.unseal
     '{
       println(~tree.show.toExpr)
       println(~tree.tpe.show.toExpr)

--- a/tests/run-separate-compilation/tasty-indexed-map/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-indexed-map/quoted_1.scala
@@ -38,8 +38,8 @@ object Index {
       case _ => Nil
     }
 
-    val key = name(k.reflect.tpe)
-    val keys = name(h.reflect.tpe) :: names(t.reflect.tpe)
+    val key = name(k.unseal.tpe)
+    val keys = name(h.unseal.tpe) :: names(t.unseal.tpe)
 
     val index = keys.indexOf(key)
 

--- a/tests/run-separate-compilation/tasty-macro-assert/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-macro-assert/quoted_1.scala
@@ -17,7 +17,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(implicit reflect: Reflection): Expr[Unit] = {
     import reflect._
 
-    val tree = cond.reflect
+    val tree = cond.unseal
 
     def isOps(tpe: TypeOrBounds): Boolean = tpe match {
       case Type.SymRef(IsDefSymbol(sym), _) => sym.name == "Ops"// TODO check that the parent is Asserts
@@ -35,8 +35,8 @@ object Asserts {
     tree match {
       case Term.Inlined(_, Nil, Term.Apply(Term.Select(OpsTree(left), op, _), right :: Nil)) =>
         op match {
-          case "===" => '(assertEquals(~left.reify[Any], ~right.reify[Any]))
-          case "!==" => '(assertNotEquals(~left.reify[Any], ~right.reify[Any]))
+          case "===" => '(assertEquals(~left.seal[Any], ~right.seal[Any]))
+          case "!==" => '(assertNotEquals(~left.seal[Any], ~right.seal[Any]))
         }
       case _ =>
         '(assertTrue(~cond))

--- a/tests/run-separate-compilation/tasty-macro-const/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-macro-const/quoted_1.scala
@@ -7,12 +7,12 @@ object Macros {
 
   def natConstImpl(x: Expr[Int])(implicit reflection: Reflection): Expr[Int] = {
     import reflection._
-    val xTree: Term = x.reflect
+    val xTree: Term = x.unseal
     xTree match {
       case Term.Literal(Constant.Int(n)) =>
         if (n <= 0)
           throw new QuoteError("Parameter must be natural number")
-        xTree.reify[Int]
+        xTree.seal[Int]
       case _ =>
         throw new QuoteError("Parameter must be a known constant")
     }

--- a/tests/run-separate-compilation/tasty-subtyping/quoted_1.scala
+++ b/tests/run-separate-compilation/tasty-subtyping/quoted_1.scala
@@ -12,13 +12,13 @@ object Macros {
 
   def isTypeEqualImpl[T, U](t: Type[T], u: Type[U])(implicit reflect: Reflection): Expr[Boolean] = {
     import reflect._
-    val isTypeEqual = t.reflect.tpe =:= u.reflect.tpe
+    val isTypeEqual = t.unseal.tpe =:= u.unseal.tpe
     isTypeEqual.toExpr
   }
 
   def isSubTypeOfImpl[T, U](t: Type[T], u: Type[U])(implicit reflect: Reflection): Expr[Boolean] = {
     import reflect._
-    val isTypeEqual = t.reflect.tpe <:< u.reflect.tpe
+    val isTypeEqual = t.unseal.tpe <:< u.unseal.tpe
     isTypeEqual.toExpr
   }
 }

--- a/tests/run-separate-compilation/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-separate-compilation/xml-interpolation-1/XmlQuote_1.scala
@@ -27,7 +27,7 @@ object XmlQuote {
 
     def liftListOfAny(lst: List[Term]): Expr[List[Any]] = lst match {
       case x :: xs  =>
-        val head = x.reify[Any]
+        val head = x.seal[Any]
         val tail = liftListOfAny(xs)
         '{ ~head :: ~tail }
       case Nil => '(Nil)
@@ -45,7 +45,7 @@ object XmlQuote {
       tree.symbol.fullName == "scala.StringContext$.apply"
 
     // XmlQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts = receiver.reflect.underlyingArgument match {
+    val parts = receiver.unseal.underlyingArgument match {
       case Apply(conv, List(Apply(fun, List(Typed(Repeated(values), _)))))
           if isSCOpsConversion(conv) &&
              isStringContextApply(fun) &&
@@ -56,7 +56,7 @@ object XmlQuote {
     }
 
     // [a0, ...]: Any*
-    val Typed(Repeated(args0), _) = args.reflect.underlyingArgument
+    val Typed(Repeated(args0), _) = args.unseal.underlyingArgument
 
     val string = parts.mkString("??")
     '(new Xml(~string.toExpr, ~liftListOfAny(args0)))

--- a/tests/run-separate-compilation/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-separate-compilation/xml-interpolation-2/XmlQuote_1.scala
@@ -39,7 +39,7 @@ object XmlQuote {
     }
 
     // XmlQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts: List[String] = stripTyped(receiver.reflect.underlying) match {
+    val parts: List[String] = stripTyped(receiver.unseal.underlying) match {
       case Apply(conv, List(ctx1)) if isSCOpsConversion(conv) =>
         ctx1 match {
           case Apply(fun, List(Typed(Repeated(values), _))) if isStringContextApply(fun) =>
@@ -54,13 +54,13 @@ object XmlQuote {
     }
 
     // [a0, ...]: Any*
-    val args2: Expr[List[Any]] = args.reflect.underlyingArgument match {
+    val args2: Expr[List[Any]] = args.unseal.underlyingArgument match {
       case Typed(Repeated(args0), _) => // statically known args, make list directly
         def liftListOfAny(lst: List[Expr[Any]]): Expr[List[Any]] = lst match {
           case x :: xs  => '{ ~x :: ~liftListOfAny(xs) }
           case Nil => '(Nil)
         }
-        liftListOfAny(args0.map(_.reify[Any]))
+        liftListOfAny(args0.map(_.seal[Any]))
       case _ =>
         '((~args).toList)
 


### PR DESCRIPTION
Remove implicit conversion of the extension methods from the API