### PR TITLE
Fix assertion error in #5690

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -661,7 +661,7 @@ class ClassfileParser(
           val constr = ctx.newSymbol(
             owner = classRoot.symbol,
             name = nme.CONSTRUCTOR,
-            flags = Flags.Synthetic | Flags.JavaDefined,
+            flags = Flags.Synthetic | Flags.JavaDefined | Flags.Method,
             info = constrType
           ).entered
           for ((attr, i) <- attrs.zipWithIndex)

--- a/tests/pending/neg/i5690.scala
+++ b/tests/pending/neg/i5690.scala
@@ -1,0 +1,8 @@
+// instantiating java annotations should not be allowed 
+// (would fail at runtime with java.lang.InstantiationError)
+// see tests/pos/i5690.scala
+object AnnotInst{
+  def main(a: Array[String]) = {
+    new java.lang.annotation.Inherited // error
+  }
+}

--- a/tests/pos/i5690.scala
+++ b/tests/pos/i5690.scala
@@ -1,0 +1,8 @@
+// TODO: this should be a compilation error
+// program fails at runtime with java.lang.InstantiationError
+// see tests/pending/neg/i5690.scala
+object AnnotInst{
+  def main(a: Array[String]) = {
+    new java.lang.annotation.Inherited
+  }
+}


### PR DESCRIPTION
Fixes the assertion error in #5690 by adding the `Method` flag to java annotation constructors.
This makes the program compile, but fail at runtime with `java.lang.InstantiationError`.
The expected outcome is a compile error, so #5690 should be kept open.