### PR TITLE
Fix #6585: implement Type.isFunctionType in tasty reflect API

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/KernelImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/KernelImpl.scala
@@ -1080,6 +1080,16 @@ class KernelImpl(val rootContext: core.Contexts.Context, val rootPosition: util.
   def Type_isFunctionType(self: Type)(implicit ctx: Context): Boolean =
     defn.isFunctionType(self)
 
+  def Type_isImplicitFunctionType(self: Type)(implicit ctx: Context): Boolean =
+    defn.isImplicitFunctionType(self)
+
+  def Type_isErasedFunctionType(self: Type)(implicit ctx: Context): Boolean =
+    defn.isErasedFunctionType(self)
+
+  def Type_isDependentFunctionType(self: Type)(implicit ctx: Context): Boolean = {
+    val tpNoRefinement = self.dropDependentRefinement
+    tpNoRefinement != self && defn.isNonRefinedFunction(tpNoRefinement)
+  }
 
   type ConstantType = Types.ConstantType
 

--- a/compiler/src/dotty/tools/dotc/tastyreflect/KernelImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/KernelImpl.scala
@@ -1077,6 +1077,10 @@ class KernelImpl(val rootContext: core.Contexts.Context, val rootPosition: util.
   def Type_derivesFrom(self: Type)(cls: ClassDefSymbol)(implicit ctx: Context): Boolean =
     self.derivesFrom(cls)
 
+  def Type_isFunctionType(self: Type)(implicit ctx: Context): Boolean =
+    defn.isFunctionType(self)
+
+
   type ConstantType = Types.ConstantType
 
   def matchConstantType(tpe: TypeOrBounds)(implicit ctx: Context): Option[ConstantType] = tpe match {

--- a/library/src/scala/tasty/reflect/Kernel.scala
+++ b/library/src/scala/tasty/reflect/Kernel.scala
@@ -869,9 +869,31 @@ trait Kernel {
    *
    *  @return true if the dealised type of `self` without refinement is `FunctionN[T1, T2, ..., Tn]`
    *
-   *  @note `List[Int]` is not a function type, despite that `List[Int] <:< Int => Int`.
+   *  @note The function
+   *
+   *     - returns true for `given Int => Int` and `erased Int => Int`
+   *     - returns false for `List[Int]`, despite that `List[Int] <:< Int => Int`.
    */
   def Type_isFunctionType(self: Type)(implicit ctx: Context): Boolean
+
+
+  /** Is this type an implicit function type?
+   *
+   *  @see `Type_isFunctionType`
+   */
+  def Type_isImplicitFunctionType(self: Type)(implicit ctx: Context): Boolean
+
+  /** Is this type an erased function type?
+   *
+   *  @see `Type_isFunctionType`
+   */
+  def Type_isErasedFunctionType(self: Type)(implicit ctx: Context): Boolean
+
+  /** Is this type a dependent function type?
+   *
+   *  @see `Type_isFunctionType`
+   */
+  def Type_isDependentFunctionType(self: Type)(implicit ctx: Context): Boolean
 
   /** A singleton type representing a known constant value */
   type ConstantType <: Type

--- a/library/src/scala/tasty/reflect/Kernel.scala
+++ b/library/src/scala/tasty/reflect/Kernel.scala
@@ -865,6 +865,14 @@ trait Kernel {
   /** Is this type an instance of a non-bottom subclass of the given class `cls`? */
   def Type_derivesFrom(self: Type)(cls: ClassDefSymbol)(implicit ctx: Context): Boolean
 
+  /** Is this type a function type?
+   *
+   *  @return true if the dealised type of `self` without refinement is `FunctionN[T1, T2, ..., Tn]`
+   *
+   *  @note `List[Int]` is not a function type, despite that `List[Int] <:< Int => Int`.
+   */
+  def Type_isFunctionType(self: Type)(implicit ctx: Context): Boolean
+
   /** A singleton type representing a known constant value */
   type ConstantType <: Type
 

--- a/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
@@ -31,9 +31,30 @@ trait TypeOrBoundsOps extends Core {
      *
      *  @return true if the dealised type of `self` without refinement is `FunctionN[T1, T2, ..., Tn]`
      *
-     *  @note `List[Int]` is not a function type, despite that `List[Int] <:< Int => Int`.
+     *  @note The function
+     *
+     *     - returns true for `given Int => Int` and `erased Int => Int`
+     *     - returns false for `List[Int]`, despite that `List[Int] <:< Int => Int`.
      */
     def isFunctionType(implicit ctx: Context): Boolean = kernel.Type_isFunctionType(self)
+
+    /** Is this type an implicit function type?
+     *
+     *  @see `isFunctionType`
+     */
+    def isImplicitFunctionType(implicit ctx: Context): Boolean = kernel.Type_isImplicitFunctionType(self)
+
+    /** Is this type an erased function type?
+     *
+     *  @see `isFunctionType`
+     */
+    def isErasedFunctionType(implicit ctx: Context): Boolean = kernel.Type_isErasedFunctionType(self)
+
+    /** Is this type a dependent function type?
+     *
+     *  @see `isFunctionType`
+     */
+    def isDependentFunctionType(implicit ctx: Context): Boolean = kernel.Type_isDependentFunctionType(self)
   }
 
   object IsType {

--- a/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
@@ -27,6 +27,13 @@ trait TypeOrBoundsOps extends Core {
     def derivesFrom(cls: ClassDefSymbol)(implicit ctx: Context): Boolean =
       kernel.Type_derivesFrom(self)(cls)
 
+    /** Is this type a function type?
+     *
+     *  @return true if the dealised type of `self` without refinement is `FunctionN[T1, T2, ..., Tn]`
+     *
+     *  @note `List[Int]` is not a function type, despite that `List[Int] <:< Int => Int`.
+     */
+    def isFunctionType(implicit ctx: Context): Boolean = kernel.Type_isFunctionType(self)
   }
 
   object IsType {

--- a/tests/run-macros/reflect-isFunctionType/macro_1.scala
+++ b/tests/run-macros/reflect-isFunctionType/macro_1.scala
@@ -8,3 +8,27 @@ def isFunctionTypeImpl[T](tp: Type[T])(implicit refl: Reflection): Expr[Boolean]
   import refl._
   tp.unseal.tpe.isFunctionType.toExpr
 }
+
+
+inline def isImplicitFunctionType[T:Type]: Boolean = ${ isImplicitFunctionTypeImpl('[T]) }
+
+def isImplicitFunctionTypeImpl[T](tp: Type[T])(implicit refl: Reflection): Expr[Boolean] = {
+  import refl._
+  tp.unseal.tpe.isImplicitFunctionType.toExpr
+}
+
+
+inline def isErasedFunctionType[T:Type]: Boolean = ${ isErasedFunctionTypeImpl('[T]) }
+
+def isErasedFunctionTypeImpl[T](tp: Type[T])(implicit refl: Reflection): Expr[Boolean] = {
+  import refl._
+  tp.unseal.tpe.isErasedFunctionType.toExpr
+}
+
+inline def isDependentFunctionType[T:Type]: Boolean = ${ isDependentFunctionTypeImpl('[T]) }
+
+def isDependentFunctionTypeImpl[T](tp: Type[T])(implicit refl: Reflection): Expr[Boolean] = {
+  import refl._
+  tp.unseal.tpe.isDependentFunctionType.toExpr
+}
+

--- a/tests/run-macros/reflect-isFunctionType/macro_1.scala
+++ b/tests/run-macros/reflect-isFunctionType/macro_1.scala
@@ -1,0 +1,10 @@
+import scala.quoted._
+import scala.tasty._
+
+
+inline def isFunctionType[T:Type]: Boolean = ${ isFunctionTypeImpl('[T]) }
+
+def isFunctionTypeImpl[T](tp: Type[T])(implicit refl: Reflection): Expr[Boolean] = {
+  import refl._
+  tp.unseal.tpe.isFunctionType.toExpr
+}

--- a/tests/run-macros/reflect-isFunctionType/test_2.scala
+++ b/tests/run-macros/reflect-isFunctionType/test_2.scala
@@ -1,0 +1,49 @@
+trait Box {
+  type T
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    assert(!isFunctionType[Option[Int]])
+    assert(!isFunctionType[String])
+
+    assert(!isFunctionType[List[Int]])
+    assert(!isFunctionType[Set[Int]])
+
+    // TODO: compiler failed to synthesize Type[T]
+    // type T = given Set[Int] => Int
+    // assert(isFunctionType[T])
+
+    // TODO: compiler failed to synthesize Type[T]
+    // type T = Int => Int
+    // assert(isFunctionType[T])
+
+    assert(isFunctionType[(b: Box) => b.T])
+    assert(isFunctionType[() => Int])
+    assert(isFunctionType[(Int) => Int])
+    assert(isFunctionType[(Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+    assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+  }
+}

--- a/tests/run-macros/reflect-isFunctionType/test_2.scala
+++ b/tests/run-macros/reflect-isFunctionType/test_2.scala
@@ -45,5 +45,20 @@ object Test {
     assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
     assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
     assert(isFunctionType[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int])
+
+    assert(isDependentFunctionType[(b: Box) => b.T])
+    assert(!isDependentFunctionType[Int => Int])
+    // type A = (b: Box) => b.T
+    // assert(isDependentFunctionType[A])
+
+    assert(isImplicitFunctionType[given Int => Int])
+    assert(!isImplicitFunctionType[Int => Int])
+    // type B = given Set[Int] => Int
+    // assert(isImplicitFunctionType[B])
+
+    assert(isErasedFunctionType[erased Int => Int])
+    assert(!isErasedFunctionType[Int => Int])
+    // type C = erased Set[Int] => Int
+    // assert(isErasedFunctionType[C])
   }
 }


### PR DESCRIPTION
Fix #6585: implement Type.isFunctionType in tasty reflect API