### PR TITLE
Fix #7028: Fix `lines` method of SourcePosition

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -29,15 +29,15 @@ extends interfaces.SourcePosition with Showable {
     source.content.slice(source.startOfLine(start), source.nextLine(end))
 
   /** The lines of the position */
-  def lines: List[Int] = {
+  def lines: Range = {
     val startOffset = source.offsetToLine(start)
-    val endOffset = source.offsetToLine(end + 1)
-    if (startOffset >= endOffset) line :: Nil
-    else (startOffset until endOffset).toList
+    val endOffset = source.offsetToLine(end - 1) // -1 to drop a line if no chars in it form part of the position
+    if (startOffset >= endOffset) line to line
+    else startOffset to endOffset
   }
 
   def lineOffsets: List[Int] =
-    lines.map(source.lineToOffset(_))
+    lines.toList.map(source.lineToOffset(_))
 
   def beforeAndAfterPoint: (List[Int], List[Int]) =
     lineOffsets.partition(_ <= point)

--- a/tests/neg/i7028.scala
+++ b/tests/neg/i7028.scala
@@ -1,0 +1,11 @@
+object Test {
+  "abc"
+    .foo       // error
+
+  "abc"
+    .bar.baz   // error
+
+  "abc"
+    .bar       // error
+    .baz
+}


### PR DESCRIPTION
We now get:
```
- [E008] Member Not Found Error: i7028.scala:3:5 ------------------------------
2 |  "abc"
3 |    .foo       // error
  |  ^
  |  value foo is not a member of String - did you mean String("abc").+?
-- [E008] Member Not Found Error: i7028.scala:6:5 ------------------------------
5 |  "abc"
6 |    .bar.baz   // error
  |  ^
  |  value bar is not a member of String - did you mean String("abc").+?
-- [E008] Member Not Found Error: i7028.scala:9:5 ------------------------------
8 |  "abc"
9 |    .bar       // error
  |  ^
  |  value bar is not a member of String - did you mean String("abc").+?
three errors found
```
This looks fine. The current convention is that the `^` points at the start of the range in the first line.
It is hard to combine that with an indicator where the last line ends. So this part is left for future work,
if we decide to reorganize the way positions are presented.

