### PR TITLE
Split macro body check from interpreter

### DIFF
--- a/tests/neg-macros/quote-complex-top-splice.scala
+++ b/tests/neg-macros/quote-complex-top-splice.scala
@@ -6,18 +6,22 @@ object Test {
 
   inline def foo1: Unit = ${
     val x = 1 // error
-    impl(x)
+    impl(x) // error
   }
 
-  inline def foo2: Unit = ${ impl({
-    val x = 1 // error
-    x
-  }) }
+  inline def foo2: Unit = ${ impl(
+    { // error
+      val x = 1
+      x
+    }
+  ) }
 
-  inline def foo3: Unit = ${ impl({
-    println("foo3") // error
-    3
-  }) }
+  inline def foo3: Unit = ${ impl(
+    { // error
+      println("foo3")
+      3
+    }
+  ) }
 
   inline def foo4: Unit = ${
     println("foo4") // error


### PR DESCRIPTION
Currently the same code is used to check that the macro bodies are valid and to interpret the tree.
Adding more functionality to the interpreters usually ends up affecting the validity check. This has proven to allow unexpected arguments to be accepted in the macro body. 

The solution is to split the two implementations. The validity check will accept a subset of the trees that the interpreter can handle.
