### PR TITLE
Fix atoms computation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -600,8 +600,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
         compareTypeLambda
       case OrType(tp21, tp22) =>
         if (tp2.atoms.nonEmpty && canCompare(tp2.atoms))
-          return tp1.atoms.nonEmpty && tp1.atoms.subsetOf(tp2.atoms) ||
-            tp1.widen.isRef(NothingClass)
+          return tp1.atoms.nonEmpty && tp1.atoms.subsetOf(tp2.atoms) || isSubType(tp1, NothingType)
 
         // The next clause handles a situation like the one encountered in i2745.scala.
         // We have:

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -601,7 +601,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
       case OrType(tp21, tp22) =>
         if (tp2.atoms.nonEmpty && canCompare(tp2.atoms))
           return tp1.atoms.nonEmpty && tp1.atoms.subsetOf(tp2.atoms) ||
-            tp1.isRef(NothingClass)
+            tp1.widen.isRef(NothingClass)
 
         // The next clause handles a situation like the one encountered in i2745.scala.
         // We have:

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1102,8 +1102,11 @@ object Types {
             }
           case _ => tp
         }
-        Set.empty + normalize(tp)
-      case tp: OrType => tp.atoms
+        val underlyingAtoms = tp.underlying.atoms
+        if (underlyingAtoms.isEmpty) Set.empty + normalize(tp)
+        else underlyingAtoms
+      case tp: ExprType => tp.resType.atoms
+      case tp: OrType => tp.atoms // `atoms` overridden in OrType
       case tp: AndType => tp.tp1.atoms & tp.tp2.atoms
       case _ => Set.empty
     }

--- a/tests/pos/singlesubtypes.scala
+++ b/tests/pos/singlesubtypes.scala
@@ -1,0 +1,12 @@
+object E {
+  val a: String = ???
+  val b: String = ???
+}
+
+object Test {
+
+  val a: E.a.type = E.a
+  val b: E.b.type = E.b
+
+  val c: a.type | b.type = ???
+}

--- a/tests/pos/singlesubtypes.scala
+++ b/tests/pos/singlesubtypes.scala
@@ -9,4 +9,5 @@ object Test {
   val b: E.b.type = E.b
 
   val c: a.type | b.type = ???
+  val d: a.type | b.type = c
 }


### PR DESCRIPTION
It's possible that a singleton type has a disjunction of singleton types
as underlying type. In this case `atoms` of the first type should return
the disjunction, not the singleton type itself.