### PR TITLE
Partial fix for lampepfl#7113: Fix Scala.js codegen for Null/Nothing types

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -398,8 +398,17 @@ object JSEncoding {
     paramAndResultTypeNames.mkString(SignatureSep, SignatureSep, "")
 
   /** Computes the internal name for a type. */
-  private def internalName(tpe: Type)(implicit ctx: Context): String =
-    encodeTypeRef(toTypeRef(tpe))
+  private def internalName(tpe: Type)(implicit ctx: Context): String = {
+    val typeRef = toTypeRef(tpe)
+
+    val safeTypeRef: jstpe.TypeRef = typeRef match {
+      case jstpe.ClassRef("s_Null")    => jstpe.ClassRef(ir.Definitions.NullClass)
+      case jstpe.ClassRef("s_Nothing") => jstpe.ClassRef(ir.Definitions.NothingClass)
+      case otherTypeRef => otherTypeRef
+    }
+
+    encodeTypeRef(safeTypeRef)
+  }
 
   /** Encodes a [[Types.TypeRef]], such as in an encoded method signature.
    */

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -981,7 +981,7 @@ object Build {
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/lang" ** (("*.scala": FileFilter) -- "ClassTest.scala" -- "StringTest.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/io" ** (("*.scala": FileFilter) -- "ByteArrayInputStreamTest.scala" -- "ByteArrayOutputStreamTest.scala" -- "DataInputStreamTest.scala" -- "DataOutputStreamTest.scala" -- "InputStreamTest.scala" -- "OutputStreamWriterTest.scala" -- "PrintStreamTest.scala" -- "ReadersTest.scala" -- "CommonStreamsTests.scala")).get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/math" ** "*.scala").get
-          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/net" ** (("*.scala": FileFilter) -- "URITest.scala")).get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/net" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/security" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent" ** (("*.scala": FileFilter) -- "ConcurrentHashMapTest.scala" -- "ConcurrentLinkedQueueTest.scala" -- "ConcurrentMapTest.scala" -- "ConcurrentSkipListSetTest.scala" -- "CopyOnWriteArrayListTest.scala")).get


### PR DESCRIPTION
- Fix an issue where non-null parameters with default arguments of null would generate default parameter functions returning a type of null, which is unknown to the ScalaJS backend. Use the type of the non-null parameter as the return type, instead of null
- Enable the URITest for Scala.js, which was blocked by the previous issue