### PR TITLE
Alternative Syntax for Control Expressions

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -48,6 +48,9 @@ class ScalaSettings extends Settings.SettingGroup {
   val silentWarnings: Setting[Boolean] = BooleanSetting("-nowarn", "Silence all warnings.") withAbbreviation "--no-warnings"
   val fromTasty: Setting[Boolean] = BooleanSetting("-from-tasty", "Compile classes from tasty in classpath. The arguments are used as class names.") withAbbreviation "--from-tasty"
 
+  val newSyntax: Setting[Boolean] = BooleanSetting("-new-syntax", "Require `then` and `do` in control expressions")
+  val oldSyntax: Setting[Boolean] = BooleanSetting("-old-syntax", "Require `(...)` around conditions")
+
   /** Decompiler settings */
   val printTasty: Setting[Boolean] = BooleanSetting("-print-tasty", "Prints the raw tasty.") withAbbreviation "--print-tasty"
   val printLines: Setting[Boolean] = BooleanSetting("-print-lines", "Show source code line numbers.") withAbbreviation "--print-lines"

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -222,6 +222,10 @@ object Scanners {
     /** A switch whether operators at the start of lines can be infix operators */
     private var allowLeadingInfixOperators = true
 
+    val rewrite = ctx.settings.rewrite.value.isDefined
+    val oldSyntax = ctx.settings.oldSyntax.value
+    val newSyntax = ctx.settings.newSyntax.value
+
     /** All doc comments kept by their end position in a `Map` */
     private[this] var docstringMap: SortedMap[Int, Comment] = SortedMap.empty
 
@@ -236,7 +240,7 @@ object Scanners {
       def nextPos: Int = (lookahead.getc(): @switch) match {
         case ' ' | '\t' => nextPos
         case CR | LF | FF =>
-          // if we encounter line delimitng whitespace we don't count it, since
+          // if we encounter line delimiting whitespace we don't count it, since
           // it seems not to affect positions in source
           nextPos - 1
         case _ => lookahead.charOffset - 1
@@ -420,7 +424,7 @@ object Scanners {
           insertNL(NEWLINES)
         else if (!isLeadingInfixOperator)
           insertNL(NEWLINE)
-        else if (isScala2Mode)
+        else if (isScala2Mode || oldSyntax)
           ctx.warning(em"""Line starts with an operator;
                           |it is now treated as a continuation of the expression on the previous line,
                           |not as a separate statement.""",

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -251,6 +251,12 @@ object Tokens extends TokensCommon {
   final val canEndStatTokens: TokenSet = atomicExprTokens | BitSet(
     TYPE, RPAREN, RBRACE, RBRACKET)
 
+  /** Tokens that stop a lookahead scan search for a `<-`, `then`, or `do`.
+   *  Used for disambiguating between old and new syntax.
+   */
+  final val stopScanTokens: BitSet = mustStartStatTokens |
+    BitSet(IF, ELSE, WHILE, DO, FOR, YIELD, NEW, TRY, CATCH, FINALLY, THROW, RETURN, MATCH, SEMI, EOF)
+
   final val numericLitTokens: TokenSet = BitSet(INTLIT, LONGLIT, FLOATLIT, DOUBLELIT)
 
   final val scala3keywords = BitSet(ENUM, ERASED, GIVEN, IMPLIED)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -271,7 +271,13 @@ trait TypeAssigner {
               |An extension method was tried, but could not be fully constructed:
               |
               |    ${failure.tree.show.replace("\n", "\n    ")}"""
-          case _ => ""
+          case _ =>
+            if (tree.hasAttachment(desugar.MultiLineInfix))
+              i""".
+                 |Note that `$name` is treated as an infix operator in Scala 3.
+                 |If you do not want that, insert a `;` or empty line in front
+                 |or drop any spaces behind the operator."""
+            else ""
         }
       errorType(NotAMember(qualType, name, kind, addendum), tree.sourcePos)
     }

--- a/docs/docs/reference/changed-features/operators.md
+++ b/docs/docs/reference/changed-features/operators.md
@@ -3,7 +3,8 @@ layout: doc-page
 title: Rules for Operators
 ---
 
-There are two annotations that regulate operators: `infix` and `alpha`.
+The rules for infix operators have changed. There are two annotations that regulate operators: `infix` and `alpha`.
+Furthermore, a syntax change allows infix operators to be written on the left in a multi-line expression.
 
 ## The @alpha Annotation
 
@@ -127,3 +128,53 @@ The purpose of the `@infix` annotation is to achieve consistency across a code b
 
  5. To smooth migration to Scala 3.0, alphanumeric operations will only be deprecated from Scala 3.1 onwards,
 or if the `-strict` option is given in Dotty/Scala 3.
+
+## Syntax Change
+
+Infix operators can now appear at the start of lines in a multi-line expression. Examples:
+```scala
+val str = "hello"
+  ++ " world"
+  ++ "!"
+
+def condition =
+     x > 0
+  || xs.exists(_ > 0)
+  || xs.isEmpty
+```
+Previously, these expressions would have been rejected, since the compiler's semicolon inference
+would have treated the continuations `++ " world"` or `|| xs.isEmpty` as separate statements.
+
+To make this syntax work, the rules are modified to not infer semicolons in front of leading infix operators.
+A _leading infix operator_ is
+ - a symbolic identifier such as `+`, or `approx_==`, or an identifier in backticks,
+ - that starts a new line,
+ - that precedes a token on the same line that can start an expression,
+ - and that is immediately followed by at least one space character `' '`.
+
+Example:
+
+```scala
+    freezing
+  | boiling
+```
+This is recognized as a single infix operation. Compare with:
+```scala
+    freezing
+  !boiling
+```
+This is seen as two statements, `freezing` and `!boiling`. The difference is that only the operator in the first example
+is followed by a space.
+
+Another example:
+```scala
+  println("hello")
+  ???
+  ??? match { case 0 => 1 }
+```
+This code is recognized as three different statements. `???` is syntactically a symbolic identifier, but
+neither of its occurrences is followed by a space and a token that can start an expression.
+
+
+
+

--- a/docs/docs/reference/dropped-features/do-while.md
+++ b/docs/docs/reference/dropped-features/do-while.md
@@ -1,0 +1,49 @@
+---
+layout: doc-page
+title: Dropped: Do-While
+---
+
+The syntax construct
+```scala
+  do <body> while <cond>
+```
+is no longer supported. Instead, it is recommended to use the equivalent `while` loop
+below:
+```scala
+  while ({ <body> ; <cond> }) ()
+```
+For instance, instead of
+```scala
+  do
+    i += 1
+  while (f(i) == 0)
+```
+one writes
+```scala
+  while ({
+    i += 1
+    f(i) == 0
+  }) ()
+```
+Under the [new syntax rules](../other-new-features/control-syntax), this code can be written also without the awkward `({...})` bracketing like this:
+```scala
+  while {
+    i += 1
+    f(i) == 0
+  } do ()
+```
+The idea to use a block as the condition of a while also gives a solution
+to the "loop-and-a-half" problem. For instance:
+```scala
+  while {
+    val x: Int = iterator.next
+    x >= 0
+  } do print(".")
+```
+
+### Why Drop The Construct?
+
+ - `do-while` is used relatively rarely and it can expressed faithfully using just      while. So there seems to be little point in having it as a separate syntax          construct.
+ - Under the [new syntax rules](../other-new-features/control-syntax) `do` is used
+   as a statement continuation, which would clash with its meaning as a statement
+   introduction.

--- a/docs/docs/reference/other-new-features/control-syntax.md
+++ b/docs/docs/reference/other-new-features/control-syntax.md
@@ -1,0 +1,38 @@
+---
+layout: doc-page
+title: New Control Syntax
+---
+
+Scala 3 has a new "quiet" syntax for control expressions that does not rely in
+enclosing the condition in parentheses, and also allows to drop parentheses or braces
+around the generators of a `for`-expression. Examples:
+```scala
+if x < 0 then -x else x
+
+while x >= 0 do x = f(x)
+
+for x <- xs if x > 0
+yield x * x
+
+for
+  x <- xs
+  y <- ys
+do
+  println(x + y)
+```
+
+The rules in detail are:
+
+ - The condition of an `if`-expression can be written without enclosing parentheses if it is followed by a `then`.
+ - The condition of a `while`-loop can be written without enclosing parentheses if it is followed by a `do`.
+ - The enumerators of a `for`-expression can be written without enclosing parentheses or braces if they are followed by a `yield` or `do`.
+ - A `do` in a `for`-expression expresses a `for`-loop.
+ - Newline characters are not statement separators in a condition of an `if` or a `while`.
+   So the meaning of newlines is the same no matter whether parentheses are present
+   or absent.
+ - Newline characters are potential statement separators in the enumerators of a `for`-expression.
+
+### Rewrites
+
+The Dotty compiler can rewrite source code from old syntax and new syntax and back.
+When invoked with options `-rewrite -new-syntax` it will rewrite from old to new syntax, dropping parentheses and braces in conditions and enumerators. When invoked with with options `-rewrite -old-syntax` it will rewrite in the reverse direction, inserting parentheses and braces as needed.

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -101,6 +101,8 @@ sidebar:
               url: docs/reference/other-new-features/tupled-function.html
             - title: threadUnsafe Annotation
               url: docs/reference/other-new-features/threadUnsafe-annotation.html
+            - title: New Control Syntax
+              url: docs/reference/other-new-features/control-syntax.html
         - title: Other Changed Features
           subsection:
             - title: Structural Types
@@ -143,6 +145,8 @@ sidebar:
               url: docs/reference/dropped-features/existential-types.html
             - title: Type Projection
               url: docs/reference/dropped-features/type-projection.html
+            - title: Do-While
+              url: docs/reference/dropped-features/do-while.html
             - title: Procedure Syntax
               url: docs/reference/dropped-features/procedure-syntax.html
             - title: Package Objects

--- a/tests/neg/multiLineOps.scala
+++ b/tests/neg/multiLineOps.scala
@@ -1,0 +1,15 @@
+val x = 1
+  + 2
+  +3 // error: Expected a toplevel definition
+
+val b1 = {
+  22
+  * 22  // ok
+  */*one more*/22 // error: end of statement expected
+}                 // error: ';' expected, but '}' found
+
+val b2: Boolean = {
+  println(x)
+  ! "hello".isEmpty  // error: value ! is not a member of Unit
+}
+

--- a/tests/pos/multiLineOps.scala
+++ b/tests/pos/multiLineOps.scala
@@ -1,0 +1,26 @@
+val x = 1
+  + 2
+  + 3
+
+class Channel {
+  def ! (msg: String): Channel = this
+  def send_! (msg: String): Channel = this
+}
+
+val c = Channel()
+
+def send() =
+  c ! "hello"
+    ! "world"
+    send_! "!"
+
+val b: Boolean =
+  "hello".isEmpty
+  && true &&
+  !"hello".isEmpty
+
+val b2: Boolean = {
+  println(x)
+  !"hello".isEmpty
+  ???
+}

--- a/tests/pos/syntaxHeals.scala
+++ b/tests/pos/syntaxHeals.scala
@@ -1,0 +1,24 @@
+// Compile with -rewrite -pascal-style
+// Then compile again with -rewrite c-style
+// The resulting file is the same as the original one, except for better formatting
+object Test {
+
+  val xs = List(1, 2, 3)
+
+  for(x <- xs)yield x * 2
+
+  for(x <- xs)
+  yield x * 2
+
+  for{ x <- xs; y <- xs }yield x * y
+
+  for{
+    x <- xs
+    y <- xs
+  }yield x * y
+
+  if(xs == Nil)println("yes")
+
+  if(xs == Nil)
+    println("yes")
+}

--- a/tests/pos/syntaxRewrites.scala
+++ b/tests/pos/syntaxRewrites.scala
@@ -1,0 +1,73 @@
+// Compile with -rewrite -pascal-style
+// Then compile again with -rewrite c-style
+// The resulting file is the same as the original one, except for some extra spaces
+// at line ends
+object Test {
+
+  val xs = List(1, 2, 3)
+
+  for (x <- xs) yield x * 2
+
+  for (x <- xs)
+  yield x * 2
+
+  for { x <- xs; y <- xs } yield x * y
+
+  for {
+    x <- xs
+    y <- xs
+  } yield x * y
+
+  for {
+    x <- xs
+    y <- xs
+  } yield x * y
+
+  for { x <- xs }
+  yield x * 2
+
+// -----------------------------------------------
+
+  for (x <- xs) println(x)
+
+  for (x <- xs)
+    println(x)
+
+  for { x <- xs; y <- xs } println(x * y)
+
+  for {
+    x <- xs
+    y <- xs
+  }
+  println(x * y)
+
+  for {
+    x <- xs
+    y <- xs
+  } println(x * y)
+
+  for { x <- xs }
+    println(x)
+
+  if (xs == Nil) println("yes")
+
+  if (xs == Nil)
+    println("yes")
+
+  if (xs == Nil
+     && xs.length == 0)
+    println("yes")
+
+  while (xs == Nil) println("yes")
+
+  while ({
+    val ys = xs ++ xs
+    ys.nonEmpty
+  }) println("yes")
+
+  while ({
+    val ys = xs ++ xs
+    ys.nonEmpty
+  })
+  println("yes")
+}


### PR DESCRIPTION
This PR implements a new "quiet" syntax for control expressions that does not rely in
enclosing the condition in parentheses, and also allows to drop parentheses or braces
around the generators of a `for`-expression. Examples:
```scala
if x < 0 then -x else x

while x >= 0 do x = f(x)

for x <- xs if x > 0
yield x * x

for
  x <- xs
  y <- ys
do
  println(x + y)
```

The rules in detail are:

 - The condition of an `if`-expression can be written without enclosing parentheses if it is followed by a `then`.
 - The condition of a `while`-loop can be written without enclosing parentheses if it is followed by a `do`.
 - The enumerators of a `for`-expression can be written without enclosing parentheses or braces if they are followed by a `yield` or `do`.
 - A `do` in a `for`-expression expresses a `for`-loop.
 - Newline characters are not statement separators in a condition of an `if` or a `while`.
   So the meaning of newlines is the same no matter whether parentheses are present
   or absent.
 - Newline characters are statement separators in the enumerators of a `for`-expression. This turns out to be not a problem because #7031 basically removed the need to put expressions in parentheses to get nice operator formatting.


### Rewrites

The Dotty compiler can rewrite source code from old syntax and new syntax and back.
When invoked with options `-rewrite -new-syntax` it will rewrite from old to new syntax, dropping parentheses and braces in conditions and enumerators. When invoked with with options `-rewrite -old-syntax` it will rewrite in the reverse direction, inserting parentheses and braces as needed.
