### PR TITLE
Fix #5488: properly unpickle RecTypes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -392,7 +392,13 @@ class TreeUnpickler(reader: TastyReader,
         case THIS =>
           ThisType.raw(readType().asInstanceOf[TypeRef])
         case RECtype =>
-          typeAtAddr.getOrElse(start, RecType(rt => registeringType(rt, readType())))
+          typeAtAddr.get(start) match {
+            case Some(tp) =>
+              skipTree(tag)
+              tp
+            case None =>
+              RecType(rt => registeringType(rt, readType()))
+          }
         case RECthis =>
           readTypeRef().asInstanceOf[RecType].recThis
         case TYPEALIAS =>

--- a/compiler/test/dotc/pos-decompilation.blacklist
+++ b/compiler/test/dotc/pos-decompilation.blacklist
@@ -12,3 +12,6 @@ tcpoly_checkkinds_mix.scala
 i3050.scala
 i4006b.scala
 i4006c.scala
+
+# Decompiling RecThis as "this" is incorrect
+avoid.scala

--- a/tests/pos/avoid.scala
+++ b/tests/pos/avoid.scala
@@ -9,6 +9,8 @@ object test {
   val z: String = x.y
 }
 
+trait M
+
 // A tricky case involving inner classes, exercised
 // in the large in dotty.tools.dotc.core.NameKinds.scala.
 object Test2 {
@@ -23,5 +25,10 @@ object Test2 {
   val y = {
     class C extends NK { type T = I }
     new C
+  }
+
+  val z = {
+    class C extends NK { type T = I }
+    new C with M
   }
 }


### PR DESCRIPTION
If the type is already present in typeAtAddr, then we don't unpickle it
again, but we forgot to skip over it before moving on.