### PR TITLE
Drop Per-Run infrastructure in Definitions

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -139,7 +139,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   val externalEqualsNumNum: Symbol = defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumNum)
   val externalEqualsNumChar: Symbol = NoSymbol // ctx.requiredMethod(BoxesRunTimeTypeRef, nme.equalsNumChar) // this method is private
   val externalEqualsNumObject: Symbol = defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumObject)
-  val externalEquals: Symbol = defn.BoxesRunTimeClass.info.decl(nme.equals_).suchThat(toDenot(_).info.firstParamTypes.size == 2).symbol
+  val externalEquals: Symbol = defn.BoxesRunTimeModule.info.decl(nme.equals_).suchThat(toDenot(_).info.firstParamTypes.size == 2).symbol
   val MaxFunctionArity: Int = Definitions.MaxImplementedFunctionArity
   val FunctionClass: Array[Symbol] = defn.FunctionClassPerRun()
   val AbstractFunctionClass: Array[Symbol] = defn.AbstractFunctionClassPerRun()

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -141,8 +141,8 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   val externalEqualsNumObject: Symbol = defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumObject)
   val externalEquals: Symbol = defn.BoxesRunTimeModule.info.decl(nme.equals_).suchThat(toDenot(_).info.firstParamTypes.size == 2).symbol
   val MaxFunctionArity: Int = Definitions.MaxImplementedFunctionArity
-  val FunctionClass: Array[Symbol] = defn.FunctionClassPerRun()
-  val AbstractFunctionClass: Array[Symbol] = defn.AbstractFunctionClassPerRun()
+  val FunctionClass: Array[Symbol] = defn.FunctionClass
+  val AbstractFunctionClass: Array[Symbol] = defn.AbstractFunctionClass
   val PartialFunctionClass: Symbol = defn.PartialFunctionClass
   val AbstractPartialFunctionClass: Symbol = defn.AbstractPartialFunctionClass
   val String_valueOf: Symbol = defn.String_valueOf_Object

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -154,11 +154,11 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   @threadUnsafe lazy val AnnotationRetentionRuntimeAttr: TermSymbol = ctx.requiredClass("java.lang.annotation.RetentionPolicy").linkedClass.requiredValue("RUNTIME")
   @threadUnsafe lazy val JavaAnnotationClass: ClassSymbol = ctx.requiredClass("java.lang.annotation.Annotation")
 
