### PR TITLE
Fix #6213: Convert RefinedTypeTrees to TypeTrees in ReTyper

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -65,6 +65,9 @@ class ReTyper extends Typer with ReChecking {
   override def typedTypeTree(tree: untpd.TypeTree, pt: Type)(implicit ctx: Context): TypeTree =
     promote(tree)
 
+  override def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(implicit ctx: Context): TypTree =
+    promote(TypeTree(tree.tpe).withSpan(tree.span))
+
   override def typedFunPart(fn: untpd.Tree, pt: Type)(implicit ctx: Context): Tree =
     typedExpr(fn, pt)
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1273,7 +1273,7 @@ class Typer extends Namer
     assignType(cpy.SingletonTypeTree(tree)(ref1), ref1)
   }
 
-  def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(implicit ctx: Context): RefinedTypeTree = track("typedRefinedTypeTree") {
+  def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(implicit ctx: Context): TypTree = track("typedRefinedTypeTree") {
     val tpt1 = if (tree.tpt.isEmpty) TypeTree(defn.ObjectType) else typedAheadType(tree.tpt)
     val refineClsDef = desugar.refinedTypeToClass(tpt1, tree.refinements).withSpan(tree.span)
     val refineCls = createSymbol(refineClsDef).asClass

--- a/tests/pos/i6213.scala
+++ b/tests/pos/i6213.scala
@@ -1,0 +1,6 @@
+object Test {
+  class C { type T }
+  inline def foo[U] <: Any = (??? : C { type T = U })
+
+  foo[Int]
+}


### PR DESCRIPTION
The standard treatment of RefinedTypeTrees creates a class definition, typechecks it
and then extracts the type from that. The class definition does not form part of the
resulting tree. This treatment is not workable for ReTyper since ReTyper is not prepared
to typecheck fresh class definitions from scratch. We avoid the problem by having
ReTyper convert the RefinedTypeTree to a TypeTree instead, keeping just the type.

Note: The only reason why Typer does not do the same thing is so that we can keep
the refinements as trees for IDE navigation. But that's not necessary for trees
that have undergone a ReTyper step (i.e. typically inlined trees).