### PR TITLE
Fix nightly publishing: change syntax after #6558

### DIFF
--- a/sbt-dotty/sbt-test/scala2-compat/eff/i6484.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/eff/i6484.scala
@@ -8,6 +8,6 @@ import org.atnos.eff.syntax.all._
 import scala.language.implicitConversions
 
 object Test {
-  def resolve[T](e: Eff[Fx1[[X] => Kleisli[Id, String, X]], T], g: String): T = 
-    e.runReader[String](g)(Member.Member1[[X] => Kleisli[Id, String, X]]).run
+  def resolve[T](e: Eff[Fx1[[X] =>> Kleisli[Id, String, X]], T], g: String): T =
+    e.runReader[String](g)(Member.Member1[[X] =>> Kleisli[Id, String, X]]).run
 }


### PR DESCRIPTION
We stopped publishing artifacts after #6558, which breaks the sbt-dotty tests that only run before publishing artifacts. 
