### PR TITLE
Fix #5449: Index class definitions before unpickling parents

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -649,7 +649,8 @@ object TastyFormat {
     case VALDEF | DEFDEF | TYPEDEF | OBJECTDEF | TYPEPARAM | PARAM | NAMEDARG | RETURN | BIND |
          SELFDEF | REFINEDtype | TERMREFin | TYPEREFin | HOLE => 1
     case RENAMED | PARAMtype => 2
-    case POLYtype | METHODtype | TYPELAMBDAtype => -1
+    case POLYtype | METHODtype | IMPLICITMETHODtype | ERASEDMETHODtype | ERASEDIMPLICITMETHODtype |
+         TYPELAMBDAtype => -1
     case _ => 0
   }
 }

--- a/tests/pos-separate-compilation/parents-cycle/Def_1.scala
+++ b/tests/pos-separate-compilation/parents-cycle/Def_1.scala
@@ -1,0 +1,15 @@
+class A[T]
+// Unpickling the parents of B1 will lead to unpickling a call to B1.<init>
+class B1 extends A[C1]
+class C1 extends B1
+
+// Unpickling the parents of B2 will lead to unpickling a call to the secondary B2.<init>
+class B2 extends A[C2] {
+  def this(x: Int) = this()
+}
+class C2 extends B2(1)
+
+// Unpickling the parents of B3 will lead to unpickling a call to B3#Hi
+class B3 extends A[B3#Hi[Int]] {
+  type Hi[X] = X
+}

--- a/tests/pos-separate-compilation/parents-cycle/Use_2.scala
+++ b/tests/pos-separate-compilation/parents-cycle/Use_2.scala
@@ -1,0 +1,5 @@
+object Use {
+  val b1 = new B1
+  val b2 = new B2
+  val b3 = new B3
+}


### PR DESCRIPTION
Otherwise we may try to unpickle references to these definitions before
we have symbols for them (this manifests itself as "undefined: ..."
error messages)

--

Also fix an unrelated issue in TastyFormat#numRefs I stumbled upon.