### PR TITLE
Add missing QuoteContext to Liftable.toExpr

### DIFF
--- a/docs/docs/reference/metaprogramming/tasty-reflect.md
+++ b/docs/docs/reference/metaprogramming/tasty-reflect.md
@@ -25,7 +25,6 @@ is used.
 
 ```scala
 import scala.quoted._
-import scala.tasty._
 
 inline def natConst(x: => Int): Int = ${natConstImpl('{x})}
 

--- a/library/src-3.x/scala/quoted/Liftable.scala
+++ b/library/src-3.x/scala/quoted/Liftable.scala
@@ -6,7 +6,7 @@ import scala.runtime.quoted.Unpickler.liftedExpr
  *  without going through an explicit `'{...}` operation.
  */
 abstract class Liftable[T] {
-  def toExpr(x: T): Expr[T]
+  def toExpr(x: T) given QuoteContext: Expr[T]
 }
 
 /** Some liftable base types. To be completed with at least all types
@@ -27,7 +27,7 @@ object Liftable {
   implicit def ClassIsLiftable[T]: Liftable[Class[T]] = new PrimitiveLiftable
 
   private class PrimitiveLiftable[T] extends Liftable[T] {
-    override def toExpr(x: T): Expr[T] = liftedExpr(x)
+    override def toExpr(x: T) given QuoteContext: Expr[T] = liftedExpr(x)
   }
 
 }

--- a/library/src-3.x/scala/quoted/package.scala
+++ b/library/src-3.x/scala/quoted/package.scala
@@ -48,11 +48,11 @@ package object quoted {
   private object NoResult
 
   object autolift {
-    implicit def autoToExpr[T: Liftable](x: T): Expr[T] = x.toExpr
+    implicit def autoToExpr[T: Liftable](x: T) given QuoteContext: Expr[T] = x.toExpr
   }
 
   implicit object ExprOps {
-    def (x: T) toExpr[T] given Liftable[T]: Expr[T] = the[Liftable[T]].toExpr(x)
+    def (x: T) toExpr[T: Liftable] given QuoteContext: Expr[T] = the[Liftable[T]].toExpr(x)
 
     def (list: List[Expr[T]]) toExprOfList[T] given Type[T]: Expr[List[T]] = list match {
       case x :: xs  => '{ $x :: ${xs.toExprOfList} }

--- a/library/src-non-bootstrapped/dotty/internal/StringContextMacro.scala
+++ b/library/src-non-bootstrapped/dotty/internal/StringContextMacro.scala
@@ -4,7 +4,6 @@ package dotty.internal
 
 import scala.quoted._
 import scala.quoted.matching._
-import scala.tasty.Reflection
 import reflect._
 
 object StringContextMacro {

--- a/semanticdb/src/dotty/semanticdb/Main.scala
+++ b/semanticdb/src/dotty/semanticdb/Main.scala
@@ -1,6 +1,5 @@
 package dotty.semanticdb
 
-import scala.tasty.Reflection
 import scala.tasty.file._
 import scala.NotImplementedError
 

--- a/semanticdb/src/dotty/semanticdb/TastyScalaFileInferrer.scala
+++ b/semanticdb/src/dotty/semanticdb/TastyScalaFileInferrer.scala
@@ -1,7 +1,5 @@
 package dotty.semanticdb
 
-import scala.tasty.Reflection
-
 import scala.meta.internal.{semanticdb => s}
 import scala.tasty.Reflection
 import scala.tasty.file.TastyConsumer

--- a/semanticdb/src/dotty/semanticdb/Utils.scala
+++ b/semanticdb/src/dotty/semanticdb/Utils.scala
@@ -1,7 +1,6 @@
 package dotty.semanticdb
 
 
-import scala.tasty.Reflection
 import scala.tasty.file._
 import scala.collection.mutable.HashMap
 
@@ -11,7 +10,6 @@ import java.nio.file._
 import scala.meta.internal.{semanticdb => s}
 import scala.collection.JavaConverters._
 import java.io.File
-import scala.tasty.Reflection
 import scala.tasty.file.TastyConsumer
 import java.lang.reflect.InvocationTargetException
 

--- a/semanticdb/test/dotty/semanticdb/Tests.scala
+++ b/semanticdb/test/dotty/semanticdb/Tests.scala
@@ -1,6 +1,5 @@
 package dotty.semanticdb
 
-import scala.tasty.Reflection
 import scala.tasty.file._
 import scala.collection.mutable.HashMap
 
@@ -10,7 +9,6 @@ import java.nio.file._
 import scala.meta.internal.{semanticdb => s}
 import scala.collection.JavaConverters._
 import java.io.File
-import scala.tasty.Reflection
 import scala.tasty.file.TastyConsumer
 import java.lang.reflect.InvocationTargetException
 

--- a/tests/neg-macros/inline-case-objects/Macro_1.scala
+++ b/tests/neg-macros/inline-case-objects/Macro_1.scala
@@ -1,9 +1,8 @@
 
 import scala.quoted._
-import scala.quoted.autolift._
 
 object Macros {
-  def impl(foo: Any): Expr[String] = foo.getClass.getCanonicalName
+  def impl(foo: Any) given QuoteContext: Expr[String] = foo.getClass.getCanonicalName.toExpr
 }
 
 class Bar {

--- a/tests/neg-macros/inline-macro-staged-interpreter/Macro_1.scala
+++ b/tests/neg-macros/inline-macro-staged-interpreter/Macro_1.scala
@@ -6,29 +6,29 @@ object E {
 
   inline def eval[T](inline x: E[T]): T = ${ impl(x) }
 
-  def impl[T](x: E[T]): Expr[T] = x.lift
+  def impl[T](x: E[T]) given QuoteContext: Expr[T] = x.lift
 
 }
 
 trait E[T] {
-  def lift: Expr[T]
+  def lift given QuoteContext: Expr[T]
 }
 
 case class I(n: Int) extends E[Int] {
-  def lift: Expr[Int] = n
+  def lift given QuoteContext: Expr[Int] = n
 }
 
 case class Plus[T](x: E[T], y: E[T])(implicit op: Plus2[T]) extends E[T] {
-  def lift: Expr[T] = op(x.lift, y.lift)
+  def lift given QuoteContext: Expr[T] = op(x.lift, y.lift)
 }
 
 trait Op2[T] {
-  def apply(x: Expr[T], y: Expr[T]): Expr[T]
+  def apply(x: Expr[T], y: Expr[T]) given QuoteContext: Expr[T]
 }
 
 trait Plus2[T] extends Op2[T]
 object Plus2 {
   implicit case object IPlus extends Plus2[Int] {
-    def apply(x: Expr[Int], y: Expr[Int]): Expr[Int] = '{$x + $y}
+    def apply(x: Expr[Int], y: Expr[Int]) given QuoteContext: Expr[Int] = '{$x + $y}
   }
 }

--- a/tests/neg-macros/inline-option/Macro_1.scala
+++ b/tests/neg-macros/inline-option/Macro_1.scala
@@ -1,10 +1,9 @@
 
 import scala.quoted._
-import scala.quoted.autolift._
 
 object Macro {
-  def impl(opt: Option[Int]): Expr[Int] = opt match {
-    case Some(i) => i
+  def impl(opt: Option[Int]) given QuoteContext: Expr[Int] = opt match {
+    case Some(i) => i.toExpr
     case None => '{-1}
   }
 }

--- a/tests/neg-macros/inline-tuples-1/Macro_1.scala
+++ b/tests/neg-macros/inline-tuples-1/Macro_1.scala
@@ -3,26 +3,26 @@ import scala.quoted._
 import scala.quoted.autolift._
 
 object Macros {
-  def tup1(tup: Tuple1[Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup2(tup: Tuple2[Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup3(tup: Tuple3[Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup4(tup: Tuple4[Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup5(tup: Tuple5[Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup6(tup: Tuple6[Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup7(tup: Tuple7[Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup8(tup: Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup9(tup: Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup10(tup: Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup11(tup: Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup12(tup: Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup13(tup: Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup14(tup: Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup15(tup: Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup16(tup: Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup17(tup: Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup18(tup: Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup19(tup: Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup20(tup: Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup21(tup: Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup22(tup: Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup1(tup: Tuple1[Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup2(tup: Tuple2[Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup3(tup: Tuple3[Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup4(tup: Tuple4[Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup5(tup: Tuple5[Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup6(tup: Tuple6[Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup7(tup: Tuple7[Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup8(tup: Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup9(tup: Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup10(tup: Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup11(tup: Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup12(tup: Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup13(tup: Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup14(tup: Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup15(tup: Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup16(tup: Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup17(tup: Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup18(tup: Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup19(tup: Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup20(tup: Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup21(tup: Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup22(tup: Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
 }

--- a/tests/neg-macros/quote-interpolator-core-old.scala
+++ b/tests/neg-macros/quote-interpolator-core-old.scala
@@ -12,12 +12,12 @@ object FInterpolation {
     // ...
   }
 
-  private def liftSeq(args: Seq[Expr[Any]]): Expr[Seq[Any]] = args match {
+  private def liftSeq(args: Seq[Expr[Any]]) given QuoteContext: Expr[Seq[Any]] = args match {
     case x :: xs  => '{ ($x) +: ${liftSeq(xs)}  }
     case Nil => '{Seq(): Seq[Any]}
   }
 
-  def fInterpolation(sc: StringContext, args: Seq[Expr[Any]]): Expr[String] = {
+  def fInterpolation(sc: StringContext, args: Seq[Expr[Any]]) given QuoteContext: Expr[String] = {
     val str: Expr[String] = sc.parts.mkString("")
     val args1: Expr[Seq[Any]] = liftSeq(args)
     '{ $str.format($args1: _*) }

--- a/tests/neg-macros/quote-macro-complex-arg-0.scala
+++ b/tests/neg-macros/quote-macro-complex-arg-0.scala
@@ -2,5 +2,5 @@ import scala.quoted._
 
 object Macros {
   inline def foo(inline i: Int, dummy: Int, j: Int): Int = ${ bar(i + 1, 'j) } // error: i + 1 is not a parameter or field reference
-  def bar(x: Int, y: Expr[Int]): Expr[Int] = '{ ${x.toExpr} + $y }
+  def bar(x: Int, y: Expr[Int]) given QuoteContext: Expr[Int] = '{ ${x.toExpr} + $y }
 }

--- a/tests/neg-macros/splice-in-top-level-splice-1.scala
+++ b/tests/neg-macros/splice-in-top-level-splice-1.scala
@@ -4,5 +4,5 @@ import scala.quoted.autolift._
 object Foo {
   inline def foo(): Int = ${bar(${x})} // error
   def x: Expr[Int] = '{1}
-  def bar(i: Int): Expr[Int] = i
+  def bar(i: Int) given QuoteContext: Expr[Int] = i
 }

--- a/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Asserts {
 
   implicit class Ops[T](left: T) {

--- a/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Asserts {
 
   implicit class Ops[T](left: T) {

--- a/tests/neg-macros/tasty-macro-error/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-error/quoted_1.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Macros {
 
   inline def fun(x: Any): Unit = ${ impl('x) }

--- a/tests/neg-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-positions/quoted_1.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Macros {
 
   inline def fun(x: Any): Unit = ${ impl('x) }

--- a/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty.Reflection
 import scala.language.implicitConversions
 
 object Macro {

--- a/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty.Reflection
 import scala.language.implicitConversions
 
 object Macro {

--- a/tests/neg-with-compiler/i5941/macro_1.scala
+++ b/tests/neg-with-compiler/i5941/macro_1.scala
@@ -4,7 +4,6 @@ abstract class Lens[S, T] {
 }
 
 import scala.quoted._
-import scala.tasty._
 
 object Lens {
   def apply[S, T](_get: S => T)(_set: T => S => S): Lens[S, T] = new Lens {

--- a/tests/neg-with-compiler/quote-run-in-macro-1/quoted_1.scala
+++ b/tests/neg-with-compiler/quote-run-in-macro-1/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
 
   implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
-  def fooImpl(i: Expr[Int]): Expr[Int] = {
+  def fooImpl(i: Expr[Int]) given QuoteContext: Expr[Int] = {
     val y: Int = run(i)
     y
   }

--- a/tests/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
+++ b/tests/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
@@ -4,7 +4,7 @@ import scala.quoted.autolift._
 object Macros {
 
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
-  def fooImpl(i: Expr[Int]): Expr[Int] = {
+  def fooImpl(i: Expr[Int]) given QuoteContext: Expr[Int] = {
     implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
     val y: Int = run(i)
     y

--- a/tests/pending/run/tasty-comments/quoted_1.scala
+++ b/tests/pending/run/tasty-comments/quoted_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
 
 object Macros {
 

--- a/tests/pos-macros/i6171/Macro_1.scala
+++ b/tests/pos-macros/i6171/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/pos-macros/quote-nested-object/Macro_1.scala
+++ b/tests/pos-macros/quote-nested-object/Macro_1.scala
@@ -9,7 +9,7 @@ object Macro {
 
     inline def plus(inline n: Int, m: Int): Int = ${ plus(n, 'm) }
 
-    def plus(n: Int, m: Expr[Int]): Expr[Int] =
+    def plus(n: Int, m: Expr[Int]) given QuoteContext: Expr[Int] =
       if (n == 0) m
       else '{ ${n} + $m }
 
@@ -17,7 +17,7 @@ object Macro {
 
       inline def plus(inline n: Int, m: Int): Int = ${ plus(n, 'm) }
 
-      def plus(n: Int, m: Expr[Int]): Expr[Int] =
+      def plus(n: Int, m: Expr[Int]) given QuoteContext: Expr[Int] =
         if (n == 0) m
         else '{ ${n} + $m }
     }

--- a/tests/pos-macros/quote-whitebox-2/Macro_1.scala
+++ b/tests/pos-macros/quote-whitebox-2/Macro_1.scala
@@ -5,6 +5,6 @@ object Macro {
 
   inline def charOrString(inline str: String) <: Any = ${ impl(str) }
 
-  def impl(str: String) = if (str.length == 1) str.charAt(0).toExpr else str.toExpr
+  def impl(str: String) given QuoteContext = if (str.length == 1) str.charAt(0).toExpr else str.toExpr
 
 }

--- a/tests/pos-with-compiler/quote-0.scala
+++ b/tests/pos-with-compiler/quote-0.scala
@@ -7,15 +7,15 @@ object Macros {
   inline def assert(expr: => Boolean): Unit =
     ${ assertImpl('expr) }
 
-  def assertImpl(expr: Expr[Boolean]) =
+  def assertImpl(expr: Expr[Boolean]) given QuoteContext =
     '{ if !($expr) then throw new AssertionError(s"failed assertion: ${${showExpr(expr)}}") }
 
 
-  def showExpr[T](expr: Expr[T]): Expr[String] = expr.toString
+  def showExpr[T](expr: Expr[T]) given QuoteContext: Expr[String] = expr.toString
 
   inline def power(inline n: Int, x: Double) = ${ powerCode(n, 'x) }
 
-  def powerCode(n: Int, x: Expr[Double]): Expr[Double] =
+  def powerCode(n: Int, x: Expr[Double]) given QuoteContext: Expr[Double] =
     if (n == 0) '{1.0}
     else if (n == 1) x
     else if (n % 2 == 0) '{ { val y = $x * $x; ${ powerCode(n / 2, 'y) } } }
@@ -24,21 +24,24 @@ object Macros {
 
 class Test {
 
-  val program = '{
-    import Macros._
-
-    val x = 1
-    assert(x != 0)
-
-    ${ assertImpl('{x != 0}) }
-
-    val y = math.sqrt(2.0)
-
-    power(3, y)
-
-    ${ powerCode(3, '{math.sqrt(2.0)}) }
-  }
-
   implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
-  program.run
+
+  run {
+    val program = '{
+      import Macros._
+
+      val x = 1
+      assert(x != 0)
+
+      ${ assertImpl('{x != 0}) }
+
+      val y = math.sqrt(2.0)
+
+      power(3, y)
+
+      ${ powerCode(3, '{math.sqrt(2.0)}) }
+    }
+
+    program
+  }
 }

--- a/tests/pos/i5962.scala
+++ b/tests/pos/i5962.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 class MatchFactory1[T, S[_]] {
   def f: Int = 2
@@ -7,7 +6,7 @@ class MatchFactory1[T, S[_]] {
 
 object MatcherFactory1 {
 
-  def impl[T: Type, S[_], M >: MatchFactory1[T, S] <: MatchFactory1[T, S] : Type](self: Expr[M])(implicit refl: Reflection, tpS: Type[S[T]]) =
+  def impl[T: Type, S[_], M >: MatchFactory1[T, S] <: MatchFactory1[T, S] : Type](self: Expr[M])(implicit qctx: QuoteContext, tpS: Type[S[T]]) =
     '{ val a = ${self}; a.f }
 
 }

--- a/tests/pos/i6253.scala
+++ b/tests/pos/i6253.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty.Reflection
 object Macros {
   def impl(self: Expr[StringContext]) given QuoteContext: Expr[String] = self match {
     case '{ StringContext() } => '{""}

--- a/tests/pos/quote-lift.scala
+++ b/tests/pos/quote-lift.scala
@@ -1,6 +1,7 @@
 import scala.quoted._
 
 object Test {
+   delegate for QuoteContext = ???
 
   '{ ${implicitly[Liftable[Int]].toExpr(1)} }
 

--- a/tests/pos/quote-liftable-list-2.scala
+++ b/tests/pos/quote-liftable-list-2.scala
@@ -3,11 +3,11 @@ import scala.quoted._
 object Test {
 
   implicit def ListIsLiftableOr[T: Type, U: Type]: Liftable[List[T | U]] = new {
-    def toExpr(xs: List[T | U]): Expr[List[T | U]] = '{ Nil: List[T | U] }
+    def toExpr(xs: List[T | U]) given QuoteContext: Expr[List[T | U]] = '{ Nil: List[T | U] }
   }
 
   implicit def ListIsLiftableAnd[T: Type, U: Type]: Liftable[List[T & U]] = new {
-    def toExpr(xs: List[T & U]): Expr[List[T & U]] = '{ Nil: List[T & U] }
+    def toExpr(xs: List[T & U]) given QuoteContext: Expr[List[T & U]] = '{ Nil: List[T & U] }
   }
 
 }

--- a/tests/pos/quote-liftable-list.scala
+++ b/tests/pos/quote-liftable-list.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 object Test {
 
   implicit def ListIsLiftable[T: Liftable: Type]: Liftable[List[T]] = new {
-    def toExpr(xs: List[T]): Expr[List[T]] = '{ Nil: List[T] }
+    def toExpr(xs: List[T]) given QuoteContext: Expr[List[T]] = '{ Nil: List[T] }
   }
 
 }

--- a/tests/pos/quote-liftable.scala
+++ b/tests/pos/quote-liftable.scala
@@ -2,8 +2,10 @@ import scala.quoted._
 
 object Test {
 
+  delegate for QuoteContext = ???
+
   implicit def IntIsLiftable: Liftable[Int] = new {
-    def toExpr(n: Int): Expr[Int] = n match {
+    def toExpr(n: Int) given QuoteContext: Expr[Int] = n match {
       case Int.MinValue    => '{Int.MinValue}
       case _ if n < 0      => '{- ${toExpr(n)}}
       case 0               => '{0}
@@ -13,12 +15,12 @@ object Test {
   }
 
   implicit def BooleanIsLiftable: Liftable[Boolean] = new {
-    implicit def toExpr(b: Boolean) =
+    implicit def toExpr(b: Boolean) given QuoteContext: Expr[Boolean] =
       if (b) '{true} else '{false}
   }
 
   implicit def ListIsLiftable[T: Liftable: Type]: Liftable[List[T]] = new {
-    def toExpr(xs: List[T]): Expr[List[T]] = xs match {
+    def toExpr(xs: List[T]) given QuoteContext: Expr[List[T]] = xs match {
       case x :: xs1 => '{ ${ implicitly[Liftable[T]].toExpr(x) } :: ${ toExpr(xs1) } }
       case Nil => '{Nil: List[T]}
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 import scala.quoted.autolift._
 
 object Foo {

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.autolift._
-import scala.tasty._
 
 object Foo {
 

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 object Macros {
 
   implicit inline def printOwners[T](x: => T): Unit =

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
 
 object Foo {
 

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Foo {
 
   inline def inspectBody(i: => Int): String =

--- a/tests/run-macros/f-interpolation-1/FQuote_1.scala
+++ b/tests/run-macros/f-interpolation-1/FQuote_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty.Reflection
 import scala.quoted.autolift._
 
 import scala.language.implicitConversions

--- a/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
+++ b/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
@@ -2,7 +2,6 @@
 // using staging reflection
 
 import scala.quoted._
-import scala.tasty._
 
 object TypeToolbox {
   /** are the two types equal? */
