### PR TITLE
Fix 6057: Be more forgiving in LazyRef checking

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2438,7 +2438,14 @@ object Types {
     private[this] var myRef: Type = null
     private[this] var computed = false
     def ref(implicit ctx: Context): Type = {
-      if (computed) assert(myRef != null)
+      if (computed) {
+        if (myRef == null) {
+          // if errors were reported previously handle this by throwing a CyclicReference
+          // instead of crashing immediately. A test case is neg/i6057.scala.
+          assert(ctx.reporter.errorsReported)
+          CyclicReference(NoDenotation)
+        }
+      }
       else {
         computed = true
         myRef = refFn(ctx)

--- a/tests/neg/i6057.scala
+++ b/tests/neg/i6057.scala
@@ -1,0 +1,4 @@
+class i0[i1] {
+    type i2 <: i0[i2]
+    val i3: i2[i4] {}  // error
+}


### PR DESCRIPTION
Be more forgiving in LazyRef checking if errors were reported previously