### PR TITLE
Micro optimise @volatile lazy vals

### DIFF
--- a/docs/docs/reference/changed/lazy-vals-spec.md
+++ b/docs/docs/reference/changed/lazy-vals-spec.md
@@ -29,36 +29,34 @@ The Dotty compiler will generate code equivalent to:
 class Foo {
   import dotty.runtime.LazyVals
   var value_0: Int = _
-  var bitmap = 0
-  val bitmap_offset = LazyVals.getOffset(classOf[LazyCell], "bitmap")
+  var bitmap: Long = 0L
+  val bitmap_offset: Long = LazyVals.getOffset(classOf[LazyCell], "bitmap")
 
   def bar(): Int = {
-    var result: Int = 0
-    var retry: Boolean = true
-    var flag: Long = 0L
-    while (retry) {
-      flag = LazyVals.get(this, bitmap_offset)
-      LazyVals.STATE(flag, <field-id>) match {
-        case <state-0> =>
-          if (LazyVals.CAS(this, bitmap_offset, flag, <state-1>, <field-id>)) {
-            try result = <RHS>
-            catch {
-              case ex =>
-                LazyVals.setFlag(this, bitmap_offset, <state-0>, <field-id>)
-                throw ex
-            }
+    while (true) {
+      val flag = LazyVals.get(this, bitmap_offset)
+      val state = LazyVals.STATE(flag, <field-id>)
+
+      if (state == <state-3>) {
+        return value_0
+      } else if (state == <state-0>) {
+        if (LazyVals.CAS(this, bitmap_offset, flag, <state-1>, <field-id>)) {
+          try {
+            val result = <RHS>
             value_0 = result
             LazyVals.setFlag(this, bitmap_offset, <state-3>, <field-id>)
-            retry = false
+            return result
           }
-        case <state-1> | <state-2> =>
-          LazyVals.wait4Notification(this, bitmap_offset, flag, <field-id>)
-        case <state-3> =>
-          retry = false
-          result = value_0
+          catch {
+            case ex =>
+              LazyVals.setFlag(this, bitmap_offset, <state-0>, <field-id>)
+              throw ex
+          }
         }
+      } else /* if (state == <state-1> || state == <state-2>) */ {
+        LazyVals.wait4Notification(this, bitmap_offset, flag, <field-id>)
       }
-    result
+    }
   }
 }
 ```

--- a/library/src/dotty/runtime/LazyVals.scala
+++ b/library/src/dotty/runtime/LazyVals.scala
@@ -1,12 +1,10 @@
 package dotty.runtime
 
-import scala.forceInline
-
 /**
  * Helper methods used in thread-safe lazy vals.
  */
 object LazyVals {
-  private val unsafe: sun.misc.Unsafe =
+  private[this] val unsafe: sun.misc.Unsafe =
       classOf[sun.misc.Unsafe].getDeclaredFields.find { field =>
         field.getType == classOf[sun.misc.Unsafe] && {
           field.setAccessible(true)
@@ -20,24 +18,45 @@ object LazyVals {
         }
       }
 
-  final val BITS_PER_LAZY_VAL = 2L
-  final val LAZY_VAL_MASK = 3L
-  final val debug = false
+  private[this] val base: Int = {
+    val processors = java.lang.Runtime.getRuntime.availableProcessors()
+    8 * processors * processors
+  }
+  private[this] val monitors: Array[Object] =
+    Array.tabulate(base)(_ => new Object)
 
-  @forceInline def STATE(cur: Long, ord: Int) = {
+  private def getMonitor(obj: Object, fieldId: Int = 0) = {
+    var id = (
+      /*java.lang.System.identityHashCode(obj) + */ // should be here, but #548
+      fieldId) % base
+
+    if (id < 0) id += base
+    monitors(id)
+  }
+
+  private final val LAZY_VAL_MASK = 3L
+  private final val debug = false
+
+  /* ------------- Start of public API ------------- */
+
+  final val BITS_PER_LAZY_VAL = 2L
+
+  def STATE(cur: Long, ord: Int): Long = {
     val r = (cur >> (ord * BITS_PER_LAZY_VAL)) & LAZY_VAL_MASK
     if (debug)
       println(s"STATE($cur, $ord) = $r")
     r
   }
-  @forceInline def CAS(t: Object, offset: Long, e: Long, v: Int, ord: Int) = {
+
+  def CAS(t: Object, offset: Long, e: Long, v: Int, ord: Int): Boolean = {
     if (debug)
       println(s"CAS($t, $offset, $e, $v, $ord)")
     val mask = ~(LAZY_VAL_MASK << ord * BITS_PER_LAZY_VAL)
     val n = (e & mask) | (v.toLong << (ord * BITS_PER_LAZY_VAL))
-    compareAndSet(t, offset, e, n)
+    unsafe.compareAndSwapLong(t, offset, e, n)
   }
-  @forceInline def setFlag(t: Object, offset: Long, v: Int, ord: Int) = {
+
+  def setFlag(t: Object, offset: Long, v: Int, ord: Int): Unit = {
     if (debug)
       println(s"setFlag($t, $offset, $v, $ord)")
     var retry = true
@@ -56,7 +75,8 @@ object LazyVals {
       }
     }
   }
-  @forceInline def wait4Notification(t: Object, offset: Long, cur: Long, ord: Int) = {
+
+  def wait4Notification(t: Object, offset: Long, cur: Long, ord: Int): Unit = {
     if (debug)
       println(s"wait4Notification($t, $offset, $cur, $ord)")
     var retry = true
@@ -75,29 +95,13 @@ object LazyVals {
     }
   }
 
-  @forceInline def compareAndSet(t: Object, off: Long, e: Long, v: Long) = unsafe.compareAndSwapLong(t, off, e, v)
-  @forceInline def get(t: Object, off: Long) = {
+  def get(t: Object, off: Long): Long = {
     if (debug)
       println(s"get($t, $off)")
     unsafe.getLongVolatile(t, off)
   }
 
-  val processors: Int = java.lang.Runtime.getRuntime.availableProcessors()
-  val base: Int = 8 * processors * processors
-  val monitors: Array[Object] = (0 to base).map {
-    x => new Object()
-  }.toArray
-
-  @forceInline def getMonitor(obj: Object, fieldId: Int = 0) = {
-    var id = (
-      /*java.lang.System.identityHashCode(obj) + */ // should be here, but #548
-      fieldId) % base
-
-    if (id < 0) id += base
-    monitors(id)
-  }
-
-  @forceInline def getOffset(clz: Class[_], name: String) = {
+  def getOffset(clz: Class[_], name: String): Long = {
     val r = unsafe.objectFieldOffset(clz.getDeclaredField(name))
     if (debug)
       println(s"getOffset($clz, $name) = $r")
@@ -109,7 +113,6 @@ object LazyVals {
     final val cas = "CAS"
     final val setFlag = "setFlag"
     final val wait4Notification = "wait4Notification"
-    final val compareAndSet = "compareAndSet"
     final val get = "get"
     final val getOffset = "getOffset"
   }


### PR DESCRIPTION
Given a lazy field of the form:

```scala
class Foo {
  @volatile lazy val bar: Int = <RHS>
}
```

The compiler will now generate code equivalent to:

```scala
class Foo {
  import dotty.runtime.LazyVals
  var value_0: Int = _
  var bitmap: Long = 0L
  val bitmap_offset: Long = LazyVals.getOffset(classOf[LazyCell], "bitmap")

  def bar(): Int = {
    while (true) {
      val flag = LazyVals.get(this, bitmap_offset)
      val state = LazyVals.STATE(flag, <field-id>)

      if (state == <state-3>) {
        return value_0
      } else if (state == <state-0>) {
        if (LazyVals.CAS(this, bitmap_offset, flag, <state-1>, <field-id>)) {
          try {
            val result = <RHS>
            value_0 = result
            LazyVals.setFlag(this, bitmap_offset, <state-3>, <field-id>)
            return result
          }
          catch {
            case ex =>
              LazyVals.setFlag(this, bitmap_offset, <state-0>, <field-id>)
              throw ex
          }
        }
      } else /* if (state == <state-1> || state == <state-2>) */ {
        LazyVals.wait4Notification(this, bitmap_offset, flag, <field-id>)
      }
    }
  }
}
```