### PR TITLE
Print report even if the executor crashed

### DIFF
--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -481,7 +481,14 @@ trait ParallelTesting extends RunnerOrchestration { self =>
           throw new TimeoutException("Compiling targets timed out")
         }
 
-        eventualResults.foreach(_.get)
+        eventualResults.foreach { x =>
+          try x.get()
+          catch {
+            case ex: Exception =>
+              System.err.println(ex.getMessage)
+              ex.printStackTrace()
+          }
+        }
 
         if (logProgress) {
           timer.cancel()


### PR DESCRIPTION
When an executor crashes the error report is emitted and the exception is printed out.