### PR TITLE
Fix #6247: Heal selection errors by fully defining qualifier type

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2250,20 +2250,6 @@ class Typer extends Namer
   def typedPattern(tree: untpd.Tree, selType: Type = WildcardType)(implicit ctx: Context): Tree =
     typed(tree, selType)(ctx addMode Mode.Pattern)
 
-  def tryEither[T](op: Context => T)(fallBack: (T, TyperState) => T)(implicit ctx: Context): T = {
-    val nestedCtx = ctx.fresh.setNewTyperState()
-    val result = op(nestedCtx)
-    if (nestedCtx.reporter.hasErrors && !nestedCtx.reporter.hasStickyErrors) {
-      record("tryEither.fallBack")
-      fallBack(result, nestedCtx.typerState)
-    }
-    else {
-      record("tryEither.commit")
-      nestedCtx.typerState.commit()
-      result
-    }
-  }
-
   /** Try `op1`, if there are errors, try `op2`, if `op2` also causes errors, fall back
    *  to errors and result of `op1`.
    */

--- a/tests/pos/i6247.scala
+++ b/tests/pos/i6247.scala
@@ -1,0 +1,10 @@
+implicit class NN[T](x:T|Null) {
+  def nn: T = x.asInstanceOf[T]
+}
+
+class Foo {
+  val x1: String|Null = null
+  x1.nn.length
+  val x2: String = x1.nn
+  x1.nn.length
+}


### PR DESCRIPTION
This solves a situation where we cannot find a member `m` of a qualifier of type `T`
where `T` is a type variable with lower bound `L`, where `m` is a member of `L`.
This has come up occasionally before, but never until now in minimized form. The
solution is to instantiate the type variable using `fullyDefinedType` and try again.