### PR TITLE
In Scala.js mode, compile all lazy vals as thread-unsafe.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -2162,7 +2162,7 @@ class JSCodeGen()(implicit ctx: Context) {
 
     val genBody = {
       val call = if (isStaticCall) {
-        genApplyStatic(sym, formalCaptures.map(_.ref))
+        genApplyStatic(sym, formalCaptures.map(_.ref) ::: actualParams)
       } else {
         val thisCaptureRef :: argCaptureRefs = formalCaptures.map(_.ref)
         genApplyMethodMaybeStatically(thisCaptureRef, sym,

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -936,7 +936,13 @@ class JSCodeGen()(implicit ctx: Context) {
             js.Skip()
           case BooleanTag =>
             js.BooleanLiteral(value.booleanValue)
-          case ByteTag | ShortTag | CharTag | IntTag =>
+          case ByteTag =>
+            js.ByteLiteral(value.byteValue)
+          case ShortTag =>
+            js.ShortLiteral(value.shortValue)
+          case CharTag =>
+            js.CharLiteral(value.charValue)
+          case IntTag =>
             js.IntLiteral(value.intValue)
           case LongTag =>
             js.LongLiteral(value.longValue)

--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -258,16 +258,24 @@ object JSEncoding {
         if (sym.asClass.isPrimitiveValueClass) {
           if (sym == defn.BooleanClass)
             jstpe.BooleanType
+          else if (sym == defn.CharClass)
+            jstpe.CharType
+          else if (sym == defn.ByteClass)
+            jstpe.ByteType
+          else if (sym == defn.ShortClass)
+            jstpe.ShortType
+          else if (sym == defn.IntClass)
+            jstpe.IntType
+          else if (sym == defn.LongClass)
+            jstpe.LongType
           else if (sym == defn.FloatClass)
             jstpe.FloatType
           else if (sym == defn.DoubleClass)
             jstpe.DoubleType
-          else if (sym == defn.LongClass)
-            jstpe.LongType
           else if (sym == defn.UnitClass)
             jstpe.NoType
           else
-            jstpe.IntType
+            throw new AssertionError(s"unknown primitive value class $sym")
         } else {
           if (sym == defn.ObjectClass || isJSType(sym))
             jstpe.AnyType

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -76,8 +76,8 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
       if (isField) {
         if (sym.isAllOf(SyntheticModule))
           transformSyntheticModule(tree)
-        else if (sym.isThreadUnsafe) {
-          if (sym.is(Module)) {
+        else if (sym.isThreadUnsafe || ctx.settings.scalajs.value) {
+          if (sym.is(Module) && !ctx.settings.scalajs.value) {
             ctx.error(em"@threadUnsafe is only supported on lazy vals", sym.sourcePos)
             transformMemberDefThreadSafe(tree)
           }
@@ -453,6 +453,3 @@ object LazyVals {
     val retry: TermName       = "retry".toTermName
   }
 }
-
-
-

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -937,6 +937,7 @@ object Build {
         val dir = fetchScalaJSSource.value / "test-suite"
         (
           (dir / "shared/src/test/scala/org/scalajs/testsuite/compiler" ** "IntTest.scala").get
+          ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util" ** "Base64Test.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/utils" ** "*.scala").get
         )
       }


### PR DESCRIPTION
Since JS is a single-threaded environment, there is no point going through all the machinery of thread-safe lazy vals.

This fixes lazy vals for JS, which would previously fail to link because of the dependency on `Unsafe`, which is not supported in Scala.js.

The first 3 commits fix a few other bugs in the JS codegen, that prevented `Base64Test` from compiling. `Base64Test` contains `lazy val`s and is therefore an appropriate test for the last commit.