### PR TITLE
Fix #6395: Drop expected type in inlineCall

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -396,7 +396,7 @@ object SymDenotations {
         // need to use initial owner to disambiguate, as multiple private symbols with the same name
         // might have been moved from different origins into the same class
 
-    /** The name with which the denoting symbol was created */
+    /** The effective name with which the denoting symbol was created */
     final def originalName(implicit ctx: Context): Name = initial.effectiveName
 
     /** The owner with which the denoting symbol was created. */

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -61,7 +61,7 @@ object Inliner {
    *  @return   An `Inlined` node that refers to the original call and the inlined bindings
    *            and body that replace it.
    */
-  def inlineCall(tree: Tree, pt: Type)(implicit ctx: Context): Tree = {
+  def inlineCall(tree: Tree)(implicit ctx: Context): Tree = {
 
    /** Set the position of all trees logically contained in the expansion of
     *  inlined call `call` to the position of `call`. This transform is necessary
@@ -102,11 +102,11 @@ object Inliner {
 
     val tree1 = liftBindings(tree, identity)
     if (bindings.nonEmpty)
-      cpy.Block(tree)(bindings.toList, inlineCall(tree1, pt))
+      cpy.Block(tree)(bindings.toList, inlineCall(tree1))
     else if (enclosingInlineds.length < ctx.settings.XmaxInlines.value) {
       val body = bodyToInline(tree.symbol) // can typecheck the tree and thereby produce errors
       if (ctx.reporter.hasErrors) tree
-      else new Inliner(tree, body).inlined(pt, tree.sourcePos)
+      else new Inliner(tree, body).inlined(tree.sourcePos)
     }
     else
       errorTree(
@@ -384,7 +384,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
     }
 
   /** The Inlined node representing the inlined call */
-  def inlined(pt: Type, sourcePos: SourcePosition): Tree = {
+  def inlined(sourcePos: SourcePosition): Tree = {
 
     if (callTypeArgs.length == 1)
       if (inlinedMethod == defn.Compiletime_constValue) {
@@ -509,7 +509,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       }
 
       // Run a typing pass over the inlined tree. See InlineTyper for details.
-      val expansion1 = inlineTyper.typed(expansion, pt)(inlineCtx)
+      val expansion1 = inlineTyper.typed(expansion)(inlineCtx)
 
       if (ctx.settings.verbose.value) {
         inlining.println(i"to inline = $rhsToInline")

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2772,7 +2772,7 @@ class Typer extends Namer
                !ctx.isAfterTyper &&
                !ctx.reporter.hasErrors) {
         tree.tpe <:< wildApprox(pt)
-        readaptSimplified(Inliner.inlineCall(tree, pt))
+        readaptSimplified(Inliner.inlineCall(tree))
       }
       else if (tree.symbol.isScala2Macro) {
         if (ctx.settings.XignoreScala2Macros.value) {
@@ -2786,7 +2786,7 @@ class Typer extends Namer
           // As the macro is implemented in the bootstrapped library, it can only be used from the bootstrapped compiler.
           val Apply(TypeApply(Select(sc, _), _), args) = tree
           val newCall = ref(defn.InternalStringContextModule_f).appliedTo(sc).appliedToArgs(args)
-          Inliner.inlineCall(newCall, pt)
+          readaptSimplified(Inliner.inlineCall(newCall))
         } else {
           ctx.error("Scala 2 macro cannot be used in Dotty. See http://dotty.epfl.ch/docs/reference/dropped-features/macros.html", tree.sourcePos)
           tree

--- a/tests/pos/i6395.scala
+++ b/tests/pos/i6395.scala
@@ -1,0 +1,5 @@
+object Foo {
+  inline def (self: Int) foo (that: Int): Int = 5
+  def (self: Int) bar: Int = self
+  1.foo(2).bar
+}


### PR DESCRIPTION
The Inliner ReTyper got confused if the expected type was an
extension method. We can fix this by simply not propafating the
expected type into the inline expansion.