### PR TITLE
Allow `,` in parents of template

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -250,6 +250,11 @@ object Scanners {
       isScala2Mode
     }
 
+    /** A migration warning if in Scala-2 mode, an error otherwise */
+    def errorOrMigrationWarning(msg: String, pos: Position = Position(offset)): Unit =
+      if (isScala2Mode) ctx.migrationWarning(msg, source.atPos(pos))
+      else ctx.error(msg, source.atPos(pos))
+
 // Get next token ------------------------------------------------------------
 
     /** Are we directly in a string interpolation expression?

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -186,7 +186,7 @@ PostfixExpr       ::=  InfixExpr [id]                                           
 InfixExpr         ::=  PrefixExpr
                     |  InfixExpr id [nl] InfixExpr                              InfixOp(expr, op, expr)
 PrefixExpr        ::=  [‘-’ | ‘+’ | ‘~’ | ‘!’] SimpleExpr                       PrefixOp(expr, op)
-SimpleExpr        ::=  ‘new’ Template                                           New(templ)
+SimpleExpr        ::=  ‘new’ (ConstrApp [TemplateBody] | TemplateBody)          New(constr | templ)
                     |  BlockExpr
                     |  ''{’ BlockExprContents ‘}’
                     |  ‘'(’ ExprsInParens ‘)’
@@ -340,14 +340,14 @@ DefDef            ::=  DefSig [(‘:’ | ‘<:’) Type] ‘=’ Expr          
 TmplDef           ::=  ([‘case’] ‘class’ | ‘trait’) ClassDef
                     |  [‘case’] ‘object’ ObjectDef
                     |  ‘enum’ EnumDef
-ClassDef          ::=  id ClassConstr TemplateOpt                               ClassDef(mods, name, tparams, templ)
-ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses         with DefDef(_, <init>, Nil, vparamss, EmptyTree, EmptyTree) as first stat
+ClassDef          ::=  id ClassConstr [Template]                                ClassDef(mods, name, tparams, templ)
+ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses        with DefDef(_, <init>, Nil, vparamss, EmptyTree, EmptyTree) as first stat
 ConstrMods        ::=  {Annotation} [AccessModifier]
-ObjectDef         ::=  id TemplateOpt                                           ModuleDef(mods, name, template)  // no constructor
-EnumDef           ::=  id ClassConstr [‘extends’ [ConstrApps]] EnumBody         EnumDef(mods, name, tparams, template)
-TemplateOpt       ::=  [‘extends’ Template | [nl] TemplateBody]
+ObjectDef         ::=  id [Template]                                            ModuleDef(mods, name, template)  // no constructor
+EnumDef           ::=  id ClassConstr [‘extends’ ConstrApps] EnumBody           EnumDef(mods, name, tparams, template)
 Template          ::=  ConstrApps [TemplateBody] | TemplateBody                 Template(constr, parents, self, stats)
 ConstrApps        ::=  ConstrApp {‘with’ ConstrApp}
+                    |  ConstrApp {‘,’ ConstrApp}
 ConstrApp         ::=  AnnotType {ArgumentExprs}                                Apply(tp, args)
 ConstrExpr        ::=  SelfInvocation
                     |  ConstrBlock

--- a/tests/invalid/neg/typelevel.scala
+++ b/tests/invalid/neg/typelevel.scala
@@ -53,7 +53,7 @@ object Test {
   val rr1 = new Deco1(HCons(1, HNil)) ++ HNil
   val rr1a: HCons[Int, HNil.type] = rr1   // error (type error because no inline)
 
-  class Deco2(val as: HList) extends java.lang.Cloneable with java.lang.Comparable[Deco2] {
+  class Deco2(val as: HList) extends java.lang.Cloneable, java.lang.Comparable[Deco2] {
     inline def ++ (bs: HList) = concat(as, bs)
   }
 }

--- a/tests/neg/i2770.scala
+++ b/tests/neg/i2770.scala
@@ -8,7 +8,7 @@ trait C2 extends B2 { type L[X, Y] <: String } // error: illegal override
 trait D { type I }
 trait E extends D { type I <: String }
 trait F extends D { type I >: String }
-trait G extends E with F // ok
+trait G extends E, F // ok
 
 trait H extends D { type I >: Int }
-trait H2 extends E with H // error: illegal override
+trait H2 extends E, H // error: illegal override

--- a/tests/pos/Iter2.scala
+++ b/tests/pos/Iter2.scala
@@ -58,16 +58,16 @@ object Iter2 {
     def fromIterator[B](it: Iterator[B]): C[B]
   }
 
-  trait Iterable[+IA] extends IterableOnce[IA] with FromIterator[Iterable] {
+  trait Iterable[+IA] extends IterableOnce[IA], FromIterator[Iterable] {
     def view: View[IA] = new View(iterator)
   }
 
-  trait Seq[+AA] extends Iterable[AA] with FromIterator[Seq] {
+  trait Seq[+AA] extends Iterable[AA], FromIterator[Seq] {
     def apply(i: Int): AA
     def length: Int
   }
 
-  sealed trait List[+A] extends Seq[A] with FromIterator[List] {
+  sealed trait List[+A] extends Seq[A], FromIterator[List] {
     def isEmpty: Boolean
     def head: A
     def tail: List[A]
@@ -84,7 +84,7 @@ object Iter2 {
       if (isEmpty) 0 else 1 + tail.length
   }
 
-  class View[+A](it: Iterator[A]) extends Iterable[A] with FromIterator[View] {
+  class View[+A](it: Iterator[A]) extends Iterable[A], FromIterator[View] {
     def iterator: Iterator[A] = it.copy
     def fromIterator[B](it: Iterator[B]): View[B] = new View(it)
   }
@@ -101,7 +101,7 @@ object Iter2 {
     def tail = ???
   }
 
-  class ArrayBuffer[A] private (initElems: Array[AnyRef], initLen: Int) extends Seq[A] with FromIterator[ArrayBuffer] {
+  class ArrayBuffer[A] private (initElems: Array[AnyRef], initLen: Int) extends Seq[A], FromIterator[ArrayBuffer] {
     def this() = this(new Array[AnyRef](16), 0)
     def this(it: ArrayIterator[A]) = this(it.elems, it.len)
     private var elems: Array[AnyRef] = initElems
@@ -116,7 +116,7 @@ object Iter2 {
     def length = len
   }
 /*
-  class SeqView[A](itf: () => Iterator) extends Seq[A] with FromIterator[SeqView] {
+  class SeqView[A](itf: () => Iterator) extends Seq[A], FromIterator[SeqView] {
     def iterator = it
     def buildIterator = it
     def fromIterator[B](it: Iterator[B]) = it match {

--- a/tests/pos/this-types.scala
+++ b/tests/pos/this-types.scala
@@ -9,7 +9,7 @@ trait C extends A {
   type A_This = C_This
   type C_This <: C
 }
-trait D extends B with C {
+trait D extends B, C {
   type B_This = D_This
   type C_This = D_This
   type D_This <: D

--- a/tests/pos/traits_1.scala
+++ b/tests/pos/traits_1.scala
@@ -17,7 +17,7 @@ object Test {
       case _ => false
     }
   }
-  trait BorderedColoredShape extends Shape with Bordered with Colored {
+  trait BorderedColoredShape extends Shape, Bordered, Colored {
     override def equals(other: Any) = other match {
       case that: BorderedColoredShape => (
         super.equals(that) &&

--- a/tests/pos/typeclass-encoding.scala
+++ b/tests/pos/typeclass-encoding.scala
@@ -65,7 +65,7 @@ object semiGroups {
     type StaticPart[X] = MonoidStatic[X]
   }
 
-  implicit object extend_Int_Monoid extends MonoidStatic[Int] with Implementation[Int] {
+  implicit object extend_Int_Monoid extends MonoidStatic[Int], Implementation[Int] {
     type Implemented = Monoid
     def unit: Int = 0
     def inject($this: Int) = new Monoid {
@@ -74,7 +74,7 @@ object semiGroups {
     }
   }
 
-  implicit object extend_String_Monoid extends MonoidStatic[String] with Implementation[String] {
+  implicit object extend_String_Monoid extends MonoidStatic[String], Implementation[String] {
     type Implemented = Monoid
     def unit = ""
     def inject($this: String): Monoid { type This = String } =

--- a/tests/run-separate-compilation/tasty-positioned.check
+++ b/tests/run-separate-compilation/tasty-positioned.check
@@ -5,4 +5,4 @@ acbvasdfa columns:13-36 lines:12-12
 acbvasdfa columns:13-24 lines:13-13
 a
 b columns:6-25 lines:15-16
-Foo columns:16-19 lines:17-17
+Foo columns:12-19 lines:17-17

--- a/tests/run/generic/SearchResult.scala
+++ b/tests/run/generic/SearchResult.scala
@@ -11,7 +11,7 @@ import Shapes._
  */
 sealed trait SearchResult extends Enum
 
-object SearchResult extends {
+object SearchResult {
 
   private val $values = new runtime.EnumValues[SearchResult]
   def valueOf = $values.fromInt

--- a/tests/run/t6090.scala
+++ b/tests/run/t6090.scala
@@ -1,6 +1,6 @@
 class X { def ==(other: X) = true }
 class V(val x: X) extends AnyVal
-object Test extends {
+object Test {
   def main(args: Array[String]) =
     assert((new V(new X) == new V(new X)))
 }


### PR DESCRIPTION
New syntax

    A extends B, C { ... }

instead of

    A extends B with C { ... }

The old syntax is still allowed, but it's planned to phase it out together
with `with` as a type operator.

Also: disallow

    A extends { ... }

(make it a migration warning under -language:Scala2)

While doing these changes, applied some refactorings to handle templates
in the parser which hopefully make the code clearer.

(This is all in preparation for adding `derives` clauses.)
