### PR TITLE
Three tweaks

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1616,7 +1616,7 @@ object desugar {
    */
   private object IdPattern {
     def unapply(tree: Tree)(implicit ctx: Context): Option[VarInfo] = tree match {
-      case id: Ident => Some(id, TypeTree())
+      case id: Ident if id.name != nme.WILDCARD => Some(id, TypeTree())
       case Typed(id: Ident, tpt) => Some((id, tpt))
       case _ => None
     }

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -690,6 +690,15 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     } else tp1
   }
 
+  /** Read type ref, mapping a TypeRef to a package to the package's ThisType
+   *  Packae references should be TermRefs or ThisTypes but it was observed that
+   *  nsc sometimes pickles them as TypeRefs instead.
+   */
+  private def readPrefix()(implicit ctx: Context): Type = readTypeRef() match {
+    case pre: TypeRef if pre.symbol.is(Package) => pre.symbol.thisType
+    case pre => pre
+  }
+
   /** Read a type
    *
    *  @param forceProperType is used to ease the transition to NullaryMethodTypes (commentmarker: NMT_TRANSITION)
@@ -707,7 +716,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       case THIStpe =>
         readSymbolRef().thisType
       case SINGLEtpe =>
-        val pre = readTypeRef()
+        val pre = readPrefix()
         val sym = readDisambiguatedSymbolRef(_.info.isParameterless)
         pre.select(sym)
       case SUPERtpe =>
@@ -717,7 +726,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       case CONSTANTtpe =>
         ConstantType(readConstantRef())
       case TYPEREFtpe =>
-        var pre = readTypeRef()
+        var pre = readPrefix()
         val sym = readSymbolRef()
         pre match {
           case thispre: ThisType =>

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -691,7 +691,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
   }
 
   /** Read type ref, mapping a TypeRef to a package to the package's ThisType
-   *  Packae references should be TermRefs or ThisTypes but it was observed that
+   *  Package references should be TermRefs or ThisTypes but it was observed that
    *  nsc sometimes pickles them as TypeRefs instead.
    */
   private def readPrefix()(implicit ctx: Context): Type = readTypeRef() match {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2574,7 +2574,7 @@ object Parsers {
           }
         } else EmptyTree
       lhs match {
-        case (id @ Ident(name: TermName)) :: Nil =>
+        case (id @ Ident(name: TermName)) :: Nil if name != nme.WILDCARD =>
           val vdef = ValDef(name, tpt, rhs)
           if (isBackquoted(id)) vdef.pushAttachment(Backquoted, ())
           finalizeDef(vdef, mods, start)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1320,15 +1320,8 @@ class Namer { typer: Typer =>
       def cookedRhsType = deskolemize(dealiasIfUnit(widenRhs(rhsType)))
       def lhsType = fullyDefinedType(cookedRhsType, "right-hand side", mdef.span)
       //if (sym.name.toString == "y") println(i"rhs = $rhsType, cooked = $cookedRhsType")
-      if (inherited.exists) {
-        if (sym.is(Final, butNot = Method)) {
-          val tp = lhsType
-          if (tp.isInstanceOf[ConstantType])
-            tp // keep constant types that fill in for a non-constant (to be revised when inline has landed).
-          else inherited
-        }
-        else inherited
-      }
+      if (inherited.exists)
+        if (isInlineVal) lhsType else inherited
       else {
         if (sym.is(Implicit))
           mdef match {

--- a/tests/pos/givenFallback.scala
+++ b/tests/pos/givenFallback.scala
@@ -1,0 +1,15 @@
+trait TC[T] { def x: Int; def y: Int = 0 }
+
+given [T] as TC[T] {
+  inline val x = 1
+}
+
+given as TC[Int] {
+  inline val x = 2
+  inline override val y = 3
+}
+
+object Test extends App {
+  val z: 2 = the[TC[Int]].x
+  val _: 3 = the[TC[Int]].y
+}

--- a/tests/pos/wildcardDefs.scala
+++ b/tests/pos/wildcardDefs.scala
@@ -1,0 +1,4 @@
+object Test {
+  val _ = 2
+  val _ = 3
+}


### PR DESCRIPTION
1. Treat `val _ = ...` as a PatDef, which enables multiple such definitions without double definition errors.
2. Specialize types of inline values even if a wider type was given in an inherited definition. This generalizes a previous scheme for final vals.
3. Fix Scala2 unpickler's handling of package references