### PR TITLE
Fix pattern matching alternative

### DIFF
--- a/tests/pos/patternMatchAlternative.scala
+++ b/tests/pos/patternMatchAlternative.scala
@@ -1,0 +1,28 @@
+
+object Main {
+  val a: Int = 4
+  a match {
+    case 1 => println("1")
+    case 1 | 2 => println("1 or 2")
+  }
+
+  a match {
+    case 1 => 1
+    case 0 | 0 => 0
+    case 2 | 2 | 2 | 3 | 2 | 3 => 0
+    case 4 | (_ @ 4) => 0
+    case _ => -1
+  }
+
+  a match {
+    case 1 => 1
+    case 0 | 0 => 0
+    case 2 | 2 | 2 | 3 | 2 | 3 => 0
+    case _ => -1
+  }
+
+  a match {
+    case 0 | 1 => 0
+    case 1 => 1
+  }
+}


### PR DESCRIPTION
Fix #5402 

The same problem was fixed in scalac in 2013 in this pull request https://github.com/scala/scala/pull/2291

I've reused the same test cases. Though there is one other issue

```scala
a match {
  case 0 | 1 => 1
  case 1 => 0
}
```
Will also crash the compiler with the same error described in #5402 . Compiling this code in scalac 
results in a "code unreachable" warning. This suggest to me that this bug should be fixed in the code path analysis phase and not the switch case generation.

Should this problem be fixed in another pull request?