### PR TITLE
Support implicit scope augmentation for Mirror

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -889,34 +889,11 @@ trait Implicits { self: Typer =>
    *       Scope = <scope> // if scope ne NoType
    *     }
    */
-  private def mirrorCore(parentClass: ClassSymbol, monoType: Type, mirroredType: Type, label: Name, extras: List[(Name, Type)])(implicit ctx: Context) = {
-    val m = parentClass.typeRef
+  private def mirrorCore(parentClass: ClassSymbol, monoType: Type, mirroredType: Type, label: Name, formal: Type)(implicit ctx: Context) =
+    formal & parentClass.typeRef
       .refinedWith(tpnme.MirroredMonoType, TypeAlias(monoType))
       .refinedWith(tpnme.MirroredType, TypeAlias(mirroredType))
       .refinedWith(tpnme.MirroredLabel, TypeAlias(ConstantType(Constant(label.toString))))
-
-    extras.foldLeft(m) { case (m, (tpnme, tpe)) => m.refinedWith(tpnme, tpe) }
-  }
-
-  private def extraRefinements(formal: Type)(implicit ctx: Context): List[(Name, Type)] = {
-    def isMirrorMember(nme: Name): Boolean =
-      nme == tpnme.MirroredType ||
-      nme == tpnme.MirroredMonoType ||
-      nme == tpnme.MirroredLabel ||
-      nme == tpnme.MirroredElemTypes ||
-      nme == tpnme.MirroredElemLabels
-
-    @tailrec
-    def loop(tp: Type, acc: List[(Name, Type)]): List[(Name, Type)] = tp match {
-      case RefinedType(parent, nme, rhs) if !isMirrorMember(nme) =>
-        loop(parent, (nme, rhs) :: acc)
-      case RefinedType(parent, nme, rhs) =>
-        loop(parent, acc)
-      case other =>
-        acc
-    }
-    loop(formal, Nil)
-  }
 
   /** A path referencing the companion of class type `clsType` */
   private def companionPath(clsType: Type, span: Span)(implicit ctx: Context) = {
@@ -940,12 +917,12 @@ trait Implicits { self: Typer =>
               val module = mirroredType.termSymbol
               val modulePath = pathFor(mirroredType).withSpan(span)
               if (module.info.classSymbol.is(Scala2x)) {
-                val mirrorType = mirrorCore(defn.Mirror_SingletonProxyClass, mirroredType, mirroredType, module.name, extraRefinements(formal))
+                val mirrorType = mirrorCore(defn.Mirror_SingletonProxyClass, mirroredType, mirroredType, module.name, formal)
                 val mirrorRef = New(defn.Mirror_SingletonProxyClass.typeRef, modulePath :: Nil)
                 mirrorRef.cast(mirrorType)
               }
               else {
-                val mirrorType = mirrorCore(defn.Mirror_SingletonClass, mirroredType, mirroredType, module.name, extraRefinements(formal))
+                val mirrorType = mirrorCore(defn.Mirror_SingletonClass, mirroredType, mirroredType, module.name, formal)
                 modulePath.cast(mirrorType)
               }
             }
@@ -967,7 +944,7 @@ trait Implicits { self: Typer =>
                   (mirroredType, elems)
               }
               val mirrorType =
-                mirrorCore(defn.Mirror_ProductClass, monoType, mirroredType, cls.name, extraRefinements(formal))
+                mirrorCore(defn.Mirror_ProductClass, monoType, mirroredType, cls.name, formal)
                   .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
                   .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
               val mirrorRef =
@@ -1048,7 +1025,7 @@ trait Implicits { self: Typer =>
             }
 
             val mirrorType =
-               mirrorCore(defn.Mirror_SumClass, monoType, mirroredType, cls.name, extraRefinements(formal))
+               mirrorCore(defn.Mirror_SumClass, monoType, mirroredType, cls.name, formal)
                 .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
                 .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
             val mirrorRef =

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -901,6 +901,16 @@ trait Implicits { self: Typer =>
     ref.withSpan(span)
   }
 
+  private def checkFormal(formal: Type)(implicit ctx: Context): Boolean = {
+    @tailrec
+    def loop(tp: Type): Boolean = tp match {
+      case RefinedType(_, _, _: MethodicType) => false
+      case RefinedType(parent, _, _) => loop(parent)
+      case _ => true
+    }
+    loop(formal)
+  }
+
   /** An implied instance for a type of the form `Mirror.Product { type MirroredType = T }`
    *  where `T` is a generic product type or a case object or an enum case.
    */
@@ -955,10 +965,12 @@ trait Implicits { self: Typer =>
         }
       }
 
