### PR TITLE
Upgrade to Scala.js 1.0.0-M7.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -24,6 +24,9 @@ final class JSDefinitions()(implicit ctx: Context) {
   lazy val NoinlineAnnotType: TypeRef = ctx.requiredClassRef("scala.noinline")
   def NoinlineAnnot(implicit ctx: Context) = NoinlineAnnotType.symbol.asClass
 
+  lazy val JavaLangVoidType: TypeRef = ctx.requiredClassRef("java.lang.Void")
+  def JavaLangVoidClass(implicit ctx: Context) = JavaLangVoidType.symbol.asClass
+
   lazy val ScalaJSJSPackageVal = ctx.requiredPackage("scala.scalajs.js")
   lazy val ScalaJSJSPackageClass = ScalaJSJSPackageVal.moduleClass.asClass
     lazy val JSPackage_typeOfR = ScalaJSJSPackageClass.requiredMethodRef("typeOf")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -569,11 +569,6 @@ object Build {
           IO.createDirectory(trgDir)
           IO.unzip(scalaJSIRSourcesJar, trgDir)
 
-          // Remove f interpolator macro call to avoid its expansion while compiling the compiler and the implementation of the f macro
-          val utilsFile = trgDir / "org/scalajs/ir/Utils.scala"
-          val patchedSource = IO.read(utilsFile).replace("""f"\\u$c%04x"""", """"\\u%04x".format(c)""")
-          IO.write(utilsFile, patchedSource)
-
           (trgDir ** "*.scala").get.toSet
         } (Set(scalaJSIRSourcesJar)).toSeq
       }.taskValue,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@
 // Scala IDE project file generator
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-M6")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-M7")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.1")
 


### PR DESCRIPTION
* Remove the build hack for the f interpolator in the IR sources
* Update codegen wrt. the changes in the IR:
  * `scala.runtime.BoxedUnit$` erases to `java.lang.Void`
  * First-class private methods and dedicated namespace for construtors
  * Miscellaneous refactorings

Relevant PRs upstream:
* https://github.com/scala-js/scala-js/pull/3535
* https://github.com/scala-js/scala-js/pull/3240