### PR TITLE
Add script that generates commands for our releases

### DIFF
--- a/project/scripts/release.sh
+++ b/project/scripts/release.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Usage:
+# RELEASE_DIR=<directory to place fresh clones of projects> ./release.sh
+
+set -e
+
+# TODO: clone all the projects
+    # cd $RELEASE_DIR
+    # git@github.com:lampepfl/dotty
+    # git clone git@github.com:lampepfl/dotty-example-project.git
+    # git clone --single-branch --branch mill git@github.com:lampepfl/dotty-example-project.git
+    # git clone git@github.com:lampepfl/dotty.g8.git
+    # git clone git@github.com:lampepfl/dotty-cross.g8.git
+    # git clone git@github.com:lampepfl/homebrew-brew.git
+    # git clone git@github.com:lampepfl/packtest.git
+    # git clone git@github.com:scalacenter/scastie/.git
+
+# Parsing latest release from the list of tags not ending in RCX
+version=($(git tag --list '*.0' --sort=v:refname | tail -n1 | tr '.' '\n'))
+
+major=${version[0]}
+minor=${version[1]}
+build=${version[2]}
+
+LAST_RELEASE="$major.$minor"
+
+RELEASE="$major.$((minor+1))"
+
+RC_RELEASE="0.$((minor+2))"
+
+V_NEXT="0.$((minor+3))"
+
+echo "cd $RELEASE_DIR/dotty"
+
+echo "git checkout $RELEASE.x"
+
+echo "sed -i '' 's/^\([[:blank:]]*\)val baseVersion = \"$RELEASE.0-RC1\".*/\1val baseVersion = \"$RELEASE.0\"/' project/Build.scala"
+
+echo "git commit -am 'Release Dotty $RELEASE.0'"
+
+echo "git tag $RELEASE.0"
+
+echo "git push --follow-tags --set-upstream origin $RELEASE"
+
+echo "git checkout master"
+
+echo "git merge $RELEASE.x"
+
+echo "git push"
+
+echo "git checkout -b $RC_RELEASE.x"
+
+echo "sed -i '' 's/^\([[:blank:]]*\)val baseVersion = \"$RELEASE.0\".*/\1val baseVersion = \"$RC_RELEASE.0-RC1\"/' project/Build.scala"
+
+echo "git commit -am 'Release Dotty $RC_RELEASE.0-RC1'"
+
+echo "git tag $RC_RELEASE.0-RC1"
+
+echo "git push --follow-tags --set-upstream origin $RC_RELEASE.x"
+
+echo "git checkout master"
+
+echo "sed -i '' 's/^\([[:blank:]]*\)val baseVersion = \"$RC_RELEASE.0\".*/\1val baseVersion = \"$V_NEXT.0\"/' project/Build.scala"
+
+echo "git commit -am 'Set baseVersion to $V_NEXT.0'"
+
+echo "git push"
+
+# TODO: perform all the version bumps, commit, push and create the PRs


### PR DESCRIPTION
This small script, currently, it just generates the necessary commands according to our release. For now it gets the latest release from the list of tags not ending in RCXX. In the future it may be used to fully automate our release process.

Sample output for the current release #5907:

```shell
cd /dotty
git checkout 0.12.x
sed -i '' 's/^\([[:blank:]]*\)val baseVersion = "0.12.0-RC1".*/\1val baseVersion = "0.12.0"/' project/Build.scala
git commit -am 'Release Dotty 0.12.0'
git tag 0.12.0
git push --follow-tags --set-upstream origin 0.12
git checkout master
git merge 0.12.x
git push
git checkout -b 0.13.x
sed -i '' 's/^\([[:blank:]]*\)val baseVersion = "0.12.0".*/\1val baseVersion = "0.13.0-RC1"/' project/Build.scala
git commit -am 'Release Dotty 0.13.0-RC1'
git tag 0.13.0-RC1
git push --follow-tags --set-upstream origin 0.13.x
git checkout master
sed -i '' 's/^\([[:blank:]]*\)val baseVersion = "0.13.0".*/\1val baseVersion = "0.14.0"/' project/Build.scala
git commit -am 'Set baseVersion to 0.14.0'
git push
```