### PR TITLE
Fix #6902: Avoid illegal characters for generated given names

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -895,7 +895,7 @@ object desugar {
    */
   def normalizeName(mdef: MemberDef, impl: Tree)(implicit ctx: Context): Name = {
     var name = mdef.name
-    if (name.isEmpty) name = name.likeSpaced(s"${inventName(impl)}_given".toTermName)
+    if (name.isEmpty) name = name.likeSpaced(avoidIllegalChars(s"${inventName(impl)}_given".toTermName.asSimpleName))
     if (ctx.owner == defn.ScalaPackageClass && defn.reservedScalaClassNames.contains(name.toTypeName)) {
       def kind = if (name.isTypeName) "class" else "object"
       ctx.error(em"illegal redefinition of standard $kind $name", mdef.sourcePos)

--- a/tests/run/i6902.scala
+++ b/tests/run/i6902.scala
@@ -1,0 +1,9 @@
+object Test {
+  given [A] { def (a: A) <<< : A = a }
+  given { def (b: Int) <<<< : Int = b }
+
+  def main(args: Array[String]): Unit = {
+    1.<<<
+    1.<<<<
+  }
+}


### PR DESCRIPTION
Name encoding does not kick in automatically for operator symbols which
appear in a prefix of a name, so the name `<<<_of_A_given` was kept as
is, which is problematic since `<` is not valid in method names on the
JVM (in `i6902.scala`, `<<<<` runs fine even before this change, because
monomorphic givens are implemented as objects, not defs).

Having to remember to call `avoidIllegalChars` isn't great, but fixing
that should be part of a bigger refactoring of name mangling we still
need to do: #5936.