### PR TITLE
Change enum Desugarings

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -598,7 +598,8 @@ object desugar {
           if (constrTparams.nonEmpty ||
               constrVparamss.length > 1 ||
               mods.is(Abstract) ||
-              restrictedAccess) anyRef
+              restrictedAccess ||
+              isEnumCase && applyResultTpt.isEmpty) anyRef
           else
             // todo: also use anyRef if constructor has a dependent method type (or rule that out)!
             (constrVparamss :\ (if (isEnumCase) applyResultTpt else classTypeRef)) (

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -599,10 +599,10 @@ object desugar {
               constrVparamss.length > 1 ||
               mods.is(Abstract) ||
               restrictedAccess ||
-              isEnumCase && applyResultTpt.isEmpty) anyRef
+              isEnumCase) anyRef
           else
             // todo: also use anyRef if constructor has a dependent method type (or rule that out)!
-            (constrVparamss :\ (if (isEnumCase) applyResultTpt else classTypeRef)) (
+            (constrVparamss :\ classTypeRef) (
               (vparams, restpe) => Function(vparams map (_.tpt), restpe))
         def widenedCreatorExpr =
           (creatorExpr /: widenDefs)((rhs, meth) => Apply(Ident(meth.name), rhs :: Nil))

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -355,7 +355,8 @@ object desugar {
     val originalVparamss = constr1.vparamss
     lazy val derivedEnumParams = enumClass.typeParams.map(derivedTypeParam)
     val impliedTparams =
-      if (isEnumCase && originalTparams.isEmpty)
+      if (isEnumCase && originalTparams.isEmpty &&
+          typeParamIsReferenced(enumClass.typeParams, originalVparamss, parents))
         derivedEnumParams.map(tdef => tdef.withFlags(tdef.mods.flags | PrivateLocal))
       else
         originalTparams

--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -201,7 +201,7 @@ object DesugarEnums {
       case TypeApply(_, targs) => targs.exists(typeHasRef)
       case Select(nu, nme.CONSTRUCTOR) => parentHasRef(nu)
       case New(tpt) => typeHasRef(tpt)
-      case parent if parent.isType => typeHasRef(parent)
+      case parent => parent.isType && typeHasRef(parent)
     }
 
     parents.isEmpty ||  // a parent class that refers to type parameters will be generated in this case

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1419,7 +1419,7 @@ object Trees {
       }
 
       def foldMoreCases(x: X, tree: Tree)(implicit ctx: Context): X = {
-        assert(ctx.reporter.errorsReported || ctx.mode.is(Mode.Interactive))
+        assert(ctx.reporter.errorsReported || ctx.mode.is(Mode.Interactive), tree)
           // In interactive mode, errors might come from previous runs.
           // In case of errors it may be that typed trees point to untyped ones.
           // The IDE can still traverse inside such trees, either in the run where errors

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -25,9 +25,9 @@ some terminology and notational conventions:
 
 The desugaring rules imply that class cases are mapped to case classes, and singleton cases are mapped to `val` definitions.
 
-There are eight desugaring rules. Rule (1) desugar enum definitions. Rules
+There are nine desugaring rules. Rule (1) desugar enum definitions. Rules
 (2) and (3) desugar simple cases. Rules (4) to (6) define extends clauses for cases that
-are missing them. Rules (7) and (8) define how such cases with extends clauses
+are missing them. Rules (7) to (9) define how such cases with extends clauses
 map into case classes or vals.
 
 1.  An `enum` definition
@@ -80,7 +80,7 @@ map into case classes or vals.
        case C extends E[B1, ..., Bn]
 
    where `Bi` is `Li` if `Vi = '+'` and `Ui` if `Vi = '-'`. This result is then further
-   rewritten with rule (7). Simple cases of enums with non-variant type
+   rewritten with rule (8). Simple cases of enums with non-variant type
    parameters are not permitted.
 
 5. A class case without an extends clause
@@ -91,7 +91,7 @@ map into case classes or vals.
 
         case C <type-params> <value-params> extends E
 
-   This result is then further rewritten with rule (8).
+   This result is then further rewritten with rule (9).
 
 6. If `E` is an enum with type parameters `Ts`, a class case with neither type parameters nor an extends clause
 
@@ -101,9 +101,20 @@ map into case classes or vals.
 
         case C[Ts] <value-params> extends E[Ts]
 
-   This result is then further rewritten with rule (8). For class cases that have type parameters themselves, an extends clause needs to be given explicitly.
+   This result is then further rewritten with rule (9). For class cases that have type parameters themselves, an extends clause needs to be given explicitly.
 
-7. A value case
+7. If `E` is an enum with type parameters `Ts`, a class case without type parameters but with an extends clause
+
+       case C <value-params> extends <parents>
+
+   expands to
+
+       case C[Ts] <value-params> extends <parents>
+
+   provided at least one of the parameters `Ts` is mentioned in a parameter type in
+   `<value-params>` or in a type argument in `<parents>`.
+
+8. A value case
 
        case C extends <parents>
 
@@ -116,7 +127,7 @@ map into case classes or vals.
    as one of the `enumValues` of the enumeration (see below). `$values` is a
    compiler-defined private value in the companion object.
 
-8. A class case
+9. A class case
 
        case C <params> extends <parents>
 

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -127,6 +127,9 @@ map into case classes or vals.
    as one of the `enumValues` of the enumeration (see below). `$values` is a
    compiler-defined private value in the companion object.
 
+   It is an error if a value case refers to a type parameter of the enclosing `enum`
+   in a type argument of `<parents>`.
+
 9. A class case
 
        case C <params> extends <parents>
@@ -144,6 +147,11 @@ map into case classes or vals.
 
    where `n` is the ordinal number of the case in the companion object,
    starting from 0.
+
+   It is an error if a value case refers to a type parameter of the enclosing `enum`
+   in a parameter type in `<params>` or in a type argument of `<parents>`, unless that parameter is already
+   a type parameter of the case, i.e. the parameter name is defined in `<params>`.
+
 
 ### Translation of Enumerations
 

--- a/tests/neg/enum-tparams.scala
+++ b/tests/neg/enum-tparams.scala
@@ -1,0 +1,40 @@
+object Test {
+
+  enum Opt[+T] {
+    case S(x: T) extends Opt[T]
+    case I(x: Int) extends Opt[Int]
+    case V() extends Opt[`T`]
+    case P(x: List[T]) extends Opt[String]
+    case N extends Opt[Nothing]
+  }
+
+  type Id[_]
+
+  enum E[F[_], G[_]] {
+    case C1() extends E[[X] => X, Id]
+    case C2() extends E[[F] => F, Id]
+    case C3() extends E[[X] => { type Y = F[Int] }, Id]
+    case C4() extends E[[X] => { type F = Int }, Id]
+    case C5() extends E[[F] => G[Int], Id]
+  }
+
+  Opt.S[Int](1) // OK
+  Opt.S(1)      // OK
+  Opt.I[Int](1) // error: does not take type parameters
+  Opt.I(1)      // OK
+  Opt.V[Int]()  // OK
+  Opt.V()       // OK
+  Opt.P[Int](List(1, 2, 3)) // OK
+  Opt.P(List(1, 2, 3)) // OK
+
+  E.C1[List, Id]()  // error: does not take type parameters
+  E.C1()            // OK
+  E.C2[List, Id]()  // error: does not take type parameters
+  E.C2()            // OK
+  E.C3[List, Id]()  // OK
+  E.C3()            // OK
+  E.C4[List, Id]()  // error: does not take type parameters
+  E.C4()            // OK
+  E.C5[List, Id]()  // OK
+  E.C5()            // OK
+}

--- a/tests/neg/enums.scala
+++ b/tests/neg/enums.scala
@@ -24,6 +24,12 @@ enum E4 {
 case class C4() extends E4 // error: cannot extend enum
 case object O4 extends E4 // error: cannot extend enum
 
+enum Captured[T] {
+  case Case1[U](x: T) extends Captured[U] // error: illegal reference to type parameter T from enum case
+  case Case2[U]()     extends Captured[T] // error: illegal reference to type parameter T from enum case
+  case Case3          extends Captured[T] // error: illegal reference to type parameter T from enum case
+}
+
 enum Option[+T] derives Eql {
   case Some(x: T)
   case None

--- a/tests/neg/enums.scala
+++ b/tests/neg/enums.scala
@@ -19,6 +19,11 @@ enum E3[-T <: Ordered[T]] {
 
 enum E4 {
   case C
+  case C4(x: Int)
+}
+object E4 {
+  val x1: Int => E4 = C4    // error: found: C4, required: Int => E4
+  val x2: Int => E4 = C4(_) // ok
 }
 
 case class C4() extends E4 // error: cannot extend enum

--- a/tests/pos/enums-capture.scala
+++ b/tests/pos/enums-capture.scala
@@ -1,0 +1,7 @@
+class T
+
+enum Foo[T](val foo: Any) {
+  case Case1(x: Int) extends Foo(new T)
+  case Case2[U](x: U) extends Foo(new T)
+  case Case3 extends Foo(new T)
+}

--- a/tests/run/enums.scala
+++ b/tests/run/enums.scala
@@ -105,6 +105,7 @@ object Test6 {
     case Green  extends Color(3)
     case Red    extends Color(2)
     case Violet extends Color(Green.x + Red.x)
+    case RGB(xx: Int) extends Color(xx)
   }
 }
 


### PR DESCRIPTION
Change the condition when type parameters of an enum are added to a class case.

Quoting my comment on #6095:

> We have the following possibilities:

 1. type parameters are added only of there is no extends clause,
 2. (all) type parameters are added if one of them is referenced in the case,
 3. type parameters are always added if the case has value parameters (i.e. is not translated to an object).

> (1) is what the current rules say. (2) is what Adriaan proposed. (3) is what is currently implemented.

> In addition we have to clarify what should happen if a type parameter that is not added is nevertheless referred to in the case. Since enum expansion is done during desugaring, this could silently rebind to some other type. We should come up with a solution that avoids this, if possible.

This PR changes the rules to implement (2).