### PR TITLE
Produce documentation for the non-bootsrapped library

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -330,7 +330,10 @@ object Build {
 
       val sources =
         unmanagedSources.in(Compile, compile).value ++
-        unmanagedSources.in(`dotty-compiler`, Compile).value
+        unmanagedSources.in(`dotty-compiler`, Compile).value ++
+        // TODO use bootstrapped library
+        // Blocked by #6295, also see https://github.com/lampepfl/dotty/pull/5499
+        unmanagedSources.in(`dotty-library`, Compile).value
       val args = Seq(
         "-siteroot", "docs",
         "-project", "Dotty",


### PR DESCRIPTION
This is still not the actual documentation we want to generate, but at least we will have the documentation for TASTy reflect available. 

Later, when #6295 we will update it to generate the docs for the bootstrapped library.