### PR TITLE
Fix #5650: Use upper bound of match types for rhs

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1229,8 +1229,8 @@ class Namer { typer: Typer =>
 
   def typeDefSig(tdef: TypeDef, sym: Symbol, tparamSyms: List[TypeSymbol])(implicit ctx: Context): Type = {
     def abstracted(tp: Type): Type = HKTypeLambda.fromParams(tparamSyms, tp)
-    val dummyInfo = abstracted(TypeBounds.empty)
-    sym.info = dummyInfo
+    val dummyInfo1 = abstracted(TypeBounds.empty)
+    sym.info = dummyInfo1
     sym.setFlag(Provisional)
       // Temporarily set info of defined type T to ` >: Nothing <: Any.
       // This is done to avoid cyclic reference errors for F-bounds.
@@ -1248,6 +1248,16 @@ class Namer { typer: Typer =>
       case LambdaTypeTree(_, body) => body
       case rhs => rhs
     }
+
+    // For match types: approximate with upper bound while evaluating the rhs.
+    val dummyInfo2 = rhs match {
+      case MatchTypeTree(bound, _, _) if !bound.isEmpty =>
+        abstracted(TypeBounds.upper(typedAheadType(bound).tpe))
+      case _ =>
+        dummyInfo1
+    }
+    sym.info = dummyInfo2
+
     val rhsBodyType = typedAheadType(rhs).tpe
     val rhsType = if (isDerived) rhsBodyType else abstracted(rhsBodyType)
     val unsafeInfo = rhsType.toBounds
@@ -1268,7 +1278,8 @@ class Namer { typer: Typer =>
       case _ =>
     }
     sym.normalizeOpaque()
-    ensureUpToDate(sym.typeRef, dummyInfo)
+    ensureUpToDate(sym.typeRef, dummyInfo1)
+    if (dummyInfo2 `ne` dummyInfo1) ensureUpToDate(sym.typeRef, dummyInfo2)
     ensureUpToDate(sym.typeRef.appliedTo(tparamSyms.map(_.typeRef)), TypeBounds.empty)
     sym.info
   }

--- a/tests/pos/i5650.scala
+++ b/tests/pos/i5650.scala
@@ -1,0 +1,11 @@
+sealed abstract class N
+trait Z extends N
+trait S[P] extends N
+
+object Test {
+  type T[X] <: N =
+    X match {
+      case Z => Z
+      case S[p] => T[p]
+    }
+}


### PR DESCRIPTION
Assume a match typedef is a subtype of its upper bound while typechecking
the right hand side.