### PR TITLE
Fix #6734: Suppress interpolation for extension methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -384,9 +384,7 @@ trait Inferencing { this: Typer =>
     // `qualifying`.
 
     val ownedVars = state.ownedVars
-    if ((ownedVars ne locked) && !ownedVars.isEmpty &&
-        !tree.isInstanceOf[Applications.IntegratedTypeArgs] // suppress interpolation in the middle of an extension method application
-        ) {
+    if ((ownedVars ne locked) && !ownedVars.isEmpty) {
       val qualifying = ownedVars -- locked
       if (!qualifying.isEmpty) {
         typr.println(i"interpolate $tree: ${tree.tpe.widen} in $state, owned vars = ${state.ownedVars.toList}%, %, previous = ${locked.toList}%, % / ${state.constraint}")

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -384,7 +384,9 @@ trait Inferencing { this: Typer =>
     // `qualifying`.
 
     val ownedVars = state.ownedVars
-    if ((ownedVars ne locked) && !ownedVars.isEmpty) {
+    if ((ownedVars ne locked) && !ownedVars.isEmpty &&
+        !tree.isInstanceOf[Applications.IntegratedTypeArgs] // suppress interpolation in the middle of an extension method application
+        ) {
       val qualifying = ownedVars -- locked
       if (!qualifying.isEmpty) {
         typr.println(i"interpolate $tree: ${tree.tpe.widen} in $state, owned vars = ${state.ownedVars.toList}%, %, previous = ${locked.toList}%, % / ${state.constraint}")

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2206,7 +2206,11 @@ class Typer extends Namer
 
   /** Interpolate and simplify the type of the given tree. */
   protected def simplify(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): tree.type = {
-    if (!tree.denot.isOverloaded) // for overloaded trees: resolve overloading before simplifying
+    if (!tree.denot.isOverloaded &&
+          // for overloaded trees: resolve overloading before simplifying
+        !tree.isInstanceOf[Applications.IntegratedTypeArgs]
+          // don't interpolatie in the middle of an extension method application
+       )
       if (!tree.tpe.widen.isInstanceOf[MethodOrPoly] // wait with simplifying until method is fully applied
           || tree.isDef)                             // ... unless tree is a definition
       {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2209,7 +2209,7 @@ class Typer extends Namer
     if (!tree.denot.isOverloaded &&
           // for overloaded trees: resolve overloading before simplifying
         !tree.isInstanceOf[Applications.IntegratedTypeArgs]
-          // don't interpolatie in the middle of an extension method application
+          // don't interpolate in the middle of an extension method application
        )
       if (!tree.tpe.widen.isInstanceOf[MethodOrPoly] // wait with simplifying until method is fully applied
           || tree.isDef)                             // ... unless tree is a definition

--- a/tests/pos/i6734.scala
+++ b/tests/pos/i6734.scala
@@ -1,0 +1,11 @@
+object Bug {
+
+  def (ab: (A, B)) pipe2[A, B, Z](f: (A, B) => Z): Z = f(ab._1, ab._2)
+
+  def (a: A) leftErr[A, B](b: B): A = (a, b).pipe2((a, b) => a) //Did not compile before.
+  def (a: A) leftOk1[A, B](b: B): A = Tuple2(a, b).pipe2((a, b) => a) //Compiles
+  def (a: A) leftOk2[A, B](b: B): A = {
+    val t = (a, b)
+    t.pipe2((a, b) => a) //Compiles
+  }
+}


### PR DESCRIPTION
Suppress interpolation in the middle of an ExtMethodApply. The reason is that
the ExtMethodApply has a WildcardType, which hides information about bound type
variables in the result type.