### PR TITLE
Fix #5773: Apply more context info to avoid ambiguous implicits

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -104,6 +104,6 @@ object Mode {
   /** Read comments from definitions when unpickling from TASTY */
   val ReadComments: Mode = newMode(22, "ReadComments")
 
-  /** Suppress insertion of apply or implicit conversion on qualifier */
-  val FixedQualifier: Mode = newMode(23, "FixedQualifier")
+  /** We are synthesizing the receiver of an extension method */
+  val SynthesizeExtMethodReceiver: Mode = newMode(23, "SynthesizeExtMethodReceiver")
 }

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1227,7 +1227,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
   /** Defer constraining type variables when compared against prototypes */
   def isMatchedByProto(proto: ProtoType, tp: Type): Boolean = tp.stripTypeVar match {
     case tp: TypeParamRef if constraint contains tp => true
-    case _ => proto.isMatchedBy(tp)
+    case _ => proto.isMatchedBy(tp, keepConstraint = true)
   }
 
   /** Narrow gadt.bounds for the type parameter referenced by `tr` to include

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1665,7 +1665,7 @@ object Types {
 
   /** A trait for proto-types, used as expected types in typer */
   trait ProtoType extends Type {
-    def isMatchedBy(tp: Type)(implicit ctx: Context): Boolean
+    def isMatchedBy(tp: Type, keepConstraint: Boolean = false)(implicit ctx: Context): Boolean
     def fold[T](x: T, ta: TypeAccumulator[T])(implicit ctx: Context): T
     def map(tm: TypeMap)(implicit ctx: Context): ProtoType
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -524,7 +524,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
         case result: AmbiguousImplicits =>
           "Ambiguous Implicit: " ~ toText(result.alt1.ref) ~ " and " ~ toText(result.alt2.ref)
         case _ =>
-          "?Unknown Implicit Result?" + result.getClass
+          "Search Failure: " ~ toText(result.tree)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -300,7 +300,7 @@ object messages {
     val explanation: String = ""
   }
 
-  case class NotAMember(site: Type, name: Name, selected: String)(implicit ctx: Context)
+  case class NotAMember(site: Type, name: Name, selected: String, addendum: String = "")(implicit ctx: Context)
   extends Message(NotAMemberID) {
     val kind: String = "Member Not Found"
 
@@ -360,7 +360,7 @@ object messages {
         )
       }
 
-      ex"$selected $name is not a member of ${site.widen}$closeMember"
+      ex"$selected $name is not a member of ${site.widen}$closeMember$addendum"
     }
 
     val explanation: String = ""

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -799,7 +799,9 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
        *  part. Return an optional value to indicate success.
        */
       def tryWithImplicitOnQualifier(fun1: Tree, proto: FunProto)(implicit ctx: Context): Option[Tree] =
-        if (ctx.mode.is(Mode.FixedQualifier)) None
+        if (ctx.mode.is(Mode.SynthesizeExtMethodReceiver))
+          // Suppress insertion of apply or implicit conversion on extension method receiver
+          None
         else
           tryInsertImplicitOnQualifier(fun1, proto, ctx.typerState.ownedVars) flatMap { fun2 =>
             tryEither {
@@ -1691,7 +1693,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
     }
     val app =
       typed(untpd.Apply(core, untpd.TypedSplice(receiver) :: Nil), pt1, ctx.typerState.ownedVars)(
-        ctx.addMode(Mode.FixedQualifier))
+        ctx.addMode(Mode.SynthesizeExtMethodReceiver))
     if (!app.symbol.is(Extension))
       ctx.error(em"not an extension method: $methodRef", receiver.sourcePos)
     app

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -277,10 +277,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
     private[this] var _ok = true
 
     def ok: Boolean = _ok
-    def ok_=(x: Boolean): Unit = {
-      assert(x || ctx.reporter.errorsReported || !ctx.typerState.isCommittable) // !!! DEBUG
-      _ok = x
-    }
+    def ok_=(x: Boolean): Unit = _ok = x
 
     /** The function's type after widening and instantiating polytypes
      *  with TypeParamRefs in constraint set
@@ -1118,8 +1115,11 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
   /** Is given method reference applicable to type arguments `targs` and argument trees `args`?
    *  @param  resultType   The expected result type of the application
    */
