### PR TITLE
Use standard syntax for `if` in macro docs

### DIFF
--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -37,7 +37,7 @@ prints it again in an error message if it evaluates to `false`.
       ${ assertImpl('expr) }
 
     def assertImpl(expr: Expr[Boolean]) = '{
-      if !($expr) then
+      if (!$expr)
         throw new AssertionError(s"failed assertion: ${${ showExpr(expr) }}")
     }
 


### PR DESCRIPTION
The `then` syntax is not documented anywhere and is confusing. My first impression was that it was related to macros in some way.