### PR TITLE
Add header to some doc pages

### DIFF
--- a/docs/docs/contributing/contribute-knowledge.md
+++ b/docs/docs/contributing/contribute-knowledge.md
@@ -1,3 +1,8 @@
+---
+layout: doc-page
+title: Contributing Knowledge
+---
+
 # Contribute Internals-related Knowledge
 If you know anything useful at all about Dotty, feel free to log this knowledge:
 

--- a/docs/docs/contributing/debugging.md
+++ b/docs/docs/contributing/debugging.md
@@ -1,3 +1,8 @@
+---
+layout: doc-page
+title: Debugging Techniques
+---
+
 # Debugging Techniques
 - [Setting up the playground](#setting-up-the-playground)
 - [Show for human readable output](#show-for-human-readable-output)

--- a/docs/docs/contributing/procedures/vulpix.md
+++ b/docs/docs/contributing/procedures/vulpix.md
@@ -1,3 +1,8 @@
+---
+layout: doc-page
+title: Test Vulpix Framework
+---
+
 # Test Vulpix Framework
 If you are modifying the Vulpix framework and need a playground with dummy tests to try out your modifications, do the following.
 

--- a/docs/docs/contributing/scala2-vs-scala3.md
+++ b/docs/docs/contributing/scala2-vs-scala3.md
@@ -1,3 +1,8 @@
+---
+layout: doc-page
+title: Divergences between Scala 2 and Dotty
+---
+
 # Divergences between Scala 2 and Dotty
 The following issues encountered when compiling Scala 2 code as-is under Dotty:
 

--- a/docs/docs/contributing/tools/mill.md
+++ b/docs/docs/contributing/tools/mill.md
@@ -1,3 +1,8 @@
+---
+layout: doc-page
+title: Basic Operations with Mill
+---
+
 Here's an example of how to test a project that uses mill:
 
 ```bash

--- a/docs/docs/contributing/tools/scalafix.md
+++ b/docs/docs/contributing/tools/scalafix.md
@@ -1,3 +1,8 @@
+---
+layout: doc-page
+title: Working with Scalafix
+---
+
 # Working with Scalafix
 
 First, create a new rule as follows (command from https://scalacenter.github.io/scalafix/docs/developers/setup.html):


### PR DESCRIPTION
Currently, some doc pages, e.g. [debugging](http://dotty.epfl.ch/docs/contributing/debugging.html), are not rendered correctly.