### PR TITLE
Fix #2723: generate direct method for inline accessors

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ShortcutImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ShortcutImplicits.scala
@@ -129,7 +129,7 @@ class ShortcutImplicits extends MiniPhase with IdentityDenotTransformer { thisPh
             .appliedToArgss(vparamSymss.map(_.map(ref(_))) :+ clparamSyms.map(ref(_)))
           val fwdClosure = cpy.Block(tree)(cpy.DefDef(meth)(rhs = forwarder) :: Nil, cl)
           (remappedCore, fwdClosure)
-        case id: Ident =>
+        case id: RefTree =>
           val SAMType(mt) = id.tpe.widen
           splitClosure(tpd.Lambda(mt, args => id.select(nme.apply).appliedToArgs(args))(ctx.withOwner(original)))
         case EmptyTree =>

--- a/tests/pos/i2723.scala
+++ b/tests/pos/i2723.scala
@@ -1,0 +1,3 @@
+trait App(init: given Array[String] => Unit) {
+  inline def main(args: Array[String]): Unit = init given args
+}


### PR DESCRIPTION
Fix #2723: generate direct method for inline accessors

If the inline accessor is an implicit function type,
the rhs is a RefTree instead of a closure. We need to
first eta-expand and then generate the direct method.