### PR TITLE
 Fix #5895: REPL autocompletion crashes in certain cases

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -241,7 +241,7 @@ class ReplCompiler extends Compiler {
         PackageDef(Ident(nme.EMPTY_PACKAGE), List(wrapper))
       }
 
-      ParseResult(expr)(state) match {
+      ParseResult(sourceFile)(state) match {
         case Parsed(_, trees) =>
           wrap(trees).result
         case SyntaxErrors(_, reported, trees) =>

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -124,4 +124,8 @@ class TabcompleteTests extends ReplTest {
     val comp = tabComplete("???.")
     assertEquals(Nil, comp)
   }
+
+  @Test def moduleCompletion = fromInitialState { implicit s =>
+    assertEquals(List("Predef"), tabComplete("object Foo { type T = Pre"))
+  }
 }


### PR DESCRIPTION
# Crashes
The crashes happen due to the fact that in certain cases,
certain trees get mispositioned during code completion. E.g.
this happens with `opaque type T = Int` or `object Foo { type T = Int`.
The tree spans are set incorrectly because repl doesn't set the
sources of these trees correctly. Precisely, when typechecking
on code completion, a virtual source is used. However, when
parsing for autocompletion, a line source is used which is
created by the parsing logic. This commit makes sure that REPL
is consistent in its source choices when computing code completions.

# Completion
The above commit does not bring the code completion for opaque types, however.

REPL code completion computes completion candidates for a given
expression after typechecking it. Typechecking opaque types
desugars them from `<mods> type T = Int` to `<mods> type T = T.T`.
The completion relies on the position of the user's cursor
in the input expression to know what part of this expression to complete.
Since the cursor does not take the semantic info computed by typechecking,
the cursor points to `T.T` and not to `Int` on completion request.
Completion on synthetic `T.T` does not pick any candidates, which is
unexpected to the user. The expected behavior is to complete on `Int`,
the underlying type. This commit achieves the expected behavior by
making sure opaque types are treated as ordinary types on code completion.
