### PR TITLE
Fix checkInlineConformant check for inlined trees

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -356,7 +356,7 @@ object Splicer {
         interpretTree(expr)(newEnv)
       case NamedArg(_, arg) => interpretTree(arg)
 
-      case Inlined(EmptyTree, Nil, expansion) => interpretTree(expansion)
+      case Inlined(_, Nil, expansion) => interpretTree(expansion)
 
       case Typed(expr, _) =>
         interpretTree(expr)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -710,6 +710,8 @@ trait Checking {
         tree match {
           case Typed(expr, _) =>
             checkInlineConformant(expr, isFinal, what)
+          case Inlined(_, Nil, expr) =>
+            checkInlineConformant(expr, isFinal, what)
           case SeqLiteral(elems, _) =>
             elems.foreach(elem => checkInlineConformant(elem, isFinal, what))
           case Apply(fn, List(arg)) if defn.WrapArrayMethods().contains(fn.symbol) =>

--- a/tests/pos/inlined-inline-param.scala
+++ b/tests/pos/inlined-inline-param.scala
@@ -1,0 +1,4 @@
+class Foo {
+  inline def foo(inline x: Int): Int = x
+  def bar: Int = foo(foo(4))
+}

--- a/tests/run-with-compiler/reflect-inline/assert_1.scala
+++ b/tests/run-with-compiler/reflect-inline/assert_1.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.tasty._
 
 object api {
-  inline def (inline x: String) stripMargin <: String =
+  inline def (inline x: String) stripMargin: String =
     ${ stripImpl(x) }
 
   private def stripImpl(x: String)(implicit refl: Reflection): Expr[String] =


### PR DESCRIPTION
We where considering an `Inlined` tree as not conformant even if its contents are conformat.
Now we check if the exapnsion is conformant.