### PR TITLE
Non-parametric derived instances now lazy vals

### DIFF
--- a/tests/run/lazy-derives.scala
+++ b/tests/run/lazy-derives.scala
@@ -1,0 +1,38 @@
+import scala.deriving._
+
+object Test extends App {
+  case class Mono(i: Int) derives Foo, Bar
+  case class Poly[T](t: T) derives Foo, Bar, Baz
+
+  trait Quux[T]
+  object Quux {
+    given [T] as Quux[T] = new Quux[T] {}
+  }
+
+  trait Foo[T]
+  object Foo {
+    given as Foo[Int] {}
+    def derived[T] given (m: Mirror.Of[T]): Foo[T] = new Foo[T] {}
+  }
+
+  trait Bar[T]
+  object Bar {
+    given as Bar[Int] {}
+    def derived[T] given (m: Mirror.Of[T], o: Quux[T]): Bar[T] = new Bar[T] {}
+  }
+
+  trait Baz[F[_]]
+  object Baz {
+    def derived[F[_]] given (m: Mirror { type MirroredType = F }): Baz[F] = new Baz[F] {}
+  }
+
+  // Unfortunately these tests doesn't distinguish a lazy val
+  // from a cached def
+  assert(the[Foo[Mono]] eq the[Foo[Mono]])
+  assert(the[Bar[Mono]] eq the[Bar[Mono]])
+  assert(the[Baz[Poly]] eq the[Baz[Poly]])
+
+  // These have term arguments so should be distinct
+  assert(the[Foo[Poly[Int]]] ne the[Foo[Poly[Int]]])
+  assert(the[Bar[Poly[Int]]] ne the[Bar[Poly[Int]]])
+}

--- a/tests/run/lazy-derives.scala
+++ b/tests/run/lazy-derives.scala
@@ -1,8 +1,8 @@
 import scala.deriving._
 
 object Test extends App {
-  case class Mono(i: Int) derives Foo, Bar
-  case class Poly[T](t: T) derives Foo, Bar, Baz
+  case class Mono(i: Int) derives Foo, Bar, Inline
+  case class Poly[T](t: T) derives Foo, Bar, Baz, Inline
 
   trait Quux[T]
   object Quux {
@@ -26,13 +26,21 @@ object Test extends App {
     def derived[F[_]] given (m: Mirror { type MirroredType = F }): Baz[F] = new Baz[F] {}
   }
 
+  trait Inline[T]
+  object Inline {
+    given as Inline[Int] {}
+    inline def derived[T] given (m: Mirror.Of[T]): Inline[T] = new Inline[T] {}
+  }
+
   // Unfortunately these tests doesn't distinguish a lazy val
   // from a cached def
   assert(the[Foo[Mono]] eq the[Foo[Mono]])
   assert(the[Bar[Mono]] eq the[Bar[Mono]])
   assert(the[Baz[Poly]] eq the[Baz[Poly]])
+  assert(the[Inline[Mono]] eq the[Inline[Mono]])
 
   // These have term arguments so should be distinct
   assert(the[Foo[Poly[Int]]] ne the[Foo[Poly[Int]]])
   assert(the[Bar[Poly[Int]]] ne the[Bar[Poly[Int]]])
+  assert(the[Inline[Poly[Int]]] ne the[Inline[Poly[Int]]])
 }


### PR DESCRIPTION
Currently all derived instances would be compiled as given defs, which have caching logic added, where possible, in `CacheAliasImplicits`. These caches are unsynchronized, which is a reasonable default in circumstances where the programmer has the option to manually insert a lazy val or some other form of synchronization.

That option isn't available for derived instances, however, because these givens aren't written explicitly. In this case the more appropriate default is to compile non-parametric derived instances as given lazy vals.

This PR makes that change. Unfortunately the tests aren't all that convincing because an identity test isn't sufficient to distinguish between a lazy val and a def with unsynchronized caching logic. Suggestions for a better approach to the test would be very welcome.