### PR TITLE
Reject incomplete implicit dictionaries

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1842,6 +1842,7 @@ final class SearchRoot extends SearchHistory {
           val pruned = prune(List(tree), implicitDictionary.map(_._2).toList, Nil)
           implicitDictionary0 = null
           if (pruned.isEmpty) result
+          else if (pruned.exists(_._2 == EmptyTree)) NoMatchingImplicitsFailure
           else {
             // If there are any dictionary entries remaining after pruning, construct a dictionary
             // class of the form,

--- a/tests/neg/i6796.scala
+++ b/tests/neg/i6796.scala
@@ -1,0 +1,10 @@
+object Test {
+  class A
+  class B
+
+  implicit def mkA(implicit b: => B): A = ???
+  implicit def mkB(implicit a: A, i: Int): B = ???
+
+  implicitly[A] // error
+}
+


### PR DESCRIPTION
If any RHS of a recursive implicit dictionary (after pruning) is an `EmptyTree`, then this indicates that implicit search failed and we should report the overall search as a failure.

Fixes #6796.