### PR TITLE
Fix #6460: less forcing in checkNonCyclic

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1301,12 +1301,12 @@ object Denotations {
         if (owner.exists) {
           val result = if (isPackage) owner.info.decl(selector) else owner.info.member(selector)
           if (result.exists) result
+          else if (isPackageFromCoreLibMissing) throw new MissingCoreLibraryException(selector.toString)
           else {
             val alt =
               if (generateStubs) missingHook(owner.symbol.moduleClass, selector)
               else NoSymbol
             if (alt.exists) alt.denot
-            else if (isPackageFromCoreLibMissing) throw new MissingCoreLibraryException(selector.toString)
             else MissingRef(owner, selector)
           }
         }

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -254,7 +254,7 @@ object Completion {
       !sym.isAbsent &&
       !sym.isPrimaryConstructor &&
       sym.sourceSymbol.exists &&
-      (!sym.is(Package) || !sym.moduleClass.exists) &&
+      (!sym.is(Package) || sym.is(ModuleClass)) &&
       !sym.is(allOf(Mutable, Accessor)) &&
       !sym.isPackageObject &&
       !sym.is(Artifact) &&

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -240,7 +240,7 @@ object Checking {
               )
             case prefix: NamedType =>
               (!sym.is(Private) && prefix.derivesFrom(sym.owner)) ||
-              (!prefix.symbol.isStaticOwner && isInteresting(prefix.prefix))
+              (!prefix.symbol.moduleClass.isStaticOwner && isInteresting(prefix.prefix))
             case SuperType(thistp, _) => isInteresting(thistp)
             case AndType(tp1, tp2) => isInteresting(tp1) || isInteresting(tp2)
             case OrType(tp1, tp2) => isInteresting(tp1) && isInteresting(tp2)

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -48,7 +48,15 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
       compileDir("compiler/src/dotty/tools/dotc/reporting", withCompilerOptions),
       compileDir("compiler/src/dotty/tools/dotc/typer", withCompilerOptions),
       compileDir("compiler/src/dotty/tools/dotc/util", withCompilerOptions),
-      compileDir("compiler/src/dotty/tools/io", withCompilerOptions)
+      compileDir("compiler/src/dotty/tools/io", withCompilerOptions),
+      compileList(
+        "testIssue6460",
+        List(
+          "compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala",
+          "compiler/src/dotty/tools/dotc/core/Types.scala"
+        ),
+        withCompilerOptions
+      ),
     ).checkCompile()
   }
 

--- a/tests/neg/toplevel-cyclic/defs_1.scala
+++ b/tests/neg/toplevel-cyclic/defs_1.scala
@@ -1,2 +1,2 @@
-type A = B  // error: illegal cyclic reference
+type A = B  // error: recursion limit exceeded
 

--- a/tests/neg/toplevel-cyclic/moredefs_1.scala
+++ b/tests/neg/toplevel-cyclic/moredefs_1.scala
@@ -1,1 +1,1 @@
-type B = A
+type B = A // error: recursion limit exceeded // error: recursion limit exceeded


### PR DESCRIPTION
checkNonCyclic was forcing too many infos because it didn't account for
the case where the prefix is a ModuleVal and not a ModuleClass. Fixing
this solves the incremental compilation issue in the Dotty build
reported in #6460 were the root cause was a completion cycle when
jointly compiling SymbolLoaders and Types that looked like this:

Complete `object tpd`
 Complete its parent `Trees.Instance`
  Complete its type parameter `T >: Untyped <: Type`
    run `checkNonCyclic` on the the type parameter definition
      Complete `Type`
        Complete `import ast.tpd._` in `Types.scala`
          Eventually this requires unpickling the selection `Trees.Instance#T` which
          gets a `NoDenotation` since `T` hasn't been entered yet.

As a side-effect this also means that the neg/toplevel-cyclic
test no longer leads to an "illegal cyclic reference" error, instead it
now causes "recursion limit exceeded" errors, which are less nice but
still acceptable.