### PR TITLE
Increase tests timeout to 45 sec

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -22,7 +22,7 @@ class CompilationTests extends ParallelTesting {
 
   // Test suite configuration --------------------------------------------------
 
-  def maxDuration = 30.seconds
+  def maxDuration = 45.seconds
   def numberOfSlaves = 5
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive


### PR DESCRIPTION
This change tries to mitigate the timeouts caused by tests/run/module-serialization-proxy-class-unload.scala