### PR TITLE
Rename community build sbt-dotty.sbt to sbt-dotty-sbt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,6 @@ bench/compile.txt
 
 # The vscode app for testing
 vscode-dotty/.vscode-test
-dotty-bootstrapped.version
-sbt-dotty.sbt
+
+community-build/dotty-bootstrapped.version
+community-build/sbt-dotty-sbt

--- a/community-build/dotty-bootstrapped.version
+++ b/community-build/dotty-bootstrapped.version
@@ -1,1 +1,0 @@
-0.13.0-bin-SNAPSHOT

--- a/community-build/sbt-dotty.sbt
+++ b/community-build/sbt-dotty.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.2.7-SNAPSHOT")

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -17,7 +17,7 @@ class CommunityBuildTest {
   /** Build the given project with the published local compiler and sbt plugin.
    *
    *  This test reads the compiler version from community-build/dotty-bootstrapped.version
-   *  and expects community-build/sbt-dotty.sbt to set the compiler plugin.
+   *  and expects community-build/sbt-dotty-sbt to set the compiler plugin.
    *
    *  @param project  The project name, should be a git submodule in community-build/
    *  @param command  The sbt command used to build the project
@@ -51,7 +51,7 @@ class CommunityBuildTest {
 
     // Workaround for https://github.com/sbt/sbt/issues/4395
     new File(sys.props("user.home") + "/.sbt/1.0/plugins").mkdirs()
-    val pluginFilePath = communitybuildDir.resolve("sbt-dotty.sbt").toAbsolutePath().toString()
+    val pluginFilePath = communitybuildDir.resolve("sbt-dotty-sbt").toAbsolutePath().toString()
 
     // Run the sbt command with the compiler version and sbt plugin set in the build
     val arguments = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -962,7 +962,7 @@ object Build {
       }.dependsOn(compile in Compile).evaluated
     )
 
-  val prepareCommunityBuild = taskKey[Unit]("Publish local the compiler and the sbt plugin. Also store the versions of the published local artefacts in two files, community-build/{dotty-bootstrapped.version,sbt-dotty.sbt}.")
+  val prepareCommunityBuild = taskKey[Unit]("Publish local the compiler and the sbt plugin. Also store the versions of the published local artefacts in two files, community-build/{dotty-bootstrapped.version,sbt-dotty-sbt}.")
 
   lazy val `community-build` = project.in(file("community-build")).
     settings(commonNonBootstrappedSettings).
@@ -978,7 +978,7 @@ object Build {
         (publishLocal in `sbt-dotty`).value
         (publishLocal in `dotty-bootstrapped`).value
         val pluginText = s"""addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "$sbtDottyVersion")"""
-        IO.write(baseDirectory.value / "sbt-dotty.sbt", pluginText)
+        IO.write(baseDirectory.value / "sbt-dotty-sbt", pluginText)
         IO.write(baseDirectory.value / "dotty-bootstrapped.version", dottyVersion)
       },
       (Test / testOnly) := ((Test / testOnly) dependsOn prepareCommunityBuild).evaluated,


### PR DESCRIPTION
@smarter This should be enough, right?