### PR TITLE
Drop implicit match and given match

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1648,11 +1648,8 @@ object Parsers {
 
     def expr(location: Location.Value): Tree = {
       val start = in.offset
-      if (closureMods.contains(in.token)) {
-        val imods = modifiers(closureMods)
-        if (in.token == MATCH) impliedMatch(start, imods)
-        else implicitClosure(start, location, imods)
-      }
+      if (closureMods.contains(in.token))
+        implicitClosure(start, location, modifiers(closureMods))
       else {
         val saved = placeholderParams
         placeholderParams = Nil
@@ -1853,30 +1850,6 @@ object Parsers {
           mkMatch(t, inBracesOrIndented(caseClauses(caseClause)))
         }
       }
-
-    /**    `match' { ImplicitCaseClauses }
-     */
-    def impliedMatch(start: Int, imods: Modifiers) = {
-      def markFirstIllegal(mods: List[Mod]) = mods match {
-        case mod :: _ => syntaxError(em"illegal modifier for given match", mod.span)
-        case _ =>
-      }
-      imods.mods match {
-        case (Mod.Implicit() | Mod.Given()) :: mods => markFirstIllegal(mods)
-        case mods => markFirstIllegal(mods)
-      }
-      val result @ Match(t, cases) =
-        matchExpr(EmptyTree, start, InlineMatch)
-      for (CaseDef(pat, _, _) <- cases) {
-        def isImplicitPattern(pat: Tree) = pat match {
-          case Typed(pat1, _) => isVarPattern(pat1)
-          case pat => isVarPattern(pat)
-        }
-        if (!isImplicitPattern(pat))
-          syntaxError(em"not a legal pattern for a given match", pat.span)
-      }
-      result
-    }
 
     /**    `match' { TypeCaseClauses }
      */
@@ -3673,8 +3646,6 @@ object Parsers {
             var imods = modifiers(closureMods)
             if (isBindingIntro)
               stats += implicitClosure(start, Location.InBlock, imods)
-            else if (in.token == MATCH)
-              stats += impliedMatch(start, imods)
             else
               stats +++= localDef(start, imods)
           }

--- a/docs/docs/reference/contextual/derivation.md
+++ b/docs/docs/reference/contextual/derivation.md
@@ -165,7 +165,7 @@ worked out example of such a library, see [shapeless 3](https://github.com/miles
 #### How to write a type class `derived` method using low level mechanisms
 
 The low-level method we will use to implement a type class `derived` method in this example exploits three new
-type-level constructs in Dotty: inline methods, inline matches, and given matches. Given this definition of the
+type-level constructs in Dotty: inline methods, inline matches, and implicit searches via `summonFrom`. Given this definition of the
 `Eq` type class,
 
 

--- a/docs/docs/reference/metaprogramming/inline.md
+++ b/docs/docs/reference/metaprogramming/inline.md
@@ -475,18 +475,17 @@ summon[Ordering[String]]
 println(setFor[String].getClass) // prints class scala.collection.immutable.TreeSet
 ```
 
-**Note** implicit matches can raise ambiguity errors. Consider the following
-code with two implicit values in scope of type `A`. The single pattern match
-case of the implicit match with type ascription of an `A` raises the ambiguity
-error.
+**Note** `summonFrom` applications can raise ambiguity errors. Consider the following
+code with two implicit values in scope of type `A`. The pattern match in `f` will raise
+an ambiguity error of `f` is applied.
 
 ```scala
 class A
 implicit val a1: A = new A
 implicit val a2: A = new A
 
-inline def f: Any = implicit match {
-  case _: A => ???  // error: ambiguous implicits
+inline def f: Any = summonFrom {
+  case given _: A => ???  // error: ambiguous implicits
 }
 ```
 

--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -571,7 +571,7 @@ sum
 
 ### Find implicits within a macro
 
-Similarly to the `implicit match` construct, it is possible to make implicit search available
+Similarly to the `summonFrom` construct, it is possible to make implicit search available
 in a quote context. For this we simply provide `scala.quoted.matching.searchImplicitExpr:
 
 ```scala

--- a/library/src/dotty/DottyPredef.scala
+++ b/library/src/dotty/DottyPredef.scala
@@ -1,6 +1,7 @@
 package dotty
 
 object DottyPredef {
+  import compiletime.summonFrom
 
   @forceInline final def assert(assertion: => Boolean, message: => Any): Unit = {
     if (!assertion)
@@ -32,7 +33,7 @@ object DottyPredef {
    * }}}
    * @group utilities
    */
-  inline def valueOf[T]: T = implicit match {
+  inline def valueOf[T]: T = summonFrom {
     case ev: ValueOf[T] => ev.value
   }
 

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -50,7 +50,7 @@ package object compiletime {
    *
    *  the returned value would be `2`.
    */
-  inline def summonFrom(f: Nothing => Any) <: Any = ???
+  inline def summonFrom[T](f: Nothing => T) <: T = ???
 
   type S[X <: Int] <: Int
 }

--- a/tests/neg/machine-state-encoding-with-implicit-match.scala
+++ b/tests/neg/machine-state-encoding-with-implicit-match.scala
@@ -1,4 +1,5 @@
 import scala.annotation.implicitNotFound
+import scala.compiletime.summonFrom
 
 sealed trait State
 final class On extends State
@@ -17,10 +18,10 @@ object IsOn {
 }
 
 class Machine[S <: State] {
-  inline def turnOn() given (s: IsOff[S]) <: Machine[On] = implicit match {
+  inline def turnOn() given (s: IsOff[S]) <: Machine[On] = summonFrom {
     case _: IsOff[Off]  => new Machine[On]
   }
-  inline def turnOff() given (s: IsOn[S]) <: Machine[Off] = implicit match {
+  inline def turnOff() given (s: IsOn[S]) <: Machine[Off] = summonFrom {
     case _: IsOn[On]    => new Machine[Off]
   }
 }

--- a/tests/pos/scala-days-2019-slides/metaprogramming-1-forset.scala
+++ b/tests/pos/scala-days-2019-slides/metaprogramming-1-forset.scala
@@ -1,9 +1,10 @@
 object ForSetExample {
 
   import scala.collection.immutable._
+  import scala.compiletime.summonFrom
 
   inline def setFor[T]: Set[T] =
-    implicit match {
+    summonFrom {
       case ord: Ordering[T] => new TreeSet[T]
       case _                => new HashSet[T]
     }

--- a/tests/run/implicitMatch.scala
+++ b/tests/run/implicitMatch.scala
@@ -1,13 +1,14 @@
 object Test extends App {
   import collection.immutable.TreeSet
   import collection.immutable.HashSet
+  import compiletime.summonFrom
 
-  inline def f1[T]() = implicit match {
+  inline def f1[T]() = summonFrom {
     case ord: Ordering[T] => new TreeSet[T]
     case _ => new HashSet[T]
   }
 
-  inline def f2[T]() = implicit match {
+  inline def f2[T]() = summonFrom {
     case _: Ordering[T] => new TreeSet[T]
     case _ => new HashSet[T]
   }
@@ -16,7 +17,7 @@ object Test extends App {
   class B
   implicit val b: B = new B
 
-  inline def g = implicit match {
+  inline def g = summonFrom {
     case _: A => println("A")
     case _: B => println("B")
   }

--- a/tests/run/typeclass-derivation-doc-example.scala
+++ b/tests/run/typeclass-derivation-doc-example.scala
@@ -1,7 +1,7 @@
 import scala.deriving._
-import scala.compiletime.erasedValue
+import scala.compiletime.{erasedValue, summonFrom}
 
-inline def summon[T]: T = given match {
+inline def summon[T]: T = summonFrom {
   case t: T => t
 }
 


### PR DESCRIPTION
Drop `given match` and `implict match` syntax.
The docs on typeclass derivation still have to be updated to conform to the
new terminology.