### PR TITLE
Test demonstrating extension method shorthands

### DIFF
--- a/tests/run/extmethods2.scala
+++ b/tests/run/extmethods2.scala
@@ -5,12 +5,12 @@ object Test extends App {
   implied StringListOps given TC {
     type T = List[String]
     def (x: T) foo (y: T) = (x ++ y, the[TC])
-    def (x: T) bar (y: Int) = (x(y), the[TC])
+    def (x: T) bar (y: Int) = (x(0)(y), the[TC])
   }
 
   def test given TC = {
     assert(List("abc").foo(List("def"))._1 == List("abc", "def"))
-    assert(List("abc").bar(2)._1 == "c")
+    assert(List("abc").bar(2)._1 == 'c')
   }
 
   test given TC()

--- a/tests/run/extmethods2.scala
+++ b/tests/run/extmethods2.scala
@@ -1,0 +1,17 @@
+object Test extends App {
+
+  class TC
+
+  implied StringListOps given TC {
+    type T = List[String]
+    def (x: T) foo (y: T) = (x ++ y, the[TC])
+    def (x: T) bar (y: Int) = (x(y), the[TC])
+  }
+
+  def test given TC = {
+    assert(List("abc").foo(List("def"))._1 == List("abc", "def"))
+    assert(List("abc").bar(2)._1 == "c")
+  }
+
+  test given TC()
+}


### PR DESCRIPTION
This test shows that the overhead of extension methods can be reduced
to be no more than 7 characters per method, using two tricks:

 - Any implicit parameters become parameters of the enclosing implied instance
 - A local type alias can be used to abbreviate the (repetitive) first parameter
   string.

This demonstration strengthens the case for the current syntax for extension methods.