### PR TITLE
Move TASTy Reflect decorators to top level

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsOpsImpl.scala
@@ -4,32 +4,108 @@ import dotty.tools.dotc.core.{Contexts, Names, Types}
 
 trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreImpl {
 
-  // ===== Types ====================================================
-
   def TypeDeco(tpe: Type): TypeAPI = new TypeAPI {
     def =:=(other: Type)(implicit ctx: Context): Boolean = tpe =:= other
     def <:<(other: Type)(implicit ctx: Context): Boolean = tpe <:< other
   }
 
-  def MethodTypeDeco(tpe: MethodType): MethodTypeAPI = new MethodTypeAPI {
-    def isErased: Boolean = tpe.isErasedMethod
-    def isImplicit: Boolean = tpe.isImplicitMethod
-    def paramNames(implicit ctx: Context): List[String] = tpe.paramNames.map(_.toString)
-    def paramTypes(implicit ctx: Context): List[Type] = tpe.paramInfos
-    def resultTpe(implicit ctx: Context): Type = tpe.resType
+  def ConstantTypeDeco(x: ConstantType): Type.ConstantTypeAPI = new Type.ConstantTypeAPI {
+    def value(implicit ctx: Context): Any = x.value
   }
 
-  def PolyTypeDeco(tpe: Types.PolyType): PolyTypeAPI = new PolyTypeAPI {
-    def paramNames(implicit ctx: Context): List[String] = tpe.paramNames.map(_.toString)
-    def paramTypes(implicit ctx: Context): List[TypeBounds] = tpe.paramInfos
-    def resultTpe(implicit ctx: Context): Type = tpe.resType
+  def SymRefDeco(x: SymRef): Type.SymRefAPI = new Type.SymRefAPI {
+    def qualifier(implicit ctx: Context): TypeOrBounds = x.prefix
   }
 
-  def TypeLambdaDeco(tpe: TypeLambda): TypeLambdaAPI = new TypeLambdaAPI {
-    def paramNames(implicit ctx: Context): List[String] = tpe.paramNames.map(_.toString)
-    def paramTypes(implicit ctx: Context): List[TypeBounds] = tpe.paramInfos
-    def resultTpe(implicit ctx: Context): Type = tpe.resType
+  def TermRefDeco(x: TermRef): Type.TermRefAPI = new Type.TermRefAPI {
+    def qualifier(implicit ctx: Context): TypeOrBounds = x.prefix
   }
+
+  def TypeRefDeco(x: TypeRef): Type.TypeRefAPI = new Type.TypeRefAPI {
+    def name(implicit ctx: Context): String = x.name.toString
+    def qualifier(implicit ctx: Context): TypeOrBounds = x.prefix
+  }
+
+  def SuperTypeDeco(x: SuperType): Type.SuperTypeAPI = new Type.SuperTypeAPI {
+    def thistpe(implicit ctx: Context): Type = x.thistpe
+    def supertpe(implicit ctx: Context): Type = x.supertpe
+  }
+
+  def RefinementDeco(x: Refinement): Type.RefinementAPI = new Type.RefinementAPI {
+    def parent(implicit ctx: Context): Type = x.parent
+    def name(implicit ctx: Context): String = x.refinedName.toString
+    def info(implicit ctx: Context): TypeOrBounds = x.refinedInfo
+  }
+
+  def AppliedTypeDeco(x: AppliedType): Type.AppliedTypeAPI = new Type.AppliedTypeAPI {
+    def tycon(implicit ctx: Context): Type = x.tycon
+    def args(implicit ctx: Context): List[TypeOrBounds] = x.args
+  }
+
+  def AnnotatedTypeDeco(x: AnnotatedType): Type.AnnotatedTypeAPI = new Type.AnnotatedTypeAPI {
+    def underlying(implicit ctx: Context): Type = x.underlying.stripTypeVar
+    def annot(implicit ctx: Context): Term = x.annot.tree
+  }
+
+  def AndTypeDeco(x: AndType): Type.AndTypeAPI = new Type.AndTypeAPI {
+    def left(implicit ctx: Context): Type = x.tp1.stripTypeVar
+    def right(implicit ctx: Context): Type = x.tp2.stripTypeVar
+  }
+
+  def OrTypeDeco(x: OrType): Type.OrTypeAPI = new Type.OrTypeAPI {
+    def left(implicit ctx: Context): Type = x.tp1
+    def right(implicit ctx: Context): Type = x.tp2
+  }
+
+  def MatchTypeDeco(x: MatchType): Type.MatchTypeAPI = new Type.MatchTypeAPI {
+    def bound(implicit ctx: Context): Type = x.bound
+    def scrutinee(implicit ctx: Context): Type = x.scrutinee
+    def cases(implicit ctx: Context): List[Type] = x.cases
+  }
+
+  def ByNameTypeDeco(x: ByNameType): Type.ByNameTypeAPI = new Type.ByNameTypeAPI {
+    def underlying(implicit ctx: Context): Type = x.resType.stripTypeVar
+  }
+
+  def ParamRefDeco(x: ParamRef): Type.ParamRefAPI = new Type.ParamRefAPI {
+    def binder(implicit ctx: Context): LambdaType[TypeOrBounds] =
+      x.binder.asInstanceOf[LambdaType[TypeOrBounds]] // Cast to tpd
+    def paramNum(implicit ctx: Context): Int = x.paramNum
+  }
+
+  def ThisTypeDeco(x: ThisType): Type.ThisTypeAPI = new Type.ThisTypeAPI {
+    def underlying(implicit ctx: Context): Type = x.underlying
+  }
+
+  def RecursiveThisDeco(x: RecursiveThis): Type.RecursiveThisAPI = new Type.RecursiveThisAPI {
+    def binder(implicit ctx: Context): RecursiveType = x.binder
+  }
+
+  def RecursiveTypeDeco(x: RecursiveType): Type.RecursiveTypeAPI = new Type.RecursiveTypeAPI {
+    def underlying(implicit ctx: Context): Type = x.underlying.stripTypeVar
+  }
+
+  def MethodTypeDeco(x: MethodType): Type.MethodTypeAPI = new Type.MethodTypeAPI {
+    def isErased: Boolean = x.isErasedMethod
+    def isImplicit: Boolean = x.isImplicitMethod
+    def paramNames(implicit ctx: Context): List[String] = x.paramNames.map(_.toString)
+    def paramTypes(implicit ctx: Context): List[Type] = x.paramInfos
+    def resType(implicit ctx: Context): Type = x.resType
+  }
+
+  def PolyTypeDeco(x: PolyType): Type.PolyTypeAPI = new Type.PolyTypeAPI {
+    def paramNames(implicit ctx: Contexts.Context): List[String] = x.paramNames.map(_.toString)
+    def paramBounds(implicit ctx: Contexts.Context): List[TypeBounds] = x.paramInfos
+    def resType(implicit ctx: Contexts.Context): Type = x.resType
+  }
+
+  def TypeLambdaDeco(x: TypeLambda): Type.TypeLambdaAPI = new Type.TypeLambdaAPI {
+    def paramNames(implicit ctx: Contexts.Context): List[String] = x.paramNames.map(_.toString)
+    def paramBounds(implicit ctx: Contexts.Context): List[TypeBounds] = x.paramInfos
+    def resType(implicit ctx: Contexts.Context): Type = x.resType
+  }
+
+  // ===== Types ====================================================
 
   object IsType extends IsTypeModule {
     def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[Type] = x match {
@@ -48,10 +124,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def ConstantTypeDeco(x: ConstantType): ConstantTypeAPI = new ConstantTypeAPI {
-      def value(implicit ctx: Context): Any = x.value
-    }
-
     object ConstantType extends ConstantTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[Constant] = x match {
         case Types.ConstantType(value) => Some(value)
@@ -68,10 +140,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
           }
         case _ => None
       }
-    }
-
-    def SymRefDeco(x: SymRef): SymRefAPI = new SymRefAPI {
-      def qualifier(implicit ctx: Context): TypeOrBounds = x.prefix
     }
 
     object SymRef extends SymRefModule {
@@ -96,10 +164,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def TermRefDeco(x: TermRef): TermRefAPI = new TermRefAPI {
-      def qualifier(implicit ctx: Context): TypeOrBounds = x.prefix
-    }
-
     object TermRef extends TermRefModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)] = x match {
         case tp: Types.NamedType =>
@@ -122,11 +186,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def TypeRefDeco(x: TypeRef): TypeRefAPI = new TypeRefAPI {
-      def name(implicit ctx: Context): String = x.name.toString
-      def qualifier(implicit ctx: Context): TypeOrBounds = x.prefix
-    }
-
     object TypeRef extends TypeRefModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)] = x match {
         case tp: Types.NamedType =>
@@ -145,11 +204,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def SuperTypeDeco(x: SuperType): SuperTypeAPI = new SuperTypeAPI {
-      def thistpe(implicit ctx: Context): Type = x.thistpe
-      def supertpe(implicit ctx: Context): Type = x.supertpe
-    }
-
     object SuperType extends SuperTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)] = x match {
         case Types.SuperType(thistpe, supertpe) => Some(thistpe, supertpe)
@@ -164,11 +218,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def RefinementDeco(x: Refinement): RefinementAPI = new RefinementAPI {
-      def parent(implicit ctx: Context): Type = x.parent
-      def name(implicit ctx: Context): String = x.refinedName.toString
-      def info(implicit ctx: Context): TypeOrBounds = x.refinedInfo
-    }
 
     object Refinement extends RefinementModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, String, TypeOrBounds /* Type | TypeBounds */)] = x match {
@@ -182,11 +231,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
         case tpe: Types.AppliedType => Some(tpe)
         case _ => None
       }
