### PR TITLE
Move reflection inside QuoteContext

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -762,6 +762,12 @@ class Definitions {
   @threadUnsafe lazy val QuotedExprType: TypeRef = ctx.requiredClassRef("scala.quoted.Expr")
   def QuotedExprClass(implicit ctx: Context): ClassSymbol = QuotedExprType.symbol.asClass
 
+  @threadUnsafe lazy val QuoteContextType: TypeRef = ctx.requiredClassRef("scala.quoted.QuoteContext")
+  def QuoteContextClass(implicit ctx: Context): ClassSymbol = QuoteContextType.symbol.asClass
+
+  @threadUnsafe lazy val QuoteContextModule: TermSymbol = ctx.requiredModule("scala.quoted.QuoteContext")
+    @threadUnsafe lazy val QuoteContext_macroContext: TermSymbol = QuoteContextModule.requiredMethod("macroContext")
+
   @threadUnsafe lazy val InternalQuotedModuleRef: TermRef = ctx.requiredModuleRef("scala.internal.Quoted")
   def InternalQuotedModule: Symbol = InternalQuotedModuleRef.symbol
     @threadUnsafe lazy val InternalQuoted_exprQuoteR: TermRef = InternalQuotedModule.requiredMethodRef("exprQuote")

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -166,6 +166,7 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
       l == level ||
         level == -1 && (
           sym == defn.TastyReflection_macroContext ||
+          sym == defn.QuoteContext_macroContext ||
             // here we assume that Splicer.canBeSpliced was true before going to level -1,
             // this implies that all non-inline arguments are quoted and that the following two cases are checked
             // on inline parameters or type parameters.

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -114,6 +114,8 @@ object Splicer {
       args.toSeq
 
     protected def interpretTastyContext()(implicit env: Env): Object = ReflectionImpl(ctx, pos)
+    protected def interpretQuoteContext()(implicit env: Env): Object =
+      new scala.quoted.QuoteContext(ReflectionImpl(ctx, pos))
 
     protected def interpretStaticMethodCall(moduleClass: Symbol, fn: Symbol, args: => List[Object])(implicit env: Env): Object = {
       val (inst, clazz) =
@@ -308,6 +310,7 @@ object Splicer {
     protected def interpretLiteral(value: Any)(implicit env: Env): Result
     protected def interpretVarargs(args: List[Result])(implicit env: Env): Result
     protected def interpretTastyContext()(implicit env: Env): Result
+    protected def interpretQuoteContext()(implicit env: Env): Result
     protected def interpretStaticMethodCall(module: Symbol, fn: Symbol, args: => List[Result])(implicit env: Env): Result
     protected def interpretModuleAccess(fn: Symbol)(implicit env: Env): Result
     protected def interpretNew(fn: Symbol, args: => List[Result])(implicit env: Env): Result
@@ -332,6 +335,9 @@ object Splicer {
 
       case _ if tree.symbol == defn.TastyReflection_macroContext =>
         interpretTastyContext()
+
+      case _ if tree.symbol == defn.QuoteContext_macroContext =>
+        interpretQuoteContext()
 
       case Call(fn, args) =>
         if (fn.symbol.isConstructor && fn.symbol.owner.owner.is(Package)) {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -707,6 +707,11 @@ trait Implicits { self: Typer =>
       if (ctx.inInlineMethod || enclosingInlineds.nonEmpty) ref(defn.TastyReflection_macroContext)
       else EmptyTree
 
+  lazy val synthesizedQuoteContext: SpecialHandler =
+    (formal, span) => implicit ctx =>
+      if (ctx.inInlineMethod || enclosingInlineds.nonEmpty) ref(defn.QuoteContext_macroContext)
+      else EmptyTree
+
   lazy val synthesizedTupleFunction: SpecialHandler =
     (formal, span) => implicit ctx => formal match {
       case AppliedType(_, funArgs @ fun :: tupled :: Nil) =>
@@ -1033,9 +1038,10 @@ trait Implicits { self: Typer =>
       mySpecialHandlers = List(
         defn.ClassTagClass        -> synthesizedClassTag,
         defn.QuotedTypeClass      -> synthesizedTypeTag,
+        defn.QuoteContextClass    -> synthesizedQuoteContext,
         defn.TastyReflectionClass -> synthesizedTastyContext,
         defn.EqlClass             -> synthesizedEq,
-        defn.TupledFunctionClass -> synthesizedTupleFunction,
+        defn.TupledFunctionClass  -> synthesizedTupleFunction,
         defn.ValueOfClass         -> synthesizedValueOf,
         defn.Mirror_ProductClass  -> synthesizedProductMirror,
         defn.Mirror_SumClass      -> synthesizedSumMirror,

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1978,7 +1978,7 @@ class Typer extends Namer
             fun = ref(defn.InternalQuotedMatcher_unapplyR).appliedToType(patType),
             implicits =
               ref(defn.InternalQuoted_exprQuoteR).appliedToType(shape.tpe).appliedTo(shape) ::
-              implicitArgTree(defn.TastyReflectionType, tree.span) :: Nil,
+              implicitArgTree(defn.QuoteContextType, tree.span) :: Nil,
             patterns = splicePat :: Nil,
             proto = pt)
         }

--- a/library/src-3.x/scala/internal/quoted/Matcher.scala
+++ b/library/src-3.x/scala/internal/quoted/Matcher.scala
@@ -4,7 +4,6 @@ import scala.annotation.internal.sharable
 
 import scala.quoted._
 import scala.quoted.matching.Bind
-import scala.tasty._
 
 object Matcher {
 
@@ -27,12 +26,11 @@ object Matcher {
    *
    *  @param scrutineeExpr `Expr[_]` on which we are pattern matching
    *  @param patternExpr `Expr[_]` containing the pattern tree
-   *  @param reflection instance of the reflection API (implicitly provided by the macro)
+   *  @param qctx the current QuoteContext
    *  @return None if it did not match, `Some(tup)` if it matched where `tup` contains `Expr[Ti]``
    */
-  def unapply[Tup <: Tuple](scrutineeExpr: Expr[_])(implicit patternExpr: Expr[_], reflection: Reflection): Option[Tup] = {
-    // TODO improve performance
-    import reflection.{Bind => BindPattern, _}
+  def unapply[Tup <: Tuple](scrutineeExpr: Expr[_])(implicit patternExpr: Expr[_], qctx: QuoteContext): Option[Tup] = {
+    import qctx.tasty.{Bind => BindPattern, _}
     import Matching._
 
     type Env = Set[(Symbol, Symbol)]

--- a/library/src-3.x/scala/quoted/Expr.scala
+++ b/library/src-3.x/scala/quoted/Expr.scala
@@ -48,8 +48,8 @@ package quoted {
      *  Given list of statements `s1 :: s2 :: ... :: Nil` and an expression `e` the resulting expression
      *  will be equivalent to `'{ $s1; $s2; ...; $e }`.
      */
-    def block[T](statements: List[Expr[_]], expr: Expr[T])(implicit refl: tasty.Reflection): Expr[T] = {
-      import refl._
+    def block[T](statements: List[Expr[_]], expr: Expr[T])(implicit qctx: QuoteContext): Expr[T] = {
+      import qctx.tasty._
       Block(statements.map(_.unseal), expr.unseal).seal.asInstanceOf[Expr[T]]
     }
 

--- a/library/src-3.x/scala/quoted/matching/Bind.scala
+++ b/library/src-3.x/scala/quoted/matching/Bind.scala
@@ -1,8 +1,6 @@
 package scala.quoted
 package matching
 
-import scala.tasty.Reflection // TODO do not depend on reflection directly
-
 /** Bind of an Expr[T] used to know if some Expr[T] is a reference to the binding
  *
  *  @param name string name of this binding
@@ -21,8 +19,8 @@ class Bind[T <: AnyKind] private[scala](val name: String, private[Bind] val id: 
 
 object Bind {
 
-  def unapply[T](expr: Expr[T])(implicit reflect: Reflection): Option[Bind[T]] = {
-    import reflect.{Bind => BindPattern, _}
+  def unapply[T](expr: Expr[T]) given (qctx: QuoteContext): Option[Bind[T]] = {
+    import qctx.tasty.{Bind => BindPattern, _}
     expr.unseal match {
       case IsIdent(ref) =>
         val sym = ref.symbol

--- a/library/src-3.x/scala/quoted/matching/Const.scala
+++ b/library/src-3.x/scala/quoted/matching/Const.scala
@@ -1,8 +1,5 @@
-package scala.quoted.matching
-
-import scala.quoted.Expr
-
-import scala.tasty.Reflection // TODO do not depend on reflection directly
+package scala.quoted
+package matching
 
 /** Matches expressions containing literal constant values and extracts the value.
  *  It may match expressions of type Boolean, Byte, Short, Int, Long,
@@ -17,8 +14,8 @@ import scala.tasty.Reflection // TODO do not depend on reflection directly
  */
 object Const {
 
-  def unapply[T](expr: Expr[T])(implicit reflect: Reflection): Option[T] = {
-    import reflect._
+  def unapply[T](expr: Expr[T]) given (qctx: QuoteContext): Option[T] = {
+    import qctx.tasty._
     def rec(tree: Term): Option[T] = tree match {
       case Literal(c) => Some(c.value.asInstanceOf[T])
       case Block(Nil, e) => rec(e)

--- a/library/src-3.x/scala/quoted/matching/ConstSeq.scala
+++ b/library/src-3.x/scala/quoted/matching/ConstSeq.scala
@@ -1,14 +1,11 @@
-package scala.quoted.matching
-
-import scala.quoted.Expr
-
-import scala.tasty.Reflection // TODO do not depend on reflection directly
+package scala.quoted
+package matching
 
 /** Literal sequence of literal constant value expressions */
 object ConstSeq {
 
   /** Matches literal sequence of literal constant value expressions */
-  def unapply[T](expr: Expr[Seq[T]]) given Reflection: Option[Seq[T]] = expr match {
+  def unapply[T](expr: Expr[Seq[T]]) given (qctx: QuoteContext): Option[Seq[T]] = expr match {
     case ExprSeq(elems) =>
       elems.foldRight(Option(List.empty[T])) { (elem, acc) =>
         (elem, acc) match {

--- a/library/src-3.x/scala/quoted/matching/ExprSeq.scala
+++ b/library/src-3.x/scala/quoted/matching/ExprSeq.scala
@@ -1,15 +1,12 @@
-package scala.quoted.matching
-
-import scala.quoted.Expr
-
-import scala.tasty.Reflection // TODO do not depend on reflection directly
+package scala.quoted
+package matching
 
 /** Literal sequence of expressions */
 object ExprSeq {
 
   /** Matches a literal sequence of expressions */
-  def unapply[T](expr: Expr[Seq[T]])(implicit reflect: Reflection): Option[Seq[Expr[T]]] = {
-    import reflect._
+  def unapply[T](expr: Expr[Seq[T]]) given (qctx: QuoteContext): Option[Seq[Expr[T]]] = {
+    import qctx.tasty._
     def rec(tree: Term): Option[Seq[Expr[T]]] = tree match {
       case Typed(Repeated(elems, _), _) => Some(elems.map(x => x.seal.asInstanceOf[Expr[T]]))
       case Block(Nil, e) => rec(e)

--- a/library/src-bootstrapped/scala/testing/typeChecks.scala
+++ b/library/src-bootstrapped/scala/testing/typeChecks.scala
@@ -1,12 +1,10 @@
 package scala.testing
 
 import scala.quoted._
-import scala.tasty.Reflection
 
 inline def typeChecks(inline code: String): Boolean = ${ typeChecksImpl(code) }
 
-private def typeChecksImpl(code: String)(implicit reflect: Reflection): Expr[Boolean] = {
-  import reflect._
+private def typeChecksImpl(code: String) given (qctx: QuoteContext): Expr[Boolean] = {
+  import qctx.tasty._
   typing.typeChecks(code).toExpr
 }
-

--- a/library/src-non-bootstrapped/dotty/internal/StringContextMacro.scala
+++ b/library/src-non-bootstrapped/dotty/internal/StringContextMacro.scala
@@ -1,0 +1,16 @@
+// ALWAYS KEEP THIS FILE IN src-non-bootstrapped
+
+package dotty.internal
+
+import scala.quoted._
+import scala.quoted.matching._
+import scala.tasty.Reflection
+import reflect._
+
+object StringContextMacro {
+
+  /** Implementation of scala.StringContext.f used in Dotty */
+  inline def f(sc: => StringContext)(args: Any*): String =
+    scala.compiletime.error("Cannot expand f interpolator while bootstrapping the compiler")
+
+}

--- a/library/src-non-bootstrapped/scala/testing/typeChecks.scala
+++ b/library/src-non-bootstrapped/scala/testing/typeChecks.scala
@@ -1,0 +1,4 @@
+package scala.testing
+
+inline def typeChecks(inline code: String): Boolean =
+  scala.compiletime.error("Cannot expand typeChecks while bootstrapping the compiler")

--- a/library/src/scala/quoted/QuoteContext.scala
+++ b/library/src/scala/quoted/QuoteContext.scala
@@ -2,6 +2,14 @@ package scala.quoted
 
 import scala.quoted.show.SyntaxHighlight
 
+/** Quotation context provided by a macro expansion or in the scope of `scala.quoted.run`.
+ *  Used to perform all operations on quoted `Expr` or `Type`.
+ *
+ *  It contains the low-level Typed AST API `tasty` meta-programming API.
+ *  This API does not have the static type guarantiees that `Expr` and `Type` provide.
+ *
+ *  @param tasty Typed AST API. Usage: `def f(qctx: QuoteContext) = { import qctx.tasty._; ... }`.
+ */
 class QuoteContext(val tasty: scala.tasty.Reflection) {
 
   def show[T](expr: Expr[T], syntaxHighlight: SyntaxHighlight): String = {

--- a/library/src/scala/quoted/QuoteContext.scala
+++ b/library/src/scala/quoted/QuoteContext.scala
@@ -2,16 +2,26 @@ package scala.quoted
 
 import scala.quoted.show.SyntaxHighlight
 
-class QuoteContext(reflection: tasty.Reflection) {
+class QuoteContext(val tasty: scala.tasty.Reflection) {
 
   def show[T](expr: Expr[T], syntaxHighlight: SyntaxHighlight): String = {
-    import reflection._
+    import tasty._
     expr.unseal.show(syntaxHighlight)
   }
 
   def show[T](tpe: Type[T], syntaxHighlight: SyntaxHighlight): String = {
-    import reflection._
+    import tasty._
     tpe.unseal.show(syntaxHighlight)
   }
 
+}
+
+object QuoteContext {
+  // TODO remove in 0.18
+  // For backward compat with macros
+  @deprecated("Provide scala.quoted.QuoteContext instead of using a scala.tasty.Reflection", "0.17")
+  implicit def reflectionToQuoteContext(implicit reflect: tasty.Reflection): scala.quoted.QuoteContext =
+    new scala.quoted.QuoteContext(reflect)
+
+  def macroContext: QuoteContext = throw new Exception("Not in inline macro.")
 }

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -26,6 +26,7 @@ class Reflection(val kernel: Kernel)
   def typeOf[T: scala.quoted.Type]: Type =
     implicitly[scala.quoted.Type[T]].unseal.tpe
 
+  // TODO move out of Reflection
   object typing {
    /** Whether the code type checks in the given context?
     *
@@ -38,18 +39,15 @@ class Reflection(val kernel: Kernel)
     def typeChecks(code: String)(implicit ctx: Context): Boolean = kernel.typeChecks(code)(ctx)
   }
 
+  // TODO integrate with TreeUtils
   val util: reflect.utils.TreeUtils { val reflect: self.type } = new reflect.utils.TreeUtils {
     val reflect: self.type = self
   }
-
-  // TODO remove
-  // For backward compat with macros
-  implicit def reflectionToQuoteContext(implicit reflect: Reflection): scala.quoted.QuoteContext =
-    new scala.quoted.QuoteContext(reflect)
 
 }
 
 object Reflection {
   /** Compiler tasty context available in a top level ~ of an inline macro */
+  @deprecated("Use scala.quoted.QuoteContext instead", "0.17")
   def macroContext: Reflection = throw new Exception("Not in inline macro.")
 }

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -6,8 +6,8 @@ import scala.quoted.matching._
 object Macro {
   inline def (sc: => StringContext) foo (args: String*): Unit = ${ impl('sc) }
 
-  def impl(sc: Expr[StringContext])(implicit reflect: tasty.Reflection): Expr[Unit] = {
-    import reflect._
+  def impl(sc: Expr[StringContext]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     sc match {
       case '{ StringContext(${ExprSeq(parts)}: _*) } =>
         for (part @ Const(s) <- parts)

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -6,8 +6,8 @@ import scala.quoted.matching._
 object Macro {
   inline def (sc: => StringContext) foo (args: String*): Unit = ${ impl('sc) }
 
-  def impl(sc: Expr[StringContext])(implicit reflect: tasty.Reflection): Expr[Unit] = {
-    import reflect._
+  def impl(sc: Expr[StringContext]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     sc match {
       case '{ StringContext(${ExprSeq(parts)}: _*) } =>
         for (part @ Const(s) <- parts)

--- a/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
@@ -14,8 +14,8 @@ object Asserts {
   inline def macroAssert(cond: => Boolean): Unit =
     ${impl('cond)}
 
-  def impl(cond: Expr[Boolean])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl(cond: Expr[Boolean]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val tree = cond.unseal
 

--- a/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
@@ -14,8 +14,8 @@ object Asserts {
   inline def macroAssert(cond: => Boolean): Unit =
     ${ impl('cond) }
 
-  def impl(cond: Expr[Boolean])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl(cond: Expr[Boolean]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val tree = cond.unseal
 

--- a/tests/neg-macros/tasty-macro-error/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-error/quoted_1.scala
@@ -6,8 +6,8 @@ object Macros {
 
   inline def fun(x: Any): Unit = ${ impl('x) }
 
-  def impl(x: Expr[Any])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl(x: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     error("here is the the argument is " + x.unseal.underlyingArgument.show, x.unseal.underlyingArgument.pos)
     '{}
   }

--- a/tests/neg-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-positions/quoted_1.scala
@@ -6,8 +6,8 @@ object Macros {
 
   inline def fun(x: Any): Unit = ${ impl('x) }
 
-  def impl(x: Expr[Any])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl(x: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     val pos = x.unseal.underlyingArgument.pos
     error("here is the the argument is " + x.unseal.underlyingArgument.show, pos)
     error("here (+5) is the the argument is " + x.unseal.underlyingArgument.show, pos.sourceFile, pos.start + 5, pos.end + 5)

--- a/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
@@ -10,8 +10,8 @@ object Macro {
 
 object FIntepolator {
 
-  def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     error("there are no parts", strCtxExpr.unseal.underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }

--- a/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
@@ -9,8 +9,8 @@ object Macro {
 }
 
 object FIntepolator {
-  def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     error("there are no args", argsExpr.unseal.underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }

--- a/tests/neg-with-compiler/i5941/macro_1.scala
+++ b/tests/neg-with-compiler/i5941/macro_1.scala
@@ -12,9 +12,9 @@ object Lens {
     def set(t: T, s: S): S = _set(t)(s)
   }
 
-  def impl[S: Type, T: Type](getter: Expr[S => T])(implicit refl: Reflection): Expr[Lens[S, T]] = {
+  def impl[S: Type, T: Type](getter: Expr[S => T]) given (qctx: QuoteContext): Expr[Lens[S, T]] = {
     implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(this.getClass.getClassLoader)
-    import refl._
+    import qctx.tasty._
     import util._
     // obj.copy(field = value)
     def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =

--- a/tests/neg/quotedPatterns-1.scala
+++ b/tests/neg/quotedPatterns-1.scala
@@ -1,5 +1,5 @@
 object Test {
-  def test(x: quoted.Expr[Int]) given tasty.Reflection = x match {
+  def test(x: quoted.Expr[Int]) given scala.quoted.QuoteContext = x match {
     case '{ val a = '{ println($y) }; 0 } => ??? // error: Not found: y
     case _ =>
   }

--- a/tests/neg/quotedPatterns-2.scala
+++ b/tests/neg/quotedPatterns-2.scala
@@ -1,5 +1,5 @@
 object Test {
-  def test(x: quoted.Expr[Int]) given tasty.Reflection = x match {
+  def test(x: quoted.Expr[Int]) given scala.quoted.QuoteContext = x match {
     case '{ val a = 4; '{ a }; $y } => y // error: access to value a from wrong staging level
     case _ =>
   }

--- a/tests/neg/quotedPatterns-3.scala
+++ b/tests/neg/quotedPatterns-3.scala
@@ -1,5 +1,5 @@
 object Test {
-  def test(x: quoted.Expr[Int]) given tasty.Reflection = x match {
+  def test(x: quoted.Expr[Int]) given scala.quoted.QuoteContext = x match {
     case '{ val `$y`: Int = 2; 1 } =>
       y // error: Not found: y
     case '{ ((`$y`: Int) => 3); 2 } =>

--- a/tests/neg/quotedPatterns-4.scala
+++ b/tests/neg/quotedPatterns-4.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 object Test {
-  def impl(receiver: Expr[StringContext])(implicit reflect: scala.tasty.Reflection) = {
-    import reflect.Repeated
+  def impl(receiver: Expr[StringContext]) given (qctx: scala.quoted.QuoteContext) = {
+    import qctx.tasty.Repeated
     receiver match {
       case '{ StringContext(${Repeated(parts)}: _*) } => // error
     }

--- a/tests/patmat/i6255.scala
+++ b/tests/patmat/i6255.scala
@@ -1,5 +1,5 @@
 class Foo {
-  def foo(x: quoted.Expr[Int]) given scala.tasty.Reflection: Unit = x match {
+  def foo(x: quoted.Expr[Int]) given scala.quoted.QuoteContext: Unit = x match {
     case '{ 1 } =>
     case '{ 2 } =>
     case _ =>

--- a/tests/patmat/i6255b.scala
+++ b/tests/patmat/i6255b.scala
@@ -1,5 +1,5 @@
 class Foo {
-  def foo(x: quoted.Expr[Int]) given scala.tasty.Reflection: Unit = x match {
+  def foo(x: quoted.Expr[Int]) given scala.quoted.QuoteContext: Unit = x match {
     case '{ 1 } =>
     case '{ 2 } =>
   }

--- a/tests/pending/run/tasty-comments/quoted_1.scala
+++ b/tests/pending/run/tasty-comments/quoted_1.scala
@@ -8,8 +8,8 @@ object Macros {
   inline def printComment[T](t: => T): Unit =
     ${ impl('t) }
 
-  def impl[T](x: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl[T](x: Expr[T]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val tree = x.unseal
     tree.symbol.comment.map(_.raw) match {

--- a/tests/pos-macros/i6171/Macro_1.scala
+++ b/tests/pos-macros/i6171/Macro_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(x: => Any): Unit = ${ assertImpl('x) }
 
-  def assertImpl(x: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(x: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     x.unseal.underlyingArgument
     '{ () }
   }

--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition) }
 
-  def assertImpl(cond: Expr[Boolean])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     import util._
 
     cond.unseal.underlyingArgument match {

--- a/tests/pos-macros/tasty-constant-type/Macro_1.scala
+++ b/tests/pos-macros/tasty-constant-type/Macro_1.scala
@@ -6,8 +6,8 @@ object Macro {
 
   inline def ff[A <: Int, B <: Int]() <: AddInt[A, B] = ${ impl('[A], '[B]) }
 
-  def impl[A <: Int : Type, B <: Int : Type](a: Type[A], b: Type[B])(implicit r: tasty.Reflection): Expr[AddInt[A, B]] = {
-    import r._
+  def impl[A <: Int : Type, B <: Int : Type](a: Type[A], b: Type[B]) given (qctx: QuoteContext): Expr[AddInt[A, B]] = {
+    import qctx.tasty._
 
     val Type.ConstantType(Constant.Int(v1)) = a.unseal.tpe
     val Type.ConstantType(Constant.Int(v2)) = b.unseal.tpe

--- a/tests/pos/i6214.scala
+++ b/tests/pos/i6214.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 object Test {
-  def res(x: quoted.Expr[Int]) given tasty.Reflection: quoted.Expr[Int] = x match {
+  def res(x: quoted.Expr[Int]) given QuoteContext: quoted.Expr[Int] = x match {
     case '{ val a: Int = $y; 1} => y                     // owner of `y` is `res`
     case _ => '{ val b: Int = ${val c = 2; c.toExpr}; 1} // owner of `c` is `b`, but that seems to be OK
   }

--- a/tests/pos/i6214b.scala
+++ b/tests/pos/i6214b.scala
@@ -1,5 +1,5 @@
 object Test {
-  def res(x: quoted.Expr[Int]) given tasty.Reflection: quoted.Expr[Int] = x match {
+  def res(x: quoted.Expr[Int]) given scala.quoted.QuoteContext: quoted.Expr[Int] = x match {
     case '{ val a: Int = ${ Foo('{ val b: Int = $y; b }) }; a } => y // owner of y is res
   }
   object Foo {

--- a/tests/pos/i6253.scala
+++ b/tests/pos/i6253.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.tasty.Reflection
 object Macros {
-  def impl(self: Expr[StringContext]) given Reflection: Expr[String] = self match {
+  def impl(self: Expr[StringContext]) given QuoteContext: Expr[String] = self match {
     case '{ StringContext() } => '{""}
     case '{ StringContext($part1) } => part1
     case '{ StringContext($part1, $part2) } => '{ $part1 + $part2 }

--- a/tests/pos/i6435.scala
+++ b/tests/pos/i6435.scala
@@ -1,7 +1,7 @@
 class Foo {
   import scala.quoted._
   import scala.quoted.matching._
-  def f(sc: quoted.Expr[StringContext]) given tasty.Reflection: Unit = {
+  def f(sc: quoted.Expr[StringContext]) given QuoteContext: Unit = {
 
     val '{ StringContext(${parts}: _*) } = sc
     val ps0: Expr[Seq[String]] = parts

--- a/tests/pos/quotedPatterns.scala
+++ b/tests/pos/quotedPatterns.scala
@@ -5,7 +5,7 @@ object Test {
   def f(x: Int) = x
   def g(x: Int, y: Int) = x * y
 
-  def res given tasty.Reflection: quoted.Expr[Int] = x match {
+  def res given scala.quoted.QuoteContext: quoted.Expr[Int] = x match {
     case '{1 + 2} => '{0}
     case '{f($y)} => y
     case '{g($y, $z)} => '{$y * $z}

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -7,8 +7,8 @@ object Foo {
   inline def inspectBody(i: => Int): String =
     ${ inspectBodyImpl('i) }
 
-  def inspectBodyImpl(x: Expr[Int])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  def inspectBodyImpl(x: Expr[Int]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     def definitionString(tree: Tree): Expr[String] = tree.symbol match {
       case IsDefDefSymbol(sym) => sym.tree.showExtractors
       case IsValDefSymbol(sym) => sym.tree.showExtractors

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -7,8 +7,8 @@ object Foo {
   inline def inspectBody(i: => Int): String =
     ${ inspectBodyImpl('i) }
 
-  def inspectBodyImpl(x: Expr[Int])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  def inspectBodyImpl(x: Expr[Int]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     def definitionString(tree: Tree): Expr[String] = tree.symbol match {
       case IsDefDefSymbol(sym) => sym.tree.showExtractors
       case IsValDefSymbol(sym) => sym.tree.showExtractors

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -8,8 +8,8 @@ object Macros {
   implicit inline def printOwners[T](x: => T): Unit =
     ${ impl('x) }
 
-  def impl[T](x: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl[T](x: Expr[T]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val buff = new StringBuilder
 

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
@@ -7,8 +7,8 @@ object Foo {
   inline def inspectBody(i: => Int): String =
     ${ inspectBodyImpl('i) }
 
-  def inspectBodyImpl(x: Expr[Int])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  def inspectBodyImpl(x: Expr[Int]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
 
     def definitionString(tree: Tree): Expr[String] = tree.symbol match {
       case IsClassDefSymbol(sym) => sym.tree.showExtractors.toExpr

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
@@ -7,8 +7,8 @@ object Foo {
   inline def inspectBody(i: => Int): String =
     ${ inspectBodyImpl('i) }
 
-  def inspectBodyImpl(x: Expr[Int])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  def inspectBodyImpl(x: Expr[Int]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
 
     def definitionString(tree: Tree): Expr[String] = tree.symbol match {
       case IsClassDefSymbol(sym) => sym.tree.showExtractors.toExpr

--- a/tests/run-macros/f-interpolation-1/FQuote_1.scala
+++ b/tests/run-macros/f-interpolation-1/FQuote_1.scala
@@ -10,8 +10,8 @@ object FQuote {
     inline def ff(args: => Any*): String = ${impl('this, 'args)}
   }
 
-  /*private*/ def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  /*private*/ def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
 
     def liftListOfAny(lst: List[Term]): Expr[List[Any]] = lst match {
       case x :: xs  =>

--- a/tests/run-macros/f-interpolator-neg/Macros_1.scala
+++ b/tests/run-macros/f-interpolator-neg/Macros_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 import scala.quoted.matching._
-import scala.tasty.Reflection
 
 import scala.language.implicitConversions
 
@@ -13,7 +12,7 @@ object TestFooErrors { // Defined in tests
 
 object Macro {
 
-  def fooErrors(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]) given (reflect: Reflection): Expr[List[(Boolean, Int, Int, Int, String)]] = {
+  def fooErrors(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]) given QuoteContext: Expr[List[(Boolean, Int, Int, Int, String)]] = {
     (strCtxExpr, argsExpr) match {
       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args)) =>
         fooErrorsImpl(parts, args, argsExpr)
@@ -22,7 +21,7 @@ object Macro {
     }
   }
 
-  def fooErrorsImpl(parts : Seq[Expr[String]], args: Seq[Expr[Any]], argsExpr: Expr[Seq[Any]]) given (reflect: Reflection)= {
+  def fooErrorsImpl(parts : Seq[Expr[String]], args: Seq[Expr[Any]], argsExpr: Expr[Seq[Any]]) given QuoteContext= {
     val errors = List.newBuilder[Expr[(Boolean, Int, Int, Int, String)]]
     // true if error, false if warning
     // 0 if part, 1 if arg, 2 if strCtx, 3 if args

--- a/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
+++ b/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
@@ -7,32 +7,32 @@ import scala.tasty._
 object TypeToolbox {
   /** are the two types equal? */
   inline def =:=[A, B]: Boolean = ${tpEqImpl('[A], '[B])}
-  private def tpEqImpl[A, B](a: Type[A], b: Type[B])(implicit reflect: Reflection): Expr[Boolean] = {
-    import reflect._
+  private def tpEqImpl[A, B](a: Type[A], b: Type[B]) given (qctx: QuoteContext): Expr[Boolean] = {
+    import qctx.tasty._
     val res = a.unseal.tpe =:= b.unseal.tpe
     res.toExpr
   }
 
   /** is `tp1` a subtype of `tp2` */
   inline def <:<[A, B]: Boolean = ${tpLEqImpl('[A], '[B])}
-  private def tpLEqImpl[A, B](a: Type[A], b: Type[B])(implicit reflect: Reflection): Expr[Boolean] = {
-    import reflect._
+  private def tpLEqImpl[A, B](a: Type[A], b: Type[B]) given (qctx: QuoteContext): Expr[Boolean] = {
+    import qctx.tasty._
     val res = a.unseal.tpe <:< b.unseal.tpe
     res.toExpr
   }
 
   /** type associated with the tree */
   inline def typeOf[T, Expected](a: T): Boolean = ${typeOfImpl('a, '[Expected])}
-  private def typeOfImpl(a: Expr[_], expected: Type[_])(implicit reflect: Reflection): Expr[Boolean] = {
-    import reflect._
+  private def typeOfImpl(a: Expr[_], expected: Type[_]) given (qctx: QuoteContext): Expr[Boolean] = {
+    import qctx.tasty._
     val res = a.unseal.tpe =:= expected.unseal.tpe
     res.toExpr
   }
 
   /** does the type refer to a case class? */
   inline def isCaseClass[A]: Boolean = ${isCaseClassImpl('[A])}
-  private def isCaseClassImpl(tp: Type[_])(implicit reflect: Reflection): Expr[Boolean] = {
-    import reflect._
+  private def isCaseClassImpl(tp: Type[_]) given (qctx: QuoteContext): Expr[Boolean] = {
+    import qctx.tasty._
     val res = tp.unseal.symbol match {
       case IsClassDefSymbol(sym) => sym.flags.is(Flags.Case)
       case _ => false
@@ -42,67 +42,67 @@ object TypeToolbox {
 
   /** val fields of a case class Type -- only the ones declared in primary constructor */
   inline def caseFields[T]: List[String] = ${caseFieldsImpl('[T])}
-  private def caseFieldsImpl(tp: Type[_])(implicit reflect: Reflection): Expr[List[String]] = {
-    import reflect._
+  private def caseFieldsImpl(tp: Type[_]) given (qctx: QuoteContext): Expr[List[String]] = {
+    import qctx.tasty._
     val fields = tp.unseal.symbol.asClassDef.caseFields.map(_.name)
     fields.toExpr
   }
 
   inline def fieldIn[T](inline mem: String): String = ${fieldInImpl('[T], mem)}
-  private def fieldInImpl(t: Type[_], mem: String)(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  private def fieldInImpl(t: Type[_], mem: String) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     val field = t.unseal.symbol.asClassDef.field(mem)
     field.map(_.name).getOrElse("").toExpr
   }
 
   inline def fieldsIn[T]: Seq[String] = ${fieldsInImpl('[T])}
-  private def fieldsInImpl(t: Type[_])(implicit reflect: Reflection): Expr[Seq[String]] = {
-    import reflect._
+  private def fieldsInImpl(t: Type[_]) given (qctx: QuoteContext): Expr[Seq[String]] = {
+    import qctx.tasty._
     val fields = t.unseal.symbol.asClassDef.fields
     fields.map(_.name).toList.toExpr
   }
 
   inline def methodIn[T](inline mem: String): Seq[String] = ${methodInImpl('[T], mem)}
-  private def methodInImpl(t: Type[_], mem: String)(implicit reflect: Reflection): Expr[Seq[String]] = {
-    import reflect._
+  private def methodInImpl(t: Type[_], mem: String) given (qctx: QuoteContext): Expr[Seq[String]] = {
+    import qctx.tasty._
     t.unseal.symbol.asClassDef.classMethod(mem).map(_.name).toExpr
   }
 
   inline def methodsIn[T]: Seq[String] = ${methodsInImpl('[T])}
-  private def methodsInImpl(t: Type[_])(implicit reflect: Reflection): Expr[Seq[String]] = {
-    import reflect._
+  private def methodsInImpl(t: Type[_]) given (qctx: QuoteContext): Expr[Seq[String]] = {
+    import qctx.tasty._
     t.unseal.symbol.asClassDef.classMethods.map(_.name).toExpr
   }
 
   inline def method[T](inline mem: String): Seq[String] = ${methodImpl('[T], mem)}
-  private def methodImpl(t: Type[_], mem: String)(implicit reflect: Reflection): Expr[Seq[String]] = {
-    import reflect._
+  private def methodImpl(t: Type[_], mem: String) given (qctx: QuoteContext): Expr[Seq[String]] = {
+    import qctx.tasty._
     t.unseal.symbol.asClassDef.method(mem).map(_.name).toExpr
   }
 
   inline def methods[T]: Seq[String] = ${methodsImpl('[T])}
-  private def methodsImpl(t: Type[_])(implicit reflect: Reflection): Expr[Seq[String]] = {
-    import reflect._
+  private def methodsImpl(t: Type[_]) given (qctx: QuoteContext): Expr[Seq[String]] = {
+    import qctx.tasty._
     t.unseal.symbol.asClassDef.methods.map(_.name).toExpr
   }
 
   inline def typeTag[T](x: T): String = ${typeTagImpl('[T])}
-  private def typeTagImpl(tp: Type[_])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  private def typeTagImpl(tp: Type[_]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     val res = tp.unseal.tpe.show
     res.toExpr
   }
 
   inline def companion[T1, T2]: Boolean = ${companionImpl('[T1], '[T2])}
-  private def companionImpl(t1: Type[_], t2: Type[_])(implicit reflect: Reflection): Expr[Boolean] = {
-    import reflect._
+  private def companionImpl(t1: Type[_], t2: Type[_]) given (qctx: QuoteContext): Expr[Boolean] = {
+    import qctx.tasty._
     val res = t1.unseal.symbol.asClassDef.companionModule.contains(t2.unseal.symbol)
     res.toExpr
   }
 
   inline def companionName[T1]: String = ${companionNameImpl('[T1])}
-  private def companionNameImpl(tp: Type[_])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  private def companionNameImpl(tp: Type[_]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     val companionClassOpt = tp.unseal.symbol match {
       case IsClassDefSymbol(sym) => sym.companionClass
       case IsValDefSymbol(sym) => sym.companionClass

--- a/tests/run-macros/i4515b/Macro_1.scala
+++ b/tests/run-macros/i4515b/Macro_1.scala
@@ -1,6 +1,6 @@
-import scala.tasty.Reflection
+import scala.quoted._
 
 object Macro {
   inline def foo: Unit = ${ fooImpl }
-  def fooImpl(implicit reflect: Reflection): quoted.Expr[Unit] = '{}
+  def fooImpl given QuoteContext: Expr[Unit] = '{}
 }

--- a/tests/run-macros/i5119/Macro_1.scala
+++ b/tests/run-macros/i5119/Macro_1.scala
@@ -7,8 +7,8 @@ object Macro {
     inline def ff(args: => Any*): String = ${ Macro.impl('sc, 'args) }
   }
   implicit inline def XmlQuote(sc: => StringContext): StringContextOps = new StringContextOps(sc)
-  def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  def impl(sc: Expr[StringContext], args: Expr[Seq[Any]]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     (sc.unseal.underlyingArgument.showExtractors + "\n" + args.unseal.underlyingArgument.showExtractors)
   }
 }

--- a/tests/run-macros/i5119b/Macro_1.scala
+++ b/tests/run-macros/i5119b/Macro_1.scala
@@ -7,8 +7,8 @@ object Macro {
 
   inline def ff(arg1: Any,  arg2: Any): String = ${ Macro.impl('{arg1}, '{arg2}) }
 
-  def impl(arg1: Expr[Any], arg2: Expr[Any])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  def impl(arg1: Expr[Any], arg2: Expr[Any]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     (arg1.unseal.underlyingArgument.showExtractors + "\n" + arg2.unseal.underlyingArgument.showExtractors)
   }
 

--- a/tests/run-macros/i5533/Macro_1.scala
+++ b/tests/run-macros/i5533/Macro_1.scala
@@ -8,8 +8,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
-  def assertImpl(condition: Expr[Boolean])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(condition: Expr[Boolean]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val tree = condition.unseal
 

--- a/tests/run-macros/i5533b/Macro_1.scala
+++ b/tests/run-macros/i5533b/Macro_1.scala
@@ -7,8 +7,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
-  def assertImpl(condition: Expr[Boolean])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(condition: Expr[Boolean]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     val tree = condition.unseal
     def exprStr: String = condition.show
 

--- a/tests/run-macros/i5536/Macro_1.scala
+++ b/tests/run-macros/i5536/Macro_1.scala
@@ -4,8 +4,8 @@ import scala.tasty._
 object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
-  def assertImpl(condition: Expr[Boolean])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(condition: Expr[Boolean]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     val tree = condition.unseal
     def exprStr: String = condition.show
 

--- a/tests/run-macros/i5629/Macro_1.scala
+++ b/tests/run-macros/i5629/Macro_1.scala
@@ -5,16 +5,16 @@ object Macros {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('{condition}, '{""}) }
 
-  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean], clue: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     val b = cond.unseal.underlyingArgument.seal.cast[Boolean]
     '{ scala.Predef.assert($b) }
   }
 
   inline def thisLineNumber = ${ thisLineNumberImpl }
 
-  def thisLineNumberImpl(implicit refl: Reflection): Expr[Int] = {
-    import refl._
-    refl.rootPosition.startLine.toExpr
+  def thisLineNumberImpl given (qctx: QuoteContext): Expr[Int] = {
+    import qctx.tasty._
+    rootPosition.startLine.toExpr
   }
 }

--- a/tests/run-macros/i5715/Macro_1.scala
+++ b/tests/run-macros/i5715/Macro_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
-  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean], clue: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     cond.unseal.underlyingArgument match {
       case app @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>

--- a/tests/run-macros/i5941/macro_1.scala
+++ b/tests/run-macros/i5941/macro_1.scala
@@ -12,8 +12,8 @@ object Lens {
     def set(t: T, s: S): S = _set(t)(s)
   }
 
-  def impl[S: Type, T: Type](getter: Expr[S => T])(implicit refl: Reflection): Expr[Lens[S, T]] = {
-    import refl._
+  def impl[S: Type, T: Type](getter: Expr[S => T]) given (qctx: QuoteContext): Expr[Lens[S, T]] = {
+    import qctx.tasty._
     import util._
 
     // obj.copy(a = obj.a.copy(b = a.b.copy(c = v)))
@@ -90,8 +90,8 @@ object Iso {
     def to(s: S): A = _to(s)
   }
 
-  def impl[S: Type, A: Type](implicit refl: Reflection): Expr[Iso[S, A]] = {
-    import refl._
+  def impl[S: Type, A: Type] given (qctx: QuoteContext): Expr[Iso[S, A]] = {
+    import qctx.tasty._
     import util._
 
     val tpS = typeOf[S]
@@ -126,8 +126,8 @@ object Iso {
     }
   }
 
-  def implUnit[S: Type](implicit refl: Reflection): Expr[Iso[S, 1]] = {
-    import refl._
+  def implUnit[S: Type] given (qctx: QuoteContext): Expr[Iso[S, 1]] = {
+    import qctx.tasty._
     import util._
 
     val tpS = typeOf[S]
@@ -161,7 +161,7 @@ object Iso {
   }
 
   // TODO: require whitebox macro
-  def implFields[S: Type](implicit refl: Reflection): Expr[Iso[S, Any]] = ???
+  def implFields[S: Type] given (qctx: QuoteContext): Expr[Iso[S, Any]] = ???
 }
 
 object GenIso {
@@ -196,8 +196,8 @@ object Prism {
     def apply(a: A): S = app(a)
   }
 
-  def impl[S: Type, A <: S : Type](implicit refl: Reflection): Expr[Prism[S, A]] = {
-    import refl._
+  def impl[S: Type, A <: S : Type] given (qctx: QuoteContext): Expr[Prism[S, A]] = {
+    import qctx.tasty._
     import util._
 
     '{

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
-  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean], clue: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean =

--- a/tests/run-macros/i6253-b/quoted_1.scala
+++ b/tests/run-macros/i6253-b/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
 
   inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}
 
-  private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(implicit reflect: Reflection): Expr[String] = {
+  private def impl(self: Expr[StringContext], args: Expr[Seq[String]]) given QuoteContext: Expr[String] = {
     self match {
       case '{ StringContext($parts: _*) } =>
         '{

--- a/tests/run-macros/i6253/quoted_1.scala
+++ b/tests/run-macros/i6253/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
 
   inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}
 
-  private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(implicit reflect: Reflection): Expr[String] = {
+  private def impl(self: Expr[StringContext], args: Expr[Seq[String]]) given QuoteContext: Expr[String] = {
     self match {
       case '{ StringContext($parts: _*) } =>
         '{ StringContext($parts: _*).s($args: _*) }

--- a/tests/run-macros/i6518/Macro_1.scala
+++ b/tests/run-macros/i6518/Macro_1.scala
@@ -6,8 +6,8 @@ object Macros {
 
   inline def test(): String = ${ testImpl }
 
-  private def testImpl(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  private def testImpl given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     val classSym = typeOf[Function1[_, _]].classSymbol.get
     classSym.classMethod("apply")
     classSym.classMethods

--- a/tests/run-macros/inferred-repeated-result/test_1.scala
+++ b/tests/run-macros/inferred-repeated-result/test_1.scala
@@ -4,8 +4,8 @@ object Macros {
   import scala.tasty._
 
   inline def go[T](t: => T) = ${ impl('t) }
-  def impl[T](expr: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl[T](expr: Expr[T]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val tree = expr.unseal
 

--- a/tests/run-macros/quote-impure-by-name/quoted_1.scala
+++ b/tests/run-macros/quote-impure-by-name/quoted_1.scala
@@ -12,8 +12,7 @@ object Index {
 
   implicit inline def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ${ succImpl[K, H, T]('prev) }
 
-  def succImpl[K, H, T](prev: Expr[Index[K, T]])(implicit k: Type[K], h: Type[H], t: Type[T], relection: Reflection): Expr[Index[K, (H, T)]] = {
-    import relection._
+  def succImpl[K: Type, H: Type, T: Type](prev: Expr[Index[K, T]]) given QuoteContext: Expr[Index[K, (H, T)]] = {
     val value = s"1 + {${prev.show}}"
     '{new Index(${value})}
   }

--- a/tests/run-macros/quote-inline-function/quoted_1.scala
+++ b/tests/run-macros/quote-inline-function/quoted_1.scala
@@ -7,8 +7,8 @@ object Macros {
   inline def foreach1(start: Int, end: Int, f: Int => Unit): String = ${impl('start, 'end, 'f)}
   inline def foreach2(start: Int, end: Int, f: => Int => Unit): String = ${impl('start, 'end, 'f)}
 
-  def impl(start: Expr[Int], end: Expr[Int], f: Expr[Int => Unit])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  def impl(start: Expr[Int], end: Expr[Int], f: Expr[Int => Unit]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     val res = '{
       var i = $start
       val j = $end

--- a/tests/run-macros/quote-matcher-runtime/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-runtime/quoted_1.scala
@@ -7,10 +7,10 @@ object Macros {
 
   inline def matches[A, B](a: => A, b: => B): Unit = ${impl('a, 'b)}
 
-  private def impl[A, B](a: Expr[A], b: Expr[B])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect.{Bind => _, _}
+  private def impl[A, B](a: Expr[A], b: Expr[B]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty.{Bind => _, _}
 
-    val res = scala.internal.quoted.Matcher.unapply[Tuple](a)(b, reflect).map { tup =>
+    val res = scala.internal.quoted.Matcher.unapply[Tuple](a)(b, qctx).map { tup =>
       tup.toArray.toList.map {
         case r: Expr[_] =>
           s"Expr(${r.unseal.show})"

--- a/tests/run-macros/quote-matcher-string-interpolator-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-string-interpolator-2/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
 
   inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}
 
-  private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(implicit reflect: Reflection): Expr[String] = {
+  private def impl(self: Expr[StringContext], args: Expr[Seq[String]]) given QuoteContext: Expr[String] = {
     (self, args) match {
       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args1)) =>
         val strParts = parts.map { case Const(str) => str.reverse }

--- a/tests/run-macros/quote-matcher-string-interpolator-3/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-string-interpolator-3/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
 
   inline def (self: => StringContext) S(args: => String*): String = ${impl('self, 'args)}
 
-  private def impl(self: Expr[StringContext], args: Expr[Seq[String]]) given Reflection: Expr[String] = {
+  private def impl(self: Expr[StringContext], args: Expr[Seq[String]]) given QuoteContext: Expr[String] = {
     self match {
       case '{ StringContext(${ConstSeq(parts)}: _*) } =>
         val upprerParts: List[String] = parts.toList.map(_.toUpperCase)

--- a/tests/run-macros/quote-matcher-string-interpolator/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-string-interpolator/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
 
   inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}
 
-  private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(implicit reflect: Reflection): Expr[String] = {
+  private def impl(self: Expr[StringContext], args: Expr[Seq[String]]) given QuoteContext: Expr[String] = {
     self match {
       case '{ StringContext(${ExprSeq(parts)}: _*) } =>
         val parts2 = parts.map(x => '{ $x.reverse }).toList.toExprOfList

--- a/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
@@ -9,7 +9,7 @@ object Macros {
 
   inline def lift[T](sym: Symantics[T])(a: => DSL): T = ${impl[T]('sym, 'a)}
 
-  private def impl[T: Type](sym: Expr[Symantics[T]], a: Expr[DSL])(implicit reflect: Reflection): Expr[T] = {
+  private def impl[T: Type](sym: Expr[Symantics[T]], a: Expr[DSL]) given (qctx: QuoteContext): Expr[T] = {
 
     def lift(e: Expr[DSL]): Expr[T] = e match {
 
@@ -26,7 +26,7 @@ object Macros {
         '{ $sym.times(${lift(x)}, ${lift(y)}) }
 
       case _ =>
-        import reflect._
+        import qctx.tasty._
         error("Expected explicit DSL", e.unseal.pos)
         '{ ??? }
 

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.matching._
 
-import scala.tasty.Reflection
-
 object Macros {
 
   inline def liftString(a: => DSL): String = ${impl(StringNum, 'a)}
@@ -11,7 +9,7 @@ object Macros {
 
   inline def liftAST(a: => DSL): ASTNum = ${impl(ASTNum, 'a)}
 
-  private def impl[T: Type](sym: Symantics[T], a: Expr[DSL])(implicit reflect: Reflection): Expr[T] = {
+  private def impl[T: Type](sym: Symantics[T], a: Expr[DSL]) given (qctx: QuoteContext): Expr[T] = {
 
     def lift(e: Expr[DSL])(implicit env: Map[Bind[DSL], Expr[T]]): Expr[T] = e match {
 
@@ -28,7 +26,7 @@ object Macros {
       case Bind(b) if env.contains(b) => env(b)
 
       case _ =>
-        import reflect._
+        import qctx.tasty._
         error("Expected explicit DSL", e.unseal.pos)
         ???
     }
@@ -38,7 +36,7 @@ object Macros {
         sym.lam((y: Expr[T]) => lift(body)(env + (x -> y)))
 
       case _ =>
-        import reflect._
+        import qctx.tasty._
         error("Expected explicit DSL => DSL", e.unseal.pos)
         ???
     }

--- a/tests/run-macros/quoted-expr-block/quoted_1.scala
+++ b/tests/run-macros/quoted-expr-block/quoted_1.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 inline def replicate(inline times: Int, code: => Any) = ${replicateImpl(times, 'code)}
 
-private def replicateImpl(times: Int, code: Expr[Any]) given tasty.Reflection = {
+private def replicateImpl(times: Int, code: Expr[Any]) given QuoteContext = {
   @annotation.tailrec def loop(n: Int, accum: List[Expr[Any]]): List[Expr[Any]] =
     if (n > 0) loop(n - 1, code :: accum) else accum
   Expr.block(loop(times, Nil), '{})

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
-  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean], clue: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean =

--- a/tests/run-macros/reflect-isFunctionType/macro_1.scala
+++ b/tests/run-macros/reflect-isFunctionType/macro_1.scala
@@ -4,31 +4,31 @@ import scala.tasty._
 
 inline def isFunctionType[T:Type]: Boolean = ${ isFunctionTypeImpl('[T]) }
 
-def isFunctionTypeImpl[T](tp: Type[T])(implicit refl: Reflection): Expr[Boolean] = {
-  import refl._
+def isFunctionTypeImpl[T](tp: Type[T]) given (qctx: QuoteContext): Expr[Boolean] = {
+  import qctx.tasty._
   tp.unseal.tpe.isFunctionType.toExpr
 }
 
 
 inline def isImplicitFunctionType[T:Type]: Boolean = ${ isImplicitFunctionTypeImpl('[T]) }
 
-def isImplicitFunctionTypeImpl[T](tp: Type[T])(implicit refl: Reflection): Expr[Boolean] = {
-  import refl._
+def isImplicitFunctionTypeImpl[T](tp: Type[T]) given (qctx: QuoteContext): Expr[Boolean] = {
+  import qctx.tasty._
   tp.unseal.tpe.isImplicitFunctionType.toExpr
 }
 
 
 inline def isErasedFunctionType[T:Type]: Boolean = ${ isErasedFunctionTypeImpl('[T]) }
 
-def isErasedFunctionTypeImpl[T](tp: Type[T])(implicit refl: Reflection): Expr[Boolean] = {
-  import refl._
+def isErasedFunctionTypeImpl[T](tp: Type[T]) given (qctx: QuoteContext): Expr[Boolean] = {
+  import qctx.tasty._
   tp.unseal.tpe.isErasedFunctionType.toExpr
 }
 
 inline def isDependentFunctionType[T:Type]: Boolean = ${ isDependentFunctionTypeImpl('[T]) }
 
-def isDependentFunctionTypeImpl[T](tp: Type[T])(implicit refl: Reflection): Expr[Boolean] = {
-  import refl._
+def isDependentFunctionTypeImpl[T](tp: Type[T]) given (qctx: QuoteContext): Expr[Boolean] = {
+  import qctx.tasty._
   tp.unseal.tpe.isDependentFunctionType.toExpr
 }
 

--- a/tests/run-macros/reflect-pos-fun/assert_1.scala
+++ b/tests/run-macros/reflect-pos-fun/assert_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition) }
 
-  def assertImpl(cond: Expr[Boolean])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     import util._
 
     cond.unseal.underlyingArgument match {

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
-  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean], clue: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean =

--- a/tests/run-macros/reflect-select-copy/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy/assert_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
-  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean], clue: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     cond.unseal.underlyingArgument match {
       case Apply(sel @ Select(lhs, op), rhs :: Nil) =>

--- a/tests/run-macros/reflect-select-copy/reflect-select-copy/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy/reflect-select-copy/assert_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
-  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean], clue: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean =

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
-  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean], clue: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean =

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -5,8 +5,8 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
-  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(cond: Expr[Boolean], clue: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean =

--- a/tests/run-macros/reflect-typeChecks/assert_1.scala
+++ b/tests/run-macros/reflect-typeChecks/assert_1.scala
@@ -6,8 +6,8 @@ object scalatest {
   inline def assertCompile(inline code: String): Unit = ${ assertImpl(code, true) }
   inline def assertNotCompile(inline code: String): Unit = ${ assertImpl(code, false) }
 
-  def assertImpl(code: String, expect: Boolean)(implicit refl: Reflection): Expr[Unit] = {
-    import refl._
+  def assertImpl(code: String, expect: Boolean) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val actual = typing.typeChecks(code)
 

--- a/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
@@ -7,8 +7,8 @@ object Macros {
 
   inline def inspect[T](x: T): Unit = ${ impl('x) }
 
-  def impl[T](x: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl[T](x: Expr[T]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     val tree = x.unseal
     '{
       println()

--- a/tests/run-macros/tasty-custom-show/quoted_1.scala
+++ b/tests/run-macros/tasty-custom-show/quoted_1.scala
@@ -8,8 +8,8 @@ object Macros {
   implicit inline def printOwners[T](x: => T): Unit =
     ${ impl('x) }
 
-  def impl[T](x: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl[T](x: Expr[T]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val buff = new StringBuilder
 
@@ -39,15 +39,15 @@ object Macros {
     '{print(${buff.result()})}
   }
 
-  def dummyShow(implicit reflect: Reflection): reflect.Printer = {
-    import reflect._
+  def dummyShow given (qctx: QuoteContext): qctx.tasty.Printer = {
+    import qctx.tasty._
     new Printer {
       def showTree(tree: Tree)(implicit ctx: Context): String = "Tree"
       def showPattern(pattern: Pattern)(implicit ctx: Context): String = "Pattern"
       def showTypeOrBounds(tpe: TypeOrBounds)(implicit ctx: Context): String = "TypeOrBounds"
       def showConstant(const: Constant)(implicit ctx: Context): String = "Constant"
       def showSymbol(symbol: Symbol)(implicit ctx: Context): String = "Symbol"
-      def showFlags(flags: Flags)(implicit ctx: reflect.Context): String = "Flags"
+      def showFlags(flags: Flags)(implicit ctx: Context): String = "Flags"
     }
   }
 

--- a/tests/run-macros/tasty-dealias/quoted_1.scala
+++ b/tests/run-macros/tasty-dealias/quoted_1.scala
@@ -5,8 +5,8 @@ object Macros {
 
   inline def dealias[T]: String = ${ impl('[T]) }
 
-  def impl[T](x: quoted.Type[T])(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  def impl[T](x: quoted.Type[T]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     x.unseal.tpe.dealias.show.toExpr
   }
 }

--- a/tests/run-macros/tasty-definitions-1/quoted_1.scala
+++ b/tests/run-macros/tasty-definitions-1/quoted_1.scala
@@ -7,8 +7,8 @@ object Macros {
 
   inline def testDefinitions(): Unit = ${testDefinitionsImpl}
 
-  def testDefinitionsImpl(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def testDefinitionsImpl given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val buff = List.newBuilder[String]
     def printout(x: => String): Unit = {

--- a/tests/run-macros/tasty-eval/quoted_1.scala
+++ b/tests/run-macros/tasty-eval/quoted_1.scala
@@ -8,19 +8,19 @@ object Macros {
   implicit inline def foo(i: Int): String =
     ${ impl('i) }
 
-  def impl(i: Expr[Int])(implicit reflect: Reflection): Expr[String] = {
+  def impl(i: Expr[Int]) given QuoteContext: Expr[String] = {
     value(i).toString
   }
 
-  inline implicit def value[X](e: Expr[X])(implicit reflect: Reflection, ev: Valuable[X]): Option[X] = ev.value(e)
+  inline implicit def value[X](e: Expr[X])(implicit qctx: QuoteContext, ev: Valuable[X]): Option[X] = ev.value(e)
 
   trait Valuable[X] {
-    def value(e: Expr[X])(implicit reflect: Reflection): Option[X]
+    def value(e: Expr[X]) given QuoteContext: Option[X]
   }
 
   implicit def intIsEvalable: Valuable[Int] = new Valuable[Int] {
-    override def value(e: Expr[Int])(implicit reflect: Reflection): Option[Int] = {
-      import reflect._
+    override def value(e: Expr[Int]) given (qctx: QuoteContext): Option[Int] = {
+      import qctx.tasty._
 
       e.unseal.tpe match {
         case Type.SymRef(IsValDefSymbol(sym), pre) =>

--- a/tests/run-macros/tasty-extractors-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-1/quoted_1.scala
@@ -8,8 +8,8 @@ object Macros {
   implicit inline def printTree[T](x: => T): Unit =
     ${ impl('x) }
 
-  def impl[T](x: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl[T](x: Expr[T]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val tree = x.unseal
     val treeStr = tree.showExtractors

--- a/tests/run-macros/tasty-extractors-2/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-2/quoted_1.scala
@@ -8,8 +8,8 @@ object Macros {
   implicit inline def printTree[T](x: => T): Unit =
     ${ impl('x) }
 
-  def impl[T](x: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl[T](x: Expr[T]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val tree = x.unseal
 

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -8,8 +8,8 @@ object Macros {
   implicit inline def printTypes[T](x: => T): Unit =
     ${impl('x)}
 
-  def impl[T](x: Expr[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl[T](x: Expr[T]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val buff = new StringBuilder
     val traverser = new TreeTraverser {

--- a/tests/run-macros/tasty-extractors-constants-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-constants-1/quoted_1.scala
@@ -10,7 +10,7 @@ object Macros {
 
   implicit inline def testMacro: Unit = ${impl}
 
-  def impl(implicit reflect: Reflection): Expr[Unit] = {
+  def impl given QuoteContext: Expr[Unit] = {
 
     val buff = new StringBuilder
     def stagedPrintln(x: Any): Unit = buff append java.util.Objects.toString(x) append "\n"

--- a/tests/run-macros/tasty-extractors-types/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-types/quoted_1.scala
@@ -7,8 +7,8 @@ object Macros {
 
   implicit inline def printType[T]: Unit = ${ impl('[T]) }
 
-  def impl[T](x: Type[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl[T](x: Type[T]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val tree = x.unseal
     '{

--- a/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
@@ -1,19 +1,17 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty.Reflection
-
 object SourceFiles {
 
-  type Macro[X] = given Reflection => Expr[X]
-  def tastyContext(implicit ctx: Reflection): Reflection = ctx
+  type Macro[X] = given QuoteContext => Expr[X]
+  def tastyContext given (qctx: QuoteContext): QuoteContext = qctx
 
   implicit inline def getThisFile: String =
     ${getThisFileImpl}
 
   def getThisFileImpl: Macro[String] = {
-    val reflect = tastyContext
-    import reflect._
+    val qctx = tastyContext
+    import qctx.tasty._
     rootContext.source.getFileName.toString
   }
 

--- a/tests/run-macros/tasty-getfile/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile/Macro_1.scala
@@ -8,8 +8,8 @@ object SourceFiles {
   implicit inline def getThisFile: String =
     ${getThisFileImpl}
 
-  private def getThisFileImpl(implicit reflect: Reflection): Expr[String] = {
-    import reflect._
+  private def getThisFileImpl given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     rootContext.source.getFileName.toString
   }
 

--- a/tests/run-macros/tasty-implicit-fun-context-2/Macro_1.scala
+++ b/tests/run-macros/tasty-implicit-fun-context-2/Macro_1.scala
@@ -3,13 +3,13 @@ import scala.tasty.Reflection
 
 object Foo {
 
-  type Macro[X] = given Reflection => Expr[X]
-  type Tastier[X] = given Reflection => X
+  type Macro[X] = given QuoteContext => Expr[X]
+  type Tastier[X] = given QuoteContext => X
 
   implicit inline def foo: String =
     ${fooImpl}
 
-  def fooImpl(implicit reflect: Reflection): given Reflection => Tastier[given Reflection => Macro[String]] = {
+  def fooImpl given QuoteContext: given QuoteContext => Tastier[given QuoteContext => Macro[String]] = {
     '{"abc"}
   }
 

--- a/tests/run-macros/tasty-indexed-map/quoted_1.scala
+++ b/tests/run-macros/tasty-indexed-map/quoted_1.scala
@@ -27,8 +27,8 @@ object Index {
 
   implicit inline def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ${succImpl[K, H, T]}
 
-  def succImpl[K, H, T](implicit reflect: Reflection, k: Type[K], h: Type[H], t: Type[T]): Expr[Index[K, (H, T)]] = {
-    import reflect._
+  def succImpl[K, H, T](implicit qctx: QuoteContext, k: Type[K], h: Type[H], t: Type[T]): Expr[Index[K, (H, T)]] = {
+    import qctx.tasty._
 
     def name(tp: TypeOrBounds): String = tp match {
       case Type.ConstantType(Constant.String(str)) => str

--- a/tests/run-macros/tasty-linenumber-2/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber-2/quoted_1.scala
@@ -11,8 +11,8 @@ object LineNumber {
 
   implicit inline def line: LineNumber = ${lineImpl}
 
-  def lineImpl(implicit reflect: Reflection): Expr[LineNumber] = {
-    import reflect._
+  def lineImpl given (qctx: QuoteContext): Expr[LineNumber] = {
+    import qctx.tasty._
     '{new LineNumber(${rootPosition.startLine})}
   }
 

--- a/tests/run-macros/tasty-linenumber/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber/quoted_1.scala
@@ -12,8 +12,8 @@ object LineNumber {
   implicit inline def line[T >: Unit <: Unit]: LineNumber =
     ${lineImpl('[T])}
 
-  def lineImpl(x: Type[Unit])(implicit reflect: Reflection): Expr[LineNumber] = {
-    import reflect._
+  def lineImpl(x: Type[Unit]) given (qctx: QuoteContext): Expr[LineNumber] = {
+    import qctx.tasty._
     '{new LineNumber(${rootPosition.startLine})}
   }
 

--- a/tests/run-macros/tasty-location/quoted_1.scala
+++ b/tests/run-macros/tasty-location/quoted_1.scala
@@ -9,8 +9,8 @@ object Location {
 
   implicit inline def location: Location = ${impl}
 
-  def impl(implicit reflect: Reflection): Expr[Location] = {
-    import reflect._
+  def impl given (qctx: QuoteContext): Expr[Location] = {
+    import qctx.tasty._
 
     def listOwnerNames(sym: Symbol, acc: List[String]): List[String] =
       if (sym == definitions.RootClass || sym == definitions.EmptyPackageClass) acc

--- a/tests/run-macros/tasty-macro-assert/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-assert/quoted_1.scala
@@ -14,8 +14,8 @@ object Asserts {
   inline def macroAssert(cond: => Boolean): Unit =
     ${impl('cond)}
 
-  def impl(cond: Expr[Boolean])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl(cond: Expr[Boolean]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val tree = cond.unseal
 

--- a/tests/run-macros/tasty-macro-const/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-const/quoted_1.scala
@@ -5,8 +5,8 @@ object Macros {
 
   inline def natConst(x: Int): Int = ${ natConstImpl('x) }
 
-  def natConstImpl(x: Expr[Int])(implicit reflection: Reflection): Expr[Int] = {
-    import reflection._
+  def natConstImpl(x: Expr[Int]) given (qctx: QuoteContext): Expr[Int] = {
+    import qctx.tasty._
     val xTree: Term = x.unseal
     xTree match {
       case Inlined(_, _, Literal(Constant.Int(n))) =>

--- a/tests/run-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-positions/quoted_1.scala
@@ -10,28 +10,28 @@ object Macros {
 
   inline def fun3[T]: Unit = ${ impl2('[T]) }
 
-  def impl(x: Expr[Any])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl(x: Expr[Any]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     val pos = x.unseal.underlyingArgument.pos
     val code = x.unseal.underlyingArgument.show
     '{
-      println(${posStr(reflect)(pos)})
+      println(${posStr(qctx)(pos)})
       println(${code.toExpr})
     }
   }
 
-  def impl2[T](x: quoted.Type[T])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  def impl2[T](x: quoted.Type[T]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     val pos = x.unseal.pos
     val code = x.unseal.show
     '{
-      println(${posStr(reflect)(pos)})
+      println(${posStr(qctx)(pos)})
       println(${code.toExpr})
     }
   }
 
-  def posStr(relfection: Reflection)(pos: relfection.Position): Expr[String] = {
-    import relfection._
+  def posStr(qctx: QuoteContext)(pos: qctx.tasty.Position): Expr[String] = {
+    import qctx.tasty._
     s"${pos.sourceFile.jpath.getFileName.toString}:[${pos.start}..${pos.end}]".toExpr
   }
 }

--- a/tests/run-macros/tasty-original-source/Macros_1.scala
+++ b/tests/run-macros/tasty-original-source/Macros_1.scala
@@ -7,8 +7,8 @@ object Macros {
 
   implicit inline def withSource(arg: Any): (String, Any) = ${ impl('arg) }
 
-  private def impl(arg: Expr[Any])(implicit reflect: Reflection): Expr[(String, Any)] = {
-    import reflect._
+  private def impl(arg: Expr[Any]) given (qctx: QuoteContext): Expr[(String, Any)] = {
+    import qctx.tasty._
     val source = arg.unseal.underlyingArgument.pos.sourceCode.toString
     '{Tuple2($source, $arg)}
   }

--- a/tests/run-macros/tasty-positioned/quoted_1.scala
+++ b/tests/run-macros/tasty-positioned/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 case class Position(path: String, start: Int, end: Int,
     startLine: Int, startColumn: Int, endLine: Int, endColumn: Int)
 
@@ -12,8 +10,8 @@ object Positioned {
 
   implicit inline def apply[T](x: => T): Positioned[T] = ${impl('x)}
 
-  def impl[T](x: Expr[T])(implicit ev: Type[T], reflect: Reflection): Expr[Positioned[T]] = {
-    import reflect.{Position => _, _}
+  def impl[T](x: Expr[T])(implicit ev: Type[T], qctx: QuoteContext): Expr[Positioned[T]] = {
+    import qctx.tasty.{Position => _, _}
     val pos = rootPosition
 
     val path = pos.sourceFile.jpath.toString

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -8,8 +8,8 @@ object Asserts {
     ${ zeroLastArgsImpl('x) }
 
   /** Replaces last argument list by 0s */
-  def zeroLastArgsImpl(x: Expr[Int])(implicit reflect: Reflection): Expr[Int] = {
-    import reflect._
+  def zeroLastArgsImpl(x: Expr[Int]) given (qctx: QuoteContext): Expr[Int] = {
+    import qctx.tasty._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
     x.unseal.underlyingArgument match {
       case Apply(fn, args) =>
@@ -30,8 +30,8 @@ object Asserts {
     ${ zeroAllArgsImpl('x) }
 
   /** Replaces all argument list by 0s */
-  def zeroAllArgsImpl(x: Expr[Int])(implicit reflect: Reflection): Expr[Int] = {
-    import reflect._
+  def zeroAllArgsImpl(x: Expr[Int]) given (qctx: QuoteContext): Expr[Int] = {
+    import qctx.tasty._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
     def rec(term: Term): Term = term match {
       case Apply(fn, args) =>

--- a/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
+++ b/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 import scala.quoted.matching._
-import scala.tasty.Reflection
 
 import scala.language.implicitConversions
 
@@ -20,12 +19,12 @@ object TestFooErrors { // Defined in tests
 
 object Macro {
 
-  def foo(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]]) given (reflect: Reflection): Expr[String] = {
+  def foo(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]]) given (qctx: QuoteContext): Expr[String] = {
     (sc, argsExpr) match {
       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args)) =>
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
-            import reflect._
+            import qctx.tasty._
             error(msg, parts(partIdx).unseal.pos)
           }
         }
@@ -33,13 +32,13 @@ object Macro {
     }
   }
 
-  def fooErrors(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]]) given (reflect: Reflection): Expr[List[(Int, Int, Int, String)]] = {
+  def fooErrors(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]]) given (qctx: QuoteContext): Expr[List[(Int, Int, Int, String)]] = {
     (sc, argsExpr) match {
       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args)) =>
         val errors = List.newBuilder[Expr[(Int, Int, Int, String)]]
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
-            import reflect._
+            import qctx.tasty._
             val pos = parts(partIdx).unseal.pos
             errors += '{ Tuple4($partIdx, ${pos.start}, ${pos.end}, $msg) }
           }
@@ -52,7 +51,7 @@ object Macro {
   }
 
 
-  private def fooCore(parts: Seq[Expr[String]], args: Seq[Expr[Any]], reporter: Reporter) given Reflection: Expr[String] = {
+  private def fooCore(parts: Seq[Expr[String]], args: Seq[Expr[Any]], reporter: Reporter) given QuoteContext: Expr[String] = {
     for ((part, idx) <- parts.zipWithIndex) {
       val Const(v: String) = part
       if (v.contains("#"))

--- a/tests/run-macros/tasty-subtyping/quoted_1.scala
+++ b/tests/run-macros/tasty-subtyping/quoted_1.scala
@@ -11,14 +11,14 @@ object Macros {
   inline def isSubTypeOf[T, U]: Boolean =
     ${isSubTypeOfImpl('[T], '[U])}
 
-  def isTypeEqualImpl[T, U](t: Type[T], u: Type[U])(implicit reflect: Reflection): Expr[Boolean] = {
-    import reflect._
+  def isTypeEqualImpl[T, U](t: Type[T], u: Type[U]) given (qctx: QuoteContext): Expr[Boolean] = {
+    import qctx.tasty._
     val isTypeEqual = t.unseal.tpe =:= u.unseal.tpe
     isTypeEqual
   }
 
-  def isSubTypeOfImpl[T, U](t: Type[T], u: Type[U])(implicit reflect: Reflection): Expr[Boolean] = {
-    import reflect._
+  def isSubTypeOfImpl[T, U](t: Type[T], u: Type[U]) given (qctx: QuoteContext): Expr[Boolean] = {
+    import qctx.tasty._
     val isTypeEqual = t.unseal.tpe <:< u.unseal.tpe
     isTypeEqual
   }

--- a/tests/run-macros/tasty-tree-map/quoted_1.scala
+++ b/tests/run-macros/tasty-tree-map/quoted_1.scala
@@ -5,8 +5,8 @@ object Macros {
 
   implicit inline def identityMaped[T](x: => T): T = ${ impl('x) }
 
-  def impl[T: Type](x: Expr[T])(implicit reflection: Reflection): Expr[T] = {
-    import reflection._
+  def impl[T: Type](x: Expr[T]) given (qctx: QuoteContext): Expr[T] = {
+    import qctx.tasty._
     val identityMap = new TreeMap { }
     val transformed = identityMap.transformTerm(x.unseal).seal.cast[T]
     transformed

--- a/tests/run-macros/tasty-typeof/Macro_1.scala
+++ b/tests/run-macros/tasty-typeof/Macro_1.scala
@@ -6,8 +6,8 @@ object Macros {
 
   inline def testTypeOf(): Unit = ${ testTypeOfImpl }
 
-  private def testTypeOfImpl(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  private def testTypeOfImpl given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
     '{
       assert(${(typeOf[Unit] =:= definitions.UnitType)}, "Unit")
       assert(${(typeOf[Byte] =:= definitions.ByteType)}, "Byte")

--- a/tests/run-macros/type-show/Macro_1.scala
+++ b/tests/run-macros/type-show/Macro_1.scala
@@ -3,8 +3,8 @@ import scala.tasty._
 
 object TypeToolbox {
   inline def show[A]: String = ${ showImpl('[A]) }
-  private def showImpl[A, B](a: Type[A])(implicit refl: Reflection): Expr[String] = {
-    import refl._
+  private def showImpl[A, B](a: Type[A]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     a.show.toExpr
   }
 }

--- a/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
@@ -14,8 +14,8 @@ object XmlQuote {
   }
 
   def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])
-          (implicit reflect: Reflection): Expr[Xml] = {
-    import reflect._
+           given (qctx: QuoteContext): Expr[Xml] = {
+    import qctx.tasty._
 
     def abort(msg: String): Nothing =
       QuoteError(msg)

--- a/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
@@ -15,9 +15,8 @@ object XmlQuote {
   }
   implicit inline def SCOps(ctx: => StringContext): SCOps = new SCOps(ctx)
 
-  def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])
-          (implicit reflect: Reflection): Expr[Xml] = {
-    import reflect._
+  def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]]) given (qctx: QuoteContext): Expr[Xml] = {
+    import qctx.tasty._
 
     // for debugging purpose
     def pp(tree: Tree): Unit = {

--- a/tests/run-with-compiler/i6201/macro_1.scala
+++ b/tests/run-with-compiler/i6201/macro_1.scala
@@ -4,12 +4,12 @@ import scala.tasty._
 inline def (inline x: String) strip: String =
   ${ stripImpl(x) }
 
-def stripImpl(x: String)(implicit refl: Reflection): Expr[String] =
+def stripImpl(x: String) given (qctx: QuoteContext): Expr[String] =
   x.stripMargin.toExpr
 
 inline def isHello(inline x: String): Boolean =
   ${ isHelloImpl(x) }
 
-def isHelloImpl(x: String)(implicit refl: Reflection): Expr[Boolean] =
+def isHelloImpl(x: String) given (qctx: QuoteContext): Expr[Boolean] =
   if (x == "hello") true.toExpr else false.toExpr
 

--- a/tests/run-with-compiler/i6270/Macro_1.scala
+++ b/tests/run-with-compiler/i6270/Macro_1.scala
@@ -6,16 +6,16 @@ object api {
   inline def (x: => String) reflect : String =
     ${ reflImpl('x) }
 
-  private def reflImpl(x: Expr[String])(implicit refl: Reflection): Expr[String] = {
-    import refl._
+  private def reflImpl(x: Expr[String]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     x.show.toExpr
   }
 
   inline def (x: => String) reflectColor : String =
     ${ reflImplColor('x) }
 
-  private def reflImplColor(x: Expr[String])(implicit refl: Reflection): Expr[String] = {
-    import refl._
+  private def reflImplColor(x: Expr[String]) given (qctx: QuoteContext): Expr[String] = {
+    import qctx.tasty._
     x.show(ANSI).toExpr
   }
 }

--- a/tests/run-with-compiler/reflect-inline/assert_1.scala
+++ b/tests/run-with-compiler/reflect-inline/assert_1.scala
@@ -1,18 +1,17 @@
 import scala.quoted._
-import scala.tasty._
 
 object api {
   inline def (inline x: String) stripMargin: String =
     ${ stripImpl(x) }
 
-  private def stripImpl(x: String)(implicit refl: Reflection): Expr[String] =
+  private def stripImpl(x: String) given (qctx: QuoteContext): Expr[String] =
     x.stripMargin.toExpr
 
   inline def typeChecks(inline x: String): Boolean =
     ${ typeChecksImpl(x) }
 
-  private def typeChecksImpl(x: String)(implicit refl: Reflection): Expr[Boolean] = {
-    import refl._
-    if (refl.typing.typeChecks(x)) true.toExpr else false.toExpr
+  private def typeChecksImpl(x: String) given (qctx: QuoteContext): Expr[Boolean] = {
+    import qctx.tasty._
+    if (qctx.tasty.typing.typeChecks(x)) true.toExpr else false.toExpr
   }
 }

--- a/tests/run-with-compiler/staged-tuples/StagedTuple.scala
+++ b/tests/run-with-compiler/staged-tuples/StagedTuple.scala
@@ -125,7 +125,7 @@ object StagedTuple {
     }
   }
 
-  def applyStaged[Tup <: NonEmptyTuple : Type, N <: Int : Type](tup: Expr[Tup], size: Option[Int], n: Expr[N], nValue: Option[Int])(implicit reflect: tasty.Reflection): Expr[Elem[Tup, N]] = {
+  def applyStaged[Tup <: NonEmptyTuple : Type, N <: Int : Type](tup: Expr[Tup], size: Option[Int], n: Expr[N], nValue: Option[Int]) given (qctx: QuoteContext): Expr[Elem[Tup, N]] = {
     import reflect._
 
     if (!specialize) '{dynamicApply($tup, $n)}

--- a/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
+++ b/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
 
   inline def testMacro: Unit = ${impl}
 
-  def impl(implicit reflect: Reflection): Expr[Unit] = {
+  def impl given QuoteContext: Expr[Unit] = {
     implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
     // 2 is a lifted constant
     val show1 = withQuoteContext(power(2, 3.0).show)
@@ -44,7 +44,7 @@ object Macros {
     }
   }
 
-  def power(n: Expr[Int], x: Expr[Double])(implicit reflect: Reflection): Expr[Double] = {
+  def power(n: Expr[Int], x: Expr[Double]) given QuoteContext: Expr[Double] = {
     import quoted.matching.Const
     n match {
       case Const(n1) => powerCode(n1, x)

--- a/tests/run-with-compiler/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-with-compiler/tasty-unsafe-let/quoted_1.scala
@@ -7,12 +7,12 @@ object Macros {
   inline def let[T](rhs: T)(body: => T => Unit): Unit =
     ${ impl('rhs, 'body) }
 
-  private def impl[T](rhs: Expr[T], body: Expr[T => Unit])(implicit reflect: Reflection): Expr[Unit] = {
-    import reflect._
+  private def impl[T](rhs: Expr[T], body: Expr[T => Unit]) given (qctx: QuoteContext): Expr[Unit] = {
+    import qctx.tasty._
 
     val rhsTerm = rhs.unseal
 
-    import reflect.util.{let => letTerm}
+    import qctx.tasty.util.{let => letTerm}
     letTerm(rhsTerm) { rhsId =>
       body(rhsId.seal.asInstanceOf[Expr[T]]).unseal // Dangerous uncheked cast!
     }.seal.cast[Unit]


### PR DESCRIPTION
Homogenize API used for macros and runtime staging. Support `QuoteContext` instead of `Reflection` as the implicit that macros take as parameter. We still a keep deprecated support for `Reflection` in macros. Note that the macros in `scalatest`, `sourcecode` and `xml-interpolator` did not need to change, they only get the warning suggesting to use `QuoteContext`.