### PR TITLE
Issue warnings if braces are missing

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -606,7 +606,7 @@ object Parsers {
           if (in.token == NEWLINE || in.token == NEWLINES)
             && !(nextIndentWidth < startIndentWidth)
           then
-            syntaxError(
+            warning(
               if startIndentWidth <= nextIndentWidth then
                 i"""Line is indented too far to the right, or a `{' is missing before:
                    |

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -604,7 +604,7 @@ object Parsers {
           // Therefore, make sure there would be a matching <outdent>
           def nextIndentWidth = in.indentWidth(in.next.offset)
           if (in.token == NEWLINE || in.token == NEWLINES)
-            && !(nextIndentWidth < startIndentWidth)
+             && !(nextIndentWidth < startIndentWidth)
           then
             warning(
               if startIndentWidth <= nextIndentWidth then
@@ -632,7 +632,7 @@ object Parsers {
 /* -------- REWRITES ----------------------------------------------------------- */
 
     /** The last offset where a colon at the end of line would be required if a subsequent { ... }
-     *  block would be converted to an indentation reg`ion.
+     *  block would be converted to an indentation region.
      */
     var possibleColonOffset: Int = -1
 

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -492,10 +492,6 @@ object Scanners {
           indentPrefix = LBRACE
         case _ =>
       }
-      def isMatchCatchFollow(prev: Token) =
-        nextWidth == lastWidth
-        && (prev == MATCH || prev == CATCH)
-        && token != CASE
       if (newlineIsSeparating &&
           canEndStatTokens.contains(lastToken) &&
           canStartStatTokens.contains(token) &&

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -263,6 +263,8 @@ object Tokens extends TokensCommon {
 
   final val statCtdTokens: BitSet = BitSet(THEN, ELSE, DO, CATCH, FINALLY, YIELD, MATCH)
 
+  final val closingRegionTokens = BitSet(RBRACE, CASE) | statCtdTokens
+
   final val canStartIndentTokens: BitSet =
     statCtdTokens | BitSet(COLONEOL, EQUALS, ARROW, LARROW, WHILE, TRY, FOR)
       // `if` is excluded because it often comes after `else` which makes for awkward indentation rules  TODO: try to do without the exception

--- a/compiler/src/dotty/tools/dotc/plugins/Plugins.scala
+++ b/compiler/src/dotty/tools/dotc/plugins/Plugins.scala
@@ -96,12 +96,11 @@ trait Plugins {
 
   private var _plugins: List[Plugin] = _
   def plugins(implicit ctx: Context): List[Plugin] =
-  if (_plugins == null) {
-    _plugins = loadPlugins
-    _plugins
-  }
-  else _plugins
-
+    if (_plugins == null) {
+      _plugins = loadPlugins
+      _plugins
+    }
+    else _plugins
 
   /** A description of all the plugins that are loaded */
   def pluginDescriptions: String =

--- a/compiler/test/debug/Gen.scala
+++ b/compiler/test/debug/Gen.scala
@@ -126,38 +126,38 @@ object Gen {
             |""".stripMargin
     }).mkString("\n\n")
 
-s"""|#!/usr/bin/expect
-    |
-    |# log_user 1
-    |# exp_internal 1
-    |# set timeout 5
-    |
-    |send_user "spawning job...\\n"
-    |
-    |spawn jdb -attach 5005 -sourcepath $source
-    |
-    |send_user "interacting...\\n"
-    |
-    |expect {
-    |  "*VM Started*" { send_user "success - connected to server \\n" }
-    |  timeout {
-    |      send_user "timeout while waiting for: *VM Started*\\n"
-    |      exit 1
-    |  }
-    |}
-    |
-    |send_user "setting breakpoints...\\n"
-    |
-    |# breakpoints
-    |$breakpoints
-    |
-    |# run
-    |send_user "run program...\\n"
-    |send "run\\r"
-    |expect "Breakpoint hit"
-    |
-    |# interactions
-    |$commands""".stripMargin
+  s"""|#!/usr/bin/expect
+      |
+      |# log_user 1
+      |# exp_internal 1
+      |# set timeout 5
+      |
+      |send_user "spawning job...\\n"
+      |
+      |spawn jdb -attach 5005 -sourcepath $source
+      |
+      |send_user "interacting...\\n"
+      |
+      |expect {
+      |  "*VM Started*" { send_user "success - connected to server \\n" }
+      |  timeout {
+      |      send_user "timeout while waiting for: *VM Started*\\n"
+      |      exit 1
+      |  }
+      |}
+      |
+      |send_user "setting breakpoints...\\n"
+      |
+      |# breakpoints
+      |$breakpoints
+      |
+      |# run
+      |send_user "run program...\\n"
+      |send "run\\r"
+      |expect "Breakpoint hit"
+      |
+      |# interactions
+      |$commands""".stripMargin
   }
 
   def main(args: Array[String]): Unit = {

--- a/compiler/test/debug/Gen.scala
+++ b/compiler/test/debug/Gen.scala
@@ -126,38 +126,38 @@ object Gen {
             |""".stripMargin
     }).mkString("\n\n")
 
-  s"""|#!/usr/bin/expect
-      |
-      |# log_user 1
-      |# exp_internal 1
-      |# set timeout 5
-      |
-      |send_user "spawning job...\\n"
-      |
-      |spawn jdb -attach 5005 -sourcepath $source
-      |
-      |send_user "interacting...\\n"
-      |
-      |expect {
-      |  "*VM Started*" { send_user "success - connected to server \\n" }
-      |  timeout {
-      |      send_user "timeout while waiting for: *VM Started*\\n"
-      |      exit 1
-      |  }
-      |}
-      |
-      |send_user "setting breakpoints...\\n"
-      |
-      |# breakpoints
-      |$breakpoints
-      |
-      |# run
-      |send_user "run program...\\n"
-      |send "run\\r"
-      |expect "Breakpoint hit"
-      |
-      |# interactions
-      |$commands""".stripMargin
+    s"""|#!/usr/bin/expect
+        |
+        |# log_user 1
+        |# exp_internal 1
+        |# set timeout 5
+        |
+        |send_user "spawning job...\\n"
+        |
+        |spawn jdb -attach 5005 -sourcepath $source
+        |
+        |send_user "interacting...\\n"
+        |
+        |expect {
+        |  "*VM Started*" { send_user "success - connected to server \\n" }
+        |  timeout {
+        |      send_user "timeout while waiting for: *VM Started*\\n"
+        |      exit 1
+        |  }
+        |}
+        |
+        |send_user "setting breakpoints...\\n"
+        |
+        |# breakpoints
+        |$breakpoints
+        |
+        |# run
+        |send_user "run program...\\n"
+        |send "run\\r"
+        |expect "Breakpoint hit"
+        |
+        |# interactions
+        |$commands""".stripMargin
   }
 
   def main(args: Array[String]): Unit = {

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -139,7 +139,8 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/neg-custom-args/i6300.scala", allowDeepSubtypes),
       compileFile("tests/neg-custom-args/infix.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/missing-alpha.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings")),
-      compileFile("tests/neg-custom-args/wildcards.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings"))
+      compileFile("tests/neg-custom-args/wildcards.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings")),
+      compileFile("tests/neg-custom-args/indentRight.scala", defaultOptions.and("-noindent", "-Xfatal-warnings"))
     ).checkExpectedErrors()
   }
 

--- a/language-server/test/dotty/tools/languageserver/util/actions/SignatureHelp.scala
+++ b/language-server/test/dotty/tools/languageserver/util/actions/SignatureHelp.scala
@@ -29,7 +29,7 @@ class SignatureHelp(override val marker: CodeMarker,
                     activeSignature: Option[Int],
                     activeParam: Int) extends ActionOnMarker {
 
-   val expectedSignatures = expected.map(DottyLanguageServer.signatureToSignatureInformation)
+  val expectedSignatures = expected.map(DottyLanguageServer.signatureToSignatureInformation)
 
   override def execute(): Exec[Unit] = {
     val results = server.signatureHelp(marker.toTextDocumentPositionParams).get()

--- a/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
+++ b/library/src/scala/tasty/reflect/TypeOrBoundsOps.scala
@@ -96,7 +96,7 @@ trait TypeOrBoundsOps extends Core {
         internal.matchTermRef(typeOrBounds).map(x => (x.qualifier, x.name))
     }
 
-   object IsTypeRef {
+    object IsTypeRef {
       /** Matches any TypeRef and returns it */
       def unapply(tpe: TypeOrBounds)(given ctx: Context): Option[TypeRef] =
         internal.matchTypeRef(tpe)

--- a/tests/neg-custom-args/fatal-warnings/indentLeft.scala
+++ b/tests/neg-custom-args/fatal-warnings/indentLeft.scala
@@ -1,0 +1,8 @@
+object Test {
+
+  if (true) {
+    println("hi")
+
+  println("!")  // error: too far to the left
+}
+// error: too far to the left

--- a/tests/neg-custom-args/indentRight.scala
+++ b/tests/neg-custom-args/indentRight.scala
@@ -17,6 +17,10 @@ object Test {
 
   }
 
+  trait A
+    case class B() extends A  // error: Line is indented too far to the right
+    case object C extends A   // error: Line is indented too far to the right
+
   if (true)   // OK
     println("hi")
   }

--- a/tests/neg-custom-args/indentRight.scala
+++ b/tests/neg-custom-args/indentRight.scala
@@ -1,0 +1,25 @@
+object Test {
+
+  if (true)
+    println("ho")
+    println("hu") // error: Line is indented too far to the right
+
+  if (true)
+    { println("ho")
+    }
+    println("hu") // error: Line is indented too far to the right
+
+  while (true)
+  ()
+
+  for (x <- List())  // OK
+  {
+
+  }
+
+  if (true)   // OK
+    println("hi")
+  }
+
+  println("!")  // error: expected a toplevel definition
+}

--- a/tests/neg/indentRight.scala
+++ b/tests/neg/indentRight.scala
@@ -1,0 +1,8 @@
+object Test {
+
+  if (true)
+    println("hi")
+  }
+
+  println("!")  // error: expected a toplevel definition
+}

--- a/tests/neg/indentRight.scala
+++ b/tests/neg/indentRight.scala
@@ -1,8 +1,0 @@
-object Test {
-
-  if (true)
-    println("hi")
-  }
-
-  println("!")  // error: expected a toplevel definition
-}

--- a/tests/patmat/patmatexhaust.scala
+++ b/tests/patmat/patmatexhaust.scala
@@ -1,60 +1,60 @@
 class TestSealedExhaustive { // compile only
-    sealed abstract class Foo
+  sealed abstract class Foo
 
-    case class Bar(x:Int) extends Foo
-    case object Baz extends Foo
+  case class Bar(x:Int) extends Foo
+  case object Baz extends Foo
 
-    def ma1(x:Foo) = x match {
-      case Bar(_) => // not exhaustive
-    }
+  def ma1(x:Foo) = x match {
+    case Bar(_) => // not exhaustive
+  }
 
-    def ma2(x:Foo) = x match {
-      case Baz    => // not exhaustive
-    }
+  def ma2(x:Foo) = x match {
+    case Baz    => // not exhaustive
+  }
 
-    sealed abstract class Mult
-    case class Kult(s:Mult) extends Mult
-    case class Qult() extends Mult
+  sealed abstract class Mult
+  case class Kult(s:Mult) extends Mult
+  case class Qult() extends Mult
 
-    def ma33(x:Kult) = x match { // exhaustive
-      case Kult(_) => // exhaustive
-    }
+  def ma33(x:Kult) = x match { // exhaustive
+    case Kult(_) => // exhaustive
+  }
 
-    def ma3(x:Mult) = (x,x) match { // not exhaustive
-      case (Kult(_), Qult())    => // Kult missing
-      //case (Kult(_), Kult(_))    =>
-      case (Qult(), Kult(_))    => // Qult missing
-      //case (Qult(), Qult())    =>
-    }
+  def ma3(x:Mult) = (x,x) match { // not exhaustive
+    case (Kult(_), Qult())    => // Kult missing
+    //case (Kult(_), Kult(_))    =>
+    case (Qult(), Kult(_))    => // Qult missing
+    //case (Qult(), Qult())    =>
+  }
 
-    def ma3u(x:Mult) = ((x,x) : @unchecked) match { // not exhaustive, but not checked!
-      case (Kult(_), Qult())    =>
-      case (Qult(), Kult(_))    =>
-    }
+  def ma3u(x:Mult) = ((x,x) : @unchecked) match { // not exhaustive, but not checked!
+    case (Kult(_), Qult())    =>
+    case (Qult(), Kult(_))    =>
+  }
 
-    sealed abstract class Deep
+  sealed abstract class Deep
 
-    case object Ga extends Deep
-    sealed class Gp extends Deep
-    case object Gu extends Gp
+  case object Ga extends Deep
+  sealed class Gp extends Deep
+  case object Gu extends Gp
 
-    def zma3(x:Deep) = x match { // exhaustive!
-      case _ =>
-    }
-    def zma4(x:Deep) = x match { // exhaustive!
-      case Ga =>
-      case _ =>
-    }
+  def zma3(x:Deep) = x match { // exhaustive!
+    case _ =>
+  }
+  def zma4(x:Deep) = x match { // exhaustive!
+    case Ga =>
+    case _ =>
+  }
 
-    def ma4(x:Deep) = x match { // missing cases: Gu, Gp which is not abstract so must be included
-      case Ga =>
-    }
+  def ma4(x:Deep) = x match { // missing cases: Gu, Gp which is not abstract so must be included
+    case Ga =>
+  }
 
-    def ma5(x:Deep) = x match {
-      case Gu =>
-      case _ if 1 == 0 =>
-      case Ga =>
-    }
+  def ma5(x:Deep) = x match {
+    case Gu =>
+    case _ if 1 == 0 =>
+    case Ga =>
+  }
 
   def ma6()  = List(1,2) match { // give up
     case List(1,2) =>

--- a/tests/pos/Labels.scala
+++ b/tests/pos/Labels.scala
@@ -1,21 +1,22 @@
 object Labels {
   def main(args: Array[String]): Unit = {
-  var i = 10
-  while(i>0) {
-   var j = 0
-   while(j<i) {
-   println(j +" " + i)
-   j = j + 1
-   }
-   i = i - 1}
-   pattern(1)
-   pattern(2)
-   pattern(3)
- }
+    var i = 10
+    while(i>0) {
+      var j = 0
+      while(j<i) {
+        println(j +" " + i)
+        j = j + 1
+      }
+      i = i - 1
+    }
+    pattern(1)
+    pattern(2)
+    pattern(3)
+  }
 
- def pattern(a: Int) = a match {
-  case 1 if (a>0) => println("one")
-  case t@2 => println("two" + t)
-  case _ => println("default")
- }
+  def pattern(a: Int) = a match {
+    case 1 if (a>0) => println("one")
+    case t@2 => println("two" + t)
+    case _ => println("default")
+  }
 }

--- a/tests/pos/i1442.scala
+++ b/tests/pos/i1442.scala
@@ -1,22 +1,22 @@
 object Test1442 {
   final def sumMinimized[B](num: Numeric[B]): Int = {
-       var cse: scala.math.Numeric.type = null.asInstanceOf[scala.math.Numeric.type]
-       ({cse = scala.math.Numeric; num eq cse.IntIsIntegral} ||
+      var cse: scala.math.Numeric.type = null.asInstanceOf[scala.math.Numeric.type]
+      ({cse = scala.math.Numeric; num eq cse.IntIsIntegral} ||
                (num eq cse.BigDecimalAsIfIntegral))
       2
-  } 
+  }
 
   final def sum[B](implicit num: Numeric[B]): B = {
            // arithmetic series formula  can be used for regular addition
-       var cse: scala.math.Numeric.type = null.asInstanceOf[scala.math.Numeric.type]   
+       var cse: scala.math.Numeric.type = null.asInstanceOf[scala.math.Numeric.type]
        if ({cse = scala.math.Numeric; num eq cse.IntIsIntegral}||
                (num eq cse.BigIntIsIntegral)||
                (num eq cse.ShortIsIntegral)||
                (num eq cse.ByteIsIntegral)||
                (num eq cse.CharIsIntegral)||
                (num eq cse.LongIsIntegral)||
-               (num eq cse.BigDecimalIsFractional)) {     
+               (num eq cse.BigDecimalIsFractional)) {
         null.asInstanceOf[B]
       } else null.asInstanceOf[B]
-  } 
+  }
 }

--- a/tests/pos/reference/union-types.scala
+++ b/tests/pos/reference/union-types.scala
@@ -2,36 +2,36 @@ package unionTypes
 
 object t1 {
 
-type Hash = Int
+  type Hash = Int
 
-case class UserName(name: String)
-case class Password(hash: Hash)
+  case class UserName(name: String)
+  case class Password(hash: Hash)
 
-def help(id: UserName | Password) = {
-  val user = id match {
-    case UserName(name) => lookupName(name)
-    case Password(hash) => lookupPassword(hash)
+  def help(id: UserName | Password) = {
+    val user = id match {
+      case UserName(name) => lookupName(name)
+      case Password(hash) => lookupPassword(hash)
+    }
   }
-}
 
-def lookupName(name: String) = ???
-def lookupPassword(hash: Hash) = ???
+  def lookupName(name: String) = ???
+  def lookupPassword(hash: Hash) = ???
 
 }
 
 object t2 {
   import t1._
 
-trait Admin
-trait UserData
+  trait Admin
+  trait UserData
 
-trait L { def lookup(admin: Admin): Object }
+  trait L { def lookup(admin: Admin): Object }
 
-case class UserName(name: String) extends L {
-  def lookup(admin: Admin): UserData = ???
-}
-case class Password(hash: Hash) extends L {
-  def lookup(admin: Admin): UserData = ???
-}
+  case class UserName(name: String) extends L {
+    def lookup(admin: Admin): UserData = ???
+  }
+  case class Password(hash: Hash) extends L {
+    def lookup(admin: Admin): UserData = ???
+  }
 
 }

--- a/tests/pos/scoping1.scala
+++ b/tests/pos/scoping1.scala
@@ -2,7 +2,7 @@ object This extends App {
   trait A {
     def foo(): Unit
   }
- abstract class C { self: A =>
+  abstract class C { self: A =>
     def bar() = this.foo()
   }
   class D extends C with A {

--- a/tests/pos/simple-exceptions.scala
+++ b/tests/pos/simple-exceptions.scala
@@ -7,7 +7,7 @@ object Test {
   def main(args: Array[String]): Unit = {
     try {
       try {
-          Console.println("hi!")
+        Console.println("hi!")
         sys.error("xx")
       }
       finally Console.println("ho!")

--- a/tests/pos/spec-partialmap.scala
+++ b/tests/pos/spec-partialmap.scala
@@ -4,8 +4,8 @@ import scala.collection.{Iterable,IterableOps};
 trait PartialMap[@specialized A,@specialized B] extends PartialFunction[A,B] with Iterable[(A,B)] {
    // commenting out this declaration gives a different exception.
   /** Getter for all values for which the given key function returns true. */
-   def apply(f : (A => Boolean)) : Iterator[B] =
-     for ((k,v) <- iterator; if f(k)) yield v
+  def apply(f : (A => Boolean)) : Iterator[B] =
+    for ((k,v) <- iterator; if f(k)) yield v
 
   // if this is commented, it compiles fine:
   def apply[This <: Iterable[A]](keys : IterableOps[A, Iterable, This]): Iterable[B] = keys.map(apply)

--- a/tests/pos/spec-traits.scala
+++ b/tests/pos/spec-traits.scala
@@ -57,7 +57,7 @@ object AA
         }
     }
 
-  def foo[T](x: T) = { object A; false }
+    def foo[T](x: T) = { object A; false }
 }
 
 // issue 3325

--- a/tests/pos/t1164.scala
+++ b/tests/pos/t1164.scala
@@ -1,11 +1,11 @@
 object test {
 
-        class Foo[a](val arg : a)
+    class Foo[a](val arg : a)
 
-        object Foo  {
+    object Foo  {
         def apply [a](arg : a, right :a) = new Foo[a](arg)
         def unapply [a](m : Foo[a]) = Some (m.arg)
-        }
+    }
 
     def matchAndGetArgFromFoo[a]( e:Foo[a]):a = {e match { case Foo(x) => x }}
   // Unapply node here will have type argument [a] instantiated to scala.Nothing:
@@ -18,7 +18,7 @@ object test {
     // constructor
 
     type FunIntToA [a] = (Int) => a
-        class Bar[a] (var f: FunIntToA[a])
+    class Bar[a] (var f: FunIntToA[a])
 
     object Bar {
         def apply[a](f: FunIntToA[a]) = new Bar[a](f)

--- a/tests/pos/t2591.scala
+++ b/tests/pos/t2591.scala
@@ -7,9 +7,9 @@ object Implicits {
 }
 
 object Test {
-    // should cause imp to be in scope so that the next expression type checks
-    // `import Implicits._` works
-    import Implicits.imp
+  // should cause imp to be in scope so that the next expression type checks
+  // `import Implicits._` works
+  import Implicits.imp
 
   (new A) : Int
 }

--- a/tests/pos/t3278.scala
+++ b/tests/pos/t3278.scala
@@ -20,7 +20,7 @@ object Test {
 }
 object Test2 {
     def main(args : Array[String]): Unit = {
-                args(0) += "a"
+        args(0) += "a"
         val a = new Test2
         val f = new Foo
         a(f) = 1 //works

--- a/tests/pos/t443.scala
+++ b/tests/pos/t443.scala
@@ -3,12 +3,12 @@ object Test {
   def lookup(): Option[Tuple2[String, String]] =
     ((null: Option[Tuple2[String, String]]) : @unchecked) match {
       case Some((_, _)) =>
-    if (true)
-      Some((null, null))
-    else
-      lookup() match {
-        case Some(_) => Some(null)
-        case None => None
-      }
+        if (true)
+          Some((null, null))
+        else
+          lookup() match {
+            case Some(_) => Some(null)
+            case None => None
+          }
     }
 }

--- a/tests/pos/t5508.scala
+++ b/tests/pos/t5508.scala
@@ -13,7 +13,7 @@ object Base1 {
     private[this] var _st : Int = 0
     def close : PartialFunction[Any,Any] = {
       case x : Int =>
-  _st = identity(_st)
+        _st = identity(_st)
     }
   }
 }
@@ -31,7 +31,7 @@ object Base2 {
     private[this] var _st : Int = 0
     def close : PartialFunction[Any,Any] = {
       case x : Int =>
-  _st = 1
+        _st = 1
     }
   }
 }
@@ -41,7 +41,7 @@ class Base3 {
     private[this] var _st : Int = 0
     def close : PartialFunction[Any,Any] = {
       case x : Int =>
-  _st = 1
+        _st = 1
     }
   }
 }

--- a/tests/pos/t6335.scala
+++ b/tests/pos/t6335.scala
@@ -21,5 +21,5 @@ object Test {
 
     "".yy
 
-  true.zz
+    true.zz
 }

--- a/tests/pos/t8230a.scala
+++ b/tests/pos/t8230a.scala
@@ -15,8 +15,8 @@ object Test {
   object Okay {
     Arr("1")
 
-   import I.{ arrToTrav, longArrToTrav }
-   val x = foo(Arr("2"))
+    import I.{ arrToTrav, longArrToTrav }
+    val x = foo(Arr("2"))
  }
 
   object Fail {

--- a/tests/pos/unapplyComplex.scala
+++ b/tests/pos/unapplyComplex.scala
@@ -14,26 +14,26 @@ object ComplexRect {
   def unapply(z:Complex): Option[Complex] = {
     if (z.isInstanceOf[ComplexRect]) Some(z) else z match {
       case ComplexPolar(mod, arg) =>
-    Some(new ComplexRect(mod*math.cos(arg), mod*math.sin(arg)))
+        Some(new ComplexRect(mod*math.cos(arg), mod*math.sin(arg)))
 } } }
 
 object ComplexPolar {
   def unapply(z:Complex): Option[Complex] = {
     if (z.isInstanceOf[ComplexPolar]) Some(z) else z match {
       case ComplexRect(re,im) =>
-    Some(new ComplexPolar(math.sqrt(re*re + im*im), math.atan(re/im)))
+        Some(new ComplexPolar(math.sqrt(re*re + im*im), math.atan(re/im)))
 } } }
 
 object Test {
   def main(args:Array[String]) = {
     new ComplexRect(1,1) match {
       case ComplexPolar(mod,arg) => // z @ ???
-    Console.println("mod"+mod+"arg"+arg)
+        Console.println("mod"+mod+"arg"+arg)
     }
     val Komplex = ComplexRect
     new ComplexPolar(math.sqrt(2),math.Pi / 4.0) match {
       case Komplex(re,im) => // z @ ???
-    Console.println("re"+re+" im"+im)
+        Console.println("re"+re+" im"+im)
     }
   }
 }

--- a/tests/run-staging/shonan-hmm-simple.scala
+++ b/tests/run-staging/shonan-hmm-simple.scala
@@ -71,8 +71,7 @@ case class Complex[T](re: T, im: T)
 
 object Complex
   implicit def isLiftable[T: Type: Liftable]: Liftable[Complex[T]] = new Liftable[Complex[T]]
-    def toExpr(comp: Complex[T]) = '{Complex(${comp.re}, ${comp.im})}
-
+  def toExpr(comp: Complex[T]) = '{Complex(${comp.re}, ${comp.im})}
 
 case class Vec[Idx, T](size: Idx, get: Idx => T) {
   def map[U](f: T => U): Vec[Idx, U] = Vec(size, i => f(get(i)))

--- a/tests/run-staging/shonan-hmm-simple.scala
+++ b/tests/run-staging/shonan-hmm-simple.scala
@@ -70,8 +70,9 @@ class RingPV[U: Liftable](u: Ring[U], eu: Ring[Expr[U]])(given QuoteContext) ext
 case class Complex[T](re: T, im: T)
 
 object Complex
-  implicit def isLiftable[T: Type: Liftable]: Liftable[Complex[T]] = new Liftable[Complex[T]]
-  def toExpr(comp: Complex[T]) = '{Complex(${comp.re}, ${comp.im})}
+  implicit def isLiftable[T: Type: Liftable]: Liftable[Complex[T]] = new Liftable[Complex[T]] {
+    def toExpr(comp: Complex[T]) = '{Complex(${comp.re}, ${comp.im})}
+  }
 
 case class Vec[Idx, T](size: Idx, get: Idx => T) {
   def map[U](f: T => U): Vec[Idx, U] = Vec(size, i => f(get(i)))

--- a/tests/run-staging/shonan-hmm-simple.scala
+++ b/tests/run-staging/shonan-hmm-simple.scala
@@ -2,29 +2,28 @@ import scala.quoted._
 import scala.quoted.staging._
 import scala.quoted.autolift.given
 
-trait Ring[T] {
+trait Ring[T]
   val zero: T
   val one: T
   val add: (x: T, y: T) => T
   val sub: (x: T, y: T) => T
   val mul: (x: T, y: T) => T
-}
+end Ring
 
-class RingInt extends Ring[Int] {
+class RingInt extends Ring[Int]
   val zero = 0
   val one  = 1
   val add  = (x, y) => x + y
   val sub  = (x, y) => x - y
   val mul  = (x, y) => x * y
-}
 
-class RingIntExpr(given QuoteContext) extends Ring[Expr[Int]] {
+
+class RingIntExpr(given QuoteContext) extends Ring[Expr[Int]]
   val zero = '{0}
   val one  = '{1}
   val add  = (x, y) => '{$x + $y}
   val sub  = (x, y) => '{$x - $y}
   val mul  = (x, y) => '{$x * $y}
-}
 
 class RingComplex[U](u: Ring[U]) extends Ring[Complex[U]] {
   val zero = Complex(u.zero, u.zero)
@@ -34,15 +33,14 @@ class RingComplex[U](u: Ring[U]) extends Ring[Complex[U]] {
   val mul  = (x, y) => Complex(u.sub(u.mul(x.re, y.re), u.mul(x.im, y.im)), u.add(u.mul(x.re, y.im), u.mul(x.im, y.re)))
 }
 
-sealed trait PV[T] {
+sealed trait PV[T]
   def expr(given Liftable[T], QuoteContext): Expr[T]
-}
-case class Sta[T](x: T) extends PV[T] {
+
+case class Sta[T](x: T) extends PV[T]
   def expr(given Liftable[T], QuoteContext): Expr[T] = x
-}
-case class Dyn[T](x: Expr[T]) extends PV[T] {
+
+case class Dyn[T](x: Expr[T]) extends PV[T]
   def expr(given Liftable[T], QuoteContext): Expr[T] = x
-}
 
 class RingPV[U: Liftable](u: Ring[U], eu: Ring[Expr[U]])(given QuoteContext) extends Ring[PV[U]] {
   val zero: PV[U] = Sta(u.zero)
@@ -71,11 +69,10 @@ class RingPV[U: Liftable](u: Ring[U], eu: Ring[Expr[U]])(given QuoteContext) ext
 
 case class Complex[T](re: T, im: T)
 
-object Complex {
-  implicit def isLiftable[T: Type: Liftable]: Liftable[Complex[T]] = new Liftable[Complex[T]] {
+object Complex
+  implicit def isLiftable[T: Type: Liftable]: Liftable[Complex[T]] = new Liftable[Complex[T]]
     def toExpr(comp: Complex[T]) = '{Complex(${comp.re}, ${comp.im})}
-  }
-}
+
 
 case class Vec[Idx, T](size: Idx, get: Idx => T) {
   def map[U](f: T => U): Vec[Idx, U] = Vec(size, i => f(get(i)))
@@ -99,17 +96,15 @@ class StaticVecOps[T] extends VecOps[Int, T] {
   }
 }
 
-class ExprVecOps[T: Type](given QuoteContext) extends VecOps[Expr[Int], Expr[T]] {
+class ExprVecOps[T: Type](given QuoteContext) extends VecOps[Expr[Int], Expr[T]]
   val reduce: ((Expr[T], Expr[T]) => Expr[T], Expr[T], Vec[Expr[Int], Expr[T]]) => Expr[T] = (plus, zero, vec) => '{
     var sum = $zero
     var i = 0
-    while (i < ${vec.size}) {
+    while i < ${vec.size} do
       sum = ${ plus('sum, vec.get('i)) }
       i += 1
-    }
     sum
   }
-}
 
 class Blas1[Idx, T](r: Ring[T], ops: VecOps[Idx, T]) {
   def dot(v1: Vec[Idx, T], v2: Vec[Idx, T]): T = ops.reduce(r.add, r.zero, v1.zipWith(v2, r.mul))

--- a/tests/run/Course-2002-08.scala
+++ b/tests/run/Course-2002-08.scala
@@ -517,9 +517,9 @@ abstract class CircuitSimulator() extends BasicCircuitSimulator() {
   def demux2(in: Wire, ctrl: List[Wire], out: List[Wire]) : Unit = {
     val ctrlN = ctrl.map(w => { val iw = new Wire(); inverter(w,iw); iw});
     val w0 = new Wire();
-  val w1 = new Wire();
-  val w2 = new Wire();
-  val w3 = new Wire();
+    val w1 = new Wire();
+    val w2 = new Wire();
+    val w3 = new Wire();
 
     andGate(in, ctrl(1), w3);
     andGate(in, ctrl(1), w2);

--- a/tests/run/classTags.scala
+++ b/tests/run/classTags.scala
@@ -3,7 +3,8 @@ object Test {
 
 /*  val a /* : Class[T]                  */ = classOf[T]                        // [Ljava/lang/String;
   println(a)
-*/  val b /* : ClassTag[T]               */ = reflect.classTag[T]               // ClassTag(classOf[java.lang.String])
+*/
+  val b /* : ClassTag[T]               */ = reflect.classTag[T]               // ClassTag(classOf[java.lang.String])
 /*  println(b)
 
   val d /* : ClassTag[T with U]        */ = reflect.classTag[T with U]        // ClassTag(classOf[java.lang.String])

--- a/tests/run/coop-equality.scala
+++ b/tests/run/coop-equality.scala
@@ -17,6 +17,6 @@ object Test extends App {
       val a = A("")
       val b = B("")
 
-  assert(a === b)
-  assert(!((a: ANY) === (b: ANY)))
+      assert(a === b)
+      assert(!((a: ANY) === (b: ANY)))
 }

--- a/tests/run/generic/Serialization.scala
+++ b/tests/run/generic/Serialization.scala
@@ -92,10 +92,10 @@ object Serialization {
         ev1.write(x.fst, out)
         ev2.write(x.snd, out)
       }
-    def read(in: DataInputStream) = {
-      Prod(ev1.read(in), ev2.read(in))
+      def read(in: DataInputStream) = {
+        Prod(ev1.read(in), ev2.read(in))
+      }
     }
-  }
 
   implicit def IterableSerializable[I[X] <: Iterable[X], Elem](implicit
     ev1: IterableFactory[I],

--- a/tests/run/lists-run.scala
+++ b/tests/run/lists-run.scala
@@ -69,10 +69,10 @@ min cardinality(ys, e)))
       }, "obey min cardinality")
     assert({
         val intersection = xs intersect ys
-    val unconsumed = xs.foldLeft(intersection){(rest, e) =>
-      if (! rest.isEmpty && e == rest.head) rest.tail else rest
-    }
-    unconsumed.isEmpty
+        val unconsumed = xs.foldLeft(intersection){(rest, e) =>
+          if (! rest.isEmpty && e == rest.head) rest.tail else rest
+        }
+        unconsumed.isEmpty
       }, "maintain order")
     assert(xs == (xs intersect xs),
       "has the list as again intersection")
@@ -87,47 +87,47 @@ object Test1 {
     val xs4 = List(2, 4, 6, 8)
     val xs5 = List(List(3, 4), List(3), List(4, 5))
 
-  {
-    val n1 = xs1 count { e => e % 2 != 0 }
-    val n2 = xs4 count { e => e < 5 }
-    assert(4 == (n1 + n2), "check_count")
-  }
-  {
-    val b1 = xs1 exists { e => e % 2 == 0 }
-    val b2 = xs4 exists { e => e == 5 }
-    assert(!(b1 & b2), "check_exists")
-  }
-  {
-    val ys1 = xs1 filter { e => e % 2 == 0 }
-    val ys2 = xs4 filter { e => e < 5 }
-    assert(3 == ys1.length + ys2.length, "check_filter")
-  }
-  {
-    val n1 = xs1.foldLeft(0)((e1, e2) => e1 + e2)
-    val ys1 = xs4.foldLeft(List[Int]())((e1, e2) => e2 :: e1)
-    assert(10 == n1 + ys1.length, "check_foldLeft")
-  }
-  {
-    val b1 = xs1 forall { e => e < 10}
-    val b2 = xs4 forall { e => e % 2 == 0 }
-    assert(b1 & b2, "check_forall")
-  }
-  {
-    val ys1 = xs1 filterNot { e => e % 2 != 0 }
-    val ys2 = xs4 filterNot { e => e < 5 }
-    assert(3 == ys1.length + ys2.length, "check_remove")
-  }
-  {
-    val ys1 = xs1 zip xs2
-    val ys2 = xs1 zip xs3
-    assert(4 == ys1.length + ys2.length, "check_zip")
-  }
-  {
-    val ys1 = xs1.zipAll(xs2, 0, '_')
-    val ys2 = xs2.zipAll(xs1, '_', 0)
-    val ys3 = xs1.zipAll(xs3, 0, List(-1))
-    assert(9 == ys1.length + ys2.length + ys3.length, "check_zipAll")
-  }
+    {
+      val n1 = xs1 count { e => e % 2 != 0 }
+      val n2 = xs4 count { e => e < 5 }
+      assert(4 == (n1 + n2), "check_count")
+    }
+    {
+      val b1 = xs1 exists { e => e % 2 == 0 }
+      val b2 = xs4 exists { e => e == 5 }
+      assert(!(b1 & b2), "check_exists")
+    }
+    {
+      val ys1 = xs1 filter { e => e % 2 == 0 }
+      val ys2 = xs4 filter { e => e < 5 }
+      assert(3 == ys1.length + ys2.length, "check_filter")
+    }
+    {
+      val n1 = xs1.foldLeft(0)((e1, e2) => e1 + e2)
+      val ys1 = xs4.foldLeft(List[Int]())((e1, e2) => e2 :: e1)
+      assert(10 == n1 + ys1.length, "check_foldLeft")
+    }
+    {
+      val b1 = xs1 forall { e => e < 10}
+      val b2 = xs4 forall { e => e % 2 == 0 }
+      assert(b1 & b2, "check_forall")
+    }
+    {
+      val ys1 = xs1 filterNot { e => e % 2 != 0 }
+      val ys2 = xs4 filterNot { e => e < 5 }
+      assert(3 == ys1.length + ys2.length, "check_remove")
+    }
+    {
+      val ys1 = xs1 zip xs2
+      val ys2 = xs1 zip xs3
+      assert(4 == ys1.length + ys2.length, "check_zip")
+    }
+    {
+      val ys1 = xs1.zipAll(xs2, 0, '_')
+      val ys2 = xs2.zipAll(xs1, '_', 0)
+      val ys3 = xs1.zipAll(xs3, 0, List(-1))
+      assert(9 == ys1.length + ys2.length + ys3.length, "check_zipAll")
+    }
   }
 }
 

--- a/tests/run/llift.scala
+++ b/tests/run/llift.scala
@@ -48,7 +48,7 @@ object Test {
         new C2().f3
       }
 //    }
-    /*new C1().*/f2
+      /*new C1().*/f2
   }
 
   def f1b(x: Int) = {

--- a/tests/run/serialization-new.scala
+++ b/tests/run/serialization-new.scala
@@ -482,8 +482,8 @@ class WithTransient extends Serializable {
 }
 
 object Test8 {
-    val x = new WithTransient
-    x.test
+  val x = new WithTransient
+  x.test
   try {
     val y:WithTransient = read(write(x))
     y.test

--- a/tests/run/typeclass-derivation2.scala
+++ b/tests/run/typeclass-derivation2.scala
@@ -253,7 +253,7 @@ object Eq {
           case _ =>
             error("invalid call to eqlCases: one of Alts is not a subtype of T")
         }
-     case _: Unit =>
+      case _: Unit =>
         false
     }
 

--- a/tests/run/typeclass-derivation2a.scala
+++ b/tests/run/typeclass-derivation2a.scala
@@ -240,7 +240,7 @@ object Eq {
       case _: (Shape.Case[alt, elems] *: alts1) =>
         if (xm.ordinal == n) eqlElems[elems](xm, ym, 0)
         else eqlCases[alts1](xm, ym, n + 1)
-     case _: Unit =>
+      case _: Unit =>
         false
     }
 

--- a/tests/run/typeclass-derivation2b.scala
+++ b/tests/run/typeclass-derivation2b.scala
@@ -121,7 +121,7 @@ object Eq {
                 0)
           }
         else eqlCases[T, alts1](x, y, genSum, ord, n + 1)
-     case _: Unit =>
+      case _: Unit =>
         false
     }
 

--- a/tests/run/virtpatmat_try.scala
+++ b/tests/run/virtpatmat_try.scala
@@ -20,7 +20,7 @@ object Test extends App {
     case _: Throwable => println("other")
   }
 
- def simpleTry: Unit = {
+  def simpleTry: Unit = {
     try {
       bla
     } catch {


### PR DESCRIPTION
Issue warnings if brace structure does not correspond to indentation structure. 

There are three cases. 

**Case 1**: In a brace-delimited region, if there would be an `<outdent>` between
one line and the next, a warning is now issued that states:

    Line is indented too far to the left or a `}' is missing

This is very helpful for finding missing closing braces. It prevents errors like:

```scala
if (x < 0) {
  println(1)
  println(2)

println("done")
```


**Case 2**: If significant indentation is turned off (i.e. under -noindent) and we are at the start
of an indented sub-part (i.e. an `<indent>` would have been inserted under significant indentation),
and the indented part ends in a newline, check that the next statement starts at an indentation width less than the sub-part. This prevents errors like

```scala
if (x < 0)
  println(1)
  println(2)

println("done")
```

**Case 3**: Under -noindent, warn if code that follows an empty template is
indented more deeply than the template header. Inserting braces
automatically would change meaning in this case.

Example:

```scala
  trait A
    case class B() extends A  // error: Line is indented too far to the right
    case object C extends A   // error: Line is indented too far to the right
```