### PR TITLE
Move macro error reporting to QuoteContext

### DIFF
--- a/library/src-non-bootstrapped/scala/quoted/QuoteError.scala
+++ b/library/src-non-bootstrapped/scala/quoted/QuoteError.scala
@@ -3,8 +3,10 @@ package scala.quoted
 /** Throwing this error in the implementation of a macro
  *  will result in a compilation error with the given message.
  */
+@deprecated("", "0.17")
 class QuoteError(message: String, val from: Option[Expr[_]]) extends Throwable(message)
 
+@deprecated("", "0.17")
 object QuoteError {
   /** Throws a QuoteError with the given message */
   def apply(message: => String): Nothing = throw new QuoteError(message, None)

--- a/library/src/scala/quoted/QuoteContext.scala
+++ b/library/src/scala/quoted/QuoteContext.scala
@@ -22,6 +22,30 @@ class QuoteContext(val tasty: scala.tasty.Reflection) {
     tpe.unseal.show(syntaxHighlight)
   }
 
+  /** Report an error */
+  def error(msg: => String): Unit = {
+    import tasty._
+    tasty.error(msg, rootPosition) given rootContext
+  }
+
+  /** Report an error at the on the position of `expr` */
+  def error(msg: => String, expr: Expr[_]): Unit = {
+    import tasty._
+    tasty.error(msg, expr.unseal.pos) given rootContext
+  }
+
+  /** Report a warning */
+  def warning(msg: => String): Unit = {
+    import tasty._
+    tasty.warning(msg, rootPosition) given rootContext
+  }
+
+  /** Report a warning at the on the position of `expr` */
+  def warning(msg: => String, expr: Expr[_]): Unit = {
+    import tasty._
+    tasty.warning(msg, expr.unseal.pos) given rootContext
+  }
+
 }
 
 object QuoteContext {

--- a/tests/neg-macros/quote-error-2/Macro_1.scala
+++ b/tests/neg-macros/quote-error-2/Macro_1.scala
@@ -5,8 +5,8 @@ object Macro_1 {
   def fooImpl(b: Boolean) given QuoteContext: Expr[Unit] =
     '{println(${msg(b)})}
 
-  def msg(b: Boolean) given QuoteContext: Expr[String] =
+  def msg(b: Boolean) given (qctx: QuoteContext): Expr[String] =
     if (b) '{"foo(true)"}
-    else QuoteError("foo cannot be called with false")
+    else { qctx.error("foo cannot be called with false"); '{ ??? } }
 
 }

--- a/tests/neg-macros/quote-error/Macro_1.scala
+++ b/tests/neg-macros/quote-error/Macro_1.scala
@@ -2,7 +2,7 @@ import quoted._
 
 object Macro_1 {
   inline def foo(inline b: Boolean): Unit = ${fooImpl(b)}
-  def fooImpl(b: Boolean) given QuoteContext: Expr[Unit] =
+  def fooImpl(b: Boolean) given (qctx: QuoteContext): Expr[Unit] =
     if (b) '{println("foo(true)")}
-    else QuoteError("foo cannot be called with false")
+    else { qctx.error("foo cannot be called with false"); '{ ??? } }
 }

--- a/tests/neg-with-compiler/i5941/macro_1.scala
+++ b/tests/neg-with-compiler/i5941/macro_1.scala
@@ -33,7 +33,8 @@ object Lens {
           apply($getter)(setter)
         }
       case _ =>
-        QuoteError("Unsupported syntax. Example: `GenLens[Address](_.streetNumber)`")
+        qctx.error("Unsupported syntax. Example: `GenLens[Address](_.streetNumber)`")
+        '{???}
     }
   }
 }

--- a/tests/run-macros/f-interpolation-1/FQuote_1.scala
+++ b/tests/run-macros/f-interpolation-1/FQuote_1.scala
@@ -39,7 +39,8 @@ object FQuote {
              values.forall(isStringConstant) =>
         values.collect { case Literal(Constant(value: String)) => value }
       case tree =>
-        QuoteError(s"String literal expected, but ${tree.showExtractors} found")
+        qctx.error(s"String literal expected, but ${tree.showExtractors} found")
+        return '{???}
     }
 
     // [a0, ...]: Any*

--- a/tests/run-macros/f-interpolator-neg/Macros_1.scala
+++ b/tests/run-macros/f-interpolator-neg/Macros_1.scala
@@ -21,7 +21,7 @@ object Macro {
     }
   }
 
