### PR TITLE
Fix unreachable code in DynamicTuple.dynamiamicConcat

### DIFF
--- a/library/src/scala/runtime/DynamicTuple.scala
+++ b/library/src/scala/runtime/DynamicTuple.scala
@@ -212,8 +212,8 @@ object DynamicTuple {
 
   def dynamicConcat[This <: Tuple, That <: Tuple](self: This, that: That): Concat[This, That] = {
     type Result = Concat[This, That]
-    (this: Any) match {
-      case self: Unit => return self.asInstanceOf[Result]
+    (self: Any) match {
+      case self: Unit => return that.asInstanceOf[Result]
       case _ =>
     }
     (that: Any) match {

--- a/tests/run/tuple-concat.check
+++ b/tests/run/tuple-concat.check
@@ -1,0 +1,5 @@
+tuple1 ++ emptyTuple = (e1,e2,e3)
+emptyTuple ++ tuple1 = (e1,e2,e3)
+tuple2 ++ emptyTuple = (e4,e5,e6)
+emptyTuple ++ tuple2 = (e4,e5,e6)
+tuple1 ++ tuple2 = (e1,e2,e3,e4,e5,e6)

--- a/tests/run/tuple-concat.scala
+++ b/tests/run/tuple-concat.scala
@@ -10,6 +10,6 @@ object Test extends App {
   println("tuple2 ++ emptyTuple = " + (tuple2 ++ emptyTuple))
   println("emptyTuple ++ tuple2 = " + (emptyTuple ++ tuple2))
   println("tuple1 ++ tuple2 = " + (tuple1 ++ tuple2))
-  assert((tuple1 ++ emptyTuple) eq tuple1)
-  assert((emptyTuple ++tuple1) eq tuple1)
+  assert((tuple1 ++ emptyTuple).asInstanceOf[AnyRef] eq tuple1.asInstanceOf[AnyRef])
+  assert((emptyTuple ++tuple1).asInstanceOf[AnyRef] eq tuple1.asInstanceOf[AnyRef])
 }

--- a/tests/run/tuple-concat.scala
+++ b/tests/run/tuple-concat.scala
@@ -1,0 +1,13 @@
+
+object Test extends App {
+  val emptyTuple: Tuple = ()
+  val tuple1: Tuple = "e1" *: "e2" *: "e3" *: ()
+  val tuple2: Tuple = "e4" *: "e5" *: "e6" *: ()
+  val result: Tuple = "e1" *: "e2" *: "e3" *: "e4" *: "e5" *: "e6" *: ()
+
+  println("tuple1 ++ emptyTuple = " + (tuple1 ++ emptyTuple))
+  println("emptyTuple ++ tuple1 = " + (emptyTuple ++ tuple1))
+  println("tuple2 ++ emptyTuple = " + (tuple2 ++ emptyTuple))
+  println("emptyTuple ++ tuple2 = " + (emptyTuple ++ tuple2))
+  println("tuple1 ++ tuple2 = " + (tuple1 ++ tuple2))
+}

--- a/tests/run/tuple-concat.scala
+++ b/tests/run/tuple-concat.scala
@@ -10,4 +10,6 @@ object Test extends App {
   println("tuple2 ++ emptyTuple = " + (tuple2 ++ emptyTuple))
   println("emptyTuple ++ tuple2 = " + (emptyTuple ++ tuple2))
   println("tuple1 ++ tuple2 = " + (tuple1 ++ tuple2))
+  assert((tuple1 ++ emptyTuple) eq tuple1)
+  assert((emptyTuple ++tuple1) eq tuple1)
 }


### PR DESCRIPTION
There was an issue in `DynamicTuple.dynamicConcat` where "this" was pattern matched instead of "self", making part of the code unreachable.