### PR TITLE
Drop implicit match expressions

### DIFF
--- a/library/src-bootstrapped/scala/compiletime/package.scala
+++ b/library/src-bootstrapped/scala/compiletime/package.scala
@@ -11,4 +11,9 @@ package object compiletime {
   inline def constValue[T]: T = ???
 
   type S[X <: Int] <: Int
+
+  inline def findImplied[T] given (ev: (T | Null) = null): Option[ev.type] = inline ev match {
+    case _: Null => None
+    case _ => Some(ev)
+  }
 }

--- a/tests/run/findImplied.scala
+++ b/tests/run/findImplied.scala
@@ -1,0 +1,29 @@
+object Test extends App {
+  import compiletime.erasedValue
+
+  inline def findImplied[T] given (ev: (T | Null) = null): Option[ev.type] = inline ev match {
+    case _: Null => None
+    case _ => Some(ev)
+  }
+
+  class A
+  implied a for A
+
+  class B
+
+  class C[T]
+  implied c for C[String]
+
+  assert(!findImplied[A].isEmpty)
+  assert(findImplied[B].isEmpty)
+
+  assert(!findImplied[C[String]].isEmpty)
+  assert(findImplied[C[Int]].isEmpty)
+
+  findImplied[C[_]] match {
+    case Some(c: C[t]) => // current GADT reasoning is not strong enough to infer `t == String`
+      //val x: t = "a"; assert(x == "a")
+    case None =>
+      assert(false)
+  }
+}


### PR DESCRIPTION
It turns out we don't need them since we can simulate them with default arguments for implicit parameters.
