### PR TITLE
Fix #6060: Don't insert apply or implicits on constructor calls

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -795,6 +795,19 @@ trait Checking {
         }
         traverser.traverse(call)
       }
+
+      // Check that constructor call is of the form _.<init>(args1)...(argsN).
+      // This guards against calls resulting from inserted implicits or applies.
+      def checkLegalConstructorCall(tree: Tree, encl: Tree, kind: String): Unit = tree match {
+        case Apply(fn, _) => checkLegalConstructorCall(fn, tree, "")
+        case TypeApply(fn, _) => checkLegalConstructorCall(fn, tree, "type ")
+        case Select(_, nme.CONSTRUCTOR) => // ok
+        case _ => ctx.error(s"too many ${kind}arguments in parent constructor", encl.sourcePos)
+      }
+      call match {
+        case Apply(fn, _) => checkLegalConstructorCall(fn, call, "")
+        case _ =>
+      }
     }
 
   /** Check that `tpt` does not define a higher-kinded type */

--- a/tests/neg/i6060.scala
+++ b/tests/neg/i6060.scala
@@ -1,0 +1,11 @@
+class I1(i2: Int) {
+  def apply(i3: Int) = 1
+  new I1(1)(2) {} // error: too many arguments in parent constructor
+}
+
+class I0(i1: Int) {
+  class I0[I2] {
+    def apply(i3: Int) = 1
+    new I0[Int]()(2) {} // error: too many arguments in parent constructor
+  }
+}


### PR DESCRIPTION
This mirrors scalac's behavior.