-    }
-
-    def AppliedTypeDeco(x: AppliedType): AppliedTypeAPI = new AppliedTypeAPI {
-      def tycon(implicit ctx: Context): Type = x.tycon
-      def args(implicit ctx: Context): List[TypeOrBounds] = x.args
     }
 
     object AppliedType extends AppliedTypeModule {
@@ -203,11 +247,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def AnnotatedTypeDeco(x: AnnotatedType): AnnotatedTypeAPI = new AnnotatedTypeAPI {
-      def underlying(implicit ctx: Context): Type = x.underlying.stripTypeVar
-      def annot(implicit ctx: Context): Term = x.annot.tree
-    }
-
     object AnnotatedType extends AnnotatedTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, Term)] = x match {
         case Types.AnnotatedType(underlying, annot) => Some((underlying.stripTypeVar, annot.tree))
@@ -220,11 +259,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
         case tpe: Types.AndType => Some(tpe)
         case _ => None
       }
-    }
-
-    def AndTypeDeco(x: AndType): AndTypeAPI = new AndTypeAPI {
-      def left(implicit ctx: Context): Type = x.tp1.stripTypeVar
-      def right(implicit ctx: Context): Type = x.tp2.stripTypeVar
     }
 
     object AndType extends AndTypeModule {
@@ -241,11 +275,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def OrTypeDeco(x: OrType): OrTypeAPI = new OrTypeAPI {
-      def left(implicit ctx: Context): Type = x.tp1
-      def right(implicit ctx: Context): Type = x.tp2
-    }
-
     object OrType extends OrTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(Type, Type)] = x match {
         case Types.OrType(left, right) => Some(left.stripTypeVar, right.stripTypeVar)
@@ -258,12 +287,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
         case tpe: Types.MatchType => Some(tpe)
         case _ => None
       }
