### PR TITLE
Replace CompilationTest + by aggregateTests

### DIFF
--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -17,6 +17,7 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
   import ParallelTesting._
   import TestConfiguration._
   import BootstrappedOnlyCompilationTests._
+  import CompilationTest.aggregateTests
 
   // Test suite configuration --------------------------------------------------
 
@@ -31,58 +32,62 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
 
   @Test def posMacros: Unit = {
     implicit val testGroup: TestGroup = TestGroup("compilePosMacros")
-    compileFilesInDir("tests/pos-macros", defaultOptions)
-  }.checkCompile()
+    compileFilesInDir("tests/pos-macros", defaultOptions).checkCompile()
+  }
 
   @Test def posWithCompiler: Unit = {
     implicit val testGroup: TestGroup = TestGroup("compilePosWithCompiler")
-    compileFilesInDir("tests/pos-with-compiler", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/ast", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/config", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/core", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/transform", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/parsing", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/printing", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/reporting", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/typer", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/util", withCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/io", withCompilerOptions)
-  }.checkCompile()
+    aggregateTests(
+      compileFilesInDir("tests/pos-with-compiler", withCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/ast", withCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/config", withCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/core", withCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/transform", withCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/parsing", withCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/printing", withCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/reporting", withCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/typer", withCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/util", withCompilerOptions),
+      compileDir("compiler/src/dotty/tools/io", withCompilerOptions)
+    ).checkCompile()
+  }
 
   @Test def posTwiceWithCompiler: Unit = {
     implicit val testGroup: TestGroup = TestGroup("posTwiceWithCompiler")
-    compileFile("tests/pos-with-compiler/Labels.scala", withCompilerOptions) +
-    compileFile("tests/pos-with-compiler/Patterns.scala", withCompilerOptions) +
-    compileList(
-      "testNonCyclic",
-      List(
-        "compiler/src/dotty/tools/dotc/CompilationUnit.scala",
-        "compiler/src/dotty/tools/dotc/core/Types.scala",
-        "compiler/src/dotty/tools/dotc/ast/Trees.scala"
+    aggregateTests(
+      compileFile("tests/pos-with-compiler/Labels.scala", withCompilerOptions),
+      compileFile("tests/pos-with-compiler/Patterns.scala", withCompilerOptions),
+      compileList(
+        "testNonCyclic",
+        List(
+          "compiler/src/dotty/tools/dotc/CompilationUnit.scala",
+          "compiler/src/dotty/tools/dotc/core/Types.scala",
+          "compiler/src/dotty/tools/dotc/ast/Trees.scala"
+        ),
+        withCompilerOptions
       ),
-      withCompilerOptions
-    ) +
-    compileList(
-      "testIssue34",
-      List(
-        "compiler/src/dotty/tools/dotc/config/Properties.scala",
-        "compiler/src/dotty/tools/dotc/config/PathResolver.scala"
-      ),
-      withCompilerOptions
-    )
-  }.times(2).checkCompile()
+      compileList(
+        "testIssue34",
+        List(
+          "compiler/src/dotty/tools/dotc/config/Properties.scala",
+          "compiler/src/dotty/tools/dotc/config/PathResolver.scala"
+        ),
+        withCompilerOptions
+      )
+    ).times(2).checkCompile()
+  }
 
   // Negative tests ------------------------------------------------------------
 
   @Test def negMacros: Unit = {
     implicit val testGroup: TestGroup = TestGroup("compileNegWithCompiler")
-    compileFilesInDir("tests/neg-macros", defaultOptions)
-  }.checkExpectedErrors()
+    compileFilesInDir("tests/neg-macros", defaultOptions).checkExpectedErrors()
+  }
 
   @Test def negWithCompiler: Unit = {
     implicit val testGroup: TestGroup = TestGroup("compileNegWithCompiler")
-    compileFilesInDir("tests/neg-with-compiler", withCompilerOptions)
-  }.checkExpectedErrors()
+    compileFilesInDir("tests/neg-with-compiler", withCompilerOptions).checkExpectedErrors()
+  }
 
   // Run tests -----------------------------------------------------------------
 
@@ -93,10 +98,12 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
 
   @Test def runWithCompiler: Unit = {
     implicit val testGroup: TestGroup = TestGroup("runWithCompiler")
-    compileFilesInDir("tests/run-with-compiler", withCompilerOptions) +
-    compileDir("tests/run-with-compiler-custom-args/tasty-interpreter", withCompilerOptions) +
-    compileFile("tests/run-with-compiler-custom-args/staged-streams_1.scala", withCompilerOptions without "-Yno-deep-subtypes")
-  }.checkRuns()
+    aggregateTests(
+      compileFilesInDir("tests/run-with-compiler", withCompilerOptions),
+      compileDir("tests/run-with-compiler-custom-args/tasty-interpreter", withCompilerOptions),
+      compileFile("tests/run-with-compiler-custom-args/staged-streams_1.scala", withCompilerOptions without "-Yno-deep-subtypes")
+    ).checkRuns()
+  }
 
   // Pickling Tests ------------------------------------------------------------
   //
