### PR TITLE
Fix #5976: Don't assume `T <:< (=>T)`.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -518,8 +518,8 @@ object Denotations {
           val info1 = denot1.info
           val info2 = denot2.info
           val sameSym = sym1 eq sym2
-          if (sameSym && (info1 frozen_<:< info2)) denot2
-          else if (sameSym && (info2 frozen_<:< info1)) denot1
+          if (sameSym && (info1.widenExpr frozen_<:< info2.widenExpr)) denot2
+          else if (sameSym && (info2.widenExpr frozen_<:< info1.widenExpr)) denot1
           else {
             val jointSym =
               if (sameSym) sym1
@@ -586,9 +586,11 @@ object Denotations {
       (for ((name1, name2, idx) <- (tp1.paramNames, tp2.paramNames, tp1.paramNames.indices).zipped)
        yield if (name1 == name2) name1 else tp1.companion.syntheticParamName(idx)).toList
 
-    /** Normally, `tp1 & tp2`. Special cases for matching methods and classes, with
-      *  the possibility of raising a merge error.
-      */
+    /** Normally, `tp1 & tp2`.
+     *  Special cases for matching methods and classes, with
+     *  the possibility of raising a merge error.
+     *  Special handling of ExprTypes, where mixed intersections widen the ExprType away.
+     */
     def infoMeet(tp1: Type, tp2: Type, sym1: Symbol, sym2: Symbol, safeIntersection: Boolean)(implicit ctx: Context): Type = {
       if (tp1 eq tp2) tp1
       else tp1 match {
@@ -645,9 +647,13 @@ object Denotations {
             case _ =>
               mergeConflict(sym1, sym2, tp1, tp2)
           }
-
+        case ExprType(rtp1) =>
+          tp2 match {
+            case ExprType(rtp2) => ExprType(rtp1 & rtp2)
+            case _ => rtp1 & tp2
+          }
         case _ =>
-          try tp1.widenExpr & tp2.widenExpr
+          try tp1 & tp2.widenExpr
           catch {
             case ex: Throwable =>
               println(i"error for meet: $tp1 &&& $tp2, ${tp1.getClass}, ${tp2.getClass}")
@@ -656,9 +662,11 @@ object Denotations {
       }
     }
 
-    /** Normally, `tp1 | tp2`. Special cases for matching methods and classes, with
-      *  the possibility of raising a merge error.
-      */
+    /** Normally, `tp1 | tp2`.
+     *  Special cases for matching methods and classes, with
+     *  the possibility of raising a merge error.
+     *  Special handling of ExprTypes, where mixed unions widen the ExprType away.
+     */
     def infoJoin(tp1: Type, tp2: Type, sym1: Symbol, sym2: Symbol)(implicit ctx: Context): Type = tp1 match {
       case tp1: TypeBounds =>
         tp2 match {
@@ -697,8 +705,13 @@ object Denotations {
           case _ =>
             mergeConflict(sym1, sym2, tp1, tp2)
         }
+      case ExprType(rtp1) =>
+        tp2 match {
+          case ExprType(rtp2) => ExprType(rtp1 | rtp2)
+          case _ => rtp1 | tp2
+        }
       case _ =>
-        tp1 | tp2
+        tp1 | tp2.widenExpr
     }
 
   /** A non-overloaded denotation */

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -647,7 +647,7 @@ object Denotations {
           }
 
         case _ =>
-          try tp1 & tp2
+          try tp1.widenExpr & tp2.widenExpr
           catch {
             case ex: Throwable =>
               println(i"error for meet: $tp1 &&& $tp2, ${tp1.getClass}, ${tp2.getClass}")

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -621,7 +621,8 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
           // ()T <:< => T, since everything one can do with a => T one can
           // also do with a ()T by automatic () insertion.
           case tp1 @ MethodType(Nil) => isSubType(tp1.resultType, restpe2)
-          case _ => isSubType(tp1.widenExpr, restpe2)
+          case tp1 @ ExprType(restpe1) => isSubType(restpe1, restpe2)
+          case _ => fourthTry
         }
         compareExpr
       case tp2 @ TypeBounds(lo2, hi2) =>
@@ -1237,7 +1238,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
       }
 
       def qualifies(m: SingleDenotation) =
-        isSubType(m.info, rinfo2) || matchAbstractTypeMember(m.info)
+        isSubType(m.info.widenExpr, rinfo2.widenExpr) || matchAbstractTypeMember(m.info)
 
       tp1.member(name) match { // inlined hasAltWith for performance
         case mbr: SingleDenotation => qualifies(mbr)

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1757,7 +1757,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
         case ExprType(rt2) =>
           ExprType(rt1 & rt2)
         case _ =>
-          rt1 & tp2
+          NoType
       }
     case tp1: TypeVar if tp1.isInstantiated =>
       tp1.underlying & tp2
@@ -1777,7 +1777,12 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
    */
   private def distributeOr(tp1: Type, tp2: Type): Type = tp1 match {
     case ExprType(rt1) =>
-      ExprType(rt1 | tp2.widenExpr)
+      tp2 match {
+        case ExprType(rt2) =>
+          ExprType(rt1 | rt2)
+        case _ =>
+          NoType
+      }
     case tp1: TypeVar if tp1.isInstantiated =>
       tp1.underlying | tp2
     case tp1: AnnotatedType if !tp1.isRefining =>

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -119,7 +119,7 @@ object Applications {
       def lengthCompareTp = MethodType(List(defn.IntType), defn.IntType)
       def applyTp(elemTp: Type) = MethodType(List(defn.IntType), elemTp)
       def dropTp(elemTp: Type) = MethodType(List(defn.IntType), defn.SeqType.appliedTo(elemTp))
-      def toSeqTp(elemTp: Type) = ExprType(defn.SeqType.appliedTo(elemTp))
+      def toSeqTp(elemTp: Type) = defn.SeqType.appliedTo(elemTp)
 
       // the result type of `def apply(i: Int): T`
       val elemTp = getTp.member(nme.apply).suchThat(_.info <:< applyTp(WildcardType)).info.resultType
@@ -603,7 +603,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
    * argument trees.
    */
   class ApplicableToTreesDirectly(methRef: TermRef, targs: List[Type], args: List[Tree], resultType: Type)(implicit ctx: Context) extends ApplicableToTrees(methRef, targs, args, resultType)(ctx) {
-    override def argOK(arg: TypedArg, formal: Type): Boolean = argType(arg, formal) <:< formal
+    override def argOK(arg: TypedArg, formal: Type): Boolean = argType(arg, formal) <:< formal.widenExpr
   }
 
   /** Subclass of Application for applicability tests with value argument types. */

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -98,7 +98,7 @@ object Implicits {
             else if (mt.paramInfos.lengthCompare(1) == 0 && {
                   var formal = widenSingleton(mt.paramInfos.head)
                   if (approx) formal = wildApprox(formal)
-                  ctx.test(implicit ctx => argType relaxed_<:< formal)
+                  ctx.test(implicit ctx => argType relaxed_<:< formal.widenExpr)
                 })
               Candidate.Conversion
             else
@@ -1039,7 +1039,7 @@ trait Implicits { self: Typer =>
       val locked = ctx.typerState.ownedVars
       val adapted =
         if (argument.isEmpty)
-          adapt(generated, pt, locked)
+          adapt(generated, pt.widenExpr, locked)
         else {
           val untpdGenerated = untpd.TypedSplice(generated)
           def tryConversion(implicit ctx: Context) =

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1215,7 +1215,7 @@ class Namer { typer: Typer =>
 
       var rhsCtx = ctx.addMode(Mode.InferringReturnType)
       if (sym.isInlineMethod) rhsCtx = rhsCtx.addMode(Mode.InlineableBody)
-      def rhsType = typedAheadExpr(mdef.rhs, inherited orElse rhsProto)(rhsCtx).tpe
+      def rhsType = typedAheadExpr(mdef.rhs, (inherited orElse rhsProto).widenExpr)(rhsCtx).tpe
 
       // Approximate a type `tp` with a type that does not contain skolem types.
       val deskolemize = new ApproximatingTypeMap {

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -31,6 +31,7 @@ object ProtoTypes {
      *    2. `pt` is by name parameter type, and `tp` is compatible with its underlying type
      *    3. there is an implicit conversion from `tp` to `pt`.
      *    4. `tp` is a numeric subtype of `pt` (this case applies even if implicit conversions are disabled)
+     *  If `pt` is a by-name type, we compare against the underlying type instead.
      */
     def isCompatible(tp: Type, pt: Type)(implicit ctx: Context): Boolean =
       (tp.widenExpr relaxed_<:< pt.widenExpr) || viewExists(tp, pt)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -54,7 +54,9 @@ trait TypeAssigner {
           required = EmptyFlagConjunction, excluded = Private)
           .suchThat(decl.matches(_))
       val inheritedInfo = inherited.info
-      if (inheritedInfo.exists && decl.info <:< inheritedInfo && !(inheritedInfo <:< decl.info)) {
+      if (inheritedInfo.exists &&
+          decl.info.widenExpr <:< inheritedInfo.widenExpr &&
+          !(inheritedInfo.widenExpr <:< decl.info.widenExpr)) {
         val r = RefinedType(parent, decl.name, decl.info)
         typr.println(i"add ref $parent $decl --> " + r)
         r

--- a/tests/neg/i5976.scala
+++ b/tests/neg/i5976.scala
@@ -1,0 +1,7 @@
+object Test {
+  def f(i: => Int) = i + i
+  val res = List(42).map(f) // error
+
+  val g: (=> Int) => Int = f
+  val h: Int => Int = g // error
+}

--- a/tests/run/i5976.scala
+++ b/tests/run/i5976.scala
@@ -1,0 +1,10 @@
+object Test extends App {
+  def f(i: => Int) = i + i
+  implicit def ups(f: ((=>Int) => Int)): (Int => Int) = x => f(x)
+  val res = List(42).map(f)
+
+  val g: (=> Int) => Int = f
+  val h: Int => Int = g
+
+  assert(res == List(84))
+}


### PR DESCRIPTION
It's incorrect to assume `T <:< (=> T)` since, taken as parameters,
the erasure of the two types is different: `|T|` vs `Function1`.

To compenate, we need to `widenExpr` in various places.