### PR TITLE
Better error messages for missing symbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -496,10 +496,10 @@ class Definitions {
     def Int_<= : Symbol = Int_leR.symbol
   lazy val LongType: TypeRef = valueTypeRef("scala.Long", BoxedLongType, java.lang.Long.TYPE, LongEnc, nme.specializedTypeNames.Long)
   def LongClass(implicit ctx: Context): ClassSymbol = LongType.symbol.asClass
-    lazy val Long_XOR_Long: Symbol = LongType.member(nme.XOR).requiredSymbol(
+    lazy val Long_XOR_Long: Symbol = LongType.member(nme.XOR).requiredSymbol("method", nme.XOR, LongType.denot)(
       x => (x is Method) && (x.info.firstParamTypes.head isRef defn.LongClass)
     )
-    lazy val Long_LSR_Int: Symbol = LongType.member(nme.LSR).requiredSymbol(
+    lazy val Long_LSR_Int: Symbol = LongType.member(nme.LSR).requiredSymbol("method", nme.LSR, LongType.denot)(
       x => (x is Method) && (x.info.firstParamTypes.head isRef defn.IntClass)
     )
     lazy val Long_plusR: TermRef   = LongClass.requiredMethodRef(nme.PLUS, List(LongType))
@@ -729,7 +729,7 @@ class Definitions {
   def TupleXXLModule(implicit ctx: Context): Symbol = TupleXXLClass.companionModule
 
     def TupleXXL_apply(implicit ctx: Context): Symbol =
-      TupleXXLModule.info.member(nme.apply).requiredSymbol(_.info.isVarArgsMethod)
+      TupleXXLModule.info.member(nme.apply).requiredSymbol("method", nme.apply, TupleXXLModule)(_.info.isVarArgsMethod)
 
   // Annotation base classes
   lazy val AnnotationType: TypeRef              = ctx.requiredClassRef("scala.annotation.Annotation")

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -359,32 +359,43 @@ trait Symbols { this: Context =>
 
 // ----- Locating predefined symbols ----------------------------------------
 
-  def requiredPackage(path: PreName): TermSymbol =
-    base.staticRef(path.toTermName, isPackage = true).requiredSymbol(_ is Package).asTerm
+  def requiredPackage(path: PreName): TermSymbol = {
+    val name = path.toTermName
+    base.staticRef(name, isPackage = true).requiredSymbol("package", name)(_ is Package).asTerm
+  }
 
   def requiredPackageRef(path: PreName): TermRef = requiredPackage(path).termRef
 
-  def requiredClass(path: PreName): ClassSymbol =
-    base.staticRef(path.toTypeName).requiredSymbol(_.isClass) match {
+  def requiredClass(path: PreName): ClassSymbol = {
+    val name = path.toTypeName
+    base.staticRef(name).requiredSymbol("class", name)(_.isClass) match {
       case cls: ClassSymbol => cls
       case sym => defn.AnyClass
     }
+  }
 
   def requiredClassRef(path: PreName): TypeRef = requiredClass(path).typeRef
 
   /** Get ClassSymbol if class is either defined in current compilation run
    *  or present on classpath.
    *  Returns NoSymbol otherwise. */
-  def getClassIfDefined(path: PreName): Symbol =
-    base.staticRef(path.toTypeName, generateStubs = false).requiredSymbol(_.isClass, generateStubs = false)
+  def getClassIfDefined(path: PreName): Symbol = {
+    val name = path.toTypeName
+    base.staticRef(name, generateStubs = false)
+      .requiredSymbol("class", name, generateStubs = false)(_.isClass)
+  }
 
-  def requiredModule(path: PreName): TermSymbol =
-    base.staticRef(path.toTermName).requiredSymbol(_ is Module).asTerm
+  def requiredModule(path: PreName): TermSymbol = {
+    val name = path.toTermName
+    base.staticRef(name).requiredSymbol("object", name)(_ is Module).asTerm
+  }
 
   def requiredModuleRef(path: PreName): TermRef = requiredModule(path).termRef
 
-  def requiredMethod(path: PreName): TermSymbol =
-    base.staticRef(path.toTermName).requiredSymbol(_ is Method).asTerm
+  def requiredMethod(path: PreName): TermSymbol = {
+    val name = path.toTermName
+    base.staticRef(name).requiredSymbol("method", name)(_ is Method).asTerm
+  }
 
   def requiredMethodRef(path: PreName): TermRef = requiredMethod(path).termRef
 }


### PR DESCRIPTION
When I changed branches, the compiler encountered a missing required symbol
"DottyPredef.ImplicitConverter" because in the previous branch that symbol
had been renamed to "ImplicitConversion". The error message was not exactly
helpful, however:

   None of the required alternatives of <none> satisfies required predicate

This commit changes things so that we give a meaningful error message in all cases where
a required symbol is missing.