-  def isApplicable(methRef: TermRef, targs: List[Type], args: List[Tree], resultType: Type)(implicit ctx: Context): Boolean =
-    ctx.test(implicit ctx => new ApplicableToTrees(methRef, targs, args, resultType).success)
+  def isApplicable(methRef: TermRef, targs: List[Type], args: List[Tree], resultType: Type, keepConstraint: Boolean)(implicit ctx: Context): Boolean = {
+    def isApp(implicit ctx: Context): Boolean =
+      new ApplicableToTrees(methRef, targs, args, resultType).success
+    if (keepConstraint) isApp else ctx.test(implicit ctx => isApp)
+  }
 
   /** Is given method reference applicable to type arguments `targs` and argument trees `args` without inferring views?
     *  @param  resultType   The expected result type of the application
@@ -1137,8 +1137,8 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
    *  possibly after inserting an `apply`?
    *  @param  resultType   The expected result type of the application
    */
-  def isApplicable(tp: Type, targs: List[Type], args: List[Tree], resultType: Type)(implicit ctx: Context): Boolean =
-    onMethod(tp, isApplicable(_, targs, args, resultType))
+  def isApplicable(tp: Type, targs: List[Type], args: List[Tree], resultType: Type, keepConstraint: Boolean)(implicit ctx: Context): Boolean =
+    onMethod(tp, isApplicable(_, targs, args, resultType, keepConstraint))
 
   /** Is given type applicable to argument types `args`, possibly after inserting an `apply`?
    *  @param  resultType   The expected result type of the application
@@ -1491,7 +1491,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
           )
           if (alts2.isEmpty && !ctx.isAfterTyper)
             alts.filter(alt =>
-              isApplicable(alt, targs, args, resultType)
+              isApplicable(alt, targs, args, resultType, keepConstraint = false)
             )
           else
             alts2
@@ -1511,14 +1511,14 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
         }
 
       case pt @ PolyProto(targs1, pt1) if targs.isEmpty =>
-        val alts1 = alts filter pt.isMatchedBy
+        val alts1 = alts.filter(pt.isMatchedBy(_))
         resolveOverloaded(alts1, pt1, targs1.tpes)
 
       case defn.FunctionOf(args, resultType, _, _) =>
         narrowByTypes(alts, args, resultType)
 
       case pt =>
-        val compat = alts.filter(normalizedCompatible(_, pt))
+        val compat = alts.filter(normalizedCompatible(_, pt, keepConstraint = false))
         if (compat.isEmpty)
           /*
            * the case should not be moved to the enclosing match

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -93,7 +93,9 @@ object Implicits {
         def viewCandidateKind(tpw: Type, argType: Type, resType: Type): Candidate.Kind = {
 
           def methodCandidateKind(mt: MethodType, approx: Boolean) =
-            if (!mt.isImplicitMethod &&
+            if (mt.isImplicitMethod)
+              viewCandidateKind(normalize(mt, pt), argType, resType)
+            else if (!mt.isImplicitMethod &&
                 mt.paramInfos.lengthCompare(1) == 0 && {
                   var formal = widenSingleton(mt.paramInfos.head)
                   if (approx) formal = wildApprox(formal)

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -304,11 +304,13 @@ object ProtoTypes {
      *                  with unknown parameter types - this will then cause a
      *                  "missing parameter type" error
      */
