### PR TITLE
Fix #5606: Handle closures in extension method calls

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -27,6 +27,7 @@ import EtaExpansion.etaExpand
 import util.Positions._
 import util.common._
 import util.Property
+import Applications.{ExtMethodApply, wrapDefs, productSelectorTypes}
 
 import collection.mutable
 import annotation.tailrec
@@ -426,7 +427,7 @@ class Typer extends Namer
 
     def typeSelectOnTerm(implicit ctx: Context): Tree =
       typedExpr(tree.qualifier, selectionProto(tree.name, pt, this)) match {
-        case qual1 @ Applications.ExtMethodApply(app) =>
+        case qual1 @ ExtMethodApply(app) =>
           pt.revealIgnored match {
             case _: PolyProto => qual1 // keep the ExtMethodApply to strip at next typedTypeApply
             case _ => app
@@ -926,7 +927,7 @@ class Typer extends Namer
     def ptIsCorrectProduct(formal: Type) = {
       isFullyDefined(formal, ForceDegree.noBottom) &&
       (defn.isProductSubType(formal) || formal.derivesFrom(defn.PairClass)) &&
-      Applications.productSelectorTypes(formal).corresponds(params) {
+      productSelectorTypes(formal).corresponds(params) {
         (argType, param) =>
           param.tpt.isEmpty || argType <:< typedAheadType(param.tpt).tpe
       }
@@ -1837,7 +1838,7 @@ class Typer extends Namer
         case Block(stats, expr) =>
           tpd.cpy.Block(app)(stats, lift(expr))
       }
-      Applications.wrapDefs(defs, lift(app))
+      wrapDefs(defs, lift(app))
     }
   }
 
@@ -2640,7 +2641,9 @@ class Typer extends Namer
           val app = tryExtension(nestedCtx)
           if (!app.isEmpty && !nestedCtx.reporter.hasErrors) {
             nestedCtx.typerState.commit()
-            return Applications.ExtMethodApply(app).withType(app.tpe)
+            return ExtMethodApply(app).withType(WildcardType)
+              // Use wildcard type in order not to prompt any further adaptations such as eta expansion
+              // before the method is fully applied.
           }
         case _ =>
       }
@@ -2652,7 +2655,7 @@ class Typer extends Namer
         else err.typeMismatch(tree, pt, failure)
       if (ctx.mode.is(Mode.ImplicitsEnabled) && tree.typeOpt.isValueType)
         inferView(tree, pt) match {
-          case SearchSuccess(inferred: Applications.ExtMethodApply, _, _) =>
+          case SearchSuccess(inferred: ExtMethodApply, _, _) =>
             inferred // nothing to check or adapt for extension method applications
           case SearchSuccess(inferred, _, _) =>
             checkImplicitConversionUseOK(inferred.symbol, tree.pos)
@@ -2732,7 +2735,7 @@ class Typer extends Namer
               adaptToArgs(wtp, pt)
             case pt: PolyProto =>
               tree match {
-                case _: Applications.ExtMethodApply => tree
+                case _: ExtMethodApply => tree
                 case _ =>  tryInsertApplyOrImplicit(tree, pt, locked)(tree) // error will be reported in typedTypeApply
               }
             case _ =>

--- a/tests/run/i5606.scala
+++ b/tests/run/i5606.scala
@@ -1,0 +1,14 @@
+object Test extends App {
+
+  def (f: A => B) $[A, B](a: A): B = f(a)
+
+  assert((((a: Int) => a.toString()) $ 10) == "10")
+
+  def g(x: Int): String = x.toString
+
+  assert((g $ 10) == "10")
+
+  val h: Int => String = _.toString
+
+  assert((h $ 10) == "10")
+}


### PR DESCRIPTION
Handle closures as left arguments of extension method calls.