### PR TITLE
Fix #6914: Improve type inference for implicit Conversions

### DIFF
--- a/tests/pos/i6914.scala
+++ b/tests/pos/i6914.scala
@@ -1,19 +1,29 @@
 trait Expr[T]
 trait Liftable[T]
 
-/*given autoToExpr[T] as Conversion[T, Expr[T]] given Liftable[T] {
-  def apply(x: T): Expr[T] = ???
+object test1 {
+  class ToExpr[T] given Liftable[T] extends Conversion[T, Expr[T]] {
+    def apply(x: T): Expr[T] = ???
+  }
+  given toExpr[T] as ToExpr[T] given Liftable[T]
+
+  given as Liftable[Int] = ???
+  given as Liftable[String] = ???
+
+  def x = the[ToExpr[String]]
+  def y = the[Conversion[String, Expr[String]]]
+
+  def a: Expr[String] = "abc"
 }
-*/
-class ToExpr[T] given Liftable[T] extends Conversion[T, Expr[T]] {
-  def apply(x: T): Expr[T] = ???
+
+object test2 {
+
+  given autoToExpr[T] as Conversion[T, Expr[T]] given Liftable[T] {
+    def apply(x: T): Expr[T] = ???
+  }
+
+  given as Liftable[Int] = ???
+  given as Liftable[String] = ???
+
+  def a: Expr[String] = "abc"
 }
-given toExpr[T] as ToExpr[T] given Liftable[T]
-
-given as Liftable[Int] = ???
-given as Liftable[String] = ???
-
-def x = the[ToExpr[String]]
-def y = the[Conversion[String, Expr[String]]]
-
-def a: Expr[String] = "abc"

--- a/tests/pos/i6914.scala
+++ b/tests/pos/i6914.scala
@@ -1,0 +1,19 @@
+trait Expr[T]
+trait Liftable[T]
+
+/*given autoToExpr[T] as Conversion[T, Expr[T]] given Liftable[T] {
+  def apply(x: T): Expr[T] = ???
+}
+*/
+class ToExpr[T] given Liftable[T] extends Conversion[T, Expr[T]] {
+  def apply(x: T): Expr[T] = ???
+}
+given toExpr[T] as ToExpr[T] given Liftable[T]
+
+given as Liftable[Int] = ???
+given as Liftable[String] = ???
+
+def x = the[ToExpr[String]]
+def y = the[Conversion[String, Expr[String]]]
+
+def a: Expr[String] = "abc"


### PR DESCRIPTION
Make use of the knowlegde that a given instance used for a conversion
must be an instance of `scala.Conversion`.