### PR TITLE
Switch to `?` for wildcard types

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
+++ b/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
@@ -39,9 +39,9 @@ object NavigateAST {
    */
   def untypedPath(tree: tpd.Tree, exactMatch: Boolean = false)(implicit ctx: Context): List[Positioned] =
     tree match {
-      case tree: MemberDef[_] =>
+      case tree: MemberDef[?] =>
         untypedPath(tree.span) match {
-          case path @ (last: DefTree[_]) :: _ => path
+          case path @ (last: DefTree[?]) :: _ => path
           case path if !exactMatch => path
           case _ => Nil
         }
@@ -75,7 +75,7 @@ object NavigateAST {
         val path1 = it.next() match {
           case p: Positioned => singlePath(p, path)
           case m: untpd.Modifiers => childPath(m.productIterator, path)
-          case xs: List[_] => childPath(xs.iterator, path)
+          case xs: List[?] => childPath(xs.iterator, path)
           case _ => path
         }
         if ((path1 ne path) &&
@@ -92,7 +92,7 @@ object NavigateAST {
         // our usage of `productIterator` by something in `Positioned` that takes
         // care of low-level details like this for us.
         p match {
-          case p: WithLazyField[_] =>
+          case p: WithLazyField[?] =>
             p.forceIfLazy
           case _ =>
         }

--- a/compiler/src/dotty/tools/dotc/ast/PluggableTransformers.scala
+++ b/compiler/src/dotty/tools/dotc/ast/PluggableTransformers.scala
@@ -64,7 +64,7 @@ object PluggableTransformers {
       else finishIdent(ops(tree, old, c), old, c, ops.next)
 
     override def finishIdent(tree: Tree[T], old: Tree[T], c: Context, plugins: Plugins): Tree[T] = tree match {
-      case tree: Ident[_] => postIdent(tree, old, c, plugins.IdentOps)
+      case tree: Ident[?] => postIdent(tree, old, c, plugins.IdentOps)
       case _ => postProcess(tree, old, c, plugins)
     }
 
@@ -73,13 +73,13 @@ object PluggableTransformers {
       else finishSelect(ops(tree, old, c), old, c, ops.next)
 
     override def finishSelect(tree: Tree[T], old: Tree[T], c: Context, plugins: Plugins): Tree[T] = tree match {
-      case tree: Select[_] => postSelect(tree, old, c, plugins.SelectOps)
+      case tree: Select[?] => postSelect(tree, old, c, plugins.SelectOps)
       case _ => postProcess(tree, old, c, plugins)
     }
 
     protected def postProcess(tree: Tree[T], old: Tree[T], c: Context, plugins: Plugins): Tree[T] = tree match {
-      case tree: Ident[_] => finishIdent(tree, old, c, plugins)
-      case tree: Select[_] => finishSelect(tree, old, c, plugins)
+      case tree: Ident[?] => finishIdent(tree, old, c, plugins)
+      case tree: Select[?] => finishSelect(tree, old, c, plugins)
     }
   }
 }

--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -128,7 +128,7 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Pro
         x.contains(that)
       case m: untpd.Modifiers =>
         m.mods.exists(isParent) || m.annotations.exists(isParent)
-      case xs: List[_] =>
+      case xs: List[?] =>
         xs.exists(isParent)
       case _ =>
         false
@@ -195,7 +195,7 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Pro
       case m: untpd.Modifiers =>
         m.annotations.foreach(check)
         m.mods.foreach(check)
-      case xs: List[_] =>
+      case xs: List[?] =>
         xs.foreach(check)
       case _ =>
     }

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -119,14 +119,14 @@ object Trees {
      *   - errors were reported
      */
     private def checkChildrenTyped(it: Iterator[Any])(implicit ctx: Context): Unit =
-      if (!this.isInstanceOf[Import[_]])
+      if (!this.isInstanceOf[Import[?]])
         while (it.hasNext)
           it.next() match {
-            case x: Ident[_] => // untyped idents are used in a number of places in typed trees
-            case x: Tree[_] =>
+            case x: Ident[?] => // untyped idents are used in a number of places in typed trees
+            case x: Tree[?] =>
               assert(x.hasType || ctx.reporter.errorsReported,
                      s"$this has untyped child $x")
-            case xs: List[_] => checkChildrenTyped(xs.iterator)
+            case xs: List[?] => checkChildrenTyped(xs.iterator)
             case _ =>
           }
 
@@ -188,8 +188,8 @@ object Trees {
     def treeSize: Int = {
       var s = 1
       def addSize(elem: Any): Unit = elem match {
-        case t: Tree[_] => s += t.treeSize
-        case ts: List[_] => ts foreach addSize
+        case t: Tree[?] => s += t.treeSize
+        case ts: List[?] => ts foreach addSize
         case _ =>
       }
       productIterator foreach addSize
@@ -203,18 +203,18 @@ object Trees {
 
     override def toText(printer: Printer): Text = printer.toText(this)
 
-    def sameTree(that: Tree[_]): Boolean = {
+    def sameTree(that: Tree[?]): Boolean = {
       def isSame(x: Any, y: Any): Boolean =
         x.asInstanceOf[AnyRef].eq(y.asInstanceOf[AnyRef]) || {
           x match {
-            case x: Tree[_] =>
+            case x: Tree[?] =>
               y match {
-                case y: Tree[_] => x.sameTree(y)
+                case y: Tree[?] => x.sameTree(y)
                 case _ => false
               }
-            case x: List[_] =>
+            case x: List[?] =>
               y match {
-                case y: List[_] => x.corresponds(y)(isSame)
+                case y: List[?] => x.corresponds(y)(isSame)
                 case _ => false
               }
             case _ =>
@@ -771,7 +771,7 @@ object Trees {
     type ThisTree[-T >: Untyped] = TypeDef[T]
 
     /** Is this a definition of a class? */
-    def isClassDef: Boolean = rhs.isInstanceOf[Template[_]]
+    def isClassDef: Boolean = rhs.isInstanceOf[Template[?]]
 
     def isBackquoted: Boolean = hasAttachment(Backquoted)
   }

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -241,7 +241,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     def hasFlags: Boolean = flags != EmptyFlags
     def hasAnnotations: Boolean = annotations.nonEmpty
     def hasPrivateWithin: Boolean = privateWithin != tpnme.EMPTY
-    def hasMod(cls: Class[_]) = mods.exists(_.getClass == cls)
+    def hasMod(cls: Class[?]) = mods.exists(_.getClass == cls)
 
     private def isEnum = is(Enum, butNot = JavaDefined)
 

--- a/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -68,11 +68,11 @@ object CompilerCommand {
     val settings = ctx.settings
 
     /** Creates a help message for a subset of options based on cond */
-    def availableOptionsMsg(cond: Setting[_] => Boolean): String = {
+    def availableOptionsMsg(cond: Setting[?] => Boolean): String = {
       val ss                  = (ctx.settings.allSettings filter cond).toList sortBy (_.name)
       val width               = (ss map (_.name.length)).max
       def format(s: String)   = ("%-" + width + "s") format s
-      def helpStr(s: Setting[_]) = {
+      def helpStr(s: Setting[?]) = {
         def defaultValue = s.default match {
           case _: Int | _: String => s.default.toString
           case _ =>
@@ -91,7 +91,7 @@ object CompilerCommand {
       ss map helpStr mkString "\n"
     }
 
-    def createUsageMsg(label: String, shouldExplain: Boolean, cond: Setting[_] => Boolean): String = {
+    def createUsageMsg(label: String, shouldExplain: Boolean, cond: Setting[?] => Boolean): String = {
       val prefix = List(
         Some(shortUsage),
         Some(explainAdvanced) filter (_ => shouldExplain),
@@ -101,9 +101,9 @@ object CompilerCommand {
       prefix + "\n" + availableOptionsMsg(cond)
     }
 
-    def isStandard(s: Setting[_]): Boolean = !isAdvanced(s) && !isPrivate(s)
-    def isAdvanced(s: Setting[_]): Boolean = s.name startsWith "-X"
-    def isPrivate(s: Setting[_]) : Boolean = s.name startsWith "-Y"
+    def isStandard(s: Setting[?]): Boolean = !isAdvanced(s) && !isPrivate(s)
+    def isAdvanced(s: Setting[?]): Boolean = s.name startsWith "-X"
+    def isPrivate(s: Setting[?]) : Boolean = s.name startsWith "-Y"
 
     /** Messages explaining usage and options */
     def usageMessage    = createUsageMsg("where possible standard", shouldExplain = false, isStandard)

--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -10,7 +10,7 @@ import java.util.jar.Attributes.{ Name => AttributeName }
 /** Loads `library.properties` from the jar. */
 object Properties extends PropertiesTrait {
   protected def propCategory: String = "compiler"
-  protected def pickJarBasedOn: Class[Option[_]] = classOf[Option[_]]
+  protected def pickJarBasedOn: Class[Option[?]] = classOf[Option[?]]
 
   /** Scala manifest attributes.
    */
@@ -19,7 +19,7 @@ object Properties extends PropertiesTrait {
 
 trait PropertiesTrait {
   protected def propCategory: String      // specializes the remainder of the values
-  protected def pickJarBasedOn: Class[_]  // props file comes from jar containing this
+  protected def pickJarBasedOn: Class[?]  // props file comes from jar containing this
 
   /** The name of the properties file */
   protected val propFilename: String = "/" + propCategory + ".properties"

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -19,9 +19,9 @@ object Settings {
   val BooleanTag: ClassTag[Boolean]      = ClassTag.Boolean
   val IntTag: ClassTag[Int]              = ClassTag.Int
   val StringTag: ClassTag[String]        = ClassTag(classOf[String])
-  val ListTag: ClassTag[List[_]]         = ClassTag(classOf[List[_]])
+  val ListTag: ClassTag[List[?]]         = ClassTag(classOf[List[?]])
   val VersionTag: ClassTag[ScalaVersion] = ClassTag(classOf[ScalaVersion])
-  val OptionTag: ClassTag[Option[_]]     = ClassTag(classOf[Option[_]])
+  val OptionTag: ClassTag[Option[?]]     = ClassTag(classOf[Option[?]])
   val OutputTag: ClassTag[AbstractFile]  = ClassTag(classOf[AbstractFile])
 
   class SettingsState(initialValues: Seq[Any]) {
@@ -65,8 +65,8 @@ object Settings {
     choices: Seq[T] = Nil,
     prefix: String = "",
     aliases: List[String] = Nil,
-    depends: List[(Setting[_], Any)] = Nil,
-    propertyClass: Option[Class[_]] = None)(private[Settings] val idx: Int) {
+    depends: List[(Setting[?], Any)] = Nil,
+    propertyClass: Option[Class[?]] = None)(private[Settings] val idx: Int) {
 
     private[this] var changed: Boolean = false
 
@@ -95,7 +95,7 @@ object Settings {
       if (choices.isEmpty) ""
       else choices match {
         case r: Range => s"${r.head}..${r.last}"
-        case xs: List[_] => xs.mkString(", ")
+        case xs: List[?] => xs.mkString(", ")
       }
 
     def isLegal(arg: Any): Boolean =
@@ -110,7 +110,7 @@ object Settings {
             case x: Int => r.head <= x && x <= r.last
             case _ => false
           }
-        case xs: List[_] =>
+        case xs: List[?] =>
           xs contains arg
       }
 
@@ -193,12 +193,12 @@ object Settings {
 
   class SettingGroup {
 
-    private[this] val _allSettings = new ArrayBuffer[Setting[_]]
-    def allSettings: Seq[Setting[_]] = _allSettings.toSeq
+    private[this] val _allSettings = new ArrayBuffer[Setting[?]]
+    def allSettings: Seq[Setting[?]] = _allSettings.toSeq
 
     def defaultState: SettingsState = new SettingsState(allSettings map (_.default))
 
-    def userSetSettings(state: SettingsState): Seq[Setting[_]] =
+    def userSetSettings(state: SettingsState): Seq[Setting[?]] =
       allSettings filterNot (_.isDefaultIn(state))
 
     def toConciseString(state: SettingsState): String =
@@ -207,7 +207,7 @@ object Settings {
     private def checkDependencies(state: ArgsSummary): ArgsSummary =
       userSetSettings(state.sstate).foldLeft(state)(checkDependenciesOfSetting)
 
-    private def checkDependenciesOfSetting(state: ArgsSummary, setting: Setting[_]) =
+    private def checkDependenciesOfSetting(state: ArgsSummary, setting: Setting[?]) =
       setting.depends.foldLeft(state) { (s, dep) =>
         val (depSetting, reqValue) = dep
         if (depSetting.valueIn(state.sstate) == reqValue) s
@@ -237,7 +237,7 @@ object Settings {
         case "--" :: args =>
           checkDependencies(stateWithArgs(skipped ++ args))
         case x :: _ if x startsWith "-" =>
-          @tailrec def loop(settings: List[Setting[_]]): ArgsSummary = settings match {
+          @tailrec def loop(settings: List[Setting[?]]): ArgsSummary = settings match {
             case setting :: settings1 =>
               val state1 = setting.tryToSet(state)
               if (state1 ne state) processArguments(state1, processAll, skipped)

--- a/compiler/src/dotty/tools/dotc/config/WrappedProperties.scala
+++ b/compiler/src/dotty/tools/dotc/config/WrappedProperties.scala
@@ -12,7 +12,7 @@ trait WrappedProperties extends PropertiesTrait {
   def wrap[T](body: => T): Option[T]
 
   protected def propCategory: String     = "wrapped"
-  protected def pickJarBasedOn: Class[_] = this.getClass
+  protected def pickJarBasedOn: Class[?] = this.getClass
 
   override def propIsSet(name: String): Boolean              = wrap(super.propIsSet(name)) exists (x => x)
   override def propOrElse(name: String, alt: String): String = wrap(super.propOrElse(name, alt)) getOrElse alt

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -114,9 +114,9 @@ object Contexts {
     final def owner: Symbol = _owner
 
     /** The current tree */
-    private[this] var _tree: Tree[_ >: Untyped]= _
-    protected def tree_=(tree: Tree[_ >: Untyped]): Unit = _tree = tree
-    final def tree: Tree[_ >: Untyped] = _tree
+    private[this] var _tree: Tree[? >: Untyped]= _
+    protected def tree_=(tree: Tree[? >: Untyped]): Unit = _tree = tree
+    final def tree: Tree[? >: Untyped] = _tree
 
     /** The current scope */
     private[this] var _scope: Scope = _
@@ -337,7 +337,7 @@ object Contexts {
      *  Note: Currently unused
     def enclTemplate: Context = {
       var c = this
-      while (c != NoContext && !c.tree.isInstanceOf[Template[_]] && !c.tree.isInstanceOf[PackageDef[_]])
+      while (c != NoContext && !c.tree.isInstanceOf[Template[?]] && !c.tree.isInstanceOf[PackageDef[?]])
         c = c.outer
       c
     }*/
@@ -392,15 +392,15 @@ object Contexts {
     }
 
     /** The context of expression `expr` seen as a member of a statement sequence */
-    def exprContext(stat: Tree[_ >: Untyped], exprOwner: Symbol): Context =
+    def exprContext(stat: Tree[? >: Untyped], exprOwner: Symbol): Context =
       if (exprOwner == this.owner) this
       else if (untpd.isSuperConstrCall(stat) && this.owner.isClass) superCallContext
       else ctx.fresh.setOwner(exprOwner)
 
     /** A new context that summarizes an import statement */
-    def importContext(imp: Import[_], sym: Symbol): FreshContext = {
+    def importContext(imp: Import[?], sym: Symbol): FreshContext = {
       val impNameOpt = imp.expr match {
-        case ref: RefTree[_] => Some(ref.name.asTermName)
+        case ref: RefTree[?] => Some(ref.name.asTermName)
         case _               => None
       }
       ctx.fresh.setImportInfo(
@@ -524,7 +524,7 @@ object Contexts {
     def setPeriod(period: Period): this.type = { this.period = period; this }
     def setMode(mode: Mode): this.type = { this.mode = mode; this }
     def setOwner(owner: Symbol): this.type = { assert(owner != NoSymbol); this.owner = owner; this }
-    def setTree(tree: Tree[_ >: Untyped]): this.type = { this.tree = tree; this }
+    def setTree(tree: Tree[? >: Untyped]): this.type = { this.tree = tree; this }
     def setScope(scope: Scope): this.type = { this.scope = scope; this }
     def setNewScope: this.type = { this.scope = newScope; this }
     def setTyperState(typerState: TyperState): this.type = { this.typerState = typerState; this }
@@ -559,7 +559,7 @@ object Contexts {
     def setProperty[T](key: Key[T], value: T): this.type =
       setMoreProperties(moreProperties.updated(key, value))
 
-    def dropProperty(key: Key[_]): this.type =
+    def dropProperty(key: Key[?]): this.type =
       setMoreProperties(moreProperties - key)
 
     def addLocation[T](initial: T): Store.Location[T] = {

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -843,7 +843,7 @@ class Definitions {
    *  Note that this will also extract the high bound if an
    *  element type is a wildcard. E.g.
    *
-   *     Array[_ <: Array[_ <: Number]]
+   *     Array[? <: Array[? <: Number]]
    *
    *  would match
    *
@@ -1211,10 +1211,10 @@ class Definitions {
   private val typeTags = mutable.Map[TypeName, Name]().withDefaultValue(nme.specializedTypeNames.Object)
 
 //  private val unboxedTypeRef = mutable.Map[TypeName, TypeRef]()
-//  private val javaTypeToValueTypeRef = mutable.Map[Class[_], TypeRef]()
-//  private val valueTypeNamesToJavaType = mutable.Map[TypeName, Class[_]]()
+//  private val javaTypeToValueTypeRef = mutable.Map[Class[?], TypeRef]()
+//  private val valueTypeNamesToJavaType = mutable.Map[TypeName, Class[?]]()
 
-  private def valueTypeRef(name: String, jtype: Class[_], enc: Int, tag: Name): TypeRef = {
+  private def valueTypeRef(name: String, jtype: Class[?], enc: Int, tag: Name): TypeRef = {
     val vcls = ctx.requiredClassRef(name)
     valueTypeEnc(vcls.name) = enc
     typeTags(vcls.name) = tag
@@ -1242,8 +1242,8 @@ class Definitions {
   /** The JVM tag for `tp` if it's a primitive, `java.lang.Object` otherwise. */
   def typeTag(tp: Type)(implicit ctx: Context): Name = typeTags(scalaClassName(tp))
 
-//  /** The `Class[_]` of a primitive value type name */
-//  def valueTypeNameToJavaType(name: TypeName)(implicit ctx: Context): Option[Class[_]] =
+//  /** The `Class[?]` of a primitive value type name */
+//  def valueTypeNameToJavaType(name: TypeName)(implicit ctx: Context): Option[Class[?]] =
 //    valueTypeNamesToJavaType.get(if (name.firstPart eq nme.scala_) name.lastPart.toTypeName else name)
 
   type PrimitiveClassEnc = Int

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -252,7 +252,7 @@ object Phases {
     final def genBCodePhase: Phase = myGenBCodePhase
 
     private def setSpecificPhases() = {
-      def phaseOfClass(pclass: Class[_]) = phases.find(pclass.isInstance).getOrElse(NoPhase)
+      def phaseOfClass(pclass: Class[?]) = phases.find(pclass.isInstance).getOrElse(NoPhase)
 
       myTyperPhase = phaseOfClass(classOf[FrontEnd])
       myPostTyperPhase = phaseOfClass(classOf[PostTyper])
@@ -420,7 +420,7 @@ object Phases {
   /** Replace all instances of `oldPhaseClass` in `current` phases
    *  by the result of `newPhases` applied to the old phase.
    */
-  def replace(oldPhaseClass: Class[_ <: Phase], newPhases: Phase => List[Phase], current: List[List[Phase]]): List[List[Phase]] =
+  def replace(oldPhaseClass: Class[? <: Phase], newPhases: Phase => List[Phase], current: List[List[Phase]]): List[List[Phase]] =
     current.map(_.flatMap(phase =>
       if (oldPhaseClass.isInstance(phase)) newPhases(phase) else phase :: Nil))
 }

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -80,7 +80,7 @@ object TypeApplications {
    *  and there are no other occurrences of `X` in the reduced type. In that case
    *  the refinement above is replaced by
    *
-   *        C[..., _ >: L <: H, ...]
+   *        C[..., ? >: L <: H, ...]
    *
    *  The `allReplaced` field indicates whether all occurrences of type lambda parameters
    *  in the reduced type have been replaced with arguments.
@@ -88,7 +88,7 @@ object TypeApplications {
    *  2. If Mode.AllowLambdaWildcardApply is not set:
    *  All `X` arguments are replaced by:
    *
-   *        _ >: L <: H
+   *        ? >: L <: H
    *
    *  Any other occurrence of `X` in `tycon` is replaced by `U`, if the
    *  occurrence of `X` in `tycon` is covariant, or nonvariant, or by `L`,
@@ -442,7 +442,7 @@ class TypeApplications(val self: Type) extends AnyVal {
     case _ => if (self.isMatch) MatchAlias(self) else TypeAlias(self)
   }
 
-  /** Translate a type of the form From[T] to either To[T] or To[_ <: T] (if `wildcardArg` is set). Keep other types as they are.
+  /** Translate a type of the form From[T] to either To[T] or To[? <: T] (if `wildcardArg` is set). Keep other types as they are.
    *  `from` and `to` must be static classes, both with one type parameter, and the same variance.
    *  Do the same for by name types => From[T] and => To[T]
    */
@@ -464,7 +464,7 @@ class TypeApplications(val self: Type) extends AnyVal {
   def underlyingIfRepeated(isJava: Boolean)(implicit ctx: Context): Type =
     if (self.isRepeatedParam) {
       val seqClass = if (isJava) defn.ArrayClass else defn.SeqClass
-      // If `isJava` is set, then we want to turn `RepeatedParam[T]` into `Array[_ <: T]`,
+      // If `isJava` is set, then we want to turn `RepeatedParam[T]` into `Array[? <: T]`,
       // since arrays aren't covariant until after erasure. See `tests/pos/i5140`.
       translateParameterized(defn.RepeatedParamClass, seqClass, wildcardArg = isJava)
     }

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1180,7 +1180,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
         /** Try a capture conversion:
          *  If the original left-hand type `leftRoot` is a path `p.type`,
          *  and the current widened left type is an application with wildcard arguments
-         *  such as `C[_]`, where `X` is `C`'s type parameter corresponding to the `_` argument,
+         *  such as `C[?]`, where `X` is `C`'s type parameter corresponding to the `_` argument,
          *  compare with `C[p.X]` instead. Otherwise approximate based on variance.
          *  Also do a capture conversion in either of the following cases:
          *
@@ -1459,7 +1459,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
       // or like:
       //
       //    class C[T]
-      //    C[_] <: C[TV]
+      //    C[?] <: C[TV]
       //
       // where TV is a type variable. See i2397.scala for an example of the latter.
       def matchAbstractTypeMember(info1: Type) = info1 match {

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -409,9 +409,9 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
 
           for (sym <- lazyRefs) {
 
-            // If symbol `S` has an F-bound such as `C[_, S]` that contains wildcards,
+            // If symbol `S` has an F-bound such as `C[?, S]` that contains wildcards,
             // add a modifieed bound where wildcards are skolemized as a GADT bound for `S`.
-            // E.g. for `C[_, S]` we would add `C[C[_, S]#T0, S]` where `T0` is the first
+            // E.g. for `C[?, S]` we would add `C[C[?, S]#T0, S]` where `T0` is the first
             // type parameter of `C`. The new bound is added as a GADT bound for `S` in
             // `checkCtx`.
             // This mirrors what we do for the bounds that are checked and allows us thus

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1066,7 +1066,7 @@ object Types {
   	 * 	      ArrayBuffer[Int] | ArrayBuffer[A]
   	 *
      *  is approximated by constraining `A` to be =:= to `Int` and returning `ArrayBuffer[Int]`
-     *  instead of `ArrayBuffer[_ >: Int | A <: Int & A]`
+     *  instead of `ArrayBuffer[? >: Int | A <: Int & A]`
      */
     def widenUnion(implicit ctx: Context): Type = widen match {
       case OrType(tp1, tp2) =>
@@ -4380,11 +4380,11 @@ object Types {
               // Given a SAM type such as:
               //
               //     import java.util.function.Function
-              //     Function[_ >: String, _ <: Int]
+              //     Function[? >: String, ? <: Int]
               //
               // the single abstract method will have type:
               //
-              //     (x: Function[_ >: String, _ <: Int]#T): Function[_ >: String, _ <: Int]#R
+              //     (x: Function[? >: String, ? <: Int]#T): Function[? >: String, ? <: Int]#R
               //
               // which is not implementable outside of the scope of Function.
               //
@@ -4700,7 +4700,7 @@ object Types {
             // hence we can replace with U under all variances
             reapply(alias.rewrapAnnots(tp1))
           case tp: TypeBounds =>
-            // If H#T = _ >: S <: U, then for any x in L..H, S <: x.T <: U,
+            // If H#T = ? >: S <: U, then for any x in L..H, S <: x.T <: U,
             // hence we can replace with S..U under all variances
             expandBounds(tp)
           case info: SingletonType =>

--- a/compiler/src/dotty/tools/dotc/core/Uniques.scala
+++ b/compiler/src/dotty/tools/dotc/core/Uniques.scala
@@ -14,7 +14,7 @@ import util.HashSet
 object Uniques {
 
   private def recordCaching(tp: Type): Unit = recordCaching(tp.hash, tp.getClass)
-  private def recordCaching(h: Int, clazz: Class[_]): Unit =
+  private def recordCaching(h: Int, clazz: Class[?]): Unit =
     if (h == NotCached) {
       record("uncached-types")
       record(s"uncached: $clazz")

--- a/compiler/src/dotty/tools/dotc/core/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/core/quoted/PickledQuotes.scala
@@ -42,7 +42,7 @@ object PickledQuotes {
   }
 
   /** Transform the expression into its fully spliced TypeTree */
-  def quotedTypeToTree(tpe: quoted.Type[_])(implicit ctx: Context): Tree = {
+  def quotedTypeToTree(tpe: quoted.Type[?])(implicit ctx: Context): Tree = {
     val tpe1 = tpe.asInstanceOf[TreeType[Tree]]
     QuoteContext.checkScopeId(tpe1.scopeId)
     healOwner(tpe1.typeTree)

--- a/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -53,16 +53,16 @@ class PositionPickler(pickler: TastyPickler, addrOfTree: untpd.Tree => Addr) {
     def alwaysNeedsPos(x: Positioned) = x match {
       case
           // initialSpan is inaccurate for trees with lazy field
-          _: WithLazyField[_]
+          _: WithLazyField[?]
 
           // A symbol is created before the corresponding tree is unpickled,
           // and its position cannot be changed afterwards.
           // so we cannot use the tree initialSpan to set the symbol position.
           // Instead, we always pickle the position of definitions.
-          | _: Trees.DefTree[_]
+          | _: Trees.DefTree[?]
 
           // package defs might be split into several Tasty files
-          | _: Trees.PackageDef[_]
+          | _: Trees.PackageDef[?]
           // holes can change source files when filled, which means
           // they might lose their position
           | _: TreePickler.Hole => true

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1275,11 +1275,11 @@ class TreeUnpickler(reader: TastyReader,
         else new TreeType(arg, QuoteContext.scopeId)
       val reifiedArgs = args.map(wrap)
       val filled = if (isType) {
-        val quotedType = splice.asInstanceOf[Seq[Any] => quoted.Type[_]](reifiedArgs)
+        val quotedType = splice.asInstanceOf[Seq[Any] => quoted.Type[?]](reifiedArgs)
         PickledQuotes.quotedTypeToTree(quotedType)
       }
       else {
-        val splice1 = splice.asInstanceOf[Seq[Any] => given scala.quoted.QuoteContext => quoted.Expr[_]]
+        val splice1 = splice.asInstanceOf[Seq[Any] => given scala.quoted.QuoteContext => quoted.Expr[?]]
         val quotedExpr = splice1(reifiedArgs) given dotty.tools.dotc.quoted.QuoteContext()
         PickledQuotes.quotedExprToTree(quotedExpr)
       }

--- a/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
@@ -47,7 +47,7 @@ class ReadTasty extends Phase {
                 unit.pickled += (cls -> unpickler.unpickler.bytes)
                 Some(unit)
               }
-            case tree: Tree[_] =>
+            case tree: Tree[?] =>
                alreadyLoaded()
             case _ =>
               cannotUnpickle(s"its class file does not have a TASTY attribute")

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -69,8 +69,8 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
       // 9+, we can safely ignore it for now because it's only used for the
       // standard Java library, but this will change once we start supporting
       // adding entries to the modulepath.
-      val zipCps = cps.collect { case cp: ZipArchiveFileLookup[_] => cp }
-      val dirCps = cps.collect { case cp: JFileDirectoryLookup[_] => cp }
+      val zipCps = cps.collect { case cp: ZipArchiveFileLookup[?] => cp }
+      val dirCps = cps.collect { case cp: JFileDirectoryLookup[?] => cp }
       (zipCps, dirCps)
     case _ =>
       (Seq(), Seq())

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2119,7 +2119,7 @@ object Parsers {
         (lookahead.token == LPAREN) && {
           lookahead.nextToken()
           if (lookahead.token == RPAREN)
-            !fn.isInstanceOf[Trees.Apply[_]] // allow one () as annotation argument
+            !fn.isInstanceOf[Trees.Apply[?]] // allow one () as annotation argument
           else if (lookahead.token == IDENTIFIER) {
             lookahead.nextToken()
             lookahead.token != COLON

--- a/compiler/src/dotty/tools/dotc/plugins/Plugin.scala
+++ b/compiler/src/dotty/tools/dotc/plugins/Plugin.scala
@@ -77,7 +77,7 @@ object Plugin {
     new java.net.URLClassLoader(urls.toArray, compilerLoader)
   }
 
-  type AnyClass = Class[_]
+  type AnyClass = Class[?]
 
   /** Use a class loader to load the plugin class.
    */

--- a/compiler/src/dotty/tools/dotc/printing/DecompilerPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/DecompilerPrinter.scala
@@ -32,7 +32,7 @@ class DecompilerPrinter(_ctx: Context) extends RefinedPrinter(_ctx) {
 
   override protected def packageDefText(tree: PackageDef): Text = {
     val stats = tree.stats.filter {
-      case vdef: ValDef[_] => !vdef.symbol.is(Module)
+      case vdef: ValDef[?] => !vdef.symbol.is(Module)
       case _ => true
     }
     val statsText = stats match {

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -38,7 +38,7 @@ object Formatting {
     }
 
     private def treatArg(arg: Any, suffix: String)(implicit ctx: Context): (Any, String) = arg match {
-      case arg: Seq[_] if suffix.nonEmpty && suffix.head == '%' =>
+      case arg: Seq[?] if suffix.nonEmpty && suffix.head == '%' =>
         val (rawsep, rest) = suffix.tail.span(_ != '%')
         val sep = StringContext.processEscapes(rawsep)
         if (rest.nonEmpty) (arg.map(showArg).mkString(sep), rest.tail)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -103,7 +103,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
     (refinementNameString(rt) ~ toTextRHS(rt.refinedInfo)).close
 
   protected def argText(arg: Type): Text = homogenizeArg(arg) match {
-    case arg: TypeBounds => "_" ~ toText(arg)
+    case arg: TypeBounds => "?" ~ toText(arg)
     case arg => toText(arg)
   }
 
@@ -505,7 +505,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   def toText[T >: Untyped](tree: Tree[T]): Text = {
     def toTextElem(elem: Any): Text = elem match {
       case elem: Showable => elem.toText(this)
-      case elem: List[_] => "List(" ~ Text(elem map toTextElem, ",") ~ ")"
+      case elem: List[?] => "List(" ~ Text(elem map toTextElem, ",") ~ ")"
       case elem => elem.toString
     }
     val nodeName = tree.productPrefix

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -37,7 +37,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
 
   override protected[this] implicit def ctx: Context = myCtx
 
-  def withEnclosingDef(enclDef: Tree[_ >: Untyped])(op: => Text): Text = {
+  def withEnclosingDef(enclDef: Tree[? >: Untyped])(op: => Text): Text = {
     val savedCtx = myCtx
     if (enclDef.hasType && enclDef.symbol.exists)
       myCtx = ctx.withOwner(enclDef.symbol)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -323,7 +323,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       def selectorText(sel: Tree): Text = sel match {
         case Thicket(l :: r :: Nil) => toTextGlobal(l) ~ " => " ~ toTextGlobal(r)
         case _: Ident => toTextGlobal(sel)
-        case TypeBoundsTree(_, tpt) => "for " ~ toTextGlobal(tpt)
+        case TypeBoundsTree(_, tpt) => "_: " ~ toTextGlobal(tpt)
       }
       val selectorsText: Text = selectors match {
         case id :: Nil => toText(id)
@@ -334,7 +334,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     }
 
     tree match {
-      case id: Trees.SearchFailureIdent[_] =>
+      case id: Trees.SearchFailureIdent[?] =>
         tree.typeOpt match {
           case reason: Implicits.SearchFailureType =>
             toText(id.name) ~ "implicitly[" ~ toText(reason.clarify(reason.expectedType)) ~ "]"
@@ -403,7 +403,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case block: Block =>
         blockToText(block)
       case If(cond, thenp, elsep) =>
-        val isInline = tree.isInstanceOf[Trees.InlineIf[_]]
+        val isInline = tree.isInstanceOf[Trees.InlineIf[?]]
         changePrec(GlobalPrec) {
           keywordStr(if (isInline) "inline if " else "if ") ~
           toText(cond) ~ (keywordText(" then") provided !cond.isInstanceOf[Parens]) ~~
@@ -413,7 +413,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         "closure(" ~ (toTextGlobal(env, ", ") ~ " | " provided env.nonEmpty) ~
         toTextGlobal(ref) ~ (":" ~ toText(target) provided !target.isEmpty) ~ ")"
       case Match(sel, cases) =>
-        val isInline = tree.isInstanceOf[Trees.InlineMatch[_]]
+        val isInline = tree.isInstanceOf[Trees.InlineMatch[?]]
         if (sel.isEmpty && !isInline) blockText(cases)
         else changePrec(GlobalPrec) {
           val selTxt: Text =
@@ -637,7 +637,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         // with the original types before they are rewritten, which causes a discrepancy.
 
     def suppressPositions = tree match {
-      case _: WithoutTypeOrPos[_] | _: TypeTree => true // TypeTrees never have an interesting position
+      case _: WithoutTypeOrPos[?] | _: TypeTree => true // TypeTrees never have an interesting position
       case _ => false
     }
 
@@ -730,7 +730,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     }
     else toText(tree.name) ~ idText(tree)
 
-  private def toTextOwner(tree: Tree[_]) =
+  private def toTextOwner(tree: Tree[?]) =
     "[owner = " ~ tree.symbol.maybeOwner.show ~ "]" provided ctx.settings.YprintDebugOwners.value
 
   protected def dclTextOr[T >: Untyped](tree: Tree[T])(treeText: => Text): Text =

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -305,10 +305,10 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       else ""
 
     def argText(arg: Tree): Text = arg match {
-      case arg: TypeBoundsTree => "_" ~ toTextGlobal(arg)
+      case arg: TypeBoundsTree => "?" ~ toTextGlobal(arg)
       case arg: TypeTree =>
         arg.typeOpt match {
-          case tp: TypeBounds => "_" ~ toTextGlobal(arg)
+          case tp: TypeBounds => "?" ~ toTextGlobal(arg)
           case _ => toTextGlobal(arg)
         }
       case _ => toTextGlobal(arg)

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -182,7 +182,7 @@ trait Reporting { this: Context =>
     if (this.settings.Ydebug.value) warning(msg, pos)
 
   private def addInlineds(pos: SourcePosition)(implicit ctx: Context) = {
-    def recur(pos: SourcePosition, inlineds: List[Trees.Tree[_]]): SourcePosition = inlineds match {
+    def recur(pos: SourcePosition, inlineds: List[Trees.Tree[?]]): SourcePosition = inlineds match {
       case inlined :: inlineds1 => pos.withOuter(recur(inlined.sourcePos, inlineds1))
       case Nil => pos
     }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -226,7 +226,7 @@ object messages {
       """
         |object TyperDemo {
         |  class Team[A]
-        |  val team = new Team[_]
+        |  val team = new Team[?]
         |}
       """.stripMargin
 
@@ -323,7 +323,7 @@ object messages {
         }
 
       // Calculate Levenshtein distance
-      def distance(n1: Iterable[_], n2: Iterable[_]) =
+      def distance(n1: Iterable[?], n2: Iterable[?]) =
         n1.foldLeft(List.range(0, n2.size)) { (prev, x) =>
           (prev zip prev.tail zip n2).scanLeft(prev.head + 1) {
             case (h, ((d, v), y)) => math.min(
@@ -1034,7 +1034,7 @@ object messages {
            |
            |Try using a wildcard type variable
            |
-           |${hl("List[_]")}
+           |${hl("List[?]")}
            |"""
   }
 
@@ -1060,7 +1060,7 @@ object messages {
            |- Type arguments
            |
            |  Instead of:
-           |    ${hl("val foo = List[_](1, 2)")}
+           |    ${hl("val foo = List[?](1, 2)")}
            |
            |  Use:
            |    ${hl("val foo = List[Int](1, 2)")}

--- a/compiler/src/dotty/tools/dotc/sbt/ThunkHolder.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ThunkHolder.scala
@@ -10,7 +10,7 @@ import xsbti.api
  *  that may be evaluated once.
  */
 private[sbt] trait ThunkHolder {
-  private[this] val thunks = new ListBuffer[api.Lazy[_]]
+  private[this] val thunks = new ListBuffer[api.Lazy[?]]
 
   /** Force all unevaluated thunks to prevent space leaks. */
   @tailrec protected final def forceThunks(): Unit = if (!thunks.isEmpty) {

--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -33,10 +33,10 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   // QUOTE UNPICKLING
   //
 
-  def unpickleExpr(repr: Unpickler.PickledQuote, args: Unpickler.PickledExprArgs): scala.quoted.Expr[_] =
+  def unpickleExpr(repr: Unpickler.PickledQuote, args: Unpickler.PickledExprArgs): scala.quoted.Expr[?] =
     new scala.internal.quoted.TastyTreeExpr(PickledQuotes.unpickleExpr(repr, args), compilerId)
 
-  def unpickleType(repr: Unpickler.PickledQuote, args: Unpickler.PickledTypeArgs): scala.quoted.Type[_] =
+  def unpickleType(repr: Unpickler.PickledQuote, args: Unpickler.PickledTypeArgs): scala.quoted.Type[?] =
     new scala.internal.quoted.TreeType(PickledQuotes.unpickleType(repr, args), compilerId)
 
   //
@@ -1068,7 +1068,7 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
     case _ => Some(x)
   }
 
-  def Type_apply(clazz: Class[_]) given (ctx: Context): Type =
+  def Type_apply(clazz: Class[?]) given (ctx: Context): Type =
     if (clazz.isPrimitive)
       if (clazz == classOf[Boolean]) defn.BooleanType
       else if (clazz == classOf[Byte]) defn.ByteType
@@ -1729,12 +1729,12 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   // QUOTED SEAL/UNSEAL
   //
 
-  /** View this expression `quoted.Expr[_]` as a `Term` */
-  def QuotedExpr_unseal(self: scala.quoted.Expr[_]) given Context: Term =
+  /** View this expression `quoted.Expr[?]` as a `Term` */
+  def QuotedExpr_unseal(self: scala.quoted.Expr[?]) given Context: Term =
     PickledQuotes.quotedExprToTree(self)
 
-  /** View this expression `quoted.Type[_]` as a `TypeTree` */
-  def QuotedType_unseal(self: scala.quoted.Type[_]) given Context: TypeTree =
+  /** View this expression `quoted.Type[?]` as a `TypeTree` */
+  def QuotedType_unseal(self: scala.quoted.Type[?]) given Context: TypeTree =
     PickledQuotes.quotedTypeToTree(self)
 
   /** Convert `Term` to an `quoted.Expr[Any]`  */
@@ -1754,7 +1754,7 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   }
 
   /** Checked cast to a `quoted.Expr[U]` */
-  def QuotedExpr_cast[U](self: scala.quoted.Expr[_]) given (tp: scala.quoted.Type[U], ctx: Context): scala.quoted.Expr[U] = {
+  def QuotedExpr_cast[U](self: scala.quoted.Expr[?]) given (tp: scala.quoted.Type[U], ctx: Context): scala.quoted.Expr[U] = {
     val tree = QuotedExpr_unseal(self)
     val expectedType = QuotedType_unseal(tp).tpe
     if (tree.tpe <:< expectedType)
@@ -1767,8 +1767,8 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
       )
   }
 
-  /** Convert `Type` to an `quoted.Type[_]` */
-  def QuotedType_seal(self: Type) given (ctx: Context): scala.quoted.Type[_] = {
+  /** Convert `Type` to an `quoted.Type[?]` */
+  def QuotedType_seal(self: Type) given (ctx: Context): scala.quoted.Type[?] = {
     val dummySpan = ctx.owner.span // FIXME
     new scala.internal.quoted.TreeType(tpd.TypeTree(self).withSpan(dummySpan), compilerId)
   }
@@ -1925,7 +1925,7 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   // HELPERS
   //
 
-  private def optional[T <: Trees.Tree[_]](tree: T): Option[tree.type] =
+  private def optional[T <: Trees.Tree[?]](tree: T): Option[tree.type] =
     if (tree.isEmpty) None else Some(tree)
 
   private def withDefaultPos[T <: Tree](fn: given Context => T) given (ctx: Context): T =

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -128,9 +128,9 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
    *
    *  A bridge is necessary because the following hold
    *    - the varargs in `ddef` will change from `RepeatedParam[T]` to `Seq[T]` after this phase
-   *    - _but_ the callers of `ddef` expect its varargs to be changed to `Array[_ <: T]`, since it overrides
+   *    - _but_ the callers of `ddef` expect its varargs to be changed to `Array[? <: T]`, since it overrides
    *      a Java varargs
-   *  The solution is to add a "bridge" method that converts its argument from `Array[_ <: T]` to `Seq[T]` and
+   *  The solution is to add a "bridge" method that converts its argument from `Array[? <: T]` to `Seq[T]` and
    *  forwards it to `ddef`.
    */
   private def addVarArgsBridge(ddef: DefDef)(implicit ctx: Context): Tree = {
@@ -141,7 +141,7 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
     val bridgeDef = polyDefDef(bridge, trefs => vrefss => {
       val (vrefs :+ varArgRef) :: vrefss1 = vrefss
       // Can't call `.argTypes` here because the underlying array type is of the
-      // form `Array[_ <: SomeType]`, so we need `.argInfos` to get the `TypeBounds`.
+      // form `Array[? <: SomeType]`, so we need `.argInfos` to get the `TypeBounds`.
       val elemtp = varArgRef.tpe.widen.argInfos.head
       ref(original.termRef)
         .appliedToTypes(trefs)

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -165,7 +165,7 @@ object ExplicitOuter {
    *  - if owner == cls, O[X1, ..., Xn]
    *  - otherwise, if the class P enclosing `owner` derives from O, the
    *    base type of P.this wrt class O
-   *  - otherwise O[_, ..., _]
+   *  - otherwise O[?, ..., ?]
    */
   private def newOuterSym(owner: ClassSymbol, cls: ClassSymbol, name: TermName, flags: FlagSet)(implicit ctx: Context) = {
     val outerThis = owner.owner.enclosingClass.thisType

--- a/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
@@ -434,13 +434,13 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
   }
 
   /** Class#getDeclaredMethods is slow, so we cache its output */
-  private val clsMethodsCache = new java.util.IdentityHashMap[Class[_], Array[java.lang.reflect.Method]]
+  private val clsMethodsCache = new java.util.IdentityHashMap[Class[?], Array[java.lang.reflect.Method]]
 
   /** Does `phase` contain a redefinition of method `name`?
    *  (which is a method of MiniPhase)
    */
   private def defines(phase: MiniPhase, name: String) = {
-    def hasRedefinedMethod(cls: Class[_]): Boolean =
+    def hasRedefinedMethod(cls: Class[?]): Boolean =
       if (cls.eq(classOf[MiniPhase])) false
       else {
         var clsMethods = clsMethodsCache.get(cls)

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -305,9 +305,9 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
             // conform to selector bounds. I.e. assume
             //     type Tree[T >: Null <: Type]
             // One is still allowed to write
-            //     case x: Tree[_]
+            //     case x: Tree[?]
             // (which translates to)
-            //     case x: (_: Tree[_])
+            //     case x: (_: Tree[?])
         case tree =>
           super.transform(tree)
       }

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -313,12 +313,12 @@ object Splicer {
         clazz.getConstructor().newInstance().asInstanceOf[Object]
       }
 
-    private def loadReplLineClass(moduleClass: Symbol)(implicit env: Env): Class[_] = {
+    private def loadReplLineClass(moduleClass: Symbol)(implicit env: Env): Class[?] = {
       val lineClassloader = new AbstractFileClassLoader(ctx.settings.outputDir.value, classLoader)
       lineClassloader.loadClass(moduleClass.name.firstPart.toString)
     }
 
-    private def loadClass(name: String): Class[_] =
+    private def loadClass(name: String): Class[?] =
       try classLoader.loadClass(name)
       catch {
         case _: ClassNotFoundException =>
@@ -326,7 +326,7 @@ object Splicer {
           throw new StopInterpretation(msg, pos)
       }
 
-    private def getMethod(clazz: Class[_], name: Name, paramClasses: List[Class[_]]): Method =
+    private def getMethod(clazz: Class[?], name: Name, paramClasses: List[Class[?]]): Method =
       try clazz.getMethod(name.toString, paramClasses: _*)
       catch {
         case _: NoSuchMethodException =>
@@ -364,8 +364,8 @@ object Splicer {
       }
 
     /** List of classes of the parameters of the signature of `sym` */
-    private def paramsSig(sym: Symbol): List[Class[_]] = {
-      def paramClass(param: Type): Class[_] = {
+    private def paramsSig(sym: Symbol): List[Class[?]] = {
+      def paramClass(param: Type): Class[?] = {
         def arrayDepth(tpe: Type, depth: Int): (Type, Int) = tpe match {
           case JavaArrayType(elemType) => arrayDepth(elemType, depth + 1)
           case _ => (tpe, depth)

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -396,7 +396,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
      *  ```
      *  where
      *  ```
-     *  type MirroredMonoType = C[_]
+     *  type MirroredMonoType = C[?]
      *  ```
      */
     def fromProductBody(caseClass: Symbol, param: Tree)(implicit ctx: Context): Tree = {
@@ -438,7 +438,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
    *        case _: C_n => n - 1
    *     }
    *
-   *  Here, the normalized type of a class C is C[_, ...., _] with
+   *  Here, the normalized type of a class C is C[?, ...., ?] with
    *  a wildcard for each type parameter. The normalized type of an object
    *  O is O.type.
    */

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -294,7 +294,7 @@ class TreeChecker extends Phase with SymTransformer {
 
     override def typedUnadapted(tree: untpd.Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): Tree = {
       val res = tree match {
-        case _: untpd.TypedSplice | _: untpd.Thicket | _: EmptyValDef[_] =>
+        case _: untpd.TypedSplice | _: untpd.Thicket | _: EmptyValDef[?] =>
           super.typedUnadapted(tree, pt, locked)
         case _ if tree.isType =>
           promote(tree)

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -368,7 +368,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
   /** Erase pattern bound types with WildcardType
    *
-   *  For example, the type `C[T$1]` should match any `C[_]`, thus
+   *  For example, the type `C[T$1]` should match any `C[?]`, thus
    *  `v` should be `WildcardType` instead of `T$1`:
    *
    *     sealed trait B
@@ -377,7 +377,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
    *        case C(v) =>      //    case C.unapply[T$1 @ T$1](v @ _):C[T$1]
    *     }
    *
-   *  However, we cannot use WildcardType for Array[_], due to that
+   *  However, we cannot use WildcardType for Array[?], due to that
    *  `Array[WildcardType] <: Array[Array[WildcardType]]`, which may
    *  cause false unreachable warnings. See tests/patmat/t2425.scala
    *

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -464,7 +464,7 @@ trait Applications extends Compatibility {
         case mr => mr.tpe.normalizedPrefix match {
           case mr: TermRef => ref(mr)
           case mr =>
-            if (this.isInstanceOf[TestApplication[_]])
+            if (this.isInstanceOf[TestApplication[?]])
               // In this case it is safe to skolemize now; we will produce a stable prefix for the actual call.
               ref(mr.narrow)
             else
@@ -729,7 +729,7 @@ trait Applications extends Compatibility {
     /** The index of the first difference between lists of trees `xs` and `ys`
      *  -1 if there are no differences.
      */
-    private def firstDiff[T <: Trees.Tree[_]](xs: List[T], ys: List[T], n: Int = 0): Int = xs match {
+    private def firstDiff[T <: Trees.Tree[?]](xs: List[T], ys: List[T], n: Int = 0): Int = xs match {
       case x :: xs1 =>
         ys match {
           case y :: ys1 => if (x ne y) n else firstDiff(xs1, ys1, n + 1)
@@ -741,7 +741,7 @@ trait Applications extends Compatibility {
           case nil => -1
         }
     }
-    private def sameSeq[T <: Trees.Tree[_]](xs: List[T], ys: List[T]): Boolean = firstDiff(xs, ys) < 0
+    private def sameSeq[T <: Trees.Tree[?]](xs: List[T], ys: List[T]): Boolean = firstDiff(xs, ys) < 0
 
     val result:   Tree = {
       var typedArgs = typedArgBuf.toList

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1133,7 +1133,7 @@ trait Implicits { self: Typer =>
   def missingArgMsg(arg: Tree, pt: Type, where: String)(implicit ctx: Context): String = {
 
     def msg(shortForm: String)(headline: String = shortForm) = arg match {
-      case arg: Trees.SearchFailureIdent[_] =>
+      case arg: Trees.SearchFailureIdent[?] =>
         shortForm
       case _ =>
         arg.tpe match {

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -193,7 +193,7 @@ object Inferencing {
     @tailrec def boundVars(tree: Tree, acc: List[TypeVar]): List[TypeVar] = tree match {
       case Apply(fn, _) => boundVars(fn, acc)
       case TypeApply(fn, targs) =>
-        val tvars = targs.filter(_.isInstanceOf[TypeVarBinder[_]]).tpes.collect {
+        val tvars = targs.filter(_.isInstanceOf[TypeVarBinder[?]]).tpes.collect {
           case tvar: TypeVar
           if !tvar.isInstantiated &&
              ctx.typerState.ownedVars.contains(tvar) &&

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -149,7 +149,7 @@ object Inliner {
       def reposition(tree: Tree)(implicit ctx: Context): Tree = enclosingInlineds match {
         case call :: _ if call.symbol.source != curSource =>
           tree match {
-            case _: EmptyTree[_] | _: EmptyValDef[_] => tree
+            case _: EmptyTree[?] | _: EmptyValDef[?] => tree
             case _ =>
               // Until we implement JSR-45, we cannot represent in output positions in other source files.
               // So, reposition inlined code from other files with the call position:
@@ -172,7 +172,7 @@ object Inliner {
           case tree: DefTree => super.transform(tree).setDefTree
           case _ => super.transform(tree)
         })
-        assert(transformed.isInstanceOf[EmptyTree[_]] || transformed.isInstanceOf[EmptyValDef[_]] || transformed.source == curSource)
+        assert(transformed.isInstanceOf[EmptyTree[?]] || transformed.isInstanceOf[EmptyValDef[?]] || transformed.source == curSource)
         transformed
       }
     }
@@ -690,7 +690,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
      */
     private object InlineableArg {
       lazy val paramProxies = paramProxy.values.toSet
-      def unapply(tree: Trees.Ident[_])(implicit ctx: Context): Option[Tree] = {
+      def unapply(tree: Trees.Ident[?])(implicit ctx: Context): Option[Tree] = {
         def search(buf: mutable.ListBuffer[ValOrDefDef]) = buf.find(_.name == tree.name)
         if (paramProxies.contains(tree.typeOpt))
           search(bindingsBuf) match {

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1596,9 +1596,9 @@ class RefChecks extends MiniPhase { thisPhase =>
               //         that we are in the user-supplied code in the case body.
               //
               //         Relies on the translation of:
-              //            (null: Any) match { case x: List[_] => x; x.reverse; case _ => }'
+              //            (null: Any) match { case x: List[?] => x; x.reverse; case _ => }'
               //         to:
-              //            <synthetic> val x2: List[_] = (x1.asInstanceOf[List[_]]: List[_]);
+              //            <synthetic> val x2: List[?] = (x1.asInstanceOf[List[?]]: List[?]);
               //                  matchEnd4({ x2; x2.reverse}) // case body is an argument to a label apply.
               inPattern = false
               super.transform(result)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1285,7 +1285,7 @@ class Typer extends Namer
       val elemtptType =
         if (isFullyDefined(elemProto, ForceDegree.none))
           elemProto
-        else if (tree.elems.isEmpty && tree.isInstanceOf[Trees.JavaSeqLiteral[_]])
+        else if (tree.elems.isEmpty && tree.isInstanceOf[Trees.JavaSeqLiteral[?]])
           defn.ObjectType // generic empty Java varargs are of type Object[]
         else
           ctx.typeComparer.lub(elems1.tpes)
@@ -1386,8 +1386,8 @@ class Typer extends Namer
                  tpt1.tpe.typeParamSymbols.nonEmpty &&
                  !ctx.mode.is(Mode.Pattern) =>
                 // An unbounded `_` automatically adapts to type parameter bounds. This means:
-                // If we have wildcard application C[_], where `C` is a class replace
-                // with C[_ >: L <: H] where `L` and `H` are the bounds of the corresponding
+                // If we have wildcard application C[?], where `C` is a class replace
+                // with C[? >: L <: H] where `L` and `H` are the bounds of the corresponding
                 // type parameter in `C`.
                 // The transform does not apply for patterns, where empty bounds translate to
                 // wildcard identifiers `_` instead.
@@ -3001,7 +3001,7 @@ class Typer extends Namer
     }
 
     tree match {
-      case _: MemberDef | _: PackageDef | _: Import | _: WithoutTypeOrPos[_] | _: Closure => tree
+      case _: MemberDef | _: PackageDef | _: Import | _: WithoutTypeOrPos[?] | _: Closure => tree
       case _ => tree.tpe.widen match {
         case tp: FlexType =>
           ensureReported(tp)

--- a/compiler/src/dotty/tools/dotc/util/Attachment.scala
+++ b/compiler/src/dotty/tools/dotc/util/Attachment.scala
@@ -13,7 +13,7 @@ object Attachment {
    *  Clients should inherit from Container instead.
    */
   trait LinkSource {
-    private[Attachment] var next: Link[_]
+    private[Attachment] var next: Link[?]
 
     /** Optionally get attachment corresponding to `key` */
     final def getAttachment[V](key: Key[V]): Option[V] = {
@@ -84,7 +84,7 @@ object Attachment {
     }
 
     /** The list of all keys and values attached to this container. */
-    final def allAttachments: List[(Key[_], Any)] = {
+    final def allAttachments: List[(Key[?], Any)] = {
       val nx = next
       if (nx == null) Nil else (nx.key, nx.value) :: nx.allAttachments
     }
@@ -92,18 +92,18 @@ object Attachment {
 
   /** A private, concrete implementation class linking attachments.
    */
-  private[Attachment] class Link[+V](val key: Key[V], val value: V, var next: Link[_])
+  private[Attachment] class Link[+V](val key: Key[V], val value: V, var next: Link[?])
       extends LinkSource
 
   /** A trait for objects that can contain attachments */
   trait Container extends LinkSource {
-    private[Attachment] var next: Link[_] = null
+    private[Attachment] var next: Link[?] = null
 
     /** Copy the sticky attachments from `container` to this container. */
     final def withAttachmentsFrom(container: Container): this.type = {
-      var current: Link[_] = container.next
+      var current: Link[?] = container.next
       while (current != null) {
-        if (current.key.isInstanceOf[StickyKey[_]]) pushAttachment(current.key, current.value)
+        if (current.key.isInstanceOf[StickyKey[?]]) pushAttachment(current.key, current.value)
         current = current.next
       }
       this

--- a/compiler/src/dotty/tools/dotc/util/SimpleIdentitySet.scala
+++ b/compiler/src/dotty/tools/dotc/util/SimpleIdentitySet.scala
@@ -148,7 +148,7 @@ object SimpleIdentitySet {
     }
     override def ++ [E >: Elem <: AnyRef](that: SimpleIdentitySet[E]): SimpleIdentitySet[E] =
       that match {
-        case that: SetN[_] =>
+        case that: SetN[?] =>
           var toAdd: mutable.ArrayBuffer[AnyRef] = null
           var i = 0
           val limit = that.xs.length
@@ -176,7 +176,7 @@ object SimpleIdentitySet {
       }
     override def -- [E >: Elem <: AnyRef](that: SimpleIdentitySet[E]): SimpleIdentitySet[E] =
       that match {
-        case that: SetN[_] =>
+        case that: SetN[?] =>
           // both sets are large, optimize assuming they are similar
           // by starting from empty set and adding elements
           var toAdd: mutable.ArrayBuffer[AnyRef] = null

--- a/compiler/src/dotty/tools/repl/AbstractFileClassLoader.scala
+++ b/compiler/src/dotty/tools/repl/AbstractFileClassLoader.scala
@@ -11,7 +11,7 @@ import io.AbstractFile
 class AbstractFileClassLoader(root: AbstractFile, parent: ClassLoader)
 extends ClassLoader(parent)
 {
-  override def findClass(name: String): Class[_] = {
+  override def findClass(name: String): Class[?] = {
     var file: AbstractFile = root
     val pathParts = name.split("[./]").toList
     for (dirPart <- pathParts.init) {
@@ -28,7 +28,7 @@ extends ClassLoader(parent)
     defineClass(name, bytes, 0, bytes.length)
   }
 
-  override def loadClass(name: String): Class[_] =
+  override def loadClass(name: String): Class[?] =
     try findClass(name)
     catch {
       case _: ClassNotFoundException => super.loadClass(name)

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -65,7 +65,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None) {
   private[this] def valueOf(sym: Symbol)(implicit ctx: Context): Option[String] = {
     val defn = ctx.definitions
     val objectName = sym.owner.fullName.encode.toString.stripSuffix("$")
-    val resObj: Class[_] = Class.forName(objectName, true, classLoader())
+    val resObj: Class[?] = Class.forName(objectName, true, classLoader())
     val value =
       resObj
         .getDeclaredMethods.find(_.getName == sym.name.encode.toString)

--- a/compiler/test-resources/pending/repl/i2554
+++ b/compiler/test-resources/pending/repl/i2554
@@ -1,7 +1,7 @@
-scala> object foo { trait ShapeLevel; trait FlatShapeLevel extends ShapeLevel; trait ColumnsShapeLevel extends FlatShapeLevel; abstract class Shape[Level <: ShapeLevel, -Mixed, Unpacked, Packed]; object Shape extends TupleShapeImplicits { }; trait TupleShapeImplicits { implicit final def tuple2Shape[Level <: ShapeLevel, M1,M2, U1,U2, P1,P2](implicit u1: Shape[_ <: Level, M1, U1, P1], u2: Shape[_ <: Level, M2, U2, P2]): Shape[Level, (M1,M2), (U1,U2), (P1,P2)] = ???; }; }
+scala> object foo { trait ShapeLevel; trait FlatShapeLevel extends ShapeLevel; trait ColumnsShapeLevel extends FlatShapeLevel; abstract class Shape[Level <: ShapeLevel, -Mixed, Unpacked, Packed]; object Shape extends TupleShapeImplicits { }; trait TupleShapeImplicits { implicit final def tuple2Shape[Level <: ShapeLevel, M1,M2, U1,U2, P1,P2](implicit u1: Shape[? <: Level, M1, U1, P1], u2: Shape[? <: Level, M2, U2, P2]): Shape[Level, (M1,M2), (U1,U2), (P1,P2)] = ???; }; }
 // defined object foo
 scala> import foo._
-scala> implicit val shape: Shape[_ <: FlatShapeLevel, Int, Int, _] = null
-implicit val shape: foo.Shape[_ <: foo.FlatShapeLevel, Int, Int, _] = null
+scala> implicit val shape: Shape[? <: FlatShapeLevel, Int, Int, ?] = null
+implicit val shape: foo.Shape[? <: foo.FlatShapeLevel, Int, Int, ?] = null
 scala> def hint = Shape.tuple2Shape(shape, shape)
 def hint: foo.Shape[foo.FlatShapeLevel, (Int, Int), (Int, Int), (_, _)]

--- a/compiler/test-resources/repl/getClass
+++ b/compiler/test-resources/repl/getClass
@@ -1,4 +1,4 @@
 scala> val xs = List(1)
 val xs: List[Int] = List(1)
 scala> xs.getClass
-val res0: Class[_] = class scala.collection.immutable.$colon$colon
+val res0: Class[?] = class scala.collection.immutable.$colon$colon

--- a/compiler/test-resources/type-printer/hkClass
+++ b/compiler/test-resources/type-printer/hkClass
@@ -1,4 +1,4 @@
-scala> case class Foo[M[_]](x: M[Int])
+scala> case class Foo[M[?]](x: M[Int])
 // defined case class Foo
 scala> Foo(Option(1))
 val res0: Foo[Option] = Foo(Some(1))

--- a/compiler/test/dotty/tools/CheckTypesTests.scala
+++ b/compiler/test/dotty/tools/CheckTypesTests.scala
@@ -17,7 +17,7 @@ class CheckTypeTest extends DottyTest {
     val types = List(
       "A",
       "B",
-      "List[_]",
+      "List[?]",
       "List[Int]",
       "List[AnyRef]",
       "List[String]",

--- a/compiler/test/dotty/tools/dotc/plugins/PluginsTest.scala
+++ b/compiler/test/dotty/tools/dotc/plugins/PluginsTest.scala
@@ -37,7 +37,7 @@ class PluginsTest {
     List(new P8)
   )
 
-  implicit def clazzToName(cls: Class[_]): String = cls.getName
+  implicit def clazzToName(cls: Class[?]): String = cls.getName
 
   def debugPlan(plan: List[List[Phase]]): Unit = {
     println(plan.mkString("plan:\n- ", "\n- ", ""))

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1028,7 +1028,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       """
         |object TyperDemo {
         |  class Team[A]
-        |  val team = new Team[_]
+        |  val team = new Team[?]
         |}""".stripMargin
     }
     .expect { (ictx, messages) =>

--- a/compiler/test/dotty/tools/dotc/typer/DivergenceChecker.scala
+++ b/compiler/test/dotty/tools/dotc/typer/DivergenceChecker.scala
@@ -21,7 +21,7 @@ class DivergenceCheckerTests extends DottyTest {
     val types = List(
       "A",
       "B",
-      "List[_]",
+      "List[?]",
       "List[Int]",
       "List[AnyRef]",
       "List[String]",
@@ -29,7 +29,7 @@ class DivergenceCheckerTests extends DottyTest {
       "List[List[(A, B) { type Baz = Int }]] { type Foo = A }"
     )
 
-    val elements = List("A", "B", "Nothing", "Object", "String", "Tuple2[_, _]", "Int", "List[_]")
+    val elements = List("A", "B", "Nothing", "Object", "String", "Tuple2[?, ?]", "Int", "List[?]")
 
     checkTypes(source, List(types, elements)) {
       case (List(tpes, elements0), context) =>


### PR DESCRIPTION
Refactor dotty codebase so that we now use `?` instead of `_` for wildcard types