### PR TITLE
Fix #6127: Drop followAlias

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -106,13 +106,12 @@ object Inferencing {
       case tvar: TypeVar
       if !tvar.isInstantiated && ctx.typerState.constraint.contains(tvar) =>
         force.appliesTo(tvar) && {
-          val pref = tvar.origin
-          val direction = instDirection(pref)
+          val direction = instDirection(tvar.origin)
           def avoidBottom =
             !force.allowBottom &&
-            defn.isBottomType(ctx.typeComparer.approximation(pref, fromBelow = true))
+            defn.isBottomType(ctx.typeComparer.approximation(tvar.origin, fromBelow = true))
           def preferMin = force.minimizeAll || variance >= 0 && !avoidBottom
-          if (direction != 0) instantiate(tvar, fromBelow = direction < 0)
+          if (direction != 0) instantiate(tvar, direction < 0)
           else if (preferMin) instantiate(tvar, fromBelow = true)
           else toMaximize = true
           foldOver(x, tvar)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2553,10 +2553,12 @@ class Typer extends Namer
           inst(lo)
         case tp: TypeParamRef =>
           constraint.typeVarOfParam(tp).orElse(tp)
-        case _ => tp
+        case _ =>
+          NoType
       }
       tp match {
-        case tp: TypeVar if constraint.contains(tp) => inst(constraint.entry(tp.origin))
+        case tp: TypeVar if constraint.contains(tp) =>
+          inst(constraint.entry(tp.origin)).orElse(tp)
         case _ => tp
       }
     }

--- a/tests/pos/i6127.scala
+++ b/tests/pos/i6127.scala
@@ -1,0 +1,4 @@
+class Foo[+FT](x: FT) {
+  def fooArray: Foo[Array[String]] = new Foo(Array.empty)
+  val y: Array[String] = Array.empty
+}

--- a/tests/pos/i6127.scala
+++ b/tests/pos/i6127.scala
@@ -1,4 +1,18 @@
+import reflect.ClassTag
+class Co[+S]
+object Co {
+  def empty[X: ClassTag]: Co[X] = ???
+}
+class Contra[-S]
+object Contra {
+  def empty[X: ClassTag]: Contra[X] = ???
+}
 class Foo[+FT](x: FT) {
   def fooArray: Foo[Array[String]] = new Foo(Array.empty)
-  val y: Array[String] = Array.empty
+  val y1: Array[String] = Array.empty
+  def fooCo: Foo[Co[String]] = new Foo(Co.empty)
+  val y2: Co[String] = Co.empty
+  def fooContra: Foo[Contra[String]] = new Foo(Contra.empty)
+  val y3: Contra[String] = Contra.empty
 }
+


### PR DESCRIPTION
FollowAlias would return the bounds of a constraint type variable
instead of the variable itself. This meant that constrain result
in adapt would almost always return true for an expected type that
was a type variable instead of adding a constraint for it.