### PR TITLE
Fix #6484: Properly unpickle some Scala 2 type lambdas

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -46,7 +46,11 @@ object Scala2Unpickler {
   /** Convert temp poly type to poly type and leave other types alone. */
   def translateTempPoly(tp: Type)(implicit ctx: Context): Type = tp match {
     case TempPolyType(tparams, restpe) =>
-      (if (tparams.head.owner.isTerm) PolyType else HKTypeLambda)
+      // This check used to read `owner.isTerm` but that wasn't always correct,
+      // I'm not sure `owner.is(Method)` is 100% correct either but it seems to
+      // work better. See the commit message where this change was introduced
+      // for more information.
+      (if (tparams.head.owner.is(Method)) PolyType else HKTypeLambda)
         .fromParams(tparams, restpe)
     case tp => tp
   }

--- a/sbt-dotty/sbt-test/scala2-compat/eff/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/eff/build.sbt
@@ -1,0 +1,4 @@
+scalaVersion := sys.props("plugin.scalaVersion")
+
+libraryDependencies +=
+   ("org.atnos" %% "eff" % "5.4.1").withDottyCompat(scalaVersion.value)

--- a/sbt-dotty/sbt-test/scala2-compat/eff/i6484.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/eff/i6484.scala
@@ -1,0 +1,13 @@
+import cats._
+import cats.data._
+import cats.implicits._
+import org.atnos.eff._
+import org.atnos.eff.all._
+import org.atnos.eff.syntax.all._
+
+import scala.language.implicitConversions
+
+object Test {
+  def resolve[T](e: Eff[Fx1[[X] => Kleisli[Id, String, X]], T], g: String): T = 
+    e.runReader[String](g)(Member.Member1[[X] => Kleisli[Id, String, X]]).run
+}

--- a/sbt-dotty/sbt-test/scala2-compat/eff/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/eff/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))

--- a/sbt-dotty/sbt-test/scala2-compat/eff/test
+++ b/sbt-dotty/sbt-test/scala2-compat/eff/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
Scala 2 pickles both type lambdas and polymorphic methods using the
POLYtpe tag. When we unpickle them, we distinguish them based on whether
the symbol for the owner of the type parameters is a term or a type, but
it seems that some type parameter symbols for type lambdas are pickled
with a term owner. In Eff for example, the pickled information for the
`runReader` method in:
https://github.com/atnos-org/eff/blob/85bd7b2dc1cd26c22e45d69910755f2a9ea4ece4/shared/src/main/scala/org/atnos/eff/syntax/reader.scala#L12
contains a POLYtpe `[A] => A` (because `Reader` is defined in cats as
`type Reader[A, B] = Kleisli[Id, A, B]`, and `Id` is defined as
`type Id[A] = A`), somehow the owner of the symbol for `A` is the
object `reader` defined in the same file.

That doesn't make any sense to me, but just checking if the owner is
actually a method should work just as well and fixes the problem. Given
that Scala 2 unpickling support is a temporary crutch I think that's
good enough.