### PR TITLE
Accept underscore as numeric literal separator

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaScanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaScanners.scala
@@ -521,7 +521,7 @@ object JavaScanners {
       case FLOATLIT =>
         "float(" + floatVal + ")"
       case DOUBLELIT =>
-        "double(" + floatVal + ")"
+        "double(" + doubleVal + ")"
       case STRINGLIT =>
         "string(" + name + ")"
       case SEMI =>

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -726,7 +726,7 @@ object Parsers {
           case INTLIT                 => in.intVal(isNegated).toInt
           case LONGLIT                => in.intVal(isNegated)
           case FLOATLIT               => in.floatVal(isNegated).toFloat
-          case DOUBLELIT              => in.floatVal(isNegated)
+          case DOUBLELIT              => in.doubleVal(isNegated)
           case STRINGLIT | STRINGPART => in.strVal
           case TRUE                   => true
           case FALSE                  => false

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -508,6 +508,8 @@ object Scanners {
             if (ch == 'x' || ch == 'X') {
               nextChar()
               base = 16
+              if (isNumberSeparator(ch))
+                errorButContinue("leading separator is not allowed", offset + 2)
             } else {
               /**
                * What should leading 0 be in the future? It is potentially dangerous

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -67,9 +67,13 @@ object Scanners {
 
     /** Generate an error at the given offset */
     def error(msg: String, off: Offset = offset): Unit = {
-      ctx.error(msg, source atSpan Span(off))
+      errorButContinue(msg, off)
       token = ERROR
       errOffset = off
+    }
+
+    def errorButContinue(msg: String, off: Offset = offset): Unit = {
+      ctx.error(msg, source atSpan Span(off))
     }
 
     /** signal an error where the input ended in the middle of a token */
@@ -129,19 +133,22 @@ object Scanners {
         var i = 0
         val len = strVal.length
         while (i < len) {
-          val d = digit2int(strVal charAt i, base)
-          if (d < 0) {
-            error("malformed integer number")
-            return 0
+          val c = strVal charAt i
+          if (! isNumberSeparator(c)) {
+            val d = digit2int(c, base)
+            if (d < 0) {
+              error(s"malformed integer number")
+              return 0
+            }
+            if (value < 0 ||
+              limit / (base / divider) < value ||
+              limit - (d / divider) < value * (base / divider) &&
+                !(negated && limit == value * base - 1 + d)) {
+              error("integer number too large")
+              return 0
+            }
+            value = value * base + d
           }
-          if (value < 0 ||
-            limit / (base / divider) < value ||
-            limit - (d / divider) < value * (base / divider) &&
-              !(negated && limit == value * base - 1 + d)) {
-            error("integer number too large")
-            return 0
-          }
-          value = value * base + d
           i += 1
         }
         if (negated) -value else value
@@ -153,10 +160,11 @@ object Scanners {
     /** Convert current strVal, base to double value
       */
     def floatVal(negated: Boolean): Double = {
+      val text = removeNumberSeparators(strVal)
       val limit: Double =
         if (token == DOUBLELIT) Double.MaxValue else Float.MaxValue
       try {
-        val value: Double = java.lang.Double.valueOf(strVal).doubleValue()
+        val value: Double = java.lang.Double.valueOf(text).doubleValue()
         if (value > limit)
           error("floating point number too large")
         if (negated) -value else value
@@ -168,6 +176,17 @@ object Scanners {
     }
 
     def floatVal: Double = floatVal(false)
+
+    @inline def isNumberSeparator(c: Char): Boolean = c == '_'
+
+    @inline def removeNumberSeparators(s: String): String =
+      if (s.indexOf('_') > 0) s.replaceAllLiterally("_", "") /*.replaceAll("'","")*/ else s
+
+    // disallow trailing numeric separator char, but continue lexing
+    def checkNoTrailingSeparator(): Unit = {
+      if (isNumberSeparator(litBuf.last))
+        errorButContinue("trailing separator is not allowed", offset + litBuf.length - 1)
+    }
 
   }
 
@@ -911,27 +930,29 @@ object Scanners {
      */
     protected def getFraction(): Unit = {
       token = DOUBLELIT
-      while ('0' <= ch && ch <= '9') {
+      while ('0' <= ch && ch <= '9' || isNumberSeparator(ch)) {
         putChar(ch)
         nextChar()
       }
+      checkNoTrailingSeparator()
       if (ch == 'e' || ch == 'E') {
         val lookahead = lookaheadReader()
         lookahead.nextChar()
         if (lookahead.ch == '+' || lookahead.ch == '-') {
           lookahead.nextChar()
         }
-        if ('0' <= lookahead.ch && lookahead.ch <= '9') {
+        if ('0' <= lookahead.ch && lookahead.ch <= '9' || isNumberSeparator(ch)) {
           putChar(ch)
           nextChar()
           if (ch == '+' || ch == '-') {
             putChar(ch)
             nextChar()
           }
-          while ('0' <= ch && ch <= '9') {
+          while ('0' <= ch && ch <= '9' || isNumberSeparator(ch)) {
             putChar(ch)
             nextChar()
           }
+          checkNoTrailingSeparator()
         }
         token = DOUBLELIT
       }
@@ -954,15 +975,18 @@ object Scanners {
     /** Read a number into strVal and set base
     */
     protected def getNumber(): Unit = {
-      while (digit2int(ch, base) >= 0) {
+      while (isNumberSeparator(ch) || digit2int(ch, base) >= 0) {
         putChar(ch)
         nextChar()
       }
+      checkNoTrailingSeparator()
       token = INTLIT
       if (base == 10 && ch == '.') {
         val lch = lookaheadChar()
         if ('0' <= lch && lch <= '9') {
-          putChar('.'); nextChar(); getFraction()
+          putChar('.')
+          nextChar()
+          getFraction()
         }
       } else (ch: @switch) match {
         case 'e' | 'E' | 'f' | 'F' | 'd' | 'D' =>
@@ -972,6 +996,9 @@ object Scanners {
           token = LONGLIT
         case _ =>
       }
+
+      checkNoTrailingSeparator()
+
       setStrVal()
     }
 

--- a/tests/neg/t6124.check
+++ b/tests/neg/t6124.check
@@ -1,3 +1,5 @@
+<304..304> in t6124.scala
+double precision floating point number too small
 <273..273> in t6124.scala
 trailing separator is not allowed
 <235..235> in t6124.scala

--- a/tests/neg/t6124.check
+++ b/tests/neg/t6124.check
@@ -1,0 +1,20 @@
+<273..273> in t6124.scala
+trailing separator is not allowed
+<235..235> in t6124.scala
+Invalid literal number
+<240..240> in t6124.scala
+trailing separator is not allowed
+<213..213> in t6124.scala
+trailing separator is not allowed
+<187..187> in t6124.scala
+trailing separator is not allowed
+<160..160> in t6124.scala
+trailing separator is not allowed
+<125..125> in t6124.scala
+Invalid literal number
+<101..101> in t6124.scala
+trailing separator is not allowed
+<67..67> in t6124.scala
+trailing separator is not allowed
+<33..33> in t6124.scala
+trailing separator is not allowed

--- a/tests/neg/t6124.check
+++ b/tests/neg/t6124.check
@@ -1,22 +1,34 @@
-<304..304> in t6124.scala
+[490..493] in t6124.scala
+Not found: _52
+[404..406..412] in t6124.scala
+value _1415F is not a member of Int
+<594..594> in t6124.scala
+trailing separator is not allowed
+<567..567> in t6124.scala
+leading separator is not allowed
+<540..540> in t6124.scala
+trailing separator is not allowed
+<516..516> in t6124.scala
+trailing separator is not allowed
+<467..467> in t6124.scala
+trailing separator is not allowed
+<375..375> in t6124.scala
+trailing separator is not allowed
+<228..228> in t6124.scala
 double precision floating point number too small
-<273..273> in t6124.scala
+<197..197> in t6124.scala
 trailing separator is not allowed
-<235..235> in t6124.scala
+<159..159> in t6124.scala
 Invalid literal number
-<240..240> in t6124.scala
+<164..164> in t6124.scala
 trailing separator is not allowed
-<213..213> in t6124.scala
+<137..137> in t6124.scala
 trailing separator is not allowed
-<187..187> in t6124.scala
+<111..111> in t6124.scala
 trailing separator is not allowed
-<160..160> in t6124.scala
+<84..84> in t6124.scala
 trailing separator is not allowed
-<125..125> in t6124.scala
+<49..49> in t6124.scala
 Invalid literal number
-<101..101> in t6124.scala
-trailing separator is not allowed
-<67..67> in t6124.scala
-trailing separator is not allowed
-<33..33> in t6124.scala
+<25..25> in t6124.scala
 trailing separator is not allowed

--- a/tests/neg/t6124.scala
+++ b/tests/neg/t6124.scala
@@ -12,5 +12,7 @@ trait T {
   def r = 3.1_4_dd // error // error
   def s = 3_.1 // error
 
+  def tooSmall = 1.0E-325 // error
+
   def z = 0
 }

--- a/tests/neg/t6124.scala
+++ b/tests/neg/t6124.scala
@@ -1,8 +1,5 @@
 
 trait T {
-  def i: Int = 123_456_ // error
-  def j: Long = 123_456_L * 1000 // error
-
   def f = 3_14_E-2 // error
   def e = 3_14E-_2 // error
   def d = 3_14E-2_ // error
@@ -13,6 +10,20 @@ trait T {
   def s = 3_.1 // error
 
   def tooSmall = 1.0E-325 // error
+
+  // Examples from
+  // https://docs.oracle.com/javase/8/docs/technotes/guides/language/underscores-literals.html
+
+  val pi1 = 3_.1415F // error
+  val pi2 = 3._1415F // error
+  val socialSecurityNumber1
+    = 999_99_9999_L // error
+  val x1 = _52 // error
+  val x3 = 52_ // error
+
+  val x5 = 0_x52 // error
+  val x6 = 0x_52 // error
+  val x8 = 0x52_ // error
 
   def z = 0
 }

--- a/tests/neg/t6124.scala
+++ b/tests/neg/t6124.scala
@@ -1,0 +1,16 @@
+
+trait T {
+  def i: Int = 123_456_ // error
+  def j: Long = 123_456_L * 1000 // error
+
+  def f = 3_14_E-2 // error
+  def e = 3_14E-_2 // error
+  def d = 3_14E-2_ // error
+
+  def p = 3.1_4_ // error
+  def q = 3.1_4_d // error
+  def r = 3.1_4_dd // error // error
+  def s = 3_.1 // error
+
+  def z = 0
+}

--- a/tests/pos/t6124.scala
+++ b/tests/pos/t6124.scala
@@ -8,4 +8,11 @@ trait T {
   def d = 3_14E-2_1
 
   def z = 0
+
+
+  // Examples from
+  // https://docs.oracle.com/javase/8/docs/technotes/guides/language/underscores-literals.html
+  val x2 = 5_2;              // OK (decimal literal)
+  val x4 = 5_______2;        // OK (decimal literal)
+  val x7 = 0x5_2;            // OK (hexadecimal literal)
 }

--- a/tests/pos/t6124.scala
+++ b/tests/pos/t6124.scala
@@ -1,0 +1,11 @@
+
+trait T {
+  def i: Int = 1_024
+  def j: Long = 1_024L * 1_024
+  //def k = 1'024
+
+  def f = 3_14e-2f
+  def d = 3_14E-2_1
+
+  def z = 0
+}


### PR DESCRIPTION
This is a port of scala/scala#6989 and should close #6332.

The syntax documentation wasn't update in the original patch, so I tried to fix it. While doing so I found a (corner?) case where Scala and Dotty with this patch behave differently: The float literal `0_1.1` fails in Scala but is OK here. The integer `0_1` is OK for both Scala and Dotty. I found no case where Dotty coudn't parse a valid Scala number literal.

I think the behaviour of Dotty is right more consistent, but I not sure how such issues should be resolved. 