### PR TITLE
enums page: if you use `extends`, you have to supply type parameters …

### DIFF
--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -26,8 +26,8 @@ be given explicitly:
 
 ```scala
 enum Option[+T] {
-  case Some(x: T) extends Option[T]
-  case None       extends Option[Nothing]
+  case Some[T](x: T) extends Option[T]
+  case None          extends Option[Nothing]
 }
 ```
 


### PR DESCRIPTION
…if you want them

@dragos noted that the compiler actually accepts the original form though, is that a bug? if so, that may need a separate bug report

 but then the whole thing seems iffy, since `T` certainly _looks_ like it's in scope, but then it isn't...?

so, not sure if this should be merged, opening it anyway so the Dotty team is reminded to decide