### PR TITLE
Add `updateCheckFiles` to override tests check files with output

### DIFF
--- a/compiler/test/dotc/comptest.scala
+++ b/compiler/test/dotc/comptest.scala
@@ -11,6 +11,7 @@ object comptest extends ParallelTesting {
   def safeMode = false
   def isInteractive = true
   def testFilter = None
+  def updateCheckFiles: Boolean = false
 
   val posDir = "./tests/pos/"
   val negDir = "./tests/neg/"

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -20,6 +20,9 @@ object Properties {
    */
   val testsFilter: Option[String] = sys.props.get("dotty.tests.filter")
 
+  /** Tests should override the checkfiles with the current output */
+  val testsUpdateCheckfile: Boolean = propIsNullOrTrue("dotty.tests.updateCheckfiles")
+
   /** When set, the run tests are only compiled - not run, a warning will be
    *  issued
    */

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -7,13 +7,8 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.experimental.categories.Category
 
-import java.nio.file._
-import java.util.stream.{ Stream => JStream }
-import scala.collection.JavaConverters._
-import scala.util.matching.Regex
 import scala.concurrent.duration._
 import vulpix._
-import dotty.tools.io.JFile
 
 @Category(Array(classOf[BootstrappedOnlyTests]))
 class BootstrappedOnlyCompilationTests extends ParallelTesting {
@@ -28,6 +23,7 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive
   def testFilter = Properties.testsFilter
+  def updateCheckFiles: Boolean = Properties.testsUpdateCheckfile
 
   // Positive tests ------------------------------------------------------------
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -303,7 +303,7 @@ class CompilationTests extends ParallelTesting {
 }
 
 object CompilationTests {
-  implicit val summaryReport: SummaryReporting = new SummaryReport
+  implicit val summaryReport: SummaryReporting = new SummaryReport(updateCheckFiles = false)
   @AfterClass def cleanup(): Unit = summaryReport.echoSummary()
 
   def sources(paths: JStream[Path], excludedFiles: List[String] = Nil): List[String] = {

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -27,6 +27,7 @@ class CompilationTests extends ParallelTesting {
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive
   def testFilter = Properties.testsFilter
+  def updateCheckFiles: Boolean = Properties.testsUpdateCheckfile
 
   // Positive tests ------------------------------------------------------------
 
@@ -303,7 +304,7 @@ class CompilationTests extends ParallelTesting {
 }
 
 object CompilationTests {
-  implicit val summaryReport: SummaryReporting = new SummaryReport(updateCheckFiles = false)
+  implicit val summaryReport: SummaryReporting = new SummaryReport
   @AfterClass def cleanup(): Unit = summaryReport.echoSummary()
 
   def sources(paths: JStream[Path], excludedFiles: List[String] = Nil): List[String] = {

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -51,6 +51,6 @@ class FromTastyTests extends ParallelTesting {
 }
 
 object FromTastyTests {
-  implicit val summaryReport: SummaryReporting = new SummaryReport
+  implicit val summaryReport: SummaryReporting = new SummaryReport(updateCheckFiles = false)
   @AfterClass def cleanup(): Unit = summaryReport.echoSummary()
 }

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -20,7 +20,7 @@ class FromTastyTests extends ParallelTesting {
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive
   def testFilter = Properties.testsFilter
-
+  def updateCheckFiles: Boolean = Properties.testsUpdateCheckfile
 
   @Test def posTestFromTasty: Unit = {
     // Can be reproduced with
@@ -51,6 +51,6 @@ class FromTastyTests extends ParallelTesting {
 }
 
 object FromTastyTests {
-  implicit val summaryReport: SummaryReporting = new SummaryReport(updateCheckFiles = false)
+  implicit val summaryReport: SummaryReporting = new SummaryReport
   @AfterClass def cleanup(): Unit = summaryReport.echoSummary()
 }

--- a/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
+++ b/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
@@ -72,6 +72,6 @@ class IdempotencyTests extends ParallelTesting {
 }
 
 object IdempotencyTests {
-  implicit val summaryReport: SummaryReporting = new SummaryReport
+  implicit val summaryReport: SummaryReporting = new SummaryReport(updateCheckFiles = false)
   @AfterClass def cleanup(): Unit = summaryReport.echoSummary()
 }

--- a/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
+++ b/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
@@ -24,6 +24,7 @@ class IdempotencyTests extends ParallelTesting {
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive
   def testFilter = Properties.testsFilter
+  def updateCheckFiles: Boolean = Properties.testsUpdateCheckfile
 
   @Category(Array(classOf[SlowTests]))
   @Test def idempotency: Unit = {
@@ -72,6 +73,6 @@ class IdempotencyTests extends ParallelTesting {
 }
 
 object IdempotencyTests {
-  implicit val summaryReport: SummaryReporting = new SummaryReport(updateCheckFiles = false)
+  implicit val summaryReport: SummaryReporting = new SummaryReport
   @AfterClass def cleanup(): Unit = summaryReport.echoSummary()
 }

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -1391,7 +1391,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
             |Test '$title' compiled with $errors error(s) and $warnings warning(s),
             |the test can be reproduced by running:
             |
-            |  sbt "testFromTasty $file"
+            |  sbt "testCompilation --from-tasty $file"
             |
             |This tests can be disabled by adding `${file.getName}` to `compiler${JFile.separator}test${JFile.separator}dotc${JFile.separator}$runOrPos-$listName.blacklist`
             |

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -46,6 +46,9 @@ trait ParallelTesting extends RunnerOrchestration { self =>
    */
   def testFilter: Option[String]
 
+  /** Tests should override the checkfiles with the current output */
+  def updateCheckFiles: Boolean
+
   /** A test source whose files or directory of files is to be compiled
    *  in a specific way defined by the `Test`
    */
@@ -550,7 +553,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
 
                     if (output.mkString(EOL) != check) {
                       val outFile = dotty.tools.io.File(checkFile.toPath).addExtension(".out")
-                      if (summaryReport.updateCheckFiles) {
+                      if (updateCheckFiles) {
                         updateCheckFile(checkFile, output)
                       } else {
                         outFile.writeAll(output.mkString("", EOL, ""))
@@ -642,7 +645,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
             // Fail target:
             failTestSource(testSource)
 
-            if (summaryReport.updateCheckFiles)
+            if (updateCheckFiles)
               updateCheckFile(checkFile.get, outputLines)
           }
         }
@@ -781,7 +784,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
           val expexted = Source.fromFile(checkFile, "UTF-8").getLines().toList
           for (msg <- diffMessage(sourceName, actual, expexted)) {
             fail(msg)
-            if (summaryReport.updateCheckFiles)
+            if (updateCheckFiles)
               updateCheckFile(checkFile, actual)
           }
         }

--- a/compiler/test/dotty/tools/vulpix/SummaryReport.scala
+++ b/compiler/test/dotty/tools/vulpix/SummaryReport.scala
@@ -40,6 +40,9 @@ trait SummaryReporting {
 
   /** Echoes contents of `it` to file *immediately* then flushes */
   def echoToLog(it: Iterator[String]): Unit
+
+  /** Echoes outputs of the test into the thier checkfiles */
+  def updateCheckFiles: Boolean
 }
 
 /** A summary report that doesn't do anything */
@@ -53,12 +56,13 @@ final class NoSummaryReport extends SummaryReporting {
   def echoSummary(): Unit = ()
   def echoToLog(msg: String): Unit = ()
   def echoToLog(it: Iterator[String]): Unit = ()
+  def updateCheckFiles: Boolean = false
 }
 
 /** A summary report that logs to both stdout and the `TestReporter.logWriter`
  *  which outputs to a log file in `./testlogs/`
  */
-final class SummaryReport extends SummaryReporting {
+final class SummaryReport(val updateCheckFiles: Boolean) extends SummaryReporting {
   import scala.collection.JavaConverters._
 
   private val startingMessages = new java.util.concurrent.ConcurrentLinkedDeque[String]

--- a/compiler/test/dotty/tools/vulpix/SummaryReport.scala
+++ b/compiler/test/dotty/tools/vulpix/SummaryReport.scala
@@ -41,8 +41,6 @@ trait SummaryReporting {
   /** Echoes contents of `it` to file *immediately* then flushes */
   def echoToLog(it: Iterator[String]): Unit
 
-  /** Echoes outputs of the test into the thier checkfiles */
-  def updateCheckFiles: Boolean
 }
 
 /** A summary report that doesn't do anything */
@@ -62,7 +60,7 @@ final class NoSummaryReport extends SummaryReporting {
 /** A summary report that logs to both stdout and the `TestReporter.logWriter`
  *  which outputs to a log file in `./testlogs/`
  */
-final class SummaryReport(val updateCheckFiles: Boolean) extends SummaryReporting {
+final class SummaryReport extends SummaryReporting {
   import scala.collection.JavaConverters._
 
   private val startingMessages = new java.util.concurrent.ConcurrentLinkedDeque[String]

--- a/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
@@ -4,7 +4,6 @@ package vulpix
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import scala.concurrent.duration._
-import dotty.Properties
 import TestConfiguration._
 
 /** Meta tests for the Vulpix test suite. This test follows the structure of
@@ -19,8 +18,9 @@ class VulpixMetaTests extends ParallelTesting {
   def safeMode = false // Don't fork a new VM after each run test
   def isInteractive = false // Don't beautify output for interactive use.
   def testFilter = None // Run all the tests.
+  def updateCheckFiles: Boolean = false
 
-  implicit val summaryReport: SummaryReporting = new SummaryReport(updateCheckFiles = false)
+  implicit val summaryReport: SummaryReporting = new SummaryReport
   implicit def testGroup: TestGroup = TestGroup("VulpixMetaTests")
 
   @Test def compilePos: Unit = compileFilesInDir("tests/vulpix-tests/meta/pos", defaultOptions).checkCompile()

--- a/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
@@ -20,7 +20,7 @@ class VulpixMetaTests extends ParallelTesting {
   def isInteractive = false // Don't beautify output for interactive use.
   def testFilter = None // Run all the tests.
 
-  implicit val summaryReport: SummaryReporting = new SummaryReport
+  implicit val summaryReport: SummaryReporting = new SummaryReport(updateCheckFiles = false)
   implicit def testGroup: TestGroup = TestGroup("VulpixMetaTests")
 
   @Test def compilePos: Unit = compileFilesInDir("tests/vulpix-tests/meta/pos", defaultOptions).checkCompile()

--- a/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
@@ -21,6 +21,7 @@ class VulpixUnitTests extends ParallelTesting {
   def safeMode = sys.env.get("SAFEMODE").isDefined
   def isInteractive = !sys.env.contains("DRONE")
   def testFilter = None
+  def updateCheckFiles: Boolean = false
 
   // To fail with something else than an AssertionError
   def fail(): Unit = throw new Exception("didn't fail properly")

--- a/docs/docs/contributing/testing.md
+++ b/docs/docs/contributing/testing.md
@@ -92,3 +92,15 @@ To run `testCompilation` on a bootstrapped Dotty compiler, use
 `dotty-compiler-bootstrapped/testCompilation` (with the same syntax as above).
 Some tests can only be run in bootstrapped compilers; that includes all tests
 with `with-compiler` in their name.
+
+### From TASTy tests
+
+`testCompilation` has a additional mode to run tests that compile code from a `.tasty` file, decompile a `.tasty` file and recompile the decompiled tasty.
+ Modify blacklist and whitelists in `compiler/test/dotc` to enable or disable tests from `.tasty` files.
+
+ ```bash
+ $ sbt
+ > testCompilation --from-tasty
+ ```
+ 
+ This mode can be combined with `--update-checkfiles` to update the `.decompiled` files or can be run under `dotty-compiler-bootstrapped/testCompilation` to test on a bootstrapped Dotty compiler. 

--- a/docs/docs/contributing/testing.md
+++ b/docs/docs/contributing/testing.md
@@ -80,6 +80,12 @@ This will run both the test `./tests/pos/companions.scala` and
 `./tests/neg/companions.scala` since both of these match the given string.
 This also means that you could run `testCompilation` with no arguments to run all integration tests.
 
+When complex checkfiles must be updated, `testCompilation` can run in a mode where it overrides the checkfiles with the test outputs.
+```bash
+$ sbt
+> testCompilation --update-checkfiles
+```
+
 ### Bootstrapped-only tests
 
 To run `testCompilation` on a bootstrapped Dotty compiler, use

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -440,10 +440,11 @@ object Build {
 
   def testOnlyFiltered(test: String, options: String) = Def.inputTaskDyn {
     val args = spaceDelimited("<arg>").parsed
-    val cmd = s" $test -- $options" + {
-      if (args.nonEmpty) " -Ddotty.tests.filter=" + args.mkString(" ")
-      else ""
-    }
+    val updateCheckfile = args.contains("--update-checkfiles")
+    val args1 = if (updateCheckfile) args.filter(_ != "--update-checkfiles") else args
+    val cmd = s" $test -- $options" +
+      (if (updateCheckfile) " -Ddotty.tests.updateCheckfiles=true" else "") +
+      (if (args1.nonEmpty) " -Ddotty.tests.filter=" + args1.mkString(" ") else "")
     (testOnly in Test).toTask(cmd)
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -85,9 +85,6 @@ object Build {
   // Run tests with filter through vulpix test suite
   val testCompilation = inputKey[Unit]("runs integration test with the supplied filter")
 
-  // Run TASTY tests with filter through vulpix test suite
-  val testFromTasty = inputKey[Unit]("runs tasty integration test with the supplied filter")
-
   // Spawns a repl with the correct classpath
   val repl = inputKey[Unit]("run the REPL with correct classpath")
 
@@ -438,16 +435,6 @@ object Build {
     case Bootstrapped => `dotty-doc-bootstrapped`
   }
 
-  def testOnlyFiltered(test: String, options: String) = Def.inputTaskDyn {
-    val args = spaceDelimited("<arg>").parsed
-    val updateCheckfile = args.contains("--update-checkfiles")
-    val args1 = if (updateCheckfile) args.filter(_ != "--update-checkfiles") else args
-    val cmd = s" $test -- $options" +
-      (if (updateCheckfile) " -Ddotty.tests.updateCheckfiles=true" else "") +
-      (if (args1.nonEmpty) " -Ddotty.tests.filter=" + args1.mkString(" ") else "")
-    (testOnly in Test).toTask(cmd)
-  }
-
   def findLib(attList: Seq[Attributed[File]], name: String) = attList
     .map(_.data.getAbsolutePath)
     .find(_.contains(name))
@@ -548,8 +535,17 @@ object Build {
         jarOpts ::: tuning ::: agentOptions ::: ci_build
       },
 
-      testCompilation := testOnlyFiltered("dotty.tools.dotc.*CompilationTests", "--exclude-categories=dotty.SlowTests").evaluated,
-      testFromTasty := testOnlyFiltered("dotty.tools.dotc.FromTastyTests", "").evaluated,
+      testCompilation := Def.inputTaskDyn {
+        val args = spaceDelimited("<arg>").parsed
+        val updateCheckfile = args.contains("--update-checkfiles")
+        val fromTasty = args.contains("--from-tasty")
+        val args1 = if (updateCheckfile | fromTasty) args.filter(x => x != "--update-checkfiles" && x != "--from-tasty") else args
+        val test = if (fromTasty) "dotty.tools.dotc.FromTastyTests" else "dotty.tools.dotc.*CompilationTests"
+        val cmd = s" $test -- --exclude-categories=dotty.SlowTests" +
+          (if (updateCheckfile) " -Ddotty.tests.updateCheckfiles=true" else "") +
+          (if (args1.nonEmpty) " -Ddotty.tests.filter=" + args1.mkString(" ") else "")
+        (testOnly in Test).toTask(cmd)
+      }.evaluated,
 
       dotr := {
         val args: List[String] = spaceDelimited("<arg>").parsed.toList

--- a/tests/pos/classWithCompObj.decompiled
+++ b/tests/pos/classWithCompObj.decompiled
@@ -1,3 +1,2 @@
-/** Decompiled from out/posTestFromTasty/pos/classWithCompObj/Foo.class */
 class Foo()
 object Foo

--- a/tests/pos/conforms.decompiled
+++ b/tests/pos/conforms.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/conforms/Test.class */
 object Test {
   def f[A, B](x: A)(implicit e: scala.Predef.<:<[A, B]): B = e.apply(x)
 }

--- a/tests/pos/i0306.decompiled
+++ b/tests/pos/i0306.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/i0306/bar.class */
 object bar {
   class C[T <: scala.Seq[_ >: scala.Nothing <: scala.Any]]()
   val x: scala.AnyRef = new bar.C[scala.collection.Seq[_ >: scala.Nothing <: scala.Any]]()

--- a/tests/pos/i1181.decompiled
+++ b/tests/pos/i1181.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/i1181/Test.class */
 object Test {
   def foo[M[_$1]](x: M[scala.Int]): M[scala.Int] = x
   type Alias[A] = scala.Tuple2[A, A]

--- a/tests/pos/i1444.decompiled
+++ b/tests/pos/i1444.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/i1444/Test.class */
 object Test {
   class Cls(implicit x: Test.X)
   class ClsImpl() extends Test.Cls()(Test.AnX)

--- a/tests/pos/i1570.decompiled
+++ b/tests/pos/i1570.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/i1570/Test.class */
 object Test {
   inline def foo(n: scala.Int): scala.Int = Test.bar(n)
   inline def bar(n: scala.Int): scala.Int = n

--- a/tests/pos/i2104b.decompiled
+++ b/tests/pos/i2104b.decompiled
@@ -1,10 +1,8 @@
-/** Decompiled from out/posTestFromTasty/pos/i2104b/Cons.tasty */
 trait Cons[+H, +T]() extends java.lang.Object
 object Cons {
   def apply[H, T](h: H, t: T): Cons[H, T] = scala.Predef.???
   def unapply[H, T](t: Cons[H, T]): scala.Option[Pair[H, T]] = scala.Predef.???
 }
-/** Decompiled from out/posTestFromTasty/pos/i2104b/Pair.tasty */
 case class Pair[A, B](_1: A, _2: B) {
   override def hashCode(): scala.Int = {
     var acc: scala.Int = 2479866
@@ -32,7 +30,6 @@ case class Pair[A, B](_1: A, _2: B) {
   }
 }
 object Pair extends scala.AnyRef
-/** Decompiled from out/posTestFromTasty/pos/i2104b/Test.tasty */
 object Test {
   def main(args: scala.Array[scala.Predef.String]): scala.Unit = Cons.apply[scala.Option[scala.Int], scala.None.type](scala.Option.apply[scala.Int](1), scala.None) match {
     case Cons(scala.Some(i), scala.None) =>

--- a/tests/pos/i4526-2.decompiled
+++ b/tests/pos/i4526-2.decompiled
@@ -1,2 +1,1 @@
-/** Decompiled from out/posTestFromTasty/pos/i4526-2/Foo.class */
 class Foo(x: scala.Int, y: scala.Int)

--- a/tests/pos/i4526a.decompiled
+++ b/tests/pos/i4526a.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/i4526a/bar/Foo.class */
 package bar {
   class Foo() {
     protected[bar] def foo(): scala.Int = 0

--- a/tests/pos/i4526b.decompiled
+++ b/tests/pos/i4526b.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/i4526b/Foo.class */
 class Foo() {
   def justdoit(f: scala.Either[scala.Int, scala.Predef.String]): scala.Predef.String = f match {
     case scala.Left(i) =>

--- a/tests/pos/i4678.decompiled
+++ b/tests/pos/i4678.decompiled
@@ -1,14 +1,8 @@
-/** Decompiled from out/posTestFromTasty/pos/i4678/Foo.tasty */
 class Foo() {
   val x: scala.Int = (1: @annot1 @annot2 @annot3 @annot4 @annot5)
 }
-/** Decompiled from out/posTestFromTasty/pos/i4678/annot1.tasty */
 class annot1() extends scala.annotation.Annotation
-/** Decompiled from out/posTestFromTasty/pos/i4678/annot2.tasty */
 class annot2() extends scala.annotation.Annotation
-/** Decompiled from out/posTestFromTasty/pos/i4678/annot3.tasty */
 class annot3() extends scala.annotation.Annotation
-/** Decompiled from out/posTestFromTasty/pos/i4678/annot4.tasty */
 class annot4() extends scala.annotation.Annotation
-/** Decompiled from out/posTestFromTasty/pos/i4678/annot5.tasty */
 class annot5() extends scala.annotation.Annotation

--- a/tests/pos/i566.decompiled
+++ b/tests/pos/i566.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/i566/Test.class */
 class Test() {
   type T = scala.Predef.String
   type U

--- a/tests/pos/lambda.decompiled
+++ b/tests/pos/lambda.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/lambda/foo/Foo.class */
 package foo {
   class Foo() {
     ((x: scala.Int) => 2)

--- a/tests/pos/methodTypes.decompiled
+++ b/tests/pos/methodTypes.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/methodTypes/Foo.class */
 class Foo() {
   val x: scala.Int = 1
   def y: scala.Int = 2

--- a/tests/pos/selftypes.decompiled
+++ b/tests/pos/selftypes.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/selftypes/selftypes.class */
 object selftypes {
   trait A() extends java.lang.Object { self: selftypes.AB =>
     type AA = scala.List[this.BX]

--- a/tests/pos/simple-repeated-args.decompiled
+++ b/tests/pos/simple-repeated-args.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simple-repeated-args/Foo.class */
 class Foo() {
   scala.List.apply[scala.Any](1, "2", '3')
   scala.Array.apply(1)

--- a/tests/pos/simpleAnnot.decompiled
+++ b/tests/pos/simpleAnnot.decompiled
@@ -1,9 +1,7 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleAnnot/Foo.tasty */
 class Foo() {
   @annot type A = scala.Int
   @annot val a: scala.Int = scala.Predef.???
   val b: scala.Int @annot = scala.Predef.???
   def c(x: scala.Int): scala.Int = (x: @annot)
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleAnnot/annot.tasty */
 class annot() extends scala.annotation.Annotation

--- a/tests/pos/simpleCaseClass-1.decompiled
+++ b/tests/pos/simpleCaseClass-1.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleCaseClass-1/A.tasty */
 case class A() {
   override def hashCode(): scala.Int = 1914112431
   override def equals(x$0: scala.Any): scala.Boolean = A.this.eq(x$0.asInstanceOf[java.lang.Object]).||(x$0 match {

--- a/tests/pos/simpleCaseClass-2.decompiled
+++ b/tests/pos/simpleCaseClass-2.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleCaseClass-2/A.tasty */
 case class A(x: scala.Int) {
   override def hashCode(): scala.Int = {
     var acc: scala.Int = 65

--- a/tests/pos/simpleCaseClass-3.decompiled
+++ b/tests/pos/simpleCaseClass-3.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleCaseClass-3/A.tasty */
 case class A[T](x: T) {
   override def hashCode(): scala.Int = {
     var acc: scala.Int = 65

--- a/tests/pos/simpleCaseObject.decompiled
+++ b/tests/pos/simpleCaseObject.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleCaseObject/foo/Foo.tasty */
 package foo {
   case object Foo {
     override def hashCode(): scala.Int = 1045991777

--- a/tests/pos/simpleClass-2.decompiled
+++ b/tests/pos/simpleClass-2.decompiled
@@ -1,8 +1,6 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleClass-2/foo/A.tasty */
 package foo {
   class A() extends foo.B
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleClass-2/foo/B.tasty */
 package foo {
   class B()
 }

--- a/tests/pos/simpleClass-3.decompiled
+++ b/tests/pos/simpleClass-3.decompiled
@@ -1,6 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleClass-3/A.class */
 class A() extends B with C
-/** Decompiled from out/posTestFromTasty/pos/simpleClass-3/B.class */
 trait B() extends java.lang.Object
-/** Decompiled from out/posTestFromTasty/pos/simpleClass-3/C.class */
 trait C() extends java.lang.Object

--- a/tests/pos/simpleClass.decompiled
+++ b/tests/pos/simpleClass.decompiled
@@ -1,8 +1,6 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleClass/foo/A.tasty */
 package foo {
   class A()
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleClass/foo/B.tasty */
 package foo {
   class B() extends foo.A
 }

--- a/tests/pos/simpleConstructor.decompiled
+++ b/tests/pos/simpleConstructor.decompiled
@@ -1,4 +1,2 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleConstructor/A.class */
 class A(a: scala.Int, val b: scala.Int, var c: scala.Int)
-/** Decompiled from out/posTestFromTasty/pos/simpleConstructor/B.class */
 class B(protected val x: scala.Int, protected[B] val y: scala.Int, private[B] val z: scala.Int)

--- a/tests/pos/simpleDoWhile.decompiled
+++ b/tests/pos/simpleDoWhile.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleDoWhile/Foo.class */
 class Foo() {
   def foo: scala.Unit = {
     var i: scala.Int = 1

--- a/tests/pos/simpleExtractors-1.decompiled
+++ b/tests/pos/simpleExtractors-1.decompiled
@@ -1,20 +1,15 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleExtractors-1/Bar.class */
 object Bar {
   def unapply(arg: scala.Any): scala.Option[scala.Any] = scala.Some.apply[scala.Any](arg)
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleExtractors-1/BarSeq.class */
 object BarSeq {
   def unapplySeq(arg: scala.Any): scala.Option[scala.Seq[scala.Any]] = scala.Some.apply[collection.immutable.List[scala.Any]](scala.List.apply[scala.Any](arg))
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleExtractors-1/Baz.class */
 object Baz {
   def unapply[T](arg: T): scala.Option[T] = scala.Some.apply[T](arg)
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleExtractors-1/BazSeq.class */
 object BazSeq {
   def unapplySeq[T](arg: T): scala.Option[scala.Seq[T]] = scala.Some.apply[collection.immutable.List[T]](scala.List.apply[T](arg))
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleExtractors-1/Foo.class */
 class Foo() {
   def bar(x: scala.Any): scala.Unit = x match {
     case Bar(a) =>

--- a/tests/pos/simpleExtractors-2.decompiled
+++ b/tests/pos/simpleExtractors-2.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleExtractors-2/Foo.class */
 class Foo() {
   def bar(x: scala.Any): scala.Unit = x match {
     case scala.Some(scala.Some(i: scala.Int)) =>

--- a/tests/pos/simpleInline.decompiled
+++ b/tests/pos/simpleInline.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleInline/Foo.class */
 class Foo() {
   inline def foo: scala.Int = (9: scala.Int)
   def bar: scala.Int = (9: scala.Int)

--- a/tests/pos/simpleMatchCase.decompiled
+++ b/tests/pos/simpleMatchCase.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleMatchCase/Foo.class */
 class Foo() {
   def foo: scala.Unit = "c" match {
     case x =>

--- a/tests/pos/simpleMatchRef.decompiled
+++ b/tests/pos/simpleMatchRef.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleMatchRef/Foo.class */
 class Foo() {
   val X: scala.Int = scala.Predef.???
   def foo(x: scala.Any): scala.Unit = x match {
@@ -8,5 +7,4 @@ class Foo() {
       scala.Predef.println("b")
   }
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleMatchRef/Y.class */
 object Y

--- a/tests/pos/simpleRefinement.decompiled
+++ b/tests/pos/simpleRefinement.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleRefinement/Bar.class */
 trait Bar() extends java.lang.Object {
   type S
   type T
@@ -10,7 +9,6 @@ trait Bar() extends java.lang.Object {
   def w[T]: scala.Any
   def w2[T](a: scala.Null)(b: scala.Null): scala.Any
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleRefinement/Foo.class */
 class Foo() {
   val bar: Bar {
     type S >: scala.Int <: scala.Int

--- a/tests/pos/simpleSetter.decompiled
+++ b/tests/pos/simpleSetter.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleSetter/Test.class */
 object Test {
   var name: scala.Predef.String = "foo"
   Test.name = Test.name.+("123")

--- a/tests/pos/simpleSingleton.decompiled
+++ b/tests/pos/simpleSingleton.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleSingleton/Foo.class */
 class Foo() {
   def foo(x: scala.Int): scala.Unit = {
     val a: x.type = x

--- a/tests/pos/simpleSuper.decompiled
+++ b/tests/pos/simpleSuper.decompiled
@@ -1,16 +1,13 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleSuper/foo/A.tasty */
 package foo {
   class A() {
     def foo: scala.Int = 1
   }
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleSuper/foo/B.tasty */
 package foo {
   trait B() extends java.lang.Object {
     def foo: scala.Int = 2
   }
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleSuper/foo/C.tasty */
 package foo {
   class C() extends foo.A with foo.B {
     override def foo: scala.Int = super.foo.+(super[B].foo)

--- a/tests/pos/simpleTry.decompiled
+++ b/tests/pos/simpleTry.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleTry/Foo.class */
 class Foo() {
   try 3 catch {
     case e: scala.Throwable =>

--- a/tests/pos/simpleTypeSelect.decompiled
+++ b/tests/pos/simpleTypeSelect.decompiled
@@ -1,8 +1,6 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleTypeSelect/Foo.class */
 trait Foo() extends java.lang.Object {
   type Bar
 }
-/** Decompiled from out/posTestFromTasty/pos/simpleTypeSelect/Test.class */
 object Test {
   val x: Foo#Bar = scala.Predef.???
 }

--- a/tests/pos/simpleWhile.decompiled
+++ b/tests/pos/simpleWhile.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/simpleWhile/Foo.class */
 class Foo() {
   def foo: scala.Unit = {
     var i: scala.Int = 1

--- a/tests/pos/t0905.decompiled
+++ b/tests/pos/t0905.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/t0905/Test.class */
 object Test {
   trait A[T]() extends java.lang.Object
   def f(implicit p: Test.A[_ >: scala.Nothing <: scala.Any]): scala.Null = null

--- a/tests/pos/t116.decompiled
+++ b/tests/pos/t116.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/t116/C.tasty */
 class C() {
   def this(x: scala.Int) = {
     this()

--- a/tests/pos/t3869.decompiled
+++ b/tests/pos/t3869.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/posTestFromTasty/pos/t3869/Test.class */
 object Test {
   def f: scala.Unit = try return () finally while (true) ()
   def main(args: scala.Array[scala.Predef.String]): scala.Unit = Test.f

--- a/tests/pos/t6225b.decompiled
+++ b/tests/pos/t6225b.decompiled
@@ -1,10 +1,8 @@
-/** Decompiled from out/posTestFromTasty/pos/t6225b/library/x/X.tasty */
 package library.x {
   class X() {
     class Foo()
   }
 }
-/** Decompiled from out/posTestFromTasty/pos/t6225b/library/y/package.tasty */
 package library {
   package object y extends library.x.X
 }

--- a/tests/pos/t704.decompiled
+++ b/tests/pos/t704.decompiled
@@ -1,6 +1,4 @@
-/** Decompiled from out/posTestFromTasty/pos/t704/C.class */
 class C() extends E
-/** Decompiled from out/posTestFromTasty/pos/t704/D.class */
 trait D() extends java.lang.Object {
   val x: java.lang.String = "xxxx should appear twice"
   object xxxx {
@@ -8,7 +6,6 @@ trait D() extends java.lang.Object {
   }
   def get_xxxx: scala.AnyRef = D.this.xxxx
 }
-/** Decompiled from out/posTestFromTasty/pos/t704/E.class */
 trait E() extends java.lang.Object with D {
   def f(): scala.Unit = {
     val y: java.lang.String = "yyyy should appear twice"
@@ -20,7 +17,6 @@ trait E() extends java.lang.Object with D {
     ()
   }
 }
-/** Decompiled from out/posTestFromTasty/pos/t704/Go.class */
 object Go extends D {
   def main(args: scala.Array[scala.Predef.String]): scala.Unit = {
     new C().f()

--- a/tests/run/classof-object.decompiled
+++ b/tests/run/classof-object.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/runTestFromTasty/run/classof-object/Test.tasty */
 object Test {
   def main(args: scala.Array[scala.Predef.String]): scala.Unit = if (scala.Predef.classOf[Test.type].==(Test.getClass()).unary_!) dotty.DottyPredef.assertFail() else ()
 }

--- a/tests/run/literals.decompiled
+++ b/tests/run/literals.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/runTestFromTasty/run/literals/Test.tasty */
 object Test {
   def αρετη: java.lang.String = "alpha rho epsilon tau eta"
   case class GGG(i: scala.Int) {

--- a/tests/run/simpleClass.decompiled
+++ b/tests/run/simpleClass.decompiled
@@ -1,15 +1,12 @@
-/** Decompiled from out/runTestFromTasty/run/simpleClass/Test.tasty */
 object Test {
   def main(args: scala.Array[scala.Predef.String]): scala.Unit = {
     scala.Predef.println(new foo.A().getClass().getName())
     scala.Predef.println(new foo.B().getClass().getName())
   }
 }
-/** Decompiled from out/runTestFromTasty/run/simpleClass/foo/A.tasty */
 package foo {
   class A()
 }
-/** Decompiled from out/runTestFromTasty/run/simpleClass/foo/B.tasty */
 package foo {
   class B() extends foo.A
 }

--- a/tests/run/t4300.decompiled
+++ b/tests/run/t4300.decompiled
@@ -1,8 +1,6 @@
-/** Decompiled from out/runTestFromTasty/run/t4300/A.tasty */
 trait A() extends java.lang.Object {
   def f(): scala.Unit = scala.Predef.println("A")
 }
-/** Decompiled from out/runTestFromTasty/run/t4300/B.tasty */
 class B() extends A {
   def b(): scala.Unit = super[A].f()
   trait C() extends java.lang.Object {
@@ -12,7 +10,6 @@ class B() extends A {
   def h(): scala.Unit = scala.Predef.intWrapper(0).until(1).foreach[scala.Unit](((i: scala.Int) => B.super[A].f()))
   override def f(): scala.Unit = scala.Predef.println("B")
 }
-/** Decompiled from out/runTestFromTasty/run/t4300/Test.tasty */
 object Test {
   def main(args: scala.Array[scala.Predef.String]): scala.Unit = {
     val b: B = new B()

--- a/tests/run/t8100.decompiled
+++ b/tests/run/t8100.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/runTestFromTasty/run/t8100/Test.class */
 object Test {
   import scala.util.{Try}
   def main(args: scala.Array[scala.Predef.String]): scala.Unit = {

--- a/tests/run/t889.decompiled
+++ b/tests/run/t889.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/runTestFromTasty/run/t889/Test.tasty */
 object Test extends dotty.runtime.LegacyApp {
   val a: collection.immutable.List[java.lang.String] = scala.List.apply[java.lang.String]("a")
   Test.a match {

--- a/tests/run/valueclasses-pavlov.decompiled
+++ b/tests/run/valueclasses-pavlov.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/runTestFromTasty/run/valueclasses-pavlov/Box1.tasty */
 final class Box1(val value: scala.Predef.String) extends scala.AnyVal {
   override def hashCode(): scala.Int = Box1.this.value.hashCode()
   override def equals(x$0: scala.Any): scala.Boolean = x$0 match {
@@ -9,7 +8,6 @@ final class Box1(val value: scala.Predef.String) extends scala.AnyVal {
   }
 }
 object Box1 extends scala.AnyRef
-/** Decompiled from out/runTestFromTasty/run/valueclasses-pavlov/Box2.tasty */
 final class Box2(val value: scala.Predef.String) extends scala.AnyVal with Foo {
   override def hashCode(): scala.Int = Box2.this.value.hashCode()
   override def equals(x$0: scala.Any): scala.Boolean = x$0 match {
@@ -22,19 +20,16 @@ final class Box2(val value: scala.Predef.String) extends scala.AnyVal with Foo {
   def box2(x: Box2): scala.Predef.String = "box2: ok"
 }
 object Box2 extends scala.AnyRef
-/** Decompiled from out/runTestFromTasty/run/valueclasses-pavlov/C.tasty */
 class C(x: scala.Predef.String) {
   def this() = {
     this("")
     ()
   }
 }
-/** Decompiled from out/runTestFromTasty/run/valueclasses-pavlov/Foo.tasty */
 trait Foo() extends scala.Any {
   def box1(x: Box1): scala.Predef.String
   def box2(x: Box2): scala.Predef.String
 }
-/** Decompiled from out/runTestFromTasty/run/valueclasses-pavlov/Test.tasty */
 object Test {
   def main(args: scala.Array[scala.Predef.String]): scala.Unit = {
     val b1: Box1 = new Box1("")

--- a/tests/run/virtpatmat_alts.decompiled
+++ b/tests/run/virtpatmat_alts.decompiled
@@ -1,4 +1,3 @@
-/** Decompiled from out/runTestFromTasty/run/virtpatmat_alts/Test.tasty */
 object Test extends dotty.runtime.LegacyApp {
   scala.Tuple2.apply[scala.Boolean, scala.Boolean](true, true) match {
     case (scala.Tuple2(true, true) | scala.Tuple2(false, false)) =>


### PR DESCRIPTION
* Also updated `testFromTasty` checkfiles using it to remove first comment line
which cannot be tested on Windows adn added missing EOLs.
* Add `--update-checkfiles` to `testCompilation`
* Replace `testFromTasty` with `testCompilation --from-tasty`