### PR TITLE
Fix typo in creator-applications.md

### DIFF
--- a/docs/docs/reference/other-new-features/creator-applications.md
+++ b/docs/docs/reference/other-new-features/creator-applications.md
@@ -7,7 +7,7 @@ Creator applications allow to use simple function call syntax to create instance
 of a class, even if there is no apply method implemented. Example:
 ```scala
 class StringBuilder(s: String) {
-   def this() = this(s)
+   def this() = this("")
 }
 
 StringBuilder("abc")  // same as new StringBuilder("abc")


### PR DESCRIPTION
The `s` variable is not accessible on construction time.