### PR TITLE
Fix interaction between by-name implicits and inlining

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1619,7 +1619,7 @@ final class SearchRoot extends SearchHistory {
             // Substitute dictionary references into dictionary entry RHSs
             val rhsMap = new TreeTypeMap(treeMap = {
               case id: Ident if vsymMap.contains(id.symbol) =>
-                tpd.ref(vsymMap(id.symbol)).withSpan(id.span)
+                tpd.ref(vsymMap(id.symbol))
               case tree => tree
             })
             val nrhss = rhss.map(rhsMap(_))
@@ -1643,7 +1643,7 @@ final class SearchRoot extends SearchHistory {
 
             val res = resMap(tree)
 
-            val blk = Block(classDef :: inst :: Nil, res)
+            val blk = Inliner.reposition(Block(classDef :: inst :: Nil, res), span)
 
             success.copy(tree = blk)(success.tstate, success.gstate)
           }

--- a/tests/pos/inline-separate/A_1.scala
+++ b/tests/pos/inline-separate/A_1.scala
@@ -1,0 +1,5 @@
+object A {
+  inline def summon[T] = implicit match {
+    case t: T => t
+  }
+}

--- a/tests/pos/inline-separate/Test_2.scala
+++ b/tests/pos/inline-separate/Test_2.scala
@@ -1,0 +1,7 @@
+import A._
+object Test extends App {
+  class Foo(f: => Foo)
+  inline implicit def foo(implicit f: => Foo): Foo = new Foo(summon[Foo])
+  def summonFoo(implicit ev: Foo): Foo = ev
+  summonFoo
+}


### PR DESCRIPTION
The construction of the dictionaries needed to support recursive by-name implicit arguments requires trees to be hoisted out of the arguments as they are elaborated. Moving trees around in this way has always been a delicate operation because of the need to maintain correct owner chains.

Inlining and the position checking phase added in 69cf220 complicates this still further because we now have to make the source associated with the hoisted tree match the checkers expectations after it has been moved. This is done by reusing the repositioning logic from the inliner.

The issue this commit fixes only shows up in cases where an inline method is used as part of a by-name implicit argument resolution in a different source file.