### PR TITLE
Gadt unification

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Printers.scala
+++ b/compiler/src/dotty/tools/dotc/config/Printers.scala
@@ -20,6 +20,7 @@ object Printers {
   val dottydoc: Printer = noPrinter
   val exhaustivity: Printer = noPrinter
   val gadts: Printer = noPrinter
+  val gadtsConstr: Printer = noPrinter
   val hk: Printer = noPrinter
   val implicits: Printer = noPrinter
   val implicitsDetailed: Printer = noPrinter

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -23,13 +23,13 @@ trait ConstraintHandling {
   def constr_println(msg: => String): Unit = constr.println(msg)
   def typr_println(msg: => String): Unit = typr.println(msg)
 
-  implicit val ctx: Context
+  implicit def ctx: Context
 
   protected def isSubType(tp1: Type, tp2: Type): Boolean
   protected def isSameType(tp1: Type, tp2: Type): Boolean
 
-  val state: TyperState
-  import state.constraint
+  protected def constraint: Constraint
+  protected def constraint_=(c: Constraint): Unit
 
   private[this] var addConstraintInvocations = 0
 

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -20,6 +20,9 @@ import config.Printers.{constr, typr}
  */
 trait ConstraintHandling {
 
+  def constr_println(msg: => String): Unit = constr.println(msg)
+  def typr_println(msg: => String): Unit = typr.println(msg)
+
   implicit val ctx: Context
 
   protected def isSubType(tp1: Type, tp2: Type): Boolean
@@ -120,23 +123,23 @@ trait ConstraintHandling {
       if (Config.failOnInstantiationToNothing) assert(false, msg)
       else ctx.log(msg)
     }
-    constr.println(i"adding $description$location")
+    constr_println(i"adding $description$location")
     val lower = constraint.lower(param)
     val res =
       addOneBound(param, bound, isUpper = true) &&
       lower.forall(addOneBound(_, bound, isUpper = true))
-    constr.println(i"added $description = $res$location")
+    constr_println(i"added $description = $res$location")
     res
   }
 
   protected def addLowerBound(param: TypeParamRef, bound: Type): Boolean = {
     def description = i"constraint $param >: $bound to\n$constraint"
-    constr.println(i"adding $description")
+    constr_println(i"adding $description")
     val upper = constraint.upper(param)
     val res =
       addOneBound(param, bound, isUpper = false) &&
       upper.forall(addOneBound(_, bound, isUpper = false))
-    constr.println(i"added $description = $res$location")
+    constr_println(i"added $description = $res$location")
     res
   }
 
@@ -149,12 +152,12 @@ trait ConstraintHandling {
         val up2 = p2 :: constraint.exclusiveUpper(p2, p1)
         val lo1 = constraint.nonParamBounds(p1).lo
         val hi2 = constraint.nonParamBounds(p2).hi
-        constr.println(i"adding $description down1 = $down1, up2 = $up2$location")
+        constr_println(i"adding $description down1 = $down1, up2 = $up2$location")
         constraint = constraint.addLess(p1, p2)
         down1.forall(addOneBound(_, hi2, isUpper = true)) &&
         up2.forall(addOneBound(_, lo1, isUpper = false))
       }
-    constr.println(i"added $description = $res$location")
+    constr_println(i"added $description = $res$location")
     res
   }
 
@@ -162,7 +165,7 @@ trait ConstraintHandling {
    *  @pre  less(p1)(p2)
    */
   private def unify(p1: TypeParamRef, p2: TypeParamRef): Boolean = {
-    constr.println(s"unifying $p1 $p2")
+    constr_println(s"unifying $p1 $p2")
     assert(constraint.isLess(p1, p2))
     val down = constraint.exclusiveLower(p2, p1)
     val up = constraint.exclusiveUpper(p1, p2)
@@ -260,7 +263,7 @@ trait ConstraintHandling {
       case _: TypeBounds =>
         val bound = if (fromBelow) constraint.fullLowerBound(param) else constraint.fullUpperBound(param)
         val inst = avoidParam(bound)
-        typr.println(s"approx ${param.show}, from below = $fromBelow, bound = ${bound.show}, inst = ${inst.show}")
+        typr_println(s"approx ${param.show}, from below = $fromBelow, bound = ${bound.show}, inst = ${inst.show}")
         inst
       case inst =>
         assert(inst.exists, i"param = $param\nconstraint = $constraint")
@@ -359,7 +362,7 @@ trait ConstraintHandling {
             val lower = constraint.lower(param)
             val upper = constraint.upper(param)
             if (lower.nonEmpty && !bounds.lo.isRef(defn.NothingClass) ||
-              upper.nonEmpty && !bounds.hi.isRef(defn.AnyClass)) constr.println(i"INIT*** $tl")
+              upper.nonEmpty && !bounds.hi.isRef(defn.AnyClass)) constr_println(i"INIT*** $tl")
             lower.forall(addOneBound(_, bounds.hi, isUpper = true)) &&
               upper.forall(addOneBound(_, bounds.lo, isUpper = false))
           case _ =>

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -50,6 +50,19 @@ trait ConstraintHandling {
    */
   protected var comparedTypeLambdas: Set[TypeLambda] = Set.empty
 
+  /** Gives for each instantiated type var that does not yet have its `inst` field
+    *  set, the instance value stored in the constraint. Storing instances in constraints
+    *  is done only in a temporary way for contexts that may be retracted
+    *  without also retracting the type var as a whole.
+    */
+  def instType(tvar: TypeVar): Type = constraint.entry(tvar.origin) match {
+    case _: TypeBounds => NoType
+    case tp: TypeParamRef =>
+      var tvar1 = constraint.typeVarOfParam(tp)
+      if (tvar1.exists) tvar1 else tp
+    case tp => tp
+  }
+
   protected def addOneBound(param: TypeParamRef, bound: Type, isUpper: Boolean): Boolean =
     !constraint.contains(param) || {
       def occursIn(bound: Type): Boolean = {

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -480,7 +480,7 @@ object Contexts {
     def setTyper(typer: Typer): this.type = { this.scope = typer.scope; setTypeAssigner(typer) }
     def setImportInfo(importInfo: ImportInfo): this.type = { this.importInfo = importInfo; this }
     def setGadt(gadt: GADTMap): this.type = { this.gadt = gadt; this }
-    def setFreshGADTBounds: this.type = setGadt(new GADTMap(gadt.bounds))
+    def setFreshGADTBounds: this.type = setGadt(gadt.fresh)
     def setSearchHistory(searchHistory: SearchHistory): this.type = { this.searchHistory = searchHistory; this }
     def setTypeComparerFn(tcfn: Context => TypeComparer): this.type = { this.typeComparer = tcfn(this); this }
     private def setMoreProperties(moreProperties: Map[Key[Any], Any]): this.type = { this.moreProperties = moreProperties; this }
@@ -708,14 +708,201 @@ object Contexts {
       else assert(thread == Thread.currentThread(), "illegal multithreaded access to ContextBase")
   }
 
-  class GADTMap(initBounds: SimpleIdentityMap[Symbol, TypeBounds]) {
-    private[this] var myBounds = initBounds
-    def setBounds(sym: Symbol, b: TypeBounds): Unit =
-      myBounds = myBounds.updated(sym, b)
-    def bounds: SimpleIdentityMap[Symbol, TypeBounds] = myBounds
+  sealed abstract class GADTMap {
+    def addEmptyBounds(sym: Symbol)(implicit ctx: Context): Unit
+    def addBound(sym: Symbol, bound: Type, isUpper: Boolean)(implicit ctx: Context): Boolean
+    def bounds(sym: Symbol)(implicit ctx: Context): TypeBounds
+    def contains(sym: Symbol)(implicit ctx: Context): Boolean
+    def debugBoundsDescription(implicit ctx: Context): String
+    def fresh: GADTMap
   }
 
-  @sharable object EmptyGADTMap extends GADTMap(SimpleIdentityMap.Empty) {
-    override def setBounds(sym: Symbol, b: TypeBounds): Unit = unsupported("EmptyGADTMap.setBounds")
+  final class SmartGADTMap private (
+    private[this] var myConstraint: Constraint,
+    private[this] var mapping: SimpleIdentityMap[Symbol, TypeVar],
+    private[this] var reverseMapping: SimpleIdentityMap[TypeParamRef, Symbol]
+  ) extends GADTMap with ConstraintHandling {
+    import dotty.tools.dotc.config.Printers.{gadts, gadtsConstr}
+
+    def this() = this(
+      myConstraint = new OrderingConstraint(SimpleIdentityMap.Empty, SimpleIdentityMap.Empty, SimpleIdentityMap.Empty),
+      mapping = SimpleIdentityMap.Empty,
+      reverseMapping = SimpleIdentityMap.Empty
+    )
+
+    // TODO: clean up this dirty kludge
+    private[this] var myCtx: Context = null
+    implicit override def ctx = myCtx
+    @forceInline private[this] final def inCtx[T](_ctx: Context)(op: => T) = {
+      val savedCtx = myCtx
+      myCtx = _ctx
+      try op finally myCtx = savedCtx
+    }
+
+    override protected def constraint = myConstraint
+    override protected def constraint_=(c: Constraint) = myConstraint = c
+
+    override def isSubType(tp1: Type, tp2: Type): Boolean = ctx.typeComparer.isSubType(tp1, tp2)
+    override def isSameType(tp1: Type, tp2: Type): Boolean = ctx.typeComparer.isSameType(tp1, tp2)
+
+
+    override def addEmptyBounds(sym: Symbol)(implicit ctx: Context): Unit = tvar(sym)
+
+    override def addBound(sym: Symbol, bound: Type, isUpper: Boolean)(implicit ctx: Context): Boolean = inCtx(ctx) {
+      @annotation.tailrec def stripInst(tp: Type): Type = tp match {
+        case tv: TypeVar =>
+          val inst = instType(tv)
+          if (inst.exists) stripInst(inst) else tv
+        case _ => tp
+      }
+
+      def cautiousSubtype(tp1: Type, tp2: Type, isSubtype: Boolean): Boolean = {
+        val externalizedTp1 = removeTypeVars(tp1)
+        val externalizedTp2 = removeTypeVars(tp2)
+
+        def descr = {
+          def op = s"frozen_${if (isSubtype) "<:<" else ">:>"}"
+          i"$tp1 $op $tp2\n\t$externalizedTp1 $op $externalizedTp2"
+        }
+        // gadts.println(descr)
+
+        val res =
+          // TypeComparer.explain[Boolean](gadts.println) { implicit ctx =>
+          if (isSubtype) externalizedTp1 frozen_<:< externalizedTp2
+          else externalizedTp2 frozen_<:< externalizedTp1
+          // }
+
+        gadts.println(i"$descr = $res")
+        res
+      }
+
+      def unify(tv: TypeVar, tp: Type): Unit = {
+        gadts.println(i"manually unifying $tv with $tp")
+        constraint = constraint.updateEntry(tv.origin, tp)
+      }
+
+      val symTvar: TypeVar = stripInst(tvar(sym)) match {
+        case tv: TypeVar => tv
+        case inst =>
+          gadts.println(i"instantiated: $sym -> $inst")
+          // this is wrong in general, but "correct" due to a subtype check in TypeComparer#narrowGadtBounds
+          return true
+      }
+
+      val internalizedBound = insertTypeVars(bound)
+      val res = stripInst(internalizedBound) match {
+        case boundTvar: TypeVar =>
+          if (boundTvar eq symTvar) true
+          else if (isUpper) addLess(symTvar.origin, boundTvar.origin)
+          else addLess(boundTvar.origin, symTvar.origin)
+        case bound =>
+          if (cautiousSubtype(symTvar, bound, isSubtype = !isUpper)) { unify(symTvar, bound); true }
+          else if (isUpper) addUpperBound(symTvar.origin, bound)
+          else addLowerBound(symTvar.origin, bound)
+      }
+
+      gadts.println {
+        val descr = if (isUpper) "upper" else "lower"
+        val op = if (isUpper) "<:" else ">:"
+        i"adding $descr bound $sym $op $bound = $res\t( $symTvar $op $internalizedBound )"
+      }
+      res
+    }
+
+    override def bounds(sym: Symbol)(implicit ctx: Context): TypeBounds = inCtx(ctx) {
+      mapping(sym) match {
+        case null => null
+        case tv =>
+          val tb = constraint.fullBounds(tv.origin)
+          val res = removeTypeVars(tb).asInstanceOf[TypeBounds]
+          // gadts.println(i"gadt bounds $sym: $res")
+          res
+      }
+    }
+
+    override def contains(sym: Symbol)(implicit ctx: Context): Boolean = mapping(sym) ne null
+
+    override def fresh: GADTMap = new SmartGADTMap(
+      myConstraint,
+      mapping,
+      reverseMapping
+    )
+
+    // ---- Private ----------------------------------------------------------
+
+    private[this] def tvar(sym: Symbol)(implicit ctx: Context): TypeVar = {
+      mapping(sym) match {
+        case tv: TypeVar =>
+          tv
+        case null =>
+          val res = {
+            import NameKinds.DepParamName
+            // avoid registering the TypeVar with TyperState / TyperState#constraint
+            // - we don't want TyperState instantiating these TypeVars
+            // - we don't want TypeComparer constraining these TypeVars
+            val poly = PolyType(DepParamName.fresh(sym.name.toTypeName) :: Nil)(
+              pt => TypeBounds.empty :: Nil,
+              pt => defn.AnyType)
+            new TypeVar(poly.paramRefs.head, creatorState = null)
+          }
+          gadts.println(i"GADTMap: created tvar $sym -> $res")
+          constraint = constraint.add(res.origin.binder, res :: Nil)
+          mapping = mapping.updated(sym, res)
+          reverseMapping = reverseMapping.updated(res.origin, sym)
+          res
+      }
+    }
+
+    private def insertTypeVars(tp: Type, map: TypeMap = null)(implicit ctx: Context) = tp match {
+      case tp: TypeRef =>
+        val sym = tp.typeSymbol
+        if (contains(sym)) tvar(sym) else tp
+      case _ =>
+        (if (map != null) map else new TypeVarInsertingMap()).mapOver(tp)
+    }
+    private final class TypeVarInsertingMap(implicit ctx: Context) extends TypeMap {
+      override def apply(tp: Type): Type = insertTypeVars(tp, this)
+    }
+
+    private def removeTypeVars(tp: Type, map: TypeMap = null)(implicit ctx: Context) = tp match {
+      case tpr: TypeParamRef =>
+        reverseMapping(tpr) match {
+          case null => tpr
+          case sym => sym.typeRef
+        }
+      case tv: TypeVar =>
+        reverseMapping(tv.origin) match {
+          case null => tv
+          case sym => sym.typeRef
+        }
+      case _ =>
+        (if (map != null) map else new TypeVarRemovingMap()).mapOver(tp)
+    }
+    private final class TypeVarRemovingMap(implicit ctx: Context) extends TypeMap {
+      override def apply(tp: Type): Type = removeTypeVars(tp, this)
+    }
+
+    // ---- Debug ------------------------------------------------------------
+
+    override def constr_println(msg: => String): Unit = gadtsConstr.println(msg)
+
+    override def debugBoundsDescription(implicit ctx: Context): String = {
+      val sb = new mutable.StringBuilder
+      sb ++= constraint.show
+      sb += '\n'
+      mapping.foreachBinding { case (sym, _) =>
+        sb ++= i"$sym: ${bounds(sym)}\n"
+      }
+      sb.result
+    }
+  }
+
+  @sharable object EmptyGADTMap extends GADTMap {
+    override def addEmptyBounds(sym: Symbol)(implicit ctx: Context): Unit = unsupported("EmptyGADTMap.addEmptyBounds")
+    override def addBound(sym: Symbol, bound: Type, isUpper: Boolean)(implicit ctx: Context): Boolean = unsupported("EmptyGADTMap.addBound")
+    override def bounds(sym: Symbol)(implicit ctx: Context): TypeBounds = null
+    override def contains(sym: Symbol)(implicit ctx: Context) = false
+    override def debugBoundsDescription(implicit ctx: Context): String = "EmptyGADTMap"
+    override def fresh = new SmartGADTMap
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -325,8 +325,8 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
   private def order(current: This, param1: TypeParamRef, param2: TypeParamRef)(implicit ctx: Context): This =
     if (param1 == param2 || current.isLess(param1, param2)) this
     else {
-      assert(contains(param1))
-      assert(contains(param2))
+      assert(contains(param1), i"$param1")
+      assert(contains(param2), i"$param2")
       val newUpper = param2 :: exclusiveUpper(param2, param1)
       val newLower = param1 :: exclusiveLower(param1, param2)
       val current1 = (current /: newLower)(upperLens.map(this, _, _, newUpper ::: _))

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -214,7 +214,11 @@ trait Symbols { this: Context =>
    */
   def newPatternBoundSymbol(name: Name, info: Type, pos: Position): Symbol = {
     val sym = newSymbol(owner, name, Case, info, coord = pos)
-    if (name.isTypeName) gadt.setBounds(sym, info.bounds)
+    if (name.isTypeName) {
+      val bounds = info.bounds
+      gadt.addBound(sym, bounds.lo, isUpper = false)
+      gadt.addBound(sym, bounds.hi, isUpper = true)
+    }
     sym
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1237,14 +1237,8 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
       val tparam = tr.symbol
       gadts.println(i"narrow gadt bound of $tparam: ${tparam.info} from ${if (isUpper) "above" else "below"} to $bound ${bound.toString} ${bound.isRef(tparam)}")
       if (bound.isRef(tparam)) false
-      else {
-        val oldBounds = gadtBounds(tparam)
-        val newBounds =
-          if (isUpper) TypeBounds(oldBounds.lo, oldBounds.hi & bound)
-          else TypeBounds(oldBounds.lo | bound, oldBounds.hi)
-        isSubType(newBounds.lo, newBounds.hi) &&
-          (if (isUpper) gadtAddUpperBound(tparam, bound) else gadtAddLowerBound(tparam, bound))
-      }
+      else if (isUpper) gadtAddUpperBound(tparam, bound)
+      else gadtAddLowerBound(tparam, bound)
     }
   }
 
@@ -1826,13 +1820,14 @@ object TypeComparer {
 
   val NoApprox: ApproxState = new ApproxState(0)
 
-  def explain[T](say: String => Unit)(op: Context => T)(implicit ctx: Context): T = {
+  /** Show trace of comparison operations when performing `op` as result string */
+  def explaining[T](say: String => Unit)(op: Context => T)(implicit ctx: Context): T = {
     val (res, explanation) = underlyingExplained(op)
     say(explanation)
     res
   }
 
-  /** Show trace of comparison operations when performing `op` as result string */
+  /** Like [[explaining]], but returns the trace instead */
   def explained[T](op: Context => T)(implicit ctx: Context): String = {
     underlyingExplained(op)._2
   }

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -830,9 +830,9 @@ class TypeComparer(initctx: Context) extends ConstraintHandling {
       *    tp1 <:< tp2    using fourthTry (this might instantiate params in tp1)
       *    tp1 <:< app2   using isSubType (this might instantiate params in tp2)
       */
-      def compareLower(tycon2bounds: TypeBounds, followSuperType: Boolean): Boolean =
+      def compareLower(tycon2bounds: TypeBounds, tyconIsTypeRef: Boolean): Boolean =
         if ((tycon2bounds.lo `eq` tycon2bounds.hi) && !tycon2bounds.isInstanceOf[MatchAlias])
-          if (followSuperType) recur(tp1, tp2.superType)
+          if (tyconIsTypeRef) recur(tp1, tp2.superType)
           else isSubApproxHi(tp1, tycon2bounds.lo.applyIfParameterized(args2))
         else
           fallback(tycon2bounds.lo)
@@ -841,15 +841,13 @@ class TypeComparer(initctx: Context) extends ConstraintHandling {
         case param2: TypeParamRef =>
           isMatchingApply(tp1) ||
           canConstrain(param2) && canInstantiate(param2) ||
-          compareLower(bounds(param2), followSuperType = false)
+          compareLower(bounds(param2), tyconIsTypeRef = false)
         case tycon2: TypeRef =>
           isMatchingApply(tp1) ||
           defn.isTypelevel_S(tycon2.symbol) && compareS(tp2, tp1, fromBelow = true) || {
             tycon2.info match {
               case info2: TypeBounds =>
-                val gbounds2 = ctx.gadt.bounds(tycon2.symbol)
-                if (gbounds2 == null) compareLower(info2, followSuperType = true)
-                else compareLower(gbounds2 & info2, followSuperType = false)
+                compareLower(info2, tyconIsTypeRef = true)
               case info2: ClassInfo =>
                 tycon2.name.toString.startsWith("Tuple") &&
                   defn.isTupleType(tp2) && isSubType(tp1, tp2.toNestedPairs) ||
@@ -885,11 +883,8 @@ class TypeComparer(initctx: Context) extends ConstraintHandling {
         case tycon1: TypeRef =>
           val sym = tycon1.symbol
           !sym.isClass && (
-            defn.isTypelevel_S(sym) && compareS(tp1, tp2, fromBelow = false) || {
-              val gbounds1 = ctx.gadt.bounds(tycon1.symbol)
-              if (gbounds1 == null) recur(tp1.superType, tp2)
-              else recur((gbounds1.hi & tycon1.info.bounds.hi).applyIfParameterized(args1), tp2)
-            })
+            defn.isTypelevel_S(sym) && compareS(tp1, tp2, fromBelow = false) ||
+            recur(tp1.superType, tp2))
         case tycon1: TypeProxy =>
           recur(tp1.superType, tp2)
         case _ =>

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1822,20 +1822,17 @@ object TypeComparer {
 
   /** Show trace of comparison operations when performing `op` as result string */
   def explaining[T](say: String => Unit)(op: Context => T)(implicit ctx: Context): T = {
-    val (res, explanation) = underlyingExplained(op)
-    say(explanation)
+    val nestedCtx = ctx.fresh.setTypeComparerFn(new ExplainingTypeComparer(_))
+    val res = op(nestedCtx)
+    say(nestedCtx.typeComparer.lastTrace())
     res
   }
 
   /** Like [[explaining]], but returns the trace instead */
   def explained[T](op: Context => T)(implicit ctx: Context): String = {
-    underlyingExplained(op)._2
-  }
-
-  private def underlyingExplained[T](op: Context => T)(implicit ctx: Context): (T, String) = {
-    val nestedCtx = ctx.fresh.setTypeComparerFn(new ExplainingTypeComparer(_))
-    val res = op(nestedCtx)
-    (res, nestedCtx.typeComparer.lastTrace())
+    var trace: String = null
+    explaining(trace = _)(op)
+    trace
   }
 }
 

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -79,19 +79,6 @@ class TyperState(previous: TyperState /* | Null */) {
   def ownedVars: TypeVars = myOwnedVars
   def ownedVars_=(vs: TypeVars): Unit = myOwnedVars = vs
 
-  /** Gives for each instantiated type var that does not yet have its `inst` field
-   *  set, the instance value stored in the constraint. Storing instances in constraints
-   *  is done only in a temporary way for contexts that may be retracted
-   *  without also retracting the type var as a whole.
-   */
-  def instType(tvar: TypeVar)(implicit ctx: Context): Type = constraint.entry(tvar.origin) match {
-    case _: TypeBounds => NoType
-    case tp: TypeParamRef =>
-      var tvar1 = constraint.typeVarOfParam(tp)
-      if (tvar1.exists) tvar1 else tp
-    case tp => tp
-  }
-
   /** The closest ancestor of this typer state (including possibly this typer state itself)
    *  which is not yet committed, or which does not have a parent.
    */
@@ -173,7 +160,7 @@ class TyperState(previous: TyperState /* | Null */) {
     val toCollect = new mutable.ListBuffer[TypeLambda]
     constraint foreachTypeVar { tvar =>
       if (!tvar.inst.exists) {
-        val inst = instType(tvar)
+        val inst = ctx.typeComparer.instType(tvar)
         if (inst.exists && (tvar.owningState.get eq this)) {
           tvar.inst = inst
           val lam = tvar.origin.binder

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -563,7 +563,7 @@ object Types {
             case _ =>
               go(tp.superType)
           }
-        case tp: ThisType =>
+        case tp: ThisType => // ??? inline
           goThis(tp)
         case tp: RefinedType =>
           if (name eq tp.refinedName) goRefined(tp) else go(tp.parent)

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -168,7 +168,7 @@ object Formatting {
         s"is a reference to a value parameter"
       case sym: Symbol =>
         val info =
-          if (ctx.gadt.bounds.contains(sym))
+          if (ctx.gadt.contains(sym))
             sym.info & ctx.gadt.bounds(sym)
           else
             sym.info
@@ -189,7 +189,7 @@ object Formatting {
       case param: TermParamRef => false
       case skolem: SkolemType => true
       case sym: Symbol =>
-        ctx.gadt.bounds.contains(sym) && ctx.gadt.bounds(sym) != TypeBounds.empty
+        ctx.gadt.contains(sym) && ctx.gadt.bounds(sym) != TypeBounds.empty
       case _ =>
         assert(false, "unreachable")
         false

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -206,7 +206,11 @@ object Inferencing {
     }
 
     val widePt = if (ctx.scala2Mode || refinementIsInvariant(tp)) pt else widenVariantParams(pt)
-    tp <:< widePt
+    import dotty.tools.dotc.config.Printers.gadts
+    gadts.println(i"constraining pattern type $tp <:< $widePt")
+    val res = tp <:< widePt
+    gadts.println(i"constrained pattern type $tp <:< $widePt = $res\n${ctx.gadt.debugBoundsDescription}")
+    res
   }
 
   /** The list of uninstantiated type variables bound by some prefix of type `T` which

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -11,7 +11,7 @@ import NameKinds.UniqueName
 import util.Positions._
 import util.{Stats, SimpleIdentityMap}
 import Decorators._
-import config.Printers.typr
+import config.Printers.{gadts, typr}
 import annotation.tailrec
 import reporting._
 import collection.mutable
@@ -206,11 +206,9 @@ object Inferencing {
     }
 
     val widePt = if (ctx.scala2Mode || refinementIsInvariant(tp)) pt else widenVariantParams(pt)
-    import dotty.tools.dotc.config.Printers.gadts
-    gadts.println(i"constraining pattern type $tp <:< $widePt")
-    val res = tp <:< widePt
-    gadts.println(i"constrained pattern type $tp <:< $widePt = $res\n${ctx.gadt.debugBoundsDescription}")
-    res
+    trace(i"constraining pattern type $tp <:< $widePt", gadts, res => s"$res\n${ctx.gadt.debugBoundsDescription}") {
+      tp <:< widePt
+    }
   }
 
   /** The list of uninstantiated type variables bound by some prefix of type `T` which

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -730,7 +730,11 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
                 for (tpt <- tpts) boundVars = getBoundVars(boundVars, tpt)
               case _ =>
             }
-            for (bv <- boundVars) ctx.gadt.setBounds(bv, bv.info.bounds)
+            for (bv <- boundVars) {
+              val TypeBounds(lo, hi) = bv.info.bounds
+              ctx.gadt.addBound(bv, lo, isUpper = false)
+              ctx.gadt.addBound(bv, hi, isUpper = true)
+            }
             scrut <:< tpt.tpe && {
               for (bv <- boundVars) {
                 bv.info = TypeAlias(ctx.gadt.bounds(bv).lo)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1023,8 +1023,7 @@ class Typer extends Namer
   def gadtContext(gadtSyms: Set[Symbol])(implicit ctx: Context): Context = {
     val gadtCtx = ctx.fresh.setFreshGADTBounds
     for (sym <- gadtSyms)
-      if (!gadtCtx.gadt.bounds.contains(sym))
-        gadtCtx.gadt.setBounds(sym, TypeBounds.empty)
+      if (!gadtCtx.gadt.contains(sym)) gadtCtx.gadt.addEmptyBounds(sym)
     gadtCtx
   }
 
@@ -1502,8 +1501,11 @@ class Typer extends Namer
       // that their type parameters are aliases of the class type parameters.
       // See pos/i941.scala
       rhsCtx = ctx.fresh.setFreshGADTBounds
-      (tparams1, sym.owner.typeParams).zipped.foreach ((tdef, tparam) =>
-        rhsCtx.gadt.setBounds(tdef.symbol, TypeAlias(tparam.typeRef)))
+      (tparams1, sym.owner.typeParams).zipped.foreach { (tdef, tparam) =>
+        val tr = tparam.typeRef
+        rhsCtx.gadt.addBound(tdef.symbol, tr, isUpper = false)
+        rhsCtx.gadt.addBound(tdef.symbol, tr, isUpper = true)
+      }
     }
     if (sym.isInlineMethod) rhsCtx = rhsCtx.addMode(Mode.InlineableBody)
     val rhs1 = typedExpr(ddef.rhs, tpt1.tpe)(rhsCtx)

--- a/tests/neg/gadt-banal-nested.scala
+++ b/tests/neg/gadt-banal-nested.scala
@@ -1,0 +1,12 @@
+object banal {
+  sealed trait T[A]
+  final case class StrLit(v: String) extends T[String]
+  final case class IntLit(v: Int) extends T[Int]
+
+  def eval[A](t: T[A]): A = t match {
+    case _: T[a] => t match {
+      case StrLit(v) => v
+      case IntLit(_) => "" // error
+    }
+  }
+}

--- a/tests/neg/gadt-banal.scala
+++ b/tests/neg/gadt-banal.scala
@@ -1,0 +1,17 @@
+object banal {
+  final case class Box[A](a: A)
+
+  sealed trait T[A]
+  final case class StrLit(v: String) extends T[String]
+  final case class IntLit(v: Int) extends T[Int]
+
+  def evul[A](t: T[A]): A = t match {
+    case StrLit(v) => (v: Any) // error
+    case IntLit(v) => (??? : Nothing)
+  }
+
+  def noeval[A](t: T[A]): Box[A] = t match {
+    case StrLit(v) => Box[Any](v) // error
+    case IntLit(v) => Box[Nothing](???) // error
+  }
+}

--- a/tests/neg/gadt-i4075.scala
+++ b/tests/neg/gadt-i4075.scala
@@ -1,0 +1,8 @@
+object i4075 {
+  case class One[T](fst: T)
+  def bad[T](e: One[T]) = e match {
+    case foo: One[a] =>
+      val nok: Nothing = foo.fst // error
+      ???
+  }
+}

--- a/tests/neg/gadt-injectivity.scala
+++ b/tests/neg/gadt-injectivity.scala
@@ -1,0 +1,17 @@
+object injectivity {
+  sealed trait EQ[A, B]
+  final case class Refl[A](u: Unit) extends EQ[A, A]
+
+  def conform[A, B, C, D](a: A, b: B, eq: EQ[(A, B), (C, D)]): C =
+    eq match {
+      case _: Refl[a] =>
+        val ab: (A, B) = (a, b)
+        val cd: (C, D) = ab
+        val bb: (B, B) = ab // error
+        val cc: (C, C) = cd // error
+        val dd: (D, D) = cd // error
+        val rab: a = ab
+        val rcd: a = cd
+        a
+    }
+}

--- a/tests/neg/gadt-uninjectivity.scala
+++ b/tests/neg/gadt-uninjectivity.scala
@@ -1,0 +1,24 @@
+object uninjectivity {
+  sealed trait EQ[A, B]
+  final case class Refl[T]() extends EQ[T, T]
+
+  def absurd1[F[_], X, Y](eq: EQ[F[X], F[Y]], x: X): Y = eq match {
+    case Refl() =>
+      x // should be an error
+  }
+
+  def absurd2[F[_], G[_]](eq: EQ[F[Int], G[Int]], fi: F[Int], fs: F[String]): G[Int] = eq match {
+    case Refl() =>
+      val gs: G[String] = fs // error
+      // fi
+      ???
+  }
+
+  def absurd3[F[_], G[_], X, Y](eq: EQ[F[X], G[Y]], fx: F[X]): G[Y] = eq match {
+    case Refl() =>
+      val gx: G[X] = fx // error
+      val fy: F[Y] = fx // error
+      // fx
+      ???
+  }
+}

--- a/tests/pos/gadt-EQK.scala
+++ b/tests/pos/gadt-EQK.scala
@@ -1,0 +1,33 @@
+object EQK {
+  sealed trait EQ[A, B]
+  final case class Refl[A]() extends EQ[A, A]
+
+  sealed trait EQK[F[_], G[_]]
+  final case class ReflK[F[_]]() extends EQK[F, F]
+
+  def m0[F[_], G[_], A](fa: F[A], eqk: EQK[F, G]): G[A] =
+    eqk match { case ReflK() => fa }
+
+  def m1[F[_], G[_], A](fa: F[A], eq: EQ[A, Int], eqk: EQK[F, G]): G[Int] =
+    eqk match {
+      case ReflK() => eq match {
+        case Refl() =>
+          val r1: F[Int] = fa
+          val r2: G[A] = fa
+          val r3: F[Int] = r2
+          fa : G[Int]
+      }
+    }
+
+  def m2[F[_], G[_], A](fa: F[A], a: A, eq: EQ[F[A], G[Int]], eqk: EQK[F, G]): Int =
+    eqk match {
+      case ReflK() => eq match {
+        case Refl() =>
+          val r1: F[Int] = fa
+          val r2: G[A] = fa
+          val r3: F[Int] = r2
+          a
+      }
+    }
+
+}

--- a/tests/pos/gadt-GadtStlc.scala
+++ b/tests/pos/gadt-GadtStlc.scala
@@ -1,0 +1,127 @@
+object GadtStlc {
+  // creates type-level "strings" like M[M[M[W]]]
+  object W
+  type W = W.type
+  class M[A]
+
+
+  // variable with name A
+  // Var[W]
+  // Var[M[W]]
+  sealed trait Var[A]
+  object VarW extends Var[W]
+  case class VarM[A] extends Var[M[A]]
+
+  // \s.e
+  sealed trait Abs[S, E]
+  case class AbsC[S, E](v: Var[S], b: E) extends Abs[Var[S], E]
+
+  // e1 e2
+  case class App[E1, E2](e1: E1, e2: E2)
+
+  // T1 -> T2
+  case class TyFun[T1, T2](t1: T1, t2: T2)
+
+  // arbitrary base literal
+  case object Lit
+  type Lit = Lit.type
+
+  // arbitrary base type
+  case object TyBase
+  type TyBase = TyBase.type
+
+  // IN[G, (X, TY)] === evidence that binding (X, TY) is in environment G
+  // x: ty \in G
+  sealed trait IN[G, P]
+  case class INOne[G, X, TY]() extends IN[(G, (X,TY)), (X, TY)]
+  // this is wrong - we need evidence that A does not contain a binding for X
+  case class INShift[G0, A, X, TY](in: IN[G0, (X, TY)]) extends IN[(G0, A), (X, TY)]
+
+  // DER[G, E, TY] === evidence that G |- E : TY
+  sealed trait DER[G, E, TY]
+  case class DVar[G, G0, X, TY](
+    in: IN[(G, G0), (Var[X], TY)]
+  ) extends DER[(G, G0), Var[X], TY]
+
+  case class DApp[G, E1, E2, TY1, TY2](
+    d1: DER[G, E1, TyFun[TY1, TY2]],
+    d2: DER[G, E2, TY1]
+  ) extends DER[G, App[E1, E2], TY2]
+
+  case class DAbs[G, X, E, TY1, TY2](
+    d1: DER[(G, (Var[X], TY1)), E, TY2]
+  ) extends DER[G, Abs[Var[X], E], TyFun[TY1, TY2]]
+
+  case class DLit[G]() extends DER[G, Lit, TyBase]
+
+  // forall G, a. G |- \x.x : a -> a
+  def test1[G, TY]: DER[G, Abs[Var[W], Var[W]], TyFun[TY, TY]] =
+    DAbs(DVar(INOne()))
+
+  // forall G. G |- \x.x : Lit -> Lit
+  def test2[G]: DER[G,  App[Abs[Var[W], Var[W]], Lit],  TyBase] =
+    DApp(DAbs(DVar(INOne())), DLit())
+
+  // forall G, c. G |- \x.\y. x y : (c -> c) -> c -> c
+  def test3[G, TY]: DER[G,
+    Abs[Var[W],
+      Abs[Var[M[W]],
+        App[Var[W], Var[M[W]]]
+      ]
+    ],
+    TyFun[TyFun[TY, TY], TyFun[TY, TY]]
+  ] = DAbs(DAbs(DApp(DVar(INShift(INOne())), DVar(INOne()))))
+
+
+  // evidence that E is a value
+  sealed trait ISVAL[E]
+  case class ISVAL_Abs[X, E]()  extends ISVAL[Abs[Var[X], E]]
+  case object ISVAL_Lit extends ISVAL[Lit]
+
+  // evidence that E1 reduces to E2
+  sealed trait REDUDER[E1, E2]
+  case class EApp1[E1a, E1b, E2](
+    ed: REDUDER[E1a, E1b]
+  ) extends REDUDER[App[E1a, E2], App[E1b, E2]]
+
+  case class EApp2[V1, E2a, E2b](
+    isval: ISVAL[V1],
+    ed: REDUDER[E2a, E2b]
+  ) extends REDUDER[App[V1, E2a], App[V1, E2b]]
+
+  case class EAppAbs[X, E, V2, R](
+    isval: ISVAL[V2]
+    // cheating - subst is hard
+    // , subst: SUBST[E, X, V2, R]
+  ) extends REDUDER[App[Abs[Var[X], E], V2], R]
+
+  // evidence that V is a lambda
+  sealed trait ISLAMBDA[V]
+  case class ISLAMBDAC[X, E]() extends ISLAMBDA[Abs[Var[X], E]]
+
+  // evidence that E reduces
+  type REDUCES[E] = REDUDER[E, _]
+
+  def followsIsLambda[G, V, TY1, TY2](
+    isval: ISVAL[V],
+    der: DER[G, V, TyFun[TY1, TY2]]
+  ): ISLAMBDA[V] = (isval, der) match {
+    case (_: ISVAL_Abs[x, e], _) => ISLAMBDAC[x, e]()
+  }
+
+  // \empty |- E : TY ==> E is a value /\ E reduces to some E1
+  def progress[E, TY](der: DER[Unit, E, TY]): Either[ISVAL[E], REDUCES[E]] =
+    der match {
+      case _: DAbs[g, a, e, ty1, ty2] => Left(ISVAL_Abs[a, e]())
+      case DLit() => Left(ISVAL_Lit)
+      case dapp: DApp[Unit, a, b, ty1, ty2] => progress(dapp.d1) match {
+        case Right(r1) => Right(EApp1[E2 = b](r1))
+        case Left(isv1) => progress(dapp.d2) match {
+          case Right(r2) => Right(EApp2(isv1, r2))
+          case Left(isv2) => followsIsLambda(isv1, dapp.d1) match {
+            case _: ISLAMBDAC[x, e] => Right(EAppAbs[x, e, b, _](isv2))
+          }
+        }
+      }
+    }
+}

--- a/tests/pos/gadt-TailCalls.scala
+++ b/tests/pos/gadt-TailCalls.scala
@@ -1,0 +1,39 @@
+// package scala.util.control
+object TailCalls {
+
+  abstract class TailRec[+A] {
+
+    final def flatMap[B](f: A => TailRec[B]): TailRec[B] =
+      this match {
+        case Done(a) => Call(() => f(a))
+        case c@Call(_) => Cont(c, f)
+        case c: Cont[a1, b1] => Cont(c.a, (x: a1) => c.f(x) flatMap f)
+      }
+
+    @annotation.tailrec final def resume: Either[() => TailRec[A], A] = this match {
+      case Done(a) => Right(a)
+      case Call(k) => Left(k)
+      case Cont(a, f) => a match {
+        case Done(v) => f(v).resume
+        case Call(k) => Left(() => k().flatMap(f))
+        case Cont(b, g) => b.flatMap(x => g(x) flatMap f).resume
+      }
+    }
+
+    @annotation.tailrec final def result: A = this match {
+      case Done(a) => a
+      case Call(t) => t().result
+      case Cont(a, f) => a match {
+        case Done(v) => f(v).result
+        case Call(t) => t().flatMap(f).result
+        case Cont(b, g) => b.flatMap(x => g(x) flatMap f).result
+      }
+    }
+  }
+
+  protected case class Call[A](rest: () => TailRec[A]) extends TailRec[A]
+
+  protected case class Done[A](value: A) extends TailRec[A]
+
+  protected case class Cont[A, B](a: TailRec[A], f: A => TailRec[B]) extends TailRec[B]
+}

--- a/tests/pos/gadt-TypeSafeLambda.scala
+++ b/tests/pos/gadt-TypeSafeLambda.scala
@@ -1,0 +1,109 @@
+object TypeSafeLambda {
+
+  trait Category[Arr[_, _]] {
+    def id[A]: Arr[A, A]
+    def comp[A, B, C](ab: Arr[A, B], bc: Arr[B, C]): Arr[A, C]
+  }
+
+  trait Terminal[Term, Arr[_, _]] extends Category[Arr] {
+    def terminal[A]: Arr[A, Term]
+  }
+
+  trait ProductCategory[Prod[_, _], Arr[_, _]] extends Category[Arr] {
+    def first[A, B]: Arr[Prod[A, B], A]
+    def second[A, B]: Arr[Prod[A, B], B]
+    def pair[A, B, C](ab: Arr[A, B], ac: Arr[A, C]): Arr[A, Prod[B, C]]
+  }
+
+  trait Exponential[Exp[_, _], Prod[_, _], Arr[_, _]]
+    extends ProductCategory[Prod, Arr] {
+    def eval[A, B]: Arr[Prod[Exp[A, B], A], B]
+    def curry[A, B, C](a: Arr[Prod[C, A], B]): Arr[C, Exp[A, B]]
+  }
+
+  trait CartesianClosed[Term, Exp[_, _], Prod[_, _], Arr[_, _]]
+    extends Exponential[Exp, Prod, Arr] with Terminal[Term, Arr]
+
+  sealed trait V[Prod[_, _], Env, R]
+  case class Zero[Prod[_, _], Env, R]() extends V[Prod, Prod[Env, R], R]
+  case class Succ[Prod[_, _], Env, R, X](
+    v: V[Prod, Env, R]
+  ) extends V[Prod, Prod[Env, X], R]
+
+  sealed trait Lambda[Terminal, Exp[_, _], Prod[_, _], Env, R]
+
+  case class LUnit[Terminal, Exp[_, _], Prod[_, _], Env]()
+    extends Lambda[Terminal, Exp, Prod, Env, Terminal]
+
+  case class Var[Terminal, Exp[_, _], Prod[_, _], Env, R](
+    v: V[Prod, Env, R]
+  ) extends Lambda[Terminal, Exp, Prod, Env, R]
+
+  case class Lam[Terminal, Exp[_, _], Prod[_, _], Env, R, A](
+    lam: Lambda[Terminal, Exp, Prod, Prod[Env, A], R]
+  ) extends Lambda[Terminal, Exp, Prod, Env, Exp[A, R]]
+
+  case class App[Terminal, Exp[_, _], Prod[_, _], Env, R, R_](
+    f: Lambda[Terminal, Exp, Prod, Env, Exp[R, R_]],
+    a: Lambda[Terminal, Exp, Prod, Env, R]
+  ) extends Lambda[Terminal, Exp, Prod, Env, R_]
+
+  def interp[Term, Exp[_, _], Prod[_, _], Arr[_, _], S, T](
+    c: CartesianClosed[Term, Exp, Prod, Arr],
+    exp: Lambda[Term, Exp, Prod, S, T]
+  ): Arr[S, T] = exp match {
+    case LUnit() => c.terminal
+    case v: Var[t, e, var_p, env, r] => v.v match {
+      case _: Zero[z_p, z_env, z_r] => c.second[z_env, z_r]
+      case s: Succ[s_prod, s_env, s_r, x] =>
+        c.comp[A = s_prod[s_env, x], C = s_r](
+          c.first,
+          interp(c, Var[Term, Exp, Prod, s_env, s_r](s.v))
+        )
+    }
+    case Lam(lam) => c.curry(interp(c, lam))
+    case app: App[t, e, p, env, r, r_] =>
+      c.comp(
+        c.pair(
+          interp(c, app.f),
+          interp(c, app.a)),
+        c.eval[r, r_]
+      )
+  }
+
+  object example {
+    type Term = Unit
+    type Prod[A, B] = (A, B)
+    type Exp[A, B] = A => B
+    type Arr[A, B] = A => B
+
+    val c = new CartesianClosed[Term, Exp, Prod, Arr] {
+      def id[A]: A => A = a => a
+      def comp[A, B, C](f: A => B, g: B => C): A => C = f andThen g
+
+      def terminal[A]: A => Unit = a => ()
+
+      def first[A, B]: ((A, B)) => A = { case (a, _) => a }
+      def second[A, B]: ((A, B)) => B = { case (_, b) => b }
+      def pair[A, B, C](f: A => B, g: A => C): A => (B, C) =
+        a => (f(a), g(a))
+
+      def eval[A, B]: ((A => B, A)) => B = { case (f, a) => f(a) }
+      def curry[A, B, C](f: ((C, A)) => B): C => A => B =
+        c => a => f((c, a))
+    }
+
+    type Env = Unit Prod Int Prod (Int => String)
+    val exp = App[Term, Exp, Prod, Env, Int, String](
+      // args to Var are RHS "indices" into Env
+      Var(Zero()),
+      Var(Succ(Zero()))
+    )
+
+    val interped: (Env) => String =
+      interp[Term, Exp, Prod, Arr, Env, String] (c, exp)
+
+    interped((((), 1), { i: Int => i.toString })) : String // "1"
+  }
+
+}

--- a/tests/pos/gadt-banal.scala
+++ b/tests/pos/gadt-banal.scala
@@ -1,0 +1,15 @@
+object banal {
+  sealed trait T[A]
+  final case class StrLit(v: String) extends T[String]
+  final case class IntLit(v: Int) extends T[Int]
+
+  def eval[A](t: T[A]): A = t match {
+    case StrLit(v) => v
+    case IntLit(v) => v
+  }
+
+  def evul[A](t: T[A]): A = t match {
+    case StrLit(_) => ""
+    case IntLit(_) => 0
+  }
+}

--- a/tests/pos/gadt-complexEQ.scala
+++ b/tests/pos/gadt-complexEQ.scala
@@ -1,0 +1,24 @@
+object complexEQ {
+  sealed trait EQ[A, B]
+  final case class Refl[A]() extends EQ[A, A]
+
+  def m[A, B, C, D](e1: EQ[A, (B, C)], e2: EQ[A, (C, D)], d: D): A =
+    e1 match {
+      case Refl() => e2 match {
+        case Refl() => 
+          val r1: (B, B) = (d, d)
+          val r2: (C, C) = r1
+          val r3: (D, D) = r1
+          r1
+      }
+    }
+
+  def m2[Z, A, B, C, D](e0: EQ[Z, A], e1: EQ[A, (B, C)], e2: EQ[Z, (C, D)], d: D): Z =
+    (e0, e1, e2) match {
+      case (Refl(), Refl(), Refl()) =>
+          val r1: (B, B) = (d, d)
+          val r2: (C, C) = r1
+          val r3: (D, D) = r1
+          r1
+    }
+}

--- a/tests/pos/gadt-foo.scala
+++ b/tests/pos/gadt-foo.scala
@@ -1,0 +1,11 @@
+object foo {
+  sealed trait Exp[T]
+  case class Var[T](name: String) extends Exp[T]
+
+  def env[T](x: Var[T]): T = ???
+
+  def eval[S](e: Exp[S]) = e match {
+    case v: Var[foo] =>
+      env(v)
+  }
+}

--- a/tests/pos/gadt-simpleEQ.scala
+++ b/tests/pos/gadt-simpleEQ.scala
@@ -1,0 +1,13 @@
+object simpleEQ {
+  sealed trait EQ[A, B]
+  final case class Refl[A](u: Unit) extends EQ[A, A]
+
+  def conform[A, B](a: A, eq: EQ[A, B]): B = eq match {
+    case Refl(()) => a
+  }
+
+  def conform2[A, B, C, D](a: A, b: B, eq: EQ[(A, B), (C, D)]): (C, D) =
+    eq match {
+      case Refl(()) => (a, b)
+    }
+}

--- a/tests/pos/i3666-gadt.scala
+++ b/tests/pos/i3666-gadt.scala
@@ -1,0 +1,65 @@
+object i3666 {
+  sealed trait Exp[T]
+  case class Num(n: Int) extends Exp[Int]
+  case class Plus(e1: Exp[Int], e2: Exp[Int]) extends Exp[Int]
+  case class Var[T](name: String) extends Exp[T]
+  case class Lambda[T, U](x: Var[T], e: Exp[U]) extends Exp[T => U]
+  case class App[T, U](f: Exp[T => U], e: Exp[T]) extends Exp[U]
+
+  abstract class Env { outer =>
+    def apply[T](x: Var[T]): T
+
+    def + [T](xe: (Var[T], T)) = new Env {
+      def apply[T](x: Var[T]): T =
+        if (x == xe._1) xe._2.asInstanceOf[T]
+        else outer(x)
+    }
+  }
+
+  object Env {
+    val empty = new Env {
+      def apply[T](x: Var[T]): T = ???
+    }
+  }
+
+  object Test {
+
+    val exp = App(Lambda(Var[Int]("x"), Plus(Var[Int]("x"), Num(1))), Var[Int]("2"))
+
+    def eval[T](e: Exp[T])(env: Env): T = e match {
+      case Num(n) => n
+      case Plus(e1, e2) => eval(e1)(env) + eval(e2)(env)
+      case v: Var[_] => env(v)
+      case Lambda(x: Var[s], e) => ((y: s) => eval(e)(env + (x -> y)))
+      case App(f, e) => eval(f)(env)(eval(e)(env))
+    }
+
+    eval(exp)(Env.empty)
+  }
+}
+// A HOAS well-typed interpreter
+object i3666Hoas {
+  sealed trait Exp[T]
+  case class IntLit(n: Int) extends Exp[Int]
+  case class BooleanLit(b: Boolean) extends Exp[Boolean]
+
+  case class GenLit[T](t: T) extends Exp[T]
+  case class Plus(e1: Exp[Int], e2: Exp[Int]) extends Exp[Int]
+  case class Fun[S, T](f: Exp[S] => Exp[T]) extends Exp[S => T]
+  case class App[T, U](f: Exp[T => U], e: Exp[T]) extends Exp[U]
+
+
+  def eval[T](e: Exp[T]): T = e match {
+    case IntLit(n) => n
+    case BooleanLit(b) => b
+    case GenLit(t) => t
+    case Plus(e1, e2) => eval(e1) + eval(e2)
+    case f: Fun[s, t]  =>
+      (v: s) => eval(f.f(GenLit(v)))
+    case App(f, e) => eval(f)(eval(e))
+  }
+
+  val exp = App(Fun[S = Int](x => Plus(x, IntLit(1))), IntLit(2))
+
+  eval(exp)
+}

--- a/tests/pos/i4075-gadt.scala
+++ b/tests/pos/i4075-gadt.scala
@@ -1,0 +1,12 @@
+object i4075 {
+  case class One[T](fst: T)
+  def bad[T](e: One[T]) = e match {
+    case foo: One[a] =>
+      val t: T = e.fst
+      // val nok: Nothing = t // should not compile
+      val ok: a = t // does compile
+      One(ok)
+  }
+
+  val one: One[Int] = bad(One(0))
+}

--- a/tests/pos/i4176-gadt.scala
+++ b/tests/pos/i4176-gadt.scala
@@ -1,0 +1,36 @@
+object i4176 {
+  sealed trait TNat
+  case class TZero() extends TNat
+  case class TSucc[N <: TNat] extends TNat
+
+  object TNatSum {
+    sealed trait TSum[M, N, R]
+    case class TSumZero[N]() extends TSum[TZero, N, N]
+    case class TSumM[M <: TNat, N, R <: TNat](sum: TSum[M, N, R]) extends TSum[TSucc[M], N, TSucc[R]]
+  }
+  import TNatSum._
+
+  implicit def tSumZero[N]: TSum[TZero, N, N] =
+    TSumZero()
+  implicit def tSumM[M <: TNat, N, R <: TNat](implicit sum: TSum[M, N, R]): TSum[TSucc[M], N, TSucc[R]] =
+    TSumM(sum)
+
+  sealed trait Vec[T, N <: TNat]
+  case object VNil extends Vec[Nothing, TZero] // fails but in refchecks
+  case class VCons[T, N <: TNat](x: T, xs: Vec[T, N]) extends Vec[T, TSucc[N]]
+
+  def append0[T, M <: TNat, N <: TNat, R <: TNat]($this: Vec[T, M], that: Vec[T, N])(implicit tsum: TSum[M, N, R]): Vec[T, R] =
+    ($this, tsum) match {
+      case (VNil, TSumZero()) => that
+      case (VCons(x, xs), TSumM(sum)) => VCons(x, append0(xs, that)(sum))
+    }
+
+  def append[T, M <: TNat, N <: TNat, R <: TNat]($this: Vec[T, M], that: Vec[T, N])(implicit tsum: TSum[M, N, R]): Vec[T, R] =
+      tsum match {
+        case TSumZero() =>
+          $this match { case VNil => that }
+        case TSumM(sum) =>
+          $this match { case VCons(x, xs) => VCons(x, append(xs, that)(sum)) }
+      }
+
+}

--- a/tests/pos/i4471-gadt.scala
+++ b/tests/pos/i4471-gadt.scala
@@ -1,0 +1,31 @@
+object i4471 {
+  sealed trait Shuffle[A1, A2] {
+    def andThen[A3](that: Shuffle[A2, A3]): Shuffle[A1, A3] = AndThen(this, that)
+  }
+
+  case class Id[A]() extends Shuffle[A, A]
+  case class Swap[A, B]() extends Shuffle[(A, B), (B, A)]
+  case class AssocLR[A, B, C]() extends Shuffle[((A, B), C), (A, (B, C))]
+  case class AssocRL[A, B, C]() extends Shuffle[(A, (B, C)), ((A, B), C)]
+  case class Par[A1, B1, A2, B2](_1: Shuffle[A1, B1], _2: Shuffle[A2, B2]) extends Shuffle[(A1, A2), (B1, B2)]
+  case class AndThen[A1, A2, A3](_1: Shuffle[A1, A2], _2: Shuffle[A2, A3]) extends Shuffle[A1, A3]
+  
+  def rewrite3[A1, A2, A3, A4](
+    op1: Shuffle[A1, A2],
+    op2: Shuffle[A2, A3],
+    op3: Shuffle[A3, A4]
+  ): Option[Shuffle[A1, A4]] = (op1, op2, op3) match {
+    case (
+      _: Swap[x, y],
+      _: AssocRL[u, v, w],
+      op3_ : Par[p1, q1, p2, q2]
+    ) => op3_ match {
+      case Par(_: Swap[r, s], _: Id[p2_]) =>
+        Some(
+          AssocLR[v, w, u]() andThen Par(Id[v](), Swap[w, u]()) andThen AssocRL[v, u, w]()
+        )
+      case _ => None
+    }
+    case _ => None
+  }
+}

--- a/tests/pos/i5068-gadt.scala
+++ b/tests/pos/i5068-gadt.scala
@@ -1,0 +1,24 @@
+object i5068 {
+  case class Box[F[_]](value: F[Int])
+  sealed trait IsK[F[_], G[_]]
+  final case class ReflK[F[_]]() extends IsK[F, F]
+
+  def foo[F[_], G[_]](r: F IsK G, a: Box[F]): Box[G] = r match { case ReflK() => a }
+}
+
+object i5068b {
+  type WeirdShape[A[_], B] = A[B]
+  // type WeirderShape[S[_[_], _], I, M] = Any
+  case class Box[ F[_[_[_], _], _, _[_]] ](value: F[WeirdShape, Int, Option])
+  sealed trait IsK[F[_[_[_], _], _, _[_]], G[_[_[_], _], _, _[_]]]
+  final case class ReflK[ F[_[_[_], _], _, _[_]] ]() extends IsK[F, F]
+
+  def foo[F[_[_[_], _], _, _[_]], G[_[_[_], _], _, _[_]]](
+    r: F IsK G,
+    a: Box[F]
+  ): Box[G] = r match { case ReflK() => a }
+
+  // def main(args: Array[String]): Unit = {
+  //   println(foo(ReflK(), Box[WeirderShape](???)))
+  // }
+}

--- a/tests/pos/injectivity-gadt.scala
+++ b/tests/pos/injectivity-gadt.scala
@@ -1,0 +1,14 @@
+object injectivity {
+  sealed trait EQ[A, B]
+  final case class Refl[A]() extends EQ[A, A]
+
+  def conform[A, B, C, D](a: A, b: B, eq: EQ[(A, B), (C, D)]): C =
+    eq match {
+      case _: Refl[a] =>
+        val ab: (A, B) = (a, b)
+        val cd: (C, D) = ab
+        val rab: a = ab
+        val rcd: a = cd
+        a
+    }
+}

--- a/tests/run/gadt-injectivity-unsoundness.scala
+++ b/tests/run/gadt-injectivity-unsoundness.scala
@@ -1,0 +1,19 @@
+object Test {
+  sealed trait EQ[A, B]
+  final case class Refl[T]() extends EQ[T, T]
+
+  def absurd[F[_], X, Y](eq: EQ[F[X], F[Y]], x: X): Y = eq match {
+    case Refl() => x
+  }
+
+  var ex: Exception = _
+  try {
+    type Unsoundness[X] = Int
+    val s: String = absurd[Unsoundness, Int, String](Refl(), 0)
+  } catch {
+    case e: ClassCastException => ex = e
+  }
+
+  def main(args: Array[String]) =
+    assert(ex != null)
+}


### PR DESCRIPTION
Cleaned up version of #5258.

Copying over relevant information:

This fixes all of the below:
- #3666
- #4176
- #4075
- #5068
- #4471

For the time being, we mishandle injectivity and so we are unsound. See tests/run/gadt-injectivity-unsoundness.scala for a test showing a class cast exception. We will need to create an issue for this.

756cd0a was reverted because it was making the tests fail, and reverting it caused no test failures. I might bring it back later when working on injectivity.

At first glance, it might make sense to merge `GADTMap` state with `TyperState`. However, it's not necessary (since it's possible to just keep a fresh copy of `GADTMap` as the "state") and it's not entirely obvious how to adapt already existing code. See https://github.com/lampepfl/dotty/pull/5258#issuecomment-444850132 for detailed reasoning. For the time being, I think it'd be best to leave the state where it is and refactor later if handling the GADT state becomes problematic.