### PR TITLE
Fix #5638: disallow `get` of named match to be PolyType

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -40,7 +40,7 @@ object Applications {
   import tpd._
 
   def extractorMember(tp: Type, name: Name)(implicit ctx: Context): SingleDenotation =
-    tp.member(name).suchThat(_.info.isParameterless)
+    tp.member(name).suchThat(sym => sym.info.isParameterless && sym.info.widenExpr.isValueType)
 
   def extractorMemberType(tp: Type, name: Name, errorPos: SourcePosition)(implicit ctx: Context): Type = {
     val ref = extractorMember(tp, name)

--- a/tests/neg/i5638.scala
+++ b/tests/neg/i5638.scala
@@ -1,0 +1,13 @@
+class Opt{
+  def isEmpty: Boolean = false
+  def get[T]: Int = 1
+}
+object Extract{
+  def unapply(x: Int): Opt = new Opt
+}
+object O {
+  def m(x: Int) = x match {
+    case Extract(r) =>  // error
+      r  // error
+  }
+}


### PR DESCRIPTION
Fix #5638: disallow `get` of named match to be PolyType