### PR TITLE
Avoid leaking ReflectImpl/KenelImpl in the compiler

### DIFF
--- a/compiler/src/dotty/tools/dotc/consumetasty/TastyConsumerPhase.scala
+++ b/compiler/src/dotty/tools/dotc/consumetasty/TastyConsumerPhase.scala
@@ -12,7 +12,7 @@ class TastyConsumerPhase(consumer: TastyConsumer) extends Phase {
 
   override def run(implicit ctx: Context): Unit = {
     val reflect = ReflectionImpl(ctx)
-    consumer(reflect)(ctx.compilationUnit.tpdTree)
+    consumer(reflect)(ctx.compilationUnit.tpdTree.asInstanceOf[reflect.Tree])
   }
 
 }

--- a/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
@@ -43,8 +43,7 @@ class DecompilationPrinter extends Phase {
     } else {
       val unitFile = unit.source.toString.replace("\\", "/").replace(".class", ".tasty")
       out.println(s"/** Decompiled from $unitFile */")
-      val refl = ReflectionImpl(ctx)
-      out.println(new refl.SourceCodePrinter().showTree(unit.tpdTree)(ctx))
+      out.println(ReflectionImpl.showTree(unit.tpdTree))
     }
   }
 }

--- a/compiler/src/dotty/tools/dotc/decompiler/IDEDecompilerDriver.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/IDEDecompilerDriver.scala
@@ -35,8 +35,7 @@ class IDEDecompilerDriver(val settings: List[String]) extends dotc.Driver {
     run.printSummary()
     val unit = ctx.run.units.head
 
-    val refl = ReflectionImpl(ctx)
-    val decompiled = new refl.SourceCodePrinter().showTree(unit.tpdTree)
+    val decompiled = ReflectionImpl.showTree(unit.tpdTree)
     val tree = new TastyHTMLPrinter(unit.pickled.head._2).printContents()
 
     reporter.removeBufferedMessages.foreach(message => System.err.println(message))

--- a/compiler/src/dotty/tools/dotc/quoted/QuoteDriver.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuoteDriver.scala
@@ -47,8 +47,7 @@ class QuoteDriver extends Driver {
       val tree1 =
         if (ctx.settings.YshowRawQuoteTrees.value) tree
         else (new TreeCleaner).transform(tree)
-      val refl = ReflectionImpl(ctx)
-      new refl.SourceCodePrinter().showTree(tree1)
+      ReflectionImpl.showTree(tree1)
     }
     withTree(expr, show, settings)
   }

--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionImpl.scala
@@ -1,16 +1,22 @@
 package dotty.tools.dotc.tastyreflect
 
+import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core._
 import dotty.tools.dotc.util.{SourcePosition, Spans}
 
 object ReflectionImpl {
 
-  def apply(rootContext: Contexts.Context): scala.tasty.Reflection { val kernel: KernelImpl } =
+  def apply(rootContext: Contexts.Context): scala.tasty.Reflection =
     apply(rootContext, SourcePosition(rootContext.source, Spans.NoSpan))
 
-  def apply(rootContext: Contexts.Context, rootPosition: SourcePosition): scala.tasty.Reflection { val kernel: KernelImpl } = {
-    class ReflectionImpl(val kernel: KernelImpl) extends scala.tasty.Reflection
+  def apply(rootContext: Contexts.Context, rootPosition: SourcePosition): scala.tasty.Reflection =
     new ReflectionImpl(new KernelImpl(rootContext, rootPosition))
+
+  def showTree(tree: tpd.Tree)(implicit ctx: Contexts.Context): String = {
+    val refl = new ReflectionImpl(new KernelImpl(ctx, tree.sourcePos))
+    new refl.SourceCodePrinter().showTree(tree)
   }
+
+  private class ReflectionImpl(val kernel: KernelImpl) extends scala.tasty.Reflection
 
 }


### PR DESCRIPTION
Prviously we partally exposed the implementation of `ReflectImpl` by exposing `KernelImpl` in `Reflect { val kernel: KernelImpl }`.