### PR TITLE
Add infrastructure to run the JUnit tests of upstream Scala.js.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,7 @@ pipeline:
     image: lampepfl/dotty:2019-04-22
     commands:
       - cp -R . /tmp/2/ && cd /tmp/2/
-      - ./project/scripts/sbt ";dotty-bootstrapped/compile ;dotty-bootstrapped/test; dotty-semanticdb/compile; dotty-semanticdb/test:compile;sjsSandbox/run;sjsSandbox/test"
+      - ./project/scripts/sbt ";dotty-bootstrapped/compile ;dotty-bootstrapped/test; dotty-semanticdb/compile; dotty-semanticdb/test:compile;sjsSandbox/run;sjsSandbox/test;sjsJUnitTests/test"
       - ./project/scripts/bootstrapCmdTests
 
   community_build:

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val `dotty-compiler` = Build.`dotty-compiler`
 val `dotty-compiler-bootstrapped` = Build.`dotty-compiler-bootstrapped`
 val `dotty-library` = Build.`dotty-library`
 val `dotty-library-bootstrapped` = Build.`dotty-library-bootstrapped`
+val `dotty-library-bootstrappedJS` = Build.`dotty-library-bootstrappedJS`
 val `dotty-sbt-bridge` = Build.`dotty-sbt-bridge`
 val `dotty-sbt-bridge-tests` = Build.`dotty-sbt-bridge-tests`
 val `dotty-language-server` = Build.`dotty-language-server`
@@ -23,6 +24,7 @@ val `dist-bootstrapped` = Build.`dist-bootstrapped`
 val `community-build` = Build.`community-build`
 
 val sjsSandbox = Build.sjsSandbox
+val sjsJUnitTests = Build.sjsJUnitTests
 
 val `sbt-dotty` = Build.`sbt-dotty`
 val `vscode-dotty` = Build.`vscode-dotty`

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -981,8 +981,9 @@ class JSCodeGen()(implicit ctx: Context) {
                 currentMethodSym.get.owner == qualifier.symbol &&
                 qualifier.isInstanceOf[This]
             )
-            if (!sym.is(Mutable) && !ctorAssignment)
-              throw new FatalError(s"Assigning to immutable field ${sym.fullName} at $pos")
+            // TODO This fails for OFFSET$x fields. Re-enable when we can.
+            /*if (!sym.is(Mutable) && !ctorAssignment)
+              throw new FatalError(s"Assigning to immutable field ${sym.fullName} at $pos")*/
 
             val genQual = genExpr(qualifier)
 

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -862,7 +862,10 @@ class JSCodeGen()(implicit ctx: Context) {
         }, label)
 
       case WhileDo(cond, body) =>
