### PR TITLE
Enable javalib security and util sjs tests

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -984,6 +984,7 @@ object Build {
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/io" ** (("ThrowablesTest.scala": FileFilter) || "SerializableTest.scala" || "PrintWriterTest.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/math" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/net" ** ("URLDecoderTest.scala": FileFilter)).get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/security" ** "*.scala").get
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang" ** "*.scala").get
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util" ** (("Base64Test.scala": FileFilter) || "OptionalTest.scala" || "SplittableRandom.scala" || "ObjectsTestOnJDK8.scala" || "ComparatorTestOnJDK8.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/utils" ** "*.scala").get

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -985,6 +985,7 @@ object Build {
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/math" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/net" ** ("URLDecoderTest.scala": FileFilter)).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/security" ** "*.scala").get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/util" ** (("ArraysTest.scala": FileFilter) || "UUIDTest.scala" || "ThrowablesTest.scala" || "RandomTest.scala" || "PropertiesTest.scala" || "PriorityQueueTest.scala" || "HashtableTest.scala" || "DateTest.scala")).get
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang" ** "*.scala").get
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util" ** (("Base64Test.scala": FileFilter) || "OptionalTest.scala" || "SplittableRandom.scala" || "ObjectsTestOnJDK8.scala" || "ComparatorTestOnJDK8.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/utils" ** "*.scala").get


### PR DESCRIPTION
The following test from `javalib/secutity` (the only one in the group) has been enabled:
1. javalib/security/ThrowablesTest.scala

The following tests from `javalib/util` have been enabled:
1. javalib/util/ArraysTest.scala                                      
2. javalib/util/UUIDTest.scala                                        
3. javalib/util/ThrowablesTest.scala
4. javalib/util/RandomTest.scala                                      
5. javalib/util/PropertiesTest.scala
6. javalib/util/PriorityQueueTest.scala                                                                                                        
7. javalib/util/HashtableTest.scala                                                                                                            
8. javalib/util/DateTest.scala
