### PR TITLE
Avoid Context#clone

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -433,7 +433,10 @@ object Contexts {
     }
 
     /** A fresh clone of this context. */
-    def fresh: FreshContext = clone.asInstanceOf[FreshContext].init(this)
+    def fresh: FreshContext = {
+      util.Stats.record("Context.fresh")
+      clone.asInstanceOf[FreshContext].init(this)
+    }
 
     final def withOwner(owner: Symbol): Context =
       if (owner ne this.owner) fresh.setOwner(owner) else this

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -9,6 +9,7 @@ import reporting._
 import config.Config
 import collection.mutable
 import java.lang.ref.WeakReference
+import util.Stats
 
 import scala.annotation.internal.sharable
 
@@ -17,6 +18,8 @@ object TyperState {
 }
 
 class TyperState(previous: TyperState /* | Null */) {
+
+  Stats.record("typerState")
 
   val id: Int = TyperState.nextId
   TyperState.nextId += 1
@@ -138,6 +141,7 @@ class TyperState(previous: TyperState /* | Null */) {
    * many parts of dotty itself.
    */
   def commit()(implicit ctx: Context): Unit = {
+    Stats.record("typerState.commit")
     val targetState = ctx.typerState
     assert(isCommittable)
     targetState.constraint =

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -5,7 +5,7 @@ package typer
 import core._
 import ast.{Trees, tpd, untpd}
 import util.Spans._
-import util.Stats.track
+import util.Stats.{track, record}
 import util.{SourcePosition, NoSourcePosition, SourceFile}
 import Trees.Untyped
 import Contexts._
@@ -782,6 +782,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
 
     def realApply(implicit ctx: Context): Tree = track("realApply") {
       val originalProto = new FunProto(tree.args, IgnoredProto(pt))(this, tree.isContextual)(argCtx(tree))
+      record("typedApply")
       val fun1 = typedExpr(tree.fun, originalProto)
 
       // Warning: The following lines are dirty and fragile. We record that auto-tupling was demanded as
@@ -916,6 +917,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
   def typedTypeApply(tree: untpd.TypeApply, pt: Type)(implicit ctx: Context): Tree = track("typedTypeApply") {
     val isNamed = hasNamedArg(tree.args)
     val typedArgs = if (isNamed) typedNamedArgs(tree.args) else tree.args.mapconserve(typedType(_))
+    record("typedTypeApply")
     handleMeta(typedExpr(tree.fun, PolyProto(typedArgs, pt)) match {
       case ExtMethodApply(app) =>
         app

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2190,9 +2190,12 @@ class Typer extends Namer
   def tryEither[T](op: Context => T)(fallBack: (T, TyperState) => T)(implicit ctx: Context): T = {
     val nestedCtx = ctx.fresh.setNewTyperState()
     val result = op(nestedCtx)
-    if (nestedCtx.reporter.hasErrors)
+    if (nestedCtx.reporter.hasErrors) {
+      record("tryEither.fallBack")
       fallBack(result, nestedCtx.typerState)
+    }
     else {
+      record("tryEither.commit")
       nestedCtx.typerState.commit()
       result
     }


### PR DESCRIPTION
Creating a context with a regular allocation is clearer. 

Let's find out whether it is more efficient or not.

