### PR TITLE
Take implicit parameters into account for is-as-specific computations

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -612,7 +612,10 @@ object Flags {
   final val InlineParam: FlagConjunction = allOf(Inline, Param)
 
   /** An extension method */
-  final val ExtensionMethod = allOf(Method, Extension)
+  final val ExtensionMethod = allOf(Extension, Method)
+
+  /** An implied method */
+  final val SyntheticImpliedMethod: FlagConjunction = allOf(Synthetic, Implied, Method)
 
   /** An enum case */
   final val EnumCase: FlagConjunction = allOf(Enum, Case)

--- a/compiler/test/dotty/tools/dotc/reporting/UserDefinedErrorMessages.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/UserDefinedErrorMessages.scala
@@ -113,7 +113,7 @@ class UserDefinedErrorMessages extends ErrorMessagesTest {
         |class C {
         |  @annotation.implicitAmbiguous("msg A=${A}")
         |  implicit def f[A](implicit x: String): Int = 1
-        |  implicit def g: Int = 2
+        |  implicit def g(implicit x: String): Int = 2
         |  def test: Unit = {
         |    implicit val s: String = "Hello"
         |    implicitly[Int]

--- a/docs/docs/reference/changed-features/implicit-resolution.md
+++ b/docs/docs/reference/changed-features/implicit-resolution.md
@@ -81,4 +81,20 @@ affect implicits on the language level.
         def buzz(y: A) = ???
         buzz(1)   // error: ambiguous
 
+ 6. The rule for picking a _most specific_ alternative among a set of overloaded or implicit
+    alternatives is refined to take the number of inferable parameters into account. All else
+    being equal, an alternative that takes more inferable parameters is taken to be more specific
+    than an alternative that takes fewer. The following paragraph in the SLS is affected by this change:
+
+    _Original version:_
+
+    > An alternative A is _more specific_ than an alternative B if the relative weight of A over B is greater than the relative weight of B over A.
+
+    _Modified version:_
+
+    An alternative A is _more specific_ than an alternative B if
+
+     - the relative weight of A over B is greater than the relative weight of B over A, or
+     - the relative weights are the same and A takes more inferable parameters than B.
+
 [//]: # todo: expand with precise rules

--- a/docs/docs/reference/changed-features/implicit-resolution.md
+++ b/docs/docs/reference/changed-features/implicit-resolution.md
@@ -99,9 +99,11 @@ affect implicits on the language level.
         buzz(1)   // error: ambiguous
 
  7. The rule for picking a _most specific_ alternative among a set of overloaded or implicit
-    alternatives is refined to take the number of inferable parameters into account. All else
+    alternatives is refined to take inferable parameters into account. All else
     being equal, an alternative that takes more inferable parameters is taken to be more specific
-    than an alternative that takes fewer. The following paragraph in the SLS is affected by this change:
+    than an alternative that takes fewer. If both alternatives take the same number of
+    inferable parameters, we try to choose between them as if they were methods with regular parameters.
+    The following paragraph in the SLS is affected by this change:
 
     _Original version:_
 
@@ -112,6 +114,9 @@ affect implicits on the language level.
     An alternative A is _more specific_ than an alternative B if
 
      - the relative weight of A over B is greater than the relative weight of B over A, or
-     - the relative weights are the same and A takes more inferable parameters than B.
+     - the relative weights are the same and A takes more inferable parameters than B, or
+     - the relative weights and the number of inferable parameters are the same and
+       A is more specific than B if all inferable parameters in either alternative are
+       replaced by regular parameters.
 
 [//]: # todo: expand with precise rules

--- a/docs/docs/reference/changed-features/implicit-resolution.md
+++ b/docs/docs/reference/changed-features/implicit-resolution.md
@@ -35,9 +35,26 @@ affect implicits on the language level.
 
     This will now resolve the `implicitly` call to `j`, because `j` is nested
     more deeply than `i`. Previously, this would have resulted in an
-    ambiguity error.
+    ambiguity error. The previous possibility of an implicit search failure
+    due to _shadowing_ (where an implicit is hidden by a nested definition)
+    no longer applies.
 
- 3. The treatment of ambiguity errors has changed. If an ambiguity is encountered
+ 3. Package prefixes no longer contribute to the implicit scope of a type.
+    Example:
+
+        package p
+        implied a for A
+
+        object o {
+          implied b for B
+          type C
+        }
+
+    Both `a` and `b` are visible as implicits at the point of the definition
+    of `type C`. However, a reference to `p.o.C` outside of package `p` will
+    have only `b` in its implicit scope but not `a`.
+
+ 4. The treatment of ambiguity errors has changed. If an ambiguity is encountered
     in some recursive step of an implicit search, the ambiguity is propagated to the caller.
     Example: Say you have the following definitions:
 
@@ -65,14 +82,14 @@ affect implicits on the language level.
     which implements negation directly. For any query type `Q`: `Not[Q]` succeeds if and only if
     the implicit search for `Q` fails.
 
- 4. The treatment of divergence errors has also changed. A divergent implicit is
+ 5. The treatment of divergence errors has also changed. A divergent implicit is
     treated as a normal failure, after which alternatives are still tried. This also makes
     sense: Encountering a divergent implicit means that we assume that no finite
     solution can be found on the given path, but another path can still be tried. By contrast
     most (but not all) divergence errors in Scala 2 would terminate the implicit
     search as a whole.
 
- 5. Scala-2 gives a lower level of priority to implicit conversions with call-by-name
+ 6. Scala-2 gives a lower level of priority to implicit conversions with call-by-name
     parameters relative to implicit conversions with call-by-value parameters. Dotty
     drops this distinction. So the following code snippet would be ambiguous in Dotty:
 
@@ -81,7 +98,7 @@ affect implicits on the language level.
         def buzz(y: A) = ???
         buzz(1)   // error: ambiguous
 
- 6. The rule for picking a _most specific_ alternative among a set of overloaded or implicit
+ 7. The rule for picking a _most specific_ alternative among a set of overloaded or implicit
     alternatives is refined to take the number of inferable parameters into account. All else
     being equal, an alternative that takes more inferable parameters is taken to be more specific
     than an alternative that takes fewer. The following paragraph in the SLS is affected by this change:

--- a/tests/neg/overloading-specifity.scala
+++ b/tests/neg/overloading-specifity.scala
@@ -1,0 +1,27 @@
+// Shows that overloading resolution does not test implicits to decide
+// applicability. A best alternative is picked first, and then implicits
+// are searched for this one.
+case class Show[T](val i: Int)
+class Show1[T](i: Int) extends Show[T](i)
+
+class Generic
+object Generic {
+  implicit val gen: Generic = new Generic
+  implicit def showGen[T](implicit gen: Generic): Show[T] = new Show[T](2)
+}
+
+object Test extends App {
+  trait Context
+  //implied ctx for Context
+
+  object a {
+    def foo[T](implicit gen: Generic): Show[T] = new Show[T](1)
+    def foo[T](implicit gen: Generic, ctx: Context): Show1[T] = new Show1[T](2)
+  }
+  object b {
+    def foo[T](implicit gen: Generic): Show[T] = new Show[T](1)
+    def foo[T]: Show[T] = new Show[T](2)
+  }
+
+  assert(a.foo[Int].i == 2) // error: no implicit argument of type Test.Context was found for parameter ctx
+}

--- a/tests/run/implicit-specifity-2.scala
+++ b/tests/run/implicit-specifity-2.scala
@@ -1,0 +1,36 @@
+class Low
+object Low {
+  implicit val low: Low = new Low
+}
+class Medium extends Low
+object Medium {
+  implicit val medium: Medium = new Medium
+}
+class High extends Medium
+object High {
+  implicit val high: High = new High
+}
+
+class Foo[T](val i: Int)
+object Foo {
+  def apply[T](implicit fooT: Foo[T]): Int = fooT.i
+
+  implicit def foo[T](implicit priority: Low): Foo[T] = new Foo[T](0)
+  implicit def foobar[T](implicit priority: Low): Foo[Bar[T]] = new Foo[Bar[T]](1)
+  implicit def foobarbaz(implicit priority: Low): Foo[Bar[Baz]] = new Foo[Bar[Baz]](2)
+}
+class Bar[T]
+object Bar {
+  implicit def foobar[T](implicit priority: Medium): Foo[Bar[T]] = new Foo[Bar[T]](3)
+  implicit def foobarbaz(implicit priority: Medium): Foo[Bar[Baz]] = new Foo[Bar[Baz]](4)
+}
+class Baz
+object Baz {
+  implicit def baz(implicit priority: High): Foo[Bar[Baz]] = new Foo[Bar[Baz]](5)
+}
+
+object Test extends App {
+  assert(Foo[Int] == 0)
+  assert(Foo[Bar[Int]] == 3)
+  assert(Foo[Bar[Baz]] == 5)
+}

--- a/tests/run/implicit-specifity.scala
+++ b/tests/run/implicit-specifity.scala
@@ -1,0 +1,30 @@
+case class Show[T](val i: Int)
+object Show {
+  def apply[T](implicit st: Show[T]): Int = st.i
+
+  implied showInt for Show[Int] = new Show[Int](0)
+  implied fallback[T] for Show[T] = new Show[T](1)
+}
+
+class Generic
+object Generic {
+  implied gen for Generic = new Generic
+  implied showGen[T] given Generic for Show[T] = new Show[T](2)
+}
+
+object Contextual {
+  trait Context
+  implied ctx for Context
+  implied showGen[T] given Generic for Show[T] = new Show[T](2)
+  implied showGen[T] given Generic, Context for Show[T] = new Show[T](3)
+}
+
+object Test extends App {
+  assert(Show[Int] == 0)
+  assert(Show[String] == 1)
+  assert(Show[Generic] == 2) // showGen beats fallback due to longer argument list
+
+  { import implied Contextual._
+    assert(Show[Generic] == 3)
+  }
+}

--- a/tests/run/implied-specifity-2.scala
+++ b/tests/run/implied-specifity-2.scala
@@ -1,0 +1,36 @@
+class Low
+object Low {
+  implied low for Low
+}
+class Medium extends Low
+object Medium {
+  implied medium for Medium
+}
+class High extends Medium
+object High {
+  implied high for High
+}
+
+class Foo[T](val i: Int)
+object Foo {
+  def apply[T] given (fooT: Foo[T]): Int = fooT.i
+
+  implied foo[T]    given Low for Foo[T](0)
+  implied foobar[T] given Low for Foo[Bar[T]](1)
+  implied foobarbaz given Low for Foo[Bar[Baz]](2)
+}
+class Bar[T]
+object Bar {
+  implied foobar[T] given Medium for Foo[Bar[T]](3)
+  implied foobarbaz given Medium for Foo[Bar[Baz]](4)
+}
+class Baz
+object Baz {
+  implied baz given High for Foo[Bar[Baz]](5)
+}
+
+object Test extends App {
+  assert(Foo[Int] == 0)
+  assert(Foo[Bar[Int]] == 3)
+  assert(Foo[Bar[Baz]] == 5)
+}

--- a/tests/run/implied-specifity.scala
+++ b/tests/run/implied-specifity.scala
@@ -1,0 +1,30 @@
+case class Show[T](val i: Int)
+object Show {
+  def apply[T](implicit st: Show[T]): Int = st.i
+
+  implied showInt for Show[Int](0)
+  implied fallback[T] for Show[T](1)
+}
+
+class Generic
+object Generic {
+  implied gen for Generic
+  implied showGen[T] given Generic for Show[T](2)
+}
+
+object Contextual {
+  trait Context
+  implied ctx for Context
+  implied showGen2[T] given Generic for Show[T](2)
+  implied showGen3[T] given Generic, Context for Show[T](3)
+}
+
+object Test extends App {
+  assert(Show[Int] == 0)
+  assert(Show[String] == 1)
+  assert(Show[Generic] == 2) // showGen beats fallback due to longer argument list
+
+  { import implied Contextual._
+    assert(Show[Generic] == 3)
+  }
+}

--- a/tests/run/overloading-specifity.scala
+++ b/tests/run/overloading-specifity.scala
@@ -1,0 +1,27 @@
+// Shows that now implicit parameters act as a tie-breaker.
+// The alternative with more implicit parameters wins.
+case class Show[T](val i: Int)
+
+class Generic
+object Generic {
+  implicit val gen: Generic = new Generic
+  implicit def showGen[T](implicit gen: Generic): Show[T] = new Show[T](2)
+}
+
+object Test extends App {
+  trait Context
+  implied ctx for Context
+
+  object a {
+    def foo[T](implicit gen: Generic): Show[T] = new Show[T](1)
+    def foo[T](implicit gen: Generic, ctx: Context): Show[T] = new Show[T](2)
+  }
+  object b {
+    def foo[T](implicit gen: Generic): Show[T] = new Show[T](1)
+    def foo[T]: Show[T] = new Show[T](2)
+  }
+
+  assert(a.foo[Int].i == 2)
+  assert(b.foo[Int].i == 1)
+
+}


### PR DESCRIPTION
Number of implicit parameters is applied as a final tie break, if
two alternatives would be otherwise equally specific.

I tried to roll them into type specificity first, but this fails
the dotc bootstrap where we have:

     def name(implicit ctx: Context): Name  in class Denotation

     val name: Name                         in subclass SymDenotation

The `val name` wins, since it is defined in a subclass and the result types
are the same. If we let the type `(implicit ctx: Context): Name` win over
`Name` this would be ambiguous instead.
