### PR TITLE
Fix #7383: Don't include nested classes in class bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -57,13 +57,15 @@ trait TypeAssigner {
           .suchThat(decl.matches(_))
       val inheritedInfo = inherited.info
       val isPolyFunctionApply = decl.name == nme.apply && (parent <:< defn.PolyFunctionType)
-      if (isPolyFunctionApply || inheritedInfo.exists &&
-          decl.info.widenExpr <:< inheritedInfo.widenExpr &&
-          !(inheritedInfo.widenExpr <:< decl.info.widenExpr)) {
+      if isPolyFunctionApply
+         || inheritedInfo.exists
+            && decl.info.widenExpr <:< inheritedInfo.widenExpr
+            && !(inheritedInfo.widenExpr <:< decl.info.widenExpr)
+            && !decl.isClass
+      then
         val r = RefinedType(parent, decl.name, decl.info)
         typr.println(i"add ref $parent $decl --> " + r)
         r
-      }
       else
         parent
     }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -53,15 +53,15 @@ trait TypeAssigner {
     def addRefinement(parent: Type, decl: Symbol) = {
       val inherited =
         parentType.findMember(decl.name, cls.thisType,
-          required = EmptyFlags, excluded = Private)
-          .suchThat(decl.matches(_))
+          required = EmptyFlags, excluded = Private
+        ).suchThat(decl.matches(_))
       val inheritedInfo = inherited.info
       val isPolyFunctionApply = decl.name == nme.apply && (parent <:< defn.PolyFunctionType)
       if isPolyFunctionApply
          || inheritedInfo.exists
+            && !decl.isClass
             && decl.info.widenExpr <:< inheritedInfo.widenExpr
             && !(inheritedInfo.widenExpr <:< decl.info.widenExpr)
-            && !decl.isClass
       then
         val r = RefinedType(parent, decl.name, decl.info)
         typr.println(i"add ref $parent $decl --> " + r)

--- a/tests/pos/i7383.scala
+++ b/tests/pos/i7383.scala
@@ -1,0 +1,12 @@
+trait ZSink {
+
+  type State
+
+  def foo: ZSink =
+    class Anon extends ZSink
+      case class State(x: Int)
+    new Anon
+//    new ZSink {
+//      case class State(x: Int)
+//    }
+}

--- a/tests/pos/i7383.scala
+++ b/tests/pos/i7383.scala
@@ -3,10 +3,13 @@ trait ZSink {
   type State
 
   def foo: ZSink =
-    class Anon extends ZSink
+    class Anon extends ZSink {
       case class State(x: Int)
+    }
     new Anon
-//    new ZSink {
-//      case class State(x: Int)
-//    }
+
+  def foo2: ZSink =
+    new ZSink {
+      case class State(x: Int)
+    }
 }


### PR DESCRIPTION
When computing the class bound in an avoid, we approximate
members by refinements. But if the member itself is a class,
we cannot refine with  Classinfo type.

The current fix is to give up in this case and not refine
anything. We could try to refine with an abstract type, but
in that case we have to be careful with F-bounds.