### PR TITLE
Generate CNAME file on docs generation

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -369,6 +369,9 @@ object Build {
       val majorVersion = baseVersion.take(baseVersion.lastIndexOf('.'))
       IO.write(file("./docs/_site/versions/latest-nightly-base"), majorVersion)
 
+      // This file is used by GitHub Pages when the page is available in a custom domain
+      IO.write(file("./docs/_site/CNAME"), "dotty.epfl.ch")
+
       val sources = unmanagedSources.in(mode match {
         case NonBootstrapped => `dotty-library`
         case Bootstrapped => `dotty-library-bootstrapped`


### PR DESCRIPTION
At the moment http://dotty.epfl.ch does not redirect to https://dotty.epfl.ch 
This PR will fix this.

GitHub reference:
https://help.github.com/en/articles/setting-up-a-www-subdomain