### PR TITLE
Set spans of Child annotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -6,6 +6,7 @@ import config.ScalaVersion
 import StdNames._
 import dotty.tools.dotc.ast.tpd
 import scala.util.Try
+import util.Spans.Span
 
 object Annotations {
 
@@ -158,16 +159,17 @@ object Annotations {
     object Child {
 
       /** A deferred annotation to the result of a given child computation */
-      def apply(delayedSym: Context => Symbol)(implicit ctx: Context): Annotation = {
+      def apply(delayedSym: Context => Symbol, span: Span)(implicit ctx: Context): Annotation = {
         def makeChildLater(implicit ctx: Context) = {
           val sym = delayedSym(ctx)
           New(defn.ChildAnnotType.appliedTo(sym.owner.thisType.select(sym.name, sym)), Nil)
+            .withSpan(span)
         }
         deferred(defn.ChildAnnot, implicit ctx => makeChildLater(ctx))
       }
 
       /** A regular, non-deferred Child annotation */
-      def apply(sym: Symbol)(implicit ctx: Context): Annotation = apply(_ => sym)
+      def apply(sym: Symbol, span: Span)(implicit ctx: Context): Annotation = apply(_ => sym, span)
 
       def unapply(ann: Annotation)(implicit ctx: Context): Option[Symbol] =
         if (ann.symbol == defn.ChildAnnot) {

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -277,7 +277,7 @@ class ClassfileParser(
             ctx.warning(s"no linked class for java enum $sym in ${sym.owner}. A referencing class file might be missing an InnerClasses entry.")
           else {
             if (!enumClass.is(Flags.Sealed)) enumClass.setFlag(Flags.AbstractSealed)
-            enumClass.addAnnotation(Annotation.Child(sym))
+            enumClass.addAnnotation(Annotation.Child(sym, NoSpan))
           }
         }
       } finally {

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -835,7 +835,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       readNat() // skip reference for now
       target.addAnnotation(
           Annotation.Child(implicit ctx =>
-              atReadPos(start, () => readSymbolRef())))
+              atReadPos(start, () => readSymbolRef()), NoSpan))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -523,7 +523,7 @@ class Namer { typer: Typer =>
             prefix ::: otherAnnot :: insertInto(rest)
           }
         case _ =>
-          Annotation.Child(child) :: annots
+          Annotation.Child(child, cls.span.startPos) :: annots
       }
     cls.annotations = insertInto(cls.annotations)
   }


### PR DESCRIPTION
This is necessary to prevent unstability of pickled positions under -Ytest-pickler