### PR TITLE
Enable require-sam/** tests for ScalaJS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1001,6 +1001,7 @@ object Build {
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/junit" ** (("*.scala": FileFilter) -- "JUnitAnnotationsParamTest.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niobuffer" ** (("*.scala": FileFilter)  -- "ByteBufferTest.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/scalalib" ** (("*.scala": FileFilter)  -- "ArrayBuilderTest.scala" -- "ClassTagTest.scala" -- "EnumerationTest.scala" -- "RangesTest.scala" -- "SymbolTest.scala")).get
+          ++ (dir / "shared/src/test/require-sam" ** (("*.scala": FileFilter) -- "SAMTest.scala")).get
         )
       }
     )


### PR DESCRIPTION
This patch enables all tests in the directories that are nested in the **`require-sam/`** directory for **ScalaJS** excluding `require-sam/org/scalajs/testsuite/compiler/SAMTest.scala`