### PR TITLE
Move quoted.{Expr|Type}.apply to scala.internal

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -704,10 +704,14 @@ class Definitions {
 
   lazy val QuotedExprType: TypeRef = ctx.requiredClassRef("scala.quoted.Expr")
   def QuotedExprClass(implicit ctx: Context): ClassSymbol = QuotedExprType.symbol.asClass
-  def QuotedExprModule(implicit ctx: Context): Symbol = QuotedExprClass.companionModule
-    lazy val QuotedExpr_applyR: TermRef = QuotedExprModule.requiredMethodRef(nme.apply)
-    def QuotedExpr_apply(implicit ctx: Context): Symbol = QuotedExpr_applyR.symbol
     lazy val QuotedExpr_splice : TermSymbol = QuotedExprClass.requiredMethod(nme.splice)
+
+  lazy val InternalQuotedModule: TermRef = ctx.requiredModuleRef("scala.internal.Quoted")
+  def InternalQuotedModuleClass: Symbol = InternalQuotedModule.symbol
+    lazy val InternalQuoted_exprQuoteR: TermRef = InternalQuotedModuleClass.requiredMethodRef("exprQuote".toTermName)
+    def InternalQuoted_exprQuote(implicit ctx: Context): Symbol = InternalQuoted_exprQuoteR.symbol
+    lazy val InternalQuoted_typeQuoteR: TermRef = InternalQuotedModuleClass.requiredMethodRef("typeQuote".toTermName)
+    def InternalQuoted_typeQuote(implicit ctx: Context): Symbol = InternalQuoted_typeQuoteR.symbol
 
   lazy val QuotedExprsModule: TermSymbol = ctx.requiredModule("scala.quoted.Exprs")
   def QuotedExprsClass(implicit ctx: Context): ClassSymbol = QuotedExprsModule.asClass
@@ -720,8 +724,6 @@ class Definitions {
 
   lazy val QuotedTypeModuleType: TermRef = ctx.requiredModuleRef("scala.quoted.Type")
   def QuotedTypeModule(implicit ctx: Context): Symbol = QuotedTypeModuleType.symbol
-    lazy val QuotedType_applyR: TermRef = QuotedTypeModule.requiredMethodRef(nme.apply)
-    def QuotedType_apply(implicit ctx: Context): Symbol = QuotedType_applyR.symbol
 
   lazy val QuotedLiftableModule: TermSymbol = ctx.requiredModule("scala.quoted.Liftable")
   def QuotedLiftableModuleClass(implicit ctx: Context): ClassSymbol = QuotedLiftableModule.asClass

--- a/compiler/src/dotty/tools/dotc/printing/DecompilerPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/DecompilerPrinter.scala
@@ -74,8 +74,8 @@ class DecompilerPrinter(_ctx: Context) extends RefinedPrinter(_ctx) {
   }
 
   override protected def typeApplyText[T >: Untyped](tree: TypeApply[T]): Text = {
-    if (tree.symbol eq defn.QuotedExpr_apply) "'"
-    else if (tree.symbol eq defn.QuotedType_apply) "'[" ~ toTextGlobal(tree.args, ", ") ~ "]"
+    if (tree.symbol eq defn.InternalQuoted_exprQuote) "'"
+    else if (tree.symbol eq defn.InternalQuoted_typeQuote) "'[" ~ toTextGlobal(tree.args, ", ") ~ "]"
     else super.typeApplyText(tree)
   }
 }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -252,7 +252,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     ("{" ~ toText(trees, "\n") ~ "}").close
 
   protected def typeApplyText[T >: Untyped](tree: TypeApply[T]): Text = {
-    val isQuote = tree.fun.hasType && tree.fun.symbol == defn.QuotedType_apply
+    val isQuote = tree.fun.hasType && tree.fun.symbol == defn.InternalQuoted_typeQuote
     val (open, close) = if (isQuote) (keywordStr("'["), keywordStr("]")) else ("[", "]")
     toTextLocal(tree.fun).provided(!isQuote) ~ open ~ toTextGlobal(tree.args, ", ") ~ close
   }
@@ -341,7 +341,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           changePrec (GlobalPrec) {
             keywordStr("throw ") ~ toText(args.head)
           }
-        else if (fun.hasType && fun.symbol == defn.QuotedExpr_apply)
+        else if (fun.hasType && fun.symbol == defn.InternalQuoted_exprQuote)
           keywordStr("'{") ~ toTextGlobal(args, ", ") ~ keywordStr("}")
         else
           toTextLocal(fun) ~ "(" ~ toTextGlobal(args, ", ") ~ ")"

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -169,7 +169,7 @@ class ReifyQuotes extends MacroTransform {
      *  core and splices as arguments.
      */
     override protected def transformQuotation(body: Tree, quote: Tree)(implicit ctx: Context): Tree = {
-      val isType = quote.symbol eq defn.QuotedType_apply
+      val isType = quote.symbol eq defn.InternalQuoted_typeQuote
       assert(!body.symbol.isSplice)
       if (level > 0) {
         val body1 = nested(isQuote = true).transform(body)(quoteContext)

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -307,7 +307,7 @@ object Splicer {
     protected def unexpectedTree(tree: Tree)(implicit env: Env): Result
 
     protected final def interpretTree(tree: Tree)(implicit env: Env): Result = tree match {
-      case Apply(TypeApply(fn, _), quoted :: Nil) if fn.symbol == defn.QuotedExpr_apply =>
+      case Apply(TypeApply(fn, _), quoted :: Nil) if fn.symbol == defn.InternalQuoted_exprQuote =>
         val quoted1 = quoted match {
           case quoted: Ident if quoted.symbol.is(InlineByNameProxy) =>
             // inline proxy for by-name parameter
@@ -317,7 +317,7 @@ object Splicer {
         }
         interpretQuote(quoted1)
 
-      case TypeApply(fn, quoted :: Nil) if fn.symbol == defn.QuotedType_apply =>
+      case TypeApply(fn, quoted :: Nil) if fn.symbol == defn.InternalQuoted_typeQuote =>
         interpretTypeQuote(quoted)
 
       case Literal(Constant(value)) =>

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -159,7 +159,7 @@ class SymUtils(val self: Symbol) extends AnyVal {
 
   /** Is symbol a quote operation? */
   def isQuote(implicit ctx: Context): Boolean =
-    self == defn.QuotedExpr_apply || self == defn.QuotedType_apply
+    self == defn.InternalQuoted_exprQuote || self == defn.InternalQuoted_typeQuote
 
   /** Is symbol a splice operation? */
   def isSplice(implicit ctx: Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -678,10 +678,10 @@ trait Implicits { self: Typer =>
           }
         }
         val tag = bindFreeVars(arg)
-        if (bindFreeVars.ok) ref(defn.QuotedType_apply).appliedToType(tag)
+        if (bindFreeVars.ok) ref(defn.InternalQuoted_typeQuote).appliedToType(tag)
         else EmptyTree
       case arg :: Nil if ctx.inInlineMethod =>
-        ref(defn.QuotedType_apply).appliedToType(arg)
+        ref(defn.InternalQuoted_typeQuote).appliedToType(arg)
       case _ =>
         EmptyTree
     }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1935,9 +1935,9 @@ class Typer extends Namer
   def typedQuote(tree: untpd.Quote, pt: Type)(implicit ctx: Context): Tree = track("typedQuote") {
     val tree1 =
       if (tree.t.isType)
-        typedTypeApply(untpd.TypeApply(untpd.ref(defn.QuotedType_applyR), List(tree.t)), pt)(quoteContext)
+        typedTypeApply(untpd.TypeApply(untpd.ref(defn.InternalQuoted_typeQuoteR), List(tree.t)), pt)(quoteContext)
       else
-        typedApply(untpd.Apply(untpd.ref(defn.QuotedExpr_applyR), tree.t), pt)(quoteContext)
+        typedApply(untpd.Apply(untpd.ref(defn.InternalQuoted_exprQuoteR), tree.t), pt)(quoteContext)
     tree1.withSpan(tree.span)
   }
 

--- a/library/src-bootstrapped/scala/internal/Quoted.scala
+++ b/library/src-bootstrapped/scala/internal/Quoted.scala
@@ -1,0 +1,15 @@
+package scala.internal
+
+import scala.quoted._
+
+object Quoted {
+
+  /** A term quote is desugared by the compiler into a call to this method */
+  def exprQuote[T](x: T): Expr[T] =
+    throw new Error("Internal error: this method call should have been replaced by the compiler")
+
+  /** A type quote is desugared by the compiler into a call to this method */
+  def typeQuote[T <: AnyKind]: Type[T] =
+    throw new Error("Internal error: this method call should have been replaced by the compiler")
+
+}

--- a/library/src-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/quoted/Type.scala
@@ -10,9 +10,6 @@ sealed abstract class Type[T <: AnyKind] {
 
 /** Some basic type tags, currently incomplete */
 object Type {
-  /** A term quote is desugared by the compiler into a call to this method */
-  def apply[T <: AnyKind]: Type[T] =
-    throw new Error("Internal error: this method call should have been replaced by the compiler")
 
   implicit def UnitTag: Type[Unit] = new TaggedType[Unit]
   implicit def BooleanTag: Type[Boolean] = new TaggedType[Boolean]

--- a/library/src-non-bootstrapped/scala/internal/Quoted.scala
+++ b/library/src-non-bootstrapped/scala/internal/Quoted.scala
@@ -1,0 +1,15 @@
+package scala.internal
+
+import scala.quoted._
+
+object Quoted {
+
+  /** A term quote is desugared by the compiler into a call to this method */
+  def exprQuote[T](x: T): Expr[T] =
+    throw new Error("Internal error: this method call should have been replaced by the compiler")
+
+  /** A type quote is desugared by the compiler into a call to this method */
+  def typeQuote[T/* <: AnyKind */]: Type[T] =
+    throw new Error("Internal error: this method call should have been replaced by the compiler")
+
+}

--- a/library/src-non-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-non-bootstrapped/scala/quoted/Type.scala
@@ -10,10 +10,6 @@ sealed abstract class Type[T] {
 
 /** Some basic type tags, currently incomplete */
 object Type {
-  /** A term quote is desugared by the compiler into a call to this method */
-  def apply[T]: Type[T] =
-    throw new Error("Internal error: this method call should have been replaced by the compiler")
-
   implicit def UnitTag: Type[Unit] = new TaggedType[Unit]
   implicit def BooleanTag: Type[Boolean] = new TaggedType[Boolean]
   implicit def ByteTag: Type[Byte] = new TaggedType[Byte]

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -18,9 +18,6 @@ sealed abstract class Expr[+T] {
 }
 
 object Expr {
-  /** A term quote is desugared by the compiler into a call to this method */
-  def apply[T](x: T): Expr[T] =
-    throw new Error("Internal error: this method call should have been replaced by the compiler")
 
   // TODO simplify using new extension methods
 

--- a/library/src/scala/tasty/reflect/Printers.scala
+++ b/library/src/scala/tasty/reflect/Printers.scala
@@ -849,6 +849,26 @@ trait Printers
           this += "throw "
           printTree(expr)
 
+        case Term.Apply(fn, args) if fn.symbol.fullName == "scala.internal.Quoted$.exprQuote" =>
+          args.head match {
+            case Term.Block(stats, expr) =>
+              this += "'{"
+              indented {
+                this += lineBreak()
+                printFlatBlock(stats, expr)
+              }
+              this += lineBreak() += "}"
+            case _ =>
+              this += "'{"
+              printTree(args.head)
+              this += "}"
+          }
+
+        case Term.TypeApply(fn, args) if fn.symbol.fullName == "scala.internal.Quoted$.typeQuote" =>
+          this += "'["
+          printTypeTree(args.head)
+          this += "]"
+
         case Term.Apply(fn, args) =>
           fn match {
             case Term.Select(Term.This(_), "<init>") => this += "this" // call to constructor inside a constructor

--- a/tests/run-with-compiler/quote-nested-1.check
+++ b/tests/run-with-compiler/quote-nested-1.check
@@ -1,1 +1,1 @@
-scala.quoted.Expr.apply[scala.Int](3)
+scala.internal.Quoted.exprQuote[scala.Int](3)

--- a/tests/run-with-compiler/quote-nested-1.check
+++ b/tests/run-with-compiler/quote-nested-1.check
@@ -1,1 +1,1 @@
-scala.internal.Quoted.exprQuote[scala.Int](3)
+'{3}

--- a/tests/run-with-compiler/quote-nested-2.check
+++ b/tests/run-with-compiler/quote-nested-2.check
@@ -1,4 +1,4 @@
 {
-  val a: scala.quoted.Expr[scala.Int] = scala.quoted.Expr.apply[scala.Int](4)
+  val a: scala.quoted.Expr[scala.Int] = scala.internal.Quoted.exprQuote[scala.Int](4)
   a
 }

--- a/tests/run-with-compiler/quote-nested-2.check
+++ b/tests/run-with-compiler/quote-nested-2.check
@@ -1,4 +1,4 @@
 {
-  val a: scala.quoted.Expr[scala.Int] = scala.internal.Quoted.exprQuote[scala.Int](4)
+  val a: scala.quoted.Expr[scala.Int] = '{4}
   a
 }

--- a/tests/run-with-compiler/quote-nested-4.check
+++ b/tests/run-with-compiler/quote-nested-4.check
@@ -1,5 +1,5 @@
 {
-  val t: scala.quoted.Type[scala.Predef.String] = scala.quoted.Type.apply[scala.Predef.String]
+  val t: scala.quoted.Type[scala.Predef.String] = scala.internal.Quoted.typeQuote[scala.Predef.String]
 
   (t: scala.quoted.Type[scala.Predef.String])
 }

--- a/tests/run-with-compiler/quote-nested-4.check
+++ b/tests/run-with-compiler/quote-nested-4.check
@@ -1,5 +1,5 @@
 {
-  val t: scala.quoted.Type[scala.Predef.String] = scala.internal.Quoted.typeQuote[scala.Predef.String]
+  val t: scala.quoted.Type[scala.Predef.String] = '[scala.Predef.String]
 
   (t: scala.quoted.Type[scala.Predef.String])
 }

--- a/tests/run-with-compiler/quote-nested-5.check
+++ b/tests/run-with-compiler/quote-nested-5.check
@@ -1,4 +1,4 @@
 {
-  val a: scala.quoted.Expr[scala.Int] = scala.quoted.Expr.apply[scala.Int](4)
+  val a: scala.quoted.Expr[scala.Int] = scala.internal.Quoted.exprQuote[scala.Int](4)
   a
 }

--- a/tests/run-with-compiler/quote-nested-5.check
+++ b/tests/run-with-compiler/quote-nested-5.check
@@ -1,4 +1,4 @@
 {
-  val a: scala.quoted.Expr[scala.Int] = scala.internal.Quoted.exprQuote[scala.Int](4)
+  val a: scala.quoted.Expr[scala.Int] = '{4}
   a
 }


### PR DESCRIPTION
This is to avoid having this internal representation leaked to the user with `scala.quoted.Expr.apply`. Users could have accidentally quoted a term using `Expr(myTerm)` which does not get the correct level in the context while typing.