### PR TITLE
Replacing empty+erased function check with assert

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -862,10 +862,8 @@ class Typer extends Namer
       case tree: untpd.FunctionWithMods => tree.mods.flags
       case _ => EmptyFlags
     }
-    if (funFlags.is(Erased) && args.isEmpty) {
-      ctx.error("An empty function cannot not be erased", tree.sourcePos)
-      funFlags = funFlags &~ Erased
-    }
+
+    assert(!funFlags.is(Erased) || !args.isEmpty, "An empty function cannot not be erased")
 
     val funCls = defn.FunctionClass(args.length,
         isContextual = funFlags.is(Given), isErased = funFlags.is(Erased))


### PR DESCRIPTION
A followup for conversation in Gitter with @smarter. Looks like assert is a way to go, since these conditions cannot be met. 

This should be relevant #1589 - `Typer.scala:866`