### PR TITLE
Correct owner chains when mixing byname implicits and inlining

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -741,9 +741,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
         def traverse(tree: Tree)(implicit ctx: Context): Unit = {
           tree match {
             case _: DefTree => if(tree.symbol ne NoSymbol) localOwners += tree.symbol
-            case _ =>
+            case _ =>          traverseChildren(tree)
           }
-          traverseChildren(tree)
         }
       }
       traverser.traverse(tree)

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1577,7 +1577,7 @@ final class SearchRoot extends SearchHistory {
             val nrhss = rhss.map(rhsMap(_))
 
             val vdefs = (nsyms zip nrhss) map {
-              case (nsym, nrhs) => ValDef(nsym.asTerm, nrhs)
+              case (nsym, nrhs) => ValDef(nsym.asTerm, nrhs.changeNonLocalOwners(nsym))
             }
 
             val constr = ctx.newConstructor(classSym, Synthetic, Nil, Nil).entered

--- a/tests/pos/i5766.scala
+++ b/tests/pos/i5766.scala
@@ -1,0 +1,32 @@
+object Test1 {
+  trait Foo { def next: Foo }
+
+  inline implicit def foo(implicit loop: => Foo): Foo = new Foo { def next = loop }
+
+  def summon(implicit f: Foo) = ()
+  summon
+}
+
+object Test2 {
+  trait Foo { def next: Bar }
+  trait Bar { def next: Foo }
+
+  implicit def foo(implicit loop: => Bar): Foo = new Foo { def next = loop }
+  inline implicit def bar(implicit loop: Foo): Bar = new Bar { def next = loop }
+
+  def summon(implicit f: Foo) = ()
+  summon
+}
+
+object Test3 {
+  trait Foo { def next: Bar }
+  trait Bar { def next: Baz }
+  trait Baz { def next: Foo }
+
+  implicit def foo(implicit loop: Bar): Foo = new Foo { def next = loop }
+  inline implicit def bar(implicit loop: Baz): Bar = new Bar { def next = loop }
+  inline implicit def baz(implicit loop: => Foo): Baz = new Baz { def next = loop }
+
+  def summon(implicit f: Foo) = ()
+  summon
+}


### PR DESCRIPTION
When constructing the dictionary for a byname implicit resolution we have to ensure that the owners of any definitions which have been hoisted into the dictionary are correct. Prior to this PR this was only
done fully for implicit expansions which didn't involve inlining. We fix that here by ensuring that all definitions under a given dictionary entry are owned directly or indirectly by that dictionary entry.

Fixes #5766.