### PR TITLE
sbt-dotty: fix "sbt doc" after the Java rewrite

### DIFF
--- a/sbt-bridge/src/xsbt/DottydocRunner.java
+++ b/sbt-bridge/src/xsbt/DottydocRunner.java
@@ -67,7 +67,7 @@ public class DottydocRunner {
         }
         return msg.toString();
       });
-      args = retained.toArray(args0);
+      args = retained.toArray(new String[retained.size()]);
     } else {
       args = args0;
     }


### PR DESCRIPTION
If args0 is bigger than retained, `retained.toArray(args0)` will fill
args0 with the elements of retained and fill the rest with `null`,
leading to an NPE later on. This was caught by the sbt scripted tests and
can be reproduced by running:

sbt-dotty/scripted sbt-dotty/example-project