### PR TITLE
Fix #6697: Ingore bounds checks in match type patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -303,6 +303,15 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
             //     case x: Tree[?]
             // (which translates to)
             //     case x: (_: Tree[?])
+        case m @ MatchTypeTree(bounds, selector, cases) =>
+          // Analog to the case above for match types
+          def tranformIgnoringBoundsCheck(x: CaseDef): CaseDef =
+            super.transform(x)(ctx.addMode(Mode.Pattern)).asInstanceOf[CaseDef]
+          cpy.MatchTypeTree(tree)(
+            super.transform(bounds),
+            super.transform(selector),
+            cases.mapConserve(tranformIgnoringBoundsCheck)
+          )
         case tree =>
           super.transform(tree)
       }

--- a/tests/pos/6697.scala
+++ b/tests/pos/6697.scala
@@ -1,0 +1,7 @@
+object Test {
+  sealed trait Off
+  case class Of[sup, sub <: sup]() extends Off
+  type Sup[O <: Off] = O match { case Of[sup, sub] => sup }
+  type Sub[O <: Off] = O match { case Of[sup, sub] => sub }
+  type Copy[O <: Off] = Of[Sup[O], Sub[O]]
+}


### PR DESCRIPTION
Similarly to what's done for values when we write `case _: F[x]`, there is no need to check that `x` conforms to its bounds as we are currently binding it.