### PR TITLE
Avoid cycles when unpickling the stdlib from TASTY

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -171,8 +171,8 @@ class ClassfileParser(
       classRoot.registerCompanion(moduleRoot.symbol)
       moduleRoot.registerCompanion(classRoot.symbol)
 
-      setClassInfo(classRoot, classInfo)
-      setClassInfo(moduleRoot, staticInfo)
+      setClassInfo(classRoot, classInfo, fromScala2 = false)
+      setClassInfo(moduleRoot, staticInfo, fromScala2 = false)
     } else if (result == Some(NoEmbedded)) {
       for (sym <- List(moduleRoot.sourceModule, moduleRoot.symbol, classRoot.symbol)) {
         classRoot.owner.asClass.delete(sym)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -893,7 +893,7 @@ class TreeUnpickler(reader: TastyReader,
           case _ => readTpt()(parentCtx)
         }
       }
-      val parentTypes = defn.adjustForTuple(cls, cls.typeParams, parents.map(_.tpe.dealias))
+      val parentTypes = parents.map(_.tpe.dealias)
       val self =
         if (nextByte == SELFDEF) {
           readByte()

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -91,7 +91,7 @@ object Scala2Unpickler {
       cls.enter(constr, scope)
     }
 
-  def setClassInfo(denot: ClassDenotation, info: Type, selfInfo: Type = NoType)(implicit ctx: Context): Unit = {
+  def setClassInfo(denot: ClassDenotation, info: Type, fromScala2: Boolean, selfInfo: Type = NoType)(implicit ctx: Context): Unit = {
     val cls = denot.classSymbol
     val (tparams, TempClassInfoType(parents, decls, clazz)) = info match {
       case TempPolyType(tps, cinfo) => (tps, cinfo)
@@ -106,9 +106,11 @@ object Scala2Unpickler {
       else selfInfo
     val tempInfo = new TempClassInfo(denot.owner.thisType, cls, decls, ost)
     denot.info = tempInfo // first rough info to avoid CyclicReferences
+    val parents1 = if (parents.isEmpty) defn.ObjectType :: Nil else parents.map(_.dealias)
+    // Add extra parents to the tuple classes from the standard library
     val normalizedParents =
-      defn.adjustForTuple(cls, tparams,
-      	if (parents.isEmpty) defn.ObjectType :: Nil else parents.map(_.dealias))
+      if (fromScala2) defn.adjustForTuple(cls, tparams, parents1)
+      else parents1 // We are setting the info of a Java class, so it cannot be one of the tuple classes
     for (tparam <- tparams) {
       val tsym = decls.lookup(tparam.name)
       if (tsym.exists) tsym.setFlag(TypeParam)
@@ -553,7 +555,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         denot match {
           case denot: ClassDenotation =>
             val selfInfo = if (atEnd) NoType else readTypeRef()
-            setClassInfo(denot, tp, selfInfo)
+            setClassInfo(denot, tp, fromScala2 = true, selfInfo)
           case denot =>
             val tp1 = translateTempPoly(tp)
             denot.info =


### PR DESCRIPTION
`adjustForTuple` shouldn't be used when unpickling Java (because the
Tuple classes are always defined in .scala files) nor when unpickling
TASTY (because at that point, `adjustForTuple` has already been called
by Namer before pickling). This avoids some cycles when unpickling
the standard library from TASTY (we don't have a published
Dotty-compiled standard library yet, but trying to use incremental
compilation in the stdlib that is part of our community build is enough
to trigger the issue).

Note: This won't handle the hypothetical future case of Scala 2
generated TASTY files which wouldn't have the extra parents, but let's not
worry about that for now.