### PR TITLE
Fix #5556: Check SAM types for realizability

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -641,9 +641,7 @@ object Types {
         val rinfo = tp.refinedInfo
         if (name.isTypeName && !pinfo.isInstanceOf[ClassInfo]) { // simplified case that runs more efficiently
           val jointInfo =
-            if (rinfo.isTypeAlias) rinfo
-            else if (pinfo.isTypeAlias) pinfo
-            else if (ctx.base.pendingMemberSearches.contains(name)) pinfo safe_& rinfo
+            if (ctx.base.pendingMemberSearches.contains(name)) pinfo safe_& rinfo
             else pinfo recoverable_& rinfo
           pdenot.asSingleDenotation.derivedSingleDenotation(pdenot.symbol, jointInfo)
         } else {

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -268,6 +268,9 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
         case tree: New if isCheckable(tree) =>
           Checking.checkInstantiable(tree.tpe, tree.pos)
           super.transform(tree)
+        case tree: Closure if !tree.tpt.isEmpty =>
+          Checking.checkRealizable(tree.tpt.tpe, tree.pos, "SAM type")
+          super.transform(tree)
         case tree @ Annotated(annotated, annot) =>
           cpy.Annotated(tree)(transform(annotated), transformAnnot(annot))
         case tree: AppliedTypeTree =>

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -136,10 +136,10 @@ object Checking {
     }
 
   /** Check that type `tp` is realizable. */
-  def checkRealizable(tp: Type, pos: Position)(implicit ctx: Context): Unit = {
+  def checkRealizable(tp: Type, pos: Position, what: String = "path")(implicit ctx: Context): Unit = {
     val rstatus = realizability(tp)
     if (rstatus ne Realizable)
-      ctx.errorOrMigrationWarning(em"$tp is not a legal path\nsince it${rstatus.msg}", pos)
+      ctx.errorOrMigrationWarning(em"$tp is not a legal $what\nsince it${rstatus.msg}", pos)
   }
 
   /** A type map which checks that the only cycles in a type are F-bounds

--- a/tests/neg/i5556.scala
+++ b/tests/neg/i5556.scala
@@ -1,0 +1,13 @@
+trait SAM {
+  type T >: Int
+  def apply(x: Int): Int
+  def t: T = 1
+}
+
+object O{
+  def main(a:Array[String])={
+    val fn: SAM {type T = String} = (i:Int) => i  // error: SAM{T = String} is not a legal SAM type
+    def cce: String = fn.t
+    println(cce)
+  }
+}


### PR DESCRIPTION
Also: avoid shortcuts in findMember which can mask bad bounds