### PR TITLE
.drone.yml: Fix manual nightly build run

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -62,7 +62,7 @@ steps:
   when:
     event:
     - tag
-    - deployment
+    - promote
 
 - name: test_java11
   pull: default
@@ -76,7 +76,7 @@ steps:
     event:
     - push
     - tag
-    - deployment
+    - promote
 
 - name: documentation
   pull: default
@@ -120,7 +120,7 @@ steps:
       from_secret: sonatype_user
   when:
     event:
-    - deployment
+    - promote
     target:
     - nightly
 
@@ -190,7 +190,7 @@ steps:
       from_secret: sonatype_user
   when:
     event:
-    - deployment
+    - promote
     target:
     - sbt_release
 
@@ -206,7 +206,7 @@ steps:
     event:
     - push
     - tag
-    - deployment
+    - promote
     status:
     - failure
 


### PR DESCRIPTION
Automatically running the nightly build is still broken (#6878), but
manually running it using:

    drone build promote lampepfl/dotty 263 nightly

Should now work, following the apparent renaming of the event used for
deployment in drone 1.0: https://docs.drone.io/user-guide/pipeline/promotion/