### PR TITLE
Improve error/waring error format

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
@@ -6,7 +6,7 @@ import java.lang.System.{lineSeparator => EOL}
 
 import core.Contexts.Context
 import core.Decorators._
-import printing.Highlighting.{Blue, Red}
+import printing.Highlighting.{Blue, Red, Yellow}
 import printing.SyntaxHighlighting
 import diagnostic.{ErrorMessageID, Message, MessageContainer}
 import diagnostic.messages._
@@ -42,14 +42,14 @@ trait MessageRendering {
     *
     * @return (lines before error, lines after error, line numbers offset)
     */
-  def sourceLines(pos: SourcePosition)(implicit ctx: Context): (List[String], List[String], Int) = {
+  def sourceLines(pos: SourcePosition, diagnosticLevel: String)(implicit ctx: Context): (List[String], List[String], Int) = {
     var maxLen = Int.MinValue
     def render(offsetAndLine: (Int, String)): String = {
       val (offset, line) = offsetAndLine
       val lineNbr = pos.source.offsetToLine(offset)
       val prefix = s"${lineNbr + 1} |"
       maxLen = math.max(maxLen, prefix.length)
-      val lnum = Red(" " * math.max(0, maxLen - prefix.length) + prefix).show
+      val lnum = hl(diagnosticLevel)(" " * math.max(0, maxLen - prefix.length) + prefix)
       lnum + line.stripLineEnd
     }
 
@@ -78,15 +78,15 @@ trait MessageRendering {
   }
 
   /** The column markers aligned under the error */
-  def columnMarker(pos: SourcePosition, offset: Int)(implicit ctx: Context): String = {
+  def columnMarker(pos: SourcePosition, offset: Int, diagnosticLevel: String)(implicit ctx: Context): String = {
     val prefix = " " * (offset - 1)
     val padding = pos.startColumnPadding
-    val carets = Red {
+    val carets = hl(diagnosticLevel) {
       if (pos.startLine == pos.endLine)
         "^" * math.max(1, pos.endColumn - pos.startColumn)
       else "^"
     }
-    s"$prefix|$padding${carets.show}"
+    s"$prefix|$padding$carets"
   }
 
   /** The error message (`msg`) aligned under `pos`
@@ -112,7 +112,7 @@ trait MessageRendering {
     * @return separator containing error location and kind
     */
   def posStr(pos: SourcePosition, diagnosticLevel: String, message: Message)(implicit ctx: Context): String =
-    if (pos.exists) Blue({
+    if (pos.exists) hl(diagnosticLevel)({
       val file = s"${pos.source.file.toString}:${pos.line + 1}:${pos.column}"
       val errId =
         if (message.errorId ne ErrorMessageID.NoExplanationID) {
@@ -126,7 +126,7 @@ trait MessageRendering {
 
       prefix +
         ("-" * math.max(ctx.settings.pageWidth.value - stripColor(prefix).length, 0))
-    }).show else ""
+    }) else ""
 
   /** Explanation rendered under "Explanation" header */
   def explanation(m: Message)(implicit ctx: Context): String = {
@@ -146,12 +146,20 @@ trait MessageRendering {
     val posString = posStr(pos, diagnosticLevel, msg)
     if (posString.nonEmpty) sb.append(posString).append(EOL)
     if (pos.exists) {
-      val (srcBefore, srcAfter, offset) = sourceLines(pos)
-      val marker = columnMarker(pos, offset)
+      val (srcBefore, srcAfter, offset) = sourceLines(pos, diagnosticLevel)
+      val marker = columnMarker(pos, offset, diagnosticLevel)
       val err = errorMsg(pos, msg.msg, offset)
       sb.append((srcBefore ::: marker :: err :: outer(pos, " " * (offset - 1)) ::: srcAfter).mkString(EOL))
     } else sb.append(msg.msg)
     sb.toString
+  }
+
+  def hl(diagnosticLevel: String)(str: String)(implicit ctx: Context): String = diagnosticLevel match {
+    case "Info" => Blue(str).show
+    case "Error" => Red(str).show
+    case _ =>
+      assert(diagnosticLevel.contains("Warning"))
+      Yellow(str).show
   }
 
   def diagnosticLevel(cont: MessageContainer): String =


### PR DESCRIPTION
Use red for error, yellow for warnings and blue for info.

Previously all warnings looked like errors:
<img width="376" alt="Screenshot 2019-04-11 at 22 41 27" src="https://user-images.githubusercontent.com/3648029/55991658-0edc6a80-5cab-11e9-86e2-4f915a34be45.png">

Now we can easely diferentiate them (blue is still kept for info):
<img width="375" alt="Screenshot 2019-04-11 at 22 41 38" src="https://user-images.githubusercontent.com/3648029/55991662-100d9780-5cab-11e9-8c67-43c888503485.png">
