### PR TITLE
Implement Monocle macros

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/TreeOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TreeOpsImpl.scala
@@ -383,8 +383,8 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with RootPositionImpl with
     }
 
     object Ident extends IdentModule {
-      def apply(tmref: TermRef)(implicit ctx: Context): Ident =
-        withDefaultPos(implicit ctx => tpd.Ident(tmref))
+      def apply(tmref: TermRef)(implicit ctx: Context): Term =
+        withDefaultPos(implicit ctx => tpd.ref(tmref).asInstanceOf[Term])
 
       def copy(original: Tree)(name: String)(implicit ctx: Context): Ident =
         tpd.cpy.Ident(original)(name.toTermName)

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TreeOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TreeOpsImpl.scala
@@ -383,6 +383,9 @@ trait TreeOpsImpl extends scala.tasty.reflect.TreeOps with RootPositionImpl with
     }
 
     object Ident extends IdentModule {
+      def apply(tmref: TermRef)(implicit ctx: Context): Ident =
+        withDefaultPos(implicit ctx => tpd.Ident(tmref))
+
       def copy(original: Tree)(name: String)(implicit ctx: Context): Ident =
         tpd.cpy.Ident(original)(name.toTermName)
 

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsOpsImpl.scala
@@ -25,6 +25,8 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
 
     def typeSymbol(implicit ctx: Context): Symbol = tpe.typeSymbol
 
+    def isSingleton(implicit ctx: Context): Boolean = tpe.isSingleton
+
     def memberType(member: Symbol)(implicit ctx: Context): Type =
       member.info.asSeenFrom(tpe, member.owner)
   }

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsOpsImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TypeOrBoundsOpsImpl.scala
@@ -1,6 +1,7 @@
 package dotty.tools.dotc.tastyreflect
 
 import dotty.tools.dotc.core.{Contexts, Names, Types}
