### PR TITLE
remove the link to a non-existing sbt page

### DIFF
--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -191,8 +191,6 @@ sidebar:
               url: docs/contributing/tools/intellij-idea.html
             - title: Mill
               url: docs/contributing/tools/mill.html
-            - title: Sbt
-              url: docs/contributing/tools/sbt.html
             - title: Scalafix
               url: docs/contributing/tools/scalafix.html
         - title: Procedures


### PR DESCRIPTION
This patch removes the sbt section from the sidebar because there is no corresponding page to open