### PR TITLE
Fix #6247: Remove incorrect early check

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SimpleIdentitySet.scala
+++ b/compiler/src/dotty/tools/dotc/util/SimpleIdentitySet.scala
@@ -7,6 +7,7 @@ import collection.mutable.ListBuffer
  */
 abstract class SimpleIdentitySet[+Elem <: AnyRef] {
   def size: Int
+  def isEmpty: Boolean = size == 0
   def + [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[E]
   def - [E >: Elem <: AnyRef](x: E): SimpleIdentitySet[Elem]
   def contains[E >: Elem <: AnyRef](x: E): Boolean

--- a/tests/pos/i6247.scala
+++ b/tests/pos/i6247.scala
@@ -1,0 +1,10 @@
+class Foo {
+  implicit class NN[T](x:T|Null) {
+    def nn: T = x.asInstanceOf[T]
+  }
+
+  val x1: String|Null = null
+  x1.nn.length
+  val x2: String = x1.nn
+  x1.nn.length
+}


### PR DESCRIPTION
The check relied on the assumption that `locked` is always contained in
`state.ownedVars`, but this can stop being true when an owned type
variable is garbage-collected.