### PR TITLE
Fix #6152: Dotty tries to override Java bridge methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -210,7 +210,7 @@ class ClassfileParser(
       if (method) Flags.Method | methodTranslation.flags(jflags)
       else fieldTranslation.flags(jflags)
     val name = pool.getName(in.nextChar)
-    if (!(sflags is Flags.Private) || name == nme.CONSTRUCTOR) {
+    if (!(sflags.is(Flags.Private) || sflags.is(Flags.Bridge)) || name == nme.CONSTRUCTOR) {
       val member = ctx.newSymbol(
         getOwner(jflags), name, sflags, memberCompleter, coord = start)
       getScope(jflags).enter(member)

--- a/tests/pos/i6152/A_1.java
+++ b/tests/pos/i6152/A_1.java
@@ -1,0 +1,8 @@
+abstract class A {
+  public abstract Object f();
+
+  public static abstract class B extends A {
+    @Override
+    public abstract String f();
+  }
+}

--- a/tests/pos/i6152/Test_2.scala
+++ b/tests/pos/i6152/Test_2.scala
@@ -1,0 +1,8 @@
+class C extends A.B {
+  def f() = "hello"
+}
+
+object Main extends App {
+  val c: A = new C
+  println(c.f())
+}


### PR DESCRIPTION
Dotty overrides Java bridge methods when the user intends to override
the methods for which the bridges were generated. This commit forbids
Dotty to override bridge methods altogether.

This fix rests on the assumption that it is never legal to override synthetically generated bridge methods from the user's code.

Also, it seems that the current test framework does not allow to create tests for this issue. I haven't found a way to reproduce the issue as specified [here](https://github.com/lampepfl/dotty/issues/6152#issuecomment-480221977) with the existing test framework.