### PR TITLE
Fix #5823: better erasure of bottom types

### DIFF
--- a/tests/neg/i5823.scala
+++ b/tests/neg/i5823.scala
@@ -1,0 +1,38 @@
+// Test that `C|Null` is erased to `C` if `C` is
+// a reference type.
+// If `C` is a value type, then `C|Null = Object`.
+// Ditto for `C|Nothing`.
+
+class A
+class B
+
+class Foo {
+  
+  // ok, because A and B are <: Object.
+  def foo(a: A|Null): Unit = ()
+  def foo(b: B|Null): Unit = ()
+
+  def bar(a: Int|Null): Unit = ()
+  def bar(b: Boolean|Null): Unit = () // error: signatures match
+
+  // ok, T is erased to `String` and `Integer`, respectively
+  def gen[T <: String](s: T|Null): Unit = ()
+  def gen[T <: Integer](i: T|Null): Unit = ()
+
+  def gen2[T <: Int](i: T|Null): Unit = ()
+  def gen2[T <: Boolean](b: T|Null): Unit = () // error: signatures match
+
+  // ok, because A and B are <: Object.
+  def foo2(a: A|Nothing): Unit = ()
+  def foo2(b: B|Nothing): Unit = ()
+
+  def bar2(a: Int|Nothing): Unit = ()
+  def bar2(b: Boolean|Nothing): Unit = () // error: signatures match
+
+  // ok, T is erased to `String` and `Integer`, respectively
+  def gen3[T <: String](s: T|Nothing): Unit = ()
+  def gen3[T <: Integer](i: T|Nothing): Unit = ()
+
+  def gen4[T <: Int](i: T|Nothing): Unit = ()
+  def gen4[T <: Boolean](b: T|Nothing): Unit = () // error: signatures match
+}

--- a/tests/run/i5823.check
+++ b/tests/run/i5823.check
@@ -1,0 +1,8 @@
+foo(A) called
+foo(B) called
+foo(C) called
+foo(D) called
+bar(A) called
+bar(B) called
+fooz(A) called
+fooz(B) called

--- a/tests/run/i5823.scala
+++ b/tests/run/i5823.scala
@@ -1,0 +1,60 @@
+// Test that `C|Null` and `C|Nothing` are erased to `C`.
+
+class A
+class B
+class C
+class D
+
+object Foo {
+  // This code would not have compiled before, when `C|Null` was erased
+  // to `Object`, because post-erasure we would end up with multiple methods
+  // with the same signature.
+
+  def foo(a: A|Null): Unit = {
+    println("foo(A) called")
+  }
+  
+  def foo(b: B|Null): Unit = {
+    println("foo(B) called")
+  }
+
+  def foo(c: Null|C): Unit = {
+    println("foo(C) called")
+  }
+
+  def foo(d: Null|D): Unit = {
+    println("foo(D) called")
+  }
+
+  def bar[T <: A](a: Null|T): Unit = {
+    println("bar(A) called")
+  }
+
+  def bar[T <: B](b: Null|T): Unit = {
+    println("bar(B) called")
+  }
+
+  def fooz(a: A|Nothing): Unit = {
+    println("fooz(A) called")
+  }
+
+  def fooz(b: B|Nothing): Unit = {
+    println("fooz(B) called")
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    import Foo._
+    foo(new A)
+    foo(new B)
+    foo(new C)
+    foo(new D)
+
+    bar(new A)
+    bar(new B)
+
+    fooz(new A)
+    fooz(new B)
+  }
+}


### PR DESCRIPTION
Change the definition of lub so that:
  - lub(C, {Null, Nothing}) = C if C is a reference type
  - lub(C, {Null, Nothing}) = Object if C is a value type (as before)

This allows us to generate more efficient code, and it better
matches the user's expectations.