### PR TITLE
Fix of the 404 link to intellij-idea.md

### DIFF
--- a/docs/docs/contributing/workflow.md
+++ b/docs/docs/contributing/workflow.md
@@ -4,7 +4,7 @@ title: Workflow
 ---
 
 Check [Getting Started](getting-started.md) for instructions on how to obtain the source code of dotty and 
-[Eclipse](eclipse.md) or [IntelliJ-IDEA](tools/intellij-idea.md).
+[Eclipse](tools/eclipse.md) or [IntelliJ-IDEA](tools/intellij-idea.md).
 This document details common workflow patterns when working with Dotty before using the debugging tools.
 
 ## Compiling files with dotc ##

--- a/docs/docs/contributing/workflow.md
+++ b/docs/docs/contributing/workflow.md
@@ -4,7 +4,7 @@ title: Workflow
 ---
 
 Check [Getting Started](getting-started.md) for instructions on how to obtain the source code of dotty and 
-[Eclipse](eclipse.md) or [IntelliJ-IDEA](intellij-idea.md).
+[Eclipse](eclipse.md) or [IntelliJ-IDEA](tools/intellij-idea.md).
 This document details common workflow patterns when working with Dotty before using the debugging tools.
 
 ## Compiling files with dotc ##


### PR DESCRIPTION
A simple fix of the link to intellij-idea.md file