### PR TITLE
Fix #6989: Make sure scalacLinkedClass finds companion when unpickling

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -801,6 +801,7 @@ class TreeUnpickler(reader: TastyReader,
           ValDef(tpt)
         case TYPEDEF | TYPEPARAM =>
           if (sym.isClass) {
+            sym.owner.ensureCompleted() // scalacLinkedClass uses unforcedDecls. Make sure it does not miss anything.
             val companion = sym.scalacLinkedClass
 
             // Is the companion defined in the same Tasty file as `sym`?

--- a/tests/pos/i6989/Container_1.scala
+++ b/tests/pos/i6989/Container_1.scala
@@ -1,0 +1,12 @@
+package mypkg
+
+object Container {
+  class StringExtras(val s: String) extends AnyVal {
+    def op(item: Int): Int = ???
+  }
+}
+
+trait Container {
+  import Container._
+  implicit def mkStringExtras(s: String): StringExtras = new StringExtras(s)
+}

--- a/tests/pos/i6989/SimpleTest_2.scala
+++ b/tests/pos/i6989/SimpleTest_2.scala
@@ -1,0 +1,5 @@
+package mypkg
+
+class SimpleTest extends Container {
+  "foo".op(5)
+}


### PR DESCRIPTION
scalacLinkedClass uses unforcedDecls which might miss a companion object when
unpickling. I tried to make scalacLinekdClass stricter, but ran into
problems. It turns out that it is finely balanced as it is.

The fix is to make sure the owner is completed before calling scalacLinkedClass
from an unpickler.