### PR TITLE
Fix #5411: varargs with intersection type elements

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -13,6 +13,7 @@ import Constants._
 import Decorators._
 import Denotations._, SymDenotations._
 import dotty.tools.dotc.ast.tpd
+import TypeErasure.erasure
 import DenotTransformers._
 
 object ElimRepeated {
@@ -92,7 +93,7 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
       JavaSeqLiteral(elems, elemtpt)
     case _ =>
       val elemType = tree.tpe.elemType
-      var elemClass = elemType.classSymbol
+      var elemClass = erasure(elemType).classSymbol
       if (defn.NotRuntimeClasses.contains(elemClass)) elemClass = defn.ObjectClass
       ref(defn.DottyArraysModule)
         .select(nme.seqToArray)

--- a/tests/pos/i5411.scala
+++ b/tests/pos/i5411.scala
@@ -1,0 +1,5 @@
+trait A
+trait B
+object O {
+  def m(x: Seq[A & B]) = java.util.Arrays.asList(x: _*)
+}


### PR DESCRIPTION
We need to generate a ClassTag to construct a Java vararg array.
Just computing the class symbol of the element type is not enough,
as some types do not have class symbols. We need instead to compute
the class symbol on the erased element type.