### PR TITLE
Fix #7011: check possibly side-effecting transform

### DIFF
--- a/tests/pos/i7011/Macros_1.scala
+++ b/tests/pos/i7011/Macros_1.scala
@@ -1,0 +1,16 @@
+import scala.quoted._, scala.quoted.matching._
+import delegate scala.quoted._
+
+inline def mcr(body: => Any): Unit = ${mcrImpl('body)}
+
+def mcrImpl[T](body: Expr[Any]) given (ctx: QuoteContext): Expr[Any] = {
+  import ctx.tasty._
+
+  val bTree = body.unseal
+  val under = bTree.underlyingArgument
+
+  val res = '{Box(${under.asInstanceOf[Term].seal})}
+  res
+}
+
+class Box(inner: => Any)

--- a/tests/pos/i7011/Test_2.scala
+++ b/tests/pos/i7011/Test_2.scala
@@ -1,0 +1,1 @@
+def f = mcr { try () catch { case x => } }


### PR DESCRIPTION
The transform function in question can be overridden with a version
that produces side effects. If that is the case, and if the superclass
transform function is called from the overridden transform function,
the overridden transform function might be executed twice with all its
side effects. This commit makes sure the transform function is not
called twice on the same input. An example where it can go wrong is:

https://github.com/lampepfl/dotty/blob/9a4b7d39a595dba3c0baf340b0bf911844fcae69/compiler/src/dotty/tools/dotc/typer/Typer.scala#L1080-L1094

Here, the transform function performs the side effect of entering a symbol
into scope. Furthermore, if the symbol already exists in scope, it emits
an error. Hence, if we call this function twice on the same argument,
we are guaranteed to get an error.