### PR TITLE
Fix TASTY reflect examples

### DIFF
--- a/docs/docs/reference/other-new-features/tasty-reflect.md
+++ b/docs/docs/reference/other-new-features/tasty-reflect.md
@@ -24,7 +24,7 @@ To provide reflection capabilities in macros we need to add an implicit paramete
 import scala.quoted._
 import scala.tasty._
 
-inline def natConst(x: => Int): Int = ~natConstImpl('(x))
+inline def natConst(x: => Int): Int = ${natConstImpl('{x})}
 
 def natConstImpl(x: Expr[Int])(implicit reflection: Reflection): Expr[Int] = {
   import reflection._

--- a/docs/docs/reference/other-new-features/tasty-reflect.md
+++ b/docs/docs/reference/other-new-features/tasty-reflect.md
@@ -24,7 +24,7 @@ To provide reflection capabilities in macros we need to add an implicit paramete
 import scala.quoted._
 import scala.tasty._
 
-inline def natConst(x: Int): Int = ~natConstImpl('x)
+inline def natConst(x: => Int): Int = ~natConstImpl('(x))
 
 def natConstImpl(x: Expr[Int])(implicit reflection: Reflection): Expr[Int] = {
   import reflection._


### PR DESCRIPTION
 - `'x` is deprecated symbol syntax, not splicing (yet)
 - without by-name parameter passing anything else than a constant will not work (`Expr[Int]` will be `Ident(x)`)

(Is that requirement of the by-name modifier explained somewhere? Is it a consequence / interaction of how the inline modifier works?)