### PR TITLE
Add TASTy Reflect opaque API prototype

### DIFF
--- a/tests/pos/tasty-reflect-opaque-api-proto.scala
+++ b/tests/pos/tasty-reflect-opaque-api-proto.scala
@@ -1,0 +1,30 @@
+
+trait CompilerInterface {
+  type Tree
+  type Term <: Tree
+}
+
+class Reflect(val internal: CompilerInterface) {
+
+  opaque type Tree = internal.Tree
+  opaque type Term <: Tree = internal.Term
+
+  object Tree {
+    given Ops (tree: Tree) {
+      def show: String = ???
+    }
+  }
+
+}
+
+object App {
+  val refl: Reflect = ???
+  import refl._
+
+  val tree: Tree = ???
+  tree.show
+
+  val term: Term = ???
+  tree.show
+
+}


### PR DESCRIPTION
The motivation is to be able to define extension methods for the type members of the reflection API such as `Tree` without needing an `import given`. This work only if the type is opaque.