### PR TITLE
Don't unnecessarily compile the bootstrapped compiler

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -438,7 +438,7 @@ object Build {
     // packageAll should always be run before tests
     javaOptions ++= {
       val externalDeps = externalCompilerClasspathTask.value
-      val jars = packageAll.in(LocalProject("dotty-compiler-bootstrapped")).value
+      val jars = packageAll.in(LocalProject("dotty-compiler")).value
 
       List(
         "-Ddotty.tests.classes.dottyInterfaces=" + jars("dotty-interfaces"),


### PR DESCRIPTION
Previously, running `dotc ...` would compile the bootstrapped compiler
even though it runs the non-bootstrapped compiler.