### PR TITLE
Improve inference of dependent function types to fix #5526

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1155,7 +1155,12 @@ class Namer { typer: Typer =>
       case TypeTree() =>
         checkMembersOK(inferredType, mdef.pos)
       case DependentTypeTree(tpFun) =>
-        tpFun(paramss.head)
+        val tpe = tpFun(paramss.head)
+        if (!isFullyDefined(tpe, ForceDegree.none)) {
+          typedAheadExpr(mdef.rhs, tpe).tpe
+        } else {
+          tpe
+        }
       case TypedSplice(tpt: TypeTree) if !isFullyDefined(tpt.tpe, ForceDegree.none) =>
         val rhsType = typedAheadExpr(mdef.rhs, tpt.tpe).tpe
         mdef match {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1215,7 +1215,7 @@ class Typer extends Namer
         }
       case _ =>
         tree.withType(
-          if (isFullyDefined(pt, ForceDegree.none)) pt else UnspecifiedErrorType)
+          if (isFullyDefined(pt, ForceDegree.noBottom)) pt else UnspecifiedErrorType)
     }
   }
 

--- a/tests/pos/i5526.scala
+++ b/tests/pos/i5526.scala
@@ -1,0 +1,21 @@
+trait A
+object test1 {
+  def foo[E](f: (a: A) => (a.type, E)): E = {
+    val a = new A {}
+    f(a)._2
+  }
+
+  val res = foo { a => (a, 42) }
+  val x: Int = res
+}
+
+object test2 {
+  trait F[A, -E]
+  def empty[A](value: A): F[A, Any] = ???
+
+  def hof[R](f: (p: AnyRef) => F[R, p.type]): F[R, Any] = ???
+
+  hof { p =>
+    empty(42)
+  }
+}


### PR DESCRIPTION
Try to improve type inference on dependent function types. Addresses #5526.

This does not fix all related problems of inference on dependent function types (such as #4130). However, some cases like the ones in the tests now don't throw the Unspecified Error anymore.