### PR TITLE
Trait constructors on scala.js

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1001,6 +1001,7 @@ object Build {
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/junit" ** (("*.scala": FileFilter) -- "JUnitAnnotationsParamTest.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niobuffer" ** (("*.scala": FileFilter)  -- "ByteBufferTest.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niocharset" ** (("*.scala": FileFilter)  -- "BaseCharsetTest.scala" -- "Latin1Test.scala" -- "USASCIITest.scala" -- "UTF16Test.scala" -- "UTF8Test.scala")).get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/scalalib" ** (("*.scala": FileFilter)  -- "ArrayBuilderTest.scala" -- "ClassTagTest.scala" -- "EnumerationTest.scala" -- "RangesTest.scala" -- "SymbolTest.scala")).get
           ++ (dir / "shared/src/test/require-sam" ** (("*.scala": FileFilter) -- "SAMTest.scala")).get
         )

--- a/sandbox/scalajs/src/Integral.scala
+++ b/sandbox/scalajs/src/Integral.scala
@@ -1,0 +1,13 @@
+package hello
+
+// Minimal reproduction
+object Integral {
+  def main(args: Array[String]): Unit = {
+    trait A[T] extends Ordering[T]
+    case class B[T](v: T) extends A[T] {
+      def compare(x: T, y: T): Int = 0
+    }
+
+    B(0)
+  }
+}


### PR DESCRIPTION
I'm trying to get `RangesTests` to run on scala.js but I by default get a Linking error 
```
[error] Referring to non-existent method constructor scala.math.Integral.<init>() [error] called from constructor org.scalajs.testsuite.scalalib.RangesTest$aIsIntegral$1$.<init>(scala.runtime.LazyRef,org.scalajs.testsuite.scalalib.RangesTest)
```
After some discussions in gitter I managed to change it to call the trait constructor but there is an extra step of making the call static and I haven't been able to find it. At the moment my error is as below with a minimal test code to reproduce it
```
[error] Referring to non-existent method static scala.math.PartialOrdering.$$init$(scala.math.PartialOrdering)void
[error]   called from constructor hello.Integral$B$2.<init>(java.lang.Object)
```

I've discussed this with @sjrd in Gitter but haven't found a solution. Hence I'm sending this draft PR to get feedback