### PR TITLE
Fix #5481: Follow opaque aliases in prototypes of functions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1083,11 +1083,15 @@ object Types {
     /** Like `dealiasKeepAnnots`, but keeps only refining annotations */
     final def dealiasKeepRefiningAnnots(implicit ctx: Context): Type = dealias1(keepIfRefining)
 
-    /** If this is a synthetic opaque type, its opaque alias, otherwise the type itself */
+    /** If this is a synthetic opaque type seen from inside the opaque companion object,
+     *  its opaque alias, otherwise the type itself.
+     */
     final def followSyntheticOpaque(implicit ctx: Context): Type = this match {
       case tp: TypeProxy if tp.typeSymbol.is(SyntheticOpaque) =>
-        val AndType(alias, _) = tp.superType
-        alias
+        tp.superType match {
+          case AndType(alias, _) => alias   // in this case we are inside the companion object
+          case _ => this
+        }
       case _ => this
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1083,6 +1083,14 @@ object Types {
     /** Like `dealiasKeepAnnots`, but keeps only refining annotations */
     final def dealiasKeepRefiningAnnots(implicit ctx: Context): Type = dealias1(keepIfRefining)
 
+    /** If this is a synthetic opaque type, its opaque alias, otherwise the type itself */
+    final def followSyntheticOpaque(implicit ctx: Context): Type = this match {
+      case tp: TypeProxy if tp.typeSymbol.is(SyntheticOpaque) =>
+        val AndType(alias, _) = tp.superType
+        alias
+      case _ => this
+    }
+
     /** The result of normalization using `tryNormalize`, or the type itself if
      *  tryNormlize yields NoType
      */

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -728,13 +728,12 @@ class Typer extends Namer
       case _: WildcardType => untpd.TypeTree()
       case _ => untpd.TypeTree(tp)
     }
-    pt.stripTypeVar match {
-      case _ if defn.isNonDepFunctionType(pt) =>
+    pt.stripTypeVar.dealias.followSyntheticOpaque match {
+      case pt1 if defn.isNonDepFunctionType(pt1) =>
         // if expected parameter type(s) are wildcards, approximate from below.
         // if expected result type is a wildcard, approximate from above.
         // this can type the greatest set of admissible closures.
-        val funType = pt.dealias
-        (funType.argTypesLo.init, typeTree(funType.argTypesHi.last))
+        (pt1.argTypesLo.init, typeTree(pt1.argTypesHi.last))
       case SAMType(sam @ MethodTpe(_, formals, restpe)) =>
         (formals,
          if (sam.isResultDependent)

--- a/tests/neg/i5481.scala
+++ b/tests/neg/i5481.scala
@@ -16,4 +16,5 @@ object OpaqueType {
     def singleton0[A](a: A): Set[A] = (_: A) == a
   }
 
+  def singleton[A](a: A): Set[A] = _ == a       // error: missing parameter type
 }

--- a/tests/pos/i5481.scala
+++ b/tests/pos/i5481.scala
@@ -1,0 +1,18 @@
+object TypeAlias {
+
+  type Set[A] = A => Boolean
+
+  object Set {
+    def singleton[A](a: A): Set[A] = _ == a       // Works
+  }
+}
+
+object OpaqueType {
+
+  opaque type Set[A] = A => Boolean
+
+  object Set {
+    def singleton[A](a: A): Set[A] = _ == a     // Does not compile
+    def singleton0[A](a: A): Set[A] = (_: A) == a // Works
+  }
+}


### PR DESCRIPTION
If the prototype of a function value is a synthetic opaque type alias, assume
the alias type. If the alias type is a function type, this allows one to infer
the parameter types of the function value.