### PR TITLE
Allow inline matches to bind type variables

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -346,7 +346,7 @@ object Implicits {
    *  @param level  The level where the reference was found
    *  @param tstate The typer state to be committed if this alternative is chosen
    */
-  case class SearchSuccess(tree: Tree, ref: TermRef, level: Int)(val tstate: TyperState) extends SearchResult with Showable
+  case class SearchSuccess(tree: Tree, ref: TermRef, level: Int)(val tstate: TyperState, val gstate: GADTMap) extends SearchResult with Showable
 
   /** A failed search */
   case class SearchFailure(tree: Tree) extends SearchResult {
@@ -880,6 +880,7 @@ trait Implicits { self: Typer =>
         result0 match {
           case result: SearchSuccess =>
             result.tstate.commit()
+            ctx.gadt.restore(result.gstate)
             implicits.println(i"success: $result")
             implicits.println(i"committing ${result.tstate.constraint} yielding ${ctx.typerState.constraint} in ${ctx.typerState}")
             result
@@ -1004,7 +1005,7 @@ trait Implicits { self: Typer =>
         val generated2 =
           if (cand.isExtension) Applications.ExtMethodApply(generated1).withType(generated1.tpe)
           else generated1
-        SearchSuccess(generated2, ref, cand.level)(ctx.typerState)
+        SearchSuccess(generated2, ref, cand.level)(ctx.typerState, ctx.gadt)
       }
     }}
 
@@ -1016,7 +1017,8 @@ trait Implicits { self: Typer =>
         SearchFailure(new DivergingImplicit(cand.ref, pt.widenExpr, argument))
       else {
         val history = ctx.searchHistory.nest(cand, pt)
-        val result = typedImplicit(cand, contextual)(nestedContext().setNewTyperState().setSearchHistory(history))
+        val result =
+          typedImplicit(cand, contextual)(nestedContext().setNewTyperState().setFreshGADTBounds.setSearchHistory(history))
         result match {
           case res: SearchSuccess =>
             ctx.searchHistory.defineBynameImplicit(pt.widenExpr, res)
@@ -1118,7 +1120,9 @@ trait Implicits { self: Typer =>
           result match {
             case _: SearchFailure =>
               SearchSuccess(ref(defn.Not_value), defn.Not_value.termRef, 0)(
-                ctx.typerState.fresh().setCommittable(true))
+                ctx.typerState.fresh().setCommittable(true),
+                ctx.gadt
+              )
             case _: SearchSuccess =>
               NoMatchingImplicitsFailure
           }
@@ -1188,7 +1192,7 @@ trait Implicits { self: Typer =>
       // other candidates need to be considered.
       ctx.searchHistory.recursiveRef(pt) match {
         case ref: TermRef =>
-          SearchSuccess(tpd.ref(ref).withPos(pos.startPos), ref, 0)(ctx.typerState)
+          SearchSuccess(tpd.ref(ref).withPos(pos.startPos), ref, 0)(ctx.typerState, ctx.gadt)
         case _ =>
           val eligible =
             if (contextual) ctx.implicits.eligible(wildProto)
@@ -1428,7 +1432,7 @@ final class SearchRoot extends SearchHistory {
     implicitDictionary.get(tpe) match {
       case Some((ref, _)) =>
         implicitDictionary.put(tpe, (ref, result.tree))
-        SearchSuccess(tpd.ref(ref).withPos(result.tree.pos), result.ref, result.level)(result.tstate)
+        SearchSuccess(tpd.ref(ref).withPos(result.tree.pos), result.ref, result.level)(result.tstate, result.gstate)
       case None => result
     }
   }
@@ -1529,7 +1533,7 @@ final class SearchRoot extends SearchHistory {
 
             val blk = Block(classDef :: inst :: Nil, res)
 
-            success.copy(tree = blk)(success.tstate)
+            success.copy(tree = blk)(success.tstate, success.gstate)
           }
       }
     }

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -855,10 +855,9 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
         }
         if (!isImplicit) caseBindingsBuf += scrutineeBinding
         val gadtCtx = typer.gadtContext(gadtSyms).addMode(Mode.GADTflexible)
-        val pat1 = typer.typedPattern(cdef.pat, scrutType)(gadtCtx)
         val fromBuf = mutable.ListBuffer.empty[TypeSymbol]
         val toBuf = mutable.ListBuffer.empty[TypeSymbol]
-        if (reducePattern(caseBindingsBuf, fromBuf, toBuf, scrutineeSym.termRef, pat1)(gadtCtx) && guardOK) {
+        if (reducePattern(caseBindingsBuf, fromBuf, toBuf, scrutineeSym.termRef, cdef.pat)(gadtCtx) && guardOK) {
           val caseBindings = caseBindingsBuf.toList
           val from = fromBuf.toList
           val to = toBuf.toList

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -955,7 +955,8 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
         val selType = if (sel.isEmpty) wideSelType else sel.tpe
         reduceInlineMatch(sel, selType, cases.asInstanceOf[List[CaseDef]], this) match {
           case Some((caseBindings, rhs0)) =>
-            // drop type ascriptions/casts hiding internal types (which are now aliases after reducing the match)
+            // drop type ascriptions/casts hiding pattern-bound types (which are now aliases after reducing the match)
+            // note that any actually necessary casts will be reinserted by the typing pass below
             val rhs1 = rhs0 match {
               case Block(stats, t) if t.pos.isSynthetic =>
                 t match {

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -573,7 +573,8 @@ object ProtoTypes {
    */
   private def wildApprox(tp: Type, theMap: WildApproxMap, seen: Set[TypeParamRef])(implicit ctx: Context): Type = tp match {
     case tp: NamedType => // default case, inlined for speed
-      if (tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
+      if (tp.isInstanceOf[TypeRef] && tp.symbol.is(Flags.Case) && !tp.symbol.isClass) WildcardType(tp.underlying.bounds)
+      else if (tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
       else tp.derivedSelect(wildApprox(tp.prefix, theMap, seen))
     case tp @ AppliedType(tycon, args) =>
       wildApprox(tycon, theMap, seen) match {

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -573,7 +573,8 @@ object ProtoTypes {
    */
   private def wildApprox(tp: Type, theMap: WildApproxMap, seen: Set[TypeParamRef])(implicit ctx: Context): Type = tp match {
     case tp: NamedType => // default case, inlined for speed
-      if (tp.isInstanceOf[TypeRef] && tp.symbol.is(Flags.Case) && !tp.symbol.isClass) WildcardType(tp.underlying.bounds)
+      val isPatternBoundTypeRef = tp.isInstanceOf[TypeRef] && tp.symbol.is(Flags.Case) && !tp.symbol.isClass
+      if (isPatternBoundTypeRef) WildcardType(tp.underlying.bounds)
       else if (tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
       else tp.derivedSelect(wildApprox(tp.prefix, theMap, seen))
     case tp @ AppliedType(tycon, args) =>

--- a/compiler/test/dotc/pos-from-tasty.blacklist
+++ b/compiler/test/dotc/pos-from-tasty.blacklist
@@ -20,3 +20,8 @@ default-super.scala
 i3050.scala
 i4006b.scala
 i4006c.scala
+
+# Need to print empty tree for implicit match
+implicit-match.scala
+implicit-match-nested.scala
+implicit-match-and-inline-match.scala

--- a/tests/neg/implicit-match-ambiguous-bind.scala
+++ b/tests/neg/implicit-match-ambiguous-bind.scala
@@ -1,0 +1,9 @@
+object `implicit-match-ambiguous-bind` {
+  case class Box[T](value: T)
+  implicit val ibox: Box[Int] = Box(0)
+  implicit val sbox: Box[String] = Box("")
+  inline def unbox = implicit match {
+    case b: Box[t] => b.value // error
+  }
+  val unboxed = unbox
+}

--- a/tests/pos/i5574.scala
+++ b/tests/pos/i5574.scala
@@ -1,0 +1,14 @@
+import scala.typelevel._
+
+object i5574 {
+  class Box[F[_]]
+
+  inline def foo[T] <: Any =
+    inline erasedValue[T] match {
+      case _: Box[f] =>
+        type t = f
+        23
+    }
+
+  foo[Box[List]]
+}

--- a/tests/pos/implicit-match-and-inline-match.scala
+++ b/tests/pos/implicit-match-and-inline-match.scala
@@ -1,0 +1,24 @@
+object `implicit-match-and-inline-match` {
+  import scala.typelevel._
+
+  case class Box[T](value: T)
+  implicit val ibox: Box[Int] = Box(0)
+
+  object a {
+    inline def isTheBoxInScopeAnInt = implicit match {
+      case _: Box[t] => inline erasedValue[t] match {
+        case _: Int => true
+      }
+    }
+    val wellIsIt = isTheBoxInScopeAnInt
+  }
+
+  object b {
+    inline def isTheBoxInScopeAnInt = implicit match {
+      case _: Box[t] => inline 0 match {
+        case _: t => true
+      }
+    }
+    val wellIsIt = isTheBoxInScopeAnInt
+  }
+}

--- a/tests/pos/implicit-match-nested.scala
+++ b/tests/pos/implicit-match-nested.scala
@@ -1,0 +1,16 @@
+object `implicit-match-nested` {
+  case class A[T]()
+  case class B[T]()
+
+  implicit val a: A[Int] = A[Int]()
+  implicit val b1: B[Int] = B[Int]()
+  implicit val b2: B[String] = B[String]()
+
+  inline def locateB <: B[_] = implicit match {
+    case _: A[t] => implicit match {
+      case b: B[`t`] => b
+    }
+  }
+
+  locateB
+}

--- a/tests/pos/implicit-match.scala
+++ b/tests/pos/implicit-match.scala
@@ -1,0 +1,34 @@
+object `implicit-match` {
+  object invariant {
+    case class Box[T](value: T)
+    implicit val box: Box[Int] = Box(0)
+    inline def unbox <: Any = implicit match {
+      case b: Box[t] => b.value
+    }
+    val i: Int = unbox
+    val i2 = unbox
+    val i3: Int = i2
+  }
+
+  object covariant {
+    case class Box[+T](value: T)
+    implicit val box: Box[Int] = Box(0)
+    inline def unbox <: Any = implicit match {
+      case b: Box[t] => b.value
+    }
+    val i: Int = unbox
+    val i2 = unbox
+    val i3: Int = i2
+  }
+
+  object contravariant {
+    case class TrashCan[-T](trash: T => Unit)
+    implicit val trashCan: TrashCan[Int] = TrashCan { i => ; }
+    inline def trash <: Nothing => Unit = implicit match {
+      case c: TrashCan[t] => c.trash
+    }
+    val t1: Int => Unit = trash
+    val t2 = trash
+    val t3: Int => Unit = t2
+  }
+}

--- a/tests/pos/inline-match-gadt-nested.scala
+++ b/tests/pos/inline-match-gadt-nested.scala
@@ -1,0 +1,14 @@
+object `inline-match-gadt-nested` {
+  import scala.typelevel._
+
+  enum Gadt[A, B] {
+    case Nested(gadt: Gadt[A, Int]) extends Gadt[A, Int]
+    case Simple extends Gadt[String, Int]
+  }
+  import Gadt._
+
+  inline def foo[A, B](g: Gadt[A, B]): (A, B) =
+    inline g match {
+      case Nested(Simple) => ("", 0)
+    }
+}

--- a/tests/pos/inline-match-gadt.scala
+++ b/tests/pos/inline-match-gadt.scala
@@ -1,0 +1,10 @@
+object `inline-match-gadt` {
+  class Exactly[T]
+  erased def exactType[T]: Exactly[T] = ???
+
+  inline def foo[T](t: T): T =
+    inline exactType[T] match {
+      case _: Exactly[Int] => 23
+      case _ => t
+    }
+}

--- a/tests/pos/inline-match-specialize.scala
+++ b/tests/pos/inline-match-specialize.scala
@@ -1,0 +1,8 @@
+object `inline-match-specialize` {
+  case class Box[+T](value: T)
+  inline def specialize[T](box: Box[T]) <: Box[T] = inline box match {
+    case box: Box[t] => box
+  }
+
+  val ibox: Box[Int] = specialize[Any](Box(0))
+}


### PR DESCRIPTION
Fixes #5405, #5574.

Github diff is unusually horrible for `dropUnusedBindings`, so let me quote part of commit message:
> When dropping unused bindings in Inliner, insert type bindings
> with a single pre-pass to correctly handle updating singleton types.
> Previously Select trees retained old type values, which prevented
> pickler roundtripping.