### PR TITLE
documentation: use more intuitive value to compare against

### DIFF
--- a/docs/docs/reference/contextual/given-clauses.md
+++ b/docs/docs/reference/contextual/given-clauses.md
@@ -13,7 +13,7 @@ For example, with the [given instances](./delegates.md) defined previously,
 a maximum function that works for any arguments for which an ordering exists can be defined as follows:
 ```scala
 def max[T](x: T, y: T) given (ord: Ord[T]): T =
-  if (ord.compare(x, y) < 1) y else x
+  if (ord.compare(x, y) < 0) y else x
 ```
 Here, `ord` is an _implicit parameter_ introduced with a `given` clause.
 The `max` method can be applied as follows:


### PR DESCRIPTION
I think this is also a bug because `Ord`, even though formally not defined here, would normally be expected to have range `-infinity .. +infinity` by an average programmer, not necessarily only taking `-1, 0, 1` as values.

Even if it's not a bug, comparing with `0` would look better and more intuitive.