### PR TITLE
Fix #4785: Change typing rule for wildcard star args

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -497,7 +497,7 @@ class TypeApplications(val self: Type) extends AnyVal {
   }
 
   /** The element type of a sequence or array */
-  def elemType(implicit ctx: Context): Type = self match {
+  def elemType(implicit ctx: Context): Type = self.widenDealias match {
     case defn.ArrayOf(elemtp) => elemtp
     case JavaArrayType(elemtp) => elemtp
     case _ => self.baseType(defn.SeqClass).argInfos.headOption.getOrElse(NoType)

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -71,29 +71,23 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
     transformTypeOfTree(tree)
 
   override def transformApply(tree: Apply)(implicit ctx: Context): Tree = {
-    val formals =
-      ctx.atPhase(thisPhase) { implicit ctx =>
-        tree.fun.tpe.widen.asInstanceOf[MethodType].paramInfos
-      }
-    val args1 = tree.args.zipWithConserve(formals) { (arg, formal) =>
-      arg match {
-        case arg: Typed if isWildcardStarArg(arg) =>
-          val isJavaDefined = tree.fun.symbol.is(JavaDefined)
-          val tpe = arg.expr.tpe
-          if (isJavaDefined && tpe.derivesFrom(defn.SeqClass))
-            seqToArray(arg.expr, formal.underlyingIfRepeated(isJava = true))
-          else if (!isJavaDefined && tpe.derivesFrom(defn.ArrayClass))
-            arrayToSeq(arg.expr)
-          else
-            arg.expr
-        case arg => arg
-      }
+    val args = tree.args.mapConserve {
+      case arg: Typed if isWildcardStarArg(arg) =>
+        val isJavaDefined = tree.fun.symbol.is(JavaDefined)
+        val tpe = arg.expr.tpe
+        if (isJavaDefined && tpe.derivesFrom(defn.SeqClass))
+          seqToArray(arg.expr)
+        else if (!isJavaDefined && tpe.derivesFrom(defn.ArrayClass))
+          arrayToSeq(arg.expr)
+        else
+          arg.expr
+      case arg => arg
     }
-    transformTypeOfTree(cpy.Apply(tree)(tree.fun, args1))
+    transformTypeOfTree(cpy.Apply(tree)(tree.fun, args))
   }
 
-  /** Convert sequence argument to Java array of type `pt` */
-  private def seqToArray(tree: Tree, pt: Type)(implicit ctx: Context): Tree = tree match {
+  /** Convert sequence argument to Java array */
+  private def seqToArray(tree: Tree)(implicit ctx: Context): Tree = tree match {
     case SeqLiteral(elems, elemtpt) =>
       JavaSeqLiteral(elems, elemtpt)
     case _ =>
@@ -104,8 +98,6 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
         .select(nme.seqToArray)
         .appliedToType(elemType)
         .appliedTo(tree, Literal(Constant(elemClass.typeRef)))
-        .ensureConforms(pt)
-          // Because of phantomclasses, the Java array's type might not conform to the return type
   }
 
   /** Convert Java array argument to Scala Seq */

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -153,8 +153,12 @@ trait TypeAssigner {
     if (!sym.is(SyntheticOrPrivate) && sym.owner.isClass) checkNoPrivateLeaks(sym, pos)
     else sym.info
 
-  def seqToRepeated(tree: Tree)(implicit ctx: Context): Tree =
-    Typed(tree, TypeTree(tree.tpe.widen.translateParameterized(defn.SeqClass, defn.RepeatedParamClass)))
+  private def toRepeated(tree: Tree, from: ClassSymbol)(implicit ctx: Context): Tree =
+    Typed(tree, TypeTree(tree.tpe.widen.translateParameterized(from, defn.RepeatedParamClass)))
+
+   def seqToRepeated(tree: Tree)(implicit ctx: Context): Tree = toRepeated(tree, defn.SeqClass)
+
+   def arrayToRepeated(tree: Tree)(implicit ctx: Context): Tree = toRepeated(tree, defn.ArrayClass)
 
   /** A denotation exists really if it exists and does not point to a stale symbol. */
   final def reallyExists(denot: Denotation)(implicit ctx: Context): Boolean = try

--- a/tests/neg/repeatedArgs213.scala
+++ b/tests/neg/repeatedArgs213.scala
@@ -33,11 +33,11 @@ class repeatedArgs {
     bar("a", "b", "c")
     bar(xs: _*)
     bar(ys: _*) // error: immutable.Seq expected, found Seq
-    bar(zs: _*) // error: immutable.Seq expected, found Array
+    bar(zs: _*) // old-error: Remove (compiler generated) Array to Seq convertion in 2.13?
 
     Paths.get("Hello", "World")
     Paths.get("Hello", xs: _*)
     Paths.get("Hello", ys: _*) // error: immutable.Seq expected, found Seq
-    Paths.get("Hello", zs: _*) // error: immutable.Seq expected, found Array
+    Paths.get("Hello", zs: _*)
   }
 }

--- a/tests/pos/i4785.scala
+++ b/tests/pos/i4785.scala
@@ -1,0 +1,15 @@
+import scala.Predef.Set // unimport Predef.wrapRefArray
+
+import java.nio.file.Paths
+
+class i4785 {
+  def bar(xs: String*) = xs.length
+
+  def test(xs: Seq[String], ys: Array[String]) = {
+    Paths.get("Hello", xs: _*)
+    Paths.get("Hello", ys: _*)
+
+    bar(xs: _*)
+    bar(ys: _*)
+  }
+}

--- a/tests/pos/repeatedArgs.scala
+++ b/tests/pos/repeatedArgs.scala
@@ -1,5 +1,6 @@
 import scala.collection.{immutable, mutable}
 import java.nio.file.Paths
+import java.util.concurrent.ForkJoinTask
 
 class repeatedArgs {
   def bar(xs: String*): Int = xs.length
@@ -19,4 +20,7 @@ class repeatedArgs {
     val x: collection.Seq[String] = others
     // val y: immutable.Seq[String] = others // ok in 2.13
   }
+
+  def invokeAll[T](tasks: ForkJoinTask[T]*): Unit = ForkJoinTask.invokeAll(tasks: _*)
+  def invokeAll2(tasks: ForkJoinTask[_]*): Unit = ForkJoinTask.invokeAll(tasks: _*)
 }


### PR DESCRIPTION
We typecheck them without expected type to avoid relying on the implicit
conversion from Array to Seq defined in Predef. ElimRepeated does the
necessary adaptations (i.e. seqToArray and arrayToSeq conversions).