### PR TITLE
Make links relative and to `.md` (instead of `.html`)

### DIFF
--- a/docs/docs/reference/changed-features/eta-expansion.md
+++ b/docs/docs/reference/changed-features/eta-expansion.md
@@ -38,5 +38,5 @@ conflict with eta expansion. Automatic `()` insertion is
 [limited](../dropped-features/auto-apply.md) in Dotty, but the fundamental ambiguity
 remains.
 
-[More details](eta-expansion-spec.html)
+[More details](eta-expansion-spec.md)
 

--- a/docs/docs/reference/changed-features/implicit-conversions-spec.md
+++ b/docs/docs/reference/changed-features/implicit-conversions-spec.md
@@ -81,7 +81,7 @@ implicit val myConverter: Conversion[Int, String] = _.toString
 ```
 
 Note that implicit conversions are also  affected by the [changes to
-implicit resolution](implicit-resolution.html) between Scala 2 and
+implicit resolution](implicit-resolution.md) between Scala 2 and
 Scala 3.
 
 ## Motivation for the changes
@@ -111,12 +111,12 @@ to `Conversion`.
 
 For the migration of implicit conversions that are affected by the
 changes to implicit resolution, refer to the [Changes in Implicit
-Resolution](implicit-resolution.html) for more information.
+Resolution](implicit-resolution.md) for more information.
 
 ## Reference
 
 For more information about implicit resolution, see [Changes in
-Implicit Resolution](implicit-resolution.html).
+Implicit Resolution](implicit-resolution.md).
 Other details are available in
 [PR #2065](https://github.com/lampepfl/dotty/pull/2065)
 

--- a/docs/docs/reference/changed-features/implicit-conversions.md
+++ b/docs/docs/reference/changed-features/implicit-conversions.md
@@ -61,4 +61,4 @@ implicitly[Ordering[A]] // Ok, will use the implicit conversion from
                         // `A` to `Int` and the `Ordering` for `Int`.
 ```
 
-[More details](implicit-conversions-spec.html)
+[More details](implicit-conversions-spec.md)

--- a/docs/docs/reference/changed-features/overload-resolution.md
+++ b/docs/docs/reference/changed-features/overload-resolution.md
@@ -41,7 +41,7 @@ resolution yields several competing alternatives when `n >= 1` parameter lists a
 into account, then resolution re-tried using `n + 1` argument lists.
 
 This change is motivated by the new language feature [extension
-methods](../contextual/extension-methods.html), where emerges the need to do
+methods](../contextual/extension-methods.md), where emerges the need to do
 overload resolution based on additional argument blocks.
 
 ## Parameter Types of Function Values

--- a/docs/docs/reference/changed-features/structural-types.md
+++ b/docs/docs/reference/changed-features/structural-types.md
@@ -74,4 +74,4 @@ differences.
   `ClassTag` indicating the method's formal parameter types. `Dynamic`
   comes with `updateDynamic`.
 
-[More details](structural-types-spec.html)
+[More details](structural-types-spec.md)

--- a/docs/docs/reference/contextual/delegates.md
+++ b/docs/docs/reference/contextual/delegates.md
@@ -4,7 +4,7 @@ title: "Given Instances"
 ---
 
 Given instances (or, simply, "givens") define "canonical" values of certain types
-that serve for synthesizing arguments to [given clauses](./given-clauses.html). Example:
+that serve for synthesizing arguments to [given clauses](./given-clauses.md). Example:
 
 ```scala
 trait Ord[T] {
@@ -34,7 +34,7 @@ This code defines a trait `Ord` with two given instances. `IntOrd` defines
 a given for the type `Ord[Int]` whereas `ListOrd[T]` defines givens
 for `Ord[List[T]]` for all types `T` that come with a given instance for `Ord[T]` themselves.
 The `given (ord: Ord[T])` clause in `ListOrd` defines an implicit parameter.
-Given clauses are further explained in the [next section](./given-clauses.html).
+Given clauses are further explained in the [next section](./given-clauses.md).
 
 ## Anonymous Given Instances
 
@@ -74,7 +74,7 @@ If a `given` definition has type parameters or a given clause, a fresh instance 
 
 ## Syntax
 
-Here is the new syntax of given instances, seen as a delta from the [standard context free syntax of Scala 3](http://dotty.epfl.ch/docs/internals/syntax.html).
+Here is the new syntax of given instances, seen as a delta from the [standard context free syntax of Scala 3](../../internals/syntax.md).
 ```
 TmplDef          ::=  ...
                   |   ‘given’ GivenDef

--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -139,7 +139,7 @@ As usual, type parameters of the extension method follow the defined method name
 ### Syntax
 
 The required syntax extension just adds one clause for extension methods relative
-to the [current syntax](https://github.com/lampepfl/dotty/blob/master/docs/docs/internals/syntax.md).
+to the [current syntax](../../internals/syntax.md).
 ```
 DefSig            ::=  ...
                     |  ‘(’ DefParam ‘)’ [nl] id [DefTypeParamClause] DefParamClauses

--- a/docs/docs/reference/contextual/given-clauses.md
+++ b/docs/docs/reference/contextual/given-clauses.md
@@ -98,7 +98,7 @@ def the[T] given (x: T): x.type = x
 
 ## Syntax
 
-Here is the new syntax of parameters and arguments seen as a delta from the [standard context free syntax of Scala 3](http://dotty.epfl.ch/docs/internals/syntax.html).
+Here is the new syntax of parameters and arguments seen as a delta from the [standard context free syntax of Scala 3](../../internals/syntax.md).
 ```
 ClsParamClauses     ::=  ...
                       |  {ClsParamClause} {GivenClsParamClause}

--- a/docs/docs/reference/contextual/implicit-function-types-spec.md
+++ b/docs/docs/reference/contextual/implicit-function-types-spec.md
@@ -65,7 +65,7 @@ itself a implicit function literal. This is analogous to the automatic
 insertion of `scala.Function0` around expressions in by-name argument position.
 
 Implicit function types generalize to `N > 22` in the same way that function types do, see [the corresponding
-documentation](https://dotty.epfl.ch/docs/reference/dropped-features/limit22.html).
+documentation](../dropped-features/limit22.md).
 
 ## Examples
 

--- a/docs/docs/reference/contextual/implicit-function-types.md
+++ b/docs/docs/reference/contextual/implicit-function-types.md
@@ -148,4 +148,4 @@ as the best possible code one could write by hand:
 For more info, see the [blog article](https://www.scala-lang.org/blog/2016/12/07/implicit-function-types.html),
 (which uses a different syntax that has been superseded).
 
-[More details](./implicit-function-types-spec.html)
+[More details](./implicit-function-types-spec.md)

--- a/docs/docs/reference/contextual/implicit-match.md
+++ b/docs/docs/reference/contextual/implicit-match.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./delegate-match.html).
+The contents of this page have [moved](./delegate-match.md).

--- a/docs/docs/reference/contextual/import-implied.md
+++ b/docs/docs/reference/contextual/import-implied.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./import-delegate.html).
+The contents of this page have [moved](./import-delegate.md).

--- a/docs/docs/reference/contextual/inferable-by-name-parameters.md
+++ b/docs/docs/reference/contextual/inferable-by-name-parameters.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./implicit-by-name-parameters.html).
+The contents of this page have [moved](./implicit-by-name-parameters.md).

--- a/docs/docs/reference/contextual/inferable-params.md
+++ b/docs/docs/reference/contextual/inferable-params.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./given-clauses.html).
+The contents of this page have [moved](./given-clauses.md).

--- a/docs/docs/reference/contextual/instance-defs.md
+++ b/docs/docs/reference/contextual/instance-defs.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./delegates.html).
+The contents of this page have [moved](./delegates.md).

--- a/docs/docs/reference/contextual/motivation.md
+++ b/docs/docs/reference/contextual/motivation.md
@@ -47,25 +47,25 @@ Existing Scala programmers by and large have gotten used to the status quo and s
 
 The following pages introduce a redesign of contextual abstractions in Scala. They introduce four fundamental changes:
 
