### PR TITLE
Allow collective parameters for extension methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -914,7 +914,7 @@ object desugar {
           ctx.error(em"No extension method $allowed", mdef.sourcePos)
           mdef
         }
-        else cpy.DefDef(mdef)(tparams = tparams ++ mdef.tparams, vparamss = leadingParams :: Nil)
+        else cpy.DefDef(mdef)(tparams = tparams ++ mdef.tparams, vparamss = leadingParams :: mdef.vparamss)
           .withFlags(Extension)
       case mdef: Import =>
         mdef

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -387,6 +387,7 @@ EnumDef           ::=  id ClassConstr InheritClauses EnumBody                   
 GivenDef          ::=  [id] [DefTypeParamClause] GivenBody
 GivenBody         ::=  [‘as ConstrApp {‘,’ ConstrApp }] {GivenParamClause} [TemplateBody]
                     |  ‘as’ Type {GivenParamClause} ‘=’ Expr
+                    |  ‘(’ DefParam ‘)’ TemplateBody
 Template          ::=  InheritClauses [TemplateBody]                            Template(constr, parents, self, stats)
 InheritClauses    ::=  [‘extends’ ConstrApps] [‘derives’ QualId {‘,’ QualId}]
 ConstrApps        ::=  ConstrApp {‘with’ ConstrApp}

--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -80,7 +80,7 @@ So `circle.circumference` translates to `CircleOps.circumference(circle)`, provi
 
 ### Given Instances for Extension Methods
 
-Given instances that define extension methods can also be defined without a `for` clause. E.g.,
+Given instances that define extension methods can also be defined without an `as` clause. E.g.,
 
 ```scala
 given StringOps {
@@ -94,8 +94,33 @@ given {
   def (xs: List[T]) second[T] = xs.tail.head
 }
 ```
-If such given instances are anonymous (as in the second clause), their name is synthesized from the name
-of the first defined extension method.
+If such given instances are anonymous (as in the second clause), their name is synthesized from the name of the first defined extension method.
+
+### Given Instances with Collective Parameters
+
+If a given instance has several extension methods one can pull out the left parameter section
+as well as any type parameters of these extension methods into the given instance itself.
+For instance, here is a given instance with two extension methods.
+```scala
+given ListOps {
+  def (xs: List[T]) second[T]: T = xs.tail.head
+  def (xs: List[T]) third[T]: T = xs.tail.tail.head
+}
+```
+The repetition in the parameters can be avoided by moving the parameters into the given instance itself. The following version is a shorthand for the code above.
+```scala
+given ListOps[T](xs: List[T]) {
+  def second: T = xs.tail.head
+  def third: T = xs.tail.tail.head
+}
+```
+This syntax just adds convenience at the definition site. Applications of such extension methods are exactly the same as if their parameters were repeated in each extension method.
+Examples:
+```scala
+val xs = List(1, 2, 3)
+xs.second[Int]
+ListOps.third[T](xs)
+```
 
 ### Operators
 
@@ -143,4 +168,6 @@ to the [current syntax](../../internals/syntax.md).
 ```
 DefSig            ::=  ...
                     |  ‘(’ DefParam ‘)’ [nl] id [DefTypeParamClause] DefParamClauses
+GivenBody         ::=  ...
+                    |  ‘(’ DefParam ‘)’ TemplateBody
 ```

--- a/tests/neg/extension-methods.scala
+++ b/tests/neg/extension-methods.scala
@@ -10,5 +10,9 @@ object Test {
   "".l2 // error
   1.l1 // error
 
-
+  given [T](xs: List[T]) {
+    def (x: Int) f1: T = ???  // error: No extension method allowed here, since collective parameters are given
+    def f2[T]: T = ???        // error: T is already defined as type T
+    def f3(xs: List[T]) = ??? // error: xs is already defined as value xs
+  }
 }

--- a/tests/run/extmethods2.scala
+++ b/tests/run/extmethods2.scala
@@ -14,4 +14,25 @@ object Test extends App {
   }
 
   test given TC()
+
+  object A {
+    given ListOps[T](xs: List[T]) {
+      def second: T = xs.tail.head
+      def third: T = xs.tail.tail.head
+    }
+    given (xs: List[Int]) {
+      def prod = (1 /: xs)(_ * _)
+    }
+  }
+
+  object B {
+    import given A._
+    val xs = List(1, 2, 3)
+    assert(xs.second[Int] == 2)
+    assert(xs.third == 3)
+    assert(A.ListOps.second[Int](xs) == 2)
+    assert(A.ListOps.third(xs) == 3)
+    assert(xs.prod == 6)
+  }
 }
+

--- a/tests/run/extmethods2.scala
+++ b/tests/run/extmethods2.scala
@@ -19,10 +19,14 @@ object Test extends App {
     given ListOps[T](xs: List[T]) {
       def second: T = xs.tail.head
       def third: T = xs.tail.tail.head
+      def concat(ys: List[T]) = xs ++ ys
+      def zipp[U](ys: List[U]): List[(T, U)] = xs.zip(ys)
     }
     given (xs: List[Int]) {
       def prod = (1 /: xs)(_ * _)
     }
+
+
   }
 
   object B {
@@ -33,6 +37,9 @@ object Test extends App {
     assert(A.ListOps.second[Int](xs) == 2)
     assert(A.ListOps.third(xs) == 3)
     assert(xs.prod == 6)
+    assert(xs.concat(xs).length == 6)
+    assert(xs.zipp(xs).map(_ + _).prod == 36)
+    assert(xs.zipp[Int, Int](xs).map(_ + _).prod == 36)
   }
 }
 


### PR DESCRIPTION
This is a trial balloon. The idea is to allow one to "pull out" the leading parameter and any type parameters of extension methods to an enclosing given clause. E.g.
```scala
given ListOps {
  def (xs: List[T]) second[T]: T = xs.tail.head
  def (xs: List[T]) third[T]: T = xs.tail.tail.head
}
```
The repetition in the parameters can be avoided by moving the parameters into the given instance itself. The following version is a shorthand for the code above.
```scala
given ListOps[T](xs: List[T]) {
  def second: T = xs.tail.head
  def third: T = xs.tail.tail.head
}
```
IF we decide to go down this route, we might also want to re-open the issue where type parameters of extension methods go. Right now, they go after the method name. An alternative was proposed that would let them go in front, like this:
```scala
given ListOps {
  def [T](xs: List[T]) second: T = xs.tail.head
  def [T](xs: List[T]) third: T = xs.tail.tail.head
}
```
The argument for the current choice is that parameter definition and application syntax lines up this way. The argument for parameters first is that it keeps the principle that usages follow definitions. Right now, I think the "line up definition and application syntax " argument is stronger. But with collective parameters we would have to break it, since collective type parameter definitions have to go first, which is not the point where they would be applied. So under these circumstances the scales might well shift to favor putting type parameters always first.

