### PR TITLE
Fix a potential StackOverflow in recursion detection code

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -40,16 +40,21 @@ class MissingType(pre: Type, name: Name) extends TypeError {
   }
 }
 
-class RecursionOverflow(val op: String, details: => String, previous: Throwable, val weight: Int) extends TypeError {
+class RecursionOverflow(val op: String, details: => String, val previous: Throwable, val weight: Int) extends TypeError {
 
   def explanation: String = s"$op $details"
 
   private def recursions: List[RecursionOverflow] = {
-    val nested = previous match {
-      case previous: RecursionOverflow => previous.recursions
-      case _ => Nil
+    import scala.collection.mutable.ListBuffer
+    val result = ListBuffer.empty[RecursionOverflow]
+    @annotation.tailrec def loop(throwable: Throwable): List[RecursionOverflow] = throwable match {
+      case ro: RecursionOverflow =>
+        result += ro
+        loop(ro.previous)
+      case _ => result.toList
+
     }
-    this :: nested
+    loop(this)
   }
 
   def opsString(rs: List[RecursionOverflow])(implicit ctx: Context): String = {


### PR DESCRIPTION
Since the length of the chain of `RecursionOverflow`s is proportional to stack size, it's best to build `recursions` in a loop to avoid a potential stack overflow.

See https://github.com/lampepfl/dotty/pull/5862#discussion_r254375104.