### PR TITLE
Fix #4659: disallow reference to object itself in super calls

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -785,10 +785,9 @@ trait Checking {
                    |its constructor cannot be called again""", call.sourcePos)
 
       if (caller.is(Module)) {
-        val objRef = caller.sourceModule.termRef
         val traverser = new TreeTraverser {
           def traverse(tree: Tree)(implicit ctx: Context) = tree match {
-            case tree: RefTree if tree.isTerm && tree.tpe <:< objRef =>
+            case tree: RefTree if tree.isTerm && (tree.tpe.widen.classSymbol eq caller) =>
               ctx.error("super constructor cannot be passed a self reference", tree.sourcePos)
             case _ =>
               traverseChildren(tree)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -783,6 +783,19 @@ trait Checking {
       else if (called.is(Trait) && !caller.mixins.contains(called))
         ctx.error(i"""$called is already implemented by super${caller.superClass},
                    |its constructor cannot be called again""", call.sourcePos)
+
+      if (caller.is(Module)) {
+        val objRef = caller.sourceModule.termRef
+        val traverser = new TreeTraverser {
+          def traverse(tree: Tree)(implicit ctx: Context) = tree match {
+            case tree: RefTree if tree.isTerm && tree.tpe <:< objRef =>
+              ctx.error("super constructor cannot be passed a self reference", tree.sourcePos)
+            case _ =>
+              traverseChildren(tree)
+          }
+        }
+        traverser.traverse(call)
+      }
     }
 
   /** Check that `tpt` does not define a higher-kinded type */

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -70,7 +70,7 @@ extends interfaces.SourcePosition with Showable {
 }
 
 /** A sentinel for a non-existing source position */
-@sharable object NoSourcePosition extends SourcePosition(NoSource, NoSpan) {
+@sharable object NoSourcePosition extends SourcePosition(NoSource, NoSpan, null) {
   override def toString: String = "?"
   override def withOuter(outer: SourcePosition): SourcePosition = outer
 }

--- a/tests/neg/i4659.scala
+++ b/tests/neg/i4659.scala
@@ -1,0 +1,11 @@
+class A(val a: A)(val b:a.T) {
+  type T
+}
+
+object a0 extends A(a0)(0) {  // error
+  type T = Int
+}
+
+object Test extends App {
+  new A(a0)(1)
+}

--- a/tests/neg/i4659b.scala
+++ b/tests/neg/i4659b.scala
@@ -1,0 +1,5 @@
+case class SourcePosition(outer: SourcePosition = NoSourcePosition) {
+  assert(outer != null)  // crash
+}
+
+object NoSourcePosition extends SourcePosition() // error

--- a/tests/run/i4659b.scala
+++ b/tests/run/i4659b.scala
@@ -1,5 +1,6 @@
 case class SourcePosition(outer: SourcePosition = (NoSourcePosition: SourcePosition))
 
+// The code should not compile -- currently out of reach
 object NoSourcePosition extends SourcePosition()
 
 object Test extends App {

--- a/tests/run/i4659b.scala
+++ b/tests/run/i4659b.scala
@@ -1,0 +1,7 @@
+case class SourcePosition(outer: SourcePosition = (NoSourcePosition: SourcePosition))
+
+object NoSourcePosition extends SourcePosition()
+
+object Test extends App {
+  assert(NoSourcePosition.outer == null)
+}


### PR DESCRIPTION
Fix #4659: disallow reference to object itself in super calls