### PR TITLE
Remove erroneous usages of `List::union`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -131,7 +131,7 @@ object Decorators {
     }
 
     /** Union on lists seen as sets */
-    def | (ys: List[T]): List[T] = xs ++ (ys filterNot (xs contains _))
+    def | (ys: List[T]): List[T] = xs ::: (ys filterNot (xs contains _))
 
     /** Intersection on lists seen as sets */
     def & (ys: List[T]): List[T] = xs filter (ys contains _)

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -221,7 +221,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
   def dependentParams(tp: Type, isUpper: Boolean): List[TypeParamRef] = tp match {
     case param: TypeParamRef if contains(param) =>
       param :: (if (isUpper) upper(param) else lower(param))
-    case tp: AndType => dependentParams(tp.tp1, isUpper).union    (dependentParams(tp.tp2, isUpper))
+    case tp: AndType => dependentParams(tp.tp1, isUpper) | (dependentParams(tp.tp2, isUpper))
     case tp: OrType  => dependentParams(tp.tp1, isUpper).intersect(dependentParams(tp.tp2, isUpper))
     case _ =>
       Nil

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -441,7 +441,7 @@ object Types {
       case tp: TypeProxy =>
         tp.underlying.classSymbols
       case AndType(l, r) =>
-        l.classSymbols union r.classSymbols
+        l.classSymbols | r.classSymbols
       case OrType(l, r) =>
         l.classSymbols intersect r.classSymbols // TODO does not conform to spec
       case _ =>


### PR DESCRIPTION
`union` on `List` is concatenation. Duplicates are not removed. Also `union` is deprecated in 2.13.