-      formal.member(tpnme.MirroredType).info match {
-        case TypeBounds(mirroredType, _) => mirrorFor(mirroredType)
-        case other => EmptyTree
-      }
+      if (!checkFormal(formal)) EmptyTree
+      else
+        formal.member(tpnme.MirroredType).info match {
+          case TypeBounds(mirroredType, _) if checkFormal(formal) => mirrorFor(mirroredType)
+          case other => EmptyTree
+        }
     }
 
   /** An implied instance for a type of the form `Mirror.Sum { type MirroredType = T }`
@@ -966,74 +978,76 @@ trait Implicits { self: Typer =>
    */
   lazy val synthesizedSumMirror: SpecialHandler =
     (formal, span) => implicit ctx => {
-      formal.member(tpnme.MirroredType).info match {
-        case TypeBounds(mirroredType0, _) =>
-          val mirroredType = mirroredType0.stripTypeVar
-          if (mirroredType.classSymbol.isGenericSum) {
-            val cls = mirroredType.classSymbol
-            val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))
+      if (!checkFormal(formal)) EmptyTree
+      else
+        formal.member(tpnme.MirroredType).info match {
+          case TypeBounds(mirroredType0, _) =>
+            val mirroredType = mirroredType0.stripTypeVar
+            if (mirroredType.classSymbol.isGenericSum) {
+              val cls = mirroredType.classSymbol
+              val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))
 
-            def solve(sym: Symbol): Type = sym match {
-              case caseClass: ClassSymbol =>
-                assert(caseClass.is(Case))
-                if (caseClass.is(Module))
-                  caseClass.sourceModule.termRef
-                else {
-                  caseClass.primaryConstructor.info match {
-                    case info: PolyType =>
-                      // Compute the the full child type by solving the subtype constraint
-                      // `C[X1, ..., Xn] <: P`, where
-                      //
-                      //   - P is the current `mirroredType`
-                      //   - C is the child class, with type parameters X1, ..., Xn
-                      //
-                      // Contravariant type parameters are minimized, all other type parameters are maximized.
-                      def instantiate(implicit ctx: Context) = {
-                        val poly = constrained(info, untpd.EmptyTree)._1
-                        val resType = poly.finalResultType
-                        val target = mirroredType match {
-                          case tp: HKTypeLambda => tp.resultType
-                          case tp => tp
+              def solve(sym: Symbol): Type = sym match {
+                case caseClass: ClassSymbol =>
+                  assert(caseClass.is(Case))
+                  if (caseClass.is(Module))
+                    caseClass.sourceModule.termRef
+                  else {
+                    caseClass.primaryConstructor.info match {
+                      case info: PolyType =>
+                        // Compute the the full child type by solving the subtype constraint
+                        // `C[X1, ..., Xn] <: P`, where
+                        //
+                        //   - P is the current `mirroredType`
+                        //   - C is the child class, with type parameters X1, ..., Xn
+                        //
+                        // Contravariant type parameters are minimized, all other type parameters are maximized.
+                        def instantiate(implicit ctx: Context) = {
+                          val poly = constrained(info, untpd.EmptyTree)._1
+                          val resType = poly.finalResultType
+                          val target = mirroredType match {
+                            case tp: HKTypeLambda => tp.resultType
+                            case tp => tp
+                          }
+                          resType <:< target
+                          val tparams = poly.paramRefs
+                          val variances = caseClass.typeParams.map(_.paramVariance)
+                          val instanceTypes = (tparams, variances).zipped.map((tparam, variance) =>
+                            ctx.typeComparer.instanceType(tparam, fromBelow = variance < 0))
+                          resType.substParams(poly, instanceTypes)
                         }
-                        resType <:< target
-                        val tparams = poly.paramRefs
-                        val variances = caseClass.typeParams.map(_.paramVariance)
-                        val instanceTypes = (tparams, variances).zipped.map((tparam, variance) =>
-                          ctx.typeComparer.instanceType(tparam, fromBelow = variance < 0))
-                        resType.substParams(poly, instanceTypes)
-                      }
-                      instantiate(ctx.fresh.setExploreTyperState().setOwner(caseClass))
-                    case _ =>
-                      caseClass.typeRef
+                        instantiate(ctx.fresh.setExploreTyperState().setOwner(caseClass))
+                      case _ =>
+                        caseClass.typeRef
+                    }
                   }
-                }
-              case child => child.termRef
-            }
+                case child => child.termRef
+              }
 
-            val (monoType, elemsType) = mirroredType match {
-              case mirroredType: HKTypeLambda =>
-                val elems = mirroredType.derivedLambdaType(
-                  resType = TypeOps.nestedPairs(cls.children.map(solve))
-                )
-                val AppliedType(tycon, _) = mirroredType.resultType
-                val monoType = AppliedType(tycon, mirroredType.paramInfos)
-                (monoType, elems)
-              case _ =>
-                val elems = TypeOps.nestedPairs(cls.children.map(solve))
-                (mirroredType, elems)
-            }
+              val (monoType, elemsType) = mirroredType match {
+                case mirroredType: HKTypeLambda =>
+                  val elems = mirroredType.derivedLambdaType(
+                    resType = TypeOps.nestedPairs(cls.children.map(solve))
+                  )
+                  val AppliedType(tycon, _) = mirroredType.resultType
+                  val monoType = AppliedType(tycon, mirroredType.paramInfos)
+                  (monoType, elems)
+                case _ =>
+                  val elems = TypeOps.nestedPairs(cls.children.map(solve))
+                  (mirroredType, elems)
+              }
 
-            val mirrorType =
-               mirrorCore(defn.Mirror_SumClass, monoType, mirroredType, cls.name, formal)
-                .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
-                .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
-            val mirrorRef =
-              if (cls.linkedClass.exists && !cls.is(Scala2x)) companionPath(mirroredType, span)
-              else anonymousMirror(monoType, ExtendsSumMirror, span)
-            mirrorRef.cast(mirrorType)
-          } else EmptyTree
-        case _ => EmptyTree
-      }
+              val mirrorType =
+                 mirrorCore(defn.Mirror_SumClass, monoType, mirroredType, cls.name, formal)
+                  .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
+                  .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
+              val mirrorRef =
+                if (cls.linkedClass.exists && !cls.is(Scala2x)) companionPath(mirroredType, span)
+                else anonymousMirror(monoType, ExtendsSumMirror, span)
+              mirrorRef.cast(mirrorType)
+            } else EmptyTree
+          case _ => EmptyTree
+        }
     }
 
   /** An implied instance for a type of the form `Mirror { type MirroredType = T }`

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -904,8 +904,8 @@ trait Implicits { self: Typer =>
   private def checkFormal(formal: Type)(implicit ctx: Context): Boolean = {
     @tailrec
     def loop(tp: Type): Boolean = tp match {
-      case RefinedType(_, _, _: MethodicType) => false
-      case RefinedType(parent, _, _) => loop(parent)
+      case RefinedType(parent, _, _: TypeBounds) => loop(parent)
+      case RefinedType(_, _, _) => false
       case _ => true
     }
     loop(formal)

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -885,8 +885,7 @@ trait Implicits { self: Typer =>
    *     <parent> {
    *       MirroredMonoType = <monoType>
    *       MirroredType = <mirroredType>
-   *       MirroredLabel = <label>
-   *       Scope = <scope> // if scope ne NoType
+   *       MirroredLabel = <label> }
    *     }
    */
   private def mirrorCore(parentClass: ClassSymbol, monoType: Type, mirroredType: Type, label: Name, formal: Type)(implicit ctx: Context) =

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -968,7 +968,7 @@ trait Implicits { self: Typer =>
       if (!checkFormal(formal)) EmptyTree
       else
         formal.member(tpnme.MirroredType).info match {
-          case TypeBounds(mirroredType, _) if checkFormal(formal) => mirrorFor(mirroredType)
+          case TypeBounds(mirroredType, _) => mirrorFor(mirroredType)
           case other => EmptyTree
         }
     }