-    private def typedArgs(force: Boolean): List[Tree] = {
-      if (state.typedArgs.size != args.length)
-        state.typedArgs = args.mapconserve(cacheTypedArg(_, typer.typed(_), force))
-      state.typedArgs
-    }
+    private def typedArgs(force: Boolean): List[Tree] =
+      if (state.typedArgs.size == args.length) state.typedArgs
+      else {
+        val args1 = args.mapconserve(cacheTypedArg(_, typer.typed(_), force))
+        if (!args1.contains(WildcardType)) state.typedArgs = args1
+        args1
+      }
 
     def typedArgs: List[Tree] = typedArgs(force = true)
     def unforcedTypedArgs: List[Tree] = typedArgs(force = false)

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -107,7 +107,7 @@ object ProtoTypes {
   /** A class marking ignored prototypes that can be revealed by `deepenProto` */
   case class IgnoredProto(ignored: Type) extends UncachedGroundType with MatchAlways {
     override def revealIgnored = ignored.revealIgnored
-    override def deepenProto(implicit ctx: Context): Type = ignored
+    override def deepenProto(implicit ctx: Context): Type = ignored.deepenProto
   }
 
   /** A prototype for expressions [] that are part of a selection operation:

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -107,7 +107,7 @@ object ProtoTypes {
   /** A class marking ignored prototypes that can be revealed by `deepenProto` */
   case class IgnoredProto(ignored: Type) extends UncachedGroundType with MatchAlways {
     override def revealIgnored = ignored.revealIgnored
-    override def deepenProto(implicit ctx: Context): Type = ignored.deepenProto
+    override def deepenProto(implicit ctx: Context): Type = ignored
   }
 
   /** A prototype for expressions [] that are part of a selection operation:

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -75,7 +75,7 @@ object Typer {
    */
   private val DroppedEmptyArgs = new Property.Key[Unit]
 
-  /** Am attachment that indicates a failed conversion or extension method
+  /** An attachment that indicates a failed conversion or extension method
    *  search was tried on a tree. This will in some cases be reported in error messages
    */
   private[typer] val HiddenSearchFailure = new Property.Key[SearchFailure]

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2398,7 +2398,7 @@ class Typer extends Namer
     }
 
     /** Reveal ignored parts of prototype when synthesizing the receiver
-     *  of an extension method. This is necessary for pos/i5773.scala
+     *  of an extension method. This is necessary for pos/i5773a.scala
      */
     def revealProtoOfExtMethod(tp: Type)(implicit ctx: Context): Type =
       if (ctx.mode.is(Mode.SynthesizeExtMethodReceiver)) tp.deepenProto

--- a/tests/neg/i5773.scala
+++ b/tests/neg/i5773.scala
@@ -20,7 +20,7 @@ object Main {
   def f1 = {
     println(1 appendS 2) // error This should give the following error message:
 /*
-21 |    println(1 appendS 2) // error This should give the following error message:
+21 |    println(1 appendS 2)
    |            ^^^^^^^^^
    |value appendS is not a member of Int.
    |An extension method was tried, but could not be fully constructed:

--- a/tests/neg/i5773.scala
+++ b/tests/neg/i5773.scala
@@ -1,0 +1,32 @@
+trait Semigroup[T] {
+  def (lhs: T) append (rhs: T): T
+}
+
+object Semigroup {
+  implicit object stringAppend extends Semigroup[String] {
+    override def (lhs: String) append (rhs: String): String = lhs + rhs
+  }
+
+  implicit def sumSemigroup[N](implicit N: Numeric[N]): Semigroup[N] = new {
+    override def (lhs: N) append (rhs: N): N = ??? // N.plus(lhs, rhs)
+  }
+
+  implicit class SumSemigroupDeco[N](implicit N: Numeric[N]) extends Semigroup[N] {
+    override def (lhs: N) append (rhs: N): N = ??? // N.plus(lhs, rhs)
+  }
+}
+
+
+object Main {
+  import Semigroup.sumSemigroup // this is not sufficient
+  def f1 = {
+    import Semigroup.stringAppend // necessary to make the extension method visible
+    println("Hi" append " mum") // ok
+    println(1 append 2) // error: this won't compile
+  }
+
+  def f2 = {
+    implicit val intSumAppend: Semigroup[Int] = sumSemigroup[Int]
+    println(3 append 4) // this will
+  }
+}

--- a/tests/neg/i5773.scala
+++ b/tests/neg/i5773.scala
@@ -1,5 +1,6 @@
 trait Semigroup[T] {
   def (lhs: T) append (rhs: T): T
+  def (lhs: Int) appendS (rhs: T): T = ???
 }
 
 object Semigroup {
@@ -8,11 +9,8 @@ object Semigroup {
   }
 
   implicit def sumSemigroup[N](implicit N: Numeric[N]): Semigroup[N] = new {
-    override def (lhs: N) append (rhs: N): N = ??? // N.plus(lhs, rhs)
-  }
-
-  implicit class SumSemigroupDeco[N](implicit N: Numeric[N]) extends Semigroup[N] {
-    override def (lhs: N) append (rhs: N): N = ??? // N.plus(lhs, rhs)
+    override def (lhs: N) append (rhs: N): N = N.plus(lhs, rhs)
+    def (lhs: Int) appendS (rhs: N): N = ??? // N.plus(lhs, rhs)
   }
 }
 
@@ -20,13 +18,15 @@ object Semigroup {
 object Main {
   import Semigroup.sumSemigroup // this is not sufficient
   def f1 = {
-    import Semigroup.stringAppend // necessary to make the extension method visible
-    println("Hi" append " mum") // ok
-    println(1 append 2) // error: this won't compile
-  }
-
-  def f2 = {
-    implicit val intSumAppend: Semigroup[Int] = sumSemigroup[Int]
-    println(3 append 4) // this will
+    println(1 appendS 2) // error This should give the following error message:
+/*
+21 |    println(1 appendS 2) // error This should give the following error message:
+   |            ^^^^^^^^^
+   |value appendS is not a member of Int.
+   |An extension method was tried, but could not be fully constructed:
+   |
+   |    Semigroup.sumSemigroup[Any](/* ambiguous */implicitly[Numeric[Any]]).appendS()
+one error found
+*/
   }
 }

