### PR TITLE
Count references correctly when dropping unused defs

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -954,13 +954,18 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       override def traverse(t: Tree)(implicit ctx: Context) = {
         def updateRefCount(sym: Symbol, inc: Int) =
           for (x <- refCount.get(sym)) refCount(sym) = x + inc
+        def updateTermRefCounts(t: Tree) =
+          t.typeOpt.foreachPart {
+            case ref: TermRef => updateRefCount(ref.symbol, 2) // can't be inlined, so make sure refCount is at least 2
+            case _ =>
+          }
+
         t match {
-          case t: RefTree => updateRefCount(t.symbol, 1)
+          case t: RefTree =>
+            updateRefCount(t.symbol, 1)
+            updateTermRefCounts(t)
           case _: New | _: TypeTree =>
-            t.typeOpt.foreachPart {
-              case ref: TermRef => updateRefCount(ref.symbol, 2) // can't be inlined, so make sure refCount is at least 2
-              case _ =>
-            }
+            updateTermRefCounts(t)
           case _ =>
         }
         traverseChildren(t)

--- a/tests/pos/i5572.scala
+++ b/tests/pos/i5572.scala
@@ -1,0 +1,14 @@
+trait Foo {
+  type Id[t] = t
+  inline def foo[T](t: T) <: Id[T] =
+    inline t match {
+      case i: Int => (i+1).asInstanceOf[Id[T]]
+      case _ => t
+    }
+}
+
+object Bar extends Foo
+
+object Test {
+  Bar.foo(23)
+}


### PR DESCRIPTION
When dropping unused definitions during inlining we must also count references to terms which are reachable via the types of `RefTrees`.

Fixes #5572.