### PR TITLE
IDE: Make telemetry dialog modal

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -849,7 +849,7 @@ object Build {
     settings(commonSettings).
     settings(
       EclipseKeys.skipProject := true,
-      version := "0.1.14", // Keep in sync with package.json
+      version := "0.1.15-snapshot", // Keep in sync with package.json
       autoScalaLibrary := false,
       publishArtifact := false,
       includeFilter in unmanagedSources := NothingFilter | "*.ts" | "**.json",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -849,7 +849,7 @@ object Build {
     settings(commonSettings).
     settings(
       EclipseKeys.skipProject := true,
-      version := "0.1.14-snapshot", // Keep in sync with package.json
+      version := "0.1.14", // Keep in sync with package.json
       autoScalaLibrary := false,
       publishArtifact := false,
       includeFilter in unmanagedSources := NothingFilter | "*.ts" | "**.json",

--- a/vscode-dotty/package-lock.json
+++ b/vscode-dotty/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dotty",
-  "version": "0.1.14-snapshot",
+  "version": "0.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vscode-dotty/package-lock.json
+++ b/vscode-dotty/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dotty",
-  "version": "0.1.14",
+  "version": "0.1.15-snapshot",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -2,7 +2,7 @@
   "name": "dotty",
   "displayName": "Dotty Language Server",
   "description": "IDE integration for Dotty, the experimental Scala compiler",
-  "version": "0.1.14-snapshot",
+  "version": "0.1.14",
   "license": "BSD-3-Clause",
   "publisher": "lampepfl",
   "repository": {

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -2,7 +2,7 @@
   "name": "dotty",
   "displayName": "Dotty Language Server",
   "description": "IDE integration for Dotty, the experimental Scala compiler",
-  "version": "0.1.14",
+  "version": "0.1.15-snapshot",
   "license": "BSD-3-Clause",
   "publisher": "lampepfl",
   "repository": {

--- a/vscode-dotty/src/tracer.ts
+++ b/vscode-dotty/src/tracer.ts
@@ -101,9 +101,11 @@ export class Tracer {
             'the content of every Scala file in your project and ' +
             'every interaction with Scala files in the IDE, including keystrokes. ' +
             'This data will be stored anonymously (we won\'t know your name) on servers at EPFL in Switzerland.',
-            'Allow', 'Deny',
-        ).then((value: string | undefined) => {
-            if (value === 'Allow' || value === 'Deny') this.tracingConsent.set(value)
+            { 'modal': true },
+            { title: 'Allow' },
+            { title: 'Deny', isCloseAffordance: true }
+        ).then(value => {
+            if (value !== undefined && (value.title === 'Allow' || value.title === 'Deny')) this.tracingConsent.set(value.title)
         })
     }
 


### PR DESCRIPTION
VSCode 1.29 made information dialog hide themselves after a few
students, so students are likely to miss the dialog, the only way
to avoid the timeout is to make the dialog modal.