### PR TITLE
Add safety checks to `samMethod`

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -853,8 +853,14 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
 
     def addRemoteRemoteExceptionAnnotation: Unit = ()
 
-    def samMethod(): Symbol =
-      toDenot(sym).info.abstractTermMembers.headOption.getOrElse(toDenot(sym).info.member(nme.apply)).symbol
+    def samMethod(): Symbol = ctx.atPhase(ctx.erasurePhase) { implicit ctx =>
+      toDenot(sym).info.abstractTermMembers.toList match {
+        case x :: Nil => x.symbol
+        case Nil => abort(s"${sym.show} is not a functional interface. It doesn't have abstract methods")
+        case xs => abort(s"${sym.show} is not a functional interface. " +
+          s"It has the following abstract methods: ${xs.map(_.name).mkString(", ")}")
+      }
+    }
 
     def isFunctionClass: Boolean =
       defn.isFunctionClass(sym)

--- a/library/src/dotty/runtime/function/JFunction1$mcDD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcDD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcDD$sp extends JFunction1 {
+public interface JFunction1$mcDD$sp extends JFunction1<Object, Object> {
     abstract double apply$mcDD$sp(double v1);
 
     default Object apply(Object t) { return (Double) apply$mcDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcDF$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcDF$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcDF$sp extends JFunction1 {
+public interface JFunction1$mcDF$sp extends JFunction1<Object, Object> {
     abstract double apply$mcDF$sp(float v1);
 
     default Object apply(Object t) { return (Double) apply$mcDF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcDI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcDI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcDI$sp extends JFunction1 {
+public interface JFunction1$mcDI$sp extends JFunction1<Object, Object> {
     abstract double apply$mcDI$sp(int v1);
 
     default Object apply(Object t) { return (Double) apply$mcDI$sp(scala.runtime.BoxesRunTime.unboxToInt(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcDJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcDJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcDJ$sp extends JFunction1 {
+public interface JFunction1$mcDJ$sp extends JFunction1<Object, Object> {
     abstract double apply$mcDJ$sp(long v1);
 
     default Object apply(Object t) { return (Double) apply$mcDJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcFD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcFD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcFD$sp extends JFunction1 {
+public interface JFunction1$mcFD$sp extends JFunction1<Object, Object> {
     abstract float apply$mcFD$sp(double v1);
 
     default Object apply(Object t) { return (Float) apply$mcFD$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcFF$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcFF$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcFF$sp extends JFunction1 {
+public interface JFunction1$mcFF$sp extends JFunction1<Object, Object> {
     abstract float apply$mcFF$sp(float v1);
 
     default Object apply(Object t) { return (Float) apply$mcFF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcFI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcFI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcFI$sp extends JFunction1 {
+public interface JFunction1$mcFI$sp extends JFunction1<Object, Object> {
     abstract float apply$mcFI$sp(int v1);
 
     default Object apply(Object t) { return (Float) apply$mcFI$sp(scala.runtime.BoxesRunTime.unboxToInt(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcFJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcFJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcFJ$sp extends JFunction1 {
+public interface JFunction1$mcFJ$sp extends JFunction1<Object, Object> {
     abstract float apply$mcFJ$sp(long v1);
 
     default Object apply(Object t) { return (Float) apply$mcFJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcID$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcID$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcID$sp extends JFunction1 {
+public interface JFunction1$mcID$sp extends JFunction1<Object, Object> {
     abstract int apply$mcID$sp(double v1);
 
     default Object apply(Object t) { return (Integer) apply$mcID$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcIF$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcIF$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcIF$sp extends JFunction1 {
+public interface JFunction1$mcIF$sp extends JFunction1<Object, Object> {
     abstract int apply$mcIF$sp(float v1);
 
     default Object apply(Object t) { return (Integer) apply$mcIF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcII$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcII$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcII$sp extends JFunction1 {
+public interface JFunction1$mcII$sp extends JFunction1<Object, Object> {
     abstract int apply$mcII$sp(int v1);
 
     default Object apply(Object t) { return (Integer) apply$mcII$sp(scala.runtime.BoxesRunTime.unboxToInt(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcIJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcIJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcIJ$sp extends JFunction1 {
+public interface JFunction1$mcIJ$sp extends JFunction1<Object, Object> {
     abstract int apply$mcIJ$sp(long v1);
 
     default Object apply(Object t) { return (Integer) apply$mcIJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcJD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcJD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcJD$sp extends JFunction1 {
+public interface JFunction1$mcJD$sp extends JFunction1<Object, Object> {
     abstract long apply$mcJD$sp(double v1);
 
     default Object apply(Object t) { return (Long) apply$mcJD$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcJF$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcJF$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcJF$sp extends JFunction1 {
+public interface JFunction1$mcJF$sp extends JFunction1<Object, Object> {
     abstract long apply$mcJF$sp(float v1);
 
     default Object apply(Object t) { return (Long) apply$mcJF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcJI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcJI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcJI$sp extends JFunction1 {
+public interface JFunction1$mcJI$sp extends JFunction1<Object, Object> {
     abstract long apply$mcJI$sp(int v1);
 
     default Object apply(Object t) { return (Long) apply$mcJI$sp(scala.runtime.BoxesRunTime.unboxToInt(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcJJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcJJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcJJ$sp extends JFunction1 {
+public interface JFunction1$mcJJ$sp extends JFunction1<Object, Object> {
     abstract long apply$mcJJ$sp(long v1);
 
     default Object apply(Object t) { return (Long) apply$mcJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcVD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcVD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcVD$sp extends JFunction1 {
+public interface JFunction1$mcVD$sp extends JFunction1<Object, Object> {
     abstract void apply$mcVD$sp(double v1);
 
     default Object apply(Object t) { apply$mcVD$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction1$mcVF$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcVF$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcVF$sp extends JFunction1 {
+public interface JFunction1$mcVF$sp extends JFunction1<Object, Object> {
     abstract void apply$mcVF$sp(float v1);
 
     default Object apply(Object t) { apply$mcVF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction1$mcVI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcVI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcVI$sp extends JFunction1 {
+public interface JFunction1$mcVI$sp extends JFunction1<Object, Object> {
     abstract void apply$mcVI$sp(int v1);
 
     default Object apply(Object t) { apply$mcVI$sp(scala.runtime.BoxesRunTime.unboxToInt(t)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction1$mcVJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcVJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcVJ$sp extends JFunction1 {
+public interface JFunction1$mcVJ$sp extends JFunction1<Object, Object> {
     abstract void apply$mcVJ$sp(long v1);
 
     default Object apply(Object t) { apply$mcVJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction1$mcZD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcZD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcZD$sp extends JFunction1 {
+public interface JFunction1$mcZD$sp extends JFunction1<Object, Object> {
     abstract boolean apply$mcZD$sp(double v1);
 
     default Object apply(Object t) { return (Boolean) apply$mcZD$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcZF$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcZF$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcZF$sp extends JFunction1 {
+public interface JFunction1$mcZF$sp extends JFunction1<Object, Object> {
     abstract boolean apply$mcZF$sp(float v1);
 
     default Object apply(Object t) { return (Boolean) apply$mcZF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcZI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcZI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcZI$sp extends JFunction1 {
+public interface JFunction1$mcZI$sp extends JFunction1<Object, Object> {
     abstract boolean apply$mcZI$sp(int v1);
 
     default Object apply(Object t) { return (Boolean) apply$mcZI$sp(scala.runtime.BoxesRunTime.unboxToInt(t)); }

--- a/library/src/dotty/runtime/function/JFunction1$mcZJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction1$mcZJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction1$mcZJ$sp extends JFunction1 {
+public interface JFunction1$mcZJ$sp extends JFunction1<Object, Object> {
     abstract boolean apply$mcZJ$sp(long v1);
 
     default Object apply(Object t) { return (Boolean) apply$mcZJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcDDD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcDDD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcDDD$sp extends JFunction2 {
+public interface JFunction2$mcDDD$sp extends JFunction2<Object, Object, Object> {
     abstract double apply$mcDDD$sp(double v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Double) apply$mcDDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcDDI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcDDI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcDDI$sp extends JFunction2 {
+public interface JFunction2$mcDDI$sp extends JFunction2<Object, Object, Object> {
     abstract double apply$mcDDI$sp(double v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Double) apply$mcDDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcDDJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcDDJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcDDJ$sp extends JFunction2 {
+public interface JFunction2$mcDDJ$sp extends JFunction2<Object, Object, Object> {
     abstract double apply$mcDDJ$sp(double v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Double) apply$mcDDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcDID$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcDID$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcDID$sp extends JFunction2 {
+public interface JFunction2$mcDID$sp extends JFunction2<Object, Object, Object> {
     abstract double apply$mcDID$sp(int v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Double) apply$mcDID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcDII$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcDII$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcDII$sp extends JFunction2 {
+public interface JFunction2$mcDII$sp extends JFunction2<Object, Object, Object> {
     abstract double apply$mcDII$sp(int v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Double) apply$mcDII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcDIJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcDIJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcDIJ$sp extends JFunction2 {
+public interface JFunction2$mcDIJ$sp extends JFunction2<Object, Object, Object> {
     abstract double apply$mcDIJ$sp(int v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Double) apply$mcDIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcDJD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcDJD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcDJD$sp extends JFunction2 {
+public interface JFunction2$mcDJD$sp extends JFunction2<Object, Object, Object> {
     abstract double apply$mcDJD$sp(long v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Double) apply$mcDJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcDJI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcDJI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcDJI$sp extends JFunction2 {
+public interface JFunction2$mcDJI$sp extends JFunction2<Object, Object, Object> {
     abstract double apply$mcDJI$sp(long v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Double) apply$mcDJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcDJJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcDJJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcDJJ$sp extends JFunction2 {
+public interface JFunction2$mcDJJ$sp extends JFunction2<Object, Object, Object> {
     abstract double apply$mcDJJ$sp(long v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Double) apply$mcDJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcFDD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcFDD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcFDD$sp extends JFunction2 {
+public interface JFunction2$mcFDD$sp extends JFunction2<Object, Object, Object> {
     abstract float apply$mcFDD$sp(double v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Float) apply$mcFDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcFDI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcFDI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcFDI$sp extends JFunction2 {
+public interface JFunction2$mcFDI$sp extends JFunction2<Object, Object, Object> {
     abstract float apply$mcFDI$sp(double v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Float) apply$mcFDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcFDJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcFDJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcFDJ$sp extends JFunction2 {
+public interface JFunction2$mcFDJ$sp extends JFunction2<Object, Object, Object> {
     abstract float apply$mcFDJ$sp(double v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Float) apply$mcFDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcFID$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcFID$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcFID$sp extends JFunction2 {
+public interface JFunction2$mcFID$sp extends JFunction2<Object, Object, Object> {
     abstract float apply$mcFID$sp(int v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Float) apply$mcFID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcFII$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcFII$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcFII$sp extends JFunction2 {
+public interface JFunction2$mcFII$sp extends JFunction2<Object, Object, Object> {
     abstract float apply$mcFII$sp(int v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Float) apply$mcFII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcFIJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcFIJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcFIJ$sp extends JFunction2 {
+public interface JFunction2$mcFIJ$sp extends JFunction2<Object, Object, Object> {
     abstract float apply$mcFIJ$sp(int v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Float) apply$mcFIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcFJD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcFJD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcFJD$sp extends JFunction2 {
+public interface JFunction2$mcFJD$sp extends JFunction2<Object, Object, Object> {
     abstract float apply$mcFJD$sp(long v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Float) apply$mcFJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcFJI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcFJI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcFJI$sp extends JFunction2 {
+public interface JFunction2$mcFJI$sp extends JFunction2<Object, Object, Object> {
     abstract float apply$mcFJI$sp(long v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Float) apply$mcFJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcFJJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcFJJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcFJJ$sp extends JFunction2 {
+public interface JFunction2$mcFJJ$sp extends JFunction2<Object, Object, Object> {
     abstract float apply$mcFJJ$sp(long v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Float) apply$mcFJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcIDD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcIDD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcIDD$sp extends JFunction2 {
+public interface JFunction2$mcIDD$sp extends JFunction2<Object, Object, Object> {
     abstract int apply$mcIDD$sp(double v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Integer) apply$mcIDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcIDI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcIDI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcIDI$sp extends JFunction2 {
+public interface JFunction2$mcIDI$sp extends JFunction2<Object, Object, Object> {
     abstract int apply$mcIDI$sp(double v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Integer) apply$mcIDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcIDJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcIDJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcIDJ$sp extends JFunction2 {
+public interface JFunction2$mcIDJ$sp extends JFunction2<Object, Object, Object> {
     abstract int apply$mcIDJ$sp(double v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Integer) apply$mcIDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcIID$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcIID$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcIID$sp extends JFunction2 {
+public interface JFunction2$mcIID$sp extends JFunction2<Object, Object, Object> {
     abstract int apply$mcIID$sp(int v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Integer) apply$mcIID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcIII$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcIII$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcIII$sp extends JFunction2 {
+public interface JFunction2$mcIII$sp extends JFunction2<Object, Object, Object> {
     abstract int apply$mcIII$sp(int v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Integer) apply$mcIII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcIIJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcIIJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcIIJ$sp extends JFunction2 {
+public interface JFunction2$mcIIJ$sp extends JFunction2<Object, Object, Object> {
     abstract int apply$mcIIJ$sp(int v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Integer) apply$mcIIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcIJD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcIJD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcIJD$sp extends JFunction2 {
+public interface JFunction2$mcIJD$sp extends JFunction2<Object, Object, Object> {
     abstract int apply$mcIJD$sp(long v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Integer) apply$mcIJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcIJI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcIJI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcIJI$sp extends JFunction2 {
+public interface JFunction2$mcIJI$sp extends JFunction2<Object, Object, Object> {
     abstract int apply$mcIJI$sp(long v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Integer) apply$mcIJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcIJJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcIJJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcIJJ$sp extends JFunction2 {
+public interface JFunction2$mcIJJ$sp extends JFunction2<Object, Object, Object> {
     abstract int apply$mcIJJ$sp(long v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Integer) apply$mcIJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcJDD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcJDD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcJDD$sp extends JFunction2 {
+public interface JFunction2$mcJDD$sp extends JFunction2<Object, Object, Object> {
     abstract long apply$mcJDD$sp(double v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Long) apply$mcJDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcJDI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcJDI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcJDI$sp extends JFunction2 {
+public interface JFunction2$mcJDI$sp extends JFunction2<Object, Object, Object> {
     abstract long apply$mcJDI$sp(double v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Long) apply$mcJDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcJDJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcJDJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcJDJ$sp extends JFunction2 {
+public interface JFunction2$mcJDJ$sp extends JFunction2<Object, Object, Object> {
     abstract long apply$mcJDJ$sp(double v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Long) apply$mcJDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcJID$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcJID$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcJID$sp extends JFunction2 {
+public interface JFunction2$mcJID$sp extends JFunction2<Object, Object, Object> {
     abstract long apply$mcJID$sp(int v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Long) apply$mcJID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcJII$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcJII$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcJII$sp extends JFunction2 {
+public interface JFunction2$mcJII$sp extends JFunction2<Object, Object, Object> {
     abstract long apply$mcJII$sp(int v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Long) apply$mcJII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcJIJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcJIJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcJIJ$sp extends JFunction2 {
+public interface JFunction2$mcJIJ$sp extends JFunction2<Object, Object, Object> {
     abstract long apply$mcJIJ$sp(int v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Long) apply$mcJIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcJJD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcJJD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcJJD$sp extends JFunction2 {
+public interface JFunction2$mcJJD$sp extends JFunction2<Object, Object, Object> {
     abstract long apply$mcJJD$sp(long v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Long) apply$mcJJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcJJI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcJJI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcJJI$sp extends JFunction2 {
+public interface JFunction2$mcJJI$sp extends JFunction2<Object, Object, Object> {
     abstract long apply$mcJJI$sp(long v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Long) apply$mcJJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcJJJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcJJJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcJJJ$sp extends JFunction2 {
+public interface JFunction2$mcJJJ$sp extends JFunction2<Object, Object, Object> {
     abstract long apply$mcJJJ$sp(long v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Long) apply$mcJJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcVDD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcVDD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcVDD$sp extends JFunction2 {
+public interface JFunction2$mcVDD$sp extends JFunction2<Object, Object, Object> {
     abstract void apply$mcVDD$sp(double v1, double v2);
 
     default Object apply(Object v1, Object v2) { apply$mcVDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction2$mcVDI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcVDI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcVDI$sp extends JFunction2 {
+public interface JFunction2$mcVDI$sp extends JFunction2<Object, Object, Object> {
     abstract void apply$mcVDI$sp(double v1, int v2);
 
     default Object apply(Object v1, Object v2) { apply$mcVDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction2$mcVDJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcVDJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcVDJ$sp extends JFunction2 {
+public interface JFunction2$mcVDJ$sp extends JFunction2<Object, Object, Object> {
     abstract void apply$mcVDJ$sp(double v1, long v2);
 
     default Object apply(Object v1, Object v2) { apply$mcVDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction2$mcVID$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcVID$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcVID$sp extends JFunction2 {
+public interface JFunction2$mcVID$sp extends JFunction2<Object, Object, Object> {
     abstract void apply$mcVID$sp(int v1, double v2);
 
     default Object apply(Object v1, Object v2) { apply$mcVID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction2$mcVII$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcVII$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcVII$sp extends JFunction2 {
+public interface JFunction2$mcVII$sp extends JFunction2<Object, Object, Object> {
     abstract void apply$mcVII$sp(int v1, int v2);
 
     default Object apply(Object v1, Object v2) { apply$mcVII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction2$mcVIJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcVIJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcVIJ$sp extends JFunction2 {
+public interface JFunction2$mcVIJ$sp extends JFunction2<Object, Object, Object> {
     abstract void apply$mcVIJ$sp(int v1, long v2);
 
     default Object apply(Object v1, Object v2) { apply$mcVIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction2$mcVJD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcVJD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcVJD$sp extends JFunction2 {
+public interface JFunction2$mcVJD$sp extends JFunction2<Object, Object, Object> {
     abstract void apply$mcVJD$sp(long v1, double v2);
 
     default Object apply(Object v1, Object v2) { apply$mcVJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction2$mcVJI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcVJI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcVJI$sp extends JFunction2 {
+public interface JFunction2$mcVJI$sp extends JFunction2<Object, Object, Object> {
     abstract void apply$mcVJI$sp(long v1, int v2);
 
     default Object apply(Object v1, Object v2) { apply$mcVJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction2$mcVJJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcVJJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcVJJ$sp extends JFunction2 {
+public interface JFunction2$mcVJJ$sp extends JFunction2<Object, Object, Object> {
     abstract void apply$mcVJJ$sp(long v1, long v2);
 
     default Object apply(Object v1, Object v2) { apply$mcVJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); return scala.runtime.BoxedUnit.UNIT; }

--- a/library/src/dotty/runtime/function/JFunction2$mcZDD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcZDD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcZDD$sp extends JFunction2 {
+public interface JFunction2$mcZDD$sp extends JFunction2<Object, Object, Object> {
     abstract boolean apply$mcZDD$sp(double v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Boolean) apply$mcZDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcZDI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcZDI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcZDI$sp extends JFunction2 {
+public interface JFunction2$mcZDI$sp extends JFunction2<Object, Object, Object> {
     abstract boolean apply$mcZDI$sp(double v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Boolean) apply$mcZDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcZDJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcZDJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcZDJ$sp extends JFunction2 {
+public interface JFunction2$mcZDJ$sp extends JFunction2<Object, Object, Object> {
     abstract boolean apply$mcZDJ$sp(double v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Boolean) apply$mcZDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcZID$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcZID$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcZID$sp extends JFunction2 {
+public interface JFunction2$mcZID$sp extends JFunction2<Object, Object, Object> {
     abstract boolean apply$mcZID$sp(int v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Boolean) apply$mcZID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcZII$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcZII$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcZII$sp extends JFunction2 {
+public interface JFunction2$mcZII$sp extends JFunction2<Object, Object, Object> {
     abstract boolean apply$mcZII$sp(int v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Boolean) apply$mcZII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcZIJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcZIJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcZIJ$sp extends JFunction2 {
+public interface JFunction2$mcZIJ$sp extends JFunction2<Object, Object, Object> {
     abstract boolean apply$mcZIJ$sp(int v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Boolean) apply$mcZIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcZJD$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcZJD$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcZJD$sp extends JFunction2 {
+public interface JFunction2$mcZJD$sp extends JFunction2<Object, Object, Object> {
     abstract boolean apply$mcZJD$sp(long v1, double v2);
 
     default Object apply(Object v1, Object v2) { return (Boolean) apply$mcZJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcZJI$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcZJI$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcZJI$sp extends JFunction2 {
+public interface JFunction2$mcZJI$sp extends JFunction2<Object, Object, Object> {
     abstract boolean apply$mcZJI$sp(long v1, int v2);
 
     default Object apply(Object v1, Object v2) { return (Boolean) apply$mcZJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)); }

--- a/library/src/dotty/runtime/function/JFunction2$mcZJJ$sp.java
+++ b/library/src/dotty/runtime/function/JFunction2$mcZJJ$sp.java
@@ -6,7 +6,7 @@
 package dotty.runtime.function;
 
 @FunctionalInterface
-public interface JFunction2$mcZJJ$sp extends JFunction2 {
+public interface JFunction2$mcZJJ$sp extends JFunction2<Object, Object, Object> {
     abstract boolean apply$mcZJJ$sp(long v1, long v2);
 
     default Object apply(Object v1, Object v2) { return (Boolean) apply$mcZJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)); }

--- a/tests/run-with-compiler/i3876-c.scala
+++ b/tests/run-with-compiler/i3876-c.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit def toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
 
     val x: Expr[Int] = '{3}
 


### PR DESCRIPTION
`sam` in `samMethod` stands for "single abstract method". However,
presently, no check is performed to verify that the abstract method
it finds is indeed single. This commit adds such a check to this method.

As mentioned [here](https://github.com/lampepfl/dotty/pull/6266#issuecomment-481722323), `samMethod` is unsafe. Since it is only used in [`genInvokeDynamicLambda`](https://github.com/lampepfl/dotty/blob/e750a8afbba8b2448b5bb4b9728c6129911ca8cb/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala#L1439), which is only used when [generating the bytecode](https://github.com/lampepfl/dotty/blob/e750a8afbba8b2448b5bb4b9728c6129911ca8cb/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala#L316) for `Closure`s, this is no immediate problem. However, since this method is a part of a public API, not performing the safety checks can lead to runtime errors if it is used elsewhere incorrectly.