### PR TITLE
Follow up to #6002

### DIFF
--- a/tests/neg/i5015.scala
+++ b/tests/neg/i5015.scala
@@ -1,1 +1,6 @@
-enum A extends AnyRef { } // error
+enum A extends AnyRef { } // error: missing case
+
+enum B { def foo = 1 } // error: missing case
+
+enum C // error: missing case
+// error: '{' expected, but eof found


### PR DESCRIPTION
- Reject enums with no case instead of empty enums.
- Remove special case in parser by using the `tenmplate` parser
  to enforce enums have bodies.