### PR TITLE
Fix #6208, #6605: Properly support toplevel defs in the IDE

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -239,8 +239,8 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
     }
   }
 
-  def compile(sourceCode: String): Unit = {
-    val virtualFile = new VirtualFile(sourceCode)
+  def compileFromString(sourceCode: String): Unit = {
+    val virtualFile = new VirtualFile("compileFromString-${java.util.UUID.randomUUID().toString}")
     val writer = new BufferedWriter(new OutputStreamWriter(virtualFile.output, "UTF-8")) // buffering is still advised by javadoc
     writer.write(sourceCode)
     writer.close()

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -296,7 +296,8 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
   }
 
   private def toSource(uri: URI, sourceCode: String): SourceFile = {
-    val virtualFile = new VirtualFile(uri.toString, Paths.get(uri).toString)
+    val path = Paths.get(uri)
+    val virtualFile = new VirtualFile(path.getFileName.toString, path.toString)
     val writer = new BufferedWriter(new OutputStreamWriter(virtualFile.output, "UTF-8"))
     writer.write(sourceCode)
     writer.close()

--- a/compiler/test/dotty/tools/DottyTest.scala
+++ b/compiler/test/dotty/tools/DottyTest.scala
@@ -64,14 +64,7 @@ trait DottyTest extends ContextEscapeDetection {
   def checkCompile(checkAfterPhase: String, source: String)(assertion: (tpd.Tree, Context) => Unit): Context = {
     val c = compilerWithChecker(checkAfterPhase)(assertion)
     val run = c.newRun
-    run.compile(source)
-    run.runContext
-  }
-
-  def checkCompile(checkAfterPhase: String, sources: List[String])(assertion: (tpd.Tree, Context) => Unit): Context = {
-    val c = compilerWithChecker(checkAfterPhase)(assertion)
-    val run = c.newRun
-    run.compile(sources)
+    run.compileFromString(source)
     run.runContext
   }
 

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTest.scala
@@ -58,7 +58,7 @@ trait DottyBytecodeTest {
 
     val compiler = new Compiler
     val run = compiler.newRun
-    compiler.newRun.compile(source)
+    compiler.newRun.compileFromString(source)
 
     checkOutput(ctx.settings.outputDir.value)
   }

--- a/language-server/test/dotty/tools/languageserver/HoverTest.scala
+++ b/language-server/test/dotty/tools/languageserver/HoverTest.scala
@@ -200,4 +200,13 @@ class HoverTest {
       .hover(m3 to m4, hoverContent("Test.🤪"))
 
   }
+
+  @Test def topLevel: Unit = {
+    code"""package hello
+          |val x: Int = 1
+          |val y = ${m1}this${m2}.x""".withSource
+      // The test framework will place the code above in a virtual file called Source0.scala,
+      // sp the top-level definitions should be enclosed in an object called `Source0$package`.
+      .hover(m1 to m2, hoverContent("hello.Source0$package.type(hello.Source0$package)"))
+  }
 }


### PR DESCRIPTION
Toplevel defs are enclosed in an object named `<source>$package` by
`Desugar#packageDef`, this didn't work correctly in the IDE because the
name of the VirtualFile was the whole URI of the file. In particular
this lead to double-vision problems ("cannot merge ...") when the
toplevel definition was also present on the classpath.