### PR TITLE
Check for symbol existence when working with GADT bounds in TypeComparer

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2107,7 +2107,7 @@ class TrackingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
   }
 
   override def gadtBounds(sym: Symbol)(implicit ctx: Context): TypeBounds = {
-    if (sym eq NoSymbol) null
+    if (!sym.exists) null
     else {
       footprint += sym.typeRef
       super.gadtBounds(sym)

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -678,7 +678,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
                 narrowGADTBounds(tp1, tp2, approx, isUpper = true)) &&
                 GADTusage(tp1.symbol)
             }
-            isSubType(hi1, tp2, approx.addLow) || ((tp1.symbol ne NoSymbol) && compareGADT)
+            isSubType(hi1, tp2, approx.addLow) || compareGADT
           case _ =>
             def isNullable(tp: Type): Boolean = tp.widenDealias match {
               case tp: TypeRef => tp.symbol.isNullableClass
@@ -2107,8 +2107,11 @@ class TrackingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
   }
 
   override def gadtBounds(sym: Symbol)(implicit ctx: Context): TypeBounds = {
-    footprint += sym.typeRef
-    super.gadtBounds(sym)
+    if (sym eq NoSymbol) null
+    else {
+      footprint += sym.typeRef
+      super.gadtBounds(sym)
+    }
   }
 
   override def gadtAddLowerBound(sym: Symbol, b: Type): Boolean = {

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2107,20 +2107,17 @@ class TrackingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
   }
 
   override def gadtBounds(sym: Symbol)(implicit ctx: Context): TypeBounds = {
-    if (!sym.exists) null
-    else {
-      footprint += sym.typeRef
-      super.gadtBounds(sym)
-    }
+    if (sym.exists) footprint += sym.typeRef
+    super.gadtBounds(sym)
   }
 
   override def gadtAddLowerBound(sym: Symbol, b: Type): Boolean = {
-    footprint += sym.typeRef
+    if (sym.exists) footprint += sym.typeRef
     super.gadtAddLowerBound(sym, b)
   }
 
   override def gadtAddUpperBound(sym: Symbol, b: Type): Boolean = {
-    footprint += sym.typeRef
+    if (sym.exists) footprint += sym.typeRef
     super.gadtAddUpperBound(sym, b)
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -678,7 +678,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
                 narrowGADTBounds(tp1, tp2, approx, isUpper = true)) &&
                 GADTusage(tp1.symbol)
             }
-            isSubType(hi1, tp2, approx.addLow) || compareGADT
+            isSubType(hi1, tp2, approx.addLow) || ((tp1.symbol ne NoSymbol) && compareGADT)
           case _ =>
             def isNullable(tp: Type): Boolean = tp.widenDealias match {
               case tp: TypeRef => tp.symbol.isNullableClass

--- a/tests/pos/dep-match.scala
+++ b/tests/pos/dep-match.scala
@@ -1,0 +1,9 @@
+object Test {
+  type Foo = Int { type U }
+  type Bar[T] = T match {
+    case Unit => Unit
+  }
+  inline def baz(foo: Foo): Unit = {
+    val v: Bar[foo.U] = ???
+  }
+}


### PR DESCRIPTION
Without the guard the test case crashes with an assert attempting get the owner of `NoSymbol`.