### PR TITLE
Prevent adaptations of extension method applications

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -216,8 +216,11 @@ object Applications {
   /** A wrapper indicating that its argument is an application of an extension method.
    */
   class ExtMethodApply(app: Tree)(implicit @constructorOnly src: SourceFile)
-  extends IntegratedTypeArgs(app)
-
+  extends IntegratedTypeArgs(app) {
+    overwriteType(WildcardType)
+      // ExtMethodApply always has wildcard type in order not to prompt any further adaptations
+      // such as eta expansion before the method is fully applied.
+  }
 }
 
 trait Applications extends Compatibility { self: Typer with Dynamic =>

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1348,7 +1348,10 @@ trait Implicits { self: Typer =>
       }
       else {
         val returned =
-          if (cand.isExtension) new Applications.ExtMethodApply(adapted).withType(adapted.tpe)
+          if (cand.isExtension)
+            new Applications.ExtMethodApply(adapted).withType(WildcardType)
+              // Use wildcard type in order not to prompt any further adaptations such as eta expansion
+              // before the method is fully applied.
           else adapted
         SearchSuccess(returned, ref, cand.level)(ctx.typerState, ctx.gadt)
       }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1348,10 +1348,7 @@ trait Implicits { self: Typer =>
       }
       else {
         val returned =
-          if (cand.isExtension)
-            new Applications.ExtMethodApply(adapted).withType(WildcardType)
-              // Use wildcard type in order not to prompt any further adaptations such as eta expansion
-              // before the method is fully applied.
+          if (cand.isExtension) Applications.ExtMethodApply(adapted)
           else adapted
         SearchSuccess(returned, ref, cand.level)(ctx.typerState, ctx.gadt)
       }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3021,9 +3021,7 @@ class Typer extends Namer
           val app = tryExtension(nestedCtx)
           if (!app.isEmpty && !nestedCtx.reporter.hasErrors) {
             nestedCtx.typerState.commit()
-            return new ExtMethodApply(app).withType(WildcardType)
-              // Use wildcard type in order not to prompt any further adaptations such as eta expansion
-              // before the method is fully applied.
+            return ExtMethodApply(app)
           }
         case _ =>
       }

--- a/tests/pos/combine.scala
+++ b/tests/pos/combine.scala
@@ -1,0 +1,10 @@
+trait Semigroup[A] {
+  def (x: A) combine (y: A): A
+}
+delegate for Semigroup[Int] = ???
+delegate [A, B] for Semigroup[(A, B)] given Semigroup[A], Semigroup[B] = ???
+object Test extends App {
+  ((1, 1)) combine ((2, 2)) // doesn't compile
+  ((1, 1): (Int, Int)) combine (2, 2) // compiles
+  //the error that compiler spat out was "value combine is not a member of ((Int, Int)) => (Int, Int)". what's
+}


### PR DESCRIPTION

Prevent adaptations of extension method applications coming from implicit search.
We already did the same for extension method applications coming from imports.