### PR TITLE
2.13 stdlib fix: Seq#lengthCompare is now overloaded

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -444,7 +444,7 @@ class Definitions {
     def Seq_head(implicit ctx: Context): Symbol = Seq_headR.symbol
     lazy val Seq_dropR: TermRef = SeqClass.requiredMethodRef(nme.drop)
     def Seq_drop(implicit ctx: Context): Symbol = Seq_dropR.symbol
-    lazy val Seq_lengthCompareR: TermRef = SeqClass.requiredMethodRef(nme.lengthCompare)
+    lazy val Seq_lengthCompareR: TermRef = SeqClass.requiredMethodRef(nme.lengthCompare, List(IntType))
     def Seq_lengthCompare(implicit ctx: Context): Symbol = Seq_lengthCompareR.symbol
     lazy val Seq_lengthR: TermRef = SeqClass.requiredMethodRef(nme.length)
     def Seq_length(implicit ctx: Context): Symbol = Seq_lengthR.symbol


### PR DESCRIPTION
This is needed to compile the 2.13 standard library since
https://github.com/scala/scala/pull/7805.