### PR TITLE
Add constructor for AppliedType

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionInternal.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionInternal.scala
@@ -1230,6 +1230,8 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   def AppliedType_tycon(self: AppliedType) given Context: Type = self.tycon
   def AppliedType_args(self: AppliedType) given Context: List[TypeOrBounds] = self.args
 
+  def AppliedType_apply(tycon: Type, args: List[TypeOrBounds]) given Context: AppliedType = Types.AppliedType(tycon, args)
+
   type AnnotatedType = Types.AnnotatedType
 
   def matchAnnotatedType(tpe: TypeOrBounds) given Context: Option[AnnotatedType] = tpe match {

--- a/library/src/scala/tasty/reflect/CompilerInterface.scala
+++ b/library/src/scala/tasty/reflect/CompilerInterface.scala
@@ -978,6 +978,8 @@ trait CompilerInterface {
   def AppliedType_tycon(self: AppliedType) given (ctx: Context): Type
   def AppliedType_args(self: AppliedType) given (ctx: Context): List[TypeOrBounds]
 
+  def AppliedType_apply(tycon: Type, args: List[TypeOrBounds]) given (ctx: Context) : AppliedType
+
   /** A type with an anottation `T @foo` */
   type AnnotatedType <: Type
 

--- a/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
@@ -142,6 +142,8 @@ trait TypeOrBoundsOps extends Core {
     }
 
     object AppliedType {
+      def apply(tycon: Type, args: List[TypeOrBounds]) given (ctx: Context) : AppliedType =
+        internal.AppliedType_apply(tycon, args)
       def unapply(typeOrBounds: TypeOrBounds) given (ctx: Context): Option[(Type, List[TypeOrBounds /* Type | TypeBounds */])] =
         internal.matchAppliedType(typeOrBounds).map(x => (x.tycon, x.args))
     }


### PR DESCRIPTION
Temporary addition of a constructor for `AppliedType` ... to be revisited in the process of putting together `TypeMap`/`TypeCollector`.