### PR TITLE
Add inlined invariant assertions and fixes

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -37,6 +37,7 @@ class Compiler {
   /** Phases dealing with the frontend up to trees ready for TASTY pickling */
   protected def frontendPhases: List[List[Phase]] =
     List(new FrontEnd) ::           // Compiler frontend: scanner, parser, namer, typer
+    List(new YCheckPositions) ::    // YCheck positions
     List(new Staging) ::            // Check PCP, heal quoted types and expand macros
     List(new sbt.ExtractDependencies) :: // Sends information on classes' dependencies to sbt via callbacks
     List(new PostTyper) ::          // Additional checks and cleanups after type checking

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -481,6 +481,7 @@ object Contexts {
     }
 
     def typerPhase: Phase                  = base.typerPhase
+    def postTyperPhase: Phase              = base.postTyperPhase
     def sbtExtractDependenciesPhase: Phase = base.sbtExtractDependenciesPhase
     def picklerPhase: Phase                = base.picklerPhase
     def reifyQuotesPhase: Phase            = base.reifyQuotesPhase

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -217,6 +217,7 @@ object Phases {
     }
 
     private[this] var myTyperPhase: Phase = _
+    private[this] var myPostTyperPhase: Phase = _
     private[this] var mySbtExtractDependenciesPhase: Phase = _
     private[this] var myPicklerPhase: Phase = _
     private[this] var myReifyQuotesPhase: Phase = _
@@ -234,6 +235,7 @@ object Phases {
     private[this] var myGenBCodePhase: Phase = _
 
     final def typerPhase: Phase = myTyperPhase
+    final def postTyperPhase: Phase = myPostTyperPhase
     final def sbtExtractDependenciesPhase: Phase = mySbtExtractDependenciesPhase
     final def picklerPhase: Phase = myPicklerPhase
     final def reifyQuotesPhase: Phase = myReifyQuotesPhase
@@ -254,6 +256,7 @@ object Phases {
       def phaseOfClass(pclass: Class[_]) = phases.find(pclass.isInstance).getOrElse(NoPhase)
 
       myTyperPhase = phaseOfClass(classOf[FrontEnd])
+      myPostTyperPhase = phaseOfClass(classOf[PostTyper])
       mySbtExtractDependenciesPhase = phaseOfClass(classOf[sbt.ExtractDependencies])
       myPicklerPhase = phaseOfClass(classOf[Pickler])
       myReifyQuotesPhase = phaseOfClass(classOf[ReifyQuotes])

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -33,9 +33,13 @@ import scala.annotation.constructorOnly
 class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(ictx) {
   import tpd._
 
-  override def transform(tree: Tree)(implicit ctx: Context): Tree = tree match {
-    case tree: DefDef if tree.symbol.is(Inline) && level > 0 => EmptyTree
-    case _ => checkLevel(super.transform(tree))
+  override def transform(tree: Tree)(implicit ctx: Context): Tree = {
+    if (tree.source != ctx.source && tree.source.exists)
+      transform(tree)(ctx.withSource(tree.source))
+    else tree match {
+      case tree: DefDef if tree.symbol.is(Inline) && level > 0 => EmptyTree
+      case _ => checkLevel(super.transform(tree))
+    }
   }
 
   /** Transform quoted trees while maintaining phase correctness */

--- a/compiler/src/dotty/tools/dotc/transform/Staging.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Staging.scala
@@ -68,6 +68,7 @@ class Staging extends MacroTransform {
           new TreeTraverser {
             private[this] var sources: List[SourceFile] = ctx.source :: Nil
             def traverse(tree: tpd.Tree)(implicit ctx: Context): Unit = {
+              assert(ctx.source == sources.head)
               if (!tree.isEmpty && !tree.isInstanceOf[untpd.TypedSplice] && ctx.typerState.isGlobalCommittable) {
                 if (!tree.isType) { // TODO also check types, currently we do not add Inlined(EmptyTree, _, _) for types. We should.
                   val currentSource = sources.head

--- a/compiler/src/dotty/tools/dotc/transform/Staging.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Staging.scala
@@ -14,8 +14,7 @@ import dotty.tools.dotc.core.StdNames._
 import dotty.tools.dotc.core.Symbols._
 import dotty.tools.dotc.core.tasty.TreePickler.Hole
 import dotty.tools.dotc.core.Types._
-import dotty.tools.dotc.util.SourcePosition
-import dotty.tools.dotc.util.Spans._
+import dotty.tools.dotc.util.{SourceFile, SourcePosition}
 import dotty.tools.dotc.transform.SymUtils._
 import dotty.tools.dotc.transform.TreeMapWithStages._
 import dotty.tools.dotc.typer.Implicits.SearchFailureType
@@ -62,6 +61,43 @@ class Staging extends MacroTransform {
           checker.transform(tree)
         case _ =>
       }
+    }
+    if (ctx.phase <= ctx.erasurePhase) {
+      tree match {
+        case PackageDef(pid, _) if tree.symbol.owner == defn.RootClass =>
+          new TreeTraverser {
+            private[this] var sources: List[SourceFile] = ctx.source :: Nil
+            def traverse(tree: tpd.Tree)(implicit ctx: Context): Unit = {
+              if (!tree.isEmpty && !tree.isInstanceOf[untpd.TypedSplice] && ctx.typerState.isGlobalCommittable) {
+                if (!tree.isType) { // TODO also check types, currently we do not add Inlined(EmptyTree, _, _) for types. We should.
+                  val currentSource = sources.head
+                  assert(tree.source == currentSource, i"wrong source set for $tree # ${tree.uniqueId} of ${tree.getClass}, set to ${tree.source} but context had $currentSource")
+                }
+              }
+              tree match {
+                case Inlined(EmptyTree, bindings, expansion) =>
+                  assert(bindings.isEmpty)
+                  val old = sources
+                  sources = old.tail
+                  traverse(expansion)(inlineContext(EmptyTree))
+                  sources = old
+                case Inlined(call, bindings, expansion) =>
+                  bindings.foreach(traverse(_))
+                  sources = call.symbol.topLevelClass.source :: sources
+                  if (
+                    !( // FIXME macro implementations can drop Inlined nodes. We should reinsert them after macro expansion based on the positions of the trees
+                      ((ctx.phase <= ctx.typerPhase.next) && call.symbol.is(Macro)) ||
+                      (!(ctx.phase <= ctx.typerPhase.next) && call.symbol.unforcedDecls.exists(_.is(Macro)) || call.symbol.unforcedDecls.toList.exists(_.is(Macro)))
+                    )
+                  ) traverse(expansion)(inlineContext(call))
+                  sources = sources.tail
+                case _ => traverseChildren(tree)
+              }
+            }
+          }.traverse(tree)
+        case _ =>
+      }
+
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/TreeMapWithStages.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeMapWithStages.scala
@@ -30,6 +30,7 @@ import scala.annotation.constructorOnly
  *  @param  levels     a stacked map from symbols to the levels in which they were defined
  */
 abstract class TreeMapWithStages(@constructorOnly ictx: Context) extends TreeMapWithImplicits {
+
   import tpd._
   import TreeMapWithStages._
 
@@ -68,7 +69,9 @@ abstract class TreeMapWithStages(@constructorOnly ictx: Context) extends TreeMap
   protected def transformSplice(body: Tree, splice: Tree)(implicit ctx: Context): Tree
 
   override def transform(tree: Tree)(implicit ctx: Context): Tree = {
-    reporting.trace(i"StagingTransformer.transform $tree at $level", show = true) {
+    if (tree.source != ctx.source && tree.source.exists)
+      transform(tree)(ctx.withSource(tree.source))
+    else reporting.trace(i"StagingTransformer.transform $tree at $level", show = true) {
       def mapOverTree(lastEntered: List[Symbol]) =
         try super.transform(tree)
         finally

--- a/compiler/src/dotty/tools/dotc/transform/YCheckPositions.scala
+++ b/compiler/src/dotty/tools/dotc/transform/YCheckPositions.scala
@@ -57,8 +57,8 @@ class YCheckPositions extends Phases.Phase {
   }
 
   private def isMacro(call: Tree)(implicit ctx: Context) = {
-    ((ctx.phase <= ctx.typerPhase.next) && call.symbol.is(Macro)) ||
-    (!(ctx.phase <= ctx.typerPhase.next) && call.symbol.unforcedDecls.exists(_.is(Macro)) || call.symbol.unforcedDecls.toList.exists(_.is(Macro)))
+    if (ctx.phase <= ctx.typerPhase.next) call.symbol.is(Macro)
+    else (call.symbol.unforcedDecls.exists(_.is(Macro)) || call.symbol.unforcedDecls.toList.exists(_.is(Macro)))
   }
 
 }

--- a/compiler/src/dotty/tools/dotc/transform/YCheckPositions.scala
+++ b/compiler/src/dotty/tools/dotc/transform/YCheckPositions.scala
@@ -1,0 +1,64 @@
+package dotty.tools.dotc
+package transform
+
+import dotty.tools.dotc.ast.Trees._
+import dotty.tools.dotc.ast.{tpd, untpd}
+import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.core.Decorators._
+import dotty.tools.dotc.core.Flags._
+import dotty.tools.dotc.core.Phases
+import dotty.tools.dotc.core.Symbols._
+import dotty.tools.dotc.util.{SourceFile, SourcePosition}
+
+/** Ycheck inlined positions */
+class YCheckPositions extends Phases.Phase {
+  import tpd._
+
+  def phaseName: String = "inlinedPositions"
+
+  override def run(implicit ctx: Context): Unit = () // YCheck only
+
+  override def checkPostCondition(tree: Tree)(implicit ctx: Context): Unit = {
+    tree match {
+      case PackageDef(pid, _) if tree.symbol.owner == defn.RootClass =>
+        new TreeTraverser {
+          private[this] var sources: List[SourceFile] = ctx.source :: Nil
+          def traverse(tree: tpd.Tree)(implicit ctx: Context): Unit = {
+
+            // Check current context is correct
+            assert(ctx.source == sources.head)
+            if (!tree.isEmpty && !tree.isInstanceOf[untpd.TypedSplice] && ctx.typerState.isGlobalCommittable) {
+              if (!tree.isType) { // TODO also check types, currently we do not add Inlined(EmptyTree, _, _) for types. We should.
+                val currentSource = sources.head
+                assert(tree.source == currentSource, i"wrong source set for $tree # ${tree.uniqueId} of ${tree.getClass}, set to ${tree.source} but context had $currentSource")
+              }
+            }
+
+            // Recursivlely check children while keeping track of current source
+            tree match {
+              case Inlined(EmptyTree, bindings, expansion) =>
+                assert(bindings.isEmpty)
+                val old = sources
+                sources = old.tail
+                traverse(expansion)(inlineContext(EmptyTree))
+                sources = old
+              case Inlined(call, bindings, expansion) =>
+                bindings.foreach(traverse(_))
+                sources = call.symbol.topLevelClass.source :: sources
+                if (
+                  !( // FIXME macro implementations can drop Inlined nodes. We should reinsert them after macro expansion based on the positions of the trees
+                    ((ctx.phase <= ctx.typerPhase.next) && call.symbol.is(Macro)) ||
+                    (!(ctx.phase <= ctx.typerPhase.next) && call.symbol.unforcedDecls.exists(_.is(Macro)) || call.symbol.unforcedDecls.toList.exists(_.is(Macro)))
+                  )
+                ) traverse(expansion)(inlineContext(call))
+                sources = sources.tail
+              case _ => traverseChildren(tree)
+            }
+          }
+        }.traverse(tree)
+      case _ =>
+    }
+
+  }
+
+}

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1587,7 +1587,7 @@ final class SearchRoot extends SearchHistory {
             // Substitute dictionary references into dictionary entry RHSs
             val rhsMap = new TreeTypeMap(treeMap = {
               case id: Ident if vsymMap.contains(id.symbol) =>
-                tpd.ref(vsymMap(id.symbol))
+                tpd.ref(vsymMap(id.symbol)).withSpan(id.span)
               case tree => tree
             })
             val nrhss = rhss.map(rhsMap(_))

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -415,7 +415,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
     val inlineCtx = inlineContext(call).fresh.setTyper(inlineTyper).setNewScope
 
     def inlinedFromOutside(tree: Tree)(span: Span): Tree =
-      Inlined(EmptyTree, Nil, tree)(inlinedSourceCtx).withSpan(span)
+      Inlined(EmptyTree, Nil, tree)(ctx.withSource(inlinedMethod.topLevelClass.source)).withSpan(span)
 
     // A tree type map to prepare the inlined body for typechecked.
     // The translation maps references to `this` and parameters to

--- a/tests/run/i4803/App_2.scala
+++ b/tests/run/i4803/App_2.scala
@@ -12,9 +12,9 @@ object Test {
     println(n.power(5))
 
     val n2 = new Num2(1.5)
-    println(n.power(0))
-    println(n.power(1))
-    println(n.power(2))
-    println(n.power(5))
+    println(n2.power(0))
+    println(n2.power(1))
+    println(n2.power(2))
+    println(n2.power(5))
   }
 }


### PR DESCRIPTION
Add `Ycheck` assertions that check that all trees have the expected source. Trees inside the expansion of an `Inlined` tree have the source of the definition of the inlined call. If the call is empty the source is reset to the source in the outer `Inlined`.

At the same time fix all inconsistencies found by the new assertions.

Future PR:
* Add `Inlined(Empty, ...)` around inlined types
* Check `Inlined` inside macro-expanded code.