### PR TITLE
Run worksheets after willSave instead of didSave

### DIFF
--- a/vscode-dotty/src/worksheet.ts
+++ b/vscode-dotty/src/worksheet.ts
@@ -325,16 +325,11 @@ export class WorksheetProvider implements Disposable {
       codeLensProvider,
       vscode.languages.registerCodeLensProvider(documentSelector, codeLensProvider),
       vscode.workspace.onWillSaveTextDocument(event => {
+        const runWorksheetOnSave = vscode.workspace.getConfiguration("dotty").get("runWorksheetOnSave")
         const worksheet = this.worksheetFor(event.document)
         if (worksheet) {
           event.waitUntil(Promise.resolve(worksheet.prepareRun()))
-        }
-      }),
-      vscode.workspace.onDidSaveTextDocument(document => {
-        const runWorksheetOnSave = vscode.workspace.getConfiguration("dotty").get("runWorksheetOnSave")
-        const worksheet = this.worksheetFor(document)
-        if (runWorksheetOnSave && worksheet) {
-          worksheet.run()
+          if (runWorksheetOnSave) worksheet.run()
         }
       }),
       vscode.workspace.onDidCloseTextDocument(document => {


### PR DESCRIPTION
We were triggering the worksheet run after a `didSave` event. This means
that, if the file was unmodified, hitting `<ctrl-s>` would not re-run
the worksheet, even though the previous output would disappear.

We know run the worksheet after the `willSave` event, which is triggered
regardless of the buffer state. This is not an issue for the language
server which uses the tree that it has in memory rather than what's on
disk at the moment.