### PR TITLE
[CI only] Demonstrate unusual TypeDefTree

### DIFF
--- a/tests/run-with-compiler/tasty-consumer-check.check
+++ b/tests/run-with-compiler/tasty-consumer-check.check
@@ -1,0 +1,5 @@
+ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("foo", TypeIdent("Int"), Some(Literal(Constant.Int(2)))), DefDef("bar", Nil, List(List(ValDef("i", TypeIdent("Int"), None))), TypeIdent("Int"), Some(Literal(Constant.Int(3))))))
+DefDef("<init>", Nil, List(Nil), Inferred(), None)
+ValDef("foo", TypeIdent("Int"), Some(Literal(Constant.Int(2))))
+DefDef("bar", Nil, List(List(ValDef("i", TypeIdent("Int"), None))), TypeIdent("Int"), Some(Literal(Constant.Int(3))))
+ValDef("i", TypeIdent("Int"), None)

--- a/tests/run-with-compiler/tasty-consumer-check/Foo.scala
+++ b/tests/run-with-compiler/tasty-consumer-check/Foo.scala
@@ -1,0 +1,7 @@
+package pack
+trait Foo {
+  type F = List
+  type G[X] = List[X]
+  type I <: Int
+  type J[X] >: String <: X
+}

--- a/tests/run-with-compiler/tasty-consumer-check/Test.scala
+++ b/tests/run-with-compiler/tasty-consumer-check/Test.scala
@@ -1,0 +1,40 @@
+import scala.tasty.Reflection
+import scala.tasty.file._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    ConsumeTasty("", List("pack.Foo"), new DBConsumer)
+  }
+}
+
+class DBConsumer extends TastyConsumer {
+
+  final def apply(reflect: Reflection)(root: reflect.Tree): Unit = {
+    import reflect._
+    object Traverser extends TreeTraverser {
+
+      override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
+        case IsClassDef(tree) =>
+          super.traverseTree(tree)
+        case IsTypeDef(tree) =>
+          println("got type def")
+          tree.rhs match {
+            case IsTypeTree(ttree) =>
+              println(ttree.show)
+              ttree.tpe match {
+                case IsType(_) => ;
+                case IsTypeBounds(_) => sys.error("this should never happen")
+              }
+              super.traverseTree(ttree)
+            case _ => ;
+          }
+          super.traverseTree(tree)
+        case tree =>
+          super.traverseTree(tree)
+      }
+
+    }
+    Traverser.traverseTree(root)(reflect.rootContext)
+  }
+
+}


### PR DESCRIPTION
A `TypeDefTree` does not necessarily represent an alias if its RHS is not a `TypeBounds`.
Definitions like:

```scala
  type J[X] >: String <: X
```

seem to produce an RHS ~with a type like~ `TypeTree` printing as follows:

```
[X] => _ >: scala.Predef.String <: X
```

See the stack trace:

<details><p>

