### PR TITLE
Fix #7090: Add final flag to synthetic ImplicitFunctionN traits

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -129,7 +129,9 @@ class Definitions {
           ClassInfo(ScalaPackageClass.thisType, cls, ObjectType :: Nil, decls)
       }
     }
-    newClassSymbol(ScalaPackageClass, name, Trait | NoInits, completer)
+    val flags0 = Trait | NoInits
+    val flags = if (name.isImplicitFunction) flags0 | Final else flags0
+    newClassSymbol(ScalaPackageClass, name, flags, completer)
   }
 
   private def newMethod(cls: ClassSymbol, name: TermName, info: Type, flags: FlagSet = EmptyFlags): TermSymbol =

--- a/tests/neg/i2539.scala
+++ b/tests/neg/i2539.scala
@@ -6,8 +6,6 @@ object Foo {
   val f26: Function26[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]{ def foo(): Int } =
     (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26) => 42 // error
 
-  val if1: ImplicitFunction1[Int, Int]{ def foo(): Int } = implicit x1 => 42 // error
-
   abstract class Fun0[X] extends Function0[X]
   val fun0a: Fun0[Int] = () => 42
   val fun0b: Fun0[Int] { def foo(): Int } = () => 42 // error

--- a/tests/neg/implicit-funs.scala
+++ b/tests/neg/implicit-funs.scala
@@ -1,0 +1,11 @@
+trait IF1 extends (given Int => Unit) // error
+abstract class IF2 extends (given (Int, String) => Unit) // error
+class IF3 extends (ImplicitFunction3[Int, String, Boolean, Unit]) { // error
+  def apply given (Int, String, Boolean) = ()
+}
+
+trait IFXXL extends (given ( // error
+  Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int) => Unit)
+
+val IFOK: given ( // OK
+  Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int) => Unit = ()


### PR DESCRIPTION
Should this also apply to erased or any other special function traits?

fixes #7090 