### PR TITLE
Fix #5948: Tighten rule in hasMatchingMember

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1148,7 +1148,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
       def matchAbstractTypeMember(info1: Type) = info1 match {
         case TypeBounds(lo, hi) if lo ne hi =>
           tp2.refinedInfo match {
-            case rinfo2: TypeBounds if tp1.widenExpr.isSingleton =>
+            case rinfo2: TypeBounds if tp1.isStable =>
               val ref1 = tp1.widenExpr.select(name)
               isSubType(rinfo2.lo, ref1) && isSubType(ref1, rinfo2.hi)
             case _ =>

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1132,7 +1132,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
     /*>|>*/ trace(i"hasMatchingMember($tp1 . $name :? ${tp2.refinedInfo}), mbr: ${tp1.member(name).info}", subtyping) /*<|<*/ {
       val rinfo2 = tp2.refinedInfo
 
-      // If the member is an abstract type, compare the member itself
+      // If the member is an abstract type and the prefix is a path, compare the member itself
       // instead of its bounds. This case is needed situations like:
       //
       //    class C { type T }
@@ -1148,7 +1148,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
       def matchAbstractTypeMember(info1: Type) = info1 match {
         case TypeBounds(lo, hi) if lo ne hi =>
           tp2.refinedInfo match {
-            case rinfo2: TypeBounds =>
+            case rinfo2: TypeBounds if tp1.widenExpr.isSingleton =>
               val ref1 = tp1.widenExpr.select(name)
               isSubType(rinfo2.lo, ref1) && isSubType(ref1, rinfo2.hi)
             case _ =>

--- a/tests/neg/i5948.scala
+++ b/tests/neg/i5948.scala
@@ -1,0 +1,20 @@
+abstract class Foo {
+  type A
+  var elem: A
+}
+
+object Test {
+  def setFirstInList[T](list: List[Foo { type A = T }]) = {
+    list(0).elem = list(1).elem
+  }
+
+  def main(args: Array[String]): Unit = {
+    val fooInt = new Foo { type A = Int; var elem = 1 }
+    val fooString = new Foo { type A = String; var elem = "" }
+
+    val list: List[Foo] = List(fooInt, fooString)
+    setFirstInList[Foo#A](list) // error
+    setFirstInList(list) // error
+    println(fooInt.elem + 1)
+  }
+}

--- a/tests/neg/i5948a.scala
+++ b/tests/neg/i5948a.scala
@@ -1,0 +1,14 @@
+trait Bar {
+  type A
+}
+
+object Test {
+  def test0: Unit = {
+    val b1: Bar = new Bar {}
+    val b2: Bar { type A = Bar#A } = b1 // error
+  }
+  def test1: Unit = {
+    val b1: List[Bar] = List(new Bar {})
+    val b2: List[Bar { type A = Bar#A }] = b1 // error
+  }
+}


### PR DESCRIPTION
This is a partial fix only. We still have to tighten rules around capture to
flag the original example as erroneous.