### PR TITLE
Fix #6341: Revise purity checking

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -367,7 +367,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   }
 
   /** The purity level of this expression.
-   *  @return   SimplyPure  if expression has no side effects and cannot contain local definitions
+   *  @return   SimplyPure  if expression has no side effects is a path
    *            Pure        if expression has no side effects
    *            Idempotent  if running the expression a second time has no side effects
    *            Impure      otherwise
@@ -381,16 +381,15 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
     case EmptyTree
        | This(_)
        | Super(_, _)
-       | Literal(_)
-       | Closure(_, _, _) =>
+       | Literal(_) =>
       SimplyPure
     case Ident(_) =>
       refPurity(tree)
     case Select(qual, _) =>
       if (tree.symbol.is(Erased)) Pure
       else refPurity(tree).min(exprPurity(qual))
-    case New(_) =>
-      SimplyPure
+    case New(_) | Closure(_, _, _) =>
+      Pure
     case TypeApply(fn, _) =>
       if (fn.symbol.is(Erased)) Pure else exprPurity(fn)
     case Apply(fn, args) =>

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -423,10 +423,21 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
 
   private def minOf(l0: PurityLevel, ls: List[PurityLevel]) = (l0 /: ls)(_ `min` _)
 
-  def isPurePath(tree: Tree)(implicit ctx: Context): Boolean = exprPurity(tree) == PurePath
-  def isPureExpr(tree: Tree)(implicit ctx: Context): Boolean = exprPurity(tree) >= Pure
-  def isIdempotentExpr(tree: Tree)(implicit ctx: Context): Boolean = exprPurity(tree) >= Idempotent
-  def isIdempotentPath(tree: Tree)(implicit ctx: Context): Boolean = exprPurity(tree) >= IdempotentPath
+  def isPurePath(tree: Tree)(implicit ctx: Context): Boolean = tree.tpe match {
+    case tpe: ConstantType => exprPurity(tree) >= Pure
+    case _ => exprPurity(tree) == PurePath
+  }
+
+  def isPureExpr(tree: Tree)(implicit ctx: Context): Boolean =
+    exprPurity(tree) >= Pure
+
+  def isIdempotentPath(tree: Tree)(implicit ctx: Context): Boolean = tree.tpe match {
+    case tpe: ConstantType => exprPurity(tree) >= Idempotent
+    case _ => exprPurity(tree) >= IdempotentPath
+  }
+
+  def isIdempotentExpr(tree: Tree)(implicit ctx: Context): Boolean =
+    exprPurity(tree) >= Idempotent
 
   def isPureBinding(tree: Tree)(implicit ctx: Context): Boolean = statPurity(tree) >= Pure
 

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -367,15 +367,6 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   }
 
   /** The purity level of this expression. See docs for PurityLevel for what that means
-   *  @return   A possibly combination of
-   *
-   *            Path        if expression is at least idempotent and is a path
-   *
-   *            Pure        if expression has no side effects
-   *            Idempotent  if running the expression a second time has no side effects
-   *
-   *            Pure implies Idempotent.
-   *            Impure designates the empty combination.
    *
    *  Note that purity and idempotency are treated differently.
    *  References to modules and lazy vals are impure (side-effecting) both because

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -366,7 +366,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
       // But if we do that the repl/vars test break. Need to figure out why that's the case.
   }
 
-  /** The purity level of this expression.
+  /** The purity level of this expression. See docs for PurityLevel for what that means
    *  @return   A possibly combination of
    *
    *            Path        if expression is at least idempotent and is a path
@@ -857,16 +857,29 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
 }
 
 object TreeInfo {
+  /** A purity level is represented as a bitset (expressed as an Int) */
   class PurityLevel(val x: Int) extends AnyVal {
+    /** `this` contains the bits of `that` */
     def >= (that: PurityLevel): Boolean = (x & that.x) == that.x
+
+    /** The intersection of the bits of `this` and `that` */
     def min(that: PurityLevel): PurityLevel = new PurityLevel(x & that.x)
   }
 
+  /** An expression is a stable path. Requires that expression is at least idempotent */
   val Path: PurityLevel = new PurityLevel(4)
+
+  /** The expression has no side effects */
   val Pure: PurityLevel = new PurityLevel(3)
+
+  /** Running the expression a second time has no side effects. Implied by `Pure`. */
   val Idempotent: PurityLevel = new PurityLevel(1)
+
   val Impure: PurityLevel = new PurityLevel(0)
 
-  val PurePath: PurityLevel = new PurityLevel(7)
-  val IdempotentPath: PurityLevel = new PurityLevel(5)
+  /** A stable path that is evaluated without side effects */
+  val PurePath: PurityLevel = new PurityLevel(Pure.x | Path.x)
+
+  /** A stable path that is also idempotent */
+  val IdempotentPath: PurityLevel = new PurityLevel(Idempotent.x | Path.x)
 }

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -121,12 +121,10 @@ abstract class Lifter {
    *     val x0 = pre
    *     x0.f(...)
    *
-   *  unless `pre` is a `New` or `pre` is idempotent.
+   *  unless `pre` is idempotent.
    */
-  def liftPrefix(defs: mutable.ListBuffer[Tree], tree: Tree)(implicit ctx: Context): Tree = tree match {
-    case New(_) => tree
-    case _ => if (isIdempotentExpr(tree)) tree else lift(defs, tree)
-  }
+  def liftPrefix(defs: mutable.ListBuffer[Tree], tree: Tree)(implicit ctx: Context): Tree = 
+    if (isIdempotentExpr(tree)) tree else lift(defs, tree)
 }
 
 /** No lifting at all */
@@ -142,7 +140,7 @@ object LiftImpure extends LiftImpure
 
 /** Lift all impure or complex arguments */
 class LiftComplex extends Lifter {
-  def noLift(expr: tpd.Tree)(implicit ctx: Context): Boolean = tpd.isSimplyPure(expr)
+  def noLift(expr: tpd.Tree)(implicit ctx: Context): Boolean = tpd.isPurePath(expr)
   override def exprLifter: Lifter = LiftToDefs
 }
 object LiftComplex extends LiftComplex

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -285,7 +285,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       (tp.paramNames, tp.paramInfos, argss.head).zipped.foreach { (name, paramtp, arg) =>
         paramSpan(name) = arg.span
         paramBinding(name) = arg.tpe.dealias match {
-          case _: SingletonType if isIdempotentExpr(arg) => arg.tpe
+          case _: SingletonType if isIdempotentPath(arg) => arg.tpe
           case _ => paramBindingDef(name, paramtp, arg, bindingsBuf).symbol.termRef
         }
       }

--- a/tests/run/i6341.scala
+++ b/tests/run/i6341.scala
@@ -1,0 +1,7 @@
+object Test extends App {
+  class Config(val t1: Int)
+
+  inline def m(t2:Int) = t2
+
+  m(new Config(3).t1)
+}


### PR DESCRIPTION
There is some confusion on terminology that needs to be fixed.

Step 1: Make SimplyPure apply to paths only.

The only point where it is used is in eta expansion to answer the question
whether in a partial application `f(e, _)` the expression `e` should be
lifted out, giving `{ val x = e; y => f(x, y) }` instead of `y => f(e, y)`.
With the change, closures and new expressions are never simply pure, so
are always lifted out. This can reduce the number of allocations, if the
lambda is applied several times.

Step 2: Split the property that something is a path from the property that something is pure, or idempotent.

Step 3: Require an idempotent _path_ in the critical Inliner code.