--- a/tests/neg/mirror-implicit-scope.scala
+++ b/tests/neg/mirror-implicit-scope.scala
@@ -11,4 +11,5 @@ object Test {
   val v3 = the[Mirror.Product { type MirroredType = ISB ; def foo: Int }] // error
   val v4 = the[Mirror.Product { type MirroredType = ISB ; def foo(i: Int): Int }] // error
   val v5 = the[Mirror.Product { type MirroredType = ISB ; def foo[T](t: T): T }] // error // error
+  val v6 = the[Mirror.Product { type MirroredType = ISB ; val foo: Int }] // error
 }

--- a/tests/neg/mirror-implicit-scope.scala
+++ b/tests/neg/mirror-implicit-scope.scala
@@ -1,0 +1,14 @@
+import scala.deriving._
+
+object Test {
+  class SomeClass
+  case class ISB(i: Int, s: String, b: Boolean)
+  case class BI(b: Boolean, i: Int)
+
+  val v0 = the[Mirror.ProductOf[ISB]] // OK
+  val v1 = the[SomeClass & Mirror.ProductOf[ISB]] // error
+  val v2 = the[Mirror.ProductOf[ISB] & Mirror.ProductOf[BI]] // error
+  val v3 = the[Mirror.Product { type MirroredType = ISB ; def foo: Int }] // error
+  val v4 = the[Mirror.Product { type MirroredType = ISB ; def foo(i: Int): Int }] // error
+  val v5 = the[Mirror.Product { type MirroredType = ISB ; def foo[T](t: T): T }] // error // error
+}

