### PR TITLE
Fix span of simple enum cases

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -895,7 +895,7 @@ object desugar {
       pats map {
         case id: Ident =>
           expandSimpleEnumCase(id.name.asTermName, mods,
-            Span(pdef.span.start, id.span.end, id.span.start))
+            Span(id.span.start, id.span.end, id.span.start))
     }
     else {
       val pats1 = if (tpt.isEmpty) pats else pats map (Typed(_, tpt))


### PR DESCRIPTION
The span should start with the enum case itself, not the preceding `case` keyword.
This matters if there are many cases in a list.

We got a crash when converting `ErrorMessageID` to Scala since the spans were longer than where a `nameSpan` could be recorded. This led to crash due to a duplicate position when registering a child.
