### PR TITLE
Make Modifiers not extend from Positioned

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
+++ b/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
@@ -72,6 +72,7 @@ object NavigateAST {
       while (it.hasNext) {
         val path1 = it.next() match {
           case p: Positioned => singlePath(p, path)
+          case m: untpd.Modifiers => childPath(m.productIterator, path)
           case xs: List[_] => childPath(xs.iterator, path)
           case _ => path
         }

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -146,7 +146,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     flags: FlagSet = EmptyFlags,
     privateWithin: TypeName = tpnme.EMPTY,
     annotations: List[Tree] = Nil,
-    mods: List[Mod] = Nil) extends Positioned with Cloneable {
+    mods: List[Mod] = Nil) extends Cloneable {
 
     def is(fs: FlagSet): Boolean = flags is fs
     def is(fc: FlagConjunction): Boolean = flags is fc

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -732,7 +732,7 @@ object JavaParsers {
       val members = new ListBuffer[Tree]
       while (in.token != RBRACE && in.token != EOF) {
         val start = in.offset
-        var mods = atPos(start) { modifiers(inInterface) }
+        var mods = modifiers(inInterface)
         if (in.token == LBRACE) {
           skipAhead() // skip init block, we just assume we have seen only static
           accept(RBRACE)
@@ -895,7 +895,7 @@ object JavaParsers {
         while (in.token == SEMI) in.nextToken()
         if (in.token != EOF) {
           val start = in.offset
-          val mods = atPos(start) { modifiers(inInterface = false) }
+          val mods = modifiers(inInterface = false)
           buf ++= typeDecl(start, mods)
         }
       }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -265,7 +265,7 @@ class Namer { typer: Typer =>
   def createSymbol(tree: Tree)(implicit ctx: Context): Symbol = {
 
     def privateWithinClass(mods: Modifiers) =
-      enclosingClassNamed(mods.privateWithin, mods.pos)
+      enclosingClassNamed(mods.privateWithin, tree.pos)
 
     /** Check that flags are OK for symbol. This is done early to avoid
      *  catastrophic failure when we create a TermSymbol with TypeFlags, or vice versa.


### PR DESCRIPTION
Modifiers was made a subclass of Positioned since it contains elements that
are Positioned: source modifiers and annotations. That way, we got the navigation
logic to get to the elements for free. However, a lot of modifiers are synthetic,
and it seems artificial to give these a position. With the addition of a source
component to position the balance swings the other way. It now seems preferable
to have Modifiers not extend Positions and to consider Modifier as a as a separate
case for navigation instead.