### PR TITLE
Fix #5986: Add autolift implicit conversion

### DIFF
--- a/docs/docs/reference/other-new-features/principled-meta-programming.md
+++ b/docs/docs/reference/other-new-features/principled-meta-programming.md
@@ -600,6 +600,12 @@ Using lifting, we can now give the missing definition of `showExpr` in the intro
 That is, the `showExpr` method converts its `Expr` argument to a string (`code`), and lifts
 the result back to an `Expr[String]` using the `toExpr` wrapper.
 
+**Note**: the `toExpr` extension method can be ommited by importing an implicit
+conversion with `import scala.quoted.autolift._`. The programmer is able to
+declutter slightly the code at the cost of readable _phase distinction_ between
+stages.
+
+
 ## Implementation
 
 ### Syntax

--- a/library/src-bootstrapped/scala/quoted/package.scala
+++ b/library/src-bootstrapped/scala/quoted/package.scala
@@ -2,6 +2,10 @@ package scala
 
 package object quoted {
 
+  object autolift {
+    implicit def autoToExpr[T: Liftable](x: T): Expr[T] = x.toExpr
+  }
+
   implicit class LiftExprOps[T](val x: T) extends AnyVal {
     def toExpr(implicit ev: Liftable[T]): Expr[T] = ev.toExpr(x)
   }

--- a/tests/disabled/run/xml-interpolation-3/XmlQuote_1.scala
+++ b/tests/disabled/run/xml-interpolation-3/XmlQuote_1.scala
@@ -1,5 +1,6 @@
 import scala.quoted._
 import scala.tasty.Tasty
+import scala.quoted.autolift._
 
 import scala.language.implicitConversions
 
@@ -14,6 +15,6 @@ object XmlQuote {
 
   def impl(receiver: StringContext, args: Expr[Seq[Any]]): Expr[Xml] = {
     val string = receiver.parts.mkString("??")
-    '{new Xml(${string.toExpr}, ($args).toList)}
+    '{new Xml(${string}, ($args).toList)}
   }
 }

--- a/tests/neg-with-compiler/quote-run-in-macro-1/quoted_1.scala
+++ b/tests/neg-with-compiler/quote-run-in-macro-1/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.quoted.Toolbox.Default._
 
@@ -6,6 +7,6 @@ object Macros {
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
   def fooImpl(i: Expr[Int]): Expr[Int] = {
     val y: Int = i.run
-    y.toExpr
+    y
   }
 }

--- a/tests/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
+++ b/tests/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
@@ -1,11 +1,11 @@
 import scala.quoted._
-
+import scala.quoted.autolift._
 import scala.quoted.Toolbox.Default._
 
 object Macros {
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
   def fooImpl(i: Expr[Int]): Expr[Int] = {
     val y: Int = i.run
-    y.toExpr
+    y
   }
 }

--- a/tests/neg/inline-case-objects/Macro_1.scala
+++ b/tests/neg/inline-case-objects/Macro_1.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macros {
-  def impl(foo: Any): Expr[String] = foo.getClass.getCanonicalName.toExpr
+  def impl(foo: Any): Expr[String] = foo.getClass.getCanonicalName
 }
 
 class Bar {

--- a/tests/neg/inline-macro-staged-interpreter/Macro_1.scala
+++ b/tests/neg/inline-macro-staged-interpreter/Macro_1.scala
@@ -1,5 +1,6 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object E {
 
@@ -14,7 +15,7 @@ trait E[T] {
 }
 
 case class I(n: Int) extends E[Int] {
-  def lift: Expr[Int] = n.toExpr
+  def lift: Expr[Int] = n
 }
 
 case class Plus[T](x: E[T], y: E[T])(implicit op: Plus2[T]) extends E[T] {

--- a/tests/neg/inline-option/Macro_1.scala
+++ b/tests/neg/inline-option/Macro_1.scala
@@ -1,9 +1,10 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macro {
   def impl(opt: Option[Int]): Expr[Int] = opt match {
-    case Some(i) => i.toExpr
+    case Some(i) => i
     case None => '{-1}
   }
 }

--- a/tests/neg/inline-tuples-1/Macro_1.scala
+++ b/tests/neg/inline-tuples-1/Macro_1.scala
@@ -1,27 +1,28 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macros {
-  def tup1(tup: Tuple1[Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup2(tup: Tuple2[Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup3(tup: Tuple3[Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup4(tup: Tuple4[Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup5(tup: Tuple5[Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup6(tup: Tuple6[Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup7(tup: Tuple7[Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup8(tup: Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup9(tup: Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup10(tup: Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup11(tup: Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup12(tup: Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup13(tup: Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup14(tup: Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup15(tup: Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup16(tup: Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup17(tup: Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup18(tup: Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup19(tup: Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup20(tup: Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup21(tup: Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup22(tup: Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
+  def tup1(tup: Tuple1[Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup2(tup: Tuple2[Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup3(tup: Tuple3[Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup4(tup: Tuple4[Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup5(tup: Tuple5[Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup6(tup: Tuple6[Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup7(tup: Tuple7[Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup8(tup: Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup9(tup: Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup10(tup: Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup11(tup: Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup12(tup: Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup13(tup: Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup14(tup: Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup15(tup: Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup16(tup: Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup17(tup: Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup18(tup: Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup19(tup: Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup20(tup: Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup21(tup: Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup22(tup: Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
 }

--- a/tests/neg/quote-interpolator-core-old.scala
+++ b/tests/neg/quote-interpolator-core-old.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 // This test checks the correct interpretation of the inlined value class
 
@@ -17,7 +18,7 @@ object FInterpolation {
   }
 
   def fInterpolation(sc: StringContext, args: Seq[Expr[Any]]): Expr[String] = {
-    val str: Expr[String] = sc.parts.mkString("").toExpr
+    val str: Expr[String] = sc.parts.mkString("")
     val args1: Expr[Seq[Any]] = liftSeq(args)
     '{ $str.format($args1: _*) }
   }

--- a/tests/neg/quote-macro-splice.scala
+++ b/tests/neg/quote-macro-splice.scala
@@ -1,15 +1,16 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Test {
 
   inline def foo1: Int = { // error
     println()
-    ${ impl(1.toExpr) }
+    ${ impl(1) }
   }
 
   inline def foo2: Int = { // error
-    ${ impl(1.toExpr) }
-    ${ impl(2.toExpr) }
+    ${ impl(1) }
+    ${ impl(2) }
   }
 
   inline def foo3: Int = { // error

--- a/tests/neg/splice-in-top-level-splice-1.scala
+++ b/tests/neg/splice-in-top-level-splice-1.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Foo {
   inline def foo(): Int = ${bar(${x})} // error
   def x: Expr[Int] = '{1}
-  def bar(i: Int): Expr[Int] = i.toExpr
+  def bar(i: Int): Expr[Int] = i
 }

--- a/tests/pending/run/tasty-comments/quoted_1.scala
+++ b/tests/pending/run/tasty-comments/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -12,7 +13,7 @@ object Macros {
 
     val tree = x.unseal
     tree.symbol.comment.map(_.raw) match {
-      case Some(str) => '{ println(${str.toExpr}) }
+      case Some(str) => '{ println(${str}) }
       case None => '{ println() }
     }
   }

--- a/tests/pos-with-compiler/quote-0.scala
+++ b/tests/pos-with-compiler/quote-0.scala
@@ -1,8 +1,10 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.quoted.Toolbox.Default._
 
 object Macros {
+
 
   inline def assert(expr: => Boolean): Unit =
     ${ assertImpl('expr) }
@@ -10,7 +12,8 @@ object Macros {
   def assertImpl(expr: Expr[Boolean]) =
     '{ if !($expr) then throw new AssertionError(s"failed assertion: ${${showExpr(expr)}}") }
 
-  def showExpr[T](expr: Expr[T]): Expr[String] = expr.toString.toExpr
+
+  def showExpr[T](expr: Expr[T]): Expr[String] = expr.toString
 
   inline def power(inline n: Int, x: Double) = ${ powerCode(n, 'x) }
 

--- a/tests/pos/quote-nested-object/Macro_1.scala
+++ b/tests/pos/quote-nested-object/Macro_1.scala
@@ -1,5 +1,6 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macro {
 
@@ -10,7 +11,7 @@ object Macro {
 
     def plus(n: Int, m: Expr[Int]): Expr[Int] =
       if (n == 0) m
-      else '{ ${n.toExpr} + $m }
+      else '{ ${n} + $m }
 
     object Implementation2 {
 
@@ -18,7 +19,7 @@ object Macro {
 
       def plus(n: Int, m: Expr[Int]): Expr[Int] =
         if (n == 0) m
-        else '{ ${n.toExpr} + $m }
+        else '{ ${n} + $m }
     }
   }
 

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -1,5 +1,6 @@
 import scala.quoted._
 import scala.tasty._
+import scala.quoted.autolift._
 
 object Foo {
 
@@ -9,9 +10,9 @@ object Foo {
   def inspectBodyImpl(x: Expr[Int])(implicit reflect: Reflection): Expr[String] = {
     import reflect._
     def definitionString(tree: Tree): Expr[String] = tree.symbol match {
-      case IsDefDefSymbol(sym) => sym.tree.show.toExpr
-      case IsValDefSymbol(sym) => sym.tree.show.toExpr
-      case IsBindSymbol(sym) => sym.tree.show.toExpr
+      case IsDefDefSymbol(sym) => sym.tree.show
+      case IsValDefSymbol(sym) => sym.tree.show
+      case IsBindSymbol(sym) => sym.tree.show
     }
     x.unseal match {
       case Term.Inlined(None, Nil, arg) => definitionString(arg)

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 import scala.tasty._
 
 object Foo {
@@ -9,9 +10,9 @@ object Foo {
   def inspectBodyImpl(x: Expr[Int])(implicit reflect: Reflection): Expr[String] = {
     import reflect._
     def definitionString(tree: Tree): Expr[String] = tree.symbol match {
-      case IsDefDefSymbol(sym) => sym.tree.show.toExpr
-      case IsValDefSymbol(sym) => sym.tree.show.toExpr
-      case IsBindSymbol(sym) => sym.tree.show.toExpr
+      case IsDefDefSymbol(sym) => sym.tree.show
+      case IsValDefSymbol(sym) => sym.tree.show
+      case IsBindSymbol(sym) => sym.tree.show
     }
     x.unseal match {
       case Term.Inlined(None, Nil, arg) => definitionString(arg)

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -42,7 +43,7 @@ object Macros {
 
     val tree = x.unseal
     output.traverseTree(tree)
-    '{print(${buff.result().toExpr})}
+    '{print(${buff.result()})}
   }
 
 }

--- a/tests/run-with-compiler-custom-args/staged-streams_1.scala
+++ b/tests/run-with-compiler-custom-args/staged-streams_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 /**
   * Port of the strymonas library as described in O. Kiselyov et al., Stream fusion, to completeness (POPL 2017)
@@ -598,7 +599,7 @@ object Test {
 
         def init(k: St => Expr[Unit]): Expr[Unit] = {
           Var('{($arr).length}) { n =>
-            Var(0.toExpr){ i =>
+            Var(0){ i =>
               k((i, n, arr))
             }
           }

--- a/tests/run-with-compiler/quote-impure-by-name/quoted_1.scala
+++ b/tests/run-with-compiler/quote-impure-by-name/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.quoted.Toolbox.Default._
 
@@ -13,6 +14,6 @@ object Index {
 
   def succImpl[K, H, T](prev: Expr[Index[K, T]])(implicit k: Type[K], h: Type[H], t: Type[T]): Expr[Index[K, (H, T)]] = {
     val value = s"1 + {${prev.show}}"
-    '{new Index(${value.toExpr})}
+    '{new Index(${value})}
   }
 }

--- a/tests/run-with-compiler/quote-inline-function/quoted_1.scala
+++ b/tests/run-with-compiler/quote-inline-function/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.quoted.Toolbox.Default._
 
@@ -20,6 +21,6 @@ object Macros {
         i += 1
       } while (i < j)
     }
-    res.show.toExpr
+    res.show
   }
 }

--- a/tests/run-with-compiler/quote-lib.scala
+++ b/tests/run-with-compiler/quote-lib.scala
@@ -1,6 +1,7 @@
 
 import scala.quoted._
 import scala.quoted.Toolbox.Default._
+import scala.quoted.autolift._
 
 import liftable.Units._
 import liftable.Lets._
@@ -22,18 +23,18 @@ object Test {
     liftedWhile('{true})('{ println(1) }).show
     liftedDoWhile('{ println(1) })('{true}).show
 
-    val t1: Expr[Tuple1[Int]] = Tuple1(4).toExpr
-    val t2: Expr[(Int, Int)] = (2, 3).toExpr
-    val t3: Expr[(Int, Int, Int)] = (2, 3, 4).toExpr
-    val t4: Expr[(Int, Int, Int, Int)] = (2, 3, 4, 5).toExpr
+    val t1: Expr[Tuple1[Int]] = Tuple1(4)
+    val t2: Expr[(Int, Int)] = (2, 3)
+    val t3: Expr[(Int, Int, Int)] = (2, 3, 4)
+    val t4: Expr[(Int, Int, Int, Int)] = (2, 3, 4, 5)
 
     val list: List[Int] = List(1, 2, 3)
-    val liftedList: Expr[List[Int]] = list.toExpr
+    val liftedList: Expr[List[Int]] = list
 
-    liftedList.foldLeft[Int](0.toExpr)('{ (acc: Int, x: Int) => acc + x }).show
+    liftedList.foldLeft[Int](0)('{ (acc: Int, x: Int) => acc + x }).show
     liftedList.foreach('{ (x: Int) => println(x) }).show
 
-    list.unrolledFoldLeft[Int](0.toExpr)('{ (acc: Int, x: Int) => acc + x }).show
+    list.unrolledFoldLeft[Int](0)('{ (acc: Int, x: Int) => acc + x }).show
     list.unrolledForeach('{ (x: Int) => println(x) }).show
 
     println("quote lib ok")
@@ -76,24 +77,24 @@ package liftable {
 
     implicit def Tuple1IsLiftable[T1: Liftable](implicit t1: Type[T1]): Liftable[Tuple1[T1]] = new Liftable[Tuple1[T1]] {
       def toExpr(x: Tuple1[T1]): Expr[Tuple1[T1]] =
-        '{ Tuple1[$t1](${ x._1.toExpr}) }
+        '{ Tuple1[$t1](${ x._1}) }
     }
 
     implicit def Tuple2IsLiftable[T1: Liftable, T2: Liftable](implicit t1: Type[T1], t2: Type[T2]): Liftable[(T1, T2)] = new Liftable[(T1, T2)] {
       def toExpr(x: (T1, T2)): Expr[(T1, T2)] =
-        '{ Tuple2[$t1, $t2](${x._1.toExpr}, ${x._2.toExpr}) }
+        '{ Tuple2[$t1, $t2](${x._1}, ${x._2}) }
 
     }
 
     implicit def Tuple3IsLiftable[T1: Liftable, T2: Liftable, T3: Liftable](implicit t1: Type[T1], t2: Type[T2], t3: Type[T3]): Liftable[(T1, T2, T3)] = new Liftable[(T1, T2, T3)] {
       def toExpr(x: (T1, T2, T3)): Expr[(T1, T2, T3)] =
-        '{ Tuple3[$t1, $t2, $t3](${x._1.toExpr}, ${x._2.toExpr}, ${x._3.toExpr}) }
+        '{ Tuple3[$t1, $t2, $t3](${x._1}, ${x._2}, ${x._3}) }
 
     }
 
     implicit def Tuple4IsLiftable[T1: Liftable, T2: Liftable, T3: Liftable, T4: Liftable](implicit t1: Type[T1], t2: Type[T2], t3: Type[T3], t4: Type[T4]): Liftable[(T1, T2, T3, T4)] = new Liftable[(T1, T2, T3, T4)] {
       def toExpr(x: (T1, T2, T3, T4)): Expr[(T1, T2, T3, T4)] =
-        '{ Tuple4[$t1, $t2, $t3, $t4](${x._1.toExpr}, ${x._2.toExpr}, ${x._3.toExpr}, ${x._4.toExpr}) }
+        '{ Tuple4[$t1, $t2, $t3, $t4](${x._1}, ${x._2}, ${x._3}, ${x._4}) }
     }
 
     // TODO more tuples
@@ -104,7 +105,7 @@ package liftable {
   object Lists {
     implicit def ListIsLiftable[T: Liftable](implicit t: Type[T]): Liftable[List[T]] = new Liftable[List[T]] {
       def toExpr(x: List[T]): Expr[List[T]] = x match {
-        case x :: xs  => '{ (${xs.toExpr}).::[$t](${x.toExpr}) }
+        case x :: xs  => '{ (${xs}).::[$t](${x}) }
         case Nil => '{ Nil: List[$t] }
       }
     }
@@ -118,18 +119,18 @@ package liftable {
 
     implicit class UnrolledOps[T: Liftable](list: List[T])(implicit t: Type[T]) {
       def unrolledFoldLeft[U](acc: Expr[U])(f: Expr[(U, T) => U])(implicit u: Type[U]): Expr[U] = list match {
-        case x :: xs => xs.unrolledFoldLeft('{ ($f).apply($acc, ${x.toExpr}) })(f)
+        case x :: xs => xs.unrolledFoldLeft('{ ($f).apply($acc, ${x}) })(f)
         case Nil => acc
       }
        def unrolledForeach(f: Expr[T => Unit]): Expr[Unit] = list match {
-         case x :: xs => '{ ($f).apply(${x.toExpr}); ${ xs.unrolledForeach(f) } }
+         case x :: xs => '{ ($f).apply(${x}); ${ xs.unrolledForeach(f) } }
          case Nil => '{}
        }
     }
 
     object Arrays {
       implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T], ct: Expr[ClassTag[T]]): Liftable[Array[T]] = new Liftable[Array[T]] {
-        def toExpr(arr: Array[T]): Expr[Array[T]] = '{ new Array[$t](${arr.length.toExpr})($ct) }
+        def toExpr(arr: Array[T]): Expr[Array[T]] = '{ new Array[$t](${arr.length})($ct) }
       }
     }
 

--- a/tests/run-with-compiler/quote-run-constants.scala
+++ b/tests/run-with-compiler/quote-run-constants.scala
@@ -1,5 +1,6 @@
 
 import scala.quoted.Toolbox.Default._
+import scala.quoted.autolift._
 
 import scala.quoted._
 
@@ -10,35 +11,35 @@ object Test {
     def run[T](expr: Expr[T]): Unit = println(expr.run)
     def show[T](expr: Expr[T]): Unit = println(expr.show)
 
-    run(true.toExpr)
-    run('a'.toExpr)
-    run('\n'.toExpr)
-    run('"'.toExpr)
-    run('\''.toExpr)
-    run('\\'.toExpr)
-    run(1.toExpr)
-    run(2.toExpr)
-    run(3L.toExpr)
-    run(4.0f.toExpr)
-    run(5.0d.toExpr)
-    run("xyz".toExpr)
+    run(true)
+    run('a')
+    run('\n')
+    run('"')
+    run('\'')
+    run('\\')
+    run(1)
+    run(2)
+    run(3L)
+    run(4.0f)
+    run(5.0d)
+    run("xyz")
 
     println("======")
 
-    show(true.toExpr)
-    show('a'.toExpr)
-    show('\n'.toExpr)
-    show('"'.toExpr)
-    show('\''.toExpr)
-    show('\\'.toExpr)
-    show(1.toExpr)
-    show(2.toExpr)
-    show(3L.toExpr)
-    show(4.0f.toExpr)
-    show(5.0d.toExpr)
-    show("xyz".toExpr)
-    show("\n\\\"'".toExpr)
+    show(true)
+    show('a')
+    show('\n')
+    show('"')
+    show('\'')
+    show('\\')
+    show(1)
+    show(2)
+    show(3L)
+    show(4.0f)
+    show(5.0d)
+    show("xyz")
+    show("\n\\\"'")
     show("""abc
-         xyz""".toExpr)
+         xyz""")
   }
 }

--- a/tests/run-with-compiler/quote-run-many.scala
+++ b/tests/run-with-compiler/quote-run-many.scala
@@ -1,11 +1,12 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Test {
   def main(args: Array[String]): Unit = {
     implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make
 
     def expr(i: Int) = '{
-      val a = 3 + ${i.toExpr}
+      val a = 3 + ${i}
       2 + a
     }
     for (i <- 0 to 200)

--- a/tests/run-with-compiler/quote-run-staged-interpreter.scala
+++ b/tests/run-with-compiler/quote-run-staged-interpreter.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.quoted.Toolbox.Default._
 
@@ -14,7 +15,7 @@ object Test {
 
   def compile(e: Exp, env: Map[String, Expr[Int]], keepLets: Boolean): Expr[Int] = {
     def compileImpl(e: Exp, env: Map[String, Expr[Int]]): Expr[Int] = e match {
-      case Num(n) => n.toExpr
+      case Num(n) => n
       case Plus(e1, e2) => '{${compileImpl(e1, env)} + ${compileImpl(e2, env)}}
       case Var(x) => env(x)
       case Let(x, e, body) =>

--- a/tests/run-with-compiler/quote-show-blocks.scala
+++ b/tests/run-with-compiler/quote-show-blocks.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Test {
   def main(args: Array[String]): Unit = {
@@ -6,14 +7,14 @@ object Test {
 
     def a(n: Int, x: Expr[Unit]): Expr[Unit] =
       if (n == 0) x
-      else a(n - 1, '{ println(${n.toExpr}); $x })
+      else a(n - 1, '{ println(${n}); $x })
 
     println(a(5, '{}).show)
 
 
     def b(n: Int, x: Expr[Unit]): Expr[Unit] =
       if (n == 0) x
-      else b(n - 1, '{ $x; println(${n.toExpr}) })
+      else b(n - 1, '{ $x; println(${n}) })
 
     println(b(5, '{}).show)
   }

--- a/tests/run-with-compiler/quote-unrolled-foreach.scala
+++ b/tests/run-with-compiler/quote-unrolled-foreach.scala
@@ -1,5 +1,6 @@
 import scala.annotation.tailrec
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Test {
   implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make
@@ -29,13 +30,13 @@ object Test {
     println(code4.show)
     println()
 
-    val liftedArray = Array(1, 2, 3, 4).toExpr
+    val liftedArray = Array(1, 2, 3, 4)
     println(liftedArray.show)
     println()
 
 
     def printAll(arr: Array[Int]) = '{
-      val arr1 = ${ arr.toExpr }
+      val arr1 = ${ arr }
       ${ foreach1('arr1, '{x => println(x)}) }
     }
 
@@ -110,17 +111,17 @@ object Test {
   def foreach4(arrRef: Expr[Array[Int]], f: Expr[Int => Unit], unrollSize: Int): Expr[Unit] = '{
     val size = ($arrRef).length
     var i = 0
-    if (size % ${unrollSize.toExpr} != 0) throw new Exception("...") // for simplicity of the implementation
+    if (size % ${unrollSize} != 0) throw new Exception("...") // for simplicity of the implementation
     while (i < size) {
-      ${ foreachInRange(0, unrollSize)(j => '{ ($f)(($arrRef)(i + ${j.toExpr})) }) }
-      i += ${unrollSize.toExpr}
+      ${ foreachInRange(0, unrollSize)(j => '{ ($f)(($arrRef)(i + ${j})) }) }
+      i += ${unrollSize}
     }
   }
 
   implicit object ArrayIntIsLiftable extends Liftable[Array[Int]] {
     override def toExpr(x: Array[Int]): Expr[Array[Int]] = '{
-      val array = new Array[Int](${x.length.toExpr})
-      ${ foreachInRange(0, x.length)(i => '{ array(${i.toExpr}) = ${x(i).toExpr}}) }
+      val array = new Array[Int](${x.length})
+      ${ foreachInRange(0, x.length)(i => '{ array(${i}) = ${x(i)}}) }
       array
     }
   }

--- a/tests/run-with-compiler/shonan-hmm/Lifters.scala
+++ b/tests/run-with-compiler/shonan-hmm/Lifters.scala
@@ -6,12 +6,12 @@ import scala.quoted._
 import scala.quoted.autolift._
 
 object Lifters {
-
-  implicit def ClassTagIsLiftable[T : Type](implicit ct: ClassTag[T]): Liftable[ClassTag[T]] =
-    ct => '{ClassTag(${ct.runtimeClass})}
+  implicit def LiftedClassTag[T: Type](implicit ct: ClassTag[T]): Expr[ClassTag[T]] = {
+    '{ ClassTag(${ct.runtimeClass })}
+  }
 
   implicit def ArrayIsLiftable[T : Type: ClassTag](implicit l: Liftable[T]): Liftable[Array[T]] = arr => '{
-    val array = new Array[T](${arr.length})(${implicitly[ClassTag[T]]})
+    val array = new Array[T](${arr.length})(${implicitly[Expr[ClassTag[T]]]})
     ${initArray(arr, 'array)}
   }
 
@@ -27,5 +27,4 @@ object Lifters {
       }.toList,
       array)
   }
-
 }

--- a/tests/run-with-compiler/shonan-hmm/Lifters.scala
+++ b/tests/run-with-compiler/shonan-hmm/Lifters.scala
@@ -3,26 +3,27 @@ import UnrolledExpr._
 
 import scala.reflect.ClassTag
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Lifters {
 
   implicit def ClassTagIsLiftable[T : Type](implicit ct: ClassTag[T]): Liftable[ClassTag[T]] =
-    ct => '{ClassTag(${ct.runtimeClass.toExpr})}
+    ct => '{ClassTag(${ct.runtimeClass})}
 
   implicit def ArrayIsLiftable[T : Type: ClassTag](implicit l: Liftable[T]): Liftable[Array[T]] = arr => '{
-    val array = new Array[T](${arr.length.toExpr})(${implicitly[ClassTag[T]].toExpr})
+    val array = new Array[T](${arr.length})(${implicitly[ClassTag[T]]})
     ${initArray(arr, 'array)}
   }
 
   implicit def IntArrayIsLiftable: Liftable[Array[Int]] = arr => '{
-    val array = new Array[Int](${arr.length.toExpr})
+    val array = new Array[Int](${arr.length})
     ${initArray(arr, 'array)}
   }
 
   private def initArray[T : Liftable : Type](arr: Array[T], array: Expr[Array[T]]): Expr[Array[T]] = {
     UnrolledExpr.block(
       arr.zipWithIndex.map {
-        case (x, i) => '{ $array(${i.toExpr}) = ${x.toExpr} }
+        case (x, i) => '{ $array(${i}) = ${x} }
       }.toList,
       array)
   }

--- a/tests/run-with-compiler/shonan-hmm/MVmult.scala
+++ b/tests/run-with-compiler/shonan-hmm/MVmult.scala
@@ -1,6 +1,7 @@
 
 import scala.quoted.Toolbox.Default._
 import scala.quoted._
+import scala.quoted.autolift._
 
 class MVmult[Idx, T, Unt](tring: Ring[T], vec: VecROp[Idx, T, Unt]) {
   private[this] val blas2 = new Blas2(tring, vec)
@@ -41,12 +42,12 @@ object MVmult {
     val MV = new MVmult[Int, Expr[Int], Expr[Unit]](RingIntExpr, new VecRStaDim(RingIntExpr))
     '{
       (vout, a, v) => {
-        if (${n.toExpr} != vout.length) throw new IndexOutOfBoundsException(${n.toString.toExpr})
-        if (${m.toExpr} != v.length) throw new IndexOutOfBoundsException(${m.toString.toExpr})
+        if (${n} != vout.length) throw new IndexOutOfBoundsException(${n.toString})
+        if (${m} != v.length) throw new IndexOutOfBoundsException(${m.toString})
         ${
-          val vout_ = OVec(n, (i, x: Expr[Int]) => '{vout(${i.toExpr}) = $x})
-          val a_ = Vec(n, i => Vec(m, j => '{ a(${i.toExpr})(${j.toExpr}) } ))
-          val v_ = Vec(m, i => '{v(${i.toExpr})})
+          val vout_ = OVec(n, (i, x: Expr[Int]) => '{vout(${i}) = $x})
+          val a_ = Vec(n, i => Vec(m, j => '{ a(${i})(${j}) } ))
+          val v_ = Vec(m, i => '{v(${i})})
 
           MV.mvmult(vout_, a_, v_)
         }
@@ -57,7 +58,7 @@ object MVmult {
   def mvmult_ac(a: Array[Array[Int]]): Expr[(Array[Int], Array[Int]) => Unit] = {
     import Lifters._
     '{
-      val arr = ${a.toExpr}
+      val arr = ${a}
       ${
         val (n, m, a2) = amat1(a, 'arr)
         mvmult_abs0(new RingIntPExpr, new VecRStaDyn(new RingIntPExpr))(n, m, a2)
@@ -68,7 +69,7 @@ object MVmult {
   def mvmult_opt(a: Array[Array[Int]]): Expr[(Array[Int], Array[Int]) => Unit] = {
     import Lifters._
     '{
-      val arr = ${a.toExpr}
+      val arr = ${a}
       ${
         val (n, m, a2) = amat1(a, 'arr)
         mvmult_abs0(new RingIntOPExpr, new VecRStaDyn(new RingIntPExpr))(n, m, a2)
@@ -79,7 +80,7 @@ object MVmult {
   def mvmult_roll(a: Array[Array[Int]]): Expr[(Array[Int], Array[Int]) => Unit] = {
     import Lifters._
     '{
-      val arr = ${a.toExpr}
+      val arr = ${a}
       ${
         val (n, m, a2) = amat1(a, 'arr)
         mvmult_abs0(new RingIntOPExpr, new VecRStaOptDynInt(new RingIntPExpr))(n, m, a2)
@@ -107,7 +108,7 @@ object MVmult {
         val default: Expr[Array[Int]] = '{null.asInstanceOf[Array[Int]]} // never accessed
         loop(i + 1, default :: acc)
       } else '{
-        val row = ${a(i).toExpr}
+        val row = ${a(i)}
         ${ loop(i + 1, 'row :: acc) }
       }
     }
@@ -119,7 +120,7 @@ object MVmult {
     val m = a(0).length
     val vec: Vec[PV[Int], Vec[PV[Int], PV[Int]]] = Vec(Sta(n), i => Vec(Sta(m), j => (i, j) match {
       case (Sta(i), Sta(j)) => Sta(a(i)(j))
-      case (Sta(i), Dyn(j)) => Dyn('{$aa(${i.toExpr})($j)})
+      case (Sta(i), Dyn(j)) => Dyn('{$aa(${i})($j)})
       case (i, j) => Dyn('{ $aa(${Dyns.dyni(i)})(${Dyns.dyni(j)}) })
     }))
     (n, m, vec)
@@ -150,21 +151,21 @@ object MVmult {
 
   def copy_row1: Array[Int] => (Expr[Int] => Expr[Int]) = v => {
     import Lifters._
-    val arr = v.toExpr
+    val arr = v
     i => '{ ($arr).apply($i) }
   }
 
   def copy_row_let: Array[Int] => (Expr[Int] => Expr[Int]) = v => {
     import Lifters._
-    val arr: Expr[Array[Int]] = ??? // FIXME used genlet v.toExpr
+    val arr: Expr[Array[Int]] = ??? // FIXME used genlet v
     i => '{ ($arr).apply($i) }
   }
 
   private def mvmult_abs0(ring: Ring[PV[Int]], vecOp: VecROp[PV[Int], PV[Int], Expr[Unit]])(n: Int, m: Int, a: Vec[PV[Int], Vec[PV[Int], PV[Int]]]): Expr[(Array[Int], Array[Int]) => Unit] = {
     '{
       (vout, v) => {
-        if (${n.toExpr} != vout.length) throw new IndexOutOfBoundsException(${n.toString.toExpr})
-        if (${m.toExpr} != v.length) throw new IndexOutOfBoundsException(${m.toString.toExpr})
+        if (${n} != vout.length) throw new IndexOutOfBoundsException(${n.toString})
+        if (${m} != v.length) throw new IndexOutOfBoundsException(${m.toString})
         ${
           val vout_ : OVec[PV[Int], PV[Int], Expr[Unit]] = OVec(Sta(n), (i, x) => '{vout(${Dyns.dyni(i)}) = ${Dyns.dyn(x)}})
           val v_ : Vec[PV[Int], PV[Int]] = Vec(Sta(m), i => Dyn('{v(${Dyns.dyni(i)})}))

--- a/tests/run-with-compiler/shonan-hmm/VecROp.scala
+++ b/tests/run-with-compiler/shonan-hmm/VecROp.scala
@@ -1,5 +1,6 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 trait VecROp[Idx, T, Unt] extends VecOp[Idx, Unt] {
   def reduce: ((T, T) => T, T, Vec[Idx, T]) => T
@@ -79,7 +80,7 @@ class VecRStaOptDynInt(r: Ring[PV[Int]]) extends VecRStaDyn(r) {
   override def reduce: ((PV[Int], PV[Int]) => PV[Int], PV[Int], Vec[PV[Int], PV[Int]]) => PV[Int] = (plus, zero, vec) => vec match {
     case Vec(Sta(n), vecf) =>
       if (count_non_zeros(n, vecf) < VecRStaOptDynInt.threshold) M.reduce(plus, zero, vec)
-      else M.reduce(plus, zero, Vec(Dyn(n.toExpr), vecf))
+      else M.reduce(plus, zero, Vec(Dyn(n), vecf))
     case _ => M.reduce(plus, zero, vec)
   }
 

--- a/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
+++ b/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
@@ -1,5 +1,6 @@
 import scala.quoted._
 import scala.quoted.Toolbox.Default._
+import scala.quoted.autolift._
 
 import scala.tasty._
 import scala.tasty.util._
@@ -10,36 +11,36 @@ object Macros {
 
   def impl(implicit reflect: Reflection): Expr[Unit] = {
     // 2 is a lifted constant
-    val show1 = power(2.toExpr, 3.0.toExpr).show
-    val run1  = power(2.toExpr, 3.0.toExpr).run
+    val show1 = power(2, 3.0).show
+    val run1  = power(2, 3.0).run
 
     // n is a lifted constant
     val n = 2
-    val show2 = power(n.toExpr, 4.0.toExpr).show
-    val run2  = power(n.toExpr, 4.0.toExpr).run
+    val show2 = power(n, 4.0).show
+    val run2  = power(n, 4.0).run
 
     // n is a constant in a quote
-    val show3 = power('{2}, 5.0.toExpr).show
-    val run3 =  power('{2}, 5.0.toExpr).run
+    val show3 = power('{2}, 5.0).show
+    val run3 =  power('{2}, 5.0).run
 
     // n2 is clearly not a constant
     // FIXME
 //    val n2 = '{ println("foo"); 2 }
-//    val show4 = (power(n2, 6.0.toExpr).show)
-//    val run4  = (power(n2, 6.0.toExpr).run)
+//    val show4 = (power(n2, 6.0).show)
+//    val run4  = (power(n2, 6.0).run)
 
     '{
-      println(${show1.toExpr})
-      println(${run1.toExpr})
+      println(${show1})
+      println(${run1})
       println()
-      println(${show2.toExpr})
-      println(${run2.toExpr})
+      println(${show2})
+      println(${run2})
       println()
-      println(${show3.toExpr})
-      println(${run3.toExpr})
+      println(${show3})
+      println(${run3})
 //      println()
-//      println(${show4.toExpr})
-//      println(${run4.toExpr})
+//      println(${show4})
+//      println(${run4})
     }
   }
 

--- a/tests/run/f-interpolation-1/FQuote_1.scala
+++ b/tests/run/f-interpolation-1/FQuote_1.scala
@@ -1,5 +1,6 @@
 import scala.quoted._
 import scala.tasty.Reflection
+import scala.quoted.autolift._
 
 import scala.language.implicitConversions
 
@@ -47,12 +48,12 @@ object FQuote {
 
     for ((arg, part) <- allArgs.zip(parts.tail)) {
       if (part.startsWith("%d") && !(arg.tpe <:< definitions.IntType)) {
-        return '{s"`${${arg.showCode.toExpr}}` is not of type Int"}
+        return '{s"`${${arg.showCode}}` is not of type Int"}
       }
 
     }
 
     val string = parts.mkString("")
-    '{ new collection.immutable.StringOps(${string.toExpr}).format($args: _*) }
+    '{ new collection.immutable.StringOps(${string}).format($args: _*) }
   }
 }

--- a/tests/run/i4734/Macro_1.scala
+++ b/tests/run/i4734/Macro_1.scala
@@ -1,5 +1,6 @@
 import scala.annotation.tailrec
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macros {
   inline def unrolledForeach(seq: IndexedSeq[Int], f: => Int => Unit, inline unrollSize: Int): Unit = // or f: Int => Unit
@@ -7,17 +8,17 @@ object Macros {
 
   def unrolledForeachImpl(seq: Expr[IndexedSeq[Int]], f: Expr[Int => Unit], unrollSize: Int): Expr[Unit] = '{
     val size = ($seq).length
-    assert(size % (${unrollSize.toExpr}) == 0) // for simplicity of the implementation
+    assert(size % (${unrollSize}) == 0) // for simplicity of the implementation
     var i = 0
     while (i < size) {
       ${
         for (j <- new UnrolledRange(0, unrollSize)) '{
-          val index = i + ${j.toExpr}
+          val index = i + ${j}
           val element = ($seq)(index)
           ${ f('element) } // or `($f)(element)` if `f` should not be inlined
         }
       }
-      i += ${unrollSize.toExpr}
+      i += ${unrollSize}
     }
 
   }

--- a/tests/run/i4735/Macro_1.scala
+++ b/tests/run/i4735/Macro_1.scala
@@ -1,4 +1,6 @@
 import scala.annotation.tailrec
+import scala.quoted.autolift._
+
 import scala.quoted._
 
 object Macro {
@@ -8,17 +10,17 @@ object Macro {
 
   private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{
     val size = ($seq).length
-    assert(size % (${unrollSize.toExpr}) == 0) // for simplicity of the implementation
+    assert(size % (${unrollSize}) == 0) // for simplicity of the implementation
     var i = 0
     while (i < size) {
       println("<log> start loop")
       ${
         for (j <- new UnrolledRange(0, unrollSize)) '{
-          val element = ($seq)(i + ${j.toExpr})
+          val element = ($seq)(i + ${j})
           ${f('element)} // or `($f)(element)` if `f` should not be inlined
         }
       }
-      i += ${unrollSize.toExpr}
+      i += ${unrollSize}
     }
 
   }

--- a/tests/run/i5119/Macro_1.scala
+++ b/tests/run/i5119/Macro_1.scala
@@ -1,5 +1,6 @@
 import scala.quoted._
 import scala.tasty.Reflection
+import scala.quoted.autolift._
 
 object Macro {
   class StringContextOps(sc: => StringContext) {
@@ -8,6 +9,6 @@ object Macro {
   implicit inline def XmlQuote(sc: => StringContext): StringContextOps = new StringContextOps(sc)
   def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(implicit reflect: Reflection): Expr[String] = {
     import reflect._
-    (sc.unseal.underlyingArgument.show + "\n" + args.unseal.underlyingArgument.show).toExpr
+    (sc.unseal.underlyingArgument.show + "\n" + args.unseal.underlyingArgument.show)
   }
 }

--- a/tests/run/i5119b/Macro_1.scala
+++ b/tests/run/i5119b/Macro_1.scala
@@ -1,4 +1,6 @@
 import scala.quoted._
+import scala.quoted.autolift._
+
 import scala.tasty.Reflection
 
 object Macro {
@@ -7,7 +9,7 @@ object Macro {
 
   def impl(arg1: Expr[Any], arg2: Expr[Any])(implicit reflect: Reflection): Expr[String] = {
     import reflect._
-    (arg1.unseal.underlyingArgument.show + "\n" + arg2.unseal.underlyingArgument.show).toExpr
+    (arg1.unseal.underlyingArgument.show + "\n" + arg2.unseal.underlyingArgument.show)
   }
 
 }

--- a/tests/run/i5188a/Macro_1.scala
+++ b/tests/run/i5188a/Macro_1.scala
@@ -1,6 +1,7 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Lib {
   inline def sum(inline args: Int*): Int = ${ impl(args: _*) }
-  def impl(args: Int*): Expr[Int] = args.sum.toExpr
+  def impl(args: Int*): Expr[Int] = args.sum
 }

--- a/tests/run/inline-case-objects/Macro_1.scala
+++ b/tests/run/inline-case-objects/Macro_1.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macros {
-  def impl(foo: Any): Expr[String] = foo.getClass.getCanonicalName.toExpr
+  def impl(foo: Any): Expr[String] = foo.getClass.getCanonicalName
 }
 
 case object Bar {

--- a/tests/run/inline-macro-staged-interpreter/Macro_1.scala
+++ b/tests/run/inline-macro-staged-interpreter/Macro_1.scala
@@ -1,5 +1,6 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object E {
 
@@ -14,11 +15,11 @@ trait E[T] {
 }
 
 case class I(n: Int) extends E[Int] {
-  def lift: Expr[Int] = n.toExpr
+  def lift: Expr[Int] = n
 }
 
 case class D(n: Double) extends E[Double] {
-  def lift: Expr[Double] = n.toExpr
+  def lift: Expr[Double] = n
 }
 
 case class Plus[T](x: E[T], y: E[T])(implicit op: Plus2[T]) extends E[T] {

--- a/tests/run/inline-option/Macro_1.scala
+++ b/tests/run/inline-option/Macro_1.scala
@@ -1,10 +1,11 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macros {
 
   def impl(opt: Option[Int]): Expr[Int] = opt match {
-    case Some(i) => i.toExpr
+    case Some(i) => i
     case None => '{-1}
   }
 

--- a/tests/run/inline-tuples-1/Macro_1.scala
+++ b/tests/run/inline-tuples-1/Macro_1.scala
@@ -1,27 +1,28 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macros {
-  def tup1(tup: Tuple1[Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup2(tup: Tuple2[Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup3(tup: Tuple3[Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup4(tup: Tuple4[Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup5(tup: Tuple5[Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup6(tup: Tuple6[Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup7(tup: Tuple7[Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup8(tup: Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup9(tup: Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup10(tup: Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup11(tup: Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup12(tup: Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup13(tup: Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup14(tup: Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup15(tup: Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup16(tup: Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup17(tup: Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup18(tup: Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup19(tup: Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup20(tup: Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup21(tup: Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
-  def tup22(tup: Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum.toExpr
+  def tup1(tup: Tuple1[Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup2(tup: Tuple2[Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup3(tup: Tuple3[Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup4(tup: Tuple4[Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup5(tup: Tuple5[Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup6(tup: Tuple6[Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup7(tup: Tuple7[Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup8(tup: Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup9(tup: Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup10(tup: Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup11(tup: Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup12(tup: Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup13(tup: Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup14(tup: Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup15(tup: Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup16(tup: Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup17(tup: Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup18(tup: Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup19(tup: Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup20(tup: Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup21(tup: Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup22(tup: Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
 }

--- a/tests/run/inline-tuples-2/Macro_1.scala
+++ b/tests/run/inline-tuples-2/Macro_1.scala
@@ -1,9 +1,10 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macros {
 
-  def impl(tup: Tuple1[Int]): Expr[Int] = tup._1.toExpr
+  def impl(tup: Tuple1[Int]): Expr[Int] = tup._1
 
   def impl2(tup: Tuple1[Tuple1[Int]]): Expr[Int] = impl(tup._1)
 

--- a/tests/run/inline-varargs-1/Macro_1.scala
+++ b/tests/run/inline-varargs-1/Macro_1.scala
@@ -1,6 +1,7 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macros {
-  def sum(nums: Int*): Expr[Int] = nums.sum.toExpr
+  def sum(nums: Int*): Expr[Int] = nums.sum
 }

--- a/tests/run/quote-force/quoted_1.scala
+++ b/tests/run/quote-force/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 case class Location(owners: List[String])
 
@@ -8,11 +9,11 @@ object Location {
 
   def impl: Expr[Location] = {
     val list = List("a", "b", "c", "d", "e", "f")
-    '{new Location(${list.toExpr})}
+    '{new Location(${list})}
   }
 
   private implicit def ListIsLiftable[T : Liftable : Type]: Liftable[List[T]] = {
-    case x :: xs  => '{ ${x.toExpr} :: ${xs.toExpr} }
+    case x :: xs  => '{ ${x} :: ${xs} }
     case Nil => '{ List.empty[T] }
   }
 }

--- a/tests/run/quote-simple-macro/quoted_1.scala
+++ b/tests/run/quote-simple-macro/quoted_1.scala
@@ -1,6 +1,7 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macros {
   inline def foo(inline i: Int, dummy: Int, j: Int): Int = ${ bar(i, 'j) }
-  def bar(x: Int, y: Expr[Int]): Expr[Int] = '{ ${x.toExpr} + $y }
+  def bar(x: Int, y: Expr[Int]): Expr[Int] = '{ ${x} + $y }
 }

--- a/tests/run/quote-unrolled-foreach/quoted_1.scala
+++ b/tests/run/quote-unrolled-foreach/quoted_1.scala
@@ -1,5 +1,6 @@
 import scala.annotation.tailrec
 import scala.quoted._
+import scala.quoted.autolift._
 
 object Macro {
 
@@ -8,17 +9,17 @@ object Macro {
 
   private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{
     val size = $seq.length
-    assert(size % (${unrollSize.toExpr}) == 0) // for simplicity of the implementation
+    assert(size % (${unrollSize}) == 0) // for simplicity of the implementation
     var i = 0
     while (i < size) {
       println("<log> start loop")
       ${
         @tailrec def loop(j: Int, acc: Expr[Unit]): Expr[Unit] =
-          if (j >= 0) loop(j - 1, '{ ${f('{$seq(i + ${j.toExpr})})}; $acc })
-          else acc
+        if (j >= 0) loop(j - 1, '{ ${f('{$seq(i + ${j})})}; $acc })
+        else acc
         loop(unrollSize - 1, '{})
       }
-      i += ${unrollSize.toExpr}
+      i += ${unrollSize}
     }
   }
 }

--- a/tests/run/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run/tasty-argument-tree-1/quoted_1.scala
@@ -1,4 +1,6 @@
 import scala.quoted._
+import scala.quoted.autolift._
+
 import scala.tasty._
 
 object Macros {
@@ -10,8 +12,8 @@ object Macros {
     val tree = x.unseal
     '{
       println()
-      println("tree: " + ${tree.show.toExpr})
-      println("tree deref. vals: " + ${tree.underlying.show.toExpr})
+      println("tree: " + ${tree.show})
+      println("tree deref. vals: " + ${tree.underlying.show})
     }
   }
 }

--- a/tests/run/tasty-custom-show/quoted_1.scala
+++ b/tests/run/tasty-custom-show/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty.Reflection
 
@@ -35,7 +36,7 @@ object Macros {
 
     val tree = x.unseal
     output.traverseTree(tree)
-    '{print(${buff.result().toExpr})}
+    '{print(${buff.result()})}
   }
 
   def dummyShow(implicit reflect: Reflection): reflect.Printer = {

--- a/tests/run/tasty-definitions-1/quoted_1.scala
+++ b/tests/run/tasty-definitions-1/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -93,7 +94,7 @@ object Macros {
     printout(definitions.StringType.show)
 
 
-    '{println(${buff.result().mkString("\n").toExpr})}
+    '{println(${buff.result().mkString("\n")})}
   }
 
 }

--- a/tests/run/tasty-eval/quoted_1.scala
+++ b/tests/run/tasty-eval/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -8,7 +9,7 @@ object Macros {
     ${ impl('i) }
 
   def impl(i: Expr[Int])(implicit reflect: Reflection): Expr[String] = {
-    value(i).toString.toExpr
+    value(i).toString
   }
 
   inline implicit def value[X](e: Expr[X])(implicit reflect: Reflection, ev: Valuable[X]): Option[X] = ev.value(e)

--- a/tests/run/tasty-extractors-1/quoted_1.scala
+++ b/tests/run/tasty-extractors-1/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -15,8 +16,8 @@ object Macros {
     val treeTpeStr = tree.tpe.show
 
     '{
-      println(${treeStr.toExpr})
-      println(${treeTpeStr.toExpr})
+      println(${treeStr})
+      println(${treeTpeStr})
       println()
     }
   }

--- a/tests/run/tasty-extractors-2/quoted_1.scala
+++ b/tests/run/tasty-extractors-2/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -16,8 +17,8 @@ object Macros {
     val treeTpeStr = tree.tpe.show
 
     '{
-      println(${treeStr.toExpr})
-      println(${treeTpeStr.toExpr})
+      println(${treeStr})
+      println(${treeTpeStr})
       println()
     }
   }

--- a/tests/run/tasty-extractors-3/quoted_1.scala
+++ b/tests/run/tasty-extractors-3/quoted_1.scala
@@ -1,6 +1,7 @@
 import scala.quoted._
 
 import scala.tasty.Reflection
+import scala.quoted.autolift._
 
 object Macros {
 
@@ -28,6 +29,6 @@ object Macros {
 
     val tree = x.unseal
     traverser.traverseTree(tree)
-    '{print(${buff.result().toExpr})}
+    '{print(${buff.result()})}
   }
 }

--- a/tests/run/tasty-extractors-constants-1/quoted_1.scala
+++ b/tests/run/tasty-extractors-constants-1/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 import scala.tasty.util._
@@ -22,6 +23,6 @@ object Macros {
 
     '{new Object} match { case Constant(n) => println(n); case _ => stagedPrintln("OK") }
 
-    '{print(${buff.result().toExpr})}
+    '{print(${buff.result()})}
   }
 }

--- a/tests/run/tasty-extractors-types/quoted_1.scala
+++ b/tests/run/tasty-extractors-types/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -11,8 +12,8 @@ object Macros {
 
     val tree = x.unseal
     '{
-      println(${tree.show.toExpr})
-      println(${tree.tpe.show.toExpr})
+      println(${tree.show})
+      println(${tree.tpe.show})
       println()
     }
   }

--- a/tests/run/tasty-getfile-implicit-fun-context/Macro_1.scala
+++ b/tests/run/tasty-getfile-implicit-fun-context/Macro_1.scala
@@ -1,4 +1,6 @@
 import scala.quoted._
+import scala.quoted.autolift._
+
 import scala.tasty.Reflection
 
 object SourceFiles {
@@ -12,7 +14,7 @@ object SourceFiles {
   def getThisFileImpl: Macro[String] = {
     val reflect = tastyContext
     import reflect._
-    rootContext.source.getFileName.toString.toExpr
+    rootContext.source.getFileName.toString
   }
 
 

--- a/tests/run/tasty-getfile/Macro_1.scala
+++ b/tests/run/tasty-getfile/Macro_1.scala
@@ -1,4 +1,6 @@
 import scala.quoted._
+import scala.quoted.autolift._
+
 import scala.tasty.Reflection
 
 object SourceFiles {
@@ -8,7 +10,7 @@ object SourceFiles {
 
   private def getThisFileImpl(implicit reflect: Reflection): Expr[String] = {
     import reflect._
-    rootContext.source.getFileName.toString.toExpr
+    rootContext.source.getFileName.toString
   }
 
 }

--- a/tests/run/tasty-indexed-map/quoted_1.scala
+++ b/tests/run/tasty-indexed-map/quoted_1.scala
@@ -1,5 +1,6 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -43,6 +44,6 @@ object Index {
 
     val index = keys.indexOf(key)
 
-    '{new Index(${index.toExpr})}
+    '{new Index(${index})}
   }
 }

--- a/tests/run/tasty-interpolation-1/Macro.scala
+++ b/tests/run/tasty-interpolation-1/Macro.scala
@@ -4,6 +4,7 @@ import scala.tasty.Reflection
 import scala.language.implicitConversions
 import scala.quoted.Exprs.LiftedExpr
 import scala.quoted.Toolbox.Default._
+import scala.quoted.autolift._
 
 object Macro {
 
@@ -17,17 +18,17 @@ object Macro {
 
 object SIntepolator extends MacroStringInterpolator[String] {
   protected def interpolate(strCtx: StringContext, args: List[Expr[Any]])(implicit reflect: Reflection): Expr[String] =
-    '{(${strCtx.toExpr}).s(${args.toExprOfList}: _*)}
+    '{(${strCtx}).s(${args.toExprOfList}: _*)}
 }
 
 object RawIntepolator extends MacroStringInterpolator[String] {
   protected def interpolate(strCtx: StringContext, args: List[Expr[Any]])(implicit reflect: Reflection): Expr[String] =
-    '{(${strCtx.toExpr}).raw(${args.toExprOfList}: _*)}
+    '{(${strCtx}).raw(${args.toExprOfList}: _*)}
 }
 
 object FooIntepolator extends MacroStringInterpolator[String] {
   protected def interpolate(strCtx: StringContext, args: List[Expr[Any]])(implicit reflect: Reflection): Expr[String] =
-    '{(${strCtx.toExpr}).s(${args.map(_ => '{"foo"}).toExprOfList}: _*)}
+    '{(${strCtx}).s(${args.map(_ => '{"foo"}).toExprOfList}: _*)}
 }
 
 // TODO put this class in the stdlib or separate project?
@@ -84,7 +85,7 @@ abstract class MacroStringInterpolator[T] {
           case Nil => '{Nil}
         }
       }
-      '{StringContext(${strCtx.parts.toList.toExpr}: _*)}
+      '{StringContext(${strCtx.parts.toList}: _*)}
     }
   }
 

--- a/tests/run/tasty-linenumber-2/quoted_1.scala
+++ b/tests/run/tasty-linenumber-2/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -12,7 +13,7 @@ object LineNumber {
 
   def lineImpl(implicit reflect: Reflection): Expr[LineNumber] = {
     import reflect._
-    '{new LineNumber(${rootPosition.startLine.toExpr})}
+    '{new LineNumber(${rootPosition.startLine})}
   }
 
 }

--- a/tests/run/tasty-linenumber/quoted_1.scala
+++ b/tests/run/tasty-linenumber/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -13,7 +14,7 @@ object LineNumber {
 
   def lineImpl(x: Type[Unit])(implicit reflect: Reflection): Expr[LineNumber] = {
     import reflect._
-    '{new LineNumber(${rootPosition.startLine.toExpr})}
+    '{new LineNumber(${rootPosition.startLine})}
   }
 
 }

--- a/tests/run/tasty-location/quoted_1.scala
+++ b/tests/run/tasty-location/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -16,11 +17,11 @@ object Location {
       else listOwnerNames(sym.owner, sym.name :: acc)
 
     val list = listOwnerNames(rootContext.owner, Nil)
-    '{new Location(${list.toExpr})}
+    '{new Location(${list})}
   }
 
   private implicit def ListIsLiftable[T : Liftable : Type]: Liftable[List[T]] = {
-    case x :: xs  => '{ ${x.toExpr} :: ${xs.toExpr} }
+    case x :: xs  => '{ ${x} :: ${xs} }
     case Nil => '{ List.empty[T] }
   }
 }

--- a/tests/run/tasty-original-source/Macros_1.scala
+++ b/tests/run/tasty-original-source/Macros_1.scala
@@ -1,4 +1,6 @@
 import scala.quoted._
+import scala.quoted.autolift._
+
 import scala.tasty._
 
 object Macros {
@@ -7,7 +9,7 @@ object Macros {
 
   private def impl(arg: Expr[Any])(implicit reflect: Reflection): Expr[(String, Any)] = {
     import reflect._
-    val source = arg.unseal.underlyingArgument.pos.sourceCode.toString.toExpr
+    val source = arg.unseal.underlyingArgument.pos.sourceCode.toString
     '{Tuple2($source, $arg)}
   }
 

--- a/tests/run/tasty-positioned/quoted_1.scala
+++ b/tests/run/tasty-positioned/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -15,13 +16,13 @@ object Positioned {
     import reflect.{Position => _, _}
     val pos = rootPosition
 
-    val path = pos.sourceFile.jpath.toString.toExpr
-    val start = pos.start.toExpr
-    val end = pos.end.toExpr
-    val startLine = pos.startLine.toExpr
-    val endLine = pos.endLine.toExpr
-    val startColumn = pos.startColumn.toExpr
-    val endColumn = pos.endColumn.toExpr
+    val path = pos.sourceFile.jpath.toString
+    val start = pos.start
+    val end = pos.end
+    val startLine = pos.startLine
+    val endLine = pos.endLine
+    val startColumn = pos.startColumn
+    val endColumn = pos.endColumn
 
     val liftedPosition = '{new Position($path, $start, $end, $startLine, $startColumn, $endLine, $endColumn)}
     '{Positioned[T]($x, $liftedPosition)}

--- a/tests/run/tasty-subtyping/quoted_1.scala
+++ b/tests/run/tasty-subtyping/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty._
 
@@ -13,12 +14,12 @@ object Macros {
   def isTypeEqualImpl[T, U](t: Type[T], u: Type[U])(implicit reflect: Reflection): Expr[Boolean] = {
     import reflect._
     val isTypeEqual = t.unseal.tpe =:= u.unseal.tpe
-    isTypeEqual.toExpr
+    isTypeEqual
   }
 
   def isSubTypeOfImpl[T, U](t: Type[T], u: Type[U])(implicit reflect: Reflection): Expr[Boolean] = {
     import reflect._
     val isTypeEqual = t.unseal.tpe <:< u.unseal.tpe
-    isTypeEqual.toExpr
+    isTypeEqual
   }
 }

--- a/tests/run/tasty-typeof/Macro_1.scala
+++ b/tests/run/tasty-typeof/Macro_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 import scala.tasty._
 
 object Macros {
@@ -8,25 +9,25 @@ object Macros {
   private def testTypeOfImpl(implicit reflect: Reflection): Expr[Unit] = {
     import reflect._
     '{
-      assert(${(typeOf[Unit] =:= definitions.UnitType).toExpr}, "Unit")
-      assert(${(typeOf[Byte] =:= definitions.ByteType).toExpr}, "Byte")
-      assert(${(typeOf[Short] =:= definitions.ShortType).toExpr}, "Short")
-      assert(${(typeOf[Int] =:= definitions.IntType).toExpr}, "Int")
-      assert(${(typeOf[Long] =:= definitions.LongType).toExpr}, "Long")
-      assert(${(typeOf[Float] =:= definitions.FloatType).toExpr}, "Float")
-      assert(${(typeOf[Double] =:= definitions.DoubleType).toExpr}, "Double")
-      assert(${(typeOf[Char] =:= definitions.CharType).toExpr}, "Char")
-      assert(${(typeOf[String] =:= definitions.StringType).toExpr}, "String")
+      assert(${(typeOf[Unit] =:= definitions.UnitType)}, "Unit")
+      assert(${(typeOf[Byte] =:= definitions.ByteType)}, "Byte")
+      assert(${(typeOf[Short] =:= definitions.ShortType)}, "Short")
+      assert(${(typeOf[Int] =:= definitions.IntType)}, "Int")
+      assert(${(typeOf[Long] =:= definitions.LongType)}, "Long")
+      assert(${(typeOf[Float] =:= definitions.FloatType)}, "Float")
+      assert(${(typeOf[Double] =:= definitions.DoubleType)}, "Double")
+      assert(${(typeOf[Char] =:= definitions.CharType)}, "Char")
+      assert(${(typeOf[String] =:= definitions.StringType)}, "String")
 
-      assert(${(typeOf[Any] =:= definitions.AnyType).toExpr}, "Any")
-      assert(${(typeOf[AnyRef] =:= definitions.AnyRefType).toExpr}, "AnyRef")
-      assert(${(typeOf[AnyVal] =:= definitions.AnyValType).toExpr}, "AnyVal")
-      assert(${(typeOf[Object] =:= definitions.ObjectType).toExpr}, "Object")
-      assert(${(typeOf[Nothing] =:= definitions.NothingType).toExpr}, "Nothing")
+      assert(${(typeOf[Any] =:= definitions.AnyType)}, "Any")
+      assert(${(typeOf[AnyRef] =:= definitions.AnyRefType)}, "AnyRef")
+      assert(${(typeOf[AnyVal] =:= definitions.AnyValType)}, "AnyVal")
+      assert(${(typeOf[Object] =:= definitions.ObjectType)}, "Object")
+      assert(${(typeOf[Nothing] =:= definitions.NothingType)}, "Nothing")
 
-      println(${typeOf[List[Int]].showCode.toExpr})
-      println(${typeOf[Macros].showCode.toExpr})
-      println(${typeOf[Macros.type].showCode.toExpr})
+      println(${typeOf[List[Int]].showCode})
+      println(${typeOf[Macros].showCode})
+      println(${typeOf[Macros.type].showCode})
     }
   }
 

--- a/tests/run/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run/xml-interpolation-1/XmlQuote_1.scala
@@ -1,4 +1,6 @@
 import scala.quoted._
+import scala.quoted.autolift._
+
 import scala.tasty.Reflection
 
 import scala.language.implicitConversions
@@ -59,6 +61,6 @@ object XmlQuote {
     val Typed(Repeated(args0, _), _) = args.unseal.underlyingArgument
 
     val string = parts.mkString("??")
-    '{new Xml(${string.toExpr}, ${liftListOfAny(args0)})}
+    '{new Xml(${string}, ${liftListOfAny(args0)})}
   }
 }

--- a/tests/run/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run/xml-interpolation-2/XmlQuote_1.scala
@@ -1,5 +1,6 @@
 
 import scala.quoted._
+import scala.quoted.autolift._
 
 import scala.tasty.Reflection
 
@@ -63,6 +64,6 @@ object XmlQuote {
     }
 
     val string = parts.mkString("??")
-    '{new Xml(${string.toExpr}, $args2)}
+    '{new Xml(${string}, $args2)}
   }
 }

--- a/tests/run/xml-interpolation-3/XmlQuote_1.scala
+++ b/tests/run/xml-interpolation-3/XmlQuote_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.autolift._
 import scala.tasty.Reflection
 
 import scala.language.implicitConversions
@@ -14,6 +15,6 @@ object XmlQuote {
 
   def impl(receiver: StringContext, args: Expr[Seq[Any]]): Expr[Xml] = {
     val string = receiver.parts.mkString("??")
-    '{new Xml(${string.toExpr}, $args.toList)}
+    '{new Xml(${string}, $args.toList)}
   }
 }


### PR DESCRIPTION
Add an `autolift` implicit conversion and update tests.

Eliminating `.toExpr` doesn't give always good intuition about what kind of values exist inside a splice. 
For example with `autolift` the following code has `x` in both cases. One of them is implicitly lifted and the other is not 😛.

```scala
def dyn[T: Liftable](pv: PV[T]): Expr[T] = pv match {
  case Sta(x) => x 
  case Dyn(x) => x
}
```

WDYT?