### PR TITLE
Fix typing of new

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -331,7 +331,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         if (tree.hasType && tree.symbol == defn.QuotedExpr_splice) keywordStr("${") ~ toTextLocal(qual) ~ keywordStr("}")
         else if (tree.hasType && tree.symbol == defn.QuotedType_splice) typeText("${") ~ toTextLocal(qual) ~ typeText("}")
         else if (qual.isType) toTextLocal(qual) ~ "#" ~ typeText(toText(name))
-        else toTextLocal(qual) ~ ("." ~ nameIdText(tree) provided name != nme.CONSTRUCTOR)
+        else toTextLocal(qual) ~ ("." ~ nameIdText(tree) provided name != nme.CONSTRUCTOR || ctx.settings.YprintDebug.value)
       case tree: This =>
         optDotPrefix(tree) ~ keywordStr("this") ~ idText(tree)
       case Super(qual: This, mix) =>
@@ -356,11 +356,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         keywordStr("new ") ~ {
           tpt match {
             case tpt: Template => toTextTemplate(tpt, ofNew = true)
-            case _ =>
-              if (tpt.hasType)
-                toTextLocal(tpt.typeOpt.underlyingClassRef(refinementOK = false))
-              else
-                toTextLocal(tpt)
+            case _ => toTextLocal(tpt)
           }
         }
       case Typed(expr, tpt) =>

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -331,7 +331,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         if (tree.hasType && tree.symbol == defn.QuotedExpr_splice) keywordStr("${") ~ toTextLocal(qual) ~ keywordStr("}")
         else if (tree.hasType && tree.symbol == defn.QuotedType_splice) typeText("${") ~ toTextLocal(qual) ~ typeText("}")
         else if (qual.isType) toTextLocal(qual) ~ "#" ~ typeText(toText(name))
-        else toTextLocal(qual) ~ ("." ~ nameIdText(tree) provided name != nme.CONSTRUCTOR || ctx.settings.YprintDebug.value)
+        else toTextLocal(qual) ~ ("." ~ nameIdText(tree) provided (name != nme.CONSTRUCTOR || ctx.settings.YprintDebug.value))
       case tree: This =>
         optDotPrefix(tree) ~ keywordStr("this") ~ idText(tree)
       case Super(qual: This, mix) =>

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -301,8 +301,16 @@ trait TypeAssigner {
     ConstFold(tree.withType(tp))
   }
 
+  /** Normalize type T appearing in a new T by following eta expansions to
+   *  avoid higher-kinded types.
+   */
+  def typeOfNew(tpt: Tree)(implicit ctx: Context): Type = tpt.tpe.dealias match {
+    case TypeApplications.EtaExpansion(tycon) => tycon
+    case t => tpt.tpe
+  }
+
   def assignType(tree: untpd.New, tpt: Tree)(implicit ctx: Context): New =
-    tree.withType(tpt.tpe)
+    tree.withType(typeOfNew(tpt))
 
   def assignType(tree: untpd.Literal)(implicit ctx: Context): Literal =
     tree.withType {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -533,11 +533,8 @@ class Typer extends Namer
       case _ =>
         var tpt1 = typedType(tree.tpt)
         tpt1 = tpt1.withType(ensureAccessible(tpt1.tpe, superAccess = false, tpt1.sourcePos))
-        tpt1.tpe.dealias match {
-          case TypeApplications.EtaExpansion(tycon) => tpt1 = tpt1.withType(tycon)
-          case _ =>
-        }
-        if (checkClassType(tpt1.tpe, tpt1.sourcePos, traitReq = false, stablePrefixReq = true) eq defn.ObjectType)
+
+        if (checkClassType(typeOfNew(tpt1), tpt1.sourcePos, traitReq = false, stablePrefixReq = true) eq defn.ObjectType)
           tpt1 = TypeTree(defn.ObjectType).withSpan(tpt1.span)
 
         tpt1 match {
@@ -548,7 +545,6 @@ class Typer extends Namer
         }
 
         assignType(cpy.New(tree)(tpt1), tpt1)
-        // todo in a later phase: checkInstantiatable(cls, tpt1.pos)
     }
   }
 

--- a/library/src/scala/tasty/reflect/Printers.scala
+++ b/library/src/scala/tasty/reflect/Printers.scala
@@ -593,8 +593,8 @@ trait Printers
               printParent(fun)
               if (!args.isEmpty || needEmptyParens)
                 inParens(printTrees(args, ", "))
-            case IsTerm(Term.Select(Term.New(tpt), _)) =>
-              printTypeTree(tpt)
+            case IsTerm(Term.Select(Term.IsNew(newTree), _)) =>
+              printType(newTree.tpe)
             case IsTerm(parent) =>
               throw new MatchError(parent.show)
           }
@@ -772,9 +772,9 @@ trait Printers
           }
           this += "this"
 
-        case Term.New(tpt) =>
+        case Term.IsNew(tree) =>
           this += "new "
-          printTypeTree(tpt)
+          printType(tree.tpe)
 
         case Term.NamedArg(name, arg) =>
           this += name += " = "

--- a/tests/pos/alias-new.scala
+++ b/tests/pos/alias-new.scala
@@ -1,0 +1,9 @@
+object O {
+  class B[T]
+}
+object O2 {
+  type B[T] = O.B[T]
+}
+object Test {
+  val x: O2.B[String] = new O2.B()
+}

--- a/tests/run-with-compiler/i3847-b.check
+++ b/tests/run-with-compiler/i3847-b.check
@@ -1,1 +1,1 @@
-new scala.Array[scala.List[scala.Int]](1)
+new scala.Array[scala.collection.immutable.List[scala.Int]](1)


### PR DESCRIPTION
Assume
```
   class C[X]
   type A[X] = C[X]
```
The previous rule for `new A` overwrote the type of `A`
with `C`, in order to satisfy the condition that the type
of `new` should be a class type. Overwriting types like
that in Typer is wrong, since it is not preserved by pickling.
We tried to patch up things in RefinedPrinter, but this is not
enough, as test case `alias-new.scala` shows. This test caused
the type in a `new` to be unpickled as a `<notype>`.

The fix is to treat eta-reduction in new types in a purely functional
way, applied in both Typer and TypeAssigner.

The problem was encountered when systematically testing creation methods,
but it has nothing to do with them.