### PR TITLE
Correct misspelling in nonlocal returns

### DIFF
--- a/docs/docs/reference/dropped-features/nonlocal-returns.md
+++ b/docs/docs/reference/dropped-features/nonlocal-returns.md
@@ -3,7 +3,7 @@ layout: doc-page
 title: Deprecated: Nonlocal Returns
 ---
 
-Returning from nested anonymous functions has been deprecated. Nonlocal returns are implemented by throwing and catching `scala.runtime.NonLocalReturnException`-s. This is rarely what is intendant by the programmer. It can be problematic because of the hidden performance cost of throwing and catching exceptions. Furthermore, it is a leaky implementation: a catch-all exception handler can intercept a `NonLocalReturnException`.
+Returning from nested anonymous functions has been deprecated. Nonlocal returns are implemented by throwing and catching `scala.runtime.NonLocalReturnException`-s. This is rarely what is intended by the programmer. It can be problematic because of the hidden performance cost of throwing and catching exceptions. Furthermore, it is a leaky implementation: a catch-all exception handler can intercept a `NonLocalReturnException`.
 
 A drop-in library replacement is provided in `scala.util.control.NonLocalReturns`:
 


### PR DESCRIPTION
Correction 1 of 3 that I found while reading the docs last night.