### PR TITLE
Fix leak checking

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -715,7 +715,7 @@ class Typer extends Namer
 
   def escapingRefs(block: Tree, localSyms: => List[Symbol])(implicit ctx: Context): collection.Set[NamedType] = {
     lazy val locals = localSyms.toSet
-    block.tpe.namedPartsWith(tp => locals.contains(tp.symbol) && !tp.widen.isErroneous)
+    block.tpe.namedPartsWith(tp => locals.contains(tp.symbol) && !tp.isErroneous)
   }
 
   /** Ensure that an expression's type can be expressed without references to locally defined

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -715,7 +715,7 @@ class Typer extends Namer
 
   def escapingRefs(block: Tree, localSyms: => List[Symbol])(implicit ctx: Context): collection.Set[NamedType] = {
     lazy val locals = localSyms.toSet
-    block.tpe namedPartsWith (tp => locals.contains(tp.symbol))
+    block.tpe.namedPartsWith(tp => locals.contains(tp.symbol) && !tp.widen.isErroneous)
   }
 
   /** Ensure that an expression's type can be expressed without references to locally defined


### PR DESCRIPTION
When compiling Parsers.scala with mismatched braces, I saw

```
java.lang.AssertionError: assertion failed: leak: <error no implicit values were found that match type dotty.tools.dotc.core.Contexts.Context>
[error]   (
[error] vdef) in ...
```
The issue is here that we should disregard leaks with erroneous types.