### PR TITLE
Enable compiler/* tests for Scala.js

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -977,7 +977,7 @@ object Build {
       managedSources in Test ++= {
         val dir = fetchScalaJSSource.value / "test-suite"
         (
-          (dir / "shared/src/test/scala/org/scalajs/testsuite/compiler" ** (("IntTest.scala": FileFilter) || "BooleanTest.scala" || "ByteTest.scala" || "CharTest.scala" || "DoubleTest.scala" || "FloatTest.scala" || "ShortTest.scala" || "UnitTest.scala")).get
+          (dir / "shared/src/test/scala/org/scalajs/testsuite/compiler" ** (("*.scala":FileFilter) -- "RegressionTest.scala" -- "ReflectiveCallTest.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/lang" ** (("*.scala": FileFilter) -- "ClassTest.scala" -- "StringTest.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/io" ** (("ThrowablesTest.scala": FileFilter) || "SerializableTest.scala" || "PrintWriterTest.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/math" ** "*.scala").get


### PR DESCRIPTION
The following tests for the **`compiler/*`** group enabled:

- compiler/PatMatOuterPointerCheckTest.scala
- compiler/OuterClassTest.scala
- compiler/MatchTest.scala
- compiler/LongTest.scala
- compiler/ArrayTest.scala

Signed-off-by: Nikita Eshkeev <kastolom@gmail.com>