### PR TITLE
Fix #6570: Don't reduce match types with empty scrutinies

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2140,14 +2140,14 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
   private def typeparamCorrespondsToField(tycon: Type, tparam: TypeParamInfo): Boolean =
     productSelectorTypes(tycon, null).exists {
       case tp: TypeRef =>
-        (tp.designator: Any) == tparam // Bingo!
+        tp.designator.eq(tparam) // Bingo!
       case _ =>
         false
     }
 
   /** Is `tp` an empty type?
    *
-   *  `true` implies that we found a proof; uncertainty default to `false`.
+   *  `true` implies that we found a proof; uncertainty defaults to `false`.
    */
   def provablyEmpty(tp: Type): Boolean =
     tp.dealias match {
@@ -2156,9 +2156,9 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
       case OrType(tp1, tp2) => provablyEmpty(tp1) && provablyEmpty(tp2)
       case at @ AppliedType(tycon, args) =>
         args.lazyZip(tycon.typeParams).exists { (arg, tparam) =>
-          tparam.paramVariance >= 0 &&
-          provablyEmpty(arg)        &&
-          typeparamCorrespondsToField(tycon, tparam)
+          tparam.paramVariance >= 0
+          && provablyEmpty(arg)
+          && typeparamCorrespondsToField(tycon, tparam)
         }
       case tp: TypeProxy =>
         provablyEmpty(tp.underlying)
@@ -2168,7 +2168,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
 
   /** Are `tp1` and `tp2` provablyDisjoint types?
    *
-   *  `true` implies that we found a proof; uncertainty default to `false`.
+   *  `true` implies that we found a proof; uncertainty defaults to `false`.
    *
    *  Proofs rely on the following properties of Scala types:
    *
@@ -2178,7 +2178,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
    *  4. There is no value of type Nothing
    *
    *  Note on soundness: the correctness of match types relies on on the
-   *  property that in all possible contexts, a same match type expression
+   *  property that in all possible contexts, the same match type expression
    *  is either stuck or reduces to the same case.
    */
   def provablyDisjoint(tp1: Type, tp2: Type)(implicit ctx: Context): Boolean = {
@@ -2221,8 +2221,8 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
           else
             false
       case (AppliedType(tycon1, args1), AppliedType(tycon2, args2)) if tycon1 == tycon2 =>
-        // It is possible to conclude that two types applies are disjoints by
-        // looking at covariant type parameters if The said type parameters
+        // It is possible to conclude that two types applies are disjoint by
+        // looking at covariant type parameters if the said type parameters
         // are disjoin and correspond to fields.
         // (Type parameter disjointness is not enough by itself as it could
         // lead to incorrect conclusions for phantom type parameters).

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -302,7 +302,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     // Since projections of types don't include null, intersection with null is empty.
     if (tp1 == nullType || tp2 == nullType) Empty
     else {
-      val res = ctx.typeComparer.disjoint(tp1, tp2)
+      val res = ctx.typeComparer.provablyDisjoint(tp1, tp2)
 
       if (res) Empty
       else if (tp1.isSingleton) Typ(tp1, true)
@@ -529,7 +529,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
           def inhabited(tp: Type): Boolean =
             tp.dealias match {
-              case AndType(tp1, tp2) => !ctx.typeComparer.disjoint(tp1, tp2)
+              case AndType(tp1, tp2) => !ctx.typeComparer.provablyDisjoint(tp1, tp2)
               case OrType(tp1, tp2) => inhabited(tp1) || inhabited(tp2)
               case tp: RefinedType => inhabited(tp.parent)
               case tp: TypeRef => inhabited(tp.prefix)

--- a/tests/neg/6314-1.scala
+++ b/tests/neg/6314-1.scala
@@ -18,7 +18,7 @@ object G {
   }
 
   def main(args: Array[String]): Unit = {
-    val a: Bar[X & Y] = "hello"
+    val a: Bar[X & Y] = "hello" // error
     val i: Bar[Y & Foo] = Foo.apply[Bar](a)
     val b: Int = i // error
     println(b + 1)

--- a/tests/neg/6314-2.scala
+++ b/tests/neg/6314-2.scala
@@ -12,11 +12,11 @@ object G {
     case Y => Int
   }
 
-  val a: Bar[X & Foo] = "hello"
+  val a: Bar[X & Foo] = "hello" // error
   val b: Bar[Y & Foo] = 1 // error
 
   def main(args: Array[String]): Unit = {
-    val a: Bar[X & Foo] = "hello"
+    val a: Bar[X & Foo] = "hello" // error
     val i: Bar[Y & Foo] = Foo.apply[Bar](a)
     val b: Int = i // error
     println(b + 1)

--- a/tests/neg/6570-1.scala
+++ b/tests/neg/6570-1.scala
@@ -1,0 +1,33 @@
+import scala.Tuple._
+
+trait Trait1
+trait Trait2
+
+case class Box[+T](t: T)
+
+type N[x] = x match {
+  case Box[String] => Trait1
+  case Box[Int] => Trait2
+}
+
+trait Cov[+T]
+type M[t] = t match {
+  case Cov[x] => N[x]
+}
+
+trait Root[A] {
+  def thing: M[A]
+}
+
+class Asploder extends Root[Cov[Box[Int & String]]] {
+  def thing = new Trait1 {} // error
+}
+
+object Main {
+  def foo[T <: Cov[Box[Int]]](c: Root[T]): Trait2 = c.thing
+
+  def explode = foo(new Asploder)
+
+  def main(args: Array[String]): Unit =
+    explode
+}

--- a/tests/neg/6570.scala
+++ b/tests/neg/6570.scala
@@ -1,0 +1,109 @@
+object Base {
+  trait Trait1
+  trait Trait2
+  type N[t] = t match {
+    case String => Trait1
+    case Int => Trait2
+  }
+}
+import Base._
+
+object UpperBoundParametricVariant {
+  trait Cov[+T]
+  type M[t] = t match {
+    case Cov[x] => N[x]
+  }
+
+  trait Root[A] {
+    def thing: M[A]
+  }
+
+  trait Child[A <: Cov[Int]] extends Root[A]
+
+  // we reduce `M[T]` to `Trait2`, even though we cannot be certain of that
+  def foo[T <: Cov[Int]](c: Child[T]): Trait2 = c.thing
+
+  class Asploder extends Child[Cov[String & Int]] {
+    def thing = new Trait1 {} // error
+  }
+
+  def explode = foo(new Asploder) // ClassCastException
+}
+
+object InheritanceVariant {
+  // allows binding a variable to the UB of a type member
+  type Trick[a] = { type A <: a }
+  type M[t] = t match { case Trick[a] => N[a] }
+
+  trait Root {
+    type B
+    def thing: M[B]
+  }
+
+  trait Child extends Root { type B <: { type A <: Int } }
+
+  def foo(c: Child): Trait2 = c.thing
+
+  class Asploder extends Child {
+    type B = { type A = String & Int }
+    def thing = new Trait1 {} // error
+  }
+}
+
+object ThisTypeVariant {
+  type Trick[a] = { type A <: a }
+  type M[t] = t match { case Trick[a] => N[a] }
+
+  trait Root {
+    def thing: M[this.type]
+  }
+
+  trait Child extends Root { type A <: Int }
+
+  def foo(c: Child): Trait2 = c.thing
+
+  class Asploder extends Child {
+    type A = String & Int
+    def thing = new Trait1 {} // error
+  }
+}
+
+object ParametricVariant {
+  type Trick[a] = { type A <: a }
+  type M[t] = t match { case Trick[a] => N[a] }
+
+  trait Root[B] {
+    def thing: M[B]
+  }
+
+  trait Child[B <: { type A <: Int }] extends Root[B]
+
+  def foo[T <: { type A <: Int }](c: Child[T]): Trait2 = c.thing
+
+  class Asploder extends Child[{ type A = String & Int }] {
+    def thing = new Trait1 {} // error
+  }
+
+  def explode = foo(new Asploder)
+}
+
+object UpperBoundVariant {
+  trait Cov[+T]
+  type M[t] = t match { case Cov[t] => N[t] }
+
+  trait Root {
+    type A
+    def thing: M[A]
+  }
+
+  trait Child extends Root { type A <: Cov[Int] }
+
+  def foo(c: Child): Trait2 = c.thing
+
+  class Asploder extends Child {
+    type A = Cov[String & Int]
+    def thing = new Trait1 {} // error
+  }
+
+  def explode = foo(new Asploder)
+}

--- a/tests/neg/matchtype-seq.scala
+++ b/tests/neg/matchtype-seq.scala
@@ -102,10 +102,10 @@ object Test {
 
   identity[T9[Tuple2[Int, String]]](1)
   identity[T9[Tuple2[String, Int]]]("1")
-  identity[T9[Tuple2[Nothing, String]]](1)
-  identity[T9[Tuple2[String, Nothing]]]("1")
-  identity[T9[Tuple2[Int, Nothing]]](1)
-  identity[T9[Tuple2[Nothing, Int]]]("1")
+  identity[T9[Tuple2[Nothing, String]]](1) // error
+  identity[T9[Tuple2[String, Nothing]]]("1") // error
+  identity[T9[Tuple2[Int, Nothing]]](1) // error
+  identity[T9[Tuple2[Nothing, Int]]]("1") // error
   identity[T9[Tuple2[_, _]]]("") // error
   identity[T9[Tuple2[_, _]]](1) // error
   identity[T9[Tuple2[Any, Any]]]("") // error

--- a/tests/run-staging/staged-tuples/StagedTuple.scala
+++ b/tests/run-staging/staged-tuples/StagedTuple.scala
@@ -79,7 +79,7 @@ object StagedTuple {
   }
 
   def headStaged[Tup <: NonEmptyTuple : Type](tup: Expr[Tup], size: Option[Int])(given QuoteContext): Expr[Head[Tup]] = {
-    if (!specialize) '{dynamicApply($tup, 0)}
+    if (!specialize) '{dynamicApply[Tup, 0]($tup, 0)}
     else {
       val resVal = size match {
         case Some(1) =>

--- a/tests/run/tuples1.scala
+++ b/tests/run/tuples1.scala
@@ -62,7 +62,8 @@ object Test extends App {
   def head2[X <: NonEmptyTuple](x: X): Tuple.Head[X] = x.head
 
   val hd1: Int = head1(x3)
-  val hd2: Int = head2(x3)
+  // Without an explicit type parameter type inferance infers Nothing here.
+  val hd2: Int = head2[x3.type](x3)
 
   def tail1(x: NonEmptyTuple): Tuple.Tail[x.type] = x.tail
   def tail2[X <: NonEmptyTuple](x: X): Tuple.Tail[X] = x.tail


### PR DESCRIPTION
This PR fixes the soundness hole exposed in #6570 by adding an extra condition to match type reduction: scrutinies should be non empty.