### PR TITLE
Handle $asInstanceOf$ in Splicer

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -193,8 +193,12 @@ object Splicer {
           val staticMethodCall = interpretedStaticMethodCall(fn.symbol.owner, fn.symbol)
           staticMethodCall(args.flatten.map(interpretTree))
         } else if (fn.qualifier.symbol.is(Module) && fn.qualifier.symbol.isStatic) {
-          val staticMethodCall = interpretedStaticMethodCall(fn.qualifier.symbol.moduleClass, fn.symbol)
-          staticMethodCall(args.flatten.map(interpretTree))
+          if (fn.name == nme.asInstanceOfPM) {
+            interpretModuleAccess(fn.qualifier.symbol)
+          } else {
+            val staticMethodCall = interpretedStaticMethodCall(fn.qualifier.symbol.moduleClass, fn.symbol)
+            staticMethodCall(args.flatten.map(interpretTree))
+          }
         } else if (env.contains(fn.name)) {
           env(fn.name)
         } else if (tree.symbol.is(InlineProxy)) {
@@ -265,7 +269,6 @@ object Splicer {
 
       val name = getDirectName(fn.info.finalResultType, fn.name.asTermName)
       val method = getMethod(clazz, name, paramsSig(fn))
-
       (args: List[Object]) => stopIfRuntimeException(method.invoke(inst, args: _*))
     }
 

--- a/tests/run-macros/dollar-asInstanceOf-dollar/1.scala
+++ b/tests/run-macros/dollar-asInstanceOf-dollar/1.scala
@@ -1,0 +1,12 @@
+import scala.quoted._
+import scala.deriving._
+
+case class Box[A](x: A)
+
+object Macro {
+  inline def foo[X[_]](implicit inline m: Mirror { type MirroredType = X }): Int =
+    ${ fooImpl }
+
+  def fooImpl[X[_]](implicit m: Mirror { type MirroredType = X }, qc: QuoteContext): Expr[Int] =
+    '{ 1 }
+}

--- a/tests/run-macros/dollar-asInstanceOf-dollar/2.scala
+++ b/tests/run-macros/dollar-asInstanceOf-dollar/2.scala
@@ -1,0 +1,4 @@
+object Test {
+  def main(args: Array[String]): Unit =
+    assert(Macro.foo[Box] == 1)
+}


### PR DESCRIPTION
Before that commit macro expansion would fail with:

"Could not find method Box$.$asInstanceOf$ with parameters (). The most common reason for that is that you apply macros in the compilation run that defines them"

The code in question comes from the way we handle `Mirrors`; when implicitly summoned they get a more precise type via a cast.

Doing this by name feels hacky but I'm still opening the PR for discussion.