-    }
-
-    def MatchTypeDeco(x: MatchType): MatchTypeAPI = new MatchTypeAPI {
-      def bound(implicit ctx: Context): Type = x.bound
-      def scrutinee(implicit ctx: Context): Type = x.scrutinee
-      def cases(implicit ctx: Context): List[Type] = x.cases
     }
 
     object MatchType extends MatchTypeModule {
@@ -280,10 +303,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def ByNameTypeDeco(x: ByNameType): ByNameTypeAPI = new ByNameTypeAPI {
-      def underlying(implicit ctx: Context): Type = x.resType.stripTypeVar
-    }
-
     object ByNameType extends ByNameTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[Type] = x match {
         case Types.ExprType(resType) => Some(resType.stripTypeVar)
@@ -297,12 +316,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
         case tpe: Types.TermParamRef => Some(tpe)
         case _ => None
       }
-    }
-
-    def ParamRefDeco(x: ParamRef): ParamRefAPI = new ParamRefAPI {
-      def binder(implicit ctx: Context): LambdaType[TypeOrBounds] =
-        x.binder.asInstanceOf[LambdaType[TypeOrBounds]] // Cast to tpd
-      def paramNum(implicit ctx: Context): Int = x.paramNum
     }
 
     object ParamRef extends ParamRefModule {
@@ -323,10 +336,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def ThisTypeDeco(x: ThisType): ThisTypeAPI = new ThisTypeAPI {
-      def underlying(implicit ctx: Context): Type = x.underlying
-    }
-
     object ThisType extends ThisTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[Type] = x match {
         case Types.ThisType(tp) => Some(tp)
@@ -339,10 +348,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
         case tpe: Types.RecThis => Some(tpe)
         case _ => None
       }
-    }
-
-    def RecursiveThisDeco(x: RecursiveThis): RecursiveThisAPI = new RecursiveThisAPI {
-      def binder(implicit ctx: Context): RecursiveType = x.binder
     }
 
     object RecursiveThis extends RecursiveThisModule {
@@ -359,10 +364,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def RecursiveTypeDeco(x: RecursiveType): RecursiveTypeAPI = new RecursiveTypeAPI {
-      def underlying(implicit ctx: Context): Type = x.underlying.stripTypeVar
-    }
-
     object RecursiveType extends RecursiveTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[Type] = x match {
         case tp: Types.RecType => Some(tp.underlying.stripTypeVar)
@@ -375,12 +376,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
         case tpe: Types.MethodType => Some(tpe)
         case _ => None
       }
-    }
-
-    def MethodTypeDeco(x: MethodType): MethodTypeAPI = new MethodTypeAPI {
-      def paramNames(implicit ctx: Context): List[String] = x.paramNames.map(_.toString)
-      def paramTypes(implicit ctx: Context): List[Type] = x.paramInfos
-      def resType(implicit ctx: Context): Type = x.resType
     }
 
     object MethodType extends MethodTypeModule {
@@ -397,12 +392,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       }
     }
 
-    def PolyTypeDeco(x: PolyType): PolyTypeAPI = new PolyTypeAPI {
-      def paramNames(implicit ctx: Contexts.Context): List[String] = x.paramNames.map(_.toString)
-      def paramBounds(implicit ctx: Contexts.Context): List[TypeBounds] = x.paramInfos
-      def resType(implicit ctx: Contexts.Context): Type = x.resType
-    }
-
     object PolyType extends PolyTypeModule {
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(List[String], List[TypeBounds], Type)] = x match {
         case x: PolyType => Some(x.paramNames.map(_.toString), x.paramInfos, x.resType)
@@ -415,12 +404,6 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
         case tpe: Types.TypeLambda => Some(tpe)
         case _ => None
       }
