### PR TITLE
Fix #6253: Handle repeated args in quoted patterns 

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/KernelImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/KernelImpl.scala
@@ -1,6 +1,7 @@
 package dotty.tools.dotc
 package tastyreflect
 
+import dotty.tools.dotc.ast.Trees.SeqLiteral
 import dotty.tools.dotc.ast.{Trees, tpd, untpd}
 import dotty.tools.dotc.ast.tpd.TreeOps
 import dotty.tools.dotc.typer.Typer
@@ -1055,6 +1056,9 @@ class KernelImpl(val rootContext: core.Contexts.Context, val rootPosition: util.
   def Type_memberType(self: Type)(member: Symbol)(implicit ctx: Context): Type =
     member.info.asSeenFrom(self, member.owner)
 
+  def Type_derivesFrom(self: Type)(cls: ClassDefSymbol)(implicit ctx: Context): Boolean =
+    self.derivesFrom(cls)
+
   type ConstantType = Types.ConstantType
 
   def matchConstantType(tpe: TypeOrBounds)(implicit ctx: Context): Option[ConstantType] = tpe match {
@@ -1774,7 +1778,7 @@ class KernelImpl(val rootContext: core.Contexts.Context, val rootPosition: util.
   def Definitions_Array_length: Symbol = defn.Array_length.asTerm
   def Definitions_Array_update: Symbol = defn.Array_update.asTerm
 
-  def Definitions_RepeatedParamClass: Symbol = defn.RepeatedParamClass
+  def Definitions_RepeatedParamClass: ClassDefSymbol = defn.RepeatedParamClass
 
   def Definitions_OptionClass: Symbol = defn.OptionClass
   def Definitions_NoneModule: Symbol = defn.NoneClass.companionModule.asTerm

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -581,7 +581,7 @@ class Typer extends Namer
     if (untpd.isWildcardStarArg(tree)) {
       def typedWildcardStarArgExpr = {
         val ptArg =
-          if (ctx.mode.is(Mode.QuotedPattern)) pt.subst(defn.RepeatedParamClass :: Nil, defn.SeqType :: Nil)
+          if (ctx.mode.is(Mode.QuotedPattern)) pt.underlyingIfRepeated(isJava = false)
           else WildcardType
         val tpdExpr = typedExpr(tree.expr, ptArg)
         tpdExpr.tpe.widenDealias match {
@@ -1969,7 +1969,9 @@ class Typer extends Namer
         case Splice(pat) =>
           try patternHole(tree)
           finally {
-            val pat1 = pat.subst(defn.RepeatedParamClass :: Nil, defn.SeqClass :: Nil)
+            val patType = pat.tpe.widen
+            val patType1 = patType.underlyingIfRepeated(isJava = false)
+            val pat1 = if (patType eq patType1) pat else pat.withType(patType1)
             patBuf += pat1
           }
         case _ =>

--- a/library/src/scala/quoted/matching/Repeated.scala
+++ b/library/src/scala/quoted/matching/Repeated.scala
@@ -1,0 +1,21 @@
+package scala.quoted.matching
+
+import scala.quoted.Expr
+
+import scala.tasty.Reflection // TODO do not depend on reflection directly
+
+/** Matches a literal sequence of expressions */
+object Repeated {
+
+  def unapply[T](expr: Expr[Seq[T]])(implicit reflect: Reflection): Option[Seq[Expr[T]]] = {
+    import reflect.{Repeated => RepeatedTree, _} // TODO rename to avoid clash
+    def repeated(tree: Term): Option[Seq[Expr[T]]] = tree match {
+      case Typed(RepeatedTree(elems, _), _) => Some(elems.map(x => x.seal.asInstanceOf[Expr[T]]))
+      case Block(Nil, e) => repeated(e)
+      case Inlined(_, Nil, e) => repeated(e)
+      case _  => None
+    }
+    repeated(expr.unseal)
+  }
+
+}

--- a/library/src/scala/tasty/reflect/Kernel.scala
+++ b/library/src/scala/tasty/reflect/Kernel.scala
@@ -844,6 +844,9 @@ trait Kernel {
 
   def Type_memberType(self: Type)(member: Symbol)(implicit ctx: Context): Type
 
+  /** Is this type an instance of a non-bottom subclass of the given class `cls`? */
+  def Type_derivesFrom(self: Type)(cls: ClassDefSymbol)(implicit ctx: Context): Boolean
+
   /** A singleton type representing a known constant value */
   type ConstantType <: Type
 
@@ -1434,7 +1437,7 @@ trait Kernel {
   def Definitions_Array_length: Symbol
   def Definitions_Array_update: Symbol
 
-  def Definitions_RepeatedParamClass: Symbol
+  def Definitions_RepeatedParamClass: ClassDefSymbol
 
   def Definitions_OptionClass: Symbol
   def Definitions_NoneModule: Symbol

--- a/library/src/scala/tasty/reflect/StandardDefinitions.scala
+++ b/library/src/scala/tasty/reflect/StandardDefinitions.scala
@@ -106,7 +106,7 @@ trait StandardDefinitions extends Core {
     /** A dummy class symbol that is used to indicate repeated parameters
       *  compiled by the Scala compiler.
       */
-    def RepeatedParamClass: Symbol = kernel.Definitions_RepeatedParamClass
+    def RepeatedParamClass: ClassDefSymbol = kernel.Definitions_RepeatedParamClass
 
     /** The class symbol of class `scala.Option`. */
     def OptionClass: Symbol = kernel.Definitions_OptionClass

--- a/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
@@ -22,6 +22,11 @@ trait TypeOrBoundsOps extends Core {
     def typeSymbol(implicit ctx: Context): Symbol = kernel.Type_typeSymbol(self)
     def isSingleton(implicit ctx: Context): Boolean = kernel.Type_isSingleton(self)
     def memberType(member: Symbol)(implicit ctx: Context): Type = kernel.Type_memberType(self)(member)
+
+    /** Is this type an instance of a non-bottom subclass of the given class `cls`? */
+    def derivesFrom(cls: ClassDefSymbol)(implicit ctx: Context): Boolean =
+      kernel.Type_derivesFrom(self)(cls)
+
   }
 
   object IsType {

--- a/tests/pos/i6253.scala
+++ b/tests/pos/i6253.scala
@@ -1,0 +1,10 @@
+import scala.quoted._
+import scala.tasty.Reflection
+object Macros {
+  def impl(self: Expr[StringContext]) given Reflection: Expr[String] = self match {
+    case '{ StringContext() } => '{""}
+    case '{ StringContext($part1) } => part1
+    case '{ StringContext($part1, $part2) } => '{ $part1 + $part2 }
+    case '{ StringContext($parts: _*) } => '{ $parts.mkString }
+  }
+}

--- a/tests/run-with-compiler/i6253-b.check
+++ b/tests/run-with-compiler/i6253-b.check
@@ -1,0 +1,2 @@
+Hello World
+Hello World

--- a/tests/run-with-compiler/i6253-b/quoted_1.scala
+++ b/tests/run-with-compiler/i6253-b/quoted_1.scala
@@ -1,0 +1,22 @@
+import scala.quoted._
+import scala.quoted.matching._
+
+import scala.tasty.Reflection
+
+object Macros {
+
+  inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}
+
+  private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(implicit reflect: Reflection): Expr[String] = {
+    self match {
+      case '{ StringContext($parts: _*) } =>
+        '{
+          val p: Seq[String] = $parts
+          val a: Seq[Any] = $args ++ Seq("")
+          p.zip(a).map(_ + _.toString).mkString
+        }
+      case _ =>
+        '{ "ERROR" }
+    }
+  }
+}

--- a/tests/run-with-compiler/i6253-b/quoted_2.scala
+++ b/tests/run-with-compiler/i6253-b/quoted_2.scala
@@ -1,0 +1,10 @@
+import Macros._
+
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    println(xyz"Hello World")
+    println(xyz"Hello ${"World"}")
+  }
+
+}

--- a/tests/run-with-compiler/i6253.check
+++ b/tests/run-with-compiler/i6253.check
@@ -1,0 +1,2 @@
+Hello World
+Hello World

--- a/tests/run-with-compiler/i6253/quoted_1.scala
+++ b/tests/run-with-compiler/i6253/quoted_1.scala
@@ -1,0 +1,18 @@
+import scala.quoted._
+import scala.quoted.matching._
+
+import scala.tasty.Reflection
+
+object Macros {
+
+  inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}
+
+  private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(implicit reflect: Reflection): Expr[String] = {
+    self match {
+      case '{ StringContext($parts: _*) } =>
+        '{ StringContext($parts: _*).s($args: _*) }
+      case _ =>
+        '{ "ERROR" }
+    }
+  }
+}

--- a/tests/run-with-compiler/i6253/quoted_2.scala
+++ b/tests/run-with-compiler/i6253/quoted_2.scala
@@ -1,0 +1,10 @@
+import Macros._
+
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    println(xyz"Hello World")
+    println(xyz"Hello ${"World"}")
+  }
+
+}

--- a/tests/run-with-compiler/quote-matcher-runtime.check
+++ b/tests/run-with-compiler/quote-matcher-runtime.check
@@ -190,7 +190,7 @@ Result: Some(List())
 
 Scrutinee: fs()
 Pattern: fs((scala.internal.Quoted.patternHole[scala.Seq[scala.Int]]: scala.<repeated>[scala.Int]))
-Result: Some(List(Expr()))
+Result: Some(List(Expr((: scala.<repeated>[scala.Int]))))
 
 Scrutinee: fs((1, 2, 3: scala.<repeated>[scala.Int]))
 Pattern: fs((1, 2, 3: scala.<repeated>[scala.Int]))
@@ -202,7 +202,7 @@ Result: Some(List(Expr(1), Expr(2)))
 
 Scrutinee: fs((1, 2, 3: scala.<repeated>[scala.Int]))
 Pattern: fs((scala.internal.Quoted.patternHole[scala.Seq[scala.Int]]: scala.<repeated>[scala.Int]))
-Result: Some(List(Expr(1, 2, 3)))
+Result: Some(List(Expr((1, 2, 3: scala.<repeated>[scala.Int]))))
 
 Scrutinee: f2(1, 2)
 Pattern: f2(1, 2)
@@ -246,7 +246,7 @@ Result: Some(List(Expr("abc"), Expr("xyz")))
 
 Scrutinee: scala.StringContext.apply(("abc", "xyz": scala.<repeated>[scala.Predef.String]))
 Pattern: scala.StringContext.apply((scala.internal.Quoted.patternHole[scala.Seq[scala.Predef.String]]: scala.<repeated>[scala.Predef.String]))
-Result: Some(List(Expr("abc", "xyz")))
+Result: Some(List(Expr(("abc", "xyz": scala.<repeated>[scala.Predef.String]))))
 
 Scrutinee: {
   val a: scala.Int = 45

--- a/tests/run-with-compiler/quote-matcher-string-interpolator-2.check
+++ b/tests/run-with-compiler/quote-matcher-string-interpolator-2.check
@@ -1,0 +1,2 @@
+dlroW olleH
+ olleHWorld

--- a/tests/run-with-compiler/quote-matcher-string-interpolator-2/quoted_1.scala
+++ b/tests/run-with-compiler/quote-matcher-string-interpolator-2/quoted_1.scala
@@ -1,0 +1,21 @@
+import scala.quoted._
+import scala.quoted.matching._
+
+import scala.tasty.Reflection
+
+object Macros {
+
+  inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}
+
+  private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(implicit reflect: Reflection): Expr[String] = {
+    (self, args) match {
+      case ('{ StringContext(${Repeated(parts)}: _*) }, Repeated(args1)) =>
+        val strParts = parts.map { case Literal(str) => str.reverse }
+        val strArgs = args1.map { case Literal(str) => str }
+        StringContext(strParts: _*).s(strArgs: _*).toExpr
+      case _ => ???
+    }
+
+  }
+
+}

--- a/tests/run-with-compiler/quote-matcher-string-interpolator-2/quoted_2.scala
+++ b/tests/run-with-compiler/quote-matcher-string-interpolator-2/quoted_2.scala
@@ -1,0 +1,10 @@
+import Macros._
+
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    println(xyz"Hello World")
+    println(xyz"Hello ${"World"}")
+  }
+
+}

--- a/tests/run-with-compiler/quote-matcher-string-interpolator.check
+++ b/tests/run-with-compiler/quote-matcher-string-interpolator.check
@@ -1,0 +1,2 @@
+dlroW olleH
+ olleHWorld

--- a/tests/run-with-compiler/quote-matcher-string-interpolator/quoted_1.scala
+++ b/tests/run-with-compiler/quote-matcher-string-interpolator/quoted_1.scala
@@ -1,0 +1,21 @@
+import scala.quoted._
+import scala.quoted.matching._
+
+import scala.tasty.Reflection
+
+object Macros {
+
+  inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}
+
+  private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(implicit reflect: Reflection): Expr[String] = {
+    self match {
+      case '{ StringContext(${Repeated(parts)}: _*) } =>
+        val parts2 = parts.map(x => '{ $x.reverse }).toList.toExprOfList
+        '{ StringContext($parts2: _*).s($args: _*) }
+      case _ =>
+        '{ "ERROR" }
+    }
+
+  }
+
+}

--- a/tests/run-with-compiler/quote-matcher-string-interpolator/quoted_2.scala
+++ b/tests/run-with-compiler/quote-matcher-string-interpolator/quoted_2.scala
@@ -1,0 +1,10 @@
+import Macros._
+
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    println(xyz"Hello World")
+    println(xyz"Hello ${"World"}")
+  }
+
+}


### PR DESCRIPTION
* Handle repeated args in quoted patterns in Typer
* Handle repeated args in quoted patterns in Matcher
* Add Repeated extractor to get `Seq[Expr[T]]` from an `Expr[Seq[T]]`