### PR TITLE
Auto-unindent end

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1061,7 +1061,7 @@ object Build {
   lazy val `vscode-dotty` = project.in(file("vscode-dotty")).
     settings(commonSettings).
     settings(
-      version := "0.1.16", // Keep in sync with package.json
+      version := "0.1.17-snapshot", // Keep in sync with package.json
       autoScalaLibrary := false,
       publishArtifact := false,
       includeFilter in unmanagedSources := NothingFilter | "*.ts" | "**.json",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1061,7 +1061,7 @@ object Build {
   lazy val `vscode-dotty` = project.in(file("vscode-dotty")).
     settings(commonSettings).
     settings(
-      version := "0.1.16-snapshot", // Keep in sync with package.json
+      version := "0.1.16", // Keep in sync with package.json
       autoScalaLibrary := false,
       publishArtifact := false,
       includeFilter in unmanagedSources := NothingFilter | "*.ts" | "**.json",

--- a/vscode-dotty/package-lock.json
+++ b/vscode-dotty/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dotty",
-  "version": "0.1.16",
+  "version": "0.1.17-snapshot",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vscode-dotty/package-lock.json
+++ b/vscode-dotty/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dotty",
-  "version": "0.1.16-snapshot",
+  "version": "0.1.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -2,7 +2,7 @@
   "name": "dotty",
   "displayName": "Dotty Language Server",
   "description": "IDE integration for Dotty, the experimental Scala compiler",
-  "version": "0.1.16",
+  "version": "0.1.17-snapshot",
   "license": "BSD-3-Clause",
   "publisher": "lampepfl",
   "repository": {

--- a/vscode-dotty/package.json
+++ b/vscode-dotty/package.json
@@ -2,7 +2,7 @@
   "name": "dotty",
   "displayName": "Dotty Language Server",
   "description": "IDE integration for Dotty, the experimental Scala compiler",
-  "version": "0.1.16-snapshot",
+  "version": "0.1.16",
   "license": "BSD-3-Clause",
   "publisher": "lampepfl",
   "repository": {

--- a/vscode-dotty/src/extension.ts
+++ b/vscode-dotty/src/extension.ts
@@ -54,8 +54,12 @@ export function activate(context: ExtensionContext) {
   // package.json does not work)
   vscode.languages.setLanguageConfiguration("scala", {
     "indentationRules": {
-      // Auto-indent when pressing enter on a line matching this regexp
-      "increaseIndentPattern": /(((\b(then|else|do|catch|finally|yield|match|while|try|for|if|case)\b)|\bif\s*\(.*\)|=|=>|<-|=>>)\s*$)/,
+      // Auto-indent when pressing enter on a line matching this regexp, in details:
+      // 1. If they're not preceded by `end`, auto-indent after `while`, `for`, `match`, `try`, `if`
+      // 2. Auto-indent after `if ...` as long as it doesn't match `if ... then ...`
+      // 3. Auto-indent after `then`, `else`, `do`, `catch`, `finally`, `yield`, `case`, `=`, `=>`, `<-`, `=>>`x
+      "increaseIndentPattern":
+        /(((?<!\bend\b\s*?)\b(if|while|for|match|try))|(\bif\s+(?!.*?\bthen\b.*?$)[^\s]*?)|(\b(then|else|do|catch|finally|yield|case))|=|=>|<-|=>>)\s*?$/,
       // Auto-unindent disabled, because it doesn't work well with all
       // indentation styles
       "decreaseIndentPattern": /^.$/

--- a/vscode-dotty/src/extension.ts
+++ b/vscode-dotty/src/extension.ts
@@ -60,9 +60,8 @@ export function activate(context: ExtensionContext) {
       // 3. Auto-indent after `then`, `else`, `do`, `catch`, `finally`, `yield`, `case`, `=`, `=>`, `<-`, `=>>`x
       "increaseIndentPattern":
         /(((?<!\bend\b\s*?)\b(if|while|for|match|try))|(\bif\s+(?!.*?\bthen\b.*?$)[^\s]*?)|(\b(then|else|do|catch|finally|yield|case))|=|=>|<-|=>>)\s*?$/,
-      // Auto-unindent disabled, because it doesn't work well with all
-      // indentation styles
-      "decreaseIndentPattern": /^.$/
+      // Only auto-unindent completed `end` folowed by `while`, `for`, `match`, `try`, `if`
+      "decreaseIndentPattern": /(\bend\b\s*)\b(if|while|for|match|try)$/
     }
   })
 

--- a/vscode-dotty/src/extension.ts
+++ b/vscode-dotty/src/extension.ts
@@ -61,7 +61,7 @@ export function activate(context: ExtensionContext) {
       "increaseIndentPattern":
         /(((?<!\bend\b\s*?)\b(if|while|for|match|try))|(\bif\s+(?!.*?\bthen\b.*?$)[^\s]*?)|(\b(then|else|do|catch|finally|yield|case))|=|=>|<-|=>>)\s*?$/,
       // Only auto-unindent completed `end` folowed by `while`, `for`, `match`, `try`, `if`
-      "decreaseIndentPattern": /(\bend\b\s*)\b(if|while|for|match|try)$/
+      "decreaseIndentPattern": /(^\s*end\b\s*)\b(if|while|for|match|try)$/
     }
   })
 


### PR DESCRIPTION
Based on #7278 
Auto-unindent completed `end` folowed by `while`, `for`, `match`, `try`, `if`.

Example:
```scala
if a then 
  b
else
  c
  end i
```

```scala
if a then 
  b
else
  c
end if
```