### PR TITLE
Implement `tasty.Reflection` in the library

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionImpl.scala
@@ -10,13 +10,13 @@ object ReflectionImpl {
     apply(rootContext, SourcePosition(rootContext.source, Spans.NoSpan))
 
   def apply(rootContext: Contexts.Context, rootPosition: SourcePosition): scala.tasty.Reflection =
-    new ReflectionImpl(new KernelImpl(rootContext, rootPosition))
+    new scala.tasty.Reflection(new KernelImpl(rootContext, rootPosition))
 
   def showTree(tree: tpd.Tree)(implicit ctx: Contexts.Context): String = {
-    val refl = new ReflectionImpl(new KernelImpl(ctx, tree.sourcePos))
-    new refl.SourceCodePrinter().showTree(tree)
+    val refl = new scala.tasty.Reflection(new KernelImpl(ctx, tree.sourcePos))
+    val reflCtx = ctx.asInstanceOf[refl.Context]
+    val reflTree = tree.asInstanceOf[refl.Tree]
+    new refl.SourceCodePrinter().showTree(reflTree)(reflCtx)
   }
-
-  private class ReflectionImpl(val kernel: KernelImpl) extends scala.tasty.Reflection
 
 }

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -2,7 +2,7 @@ package scala.tasty
 
 import scala.tasty.reflect._
 
-abstract class Reflection
+class Reflection(val kernel: Kernel)
     extends Core
     with ConstantOps
     with ContextOps


### PR DESCRIPTION
Now the only interface between the compiler and the library is the `tasty.reflect.Kernel` which is a pure interface.