### PR TITLE
Fix #6142: remove unreasonable type change for _

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -614,10 +614,7 @@ object Erasure {
           if (sym.isConstructor) defn.UnitType
           else sym.info.resultType
         var vparamss1 = (outer.paramDefs(sym) ::: ddef.vparamss.flatten) :: Nil
-        var rhs1 = ddef.rhs match {
-          case id @ Ident(nme.WILDCARD) => untpd.TypedSplice(id.withType(restpe))
-          case _ => ddef.rhs
-        }
+        var rhs1 = ddef.rhs
         if (sym.isAnonymousFunction && vparamss1.head.length > MaxImplementedFunctionArity) {
           val bunchedParam = ctx.newSymbol(sym, nme.ALLARGS, Flags.TermParam, JavaArrayType(defn.ObjectType))
           def selector(n: Int) = ref(bunchedParam)

--- a/tests/pos/i6142.scala
+++ b/tests/pos/i6142.scala
@@ -1,0 +1,10 @@
+import scala.quoted._
+
+object O {
+  def foo given QuoteContext = {
+    type T
+    implicit val _: scala.quoted.Type[T] = ???
+    '[List[T]]
+    ()
+  }
+}


### PR DESCRIPTION
The logic was introduced in f618e47, which is hard to justify.
The problem is exhibited in tests/pos/i6142.scala, where
we have code lik the following:

```Scala
    implicit val _: scala.quoted.Type = ...
    {
      def $anon$ = _
      closure($anon$)
    }
```

Changing the type of `_` will break LambdLift (`_` is not free anymore),
and the compiler crashes at backend when generating code for the unfound local variable `_`,
whose symbol is `scala.quoted.Type`.