### PR TITLE
Fix #6868: Move adding annotation constructor after setting classinfo

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -166,13 +166,14 @@ class ClassfileParser(
       for (i <- 0 until in.nextChar) parseMember(method = false)
       for (i <- 0 until in.nextChar) parseMember(method = true)
       classInfo = parseAttributes(classRoot.symbol, classInfo)
-      if (isAnnotation) addAnnotationConstructor(classInfo)
 
       classRoot.registerCompanion(moduleRoot.symbol)
       moduleRoot.registerCompanion(classRoot.symbol)
 
-      setClassInfo(classRoot, classInfo, fromScala2 = false)
-      setClassInfo(moduleRoot, staticInfo, fromScala2 = false)
+      setClassInfo(classRoot, classInfo, fromScala2 = false, isAnnotation = isAnnotation)
+      setClassInfo(moduleRoot, staticInfo, fromScala2 = false, isAnnotation = isAnnotation)
+
+      if (isAnnotation) addAnnotationConstructor(classInfo)
     } else if (result == Some(NoEmbedded)) {
       for (sym <- List(moduleRoot.sourceModule, moduleRoot.symbol, classRoot.symbol)) {
         classRoot.owner.asClass.delete(sym)

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -95,7 +95,7 @@ object Scala2Unpickler {
       cls.enter(constr, scope)
     }
 
-  def setClassInfo(denot: ClassDenotation, info: Type, fromScala2: Boolean, selfInfo: Type = NoType)(implicit ctx: Context): Unit = {
+  def setClassInfo(denot: ClassDenotation, info: Type, fromScala2: Boolean, selfInfo: Type = NoType, isAnnotation: Boolean = false)(implicit ctx: Context): Unit = {
     val cls = denot.classSymbol
     val (tparams, TempClassInfoType(parents, decls, clazz)) = info match {
       case TempPolyType(tps, cinfo) => (tps, cinfo)
@@ -120,7 +120,8 @@ object Scala2Unpickler {
       if (tsym.exists) tsym.setFlag(TypeParam)
       else denot.enter(tparam, decls)
     }
-    if (!denot.flagsUNSAFE.isAllOf(JavaModule)) ensureConstructor(denot.symbol.asClass, decls)
+    if (!denot.flagsUNSAFE.isAllOf(JavaModule) && !isAnnotation)
+      ensureConstructor(denot.symbol.asClass, decls)
 
     val scalacCompanion = denot.classSymbol.scalacLinkedClass
 

--- a/tests/pos-java-interop-separate/annotation-with-inner-class-ref/MyJava_1.java
+++ b/tests/pos-java-interop-separate/annotation-with-inner-class-ref/MyJava_1.java
@@ -1,0 +1,13 @@
+public @interface MyJava_1 {
+
+    public MyClassTypeA typeA() default MyClassTypeA.A;
+
+    public MyClassTypeB typeB();
+
+    public enum MyClassTypeA {
+	A
+    }
+
+    public @interface MyClassTypeB {}
+}
+

--- a/tests/pos-java-interop-separate/annotation-with-inner-class-ref/MyJava_1.java
+++ b/tests/pos-java-interop-separate/annotation-with-inner-class-ref/MyJava_1.java
@@ -1,11 +1,13 @@
 public @interface MyJava_1 {
 
-    public MyClassTypeA typeA() default MyClassTypeA.A;
+    public String value() default "MyJava";
 
-    public MyClassTypeB typeB();
+    public MyClassTypeA typeA();
+
+    public MyClassTypeB typeB() default @MyClassTypeB;
 
     public enum MyClassTypeA {
-	A
+	A, B
     }
 
     public @interface MyClassTypeB {}

--- a/tests/pos-java-interop-separate/annotation-with-inner-class-ref/MyScala_2.scala
+++ b/tests/pos-java-interop-separate/annotation-with-inner-class-ref/MyScala_2.scala
@@ -1,6 +1,13 @@
+@MyJava_1("MyScala1", typeA = MyJava_1.MyClassTypeA.B)
 object MyScala {
   def a(mj: MyJava_1): Unit = {
     println("MyJava")
   }
+
+  @MyJava_1(typeA = MyJava_1.MyClassTypeA.A)
+  def b(): Int = 1
+
+  @MyJava_1(value = "MyScala2", typeA = MyJava_1.MyClassTypeA.B)
+  def c(): Int = 2
 }
 

--- a/tests/pos-java-interop-separate/annotation-with-inner-class-ref/MyScala_2.scala
+++ b/tests/pos-java-interop-separate/annotation-with-inner-class-ref/MyScala_2.scala
@@ -1,0 +1,6 @@
+object MyScala {
+  def a(mj: MyJava_1): Unit = {
+    println("MyJava")
+  }
+}
+


### PR DESCRIPTION
This PR should fix issue #6868. My another PR #6893 is also blocked by this issue.

When parsing an annotation class in `ClassfileParser`, if some of its paramter types are its inner classes, a `CyclicReferenceInvolving` is thrown.

Here is a small example:

MyScala.scala:

```scala
object MyScala {
  def a(mj: MyJava): Unit = {
    println("MyJava")
  }
}
```

MyJava.java:

```java
public @interface MyJava {
    public MyClassType type();
    public @interface MyClassType { }
}
```

The output is:

```
> javac MyJava.java
> ./bin/dotc -explain MyScala.scala
exception caught when loading class MyClassType: CyclicReferenceInvolving(class MyClassType)
exception caught when loading class MyJava: CyclicReferenceInvolving(class MyClassType)
-- [E046] Cyclic Error: MyScala.scala:2:12 -------------------------------------
2 |  def a(mj: MyJava): Unit = {
  |            ^
  |            Cyclic reference involving class MyClassType

Explanation
===========
class MyClassType is declared as part of a cycle which makes it impossible for the
compiler to decide upon MyClassType's type.
To avoid this error, try giving MyClassType an explicit type.


one error found
```

The issue is when the parser tries to get the type of a paramter, a cyclic reference will be detected as the parent relationship information has not been set up. 

By moving adding annotation constructor after the setting classInfo, the annotation class can be parsed correctly.