### PR TITLE
Fix #5486: Constant-fold types in TypeAssigner

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -13,6 +13,7 @@ import Decorators._, DenotTransformers._
 import collection.mutable
 import util.{Property, SourceFile, NoSource}
 import NameKinds.{TempResultName, OuterSelectName}
+import typer.ConstFold
 
 import scala.annotation.tailrec
 import scala.io.Codec
@@ -525,10 +526,12 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       tree match {
         case tree: Select if qualifier.tpe eq tree.qualifier.tpe =>
           tree1.withTypeUnchecked(tree.tpe)
-        case _ => tree.tpe match {
-          case tpe: NamedType => tree1.withType(tpe.derivedSelect(qualifier.tpe.widenIfUnstable))
-          case _ => tree1.withTypeUnchecked(tree.tpe)
-        }
+        case _ =>
+          val tree2 = tree.tpe match {
+            case tpe: NamedType => tree1.withType(tpe.derivedSelect(qualifier.tpe.widenIfUnstable))
+            case _ => tree1.withTypeUnchecked(tree.tpe)
+          }
+          ConstFold(tree2)
       }
     }
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -16,6 +16,7 @@ import Flags._
 import Constants._
 import Annotations._
 import NameKinds._
+import typer.ConstFold
 import typer.Checking.checkNonCyclic
 import util.Positions._
 import ast.{TreeTypeMap, Trees, tpd, untpd}
@@ -996,7 +997,7 @@ class TreeUnpickler(reader: TastyReader,
         val localCtx =
           if (name == nme.CONSTRUCTOR) ctx.addMode(Mode.InSuperCall) else ctx
         val qual = readTerm()(localCtx)
-        untpd.Select(qual, name).withType(tpf(qual.tpe.widenIfUnstable))
+        ConstFold(untpd.Select(qual, name).withType(tpf(qual.tpe.widenIfUnstable)))
       }
 
       def readQualId(): (untpd.Ident, TypeRef) = {

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -588,15 +588,6 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       // add type to term nodes; replace type nodes with their types unless -Yprint-pos is also set.
       def tp = tree.typeOpt match {
         case tp: TermRef if tree.isInstanceOf[RefTree] && !tp.denot.isOverloaded => tp.underlying
-        case tp: ConstantType if homogenizedView =>
-          // constant folded types are forgotten in Tasty, are reconstituted subsequently in FirstTransform.
-          // Therefore we have to gloss over this when comparing before/after pickling by widening to
-          // underlying type `T`, or, if expression is a unary primitive operation, to `=> T`.
-          tree match {
-            case Select(qual, _) if qual.typeOpt.widen.typeSymbol.isPrimitiveValueClass =>
-              ExprType(tp.widen)
-            case _ => tp.widen
-          }
         case tp => tp
       }
       if (!suppressTypes)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -769,7 +769,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
                 new ApplyToTyped(tree, fun1, funRef, proto.typedArgs, pt)
               else
                 new ApplyToUntyped(tree, fun1, funRef, proto, pt)(argCtx(tree))
-            convertNewGenericArray(ConstFold(app.result))
+            convertNewGenericArray(app.result)
           case _ =>
             handleUnexpectedFunType(tree, fun1)
         }

--- a/compiler/src/dotty/tools/dotc/typer/ConstFold.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ConstFold.scala
@@ -17,7 +17,7 @@ object ConstFold {
   import tpd._
 
   /** If tree is a constant operation, replace with result. */
-  def apply(tree: Tree)(implicit ctx: Context): Tree = finish(tree) {
+  def apply[T <: Tree](tree: T)(implicit ctx: Context): T = finish(tree) {
     tree match {
       case Apply(Select(xt, op), yt :: Nil) =>
         xt.tpe.widenTermRefExpr match {
@@ -40,7 +40,7 @@ object ConstFold {
   /** If tree is a constant value that can be converted to type `pt`, perform
    *  the conversion.
    */
-  def apply(tree: Tree, pt: Type)(implicit ctx: Context): Tree =
+  def apply[T <: Tree](tree: T, pt: Type)(implicit ctx: Context): T =
     finish(apply(tree)) {
       tree.tpe.widenTermRefExpr match {
         case ConstantType(x) => x convertTo pt
@@ -48,10 +48,10 @@ object ConstFold {
       }
     }
 
-  private def finish(tree: Tree)(compX: => Constant)(implicit ctx: Context): Tree =
+  private def finish[T <: Tree](tree: T)(compX: => Constant)(implicit ctx: Context): T =
     try {
       val x = compX
-      if (x ne null) tree withType ConstantType(x)
+      if (x ne null) tree.withType(ConstantType(x)).asInstanceOf[T]
       else tree
     } catch {
       case _: ArithmeticException => tree   // the code will crash at runtime,

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -291,7 +291,7 @@ trait TypeAssigner {
 
       case _ => accessibleSelectionType(tree, qual)
     }
-    tree.withType(tp)
+    ConstFold(tree.withType(tp))
   }
 
   def assignType(tree: untpd.New, tpt: Tree)(implicit ctx: Context): New =
@@ -372,7 +372,7 @@ trait TypeAssigner {
       case t =>
         errorType(err.takesNoParamsStr(fn, ""), tree.pos)
     }
-    tree.withType(ownType)
+    ConstFold(tree.withType(ownType))
   }
 
   def assignType(tree: untpd.TypeApply, fn: Tree, args: List[Tree])(implicit ctx: Context): TypeApply = {

--- a/tests/pos/constfold.scala
+++ b/tests/pos/constfold.scala
@@ -1,8 +1,12 @@
 object A {
-  val x = 2;
-  val y = x.asInstanceOf[Byte];
-  val z = 1.0 / 2;
-  val s = "z is " + z;
+  val x = 2
+  val y = x.asInstanceOf[Byte]
+  val z = 1.0 / 2
+  val s = "z is " + z
+
+  val a = 1 + 1
+  val b = -(1:1)
+  val c = -(1:1 & Any)
 }
 
 object Test extends App {

--- a/tests/pos/inline-constfold.scala
+++ b/tests/pos/inline-constfold.scala
@@ -1,0 +1,15 @@
+object Test {
+  inline def not(x: Boolean) <: Boolean = {
+    !x
+  }
+
+  final val a = not(true)
+  val b: false = a
+
+  inline def add(x: Int, y: Int) <: Int = {
+    x + y
+  }
+
+  final val c = add(3, 4)
+  val d: 7 = c
+}


### PR DESCRIPTION
To be consistent we also need to do it in TreeUnpickler and
TypedTreeCopier because they don't use TypeAssigner for Select nodes.

The main reason for this change is that it ensures that the pickled and
unpickled trees have the same constant types, but it also means that
inlined trees can get more precise types as witnessed by the added
inline-constfold.scala test