### PR TITLE
Make SourcePosition showable

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -8,6 +8,7 @@ import StdNames.nme
 import ast.Trees._
 import typer.Implicits._
 import typer.ImportInfo
+import util.SourcePosition
 import java.lang.Integer.toOctalString
 import config.Config.summarizeDepth
 import scala.util.control.NonFatal
@@ -503,6 +504,11 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
     nodeName ~ "(" ~ elems ~ tpSuffix ~ ")" ~ (Str(tree.pos.toString) provided ctx.settings.YprintPos.value)
   }.close // todo: override in refined printer
+
+  def toText(pos: SourcePosition): Text =
+    if (!pos.exists) "<no position>"
+    else if (pos.source.exists) s"${pos.source.file}:${pos.line + 1}"
+    else s"(no source file, offset = ${pos.pos.point})"
 
   def toText(result: SearchResult): Text = result match {
     case result: SearchSuccess =>

--- a/compiler/src/dotty/tools/dotc/printing/Printer.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Printer.scala
@@ -7,6 +7,7 @@ import Texts._, ast.Trees._
 import Types.Type, Symbols.Symbol, Scopes.Scope, Constants.Constant,
        Names.Name, Denotations._, Annotations.Annotation
 import typer.Implicits.SearchResult
+import util.SourcePosition
 import typer.ImportInfo
 
 import scala.annotation.internal.sharable
@@ -133,6 +134,9 @@ abstract class Printer {
 
   /** Textual representation of tree */
   def toText[T >: Untyped](tree: Tree[T]): Text
+
+  /** Textual representation of source position */
+  def toText(pos: SourcePosition): Text
 
   /** Textual representation of implicit search result */
   def toText(result: SearchResult): Text

--- a/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
@@ -33,7 +33,7 @@ trait MessageRendering {
     */
   def outer(pos: SourcePosition, prefix: String)(implicit ctx: Context): List[String] =
     if (pos.outer.exists) {
-       s"$prefix| This location is in code that was inlined at ${pos.outer}" ::
+       i"$prefix| This location is in code that was inlined at ${pos.outer}" ::
        outer(pos.outer, prefix)
     } else Nil
 

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -2,13 +2,15 @@ package dotty.tools
 package dotc
 package util
 
+import printing.{Showable, Printer}
+import printing.Texts._
 import Positions.{Position, NoPosition}
 
 import scala.annotation.internal.sharable
 
 /** A source position is comprised of a position in a source file */
 case class SourcePosition(source: SourceFile, pos: Position, outer: SourcePosition = NoSourcePosition)
-extends interfaces.SourcePosition {
+extends interfaces.SourcePosition with Showable {
   /** Is `that` a source position contained in this source position ?
    *  `outer` is not taken into account. */
   def contains(that: SourcePosition): Boolean =
@@ -56,8 +58,9 @@ extends interfaces.SourcePosition {
   def withOuter(outer: SourcePosition): SourcePosition = new SourcePosition(source, pos, outer)
 
   override def toString: String =
-    if (source.exists) s"${source.file}:${line + 1}"
-    else s"(no source file, offset = ${pos.point})"
+    s"${if (source.exists) source.file.toString else "(no source)"}:$pos"
+
+  def toText(printer: Printer): Text = printer.toText(this)
 }
 
 /** A sentinel for a non-existing source position */

--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -5,6 +5,7 @@ package reporting
 import java.io.{ PrintStream, PrintWriter, File => JFile, FileOutputStream }
 import java.text.SimpleDateFormat
 import java.util.Date
+import core.Decorators._
 
 import scala.collection.mutable
 
@@ -28,10 +29,10 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
   private[this] var _didCrash = false
   final def compilerCrashed: Boolean = _didCrash
 
-  protected final def inlineInfo(pos: SourcePosition): String =
+  protected final def inlineInfo(pos: SourcePosition)(implicit ctx: Context): String =
     if (pos.exists) {
       if (pos.outer.exists)
-        s"\ninlined at ${pos.outer}:\n" + inlineInfo(pos.outer)
+        i"\ninlined at ${pos.outer}:\n" + inlineInfo(pos.outer)
       else ""
     }
     else ""


### PR DESCRIPTION
 - show gives just the source file and the line, i.e. what toString
   did before.

 - toString now gives full position info, used for debugging.