### PR TITLE
 Fix #6415: Enable REPL code completion for opaque types

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -828,7 +828,7 @@ object desugar {
       val moduleName = tdef.name.toTermName
       val localRef = Select(Ident(moduleName), tdef.name)
       localRef.pushAttachment(SuppressAccessCheck, ())
-      val aliasType = cpy.TypeDef(tdef)(rhs = completeForwarder(localRef))
+      val aliasType = cpy.TypeDef(tdef)(rhs = completeForwarder(localRef)).withSpan(tdef.span.startPos)
       val localType = tdef.withMods(Modifiers(Synthetic | Opaque).withPrivateWithin(tdef.name))
 
       val companions = moduleDef(ModuleDef(

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -128,4 +128,8 @@ class TabcompleteTests extends ReplTest {
   @Test def moduleCompletion = fromInitialState { implicit s =>
     assertEquals(List("Predef"), tabComplete("object Foo { type T = Pre"))
   }
+
+  @Test def i6415 = fromInitialState { implicit s =>
+    assertEquals(List("Predef"), tabComplete("opaque type T = Pre"))
+  }
 }


### PR DESCRIPTION
`opaque type T = Int` desugars to (roughly):

```scala
opaque type T = T.T
object T {
  opaque type T = Int
}
```

So one `opaque type T` desugars to two `opaque type T`'s. One of them is synthetic – the first one. It shadows the second one during code completion due to the fact that it has the same span.