### PR TITLE
Fix #6724: Don't suggest types for terms and vice versa

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -315,10 +315,12 @@ object messages {
     val msg: String = {
       import core.Flags._
       val maxDist = 3
-      val decls = site.decls.toList.flatMap { sym =>
-        if (sym.flagsUNSAFE.isOneOf(Synthetic | PrivateLocal) || sym.isConstructor) Nil
-        else List((sym.name.show, sym))
-      }
+      val decls = site.decls.toList
+        .filter(_.isType == name.isTypeName)
+        .flatMap { sym =>
+          if (sym.flagsUNSAFE.isOneOf(Synthetic | PrivateLocal) || sym.isConstructor) Nil
+          else List((sym.name.show, sym))
+        }
 
       // Calculate Levenshtein distance
       def distance(n1: Iterable[_], n2: Iterable[_]) =
@@ -358,7 +360,8 @@ object messages {
       }
 
       val closeMember = closest match {
-        case (n, sym) :: Nil => s" - did you mean $siteName.$n?"
+        case (n, sym) :: Nil =>
+          s" - did you mean $siteName.$n?"
         case Nil => ""
         case _ => assert(
           false,

--- a/compiler/test-resources/repl/importFromObj
+++ b/compiler/test-resources/repl/importFromObj
@@ -14,8 +14,8 @@ val res0: scala.collection.mutable.ListBuffer[Int] = ListBuffer(1, 2, 3)
 scala> import util.foo
 1 | import util.foo
   |             ^^^
-  |             value foo is not a member of util - did you mean util.Left?
+  |             value foo is not a member of util - did you mean util.Try?
 scala> import util.foo.bar
 1 | import util.foo.bar
   |        ^^^^^^^^
-  |        value foo is not a member of util - did you mean util.Left?
+  |        value foo is not a member of util - did you mean util.Try?

--- a/tests/neg/i6724.check
+++ b/tests/neg/i6724.check
@@ -1,0 +1,4 @@
+-- [E008] Member Not Found Error: tests/neg/i6724.scala:7:17 -----------------------------------------------------------
+7 |  def f(foo: Foo.Baz): Foo[_] = foo // error
+  |             ^^^^^^^
+  |             type Baz is not a member of object Foo - did you mean Foo.Bar?

--- a/tests/neg/i6724.scala
+++ b/tests/neg/i6724.scala
@@ -4,5 +4,5 @@ enum Foo[T] {
 }
 
 object Main {
-  def f(foo: Foo.Baz): Foo[_] = foo
+  def f(foo: Foo.Baz): Foo[_] = foo // error
 }

--- a/tests/neg/i6724.scala
+++ b/tests/neg/i6724.scala
@@ -1,0 +1,8 @@
+enum Foo[T] {
+  case Bar(s: String)
+  case Baz extends Foo[Int]
+}
+
+object Main {
+  def f(foo: Foo.Baz): Foo[_] = foo
+}


### PR DESCRIPTION
Filter candidate definitions for member suggestions to be either types or terms,
depending on the selection name.