### PR TITLE
Fix #7078: Allow <: T in given alias definitions

### DIFF
--- a/tests/neg/i7078.scala
+++ b/tests/neg/i7078.scala
@@ -1,0 +1,8 @@
+trait A
+class B extends A
+
+given g1 <: A = B()  // error: `<:' is only allowed for given with `inline' modifier // error
+
+inline given g2 <: A  // error: <: A is not a class type
+  def foo = 2    // error: `=' expected
+

--- a/tests/pos/i7078.scala
+++ b/tests/pos/i7078.scala
@@ -1,0 +1,7 @@
+trait A
+class B extends A
+
+inline given tc <: A = B()
+
+val x: B = summon[A]
+


### PR DESCRIPTION
Syntax:
```
GivenDef       ::=  [GivenSig (‘:’ | <:)] Type ‘=’ Expr
```