### PR TITLE
Fix error in SemanticDbs

### DIFF
--- a/semanticdb/test/dotty/semanticdb/Semanticdbs.scala
+++ b/semanticdb/test/dotty/semanticdb/Semanticdbs.scala
@@ -82,7 +82,7 @@ object Semanticdbs {
   def printTextDocument(doc: s.TextDocument): String = {
     val sb = new StringBuilder
     val occurrences = doc.occurrences.sorted
-    val sourceFile = new SourceFile(doc.uri, doc.text)
+    val sourceFile = SourceFile.virtual(doc.uri, doc.text)
     var offset = 0
     occurrences.foreach { occ =>
       val range = occ.range.get


### PR DESCRIPTION
SemanticDbs was not updated to conform to the new SourceFile API, we got an error compiling it. This caused launchIDE to fail. I wonder why this was not discovered in the builds.