@@ -113,7 +112,7 @@ object TypeToolbox {
 
   // TODO add to the std lib
   private implicit def listIsLiftable[T: Type: Liftable]: Liftable[List[T]] = new Liftable {
-    def toExpr(list: List[T]): Expr[List[T]] = list match {
+    def toExpr(list: List[T]) given QuoteContext: Expr[List[T]] = list match {
       case x :: xs => '{${x.toExpr} :: ${toExpr(xs)}}
       case Nil => '{Nil}
     }

--- a/tests/run-macros/i4734/Macro_1.scala
+++ b/tests/run-macros/i4734/Macro_1.scala
@@ -6,7 +6,7 @@ object Macros {
   inline def unrolledForeach(seq: IndexedSeq[Int], f: => Int => Unit, inline unrollSize: Int): Unit = // or f: Int => Unit
     ${ unrolledForeachImpl('seq, 'f, unrollSize) }
 
-  def unrolledForeachImpl(seq: Expr[IndexedSeq[Int]], f: Expr[Int => Unit], unrollSize: Int): Expr[Unit] = '{
+  def unrolledForeachImpl(seq: Expr[IndexedSeq[Int]], f: Expr[Int => Unit], unrollSize: Int) given QuoteContext: Expr[Unit] = '{
     val size = ($seq).length
     assert(size % (${unrollSize}) == 0) // for simplicity of the implementation
     var i = 0

--- a/tests/run-macros/i4735/Macro_1.scala
+++ b/tests/run-macros/i4735/Macro_1.scala
@@ -8,7 +8,7 @@ object Macro {
   inline def unrolledForeach(inline unrollSize: Int, seq: Array[Int], f: => Int => Unit): Unit = // or f: Int => Unit
     ${ unrolledForeachImpl(unrollSize, 'seq, 'f) }
 
-  private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{
+  private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]) given QuoteContext: Expr[Unit] = '{
     val size = ($seq).length
     assert(size % (${unrollSize}) == 0) // for simplicity of the implementation
     var i = 0

--- a/tests/run-macros/i5119/Macro_1.scala
+++ b/tests/run-macros/i5119/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty.Reflection
 import scala.quoted.autolift._
 
 object Macro {

--- a/tests/run-macros/i5119b/Macro_1.scala
+++ b/tests/run-macros/i5119b/Macro_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty.Reflection
 
 object Macro {
 

--- a/tests/run-macros/i5188a/Macro_1.scala
+++ b/tests/run-macros/i5188a/Macro_1.scala
@@ -3,5 +3,5 @@ import scala.quoted.autolift._
 
 object Lib {
   inline def sum(inline args: Int*): Int = ${ impl(args: _*) }
-  def impl(args: Int*): Expr[Int] = args.sum
+  def impl(args: Int*) given QuoteContext: Expr[Int] = args.sum
 }

--- a/tests/run-macros/i5533/Macro_1.scala
+++ b/tests/run-macros/i5533/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/i5533b/Macro_1.scala
+++ b/tests/run-macros/i5533b/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
   def f(x: Int): Int = x

--- a/tests/run-macros/i5536/Macro_1.scala
+++ b/tests/run-macros/i5536/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}

--- a/tests/run-macros/i5629/Macro_1.scala
+++ b/tests/run-macros/i5629/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object Macros {
 

--- a/tests/run-macros/i5715/Macro_1.scala
+++ b/tests/run-macros/i5715/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/i5941/macro_1.scala
+++ b/tests/run-macros/i5941/macro_1.scala
@@ -4,7 +4,6 @@ trait Lens[S, T] {
 }
 
 import scala.quoted._
-import scala.tasty._
 
 object Lens {
   def apply[S, T](_get: S => T)(_set: T => S => S): Lens[S, T] = new Lens {

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/i6253-b/quoted_1.scala
+++ b/tests/run-macros/i6253-b/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.matching._
 
-import scala.tasty.Reflection
-
 object Macros {
 
   inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}

--- a/tests/run-macros/i6253/quoted_1.scala
+++ b/tests/run-macros/i6253/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.matching._
 
-import scala.tasty.Reflection
-
 object Macros {
 
   inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}

--- a/tests/run-macros/i6518/Macro_1.scala
+++ b/tests/run-macros/i6518/Macro_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.autolift._
-import scala.tasty._
 
 object Macros {
 

--- a/tests/run-macros/inferred-repeated-result/test_1.scala
+++ b/tests/run-macros/inferred-repeated-result/test_1.scala
@@ -1,7 +1,6 @@
 object Macros {
   import scala.quoted._
   import scala.quoted.autolift._
-  import scala.tasty._
 
   inline def go[T](t: => T) = ${ impl('t) }
   def impl[T](expr: Expr[T]) given (qctx: QuoteContext): Expr[Unit] = {

--- a/tests/run-macros/inline-case-objects/Macro_1.scala
+++ b/tests/run-macros/inline-case-objects/Macro_1.scala
@@ -1,9 +1,8 @@
 
 import scala.quoted._
-import scala.quoted.autolift._
 
 object Macros {
-  def impl(foo: Any): Expr[String] = foo.getClass.getCanonicalName
+  def impl(foo: Any) given QuoteContext: Expr[String] = foo.getClass.getCanonicalName.toExpr
 }
 
 case object Bar {

--- a/tests/run-macros/inline-macro-staged-interpreter/Macro_1.scala
+++ b/tests/run-macros/inline-macro-staged-interpreter/Macro_1.scala
@@ -1,33 +1,32 @@
 
 import scala.quoted._
-import scala.quoted.autolift._
 
 object E {
 
   inline def eval[T](inline x: E[T]): T = ${ impl(x) }
 
-  def impl[T](x: E[T]): Expr[T] = x.lift
+  def impl[T](x: E[T]) given QuoteContext: Expr[T] = x.lift
 
 }
 
 trait E[T] {
-  def lift: Expr[T]
+  def lift given QuoteContext: Expr[T]
 }
 
 case class I(n: Int) extends E[Int] {
-  def lift: Expr[Int] = n
+  def lift given QuoteContext: Expr[Int] = n.toExpr
 }
 
 case class D(n: Double) extends E[Double] {
-  def lift: Expr[Double] = n
+  def lift given QuoteContext: Expr[Double] = n.toExpr
 }
 
 case class Plus[T](x: E[T], y: E[T])(implicit op: Plus2[T]) extends E[T] {
-  def lift: Expr[T] = op(x.lift, y.lift)
+  def lift given QuoteContext: Expr[T] = op(x.lift, y.lift)
 }
 
 case class Times[T](x: E[T], y: E[T])(implicit op: Times2[T]) extends E[T] {
-  def lift: Expr[T] = op(x.lift, y.lift)
+  def lift given QuoteContext: Expr[T] = op(x.lift, y.lift)
 }
 
 trait Op2[T] {

--- a/tests/run-macros/inline-option/Macro_1.scala
+++ b/tests/run-macros/inline-option/Macro_1.scala
@@ -4,11 +4,11 @@ import scala.quoted.autolift._
 
 object Macros {
 
-  def impl(opt: Option[Int]): Expr[Int] = opt match {
+  def impl(opt: Option[Int]) given QuoteContext: Expr[Int] = opt match {
     case Some(i) => i
     case None => '{-1}
   }
 
-  def impl2(opt: Option[Option[Int]]): Expr[Int] = impl(opt.flatten)
+  def impl2(opt: Option[Option[Int]]) given QuoteContext: Expr[Int] = impl(opt.flatten)
 
 }

--- a/tests/run-macros/inline-tuples-1/Macro_1.scala
+++ b/tests/run-macros/inline-tuples-1/Macro_1.scala
@@ -3,26 +3,26 @@ import scala.quoted._
 import scala.quoted.autolift._
 
 object Macros {
-  def tup1(tup: Tuple1[Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup2(tup: Tuple2[Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup3(tup: Tuple3[Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup4(tup: Tuple4[Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup5(tup: Tuple5[Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup6(tup: Tuple6[Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup7(tup: Tuple7[Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup8(tup: Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup9(tup: Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup10(tup: Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup11(tup: Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup12(tup: Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup13(tup: Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup14(tup: Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup15(tup: Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup16(tup: Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup17(tup: Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup18(tup: Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup19(tup: Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup20(tup: Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup21(tup: Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup22(tup: Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]): Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup1(tup: Tuple1[Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup2(tup: Tuple2[Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup3(tup: Tuple3[Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup4(tup: Tuple4[Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup5(tup: Tuple5[Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup6(tup: Tuple6[Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup7(tup: Tuple7[Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup8(tup: Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup9(tup: Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup10(tup: Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup11(tup: Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup12(tup: Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup13(tup: Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup14(tup: Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup15(tup: Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup16(tup: Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup17(tup: Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup18(tup: Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup19(tup: Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup20(tup: Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup21(tup: Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup22(tup: Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]) given QuoteContext: Expr[Int] = tup.productIterator.map(_.asInstanceOf[Int]).sum
 }

--- a/tests/run-macros/inline-tuples-2/Macro_1.scala
+++ b/tests/run-macros/inline-tuples-2/Macro_1.scala
@@ -4,8 +4,8 @@ import scala.quoted.autolift._
 
 object Macros {
 
-  def impl(tup: Tuple1[Int]): Expr[Int] = tup._1
+  def impl(tup: Tuple1[Int]) given QuoteContext: Expr[Int] = tup._1
 
-  def impl2(tup: Tuple1[Tuple1[Int]]): Expr[Int] = impl(tup._1)
+  def impl2(tup: Tuple1[Tuple1[Int]]) given QuoteContext: Expr[Int] = impl(tup._1)
 
 }

--- a/tests/run-macros/inline-varargs-1/Macro_1.scala
+++ b/tests/run-macros/inline-varargs-1/Macro_1.scala
@@ -3,5 +3,5 @@ import scala.quoted._
 import scala.quoted.autolift._
 
 object Macros {
-  def sum(nums: Int*): Expr[Int] = nums.sum
+  def sum(nums: Int*) given QuoteContext: Expr[Int] = nums.sum
 }

--- a/tests/run-macros/quote-force/quoted_1.scala
+++ b/tests/run-macros/quote-force/quoted_1.scala
@@ -7,13 +7,15 @@ object Location {
 
   implicit inline def location: Location = ${impl}
 
-  def impl: Expr[Location] = {
+  def impl given QuoteContext: Expr[Location] = {
     val list = List("a", "b", "c", "d", "e", "f")
     '{new Location(${list})}
   }
 
-  private implicit def ListIsLiftable[T : Liftable : Type]: Liftable[List[T]] = {
-    case x :: xs  => '{ ${x} :: ${xs} }
-    case Nil => '{ List.empty[T] }
+  private implicit def ListIsLiftable[T : Liftable : Type]: Liftable[List[T]] = new Liftable[List[T]] {
+    def toExpr(x: List[T]) given QuoteContext: Expr[List[T]] = x match {
+      case x :: xs  => '{ ${x} :: ${xs} }
+      case Nil => '{ List.empty[T] }
+    }
   }
 }

--- a/tests/run-macros/quote-impure-by-name/quoted_1.scala
+++ b/tests/run-macros/quote-impure-by-name/quoted_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty.Reflection
 
 class Index[K, Keys](val index: String) extends AnyVal {
   override def toString: String = index

--- a/tests/run-macros/quote-inline-function/quoted_1.scala
+++ b/tests/run-macros/quote-inline-function/quoted_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.autolift._
-import scala.tasty.Reflection
 
 object Macros {
 

--- a/tests/run-macros/quote-matcher-runtime/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-runtime/quoted_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.matching._
 
-import scala.tasty.Reflection
 
 object Macros {
 

--- a/tests/run-macros/quote-matcher-string-interpolator-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-string-interpolator-2/quoted_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.matching._
 
-import scala.tasty.Reflection
 
 object Macros {
 

--- a/tests/run-macros/quote-matcher-string-interpolator-3/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-string-interpolator-3/quoted_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.matching._
 
-import scala.tasty.Reflection
 
 object Macros {
 

--- a/tests/run-macros/quote-matcher-string-interpolator/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-string-interpolator/quoted_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.matching._
 
-import scala.tasty.Reflection
 
 object Macros {
 

--- a/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
@@ -2,9 +2,6 @@
 import scala.quoted._
 import scala.quoted.matching._
 
-import scala.tasty.Reflection
-
-
 object Macros {
 
   inline def lift[T](sym: Symantics[T])(a: => DSL): T = ${impl[T]('sym, 'a)}

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -61,7 +61,7 @@ case class LitDSL(x: Int) extends DSL
 //
 
 trait Symantics[Num] {
-  def value(x: Int): Expr[Num]
+  def value(x: Int) given QuoteContext: Expr[Num]
   def plus(x: Expr[Num], y: Expr[Num]): Expr[Num]
   def times(x: Expr[Num], y: Expr[Num]): Expr[Num]
   def app(f: Expr[Num => Num], x: Expr[Num]): Expr[Num]
@@ -69,7 +69,7 @@ trait Symantics[Num] {
 }
 
 object StringNum extends Symantics[String] {
-  def value(x: Int): Expr[String] = x.toString.toExpr
+  def value(x: Int) given QuoteContext: Expr[String] = x.toString.toExpr
   def plus(x: Expr[String], y: Expr[String]): Expr[String] = '{ s"${$x} + ${$y}" } // '{ x + " + " + y }
   def times(x: Expr[String], y: Expr[String]): Expr[String] = '{ s"${$x} * ${$y}" }
   def app(f: Expr[String => String], x: Expr[String]): Expr[String] = f(x) // functions are beta reduced
@@ -77,7 +77,7 @@ object StringNum extends Symantics[String] {
 }
 
 object ComputeNum extends Symantics[Int] {
-  def value(x: Int): Expr[Int] = x.toExpr
+  def value(x: Int) given QuoteContext: Expr[Int] = x.toExpr
   def plus(x: Expr[Int], y: Expr[Int]): Expr[Int] = '{ $x + $y }
   def times(x: Expr[Int], y: Expr[Int]): Expr[Int] = '{ $x * $y }
   def app(f: Expr[Int => Int], x: Expr[Int]): Expr[Int] = '{ $f($x) }
@@ -85,7 +85,7 @@ object ComputeNum extends Symantics[Int] {
 }
 
 object ASTNum extends Symantics[ASTNum] {
-  def value(x: Int): Expr[ASTNum] = '{ LitAST(${x.toExpr}) }
+  def value(x: Int) given QuoteContext: Expr[ASTNum] = '{ LitAST(${x.toExpr}) }
   def plus(x: Expr[ASTNum], y: Expr[ASTNum]): Expr[ASTNum] = '{ PlusAST($x, $y) }
   def times(x: Expr[ASTNum], y: Expr[ASTNum]): Expr[ASTNum] = '{ TimesAST($x, $y) }
   def app(f: Expr[ASTNum => ASTNum], x: Expr[ASTNum]): Expr[ASTNum] = '{ AppAST($f, $x) }

--- a/tests/run-macros/quote-simple-macro/quoted_1.scala
+++ b/tests/run-macros/quote-simple-macro/quoted_1.scala
@@ -3,5 +3,5 @@ import scala.quoted.autolift._
 
 object Macros {
   inline def foo(inline i: Int, dummy: Int, j: Int): Int = ${ bar(i, 'j) }
-  def bar(x: Int, y: Expr[Int]): Expr[Int] = '{ ${x} + $y }
+  def bar(x: Int, y: Expr[Int]) given QuoteContext: Expr[Int] = '{ ${x} + $y }
 }

--- a/tests/run-macros/quote-unrolled-foreach/quoted_1.scala
+++ b/tests/run-macros/quote-unrolled-foreach/quoted_1.scala
@@ -7,7 +7,7 @@ object Macro {
   inline def unrolledForeach(inline unrollSize: Int, seq: Array[Int])(f: => Int => Unit): Unit = // or f: Int => Unit
     ${unrolledForeachImpl(unrollSize, 'seq, 'f)}
 
-  private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{
+  private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit]) given QuoteContext: Expr[Unit] = '{
     val size = $seq.length
     assert(size % (${unrollSize}) == 0) // for simplicity of the implementation
     var i = 0

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/reflect-isFunctionType/macro_1.scala
+++ b/tests/run-macros/reflect-isFunctionType/macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 
 inline def isFunctionType[T:Type]: Boolean = ${ isFunctionTypeImpl('[T]) }

--- a/tests/run-macros/reflect-pos-fun/assert_1.scala
+++ b/tests/run-macros/reflect-pos-fun/assert_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/reflect-select-copy/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy/assert_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/reflect-select-copy/reflect-select-copy/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy/reflect-select-copy/assert_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/reflect-typeChecks/assert_1.scala
+++ b/tests/run-macros/reflect-typeChecks/assert_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object scalatest {
 

--- a/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 object Macros {
 
   inline def inspect[T](x: T): Unit = ${ impl('x) }

--- a/tests/run-macros/tasty-custom-show/quoted_1.scala
+++ b/tests/run-macros/tasty-custom-show/quoted_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty.Reflection
 
 object Macros {
 

--- a/tests/run-macros/tasty-dealias/quoted_1.scala
+++ b/tests/run-macros/tasty-dealias/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object Macros {
 

--- a/tests/run-macros/tasty-definitions-1/quoted_1.scala
+++ b/tests/run-macros/tasty-definitions-1/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 object Macros {
 
   inline def testDefinitions(): Unit = ${testDefinitionsImpl}

--- a/tests/run-macros/tasty-eval/quoted_1.scala
+++ b/tests/run-macros/tasty-eval/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 object Macros {
 
   implicit inline def foo(i: Int): String =

--- a/tests/run-macros/tasty-extractors-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-1/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 object Macros {
 
   implicit inline def printTree[T](x: => T): Unit =

--- a/tests/run-macros/tasty-extractors-2/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-2/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 object Macros {
 
   implicit inline def printTree[T](x: => T): Unit =

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 
-import scala.tasty.Reflection
 import scala.quoted.autolift._
 
 object Macros {

--- a/tests/run-macros/tasty-extractors-constants-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-constants-1/quoted_1.scala
@@ -3,7 +3,6 @@ import scala.quoted.autolift._
 
 import scala.quoted.matching._
 
-import scala.tasty._
 import scala.tasty.util._
 
 object Macros {

--- a/tests/run-macros/tasty-extractors-types/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-types/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 object Macros {
 
   implicit inline def printType[T]: Unit = ${ impl('[T]) }

--- a/tests/run-macros/tasty-getfile/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile/Macro_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty.Reflection
 
 object SourceFiles {
 

--- a/tests/run-macros/tasty-implicit-fun-context-2/Macro_1.scala
+++ b/tests/run-macros/tasty-implicit-fun-context-2/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty.Reflection
 
 object Foo {
 

--- a/tests/run-macros/tasty-indexed-map/quoted_1.scala
+++ b/tests/run-macros/tasty-indexed-map/quoted_1.scala
@@ -2,8 +2,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 class MyMap[Keys](private val underlying: Array[Int]) extends AnyVal {
   def get[K <: String](implicit i: Index[K, Keys]): Int = underlying(i.index)
   def set[K <: String](value: Int)(implicit i: Index[K, Keys]): Unit = underlying(i.index) = value

--- a/tests/run-macros/tasty-interpolation-1/Macro.scala
+++ b/tests/run-macros/tasty-interpolation-1/Macro.scala
@@ -1,6 +1,5 @@
 
 import scala.quoted._
-import scala.tasty.Reflection
 import scala.language.implicitConversions
 import scala.quoted.autolift._
 
@@ -75,10 +74,10 @@ abstract class MacroStringInterpolator[T] {
   }
 
   protected implicit def StringContextIsLiftable: Liftable[StringContext] = new Liftable[StringContext] {
-    def toExpr(strCtx: StringContext): Expr[StringContext] = {
+    def toExpr(strCtx: StringContext) given QuoteContext: Expr[StringContext] = {
       // TODO define in stdlib?
       implicit def ListIsLiftable: Liftable[List[String]] = new Liftable[List[String]] {
-        override def toExpr(list: List[String]): Expr[List[String]] = list match {
+        override def toExpr(list: List[String]) given QuoteContext: Expr[List[String]] = list match {
           case x :: xs => '{${x.toExpr} :: ${toExpr(xs)}}
           case Nil => '{Nil}
         }

--- a/tests/run-macros/tasty-linenumber-2/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber-2/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 class LineNumber(val value: Int) {
   override def toString: String = value.toString
 }

--- a/tests/run-macros/tasty-linenumber/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 class LineNumber(val value: Int) {
   override def toString: String = value.toString
 }

--- a/tests/run-macros/tasty-location/quoted_1.scala
+++ b/tests/run-macros/tasty-location/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 case class Location(owners: List[String])
 
 object Location {
@@ -20,8 +18,10 @@ object Location {
     '{new Location(${list})}
   }
 
-  private implicit def ListIsLiftable[T : Liftable : Type]: Liftable[List[T]] = {
-    case x :: xs  => '{ ${x} :: ${xs} }
-    case Nil => '{ List.empty[T] }
+  private implicit def ListIsLiftable[T : Liftable : Type]: Liftable[List[T]] = new Liftable[List[T]] {
+    def toExpr(x: List[T]) given QuoteContext: Expr[List[T]] = x match {
+      case x :: xs  => '{ $x :: $xs }
+      case Nil => '{ List.empty[T] }
+    }
   }
 }

--- a/tests/run-macros/tasty-macro-assert/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-assert/quoted_1.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Asserts {
 
   implicit class Ops[T](left: T) {

--- a/tests/run-macros/tasty-macro-const/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-const/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object Macros {
 

--- a/tests/run-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-positions/quoted_1.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Macros {
 
   inline def fun(x: Any): Unit = ${ impl('x) }
@@ -31,6 +29,7 @@ object Macros {
   }
 
   def posStr(qctx: QuoteContext)(pos: qctx.tasty.Position): Expr[String] = {
+    delegate for QuoteContext = qctx
     import qctx.tasty._
     s"${pos.sourceFile.jpath.getFileName.toString}:[${pos.start}..${pos.end}]".toExpr
   }

--- a/tests/run-macros/tasty-original-source/Macros_1.scala
+++ b/tests/run-macros/tasty-original-source/Macros_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 object Macros {
 
   implicit inline def withSource(arg: Any): (String, Any) = ${ impl('arg) }

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Asserts {
 
   inline def zeroLastArgs(x: => Int): Int =

--- a/tests/run-macros/tasty-subtyping/quoted_1.scala
+++ b/tests/run-macros/tasty-subtyping/quoted_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
-
 object Macros {
 
   inline def isTypeEqual[T, U]: Boolean =

--- a/tests/run-macros/tasty-tree-map/quoted_1.scala
+++ b/tests/run-macros/tasty-tree-map/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object Macros {
 

--- a/tests/run-macros/tasty-typeof/Macro_1.scala
+++ b/tests/run-macros/tasty-typeof/Macro_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.autolift._
-import scala.tasty._
 
 object Macros {
 

--- a/tests/run-macros/type-show/Macro_1.scala
+++ b/tests/run-macros/type-show/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 object TypeToolbox {
   inline def show[A]: String = ${ showImpl('[A]) }

--- a/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty.Reflection
 
 import scala.language.implicitConversions
 

--- a/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
@@ -2,7 +2,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty.Reflection
 
 import scala.language.implicitConversions
 

--- a/tests/run-macros/xml-interpolation-3/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-3/XmlQuote_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.autolift._
-import scala.tasty.Reflection
 
 import scala.language.implicitConversions
 
@@ -13,7 +12,7 @@ object XmlQuote {
       ${XmlQuote.impl(ctx, 'args)}
   }
 
-  def impl(receiver: StringContext, args: Expr[Seq[Any]]): Expr[Xml] = {
+  def impl(receiver: StringContext, args: Expr[Seq[Any]]) given QuoteContext: Expr[Xml] = {
     val string = receiver.parts.mkString("??")
     '{new Xml(${string}, $args.toList)}
   }

--- a/tests/run-macros/xml-interpolation-4/Macros_1.scala
+++ b/tests/run-macros/xml-interpolation-4/Macros_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.autolift._
-import scala.tasty.Reflection
 
 import scala.language.implicitConversions
 

--- a/tests/run-with-compiler-custom-args/tasty-interpreter/Test.scala
+++ b/tests/run-with-compiler-custom-args/tasty-interpreter/Test.scala
@@ -9,7 +9,6 @@ import dotty.tools.io.Path
 import scala.io.Source
 import scala.tasty.file._
 import scala.tasty.interpreter.TastyInterpreter
-import scala.tasty.Reflection
 
 object Test {
   def main(args: Array[String]): Unit = {

--- a/tests/run-with-compiler/i3847-b.scala
+++ b/tests/run-with-compiler/i3847-b.scala
@@ -4,7 +4,7 @@ import scala.reflect.ClassTag
 object Arrays {
   implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T]): Liftable[Array[List[T]]] = {
     new Liftable[Array[List[T]]] {
-      def toExpr(arr: Array[List[T]]): Expr[Array[List[T]]] = '{
+      def toExpr(arr: Array[List[T]]) given QuoteContext: Expr[Array[List[T]]] = '{
         new Array[List[$t]](${arr.length.toExpr})
         // TODO add elements
       }

--- a/tests/run-with-compiler/i3847.scala
+++ b/tests/run-with-compiler/i3847.scala
@@ -4,7 +4,7 @@ import scala.reflect.ClassTag
 object Arrays {
   implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T], ct: Expr[ClassTag[T]]): Liftable[Array[T]] = {
     new Liftable[Array[T]] {
-      def toExpr(arr: Array[T]): Expr[Array[T]] = '{
+      def toExpr(arr: Array[T]) given QuoteContext: Expr[Array[T]] = '{
         new Array[$t](${arr.length.toExpr})($ct)
         // TODO add elements
       }

--- a/tests/run-with-compiler/i5161.scala
+++ b/tests/run-with-compiler/i5161.scala
@@ -9,7 +9,7 @@ object Test {
   }
   import Exp._
 
-  def evalTest(e: Exp): Expr[Option[Int]] = e match {
+  def evalTest(e: Exp) given QuoteContext: Expr[Option[Int]] = e match {
     case Int2(x) => '{ Some(${x.toExpr}) }
     case Add(e1, e2) =>
      '{
@@ -24,7 +24,7 @@ object Test {
 
   def main(args: Array[String]): Unit = {
     val test = Add(Int2(1), Int2(1))
-    val res = evalTest(test)
+    def res given QuoteContext = evalTest(test)
     println("run : " + run(res))
     println("show : " + withQuoteContext(res.show))
   }

--- a/tests/run-with-compiler/i5965.scala
+++ b/tests/run-with-compiler/i5965.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Test {
 
   implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)

--- a/tests/run-with-compiler/i5965b.scala
+++ b/tests/run-with-compiler/i5965b.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Test {
 
   def main(args: Array[String]): Unit = {

--- a/tests/run-with-compiler/i6201/macro_1.scala
+++ b/tests/run-with-compiler/i6201/macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.tasty._
 
 inline def (inline x: String) strip: String =
   ${ stripImpl(x) }

--- a/tests/run-with-compiler/i6270/Macro_1.scala
+++ b/tests/run-with-compiler/i6270/Macro_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.show.SyntaxHighlight.ANSI
-import scala.tasty._
 
 object api {
   inline def (x: => String) reflect : String =

--- a/tests/run-with-compiler/quote-lib.scala
+++ b/tests/run-with-compiler/quote-lib.scala
@@ -47,14 +47,14 @@ package liftable {
 
   object Exprs {
     implicit class LiftExprOps[T](x: T) extends AnyVal {
-      def toExpr(implicit liftable: Liftable[T]): Expr[T] =
-        liftable.toExpr(x)
+      def toExpr given Liftable[T], QuoteContext: Expr[T] =
+        the[Liftable[T]].toExpr(x)
     }
   }
 
   object Units {
     implicit def UnitIsLiftable: Liftable[Unit] = new Liftable[Unit] {
-      def toExpr(x: Unit): Expr[Unit] = '{}
+      def toExpr(x: Unit) given QuoteContext: Expr[Unit] = '{}
     }
   }
 
@@ -75,24 +75,24 @@ package liftable {
   object Tuples {
 
     implicit def Tuple1IsLiftable[T1: Liftable](implicit t1: Type[T1]): Liftable[Tuple1[T1]] = new Liftable[Tuple1[T1]] {
-      def toExpr(x: Tuple1[T1]): Expr[Tuple1[T1]] =
+      def toExpr(x: Tuple1[T1]) given QuoteContext: Expr[Tuple1[T1]] =
         '{ Tuple1[$t1](${ x._1}) }
     }
 
     implicit def Tuple2IsLiftable[T1: Liftable, T2: Liftable](implicit t1: Type[T1], t2: Type[T2]): Liftable[(T1, T2)] = new Liftable[(T1, T2)] {
-      def toExpr(x: (T1, T2)): Expr[(T1, T2)] =
+      def toExpr(x: (T1, T2)) given QuoteContext: Expr[(T1, T2)] =
         '{ Tuple2[$t1, $t2](${x._1}, ${x._2}) }
 
     }
 
     implicit def Tuple3IsLiftable[T1: Liftable, T2: Liftable, T3: Liftable](implicit t1: Type[T1], t2: Type[T2], t3: Type[T3]): Liftable[(T1, T2, T3)] = new Liftable[(T1, T2, T3)] {
-      def toExpr(x: (T1, T2, T3)): Expr[(T1, T2, T3)] =
+      def toExpr(x: (T1, T2, T3)) given QuoteContext: Expr[(T1, T2, T3)] =
         '{ Tuple3[$t1, $t2, $t3](${x._1}, ${x._2}, ${x._3}) }
 
     }
 
     implicit def Tuple4IsLiftable[T1: Liftable, T2: Liftable, T3: Liftable, T4: Liftable](implicit t1: Type[T1], t2: Type[T2], t3: Type[T3], t4: Type[T4]): Liftable[(T1, T2, T3, T4)] = new Liftable[(T1, T2, T3, T4)] {
-      def toExpr(x: (T1, T2, T3, T4)): Expr[(T1, T2, T3, T4)] =
+      def toExpr(x: (T1, T2, T3, T4)) given QuoteContext: Expr[(T1, T2, T3, T4)] =
         '{ Tuple4[$t1, $t2, $t3, $t4](${x._1}, ${x._2}, ${x._3}, ${x._4}) }
     }
 
@@ -103,7 +103,7 @@ package liftable {
 
   object Lists {
     implicit def ListIsLiftable[T: Liftable](implicit t: Type[T]): Liftable[List[T]] = new Liftable[List[T]] {
-      def toExpr(x: List[T]): Expr[List[T]] = x match {
+      def toExpr(x: List[T]) given QuoteContext: Expr[List[T]] = x match {
         case x :: xs  => '{ (${xs}).::[$t](${x}) }
         case Nil => '{ Nil: List[$t] }
       }
@@ -116,7 +116,7 @@ package liftable {
         '{ ($list).foreach($f) }
     }
 
-    implicit class UnrolledOps[T: Liftable](list: List[T])(implicit t: Type[T]) {
+    implicit class UnrolledOps[T: Liftable](list: List[T])(implicit t: Type[T], qctx: QuoteContext) {
       def unrolledFoldLeft[U](acc: Expr[U])(f: Expr[(U, T) => U])(implicit u: Type[U]): Expr[U] = list match {
         case x :: xs => xs.unrolledFoldLeft('{ ($f).apply($acc, ${x}) })(f)
         case Nil => acc
@@ -129,7 +129,7 @@ package liftable {
 
     object Arrays {
       implicit def ArrayIsLiftable[T: Liftable](implicit t: Type[T], ct: Expr[ClassTag[T]]): Liftable[Array[T]] = new Liftable[Array[T]] {
-        def toExpr(arr: Array[T]): Expr[Array[T]] = '{ new Array[$t](${arr.length})($ct) }
+        def toExpr(arr: Array[T]) given QuoteContext: Expr[Array[T]] = '{ new Array[$t](${arr.length})($ct) }
       }
     }
 

--- a/tests/run-with-compiler/quote-run-constants.scala
+++ b/tests/run-with-compiler/quote-run-constants.scala
@@ -6,7 +6,7 @@ import scala.quoted._
 object Test {
   def main(args: Array[String]): Unit = {
     implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
-    def runAndPrint[T](expr: Expr[T]): Unit = println(run(expr))
+    def runAndPrint[T](expr: given QuoteContext => Expr[T]): Unit = println(run(expr))
 
     runAndPrint(true)
     runAndPrint('a')

--- a/tests/run-with-compiler/quote-run-many.scala
+++ b/tests/run-with-compiler/quote-run-many.scala
@@ -4,7 +4,7 @@ import scala.quoted.autolift._
 object Test {
   def main(args: Array[String]): Unit = {
     implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
-    def expr(i: Int) = '{
+    def expr(i: Int) given QuoteContext = '{
       val a = 3 + ${i}
       2 + a
     }

--- a/tests/run-with-compiler/quote-run-staged-interpreter.scala
+++ b/tests/run-with-compiler/quote-run-staged-interpreter.scala
@@ -11,7 +11,7 @@ enum Exp {
 object Test {
   import Exp._
 
-  def compile(e: Exp, env: Map[String, Expr[Int]], keepLets: Boolean): Expr[Int] = {
+  def compile(e: Exp, env: Map[String, Expr[Int]], keepLets: Boolean) given QuoteContext: Expr[Int] = {
     def compileImpl(e: Exp, env: Map[String, Expr[Int]]): Expr[Int] = e match {
       case Num(n) => n
       case Plus(e1, e2) => '{${compileImpl(e1, env)} + ${compileImpl(e2, env)}}
@@ -31,27 +31,25 @@ object Test {
     val exp = Plus(Plus(Num(2), Var("x")), Num(4))
     val letExp = Let("x", Num(3), exp)
 
-    val res1 = '{ (x: Int) => ${compile(exp, Map("x" -> 'x), false)} }
+    def res1 given QuoteContext = '{ (x: Int) => ${compile(exp, Map("x" -> 'x), false)} }
 
 
     println(withQuoteContext(res1.show))
 
-    val fn = run {
-      res1
-    }
+    val fn = run(res1)
     println(fn(0))
     println(fn(2))
     println(fn(3))
 
     println("---")
 
-    val res2 = compile(letExp, Map(), false)
+    def res2 given QuoteContext = compile(letExp, Map(), false)
     println(withQuoteContext(res2.show))
     println(run(res2))
 
     println("---")
 
-    val res3 = compile(letExp, Map(), true)
+    def res3 given QuoteContext = compile(letExp, Map(), true)
     println(withQuoteContext(res3.show))
     println(run(res3))
   }

--- a/tests/run-with-compiler/quote-unrolled-foreach.scala
+++ b/tests/run-with-compiler/quote-unrolled-foreach.scala
@@ -73,7 +73,7 @@ object Test {
     }
   }
 
-  def foreach2(arrRef: Expr[Array[Int]], f: Expr[Int => Unit]): Expr[Unit] = '{
+  def foreach2(arrRef: Expr[Array[Int]], f: Expr[Int => Unit]) given QuoteContext: Expr[Unit] = '{
     val size = ($arrRef).length
     var i = 0
     while (i < size) {
@@ -107,7 +107,7 @@ object Test {
     }
   }
 
-  def foreach4(arrRef: Expr[Array[Int]], f: Expr[Int => Unit], unrollSize: Int): Expr[Unit] = '{
+  def foreach4(arrRef: Expr[Array[Int]], f: Expr[Int => Unit], unrollSize: Int) given QuoteContext: Expr[Unit] = '{
     val size = ($arrRef).length
     var i = 0
     if (size % ${unrollSize} != 0) throw new Exception("...") // for simplicity of the implementation
@@ -118,7 +118,7 @@ object Test {
   }
 
   implicit object ArrayIntIsLiftable extends Liftable[Array[Int]] {
-    override def toExpr(x: Array[Int]): Expr[Array[Int]] = '{
+    override def toExpr(x: Array[Int]) given QuoteContext: Expr[Array[Int]] = '{
       val array = new Array[Int](${x.length})
       ${ foreachInRange(0, x.length)(i => '{ array(${i}) = ${x(i)}}) }
       array

--- a/tests/run-with-compiler/shonan-hmm/Complex.scala
+++ b/tests/run-with-compiler/shonan-hmm/Complex.scala
@@ -5,11 +5,11 @@ case class Complex[T](re: T, im: T)
 
 object Complex {
   implicit def complexIsLiftable[T: Type: Liftable]: Liftable[Complex[T]] = new Liftable {
-    def toExpr(c: Complex[T]): Expr[Complex[T]] = '{ Complex(${c.re.toExpr}, ${c.im.toExpr}) }
+    def toExpr(c: Complex[T]) given QuoteContext: Expr[Complex[T]] = '{ Complex(${c.re.toExpr}, ${c.im.toExpr}) }
   }
 
- def of_complex_expr(x: Expr[Complex[Int]]): Complex[Expr[Int]] = Complex('{$x.re}, '{$x.im})
- def of_expr_complex(x: Complex[Expr[Int]]): Expr[Complex[Int]] = '{Complex(${x.re}, ${x.im})}
+ def of_complex_expr(x: Expr[Complex[Int]]) given QuoteContext: Complex[Expr[Int]] = Complex('{$x.re}, '{$x.im})
+ def of_expr_complex(x: Complex[Expr[Int]]) given QuoteContext: Expr[Complex[Int]] = '{Complex(${x.re}, ${x.im})}
 
 
 }

--- a/tests/run-with-compiler/shonan-hmm/Lifters.scala
+++ b/tests/run-with-compiler/shonan-hmm/Lifters.scala
@@ -6,21 +6,25 @@ import scala.quoted._
 import scala.quoted.autolift._
 
 object Lifters {
-  implicit def LiftedClassTag[T: Type](implicit ct: ClassTag[T]): Expr[ClassTag[T]] = {
-    '{ ClassTag(${ct.runtimeClass })}
+  implicit def LiftedClassTag[T: Type: ClassTag]  given QuoteContext: Expr[ClassTag[T]] = {
+    '{ ClassTag(${the[ClassTag[T]].runtimeClass })}
   }
 
-  implicit def ArrayIsLiftable[T : Type: ClassTag](implicit l: Liftable[T]): Liftable[Array[T]] = arr => '{
-    val array = new Array[T](${arr.length})(${implicitly[Expr[ClassTag[T]]]})
-    ${initArray(arr, 'array)}
+  implicit def ArrayIsLiftable[T : Type: ClassTag](implicit l: Liftable[T]): Liftable[Array[T]] = new Liftable[Array[T]] {
+    def toExpr(x: Array[T]) given QuoteContext: Expr[Array[T]] = '{
+      val array = new Array[T](${x.length})(${implicitly[Expr[ClassTag[T]]]})
+      ${initArray(x, 'array)}
+    }
   }
 
-  implicit def IntArrayIsLiftable: Liftable[Array[Int]] = arr => '{
-    val array = new Array[Int](${arr.length})
-    ${initArray(arr, 'array)}
+  implicit def IntArrayIsLiftable: Liftable[Array[Int]] = new Liftable[Array[Int]] {
+    def toExpr(x: Array[Int]) given QuoteContext: Expr[Array[Int]] = '{
+      val array = new Array[Int](${x.length})
+      ${initArray(x, 'array)}
+    }
   }
 
-  private def initArray[T : Liftable : Type](arr: Array[T], array: Expr[Array[T]]): Expr[Array[T]] = {
+  private def initArray[T : Liftable : Type](arr: Array[T], array: Expr[Array[T]]) given QuoteContext: Expr[Array[T]] = {
     UnrolledExpr.block(
       arr.zipWithIndex.map {
         case (x, i) => '{ $array(${i}) = ${x} }

--- a/tests/run-with-compiler/shonan-hmm/MVmult.scala
+++ b/tests/run-with-compiler/shonan-hmm/MVmult.scala
@@ -22,7 +22,7 @@ object MVmult {
     MV.mvmult(vout_, a_, v_)
   }
 
-  def mvmult_c: Expr[(Array[Int], Array[Array[Int]], Array[Int]) => Unit] = '{
+  def mvmult_c given QuoteContext: Expr[(Array[Int], Array[Array[Int]], Array[Int]) => Unit] = '{
     (vout, a, v) => {
       val n = vout.length
       val m = v.length
@@ -37,7 +37,7 @@ object MVmult {
     }
   }
 
-  def mvmult_mc(n: Int, m: Int): Expr[(Array[Int], Array[Array[Int]], Array[Int]) => Unit] = {
+  def mvmult_mc(n: Int, m: Int) given QuoteContext: Expr[(Array[Int], Array[Array[Int]], Array[Int]) => Unit] = {
     val MV = new MVmult[Int, Expr[Int], Expr[Unit]](RingIntExpr, new VecRStaDim(RingIntExpr))
     '{
       (vout, a, v) => {
@@ -54,7 +54,7 @@ object MVmult {
     }
   }
 
-  def mvmult_ac(a: Array[Array[Int]]): Expr[(Array[Int], Array[Int]) => Unit] = {
+  def mvmult_ac(a: Array[Array[Int]]) given QuoteContext: Expr[(Array[Int], Array[Int]) => Unit] = {
     import Lifters._
     '{
       val arr = ${a}
@@ -65,7 +65,7 @@ object MVmult {
     }
   }
 
-  def mvmult_opt(a: Array[Array[Int]]): Expr[(Array[Int], Array[Int]) => Unit] = {
+  def mvmult_opt(a: Array[Array[Int]]) given QuoteContext: Expr[(Array[Int], Array[Int]) => Unit] = {
     import Lifters._
     '{
       val arr = ${a}
@@ -76,7 +76,7 @@ object MVmult {
     }
   }
 
-  def mvmult_roll(a: Array[Array[Int]]): Expr[(Array[Int], Array[Int]) => Unit] = {
+  def mvmult_roll(a: Array[Array[Int]]) given QuoteContext: Expr[(Array[Int], Array[Int]) => Unit] = {
     import Lifters._
     '{
       val arr = ${a}
@@ -87,19 +87,19 @@ object MVmult {
     }
   }
 
-  def mvmult_let1(a: Array[Array[Int]]): Expr[(Array[Int], Array[Int]) => Unit] = {
+  def mvmult_let1(a: Array[Array[Int]]) given QuoteContext: Expr[(Array[Int], Array[Int]) => Unit] = {
     val (n, m, a2) = amatCopy(a, copy_row1)
     mvmult_abs0(new RingIntOPExpr, new VecRStaOptDynInt(new RingIntPExpr))(n, m, a2)
   }
 
-  def mvmult_let(a: Array[Array[Int]]): Expr[(Array[Int], Array[Int]) => Unit] = {
+  def mvmult_let(a: Array[Array[Int]]) given QuoteContext: Expr[(Array[Int], Array[Int]) => Unit] = {
     initRows(a) { rows =>
       val (n, m, a2) = amat2(a, rows)
       mvmult_abs0(new RingIntOPExpr, new VecRStaOptDynInt(new RingIntPExpr))(n, m, a2)
     }
   }
 
-  def initRows[T: Type](a: Array[Array[Int]])(cont: Array[Expr[Array[Int]]] => Expr[T]): Expr[T] = {
+  def initRows[T: Type](a: Array[Array[Int]])(cont: Array[Expr[Array[Int]]] => Expr[T]) given QuoteContext: Expr[T] = {
     import Lifters._
     def loop(i: Int, acc: List[Expr[Array[Int]]]): Expr[T] = {
       if (i >= a.length) cont(acc.toArray.reverse)
@@ -114,7 +114,7 @@ object MVmult {
     loop(0, Nil)
   }
 
-  def amat1(a: Array[Array[Int]], aa: Expr[Array[Array[Int]]]): (Int, Int, Vec[PV[Int], Vec[PV[Int], PV[Int]]]) = {
+  def amat1(a: Array[Array[Int]], aa: Expr[Array[Array[Int]]]) given QuoteContext: (Int, Int, Vec[PV[Int], Vec[PV[Int], PV[Int]]]) = {
     val n = a.length
     val m = a(0).length
     val vec: Vec[PV[Int], Vec[PV[Int], PV[Int]]] = Vec(Sta(n), i => Vec(Sta(m), j => (i, j) match {
@@ -125,7 +125,7 @@ object MVmult {
     (n, m, vec)
   }
 
-  def amat2(a: Array[Array[Int]], refs: Array[Expr[Array[Int]]]): (Int, Int, Vec[PV[Int], Vec[PV[Int], PV[Int]]]) = {
+  def amat2(a: Array[Array[Int]], refs: Array[Expr[Array[Int]]]) given QuoteContext: (Int, Int, Vec[PV[Int], Vec[PV[Int], PV[Int]]]) = {
     val n = a.length
     val m = a(0).length
     val vec: Vec[PV[Int], Vec[PV[Int], PV[Int]]] = Vec(Sta(n), i => Vec(Sta(m), j => (i, j) match {
@@ -135,7 +135,7 @@ object MVmult {
     (n, m, vec)
   }
 
-  def amatCopy(a: Array[Array[Int]], copyRow: Array[Int] => (Expr[Int] => Expr[Int])): (Int, Int, Vec[PV[Int], Vec[PV[Int], PV[Int]]]) = {
+  def amatCopy(a: Array[Array[Int]], copyRow: Array[Int] => (Expr[Int] => Expr[Int])) given QuoteContext: (Int, Int, Vec[PV[Int], Vec[PV[Int], PV[Int]]]) = {
     val n = a.length
     val m = a(0).length
     val vec: Vec[PV[Int], Vec[PV[Int], PV[Int]]] = Vec(Sta(n), i => Vec(Sta(m), j => (i, j) match {
@@ -148,7 +148,7 @@ object MVmult {
     (n, m, vec)
   }
 
-  def copy_row1: Array[Int] => (Expr[Int] => Expr[Int]) = v => {
+  def copy_row1 given QuoteContext: Array[Int] => (Expr[Int] => Expr[Int]) = v => {
     import Lifters._
     val arr = v
     i => '{ ($arr).apply($i) }
@@ -160,7 +160,7 @@ object MVmult {
     i => '{ ($arr).apply($i) }
   }
 
-  private def mvmult_abs0(ring: Ring[PV[Int]], vecOp: VecROp[PV[Int], PV[Int], Expr[Unit]])(n: Int, m: Int, a: Vec[PV[Int], Vec[PV[Int], PV[Int]]]): Expr[(Array[Int], Array[Int]) => Unit] = {
+  private def mvmult_abs0(ring: Ring[PV[Int]], vecOp: VecROp[PV[Int], PV[Int], Expr[Unit]])(n: Int, m: Int, a: Vec[PV[Int], Vec[PV[Int], PV[Int]]]) given QuoteContext: Expr[(Array[Int], Array[Int]) => Unit] = {
     '{
       (vout, v) => {
         if (${n} != vout.length) throw new IndexOutOfBoundsException(${n.toString})

--- a/tests/run-with-compiler/shonan-hmm/PV.scala
+++ b/tests/run-with-compiler/shonan-hmm/PV.scala
@@ -8,9 +8,9 @@ case class Sta[T](x: T) extends PV[T]
 case class Dyn[T](x: Expr[T]) extends PV[T]
 
 object Dyns {
-  def dyn[T: Liftable](pv: PV[T]): Expr[T] = pv match {
+  def dyn[T: Liftable](pv: PV[T]) given QuoteContext: Expr[T] = pv match {
     case Sta(x) => x.toExpr
     case Dyn(x) => x
   }
-  val dyni: PV[Int] => Expr[Int] = dyn[Int]
+  def dyni given QuoteContext: PV[Int] => Expr[Int] = dyn[Int]
 }

--- a/tests/run-with-compiler/shonan-hmm/Ring.scala
+++ b/tests/run-with-compiler/shonan-hmm/Ring.scala
@@ -43,7 +43,7 @@ case class RingComplex[U](u: Ring[U]) extends Ring[Complex[U]] {
   override def toString(): String = s"RingComplex($u)"
 }
 
-case class RingPV[U: Liftable](staRing: Ring[U], dynRing: Ring[Expr[U]]) extends Ring[PV[U]] {
+case class RingPV[U: Liftable](staRing: Ring[U], dynRing: Ring[Expr[U]]) given QuoteContext extends Ring[PV[U]] {
   type T = PV[U]
 
   val dyn = Dyns.dyn[U]
@@ -66,9 +66,9 @@ case class RingPV[U: Liftable](staRing: Ring[U], dynRing: Ring[Expr[U]]) extends
   }
 }
 
-class RingIntPExpr extends RingPV(RingInt, RingIntExpr)
+class RingIntPExpr given QuoteContext extends RingPV(RingInt, RingIntExpr)
 
-class RingIntOPExpr extends RingIntPExpr {
+class RingIntOPExpr given QuoteContext extends RingIntPExpr {
   override def add = (x: PV[Int], y: PV[Int]) => (x, y) match {
     case (Sta(0), y) => y
     case (x, Sta(0)) => x

--- a/tests/run-with-compiler/shonan-hmm/VecROp.scala
+++ b/tests/run-with-compiler/shonan-hmm/VecROp.scala
@@ -46,7 +46,7 @@ class VecRStaDim[T: Type](r: Ring[T]) extends VecROp[Int, T, Expr[Unit]]  {
   override def toString(): String = s"VecRStaDim($r)"
 }
 
-class VecRStaDyn[T : Type : Liftable](r: Ring[PV[T]]) extends VecROp[PV[Int], PV[T], Expr[Unit]] {
+class VecRStaDyn[T : Type : Liftable](r: Ring[PV[T]])  given QuoteContext extends VecROp[PV[Int], PV[T], Expr[Unit]] {
   val VSta: VecROp[Int, PV[T], Expr[Unit]] = new VecRStaDim(r)
   val VDyn = new VecRDyn
   val dyn = Dyns.dyn[T]
@@ -74,7 +74,7 @@ object VecRStaOptDynInt {
   val threshold = 3
 }
 
-class VecRStaOptDynInt(r: Ring[PV[Int]]) extends VecRStaDyn(r) {
+class VecRStaOptDynInt(r: Ring[PV[Int]])  given QuoteContext extends VecRStaDyn(r) {
   val M: VecROp[PV[Int], PV[Int], Expr[Unit]] = new VecRStaDyn(r)
 
   override def reduce: ((PV[Int], PV[Int]) => PV[Int], PV[Int], Vec[PV[Int], PV[Int]]) => PV[Int] = (plus, zero, vec) => vec match {

--- a/tests/run-with-compiler/shonan-hmm/Vmults.scala
+++ b/tests/run-with-compiler/shonan-hmm/Vmults.scala
@@ -19,7 +19,7 @@ object Vmults {
     V.vmult(vout_, v1_, v2_)
   }
 
-  def vmultCA: Expr[(Array[Complex[Int]], Array[Complex[Int]], Array[Complex[Int]]) => Unit] = '{
+  def vmultCA given QuoteContext: Expr[(Array[Complex[Int]], Array[Complex[Int]], Array[Complex[Int]]) => Unit] = '{
     (vout, v1, v2) => {
       val n = vout.length
       ${

--- a/tests/run-with-compiler/staged-tuples/StagedTuple.scala
+++ b/tests/run-with-compiler/staged-tuples/StagedTuple.scala
@@ -12,7 +12,7 @@ object StagedTuple {
 
   private final val specialize = true
 
-  def toArrayStaged(tup: Expr[Tuple], size: Option[Int]): Expr[Array[Object]] = {
+  def toArrayStaged(tup: Expr[Tuple], size: Option[Int]) given QuoteContext: Expr[Array[Object]] = {
     if (!specialize) '{dynamicToArray($tup)}
     else size match {
       case Some(0) =>
@@ -68,7 +68,7 @@ object StagedTuple {
     }
   }
 
-  def sizeStaged[Res <: Int : Type](tup: Expr[Tuple], size: Option[Int]): Expr[Res] = {
+  def sizeStaged[Res <: Int : Type](tup: Expr[Tuple], size: Option[Int]) given QuoteContext: Expr[Res] = {
     val res =
       if (!specialize) '{dynamicSize($tup)}
       else size match {
@@ -101,7 +101,7 @@ object StagedTuple {
     }
   }
 
-  def tailStaged[Tup <: NonEmptyTuple : Type](tup: Expr[Tup], size: Option[Int]): Expr[Tail[Tup]] = {
+  def tailStaged[Tup <: NonEmptyTuple : Type](tup: Expr[Tup], size: Option[Int]) given QuoteContext: Expr[Tail[Tup]] = {
     if (!specialize) '{dynamicTail[Tup]($tup)}
     else {
       val res = size match {
@@ -183,7 +183,7 @@ object StagedTuple {
     }
   }
 
-  def consStaged[T <: Tuple & Singleton : Type, H : Type](self: Expr[T], x: Expr[H], tailSize: Option[Int]): Expr[H *: T] =
+  def consStaged[T <: Tuple & Singleton : Type, H : Type](self: Expr[T], x: Expr[H], tailSize: Option[Int]) given QuoteContext: Expr[H *: T] =
   if (!specialize) '{dynamicCons[H, T]($x, $self)}
   else {
     val res = tailSize match {
@@ -205,7 +205,7 @@ object StagedTuple {
     res.as[H *: T]
   }
 
-  def concatStaged[Self <: Tuple & Singleton : Type, That <: Tuple & Singleton : Type](self: Expr[Self], selfSize: Option[Int], that: Expr[That], thatSize: Option[Int]): Expr[Concat[Self, That]] = {
+  def concatStaged[Self <: Tuple & Singleton : Type, That <: Tuple & Singleton : Type](self: Expr[Self], selfSize: Option[Int], that: Expr[That], thatSize: Option[Int]) given QuoteContext: Expr[Concat[Self, That]] = {
     if (!specialize) '{dynamicConcat[Self, That]($self, $that)}
     else {
       def genericConcat(xs: Expr[Tuple], ys: Expr[Tuple]): Expr[Tuple] =

--- a/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
+++ b/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 import scala.quoted.autolift._
 
-import scala.tasty._
 import scala.tasty.util._
 
 object Macros {

--- a/tests/run-with-compiler/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-with-compiler/tasty-unsafe-let/quoted_1.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 
-import scala.tasty._
-
 object Macros {
 
   inline def let[T](rhs: T)(body: => T => Unit): Unit =


### PR DESCRIPTION
Add context to [Liftable.toExpr](https://github.com/lampepfl/dotty/pull/6785/files#diff-87f09b52cf84f5b1891b1a136bd91a47R9). The rest is updating and adaptations to fit this new required `QuoteContext`.