### PR TITLE
Decompiler: final, duplicate type args, default initialiser

### DIFF
--- a/library/src/scala/tasty/reflect/Printers.scala
+++ b/library/src/scala/tasty/reflect/Printers.scala
@@ -690,6 +690,7 @@ trait Printers
           val flags = vdef.symbol.flags
           if (flags.is(Flags.Implicit)) this += highlightKeyword("implicit ", color)
           if (flags.is(Flags.Override)) this += highlightKeyword("override ", color)
+          if (flags.is(Flags.Final) && !flags.is(Flags.Object)) this += highlightKeyword("final ", color)
 
           printProtectedOrPrivate(vdef)
 
@@ -739,6 +740,7 @@ trait Printers
           if (flags.is(Flags.Implicit)) this += highlightKeyword("implicit ", color)
           if (flags.is(Flags.Inline)) this += highlightKeyword("inline ", color)
           if (flags.is(Flags.Override)) this += highlightKeyword("override ", color)
+          if (flags.is(Flags.Final) && !flags.is(Flags.Object)) this += highlightKeyword("final ", color)
 
           printProtectedOrPrivate(ddef)
 

--- a/library/src/scala/tasty/reflect/Printers.scala
+++ b/library/src/scala/tasty/reflect/Printers.scala
@@ -761,6 +761,9 @@ trait Printers
           }
           this
 
+        case Term.Ident("_") =>
+          this += "_"
+
         case IsTerm(tree @ Term.Ident(_)) =>
           printType(tree.tpe)
 

--- a/library/src/scala/tasty/reflect/Printers.scala
+++ b/library/src/scala/tasty/reflect/Printers.scala
@@ -606,7 +606,6 @@ trait Printers
               printTypeTree(parent)
             case IsTerm(Term.TypeApply(fun, targs)) =>
               printParent(fun)
-              inSquare(printTypeOrBoundsTrees(targs, ", "))
             case IsTerm(Term.Apply(fun, args)) =>
               printParent(fun)
               inParens(printTrees(args, ", "))


### PR DESCRIPTION
- Added `final` flag to ValDef and DefDef
- Removed duplicate printing of type args in class hierarchy
- Properly handle default initialiser `_`