### PR TITLE
Fix smooth scrolling on index doc page

### DIFF
--- a/docs/css/default.css
+++ b/docs/css/default.css
@@ -6,6 +6,7 @@
 
 html, body {
     box-sizing: border-box;
+    scroll-behavior: smooth;
 }
 
 *, *:before, *:after {

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -1,21 +1,4 @@
 $(document).ready(function() {
     window.sr = ScrollReveal();
     sr.reveal(".scala-logo-container",  { duration: 2000, delay: 100, mobile: false });
-
-    var hostname = new RegExp(location.host);
-    $('a').each(function(){
-        var url = $(this).attr("href");
-        if (hostname.test(url) || url.slice(0, 1) == "#")
-            $(this).addClass('local');
-    });
-
-    $("a").on('click', function(event) {
-        if ($(this).hasClass("local") && this.hash != "") {
-            event.preventDefault();
-            var hash = this.hash;
-            $('html, body').animate({ scrollTop: $(hash).offset().top }, 800, function() {
-                window.location.hash = hash;
-            });
-        }
-    });
 });


### PR DESCRIPTION
Somehow the animation with Javascript was broken, as it scrolled up the
top and than jupped the actual target.
Since ~70% of all browser support this with pure CSS today, this should
be good enough for this minor feature.

The 'local' class was only used within JavaScript so it was dropped.