### PR TITLE
Actuall run the 2.12 tests on merge, not just on nightly

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,7 @@ pipeline:
       - cp -R . /tmp/5/ && cd /tmp/5/
       - ./project/scripts/sbt ";++2.12.8 ;compile ;test"
     when:
-      event: [ tag, deployment ]
+      event: [ push, tag, deployment ]
 
   # DOCUMENTATION:
   documentation:


### PR DESCRIPTION
I made a mistake in https://github.com/lampepfl/dotty/pull/6409.