### PR TITLE
Factor out staging from the core of scala.quoted

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/QuoteDriver.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuoteDriver.scala
@@ -8,7 +8,7 @@ import dotty.tools.io.{AbstractFile, Directory, PlainDirectory, VirtualDirectory
 import dotty.tools.repl.AbstractFileClassLoader
 import dotty.tools.dotc.reporting._
 import scala.quoted._
-import scala.quoted.Toolbox
+import scala.quoted.staging.Toolbox
 import java.net.URLClassLoader
 
 /** Driver to compile quoted code

--- a/compiler/src/dotty/tools/dotc/quoted/ToolboxImpl.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/ToolboxImpl.scala
@@ -22,7 +22,7 @@ object ToolboxImpl {
     def run[T](exprBuilder: QuoteContext => Expr[T]): T = synchronized {
       try {
         if (running) // detected nested run
-          throw new scala.quoted.staging.Toolbox.RunScopeException()
+          throw new scala.quoted.staging.RunScopeException()
         running = true
         driver.run(exprBuilder, settings)
       } finally {
@@ -35,7 +35,7 @@ object ToolboxImpl {
 
   private[dotty] def checkScopeId(id: ScopeId) given Context: Unit = {
     if (id != scopeId)
-      throw new staging.Toolbox.RunScopeException
+      throw new scala.quoted.staging.RunScopeException
   }
 
   // TODO Explore more fine grained scope ids.

--- a/compiler/src/dotty/tools/dotc/quoted/ToolboxImpl.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/ToolboxImpl.scala
@@ -13,7 +13,7 @@ object ToolboxImpl {
     * @param settings toolbox settings
     * @return A new instance of the toolbox
     */
-  def make(settings: scala.quoted.Toolbox.Settings, appClassloader: ClassLoader): scala.quoted.Toolbox = new scala.quoted.Toolbox {
+  def make(settings: scala.quoted.staging.Toolbox.Settings, appClassloader: ClassLoader): scala.quoted.staging.Toolbox = new scala.quoted.staging.Toolbox {
 
     private[this] val driver: QuoteDriver = new QuoteDriver(appClassloader)
 
@@ -22,7 +22,7 @@ object ToolboxImpl {
     def run[T](exprBuilder: QuoteContext => Expr[T]): T = synchronized {
       try {
         if (running) // detected nested run
-          throw new scala.quoted.Toolbox.RunScopeException()
+          throw new scala.quoted.staging.Toolbox.RunScopeException()
         running = true
         driver.run(exprBuilder, settings)
       } finally {
@@ -35,7 +35,7 @@ object ToolboxImpl {
 
   private[dotty] def checkScopeId(id: ScopeId) given Context: Unit = {
     if (id != scopeId)
-      throw new Toolbox.RunScopeException
+      throw new staging.Toolbox.RunScopeException
   }
 
   // TODO Explore more fine grained scope ids.

--- a/compiler/test-resources/repl-macros/i6007
+++ b/compiler/test-resources/repl-macros/i6007
@@ -1,9 +1,10 @@
 scala> import scala.quoted._
-scala> implicit def toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
-def toolbox: quoted.Toolbox
+scala> import scala.quoted.staging._
+scala> implicit def toolbox: Toolbox = Toolbox.make(getClass.getClassLoader)
+def toolbox: quoted.staging.Toolbox
 scala> def v given QuoteContext = '{ (if true then Some(1) else None).map(v => v+1) }
 def v given (x$1: quoted.QuoteContext): quoted.Expr[Option[Int]]
-scala> scala.quoted.withQuoteContext(v.show)
+scala> scala.quoted.staging.withQuoteContext(v.show)
 val res0: String = (if (true) scala.Some.apply[scala.Int](1) else scala.None).map[scala.Int](((v: scala.Int) => v.+(1)))
-scala> scala.quoted.run(v)
+scala> scala.quoted.staging.run(v)
 val res1: Option[Int] = Some(2)

--- a/compiler/test-resources/repl-macros/i6263
+++ b/compiler/test-resources/repl-macros/i6263
@@ -1,6 +1,7 @@
 scala> import quoted._
-scala> implicit def toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
-def toolbox: quoted.Toolbox
+scala> import quoted.staging._
+scala> implicit def toolbox: Toolbox = Toolbox.make(getClass.getClassLoader)
+def toolbox: quoted.staging.Toolbox
 scala> def fn[T : Type](v : T) = println("ok")
 def fn[T](v: T)(implicit evidence$1: quoted.Type[T]): Unit
 scala> withQuoteContext { fn("foo") }

--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -471,7 +471,7 @@ you can expand code at runtime with a method `run`. There is also a problem with
 that invokation of `run` in splices. Consider the following expression:
 
 ```scala
-    '{ (x: Int) => ${ ('x).run; 1 } }
+    '{ (x: Int) => ${ run('x); 1 } }
 ```
 This is again phase correct, but will lead us into trouble. Indeed, evaluating
 the splice will reduce the expression `('x).run` to `x`. But then the result

--- a/docs/docs/reference/metaprogramming/staging.md
+++ b/docs/docs/reference/metaprogramming/staging.md
@@ -81,8 +81,10 @@ expression at runtime. Within the scope of `run` we can also invoke `show` on an
 to get a source-like representation of the expression.
 
 ```scala
+import scala.quoted.staging._
+
 // make available the necessary toolbox for runtime code generation
-implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
 val f: Array[Int] => Int = run {
   val stagedSum: Expr[Array[Int] => Int] = '{ (arr: Array[Int]) => ${sum('arr)}}

--- a/docs/docs/reference/metaprogramming/staging.md
+++ b/docs/docs/reference/metaprogramming/staging.md
@@ -64,7 +64,7 @@ Run provides a `QuoteContext` that can be used to show the expression in the sco
 On the other hand `withQuoteContext` provides a `QuoteContext` without evauating the expression.
 
 ```scala
-package scala.quoted
+package scala.quoted.staging
 
 def run[T](expr: given QuoteContext => Expr[T]) given (toolbox: Toolbox): T = ...
 
@@ -82,7 +82,7 @@ to get a source-like representation of the expression.
 
 ```scala
 // make available the necessary toolbox for runtime code generation
-implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
 val f: Array[Int] => Int = run {
   val stagedSum: Expr[Array[Int] => Int] = '{ (arr: Array[Int]) => ${sum('arr)}}

--- a/library/src-bootstrapped/scala/quoted/package.scala
+++ b/library/src-bootstrapped/scala/quoted/package.scala
@@ -2,49 +2,6 @@ package scala
 
 package object quoted {
 
-  /** Evaluate the contents of this expression and return the result.
-   *  It provides a new QuoteContext that is only valid within the scope the argument.
-   *
-   *  Usage:
-   *  ```
-   *  val e: T = run { // (given qctx: QuoteContext) =>
-   *    expr
-   *  }
-   *  ```
-   *  where `expr: Expr[T]`
-   *
-   *  This method should not be called in a context where there is already has a `QuoteContext`
-   *  such as within a `run` or a `withQuoteContext`.
-   */
-  def run[T](expr: given QuoteContext => Expr[T]) given (toolbox: Toolbox): T = toolbox.run(expr given _)
-
-  /** Provide a new quote context within the scope of the argument that is only valid within the scope the argument.
-   *  Return the result of the argument.
-   *
-   *  Usage:
-   *  ```
-   *  val e: T = withQuoteContext { // (given qctx: QuoteContext) =>
-   *    thunk
-   *  }
-   *  ```
-   *  where `thunk: T`
-   *
-   *  This method should not be called in a context where there is already has a `QuoteContext`
-   *  such as within a `run` or a `withQuoteContext`.
-   */
-  def withQuoteContext[T](thunk: given QuoteContext => T) given (toolbox: Toolbox): T = {
-    var result: T = NoResult.asInstanceOf[T]
-    def dummyRun given QuoteContext: Expr[Unit] = {
-      result = thunk
-      Expr.unitExpr
-    }
-    toolbox.run(dummyRun given _)
-    assert(result != NoResult) // toolbox.run should have thrown an exception
-    result
-  }
-
-  private object NoResult
-
   object autolift {
     given autoToExpr[T] as Conversion[T, Expr[T]] given Liftable[T], QuoteContext = _.toExpr
   }

--- a/library/src-bootstrapped/scala/quoted/staging/package.scala
+++ b/library/src-bootstrapped/scala/quoted/staging/package.scala
@@ -1,0 +1,48 @@
+package scala.quoted
+
+package object staging {
+
+  /** Evaluate the contents of this expression and return the result.
+   *  It provides a new QuoteContext that is only valid within the scope the argument.
+   *
+   *  Usage:
+   *  ```
+   *  val e: T = run { // (given qctx: QuoteContext) =>
+   *    expr
+   *  }
+   *  ```
+   *  where `expr: Expr[T]`
+   *
+   *  This method should not be called in a context where there is already has a `QuoteContext`
+   *  such as within a `run` or a `withQuoteContext`.
+   */
+  def run[T](expr: given QuoteContext => Expr[T]) given (toolbox: Toolbox): T = toolbox.run(expr given _)
+
+  /** Provide a new quote context within the scope of the argument that is only valid within the scope the argument.
+   *  Return the result of the argument.
+   *
+   *  Usage:
+   *  ```
+   *  val e: T = withQuoteContext { // (given qctx: QuoteContext) =>
+   *    thunk
+   *  }
+   *  ```
+   *  where `thunk: T`
+   *
+   *  This method should not be called in a context where there is already has a `QuoteContext`
+   *  such as within a `run` or a `withQuoteContext`.
+   */
+  def withQuoteContext[T](thunk: given QuoteContext => T) given (toolbox: Toolbox): T = {
+    var result: T = NoResult.asInstanceOf[T]
+    def dummyRun given QuoteContext: Expr[Unit] = {
+      result = thunk
+      Expr.unitExpr
+    }
+    toolbox.run(dummyRun given _)
+    assert(result != NoResult) // toolbox.run should have thrown an exception
+    result
+  }
+
+  private object NoResult
+
+}

--- a/library/src-non-bootstrapped/scala/quoted/package.scala
+++ b/library/src-non-bootstrapped/scala/quoted/package.scala
@@ -2,49 +2,6 @@ package scala
 
 package object quoted {
 
-  /** Evaluate the contents of this expression and return the result.
-   *  It provides a new QuoteContext that is only valid within the scope the argument.
-   *
-   *  Usage:
-   *  ```
-   *  val e: T = run { // (given qctx: QuoteContext) =>
-   *    expr
-   *  }
-   *  ```
-   *  where `expr: Expr[T]`
-   *
-   *  This method should not be called in a context where there is already has a `QuoteContext`
-   *  such as within a `run` or a `withQuoteContext`.
-   */
-  def run[T](expr: given QuoteContext => Expr[T]) given (toolbox: Toolbox): T = toolbox.run(expr given _)
-
-  /** Provide a new quote context within the scope of the argument that is only valid within the scope the argument.
-   *  Return the result of the argument.
-   *
-   *  Usage:
-   *  ```
-   *  val e: T = withQuoteContext { // (given qctx: QuoteContext) =>
-   *    thunk
-   *  }
-   *  ```
-   *  where `thunk: T`
-   *
-   *  This method should not be called in a context where there is already has a `QuoteContext`
-   *  such as within a `run` or a `withQuoteContext`.
-   */
-  def withQuoteContext[T](thunk: given QuoteContext => T) given (toolbox: Toolbox): T = {
-    var result: T = NoResult.asInstanceOf[T]
-    def dummyRun given QuoteContext: Expr[Unit] = {
-      result = thunk
-      Expr.unitExpr
-    }
-    toolbox.run(dummyRun given _)
-    assert(result != NoResult) // toolbox.run should have thrown an exception
-    result
-  }
-
-  private object NoResult
-
   object autolift {
     given autoToExpr[T] as Conversion[T, Expr[T]] given Liftable[T], QuoteContext = _.toExpr
   }

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -3,6 +3,7 @@ package scala
 package quoted {
 
   import scala.quoted.show.SyntaxHighlight
+  import scala.quoted.staging.Toolbox
 
   sealed trait Expr[+T] {
 

--- a/library/src/scala/quoted/staging/RunScopeException.scala
+++ b/library/src/scala/quoted/staging/RunScopeException.scala
@@ -1,0 +1,3 @@
+package scala.quoted.staging
+
+class RunScopeException extends Exception("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")

--- a/library/src/scala/quoted/staging/Toolbox.scala
+++ b/library/src/scala/quoted/staging/Toolbox.scala
@@ -3,7 +3,7 @@ package staging
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not find implicit scala.quoted.staging.Toolbox.\n\nDefault toolbox can be instantiated with:\n  `implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)`\n\n")
+@implicitNotFound("Could not find implicit scala.quoted.staging.Toolbox.\n\nDefault toolbox can be instantiated with:\n  `delegate for scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)`\n\n")
 trait Toolbox {
   def run[T](expr: QuoteContext => Expr[T]): T
 }
@@ -14,7 +14,8 @@ object Toolbox {
     *
     * Usuage:
     * ```
-    * implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    * import scala.quoted.staging._
+    * delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     * ```
     *
     * @param appClassloader classloader of the application that generated the quotes

--- a/library/src/scala/quoted/staging/Toolbox.scala
+++ b/library/src/scala/quoted/staging/Toolbox.scala
@@ -56,8 +56,4 @@ object Toolbox {
       new Settings(outDir, showRawTree, compilerArgs)
   }
 
-  class ToolboxNotFoundException(msg: String, cause: ClassNotFoundException) extends Exception(msg, cause)
-
-  class RunScopeException extends Exception("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
-
 }

--- a/library/src/scala/quoted/staging/Toolbox.scala
+++ b/library/src/scala/quoted/staging/Toolbox.scala
@@ -1,8 +1,9 @@
 package scala.quoted
+package staging
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not find implicit quoted.Toolbox.\n\nDefault toolbox can be instantiated with:\n  `implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)`\n\n")
+@implicitNotFound("Could not find implicit scala.quoted.staging.Toolbox.\n\nDefault toolbox can be instantiated with:\n  `implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)`\n\n")
 trait Toolbox {
   def run[T](expr: QuoteContext => Expr[T]): T
 }
@@ -13,7 +14,7 @@ object Toolbox {
     *
     * Usuage:
     * ```
-    * implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    * implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     * ```
     *
     * @param appClassloader classloader of the application that generated the quotes
@@ -57,6 +58,6 @@ object Toolbox {
 
   class ToolboxNotFoundException(msg: String, cause: ClassNotFoundException) extends Exception(msg, cause)
 
-  class RunScopeException extends Exception("Cannot call `scala.quoted.run(...)` within a macro or another `run(...)`")
+  class RunScopeException extends Exception("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
 
 }

--- a/library/src/scala/quoted/staging/ToolboxNotFoundException.scala
+++ b/library/src/scala/quoted/staging/ToolboxNotFoundException.scala
@@ -1,0 +1,3 @@
+package scala.quoted.staging
+
+class ToolboxNotFoundException(msg: String, cause: ClassNotFoundException) extends Exception(msg, cause)

--- a/sbt-dotty/sbt-test/sbt-dotty/quoted-example-project/src/main/scala/hello/Hello.scala
+++ b/sbt-dotty/sbt-test/sbt-dotty/quoted-example-project/src/main/scala/hello/Hello.scala
@@ -5,7 +5,7 @@ import scala.quoted._
 
 object Main {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = {
 

--- a/sbt-dotty/sbt-test/sbt-dotty/quoted-example-project/src/test/scala/hello/Tests.scala
+++ b/sbt-dotty/sbt-test/sbt-dotty/quoted-example-project/src/test/scala/hello/Tests.scala
@@ -7,7 +7,7 @@ import scala.quoted._
 
 class Tests {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   @Test def test(): Unit = {
     import hello.Main._

--- a/tests/disabled/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
+++ b/tests/disabled/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
 
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
   def fooImpl(i: Expr[Int]) given QuoteContext: Expr[Int] = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     val y: Int = run(i)
     y
   }

--- a/tests/disabled/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
+++ b/tests/disabled/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
 
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
   def fooImpl(i: Expr[Int]) given QuoteContext: Expr[Int] = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     val y: Int = run(i)
     y
   }

--- a/tests/neg-with-compiler/i5941/macro_1.scala
+++ b/tests/neg-with-compiler/i5941/macro_1.scala
@@ -12,7 +12,7 @@ object Lens {
   }
 
   def impl[S: Type, T: Type](getter: Expr[S => T]) given (qctx: QuoteContext): Expr[Lens[S, T]] = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(this.getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(this.getClass.getClassLoader)
     import qctx.tasty._
     import util._
     // obj.copy(field = value)

--- a/tests/neg-with-compiler/quote-run-in-macro-1/quoted_1.scala
+++ b/tests/neg-with-compiler/quote-run-in-macro-1/quoted_1.scala
@@ -1,9 +1,10 @@
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 object Macros {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
   def fooImpl(i: Expr[Int]) given QuoteContext: Expr[Int] = {
     val y: Int = run(i)

--- a/tests/neg-with-compiler/quote-run-in-macro-1/quoted_1.scala
+++ b/tests/neg-with-compiler/quote-run-in-macro-1/quoted_1.scala
@@ -4,7 +4,7 @@ import given scala.quoted.autolift._
 
 object Macros {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
   def fooImpl(i: Expr[Int]) given QuoteContext: Expr[Int] = {
     val y: Int = run(i)

--- a/tests/pos-with-compiler/quote-0.scala
+++ b/tests/pos-with-compiler/quote-0.scala
@@ -25,7 +25,7 @@ object Macros {
 
 class Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   run {
     val program = '{

--- a/tests/pos-with-compiler/quote-0.scala
+++ b/tests/pos-with-compiler/quote-0.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 object Macros {
@@ -24,7 +25,7 @@ object Macros {
 
 class Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   run {
     val program = '{

--- a/tests/pos-with-compiler/quote-assert/quoted_2.scala
+++ b/tests/pos-with-compiler/quote-assert/quoted_2.scala
@@ -17,6 +17,6 @@ object Test {
     ${ assertImpl('{x != 0}) }
   }
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   run(program)
 }

--- a/tests/pos-with-compiler/quote-assert/quoted_2.scala
+++ b/tests/pos-with-compiler/quote-assert/quoted_2.scala
@@ -1,5 +1,7 @@
 
 import scala.quoted._
+import scala.quoted.staging._
+
 import Macros._
 
 object Test {
@@ -15,6 +17,6 @@ object Test {
     ${ assertImpl('{x != 0}) }
   }
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   run(program)
 }

--- a/tests/run-macros/i6765/Macro_1.scala
+++ b/tests/run-macros/i6765/Macro_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted._
 
 given as Toolbox = Toolbox.make(getClass.getClassLoader)

--- a/tests/run-macros/i6992/Macro_1.scala
+++ b/tests/run-macros/i6992/Macro_1.scala
@@ -1,5 +1,6 @@
 
 import scala.quoted._, scala.quoted.matching._
+import scala.quoted.staging._
 import delegate scala.quoted._
 
 delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
@@ -16,7 +17,7 @@ object macros {
         case '{$x: Foo} => run(x).x.toExpr
       }
     } catch {
-      case _: scala.quoted.Toolbox.RunScopeException =>
+      case _: scala.quoted.staging.Toolbox.RunScopeException =>
         '{"OK"}
     }
   }

--- a/tests/run-macros/i6992/Macro_1.scala
+++ b/tests/run-macros/i6992/Macro_1.scala
@@ -17,7 +17,7 @@ object macros {
         case '{$x: Foo} => run(x).x.toExpr
       }
     } catch {
-      case _: scala.quoted.staging.Toolbox.RunScopeException =>
+      case _: scala.quoted.staging.RunScopeException =>
         '{"OK"}
     }
   }

--- a/tests/run-with-compiler/i3823-b.scala
+++ b/tests/run-with-compiler/i3823-b.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     def f[T](x: Expr[T])(implicit t: Type[T]) = '{
       val z: $t = $x

--- a/tests/run-with-compiler/i3823-b.scala
+++ b/tests/run-with-compiler/i3823-b.scala
@@ -1,6 +1,7 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     def f[T](x: Expr[T])(implicit t: Type[T]) = '{
       val z: $t = $x

--- a/tests/run-with-compiler/i3823-c.scala
+++ b/tests/run-with-compiler/i3823-c.scala
@@ -1,6 +1,7 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     def f[T](x: Expr[T])(implicit t: Type[T]) = '{
       val z = $x

--- a/tests/run-with-compiler/i3823-c.scala
+++ b/tests/run-with-compiler/i3823-c.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     def f[T](x: Expr[T])(implicit t: Type[T]) = '{
       val z = $x

--- a/tests/run-with-compiler/i3823.scala
+++ b/tests/run-with-compiler/i3823.scala
@@ -1,6 +1,7 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     def f[T: Type](x: Expr[T])(t: Type[T]) = '{
       val z: $t = $x

--- a/tests/run-with-compiler/i3823.scala
+++ b/tests/run-with-compiler/i3823.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     def f[T: Type](x: Expr[T])(t: Type[T]) = '{
       val z: $t = $x

--- a/tests/run-with-compiler/i3847-b.scala
+++ b/tests/run-with-compiler/i3847-b.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 import scala.reflect.ClassTag
 
 object Arrays {
@@ -13,7 +14,7 @@ object Arrays {
 }
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     import Arrays._
     implicit val ct: Expr[ClassTag[Int]] = '{ClassTag.Int}

--- a/tests/run-with-compiler/i3847-b.scala
+++ b/tests/run-with-compiler/i3847-b.scala
@@ -14,7 +14,7 @@ object Arrays {
 }
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     import Arrays._
     implicit val ct: Expr[ClassTag[Int]] = '{ClassTag.Int}

--- a/tests/run-with-compiler/i3847.scala
+++ b/tests/run-with-compiler/i3847.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 import scala.reflect.ClassTag
 
 object Arrays {
@@ -13,7 +14,7 @@ object Arrays {
 }
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(this.getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(this.getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     import Arrays._
     implicit val ct: Expr[ClassTag[Int]] = '{ClassTag.Int}

--- a/tests/run-with-compiler/i3876-b.scala
+++ b/tests/run-with-compiler/i3876-b.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
     def x given QuoteContext: Expr[Int] = '{3}
 

--- a/tests/run-with-compiler/i3876-b.scala
+++ b/tests/run-with-compiler/i3876-b.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
     def x given QuoteContext: Expr[Int] = '{3}
 

--- a/tests/run-with-compiler/i3876-c.scala
+++ b/tests/run-with-compiler/i3876-c.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit def toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit def toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
     def x given QuoteContext: Expr[Int] = '{3}
 

--- a/tests/run-with-compiler/i3876-d.scala
+++ b/tests/run-with-compiler/i3876-d.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
     def x given QuoteContext: Expr[Int] = '{3}
 

--- a/tests/run-with-compiler/i3876-d.scala
+++ b/tests/run-with-compiler/i3876-d.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
     def x given QuoteContext: Expr[Int] = '{3}
 

--- a/tests/run-with-compiler/i3876-e.scala
+++ b/tests/run-with-compiler/i3876-e.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
     def x given QuoteContext: Expr[Int] = '{ println(); 3 }
 

--- a/tests/run-with-compiler/i3876-e.scala
+++ b/tests/run-with-compiler/i3876-e.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
     def x given QuoteContext: Expr[Int] = '{ println(); 3 }
 

--- a/tests/run-with-compiler/i3876.scala
+++ b/tests/run-with-compiler/i3876.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
     def x given QuoteContext: Expr[Int] = '{3}
 

--- a/tests/run-with-compiler/i3876.scala
+++ b/tests/run-with-compiler/i3876.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
     def x given QuoteContext: Expr[Int] = '{3}
 

--- a/tests/run-with-compiler/i3946.scala
+++ b/tests/run-with-compiler/i3946.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     def u given QuoteContext: Expr[Unit] = '{}
     println(withQuoteContext(u.show))
     println(run(u))

--- a/tests/run-with-compiler/i3946.scala
+++ b/tests/run-with-compiler/i3946.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     def u given QuoteContext: Expr[Unit] = '{}
     println(withQuoteContext(u.show))
     println(run(u))

--- a/tests/run-with-compiler/i3947.scala
+++ b/tests/run-with-compiler/i3947.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {
       val lclazz = clazz.toExpr

--- a/tests/run-with-compiler/i3947.scala
+++ b/tests/run-with-compiler/i3947.scala
@@ -1,9 +1,10 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {
       val lclazz = clazz.toExpr

--- a/tests/run-with-compiler/i3947b.scala
+++ b/tests/run-with-compiler/i3947b.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947b.scala
+++ b/tests/run-with-compiler/i3947b.scala
@@ -1,9 +1,10 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947b2.scala
+++ b/tests/run-with-compiler/i3947b2.scala
@@ -1,9 +1,10 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: given QuoteContext => java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947b2.scala
+++ b/tests/run-with-compiler/i3947b2.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: given QuoteContext => java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947b3.scala
+++ b/tests/run-with-compiler/i3947b3.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947b3.scala
+++ b/tests/run-with-compiler/i3947b3.scala
@@ -1,9 +1,10 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947c.scala
+++ b/tests/run-with-compiler/i3947c.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947c.scala
+++ b/tests/run-with-compiler/i3947c.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947d.scala
+++ b/tests/run-with-compiler/i3947d.scala
@@ -2,7 +2,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947d.scala
+++ b/tests/run-with-compiler/i3947d.scala
@@ -1,8 +1,8 @@
 
 import scala.quoted._
-
+import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947d2.scala
+++ b/tests/run-with-compiler/i3947d2.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947d2.scala
+++ b/tests/run-with-compiler/i3947d2.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947e.scala
+++ b/tests/run-with-compiler/i3947e.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
 

--- a/tests/run-with-compiler/i3947e.scala
+++ b/tests/run-with-compiler/i3947e.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
 

--- a/tests/run-with-compiler/i3947f.scala
+++ b/tests/run-with-compiler/i3947f.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947f.scala
+++ b/tests/run-with-compiler/i3947f.scala
@@ -1,9 +1,10 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947g.scala
+++ b/tests/run-with-compiler/i3947g.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {
       val lclazz = clazz.toExpr

--- a/tests/run-with-compiler/i3947g.scala
+++ b/tests/run-with-compiler/i3947g.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {
       val lclazz = clazz.toExpr

--- a/tests/run-with-compiler/i3947i.scala
+++ b/tests/run-with-compiler/i3947i.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947i.scala
+++ b/tests/run-with-compiler/i3947i.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947j.scala
+++ b/tests/run-with-compiler/i3947j.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i3947j.scala
+++ b/tests/run-with-compiler/i3947j.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-with-compiler/i4044a.scala
+++ b/tests/run-with-compiler/i4044a.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 class Foo {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def foo: Unit = withQuoteContext {
     val e: Expr[Int] = '{3}
     val q = '{ ${ '{ $e } } }

--- a/tests/run-with-compiler/i4044a.scala
+++ b/tests/run-with-compiler/i4044a.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 class Foo {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def foo: Unit = withQuoteContext {
     val e: Expr[Int] = '{3}
     val q = '{ ${ '{ $e } } }

--- a/tests/run-with-compiler/i4044b.scala
+++ b/tests/run-with-compiler/i4044b.scala
@@ -20,7 +20,7 @@ object VarRef {
 }
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     val q = VarRef('{4})(varRef => '{ ${varRef.update('{3})}; ${varRef.expr} })
     println(q.show)

--- a/tests/run-with-compiler/i4044b.scala
+++ b/tests/run-with-compiler/i4044b.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 sealed abstract class VarRef[T] {
   def update(expr: Expr[T]) given QuoteContext: Expr[Unit]
@@ -19,7 +20,7 @@ object VarRef {
 }
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     val q = VarRef('{4})(varRef => '{ ${varRef.update('{3})}; ${varRef.expr} })
     println(q.show)

--- a/tests/run-with-compiler/i4044c.scala
+++ b/tests/run-with-compiler/i4044c.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 class Foo {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def foo: Unit = withQuoteContext {
     val q = '{ ${ '{ ${ '{ 5 } } } } }
     println(q.show)

--- a/tests/run-with-compiler/i4044c.scala
+++ b/tests/run-with-compiler/i4044c.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 class Foo {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def foo: Unit = withQuoteContext {
     val q = '{ ${ '{ ${ '{ 5 } } } } }
     println(q.show)

--- a/tests/run-with-compiler/i4044d.scala
+++ b/tests/run-with-compiler/i4044d.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 class Foo {
   def foo: Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     run {
       val a: Expr[Int] = '{3}
       val q: Expr[Int] = '{

--- a/tests/run-with-compiler/i4044d.scala
+++ b/tests/run-with-compiler/i4044d.scala
@@ -1,8 +1,9 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 class Foo {
   def foo: Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     run {
       val a: Expr[Int] = '{3}
       val q: Expr[Int] = '{

--- a/tests/run-with-compiler/i4044e.scala
+++ b/tests/run-with-compiler/i4044e.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 class Foo {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def foo: Unit = withQuoteContext {
     val e: Expr[Int] = '{3}
     val f: Expr[Int] = '{5}

--- a/tests/run-with-compiler/i4044e.scala
+++ b/tests/run-with-compiler/i4044e.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 class Foo {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def foo: Unit = withQuoteContext {
     val e: Expr[Int] = '{3}
     val f: Expr[Int] = '{5}

--- a/tests/run-with-compiler/i4044f.scala
+++ b/tests/run-with-compiler/i4044f.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 class Foo {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def foo: Unit = withQuoteContext {
     val e: Expr[Int] = '{3}
     val f: Expr[Int] = '{5}

--- a/tests/run-with-compiler/i4044f.scala
+++ b/tests/run-with-compiler/i4044f.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 class Foo {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def foo: Unit = withQuoteContext {
     val e: Expr[Int] = '{3}
     val f: Expr[Int] = '{5}

--- a/tests/run-with-compiler/i4350.scala
+++ b/tests/run-with-compiler/i4350.scala
@@ -7,7 +7,7 @@ class Foo[T: Type] {
 }
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     println((new Foo[Object]).q.show)
     println((new Foo[String]).q.show)

--- a/tests/run-with-compiler/i4350.scala
+++ b/tests/run-with-compiler/i4350.scala
@@ -1,12 +1,13 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 class Foo[T: Type] {
   def q given QuoteContext = '{(null: Any).asInstanceOf[T]}
 }
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     println((new Foo[Object]).q.show)
     println((new Foo[String]).q.show)

--- a/tests/run-with-compiler/i4591.scala
+++ b/tests/run-with-compiler/i4591.scala
@@ -9,7 +9,7 @@ object Test {
   }
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     run(foo('{Option(9)}))
   }
 

--- a/tests/run-with-compiler/i4591.scala
+++ b/tests/run-with-compiler/i4591.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
@@ -8,7 +9,7 @@ object Test {
   }
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     run(foo('{Option(9)}))
   }
 

--- a/tests/run-with-compiler/i4730.scala
+++ b/tests/run-with-compiler/i4730.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def ret given QuoteContext: Expr[Int => Int] = '{ (x: Int) =>
     ${
       val z = run('{x + 1}) // throws a RunScopeException
@@ -13,7 +14,7 @@ object Test {
       run(ret).apply(10)
       throw new Exception
     } catch {
-      case ex: scala.quoted.Toolbox.RunScopeException =>
+      case ex: scala.quoted.staging.Toolbox.RunScopeException =>
         // ok
     }
   }

--- a/tests/run-with-compiler/i4730.scala
+++ b/tests/run-with-compiler/i4730.scala
@@ -14,7 +14,7 @@ object Test {
       run(ret).apply(10)
       throw new Exception
     } catch {
-      case ex: scala.quoted.staging.Toolbox.RunScopeException =>
+      case ex: scala.quoted.staging.RunScopeException =>
         // ok
     }
   }

--- a/tests/run-with-compiler/i4730.scala
+++ b/tests/run-with-compiler/i4730.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def ret given QuoteContext: Expr[Int => Int] = '{ (x: Int) =>
     ${
       val z = run('{x + 1}) // throws a RunScopeException

--- a/tests/run-with-compiler/i5144.scala
+++ b/tests/run-with-compiler/i5144.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def eval1(ff: Expr[Int => Int]) given QuoteContext: Expr[Int] = '{$ff(42)}
 
   def peval1() given QuoteContext: Expr[Unit] = '{

--- a/tests/run-with-compiler/i5144.scala
+++ b/tests/run-with-compiler/i5144.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def eval1(ff: Expr[Int => Int]) given QuoteContext: Expr[Int] = '{$ff(42)}
 
   def peval1() given QuoteContext: Expr[Unit] = '{

--- a/tests/run-with-compiler/i5144b.scala
+++ b/tests/run-with-compiler/i5144b.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def eval1(ff: Expr[Int => Int]) given QuoteContext: Expr[Int] = ff('{42})
 
   def peval1() given QuoteContext: Expr[Unit] = '{

--- a/tests/run-with-compiler/i5144b.scala
+++ b/tests/run-with-compiler/i5144b.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def eval1(ff: Expr[Int => Int]) given QuoteContext: Expr[Int] = ff('{42})
 
   def peval1() given QuoteContext: Expr[Unit] = '{

--- a/tests/run-with-compiler/i5152.scala
+++ b/tests/run-with-compiler/i5152.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def eval1(ff: Expr[Int => Int]) given QuoteContext: Expr[Int => Int] = '{identity}
 
   def peval1()given QuoteContext: Expr[Unit] = '{

--- a/tests/run-with-compiler/i5152.scala
+++ b/tests/run-with-compiler/i5152.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def eval1(ff: Expr[Int => Int]) given QuoteContext: Expr[Int => Int] = '{identity}
 
   def peval1()given QuoteContext: Expr[Unit] = '{

--- a/tests/run-with-compiler/i5161.scala
+++ b/tests/run-with-compiler/i5161.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   enum Exp {
     case Int2(x: Int)

--- a/tests/run-with-compiler/i5161.scala
+++ b/tests/run-with-compiler/i5161.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   enum Exp {
     case Int2(x: Int)

--- a/tests/run-with-compiler/i5161b.scala
+++ b/tests/run-with-compiler/i5161b.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = {
     def res given QuoteContext = '{

--- a/tests/run-with-compiler/i5161b.scala
+++ b/tests/run-with-compiler/i5161b.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = {
     def res given QuoteContext = '{

--- a/tests/run-with-compiler/i5247.scala
+++ b/tests/run-with-compiler/i5247.scala
@@ -1,6 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
+
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     println(foo[Object].show)
     println(bar[Object].show)

--- a/tests/run-with-compiler/i5247.scala
+++ b/tests/run-with-compiler/i5247.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     println(foo[Object].show)
     println(bar[Object].show)

--- a/tests/run-with-compiler/i5376.scala
+++ b/tests/run-with-compiler/i5376.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     var e = '{1}

--- a/tests/run-with-compiler/i5376.scala
+++ b/tests/run-with-compiler/i5376.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     var e = '{1}

--- a/tests/run-with-compiler/i5434.scala
+++ b/tests/run-with-compiler/i5434.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = {
 

--- a/tests/run-with-compiler/i5434.scala
+++ b/tests/run-with-compiler/i5434.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = {
 

--- a/tests/run-with-compiler/i5965.scala
+++ b/tests/run-with-compiler/i5965.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = {
     withQuoteContext('[List])
 

--- a/tests/run-with-compiler/i5965.scala
+++ b/tests/run-with-compiler/i5965.scala
@@ -1,8 +1,9 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = {
     withQuoteContext('[List])
 

--- a/tests/run-with-compiler/i5965b.scala
+++ b/tests/run-with-compiler/i5965b.scala
@@ -1,9 +1,10 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
     withQuoteContext('[List])
     def list given QuoteContext = bound('{List(1, 2, 3)})

--- a/tests/run-with-compiler/i5965b.scala
+++ b/tests/run-with-compiler/i5965b.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 object Test {
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
     withQuoteContext('[List])
     def list given QuoteContext = bound('{List(1, 2, 3)})

--- a/tests/run-with-compiler/i5997.scala
+++ b/tests/run-with-compiler/i5997.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     val v = '{ (if true then Some(1) else None).map(v => v+1) }
     println(v.show)

--- a/tests/run-with-compiler/i5997.scala
+++ b/tests/run-with-compiler/i5997.scala
@@ -1,6 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
+
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     val v = '{ (if true then Some(1) else None).map(v => v+1) }
     println(v.show)

--- a/tests/run-with-compiler/i6263.scala
+++ b/tests/run-with-compiler/i6263.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     fn("foo")

--- a/tests/run-with-compiler/i6263.scala
+++ b/tests/run-with-compiler/i6263.scala
@@ -1,7 +1,9 @@
 import quoted._
+import scala.quoted.staging._
+
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     fn("foo")

--- a/tests/run-with-compiler/i6281.scala
+++ b/tests/run-with-compiler/i6281.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test extends App {
 
@@ -36,7 +37,7 @@ object Test extends App {
 
   def m given QuoteContext: STM[Int, RS] = k => k('{42})
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   withQuoteContext {
      println(Effects[RS].reify[Int] { m }.show)

--- a/tests/run-with-compiler/i6754.scala
+++ b/tests/run-with-compiler/i6754.scala
@@ -16,7 +16,7 @@ object Test {
       throw new Exception
     } catch {
       case ex: java.lang.reflect.InvocationTargetException =>
-        assert(ex.getTargetException.isInstanceOf[scala.quoted.staging.Toolbox.RunScopeException])
+        assert(ex.getTargetException.isInstanceOf[scala.quoted.staging.RunScopeException])
     }
   }
 }

--- a/tests/run-with-compiler/i6754.scala
+++ b/tests/run-with-compiler/i6754.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val tbx: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val tbx: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = {
     def y given QuoteContext: Expr[Unit] = '{
@@ -15,7 +16,7 @@ object Test {
       throw new Exception
     } catch {
       case ex: java.lang.reflect.InvocationTargetException =>
-        assert(ex.getTargetException.isInstanceOf[scala.quoted.Toolbox.RunScopeException])
+        assert(ex.getTargetException.isInstanceOf[scala.quoted.staging.Toolbox.RunScopeException])
     }
   }
 }

--- a/tests/run-with-compiler/inline-quote.scala
+++ b/tests/run-with-compiler/inline-quote.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
@@ -7,7 +8,7 @@ object Test {
     $x
   }
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     val y = '{45}

--- a/tests/run-with-compiler/quote-ackermann-1.scala
+++ b/tests/run-with-compiler/quote-ackermann-1.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 object Test {
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     val ack3 = run { ackermann(3) }
     println(ack3(1))
     println(ack3(2))

--- a/tests/run-with-compiler/quote-ackermann-1.scala
+++ b/tests/run-with-compiler/quote-ackermann-1.scala
@@ -1,9 +1,10 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     val ack3 = run { ackermann(3) }
     println(ack3(1))
     println(ack3(2))

--- a/tests/run-with-compiler/quote-fun-app-1.scala
+++ b/tests/run-with-compiler/quote-fun-app-1.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 object Test {
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     val f = run {
       f1
     }

--- a/tests/run-with-compiler/quote-fun-app-1.scala
+++ b/tests/run-with-compiler/quote-fun-app-1.scala
@@ -1,9 +1,10 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     val f = run {
       f1
     }

--- a/tests/run-with-compiler/quote-function-applied-to.scala
+++ b/tests/run-with-compiler/quote-function-applied-to.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     def show(expr: given QuoteContext => Expr[_]): String = withQuoteContext(expr.show)
     println(show(('{ () => x(0) }).apply()))
     println(show(('{ (x1: Int) => x1 }).apply('{x(1)})))

--- a/tests/run-with-compiler/quote-function-applied-to.scala
+++ b/tests/run-with-compiler/quote-function-applied-to.scala
@@ -1,8 +1,9 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     def show(expr: given QuoteContext => Expr[_]): String = withQuoteContext(expr.show)
     println(show(('{ () => x(0) }).apply()))
     println(show(('{ (x1: Int) => x1 }).apply('{x(1)})))

--- a/tests/run-with-compiler/quote-lambda.scala
+++ b/tests/run-with-compiler/quote-lambda.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     '{ (x: Int) => ${'x} }
   }

--- a/tests/run-with-compiler/quote-lambda.scala
+++ b/tests/run-with-compiler/quote-lambda.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     '{ (x: Int) => ${'x} }
   }

--- a/tests/run-with-compiler/quote-lib.scala
+++ b/tests/run-with-compiler/quote-lib.scala
@@ -1,5 +1,6 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 import liftable.Units._
@@ -9,7 +10,7 @@ import liftable.Lists._
 import liftable.Exprs._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     val liftedUnit: Expr[Unit] = '{}
 

--- a/tests/run-with-compiler/quote-lib.scala
+++ b/tests/run-with-compiler/quote-lib.scala
@@ -10,7 +10,7 @@ import liftable.Lists._
 import liftable.Exprs._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     val liftedUnit: Expr[Unit] = '{}
 

--- a/tests/run-with-compiler/quote-lift-Array.scala
+++ b/tests/run-with-compiler/quote-lift-Array.scala
@@ -1,8 +1,9 @@
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     '{
       def p[T](arr: Array[T]): Unit = {

--- a/tests/run-with-compiler/quote-lift-BigDecimal.scala
+++ b/tests/run-with-compiler/quote-lift-BigDecimal.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = println(run {
     val a = BigDecimal(2.3).toExpr
     val b = BigDecimal("1005849025843905834908593485984390583429058574925.95489543").toExpr

--- a/tests/run-with-compiler/quote-lift-BigDecimal.scala
+++ b/tests/run-with-compiler/quote-lift-BigDecimal.scala
@@ -1,6 +1,7 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = println(run {
     val a = BigDecimal(2.3).toExpr
     val b = BigDecimal("1005849025843905834908593485984390583429058574925.95489543").toExpr

--- a/tests/run-with-compiler/quote-lift-BigInt.scala
+++ b/tests/run-with-compiler/quote-lift-BigInt.scala
@@ -1,6 +1,7 @@
 import scala.quoted._
+import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = println(run {
     val a = BigInt(2).toExpr
     val b = BigInt("1005849025843905834908593485984390583429058574925").toExpr

--- a/tests/run-with-compiler/quote-lift-BigInt.scala
+++ b/tests/run-with-compiler/quote-lift-BigInt.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = println(run {
     val a = BigInt(2).toExpr
     val b = BigInt("1005849025843905834908593485984390583429058574925").toExpr

--- a/tests/run-with-compiler/quote-lift-IArray.scala
+++ b/tests/run-with-compiler/quote-lift-IArray.scala
@@ -1,8 +1,9 @@
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     '{
       def p[T](arr: IArray[T]): Unit = {

--- a/tests/run-with-compiler/quote-macro-in-splice/quoted_2.scala
+++ b/tests/run-with-compiler/quote-macro-in-splice/quoted_2.scala
@@ -1,8 +1,9 @@
 import scala.quoted._
+import scala.quoted.staging._
 import Macros._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     val x = '{
       val y = 1

--- a/tests/run-with-compiler/quote-macro-in-splice/quoted_2.scala
+++ b/tests/run-with-compiler/quote-macro-in-splice/quoted_2.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 import Macros._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     val x = '{
       val y = 1

--- a/tests/run-with-compiler/quote-nested-1.scala
+++ b/tests/run-with-compiler/quote-nested-1.scala
@@ -1,7 +1,8 @@
 import quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     val q = '{ given (qctx: QuoteContext) => '{3} }
     println(q.show)

--- a/tests/run-with-compiler/quote-nested-1.scala
+++ b/tests/run-with-compiler/quote-nested-1.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     val q = '{ given (qctx: QuoteContext) => '{3} }
     println(q.show)

--- a/tests/run-with-compiler/quote-nested-2.scala
+++ b/tests/run-with-compiler/quote-nested-2.scala
@@ -1,7 +1,8 @@
 import quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     val q = '{ given (qctx: QuoteContext) =>

--- a/tests/run-with-compiler/quote-nested-2.scala
+++ b/tests/run-with-compiler/quote-nested-2.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     val q = '{ given (qctx: QuoteContext) =>

--- a/tests/run-with-compiler/quote-nested-3.scala
+++ b/tests/run-with-compiler/quote-nested-3.scala
@@ -1,7 +1,8 @@
 import quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     val q = '{

--- a/tests/run-with-compiler/quote-nested-3.scala
+++ b/tests/run-with-compiler/quote-nested-3.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     val q = '{

--- a/tests/run-with-compiler/quote-nested-4.scala
+++ b/tests/run-with-compiler/quote-nested-4.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
 
     val q = '{

--- a/tests/run-with-compiler/quote-nested-4.scala
+++ b/tests/run-with-compiler/quote-nested-4.scala
@@ -1,7 +1,8 @@
 import quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
 
     val q = '{

--- a/tests/run-with-compiler/quote-nested-5.scala
+++ b/tests/run-with-compiler/quote-nested-5.scala
@@ -1,7 +1,8 @@
 import quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
 
     val q = '{ given (qctx: QuoteContext) =>

--- a/tests/run-with-compiler/quote-nested-5.scala
+++ b/tests/run-with-compiler/quote-nested-5.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
 
     val q = '{ given (qctx: QuoteContext) =>

--- a/tests/run-with-compiler/quote-owners-2.scala
+++ b/tests/run-with-compiler/quote-owners-2.scala
@@ -1,8 +1,9 @@
 
 import quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     val q = f(g(Type.IntTag))
     println(q.show)

--- a/tests/run-with-compiler/quote-owners-2.scala
+++ b/tests/run-with-compiler/quote-owners-2.scala
@@ -3,7 +3,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     val q = f(g(Type.IntTag))
     println(q.show)

--- a/tests/run-with-compiler/quote-owners.scala
+++ b/tests/run-with-compiler/quote-owners.scala
@@ -1,8 +1,9 @@
 import quoted._
+import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     def q given QuoteContext = f
     println(run(q))
     println(withQuoteContext(q.show))

--- a/tests/run-with-compiler/quote-owners.scala
+++ b/tests/run-with-compiler/quote-owners.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     def q given QuoteContext = f
     println(run(q))
     println(withQuoteContext(q.show))

--- a/tests/run-with-compiler/quote-run-2.scala
+++ b/tests/run-with-compiler/quote-run-2.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     def powerCode(n: Int, x: Expr[Double]): Expr[Double] =
       if (n == 0) '{1.0}

--- a/tests/run-with-compiler/quote-run-2.scala
+++ b/tests/run-with-compiler/quote-run-2.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
     def powerCode(n: Int, x: Expr[Double]): Expr[Double] =
       if (n == 0) '{1.0}

--- a/tests/run-with-compiler/quote-run-b.scala
+++ b/tests/run-with-compiler/quote-run-b.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     def lambdaExpr given QuoteContext = '{
       (x: Int) => println("lambda(" + x + ")")
     }

--- a/tests/run-with-compiler/quote-run-b.scala
+++ b/tests/run-with-compiler/quote-run-b.scala
@@ -1,9 +1,10 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     def lambdaExpr given QuoteContext = '{
       (x: Int) => println("lambda(" + x + ")")
     }

--- a/tests/run-with-compiler/quote-run-c.scala
+++ b/tests/run-with-compiler/quote-run-c.scala
@@ -1,9 +1,10 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     def classExpr given QuoteContext = '{
       class A {
         override def toString: String = "Foo"

--- a/tests/run-with-compiler/quote-run-c.scala
+++ b/tests/run-with-compiler/quote-run-c.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     def classExpr given QuoteContext = '{
       class A {
         override def toString: String = "Foo"

--- a/tests/run-with-compiler/quote-run-constants.scala
+++ b/tests/run-with-compiler/quote-run-constants.scala
@@ -6,7 +6,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     def runAndPrint[T](expr: given QuoteContext => Expr[T]): Unit = println(run(expr))
 
     runAndPrint(true)

--- a/tests/run-with-compiler/quote-run-constants.scala
+++ b/tests/run-with-compiler/quote-run-constants.scala
@@ -2,10 +2,11 @@
 import given scala.quoted.autolift._
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     def runAndPrint[T](expr: given QuoteContext => Expr[T]): Unit = println(run(expr))
 
     runAndPrint(true)

--- a/tests/run-with-compiler/quote-run-large.scala
+++ b/tests/run-with-compiler/quote-run-large.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
@@ -59,7 +60,7 @@ object Test {
       new Foo(5)
     }
 
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
     withQuoteContext {
       a.show // Force unpiclking of the expression

--- a/tests/run-with-compiler/quote-run-large.scala
+++ b/tests/run-with-compiler/quote-run-large.scala
@@ -60,7 +60,7 @@ object Test {
       new Foo(5)
     }
 
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
     withQuoteContext {
       a.show // Force unpiclking of the expression

--- a/tests/run-with-compiler/quote-run-many.scala
+++ b/tests/run-with-compiler/quote-run-many.scala
@@ -1,9 +1,10 @@
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     def expr(i: Int) given QuoteContext = '{
       val a = 3 + ${i}
       2 + a

--- a/tests/run-with-compiler/quote-run-many.scala
+++ b/tests/run-with-compiler/quote-run-many.scala
@@ -4,7 +4,7 @@ import given scala.quoted.autolift._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     def expr(i: Int) given QuoteContext = '{
       val a = 3 + ${i}
       2 + a

--- a/tests/run-with-compiler/quote-run-staged-interpreter.scala
+++ b/tests/run-with-compiler/quote-run-staged-interpreter.scala
@@ -28,7 +28,7 @@ object Test {
 
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     val exp = Plus(Plus(Num(2), Var("x")), Num(4))
     val letExp = Let("x", Num(3), exp)
 

--- a/tests/run-with-compiler/quote-run-staged-interpreter.scala
+++ b/tests/run-with-compiler/quote-run-staged-interpreter.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 enum Exp {
@@ -27,7 +28,7 @@ object Test {
 
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     val exp = Plus(Plus(Num(2), Var("x")), Num(4))
     val letExp = Let("x", Num(3), exp)
 

--- a/tests/run-with-compiler/quote-run-with-settings.scala
+++ b/tests/run-with-compiler/quote-run-with-settings.scala
@@ -6,7 +6,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     def expr given QuoteContext = '{
       val a = 3
       println("foo")

--- a/tests/run-with-compiler/quote-run-with-settings.scala
+++ b/tests/run-with-compiler/quote-run-with-settings.scala
@@ -2,10 +2,11 @@
 import java.nio.file.{Files, Paths}
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     def expr given QuoteContext = '{
       val a = 3
       println("foo")
@@ -22,7 +23,7 @@ object Test {
 
     {
       implicit val settings = Toolbox.Settings.make(outDir = Some(outDir.toString))
-      implicit val toolbox2: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+      implicit val toolbox2: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
       println(run(expr))
       assert(Files.exists(classFile))
     }

--- a/tests/run-with-compiler/quote-run.scala
+++ b/tests/run-with-compiler/quote-run.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     def expr given QuoteContext = '{
       val a = 3
       println("foo")

--- a/tests/run-with-compiler/quote-run.scala
+++ b/tests/run-with-compiler/quote-run.scala
@@ -1,8 +1,9 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     def expr given QuoteContext = '{
       val a = 3
       println("foo")

--- a/tests/run-with-compiler/quote-show-blocks.scala
+++ b/tests/run-with-compiler/quote-show-blocks.scala
@@ -1,8 +1,9 @@
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def a(n: Int, x: Expr[Unit]): Expr[Unit] =
       if (n == 0) x

--- a/tests/run-with-compiler/quote-show-blocks.scala
+++ b/tests/run-with-compiler/quote-show-blocks.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def a(n: Int, x: Expr[Unit]): Expr[Unit] =
       if (n == 0) x

--- a/tests/run-with-compiler/quote-simple-hole.scala
+++ b/tests/run-with-compiler/quote-simple-hole.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     val x = '{0}

--- a/tests/run-with-compiler/quote-simple-hole.scala
+++ b/tests/run-with-compiler/quote-simple-hole.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     val x = '{0}

--- a/tests/run-with-compiler/quote-toExprOfTuple.scala
+++ b/tests/run-with-compiler/quote-toExprOfTuple.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = {
     for (n <- 0 to 25) {
       prev = 0

--- a/tests/run-with-compiler/quote-toExprOfTuple.scala
+++ b/tests/run-with-compiler/quote-toExprOfTuple.scala
@@ -1,8 +1,9 @@
 
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = {
     for (n <- 0 to 25) {
       prev = 0

--- a/tests/run-with-compiler/quote-two-captured-ref.scala
+++ b/tests/run-with-compiler/quote-two-captured-ref.scala
@@ -1,7 +1,8 @@
 import quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     val q = '{
       val x = 1

--- a/tests/run-with-compiler/quote-two-captured-ref.scala
+++ b/tests/run-with-compiler/quote-two-captured-ref.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     val q = '{
       val x = 1

--- a/tests/run-with-compiler/quote-type-tags.scala
+++ b/tests/run-with-compiler/quote-type-tags.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def asof[T: Type, U](x: Expr[T], t: Type[U]): Expr[U] =
       '{$x.asInstanceOf[$t]}

--- a/tests/run-with-compiler/quote-type-tags.scala
+++ b/tests/run-with-compiler/quote-type-tags.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def asof[T: Type, U](x: Expr[T], t: Type[U]): Expr[U] =
       '{$x.asInstanceOf[$t]}

--- a/tests/run-with-compiler/quote-unrolled-foreach.scala
+++ b/tests/run-with-compiler/quote-unrolled-foreach.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def code1 given QuoteContext = '{ (arr: Array[Int], f: Int => Unit) => ${ foreach1('arr, 'f) } }
     println(code1.show)

--- a/tests/run-with-compiler/quote-unrolled-foreach.scala
+++ b/tests/run-with-compiler/quote-unrolled-foreach.scala
@@ -1,9 +1,10 @@
 import scala.annotation.tailrec
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 object Test {
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def code1 given QuoteContext = '{ (arr: Array[Int], f: Int => Unit) => ${ foreach1('arr, 'f) } }
     println(code1.show)

--- a/tests/run-with-compiler/quote-valueof-list.scala
+++ b/tests/run-with-compiler/quote-valueof-list.scala
@@ -1,8 +1,9 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
 

--- a/tests/run-with-compiler/quote-valueof-list.scala
+++ b/tests/run-with-compiler/quote-valueof-list.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
 

--- a/tests/run-with-compiler/quote-valueof.scala
+++ b/tests/run-with-compiler/quote-valueof.scala
@@ -1,8 +1,9 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     println(('{}).getValue)

--- a/tests/run-with-compiler/quote-valueof.scala
+++ b/tests/run-with-compiler/quote-valueof.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
     println(('{}).getValue)

--- a/tests/run-with-compiler/quote-var.scala
+++ b/tests/run-with-compiler/quote-var.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 object Test {
 
@@ -30,7 +31,7 @@ object Test {
   }
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     val res = run {
       test1()
     }

--- a/tests/run-with-compiler/quote-var.scala
+++ b/tests/run-with-compiler/quote-var.scala
@@ -31,7 +31,7 @@ object Test {
   }
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     val res = run {
       test1()
     }

--- a/tests/run-with-compiler/shonan-hmm-simple.scala
+++ b/tests/run-with-compiler/shonan-hmm-simple.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 trait Ring[T] {
@@ -116,7 +117,7 @@ class Blas1[Idx, T](r: Ring[T], ops: VecOps[Idx, T]) {
 
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = {
     val arr1 = Array(0, 1, 2, 4, 8)
     val arr2 = Array(1, 0, 1, 0, 1)

--- a/tests/run-with-compiler/shonan-hmm-simple.scala
+++ b/tests/run-with-compiler/shonan-hmm-simple.scala
@@ -117,7 +117,7 @@ class Blas1[Idx, T](r: Ring[T], ops: VecOps[Idx, T]) {
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = {
     val arr1 = Array(0, 1, 2, 4, 8)
     val arr2 = Array(1, 0, 1, 0, 1)

--- a/tests/run-with-compiler/shonan-hmm/Test.scala
+++ b/tests/run-with-compiler/shonan-hmm/Test.scala
@@ -5,7 +5,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
 

--- a/tests/run-with-compiler/shonan-hmm/Test.scala
+++ b/tests/run-with-compiler/shonan-hmm/Test.scala
@@ -1,10 +1,11 @@
 import scala.quoted._
+import scala.quoted.staging._
 
 // DYNAMIC
 
 object Test {
 
-  implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuoteContext {
 

--- a/tests/run-with-compiler/staged-streams_1.scala
+++ b/tests/run-with-compiler/staged-streams_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 import scala.quoted.util._
 import given scala.quoted.autolift._
 
@@ -657,7 +658,7 @@ object Test {
     .fold('{0}, ((a: Expr[Int], b : Expr[Int]) => '{ $a + $b }))
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     println(run(test1()))
     println
     println(run(test2()))

--- a/tests/run-with-compiler/staged-streams_1.scala
+++ b/tests/run-with-compiler/staged-streams_1.scala
@@ -658,7 +658,7 @@ object Test {
     .fold('{0}, ((a: Expr[Int], b : Expr[Int]) => '{ $a + $b }))
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     println(run(test1()))
     println
     println(run(test2()))

--- a/tests/run-with-compiler/staged-tuples/Test.scala
+++ b/tests/run-with-compiler/staged-tuples/Test.scala
@@ -1,10 +1,10 @@
-import scala.quoted.run
+import scala.quoted.staging.run
 import scala.internal.StagedTuple._
 
 object Test {
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
 
     assert(run(fromArrayStaged('{ Array.empty[Object] }, Some(0))).==(()))
     assert(run(fromArrayStaged[Tuple1[String]]('{ Array[Object]("a") }, Some(1))) == Tuple1("a"))

--- a/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
+++ b/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
@@ -9,7 +9,7 @@ object Macros {
   inline def testMacro: Unit = ${impl}
 
   def impl given QuoteContext: Expr[Unit] = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    delegate for Toolbox = Toolbox.make(getClass.getClassLoader)
     // 2 is a lifted constant
     val show1 = withQuoteContext(power(2, 3.0).show)
     val run1  = run(power(2, 3.0))

--- a/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
+++ b/tests/run-with-compiler/tasty-extractors-constants-2/quoted_1.scala
@@ -1,4 +1,5 @@
 import scala.quoted._
+import scala.quoted.staging._
 import given scala.quoted.autolift._
 
 import scala.tasty.util._
@@ -8,7 +9,7 @@ object Macros {
   inline def testMacro: Unit = ${impl}
 
   def impl given QuoteContext: Expr[Unit] = {
-    implicit val toolbox: scala.quoted.Toolbox = scala.quoted.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
     // 2 is a lifted constant
     val show1 = withQuoteContext(power(2, 3.0).show)
     val run1  = run(power(2, 3.0))


### PR DESCRIPTION
Move `run` and `Toolbox` to `scala.quoted.staging`.

#### Usage 
```scala
import scala.quoted.staging._

delegate for Toolbox = Toolbox.make(getClass.getClassLoader)

run {
  val expr = '{ ... }
  expr
}

```