### PR TITLE
Make singleton typecase patterns and type checks consistent

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -147,8 +147,9 @@ class FirstTransform extends MiniPhase with InfoTransformer { thisPhase =>
     if (tree.isType) {
       toTypeTree(tree)
     } else if (tree.name != nme.WILDCARD) {
-      // Constant-foldable wildcards can occur in patterns, for instance as `case _: "a"`
-      // we avoid constant-folding those as doing so would change the meaning of the pattern
+      // We want to constant-fold _some_ idents here - for instance, @switch needs to see literals in patterns.
+      // However, constant-foldable wildcards can occur in patterns, for instance as `case _: "a"`;
+      // we avoid constant-folding those as doing so would change the meaning of the pattern.
       constToLiteral(tree)
     } else tree
 

--- a/tests/run/i6996.check
+++ b/tests/run/i6996.check
@@ -1,0 +1,3 @@
+an `a`
+false
+not `a`

--- a/tests/run/i6996.scala
+++ b/tests/run/i6996.scala
@@ -1,0 +1,14 @@
+object Test {
+
+  def isAType(arg: String): Unit = arg match {    
+    case _ : "a" => println("an `a`")
+    case _ => println("not `a`")
+  }
+
+  def main(args: Array[String]): Unit = {
+    isAType("a")
+    println(new String("a").isInstanceOf["a"])
+    isAType(new String("a"))
+  }
+
+}


### PR DESCRIPTION
Fixes #6996.

We accidentally constant-folded wildcards in typecase pattern which tested for singleton types, which made their behaviour inconsistent with normal type checks.