### PR TITLE
Fix missing refactor of TypeTree.Synthetic to TypeTree.Inferred

### DIFF
--- a/semanticdb/src/dotty/semanticdb/SemanticdbConsumer.scala
+++ b/semanticdb/src/dotty/semanticdb/SemanticdbConsumer.scala
@@ -216,7 +216,7 @@ class SemanticdbConsumer extends TastyConsumer {
 
       def typetreeSymbol(tree: Tree, typetree: TypeTree): Unit =
         typetree match {
-          case TypeTree.Synthetic => ()
+          case TypeTree.Inferred => ()
           case _ =>
             addOccurenceTypeTree(
               typetree,


### PR DESCRIPTION
83cc281569bbf74 refactors `TypeTree.Synthetic` to `TypeTree.Inferred`, one reference was missed in `dotty.semanticdb.SemanticdbConsumer`

@nicolasstucki this prevents the Language Server to fully compile when using `sbt launchIDE`