### PR TITLE
Fix #5699: retry branches if simpleAndType failed

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -751,7 +751,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
           case _ =>
             false
         }
-        isNewSubType(tp1.underlying.widenExpr) || comparePaths
+        recur(tp1.underlying.widenExpr, tp2) || comparePaths
       case tp1: RefinedType =>
         isNewSubType(tp1.parent)
       case tp1: RecType =>
@@ -786,8 +786,8 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
           case _ =>
         }
         val tp1norm = simplifyAndTypeWithFallback(tp11, tp12, tp1)
-        if (tp1 ne tp1norm) recur(tp1norm, tp2)
-        else either(recur(tp11, tp2), recur(tp12, tp2))
+        if (tp1.ne(tp1norm) && recur(tp1norm, tp2)) return true
+        either(recur(tp11, tp2), recur(tp12, tp2))
       case tp1: MatchType =>
         def compareMatch = tp2 match {
           case tp2: MatchType =>

--- a/tests/pos/gadt-no-approx.scala
+++ b/tests/pos/gadt-no-approx.scala
@@ -2,9 +2,8 @@ object `gadt-no-approx` {
   def fo[U](u: U): U =
     (0 : Int) match {
       case _: u.type =>
-        val i: Int = (??? : U) // error
-        // potentially could compile
-        // val i2: Int = u
+        val i: Int = (??? : U)
+        val i2: Int = u
         u
     }
 }

--- a/tests/pos/i5699.scala
+++ b/tests/pos/i5699.scala
@@ -1,0 +1,5 @@
+class Test {
+  type M = { type T[+A] } & { type T[-A] }
+  val M: M = ().asInstanceOf[M]
+  M: M
+}


### PR DESCRIPTION

Fix #5699: retry branches if simpleAndType failed

The test case in #5699 shows that `simplifyAndTypeWithFallback(A, B)`
may return a type which is not a subtype of `A & B`. Thus, if the
comparison fails, we should retry `A <: X` or `B <: X`.