### PR TITLE
Implement memoization

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -237,6 +237,7 @@ class Definitions {
     @threadUnsafe lazy val Compiletime_constValue   : SymbolPerRun = perRunSym(CompiletimePackageObject.requiredMethodRef("constValue"))
     @threadUnsafe lazy val Compiletime_constValueOpt: SymbolPerRun = perRunSym(CompiletimePackageObject.requiredMethodRef("constValueOpt"))
     @threadUnsafe lazy val Compiletime_code         : SymbolPerRun = perRunSym(CompiletimePackageObject.requiredMethodRef("code"))
+    @threadUnsafe lazy val Compiletime_memo         : SymbolPerRun = perRunSym(CompiletimePackageObject.requiredMethodRef("memo"))
 
   /** The `scalaShadowing` package is used to safely modify classes and
    *  objects in scala so that they can be used from dotty. They will

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -299,7 +299,7 @@ object NameKinds {
   val UniqueInlineName: UniqueNameKind       = new UniqueNameKind("$i")
   val InlineScrutineeName: UniqueNameKind    = new UniqueNameKind("$scrutinee")
   val InlineBinderName: UniqueNameKind       = new UniqueNameKind("$elem")
-  val MemoCacheName: UniqueNameKind          = new UniqueNameKind("memo$")
+  val MemoCacheName: UniqueNameKind          = new UniqueNameKind("$cache")
 
   /** A kind of unique extension methods; Unlike other unique names, these can be
    *  unmangled.

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -213,6 +213,9 @@ object NameKinds {
       safePrefix + info.num
     }
 
+    def currentCount(prefix: TermName = EmptyTermName) given (ctx: Context): Int =
+      ctx.freshNames.currentCount(prefix, this)
+
     /** Generate fresh unique term name of this kind with given prefix name */
     def fresh(prefix: TermName = EmptyTermName)(implicit ctx: Context): TermName =
       ctx.freshNames.newName(prefix, this)
@@ -296,6 +299,7 @@ object NameKinds {
   val UniqueInlineName: UniqueNameKind       = new UniqueNameKind("$i")
   val InlineScrutineeName: UniqueNameKind    = new UniqueNameKind("$scrutinee")
   val InlineBinderName: UniqueNameKind       = new UniqueNameKind("$elem")
+  val MemoCacheName: UniqueNameKind          = new UniqueNameKind("memo$")
 
   /** A kind of unique extension methods; Unlike other unique names, these can be
    *  unmangled.

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -482,6 +482,7 @@ object StdNames {
     val materializeClassTag: N  = "materializeClassTag"
     val materializeWeakTypeTag: N = "materializeWeakTypeTag"
     val materializeTypeTag: N   = "materializeTypeTag"
+    val memo: N                 = "memo"
     val mirror : N              = "mirror"
     val moduleClass : N         = "moduleClass"
     val name: N                 = "name"

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -102,8 +102,12 @@ trait SymDenotations { this: Context =>
     }
   }
 
-  /** Configurable: Accept stale symbol with warning if in IDE */
-  def staleOK: Boolean = Config.ignoreStaleInIDE && mode.is(Mode.Interactive)
+  /** Configurable: Accept stale symbol with warning if in IDE
+   *  Always accept stale symbols when testing pickling.
+   */
+  def staleOK: Boolean =
+    Config.ignoreStaleInIDE && mode.is(Mode.Interactive) ||
+    settings.YtestPickler.value
 
   /** Possibly accept stale symbol with warning if in IDE */
   def acceptStale(denot: SingleDenotation): Boolean =

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -553,9 +553,10 @@ object Symbols {
 
     /** This symbol entered into owner's scope (owner must be a class). */
     final def entered(implicit ctx: Context): this.type = {
-      assert(this.owner.isClass, s"symbol ($this) entered the scope of non-class owner ${this.owner}") // !!! DEBUG
-      this.owner.asClass.enter(this)
-      if (this.is(Module)) this.owner.asClass.enter(this.moduleClass)
+      if (this.owner.isClass) {
+        this.owner.asClass.enter(this)
+        if (this.is(Module)) this.owner.asClass.enter(this.moduleClass)
+      }
       this
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -567,14 +567,16 @@ object Symbols {
      */
     def enteredAfter(phase: DenotTransformer)(implicit ctx: Context): this.type =
       if (ctx.phaseId != phase.next.id) enteredAfter(phase)(ctx.withPhase(phase.next))
-      else {
-        if (this.owner.is(Package)) {
-          denot.validFor |= InitialPeriod
-          if (this.is(Module)) this.moduleClass.validFor |= InitialPeriod
-        }
-        else this.owner.asClass.ensureFreshScopeAfter(phase)
-        assert(isPrivate || phase.changesMembers, i"$this entered in ${this.owner} at undeclared phase $phase")
-        entered
+      else this.owner match {
+        case owner: ClassSymbol =>
+          if (owner.is(Package)) {
+            denot.validFor |= InitialPeriod
+            if (this.is(Module)) this.moduleClass.validFor |= InitialPeriod
+          }
+          else owner.ensureFreshScopeAfter(phase)
+          assert(isPrivate || phase.changesMembers, i"$this entered in $owner at undeclared phase $phase")
+          entered
+        case _ => this
       }
 
     /** Remove symbol from scope of owning class */

--- a/compiler/src/dotty/tools/dotc/transform/CacheAliasImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CacheAliasImplicits.scala
@@ -82,7 +82,7 @@ class CacheAliasImplicits extends MiniPhase with IdentityDenotTransformer { this
           val cacheFlags = if (ctx.owner.isClass) Private | Local | Mutable else Mutable
           val cacheSym =
             ctx.newSymbol(ctx.owner, CacheName(tree.name), cacheFlags, rhsType, coord = sym.coord)
-          if (ctx.owner.isClass) cacheSym.enteredAfter(thisPhase)
+              .enteredAfter(thisPhase)
           val cacheDef = ValDef(cacheSym, tpd.defaultValue(rhsType))
           val cachingDef = cpy.DefDef(tree)(rhs =
             Block(

--- a/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
@@ -91,13 +91,13 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
         val argTypeWrtConstr = argType.subst(origParams, allParamRefs(constr.info))
         // argType with references to paramRefs of the primary constructor instead of
         // local parameter accessors
-        val meth = ctx.newSymbol(
+        ctx.newSymbol(
           owner = methOwner,
           name = SuperArgName.fresh(cls.name.toTermName),
           flags = Synthetic | Private | Method | staticFlag,
           info = replaceResult(constr.info, argTypeWrtConstr),
-          coord = constr.coord)
-        if (methOwner.isClass) meth.enteredAfter(thisPhase) else meth
+          coord = constr.coord
+        ).enteredAfter(thisPhase)
       }
 
       /** Type of a reference implies that it needs to be hoisted */

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -298,8 +298,9 @@ object LambdaLift {
         proxyMap(owner) = {
           for (fv <- freeValues.toList) yield {
             val proxyName = newName(fv)
-            val proxy = ctx.newSymbol(owner, proxyName.asTermName, newFlags, fv.info, coord = fv.coord)
-            if (owner.isClass) proxy.enteredAfter(thisPhase)
+            val proxy =
+              ctx.newSymbol(owner, proxyName.asTermName, newFlags, fv.info, coord = fv.coord)
+                .enteredAfter(thisPhase)
             (fv, proxy)
           }
         }.toMap

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -424,7 +424,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
   def memoized: Tree = {
     val currentOwner = ctx.owner.skipWeakOwner
     if (currentOwner.isRealMethod) {
-      val cacheOwner = ctx.owner.effectiveOwner
+      val cacheOwner = currentOwner.owner
       val argType = callTypeArgs.head.tpe
       val memoVar = ctx.newSymbol(
         owner = cacheOwner,

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2122,6 +2122,7 @@ class Typer extends Namer
           case Some(xtree) =>
             traverse(xtree :: rest)
           case none =>
+            val memoCacheCount = MemoCacheName.currentCount()
             typed(mdef) match {
               case mdef1: DefDef if Inliner.hasBodyToInline(mdef1.symbol) =>
                 buf += inlineExpansion(mdef1)
@@ -2132,6 +2133,8 @@ class Typer extends Namer
                 mdef match {
                   case mdef: untpd.TypeDef if mdef.mods.isEnumClass =>
                     enumContexts(mdef1.symbol) = ctx
+                  case _: untpd.DefDef if MemoCacheName.currentCount() != memoCacheCount =>
+                    buf ++= Inliner.memoCacheDefs(mdef1)
                   case _ =>
                 }
                 if (!mdef1.isEmpty) // clashing synthetic case methods are converted to empty trees

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2122,19 +2122,18 @@ class Typer extends Namer
           case Some(xtree) =>
             traverse(xtree :: rest)
           case none =>
-            val memoCacheCount = MemoCacheName.currentCount()
+            val memoCacheCount = MemoCacheName.currentCount(nme.memo)
             typed(mdef) match {
               case mdef1: DefDef if Inliner.hasBodyToInline(mdef1.symbol) =>
                 buf += inlineExpansion(mdef1)
                   // replace body with expansion, because it will be used as inlined body
                   // from separately compiled files - the original BodyAnnotation is not kept.
               case mdef1 =>
-                import untpd.modsDeco
-                mdef match {
-                  case mdef: untpd.TypeDef if mdef.mods.isEnumClass =>
+                mdef1 match {
+                  case mdef1: TypeDef if mdef1.symbol.flags.is(Enum, butNot = Case) =>
                     enumContexts(mdef1.symbol) = ctx
-                  case _: untpd.DefDef if MemoCacheName.currentCount() != memoCacheCount =>
-                    buf ++= Inliner.memoCacheDefs(mdef1)
+                  case mdef1: DefDef if MemoCacheName.currentCount(nme.memo) != memoCacheCount =>
+                    buf ++= Inliner.memoCacheDefs(mdef1.rhs)
                   case _ =>
                 }
                 if (!mdef1.isEmpty) // clashing synthetic case methods are converted to empty trees

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2128,16 +2128,15 @@ class Typer extends Namer
                 buf += inlineExpansion(mdef1)
                   // replace body with expansion, because it will be used as inlined body
                   // from separately compiled files - the original BodyAnnotation is not kept.
+              case mdef1: DefDef if MemoCacheName.currentCount(nme.memo) != memoCacheCount =>
+                buf ++= Inliner.memoCacheDefs(mdef1.rhs) += mdef1
+              case mdef1: TypeDef if mdef1.symbol.is(Enum, butNot = Case) =>
+                enumContexts(mdef1.symbol) = ctx
+                buf += mdef1
+              case EmptyTree =>
+                // clashing synthetic case methods are converted to empty trees, drop them here
               case mdef1 =>
-                mdef1 match {
-                  case mdef1: TypeDef if mdef1.symbol.flags.is(Enum, butNot = Case) =>
-                    enumContexts(mdef1.symbol) = ctx
-                  case mdef1: DefDef if MemoCacheName.currentCount(nme.memo) != memoCacheCount =>
-                    buf ++= Inliner.memoCacheDefs(mdef1.rhs)
-                  case _ =>
-                }
-                if (!mdef1.isEmpty) // clashing synthetic case methods are converted to empty trees
-                  buf += mdef1
+                buf += mdef1
             }
             traverse(rest)
         }

--- a/compiler/src/dotty/tools/dotc/util/FreshNameCreator.scala
+++ b/compiler/src/dotty/tools/dotc/util/FreshNameCreator.scala
@@ -9,12 +9,19 @@ import core.StdNames.str
 
 abstract class FreshNameCreator {
   def newName(prefix: TermName, unique: UniqueNameKind): TermName
+  def currentCount(prefix: TermName, unique: UniqueNameKind): Int
 }
 
 object FreshNameCreator {
   class Default extends FreshNameCreator {
-    protected var counter: Int = 0
     protected val counters: mutable.Map[String, Int] = mutable.AnyRefMap() withDefaultValue 0
+
+    private def keyFor(prefix: TermName, unique: UniqueNameKind) =
+      str.sanitize(prefix.toString) + unique.separator
+
+    /** The current counter for the given combination of `prefix` and `unique` */
+    def currentCount(prefix: TermName, unique: UniqueNameKind): Int =
+      counters(keyFor(prefix, unique))
 
     /**
      * Create a fresh name with the given prefix. It is guaranteed
@@ -22,7 +29,7 @@ object FreshNameCreator {
      * call to this function (provided the prefix does not end in a digit).
      */
     def newName(prefix: TermName, unique: UniqueNameKind): TermName = {
-      val key = str.sanitize(prefix.toString) + unique.separator
+      val key = keyFor(prefix, unique)
       counters(key) += 1
       prefix.derived(unique.NumberedInfo(counters(key)))
     }

--- a/docs/docs/reference/metaprogramming/inline.md
+++ b/docs/docs/reference/metaprogramming/inline.md
@@ -411,6 +411,7 @@ fail(indentity("foo")) // error: failed on: indentity("foo")
 The `memo` method is used to avoid repeated evaluation of subcomputations.
 Example:
 ```
+type T = ...
 class C(x: T) {
   def costly(x: T): Int = ???
   def f(y: Int) = memo(costly(x)) * y

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -38,4 +38,6 @@ package object compiletime {
   inline def constValue[T]: T = ???
 
   type S[X <: Int] <: Int
+
+  inline def memo[T](op: => T): T = ???
 }

--- a/tests/neg/memoTest.scala
+++ b/tests/neg/memoTest.scala
@@ -1,0 +1,4 @@
+object Test {
+  import compiletime.memo
+  val a = memo(1) // error: memo(...) outside method
+}

--- a/tests/run/memoTest.check
+++ b/tests/run/memoTest.check
@@ -1,0 +1,7 @@
+computing inner
+computing f
+1
+1
+computing f
+1
+1

--- a/tests/run/memoTest.scala
+++ b/tests/run/memoTest.scala
@@ -12,4 +12,24 @@ object Test extends App {
 
   assert(foo(1) + foo(2) == 4)
   assert(bar(1) + bar(2) == 4)
+
+  class Context(val n: Int)
+  def f(c: Context): Context = {
+    println("computing f")
+    Context(c.n + 1)
+  }
+  given as Context(0)
+
+  locally {
+    given as Context given (c: Context) = memo(f(c))
+    println(the[Context].n)
+    println(the[Context].n)
+  }
+
+  val ctx = f(the[Context])
+  locally {
+    given as Context = ctx
+    println(the[Context].n)
+    println(the[Context].n)
+  }
 }

--- a/tests/run/memoTest.scala
+++ b/tests/run/memoTest.scala
@@ -1,4 +1,5 @@
 object Test extends App {
+  import compiletime.memo
 
   var opCache: Int | Null = null
 
@@ -7,6 +8,8 @@ object Test extends App {
     opCache.asInstanceOf[Int] + 1
   }
 
-  assert(foo(1) + foo(2) == 4)
+  def bar(x: Int) = memo(x * x) + 1
 
+  assert(foo(1) + foo(2) == 4)
+  assert(bar(1) + bar(2) == 4)
 }

--- a/tests/run/memoTest.scala
+++ b/tests/run/memoTest.scala
@@ -13,6 +13,22 @@ object Test extends App {
   assert(foo(1) + foo(2) == 4)
   assert(bar(1) + bar(2) == 4)
 
+  trait T {
+    def x: Int
+    def y: Int = memo {
+      def inner = memo {
+        println("computing inner");
+        x * x
+      }
+      inner + inner
+    }
+  }
+  val t = new T {
+    def x = 3
+    assert(y == 18)
+  }
+  assert(t.y == 18)
+
   class Context(val n: Int)
   def f(c: Context): Context = {
     println("computing f")


### PR DESCRIPTION
Implement `memo(...)` function which caches its argument on first evaluation
and re-uses the cached value afterwards. The cache is placed next to the
method enclosing the memo(...) call.

`memo` is a member of package `compiletime`.