### PR TITLE
Fix #7084: Drop revealProtoOfExtMethod

### DIFF
--- a/compiler/test/dotc/pos-from-tasty.blacklist
+++ b/compiler/test/dotc/pos-from-tasty.blacklist
@@ -6,3 +6,6 @@ t3612.scala
 
 # Other failure
 t802.scala
+
+# Matchtype
+i7087.scala

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -21,6 +21,7 @@ i939.scala
 typelevel0.scala
 matchtype.scala
 6322.scala
+i7087.scala
 
 # Opaque type
 i5720.scala

--- a/tests/pos/i7084.scala
+++ b/tests/pos/i7084.scala
@@ -1,0 +1,15 @@
+object Test {
+
+  type Foo
+
+  given A {
+    def (y: Any) g given Foo: Any = ???
+  }
+
+  def f(x: Any) given Foo: Any = {
+    val y = x.g
+    y.g
+
+    x.g.g
+  }
+}

--- a/tests/pos/i7087.scala
+++ b/tests/pos/i7087.scala
@@ -1,0 +1,13 @@
+type Foo
+
+type G[A]
+
+type F[T] = T match {
+  case G[a] => String
+}
+
+given A {
+  def (tup: T) g[T] given (Foo: F[T]) = ???
+}
+
+def f(x: G[Int]) given (Foo: String) = x.g


### PR DESCRIPTION
Don't call `revealProtoOfExtMethod` when constraining results in adaptation.
Revealing the prototype too early disables further implicit searches, as is
demonstrated by i7084.scala. The original reason to have `revealProtoOfExtMethod`
was to typecheck i5773a. But it looks like this is no longer valid. i5773a
now compiles regardless.