### PR TITLE
Enable testsuite/scalalib/* tests for Scala.js

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1000,6 +1000,7 @@ object Build {
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/utils" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/junit" ** (("*.scala": FileFilter) -- "JUnitAnnotationsParamTest.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niobuffer" ** (("*.scala": FileFilter)  -- "ByteBufferTest.scala")).get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/scalalib" ** (("*.scala": FileFilter)  -- "ArrayBuilderTest.scala" -- "ClassTagTest.scala" -- "EnumerationTest.scala" -- "RangesTest.scala" -- "SymbolTest.scala")).get
         )
       }
     )


### PR DESCRIPTION
This patch enables tests from **`testsuite/scalalib/*`** for **Scala.js**