```
got type def
scala.List
got type def
[X] => scala.List[X]
got type def
got type def
got type def
got type def
[X] => _ >: scala.Predef.String <: X
java.lang.RuntimeException: this should never happen while compiling pack.Foo
Exception in thread "main" java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at dotty.tools.vulpix.ChildJVMMain.runMain(ChildJVMMain.java:40)
        at dotty.tools.vulpix.ChildJVMMain.main(ChildJVMMain.java:47)
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at scala.tasty.file.ConsumeTasty$.apply(ConsumeTasty.scala:16)
        at Test$.main(Test.scala:6)
        at Test.main(Test.scala)
        ... 6 more
Caused by: java.lang.RuntimeException: this should never happen
        at scala.sys.package$.error(package.scala:30)
        at DBConsumer$Traverser$1$.traverseTree(Test.scala:27)
        at scala.tasty.reflect.TreeUtils$TreeTraverser.foldTree(TreeUtils.scala:117)
        at scala.tasty.reflect.TreeUtils$TreeTraverser.foldTree(TreeUtils.scala:117)
        at scala.tasty.reflect.TreeUtils$TreeAccumulator.foldTrees$$anonfun$1(TreeUtils.scala:17)
        at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:126)
        at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:122)
        at scala.collection.immutable.List.foldLeft(List.scala:89)
        at scala.collection.TraversableOnce.$div$colon(TraversableOnce.scala:154)
        at scala.collection.TraversableOnce.$div$colon$(TraversableOnce.scala:154)
        at scala.collection.AbstractTraversable.$div$colon(Traversable.scala:108)
        at scala.tasty.reflect.TreeUtils$TreeAccumulator.foldTrees(TreeUtils.scala:17)
        at scala.tasty.reflect.TreeUtils$TreeAccumulator.foldOverTree(TreeUtils.scala:75)
        at scala.tasty.reflect.TreeUtils$TreeTraverser.traverseTreeChildren(TreeUtils.scala:120)
        at scala.tasty.reflect.TreeUtils$TreeTraverser.traverseTree(TreeUtils.scala:114)
        at DBConsumer$Traverser$1$.traverseTree(Test.scala:19)
        at scala.tasty.reflect.TreeUtils$TreeTraverser.foldTree(TreeUtils.scala:117)
        at scala.tasty.reflect.TreeUtils$TreeTraverser.foldTree(TreeUtils.scala:117)
        at scala.tasty.reflect.TreeUtils$TreeAccumulator.foldTrees$$anonfun$1(TreeUtils.scala:17)
        at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:126)
        at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:122)
        at scala.collection.immutable.List.foldLeft(List.scala:89)
        at scala.collection.TraversableOnce.$div$colon(TraversableOnce.scala:154)
        at scala.collection.TraversableOnce.$div$colon$(TraversableOnce.scala:154)
        at scala.collection.AbstractTraversable.$div$colon(Traversable.scala:108)
        at scala.tasty.reflect.TreeUtils$TreeAccumulator.foldTrees(TreeUtils.scala:17)
        at scala.tasty.reflect.TreeUtils$TreeAccumulator.foldOverTree(TreeUtils.scala:79)
        at scala.tasty.reflect.TreeUtils$TreeTraverser.traverseTreeChildren(TreeUtils.scala:120)
        at scala.tasty.reflect.TreeUtils$TreeTraverser.traverseTree(TreeUtils.scala:114)
        at DBConsumer$Traverser$1$.traverseTree(Test.scala:34)
        at DBConsumer.apply(Test.scala:38)
        at dotty.tools.dotc.consumetasty.TastyConsumerPhase.run(TastyConsumerPhase.scala:15)
        at dotty.tools.dotc.core.Phases$Phase.runOn$$anonfun$1(Phases.scala:316)
        at scala.collection.immutable.List.map(List.scala:286)
        at dotty.tools.dotc.core.Phases$Phase.runOn(Phases.scala:318)
        at dotty.tools.dotc.Run.runPhases$4$$anonfun$4(Run.scala:158)
        at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
        at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
        at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
        at dotty.tools.dotc.Run.runPhases$5(Run.scala:170)
        at dotty.tools.dotc.Run.compileUnits$$anonfun$1(Run.scala:178)
        at dotty.runtime.function.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
        at dotty.tools.dotc.util.Stats$.maybeMonitored(Stats.scala:102)
        at dotty.tools.dotc.Run.compileUnits(Run.scala:185)
        at dotty.tools.dotc.Run.compileUnits(Run.scala:125)
        at dotty.tools.dotc.fromtasty.TASTYRun.compile(TASTYRun.scala:10)
        at dotty.tools.dotc.Driver.doCompile(Driver.scala:34)
        at dotty.tools.dotc.Driver.process(Driver.scala:172)
        at dotty.tools.dotc.Driver.process(Driver.scala:141)
        at dotty.tools.dotc.Driver.process(Driver.scala:153)
        at dotty.tools.dotc.consumetasty.ConsumeTasty$.apply(ConsumeTasty.scala:22)
        at dotty.tools.dotc.consumetasty.ConsumeTasty.apply(ConsumeTasty.scala)
        ... 13 more
```

</details>