### PR TITLE
Remove pickled type splice type tags when unpicking

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -76,6 +76,9 @@ class ReifyQuotes extends MacroTransform {
       case tree: RefTree if !ctx.inInlineMethod =>
         assert(!tree.symbol.isQuote)
         assert(!tree.symbol.isSplice)
+      case _ : TypeDef =>
+        assert(!tree.symbol.hasAnnotation(defn.InternalQuoted_QuoteTypeTagAnnot),
+          s"${tree.symbol} should have been removed by PickledQuotes because it has a @quoteTypeTag")
       case _ =>
     }
   }

--- a/library/src-3.x/scala/internal/Quoted.scala
+++ b/library/src-3.x/scala/internal/Quoted.scala
@@ -25,6 +25,15 @@ object Quoted {
   @compileTimeOnly("Illegal reference to `scala.internal.Quoted.patternBindHole`")
   class patternBindHole extends Annotation
 
-  /** Artifact of type splicing */
+  /** Artifact of pickled type splices
+   *
+   *  During quote reification a quote `'{ ... F[$t] ... }` will be transformed into
+   *  `'{ @quoteTypeTag type T$1 = $t ... F[T$1] ... }` to have a tree for `$t`.
+   *  This artifact is removed durring quote unpickling.
+   *
+   *  See ReifyQuotes.scala and PickledQuotes.scala
+   */
+  @compileTimeOnly("Illegal reference to `scala.internal.Quoted.patternBindHole`")
   class quoteTypeTag extends Annotation
+
 }

--- a/library/src/scala/tasty/reflect/Printers.scala
+++ b/library/src/scala/tasty/reflect/Printers.scala
@@ -1018,7 +1018,6 @@ trait Printers
         // Remove Lambda nodes, lambdas are printed by their definition
         val stats2 = stats1.filter {
           case Lambda(_, _) => false
-          case IsTypeDef(tree) => !tree.symbol.annots.exists(_.symbol.owner.fullName == "scala.internal.Quoted$.quoteTypeTag")
           case _ => true
         }
         val (stats3, expr3) = expr1 match {
@@ -1515,9 +1514,6 @@ trait Printers
         case Type.ConstantType(const) =>
           printConstant(const)
 
-        case Type.SymRef(sym, _) if sym.annots.exists(_.symbol.owner.fullName == "scala.internal.Quoted$.quoteTypeTag") =>
-          printType(tpe.dealias)
-
         case Type.SymRef(sym, prefix) if sym.isType =>
           prefix match {
             case Type.ThisType(Types.EmptyPackage() | Types.RootPackage()) =>
@@ -1575,7 +1571,7 @@ trait Printers
           printRefinement(tpe)
 
         case Type.AppliedType(tp, args) =>
-          normalize(tp) match {
+          tp match {
             case Type.IsTypeLambda(tp) =>
               printType(tpe.dealias)
             case Type.TypeRef("<repeated>", Types.ScalaPackage()) =>
@@ -1672,13 +1668,6 @@ trait Printers
 
         case _ =>
           throw new MatchError(tpe.showExtractors)
-      }
-
-      private def normalize(tpe: TypeOrBounds): TypeOrBounds = tpe match {
-        case Type.IsSymRef(tpe)
-            if tpe.typeSymbol.annots.exists(_.symbol.owner.fullName == "scala.internal.Quoted$.quoteTypeTag") =>
-          tpe.dealias
-        case _ => tpe
       }
 
       def printImportSelector(sel: ImportSelector): Buffer = sel match {


### PR DESCRIPTION
These are artefacts of pickling that should not be visible to the users in show
or while pattern matching on these expressions.