### PR TITLE
An alternative fix to #5808

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1074,7 +1074,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           case _ => 0
         }
         var allAlts = denot.alternatives
-          .map(_.termRef).filter(tr => typeParamCount(tr) == targs.length)
+          .map(denot => TermRef(receiver.tpe, denot.symbol))
+          .filter(tr => typeParamCount(tr) == targs.length)
         if (targs.isEmpty) allAlts = allAlts.filterNot(_.widen.isInstanceOf[PolyType])
         val alternatives = ctx.typer.resolveOverloaded(allAlts, proto)
         assert(alternatives.size == 1,
@@ -1084,10 +1085,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           i"matching alternatives: ${alternatives.map(_.symbol.showDcl).mkString(", ")}.") // this is parsed from bytecode tree. there's nothing user can do about it
         alternatives.head
       }
-      else denot.asSingleDenotation.termRef
-    val fun = receiver
-      .select(TermRef(receiver.tpe, selected.termSymbol.asTerm))
-      .appliedToTypes(targs)
+      else TermRef(receiver.tpe, denot.symbol)
+    val fun = receiver.select(selected).appliedToTypes(targs)
 
     val apply = untpd.Apply(fun, args)
     new typer.ApplyToTyped(apply, fun, selected, args, expectedType).result.asInstanceOf[Tree] // needed to handle varargs

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -748,26 +748,6 @@ object Denotations {
       if (matches) this else NoDenotation
     }
 
-    // ------ Forming types -------------------------------------------
-
-    /** The TypeRef representing this type denotation at its original location. */
-    def typeRef(implicit ctx: Context): TypeRef =
-      TypeRef(symbol.owner.thisType, symbol).withDenot(this)
-
-    /** The typeRef applied to its own type parameters */
-    def appliedRef(implicit ctx: Context): Type =
-      typeRef.appliedTo(symbol.typeParams.map(_.typeRef))
-
-    /** The TermRef representing this term denotation at its original location. */
-    def termRef(implicit ctx: Context): TermRef =
-      TermRef(symbol.owner.thisType, symbol).withDenot(this)
-
-    /** The NamedType representing this denotation at its original location.
-     *  Same as either `typeRef` or `termRef` depending whether this denotes a type or not.
-     */
-    def namedType(implicit ctx: Context): NamedType =
-      if (isType) typeRef else termRef
-
     // ------ Transformations -----------------------------------------
 
     private[this] var myValidFor: Period = Nowhere

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1233,11 +1233,21 @@ object SymDenotations {
     /** The type This(cls), where cls is this class, NoPrefix for all other symbols */
     def thisType(implicit ctx: Context): Type = NoPrefix
 
-    override def typeRef(implicit ctx: Context): TypeRef =
+    def typeRef(implicit ctx: Context): TypeRef =
       TypeRef(owner.thisType, symbol)
 
-    override def termRef(implicit ctx: Context): TermRef =
+    def termRef(implicit ctx: Context): TermRef =
       TermRef(owner.thisType, symbol)
+
+    /** The typeRef applied to its own type parameters */
+    def appliedRef(implicit ctx: Context): Type =
+      typeRef.appliedTo(symbol.typeParams.map(_.typeRef))
+
+    /** The NamedType representing this denotation at its original location.
+     *  Same as either `typeRef` or `termRef` depending whether this denotes a type or not.
+     */
+    def namedType(implicit ctx: Context): NamedType =
+      if (isType) typeRef else termRef
 
     /** The variance of this type parameter or type member as an Int, with
      *  +1 = Covariant, -1 = Contravariant, 0 = Nonvariant, or not a type parameter


### PR DESCRIPTION
An alternative fix to #5808, which is potentially problematic.

The fix restricts that we only call `.termRef` and `.typeRef` on
`SymDenotation`.