+import dotty.tools.dotc.core.Decorators._
 
 trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreImpl {
 
@@ -23,6 +24,9 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
       if (tpe.classSymbol.exists) Some(tpe.classSymbol.asClass) else None
 
     def typeSymbol(implicit ctx: Context): Symbol = tpe.typeSymbol
+
+    def memberType(member: Symbol)(implicit ctx: Context): Type =
+      member.info.asSeenFrom(tpe, member.owner)
   }
 
   def ConstantTypeDeco(x: ConstantType): Type.ConstantTypeAPI = new Type.ConstantTypeAPI {
@@ -181,6 +185,9 @@ trait TypeOrBoundsOpsImpl extends scala.tasty.reflect.TypeOrBoundsOps with CoreI
     }
 
     object TermRef extends TermRefModule {
+      def apply(qual: TypeOrBounds, name: String)(implicit ctx: Context): TermRef =
+        Types.TermRef(qual, name.toTermName)
+
       def unapply(x: TypeOrBounds)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)] = x match {
         case tp: Types.NamedType =>
           tp.designator match {

--- a/library/src/scala/tasty/reflect/TreeOps.scala
+++ b/library/src/scala/tasty/reflect/TreeOps.scala
@@ -2,7 +2,6 @@ package scala.tasty
 package reflect
 
 trait TreeOps extends Core {
-
   // Decorators
 
   implicit def TreeDeco(tree: Tree): TreeAPI
@@ -249,6 +248,7 @@ trait TreeOps extends Core {
     /** Scala term identifier */
     val Ident: IdentModule
     abstract class IdentModule {
+      def apply(tmref: TermRef)(implicit ctx: Context): Ident
 
       def copy(original: Tree)(name: String)(implicit ctx: Context): Ident
 

--- a/library/src/scala/tasty/reflect/TreeOps.scala
+++ b/library/src/scala/tasty/reflect/TreeOps.scala
@@ -248,7 +248,7 @@ trait TreeOps extends Core {
     /** Scala term identifier */
     val Ident: IdentModule
     abstract class IdentModule {
-      def apply(tmref: TermRef)(implicit ctx: Context): Ident
+      def apply(tmref: TermRef)(implicit ctx: Context): Term
 
       def copy(original: Tree)(name: String)(implicit ctx: Context): Ident
 

--- a/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
@@ -55,6 +55,7 @@ trait TypeOrBoundsOps extends Core {
     def widen(implicit ctx: Context): Type
     def classSymbol(implicit ctx: Context): Option[ClassSymbol]
     def typeSymbol(implicit ctx: Context): Symbol
+    def isSingleton(implicit ctx: Context): Boolean
     def memberType(member: Symbol)(implicit ctx: Context): Type
   }
 

--- a/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
@@ -55,6 +55,7 @@ trait TypeOrBoundsOps extends Core {
     def widen(implicit ctx: Context): Type
     def classSymbol(implicit ctx: Context): Option[ClassSymbol]
     def typeSymbol(implicit ctx: Context): Symbol
+    def memberType(member: Symbol)(implicit ctx: Context): Type
   }
 
   val IsType: IsTypeModule
@@ -107,6 +108,7 @@ trait TypeOrBoundsOps extends Core {
 
     val TermRef: TermRefModule
     abstract class TermRefModule {
+      def apply(qual: TypeOrBounds, name: String)(implicit ctx: Context): TermRef
       def unapply(typeOrBounds: TypeOrBounds)(implicit ctx: Context): Option[(String, TypeOrBounds /* Type | NoPrefix */)]
     }
 

--- a/tests/neg-with-compiler/i5941/macro_1.scala
+++ b/tests/neg-with-compiler/i5941/macro_1.scala
@@ -31,8 +31,8 @@ object Lens {
         )
       ) if o.symbol == param.symbol =>
         '{
-          val setter = (t: T) => (s: S) => ~setterBody('(s), '(t), field)
-          apply(~getter)(setter)
+          val setter = (t: T) => (s: S) => ${ setterBody('s, 't, field) }
+          apply($getter)(setter)
         }
       case _ =>
         throw new QuoteError("Unsupported syntax. Example: `GenLens[Address](_.streetNumber)`")
@@ -50,6 +50,6 @@ object GenLens {
 
   def apply[S] = new MkGenLens[S]
   class MkGenLens[S] {
-    inline def apply[T](get: => (S => T)): Lens[S, T] = ~Lens.impl('(get))
+    inline def apply[T](get: => (S => T)): Lens[S, T] = ${ Lens.impl('get) }
   }
 }

--- a/tests/neg-with-compiler/i5941/macro_1.scala
+++ b/tests/neg-with-compiler/i5941/macro_1.scala
@@ -1,0 +1,55 @@
+abstract class Lens[S, T] {
+  def get(s: S): T
+  def set(t: T, s: S) :S
+}
+
+import scala.quoted._
+import scala.tasty._
+
+object Lens {
+  def apply[S, T](_get: S => T)(_set: T => S => S): Lens[S, T] = new Lens {
+    def get(s: S): T = _get(s)
+    def set(t: T, s: S): S = _set(t)(s)
+  }
+
+  def impl[S: Type, T: Type](getter: Expr[S => T])(implicit refl: Reflection): Expr[Lens[S, T]] = {
+    import refl._
+    import util._
+    import quoted.Toolbox.Default._
+
+    // obj.copy(field = value)
+    def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =
+      Term.Select.overloaded(obj.unseal, "copy", Nil, Term.NamedArg(field, value.unseal) :: Nil).seal[S]
+
+    // exception: getter.unseal.underlyingArgument
+    getter.unseal match {
+      case Term.Inlined(
+        None, Nil,
+        Term.Block(
+          DefDef(_, Nil, (param :: Nil) :: Nil, _, Some(Term.Select(o, field))) :: Nil,
+          Term.Lambda(meth, _)
+        )
+      ) if o.symbol == param.symbol =>
+        '{
+          val setter = (t: T) => (s: S) => ~setterBody('(s), '(t), field)
+          apply(~getter)(setter)
+        }
+      case _ =>
+        throw new QuoteError("Unsupported syntax. Example: `GenLens[Address](_.streetNumber)`")
+    }
+  }
+}
+
+object GenLens {
+  /** case class Address(streetNumber: Int, streetName: String)
+   *
+   *  GenLens[Address](_.streetNumber)   ~~>
+   *
+   *  Lens[Address, Int](_.streetNumber)(n => a => a.copy(streetNumber = n))
+   */
+
+  def apply[S] = new MkGenLens[S]
+  class MkGenLens[S] {
+    inline def apply[T](get: => (S => T)): Lens[S, T] = ~Lens.impl('(get))
+  }
+}

--- a/tests/neg-with-compiler/i5941/usage_2.scala
+++ b/tests/neg-with-compiler/i5941/usage_2.scala
@@ -1,0 +1,11 @@
+case class Address(streetNumber: Int, streetName: String)
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val len = GenLens[Address](_.streetNumber + 3) // error
+    val address = Address(10, "High Street")
+    assert(len.get(address) == 10)
+    val addr2 = len.set(5, address)
+    assert(len.get(addr2) == 5)
+  }
+}

--- a/tests/run-with-compiler/i5941/macro_1.scala
+++ b/tests/run-with-compiler/i5941/macro_1.scala
@@ -163,6 +163,9 @@ object Iso {
       throw new QuoteError("Only support generation for case classes or singleton types")
     }
   }
+
+  // TODO: require whitebox macro
+  def implFields[S: Type](implicit refl: Reflection): Expr[Iso[S, Any]] = ???
 }
 
 object GenIso {
@@ -175,7 +178,9 @@ object GenIso {
    */
   inline def apply[S, A]: Iso[S, A] = ~Iso.impl[S, A]
 
-  inline def fields[S, A]: Iso[S, A] = ???
+  // TODO: require whitebox macro
+  inline def fields[S]: Iso[S, Any] = ~Iso.implFields[S]
+
   inline def unit[S]: Iso[S, 1] = ~Iso.implUnit[S]
 }
 

--- a/tests/run-with-compiler/i5941/macro_1.scala
+++ b/tests/run-with-compiler/i5941/macro_1.scala
@@ -129,7 +129,7 @@ object Iso {
     }
   }
 
-  def implUnit[S: Type](implicit refl: Reflection): Expr[Iso[S, Unit]] = {
+  def implUnit[S: Type](implicit refl: Reflection): Expr[Iso[S, 1]] = {
     import refl._
     import util._
     import quoted.Toolbox.Default._
@@ -139,7 +139,7 @@ object Iso {
     if (tpS.isSingleton) {
       val ident = Term.Ident(tpS.asInstanceOf[TermRef]).seal[S]
       '{
-        Iso[S, Unit](Function.const(~ident))(Function.const(()))
+        Iso[S, 1](Function.const(~ident))(Function.const(1))
       }
     }
     else if (tpS.classSymbol.flatMap(cls => if (cls.flags.is(Flags.Case)) Some(true) else None).nonEmpty) {
@@ -156,7 +156,7 @@ object Iso {
       val obj = Term.Select.overloaded(Term.Ident(companion), "apply", Nil, Nil).seal[S]
 
       '{
-        Iso[S, Unit](Function.const(~obj))(Function.const(()))
+        Iso[S, 1](Function.const(~obj))(Function.const(1))
       }
     }
     else {
@@ -176,7 +176,7 @@ object GenIso {
   inline def apply[S, A]: Iso[S, A] = ~Iso.impl[S, A]
 
   inline def fields[S, A]: Iso[S, A] = ???
-  inline def unit[S]: Iso[S, Unit] = ~Iso.implUnit[S]
+  inline def unit[S]: Iso[S, 1] = ~Iso.implUnit[S]
 }
 
 trait Prism[S, A] {

--- a/tests/run-with-compiler/i5941/macro_1.scala
+++ b/tests/run-with-compiler/i5941/macro_1.scala
@@ -58,8 +58,8 @@ object Lens {
     getter.unseal match {
       case Function(param :: Nil, Path(o, parts)) if o.symbol == param.symbol =>
         '{
-          val setter = (t: T) => (s: S) => ~setterBody(('(s)).unseal, ('(t)).unseal, parts).seal[S]
-          apply(~getter)(setter)
+          val setter = (t: T) => (s: S) => ${ setterBody(('s).unseal, ('t).unseal, parts).seal[S] }
+          apply($getter)(setter)
         }
       case _ =>
         throw new QuoteError("Unsupported syntax. Example: `GenLens[Address](_.streetNumber)`")
@@ -77,7 +77,7 @@ object GenLens {
 
   def apply[S] = new MkGenLens[S]
   class MkGenLens[S] {
-    inline def apply[T](get: => (S => T)): Lens[S, T] = ~Lens.impl('(get))
+    inline def apply[T](get: => (S => T)): Lens[S, T] = ${ Lens.impl('get) }
   }
 }
 
@@ -122,9 +122,9 @@ object Iso {
 
     '{
       // (p: S) => p._1
-      val to = (p: S) =>  ~{ Term.Select.unique(('(p)).unseal, "_1").seal[A] }
+      val to = (p: S) =>  ${ Term.Select.unique(('p).unseal, "_1").seal[A] }
       // (p: A) => S(p)
-      val from = (p: A) =>  ~{ Term.Select.overloaded(Term.Ident(companion), "apply", Nil, ('(p)).unseal :: Nil).seal[S] }
+      val from = (p: A) =>  ${ Term.Select.overloaded(Term.Ident(companion), "apply", Nil, ('p).unseal :: Nil).seal[S] }
       apply(from)(to)
     }
   }
@@ -139,7 +139,7 @@ object Iso {
     if (tpS.isSingleton) {
       val ident = Term.Ident(tpS.asInstanceOf[TermRef]).seal[S]
       '{
-        Iso[S, 1](Function.const(~ident))(Function.const(1))
+        Iso[S, 1](Function.const($ident))(Function.const(1))
       }
     }
     else if (tpS.classSymbol.flatMap(cls => if (cls.flags.is(Flags.Case)) Some(true) else None).nonEmpty) {
@@ -156,7 +156,7 @@ object Iso {
       val obj = Term.Select.overloaded(Term.Ident(companion), "apply", Nil, Nil).seal[S]
 
       '{
-        Iso[S, 1](Function.const(~obj))(Function.const(1))
+        Iso[S, 1](Function.const($obj))(Function.const(1))
       }
     }
     else {
@@ -176,12 +176,12 @@ object GenIso {
    *     { p => p._1 }
    *     { p => Person(p) }
    */
-  inline def apply[S, A]: Iso[S, A] = ~Iso.impl[S, A]
+  inline def apply[S, A]: Iso[S, A] = ${ Iso.impl[S, A] }
 
   // TODO: require whitebox macro
-  inline def fields[S]: Iso[S, Any] = ~Iso.implFields[S]
+  inline def fields[S]: Iso[S, Any] = ${ Iso.implFields[S] }
 
-  inline def unit[S]: Iso[S, 1] = ~Iso.implUnit[S]
+  inline def unit[S]: Iso[S, 1] = ${ Iso.implUnit[S] }
 }
 
 trait Prism[S, A] { outer =>
@@ -221,5 +221,5 @@ object GenPrism {
    *     case _       => None
    *   }(jstr => jstr)
    */
-  inline def apply[S, A <: S]: Prism[S, A] = ~Prism.impl[S, A]
+  inline def apply[S, A <: S]: Prism[S, A] = ${ Prism.impl[S, A] }
 }

--- a/tests/run-with-compiler/i5941/macro_1.scala
+++ b/tests/run-with-compiler/i5941/macro_1.scala
@@ -1,0 +1,43 @@
+abstract class Lens[S, T] {
+  def get(s: S): T
+  def set(t: T, s: S) :S
+}
+
+import scala.quoted._
+import scala.tasty._
+
+object Lens {
+  def apply[S, T](_get: S => T)(_set: T => S => S): Lens[S, T] = new Lens {
+    def get(s: S): T = _get(s)
+    def set(t: T, s: S): S = _set(t)(s)
+  }
+
+  /** case class Address(streetNumber: Int, streetName: String)
+   *
+   *  Lens.gen[Address, Int](_.streetNumber)   ~~>
+   *
+   *  Lens[Address, Int](_.streetNumber)(n => a => a.copy(streetNumber = n))
+   */
+  inline def gen[S, T](get: S => T): Lens[S, T] = ~impl('(get))
+
+  def impl[S: Type, T: Type](getter: Expr[S => T])(implicit refl: Reflection): Expr[Lens[S, T]] = {
+    import refl._
+    import util._
+    import quoted.Toolbox.Default._
+
+    // obj.copy(field = value)
+    def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =
+      Term.Select.overloaded(obj.unseal, "copy", Nil, Term.NamedArg(field, value.unseal) :: Nil).seal[S]
+
+    getter.unseal.underlyingArgument match {
+      case Term.Block(
+        DefDef(_, Nil, (param :: Nil) :: Nil, _, Some(Term.Select(o, field))) :: Nil,
+        Term.Lambda(meth, _)
+      ) =>
+        '{
+          val setter = (t: T) => (s: S) => ~setterBody('(s), '(t), field)
+          apply(~getter)(setter)
+        }
+    }
+  }
+}

--- a/tests/run-with-compiler/i5941/macro_1.scala
+++ b/tests/run-with-compiler/i5941/macro_1.scala
@@ -12,14 +12,6 @@ object Lens {
     def set(t: T, s: S): S = _set(t)(s)
   }
 
-  /** case class Address(streetNumber: Int, streetName: String)
-   *
-   *  Lens.gen[Address, Int](_.streetNumber)   ~~>
-   *
-   *  Lens[Address, Int](_.streetNumber)(n => a => a.copy(streetNumber = n))
-   */
-  inline def gen[S, T](get: S => T): Lens[S, T] = ~impl('(get))
-
   def impl[S: Type, T: Type](getter: Expr[S => T])(implicit refl: Reflection): Expr[Lens[S, T]] = {
     import refl._
     import util._
@@ -39,5 +31,19 @@ object Lens {
           apply(~getter)(setter)
         }
     }
+  }
+}
+
+object GenLens {
+  /** case class Address(streetNumber: Int, streetName: String)
+   *
+   *  Lens.gen[Address, Int](_.streetNumber)   ~~>
+   *
+   *  Lens[Address, Int](_.streetNumber)(n => a => a.copy(streetNumber = n))
+   */
+
+  def apply[S] = new MkGenLens[S]
+  class MkGenLens[S] {
+    inline def apply[T](get: S => T): Lens[S, T] = ~Lens.impl('(get))
   }
 }

--- a/tests/run-with-compiler/i5941/macro_1.scala
+++ b/tests/run-with-compiler/i5941/macro_1.scala
@@ -203,10 +203,6 @@ object Prism {
   def impl[S: Type, A <: S : Type](implicit refl: Reflection): Expr[Prism[S, A]] = {
     import refl._
     import util._
-    import quoted.Toolbox.Default._
-
-    val tpS = typeOf[S]
-    val tpA = typeOf[A]
 
     '{
       val get = (p: S) =>  if (p.isInstanceOf[A]) Some(p.asInstanceOf[A]) else None

--- a/tests/run-with-compiler/i5941/usage_2.scala
+++ b/tests/run-with-compiler/i5941/usage_2.scala
@@ -24,10 +24,10 @@ object Test {
     assert(len2.get(employee2) == 5)
 
     // prism
-    // val jStr: Prism[Json, JStr] = GenPrism[Json, JStr]
-    // assert(jStr.getOption(JNum(4.5)) == None)
-    // assert(jStr.getOption(JStr("hello")) == Some(JStr("hello")))
-    // assert(jStr(JStr("world")) == JStr("world"))
+    val jStr: Prism[Json, JStr] = GenPrism[Json, JStr]
+    assert(jStr.getOption(JNum(4.5)) == None)
+    assert(jStr.getOption(JStr("hello")) == Some(JStr("hello")))
+    assert(jStr(JStr("world")) == JStr("world"))
 
     assert(GenIso[JStr, String].to(JStr("Hello")) == "Hello")
     assert(GenIso.unit[JNull.type].to(JNull) == 1)

--- a/tests/run-with-compiler/i5941/usage_2.scala
+++ b/tests/run-with-compiler/i5941/usage_2.scala
@@ -32,5 +32,8 @@ object Test {
     assert(GenIso[JStr, String].to(JStr("Hello")) == "Hello")
     assert(GenIso.unit[JNull.type].to(JNull) == 1)
     assert(GenIso.unit[JNull.type].from(1) == JNull)
+
+    // TODO: require whitebox macros
+    // assert(GenIso.fields[Address].from((0, "a")) == Address(0, "a"))
   }
 }

--- a/tests/run-with-compiler/i5941/usage_2.scala
+++ b/tests/run-with-compiler/i5941/usage_2.scala
@@ -40,5 +40,19 @@ object Test {
     assert(jNum(3.5) == JNum(3.5))
     assert(jNum.getOption(JNum(3.5)) == Some(3.5))
     assert(jNum.getOption(JNull) == None)
+
+    // inner classes
+    val inner = new Inner
+    assert(GenIso[inner.JStr, String].to(inner.JStr("Hello")) == "Hello")
+    assert(GenIso.unit[inner.JNull.type].to(inner.JNull) == 1)
+    assert(GenIso.unit[inner.JNull.type].from(1) == inner.JNull)
   }
+}
+
+class Inner {
+  sealed trait Json
+  case object JNull extends Json
+  case class JStr(v: String) extends Json
+  case class JNum(v: Double) extends Json
+  case class JObj(v: Map[String, Json]) extends Json
 }

--- a/tests/run-with-compiler/i5941/usage_2.scala
+++ b/tests/run-with-compiler/i5941/usage_2.scala
@@ -2,8 +2,7 @@ case class Address(streetNumber: Int, streetName: String)
 
 object Test {
   def main(args: Array[String]): Unit = {
-    // val len = Lens.gen[Address, Int](_.streetNumber)
-    val len = Lens.gen[Address, Int]( (a: Address) => a.streetNumber)
+    val len = GenLens[Address](_.streetNumber)
     val address = Address(10, "High Street")
     assert(len.get(address) == 10)
     val addr2 = len.set(5, address)

--- a/tests/run-with-compiler/i5941/usage_2.scala
+++ b/tests/run-with-compiler/i5941/usage_2.scala
@@ -30,5 +30,7 @@ object Test {
     // assert(jStr(JStr("world")) == JStr("world"))
 
     assert(GenIso[JStr, String].to(JStr("Hello")) == "Hello")
+    assert(GenIso.unit[JNull.type].to(JNull) == (()))
+    assert(GenIso.unit[JNull.type].from(()) == JNull)
   }
 }

--- a/tests/run-with-compiler/i5941/usage_2.scala
+++ b/tests/run-with-compiler/i5941/usage_2.scala
@@ -35,5 +35,10 @@ object Test {
 
     // TODO: require whitebox macros
     // assert(GenIso.fields[Address].from((0, "a")) == Address(0, "a"))
+
+    val jNum: Prism[Json, Double] = GenPrism[Json, JNum] composeIso GenIso[JNum, Double]
+    assert(jNum(3.5) == JNum(3.5))
+    assert(jNum.getOption(JNum(3.5)) == Some(3.5))
+    assert(jNum.getOption(JNull) == None)
   }
 }

--- a/tests/run-with-compiler/i5941/usage_2.scala
+++ b/tests/run-with-compiler/i5941/usage_2.scala
@@ -1,0 +1,12 @@
+case class Address(streetNumber: Int, streetName: String)
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    // val len = Lens.gen[Address, Int](_.streetNumber)
+    val len = Lens.gen[Address, Int]( (a: Address) => a.streetNumber)
+    val address = Address(10, "High Street")
+    assert(len.get(address) == 10)
+    val addr2 = len.set(5, address)
+    assert(len.get(addr2) == 5)
+  }
+}

--- a/tests/run-with-compiler/i5941/usage_2.scala
+++ b/tests/run-with-compiler/i5941/usage_2.scala
@@ -1,5 +1,7 @@
 case class Address(streetNumber: Int, streetName: String)
 
+case class Employee(name: String, addr: Address)
+
 object Test {
   def main(args: Array[String]): Unit = {
     val len = GenLens[Address](_.streetNumber)
@@ -7,5 +9,12 @@ object Test {
     assert(len.get(address) == 10)
     val addr2 = len.set(5, address)
     assert(len.get(addr2) == 5)
+
+    val len2 = GenLens[Employee](_.addr.streetNumber)
+    val employee = Employee("Bob", Address(10, "High Street"))
+    assert(len2.get(employee) == 10)
+    val employee2 = len2.set(5, employee)
+    assert(employee2.name == "Bob")
+    assert(len2.get(employee2) == 5)
   }
 }

--- a/tests/run-with-compiler/i5941/usage_2.scala
+++ b/tests/run-with-compiler/i5941/usage_2.scala
@@ -30,7 +30,7 @@ object Test {
     // assert(jStr(JStr("world")) == JStr("world"))
 
     assert(GenIso[JStr, String].to(JStr("Hello")) == "Hello")
-    assert(GenIso.unit[JNull.type].to(JNull) == (()))
-    assert(GenIso.unit[JNull.type].from(()) == JNull)
+    assert(GenIso.unit[JNull.type].to(JNull) == 1)
+    assert(GenIso.unit[JNull.type].from(1) == JNull)
   }
 }

--- a/tests/run-with-compiler/i5941/usage_2.scala
+++ b/tests/run-with-compiler/i5941/usage_2.scala
@@ -1,6 +1,11 @@
 case class Address(streetNumber: Int, streetName: String)
-
 case class Employee(name: String, addr: Address)
+
+sealed trait Json
+case object JNull extends Json
+case class JStr(v: String) extends Json
+case class JNum(v: Double) extends Json
+case class JObj(v: Map[String, Json]) extends Json
 
 object Test {
   def main(args: Array[String]): Unit = {
@@ -10,11 +15,20 @@ object Test {
     val addr2 = len.set(5, address)
     assert(len.get(addr2) == 5)
 
+    // a.b.c
     val len2 = GenLens[Employee](_.addr.streetNumber)
     val employee = Employee("Bob", Address(10, "High Street"))
     assert(len2.get(employee) == 10)
     val employee2 = len2.set(5, employee)
     assert(employee2.name == "Bob")
     assert(len2.get(employee2) == 5)
+
+    // prism
+    // val jStr: Prism[Json, JStr] = GenPrism[Json, JStr]
+    // assert(jStr.getOption(JNum(4.5)) == None)
+    // assert(jStr.getOption(JStr("hello")) == Some(JStr("hello")))
+    // assert(jStr(JStr("world")) == JStr("world"))
+
+    assert(GenIso[JStr, String].to(JStr("Hello")) == "Hello")
   }
 }


### PR DESCRIPTION
Fix #5941 : Implement Monocle macros

Unfortunately, we are unable to implement `GenIso.fields` due to missing support for whitebox macros.