### PR TITLE
Fix #6033: avoid capture conversion if member absent

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1083,7 +1083,6 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
           case tparam: Symbol
           if leftRoot.isStable || (ctx.isAfterTyper || ctx.mode.is(Mode.TypevarsMissContext)) && leftRoot.member(tparam.name).exists =>
             val captured = TypeRef(leftRoot, tparam)
-            assert(captured.exists, i"$leftRoot has no member $tparam in isSubArgs($args1, $args2, $tp1, $tparams2)")
             isSubArg(captured, arg2)
           case _ =>
             false

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1081,7 +1081,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
          */
         def compareCaptured(arg1: TypeBounds, arg2: Type) = tparam match {
           case tparam: Symbol
-          if leftRoot.isStable || ctx.isAfterTyper || ctx.mode.is(Mode.TypevarsMissContext) =>
+          if leftRoot.isStable || (ctx.isAfterTyper || ctx.mode.is(Mode.TypevarsMissContext)) && leftRoot.member(tparam.name).exists =>
             val captured = TypeRef(leftRoot, tparam)
             assert(captured.exists, i"$leftRoot has no member $tparam in isSubArgs($args1, $args2, $tp1, $tparams2)")
             isSubArg(captured, arg2)

--- a/tests/pos/i6033.scala
+++ b/tests/pos/i6033.scala
@@ -1,0 +1,5 @@
+class Test {
+  def f(a: Array[_]|Null): Unit  = a match {
+   case x: Array[Int] =>
+  }
+}


### PR DESCRIPTION
Fix #6033: avoid capture conversion if member absent