### PR TITLE
Fix some broken links in documentation

### DIFF
--- a/docs/docs/reference/changed-features/eta-expansion.md
+++ b/docs/docs/reference/changed-features/eta-expansion.md
@@ -35,7 +35,7 @@ rather than `next _`.
 The reason for excluding nullary methods from automatic eta expansion
 is that Scala implicitly inserts the `()` argument, which would
 conflict with eta expansion. Automatic `()` insertion is
-[limited](../dropped/auto-apply.md) in Dotty, but the fundamental ambiguity
+[limited](../dropped-features/auto-apply.md) in Dotty, but the fundamental ambiguity
 remains.
 
 [More details](eta-expansion-spec.html)

--- a/docs/docs/reference/dropped-features/early-initializers.md
+++ b/docs/docs/reference/dropped-features/early-initializers.md
@@ -8,4 +8,4 @@ Early initializers of the form
     class C extends { ... } with SuperClass ...
 
 have been dropped. They were rarely used, and mostly to compensate for the lack of
-[trait parameters](../trait-parameters.md), which are now directly supported in Dotty.
+[trait parameters](../other-new-features/trait-parameters.md), which are now directly supported in Dotty.

--- a/docs/docs/reference/other-new-features/inline.md
+++ b/docs/docs/reference/other-new-features/inline.md
@@ -3,7 +3,7 @@ layout: doc-page
 title: Inline
 ---
 
-`inline` is a new [soft modifier](./soft-modifier.html) that guarantees that a definition will be inline at the point of use. Example:
+`inline` is a new [soft modifier](../soft-modifier.html) that guarantees that a definition will be inline at the point of use. Example:
 
     object Config {
       inline val logging = false

--- a/docs/docs/reference/other-new-features/principled-meta-programming.md
+++ b/docs/docs/reference/other-new-features/principled-meta-programming.md
@@ -624,7 +624,7 @@ and adding quoted variants `'(...)`, `'{...}` and `'[...]` to the
                           |  ‘'’ ‘[’ Type ‘]’
 
 Syntax changes are given relative to the [Dotty reference
-grammar](../internal/syntax.md).
+grammar](../../internals/syntax.md).
 
 An alternative syntax would treat `'` as a separate operator. This
 would be attractive since it enables quoting single identifiers as
@@ -764,7 +764,7 @@ environments and terms.
                            Es |- 't: expr T
 
 The meta theory of a slightly simplified variant 2-stage variant of this calculus
-is studied [separately](simple-smp.md).
+is studied [separately](../simple-smp.md).
 
 ## Going Further
 


### PR DESCRIPTION
Hi,
while reading the documentation I found some broken links.

https://www.brokenlinkcheck.com/ revealed even more.

This fixes some of this links, but more are still broken:
- the prominent Implicit function types in the feature list of the index page
- some links in blog posts

Kind regards,
Jentsch
