### PR TITLE
IDE: fix signature help for Java and Scala 2 methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -355,11 +355,17 @@ class Definitions {
     lazy val Predef_undefinedR: TermRef = ScalaPredefModule.requiredMethodRef(nme.???)
     def Predef_undefined(implicit ctx: Context): Symbol = Predef_undefinedR.symbol
 
-  def SubTypeClass(implicit ctx: Context): Symbol =
+  def SubTypeClass(implicit ctx: Context): ClassSymbol =
     if (isNewCollections)
       ctx.requiredClass("scala.<:<")
     else
       ScalaPredefModule.requiredClass("<:<")
+
+  def DummyImplicitClass(implicit ctx: Context): ClassSymbol =
+    if (isNewCollections)
+      ctx.requiredClass("scala.DummyImplicit")
+    else
+      ScalaPredefModule.requiredClass("DummyImplicit")
 
   lazy val ScalaRuntimeModuleRef: TermRef = ctx.requiredModuleRef("scala.runtime.ScalaRunTime")
   def ScalaRuntimeModule(implicit ctx: Context): Symbol = ScalaRuntimeModuleRef.symbol

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -84,11 +84,13 @@ object Signatures {
     def toParamss(tp: MethodType)(implicit ctx: Context): List[List[Param]] = {
       val rest = tp.resType match {
         case res: MethodType =>
-          // HACK: Hide parameter lists consisting only of CanBuildFrom,
-          // remove this once we switch to the 2.13 standard library.
+          // Hide parameter lists consisting only of CanBuildFrom or DummyImplicit,
+          // we can remove the CanBuildFrom special-case once we switch to the 2.13 standard library.
           if (res.resultType.isParameterless &&
               res.isImplicitMethod &&
-              res.paramInfos.forall(_.classSymbol.fullName.toString == "scala.collection.generic.CanBuildFrom"))
+              res.paramInfos.forall(info =>
+                info.classSymbol.fullName.toString == "scala.collection.generic.CanBuildFrom" ||
+                info.classSymbol.derivesFrom(ctx.definitions.DummyImplicitClass)))
             Nil
           else
             toParamss(res)

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -8,7 +8,7 @@ import dotty.tools.dotc.util.Signatures.{Param => P, Signature => S}
 
 class SignatureHelpTest {
 
-  @Test def javaParam: Unit = {
+  @Test def fromJava: Unit = {
     val signature =
       S("codePointAt", Nil, List(List(P("x$0", "Int"))), Some("Int"))
     code"""object O {
@@ -17,13 +17,17 @@ class SignatureHelpTest {
       .signatureHelp(m1, List(signature), Some(0), 0)
   }
 
-  @Test def scala2Param: Unit = {
-    val signature =
+  @Test def fromScala2: Unit = {
+    val applySig =
       S("apply[A]", Nil, List(List(P("xs", "A*"))), Some("List[A]"))
+    val mapSig =
+      S("map[B, That]", Nil, List(List(P("f", "A => B"))), Some("That"))
     code"""object O {
              List($m1)
+             List(1, 2, 3).map($m2)
            }""".withSource
-      .signatureHelp(m1, List(signature), Some(0), 0)
+      .signatureHelp(m1, List(applySig), Some(0), 0)
+      .signatureHelp(m2, List(mapSig), Some(0), 0)
   }
 
   @Test def singleParam: Unit = {

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -8,6 +8,24 @@ import dotty.tools.dotc.util.Signatures.{Param => P, Signature => S}
 
 class SignatureHelpTest {
 
+  @Test def javaParam: Unit = {
+    val signature =
+      S("codePointAt", Nil, List(List(P("x$0", "Int"))), Some("Int"))
+    code"""object O {
+             "hello".codePointAt($m1)
+           }""".withSource
+      .signatureHelp(m1, List(signature), Some(0), 0)
+  }
+
+  @Test def scala2Param: Unit = {
+    val signature =
+      S("apply[A]", Nil, List(List(P("xs", "A*"))), Some("List[A]"))
+    code"""object O {
+             List($m1)
+           }""".withSource
+      .signatureHelp(m1, List(signature), Some(0), 0)
+  }
+
   @Test def singleParam: Unit = {
     val signature =
       S("foo", Nil, List(List(P("param0", "Int"))), Some("Int"))

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -30,6 +30,34 @@ class SignatureHelpTest {
       .signatureHelp(m2, List(mapSig), Some(0), 0)
   }
 
+  /** Implicit parameter lists consisting solely of DummyImplicits are hidden. */
+  @Test def hiddenDummyParams: Unit = {
+    val foo1Sig =
+      S("foo1", Nil, List(List(P("param0", "Int"))), Some("Int"))
+    val foo2Sig =
+      S("foo2", Nil, List(List(P("param0", "Int"))), Some("Int"))
+    val foo3Sig =
+      S("foo3", Nil, List(List(P("param0", "Int")),
+        List(P("dummy", "DummyImplicit"))), Some("Int"))
+    val foo4Sig =
+      S("foo4", Nil, List(List(P("param0", "Int")),
+        List(P("x", "Int", isImplicit = true), P("dummy", "DummyImplicit", isImplicit = true))), Some("Int"))
+    code"""object O {
+             def foo1(param0: Int)(implicit dummy: DummyImplicit): Int = ???
+             def foo2(param0: Int)(implicit dummy1: DummyImplicit, dummy2: DummyImplicit): Int = ???
+             def foo3(param0: Int)(dummy: DummyImplicit): Int = ???
+             def foo4(param0: Int)(implicit x: Int, dummy: DummyImplicit): Int = ???
+             foo1($m1)
+             foo2($m2)
+             foo3($m3)
+             foo4($m4)
+           }""".withSource
+      .signatureHelp(m1, List(foo1Sig), Some(0), 0)
+      .signatureHelp(m2, List(foo2Sig), Some(0), 0)
+      .signatureHelp(m3, List(foo3Sig), Some(0), 0)
+      .signatureHelp(m4, List(foo4Sig), Some(0), 0)
+  }
+
   @Test def singleParam: Unit = {
     val signature =
       S("foo", Nil, List(List(P("param0", "Int"))), Some("Int"))


### PR DESCRIPTION
Asking for the signature of a method not defined in sources or in Tasty
used to throw an exception because the symbol passed to `defPath` must
have a span. The call to `defPath` was only used to determine which
parameters were implicit, but this can be done in an easier way by
checking `isImplicitMethod`, so we can get rid of it at no loss.

(note that right now launchIDE is broken, this is being fixed in https://github.com/lampepfl/dotty/pull/5917)