### PR TITLE
Fix #5013: Check statement purity for adapted expressions of Unit

### DIFF
--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -157,8 +157,7 @@ final class FileZipArchive(jpath: JPath) extends ZipArchive(jpath) {
       while (entries.hasMoreElements) {
         val zipEntry = entries.nextElement
         val dir = getDir(dirs, zipEntry)
-        if (zipEntry.isDirectory) dir
-        else {
+        if (!zipEntry.isDirectory) {
           val f =
             if (ZipArchive.closeZipFile)
               new LazyEntry(

--- a/tests/neg-custom-args/fatal-warnings/i5013.scala
+++ b/tests/neg-custom-args/fatal-warnings/i5013.scala
@@ -1,0 +1,9 @@
+class Foo {
+
+  def foo1: Unit = 2 // error: A pure expression does nothing in statement position
+
+  def foo2: Unit = {
+    3 // error: A pure expression does nothing in statement position
+    4 // error: A pure expression does nothing in statement position
+  }
+}

--- a/tests/neg-custom-args/fatal-warnings/i5013b.scala
+++ b/tests/neg-custom-args/fatal-warnings/i5013b.scala
@@ -1,0 +1,16 @@
+class Foo {
+
+  val a: Int = 3
+
+  def b: 1 = {
+    println("1")
+    1
+  }
+
+  val c: Unit = ()
+
+  def foo1: Unit = a // error: A pure expression does nothing in statement position
+  def foo2: Unit = b
+  def foo3: Unit = c // Not addapted to { c; () } and hence c is not a statement
+
+}

--- a/tests/patmat/i4226.scala
+++ b/tests/patmat/i4226.scala
@@ -9,7 +9,7 @@ object Empty {
 object Test {
   val a: Maybe[Int] = Just(2)
   def main(args: Array[String]): Unit = a match {
-    case Just(2) => true
+    case Just(2) =>
     case Empty() =>
   }
 }

--- a/tests/patmat/i4226b.scala
+++ b/tests/patmat/i4226b.scala
@@ -9,7 +9,7 @@ object Empty {
 object Test {
   val a: Maybe[Int] = Just(2)
   def main(args: Array[String]): Unit = a match {
-    case Just(2) => true
+    case Just(2) =>
     case Empty() =>
   }
 }


### PR DESCRIPTION
```scala
def foo: Unit = 2 
```
is adapted to 
```scala
def foo: Unit = { 2; () } 
```

Hence the expression `2` is a statement and need to be handled as such.