### PR TITLE
Add Support of Parsing Annotations without Arguments to Java Parser

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -344,20 +344,19 @@ object JavaParsers {
       */
     def annotation(): Option[Tree] = {
       val id = convertToTypeId(qualId())
-      var skipAnnot = false
+      var annot: Option[Tree] = Some(ensureApplied(Select(New(id), nme.CONSTRUCTOR)))
 
       // only parse annotations without arguments
       if (in.token == LPAREN) {
         if (in.lookaheadToken != RPAREN) {
-          skipAnnot = true
+          annot = None
           skipAhead()
         }
         else in.nextToken()
         accept(RPAREN)
       }
 
-      if (skipAnnot) None
-      else Some(ensureApplied(Select(New(id), nme.CONSTRUCTOR)))
+      annot
     }
 
     def modifiers(inInterface: Boolean): Modifiers = {

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -344,19 +344,19 @@ object JavaParsers {
       */
     def annotation(): Option[Tree] = {
       val id = convertToTypeId(qualId())
-      var annot: Option[Tree] = Some(ensureApplied(Select(New(id), nme.CONSTRUCTOR)))
-
       // only parse annotations without arguments
-      if (in.token == LPAREN) {
-        if (in.lookaheadToken != RPAREN) {
-          annot = None
-          skipAhead()
-        }
-        else in.nextToken()
+      if (in.token == LPAREN && in.lookaheadToken != RPAREN) {
+        skipAhead()
         accept(RPAREN)
+        None
       }
-
-      annot
+      else {
+        if (in.token == LPAREN) {
+          in.nextToken()
+          accept(RPAREN)
+        }
+        Some(ensureApplied(Select(New(id), nme.CONSTRUCTOR)))
+      }
     }
 
     def modifiers(inInterface: Boolean): Modifiers = {

--- a/tests/pos/annotations-in-java/AnnoJava.java
+++ b/tests/pos/annotations-in-java/AnnoJava.java
@@ -6,6 +6,16 @@ class AnnoJavaParent {
 
 public class AnnoJava extends AnnoJavaParent {
 
+    @MyAnno
+    int f() {
+        return 0;
+    }
+
+    @MyAnno(1)
+    int g() {
+        return 1;
+    }
+
     @MyAnno()
     public static String m(int i) {
         return "m: " + i;

--- a/tests/pos/annotations-in-java/AnnoJava.java
+++ b/tests/pos/annotations-in-java/AnnoJava.java
@@ -1,0 +1,23 @@
+class AnnoJavaParent {
+    public String n(int i) {
+        return "n: " + i;
+    }
+}
+
+public class AnnoJava extends AnnoJavaParent {
+
+    @MyAnno()
+    public static String m(int i) {
+        return "m: " + i;
+    }
+
+    @Override
+    public String n(int i) {
+        return "n: " + i;
+    }
+}
+
+@interface MyAnno {
+    int value() default 1;
+}
+

--- a/tests/pos/annotations-in-java/CallJava.scala
+++ b/tests/pos/annotations-in-java/CallJava.scala
@@ -1,0 +1,4 @@
+class CallJava {
+  def mm(i: Int): String = AnnoJava.m(i)
+}
+


### PR DESCRIPTION
This PR adds support of parsing simple annotations in Java files which don't have arguments.

This PR is similar to #6731. For the explicit-nulls project, we want to read NotNull annotations of Java methods to generate better types. With this change, dotc can read simple annotations of methods in Java files. 

Since all the NotNull annotations we are interested in does not require arguments, all the annotations with arguments are ignored.

This PR should not break any other functionalities.