### PR TITLE
Add missing XMLBlock

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
@@ -163,7 +163,7 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(implicit ctx: Cont
     val buffer = ValDef(_buf, TypeTree(), New(_scala_xml_NodeBuffer, ListOfNil))
     val applies = args filterNot isEmptyText map (t => Apply(Select(Ident(_buf), _plus), List(t)))
 
-    atSpan(span)( Block(buffer :: applies.toList, Ident(_buf)) )
+    atSpan(span)(new XMLBlock(buffer :: applies.toList, Ident(_buf)) )
   }
 
   /** Returns (Some(prefix) | None, rest) based on position of ':' */

--- a/tests/pos/xml-attribute-block.scala
+++ b/tests/pos/xml-attribute-block.scala
@@ -1,0 +1,3 @@
+class Foo {
+  <foo a="hello &name; aaa"/>
+}


### PR DESCRIPTION
Add missing workaround of `XMLBlock` positions. This is used in [Positioned.scala#L179](https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/ast/Positioned.scala#L179) to avoid an assertion failure.

This issue is mesing a test in the string interpolator macro project where `<foo a="hello &name; aaa"/>` crashes dotty while `xml"""<foo a="hello &name; aaa"/>"""` works.