### PR TITLE
Fix errors while running publishSigned

### DIFF
--- a/project/scripts/sbtPublish
+++ b/project/scripts/sbtPublish
@@ -18,10 +18,15 @@ if [ ! "$NIGHTLYBUILD" = "yes" ] && [ ! "$RELEASEBUILD" = "yes" ]; then
     exit 1
 fi
 
-# Setup gpg
-export GPG_TTY="$(tty)"
-echo "$PGP_SECRET" | gpg --batch --import
+# Setup gpg (disabled, we use bouncycastle instead)
+# export GPG_TTY="$(tty)"
+# echo "$PGP_SECRET" | gpg --batch --import
+
+# Setup bouncycastle instead of gpg to do signing, because gpg explodes when
+# doing too many signing requests in parallel (https://github.com/sbt/sbt-pgp/issues/168)
+mkdir -p "$HOME/.sbt/gpg"
+echo "$PGP_SECRET" > "$HOME/.sbt/gpg/secring.asc"
 
 # run sbt with the supplied arg
 SBT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/sbt"
-"$SBT" "$RELEASE_CMD"
+"$SBT" -DSBT_PGP_USE_GPG=false "$RELEASE_CMD"


### PR DESCRIPTION
In 54266c1320f9a330ddb0cf3d276ff1206f757c95 I upgraded sbt-pgp from
1.1.0 to 2.0.0-M2, this changed the way signing was done: instead of
using the bouncycastle Java library, sbt-pgp now just calls gpg.
Unfortunately, it turns out that multiple parallel calls to gpg can lead
to the gpg-agent running out of memory, causing `publishSigned` to
fai, as happened in https://dotty-ci.epfl.ch/lampepfl/dotty/1487/1/8
while trying to publish Dotty 0.19.0-RC1:
gpg: signing failed: Cannot allocate memory

I've opened an issue at https://github.com/sbt/sbt-pgp/issues/168, but
meanwhile this is fixed by reverting back to using bouncycastle by
setting SBT_PGP_USE_GPG=0 as documented in the README of sbt-pgp.