### PR TITLE
Upgrade sbt-sonatype, sbt-pgp

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,7 +27,7 @@ steps:
 
 - name: test
   pull: default
-  image: lampepfl/dotty:2019-08-22
+  image: lampepfl/dotty:2019-09-10
   depends_on: [ clone ]
   commands:
   - cp -R . /tmp/1/ && cd /tmp/1/
@@ -36,7 +36,7 @@ steps:
 
 - name: test_bootstrapped
   pull: default
-  image: lampepfl/dotty:2019-08-22
+  image: lampepfl/dotty:2019-09-10
   depends_on: [ clone ]
   commands:
   - cp -R . /tmp/2/ && cd /tmp/2/
@@ -45,7 +45,7 @@ steps:
 
 - name: community_build
   pull: default
-  image: lampepfl/dotty:2019-08-22
+  image: lampepfl/dotty:2019-09-10
   depends_on: [ clone ]
   commands:
   - cp -R . /tmp/3/ && cd /tmp/3/
@@ -54,7 +54,7 @@ steps:
 
 - name: test_sbt
   pull: default
-  image: lampepfl/dotty:2019-08-22
+  image: lampepfl/dotty:2019-09-10
   depends_on: [ clone ]
   commands:
   - cp -R . /tmp/4/ && cd /tmp/4/
@@ -66,7 +66,7 @@ steps:
 
 - name: test_java11
   pull: default
-  image: lampepfl/dotty:2019-08-22
+  image: lampepfl/dotty:2019-09-10
   depends_on: [ clone ]
   commands:
   - export PATH="/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH"
@@ -80,7 +80,7 @@ steps:
 
 - name: documentation
   pull: default
-  image: lampepfl/dotty:2019-08-22
+  image: lampepfl/dotty:2019-09-10
   depends_on:
   - test
   - test_bootstrapped
@@ -99,7 +99,7 @@ steps:
 
 - name: publish_nightly
   pull: default
-  image: lampepfl/dotty:2019-08-22
+  image: lampepfl/dotty:2019-09-10
   depends_on:
   - test
   - test_bootstrapped
@@ -126,7 +126,7 @@ steps:
 
 - name: publish_release
   pull: default
-  image: lampepfl/dotty:2019-08-22
+  image: lampepfl/dotty:2019-09-10
   depends_on:
   - test
   - test_bootstrapped
@@ -169,7 +169,7 @@ steps:
 
 - name: publish_sbt_release
   pull: default
-  image: lampepfl/dotty:2019-08-22
+  image: lampepfl/dotty:2019-09-10
   depends_on:
   - test
   - test_bootstrapped

--- a/.drone.yml
+++ b/.drone.yml
@@ -107,7 +107,7 @@ steps:
   - test_sbt
   - test_java11
   commands:
-  - ./project/scripts/sbtPublish ";dotty-bootstrapped/publishSigned ;sonatypeRelease"
+  - ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease"
   environment:
     NIGHTLYBUILD: yes
     PGP_PW:
@@ -135,7 +135,7 @@ steps:
   - test_java11
   commands:
   - ./project/scripts/sbt dist-bootstrapped/packArchive
-  - ./project/scripts/sbtPublish ";dotty-bootstrapped/publishSigned ;sonatypeRelease"
+  - ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease"
   environment:
     PGP_PW:
       from_secret: pgp_pw
@@ -177,7 +177,7 @@ steps:
   - test_sbt
   - test_java11
   commands:
-  - ./project/scripts/sbtPublish ";sbt-dotty/publishSigned ;sonatypeRelease"
+  - ./project/scripts/sbtPublish ";project sbt-dotty ;publishSigned ;sonatypeBundleRelease"
   environment:
     PGP_PW:
       from_secret: pgp_pw

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,6 +13,7 @@ import sbt.plugins.SbtPlugin
 import sbt.ScriptedPlugin.autoImport._
 import xerial.sbt.pack.PackPlugin
 import xerial.sbt.pack.PackPlugin.autoImport._
+import xerial.sbt.Sonatype.autoImport._
 
 import dotty.tools.sbtplugin.DottyPlugin.autoImport._
 import dotty.tools.sbtplugin.DottyPlugin.makeScalaInstance
@@ -198,7 +199,8 @@ object Build {
         password <- sys.env.get("SONATYPE_PW")
       } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)
     ).toList,
-    PgpKeys.pgpPassphrase := sys.env.get("PGP_PW").map(_.toCharArray())
+    PgpKeys.pgpPassphrase := sys.env.get("PGP_PW").map(_.toCharArray()),
+    PgpKeys.useGpgPinentry := true,
   )
 
   lazy val commonSettings = publishSettings ++ Seq(
@@ -1150,12 +1152,7 @@ object Build {
   lazy val publishSettings = Seq(
     publishMavenStyle := true,
     isSnapshot := version.value.contains("SNAPSHOT"),
-    publishTo := Some(
-      if (isSnapshot.value)
-        Opts.resolver.sonatypeSnapshots
-      else
-        Opts.resolver.sonatypeStaging
-    ),
+    publishTo := sonatypePublishToBundle.value,
     publishArtifact in Test := false,
     homepage := Some(url(dottyGithubUrl)),
     licenses += ("BSD New",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,9 +4,9 @@
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-M8")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.6")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0-M2")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.10.1")
 

--- a/project/scripts/sbtPublish
+++ b/project/scripts/sbtPublish
@@ -18,9 +18,9 @@ if [ ! "$NIGHTLYBUILD" = "yes" ] && [ ! "$RELEASEBUILD" = "yes" ]; then
     exit 1
 fi
 
-# Write down PGP secret key to the location expected by sbt-pgp
-mkdir -p "$HOME/.sbt/gpg"
-echo "$PGP_SECRET" > "$HOME/.sbt/gpg/secring.asc"
+# Setup gpg
+export GPG_TTY="$(tty)"
+echo "$PGP_SECRET" | gpg --batch --import
 
 # run sbt with the supplied arg
 SBT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/sbt"


### PR DESCRIPTION
The new sbt-sonatype adds a command to publish all modules in one
step (`sonatypeBundleRelease`) which should avoid getting into
inconsistent states (#7190, #6922).