--- a/tests/pos/mirror-implicit-scope.scala
+++ b/tests/pos/mirror-implicit-scope.scala
@@ -1,0 +1,27 @@
+import scala.deriving._
+
+object Test {
+  object K0 {
+    type Generic[T] = Mirror { type Scope = K0.type ; type MirroredType = T ; type MirroredElemTypes }
+    given Ops {
+      inline def (gen: Generic[T]) toRepr[T <: Product](t: T): gen.MirroredElemTypes = Tuple.fromProduct(t).asInstanceOf
+    }
+  }
+
+  object K1 {
+    type Generic[F[_]] = Mirror { type Scope = K1.type ; type MirroredType = F ; type MirroredElemTypes[_] }
+    given Ops {
+      inline def (gen: Generic[F]) toRepr[F[_] <: Product, T](t: F[T]): gen.MirroredElemTypes[T] = Tuple.fromProduct(t).asInstanceOf
+    }
+  }
+
+  case class ISB(i: Int, s: String, b: Boolean)
+  val v0 = the[K0.Generic[ISB]]
+  val v1 = v0.toRepr(ISB(23, "foo", true))
+  val v2: (Int, String, Boolean) = v1
+
+  case class Box[T](t: T)
+  val v3 = the[K1.Generic[Box]]
+  val v4 = v3.toRepr(Box(23))
+  val v5: Tuple1[Int] = v4
+}


### PR DESCRIPTION
`Mirrors` can now be materialized with additional type member refinements. Any additional type members will contribute to the implicit scope of any searches involving the type of the summoned `Mirror`.  Typically such types will be the singleton types of objects containing implicit extension methods for the `Mirror`, or other related implicit definitions.

Given,

```scala
case class Foo(i: Int)

the[Mirror.Product { type MirroredType = Foo ; type Phantom = Other.type }]
```

then requested type (`formal` in the code) will be,

```scala
Mirror.Product { type MirroredType = Foo ; type Phantom = Other }
```
and the core synthesized mirror type will be,

```scala
Mirror.Product {
  type MirroredType = Foo
  type MirroedMonoType = Foo
  type Label = "Foo"
  type MirroredElemTypes = Tuple1[Int]
  type MirroredElemLabels = Tuple1["i"]
}
```
The result of intersecting these two is then,
```scala
Mirror.Product {
  type MirroredType = Foo
  type MirroedMonoType = Foo
  type Label = "Foo"
  type MirroredElemTypes = Tuple1[Int]
  type MirroredElemLabels = Tuple1["i"]
  type Phantom = Other.type
}
```

That's the refined type that we'll get for the mirror as a given argument, so if we have an object `Other` containing extension methods like so,

```scala
object Other {
  given Ops {
    def (m: Mirror.Product { type MirroredType = T }) extension [T]
  }
}
```
they will be found because the contents of `Other` is included in the implicit scope for the extension method search via the parts of the refined type of the mirror.
