### PR TITLE
Support Mirrors for value classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -625,6 +625,8 @@ class Definitions {
   @tu lazy val Mirror_SumClass: ClassSymbol = ctx.requiredClass("scala.deriving.Mirror.Sum")
   @tu lazy val Mirror_SingletonClass: ClassSymbol = ctx.requiredClass("scala.deriving.Mirror.Singleton")
   @tu lazy val Mirror_SingletonProxyClass: ClassSymbol = ctx.requiredClass("scala.deriving.Mirror.SingletonProxy")
+  @tu lazy val Mirror_ValueClassClass: ClassSymbol = ctx.requiredClass("scala.deriving.Mirror.ValueClass")
+    @tu lazy val Mirror_ValueClassClass_wrapValue: Symbol = Mirror_ValueClassClass.requiredMethod(nme.wrapValue)
 
   @tu lazy val LanguageModule: Symbol = ctx.requiredModule("scala.language")
   @tu lazy val NonLocalReturnControlClass: ClassSymbol = ctx.requiredClass("scala.runtime.NonLocalReturnControl")

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -573,6 +573,7 @@ object StdNames {
     val withFilterIfRefutable: N = "withFilterIfRefutable$"
     val WorksheetWrapper: N     = "WorksheetWrapper"
     val wrap: N                 = "wrap"
+    val wrapValue: N            = "wrapValue"
     val writeReplace: N         = "writeReplace"
     val zero: N                 = "zero"
     val zip: N                  = "zip"

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -12,7 +12,6 @@ import StdNames._
 import NameKinds._
 import Flags._
 import Annotations._
-import ValueClasses.isDerivedValueClass
 import Decorators._
 
 import language.implicitConversions
@@ -79,7 +78,6 @@ class SymUtils(val self: Symbol) extends AnyVal {
     if (!self.is(CaseClass)) "it is not a case class"
     else if (self.is(Abstract)) "it is an abstract class"
     else if (self.primaryConstructor.info.paramInfoss.length != 1) "it takes more than one parameter list"
-    else if (isDerivedValueClass(self)) "it is a value class"
     else ""
 
   def isGenericProduct(implicit ctx: Context): Boolean = whyNotGenericProduct.isEmpty

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -30,6 +30,7 @@ import Trees._
 import transform.SymUtils._
 import transform.TypeUtils._
 import transform.SyntheticMembers._
+import transform.ValueClasses.isDerivedValueClass
 import Hashable._
 import util.{Property, SourceFile, NoSource}
 import config.Config
@@ -960,8 +961,9 @@ trait Implicits { self: Typer =>
                   val elems = TypeOps.nestedPairs(accessors.map(mirroredType.memberInfo(_).widenExpr))
                   (mirroredType, elems)
               }
+              val mirrorClass = if (isDerivedValueClass(cls)) defn.Mirror_ValueClassClass else defn.Mirror_ProductClass
               val mirrorType =
-                mirrorCore(defn.Mirror_ProductClass, monoType, mirroredType, cls.name, formal)
+                mirrorCore(mirrorClass, monoType, mirroredType, cls.name, formal)
                   .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
                   .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
               val mirrorRef =

--- a/library/src/scala/deriving.scala
+++ b/library/src/scala/deriving.scala
@@ -26,7 +26,6 @@ object deriving {
 
     /** The Mirror for a product type */
     trait Product extends Mirror {
-
       /** Create a new instance of type `T` with elements taken from product `p`. */
       def fromProduct(p: scala.Product): MirroredMonoType
     }
@@ -46,6 +45,12 @@ object deriving {
       type MirroredElemTypes = Unit
       type MirroredElemLabels = Unit
       def fromProduct(p: scala.Product) = value
+    }
+
+    trait ValueClass extends Product {
+      type MirroredMonoType <: scala.Product
+      def fromProduct(p: scala.Product): MirroredMonoType = wrapValue(p.productElement(0))
+      def wrapValue(v: Any): MirroredMonoType
     }
 
     type Of[T]        = Mirror { type MirroredType = T; type MirroredMonoType = T ; type MirroredElemTypes <: Tuple }

--- a/tests/run/i7000.scala
+++ b/tests/run/i7000.scala
@@ -1,0 +1,16 @@
+import scala.deriving._
+import compiletime._
+
+object Test extends App {
+  case class B(v: Double) extends AnyVal
+  val m0 = the[Mirror.ProductOf[B]]
+
+  val v0 = m0.fromProduct(Tuple1(23.0))
+  assert(v0 == B(23.0))
+
+  case class C[T](v: T) extends AnyVal
+  val m1 = the[Mirror.ProductOf[C[Double]]]
+
+  val v1 = m1.fromProduct(Tuple1(23.0))
+  assert(v1 == C(23.0))
+}


### PR DESCRIPTION
This PR adds support for `Mirrors` for value classes, fixing #7000.

As discussed on that issue, the reason for value classes being prohibited from having `Mirrors` was a subtle issue with the bridges for the `fromProduct` method which are generated due to its result type being the value class type. In the case of value classes with polymorphic contents which erase to `Object`, the bridge method collides with the underlying method as in #1905.

@smarter suggested putting a bound of `<: Product` on `MirroredMonoType` to prevent the erasures being the same. This can't be done in general (in general the type need not be `<: Product`), but we can create a subtype of `Mirror.Product` for value classes which can have that additional constraint.

Intuitively, the following ought to have been sufficient,

```scala
trait ValueClass extends Product {
  type MirroredMonoType <: scala.Product
}
```

however, the bridges transform still sees a collision in this case. The following does work though,

```scala
trait ValueClass  extends Product {
  type MirroredMonoType <: scala.Product
  def fromProduct(p: scala.Product): MirroredMonoType = wrapValue(p.productElement(0))
  def wrapValue(v: Any): MirroredMonoType
}
```
where for value classes we now implement `wrapValue` on the companion.

It's not clear to me if this really is necessary, or if the simpler fix ought to have worked as I had expected. The collision reported in that case appears to be between the bridge method and the `fromProduct` method from `Product` (ie. further up the hierarchy than the refinement which introduces the `<: Product` bound). I'm a bit out of my depth here, but it seems at least possible that the bridge code is missing some `asSeenFrom` somewhere and so isn't seeing the refinement which would remove the collision.
