### PR TITLE
Fix #7392: Interpolate all wildcards in the resulttype of a closure

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -833,10 +833,10 @@ class Typer extends Namer
       case _: WildcardType => untpd.TypeTree()
       case _ => untpd.TypeTree(tp)
     }
-    def interpolateWildcards = new ApproximatingTypeMap {
+    def interpolateWildcards = new TypeMap {
       def apply(t: Type) = t match
-        case WildcardType => emptyRange
-        case WildcardType(bounds: TypeBounds) => range(bounds.lo, bounds.hi)
+        case WildcardType => newTypeVar(TypeBounds.empty)
+        case WildcardType(bounds: TypeBounds) => newTypeVar(bounds)
         case _ => mapOver(t)
     }
     pt.stripTypeVar.dealias match {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -834,9 +834,9 @@ class Typer extends Namer
       case _ => untpd.TypeTree(tp)
     }
     def interpolateWildcards = new TypeMap {
-      def apply(t: Type) = t match
-        case WildcardType => newTypeVar(TypeBounds.empty)
-        case WildcardType(bounds: TypeBounds) => newTypeVar(bounds)
+      def apply(t: Type): Type = t match
+        case WildcardType(bounds: TypeBounds) =>
+          newTypeVar(apply(bounds.orElse(TypeBounds.empty)).bounds)
         case _ => mapOver(t)
     }
     pt.stripTypeVar.dealias match {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -833,12 +833,18 @@ class Typer extends Namer
       case _: WildcardType => untpd.TypeTree()
       case _ => untpd.TypeTree(tp)
     }
+    def interpolateWildcards = new ApproximatingTypeMap {
+      def apply(t: Type) = t match
+        case WildcardType => emptyRange
+        case WildcardType(bounds: TypeBounds) => range(bounds.lo, bounds.hi)
+        case _ => mapOver(t)
+    }
     pt.stripTypeVar.dealias match {
       case pt1 if defn.isNonRefinedFunction(pt1) =>
         // if expected parameter type(s) are wildcards, approximate from below.
         // if expected result type is a wildcard, approximate from above.
         // this can type the greatest set of admissible closures.
-        (pt1.argTypesLo.init, typeTree(pt1.argTypesHi.last))
+        (pt1.argTypesLo.init, typeTree(interpolateWildcards(pt1.argTypesHi.last)))
       case SAMType(sam @ MethodTpe(_, formals, restpe)) =>
         (formals,
          if (sam.isResultDependent)
@@ -1899,7 +1905,6 @@ class Typer extends Namer
         if (ctx.owner ne tree.owner) tree1.changeOwner(tree.owner, ctx.owner)
         else tree1
     }
-
 
   def typedAsFunction(tree: untpd.PostfixOp, pt: Type)(implicit ctx: Context): Tree = {
     val untpd.PostfixOp(qual, Ident(nme.WILDCARD)) = tree

--- a/tests/pos/i7392.scala
+++ b/tests/pos/i7392.scala
@@ -1,0 +1,16 @@
+object Test {
+
+  trait ZStream[-R, +E, +A]
+
+  object ZStream {
+    def empty: ZStream[Any, Nothing, Nothing] =
+      ???
+  }
+
+  trait Gen[-R, +A](sample: ZStream[R, Nothing, A])
+
+  def fromIterable[R, A](
+    as: Iterable[A],
+    shrinker: (A => ZStream[R, Nothing, A]) = (_: A) => ZStream.empty
+  ): Gen[R, A] = ???
+}


### PR DESCRIPTION
Make sure we interpolate all wildcards in the prototype before making it
the result type of an anonymous function. This was done previously only for
toplevel wildcards, but not for wildcards nested in some type.