### PR TITLE
Propagate dependencies through implicit parameters

### DIFF
--- a/tests/neg/i5427.scala
+++ b/tests/neg/i5427.scala
@@ -1,0 +1,26 @@
+trait Foo[In] { type Out }
+
+object Test {
+  def fooInt: Foo[Int] { type Out = String } = ???
+  implicit def str: String = ???
+
+  def test1[A](f1: Foo[A])(implicit f2: f1.Out) = ???
+  def test2[A](implicit f1: Foo[A], f2: f1.Out) = ???
+
+  test1(fooInt)   // OK
+  test2           // error
+}
+
+object Test2 {
+  implicit def fooInt: Foo[Int] { type Out = String } = ???
+  implicit def fooString: Foo[String] { type Out = Boolean } = ???
+  implicit def fooBoolean: Foo[Boolean] { type Out = Double } = ???
+
+  def test3[A](f1: Foo[A], f2: Foo[f1.Out])(implicit f3: Foo[f2.Out]): f3.Out = ???
+  def test4[A](implicit f1: Foo[A], f2: Foo[f1.Out], f3: Foo[f2.Out]): f3.Out = ???
+
+  val t3 = test3(fooInt, fooString)
+  t3: Double
+  val t4 = test4  // error
+  t4: Double
+}

--- a/tests/pos/i5427.scala
+++ b/tests/pos/i5427.scala
@@ -1,0 +1,46 @@
+trait Foo[In] { type Out }
+
+object Test {
+  implicit def fooInt: Foo[Int] { type Out = String } = ???
+  implicit def str: String = ???
+
+  def test1[A](f1: Foo[A])(implicit f2: f1.Out) = ???
+  def test2[A](implicit f1: Foo[A], f2: f1.Out) = ???
+
+  test1(fooInt) // OK
+  test2         // OK
+}
+
+object Test2 {
+  implicit def fooInt: Foo[Int] { type Out = String } = ???
+  implicit def fooString: Foo[String] { type Out = Boolean } = ???
+  implicit def fooBoolean: Foo[Boolean] { type Out = Double } = ???
+
+  def test3[A](f1: Foo[A], f2: Foo[f1.Out])(implicit f3: Foo[f2.Out]): f3.Out = ???
+  def test4[A](implicit f1: Foo[A], f2: Foo[f1.Out], f3: Foo[f2.Out]): f3.Out = ???
+
+  val t3 = test3(fooInt, fooString)
+  t3: Double
+  val t4 = test4[Int]
+  t4: Double
+}
+
+object Test3 {
+  def fooInt: Foo[Int] { type Out = String } = ???
+  implicit def str: String = ???
+
+  def test5[A](implicit f1: Foo[A] = fooInt, f2: f1.Out) = f2
+
+  val t5 = test5
+  t5: String
+}
+
+object Test4 {
+  implicit def fooInt: Foo[Int] { type Out = String } = ???
+  def str: String = ???
+
+  def test6[A](implicit f1: Foo[A], f2: f1.Out = str) = f2
+
+  val t6 = test6
+  t6: String
+}


### PR DESCRIPTION
Fixes #5427.

If an implicit parameter list is dependent, we must propagate inferred types through the remainder of the parameter list, similarly to how it's done for non-implicit parameter lists in `Applications#matchArgs#addTyped`.