### PR TITLE
Fix the test for error messages

### DIFF
--- a/tests/neg/tasty-macro-error.check
+++ b/tests/neg/tasty-macro-error.check
@@ -1,16 +1,2 @@
-[486..500] in quoted_2.scala
-here is the the argument is _root_.scala.StringContext.apply(("abc", "": scala.<repeated>[scala#Predef.String])).s(("def": scala.<repeated>[scala.Any]))
-[453..466] in quoted_2.scala
-here is the the argument is ("abc": scala.Predef.String)
-[407..408] in quoted_2.scala
-here is the the argument is d
-[386..387] in quoted_2.scala
-here is the the argument is c
-[309..323] in quoted_2.scala
-here is the the argument is _root_.scala.StringContext.apply(("abc", "": scala.<repeated>[scala#Predef.String])).s(("def": scala.<repeated>[scala.Any]))
-[277..290] in quoted_2.scala
-here is the the argument is ("abc": scala.Predef.String)
-[233..234] in quoted_2.scala
-here is the the argument is d
-[213..214] in quoted_2.scala
-here is the the argument is c
+[117..120] in quoted_2.scala
+here is the the argument is foo

--- a/tests/neg/tasty-macro-error/quoted_1.scala
+++ b/tests/neg/tasty-macro-error/quoted_1.scala
@@ -6,19 +6,9 @@ object Macros {
 
   inline def fun(x: Any): Unit = ${ impl('x) }
 
-  inline def fun2(x: =>Any): Unit = ${ impl('x) }
-
-  inline def fun3[T]: Unit = ${ impl2('[T]) }
-
   def impl(x: Expr[Any])(implicit reflect: Reflection): Expr[Unit] = {
     import reflect._
     error("here is the the argument is " + x.unseal.underlyingArgument.showCode, x.unseal.underlyingArgument.pos)
-    '{}
-  }
-
-  def impl2[T](x: quoted.Type[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
-    error("here is the the argument is " + x.unseal.showCode, x.unseal.pos)
     '{}
   }
 

--- a/tests/neg/tasty-macro-error/quoted_2.scala
+++ b/tests/neg/tasty-macro-error/quoted_2.scala
@@ -3,36 +3,9 @@ import Macros._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    val a: String = "abc"
-    val b: 42 = 42
-    def c: String = "abc"
-    def d: 42 = 42
-
-//  fun(a) // ERROR
-//  fun(b) // ERROR
-    fun(c) // error
-    fun(d) // error
-//  fun("abc") // ERROR
-    fun("abc": String) // error
-    fun(s"abc${"def"}") // error
-
-//  fun2(a) // ERROR
-//  fun2(b) // ERROR
-    fun2(c) // error
-    fun2(d) // error
-//  fun2("abc") // ERROR
-    fun2("abc": String) // error
-    fun2(s"abc${"def"}") // error
-
-//    type T
-//    type U = "abc"
-//
-//    fun3[T] // ERROR
-//    fun3[String] // ERROR
-//    fun3["abc"] // ERROR
-//    fun3[U] // ERROR
+    def foo: String = "abc"
+    fun(
+      foo // error
+    )
   }
-// FIXME all the lines marked as ERROR have the wrong position on the three of the argument.
-// they all have as source file this file but the span of `'x` in `fun` or `fun2`.
-// see #6026 and #6027
 }

--- a/tests/run/tasty-macro-positions.check
+++ b/tests/run/tasty-macro-positions.check
@@ -1,0 +1,36 @@
+quoted_2.scala:[103..103]
+a
+quoted_2.scala:[103..103]
+b
+quoted_2.scala:[213..214]
+c
+quoted_2.scala:[224..225]
+d
+quoted_2.scala:[103..103]
+"abc"
+quoted_2.scala:[259..272]
+("abc": scala.Predef.String)
+quoted_2.scala:[282..296]
+_root_.scala.StringContext.apply(("abc", "": scala.<repeated>[scala#Predef.String])).s(("def": scala.<repeated>[scala.Any]))
+quoted_2.scala:[154..154]
+a
+quoted_2.scala:[154..154]
+b
+quoted_2.scala:[350..351]
+c
+quoted_2.scala:[362..363]
+d
+quoted_2.scala:[154..154]
+"abc"
+quoted_2.scala:[399..412]
+("abc": scala.Predef.String)
+quoted_2.scala:[423..437]
+_root_.scala.StringContext.apply(("abc", "": scala.<repeated>[scala#Predef.String])).s(("def": scala.<repeated>[scala.Any]))
+quoted_2.scala:[201..202]
+T
+quoted_2.scala:[201..202]
+scala.Predef.String
+quoted_2.scala:[201..202]
+"abc"
+quoted_2.scala:[201..202]
+U

--- a/tests/run/tasty-macro-positions/quoted_1.scala
+++ b/tests/run/tasty-macro-positions/quoted_1.scala
@@ -1,0 +1,37 @@
+import scala.quoted._
+
+import scala.tasty._
+
+object Macros {
+
+  inline def fun(x: Any): Unit = ${ impl('x) }
+
+  inline def fun2(x: =>Any): Unit = ${ impl('x) }
+
+  inline def fun3[T]: Unit = ${ impl2('[T]) }
+
+  def impl(x: Expr[Any])(implicit reflect: Reflection): Expr[Unit] = {
+    import reflect._
+    val pos = x.unseal.underlyingArgument.pos
+    val code = x.unseal.underlyingArgument.showCode
+    '{
+      println(${posStr(reflect)(pos)})
+      println(${code.toExpr})
+    }
+  }
+
+  def impl2[T](x: quoted.Type[T])(implicit reflect: Reflection): Expr[Unit] = {
+    import reflect._
+    val pos = x.unseal.pos
+    val code = x.unseal.showCode
+    '{
+      println(${posStr(reflect)(pos)})
+      println(${code.toExpr})
+    }
+  }
+
+  def posStr(relfection: Reflection)(pos: relfection.Position): Expr[String] = {
+    import relfection._
+    s"${pos.sourceFile.getFileName.toString}:[${pos.start}..${pos.end}]".toExpr
+  }
+}

--- a/tests/run/tasty-macro-positions/quoted_2.scala
+++ b/tests/run/tasty-macro-positions/quoted_2.scala
@@ -1,0 +1,38 @@
+
+import Macros._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val a: String = "abc"
+    val b: 42 = 42
+    def c: String = "abc"
+    def d: 42 = 42
+
+    fun(a) // ERROR
+    fun(b) // ERROR
+    fun(c)
+    fun(d)
+    fun("abc") // ERROR
+    fun("abc": String)
+    fun(s"abc${"def"}")
+
+    fun2(a) // ERROR
+    fun2(b) // ERROR
+    fun2(c)
+    fun2(d)
+    fun2("abc") // ERROR
+    fun2("abc": String)
+    fun2(s"abc${"def"}")
+
+    type T
+    type U = "abc"
+
+    fun3[T] // ERROR
+    fun3[String] // ERROR
+    fun3["abc"] // ERROR
+    fun3[U] // ERROR
+  }
+  // FIXME all the lines marked as ERROR have the wrong position on the three of the argument.
+  // they all have as source file this file but the span of `'x` in `fun` or `fun2`.
+  // see #6026 and #6027
+}


### PR DESCRIPTION
This fixes the current failure in master.

Now that we expand macros in typer, we only get one expansion error and the typer stops inlining. Hence only one macro expansion can be tested at a time.

We keep the tests on the positions separately without emitting an error.