### PR TITLE
Fix -Ytest-pickler with super trees

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -451,6 +451,7 @@ class TreePickler(pickler: TastyPickler) {
           withLength {
             pickleTree(qual);
             if (!mix.isEmpty) {
+              // mixinType being a TypeRef when mix is non-empty is enforced by TreeChecker#checkSuper              
               val SuperType(_, mixinType: TypeRef) = tree.tpe: @unchecked
               pickleTree(mix.withType(mixinType))
             }

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -305,9 +305,26 @@ class TreeChecker extends Phase with SymTransformer {
     override def excludeFromDoubleDeclCheck(sym: Symbol)(using Context): Boolean =
       sym.isEffectivelyErased && sym.is(Private) && !sym.initial.is(Private)
 
+    /** Check that all invariants related to Super and SuperType are met */
+    def checkSuper(tree: Tree)(implicit ctx: Context): Unit = tree match
+      case Super(qual, mix) =>
+        tree.tpe match
+          case tp @ SuperType(thistpe, supertpe) =>
+            if (!mix.isEmpty)
+              assert(supertpe.isInstanceOf[TypeRef],
+                s"Precondition of pickling violated: the supertpe in $tp is not a TypeRef even though $tree has a non-empty mix")
+          case tp =>
+            assert(false, s"The type of a Super tree must be a SuperType, but $tree has type $tp")
+      case _ =>
+        tree.tpe match
+          case tp: SuperType =>
+            assert(false, s"The type of a non-Super tree must not be a SuperType, but $tree has type $tp")
+          case _ =>
+
     override def typed(tree: untpd.Tree, pt: Type = WildcardType)(using Context): Tree = {
       val tpdTree = super.typed(tree, pt)
       Typer.assertPositioned(tree)
+      checkSuper(tpdTree)
       if (ctx.erasedTypes)
         // Can't be checked in earlier phases since `checkValue` is only run in
         // Erasure (because running it in Typer would force too much)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -255,7 +255,7 @@ trait TypeAssigner {
             errorType("ambiguous parent class qualifier", pos)
         }
         val owntype =
-          if (mixinClass.exists) mixinClass.appliedRef
+          if (mixinClass.exists) mixinClass.typeRef
           else if (!mix.isEmpty) findMixinSuper(cls.info)
           else if (ctx.erasedTypes) cls.info.firstParent.typeConstructor
           else {

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -2,7 +2,6 @@ i94-nada.scala
 i1812.scala
 i1867.scala
 i3067.scala
-t247.scala
 t2712-5.scala
 t284-pos.scala
 t3249


### PR DESCRIPTION
in t247.scala, `super[Tree]` was typed as `SuperType(TreeMap, Tree)` but
the unpickled type was reconstructed as `SuperType(TreeMap, Tree[KEY,
Entry])` leading to a -Ytest-pickler failure. We fix this by tweaking
TypeAssigner for Super, and while we're at it we also add some checks
related to Super in TreeChecker.