### PR TITLE
STOP THE PRESS - Fix privateWithin printing

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -108,11 +108,11 @@ object Flags {
 
     /** The list of non-empty names of flags that are set in this FlagSet */
     def flagStrings(privateWithin: String): Seq[String] = {
-      val rawStrings = (2 to MaxFlag).flatMap(flagString)
-      val scopeStr =
-        if (this is Local) "this"
-        else privateWithin
-      if (privateWithin != "")
+      var rawStrings = (2 to MaxFlag).flatMap(flagString)
+      if (!privateWithin.isEmpty && !this.is(Protected))
+      	rawStrings = rawStrings :+ "private"
+      val scopeStr = if (this.is(Local)) "this" else privateWithin
+      if (scopeStr != "")
         rawStrings.filter(_ != "<local>").map {
           case "private" => s"private[$scopeStr]"
           case "protected" => s"protected[$scopeStr]"

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -403,9 +403,16 @@ class PlainPrinter(_ctx: Context) extends Printer {
     else ""
   }
 
+  protected def privateWithinString(sym: Symbol): String =
+  	if (sym.exists && sym.privateWithin.exists)
+      nameString(sym.privateWithin.name.stripModuleClassSuffix)
+    else ""
+
   /** String representation of symbol's flags */
-  protected def toTextFlags(sym: Symbol): Text =
-    Text(sym.flagsUNSAFE.flagStrings(nameString(sym.privateWithin.name)) map stringToText, " ")
+  protected def toTextFlags(sym: Symbol): Text = toTextFlags(sym, sym.flagsUNSAFE)
+
+  protected def toTextFlags(sym: Symbol, flags: FlagSet): Text =
+    Text(flags.flagStrings(privateWithinString(sym)).map(flag => stringToText(keywordStr(flag))), " ")
 
   /** String representation of symbol's variance or "" if not applicable */
   protected def varianceString(sym: Symbol): String = varianceString(sym.variance)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -819,7 +819,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     val rawFlags = if (sym.exists) sym.flags else mods.flags
     if (rawFlags.is(Param)) flagMask = flagMask &~ Given
     val flags = rawFlags & flagMask
-    val flagsText = if (flags.isEmpty) "" else keywordStr(flags.flagStrings(nameString(sym.privateWithin.name)).mkString(" "))
+    val flagsText = toTextFlags(sym, flags)
     val annotations =
       if (sym.exists) sym.annotations.filterNot(ann => dropAnnotForModText(ann.symbol)).map(_.tree)
       else mods.annotations.filterNot(tree => dropAnnotForModText(tree.symbol))
@@ -896,7 +896,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     else {
       var flags = sym.flagsUNSAFE
       if (flags is TypeParam) flags = flags &~ Protected
-      Text((flags & PrintableFlags(sym.isType)).flagStrings(nameString(sym.privateWithin.name)) map (flag => stringToText(keywordStr(flag))), " ")
+      toTextFlags(sym, flags & PrintableFlags(sym.isType))
     }
 
   override def toText(denot: Denotation): Text = denot match {

--- a/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
@@ -19,12 +19,15 @@ object factories {
 
   type TypeTree = dotty.tools.dotc.ast.Trees.Tree[Type]
 
-  def flags(t: Tree)(implicit ctx: Context): List[String] =
+  def flags(t: Tree)(implicit ctx: Context): List[String] = {
+    val pw = t.symbol.privateWithin
+    val pwStr = if (pw.exists) pw.name.show else ""
     (t.symbol.flags & (if (t.symbol.isType) TypeSourceModifierFlags else TermSourceModifierFlags))
-      .flagStrings(t.symbol.privateWithin.name.show).toList
+      .flagStrings(pwStr).toList
       .filter(_ != "<trait>")
       .filter(_ != "interface")
       .filter(_ != "case")
+  }
 
   def path(sym: Symbol)(implicit ctx: Context): List[String] = {
     @tailrec def go(sym: Symbol, acc: List[String]): List[String] =

--- a/tests/pos/reference/inlines.scala
+++ b/tests/pos/reference/inlines.scala
@@ -4,9 +4,18 @@ object Config {
   inline val logging = false
 }
 
+class Logger {
+  protected[this] var a = 0
+  protected [Logger] var b = 0
+  protected var c = 0
+
+}
+
 object Logger {
 
   private var indent = 0
+  private[this] var a = 0
+  private[Logger] var b = 0
 
   inline def log[T](msg: String)(op: => T): T =
     if (Config.logging) {


### PR DESCRIPTION
Reverts:
  Fix #620: show privateWithin in tree printing (reverted from commit 8a7e01eb9421b57830ebac02d887700b1a875212)

The previous fix messed up printing of all private definitions that did not have a privateWithin.

We need to wait with the 0.16 release until this is merged. 
Also, it would be good to add tests. I verified interactively that it does the right thing now, but am out of time to write a proper test.
