### PR TITLE
Fix #5966: Narrow criterion for when we have an inserted apply

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -432,7 +432,7 @@ object Trees {
     extends GenericApply[T] {
     type ThisTree[-T >: Untyped] = Apply[T]
 
-    def isContextual = getAttachment(untpd.WithApply).nonEmpty
+    def isContextual = getAttachment(untpd.ApplyGiven).nonEmpty
   }
 
   /** fun[args] */

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -274,8 +274,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
    */
   val OriginalSymbol: Property.Key[Symbol] = new Property.Key
 
-  /** Property key for contextual Apply trees of the form `fn with arg` */
-  val WithApply: Property.StickyKey[Unit] = new Property.StickyKey
+  /** Property key for contextual Apply trees of the form `fn given arg` */
+  val ApplyGiven: Property.StickyKey[Unit] = new Property.StickyKey
 
   // ------ Creation methods for untyped only -----------------
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -548,7 +548,7 @@ object Parsers {
             val args = if (in.token == LPAREN) parArgumentExprs() else operand() :: Nil
             Apply(top, args)
           }
-          app.pushAttachment(WithApply, ())
+          app.pushAttachment(ApplyGiven, ())
           recur(app)
         }
         else reduceStack(base, top, minPrec, leftAssoc = true, in.name, isType)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -232,7 +232,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           case dummyTreeOfType(tp) :: Nil if !(tp isRef defn.NullClass) => "null: " ~ toText(tp)
           case _ => toTextGlobal(args, ", ")
         }
-        return "FunProto(" ~ argsText ~ "):" ~ toText(resultType)
+        return "FunProto(" ~ (Str("given ") provided tp.isContextual) ~ argsText ~ "):" ~ toText(resultType)
       case IgnoredProto(ignored) =>
         return "?" ~ (("(ignored: " ~ toText(ignored) ~ ")") provided ctx.settings.verbose.value)
       case tp @ PolyProto(targs, resType) =>

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -218,7 +218,7 @@ object EtaExpansion extends LiftImpure {
     if (mt.paramInfos.nonEmpty && mt.paramInfos.last.isRepeatedParam)
       ids = ids.init :+ repeated(ids.last)
     var body: Tree = Apply(lifted, ids)
-    if (mt.isContextual) body.pushAttachment(WithApply, ())
+    if (mt.isContextual) body.pushAttachment(ApplyGiven, ())
     if (!isLastApplication) body = PostfixOp(body, Ident(nme.WILDCARD))
     val fn =
       if (mt.isContextual) new untpd.FunctionWithMods(params, body, Modifiers(Implicit | Given))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2200,7 +2200,6 @@ class Typer extends Namer
    *  with `fallBack` otherwise. `fallBack` is supposed to always give an error.
    */
   def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType, locked: TypeVars)(fallBack: => Tree)(implicit ctx: Context): Tree = {
-
     def isMethod(tree: Tree) = tree.tpe match {
       case ref: TermRef => ref.denot.alternatives.forall(_.info.widen.isInstanceOf[MethodicType])
       case _ => false
@@ -2208,7 +2207,6 @@ class Typer extends Namer
 
     def isSyntheticApply(tree: Tree): Boolean = tree match {
       case tree: Select => tree.getAttachment(InsertedApply).isDefined
-      case Apply(fn, _) => fn.getAttachment(InsertedApply).isDefined
       case _ => false
     }
 


### PR DESCRIPTION
`insertApplyOrImplicit` checks whether we already have an inserted apply
in order to prevent an infinite insertion sequence. This criterion should
be restricted to just look at Select nodes. Once an inserted `apply`
is in fact applied it should not count anymore.

Also: Fix printing of FunProtos for "given" arguments.