-  def fooErrorsImpl(parts : Seq[Expr[String]], args: Seq[Expr[Any]], argsExpr: Expr[Seq[Any]]) given QuoteContext= {
+  def fooErrorsImpl(parts0: Seq[Expr[String]], args: Seq[Expr[Any]], argsExpr: Expr[Seq[Any]]) given QuoteContext= {
     val errors = List.newBuilder[Expr[(Boolean, Int, Int, Int, String)]]
     // true if error, false if warning
     // 0 if part, 1 if arg, 2 if strCtx, 3 if args
@@ -67,6 +67,7 @@ object Macro {
         reported = oldReported
       }
     }
+    val parts = parts0.map { case Const(s) => s }
     dotty.internal.StringContextMacro.interpolate(parts.toList, args.toList, argsExpr, reporter) // Discard result
     errors.result().toExprOfList
   }

--- a/tests/run-macros/tasty-interpolation-1/Macro.scala
+++ b/tests/run-macros/tasty-interpolation-1/Macro.scala
@@ -31,18 +31,21 @@ object FooIntepolator extends MacroStringInterpolator[String] {
 // TODO put this class in the stdlib or separate project?
 abstract class MacroStringInterpolator[T] {
 
-  final def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]) given QuoteContext: Expr[T] = {
+  final def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]) given (qctx: QuoteContext): Expr[T] = {
     try interpolate(strCtxExpr, argsExpr)
     catch {
       case ex: NotStaticlyKnownError =>
         // TODO use ex.expr to recover the position
-        QuoteError(ex.getMessage)
+        qctx.error(ex.getMessage)
+        '{???}
       case ex: StringContextError =>
         // TODO use ex.idx to recover the position
-        QuoteError(ex.getMessage)
+        qctx.error(ex.getMessage)
+        '{???}
       case ex: ArgumentError =>
         // TODO use ex.idx to recover the position
-        QuoteError(ex.getMessage)
+        qctx.error(ex.getMessage)
+        '{???}
     }
   }
 

--- a/tests/run-macros/tasty-macro-const/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-const/quoted_1.scala
@@ -9,11 +9,15 @@ object Macros {
     val xTree: Term = x.unseal
     xTree match {
       case Inlined(_, _, Literal(Constant(n: Int))) =>
-        if (n <= 0)
-          QuoteError("Parameter must be natural number")
-        xTree.seal.cast[Int]
+        if (n <= 0) {
+          qctx.error("Parameter must be natural number")
+          '{0}
+        } else {
+          xTree.seal.cast[Int]
+        }
       case _ =>
-        QuoteError("Parameter must be a known constant")
+        qctx.error("Parameter must be a known constant")
+        '{0}
     }
   }
 

--- a/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
@@ -16,9 +16,6 @@ object XmlQuote {
            given (qctx: QuoteContext): Expr[Xml] = {
     import qctx.tasty._
 
-    def abort(msg: String): Nothing =
-      QuoteError(msg)
-
     // for debugging purpose
     def pp(tree: Tree): Unit = {
       println(tree.showExtractors)
@@ -52,7 +49,8 @@ object XmlQuote {
              values.forall(isStringConstant) =>
         values.collect { case Literal(Constant(value: String)) => value }
       case tree =>
-        abort(s"String literal expected, but ${tree.showExtractors} found")
+        qctx.error(s"String literal expected, but ${tree.showExtractors} found")
+        return '{ ??? }
     }
 
     // [a0, ...]: Any*

--- a/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
@@ -43,12 +43,17 @@ object XmlQuote {
           case Apply(fun, List(Typed(Repeated(values, _), _))) if isStringContextApply(fun) =>
             values.iterator.map {
               case Literal(Constant(value: String)) => value
-              case _ => QuoteError("Expected statically known String")
+              case _ =>
+                qctx.error("Expected statically known String")
+                return '{???}
             }.toList
-          case _ => QuoteError("Expected statically known StringContext")
+          case _ =>
+            qctx.error("Expected statically known StringContext")
+            return '{???}
         }
       case _ =>
-        QuoteError("Expected statically known SCOps")
+        qctx.error("Expected statically known SCOps")
+        return '{???}
     }
 
     // [a0, ...]: Any*

--- a/tests/run-with-compiler/staged-tuples/StagedTuple.scala
+++ b/tests/run-with-compiler/staged-tuples/StagedTuple.scala
@@ -131,7 +131,9 @@ object StagedTuple {
     if (!specialize) '{dynamicApply($tup, $n)}
     else {
       def fallbackApply(): Expr[Elem[Tup, N]] = nValue match {
-        case Some(n) => QuoteError("index out of bounds: " + n, tup)
+        case Some(n) =>
+          qctx.error("index out of bounds: " + n, tup)
+          '{ throw new IndexOutOfBoundsException(${n.toString.toExpr}) }
         case None => '{dynamicApply($tup, $n)}
       }
       val res = size match {


### PR DESCRIPTION
Add `QuoteContext.{error, warning}` and remove `QuoteError` exception.