### PR TITLE
Split quoted.Expr casting from sealing

### DIFF
--- a/library/src-bootstrapped/scala/tasty/reflect/QuotedOps.scala
+++ b/library/src-bootstrapped/scala/tasty/reflect/QuotedOps.scala
@@ -4,25 +4,29 @@ package scala.tasty.reflect
 trait QuotedOps extends Core {
 
   implicit class QuotedExprAPI[T](expr: scala.quoted.Expr[T]) {
-    /** View this expression `Expr[T]` as a `Term` */
+    /** View this expression `quoted.Expr[T]` as a `Term` */
     def unseal(implicit ctx: Context): Term =
       kernel.QuotedExpr_unseal(expr)
+
+    /** Checked cast to a `quoted.Expr[U]` */
+    def cast[U: scala.quoted.Type](implicit ctx: Context): scala.quoted.Expr[U] =
+      kernel.QuotedExpr_cast[U](expr)
   }
 
   implicit class QuotedTypeAPI[T <: AnyKind](tpe: scala.quoted.Type[T]) {
-    /** View this expression `Type[T]` as a `TypeTree` */
+    /** View this expression `quoted.Type[T]` as a `TypeTree` */
     def unseal(implicit ctx: Context): TypeTree =
       kernel.QuotedType_unseal(tpe)
   }
 
   implicit class TermToQuotedAPI(term: Term) {
-    /** Convert `Term` to an `Expr[T]` and check that it conforms to `T` */
-    def seal[T](implicit tpe: scala.quoted.Type[T], ctx: Context): scala.quoted.Expr[T] =
-      kernel.QuotedExpr_seal(term)(tpe)
+    /** Convert `Term` to an `quoted.Expr[Any]` */
+    def seal(implicit ctx: Context): scala.quoted.Expr[Any] =
+      kernel.QuotedExpr_seal(term)
   }
 
   implicit class TypeToQuotedAPI(tpe: Type) {
-    /** Convert `Type` to an `quoted.Type[T]` */
+    /** Convert `Type` to an `quoted.Type[_]` */
     def seal(implicit ctx: Context): scala.quoted.Type[_] =
       kernel.QuotedType_seal(tpe)
   }

--- a/library/src-bootstrapped/scala/tasty/reflect/utils/TreeUtils.scala
+++ b/library/src-bootstrapped/scala/tasty/reflect/utils/TreeUtils.scala
@@ -12,12 +12,12 @@ trait TreeUtils {
   def let(rhs: Term)(body: Ident => Term): Term = {
     type T // TODO probably it is better to use the Sealed contruct rather than let the user create their own existential type
     implicit val rhsTpe: quoted.Type[T] = rhs.tpe.seal.asInstanceOf[quoted.Type[T]]
-    val rhsExpr = rhs.seal[T]
+    val rhsExpr = rhs.seal.cast[T]
     val expr = '{
       val x = $rhsExpr
       ${
         val id = ('x).unseal.asInstanceOf[Ident]
-        body(id).seal[Any]
+        body(id).seal
       }
     }
     expr.unseal

--- a/library/src-non-bootstrapped/scala/tasty/reflect/QuotedOps.scala
+++ b/library/src-non-bootstrapped/scala/tasty/reflect/QuotedOps.scala
@@ -4,25 +4,29 @@ package scala.tasty.reflect
 trait QuotedOps extends Core {
 
   implicit class QuotedExprAPI[T](expr: scala.quoted.Expr[T]) {
-    /** View this expression `Expr[T]` as a `Term` */
+    /** View this expression `quoted.Expr[T]` as a `Term` */
     def unseal(implicit ctx: Context): Term =
       kernel.QuotedExpr_unseal(expr)
+
+    /** Checked cast to a `quoted.Expr[U]` */
+    def cast[U: scala.quoted.Type](implicit ctx: Context): scala.quoted.Expr[U] =
+      kernel.QuotedExpr_cast[U](expr)
   }
 
   implicit class QuotedTypeAPI[T](tpe: scala.quoted.Type[T]) {
-    /** View this expression `Type[T]` as a `TypeTree` */
+    /** View this expression `quoted.Type[T]` as a `TypeTree` */
     def unseal(implicit ctx: Context): TypeTree =
       kernel.QuotedType_unseal(tpe)
   }
 
   implicit class TermToQuotedAPI(term: Term) {
-    /** Convert `Term` to an `Expr[T]` and check that it conforms to `T` */
-    def seal[T](implicit tpe: scala.quoted.Type[T], ctx: Context): scala.quoted.Expr[T] =
-      kernel.QuotedExpr_seal(term)(tpe)
+    /** Convert `Term` to an `quoted.Expr[Any]` */
+    def seal(implicit ctx: Context): scala.quoted.Expr[Any] =
+      kernel.QuotedExpr_seal(term)
   }
 
   implicit class TypeToQuotedAPI(tpe: Type) {
-    /** Convert `Type` to an `quoted.Type[T]` */
+    /** Convert `Type` to an `quoted.Type[_]` */
     def seal(implicit ctx: Context): scala.quoted.Type[_] =
       kernel.QuotedType_seal(tpe)
   }

--- a/library/src/scala/tasty/TastyTypecheckError.scala
+++ b/library/src/scala/tasty/TastyTypecheckError.scala
@@ -1,3 +1,0 @@
-package scala.tasty
-
-class TastyTypecheckError(msg: String) extends Throwable(msg)

--- a/library/src/scala/tasty/reflect/ExprCastError.scala
+++ b/library/src/scala/tasty/reflect/ExprCastError.scala
@@ -1,0 +1,3 @@
+package scala.tasty.reflect
+
+class ExprCastError(msg: String) extends Throwable(msg)

--- a/library/src/scala/tasty/reflect/Kernel.scala
+++ b/library/src/scala/tasty/reflect/Kernel.scala
@@ -1375,16 +1375,20 @@ trait Kernel {
   // QUOTED SEAL/UNSEAL
   //
 
-  /** View this expression `Expr[_]` as a `Term` */
+  /** View this expression `quoted.Expr[_]` as a `Term` */
   def QuotedExpr_unseal(self: scala.quoted.Expr[_])(implicit ctx: Context): Term
 
-  /** View this expression `Type[T]` as a `TypeTree` */
+  /** Checked cast to a `quoted.Expr[U]` */
+  def QuotedExpr_cast[U](self: scala.quoted.Expr[_])(implicit tp: scala.quoted.Type[U], ctx: Context): scala.quoted.Expr[U]
+
+  /** View this expression `quoted.Type[T]` as a `TypeTree` */
   def QuotedType_unseal(self: scala.quoted.Type[_])(implicit ctx: Context): TypeTree
 
-  /** Convert `Term` to an `Expr[T]` and check that it conforms to `T` */
-  def QuotedExpr_seal[T](self: Term)(tpe: scala.quoted.Type[T])(implicit ctx: Context): scala.quoted.Expr[T]
+  /** Convert `Term` to an `quoted.Expr[Any]` */
+  def QuotedExpr_seal(self: Term)(implicit ctx: Context): scala.quoted.Expr[Any]
 
-  /** Convert `Type` to an `quoted.Type[T]` */
+
+  /** Convert `Type` to an `quoted.Type[_]` */
   def QuotedType_seal(self: Type)(implicit ctx: Context): scala.quoted.Type[_]
 
   //

--- a/tests/neg-with-compiler/i5941/macro_1.scala
+++ b/tests/neg-with-compiler/i5941/macro_1.scala
@@ -19,7 +19,7 @@ object Lens {
 
     // obj.copy(field = value)
     def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =
-      Select.overloaded(obj.unseal, "copy", Nil, NamedArg(field, value.unseal) :: Nil).seal[S]
+      Select.overloaded(obj.unseal, "copy", Nil, NamedArg(field, value.unseal) :: Nil).seal.cast[S]
 
     // exception: getter.unseal.underlyingArgument
     getter.unseal match {

--- a/tests/neg/tasty-macro-assert-1/quoted_1.scala
+++ b/tests/neg/tasty-macro-assert-1/quoted_1.scala
@@ -34,7 +34,7 @@ object Asserts {
 
     tree match {
       case Inlined(_, Nil, Apply(Select(OpsTree(left), op), right :: Nil)) =>
-        '{assertTrue(${left.seal[Boolean]})} // Buggy code. To generate the errors
+        '{assertTrue(${left.seal.cast[Boolean]})} // Buggy code. To generate the errors
       case _ =>
         '{assertTrue($cond)}
     }

--- a/tests/neg/tasty-macro-assert-2/quoted_1.scala
+++ b/tests/neg/tasty-macro-assert-2/quoted_1.scala
@@ -34,7 +34,7 @@ object Asserts {
 
     tree match {
       case Inlined(_, Nil, Apply(Select(OpsTree(left), op), right :: Nil)) =>
-        '{assertTrue(${left.seal[Boolean]})} // Buggy code. To generate the errors
+        '{assertTrue(${left.seal.cast[Boolean]})} // Buggy code. To generate the errors
       case _ =>
         '{assertTrue($cond)}
     }

--- a/tests/run-with-compiler/i5715/Macro_1.scala
+++ b/tests/run-with-compiler/i5715/Macro_1.scala
@@ -11,7 +11,7 @@ object scalatest {
     cond.unseal.underlyingArgument match {
       case app @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         val IsSelect(select) = sel
-        val cond = Apply(Select.copy(select)(lhs, "exists"), rhs :: Nil).seal[Boolean]
+        val cond = Apply(Select.copy(select)(lhs, "exists"), rhs :: Nil).seal.cast[Boolean]
         '{ scala.Predef.assert($cond) }
       case _ =>
         '{ scala.Predef.assert($cond) }

--- a/tests/run-with-compiler/i5941/macro_1.scala
+++ b/tests/run-with-compiler/i5941/macro_1.scala
@@ -58,7 +58,7 @@ object Lens {
     getter.unseal match {
       case Function(param :: Nil, Path(o, parts)) if o.symbol == param.symbol =>
         '{
-          val setter = (t: T) => (s: S) => ${ setterBody(('s).unseal, ('t).unseal, parts).seal[S] }
+          val setter = (t: T) => (s: S) => ${ setterBody(('s).unseal, ('t).unseal, parts).seal.cast[S] }
           apply($getter)(setter)
         }
       case _ =>
@@ -122,9 +122,9 @@ object Iso {
 
     '{
       // (p: S) => p._1
-      val to = (p: S) =>  ${ Select.unique(('p).unseal, "_1").seal[A] }
+      val to = (p: S) =>  ${ Select.unique(('p).unseal, "_1").seal.cast[A] }
       // (p: A) => S(p)
-      val from = (p: A) =>  ${ Select.overloaded(Ident(companion), "apply", Nil, ('p).unseal :: Nil).seal[S] }
+      val from = (p: A) =>  ${ Select.overloaded(Ident(companion), "apply", Nil, ('p).unseal :: Nil).seal.cast[S] }
       apply(from)(to)
     }
   }
@@ -137,7 +137,7 @@ object Iso {
     val tpS = typeOf[S]
 
     if (tpS.isSingleton) {
-      val ident = Ident(tpS.asInstanceOf[TermRef]).seal[S]
+      val ident = Ident(tpS.asInstanceOf[TermRef]).seal.cast[S]
       '{
         Iso[S, 1](Function.const($ident))(Function.const(1))
       }
@@ -153,7 +153,7 @@ object Iso {
         case Type.TypeRef(name, prefix) => Type.TermRef(prefix, name)
       }
 
-      val obj = Select.overloaded(Ident(companion), "apply", Nil, Nil).seal[S]
+      val obj = Select.overloaded(Ident(companion), "apply", Nil, Nil).seal.cast[S]
 
       '{
         Iso[S, 1](Function.const($obj))(Function.const(1))

--- a/tests/run-with-compiler/i6171/Macro_1.scala
+++ b/tests/run-with-compiler/i6171/Macro_1.scala
@@ -18,28 +18,28 @@ object scalatest {
           let(rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
             let(app) { result =>
-              val l = left.seal[Any]
-              val r = right.seal[Any]
-              val b = result.seal[Boolean]
+              val l = left.seal
+              val r = right.seal
+              val b = result.seal.cast[Boolean]
               val code = '{ scala.Predef.assert($b) }
               code.unseal
             }
           }
-        }.seal[Unit]
+        }.seal.cast[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
         if isImplicitMethodType(f.tpe) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
             let(Apply(app, implicits)) { result =>
-              val l = left.seal[Any]
-              val r = right.seal[Any]
-              val b = result.seal[Boolean]
+              val l = left.seal
+              val r = right.seal
+              val b = result.seal.cast[Boolean]
               val code = '{ scala.Predef.assert($b) }
               code.unseal
             }
           }
-        }.seal[Unit]
+        }.seal.cast[Unit]
     }
   }
 }

--- a/tests/run-with-compiler/reflect-select-constructor/assert_1.scala
+++ b/tests/run-with-compiler/reflect-select-constructor/assert_1.scala
@@ -19,28 +19,28 @@ object scalatest {
           let(rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
             let(app) { result =>
-              val l = left.seal[Any]
-              val r = right.seal[Any]
-              val b = result.seal[Boolean]
+              val l = left.seal
+              val r = right.seal
+              val b = result.seal.cast[Boolean]
               val code = '{ scala.Predef.assert($b) }
               code.unseal
             }
           }
-        }.seal[Unit]
+        }.seal.cast[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
             let(Apply(app, implicits)) { result =>
-              val l = left.seal[Any]
-              val r = right.seal[Any]
-              val b = result.seal[Boolean]
+              val l = left.seal
+              val r = right.seal
+              val b = result.seal.cast[Boolean]
               val code = '{ scala.Predef.assert($b) }
               code.unseal
             }
           }
-        }.seal[Unit]
+        }.seal.cast[Unit]
     }
   }
 

--- a/tests/run-with-compiler/reflect-select-copy/assert_1.scala
+++ b/tests/run-with-compiler/reflect-select-copy/assert_1.scala
@@ -18,27 +18,27 @@ object scalatest {
         let(lhs) { left =>
           let(rhs) { right =>
             let(Apply(Select.copy(sel)(left, op), right :: Nil)) { result =>
-              val l = left.seal[Any]
-              val r = right.seal[Any]
-              val b = result.seal[Boolean]
+              val l = left.seal
+              val r = right.seal
+              val b = result.seal.cast[Boolean]
               val code = '{ scala.Predef.assert(${b}) }
               code.unseal
             }
           }
-        }.seal[Unit]
+        }.seal.cast[Unit]
       case Apply(f @ Apply(IsSelect(sel @ Select(Apply(qual, lhs :: Nil), op)), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
         let(lhs) { left =>
           let(rhs) { right =>
             let(Apply(Apply(Select.copy(sel)(Apply(qual, left :: Nil), op), right :: Nil), implicits)) { result =>
-              val l = left.seal[Any]
-              val r = right.seal[Any]
-              val b = result.seal[Boolean]
+              val l = left.seal
+              val r = right.seal
+              val b = result.seal.cast[Boolean]
               val code = '{ scala.Predef.assert(${b}) }
               code.unseal
             }
           }
-        }.seal[Unit]
+        }.seal.cast[Unit]
     }
   }
 

--- a/tests/run-with-compiler/reflect-select-value-class/assert_1.scala
+++ b/tests/run-with-compiler/reflect-select-value-class/assert_1.scala
@@ -19,28 +19,28 @@ object scalatest {
           let(rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
             let(app) { result =>
-              val l = left.seal[Any]
-              val r = right.seal[Any]
-              val b = result.seal[Boolean]
+              val l = left.seal
+              val r = right.seal
+              val b = result.seal.cast[Boolean]
               val code = '{ scala.Predef.assert($b) }
               code.unseal
             }
           }
-        }.seal[Unit]
+        }.seal.cast[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
             let(Apply(app, implicits)) { result =>
-              val l = left.seal[Any]
-              val r = right.seal[Any]
-              val b = result.seal[Boolean]
+              val l = left.seal
+              val r = right.seal
+              val b = result.seal.cast[Boolean]
               val code = '{ scala.Predef.assert($b) }
               code.unseal
             }
           }
-        }.seal[Unit]
+        }.seal.cast[Unit]
     }
   }
 

--- a/tests/run-with-compiler/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-with-compiler/tasty-unsafe-let/quoted_1.scala
@@ -14,8 +14,8 @@ object Macros {
 
     import reflect.util.{let => letTerm}
     letTerm(rhsTerm) { rhsId =>
-      body(rhsId.seal[Any].asInstanceOf[Expr[T]]).unseal // Dangerous uncheked cast!
-    }.seal[Unit]
+      body(rhsId.seal.asInstanceOf[Expr[T]]).unseal // Dangerous uncheked cast!
+    }.seal.cast[Unit]
   }
 
 

--- a/tests/run/f-interpolation-1/FQuote_1.scala
+++ b/tests/run/f-interpolation-1/FQuote_1.scala
@@ -14,7 +14,7 @@ object FQuote {
 
     def liftListOfAny(lst: List[Term]): Expr[List[Any]] = lst match {
       case x :: xs  =>
-        val head = x.seal[Any]
+        val head = x.seal
         val tail = liftListOfAny(xs)
         '{ $head :: $tail }
       case Nil => '{Nil}

--- a/tests/run/i5533/Macro_1.scala
+++ b/tests/run/i5533/Macro_1.scala
@@ -13,7 +13,7 @@ object scalatest {
 
     val tree = condition.unseal
 
-    val expr = tree.seal[Boolean]
+    val expr = tree.seal.cast[Boolean]
 
     '{println($expr)}
   }

--- a/tests/run/i5533b/Macro_1.scala
+++ b/tests/run/i5533b/Macro_1.scala
@@ -16,8 +16,8 @@ object scalatest {
 
     tree.underlyingArgument match {
       case Apply(Select(lhs, op), rhs :: Nil) =>
-        val left = lhs.seal[Any]
-        val right = rhs.seal[Any]
+        val left = lhs.seal
+        val right = rhs.seal
         op match {
           case "==" =>
         '{

--- a/tests/run/i5536/Macro_1.scala
+++ b/tests/run/i5536/Macro_1.scala
@@ -13,8 +13,8 @@ object scalatest {
 
     tree.underlyingArgument match {
       case Apply(Select(lhs, op), rhs :: Nil) =>
-        val left = lhs.seal[Any]
-        val right = rhs.seal[Any]
+        val left = lhs.seal
+        val right = rhs.seal
         op match {
           case "===" =>
             '{

--- a/tests/run/i5629/Macro_1.scala
+++ b/tests/run/i5629/Macro_1.scala
@@ -7,7 +7,7 @@ object Macros {
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
     import refl._
-    val b = cond.unseal.underlyingArgument.seal[Boolean]
+    val b = cond.unseal.underlyingArgument.seal.cast[Boolean]
     '{ scala.Predef.assert($b) }
   }
 

--- a/tests/run/reflect-select-copy/assert_1.scala
+++ b/tests/run/reflect-select-copy/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
     cond.unseal.underlyingArgument match {
       case Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         val IsSelect(select) = sel
-        val cond = Apply(Select.copy(select)(lhs, ">"), rhs :: Nil).seal[Boolean]
+        val cond = Apply(Select.copy(select)(lhs, ">"), rhs :: Nil).seal.cast[Boolean]
         '{ scala.Predef.assert($cond) }
       case _ =>
         '{ scala.Predef.assert($cond) }

--- a/tests/run/tasty-interpolation-1/Macro.scala
+++ b/tests/run/tasty-interpolation-1/Macro.scala
@@ -59,19 +59,19 @@ abstract class MacroStringInterpolator[T] {
       case Select(Typed(Apply(_, List(Apply(_, List(Typed(Repeated(strCtxArgTrees, _), Inferred()))))), _), _) =>
         val strCtxArgs = strCtxArgTrees.map {
           case Literal(Constant.String(str)) => str
-          case tree => throw new NotStaticlyKnownError("Expected statically known StringContext", tree.seal[Any])
+          case tree => throw new NotStaticlyKnownError("Expected statically known StringContext", tree.seal)
         }
         StringContext(strCtxArgs: _*)
       case tree =>
-        throw new NotStaticlyKnownError("Expected statically known StringContext", tree.seal[Any])
+        throw new NotStaticlyKnownError("Expected statically known StringContext", tree.seal)
     }
   }
 
   protected def getArgsList(argsExpr: Expr[Seq[Any]])(implicit reflect: Reflection): List[Expr[Any]] = {
     import reflect._
     argsExpr.unseal.underlyingArgument match {
-      case Typed(Repeated(args, _), _) => args.map(_.seal[Any])
-      case tree => throw new NotStaticlyKnownError("Expected statically known argument list", tree.seal[Any])
+      case Typed(Repeated(args, _), _) => args.map(_.seal)
+      case tree => throw new NotStaticlyKnownError("Expected statically known argument list", tree.seal)
     }
   }
 

--- a/tests/run/tasty-macro-assert/quoted_1.scala
+++ b/tests/run/tasty-macro-assert/quoted_1.scala
@@ -35,8 +35,8 @@ object Asserts {
     tree match {
       case Inlined(_, Nil, Apply(Select(OpsTree(left), op), right :: Nil)) =>
         op match {
-          case "===" => '{assertEquals(${left.seal[Any]}, ${right.seal[Any]})}
-          case "!==" => '{assertNotEquals(${left.seal[Any]}, ${right.seal[Any]})}
+          case "===" => '{assertEquals(${left.seal}, ${right.seal})}
+          case "!==" => '{assertNotEquals(${left.seal}, ${right.seal})}
         }
       case _ =>
         '{assertTrue($cond)}

--- a/tests/run/tasty-macro-const/quoted_1.scala
+++ b/tests/run/tasty-macro-const/quoted_1.scala
@@ -12,7 +12,7 @@ object Macros {
       case Inlined(_, _, Literal(Constant.Int(n))) =>
         if (n <= 0)
           throw new QuoteError("Parameter must be natural number")
-        xTree.seal[Int]
+        xTree.seal.cast[Int]
       case _ =>
         throw new QuoteError("Parameter must be a known constant")
     }

--- a/tests/run/tasty-seal-method/quoted_1.scala
+++ b/tests/run/tasty-seal-method/quoted_1.scala
@@ -16,10 +16,10 @@ object Asserts {
         fn.tpe.widen match {
           case Type.IsMethodType(_) =>
             args.size match {
-              case 0 => fn.seal[() => Int].apply()
-              case 1 => fn.seal[Int => Int].apply('{0})
-              case 2 => fn.seal[(Int, Int) => Int].apply('{0}, '{0})
-              case 3 => fn.seal[(Int, Int, Int) => Int].apply('{0}, '{0}, '{0})
+              case 0 => fn.seal.cast[() => Int].apply()
+              case 1 => fn.seal.cast[Int => Int].apply('{0})
+              case 2 => fn.seal.cast[(Int, Int) => Int].apply('{0}, '{0})
+              case 3 => fn.seal.cast[(Int, Int, Int) => Int].apply('{0}, '{0}, '{0})
             }
         }
       case _ => x
@@ -37,15 +37,15 @@ object Asserts {
       case Apply(fn, args) =>
         val pre = rec(fn)
         args.size match {
-          case 0 => pre.seal[() => Any].apply().unseal
-          case 1 => pre.seal[Int => Any].apply('{0}).unseal
-          case 2 => pre.seal[(Int, Int) => Any].apply('{0}, '{0}).unseal
-          case 3 => pre.seal[(Int, Int, Int) => Any].apply('{0}, '{0}, '{0}).unseal
+          case 0 => pre.seal.cast[() => Any].apply().unseal
+          case 1 => pre.seal.cast[Int => Any].apply('{0}).unseal
+          case 2 => pre.seal.cast[(Int, Int) => Any].apply('{0}, '{0}).unseal
+          case 3 => pre.seal.cast[(Int, Int, Int) => Any].apply('{0}, '{0}, '{0}).unseal
         }
       case _ => term
     }
 
-    rec(x.unseal.underlyingArgument).seal[Int]
+    rec(x.unseal.underlyingArgument).seal.cast[Int]
   }
 
 }

--- a/tests/run/tasty-tree-map/quoted_1.scala
+++ b/tests/run/tasty-tree-map/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
   def impl[T: Type](x: Expr[T])(implicit reflection: Reflection): Expr[T] = {
     import reflection._
     val identityMap = new TreeMap { }
-    val transformed = identityMap.transformTerm(x.unseal).seal[T]
+    val transformed = identityMap.transformTerm(x.unseal).seal.cast[T]
     transformed
   }
 

--- a/tests/run/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run/xml-interpolation-1/XmlQuote_1.scala
@@ -26,7 +26,7 @@ object XmlQuote {
 
     def liftListOfAny(lst: List[Term]): Expr[List[Any]] = lst match {
       case x :: xs  =>
-        val head = x.seal[Any]
+        val head = x.seal
         val tail = liftListOfAny(xs)
         '{ $head :: $tail }
       case Nil => '{Nil}

--- a/tests/run/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run/xml-interpolation-2/XmlQuote_1.scala
@@ -55,7 +55,7 @@ object XmlQuote {
     // [a0, ...]: Any*
     val args2: Expr[List[Any]] = args.unseal.underlyingArgument match {
       case Typed(Repeated(args0, _), _) => // statically known args, make list directly
-        args0.map(_.seal[Any]).toExprOfList
+        args0.map(_.seal).toExprOfList
       case _ =>
         '{$args.toList}
 


### PR DESCRIPTION
Previously `seal` always casted the `quoted.Expr[T]` for some given `T`. Now, `seal` and `cast` can be used independently. If we need to seal to an `Expr[Any]` there is no need to check the that the type conforms. This use-case is common enough to deserve the optimization.

Additionally, due to bootstrapping issues, it is not practical to seal to a `quoted.Expr[Any]` within the library as we cannot create a `quoted.Type[Any]`.

This is needed #6042