### PR TITLE
Add -no-warn to a Bytecode test

### DIFF
--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTest.scala
@@ -46,6 +46,7 @@ trait DottyBytecodeTest {
   def initCtx = {
     val ctx0 = (new ContextBase).initialCtx.fresh
     val outputDir = new VirtualDirectory("<DottyBytecodeTest output>")
+    ctx0.setSetting(ctx0.settings.silentWarnings, true)
     ctx0.setSetting(ctx0.settings.classpath, TestConfiguration.basicClasspath)
     ctx0.setProperty(ContextDoc, new ContextDocstrings)
     ctx0.setSetting(ctx0.settings.outputDir, outputDir)


### PR DESCRIPTION
This PR silences a warning in test, thus making tests output more uniform.

This test in question is expected to produce a warning, but it ends up in the CI output and looks like an error:

```scala
-- [E115] Syntax Warning:
object Foo {
  import scala.annotation.switch
  def foo(i: Any) = (i: @switch) match {
    case x: String => println("string!")
    case x :: xs   => println("list!")
  }
}:4:33
4 |  def foo(i: Any) = (i: @switch) match {
  |                    ^
  |Could not emit switch for @switch annotated match since there are not
enough cases
5 |    case x: String => println("string!")
6 |    case x :: xs   => println("list!")
7 |  }
```