### PR TITLE
Enclose runMain in try-catch

### DIFF
--- a/compiler/test/dotty/tools/vulpix/ChildJVMMain.java
+++ b/compiler/test/dotty/tools/vulpix/ChildJVMMain.java
@@ -29,7 +29,8 @@ public class ChildJVMMain {
             Class<?> cls = ucl.loadClass("Test");
             meth = cls.getMethod("main", String[].class);
         }
-        catch(Throwable e) {
+        catch (Throwable e) {
+            // Include the failure stack trace to the test output
             System.out.println(MessageStart);
             e.printStackTrace();
             throw e;

--- a/compiler/test/dotty/tools/vulpix/ChildJVMMain.java
+++ b/compiler/test/dotty/tools/vulpix/ChildJVMMain.java
@@ -13,19 +13,27 @@ public class ChildJVMMain {
     static final String MessageEnd = "##THIS IS THE END FOR ME, GOODBYE##";
 
     private static void runMain(String dir) throws Exception {
-        String jcp = System.getProperty("java.class.path");
-        String sep = File.pathSeparator;
-        System.setProperty("java.class.path", jcp == null ? dir : dir + sep + jcp);
-
-        ArrayList<URL> cp = new ArrayList<>();
-        for (String path : dir.split(sep))
-            cp.add(new File(path).toURI().toURL());
-
-        URLClassLoader ucl = new URLClassLoader(cp.toArray(new URL[cp.size()]));
-        Class<?> cls = ucl.loadClass("Test");
-        Method meth = cls.getMethod("main", String[].class);
+        Method meth = null;
         Object[] args = new Object[]{ new String[]{ "jvm" } };
+        try {
+            String jcp = System.getProperty("java.class.path");
+            String sep = File.pathSeparator;
+            System.setProperty("java.class.path", jcp == null ? dir : dir + sep + jcp);
 
+            ArrayList<URL> cp = new ArrayList<>();
+            for (String path : dir.split(sep))
+                cp.add(new File(path).toURI().toURL());
+
+            URLClassLoader ucl = new URLClassLoader(cp.toArray(new URL[cp.size()]));
+
+            Class<?> cls = ucl.loadClass("Test");
+            meth = cls.getMethod("main", String[].class);
+        }
+        catch(Throwable e) {
+            System.out.println(MessageStart);
+            e.printStackTrace();
+            throw e;
+        }
         System.out.println(MessageStart);
 
         meth.invoke(null, args);


### PR DESCRIPTION
If an author writes a run test with an object other than "Test" they get back the general invocation exception of `invoke` which is not very informative. This catches other exception like ones originating from `loadClass`.