### PR TITLE
Fix #6603: various changes to avoid cyclic references in separate compilation

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeMapWithImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeMapWithImplicits.scala
@@ -119,7 +119,7 @@ class TreeMapWithImplicits extends tpd.TreeMap {
     }
     catch {
       case ex: TypeError =>
-        ctx.error(ex.toMessage, tree.sourcePos)
+        ctx.error(ex, tree.sourcePos)
         tree
     }
   }

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -327,6 +327,8 @@ object Trees {
 
     def rawComment: Option[Comment] = getAttachment(DocComment)
 
+    def withAnnotations(annots: List[untpd.Tree]): ThisTree[Untyped] = withMods(rawMods.withAnnotations(annots))
+
     def withMods(mods: untpd.Modifiers): ThisTree[Untyped] = {
       val tree = if (myMods == null || (myMods == mods)) this else cloneIn(source)
       tree.setMods(mods)

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -103,6 +103,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val YdebugNames: Setting[Boolean] = BooleanSetting("-Ydebug-names", "Show internal representation of names")
   val YdebugPos: Setting[Boolean] = BooleanSetting("-Ydebug-pos", "Show full source positions including spans")
   val YdebugTreeWithId: Setting[Int] = IntSetting("-Ydebug-tree-with-id", "Print the stack trace when the tree with the given id is created", Int.MinValue)
+  val YdebugTypeError: Setting[Boolean] = BooleanSetting("-Ydebug-type-error", "Print the stack trace when a TypeError is caught", false)
   val YtermConflict: Setting[String] = ChoiceSetting("-Yresolve-term-conflict", "strategy", "Resolve term conflicts", List("package", "object", "error"), "error")
   val Ylog: Setting[List[String]] = PhasesSetting("-Ylog", "Log operations during")
   val YemitTastyInClass: Setting[Boolean] = BooleanSetting("-Yemit-tasty-in-class", "Generate tasty in the .class file and add an empty *.hasTasty file.")

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -189,7 +189,7 @@ class Definitions {
 
   private def completeClass(cls: ClassSymbol, ensureCtor: Boolean = true): ClassSymbol = {
     if (ensureCtor) ensureConstructor(cls, EmptyScope)
-    if (cls.linkedClass.exists) cls.linkedClass.info = NoType
+    if (cls.linkedClass.exists) cls.linkedClass.markAbsent()
     cls
   }
 
@@ -296,12 +296,13 @@ class Definitions {
     cls.info = ClassInfo(cls.owner.thisType, cls, AnyClass.typeRef :: Nil, newScope)
     cls.setFlag(NoInits)
 
-    // The companion object doesn't really exist, `NoType` is the general
-    // technique to do that. Here we need to set it before completing
-    // attempt to load Object's classfile, which causes issue #1648.
+    // The companion object doesn't really exist, so it needs to be marked as
+    // absent. Here we need to set it before completing attempt to load Object's
+    // classfile, which causes issue #1648.
     val companion = JavaLangPackageVal.info.decl(nme.Object).symbol
-    companion.moduleClass.info = NoType // to indicate that it does not really exist
-    companion.info = NoType // to indicate that it does not really exist
+    companion.moduleClass.markAbsent()
+    companion.markAbsent()
+
     completeClass(cls)
   }
   def ObjectType: TypeRef = ObjectClass.typeRef

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -452,7 +452,7 @@ object Flags {
    *  is completed)
    */
   val AfterLoadFlags: FlagSet = commonFlags(
-    FromStartFlags, AccessFlags, Final, AccessorOrSealed, LazyOrTrait, SelfName)
+    FromStartFlags, AccessFlags, Final, AccessorOrSealed, LazyOrTrait, SelfName, JavaDefined)
 
 
   /** A value that's unstable unless complemented with a Stable flag */

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2155,13 +2155,6 @@ object SymDenotations {
     private[this] var mySourceModuleFn: Context => Symbol = NoSymbolFn
     private[this] var myModuleClassFn: Context => Symbol = NoSymbolFn
 
-    /** A proxy to this lazy type that keeps the complete operation
-     *  but provides fresh slots for scope/sourceModule/moduleClass
-     */
-    def proxy: LazyType = new LazyType {
-      override def complete(denot: SymDenotation)(implicit ctx: Context) = self.complete(denot)
-    }
-
     /** The type parameters computed by the completer before completion has finished */
     def completerTypeParams(sym: Symbol)(implicit ctx: Context): List[TypeParamInfo] =
       if (sym.is(Touched)) Nil // return `Nil` instead of throwing a cyclic reference

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2174,6 +2174,8 @@ object SymDenotations {
     def withDecls(decls: Scope): this.type = { myDecls = decls; this }
     def withSourceModule(sourceModuleFn: Context => Symbol): this.type = { mySourceModuleFn = sourceModuleFn; this }
     def withModuleClass(moduleClassFn: Context => Symbol): this.type = { myModuleClassFn = moduleClassFn; this }
+
+    override def toString: String = getClass.toString
   }
 
   /** A subtrait of LazyTypes where completerTypeParams yields a List[TypeSymbol], which

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -792,7 +792,7 @@ object SymDenotations {
       }
 
       if (pre eq NoPrefix) true
-      else if (info eq NoType) false
+      else if (isAbsent) false
       else {
         val boundary = accessBoundary(owner)
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2180,11 +2180,11 @@ object SymDenotations {
   }
 
   /** A missing completer */
-  @sharable class NoCompleter extends LazyType {
+  trait NoCompleter extends LazyType {
     def complete(denot: SymDenotation)(implicit ctx: Context): Unit = unsupported("complete")
   }
 
-  object NoCompleter extends NoCompleter
+  @sharable object NoCompleter extends NoCompleter
 
   /** A lazy type for modules that points to the module class.
    *  Needed so that `moduleClass` works before completion.

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1269,14 +1269,12 @@ object SymDenotations {
      *  as public.
      *  @param base  The access boundary to assume if this symbol is protected
      */
-    final def accessBoundary(base: Symbol)(implicit ctx: Context): Symbol = {
-      val fs = flags
-      if (fs.is(Private)) owner
-      else if (fs.isAllOf(StaticProtected)) defn.RootClass
+    final def accessBoundary(base: Symbol)(implicit ctx: Context): Symbol =
+      if (this.is(Private)) owner
+      else if (this.isAllOf(StaticProtected)) defn.RootClass
       else if (privateWithin.exists && !ctx.phase.erasedTypes) privateWithin
-      else if (fs.is(Protected)) base
+      else if (this.is(Protected)) base
       else defn.RootClass
-    }
 
     final def isPublic(implicit ctx: Context): Boolean =
       accessBoundary(owner) == defn.RootClass

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -375,7 +375,7 @@ abstract class SymbolLoader extends LazyType { self =>
         else
           ctx.newModuleSymbol(
             rootDenot.owner, rootDenot.name.toTermName, Synthetic, Synthetic,
-            (module, _) => new NoCompleter() withDecls newScope withSourceModule (_ => module))
+            (module, _) => NoLoader().withDecls(newScope).withSourceModule(_ => module))
             .moduleClass.denot.asClass
     }
     if (rootDenot.is(ModuleClass)) (linkedDenot, rootDenot)
@@ -415,4 +415,14 @@ class SourcefileLoader(val srcfile: AbstractFile) extends SymbolLoader {
   override def sourceFileOrNull: AbstractFile = srcfile
   def doComplete(root: SymDenotation)(implicit ctx: Context): Unit =
     ctx.run.lateCompile(srcfile, typeCheck = ctx.settings.YretainTrees.value)
+}
+
+/** A NoCompleter which is also a SymbolLoader. */
+class NoLoader extends SymbolLoader with NoCompleter {
+  def description(implicit ctx: Context): String = "NoLoader"
+  override def sourceFileOrNull: AbstractFile = null
+  override def complete(root: SymDenotation)(implicit ctx: Context): Unit =
+    super[NoCompleter].complete(root)
+  def doComplete(root: SymDenotation)(implicit ctx: Context): Unit =
+    unsupported("doComplete")
 }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -235,6 +235,7 @@ object Types {
      *  from the ThisType of `symd`'s owner.
      */
     def isArgPrefixOf(symd: SymDenotation)(implicit ctx: Context): Boolean =
+      symd.exists && !symd.owner.is(Package) && // Early exit if possible because the next check would force SymbolLoaders
       symd.isAllOf(ClassTypeParam) && {
         this match {
           case tp: ThisType => tp.cls ne symd.owner

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4043,7 +4043,7 @@ object Types {
   extends CachedClassInfo(prefix, cls, Nil, decls, selfInfo) {
 
     /** Install classinfo with known parents in `denot` s */
-    def finalize(denot: SymDenotation, parents: List[Type], selfInfo: TypeOrSymbol)(implicit ctx: Context): Unit =
+    def finalize(denot: SymDenotation, parents: List[Type])(implicit ctx: Context): Unit =
       denot.info = ClassInfo(prefix, cls, parents, decls, selfInfo)
 
     override def derivedClassInfo(prefix: Type)(implicit ctx: Context): ClassInfo =

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -932,7 +932,7 @@ class ClassfileParser(
             staticScope.lookup(name)
           else {
             var module = sym.companionModule
-            if (!module.exists && sym.isAbsent)
+            if (!module.exists && sym.isAbsent())
               module = sym.scalacLinkedClass
             module.info.member(name).symbol
           }

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -159,9 +159,9 @@ class ClassfileParser(
 
       val privateWithin = getPrivateWithin(jflags)
 
-      classRoot.privateWithin = privateWithin
-      moduleRoot.privateWithin = privateWithin
-      moduleRoot.sourceModule.privateWithin = privateWithin
+      classRoot.setPrivateWithin(privateWithin)
+      moduleRoot.setPrivateWithin(privateWithin)
+      moduleRoot.sourceModule.setPrivateWithin(privateWithin)
 
       for (i <- 0 until in.nextChar) parseMember(method = false)
       for (i <- 0 until in.nextChar) parseMember(method = true)

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -156,9 +156,12 @@ class ClassfileParser(
 
       classRoot.setFlag(sflags)
       moduleRoot.setFlag(Flags.JavaDefined | Flags.ModuleClassCreationFlags)
-      setPrivateWithin(classRoot, jflags)
-      setPrivateWithin(moduleRoot, jflags)
-      setPrivateWithin(moduleRoot.sourceModule, jflags)
+
+      val privateWithin = getPrivateWithin(jflags)
+
+      classRoot.privateWithin = privateWithin
+      moduleRoot.privateWithin = privateWithin
+      moduleRoot.sourceModule.privateWithin = privateWithin
 
       for (i <- 0 until in.nextChar) parseMember(method = false)
       for (i <- 0 until in.nextChar) parseMember(method = true)
@@ -212,7 +215,8 @@ class ClassfileParser(
     val name = pool.getName(in.nextChar)
     if (!sflags.is(Flags.Private) || name == nme.CONSTRUCTOR) {
       val member = ctx.newSymbol(
-        getOwner(jflags), name, sflags, memberCompleter, coord = start)
+        getOwner(jflags), name, sflags, memberCompleter,
+        getPrivateWithin(jflags), coord = start)
       getScope(jflags).enter(member)
     }
     // skip rest of member for now
@@ -263,7 +267,6 @@ class ClassfileParser(
         denot.info = pool.getType(in.nextChar)
         if (isEnum) denot.info = ConstantType(Constant(sym))
         if (isConstructor) normalizeConstructorParams()
-        setPrivateWithin(denot, jflags)
         denot.info = translateTempPoly(parseAttributes(sym, denot.info))
         if (isConstructor) normalizeConstructorInfo()
 
@@ -983,10 +986,11 @@ class ClassfileParser(
   protected def getScope(flags: Int): MutableScope =
     if (isStatic(flags)) staticScope else instanceScope
 
-  private def setPrivateWithin(denot: SymDenotation, jflags: Int)(implicit ctx: Context): Unit = {
+  private def getPrivateWithin(jflags: Int)(implicit ctx: Context): Symbol =
     if ((jflags & (JAVA_ACC_PRIVATE | JAVA_ACC_PUBLIC)) == 0)
-      denot.privateWithin = denot.enclosingPackageClass
-  }
+      classRoot.enclosingPackageClass
+    else
+      NoSymbol
 
   private def isPrivate(flags: Int)     = (flags & JAVA_ACC_PRIVATE) != 0
   private def isStatic(flags: Int)      = (flags & JAVA_ACC_STATIC) != 0

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -72,8 +72,8 @@ class ClassfileParser(
 
   private[this] var Scala2UnpicklingMode = Mode.Scala2Unpickling
 
-  classRoot.info = (new NoCompleter).withDecls(instanceScope)
-  moduleRoot.info = (new NoCompleter).withDecls(staticScope).withSourceModule(_ => staticModule)
+  classRoot.info = NoLoader().withDecls(instanceScope)
+  moduleRoot.info = NoLoader().withDecls(staticScope).withSourceModule(_ => staticModule)
 
   private def currentIsTopLevel(implicit ctx: Context) = classRoot.owner.is(Flags.PackageClass)
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -546,7 +546,7 @@ class TreeUnpickler(reader: TastyReader,
             rootd.info = adjustIfModule(
                 new Completer(subReader(start, end)) with SymbolLoaders.SecondCompleter)
             rootd.flags = flags &~ Touched // allow one more completion
-            rootd.privateWithin = privateWithin
+            rootd.setPrivateWithin(privateWithin)
             seenRoots += rootd.symbol
             rootd.symbol
           case _ =>

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -134,7 +134,7 @@ object Scala2Unpickler {
     else
       registerCompanionPair(scalacCompanion, denot.classSymbol)
 
-    tempInfo.finalize(denot, normalizedParents, ost) // install final info, except possibly for typeparams ordering
+    tempInfo.finalize(denot, normalizedParents) // install final info, except possibly for typeparams ordering
     denot.ensureTypeParamsInCorrectOrder()
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -479,7 +479,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       if (owner == defn.ScalaPackageClass && ((name eq tpnme.Serializable) || (name eq tpnme.Product)))
         denot.setFlag(NoInits)
 
-      denot.privateWithin = privateWithin
+      denot.setPrivateWithin(privateWithin)
       denot.info = completer
       denot.symbol
     }

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -251,7 +251,7 @@ object Completion {
      */
     private def include(sym: Symbol, nameInScope: Name)(implicit ctx: Context): Boolean =
       nameInScope.startsWith(prefix) &&
-      !sym.isAbsent &&
+      !sym.isAbsent() &&
       !sym.isPrimaryConstructor &&
       sym.sourceSymbol.exists &&
       (!sym.is(Package) || sym.is(ModuleClass)) &&

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -5,6 +5,7 @@ package reporting
 import scala.annotation.internal.sharable
 
 import core.Contexts._
+import core.TypeError
 import util.{SourcePosition, NoSourcePosition}
 import core.Decorators.PhaseListDecorator
 import collection.mutable
@@ -134,6 +135,12 @@ trait Reporting { this: Context =>
   def error(msg: => Message, pos: SourcePosition = NoSourcePosition, sticky: Boolean = false): Unit = {
     val fullPos = addInlineds(pos)
     reporter.report(if (sticky) new StickyError(msg, fullPos) else new Error(msg, fullPos))
+  }
+
+  def error(ex: TypeError, pos: SourcePosition): Unit = {
+    error(ex.toMessage, pos, sticky = true)
+    if (ctx.settings.YdebugTypeError.value)
+      ex.printStackTrace
   }
 
   def errorOrMigrationWarning(msg: => Message, pos: SourcePosition = NoSourcePosition): Unit =

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -247,7 +247,7 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
           case ex: TypeError =>
             // See neg/i1750a for an example where a cyclic error can arise.
             // The root cause in this example is an illegal "override" of an inner trait
-            ctx.error(ex.toMessage, csym.sourcePos, sticky = true)
+            ctx.error(ex, csym.sourcePos)
             defn.ObjectType :: Nil
         }
       if (ValueClasses.isDerivedValueClass(csym)) {

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -326,8 +326,8 @@ private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeT
 
   private def ignoreDependency(sym: Symbol)(implicit ctx: Context) =
     !sym.exists ||
-    sym.unforcedIsAbsent || // ignore dependencies that have a symbol but do not exist.
-                            // e.g. java.lang.Object companion object
+    sym.isAbsent(canForce = false) || // ignore dependencies that have a symbol but do not exist.
+                                      // e.g. java.lang.Object companion object
     sym.isEffectiveRoot ||
     sym.isAnonymousFunction ||
     sym.isAnonymousClass

--- a/compiler/src/dotty/tools/dotc/transform/MacroTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroTransform.scala
@@ -64,7 +64,7 @@ abstract class MacroTransform extends Phase {
         }
       catch {
         case ex: TypeError =>
-          ctx.error(ex.toMessage, tree.sourcePos, sticky = true)
+          ctx.error(ex, tree.sourcePos)
           tree
       }
 

--- a/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
@@ -170,7 +170,7 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
         }
       catch {
         case ex: TypeError =>
-          ctx.error(ex.toMessage, tree.sourcePos)
+          ctx.error(ex, tree.sourcePos)
           tree
       }
     def goUnnamed(tree: Tree, start: Int) =
@@ -205,7 +205,7 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
         }
       catch {
         case ex: TypeError =>
-          ctx.error(ex.toMessage, tree.sourcePos, sticky = true)
+          ctx.error(ex, tree.sourcePos)
           tree
       }
     if (tree.isInstanceOf[NameTree]) goNamed(tree, start) else goUnnamed(tree, start)

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -134,7 +134,7 @@ object OverridingPairs {
             case ex: TypeError =>
               // See neg/i1750a for an example where a cyclic error can arise.
               // The root cause in this example is an illegal "override" of an inner trait
-              ctx.error(ex.toMessage, base.sourcePos, sticky = true)
+              ctx.error(ex, base.sourcePos)
           }
         } else {
           curEntry = curEntry.prev

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -41,7 +41,7 @@ class Pickler extends Phase {
   /** Drop any elements of this list that are linked module classes of other elements in the list */
   private def dropCompanionModuleClasses(clss: List[ClassSymbol])(implicit ctx: Context): List[ClassSymbol] = {
     val companionModuleClasses =
-      clss.filterNot(_.is(Module)).map(_.linkedClass).filterNot(_.unforcedIsAbsent)
+      clss.filterNot(_.is(Module)).map(_.linkedClass).filterNot(_.isAbsent())
     clss.filterNot(companionModuleClasses.contains)
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -68,7 +68,7 @@ class TreeChecker extends Phase with SymTransformer {
   def transformSym(symd: SymDenotation)(implicit ctx: Context): SymDenotation = {
     val sym = symd.symbol
 
-    if (sym.isClass && !sym.isAbsent) {
+    if (sym.isClass && !sym.isAbsent()) {
       val validSuperclass = sym.isPrimitiveValueClass || defn.syntheticCoreClasses.contains(sym) ||
         (sym eq defn.ObjectClass) || sym.isOneOf(NoSuperClassFlags) || (sym.asClass.superClass.exists) ||
         sym.isRefinementClass

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -263,7 +263,10 @@ class TreeChecker extends Phase with SymTransformer {
 
     override def typed(tree: untpd.Tree, pt: Type = WildcardType)(implicit ctx: Context): Tree = {
       val tpdTree = super.typed(tree, pt)
-      checkIdentNotJavaClass(tpdTree)
+      if (ctx.erasedTypes)
+        // Can't be checked in earlier phases since `checkValue` is only run in
+        // Erasure (because running it in Typer would force too much)
+        checkIdentNotJavaClass(tpdTree)
       tpdTree
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -860,7 +860,7 @@ trait Checking {
     typr.println(i"check no double declarations $cls")
 
     def checkDecl(decl: Symbol): Unit = {
-      for (other <- seen(decl.name) if (!decl.isAbsent && !other.isAbsent)) {
+      for (other <- seen(decl.name) if (!decl.isAbsent() && !other.isAbsent())) {
         typr.println(i"conflict? $decl $other")
         def javaFieldMethodPair =
           decl.is(JavaDefined) && other.is(JavaDefined) &&

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -594,18 +594,6 @@ trait Checking {
   def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, posd: Positioned)(implicit ctx: Context): Unit =
     Checking.checkNonCyclicInherited(joint, parents, decls, posd)
 
-  /** Check that Java statics and packages can only be used in selections.
-   */
-  def checkValue(tree: Tree, proto: Type)(implicit ctx: Context): tree.type = {
-    if (!proto.isInstanceOf[SelectionProto] && !proto.isInstanceOf[ApplyingProto]) {
-      val sym = tree.tpe.termSymbol
-      // The check is avoided inside Java compilation units because it always fails
-      // on the singleton type Module.type.
-      if ((sym is Package) || (sym.isAllOf(JavaModule) && !ctx.compilationUnit.isJava)) ctx.error(JavaSymbolIsNotAValue(sym), tree.sourcePos)
-    }
-    tree
-  }
-
   /** Check that type `tp` is stable. */
   def checkStable(tp: Type, pos: SourcePosition)(implicit ctx: Context): Unit =
     if (!tp.isStable) ctx.error(ex"$tp is not stable", pos)
@@ -1171,7 +1159,6 @@ trait NoChecking extends ReChecking {
   import tpd._
   override def checkNonCyclic(sym: Symbol, info: TypeBounds, reportErrors: Boolean)(implicit ctx: Context): Type = info
   override def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, posd: Positioned)(implicit ctx: Context): Unit = ()
-  override def checkValue(tree: Tree, proto: Type)(implicit ctx: Context): tree.type = tree
   override def checkStable(tp: Type, pos: SourcePosition)(implicit ctx: Context): Unit = ()
   override def checkClassType(tp: Type, pos: SourcePosition, traitReq: Boolean, stablePrefixReq: Boolean)(implicit ctx: Context): Type = tp
   override def checkImplicitConversionDefOK(sym: Symbol)(implicit ctx: Context): Unit = ()

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -358,10 +358,14 @@ object Checking {
   }
 
   /** Check type members inherited from different `parents` of `joint` type for cycles,
-   *  unless a type with the same name aleadry appears in `decls`.
+   *  unless a type with the same name already appears in `decls`.
    *  @return    true iff no cycles were detected
    */
   def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, posd: Positioned)(implicit ctx: Context): Unit = {
+    // If we don't have more than one parent, then there's nothing to check
+    if (parents.lengthCompare(1) <= 0)
+      return
+
     def qualifies(sym: Symbol) = sym.name.isTypeName && !sym.is(Private)
     val abstractTypeNames =
       for (parent <- parents; mbr <- parent.abstractTypeMembers if qualifies(mbr.symbol))

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -258,7 +258,7 @@ object Checking {
             if (locked.contains(tp) || tp.symbol.infoOrCompleter.isInstanceOf[NoCompleter])
               throw CyclicReference(tp.symbol)
             locked += tp
-            try checkInfo(tp.info)
+            try if (!tp.symbol.isClass) checkInfo(tp.info)
             finally locked -= tp
             tp.withPrefix(pre1)
           }

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -16,15 +16,23 @@ object ErrorReporting {
 
   import tpd._
 
-  def errorTree(tree: untpd.Tree, msg: => Message, pos: SourcePosition, sticky: Boolean = false)(implicit ctx: Context): tpd.Tree =
-    tree.withType(errorType(msg, pos, sticky))
+  def errorTree(tree: untpd.Tree, msg: => Message, pos: SourcePosition)(implicit ctx: Context): tpd.Tree =
+    tree.withType(errorType(msg, pos))
 
   def errorTree(tree: untpd.Tree, msg: => Message)(implicit ctx: Context): tpd.Tree =
     errorTree(tree, msg, tree.sourcePos)
 
-  def errorType(msg: => Message, pos: SourcePosition, sticky: Boolean = false)(implicit ctx: Context): ErrorType = {
-    ctx.error(msg, pos, sticky)
+  def errorTree(tree: untpd.Tree, msg: TypeError, pos: SourcePosition)(implicit ctx: Context): tpd.Tree =
+    tree.withType(errorType(msg, pos))
+
+  def errorType(msg: => Message, pos: SourcePosition)(implicit ctx: Context): ErrorType = {
+    ctx.error(msg, pos)
     ErrorType(msg)
+  }
+
+  def errorType(ex: TypeError, pos: SourcePosition)(implicit ctx: Context): ErrorType = {
+    ctx.error(ex, pos)
+    ErrorType(ex.toMessage)
   }
 
   def wrongNumberOfTypeArgs(fntpe: Type, expectedArgs: List[ParamInfo], actual: List[untpd.Tree], pos: SourcePosition)(implicit ctx: Context): ErrorType =

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -792,10 +792,14 @@ class Namer { typer: Typer =>
         lazy val annotCtx = annotContext(original, sym)
         for (annotTree <- untpd.modsDeco(original).mods.annotations) {
           val cls = typedAheadAnnotationClass(annotTree)(annotCtx)
-          val ann = Annotation.deferred(cls, implicit ctx => typedAnnotation(annotTree))
-          sym.addAnnotation(ann)
-          if (cls == defn.ForceInlineAnnot && sym.is(Method, butNot = Accessor))
-            sym.setFlag(Inline)
+          if (cls eq sym)
+            ctx.error("An annotation class cannot be annotated with iself", annotTree.sourcePos)
+          else {
+            val ann = Annotation.deferred(cls, implicit ctx => typedAnnotation(annotTree))
+            sym.addAnnotation(ann)
+            if (cls == defn.ForceInlineAnnot && sym.is(Method, butNot = Accessor))
+              sym.setFlag(Inline)
+          }
         }
       case _ =>
     }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -332,7 +332,7 @@ class Namer { typer: Typer =>
         if (prev.exists) {
           prev.flags = flags1
           prev.info = infoFn(prev.asInstanceOf[S])
-          prev.privateWithin = privateWithin
+          prev.setPrivateWithin(privateWithin)
           prev
         }
         else symFn(flags1, infoFn, privateWithin)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1144,7 +1144,7 @@ class Namer { typer: Typer =>
         original.putAttachment(Deriver, deriver)
       }
 
-      tempInfo.finalize(denot, parentTypes, selfInfo)
+      tempInfo.finalize(denot, parentTypes)
 
       Checking.checkWellFormed(cls)
       if (isDerivedValueClass(cls)) cls.setFlag(Final)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -459,7 +459,7 @@ class Namer { typer: Typer =>
     def invalidate(name: TypeName) =
       if (!(definedNames contains name)) {
         val member = pkg.info.decl(name).asSymDenotation
-        if (member.isClass && !member.is(Package)) member.info = NoType
+        if (member.isClass && !(member.is(Package))) member.markAbsent()
       }
     xstats foreach {
       case stat: TypeDef if stat.isClassDef =>
@@ -828,7 +828,7 @@ class Namer { typer: Typer =>
           alt != denot.symbol && alt.info.matchesLoosely(denot.info))
       if (isClashingSynthetic) {
         typr.println(i"invalidating clashing $denot in ${denot.owner}")
-        denot.info = NoType
+        denot.markAbsent()
       }
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -971,7 +971,7 @@ class RefChecks extends MiniPhase { thisPhase =>
     tree
   } catch {
     case ex: TypeError =>
-      ctx.error(ex.toMessage, tree.sourcePos, sticky = true)
+      ctx.error(ex, tree.sourcePos)
       tree
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -170,7 +170,7 @@ trait TypeAssigner {
   final def reallyExists(denot: Denotation)(implicit ctx: Context): Boolean = try
     denot match {
       case denot: SymDenotation =>
-        denot.exists && !denot.isAbsent
+        denot.exists && !denot.isAbsent()
       case denot: SingleDenotation =>
         val sym = denot.symbol
         (sym eq NoSymbol) || reallyExists(sym.denot)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -429,7 +429,6 @@ class Typer extends Namer
     }
 
     checkStableIdentPattern(tree1, pt)
-    checkValue(tree1, pt)
   }
 
   /** Check that a stable identifier pattern is indeed stable (SLS 8.1.5)
@@ -453,7 +452,7 @@ class Typer extends Namer
       }
     case qual =>
       if (tree.name.isTypeName) checkStable(qual.tpe, qual.sourcePos)
-      val select = checkValue(assignType(cpy.Select(tree)(qual, tree.name), qual), pt)
+      val select = assignType(cpy.Select(tree)(qual, tree.name), qual)
       if (select.tpe ne TryDynamicCallType) ConstFold(checkStableIdentPattern(select, pt))
       else if (pt.isInstanceOf[FunOrPolyProto] || pt == AssignProto) select
       else typedDynamicSelect(tree, Nil, pt)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2419,7 +2419,7 @@ class Typer extends Namer
         try adapt(typedUnadapted(tree, pt, locked), pt, locked)
         catch {
           case ex: TypeError =>
-            errorTree(tree, ex.toMessage, tree.sourcePos.focus, sticky = true)
+            errorTree(tree, ex, tree.sourcePos.focus)
             // This uses tree.span.focus instead of the default tree.span, because:
             // - since tree can be a top-level definition, tree.span can point to the whole definition
             // - that would in turn hide all other type errors inside tree.
@@ -3195,7 +3195,7 @@ class Typer extends Namer
               }
             }
             catch {
-              case ex: TypeError => errorTree(tree, ex.toMessage, tree.sourcePos, sticky = true)
+              case ex: TypeError => errorTree(tree, ex, tree.sourcePos)
             }
           val nestedCtx = ctx.fresh.setNewTyperState()
           val app = tryExtension(nestedCtx)

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -214,7 +214,7 @@ class VarianceChecker()(implicit ctx: Context) {
         case _ =>
       }
       catch {
-        case ex: TypeError => ctx.error(ex.toMessage, tree.sourcePos.focus)
+        case ex: TypeError => ctx.error(ex, tree.sourcePos.focus)
       }
     }
   }

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -57,6 +57,15 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
         ),
         withCompilerOptions
       ),
+      compileList(
+        "testIssue6603",
+        List(
+          "compiler/src/dotty/tools/dotc/ast/Desugar.scala",
+          "compiler/src/dotty/tools/dotc/ast/Trees.scala",
+          "compiler/src/dotty/tools/dotc/core/Types.scala"
+        ),
+        withCompilerOptions
+      ),
     ).checkCompile()
   }
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -7,7 +7,7 @@ import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Types.WildcardType
 import dotty.tools.dotc.parsing.Tokens
 import dotty.tools.dotc.reporting.diagnostic.messages._
-import dotty.tools.dotc.transform.{CheckStatic, PostTyper, TailRec}
+import dotty.tools.dotc.transform.{CheckStatic, Erasure, PostTyper, TailRec}
 import dotty.tools.dotc.typer.{FrontEnd, RefChecks}
 import org.junit.Assert._
 import org.junit.Test
@@ -1473,22 +1473,6 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       val PolymorphicMethodMissingTypeInParent(rsym, parentSym) = messages.head
       assertEquals("method get", rsym.show)
       assertEquals("class Object", parentSym.show)
-    }
-
-  @Test def javaSymbolIsNotAValue =
-    checkMessagesAfter(CheckStatic.name) {
-      """
-        |package p
-        |object O {
-        |  val v = p
-        |}
-      """.stripMargin
-    }.expect { (itcx, messages) =>
-      implicit val ctx: Context = itcx
-
-      assertMessageCount(1, messages)
-      val JavaSymbolIsNotAValue(symbol) = messages.head
-      assertEquals(symbol.show, "package p")
     }
 
   @Test def i3187 =

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -636,16 +636,21 @@ object Build {
       else if (debugFromTasty) "dotty.tools.dotc.fromtasty.Debug"
       else "dotty.tools.dotc.Main"
 
-    var extraClasspath = s"$scalaLib${File.pathSeparator}$dottyLib"
-    if ((decompile || printTasty) && !args.contains("-classpath")) extraClasspath += s"${File.pathSeparator}."
+    var extraClasspath = Seq(scalaLib, dottyLib)
+
+    if ((decompile || printTasty) && !args.contains("-classpath"))
+      extraClasspath ++= Seq(".")
+
     if (args0.contains("-with-compiler")) {
       if (scalaVersion.value == referenceVersion) {
         log.error("-with-compiler should only be used with a bootstrapped compiler")
       }
-      extraClasspath += s"${File.pathSeparator}$dottyCompiler"
+      val dottyInterfaces = jars("dotty-interfaces")
+      val asm = findLib(attList, "scala-asm")
+      extraClasspath ++= Seq(dottyCompiler, dottyInterfaces, asm)
     }
 
-    val fullArgs = main :: insertClasspathInArgs(args, extraClasspath)
+    val fullArgs = main :: insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator))
 
     (runMain in Compile).toTask(fullArgs.mkString(" ", " ", ""))
   }

--- a/tests/fuzzy/parser-stability-15.scala
+++ b/tests/fuzzy/parser-stability-15.scala
@@ -1,0 +1,6 @@
+package x0
+class x0 {
+def x1 =
+x2 match
+]
+case x3[] => x0

--- a/tests/neg/exports.check
+++ b/tests/neg/exports.check
@@ -41,9 +41,9 @@
    |             ^^^
    |             no eligible member foo at this.foo
    |             this.foo.foo cannot be exported because it is already a member of class Foo
--- [E046] Cyclic Error: tests/neg/exports.scala:45:11 ------------------------------------------------------------------
-45 |  val bar: Bar = new Bar // error: cyclic reference
-   |           ^
-   |           Cyclic reference involving value bar
-
-longer explanation available when compiling with `-explain`
+-- [E120] Duplicate Symbol Error: tests/neg/exports.scala:46:13 --------------------------------------------------------
+46 |  export bar._  // error: double definition
+   |             ^
+   |             Double definition:
+   |             val bar: Bar in class Baz at line 45 and
+   |             final def bar: => => Bar(Baz.this.bar.baz.bar)(Baz.this.bar.bar) in class Baz at line 46

--- a/tests/neg/exports.scala
+++ b/tests/neg/exports.scala
@@ -42,8 +42,8 @@ class Foo {
 }
 
 class Baz {
-  val bar: Bar = new Bar // error: cyclic reference
-  export bar._
+  val bar: Bar = new Bar
+  export bar._  // error: double definition
 }
 class Bar {
   val baz: Baz = new Baz

--- a/tests/neg/i1212.scala
+++ b/tests/neg/i1212.scala
@@ -1,1 +1,1 @@
-@ann class ann extends scala.annotation.Annotation // error: cyclic reference
+@ann class ann extends scala.annotation.Annotation // error: An annotation class cannot be annotated with iself

--- a/tests/neg/i3506.scala
+++ b/tests/neg/i3506.scala
@@ -1,2 +1,0 @@
-trait C2[@specialized A] // error
-class specialized extends C2[Char] // error

--- a/tests/neg/i4368.scala
+++ b/tests/neg/i4368.scala
@@ -149,13 +149,13 @@ object Test9 {
 object i4369 {
   trait X { self =>
     type R <: Z
-    type Z >: X { type R = self.R; type Z = self.R }
+    type Z >: X { type R = self.R; type Z = self.R } // error: cyclic // error: cyclic // error: cyclic
   }
-  class Foo extends X { type R = Foo; type Z = Foo } // error: too deep
+  class Foo extends X { type R = Foo; type Z = Foo }
 }
 object i4370 {
-  class Foo { type R = A } // error: cyclic
-  type A = List[Foo#R]
+  class Foo { type R = A }
+  type A = List[Foo#R] // error: cyclic
 }
 object i4371 {
   class Foo { type A = Boo#B } // error: cyclic

--- a/tests/neg/i4370.scala
+++ b/tests/neg/i4370.scala
@@ -1,4 +1,4 @@
 object App {
-  class Foo { type R = A } // error
-  type A = List[Foo#R]
+  class Foo { type R = A }
+  type A = List[Foo#R] // error
 }

--- a/tests/neg/parser-stability-15.scala
+++ b/tests/neg/parser-stability-15.scala
@@ -1,7 +1,0 @@
-package x0
-class x0 {
-def x1 =
-x2 match          // error
-]                 // error
-case x3[] => x0   // error // error
-// error

--- a/tests/pos/i3506.scala
+++ b/tests/pos/i3506.scala
@@ -1,0 +1,2 @@
+trait C2[@specialized A]
+class specialized extends scala.annotation.StaticAnnotation with C2[Char]


### PR DESCRIPTION
Compiling `Desugar.scala`, `Trees.scala` and `Types.scala` with Dotty on the classpath lead to:
```scala
-- [E046] Cyclic Error: compiler/src/dotty/tools/dotc/core/Types.scala:22:7 ----
22 |import ast.tpd._
   |       ^
   |       Cyclic reference involving constructor Instance
```
This PR fixes that by judiciously reducing the amount of info which need to be completed. I've done this sort of PR many times before, but this one was by far the hardest. To solve the original problem, the following changes were necessary:

- Move the `checkValue` check after Typer
- Make `JavaDefined` an AfterLoadFlags
- Make `isAbsent` force less, this required some refactoring to be done safely
- Make `privateWithin` force less (likewise required some refactoring)

These changes were enough to fix the original problem, but paradoxically they caused new cyclic references to appear (because we're forcing less things in some situations, we end up with more unforced things at the same time and thus more chances of a cycle between all these things). Fixing these new issues required the following changes:

- Make `DerivedFromParamTree#ensureCompletions` force less, this required refactoring ClassCompleter to be able to complete the constructor without completing the whole class
- Make `checkNonCyclic` and `checkNonCyclicInherited` force less, those were simple changes
- Drop annotations from constructor parameters

Reviewing this PR requires going commit-by-commit, I've taken great care to make each commit reviewable and sensible on its own.