### PR TITLE
Add rescue to support streamline error handling

### DIFF
--- a/tests/run/rescue.scala
+++ b/tests/run/rescue.scala
@@ -1,0 +1,13 @@
+object lib {
+  inline def (op: => T) rescue[T] (fallback: => T) = try op catch { case _: Throwable => fallback }
+  inline def (op: => T) rescue[T, E <: Throwable] (fallback: E => T) = try op catch { case ex: E => fallback(ex) }
+}
+
+import lib._
+
+@main def Test = {
+  assert((9 / 1 rescue 1) == 9)
+  assert((9 / 0 rescue 1) == 1)
+  assert(((9 / 0 rescue { ex: NullPointerException => 5  }) rescue 10) == 10)
+  assert(((9 / 0 rescue { ex: ArithmeticException => 5  }) rescue 10) == 5)
+}

--- a/tests/run/rescue.scala
+++ b/tests/run/rescue.scala
@@ -10,4 +10,9 @@ import lib._
   assert((9 / 0 rescue 1) == 1)
   assert(((9 / 0 rescue { ex: NullPointerException => 5  }) rescue 10) == 10)
   assert(((9 / 0 rescue { ex: ArithmeticException => 5  }) rescue 10) == 5)
+
+  assert((9 / 0 rescue {
+    case ex: NullPointerException => 4
+    case ex: ArithmeticException => 3
+  }) == 3)
 }

--- a/tests/run/rescue.scala
+++ b/tests/run/rescue.scala
@@ -1,6 +1,16 @@
 object lib {
-  inline def (op: => T) rescue[T] (fallback: => T) = try op catch { case _: Throwable => fallback }
-  inline def (op: => T) rescue[T, E <: Throwable] (fallback: E => T) = try op catch { case ex: E => fallback(ex) }
+  inline def (op: => T) rescue[T] (fallback: => T) =
+    try op
+    catch {
+      case _: Throwable => fallback
+    }
+
+  inline def (op: => T) rescue[T, E <: Throwable] (fallback: PartialFunction[E, T]) =
+    try op
+    catch {
+      case ex: E =>
+        if (fallback.isDefinedAt(ex)) fallback(ex) else throw ex
+    }
 }
 
 import lib._
@@ -8,11 +18,28 @@ import lib._
 @main def Test = {
   assert((9 / 1 rescue 1) == 9)
   assert((9 / 0 rescue 1) == 1)
-  assert(((9 / 0 rescue { ex: NullPointerException => 5  }) rescue 10) == 10)
-  assert(((9 / 0 rescue { ex: ArithmeticException => 5  }) rescue 10) == 5)
+  assert(((9 / 0 rescue { case ex: NullPointerException => 5  }) rescue 10) == 10)
+  assert(((9 / 0 rescue { case ex: ArithmeticException => 5  }) rescue 10) == 5)
 
-  assert((9 / 0 rescue {
-    case ex: NullPointerException => 4
-    case ex: ArithmeticException => 3
-  }) == 3)
+  assert(
+    {
+      9 / 0 rescue {
+        case ex: NullPointerException => 4
+        case ex: ArithmeticException => 3
+      }
+    } == 3
+  )
+
+  assert(
+    {
+      {
+        val a = 9 / 0 rescue {
+          case ex: NullPointerException => 4
+        }
+        a * a
+      } rescue {
+        case ex: ArithmeticException => 3
+      }
+    } == 3
+  )
 }


### PR DESCRIPTION
This implements inline `rescue` like those in Ruby [1], but more powerful
in that users can specify the exception to be handled.

The `rescue` method will be very convenient in scripting.

```Scala
9 / 0 rescue 1
9 / 0 rescue { case ex: ArithmeticException => 5  }

9 / 0 rescue {
    case ex: NullPointerException => 4
    case ex: ArithmeticException => 3
}
```

[1] https://stackoverflow.com/questions/15396791/ruby-oneline-rescue
[2] https://bugs.ruby-lang.org/issues/6739