### PR TITLE
Fix #6900: Support chained polymorphic extension methods

### DIFF
--- a/tests/pos/i6900.scala
+++ b/tests/pos/i6900.scala
@@ -1,0 +1,8 @@
+object Test {
+  given bla[A] { def (a: A) foo[C]: C => A = _ => a }
+
+  1.foo.foo
+  1.foo.foo[String]
+  1.foo[String].foo
+  1.foo[String].foo[String]
+}


### PR DESCRIPTION
Given a tree `qual.foo`, when we typecheck `qual` we now that the result
must have a member named `foo`, if it doesn't we'll try to adapt it
through implicit conversion / extension method selection to something
which does have such a member.

Given a tree `qual.foo.bar`, the same process happens, but when we
perform the conversion on `qual` we actually now more about the member
`foo`: it must have a member named `bar`. However in general we cannot
use this information: this member might actually require another
conversion and as a rule we don't chain conversions. Therefore, we need
to ignore the expected type of `foo`, this is implemented by
`ProtoTypes#selectionProto` wrapping the expected member type in
`IgnoredProto`.

However, the following failed before this commit:

```scala
given bla[A] { def (a: A) foo[C]: C => A = _ => a }
1.foo[String].foo[String]
```

This happens because when `Applications#extMethodApply` extracts the
type arguments of the extension method from its expected type, it might
end up unpealing an `IgnoredProto`. The solution is to rewrap the new
expeted type into an `IgnoredProto` if the original was ignored.