### PR TITLE
Use blacklist for tests for Scala.js

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -987,8 +987,8 @@ object Build {
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang" ** "*.scala").get
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util" ** (("Base64Test.scala": FileFilter) || "OptionalTest.scala" || "SplittableRandom.scala" || "ObjectsTestOnJDK8.scala" || "ComparatorTestOnJDK8.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/utils" ** "*.scala").get
-          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/junit" ** (("JUnitAnnotationsTest.scala": FileFilter) || "JUnitAssumptionsTest.scala" || "JUnitAssertionsTest.scala")).get
-          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niobuffer" ** (("ByteBufferFactories.scala": FileFilter) || "BufferFactory.scala" || "BufferAdapter.scala" || "BaseBufferTest.scala" || "ShortBufferTest.scala" || "LongBufferTest.scala" || "IntBufferTest.scala" || "FloatBufferTest.scala" || "DoubleBufferTest.scala" || "CharBufferTest.scala")).get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/junit" ** (("*.scala": FileFilter) -- "JUnitAnnotationsParamTest.scala")).get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niobuffer" ** (("*.scala": FileFilter)  -- "ByteBufferTest.scala")).get
         )
       }
     )


### PR DESCRIPTION
Since the **blacklist-based** approach makes it easier to enable new tests this patch replaces the **whitelist-based** approach for enabling tests for **Scala.js** with the blacklist-based approach for the following groups:

- **`testsuite/junit/*`**
- **`testsuite/niobuffer`**