- 1. [Given Instances](./delegates.html) are a new way to define basic terms that can be synthesized.  They replace implicit definitions. The core principle of the proposal is that, rather than mixing the `implicit` modifier with a large number of features, we have a single way to define terms that can be synthesized for types.
+ 1. [Given Instances](./delegates.md) are a new way to define basic terms that can be synthesized.  They replace implicit definitions. The core principle of the proposal is that, rather than mixing the `implicit` modifier with a large number of features, we have a single way to define terms that can be synthesized for types.
 
- 2. [Given Clauses](./given-clauses.html) are a new syntax for implicit _parameters_ and their _arguments_. Both are introduced with the same keyword, `given`. This unambiguously aligns parameters and arguments, solving a number of language warts. It also allows us to have several implicit parameter sections, and to have implicit parameters followed by normal ones.
+ 2. [Given Clauses](./given-clauses.md) are a new syntax for implicit _parameters_ and their _arguments_. Both are introduced with the same keyword, `given`. This unambiguously aligns parameters and arguments, solving a number of language warts. It also allows us to have several implicit parameter sections, and to have implicit parameters followed by normal ones.
 
- 3. [Given Imports](./import-delegate.html) are a new class of imports that specifically import given instances and nothing else. Given instances _must be_ imported with  `import given`, a plain import will no longer bring them into scope.
+ 3. [Given Imports](./import-delegate.md) are a new class of imports that specifically import given instances and nothing else. Given instances _must be_ imported with  `import given`, a plain import will no longer bring them into scope.
 
- 4. [Implicit Conversions](./conversions.html) are now expressed as given instances of a standard `Conversion` class. All other forms of implicit conversions will be phased out.
+ 4. [Implicit Conversions](./conversions.md) are now expressed as given instances of a standard `Conversion` class. All other forms of implicit conversions will be phased out.
 
 This section also contains pages describing other language features that are related to context abstraction. These are:
 
- - [Context Bounds](./context-bounds.html), which carry over unchanged.
- - [Extension Methods](./extension-methods.html) replace implicit classes in a way that integrates better with typeclasses.
- - [Implementing Typeclasses](./typeclasses.html) demonstrates how some common typeclasses can be implemented using the new constructs.
- - [Typeclass Derivation](./derivation.html) introduces constructs to automatically derive typeclass instances for ADTs.
- - [Multiversal Equality](./multiversal-equality.html) introduces a special typeclass
+ - [Context Bounds](./context-bounds.md), which carry over unchanged.
+ - [Extension Methods](./extension-methods.md) replace implicit classes in a way that integrates better with typeclasses.
+ - [Implementing Typeclasses](./typeclasses.md) demonstrates how some common typeclasses can be implemented using the new constructs.
+ - [Typeclass Derivation](./derivation.md) introduces constructs to automatically derive typeclass instances for ADTs.
+ - [Multiversal Equality](./multiversal-equality.md) introduces a special typeclass
   to support type safe equality.
- - [Implicit Function Types](./implicit-function-types.html) provide a way to abstract over given clauses.
- - [Implicit By-Name Parameters](./implicit-by-name-parameters.html) are an essential tool to define recursive synthesized values without looping.
- - [Relationship with Scala 2 Implicits](./relationship-implicits.html) discusses the relationship between old-style implicits and new-style givens and how to migrate from one to the other.
+ - [Implicit Function Types](./implicit-function-types.md) provide a way to abstract over given clauses.
+ - [Implicit By-Name Parameters](./implicit-by-name-parameters.md) are an essential tool to define recursive synthesized values without looping.
+ - [Relationship with Scala 2 Implicits](./relationship-implicits.md) discusses the relationship between old-style implicits and new-style givens and how to migrate from one to the other.
 
 Overall, the new design achieves a better separation of term inference from the rest of the language: There is a single way to define given instances instead of a multitude of forms all taking an `implicit` modifier. There is a single way to introduce implicit parameters and arguments instead of conflating implicit with normal arguments. There is a separate way to import given instances that does not allow them to hide in a sea of normal imports. And there is a single way to define an implicit conversion which is clearly marked as such and does not require special syntax.
 

--- a/docs/docs/reference/contextual/multiversal-equality.md
+++ b/docs/docs/reference/contextual/multiversal-equality.md
@@ -94,7 +94,7 @@ Instead of defining `Eql` instances directly, it is often more convenient to der
 ```scala
 class Box[T](x: T) derives Eql
 ```
