### PR TITLE
Fix #5840: Give more informative error message

### DIFF
--- a/tests/neg-macros/quote-complex-top-splice.scala
+++ b/tests/neg-macros/quote-complex-top-splice.scala
@@ -4,23 +4,23 @@ import scala.quoted._
 
 object Test {
 
-  inline def foo1: Unit = ${ // error
-    val x = 1
+  inline def foo1: Unit = ${
+    val x = 1 // error
     impl(x)
   }
 
-  inline def foo2: Unit = ${ impl({ // error
-    val x = 1
+  inline def foo2: Unit = ${ impl({
+    val x = 1 // error
     x
   }) }
 
-  inline def foo3: Unit = ${ impl({ // error
-    println("foo3")
+  inline def foo3: Unit = ${ impl({
+    println("foo3") // error
     3
   }) }
 
-  inline def foo4: Unit = ${ // error
-    println("foo4")
+  inline def foo4: Unit = ${
+    println("foo4") // error
     impl(1)
   }
 

--- a/tests/neg-macros/quote-interpolator-core-old.scala
+++ b/tests/neg-macros/quote-interpolator-core-old.scala
@@ -6,9 +6,9 @@ import scala.quoted.autolift._
 object FInterpolation {
 
   implicit class FInterpolatorHelper(val sc: StringContext) extends AnyVal {
-    inline def ff(arg1: Any): String = ${fInterpolation(sc, Seq('arg1))} // error: Inline macro method must be a static method
-    inline def ff(arg1: Any, arg2: Any): String = ${fInterpolation(sc, Seq('arg1, 'arg2))} // error: Inline macro method must be a static method
-    inline def ff(arg1: Any, arg2: Any, arg3: Any): String = ${fInterpolation(sc, Seq('arg1, 'arg2, 'arg3))} // error: Inline macro method must be a static method
+    inline def ff(arg1: Any): String = ${fInterpolation(sc, Seq('arg1))} // error // error
+    inline def ff(arg1: Any, arg2: Any): String = ${fInterpolation(sc, Seq('arg1, 'arg2))} // error // error
+    inline def ff(arg1: Any, arg2: Any, arg3: Any): String = ${fInterpolation(sc, Seq('arg1, 'arg2, 'arg3))} // error // error
     // ...
   }
 

--- a/tests/neg-macros/quote-splice-interpret-1.scala
+++ b/tests/neg-macros/quote-splice-interpret-1.scala
@@ -2,8 +2,8 @@
 import scala.quoted._
 
 object Macros {
-  inline def isZero(inline n: Int): Boolean = ${ // error
-    if (n == 0) 'true
+  inline def isZero(inline n: Int): Boolean = ${
+    if (n == 0) 'true // error
     else 'false
   }
 }

--- a/tests/neg/i4433.scala
+++ b/tests/neg/i4433.scala
@@ -1,7 +1,7 @@
 
 object Foo {
-  inline def g(inline p: Int => Boolean): Boolean = ${ // error
-    if(p(5)) 'true
+  inline def g(inline p: Int => Boolean): Boolean = ${
+    if (p(5)) 'true // error
     else 'false
   }
 }

--- a/tests/neg/i4493-b.scala
+++ b/tests/neg/i4493-b.scala
@@ -1,7 +1,7 @@
 class Index[K]
 object Index {
-  inline def succ[K](x: K): Unit = ${ // error
-    implicit val t: quoted.Type[K] = '[K]
+  inline def succ[K](x: K): Unit = ${
+    implicit val t: quoted.Type[K] = '[K] // error
     '{new Index[K]}
   }
 }

--- a/tests/neg/i4493.scala
+++ b/tests/neg/i4493.scala
@@ -1,7 +1,7 @@
 class Index[K]
 object Index {
-  inline def succ[K]: Unit = ${ // error
-    implicit val t: quoted.Type[K] = '[K]
+  inline def succ[K]: Unit = ${
+    implicit val t: quoted.Type[K] = '[K] // error
     '{new Index[K]}
   }
 }

--- a/tests/neg/i5840.check
+++ b/tests/neg/i5840.check
@@ -1,0 +1,6 @@
+-- Error: tests/neg/i5840.scala:8:28 -----------------------------------------------------------------------------------
+8 |  inline def i5_2[T](n: T): Contextual[T] = ${ foo('n) } // error: Macros using `given X => Y` return types are not yet supported
+  |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                            Macros using a return type of the form `foo(): given X => Y` are not yet supported.
+  |                            
+  |                            Place the implicit as an argument (`foo() given X: Y`) to overcome this limitation.

--- a/tests/neg/i5840.scala
+++ b/tests/neg/i5840.scala
@@ -1,0 +1,11 @@
+import scala.quoted._
+object Test {
+
+  type Contextual[T] = given QuoteContext => T
+
+  inline def i5_1[T](n: T)(implicit thisCtx: QuoteContext): T = ${ foo('n) } // OK
+
+  inline def i5_2[T](n: T): Contextual[T] = ${ foo('n) } // error: Macros using `given X => Y` return types are not yet supported
+
+  def foo[T](x: Expr[T]) = x
+}

--- a/tests/neg/i6783.scala
+++ b/tests/neg/i6783.scala
@@ -1,7 +1,9 @@
 import scala.quoted._
 
-inline def test(f: (Int, Int) => Int) = ${ // error: Malformed macro
-  testImpl((a: Expr[Int], b: Expr[Int]) =>  '{ f(${a}, ${b}) })
+inline def test(f: (Int, Int) => Int) = ${
+  testImpl(
+    (a: Expr[Int], b: Expr[Int]) =>  '{ f(${a}, ${b}) } // error: Malformed macro
+  )
 }
 
 def testImpl(f: (Expr[Int], Expr[Int]) => Expr[Int]): Expr[Int] = ???


### PR DESCRIPTION
Also me more precise on the position where a macro is malformed.