### PR TITLE
Add a placeholder Sbt page

### DIFF
--- a/docs/docs/contributing/tools/sbt.md
+++ b/docs/docs/contributing/tools/sbt.md
@@ -1,0 +1,9 @@
+---
+layout: doc-page
+title: Building Dotty with Sbt
+---
+
+Setup
+-----------
+
+TBD


### PR DESCRIPTION
This patch adds a placeholder page In order to avoid the confusion that
happens when the link to the Sbt page is followed on
https://dotty.epfl.ch/docs/

Signed-off-by: Nikita Eshkeev <kastolom@gmail.com>