### PR TITLE
Add Support of Parsing Runtime Invisible Annotations to Classfile Parser

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -221,24 +221,24 @@ object StdNames {
     final val bridgeAnnot: N = "bridge"
 
     // Classfile Attributes
-    final val AnnotationDefaultATTR: N      = "AnnotationDefault"
-    final val BridgeATTR: N                 = "Bridge"
-    final val ClassfileAnnotationATTR: N    = "RuntimeInvisibleAnnotations" // RetentionPolicy.CLASS. Currently not used (Apr 2009).
-    final val CodeATTR: N                   = "Code"
-    final val ConstantValueATTR: N          = "ConstantValue"
-    final val DeprecatedATTR: N             = "Deprecated"
-    final val ExceptionsATTR: N             = "Exceptions"
-    final val InnerClassesATTR: N           = "InnerClasses"
-    final val LineNumberTableATTR: N        = "LineNumberTable"
-    final val LocalVariableTableATTR: N     = "LocalVariableTable"
-    final val RuntimeAnnotationATTR: N      = "RuntimeVisibleAnnotations"   // RetentionPolicy.RUNTIME
-    final val RuntimeParamAnnotationATTR: N = "RuntimeVisibleParameterAnnotations" // RetentionPolicy.RUNTIME (annotations on parameters)
-    final val ScalaATTR: N                  = "Scala"
-    final val ScalaSignatureATTR: N         = "ScalaSig"
-    final val TASTYATTR: N                  = "TASTY"
-    final val SignatureATTR: N              = "Signature"
-    final val SourceFileATTR: N             = "SourceFile"
-    final val SyntheticATTR: N              = "Synthetic"
+    final val AnnotationDefaultATTR: N            = "AnnotationDefault"
+    final val BridgeATTR: N                       = "Bridge"
+    final val CodeATTR: N                         = "Code"
+    final val ConstantValueATTR: N                = "ConstantValue"
+    final val DeprecatedATTR: N                   = "Deprecated"
+    final val ExceptionsATTR: N                   = "Exceptions"
+    final val InnerClassesATTR: N                 = "InnerClasses"
+    final val LineNumberTableATTR: N              = "LineNumberTable"
+    final val LocalVariableTableATTR: N           = "LocalVariableTable"
+    final val RuntimeVisibleAnnotationATTR: N     = "RuntimeVisibleAnnotations"   // RetentionPolicy.RUNTIME
+    final val RuntimeInvisibleAnnotationATTR: N   = "RuntimeInvisibleAnnotations" // RetentionPolicy.CLASS
+    final val RuntimeParamAnnotationATTR: N       = "RuntimeVisibleParameterAnnotations" // RetentionPolicy.RUNTIME (annotations on parameters)
+    final val ScalaATTR: N                        = "Scala"
+    final val ScalaSignatureATTR: N               = "ScalaSig"
+    final val TASTYATTR: N                        = "TASTY"
+    final val SignatureATTR: N                    = "Signature"
+    final val SourceFileATTR: N                   = "SourceFile"
+    final val SyntheticATTR: N                    = "Synthetic"
 
 
 // ----- Term names -----------------------------------------

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -570,13 +570,14 @@ class ClassfileParser(
         case tpnme.AnnotationDefaultATTR =>
           sym.addAnnotation(Annotation(defn.AnnotationDefaultAnnot, Nil))
         // Java annotations on classes / methods / fields with RetentionPolicy.RUNTIME
-        case tpnme.RuntimeAnnotationATTR =>
+        case tpnme.RuntimeVisibleAnnotationATTR
+          | tpnme.RuntimeInvisibleAnnotationATTR =>
           parseAnnotations(attrLen)
 
         // TODO 1: parse runtime visible annotations on parameters
         // case tpnme.RuntimeParamAnnotationATTR
 
-        // TODO 2: also parse RuntimeInvisibleAnnotation / RuntimeInvisibleParamAnnotation,
+        // TODO 2: also parse RuntimeInvisibleParamAnnotation
         // i.e. java annotations with RetentionPolicy.CLASS?
 
         case tpnme.ExceptionsATTR =>
@@ -852,7 +853,7 @@ class ClassfileParser(
         return Some(NoEmbedded)
       }
 
-      if (scan(tpnme.RuntimeAnnotationATTR)) {
+      if (scan(tpnme.RuntimeVisibleAnnotationATTR) || scan(tpnme.RuntimeInvisibleAnnotationATTR)) {
         val attrLen = in.nextInt
         val nAnnots = in.nextChar
         var i = 0


### PR DESCRIPTION
This PR adds support of parsing runtime invisible annotations to `ClassfileParser`.

For the explicit-nulls project, we want to read `NotNull` annotations of Java methods to generate better types. Originally, dotc was only able to parse `RuntimeVisibleAnnotations` in Classfile. However, some `NotNull` annotations are runtime invisible (`RuntimeInvisibleAnnotations`). 

Since both annotations have the same structure, this PR only changes two parts:

* Rename Classfile Attributes in `StdNames.scala`

* Add `RuntimeInvisibleAnnotations` attribute to `ClassfileParser.scala`