### PR TITLE
Change definition of classSymbol for OrType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -431,12 +431,8 @@ object Types {
         if (lsym isSubClass rsym) lsym
         else if (rsym isSubClass lsym) rsym
         else NoSymbol
-      case OrType(l, r) => // TODO does not conform to spec
-        val lsym = l.classSymbol
-        val rsym = r.classSymbol
-        if (lsym isSubClass rsym) rsym
-        else if (rsym isSubClass lsym) lsym
-        else NoSymbol
+      case tp: OrType =>
+        tp.join.classSymbol
       case _ =>
         NoSymbol
     }

--- a/tests/run/memoTest.scala
+++ b/tests/run/memoTest.scala
@@ -1,0 +1,12 @@
+object Test extends App {
+
+  var opCache: Int | Null = null
+
+  def foo(x: Int) = {
+    if (opCache == null) opCache = x
+    opCache.asInstanceOf[Int] + 1
+  }
+
+  assert(foo(1) + foo(2) == 4)
+
+}


### PR DESCRIPTION
The reason for the change is in the included test.
```
  val opCache: Int | Null = ...
  opCache.asInstanceOf[Int]
```
gave 
```
  conversion from Int | Null to Int will always fail at runtime
```
and then failed with ClassCastException as advertised. Now it compiles and runs.

