### PR TITLE
Always use Module suffix for abstract modules in TASTy Reflect

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/CaseDefOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/CaseDefOpsImpl.scala
@@ -9,7 +9,7 @@ trait CaseDefOpsImpl extends scala.tasty.reflect.CaseDefOps with CoreImpl with H
     def rhs(implicit ctx: Context): Term = caseDef.body
   }
 
-  object CaseDef extends CaseDefExtractor {
+  object CaseDef extends CaseDefModule {
     def unapply(x: CaseDef): Some[(Pattern, Option[Term], Term)] = Some(x.pat, optional(x.guard), x.body)
   }
 
@@ -18,7 +18,7 @@ trait CaseDefOpsImpl extends scala.tasty.reflect.CaseDefOps with CoreImpl with H
     def rhs(implicit ctx: Context): Term = caseDef.body
   }
 
-  object TypeCaseDef extends TypeCaseDefExtractor {
+  object TypeCaseDef extends TypeCaseDefModule {
     def unapply(x: TypeCaseDef): Some[(TypeTree, TypeTree)] = Some((x.pat, x.body))
   }
 }

--- a/compiler/src/dotty/tools/dotc/tastyreflect/ConstantOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ConstantOpsImpl.scala
@@ -11,85 +11,85 @@ trait ConstantOpsImpl extends scala.tasty.reflect.ConstantOps with CoreImpl {
 
   object Constant extends ConstantModule {
 
-    object Unit extends UnitExtractor {
+    object Unit extends UnitModule {
       def unapply(x: Constant): Boolean = x.tag == Constants.UnitTag
     }
 
-    object Null extends NullExtractor {
+    object Null extends NullModule {
       def unapply(x: Constant): Boolean = x.tag == Constants.NullTag
     }
 
-    object Boolean extends BooleanExtractor {
+    object Boolean extends BooleanModule {
       def unapply(x: Constant): Option[Boolean] = x match {
         case x: Constants.Constant if x.tag == Constants.BooleanTag => Some(x.booleanValue)
         case _ => None
       }
     }
 
-    object Byte extends ByteExtractor {
+    object Byte extends ByteModule {
       def unapply(x: Constant): Option[Byte] = x match {
         case x: Constants.Constant if x.tag == Constants.ByteTag => Some(x.byteValue)
         case _ => None
       }
     }
 
-    object Short extends ShortExtractor {
+    object Short extends ShortModule {
       def unapply(x: Constant): Option[Short] = x match {
         case x: Constants.Constant if x.tag == Constants.ShortTag => Some(x.shortValue)
         case _ => None
       }
     }
 
-    object Char extends CharExtractor {
+    object Char extends CharModule {
       def unapply(x: Constant): Option[Char] = x match {
         case x: Constants.Constant if x.tag == Constants.CharTag => Some(x.charValue)
         case _ => None
       }
     }
 
-    object Int extends IntExtractor {
+    object Int extends IntModule {
       def unapply(x: Constant): Option[Int] = x match {
         case x: Constants.Constant if x.tag == Constants.IntTag => Some(x.intValue)
         case _ => None
       }
     }
 
-    object Long extends LongExtractor {
+    object Long extends LongModule {
       def unapply(x: Constant): Option[Long] = x match {
         case x: Constants.Constant if x.tag == Constants.LongTag => Some(x.longValue)
         case _ => None
       }
     }
 
-    object Float extends FloatExtractor {
+    object Float extends FloatModule {
       def unapply(x: Constant): Option[Float] = x match {
         case x: Constants.Constant if x.tag == Constants.FloatTag => Some(x.floatValue)
         case _ => None
       }
     }
 
-    object Double extends DoubleExtractor {
+    object Double extends DoubleModule {
       def unapply(x: Constant): Option[Double] = x match {
         case x: Constants.Constant if x.tag == Constants.DoubleTag => Some(x.doubleValue)
         case _ => None
       }
     }
 
-    object String extends StringExtractor {
+    object String extends StringModule {
       def unapply(x: Constant): Option[String] = x match {
         case x: Constants.Constant if x.tag == Constants.StringTag => Some(x.stringValue)
         case _ => None
       }
     }
 
-    object ClassTag extends ClassTagExtractor {
+    object ClassTag extends ClassTagModule {
       def unapply(x: Constant): Option[Type] = x match {
         case x: Constants.Constant if x.tag == Constants.ClazzTag => Some(x.typeValue)
         case _ => None
       }
     }
 
-    object Symbol extends SymbolExtractor {
+    object Symbol extends SymbolModule {
       def unapply(x: Constant): Option[scala.Symbol] = x match {
         case x: Constants.Constant if x.tag == Constants.ScalaSymbolTag => Some(x.scalaSymbolValue)
         case _ => None

--- a/compiler/src/dotty/tools/dotc/tastyreflect/IdOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/IdOpsImpl.scala
@@ -9,7 +9,7 @@ trait IdOpsImpl extends scala.tasty.reflect.IdOps with CoreImpl {
     def name(implicit ctx: Context): String = id.name.toString
   }
 
-  object Id extends IdExtractor {
+  object Id extends IdModule {
     def unapply(id: Id): Option[String] = Some(id.name.toString)
   }
 

--- a/compiler/src/dotty/tools/dotc/tastyreflect/ImportSelectorOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ImportSelectorOpsImpl.scala
@@ -5,21 +5,21 @@ import dotty.tools.dotc.core.StdNames.nme
 
 trait ImportSelectorOpsImpl extends scala.tasty.reflect.ImportSelectorOps with CoreImpl {
 
-  object SimpleSelector extends SimpleSelectorExtractor {
+  object SimpleSelector extends SimpleSelectorModule {
     def unapply(x: ImportSelector)(implicit ctx: Context): Option[Id] = x match {
       case x: untpd.Ident => Some(x)
       case _ => None
     }
   }
 
-  object RenameSelector extends RenameSelectorExtractor {
+  object RenameSelector extends RenameSelectorModule {
     def unapply(x: ImportSelector)(implicit ctx: Context): Option[(Id, Id)] = x match {
       case Trees.Thicket((id1: untpd.Ident) :: (id2: untpd.Ident) :: Nil) if id2.name != nme.WILDCARD => Some(id1, id2)
       case _ => None
     }
   }
 
-  object OmitSelector extends OmitSelectorExtractor {
+  object OmitSelector extends OmitSelectorModule {
     def unapply(x: ImportSelector)(implicit ctx: Context): Option[Id] = x match {
       case Trees.Thicket((id: untpd.Ident) :: Trees.Ident(nme.WILDCARD) :: Nil) => Some(id)
       case _ => None

--- a/compiler/src/dotty/tools/dotc/tastyreflect/PatternOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/PatternOpsImpl.scala
@@ -14,7 +14,7 @@ trait PatternOpsImpl extends scala.tasty.reflect.PatternOps with CoreImpl {
 
   object Pattern extends PatternModule {
 
-    object Value extends ValueExtractor {
+    object Value extends ValueModule {
       def unapply(x: Pattern)(implicit ctx: Context): Option[Term] = x match {
         case lit: tpd.Literal => Some(lit)
         case ref: tpd.RefTree if ref.isTerm => Some(ref)
@@ -23,14 +23,14 @@ trait PatternOpsImpl extends scala.tasty.reflect.PatternOps with CoreImpl {
       }
     }
 
-    object Bind extends BindExtractor {
+    object Bind extends BindModule {
       def unapply(x: Pattern)(implicit ctx: Context): Option[(String, Pattern)] = x match {
         case x: tpd.Bind if x.name.isTermName => Some(x.name.toString, x.body)
         case _ => None
       }
     }
 
-    object Unapply extends UnapplyExtractor {
+    object Unapply extends UnapplyModule {
       def unapply(x: Pattern)(implicit ctx: Context): Option[(Term, List[Term], List[Pattern])] = x match {
         case Trees.UnApply(fun, implicits, patterns) => Some((fun, implicits, effectivePatterns(patterns)))
         case Trees.Typed(Trees.UnApply(fun, implicits, patterns), _) => Some((fun, implicits, effectivePatterns(patterns)))
@@ -42,14 +42,14 @@ trait PatternOpsImpl extends scala.tasty.reflect.PatternOps with CoreImpl {
       }
     }
 
-    object Alternative extends AlternativeExtractor {
+    object Alternative extends AlternativeModule {
       def unapply(x: Pattern)(implicit ctx: Context): Option[List[Pattern]] = x match {
         case x: tpd.Alternative => Some(x.trees)
         case _ => None
       }
     }
 
-    object TypeTest extends TypeTestExtractor {
+    object TypeTest extends TypeTestModule {
       def unapply(x: Pattern)(implicit ctx: Context): Option[TypeTree] = x match {
         case Trees.Typed(Trees.UnApply(_, _, _), _) => None
         case Trees.Typed(_, tpt) => Some(tpt)

--- a/compiler/src/dotty/tools/dotc/tastyreflect/SignatureOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/SignatureOpsImpl.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc.tastyreflect
 
 trait SignatureOpsImpl extends scala.tasty.reflect.SignatureOps with CoreImpl {
 
-  object Signature extends SignatureExtractor {
+  object Signature extends SignatureModule {
     def unapply(x: Signature)(implicit ctx: Context): Option[(List[String], String)] = {
       Some((x.paramsSig.map(_.toString), x.resSig.toString))
     }

--- a/compiler/src/dotty/tools/dotc/tastyreflect/StandardDefinitions.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/StandardDefinitions.scala
@@ -8,7 +8,7 @@ trait StandardDefinitions extends scala.tasty.reflect.StandardDefinitions {
 
   private implicit def ctx: Context = rootContext
 
-  val definitions: DefinitionsApi = new DefinitionsApi {
+  val definitions: DefinitionsAPI = new DefinitionsAPI {
 
     def RootPackage: Symbol = defn.RootPackage
     def RootClass: Symbol = defn.RootClass

--- a/compiler/src/dotty/tools/dotc/tastyreflect/SymbolOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/SymbolOpsImpl.scala
@@ -78,7 +78,7 @@ trait SymbolOpsImpl extends scala.tasty.reflect.SymbolOps with CoreImpl {
 
   }
 
-  object IsPackageSymbol extends IsPackageSymbolExtractor {
+  object IsPackageSymbol extends IsPackageSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[PackageSymbol] =
       if (symbol.is(Flags.Package)) Some(symbol) else None
   }
@@ -87,7 +87,7 @@ trait SymbolOpsImpl extends scala.tasty.reflect.SymbolOps with CoreImpl {
     def tree(implicit ctx: Context): PackageDef = FromSymbol.packageDefFromSym(symbol)
   }
 
-  object IsTypeSymbol extends IsTypeSymbolExtractor {
+  object IsTypeSymbol extends IsTypeSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[TypeSymbol] =
       if (symbol.isType) Some(symbol.asType) else None
   }
@@ -100,7 +100,7 @@ trait SymbolOpsImpl extends scala.tasty.reflect.SymbolOps with CoreImpl {
     def of(fullName: String)(implicit ctx: Context): ClassSymbol = ctx.requiredClass(fullName)
   }
 
-  object IsClassSymbol extends IsClassSymbolExtractor {
+  object IsClassSymbol extends IsClassSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[ClassSymbol] =
       if (symbol.isClass) Some(symbol.asClass) else None
   }
@@ -164,7 +164,7 @@ trait SymbolOpsImpl extends scala.tasty.reflect.SymbolOps with CoreImpl {
     private def isField(sym: Symbol)(implicit ctx: Context): Boolean = sym.isTerm && !sym.is(Flags.Method)
   }
 
-  object IsDefSymbol extends IsDefSymbolExtractor {
+  object IsDefSymbol extends IsDefSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[DefSymbol] =
       if (symbol.isTerm && symbol.is(Flags.Method)) Some(symbol.asTerm) else None
   }
@@ -173,7 +173,7 @@ trait SymbolOpsImpl extends scala.tasty.reflect.SymbolOps with CoreImpl {
     def tree(implicit ctx: Context): DefDef = FromSymbol.defDefFromSym(symbol)
   }
 
-  object IsValSymbol extends IsValSymbolExtractor {
+  object IsValSymbol extends IsValSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[ValSymbol] =
       if (symbol.isTerm && !symbol.is(Flags.Method) && !symbol.is(Flags.Case)) Some(symbol.asTerm) else None
   }
@@ -187,7 +187,7 @@ trait SymbolOpsImpl extends scala.tasty.reflect.SymbolOps with CoreImpl {
     }
   }
 
-  object IsBindSymbol extends IsBindSymbolExtractor {
+  object IsBindSymbol extends IsBindSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[BindSymbol] =
       if (symbol.isTerm && symbol.is(Flags.Case)) Some(symbol.asTerm) else None // TODO
   }
@@ -196,7 +196,7 @@ trait SymbolOpsImpl extends scala.tasty.reflect.SymbolOps with CoreImpl {
     def tree(implicit ctx: Context): Bind = FromSymbol.bindFromSym(symbol)
   }
 
-  object NoSymbol extends NoSymbolExtractor {
+  object NoSymbol extends NoSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Boolean = symbol ne core.Symbols.NoSymbol
   }
 }

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TreeOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TreeOpsImpl.scala
@@ -20,7 +20,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
     }
   }
 
-  object PackageClause extends PackageClauseExtractor {
+  object PackageClause extends PackageClauseModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[Tree])] = tree match {
       case x: tpd.PackageDef => Some((x.pid, x.stats))
       case _ => None
@@ -33,7 +33,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
 
   // ----- Statements -----------------------------------------------
 
-  object Import extends ImportExtractor {
+  object Import extends ImportModule {
     def unapply(x: Tree)(implicit ctx: Context): Option[(Term, List[ImportSelector])] = x match {
       case x: tpd.Import => Some((x.expr, x.selectors))
       case _ => None
@@ -68,7 +68,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
     }
   }
 
-  object ClassDef extends ClassDefExtractor {
+  object ClassDef extends ClassDefModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, DefDef, List[TermOrTypeTree],  Option[ValDef], List[Statement])] = tree match {
       case Trees.TypeDef(name, impl: tpd.Template) =>
         Some((name.toString, impl.constr, impl.parents, optional(impl.self), impl.body))
@@ -94,7 +94,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
     }
   }
 
-  object DefDef extends DefDefExtractor {
+  object DefDef extends DefDefModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, List[TypeDef],  List[List[ValDef]], TypeTree, Option[Term])] = tree match {
       case x: tpd.DefDef =>
         Some((x.name.toString, x.tparams, x.vparamss, x.tpt, optional(x.rhs)))
@@ -119,7 +119,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
     }
   }
 
-  object ValDef extends ValDefExtractor {
+  object ValDef extends ValDefModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, TypeTree, Option[Term])] = tree match {
       case x: tpd.ValDef =>
         Some((x.name.toString, x.tpt, optional(x.rhs)))
@@ -142,7 +142,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
     }
   }
 
-  object TypeDef extends TypeDefExtractor {
+  object TypeDef extends TypeDefModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, TypeOrBoundsTree /* TypeTree | TypeBoundsTree */)] = tree match {
       case x: tpd.TypeDef if !x.symbol.isClass => Some((x.name.toString, x.rhs))
       case _ => None
@@ -175,7 +175,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
     }
   }
 
-  object PackageDef extends PackageDefExtractor {
+  object PackageDef extends PackageDefModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, PackageDef)] = tree match {
       case x: PackageDefinition =>
         Some((x.symbol.name.toString, packageDefFromSym(x.symbol.owner)))
@@ -213,7 +213,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def name(implicit ctx: Context): String = x.name.show
     }
 
-    object Ident extends IdentExtractor {
+    object Ident extends IdentModule {
       def unapply(x: Term)(implicit ctx: Context): Option[String] = x match {
         case x: tpd.Ident if x.isTerm => Some(x.name.show)
         case _ => None
@@ -235,7 +235,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
         else Some(x.symbol.signature)
     }
 
-    object Select extends SelectExtractor {
+    object Select extends SelectModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, String)] = x match {
         case x: tpd.Select if x.isTerm => Some((x.qualifier, x.name.toString))
         case _ => None
@@ -254,7 +254,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def constant(implicit ctx: Context): Constant = x.const
     }
 
-    object Literal extends LiteralExtractor {
+    object Literal extends LiteralModule {
       def unapply(x: Term)(implicit ctx: Context): Option[Constant] = x match {
         case Trees.Literal(const) => Some(const)
         case _ => None
@@ -272,7 +272,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def id(implicit ctx: Context): Option[Id] = optional(x.qual)
     }
 
-    object This extends ThisExtractor {
+    object This extends ThisModule {
       def unapply(x: Term)(implicit ctx: Context): Option[Option[Id]] = x match {
         case Trees.This(qual) => Some(optional(qual))
         case _ => None
@@ -291,7 +291,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def tpt(implicit ctx: Context): TypeTree = x.tpt
     }
 
-    object New extends NewExtractor {
+    object New extends NewModule {
       def unapply(x: Term)(implicit ctx: Context): Option[TypeTree] = x match {
         case x: tpd.New => Some(x.tpt)
         case _ => None
@@ -310,7 +310,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def value(implicit ctx: Context): Term = x.arg
     }
 
-    object NamedArg extends NamedArgExtractor {
+    object NamedArg extends NamedArgModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(String, Term)] = x match {
         case x: tpd.NamedArg if x.name.isInstanceOf[Names.TermName] => Some((x.name.toString, x.arg))
         case _ => None
@@ -329,7 +329,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def args(implicit ctx: Context): List[Term] = x.args
     }
 
-    object Apply extends ApplyExtractor {
+    object Apply extends ApplyModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[Term])] = x match {
         case x: tpd.Apply => Some((x.fun, x.args))
         case _ => None
@@ -348,7 +348,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def args(implicit ctx: Context): List[TypeTree] = x.args
     }
 
-    object TypeApply extends TypeApplyExtractor {
+    object TypeApply extends TypeApplyModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[TypeTree])] = x match {
         case x: tpd.TypeApply => Some((x.fun, x.args))
         case _ => None
@@ -367,7 +367,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def id(implicit ctx: Context): Option[untpd.Ident] = optional(x.mix)
     }
 
-    object Super extends SuperExtractor {
+    object Super extends SuperModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Option[Id])] = x match {
         case x: tpd.Super => Some((x.qual, if (x.mix.isEmpty) None else Some(x.mix)))
         case _ => None
@@ -386,7 +386,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def tpt(implicit ctx: Context): TypeTree = x.tpt
     }
 
-    object Typed extends TypedExtractor {
+    object Typed extends TypedModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, TypeTree)] = x match {
         case x: tpd.Typed => Some((x.expr, x.tpt))
         case _ => None
@@ -405,7 +405,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def rhs(implicit ctx: Context): Term = x.rhs
     }
 
-    object Assign extends AssignExtractor {
+    object Assign extends AssignModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Term)] = x match {
         case x: tpd.Assign => Some((x.lhs, x.rhs))
         case _ => None
@@ -453,7 +453,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def expr(implicit ctx: Context): Term = x.expr
     }
 
-    object Block extends BlockExtractor {
+    object Block extends BlockModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(List[Statement], Term)] = x match {
         case IsBlock(x) => Some((x.stats, x.expr))
         case _ => None
@@ -473,7 +473,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def body(implicit ctx: Context): Term = x.expansion
     }
 
-    object Inlined extends InlinedExtractor {
+    object Inlined extends InlinedModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Option[TermOrTypeTree], List[Statement], Term)] = x match {
         case x: tpd.Inlined =>
           Some((optional(x.call), x.bindings, x.expansion))
@@ -493,7 +493,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def tptOpt(implicit ctx: Context): Option[TypeTree] = optional(x.tpt)
     }
 
-    object Lambda extends LambdaExtractor {
+    object Lambda extends LambdaModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Option[TypeTree])] = x match {
         case x: tpd.Closure => Some((x.meth, optional(x.tpt)))
         case _ => None
@@ -513,7 +513,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def elsep(implicit ctx: Context): Term = x.elsep
     }
 
-    object If extends IfExtractor {
+    object If extends IfModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Term, Term)] = x match {
         case x: tpd.If => Some((x.cond, x.thenp, x.elsep))
         case _ => None
@@ -532,7 +532,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def cases(implicit ctx: Context): List[tpd.CaseDef] = x.cases
     }
 
-    object Match extends MatchExtractor {
+    object Match extends MatchModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[CaseDef])] = x match {
         case x: tpd.Match => Some((x.selector, x.cases))
         case _ => None
@@ -552,7 +552,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def finalizer(implicit ctx: Context): Option[Term] = optional(x.finalizer)
     }
 
-    object Try extends TryExtractor {
+    object Try extends TryModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, List[CaseDef], Option[Term])] = x match {
         case x: tpd.Try => Some((x.expr, x.cases, optional(x.finalizer)))
         case _ => None
@@ -570,7 +570,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def expr(implicit ctx: Context): Term = x.expr
     }
 
-    object Return extends ReturnExtractor {
+    object Return extends ReturnModule {
       def unapply(x: Term)(implicit ctx: Context): Option[Term] = x match {
         case x: tpd.Return => Some(x.expr)
         case _ => None
@@ -588,7 +588,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def elems(implicit ctx: Context): List[Term] = x.elems
     }
 
-    object Repeated extends RepeatedExtractor {
+    object Repeated extends RepeatedModule {
       def unapply(x: Term)(implicit ctx: Context): Option[List[Term]] = x match {
         case x: tpd.SeqLiteral => Some(x.elems)
         case _ => None
@@ -615,7 +615,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def tpe(implicit ctx: Context): Type = x.tpe.stripTypeVar
     }
 
-    object SelectOuter extends SelectOuterExtractor {
+    object SelectOuter extends SelectOuterModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Int, Type)] = x match {
         case x: tpd.Select =>
           x.name match {
@@ -638,7 +638,7 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with CoreImpl with Helpers
       def body(implicit ctx: Context): Term = x.body
     }
 
-    object While extends WhileExtractor {
+    object While extends WhileModule {
       def unapply(x: Term)(implicit ctx: Context): Option[(Term, Term)] = x match {
         case x: tpd.WhileDo => Some((x.cond, x.body))
         case _ => None

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsOpsImpl.scala
@@ -31,7 +31,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
     def resultTpe(implicit ctx: Context): Type = tpe.resType
   }
 
-  object IsType extends IsTypeExtractor {
+  object IsType extends IsTypeModule {
     def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[Type] = x match {
       case x: TypeBounds => None
       case x if x == Types.NoPrefix => None
@@ -52,7 +52,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def value(implicit ctx: Context): Any = x.value
     }
 
-    object ConstantType extends ConstantTypeExtractor {
+    object ConstantType extends ConstantTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[Constant] = x match {
         case Types.ConstantType(value) => Some(value)
         case _ => None
@@ -74,7 +74,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def qualifier(implicit ctx: Context): TypeOrBounds = x.prefix
     }
 
-    object SymRef extends SymRefExtractor {
+    object SymRef extends SymRefModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Symbol, TypeOrBounds /* Type | NoPrefix */)] = x  match {
         case tp: Types.NamedType =>
           tp.designator match {
@@ -100,7 +100,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def qualifier(implicit ctx: Context): TypeOrBounds = x.prefix
     }
 
-    object TermRef extends TermRefExtractor {
+    object TermRef extends TermRefModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)] = x match {
         case tp: Types.NamedType =>
           tp.designator match {
@@ -127,7 +127,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def qualifier(implicit ctx: Context): TypeOrBounds = x.prefix
     }
 
-    object TypeRef extends TypeRefExtractor {
+    object TypeRef extends TypeRefModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)] = x match {
         case tp: Types.NamedType =>
           tp.designator match {
@@ -150,7 +150,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def supertpe(implicit ctx: Context): Type = x.supertpe
     }
 
-    object SuperType extends SuperTypeExtractor {
+    object SuperType extends SuperTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)] = x match {
         case Types.SuperType(thistpe, supertpe) => Some(thistpe, supertpe)
         case _ => None
@@ -170,7 +170,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def info(implicit ctx: Context): TypeOrBounds = x.refinedInfo
     }
 
-    object Refinement extends RefinementExtractor {
+    object Refinement extends RefinementModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, String, TypeOrBounds /* Type | TypeBounds */)] = x match {
         case Types.RefinedType(parent, name, info) => Some(parent, name.toString, info)
         case _ => None
@@ -189,7 +189,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def args(implicit ctx: Context): List[TypeOrBounds] = x.args
     }
 
-    object AppliedType extends AppliedTypeExtractor {
+    object AppliedType extends AppliedTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, List[TypeOrBounds /* Type | TypeBounds */])] = x match {
         case Types.AppliedType(tycon, args) => Some((tycon.stripTypeVar, args.map(_.stripTypeVar)))
         case _ => None
@@ -208,7 +208,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def annot(implicit ctx: Context): Term = x.annot.tree
     }
 
-    object AnnotatedType extends AnnotatedTypeExtractor {
+    object AnnotatedType extends AnnotatedTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, Term)] = x match {
         case Types.AnnotatedType(underlying, annot) => Some((underlying.stripTypeVar, annot.tree))
         case _ => None
@@ -227,7 +227,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def right(implicit ctx: Context): Type = x.tp2.stripTypeVar
     }
 
-    object AndType extends AndTypeExtractor {
+    object AndType extends AndTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)] = x match {
         case Types.AndType(left, right) => Some(left.stripTypeVar, right.stripTypeVar)
         case _ => None
@@ -246,7 +246,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def right(implicit ctx: Context): Type = x.tp2
     }
 
-    object OrType extends OrTypeExtractor {
+    object OrType extends OrTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)] = x match {
         case Types.OrType(left, right) => Some(left.stripTypeVar, right.stripTypeVar)
         case _ => None
@@ -266,7 +266,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def cases(implicit ctx: Context): List[Type] = x.cases
     }
 
-    object MatchType extends MatchTypeExtractor {
+    object MatchType extends MatchTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type, List[Type])] = x match {
         case Types.MatchType(bound, scrutinee, cases) => Some((bound, scrutinee, cases))
         case _ => None
@@ -284,7 +284,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def underlying(implicit ctx: Context): Type = x.resType.stripTypeVar
     }
 
-    object ByNameType extends ByNameTypeExtractor {
+    object ByNameType extends ByNameTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[Type] = x match {
         case Types.ExprType(resType) => Some(resType.stripTypeVar)
         case _ => None
@@ -305,7 +305,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def paramNum(implicit ctx: Context): Int = x.paramNum
     }
 
-    object ParamRef extends ParamRefExtractor {
+    object ParamRef extends ParamRefModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(LambdaType[TypeOrBounds], Int)] = x match {
         case Types.TypeParamRef(binder, idx) =>
           Some((
@@ -327,7 +327,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def underlying(implicit ctx: Context): Type = x.underlying
     }
 
-    object ThisType extends ThisTypeExtractor {
+    object ThisType extends ThisTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[Type] = x match {
         case Types.ThisType(tp) => Some(tp)
         case _ => None
@@ -345,7 +345,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def binder(implicit ctx: Context): RecursiveType = x.binder
     }
 
-    object RecursiveThis extends RecursiveThisExtractor {
+    object RecursiveThis extends RecursiveThisModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[RecursiveType] = x match {
         case Types.RecThis(binder) => Some(binder)
         case _ => None
@@ -363,7 +363,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def underlying(implicit ctx: Context): Type = x.underlying.stripTypeVar
     }
 
-    object RecursiveType extends RecursiveTypeExtractor {
+    object RecursiveType extends RecursiveTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[Type] = x match {
         case tp: Types.RecType => Some(tp.underlying.stripTypeVar)
         case _ => None
@@ -383,7 +383,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def resType(implicit ctx: Context): Type = x.resType
     }
 
-    object MethodType extends MethodTypeExtractor {
+    object MethodType extends MethodTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(List[String], List[Type], Type)] = x match {
         case x: MethodType => Some(x.paramNames.map(_.toString), x.paramInfos, x.resType)
         case _ => None
@@ -403,7 +403,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def resType(implicit ctx: Contexts.Context): Type = x.resType
     }
 
-    object PolyType extends PolyTypeExtractor {
+    object PolyType extends PolyTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(List[String], List[TypeBounds], Type)] = x match {
         case x: PolyType => Some(x.paramNames.map(_.toString), x.paramInfos, x.resType)
         case _ => None
@@ -423,7 +423,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       def resType(implicit ctx: Contexts.Context): Type = x.resType
     }
 
-    object TypeLambda extends TypeLambdaExtractor {
+    object TypeLambda extends TypeLambdaModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(List[String], List[TypeBounds], Type)] = x match {
         case x: TypeLambda => Some(x.paramNames.map(_.toString), x.paramInfos, x.resType)
         case _ => None
@@ -434,14 +434,14 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
 
   // ----- TypeBounds ------------------------------------------------
 
-  object IsTypeBounds extends IsTypeBoundsExtractor {
+  object IsTypeBounds extends IsTypeBoundsModule {
     def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[TypeBounds] = x match {
       case x: TypeBounds => Some(x)
       case _ => None
     }
   }
 
-  object TypeBounds extends TypeBoundsExtractor {
+  object TypeBounds extends TypeBoundsModule {
     def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)] = x match {
       case x: TypeBounds => Some(x.lo, x.hi)
       case _ => None
@@ -455,7 +455,7 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
 
   // ----- NoPrefix --------------------------------------------------
 
-  object NoPrefix extends NoPrefixExtractor {
+  object NoPrefix extends NoPrefixModule {
     def unapply(x: TypeOrBounds)(implicit ctx: Context): Boolean = x == Types.NoPrefix
   }
 

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsTreesOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsTreesOpsImpl.scala
@@ -22,7 +22,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
     def tpe(implicit ctx: Context): Type = tpt.tpe.stripTypeVar
   }
 
-  object IsTypeTree extends IsTypeTreeExtractor {
+  object IsTypeTree extends IsTypeTreeModule {
     def unapply(x: TypeOrBoundsTree)(implicit ctx: Context): Option[TypeTree] =
       if (x.isType) Some(x) else None
     def unapply(termOrTypeTree: TermOrTypeTree)(implicit ctx: Context, dummy: DummyImplicit): Option[TypeTree] =
@@ -42,7 +42,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
 
     }
 
-    object Inferred extends InferredExtractor {
+    object Inferred extends InferredModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Boolean = x match {
         case x @ Trees.TypeTree() => !x.tpe.isInstanceOf[Types.TypeBounds]
         case _ => false
@@ -60,7 +60,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def name(implicit ctx: Contexts.Context): String = x.name.toString
     }
 
-    object Ident extends IdentExtractor {
+    object Ident extends IdentModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[String] = x match {
         case x: tpd.Ident if x.isType => Some(x.name.toString)
         case _ => None
@@ -79,7 +79,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def name(implicit ctx: Contexts.Context): String = x.name.toString
     }
 
-    object Select extends SelectExtractor {
+    object Select extends SelectModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(Term, String)] = x match {
         case x: tpd.Select if x.isType && x.qualifier.isTerm => Some(x.qualifier, x.name.toString)
         case _ => None
@@ -98,7 +98,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def name(implicit ctx: Contexts.Context): String = x.name.toString
     }
 
-    object Project extends ProjectExtractor {
+    object Project extends ProjectModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, String)] = x match {
         case x: tpd.Select if x.isType && x.qualifier.isType => Some(x.qualifier, x.name.toString)
         case _ => None
@@ -116,7 +116,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def ref(implicit ctx: Contexts.Context): Term = x.ref
     }
 
-    object Singleton extends SingletonExtractor {
+    object Singleton extends SingletonModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[Term] = x match {
         case x: tpd.SingletonTypeTree => Some(x.ref)
         case _ => None
@@ -135,7 +135,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def refinements(implicit ctx: Contexts.Context): List[Definition] = x.refinements
     }
 
-    object Refined extends RefinedExtractor {
+    object Refined extends RefinedModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, List[Definition])] = x match {
         case x: tpd.RefinedTypeTree => Some(x.tpt, x.refinements)
         case _ => None
@@ -154,7 +154,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def args(implicit ctx: Contexts.Context): List[TypeOrBoundsTree] = x.args
     }
 
-    object Applied extends AppliedExtractor {
+    object Applied extends AppliedModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, List[TypeOrBoundsTree])] = x match {
         case x: tpd.AppliedTypeTree => Some(x.tpt, x.args)
         case _ => None
@@ -173,7 +173,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def annotation(implicit ctx: Contexts.Context): Term = x.annot
     }
 
-    object Annotated extends AnnotatedExtractor {
+    object Annotated extends AnnotatedModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, Term)] = x match {
         case x: tpd.Annotated => Some(x.arg, x.annot)
         case _ => None
@@ -192,7 +192,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def right(implicit ctx: Contexts.Context): TypeTree = x.right
     }
 
-    object And extends AndExtractor {
+    object And extends AndModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)] = x match {
         case x: tpd.AndTypeTree => Some(x.left, x.right)
         case _ => None
@@ -211,7 +211,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def right(implicit ctx: Contexts.Context): TypeTree = x.right
     }
 
-    object Or extends OrExtractor {
+    object Or extends OrModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)] = x match {
         case x: tpd.OrTypeTree => Some(x.left, x.right)
         case _ => None
@@ -231,7 +231,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def cases(implicit ctx: Contexts.Context): List[CaseDef] = x.cases
     }
 
-    object MatchType extends MatchTypeExtractor {
+    object MatchType extends MatchTypeModule {
       def unapply(x: TypeOrBoundsTree)(implicit ctx: Context): Option[(Option[TypeTree], TypeTree, List[CaseDef])] = x match {
         case x: tpd.MatchTypeTree => Some((if (x.bound == tpd.EmptyTree) None else Some(x.bound), x.selector, x.cases))
         case _ => None
@@ -249,7 +249,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def result(implicit ctx: Contexts.Context): TypeTree = x.result
     }
 
-    object ByName extends ByNameExtractor {
+    object ByName extends ByNameModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[TypeTree] = x match {
         case x: tpd.ByNameTypeTree => Some(x.result)
         case _ => None
@@ -268,7 +268,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def body(implicit ctx: Contexts.Context): TypeOrBoundsTree = x.body
     }
 
-    object LambdaTypeTree extends LambdaTypeTreeExtractor {
+    object LambdaTypeTree extends LambdaTypeTreeModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(List[TypeDef], TypeOrBoundsTree)] = x match {
         case Trees.LambdaTypeTree(tparams, body) => Some((tparams, body))
         case _ => None
@@ -287,7 +287,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def body(implicit ctx: Contexts.Context): TypeOrBoundsTree = x.body
     }
 
-    object Bind extends BindExtractor {
+    object Bind extends BindModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(String, TypeOrBoundsTree)] = x match {
         case x: tpd.Bind if x.name.isTypeName => Some((x.name.toString, x.body))
         case _ => None
@@ -306,7 +306,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
       def tpt(implicit ctx: Contexts.Context): TypeTree = x.expr
     }
 
-    object Block extends BlockExtractor {
+    object Block extends BlockModule {
       def unapply(x: TypeTree)(implicit ctx: Context): Option[(List[TypeDef], TypeTree)] = x match {
         case x: tpd.Block => Some((x.stats.map { case alias: TypeDef => alias }, x.expr))
         case _ => None
@@ -322,7 +322,7 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
     def hi(implicit ctx: Context): TypeTree = bounds.hi
   }
 
-  object IsTypeBoundsTree extends IsTypeBoundsTreeExtractor {
+  object IsTypeBoundsTree extends IsTypeBoundsTreeModule {
     def unapply(x: TypeOrBoundsTree)(implicit ctx: Context): Option[TypeBoundsTree] = x match {
       case x: tpd.TypeBoundsTree => Some(x)
       case x @ Trees.TypeTree() =>
@@ -336,14 +336,14 @@ trait TypeOrBoundsTreesOpsImpl extends scala.tasty.reflect.TypeOrBoundsTreeOps w
     }
   }
 
-  object TypeBoundsTree extends TypeBoundsTreeExtractor {
+  object TypeBoundsTree extends TypeBoundsTreeModule {
     def unapply(x: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)] = x match {
       case IsTypeBoundsTree(x) => Some((x.lo, x.hi))
       case _ => None
     }
   }
 
-  object WildcardTypeTree extends WildcardTypeTreeExtractor {
+  object WildcardTypeTree extends WildcardTypeTreeModule {
     def unapply(x: TypeOrBoundsTree)(implicit ctx: Context): Boolean = x match {
       case Trees.Ident(nme.WILDCARD) => x.tpe.isInstanceOf[Types.TypeBounds]
       case _ => false

--- a/library/src/scala/tasty/reflect/CaseDefOps.scala
+++ b/library/src/scala/tasty/reflect/CaseDefOps.scala
@@ -11,8 +11,8 @@ trait CaseDefOps extends Core {
   }
   implicit def CaseDefDeco(caseDef: CaseDef): CaseDefAPI
 
-  val CaseDef: CaseDefExtractor
-  abstract class CaseDefExtractor {
+  val CaseDef: CaseDefModule
+  abstract class CaseDefModule {
     def unapply(x: CaseDef): Option[(Pattern, Option[Term], Term)]
   }
 
@@ -23,8 +23,8 @@ trait CaseDefOps extends Core {
   }
   implicit def TypeCaseDefDeco(caseDef: TypeCaseDef): TypeCaseDefAPI
 
-  val TypeCaseDef: TypeCaseDefExtractor
-  abstract class TypeCaseDefExtractor {
+  val TypeCaseDef: TypeCaseDefModule
+  abstract class TypeCaseDefModule {
     def unapply(x: TypeCaseDef): Option[(TypeTree, TypeTree)]
   }
 }

--- a/library/src/scala/tasty/reflect/ConstantOps.scala
+++ b/library/src/scala/tasty/reflect/ConstantOps.scala
@@ -8,73 +8,98 @@ trait ConstantOps extends Core {
   }
   implicit def ConstantDeco(const: Constant): ConstantAPI
 
+  /** Module of Constant literals */
   val Constant: ConstantModule
   abstract class ConstantModule {
 
-    val Unit: UnitExtractor
-    abstract class UnitExtractor {
+    /** Module of Null literals */
+    val Unit: UnitModule
+    abstract class UnitModule {
+      /** Extractor for Unit literals */
       def unapply(constant: Constant): Boolean
     }
 
-    val Null: NullExtractor
-    abstract class NullExtractor {
+    /** Module of Null literals */
+    val Null: NullModule
+    abstract class NullModule {
+      /** Extractor for Null literals */
       def unapply(constant: Constant): Boolean
     }
 
-    val Boolean: BooleanExtractor
-    abstract class BooleanExtractor {
+    /** Module of Boolean literals */
+    val Boolean: BooleanModule
+    abstract class BooleanModule {
+      /** Extractor for Boolean literals */
       def unapply(constant: Constant): Option[Boolean]
     }
 
-    val Byte: ByteExtractor
-    abstract class ByteExtractor {
+    /** Module of Byte literals */
+    val Byte: ByteModule
+    abstract class ByteModule {
+      /** Extractor for Byte literals */
       def unapply(constant: Constant): Option[Byte]
     }
 
-    val Short: ShortExtractor
-    abstract class ShortExtractor {
+    /** Module of Short literals */
+    val Short: ShortModule
+    abstract class ShortModule {
+      /** Extractor for Short literals */
       def unapply(constant: Constant): Option[Short]
     }
 
-    val Char: CharExtractor
-    abstract class CharExtractor {
+    /** Module of Char literals */
+    val Char: CharModule
+    abstract class CharModule {
+      /** Extractor for Char literals */
       def unapply(constant: Constant): Option[Char]
     }
 
-    val Int: IntExtractor
-    abstract class IntExtractor {
+    /** Module of Int literals */
+    val Int: IntModule
+    abstract class IntModule {
+      /** Extractor for Int literals */
       def unapply(constant: Constant): Option[Int]
     }
 
-    val Long: LongExtractor
-    abstract class LongExtractor {
+    /** Module of Long literals */
+    val Long: LongModule
+    abstract class LongModule {
+      /** Extractor for Long literals */
       def unapply(constant: Constant): Option[Long]
     }
 
-    val Float: FloatExtractor
-    abstract class FloatExtractor {
+    /** Module of Float literals */
+    val Float: FloatModule
+    abstract class FloatModule {
+      /** Extractor for Float literals */
       def unapply(constant: Constant): Option[Float]
     }
 
-    val Double: DoubleExtractor
-    abstract class DoubleExtractor {
+    /** Module of Double literals */
+    val Double: DoubleModule
+    abstract class DoubleModule {
+      /** Extractor for Double literals */
       def unapply(constant: Constant): Option[Double]
     }
 
-    val String: StringExtractor
-    abstract class StringExtractor {
+    /** Module of String literals */
+    val String: StringModule
+    abstract class StringModule {
+      /** Extractor for String literals */
       def unapply(constant: Constant): Option[String]
     }
 
-    val ClassTag: ClassTagExtractor
-    abstract class ClassTagExtractor {
+    /** Module of ClassTag literals */
+    val ClassTag: ClassTagModule
+    abstract class ClassTagModule {
+      /** Extractor for ClassTag literals */
       def unapply(constant: Constant): Option[Type]
     }
 
+    /** Module of scala.Symbol literals */
+    val Symbol: SymbolModule
     /** Extractor for scala.Symbol literals */
-    val Symbol: SymbolExtractor
-    /** Extractor for scala.Symbol literals */
-    abstract class SymbolExtractor {
+    abstract class SymbolModule {
       def unapply(constant: Constant): Option[scala.Symbol]
     }
   }

--- a/library/src/scala/tasty/reflect/IdOps.scala
+++ b/library/src/scala/tasty/reflect/IdOps.scala
@@ -10,8 +10,8 @@ trait IdOps extends Core {
   }
   implicit def IdDeco(id: Id): IdAPI
 
-  val Id: IdExtractor
-  abstract class IdExtractor {
+  val Id: IdModule
+  abstract class IdModule {
     def unapply(id: Id): Option[String]
   }
 

--- a/library/src/scala/tasty/reflect/ImportSelectorOps.scala
+++ b/library/src/scala/tasty/reflect/ImportSelectorOps.scala
@@ -3,18 +3,18 @@ package reflect
 
 trait ImportSelectorOps extends Core {
 
-  val SimpleSelector: SimpleSelectorExtractor
-  abstract class SimpleSelectorExtractor {
+  val SimpleSelector: SimpleSelectorModule
+  abstract class SimpleSelectorModule {
     def unapply(importSelector: ImportSelector)(implicit ctx: Context): Option[Id]
   }
 
-  val RenameSelector: RenameSelectorExtractor
-  abstract class RenameSelectorExtractor {
+  val RenameSelector: RenameSelectorModule
+  abstract class RenameSelectorModule {
     def unapply(importSelector: ImportSelector)(implicit ctx: Context): Option[(Id, Id)]
   }
 
-  val OmitSelector: OmitSelectorExtractor
-  abstract class OmitSelectorExtractor {
+  val OmitSelector: OmitSelectorModule
+  abstract class OmitSelectorModule {
     def unapply(importSelector: ImportSelector)(implicit ctx: Context): Option[Id]
   }
 

--- a/library/src/scala/tasty/reflect/PatternOps.scala
+++ b/library/src/scala/tasty/reflect/PatternOps.scala
@@ -14,28 +14,28 @@ trait PatternOps extends Core {
   val Pattern: PatternModule
   abstract class PatternModule {
 
-    val Value: ValueExtractor
-    abstract class ValueExtractor {
+    val Value: ValueModule
+    abstract class ValueModule {
       def unapply(pattern: Pattern)(implicit ctx: Context): Option[Term]
     }
 
-    val Bind: BindExtractor
-    abstract class BindExtractor {
+    val Bind: BindModule
+    abstract class BindModule {
       def unapply(pattern: Pattern)(implicit ctx: Context): Option[(String, Pattern)]
     }
 
-    val Unapply: UnapplyExtractor
-    abstract class UnapplyExtractor {
+    val Unapply: UnapplyModule
+    abstract class UnapplyModule {
       def unapply(pattern: Pattern)(implicit ctx: Context): Option[(Term, List[Term], List[Pattern])]
     }
 
-    val Alternative: AlternativeExtractor
-    abstract class AlternativeExtractor {
+    val Alternative: AlternativeModule
+    abstract class AlternativeModule {
       def unapply(pattern: Pattern)(implicit ctx: Context): Option[List[Pattern]]
     }
 
-    val TypeTest: TypeTestExtractor
-    abstract class TypeTestExtractor {
+    val TypeTest: TypeTestModule
+    abstract class TypeTestModule {
       def unapply(pattern: Pattern)(implicit ctx: Context): Option[TypeTree]
     }
   }

--- a/library/src/scala/tasty/reflect/SignatureOps.scala
+++ b/library/src/scala/tasty/reflect/SignatureOps.scala
@@ -3,8 +3,8 @@ package scala.tasty.reflect
 trait SignatureOps extends Core {
 
   /** Erased (JVM) signatures. */
-  val Signature: SignatureExtractor
-  abstract class SignatureExtractor {
+  val Signature: SignatureModule
+  abstract class SignatureModule {
     /** Matches the erased (JVM) signature and returns its parameters and result type. */
     def unapply(sig: Signature)(implicit ctx: Context): Option[(List[String], String)]
   }

--- a/library/src/scala/tasty/reflect/StandardDefinitions.scala
+++ b/library/src/scala/tasty/reflect/StandardDefinitions.scala
@@ -3,15 +3,15 @@ package reflect
 
 trait StandardDefinitions extends Core {
 
-  /** A value containing all standard definitions in [[DefinitionsApi]]
+  /** A value containing all standard definitions in [[DefinitionsAPI]]
     *  @group Definitions
     */
-  val definitions: DefinitionsApi
+  val definitions: DefinitionsAPI
 
   /** Defines standard symbols (and types via its base trait).
     *  @group API
     */
-  trait DefinitionsApi extends StandardTypes {
+  trait DefinitionsAPI extends StandardTypes {
 
     /** The module symbol of root package `_root_`. */
     def RootPackage: Symbol

--- a/library/src/scala/tasty/reflect/SymbolOps.scala
+++ b/library/src/scala/tasty/reflect/SymbolOps.scala
@@ -56,8 +56,8 @@ trait SymbolOps extends Core {
 
   // PackageSymbol
 
-  val IsPackageSymbol: IsPackageSymbolExtractor
-  abstract class IsPackageSymbolExtractor {
+  val IsPackageSymbol: IsPackageSymbolModule
+  abstract class IsPackageSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[PackageSymbol]
   }
 
@@ -68,8 +68,8 @@ trait SymbolOps extends Core {
 
   // ClassSymbol
 
-  val IsClassSymbol: IsClassSymbolExtractor
-  abstract class IsClassSymbolExtractor {
+  val IsClassSymbol: IsClassSymbolModule
+  abstract class IsClassSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[ClassSymbol]
   }
 
@@ -115,8 +115,8 @@ trait SymbolOps extends Core {
 
   // TypeSymbol
 
-  val IsTypeSymbol: IsTypeSymbolExtractor
-  abstract class IsTypeSymbolExtractor {
+  val IsTypeSymbol: IsTypeSymbolModule
+  abstract class IsTypeSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[TypeSymbol]
   }
 
@@ -128,8 +128,8 @@ trait SymbolOps extends Core {
 
   // DefSymbol
 
-  val IsDefSymbol: IsDefSymbolExtractor
-  abstract class IsDefSymbolExtractor {
+  val IsDefSymbol: IsDefSymbolModule
+  abstract class IsDefSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[DefSymbol]
   }
 
@@ -141,8 +141,8 @@ trait SymbolOps extends Core {
 
   // ValSymbol
 
-  val IsValSymbol: IsValSymbolExtractor
-  abstract class IsValSymbolExtractor {
+  val IsValSymbol: IsValSymbolModule
+  abstract class IsValSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[ValSymbol]
   }
 
@@ -158,8 +158,8 @@ trait SymbolOps extends Core {
 
   // BindSymbol
 
-  val IsBindSymbol: IsBindSymbolExtractor
-  abstract class IsBindSymbolExtractor {
+  val IsBindSymbol: IsBindSymbolModule
+  abstract class IsBindSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Option[BindSymbol]
   }
 
@@ -171,8 +171,8 @@ trait SymbolOps extends Core {
 
   // NoSymbol
 
-  val NoSymbol: NoSymbolExtractor
-  abstract class NoSymbolExtractor {
+  val NoSymbol: NoSymbolModule
+  abstract class NoSymbolModule {
     def unapply(symbol: Symbol)(implicit ctx: Context): Boolean
   }
 }

--- a/library/src/scala/tasty/reflect/TreeOps.scala
+++ b/library/src/scala/tasty/reflect/TreeOps.scala
@@ -16,8 +16,8 @@ trait TreeOps extends Core {
     def unapply(tree: Tree)(implicit ctx: Context): Option[PackageClause]
   }
 
-  val PackageClause: PackageClauseExtractor
-  abstract class PackageClauseExtractor {
+  val PackageClause: PackageClauseModule
+  abstract class PackageClauseModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[Tree])]
   }
 
@@ -28,8 +28,8 @@ trait TreeOps extends Core {
 
   // ----- Statements -----------------------------------------------
 
-  val Import: ImportExtractor
-  abstract class ImportExtractor {
+  val Import: ImportModule
+  abstract class ImportModule {
     def unapply(imp: Tree)(implicit ctx: Context): Option[(Term, List[ImportSelector])]
   }
 
@@ -58,8 +58,8 @@ trait TreeOps extends Core {
     def unapply(tree: Tree)(implicit ctx: Context): Option[ClassDef]
   }
 
-  val ClassDef: ClassDefExtractor
-  abstract class ClassDefExtractor {
+  val ClassDef: ClassDefModule
+  abstract class ClassDefModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, DefDef, List[TermOrTypeTree], Option[ValDef], List[Statement])]
   }
 
@@ -80,8 +80,8 @@ trait TreeOps extends Core {
     def unapply(tree: Tree)(implicit ctx: Context): Option[DefDef]
   }
 
-  val DefDef: DefDefExtractor
-  abstract class DefDefExtractor {
+  val DefDef: DefDefModule
+  abstract class DefDefModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, List[TypeDef],  List[List[ValDef]], TypeTree, Option[Term])]
   }
 
@@ -102,8 +102,8 @@ trait TreeOps extends Core {
     def unapply(tree: Tree)(implicit ctx: Context): Option[ValDef]
   }
 
-  val ValDef: ValDefExtractor
-  abstract class ValDefExtractor {
+  val ValDef: ValDefModule
+  abstract class ValDefModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, TypeTree, Option[Term])]
   }
 
@@ -122,8 +122,8 @@ trait TreeOps extends Core {
     def unapply(tree: Tree)(implicit ctx: Context): Option[TypeDef]
   }
 
-  val TypeDef: TypeDefExtractor
-  abstract class TypeDefExtractor {
+  val TypeDef: TypeDefModule
+  abstract class TypeDefModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, TypeOrBoundsTree /* TypeTree | TypeBoundsTree */)]
   }
 
@@ -147,8 +147,8 @@ trait TreeOps extends Core {
   }
   implicit def PackageDefDeco(pdef: PackageDef): PackageDefAPI
 
-  val PackageDef: PackageDefExtractor
-  abstract class PackageDefExtractor {
+  val PackageDef: PackageDefModule
+  abstract class PackageDefModule {
     def unapply(tree: Tree)(implicit ctx: Context): Option[(String, PackageDef)]
   }
 
@@ -186,8 +186,8 @@ trait TreeOps extends Core {
     implicit def IdentDeco(ident: Ident): IdentAPI
 
     /** Scala term identifier */
-    val Ident: IdentExtractor
-    abstract class IdentExtractor {
+    val Ident: IdentModule
+    abstract class IdentModule {
       /** Matches a term identifier and returns its name */
       def unapply(tree: Tree)(implicit ctx: Context): Option[String]
     }
@@ -206,8 +206,8 @@ trait TreeOps extends Core {
     implicit def SelectDeco(select: Select): SelectAPI
 
     /** Scala term selection */
-    val Select: SelectExtractor
-    abstract class SelectExtractor {
+    val Select: SelectModule
+    abstract class SelectModule {
       /** Matches `<qual: Term>.<name: String>` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, String)]
     }
@@ -224,8 +224,8 @@ trait TreeOps extends Core {
     implicit def LiteralDeco(x: Literal): LiteralAPI
 
     /** Scala literal constant */
-    val Literal: LiteralExtractor
-    abstract class LiteralExtractor {
+    val Literal: LiteralModule
+    abstract class LiteralModule {
       def unapply(tree: Tree)(implicit ctx: Context): Option[Constant]
     }
 
@@ -241,8 +241,8 @@ trait TreeOps extends Core {
     implicit def ThisDeco(x: This): ThisAPI
 
     /** Scala `this` or `this[id]` */
-    val This: ThisExtractor
-    abstract class ThisExtractor {
+    val This: ThisModule
+    abstract class ThisModule {
       /** Matches new `this[<id: Option[Id]>` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[Option[Id]]
     }
@@ -259,8 +259,8 @@ trait TreeOps extends Core {
     implicit def NewDeco(x: New): NewAPI
 
     /** Scala `new` */
-    val New: NewExtractor
-    abstract class NewExtractor {
+    val New: NewModule
+    abstract class NewModule {
       /** Matches new `new <tpt: TypeTree>` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[TypeTree]
     }
@@ -278,8 +278,8 @@ trait TreeOps extends Core {
     implicit def NamedArgDeco(x: NamedArg): NamedArgAPI
 
     /** Scala named argument `x = y` in argument position */
-    val NamedArg: NamedArgExtractor
-    abstract class NamedArgExtractor {
+    val NamedArg: NamedArgModule
+    abstract class NamedArgModule {
       /** Matches `<name: String> = <value: Term>` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(String, Term)]
     }
@@ -297,8 +297,8 @@ trait TreeOps extends Core {
     implicit def ApplyDeco(x: Apply): ApplyAPI
 
     /** Scala parameter application */
-    val Apply: ApplyExtractor
-    abstract class ApplyExtractor {
+    val Apply: ApplyModule
+    abstract class ApplyModule {
       /** Matches function application `<fun: Term>(<args: List[Term]>)` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[Term])]
     }
@@ -316,8 +316,8 @@ trait TreeOps extends Core {
     implicit def TypeApplyDeco(x: TypeApply): TypeApplyAPI
 
     /** Scala type parameter application */
-    val TypeApply: TypeApplyExtractor
-    abstract class TypeApplyExtractor {
+    val TypeApply: TypeApplyModule
+    abstract class TypeApplyModule {
       /** Matches function type application `<fun: Term>[<args: List[TypeTree]>]` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[TypeTree])]
     }
@@ -335,8 +335,8 @@ trait TreeOps extends Core {
     implicit def SuperDeco(x: Super): SuperAPI
 
     /** Scala `x.super` or `x.super[id]` */
-    val Super: SuperExtractor
-    abstract class SuperExtractor {
+    val Super: SuperModule
+    abstract class SuperModule {
       /** Matches new `<qualifier: Term>.super[<id: Option[Id]>` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Option[Id])]
     }
@@ -354,8 +354,8 @@ trait TreeOps extends Core {
     implicit def TypedDeco(x: Typed): TypedAPI
 
     /** Scala ascription `x: T` */
-    val Typed: TypedExtractor
-    abstract class TypedExtractor {
+    val Typed: TypedModule
+    abstract class TypedModule {
       /** Matches `<expr: Term>: <tpt: Term>` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, TypeTree)]
     }
@@ -373,8 +373,8 @@ trait TreeOps extends Core {
     implicit def AssignDeco(x: Assign): AssignAPI
 
     /** Scala assign `x = y` */
-    val Assign: AssignExtractor
-    abstract class AssignExtractor {
+    val Assign: AssignModule
+    abstract class AssignModule {
       /** Matches `<lhs: Term> = <rhs: Term>` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Term)]
     }
@@ -392,8 +392,8 @@ trait TreeOps extends Core {
     implicit def BlockDeco(x: Block): BlockAPI
 
     /** Scala code block `{ stat0; ...; statN; expr }` term */
-    val Block: BlockExtractor
-    abstract class BlockExtractor {
+    val Block: BlockModule
+    abstract class BlockModule {
       /** Matches `{ <statements: List[Statement]>; <expr: Term> }` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(List[Statement], Term)]
     }
@@ -410,8 +410,8 @@ trait TreeOps extends Core {
     }
     implicit def LambdaDeco(x: Lambda): LambdaAPI
 
-    val Lambda: LambdaExtractor
-    abstract class LambdaExtractor {
+    val Lambda: LambdaModule
+    abstract class LambdaModule {
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Option[TypeTree])]
     }
 
@@ -429,8 +429,8 @@ trait TreeOps extends Core {
     implicit def IfDeco(x: If): IfAPI
 
     /** Scala `if`/`else` term */
-    val If: IfExtractor
-    abstract class IfExtractor {
+    val If: IfModule
+    abstract class IfModule {
       /** Matches `if (<cond: Term>) <thenp: Term> else <elsep: Term>` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Term, Term)]
     }
@@ -448,8 +448,8 @@ trait TreeOps extends Core {
     implicit def MatchDeco(x: Match): MatchAPI
 
     /** Scala `match` term */
-    val Match: MatchExtractor
-    abstract class MatchExtractor {
+    val Match: MatchModule
+    abstract class MatchModule {
       /** Matches `<scrutinee: Trem> match { <cases: List[CaseDef]> }` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[CaseDef])]
     }
@@ -468,8 +468,8 @@ trait TreeOps extends Core {
     implicit def TryDeco(x: Try): TryAPI
 
     /** Scala `try`/`catch`/`finally` term */
-    val Try: TryExtractor
-    abstract class TryExtractor {
+    val Try: TryModule
+    abstract class TryModule {
       /** Matches `try <body: Term> catch { <cases: List[CaseDef]> } finally <finalizer: Option[Term]>` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, List[CaseDef], Option[Term])]
     }
@@ -486,8 +486,8 @@ trait TreeOps extends Core {
     implicit def ReturnDeco(x: Return): ReturnAPI
 
     /** Scala local `return` */
-    val Return: ReturnExtractor
-    abstract class ReturnExtractor {
+    val Return: ReturnModule
+    abstract class ReturnModule {
       /** Matches `return <expr: Term>` */
       def unapply(tree: Tree)(implicit ctx: Context): Option[Term]
     }
@@ -503,8 +503,8 @@ trait TreeOps extends Core {
     }
     implicit def RepeatedDeco(x: Repeated): RepeatedAPI
 
-    val Repeated: RepeatedExtractor
-    abstract class RepeatedExtractor {
+    val Repeated: RepeatedModule
+    abstract class RepeatedModule {
       def unapply(tree: Tree)(implicit ctx: Context): Option[List[Term]]
     }
 
@@ -521,8 +521,8 @@ trait TreeOps extends Core {
     }
     implicit def InlinedDeco(x: Inlined): InlinedAPI
 
-    val Inlined: InlinedExtractor
-    abstract class InlinedExtractor {
+    val Inlined: InlinedModule
+    abstract class InlinedModule {
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Option[TermOrTypeTree], List[Definition], Term)]
     }
 
@@ -539,8 +539,8 @@ trait TreeOps extends Core {
     }
     implicit def SelectOuterDeco(x: SelectOuter): SelectOuterAPI
 
-    val SelectOuter: SelectOuterExtractor
-    abstract class SelectOuterExtractor {
+    val SelectOuter: SelectOuterModule
+    abstract class SelectOuterModule {
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Int, Type)]
     }
 
@@ -556,8 +556,8 @@ trait TreeOps extends Core {
     }
     implicit def WhileDeco(x: While): WhileAPI
 
-    val While: WhileExtractor
-    abstract class WhileExtractor {
+    val While: WhileModule
+    abstract class WhileModule {
       /** Extractor for while loops. Matches `while (<cond>) <body>` and returns (<cond>, <body>) */
       def unapply(tree: Tree)(implicit ctx: Context): Option[(Term, Term)]
     }

--- a/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
@@ -36,8 +36,8 @@ trait TypeOrBoundsOps extends Core {
   }
   implicit def TypeLambdaDeco(tpt: TypeLambda): TypeLambdaAPI
 
-  val IsType: IsTypeExtractor
-  abstract class IsTypeExtractor {
+  val IsType: IsTypeModule
+  abstract class IsTypeModule {
     def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[Type]
   }
 
@@ -55,8 +55,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def ConstantTypeDeco(x: ConstantType): ConstantTypeAPI
 
-    val ConstantType: ConstantTypeExtractor
-    abstract class ConstantTypeExtractor {
+    val ConstantType: ConstantTypeModule
+    abstract class ConstantTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[Constant]
     }
 
@@ -71,8 +71,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def SymRefDeco(x: SymRef): SymRefAPI
 
-    val SymRef: SymRefExtractor
-    abstract class SymRefExtractor {
+    val SymRef: SymRefModule
+    abstract class SymRefModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Symbol, TypeOrBounds /* Type | NoPrefix */)]
     }
 
@@ -87,8 +87,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def TermRefDeco(x: TermRef): TermRefAPI
 
-    val TermRef: TermRefExtractor
-    abstract class TermRefExtractor {
+    val TermRef: TermRefModule
+    abstract class TermRefModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)]
     }
 
@@ -104,8 +104,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def TypeRefDeco(x: TypeRef): TypeRefAPI
 
-    val TypeRef: TypeRefExtractor
-    abstract class TypeRefExtractor {
+    val TypeRef: TypeRefModule
+    abstract class TypeRefModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)]
     }
 
@@ -121,8 +121,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def SuperTypeDeco(x: SuperType): SuperTypeAPI
 
-    val SuperType: SuperTypeExtractor
-    abstract class SuperTypeExtractor {
+    val SuperType: SuperTypeModule
+    abstract class SuperTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)]
     }
 
@@ -139,8 +139,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def RefinementDeco(x: Refinement): RefinementAPI
 
-    val Refinement: RefinementExtractor
-    abstract class RefinementExtractor {
+    val Refinement: RefinementModule
+    abstract class RefinementModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, String, TypeOrBounds /* Type | TypeBounds */)]
     }
 
@@ -156,8 +156,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def AppliedTypeDeco(x: AppliedType): AppliedTypeAPI
 
-    val AppliedType: AppliedTypeExtractor
-    abstract class AppliedTypeExtractor {
+    val AppliedType: AppliedTypeModule
+    abstract class AppliedTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, List[TypeOrBounds /* Type | TypeBounds */])]
     }
 
@@ -173,8 +173,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def AnnotatedTypeDeco(x: AnnotatedType): AnnotatedTypeAPI
 
-    val AnnotatedType: AnnotatedTypeExtractor
-    abstract class AnnotatedTypeExtractor {
+    val AnnotatedType: AnnotatedTypeModule
+    abstract class AnnotatedTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Term)]
     }
 
@@ -190,8 +190,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def AndTypeDeco(x: AndType): AndTypeAPI
 
-    val AndType: AndTypeExtractor
-    abstract class AndTypeExtractor {
+    val AndType: AndTypeModule
+    abstract class AndTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)]
     }
 
@@ -207,8 +207,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def OrTypeDeco(x: OrType): OrTypeAPI
 
-    val OrType: OrTypeExtractor
-    abstract class OrTypeExtractor {
+    val OrType: OrTypeModule
+    abstract class OrTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)]
     }
 
@@ -225,8 +225,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def MatchTypeDeco(x: MatchType): MatchTypeAPI
 
-    val MatchType: MatchTypeExtractor
-    abstract class MatchTypeExtractor {
+    val MatchType: MatchTypeModule
+    abstract class MatchTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type, List[Type])]
     }
 
@@ -241,8 +241,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def ByNameTypeDeco(x: ByNameType): ByNameTypeAPI
 
-    val ByNameType: ByNameTypeExtractor
-    abstract class ByNameTypeExtractor {
+    val ByNameType: ByNameTypeModule
+    abstract class ByNameTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[Type]
     }
 
@@ -258,8 +258,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def ParamRefDeco(x: ParamRef): ParamRefAPI
 
-    val ParamRef: ParamRefExtractor
-    abstract class ParamRefExtractor {
+    val ParamRef: ParamRefModule
+    abstract class ParamRefModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(LambdaType[TypeOrBounds], Int)]
     }
 
@@ -274,8 +274,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def ThisTypeDeco(x: ThisType): ThisTypeAPI
 
-    val ThisType: ThisTypeExtractor
-    abstract class ThisTypeExtractor {
+    val ThisType: ThisTypeModule
+    abstract class ThisTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[Type]
     }
 
@@ -290,8 +290,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def RecursiveThisDeco(x: RecursiveThis): RecursiveThisAPI
 
-    val RecursiveThis: RecursiveThisExtractor
-    abstract class RecursiveThisExtractor {
+    val RecursiveThis: RecursiveThisModule
+    abstract class RecursiveThisModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[RecursiveType]
     }
 
@@ -306,8 +306,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def RecursiveTypeDeco(x: RecursiveType): RecursiveTypeAPI
 
-    val RecursiveType: RecursiveTypeExtractor
-    abstract class RecursiveTypeExtractor {
+    val RecursiveType: RecursiveTypeModule
+    abstract class RecursiveTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[Type]
     }
 
@@ -324,8 +324,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def MethodTypeDeco(x: MethodType): MethodTypeAPI
 
-    val MethodType: MethodTypeExtractor
-    abstract class MethodTypeExtractor {
+    val MethodType: MethodTypeModule
+    abstract class MethodTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(List[String], List[Type], Type)]
     }
 
@@ -342,8 +342,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def PolyTypeDeco(x: PolyType): PolyTypeAPI
 
-    val PolyType: PolyTypeExtractor
-    abstract class PolyTypeExtractor {
+    val PolyType: PolyTypeModule
+    abstract class PolyTypeModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(List[String], List[TypeBounds], Type)]
     }
 
@@ -360,8 +360,8 @@ trait TypeOrBoundsOps extends Core {
     }
     implicit def TypeLambdaDeco(x: TypeLambda): TypeLambdaAPI
 
-    val TypeLambda: TypeLambdaExtractor
-    abstract class TypeLambdaExtractor {
+    val TypeLambda: TypeLambdaModule
+    abstract class TypeLambdaModule {
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(List[String], List[TypeBounds], Type)]
     }
 
@@ -369,13 +369,13 @@ trait TypeOrBoundsOps extends Core {
 
   // ----- TypeBounds -----------------------------------------------
 
-  val IsTypeBounds: IsTypeBoundsExtractor
-  abstract class IsTypeBoundsExtractor {
+  val IsTypeBounds: IsTypeBoundsModule
+  abstract class IsTypeBoundsModule {
     def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[TypeBounds]
   }
 
-  val TypeBounds: TypeBoundsExtractor
-  abstract class TypeBoundsExtractor {
+  val TypeBounds: TypeBoundsModule
+  abstract class TypeBoundsModule {
     def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)]
   }
 
@@ -387,8 +387,8 @@ trait TypeOrBoundsOps extends Core {
 
   // ----- NoPrefix -------------------------------------------------
 
-  val NoPrefix: NoPrefixExtractor
-  abstract class NoPrefixExtractor {
+  val NoPrefix: NoPrefixModule
+  abstract class NoPrefixModule {
     def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Boolean
   }
 

--- a/library/src/scala/tasty/reflect/TypeOrBoundsTreeOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsTreeOps.scala
@@ -19,8 +19,8 @@ trait TypeOrBoundsTreeOps extends Core {
   }
   implicit def TypeTreeDeco(tpt: TypeTree): TypeTreeAPI
 
-  val IsTypeTree: IsTypeTreeExtractor
-  abstract class IsTypeTreeExtractor {
+  val IsTypeTree: IsTypeTreeModule
+  abstract class IsTypeTreeModule {
     def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[TypeTree]
     def unapply(parent: TermOrTypeTree)(implicit ctx: Context, dummy: DummyImplicit): Option[TypeTree]
   }
@@ -39,8 +39,8 @@ trait TypeOrBoundsTreeOps extends Core {
     implicit def InferredDeco(x: Inferred): InferredAPI
 
     /** TypeTree containing an inferred type */
-    val Inferred: InferredExtractor
-    abstract class InferredExtractor {
+    val Inferred: InferredModule
+    abstract class InferredModule {
       /** Matches a TypeTree containing an inferred type */
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Boolean
     }
@@ -56,8 +56,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def IdentDeco(x: Ident): IdentAPI
 
-    val Ident: IdentExtractor
-    abstract class IdentExtractor {
+    val Ident: IdentModule
+    abstract class IdentModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[String]
     }
 
@@ -73,8 +73,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def SelectDeco(x: Select): SelectAPI
 
-    val Select: SelectExtractor
-    abstract class SelectExtractor {
+    val Select: SelectModule
+    abstract class SelectModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(Term, String)]
     }
 
@@ -90,8 +90,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def ProjectDeco(x: Project): ProjectAPI
 
-    val Project: ProjectExtractor
-    abstract class ProjectExtractor {
+    val Project: ProjectModule
+    abstract class ProjectModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, String)]
     }
 
@@ -106,8 +106,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def SingletonDeco(x: Singleton): SingletonAPI
 
-    val Singleton: SingletonExtractor
-    abstract class SingletonExtractor {
+    val Singleton: SingletonModule
+    abstract class SingletonModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[Term]
     }
 
@@ -123,8 +123,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def RefinedDeco(x: Refined): RefinedAPI
 
-    val Refined: RefinedExtractor
-    abstract class RefinedExtractor {
+    val Refined: RefinedModule
+    abstract class RefinedModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, List[Definition])]
     }
 
@@ -140,8 +140,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def AppliedDeco(x: Applied): AppliedAPI
 
-    val Applied: AppliedExtractor
-    abstract class AppliedExtractor {
+    val Applied: AppliedModule
+    abstract class AppliedModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, List[TypeOrBoundsTree])]
     }
 
@@ -157,8 +157,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def AnnotatedDeco(x: Annotated): AnnotatedAPI
 
-    val Annotated: AnnotatedExtractor
-    abstract class AnnotatedExtractor {
+    val Annotated: AnnotatedModule
+    abstract class AnnotatedModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, Term)]
     }
 
@@ -174,8 +174,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def AndDeco(x: And): OrAPI
 
-    val And: AndExtractor
-    abstract class AndExtractor {
+    val And: AndModule
+    abstract class AndModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)]
     }
 
@@ -191,8 +191,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def OrDeco(x: Or): OrAPI
 
-    val Or: OrExtractor
-    abstract class OrExtractor {
+    val Or: OrModule
+    abstract class OrModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)]
     }
 
@@ -209,8 +209,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def MatchTypeDeco(x: MatchType): MatchTypeAPI
 
-    val MatchType: MatchTypeExtractor
-    abstract class MatchTypeExtractor {
+    val MatchType: MatchTypeModule
+    abstract class MatchTypeModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(Option[TypeTree], TypeTree, List[TypeCaseDef])]
     }
 
@@ -225,8 +225,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def ByNameDeco(x: ByName): ByNameAPI
 
-    val ByName: ByNameExtractor
-    abstract class ByNameExtractor {
+    val ByName: ByNameModule
+    abstract class ByNameModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[TypeTree]
     }
 
@@ -242,8 +242,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def LambdaTypeTreeDeco(x: LambdaTypeTree): LambdaTypeTreeAPI
 
-    val LambdaTypeTree: LambdaTypeTreeExtractor
-    abstract class LambdaTypeTreeExtractor {
+    val LambdaTypeTree: LambdaTypeTreeModule
+    abstract class LambdaTypeTreeModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(List[TypeDef], TypeOrBoundsTree)]
     }
 
@@ -259,8 +259,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def BindDeco(x: Bind): BindAPI
 
-    val Bind: BindExtractor
-    abstract class BindExtractor {
+    val Bind: BindModule
+    abstract class BindModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(String, TypeOrBoundsTree)]
     }
 
@@ -276,8 +276,8 @@ trait TypeOrBoundsTreeOps extends Core {
     }
     implicit def BlockDeco(x: Block): BlockAPI
 
-    val Block: BlockExtractor
-    abstract class BlockExtractor {
+    val Block: BlockModule
+    abstract class BlockModule {
       def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(List[TypeDef], TypeTree)]
     }
   }
@@ -291,19 +291,19 @@ trait TypeOrBoundsTreeOps extends Core {
   }
   implicit def TypeBoundsTreeDeco(tpt: TypeBoundsTree): TypeBoundsTreeAPI
 
-  val IsTypeBoundsTree: IsTypeBoundsTreeExtractor
-  abstract class IsTypeBoundsTreeExtractor {
+  val IsTypeBoundsTree: IsTypeBoundsTreeModule
+  abstract class IsTypeBoundsTreeModule {
     def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[TypeBoundsTree]
   }
 
-  val TypeBoundsTree: TypeBoundsTreeExtractor
-  abstract class TypeBoundsTreeExtractor {
+  val TypeBoundsTree: TypeBoundsTreeModule
+  abstract class TypeBoundsTreeModule {
     def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Option[(TypeTree, TypeTree)]
   }
 
   /** TypeBoundsTree containing wildcard type bounds */
-  val WildcardTypeTree: WildcardTypeTreeExtractor
-  abstract class WildcardTypeTreeExtractor {
+  val WildcardTypeTree: WildcardTypeTreeModule
+  abstract class WildcardTypeTreeModule {
     /** Matches a TypeBoundsTree containing wildcard type bounds */
     def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Boolean
   }


### PR DESCRIPTION
Also use API (uppercase) consistently and add some docs