### PR TITLE
Fix #5237: Do not list <xyz> in scala package completions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -80,7 +80,7 @@ class Definitions {
         denot.info = ClassInfo(ScalaPackageClass.thisType, cls, parents, paramDecls)
       }
     }
-    newClassSymbol(ScalaPackageClass, name, EmptyFlags, completer).entered
+    newClassSymbol(ScalaPackageClass, name, Artifact, completer).entered
   }
 
   /** The trait FunctionN, ImplicitFunctionN, ErasedFunctionN or ErasedImplicitFunction, for some N

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -240,7 +240,9 @@ object Completion {
      *   4. have an existing source symbol,
      *   5. are the module class in case of packages,
      *   6. are mutable accessors, to exclude setters for `var`,
-     *   7. have same term/type kind as name prefix given so far
+     *   7. symbol is not a package object
+     *   8. symbol is not an atifact of the compiler
+     *   9. have same term/type kind as name prefix given so far
      */
     private def include(sym: Symbol, nameInScope: Name)(implicit ctx: Context): Boolean =
       nameInScope.startsWith(prefix) &&
@@ -249,12 +251,12 @@ object Completion {
       sym.sourceSymbol.exists &&
       (!sym.is(Package) || !sym.moduleClass.exists) &&
       !sym.is(allOf(Mutable, Accessor)) &&
+      !sym.isPackageObject &&
+      !sym.is(Artifact) &&
       (
            (mode.is(Mode.Term) && sym.isTerm)
         || (mode.is(Mode.Type) && (sym.isType || sym.isStable))
-      ) &&
-      !sym.isPackageObject &&
-      !sym.is(Artifact)
+      )
 
     /**
      * Find all the members of `site` that are accessible and which should be included in `info`.

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -241,7 +241,7 @@ object Completion {
      *   5. are the module class in case of packages,
      *   6. are mutable accessors, to exclude setters for `var`,
      *   7. symbol is not a package object
-     *   8. symbol is not an atifact of the compiler
+     *   8. symbol is not an artifact of the compiler
      *   9. have same term/type kind as name prefix given so far
      */
     private def include(sym: Symbol, nameInScope: Name)(implicit ctx: Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -140,7 +140,7 @@ object Completion {
     private[this] val completions = new RenameAwareScope
 
     /**
-     * Return the list of symbols that shoudl be included in completion results.
+     * Return the list of symbols that should be included in completion results.
      *
      * If several symbols share the same name, the type symbols appear before term symbols inside
      * the same `Completion`.
@@ -252,7 +252,10 @@ object Completion {
       (
            (mode.is(Mode.Term) && sym.isTerm)
         || (mode.is(Mode.Type) && (sym.isType || sym.isStable))
-      )
+      ) &&
+      (sym ne defn.RepeatedParamClass) &&
+      (sym ne defn.ByNameParamClass2x) &&
+      (sym ne defn.EqualsPatternClass)
 
     /**
      * Find all the members of `site` that are accessible and which should be included in `info`.

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -253,6 +253,7 @@ object Completion {
            (mode.is(Mode.Term) && sym.isTerm)
         || (mode.is(Mode.Type) && (sym.isType || sym.isStable))
       ) &&
+      !sym.isPackageObject &&
       (sym ne defn.RepeatedParamClass) &&
       (sym ne defn.ByNameParamClass2x) &&
       (sym ne defn.EqualsPatternClass)

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -254,9 +254,7 @@ object Completion {
         || (mode.is(Mode.Type) && (sym.isType || sym.isStable))
       ) &&
       !sym.isPackageObject &&
-      (sym ne defn.RepeatedParamClass) &&
-      (sym ne defn.ByNameParamClass2x) &&
-      (sym ne defn.EqualsPatternClass)
+      !sym.is(Artifact)
 
     /**
      * Find all the members of `site` that are accessible and which should be included in `info`.

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -95,5 +95,6 @@ class TabcompleteTests extends ReplTest {
     val comp = tabComplete("import scala.")
     // check that there are no special symbols leaked: <byname>, <special-ops>, ...
     assertEquals(comp.find(_.startsWith("<")), None)
+    assert(!comp.contains("package"))
   }
 }

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -90,4 +90,10 @@ class TabcompleteTests extends ReplTest {
       val expected = List("Renamed")
       assertEquals(expected, tabComplete("val foo: Rena"))
     }
+
+  @Test def importScala = fromInitialState { implicit s =>
+    val comp = tabComplete("import scala.")
+    // check that there are no special symbols leaked: <byname>, <special-ops>, ...
+    assertEquals(comp.find(_.startsWith("<")), None)
+  }
 }


### PR DESCRIPTION
Do not recommend `<repeated>`, `<byname>`, `<equals>` and `package` as members of some package (namely the `scala` package).