### PR TITLE
Fix deadlock meta test

### DIFF
--- a/tests/vulpix-tests/unit/deadlock.scala
+++ b/tests/vulpix-tests/unit/deadlock.scala
@@ -3,17 +3,14 @@ object Test {
   val lock1 = new Lock
   val lock2 = new Lock
 
+  private[this] var took1: Boolean = false
   private[this] var took2: Boolean = false
-  def lock2Taken(): Unit = synchronized {
-    took2 = true
-    notify()
-  }
-  def tookLock2: Boolean = synchronized(took2)
 
   val thread1 = new Thread {
-    override def run(): Unit = synchronized {
+    override def run(): Unit = {
       lock1.synchronized {
-        while (!tookLock2) wait()
+        took1 = true
+        while (!took2) Thread.sleep(100)
         lock2.synchronized {
           println("thread1 in lock2!")
         }
@@ -23,9 +20,10 @@ object Test {
   }
 
   val thread2 = new Thread {
-    override def run(): Unit = synchronized {
+    override def run(): Unit = {
       lock2.synchronized {
-        lock2Taken()
+        took2 = true
+        while (!took1) Thread.sleep(100)
         lock1.synchronized {
           println("thread2 in lock1!")
         }


### PR DESCRIPTION
Make sure that deadlock happens. The previous test invovles
too many monitors, it is not obvious that deadlock always
happens.