### PR TITLE
Fix #4031, v3: Check arguments of dependent methods for realizability

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -80,7 +80,7 @@ class CheckRealizable(implicit ctx: Context) {
             else realizability(tp.info).mapError(r => new ProblemInUnderlying(tp.info, r))
           r andAlso {
             sym.setFlag(Stable)
-            realizability(tp.prefix)
+            realizability(tp.prefix).mapError(r => new ProblemInUnderlying(tp.prefix, r))
           }
         }
       if (r == Realizable || tp.info.isStableRealizable) Realizable else r

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -49,7 +49,7 @@ object CheckRealizable {
   def boundsRealizability(tp: Type)(implicit ctx: Context): Realizability =
     new CheckRealizable().boundsRealizability(tp)
 
-  private val LateInitialized = Lazy | Erased,
+  private val LateInitialized = Lazy | Erased
 }
 
 /** Compute realizability status */

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -70,18 +70,20 @@ class CheckRealizable(implicit ctx: Context) {
   def realizability(tp: Type): Realizability = tp.dealias match {
     case tp: TermRef =>
       val sym = tp.symbol
-      if (sym.is(Stable)) realizability(tp.prefix)
-      else {
-        val r =
-          if (!sym.isStable) NotStable
-          else if (!isLateInitialized(sym)) Realizable
-          else if (!sym.isEffectivelyFinal) new NotFinal(sym)
-          else realizability(tp.info).mapError(r => new ProblemInUnderlying(tp.info, r))
-        r andAlso {
-          sym.setFlag(Stable)
-          realizability(tp.prefix)
+      val r =
+        if (sym.is(Stable)) realizability(tp.prefix)
+        else {
+          val r =
+            if (!sym.isStable) NotStable
+            else if (!isLateInitialized(sym)) Realizable
+            else if (!sym.isEffectivelyFinal) new NotFinal(sym)
+            else realizability(tp.info).mapError(r => new ProblemInUnderlying(tp.info, r))
+          r andAlso {
+            sym.setFlag(Stable)
+            realizability(tp.prefix)
+          }
         }
-      }
+      if (r == Realizable || tp.info.isStableRealizable) Realizable else r
     case _: SingletonType | NoPrefix =>
       Realizable
     case tp =>

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -10,7 +10,7 @@ import collection.mutable
 /** Realizability status */
 object CheckRealizable {
 
-  abstract class Realizability(val msg: String) {
+  sealed abstract class Realizability(val msg: String) {
     def andAlso(other: => Realizability): Realizability =
       if (this == Realizable) other else this
     def mapError(f: Realizability => Realizability): Realizability =

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -406,6 +406,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling {
             if (cls2 eq AnyKindClass) return true
             if (tp1.isRef(NothingClass)) return true
             if (tp1.isLambdaSub) return false
+            if (cls2 eq AnyClass) return true
               // Note: We would like to replace this by `if (tp1.hasHigherKind)`
               // but right now we cannot since some parts of the standard library rely on the
               // idiom that e.g. `List <: Any`. We have to bootstrap without scalac first.

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -319,7 +319,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling {
         thirdTry
       case tp1: TypeParamRef =>
         def flagNothingBound = {
-          if (!frozenConstraint && tp2.isRef(defn.NothingClass) && state.isGlobalCommittable) {
+          if (!frozenConstraint && tp2.isRef(NothingClass) && state.isGlobalCommittable) {
             def msg = s"!!! instantiated to Nothing: $tp1, constraint = ${constraint.show}"
             if (Config.failOnInstantiationToNothing) assert(false, msg)
             else ctx.log(msg)
@@ -404,7 +404,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling {
         if (cls2.isClass) {
           if (cls2.typeParams.isEmpty) {
             if (cls2 eq AnyKindClass) return true
-            if (tp1.isRef(defn.NothingClass)) return true
+            if (tp1.isRef(NothingClass)) return true
             if (tp1.isLambdaSub) return false
               // Note: We would like to replace this by `if (tp1.hasHigherKind)`
               // but right now we cannot since some parts of the standard library rely on the
@@ -417,7 +417,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling {
             val base = tp1.baseType(cls2)
             if (base.typeSymbol == cls2) return true
           }
-          else if (tp1.isLambdaSub && !tp1.isRef(defn.AnyKindClass))
+          else if (tp1.isLambdaSub && !tp1.isRef(AnyKindClass))
             return recur(tp1, EtaExpansion(cls2.typeRef))
         }
         fourthTry
@@ -1382,7 +1382,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling {
                       // at run time. It would not work to replace that with `Nothing`.
                       // However, maybe we can still apply the replacement to
                       // types which are not explicitly written.
-                      defn.NothingType
+                      NothingType
                     case _ => andType(tp1, tp2)
                   }
                 case _ => andType(tp1, tp2)
@@ -1393,8 +1393,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling {
   }
 
   /** The greatest lower bound of a list types */
-  final def glb(tps: List[Type]): Type =
-    ((defn.AnyType: Type) /: tps)(glb)
+  final def glb(tps: List[Type]): Type = ((AnyType: Type) /: tps)(glb)
 
   /** The least upper bound of two types
    *  @param canConstrain  If true, new constraints might be added to simplify the lub.
@@ -1424,7 +1423,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling {
 
   /** The least upper bound of a list of types */
   final def lub(tps: List[Type]): Type =
-    ((defn.NothingType: Type) /: tps)(lub(_,_, canConstrain = false))
+    ((NothingType: Type) /: tps)(lub(_,_, canConstrain = false))
 
   /** Try to produce joint arguments for a lub `A[T_1, ..., T_n] | A[T_1', ..., T_n']` using
    *  the following strategies:

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -18,6 +18,7 @@ import Denotations._
 import Periods._
 import util.Stats._
 import util.SimpleIdentitySet
+import CheckRealizable._
 import reporting.diagnostic.Message
 import ast.tpd._
 import ast.TreeTypeMap
@@ -156,6 +157,12 @@ object Types {
       case tp: AnnotatedType => tp.parent.isStable
       case _ => false
     }
+
+    /** Does this type denote a realizable stable reference? Much more expensive to check
+     *  than isStable, that's why some of the checks are done later in PostTyper.
+     */
+    final def isStableRealizable(implicit ctx: Context): Boolean =
+      isStable && realizability(this) == Realizable
 
     /** Is this type a (possibly refined or applied or aliased) type reference
      *  to the given type symbol?

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4588,7 +4588,7 @@ object Types {
           forwarded.orElse(
             range(super.derivedSelect(tp, preLo).loBound, super.derivedSelect(tp, preHi).hiBound))
         case _ =>
-          if (pre == defn.AnyType) pre else super.derivedSelect(tp, pre) match {
+          super.derivedSelect(tp, pre) match {
             case TypeBounds(lo, hi) => range(lo, hi)
             case tp => tp
           }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4513,6 +4513,8 @@ object Types {
       else if (lo `eq` hi) lo
       else Range(lower(lo), upper(hi))
 
+    protected def emptyRange: Type = range(defn.NothingType, defn.AnyType)
+
     protected def isRange(tp: Type): Boolean = tp.isInstanceOf[Range]
 
     protected def lower(tp: Type): Type = tp match {
@@ -4586,7 +4588,7 @@ object Types {
           forwarded.orElse(
             range(super.derivedSelect(tp, preLo).loBound, super.derivedSelect(tp, preHi).hiBound))
         case _ =>
-          super.derivedSelect(tp, pre) match {
+          if (pre == defn.AnyType) pre else super.derivedSelect(tp, pre) match {
             case TypeBounds(lo, hi) => range(lo, hi)
             case tp => tp
           }
@@ -4637,7 +4639,7 @@ object Types {
       else tp.derivedTypeBounds(lo, hi)
 
     override protected def derivedSuperType(tp: SuperType, thistp: Type, supertp: Type): Type =
-      if (isRange(thistp) || isRange(supertp)) range(defn.NothingType, defn.AnyType)
+      if (isRange(thistp) || isRange(supertp)) emptyRange
       else tp.derivedSuperType(thistp, supertp)
 
     override protected def derivedAppliedType(tp: AppliedType, tycon: Type, args: List[Type]): Type =

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -478,8 +478,9 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
             addArg(typedArg(arg, formal), formal)
             if (methodType.isParamDependent && typeOfArg(arg).exists)
               // `typeOfArg(arg)` could be missing because the evaluation of `arg` produced type errors
-              safeSubstParam(_, methodType.paramRefs(n), typeOfArg(arg))
-            else identity
+              safeSubstParam(_, methodType.paramRefs(n), typeOfArg(arg), initVariance = -1)
+            else
+              identity
           }
 
           def missingArg(n: Int): Unit = {

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -979,7 +979,7 @@ class RefChecks extends MiniPhase { thisPhase =>
     checkAllOverrides(cls)
     tree
   } catch {
-    case ex: MergeError =>
+    case ex: TypeError =>
       ctx.error(ex.getMessage, tree.pos)
       tree
   }

--- a/tests/neg/i4031-anysel.scala
+++ b/tests/neg/i4031-anysel.scala
@@ -1,0 +1,3 @@
+object Test {
+  val v: Any = 1: Any#L // error
+}

--- a/tests/neg/i4031-posttyper.scala
+++ b/tests/neg/i4031-posttyper.scala
@@ -1,0 +1,7 @@
+object App {
+  trait A { type L >: Any}
+  def upcast(a: A, x: Any): a.L = x
+  lazy val p: A { type L <: Nothing } = p
+  val q = new A { type L = Any }
+  def coerce2(x: Any): Int = upcast(p, x): p.L // error: not a legal path
+}

--- a/tests/neg/i4031.scala
+++ b/tests/neg/i4031.scala
@@ -1,0 +1,17 @@
+object App {
+  trait A { type L >: Any}
+  def upcast(a: A, x: Any): a.L = x
+  lazy val p: A { type L <: Nothing } = p
+  val q = new A { type L = Any }
+  def coerce(x: Any): Int = upcast(p, x)  // error: not a legal path
+
+  def compare(x: A, y: x.L) = assert(x == y)
+  def compare2(x: A)(y: x.type) = assert(x == y)
+
+
+  def main(args: Array[String]): Unit = {
+    println(coerce("Uh oh!"))
+    compare(p, p) // error: not a legal path
+    compare2(p)(p) // error: not a legal path
+  }
+}

--- a/tests/neg/i50-volatile.scala
+++ b/tests/neg/i50-volatile.scala
@@ -12,14 +12,21 @@ class Test {
 
   class Client extends o.Inner                          // old-error // old-error
 
-  def xToString(x: o.X): String = x                     // old-error
+  def xToString(x: o.X): String = x                     // error
 
   def intToString(i: Int): String = xToString(i)
 }
+
 object Test2 {
+  trait A {
+    type X = String
+  }
+  trait B {
+    type X = Int
+  }
+  lazy val o: A & B = ???
 
-  import Test.o._                                       // error
+  def xToString(x: o.X): String = x       // error
 
-  def xToString(x: X): String = x
-
+  def intToString(i: Int): String = xToString(i)
 }

--- a/tests/neg/i50-volatile.scala
+++ b/tests/neg/i50-volatile.scala
@@ -10,7 +10,7 @@ class Test {
   }
   lazy val o: A & B = ???
 
-  class Client extends o.Inner                          // old-error // old-error
+  class Client extends o.Inner                          // error // old-error
 
   def xToString(x: o.X): String = x                     // error
 

--- a/tests/neg/realizability.scala
+++ b/tests/neg/realizability.scala
@@ -1,0 +1,22 @@
+class C { type T }
+
+class Test {
+
+  type D <: C
+
+  lazy val a: C = ???
+  final lazy val b: C = ???
+  val c: D = ???
+  final lazy val d: D = ???
+
+  val x1: a.T = ???  // error: not a legal path, since a is lazy & non-final
+  val x2: b.T = ???  // OK, b is lazy but concrete
+  val x3: c.T = ???  // OK, c is abstract but strict
+  val x4: d.T = ???  // error: not a legal path since d is abstract and lazy
+
+  val y1: Singleton = a
+  val y2: Singleton = a
+  val y3: Singleton = a
+  val y4: Singleton = a
+
+}

--- a/tests/pos-deep-subtype/i4036.scala
+++ b/tests/pos-deep-subtype/i4036.scala
@@ -1,0 +1,64 @@
+trait A { def x: this.type = this; type T }
+trait B { def y: this.type = this; def x: y.type = y; type T }
+object A {
+  val v = new A { type T = Int }
+  v: v.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.type
+
+  1: v.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.T
+
+  val u = new B { type T = Int }
+  u: u.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.
+    x.type
+
+  val z = new B { type T = this.type }
+  z: z.T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#
+    T#T#T#T#T#T#T#T#T#T#T#T#T#T#T#T
+}

--- a/tests/pos/i4031.scala
+++ b/tests/pos/i4031.scala
@@ -1,0 +1,8 @@
+object App {
+  trait A { type L >: Any}
+  def upcast(a: A, x: Any): a.L = x
+  lazy val p: A { type L <: Nothing } = p
+  val q = new A { type L = Any }
+  def coerce1(x: Any): Any = upcast(q, x)  // ok
+  def coerce3(x: Any): Any = upcast(p, x)  // ok, since dependent result type is not needed
+}


### PR DESCRIPTION
Fix #4031. This PR builds off #5558 and otherwise rebases the core changes related to that in #4036 (which were mostly about *using* realizability, not changing it).

There's still a fishy part from #4031 to make `tests/pos/i4031.scala` work:
```scala
def upcast(a: A, x: Any): a.L = x
def coerce3(x: Any): Any = upcast(p, x) // p is unstable!
```

When typechecking `coerce3`, since `p` is unstable, the return type cannot be `p.L`; so `safeSubstParam` eliminates references to `p`. Currently that produces `Any#L`; so we either produce something better, or we add some kludge so that `Any#L <: Any`. In both cases, per test `i4031-anysel.scala`, the user must still be forbidden from writing `Any#L`. There are two solutions here (from @odersky):
1. either change `derivedSelect(tp, pre = Any)` to give `Any`, so that `Any#L` gives `Any`.
2. or just make `Any` a supertype of all types, similarly to `AnyKind`, but keeping `Any` kind-monomorphic (I think?) thanks to `isLambdaSub`.