### PR TITLE
Revert SymDenotation.originalName change

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -397,7 +397,7 @@ object SymDenotations {
         // might have been moved from different origins into the same class
 
     /** The name with which the denoting symbol was created */
-    final def originalName(implicit ctx: Context): Name = initial.effectiveName
+    final def originalName(implicit ctx: Context): Name = initial.name
 
     /** The owner with which the denoting symbol was created. */
     final def originalOwner(implicit ctx: Context): Symbol = initial.maybeOwner


### PR DESCRIPTION
This got changed 10 months ago. I did not get to review this or I would have explained before:

Making `originalName` drop module class names looks like an easy fix for a display problem,
but it is a terrible idea!

 - the code mixes presentation concerns with correctness. `orgiginalName` has deep significance
   for many aspects of compilation and tooling, messing with the name in this way is super dangerous!
 - the code does not correspond to the comment which is quite clear what should go on
 - the code displays the wrong thing. A module class name is not the same as the underlying
   class name, and should not be displayed as such. That's a recipee for confusion. I just
   lost half an afternoon because I did not suspect such a change would be possible.