### PR TITLE
Fix #6064: Hardening in the presence of kind mismatches

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -58,7 +58,7 @@ trait Substituters { this: Context =>
         val sym = tp.symbol
         var fs = from
         var ts = to
-        while (fs.nonEmpty) {
+        while (fs.nonEmpty && ts.nonEmpty) {
           if (fs.head eq sym) return ts.head
           fs = fs.tail
           ts = ts.tail
@@ -203,7 +203,7 @@ trait Substituters { this: Context =>
         val sym = tp.symbol
         var fs = from
         var ts = to
-        while (fs.nonEmpty) {
+        while (fs.nonEmpty && ts.nonEmpty) {
           if (fs.head eq sym)
             return ts.head match {
               case TypeBounds(lo, hi) => range(lo, hi)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4791,10 +4791,7 @@ object Types {
 
       case tp @ AppliedType(tycon, args) =>
         @tailrec def foldArgs(x: T, tparams: List[ParamInfo], args: List[Type]): T =
-          if (args.isEmpty) {
-            assert(tparams.isEmpty)
-            x
-          }
+          if (args.isEmpty || tparams.isEmpty) x
           else {
             val tparam = tparams.head
             val acc = args.head match {

--- a/tests/neg/i6063.scala
+++ b/tests/neg/i6063.scala
@@ -1,0 +1,12 @@
+object i0 {
+trait I1[i0, I1]
+def I1[I1[I1]](I1: I1[ ;  // error
+I1[I1]
+}
+
+object test {
+object I0 {
+trait i2[I1, i2]
+def i2[i2[i2]](i2: i2[ ]) = i2  // error
+i2[i2]}
+}

--- a/tests/neg/i6064.scala
+++ b/tests/neg/i6064.scala
@@ -1,0 +1,4 @@
+trait Trait[X] {
+    def f[C[_]](arg: C[X]): Int
+    val a = f[(Int, String)] // error
+}


### PR DESCRIPTION
Three fixes for when the number of type-parameters disagrees with the number of type arguments.
One is in TypeAccumulator, two more are in Substituters.

There's a tricky balance here. On the one hand, crashing early on mismatches is
an excellent means to pinpoint errors in the compiler. On the other hand,
it makes malformed input crash the compiler. So, we should
do the minimum so that "on the other hand" is not observed. Which means doing
this driven by counter-examples (coming from fuzzing or elsewhere) is not a
bad way to tackle the problem.