### PR TITLE
Fix #6403: Do not intercept crashes

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -486,10 +486,10 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
       try body
       catch {
         case ex: Throwable =>
-          println(i"""|compiler bug: created invalid generic signature for $sym in ${sym.denot.owner.showFullName}
+          ctx.error(i"""|compiler bug: created invalid generic signature for $sym in ${sym.denot.owner.showFullName}
                       |signature: $sig
                       |if this is reproducible, please report bug at https://github.com/lampepfl/dotty/issues
-                   """.trim)
+                   """.trim, sym.sourcePos)
           throw  ex
       }
     }

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -482,11 +482,19 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
 
   private def verifySignature(sym: Symbol, sig: String)(implicit ctx: Context): Unit = {
     import scala.tools.asm.util.CheckClassAdapter
-    def wrap(body: => Unit): Boolean =
-      try { body; true }
-      catch { case ex: Throwable => println(ex.getMessage); false }
+    def wrap(body: => Unit): Unit = {
+      try body
+      catch {
+        case ex: Throwable =>
+          println(i"""|compiler bug: created invalid generic signature for $sym in ${sym.denot.owner.showFullName}
+                      |signature: $sig
+                      |if this is reproducible, please report bug at https://github.com/lampepfl/dotty/issues
+                   """.trim)
+          throw  ex
+      }
+    }
 
-    val valid = wrap {
+    wrap {
       if (sym.is(Flags.Method)) {
         CheckClassAdapter.checkMethodSignature(sig)
       }
@@ -496,14 +504,6 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
       else {
         CheckClassAdapter.checkClassSignature(sig)
       }
-    }
-
-    if (!valid) {
-      ctx.error(
-        i"""|compiler bug: created invalid generic signature for $sym in ${sym.denot.owner.showFullName}
-            |signature: $sig
-            |if this is reproducible, please report bug at https://github.com/lampepfl/dotty/issues
-        """.trim, sym.sourcePos)
     }
   }
 

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -180,8 +180,8 @@ class GenBCodePipeline(val entryPoints: List[Symbol], val int: DottyBackendInter
             try   { /*withCurrentUnit(item.cunit)*/(visit(item)) }
             catch {
               case ex: Throwable =>
-                ex.printStackTrace()
-                ctx.error(s"Error while emitting ${int.sourceFileFor(item.cunit)}\n${ex.getMessage}")
+                println(s"Error while emitting ${int.sourceFileFor(item.cunit)}")
+                throw ex
             }
           }
         }
@@ -414,8 +414,8 @@ class GenBCodePipeline(val entryPoints: List[Symbol], val int: DottyBackendInter
               addToQ3(item)
             } catch {
               case ex: Throwable =>
-                ex.printStackTrace()
-                ctx.error(s"Error while emitting ${item.plain.classNode.name}\n${ex.getMessage}")
+                println(s"Error while emitting ${item.plain.classNode.name}")
+                throw ex
             }
           }
         }

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -852,19 +852,14 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     extends Test(testSources, times, threadLimit, suppressAllOutput) {
     protected def encapsulatedCompilation(testSource: TestSource) = new LoggedRunnable {
       def checkTestSource(): Unit = tryCompile(testSource) {
-        def fail(msg: String): Nothing = {
+        def fail(msg: String): Unit = {
           echo(msg)
           failTestSource(testSource)
-          ???
         }
         testSource match {
           case testSource@JointCompilationSource(_, files, flags, outDir, fromTasty, decompilation) =>
             val sourceFiles = testSource.sourceFiles
-            val reporter =
-              try compile(sourceFiles, flags, true, outDir)
-              catch {
-                case ex: Throwable => fail(s"Fatal compiler crash when compiling: ${testSource.title}")
-              }
+            val reporter = compile(sourceFiles, flags, true, outDir)
             if (reporter.compilerCrashed)
               fail(s"Compiler crashed when compiling: ${testSource.title}")
           case testSource@SeparateCompilationSource(_, dir, flags, outDir) => unsupported("NoCrashTest - SeparateCompilationSource")


### PR DESCRIPTION
Emitting an error when the backend crashes hides the crash from the reporter and fails which cannot be identified by the testing framework.