### PR TITLE
Fix #7119: Don't infer given arguments if explicit ones are given

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -520,7 +520,7 @@ object ProtoTypes {
   /** Create a new TypeVar that represents a dependent method parameter singleton */
   def newDepTypeVar(tp: Type)(implicit ctx: Context): TypeVar =
     newTypeVar(TypeBounds.upper(AndType(tp.widenExpr, defn.SingletonClass.typeRef)))
-    
+
   /** The result type of `mt`, where all references to parameters of `mt` are
    *  replaced by either wildcards (if typevarsMissContext) or TypeParamRefs.
    */

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2575,7 +2575,14 @@ class Typer extends Namer
             readaptSimplified(tpd.Apply(tree, args))
         }
       }
-      addImplicitArgs(argCtx(tree))
+      pt.revealIgnored match {
+        case pt: FunProto if pt.isGivenApply =>
+          // We can end up here if extension methods are called with explicit given arguments.
+          // See for instance #7119.
+          tree
+        case _ =>
+          addImplicitArgs(argCtx(tree))
+      }
     }
 
     /** A synthetic apply should be eta-expanded if it is the apply of an implicit function

--- a/tests/pos/i7119.scala
+++ b/tests/pos/i7119.scala
@@ -1,0 +1,9 @@
+class Impl
+
+def (impl: Impl) prop given Int = ???//the[Int]
+
+
+def main(args: Array[String]): Unit = {
+  given as Int = 3
+  println(new Impl().prop given 3)
+}


### PR DESCRIPTION
Don't infer given arguments if explicit ones are given, even if the
explicit arguments are part of an IgnoredProto.