### PR TITLE
Fix #5450: Handle `this` and self reference in IDE

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -282,6 +282,14 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
     case Block(_, expr) => forallResults(expr, p)
     case _ => p(tree)
   }
+
+  /** Is `tree` a reference to `this` or a self type? */
+  def isThisOrSelfReference(tree: Tree)(implicit ctx: Context): Boolean = tree match {
+    case This(_) => true
+    case Ident(nme) => nme.isTermName && tree.symbol.isType
+    case _ => false
+  }
+
 }
 
 trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] =>

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -413,8 +413,9 @@ object Trees {
 
   /** qual.this */
   case class This[-T >: Untyped] private[ast] (qual: untpd.Ident)
-    extends DenotingTree[T] with TermTree[T] {
+    extends NameTree[T] with TermTree[T] {
     type ThisTree[-T >: Untyped] = This[T]
+    override def name: TermName = nme.this_
     // Denotation of a This tree is always the underlying class; needs correction for modules.
     override def denot(implicit ctx: Context): Denotation = {
       typeOpt match {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1884,6 +1884,7 @@ class Typer extends Namer
           val sym = retrieveSym(xtree)
           tree match {
             case tree: untpd.Ident => typedIdent(tree, pt)
+            case tree: untpd.This => typedThis(tree)
             case tree: untpd.Select => typedSelect(tree, pt)
             case tree: untpd.Bind => typedBind(tree, pt)
             case tree: untpd.ValDef =>
@@ -1905,7 +1906,6 @@ class Typer extends Namer
         def typedUnnamed(tree: untpd.Tree): Tree = tree match {
           case tree: untpd.Apply =>
             if (ctx.mode is Mode.Pattern) typedUnApply(tree, pt) else typedApply(tree, pt)
-          case tree: untpd.This => typedThis(tree)
           case tree: untpd.Literal => typedLiteral(tree)
           case tree: untpd.New => typedNew(tree, pt)
           case tree: untpd.Typed => typedTyped(tree, pt)

--- a/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
@@ -344,4 +344,25 @@ class DefinitionTest {
      .definition(m15 to m16, List(m7 to m8))
   }
 
+  @Test def goToSelfDefinition: Unit = {
+    code"""class Foo { ${m1}self${m2} =>
+          |  def bar: Unit = {
+          |    ${m3}self${m4}.bar
+          |    println(${m5}self${m6})
+          |    ${m7}this${m8}.bar
+          |  }
+          |}""".withSource
+      .definition(m1 to m2, List(m1 to m2))
+      .definition(m3 to m4, List(m1 to m2))
+      .definition(m5 to m6, List(m1 to m2))
+      .definition(m7 to m8, List(m1 to m2))
+  }
+
+  @Test def goToDefinitionThis: Unit = {
+    code"""class Foo {
+          |  val foo = ${m1}this${m2}
+          |}""".withSource
+      .definition(m1 to m2, Nil)
+  }
+
 }

--- a/language-server/test/dotty/tools/languageserver/DocumentSymbolTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DocumentSymbolTest.scala
@@ -44,4 +44,11 @@ class DocumentSymbolTest {
       .documentSymbol(m1, (m1 to m2).symInfo("Foo", SymbolKind.Class),
                           (m3 to m4).symInfo("x", SymbolKind.Field, "Foo"))
   }
+
+  @Test def documentSymbolSelf: Unit = {
+    code"""class ${m1}Foo${m2} { ${m3}self${m4} =>
+          |}""".withSource
+      .documentSymbol(m1, (m1 to m2).symInfo("Foo", SymbolKind.Class),
+                          (m3 to m4).symInfo("self", SymbolKind.Field, "Foo"))
+  }
 }

--- a/language-server/test/dotty/tools/languageserver/HighlightTest.scala
+++ b/language-server/test/dotty/tools/languageserver/HighlightTest.scala
@@ -2,27 +2,27 @@ package dotty.tools.languageserver
 
 import org.junit.Test
 import dotty.tools.languageserver.util.Code._
-import org.eclipse.lsp4j.DocumentHighlightKind
+import org.eclipse.lsp4j.DocumentHighlightKind.Read
 
 class HighlightTest {
 
   @Test def valHighlight0: Unit = {
     val xDef = (m1 to m2).withCode("x")
     code"class X { val $xDef = 9 }".withSource
-      .highlight(xDef.range, (xDef.range, DocumentHighlightKind.Read))
+      .highlight(xDef.range, (xDef.range, Read))
   }
 
   @Test def valHighlight1: Unit = {
     val xDef = (m1 to m2).withCode("x")
     val xRef = (m3 to m4).withCode("x")
     code"class X { val $xDef = 9; $xRef}".withSource
-      .highlight(xRef.range, (xDef.range, DocumentHighlightKind.Read), (xRef.range, DocumentHighlightKind.Read))
+      .highlight(xRef.range, (xDef.range, Read), (xRef.range, Read))
   }
 
   @Test def highlightClass(): Unit = {
     code"""class ${m1}Foo${m2} { new ${m3}Foo${m4} }""".withSource
-      .highlight(m1 to m2, (m1 to m2, DocumentHighlightKind.Read), (m3 to m4, DocumentHighlightKind.Read))
-      .highlight(m3 to m4, (m1 to m2, DocumentHighlightKind.Read), (m3 to m4, DocumentHighlightKind.Read))
+      .highlight(m1 to m2, (m1 to m2, Read), (m3 to m4, Read))
+      .highlight(m3 to m4, (m1 to m2, Read), (m3 to m4, Read))
   }
 
   @Test def importHighlight0: Unit = {
@@ -30,11 +30,11 @@ class HighlightTest {
            trait Bar { import ${m3}Foo${m4}._; def buzz = ${m7}bar${m8} }
            trait Baz { def ${m9}bar${m10}: Int = 1 }""".withSource
 
-      .highlight(m1 to m2, (m1 to m2, DocumentHighlightKind.Read), (m3 to m4, DocumentHighlightKind.Read))
-      .highlight(m3 to m4, (m1 to m2, DocumentHighlightKind.Read), (m3 to m4, DocumentHighlightKind.Read))
-      .highlight(m5 to m6, (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-      .highlight(m7 to m8, (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-      .highlight(m9 to m10, (m9 to m10, DocumentHighlightKind.Read))
+      .highlight(m1 to m2, (m1 to m2, Read), (m3 to m4, Read))
+      .highlight(m3 to m4, (m1 to m2, Read), (m3 to m4, Read))
+      .highlight(m5 to m6, (m5 to m6, Read), (m7 to m8, Read))
+      .highlight(m7 to m8, (m5 to m6, Read), (m7 to m8, Read))
+      .highlight(m9 to m10, (m9 to m10, Read))
   }
 
   @Test def importHighlight1: Unit = {
@@ -42,75 +42,75 @@ class HighlightTest {
            object ${m3}Foo${m4} { def ${m5}bar${m6}: Int = 0 }
            trait Bar { def buzz = ${m7}bar${m8} }""".withSource
 
-      .highlight(m1 to m2, (m1 to m2, DocumentHighlightKind.Read), (m3 to m4, DocumentHighlightKind.Read))
-      .highlight(m3 to m4, (m1 to m2, DocumentHighlightKind.Read), (m3 to m4, DocumentHighlightKind.Read))
-      .highlight(m5 to m6, (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-      .highlight(m7 to m8, (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
+      .highlight(m1 to m2, (m1 to m2, Read), (m3 to m4, Read))
+      .highlight(m3 to m4, (m1 to m2, Read), (m3 to m4, Read))
+      .highlight(m5 to m6, (m5 to m6, Read), (m7 to m8, Read))
+      .highlight(m7 to m8, (m5 to m6, Read), (m7 to m8, Read))
   }
 
   @Test def importHighlight2: Unit = {
     code"""object ${m1}Foo${m2} { object ${m3}Bar${m4} { object ${m5}Baz${m6} } }
            trait Buzz { import ${m7}Foo${m8}.${m9}Bar${m10}.${m11}Baz${m12} }""".withSource
 
-    .highlight(m1 to m2, (m1 to m2, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-    .highlight(m3 to m4, (m3 to m4, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read))
-    .highlight(m5 to m6, (m5 to m6, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read))
-    .highlight(m7 to m8, (m1 to m2, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-    .highlight(m9 to m10, (m3 to m4, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read))
-    .highlight(m11 to m12, (m5 to m6, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read))
+    .highlight(m1 to m2, (m1 to m2, Read), (m7 to m8, Read))
+    .highlight(m3 to m4, (m3 to m4, Read), (m9 to m10, Read))
+    .highlight(m5 to m6, (m5 to m6, Read), (m11 to m12, Read))
+    .highlight(m7 to m8, (m1 to m2, Read), (m7 to m8, Read))
+    .highlight(m9 to m10, (m3 to m4, Read), (m9 to m10, Read))
+    .highlight(m11 to m12, (m5 to m6, Read), (m11 to m12, Read))
   }
 
   @Test def importHighlight3: Unit = {
     code"""import ${m1}Foo${m2}.${m3}Bar${m4}
            object ${m5}Foo${m6} { object ${m7}Bar${m8} }""".withSource
 
-      .highlight(m1 to m2, (m1 to m2, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read))
-      .highlight(m3 to m4, (m3 to m4, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-      .highlight(m5 to m6, (m1 to m2, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read))
-      .highlight(m7 to m8, (m3 to m4, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
+      .highlight(m1 to m2, (m1 to m2, Read), (m5 to m6, Read))
+      .highlight(m3 to m4, (m3 to m4, Read), (m7 to m8, Read))
+      .highlight(m5 to m6, (m1 to m2, Read), (m5 to m6, Read))
+      .highlight(m7 to m8, (m3 to m4, Read), (m7 to m8, Read))
   }
 
   @Test def importHighlightClassAndCompanion: Unit = {
     code"""object Foo { object ${m1}Bar${m2}; class ${m3}Bar${m4} }
            trait Buzz { import Foo.${m5}Bar${m6} }""".withSource
-      .highlight(m1 to m2, (m1 to m2, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read))
-      .highlight(m3 to m4, (m3 to m4, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read))
-      .highlight(m5 to m6, (m3 to m4, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read), (m1 to m2, DocumentHighlightKind.Read))
+      .highlight(m1 to m2, (m1 to m2, Read), (m5 to m6, Read))
+      .highlight(m3 to m4, (m3 to m4, Read), (m5 to m6, Read))
+      .highlight(m5 to m6, (m3 to m4, Read), (m5 to m6, Read), (m1 to m2, Read))
   }
 
   @Test def importHighlightWithRename: Unit = {
     code"""object ${m1}Foo${m2} { object ${m3}Bar${m4} { object ${m5}Baz${m6} } }
            trait Buzz { import ${m7}Foo${m8}.${m9}Bar${m10}.{${m11}Baz${m12} => ${m13}Quux${m14}}""".withSource
 
-    .highlight(m1 to m2, (m1 to m2, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-    .highlight(m3 to m4, (m3 to m4, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read))
-    .highlight(m5 to m6, (m5 to m6, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read), (m13 to m14, DocumentHighlightKind.Read))
-    .highlight(m7 to m8, (m1 to m2, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-    .highlight(m9 to m10, (m3 to m4, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read))
-    .highlight(m11 to m12, (m5 to m6, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read), (m13 to m14, DocumentHighlightKind.Read))
-    .highlight(m13 to m14, (m5 to m6, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read), (m13 to m14, DocumentHighlightKind.Read))
+    .highlight(m1 to m2, (m1 to m2, Read), (m7 to m8, Read))
+    .highlight(m3 to m4, (m3 to m4, Read), (m9 to m10, Read))
+    .highlight(m5 to m6, (m5 to m6, Read), (m11 to m12, Read), (m13 to m14, Read))
+    .highlight(m7 to m8, (m1 to m2, Read), (m7 to m8, Read))
+    .highlight(m9 to m10, (m3 to m4, Read), (m9 to m10, Read))
+    .highlight(m11 to m12, (m5 to m6, Read), (m11 to m12, Read), (m13 to m14, Read))
+    .highlight(m13 to m14, (m5 to m6, Read), (m11 to m12, Read), (m13 to m14, Read))
   }
 
   @Test def importHighlightClassAndCompanionWithRename: Unit = {
     code"""object ${m1}Foo${m2} { object ${m3}Bar${m4}; class ${m5}Bar${m6} }
            trait Buzz { import ${m7}Foo${m8}.{${m9}Bar${m10} => ${m11}Baz${m12}} }""".withSource
 
-      .highlight(m1 to m2, (m1 to m2, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-      .highlight(m3 to m4, (m3 to m4, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read))
-      .highlight(m5 to m6, (m5 to m6, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read))
-      .highlight(m7 to m8, (m1 to m2, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-      .highlight(m9 to m10, (m3 to m4, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read))
-      .highlight(m11 to m12, (m3 to m4, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read))
+      .highlight(m1 to m2, (m1 to m2, Read), (m7 to m8, Read))
+      .highlight(m3 to m4, (m3 to m4, Read), (m9 to m10, Read), (m11 to m12, Read))
+      .highlight(m5 to m6, (m5 to m6, Read), (m9 to m10, Read), (m11 to m12, Read))
+      .highlight(m7 to m8, (m1 to m2, Read), (m7 to m8, Read))
+      .highlight(m9 to m10, (m3 to m4, Read), (m5 to m6, Read), (m9 to m10, Read), (m11 to m12, Read))
+      .highlight(m11 to m12, (m3 to m4, Read), (m5 to m6, Read), (m9 to m10, Read), (m11 to m12, Read))
   }
 
   @Test def importHighlightMembers: Unit = {
     code"""object Foo { def ${m1}bar${m2} = 2; type ${m3}bar${m4} = fizz; class fizz }
            trait Quux { import Foo.{${m5}bar${m6} => ${m7}buzz${m8}} }""".withSource
 
-    .highlight(m1 to m2, (m1 to m2, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-    .highlight(m3 to m4, (m3 to m4, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-    .highlight(m5 to m6, (m1 to m2, DocumentHighlightKind.Read), (m3 to m4, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-    .highlight(m7 to m8, (m1 to m2, DocumentHighlightKind.Read), (m3 to m4, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
+    .highlight(m1 to m2, (m1 to m2, Read), (m5 to m6, Read), (m7 to m8, Read))
+    .highlight(m3 to m4, (m3 to m4, Read), (m5 to m6, Read), (m7 to m8, Read))
+    .highlight(m5 to m6, (m1 to m2, Read), (m3 to m4, Read), (m5 to m6, Read), (m7 to m8, Read))
+    .highlight(m7 to m8, (m1 to m2, Read), (m3 to m4, Read), (m5 to m6, Read), (m7 to m8, Read))
   }
 
   @Test def multipleImportsPerLineWithRename: Unit = {
@@ -118,12 +118,12 @@ class HighlightTest {
       code"""object A { class ${m1}B${m2}; class ${m3}C${m4} }
              import A.{${m5}B${m6} => ${m7}B2${m8}, ${m9}C${m10} => ${m11}C2${m12}}
              class E"""
-    ).highlight(m1 to m2, (m1 to m2, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-     .highlight(m3 to m4, (m3 to m4, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read))
-     .highlight(m5 to m6, (m1 to m2, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-     .highlight(m7 to m8, (m1 to m2, DocumentHighlightKind.Read), (m5 to m6, DocumentHighlightKind.Read), (m7 to m8, DocumentHighlightKind.Read))
-     .highlight(m9 to m10, (m3 to m4, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read))
-     .highlight(m11 to m12, (m3 to m4, DocumentHighlightKind.Read), (m9 to m10, DocumentHighlightKind.Read), (m11 to m12, DocumentHighlightKind.Read))
+    ).highlight(m1 to m2, (m1 to m2, Read), (m5 to m6, Read), (m7 to m8, Read))
+     .highlight(m3 to m4, (m3 to m4, Read), (m9 to m10, Read), (m11 to m12, Read))
+     .highlight(m5 to m6, (m1 to m2, Read), (m5 to m6, Read), (m7 to m8, Read))
+     .highlight(m7 to m8, (m1 to m2, Read), (m5 to m6, Read), (m7 to m8, Read))
+     .highlight(m9 to m10, (m3 to m4, Read), (m9 to m10, Read), (m11 to m12, Read))
+     .highlight(m11 to m12, (m3 to m4, Read), (m9 to m10, Read), (m11 to m12, Read))
   }
 
 }

--- a/language-server/test/dotty/tools/languageserver/HighlightTest.scala
+++ b/language-server/test/dotty/tools/languageserver/HighlightTest.scala
@@ -126,4 +126,37 @@ class HighlightTest {
      .highlight(m11 to m12, (m3 to m4, Read), (m9 to m10, Read), (m11 to m12, Read))
   }
 
+  @Test def thisAndSelf: Unit = {
+    code"""class ${m1}A${m2} { ${m3}self${m4} =>
+          |  def foo = ${m5}this${m6}
+          |  def bar = ${m7}self${m8}
+          |}""".withSource
+      .highlight(m1 to m2, (m1 to m2, Read))
+      .highlight(m3 to m4, (m3 to m4, Read), (m5 to m6, Read), (m7 to m8, Read))
+      .highlight(m5 to m6, (m3 to m4, Read), (m5 to m6, Read), (m7 to m8, Read))
+      .highlight(m7 to m8, (m3 to m4, Read), (m5 to m6, Read), (m7 to m8, Read))
+  }
+
+  @Test def nestedSelf: Unit = {
+    code"""class A { ${m1}self${m2} =>
+             val bar = ${m3}self${m4}
+             class B { ${m5}self${m6} =>
+               val foo = ${m7}self${m8}
+             }
+           }""".withSource
+      .highlight(m1 to m2, (m1 to m2, Read), (m3 to m4, Read))
+      .highlight(m3 to m4, (m1 to m2, Read), (m3 to m4, Read))
+      .highlight(m5 to m6, (m5 to m6, Read), (m7 to m8, Read))
+      .highlight(m7 to m8, (m5 to m6, Read), (m7 to m8, Read))
+  }
+
+  @Test def highlightThis: Unit = {
+    code"""class A {
+          |  val foo = ${m1}this${m2}
+          |  val bar = ${m3}this${m4}
+          |}""".withSource
+      .highlight(m1 to m2, (m1 to m2, Read), (m3 to m4, Read))
+      .highlight(m3 to m4, (m1 to m2, Read), (m3 to m4, Read))
+  }
+
 }

--- a/language-server/test/dotty/tools/languageserver/HoverTest.scala
+++ b/language-server/test/dotty/tools/languageserver/HoverTest.scala
@@ -174,4 +174,12 @@ class HoverTest {
           |}""".withSource
       .hover(m1 to m2, hoverContent("Int", "hello"))
   }
+
+  @Test def hoverSelf: Unit = {
+    code"""class Foo { ${m1}self${m2} =>
+          |  val bizz = ${m3}self${m4}
+          |}""".withSource
+      .hover(m1 to m2, hoverContent("Foo"))
+      .hover(m3 to m4, hoverContent("(Foo & Foo)(Foo.this)"))
+  }
 }

--- a/language-server/test/dotty/tools/languageserver/ReferencesTest.scala
+++ b/language-server/test/dotty/tools/languageserver/ReferencesTest.scala
@@ -356,4 +356,19 @@ class ReferencesTest {
      .references(m1 to m2, List(m3 to m4), withDecl = false)
   }
 
+  @Test def referencesToSelf: Unit = {
+    code"""class Foo { ${m1}self${m2} =>
+          |  def bar: Unit = {
+          |    ${m3}self${m4}.bar
+          |    println(${m5}self${m6})
+          |  }
+          |}""".withSource
+      .references(m1 to m2, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m1 to m2, List(m3 to m4, m5 to m6), withDecl = false)
+      .references(m3 to m4, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m3 to m4, List(m3 to m4, m5 to m6), withDecl = false)
+      .references(m5 to m6, List(m1 to m2, m3 to m4, m5 to m6), withDecl = true)
+      .references(m5 to m6, List(m3 to m4, m5 to m6), withDecl = false)
+  }
+
 }

--- a/language-server/test/dotty/tools/languageserver/RenameTest.scala
+++ b/language-server/test/dotty/tools/languageserver/RenameTest.scala
@@ -332,4 +332,20 @@ class RenameTest {
 
   }
 
+  @Test def renameSelf: Unit = {
+    def testRenameFrom(marker: CodeMarker) =
+      code"""class Foo { ${m1}self${m2} =>
+            |  def bar: Unit = {
+            |    ${m3}self${m4}.bar
+            |    println(${m5}self${m6})
+            |    this.bar
+            |  }
+            |}""".withSource
+        .rename(marker, "newName", Set(m1 to m2, m3 to m4, m5 to m6))
+
+    testRenameFrom(m1)
+    testRenameFrom(m3)
+    testRenameFrom(m5)
+  }
+
 }


### PR DESCRIPTION
> In the IDE, all the class definition now have a self definition. We use
> the symbol of this definition for `this` and references to the self
> definition.

The basic facts that make handling `this` and `self` hard in the IDE is this (it seems no one references the symbol of the self definition):

> Currently, a self definition has a symbol. The symbol of references to
> the self definition is the enclosing class symbol. The symbol of `this`
> is the enclosing class symbol.

I don't know what are the reasons for having it work this way, nor how hard it would be to have a scheme that would be easier to handle for the IDE.

I also tried to use the kind of the name to know what to select (grouping `this` and `self` by knowing that they have the same symbol and the names they carry have the same kind), but I ran into problems with imports that always have term names, IIRC.

Note that if this PR is merged, we will start to be able to rename `this`. I added support for `textDocument/prepareRename` (and added checks in `rename`), and will submit a PR with these changes this week.