### PR TITLE
Fix #7342: Incorrectly setting sources for inlined lambdas on beta reduction

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -817,7 +817,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
               newOwners = ctx.owner :: Nil,
               substFrom = ddef.vparamss.head.map(_.symbol),
               substTo = argSyms)
-            Inlined(ddef, bindingsBuf.toList, expander.transform(ddef.rhs))
+            Block(bindingsBuf.toList, expander.transform(ddef.rhs))
           case _ => tree
         }
       case _ => tree

--- a/tests/pos-macros/i7342/Macro_1.scala
+++ b/tests/pos-macros/i7342/Macro_1.scala
@@ -1,0 +1,5 @@
+import scala.quoted.{ QuoteContext, Expr }
+
+trait Foo
+
+inline def g(em: Expr[Foo])(using QuoteContext) = '{$em}

--- a/tests/pos-macros/i7342/Macro_2.scala
+++ b/tests/pos-macros/i7342/Macro_2.scala
@@ -1,0 +1,3 @@
+import scala.quoted.{ QuoteContext, Expr }
+
+def h(m: Expr[Foo])(using QuoteContext): Expr[Any] = g(m)

--- a/tests/pos/i7342/First_1.scala
+++ b/tests/pos/i7342/First_1.scala
@@ -1,0 +1,1 @@
+inline def g(em: Int) = ((c: Int) => em).apply({println("AAAAAAA"); 1})

--- a/tests/pos/i7342/Second_2.scala
+++ b/tests/pos/i7342/Second_2.scala
@@ -1,0 +1,1 @@
+def h(m: Int) = g(m)


### PR DESCRIPTION
On beta reduction of lambdas, we should create a block
and not an inline node.