### PR TITLE
Fix for test 'repl\i5218' on Windows

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/Texts.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Texts.scala
@@ -117,7 +117,7 @@ object Texts {
       case _ =>
         var follow = false
         for (elem <- relems.reverse) {
-          if (follow) sb.append("\n")
+          if (follow) sb.append(System.lineSeparator)
           elem.print(sb, numberWidth)
           follow = true
         }

--- a/compiler/test/dotty/tools/repl/ScriptedTests.scala
+++ b/compiler/test/dotty/tools/repl/ScriptedTests.scala
@@ -60,16 +60,6 @@ class ScriptedTests extends ReplTest with MessageRendering {
         case nonEmptyLine => nonEmptyLine :: Nil
       }
 
-    def printOutput(prefix: String, output: String): Unit = {
-      val bytes = output.getBytes
-      println(prefix+
-        " (#chars="+output.length+
-        ", #CR="+(bytes.count(_ == 13))+
-        ", #LF="+(bytes.count(_ == 10))+
-        ") ========>"+EOL+
-        output.replaceAll("\r", "<CR>").replaceAll("\n", "<LF>"+EOL))
-    }
- 
     val expectedOutput =
       Source.fromFile(f, "UTF-8").getLines().flatMap(filterEmpties).mkString(EOL)
     val actualOutput = {
@@ -89,8 +79,10 @@ class ScriptedTests extends ReplTest with MessageRendering {
     }
 
     if (expectedOutput != actualOutput) {
-      printOutput("expected", expectedOutput)
-      printOutput("actual", actualOutput)
+      println("expected =========>")
+      println(expectedOutput)
+      println("actual ===========>")
+      println(actualOutput)
 
       fail(s"Error in file $f, expected output did not match actual")
     }

--- a/compiler/test/dotty/tools/repl/ScriptedTests.scala
+++ b/compiler/test/dotty/tools/repl/ScriptedTests.scala
@@ -62,7 +62,7 @@ class ScriptedTests extends ReplTest with MessageRendering {
 
     def printOutput(prefix: String, output: String): Unit = {
       val bytes = output.getBytes
-	  println(prefix+
+      println(prefix+
         " (#chars="+output.length+
         ", #CR="+(bytes.count(_ == 13))+
         ", #LF="+(bytes.count(_ == 10))+

--- a/compiler/test/dotty/tools/repl/ScriptedTests.scala
+++ b/compiler/test/dotty/tools/repl/ScriptedTests.scala
@@ -60,6 +60,16 @@ class ScriptedTests extends ReplTest with MessageRendering {
         case nonEmptyLine => nonEmptyLine :: Nil
       }
 
+    def printOutput(prefix: String, output: String): Unit = {
+      val bytes = output.getBytes
+	  println(prefix+
+        " (#chars="+output.length+
+        ", #CR="+(bytes.count(_ == 13))+
+        ", #LF="+(bytes.count(_ == 10))+
+        ") ========>"+EOL+
+        output.replaceAll("\r", "<CR>").replaceAll("\n", "<LF>"+EOL))
+    }
+ 
     val expectedOutput =
       Source.fromFile(f, "UTF-8").getLines().flatMap(filterEmpties).mkString(EOL)
     val actualOutput = {
@@ -79,10 +89,8 @@ class ScriptedTests extends ReplTest with MessageRendering {
     }
 
     if (expectedOutput != actualOutput) {
-      println("expected =========>")
-      println(expectedOutput)
-      println("actual ===========>")
-      println(actualOutput)
+      printOutput("expected", expectedOutput)
+      printOutput("actual", actualOutput)
 
       fail(s"Error in file $f, expected output did not match actual")
     }

--- a/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
+++ b/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
@@ -3,7 +3,7 @@ package tools
 package vulpix
 
 import java.io.{ File => JFile, InputStreamReader, BufferedReader, PrintStream }
-import java.nio.file.Paths;
+import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.TimeoutException
 
@@ -156,10 +156,9 @@ trait RunnerOrchestration {
      *  scala library.
      */
     private def createProcess: Process = {
-      val sep = JFile.separator
       val url = classOf[ChildJVMMain].getProtectionDomain.getCodeSource.getLocation
       val cp = Paths.get(url.toURI).toString + JFile.pathSeparator + Properties.scalaLibrary
-      val javaBin = sys.props("java.home") + sep + "bin" + sep + "java"
+      val javaBin = Paths.get(sys.props("java.home"), "bin", "java").toString
       new ProcessBuilder(javaBin, "-Dfile.encoding=UTF-8", "-Xmx1g", "-cp", cp, "dotty.tools.vulpix.ChildJVMMain")
         .redirectErrorStream(true)
         .redirectInput(ProcessBuilder.Redirect.PIPE)


### PR DESCRIPTION
Output prior to change is:
```scala
[info] Test run started
[info] Test dotty.tools.repl.ScriptedTests.replTests started
expected =========>
scala> val tuple = (1, "2", 3L)
val tuple: (Int, String, Long) = (1,2,3)
scala> 0.0 *: tuple
val res0: Double *: (Int, String, Long)(tuple) = (0.0,1,2,3)
scala> tuple ++ tuple
val res1: Int *: String *: Long *:
  scala.Tuple.Concat[Unit, (Int, String, Long)(tuple)] = (1,2,3,1,2,3)
actual ===========>
scala> val tuple = (1, "2", 3L)
val tuple: (Int, String, Long) = (1,2,3)
scala> 0.0 *: tuple
val res0: Double *: (Int, String, Long)(tuple) = (0.0,1,2,3)
scala> tuple ++ tuple
val res1: Int *: String *: Long *:
  scala.Tuple.Concat[Unit, (Int, String, Long)(tuple)] = (1,2,3,1,2,3)
[error] Test dotty.tools.repl.ScriptedTests.replTests failed: java.lang.AssertionError: Error in file W:\dotty-replTests\compiler\target\scala-2.12\test-classes\repl\i5218, expected output did not match actual, took 2.024 sec
[error]     at dotty.tools.repl.ScriptedTests.testFile(ScriptedTests.scala:87)
[error]     at dotty.tools.repl.ScriptedTests.$anonfun$replTests$1(ScriptedTests.scala:91)
[error]     at dotty.tools.repl.ScriptedTests.$anonfun$replTests$1$adapted(ScriptedTests.scala:91)
[error]     at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
[error]     at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
[error]     at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
[error]     at dotty.tools.repl.ScriptedTests.replTests(ScriptedTests.scala:91)
[error]     ...
[info] Test dotty.tools.repl.ScriptedTests.typePrinterTests started
[info] Test run finished: 1 failed, 0 ignored, 2 total, 3.158s
```

With the addition of method `printOutput` in file `test\dotty\tools\repl\ScriptedTests.scala` we can see the issue with `repl\i5218` on Windows (missing carriage return character on the second-last line):
```scala
[info] Test run started
[info] Test dotty.tools.repl.ScriptedTests.replTests started
expected (#chars=287, #CR=6, #LF=6) ========>
scala> val tuple = (1, "2", 3L)<CR><LF>
val tuple: (Int, String, Long) = (1,2,3)<CR><LF>
scala> 0.0 *: tuple<CR><LF>
val res0: Double *: (Int, String, Long)(tuple) = (0.0,1,2,3)<CR><LF>
scala> tuple ++ tuple<CR><LF>
val res1: Int *: String *: Long *:<CR><LF>
  scala.Tuple.Concat[Unit, (Int, String, Long)(tuple)] = (1,2,3,1,2,3)
actual (#chars=286, #CR=5, #LF=6) ========>
scala> val tuple = (1, "2", 3L)<CR><LF>
val tuple: (Int, String, Long) = (1,2,3)<CR><LF>
scala> 0.0 *: tuple<CR><LF>
val res0: Double *: (Int, String, Long)(tuple) = (0.0,1,2,3)<CR><LF>
scala> tuple ++ tuple<CR><LF>
val res1: Int *: String *: Long *:<LF>
  scala.Tuple.Concat[Unit, (Int, String, Long)(tuple)] = (1,2,3,1,2,3)
[error] Test dotty.tools.repl.ScriptedTests.replTests failed: java.lang.AssertionError: Error in file W:\dotty-replTests\compiler\target\scala-2.12\test-classes\repl\i5218, expected output did not match actual, took 2.1 sec
[error]     at dotty.tools.repl.ScriptedTests.testFile(ScriptedTests.scala:94)
[error]     at dotty.tools.repl.ScriptedTests.$anonfun$replTests$1(ScriptedTests.scala:98)
[error]     at dotty.tools.repl.ScriptedTests.$anonfun$replTests$1$adapted(ScriptedTests.scala:98)
[error]     at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
[error]     at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
[error]     at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
[error]     at dotty.tools.repl.ScriptedTests.replTests(ScriptedTests.scala:98)
[error]     ...
[info] Test dotty.tools.repl.ScriptedTests.typePrinterTests started
[info] Test run finished: 1 failed, 0 ignored, 2 total, 3.305s
```
In summary :
- The **fix** is located in file `src\dotty\tools\dotc\printing\Texts.scala`
- Method `printOutput` in file `test\dotty\tools\repl\ScriptedTests.scala` allows us to detect the issue with `repl\i5218`
- Change in file `test\dotty\tools\vulpix\RunnerOrchestration.scala` is a small code improvement (not related to the issue).

