### PR TITLE
Fix #7319: Properly support @serialVersionUID

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -421,7 +421,7 @@ trait BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
     def addSerialVUID(id: Long, jclass: asm.ClassVisitor): Unit = {
       // add static serialVersionUID field if `clasz` annotated with `@SerialVersionUID(uid: Long)`
       jclass.visitField(
-        GenBCodeOps.PublicStaticFinal,
+        GenBCodeOps.PrivateStaticFinal,
         "serialVersionUID",
         "J",
         null, // no java-generic-signature

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -791,8 +791,14 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
     }
     def methodSymbols: List[Symbol] =
       for (f <- toDenot(sym).info.decls.toList if f.isMethod && f.isTerm && !f.isModule) yield f
-    def serialVUID: Option[Long] = None
-
+    def serialVUID: Option[Long] =
+      sym.getAnnotation(defn.SerialVersionUIDAnnot).flatMap { annot =>
+        val vuid = annot.argumentConstant(0).map(_.longValue)
+        if (vuid.isEmpty)
+          ctx.error("The argument passed to @SerialVersionUID must be a constant",
+            annot.argument(0).getOrElse(annot.tree).sourcePos)
+        vuid
+      }
 
     def freshLocal(cunit: CompilationUnit, name: String, tpe: Type, pos: Position, flags: Flags): Symbol = {
       ctx.newSymbol(sym, name.toTermName, termFlagSet(flags), tpe, NoSymbol, pos)

--- a/compiler/src/dotty/tools/backend/jvm/GenBCodeOps.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCodeOps.scala
@@ -11,4 +11,5 @@ class GenBCodeOps {
 
   final val PublicStatic      = asm.Opcodes.ACC_PUBLIC | asm.Opcodes.ACC_STATIC
   final val PublicStaticFinal = asm.Opcodes.ACC_PUBLIC | asm.Opcodes.ACC_STATIC | asm.Opcodes.ACC_FINAL
+  final val PrivateStaticFinal = asm.Opcodes.ACC_PRIVATE | asm.Opcodes.ACC_STATIC | asm.Opcodes.ACC_FINAL
 }

--- a/tests/neg/serialversionuid-not-const.scala
+++ b/tests/neg/serialversionuid-not-const.scala
@@ -1,0 +1,8 @@
+@SerialVersionUID(13l.toLong) class C1 extends Serializable // error
+@SerialVersionUID(13l) class C2 extends Serializable // OK
+@SerialVersionUID(13.asInstanceOf[Long]) class C3 extends Serializable // error
+@SerialVersionUID(Test.bippy) class C4 extends Serializable // error
+
+object Test {
+  val bippy = 13L
+}

--- a/tests/run/t8549b.scala
+++ b/tests/run/t8549b.scala
@@ -1,0 +1,20 @@
+import java.lang.reflect.Modifier._
+
+@SerialVersionUID(42)
+class C extends Serializable
+
+@SerialVersionUID(43 - 1)
+class D extends Serializable
+
+
+object Test extends App {
+  def checkId(cls: Class[_]): Unit = {
+    val field = cls.getDeclaredField("serialVersionUID")
+    assert(isPrivate(field.getModifiers))
+    field.setAccessible(true)
+    val id = field.get(null).asInstanceOf[Long]
+    assert(id == 42, (cls, id))
+  }
+  checkId(classOf[C])
+  checkId(classOf[D])
+}


### PR DESCRIPTION
We need to emit a static `serialVersionUID` field when this annotation
is used, but we were missing the logic in DottyBackendInterface to
actually retrieve the value of the annotation. I also updated
BCodeHelpers to emit the field as private like scalac does since
https://github.com/scala/scala/commit/7f20b1ce6c9d01d6604bb22885bf703b6cc5cbc4