-        js.While(genExpr(cond), genStat(body))
+        val genCond =
+          if (cond == EmptyTree) js.BooleanLiteral(true)
+          else genExpr(cond)
+        js.While(genCond, genStat(body))
 
       case t: Try =>
         genTry(t, isStat)

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -947,8 +947,8 @@ class JSCodeGen()(implicit ctx: Context) {
             js.Null()
           case ClazzTag =>
             genClassConstant(value.typeValue)
-          /*case EnumTag =>
-            genStaticMember(value.symbolValue)*/
+          case EnumTag =>
+            genLoadStaticField(value.symbolValue)
         }
 
       case Block(stats, expr) =>

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -446,8 +446,8 @@ class JSCodeGen()(implicit ctx: Context) {
     assert(currentClassSym.get == classSym,
         "genClassFields called with a ClassDef other than the current one")
 
-    // Non-method term members are fields
-    classSym.info.decls.filter(f => !f.is(Method) && f.isTerm).map({ f =>
+    // Term members that are neither methods nor modules are fields
+    classSym.info.decls.filter(f => !f.is(Method | Module) && f.isTerm).map({ f =>
       implicit val pos = f.span
 
       val name =

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -1012,8 +1012,10 @@ class JSCodeGen()(implicit ctx: Context) {
         genJavaSeqLiteral(javaSeqLiteral)
 
       /** A Match reaching the backend is supposed to be optimized as a switch */
-      /*case mtch: Match =>
-        genMatch(mtch, isStat)*/
+      case mtch: Match =>
+        // TODO Correctly handle `Match` nodes
+        //genMatch(mtch, isStat)
+        js.Throw(js.Null())
 
       case tree: Closure =>
         genClosure(tree)

--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -59,6 +59,8 @@ final class JSDefinitions()(implicit ctx: Context) {
   lazy val JavaScriptExceptionType: TypeRef = ctx.requiredClassRef("scala.scalajs.js.JavaScriptException")
   def JavaScriptExceptionClass(implicit ctx: Context) = JavaScriptExceptionType.symbol.asClass
 
+  lazy val JSGlobalScopeAnnotType: TypeRef = ctx.requiredClassRef("scala.scalajs.js.annotation.JSGlobalScope")
+  def JSGlobalScopeAnnot(implicit ctx: Context) = JSGlobalScopeAnnotType.symbol.asClass
   lazy val JSNameAnnotType: TypeRef = ctx.requiredClassRef("scala.scalajs.js.annotation.JSName")
   def JSNameAnnot(implicit ctx: Context) = JSNameAnnotType.symbol.asClass
   lazy val JSFullNameAnnotType: TypeRef = ctx.requiredClassRef("scala.scalajs.js.annotation.JSFullName")
@@ -89,6 +91,8 @@ final class JSDefinitions()(implicit ctx: Context) {
 
   lazy val JSDynamicModuleRef = ctx.requiredModuleRef("scala.scalajs.js.Dynamic")
   def JSDynamicModule(implicit ctx: Context) = JSDynamicModuleRef.symbol
+    lazy val JSDynamic_globalR = JSDynamicModule.requiredMethodRef("global")
+    def JSDynamic_global(implicit ctx: Context) = JSDynamic_globalR.symbol
     lazy val JSDynamic_newInstanceR = JSDynamicModule.requiredMethodRef("newInstance")
     def JSDynamic_newInstance(implicit ctx: Context) = JSDynamic_newInstanceR.symbol
 

--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -206,13 +206,48 @@ object JSEncoding {
        */
       ir.Definitions.BoxedUnitClass
     } else {
-      ir.Definitions.encodeClassName(sym.fullName.toString)
+      ir.Definitions.encodeClassName(fullyMangledString(sym.fullName))
     }
   }
 
   private def encodeMemberNameInternal(sym: Symbol)(
       implicit ctx: Context): String = {
-    sym.name.toString.replace("_", "$und").replace("~", "$tilde")
+    fullyMangledString(sym.name)
+  }
+
+  /** Work around https://github.com/lampepfl/dotty/issues/5936 by bridging
+   *  most (all?) of the gap in encoding so that Dotty.js artifacts are
+   *  compatible with the restrictions on valid IR identifier names.
+   */
+  private def fullyMangledString(name: Name): String = {
+    val base = name.mangledString
+    val len = base.length
+
+    // slow path
+    def encodeFurther(): String = {
+      val result = new java.lang.StringBuilder()
+      var i = 0
+      while (i != len) {
+        val c = base.charAt(i)
+        if (c == '_')
+          result.append("$und")
+        else if (Character.isJavaIdentifierPart(c) || c == '.')
+          result.append(c)
+        else
+          result.append("$u%04x".format(c.toInt))
+        i += 1
+      }
+      result.toString()
+    }
+
+    var i = 0
+    while (i != len) {
+      val c = base.charAt(i)
+      if (c == '_' || !Character.isJavaIdentifierPart(c))
+        return encodeFurther()
+      i += 1
+    }
+    base
   }
 
   def toIRType(tp: Type)(implicit ctx: Context): jstpe.Type = {

--- a/compiler/src/dotty/tools/backend/sjs/JSPrimitives.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSPrimitives.scala
@@ -41,6 +41,9 @@ object JSPrimitives {
 
   final val LastJSPrimitiveCode = THROW
 
+  def isJSPrimitive(code: Int): Boolean =
+    code >= FirstJSPrimitiveCode && code <= LastJSPrimitiveCode
+
 }
 
 class JSPrimitives(ctx: Context) extends DottyPrimitives(ctx) {

--- a/project/ConstantHolderGenerator.scala
+++ b/project/ConstantHolderGenerator.scala
@@ -1,0 +1,44 @@
+import scala.annotation.tailrec
+
+import sbt._
+
+import org.scalajs.ir.ScalaJSVersions
+
+object ConstantHolderGenerator {
+  /** Generate a *.scala file that contains the given values as literals. */
+  def generate(dir: File, fqn: String, values: (String, Any)*): Seq[File] = {
+    val (fullPkg@(_ :+ pkg)) :+ objectName = fqn.split('.').toSeq
+
+    val out = dir / (objectName + ".scala")
+
+    val defs = for {
+      (name, value) <- values
+    } yield {
+      s"val $name = ${literal(value)}"
+    }
+
+    val scalaCode =
+      s"""
+      package ${fullPkg.mkString(".")}
+
+      private[$pkg] object $objectName {
+        ${defs.mkString("\n")}
+      }
+      """
+
+    IO.write(out, scalaCode)
+
+    Seq(out)
+  }
+
+  @tailrec
+  private final def literal(v: Any): String = v match {
+    case s: String  => "raw\"\"\"" + s + "\"\"\""
+    case b: Boolean => b.toString
+    case f: File    => literal(f.getAbsolutePath)
+
+    case _ =>
+      throw new IllegalArgumentException(
+          "Unsupported value type: " + v.getClass)
+  }
+}


### PR DESCRIPTION
And fix a number of bugs, just enough to be able to compile and successfully run `compiler/IntTest.scala`.

~~Based on #6304 and #6366.~~