### PR TITLE
Follow up to #6722: make dead code consistent in handling NaN

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1267,12 +1267,12 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
               emit(asm.Opcodes.LCMP)
             case FLOAT  =>
               emit(asm.Opcodes.FCONST_0)
-              if (op == LT || op == LE) emit(asm.Opcodes.FCMPG)
-              else emit(asm.Opcodes.FCMPL)
+              if (op == LT || op == LE) emit(asm.Opcodes.FCMPL)
+              else emit(asm.Opcodes.FCMPG)
             case DOUBLE =>
               emit(asm.Opcodes.DCONST_0)
-              if (op == LT || op == LE) emit(asm.Opcodes.DCMPG)
-              else emit(asm.Opcodes.DCMPL)
+              if (op == LT || op == LE) emit(asm.Opcodes.DCMPL)
+              else emit(asm.Opcodes.DCMPG)
           }
           bc.emitIF(op, success)
         }


### PR DESCRIPTION
The two branches are currently dead code, as we never
call `genCZJUMP` with tk = DOUBLE or FLOAT. However, in
case the two branches become reachable, it's good to
make the logic consistent as in `genCJUMP` (#6722).