### PR TITLE
Fix #6286:  Fix ElimOpaque transformation

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -407,7 +407,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       ref(defn.DottyArraysModule).select(defn.newArrayMethod).withSpan(span)
 
     if (!ctx.erasedTypes) {
-      assert(!TypeErasure.isGeneric(elemTpe)) //needs to be done during typer. See Applications.convertNewGenericArray
+      assert(!TypeErasure.isGeneric(elemTpe), elemTpe) //needs to be done during typer. See Applications.convertNewGenericArray
       newArr.appliedToTypeTrees(TypeTree(returnTpe) :: Nil).appliedToArgs(clsOf(elemTpe) :: clsOf(returnTpe) :: dims :: Nil).withSpan(span)
     } else  // after erasure
       newArr.appliedToArgs(clsOf(elemTpe) :: clsOf(returnTpe) :: dims :: Nil).withSpan(span)

--- a/compiler/src/dotty/tools/dotc/core/DenotTransformers.scala
+++ b/compiler/src/dotty/tools/dotc/core/DenotTransformers.scala
@@ -61,13 +61,13 @@ object DenotTransformers {
   trait SymTransformer extends DenotTransformer {
 
   	/** Tramsform the info of a denotation that is not a Symdenotation */
-    def transformInfo(tp: Type, sym: Symbol)(implicit ctx: Context): Type = tp
+    def transformNonSymInfo(tp: Type, sym: Symbol)(implicit ctx: Context): Type = tp
 
     def transformSym(sym: SymDenotation)(implicit ctx: Context): SymDenotation
 
     def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation = ref match {
       case ref: SymDenotation => transformSym(ref)
-      case _ => ref.derivedSingleDenotation(ref.symbol, transformInfo(ref.info, ref.symbol))
+      case _ => ref.derivedSingleDenotation(ref.symbol, transformNonSymInfo(ref.info, ref.symbol))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/DenotTransformers.scala
+++ b/compiler/src/dotty/tools/dotc/core/DenotTransformers.scala
@@ -57,17 +57,18 @@ object DenotTransformers {
     protected def mayChange(sym: Symbol)(implicit ctx: Context): Boolean = true
   }
 
-  /** A transformer that only transforms SymDenotations */
+  /** A transformer that only transforms SymDenotations.
+   *  Note: Infos of non-sym denotations are left as is. So the transformer should
+   *  be used before erasure only if this is not a problem. After erasure, all
+   *  denotations are SymDenotations, so SymTransformers can be used freely.
+   */
   trait SymTransformer extends DenotTransformer {
-
-  	/** Tramsform the info of a denotation that is not a Symdenotation */
-    def transformNonSymInfo(tp: Type, sym: Symbol)(implicit ctx: Context): Type = tp
 
     def transformSym(sym: SymDenotation)(implicit ctx: Context): SymDenotation
 
     def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation = ref match {
       case ref: SymDenotation => transformSym(ref)
-      case _ => ref.derivedSingleDenotation(ref.symbol, transformNonSymInfo(ref.info, ref.symbol))
+      case _ => ref
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/DenotTransformers.scala
+++ b/compiler/src/dotty/tools/dotc/core/DenotTransformers.scala
@@ -60,11 +60,14 @@ object DenotTransformers {
   /** A transformer that only transforms SymDenotations */
   trait SymTransformer extends DenotTransformer {
 
+  	/** Tramsform the info of a denotation that is not a Symdenotation */
+    def transformInfo(tp: Type, sym: Symbol)(implicit ctx: Context): Type = tp
+
     def transformSym(sym: SymDenotation)(implicit ctx: Context): SymDenotation
 
     def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation = ref match {
       case ref: SymDenotation => transformSym(ref)
-      case _ => ref
+      case _ => ref.derivedSingleDenotation(ref.symbol, transformInfo(ref.info, ref.symbol))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -19,6 +19,7 @@ import reporting.diagnostic.Message
 import reporting.diagnostic.messages.BadSymbolicReference
 import reporting.trace
 import collection.mutable
+import transform.TypeUtils._
 
 import scala.annotation.internal.sharable
 
@@ -1082,16 +1083,10 @@ object SymDenotations {
      *  containing object.
      */
     def opaqueAlias(implicit ctx: Context): Type = {
-      if (isOpaqueHelper) {
+      if (isOpaqueHelper)
         owner.asClass.classInfo.selfType match {
-          case RefinedType(_, _, TypeBounds(lo, _)) =>
-            def extractAlias(tp: Type): Type = tp match {
-              case OrType(alias, _) => alias
-              case tp: HKTypeLambda => tp.derivedLambdaType(resType = extractAlias(tp.resType))
-            }
-            extractAlias(lo)
+          case RefinedType(_, _, bounds) => bounds.extractOpaqueAlias
         }
-      }
       else NoType
     }
 

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -254,7 +254,13 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   protected def typeApplyText[T >: Untyped](tree: TypeApply[T]): Text = {
     val isQuote = tree.fun.hasType && tree.fun.symbol == defn.InternalQuoted_typeQuote
     val (open, close) = if (isQuote) (keywordStr("'["), keywordStr("]")) else ("[", "]")
-    toTextLocal(tree.fun).provided(!isQuote) ~ open ~ toTextGlobal(tree.args, ", ") ~ close
+    val funText = toTextLocal(tree.fun).provided(!isQuote)
+    tree.fun match {
+      case Select(New(tpt), nme.CONSTRUCTOR) if tpt.typeOpt.dealias.isInstanceOf[AppliedType] =>
+        funText  // type was already printed by toText(new)
+      case _ =>
+        funText ~ open ~ toTextGlobal(tree.args, ", ") ~ close
+    }
   }
 
   protected def toTextCore[T >: Untyped](tree: Tree[T]): Text = {

--- a/compiler/src/dotty/tools/dotc/transform/ElimOpaque.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimOpaque.scala
@@ -2,25 +2,15 @@ package dotty.tools.dotc
 package transform
 
 import core._
-import Names._
 import dotty.tools.dotc.transform.MegaPhase._
-import ast.Trees._
-import ast.untpd
 import Flags._
 import Types._
-import Constants.Constant
 import Contexts.Context
 import Symbols._
 import Decorators._
-import Annotations._
-import Annotations.ConcreteAnnotation
-import Denotations.SingleDenotation
 import SymDenotations.SymDenotation
-import scala.collection.mutable
 import DenotTransformers._
-import NameOps._
-import NameKinds.OuterSelectName
-import StdNames._
+import TypeUtils._
 
 object ElimOpaque {
   val name: String = "elimOpaque"
@@ -36,6 +26,9 @@ class ElimOpaque extends MiniPhase with SymTransformer {
 
   // base types of opaque aliases change
   override def changesBaseTypes = true
+
+  override def transformInfo(tp: Type, sym: Symbol)(implicit ctx: Context): Type =
+    if (sym.isOpaqueHelper) TypeAlias(tp.extractOpaqueAlias) else tp
 
   def transformSym(sym: SymDenotation)(implicit ctx: Context): SymDenotation =
     if (sym.isOpaqueHelper) {

--- a/compiler/src/dotty/tools/dotc/transform/ElimOpaque.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimOpaque.scala
@@ -27,7 +27,7 @@ class ElimOpaque extends MiniPhase with SymTransformer {
   // base types of opaque aliases change
   override def changesBaseTypes = true
 
-  override def transformInfo(tp: Type, sym: Symbol)(implicit ctx: Context): Type =
+  override def transformNonSymInfo(tp: Type, sym: Symbol)(implicit ctx: Context): Type =
     if (sym.isOpaqueHelper) TypeAlias(tp.extractOpaqueAlias) else tp
 
   def transformSym(sym: SymDenotation)(implicit ctx: Context): SymDenotation =

--- a/compiler/src/dotty/tools/dotc/transform/Getters.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Getters.scala
@@ -65,6 +65,10 @@ class Getters extends MiniPhase with SymTransformer {
         d.copySymDenotation(
           initFlags = d.flags | maybeStable | AccessorCreationFlags,
           info = ExprType(d.info))
+            // Note: This change will only affect the SymDenotation itself, not
+            // SingleDenotations referring to a getter. In this case it does not
+            // seem to be a problem since references to a getter don't care whether
+            // it's a `T` or a `=> T`
       }
       else d
 

--- a/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
@@ -51,5 +51,17 @@ object TypeUtils {
     /** The `*:` equivalent of an instance of a Tuple class */
     def toNestedPairs(implicit ctx: Context): Type =
       TypeOps.nestedPairs(tupleElementTypes)
+
+    /** Extract opaque alias from TypeBounds type that combines it with the reference
+     *  to the opaque type itself
+     */
+    def extractOpaqueAlias(implicit ctx: Context): Type = self match {
+      case TypeBounds(lo, _) =>
+        def extractAlias(tp: Type): Type = tp match {
+          case OrType(alias, _) => alias
+          case self: HKTypeLambda => self.derivedLambdaType(resType = extractAlias(self.resType))
+        }
+        extractAlias(lo)
+    }
   }
 }

--- a/tests/pos/i6286.scala
+++ b/tests/pos/i6286.scala
@@ -1,0 +1,6 @@
+object A {
+  opaque type T33 = Int
+  object T33 {
+    val a = new Array[T33](3)
+  }
+}

--- a/tests/pos/i6287.scala
+++ b/tests/pos/i6287.scala
@@ -1,0 +1,13 @@
+object O{
+  def m() = {
+    opaque type T = Int
+    object T
+  }
+}
+object A {
+  {
+    opaque type T = Int
+    object T
+    println
+  }
+}


### PR DESCRIPTION
SymTransformers used to transform only SymDenotations. But that does not work for
ElimOpaque, where we also have to transform SingleDenotations that refer to opaque
helpers.
