### PR TITLE
Fix #7082: Refine overloading resolution with default arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1721,11 +1721,15 @@ trait Applications extends Compatibility { self: Typer with Dynamic =>
           .map(advanced.toMap) // map surviving result(s) back to original candidates
       case _ =>
         val noDefaults = alts.filter(!_.symbol.hasDefaultParams)
-        if (noDefaults.length == 1) noDefaults // return unique alternative without default parameters if it exists
+        val noDefaultsCount = noDefaults.length
+        if (noDefaultsCount == 1)
+          noDefaults // return unique alternative without default parameters if it exists
+        else if (noDefaultsCount > 1 && noDefaultsCount < alts.length)
+          resolveOverloaded(noDefaults, pt, targs) // try again, dropping defult arguments
         else {
           val deepPt = pt.deepenProto
           if (deepPt ne pt) resolveOverloaded(alts, deepPt, targs)
-          else alts
+          else candidates
         }
     }
   }

--- a/tests/pos/i7082.scala
+++ b/tests/pos/i7082.scala
@@ -1,0 +1,11 @@
+object Overloads {
+
+  def foo[V](x: Int = 0, y: Int = 0, z: Int = 0): Nothing = ???
+
+  def foo[V](x: Int, y: Int): Nothing = ???
+
+  def foo[V](x: Int): Nothing = ???
+
+  foo(1)
+
+}


### PR DESCRIPTION
We previously had a fallback to pick methods without default arguments
over methods with default arguments as a final tie breaker. (Rolling the
distinction into the specificity test was tried previously, but without
success). The fallback only worked if there was a single alternative
without default arguments. This is now generalized to the case where
there are several such alternatives.

Also, we now avoid mentioning inapplicable alternatives in overloading
ambiguity error messages.