### PR TITLE
Don't uncondtionally emit forwarders as ACC_SYNTHETIC

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
@@ -22,7 +22,7 @@ class MixinOps(cls: ClassSymbol, thisPhase: DenotTransformer)(implicit ctx: Cont
     val res = member.copy(
       owner = cls,
       name = member.name.stripScala2LocalSuffix,
-      flags = member.flags &~ Deferred | Synthetic | Artifact | extraFlags,
+      flags = member.flags &~ Deferred | Synthetic | extraFlags,
       info = cls.thisType.memberInfo(member)).enteredAfter(thisPhase).asTerm
     res.addAnnotations(member.annotations.filter(_.symbol != defn.TailrecAnnot))
     res

--- a/tests/pos-java-interop-separate/forwarder/Foo_1.scala
+++ b/tests/pos-java-interop-separate/forwarder/Foo_1.scala
@@ -1,0 +1,7 @@
+import java.util.List
+
+trait Foo {
+  val x: List[String] = null
+}
+abstract class Bar extends Foo
+

--- a/tests/pos-java-interop-separate/forwarder/Test_2.java
+++ b/tests/pos-java-interop-separate/forwarder/Test_2.java
@@ -1,0 +1,5 @@
+class Test_2 {
+  public void foo() {
+    new Bar() {};
+  }
+}


### PR DESCRIPTION
It turns out that javac sometimes gets confused when a non-synthetic abstract
method is overridden by a synthetic method in a derived class.

This is a blocker for the full bootstrap due to the sbt-bridge containing Java code that extend from Scala code.