### PR TITLE
Symbol#source correct for all phases

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -165,6 +165,7 @@ object Inliner {
           case tree: SeqLiteral => finalize(tree, untpd.SeqLiteral(transform(tree.elems), transform(tree.elemtpt))(curSource))
           case tree: TypeTree => tpd.TypeTree(tree.tpe)(ctx.withSource(curSource)).withSpan(tree.span)
           case tree: Bind => finalize(tree, untpd.Bind(tree.name, transform(tree.body))(curSource))
+          case tree: DefTree => super.transform(tree).setDefTree
           case _ => super.transform(tree)
         })
         assert(transformed.isInstanceOf[EmptyTree[_]] || transformed.isInstanceOf[EmptyValDef[_]] || transformed.source == curSource)

--- a/tests/pos/inline-joint/defn.scala
+++ b/tests/pos/inline-joint/defn.scala
@@ -1,0 +1,5 @@
+object Foo {
+  inline def foo = new { bar(0) }
+
+  def bar(i: => Int): Unit = ()
+}

--- a/tests/pos/inline-joint/use.scala
+++ b/tests/pos/inline-joint/use.scala
@@ -1,0 +1,3 @@
+object Test {
+  val v = Foo.foo
+}


### PR DESCRIPTION
A combination of the inliner missing opportunities for setting `defTrees` with the correct inlined source information and some suspect post erasure logic in `Symbol#source` led to the same-source check in
`ExpandPrivate` failing in joint-compilation scenarios resulting in multi-file programs being incorrectly rejected for access violations.

~~The inliner duplicates trees and their symbols when expanding inline definitions at call sites. When the RHS of the inline definition contains a class definition its `Symbol` is duplicated, I believe correctly, preserving the original position and associated source file. The tree is duplicated, I believe also correctly, with its source attribute reflecting that the tree has been expanded in the call site source file.~~

~~In most circumstances the potential mismatch between the source of the `Symbol` and the source of its defining tree is handled: in `Symbol#source` the source of the defining tree will be used prior to erasure if the tree is non-empty, which ensures that the source as viewed via the `Symbol` will be the same as the source as viewed via the tree.~~

~~Things can go awry after erasure, however. In `ExpandPrivate` there is a same-source-file test relaxing access controls to private members of module classes. Because this happens after erasure it's possible that if a class definition has been inlined into a module and members attempt to access a definition in the module (eg. something synthetic which has been lifted into the module) the same-source-file test will fail because the source of the class symbol will now be seen as the source of the inline definition rather than the source of the inlined call site.~~

~~This is the scenario exercised in the included test. The inlined refinement and by-name argument are both essential (the latter is responsible for the private synthetic term which is lifted out into the module and then incorrectly reported as inaccessible from the inlined body). Also note that multiple source files are essential, but that separate compilation (as opposed to joint compilation) masks the issue which is why this problem didn't show up for the multi-file version of my type class derivation prototype.~~

~~In the real code from which this was reduced the refinement was actually the expansion of a polymorphic function type, but as the test shows there's nothing specific to polymorphic function types here.~~

~~The simplest approach to fixing this appears to be in `ExpandPrivate` where if the accessing symbol (on the `context.owner` side) doesn't have a matching source file we fall back to checking against the source file of the current compilation unit.~~