### PR TITLE
Fix caching of TermRef

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -752,7 +752,7 @@ object Denotations {
 
     /** The TypeRef representing this type denotation at its original location. */
     def typeRef(implicit ctx: Context): TypeRef =
-      TypeRef(symbol.owner.thisType, symbol.name.asTypeName, this)
+      TypeRef(symbol.owner.thisType, symbol).withDenot(this)
 
     /** The typeRef applied to its own type parameters */
     def appliedRef(implicit ctx: Context): Type =
@@ -760,7 +760,7 @@ object Denotations {
 
     /** The TermRef representing this term denotation at its original location. */
     def termRef(implicit ctx: Context): TermRef =
-      TermRef(symbol.owner.thisType, symbol.name.asTermName, this)
+      TermRef(symbol.owner.thisType, symbol).withDenot(this)
 
     /** The NamedType representing this denotation at its original location.
      *  Same as either `typeRef` or `termRef` depending whether this denotes a type or not.


### PR DESCRIPTION
This commit fixes a bug found in implementing ScalaTest macros, where `findMember("===")` returns 3
difference single denotations, but `alternatives.map(_.termRef)` returns 3
types of which the last 2 are the same. This causes an assertion failure in overloading resolution.

Unfortunately we are unable to create a minimized test.