### PR TITLE
Fix #6750: Use semi-erased by-name parameter signature

### DIFF
--- a/tests/neg/i6750.scala
+++ b/tests/neg/i6750.scala
@@ -1,0 +1,4 @@
+object Foo {
+  def bar(i: => Int): Unit  = ???
+  def bar(l: => Long): Unit = ??? // error
+}

--- a/tests/neg/i6750b.scala
+++ b/tests/neg/i6750b.scala
@@ -1,0 +1,4 @@
+object Foo {
+  def bar(i: => Int): Unit  = ???
+  def bar(l: () => Long): Unit = ??? // error
+}

--- a/tests/pos/i6750.scala
+++ b/tests/pos/i6750.scala
@@ -1,0 +1,7 @@
+object Foo {
+  inline def foo(i: => Int): Unit  = ???
+  inline def foo(l: => Long): Unit = ???
+
+  foo(2)
+  foo(3L)
+}

--- a/tests/run/i6750.scala
+++ b/tests/run/i6750.scala
@@ -1,0 +1,16 @@
+
+object Test {
+
+  inline def foo(i: => Int)  = i + i
+  inline def foo(l: => Long) = l * l
+
+  inline def bar(i: () => Int)  = ???
+  inline def bar[T](x: () => T) = ???
+
+  def main(args: Array[String]): Unit = {
+    assert(10 == foo(5))
+    assert(25L == foo(5L))
+
+  }
+
+}


### PR DESCRIPTION
Before `Erasure` the signatures will contain `=>X` instead of `Function0`. This makes signature
clashes of by-name parameters only show up after `Erasure`. This allows for `inline` methods to
have by-name parameter overloads.