### PR TITLE
Run Scalatest test in community build

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -105,7 +105,7 @@ class CommunityBuildTest {
 
   @Test def scalatest = test(
     project       = "scalatest",
-    testCommand   = "scalatest/compile",
+    testCommand   = ";scalacticDotty/clean;scalacticTestDotty/test;scalatestTestDotty/test",
     updateCommand = "scalatest/update"
   )
 


### PR DESCRIPTION
Now the upstream scalatest project 3.1.x has basic
support for Dotty, which means it can run its own
test set bootstrapped.