### PR TITLE
Improve Dottydoc error reporting

### DIFF
--- a/doc-tool/src/dotty/tools/dottydoc/staticsite/Template.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/staticsite/Template.scala
@@ -64,21 +64,21 @@ case class LiquidTemplate(path: String, content: SourceFile) extends Template wi
           val unexpected = LiquidTemplate.token(mm.getUnexpectedType)
           val expected = LiquidTemplate.token(mm.expecting)
 
+          // mm.index is incorrect, let's compute the index manually
+          // mm.line starts at 1, not 0
+          val index = content.lineToOffset(mm.line-1) + mm.charPositionInLine
           ctx.error(
             if (unexpected == "EOF")
-              s"unexpected end of file, expected: '$expected'"
+              s"unexpected end of file, expected $expected"
             else
-              s"unexpected token '$unexpected', expected: '$expected'",
-            content atSpan Span(mm.index)
+              s"unexpected $unexpected, expected $expected",
+            content atSpan Span(index)
           )
 
           None
         }
-        case ex => {
-          if (true || ctx.settings.Ydebug.value)
+        case _ => {
             throw ex
-
-          None
         }
       }
     }
@@ -98,17 +98,37 @@ case class LiquidTemplate(path: String, content: SourceFile) extends Template wi
 
 object LiquidTemplate {
   import liqp.parser.LiquidParser
+  import scala.collection.mutable.HashMap
 
-  private val _tokens: Map[String, String] = Map(
+  final val TokenSymbols = HashMap(
     "TagStart" -> "{%",
-    "TagEnd"   -> "%}"
-  )
+    "TagEnd"   -> "%}",
+    "OutStart" -> "{{",
+    "OutEnd"   -> "}}",
+    "Pipe"     -> "|",
+    "DotDot"   -> "..",
+    "Dot"      -> ".",
+    "Eq"       -> "==",
+    "EqSign"   -> "=",
+    "Gt"       -> ">",
+    "GtEq"     -> ">=",
+    "Lt"       -> "<",
+    "LtEq"     -> "<=",
+    "Minus"    -> "-",
+    "Col"      -> ":",
+    "Comma"    -> ",",
+    "OPar"     -> "(",
+    "CPar"     -> ")",
+    "OBr"      -> "[",
+    "CBr"      -> "]",
+    "QMark"    -> "?"
+  ).mapValuesInPlace((k,v) => s"'$v' ($k)")
 
   def token(i: Int): String =
     if (i == -1) "EOF"
-    else if (i >= LiquidParser.tokenNames.length)
-      "non-existing token"
-    else _tokens
-      .get(LiquidParser.tokenNames(i))
-      .getOrElse(s"token  $i")
+    else if (i >= LiquidParser.tokenNames.length) "non-existing token"
+    else {
+      val name = LiquidParser.tokenNames(i)
+      TokenSymbols.getOrElse(name, name)
+    }
 }


### PR DESCRIPTION
Before: incorrect line number and unclear error message
Example (from #7326):
```sh
-- Error: doc/UserGuide.md:1:6 -------------------------------------------------
1 |## ScalaCheck User Guide
  |      ^
  |      unexpected token 'token  57', expected: 'token  77'
```

After: token ids translated to name or symbol+name, and fixed line number
```sh
-- Error: docs/UserGuide.md:907:6 ----------------------------------------------
907 |   *  def canCreateNewSut(newState: State, initSuts: Traversable[State]
    |      ^
    |      unexpected Id, expected '}}' (OutEnd)
```