### PR TITLE
Fix a typo

### DIFF
--- a/docs/docs/contributing/debugging.md
+++ b/docs/docs/contributing/debugging.md
@@ -100,7 +100,7 @@ dotc -Xprint:frontend ../issues/Playground.scala
 To print out the trees after Frontend and CollectSuperCalls phases:
 
 ```
-dotc -Xprint:frontend,collectSuperCalls ../issues/Playground.scal
+dotc -Xprint:frontend,collectSuperCalls ../issues/Playground.scala
 ```
 
 To print out the trees after all phases:


### PR DESCRIPTION
This patch fixes a typo: "Playground.scal" -> "Playground.scal**a**"