### PR TITLE
Allow significant indentation syntax

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -157,6 +157,9 @@ object Config {
    */
   final val simplifyApplications = true
 
+  /** Always assume -indent */
+  final val allowIndent = true
+
   /** If set, prints a trace of all symbol completions */
   final val showCompletions = false
 

--- a/compiler/src/dotty/tools/dotc/config/Printers.scala
+++ b/compiler/src/dotty/tools/dotc/config/Printers.scala
@@ -27,6 +27,7 @@ object Printers {
   val hk: Printer = noPrinter
   val implicits: Printer = noPrinter
   val implicitsDetailed: Printer = noPrinter
+  val lexical: Printer = noPrinter
   val inlining: Printer = noPrinter
   val interactiv: Printer = noPrinter
   val overload: Printer = noPrinter

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -50,6 +50,8 @@ class ScalaSettings extends Settings.SettingGroup {
 
   val newSyntax: Setting[Boolean] = BooleanSetting("-new-syntax", "Require `then` and `do` in control expressions")
   val oldSyntax: Setting[Boolean] = BooleanSetting("-old-syntax", "Require `(...)` around conditions")
+  val indent: Setting[Boolean] = BooleanSetting("-indent", "allow significant indentation")
+  val noindent: Setting[Boolean] = BooleanSetting("-noindent", "require classical {...} syntax, indentation is not significant")
 
   /** Decompiler settings */
   val printTasty: Setting[Boolean] = BooleanSetting("-print-tasty", "Prints the raw tasty.") withAbbreviation "--print-tasty"

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -421,6 +421,7 @@ object StdNames {
     val elem: N                 = "elem"
     val elems: N                = "elems"
     val emptyValDef: N          = "emptyValDef"
+    val end: N                  = "end"
     val ensureAccessible : N    = "ensureAccessible"
     val eq: N                   = "eq"
     val eqInstance: N           = "eqInstance"

--- a/compiler/src/dotty/tools/dotc/parsing/CharArrayReader.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/CharArrayReader.scala
@@ -27,9 +27,6 @@ abstract class CharArrayReader { self =>
   /** The start offset of the current line */
   var lineStartOffset: Int = startFrom
 
-  /** The start offset of the line before the current one */
-  var lastLineStartOffset: Int = startFrom
-
   private[this] var lastUnicodeOffset = -1
 
   /** Is last character a unicode escape \\uxxxx? */
@@ -112,12 +109,8 @@ abstract class CharArrayReader { self =>
   }
 
   /** Handle line ends */
-  private def potentialLineEnd(): Unit = {
-    if (ch == LF || ch == FF) {
-      lastLineStartOffset = lineStartOffset
-      lineStartOffset = charOffset
-    }
-  }
+  private def potentialLineEnd(): Unit =
+    if (ch == LF || ch == FF) lineStartOffset = charOffset
 
   def isAtEnd: Boolean = charOffset >= buf.length
 

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -125,9 +125,11 @@ abstract class TokensCommon {
   final val RBRACKET = 93;         enter(RBRACKET, "']'")
   final val LBRACE = 94;           enter(LBRACE, "'{'")
   final val RBRACE = 95;           enter(RBRACE, "'}'")
+  final val INDENT = 96;           enter(INDENT, "indent")
+  final val OUTDENT = 97;          enter(OUTDENT, "unindent")
 
   final val firstParen = LPAREN
-  final val lastParen = RBRACE
+  final val lastParen = OUTDENT
 
   def buildKeywordArray(keywords: TokenSet): (Int, Array[Int]) = {
     def start(tok: Token) = tokenString(tok).toTermName.asSimpleName.start
@@ -186,6 +188,7 @@ object Tokens extends TokensCommon {
   /** special symbols */
   final val NEWLINE = 78;          enter(NEWLINE, "end of statement", "new line")
   final val NEWLINES = 79;         enter(NEWLINES, "end of statement", "new lines")
+  final val COLONEOL = 88;         enter(COLONEOL, ":", ": at eol")
 
   /** special keywords */
   final val USCORE = 73;           enter(USCORE, "_")
@@ -200,7 +203,7 @@ object Tokens extends TokensCommon {
   final val QUOTE = 86;            enter(QUOTE, "'")
 
   /** XML mode */
-  final val XMLSTART = 96;         enter(XMLSTART, "$XMLSTART$<") // TODO: deprecate
+  final val XMLSTART = 98;         enter(XMLSTART, "$XMLSTART$<") // TODO: deprecate
 
   final val alphaKeywords: TokenSet = tokenRange(IF, MACRO)
   final val symbolicKeywords: TokenSet = tokenRange(USCORE, TLARROW)
@@ -216,7 +219,7 @@ object Tokens extends TokensCommon {
     USCORE, NULL, THIS, SUPER, TRUE, FALSE, RETURN, QUOTEID, XMLSTART)
 
   final val canStartExpressionTokens: TokenSet = atomicExprTokens | BitSet(
-    LBRACE, LPAREN, QUOTE, IF, DO, WHILE, FOR, NEW, TRY, THROW, IMPLIED, GIVEN)
+    LBRACE, LPAREN, INDENT, QUOTE, IF, DO, WHILE, FOR, NEW, TRY, THROW, IMPLIED, GIVEN)
 
   final val canStartTypeTokens: TokenSet = literalTokens | identifierTokens | BitSet(
     THIS, SUPER, USCORE, LPAREN, AT)
@@ -249,7 +252,7 @@ object Tokens extends TokensCommon {
     AT, CASE)
 
   final val canEndStatTokens: TokenSet = atomicExprTokens | BitSet(
-    TYPE, RPAREN, RBRACE, RBRACKET)
+    TYPE, RPAREN, RBRACE, RBRACKET, OUTDENT)
 
   /** Tokens that stop a lookahead scan search for a `<-`, `then`, or `do`.
    *  Used for disambiguating between old and new syntax.
@@ -258,6 +261,12 @@ object Tokens extends TokensCommon {
     BitSet(IF, ELSE, WHILE, DO, FOR, YIELD, NEW, TRY, CATCH, FINALLY, THROW, RETURN, MATCH, SEMI, EOF)
 
   final val numericLitTokens: TokenSet = BitSet(INTLIT, LONGLIT, FLOATLIT, DOUBLELIT)
+
+  final val statCtdTokens: BitSet = BitSet(THEN, ELSE, DO, CATCH, FINALLY, YIELD, MATCH)
+
+  final val canStartIndentTokens: BitSet =
+    statCtdTokens | BitSet(COLONEOL, EQUALS, ARROW, LARROW, WHILE, TRY, FOR)
+      // `if` is excluded because it often comes after `else` which makes for awkward indentation rules
 
   final val scala3keywords = BitSet(ENUM, ERASED, GIVEN, IMPLIED)
 

--- a/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
@@ -318,6 +318,9 @@ object MarkupParsers {
 
     /** Some try/catch/finally logic used by xLiteral and xLiteralPattern.  */
     @forceInline private def xLiteralCommon(f: () => Tree, ifTruncated: String => Unit): Tree = {
+      assert(parser.in.token == Tokens.XMLSTART)
+      val saved = parser.in.newTokenData
+      saved.copyFrom(parser.in)
       var output: Tree = null.asInstanceOf[Tree]
       try output = f()
       catch {
@@ -328,7 +331,7 @@ object MarkupParsers {
         case _: ArrayIndexOutOfBoundsException =>
           parser.syntaxError("missing end tag in XML literal for <%s>" format debugLastElem, debugLastPos)
       }
-      finally parser.in resume Tokens.XMLSTART
+      finally parser.in.resume(saved)
 
       if (output == null)
         parser.errorTermTree
@@ -396,7 +399,12 @@ object MarkupParsers {
     def escapeToScala[A](op: => A, kind: String): A = {
       xEmbeddedBlock = false
       val res = saving[List[Int], A](parser.in.sepRegions, parser.in.sepRegions = _) {
-        parser.in resume LBRACE
+        val lbrace = parser.in.newTokenData
+        lbrace.token = LBRACE
+        lbrace.offset = parser.in.charOffset - 1
+        lbrace.lastOffset = parser.in.lastOffset
+        lbrace.lineOffset = parser.in.lineOffset
+        parser.in.resume(lbrace)
         op
       }
       if (parser.in.token != RBRACE)

--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -48,7 +48,9 @@ object SyntaxHighlighting {
           highlightRange(span.start, span.end, color)
       }
 
-      val scanner = new Scanner(source)
+      val scanner = new Scanner(source) {
+        override protected def printState() = ()
+      }
       while (scanner.token != EOF) {
         val start = scanner.offset
         val token = scanner.token

--- a/compiler/src/dotty/tools/dotc/util/Spans.scala
+++ b/compiler/src/dotty/tools/dotc/util/Spans.scala
@@ -77,6 +77,17 @@ object Spans {
     def contains(that: Span): Boolean =
       !that.exists || exists && (start <= that.start && end >= that.end)
 
+    /** Does the range of this span overlap with the range of that span at more than a single point? */
+    def overlaps(that: Span): Boolean = {
+      def containsInner(span: Span, offset: Int) = span.start < offset && offset < span.end
+      exists && that.exists && (
+         containsInner(this, that.start)
+      || containsInner(this, that.end)
+      || containsInner(that, this.start)
+      || containsInner(that, this.end)
+      )
+    }
+
     /** Is this span synthetic? */
     def isSynthetic: Boolean = pointDelta == SyntheticPointDelta
 

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -1,0 +1,188 @@
+---
+layout: doc-page
+title: Significant Indentation
+---
+
+As an experimental feature, Scala 3 treats indentation as significant.
+
+Indentation is significant everywhere except inside regions delineated by braces `{...}`, brackets `[...]` or parentheses `(...)` or within string or character literals.
+
+Where indentation is significant, the compiler will insert `<indent>` or `<outdent>`
+tokens at certain line breaks. Grammatically, pairs of `<indent>` and `<outdent>` tokens have the same effect as pairs of braces `{` and `}`.
+
+The algorithm makes use of a stack `IW` of previously encountered indentation widths. The stack initially holds a single element with a zero indentation width. The _current indentation width_ is the indentation width of the top of the stack.
+
+There are two rules:
+
+ 1. An `<indent>` is inserted at a line break, if
+
+     - the first token on the next line has an indentation width strictly greater
+	    than the current indentation width, and
+     - the last token on the previous line can start an indentation region.
+
+	 The following tokens can start an indentation region:
+    ```
+	  :  =  =>  <-  if  then  else  while  do  try  catch  finally  for  yield  match
+    ```
+
+   If an `<indent>` is inserted, the indentation width of the token on the next line
+	 is pushed onto `IW`, which makes it the new current indentation width.
+
+ 2. An `<outdent>` is inserted at a line break, if
+
+    - the first token on the next line has an indentation width strictly less
+	    than the current indentation width, and
+	  - the first token on the next line is not a
+	    [leading infix operator](../changed-features/operators.html).
+
+	 If an `<outdent>` is inserted, the top element if popped from `IW`.
+	 If the indentation width of the token on the next line is still less than the new current indentation width, step (2) repeats. Therefore, several `<outdent>` tokens
+	 may be inserted in a row.
+
+It is an error if the indentation width of the token following an `<outdent>` does not
+match the indentation of some previous line in the enclosing indentation region. For instance, the following would be rejected.
+```scala
+if x < 0 then
+    -x
+  else   // error: `else` does not align correctly
+	 x
+```
+
+Indentation prefixes can consist of spaces and tabs. Indentation widths are the indentation prefixes themselves, ordered by the string prefix relation. So, so for instance "2 tabs, followed by 4 spaces" is strictly less than "2 tabs, followed by 5 spaces", but "2 tabs, followed by 4 spaces" is incomparable to "6 tabs" or to "4 spaces, followed by 2 tabs". It is an error if the indentation width of some line is incomparable with the indentation width of the region that's current at that point. To avoid such errors, it is a good idea not to mix spaces and tabs in the same source file.
+
+### Indentation Marker `:`
+
+A colon `:` at the end of a line is one of the possible tokens that opens an indentation region. Examples:
+
+```scala
+  times(10):
+    println("ah")
+    println("ha")
+```
+or
+```scala
+  xs.map:
+    x =>
+	    val y = x - 1
+	    y * y
+```
+Colons at the end of lines are their own token, distinct from normal `:`.
+The Scala grammar is changed so that colons at end of lines are accepted at all points
+where an opening brace is legal, except if the previous token can already start an
+indentation region. Special provisions are taken so that method result types can still use a colon on
+the end of a line, followed by the actual type on the next.
+
+### Special Treatment of Case Clauses
+
+The indentation rules for `match` expressions and `catch` clauses are refined as follows:
+
+ - An indentation region is opened after a `match` or `catch` also if the following `case`
+   appears at the indentation width that's current for the `match` itself.
+ - In that case, the indentation region closes at the first token at that
+   same indentation width that is not a `case`, or at any token with a smaller
+	 indentation width, whichever comes first.
+
+The rules allow to write `match` expressions where cases are not indented themselves, as in the example below:
+```scala
+x match
+case 1 => print("I")
+case 2 => print("II")
+case 3 => print("III")
+case 4 => print("IV")
+case 5 => print("V")
+
+println(".")
+```
+
+### The End Marker
+
+Indentation-based syntax has many advantages over other conventions. But one possible problem is that it makes it hard to discern when a large indentation region ends, since there is no specific token that delineates the end. Braces are not much better since a brace by itself also contains no information about what region is closed.
+
+To solve this problem, Scala 3 offers an optional `end` marker. Example
+```scala
+def largeMethod(...) =
+    ...
+    if ... then ...
+    else
+        ... // a large block
+    end if
+    ... // more code
+end largeMethod
+```
+An `end` marker consists of the identifier `end` which follows an `<outdent>` token, and is in turn followed on the same line by exactly one other token, which is either an identifier or one of the reserved words
+```scala
+  if  while  for  match  try  new
+```
+If `end` is followed by a reserved word, the compiler checks that the marker closes an indentation region belonging to a construct that starts with the reserved word. If it is followed by an identifier _id_, the compiler checks that the marker closes an indentation region containing the right hand side of a `val`, `var`, or `def` or
+the body of a class, trait, object, enum, given instance, or package clause that defines _id_.
+
+`end` itself is a soft keyword. It is only treated as an `end` marker if it
+occurs at the start of a line and is followed by an identifier or one of the reserved words above.
+
+It is recommended that `end` markers are used for code where the extent of an indentation region is not immediately apparent "at a glance". Typically this is the case if an indentation region spans 20 lines or more.
+
+### Example
+
+Here is a (somewhat meta-circular) example of code using indentation. It provides a concrete representation of indentation widths as defined above together with efficient operations for constructing and comparing indentation widths.
+
+```scala
+enum IndentWidth:
+
+    /** A run of `n` characters `ch` */
+    case Run(ch: Char, n: Int)
+
+    /** `l` followed by `r` */
+    case Conc(l: IndentWidth, r: Run)
+
+    def <= (that: IndentWidth): Boolean =
+        this match
+        case Run(ch1, n1) =>
+            that match
+            case Run(ch2, n2) => n1 <= n2 && (ch1 == ch2 || n1 == 0)
+            case Conc(l, r)   => this <= l
+        case Conc(l1, r1) =>
+            that match
+            case Conc(l2, r2) => l1 == l2 && r1 <= r2
+            case _            => false
+
+    def < (that: IndentWidth): Boolean = this <= that && !(that <= this)
+
+    override def toString: String =
+        this match
+        case Run(ch, n) =>
+            val kind = ch match
+                case ' '  => "space"
+                case '\t' => "tab"
+                case _    => s"'$ch'-character"
+            val suffix = if n == 1 then "" else "s"
+            s"$n $kind$suffix"
+        case Conc(l, r) =>
+            s"$l, $r"
+
+object IndentWidth:
+    private inline val MaxCached = 40
+
+    private val spaces = IArray.tabulate(MaxCached + 1):
+        new Run(' ', _)
+    private val tabs = IArray.tabulate(MaxCached + 1):
+        new Run('\t', _)
+
+    def Run(ch: Char, n: Int): Run =
+        if n <= MaxCached && ch == ' ' then
+            spaces(n)
+        else if n <= MaxCached && ch == '\t' then
+            tabs(n)
+        else
+            new Run(ch, n)
+
+    val Zero = Run(' ', 0)
+end IndentWidth
+```
+
+### Rewrites
+
+The Dotty compiler can rewrite source code to indented code and back.
+When invoked with options `-rewrite -indent` it will rewrite braces to
+indented regions where possible. When invoked with with options `-rewrite -noindent` it will rewrite in the reverse direction, inserting braces for indentation regions.
+The `-indent` option only works on [new-style syntax](./control-syntax.html). So to go from old-style syntax to new-style indented code one has to invoke the compiler twice, first with options `-rewrite -new-syntax`, then again with options
+`-rewrite-indent`. To go in the opposite direction, from indented code to old-style syntax, it's `-rewrite -noindent`, followed by `-rewrite -old-syntax`.

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -103,6 +103,8 @@ sidebar:
               url: docs/reference/other-new-features/threadUnsafe-annotation.html
             - title: New Control Syntax
               url: docs/reference/other-new-features/control-syntax.html
+            - title: Significant Indentation
+              url: docs/reference/other-new-features/indentation.html
         - title: Other Changed Features
           subsection:
             - title: Structural Types

--- a/tests/neg/endmarkers.scala
+++ b/tests/neg/endmarkers.scala
@@ -1,0 +1,110 @@
+object Test:
+
+  locally:
+    var x = 0
+    while x < 10 do x += 1
+    end while    // error: end of statement expected but while found // error: not found: end
+    val f = 10   // error: ';' expected, but 'val' found
+    while
+      x += 1
+      x < 10
+    do ()
+  end while      // error: misaligned end marker
+
+  def f(x: Int): Int =
+    val y =
+      if x > 0 then
+        println("hello")
+        22
+      else
+        println("world")
+        33
+    end f        // error: misaligned end marker
+
+    val z = 22
+    x + y + z
+  end f          // error: misaligned end marker
+
+  def g = "!"
+
+  val xs = List(1, 2, 3)
+
+  xs.map:
+    x =>
+      val y = x * x
+      y * y
+
+  xs.map:
+    x =>
+    val y = x * x
+    y + y
+
+  println(f(2) + g)
+
+  (new Test2).foo
+  (new Test3).foo
+
+  var x = 1
+  while
+    x += 1
+    val y = x
+    println(y)
+    x < 10
+  do ()
+
+class Test2:
+  self =>
+  def foo = 1
+
+  object x:
+    new Test2:
+      override def foo = 2
+      end new               // error: end of statement expected but new found  // error: not found: end
+    def bar = 2             // error: ';' expected, but unindent found
+  end Test2                 // error: misaligned end marker
+end Test2
+
+class Test3:
+ self =>
+  def foo = 1
+ end Test3  // error: not found: end
+
+import collection.mutable.HashMap
+
+class Coder(words: List[String]):
+
+  class Foo:
+    println()
+    end Foo  // error: not found: end
+
+  (2 -> "ABC",  new ArrowAssoc('3') -> "DEF")
+
+  private val mnemonics = Map(
+      '2' -> "ABC", '3' -> "DEF", '4' -> "GHI", '5' -> "JKL",
+      '6' -> "MNO", '7' -> "PQRS", '8' -> "TUV", '9' -> "WXYZ")
+
+  ('1', "1") match
+    case (digit, str) => true
+    case _ => false
+
+  ('1', "1") match
+  case (digit, str) => true
+  case _ => false
+
+  try List(1, 2, 3) match
+  case x :: xs => println(x)
+  case Nil => println("Nil")
+  catch
+  case ex: java.io.IOException => println(ex)
+  case ex: Throwable => throw ex
+  end try
+
+  /** Invert the mnemonics map to give a map from chars 'A' ... 'Z' to '2' ... '9' */
+  private val charCode0: Map[Char, Char] =
+    mnemonics
+      .withFilter:
+        case (digit, str) => true
+        case _ => false
+      .flatMap:
+        case (digit, str) => str map (ltr => ltr -> digit)
+ end Coder    // error: The start of this line does not match any of the previous indentation widths.

--- a/tests/neg/i4373b.scala
+++ b/tests/neg/i4373b.scala
@@ -1,5 +1,5 @@
 // ==> 05bef7805687ba94da37177f7568e3ba7da1f91c.scala <==
 class x0 {
   x1: // error
-      x0 | _ // error
+      x0 | _
 // error

--- a/tests/pos/indent.scala
+++ b/tests/pos/indent.scala
@@ -1,0 +1,107 @@
+object Test:
+
+  locally:
+    var x = 0
+    while x < 10 do x += 1
+    val f = 10
+    while
+      x += 1
+      x < 10
+    do ()
+
+  def f(x: Int): Int =
+    val y =
+      if x > 0 then
+        println("hello")
+        22
+      else
+        println("world")
+        33
+    val z = 22
+    x + y + z
+  end f
+
+  def g = "!"
+
+  val xs = List(1, 2, 3)
+
+  xs.map:
+    x =>
+      val y = x * x
+      y * y
+
+  xs.map:
+    x =>
+    val y = x * x
+    y + y
+
+  println(f(2) + g)
+
+  (new Test2).foo
+  (new Test3).foo
+
+  var x = 1
+  while
+    x += 1
+    val y = x
+    println(y)
+    x < 10
+  do ()
+
+class Test2:
+  self =>
+  def foo = 1
+
+  val x =
+    new Test2:
+      override def foo = 2
+    end new
+  end x
+end Test2
+
+class Test3:
+ self =>
+  def foo = 1
+
+import collection.mutable.HashMap
+
+class Coder(words: List[String]):
+
+  class Foo:
+    println()
+  end Foo
+
+  class Bar
+
+  (2 -> "ABC",  new ArrowAssoc('3') -> "DEF")
+
+  private val mnemonics = Map(
+      '2' -> "ABC", '3' -> "DEF", '4' -> "GHI", '5' -> "JKL",
+      '6' -> "MNO", '7' -> "PQRS", '8' -> "TUV", '9' -> "WXYZ")
+
+  ('1', "1") match
+    case (digit, str) => true
+    case _ => false
+
+  ('1', "1") match
+  case (digit, str) => true
+  case _ => false
+
+  try List(1, 2, 3) match
+  case x :: xs => println(x)
+  case Nil => println("Nil")
+  catch
+  case ex: java.io.IOException => println(ex)
+  case ex: Throwable =>
+    throw ex
+  end try
+
+  /** Invert the mnemonics map to give a map from chars 'A' ... 'Z' to '2' ... '9' */
+  private val charCode0: Map[Char, Char] =
+    mnemonics
+      .withFilter:
+        case (digit, str) => true
+        case _ => false
+      .flatMap:
+        case (digit, str) => str map (ltr => ltr -> digit)
+end Coder

--- a/tests/pos/syntax-rewrite.scala
+++ b/tests/pos/syntax-rewrite.scala
@@ -1,0 +1,40 @@
+// This test source should be invariant under the following 4 compilation steps with options
+//  -rewrite -new-syntax
+//  -rewrite -indent
+//  -rewrite -noindent
+//  -rewrite -old-syntax
+object test {
+
+  for {
+    x <- List(1, 2, 3)
+  }
+    println(x)
+
+  for  (x <- List(1, 2, 3))  yield x
+
+  for {
+    x <- List(1, 2, 3)
+    if x == 0
+  }
+  println(x)
+
+  def foo = {
+    println("hi")
+    println("ho")
+    // this comment goes inside braces
+  }
+  // this comment follows the brace
+  // this comment as well
+  object o {
+  }
+
+  def loop[T]()(x: T): T = x
+
+  def g() = /*>*/ loop() /*<*/ {
+    println()
+    1
+  }
+
+  def bar() = { /* */
+  }
+}


### PR DESCRIPTION
As an experimental feature, allow indentation to be treated as significant. 

**What is supported?**

To get a feel for the code, see the example below. For precise rules, see the [doc page](https://github.com/dotty-staging/dotty/blob/add-indent/docs/docs/reference/other-new-features/indentation.md).

The old syntax using braces is also supported. Indentation is _not_ significant inside pairs of braces (or other forms of parentheses), so that gives a natural mode without requiring an explicit switch: Once you use a `{` after in a toplevel definition, indentation is off in that code.

**Why explore this option?**

When Scala was first invented, braces ruled. Almost all widely used notations were brace-based. That's why we decided to follow: there were so many other things to innovate, so we explicitly chose to have very conventional syntax. 

By now, things are quite different:

 - The most widely taught language is now (or will be soon, in any case) Python, which is indentation based. 
 - Other popular functional languages are also indentation based (e..g Haskell, F#, Elm, Agda, Idris). 
 - Documentation and configuration files have shifted from HTML and XML to markdown and yaml, which are both indentation based.

So by now indentation is very natural, even obvious, to developers. There's a chance that anything else will increasingly be considered "crufty".

This PR demonstrates that indentation based syntax is quite a nice fit for Scala. So I believe that before finalizing Scala 3 we should seriously consider this syntax _as an exploration_. We might conclude that indentation has hidden problems, or that its benefits are not enough to balance the cost of change. But to be able to conclude this with confidence we need a serious exploration of this option first. 

This PR is intended to enable the exploration. Besides supporting optional significant indentation, 
it also provides automatic rewrites from old to new syntax and back. This enables one to migrate 
a source quickly and cleanly to indentation based syntax, work with it, and migrate it back 
to braces when needed (e.g. before merging it with the master branch). Rewrites maintain formatting and (depending on coding style) it is possible to get back exactly the same source file after going to indentation based and back. 

This PR is based on #7024. In fact indentation only works well with new-style control syntax. And rewrites have to be done in two steps. To go from current Scala code to new style indented code one has to invoke the compiler twice, with options

```
 dotc -rewrite -new-syntax
 dotc -rewrite -indent
```
To go the other way, it's also to steps:
```
 dotc -rewrite -noindent
 dotc -rewrite -old-syntax
```

While indentation-based syntax requires #7024, the reverse is not true. #7024 is in my mind a definite improvement even if adopted alone. So the two should be considered independently.

**Example**:

```scala
enum IndentWidth:
    case Run(ch: Char, n: Int)
    case Conc(l: IndentWidth, r: Run)

    def <= (that: IndentWidth): Boolean =
        this match
        case Run(ch1, n1) =>
            that match
            case Run(ch2, n2) => n1 <= n2 && (ch1 == ch2 || n1 == 0)
            case Conc(l, r)   => this <= l
        case Conc(l1, r1) =>
            that match
            case Conc(l2, r2) => l1 == l2 && r1 <= r2
            case _            => false

    def < (that: IndentWidth): Boolean = this <= that && !(that <= this)

    override def toString: String =
        this match
        case Run(ch, n) =>
            val kind = ch match
                case ' '  => "space"
                case '\t' => "tab"
                case _    => s"'$ch'-character"
            val suffix = if n == 1 then "" else "s"
            s"$n $kind$suffix"
        case Conc(l, r) =>
            s"$l, $r"

object IndentWidth:
    private inline val MaxCached = 40

    private val spaces = IArray.tabulate(MaxCached + 1):
        new Run(' ', _)
    private val tabs = IArray.tabulate(MaxCached + 1):
        new Run('\t', _)

    def Run(ch: Char, n: Int): Run =
        if n <= MaxCached && ch == ' ' then
            spaces(n)
        else if n <= MaxCached && ch == '\t' then
            tabs(n)
        else
            new Run(ch, n)

    val Zero = Run(' ', 0)
```

For comparison, here's the current layout of this code, using braces:
```scala
  enum IndentWidth {
    case Run(ch: Char, n: Int)
    case Conc(l: IndentWidth, r: Run)

    def <= (that: IndentWidth): Boolean =
      this match {
        case Run(ch1, n1) =>
          that match {
            case Run(ch2, n2) => n1 <= n2 && (ch1 == ch2 || n1 == 0)
            case Conc(l, r)   => this <= l
          }
        case Conc(l1, r1) =>
          that match {
            case Conc(l2, r2) => l1 == l2 && r1 <= r2
            case _            => false
          }
      }

    def < (that: IndentWidth): Boolean = this <= that && !(that <= this)

    override def toString: String = {
      this match {
        case Run(ch, n) =>
          val kind = ch match {
           case ' '  => "space"
           case '\t' => "tab"
           case _    => s"'$ch'-character"
          }
          val suffix = if (n == 1) "" else "s"
          s"$n $kind$suffix"
        case Conc(l, r) =>
          s"$l, $r"
      }
    }
  }
  object IndentWidth {
    private inline val MaxCached = 40
    private val spaces = Array.tabulate(MaxCached + 1) {
      new Run(' ', _)
    }
    private val tabs = Array.tabulate(MaxCached + 1) {
      new Run('\t', _)
    }

    def Run(ch: Char, n: Int): Run =
      if (n <= MaxCached && ch == ' ') 
        spaces(n)
      else if (n <= MaxCached && ch == '\t') 
        tabs(n)
      else 
        new Run(ch, n)

    val Zero = Run(' ', 0)
  }
```
A difference between the two styles as shown here is that indentation uses 4 spaces per tab whereas brace-based uses only 2 spaces. This is an arbitrary choice in each case. One could also use 2 spaces for indentation based (**Edit:** a comment from me below shows the example reworked in this way).