### PR TITLE
Tweak MissingIdent's explanation

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -282,7 +282,7 @@ object messages {
     val explanation: String = {
       hl"""|The identifier for `$treeKind$name` is not bound, that is,
            |no declaration for this identifier can be found.
-           |That can happen, for instance, if `$name` or its declaration has either been
+           |That can happen, for example, if `$name` or its declaration has either been
            |misspelt or if an import is missing."""
     }
   }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -282,8 +282,8 @@ object messages {
     val explanation: String = {
       hl"""|The identifier for `$treeKind$name` is not bound, that is,
            |no declaration for this identifier can be found.
-           |That can happen for instance if $name or its declaration has either been
-           |misspelt, or if you're forgetting an import"""
+           |That can happen, for instance, if `$name` or its declaration has either been
+           |misspelt or if an import is missing."""
     }
   }
 


### PR DESCRIPTION
Firstly, split out the "for instance" clause so it doesn't get
confusing.  Also backticks-escape the name (in my case name was "the"
which was quite confusing, and funny).  Finally, rather than "accuse"
the user for forgetting, rephrase to "an import is missing".  And end
the sentence with a period.