### PR TITLE
Fix #6946: Fix generic signature for synthetic function types

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -222,8 +222,10 @@ object GenericSignatures {
             else
               jsig(unboxedSeen, toplevel, primitiveOK)
           }
-          else if (defn.isXXLFunctionClass(sym))
-            classSig(defn.FunctionXXLClass)
+          else if (defn.isSyntheticFunctionClass(sym)) {
+            val erasedSym = defn.erasedFunctionClass(sym)
+            classSig(erasedSym, pre, if (erasedSym.typeParams.isEmpty) Nil else args)
+          }
           else if (sym.isClass)
             classSig(sym, pre, args)
           else

--- a/tests/generic-java-signatures/i3653.check
+++ b/tests/generic-java-signatures/i3653.check
@@ -1,1 +1,2 @@
 public <T> scala.FunctionXXL Foo.bar()
+public scala.Function1<scala.Function1<java.lang.String, scala.runtime.BoxedUnit>, scala.runtime.BoxedUnit> Foo.baz()

--- a/tests/generic-java-signatures/i3653.scala
+++ b/tests/generic-java-signatures/i3653.scala
@@ -3,11 +3,16 @@ class Foo {
     (a0: T, a1: T, a2: T, a3: T, a4: T, a5: T, a6: T, a7: T, a8: T, a9: T,
      b0: T, b1: T, b2: T, b3: T, b4: T, b5: T, b6: T, b7: T, b8: T, b9: T,
      c0: T, c1: T, c2: T, c3: T, c4: T, c5: T, c6: T, c7: T, c8: T, c9: T) => 0
+
+  // #6946
+  def baz = (x: given String => Unit) => x given ""
 }
 
 object Test {
   def main(args: Array[String]): Unit = {
-    val meth = classOf[Foo].getDeclaredMethod("bar")
-    println(meth.toGenericString)
+    val meth1 = classOf[Foo].getDeclaredMethod("bar")
+    println(meth1.toGenericString)
+    val meth2 = classOf[Foo].getDeclaredMethod("baz")
+    println(meth2.toGenericString)
   }
 }


### PR DESCRIPTION
Generic signature generation did not take synthetic functions into account.

I lack the techniques how to test this. Maybe somebody else can add a test?

@smarter If the fix works, do we need then a new reference compiler before we can use IFTs in Reporter?

