### PR TITLE
Fix "sbt console" in Scala 2 projects when sbt-dotty is in the build

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -62,14 +62,14 @@ object Build {
   val referenceVersion = "0.15.0-RC1"
 
   val baseVersion = "0.16.0"
-  val baseSbtDottyVersion = "0.3.2"
+  val baseSbtDottyVersion = "0.3.3"
 
   // Versions used by the vscode extension to create a new project
   // This should be the latest published releases.
   // TODO: Have the vscode extension fetch these numbers from the Internet
   // instead of hardcoding them ?
-  val publishedDottyVersion = "0.13.0-RC1"
-  val publishedSbtDottyVersion = "0.3.1"
+  val publishedDottyVersion = referenceVersion
+  val publishedSbtDottyVersion = "0.3.2"
 
 
   val dottyOrganization = "ch.epfl.lamp"


### PR DESCRIPTION
See https://github.com/scala/scala-xml/issues/313 for example.

No test because apparently there's no way to properly test "sbt console"
from scripted tests:
https://github.com/sbt/sbt/blob/b6f02b9b8cd0abb15e3d8856fd76b570deb1bd61/sbt/src/sbt-test/project/console/test#L7