### PR TITLE
Type the quoted patterns as precisely as possible

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2021,7 +2021,10 @@ class Typer extends Namer
    */
   private def typedQuotePattern(quoted: untpd.Tree, pt: Type, quoteSpan: Span)(implicit ctx: Context): Tree = {
     val exprPt = pt.baseType(defn.QuotedExprClass)
-    val quotedPt = if (exprPt.exists) exprPt.argTypesHi.head else defn.AnyType
+    val quotedPt = exprPt.argInfos.headOption match {
+      case Some(argPt: ValueType) => argPt // excludes TypeBounds
+      case _ => defn.AnyType
+    }
     val quoted0 = desugar.quotedPattern(quoted, untpd.TypedSplice(TypeTree(quotedPt)))
     val quoted1 = typedExpr(quoted0, WildcardType)(quoteContext.addMode(Mode.QuotedPattern))
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2022,7 +2022,8 @@ class Typer extends Namer
   private def typedQuotePattern(quoted: untpd.Tree, pt: Type, quoteSpan: Span)(implicit ctx: Context): Tree = {
     val exprPt = pt.baseType(defn.QuotedExprClass)
     val quotedPt = if (exprPt.exists) exprPt.argTypesHi.head else defn.AnyType
-    val quoted1 = typedExpr(quoted, quotedPt)(quoteContext.addMode(Mode.QuotedPattern))
+    val quoted0 = desugar.quotedPattern(quoted, untpd.TypedSplice(TypeTree(quotedPt)))
+    val quoted1 = typedExpr(quoted0, WildcardType)(quoteContext.addMode(Mode.QuotedPattern))
 
     val (typeBindings, shape, splices) = splitQuotePattern(quoted1)
 
@@ -2070,7 +2071,7 @@ class Typer extends Namer
           Literal(Constant(typeBindings.nonEmpty)) ::
           implicitArgTree(defn.QuoteContextType, quoteSpan) :: Nil,
       patterns = splicePat :: Nil,
-      proto = pt)
+      proto = defn.QuotedExprType.appliedTo(replaceBindings(quoted1.tpe) & quotedPt))
   }
 
   /** Split a typed quoted pattern is split into its type bindings, pattern expression and inner patterns.

--- a/library/src-bootstrapped/scala/internal/quoted/Matcher.scala
+++ b/library/src-bootstrapped/scala/internal/quoted/Matcher.scala
@@ -76,7 +76,7 @@ object Matcher {
      */
     def (scrutinee0: Tree) =#= (pattern0: Tree) given Context, Env: Matching = {
 
-      /** Normalieze the tree */
+      /** Normalize the tree */
       def normalize(tree: Tree): Tree = tree match {
         case Block(Nil, expr) => normalize(expr)
         case Block(stats1, Block(stats2, expr)) => normalize(Block(stats1 ::: stats2, expr))

--- a/tests/pos/quoted-pattern-type.scala
+++ b/tests/pos/quoted-pattern-type.scala
@@ -1,0 +1,64 @@
+import scala.quoted._
+import scala.tasty.Reflection
+
+object Lib {
+
+  def impl[T: Type](arg: Expr[T])(implicit refl: Reflection): Expr[T] = {
+    arg match {
+      case e @ '{ $x: Boolean } =>
+        e: Expr[T & Boolean]
+        x: Expr[T & Boolean]
+        e
+
+      case e @ '{ println("hello"); $x } =>
+        e: Expr[T]
+        x: Expr[T]
+        e
+
+      case e @ '{ println("hello"); $x: T } =>
+        e: Expr[T]
+        x: Expr[T]
+        e
+
+      case e @ '{ Some($x: Int) } =>
+        e: Expr[T & Some[Int]]
+        x: Expr[Int]
+        e
+
+      case e @ '{ if ($x) ($y: Boolean) else ($z: Int) } =>
+        e: Expr[T & (Boolean | Int)]
+        y: Expr[T & Boolean]
+        z: Expr[T & Int]
+        e
+
+      case e @ '{ if ($x) $y else $z } =>
+        e: Expr[T]
+        y: Expr[T]
+        z: Expr[T]
+        e
+
+      case e @ '{ if ($x) $y else ($z: Int) } =>
+        e: Expr[T & (T | Int)]
+        y: Expr[T]
+        z: Expr[T & Int]
+        e
+
+      case e @ '{ ($x: Boolean) match { case _ => $y: Int } } =>
+        e: Expr[T & Int]
+        y: Expr[T & Int]
+        e
+
+      case e @ '{ ($x: Boolean) match { case _ => $y } } =>
+        e: Expr[T]
+        y: Expr[T]
+        e
+
+      case e @ '{ try ($x: Boolean) catch { case _ => $y: Int } } =>
+        e: Expr[T & (Boolean | Int)]
+        x: Expr[T & Boolean]
+        y: Expr[T & Int]
+        e
+
+    }
+  }
+}

--- a/tests/run-macros/quoted-pattern-type.check
+++ b/tests/run-macros/quoted-pattern-type.check
@@ -1,0 +1,5 @@
+Boolean: true
+Int: 4
+Printed hello and returned world
+Printed world and returned hello
+Some: 5

--- a/tests/run-macros/quoted-pattern-type/Macro_1.scala
+++ b/tests/run-macros/quoted-pattern-type/Macro_1.scala
@@ -1,0 +1,18 @@
+import scala.quoted._
+import scala.tasty.Reflection
+
+object Lib {
+
+  inline def foo[T](arg: => T): T = ${ impl('arg) }
+
+  private def impl[T: Type](arg: Expr[T])(implicit refl: Reflection): Expr[T] = {
+    arg match {
+      case e @ '{ $x: Boolean } => '{ println("Boolean: " + $e); $e }
+      case e @ '{ $x: Int } => '{ println("Int: " + $x); $x }
+      case '{ println("hello"); $arg } => '{ println("Printed hello and returned " + $arg); $arg }
+      case '{ println("world"); $arg: T } => '{ println("Printed world and returned " + $arg); $arg }
+      case e @ '{ Some($x: Int) } => '{ println("Some: " + $x); $e }
+      case arg => '{ ??? }
+    }
+  }
+}

--- a/tests/run-macros/quoted-pattern-type/Test_2.scala
+++ b/tests/run-macros/quoted-pattern-type/Test_2.scala
@@ -1,0 +1,11 @@
+object Test {
+  import Lib._
+
+  def main(args: Array[String]): Unit = {
+    foo(true)
+    foo(4)
+    foo { println("hello"); "world" }
+    foo { println("world"); "hello" }
+    foo(Some(5))
+  }
+}


### PR DESCRIPTION
In a pattern match where the contents of the quote are statically known we want to propagate the
type inside the pattern the the binding. For example `e` will not only be an `Expr[T]` but also
an `Expr[Some[Int]]`.

```scala
(s: Expr[T]) match {
  case e @ '{ Some($x: Int) } =>
    // e: Expr[T & Some[Int]]
    // x: Expr[Int]
}
```

If the expression in the pattern contains a spliced expression, possibly typed, we also need to propagate the
type of the scrutinee down into the pattern. For example `x` will not only be an `Expr[Boolean]` but also
an `Expr[T]`.

```scala
(s: Expr[T]) match {
    case e @ '{ $x: Boolean } =>
      // e: Expr[T & Boolean]
      // x: Expr[T & Boolean]
}
```