### PR TITLE
Add sourceCode to TASTy reflect Position

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/PositionOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/PositionOpsImpl.scala
@@ -15,5 +15,7 @@ trait PositionOpsImpl extends scala.tasty.reflect.PositionOps with CoreImpl {
 
     def startColumn: Int = pos.startColumn
     def endColumn: Int = pos.endColumn
+
+    def sourceCode: String = new String(pos.source.content(), pos.start, pos.end - pos.start)
   }
 }

--- a/library/src/scala/tasty/reflect/PositionOps.scala
+++ b/library/src/scala/tasty/reflect/PositionOps.scala
@@ -26,6 +26,9 @@ trait PositionOps extends Core {
     /** The end column in the source file */
     def endColumn: Int
 
+    /** Source code within the position */
+    def sourceCode: String
+
   }
   implicit def PositionDeco(pos: Position): PositionAPI
 

--- a/tests/run/tasty-original-source.check
+++ b/tests/run/tasty-original-source.check
@@ -1,0 +1,3 @@
+(foo("abc"),abc)
+(foo(  "def"  ),def)
+(foo("ghi" /* comment */),ghi)

--- a/tests/run/tasty-original-source/Macros_1.scala
+++ b/tests/run/tasty-original-source/Macros_1.scala
@@ -1,0 +1,14 @@
+import scala.quoted._
+import scala.tasty._
+
+object Macros {
+
+  implicit inline def withSource(arg: Any): (String, Any) = ~impl('(arg))
+
+  private def impl(arg: Expr[Any])(implicit reflect: Reflection): Expr[(String, Any)] = {
+    import reflect._
+    val source = arg.unseal.underlyingArgument.pos.sourceCode.toString.toExpr
+    '(Tuple2(~source, ~arg))
+  }
+
+}

--- a/tests/run/tasty-original-source/Test_2.scala
+++ b/tests/run/tasty-original-source/Test_2.scala
@@ -1,0 +1,13 @@
+
+import Macros._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    println(withSource(foo("abc")))
+    println(withSource( foo(  "def"  )))
+    println(withSource(foo("ghi" /* comment */)))
+  }
+
+  def foo(x: Any): Any = x
+
+}


### PR DESCRIPTION
Partial fix for #5782:
* get the ~raw code of arguments of the root context (in `def foo(s: Seq[Int])(implicit foo: Foo)`, with the implicit materialization of `Foo` backed by a macro - how can the macro get a String `"(1 to 10).sum"` in `f((1 to 10).sum)`?). Prevents to have `sourcecode.Text` work fine.