### PR TITLE
Experiment with Java Object <-> Any compatibility

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -19,7 +19,7 @@ class CompilationUnit protected (val source: SourceFile) {
 
   var tpdTree: tpd.Tree = tpd.EmptyTree
 
-  def isJava: Boolean = source.file.name.endsWith(".java")
+  val isJava: Boolean = source.file.name.endsWith(".java")
 
   /** Pickled TASTY binaries, indexed by class. */
   var pickled: Map[ClassSymbol, Array[Byte]] = Map()

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -8,6 +8,7 @@ import unpickleScala2.Scala2Unpickler.ensureConstructor
 import scala.collection.mutable
 import collection.mutable
 import Denotations.SingleDenotation
+import Annotations.Annotation
 import util.SimpleIdentityMap
 
 object Definitions {
@@ -317,6 +318,11 @@ class Definitions {
 
     def ObjectMethods: List[TermSymbol] = List(Object_eq, Object_ne, Object_synchronized, Object_clone,
         Object_finalize, Object_notify, Object_notifyAll, Object_wait, Object_waitL, Object_waitLI)
+
+  lazy val JavaObjectType = AnnotatedType(ObjectType, Annotation(ObjectClass))
+
+  def objectToJava(tp: Type)(implicit ctx: Context) =
+    if (tp.isDirectRef(ObjectClass) && !ctx.erasedTypes) JavaObjectType else tp
 
   lazy val AnyKindClass: ClassSymbol = {
     val cls = ctx.newCompleteClassSymbol(ScalaPackageClass, tpnme.AnyKind, AbstractFinal | Permanent, Nil)
@@ -1407,8 +1413,8 @@ class Definitions {
       for (m <- ScalaShadowingPackageClass.info.decls)
         ScalaPackageClass.enter(m)
 
-      // force initialization of every symbol that is synthesized or hijacked by the compiler
-      val forced = syntheticCoreClasses ++ syntheticCoreMethods ++ ScalaValueClasses()
+      // force initialization of every symbol or type that is synthesized or hijacked by the compiler
+      val forced = syntheticCoreClasses ++ syntheticCoreMethods ++ ScalaValueClasses() ++ List(JavaObjectType)
 
       isInitialized = true
     }

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -285,7 +285,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
       case tp2: LazyRef =>
         !tp2.evaluating && recur(tp1, tp2.ref)
       case tp2: AnnotatedType if !tp2.isRefining =>
-        recur(tp1, tp2.parent)
+        recur(tp1, if (tp2 eq defn.JavaObjectType) defn.AnyType else tp2.parent)
       case tp2: ThisType =>
         def compareThis = {
           val cls2 = tp2.cls
@@ -962,7 +962,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] {
         case _: TypeVar =>
           recur(tp1, tp2.superType)
         case tycon2: AnnotatedType if !tycon2.isRefining =>
-          recur(tp1, tp2.superType)
+          recur(tp1, if (tycon2 eq defn.JavaObjectType) defn.AnyType else tp2.superType)
         case tycon2: AppliedType =>
           fallback(tycon2.lowerBound)
         case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -219,7 +219,10 @@ trait TypeAssigner {
             else errorType(ex"$what cannot be accessed as a member of $pre$where.$whyNot", pos)
           }
         }
-        else ctx.makePackageObjPrefixExplicit(tpe withDenot d)
+        else {
+          val result = ctx.makePackageObjPrefixExplicit(tpe withDenot d)
+          if (ctx.compilationUnit.isJava) defn.objectToJava(result) else result
+        }
       case _ =>
         tpe
     }


### PR DESCRIPTION
This is an attempt to duplicate the changes in 2.13 on how Java's Object is treated. The idea treat `java.lang.Object` in Java signatures as something that can be either `Any` or `Object`, depending on how it is looked at. I did not succeed so far in making everything work correctly. The main problem is that the behavior for intersections and unions is hard to control. Since the original issue in Scala 2 that caused
the change cannot be duplicated in Dotty, I put this on hold until we find an issue that cannot be solved with existing techniques.