### PR TITLE
Try fixing compile error in docs

### DIFF
--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -68,6 +68,7 @@ sidebar:
             - title: Kind Polymorphism
               url: docs/reference/other-new-features/kind-polymorphism.html
         - title: New Implicits
+          subsection:
             - title: Instance Definitions
               url: docs/reference/instances/instance-defs.html
             - title: Context Parameters


### PR DESCRIPTION
Error: http://dotty-ci.epfl.ch/lampepfl/dotty/10144/6.
Fixed by following nearby examples — and `genDocs` now works locally.