### PR TITLE
Cancel quotes/splice early

### DIFF
--- a/tests/neg-custom-args/fatal-warnings/quote-simple-hole.scala
+++ b/tests/neg-custom-args/fatal-warnings/quote-simple-hole.scala
@@ -1,0 +1,13 @@
+class Test {
+  val x = '{0}
+  val y = '{ // error: Canceled splice directly inside a quote. '{ ${ XYZ } } is equivalent to XYZ.
+    $x
+  }
+  val z = '{
+    val a = ${ // error: Canceled quote directly inside a splice. ${ '{ XYZ } } is equivalent to XYZ.
+      '{
+        $y
+      }
+    }
+  }
+}

--- a/tests/run-with-compiler/quote-nested-2.check
+++ b/tests/run-with-compiler/quote-nested-2.check
@@ -1,4 +1,5 @@
 {
   val a: scala.quoted.Expr[scala.Int] = '{4}
-  a
+
+  (a: scala.quoted.Expr[scala.Int])
 }

--- a/tests/run-with-compiler/quote-nested-5.check
+++ b/tests/run-with-compiler/quote-nested-5.check
@@ -1,4 +1,5 @@
 {
   val a: scala.quoted.Expr[scala.Int] = '{4}
-  a
+
+  (a: scala.quoted.Expr[scala.Int])
 }


### PR DESCRIPTION
This allows us to warn about unnecessary quotes and splices rather than just cancelling them.