### PR TITLE
Fix --update-checkfiles

### DIFF
--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -21,7 +21,8 @@ object Properties {
   val testsFilter: Option[String] = sys.props.get("dotty.tests.filter")
 
   /** Tests should override the checkfiles with the current output */
-  val testsUpdateCheckfile: Boolean = propIsNullOrTrue("dotty.tests.updateCheckfiles")
+  val testsUpdateCheckfile: Boolean =
+    sys.props.getOrElse("dotty.tests.updateCheckfiles", "FALSE") == "TRUE"
 
   /** When set, the run tests are only compiled - not run, a warning will be
    *  issued

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -542,7 +542,7 @@ object Build {
         val args1 = if (updateCheckfile | fromTasty) args.filter(x => x != "--update-checkfiles" && x != "--from-tasty") else args
         val test = if (fromTasty) "dotty.tools.dotc.FromTastyTests" else "dotty.tools.dotc.*CompilationTests"
         val cmd = s" $test -- --exclude-categories=dotty.SlowTests" +
-          (if (updateCheckfile) " -Ddotty.tests.updateCheckfiles=true" else "") +
+          (if (updateCheckfile) " -Ddotty.tests.updateCheckfiles=TRUE" else "") +
           (if (args1.nonEmpty) " -Ddotty.tests.filter=" + args1.mkString(" ") else "")
         (testOnly in Test).toTask(cmd)
       }.evaluated,


### PR DESCRIPTION
The issue was that when the key `dotty.tests.updateCheckfiles` was not set
`testsUpdateCheckfile` had the value `true`. By default it should not be enabled.