### PR TITLE
Turn off Scala 2.12 CI tests outside of merges

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -58,6 +58,8 @@ pipeline:
     commands:
       - cp -R . /tmp/5/ && cd /tmp/5/
       - ./project/scripts/sbt ";++2.12.8 ;compile ;test"
+    when:
+      event: [ tag, deployment ]
 
   # DOCUMENTATION:
   documentation:


### PR DESCRIPTION
The extra load is killing our CI.