### PR TITLE
Fix #5655: Use a prefix to construct a TypeRef when parsing Java signature

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -363,7 +363,7 @@ class ClassfileParser(
             accept('.')
             val name = subName(c => c == ';' || c == '<' || c == '.').toTypeName
             val clazz = tpe.member(name).symbol
-            tpe = processClassType(processInner(clazz.typeRef))
+            tpe = processClassType(processInner(TypeRef(tpe, clazz)))
           }
           accept(';')
           tpe

--- a/tests/pos/i5655/J_1.java
+++ b/tests/pos/i5655/J_1.java
@@ -1,0 +1,11 @@
+public class J_1{
+    public class A<T>{
+        public class B<U>{}
+    }
+    A<String>.B<String> m(){
+        J_1 j = new J_1();
+        A<String> a = j.new A<>();
+        A<String>.B<String> b = a.new B<>();
+        return b;
+    }
+}

--- a/tests/pos/i5655/S_2.scala
+++ b/tests/pos/i5655/S_2.scala
@@ -1,0 +1,6 @@
+object O {
+  def main(args: Array[String]) = {
+    val j = new J_1
+    val ab: J_1#A[String]#B[String] = j.m()
+  }
+}


### PR DESCRIPTION
This seems to be a very simple fix for #5655, but please check that I am not wrong.