### PR TITLE
Fix #6972: Parially revert c53f465524597bad481f4930eaeaae8ae953e1a7

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,10 +59,10 @@ steps:
   commands:
   - cp -R . /tmp/4/ && cd /tmp/4/
   - ./project/scripts/sbt sbt-dotty/scripted
-  # when:
-  #   event:
-  #   - tag
-  #   - promote
+  when:
+    event:
+    - tag
+    - promote
 
 - name: test_java11
   pull: default

--- a/.drone.yml
+++ b/.drone.yml
@@ -59,10 +59,10 @@ steps:
   commands:
   - cp -R . /tmp/4/ && cd /tmp/4/
   - ./project/scripts/sbt sbt-dotty/scripted
-  when:
-    event:
-    - tag
-    - promote
+  # when:
+  #   event:
+  #   - tag
+  #   - promote
 
 - name: test_java11
   pull: default

--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -22,13 +22,10 @@ class JavaPlatform extends Platform {
 
   // The given symbol is a method with the right name and signature to be a runnable java program.
   def isMainMethod(sym: SymDenotation)(implicit ctx: Context): Boolean =
-    sym.name == nme.main &&
-    (sym.owner.is(Module) || sym.owner.isClass && !sym.owner.is(Trait) && sym.is(JavaStatic)) && {
-      sym.info match {
-        case MethodTpe(_, defn.ArrayOf(el) :: Nil, restpe) => el =:= defn.StringType && (restpe isRef defn.UnitClass)
-        case _ => false
-      }
-    }
+    (sym.name == nme.main) && (sym.info match {
+      case MethodTpe(_, defn.ArrayOf(el) :: Nil, restpe) => el =:= defn.StringType && (restpe isRef defn.UnitClass)
+      case _ => false
+    })
 
   /** Update classpath with a substituted subentry */
   def updateClassPath(subst: Map[ClassPath, ClassPath]): Unit = currentClassPath.get match {


### PR DESCRIPTION
The issue is that inherited `main` methods such as the one from `App` are not considered main method with this stricter condition. c53f465524597bad481f4930eaeaae8ae953e1a7

This currently breaks the nightly build.