### PR TITLE
 Fix #6197: erase pattern bound type symbols completely

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -374,7 +374,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
           // cannot use WildcardType for Array[_], due to that
           //   Array[WildcardType] <: Array[Array[WildcardType]]
           // see tests/patmat/t2425.scala
-          TypeErasure.erasure(tp)
+          tp
         case tref: TypeRef if isPatternTypeSymbol(tref.typeSymbol) =>
           WildcardType(tref.underlying.bounds)
         case _ => mapOver(tp)

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -380,7 +380,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
    *  cause false unreachable warnings. See tests/patmat/t2425.scala
    *
    *  We cannot use type erasure here, as it would lose the constraints
-   *  invovling GADTs. For example, in the following code, type
+   *  involving GADTs. For example, in the following code, type
    *  erasure would loose the constraint that `x` and `y` must be
    *  the same type, resulting in false inexhaustive warnings:
    *

--- a/compiler/test/dotty/tools/vulpix/FileDiff.scala
+++ b/compiler/test/dotty/tools/vulpix/FileDiff.scala
@@ -9,7 +9,7 @@ object FileDiff {
       s"""Test output dumped in: $actualFile
           |  See diff of the checkfile (`brew install icdiff` for colored diff)
           |    > diff $expectFile $actualFile
-          |  Replace checkfile with current output output
+          |  Replace checkfile with current output
           |    > mv $actualFile $expectFile
       """.stripMargin
 

--- a/docs/docs/contributing/testing.md
+++ b/docs/docs/contributing/testing.md
@@ -69,7 +69,7 @@ If the actual output mismatches the expected output, the test framework will dum
 Test output dumped in: tests/playground/neg/Sample.check.out
   See diff of the checkfile
     > diff tests/playground/neg/Sample.check tests/playground/neg/Sample.check.out
-  Replace checkfile with current output output
+  Replace checkfile with current output
     > mv tests/playground/neg/Sample.check.out tests/playground/neg/Sample.check
 ```
 
@@ -132,5 +132,5 @@ with `with-compiler` in their name.
  $ sbt
  > testCompilation --from-tasty
  ```
- 
+
  This mode can be run under `dotty-compiler-bootstrapped/testCompilation` to test on a bootstrapped Dotty compiler.

--- a/tests/patmat/i6197.scala
+++ b/tests/patmat/i6197.scala
@@ -1,0 +1,13 @@
+object Test {
+  sealed trait Cause[+E]
+
+  object Cause {
+    final case class Fail[E](value: E) extends Cause[E]
+  }
+
+  def fn(cause: Cause[Any]): String =
+    cause match {
+      case Cause.Fail(t: Throwable) => t.toString
+      case Cause.Fail(any)          => any.toString
+    }
+}

--- a/tests/patmat/i6197b.scala
+++ b/tests/patmat/i6197b.scala
@@ -1,0 +1,4 @@
+def foo(x: Option[Array[String]]) = x match {
+  case Some(x) =>
+  case None    =>
+}

--- a/tests/patmat/i6197c.check
+++ b/tests/patmat/i6197c.check
@@ -1,0 +1,1 @@
+3: Match case Unreachable

--- a/tests/patmat/i6197c.scala
+++ b/tests/patmat/i6197c.scala
@@ -1,0 +1,5 @@
+def foo(x: Option[Any]) = x match {
+  case _: Some[Some[_]] =>
+  case _: Some[_] =>         // unreachable
+  case None    =>
+}

--- a/tests/patmat/i6197d.check
+++ b/tests/patmat/i6197d.check
@@ -1,0 +1,1 @@
+5: Pattern Match Exhaustivity: _: Array[String]

--- a/tests/patmat/i6197d.scala
+++ b/tests/patmat/i6197d.scala
@@ -1,0 +1,7 @@
+def foo(x: Array[String]) = x match {
+  case _: Array[_] =>
+}
+
+def bar(x: Array[String]) = x match {
+  case _: Array[_ <: Int] =>
+}


### PR DESCRIPTION

Fix #6197: erase pattern bound type symbols completely