### PR TITLE
Fix broken implicit function type link on landing page

### DIFF
--- a/docs/_includes/features.html
+++ b/docs/_includes/features.html
@@ -37,7 +37,7 @@
                         <td>Implemented</td>
                     </tr>
                     <tr>
-                        <td><a href="http://dotty.epfl.ch/docs/reference/new-types/implicit-function-types.html">Implicit function types</a></td>
+                        <td><a href="http://dotty.epfl.ch/docs/reference/contextual/query-types.html">Implicit function types</a></td>
                         <td>Implemented</td>
                     </tr>
                     <tr>


### PR DESCRIPTION
This fixes the broken link to implicit function types or context queries on the landing page. The page was renamed in 3bc0547.