### PR TITLE
Fix #5110: Add regression tests

### DIFF
--- a/tests/run/i5110/quoted_1.scala
+++ b/tests/run/i5110/quoted_1.scala
@@ -1,0 +1,16 @@
+import scala.quoted._
+
+object Macro {
+
+  class Boom extends Exception
+
+  class Bomb {
+    throw new Boom
+  }
+
+  inline def (boom: Bomb) foo(): Unit = ()
+
+  // By name Boom is used to elide the evaluation of the prefix
+  inline def (boom: => Bomb) bar(): Unit = ()
+
+}

--- a/tests/run/i5110/quoted_2.scala
+++ b/tests/run/i5110/quoted_2.scala
@@ -1,0 +1,23 @@
+import scala.util.Try
+
+object Test {
+  import Macro._
+
+  def main(args: Array[String]): Unit = {
+    def bomb = new Bomb
+    new Bomb().bar() // Safely elided prefix
+    bomb.bar() // Safely elided prefix
+    shouldThrowBoom { new Bomb().foo() }
+    shouldThrowBoom { bomb.foo() }
+
+  }
+
+  def shouldThrowBoom(x: => Any): Unit = {
+    try {
+      x
+      ???
+    } catch {
+      case ex: Boom => // OK
+    }
+  }
+}

--- a/tests/run/quote-elide-prefix/quoted_1.scala
+++ b/tests/run/quote-elide-prefix/quoted_1.scala
@@ -1,0 +1,9 @@
+import scala.quoted._
+
+object Macro {
+
+  // By name StringContext is used to elide the prefix
+  inline def (sc: => StringContext) ff (args: => Any*): String = ${ Macro.impl('sc, 'args) }
+
+  def impl(sc: Expr[StringContext], args: Expr[Seq[Any]]): Expr[String] = '{ $args.mkString }
+}

--- a/tests/run/quote-elide-prefix/quoted_2.scala
+++ b/tests/run/quote-elide-prefix/quoted_2.scala
@@ -1,0 +1,9 @@
+
+object Test {
+  import Macro._
+
+  def main(args: Array[String]): Unit = {
+    def test = ff"Hello ${"World"}"
+    assert(test == "World")
+  }
+}


### PR DESCRIPTION
With the new syntax for extension method we can create a by name prefix which is elided if not used.