### PR TITLE
Follow-up of issue #5463 (String API change in JDK 11)

### DIFF
--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -776,7 +776,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
 
         def reporterOutputLines(reporters: List[TestReporter]): List[String] = {
           reporters.flatMap(_.allErrors).sortBy(_.pos.source.toString).flatMap { error =>
-            (error.pos.span.toString + " in " + error.pos.source.file.name) :: error.getMessage().lines.toList
+            (error.pos.span.toString + " in " + error.pos.source.file.name) :: error.getMessage().linesIterator.toList
           }
         }
         def checkFileTest(sourceName: String, checkFile: JFile, actual: List[String]) = {


### PR DESCRIPTION
Same error and same fix as for issue #5463:
```
> java -version
openjdk version "11.0.2" 2019-01-15
OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.2+9)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.2+9, mixed mode, sharing)

> sbt compile
[...]
[info] Test run started
[info] Test xsbt.ExtractUsedNamesSpecification.extractSymbolicNames started
[error] W:\dotty\compiler\test\dotty\tools\vulpix\ParallelTesting.scala:779:105: value toList is not a member of java.util.stream.Stream[String]
[error]             (error.pos.span.toString + " in " + error.pos.source.file.name) :: error.getMessage().lines.toList
[error]                                                                                                         ^

[error] one error found
```
