### PR TITLE
Fix #4364: Try SAM type when no candidates are found

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -816,6 +816,8 @@ class Definitions {
   def SetterMetaAnnot(implicit ctx: Context): ClassSymbol = SetterMetaAnnotType.symbol.asClass
   lazy val ShowAsInfixAnotType: TypeRef = ctx.requiredClassRef("scala.annotation.showAsInfix")
   def ShowAsInfixAnnot(implicit ctx: Context): ClassSymbol = ShowAsInfixAnotType.symbol.asClass
+  lazy val FunctionalInterfaceAnnotType = ctx.requiredClassRef("java.lang.FunctionalInterface")
+  def FunctionalInterfaceAnnot(implicit ctx: Context) = FunctionalInterfaceAnnotType.symbol.asClass
 
   // convenient one-parameter method types
   def methOfAny(tp: Type): MethodType = MethodType(List(AnyType), tp)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1364,7 +1364,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
    *  Two trials: First, without implicits or SAM conversions enabled. Then,
    *  if the fist finds no eligible candidates, with implicits and SAM conversions enabled.
    */
-  def resolveOverloaded(alts: List[TermRef], pt: Type, pos: Position = NoPosition)(implicit ctx: Context): List[TermRef] = track("resolveOverloaded") {
+  def resolveOverloaded(alts: List[TermRef], pt: Type)(implicit ctx: Context): List[TermRef] = track("resolveOverloaded") {
 
     /** Is `alt` a method or polytype whose result type after the first value parameter
      *  section conforms to the expected type `resultType`? If `resultType`
@@ -1409,9 +1409,9 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       case _ => chosen
     }
 
-    var found = resolveOverloaded(alts, pt, Nil, pos)(ctx.retractMode(Mode.ImplicitsEnabled))
+    var found = resolveOverloaded(alts, pt, Nil)(ctx.retractMode(Mode.ImplicitsEnabled))
     if (found.isEmpty && ctx.mode.is(Mode.ImplicitsEnabled))
-      found = resolveOverloaded(alts, pt, Nil, pos)
+      found = resolveOverloaded(alts, pt, Nil)
     found match {
       case alt :: Nil => adaptByResult(alt) :: Nil
       case _ => found
@@ -1423,7 +1423,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
    *  called twice from the public `resolveOverloaded` method, once with
    *  implicits and SAM conversions enabled, and once without.
    */
-  private def resolveOverloaded(alts: List[TermRef], pt: Type, targs: List[Type], pos: Position)(implicit ctx: Context): List[TermRef] = track("resolveOverloaded") {
+  private def resolveOverloaded(alts: List[TermRef], pt: Type, targs: List[Type])(implicit ctx: Context): List[TermRef] = track("resolveOverloaded") {
 
     def isDetermined(alts: List[TermRef]) = alts.isEmpty || alts.tail.isEmpty
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2481,10 +2481,12 @@ class Typer extends Namer
           !tree.symbol.is(InlineMethod) &&
           !ctx.mode.is(Mode.Pattern) &&
           !(isSyntheticApply(tree) && !isExpandableApply)) {
-        if (!pt.classSymbol.hasAnnotation(defn.FunctionalInterfaceAnnot) &&
-            !defn.isFunctionType(pt) &&
-            SAMType.unapply(pt).isDefined)
-          ctx.warning(ex"${tree.symbol} is eta-expanded even though ${pt.classSymbol} does not have the @FunctionalInterface annotation.", tree.pos)
+        if (!defn.isFunctionType(pt))
+          pt match {
+            case SAMType(_) if !pt.classSymbol.hasAnnotation(defn.FunctionalInterfaceAnnot) =>
+              ctx.warning(ex"${tree.symbol} is eta-expanded even though $pt does not have the @FunctionalInterface annotation.", tree.pos)
+            case _ =>
+          }
         simplify(typed(etaExpand(tree, wtp, arity), pt), pt, locked)
       } else if (wtp.paramInfos.isEmpty && isAutoApplied(tree.symbol))
         readaptSimplified(tpd.Apply(tree, Nil))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2481,8 +2481,8 @@ class Typer extends Namer
           !tree.symbol.is(InlineMethod) &&
           !ctx.mode.is(Mode.Pattern) &&
           !(isSyntheticApply(tree) && !isExpandableApply)) {
-        if (!pt.classSymbol.hasAnnotation(defn.FunctionalInterfaceAnnot))
-          ctx.warning(ex"${tree.symbol} is eta-expanded even though $pt does not have the @FunctionalInterface annotation.", tree.pos)
+        if (!defn.isFunctionType(pt) && !pt.classSymbol.hasAnnotation(defn.FunctionalInterfaceAnnot))
+          ctx.warning(ex"${tree.symbol} is eta-expanded even though ${pt.classSymbol} does not have the @FunctionalInterface annotation.", tree.pos)
         simplify(typed(etaExpand(tree, wtp, arity), pt), pt, locked)
       } else if (wtp.paramInfos.isEmpty && isAutoApplied(tree.symbol))
         readaptSimplified(tpd.Apply(tree, Nil))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2268,7 +2268,7 @@ class Typer extends Namer
         val altDenots = ref.denot.alternatives
         typr.println(i"adapt overloaded $ref with alternatives ${altDenots map (_.info)}%, %")
         val alts = altDenots.map(TermRef(ref.prefix, ref.name, _))
-        resolveOverloaded(alts, pt) match {
+        resolveOverloaded(alts, pt, tree.pos) match {
           case alt :: Nil =>
             readaptSimplified(tree.withType(alt))
           case Nil =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2481,8 +2481,11 @@ class Typer extends Namer
           !tree.symbol.is(InlineMethod) &&
           !ctx.mode.is(Mode.Pattern) &&
           !(isSyntheticApply(tree) && !isExpandableApply)) {
-        if (!defn.isFunctionType(pt) && !pt.classSymbol.hasAnnotation(defn.FunctionalInterfaceAnnot))
-          ctx.warning(ex"${tree.symbol} is eta-expanded even though ${pt.classSymbol} does not have the @FunctionalInterface annotation.", tree.pos)
+        pt match {
+          case SAMType(_) if !defn.isFunctionType(pt) && !pt.classSymbol.hasAnnotation(defn.FunctionalInterfaceAnnot) =>
+            ctx.warning(ex"${tree.symbol} is eta-expanded even though ${pt.classSymbol} does not have the @FunctionalInterface annotation.", tree.pos)
+          case _ =>
+        }
         simplify(typed(etaExpand(tree, wtp, arity), pt), pt, locked)
       } else if (wtp.paramInfos.isEmpty && isAutoApplied(tree.symbol))
         readaptSimplified(tpd.Apply(tree, Nil))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2481,11 +2481,10 @@ class Typer extends Namer
           !tree.symbol.is(InlineMethod) &&
           !ctx.mode.is(Mode.Pattern) &&
           !(isSyntheticApply(tree) && !isExpandableApply)) {
-        pt match {
-          case SAMType(_) if !defn.isFunctionType(pt) && !pt.classSymbol.hasAnnotation(defn.FunctionalInterfaceAnnot) =>
-            ctx.warning(ex"${tree.symbol} is eta-expanded even though ${pt.classSymbol} does not have the @FunctionalInterface annotation.", tree.pos)
-          case _ =>
-        }
+        if (!pt.classSymbol.hasAnnotation(defn.FunctionalInterfaceAnnot) &&
+            !defn.isFunctionType(pt) &&
+            SAMType.unapply(pt).isDefined)
+          ctx.warning(ex"${tree.symbol} is eta-expanded even though ${pt.classSymbol} does not have the @FunctionalInterface annotation.", tree.pos)
         simplify(typed(etaExpand(tree, wtp, arity), pt), pt, locked)
       } else if (wtp.paramInfos.isEmpty && isAutoApplied(tree.symbol))
         readaptSimplified(tpd.Apply(tree, Nil))

--- a/tests/neg-custom-args/fatal-warnings/i4364.scala
+++ b/tests/neg-custom-args/fatal-warnings/i4364.scala
@@ -1,14 +1,9 @@
 object Test {
-  def foo(c: java.util.function.Consumer[String]) = c.accept("")
-
-  def f(x: String): Unit = ()
+  def foo(c: java.util.function.Consumer[Integer]) = c.accept(0)
   def f(x: Int): Unit = ()
 
   def main(args: Array[String]) = {
     foo(f) // Ok: Consumer is @FunctionalInterface
-
-    val oos = new java.io.ObjectOutputStream(f) // error: OutputStream is not @FunctionalInterface
-    oos.write(0)
-    oos.close()
+    new java.io.ObjectOutputStream(f) // error: OutputStream is not @FunctionalInterface
   }
 }

--- a/tests/neg-custom-args/fatal-warnings/i4364.scala
+++ b/tests/neg-custom-args/fatal-warnings/i4364.scala
@@ -1,0 +1,14 @@
+object Test {
+  def foo(c: java.util.function.Consumer[String]) = c.accept("")
+
+  def f(x: String): Unit = ()
+  def f(x: Int): Unit = ()
+
+  def main(args: Array[String]) = {
+    foo(f) // Ok: Consumer is @FunctionalInterface
+
+    val oos = new java.io.ObjectOutputStream(f) // error: OutputStream is not @FunctionalInterface
+    oos.write(0)
+    oos.close()
+  }
+}

--- a/tests/neg/i2033.scala
+++ b/tests/neg/i2033.scala
@@ -3,7 +3,7 @@ import collection._
 object Test {
   def check(obj: AnyRef): Unit = {
     val bos = new ByteArrayOutputStream()
-    val out = new ObjectOutputStream(println) // error
+    val out = new ObjectOutputStream(println)
     val arr = bos toByteArray ()
     val in = (())
     val deser = ()

--- a/tests/run/i4364a.scala
+++ b/tests/run/i4364a.scala
@@ -1,9 +1,11 @@
+import java.util.function.Consumer
+
 object Test {
   def f(): Unit = assert(false)
   def f(x: Int): Unit = assert(false)
   def f(x: String): Unit = ()
 
-  def foo(c: java.util.function.Consumer[String]) = c.accept("")
+  def foo(c: Consumer[String]) = c.accept("")
 
   def main(args: Array[String]) = {
     foo(f)

--- a/tests/run/i4364a.scala
+++ b/tests/run/i4364a.scala
@@ -1,0 +1,13 @@
+object Test {
+  var flag = false
+
+  def f(): Unit = assert(false)
+  def f(x: Int): Unit = assert(false)
+  def f(x: String): Unit = flag = true
+
+  def foo(c: java.util.function.Consumer[String]) = c.accept("")
+
+  def main(args: Array[String]) = {
+    foo(f)
+  }
+}

--- a/tests/run/i4364a.scala
+++ b/tests/run/i4364a.scala
@@ -1,9 +1,7 @@
 object Test {
-  var flag = false
-
   def f(): Unit = assert(false)
   def f(x: Int): Unit = assert(false)
-  def f(x: String): Unit = flag = true
+  def f(x: String): Unit = ()
 
   def foo(c: java.util.function.Consumer[String]) = c.accept("")
 

--- a/tests/run/i4364b.scala
+++ b/tests/run/i4364b.scala
@@ -1,13 +1,12 @@
+import java.util.function.Consumer
+
 object Test {
-  def f(x: Int): Unit = assert(false)
   def f(x: String): Unit = assert(false)
-  def f: java.io.OutputStream = new java.io.OutputStream {
-    def write(x: Int) = ()
-  }
+  def f: Consumer[String] = new Consumer { def accept(s: String) = () }
+
+  def foo(c: Consumer[String]) = c.accept("")
 
   def main(args: Array[String]) = {
-    val oos = new java.io.ObjectOutputStream(f)
-    oos.write(0)
-    oos.close()
+    foo(f)
   }
 }

--- a/tests/run/i4364b.scala
+++ b/tests/run/i4364b.scala
@@ -1,23 +1,13 @@
 object Test {
-  var flag = false
-
   def f(x: Int): Unit = assert(false)
   def f(x: String): Unit = assert(false)
   def f: java.io.OutputStream = new java.io.OutputStream {
     def write(x: Int) = ()
   }
 
-  def g(x: Int): Unit = flag = true
-  def g(x: String): Unit = assert(false)
-
   def main(args: Array[String]) = {
-    val oosF = new java.io.ObjectOutputStream(f)
-    oosF.write(0)
-    oosF.close()
-
-    val oosG = new java.io.ObjectOutputStream(g) // need warning
-    oosG.write(0)
-    oosG.close()
-    assert(flag)
+    val oos = new java.io.ObjectOutputStream(f)
+    oos.write(0)
+    oos.close()
   }
 }

--- a/tests/run/i4364b.scala
+++ b/tests/run/i4364b.scala
@@ -1,0 +1,23 @@
+object Test {
+  var flag = false
+
+  def f(x: Int): Unit = assert(false)
+  def f(x: String): Unit = assert(false)
+  def f: java.io.OutputStream = new java.io.OutputStream {
+    def write(x: Int) = ()
+  }
+
+  def g(x: Int): Unit = flag = true
+  def g(x: String): Unit = assert(false)
+
+  def main(args: Array[String]) = {
+    val oosF = new java.io.ObjectOutputStream(f)
+    oosF.write(0)
+    oosF.close()
+
+    val oosG = new java.io.ObjectOutputStream(g) // need warning
+    oosG.write(0)
+    oosG.close()
+    assert(flag)
+  }
+}


### PR DESCRIPTION
For overloading resolution, try a SAM type when no candidates are found.

Also, issue a warning when eta-expanding to a SAM type without a @FunctionalInterface 
annotation.

Based on #4821
