### PR TITLE
Fix #5794: eta-expansion triggered properly

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -756,7 +756,7 @@ class Typer extends Namer
       case _ => untpd.TypeTree(tp)
     }
     pt.stripTypeVar.dealias.followSyntheticOpaque match {
-      case pt1 if defn.isNonDepFunctionType(pt1) =>
+      case pt1 if defn.isNonRefinedFunction(pt1) =>
         // if expected parameter type(s) are wildcards, approximate from below.
         // if expected result type is a wildcard, approximate from above.
         // this can type the greatest set of admissible closures.
@@ -2528,7 +2528,7 @@ class Typer extends Namer
               ctx.warning(ex"${tree.symbol} is eta-expanded even though $pt does not have the @FunctionalInterface annotation.", tree.sourcePos)
             case _ =>
           }
-        simplify(typed(etaExpand(tree, wtp, arity), pt), pt, locked)
+          simplify(typed(etaExpand(tree, wtp, arity), pt), pt, locked)
       } else if (wtp.paramInfos.isEmpty && isAutoApplied(tree.symbol))
         readaptSimplified(tpd.Apply(tree, Nil))
       else if (wtp.isImplicitMethod)

--- a/tests/pos/i5794.scala
+++ b/tests/pos/i5794.scala
@@ -1,0 +1,5 @@
+object Test {
+  trait Entry { type Key; val key: Key }
+  def extractKey(e: Entry): e.Key = e.key
+  val extractor: (e: Entry) => e.Key = extractKey
+}


### PR DESCRIPTION
Previously eta-expansion was not triggered because the refined type-ness wasn't taken under-consideration in two places. 

- `functionArity` was prohibiting the necessary branch to be taken: solved after dropping the refinement
- `isNonDepFunctionType` wasn't checking whether the prototype was a refined type (also renamed method)
