### PR TITLE
Remove Enum modifier

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -161,8 +161,6 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
     case class Inline()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Inline)
 
-    case class Enum()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Enum)
-
     case class Instance()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Implied)
   }
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2599,7 +2599,7 @@ object Parsers {
         case CASEOBJECT =>
           objectDef(start, posMods(start, mods | Case | Module))
         case ENUM =>
-          enumDef(start, mods, atSpan(in.skipToken()) { Mod.Enum() })
+          enumDef(start, posMods(start, mods | Enum))
         case IMPLIED =>
           instanceDef(start, mods, atSpan(in.skipToken()) { Mod.Instance() })
         case _ =>
@@ -2647,18 +2647,18 @@ object Parsers {
 
     /**  EnumDef ::=  id ClassConstr InheritClauses EnumBody
      */
-    def enumDef(start: Offset, mods: Modifiers, enumMod: Mod): TypeDef = atSpan(start, nameStart) {
+    def enumDef(start: Offset, mods: Modifiers): TypeDef = atSpan(start, nameStart) {
       val modName = ident()
       val clsName = modName.toTypeName
       val constr = classConstr()
       val templ = template(constr, isEnum = true)
-      finalizeDef(TypeDef(clsName, templ), addMod(mods, enumMod), start)
+      finalizeDef(TypeDef(clsName, templ), mods, start)
     }
 
     /** EnumCase = `case' (id ClassConstr [`extends' ConstrApps] | ids)
      */
     def enumCase(start: Offset, mods: Modifiers): DefTree = {
-      val mods1 = addMod(mods, atSpan(in.offset)(Mod.Enum())) | Case
+      val mods1 = mods | EnumCase
       in.skipCASE()
 
       atSpan(start, nameStart) {


### PR DESCRIPTION
Enum is no longer a modifier. This seems to be some vestige of the old enum design. Cherry-picked from #5495