### PR TITLE
Fix #4453: Avoid adding type bindings in getVariables

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1440,7 +1440,7 @@ object desugar {
     val buf = new ListBuffer[VarInfo]
     def seenName(name: Name) = buf exists (_._1.name == name)
     def add(named: NameTree, t: Tree): Unit =
-      if (!seenName(named.name)) buf += ((named, t))
+      if (!seenName(named.name) && named.name.isTermName) buf += ((named, t))
     def collect(tree: Tree): Unit = tree match {
       case Bind(nme.WILDCARD, tree1) =>
         collect(tree1)

--- a/tests/neg/i4453.scala
+++ b/tests/neg/i4453.scala
@@ -1,0 +1,2 @@
+class x0 { var x0 == _ * // error: _* can be used only for last argument // error: == cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method
+// error '=' expected, but eof found


### PR DESCRIPTION
getVariables is used when desugaring `val/var/lazy val pat = e` but after other errors
`pat` may contain a type name.