### PR TITLE
Fix features links

### DIFF
--- a/docs/_includes/features.html
+++ b/docs/_includes/features.html
@@ -9,7 +9,7 @@
                 </colgroup>
                 <tbody>
                     <tr>
-                        <td><a href="http://dotty.epfl.ch/docs/reference/union-types.html">Union</a>, <a href="http://dotty.epfl.ch/docs/reference/intersection-types.html">intersection</a> and <a href="http://dotty.epfl.ch/docs/reference/singleton-types.html">literal singleton types</a></td>
+                        <td><a href="http://dotty.epfl.ch/docs/reference/new-types/union-types.html">Union</a>, <a href="http://dotty.epfl.ch/docs/reference/new-types/intersection-types.html">intersection</a> and <a href="http://dotty.epfl.ch/docs/reference/singleton-types.html">literal singleton types</a></td>
                         <td>Implemented</td>
                     </tr>
                     <tr>
@@ -25,23 +25,23 @@
                         <td>Implemented</td>
                     </tr>
                     <tr>
-                        <td><a href="http://dotty.epfl.ch/docs/reference/changed/pattern-matching.html">Option-less pattern matching</a></td>
+                        <td><a href="http://dotty.epfl.ch/docs/reference/changed-features/pattern-matching.html">Option-less pattern matching</a></td>
                         <td>Implemented</td>
                     </tr>
                     <tr>
-                        <td><a href="http://dotty.epfl.ch/docs/reference/auto-parameter-tupling.html">Automatic tupling of function parameters</a></td>
+                        <td><a href="http://dotty.epfl.ch/docs/reference/other-new-features/auto-parameter-tupling.html">Automatic tupling of function parameters</a></td>
                         <td>Implemented</td>
                     </tr>
                     <tr>
-                        <td><a href="http://dotty.epfl.ch/docs/reference/multiversal-equality.html">Multiversal equality</a></td>
+                        <td><a href="http://dotty.epfl.ch/docs/reference/other-new-features/multiversal-equality.html">Multiversal equality</a></td>
                         <td>Implemented</td>
                     </tr>
                     <tr>
-                        <td><a href="http://dotty.epfl.ch/docs/reference/implicit-function-types.html">Implicit function types</a></td>
+                        <td><a href="http://dotty.epfl.ch/docs/reference/new-types/implicit-function-types.html">Implicit function types</a></td>
                         <td>Implemented</td>
                     </tr>
                     <tr>
-                        <td><a href="http://dotty.epfl.ch/docs/reference/erased-terms.html">Erased Terms</a></td>
+                        <td><a href="http://dotty.epfl.ch/docs/reference/other-new-features/erased-terms.html">Erased Terms</a></td>
                         <td>In progress</td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Notes and suggestions:
 - The singleton-types link should probably be moved to the same level as intersection and union types
 - A link acknowledging the presence of even more features explained in the docs would be cool