### PR TITLE
Small correction to example

### DIFF
--- a/docs/docs/reference/contextual-new/given-clauses.md
+++ b/docs/docs/reference/contextual-new/given-clauses.md
@@ -69,7 +69,7 @@ maximum(xs)(given descending(given ListOrd(given IntOrd)))
 There can be several `given` parameter clauses in a definition and `given` parameter clauses can be freely
 mixed with normal ones. Example:
 ```scala
-def f(u: Universe)(given c: u.Context)(given s: ctx.Symbol, k: ctx.Kind) = ...
+def f(u: Universe)(given ctx: u.Context)(given s: ctx.Symbol, k: ctx.Kind) = ...
 ```
 Multiple given clauses are matched left-to-right in applications. Example:
 ```scala


### PR DESCRIPTION
The parameter name in the second parameter block should match that used in the third parameter block.