### PR TITLE
Fix #5482: Empty buffer when not parsing comments

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -631,7 +631,11 @@ object Scanners {
       nextChar()
       if (ch == '/') { skipLine(); finishComment() }
       else if (ch == '*') { nextChar(); skipComment(); finishComment() }
-      else false
+      else {
+        // This was not a comment, remove the `/` from the buffer
+        commentBuf.clear()
+        false
+      }
     }
 
 // Lookahead ---------------------------------------------------------------

--- a/language-server/test/dotty/tools/languageserver/HoverTest.scala
+++ b/language-server/test/dotty/tools/languageserver/HoverTest.scala
@@ -164,6 +164,14 @@ class HoverTest {
                        |
                        |**Version**
                        | - 1.0""".stripMargin))
+  }
 
+  @Test def i5482: Unit = {
+    code"""object Test {
+          |  def bar: Int = 2 / 1
+          |  /** hello */
+          |  def ${m1}baz${m2}: Int = ???
+          |}""".withSource
+      .hover(m1 to m2, hoverContent("Int", "hello"))
   }
 }


### PR DESCRIPTION
The scanner keeps a buffer `commentBuf` which contains the content of
the comment being parsed. When encountering a `/`, we check whether this
is the beginning of a comment. Checking this adds the slash to the
buffer. If this wasn't a comment, the buffer wasn't emptied, and the
slash would still be there and would be prepended to the next comment.

This commit fixes this by emptying the buffer when we detect that the
slash wasn't the start of a comment.

Fixes #5482