### PR TITLE
Fix "find all references" when using the IDE in the Dotty build

### DIFF
--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -156,7 +156,7 @@ class DottyLanguageServer extends LanguageServer
       val allProjects = drivers.keySet
 
       def transitiveDependencies(config: ProjectConfig): Set[ProjectConfig] = {
-        val dependencies = config.projectDependencies.map(idToConfig).toSet
+        val dependencies = config.projectDependencies.flatMap(idToConfig.get).toSet
         dependencies ++ dependencies.flatMap(transitiveDependencies)
       }
 


### PR DESCRIPTION
Running "find all references" in Dotty itself used to fail because
constructing the map of project to their dependency failed, because this
map is based on the `projectDependencies` key written in
`.dotty-ide.json` which might contain projects which are not loaded in
the IDE because they were excluded with `excludeFromIDE`.
This commit fixes this by just ignoring dependencies which do not
correspond to projects loaded in the IDE, this is the most resilient
way to fix this.