--- a/tests/pos/i5773.scala
+++ b/tests/pos/i5773.scala
@@ -11,23 +11,26 @@ object Semigroup {
     override def (lhs: N) append (rhs: N): N = ??? // N.plus(lhs, rhs)
   }
 
-  implicit class SumSemigroupDeco[N](implicit N: Numeric[N]) extends Semigroup[N] {
+  implicit class SumSemiGroupDeco[N](implicit N: Numeric[N]) extends Semigroup[N] {
     override def (lhs: N) append (rhs: N): N = ??? // N.plus(lhs, rhs)
   }
 }
-
 
 object Main {
   import Semigroup.sumSemigroup // this is not sufficient
   def f1 = {
     import Semigroup.stringAppend // necessary to make the extension method visible
-    println("Hi" append " mum") // ok
-    //sumSemigroup.apply(1)(2)
-    println(1 append 2) // error: this won't compile
+    println("Hi" append " mum")
+    println(1 append 2)
   }
 
   def f2 = {
     implicit val intSumAppend: Semigroup[Int] = sumSemigroup[Int]
-    println(3 append 4) // this will
+    println(3 append 4) 
+  }
+
+  def f3 = {
+    import Semigroup.SumSemiGroupDeco
+    sumSemigroup.append(1)(2)
   }
 }

--- a/tests/pos/i5773.scala
+++ b/tests/pos/i5773.scala
@@ -1,0 +1,33 @@
+trait Semigroup[T] {
+  def (lhs: T) append (rhs: T): T
+}
+
+object Semigroup {
+  implicit object stringAppend extends Semigroup[String] {
+    override def (lhs: String) append (rhs: String): String = lhs + rhs
+  }
+
+  implicit def sumSemigroup[N](implicit N: Numeric[N]): Semigroup[N] = new {
+    override def (lhs: N) append (rhs: N): N = ??? // N.plus(lhs, rhs)
+  }
+
+  implicit class SumSemigroupDeco[N](implicit N: Numeric[N]) extends Semigroup[N] {
+    override def (lhs: N) append (rhs: N): N = ??? // N.plus(lhs, rhs)
+  }
+}
+
+
+object Main {
+  import Semigroup.sumSemigroup // this is not sufficient
+  def f1 = {
+    import Semigroup.stringAppend // necessary to make the extension method visible
+    println("Hi" append " mum") // ok
+    //sumSemigroup.apply(1)(2)
+    println(1 append 2) // error: this won't compile
+  }
+
+  def f2 = {
+    implicit val intSumAppend: Semigroup[Int] = sumSemigroup[Int]
+    println(3 append 4) // this will
+  }
+}

--- a/tests/pos/i5773a.scala
+++ b/tests/pos/i5773a.scala
@@ -1,0 +1,17 @@
+trait Semigroup[T] {
+  def (x: T) combine (y: T): T
+}
+object Test {
+  implicit val IntSemigroup: Semigroup[Int] = new {
+    def (x: Int) combine (y: Int): Int = x + y
+  }
+  implicit def OptionSemigroup[T: Semigroup]: Semigroup[Option[T]] = new {
+    def (x: Option[T]) combine (y: Option[T]): Option[T] = for {
+      x0 <- x
+      y0 <- y
+    } yield x0.combine(y0)
+  }
+  1.combine(2)
+  Some(1).combine(Some(2))
+  Option(1) combine Option(2)
+}


### PR DESCRIPTION
In the absence of a proper fix for #5773 (which is problematic since it would affect implicit search oder),
we still can give a better error message.

EDIT: We now have a full fix, but it's still good to have the better error messages.