### PR TITLE
Enable niobuffer/* tests for Scala.js

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -990,6 +990,7 @@ object Build {
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util" ** (("Base64Test.scala": FileFilter) || "OptionalTest.scala" || "SplittableRandom.scala" || "ObjectsTestOnJDK8.scala" || "ComparatorTestOnJDK8.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/utils" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/junit" ** (("JUnitAnnotationsTest.scala": FileFilter) || "JUnitAssumptionsTest.scala" || "JUnitAssertionsTest.scala")).get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niobuffer" ** (("ByteBufferFactories.scala": FileFilter) || "BufferFactory.scala" || "BufferAdapter.scala" || "BaseBufferTest.scala" || "ShortBufferTest.scala" || "LongBufferTest.scala" || "IntBufferTest.scala" || "FloatBufferTest.scala" || "DoubleBufferTest.scala" || "CharBufferTest.scala")).get
         )
       }
     )


### PR DESCRIPTION
The following tests from the **`niobuffer/*`** group are enabled:

- niobuffer/ByteBufferFactories.scala
- niobuffer/BufferFactory.scala
- niobuffer/BufferAdapter.scala
- niobuffer/BaseBufferTest.scala