### PR TITLE
Handle polymorphic overloads with apply members

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1521,7 +1521,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       if (tryApply(alt)) {
         val qual = alt.widen match {
           case pt: PolyType =>
-            pt.resultType
+            wildApprox(pt.resultType)
           case _ =>
             alt
         }

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1518,7 +1518,15 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
 
     /** Replace each alternative by its apply members where necessary */
     def applyMembers(alt: TermRef): List[TermRef] =
-      if (tryApply(alt)) alt.member(nme.apply).alternatives.map(TermRef(alt, nme.apply, _))
+      if (tryApply(alt)) {
+        val qual = alt.widen match {
+          case pt: PolyType =>
+            pt.resultType
+          case _ =>
+            alt
+        }
+        qual.member(nme.apply).alternatives.map(TermRef(alt, nme.apply, _))
+      }
       else alt :: Nil
 
     /** Fall back from an apply method to its original alternative */

--- a/tests/neg/poly-overloads.scala
+++ b/tests/neg/poly-overloads.scala
@@ -1,0 +1,24 @@
+class A {
+  def foo1(x: Int): Int = x
+  def foo1[T]: String => T = ???
+
+  foo1("") // ok
+
+  def foo2(x: Int): Int = x
+  def foo2[T]: T => String = ???
+
+  foo2(1): String // ok
+  foo2("") // error, because T isn't instantiated before overloading resolution is done
+
+  def foo3(x: Any): Any = x
+  def foo3[T <: Int]: T => T = x => x
+
+  val a = foo3(1) // ok
+  val b: Int = a // error because the non-apply alternative was chosen, like in Scala 2
+
+  def foo4(x: Any): Any = x
+  def foo4[T >: Int]: T => T = x => x
+
+  val c = foo4(1) // ok
+  val d: Int = c // ok
+}

--- a/tests/neg/poly-overloads.scala
+++ b/tests/neg/poly-overloads.scala
@@ -8,17 +8,16 @@ class A {
   def foo2[T]: T => String = ???
 
   foo2(1): String // ok
-  foo2("") // error, because T isn't instantiated before overloading resolution is done
+  foo2("") // ok, unlike Scala 2
 
   def foo3(x: Any): Any = x
   def foo3[T <: Int]: T => T = x => x
 
   val a = foo3(1) // ok
-  val b: Int = a // error because the non-apply alternative was chosen, like in Scala 2
+  val b: Int = a // ok, unlike Scala 2 which prefers the first overload
 
   def foo4(x: Any): Any = x
   def foo4[T >: Int]: T => T = x => x
 
-  val c = foo4(1) // ok
-  val d: Int = c // ok
+  val c = foo4(1) // error, unlike Scala 2 this is ambiguous
 }


### PR DESCRIPTION
When we do overloading resolution, we first replace alternatives that
could not possibly match the expected type by their `apply` members if
they exist, however the existing logic failed to select `apply` members
from the result of a polymorphic parameterless def. We fix this by
simply replacing the PolyType by its result type without making up any
type variable, the resulting behavior matches the existing behavior of
Scala 2 on the added test file.