### PR TITLE
Add regression test

### DIFF
--- a/tests/run/xml-interpolation-4/Macros_1.scala
+++ b/tests/run/xml-interpolation-4/Macros_1.scala
@@ -1,0 +1,25 @@
+import scala.quoted._
+import scala.quoted.autolift._
+import scala.tasty.Reflection
+
+import scala.language.implicitConversions
+
+object XmlQuote {
+
+  implicit object SCOps {
+    inline def (ctx: => StringContext) xml (args: => (given Scope => Any)*) given Scope: String =
+      ${XmlQuote.impl('ctx, 'args, '{implicitly[Scope]})}
+  }
+
+  private def impl(receiver: Expr[StringContext], args: Expr[Seq[given Scope => Any]], scope: Expr[Scope]): Expr[String] = '{
+    $receiver.s($args.map(_ given $scope.inner): _*)
+  }
+}
+
+case class Scope(name: String) {
+  def inner: Scope = Scope(name + "+")
+}
+
+object Scope {
+  implicit def topScope: Scope = Scope("top")
+}

--- a/tests/run/xml-interpolation-4/Test_2.scala
+++ b/tests/run/xml-interpolation-4/Test_2.scala
@@ -1,0 +1,9 @@
+import XmlQuote._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    assert(xml"Hello ${implicitly[Scope]} world!" == "Hello Scope(top+) world!")
+    assert(xml"Hello ${ xml"world ${implicitly[Scope] + " " + xml"${implicitly[Scope]}"}" }!" ==
+        "Hello world Scope(top++) Scope(top+++)!")
+  }
+}


### PR DESCRIPTION
Add regression test of a version of the xml string interpolator that can track the xml scope using contextual parameters.

This will be used to encode the logic in [fixScopes](https://github.com/densh/scala-xml-quote/blob/master/src/main/scala/scala/xml/quote/internal/Liftables.scala#L32) without any hacky postprocessing.