### PR TITLE
[CI only] Check the performance impact of tracing isSubType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -176,7 +176,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
    *  code would have two extra parameters for each of the many calls that go from
    *  one sub-part of isSubType to another.
    */
-  protected def recur(tp1: Type, tp2: Type): Boolean = trace(s"isSubType ${traceInfo(tp1, tp2)} $approx", subtyping) {
+  protected def recur(tp1: Type, tp2: Type): Boolean = {
 
     def monitoredIsSubType = {
       if (pendingSubTypes == null) {


### PR DESCRIPTION
We have essentially non-local returns inside `recur`. The
cost of throwing exceptions inside a heavily used operation might be
non-trivial, and I'd like to check it.

See:
- https://github.com/lampepfl/dotty/pull/5738#issuecomment-469240942
- https://github.com/lampepfl/dotty/pull/6156#issuecomment-475964057
