### PR TITLE
Fix #4539: Add missing `'[` in canStartExpressionTokens

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -212,7 +212,7 @@ object Tokens extends TokensCommon {
     USCORE, NULL, THIS, SUPER, TRUE, FALSE, RETURN, XMLSTART)
 
   final val canStartExpressionTokens: TokenSet = atomicExprTokens | BitSet(
-    LBRACE, LPAREN, QBRACE, QPAREN, IF, DO, WHILE, FOR, NEW, TRY, THROW)
+    LBRACE, LPAREN, QBRACE, QPAREN, QBRACKET, IF, DO, WHILE, FOR, NEW, TRY, THROW)
 
   final val canStartTypeTokens: TokenSet = literalTokens | identifierTokens | BitSet(
     THIS, SUPER, USCORE, LPAREN, AT)

--- a/compiler/test-resources/repl/i4539
+++ b/compiler/test-resources/repl/i4539
@@ -1,0 +1,7 @@
+scala> val a = '[Int]
+val a: quoted.Type[Int] = Type(Int)
+scala> '[Int]
+val res0: quoted.Type[Int] = Type(Int)
+scala> '[Int]; '[Int]
+val res1: quoted.Type[Int] = Type(Int)
+val res2: quoted.Type[Int] = Type(Int)

--- a/tests/pos/i4539.scala
+++ b/tests/pos/i4539.scala
@@ -1,0 +1,4 @@
+object Foo {
+  val q = '[String]
+  '[String]
+}

--- a/tests/pos/i4539b.scala
+++ b/tests/pos/i4539b.scala
@@ -1,0 +1,21 @@
+object Foo {
+  def f = {
+    {
+      '[String]
+      '[String]
+    }
+
+    '[String] match { case _ => }
+    try '[String] catch { case _ => }
+
+    '[String]
+    '[String]
+  }
+
+  def bar[T](t: quoted.Type[T]) = ???
+  bar('[String])
+
+  class Baz[T](t: quoted.Type[T])
+  new Baz('[String])
+
+}


### PR DESCRIPTION
Previously `'[` was not always handled as the start of an expression. Note that `'[T]` is an expression (not a type).