### PR TITLE
Add effpi to our community-build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 [submodule "community-build/community-projects/semanticdb"]
 	path = community-build/community-projects/semanticdb
 	url = https://github.com/lampepfl/dotty-semanticdb.git
+[submodule "community-build/community-projects/effpi"]
+	path = community-build/community-projects/effpi
+	url = https://github.com/dotty-staging/effpi

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -189,6 +189,15 @@ class CommunityBuildTest {
     updateCommand = "update"
   )
 
+  @Test def effpi = test(
+    project       = "effpi",
+    // We set `useEffpiPlugin := false` because we don't want to run their
+    // compiler plugin since it relies on external binaries (from the model
+    // checker mcrl2), however we do compile the compiler plugin.
+    testCommand   = ";set ThisBuild / useEffpiPlugin := false; effpi/test:compile; plugin/test:compile; benchmarks/test:compile; examples/test:compile; pluginBenchmarks/test:compile",
+    updateCommand = ";set ThisBuild / useEffpiPlugin := false; effpi/test:update; plugin/test:update; benchmarks/test:update; examples/test:update; pluginBenchmarks/test:update"
+  )
+
   // TODO @oderky? It got broken by #5458
   // @Test def pdbp = test(
   //   project       = "pdbp",


### PR DESCRIPTION
See https://github.com/alcestes/effpi for more information. This project
is interesting to have in the community build since it exercises various
Dotty features (implicit/dependent function types, unions, type lambdas,
...) and even contains the first real Dotty compiler plugin! We compile
this plugin but do not run it as part of the community build since it
depends on native binaries (it calls into the mcrl2 model checker).