### PR TITLE
Fix #5527: Fix companion module for hk opaque type aliases

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -991,10 +991,15 @@ object SymDenotations {
      */
     final def companionModule(implicit ctx: Context): Symbol =
       if (is(Module)) sourceModule
-      else if (isOpaqueAlias)
-        info match {
-          case TypeAlias(TypeRef(prefix: TermRef, _)) => prefix.termSymbol
+      else if (isOpaqueAlias) {
+        def reference(tp: Type): TermRef = tp match {
+          case TypeRef(prefix: TermRef, _) => prefix
+          case tp: HKTypeLambda => reference(tp.resType)
+          case tp: AppliedType => reference(tp.tycon)
         }
+        val TypeAlias(alias) = info
+        reference(alias).termSymbol
+      }
       else registeredCompanion.sourceModule
 
     private def companionType(implicit ctx: Context): Symbol =

--- a/tests/run/i5527.scala
+++ b/tests/run/i5527.scala
@@ -1,0 +1,35 @@
+trait Contravariant[F[_]] {
+  def contramap[A, B](fa: F[A])(f: B => A): F[B]
+}
+
+object Library {
+
+  opaque type Set[A] = A => Boolean
+
+  object Set {
+    def singleton[A](a: A): Set[A] =
+      _ == a
+
+    implicit class SetOps[A](private val set: Set[A]) extends AnyVal {
+      def contains(a: A): Boolean =
+        set(a)
+    }
+
+    implicit val setContravariant: Contravariant[Set] = new Contravariant[Set] {
+      def contramap[A, B](fa: Set[A])(f: B => A): Set[B] =
+        b => fa(f(b))
+    }
+  }
+}
+
+object Test extends App {
+  import Library._
+  //import Library.Set.setContravariant if this is imported the program will run correctly
+
+  val F = implicitly[Contravariant[Set]]
+
+  val one = Set.singleton(1)
+  val char = F.contramap(one)((s: String) => s.length)
+  assert(char.contains("a"))
+  assert(!char.contains("ab"))
+}


### PR DESCRIPTION
Higher kinded opaque aliases have a type lambda as right hand side. This
needs to be taken account of when computing the companion module of these
aliases.