-By the usual rules if [typeclass derivation](./derivation.html),
+By the usual rules if [typeclass derivation](./derivation.md),
 this generates the following `Eql` instance in the companion object of `Box`:
 ```scala
 given [T, U] as Eql[Box[T], Box[U]] given Eql[T, U] = Eql.derived

--- a/docs/docs/reference/contextual/query-types-spec.md
+++ b/docs/docs/reference/contextual/query-types-spec.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./implicit-function-types-spec.html).
+The contents of this page have [moved](./implicit-function-types-spec.md).

--- a/docs/docs/reference/contextual/query-types.md
+++ b/docs/docs/reference/contextual/query-types.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./implicit-function-types.html).
+The contents of this page have [moved](./implicit-function-types.md).

--- a/docs/docs/reference/dropped-features/class-shadowing.md
+++ b/docs/docs/reference/dropped-features/class-shadowing.md
@@ -24,4 +24,4 @@ other, but classes in Scala cannot be overridden. To keep things clean
 (and its internal operations consistent) the Dotty compiler forces you
 to rename the inner classes so that their names are different.
 
-[More details](./class-shadowing-spec.html)
+[More details](./class-shadowing-spec.md)

--- a/docs/docs/reference/dropped-features/weak-conformance.md
+++ b/docs/docs/reference/dropped-features/weak-conformance.md
@@ -39,4 +39,4 @@ Therefore, Dotty drops the general notion of weak conformance, and
 instead keeps one rule: `Int` literals are adapted to other numeric
 types if necessary.
 
-[More details](weak-conformance-spec.html)
+[More details](weak-conformance-spec.md)

--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -97,7 +97,7 @@ enum Color(val rgb: Int) {
 ### Syntax of Enums
 
 Changes to the syntax fall in two categories: enum definitions and cases inside enums.
-The changes are specified below as deltas with respect to the Scala syntax given [here](http://dotty.epfl.ch/docs/internals/syntax.html)
+The changes are specified below as deltas with respect to the Scala syntax given [here](../../internals/syntax.md)
 
  1. Enum definitions are defined as follows:
 

--- a/docs/docs/reference/features-classification.md
+++ b/docs/docs/reference/features-classification.md
@@ -16,11 +16,11 @@ The current document reflects the state of things as of April, 2019. It will be 
 
 These new constructs directly model core features of DOT, higher-kinded types, and the [SI calculus for implicit resolution](https://infoscience.epfl.ch/record/229878/files/simplicitly_1.pdf).
 
- - [Intersection types](https://dotty.epfl.ch/docs/reference/new-types/intersection-types.html), replacing compound types,
- - [Union types](https://dotty.epfl.ch/docs/reference/new-types/union-types.html),
- - [Type lambdas](https://dotty.epfl.ch/docs/reference/new-types/type-lambdas.html),
+ - [Intersection types](new-types/intersection-types.md), replacing compound types,
+ - [Union types](new-types/union-types.md),
+ - [Type lambdas](new-types/type-lambdas.md),
  replacing encodings using structural types and type projection.
- - [Context Queries](https://dotty.epfl.ch/docs/reference/contextual/implicit-function-types.html)
+ - [Context Queries](contextual/implicit-function-types.md)
   (_aka_ implicit function types) offering abstraction over given parameters.
 
 **Status: essential**
@@ -35,19 +35,19 @@ Since these are additions, there's generally no migration cost for old code. An 
 
 These constructs replace existing constructs with the aim of making the language safer and simpler to use, and to promote uniformity in code style.
 
- - [Trait Parameters](https://dotty.epfl.ch/docs/reference/other-new-features/trait-parameters.html) replace [early initializers](https://dotty.epfl.ch/docs/reference/dropped-features/early-initializers.html) with a more generally useful construct.
- - [Delegates](https://dotty.epfl.ch/docs/reference/contextual/delegates.html)
+ - [Trait Parameters](other-new-features/trait-parameters.md) replace [early initializers](dropped-features/early-initializers.md) with a more generally useful construct.
+ - [Delegates](contextual/delegates.md)
    replace implicit objects and defs, focussing on intent over mechanism.
- - [Given Clauses](https://dotty.epfl.ch/docs/reference/contextual/given-clauses.html) replace implicit parameters, avoiding their ambiguities.
- - [Extension Methods](https://dotty.epfl.ch/docs/reference/contextual/extension-methods.html) replace implicit classes with a clearer and simpler mechanism.
- - [Opaque Type Aliases](https://dotty.epfl.ch/docs/reference/other-new-features/opaques.html) replace most uses
+ - [Given Clauses](contextual/given-clauses.md) replace implicit parameters, avoiding their ambiguities.
+ - [Extension Methods](contextual/extension-methods.md) replace implicit classes with a clearer and simpler mechanism.
+ - [Opaque Type Aliases](other-new-features/opaques.md) replace most uses
    of value classes while guaranteeing absence of boxing.
- - [Toplevel definitions](https://dotty.epfl.ch/docs/reference/dropped-features/package-objects.html) replace package objects, dropping syntactic boilerplate.
- - [Export clauses](https://dotty.epfl.ch/docs/reference/new-features/export.html)
+ - [Toplevel definitions](dropped-features/package-objects.md) replace package objects, dropping syntactic boilerplate.
+ - [Export clauses](new-features/export.md)
  provide a simple and general way to express aggregation, which can replace the
  previous facade pattern of package objects inheriting from classes.
- - [Vararg patterns](https://dotty.epfl.ch/docs/reference/changed-features/vararg-patterns.html) now use the form `: _*` instead of `@ _*`, mirroring vararg expressions,
- - [Creator applications](https://dotty.epfl.ch/docs/reference/other-new-features/creator-applications.html) allow to use simple function call syntax
+ - [Vararg patterns](changed-features/vararg-patterns.md) now use the form `: _*` instead of `@ _*`, mirroring vararg expressions,
+ - [Creator applications](other-new-features/creator-applications.md) allow to use simple function call syntax
  instead of `new` expressions. `new` expressions stay around as a fallback for
  the cases where creator applications cannot be used.
 
@@ -70,10 +70,10 @@ For the next several versions, old features will remain available and deprecatio
 
 These constructs are restricted to make the language safer.
 
- - [Implicit Conversions](https://dotty.epfl.ch/docs/reference/contextual/conversions.html): there is only one way to define implicit conversions instead of many, and potentially surprising implicit conversions require a language import.
- - [Delegate Imports](https://dotty.epfl.ch/docs/reference/contextual/import-delegate.html): implicits now require a special form of import, to make the import clearly visible.
- - [Type Projection](https://dotty.epfl.ch/docs/reference/dropped-features/type-projection.html): only classes can be used as prefix `C` of a type projection `C#A`. Type projection on abstract types is no longer supported since it is unsound.
- - [Multiversal Equality](https://dotty.epfl.ch/docs/reference/contextual/multiversal-equality.html) implements an "opt-in" scheme to rule out nonsensical comparisons with `==` and `!=`.
+ - [Implicit Conversions](contextual/conversions.md): there is only one way to define implicit conversions instead of many, and potentially surprising implicit conversions require a language import.
+ - [Delegate Imports](contextual/import-delegate.md): implicits now require a special form of import, to make the import clearly visible.
+ - [Type Projection](dropped-features/type-projection.md): only classes can be used as prefix `C` of a type projection `C#A`. Type projection on abstract types is no longer supported since it is unsound.
+ - [Multiversal Equality](contextual/multiversal-equality.md) implements an "opt-in" scheme to rule out nonsensical comparisons with `==` and `!=`.
  - [@infix and @alpha](https://github.com/lampepfl/dotty/pull/5975)
  make method application syntax uniform across code bases and require alphanumeric aliases for all symbolic names (proposed, not implemented).
 
@@ -93,15 +93,15 @@ These are essential restrictions. If we decide to adopt them, we should do it fo
 
 These constructs are proposed to be dropped without a new construct replacing them. The motivation for dropping these constructs is to simplify the language and its implementation.
 
- - [DelayedInit](https://dotty.epfl.ch/docs/reference/dropped-features/delayed-init.html),
- - [Existential types](https://dotty.epfl.ch/docs/reference/dropped-features/existential-types.html),
- - [Procedure syntax](https://dotty.epfl.ch/docs/reference/dropped-features/procedure-syntax.html),
- - [Class shadowing](https://dotty.epfl.ch/docs/reference/dropped-features/class-shadowing.html),
- - [XML literals](https://dotty.epfl.ch/docs/reference/dropped-features/xml.html),
- - [Symbol literals](https://dotty.epfl.ch/docs/reference/dropped-features/symlits.html),
- - [Auto application](https://dotty.epfl.ch/docs/reference/dropped-features/auto-apply.html),
- - [Weak conformance](https://dotty.epfl.ch/docs/reference/dropped-features/weak-conformance.html),
- - [Compound types](https://dotty.epfl.ch/docs/reference/new-types/intersection-types.html),
+ - [DelayedInit](dropped-features/delayed-init.md),
+ - [Existential types](dropped-features/existential-types.md),
+ - [Procedure syntax](dropped-features/procedure-syntax.md),
+ - [Class shadowing](dropped-features/class-shadowing.md),
+ - [XML literals](dropped-features/xml.md),
+ - [Symbol literals](dropped-features/symlits.md),
+ - [Auto application](dropped-features/auto-apply.md),
+ - [Weak conformance](dropped-features/weak-conformance.md),
+ - [Compound types](new-types/intersection-types.md),
  - [Auto tupling](https://github.com/lampepfl/dotty/pull/4311) (implemented, but not merged).
 
 The date when these constructs are dropped varies. The current status is:
@@ -128,10 +128,10 @@ and sometimes need to be manual (e.g. class shadowing, auto tupling). Sometimes 
 
 These constructs have undergone changes to make them more regular and useful.
 
- - [Structural Types](https://dotty.epfl.ch/docs/reference/changed-features/structural-types.html): They now allow pluggable implementations, which greatly increases their usefulness. Some usage patterns are restricted compared to the status quo.
- - [Name-based pattern matching](https://dotty.epfl.ch/docs/reference/changed-features/pattern-matching.html): The existing undocumented Scala 2 implementation has been codified in a slightly simplified form.
- - [Eta expansion](https://dotty.epfl.ch/docs/reference/changed-features/eta-expansion.html) is now performed universally also in the absence of an expected type. The postfix `_` operator is thus made redundant. It will be deprecated and dropped after Scala 3.0.
- - [Implicit Resolution](https://dotty.epfl.ch/docs/reference/changed-features/implicit-resolution.html): The implicit resolution rules have been cleaned up to make them more useful and less surprising. Implicit scope is restricted to no longer include package prefixes.
+ - [Structural Types](changed-features/structural-types.md): They now allow pluggable implementations, which greatly increases their usefulness. Some usage patterns are restricted compared to the status quo.
+ - [Name-based pattern matching](changed-features/pattern-matching.md): The existing undocumented Scala 2 implementation has been codified in a slightly simplified form.
+ - [Eta expansion](changed-features/eta-expansion.md) is now performed universally also in the absence of an expected type. The postfix `_` operator is thus made redundant. It will be deprecated and dropped after Scala 3.0.
+ - [Implicit Resolution](changed-features/implicit-resolution.md): The implicit resolution rules have been cleaned up to make them more useful and less surprising. Implicit scope is restricted to no longer include package prefixes.
 
 Most aspects of old-style implicit resolution are still available under `-language:Scala2`. The other changes in this list are applied unconditionally.
 
@@ -147,11 +147,11 @@ Only a few programs should require changes, but some necessary changes might be 
 
 These are additions to the language that make it more powerful or pleasant to use.
 
- - [Enums](https://dotty.epfl.ch/docs/reference/enums/enums.html) provide concise syntax for enumerations and [algebraic data types](https://dotty.epfl.ch/docs/reference/enums/adts.html).
- - [Parameter Untupling](https://dotty.epfl.ch/docs/reference/other-new-features/parameter-untupling.html) avoids having to use `case` for tupled parameter destructuring.
- - [Dependent Function Types](https://dotty.epfl.ch/docs/reference/new-types/dependent-function-types.html) generalize dependent methods to dependent function values and types.
+ - [Enums](enums/enums.md) provide concise syntax for enumerations and [algebraic data types](enums/adts.md).
+ - [Parameter Untupling](other-new-features/parameter-untupling.md) avoids having to use `case` for tupled parameter destructuring.
+ - [Dependent Function Types](new-types/dependent-function-types.md) generalize dependent methods to dependent function values and types.
  - [Polymorphic Function Types](https://github.com/lampepfl/dotty/pull/4672) generalize polymorphic methods to dependent function values and types. _Current status_: There is a proposal, and a prototype implementation, but the implementation has not been finalized or merged yet.
- - [Kind Polymorphism](https://dotty.epfl.ch/docs/reference/other-new-features/kind-polymorphism.html) allows the definition of operators working equally on types and type constructors.
+ - [Kind Polymorphism](other-new-features/kind-polymorphism.md) allows the definition of operators working equally on types and type constructors.
 
 **Status: mixed**
 
@@ -169,13 +169,13 @@ It's worth noting that macros were never included in the Scala 2 language specif
 
 To enable porting most uses of macros, we are experimenting with the advanced language constructs listed below. These designs are more provisional than the rest of the proposed language constructs for Scala 3.0. There might still be some changes until the final release. Stabilizing the feature set needed for meta programming is our first priority.
 
-- [Match Types](https://dotty.epfl.ch/docs/reference/new-types/match-types.html) allow computation on types.
-- [Inline](https://dotty.epfl.ch/docs/reference/metaprogramming/inline.html) provides
+- [Match Types](new-types/match-types.md) allow computation on types.
+- [Inline](metaprogramming/inline.md) provides
 by itself a straightforward implementation of some simple macros and is at the same time an essential building block for the implementation of complex macros.
-- [Quotes and Splices](https://dotty.epfl.ch/docs/reference/metaprogramming/macros.html) provide a principled way to express macros and staging with a unified set of abstractions.
-- [Typeclass derivation](https://dotty.epfl.ch/docs/reference/contextual/derivation.html) provides an in-language implementation of the `Gen` macro in Shapeless and other foundational libraries. The new implementation is more robust, efficient and easier to use than the macro.
-- [Implicit by-name parameters](https://dotty.epfl.ch/docs/reference/contextual/implicit-by-name-parameters.html) provide a more robust in-language implementation of the `Lazy` macro in Shapeless.
-- [Erased Terms](https://dotty.epfl.ch/docs/reference/metaprogramming/erased-terms.html) provide a general mechanism for compile-time-only computations.
+- [Quotes and Splices](metaprogramming/macros.md) provide a principled way to express macros and staging with a unified set of abstractions.
+- [Typeclass derivation](contextual/derivation.md) provides an in-language implementation of the `Gen` macro in Shapeless and other foundational libraries. The new implementation is more robust, efficient and easier to use than the macro.
+- [Implicit by-name parameters](contextual/implicit-by-name-parameters.md) provide a more robust in-language implementation of the `Lazy` macro in Shapeless.
+- [Erased Terms](metaprogramming/erased-terms.md) provide a general mechanism for compile-time-only computations.
 
 **Status: not yet settled**
 

--- a/docs/docs/reference/metaprogramming/erased-terms.md
+++ b/docs/docs/reference/metaprogramming/erased-terms.md
@@ -159,7 +159,7 @@ object Test {
 }
 ```
 
-Note that in [Inline](./inline.html) we discussed `erasedValue` and inline
+Note that in [Inline](./inline.md) we discussed `erasedValue` and inline
 matches. `erasedValue` is implemented with `erased`, so the state machine above
 can be encoded as follows:
 
@@ -196,4 +196,4 @@ object Test {
 }
 ```
 
-[More Details](./erased-terms-spec.html)
+[More Details](./erased-terms-spec.md)

--- a/docs/docs/reference/metaprogramming/inline.md
+++ b/docs/docs/reference/metaprogramming/inline.md
@@ -5,7 +5,7 @@ title: Inline
 
 ## Inline Definitions
 
-`inline` is a new [soft modifier](../soft-modifier.html) that guarantees that a
+`inline` is a new [soft modifier](../soft-modifier.md) that guarantees that a
 definition will be inlined at the point of use. Example:
 
 ```scala

--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -466,7 +466,7 @@ and allow for undefined compiler behavior if they are not. This is analogous to
 the status of pattern guards in Scala, which are also required, but not
 verified, to be pure.
 
-[Multi-Stage Programming](./staging.html) introduces one additional methods where
+[Multi-Stage Programming](./staging.md) introduces one additional methods where
 you can expand code at runtime with a method `run`. There is also a problem with
 that invokation of `run` in splices. Consider the following expression:
 
@@ -571,7 +571,7 @@ sum
 
 ### Relationship with Whitebox Inline
 
-[Inline](./inline.html) documents inlining. The code below introduces a whitebox
+[Inline](./inline.md) documents inlining. The code below introduces a whitebox
 inline method that can calculate either a value of type `Int` or a value of type
 `String`.
 
@@ -588,4 +588,4 @@ val a: Int = defaultOf("int")
 val b: String = defaultOf("string")
 ```
 
-[More details](./macros-spec.html)
+[More details](./macros-spec.md)

--- a/docs/docs/reference/metaprogramming/staging.md
+++ b/docs/docs/reference/metaprogramming/staging.md
@@ -73,7 +73,7 @@ def withQuoteContext[T](thunk: given QuoteContext => T) given (toolbox: Toolbox)
 
 ## Example
 
-Now take exactly the same example as in [Macros](./macros.html). Assume that we
+Now take exactly the same example as in [Macros](./macros.md). Assume that we
 do not want to pass an array statically but generated code at run-time and pass
 the value, also at run-time. Note, how we make a future-stage function of type
 `Expr[Array[Int] => Int]` in line 4 below. Using `run { ... }` we can evaluate an 

--- a/docs/docs/reference/metaprogramming/tasty-reflect.md
+++ b/docs/docs/reference/metaprogramming/tasty-reflect.md
@@ -5,16 +5,16 @@ title: "TASTy Reflect"
 
 TASTy Reflect enables inspection and construction of Typed Abstract Syntax Trees
 (Typed-AST). It may be used on quoted expressions (`quoted.Expr`) and quoted
-types (`quoted.Type`) from [Macros](./macros.html) or on full TASTy files.
+types (`quoted.Type`) from [Macros](./macros.md) or on full TASTy files.
 
-If you are writing macros, please first read [Macros](./macros.html).
+If you are writing macros, please first read [Macros](./macros.md).
 You may find all you need without using TASTy Reflect.
 
 
 ## API: From quotes and splices to TASTy reflect trees and back
 
 With `quoted.Expr` and `quoted.Type` we can compute code but also analyze code
-by inspecting the ASTs. [Macros](./macros.html) provides the guarantee that the
+by inspecting the ASTs. [Macros](./macros.md) provides the guarantee that the
 generation of code will be type-correct. Using TASTy Reflect will break these
 guarantees and may fail at macro expansion time, hence additional explicit
 checks must be done.

--- a/docs/docs/reference/metaprogramming/toc.md
+++ b/docs/docs/reference/metaprogramming/toc.md
@@ -6,7 +6,7 @@ title: "Overview"
 The following pages introduce the redesign of metaprogramming in Scala. They
 introduce the following fundamental facilities:
 
-1. [Inline](./inline.html) `inline` is a new modifier that guarantees that
+1. [Inline](./inline.md) `inline` is a new modifier that guarantees that
    a definition will be inlined at the point of use. The primary motivation
    behind inline is to reduce the overhead behind function calls and access to
    values. The expansion will be performed by the Scala compiler during the
@@ -17,7 +17,7 @@ introduce the following fundamental facilities:
    programming), macros (enabling compile-time, generative, metaprogramming) and
    runtime code generation (multi-stage programming).
 
-2. [Macros](./macros.html) Macros are built on two well-known fundamental
+2. [Macros](./macros.md) Macros are built on two well-known fundamental
    operations: quotation and splicing.  Quotation converts program code to
    data, specifically, a (tree-like) representation of this code. It is
    expressed as `'{...}` for expressions and as `'[...]` for types. Splicing,
@@ -25,24 +25,24 @@ introduce the following fundamental facilities:
    to program code. Together with `inline`, these two abstractions allow
    to construct program code programmatically.
 
-3. [Staging](./staging.html) Where macros construct code at _compile-time_,
+3. [Staging](./staging.md) Where macros construct code at _compile-time_,
    staging lets programs construct new code at _runtime_. That way,
    code generation can depend not only on static data but also on data available at runtime. This splits the evaluation of the program in two or more phases or ...
    stages. Consequently, this method generative programming is called "Multi-Stage Programming". Staging is built on the same foundations as macros. It uses
    quotes and splices, but leaves out `inline`.
 
-4. [Erased Terms](./erased-terms.html) Erased terms are used to enforce
+4. [Erased Terms](./erased-terms.md) Erased terms are used to enforce
    guarantees about program constraints. As `erased` terms are guaranteed not to
    be used in computations, they will not appear at the generated code.
 
-5. [TASTy Reflection](./tasty-reflect.html) Quotations are a "black-box"
+5. [TASTy Reflection](./tasty-reflect.md) Quotations are a "black-box"
    representation of code. They can be parameterized and composed using
    splices but their structure cannot be analyzed from the outside. Tasty
    reflection gives a way to analyze code structure by partly revealing the representation type of a piece of code in a standard API. The representation
    type is a form of typed abstract syntax tree, which gives rise to the "TASTy`
    moniker.
 
-6. [TASTy Inspection](./tasty-inspect.html) Typed abstract syntax trees are serialized
+6. [TASTy Inspection](./tasty-inspect.md) Typed abstract syntax trees are serialized
    in a custom compressed binary format in `.tasty` files. TASTy inspection allows
    to load these files and analyze their content's tree structure.
 

--- a/docs/docs/reference/new-types/dependent-function-types-spec.md
+++ b/docs/docs/reference/new-types/dependent-function-types-spec.md
@@ -35,7 +35,7 @@ dependent function types for methods with dependent result types.
 
 Dependent functions can be implicit, and generalize to arity `N > 22` in the
 same way that other functions do, see [the corresponding
-documentation](https://dotty.epfl.ch/docs/reference/dropped-features/limit22.html).
+documentation](../dropped-features/limit22.md).
 
 ## Examples
 

--- a/docs/docs/reference/new-types/dependent-function-types.md
+++ b/docs/docs/reference/new-types/dependent-function-types.md
@@ -40,4 +40,4 @@ refinement. In fact, the dependent function type above is just syntactic sugar f
       def apply(e: Entry): e.Key
     }
 
-[More details](./dependent-function-types-spec.html)
+[More details](./dependent-function-types-spec.md)

--- a/docs/docs/reference/new-types/implicit-function-types-spec.md
+++ b/docs/docs/reference/new-types/implicit-function-types-spec.md
@@ -72,7 +72,7 @@ insertion of `scala.Function0` around expression in by-name argument position.
 
 Implicit functions generalize to `N > 22` in the same way that functions do,
 see [the corresponding
-documentation](https://dotty.epfl.ch/docs/reference/dropped-features/limit22.html).
+documentation](../dropped-features/limit22.md).
 
 ## Examples
 

--- a/docs/docs/reference/new-types/intersection-types.md
+++ b/docs/docs/reference/new-types/intersection-types.md
@@ -64,4 +64,4 @@ class C extends A with B {
 ```
 
 
-[More details](./intersection-types-spec.html)
+[More details](./intersection-types-spec.md)

--- a/docs/docs/reference/new-types/type-lambdas-spec.md
+++ b/docs/docs/reference/new-types/type-lambdas-spec.md
@@ -97,7 +97,7 @@ is treated as a shorthand for
 
 **Note**: The decision to treat `Nothing` as universal bottom type is provisional, and might be changed afer further discussion.
 
-**Note**: Scala 2 and 3 differ in that Scala 2 also treats `Any` as universal top-type. This is not done in Scala 3. See also the discussion on [kind polymorphism](../other-new-features/kind-polymorphism.html)
+**Note**: Scala 2 and 3 differ in that Scala 2 also treats `Any` as universal top-type. This is not done in Scala 3. See also the discussion on [kind polymorphism](../other-new-features/kind-polymorphism.md)
 
 ## Curried Type Parameters
 

--- a/docs/docs/reference/new-types/type-lambdas.md
+++ b/docs/docs/reference/new-types/type-lambdas.md
@@ -21,4 +21,4 @@ right-hand side:
 
     type T = [X] =>> (X, X)
 
-[More details](./type-lambdas-spec.html)
+[More details](./type-lambdas-spec.md)

--- a/docs/docs/reference/new-types/union-types-spec.md
+++ b/docs/docs/reference/new-types/union-types-spec.md
@@ -6,7 +6,7 @@ title: "Union Types - More Details"
 ## Syntax
 
 Syntactically, unions follow the same rules as intersections, but have a lower precedence, see
-[Intersection Types - More Details](http://lampepfl.github.io/dotty/docs/reference/new-types/intersection-types-spec.html).
+[Intersection Types - More Details](./intersection-types-spec.md).
 
 ### Interaction with pattern matching syntax
 `|` is also used in pattern matching to separate pattern alternatives and has

--- a/docs/docs/reference/new-types/union-types.md
+++ b/docs/docs/reference/new-types/union-types.md
@@ -41,5 +41,5 @@ The type of `res2` is `Object & Product`, which is a supertype of
 UserName`.  If we want the least supertype, we have to give it
 explicitly, as is done for the type of `either`.
 
-[More details](./union-types-spec.html)
+[More details](./union-types-spec.md)
 

--- a/docs/docs/reference/other-new-features/named-typeargs.md
+++ b/docs/docs/reference/other-new-features/named-typeargs.md
@@ -27,4 +27,4 @@ definition of `xs2` above. A missing type argument is inferred as usual by
 local type inference. This is particularly useful in situations where some type
 arguments can be easily inferred from others.
 
-[More details](./named-typeargs-spec.html)
+[More details](./named-typeargs-spec.md)

--- a/docs/docs/reference/other-new-features/opaques-details.md
+++ b/docs/docs/reference/other-new-features/opaques-details.md
@@ -9,7 +9,7 @@ title: "Opaque Type Aliases: More Details"
 Modifier          ::=  ...
                     |  ‘opaque’
 ```
-`opaque` is a [soft modifier](../soft-modifier.html). It can still be used as a normal identifier when it is not in front of a definition keyword.
+`opaque` is a [soft modifier](../soft-modifier.md). It can still be used as a normal identifier when it is not in front of a definition keyword.
 
 Opaque type aliases must be members of classes, traits, or objects, or they are defined
 at the top-level. They cannot be defined in local blocks.

--- a/docs/docs/reference/other-new-features/parameter-untupling.md
+++ b/docs/docs/reference/other-new-features/parameter-untupling.md
@@ -31,5 +31,5 @@ function type of the form `((T_1, ..., T_n)) => U`.
 ### Reference
 
 For more info see:
-* [More details](./parameter-untupling-spec.html)
+* [More details](./parameter-untupling-spec.md)
 * [Issue #897](https://github.com/lampepfl/dotty/issues/897).

--- a/docs/docs/reference/other-new-features/tupled-function.md
+++ b/docs/docs/reference/other-new-features/tupled-function.md
@@ -7,7 +7,7 @@ Tupled Function
 ----------------------
 
 With functions bounded to arities up to 22 it was possible to generalize some operation on all function types using overloading. 
-Now that we have functions and tuples generalized to [arities above 22](https://dotty.epfl.ch/docs/reference/dropped-features/limit22.html) overloading is not an option anymore. 
+Now that we have functions and tuples generalized to [arities above 22](../dropped-features/limit22.md) overloading is not an option anymore. 
 The type class `TupleFunction` provides a way to abstract directly over a function of any arity converting it to an equivalent function that receives all arguments in a single tuple.
 
 ```scala

--- a/docs/docs/reference/overview.md
+++ b/docs/docs/reference/overview.md
@@ -21,30 +21,30 @@ Corresponding to these goals, the language changes fall into seven categories:
 
 These new constructs directly model core features of DOT, higher-kinded types, and the [SI calculus for implicit resolution](https://infoscience.epfl.ch/record/229878/files/simplicitly_1.pdf).
 
- - [Intersection types](https://dotty.epfl.ch/docs/reference/new-types/intersection-types.html), replacing compound types,
- - [Union types](https://dotty.epfl.ch/docs/reference/new-types/union-types.html),
- - [Type lambdas](https://dotty.epfl.ch/docs/reference/new-types/type-lambdas.html),
+ - [Intersection types](new-types/intersection-types.md), replacing compound types,
+ - [Union types](new-types/union-types.md),
+ - [Type lambdas](new-types/type-lambdas.md),
  replacing encodings using structural types and type projection.
- - [Context Queries](https://dotty.epfl.ch/docs/reference/contextual/implicit-function-types.html)
+ - [Context Queries](contextual/implicit-function-types.md)
   (_aka_ implicit function types) offering abstraction over implicit parameters.
 
 ## Simplifications
 
 These constructs replace existing constructs with the aim of making the language safer and simpler to use, and to promote uniformity in code style.
 
- - [Trait Parameters](https://dotty.epfl.ch/docs/reference/other-new-features/trait-parameters.html) replace [early initializers](https://dotty.epfl.ch/docs/reference/dropped-features/early-initializers.html) with a more generally useful construct.
- - [Delegates](https://dotty.epfl.ch/docs/reference/contextual/delegates.html)
+ - [Trait Parameters](other-new-features/trait-parameters.md) replace [early initializers](dropped-features/early-initializers.md) with a more generally useful construct.
+ - [Delegates](contextual/delegates.md)
    replace implicit objects and defs, focussing on intent over mechanism.
- - [Given Clauses](https://dotty.epfl.ch/docs/reference/contextual/given-clauses.html) replace implicit parameters, avoiding their ambiguities.
- - [Extension Methods](https://dotty.epfl.ch/docs/reference/contextual/extension-methods.html) replace implicit classes with a clearer and simpler mechanism.
- - [Opaque Type Aliases](https://dotty.epfl.ch/docs/reference/other-new-features/opaques.html) replace most uses
+ - [Given Clauses](contextual/given-clauses.md) replace implicit parameters, avoiding their ambiguities.
+ - [Extension Methods](contextual/extension-methods.md) replace implicit classes with a clearer and simpler mechanism.
+ - [Opaque Type Aliases](other-new-features/opaques.md) replace most uses
    of value classes while guaranteeing absence of boxing.
- - [Toplevel definitions](https://dotty.epfl.ch/docs/reference/dropped-features/package-objects.html) replace package objects, dropping syntactic boilerplate.
- - [Export clauses](https://dotty.epfl.ch/docs/reference/other-new-features/export.html)
+ - [Toplevel definitions](dropped-features/package-objects.md) replace package objects, dropping syntactic boilerplate.
+ - [Export clauses](other-new-features/export.md)
  provide a simple and general way to express aggregation, which can replace the
  previous facade pattern of package objects inheriting from classes.
- - [Vararg patterns](https://dotty.epfl.ch/docs/reference/changed-features/vararg-patterns.html) now use the form `: _*` instead of `@ _*`, mirroring vararg expressions,
- - [Creator applications](https://dotty.epfl.ch/docs/reference/other-new-features/creator-applications.html) allow to use simple function call syntax
+ - [Vararg patterns](changed-features/vararg-patterns.md) now use the form `: _*` instead of `@ _*`, mirroring vararg expressions,
+ - [Creator applications](other-new-features/creator-applications.md) allow to use simple function call syntax
  instead of `new` expressions. `new` expressions stay around as a fallback for
  the cases where creator applications cannot be used.
 
@@ -57,10 +57,10 @@ e a special case. There are currently no deprecation plans for value classes, si
 
 These constructs are restricted to make the language safer.
 
- - [Implicit Conversions](https://dotty.epfl.ch/docs/reference/contextual/conversions.html): there is only one way to define implicit conversions instead of many, and potentially surprising implicit conversions require a language import.
- - [Delegate Imports](https://dotty.epfl.ch/docs/reference/contextual/import-delegate.html): implicits now require a special form of import, to make the import clearly visible.
- - [Type Projection](https://dotty.epfl.ch/docs/reference/dropped-features/type-projection.html): only classes can be used as prefix `C` of a type projection `C#A`. Type projection on abstract types is no longer supported since it is unsound.
- - [Multiversal Equality](https://dotty.epfl.ch/docs/reference/contextual/multiversal-equality.html) implements an "opt-in" scheme to rule out nonsensical comparisons with `==` and `!=`.
+ - [Implicit Conversions](contextual/conversions.md): there is only one way to define implicit conversions instead of many, and potentially surprising implicit conversions require a language import.
+ - [Delegate Imports](contextual/import-delegate.md): implicits now require a special form of import, to make the import clearly visible.
+ - [Type Projection](dropped-features/type-projection.md): only classes can be used as prefix `C` of a type projection `C#A`. Type projection on abstract types is no longer supported since it is unsound.
+ - [Multiversal Equality](contextual/multiversal-equality.md) implements an "opt-in" scheme to rule out nonsensical comparisons with `==` and `!=`.
  - [@infix and @alpha](https://github.com/lampepfl/dotty/pull/5975)
  make method application syntax uniform across code bases and require alphanumeric aliases for all symbolic names (proposed, not implemented).
 
@@ -71,15 +71,15 @@ Unrestricted implicit conversions continue to be available in Scala 3.0, but wil
 
 These constructs are proposed to be dropped without a new construct replacing them. The motivation for dropping these constructs is to simplify the language and its implementation.
 
- - [DelayedInit](https://dotty.epfl.ch/docs/reference/dropped-features/delayed-init.html),
- - [Existential types](https://dotty.epfl.ch/docs/reference/dropped-features/existential-types.html),
- - [Procedure syntax](https://dotty.epfl.ch/docs/reference/dropped-features/procedure-syntax.html),
- - [Class shadowing](https://dotty.epfl.ch/docs/reference/dropped-features/class-shadowing.html),
- - [XML literals](https://dotty.epfl.ch/docs/reference/dropped-features/xml.html),
- - [Symbol literals](https://dotty.epfl.ch/docs/reference/dropped-features/symlits.html),
- - [Auto application](https://dotty.epfl.ch/docs/reference/dropped-features/auto-apply.html),
- - [Weak conformance](https://dotty.epfl.ch/docs/reference/dropped-features/weak-conformance.html),
- - [Compound types](https://dotty.epfl.ch/docs/reference/new-types/intersection-types.html),
+ - [DelayedInit](dropped-features/delayed-init.md),
+ - [Existential types](dropped-features/existential-types.md),
+ - [Procedure syntax](dropped-features/procedure-syntax.md),
+ - [Class shadowing](dropped-features/class-shadowing.md),
+ - [XML literals](dropped-features/xml.md),
+ - [Symbol literals](dropped-features/symlits.md),
+ - [Auto application](dropped-features/auto-apply.md),
+ - [Weak conformance](dropped-features/weak-conformance.md),
+ - [Compound types](new-types/intersection-types.md),
  - [Auto tupling](https://github.com/lampepfl/dotty/pull/4311) (implemented, but not merged).
 
 The date when these constructs are dropped varies. The current status is:
@@ -96,10 +96,10 @@ The date when these constructs are dropped varies. The current status is:
 
 These constructs have undergone changes to make them more regular and useful.
 
- - [Structural Types](https://dotty.epfl.ch/docs/reference/changed-features/structural-types.html): They now allow pluggable implementations, which greatly increases their usefulness. Some usage patterns are restricted compared to the status quo.
- - [Name-based pattern matching](https://dotty.epfl.ch/docs/reference/changed-features/pattern-matching.html): The existing undocumented Scala 2 implementation has been codified in a slightly simplified form.
- - [Eta expansion](https://dotty.epfl.ch/docs/reference/changed-features/eta-expansion.html) is now performed universally also in the absence of an expected type. The postfix `_` operator is thus made redundant. It will be deprecated and dropped after Scala 3.0.
- - [Implicit Resolution](https://dotty.epfl.ch/docs/reference/changed-features/implicit-resolution.html): The implicit resolution rules have been cleaned up to make them more useful and less surprising. Implicit scope is restricted to no longer include package prefixes.
+ - [Structural Types](changed-features/structural-types.md): They now allow pluggable implementations, which greatly increases their usefulness. Some usage patterns are restricted compared to the status quo.
+ - [Name-based pattern matching](changed-features/pattern-matching.md): The existing undocumented Scala 2 implementation has been codified in a slightly simplified form.
+ - [Eta expansion](changed-features/eta-expansion.md) is now performed universally also in the absence of an expected type. The postfix `_` operator is thus made redundant. It will be deprecated and dropped after Scala 3.0.
+ - [Implicit Resolution](changed-features/implicit-resolution.md): The implicit resolution rules have been cleaned up to make them more useful and less surprising. Implicit scope is restricted to no longer include package prefixes.
 
 Most aspects of old-style implicit resolution are still available under `-language:Scala2`. The other changes in this list are applied unconditionally.
 
@@ -107,11 +107,11 @@ Most aspects of old-style implicit resolution are still available under `-langua
 
 These are additions to the language that make it more powerful or pleasant to use.
 
- - [Enums](https://dotty.epfl.ch/docs/reference/enums/enums.html) provide concise syntax for enumerations and [algebraic data types](https://dotty.epfl.ch/docs/reference/enums/adts.html).
- - [Parameter Untupling](https://dotty.epfl.ch/docs/reference/other-new-features/parameter-untupling.html) avoids having to use `case` for tupled parameter destructuring.
- - [Dependent Function Types](https://dotty.epfl.ch/docs/reference/new-types/dependent-function-types.html) generalize dependent methods to dependent function values and types.
+ - [Enums](enums/enums.md) provide concise syntax for enumerations and [algebraic data types](enums/adts.md).
+ - [Parameter Untupling](other-new-features/parameter-untupling.md) avoids having to use `case` for tupled parameter destructuring.
+ - [Dependent Function Types](new-types/dependent-function-types.md) generalize dependent methods to dependent function values and types.
  - [Polymorphic Function Types](https://github.com/lampepfl/dotty/pull/4672) generalize polymorphic methods to dependent function values and types. _Current status_: There is a proposal, and a prototype implementation, but the implementation has not been finalized or merged yet.
- - [Kind Polymorphism](https://dotty.epfl.ch/docs/reference/other-new-features/kind-polymorphism.html) allows the definition of operators working equally on types and type constructors.
+ - [Kind Polymorphism](other-new-features/kind-polymorphism.md) allows the definition of operators working equally on types and type constructors.
 
 ## Meta Programming
 
@@ -121,17 +121,17 @@ It's worth noting that macros were never included in the Scala 2 language specif
 
 To enable porting most uses of macros, we are experimenting with the advanced language constructs listed below. These designs are more provisional than the rest of the proposed language constructs for Scala 3.0. There might still be some changes until the final release. Stabilizing the feature set needed for meta programming is our first priority.
 
-- [Match Types](https://dotty.epfl.ch/docs/reference/new-types/match-types.html) allow computation on types.
-- [Inline](https://dotty.epfl.ch/docs/reference/metaprogramming/inline.html) provides
+- [Match Types](new-types/match-types.md) allow computation on types.
+- [Inline](metaprogramming/inline.md) provides
 by itself a straightforward implementation of some simple macros and is at the same time an essential building block for the implementation of complex macros.
-- [Quotes and Splices](https://dotty.epfl.ch/docs/reference/metaprogramming/macros.html) provide a principled way to express macros and staging with a unified set of abstractions.
-- [Typeclass derivation](https://dotty.epfl.ch/docs/reference/contextual/derivation.html) provides an in-language implementation of the `Gen` macro in Shapeless and other foundational libraries. The new implementation is more robust, efficient and easier to use than the macro.
-- [Implicit by-name parameters](https://dotty.epfl.ch/docs/reference/contextual/implicit-by-name-parameters.html) provide a more robust in-language implementation of the `Lazy` macro in Shapeless.
-- [Erased Terms](https://dotty.epfl.ch/docs/reference/metaprogramming/erased-terms.html) provide a general mechanism for compile-time-only computations.
+- [Quotes and Splices](metaprogramming/macros.md) provide a principled way to express macros and staging with a unified set of abstractions.
+- [Typeclass derivation](contextual/derivation.md) provides an in-language implementation of the `Gen` macro in Shapeless and other foundational libraries. The new implementation is more robust, efficient and easier to use than the macro.
+- [Implicit by-name parameters](contextual/implicit-by-name-parameters.md) provide a more robust in-language implementation of the `Lazy` macro in Shapeless.
+- [Erased Terms](metaprogramming/erased-terms.md) provide a general mechanism for compile-time-only computations.
 
 ## See Also
 
-[A classification of proposed language features](./features-classification.html) is
+[A classification of proposed language features](./features-classification.md) is
 an expanded version of this page that adds the status (i.e. relative importance to be a part of Scala 3, and relative urgency when to decide this) and expected migration cost
 of each language construct.
 

--- a/docs/docs/release-notes/0.1.2.md
+++ b/docs/docs/release-notes/0.1.2.md
@@ -76,11 +76,11 @@ This release ships with the following features:
 
 [1]: https://docs.google.com/document/d/1h3KUMxsSSjyze05VecJGQ5H2yh7fNADtIf3chD3_wr0/edit
 [2]: https://infoscience.epfl.ch/record/222780?ln=en
-[3]: http://dotty.epfl.ch/docs/reference/new-types/intersection-types.html
-[4]: http://dotty.epfl.ch/docs/reference/new-types/union-types.html
-[5]: http://dotty.epfl.ch/docs/reference/enums/adts.html
-[6]: http://dotty.epfl.ch/docs/reference/enums/desugarEnums.html
-[7]: http://dotty.epfl.ch/docs/reference/other-new-features/implicit-by-name-parameters.html
+[3]: ../reference/new-types/intersection-types.md
+[4]: ../reference/new-types/union-types.md
+[5]: ../reference/enums/adts.md
+[6]: ../reference/enums/desugarEnums.md
+[7]: ../reference/other-new-features/implicit-by-name-parameters.md
 [8]: https://infoscience.epfl.ch/record/228518
 [9]: http://docs.scala-lang.org/sips/pending/static-members.html
 [10]: http://docs.scala-lang.org/sips/pending/improved-lazy-val-initialization.html
@@ -88,7 +88,7 @@ This release ships with the following features:
 [12]: https://github.com/lampepfl/dotty/commit/b2215ed23311b2c99ea638f9d7fcad9737dba588
 [13]: https://github.com/lampepfl/dotty/pull/187
 [14]: https://github.com/lampepfl/dotty/pull/217
-[15]: http://dotty.epfl.ch/docs/reference/other-new-features/trait-parameters.html
+[15]: ../reference/other-new-features/trait-parameters.md
 [16]: https://github.com/lampepfl/dotty/commit/89540268e6c49fb92b9ca61249e46bb59981bf5a
 [17]: https://github.com/lampepfl/dotty/pull/174
 [18]: https://github.com/lampepfl/dotty/pull/488
@@ -103,10 +103,10 @@ This release ships with the following features:
 [27]: https://github.com/lampepfl/dotty/pull/2513
 [28]: https://github.com/lampepfl/dotty/pull/2361
 [29]: https://github.com/lampepfl/dotty/pull/1453
-[30]: http://dotty.epfl.ch/docs/reference/new-types/implicit-function-types.html
+[30]: ../reference/contextual/implicit-function-types.md
 [31]: https://github.com/lampepfl/dotty/pull/2136
 [32]: https://github.com/lampepfl/dotty/pull/1758
-[33]: http://dotty.epfl.ch/docs/reference/other-new-features/inline.html
+[33]: ../reference/metaprogramming/inline.md
 
 # Contributors
 The Dotty team and contributors have closed 750 issues and have merged a total of 1258 pull requests.

--- a/docs/docs/resources/talks.md
+++ b/docs/docs/resources/talks.md
@@ -17,7 +17,7 @@ transformations and more.
 
 Deep Dive with Dotty
 --------------------
-- (Mar 21, 2017) [Dotty Internals 1: Trees & Symbols](https://www.youtube.com/watch?v=yYd-zuDd3S8) by [Dmitry Petrashko](http://twitter.com/darkdimius) [\[meeting notes\]](http://dotty.epfl.ch/docs/internals/dotty-internals-1-notes.html). 
+- (Mar 21, 2017) [Dotty Internals 1: Trees & Symbols](https://www.youtube.com/watch?v=yYd-zuDd3S8) by [Dmitry Petrashko](http://twitter.com/darkdimius) [\[meeting notes\]](../internals/dotty-internals-1-notes.md). 
 This is a recorded meeting between EPFL and Waterloo, where we introduce first notions inside Dotty: Trees and Symbols.
 
 - (Mar 21, 2017) [Dotty Internals 2: Types](https://www.youtube.com/watch?v=3gmLIYlGbKc) by [Martin Odersky](http://twitter.com/odersky) and [Dmitry Petrashko](http://twitter.com/darkdimius).

--- a/docs/docs/typelevel.md
+++ b/docs/docs/typelevel.md
@@ -557,7 +557,7 @@ Rewrite methods are a safer alternative to the whitebox macros in Scala 2. Both 
 
 By contrast, Scala 2 macros mean that user-defined code is invoked to process program fragments as data. The result of this computation is then embedded instead of the macro call. Macros are thus a lot more powerful than rewrite methods, but also a lot less safe.
 
-Functionality analogous to blackbox macros in Scala-2 is available in Scala-3 through its [principled meta programming](https://dotty.epfl.ch/docs/reference/other-new-features/principled-meta-programming.html) system: Code can be turned into data using quotes `(')`. Code-returning computations can be inserted into quotes using splices `(~)`. A splice outside quotes means that the spliced computation is _run_, which is the analogue of
+Functionality analogous to blackbox macros in Scala-2 is available in Scala-3 through its [principled meta programming](reference/metaprogramming/toc.md) system: Code can be turned into data using quotes `(')`. Code-returning computations can be inserted into quotes using splices `(~)`. A splice outside quotes means that the spliced computation is _run_, which is the analogue of
 invoking a macro. Quoted code can be inspected using reflection on Tasty trees.
 
 To compare: here's the scheme used in Scala-2 to define a macro:

--- a/docs/docs/usage/getting-started.md
+++ b/docs/docs/usage/getting-started.md
@@ -35,12 +35,12 @@ For more information, see the [Dotty Example Project](https://github.com/lampepf
 
 ### IDE support
 Start using the Dotty IDE in any Dotty project by following the
-[IDE guide](http://dotty.epfl.ch/docs/usage/ide-support.html).
+[IDE guide](./ide-support.md).
 
 ### Standalone installation
 Releases are available for download on the [Releases Section](https://github.com/lampepfl/dotty/releases)
 of the Dotty repository. Releases include three executables: `dotc` the Dotty compiler,
-`dotd` the [Dotty Documentation tool](http://dotty.epfl.ch/docs/usage/dottydoc.html) and `dotr` the Dotty REPL.
+`dotd` the [Dotty Documentation tool](./dottydoc.md) and `dotr` the Dotty REPL.
 
 ```
 .

--- a/docs/docs/usage/ide-support.md
+++ b/docs/docs/usage/ide-support.md
@@ -35,7 +35,7 @@ Status
 - Go to definition (in the current project)
 - Find all references
 - Documentation on hover
-- [Worksheet mode](worksheet-mode.html)
+- [Worksheet mode](worksheet-mode.md)
 
 ## Partially working features:
 - Completion

--- a/docs/docs/usage/sbt-projects.md
+++ b/docs/docs/usage/sbt-projects.md
@@ -3,4 +3,4 @@ layout: doc-page
 title: "Using Dotty with sbt"
 ---
 
-To try it in your project see the [Getting Started User Guide](https://dotty.epfl.ch/docs/usage/getting-started.html).
+To try it in your project see the [Getting Started User Guide](./getting-started.md).

--- a/docs/docs/usage/version-numbers.md
+++ b/docs/docs/usage/version-numbers.md
@@ -3,7 +3,7 @@ layout: doc-page
 title: "Version numbers"
 ---
 
-**This documentation is outdated! Please find the newer version [here](/docs/contributing/release.html)**.
+**This documentation is outdated! Please find the newer version [here](../contributing/release.md)**.
 
 Dotty uses multiple schemes for version numbering.
 

--- a/docs/docs/usage/worksheet-mode.md
+++ b/docs/docs/usage/worksheet-mode.md
@@ -15,7 +15,7 @@ The only supported client for the Worksheet mode is [Visual Studio
 Code](https://code.visualstudio.com/).
 
 To use the worksheets, start Dotty IDE by [following the
-instruction](ide-support.html) and create a new file `MyWorksheet.sc` and
+instruction](ide-support.md) and create a new file `MyWorksheet.sc` and
 write some code:
 
 ```scala
@@ -47,4 +47,4 @@ Implementation details
 
 The implementation details of the worksheet mode and the information necessary to add support for
 other clients are available in [Worksheet mode - Implementation
-details](worksheet-mode-implementation-details.html).
+details](worksheet-mode-implementation-details.md).


### PR DESCRIPTION
this PR also contains some fixed broken links

change from `.html` to `.md`
 * makes the pages browseable even from GtiHub
 * IntelliJ or other tools mark broken links (with `.html` every link is marked as broken), preventing them from ever getting to `master`
 * should translate to `.html` without any problem; in the past, for example

[the source _given instances_ links to `./delegates.md`](https://github.com/lampepfl/dotty/blob/3c99306a5bcaa9cb494813353cebb66354b5c8ca/docs/docs/reference/contextual/given-clauses.md)
and
[the rendered _given instances_ links to `https://dotty.epfl.ch/docs/reference/contextual/delegates.html`](https://dotty.epfl.ch/docs/reference/contextual/given-clauses.html)