-  def boxMethods: Map[Symbol, Symbol] = defn.ScalaValueClasses().map{x => // @darkdimius Are you sure this should be a def?
+  def boxMethods: Map[Symbol, Symbol] = defn.ScalaValueClasses.map{x => // @darkdimius Are you sure this should be a def?
     (x, Erasure.Boxing.boxMethod(x.asClass))
   }.toMap
   def unboxMethods: Map[Symbol, Symbol] =
-    defn.ScalaValueClasses().map(x => (x, Erasure.Boxing.unboxMethod(x.asClass))).toMap
+    defn.ScalaValueClasses.map(x => (x, Erasure.Boxing.unboxMethod(x.asClass))).toMap
 
   override def isSyntheticArrayConstructor(s: Symbol): Boolean = {
     s eq defn.newArrayMethod

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -1636,7 +1636,7 @@ class JSCodeGen()(implicit ctx: Context) {
   private lazy val externalEqualsNumObject: Symbol =
     defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumObject)
   private lazy val externalEquals: Symbol =
-    defn.BoxesRunTimeClass.info.decl(nme.equals_).suchThat(toDenot(_).info.firstParamTypes.size == 2).symbol
+    defn.BoxesRunTimeModule.info.decl(nme.equals_).suchThat(toDenot(_).info.firstParamTypes.size == 2).symbol
 
   /** Gen JS code for a call to Any.== */
   private def genEqEqPrimitive(ltpe: Type, rtpe: Type, lsrc: js.Tree, rsrc: js.Tree)(

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -2696,7 +2696,7 @@ class JSCodeGen()(implicit ctx: Context) {
 
   private object WrapArray {
     lazy val isWrapArray: Set[Symbol] = {
-      val names0 = defn.ScalaValueClasses().map(sym => nme.wrapXArray(sym.name))
+      val names0 = defn.ScalaValueClasses.map(sym => nme.wrapXArray(sym.name))
       val names1 = names0 ++ Set(nme.wrapRefArray, nme.genericWrapArray)
       val names2 = names1.map(defn.ScalaPredefModule.requiredMethod(_))
       names2.toSet

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -641,7 +641,7 @@ object desugar {
     else if (isObject)
       parents1 = parents1 :+ scalaDot(nme.Serializable.toTypeName)
     if (isEnum)
-      parents1 = parents1 :+ ref(defn.EnumType)
+      parents1 = parents1 :+ ref(defn.EnumClass.typeRef)
 
     // derived type classes of non-module classes go to their companions
     val (clsDerived, companionDerived) =
@@ -984,7 +984,7 @@ object desugar {
   def makeSelector(sel: Tree, checkMode: MatchCheck)(implicit ctx: Context): Tree =
     if (checkMode == MatchCheck.Exhaustive) sel
     else {
-      val sel1 = Annotated(sel, New(ref(defn.UncheckedAnnotType)))
+      val sel1 = Annotated(sel, New(ref(defn.UncheckedAnnot.typeRef)))
       if (checkMode != MatchCheck.None) sel1.pushAttachment(CheckIrrefutable, checkMode)
       sel1
     }
@@ -1560,7 +1560,7 @@ object desugar {
           val seqType = if (ctx.compilationUnit.isJava) defn.ArrayType else defn.SeqType
           Annotated(
             AppliedTypeTree(ref(seqType), t),
-            New(ref(defn.RepeatedAnnotType), Nil :: Nil))
+            New(ref(defn.RepeatedAnnot.typeRef), Nil :: Nil))
         } else {
           assert(ctx.mode.isExpr || ctx.reporter.errorsReported || ctx.mode.is(Mode.Interactive), ctx.mode)
           Select(t, op.name)

--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -98,7 +98,7 @@ object DesugarEnums {
         .withFlags(Synthetic)
     val privateValuesDef =
       ValDef(nme.DOLLAR_VALUES, TypeTree(),
-        New(TypeTree(defn.EnumValuesType.appliedTo(enumClass.typeRef :: Nil)), ListOfNil))
+        New(TypeTree(defn.EnumValuesClass.typeRef.appliedTo(enumClass.typeRef :: Nil)), ListOfNil))
         .withFlags(Private)
 
     val valuesOfExnMessage = Apply(

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1351,7 +1351,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   /** Creates the nested pairs type tree repesentation of the type trees in `ts` */
   def nestedPairsTypeTree(ts: List[Tree])(implicit ctx: Context): Tree =
-    ts.foldRight[Tree](TypeTree(defn.UnitType))((x, acc) => AppliedTypeTree(TypeTree(defn.PairType), x :: acc :: Nil))
+    ts.foldRight[Tree](TypeTree(defn.UnitType))((x, acc) => AppliedTypeTree(TypeTree(defn.PairClass.typeRef), x :: acc :: Nil))
 
   /** Replaces all positions in `tree` with zero-extent positions */
   private def focusPositions(tree: Tree)(implicit ctx: Context): Tree = {

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -966,7 +966,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       val sym = tree.symbol
       if (sym.is(Method)) {
         val setter = sym.setter.orElse {
-          assert(sym.name.isSetterName && sym.info.firstParamTypes.nonEmpty)
+          assert(sym.name.isSetterName && sym.info.firstParamTypes.nonEmpty, sym)
           sym
         }
         val qual = tree match {

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -163,7 +163,7 @@ object Annotations {
       def later(delayedSym: given Context => Symbol, span: Span)(implicit ctx: Context): Annotation = {
         def makeChildLater(implicit ctx: Context) = {
           val sym = delayedSym
-          New(defn.ChildAnnotType.appliedTo(sym.owner.thisType.select(sym.name, sym)), Nil)
+          New(defn.ChildAnnot.typeRef.appliedTo(sym.owner.thisType.select(sym.name, sym)), Nil)
             .withSpan(span)
         }
         deferred(defn.ChildAnnot)(makeChildLater(ctx))
@@ -202,7 +202,7 @@ object Annotations {
 
   def ThrowsAnnotation(cls: ClassSymbol)(implicit ctx: Context): Annotation = {
     val tref = cls.typeRef
-    Annotation(defn.ThrowsAnnotType.appliedTo(tref), Ident(tref))
+    Annotation(defn.ThrowsAnnot.typeRef.appliedTo(tref), Ident(tref))
   }
 
   /** A decorator that provides queries for specific annotations

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -228,21 +228,16 @@ class Definitions {
   @threadUnsafe lazy val JavaLangPackageVal: TermSymbol = ctx.requiredPackage(jnme.JavaLang)
   // fundamental modules
   @threadUnsafe lazy val SysPackage: TermSymbol = ctx.requiredModule("scala.sys.package")
-    @threadUnsafe lazy val Sys_errorR: TermRef = SysPackage.moduleClass.requiredMethodRef(nme.error)
-    def Sys_error(implicit ctx: Context): Symbol = Sys_errorR.symbol
+    @threadUnsafe lazy val Sys_error: SymbolPerRun = perRun(SysPackage.moduleClass.requiredMethodRef(nme.error))
 
   @threadUnsafe lazy val ScalaXmlPackageClass: Symbol = ctx.getPackageClassIfDefined("scala.xml")
 
   @threadUnsafe lazy val CompiletimePackageObjectRef: TermRef = ctx.requiredModuleRef("scala.compiletime.package")
   @threadUnsafe lazy val CompiletimePackageObject: Symbol = CompiletimePackageObjectRef.symbol.moduleClass
-    @threadUnsafe lazy val Compiletime_errorR: TermRef = CompiletimePackageObjectRef.symbol.requiredMethodRef(nme.error)
-    def Compiletime_error(implicit ctx: Context): Symbol = Compiletime_errorR.symbol
-    @threadUnsafe lazy val Compiletime_constValueR: TermRef = CompiletimePackageObjectRef.symbol.requiredMethodRef("constValue")
-    def Compiletime_constValue(implicit ctx: Context): Symbol = Compiletime_constValueR.symbol
-    @threadUnsafe lazy val Compiletime_constValueOptR: TermRef = CompiletimePackageObjectRef.symbol.requiredMethodRef("constValueOpt")
-    def Compiletime_constValueOpt(implicit ctx: Context): Symbol = Compiletime_constValueOptR.symbol
-    @threadUnsafe lazy val Compiletime_codeR: TermRef = CompiletimePackageObjectRef.symbol.requiredMethodRef("code")
-    def Compiletime_code(implicit ctx: Context): Symbol = Compiletime_codeR.symbol
+    @threadUnsafe lazy val Compiletime_error        : SymbolPerRun = perRun(CompiletimePackageObjectRef.symbol.requiredMethodRef(nme.error))
+    @threadUnsafe lazy val Compiletime_constValue   : SymbolPerRun = perRun(CompiletimePackageObjectRef.symbol.requiredMethodRef("constValue"))
+    @threadUnsafe lazy val Compiletime_constValueOpt: SymbolPerRun = perRun(CompiletimePackageObjectRef.symbol.requiredMethodRef("constValueOpt"))
+    @threadUnsafe lazy val Compiletime_code         : SymbolPerRun = perRun(CompiletimePackageObjectRef.symbol.requiredMethodRef("code"))
 
   /** The `scalaShadowing` package is used to safely modify classes and
    *  objects in scala so that they can be used from dotty. They will
@@ -371,12 +366,9 @@ class Definitions {
 
   @threadUnsafe lazy val ScalaPredefModuleRef: TermRef = ctx.requiredModuleRef("scala.Predef")
   def ScalaPredefModule(implicit ctx: Context): Symbol = ScalaPredefModuleRef.symbol
-    @threadUnsafe lazy val Predef_conformsR: TermRef = ScalaPredefModule.requiredMethodRef(nme.conforms_)
-    def Predef_conforms(implicit ctx: Context): Symbol = Predef_conformsR.symbol
-    @threadUnsafe lazy val Predef_classOfR: TermRef = ScalaPredefModule.requiredMethodRef(nme.classOf)
-    def Predef_classOf(implicit ctx: Context): Symbol = Predef_classOfR.symbol
-    @threadUnsafe lazy val Predef_undefinedR: TermRef = ScalaPredefModule.requiredMethodRef(nme.???)
-    def Predef_undefined(implicit ctx: Context): Symbol = Predef_undefinedR.symbol
+    @threadUnsafe lazy val Predef_conforms : SymbolPerRun = perRun(ScalaPredefModule.requiredMethodRef(nme.conforms_))
+    @threadUnsafe lazy val Predef_classOf  : SymbolPerRun = perRun(ScalaPredefModule.requiredMethodRef(nme.classOf))
+    @threadUnsafe lazy val Predef_undefined: SymbolPerRun = perRun(ScalaPredefModule.requiredMethodRef(nme.???))
 
   def SubTypeClass(implicit ctx: Context): ClassSymbol =
     if (isNewCollections)
@@ -452,26 +444,21 @@ class Definitions {
     if (isNewCollections) ctx.requiredClassRef("scala.collection.immutable.Seq")
     else ctx.requiredClassRef("scala.collection.Seq")
   def SeqClass: ClassSymbol = perRunClass(SeqType)
-
-    @threadUnsafe lazy val Seq_apply: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.apply))
-    @threadUnsafe lazy val Seq_head: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.head))
-    @threadUnsafe lazy val Seq_drop: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.drop))
+    @threadUnsafe lazy val Seq_apply        : SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.apply))
+    @threadUnsafe lazy val Seq_head         : SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.head))
+    @threadUnsafe lazy val Seq_drop         : SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.drop))
     @threadUnsafe lazy val Seq_lengthCompare: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.lengthCompare, List(IntType)))
-    @threadUnsafe lazy val Seq_length: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.length))
-    @threadUnsafe lazy val Seq_toSeq: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.toSeq))
+    @threadUnsafe lazy val Seq_length       : SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.length))
+    @threadUnsafe lazy val Seq_toSeq        : SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.toSeq))
 
   @threadUnsafe lazy val ArrayType: TypeRef = ctx.requiredClassRef("scala.Array")
   def ArrayClass(implicit ctx: Context): ClassSymbol = ArrayType.symbol.asClass
-    @threadUnsafe lazy val Array_applyR: TermRef                 = ArrayClass.requiredMethodRef(nme.apply)
-    def Array_apply(implicit ctx: Context): Symbol = Array_applyR.symbol
-    @threadUnsafe lazy val Array_updateR: TermRef                = ArrayClass.requiredMethodRef(nme.update)
-    def Array_update(implicit ctx: Context): Symbol = Array_updateR.symbol
-    @threadUnsafe lazy val Array_lengthR: TermRef                = ArrayClass.requiredMethodRef(nme.length)
-    def Array_length(implicit ctx: Context): Symbol = Array_lengthR.symbol
-    @threadUnsafe lazy val Array_cloneR: TermRef                 = ArrayClass.requiredMethodRef(nme.clone_)
-    def Array_clone(implicit ctx: Context): Symbol = Array_cloneR.symbol
-    @threadUnsafe lazy val ArrayConstructorR: TermRef            = ArrayClass.requiredMethodRef(nme.CONSTRUCTOR)
-    def ArrayConstructor(implicit ctx: Context): Symbol = ArrayConstructorR.symbol
+    @threadUnsafe lazy val Array_apply     : SymbolPerRun = perRun(ArrayClass.requiredMethodRef(nme.apply))
+    @threadUnsafe lazy val Array_update    : SymbolPerRun = perRun(ArrayClass.requiredMethodRef(nme.update))
+    @threadUnsafe lazy val Array_length    : SymbolPerRun = perRun(ArrayClass.requiredMethodRef(nme.length))
+    @threadUnsafe lazy val Array_clone     : SymbolPerRun = perRun(ArrayClass.requiredMethodRef(nme.clone_))
+    @threadUnsafe lazy val ArrayConstructor: SymbolPerRun = perRun(ArrayClass.requiredMethodRef(nme.CONSTRUCTOR))
+
   @threadUnsafe lazy val ArrayModuleType: TermRef = ctx.requiredModuleRef("scala.Array")
   def ArrayModule(implicit ctx: Context): ClassSymbol = ArrayModuleType.symbol.moduleClass.asClass
 
@@ -481,22 +468,19 @@ class Definitions {
   def UnitModuleClass(implicit ctx: Context): Symbol = UnitType.symbol.asClass.linkedClass
   @threadUnsafe lazy val BooleanType: TypeRef = valueTypeRef("scala.Boolean", java.lang.Boolean.TYPE, BooleanEnc, nme.specializedTypeNames.Boolean)
   def BooleanClass(implicit ctx: Context): ClassSymbol = BooleanType.symbol.asClass
-    @threadUnsafe lazy val Boolean_notR: TermRef   = BooleanClass.requiredMethodRef(nme.UNARY_!)
-    def Boolean_! : Symbol = Boolean_notR.symbol
-    @threadUnsafe lazy val Boolean_andR: TermRef = BooleanClass.requiredMethodRef(nme.ZAND) // ### harmonize required... calls
-    def Boolean_&& : Symbol = Boolean_andR.symbol
-    @threadUnsafe lazy val Boolean_orR: TermRef  = BooleanClass.requiredMethodRef(nme.ZOR)
-    def Boolean_|| : Symbol = Boolean_orR.symbol
-    @threadUnsafe lazy val Boolean_eqeqR: SingleDenotation = BooleanClass.info.member(nme.EQ).suchThat(_.info.firstParamTypes match {
-      case List(pt) => (pt isRef BooleanClass)
-      case _ => false
-    })
-    def Boolean_== : Symbol = Boolean_eqeqR.symbol
-    @threadUnsafe lazy val Boolean_neqeqR: SingleDenotation = BooleanClass.info.member(nme.NE).suchThat(_.info.firstParamTypes match {
-      case List(pt) => (pt isRef BooleanClass)
-      case _ => false
-    })
-    def Boolean_!= : Symbol = Boolean_neqeqR.symbol
+    @threadUnsafe lazy val Boolean_!  : SymbolPerRun = perRun(BooleanClass.requiredMethodRef(nme.UNARY_!))
+    @threadUnsafe lazy val Boolean_&& : SymbolPerRun = perRun(BooleanClass.requiredMethodRef(nme.ZAND)) // ### harmonize required... calls
+    @threadUnsafe lazy val Boolean_|| : SymbolPerRun = perRun(BooleanClass.requiredMethodRef(nme.ZOR))
+    @threadUnsafe lazy val Boolean_== : SymbolPerRun = perRun(
+      BooleanClass.info.member(nme.EQ).suchThat(_.info.firstParamTypes match {
+        case List(pt) => (pt isRef BooleanClass)
+        case _ => false
+      }).symbol.termRef)
+    @threadUnsafe lazy val Boolean_!= : SymbolPerRun = perRun(
+      BooleanClass.info.member(nme.NE).suchThat(_.info.firstParamTypes match {
+        case List(pt) => (pt isRef BooleanClass)
+        case _ => false
+      }).symbol.termRef)
 
   @threadUnsafe lazy val ByteType: TypeRef = valueTypeRef("scala.Byte", java.lang.Byte.TYPE, ByteEnc, nme.specializedTypeNames.Byte)
   def ByteClass(implicit ctx: Context): ClassSymbol = ByteType.symbol.asClass
@@ -661,33 +645,23 @@ class Definitions {
 
   @threadUnsafe lazy val StringAddType: TypeRef          = ctx.requiredClassRef("scala.runtime.StringAdd")
   def StringAddClass(implicit ctx: Context): ClassSymbol = StringAddType.symbol.asClass
-
-    @threadUnsafe lazy val StringAdd_plusR: TermRef = StringAddClass.requiredMethodRef(nme.raw.PLUS)
-    def StringAdd_+(implicit ctx: Context): Symbol = StringAdd_plusR.symbol
+    @threadUnsafe lazy val StringAdd_+ : SymbolPerRun = perRun(StringAddClass.requiredMethodRef(nme.raw.PLUS))
 
   @threadUnsafe lazy val StringContextType: TypeRef       = ctx.requiredClassRef("scala.StringContext")
   def StringContextClass(implicit ctx: Context): ClassSymbol = StringContextType.symbol.asClass
-    @threadUnsafe lazy val StringContextSR: TermRef = StringContextClass.requiredMethodRef(nme.s)
-    def StringContextS(implicit ctx: Context): Symbol = StringContextSR.symbol
-    @threadUnsafe lazy val StringContextRawR: TermRef = StringContextClass.requiredMethodRef(nme.raw_)
-    def StringContextRaw(implicit ctx: Context): Symbol = StringContextRawR.symbol
-    @threadUnsafe lazy val StringContext_fR: TermRef = StringContextClass.requiredMethodRef(nme.f)
-    def StringContext_f(implicit ctx: Context): Symbol = StringContext_fR.symbol
+    @threadUnsafe lazy val StringContextS  : SymbolPerRun = perRun(StringContextClass.requiredMethodRef(nme.s))
+    @threadUnsafe lazy val StringContextRaw: SymbolPerRun = perRun(StringContextClass.requiredMethodRef(nme.raw_))
+    @threadUnsafe lazy val StringContext_f : SymbolPerRun = perRun(StringContextClass.requiredMethodRef(nme.f))
   def StringContextModule(implicit ctx: Context): Symbol = StringContextClass.companionModule
-    @threadUnsafe lazy val StringContextModule_applyR: TermRef = StringContextModule.requiredMethodRef(nme.apply)
-    def StringContextModule_apply(implicit ctx: Context): Symbol = StringContextModule_applyR.symbol
+    @threadUnsafe lazy val StringContextModule_apply: SymbolPerRun = perRun(StringContextModule.requiredMethodRef(nme.apply))
 
-  @threadUnsafe lazy val InternalStringContextMacroModuleR: TermRef = ctx.requiredModuleRef("dotty.internal.StringContextMacro")
-  def InternalStringContextMacroModule(implicit ctx: Context): Symbol = InternalStringContextMacroModuleR.termSymbol
-    @threadUnsafe lazy val InternalStringContextMacroModule_fR: TermRef = InternalStringContextMacroModule.requiredMethodRef(nme.f)
-    def InternalStringContextMacroModule_f(implicit ctx: Context): Symbol = InternalStringContextMacroModule_fR.symbol
+  @threadUnsafe lazy val InternalStringContextMacroModule: SymbolPerRun = perRun(ctx.requiredModuleRef("dotty.internal.StringContextMacro"))
+    @threadUnsafe lazy val InternalStringContextMacroModule_f: SymbolPerRun = perRun(InternalStringContextMacroModule.requiredMethodRef(nme.f))
 
   @threadUnsafe lazy val PartialFunctionType: TypeRef         = ctx.requiredClassRef("scala.PartialFunction")
   def PartialFunctionClass(implicit ctx: Context): ClassSymbol = PartialFunctionType.symbol.asClass
-    @threadUnsafe lazy val PartialFunction_isDefinedAtR: TermRef = PartialFunctionClass.requiredMethodRef(nme.isDefinedAt)
-    def PartialFunction_isDefinedAt(implicit ctx: Context): Symbol = PartialFunction_isDefinedAtR.symbol
-    @threadUnsafe lazy val PartialFunction_applyOrElseR: TermRef = PartialFunctionClass.requiredMethodRef(nme.applyOrElse)
-    def PartialFunction_applyOrElse(implicit ctx: Context): Symbol = PartialFunction_applyOrElseR.symbol
+    @threadUnsafe lazy val PartialFunction_isDefinedAt: SymbolPerRun = perRun(PartialFunctionClass.requiredMethodRef(nme.isDefinedAt))
+    @threadUnsafe lazy val PartialFunction_applyOrElse: SymbolPerRun = perRun(PartialFunctionClass.requiredMethodRef(nme.applyOrElse))
 
   @threadUnsafe lazy val AbstractPartialFunctionType: TypeRef = ctx.requiredClassRef("scala.runtime.AbstractPartialFunction")
   def AbstractPartialFunctionClass(implicit ctx: Context): ClassSymbol = AbstractPartialFunctionType.symbol.asClass
@@ -708,20 +682,15 @@ class Definitions {
   def NoneClass(implicit ctx: Context): ClassSymbol = NoneModuleRef.symbol.moduleClass.asClass
   @threadUnsafe lazy val EnumType: TypeRef                    = ctx.requiredClassRef("scala.Enum")
   def EnumClass(implicit ctx: Context): ClassSymbol = EnumType.symbol.asClass
-    @threadUnsafe lazy val Enum_ordinalR: TermRef = EnumClass.requiredMethodRef(nme.ordinal)
-    def Enum_ordinal(implicit ctx: Context): Symbol = Enum_ordinalR.symbol
+    @threadUnsafe lazy val Enum_ordinal: SymbolPerRun = perRun(EnumClass.requiredMethodRef(nme.ordinal))
   @threadUnsafe lazy val EnumValuesType: TypeRef              = ctx.requiredClassRef("scala.runtime.EnumValues")
   def EnumValuesClass(implicit ctx: Context): ClassSymbol = EnumValuesType.symbol.asClass
   @threadUnsafe lazy val ProductType: TypeRef                 = ctx.requiredClassRef("scala.Product")
   def ProductClass(implicit ctx: Context): ClassSymbol = ProductType.symbol.asClass
-    @threadUnsafe lazy val Product_canEqualR: TermRef = ProductClass.requiredMethodRef(nme.canEqual_)
-    def Product_canEqual(implicit ctx: Context): Symbol = Product_canEqualR.symbol
-    @threadUnsafe lazy val Product_productArityR: TermRef = ProductClass.requiredMethodRef(nme.productArity)
-    def Product_productArity(implicit ctx: Context): Symbol = Product_productArityR.symbol
-    @threadUnsafe lazy val Product_productElementR: TermRef = ProductClass.requiredMethodRef(nme.productElement)
-    def Product_productElement(implicit ctx: Context): Symbol = Product_productElementR.symbol
-    @threadUnsafe lazy val Product_productPrefixR: TermRef = ProductClass.requiredMethodRef(nme.productPrefix)
-    def Product_productPrefix(implicit ctx: Context): Symbol = Product_productPrefixR.symbol
+    @threadUnsafe lazy val Product_canEqual      : SymbolPerRun = perRun(ProductClass.requiredMethodRef(nme.canEqual_))
+    @threadUnsafe lazy val Product_productArity  : SymbolPerRun = perRun(ProductClass.requiredMethodRef(nme.productArity))
+    @threadUnsafe lazy val Product_productElement: SymbolPerRun = perRun(ProductClass.requiredMethodRef(nme.productElement))
+    @threadUnsafe lazy val Product_productPrefix : SymbolPerRun = perRun(ProductClass.requiredMethodRef(nme.productPrefix))
 
   @threadUnsafe lazy val IteratorType: TypeRef = ctx.requiredClassRef("scala.collection.Iterator")
   def IteratorClass(implicit ctx: Context): ClassSymbol = IteratorType.symbol.asClass
@@ -737,9 +706,7 @@ class Definitions {
 
   @threadUnsafe lazy val Mirror_ProductType: TypeRef = ctx.requiredClassRef("scala.deriving.Mirror.Product")
   def Mirror_ProductClass(implicit ctx: Context): ClassSymbol = Mirror_ProductType.symbol.asClass
-
-    @threadUnsafe lazy val Mirror_Product_fromProductR: TermRef = Mirror_ProductClass.requiredMethodRef(nme.fromProduct)
-    def Mirror_Product_fromProduct(implicit ctx: Context): Symbol = Mirror_Product_fromProductR.symbol
+    @threadUnsafe lazy val Mirror_Product_fromProduct: SymbolPerRun = perRun(Mirror_ProductClass.requiredMethodRef(nme.fromProduct))
 
   @threadUnsafe lazy val Mirror_SumType: TypeRef = ctx.requiredClassRef("scala.deriving.Mirror.Sum")
   def Mirror_SumClass(implicit ctx: Context): ClassSymbol = Mirror_SumType.symbol.asClass
@@ -758,8 +725,7 @@ class Definitions {
   @threadUnsafe lazy val ClassTagType: TypeRef = ctx.requiredClassRef("scala.reflect.ClassTag")
   def ClassTagClass(implicit ctx: Context): ClassSymbol = ClassTagType.symbol.asClass
   def ClassTagModule(implicit ctx: Context): Symbol = ClassTagClass.companionModule
-    @threadUnsafe lazy val ClassTagModule_applyR: TermRef = ClassTagModule.requiredMethodRef(nme.apply)
-    def ClassTagModule_apply(implicit ctx: Context): Symbol = ClassTagModule_applyR.symbol
+    @threadUnsafe lazy val ClassTagModule_apply: SymbolPerRun = perRun(ClassTagModule.requiredMethodRef(nme.apply))
 
   @threadUnsafe lazy val QuotedExprType: TypeRef = ctx.requiredClassRef("scala.quoted.Expr")
   def QuotedExprClass(implicit ctx: Context): ClassSymbol = QuotedExprType.symbol.asClass
@@ -775,22 +741,16 @@ class Definitions {
 
   @threadUnsafe lazy val InternalQuotedModuleRef: TermRef = ctx.requiredModuleRef("scala.internal.Quoted")
   def InternalQuotedModule: Symbol = InternalQuotedModuleRef.symbol
-    @threadUnsafe lazy val InternalQuoted_exprQuoteR: TermRef = InternalQuotedModule.requiredMethodRef("exprQuote")
-    def InternalQuoted_exprQuote(implicit ctx: Context): Symbol = InternalQuoted_exprQuoteR.symbol
-    @threadUnsafe lazy val InternalQuoted_exprSpliceR: TermRef = InternalQuotedModule.requiredMethodRef("exprSplice")
-    def InternalQuoted_exprSplice(implicit ctx: Context): Symbol = InternalQuoted_exprSpliceR.symbol
-    @threadUnsafe lazy val InternalQuoted_typeQuoteR: TermRef = InternalQuotedModule.requiredMethodRef("typeQuote")
-    def InternalQuoted_typeQuote(implicit ctx: Context): Symbol = InternalQuoted_typeQuoteR.symbol
-    @threadUnsafe lazy val InternalQuoted_patternHoleR: TermRef = InternalQuotedModule.requiredMethodRef("patternHole")
-    def InternalQuoted_patternHole(implicit ctx: Context): Symbol = InternalQuoted_patternHoleR.symbol
+    @threadUnsafe lazy val InternalQuoted_exprQuote  : SymbolPerRun = perRun(InternalQuotedModule.requiredMethodRef("exprQuote"))
+    @threadUnsafe lazy val InternalQuoted_exprSplice : SymbolPerRun = perRun(InternalQuotedModule.requiredMethodRef("exprSplice"))
+    @threadUnsafe lazy val InternalQuoted_typeQuote  : SymbolPerRun = perRun(InternalQuotedModule.requiredMethodRef("typeQuote"))
+    @threadUnsafe lazy val InternalQuoted_patternHole: SymbolPerRun = perRun(InternalQuotedModule.requiredMethodRef("patternHole"))
     @threadUnsafe lazy val InternalQuoted_patternBindHoleAnnot: ClassSymbol = InternalQuotedModule.requiredClass("patternBindHole")
     @threadUnsafe lazy val InternalQuoted_QuoteTypeTagAnnot: ClassSymbol = InternalQuotedModule.requiredClass("quoteTypeTag")
 
   @threadUnsafe lazy val InternalQuotedMatcherModuleRef: TermRef = ctx.requiredModuleRef("scala.internal.quoted.Matcher")
-    def InternalQuotedMatcherModule(implicit ctx: Context): Symbol = InternalQuotedMatcherModuleRef.symbol
-
-    @threadUnsafe lazy val InternalQuotedMatcher_unapplyR: TermRef = InternalQuotedMatcherModule.requiredMethodRef(nme.unapply)
-    def InternalQuotedMatcher_unapply(implicit ctx: Context) = InternalQuotedMatcher_unapplyR.symbol
+  def InternalQuotedMatcherModule(implicit ctx: Context): Symbol = InternalQuotedMatcherModuleRef.symbol
+    @threadUnsafe lazy val InternalQuotedMatcher_unapply: SymbolPerRun = perRun(InternalQuotedMatcherModule.requiredMethodRef(nme.unapply))
 
   @threadUnsafe lazy val QuotedTypeType: TypeRef = ctx.requiredClassRef("scala.quoted.Type")
   def QuotedTypeClass(implicit ctx: Context): ClassSymbol = QuotedTypeType.symbol.asClass
@@ -839,12 +799,10 @@ class Definitions {
 
   @threadUnsafe lazy val TupleTypeRef: TypeRef = ctx.requiredClassRef("scala.Tuple")
   def TupleClass(implicit ctx: Context): ClassSymbol = TupleTypeRef.symbol.asClass
-    @threadUnsafe lazy val Tuple_consR: TermRef = TupleClass.requiredMethod("*:").termRef
-    def Tuple_cons: Symbol = Tuple_consR.symbol
+    @threadUnsafe lazy val Tuple_cons: SymbolPerRun = perRun(TupleClass.requiredMethodRef("*:"))
   @threadUnsafe lazy val NonEmptyTupleTypeRef: TypeRef = ctx.requiredClassRef("scala.NonEmptyTuple")
   def NonEmptyTupleClass(implicit ctx: Context): ClassSymbol = NonEmptyTupleTypeRef.symbol.asClass
-    lazy val NonEmptyTuple_tailR: TermRef = NonEmptyTupleClass.requiredMethod("tail").termRef
-    def NonEmptyTuple_tail: Symbol = NonEmptyTuple_tailR.symbol
+    lazy val NonEmptyTuple_tail: SymbolPerRun = perRun(NonEmptyTupleClass.requiredMethodRef("tail"))
 
   @threadUnsafe lazy val PairType: TypeRef = ctx.requiredClassRef("scala.*:")
   def PairClass(implicit ctx: Context): ClassSymbol = PairType.symbol.asClass
@@ -1112,8 +1070,7 @@ class Definitions {
     else
       ctx.requiredClass("scala.Function" + n.toString)
 
-    @threadUnsafe lazy val Function0_applyR: TermRef = ImplementedFunctionType(0).symbol.requiredMethodRef(nme.apply)
-    def Function0_apply(implicit ctx: Context): Symbol = Function0_applyR.symbol
+    @threadUnsafe lazy val Function0_apply: SymbolPerRun = perRun(ImplementedFunctionType(0).symbol.requiredMethodRef(nme.apply))
 
   def FunctionType(n: Int, isContextual: Boolean = false, isErased: Boolean = false)(implicit ctx: Context): TypeRef =
     if (n <= MaxImplementedFunctionArity && (!isContextual || ctx.erasedTypes) && !isErased) ImplementedFunctionType(n)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -28,6 +28,13 @@ object Definitions {
    *  else without affecting the set of programs that can be compiled.
    */
   val MaxImplementedFunctionArity: Int = MaxTupleArity
+
+  type SymbolPerRun = given Context => Symbol
+
+  def perRun(tp: NamedType): given Context => Symbol =
+    tp.symbol
+
+  def perRunClass(tp: TypeRef): given Context => ClassSymbol = tp.symbol.asClass
 }
 
 /** A class defining symbols and types of standard definitions
@@ -444,19 +451,14 @@ class Definitions {
   @threadUnsafe lazy val SeqType: TypeRef =
     if (isNewCollections) ctx.requiredClassRef("scala.collection.immutable.Seq")
     else ctx.requiredClassRef("scala.collection.Seq")
-  def SeqClass(implicit ctx: Context): ClassSymbol = SeqType.symbol.asClass
-    @threadUnsafe lazy val Seq_applyR: TermRef = SeqClass.requiredMethodRef(nme.apply)
-    def Seq_apply(implicit ctx: Context): Symbol = Seq_applyR.symbol
-    @threadUnsafe lazy val Seq_headR: TermRef = SeqClass.requiredMethodRef(nme.head)
-    def Seq_head(implicit ctx: Context): Symbol = Seq_headR.symbol
-    @threadUnsafe lazy val Seq_dropR: TermRef = SeqClass.requiredMethodRef(nme.drop)
-    def Seq_drop(implicit ctx: Context): Symbol = Seq_dropR.symbol
-    @threadUnsafe lazy val Seq_lengthCompareR: TermRef = SeqClass.requiredMethodRef(nme.lengthCompare, List(IntType))
-    def Seq_lengthCompare(implicit ctx: Context): Symbol = Seq_lengthCompareR.symbol
-    @threadUnsafe lazy val Seq_lengthR: TermRef = SeqClass.requiredMethodRef(nme.length)
-    def Seq_length(implicit ctx: Context): Symbol = Seq_lengthR.symbol
-    @threadUnsafe lazy val Seq_toSeqR: TermRef = SeqClass.requiredMethodRef(nme.toSeq)
-    def Seq_toSeq(implicit ctx: Context): Symbol = Seq_toSeqR.symbol
+  def SeqClass: ClassSymbol = perRunClass(SeqType)
+
+    @threadUnsafe lazy val Seq_apply: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.apply))
+    @threadUnsafe lazy val Seq_head: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.head))
+    @threadUnsafe lazy val Seq_drop: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.drop))
+    @threadUnsafe lazy val Seq_lengthCompare: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.lengthCompare, List(IntType)))
+    @threadUnsafe lazy val Seq_length: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.length))
+    @threadUnsafe lazy val Seq_toSeq: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.toSeq))
 
   @threadUnsafe lazy val ArrayType: TypeRef = ctx.requiredClassRef("scala.Array")
   def ArrayClass(implicit ctx: Context): ClassSymbol = ArrayType.symbol.asClass

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -30,11 +30,10 @@ object Definitions {
   val MaxImplementedFunctionArity: Int = MaxTupleArity
 
   type SymbolPerRun = given Context => Symbol
+  type ClassSymbolPerRun = given Context => ClassSymbol
 
-  def perRun(tp: NamedType): given Context => Symbol =
-    tp.symbol
-
-  def perRunClass(tp: TypeRef): given Context => ClassSymbol = tp.symbol.asClass
+  def perRunSym(tp: NamedType): SymbolPerRun = tp.symbol
+  def perRunClass(tp: TypeRef): ClassSymbolPerRun = tp.symbol.asClass
 }
 
 /** A class defining symbols and types of standard definitions
@@ -223,21 +222,21 @@ class Definitions {
         else NoSymbol)
     cls
   }
-  @threadUnsafe lazy val ScalaPackageObject: SymbolPerRun = perRun(ctx.requiredModuleRef("scala.package"))
+  @threadUnsafe lazy val ScalaPackageObject: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.package"))
   @threadUnsafe lazy val JavaPackageVal: TermSymbol = ctx.requiredPackage(nme.java)
   @threadUnsafe lazy val JavaLangPackageVal: TermSymbol = ctx.requiredPackage(jnme.JavaLang)
 
   // fundamental modules
-  @threadUnsafe lazy val SysPackage : SymbolPerRun = perRun(ctx.requiredModuleRef("scala.sys.package"))
-    @threadUnsafe lazy val Sys_error: SymbolPerRun = perRun(SysPackage.moduleClass.requiredMethodRef(nme.error))
+  @threadUnsafe lazy val SysPackage : SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.sys.package"))
+    @threadUnsafe lazy val Sys_error: SymbolPerRun = perRunSym(SysPackage.moduleClass.requiredMethodRef(nme.error))
 
   @threadUnsafe lazy val ScalaXmlPackageClass: Symbol = ctx.getPackageClassIfDefined("scala.xml")
 
-  @threadUnsafe lazy val CompiletimePackageObject: SymbolPerRun = perRun(ctx.requiredModuleRef("scala.compiletime.package"))
-    @threadUnsafe lazy val Compiletime_error        : SymbolPerRun = perRun(CompiletimePackageObject.requiredMethodRef(nme.error))
-    @threadUnsafe lazy val Compiletime_constValue   : SymbolPerRun = perRun(CompiletimePackageObject.requiredMethodRef("constValue"))
-    @threadUnsafe lazy val Compiletime_constValueOpt: SymbolPerRun = perRun(CompiletimePackageObject.requiredMethodRef("constValueOpt"))
-    @threadUnsafe lazy val Compiletime_code         : SymbolPerRun = perRun(CompiletimePackageObject.requiredMethodRef("code"))
+  @threadUnsafe lazy val CompiletimePackageObject: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.compiletime.package"))
+    @threadUnsafe lazy val Compiletime_error        : SymbolPerRun = perRunSym(CompiletimePackageObject.requiredMethodRef(nme.error))
+    @threadUnsafe lazy val Compiletime_constValue   : SymbolPerRun = perRunSym(CompiletimePackageObject.requiredMethodRef("constValue"))
+    @threadUnsafe lazy val Compiletime_constValueOpt: SymbolPerRun = perRunSym(CompiletimePackageObject.requiredMethodRef("constValueOpt"))
+    @threadUnsafe lazy val Compiletime_code         : SymbolPerRun = perRunSym(CompiletimePackageObject.requiredMethodRef("code"))
 
   /** The `scalaShadowing` package is used to safely modify classes and
    *  objects in scala so that they can be used from dotty. They will
@@ -363,10 +362,10 @@ class Definitions {
   def ImplicitScrutineeTypeRef: TypeRef = ImplicitScrutineeTypeSym.typeRef
 
 
-  @threadUnsafe lazy val ScalaPredefModule: SymbolPerRun = perRun(ctx.requiredModuleRef("scala.Predef"))
-    @threadUnsafe lazy val Predef_conforms : SymbolPerRun = perRun(ScalaPredefModule.requiredMethodRef(nme.conforms_))
-    @threadUnsafe lazy val Predef_classOf  : SymbolPerRun = perRun(ScalaPredefModule.requiredMethodRef(nme.classOf))
-    @threadUnsafe lazy val Predef_undefined: SymbolPerRun = perRun(ScalaPredefModule.requiredMethodRef(nme.???))
+  @threadUnsafe lazy val ScalaPredefModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.Predef"))
+    @threadUnsafe lazy val Predef_conforms : SymbolPerRun = perRunSym(ScalaPredefModule.requiredMethodRef(nme.conforms_))
+    @threadUnsafe lazy val Predef_classOf  : SymbolPerRun = perRunSym(ScalaPredefModule.requiredMethodRef(nme.classOf))
+    @threadUnsafe lazy val Predef_undefined: SymbolPerRun = perRunSym(ScalaPredefModule.requiredMethodRef(nme.???))
 
   def SubTypeClass(implicit ctx: Context): ClassSymbol =
     if (isNewCollections)
@@ -380,25 +379,18 @@ class Definitions {
     else
       ScalaPredefModule.requiredClass("DummyImplicit")
 
-  @threadUnsafe lazy val ScalaRuntimeModule: SymbolPerRun = perRun(ctx.requiredModuleRef("scala.runtime.ScalaRunTime"))
-  def ScalaRuntimeClass(implicit ctx: Context): ClassSymbol = ScalaRuntimeModule.moduleClass.asClass
-
+  @threadUnsafe lazy val ScalaRuntimeModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.runtime.ScalaRunTime"))
     def runtimeMethodRef(name: PreName): TermRef = ScalaRuntimeModule.requiredMethodRef(name)
-    def ScalaRuntime_drop: SymbolPerRun = perRun(runtimeMethodRef(nme.drop))
+    def ScalaRuntime_drop: SymbolPerRun = perRunSym(runtimeMethodRef(nme.drop))
 
-  @threadUnsafe lazy val BoxesRunTimeModuleRef: TermRef = ctx.requiredModuleRef("scala.runtime.BoxesRunTime")
-  def BoxesRunTimeModule(implicit ctx: Context): Symbol = BoxesRunTimeModuleRef.symbol
-  def BoxesRunTimeClass(implicit ctx: Context): ClassSymbol = BoxesRunTimeModule.moduleClass.asClass
-  @threadUnsafe lazy val ScalaStaticsModuleRef: TermRef = ctx.requiredModuleRef("scala.runtime.Statics")
-  def ScalaStaticsModule(implicit ctx: Context): Symbol = ScalaStaticsModuleRef.symbol
-  def ScalaStaticsClass(implicit ctx: Context): ClassSymbol = ScalaStaticsModule.moduleClass.asClass
-
+  @threadUnsafe lazy val BoxesRunTimeModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.runtime.BoxesRunTime"))
+  @threadUnsafe lazy val ScalaStaticsModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.runtime.Statics"))
     def staticsMethodRef(name: PreName): TermRef = ScalaStaticsModule.requiredMethodRef(name)
     def staticsMethod(name: PreName): TermSymbol = ScalaStaticsModule.requiredMethod(name)
 
   // Dotty deviation: we cannot use a @threadUnsafe lazy val here because @threadUnsafe lazy vals in dotty
   // will return "null" when called recursively, see #1856.
-  def DottyPredefModuleRef: TermRef = {
+  def DottyPredefModule: SymbolPerRun = perRunSym {
     if (myDottyPredefModuleRef == null) {
       myDottyPredefModuleRef = ctx.requiredModuleRef("dotty.DottyPredef")
       assert(myDottyPredefModuleRef != null)
@@ -407,10 +399,7 @@ class Definitions {
   }
   private[this] var myDottyPredefModuleRef: TermRef = _
 
-  def DottyPredefModule(implicit ctx: Context): Symbol = DottyPredefModuleRef.symbol
-
-  @threadUnsafe lazy val DottyArraysModuleRef: TermRef = ctx.requiredModuleRef("dotty.runtime.Arrays")
-  def DottyArraysModule(implicit ctx: Context): Symbol = DottyArraysModuleRef.symbol
+  @threadUnsafe lazy val DottyArraysModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("dotty.runtime.Arrays"))
     def newGenericArrayMethod(implicit ctx: Context): TermSymbol = DottyArraysModule.requiredMethod("newGenericArray")
     def newArrayMethod(implicit ctx: Context): TermSymbol = DottyArraysModule.requiredMethod("newArray")
 
@@ -425,8 +414,7 @@ class Definitions {
     methodNames.map(getWrapVarargsArrayModule.requiredMethodRef(_).symbol)
   })
 
-  @threadUnsafe lazy val NilModuleRef: TermRef = ctx.requiredModuleRef("scala.collection.immutable.Nil")
-  def NilModule(implicit ctx: Context): Symbol = NilModuleRef.symbol
+  @threadUnsafe lazy val NilModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.collection.immutable.Nil"))
 
   @threadUnsafe lazy val SingletonClass: ClassSymbol =
     // needed as a synthetic class because Scala 2.x refers to it in classfiles
@@ -439,128 +427,99 @@ class Definitions {
   @threadUnsafe lazy val SeqType: TypeRef =
     if (isNewCollections) ctx.requiredClassRef("scala.collection.immutable.Seq")
     else ctx.requiredClassRef("scala.collection.Seq")
-  def SeqClass: ClassSymbol = perRunClass(SeqType)
-    @threadUnsafe lazy val Seq_apply        : SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.apply))
-    @threadUnsafe lazy val Seq_head         : SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.head))
-    @threadUnsafe lazy val Seq_drop         : SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.drop))
-    @threadUnsafe lazy val Seq_lengthCompare: SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.lengthCompare, List(IntType)))
-    @threadUnsafe lazy val Seq_length       : SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.length))
-    @threadUnsafe lazy val Seq_toSeq        : SymbolPerRun = perRun(SeqClass.requiredMethodRef(nme.toSeq))
+  def SeqClass given Context: ClassSymbol = SeqType.symbol.asClass
+    @threadUnsafe lazy val Seq_apply        : SymbolPerRun = perRunSym(SeqClass.requiredMethodRef(nme.apply))
+    @threadUnsafe lazy val Seq_head         : SymbolPerRun = perRunSym(SeqClass.requiredMethodRef(nme.head))
+    @threadUnsafe lazy val Seq_drop         : SymbolPerRun = perRunSym(SeqClass.requiredMethodRef(nme.drop))
+    @threadUnsafe lazy val Seq_lengthCompare: SymbolPerRun = perRunSym(SeqClass.requiredMethodRef(nme.lengthCompare, List(IntType)))
+    @threadUnsafe lazy val Seq_length       : SymbolPerRun = perRunSym(SeqClass.requiredMethodRef(nme.length))
+    @threadUnsafe lazy val Seq_toSeq        : SymbolPerRun = perRunSym(SeqClass.requiredMethodRef(nme.toSeq))
 
   @threadUnsafe lazy val ArrayType: TypeRef = ctx.requiredClassRef("scala.Array")
-  def ArrayClass(implicit ctx: Context): ClassSymbol = ArrayType.symbol.asClass
-    @threadUnsafe lazy val Array_apply     : SymbolPerRun = perRun(ArrayClass.requiredMethodRef(nme.apply))
-    @threadUnsafe lazy val Array_update    : SymbolPerRun = perRun(ArrayClass.requiredMethodRef(nme.update))
-    @threadUnsafe lazy val Array_length    : SymbolPerRun = perRun(ArrayClass.requiredMethodRef(nme.length))
-    @threadUnsafe lazy val Array_clone     : SymbolPerRun = perRun(ArrayClass.requiredMethodRef(nme.clone_))
-    @threadUnsafe lazy val ArrayConstructor: SymbolPerRun = perRun(ArrayClass.requiredMethodRef(nme.CONSTRUCTOR))
+  def ArrayClass given Context: ClassSymbol = ArrayType.symbol.asClass
+    @threadUnsafe lazy val Array_apply     : SymbolPerRun = perRunSym(ArrayClass.requiredMethodRef(nme.apply))
+    @threadUnsafe lazy val Array_update    : SymbolPerRun = perRunSym(ArrayClass.requiredMethodRef(nme.update))
+    @threadUnsafe lazy val Array_length    : SymbolPerRun = perRunSym(ArrayClass.requiredMethodRef(nme.length))
+    @threadUnsafe lazy val Array_clone     : SymbolPerRun = perRunSym(ArrayClass.requiredMethodRef(nme.clone_))
+    @threadUnsafe lazy val ArrayConstructor: SymbolPerRun = perRunSym(ArrayClass.requiredMethodRef(nme.CONSTRUCTOR))
 
-  @threadUnsafe lazy val ArrayModuleType: TermRef = ctx.requiredModuleRef("scala.Array")
-  def ArrayModule(implicit ctx: Context): ClassSymbol = ArrayModuleType.symbol.moduleClass.asClass
-
+  @threadUnsafe lazy val ArrayModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.Array"))
 
   @threadUnsafe lazy val UnitType: TypeRef = valueTypeRef("scala.Unit", java.lang.Void.TYPE, UnitEnc, nme.specializedTypeNames.Void)
-  def UnitClass(implicit ctx: Context): ClassSymbol = UnitType.symbol.asClass
-  def UnitModuleClass(implicit ctx: Context): Symbol = UnitType.symbol.asClass.linkedClass
+  def UnitClass given Context: ClassSymbol = UnitType.symbol.asClass
+  def UnitModuleClass given Context: Symbol = UnitType.symbol.asClass.linkedClass
   @threadUnsafe lazy val BooleanType: TypeRef = valueTypeRef("scala.Boolean", java.lang.Boolean.TYPE, BooleanEnc, nme.specializedTypeNames.Boolean)
-  def BooleanClass(implicit ctx: Context): ClassSymbol = BooleanType.symbol.asClass
-    @threadUnsafe lazy val Boolean_!  : SymbolPerRun = perRun(BooleanClass.requiredMethodRef(nme.UNARY_!))
-    @threadUnsafe lazy val Boolean_&& : SymbolPerRun = perRun(BooleanClass.requiredMethodRef(nme.ZAND)) // ### harmonize required... calls
-    @threadUnsafe lazy val Boolean_|| : SymbolPerRun = perRun(BooleanClass.requiredMethodRef(nme.ZOR))
-    @threadUnsafe lazy val Boolean_== : SymbolPerRun = perRun(
+  def BooleanClass given Context: ClassSymbol = BooleanType.symbol.asClass
+    @threadUnsafe lazy val Boolean_!  : SymbolPerRun = perRunSym(BooleanClass.requiredMethodRef(nme.UNARY_!))
+    @threadUnsafe lazy val Boolean_&& : SymbolPerRun = perRunSym(BooleanClass.requiredMethodRef(nme.ZAND)) // ### harmonize required... calls
+    @threadUnsafe lazy val Boolean_|| : SymbolPerRun = perRunSym(BooleanClass.requiredMethodRef(nme.ZOR))
+    @threadUnsafe lazy val Boolean_== : SymbolPerRun = perRunSym(
       BooleanClass.info.member(nme.EQ).suchThat(_.info.firstParamTypes match {
         case List(pt) => (pt isRef BooleanClass)
         case _ => false
       }).symbol.termRef)
-    @threadUnsafe lazy val Boolean_!= : SymbolPerRun = perRun(
+    @threadUnsafe lazy val Boolean_!= : SymbolPerRun = perRunSym(
       BooleanClass.info.member(nme.NE).suchThat(_.info.firstParamTypes match {
         case List(pt) => (pt isRef BooleanClass)
         case _ => false
       }).symbol.termRef)
 
   @threadUnsafe lazy val ByteType: TypeRef = valueTypeRef("scala.Byte", java.lang.Byte.TYPE, ByteEnc, nme.specializedTypeNames.Byte)
-  def ByteClass(implicit ctx: Context): ClassSymbol = ByteType.symbol.asClass
+  def ByteClass given Context: ClassSymbol = ByteType.symbol.asClass
   @threadUnsafe lazy val ShortType: TypeRef = valueTypeRef("scala.Short", java.lang.Short.TYPE, ShortEnc, nme.specializedTypeNames.Short)
-  def ShortClass(implicit ctx: Context): ClassSymbol = ShortType.symbol.asClass
+  def ShortClass given Context: ClassSymbol = ShortType.symbol.asClass
   @threadUnsafe lazy val CharType: TypeRef = valueTypeRef("scala.Char", java.lang.Character.TYPE, CharEnc, nme.specializedTypeNames.Char)
-  def CharClass(implicit ctx: Context): ClassSymbol = CharType.symbol.asClass
+  def CharClass given Context: ClassSymbol = CharType.symbol.asClass
   @threadUnsafe lazy val IntType: TypeRef = valueTypeRef("scala.Int", java.lang.Integer.TYPE, IntEnc, nme.specializedTypeNames.Int)
-  def IntClass(implicit ctx: Context): ClassSymbol = IntType.symbol.asClass
-    @threadUnsafe lazy val Int_minusR: TermRef   = IntClass.requiredMethodRef(nme.MINUS, List(IntType))
-    def Int_- : Symbol = Int_minusR.symbol
-    @threadUnsafe lazy val Int_plusR: TermRef   = IntClass.requiredMethodRef(nme.PLUS, List(IntType))
-    def Int_+ : Symbol = Int_plusR.symbol
-    @threadUnsafe lazy val Int_divR: TermRef   = IntClass.requiredMethodRef(nme.DIV, List(IntType))
-    def Int_/ : Symbol = Int_divR.symbol
-    @threadUnsafe lazy val Int_mulR: TermRef   = IntClass.requiredMethodRef(nme.MUL, List(IntType))
-    def Int_* : Symbol = Int_mulR.symbol
-    @threadUnsafe lazy val Int_eqR: TermRef   = IntClass.requiredMethodRef(nme.EQ, List(IntType))
-    def Int_== : Symbol = Int_eqR.symbol
-    @threadUnsafe lazy val Int_geR: TermRef   = IntClass.requiredMethodRef(nme.GE, List(IntType))
-    def Int_>= : Symbol = Int_geR.symbol
-    @threadUnsafe lazy val Int_leR: TermRef   = IntClass.requiredMethodRef(nme.LE, List(IntType))
-    def Int_<= : Symbol = Int_leR.symbol
+  def IntClass given Context: ClassSymbol = IntType.symbol.asClass
+    @threadUnsafe lazy val Int_-  : SymbolPerRun = perRunSym(IntClass.requiredMethodRef(nme.MINUS, List(IntType)))
+    @threadUnsafe lazy val Int_+  : SymbolPerRun = perRunSym(IntClass.requiredMethodRef(nme.PLUS, List(IntType)))
+    @threadUnsafe lazy val Int_/  : SymbolPerRun = perRunSym(IntClass.requiredMethodRef(nme.DIV, List(IntType)))
+    @threadUnsafe lazy val Int_*  : SymbolPerRun = perRunSym(IntClass.requiredMethodRef(nme.MUL, List(IntType)))
+    @threadUnsafe lazy val Int_== : SymbolPerRun = perRunSym(IntClass.requiredMethodRef(nme.EQ, List(IntType)))
+    @threadUnsafe lazy val Int_>= : SymbolPerRun = perRunSym(IntClass.requiredMethodRef(nme.GE, List(IntType)))
+    @threadUnsafe lazy val Int_<= : SymbolPerRun = perRunSym(IntClass.requiredMethodRef(nme.LE, List(IntType)))
   @threadUnsafe lazy val LongType: TypeRef = valueTypeRef("scala.Long", java.lang.Long.TYPE, LongEnc, nme.specializedTypeNames.Long)
-  def LongClass(implicit ctx: Context): ClassSymbol = LongType.symbol.asClass
-    @threadUnsafe lazy val Long_XOR_Long: Symbol = LongType.member(nme.XOR).requiredSymbol("method", nme.XOR, LongType.denot)(
-      x => x.is(Method) && (x.info.firstParamTypes.head isRef defn.LongClass)
-    )
-    @threadUnsafe lazy val Long_LSR_Int: Symbol = LongType.member(nme.LSR).requiredSymbol("method", nme.LSR, LongType.denot)(
-      x => x.is(Method) && (x.info.firstParamTypes.head isRef defn.IntClass)
-    )
-    @threadUnsafe lazy val Long_plusR: TermRef   = LongClass.requiredMethodRef(nme.PLUS, List(LongType))
-    def Long_+ : Symbol = Long_plusR.symbol
-    @threadUnsafe lazy val Long_mulR: TermRef   = LongClass.requiredMethodRef(nme.MUL, List(LongType))
-    def Long_* : Symbol = Long_mulR.symbol
-    @threadUnsafe lazy val Long_divR: TermRef   = LongClass.requiredMethodRef(nme.DIV, List(LongType))
-    def Long_/ : Symbol = Long_divR.symbol
+  def LongClass given Context: ClassSymbol = LongType.symbol.asClass
+    @threadUnsafe lazy val Long_+ : SymbolPerRun = perRunSym(LongClass.requiredMethodRef(nme.PLUS, List(LongType)))
+    @threadUnsafe lazy val Long_* : SymbolPerRun = perRunSym(LongClass.requiredMethodRef(nme.MUL, List(LongType)))
+    @threadUnsafe lazy val Long_/ : SymbolPerRun = perRunSym(LongClass.requiredMethodRef(nme.DIV, List(LongType)))
 
   @threadUnsafe lazy val FloatType: TypeRef = valueTypeRef("scala.Float", java.lang.Float.TYPE, FloatEnc, nme.specializedTypeNames.Float)
-  def FloatClass(implicit ctx: Context): ClassSymbol = FloatType.symbol.asClass
+  def FloatClass given Context: ClassSymbol = FloatType.symbol.asClass
   @threadUnsafe lazy val DoubleType: TypeRef = valueTypeRef("scala.Double", java.lang.Double.TYPE, DoubleEnc, nme.specializedTypeNames.Double)
-  def DoubleClass(implicit ctx: Context): ClassSymbol = DoubleType.symbol.asClass
+  def DoubleClass given Context: ClassSymbol = DoubleType.symbol.asClass
 
-  @threadUnsafe lazy val BoxedUnitType: TypeRef = ctx.requiredClassRef("scala.runtime.BoxedUnit")
-  def BoxedUnitClass(implicit ctx: Context): ClassSymbol = BoxedUnitType.symbol.asClass
+  @threadUnsafe lazy val BoxedUnitClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.runtime.BoxedUnit"))
+    def BoxedUnit_UNIT given Context: TermSymbol = BoxedUnitClass.linkedClass.requiredValue("UNIT")
 
-    def BoxedUnit_UNIT(implicit ctx: Context): TermSymbol = BoxedUnitClass.linkedClass.requiredValue("UNIT")
-
-  @threadUnsafe lazy val BoxedBooleanType: TypeRef = ctx.requiredClassRef("java.lang.Boolean")
-  def BoxedBooleanClass(implicit ctx: Context): ClassSymbol = BoxedBooleanType.symbol.asClass
-  @threadUnsafe lazy val BoxedByteType: TypeRef = ctx.requiredClassRef("java.lang.Byte")
-  def BoxedByteClass(implicit ctx: Context): ClassSymbol = BoxedByteType.symbol.asClass
-  @threadUnsafe lazy val BoxedShortType: TypeRef = ctx.requiredClassRef("java.lang.Short")
-  def BoxedShortClass(implicit ctx: Context): ClassSymbol = BoxedShortType.symbol.asClass
-  @threadUnsafe lazy val BoxedCharType: TypeRef = ctx.requiredClassRef("java.lang.Character")
-  def BoxedCharClass(implicit ctx: Context): ClassSymbol = BoxedCharType.symbol.asClass
-  @threadUnsafe lazy val BoxedIntType: TypeRef = ctx.requiredClassRef("java.lang.Integer")
-  def BoxedIntClass(implicit ctx: Context): ClassSymbol = BoxedIntType.symbol.asClass
-  @threadUnsafe lazy val BoxedLongType: TypeRef = ctx.requiredClassRef("java.lang.Long")
-  def BoxedLongClass(implicit ctx: Context): ClassSymbol = BoxedLongType.symbol.asClass
-  @threadUnsafe lazy val BoxedFloatType: TypeRef = ctx.requiredClassRef("java.lang.Float")
-  def BoxedFloatClass(implicit ctx: Context): ClassSymbol = BoxedFloatType.symbol.asClass
-  @threadUnsafe lazy val BoxedDoubleType: TypeRef = ctx.requiredClassRef("java.lang.Double")
-  def BoxedDoubleClass(implicit ctx: Context): ClassSymbol = BoxedDoubleType.symbol.asClass
+  @threadUnsafe lazy val BoxedBooleanClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("java.lang.Boolean"))
+  @threadUnsafe lazy val BoxedByteClass   : ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("java.lang.Byte"))
+  @threadUnsafe lazy val BoxedShortClass  : ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("java.lang.Short"))
+  @threadUnsafe lazy val BoxedCharClass   : ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("java.lang.Character"))
+  @threadUnsafe lazy val BoxedIntClass    : ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("java.lang.Integer"))
+  @threadUnsafe lazy val BoxedLongClass   : ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("java.lang.Long"))
+  @threadUnsafe lazy val BoxedFloatClass  : ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("java.lang.Float"))
+  @threadUnsafe lazy val BoxedDoubleClass : ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("java.lang.Double"))
 
   @threadUnsafe lazy val BoxedBooleanModule: TermSymbol = ctx.requiredModule("java.lang.Boolean")
-  @threadUnsafe lazy val BoxedByteModule: TermSymbol    = ctx.requiredModule("java.lang.Byte")
-  @threadUnsafe lazy val BoxedShortModule: TermSymbol   = ctx.requiredModule("java.lang.Short")
-  @threadUnsafe lazy val BoxedCharModule: TermSymbol    = ctx.requiredModule("java.lang.Character")
-  @threadUnsafe lazy val BoxedIntModule: TermSymbol     = ctx.requiredModule("java.lang.Integer")
-  @threadUnsafe lazy val BoxedLongModule: TermSymbol    = ctx.requiredModule("java.lang.Long")
-  @threadUnsafe lazy val BoxedFloatModule: TermSymbol   = ctx.requiredModule("java.lang.Float")
-  @threadUnsafe lazy val BoxedDoubleModule: TermSymbol  = ctx.requiredModule("java.lang.Double")
-  @threadUnsafe lazy val BoxedUnitModule: TermSymbol    = ctx.requiredModule("java.lang.Void")
+  @threadUnsafe lazy val BoxedByteModule   : TermSymbol = ctx.requiredModule("java.lang.Byte")
+  @threadUnsafe lazy val BoxedShortModule  : TermSymbol = ctx.requiredModule("java.lang.Short")
+  @threadUnsafe lazy val BoxedCharModule   : TermSymbol = ctx.requiredModule("java.lang.Character")
+  @threadUnsafe lazy val BoxedIntModule    : TermSymbol = ctx.requiredModule("java.lang.Integer")
+  @threadUnsafe lazy val BoxedLongModule   : TermSymbol = ctx.requiredModule("java.lang.Long")
+  @threadUnsafe lazy val BoxedFloatModule  : TermSymbol = ctx.requiredModule("java.lang.Float")
+  @threadUnsafe lazy val BoxedDoubleModule : TermSymbol = ctx.requiredModule("java.lang.Double")
+  @threadUnsafe lazy val BoxedUnitModule   : TermSymbol = ctx.requiredModule("java.lang.Void")
 
   @threadUnsafe lazy val ByNameParamClass2x: ClassSymbol = enterSpecialPolyClass(tpnme.BYNAME_PARAM_CLASS, Covariant, Seq(AnyType))
 
   @threadUnsafe lazy val RepeatedParamClass: ClassSymbol = enterSpecialPolyClass(tpnme.REPEATED_PARAM_CLASS, Covariant, Seq(ObjectType, SeqType))
 
   // fundamental classes
-  @threadUnsafe lazy val StringClass: ClassSymbol                = ctx.requiredClass("java.lang.String")
-  def StringType: Type                = StringClass.typeRef
-  @threadUnsafe lazy val StringModule: Symbol               = StringClass.linkedClass
-
+  @threadUnsafe lazy val StringClass: ClassSymbol = ctx.requiredClass("java.lang.String")
+  def StringType: Type = StringClass.typeRef
+  @threadUnsafe lazy val StringModule: Symbol = StringClass.linkedClass
     @threadUnsafe lazy val String_+ : TermSymbol = enterMethod(StringClass, nme.raw.PLUS, methOfAny(StringType), Final)
     @threadUnsafe lazy val String_valueOf_Object: Symbol = StringModule.info.member(nme.valueOf).suchThat(_.info.firstParamTypes match {
       case List(pt) => (pt isRef AnyClass) || (pt isRef ObjectClass)
@@ -598,12 +557,13 @@ class Definitions {
   // in scalac modified to have Any as parent
 
   @threadUnsafe lazy val ThrowableType: TypeRef          = ctx.requiredClassRef("java.lang.Throwable")
-  def ThrowableClass(implicit ctx: Context): ClassSymbol = ThrowableType.symbol.asClass
+  def ThrowableClass given Context: ClassSymbol = ThrowableType.symbol.asClass
   @threadUnsafe lazy val SerializableType: TypeRef       =
     if (isNewCollections)
       JavaSerializableClass.typeRef
     else
       ctx.requiredClassRef("scala.Serializable")
+  def SerializableClass given Context: ClassSymbol = SerializableType.symbol.asClass
 
    @threadUnsafe lazy val JavaEnumClass: ClassSymbol = {
     val cls = ctx.requiredClass("java.lang.Enum")
@@ -631,179 +591,123 @@ class Definitions {
   }
   def JavaEnumType = JavaEnumClass.typeRef
 
-  def SerializableClass(implicit ctx: Context): ClassSymbol = SerializableType.symbol.asClass
-  @threadUnsafe lazy val StringBuilderType: TypeRef      = ctx.requiredClassRef("scala.collection.mutable.StringBuilder")
-  def StringBuilderClass(implicit ctx: Context): ClassSymbol = StringBuilderType.symbol.asClass
-  @threadUnsafe lazy val MatchErrorType: TypeRef         = ctx.requiredClassRef("scala.MatchError")
-  def MatchErrorClass(implicit ctx: Context): ClassSymbol = MatchErrorType.symbol.asClass
-  @threadUnsafe lazy val ConversionType: TypeRef = ctx.requiredClass("scala.Conversion").typeRef
-  def ConversionClass(implicit ctx: Context): ClassSymbol = ConversionType.symbol.asClass
+  @threadUnsafe lazy val StringBuilderClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.collection.mutable.StringBuilder"))
+  @threadUnsafe lazy val MatchErrorClass   : ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.MatchError"))
+  @threadUnsafe lazy val ConversionClass   : ClassSymbolPerRun = perRunClass(ctx.requiredClass("scala.Conversion").typeRef)
 
-  @threadUnsafe lazy val StringAddType: TypeRef          = ctx.requiredClassRef("scala.runtime.StringAdd")
-  def StringAddClass(implicit ctx: Context): ClassSymbol = StringAddType.symbol.asClass
-    @threadUnsafe lazy val StringAdd_+ : SymbolPerRun = perRun(StringAddClass.requiredMethodRef(nme.raw.PLUS))
+  @threadUnsafe lazy val StringAddClass    : ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.runtime.StringAdd"))
+    @threadUnsafe lazy val StringAdd_+ : SymbolPerRun = perRunSym(StringAddClass.requiredMethodRef(nme.raw.PLUS))
 
-  @threadUnsafe lazy val StringContextType: TypeRef       = ctx.requiredClassRef("scala.StringContext")
-  def StringContextClass(implicit ctx: Context): ClassSymbol = StringContextType.symbol.asClass
-    @threadUnsafe lazy val StringContextS  : SymbolPerRun = perRun(StringContextClass.requiredMethodRef(nme.s))
-    @threadUnsafe lazy val StringContextRaw: SymbolPerRun = perRun(StringContextClass.requiredMethodRef(nme.raw_))
-    @threadUnsafe lazy val StringContext_f : SymbolPerRun = perRun(StringContextClass.requiredMethodRef(nme.f))
-  def StringContextModule(implicit ctx: Context): Symbol = StringContextClass.companionModule
-    @threadUnsafe lazy val StringContextModule_apply: SymbolPerRun = perRun(StringContextModule.requiredMethodRef(nme.apply))
+  @threadUnsafe lazy val StringContextClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.StringContext"))
+    @threadUnsafe lazy val StringContextS  : SymbolPerRun = perRunSym(StringContextClass.requiredMethodRef(nme.s))
+    @threadUnsafe lazy val StringContextRaw: SymbolPerRun = perRunSym(StringContextClass.requiredMethodRef(nme.raw_))
+    @threadUnsafe lazy val StringContext_f : SymbolPerRun = perRunSym(StringContextClass.requiredMethodRef(nme.f))
+  @threadUnsafe lazy val StringContextModule: SymbolPerRun = StringContextClass.companionModule
+    @threadUnsafe lazy val StringContextModule_apply: SymbolPerRun = perRunSym(StringContextModule.requiredMethodRef(nme.apply))
 
-  @threadUnsafe lazy val InternalStringContextMacroModule: SymbolPerRun = perRun(ctx.requiredModuleRef("dotty.internal.StringContextMacro"))
-    @threadUnsafe lazy val InternalStringContextMacroModule_f: SymbolPerRun = perRun(InternalStringContextMacroModule.requiredMethodRef(nme.f))
+  @threadUnsafe lazy val InternalStringContextMacroModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("dotty.internal.StringContextMacro"))
+    @threadUnsafe lazy val InternalStringContextMacroModule_f: SymbolPerRun = perRunSym(InternalStringContextMacroModule.requiredMethodRef(nme.f))
 
-  @threadUnsafe lazy val PartialFunctionType: TypeRef         = ctx.requiredClassRef("scala.PartialFunction")
-  def PartialFunctionClass(implicit ctx: Context): ClassSymbol = PartialFunctionType.symbol.asClass
-    @threadUnsafe lazy val PartialFunction_isDefinedAt: SymbolPerRun = perRun(PartialFunctionClass.requiredMethodRef(nme.isDefinedAt))
-    @threadUnsafe lazy val PartialFunction_applyOrElse: SymbolPerRun = perRun(PartialFunctionClass.requiredMethodRef(nme.applyOrElse))
+  @threadUnsafe lazy val PartialFunctionClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.PartialFunction"))
+    @threadUnsafe lazy val PartialFunction_isDefinedAt: SymbolPerRun = perRunSym(PartialFunctionClass.requiredMethodRef(nme.isDefinedAt))
+    @threadUnsafe lazy val PartialFunction_applyOrElse: SymbolPerRun = perRunSym(PartialFunctionClass.requiredMethodRef(nme.applyOrElse))
 
-  @threadUnsafe lazy val AbstractPartialFunctionType: TypeRef = ctx.requiredClassRef("scala.runtime.AbstractPartialFunction")
-  def AbstractPartialFunctionClass(implicit ctx: Context): ClassSymbol = AbstractPartialFunctionType.symbol.asClass
+  @threadUnsafe lazy val AbstractPartialFunctionClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.runtime.AbstractPartialFunction"))
+  @threadUnsafe lazy val FunctionXXLClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.FunctionXXL"))
+  @threadUnsafe lazy val ScalaSymbolClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.Symbol"))
+  @threadUnsafe lazy val DynamicClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.Dynamic"))
+  @threadUnsafe lazy val OptionClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.Option"))
+  @threadUnsafe lazy val SomeClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.Some"))
+  @threadUnsafe lazy val NoneModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.None"))
 
-  @threadUnsafe lazy val FunctionXXLType: TypeRef         = ctx.requiredClassRef("scala.FunctionXXL")
-  def FunctionXXLClass(implicit ctx: Context): ClassSymbol = FunctionXXLType.symbol.asClass
+  @threadUnsafe lazy val EnumClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.Enum"))
+    @threadUnsafe lazy val Enum_ordinal: SymbolPerRun = perRunSym(EnumClass.requiredMethodRef(nme.ordinal))
 
-  @threadUnsafe lazy val ScalaSymbolType: TypeRef                    = ctx.requiredClassRef("scala.Symbol")
-  def ScalaSymbolClass(implicit ctx: Context): ClassSymbol          = ScalaSymbolType.symbol.asClass
+  @threadUnsafe lazy val EnumValuesClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.runtime.EnumValues"))
+  @threadUnsafe lazy val ProductClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.Product"))
+    @threadUnsafe lazy val Product_canEqual      : SymbolPerRun = perRunSym(ProductClass.requiredMethodRef(nme.canEqual_))
+    @threadUnsafe lazy val Product_productArity  : SymbolPerRun = perRunSym(ProductClass.requiredMethodRef(nme.productArity))
+    @threadUnsafe lazy val Product_productElement: SymbolPerRun = perRunSym(ProductClass.requiredMethodRef(nme.productElement))
+    @threadUnsafe lazy val Product_productPrefix : SymbolPerRun = perRunSym(ProductClass.requiredMethodRef(nme.productPrefix))
 
-  @threadUnsafe lazy val DynamicType: TypeRef                 = ctx.requiredClassRef("scala.Dynamic")
-  def DynamicClass(implicit ctx: Context): ClassSymbol = DynamicType.symbol.asClass
-  @threadUnsafe lazy val OptionType: TypeRef                  = ctx.requiredClassRef("scala.Option")
-  def OptionClass(implicit ctx: Context): ClassSymbol = OptionType.symbol.asClass
-  @threadUnsafe lazy val SomeType: TypeRef                  = ctx.requiredClassRef("scala.Some")
-  def SomeClass(implicit ctx: Context): ClassSymbol = SomeType.symbol.asClass
-  @threadUnsafe lazy val NoneModuleRef: TermRef                  = ctx.requiredModuleRef("scala.None")
-  def NoneClass(implicit ctx: Context): ClassSymbol = NoneModuleRef.symbol.moduleClass.asClass
-  @threadUnsafe lazy val EnumType: TypeRef                    = ctx.requiredClassRef("scala.Enum")
-  def EnumClass(implicit ctx: Context): ClassSymbol = EnumType.symbol.asClass
-    @threadUnsafe lazy val Enum_ordinal: SymbolPerRun = perRun(EnumClass.requiredMethodRef(nme.ordinal))
-  @threadUnsafe lazy val EnumValuesType: TypeRef              = ctx.requiredClassRef("scala.runtime.EnumValues")
-  def EnumValuesClass(implicit ctx: Context): ClassSymbol = EnumValuesType.symbol.asClass
-  @threadUnsafe lazy val ProductType: TypeRef                 = ctx.requiredClassRef("scala.Product")
-  def ProductClass(implicit ctx: Context): ClassSymbol = ProductType.symbol.asClass
-    @threadUnsafe lazy val Product_canEqual      : SymbolPerRun = perRun(ProductClass.requiredMethodRef(nme.canEqual_))
-    @threadUnsafe lazy val Product_productArity  : SymbolPerRun = perRun(ProductClass.requiredMethodRef(nme.productArity))
-    @threadUnsafe lazy val Product_productElement: SymbolPerRun = perRun(ProductClass.requiredMethodRef(nme.productElement))
-    @threadUnsafe lazy val Product_productPrefix : SymbolPerRun = perRun(ProductClass.requiredMethodRef(nme.productPrefix))
-
-  @threadUnsafe lazy val IteratorType: TypeRef = ctx.requiredClassRef("scala.collection.Iterator")
-  def IteratorClass(implicit ctx: Context): ClassSymbol = IteratorType.symbol.asClass
+  @threadUnsafe lazy val IteratorClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.collection.Iterator"))
   def IteratorModule(implicit ctx: Context): Symbol = IteratorClass.companionModule
 
-  @threadUnsafe lazy val ModuleSerializationProxyType: TypeRef  = ctx.requiredClassRef("scala.runtime.ModuleSerializationProxy")
-  def ModuleSerializationProxyClass(implicit ctx: Context): ClassSymbol = ModuleSerializationProxyType.symbol.asClass
+  @threadUnsafe lazy val ModuleSerializationProxyClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.runtime.ModuleSerializationProxy"))
     @threadUnsafe lazy val ModuleSerializationProxyConstructor: TermSymbol =
       ModuleSerializationProxyClass.requiredMethod(nme.CONSTRUCTOR, List(ClassType(TypeBounds.empty)))
 
-  @threadUnsafe lazy val MirrorType: TypeRef = ctx.requiredClassRef("scala.deriving.Mirror")
-  def MirrorClass(implicit ctx: Context): ClassSymbol = MirrorType.symbol.asClass
+  @threadUnsafe lazy val MirrorClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.deriving.Mirror"))
+  @threadUnsafe lazy val Mirror_ProductClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.deriving.Mirror.Product"))
+    @threadUnsafe lazy val Mirror_Product_fromProduct: SymbolPerRun = perRunSym(Mirror_ProductClass.requiredMethodRef(nme.fromProduct))
+  @threadUnsafe lazy val Mirror_SumClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.deriving.Mirror.Sum"))
+  @threadUnsafe lazy val Mirror_SingletonClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.deriving.Mirror.Singleton"))
+  @threadUnsafe lazy val Mirror_SingletonProxyClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.deriving.Mirror.SingletonProxy"))
 
-  @threadUnsafe lazy val Mirror_ProductType: TypeRef = ctx.requiredClassRef("scala.deriving.Mirror.Product")
-  def Mirror_ProductClass(implicit ctx: Context): ClassSymbol = Mirror_ProductType.symbol.asClass
-    @threadUnsafe lazy val Mirror_Product_fromProduct: SymbolPerRun = perRun(Mirror_ProductClass.requiredMethodRef(nme.fromProduct))
+  @threadUnsafe lazy val LanguageModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.language"))
+  @threadUnsafe lazy val NonLocalReturnControlClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.runtime.NonLocalReturnControl"))
+  @threadUnsafe lazy val SelectableClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.Selectable"))
 
-  @threadUnsafe lazy val Mirror_SumType: TypeRef = ctx.requiredClassRef("scala.deriving.Mirror.Sum")
-  def Mirror_SumClass(implicit ctx: Context): ClassSymbol = Mirror_SumType.symbol.asClass
+  @threadUnsafe lazy val ClassTagClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.reflect.ClassTag"))
+  @threadUnsafe lazy val ClassTagModule: SymbolPerRun = ClassTagClass.companionModule
+    @threadUnsafe lazy val ClassTagModule_apply: SymbolPerRun = perRunSym(ClassTagModule.requiredMethodRef(nme.apply))
 
-  @threadUnsafe lazy val Mirror_SingletonType: TypeRef = ctx.requiredClassRef("scala.deriving.Mirror.Singleton")
-  def Mirror_SingletonClass(implicit ctx: Context): ClassSymbol = Mirror_SingletonType.symbol.asClass
+  @threadUnsafe lazy val QuotedExprClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.quoted.Expr"))
+  @threadUnsafe lazy val QuotedExprModule: SymbolPerRun = QuotedExprClass.companionModule
 
-  @threadUnsafe lazy val Mirror_SingletonProxyType: TypeRef = ctx.requiredClassRef("scala.deriving.Mirror.SingletonProxy")
-  def Mirror_SingletonProxyClass(implicit ctx: Context): ClassSymbol = Mirror_SingletonProxyType.symbol.asClass
+  @threadUnsafe lazy val QuoteContextClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.quoted.QuoteContext"))
+  @threadUnsafe lazy val QuoteContextModule: SymbolPerRun = QuoteContextClass.companionModule
+    @threadUnsafe lazy val QuoteContext_macroContext: SymbolPerRun = perRunSym(QuoteContextModule.requiredMethodRef("macroContext"))
 
-  @threadUnsafe lazy val LanguageModuleRef: TermSymbol = ctx.requiredModule("scala.language")
-  def LanguageModuleClass(implicit ctx: Context): ClassSymbol = LanguageModuleRef.moduleClass.asClass
-  @threadUnsafe lazy val NonLocalReturnControlType: TypeRef   = ctx.requiredClassRef("scala.runtime.NonLocalReturnControl")
-  @threadUnsafe lazy val SelectableType: TypeRef              = ctx.requiredClassRef("scala.Selectable")
+  @threadUnsafe lazy val LiftableModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.quoted.Liftable"))
 
-  @threadUnsafe lazy val ClassTagType: TypeRef = ctx.requiredClassRef("scala.reflect.ClassTag")
-  def ClassTagClass(implicit ctx: Context): ClassSymbol = ClassTagType.symbol.asClass
-  def ClassTagModule(implicit ctx: Context): Symbol = ClassTagClass.companionModule
-    @threadUnsafe lazy val ClassTagModule_apply: SymbolPerRun = perRun(ClassTagModule.requiredMethodRef(nme.apply))
-
-  @threadUnsafe lazy val QuotedExprType: TypeRef = ctx.requiredClassRef("scala.quoted.Expr")
-  def QuotedExprClass(implicit ctx: Context): ClassSymbol = QuotedExprType.symbol.asClass
-  def QuotedExprModule(implicit ctx: Context): Symbol = QuotedExprClass.companionModule
-
-  @threadUnsafe lazy val QuoteContextType: TypeRef = ctx.requiredClassRef("scala.quoted.QuoteContext")
-  def QuoteContextClass(implicit ctx: Context): ClassSymbol = QuoteContextType.symbol.asClass
-
-  @threadUnsafe lazy val QuoteContextModule: TermSymbol = ctx.requiredModule("scala.quoted.QuoteContext")
-    @threadUnsafe lazy val QuoteContext_macroContext: TermSymbol = QuoteContextModule.requiredMethod("macroContext")
-
-  @threadUnsafe lazy val LiftableModule: TermSymbol = ctx.requiredModule("scala.quoted.Liftable")
-
-  @threadUnsafe lazy val InternalQuotedModuleRef: TermRef = ctx.requiredModuleRef("scala.internal.Quoted")
-  def InternalQuotedModule: Symbol = InternalQuotedModuleRef.symbol
-    @threadUnsafe lazy val InternalQuoted_exprQuote  : SymbolPerRun = perRun(InternalQuotedModule.requiredMethodRef("exprQuote"))
-    @threadUnsafe lazy val InternalQuoted_exprSplice : SymbolPerRun = perRun(InternalQuotedModule.requiredMethodRef("exprSplice"))
-    @threadUnsafe lazy val InternalQuoted_typeQuote  : SymbolPerRun = perRun(InternalQuotedModule.requiredMethodRef("typeQuote"))
-    @threadUnsafe lazy val InternalQuoted_patternHole: SymbolPerRun = perRun(InternalQuotedModule.requiredMethodRef("patternHole"))
+  @threadUnsafe lazy val InternalQuotedModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.internal.Quoted"))
+    @threadUnsafe lazy val InternalQuoted_exprQuote  : SymbolPerRun = perRunSym(InternalQuotedModule.requiredMethodRef("exprQuote"))
+    @threadUnsafe lazy val InternalQuoted_exprSplice : SymbolPerRun = perRunSym(InternalQuotedModule.requiredMethodRef("exprSplice"))
+    @threadUnsafe lazy val InternalQuoted_typeQuote  : SymbolPerRun = perRunSym(InternalQuotedModule.requiredMethodRef("typeQuote"))
+    @threadUnsafe lazy val InternalQuoted_patternHole: SymbolPerRun = perRunSym(InternalQuotedModule.requiredMethodRef("patternHole"))
     @threadUnsafe lazy val InternalQuoted_patternBindHoleAnnot: ClassSymbol = InternalQuotedModule.requiredClass("patternBindHole")
     @threadUnsafe lazy val InternalQuoted_QuoteTypeTagAnnot: ClassSymbol = InternalQuotedModule.requiredClass("quoteTypeTag")
 
-  @threadUnsafe lazy val InternalQuotedMatcherModuleRef: TermRef = ctx.requiredModuleRef("scala.internal.quoted.Matcher")
-  def InternalQuotedMatcherModule(implicit ctx: Context): Symbol = InternalQuotedMatcherModuleRef.symbol
-    @threadUnsafe lazy val InternalQuotedMatcher_unapply: SymbolPerRun = perRun(InternalQuotedMatcherModule.requiredMethodRef(nme.unapply))
+  @threadUnsafe lazy val InternalQuotedMatcherModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.internal.quoted.Matcher"))
+    @threadUnsafe lazy val InternalQuotedMatcher_unapply: SymbolPerRun = perRunSym(InternalQuotedMatcherModule.requiredMethodRef(nme.unapply))
 
-  @threadUnsafe lazy val QuotedTypeType: TypeRef = ctx.requiredClassRef("scala.quoted.Type")
-  def QuotedTypeClass(implicit ctx: Context): ClassSymbol = QuotedTypeType.symbol.asClass
+  @threadUnsafe lazy val QuotedTypeClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.quoted.Type"))
+    @threadUnsafe lazy val QuotedType_splice: Symbol = QuotedTypeClass.requiredType(tpnme.splice)
 
-    @threadUnsafe lazy val QuotedType_spliceR: TypeRef = QuotedTypeClass.requiredType(tpnme.splice).typeRef
-    def QuotedType_splice : Symbol = QuotedType_spliceR.symbol
+  @threadUnsafe lazy val QuotedTypeModule: SymbolPerRun = QuotedTypeClass.companionModule
 
-  @threadUnsafe lazy val QuotedTypeModuleRef: TermRef = ctx.requiredModuleRef("scala.quoted.Type")
-  def QuotedTypeModule(implicit ctx: Context): Symbol = QuotedTypeModuleRef.symbol
+  @threadUnsafe lazy val QuotedMatchingBindingClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.quoted.matching.Bind"))
+  @threadUnsafe lazy val TastyReflectionClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.tasty.Reflection"))
 
-  @threadUnsafe lazy val QuotedMatchingBindingType: TypeRef = ctx.requiredClassRef("scala.quoted.matching.Bind")
-  def QuotedMatchingBindingClass(implicit ctx: Context): ClassSymbol = QuotedMatchingBindingType.symbol.asClass
+  @threadUnsafe lazy val Unpickler_unpickleExpr: SymbolPerRun = perRunSym(ctx.requiredMethodRef("scala.runtime.quoted.Unpickler.unpickleExpr"))
+  @threadUnsafe lazy val Unpickler_unpickleType: SymbolPerRun = perRunSym(ctx.requiredMethodRef("scala.runtime.quoted.Unpickler.unpickleType"))
 
-  def Unpickler_unpickleExpr: TermSymbol = ctx.requiredMethod("scala.runtime.quoted.Unpickler.unpickleExpr")
-  def Unpickler_unpickleType: TermSymbol = ctx.requiredMethod("scala.runtime.quoted.Unpickler.unpickleType")
+  @threadUnsafe lazy val EqlClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.Eql"))
+    def Eql_eqlAny(implicit ctx: Context): TermSymbol = EqlClass.companionModule.requiredMethod(nme.eqlAny)
 
-  @threadUnsafe lazy val TastyReflectionType: TypeRef = ctx.requiredClassRef("scala.tasty.Reflection")
-  def TastyReflectionClass(implicit ctx: Context): ClassSymbol = TastyReflectionType.symbol.asClass
+  @threadUnsafe lazy val TypeBoxClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.internal.TypeBox"))
+    @threadUnsafe lazy val TypeBox_CAP: TypeSymbol = TypeBoxClass.requiredType(tpnme.CAP)
 
-  @threadUnsafe lazy val EqlType: TypeRef = ctx.requiredClassRef("scala.Eql")
-  def EqlClass(implicit ctx: Context): ClassSymbol = EqlType.symbol.asClass
-  def EqlModule(implicit ctx: Context): Symbol = EqlClass.companionModule
+  @threadUnsafe lazy val MatchCaseClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.internal.MatchCase"))
+  @threadUnsafe lazy val NotClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.implicits.Not"))
+    @threadUnsafe lazy val Not_value: SymbolPerRun = perRunSym(NotClass.companionModule.requiredMethodRef(nme.value))
 
-    def Eql_eqlAny(implicit ctx: Context): TermSymbol = EqlModule.requiredMethod(nme.eqlAny)
+  @threadUnsafe lazy val ValueOfClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.ValueOf"))
+  @threadUnsafe lazy val StatsModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("dotty.tools.dotc.util.Stats"))
+    @threadUnsafe lazy val  Stats_doRecord: SymbolPerRun = perRunSym(StatsModule.requiredMethodRef("doRecord"))
 
-  @threadUnsafe lazy val TypeBoxType: TypeRef = ctx.requiredClassRef("scala.internal.TypeBox")
-
-    @threadUnsafe lazy val TypeBox_CAP: TypeSymbol = TypeBoxType.symbol.requiredType(tpnme.CAP)
-
-  @threadUnsafe lazy val MatchCaseType: TypeRef = ctx.requiredClassRef("scala.internal.MatchCase")
-  def MatchCaseClass(implicit ctx: Context): ClassSymbol = MatchCaseType.symbol.asClass
-
-  @threadUnsafe lazy val NotType: TypeRef = ctx.requiredClassRef("scala.implicits.Not")
-  def NotClass(implicit ctx: Context): ClassSymbol = NotType.symbol.asClass
-  def NotModule(implicit ctx: Context): Symbol = NotClass.companionModule
-
-    def Not_value(implicit ctx: Context): TermSymbol = NotModule.requiredMethod(nme.value)
-
-  @threadUnsafe lazy val ValueOfType: TypeRef = ctx.requiredClassRef("scala.ValueOf")
-  def ValueOfClass(implicit ctx: Context): ClassSymbol = ValueOfType.symbol.asClass
-
-  @threadUnsafe lazy val StatsModule = ctx.requiredModule("dotty.tools.dotc.util.Stats")
-    def Stats_doRecord(implicit ctx: Context): TermSymbol = StatsModule.requiredMethod("doRecord")
-
-  @threadUnsafe lazy val XMLTopScopeModuleRef: TermRef = ctx.requiredModuleRef("scala.xml.TopScope")
+  @threadUnsafe lazy val XMLTopScopeModule: SymbolPerRun = perRunSym(ctx.requiredModuleRef("scala.xml.TopScope"))
 
   @threadUnsafe lazy val TupleTypeRef: TypeRef = ctx.requiredClassRef("scala.Tuple")
   def TupleClass(implicit ctx: Context): ClassSymbol = TupleTypeRef.symbol.asClass
-    @threadUnsafe lazy val Tuple_cons: SymbolPerRun = perRun(TupleClass.requiredMethodRef("*:"))
+    @threadUnsafe lazy val Tuple_cons: SymbolPerRun = perRunSym(TupleClass.requiredMethodRef("*:"))
   @threadUnsafe lazy val NonEmptyTupleTypeRef: TypeRef = ctx.requiredClassRef("scala.NonEmptyTuple")
   def NonEmptyTupleClass(implicit ctx: Context): ClassSymbol = NonEmptyTupleTypeRef.symbol.asClass
-    lazy val NonEmptyTuple_tail: SymbolPerRun = perRun(NonEmptyTupleClass.requiredMethodRef("tail"))
+    lazy val NonEmptyTuple_tail: SymbolPerRun = perRunSym(NonEmptyTupleClass.requiredMethodRef("tail"))
 
-  @threadUnsafe lazy val PairType: TypeRef = ctx.requiredClassRef("scala.*:")
-  def PairClass(implicit ctx: Context): ClassSymbol = PairType.symbol.asClass
-  @threadUnsafe lazy val TupleXXLType: TypeRef = ctx.requiredClassRef("scala.TupleXXL")
-  def TupleXXLClass(implicit ctx: Context): ClassSymbol = TupleXXLType.symbol.asClass
+  @threadUnsafe lazy val PairClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.*:"))
+  @threadUnsafe lazy val TupleXXLClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.TupleXXL"))
   def TupleXXLModule(implicit ctx: Context): Symbol = TupleXXLClass.companionModule
 
     def TupleXXL_apply(implicit ctx: Context): Symbol =
@@ -830,100 +734,54 @@ class Definitions {
   def InternalTupleFunctionModule(implicit ctx: Context): Symbol = ctx.requiredModule("scala.internal.TupledFunction")
 
   // Annotation base classes
-  @threadUnsafe lazy val AnnotationType: TypeRef              = ctx.requiredClassRef("scala.annotation.Annotation")
-  def AnnotationClass(implicit ctx: Context): ClassSymbol = AnnotationType.symbol.asClass
-  @threadUnsafe lazy val ClassfileAnnotationType: TypeRef     = ctx.requiredClassRef("scala.annotation.ClassfileAnnotation")
-  def ClassfileAnnotationClass(implicit ctx: Context): ClassSymbol = ClassfileAnnotationType.symbol.asClass
-  @threadUnsafe lazy val StaticAnnotationType: TypeRef        = ctx.requiredClassRef("scala.annotation.StaticAnnotation")
-  def StaticAnnotationClass(implicit ctx: Context): ClassSymbol = StaticAnnotationType.symbol.asClass
-  @threadUnsafe lazy val RefiningAnnotationType: TypeRef      = ctx.requiredClassRef("scala.annotation.RefiningAnnotation")
-  def RefiningAnnotationClass(implicit ctx: Context): ClassSymbol = RefiningAnnotationType.symbol.asClass
+  @threadUnsafe lazy val AnnotationClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.Annotation"))
+  @threadUnsafe lazy val ClassfileAnnotationClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.ClassfileAnnotation"))
+  @threadUnsafe lazy val StaticAnnotationClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.StaticAnnotation"))
+  @threadUnsafe lazy val RefiningAnnotationClass: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.RefiningAnnotation"))
 
   // Annotation classes
-  @threadUnsafe lazy val AliasAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.Alias")
-  def AliasAnnot(implicit ctx: Context): ClassSymbol = AliasAnnotType.symbol.asClass
-  @threadUnsafe lazy val AnnotationDefaultAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.AnnotationDefault")
-  def AnnotationDefaultAnnot(implicit ctx: Context): ClassSymbol = AnnotationDefaultAnnotType.symbol.asClass
-  @threadUnsafe lazy val BodyAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.Body")
-  def BodyAnnot(implicit ctx: Context): ClassSymbol = BodyAnnotType.symbol.asClass
-  @threadUnsafe lazy val ChildAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.Child")
-  def ChildAnnot(implicit ctx: Context): ClassSymbol = ChildAnnotType.symbol.asClass
-  @threadUnsafe lazy val WithBoundsAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.WithBounds")
-  def WithBoundsAnnot(implicit ctx: Context): ClassSymbol = WithBoundsAnnotType.symbol.asClass
-  @threadUnsafe lazy val CovariantBetweenAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.CovariantBetween")
-  def CovariantBetweenAnnot(implicit ctx: Context): ClassSymbol = CovariantBetweenAnnotType.symbol.asClass
-  @threadUnsafe lazy val ContravariantBetweenAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.ContravariantBetween")
-  def ContravariantBetweenAnnot(implicit ctx: Context): ClassSymbol = ContravariantBetweenAnnotType.symbol.asClass
-  @threadUnsafe lazy val DeprecatedAnnotType: TypeRef = ctx.requiredClassRef("scala.deprecated")
-  def DeprecatedAnnot(implicit ctx: Context): ClassSymbol = DeprecatedAnnotType.symbol.asClass
-  @threadUnsafe lazy val ImplicitAmbiguousAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.implicitAmbiguous")
-  def ImplicitAmbiguousAnnot(implicit ctx: Context): ClassSymbol = ImplicitAmbiguousAnnotType.symbol.asClass
-  @threadUnsafe lazy val ImplicitNotFoundAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.implicitNotFound")
-  def ImplicitNotFoundAnnot(implicit ctx: Context): ClassSymbol = ImplicitNotFoundAnnotType.symbol.asClass
-  @threadUnsafe lazy val ForceInlineAnnotType: TypeRef = ctx.requiredClassRef("scala.forceInline")
-  def ForceInlineAnnot(implicit ctx: Context): ClassSymbol = ForceInlineAnnotType.symbol.asClass
-  @threadUnsafe lazy val InlineParamAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.InlineParam")
-  def InlineParamAnnot(implicit ctx: Context): ClassSymbol = InlineParamAnnotType.symbol.asClass
-  @threadUnsafe lazy val InvariantBetweenAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.InvariantBetween")
-  def InvariantBetweenAnnot(implicit ctx: Context): ClassSymbol = InvariantBetweenAnnotType.symbol.asClass
-  @threadUnsafe lazy val MigrationAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.migration")
-  def MigrationAnnot(implicit ctx: Context): ClassSymbol = MigrationAnnotType.symbol.asClass
-  @threadUnsafe lazy val NativeAnnotType: TypeRef                   = ctx.requiredClassRef("scala.native")
-  def NativeAnnot(implicit ctx: Context): ClassSymbol = NativeAnnotType.symbol.asClass
-  @threadUnsafe lazy val RepeatedAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.Repeated")
-  def RepeatedAnnot(implicit ctx: Context): ClassSymbol = RepeatedAnnotType.symbol.asClass
-  @threadUnsafe lazy val SourceFileAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.SourceFile")
-  def SourceFileAnnot(implicit ctx: Context): ClassSymbol = SourceFileAnnotType.symbol.asClass
-  @threadUnsafe lazy val ScalaSignatureAnnotType: TypeRef = ctx.requiredClassRef("scala.reflect.ScalaSignature")
-  def ScalaSignatureAnnot(implicit ctx: Context): ClassSymbol = ScalaSignatureAnnotType.symbol.asClass
-  @threadUnsafe lazy val ScalaLongSignatureAnnotType: TypeRef = ctx.requiredClassRef("scala.reflect.ScalaLongSignature")
-  def ScalaLongSignatureAnnot(implicit ctx: Context): ClassSymbol = ScalaLongSignatureAnnotType.symbol.asClass
-  @threadUnsafe lazy val ScalaStrictFPAnnotType: TypeRef            = ctx.requiredClassRef("scala.annotation.strictfp")
-  def ScalaStrictFPAnnot(implicit ctx: Context): ClassSymbol = ScalaStrictFPAnnotType.symbol.asClass
-  @threadUnsafe lazy val ScalaStaticAnnotType: TypeRef            = ctx.requiredClassRef("scala.annotation.static")
-  def ScalaStaticAnnot(implicit ctx: Context): ClassSymbol = ScalaStaticAnnotType.symbol.asClass
-  @threadUnsafe lazy val SerialVersionUIDAnnotType: TypeRef         = ctx.requiredClassRef("scala.SerialVersionUID")
-  def SerialVersionUIDAnnot(implicit ctx: Context): ClassSymbol = SerialVersionUIDAnnotType.symbol.asClass
-  @threadUnsafe lazy val TASTYSignatureAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.TASTYSignature")
-  def TASTYSignatureAnnot(implicit ctx: Context): ClassSymbol = TASTYSignatureAnnotType.symbol.asClass
-  @threadUnsafe lazy val TASTYLongSignatureAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.internal.TASTYLongSignature")
-  def TASTYLongSignatureAnnot(implicit ctx: Context): ClassSymbol = TASTYLongSignatureAnnotType.symbol.asClass
-  @threadUnsafe lazy val TailrecAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.tailrec")
-  def TailrecAnnot(implicit ctx: Context): ClassSymbol = TailrecAnnotType.symbol.asClass
-  @threadUnsafe lazy val ThreadUnsafeAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.threadUnsafe")
-  def ThreadUnsafeAnnot(implicit ctx: Context): ClassSymbol = ThreadUnsafeAnnotType.symbol.asClass
-  @threadUnsafe lazy val TransientParamAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.constructorOnly")
-  def TransientParamAnnot(implicit ctx: Context): ClassSymbol = TransientParamAnnotType.symbol.asClass
-  @threadUnsafe lazy val CompileTimeOnlyAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.compileTimeOnly")
-  def CompileTimeOnlyAnnot(implicit ctx: Context): ClassSymbol = CompileTimeOnlyAnnotType.symbol.asClass
-  @threadUnsafe lazy val SwitchAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.switch")
-  def SwitchAnnot(implicit ctx: Context): ClassSymbol = SwitchAnnotType.symbol.asClass
-  @threadUnsafe lazy val ThrowsAnnotType: TypeRef = ctx.requiredClassRef("scala.throws")
-  def ThrowsAnnot(implicit ctx: Context): ClassSymbol = ThrowsAnnotType.symbol.asClass
-  @threadUnsafe lazy val TransientAnnotType: TypeRef                = ctx.requiredClassRef("scala.transient")
-  def TransientAnnot(implicit ctx: Context): ClassSymbol = TransientAnnotType.symbol.asClass
-  @threadUnsafe lazy val UncheckedAnnotType: TypeRef = ctx.requiredClassRef("scala.unchecked")
-  def UncheckedAnnot(implicit ctx: Context): ClassSymbol = UncheckedAnnotType.symbol.asClass
-  @threadUnsafe lazy val UncheckedStableAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.unchecked.uncheckedStable")
-  def UncheckedStableAnnot(implicit ctx: Context): ClassSymbol = UncheckedStableAnnotType.symbol.asClass
-  @threadUnsafe lazy val UncheckedVarianceAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.unchecked.uncheckedVariance")
-  def UncheckedVarianceAnnot(implicit ctx: Context): ClassSymbol = UncheckedVarianceAnnotType.symbol.asClass
-  @threadUnsafe lazy val VolatileAnnotType: TypeRef = ctx.requiredClassRef("scala.volatile")
-  def VolatileAnnot(implicit ctx: Context): ClassSymbol = VolatileAnnotType.symbol.asClass
-  @threadUnsafe lazy val FieldMetaAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.meta.field")
-  def FieldMetaAnnot(implicit ctx: Context): ClassSymbol = FieldMetaAnnotType.symbol.asClass
-  @threadUnsafe lazy val GetterMetaAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.meta.getter")
-  def GetterMetaAnnot(implicit ctx: Context): ClassSymbol = GetterMetaAnnotType.symbol.asClass
-  @threadUnsafe lazy val SetterMetaAnnotType: TypeRef = ctx.requiredClassRef("scala.annotation.meta.setter")
-  def SetterMetaAnnot(implicit ctx: Context): ClassSymbol = SetterMetaAnnotType.symbol.asClass
-  @threadUnsafe lazy val ShowAsInfixAnotType: TypeRef = ctx.requiredClassRef("scala.annotation.showAsInfix")
-  def ShowAsInfixAnnot(implicit ctx: Context): ClassSymbol = ShowAsInfixAnotType.symbol.asClass
-  @threadUnsafe lazy val FunctionalInterfaceAnnotType = ctx.requiredClassRef("java.lang.FunctionalInterface")
-  def FunctionalInterfaceAnnot(implicit ctx: Context) = FunctionalInterfaceAnnotType.symbol.asClass
-  @threadUnsafe lazy val InfixAnnotType = ctx.requiredClassRef("scala.annotation.infix")
-  def InfixAnnot(implicit ctx: Context) = InfixAnnotType.symbol.asClass
-  @threadUnsafe lazy val AlphaAnnotType = ctx.requiredClassRef("scala.annotation.alpha")
-  def AlphaAnnot(implicit ctx: Context) = AlphaAnnotType.symbol.asClass
+  @threadUnsafe lazy val AliasAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.Alias"))
+  @threadUnsafe lazy val AnnotationDefaultAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.AnnotationDefault"))
+  @threadUnsafe lazy val BodyAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.Body"))
+  @threadUnsafe lazy val ChildAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.Child"))
+  @threadUnsafe lazy val WithBoundsAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.WithBounds"))
+  @threadUnsafe lazy val CovariantBetweenAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.CovariantBetween"))
+  @threadUnsafe lazy val ContravariantBetweenAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.ContravariantBetween"))
+  @threadUnsafe lazy val DeprecatedAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.deprecated"))
+  @threadUnsafe lazy val ImplicitAmbiguousAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.implicitAmbiguous"))
+  @threadUnsafe lazy val ImplicitNotFoundAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.implicitNotFound"))
+  @threadUnsafe lazy val ForceInlineAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.forceInline"))
+  @threadUnsafe lazy val InlineParamAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.InlineParam"))
+  @threadUnsafe lazy val InvariantBetweenAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.InvariantBetween"))
+  @threadUnsafe lazy val MigrationAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.migration"))
+  @threadUnsafe lazy val NativeAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.native"))
+  @threadUnsafe lazy val RepeatedAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.Repeated"))
+  @threadUnsafe lazy val SourceFileAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.SourceFile"))
+  @threadUnsafe lazy val ScalaSignatureAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.reflect.ScalaSignature"))
+  @threadUnsafe lazy val ScalaLongSignatureAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.reflect.ScalaLongSignature"))
+  @threadUnsafe lazy val ScalaStrictFPAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.strictfp"))
+  @threadUnsafe lazy val ScalaStaticAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.static"))
+  @threadUnsafe lazy val SerialVersionUIDAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.SerialVersionUID"))
+  @threadUnsafe lazy val TASTYSignatureAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.TASTYSignature"))
+  @threadUnsafe lazy val TASTYLongSignatureAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.internal.TASTYLongSignature"))
+  @threadUnsafe lazy val TailrecAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.tailrec"))
+  @threadUnsafe lazy val ThreadUnsafeAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.threadUnsafe"))
+  @threadUnsafe lazy val TransientParamAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.constructorOnly"))
+  @threadUnsafe lazy val CompileTimeOnlyAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.compileTimeOnly"))
+  @threadUnsafe lazy val SwitchAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.switch"))
+  @threadUnsafe lazy val ThrowsAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.throws"))
+  @threadUnsafe lazy val TransientAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.transient"))
+  @threadUnsafe lazy val UncheckedAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.unchecked"))
+  @threadUnsafe lazy val UncheckedStableAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.unchecked.uncheckedStable"))
+  @threadUnsafe lazy val UncheckedVarianceAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.unchecked.uncheckedVariance"))
+  @threadUnsafe lazy val VolatileAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.volatile"))
+  @threadUnsafe lazy val FieldMetaAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.meta.field"))
+  @threadUnsafe lazy val GetterMetaAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.meta.getter"))
+  @threadUnsafe lazy val SetterMetaAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.meta.setter"))
+  @threadUnsafe lazy val ShowAsInfixAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.showAsInfix"))
+  @threadUnsafe lazy val FunctionalInterfaceAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("java.lang.FunctionalInterface"))
+  @threadUnsafe lazy val InfixAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.infix"))
+  @threadUnsafe lazy val AlphaAnnot: ClassSymbolPerRun = perRunClass(ctx.requiredClassRef("scala.annotation.alpha"))
 
   // convenient one-parameter method types
   def methOfAny(tp: Type): MethodType = MethodType(List(AnyType), tp)
@@ -963,7 +821,7 @@ class Definitions {
 
   object PartialFunctionOf {
     def apply(arg: Type, result: Type)(implicit ctx: Context): Type =
-      PartialFunctionType.appliedTo(arg :: result :: Nil)
+      PartialFunctionClass.typeRef.appliedTo(arg :: result :: Nil)
     def unapply(pft: Type)(implicit ctx: Context): Option[(Type, List[Type])] = {
       if (pft.isRef(PartialFunctionClass)) {
         val targs = pft.dealias.argInfos
@@ -985,7 +843,7 @@ class Definitions {
 
   object MatchCase {
     def apply(pat: Type, body: Type)(implicit ctx: Context): Type =
-      MatchCaseType.appliedTo(pat, body)
+      MatchCaseClass.typeRef.appliedTo(pat, body)
     def unapply(tp: Type)(implicit ctx: Context): Option[(Type, Type)] = tp match {
       case AppliedType(tycon, pat :: body :: Nil) if tycon.isRef(MatchCaseClass) =>
         Some((pat, body))
@@ -1066,7 +924,7 @@ class Definitions {
     else
       ctx.requiredClass("scala.Function" + n.toString)
 
-    @threadUnsafe lazy val Function0_apply: SymbolPerRun = perRun(ImplementedFunctionType(0).symbol.requiredMethodRef(nme.apply))
+    @threadUnsafe lazy val Function0_apply: SymbolPerRun = perRunSym(ImplementedFunctionType(0).symbol.requiredMethodRef(nme.apply))
 
   def FunctionType(n: Int, isContextual: Boolean = false, isErased: Boolean = false)(implicit ctx: Context): TypeRef =
     if (n <= MaxImplementedFunctionArity && (!isContextual || ctx.erasedTypes) && !isErased) ImplementedFunctionType(n)
@@ -1169,7 +1027,7 @@ class Definitions {
   def erasedFunctionType(cls: Symbol): Type = {
     val arity = scalaClassName(cls).functionArity
     if (cls.name.isErasedFunction) FunctionType(0)
-    else if (arity > 22) FunctionXXLType
+    else if (arity > 22) FunctionXXLClass.typeRef
     else if (arity >= 0) FunctionType(arity)
     else NoType
   }
@@ -1242,8 +1100,7 @@ class Definitions {
     rec(tp.stripTypeVar, Nil, bound)
   }
 
-  def isProductSubType(tp: Type)(implicit ctx: Context): Boolean =
-    tp.derivesFrom(ProductType.symbol)
+  def isProductSubType(tp: Type)(implicit ctx: Context): Boolean = tp.derivesFrom(ProductClass)
 
   /** Is `tp` (an alias) of either a scala.FunctionN or a scala.ImplicitFunctionN
    *  instance?
@@ -1389,17 +1246,17 @@ class Definitions {
   /** The type of the boxed class corresponding to primitive value type `tp`. */
   def boxedType(tp: Type)(implicit ctx: Context): TypeRef = {
     val cls = tp.classSymbol
-    if (cls eq ByteClass)         BoxedByteType
-    else if (cls eq ShortClass)   BoxedShortType
-    else if (cls eq CharClass)    BoxedCharType
-    else if (cls eq IntClass)     BoxedIntType
-    else if (cls eq LongClass)    BoxedLongType
-    else if (cls eq FloatClass)   BoxedFloatType
-    else if (cls eq DoubleClass)  BoxedDoubleType
-    else if (cls eq UnitClass)    BoxedUnitType
-    else if (cls eq BooleanClass) BoxedBooleanType
+    if (cls eq ByteClass)         BoxedByteClass
+    else if (cls eq ShortClass)   BoxedShortClass
+    else if (cls eq CharClass)    BoxedCharClass
+    else if (cls eq IntClass)     BoxedIntClass
+    else if (cls eq LongClass)    BoxedLongClass
+    else if (cls eq FloatClass)   BoxedFloatClass
+    else if (cls eq DoubleClass)  BoxedDoubleClass
+    else if (cls eq UnitClass)    BoxedUnitClass
+    else if (cls eq BooleanClass) BoxedBooleanClass
     else sys.error(s"Not a primitive value type: $tp")
-  }
+  }.typeRef
 
   /** The JVM tag for `tp` if it's a primitive, `java.lang.Object` otherwise. */
   def typeTag(tp: Type)(implicit ctx: Context): Name = typeTags(scalaClassName(tp))

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -600,11 +600,11 @@ object SymDenotations {
 
     /** Is symbol a primitive value class? */
     def isPrimitiveValueClass(implicit ctx: Context): Boolean =
-      maybeOwner == defn.ScalaPackageClass && defn.ScalaValueClasses().contains(symbol)
+      maybeOwner == defn.ScalaPackageClass && defn.ScalaValueClasses.contains(symbol)
 
     /** Is symbol a primitive numeric value class? */
     def isNumericValueClass(implicit ctx: Context): Boolean =
-      maybeOwner == defn.ScalaPackageClass && defn.ScalaNumericValueClasses().contains(symbol)
+      maybeOwner == defn.ScalaPackageClass && defn.ScalaNumericValueClasses.contains(symbol)
 
     /** Is symbol a class for which no runtime representation exists? */
     def isNotRuntimeClass(implicit ctx: Context): Boolean = defn.NotRuntimeClasses contains symbol

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -193,7 +193,7 @@ object TypeErasure {
     else erase.eraseInfo(tp, sym)(erasureCtx) match {
       case einfo: MethodType =>
         if (sym.isGetter && einfo.resultType.isRef(defn.UnitClass))
-          MethodType(Nil, defn.BoxedUnitType)
+          MethodType(Nil, defn.BoxedUnitClass.typeRef)
         else if (sym.isAnonymousFunction && einfo.paramInfos.length > MaxImplementedFunctionArity)
           MethodType(nme.ALLARGS :: Nil, JavaArrayType(defn.ObjectType) :: Nil, einfo.resultType)
         else if (sym.name == nme.apply && sym.owner.derivesFrom(defn.PolyFunctionClass)) {
@@ -512,9 +512,9 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
 
   private def erasePair(tp: Type)(implicit ctx: Context): Type = {
     val arity = tp.tupleArity
-    if (arity < 0) defn.ProductType
+    if (arity < 0) defn.ProductClass.typeRef
     else if (arity <= Definitions.MaxTupleArity) defn.TupleType(arity)
-    else defn.TupleXXLType
+    else defn.TupleXXLClass.typeRef
   }
 
   /** The erasure of a symbol's info. This is different from `apply` in the way `ExprType`s and

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -480,7 +480,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
    */
   def featureEnabled(feature: TermName, owner: Symbol = NoSymbol): Boolean = {
     def hasImport = {
-      val owner1 = if (!owner.exists) defn.LanguageModuleClass else owner
+      val owner1 = if (!owner.exists) defn.LanguageModule.moduleClass else owner
       ctx.importInfo != null &&
       ctx.importInfo.featureImported(feature, owner1)(ctx.withPhase(ctx.typerPhase))
     }
@@ -673,5 +673,5 @@ object TypeOps {
   // TODO: Move other typeops here. It's a bit weird that they are a part of `ctx`
 
   def nestedPairs(ts: List[Type])(implicit ctx: Context): Type =
-    (ts :\ (defn.UnitType: Type))(defn.PairType.appliedTo(_, _))
+    (ts :\ (defn.UnitType: Type))(defn.PairClass.typeRef.appliedTo(_, _))
 }

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -132,7 +132,7 @@ class ClassfileParser(
     /** Parse parents for Java classes. For Scala, return AnyRef, since the real type will be unpickled.
      *  Updates the read pointer of 'in'. */
     def parseParents: List[Type] = {
-      val superType = if (isAnnotation) { in.nextChar; defn.AnnotationType }
+      val superType = if (isAnnotation) { in.nextChar; defn.AnnotationClass.typeRef }
                       else pool.getSuperClass(in.nextChar).typeRef
       val ifaceCount = in.nextChar
       var ifaces = for (i <- (0 until ifaceCount).toList) yield pool.getSuperClass(in.nextChar).typeRef
@@ -142,7 +142,7 @@ class ClassfileParser(
         // Consequently, no best implicit for the "Integral" evidence parameter of "range"
         // is found. Previously, this worked because of weak conformance, which has been dropped.
 
-      if (isAnnotation) ifaces = defn.ClassfileAnnotationType :: ifaces
+      if (isAnnotation) ifaces = defn.ClassfileAnnotationClass.typeRef :: ifaces
       superType :: ifaces
     }
 

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -176,7 +176,7 @@ class ClassfileParser(
     } else if (result == Some(NoEmbedded)) {
       for (sym <- List(moduleRoot.sourceModule, moduleRoot.symbol, classRoot.symbol)) {
         classRoot.owner.asClass.delete(sym)
-        if (classRoot.owner == defn.ScalaShadowingPackageClass) {
+        if (classRoot.owner == defn.ScalaShadowingPackage.moduleClass) {
           // Symbols in scalaShadowing are also added to scala
           defn.ScalaPackageClass.delete(sym)
         }

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -899,7 +899,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     // array elements are trees representing instances of scala.annotation.Annotation
     SeqLiteral(
       until(end, () => readClassfileAnnotArg(readNat())),
-      TypeTree(defn.AnnotationType))
+      TypeTree(defn.AnnotationClass.typeRef))
   }
 
   private def readAnnotInfoArg()(implicit ctx: Context): Tree = {

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -849,8 +849,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       val start = readIndex
       readNat() // skip reference for now
       target.addAnnotation(
-          Annotation.Child(implicit ctx =>
-              atReadPos(start, () => readSymbolRef()), NoSpan))
+          Annotation.Child.later(atReadPos(start, () => readSymbolRef()), NoSpan))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2722,7 +2722,7 @@ object Parsers {
                 case _ =>
                   if (mods.is(Opaque)) {
                     val annotType = AppliedTypeTree(
-                      TypeTree(defn.WithBoundsAnnotType),
+                      TypeTree(defn.WithBoundsAnnot.typeRef),
                         bounds.lo.orElse(TypeTree(defn.NothingType)) ::
                         bounds.hi.orElse(TypeTree(defn.AnyType)) :: Nil)
                     rhs = Annotated(rhs, ensureApplied(wrapNew(annotType)))

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -125,8 +125,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
    *  They are either aliased in scala.Predef or in the scala package object.
    */
   private[this] lazy val printWithoutPrefix: Set[Symbol] =
-    (defn.ScalaPredefModuleRef.typeAliasMembers
-      ++ defn.ScalaPackageObjectRef.typeAliasMembers).map(_.info.classSymbol).toSet
+    (defn.ScalaPredefModule.termRef.typeAliasMembers
+      ++ defn.ScalaPackageObject.termRef.typeAliasMembers).map(_.info.classSymbol).toSet
 
   def toText(tp: Type): Text = controlled {
     homogenize(tp) match {

--- a/compiler/src/dotty/tools/dotc/tastyreflect/KernelImpl.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/KernelImpl.scala
@@ -1820,7 +1820,7 @@ class KernelImpl(val rootContext: core.Contexts.Context, val rootPosition: util.
   def Definitions_RepeatedParamClass: ClassDefSymbol = defn.RepeatedParamClass
 
   def Definitions_OptionClass: Symbol = defn.OptionClass
-  def Definitions_NoneModule: Symbol = defn.NoneClass.companionModule.asTerm
+  def Definitions_NoneModule: Symbol = defn.NoneModule
   def Definitions_SomeModule: Symbol = defn.SomeClass.companionModule.asTerm
 
   def Definitions_ProductClass: Symbol = defn.ProductClass

--- a/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
@@ -23,7 +23,7 @@ class ArrayApply extends MiniPhase {
   override def phaseName: String = "arrayApply"
 
   override def transformApply(tree: tpd.Apply)(implicit ctx: Context): tpd.Tree = {
-    if (tree.symbol.name == nme.apply && tree.symbol.owner == defn.ArrayModule) { // Is `Array.apply`
+    if (tree.symbol.name == nme.apply && tree.symbol.owner == defn.ArrayModule.moduleClass) { // Is `Array.apply`
       tree.args match {
         case StripAscription(Apply(wrapRefArrayMeth, (seqLit: tpd.JavaSeqLiteral) :: Nil)) :: ct :: Nil
             if defn.WrapArrayMethods().contains(wrapRefArrayMeth.symbol) && elideClassTag(ct) =>

--- a/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
@@ -51,7 +51,7 @@ class ArrayApply extends MiniPhase {
         case _: Literal => true // ClassTag.apply(classOf[XYZ])
         case rc: RefTree if rc.name == nme.TYPE_ =>
           // ClassTag.apply(java.lang.XYZ.Type)
-          defn.ScalaBoxedClasses().contains(rc.symbol.maybeOwner.companionClass)
+          defn.ScalaBoxedClasses.contains(rc.symbol.maybeOwner.companionClass)
         case _ => false
       }
     case Apply(ctm: RefTree, _) if ctm.symbol.maybeOwner.companionModule == defn.ClassTagModule =>

--- a/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
@@ -26,11 +26,11 @@ class ArrayApply extends MiniPhase {
     if (tree.symbol.name == nme.apply && tree.symbol.owner == defn.ArrayModule.moduleClass) { // Is `Array.apply`
       tree.args match {
         case StripAscription(Apply(wrapRefArrayMeth, (seqLit: tpd.JavaSeqLiteral) :: Nil)) :: ct :: Nil
-            if defn.WrapArrayMethods().contains(wrapRefArrayMeth.symbol) && elideClassTag(ct) =>
+            if defn.WrapArrayMethods.contains(wrapRefArrayMeth.symbol) && elideClassTag(ct) =>
           seqLit
 
         case elem0 :: StripAscription(Apply(wrapRefArrayMeth, (seqLit: tpd.JavaSeqLiteral) :: Nil)) :: Nil
-            if defn.WrapArrayMethods().contains(wrapRefArrayMeth.symbol) =>
+            if defn.WrapArrayMethods.contains(wrapRefArrayMeth.symbol) =>
           tpd.JavaSeqLiteral(elem0 :: seqLit.elems, seqLit.elemtpt)
 
         case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/ArrayConstructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ArrayConstructors.scala
@@ -31,7 +31,7 @@ class ArrayConstructors extends MiniPhase {
     if (tree.fun.symbol eq defn.ArrayConstructor) {
       val TypeApply(tycon, targ :: Nil) = tree.fun
       expand(targ.tpe, tree.args)
-    } else if ((tree.fun.symbol.maybeOwner eq defn.ArrayModule) && (tree.fun.symbol.name eq nme.ofDim) && !tree.tpe.isInstanceOf[MethodicType]) {
+    } else if ((tree.fun.symbol.maybeOwner eq defn.ArrayModule.moduleClass) && (tree.fun.symbol.name eq nme.ofDim) && !tree.tpe.isInstanceOf[MethodicType]) {
       val Apply(Apply(TypeApply(_, List(tp)), _), _) = tree
       val cs = tp.tpe.widen.classSymbol
       tree.fun match {

--- a/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
@@ -32,7 +32,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
   private class RefInfo(implicit ctx: Context) {
     /** The classes for which a Ref type exists. */
     val refClassKeys: collection.Set[Symbol] =
-      defn.ScalaNumericValueClasses() + defn.BooleanClass + defn.ObjectClass
+      defn.ScalaNumericValueClasses + defn.BooleanClass + defn.ObjectClass
 
     val refClass: Map[Symbol, Symbol] =
       refClassKeys.map(rc => rc -> ctx.requiredClass(s"scala.runtime.${rc.name}Ref")).toMap

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -642,7 +642,7 @@ object Erasure {
     override def typedClosure(tree: untpd.Closure, pt: Type)(implicit ctx: Context): Tree = {
       val xxl = defn.isXXLFunctionClass(tree.typeOpt.typeSymbol)
       var implClosure @ Closure(_, meth, _) = super.typedClosure(tree, pt)
-      if (xxl) implClosure = cpy.Closure(implClosure)(tpt = TypeTree(defn.FunctionXXLType))
+      if (xxl) implClosure = cpy.Closure(implClosure)(tpt = TypeTree(defn.FunctionXXLClass.typeRef))
       implClosure.tpe match {
         case SAMType(sam) =>
           val implType = meth.tpe.widen.asInstanceOf[MethodType]

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -176,7 +176,7 @@ object Erasure {
      */
     private def safelyRemovableUnboxArg(tree: Tree)(implicit ctx: Context): Tree = tree match {
       case Apply(fn, arg :: Nil)
-      if isUnbox(fn.symbol) && defn.ScalaBoxedClasses().contains(arg.tpe.widen.typeSymbol) =>
+      if isUnbox(fn.symbol) && defn.ScalaBoxedClasses.contains(arg.tpe.widen.typeSymbol) =>
         arg
       case _ =>
         EmptyTree

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -260,7 +260,7 @@ object Erasure {
         case (JavaArrayType(treeElem), JavaArrayType(ptElem))
         if treeElem.widen.isPrimitiveValueType && !ptElem.isPrimitiveValueType =>
           // See SI-2386 for one example of when this might be necessary.
-          cast(ref(defn.runtimeMethodRef(nme.toObjectArray)).appliedTo(tree), pt)
+          cast(ref(defn.runtimeMethod(nme.toObjectArray)).appliedTo(tree), pt)
 
         // When casting between two EVTs, we need to check which one underlies the other to determine
         // whether u2evt or evt2u should be used.
@@ -507,9 +507,9 @@ object Erasure {
       }
 
     private def runtimeCallWithProtoArgs(name: Name, pt: Type, args: Tree*)(implicit ctx: Context): Tree = {
-      val meth = defn.runtimeMethodRef(name)
-      val followingParams = meth.symbol.info.firstParamTypes.drop(args.length)
-      val followingArgs = protoArgs(pt, meth.widen).zipWithConserve(followingParams)(typedExpr).asInstanceOf[List[tpd.Tree]]
+      val meth = defn.runtimeMethod(name)
+      val followingParams = meth.info.firstParamTypes.drop(args.length)
+      val followingArgs = protoArgs(pt, meth.info).zipWithConserve(followingParams)(typedExpr).asInstanceOf[List[tpd.Tree]]
       ref(meth).appliedToArgs(args.toList ++ followingArgs)
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -108,7 +108,9 @@ class ExpandSAMs extends MiniPhase {
       case PartialFunctionRHS(pf) =>
         val anonSym = anon.symbol
         val anonTpe = anon.tpe.widen
-        val parents = List(defn.AbstractPartialFunctionType.appliedTo(anonTpe.firstParamTypes.head, anonTpe.resultType), defn.SerializableType)
+        val parents = List(
+          defn.AbstractPartialFunctionClass.typeRef.appliedTo(anonTpe.firstParamTypes.head, anonTpe.resultType),
+          defn.SerializableType)
         val pfSym = ctx.newNormalizedClassSymbol(anonSym.owner, tpnme.ANON_CLASS, Synthetic | Final, parents, coord = tree.span)
 
         def overrideSym(sym: Symbol) = sym.copy(
@@ -128,7 +130,7 @@ class ExpandSAMs extends MiniPhase {
               Bind(defaultSym, Underscore(selectorTpe)),
               EmptyTree,
               defaultValue)
-          val unchecked = selector.annotated(New(ref(defn.UncheckedAnnotType)))
+          val unchecked = selector.annotated(New(ref(defn.UncheckedAnnot.typeRef)))
           cpy.Match(tree)(unchecked, cases :+ defaultCase)
             .subst(param.symbol :: Nil, pfParam :: Nil)
               // Needed because  a partial function can be written as:

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -107,7 +107,7 @@ class FirstTransform extends MiniPhase with InfoTransformer { thisPhase =>
     if (meth.hasAnnotation(defn.NativeAnnot)) {
       meth.resetFlag(Deferred)
       polyDefDef(meth,
-        _ => _ => ref(defn.Sys_errorR).withSpan(ddef.span)
+        _ => _ => ref(defn.Sys_error.termRef).withSpan(ddef.span)
           .appliedTo(Literal(Constant(s"native method stub"))))
 
     }

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -196,7 +196,7 @@ object GenericSignatures {
             }
           }
           else if (sym == defn.PairClass && tp.tupleArity > Definitions.MaxTupleArity)
-            jsig(defn.TupleXXLType)
+            jsig(defn.TupleXXLClass.typeRef)
           else if (isTypeParameterInSig(sym, sym0)) {
             assert(!sym.isAliasType, "Unexpected alias type: " + sym)
             typeParamSig(sym.name.lastPart)
@@ -204,14 +204,14 @@ object GenericSignatures {
           else if (defn.specialErasure.contains(sym))
             jsig(defn.specialErasure(sym).typeRef)
           else if (sym == defn.UnitClass || sym == defn.BoxedUnitModule)
-            jsig(defn.BoxedUnitType)
+            jsig(defn.BoxedUnitClass.typeRef)
           else if (sym == defn.NothingClass)
             jsig(defn.RuntimeNothingModuleRef)
           else if (sym == defn.NullClass)
             jsig(defn.RuntimeNullModuleRef)
           else if (sym.isPrimitiveValueClass) {
             if (!primitiveOK) jsig(defn.ObjectType)
-            else if (sym == defn.UnitClass) jsig(defn.BoxedUnitType)
+            else if (sym == defn.UnitClass) jsig(defn.BoxedUnitClass.typeRef)
             else builder.append(defn.typeTag(sym.info))
           }
           else if (ValueClasses.isDerivedValueClass(sym)) {

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -208,7 +208,7 @@ object GenericSignatures {
           else if (sym == defn.NothingClass)
             jsig(defn.RuntimeNothingModuleRef)
           else if (sym == defn.NullClass)
-            jsig(defn.RuntimeNullModuleRef)
+            jsig(defn.RuntimeNullModule.termRef)
           else if (sym.isPrimitiveValueClass) {
             if (!primitiveOK) jsig(defn.ObjectType)
             else if (sym == defn.UnitClass) jsig(defn.BoxedUnitClass.typeRef)

--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -53,7 +53,7 @@ class InterceptedMethods extends MiniPhase {
     val s = tree.tpe.widen.typeSymbol
 
     def staticsCall(methodName: TermName): Tree =
-      ref(defn.staticsMethodRef(methodName)).appliedTo(tree)
+      ref(defn.staticsMethod(methodName)).appliedTo(tree)
 
     if (s == defn.NullClass) Literal(Constant(0))
     else if (s == defn.DoubleClass) staticsCall(nme.doubleHash)

--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -91,7 +91,7 @@ class InterceptedMethods extends MiniPhase {
               List(qual, typer.resolveClassTag(tree.pos, qual.tpe.widen))))
           }*/
          */
-      case t if t.name == nme.getClass_ && defn.ScalaValueClasses().contains(t.owner) =>
+      case t if t.name == nme.getClass_ && defn.ScalaValueClasses.contains(t.owner) =>
           // if we got here then we're trying to send a primitive getClass method to either
           // a) an Any, in which cage Object_getClass works because Any erases to object. Or
           //

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -146,7 +146,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
 
     // val x$lzy = new scala.runtime.LazyInt()
     val holderName = LazyLocalName.fresh(xname)
-    val holderImpl = defn.LazyHolder()(ctx)(tpe.typeSymbol)
+    val holderImpl = defn.LazyHolder(tpe.typeSymbol)
     val holderSymbol = ctx.newSymbol(x.symbol.owner, holderName, containerFlags, holderImpl.typeRef, coord = x.span)
     val holderTree = ValDef(holderSymbol, New(holderImpl.typeRef, Nil))
 

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -187,7 +187,7 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
           assert(ctx.inInlineMethod)
           None
         } else {
-          val reqType = defn.QuotedTypeType.appliedTo(tp)
+          val reqType = defn.QuotedTypeClass.typeRef.appliedTo(tp)
           val tag = ctx.typer.inferImplicitArg(reqType, pos.span)
           tag.tpe match {
             case _: TermRef =>

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -414,7 +414,7 @@ object PatternMatcher {
 
     private def matchPlan(tree: Match): Plan = {
       letAbstract(tree.selector) { scrutinee =>
-        val matchError: Plan = ResultPlan(Throw(New(defn.MatchErrorType, ref(scrutinee) :: Nil)))
+        val matchError: Plan = ResultPlan(Throw(New(defn.MatchErrorClass.typeRef, ref(scrutinee) :: Nil)))
         tree.cases.foldRight(matchError) { (cdef, next) =>
           SeqPlan(caseDefPlan(scrutinee, cdef), next)
         }

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -312,7 +312,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
         MethodType(Nil, defn.AnyRefType), coord = clazz.coord).entered.asTerm
       List(
         DefDef(writeReplace,
-          _ => New(defn.ModuleSerializationProxyType,
+          _ => New(defn.ModuleSerializationProxyClass.typeRef,
                    defn.ModuleSerializationProxyConstructor,
                    List(Literal(Constant(clazz.sourceModule.termRef)))))
           .withSpan(ctx.owner.span.focus))
@@ -436,14 +436,14 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       }
     }
     def makeSingletonMirror() =
-      addParent(defn.Mirror_SingletonType)
+      addParent(defn.Mirror_SingletonClass.typeRef)
     def makeProductMirror(cls: Symbol) = {
-      addParent(defn.Mirror_ProductType)
-      addMethod(nme.fromProduct, MethodType(defn.ProductType :: Nil, monoType.typeRef), cls,
+      addParent(defn.Mirror_ProductClass.typeRef)
+      addMethod(nme.fromProduct, MethodType(defn.ProductClass.typeRef :: Nil, monoType.typeRef), cls,
         fromProductBody(_, _)(_).ensureConforms(monoType.typeRef))  // t4758.scala or i3381.scala are examples where a cast is needed
     }
     def makeSumMirror(cls: Symbol) = {
-      addParent(defn.Mirror_SumType)
+      addParent(defn.Mirror_SumClass.typeRef)
       addMethod(nme.ordinal, MethodType(monoType.typeRef :: Nil, defn.IntType), cls,
         ordinalBody(_, _)(_))
     }

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -112,7 +112,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
         coord = clazz.coord).enteredAfter(thisPhase).asTerm
 
       def forwardToRuntime(vrefs: List[Tree]): Tree =
-        ref(defn.runtimeMethodRef("_" + sym.name.toString)).appliedToArgs(This(clazz) :: vrefs)
+        ref(defn.runtimeMethod("_" + sym.name.toString)).appliedToArgs(This(clazz) :: vrefs)
 
       def ownName: Tree =
         Literal(Constant(clazz.name.stripModuleClassSuffix.toString))

--- a/compiler/src/dotty/tools/dotc/transform/TupleOptimizations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TupleOptimizations.scala
@@ -84,7 +84,7 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
           // val it = this.asInstanceOf[Product].productIterator
           // it.next()
           // TupleN-1(it.next(), ..., it.next())
-          evalOnce(tup.asInstance(defn.ProductType).select(nme.productIterator)) { it =>
+          evalOnce(tup.asInstance(defn.ProductClass.typeRef).select(nme.productIterator)) { it =>
             Block(
               it.select(nme.next).ensureApplied :: Nil,
               knownTupleFromIterator(size - 1, it).asInstance(tree.tpe)
@@ -92,7 +92,7 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
           }
         } else {
           // tup.asInstanceOf[TupleXXL].tailXXL
-          tup.asInstance(defn.TupleXXLType).select("tailXXL".toTermName)
+          tup.asInstance(defn.TupleXXLClass.typeRef).select("tailXXL".toTermName)
         }
       case None =>
         // No optimization, keep:
@@ -159,7 +159,7 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
           Typed(tup, TypeTree(defn.tupleType(tpes))).select(nme.selectorName(n))
         } else {
           // tup.asInstanceOf[TupleXXL].productElement(n)
-          tup.asInstance(defn.TupleXXLType).select(nme.productElement).appliedTo(Literal(nTpe.value))
+          tup.asInstance(defn.TupleXXLClass.typeRef).select(nme.productElement).appliedTo(Literal(nTpe.value))
         }
       case (None, nTpe: ConstantType) if nTpe.value.intValue < 0 =>
         ctx.error("index out of bounds: " + nTpe.value.intValue, nTree.sourcePos)
@@ -178,13 +178,13 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
         val size = tpes.size
         if (size == 0) {
           // Array.emptyObjectArray
-          ref(defn.ArrayModule.companionModule).select("emptyObjectArray".toTermName).ensureApplied
+          ref(defn.ArrayModule).select("emptyObjectArray".toTermName).ensureApplied
         } else if (size <= MaxTupleArity) {
           // DynamicTuple.productToArray(tup.asInstanceOf[Product])
-          ref(defn.DynamicTuple_productToArray).appliedTo(tup.asInstance(defn.ProductType))
+          ref(defn.DynamicTuple_productToArray).appliedTo(tup.asInstance(defn.ProductClass.typeRef))
         } else {
           // tup.asInstanceOf[TupleXXL].elems.clone()
-          tup.asInstance(defn.TupleXXLType).select(nme.toArray)
+          tup.asInstance(defn.TupleXXLClass.typeRef).select(nme.toArray)
         }
       case None =>
         // No optimization, keep:

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -286,7 +286,7 @@ object TypeTestsCasts {
             }
           case defn.MultiArrayOf(elem, ndims) if isUnboundedGeneric(elem) =>
             def isArrayTest(arg: Tree) =
-              ref(defn.runtimeMethodRef(nme.isArray)).appliedTo(arg, Literal(Constant(ndims)))
+              ref(defn.runtimeMethod(nme.isArray)).appliedTo(arg, Literal(Constant(ndims)))
             if (ndims == 1) isArrayTest(expr)
             else evalOnce(expr) { e =>
               derivedTree(e, defn.Any_isInstanceOf, e.tpe)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1556,7 +1556,7 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
       case untpd.Function(args, body) =>
         defn.FunctionOf(args map Function.const(defn.AnyType), typeShape(body))
       case Match(EmptyTree, _) =>
-        defn.PartialFunctionType.appliedTo(defn.AnyType :: defn.NothingType :: Nil)
+        defn.PartialFunctionClass.typeRef.appliedTo(defn.AnyType :: defn.NothingType :: Nil)
       case _ =>
         defn.NothingType
     }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -822,7 +822,7 @@ trait Checking {
             checkInlineConformant(expr, isFinal, what)
           case SeqLiteral(elems, _) =>
             elems.foreach(elem => checkInlineConformant(elem, isFinal, what))
-          case Apply(fn, List(arg)) if defn.WrapArrayMethods().contains(fn.symbol) =>
+          case Apply(fn, List(arg)) if defn.WrapArrayMethods.contains(fn.symbol) =>
             checkInlineConformant(arg, isFinal, what)
           case _ =>
             def isCaseClassApply(sym: Symbol): Boolean =

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -139,7 +139,7 @@ trait Dynamic { self: Typer with Applications =>
     val (fun @ Select(qual, name), targs, vargss) = decomposeCall(tree)
 
     def structuralCall(selectorName: TermName, ctags: List[Tree]) = {
-      val selectable = adapt(qual, defn.SelectableType)
+      val selectable = adapt(qual, defn.SelectableClass.typeRef)
 
       // ($qual: Selectable).$selectorName("$name", ..$ctags)
       val base =
@@ -175,7 +175,7 @@ trait Dynamic { self: Typer with Applications =>
           fail(name, i"has a method type with inter-parameter dependencies")
         else {
           val ctags = tpe.paramInfoss.flatten.map(pt =>
-            implicitArgTree(defn.ClassTagType.appliedTo(pt.widenDealias :: Nil), fun.span.endPos))
+            implicitArgTree(defn.ClassTagClass.typeRef.appliedTo(pt.widenDealias :: Nil), fun.span.endPos))
           structuralCall(nme.applyDynamic, ctags).cast(tpe.finalResultType)
         }
 

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -404,7 +404,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       else if (inlinedMethod == defn.Compiletime_constValueOpt) {
         val constVal = tryConstValue
         return (
-          if (constVal.isEmpty) ref(defn.NoneModuleRef)
+          if (constVal.isEmpty) ref(defn.NoneModule.termRef)
           else New(defn.SomeClass.typeRef.appliedTo(constVal.tpe), constVal :: Nil)
         )
       }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1200,7 +1200,7 @@ class Namer { typer: Typer =>
     typedAhead(tree, typer.typed(_, pt)(ctx retractMode Mode.PatternOrTypeBits))
 
   def typedAheadAnnotation(tree: Tree)(implicit ctx: Context): tpd.Tree =
-    typedAheadExpr(tree, defn.AnnotationType)
+    typedAheadExpr(tree, defn.AnnotationClass.typeRef)
 
   def typedAheadAnnotationClass(tree: Tree)(implicit ctx: Context): Symbol = tree match {
     case Apply(fn, _) => typedAheadAnnotationClass(fn)

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -35,9 +35,9 @@ trait QuotesAndSplices { self: Typer =>
    *  while tracking the quotation level in the context.
    */
   def typedQuote(tree: untpd.Quote, pt: Type)(implicit ctx: Context): Tree = track("typedQuote") {
-    val qctx = inferImplicitArg(defn.QuoteContextType, tree.span)
+    val qctx = inferImplicitArg(defn.QuoteContextClass.typeRef, tree.span)
     if (level == 0 && qctx.tpe.isInstanceOf[SearchFailureType])
-      ctx.error(missingArgMsg(qctx, defn.QuoteContextType, ""), ctx.source.atSpan(tree.span))
+      ctx.error(missingArgMsg(qctx, defn.QuoteContextClass.typeRef, ""), ctx.source.atSpan(tree.span))
 
     tree.quoted match {
       case untpd.Splice(innerExpr) if tree.isTerm =>
@@ -69,7 +69,7 @@ trait QuotesAndSplices { self: Typer =>
           if (isFullyDefined(pt, ForceDegree.all)) {
             def spliceOwner(ctx: Context): Symbol =
               if (ctx.mode.is(Mode.QuotedPattern)) spliceOwner(ctx.outer) else ctx.owner
-            val pat = typedPattern(expr, defn.QuotedExprType.appliedTo(pt))(
+            val pat = typedPattern(expr, defn.QuotedExprClass.typeRef.appliedTo(pt))(
               spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
             Splice(pat)
           } else {
@@ -115,7 +115,7 @@ trait QuotesAndSplices { self: Typer =>
             }
             val typeSym = ctx.newSymbol(spliceOwner(ctx), name, EmptyFlags, TypeBounds.empty, NoSymbol, expr.span)
             typeSym.addAnnotation(Annotation(New(ref(defn.InternalQuoted_patternBindHoleAnnot.typeRef)).withSpan(expr.span)))
-            val pat = typedPattern(expr, defn.QuotedTypeType.appliedTo(typeSym.typeRef))(
+            val pat = typedPattern(expr, defn.QuotedTypeClass.typeRef.appliedTo(typeSym.typeRef))(
                 spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
             pat.select(tpnme.splice)
           }
@@ -175,7 +175,7 @@ trait QuotesAndSplices { self: Typer =>
       override def transform(tree: Tree)(implicit ctx: Context) = tree match {
         case Typed(Splice(pat), tpt) if !tpt.tpe.derivesFrom(defn.RepeatedParamClass) =>
           val tpt1 = transform(tpt) // Transform type bindings
-          val exprTpt = AppliedTypeTree(TypeTree(defn.QuotedExprType), tpt1 :: Nil)
+          val exprTpt = AppliedTypeTree(TypeTree(defn.QuotedExprClass.typeRef), tpt1 :: Nil)
           transform(Splice(Typed(pat, exprTpt)))
         case Splice(pat) =>
           try ref(defn.InternalQuoted_patternHole.termRef).appliedToType(tree.tpe).withSpan(tree.span)
@@ -202,7 +202,7 @@ trait QuotesAndSplices { self: Typer =>
                     x => t.resType.subst(t, x).toFunctionType())
               case t => t
             }
-            val bindingExprTpe = AppliedType(defn.QuotedMatchingBindingType, bindingType :: Nil)
+            val bindingExprTpe = AppliedType(defn.QuotedMatchingBindingClass.typeRef, bindingType :: Nil)
             assert(ddef.name.startsWith("$"))
             val bindName = ddef.name.toString.stripPrefix("$").toTermName
             val sym = ctx0.newPatternBoundSymbol(bindName, bindingExprTpe, ddef.span)
@@ -217,7 +217,7 @@ trait QuotesAndSplices { self: Typer =>
 
       def transformTypeBindingTypeDef(tdef: TypeDef, buff: mutable.Builder[Tree, List[Tree]]): Tree = {
         val bindingType = getBinding(tdef.symbol).symbol.typeRef
-        val bindingTypeTpe = AppliedType(defn.QuotedTypeType, bindingType :: Nil)
+        val bindingTypeTpe = AppliedType(defn.QuotedTypeClass.typeRef, bindingType :: Nil)
         assert(tdef.name.startsWith("$"))
         val bindName = tdef.name.toString.stripPrefix("$").toTermName
         val sym = ctx0.newPatternBoundSymbol(bindName, bindingTypeTpe, tdef.span, flags = ImplicitTerm)
@@ -353,7 +353,7 @@ trait QuotesAndSplices { self: Typer =>
           Literal(Constant(typeBindings.nonEmpty)) ::
           qctx :: Nil,
       patterns = splicePat :: Nil,
-      proto = defn.QuotedExprType.appliedTo(replaceBindings(quoted1.tpe) & quotedPt))
+      proto = defn.QuotedExprClass.typeRef.appliedTo(replaceBindings(quoted1.tpe) & quotedPt))
   }
 
 }

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -49,9 +49,9 @@ trait QuotesAndSplices { self: Typer =>
       case quoted =>
         ctx.compilationUnit.needsStaging = true
         val tree1 =
-          if (quoted.isType) typedTypeApply(untpd.TypeApply(untpd.ref(defn.InternalQuoted_typeQuoteR), quoted :: Nil), pt)(quoteContext)
+          if (quoted.isType) typedTypeApply(untpd.TypeApply(untpd.ref(defn.InternalQuoted_typeQuote.termRef), quoted :: Nil), pt)(quoteContext)
           else if (ctx.mode.is(Mode.Pattern) && level == 0) typedQuotePattern(quoted, pt, qctx)
-          else typedApply(untpd.Apply(untpd.ref(defn.InternalQuoted_exprQuoteR), quoted), pt)(quoteContext)
+          else typedApply(untpd.Apply(untpd.ref(defn.InternalQuoted_exprQuote.termRef), quoted), pt)(quoteContext)
         tree1.withSpan(tree.span)
     }
   }
@@ -86,7 +86,7 @@ trait QuotesAndSplices { self: Typer =>
               else if (!c.outer.owner.is(Package)) markAsMacro(c.outer)
             markAsMacro(ctx)
           }
-          typedApply(untpd.Apply(untpd.ref(defn.InternalQuoted_exprSpliceR), tree.expr), pt)(spliceContext).withSpan(tree.span)
+          typedApply(untpd.Apply(untpd.ref(defn.InternalQuoted_exprSplice.termRef), tree.expr), pt)(spliceContext).withSpan(tree.span)
         }
     }
   }
@@ -178,7 +178,7 @@ trait QuotesAndSplices { self: Typer =>
           val exprTpt = AppliedTypeTree(TypeTree(defn.QuotedExprType), tpt1 :: Nil)
           transform(Splice(Typed(pat, exprTpt)))
         case Splice(pat) =>
-          try ref(defn.InternalQuoted_patternHoleR).appliedToType(tree.tpe).withSpan(tree.span)
+          try ref(defn.InternalQuoted_patternHole.termRef).appliedToType(tree.tpe).withSpan(tree.span)
           finally {
             val patType = pat.tpe.widen
             val patType1 = patType.underlyingIfRepeated(isJava = false)
@@ -347,9 +347,9 @@ trait QuotesAndSplices { self: Typer =>
     val splicePat = typed(untpd.Tuple(splices.map(x => untpd.TypedSplice(replaceBindingsInTree.transform(x)))).withSpan(quoted.span), patType)
 
     UnApply(
-      fun = ref(defn.InternalQuotedMatcher_unapplyR).appliedToTypeTrees(typeBindingsTuple :: TypeTree(patType) :: Nil),
+      fun = ref(defn.InternalQuotedMatcher_unapply.termRef).appliedToTypeTrees(typeBindingsTuple :: TypeTree(patType) :: Nil),
       implicits =
-        ref(defn.InternalQuoted_exprQuoteR).appliedToType(shape.tpe).appliedTo(shape) ::
+        ref(defn.InternalQuoted_exprQuote.termRef).appliedToType(shape.tpe).appliedTo(shape) ::
           Literal(Constant(typeBindings.nonEmpty)) ::
           qctx :: Nil,
       patterns = splicePat :: Nil,

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -21,3 +21,6 @@ matchtype.scala
 
 # Opaque type
 i5720.scala
+
+# Redefines types in the Scala package
+seqtype-cycle


### PR DESCRIPTION
Definitions employed a combinations of design patterns and helper functions to ensure that symbols of members in Definitions would be automatically updated in resident compiler if the definition was edited.
I.e. typical scenario:

 1. Start resident compiler and compile
 2. Change (say) `scala.collection.Seq` and compile
 3. Continue editing and compiling other files

Normally, you get a StaleSymbol error in (3) since the originally loaded symbol for `collection.Seq` is no longer valid. The per run infrastructure in definitions makes sure that the new symbol is loaded transparently instead. 

This is nice, but also quite complicated to implement. I noted that often new additions did not follow the patterns and therefore exposed the StaleSymbol vulnerability.

The big question is whether it is worth it. If this PR is merged, one would have to start a new compiler after step 2 above. Is this a problem that warrants the additional complexity? I don't know.