@@ -106,26 +113,28 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
   @Test def picklingWithCompiler: Unit = {
     val jvmBackendFilter = FileFilter.exclude(List("BTypes.scala", "Primitives.scala")) // TODO
     implicit val testGroup: TestGroup = TestGroup("testPicklingWithCompiler")
-    compileDir("compiler/src/dotty/tools", picklingWithCompilerOptions, recursive = false) +
-    compileDir("compiler/src/dotty/tools/dotc", picklingWithCompilerOptions, recursive = false) +
-    compileDir("library/src/dotty/runtime", picklingWithCompilerOptions) +
-    compileFilesInDir("compiler/src/dotty/tools/backend/jvm", picklingWithCompilerOptions, jvmBackendFilter) +
-    compileDir("compiler/src/dotty/tools/dotc/ast", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/core", picklingWithCompilerOptions, recursive = false) +
-    compileDir("compiler/src/dotty/tools/dotc/config", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/parsing", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/printing", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/repl", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/rewrites", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/transform", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/typer", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/util", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/io", picklingWithCompilerOptions) +
-    compileFile("tests/pos/pickleinf.scala", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/core/classfile", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/core/tasty", picklingWithCompilerOptions) +
-    compileDir("compiler/src/dotty/tools/dotc/core/unpickleScala2", picklingWithCompilerOptions)
-  }.limitThreads(4).checkCompile()
+    aggregateTests(
+      compileDir("compiler/src/dotty/tools", picklingWithCompilerOptions, recursive = false),
+      compileDir("compiler/src/dotty/tools/dotc", picklingWithCompilerOptions, recursive = false),
+      compileDir("library/src/dotty/runtime", picklingWithCompilerOptions),
+      compileFilesInDir("compiler/src/dotty/tools/backend/jvm", picklingWithCompilerOptions, jvmBackendFilter),
+      compileDir("compiler/src/dotty/tools/dotc/ast", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/core", picklingWithCompilerOptions, recursive = false),
+      compileDir("compiler/src/dotty/tools/dotc/config", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/parsing", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/printing", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/repl", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/rewrites", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/transform", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/typer", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/util", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/io", picklingWithCompilerOptions),
+      compileFile("tests/pos/pickleinf.scala", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/core/classfile", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/core/tasty", picklingWithCompilerOptions),
+      compileDir("compiler/src/dotty/tools/dotc/core/unpickleScala2", picklingWithCompilerOptions)
+    ).limitThreads(4).checkCompile()
+  }
 
   @Test def testPlugins: Unit = {
     val pluginFile = "plugin.properties"

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -19,6 +19,7 @@ class CompilationTests extends ParallelTesting {
   import ParallelTesting._
   import TestConfiguration._
   import CompilationTests._
+  import CompilationTest.aggregateTests
 
   // Test suite configuration --------------------------------------------------
 
@@ -39,174 +40,184 @@ class CompilationTests extends ParallelTesting {
 
   @Test def pos: Unit = {
     implicit val testGroup: TestGroup = TestGroup("compilePos")
-    compileList("compileStdLib", TestSources.stdLibSources, scala2Mode.and("-migration", "-Yno-inline")) +
-    compileFile("tests/pos/nullarify.scala", defaultOptions.and("-Ycheck:nullarify")) +
-    compileFile("tests/pos-scala2/rewrites.scala", scala2Mode.and("-rewrite")).copyToTarget() +
-    compileFile("tests/pos-special/utf8encoded.scala", explicitUTF8) +
-    compileFile("tests/pos-special/utf16encoded.scala", explicitUTF16) +
-    compileFile("tests/pos-special/completeFromSource/Test.scala", defaultOptions.and("-sourcepath", "tests/pos-special")) +
-    compileFile("tests/pos-special/completeFromSource/Test2.scala", defaultOptions.and("-sourcepath", "tests/pos-special")) +
-    compileFile("tests/pos-special/completeFromSource/Test3.scala", defaultOptions.and("-sourcepath", "tests/pos-special", "-scansource")) +
-    compileFile("tests/pos-special/completeFromSource/nested/Test4.scala", defaultOptions.and("-sourcepath", "tests/pos-special", "-scansource")) +
-    compileFile("tests/pos-special/repeatedArgs213.scala", defaultOptions.and("-Ynew-collections")) +
-    compileFilesInDir("tests/pos-special/fatal-warnings", defaultOptions.and("-Xfatal-warnings", "-feature")) +
-    compileList(
-      "compileMixed",
-      List(
-        "tests/pos/B.scala",
-        "tests/scala2-library/src/library/scala/collection/immutable/Seq.scala",
-        "tests/scala2-library/src/library/scala/collection/parallel/ParSeq.scala",
-        "tests/scala2-library/src/library/scala/package.scala",
-        "tests/scala2-library/src/library/scala/collection/GenSeqLike.scala",
-        "tests/scala2-library/src/library/scala/collection/SeqLike.scala",
-        "tests/scala2-library/src/library/scala/collection/generic/GenSeqFactory.scala"
+    aggregateTests(
+      compileList("compileStdLib", TestSources.stdLibSources, scala2Mode.and("-migration", "-Yno-inline")),
+      compileFile("tests/pos/nullarify.scala", defaultOptions.and("-Ycheck:nullarify")),
+      compileFile("tests/pos-scala2/rewrites.scala", scala2Mode.and("-rewrite")).copyToTarget(),
+      compileFile("tests/pos-special/utf8encoded.scala", explicitUTF8),
+      compileFile("tests/pos-special/utf16encoded.scala", explicitUTF16),
+      compileFile("tests/pos-special/completeFromSource/Test.scala", defaultOptions.and("-sourcepath", "tests/pos-special")),
+      compileFile("tests/pos-special/completeFromSource/Test2.scala", defaultOptions.and("-sourcepath", "tests/pos-special")),
+      compileFile("tests/pos-special/completeFromSource/Test3.scala", defaultOptions.and("-sourcepath", "tests/pos-special", "-scansource")),
+      compileFile("tests/pos-special/completeFromSource/nested/Test4.scala", defaultOptions.and("-sourcepath", "tests/pos-special", "-scansource")),
+      compileFile("tests/pos-special/repeatedArgs213.scala", defaultOptions.and("-Ynew-collections")),
+      compileFilesInDir("tests/pos-special/fatal-warnings", defaultOptions.and("-Xfatal-warnings", "-feature")),
+      compileList(
+        "compileMixed",
+        List(
+          "tests/pos/B.scala",
+          "tests/scala2-library/src/library/scala/collection/immutable/Seq.scala",
+          "tests/scala2-library/src/library/scala/collection/parallel/ParSeq.scala",
+          "tests/scala2-library/src/library/scala/package.scala",
+          "tests/scala2-library/src/library/scala/collection/GenSeqLike.scala",
+          "tests/scala2-library/src/library/scala/collection/SeqLike.scala",
+          "tests/scala2-library/src/library/scala/collection/generic/GenSeqFactory.scala"
+        ),
+        scala2Mode
       ),
-      scala2Mode
-    ) +
-    compileFilesInDir("tests/pos-special/spec-t5545", defaultOptions) +
-    compileFilesInDir("tests/pos-special/strawman-collections", defaultOptions) +
-    compileFilesInDir("tests/pos-special/isInstanceOf", allowDeepSubtypes.and("-Xfatal-warnings")) +
-    compileFile("tests/scala2-library/src/library/scala/collection/immutable/IndexedSeq.scala", defaultOptions) +
-    compileFile("tests/scala2-library/src/library/scala/collection/parallel/mutable/ParSetLike.scala", defaultOptions) +
-    compileList(
-      "parSetSubset",
-      List(
-       "tests/scala2-library/src/library/scala/collection/parallel/mutable/ParSetLike.scala",
-       "tests/scala2-library/src/library/scala/collection/parallel/mutable/ParSet.scala",
-       "tests/scala2-library/src/library/scala/collection/mutable/SetLike.scala"
+      compileFilesInDir("tests/pos-special/spec-t5545", defaultOptions),
+      compileFilesInDir("tests/pos-special/strawman-collections", defaultOptions),
+      compileFilesInDir("tests/pos-special/isInstanceOf", allowDeepSubtypes.and("-Xfatal-warnings")),
+      compileFile("tests/scala2-library/src/library/scala/collection/immutable/IndexedSeq.scala", defaultOptions),
+      compileFile("tests/scala2-library/src/library/scala/collection/parallel/mutable/ParSetLike.scala", defaultOptions),
+      compileList(
+        "parSetSubset",
+        List(
+         "tests/scala2-library/src/library/scala/collection/parallel/mutable/ParSetLike.scala",
+         "tests/scala2-library/src/library/scala/collection/parallel/mutable/ParSet.scala",
+         "tests/scala2-library/src/library/scala/collection/mutable/SetLike.scala"
+        ),
+        scala2Mode
       ),
-      scala2Mode
-    ) +
-    // FIXME: This fails with .times(2), see #2799
-    compileList(
-      "testPredefDeprecatedNonCyclic",
-      List(
-        "tests/scala2-library/src/library/scala/io/Position.scala",
-        "tests/scala2-library/src/library/scala/Predef.scala",
-        "tests/scala2-library/src/library/scala/deprecated.scala"
+      // FIXME: This fails with .times(2), see #2799
+      compileList(
+        "testPredefDeprecatedNonCyclic",
+        List(
+          "tests/scala2-library/src/library/scala/io/Position.scala",
+          "tests/scala2-library/src/library/scala/Predef.scala",
+          "tests/scala2-library/src/library/scala/deprecated.scala"
+        ),
+        scala2Mode
       ),
-      scala2Mode
-    ) +
-    compileFilesInDir("tests/new", defaultOptions) +
-    compileFilesInDir("tests/pos-scala2", scala2Mode) +
-    compileFilesInDir("tests/pos", defaultOptions) +
-    compileFilesInDir("tests/pos-deep-subtype", allowDeepSubtypes) +
-    compileFile(
-      // succeeds despite -Xfatal-warnings because of -nowarn
-      "tests/neg-custom-args/fatal-warnings/xfatalWarnings.scala",
-      defaultOptions.and("-nowarn", "-Xfatal-warnings")
-    ) +
-    compileFile("tests/pos-special/typeclass-scaling.scala", defaultOptions.and("-Xmax-inlines", "40"))
-  }.checkCompile()
+      compileFilesInDir("tests/new", defaultOptions),
+      compileFilesInDir("tests/pos-scala2", scala2Mode),
+      compileFilesInDir("tests/pos", defaultOptions),
+      compileFilesInDir("tests/pos-deep-subtype", allowDeepSubtypes),
+      compileFile(
+        // succeeds despite -Xfatal-warnings because of -nowarn
+        "tests/neg-custom-args/fatal-warnings/xfatalWarnings.scala",
+        defaultOptions.and("-nowarn", "-Xfatal-warnings")
+      ),
+      compileFile("tests/pos-special/typeclass-scaling.scala", defaultOptions.and("-Xmax-inlines", "40"))
+    ).checkCompile()
+  }
 
   @Test def posTwice: Unit = {
     implicit val testGroup: TestGroup = TestGroup("posTwice")
-    compileFilesInDir("tests/pos-java-interop", defaultOptions) +
-    compileFilesInDir("tests/pos-java-interop-separate", defaultOptions) +
-    compileFile("tests/pos/t2168.scala", defaultOptions) +
-    compileFile("tests/pos/erasure.scala", defaultOptions) +
-    compileFile("tests/pos/Coder.scala", defaultOptions) +
-    compileFile("tests/pos/blockescapes.scala", defaultOptions) +
-    compileFile("tests/pos/collections.scala", defaultOptions) +
-    compileFile("tests/pos/functions1.scala", defaultOptions) +
-    compileFile("tests/pos/implicits1.scala", defaultOptions) +
-    compileFile("tests/pos/inferred.scala", defaultOptions) +
-    compileFile("tests/pos/selftypes.scala", defaultOptions) +
-    compileFile("tests/pos/varargs.scala", defaultOptions) +
-    compileFile("tests/pos/vararg-pattern.scala", defaultOptions) +
-    compileFile("tests/pos/opassign.scala", defaultOptions) +
-    compileFile("tests/pos/typedapply.scala", defaultOptions) +
-    compileFile("tests/pos/nameddefaults.scala", defaultOptions) +
-    compileFile("tests/pos/desugar.scala", defaultOptions) +
-    compileFile("tests/pos/sigs.scala", defaultOptions) +
-    compileFile("tests/pos/typers.scala", defaultOptions) +
-    compileDir("tests/pos/typedIdents", defaultOptions) +
-    compileFile("tests/pos/assignments.scala", defaultOptions) +
-    compileFile("tests/pos/packageobject.scala", defaultOptions) +
-    compileFile("tests/pos/overloaded.scala", defaultOptions) +
-    compileFile("tests/pos/overrides.scala", defaultOptions) +
-    compileDir("tests/pos/java-override", defaultOptions) +
-    compileFile("tests/pos/templateParents.scala", defaultOptions) +
-    compileFile("tests/pos/overloadedAccess.scala", defaultOptions) +
-    compileFile("tests/pos/approximateUnion.scala", defaultOptions) +
-    compileFilesInDir("tests/pos/tailcall", defaultOptions) +
-    compileShallowFilesInDir("tests/pos/pos_valueclasses", defaultOptions) +
-    compileFile("tests/pos/subtyping.scala", defaultOptions) +
-    compileFile("tests/pos/i0239.scala", defaultOptions) +
-    compileFile("tests/pos/anonClassSubtyping.scala", defaultOptions) +
-    compileFile("tests/pos/extmethods.scala", defaultOptions) +
-    compileFile("tests/pos/companions.scala", defaultOptions)
-  }.times(2).checkCompile()
+    aggregateTests(
+      compileFilesInDir("tests/pos-java-interop", defaultOptions),
+      compileFilesInDir("tests/pos-java-interop-separate", defaultOptions),
+      compileFile("tests/pos/t2168.scala", defaultOptions),
+      compileFile("tests/pos/erasure.scala", defaultOptions),
+      compileFile("tests/pos/Coder.scala", defaultOptions),
+      compileFile("tests/pos/blockescapes.scala", defaultOptions),
+      compileFile("tests/pos/collections.scala", defaultOptions),
+      compileFile("tests/pos/functions1.scala", defaultOptions),
+      compileFile("tests/pos/implicits1.scala", defaultOptions),
+      compileFile("tests/pos/inferred.scala", defaultOptions),
+      compileFile("tests/pos/selftypes.scala", defaultOptions),
+      compileFile("tests/pos/varargs.scala", defaultOptions),
+      compileFile("tests/pos/vararg-pattern.scala", defaultOptions),
+      compileFile("tests/pos/opassign.scala", defaultOptions),
+      compileFile("tests/pos/typedapply.scala", defaultOptions),
+      compileFile("tests/pos/nameddefaults.scala", defaultOptions),
+      compileFile("tests/pos/desugar.scala", defaultOptions),
+      compileFile("tests/pos/sigs.scala", defaultOptions),
+      compileFile("tests/pos/typers.scala", defaultOptions),
+      compileDir("tests/pos/typedIdents", defaultOptions),
+      compileFile("tests/pos/assignments.scala", defaultOptions),
+      compileFile("tests/pos/packageobject.scala", defaultOptions),
+      compileFile("tests/pos/overloaded.scala", defaultOptions),
+      compileFile("tests/pos/overrides.scala", defaultOptions),
+      compileDir("tests/pos/java-override", defaultOptions),
+      compileFile("tests/pos/templateParents.scala", defaultOptions),
+      compileFile("tests/pos/overloadedAccess.scala", defaultOptions),
+      compileFile("tests/pos/approximateUnion.scala", defaultOptions),
+      compileFilesInDir("tests/pos/tailcall", defaultOptions),
+      compileShallowFilesInDir("tests/pos/pos_valueclasses", defaultOptions),
+      compileFile("tests/pos/subtyping.scala", defaultOptions),
+      compileFile("tests/pos/i0239.scala", defaultOptions),
+      compileFile("tests/pos/anonClassSubtyping.scala", defaultOptions),
+      compileFile("tests/pos/extmethods.scala", defaultOptions),
+      compileFile("tests/pos/companions.scala", defaultOptions)
+    ).times(2).checkCompile()
+  }
 
   // Negative tests ------------------------------------------------------------
 
   @Test def negAll: Unit = {
     implicit val testGroup: TestGroup = TestGroup("compileNeg")
-    compileFilesInDir("tests/neg", defaultOptions) +
-    compileFilesInDir("tests/neg-tailcall", defaultOptions) +
-    compileFilesInDir("tests/neg-no-kind-polymorphism", defaultOptions and "-Yno-kind-polymorphism") +
-    compileFilesInDir("tests/neg-custom-args/deprecation", defaultOptions.and("-Xfatal-warnings", "-deprecation")) +
-    compileFilesInDir("tests/neg-custom-args/fatal-warnings", defaultOptions.and("-Xfatal-warnings")) +
-    compileFilesInDir("tests/neg-custom-args/allow-double-bindings", allowDoubleBindings) +
-    compileDir("tests/neg-custom-args/impl-conv", defaultOptions.and("-Xfatal-warnings", "-feature")) +
-    compileFile("tests/neg-custom-args/implicit-conversions.scala", defaultOptions.and("-Xfatal-warnings", "-feature")) +
-    compileFile("tests/neg-custom-args/implicit-conversions-old.scala", defaultOptions.and("-Xfatal-warnings", "-feature")) +
-    compileFile("tests/neg-custom-args/i3246.scala", scala2Mode) +
-    compileFile("tests/neg-custom-args/overrideClass.scala", scala2Mode) +
-    compileFile("tests/neg-custom-args/autoTuplingTest.scala", defaultOptions.and("-language:noAutoTupling")) +
-    compileFile("tests/neg-custom-args/i1050.scala", defaultOptions.and("-strict")) +
-    compileFile("tests/neg-custom-args/nullless.scala", defaultOptions.and("-strict")) +
-    compileFile("tests/neg-custom-args/nopredef.scala", defaultOptions.and("-Yno-predef")) +
-    compileFile("tests/neg-custom-args/noimports.scala", defaultOptions.and("-Yno-imports")) +
-    compileFile("tests/neg-custom-args/noimports2.scala", defaultOptions.and("-Yno-imports")) +
-    compileFile("tests/neg-custom-args/i3882.scala", allowDeepSubtypes) +
-    compileFile("tests/neg-custom-args/i4372.scala", allowDeepSubtypes) +
-    compileFile("tests/neg-custom-args/i1754.scala", allowDeepSubtypes) +
-    compileFile("tests/neg-custom-args/conditionalWarnings.scala", allowDeepSubtypes.and("-deprecation").and("-Xfatal-warnings")) +
-    compileFilesInDir("tests/neg-custom-args/isInstanceOf", allowDeepSubtypes and "-Xfatal-warnings") +
-    compileFile("tests/neg-custom-args/i3627.scala", allowDeepSubtypes) +
-    compileFile("tests/neg-custom-args/matchtype-loop.scala", allowDeepSubtypes) +
-    compileFile("tests/neg-custom-args/completeFromSource/nested/Test1.scala", defaultOptions.and("-sourcepath", "tests/neg-custom-args", "-scansource")) +
-    compileFile("tests/neg-custom-args/repeatedArgs213.scala", defaultOptions.and("-Ynew-collections")) +
-    compileList("duplicate source", List(
-      "tests/neg-custom-args/toplevel-samesource/S.scala",
-      "tests/neg-custom-args/toplevel-samesource/nested/S.scala"),
-      defaultOptions) +
-    compileFile("tests/neg-custom-args/i6300.scala", allowDeepSubtypes) +
-    compileFile("tests/neg-custom-args/i6312.scala", defaultOptions and "-Xfatal-warnings" and "-migration")
-  }.checkExpectedErrors()
+    aggregateTests(
+      compileFilesInDir("tests/neg", defaultOptions),
+      compileFilesInDir("tests/neg-tailcall", defaultOptions),
+      compileFilesInDir("tests/neg-no-kind-polymorphism", defaultOptions and "-Yno-kind-polymorphism"),
+      compileFilesInDir("tests/neg-custom-args/deprecation", defaultOptions.and("-Xfatal-warnings", "-deprecation")),
+      compileFilesInDir("tests/neg-custom-args/fatal-warnings", defaultOptions.and("-Xfatal-warnings")),
+      compileFilesInDir("tests/neg-custom-args/allow-double-bindings", allowDoubleBindings),
+      compileDir("tests/neg-custom-args/impl-conv", defaultOptions.and("-Xfatal-warnings", "-feature")),
+      compileFile("tests/neg-custom-args/implicit-conversions.scala", defaultOptions.and("-Xfatal-warnings", "-feature")),
+      compileFile("tests/neg-custom-args/implicit-conversions-old.scala", defaultOptions.and("-Xfatal-warnings", "-feature")),
+      compileFile("tests/neg-custom-args/i3246.scala", scala2Mode),
+      compileFile("tests/neg-custom-args/overrideClass.scala", scala2Mode),
+      compileFile("tests/neg-custom-args/autoTuplingTest.scala", defaultOptions.and("-language:noAutoTupling")),
+      compileFile("tests/neg-custom-args/i1050.scala", defaultOptions.and("-strict")),
+      compileFile("tests/neg-custom-args/nullless.scala", defaultOptions.and("-strict")),
+      compileFile("tests/neg-custom-args/nopredef.scala", defaultOptions.and("-Yno-predef")),
+      compileFile("tests/neg-custom-args/noimports.scala", defaultOptions.and("-Yno-imports")),
+      compileFile("tests/neg-custom-args/noimports2.scala", defaultOptions.and("-Yno-imports")),
+      compileFile("tests/neg-custom-args/i3882.scala", allowDeepSubtypes),
+      compileFile("tests/neg-custom-args/i4372.scala", allowDeepSubtypes),
+      compileFile("tests/neg-custom-args/i1754.scala", allowDeepSubtypes),
+      compileFile("tests/neg-custom-args/conditionalWarnings.scala", allowDeepSubtypes.and("-deprecation").and("-Xfatal-warnings")),
+      compileFilesInDir("tests/neg-custom-args/isInstanceOf", allowDeepSubtypes and "-Xfatal-warnings"),
+      compileFile("tests/neg-custom-args/i3627.scala", allowDeepSubtypes),
+      compileFile("tests/neg-custom-args/matchtype-loop.scala", allowDeepSubtypes),
+      compileFile("tests/neg-custom-args/completeFromSource/nested/Test1.scala", defaultOptions.and("-sourcepath", "tests/neg-custom-args", "-scansource")),
+      compileFile("tests/neg-custom-args/repeatedArgs213.scala", defaultOptions.and("-Ynew-collections")),
+      compileList("duplicate source", List(
+        "tests/neg-custom-args/toplevel-samesource/S.scala",
+        "tests/neg-custom-args/toplevel-samesource/nested/S.scala"),
+        defaultOptions),
+      compileFile("tests/neg-custom-args/i6300.scala", allowDeepSubtypes),
+      compileFile("tests/neg-custom-args/i6312.scala", defaultOptions and "-Xfatal-warnings" and "-migration")
+    ).checkExpectedErrors()
+  }
 
   @Test def fuzzyAll: Unit = {
     implicit val testGroup: TestGroup = TestGroup("compileFuzzy")
-    compileFilesInDir("tests/fuzzy", defaultOptions)
-  }.checkNoCrash()
+    compileFilesInDir("tests/fuzzy", defaultOptions).checkNoCrash()
+  }
 
   // Run tests -----------------------------------------------------------------
 
   @Test def runAll: Unit = {
     implicit val testGroup: TestGroup = TestGroup("runAll")
-    compileFilesInDir("tests/run-custom-args/Yretain-trees", defaultOptions and "-Yretain-trees") +
-    compileFile("tests/run-custom-args/tuple-cons.scala", allowDeepSubtypes) +
-    compileFile("tests/run-custom-args/i5256.scala", allowDeepSubtypes) +
-    compileFile("tests/run-custom-args/no-useless-forwarders.scala", defaultOptions and "-Xmixin-force-forwarders:false") +
-    compileFilesInDir("tests/run", defaultOptions)
-  }.checkRuns()
+    aggregateTests(
+      compileFilesInDir("tests/run-custom-args/Yretain-trees", defaultOptions and "-Yretain-trees"),
+      compileFile("tests/run-custom-args/tuple-cons.scala", allowDeepSubtypes),
+      compileFile("tests/run-custom-args/i5256.scala", allowDeepSubtypes),
+      compileFile("tests/run-custom-args/no-useless-forwarders.scala", defaultOptions and "-Xmixin-force-forwarders:false"),
+      compileFilesInDir("tests/run", defaultOptions)
+    ).checkRuns()
+  }
 
   // Generic java signatures tests ---------------------------------------------
 
   @Test def genericJavaSignatures: Unit = {
     implicit val testGroup: TestGroup = TestGroup("genericJavaSignatures")
-    compileFilesInDir("tests/generic-java-signatures", defaultOptions)
-  }.checkRuns()
+    compileFilesInDir("tests/generic-java-signatures", defaultOptions).checkRuns()
+  }
 
   // Pickling Tests ------------------------------------------------------------
 
   @Test def pickling: Unit = {
     implicit val testGroup: TestGroup = TestGroup("testPickling")
-    compileFilesInDir("tests/new", picklingOptions) +
-    compileFilesInDir("tests/pos", picklingOptions, FileFilter.exclude(TestSources.posTestPicklingBlacklisted)) +
-    compileFilesInDir("tests/run", picklingOptions, FileFilter.exclude(TestSources.runTestPicklingBlacklisted))
-  }.checkCompile()
+    aggregateTests(
+      compileFilesInDir("tests/new", picklingOptions),
+      compileFilesInDir("tests/pos", picklingOptions, FileFilter.exclude(TestSources.posTestPicklingBlacklisted)),
+      compileFilesInDir("tests/run", picklingOptions, FileFilter.exclude(TestSources.runTestPicklingBlacklisted))
+    ).checkCompile()
+  }
 
   /** The purpose of this test is two-fold, being able to compile dotty
    *  bootstrapped, and making sure that TASTY can link against a compiled
@@ -248,23 +259,23 @@ class CompilationTests extends ParallelTesting {
     val dotty2 = compileList("dotty", compilerSources ++ compilerManagedSources, opt)(dotty2Group)
 
     val tests = {
-      lib.keepOutput :: dotty1.keepOutput :: {
-        dotty2 +
-        compileShallowFilesInDir("compiler/src/dotty/tools", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/dotc", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/ast", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/config", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/parsing", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/printing", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/reporting", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/rewrites", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/transform", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/typer", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/util", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/backend", opt) +
-        compileShallowFilesInDir("compiler/src/dotty/tools/backend/jvm", opt) +
+      lib.keepOutput :: dotty1.keepOutput :: aggregateTests(
+        dotty2,
+        compileShallowFilesInDir("compiler/src/dotty/tools", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/dotc", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/ast", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/config", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/parsing", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/printing", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/reporting", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/rewrites", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/transform", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/typer", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/dotc/util", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/backend", opt),
+        compileShallowFilesInDir("compiler/src/dotty/tools/backend/jvm", opt),
         compileList("managed-sources", compilerManagedSources, opt)
-      }.keepOutput :: Nil
+      ).keepOutput :: Nil
     }.map(_.checkCompile())
 
     def assertExists(path: String) = assertTrue(Files.exists(Paths.get(path)))

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -1006,28 +1006,6 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     def this(targets: List[TestSource]) =
       this(targets, 1, true, None, false, false)
 
-    /** Compose test targets from `this` with `other`
-     *
-     *  It does this, only if the two tests are compatible. Otherwise it throws
-     *  an `IllegalArgumentException`.
-     *
-     *  Grouping tests together like this allows us to take advantage of the
-     *  concurrency offered by this test suite as each call to an executing
-     *  method (`pos()` / `checkExpectedErrors()`/ `run()`) will spin up a thread pool with the
-     *  maximum allowed level of concurrency. Doing this for only a few targets
-     *  does not yield any real benefit over sequential compilation.
-     *
-     *  As such, each `CompilationTest` should contain as many targets as
-     *  possible.
-     */
-    def +(other: CompilationTest) = {
-      require(other.times == times, "can't combine tests that are meant to be benchmark compiled")
-      require(other.shouldDelete == shouldDelete, "can't combine tests that differ on deleting output")
-      require(other.shouldFail == shouldFail, "can't combine tests that have different expectations on outcome")
-      require(other.shouldSuppressOutput == shouldSuppressOutput, "can't combine tests that both suppress and don't suppress output")
-      new CompilationTest(targets ++ other.targets, times, shouldDelete, threadLimit, shouldFail, shouldSuppressOutput)
-    }
-
     /** Creates a "pos" test run, which makes sure that all tests pass
      *  compilation without generating errors and that they do not crash the
      *  compiler
@@ -1196,6 +1174,36 @@ trait ParallelTesting extends RunnerOrchestration { self =>
         case _: NoSuchFileException => // already deleted, everything's fine
       }
     }
+  }
+
+  object CompilationTest {
+
+    /** Compose test targets from `tests`
+      *
+      *  It does this, only if the two tests are compatible. Otherwise it throws
+      *  an `IllegalArgumentException`.
+      *
+      *  Grouping tests together like this allows us to take advantage of the
+      *  concurrency offered by this test suite as each call to an executing
+      *  method (`pos()` / `checkExpectedErrors()`/ `run()`) will spin up a thread pool with the
+      *  maximum allowed level of concurrency. Doing this for only a few targets
+      *  does not yield any real benefit over sequential compilation.
+      *
+      *  As such, each `CompilationTest` should contain as many targets as
+      *  possible.
+      */
+    def aggregateTests(tests: CompilationTest*): CompilationTest = {
+      assert(tests.nonEmpty)
+      def aggregate(test1: CompilationTest, test2: CompilationTest) = {
+        require(test1.times == test2.times, "can't combine tests that are meant to be benchmark compiled")
+        require(test1.shouldDelete == test2.shouldDelete, "can't combine tests that differ on deleting output")
+        require(test1.shouldFail == test2.shouldFail, "can't combine tests that have different expectations on outcome")
+        require(test1.shouldSuppressOutput == test2.shouldSuppressOutput, "can't combine tests that both suppress and don't suppress output")
+        new CompilationTest(test1.targets ++ test2.targets, test1.times, test1.shouldDelete, test1.threadLimit, test1.shouldFail, test1.shouldSuppressOutput)
+      }
+      tests.reduce(aggregate)
+    }
+
   }
 
   /** Create out directory for directory `d` */
@@ -1425,7 +1433,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
       step2.checkCompile() // Compile from tasty
 
       if (shouldDelete)
-        (step1 + step2).delete()
+        CompilationTest.aggregateTests(step1, step2).delete()
 
       this
     }
@@ -1435,7 +1443,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
       step2.checkRuns() // Compile from tasty
 
       if (shouldDelete)
-        (step1 + step2).delete()
+        CompilationTest.aggregateTests(step1, step2).delete()
 
       this
     }


### PR DESCRIPTION
The motivation is to avoid bugs like the one fixed in #6423 to ever happen.
In the previous scheme a missing `+` results in tests not being executed,
while now a missing comma will be a compilation error.