-    }
-
-    def TypeLambdaDeco(x: TypeLambda): TypeLambdaAPI = new TypeLambdaAPI {
-      def paramNames(implicit ctx: Contexts.Context): List[String] = x.paramNames.map(_.toString)
-      def paramBounds(implicit ctx: Contexts.Context): List[TypeBounds] = x.paramInfos
-      def resType(implicit ctx: Contexts.Context): Type = x.resType
     }
 
     object TypeLambda extends TypeLambdaModule {

--- a/library/src/scala/tasty/reflect/TreeOps.scala
+++ b/library/src/scala/tasty/reflect/TreeOps.scala
@@ -3,13 +3,50 @@ package reflect
 
 trait TreeOps extends Core {
 
+  // Decorators
+
+  implicit def TreeDeco(tree: Tree): TreeAPI
+  implicit def PackageClauseDeco(pack: PackageClause): PackageClauseAPI
+  implicit def ImportDeco(imp: Import): ImportAPI
+  implicit def DefinitionDeco(definition: Definition): DefinitionAPI
+  implicit def ClassDefDeco(cdef: ClassDef): ClassDefAPI
+  implicit def DefDefDeco(ddef: DefDef): DefDefAPI
+  implicit def ValDefDeco(vdef: ValDef): ValDefAPI
+  implicit def TypeDefDeco(tdef: TypeDef): TypeDefAPI
+  implicit def PackageDefDeco(pdef: PackageDef): PackageDefAPI
+  implicit def TermDeco(term: Term): TermAPI
+  implicit def IdentDeco(ident: Term.Ident): Term.IdentAPI
+  implicit def SelectDeco(select: Term.Select): Term.SelectAPI
+  implicit def LiteralDeco(x: Term.Literal): Term.LiteralAPI
+  implicit def ThisDeco(x: Term.This): Term.ThisAPI
+  implicit def NewDeco(x: Term.New): Term.NewAPI
+  implicit def NamedArgDeco(x: Term.NamedArg): Term.NamedArgAPI
+  implicit def ApplyDeco(x: Term.Apply): Term.ApplyAPI
+  implicit def TypeApplyDeco(x: Term.TypeApply): Term.TypeApplyAPI
+  implicit def SuperDeco(x: Term.Super): Term.SuperAPI
+  implicit def TypedDeco(x: Term.Typed): Term.TypedAPI
+  implicit def AssignDeco(x: Term.Assign): Term.AssignAPI
+  implicit def BlockDeco(x: Term.Block): Term.BlockAPI
+  implicit def LambdaDeco(x: Term.Lambda): Term.LambdaAPI
+  implicit def IfDeco(x: Term.If): Term.IfAPI
+  implicit def MatchDeco(x: Term.Match): Term.MatchAPI
+  implicit def TryDeco(x: Term.Try): Term.TryAPI
+  implicit def ReturnDeco(x: Term.Return): Term.ReturnAPI
+  implicit def RepeatedDeco(x: Term.Repeated): Term.RepeatedAPI
+  implicit def InlinedDeco(x: Term.Inlined): Term.InlinedAPI
+  implicit def SelectOuterDeco(x: Term.SelectOuter): Term.SelectOuterAPI
+  implicit def WhileDeco(x: Term.While): Term.WhileAPI
+
+  implicit def termAsTermOrTypeTree(term: Term): TermOrTypeTree
+
+  // ----- Tree -----------------------------------------------------
+
   trait TreeAPI {
     /** Position in the source code */
     def pos(implicit ctx: Context): Position
 
     def symbol(implicit ctx: Context): Symbol
   }
-  implicit def TreeDeco(tree: Tree): TreeAPI
 
   val IsPackageClause: IsPackageClauseModule
   abstract class IsPackageClauseModule {
@@ -22,9 +59,7 @@ trait TreeOps extends Core {
   }
 
   trait PackageClauseAPI {
-
   }
-  implicit def PackageClauseDeco(pack: PackageClause): PackageClauseAPI
 
   // ----- Statements -----------------------------------------------
 
@@ -37,7 +72,6 @@ trait TreeOps extends Core {
     def expr(implicit ctx: Context): Term
     def selector(implicit ctx: Context): List[ImportSelector]
   }
-  implicit def ImportDeco(imp: Import): ImportAPI
 
   // ----- Definitions ----------------------------------------------
 
@@ -49,7 +83,6 @@ trait TreeOps extends Core {
   trait DefinitionAPI {
     def name(implicit ctx: Context): String
   }
-  implicit def DefinitionDeco(definition: Definition): DefinitionAPI
 
   // ClassDef
 
@@ -71,7 +104,6 @@ trait TreeOps extends Core {
 
     def symbol(implicit ctx: Context): ClassSymbol
   }
-  implicit def ClassDefDeco(cdef: ClassDef): ClassDefAPI
 
   // DefDef
 
@@ -93,7 +125,6 @@ trait TreeOps extends Core {
 
     def symbol(implicit ctx: Context): DefSymbol
   }
-  implicit def DefDefDeco(ddef: DefDef): DefDefAPI
 
   // ValDef
 
@@ -113,7 +144,6 @@ trait TreeOps extends Core {
 
     def symbol(implicit ctx: Context): ValSymbol
   }
-  implicit def ValDefDeco(vdef: ValDef): ValDefAPI
 
   // TypeDef
 
@@ -131,7 +161,6 @@ trait TreeOps extends Core {
     def rhs(implicit ctx: Context): TypeOrBoundsTree
     def symbol(implicit ctx: Context): TypeSymbol
   }
-  implicit def TypeDefDeco(tdef: TypeDef): TypeDefAPI
 
   // PackageDef
 
@@ -145,7 +174,6 @@ trait TreeOps extends Core {
     def members(implicit ctx: Context): List[Statement]
     def symbol(implicit ctx: Context): PackageSymbol
   }
-  implicit def PackageDefDeco(pdef: PackageDef): PackageDefAPI
 
   val PackageDef: PackageDefModule
   abstract class PackageDefModule {
@@ -160,7 +188,6 @@ trait TreeOps extends Core {
     def underlyingArgument(implicit ctx: Context): Term
     def underlying(implicit ctx: Context): Term
   }
-  implicit def TermDeco(term: Term): TermAPI
 
   val IsTerm: IsTermModule
   abstract class IsTermModule {
@@ -183,7 +210,6 @@ trait TreeOps extends Core {
     trait IdentAPI {
       def name(implicit ctx: Context): String
     }
-    implicit def IdentDeco(ident: Ident): IdentAPI
 
     /** Scala term identifier */
     val Ident: IdentModule
@@ -203,7 +229,6 @@ trait TreeOps extends Core {
       def name(implicit ctx: Context): String
       def signature(implicit ctx: Context): Option[Signature]
     }
-    implicit def SelectDeco(select: Select): SelectAPI
 
     /** Scala term selection */
     val Select: SelectModule
@@ -221,7 +246,6 @@ trait TreeOps extends Core {
     trait LiteralAPI {
       def constant(implicit ctx: Context): Constant
     }
-    implicit def LiteralDeco(x: Literal): LiteralAPI
 
     /** Scala literal constant */
     val Literal: LiteralModule
@@ -238,7 +262,6 @@ trait TreeOps extends Core {
     trait ThisAPI {
       def id(implicit ctx: Context): Option[Id]
     }
-    implicit def ThisDeco(x: This): ThisAPI
 
     /** Scala `this` or `this[id]` */
     val This: ThisModule
@@ -256,7 +279,6 @@ trait TreeOps extends Core {
     trait NewAPI {
       def tpt(implicit ctx: Context): TypeTree
     }
-    implicit def NewDeco(x: New): NewAPI
 
     /** Scala `new` */
     val New: NewModule
@@ -275,7 +297,6 @@ trait TreeOps extends Core {
       def name(implicit ctx: Context): String
       def value(implicit ctx: Context): Term
     }
-    implicit def NamedArgDeco(x: NamedArg): NamedArgAPI
 
     /** Scala named argument `x = y` in argument position */
     val NamedArg: NamedArgModule
@@ -294,7 +315,6 @@ trait TreeOps extends Core {
       def fun(implicit ctx: Context): Term
       def args(implicit ctx: Context): List[Term]
     }
-    implicit def ApplyDeco(x: Apply): ApplyAPI
 
     /** Scala parameter application */
     val Apply: ApplyModule
@@ -313,7 +333,6 @@ trait TreeOps extends Core {
       def fun(implicit ctx: Context): Term
       def args(implicit ctx: Context): List[TypeTree]
     }
-    implicit def TypeApplyDeco(x: TypeApply): TypeApplyAPI
 
     /** Scala type parameter application */
     val TypeApply: TypeApplyModule
@@ -332,7 +351,6 @@ trait TreeOps extends Core {
       def qualifier(implicit ctx: Context): Term
       def id(implicit ctx: Context): Option[Id]
     }
-    implicit def SuperDeco(x: Super): SuperAPI
 
     /** Scala `x.super` or `x.super[id]` */
     val Super: SuperModule
@@ -351,7 +369,6 @@ trait TreeOps extends Core {
       def expr(implicit ctx: Context): Term
       def tpt(implicit ctx: Context): Term
     }
-    implicit def TypedDeco(x: Typed): TypedAPI
 
     /** Scala ascription `x: T` */
     val Typed: TypedModule
@@ -370,7 +387,6 @@ trait TreeOps extends Core {
       def lhs(implicit ctx: Context): Term
       def rhs(implicit ctx: Context): Term
     }
-    implicit def AssignDeco(x: Assign): AssignAPI
 
     /** Scala assign `x = y` */
     val Assign: AssignModule
@@ -389,7 +405,6 @@ trait TreeOps extends Core {
       def statements(implicit ctx: Context): List[Statement]
       def expr(implicit ctx: Context): Term
     }
-    implicit def BlockDeco(x: Block): BlockAPI
 
     /** Scala code block `{ stat0; ...; statN; expr }` term */
     val Block: BlockModule
@@ -408,7 +423,6 @@ trait TreeOps extends Core {
       def meth(implicit ctx: Context): Term
       def tptOpt(implicit ctx: Context): Option[TypeTree]
     }
-    implicit def LambdaDeco(x: Lambda): LambdaAPI
 
     val Lambda: LambdaModule
     abstract class LambdaModule {
@@ -426,7 +440,6 @@ trait TreeOps extends Core {
       def thenp(implicit ctx: Context): Term
       def elsep(implicit ctx: Context): Term
     }
-    implicit def IfDeco(x: If): IfAPI
 
     /** Scala `if`/`else` term */
     val If: IfModule
@@ -445,7 +458,6 @@ trait TreeOps extends Core {
       def scrutinee(implicit ctx: Context): Term
       def cases(implicit ctx: Context): List[CaseDef]
     }
-    implicit def MatchDeco(x: Match): MatchAPI
 
     /** Scala `match` term */
     val Match: MatchModule
@@ -465,7 +477,6 @@ trait TreeOps extends Core {
       def cases(implicit ctx: Context): List[CaseDef]
       def finalizer(implicit ctx: Context): Option[Term]
     }
-    implicit def TryDeco(x: Try): TryAPI
 
     /** Scala `try`/`catch`/`finally` term */
     val Try: TryModule
@@ -483,7 +494,6 @@ trait TreeOps extends Core {
     trait ReturnAPI {
       def expr(implicit ctx: Context): Term
     }
-    implicit def ReturnDeco(x: Return): ReturnAPI
 
     /** Scala local `return` */
     val Return: ReturnModule
@@ -501,7 +511,6 @@ trait TreeOps extends Core {
     trait RepeatedAPI {
       def elems(implicit ctx: Context): List[Term]
     }
-    implicit def RepeatedDeco(x: Repeated): RepeatedAPI
 
     val Repeated: RepeatedModule
     abstract class RepeatedModule {
@@ -519,7 +528,6 @@ trait TreeOps extends Core {
       def bindings(implicit ctx: Context): List[Definition]
       def body(implicit ctx: Context): Term
     }
-    implicit def InlinedDeco(x: Inlined): InlinedAPI
 
     val Inlined: InlinedModule
     abstract class InlinedModule {
@@ -537,7 +545,6 @@ trait TreeOps extends Core {
       def level(implicit ctx: Context): Int
       def tpe(implicit ctx: Context): Type
     }
-    implicit def SelectOuterDeco(x: SelectOuter): SelectOuterAPI
 
     val SelectOuter: SelectOuterModule
     abstract class SelectOuterModule {
@@ -554,7 +561,6 @@ trait TreeOps extends Core {
       def cond(implicit ctx: Context): Term
       def body(implicit ctx: Context): Term
     }
-    implicit def WhileDeco(x: While): WhileAPI
 
     val While: WhileModule
     abstract class WhileModule {
@@ -563,5 +569,4 @@ trait TreeOps extends Core {
     }
   }
 
-  implicit def termAsTermOrTypeTree(term: Term): TermOrTypeTree
 }

--- a/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
@@ -3,6 +3,48 @@ package reflect
 
 trait TypeOrBoundsOps extends Core {
 
+  implicit def TypeDeco(tpe: Type): TypeAPI
+
+  implicit def ConstantTypeDeco(x: ConstantType): Type.ConstantTypeAPI
+
+  implicit def SymRefDeco(x: SymRef): Type.SymRefAPI
+
+  implicit def TermRefDeco(x: TermRef): Type.TermRefAPI
+
+  implicit def TypeRefDeco(x: TypeRef): Type.TypeRefAPI
+
+  implicit def SuperTypeDeco(x: SuperType): Type.SuperTypeAPI
+
+  implicit def RefinementDeco(x: Refinement): Type.RefinementAPI
+
+  implicit def AppliedTypeDeco(x: AppliedType): Type.AppliedTypeAPI
+
+  implicit def AnnotatedTypeDeco(x: AnnotatedType): Type.AnnotatedTypeAPI
+
+  implicit def AndTypeDeco(x: AndType): Type.AndTypeAPI
+
+  implicit def OrTypeDeco(x: OrType): Type.OrTypeAPI
+
+  implicit def MatchTypeDeco(x: MatchType): Type.MatchTypeAPI
+
+  implicit def ByNameTypeDeco(x: ByNameType): Type.ByNameTypeAPI
+
+  implicit def ParamRefDeco(x: ParamRef): Type.ParamRefAPI
+
+  implicit def ThisTypeDeco(x: ThisType): Type.ThisTypeAPI
+
+  implicit def RecursiveThisDeco(x: RecursiveThis): Type.RecursiveThisAPI
+
+  implicit def RecursiveTypeDeco(x: RecursiveType): Type.RecursiveTypeAPI
+
+  implicit def MethodTypeDeco(x: MethodType): Type.MethodTypeAPI
+
+  implicit def PolyTypeDeco(x: PolyType): Type.PolyTypeAPI
+
+  implicit def TypeLambdaDeco(x: TypeLambda): Type.TypeLambdaAPI
+
+  implicit def TypeBoundsDeco(bounds: TypeBounds): TypeBoundsAPI
+  
   // ----- Types ----------------------------------------------------
 
   def typeOf[T: scala.quoted.Type]: Type
@@ -11,30 +53,6 @@ trait TypeOrBoundsOps extends Core {
     def =:=(other: Type)(implicit ctx: Context): Boolean
     def <:<(other: Type)(implicit ctx: Context): Boolean
   }
-  implicit def TypeDeco(tpe: Type): TypeAPI
-
-  trait MethodTypeAPI {
-    def isImplicit: Boolean
-    def isErased: Boolean
-    def paramNames(implicit ctx: Context): List[String]
-    def paramTypes(implicit ctx: Context): List[Type]
-    def resultTpe(implicit ctx: Context): Type
-  }
-  implicit def MethodTypeDeco(tpt: MethodType): MethodTypeAPI
-
-  trait PolyTypeAPI {
-    def paramNames(implicit ctx: Context): List[String]
-    def paramTypes(implicit ctx: Context): List[TypeBounds]
-    def resultTpe(implicit ctx: Context): Type
-  }
-  implicit def PolyTypeDeco(tpt: PolyType): PolyTypeAPI
-
-  trait TypeLambdaAPI {
-    def paramNames(implicit ctx: Context): List[String]
-    def paramTypes(implicit ctx: Context): List[TypeBounds]
-    def resultTpe(implicit ctx: Context): Type
-  }
-  implicit def TypeLambdaDeco(tpt: TypeLambda): TypeLambdaAPI
 
   val IsType: IsTypeModule
   abstract class IsTypeModule {
@@ -53,7 +71,6 @@ trait TypeOrBoundsOps extends Core {
     trait ConstantTypeAPI {
       def value(implicit ctx: Context): Any
     }
-    implicit def ConstantTypeDeco(x: ConstantType): ConstantTypeAPI
 
     val ConstantType: ConstantTypeModule
     abstract class ConstantTypeModule {
@@ -69,7 +86,6 @@ trait TypeOrBoundsOps extends Core {
     trait SymRefAPI {
       def qualifier(implicit ctx: Context): TypeOrBounds /* Type | NoPrefix */
     }
-    implicit def SymRefDeco(x: SymRef): SymRefAPI
 
     val SymRef: SymRefModule
     abstract class SymRefModule {
@@ -85,7 +101,6 @@ trait TypeOrBoundsOps extends Core {
     trait TermRefAPI {
       def qualifier(implicit ctx: Context): TypeOrBounds /* Type | NoPrefix */
     }
-    implicit def TermRefDeco(x: TermRef): TermRefAPI
 
     val TermRef: TermRefModule
     abstract class TermRefModule {
@@ -102,7 +117,6 @@ trait TypeOrBoundsOps extends Core {
       def name(implicit ctx: Context): String
       def qualifier(implicit ctx: Context): TypeOrBounds /* Type | NoPrefix */
     }
-    implicit def TypeRefDeco(x: TypeRef): TypeRefAPI
 
     val TypeRef: TypeRefModule
     abstract class TypeRefModule {
@@ -119,7 +133,6 @@ trait TypeOrBoundsOps extends Core {
       def thistpe(implicit ctx: Context): Type
       def supertpe(implicit ctx: Context): Type
     }
-    implicit def SuperTypeDeco(x: SuperType): SuperTypeAPI
 
     val SuperType: SuperTypeModule
     abstract class SuperTypeModule {
@@ -137,7 +150,6 @@ trait TypeOrBoundsOps extends Core {
       def name(implicit ctx: Context): String
       def info(implicit ctx: Context): TypeOrBounds
     }
-    implicit def RefinementDeco(x: Refinement): RefinementAPI
 
     val Refinement: RefinementModule
     abstract class RefinementModule {
@@ -154,7 +166,6 @@ trait TypeOrBoundsOps extends Core {
       def tycon(implicit ctx: Context): Type
       def args(implicit ctx: Context): List[TypeOrBounds /* Type | TypeBounds */]
     }
-    implicit def AppliedTypeDeco(x: AppliedType): AppliedTypeAPI
 
     val AppliedType: AppliedTypeModule
     abstract class AppliedTypeModule {
@@ -171,7 +182,6 @@ trait TypeOrBoundsOps extends Core {
       def underlying(implicit ctx: Context): Type
       def annot(implicit ctx: Context): Term
     }
-    implicit def AnnotatedTypeDeco(x: AnnotatedType): AnnotatedTypeAPI
 
     val AnnotatedType: AnnotatedTypeModule
     abstract class AnnotatedTypeModule {
@@ -188,7 +198,6 @@ trait TypeOrBoundsOps extends Core {
       def left(implicit ctx: Context): Type
       def right(implicit ctx: Context): Type
     }
-    implicit def AndTypeDeco(x: AndType): AndTypeAPI
 
     val AndType: AndTypeModule
     abstract class AndTypeModule {
@@ -205,7 +214,6 @@ trait TypeOrBoundsOps extends Core {
       def left(implicit ctx: Context): Type
       def right(implicit ctx: Context): Type
     }
-    implicit def OrTypeDeco(x: OrType): OrTypeAPI
 
     val OrType: OrTypeModule
     abstract class OrTypeModule {
@@ -223,7 +231,6 @@ trait TypeOrBoundsOps extends Core {
       def scrutinee(implicit ctx: Context): Type
       def cases(implicit ctx: Context): List[Type]
     }
-    implicit def MatchTypeDeco(x: MatchType): MatchTypeAPI
 
     val MatchType: MatchTypeModule
     abstract class MatchTypeModule {
@@ -239,7 +246,6 @@ trait TypeOrBoundsOps extends Core {
     trait ByNameTypeAPI {
       def underlying(implicit ctx: Context): Type
     }
-    implicit def ByNameTypeDeco(x: ByNameType): ByNameTypeAPI
 
     val ByNameType: ByNameTypeModule
     abstract class ByNameTypeModule {
@@ -256,7 +262,6 @@ trait TypeOrBoundsOps extends Core {
       def binder(implicit ctx: Context): LambdaType[TypeOrBounds]
       def paramNum(implicit ctx: Context): Int
     }
-    implicit def ParamRefDeco(x: ParamRef): ParamRefAPI
 
     val ParamRef: ParamRefModule
     abstract class ParamRefModule {
@@ -272,7 +277,6 @@ trait TypeOrBoundsOps extends Core {
     trait ThisTypeAPI {
       def underlying(implicit ctx: Context): Type
     }
-    implicit def ThisTypeDeco(x: ThisType): ThisTypeAPI
 
     val ThisType: ThisTypeModule
     abstract class ThisTypeModule {
@@ -288,7 +292,6 @@ trait TypeOrBoundsOps extends Core {
     trait RecursiveThisAPI {
       def binder(implicit ctx: Context): RecursiveType
     }
-    implicit def RecursiveThisDeco(x: RecursiveThis): RecursiveThisAPI
 
     val RecursiveThis: RecursiveThisModule
     abstract class RecursiveThisModule {
@@ -304,7 +307,6 @@ trait TypeOrBoundsOps extends Core {
     trait RecursiveTypeAPI {
       def underlying(implicit ctx: Context): Type
     }
-    implicit def RecursiveTypeDeco(x: RecursiveType): RecursiveTypeAPI
 
     val RecursiveType: RecursiveTypeModule
     abstract class RecursiveTypeModule {
@@ -318,11 +320,12 @@ trait TypeOrBoundsOps extends Core {
     }
 
     trait MethodTypeAPI {
+      def isImplicit: Boolean
+      def isErased: Boolean
       def paramNames(implicit ctx: Context): List[String]
       def paramTypes(implicit ctx: Context): List[Type]
       def resType(implicit ctx: Context): Type
     }
-    implicit def MethodTypeDeco(x: MethodType): MethodTypeAPI
 
     val MethodType: MethodTypeModule
     abstract class MethodTypeModule {
@@ -340,7 +343,6 @@ trait TypeOrBoundsOps extends Core {
       def paramBounds(implicit ctx: Context): List[TypeBounds]
       def resType(implicit ctx: Context): Type
     }
-    implicit def PolyTypeDeco(x: PolyType): PolyTypeAPI
 
     val PolyType: PolyTypeModule
     abstract class PolyTypeModule {
@@ -358,7 +360,6 @@ trait TypeOrBoundsOps extends Core {
       def paramBounds(implicit ctx: Context): List[TypeBounds]
       def resType(implicit ctx: Context): Type
     }
-    implicit def TypeLambdaDeco(x: TypeLambda): TypeLambdaAPI
 
     val TypeLambda: TypeLambdaModule
     abstract class TypeLambdaModule {
@@ -383,7 +384,6 @@ trait TypeOrBoundsOps extends Core {
     def low(implicit ctx: Context): Type
     def hi(implicit ctx: Context): Type
   }
-  implicit def TypeBoundsDeco(bounds: TypeBounds): TypeBoundsAPI
 
   // ----- NoPrefix -------------------------------------------------
 

--- a/library/src/scala/tasty/reflect/TypeOrBoundsTreeOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsTreeOps.scala
@@ -3,10 +3,32 @@ package reflect
 
 trait TypeOrBoundsTreeOps extends Core {
 
+  implicit def TypeOrBoundsTreeDeco(tpt: TypeOrBoundsTree): TypeOrBoundsTreeAPI
+
+  implicit def TypeTreeDeco(tpt: TypeTree): TypeTreeAPI
+  implicit def InferredDeco(x: TypeTree.Inferred): TypeTree.InferredAPI
+  implicit def TypeIdentDeco(x: TypeTree.Ident): TypeTree.IdentAPI
+  implicit def TypeSelectDeco(x: TypeTree.Select): TypeTree.SelectAPI
+  implicit def ProjectDeco(x: TypeTree.Project): TypeTree.ProjectAPI
+  implicit def SingletonDeco(x: TypeTree.Singleton): TypeTree.SingletonAPI
+  implicit def RefinedDeco(x: TypeTree.Refined): TypeTree.RefinedAPI
+  implicit def AppliedDeco(x: TypeTree.Applied): TypeTree.AppliedAPI
+  implicit def AnnotatedDeco(x: TypeTree.Annotated): TypeTree.AnnotatedAPI
+  implicit def AndDeco(x: TypeTree.And): TypeTree.OrAPI
+  implicit def OrDeco(x: TypeTree.Or): TypeTree.OrAPI
+  implicit def MatchTypeTreeDeco(x: TypeTree.MatchType): TypeTree.MatchTypeAPI
+  implicit def ByNameDeco(x: TypeTree.ByName): TypeTree.ByNameAPI
+  implicit def LambdaTypeTreeDeco(x: TypeTree.LambdaTypeTree): TypeTree.LambdaTypeTreeAPI
+  implicit def BindDeco(x: TypeTree.Bind): TypeTree.BindAPI
+  implicit def TypeBlockDeco(x: TypeTree.Block): TypeTree.BlockAPI
+
+  implicit def TypeBoundsTreeDeco(tpt: TypeBoundsTree): TypeBoundsTreeAPI
+
+  implicit def typeTreeAsParent(term: TypeTree): TermOrTypeTree
+
   trait TypeOrBoundsTreeAPI {
     def tpe(implicit ctx: Context): TypeOrBounds
   }
-  implicit def TypeOrBoundsTreeDeco(tpt: TypeOrBoundsTree): TypeOrBoundsTreeAPI
 
   // ----- TypeTrees ------------------------------------------------
 
@@ -17,7 +39,6 @@ trait TypeOrBoundsTreeOps extends Core {
     def tpe(implicit ctx: Context): Type
     def symbol(implicit ctx: Context): Symbol
   }
-  implicit def TypeTreeDeco(tpt: TypeTree): TypeTreeAPI
 
   val IsTypeTree: IsTypeTreeModule
   abstract class IsTypeTreeModule {
@@ -36,7 +57,6 @@ trait TypeOrBoundsTreeOps extends Core {
 
     trait InferredAPI {
     }
-    implicit def InferredDeco(x: Inferred): InferredAPI
 
     /** TypeTree containing an inferred type */
     val Inferred: InferredModule
@@ -54,7 +74,6 @@ trait TypeOrBoundsTreeOps extends Core {
     trait IdentAPI {
       def name(implicit ctx: Context): String
     }
-    implicit def IdentDeco(x: Ident): IdentAPI
 
     val Ident: IdentModule
     abstract class IdentModule {
@@ -71,7 +90,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def qualifier(implicit ctx: Context): Term
       def name(implicit ctx: Context): String
     }
-    implicit def SelectDeco(x: Select): SelectAPI
 
     val Select: SelectModule
     abstract class SelectModule {
@@ -88,7 +106,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def qualifier(implicit ctx: Context): TypeTree
       def name(implicit ctx: Context): String
     }
-    implicit def ProjectDeco(x: Project): ProjectAPI
 
     val Project: ProjectModule
     abstract class ProjectModule {
@@ -104,7 +121,6 @@ trait TypeOrBoundsTreeOps extends Core {
     trait SingletonAPI {
       def ref(implicit ctx: Context): Term
     }
-    implicit def SingletonDeco(x: Singleton): SingletonAPI
 
     val Singleton: SingletonModule
     abstract class SingletonModule {
@@ -121,7 +137,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def tpt(implicit ctx: Context): TypeTree
       def refinements(implicit ctx: Context): List[Definition]
     }
-    implicit def RefinedDeco(x: Refined): RefinedAPI
 
     val Refined: RefinedModule
     abstract class RefinedModule {
@@ -138,7 +153,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def tpt(implicit ctx: Context): TypeTree
       def args(implicit ctx: Context): List[TypeOrBoundsTree]
     }
-    implicit def AppliedDeco(x: Applied): AppliedAPI
 
     val Applied: AppliedModule
     abstract class AppliedModule {
@@ -155,7 +169,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def arg(implicit ctx: Context): TypeTree
       def annotation(implicit ctx: Context): Term
     }
-    implicit def AnnotatedDeco(x: Annotated): AnnotatedAPI
 
     val Annotated: AnnotatedModule
     abstract class AnnotatedModule {
@@ -172,7 +185,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def left(implicit ctx: Context): TypeTree
       def right(implicit ctx: Context): TypeTree
     }
-    implicit def AndDeco(x: And): OrAPI
 
     val And: AndModule
     abstract class AndModule {
@@ -189,7 +201,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def left(implicit ctx: Context): TypeTree
       def right(implicit ctx: Context): TypeTree
     }
-    implicit def OrDeco(x: Or): OrAPI
 
     val Or: OrModule
     abstract class OrModule {
@@ -207,7 +218,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def selector(implicit ctx: Context): TypeTree
       def cases(implicit ctx: Context): List[TypeCaseDef]
     }
-    implicit def MatchTypeDeco(x: MatchType): MatchTypeAPI
 
     val MatchType: MatchTypeModule
     abstract class MatchTypeModule {
@@ -223,7 +233,6 @@ trait TypeOrBoundsTreeOps extends Core {
     trait ByNameAPI {
       def result(implicit ctx: Context): TypeTree
     }
-    implicit def ByNameDeco(x: ByName): ByNameAPI
 
     val ByName: ByNameModule
     abstract class ByNameModule {
@@ -240,7 +249,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def tparams(implicit ctx: Context): List[TypeDef]
       def body(implicit ctx: Context): TypeOrBoundsTree
     }
-    implicit def LambdaTypeTreeDeco(x: LambdaTypeTree): LambdaTypeTreeAPI
 
     val LambdaTypeTree: LambdaTypeTreeModule
     abstract class LambdaTypeTreeModule {
@@ -257,7 +265,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def name(implicit ctx: Context): String
       def body(implicit ctx: Context): TypeOrBoundsTree
     }
-    implicit def BindDeco(x: Bind): BindAPI
 
     val Bind: BindModule
     abstract class BindModule {
@@ -274,7 +281,6 @@ trait TypeOrBoundsTreeOps extends Core {
       def aliases(implicit ctx: Context): List[TypeDef]
       def tpt(implicit ctx: Context): TypeTree
     }
-    implicit def BlockDeco(x: Block): BlockAPI
 
     val Block: BlockModule
     abstract class BlockModule {
@@ -289,7 +295,6 @@ trait TypeOrBoundsTreeOps extends Core {
     def low(implicit ctx: Context): TypeTree
     def hi(implicit ctx: Context): TypeTree
   }
-  implicit def TypeBoundsTreeDeco(tpt: TypeBoundsTree): TypeBoundsTreeAPI
 
   val IsTypeBoundsTree: IsTypeBoundsTreeModule
   abstract class IsTypeBoundsTreeModule {
@@ -308,5 +313,4 @@ trait TypeOrBoundsTreeOps extends Core {
     def unapply(typeOrBoundsTree: TypeOrBoundsTree)(implicit ctx: Context): Boolean
   }
 
-  implicit def typeTreeAsParent(term: TypeTree): TermOrTypeTree
 }


### PR DESCRIPTION
* This allows them to be imported with the rest of the reflection API.
* Removes dublicated `{Method|Poly}TypeDeco`
