### PR TITLE
Update compile-time stripMargin

### DIFF
--- a/tests/run-with-compiler/reflect-inline/assert_1.scala
+++ b/tests/run-with-compiler/reflect-inline/assert_1.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.tasty._
 
 object api {
-  inline def (inline x: String) strip <: String =
+  inline def (inline x: String) stripMargin <: String =
     ${ stripImpl(x) }
 
   private def stripImpl(x: String)(implicit refl: Reflection): Expr[String] =

--- a/tests/run-with-compiler/reflect-inline/test_2.scala
+++ b/tests/run-with-compiler/reflect-inline/test_2.scala
@@ -2,7 +2,9 @@ import api._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    assert(typeChecks("1 + 1".strip))
-    assert(scala.testing.typeChecks("1 + 1".strip))
+    val a: String = "5"
+    assert(typeChecks("|1 + 1".stripMargin))
+    assert(scala.testing.typeChecks("|1 + 1".stripMargin))
+    assert(("|3 + " + a).stripMargin == "3 + 5")
   }
 }


### PR DESCRIPTION
This test seems to suggest we can have two versions of `stripMargin`
in the stdlib, one at compile-time and one at run-time.