### PR TITLE
Fix #6452: capture plugin ordering conflict with a pos project

### DIFF
--- a/sbt-dotty/sbt-test/sbt-dotty/compiler-plugin/appOK/src/main/scala/hello/Hello.scala
+++ b/sbt-dotty/sbt-test/sbt-dotty/compiler-plugin/appOK/src/main/scala/hello/Hello.scala
@@ -1,0 +1,8 @@
+package hello
+
+object Hello {
+  def main(args: Array[String]): Unit = {
+    val dotty: Int | String = "dotty"
+    println(s"Hello $dotty!")
+  }
+}

--- a/sbt-dotty/sbt-test/sbt-dotty/compiler-plugin/build.sbt
+++ b/sbt-dotty/sbt-test/sbt-dotty/compiler-plugin/build.sbt
@@ -22,3 +22,9 @@ lazy val app = project
   .settings(
     scalaVersion := dottyVersion
   )
+
+lazy val appOk = project
+  .in(file("appOk"))
+  .settings(
+    scalaVersion := dottyVersion
+  )

--- a/sbt-dotty/sbt-test/sbt-dotty/compiler-plugin/changes/build.sbt
+++ b/sbt-dotty/sbt-test/sbt-dotty/compiler-plugin/changes/build.sbt
@@ -19,3 +19,10 @@ lazy val app = project
     scalaVersion := dottyVersion,
     addCompilerPlugin("ch.epfl.lamp" %% "dividezero" % "0.0.1")
   )
+
+lazy val appOk = project
+  .in(file("appOk"))
+  .settings(
+    scalaVersion := dottyVersion,
+    addCompilerPlugin("ch.epfl.lamp" %% "dividezero" % "0.0.1")
+  )

--- a/sbt-dotty/sbt-test/sbt-dotty/compiler-plugin/plugin/DivideZero.scala
+++ b/sbt-dotty/sbt-test/sbt-dotty/compiler-plugin/plugin/DivideZero.scala
@@ -19,8 +19,8 @@ class DivideZero extends PluginPhase with StandardPlugin {
 
   val phaseName = name
 
-  override val runsAfter = Set(Pickler.name)
-  override val runsBefore = Set(Staging.name)
+  override val runsAfter = Set(Staging.name)
+  override val runsBefore = Set(Pickler.name)
 
   def init(options: List[String]): List[PluginPhase] = this :: Nil
 

--- a/sbt-dotty/sbt-test/sbt-dotty/compiler-plugin/test
+++ b/sbt-dotty/sbt-test/sbt-dotty/compiler-plugin/test
@@ -8,6 +8,10 @@
 $ copy-file changes/build.sbt build.sbt
 > reload
 
+# Should compile with the plugin
+> clean
+> appOk/compile
+
 # Should NOT compile with the plugin
 > clean
 -> app/compile


### PR DESCRIPTION
Fix #6452: capture plugin ordering conflict with a pos project