### PR TITLE
Fix #6710: reverse code for dcmpg/dcmpl and fcmpg/fcmpl

### DIFF
--- a/compiler/src/dotty/tools/backend/ScalaPrimitivesOps.scala
+++ b/compiler/src/dotty/tools/backend/ScalaPrimitivesOps.scala
@@ -33,8 +33,8 @@ class ScalaPrimitivesOps {
   final val NE = 43                            // x != y
   final val LT = 44                            // x < y
   final val LE = 45                            // x <= y
-  final val GE = 46                            // x > y
-  final val GT = 47                            // x >= y
+  final val GT = 46                            // x > y
+  final val GE = 47                            // x >= y
 
   // Boolean unary operations
   final val ZNOT = 50                          // !x

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1236,11 +1236,11 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
           (tk: @unchecked) match {
             case LONG   => emit(asm.Opcodes.LCMP)
             case FLOAT  =>
-              if (op == LT || op == LE) emit(asm.Opcodes.FCMPG)
-              else emit(asm.Opcodes.FCMPL)
+              if (op == LT || op == LE) emit(asm.Opcodes.FCMPL)
+              else emit(asm.Opcodes.FCMPG)
             case DOUBLE =>
-              if (op == LT || op == LE) emit(asm.Opcodes.DCMPG)
-              else emit(asm.Opcodes.DCMPL)
+              if (op == LT || op == LE) emit(asm.Opcodes.DCMPL)
+              else emit(asm.Opcodes.DCMPG)
           }
           bc.emitIF(op, success)
         }

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -113,6 +113,13 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
     ).checkRuns()
   }
 
+  @Test def runBootstrappedOnly: Unit = {
+    implicit val testGroup: TestGroup = TestGroup("runBootstrappedOnly")
+    aggregateTests(
+      compileFilesInDir("tests/run-bootstrapped", withCompilerOptions),
+    ).checkRuns()
+  }
+
   // Pickling Tests ------------------------------------------------------------
   //
   // Pickling tests are very memory intensive and as such need to be run with a

--- a/tests/run-bootstrapped/i6710.scala
+++ b/tests/run-bootstrapped/i6710.scala
@@ -1,0 +1,23 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    // constant fold will fail for non-bootstrapped Dotty
+    assert(!(Float.NaN > 0.0))
+    assert(!(Float.NaN < 0.0))
+    assert(!(Double.NaN > 0.0))
+    assert(!(Double.NaN < 0.0))
+
+    val f: Float = Float.NaN
+    val d: Double = Double.NaN
+    assert(!(f > 0.0f))
+    assert(!(f < 0.0f))
+    assert(!(d > 0.0))
+    assert(!(d < 0.0))
+
+    // loop forever before the fix
+    var x = Double.NaN
+    while(x < 10.0) { x = x + 1; println(x) }
+    while(x > 10.0) { x = x + 1; println(x) }
+    do { x = x + 1; println(x) } while(x < 10.0)
+    do { x = x + 1; println(x) } while(x > 10.0)
+  }
+}

--- a/tests/run-bootstrapped/i6710.scala
+++ b/tests/run-bootstrapped/i6710.scala
@@ -19,5 +19,36 @@ object Test {
     while(x > 10.0) { x = x + 1; println(x) }
     do { x = x + 1; println(x) } while(x < 10.0)
     do { x = x + 1; println(x) } while(x > 10.0)
+
+    // tests from https://github.com/scala/scala/pull/5207
+    {
+      val n = Double.NaN
+      def ne(x: Double, y: Double) = x != y
+      val fs: List[(Double, Double) => Boolean] = List(_ < _, _ <= _, _ > _, _ >= _,  _ == _, (x, y) => !ne(x, y))
+      val vs = List[Double](n, 1, -1, 0)
+      for (f <- fs; v <- vs; (x, y) <- List((n, v), (v, n))) assert(!f(x, y))
+    }
+
+    {
+      val n = Float.NaN
+      def ne(x: Float, y: Float) = x != y
+      val fs: List[(Float, Float) => Boolean] = List(_ < _, _ <= _, _ > _, _ >= _,  _ == _, (x, y) => !ne(x, y))
+      val vs = List[Float](n, 1, -1, 0)
+      for (f <- fs; v <- vs; (x, y) <- List((n, v), (v, n))) assert(!f(x, y))
+    }
+
+    {
+      def a[T](x: T, y: T) = x == y
+      def b[T](x: T, y: T) = x != y
+      val n = Double.NaN
+      (a(n, n) :: a(n, 0) :: a (0, n) :: !b(n, n) :: !b(n, 0) :: !b(0, n) :: Nil).foreach(b => assert(!b))
+    }
+
+    {
+      def a[T](x: T, y: T) = x == y
+      def b[T](x: T, y: T) = x != y
+      val n = Float.NaN
+      (a(n, n) :: a(n, 0) :: a (0, n) :: !b(n, n) :: !b(n, 0) :: !b(0, n) :: Nil).foreach(b => assert(!b))
+    }
   }
 }


### PR DESCRIPTION
Note that the test may only run with the bootstrapped compiler,
because the ConstFold in non-bootstrapped compiler is using
the wrongly generated byte-code.