### PR TITLE
Fix #6242: package objects leak members from Any and Object

### DIFF
--- a/tests/neg/i6242.scala
+++ b/tests/neg/i6242.scala
@@ -1,0 +1,7 @@
+package object foo {
+  val x = 1
+}
+object Test {
+  foo.eq(???) // error
+  foo.==(???) // error
+}


### PR DESCRIPTION
Now they're hidden, just like in Scala 2.