### PR TITLE
Parse `macro ???` as `???` to compile the standard library

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -104,9 +104,6 @@ object JavaParsers {
     def arrayOf(tpt: Tree): AppliedTypeTree =
       AppliedTypeTree(Ident(nme.Array.toTypeName), List(tpt))
 
-    def unimplementedExpr(implicit ctx: Context): Select =
-      Select(Select(rootDot(nme.scala_), nme.Predef), nme.???)
-
     def makeTemplate(parents: List[Tree], stats: List[Tree], tparams: List[TypeDef], needsDummyConstr: Boolean): Template = {
       def pullOutFirstConstr(stats: List[Tree]): (Tree, List[Tree]) = stats match {
         case (meth: DefDef) :: rest if meth.name == nme.CONSTRUCTOR => (meth, rest)

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -180,6 +180,7 @@ object Tokens extends TokensCommon {
   final val ERASED = 63;           enter(ERASED, "erased")
   final val IMPLIED = 64;          enter(IMPLIED, "implied")
   final val GIVEN = 65;            enter(GIVEN, "given")
+  final val MACRO = 66;            enter(MACRO, "macro") // TODO: remove
 
   /** special symbols */
   final val NEWLINE = 78;          enter(NEWLINE, "end of statement", "new line")
@@ -200,7 +201,7 @@ object Tokens extends TokensCommon {
   /** XML mode */
   final val XMLSTART = 96;         enter(XMLSTART, "$XMLSTART$<") // TODO: deprecate
 
-  final val alphaKeywords: TokenSet = tokenRange(IF, GIVEN)
+  final val alphaKeywords: TokenSet = tokenRange(IF, MACRO)
   final val symbolicKeywords: TokenSet = tokenRange(USCORE, VIEWBOUND)
   final val symbolicTokens: TokenSet = tokenRange(COMMA, VIEWBOUND)
   final val keywords: TokenSet = alphaKeywords | symbolicKeywords

--- a/compiler/test/dotc/pos-decompilation.blacklist
+++ b/compiler/test/dotc/pos-decompilation.blacklist
@@ -21,3 +21,5 @@ implicit-match.scala
 implicit-match-nested.scala
 implicit-match-and-inline-match.scala
 
+# Need to add backquotes around "macro" since it's a keyword
+macro-deprecate-dont-touch-backquotedidents.scala

--- a/tests/neg/macro.scala
+++ b/tests/neg/macro.scala
@@ -1,0 +1,4 @@
+class A {
+  def bla = ???
+  def foo: Int = macro bla // error
+}

--- a/tests/pos/macro.scala
+++ b/tests/pos/macro.scala
@@ -1,0 +1,3 @@
+class A {
+  def foo: Int = macro ???
+}


### PR DESCRIPTION
This gets us closer to the goal of compiling the standard library
without any patch.