### PR TITLE
Change explaining printer

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -106,22 +106,32 @@ object Formatting {
 
   private type Recorded = AnyRef /*Symbol | ParamRef | SkolemType */
 
-  private class Seen extends mutable.HashMap[String, List[Recorded]] {
+  private case class SeenKey(str: String, isType: Boolean)
+  private class Seen extends mutable.HashMap[SeenKey, List[Recorded]] {
 
-    override def default(key: String) = Nil
+    override def default(key: SeenKey) = Nil
 
-    def record(str: String, entry: Recorded)(implicit ctx: Context): String = {
+    def record(str: String, isType: Boolean, entry: Recorded)(implicit ctx: Context): String = {
+
+      /** If `e1` is an alias of another class of the same name, return the other
+       *  class symbol instead. This normalization avoids recording e.g. scala.List
+       *  and scala.collection.immutable.List as two different types
+       */
       def followAlias(e1: Recorded): Recorded = e1 match {
         case e1: Symbol if e1.isAliasType =>
           val underlying = e1.typeRef.underlyingClassRef(refinementOK = false).typeSymbol
           if (underlying.name == e1.name) underlying else e1
         case _ => e1
       }
+      val key = SeenKey(str, isType)
+      val existing = apply(key)
       lazy val dealiased = followAlias(entry)
-      var alts = apply(str).dropWhile(alt => dealiased ne followAlias(alt))
+
+      // alts: The alternatives in `existing` that are equal, or follow (an alias of) `entry`
+      var alts = existing.dropWhile(alt => dealiased ne followAlias(alt))
       if (alts.isEmpty) {
-        alts = entry :: apply(str)
-        update(str, alts)
+        alts = entry :: existing
+        update(key, alts)
       }
       str + "'" * (alts.length - 1)
     }
@@ -135,13 +145,13 @@ object Formatting {
 
     override def simpleNameString(sym: Symbol): String =
       if (useSourceModule(sym)) simpleNameString(sym.sourceModule)
-      else seen.record(super.simpleNameString(sym), sym)
+      else seen.record(super.simpleNameString(sym), sym.isType, sym)
 
     override def ParamRefNameString(param: ParamRef): String =
-      seen.record(super.ParamRefNameString(param), param)
+      seen.record(super.ParamRefNameString(param), param.isInstanceOf[TypeParamRef], param)
 
     override def toTextRef(tp: SingletonType): Text = tp match {
-      case tp: SkolemType => seen.record(tp.repr.toString, tp)
+      case tp: SkolemType => seen.record(tp.repr.toString, isType = true, tp)
       case _ => super.toTextRef(tp)
     }
 
@@ -207,10 +217,13 @@ object Formatting {
     }
 
     val toExplain: List[(String, Recorded)] = seen.toList.flatMap {
-      case (str, entry :: Nil) =>
-        if (needsExplanation(entry)) (str, entry) :: Nil else Nil
-      case (str, entries) =>
-        entries.map(alt => (seen.record(str, alt), alt))
+      case (key, entry :: Nil) =>
+        if (needsExplanation(entry)) (key.str, entry) :: Nil else Nil
+      case (key, entries) =>
+        for (alt <- entries) yield {
+          val tickedString = seen.record(key.str, key.isType, alt)
+          (tickedString, alt)
+        }
     }.sortBy(_._1)
 
     def columnar(parts: List[(String, String)]): List[String] = {

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -298,7 +298,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
     }
   }
 
-  /** The string representation of this type used as a prefix */
+  /** The string representation of this type used as a prefix, including separator */
   protected def toTextPrefix(tp: Type): Text = controlled {
     homogenize(tp) match {
       case NoPrefix => ""

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -78,7 +78,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     if (ctx.settings.YdebugNames.value) name.debugString else NameTransformer.decodeIllegalChars(name.toString)
 
   override protected def simpleNameString(sym: Symbol): String =
-    nameString(if (ctx.property(XprintMode).isEmpty) sym.originalName else sym.name)
+    nameString(if (ctx.property(XprintMode).isEmpty) sym.initial.name else sym.name)
 
   override def fullNameString(sym: Symbol): String =
     if (isEmptyPrefix(sym.maybeOwner)) nameString(sym)

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -79,7 +79,7 @@ class CompletionTest {
     withSources(
       code"""object O { object MyObject }""",
       code"""import O.My${m1}"""
-    ).completion(m1, Set(("MyObject", Module, "O.MyObject")))
+    ).completion(m1, Set(("MyObject", Module, "O.MyObject$")))
   }
 
   @Test def importCompleteWithClassAndCompanion: Unit = {
@@ -114,7 +114,7 @@ class CompletionTest {
     ).completion(m1, Set(("myVal", Field, "Int"),
                          ("myDef", Method, "=> Int"),
                          ("myVar", Variable, "Int"),
-                         ("myObject", Module, "MyObject.myObject"),
+                         ("myObject", Module, "MyObject.myObject$"),
                          ("myClass", Class, "MyObject.myClass"),
                          ("myTrait", Class, "MyObject.myTrait")))
   }
@@ -138,7 +138,7 @@ class CompletionTest {
     code"""object O {
              val out = java.io.FileDesc${m1}
            }""".withSource
-      .completion(m1, Set(("FileDescriptor", Module, "java.io.FileDescriptor")))
+      .completion(m1, Set(("FileDescriptor", Module, "java.io.FileDescriptor$")))
   }
 
   @Test def importRename: Unit = {
@@ -197,7 +197,7 @@ class CompletionTest {
           |  object bat
           |  val bizz: ba${m1}
           |}""".withSource
-      .completion(m1, Set(("bar", Field, "Bar"), ("bat", Module, "Foo.bat")))
+      .completion(m1, Set(("bar", Field, "Bar"), ("bat", Module, "Foo.bat$")))
   }
 
   @Test def completionOnRenamedImport: Unit = {


### PR DESCRIPTION

Three changes:

1. Don't strip module class prefix in RefinedPrinter
2. New treatment of module classes in ExplainingPrinter
3. Don't disambiguate types and terms in ExplainingPrinter
