### PR TITLE
Fix syntax in docs

### DIFF
--- a/docs/docs/reference/contextual/inferable-params.md
+++ b/docs/docs/reference/contextual/inferable-params.md
@@ -18,7 +18,7 @@ def max[T](x: T, y: T) given (ord: Ord[T]): T =
 Here, `ord` is an _implicit parameter_ introduced with a `given` clause.
 The `max` method can be applied as follows:
 ```scala
-max(2, 3).given(IntOrd)
+max(2, 3) given IntOrd
 ```
 The `given IntOrd` part passes `IntOrd` as an argument for the `ord` parameter. But the point of
 implicit parameters is that this argument can also be left out (and it usually is). So the following

--- a/docs/docs/reference/contextual/typeclasses.md
+++ b/docs/docs/reference/contextual/typeclasses.md
@@ -55,7 +55,7 @@ delegate ListMonad for Monad[List] {
     List(x)
 }
 
-delegate ReaderMonad[Ctx] for Monad[[X] => Ctx => X] {
+delegate ReaderMonad[Ctx] for Monad[[X] =>> Ctx => X] {
   def (r: Ctx => A) flatMap [A, B] (f: A => Ctx => B): Ctx => B =
     ctx => f(r(ctx))(ctx)
   def pure[A](x: A): Ctx => A =


### PR DESCRIPTION
- Fix type lambda syntax in `reference/contextual/typeclasses.md`
- Remove method style `given` application in `reference/contextual/inferable-params.md`