### PR TITLE
Strengthen overloading resolution to deal with extension methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -232,11 +232,11 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           case dummyTreeOfType(tp) :: Nil if !(tp isRef defn.NullClass) => "null: " ~ toText(tp)
           case _ => toTextGlobal(args, ", ")
         }
-        return "FunProto(" ~ (Str("given ") provided tp.isContextual) ~ argsText ~ "):" ~ toText(resultType)
+        return "[applied to " ~ (Str("given ") provided tp.isContextual) ~ "(" ~ argsText ~ ") returning " ~ toText(resultType) ~ "]"
       case IgnoredProto(ignored) =>
         return "?" ~ (("(ignored: " ~ toText(ignored) ~ ")") provided ctx.settings.verbose.value)
       case tp @ PolyProto(targs, resType) =>
-        return "PolyProto(" ~ toTextGlobal(targs, ", ") ~ "): " ~ toText(resType)
+        return "[applied to [" ~ toTextGlobal(targs, ", ") ~ "] returning " ~ toText(resType)
       case _ =>
     }
     super.toText(tp)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1652,7 +1652,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
         val strippedInfo = strippedType(cand.widen)
         if (strippedInfo.exists) {
           val sym = cand.symbol.asTerm.copy(info = strippedInfo)
-          (TermRef(cand.prefix, sym), cand) :: Nil
+          (TermRef(NoPrefix, sym), cand) :: Nil
         }
         else Nil
       }

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -156,7 +156,8 @@ object RefChecks {
    *    1.8.1  M's type is a subtype of O's type, or
    *    1.8.2  M is of type []S, O is of type ()T and S <: T, or
    *    1.8.3  M is of type ()S, O is of type []T and S <: T, or
-   *    1.9    If M or O are erased, they must be both erased
+   *    1.9.1  If M or O are erased, they must both be erased
+   *    1.9.2  If M or O are extension methods, they must both be extension methods
    *    1.10   If M is an inline or Scala-2 macro method, O cannot be deferred unless
    *           there's also a concrete method that M overrides.
    *    1.11.  If O is a Scala-2 macro, M must be a Scala-2 macro.
@@ -391,10 +392,14 @@ object RefChecks {
         overrideError("may not override a non-lazy value")
       } else if (other.is(Lazy) && !other.isRealMethod && !member.is(Lazy)) {
         overrideError("must be declared lazy to override a lazy value")
-      } else if (member.is(Erased) && !other.is(Erased)) { // (1.9)
+      } else if (member.is(Erased) && !other.is(Erased)) { // (1.9.1)
         overrideError("is erased, cannot override non-erased member")
-      } else if (other.is(Erased) && !member.is(Erased)) { // (1.9)
+      } else if (other.is(Erased) && !member.is(Erased)) { // (1.9.1)
         overrideError("is not erased, cannot override erased member")
+      } else if (member.is(Extension) && !other.is(Extension)) { // (1.9.2)
+        overrideError("is an extension method, cannot override a normal method")
+      } else if (other.is(Extension) && !member.is(Extension)) { // (1.9.2)
+        overrideError("is a normal method, cannot override an extension method")
       } else if ((member.isInlineMethod || member.is(Scala2Macro)) && other.is(Deferred) &&
                  member.extendedOverriddenSymbols.forall(_.is(Deferred))) { // (1.10)
         overrideError("is an inline method, must override at least one concrete method")

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -158,7 +158,7 @@ class SignatureHelpTest {
            }""".withSource
       .signatureHelp(m1, List(sig0, sig1), None, 0)
       .signatureHelp(m2, List(sig0, sig1), None, 0)
-      .signatureHelp(m3, List(sig0, sig1), Some(1), 1)
+      .signatureHelp(m3, List(), Some(1), 1)  // TODO: investigate we do not get help at $m3
   }
 
   @Test def multipleParameterLists: Unit = {

--- a/tests/neg/extmethod-overload.scala
+++ b/tests/neg/extmethod-overload.scala
@@ -1,0 +1,14 @@
+object Test {
+  implied A {
+    def (x: Int) |+| (y: Int) = x + y
+  }
+  implied B {
+    def (x: Int) |+| (y: String) = x + y.length
+  }
+  assert((1 |+| 2) == 3)  // error ambiguous
+
+  locally {
+    import B.|+|
+    assert((1 |+| "2") == 2)  // OK
+  }
+}

--- a/tests/neg/extmethod-override.scala
+++ b/tests/neg/extmethod-override.scala
@@ -1,0 +1,8 @@
+class A {
+  def f(x: Int)(y: Int): Int = 0
+  def (x: Int) g (y: Int): Int = 1
+}
+class B extends A {
+  override def (x: Int) f (y: Int): Int = 1  // error
+  override def g(x: Int)(y: Int): Int = 0    // error
+}

--- a/tests/run/extmethod-overload.scala
+++ b/tests/run/extmethod-overload.scala
@@ -1,0 +1,36 @@
+object Test extends App {
+  // warmup
+  def f(x: Int)(y: Int) = y
+  def f(x: Int)(y: String) = y.length
+  assert(f(1)(2) == 2)
+  assert(f(1)("two") == 3)
+
+  def g[T](x: T)(y: Int) = y
+  def g[T](x: T)(y: String) = y.length
+  assert(g[Int](1)(2) == 2)
+  assert(g[Int](1)("two") == 3)
+  assert(g(1)(2) == 2)
+  assert(g(1)("two") == 3)
+
+  def h[T](x: T)(y: T)(z: Int) = z
+  def h[T](x: T)(y: T)(z: String) = z.length
+  assert(h[Int](1)(1)(2) == 2)
+  assert(h[Int](1)(1)("two") == 3)
+  assert(h(1)(1)(2) == 2)
+  assert(h(1)(1)("two") == 3)
+
+  implied Foo {
+    def (x: Int) |+| (y: Int) = x + y
+    def (x: Int) |+| (y: String) = x + y.length
+
+    def (xs: List[T]) +++ [T] (ys: List[T]): List[T] = xs ++ ys ++ ys
+    def (xs: List[T]) +++ [T] (ys: Iterator[T]): List[T] = xs ++ ys ++ ys
+  }
+
+  assert((1 |+| 2) == 3)
+  assert((1 |+| "2") == 2)
+
+  val xs = List(1, 2)
+  assert((xs +++ xs).length == 6)
+  assert((xs +++ xs.iterator).length == 4, xs +++ xs.iterator)
+}

--- a/tests/run/extmethod-overload.scala
+++ b/tests/run/extmethod-overload.scala
@@ -19,18 +19,104 @@ object Test extends App {
   assert(h(1)(1)(2) == 2)
   assert(h(1)(1)("two") == 3)
 
-  implied Foo {
-    def (x: Int) |+| (y: Int) = x + y
-    def (x: Int) |+| (y: String) = x + y.length
+  // Test with extension methods in implied object
+  object test1 {
 
-    def (xs: List[T]) +++ [T] (ys: List[T]): List[T] = xs ++ ys ++ ys
-    def (xs: List[T]) +++ [T] (ys: Iterator[T]): List[T] = xs ++ ys ++ ys
+    implied Foo {
+      def (x: Int) |+| (y: Int) = x + y
+      def (x: Int) |+| (y: String) = x + y.length
+
+      def (xs: List[T]) +++ [T] (ys: List[T]): List[T] = xs ++ ys ++ ys
+      def (xs: List[T]) +++ [T] (ys: Iterator[T]): List[T] = xs ++ ys ++ ys
+    }
+
+    assert((1 |+| 2) == 3)
+    assert((1 |+| "2") == 2)
+
+    val xs = List(1, 2)
+    assert((xs +++ xs).length == 6)
+    assert((xs +++ xs.iterator).length == 4, xs +++ xs.iterator)
+  }
+  test1
+
+  // Test with imported extension methods
+  object test2 {
+    import test1.Foo._
+
+    assert((1 |+| 2) == 3)
+    assert((1 |+| "2") == 2)
+
+    val xs = List(1, 2)
+    assert((xs +++ xs).length == 6)
+    assert((xs +++ xs.iterator).length == 4, xs +++ xs.iterator)
+  }
+  test2
+
+  // Test with implied extension methods coming from base class
+  object test3 {
+    class Foo {
+      def (x: Int) |+| (y: Int) = x + y
+      def (x: Int) |+| (y: String) = x + y.length
+
+      def (xs: List[T]) +++ [T] (ys: List[T]): List[T] = xs ++ ys ++ ys
+      def (xs: List[T]) +++ [T] (ys: Iterator[T]): List[T] = xs ++ ys ++ ys
+    }
+    implied Bar for Foo
+
+    assert((1 |+| 2) == 3)
+    assert((1 |+| "2") == 2)
+
+    val xs = List(1, 2)
+    assert((xs +++ xs).length == 6)
+    assert((xs +++ xs.iterator).length == 4, xs +++ xs.iterator)
+  }
+  test3
+
+  // Test with implied extension methods coming from implied alias
+  object test4 {
+    implied for test3.Foo = test3.Bar
+
+    assert((1 |+| 2) == 3)
+    assert((1 |+| "2") == 2)
+
+    val xs = List(1, 2)
+    assert((xs +++ xs).length == 6)
+    assert((xs +++ xs.iterator).length == 4, xs +++ xs.iterator)
+  }
+  test4
+
+  class C {
+    def xx (x: Any) = 2
+  }
+  def (c: C) xx (x: Int) = 1
+
+  val c = new C
+  assert(c.xx(1) == 2)  // member method takes precedence
+
+  object D {
+    def (x: Int) yy (y: Int) = x + y
   }
 
-  assert((1 |+| 2) == 3)
-  assert((1 |+| "2") == 2)
+  implied {
+    def (x: Int) yy (y: Int) = x - y
+  }
 
-  val xs = List(1, 2)
-  assert((xs +++ xs).length == 6)
-  assert((xs +++ xs.iterator).length == 4, xs +++ xs.iterator)
+  import D._
+  assert((1 yy 2) == 3)  // imported extension method takes precedence
+
+  trait Rectangle {
+    def a: Long
+    def b: Long
+  }
+
+  case class GenericRectangle(a: Long, b: Long) extends Rectangle
+  case class Square(a: Long) extends Rectangle {
+    def b: Long = a
+  }
+
+  def (rectangle: Rectangle) area: Long = 0
+  def (square: Square) area: Long = square.a * square.a
+  val rectangles = List(GenericRectangle(2, 3), Square(5))
+  val areas = rectangles.map(_.area)
+  assert(areas.sum == 0)
 }


### PR DESCRIPTION
If resolving with the first parameter list yields a draw, and there are
further argument lists following the first one, take these into account
as well in order to arrive at a single best alternative.

This is particularly useful for extension methods, where we might
well have several overloaded extension methods with the same first
parameter list.