### PR TITLE
Allow a newline after the first parameter list of an extension method

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2537,7 +2537,7 @@ object Parsers {
     /** DefDef ::= DefSig [(‘:’ | ‘<:’) Type] ‘=’ Expr
      *           | this ParamClause ParamClauses `=' ConstrExpr
      *  DefDcl ::= DefSig `:' Type
-     *  DefSig ::= ‘(’ DefParam ‘)’ [nl] id [DefTypeParamClause] ParamClauses
+     *  DefSig ::= [‘(’ DefParam ‘)’ [nl]] id [DefTypeParamClause] ParamClauses
      */
     def defDefOrDcl(start: Offset, mods: Modifiers): Tree = atSpan(start, nameStart) {
       def scala2ProcedureSyntax(resultTypeStr: String) = {
@@ -2567,7 +2567,8 @@ object Parsers {
       } else {
         val (leadingParamss, flags) =
           if (in.token == LPAREN)
-            (paramClause(prefix = true) :: Nil, Method | Extension)
+            try (paramClause(prefix = true) :: Nil, Method | Extension)
+            finally newLineOpt()
           else
             (Nil, Method)
         val mods1 = addFlag(mods, flags)

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -357,7 +357,7 @@ Dcl               ::=  RefineDcl
 ValDcl            ::=  ids ‘:’ Type                                             PatDef(_, ids, tpe, EmptyTree)
 VarDcl            ::=  ids ‘:’ Type                                             PatDef(_, ids, tpe, EmptyTree)
 DefDcl            ::=  DefSig [‘:’ Type]                                        DefDef(_, name, tparams, vparamss, tpe, EmptyTree)
-DefSig            ::=  ‘(’ DefParam ‘)’ [nl] id
+DefSig            ::=  [‘(’ DefParam ‘)’ [nl]] id
                        [DefTypeParamClause] DefParamClauses
 TypeDcl           ::=  id [TypeParamClause] SubtypeBounds [‘=’ Type]           TypeDefTree(_, name, tparams, bound
 

--- a/tests/run/extension-methods.scala
+++ b/tests/run/extension-methods.scala
@@ -61,7 +61,8 @@ object Test extends App {
   }
 
   class ListOrd[T: Ord] extends Ord[List[T]] {
-    def (xs: List[T]) compareTo (ys: List[T]): Int = (xs, ys) match {
+    def (xs: List[T])
+        compareTo (ys: List[T]): Int = (xs, ys) match {
       case (Nil, Nil) => 0
       case (Nil, _) => -1
       case (_, Nil) => +1
@@ -87,8 +88,11 @@ object Test extends App {
   }
 
   trait Monad[F[_]] extends Functor[F] {
-    def (x: F[A]) flatMap [A, B](f: A => F[B]): F[B]
-    def (x: F[A]) map [A, B](f: A => B) = x.flatMap(f `andThen` pure)
+    def (x: F[A])
+        flatMap [A, B](f: A => F[B]): F[B]
+
+    def (x: F[A])
+        map [A, B](f: A => B) = x.flatMap(f `andThen` pure)
 
     def pure[A](x: A): F[A]
   }


### PR DESCRIPTION
This was already postulated by the syntax, but the parser did not implement
it.

Maybe this change is enough to allow a formatting that makes defined extension
methods easy to find when scanning code.