### PR TITLE
Cleanup and improve realizability

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -47,7 +47,7 @@ object CheckRealizable {
   def boundsRealizability(tp: Type)(implicit ctx: Context): Realizability =
     new CheckRealizable().boundsRealizability(tp)
 
-  private val LateInitialized = Lazy | Erased,
+  private val LateInitialized = Lazy | Erased
 }
 
 /** Compute realizability status */

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -10,7 +10,7 @@ import collection.mutable
 /** Realizability status */
 object CheckRealizable {
 
-  abstract class Realizability(val msg: String) {
+  sealed abstract class Realizability(val msg: String) {
     def andAlso(other: => Realizability): Realizability =
       if (this == Realizable) other else this
     def mapError(f: Realizability => Realizability): Realizability =

--- a/tests/neg/i4031-anysel.scala
+++ b/tests/neg/i4031-anysel.scala
@@ -1,0 +1,3 @@
+object Test {
+  val v: Any = 1: Any#L // error
+}

--- a/tests/pos-deep-subtype/i4036.scala
+++ b/tests/pos-deep-subtype/i4036.scala
@@ -1,0 +1,64 @@
+trait A { def x: this.type = this; type T }
+trait B { def y: this.type = this; def x: y.type = y; type T }
+object A {
+  val v = new A { type T = Int }
+  v: v.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.type
+
+  1: v.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.T
+
+  val u = new B { type T = Int }
+  u: u.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.type
+
+  val z = new B { type T = this.type }
+  z: z.T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T
+}


### PR DESCRIPTION
The first part contains small changes and cleanups (mostly from #4036), except for 58aabb4deaaab8a62b9148f44e423b37e4221431 which is a more significant change.

The last commit refactors `realizability` significantly; it adds some complexity to avoid calling `realizability(tp.info)` twice, but otherwise clarifies and documents the code quite a bit, based on @abeln's patch.

Now a type is realizable if it selects a stable member on a realizable prefix — no exceptions. Which I did not know (and wasn't clear before #5521).

It might be the case that checking the prefix was in fact unnecessary in some cases, but we have neither documentation why that would be, testcases documenting the behavior, nor performance issues.

And in fact, even selecting a member with a singleton type from a path with mutable fields gives an unstable result, which I believe should hence be unrealizable.