### PR TITLE
Add missing -Yretain-trees in ConsumeTasty

### DIFF
--- a/compiler/src/dotty/tools/dotc/consumetasty/ConsumeTasty.scala
+++ b/compiler/src/dotty/tools/dotc/consumetasty/ConsumeTasty.scala
@@ -18,7 +18,7 @@ object ConsumeTasty {
 
     val currentClasspath = QuoteDriver.currentClasspath
     import java.io.File.{ pathSeparator => sep }
-    val args = "-from-tasty" +: "-classpath" +: s"$classpath$sep$currentClasspath" +: classes
+    val args = "-from-tasty" :: "-Yretain-trees" :: "-classpath" :: s"$classpath$sep$currentClasspath" :: classes
     (new Consume).process(args.toArray)
   }
 }


### PR DESCRIPTION
As we may want to see trees that come from dependencies