### PR TITLE
Add case class error message

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -352,6 +352,9 @@ object desugar {
         if (isCaseClass && originalTparams.isEmpty)
           ctx.error(CaseClassMissingParamList(cdef), cdef.namePos)
         ListOfNil
+      } else if (isCaseClass && originalVparamss.head.exists(_.mods.is(Implicit))) {
+          ctx.error("Case classes should have a non-implicit parameter list", cdef.namePos)
+        ListOfNil
       }
       else originalVparamss.nestedMap(toDefParam)
     val constr = cpy.DefDef(constr1)(tparams = constrTparams, vparamss = constrVparamss)

--- a/tests/neg/5541.scala
+++ b/tests/neg/5541.scala
@@ -1,0 +1,1 @@
+case class Foo(implicit i: Int) // error: Case classes should have a non-implicit parameter list


### PR DESCRIPTION
Add error message for case classes with a single implicit parameter list. Current it fails in an unfriendly way:

```scala
Starting dotty REPL...
scala> case class Foo(implicit i: Int)
     | 
1 |case class Foo(implicit i: Int)
  |^
  |too many arguments for constructor Foo: ()(implicit i: Int): Foo
```

Scalac is in my opinion unnecessarily nice in that case:

```scala
Welcome to Scala 2.12.2 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_161).
Type in expressions for evaluation. Or try :help.
scala> case class Foo(implicit i: Int)
<console>:11: warning: case classes should have a non-implicit parameter list; adapting to "case class Foo()(...)"
       case class Foo(implicit i: Int)
                     ^
defined class Foo
```