### PR TITLE
 Do not rename names starting with `$` in quoted patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1986,7 +1986,9 @@ class Typer extends Namer
               case t => t
             }
             val bindingExprTpe = AppliedType(defn.QuotedMatchingBindingType, bindingType :: Nil)
-            val sym = ctx0.newPatternBoundSymbol(ddef.name, bindingExprTpe, ddef.span)
+            assert(ddef.name.startsWith("$"))
+            val bindName = ddef.name.toString.stripPrefix("$").toTermName
+            val sym = ctx0.newPatternBoundSymbol(bindName, bindingExprTpe, ddef.span)
             patBuf += Bind(sym, untpd.Ident(nme.WILDCARD).withType(bindingExprTpe)).withSpan(ddef.span)
           }
           super.transform(tree)

--- a/tests/pos/quotedPatterns.scala
+++ b/tests/pos/quotedPatterns.scala
@@ -16,13 +16,13 @@ object Test {
       // but only when used in conjunction with the others.
       // I believe this is because implicit arguments are not taken
       // into account when checking whether we have already seen an `unapply` before.
-    case '{ val $y: Int = $z; 1 } =>
+    case '{ val $y: Int = $z; println(`$y`); 1 } =>
       val a: quoted.matching.Bind[Int] = y
       z
-    case '{ (($y: Int) => 1 + y + ($z: Int))(2) } =>
+    case '{ (($y: Int) => 1 + `$y` + ($z: Int))(2) } =>
       val a: quoted.matching.Bind[Int] = y
       z
-    case '{ def $ff: Int = $z; ff } =>
+    case '{ def $ff: Int = $z; `$ff` } =>
       val a: quoted.matching.Bind[Int] = ff
       z
     case '{ def $ff(i: Int): Int = $z; 2 } =>

--- a/tests/pos/quotedPatterns.scala
+++ b/tests/pos/quotedPatterns.scala
@@ -12,10 +12,6 @@ object Test {
     case '{ ((a: Int) => 3)($y) } => y
     case '{ 1 + ($y: Int)} => y
     case '{ val a = 1 + ($y: Int); 3 } => y
-      // currently gives an unreachable case warning
-      // but only when used in conjunction with the others.
-      // I believe this is because implicit arguments are not taken
-      // into account when checking whether we have already seen an `unapply` before.
     case '{ val $y: Int = $z; println(`$y`); 1 } =>
       val a: quoted.matching.Bind[Int] = y
       z


### PR DESCRIPTION
Previously we renamed `val $a` to `val a` and at the same time created a binding
named `a`. A reference to `a` inside a splice could not be disambiguated.

```scala
case '{ val $a: Int = 4; `$a` + ${ ... a ... '{ .. `$a` .. } ... } } => a
```

This change allows us to both refer to the `a` binding and the `$a` reference inside splices without ambiguities.