### PR TITLE
Fix #6834: Make module constructors private

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -679,7 +679,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
       isFinal &&  !toDenot(sym).isClassConstructor && !(sym.is(Flags.Mutable)) &&  !(sym.enclosingClass.is(Flags.Trait))
 
     def getsJavaPrivateFlag: Boolean =
-      isPrivate //|| (sym.isPrimaryConstructor && sym.owner.isTopLevelModuleClass)
+      isPrivate || (sym.isPrimaryConstructor && sym.owner.isTopLevelModuleClass)
 
     def isFinal: Boolean = sym.is(Flags.Final)
     def isStaticMember: Boolean = (sym ne NoSymbol) &&

--- a/tests/run/i6834.scala
+++ b/tests/run/i6834.scala
@@ -1,0 +1,5 @@
+object Foo
+object Test {
+  def main(args: Array[String]) =
+    assert(Foo.getClass.getConstructors.length == 0)
+}


### PR DESCRIPTION
Now let us see exactly at which place it breaks and why that was commented out in first place...