### PR TITLE
Make indentation significant in old-style control syntax

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -2588,7 +2588,8 @@ class JSCodeGen()(implicit ctx: Context) {
       sym.info.paramNamess.flatten.zip(sym.info.paramInfoss.flatten)
 
     val wereRepeated = ctx.atPhase(ctx.elimRepeatedPhase) {
-      val list = for ((name, tpe) <- paramNamesAndTypes)
+      val list =
+        for ((name, tpe) <- paramNamesAndTypes)
         yield (name -> tpe.isRepeatedParam)
       list.toMap
     }

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -52,6 +52,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val oldSyntax: Setting[Boolean] = BooleanSetting("-old-syntax", "Require `(...)` around conditions")
   val indent: Setting[Boolean] = BooleanSetting("-indent", "allow significant indentation")
   val noindent: Setting[Boolean] = BooleanSetting("-noindent", "require classical {...} syntax, indentation is not significant")
+  val YindentColons: Setting[Boolean] = BooleanSetting("-Yindent-colons", "allow colons at ends-of-lines to start indentation blocks")
 
   /** Decompiler settings */
   val printTasty: Setting[Boolean] = BooleanSetting("-print-tasty", "Prints the raw tasty.") withAbbreviation "--print-tasty"

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1636,8 +1636,10 @@ object Parsers {
           if (rewriteToOldSyntax()) revertToParens(t)
           in.nextToken()
         }
-        else if (rewriteToNewSyntax(t.span))
-          dropParensOrBraces(t.span.start, s"${tokenString(altToken)}")
+        else
+          in.observeIndented()
+          if (rewriteToNewSyntax(t.span))
+            dropParensOrBraces(t.span.start, s"${tokenString(altToken)}")
         t
       }
       else {
@@ -2296,6 +2298,7 @@ object Parsers {
                 dropParensOrBraces(start, if (in.token == YIELD || in.token == DO) "" else "do")
               }
             }
