### PR TITLE
Enable javalib/net/URLDecoderTest.scala for Scala.js

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -982,6 +982,7 @@ object Build {
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ref" ** ("ReferenceTest.scala": FileFilter)).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect" ** ("ReflectArrayTest.scala": FileFilter)).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/io" ** (("ThrowablesTest.scala": FileFilter) || "SerializableTest.scala" || "PrintWriterTest.scala")).get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/net" ** ("URLDecoderTest.scala": FileFilter)).get
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang" ** "*.scala").get
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util" ** (("Base64Test.scala": FileFilter) || "OptionalTest.scala" || "SplittableRandom.scala" || "ObjectsTestOnJDK8.scala" || "ComparatorTestOnJDK8.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/utils" ** "*.scala").get


### PR DESCRIPTION
One ([`javalib/net/URLDecoderTest.scala`](https://github.com/scala-js/scala-js/blob/v1.0.0-M8/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URLDecoderTest.scala)) out of two tests from the [`javalib.net`](https://github.com/scala-js/scala-js/blob/v1.0.0-M8/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/) group has been enabled. The second one ([`javalib/net/URITest.scala`](https://github.com/scala-js/scala-js/blob/v1.0.0-M8/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala)) [fails](https://gist.github.com/neshkeev/d19a8d368b88c81a3916496fb250b430)