### PR TITLE
Fix #5915: Implied classes need wrapper object

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1007,7 +1007,7 @@ object desugar {
       case _: ValDef | _: PatDef | _: DefDef => true
       case stat: ModuleDef =>
         stat.mods.is(ImplicitOrImplied) || opaqueNames.contains(stat.name.stripModuleClassSuffix.toTypeName)
-      case stat: TypeDef => !stat.isClassDef || stat.mods.is(Implicit)
+      case stat: TypeDef => !stat.isClassDef || stat.mods.is(ImplicitOrImplied)
       case _ => false
     }
     val (nestedStats, topStats) = pdef.stats.partition(needsObject)

--- a/tests/pos/i5915.scala
+++ b/tests/pos/i5915.scala
@@ -1,0 +1,9 @@
+trait RunDSL
+
+val rdsl = new RunDSL {}
+
+implied RunNNFExpr[B] for RunDSL = rdsl
+
+implied RunNNFImpl[B] for RunDSL {
+  //override def runDSL(b: NNF[B]): B = b.terminal
+}


### PR DESCRIPTION
This was a merge breakage between two in-flight PRs.