### PR TITLE
Update extension-methods.md

### DIFF
--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -80,7 +80,7 @@ So `circle.circumference` translates to `CircleOps.circumference(circle)`, provi
 
 ### Implied Instances for Extension Methods
 
-Implied instances that define extension methods can also be defined without an `of` clause. E.g.,
+Implied instances that define extension methods can also be defined without a `for` clause. E.g.,
 
 ```scala
 implied StringOps {
@@ -130,7 +130,7 @@ def (xs: List[List[T]]) flattened [T] =
   xs.foldLeft[List[T]](Nil)(_ ++ _)
 
 def (x: T) + [T : Numeric](y: T): T =
-  implicitly[Numeric[T]].plus(x, y)
+  the[Numeric[T]].plus(x, y)
 ```
 
 As usual, type parameters of the extension method follow the defined method name. Nevertheless, such type parameters can already be used in the preceding parameter clause.


### PR DESCRIPTION
There is no "of clause" found in the code on this page. "implicitly[]" is (I believe) no longer the current nomenclature.