### PR TITLE
Fix #6816: Deny methods with implicit members from tpd.applyOverloaded

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1149,6 +1149,10 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
         var allAlts = denot.alternatives
           .map(denot => TermRef(receiver.tpe, denot.symbol))
           .filter(tr => typeParamCount(tr) == targs.length)
+          .filter { _.widen match {
+            case MethodTpe(_, _, x: MethodType) => !x.isImplicitMethod
+            case _ => true
+          }}
         if (targs.isEmpty) allAlts = allAlts.filterNot(_.widen.isInstanceOf[PolyType])
         val alternatives = ctx.typer.resolveOverloaded(allAlts, proto)
         assert(alternatives.size == 1,

--- a/tests/run/i6816.scala
+++ b/tests/run/i6816.scala
@@ -1,0 +1,14 @@
+trait Bar
+trait Foo {
+  def ==(that: Foo)(implicit b: Bar): Boolean = ???
+}
+
+case class FooCC(f: Foo)
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val foo1, foo2 = new Foo {}
+    assert(FooCC(foo1) == FooCC(foo1))
+    assert(FooCC(foo1) != FooCC(foo2))
+  }
+}


### PR DESCRIPTION
We cannot resolve implicit parameters outside Typer. Hence methods
that require implicit parameters should not be considered.