### PR TITLE
Add `-Ydebug-tree-with-id n`

### DIFF
--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -7,6 +7,7 @@ import config.CompilerCommand
 import core.Comments.{ContextDoc, ContextDocstrings}
 import core.Contexts.{Context, ContextBase}
 import core.{MacroClassLoader, Mode, TypeError}
+import dotty.tools.dotc.ast.Positioned
 import reporting._
 
 import scala.util.control.NonFatal
@@ -55,6 +56,7 @@ class Driver {
     val summary = CompilerCommand.distill(args)(ctx)
     ctx.setSettings(summary.sstate)
     MacroClassLoader.init(ctx)
+    Positioned.updateDebugPos(ctx)
 
     if (!ctx.settings.YdropComments.value(ctx) || ctx.mode.is(Mode.ReadComments)) {
       ctx.setProperty(ContextDoc, new ContextDocstrings)

--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -23,11 +23,14 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Pro
    */
   def uniqueId: Int = myUniqueId
 
-  private def uniqueId_=(id: Int): Unit = {
-    // FOR DEBUGGING
-    // assert(id != 2523, this)
-    // if (id == 1234) new Throwable().printStackTrace()
-    
+  def uniqueId_=(id: Int): Unit = {
+    if (Positioned.debugId == id) {
+      def printTrace() = {
+        val stack = Thread.currentThread().getStackTrace().map(">   " + _)
+        System.err.println(stack.mkString(s"> Debug tree (id=${Positioned.debugId}) creation \n> $this\n", "\n", "\n"))
+      }
+      printTrace()
+    }
     myUniqueId = id
   }
 
@@ -227,5 +230,13 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Pro
     case ex: AssertionError =>
       println(i"error while checking $this")
       throw ex
+  }
+}
+
+object Positioned {
+  @sharable private[Positioned] var debugId = Int.MinValue
+
+  def updateDebugPos(implicit ctx: Context): Unit = {
+    debugId = ctx.settings.YdebugTreeWithId.value
   }
 }

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -102,6 +102,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val YdebugMissingRefs: Setting[Boolean] = BooleanSetting("-Ydebug-missing-refs", "Print a stacktrace when a required symbol is missing")
   val YdebugNames: Setting[Boolean] = BooleanSetting("-Ydebug-names", "Show internal representation of names")
   val YdebugPos: Setting[Boolean] = BooleanSetting("-Ydebug-pos", "Show full source positions including spans")
+  val YdebugTreeWithId: Setting[Int] = IntSetting("-Ydebug-tree-with-id", "Print the stack trace when the tree with the given id is created", Int.MinValue)
   val YtermConflict: Setting[String] = ChoiceSetting("-Yresolve-term-conflict", "strategy", "Resolve term conflicts", List("package", "object", "error"), "error")
   val Ylog: Setting[List[String]] = PhasesSetting("-Ylog", "Log operations during")
   val YemitTastyInClass: Setting[Boolean] = BooleanSetting("-Yemit-tasty-in-class", "Generate tasty in the .class file and add an empty *.hasTasty file.")


### PR DESCRIPTION
This postion allow descovering the place creation of a tree given its unique id.
Adding is as a setting to simplify debuging on a released version of dotty.