### PR TITLE
Fix #3559: fix scope for typing this(...) in 2nd constructor

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -381,6 +381,8 @@ object Contexts {
       superOrThisCallContext(owner, constrCtx.scope)
         .setTyperState(typerState)
         .setGadt(gadt)
+        .fresh
+        .setScope(this.scope)
     }
 
     /** The super- or this-call context with given owner and locals. */

--- a/tests/neg/3559.check
+++ b/tests/neg/3559.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/3559.scala:3:9 -------------------------------------------------------------------------------------
+3 |    this(b)           // error: forward reference not allowed from self constructor invocation
+  |         ^
+  |         forward reference not allowed from self constructor invocation

--- a/tests/neg/3559.scala
+++ b/tests/neg/3559.scala
@@ -1,0 +1,6 @@
+class A(a: Any) {
+  def this() = {
+    this(b)           // error: forward reference not allowed from self constructor invocation
+    def b = new {}
+  }
+}

--- a/tests/neg/3559b.check
+++ b/tests/neg/3559b.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/3559b.scala:3:9 ------------------------------------------------------------------------------------
+3 |    this(b)           // error
+  |         ^
+  |         b is not accessible from constructor arguments

--- a/tests/neg/3559b.scala
+++ b/tests/neg/3559b.scala
@@ -1,0 +1,7 @@
+class A(a: Any) {
+  def this() = {
+    this(b)           // error
+  }
+
+  def b = new {}
+}

--- a/tests/neg/3559c.check
+++ b/tests/neg/3559c.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/3559c.scala:3:9 ------------------------------------------------------------------------------------
+3 |    this(a)           // error
+  |         ^
+  |         a is not accessible from constructor arguments

--- a/tests/neg/3559c.scala
+++ b/tests/neg/3559c.scala
@@ -1,0 +1,7 @@
+class A(a: Any) {
+  def this() = {
+    this(a)           // error
+  }
+
+  def b = new {}
+}

--- a/tests/neg/3559d.check
+++ b/tests/neg/3559d.check
@@ -1,0 +1,6 @@
+-- [E006] Unbound Identifier Error: tests/neg/3559d.scala:7:9 ----------------------------------------------------------
+7 |    this(f)           // error
+  |         ^
+  |         Not found: f
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/3559d.scala
+++ b/tests/neg/3559d.scala
@@ -1,0 +1,9 @@
+class B {
+  def f: String = "hello"
+}
+
+class A(a: Any) extends B {
+  def this() = {
+    this(f)           // error
+  }
+}


### PR DESCRIPTION
Fix #3559: fix scope for typing this(...) in 2nd constructor

The scope for typing `this(...)` should include both
constructor params and local defs. The latter are
included to provide more friendly error messages
for references to local definitions.