### PR TITLE
Partial fix for inlining with opaque types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -592,7 +592,7 @@ object SymDenotations {
 
     def seesOpaques(implicit ctx: Context): Boolean =
       containsOpaques ||
-      is(Module, butNot = Package) && owner.containsOpaques
+      is(Module, butNot = Package) && owner.seesOpaques
 
     /** Is this the denotation of a self symbol of some class?
      *  This is the case if one of two conditions holds:

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2463,9 +2463,9 @@ class ExplainingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
     if (skipped) op
     else {
       indent += 2
-      b append "\n" append (" " * indent) append "==> " append str
+      b.append("\n").append(" " * indent).append("==> ").append(str)
       val res = op
-      b append "\n" append (" " * indent) append "<== " append str append " = " append show(res)
+      b.append("\n").append(" " * indent).append("<== ").append(str).append(" = ").append(show(res))
       indent -= 2
       res
     }

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -201,7 +201,8 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
 
   private val (methPart, callTypeArgs, callValueArgss) = decomposeCall(call)
   private val inlinedMethod = methPart.symbol
-  private val inlineCallPrefix = qualifier(methPart)
+  private val inlineCallPrefix =
+     qualifier(methPart).orElse(This(inlinedMethod.enclosingClass.asClass))
 
   // Make sure all type arguments to the call are fully determined
   for (targ <- callTypeArgs) fullyDefinedType(targ.tpe, "inlined type argument", targ.span)

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -320,7 +320,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
           ref(rhsClsSym.sourceModule)
         else
           inlineCallPrefix
-      val binding = ValDef(selfSym.asTerm, rhs).withSpan(selfSym.span).setDefTree
+      val binding = ValDef(selfSym.asTerm, rhs.ensureConforms(selfSym.info)).withSpan(selfSym.span).setDefTree
       bindingsBuf += binding
       inlining.println(i"proxy at $level: $selfSym = ${bindingsBuf.last}")
       lastSelf = selfSym

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -49,7 +49,7 @@ object Typer {
    */
   enum BindingPrec {
     case NothingBound, PackageClause, WildImport, NamedImport, Definition
-    
+
     def isImportPrec = this == NamedImport || this == WildImport
   }
 

--- a/compiler/test/dotc/pos-from-tasty.blacklist
+++ b/compiler/test/dotc/pos-from-tasty.blacklist
@@ -6,3 +6,6 @@ t3612.scala
 
 # Other failure
 t802.scala
+
+# Recursion limit exceeded: find-member K0.ToUnion
+shapeless.scala

--- a/tests/pos/shapeless.scala
+++ b/tests/pos/shapeless.scala
@@ -1,0 +1,265 @@
+package test.shapeless {
+
+import scala.collection.mutable.WrappedArray
+import scala.compiletime._
+import scala.deriving._
+import annotation.tailrec
+
+object K0 {
+  type Generic[O] = Mirror { type MirroredType = O ; type MirroredElemTypes }
+  type ProductGeneric[O] = Mirror.Product { type MirroredType = O ; type MirroredElemTypes }
+
+  def Generic[O] given (gen: Generic[O]): Generic[O] { type MirroredElemTypes = gen.MirroredElemTypes ; type MirroredLabel = gen.MirroredLabel ; type MirroredElemLabels = gen.MirroredElemLabels } = gen
+  def ProductGeneric[O] given (gen: ProductGeneric[O]): ProductGeneric[O] { type MirroredElemTypes = gen.MirroredElemTypes ; type MirroredLabel = gen.MirroredLabel ; type MirroredElemLabels = gen.MirroredElemLabels } = gen
+
+  opaque type Instances[F[_], T] = ErasedInstances[F[T]]
+  opaque type ProductInstances[F[_], T] = ErasedProductInstances[F[T]]
+
+  def Instances[F[_], T] given (inst: Instances[F, T]): inst.type = inst
+  def ProductInstances[F[_], T] given (inst: ProductInstances[F, T]): inst.type = inst
+
+  type ToUnion[T] = T match {
+    case Unit => Nothing
+    case a *: b => a | ToUnion[b]
+  }
+
+  type IndexOf[E, X] = IndexOf0[E, X, 0]
+
+  type IndexOf0[E, X, I <: Int] <: Int = X match {
+    case Unit => -1
+    case x *: xs => x match {
+      case E => I
+      case _ => IndexOf0[E, xs, S[I]]
+    }
+  }
+
+  inline def summonAsArray[F[_], T]: Array[Any] = inline erasedValue[T] match {
+    case _: Unit => Array()
+    case _: Tuple1[a] => Array(summon[F[a]])
+    case _: (a, b) => Array(summon[F[a]], summon[F[b]])
+    case _: (a, b, c) => Array(summon[F[a]], summon[F[b]], summon[F[c]])
+    case _: (a, b, c, d) => Array(summon[F[a]], summon[F[b]], summon[F[c]], summon[F[d]])
+    case _: (a, b, c, d, e) => Array(summon[F[a]], summon[F[b]], summon[F[c]], summon[F[d]], summon[F[e]])
+    // Add fallback for larger sizes
+  }
+
+  type LiftP[F[_], T] <: Tuple = T match {
+    case Unit => Unit
+    case a *: b => F[a] *: LiftP[F, b]
+  }
+
+  inline def summonFirst[F[_], T, U]: F[U] = summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
+
+  inline def summonFirst0[T] <: Any = inline erasedValue[T] match {
+    case _: (a *: b) => implicit match {
+      case aa: `a` => aa
+      case _ => summonFirst0[b]
+    }
+  }
+
+  given Ops {
+    inline def (gen: ProductGeneric[Obj]) toRepr [Obj] (o: Obj): gen.MirroredElemTypes = Tuple.fromProduct(o.asInstanceOf).asInstanceOf[gen.MirroredElemTypes]
+    inline def (gen: ProductGeneric[Obj]) fromRepr [Obj] (r: gen.MirroredElemTypes): Obj = gen.fromProduct(r.asInstanceOf).asInstanceOf[Obj]
+
+    inline def (inst: ProductInstances[F, T]) construct [F[_], T] (f: [t] => F[t] => t): T =
+      inst.asInstanceOf[ErasedProductInstances[F[T]]].erasedConstruct(f.asInstanceOf).asInstanceOf
+        // Note the necessary cast here
+    inline def (inst: ProductInstances[F, T]) map2 [F[_], T] (x: T, y: T)(f: [t] => (F[t], t, t) => t): T =
+      inst.asInstanceOf[ErasedProductInstances[F[T]]].erasedMap2(x, y)(f.asInstanceOf).asInstanceOf
+        // Note the necessary cast here
+  }
+
+  type ProductGenericR[O, R] = Mirror.Product { type MirroredType = O ; type MirroredElemTypes = R }
+
+  inline given mkInstances[F[_], T] as Instances[F, T] given (gen: Generic[T]) =
+    inline gen match {
+      case p: ProductGeneric[T]   => mkProductInstances[F, T] given p
+    }
+
+  inline given mkProductInstances[F[_], T] as ProductInstances[F, T] given (gen: ProductGeneric[T]) =
+    new ErasedProductInstances(gen, summonAsArray[F, gen.MirroredElemTypes]).asInstanceOf[ProductInstances[F, T]]
+
+  inline def derive[F[_], T](gen: Generic[T], pg: ProductInstances[F, T] => F[T]): F[T] =
+    inline gen match {
+      case p: ProductGeneric[T]   => pg(mkProductInstances[F, T] given p)
+    }
+}
+
+// --------------------------------------------------------------
+
+abstract class ErasedInstances[FT] {
+  def erasedMap(x: Any)(f: (Any, Any) => Any): Any
+}
+
+final class ErasedProductInstances[FT](val mirror: Mirror.Product, is0: => Array[Any]) extends ErasedInstances[FT] {
+  lazy val is = is0
+
+  inline def toProduct(x: Any): Product = x.asInstanceOf[Product]
+
+  class ArrayProduct(val elems: Array[Any]) extends Product {
+    def canEqual(that: Any): Boolean = true
+    def productElement(n: Int) = elems(n)
+    def productArity = elems.length
+    override def productIterator: Iterator[Any] = elems.iterator
+  }
+
+  def erasedConstruct(f: Any => Any): Any = {
+    val n = is.length
+    val arr = new Array[Any](n)
+    var i = 0
+    while(i < n) {
+      arr(i) = f(is(i))
+      i = i+1
+    }
+    mirror.fromProduct(ArrayProduct(arr))
+  }
+
+  def erasedUnfold(a: Any)(f: (Any, Any) => (Any, Option[Any])): (Any, Option[Any]) = {
+    val n = is.length
+    val arr = new Array[Any](n)
+    var acc = a
+    var i = 0
+    while(i < n) {
+      val (acc0, e0) = f(acc, is(i))
+      e0 match {
+        case Some(e) =>
+          acc = acc0
+          arr(i) = e
+        case None =>
+          return (acc0, None)
+      }
+      i = i+1
+    }
+    (acc, Some(mirror.fromProduct(ArrayProduct(arr))))
+  }
+
+  def erasedMap(x0: Any)(f: (Any, Any) => Any): Any = {
+    val x = toProduct(x0)
+    val n = is.length
+    val arr = new Array[Any](n)
+    var i = 0
+    while(i < n) {
+      arr(i) = f(is(i), x.productElement(i))
+      i = i+1
+    }
+    mirror.fromProduct(ArrayProduct(arr))
+  }
+
+  def erasedMap2(x0: Any, y0: Any)(f: (Any, Any, Any) => Any): Any = {
+    val x = toProduct(x0)
+    val y = toProduct(y0)
+    val n = is.length
+    val arr = new Array[Any](n)
+    var i = 0
+    while(i < n) {
+      arr(i) = f(is(i), x.productElement(i), y.productElement(i))
+      i = i+1
+    }
+    mirror.fromProduct(ArrayProduct(arr))
+  }
+
+  def erasedFoldLeft(x0: Any)(i: Any)(f: (Any, Any, Any) => CompleteOr[Any]): Any = {
+    val x = toProduct(x0)
+    val n = x.productArity
+    @tailrec
+    def loop(i: Int, acc: Any): Any =
+      if(i >= n) acc
+      else
+        f(acc, is(i), x.productElement(i)) match {
+          case Complete(r) => r
+          case Continue(acc) =>
+            loop(i+1, acc)
+        }
+
+    loop(0, i)
+  }
+
+  def erasedFoldLeft2(x0: Any, y0: Any)(i: Any)(f: (Any, Any, Any, Any) => CompleteOr[Any]): Any = {
+    val x = toProduct(x0)
+    val y = toProduct(y0)
+    val n = x.productArity
+    @tailrec
+    def loop(i: Int, acc: Any): Any =
+      if(i >= n) acc
+      else
+        f(acc, is(i), x.productElement(i), y.productElement(i)) match {
+          case Complete(r) => r
+          case Continue(acc) =>
+            loop(i+1, acc)
+        }
+
+    loop(0, i)
+  }
+}
+
+// ---------------------------------------------------
+
+type Id[t] = t
+type Const[c] = [t] =>> c
+case class Wrap[T](t: T)
+
+type ~>[A[_], B[_]] = [t] => A[t] => B[t]
+
+inline def summon[T] = implicit match {
+  case t: T => t
+}
+
+inline def summonValues[T] <: Tuple = inline erasedValue[T] match {
+  case _: Unit => ()
+  case _: (a *: b) => constValue[a] *: summonValues[b]
+}
+
+inline def summonValuesAsArray[T]: Array[Any] = inline erasedValue[Id[T]] match {
+  case _: Unit => Array()
+  case _: Tuple1[a] => Array(constValue[a])
+  case _: (a, b) => Array(constValue[a], constValue[b])
+  case _: (a, b, c) => Array(constValue[a], constValue[b], constValue[c])
+  case _: (a, b, c, d) => Array(constValue[a], constValue[b], constValue[c], constValue[d])
+  case _: (a, b, c, d, e) => Array(constValue[a], constValue[b], constValue[c], constValue[d], constValue[e])
+  // Add fallback for larger sizes
+}
+
+case class Labelling[T](label: String, elemLabels: Seq[String])
+object Labelling {
+  inline given apply[T0] as Labelling[T0] given (mirror: Mirror { type MirroredType = T0 }) =
+    Labelling[T0](
+      constValue[mirror.MirroredLabel & String],
+      WrappedArray.make[String](summonValuesAsArray[mirror.MirroredElemLabels])
+    )
+}
+
+sealed trait CompleteOr[T]
+case class Complete[T](t: T) extends CompleteOr[T]
+case class Continue[T](t: T) extends CompleteOr[T]
+
+object Complete {
+  inline def apply[T](c: Boolean)(t: T)(f: T): CompleteOr[T] =
+    if(c) Complete(t)
+    else Continue(f)
+}
+
+// ---------------------------------------------------------------------
+
+case class ISB(i: Int) derives Monoid
+
+trait Monoid[A] {
+  def empty: A
+  def combine(x: A, y: A): A
+}
+
+object Monoid {
+  given as Monoid[Int] = new Monoid[Int] {
+    def empty: Int = 0
+    def combine(x: Int, y: Int): Int = x+y
+  }
+
+  given monoidGen[A] as Monoid[A] given (inst: K0.ProductInstances[Monoid, A]) {
+    def empty: A = inst.construct([t] => (ma: Monoid[t]) => ma.empty)
+    def combine(x: A, y: A): A = inst.map2(x, y)([t] => (mt: Monoid[t], t0: t, t1: t) => mt.combine(t0, t1))
+  }
+
+  inline def derived[A] given (gen: K0.ProductGeneric[A]): Monoid[A] = monoidGen
+}
+
+
+}


### PR DESCRIPTION
When compiling shapeless, we saw an error message
```
[error] -- [E007] Type Mismatch Error: /home/miles/projects/shapeless-ng/core/src/test/scala/shapeless/type-classes.scala:53:80
[error] 53 |  inline def derived[A] given (gen: K0.ProductGeneric[A]): Monoid[A] = monoidGen
[error]    |                                                                                ^
[error]    |Found:    shapeless.K0.ProductInstances[shapeless.Monoid, shapeless.ISB]
[error]    |Required: shapeless.K0.ProductInstances[shapeless.Monoid, shapeless.ISB]
```
With -Yprint-debug that became clearer:
```
|Found:    K0.this.ProductInstances[[A] => shapeless.this.Monoid[A], shapeless.this.ISB]
|Required: shapeless.this.K0.ProductInstances[[A] => shapeless.this.Monoid[A],
```
The problem is that one of the two types thinks it is inside `K0` and dealiases to `ErasedProductInstances` while the other think it is outside and gets stuck. The weird thing
is that a type claiming to be inside an opaque scope shows up outside this scope.

This commit ensures that the type K0.this.ProductInstances does not show up outside of `K0`.
There were two places in the inliner where `M.this` for static `M` was kept as is. Normally
that's OK, but it does matter if `M` contains opaque types.

This is a partial fix only. Compared to the original shapeless code, test pos/shapeless.scala also
contains two casts (on lines 65 and 68), which would lead to inlining failures if missing.

Unfortunately, this second problem looks impossible to fix in general. We cannot simply move
code compiled inside an opaque alias scope to outside this scope. The compiler can try to insert
some casts to make it work, but I see no general proven way to do so, because opaque types are
explained through type abstraction instead of through implicit conversions.