### PR TITLE
Fix #6151: MatchError for imported java enum Values

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -254,7 +254,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
         }
       case t: TypeApply if (t.fun.symbol == Predef_classOf) =>
         av.visit(name, t.args.head.tpe.classSymbol.denot.info.toTypeKind(bcodeStore)(innerClasesStore).toASMType)
-      case t: tpd.Select =>
+      case t: tpd.RefTree =>
         if (t.symbol.denot.owner.is(Flags.JavaEnum)) {
           val edesc = innerClasesStore.typeDescriptor(t.tpe.asInstanceOf[bcodeStore.int.Type]) // the class descriptor of the enumeration class.
           val evalue = t.symbol.name.mangledString // value the actual enumeration value.

--- a/tests/pos/i6151/Expect.java
+++ b/tests/pos/i6151/Expect.java
@@ -1,0 +1,1 @@
+public enum Expect  { ExpectVal }

--- a/tests/pos/i6151/Outcome.java
+++ b/tests/pos/i6151/Outcome.java
@@ -1,0 +1,1 @@
+public @interface Outcome { Expect enm(); }

--- a/tests/pos/i6151/Test.scala
+++ b/tests/pos/i6151/Test.scala
@@ -1,0 +1,3 @@
+import Expect._
+@Outcome(ExpectVal)
+class SimpleTest


### PR DESCRIPTION
When emitting annotations' arguments from the `DottyBackendInterface`,
the case when the argument value can be an `Ident` is not considered.
This commit adds such a case and implements it similarly to that of
the `Select` one.