### PR TITLE
Fix #7314: Issue warnings when pattern matching against opaque types

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -664,6 +664,14 @@ class Typer extends Namer
         val tpt1 = typedTpt
         if (!ctx.isAfterTyper && pt != defn.ImplicitScrutineeTypeRef)
           ctx.addMode(Mode.GadtConstraintInference).typeComparer.constrainPatternType(tpt1.tpe, pt)
+          if (tpt1.tpe.typeSymbol.isOpaqueAlias || pt.typeSymbol.isOpaqueAlias)
+             && !(pt <:< tpt1.tpe)
+             && !tpt1.tpe.hasAnnotation(defn.UncheckedAnnot)
+          then
+            def tpStr(tp: Type) = if tp.typeSymbol.isOpaqueAlias then i"opaque type $tp" else i"type $tp"
+            ctx.warning(
+              em"type test of scrutinee of ${tpStr(pt)} against ${tpStr(tpt1.tpe)} cannot be checked at runtime",
+              tree.sourcePos)
         // special case for an abstract type that comes with a class tag
         tryWithClassTag(ascription(tpt1, isWildcard = true), pt)
       }

--- a/tests/neg-custom-args/fatal-warnings/i7314.scala
+++ b/tests/neg-custom-args/fatal-warnings/i7314.scala
@@ -1,0 +1,29 @@
+object Test {
+
+  // conversion into the opaque type:
+  val arr = Array(1,2,3)
+  val imm0: IArray[Int] // supposedly immutable
+    = oops(arr)
+  println(imm0(0)) // 1
+  arr(0) = 0
+  println(imm0(0)) // 0, the value has changed!
+
+  // conversion out of the opaque type:
+  val imm1 = IArray(1,2,3) // supposedly immutable
+  println(imm1(0)) // 1
+  imm1 match {
+    case a: Array[Int] =>   // error: type test of scrutinee of opaque type opaques.IArray[Int] against type Array[Int] cannot be checked at runtime
+      a(0) = 0
+  }
+  println(imm1(0)) // 0
+
+  opaque type IA[A] = Array[A]
+
+  ??? : IA[Int] match {
+    case a: IArray[Int] => a  // error: type test of scrutinee of opaque type Test.IA[Int] against opaque type opaques.IArray[Int] cannot be checked at runtime
+  }
+
+  def oops(a: Array[Int]): IArray[Int] = a match {
+    case a: IArray[Int] => a // error: type test of scrutinee of type Array[Int] against opaque type opaques.IArray[Int] cannot be checked at runtime
+  }
+}


### PR DESCRIPTION
Issue warnings when scrutinee type or match type in a pattern match is an opaque type. 

This is an incomplete check, since one can always avoid some checks by upcasting the scrutinee to Any. Also `isInstanceOf` is not covered, only `_: T` matches are.
