### PR TITLE
Dump output file when test fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ vscode-dotty/.vscode-test
 
 community-build/dotty-bootstrapped.version
 community-build/sbt-dotty-sbt
+
+# Vulpix output files
+*.check.out


### PR DESCRIPTION
Dumps the output of all failed check files into a `.check.out` file next to the `.check` file.