### PR TITLE
Fix #6419: Support @compileTimeOnly

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -858,7 +858,7 @@ class Definitions {
   lazy val TransientParamAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.constructorOnly")
   def TransientParamAnnot(implicit ctx: Context): ClassSymbol = TransientParamAnnotType.symbol.asClass
   lazy val CompileTimeOnlyAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.compileTimeOnly")
-  def CompileTimeOnlyParamAnnot(implicit ctx: Context): ClassSymbol = CompileTimeOnlyAnnotType.symbol.asClass
+  def CompileTimeOnlyAnnot(implicit ctx: Context): ClassSymbol = CompileTimeOnlyAnnotType.symbol.asClass
   lazy val SwitchAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.switch")
   def SwitchAnnot(implicit ctx: Context): ClassSymbol = SwitchAnnotType.symbol.asClass
   lazy val ThrowsAnnotType: TypeRef = ctx.requiredClassRef("scala.throws")

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -170,7 +170,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
     private object dropInlines extends TreeMap {
       override def transform(tree: Tree)(implicit ctx: Context): Tree = tree match {
         case Inlined(call, _, _) =>
-          cpy.Inlined(tree)(call, Nil, Typed(ref(defn.Predef_undefined), TypeTree(tree.tpe)))
+          cpy.Inlined(tree)(call, Nil, Typed(ref(defn.Predef_undefined), TypeTree(tree.tpe)).withSpan(tree.span))
         case _ => super.transform(tree)
       }
     }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -401,8 +401,6 @@ object Checking {
       if (!sym.is(Deferred))
         fail(NativeMembersMayNotHaveImplementation(sym))
     }
-    if (sym.hasAnnotation(defn.CompileTimeOnlyParamAnnot))
-      ctx.migrationWarning("`@compileTimeOnly(msg)` will be replaced by `scala.compiletime.error(msg)`", sym.sourcePos)
     else if (sym.is(Deferred, butNot = Param) && !sym.isType && !sym.isSelfSym) {
       if (!sym.owner.isClass || sym.owner.is(Module) || sym.owner.isAnonymousClass)
         fail(OnlyClassesCanHaveDeclaredButUndefinedMembers(sym))

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -822,16 +822,6 @@ object RefChecks {
         case _ =>
       }
     }
-    /*  (Not enabled yet)
-       *  See an explanation of compileTimeOnly in its scaladoc at scala.annotation.compileTimeOnly.
-       *
-      if (sym.isCompileTimeOnly) {
-        def defaultMsg =
-          sm"""Reference to ${sym.fullLocationString} should not have survived past type checking,
-              |it should have been processed and eliminated during expansion of an enclosing macro."""
-        // The getOrElse part should never happen, it's just here as a backstop.
-        ctx.error(sym.compileTimeOnlyMessage getOrElse defaultMsg, pos)
-      }*/
   }
 
   /** Check that a deprecated val or def does not override a

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -178,8 +178,7 @@ class CompilationTests extends ParallelTesting {
         "tests/neg-custom-args/toplevel-samesource/S.scala",
         "tests/neg-custom-args/toplevel-samesource/nested/S.scala"),
         defaultOptions),
-      compileFile("tests/neg-custom-args/i6300.scala", allowDeepSubtypes),
-      compileFile("tests/neg-custom-args/i6312.scala", defaultOptions and "-Xfatal-warnings" and "-migration")
+      compileFile("tests/neg-custom-args/i6300.scala", allowDeepSubtypes)
     ).checkExpectedErrors()
   }
 

--- a/library/src-3.x/scala/runtime/DynamicTuple.scala
+++ b/library/src-3.x/scala/runtime/DynamicTuple.scala
@@ -83,7 +83,7 @@ object DynamicTuple {
   def dynamic_*: [This <: Tuple, H] (self: Tuple, x: H): H *: This = {
     type Result = H *: This
     (self: Any) match {
-      case Unit =>
+      case () =>
         Tuple1(x).asInstanceOf[Result]
       case self: Tuple1[_] =>
         Tuple2(x, self._1).asInstanceOf[Result]

--- a/tests/neg-custom-args/i6312.scala
+++ b/tests/neg-custom-args/i6312.scala
@@ -1,6 +1,0 @@
-class Foo {
-  inline def foo: Unit = {
-    @scala.annotation.compileTimeOnly("some message") val res = ??? // error
-    res
-  }
-}

--- a/tests/neg/i6419.scala
+++ b/tests/neg/i6419.scala
@@ -1,0 +1,12 @@
+trait A {
+  @scala.annotation.compileTimeOnly("oops") def f: Int
+}
+
+class B extends A {
+  def f = 0
+}
+
+object App {
+  (new B).f
+  (new B: A).f // error
+}

--- a/tests/neg/i6419b.scala
+++ b/tests/neg/i6419b.scala
@@ -1,0 +1,12 @@
+trait A {
+  inline def f: Int = scala.compiletime.error("oops")
+}
+
+class B extends A {
+  override def f = 0
+}
+
+object App {
+  (new B).f
+  (new B: A).f // error
+}

--- a/tests/pos/i6312b.scala
+++ b/tests/pos/i6312b.scala
@@ -1,0 +1,6 @@
+class Foo {
+  inline def foo: Unit = {
+    @scala.annotation.compileTimeOnly("some message") val res = ???
+    res
+  }
+}

--- a/tests/pos/i6419.scala
+++ b/tests/pos/i6419.scala
@@ -1,0 +1,14 @@
+class Foo {
+  inline def foo: Unit = {
+    @scala.annotation.compileTimeOnly("some message") val res = ???
+    res
+  }
+
+  inline def bar: Unit = {
+    foo
+  }
+
+  erased def baz: Unit = {
+    foo
+  }
+}


### PR DESCRIPTION
Support @compileTimeOnly and remove migration waining (see https://github.com/lampepfl/dotty/issues/6419#issuecomment-489008330).