### PR TITLE
Fix #5034: Add error on lazy enum

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -70,8 +70,8 @@ object DesugarEnums {
 
   /** Add implied flags to an enum class or an enum case */
   def addEnumFlags(cdef: TypeDef)(implicit ctx: Context): TypeDef =
-    if (cdef.mods.isEnumClass) cdef.withMods(cdef.mods.withFlags(cdef.mods.flags | Abstract | Sealed))
-    else if (isEnumCase(cdef)) cdef.withMods(cdef.mods.withFlags(cdef.mods.flags | Final))
+    if (cdef.mods.isEnumClass) cdef.withMods(cdef.mods.withFlags(cdef.mods.flags.toTypeFlags | Abstract | Sealed))
+    else if (isEnumCase(cdef)) cdef.withMods(cdef.mods | Final)
     else cdef
 
   private def valuesDot(name: PreName)(implicit src: SourceFile) =

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2259,6 +2259,13 @@ object messages {
     override def explanation: String = ""
   }
 
+  case class LazyEnum()(implicit val ctx: Context)
+    extends Message(LazyStaticFieldID) {
+    override def msg: String = "modifier lazy is not allowed for enums"
+    override def kind: String = "Syntax"
+    override def explanation: String = ""
+  }
+
   case class StaticOverridingNonStaticMembers()(implicit val ctx: Context)
     extends Message(StaticOverridingNonStaticMembersID) {
     override def msg: String = em"${hl("@static")} members cannot override or implement non-static ones"

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -440,7 +440,9 @@ object Checking {
     checkCombination(Lazy, Inline)
     checkNoConflict(Lazy, ParamAccessor, s"parameter may not be `lazy`")
     if (sym.is(Inline)) checkApplicable(Inline, sym.isTerm && !sym.is(Mutable | Module))
-    if (sym.is(Lazy)) checkApplicable(Lazy, !sym.is(Method | Mutable))
+    if(sym.is(Enum) && sym.flags.toTermFlags.is(Lazy)) {
+      fail(LazyEnum())
+    }
     if (sym.isType && !sym.is(Deferred))
       for (cls <- sym.allOverriddenSymbols.filter(_.isClass)) {
         fail(CannotHaveSameNameAs(sym, cls, CannotHaveSameNameAs.CannotBeOverridden))

--- a/tests/neg/i5034.scala
+++ b/tests/neg/i5034.scala
@@ -1,0 +1,3 @@
+lazy enum Color { // error
+  case Blue
+}

--- a/tests/pending/fuzzy/AE-2251401fe4c14de0510247ea75752a42fcfb237a.scala
+++ b/tests/pending/fuzzy/AE-2251401fe4c14de0510247ea75752a42fcfb237a.scala
@@ -1,1 +1,0 @@
-lazy enum i0


### PR DESCRIPTION
Prevents the compiler from crashing, and returns error instead.

```
1 |lazy enum Color {case Blue}
  |          ^
  |          modifier lazy is not allowed for enums
```

I based my solution on work made at https://github.com/lampepfl/dotty/pull/5525 and @odersky concerns regarding the checking for it at `checkWellformed`.