+            in.observeIndented()
             res
           }
           else {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1636,10 +1636,11 @@ object Parsers {
           if (rewriteToOldSyntax()) revertToParens(t)
           in.nextToken()
         }
-        else
+        else {
           in.observeIndented(noIndentAfterConditionTokens)
           if (rewriteToNewSyntax(t.span))
             dropParensOrBraces(t.span.start, s"${tokenString(altToken)}")
+        }
         t
       }
       else {
@@ -3542,14 +3543,14 @@ object Parsers {
 
     /** TemplateOpt = [Template]
      */
-    def templateOpt(constr: DefDef): Template =
+    def templateOpt(constr: DefDef): Template = {
       possibleTemplateStart()
       if (in.token == EXTENDS || isIdent(nme.derives))
         template(constr)
-      else {
+      else
         if (in.isNestedStart) template(constr)
         else Template(constr, Nil, Nil, EmptyValDef, Nil)
-      }
+    }
 
     /** TemplateBody ::= [nl] `{' TemplateStatSeq `}'
      */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -717,6 +717,7 @@ object Parsers {
      */
     def bracesToIndented[T](body: => T): T = {
       val colonRequired = possibleColonOffset == in.lastOffset
+      if colonRequired && !in.colonSyntax then return body
       val (startOpening, endOpening) = startingElimRegion(colonRequired)
       val isOutermost = in.currentRegion.isOutermost
       def allBraces(r: Region): Boolean = r match {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1234,6 +1234,9 @@ object Parsers {
       case _ => op
     }
 
+    def observeIndentedUnlessFollowedBy(followers: BitSet): Unit =
+      if !followers.contains(in.token) then in.observeIndented()
+
 /* ------------- TYPES ------------------------------------------------------ */
 
     /** Same as [[typ]], but if this results in a wildcard it emits a syntax error and
@@ -1637,7 +1640,7 @@ object Parsers {
           in.nextToken()
         }
         else
-          in.observeIndented()
+          observeIndentedUnlessFollowedBy(BitSet(THEN, DO))
           if (rewriteToNewSyntax(t.span))
             dropParensOrBraces(t.span.start, s"${tokenString(altToken)}")
         t
@@ -2298,7 +2301,7 @@ object Parsers {
                 dropParensOrBraces(start, if (in.token == YIELD || in.token == DO) "" else "do")
               }
             }
-            in.observeIndented()
+            observeIndentedUnlessFollowedBy(BitSet(YIELD, DO))
             res
           }
           else {

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -547,13 +547,14 @@ object Scanners {
           case _ => nextWidth
         }
 
-        if lastWidth < nextWidth
+        if (lastWidth < nextWidth
            && !unless.contains(nextToken)
-           && (unlessSoftKW.isEmpty || token != IDENTIFIER || name != unlessSoftKW) then
+           && (unlessSoftKW.isEmpty || token != IDENTIFIER || name != unlessSoftKW)) {
           currentRegion = Indented(nextWidth, Set(), COLONEOL, currentRegion)
           if (!newLineInserted) next.copyFrom(this)
           offset = nextOffset
           token = INDENT
+        }
       }
 
     /** - Join CASE + CLASS => CASECLASS, CASE + OBJECT => CASEOBJECT, SEMI + ELSE => ELSE, COLON + <EOL> => COLONEOL
@@ -595,7 +596,7 @@ object Scanners {
           lookahead()
           val atEOL = isAfterLineEnd
           reset()
-          if colonSyntax && atEOL then token = COLONEOL
+          if (colonSyntax && atEOL) token = COLONEOL
         case EOF | RBRACE =>
           currentRegion match {
             case r: Indented if !r.isOutermost =>

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -152,12 +152,15 @@ object Scanners {
     val rewriteNoIndent = ctx.settings.noindent.value && rewrite
 
     val noindentSyntax =
-      ctx.settings.noindent.value ||
-      ctx.settings.oldSyntax.value ||
-      isScala2Mode
+      ctx.settings.noindent.value
+      || ctx.settings.oldSyntax.value
+      || isScala2Mode
     val indentSyntax =
-      (if (Config.defaultIndent) !noindentSyntax else ctx.settings.indent.value) ||
-      rewriteNoIndent
+      (if (Config.defaultIndent) !noindentSyntax else ctx.settings.indent.value)
+      || rewriteNoIndent
+    val colonSyntax =
+      ctx.settings.YindentColons.value
+      || rewriteNoIndent
 
     if (rewrite) {
       val s = ctx.settings
@@ -590,7 +593,7 @@ object Scanners {
           lookahead()
           val atEOL = isAfterLineEnd
           reset()
-          if (atEOL) token = COLONEOL
+          if colonSyntax && atEOL then token = COLONEOL
         case EOF | RBRACE =>
           currentRegion match {
             case r: Indented if !r.isOutermost =>

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -281,6 +281,10 @@ object Tokens extends TokensCommon {
    */
   final val startParamOrGivenTypeTokens: BitSet = startParamTokens | BitSet(GIVEN, ERASED)
 
+  final val noIndentTemplateTokens = BitSet(EXTENDS)
+  final val noIndentAfterConditionTokens = BitSet(THEN, DO)
+  final val noIndentAfterEnumeratorTokens = BitSet(YIELD, DO)
+
   final val scala3keywords = BitSet(ENUM, ERASED, GIVEN, IMPLIED)
 
   final val softModifierNames = Set(nme.inline, nme.opaque)

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2174,7 +2174,8 @@ object messages {
       def symLocation(sym: Symbol) = {
         val lineDesc =
           if (sym.span.exists && sym.span != sym.owner.span)
-            s" at line ${sym.sourcePos.line + 1}" else ""
+            s" at line ${sym.sourcePos.line + 1}"
+          else ""
         i"in ${sym.owner}${lineDesc}"
       }
       val clashDescription =

--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -254,7 +254,7 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
 
     def setters(mixin: ClassSymbol): List[Tree] =
       for (setter <- mixin.info.decls.filter(setr => setr.isSetter && !wasOneOf(setr, Deferred)))
-        yield transformFollowing(DefDef(mkForwarderSym(setter.asTerm), unitLiteral.withSpan(cls.span)))
+      yield transformFollowing(DefDef(mkForwarderSym(setter.asTerm), unitLiteral.withSpan(cls.span)))
 
     def mixinForwarders(mixin: ClassSymbol): List[Tree] =
       for (meth <- mixin.info.decls.toList if needsMixinForwarder(meth))

--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -263,7 +263,6 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
         transformFollowing(polyDefDef(mkForwarderSym(meth.asTerm, Bridge), forwarderRhsFn(meth)))
       }
 
-
     cpy.Template(impl)(
       constr =
         if (cls.is(Trait)) cpy.DefDef(impl.constr)(vparamss = Nil :: Nil)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -890,8 +890,8 @@ trait Applications extends Compatibility {
         case err: ErrorType => cpy.Apply(tree)(fun1, proto.unforcedTypedArgs).withType(err)
         case TryDynamicCallType => typedDynamicApply(tree, pt)
         case _ =>
-          if originalProto.isDropped then fun1
-          else if fun1.symbol == defn.Compiletime_summonFrom then
+          if (originalProto.isDropped) fun1
+          else if (fun1.symbol == defn.Compiletime_summonFrom)
             // Special handling of `summonFrom { ... }`.
             // We currently cannot use a macro for that since unlike other inline methods
             // summonFrom needs to expand lazily. For instance, in

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -1252,7 +1252,8 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
            |""".stripMargin
       ctx.error(msg, inlinedFrom.sourcePos)
       EmptyTree
-    } else {
+    }
+    else {
       val evaluatedSplice = Splicer.splice(body, inlinedFrom.sourcePos, MacroClassLoader.fromContext)(ctx1)
 
       val inlinedNormailizer = new TreeMap {
@@ -1270,10 +1271,10 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
   /** Return the set of symbols that are refered at level -1 by the tree and defined in the current run.
    *  This corresponds to the symbols that will need to be interpreted.
    */
-  private def macroDependencies(tree: Tree)(implicit ctx: Context) = {
+  private def macroDependencies(tree: Tree)(implicit ctx: Context) =
     new TreeAccumulator[Set[Symbol]] {
       private[this] var level = -1
-      override def apply(syms: Set[Symbol], tree: tpd.Tree)(implicit ctx: Context): Set[Symbol] = {
+      override def apply(syms: Set[Symbol], tree: tpd.Tree)(implicit ctx: Context): Set[Symbol] =
         if (level != -1) foldOver(syms, tree)
         else tree match {
           case tree: RefTree if level == -1 && tree.symbol.isDefinedInCurrentRun && !tree.symbol.isLocal =>
@@ -1289,8 +1290,6 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
           case _ =>
             foldOver(syms, tree)
         }
-      }
     }.apply(Set.empty, tree)
-  }
 }
 

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -216,7 +216,7 @@ trait QuotesAndSplices {
           super.transform(tree)
         case tdef: TypeDef if tdef.symbol.hasAnnotation(defn.InternalQuoted_patternBindHoleAnnot) =>
           transformTypeBindingTypeDef(tdef, typePatBuf)
-         case tree @ AppliedTypeTree(tpt, args) =>
+        case tree @ AppliedTypeTree(tpt, args) =>
             val args1: List[Tree] = args.zipWithConserve(tpt.tpe.typeParams.map(_.paramVariance)) { (arg, v) =>
               arg.tpe match {
                 case _: TypeBounds => transform(arg)

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -56,7 +56,8 @@ class CompilationTests extends ParallelTesting {
         "tests/neg-custom-args/fatal-warnings/xfatalWarnings.scala",
         defaultOptions.and("-nowarn", "-Xfatal-warnings")
       ),
-      compileFile("tests/pos-special/typeclass-scaling.scala", defaultOptions.and("-Xmax-inlines", "40"))
+      compileFile("tests/pos-special/typeclass-scaling.scala", defaultOptions.and("-Xmax-inlines", "40")),
+      compileFile("tests/pos-special/indent-colons.scala", defaultOptions.and("-Yindent-colons"))
     ).checkCompile()
   }
 

--- a/tests/neg/endmarkers.scala
+++ b/tests/neg/endmarkers.scala
@@ -1,6 +1,6 @@
 object Test
 
-  locally:
+  locally {
     var x = 0
     while x < 10 do x += 1
     end while    // error: end of statement expected but while found // error: not found: end
@@ -9,7 +9,8 @@ object Test
       x += 1
       x < 10
     do ()
-  end while      // error: misaligned end marker
+  end while      // error: misaligned end marker // error: not found : end
+  }              // error: ';' expected, but '}' found
 
   def f(x: Int): Int =
     val y =
@@ -23,21 +24,11 @@ object Test
 
     val z = 22
     x + y + z
-  end f          // error: misaligned end marker
+  end f
 
   def g = "!"
 
   val xs = List(1, 2, 3)
-
-  xs.map:
-    x =>
-      val y = x * x
-      y * y
-
-  xs.map:
-    x =>
-    val y = x * x
-    y + y
 
   println(f(2) + g)
 
@@ -57,10 +48,11 @@ class Test2
   def foo = 1
 
   object x
-    new Test2:
+    new Test2 {
       override def foo = 2
       end new               // error: end of statement expected but new found  // error: not found: end
-    def bar = 2             // error: ';' expected, but unindent found
+    }                       // error: ';' expected, but '}' found
+    def bar = 2
   end Test2                 // error: misaligned end marker
 end Test2
 
@@ -102,9 +94,11 @@ class Coder(words: List[String])
   /** Invert the mnemonics map to give a map from chars 'A' ... 'Z' to '2' ... '9' */
   private val charCode0: Map[Char, Char] =
     mnemonics
-      .withFilter:
+      .withFilter {
         case (digit, str) => true
         case _ => false
-      .flatMap:
+      }
+      .flatMap {
         case (digit, str) => str map (ltr => ltr -> digit)
+      }
  end Coder    // error: The start of this line does not match any of the previous indentation widths.

--- a/tests/neg/i4373b.scala
+++ b/tests/neg/i4373b.scala
@@ -1,5 +1,5 @@
 // ==> 05bef7805687ba94da37177f7568e3ba7da1f91c.scala <==
 class x0 {
   x1: // error
-      x0 | _
+      x0 | _  // error
 // error

--- a/tests/pos-special/indent-colons.scala
+++ b/tests/pos-special/indent-colons.scala
@@ -1,6 +1,6 @@
 object Test
 
-  locally {
+  locally:
     var x = 0
     while x < 10 do x += 1
     val f = 10
@@ -8,7 +8,6 @@ object Test
       x += 1
       x < 10
     do ()
-  }
 
   def f(x: Int): Int =
     val y =
@@ -26,17 +25,15 @@ object Test
 
   val xs = List(1, 2, 3)
 
-  xs.map {
+  xs.map:
     x =>
       val y = x * x
       y * y
-  }
 
-  xs.map {
+  xs.map:
     x =>
     val y = x * x
     y + y
-  }
 
   xs.map { x =>
     val y = x * x
@@ -64,9 +61,9 @@ class Test2
   def foo = 1
 
   val x =
-    new Test2 {
+    new Test2:
       override def foo = 2
-    }
+    end new
   end x
 end Test2
 
@@ -110,13 +107,11 @@ class Coder(words: List[String])
   /** Invert the mnemonics map to give a map from chars 'A' ... 'Z' to '2' ... '9' */
   private val charCode0: Map[Char, Char] =
     mnemonics
-      .withFilter {
+      .withFilter:
         case (digit, str) => true
         case _ => false
-      }
-      .flatMap {
+      .flatMap:
         case (digit, str) => str map (ltr => ltr -> digit)
-      }
 end Coder
 
 object Test22

--- a/tests/pos/Coder.scala
+++ b/tests/pos/Coder.scala
@@ -15,14 +15,16 @@ class Coder(words: List[String]) {
   }
 
   /** Invert the mnemonics map to give a map from chars 'A' ... 'Z' to '2' ... '9' */
-  private val charCode0: Map[Char, Char] = mnemonics withFilter {
-    case (digit, str) => true
-    case _ => false
-  } flatMap { x$1 =>
-    x$1 match {
-      case (digit, str) => str map (ltr => ltr -> digit)
+  private val charCode0: Map[Char, Char] = mnemonics
+    .withFilter {
+      case (digit, str) => true
+      case _ => false
     }
-  }
+    .flatMap { x$1 =>
+      x$1 match {
+        case (digit, str) => str map (ltr => ltr -> digit)
+      }
+    }
 
   private val charCode: Map[Char, Char] =
     for ((digit, str) <- mnemonics; ltr <- str) yield ltr -> digit
@@ -42,12 +44,12 @@ class Coder(words: List[String]) {
         splitPoint <- 1 to number.length
         word <- wordsForNum(number take splitPoint)
         rest <- encode(number drop splitPoint)
-      } yield word :: rest
+      }
+      yield word :: rest
     }.toSet
 
   /** Maps a number to a list of all word phrases that can represent it */
   def translate(number: String): Set[String] = encode(number) map (_ mkString " ")
-
 }
 
 object Coder {

--- a/tests/pos/i7217.scala
+++ b/tests/pos/i7217.scala
@@ -1,4 +1,4 @@
-class Foo(p1: String, p2: String):
+class Foo(p1: String, p2: String)
   def this(p1: String) = this(p1, "blah")
 
 val x = { Foo("blah", "hah") }

--- a/tests/pos/indent4.scala
+++ b/tests/pos/indent4.scala
@@ -1,0 +1,24 @@
+object testindent
+
+  if (true)
+    val x = 1
+    println(x)
+
+  while (false)
+    val x = 1
+    println(x)
+
+  for (x <- List(1, 2, 3))
+    val y = x
+    println(y)
+
+  for { x <- List(1, 2, 3) }
+    val y = x
+    println(y)
+
+  for {
+    x <- List(1, 2, 3)
+  }
+    val y = x
+    println(y)
+


### PR DESCRIPTION
Indentation was significant only after new-style if-then, while-do, for-yield, for-do.
This was prone to cause gotchas. We now treat indentation as significant also if the
conditions or enumerators of these constructs use parens or braces.

Also: Introduce option to treat colon at eol as indentation start

A `:` at the end of a line starting an indentation region is now
allowed only if option `-Yindent-colons` is set. Rewriting to colons
is also subject to that setting.