### PR TITLE
Fix #4762: Add regression test

### DIFF
--- a/tests/pos-scala2/i4762.scala
+++ b/tests/pos-scala2/i4762.scala
@@ -1,0 +1,3 @@
+class Foo {
+  inline def foo = 1
+}


### PR DESCRIPTION
`inline` is now a soft keyword and can be used as an identifier