### PR TITLE
Fix #5897 and #6200: implicits are not retained in REPL

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -13,11 +13,11 @@ import printing.Texts.Text
 
 object ImportInfo {
   /** The import info for a root import from given symbol `sym` */
-  def rootImport(refFn: () => TermRef)(implicit ctx: Context): ImportInfo = {
+  def rootImport(refFn: () => TermRef, importImplied: Boolean = false)(implicit ctx: Context): ImportInfo = {
     val selectors = untpd.Ident(nme.WILDCARD) :: Nil
     def expr(implicit ctx: Context) = tpd.Ident(refFn())
-    def imp(implicit ctx: Context) = tpd.Import(importImplied = false, expr, selectors)
-    new ImportInfo(implicit ctx => imp.symbol, selectors, None, importImplied = false, isRootImport = true)
+    def imp(implicit ctx: Context) = tpd.Import(importImplied = importImplied, expr, selectors)
+    new ImportInfo(implicit ctx => imp.symbol, selectors, None, importImplied = importImplied, isRootImport = true)
   }
 }
 

--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -48,9 +48,12 @@ class ReplCompiler extends Compiler {
       def importPreviousRun(id: Int)(implicit ctx: Context) = {
         // we first import the wrapper object id
         val path = nme.EMPTY_PACKAGE ++ "." ++ objectNames(id)
-        val importInfo = ImportInfo.rootImport(() =>
-          ctx.requiredModuleRef(path))
-        val ctx0 = ctx.fresh.setNewScope.setImportInfo(importInfo)
+        def importWrapper(c: Context, importImplied: Boolean) = {
+          val importInfo = ImportInfo.rootImport(() =>
+            c.requiredModuleRef(path), importImplied)
+          c.fresh.setNewScope.setImportInfo(importInfo)
+        }
+        val ctx0 = importWrapper(importWrapper(ctx, false), true)
 
         // then its user defined imports
         val imports = state.imports.getOrElse(id, Nil)


### PR DESCRIPTION
When evaluating definitions in REPL (`def`, `implied` etc), they are brought in scope for all the subsequent evaluations of the user input. This is done via the `import` mechanism. However, in Dotty,
the semantics of the imports changed: by default, the implied values are not imported. This commit makes sure that all the members, including the implied ones, are imported from the previous evaluations of the input.