### PR TITLE
Fix #6822: Fix self type handling for opaque types in classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -444,7 +444,7 @@ object SymDenotations {
             enclClassInfo.selfInfo match {
               case self: Type =>
                 owner.info = enclClassInfo.derivedClassInfo(
-                  selfInfo = refineSelfType(enclClassInfo.selfType))
+                  selfInfo = refineSelfType(self.orElse(defn.AnyType)))
               case self: Symbol =>
                 self.info = refineSelfType(self.info)
             }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -443,7 +443,8 @@ object SymDenotations {
             val enclClassInfo = owner.asClass.classInfo
             enclClassInfo.selfInfo match {
               case self: Type =>
-                owner.info = enclClassInfo.derivedClassInfo(selfInfo = refineSelfType(self))
+                owner.info = enclClassInfo.derivedClassInfo(
+                  selfInfo = refineSelfType(enclClassInfo.selfType))
               case self: Symbol =>
                 self.info = refineSelfType(self.info)
             }
@@ -1177,7 +1178,7 @@ object SymDenotations {
         case _ =>
           NoType
       }
-      recur(owner.asClass.classInfo.selfType)
+      recur(owner.asClass.givenSelfType)
     }
 
     /** The non-private symbol whose name and type matches the type of this symbol

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -511,7 +511,7 @@ class TreePickler(pickler: TastyPickler) {
             pickleParams(params)
             tree.parents.foreach(pickleTree)
             val cinfo @ ClassInfo(_, _, _, _, selfInfo) = tree.symbol.owner.info
-            if ((selfInfo ne NoType) || !tree.self.isEmpty) {
+            if (!tree.self.isEmpty) {
               writeByte(SELFDEF)
               pickleName(tree.self.name)
 

--- a/tests/pos/i6822.scala
+++ b/tests/pos/i6822.scala
@@ -1,0 +1,3 @@
+class C {
+  opaque type T = Int
+}


### PR DESCRIPTION
Two problems fixed:

 - selfInfo's can be NoType, so need to use the selfType as a refinement parent.
 - selfTypes for classes can be conjunctions of given self type and underlying type,
   so need to use givenselfType to extract the opaque alias.