### PR TITLE
Fix #6432: Refine positions of string interpolator string parts

### DIFF
--- a/tests/neg-macros/i6432.check
+++ b/tests/neg-macros/i6432.check
@@ -1,0 +1,6 @@
+[61..64] in Test_2.scala
+fgh
+[50..53] in Test_2.scala
+xyz
+[39..42] in Test_2.scala
+abc

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -1,0 +1,18 @@
+
+import scala.quoted._
+import scala.quoted.autolift._
+import scala.quoted.matching._
+
+object Macro {
+  inline def (sc: => StringContext) foo (args: String*): Unit = ${ impl('sc) }
+
+  def impl(sc: Expr[StringContext])(implicit reflect: tasty.Reflection): Expr[Unit] = {
+    import reflect._
+    sc match {
+      case '{ StringContext(${ExprSeq(parts)}: _*) } =>
+        for (part @ Const(s) <- parts)
+          error(s, part.unseal.pos)
+    }
+    '{}
+  }
+}

--- a/tests/neg-macros/i6432/Test_2.scala
+++ b/tests/neg-macros/i6432/Test_2.scala
@@ -1,0 +1,5 @@
+
+object TestA {
+  import Macro._
+  foo"abc${"123"}xyz${"456"}fgh" // error // error // error
+}

--- a/tests/neg-macros/i6432b.check
+++ b/tests/neg-macros/i6432b.check
@@ -1,0 +1,6 @@
+[63..66] in Test_2.scala
+fgh
+[52..55] in Test_2.scala
+xyz
+[41..44] in Test_2.scala
+abc

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -1,0 +1,18 @@
+
+import scala.quoted._
+import scala.quoted.autolift._
+import scala.quoted.matching._
+
+object Macro {
+  inline def (sc: => StringContext) foo (args: String*): Unit = ${ impl('sc) }
+
+  def impl(sc: Expr[StringContext])(implicit reflect: tasty.Reflection): Expr[Unit] = {
+    import reflect._
+    sc match {
+      case '{ StringContext(${ExprSeq(parts)}: _*) } =>
+        for (part @ Const(s) <- parts)
+          error(s, part.unseal.pos)
+    }
+    '{}
+  }
+}

--- a/tests/neg-macros/i6432b/Test_2.scala
+++ b/tests/neg-macros/i6432b/Test_2.scala
@@ -1,0 +1,5 @@
+
+object TestA {
+  import Macro._
+  foo"""abc${"123"}xyz${"456"}fgh""" // error // error // error
+}


### PR DESCRIPTION
From
```scala
s"abc${"123"}xyz${1}fgh"
 ^^^^^       ^^^^   ^^^^
```
to
```scala
s"abc${"123"}xyz${1}fgh"
  ^^^        ^^^    ^^^
```

See #6432 for more deatails