### PR TITLE
Add syntax highlighting issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/syntax-highlight.md
+++ b/.github/ISSUE_TEMPLATE/syntax-highlight.md
@@ -1,0 +1,13 @@
+---
+name: "Syntax highlighting"
+about: Please create a syntax highlighting issue here https://github.com/scala/vscode-scala-syntax/issues
+title: ''
+labels:
+assignees: ''
+
+---
+
+Please create a syntax highlighting issue here: [scala/vscode-scala-syntax](https://github.com/scala/vscode-scala-syntax/issues).
+
+
+


### PR DESCRIPTION
To avoid duplication of issues like #7233 and https://github.com/scala/vscode-scala-syntax/issues/55 in different repos.