### PR TITLE
Fix #1252: Fix variance checking for parameterized typedefs

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -640,7 +640,29 @@ object Trees {
     def forwardTo: Tree[T] = tpt
   }
 
-  /** [typeparams] -> tpt */
+  /** [typeparams] -> tpt
+   *
+   *  Note: the type of such a tree is not necessarily a `HKTypeLambda`, it can
+   *  also be a `TypeBounds` where the upper bound is an `HKTypeLambda`, and the
+   *  lower bound is either a reference to `Nothing` or an `HKTypeLambda`,
+   *  this happens because these trees are typed by `HKTypeLambda#fromParams` which
+   *  makes sure to move bounds outside of the type lambda itself to simplify their
+   *  handling in the compiler.
+   *
+   *  You may ask: why not normalize the trees too? That way,
+   *
+   *      LambdaTypeTree(X, TypeBoundsTree(A, B))
+   *
+   *  would become,
+   *
+   *      TypeBoundsTree(LambdaTypeTree(X, A), LambdaTypeTree(X, B))
+   *
+   *  which would maintain consistency between a tree and its type. The problem
+   *  with this definition is that the same tree `X` appears twice, therefore
+   *  we'd have to create two symbols for it which makes it harder to relate the
+   *  source code written by the user with the trees used by the compiler (for
+   *  example, to make "find all references" work in the IDE).
+   */
   case class LambdaTypeTree[-T >: Untyped] private[ast] (tparams: List[TypeDef[T]], body: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends TypTree[T] {
     type ThisTree[-T >: Untyped] = LambdaTypeTree[T]

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3358,9 +3358,9 @@ object Types {
       param.paramName.withVariance(param.paramVariance)
 
     /** Distributes Lambda inside type bounds. Examples:
-  	 *
-   	 *      type T[X] = U        becomes    type T = [X] -> U
-   	 *      type T[X] <: U       becomes    type T >: Nothign <: ([X] -> U)
+     *
+     *      type T[X] = U        becomes    type T = [X] -> U
+     *      type T[X] <: U       becomes    type T >: Nothing <: ([X] -> U)
      *      type T[X] >: L <: U  becomes    type T >: ([X] -> L) <: ([X] -> U)
      */
     override def fromParams[PI <: ParamInfo.Of[TypeName]](params: List[PI], resultType: Type)(implicit ctx: Context): Type = {

--- a/tests/neg/type-lambdas-posttyper.scala
+++ b/tests/neg/type-lambdas-posttyper.scala
@@ -23,4 +23,19 @@ object Test extends App {
   aref.x = 1
   val s: String = sref.x
 
+  type Neg1[-X] = X // error
+  type Neg2[-X] >: X // error
+  type Neg3[-X] <: X // error
+
+  type Neg4 = [-X] => X // error
+  type Neg5 >: [-X] => X <: [-X] => Any // error
+  type Neg6 <: [-X] => X // error
+
+  type Pos1[+X] = Ref[X] // error
+  type Pos2[+X] >: Ref[X] // error
+  type Pos3[+X] <: Ref[X] // error
+
+  type Pos4 = [+X] => Ref[X] // error
+  type Pos5 >: [+X] => Ref[X] <: [+X] => Any // error
+  type Pos6 <: [+X] => Ref[X] // error
 }


### PR DESCRIPTION
940f5174d164d4ec2120cd7386f58262612e5804 added these checks but missed
the case where a TypeLambdaTree type is a TypeBounds, this commit just
adds the missing case as well as an explanatory comment in TypeLambdaTree.