### PR TITLE
Don't emit mixin forwarders as final

### DIFF
--- a/tests/run/t11485.scala
+++ b/tests/run/t11485.scala
@@ -1,0 +1,16 @@
+import java.lang.reflect.Modifier
+
+trait HaveFinalMethod {
+  final def finalMethod: String = "final"
+}
+
+class Child extends HaveFinalMethod
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val meth = classOf[Child].getMethod("finalMethod")
+    assert(meth.isBridge)
+    val mods = meth.getModifiers
+    assert(!Modifier.isFinal(mods))
+  }
+}


### PR DESCRIPTION
This is the same change I did for scalac in
https://github.com/scala/scala/pull/7980, see the commit there for a
rationale.