### PR TITLE
Release sbt-dotty 0.3.4, future-proof isDotty

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -61,14 +61,14 @@ object Build {
   val referenceVersion = "0.18.1-bin-20190825-6960f8d-NIGHTLY"
 
   val baseVersion = "0.18.1"
-  val baseSbtDottyVersion = "0.3.4"
+  val baseSbtDottyVersion = "0.3.5"
 
   // Versions used by the vscode extension to create a new project
   // This should be the latest published releases.
   // TODO: Have the vscode extension fetch these numbers from the Internet
   // instead of hardcoding them ?
   val publishedDottyVersion = referenceVersion
-  val publishedSbtDottyVersion = "0.3.3"
+  val publishedSbtDottyVersion = "0.3.4"
 
   /** scala-library version required to compile Dotty.
    *

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -168,7 +168,7 @@ object DottyPlugin extends AutoPlugin {
   val Def = sbt.Def
   override def projectSettings: Seq[Setting[_]] = {
     Seq(
-      isDotty := scalaVersion.value.startsWith("0."),
+      isDotty := scalaVersion.value.startsWith("0.") || scalaVersion.value.startsWith("3."),
 
       scalaOrganization := {
         if (isDotty.value)

--- a/tests/run/t6827.check
+++ b/tests/run/t6827.check
@@ -1,5 +1,5 @@
-start at -5: java.lang.ArrayIndexOutOfBoundsException: -5
-start at -1: java.lang.ArrayIndexOutOfBoundsException: -1
+start at -5: OOB
+start at -1: OOB
 start at limit: ok
 start at limit-1: ok
 first 10: ok

--- a/tests/run/t6827.scala
+++ b/tests/run/t6827.scala
@@ -9,16 +9,9 @@ object Test extends App {
       "ok"
     } catch {
       case e: ArrayIndexOutOfBoundsException =>
-        // Special-case printing this exception because the toString changed in Java 11
-        val java11toString = """java.lang.ArrayIndexOutOfBoundsException: Index (-?\d+).*""".r
-
-        e.toString match {
-          case java11toString(index) =>
-            s"java.lang.ArrayIndexOutOfBoundsException: $index"
-          case str =>
-            str
-        }
-      case e: Exception => e.toString
+        "OOB"
+      case e: Exception =>
+        e.toString
     }
     println("%s: %s" format (label, status))
   }


### PR DESCRIPTION
We need a released sbt-dotty with https://github.com/lampepfl/dotty/commit/f5459d0d55b7082c4c8df268b391384ebc6dc497#diff-2341add22275f228b7ecd69d80025b8a in.

I'm doing the sbt-dotty release manually as usual by running:
```shell
drone build promote lampepfl/dotty $BUILD_ID sbt_release
```