### PR TITLE
Fix #6676: Add missing buffer bound check

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -799,7 +799,10 @@ object Parsers {
     private def interpolatedString(inPattern: Boolean = false): Tree = atSpan(in.offset) {
       val segmentBuf = new ListBuffer[Tree]
       val interpolator = in.name
-      val isTripleQuoted = in.buf(in.charOffset) == '"' && in.buf(in.charOffset + 1) == '"'
+      val isTripleQuoted =
+        in.charOffset + 1 < in.buf.length &&
+        in.buf(in.charOffset) == '"' &&
+        in.buf(in.charOffset + 1) == '"'
       in.nextToken()
       def nextSegment(literalOffset: Offset) =
         segmentBuf += Thicket(

--- a/compiler/test-resources/repl/i6676
+++ b/compiler/test-resources/repl/i6676
@@ -1,0 +1,25 @@
+scala> xml"
+1 | xml"
+  |    ^
+  |    unclosed string literal
+1 | xml"
+  |     ^
+  |     ';' expected, but eof found
+scala> xml""
+1 | xml""
+  |    ^
+  |value xml is not a member of StringContext - did you mean StringContext.s?
+scala> xml"""
+1 | xml"""
+  |    ^
+  |    unclosed multi-line string literal
+1 | xml"""
+  |       ^
+  |       unclosed multi-line string literal
+scala> s"
+1 | s"
+  |  ^
+  |  unclosed string literal
+1 | s"
+  |   ^
+  |   ';' expected, but eof found


### PR DESCRIPTION
The string interpolator migth be unclosed at the end of the input