### PR TITLE
Workaround Scala 2 package import limitation

### DIFF
--- a/library/src-2.x/scala/quoted/Expr.scala
+++ b/library/src-2.x/scala/quoted/Expr.scala
@@ -17,17 +17,15 @@ package quoted {
 package internal {
   package quoted {
 
-    import scala.quoted._
-
     /** An Expr backed by a pickled TASTY tree */
-    final class TastyExpr[+T](val tasty: scala.runtime.quoted.Unpickler.Pickled, val args: Seq[Any]) extends Expr[T] {
+    final class TastyExpr[+T](val tasty: scala.runtime.quoted.Unpickler.Pickled, val args: Seq[Any]) extends scala.quoted.Expr[T] {
       override def toString: String = s"Expr(<pickled tasty>)"
     }
 
     /** An Expr backed by a lifted value.
      *  Values can only be of type Boolean, Byte, Short, Char, Int, Long, Float, Double, Unit, String or Null.
      */
-    final class LiftedExpr[+T](val value: T) extends Expr[T] {
+    final class LiftedExpr[+T](val value: T) extends scala.quoted.Expr[T] {
       override def toString: String = s"Expr($value)"
     }
 
@@ -38,7 +36,7 @@ package internal {
      *
      *  May contain references to code defined outside this TastyTreeExpr instance.
      */
-    final class TastyTreeExpr[Tree](val tree: Tree) extends quoted.Expr[Any] {
+    final class TastyTreeExpr[Tree](val tree: Tree) extends scala.quoted.Expr[Any] {
       override def toString: String = s"Expr(<tasty tree>)"
     }
 
@@ -46,7 +44,7 @@ package internal {
     // FIXME: Having the List in the code above trigers an assertion error while testing dotty.tools.dotc.reporting.ErrorMessagesTests.i3187
     //        This test does redefine `scala.collection`. Further investigation is needed.
     /** An Expr representing `'{($f).apply($x1, ..., $xn)}` but it is beta-reduced when the closure is known */
-    final class FunctionAppliedTo[+R](val f: Expr[_], val args: Array[Expr[_]]) extends Expr[R] {
+    final class FunctionAppliedTo[+R](val f: scala.quoted.Expr[_], val args: Array[scala.quoted.Expr[_]]) extends scala.quoted.Expr[R] {
       override def toString: String = s"Expr($f <applied to> ${args.toList})"
     }
 

--- a/library/src-2.x/scala/quoted/Type.scala
+++ b/library/src-2.x/scala/quoted/Type.scala
@@ -15,37 +15,36 @@ package quoted {
       def show(implicit toolbox: Toolbox): String = toolbox.show(tpe.asInstanceOf[Type[Any]])
     }
 
-    implicit def UnitTag: Type[Unit] = new TaggedType[Unit]
-    implicit def BooleanTag: Type[Boolean] = new TaggedType[Boolean]
-    implicit def ByteTag: Type[Byte] = new TaggedType[Byte]
-    implicit def CharTag: Type[Char] = new TaggedType[Char]
-    implicit def ShortTag: Type[Short] = new TaggedType[Short]
-    implicit def IntTag: Type[Int] = new TaggedType[Int]
-    implicit def LongTag: Type[Long] = new TaggedType[Long]
-    implicit def FloatTag: Type[Float] = new TaggedType[Float]
-    implicit def DoubleTag: Type[Double] = new TaggedType[Double]
+    implicit def UnitTag: Type[Unit] = new scala.internal.quoted.TaggedType[Unit]
+    implicit def BooleanTag: Type[Boolean] = new scala.internal.quoted.TaggedType[Boolean]
+    implicit def ByteTag: Type[Byte] = new scala.internal.quoted.TaggedType[Byte]
+    implicit def CharTag: Type[Char] = new scala.internal.quoted.TaggedType[Char]
+    implicit def ShortTag: Type[Short] = new scala.internal.quoted.TaggedType[Short]
+    implicit def IntTag: Type[Int] = new scala.internal.quoted.TaggedType[Int]
+    implicit def LongTag: Type[Long] = new scala.internal.quoted.TaggedType[Long]
+    implicit def FloatTag: Type[Float] = new scala.internal.quoted.TaggedType[Float]
+    implicit def DoubleTag: Type[Double] = new scala.internal.quoted.TaggedType[Double]
   }
 
 }
 
 package internal {
   package quoted {
-    import scala.quote.Type
     import scala.reflect.ClassTag
     import scala.runtime.quoted.Unpickler.Pickled
 
     /** A Type backed by a pickled TASTY tree */
-    final class TastyType[T](val tasty: Pickled, val args: Seq[Any]) extends Type[T] {
+    final class TastyType[T](val tasty: Pickled, val args: Seq[Any]) extends scala.quoted.Type[T] {
       override def toString(): String = s"Type(<pickled tasty>)"
     }
 
     /** An Type backed by a value */
-    final class TaggedType[T](implicit val ct: ClassTag[T]) extends Type[T] {
+    final class TaggedType[T](implicit val ct: ClassTag[T]) extends scala.quoted.Type[T] {
       override def toString: String = s"Type($ct)"
     }
 
     /** An Type backed by a tree */
-    final class TreeType[Tree](val typeTree: Tree) extends quoted.Type[Any] {
+    final class TreeType[Tree](val typeTree: Tree) extends scala.quoted.Type[Any] {
       override def toString: String = s"Type(<tasty tree>)"
     }
 


### PR DESCRIPTION
In Scala 2 importing the contents of a different pacakge in the same file does not work.
We use fully qualified paths to workaround this limitation.