### PR TITLE
Fix #5295: handle inline accessor in shortcut implicits

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ShortcutImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ShortcutImplicits.scala
@@ -129,6 +129,9 @@ class ShortcutImplicits extends MiniPhase with IdentityDenotTransformer { thisPh
             .appliedToArgss(vparamSymss.map(_.map(ref(_))) :+ clparamSyms.map(ref(_)))
           val fwdClosure = cpy.Block(tree)(cpy.DefDef(meth)(rhs = forwarder) :: Nil, cl)
           (remappedCore, fwdClosure)
+        case id: Ident =>
+          val SAMType(mt) = id.tpe.widen
+          splitClosure(tpd.Lambda(mt, args => id.select(nme.apply).appliedToArgs(args))(ctx.withOwner(original)))
         case EmptyTree =>
           (_ => _ => EmptyTree, EmptyTree)
       }

--- a/tests/pos/i5295.scala
+++ b/tests/pos/i5295.scala
@@ -1,0 +1,2 @@
+inline def foo: String = bar given (4)
+private def bar: given Int => String = "baz"


### PR DESCRIPTION
Fix #5295: handle inline accessor in shortcut implicits