### PR TITLE
Fixes #6626. Pass sym.name to sanitizeName instead of sym.name.asSimpleName

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -6,7 +6,7 @@ import core.Annotations.Annotation
 import core.Contexts.Context
 import core.Definitions
 import core.Flags._
-import core.Names.Name
+import core.Names.{DerivedName, Name, SimpleName, TypeName}
 import core.Symbols._
 import core.TypeApplications.TypeParamInfo
 import core.TypeErasure.erasure
@@ -16,6 +16,8 @@ import ast.Trees._
 import SymUtils._
 import TypeUtils._
 import java.lang.StringBuilder
+
+import scala.annotation.tailrec
 
 /** Helper object to generate generic java signatures, as defined in
  *  the Java Virtual Machine Specification, §4.3.4
@@ -161,7 +163,7 @@ object GenericSignatures {
 
             // TODO revisit this. Does it align with javac for code that can be expressed in both languages?
             val delimiter = if (builder.charAt(builder.length() - 1) == '>') '.' else '$'
-            builder.append(delimiter).append(sanitizeName(sym.name.asSimpleName))
+            builder.append(delimiter).append(sanitizeName(sym.name))
           }
           else fullNameInSig(sym)
         }

--- a/tests/generic-java-signatures/derivedNames.check
+++ b/tests/generic-java-signatures/derivedNames.check
@@ -1,0 +1,1 @@
+Test$Foo$A<Test$Foo<T1>$B$>

--- a/tests/generic-java-signatures/derivedNames.scala
+++ b/tests/generic-java-signatures/derivedNames.scala
@@ -1,0 +1,15 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val objectB = classOf[Foo[Any]].getClasses
+    val returnType = objectB(1).getDeclaredMethod("m").getGenericReturnType
+    println(returnType)
+  }
+  class Foo[T1] {
+    class A[T2]
+
+    object B  {
+      def m: A[B.type] = ???
+    }
+  }
+}
+


### PR DESCRIPTION
`asSimpleName` method on `DerivedName` is implemented to throw `UnspportedOperationException`. The class `GenericSignatures`'s method `classSig` calls `asSimpleName` on instances of `Name` without checking on the actual type (`DerivedName` extends `TermName` which extends `Name`). 
~~A check has been added to refrain calling `asSimpleName` if the type is `DerivedName`. ~~
As @smarter suggested, refrained from calling `asSimpleName` for all the cases because `mangledString` takes care of giving the name of the class in byte code and it is already being called by `sanitizeName`. 