### PR TITLE
Fix the list rendering

### DIFF
--- a/docs/docs/internals/contexts.md
+++ b/docs/docs/internals/contexts.md
@@ -4,6 +4,7 @@ title: Contexts
 ---
 
 The `Context` contains the state of the compiler, for example
+
   * `settings`
   * `freshNames` (`FreshNameCreator`)
   * `period` (run and phase id)


### PR DESCRIPTION
Markdown requires a newline before a list so it is rendered correctly, this patch adds a newline before the list