### PR TITLE
Add tasty.reflect.utils

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/QuotedOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/QuotedOpsImpl.scala
@@ -48,4 +48,11 @@ trait QuotedOpsImpl extends scala.tasty.reflect.QuotedOps with CoreImpl {
       }
     }
   }
+
+  def TypeToQuoteDeco(tpe: Types.Type): TypeToQuotedAPI = new TypeToQuotedAPI {
+    def seal(implicit ctx: Context): quoted.Type[_] = {
+      val dummyPos = ctx.owner.pos // FIXME
+      new scala.quoted.Types.TreeType(tpd.TypeTree(tpe).withPos(dummyPos))
+    }
+  }
 }

--- a/compiler/src/dotty/tools/dotc/transform/Staging.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Staging.scala
@@ -174,8 +174,6 @@ class Staging extends MacroTransformWithImplicits {
         val rhs = transform(tag.select(tpnme.UNARY_~))
         val alias = ctx.typeAssigner.assignType(untpd.TypeBoundsTree(rhs, rhs), rhs, rhs)
 
-        val original = typeRef.symbol.asType
-
         val local = ctx.newSymbol(
           owner = ctx.owner,
           name = UniqueName.fresh("T".toTermName).toTypeName,

--- a/library/src-bootstrapped/scala/tasty/reflect/utils/TreeUtils.scala
+++ b/library/src-bootstrapped/scala/tasty/reflect/utils/TreeUtils.scala
@@ -1,0 +1,22 @@
+package scala.tasty
+package reflect.utils
+
+import scala.quoted._
+
+trait TreeUtils {
+
+  val reflect: Reflection
+  import reflect._
+
+  def let(rhs: Term)(in: Term.Ident => Term): Term = {
+    type T // TODO probably it is better to use the Sealed contruct rather than let the user create their own existential type
+    implicit val rhsTpe: quoted.Type[T] = rhs.tpe.seal.asInstanceOf[quoted.Type[T]]
+    val rhsExpr = rhs.seal[T]
+    val expr = '{
+      val x = ~rhsExpr
+      ~in(('(x)).unseal.asInstanceOf[Term.Ident]).seal[Any]
+    }
+    expr.unseal
+  }
+
+}

--- a/library/src-non-bootstrapped/scala/tasty/reflect/utils/TreeUtils.scala
+++ b/library/src-non-bootstrapped/scala/tasty/reflect/utils/TreeUtils.scala
@@ -1,0 +1,11 @@
+package scala.tasty
+package reflect.utils
+
+trait TreeUtils {
+
+  val reflect: Reflection
+  import reflect._
+
+  def let(rhs: Term)(in: Term.Ident => Term): Term = throw new Exception("non bootstrpped lib")
+
+}

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -21,10 +21,14 @@ abstract class Reflection
     with TreeOps
     with TreeUtils
     with TypeOrBoundsTreeOps
-    with TypeOrBoundsOps {
+    with TypeOrBoundsOps { self =>
 
   def typeOf[T: scala.quoted.Type]: Type =
     implicitly[scala.quoted.Type[T]].unseal.tpe
+
+  val util: reflect.utils.TreeUtils { val reflect: self.type } = new reflect.utils.TreeUtils {
+    val reflect: self.type = self
+  }
 }
 
 object Reflection {

--- a/library/src/scala/tasty/reflect/QuotedOps.scala
+++ b/library/src/scala/tasty/reflect/QuotedOps.scala
@@ -21,4 +21,9 @@ trait QuotedOps extends Core {
   }
   implicit def TermToQuoteDeco(term: Term): TermToQuotedAPI
 
+  trait TypeToQuotedAPI {
+    /** Convert `Type` to an `quoted.Type[T]` */
+    def seal(implicit ctx: Context): scala.quoted.Type[_]
+  }
+  implicit def TypeToQuoteDeco(tpe: Type): TypeToQuotedAPI
 }

--- a/tests/run-with-compiler/tasty-unsafe-let.check
+++ b/tests/run-with-compiler/tasty-unsafe-let.check
@@ -1,0 +1,7 @@
+1
+1
+null
+null
+foo
+bar
+bar

--- a/tests/run-with-compiler/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-with-compiler/tasty-unsafe-let/quoted_1.scala
@@ -1,0 +1,22 @@
+import scala.quoted._
+
+import scala.tasty._
+
+object Macros {
+
+  inline def let[T](rhs: T)(body: => T => Unit): Unit =
+    ~impl('(rhs), '(body))
+
+  private def impl[T](rhs: Expr[T], body: Expr[T => Unit])(implicit reflect: Reflection): Expr[Unit] = {
+    import reflect._
+
+    val rhsTerm = rhs.unseal
+
+    import reflect.util.{let => letTerm}
+    letTerm(rhsTerm) { rhsId =>
+      body(rhsId.seal[Any].asInstanceOf[Expr[T]]).unseal // Dangerous uncheked cast!
+    }.seal[Unit]
+  }
+
+
+}

--- a/tests/run-with-compiler/tasty-unsafe-let/quoted_2.scala
+++ b/tests/run-with-compiler/tasty-unsafe-let/quoted_2.scala
@@ -1,0 +1,17 @@
+
+import Macros._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    let(1)(x => { println(x); println(x) })
+    let(null)(x => { println(x); println(x) })
+    let {
+      println("foo")
+      "bar"
+    } { x =>
+      println(x)
+      println(x)
+    }
+  }
+
+}


### PR DESCRIPTION
With implementation of `def let(rhs: Term)(in: Term.Ident => Term): Term`.

---------------------------

This version allows sealing terms even if the type is not statically known while keeping the type safety guarantees on quoted expressions.

Added reflective `tpe` on `quoted.Expr[T]` to get its `quoted.Type[T]` even when `T` is just an existential type.

Added `asExprOf` to cast an `Expr[_]` to an `Expr[U]`. Fails if the expression is not a subtype of `U`.

---------------------------------

Use `asExprOf[T]` when needed.