### PR TITLE
Fix #6199: Use a skolemized prefix in asSeenFrom when needed

### DIFF
--- a/tests/pos/i6199a.scala
+++ b/tests/pos/i6199a.scala
@@ -1,0 +1,8 @@
+class Encoder[T] { def encode(v: T): String = v.toString }
+case class ValueWithEncoder[T](value: T, encoder: Encoder[T])
+
+object Test {
+  val a: Seq[ValueWithEncoder[_]] = Seq.empty
+  val b = a.map((value, encoder) => encoder.encode(value))
+  val c: Seq[String] = b
+}

--- a/tests/pos/i6199b.scala
+++ b/tests/pos/i6199b.scala
@@ -1,0 +1,11 @@
+trait Foo {
+  type State
+  def bar(f: Bar[State] => Bar[State]): Foo = this
+}
+object Foo {
+  def unit: Foo = new Foo {
+    type State = Any
+  }
+  def doBar: Foo = unit.bar(bar => bar)
+}
+class Bar[+A]

--- a/tests/pos/i6199c.scala
+++ b/tests/pos/i6199c.scala
@@ -1,0 +1,8 @@
+trait Foo[State] {
+  def bar(f: Bar[State] => Bar[State]): Foo[_] = this
+}
+object Foo {
+  def unit: Foo[_] = new Foo[Any] {}
+  def doBar: Foo[_] = unit.bar(bar => bar)
+}
+class Bar[+A]


### PR DESCRIPTION
Prior to
https://github.com/lampepfl/dotty/commit/91ee02fcca4881b34e35d3e2721e1b00e98fd512,
unstable prefixes appearing in selection types were handled in a
two-pass approach which can be summarized as:

1. Type the selection with the unstable prefix, if this prefix appears
   in a position where it cannot be widened away, mark it with a special
   annotation.
2. If the result of the selection contains this annotation, retype it
   after having wrapped its prefix in a skolem.

This got replaced by the use of an `ApproximatingTypeMap` which can
always construct a valid (but potentially approximated) type for the
selection.

Most of the time this is all we need but there are some cases where
skolemizing the prefix is still useful as witnessed by the tests added
in this commit. They are now handled by unconditionally skolemizing
unstable prefixes.

To avoid any potential performance impact from this, we teach
`asSeenFrom` to always widen these prefixes first and only make use of
the skolem to avoid returning an approximation. Since this almost never
occurs (it happens only once when compiling Dotty) this means we incur
almost no extra cost (the skolem itself still needs to be allocated
unconditionally in advance, this cannot be delegated to `asSeenFrom`
because it's supposed to be an idempotent operation and each skolem is
unique).