### PR TITLE
Revert deprecation warnings disable

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -55,7 +55,7 @@ trait Reporting { this: Context =>
     }
 
   def deprecationWarning(msg: => Message, pos: SourcePosition = NoSourcePosition): Unit =
-    if (this.settings.deprecation.value) reportWarning(new DeprecationWarning(msg, pos))
+    reportWarning(new DeprecationWarning(msg, pos))
 
   def migrationWarning(msg: => Message, pos: SourcePosition = NoSourcePosition): Unit =
     reportWarning(new MigrationWarning(msg, pos))

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -50,7 +50,13 @@ trait Reporting { this: Context =>
 
   def reportWarning(warning: Warning): Unit =
     if (!this.settings.silentWarnings.value) {
-      if (this.settings.XfatalWarnings.value) reporter.report(warning.toError)
+      if (this.settings.XfatalWarnings.value)
+        warning match {
+          case warning: ConditionalWarning if !warning.enablingOption.value =>
+            reporter.report(warning) // conditional warnings that are not enabled are not fatal
+          case _ =>
+            reporter.report(warning.toError)
+        }
       else reporter.report(warning)
     }
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -162,6 +162,7 @@ class CompilationTests extends ParallelTesting {
     compileFile("tests/neg-custom-args/i3882.scala", allowDeepSubtypes) +
     compileFile("tests/neg-custom-args/i4372.scala", allowDeepSubtypes) +
     compileFile("tests/neg-custom-args/i1754.scala", allowDeepSubtypes) +
+    compileFile("tests/neg-custom-args/conditionalWarnings.scala", allowDeepSubtypes.and("-deprecation").and("-Xfatal-warnings")) +
     compileFilesInDir("tests/neg-custom-args/isInstanceOf", allowDeepSubtypes and "-Xfatal-warnings") +
     compileFile("tests/neg-custom-args/i3627.scala", allowDeepSubtypes) +
     compileFile("tests/neg-custom-args/matchtype-loop.scala", allowDeepSubtypes) +

--- a/tests/neg-custom-args/conditionalWarnings.scala
+++ b/tests/neg-custom-args/conditionalWarnings.scala
@@ -1,0 +1,14 @@
+
+// run with -deprecation -Xfatal-warnings
+object Test {
+  @deprecated def foo = ???
+
+  implied for Conversion[String, Int] = _.length
+
+  foo    // error
+
+  val x: Int = "abc"
+    // OK, since -feature warnings are not enabled.
+    // The program compiles with final line
+    // there were 1 feature warning(s); re-run with -feature for details
+}


### PR DESCRIPTION
Deprecation warnings did not print a "There were deprecation warnings" anymore.
This invalidates the whole point of making them conditional warnings in the first place!