### PR TITLE
Fix #2950: prefer inner error

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -940,7 +940,9 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
   def typedUnApply(tree: untpd.Apply, selType: Type)(implicit ctx: Context): Tree = track("typedUnApply") {
     val Apply(qual, args) = tree
 
-    def notAnExtractor(tree: Tree) = errorTree(tree, NotAnExtractor(qual))
+    def notAnExtractor(tree: Tree) =
+      if (tree.tpe.isErroneous) tree
+      else errorTree(tree, NotAnExtractor(qual))
 
     /** If this is a term ref tree, try to typecheck with its type name.
      *  If this refers to a type alias, follow the alias, and if

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -941,6 +941,8 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
     val Apply(qual, args) = tree
 
     def notAnExtractor(tree: Tree) =
+      // prefer inner errors
+      // e.g. report not found ident instead of not an extractor in tests/neg/i2950.scala
       if (!tree.tpe.isError && tree.tpe.isErroneous) tree
       else errorTree(tree, NotAnExtractor(qual))
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -941,7 +941,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
     val Apply(qual, args) = tree
 
     def notAnExtractor(tree: Tree) =
-      if (tree.tpe.isErroneous) tree
+      if (!tree.tpe.isError && tree.tpe.isErroneous) tree
       else errorTree(tree, NotAnExtractor(qual))
 
     /** If this is a term ref tree, try to typecheck with its type name.

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1554,7 +1554,8 @@ class ErrorMessagesTests extends ErrorMessagesTest {
   @Test def notAnExtractor() =
     checkMessagesAfter(FrontEnd.name) {
       """
-        | class Foo
+        | trait Foo
+        | object Foo
         | object Test {
         |   def test(foo: Foo) = foo match {
         |       case Foo(name) => ???

--- a/tests/neg/i2950.scala
+++ b/tests/neg/i2950.scala
@@ -1,0 +1,9 @@
+class T1 {
+  case class Foo(x: Int, xs1: List[String], xs2: List[String])
+}
+
+object T2 {
+  val foo: T1#Foo = ???
+
+  val Foo(x1, xs1, xs2) = foo // error
+}

--- a/tests/neg/parser-stability-10.scala
+++ b/tests/neg/parser-stability-10.scala
@@ -9,6 +9,6 @@ def unapply(i1: Int)(i6: List[Int]): Int = {
 }  // error
 object i5 {
   import collection.mutable._
-  try { ??? mutable { case i1(i5, i3, i4) => i5 }}  // error // error // error
+  try { ??? mutable { case i1(i5, i3, i4) => i5 }}  // error // error
 }
 // error


### PR DESCRIPTION
Fix #2950: prefer inner error

The inner error is supposed to be more informative thus should be preferred.