### PR TITLE
Fix #6210: Erase type blocks in Typed trees

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -358,9 +358,13 @@ object Erasure {
     /** This override is only needed to semi-erase type ascriptions */
     override def typedTyped(tree: untpd.Typed, pt: Type)(implicit ctx: Context): Tree = {
       val Typed(expr, tpt) = tree
-      val tpt1 = promote(tpt)
-      val expr1 = typed(expr, tpt1.tpe)
-      assignType(untpd.cpy.Typed(tree)(expr1, tpt1), tpt1)
+      val tpt1 = tpt match {
+        case Block(_, tpt) => tpt // erase type aliases (statements) from type block
+        case tpt => tpt
+      }
+      val tpt2 = promote(tpt1)
+      val expr1 = typed(expr, tpt2.tpe)
+      assignType(untpd.cpy.Typed(tree)(expr1, tpt2), tpt2)
     }
 
     override def typedLiteral(tree: untpd.Literal)(implicit ctx: Context): Tree =

--- a/tests/pos/i6210/Macros_1.scala
+++ b/tests/pos/i6210/Macros_1.scala
@@ -1,0 +1,14 @@
+import scala.quoted._
+
+object Macro {
+  inline def test[A, B]: Any =
+    ${ impl[A, B] }
+
+  def impl[A : Type, B : Type]: Expr[Any] = {
+    val t = '[Map[A, B]]
+    '{
+      new Object().asInstanceOf[$t]
+      ???.asInstanceOf[$t]
+    }
+  }
+}

--- a/tests/pos/i6210/Test_2.scala
+++ b/tests/pos/i6210/Test_2.scala
@@ -1,0 +1,5 @@
+object Test {
+  type T
+  def t1 = Macro.test[Int, String]
+  def t2 = Macro.test[Test.type, T]
+}


### PR DESCRIPTION
Type blocks of the for `{ type T1 = X1; ... ; type Tn = Xn; F[T1,..., Tn] }`
are erased to `F[X1,..., Xn]`. We where erasing the type of the tree correctly but
needed to drop the block as well.