### PR TITLE
Fix character encoding when piping stdout on Windows

### DIFF
--- a/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
+++ b/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
@@ -117,7 +117,7 @@ trait RunnerOrchestration {
           val sb = new StringBuilder
 
           if (childStdout eq null)
-            childStdout = new BufferedReader(new InputStreamReader(process.getInputStream))
+            childStdout = new BufferedReader(new InputStreamReader(process.getInputStream, "UTF-8"))
 
           var childOutput: String = childStdout.readLine()
 
@@ -127,8 +127,7 @@ trait RunnerOrchestration {
           childOutput = childStdout.readLine()
 
           while (childOutput != ChildJVMMain.MessageEnd && childOutput != null) {
-            sb.append(childOutput)
-            sb += '\n'
+            sb.append(childOutput).append(System.lineSeparator)
             childOutput = childStdout.readLine()
           }
 
@@ -161,7 +160,7 @@ trait RunnerOrchestration {
       val url = classOf[ChildJVMMain].getProtectionDomain.getCodeSource.getLocation
       val cp = Paths.get(url.toURI).toString + JFile.pathSeparator + Properties.scalaLibrary
       val javaBin = sys.props("java.home") + sep + "bin" + sep + "java"
-      new ProcessBuilder(javaBin, "-Xmx1g", "-cp", cp, "dotty.tools.vulpix.ChildJVMMain")
+      new ProcessBuilder(javaBin, "-Dfile.encoding=UTF-8", "-Xmx1g", "-cp", cp, "dotty.tools.vulpix.ChildJVMMain")
         .redirectErrorStream(true)
         .redirectInput(ProcessBuilder.Redirect.PIPE)
         .redirectOutput(ProcessBuilder.Redirect.PIPE)


### PR DESCRIPTION
Character encoding is wrong when piping stdout on Windows, e.g. test case `test\run\productElementName.scala` contains UTF-8 characters and fails with the following output:
```scala
[info] Test dotty.tools.dotc.CompilationTests.runAll started
Output from "tests\run\productElementName.scala" did not match check file.6s)
Diff (expected on the left, actual right):
User(name=Susan, age=42)                             |  User(name=Susan, age=42)
????(??=Susan, ??=42)                                |  ????(??=Susan, ??=42)
U$er(na$me=Susan, a$ge=42)                           |  U$er(na$me=Susan, a$ge=42)
type(for=Susan, if=42)                               |  type(for=Susan, if=42)
contains spaces(first param=Susan, second param=42)  |  contains spaces(first param=Susan, second param=42)
Symbols(::=Susan, ||=42)                             |  Symbols(::=Susan, ||=42)
MultipleParamLists(a=Susan, b=42)                    |  MultipleParamLists(a=Susan, b=42)
AuxiliaryConstructor(a=Susan, b=42)                  |  AuxiliaryConstructor(a=Susan, b=42)
OverloadedApply(a=Susan, b=123)                      |  OverloadedApply(a=Susan, b=123)
PrivateMembers(a=10, b=20, c=30, d=40, e=50, f=60)   |  PrivateMembers(a=10, b=20, c=30, d=40, e=50, f=60)

NoParams()                                           |  NoParams()
EOF                                                  |  EOF

[=======================================] completed (1123/1123, 1 failed, 101s)
[error] Test dotty.tools.dotc.CompilationTests.runAll failed: java.lang.AssertionError: Run test failed, but should not, reasons:
[error]
[error]   - encountered 1 test failures(s), took 113.944 sec
[error]     at dotty.tools.vulpix.ParallelTesting$CompilationTest.checkRuns(ParallelTesting.scala:1008)
[error]     at dotty.tools.dotc.CompilationTests.runAll(CompilationTests.scala:176)
[error]     ...
```