### PR TITLE
Fix type lambda reductions involving refinements

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -129,6 +129,8 @@ object TypeApplications {
     def apply(t: Type): Type = t match {
       case t @ AppliedType(tycon, args1) if tycon.typeSymbol.isClass =>
         t.derivedAppliedType(apply(tycon), args1.mapConserve(applyArg))
+      case t @ RefinedType(parent, name, TypeAlias(info)) =>
+        t.derivedRefinedType(apply(parent), name, applyArg(info).bounds)
       case p: TypeParamRef if p.binder == tycon =>
         args(p.paramNum) match {
           case TypeBounds(lo, hi) =>

--- a/tests/pos/hkRefAlias.scala
+++ b/tests/pos/hkRefAlias.scala
@@ -1,0 +1,10 @@
+class Bar
+class X
+class Y extends X
+
+object Test {
+  type G[X] = Bar { type R = X }
+
+  implicitly[G[_] =:= (Bar { type R })]
+  implicitly[G[_ >: Y <: X] =:= (Bar { type R >: Y <: X })]
+}


### PR DESCRIPTION
Given:

    type F[X] = Foo[X]

We've always been able to reduce `F[_]` to `Foo[_]` if `Foo` is a class.
This commit does something similar for refinements, given:

    type G[X] = Bla { type R = X }

We can reduce `G[_]` to `Bar { type R }` (previously we reduced it to
`Bar { type R = Any }` which is incorrect).