### PR TITLE
Infer private[this]

### DIFF
--- a/compiler/src/dotty/tools/backend/WorklistAlgorithm.scala
+++ b/compiler/src/dotty/tools/backend/WorklistAlgorithm.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable
 trait WorklistAlgorithm {
   type Elem
   class WList {
-    private[this] var list: List[Elem] = Nil
+    private var list: List[Elem] = Nil
     def isEmpty = list.isEmpty
     def nonEmpty = !isEmpty
     def push(e: Elem): Unit = { list = e :: list }

--- a/compiler/src/dotty/tools/backend/jvm/CoreBTypes.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CoreBTypes.scala
@@ -203,7 +203,7 @@ final class CoreBTypesProxy[BTFS <: BTypesFromSymbols[_ <: BackendInterface]](va
   import bTypes._
   import bTypes.int._
 
-  private[this] var _coreBTypes: CoreBTypes[bTypes.type] = _
+  private var _coreBTypes: CoreBTypes[bTypes.type] = _
   def setBTypes(coreBTypes: CoreBTypes[BTFS]): Unit = {
     _coreBTypes = coreBTypes.asInstanceOf[CoreBTypes[bTypes.type]]
   }

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -535,8 +535,10 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
 
   private def getGenericSignature(sym: Symbol, owner: Symbol, memberTpe: Type)(implicit ctx: Context): Option[String] =
     if (needsGenericSignature(sym)) {
-      val erasedTypeSym = sym.denot.info.typeSymbol
+      val erasedTypeSym = TypeErasure.fullErasure(sym.denot.info).typeSymbol
       if (erasedTypeSym.isPrimitiveValueClass) {
+        // Suppress signatures for symbols whose types erase in the end to primitive
+        // value types. This is needed to fix #7416.
         None
       } else {
         val jsOpt = GenericSignatures.javaSig(sym, memberTpe)

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -39,7 +39,7 @@ class GenBCode extends Phase {
     superCallsMap.update(sym, old + calls)
   }
 
-  private[this] var myOutput: AbstractFile = _
+  private var myOutput: AbstractFile = _
 
   private def outputDir(implicit ctx: Context): AbstractFile = {
     if (myOutput eq null)
@@ -68,14 +68,14 @@ object GenBCode {
 
 class GenBCodePipeline(val int: DottyBackendInterface)(implicit val ctx: Context) extends BCodeSyncAndTry {
 
-  private[this] var tree: Tree = _
+  private var tree: Tree = _
 
-  private[this] val sourceFile: SourceFile = ctx.compilationUnit.source
+  private val sourceFile: SourceFile = ctx.compilationUnit.source
 
   /** Convert a `dotty.tools.io.AbstractFile` into a
    *  `dotty.tools.dotc.interfaces.AbstractFile`.
    */
-  private[this] def convertAbstractFile(absfile: dotty.tools.io.AbstractFile): interfaces.AbstractFile =
+  private def convertAbstractFile(absfile: dotty.tools.io.AbstractFile): interfaces.AbstractFile =
     new interfaces.AbstractFile {
       override def name = absfile.name
       override def path = absfile.path
@@ -86,8 +86,8 @@ class GenBCodePipeline(val int: DottyBackendInterface)(implicit val ctx: Context
 
 //  class BCodePhase() {
 
-  private[this] var bytecodeWriter  : BytecodeWriter   = null
-  private[this] var mirrorCodeGen   : JMirrorBuilder   = null
+  private var bytecodeWriter  : BytecodeWriter   = null
+  private var mirrorCodeGen   : JMirrorBuilder   = null
 
   /* ---------------- q1 ---------------- */
 

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -82,7 +82,7 @@ class JSCodeGen()(implicit ctx: Context) {
   /* See genSuperCall()
    * TODO Can we avoid this unscoped var?
    */
-  private[this] var isModuleInitialized: Boolean = false
+  private var isModuleInitialized: Boolean = false
 
   private def currentClassType = encodeClassType(currentClassSym)
 

--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -173,7 +173,7 @@ final class JSDefinitions()(implicit ctx: Context) {
     @threadUnsafe lazy val Reflect_registerInstantiatableClassR = ReflectModule.requiredMethodRef("registerInstantiatableClass")
     def Reflect_registerInstantiatableClass(implicit ctx: Context) = Reflect_registerInstantiatableClassR.symbol
 
-  private[this] var allRefClassesCache: Set[Symbol] = _
+  private var allRefClassesCache: Set[Symbol] = _
   def allRefClasses(implicit ctx: Context): Set[Symbol] = {
     if (allRefClassesCache == null) {
       val baseNames = List("Object", "Boolean", "Character", "Byte", "Short",

--- a/compiler/src/dotty/tools/backend/sjs/JSPositions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSPositions.scala
@@ -35,11 +35,11 @@ class JSPositions()(implicit ctx: Context) {
   implicit def implicitSourcePos2irPos(implicit sourcePos: SourcePosition): ir.Position =
     sourceAndSpan2irPos(sourcePos.source, sourcePos.span)
 
-  private[this] object span2irPosCache { // scalastyle:ignore
+  private object span2irPosCache { // scalastyle:ignore
     import dotty.tools.dotc.util._
 
-    private[this] var lastDotcSource: SourceFile = null
-    private[this] var lastIRSource: ir.Position.SourceFile = null
+    private var lastDotcSource: SourceFile = null
+    private var lastIRSource: ir.Position.SourceFile = null
 
     def toIRSource(dotcSource: SourceFile): ir.Position.SourceFile = {
       if (dotcSource != lastDotcSource) {
@@ -49,7 +49,7 @@ class JSPositions()(implicit ctx: Context) {
       lastIRSource
     }
 
-    private[this] def convert(dotcSource: SourceFile): ir.Position.SourceFile = {
+    private def convert(dotcSource: SourceFile): ir.Position.SourceFile = {
       dotcSource.file.file match {
         case null =>
           new java.net.URI(

--- a/compiler/src/dotty/tools/dotc/Bench.scala
+++ b/compiler/src/dotty/tools/dotc/Bench.scala
@@ -12,7 +12,7 @@ import scala.annotation.internal.sharable
  */
 object Bench extends Driver {
 
-  @sharable private[this] var numRuns = 1
+  @sharable private var numRuns = 1
 
   private def ntimes(n: Int)(op: => Reporter): Reporter =
     (0 until n).foldLeft(emptyReporter)((_, _) => op)

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -59,9 +59,9 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
     defn.RootImportFns.foldLeft(start.setRun(this))(addImport)
   }
 
-  private[this] var compiling = false
+  private var compiling = false
 
-  private[this] var myCtx = rootContext(ictx)
+  private var myCtx = rootContext(ictx)
 
   /** The context created for this run */
   def runContext: Context = myCtx
@@ -69,9 +69,9 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   protected implicit def ctx: Context = myCtx
   assert(ctx.runId <= Periods.MaxPossibleRunId)
 
-  private[this] var myUnits: List[CompilationUnit] = _
-  private[this] var myUnitsCached: List[CompilationUnit] = _
-  private[this] var myFiles: Set[AbstractFile] = _
+  private var myUnits: List[CompilationUnit] = _
+  private var myUnitsCached: List[CompilationUnit] = _
+  private var myFiles: Set[AbstractFile] = _
 
   /** The compilation units currently being compiled, this may return different
     *  results over time.
@@ -94,10 +94,10 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   }
 
   /** The source files of all late entered symbols, as a set */
-  private[this] var lateFiles = mutable.Set[AbstractFile]()
+  private var lateFiles = mutable.Set[AbstractFile]()
 
   /** Actions that need to be performed at the end of the current compilation run */
-  private[this] var finalizeActions = mutable.ListBuffer[() => Unit]()
+  private var finalizeActions = mutable.ListBuffer[() => Unit]()
 
   def compile(fileNames: List[String]): Unit = try {
     val sources = fileNames.map(ctx.getSource(_))

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -39,7 +39,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
    *                 for type checking.
    *    imports      For each element of RootImports, an import context
    */
-  protected[this] def rootContext(implicit ctx: Context): Context = {
+  protected def rootContext(implicit ctx: Context): Context = {
     ctx.initialize()(ctx)
     ctx.base.setPhasePlan(comp.phases)
     val rootScope = new MutableScope
@@ -66,7 +66,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   /** The context created for this run */
   def runContext: Context = myCtx
 
-  protected[this] implicit def ctx: Context = myCtx
+  protected implicit def ctx: Context = myCtx
   assert(ctx.runId <= Periods.MaxPossibleRunId)
 
   private[this] var myUnits: List[CompilationUnit] = _

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -155,7 +155,7 @@ object desugar {
     val vdef @ ValDef(name, tpt, rhs) = transformQuotedPatternName(vdef0)
     val mods = vdef.mods
     val setterNeeded =
-      mods.is(Mutable) && ctx.owner.isClass && (!mods.isAllOf(PrivateLocal) || ctx.owner.is(Trait))
+      mods.is(Mutable) && ctx.owner.isClass && (!mods.is(Private) || ctx.owner.is(Trait))
     if (setterNeeded) {
       // TODO: copy of vdef as getter needed?
       // val getter = ValDef(mods, name, tpt, rhs) withPos vdef.pos?

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -150,6 +150,8 @@ object desugar {
    *  ==>
    *    def x: Int = expr
    *    def x_=($1: <TypeTree()>): Unit = ()
+   *
+   *  Generate the setter only for non-private class members and all trait members.
    */
   def valDef(vdef0: ValDef)(implicit ctx: Context): Tree = {
     val vdef @ ValDef(name, tpt, rhs) = transformQuotedPatternName(vdef0)

--- a/compiler/src/dotty/tools/dotc/ast/PluggableTransformers.scala
+++ b/compiler/src/dotty/tools/dotc/ast/PluggableTransformers.scala
@@ -9,8 +9,8 @@ object PluggableTransformers {
   abstract class PluggableTransformer[T] extends TreeTransformer[T, Context] {
     type PluginOp[-N <: Tree[T]] = N => Tree[T]
 
-    private[this] var _ctx: Context = _
-    private[this] var _oldTree: Tree[T] = _
+    private var _ctx: Context = _
+    private var _oldTree: Tree[T] = _
 
     protected implicit def ctx: Context = _ctx
     protected def oldTree: Tree[T] = _oldTree
@@ -44,7 +44,7 @@ object PluggableTransformers {
 
     val EmptyPlugin = new Plugins
 
-    private[this] var _plugins: Plugins = EmptyPlugin
+    private var _plugins: Plugins = EmptyPlugin
 
     override def plugins: Plugins = _plugins
 

--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -18,8 +18,8 @@ import java.io.{ PrintWriter }
  */
 abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Product with Cloneable {
 
-  private[this] var myUniqueId: Int = _
-  private[this] var mySpan: Span = _
+  private var myUniqueId: Int = _
+  private var mySpan: Span = _
 
   /** A unique identifier. Among other things, used for determining the source file
    *  component of the position.

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -309,7 +309,7 @@ object Trees {
   trait DefTree[-T >: Untyped] extends DenotingTree[T] {
     type ThisTree[-T >: Untyped] <: DefTree[T]
 
-    private[this] var myMods: untpd.Modifiers = null
+    private var myMods: untpd.Modifiers = null
 
     private[dotc] def rawMods: untpd.Modifiers =
       if (myMods == null) untpd.EmptyModifiers else myMods

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1080,7 +1080,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   trait TreeProvider {
     protected def computeRootTrees(implicit ctx: Context): List[Tree]
 
-    private[this] var myTrees: List[Tree] = null
+    private var myTrees: List[Tree] = null
 
     /** Get trees defined by this provider. Cache them if -Yretain-trees is set. */
     def rootTrees(implicit ctx: Context): List[Tree] =

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -276,7 +276,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
    */
   abstract class DerivedTypeTree(implicit @constructorOnly src: SourceFile) extends TypeTree {
 
-    private[this] var myWatched: Tree = EmptyTree
+    private var myWatched: Tree = EmptyTree
 
     /** The watched tree; used only for printing */
     def watched: Tree = myWatched

--- a/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
@@ -23,7 +23,7 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
       case Some(x) => x
     }
   }
-  private[this] val packageIndex: collection.mutable.Map[String, Seq[ClassPath]] = collection.mutable.Map()
+  private val packageIndex: collection.mutable.Map[String, Seq[ClassPath]] = collection.mutable.Map()
   private def aggregatesForPackage(pkg: String): Seq[ClassPath] = packageIndex.synchronized {
     packageIndex.getOrElseUpdate(pkg, aggregates.filter(_.hasPackage(pkg)))
   }

--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -11,7 +11,7 @@ import transform.ExplicitOuter, transform.SymUtils._
 
 class JavaPlatform extends Platform {
 
-  private[this] var currentClassPath: Option[ClassPath] = None
+  private var currentClassPath: Option[ClassPath] = None
 
   def classPath(implicit ctx: Context): ClassPath = {
     if (currentClassPath.isEmpty)

--- a/compiler/src/dotty/tools/dotc/config/OutputDirs.scala
+++ b/compiler/src/dotty/tools/dotc/config/OutputDirs.scala
@@ -12,12 +12,12 @@ import io._
  */
 class OutputDirs {
   /** Pairs of source directory - destination directory. */
-  private[this] var outputDirs: List[(AbstractFile, AbstractFile)] = Nil
+  private var outputDirs: List[(AbstractFile, AbstractFile)] = Nil
 
   /** If this is not None, the output location where all
    *  classes should go.
    */
-  private[this] var singleOutDir: Option[AbstractFile] = None
+  private var singleOutDir: Option[AbstractFile] = None
 
   /** Add a destination directory for sources found under srcdir.
    *  Both directories should exits.

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -25,8 +25,8 @@ object Settings {
   val OutputTag: ClassTag[AbstractFile]  = ClassTag(classOf[AbstractFile])
 
   class SettingsState(initialValues: Seq[Any]) {
-    private[this] var values = ArrayBuffer(initialValues: _*)
-    private[this] var _wasRead: Boolean = false
+    private var values = ArrayBuffer(initialValues: _*)
+    private var _wasRead: Boolean = false
 
     override def toString: String = s"SettingsState(values: ${values.toList})"
 
@@ -68,7 +68,7 @@ object Settings {
     depends: List[(Setting[?], Any)] = Nil,
     propertyClass: Option[Class[?]] = None)(private[Settings] val idx: Int) {
 
-    private[this] var changed: Boolean = false
+    private var changed: Boolean = false
 
     def withAbbreviation(abbrv: String): Setting[T] =
       copy(aliases = aliases :+ abbrv)(idx)
@@ -193,7 +193,7 @@ object Settings {
 
   class SettingGroup {
 
-    private[this] val _allSettings = new ArrayBuffer[Setting[?]]
+    private val _allSettings = new ArrayBuffer[Setting[?]]
     def allSettings: Seq[Setting[?]] = _allSettings.toSeq
 
     def defaultState: SettingsState = new SettingsState(allSettings map (_.default))

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -51,7 +51,7 @@ object Annotations {
     override def symbol(implicit ctx: Context): Symbol
     def complete(implicit ctx: Context): Tree
 
-    private[this] var myTree: Tree = null
+    private var myTree: Tree = null
     def tree(implicit ctx: Context): Tree = {
       if (myTree == null) myTree = complete(ctx)
       myTree
@@ -78,8 +78,8 @@ object Annotations {
 
   case class LazyBodyAnnotation(private var bodyExpr: Context => Tree) extends BodyAnnotation {
     // TODO: Make `bodyExpr` an IFT once #6865 os in bootstrap
-    private[this] var evaluated = false
-    private[this] var myBody: Tree = _
+    private var evaluated = false
+    private var myBody: Tree = _
     def tree(implicit ctx: Context): Tree = {
       if (evaluated) assert(myBody != null)
       else {
@@ -127,7 +127,7 @@ object Annotations {
     /** Create an annotation where the symbol and the tree are computed lazily. */
     def deferredSymAndTree(symf: (given Context) => Symbol)(treeFn: (given Context) => Tree)(implicit ctx: Context): Annotation =
       new LazyAnnotation {
-        private[this] var mySym: Symbol = _
+        private var mySym: Symbol = _
 
         override def symbol(implicit ctx: Context): Symbol = {
           if (mySym == null || mySym.defRunId != ctx.runId) {

--- a/compiler/src/dotty/tools/dotc/core/Comments.scala
+++ b/compiler/src/dotty/tools/dotc/core/Comments.scala
@@ -24,7 +24,7 @@ object Comments {
     */
   class ContextDocstrings {
 
-    private[this] val _docstrings: MutableSymbolMap[Comment] = newMutableSymbolMap
+    private val _docstrings: MutableSymbolMap[Comment] = newMutableSymbolMap
 
     val templateExpander: CommentExpander = new CommentExpander
 
@@ -93,7 +93,7 @@ object Comments {
      *  def foo: A = ???
      *  }}}
      */
-    private[this] def decomposeUseCase(body: String, span: Span, start: Int, end: Int)(implicit ctx: Context): UseCase = {
+    private def decomposeUseCase(body: String, span: Span, start: Int, end: Int)(implicit ctx: Context): UseCase = {
       def subPos(start: Int, end: Int) =
         if (span == NoSpan) NoSpan
         else {

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -34,7 +34,7 @@ trait ConstraintHandling[AbstractContext] {
   protected def constraint: Constraint
   protected def constraint_=(c: Constraint): Unit
 
-  private[this] var addConstraintInvocations = 0
+  private var addConstraintInvocations = 0
 
   /** If the constraint is frozen we cannot add new bounds to the constraint. */
   protected var frozenConstraint: Boolean = false

--- a/compiler/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
@@ -5,8 +5,8 @@ import Contexts._
 import config.Printers.{default, typr}
 
 trait ConstraintRunInfo { self: Run =>
-  private[this] var maxSize = 0
-  private[this] var maxConstraint: Constraint = _
+  private var maxSize = 0
+  private var maxConstraint: Constraint = _
   def recordConstraintSize(c: Constraint, size: Int): Unit =
     if (size > maxSize) {
       maxSize = size

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -91,12 +91,12 @@ object Contexts {
     }
 
     /** The outer context */
-    private[this] var _outer: Context = _
+    private var _outer: Context = _
     protected def outer_=(outer: Context): Unit = _outer = outer
     final def outer: Context = _outer
 
     /** The current context */
-    private[this] var _period: Period = _
+    private var _period: Period = _
     protected def period_=(period: Period): Unit = {
       assert(period.firstPhaseId == period.lastPhaseId, period)
       _period = period
@@ -104,54 +104,54 @@ object Contexts {
     final def period: Period = _period
 
     /** The scope nesting level */
-    private[this] var _mode: Mode = _
+    private var _mode: Mode = _
     protected def mode_=(mode: Mode): Unit = _mode = mode
     final def mode: Mode = _mode
 
     /** The current owner symbol */
-    private[this] var _owner: Symbol = _
+    private var _owner: Symbol = _
     protected def owner_=(owner: Symbol): Unit = _owner = owner
     final def owner: Symbol = _owner
 
     /** The current tree */
-    private[this] var _tree: Tree[? >: Untyped]= _
+    private var _tree: Tree[? >: Untyped]= _
     protected def tree_=(tree: Tree[? >: Untyped]): Unit = _tree = tree
     final def tree: Tree[? >: Untyped] = _tree
 
     /** The current scope */
-    private[this] var _scope: Scope = _
+    private var _scope: Scope = _
     protected def scope_=(scope: Scope): Unit = _scope = scope
     final def scope: Scope = _scope
 
     /** The current type comparer */
-    private[this] var _typerState: TyperState = _
+    private var _typerState: TyperState = _
     protected def typerState_=(typerState: TyperState): Unit = _typerState = typerState
     final def typerState: TyperState = _typerState
 
     /** The current type assigner or typer */
-    private[this] var _typeAssigner: TypeAssigner = _
+    private var _typeAssigner: TypeAssigner = _
     protected def typeAssigner_=(typeAssigner: TypeAssigner): Unit = _typeAssigner = typeAssigner
     final def typeAssigner: TypeAssigner = _typeAssigner
 
     /** The currently active import info */
-    private[this] var _importInfo: ImportInfo = _
+    private var _importInfo: ImportInfo = _
     protected def importInfo_=(importInfo: ImportInfo): Unit = _importInfo = importInfo
     final def importInfo: ImportInfo = _importInfo
 
     /** The current bounds in force for type parameters appearing in a GADT */
-    private[this] var _gadt: GadtConstraint = _
+    private var _gadt: GadtConstraint = _
     protected def gadt_=(gadt: GadtConstraint): Unit = _gadt = gadt
     final def gadt: GadtConstraint = _gadt
 
     /** The history of implicit searches that are currently active */
-    private[this] var _searchHistory: SearchHistory = null
+    private var _searchHistory: SearchHistory = null
     protected def searchHistory_= (searchHistory: SearchHistory): Unit = _searchHistory = searchHistory
     final def searchHistory: SearchHistory = _searchHistory
 
     /** The current type comparer. This ones updates itself automatically for
      *  each new context.
      */
-    private[this] var _typeComparer: TypeComparer = _
+    private var _typeComparer: TypeComparer = _
     protected def typeComparer_=(typeComparer: TypeComparer): Unit = _typeComparer = typeComparer
     def typeComparer: TypeComparer = {
       if (_typeComparer.ctx ne this)
@@ -160,14 +160,14 @@ object Contexts {
     }
 
     /** The current source file */
-    private[this] var _source: SourceFile = _
+    private var _source: SourceFile = _
     protected def source_=(source: SourceFile): Unit = _source = source
     final def source: SourceFile = _source
 
     /** A map in which more contextual properties can be stored
      *  Typically used for attributes that are read and written only in special situations.
      */
-    private[this] var _moreProperties: Map[Key[Any], Any] = _
+    private var _moreProperties: Map[Key[Any], Any] = _
     protected def moreProperties_=(moreProperties: Map[Key[Any], Any]): Unit = _moreProperties = moreProperties
     final def moreProperties: Map[Key[Any], Any] = _moreProperties
 
@@ -257,8 +257,8 @@ object Contexts {
       * phasedCtxs is array that uses phaseId's as indexes,
       * contexts are created only on request and cached in this array
       */
-    private[this] var phasedCtx: Context = this
-    private[this] var phasedCtxs: Array[Context] = _
+    private var phasedCtx: Context = this
+    private var phasedCtxs: Array[Context] = _
 
     /** This context at given phase.
      *  This method will always return a phase period equal to phaseId, thus will never return squashed phases
@@ -292,7 +292,7 @@ object Contexts {
     /** If -Ydebug is on, the top of the stack trace where this context
      *  was created, otherwise `null`.
      */
-    private[this] var creationTrace: Array[StackTraceElement] = _
+    private var creationTrace: Array[StackTraceElement] = _
 
     private def setCreationTrace() =
       if (this.settings.YtraceContextCreation.value)
@@ -640,7 +640,7 @@ object Contexts {
     val initialCtx: Context = new InitialContext(this, settings)
 
     /** The platform, initialized by `initPlatform()`. */
-    private[this] var _platform: Platform = _
+    private var _platform: Platform = _
 
     /** The platform */
     def platform: Platform = {
@@ -680,7 +680,7 @@ object Contexts {
     // Symbols state
 
     /** Counter for unique symbol ids */
-    private[this] var _nextSymId: Int = 0
+    private var _nextSymId: Int = 0
     def nextSymId: Int = { _nextSymId += 1; _nextSymId }
 
     /** Sources that were loaded */
@@ -766,7 +766,7 @@ object Contexts {
     // Test that access is single threaded
 
     /** The thread on which `checkSingleThreaded was invoked last */
-    @sharable private[this] var thread: Thread = null
+    @sharable private var thread: Thread = null
 
     /** Check that we are on the same thread as before */
     def checkSingleThreaded(): Unit =

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -375,7 +375,7 @@ class Definitions {
     }
     myDottyPredefModule
   }
-  private[this] var myDottyPredefModule: Symbol = _
+  private var myDottyPredefModule: Symbol = _
 
   @tu lazy val DottyArraysModule: Symbol = ctx.requiredModule("dotty.runtime.Arrays")
     def newGenericArrayMethod(implicit ctx: Context): TermSymbol = DottyArraysModule.requiredMethod("newGenericArray")
@@ -1201,8 +1201,8 @@ class Definitions {
 
   /** This class would also be obviated by the implicit function type design */
   class PerRun[T](generate: Context => T) {
-    private[this] var current: RunId = NoRunId
-    private[this] var cached: T = _
+    private var current: RunId = NoRunId
+    private var cached: T = _
     def apply()(implicit ctx: Context): T = {
       if (current != ctx.runId) {
         cached = generate(ctx)
@@ -1315,7 +1315,7 @@ class Definitions {
 
   @tu lazy val reservedScalaClassNames: Set[Name] = syntheticScalaClasses.map(_.name).toSet
 
-  private[this] var isInitialized = false
+  private var isInitialized = false
 
   def init()(implicit ctx: Context): Unit = {
     this.ctx = ctx

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -116,9 +116,9 @@ object Denotations {
      */
     def filterWithFlags(required: FlagSet, excluded: FlagSet)(implicit ctx: Context): PreDenotation
 
-    private[this] var cachedPrefix: Type = _
-    private[this] var cachedAsSeenFrom: AsSeenFromResult = _
-    private[this] var validAsSeenFrom: Period = Nowhere
+    private var cachedPrefix: Type = _
+    private var cachedAsSeenFrom: AsSeenFromResult = _
+    private var validAsSeenFrom: Period = Nowhere
 
     type AsSeenFromResult <: PreDenotation
 
@@ -774,7 +774,7 @@ object Denotations {
 
     // ------ Transformations -----------------------------------------
 
-    private[this] var myValidFor: Period = Nowhere
+    private var myValidFor: Period = Nowhere
 
     def validFor: Period = myValidFor
     def validFor_=(p: Period): Unit = {

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -261,16 +261,16 @@ final class ProperGadtConstraint private(
 
   // ---- Private ----------------------------------------------------------
 
-  private[this] def externalize(param: TypeParamRef)(implicit ctx: Context): Type =
+  private def externalize(param: TypeParamRef)(implicit ctx: Context): Type =
     reverseMapping(param) match {
       case sym: Symbol => sym.typeRef
       case null => param
     }
 
-  private[this] def tvarOrError(sym: Symbol)(implicit ctx: Context): TypeVar =
+  private def tvarOrError(sym: Symbol)(implicit ctx: Context): TypeVar =
     mapping(sym).ensuring(_ ne null, i"not a constrainable symbol: $sym")
 
-  private[this] def containsNoInternalTypes(
+  private def containsNoInternalTypes(
     tp: Type,
     acc: TypeAccumulator[Boolean] = null
   )(implicit ctx: Context): Boolean = tp match {
@@ -280,7 +280,7 @@ final class ProperGadtConstraint private(
       (if (acc ne null) acc else new ContainsNoInternalTypesAccumulator()).foldOver(true, tp)
   }
 
-  private[this] class ContainsNoInternalTypesAccumulator(implicit ctx: Context) extends TypeAccumulator[Boolean] {
+  private class ContainsNoInternalTypesAccumulator(implicit ctx: Context) extends TypeAccumulator[Boolean] {
     override def apply(x: Boolean, tp: Type): Boolean = x && containsNoInternalTypes(tp)
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -168,7 +168,7 @@ object Names {
     override def asTermName: TermName = this
 
     @sharable // because it is only modified in the synchronized block of toTypeName.
-    @volatile private[this] var _typeName: TypeName = null
+    @volatile private var _typeName: TypeName = null
 
     override def toTypeName: TypeName = {
       if (_typeName == null)
@@ -185,7 +185,7 @@ object Names {
     def underlying: TermName = unsupported("underlying")
 
     @sharable // because of synchronized block in `and`
-    private[this] var derivedNames: immutable.Map[NameInfo, DerivedName] | HashMap[NameInfo, DerivedName] =
+    private var derivedNames: immutable.Map[NameInfo, DerivedName] | HashMap[NameInfo, DerivedName] =
       immutable.Map.empty[NameInfo, DerivedName]
 
     private def getDerived(info: NameInfo): DerivedName /* | Null */ = (derivedNames: @unchecked) match {
@@ -253,10 +253,10 @@ object Names {
     }
 
     @sharable // because it's just a cache for performance
-    private[this] var myMangledString: String = null
+    private var myMangledString: String = null
 
     @sharable // because it's just a cache for performance
-    private[this] var myMangled: Name = null
+    private var myMangled: Name = null
 
     protected[Names] def mangle: ThisName
 
@@ -532,15 +532,15 @@ object Names {
 
   /** The number of characters filled. */
   @sharable // because it's only mutated in synchronized block of termName
-  private[this] var nc = 0
+  private var nc = 0
 
   /** Hashtable for finding term names quickly. */
   @sharable // because it's only mutated in synchronized block of termName
-  private[this] var table = new Array[SimpleName](InitialHashSize)
+  private var table = new Array[SimpleName](InitialHashSize)
 
   /** The number of defined names. */
   @sharable // because it's only mutated in synchronized block of termName
-  private[this] var size = 1
+  private var size = 1
 
   /** The hash of a name made of from characters cs[offset..offset+len-1].  */
   private def hashValue(cs: Array[Char], offset: Int, len: Int): Int = {

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -595,7 +595,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
     upperMap.foreachBinding((_, paramss) => paramss.foreach(_.foreach(checkClosedType(_, "upper"))))
   }
 
-  private[this] var myUninstVars: mutable.ArrayBuffer[TypeVar] = _
+  private var myUninstVars: mutable.ArrayBuffer[TypeVar] = _
 
   /** The uninstantiated typevars of this constraint */
   def uninstVars: collection.Seq[TypeVar] = {

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -215,23 +215,23 @@ object Phases {
       config.println(s"nextDenotTransformerId = ${nextDenotTransformerId.toList}")
     }
 
-    private[this] var myTyperPhase: Phase = _
-    private[this] var myPostTyperPhase: Phase = _
-    private[this] var mySbtExtractDependenciesPhase: Phase = _
-    private[this] var myPicklerPhase: Phase = _
-    private[this] var myReifyQuotesPhase: Phase = _
-    private[this] var myCollectNullableFieldsPhase: Phase = _
-    private[this] var myRefChecksPhase: Phase = _
-    private[this] var myPatmatPhase: Phase = _
-    private[this] var myElimRepeatedPhase: Phase = _
-    private[this] var myExtensionMethodsPhase: Phase = _
-    private[this] var myExplicitOuterPhase: Phase = _
-    private[this] var myGettersPhase: Phase = _
-    private[this] var myErasurePhase: Phase = _
-    private[this] var myElimErasedValueTypePhase: Phase = _
-    private[this] var myLambdaLiftPhase: Phase = _
-    private[this] var myFlattenPhase: Phase = _
-    private[this] var myGenBCodePhase: Phase = _
+    private var myTyperPhase: Phase = _
+    private var myPostTyperPhase: Phase = _
+    private var mySbtExtractDependenciesPhase: Phase = _
+    private var myPicklerPhase: Phase = _
+    private var myReifyQuotesPhase: Phase = _
+    private var myCollectNullableFieldsPhase: Phase = _
+    private var myRefChecksPhase: Phase = _
+    private var myPatmatPhase: Phase = _
+    private var myElimRepeatedPhase: Phase = _
+    private var myExtensionMethodsPhase: Phase = _
+    private var myExplicitOuterPhase: Phase = _
+    private var myGettersPhase: Phase = _
+    private var myErasurePhase: Phase = _
+    private var myElimErasedValueTypePhase: Phase = _
+    private var myLambdaLiftPhase: Phase = _
+    private var myFlattenPhase: Phase = _
+    private var myGenBCodePhase: Phase = _
 
     final def typerPhase: Phase = myTyperPhase
     final def postTyperPhase: Phase = myPostTyperPhase
@@ -347,17 +347,17 @@ object Phases {
 
     def initContext(ctx: FreshContext): Unit = ()
 
-    private[this] var myPeriod: Period = Periods.InvalidPeriod
-    private[this] var myBase: ContextBase = null
-    private[this] var myErasedTypes = false
-    private[this] var myFlatClasses = false
-    private[this] var myRefChecked = false
-    private[this] var myLambdaLifted = false
-    private[this] var myPatternTranslated = false
+    private var myPeriod: Period = Periods.InvalidPeriod
+    private var myBase: ContextBase = null
+    private var myErasedTypes = false
+    private var myFlatClasses = false
+    private var myRefChecked = false
+    private var myLambdaLifted = false
+    private var myPatternTranslated = false
 
-    private[this] var mySameMembersStartId = NoPhaseId
-    private[this] var mySameParentsStartId = NoPhaseId
-    private[this] var mySameBaseTypesStartId = NoPhaseId
+    private var mySameMembersStartId = NoPhaseId
+    private var mySameParentsStartId = NoPhaseId
+    private var mySameBaseTypesStartId = NoPhaseId
 
     /** The sequence position of this phase in the given context where 0
      * is reserved for NoPhase and the first real phase is at position 1.

--- a/compiler/src/dotty/tools/dotc/core/Scopes.scala
+++ b/compiler/src/dotty/tools/dotc/core/Scopes.scala
@@ -201,18 +201,18 @@ object Scopes {
     private[dotc] var lastEntry: ScopeEntry = initElems
 
     /** The size of the scope */
-    private[this] var _size = initSize
+    private var _size = initSize
 
     override final def size: Int = _size
     private def size_= (x: Int) = _size = x
 
     /** the hash table
      */
-    private[this] var hashTable: Array[ScopeEntry] = null
+    private var hashTable: Array[ScopeEntry] = null
 
     /** a cache for all elements, to be used by symbol iterator.
      */
-    private[this] var elemsCache: List[Symbol] = null
+    private var elemsCache: List[Symbol] = null
 
     /** The synthesizer to be used, or `null` if no synthesis is done on this scope */
     private var synthesize: SymbolSynthesizer = null

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -145,9 +145,9 @@ object SymDenotations {
 
     // ------ Getting and setting fields -----------------------------
 
-    private[this] var myFlags: FlagSet = adaptFlags(initFlags)
-    private[this] var myPrivateWithin: Symbol = initPrivateWithin
-    private[this] var myAnnotations: List[Annotation] = Nil
+    private var myFlags: FlagSet = adaptFlags(initFlags)
+    private var myPrivateWithin: Symbol = initPrivateWithin
+    private var myAnnotations: List[Annotation] = Nil
 
     /** The owner of the symbol; overridden in NoDenotation */
     def owner: Symbol = maybeOwner
@@ -1023,7 +1023,7 @@ object SymDenotations {
 
     /** The chain of owners of this denotation, starting with the denoting symbol itself */
     final def ownersIterator(implicit ctx: Context): Iterator[Symbol] = new Iterator[Symbol] {
-      private[this] var current = symbol
+      private var current = symbol
       def hasNext = current.exists
       def next: Symbol = {
         val result = current
@@ -1483,16 +1483,16 @@ object SymDenotations {
 
     // ----- caches -------------------------------------------------------
 
-    private[this] var myTypeParams: List[TypeSymbol] = null
-    private[this] var fullNameCache: SimpleIdentityMap[QualifiedNameKind, Name] = SimpleIdentityMap.Empty
+    private var myTypeParams: List[TypeSymbol] = null
+    private var fullNameCache: SimpleIdentityMap[QualifiedNameKind, Name] = SimpleIdentityMap.Empty
 
-    private[this] var myMemberCache: LRUCache[Name, PreDenotation] = null
-    private[this] var myMemberCachePeriod: Period = Nowhere
+    private var myMemberCache: LRUCache[Name, PreDenotation] = null
+    private var myMemberCachePeriod: Period = Nowhere
 
     /** A cache from types T to baseType(T, C) */
     type BaseTypeMap = java.util.IdentityHashMap[CachedType, Type]
-    private[this] var myBaseTypeCache: BaseTypeMap = null
-    private[this] var myBaseTypeCachePeriod: Period = Nowhere
+    private var myBaseTypeCache: BaseTypeMap = null
+    private var myBaseTypeCachePeriod: Period = Nowhere
 
     private var baseDataCache: BaseData = BaseData.None
     private var memberNamesCache: MemberNames = MemberNames.None
@@ -1609,7 +1609,7 @@ object SymDenotations {
 
    // ------ class-specific operations -----------------------------------
 
-    private[this] var myThisType: Type = null
+    private var myThisType: Type = null
 
     /** The this-type depends on the kind of class:
      *  - for a package class `p`:  ThisType(TypeRef(Noprefix, p))
@@ -1627,7 +1627,7 @@ object SymDenotations {
       ThisType.raw(TypeRef(pre, cls))
     }
 
-    private[this] var myTypeRef: TypeRef = null
+    private var myTypeRef: TypeRef = null
 
     override def typeRef(implicit ctx: Context): TypeRef = {
       if (myTypeRef == null) myTypeRef = super.typeRef
@@ -2047,7 +2047,7 @@ object SymDenotations {
             .installAfter(phase)
       }
 
-    private[this] var myCompanion: Symbol = NoSymbol
+    private var myCompanion: Symbol = NoSymbol
 
     /** Register companion class */
     override def registerCompanion(companion: Symbol)(implicit ctx: Context) =
@@ -2070,8 +2070,8 @@ object SymDenotations {
     initPrivateWithin: Symbol)
     extends ClassDenotation(symbol, ownerIfExists, name, initFlags, initInfo, initPrivateWithin) {
 
-    private[this] var packageObjsCache: List[ClassDenotation] = _
-    private[this] var packageObjsRunId: RunId = NoRunId
+    private var packageObjsCache: List[ClassDenotation] = _
+    private var packageObjsRunId: RunId = NoRunId
 
     /** The package objects in this class */
     def packageObjs(implicit ctx: Context): List[ClassDenotation] = {
@@ -2221,10 +2221,10 @@ object SymDenotations {
     def apply(sym: Symbol): LazyType = this
     def apply(module: TermSymbol, modcls: ClassSymbol): LazyType = this
 
-    private[this] val NoSymbolFn = (_: Context) => NoSymbol
-    private[this] var myDecls: Scope = EmptyScope
-    private[this] var mySourceModuleFn: Context => Symbol = NoSymbolFn
-    private[this] var myModuleClassFn: Context => Symbol = NoSymbolFn
+    private val NoSymbolFn = (_: Context) => NoSymbol
+    private var myDecls: Scope = EmptyScope
+    private var mySourceModuleFn: Context => Symbol = NoSymbolFn
+    private var myModuleClassFn: Context => Symbol = NoSymbolFn
 
     /** The type parameters computed by the completer before completion has finished */
     def completerTypeParams(sym: Symbol)(implicit ctx: Context): List[TypeParamInfo] =
@@ -2347,8 +2347,8 @@ object SymDenotations {
   private abstract class InheritedCacheImpl(val createdAt: Period) extends InheritedCache {
     protected def sameGroup(p1: Phase, p2: Phase): Boolean
 
-    private[this] var dependent: WeakHashMap[InheritedCache, Unit] = null
-    private[this] var checkedPeriod: Period = Nowhere
+    private var dependent: WeakHashMap[InheritedCache, Unit] = null
+    private var checkedPeriod: Period = Nowhere
 
     protected def invalidateDependents() = {
       if (dependent != null) {
@@ -2378,12 +2378,12 @@ object SymDenotations {
   }
 
   private class MemberNamesImpl(createdAt: Period) extends InheritedCacheImpl(createdAt) with MemberNames {
-    private[this] var cache: SimpleIdentityMap[NameFilter, Set[Name]] = SimpleIdentityMap.Empty
+    private var cache: SimpleIdentityMap[NameFilter, Set[Name]] = SimpleIdentityMap.Empty
 
     final def isValid(implicit ctx: Context): Boolean =
       cache != null && isValidAt(ctx.phase)
 
-    private[this] var locked = false
+    private var locked = false
 
     /** Computing parent member names might force parents, which could invalidate
      *  the cache itself. In that case we should cancel invalidation and
@@ -2417,11 +2417,11 @@ object SymDenotations {
   }
 
   private class BaseDataImpl(createdAt: Period) extends InheritedCacheImpl(createdAt) with BaseData {
-    private[this] var cache: (List[ClassSymbol], BaseClassSet) = null
+    private var cache: (List[ClassSymbol], BaseClassSet) = null
 
-    private[this] var valid = true
-    private[this] var locked = false
-    private[this] var provisional = false
+    private var valid = true
+    private var locked = false
+    private var provisional = false
 
     final def isValid(implicit ctx: Context): Boolean = valid && isValidAt(ctx.phase)
 
@@ -2480,9 +2480,9 @@ object SymDenotations {
 
   /** A class to combine base data from parent types */
   class BaseDataBuilder {
-    private[this] var classes: List[ClassSymbol] = Nil
-    private[this] var classIds = new Array[Int](32)
-    private[this] var length = 0
+    private var classes: List[ClassSymbol] = Nil
+    private var classIds = new Array[Int](32)
+    private var length = 0
 
     private def resize(size: Int) = {
       val classIds1 = new Array[Int](size)
@@ -2520,5 +2520,5 @@ object SymDenotations {
 
   private val packageTypeName = ModuleClassName(nme.PACKAGE).toTypeName
 
-  @sharable private[this] var indent = 0 // for completions printing
+  @sharable private var indent = 0 // for completions printing
 }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -795,7 +795,7 @@ object SymDenotations {
      *  @param superAccess  Access is via super
      *  Everything is accessible if `pre` is `NoPrefix`.
      *  A symbol with type `NoType` is not accessible for any other prefix.
-     *  
+     *
      *  As a side effect, drop Local flags of members that are not accessed via the ThisType
      *  of their owner.
      */
@@ -2192,19 +2192,16 @@ object SymDenotations {
     validFor = Period.allInRun(NoRunId)
   }
 
-  /** Can a pruvate symbol with given name and flags be inferred to be local,
+  /** Can a private symbol with given name and flags be inferred to be local,
    *  if all references to such symbols are via `this`?
-   *  This holds for all term symbols, except
+   *  This holds for all symbols except
    *   - constructors, since they can never be referred to as members of their
    *     own, fully elaborated `this`.
    *   - parameters and parameter accessors, since their Local status is already
    *     determined by whether they have a `val` or `var` or not.
    */
   def canBeLocal(name: Name, flags: FlagSet)(given Context) =
-    name.isTermName
-    && !name.isConstructorName
-    && !flags.is(Param)
-    && !flags.is(ParamAccessor)
+    !name.isConstructorName && !flags.is(Param) && !flags.is(ParamAccessor)
 
   // ---- Completion --------------------------------------------------------
 

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -203,7 +203,7 @@ object SymbolLoaders {
     override def sourceModule(implicit ctx: Context): TermSymbol = _sourceModule
     def description(implicit ctx: Context): String = "package loader " + sourceModule.fullName
 
-    private[this] var enterFlatClasses: Option[Context => Unit] = None
+    private var enterFlatClasses: Option[Context => Unit] = None
 
     Stats.record("package scopes")
 

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -418,7 +418,7 @@ object Symbols {
    *  @param coord  The coordinates of the symbol (a position or an index)
    *  @param id     A unique identifier of the symbol (unique per ContextBase)
    */
-  class Symbol private[Symbols] (private[this] var myCoord: Coord, val id: Int)
+  class Symbol private[Symbols] (private var myCoord: Coord, val id: Int)
     extends Designator with ParamInfo with printing.Showable {
 
     type ThisName <: Name
@@ -437,7 +437,7 @@ object Symbols {
       myCoord = c
     }
 
-    private[this] var myDefTree: Tree = null
+    private var myDefTree: Tree = null
 
     /** The tree defining the symbol at pickler time, EmptyTree if none was retained */
     def defTree: Tree =
@@ -457,8 +457,8 @@ object Symbols {
       denot.isOneOf(InlineOrProxy)      // need to keep inline info
 
     /** The last denotation of this symbol */
-    private[this] var lastDenot: SymDenotation = _
-    private[this] var checkedPeriod: Period = Nowhere
+    private var lastDenot: SymDenotation = _
+    private var checkedPeriod: Period = Nowhere
 
     private[core] def invalidateDenotCache(): Unit = { checkedPeriod = Nowhere }
 
@@ -726,7 +726,7 @@ object Symbols {
 
     type TreeOrProvider = tpd.TreeProvider | tpd.Tree
 
-    private[this] var myTree: TreeOrProvider = tpd.EmptyTree
+    private var myTree: TreeOrProvider = tpd.EmptyTree
 
     /** If this is a top-level class and `-Yretain-trees` (or `-from-tasty`) is set.
       * Returns the TypeDef tree (possibly wrapped inside PackageDefs) for this class, otherwise EmptyTree.
@@ -783,7 +783,7 @@ object Symbols {
       if (assocFile != null || this.owner.is(PackageClass) || this.isEffectiveRoot) assocFile
       else super.associatedFile
 
-    private[this] var mySource: SourceFile = NoSource
+    private var mySource: SourceFile = NoSource
 
     final def sourceOfClass(implicit ctx: Context): SourceFile = {
       if (!mySource.exists && !denot.is(Package))

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -103,7 +103,7 @@ object TypeApplications {
    *  produce a higher-kinded application with a type lambda as type constructor.
    */
   class Reducer(tycon: TypeLambda, args: List[Type])(implicit ctx: Context) extends TypeMap {
-    private[this] var available = (0 until args.length).toSet
+    private var available = (0 until args.length).toSet
     var allReplaced: Boolean = true
     def hasWildcardArg(p: TypeParamRef): Boolean =
       p.binder == tycon && isBounds(args(p.paramNum))

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -34,11 +34,11 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
   def constraint: Constraint = state.constraint
   def constraint_=(c: Constraint): Unit = state.constraint = c
 
-  private[this] var pendingSubTypes: mutable.Set[(Type, Type)] = null
-  private[this] var recCount = 0
-  private[this] var monitored = false
+  private var pendingSubTypes: mutable.Set[(Type, Type)] = null
+  private var recCount = 0
+  private var monitored = false
 
-  private[this] var needsGc = false
+  private var needsGc = false
 
   /** Is a subtype check in progress? In that case we may not
    *  permanently instantiate type variables, because the corresponding
@@ -55,17 +55,17 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
   }
 
   /** For statistics: count how many isSubTypes are part of successful comparisons */
-  private[this] var successCount = 0
-  private[this] var totalCount = 0
+  private var successCount = 0
+  private var totalCount = 0
 
-  private[this] var myAnyClass: ClassSymbol = null
-  private[this] var myAnyKindClass: ClassSymbol = null
-  private[this] var myNothingClass: ClassSymbol = null
-  private[this] var myNullClass: ClassSymbol = null
-  private[this] var myObjectClass: ClassSymbol = null
-  private[this] var myAnyType: TypeRef = null
-  private[this] var myAnyKindType: TypeRef = null
-  private[this] var myNothingType: TypeRef = null
+  private var myAnyClass: ClassSymbol = null
+  private var myAnyKindClass: ClassSymbol = null
+  private var myNothingClass: ClassSymbol = null
+  private var myNullClass: ClassSymbol = null
+  private var myObjectClass: ClassSymbol = null
+  private var myAnyType: TypeRef = null
+  private var myAnyKindType: TypeRef = null
+  private var myNothingType: TypeRef = null
 
   def AnyClass: ClassSymbol = {
     if (myAnyClass == null) myAnyClass = defn.AnyClass
@@ -133,7 +133,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
   }
 
   /** The current approximation state. See `ApproxState`. */
-  private[this] var approx: ApproxState = FreshApprox
+  private var approx: ApproxState = FreshApprox
   protected def approxState: ApproxState = approx
 
   /** The original left-hand type of the comparison. Gets reset
@@ -147,7 +147,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
    *  This flag is set when we're already in [[Mode.GadtConstraintInference]],
    *  to signify that we temporarily cannot record any GADT constraints.
    */
-  private[this] var frozenGadt = false
+  private var frozenGadt = false
 
   protected def isSubType(tp1: Type, tp2: Type, a: ApproxState): Boolean = {
     val savedApprox = approx
@@ -1889,7 +1889,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
         NoType
     }
 
-  private[this] def andTypeGen(tp1: Type, tp2: Type, op: (Type, Type) => Type,
+  private def andTypeGen(tp1: Type, tp2: Type, op: (Type, Type) => Type,
       original: (Type, Type) => Type = _ & _, isErased: Boolean = ctx.erasedTypes): Type = trace(s"glb(${tp1.show}, ${tp2.show})", subtyping, show = true) {
     val t1 = distributeAnd(tp1, tp2)
     if (t1.exists) t1
@@ -2492,10 +2492,10 @@ class TrackingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
 class ExplainingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
   import TypeComparer._
 
-  private[this] var indent = 0
+  private var indent = 0
   private val b = new StringBuilder
 
-  private[this] var skipped = false
+  private var skipped = false
 
   override def traceIndented[T](str: String)(op: => T): T =
     if (skipped) op

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -147,6 +147,12 @@ object TypeErasure {
   def valueErasure(tp: Type)(implicit ctx: Context): Type =
     erasureFn(isJava = false, semiEraseVCs = true, isConstructor = false, wildcardOK = false)(tp)(erasureCtx)
 
+  /** Like value class erasure, but value classes erase to their underlying type erasure */
+  def fullErasure(tp: Type)(implicit ctx: Context): Type =
+    valueErasure(tp) match
+      case ErasedValueType(_, underlying) => erasure(underlying)
+      case etp => etp
+
   def sigName(tp: Type, isJava: Boolean)(implicit ctx: Context): TypeName = {
     val normTp = tp.underlyingIfRepeated(isJava)
     val erase = erasureFn(isJava, semiEraseVCs = false, isConstructor = false, wildcardOK = true)

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -26,7 +26,7 @@ class TyperState(private val previous: TyperState /* | Null */) {
   val id: Int = TyperState.nextId
   TyperState.nextId += 1
 
-  private[this] var myReporter =
+  private var myReporter =
     if (previous == null) new ConsoleReporter() else previous.reporter
 
   def reporter: Reporter = myReporter
@@ -34,7 +34,7 @@ class TyperState(private val previous: TyperState /* | Null */) {
   /** A fresh type state with the same constraint as this one and the given reporter */
   def setReporter(reporter: Reporter): this.type = { myReporter = reporter; this }
 
-  private[this] var myConstraint: Constraint =
+  private var myConstraint: Constraint =
     if (previous == null) OrderingConstraint.empty
     else previous.constraint
 
@@ -53,7 +53,7 @@ class TyperState(private val previous: TyperState /* | Null */) {
   private val previousConstraint =
     if (previous == null) constraint else previous.constraint
 
-  private[this] var myIsCommittable = true
+  private var myIsCommittable = true
 
   def isCommittable: Boolean = myIsCommittable
 
@@ -62,7 +62,7 @@ class TyperState(private val previous: TyperState /* | Null */) {
   def isGlobalCommittable: Boolean =
     isCommittable && (previous == null || previous.isGlobalCommittable)
 
-  private[this] var isShared = false
+  private var isShared = false
 
   /** Mark typer state as shared (typically because it is the typer state of
    *  the creation context of a source definition that potentially still needs
@@ -70,7 +70,7 @@ class TyperState(private val previous: TyperState /* | Null */) {
    */
   def markShared(): Unit = isShared = true
 
-  private[this] var isCommitted = false
+  private var isCommitted = false
 
   /** A fresh typer state with the same constraint as this one. */
   def fresh(): TyperState =
@@ -80,7 +80,7 @@ class TyperState(private val previous: TyperState /* | Null */) {
   def uninstVars: collection.Seq[TypeVar] = constraint.uninstVars
 
   /** The set of uninstantiated type variables which have this state as their owning state */
-  private[this] var myOwnedVars: TypeVars = SimpleIdentitySet.empty
+  private var myOwnedVars: TypeVars = SimpleIdentitySet.empty
   def ownedVars: TypeVars = myOwnedVars
   def ownedVars_=(vs: TypeVars): Unit = myOwnedVars = vs
 
@@ -90,7 +90,7 @@ class TyperState(private val previous: TyperState /* | Null */) {
   def uncommittedAncestor: TyperState =
     if (isCommitted) previous.uncommittedAncestor else this
 
-  private[this] var testReporter: TestReporter = null
+  private var testReporter: TestReporter = null
 
   /** Test using `op`. If current typerstate is shared, run `op` in a fresh exploration
    *  typerstate. If it is unshared, run `op` in current typerState, restoring typerState

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -39,7 +39,7 @@ import scala.annotation.threadUnsafe
 
 object Types {
 
-  @sharable private[this] var nextId = 0
+  @sharable private var nextId = 0
 
   implicit def eqType: Eql[Type, Type] = Eql.derived
 
@@ -1654,7 +1654,7 @@ object Types {
 
   /**  Instances of this class are cached and are not proxies. */
   abstract class CachedGroundType extends Type with CachedType {
-    private[this] var myHash = HashUnknown
+    private var myHash = HashUnknown
     final def hash: Int = {
       if (myHash == HashUnknown) {
         myHash = computeHash(null)
@@ -1759,7 +1759,7 @@ object Types {
 
   /** Implementations of this trait cache the results of `narrow`. */
   trait NarrowCached extends Type {
-    private[this] var myNarrow: TermRef = null
+    private var myNarrow: TermRef = null
     override def narrow(implicit ctx: Context): TermRef = {
       if (myNarrow eq null) myNarrow = super.narrow
       myNarrow
@@ -1779,11 +1779,11 @@ object Types {
 
     assert(prefix.isValueType || (prefix eq NoPrefix), s"invalid prefix $prefix")
 
-    private[this] var myName: Name = null
-    private[this] var lastDenotation: Denotation = null
-    private[this] var lastSymbol: Symbol = null
-    private[this] var checkedPeriod: Period = Nowhere
-    private[this] var myStableHash: Byte = 0
+    private var myName: Name = null
+    private var lastDenotation: Denotation = null
+    private var lastSymbol: Symbol = null
+    private var checkedPeriod: Period = Nowhere
+    private var myStableHash: Byte = 0
 
     // Invariants:
     // (1) checkedPeriod != Nowhere  =>  lastDenotation != null
@@ -2501,8 +2501,8 @@ object Types {
   }
 
   case class LazyRef(private var refFn: Context => Type) extends UncachedProxyType with ValueType {
-    private[this] var myRef: Type = null
-    private[this] var computed = false
+    private var myRef: Type = null
+    private var computed = false
     def ref(implicit ctx: Context): Type = {
       if (computed) {
         if (myRef == null) {
@@ -2629,7 +2629,7 @@ object Types {
 
     val parent: Type = parentExp(this)
 
-    private[this] var myRecThis: RecThis = null
+    private var myRecThis: RecThis = null
 
     def recThis: RecThis = {
       if (myRecThis == null) myRecThis = new RecThisImpl(this)
@@ -2733,8 +2733,8 @@ object Types {
 
   abstract case class AndType(tp1: Type, tp2: Type) extends AndOrType {
     def isAnd: Boolean = true
-    private[this] var myBaseClassesPeriod: Period = Nowhere
-    private[this] var myBaseClasses: List[ClassSymbol] = _
+    private var myBaseClassesPeriod: Period = Nowhere
+    private var myBaseClasses: List[ClassSymbol] = _
     /** Base classes of are the merge of the operand base classes. */
     override final def baseClasses(implicit ctx: Context): List[ClassSymbol] = {
       if (myBaseClassesPeriod != ctx.period) {
@@ -2798,8 +2798,8 @@ object Types {
 
   abstract case class OrType(tp1: Type, tp2: Type) extends AndOrType {
     def isAnd: Boolean = false
-    private[this] var myBaseClassesPeriod: Period = Nowhere
-    private[this] var myBaseClasses: List[ClassSymbol] = _
+    private var myBaseClassesPeriod: Period = Nowhere
+    private var myBaseClasses: List[ClassSymbol] = _
     /** Base classes of are the intersection of the operand base classes. */
     override final def baseClasses(implicit ctx: Context): List[ClassSymbol] = {
       if (myBaseClassesPeriod != ctx.period) {
@@ -2823,8 +2823,8 @@ object Types {
     assert(tp1.isValueTypeOrWildcard &&
            tp2.isValueTypeOrWildcard, s"$tp1 $tp2")
 
-    private[this] var myJoin: Type = _
-    private[this] var myJoinPeriod: Period = Nowhere
+    private var myJoin: Type = _
+    private var myJoinPeriod: Period = Nowhere
 
     /** Replace or type by the closest non-or type above it */
     def join(implicit ctx: Context): Type = {
@@ -2837,9 +2837,9 @@ object Types {
       myJoin
     }
 
-    private[this] var atomsRunId: RunId = NoRunId
-    private[this] var myAtoms: Set[Type] = _
-    private[this] var myWidened: Type = _
+    private var atomsRunId: RunId = NoRunId
+    private var myAtoms: Set[Type] = _
+    private var myWidened: Type = _
 
     private def ensureAtomsComputed()(implicit ctx: Context): Unit =
       if (atomsRunId != ctx.runId) {
@@ -2985,7 +2985,7 @@ object Types {
     final def isTypeLambda: Boolean = isInstanceOf[TypeLambda]
     final def isHigherKinded: Boolean = isInstanceOf[TypeProxy]
 
-    private[this] var myParamRefs: List[ParamRefType] = null
+    private var myParamRefs: List[ParamRefType] = null
 
     def paramRefs: List[ParamRefType] = {
       if (myParamRefs == null) myParamRefs = paramNames.indices.toList.map(newParamRef)
@@ -3097,8 +3097,8 @@ object Types {
       }
       else resType
 
-    private[this] var myDependencyStatus: DependencyStatus = Unknown
-    private[this] var myParamDependencyStatus: DependencyStatus = Unknown
+    private var myDependencyStatus: DependencyStatus = Unknown
+    private var myParamDependencyStatus: DependencyStatus = Unknown
 
     private def depStatus(initial: DependencyStatus, tp: Type)(implicit ctx: Context): DependencyStatus = {
       def combine(x: DependencyStatus, y: DependencyStatus) = {
@@ -3502,12 +3502,12 @@ object Types {
   abstract case class AppliedType(tycon: Type, args: List[Type])
   extends CachedProxyType with ValueType {
 
-    private[this] var validSuper: Period = Nowhere
-    private[this] var cachedSuper: Type = _
-    private[this] var myStableHash: Byte = 0
+    private var validSuper: Period = Nowhere
+    private var cachedSuper: Type = _
+    private var myStableHash: Byte = 0
 
-    private[this] var isGroundKnown: Boolean = false
-    private[this] var isGroundCache: Boolean = _
+    private var isGroundKnown: Boolean = false
+    private var isGroundCache: Boolean = _
 
     def isGround(acc: TypeAccumulator[Boolean])(implicit ctx: Context): Boolean = {
       if (!isGroundKnown) {
@@ -3735,7 +3735,7 @@ object Types {
 
     def withName(name: Name): this.type = { myRepr = name; this }
 
-    private[this] var myRepr: Name = null
+    private var myRepr: Name = null
     def repr(implicit ctx: Context): Name = {
       if (myRepr == null) myRepr = SkolemName.fresh()
       myRepr
@@ -3788,7 +3788,7 @@ object Types {
     def setOrigin(p: TypeParamRef) = _origin = p
 
     /** The permanent instance type of the variable, or NoType is none is given yet */
-    private[this] var myInst: Type = NoType
+    private var myInst: Type = NoType
 
     private[core] def inst: Type = myInst
     private[core] def inst_=(tp: Type): Unit = {
@@ -3887,8 +3887,8 @@ object Types {
     def alternatives(implicit ctx: Context): List[Type] = cases.map(caseType)
     def underlying(implicit ctx: Context): Type = bound
 
-    private[this] var myReduced: Type = null
-    private[this] var reductionContext: mutable.Map[Type, Type] = null
+    private var myReduced: Type = null
+    private var reductionContext: mutable.Map[Type, Type] = null
 
     override def tryNormalize(implicit ctx: Context): Type = reduced.normalized
 
@@ -3976,8 +3976,8 @@ object Types {
       decls: Scope,
       selfInfo: TypeOrSymbol) extends CachedGroundType with TypeType {
 
-    private[this] var selfTypeCache: Type = null
-    private[this] var appliedRefCache: Type = null
+    private var selfTypeCache: Type = null
+    private var appliedRefCache: Type = null
 
     /** The self type of a class is the conjunction of
      *   - the explicit self type if given (or the info of a given self symbol), and
@@ -4003,7 +4003,7 @@ object Types {
     }
 
     // cached because baseType needs parents
-    private[this] var parentsCache: List[Type] = null
+    private var parentsCache: List[Type] = null
 
     override def parents(implicit ctx: Context): List[Type] = {
       if (parentsCache == null)
@@ -4211,8 +4211,8 @@ object Types {
 
     override def stripAnnots(implicit ctx: Context): Type = parent.stripAnnots
 
-    private[this] var isRefiningKnown = false
-    private[this] var isRefiningCache: Boolean = _
+    private var isRefiningKnown = false
+    private var isRefiningCache: Boolean = _
 
     def isRefining(implicit ctx: Context): Boolean = {
       if (!isRefiningKnown) {

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1668,7 +1668,7 @@ object Types {
 
   /**  Instances of this class are cached and are proxies. */
   abstract class CachedProxyType extends TypeProxy with CachedType {
-    protected[this] var myHash: Int = HashUnknown
+    protected var myHash: Int = HashUnknown
     final def hash: Int = {
       if (myHash == HashUnknown) {
         myHash = computeHash(null)
@@ -2894,8 +2894,8 @@ object Types {
 
   /** A trait that mixes in functionality for signature caching */
   trait SignatureCachingType extends TermType {
-    protected[this] var mySignature: Signature = _
-    protected[this] var mySignatureRunId: Int = NoRunId
+    protected var mySignature: Signature = _
+    protected var mySignatureRunId: Int = NoRunId
 
     protected def computeSignature(implicit ctx: Context): Signature
 

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -70,7 +70,7 @@ class ClassfileParser(
   protected var currentClassName: SimpleName = _      // JVM name of the current class
   protected var classTParams: Map[Name, Symbol] = Map()
 
-  private[this] var Scala2UnpicklingMode = Mode.Scala2Unpickling
+  private var Scala2UnpicklingMode = Mode.Scala2Unpickling
 
   classRoot.info = NoLoader().withDecls(instanceScope)
   moduleRoot.info = NoLoader().withDecls(staticScope).withSourceModule(_ => staticModule)
@@ -696,7 +696,7 @@ class ClassfileParser(
 
   // Nothing$ and Null$ were incorrectly emitted with a Scala attribute
   // instead of ScalaSignature before 2.13.0-M2, see https://github.com/scala/scala/pull/5952
-  private[this] val scalaUnpickleWhitelist = List(tpnme.nothingClass, tpnme.nullClass)
+  private val scalaUnpickleWhitelist = List(tpnme.nothingClass, tpnme.nullClass)
 
   /** Parse inner classes. Expects `in.bp` to point to the superclass entry.
    *  Restores the old `bp`.

--- a/compiler/src/dotty/tools/dotc/core/tasty/CommentPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/CommentPickler.scala
@@ -8,7 +8,7 @@ import dotty.tools.dotc.core.tasty.TastyBuffer.{Addr, NoAddr}
 import java.nio.charset.Charset
 
 class CommentPickler(pickler: TastyPickler, addrOfTree: tpd.Tree => Addr)(implicit ctx: Context) {
-  private[this] val buf = new TastyBuffer(5000)
+  private val buf = new TastyBuffer(5000)
   pickler.newSection("Comments", buf)
 
   def pickleComment(root: tpd.Tree): Unit = {

--- a/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
@@ -56,7 +56,7 @@ class DottyUnpickler(bytes: Array[Byte], mode: UnpickleMode = UnpickleMode.TopLe
 
   protected def computeRootTrees(implicit ctx: Context): List[Tree] = treeUnpickler.unpickle(mode)
 
-  private[this] var ids: Array[String] = null
+  private var ids: Array[String] = null
 
   override def mightContain(id: String)(implicit ctx: Context): Boolean = {
     if (ids == null)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -11,7 +11,7 @@ import printing.Highlighting._
 
 class TastyPrinter(bytes: Array[Byte])(implicit ctx: Context) {
 
-  private[this] val sb: StringBuilder = new StringBuilder
+  private val sb: StringBuilder = new StringBuilder
 
   val unpickler: TastyUnpickler = new TastyUnpickler(bytes)
   import unpickler.{nameAtRef, unpickle}
@@ -51,7 +51,7 @@ class TastyPrinter(bytes: Array[Byte])(implicit ctx: Context) {
   class TreeSectionUnpickler extends SectionUnpickler[String](TreePickler.sectionName) {
     import TastyFormat._
 
-    private[this] val sb: StringBuilder = new StringBuilder
+    private val sb: StringBuilder = new StringBuilder
 
     def unpickle(reader: TastyReader, tastyName: NameTable): String = {
       import reader._
@@ -127,7 +127,7 @@ class TastyPrinter(bytes: Array[Byte])(implicit ctx: Context) {
 
   class PositionSectionUnpickler extends SectionUnpickler[String]("Positions") {
 
-    private[this] val sb: StringBuilder = new StringBuilder
+    private val sb: StringBuilder = new StringBuilder
 
     def unpickle(reader: TastyReader, tastyName: NameTable): String = {
       sb.append(s" ${reader.endAddr.index - reader.currentAddr.index}")
@@ -144,7 +144,7 @@ class TastyPrinter(bytes: Array[Byte])(implicit ctx: Context) {
 
   class CommentSectionUnpickler extends SectionUnpickler[String]("Comments") {
 
-    private[this] val sb: StringBuilder = new StringBuilder
+    private val sb: StringBuilder = new StringBuilder
 
     def unpickle(reader: TastyReader, tastyName: NameTable): String = {
       sb.append(s" ${reader.endAddr.index - reader.currentAddr.index}")

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyReader.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyReader.scala
@@ -18,7 +18,7 @@ class TastyReader(val bytes: Array[Byte], start: Int, end: Int, val base: Int = 
 
   def this(bytes: Array[Byte]) = this(bytes, 0, bytes.length)
 
-  private[this] var bp: Int = start
+  private var bp: Int = start
 
   def addr(idx: Int): Addr = Addr(idx - base)
   def index(addr: Addr): Int = addr.index + base

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
@@ -12,10 +12,10 @@ class TreeBuffer extends TastyBuffer(50000) {
 
   private final val ItemsOverOffsets = 2
   private val initialOffsetSize = bytes.length / (AddrWidth * ItemsOverOffsets)
-  private[this] var offsets = new Array[Int](initialOffsetSize)
-  private[this] var isRelative = new Array[Boolean](initialOffsetSize)
-  private[this] var delta: Array[Int] = _
-  private[this] var numOffsets = 0
+  private var offsets = new Array[Int](initialOffsetSize)
+  private var isRelative = new Array[Boolean](initialOffsetSize)
+  private var delta: Array[Int] = _
+  private var numOffsets = 0
 
   /** A map from trees to the address at which a tree is pickled. */
   private val treeAddrs = new java.util.IdentityHashMap[Tree, Any] // really: Addr | Null

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -71,15 +71,15 @@ class TreeUnpickler(reader: TastyReader,
   /** The root symbol denotation which are defined by the Tasty file associated with this
    *  TreeUnpickler. Set by `enterTopLevel`.
    */
-  private[this] var roots: Set[SymDenotation] = null
+  private var roots: Set[SymDenotation] = null
 
   /** The root symbols that are defined in this Tasty file. This
    *  is a subset of `roots.map(_.symbol)`.
    */
-  private[this] var seenRoots: Set[Symbol] = Set()
+  private var seenRoots: Set[Symbol] = Set()
 
   /** The root owner tree. See `OwnerTree` class definition. Set by `enterTopLevel`. */
-  private[this] var ownerTree: OwnerTree = _
+  private var ownerTree: OwnerTree = _
 
   private def registerSym(addr: Addr, sym: Symbol) =
     symAtAddr(addr) = sym

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Flags.scala
@@ -32,7 +32,7 @@ object Scala2Flags {
   final val BYNAMEPARAM   = 1 << 16       // parameter is by name
   final val CONTRAVARIANT = 1 << 17       // symbol is a contravariant type variable
   final val ABSOVERRIDE   = 1 << 18       // combination of abstract & override
-  final val LOCAL         = 1 << 19       // symbol is local to current class (i.e. private[this] or protected[this]
+  final val LOCAL         = 1 << 19       // symbol is local to current class (i.e. private[this] or protected
                                           // pre: PRIVATE or PROTECTED are also set
   final val JAVA          = 1 << 20       // symbol was defined by a Java class
   final val STATIC        = 1 << 23       // static field, method or class

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -136,7 +136,7 @@ object Completion {
 
   private class CompletionBuffer(val mode: Mode, val prefix: String, pos: SourcePosition) {
 
-    private[this] val completions = new RenameAwareScope
+    private val completions = new RenameAwareScope
 
     /**
      * Return the list of symbols that should be included in completion results.
@@ -316,7 +316,7 @@ object Completion {
     }
 
     /** Filter for names that should appear when looking for completions. */
-    private[this] object completionsFilter extends NameFilter {
+    private object completionsFilter extends NameFilter {
       def apply(pre: Type, name: Name)(implicit ctx: Context): Boolean =
         !name.isConstructorName && name.toTermName.info.kind == SimpleNameKind
     }
@@ -349,7 +349,7 @@ object Completion {
    *  in the REPL and the IDE.
    */
   private class RenameAwareScope extends Scopes.MutableScope {
-    private[this] val nameToSymbols: mutable.Map[TermName, List[Symbol]] = mutable.Map.empty
+    private val nameToSymbols: mutable.Map[TermName, List[Symbol]] = mutable.Map.empty
 
     /** Enter the symbol `sym` in this scope, recording a potential renaming. */
     def enter[T <: Symbol](sym: T, name: Name)(implicit ctx: Context): T = {

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -35,7 +35,7 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
     ctx
   }
 
-  private[this] var myCtx: Context = myInitCtx
+  private var myCtx: Context = myInitCtx
   def currentCtx: Context = myCtx
 
   private val compiler: Compiler = new InteractiveCompiler
@@ -311,7 +311,7 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
    * this compiler). In those cases, an un-initialized compiler may crash (for instance if
    * late-compilation is needed).
    */
-  private[this] def initialize(): Unit = {
+  private def initialize(): Unit = {
     val run = compiler.newRun(myInitCtx.fresh)
     myCtx = run.runContext
     run.compileUnits(Nil, myCtx)

--- a/compiler/src/dotty/tools/dotc/parsing/CharArrayReader.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/CharArrayReader.scala
@@ -27,7 +27,7 @@ abstract class CharArrayReader { self =>
   /** The start offset of the current line */
   var lineStartOffset: Int = startFrom
 
-  private[this] var lastUnicodeOffset = -1
+  private var lastUnicodeOffset = -1
 
   /** Is last character a unicode escape \\uxxxx? */
   def isUnicodeEscape: Boolean = charOffset == lastUnicodeOffset

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -36,7 +36,7 @@ object JavaParsers {
     val in: JavaScanner = new JavaScanner(source)
 
     /** The simple name of the package of the currently parsed file */
-    private[this] var thisPackageName: TypeName = tpnme.EMPTY
+    private var thisPackageName: TypeName = tpnme.EMPTY
 
     /** This is the general parse entry point.
      *  Overridden by ScriptParser

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -37,7 +37,7 @@ object Parsers {
   case class OpInfo(operand: Tree, operator: Ident, offset: Offset)
 
   class ParensCounters {
-    private[this] var parCounts = new Array[Int](lastParen - firstParen)
+    private var parCounts = new Array[Int](lastParen - firstParen)
 
     def count(tok: Token): Int = parCounts(tok - firstParen)
     def change(tok: Token, delta: Int): Unit = parCounts(tok - firstParen) += delta
@@ -233,7 +233,7 @@ object Parsers {
     /** The offset of the last time when a statement on a new line was definitely
      *  encountered in the current scope or an outer scope.
      */
-    private[this] var lastStatOffset = -1
+    private var lastStatOffset = -1
 
     def setLastStatOffset(): Unit =
       if (mustStartStat && in.isAfterLineEnd)
@@ -397,7 +397,7 @@ object Parsers {
 
     def errorTermTree: Literal = atSpan(in.offset) { Literal(Constant(null)) }
 
-    private[this] var inFunReturnType = false
+    private var inFunReturnType = false
     private def fromWithinReturnType[T](body: => T): T = {
       val saved = inFunReturnType
       try {
@@ -410,7 +410,7 @@ object Parsers {
     /** A flag indicating we are parsing in the annotations of a primary
      *  class constructor
      */
-    private[this] var inClassConstrAnnots = false
+    private var inClassConstrAnnots = false
     private def fromWithinClassConstr[T](body: => T): T = {
       val saved = inClassConstrAnnots
       inClassConstrAnnots = true
@@ -418,7 +418,7 @@ object Parsers {
       finally inClassConstrAnnots = saved
     }
 
-    private[this] var inEnum = false
+    private var inEnum = false
     private def withinEnum[T](body: => T): T = {
       val saved = inEnum
       inEnum = true
@@ -426,7 +426,7 @@ object Parsers {
       finally inEnum = saved
     }
 
-    private[this] var staged = StageKind.None
+    private var staged = StageKind.None
     def withinStaged[T](kind: StageKind)(op: => T): T = {
       val saved = staged
       staged |= kind
@@ -538,7 +538,7 @@ object Parsers {
      *  NoSourcePosition if there were no XML literals.
      */
     def firstXmlPos: SourcePosition = myFirstXmlPos
-    private[this] var myFirstXmlPos: SourcePosition = NoSourcePosition
+    private var myFirstXmlPos: SourcePosition = NoSourcePosition
 
     object symbXMLBuilder extends xml.SymbolicXMLBuilder(this, true) // DEBUG choices
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2642,7 +2642,11 @@ object Parsers {
         if (mods.is(Local) || mods.hasPrivateWithin)
           syntaxError(DuplicatePrivateProtectedQualifier())
         inBrackets {
-          if (in.token == THIS) { in.nextToken(); mods | Local }
+          if in.token == THIS then
+            if ctx.settings.strict.value then
+              deprecationWarning("The [this] qualifier is deprecated in Scala 3.1; it should be dropped.")
+            in.nextToken()
+            mods | Local
           else mods.withPrivateWithin(ident().toTypeName)
         }
       }

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -171,15 +171,15 @@ object Scanners {
     }
 
     /** All doc comments kept by their end position in a `Map` */
-    private[this] var docstringMap: SortedMap[Int, Comment] = SortedMap.empty
+    private var docstringMap: SortedMap[Int, Comment] = SortedMap.empty
 
     /* A Buffer for comment positions */
-    private[this] val commentPosBuf = new mutable.ListBuffer[Span]
+    private val commentPosBuf = new mutable.ListBuffer[Span]
 
     /** Return a list of all the comment positions */
     def commentSpans: List[Span] = commentPosBuf.toList
 
-    private[this] def addComment(comment: Comment): Unit = {
+    private def addComment(comment: Comment): Unit = {
       val lookahead = lookaheadReader()
       def nextPos: Int = (lookahead.getc(): @switch) match {
         case ' ' | '\t' => nextPos
@@ -196,7 +196,7 @@ object Scanners {
     def getDocComment(pos: Int): Option[Comment] = docstringMap.get(pos)
 
     /** A buffer for comments */
-    private[this] val commentBuf = new mutable.StringBuilder
+    private val commentBuf = new mutable.StringBuilder
 
     private def handleMigration(keyword: Token): Token =
       if (!isScala2Mode) keyword

--- a/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
@@ -87,7 +87,7 @@ object MarkupParsers {
 
     var xEmbeddedBlock: Boolean = false
 
-    private[this] var debugLastStartElement = List.empty[(Int, String)]
+    private var debugLastStartElement = List.empty[(Int, String)]
     private def debugLastPos = debugLastStartElement.head._1
     private def debugLastElem = debugLastStartElement.head._2
 

--- a/compiler/src/dotty/tools/dotc/printing/Highlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Highlighting.scala
@@ -31,7 +31,7 @@ object Highlighting {
   }
 
   case class HighlightBuffer(hl: Highlight)(implicit ctx: Context) {
-    private[this] val buffer = new mutable.ListBuffer[String]
+    private val buffer = new mutable.ListBuffer[String]
 
     buffer += hl.show
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -15,8 +15,8 @@ import scala.util.control.NonFatal
 import scala.annotation.switch
 
 class PlainPrinter(_ctx: Context) extends Printer {
-  protected[this] implicit def ctx: Context = _ctx.addMode(Mode.Printing)
-  protected[this] def printDebug = ctx.settings.YprintDebug.value
+  protected implicit def ctx: Context = _ctx.addMode(Mode.Printing)
+  protected def printDebug = ctx.settings.YprintDebug.value
 
   private[this] var openRecs: List[RecType] = Nil
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -18,7 +18,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected implicit def ctx: Context = _ctx.addMode(Mode.Printing)
   protected def printDebug = ctx.settings.YprintDebug.value
 
-  private[this] var openRecs: List[RecType] = Nil
+  private var openRecs: List[RecType] = Nil
 
   protected def maxToTextRecursions: Int = 100
 
@@ -124,7 +124,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   /** Direct references to these symbols are printed without their prefix for convenience.
    *  They are either aliased in scala.Predef or in the scala package object.
    */
-  private[this] lazy val printWithoutPrefix: Set[Symbol] =
+  private lazy val printWithoutPrefix: Set[Symbol] =
     (defn.ScalaPredefModule.termRef.typeAliasMembers
       ++ defn.ScalaPackageObject.termRef.typeAliasMembers).map(_.info.classSymbol).toSet
 
@@ -549,7 +549,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case _ => "{...}"
     s"import $exprStr.$selectorStr"
 
-  private[this] var maxSummarized = Int.MaxValue
+  private var maxSummarized = Int.MaxValue
 
   def summarized[T](depth: Int)(op: => T): T = {
     val saved = maxSummarized

--- a/compiler/src/dotty/tools/dotc/printing/Printer.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Printer.scala
@@ -16,7 +16,7 @@ import scala.annotation.internal.sharable
  */
 abstract class Printer {
 
-  private[this] var prec: Precedence = GlobalPrec
+  private var prec: Precedence = GlobalPrec
 
   /** The current precedence level.
    *  When pretty-printing arguments of operator `op`, `currentPrecedence` must equal `op`'s precedence level,

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -30,10 +30,10 @@ import dotty.tools.dotc.ast.untpd.{MemberDef, Modifiers, PackageDef, RefTree, Te
 class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
 
   /** A stack of enclosing DefDef, TypeDef, or ClassDef, or ModuleDefs nodes */
-  private[this] var enclosingDef: untpd.Tree = untpd.EmptyTree
-  private[this] var myCtx: Context = super.ctx
-  private[this] var printPos = ctx.settings.YprintPos.value
-  private[this] val printLines = ctx.settings.printLines.value
+  private var enclosingDef: untpd.Tree = untpd.EmptyTree
+  private var myCtx: Context = super.ctx
+  private var printPos = ctx.settings.YprintPos.value
+  private val printLines = ctx.settings.printLines.value
 
   override protected implicit def ctx: Context = myCtx
 

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -35,7 +35,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   private[this] var printPos = ctx.settings.YprintPos.value
   private[this] val printLines = ctx.settings.printLines.value
 
-  override protected[this] implicit def ctx: Context = myCtx
+  override protected implicit def ctx: Context = myCtx
 
   def withEnclosingDef(enclDef: Tree[? >: Untyped])(op: => Text): Text = {
     val savedCtx = myCtx

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -204,7 +204,7 @@ abstract class Reporter extends interfaces.ReporterResult {
    *  debugging information (like printing the classpath) is not rendered
    *  invisible due to the max message length.
    */
-  private[this] var _truncationOK: Boolean = true
+  private var _truncationOK: Boolean = true
   def truncationOK: Boolean = _truncationOK
   def withoutTruncating[T](body: => T): T = {
     val saved = _truncationOK
@@ -213,7 +213,7 @@ abstract class Reporter extends interfaces.ReporterResult {
     finally _truncationOK = saved
   }
 
-  private[this] var incompleteHandler: ErrorHandler = defaultIncompleteHandler
+  private var incompleteHandler: ErrorHandler = defaultIncompleteHandler
 
   def withIncompleteHandler[T](handler: ErrorHandler)(op: => T): T = {
     val saved = incompleteHandler
@@ -222,8 +222,8 @@ abstract class Reporter extends interfaces.ReporterResult {
     finally incompleteHandler = saved
   }
 
-  private[this] var _errorCount = 0
-  private[this] var _warningCount = 0
+  private var _errorCount = 0
+  private var _warningCount = 0
 
   /** The number of errors reported by this reporter (ignoring outer reporters) */
   def errorCount: Int = _errorCount
@@ -237,7 +237,7 @@ abstract class Reporter extends interfaces.ReporterResult {
   /** Have warnings been reported by this reporter (ignoring outer reporters)? */
   def hasWarnings: Boolean = warningCount > 0
 
-  private[this] var errors: List[Error] = Nil
+  private var errors: List[Error] = Nil
 
   /** All errors reported by this reporter (ignoring outer reporters) */
   def allErrors: List[Error] = errors
@@ -258,7 +258,7 @@ abstract class Reporter extends interfaces.ReporterResult {
     errorCount > initial
   }
 
-  private[this] var reportedFeaturesUseSites = Set[Symbol]()
+  private var reportedFeaturesUseSites = Set[Symbol]()
 
   def isReportedFeatureUseSite(featureTrait: Symbol): Boolean =
     featureTrait.ne(NoSymbol) && reportedFeaturesUseSites.contains(featureTrait)

--- a/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
@@ -20,7 +20,7 @@ import diagnostic.messages._
   */
 class StoreReporter(outer: Reporter) extends Reporter {
 
-  protected[this] var infos: mutable.ListBuffer[MessageContainer] = null
+  protected var infos: mutable.ListBuffer[MessageContainer] = null
 
   def doReport(m: MessageContainer)(implicit ctx: Context): Unit = {
     typr.println(s">>>> StoredError: ${m.message}") // !!! DEBUG

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/MessageContainer.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/MessageContainer.scala
@@ -29,9 +29,9 @@ class MessageContainer(
   val level: Int
 ) extends Exception with interfaces.Diagnostic {
   import MessageContainer._
-  private[this] var myMsg: String = null
-  private[this] var myIsNonSensical: Boolean = false
-  private[this] var myContained: Message = null
+  private var myMsg: String = null
+  private var myIsNonSensical: Boolean = false
+  private var myContained: Message = null
 
   override def position: Optional[interfaces.SourcePosition] =
     if (pos.exists && pos.source.exists) Optional.of(pos) else Optional.empty()

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -131,19 +131,19 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
   /** This cache is necessary for correctness, see the comment about inherited
    *  members in `apiClassStructure`
    */
-  private[this] val classLikeCache = new mutable.HashMap[ClassSymbol, api.ClassLikeDef]
+  private val classLikeCache = new mutable.HashMap[ClassSymbol, api.ClassLikeDef]
   /** This cache is optional, it avoids recomputing representations */
-  private[this] val typeCache = new mutable.HashMap[Type, api.Type]
+  private val typeCache = new mutable.HashMap[Type, api.Type]
   /** This cache is necessary to avoid unstable name hashing when `typeCache` is present,
    *  see the comment in the `RefinedType` case in `computeType`
    *  The cache key is (api of RefinedType#parent, api of RefinedType#refinedInfo).
     */
-  private[this] val refinedTypeCache = new mutable.HashMap[(api.Type, api.Definition), api.Structure]
+  private val refinedTypeCache = new mutable.HashMap[(api.Type, api.Definition), api.Structure]
 
-  private[this] val allNonLocalClassesInSrc = new mutable.HashSet[xsbti.api.ClassLike]
-  private[this] val _mainClasses = new mutable.HashSet[String]
+  private val allNonLocalClassesInSrc = new mutable.HashSet[xsbti.api.ClassLike]
+  private val _mainClasses = new mutable.HashSet[String]
 
-  private[this] object Constants {
+  private object Constants {
     val emptyStringArray = Array[String]()
     val local            = api.ThisQualifier.create()
     val public           = api.Public.create()

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -201,8 +201,8 @@ private final class UsedNamesInClass {
 private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeTraverser =>
   import tpd._
 
-  private[this] val _usedNames = new mutable.HashMap[Symbol, UsedNamesInClass]
-  private[this] val _dependencies = new mutable.HashSet[ClassDependency]
+  private val _usedNames = new mutable.HashMap[Symbol, UsedNamesInClass]
+  private val _dependencies = new mutable.HashSet[ClassDependency]
 
   /** The names used in this class, this does not include names which are only
    *  defined and not referenced.
@@ -216,7 +216,7 @@ private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeT
   /** Top level import dependencies are registered as coming from a first top level
    *  class/trait/object declared in the compilation unit. If none exists, issue warning.
    */
-  private[this] var _responsibleForImports: Symbol = _
+  private var _responsibleForImports: Symbol = _
   private def responsibleForImports(implicit ctx: Context) = {
     def firstClassOrModule(tree: Tree) = {
       val acc = new TreeAccumulator[Symbol] {
@@ -243,8 +243,8 @@ private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeT
     _responsibleForImports
   }
 
-  private[this] var lastOwner: Symbol = _
-  private[this] var lastDepSource: Symbol = _
+  private var lastOwner: Symbol = _
+  private var lastDepSource: Symbol = _
 
   /**
    * Resolves dependency source (that is, the closest non-local enclosing

--- a/compiler/src/dotty/tools/dotc/sbt/ThunkHolder.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ThunkHolder.scala
@@ -10,7 +10,7 @@ import xsbti.api
  *  that may be evaluated once.
  */
 private[sbt] trait ThunkHolder {
-  private[this] val thunks = new ListBuffer[api.Lazy[?]]
+  private val thunks = new ListBuffer[api.Lazy[?]]
 
   /** Force all unevaluated thunks to prevent space leaks. */
   @tailrec protected final def forceThunks(): Unit = if (!thunks.isEmpty) {

--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -36,7 +36,7 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(implicit ctx: Cont
 
   //val site = root.thisType
 
-  private[this] var toBeRemoved = immutable.Set[Symbol]()
+  private var toBeRemoved = immutable.Set[Symbol]()
   private val bridges = mutable.ListBuffer[Tree]()
   private val bridgesScope = newScope
   private val bridgeTarget = newMutableSymbolMap[Symbol]

--- a/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
@@ -23,7 +23,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
   /** the following two members override abstract members in Transform */
   val phaseName: String = "capturedVars"
 
-  private var Captured: Store.Location[collection.Set[Symbol]] = _
+  private[this] var Captured: Store.Location[collection.Set[Symbol]] = _
   private def captured(implicit ctx: Context) = ctx.store(Captured)
 
   override def initContext(ctx: FreshContext): Unit =
@@ -82,7 +82,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
     */
   def refClass(cls: Symbol, isVolatile: Boolean)(implicit ctx: Context): Symbol = {
     val refMap = if (isVolatile) refInfo.volatileRefClass else refInfo.refClass
-    if (cls.isClass) 
+    if (cls.isClass)
       refMap.getOrElse(cls, refMap(defn.ObjectClass))
     else refMap(defn.ObjectClass)
   }

--- a/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
@@ -23,7 +23,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
   /** the following two members override abstract members in Transform */
   val phaseName: String = "capturedVars"
 
-  private[this] var Captured: Store.Location[collection.Set[Symbol]] = _
+  private var Captured: Store.Location[collection.Set[Symbol]] = _
   private def captured(implicit ctx: Context) = ctx.store(Captured)
 
   override def initContext(ctx: FreshContext): Unit =
@@ -44,7 +44,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
       refClassKeys.flatMap(k => Set(refClass(k), volatileRefClass(k)))
   }
 
-  private[this] var myRefInfo: RefInfo = null
+  private var myRefInfo: RefInfo = null
   private def refInfo(implicit ctx: Context) = {
     if (myRefInfo == null) myRefInfo = new RefInfo()
     myRefInfo

--- a/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
@@ -32,9 +32,9 @@ class CheckReentrant extends MiniPhase {
 
   override def phaseName: String = "checkReentrant"
 
-  private[this] var shared: Set[Symbol] = Set()
-  private[this] var seen: Set[ClassSymbol] = Set()
-  private[this] var indent: Int = 0
+  private var shared: Set[Symbol] = Set()
+  private var seen: Set[ClassSymbol] = Set()
+  private var indent: Int = 0
 
   private val sharableAnnot = new CtxLazy(
     summon[Context].requiredClass("scala.annotation.internal.sharable"))

--- a/compiler/src/dotty/tools/dotc/transform/CollectNullableFields.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CollectNullableFields.scala
@@ -46,12 +46,12 @@ class CollectNullableFields extends MiniPhase {
   /** Running after `ElimByName` to see by names as nullable types. */
   override def runsAfter: Set[String] = Set(ElimByName.name)
 
-  private[this] sealed trait FieldInfo
-  private[this] case object NotNullable extends FieldInfo
-  private[this] case class Nullable(by: Symbol) extends FieldInfo
+  private sealed trait FieldInfo
+  private case object NotNullable extends FieldInfo
+  private case class Nullable(by: Symbol) extends FieldInfo
 
   /** Whether or not a field is nullable */
-  private[this] var nullability: IdentityHashMap[Symbol, FieldInfo] = _
+  private var nullability: IdentityHashMap[Symbol, FieldInfo] = _
 
   override def prepareForUnit(tree: Tree)(implicit ctx: Context): Context = {
     if (nullability == null) nullability = new IdentityHashMap

--- a/compiler/src/dotty/tools/dotc/transform/CtxLazy.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CtxLazy.scala
@@ -12,8 +12,8 @@ import core.Contexts.Context
  *  the expression intiializing the lazy val depends only on the root context, but not any changes afterwards.
  */
 class CtxLazy[T](expr: (given Context) => T) {
-  private[this] var myValue: T = _
-  private[this] var forced = false
+  private var myValue: T = _
+  private var forced = false
   def apply()(implicit ctx: Context): T = {
     if (!forced) {
       myValue = expr(given ctx)

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -93,7 +93,7 @@ class Erasure extends Phase with DenotTransformer {
       ref.derivedSingleDenotation(ref.symbol, transformInfo(ref.symbol, ref.symbol.info))
   }
 
-  private[this] val eraser = new Erasure.Typer(this)
+  private val eraser = new Erasure.Typer(this)
 
   def run(implicit ctx: Context): Unit = {
     val unit = ctx.compilationUnit

--- a/compiler/src/dotty/tools/dotc/transform/FunctionalInterfaces.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FunctionalInterfaces.scala
@@ -23,8 +23,8 @@ class FunctionalInterfaces extends MiniPhase {
 
   def phaseName: String = FunctionalInterfaces.name
 
-  private[this] val functionName = "JFunction".toTermName
-  private[this] val functionPackage = "dotty.runtime.function.".toTermName
+  private val functionName = "JFunction".toTermName
+  private val functionPackage = "dotty.runtime.function.".toTermName
 
   override def transformClosure(tree: Closure)(implicit ctx: Context): Tree = {
     val cls = tree.tpe.widen.classSymbol.asClass

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -9,13 +9,14 @@ import core.Flags._
 import core.Names.{DerivedName, Name, SimpleName, TypeName}
 import core.Symbols._
 import core.TypeApplications.TypeParamInfo
-import core.TypeErasure.erasure
+import core.TypeErasure.{erasure, fullErasure}
 import core.Types._
 import core.classfile.ClassfileConstants
 import ast.Trees._
 import SymUtils._
 import TypeUtils._
 import java.lang.StringBuilder
+import core.Decorators._
 
 import scala.annotation.tailrec
 
@@ -33,7 +34,12 @@ object GenericSignatures {
    */
   def javaSig(sym0: Symbol, info: Type)(implicit ctx: Context): Option[String] =
     // Avoid generating a signature for local symbols.
-    if (sym0.isLocal) None
+    // Also suppress signatures for private symbols whose types erase in the end to primitive
+    // value types. This is done to fix #7416. Since I do not know GenericSignatures well,
+    // I did a minimal fix that lets #7416 pass. Maybe it can be generalized
+    if sym0.isLocal
+       || sym0.is(Private) && fullErasure(info).isPrimitiveValueType
+    then None
     else javaSig0(sym0, info)(ctx.withPhase(ctx.erasurePhase))
 
   @noinline

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -9,14 +9,13 @@ import core.Flags._
 import core.Names.{DerivedName, Name, SimpleName, TypeName}
 import core.Symbols._
 import core.TypeApplications.TypeParamInfo
-import core.TypeErasure.{erasure, fullErasure}
+import core.TypeErasure.erasure
 import core.Types._
 import core.classfile.ClassfileConstants
 import ast.Trees._
 import SymUtils._
 import TypeUtils._
 import java.lang.StringBuilder
-import core.Decorators._
 
 import scala.annotation.tailrec
 
@@ -34,12 +33,7 @@ object GenericSignatures {
    */
   def javaSig(sym0: Symbol, info: Type)(implicit ctx: Context): Option[String] =
     // Avoid generating a signature for local symbols.
-    // Also suppress signatures for private symbols whose types erase in the end to primitive
-    // value types. This is done to fix #7416. Since I do not know GenericSignatures well,
-    // I did a minimal fix that lets #7416 pass. Maybe it can be generalized
-    if sym0.isLocal
-       || sym0.is(Private) && fullErasure(info).isPrimitiveValueType
-    then None
+    if (sym0.isLocal) None
     else javaSig0(sym0, info)(ctx.withPhase(ctx.erasurePhase))
 
   @noinline

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -59,10 +59,10 @@ object LambdaLift {
     val liftedDefs: mutable.HashMap[Symbol, mutable.ListBuffer[Tree]] = new HashMap
 
     /** A flag to indicate whether new free variables have been found */
-    private[this] var changedFreeVars: Boolean = _
+    private var changedFreeVars: Boolean = _
 
     /** A flag to indicate whether lifted owners have changed */
-    private[this] var changedLiftedOwner: Boolean = _
+    private var changedLiftedOwner: Boolean = _
 
     private val ord: Ordering[Symbol] = Ordering.by(_.id)
     private def newSymSet = TreeSet.empty[Symbol](ord)
@@ -324,7 +324,7 @@ object LambdaLift {
     private def liftLocals()(implicit ctx: Context): Unit = {
       for ((local, lOwner) <- liftedOwner) {
         val (newOwner, maybeStatic) =
-          if (lOwner is Package) { 
+          if (lOwner is Package) {
             val encClass = local.enclosingClass
             val topClass = local.topLevelClass
             val preferEncClass =

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -26,7 +26,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
   /** this map contains mutable state of transformation: OffsetDefs to be appended to companion object definitions,
     * and number of bits currently used */
   class OffsetInfo(var defs: List[Tree], var ord:Int)
-  private[this] val appendOffsetDefs = mutable.Map.empty[Symbol, OffsetInfo]
+  private val appendOffsetDefs = mutable.Map.empty[Symbol, OffsetInfo]
 
   override def phaseName: String = LazyVals.name
 
@@ -42,7 +42,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
   val containerFlagsMask: FlagSet = Method | Lazy | Accessor | Module
 
   /** A map of lazy values to the fields they should null after initialization. */
-  private[this] var lazyValNullables: IdentityHashMap[Symbol, mutable.ListBuffer[Symbol]] = _
+  private var lazyValNullables: IdentityHashMap[Symbol, mutable.ListBuffer[Symbol]] = _
   private def nullableFor(sym: Symbol)(implicit ctx: Context) = {
     // optimisation: value only used once, we can remove the value from the map
     val nullables = lazyValNullables.remove(sym)

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -82,10 +82,10 @@ object OverridingPairs {
 
     /** The current entry candidate for overriding
      */
-    private[this] var curEntry = decls.lastEntry
+    private var curEntry = decls.lastEntry
 
     /** The current entry candidate for overridden */
-    private[this] var nextEntry = curEntry
+    private var nextEntry = curEntry
 
     /** The current candidate symbol for overriding */
     var overriding: Symbol = _

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -129,7 +129,7 @@ object PatternMatcher {
     // ------- Plan and test types ------------------------
 
     /** Counter to display plans nicely, for debugging */
-    private[this] var nxId = 0
+    private var nxId = 0
 
     /** The different kinds of plans */
     sealed abstract class Plan { val id: Int = nxId; nxId += 1 }

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -243,10 +243,12 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
         case tree: TypeDef =>
           val sym = tree.symbol
           if (sym.isClass)
+            VarianceChecker.check(tree)
             // Add SourceFile annotation to top-level classes
-            if (sym.owner.is(Package) &&
-              ctx.compilationUnit.source.exists &&
-              sym != defn.SourceFileAnnot)
+            if sym.owner.is(Package)
+               && ctx.compilationUnit.source.exists
+               && sym != defn.SourceFileAnnot
+            then
               sym.addAnnotation(Annotation.makeSourceFile(ctx.compilationUnit.source.file.path))
           processMemberDef(super.transform(tree))
         case tree: New if isCheckable(tree) =>

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -86,9 +86,9 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
 
   class PostTyperTransformer extends Transformer {
 
-    private[this] var inJavaAnnot: Boolean = false
+    private var inJavaAnnot: Boolean = false
 
-    private[this] var noCheckNews: Set[New] = Set()
+    private var noCheckNews: Set[New] = Set()
 
     def withNoCheckNews[T](ts: List[New])(op: => T): T = {
       val saved = noCheckNews

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -46,7 +46,7 @@ class SuperAccessors(thisPhase: DenotTransformer) {
     *  The `invalidEnclClass` field, if different from NoSymbol,
     *  contains the symbol that is not a valid owner.
     */
-  private[this] var invalidEnclClass: Symbol = NoSymbol
+  private var invalidEnclClass: Symbol = NoSymbol
 
   private def withInvalidCurrentClass[A](trans: => A)(implicit ctx: Context): A = {
     val saved = invalidEnclClass

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -53,10 +53,10 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
   import SyntheticMembers._
   import ast.tpd._
 
-  private[this] var myValueSymbols: List[Symbol] = Nil
-  private[this] var myCaseSymbols: List[Symbol] = Nil
-  private[this] var myCaseModuleSymbols: List[Symbol] = Nil
-  private[this] var myEnumCaseSymbols: List[Symbol] = Nil
+  private var myValueSymbols: List[Symbol] = Nil
+  private var myCaseSymbols: List[Symbol] = Nil
+  private var myCaseModuleSymbols: List[Symbol] = Nil
+  private var myEnumCaseSymbols: List[Symbol] = Nil
 
   private def initSymbols(implicit ctx: Context) =
     if (myValueSymbols.isEmpty) {

--- a/compiler/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TailRec.scala
@@ -196,7 +196,7 @@ class TailRec extends MiniPhase {
     var failureReported: Boolean = false
 
     /** The `tailLabelN` label symbol, used to encode a `continue` from the infinite `while` loop. */
-    private[this] var myContinueLabel: Symbol = _
+    private var myContinueLabel: Symbol = _
     def continueLabel(implicit ctx: Context): Symbol = {
       if (myContinueLabel == null)
         myContinueLabel = ctx.newSymbol(method, TailLabelName.fresh(), Label, defn.UnitType)
@@ -235,7 +235,7 @@ class TailRec extends MiniPhase {
     /** Symbols of Labeled blocks that are in tail position. */
     private val tailPositionLabeledSyms = new mutable.HashSet[Symbol]()
 
-    private[this] var inTailPosition = true
+    private var inTailPosition = true
 
     /** Rewrite this tree to contain no tail recursive calls */
     def transform(tree: Tree, tailPosition: Boolean)(implicit ctx: Context): Tree =

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -129,9 +129,9 @@ class TreeChecker extends Phase with SymTransformer {
 
   class Checker(phasesToCheck: Seq[Phase]) extends ReTyper with Checking {
 
-    private[this] val nowDefinedSyms = new mutable.HashSet[Symbol]
-    private[this] val patBoundSyms = new mutable.HashSet[Symbol]
-    private[this] val everDefinedSyms = newMutableSymbolMap[untpd.Tree]
+    private val nowDefinedSyms = new mutable.HashSet[Symbol]
+    private val patBoundSyms = new mutable.HashSet[Symbol]
+    private val everDefinedSyms = newMutableSymbolMap[untpd.Tree]
 
     // don't check value classes after typer, as the constraint about constructors doesn't hold after transform
     override def checkDerivedValueClass(clazz: Symbol, stats: List[Tree])(implicit ctx: Context): Unit = ()

--- a/compiler/src/dotty/tools/dotc/transform/TreeMapWithStages.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeMapWithStages.scala
@@ -36,10 +36,10 @@ abstract class TreeMapWithStages(@constructorOnly ictx: Context) extends TreeMap
   import TreeMapWithStages._
 
   /** A map from locally defined symbols to their definition quotation level */
-  private[this] val levelOfMap: mutable.HashMap[Symbol, Int] = ictx.property(LevelOfKey).get
+  private val levelOfMap: mutable.HashMap[Symbol, Int] = ictx.property(LevelOfKey).get
 
   /** A stack of entered symbols, to be unwound after scope exit */
-  private[this] var enteredSyms: List[Symbol] = Nil
+  private var enteredSyms: List[Symbol] = Nil
 
   /** The quotation level of the definition of the locally defined symbol */
   protected def levelOf(sym: Symbol): Option[Int] = levelOfMap.get(sym)

--- a/compiler/src/dotty/tools/dotc/transform/YCheckPositions.scala
+++ b/compiler/src/dotty/tools/dotc/transform/YCheckPositions.scala
@@ -22,7 +22,7 @@ class YCheckPositions extends Phases.Phase {
     tree match {
       case PackageDef(pid, _) if tree.symbol.owner == defn.RootClass =>
         new TreeTraverser {
-          private[this] var sources: List[SourceFile] = ctx.source :: Nil
+          private var sources: List[SourceFile] = ctx.source :: Nil
           def traverse(tree: tpd.Tree)(implicit ctx: Context): Unit = {
 
             // Check current context is correct

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -307,7 +307,7 @@ trait Applications extends Compatibility {
     }
 
     /** A flag signalling that the typechecking the application was so far successful */
-    private[this] var _ok = true
+    private var _ok = true
 
     def ok: Boolean = _ok
     def ok_=(x: Boolean): Unit = _ok = x
@@ -686,9 +686,9 @@ trait Applications extends Compatibility {
   extends Application(methRef, fun.tpe, args, resultType) {
     type TypedArg = Tree
     def isVarArg(arg: Trees.Tree[T]): Boolean = untpd.isWildcardStarArg(arg)
-    private[this] var typedArgBuf = new mutable.ListBuffer[Tree]
-    private[this] var liftedDefs: mutable.ListBuffer[Tree] = null
-    private[this] var myNormalizedFun: Tree = fun
+    private var typedArgBuf = new mutable.ListBuffer[Tree]
+    private var liftedDefs: mutable.ListBuffer[Tree] = null
+    private var myNormalizedFun: Tree = fun
     init()
 
     def addArg(arg: Tree, formal: Type): Unit =

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -165,10 +165,10 @@ object Checking {
     private val locked = mutable.Set[TypeRef]()
 
     /** Are cycles allowed within nested refinedInfos of currently checked type? */
-    private[this] var nestedCycleOK = false
+    private var nestedCycleOK = false
 
     /** Are cycles allowed within currently checked type? */
-    private[this] var cycleOK = false
+    private var cycleOK = false
 
     /** A diagnostic output string that indicates the position of the last
      *  part of a type bounds checked by checkInfo. Possible choices:

--- a/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -24,12 +24,12 @@ class FrontEnd extends Phase {
   override def allowsImplicitSearch: Boolean = true
 
   /** The contexts for compilation units that are parsed but not yet entered */
-  private[this] var remaining: List[Context] = Nil
+  private var remaining: List[Context] = Nil
 
   /** The position of the first XML literal encountered while parsing,
    *  NoSourcePosition if there were no XML literals.
    */
-  private[this] var firstXmlPos: SourcePosition = NoSourcePosition
+  private var firstXmlPos: SourcePosition = NoSourcePosition
 
   /** Does a source file ending with `<name>.scala` belong to a compilation unit
    *  that is parsed but not yet entered?

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -80,7 +80,7 @@ object Implicits {
     /** The implicit references */
     def refs: List[ImplicitRef]
 
-    private[this] var SingletonClass: ClassSymbol = null
+    private var SingletonClass: ClassSymbol = null
 
     /** Widen type so that it is neither a singleton type nor a type that inherits from scala.Singleton. */
     private def widenSingleton(tp: Type)(implicit ctx: Context): Type = {
@@ -1954,7 +1954,7 @@ final class SearchRoot extends SearchHistory {
 
 /** A set of term references where equality is =:= */
 final class TermRefSet(implicit ctx: Context) {
-  private[this] val elems = new java.util.LinkedHashMap[TermSymbol, List[Type]]
+  private val elems = new java.util.LinkedHashMap[TermSymbol, List[Type]]
 
   def += (ref: TermRef): Unit = {
     val pre = ref.prefix

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -57,7 +57,7 @@ class ImportInfo(symf: (given Context) => Symbol,
     }
     mySym
   }
-  private[this] var mySym: Symbol = _
+  private var mySym: Symbol = _
 
   /** The (TermRef) type of the qualifier of the import clause */
   def site(implicit ctx: Context): Type = sym.info match {
@@ -80,13 +80,13 @@ class ImportInfo(symf: (given Context) => Symbol,
   /** Does the import clause have at least one `given` selector? */
   def isGivenImport: Boolean = { ensureInitialized(); myGivenImport }
 
-  private[this] var myExcluded: Set[TermName] = null
-  private[this] var myForwardMapping: SimpleIdentityMap[TermName, TermName] = null
-  private[this] var myReverseMapping: SimpleIdentityMap[TermName, TermName] = null
-  private[this] var myWildcardImport: Boolean = false
-  private[this] var myGivenImport: Boolean = false
-  private[this] var myWildcardBound: Type = NoType
-  private[this] var myGivenBound: Type = NoType
+  private var myExcluded: Set[TermName] = null
+  private var myForwardMapping: SimpleIdentityMap[TermName, TermName] = null
+  private var myReverseMapping: SimpleIdentityMap[TermName, TermName] = null
+  private var myWildcardImport: Boolean = false
+  private var myGivenImport: Boolean = false
+  private var myWildcardBound: Type = NoType
+  private var myGivenBound: Type = NoType
 
   /** Compute info relating to the selector list */
   private def ensureInitialized(): Unit = if myExcluded == null then
@@ -169,7 +169,7 @@ class ImportInfo(symf: (given Context) => Symbol,
       assert(myUnimported != null)
     myUnimported
 
-  private[this] var myUnimported: Symbol = _
+  private var myUnimported: Symbol = _
 
   /** Does this import clause or a preceding import clause import `owner.feature`? */
   def featureImported(feature: TermName, owner: Symbol)(implicit ctx: Context): Boolean =
@@ -189,8 +189,8 @@ class ImportInfo(symf: (given Context) => Symbol,
     }
     lastResults(feature)
 
-  private[this] var lastOwner: Symbol = null
-  private[this] var lastResults: SimpleIdentityMap[TermName, java.lang.Boolean] = SimpleIdentityMap.Empty
+  private var lastOwner: Symbol = null
+  private var lastResults: SimpleIdentityMap[TermName, java.lang.Boolean] = SimpleIdentityMap.Empty
 
   def toText(printer: Printer): Text = printer.toText(this)
 }

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -99,7 +99,7 @@ object Inferencing {
       inst
     }
 
-    private[this] var toMaximize: Boolean = false
+    private var toMaximize: Boolean = false
 
     def apply(x: Boolean, tp: Type): Boolean = tp.dealias match {
       case _: WildcardType | _: ProtoType =>

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -1273,7 +1273,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
    */
   private def macroDependencies(tree: Tree)(implicit ctx: Context) =
     new TreeAccumulator[Set[Symbol]] {
-      private[this] var level = -1
+      private var level = -1
       override def apply(syms: Set[Symbol], tree: tpd.Tree)(implicit ctx: Context): Set[Symbol] =
         if (level != -1) foldOver(syms, tree)
         else tree match {

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -237,7 +237,7 @@ class Namer { typer: Typer =>
   val scope: MutableScope = newScope
 
   /** We are entering symbols coming from a SourceLoader */
-  private[this] var lateCompile = false
+  private var lateCompile = false
 
   /** The symbol of the given expanded tree. */
   def symbolOfTree(tree: Tree)(implicit ctx: Context): Symbol = {
@@ -898,8 +898,8 @@ class Namer { typer: Typer =>
   }
 
   class TypeDefCompleter(original: TypeDef)(ictx: Context) extends Completer(original)(ictx) with TypeParamsCompleter {
-    private[this] var myTypeParams: List[TypeSymbol] = null
-    private[this] var nestedCtx: Context = null
+    private var myTypeParams: List[TypeSymbol] = null
+    private var nestedCtx: Context = null
     assert(!original.isClassDef)
 
     override def completerTypeParams(sym: Symbol)(implicit ctx: Context): List[TypeSymbol] = {
@@ -934,9 +934,9 @@ class Namer { typer: Typer =>
 
     protected implicit val ctx: Context = localContext(cls).setMode(ictx.mode &~ Mode.InSuperCall)
 
-    private[this] var localCtx: Context = _
+    private var localCtx: Context = _
     /** info to be used temporarily while completing the class, to avoid cyclic references. */
-    private[this] var tempInfo: TempClassInfo = _
+    private var tempInfo: TempClassInfo = _
 
     val TypeDef(name, impl @ Template(constr, _, self, _)) = original
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -288,7 +288,7 @@ class Namer { typer: Typer =>
           case _ => (flags.isTermFlags, flags.toTermFlags, "value")
         }
         def canBeLocal = tree match
-          case tree: ValOrDefDef => SymDenotations.canBeLocal(tree.name, flags)
+          case tree: MemberDef => SymDenotations.canBeLocal(tree.name, flags)
           case _ => false
         if !ok then
           ctx.error(i"modifier(s) `${flags.flagsString}` incompatible with $kind definition", tree.sourcePos)

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -342,7 +342,7 @@ trait QuotesAndSplices {
     val typeBindingsTuple = tpd.tupleTypeTree(typeBindings.values.toList)
 
     val replaceBindingsInTree = new TreeMap {
-      private[this] var bindMap = Map.empty[Symbol, Symbol]
+      private var bindMap = Map.empty[Symbol, Symbol]
       override def transform(tree: tpd.Tree)(implicit ctx: Context): tpd.Tree =
         tree match {
           case tree: Bind =>
@@ -354,7 +354,7 @@ trait QuotesAndSplices {
           case _ =>
             super.transform(tree).withType(replaceBindingsInType(tree.tpe))
         }
-      private[this] val replaceBindingsInType = new ReplaceBindings {
+      private val replaceBindingsInType = new ReplaceBindings {
         override def apply(tp: Type): Type = tp match {
           case tp: TermRef => bindMap.get(tp.termSymbol).fold[Type](tp)(_.typeRef)
           case tp => super.apply(tp)

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -130,7 +130,6 @@ class ReTyper extends Typer with ReChecking {
 
   override def inlineExpansion(mdef: DefDef)(implicit ctx: Context): Tree = mdef
 
-  override def checkVariance(tree: Tree)(implicit ctx: Context): Unit = ()
   override def inferView(from: Tree, to: Type)(implicit ctx: Context): Implicits.SearchResult =
     Implicits.NoMatchingImplicitsFailure
   override def checkCanEqual(ltp: Type, rtp: Type, span: Span)(implicit ctx: Context): Unit = ()

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1740,7 +1740,6 @@ class Typer extends Namer
         checkEnum(cdef, cls, firstParent)
       }
       val cdef1 = assignType(cpy.TypeDef(cdef)(name, impl1), cls)
-      checkVariance(cdef1)
 
       val reportDynamicInheritance =
         ctx.phase.isTyper &&
@@ -1827,9 +1826,6 @@ class Typer extends Namer
       typed(untpd.New(untpd.TypedSplice(firstParent), Nil)) :: otherParents
     else parents
   }
-
-  /** Overridden in retyper */
-  def checkVariance(tree: Tree)(implicit ctx: Context): Unit = VarianceChecker.check(tree)
 
   def localDummy(cls: ClassSymbol, impl: untpd.Template)(implicit ctx: Context): Symbol =
     ctx.newLocalDummy(cls, impl.span)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -102,14 +102,14 @@ class Typer extends Namer
    *  Note: It would be more proper to move importedFromRoot into typedIdent.
    *  We should check that this has no performance degradation, however.
    */
-  private[this] var unimported: Set[Symbol] = Set()
+  private var unimported: Set[Symbol] = Set()
 
   /** Temporary data item for single call to typed ident:
    *  This symbol would be found under Scala2 mode, but is not
    *  in dotty (because dotty conforms to spec section 2
    *  wrt to package member resolution but scalac doe not).
    */
-  private[this] var foundUnderScala2: Type = NoType
+  private var foundUnderScala2: Type = NoType
 
   // Overridden in derived typers
   def newLikeThis: Typer = new Typer

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -81,7 +81,7 @@ class VarianceChecker()(implicit ctx: Context) {
   import tpd._
 
   private object Validator extends TypeAccumulator[Option[VarianceError]] {
-    private[this] var base: Symbol = _
+    private var base: Symbol = _
 
     /** Is no variance checking needed within definition of `base`? */
     def ignoreVarianceIn(base: Symbol): Boolean = (

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -3,9 +3,9 @@ package dotty.tools.dotc.util
 /** A hash set that allows some privileged protected access to its internals
  */
 class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int, loadFactor: Float = 0.25f) extends Set[T] {
-  private[this] var used: Int = _
-  private[this] var limit: Int = _
-  private[this] var table: Array[AnyRef] = _
+  private var used: Int = _
+  private var limit: Int = _
+  private var table: Array[AnyRef] = _
 
   assert(Integer.bitCount(powerOfTwoInitialCapacity) == 1)
   protected def isEqual(x: T, y: T): Boolean = x.equals(y)
@@ -75,7 +75,7 @@ class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int, loadFactor: F
     entry.asInstanceOf[T]
   }
 
-  private[this] var rover: Int = -1
+  private var rover: Int = -1
 
   /** Add entry `x` to set */
   def addEntry(x: T): Unit = {
@@ -99,7 +99,7 @@ class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int, loadFactor: F
 
   /** The iterator of all elements in the set */
   def iterator: Iterator[T] = new Iterator[T] {
-    private[this] var i = 0
+    private var i = 0
     def hasNext: Boolean = {
       while (i < table.length && (table(i) eq null)) i += 1
       i < table.length

--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -124,7 +124,7 @@ class SourceFile(val file: AbstractFile, computeContent: => Array[Char]) extends
       Some(lineToOffset(index))
 
   /** A cache to speed up offsetToLine searches to similar lines */
-  private[this] var lastLine = 0
+  private var lastLine = 0
 
   /** Convert offset to line in this source file
    *  Lines are numbered from 0
@@ -175,7 +175,7 @@ class SourceFile(val file: AbstractFile, computeContent: => Array[Char]) extends
 
   // Positioned ids
 
-  private[this] val ctr = new AtomicInteger
+  private val ctr = new AtomicInteger
 
   def nextId: Int = {
     val id = ctr.get

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -13,7 +13,7 @@ import collection.mutable
 
   var monitored: Boolean = false
 
-  @volatile private[this] var stack: List[String] = Nil
+  @volatile private var stack: List[String] = Nil
 
   val hits: mutable.HashMap[String, Int] = new mutable.HashMap[String, Int] {
     override def default(key: String): Int = 0

--- a/compiler/src/dotty/tools/dotc/util/WeakHashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/WeakHashSet.scala
@@ -30,12 +30,12 @@ final class WeakHashSet[A <: AnyRef](initialCapacity: Int, loadFactor: Double) e
    * the removeStaleEntries() method works through the queue to remove
    * stale entries from the table
    */
-  private[this] val queue = new ReferenceQueue[A]
+  private val queue = new ReferenceQueue[A]
 
   /**
    * the number of elements in this set
    */
-  private[this] var count = 0
+  private var count = 0
 
   /**
    * from a specified initial capacity compute the capacity we'll use as being the next
@@ -52,21 +52,21 @@ final class WeakHashSet[A <: AnyRef](initialCapacity: Int, loadFactor: Double) e
   /**
    * the underlying table of entries which is an array of Entry linked lists
    */
-  private[this] var table = new Array[Entry[A]](computeCapacity)
+  private var table = new Array[Entry[A]](computeCapacity)
 
   /**
    * the limit at which we'll increase the size of the hash table
    */
-  private[this] var threshold = computeThreshold
+  private var threshold = computeThreshold
 
-  private[this] def computeThreshold: Int = (table.size * loadFactor).ceil.toInt
+  private def computeThreshold: Int = (table.size * loadFactor).ceil.toInt
 
   def get(elem: A): Option[A] = Option(findEntry(elem))
 
   /**
    * find the bucket associated with an element's hash code
    */
-  private[this] def bucketFor(hash: Int): Int = {
+  private def bucketFor(hash: Int): Int = {
     // spread the bits around to try to avoid accidental collisions using the
     // same algorithm as java.util.HashMap
     var h = hash
@@ -85,7 +85,7 @@ final class WeakHashSet[A <: AnyRef](initialCapacity: Int, loadFactor: Double) e
   /**
    * remove a single entry from a linked list in a given bucket
    */
-  private[this] def remove(bucket: Int, prevEntry: Entry[A], entry: Entry[A]): Unit = {
+  private def remove(bucket: Int, prevEntry: Entry[A], entry: Entry[A]): Unit = {
     prevEntry match {
       case null => table(bucket) = entry.tail
       case _ => prevEntry.tail = entry.tail
@@ -96,7 +96,7 @@ final class WeakHashSet[A <: AnyRef](initialCapacity: Int, loadFactor: Double) e
   /**
    * remove entries associated with elements that have been gc'ed
    */
-  private[this] def removeStaleEntries(): Unit = {
+  private def removeStaleEntries(): Unit = {
     def poll(): Entry[A] = queue.poll().asInstanceOf[Entry[A]]
 
     @tailrec
@@ -121,7 +121,7 @@ final class WeakHashSet[A <: AnyRef](initialCapacity: Int, loadFactor: Double) e
   /**
    * Double the size of the internal table
    */
-  private[this] def resize(): Unit = {
+  private def resize(): Unit = {
     val oldTable = table
     table = new Array[Entry[A]](oldTable.size * 2)
     threshold = computeThreshold
@@ -275,17 +275,17 @@ final class WeakHashSet[A <: AnyRef](initialCapacity: Int, loadFactor: Double) e
       /**
        * the bucket currently being examined. Initially it's set past the last bucket and will be decremented
        */
-      private[this] var currentBucket: Int = table.size
+      private var currentBucket: Int = table.size
 
       /**
        * the entry that was last examined
        */
-      private[this] var entry: Entry[A] = null
+      private var entry: Entry[A] = null
 
       /**
        * the element that will be the result of the next call to next()
        */
-      private[this] var lookaheadelement: A = null.asInstanceOf[A]
+      private var lookaheadelement: A = null.asInstanceOf[A]
 
       @tailrec
       def hasNext: Boolean = {

--- a/compiler/src/dotty/tools/io/VirtualFile.scala
+++ b/compiler/src/dotty/tools/io/VirtualFile.scala
@@ -38,7 +38,7 @@ class VirtualFile(val name: String, override val path: String) extends AbstractF
     this.content = content
   }
 
-  private[this] var content = Array.emptyByteArray
+  private var content = Array.emptyByteArray
 
   def absolute: AbstractFile = this
 
@@ -66,7 +66,7 @@ class VirtualFile(val name: String, override val path: String) extends AbstractF
   /** @inheritdoc */
   override def isVirtual: Boolean = true
 
-  // private[this] var _lastModified: Long = 0
+  // private var _lastModified: Long = 0
   // _lastModified
 
   /** Returns the time that this abstract file was last modified. */

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -111,13 +111,13 @@ abstract class ZipArchive(override val jpath: JPath) extends AbstractFile with E
 }
 /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 final class FileZipArchive(jpath: JPath) extends ZipArchive(jpath) {
-  private[this] def openZipFile(): ZipFile = try {
+  private def openZipFile(): ZipFile = try {
     new ZipFile(file)
   } catch {
     case ioe: IOException => throw new IOException("Error accessing " + file.getPath, ioe)
   }
 
-  private[this] class LazyEntry(
+  private class LazyEntry(
     name: String,
     time: Long,
     size: Int
@@ -138,7 +138,7 @@ final class FileZipArchive(jpath: JPath) extends ZipArchive(jpath) {
   // on Windows, and leaks memory on all OS (typically by stopping
   // classloaders from being garbage collected). But is slightly
   // faster than LazyEntry.
-  private[this] class LeakyEntry(
+  private class LeakyEntry(
     zipFile: ZipFile,
     zipEntry: ZipEntry
   ) extends Entry(zipEntry.getName) {

--- a/compiler/src/dotty/tools/repl/CollectTopLevelImports.scala
+++ b/compiler/src/dotty/tools/repl/CollectTopLevelImports.scala
@@ -15,7 +15,7 @@ class CollectTopLevelImports extends Phase {
 
   def phaseName: String = "collectTopLevelImports"
 
-  private[this] var myImports: List[Import] = _
+  private var myImports: List[Import] = _
   def imports: List[Import] = myImports
 
   def run(implicit ctx: Context): Unit = {

--- a/compiler/src/dotty/tools/repl/ParseResult.scala
+++ b/compiler/src/dotty/tools/repl/ParseResult.scala
@@ -106,7 +106,7 @@ case object Help extends Command {
 
 object ParseResult {
 
-  @sharable private[this] val CommandExtract = """(:[\S]+)\s*(.*)""".r
+  @sharable private val CommandExtract = """(:[\S]+)\s*(.*)""".r
 
   private def parseStats(implicit ctx: Context): List[untpd.Tree] = {
     val parser = new Parser(ctx.source)

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -21,11 +21,11 @@ import dotc.core.StdNames.str
  */
 private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None) {
 
-  private[this] val MaxStringElements: Int = 1000  // no need to mkString billions of elements
+  private val MaxStringElements: Int = 1000  // no need to mkString billions of elements
 
-  private[this] var myClassLoader: ClassLoader = _
+  private var myClassLoader: ClassLoader = _
 
-  private[this] var myReplStringOf: Object => String = _
+  private var myReplStringOf: Object => String = _
 
 
   /** Class loader used to load compiled code */
@@ -62,7 +62,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None) {
    *
    *  Calling this method evaluates the expression using reflection
    */
-  private[this] def valueOf(sym: Symbol)(implicit ctx: Context): Option[String] = {
+  private def valueOf(sym: Symbol)(implicit ctx: Context): Option[String] = {
     val defn = ctx.definitions
     val objectName = sym.owner.fullName.encode.toString.stripSuffix("$")
     val resObj: Class[?] = Class.forName(objectName, true, classLoader())

--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -41,7 +41,7 @@ class ReplCompiler extends Compiler {
   def newRun(initCtx: Context, state: State): Run = new Run(this, initCtx) {
 
     /** Import previous runs and user defined imports */
-    override protected[this] def rootContext(implicit ctx: Context): Context = {
+    override protected def rootContext(implicit ctx: Context): Context = {
       def importContext(imp: tpd.Import)(implicit ctx: Context) =
         ctx.importContext(imp, imp.symbol)
 

--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -67,7 +67,7 @@ class ReplCompiler extends Compiler {
     }
   }
 
-  private[this] val objectNames = mutable.Map.empty[Int, TermName]
+  private val objectNames = mutable.Map.empty[Int, TermName]
 
   private case class Definitions(stats: List[untpd.Tree], state: State)
 

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -78,7 +78,7 @@ class ReplDriver(settings: Array[String],
    *  such, when the user enters `:reset` this method should be called to reset
    *  everything properly
    */
-  protected[this] def resetToInitial(): Unit = {
+  protected def resetToInitial(): Unit = {
     rootCtx = initialCtx
     if (rootCtx.settings.outputDir.isDefault(rootCtx))
       rootCtx = rootCtx.fresh
@@ -159,7 +159,7 @@ class ReplDriver(settings: Array[String],
   }
 
   /** Extract possible completions at the index of `cursor` in `expr` */
-  protected[this] final def completions(cursor: Int, expr: String, state0: State): List[Candidate] = {
+  protected final def completions(cursor: Int, expr: String, state0: State): List[Candidate] = {
     def makeCandidate(completion: Completion) = {
       val displ = completion.label
       new Candidate(

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -61,7 +61,7 @@ class ReplDriver(settings: Array[String],
   override def sourcesRequired: Boolean = false
 
   /** Create a fresh and initialized context with IDE mode enabled */
-  private[this] def initialCtx = {
+  private def initialCtx = {
     val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions | Mode.Interactive | Mode.ReadComments)
     rootCtx.setSetting(rootCtx.settings.YcookComments, true)
     val ictx = setup(settings, rootCtx)._2
@@ -87,9 +87,9 @@ class ReplDriver(settings: Array[String],
     rendering = new Rendering(classLoader)
   }
 
-  private[this] var rootCtx: Context = _
-  private[this] var compiler: ReplCompiler = _
-  private[this] var rendering: Rendering = _
+  private var rootCtx: Context = _
+  private var compiler: ReplCompiler = _
+  private var rendering: Rendering = _
 
   // initialize the REPL session as part of the constructor so that once `run`
   // is called, we're in business

--- a/compiler/src/dotty/tools/repl/ScriptEngine.scala
+++ b/compiler/src/dotty/tools/repl/ScriptEngine.scala
@@ -17,14 +17,14 @@ import dotc.core.StdNames.str
  *  println(e.eval("42"))
  */
 class ScriptEngine extends AbstractScriptEngine {
-  private[this] val driver = new ReplDriver(
+  private val driver = new ReplDriver(
     Array(
       "-classpath", "", // Avoid the default "."
       "-usejavacp",
       "-color:never"
     ), Console.out, None)
-  private[this] val rendering = new Rendering
-  private[this] var state: State = driver.initialState
+  private val rendering = new Rendering
+  private var state: State = driver.initialState
 
   def getFactory: ScriptEngineFactory = new ScriptEngine.Factory
 

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -6,7 +6,7 @@ import java.nio.file._
 object Properties {
 
   /** If property is unset or "TRUE" we consider it `true` */
-  private[this] def propIsNullOrTrue(prop: String): Boolean = {
+  private def propIsNullOrTrue(prop: String): Boolean = {
     val prop = System.getProperty("dotty.tests.interactive")
     prop == null || prop == "TRUE"
   }

--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -30,7 +30,7 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
   protected final val _consoleReporter = new ConsoleReporter(null, new PrintWriter(_consoleBuf))
   final def consoleOutput: String = _consoleBuf.toString
 
-  private[this] var _didCrash = false
+  private var _didCrash = false
   final def compilerCrashed: Boolean = _didCrash
 
   protected final def inlineInfo(pos: SourcePosition)(implicit ctx: Context): String =
@@ -87,10 +87,10 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
 }
 
 object TestReporter {
-  private[this] var outFile: JFile = _
-  private[this] var logWriter: PrintWriter = _
+  private var outFile: JFile = _
+  private var logWriter: PrintWriter = _
 
-  private[this] def initLog() = if (logWriter eq null) {
+  private def initLog() = if (logWriter eq null) {
     val date = new Date
     val df0 = new SimpleDateFormat("yyyy-MM-dd")
     val df1 = new SimpleDateFormat("yyyy-MM-dd-'T'HH-mm-ss")

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -7,7 +7,7 @@ import org.junit.Test
 class TabcompleteTests extends ReplTest {
 
   /** Returns the `(<instance completions>, <companion completions>)`*/
-  private[this] def tabComplete(src: String)(implicit state: State): List[String] =
+  private def tabComplete(src: String)(implicit state: State): List[String] =
     completions(src.length, src, state).map(_.value).sorted
 
   @Test def tabCompleteList = fromInitialState { implicit s =>

--- a/compiler/test/dotty/tools/vulpix/FileFilter.scala
+++ b/compiler/test/dotty/tools/vulpix/FileFilter.scala
@@ -7,12 +7,12 @@ sealed trait FileFilter {
 object FileFilter {
 
   def exclude(files: List[String]): FileFilter = new FileFilter {
-    private[this] val blackList = files.toSet
+    private val blackList = files.toSet
     def accept(file: String): Boolean = !blackList.contains(file)
   }
 
   def include(files: List[String]): FileFilter = new FileFilter {
-    private[this] val whiteList = files.toSet
+    private val whiteList = files.toSet
     def accept(file: String): Boolean = whiteList.contains(file)
   }
 

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -304,7 +304,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
        */
       def checkTestSource(): Unit
 
-      private[this] val logBuffer = mutable.ArrayBuffer.empty[String]
+      private val logBuffer = mutable.ArrayBuffer.empty[String]
       def log(msg: String): Unit = logBuffer.append(msg)
 
       def logReporterContents(reporter: TestReporter): Unit =
@@ -334,7 +334,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     /** Total amount of test sources being compiled by this test */
     val sourceCount = filteredSources.length
 
-    private[this] var _testSourcesCompleted = 0
+    private var _testSourcesCompleted = 0
     private def testSourcesCompleted: Int = _testSourcesCompleted
 
     /** Complete the current compilation with the amount of errors encountered */
@@ -347,8 +347,8 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     case class TimeoutFailure(title: String) extends Failure
     case object Generic extends Failure
 
-    private[this] var _failures = Set.empty[Failure]
-    private[this] var _failureCount = 0
+    private var _failures = Set.empty[Failure]
+    private var _failureCount = 0
 
     /** Fail the current test */
     protected final def fail(failure: Failure = Generic): Unit = synchronized {
@@ -370,12 +370,12 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     }
 
     /** Instructions on how to reproduce failed test source compilations */
-    private[this] val reproduceInstructions = mutable.ArrayBuffer.empty[String]
+    private val reproduceInstructions = mutable.ArrayBuffer.empty[String]
     protected final def addFailureInstruction(ins: String): Unit =
       synchronized { reproduceInstructions.append(ins) }
 
     /** The test sources that failed according to the implementing subclass */
-    private[this] val failedTestSources = mutable.ArrayBuffer.empty[String]
+    private val failedTestSources = mutable.ArrayBuffer.empty[String]
     protected final def failTestSource(testSource: TestSource, reason: Failure = Generic) = synchronized {
       val extra = reason match {
         case TimeoutFailure(title) => s", test '$title' timed out"
@@ -586,8 +586,8 @@ trait ParallelTesting extends RunnerOrchestration { self =>
 
   private final class RunTest(testSources: List[TestSource], times: Int, threadLimit: Option[Int], suppressAllOutput: Boolean)(implicit summaryReport: SummaryReporting)
   extends Test(testSources, times, threadLimit, suppressAllOutput) {
-    private[this] var didAddNoRunWarning = false
-    private[this] def addNoRunWarning() = if (!didAddNoRunWarning) {
+    private var didAddNoRunWarning = false
+    private def addNoRunWarning() = if (!didAddNoRunWarning) {
       didAddNoRunWarning = true
       summaryReport.addStartingMessage {
         """|WARNING
@@ -907,7 +907,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     }
 
     /** Extract `Failure` set and render from `Test` */
-    private[this] def reasonsForFailure(test: Test): String = {
+    private def reasonsForFailure(test: Test): String = {
       val failureReport =
         if (test.failureCount == 0) ""
         else s"\n  - encountered ${test.failureCount} test failures(s)"

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -351,7 +351,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     private[this] var _failureCount = 0
 
     /** Fail the current test */
-    protected[this] final def fail(failure: Failure = Generic): Unit = synchronized {
+    protected final def fail(failure: Failure = Generic): Unit = synchronized {
       _failures = _failures + failure
       _failureCount = _failureCount + 1
     }

--- a/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
+++ b/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
@@ -48,7 +48,7 @@ trait RunnerOrchestration {
   def runMain(classPath: String)(implicit summaryReport: SummaryReporting): Status =
     monitor.runMain(classPath)
 
-  private[this] val monitor = new RunnerMonitor
+  private val monitor = new RunnerMonitor
 
   /** The runner monitor object keeps track of child JVM processes by keeping
    *  them in two structures - one for free, and one for busy children.
@@ -63,9 +63,9 @@ trait RunnerOrchestration {
     def runMain(classPath: String)(implicit summaryReport: SummaryReporting): Status =
       withRunner(_.runMain(classPath))
 
-    private class Runner(private[this] var process: Process) {
-      private[this] var childStdout: BufferedReader = _
-      private[this] var childStdin: PrintStream = _
+    private class Runner(private var process: Process) {
+      private var childStdout: BufferedReader = _
+      private var childStdin: PrintStream = _
 
       /** Checks if `process` is still alive
        *
@@ -86,7 +86,7 @@ trait RunnerOrchestration {
       }
 
       /** Did add hook to kill the child VMs? */
-      private[this] val didAddCleanupCallback = new AtomicBoolean(false)
+      private val didAddCleanupCallback = new AtomicBoolean(false)
 
       /** Blocks less than `maxDuration` while running `Test.main` from `dir` */
       def runMain(classPath: String)(implicit summaryReport: SummaryReporting): Status = {
@@ -166,9 +166,9 @@ trait RunnerOrchestration {
         .start()
     }
 
-    private[this] val allRunners = List.fill(numberOfSlaves)(new Runner(createProcess))
-    private[this] val freeRunners = mutable.Queue(allRunners: _*)
-    private[this] val busyRunners = mutable.Set.empty[Runner]
+    private val allRunners = List.fill(numberOfSlaves)(new Runner(createProcess))
+    private val freeRunners = mutable.Queue(allRunners: _*)
+    private val busyRunners = mutable.Set.empty[Runner]
 
     private def getRunner(): Runner = synchronized {
       while (freeRunners.isEmpty) wait()

--- a/compiler/test/dotty/tools/vulpix/SummaryReport.scala
+++ b/compiler/test/dotty/tools/vulpix/SummaryReport.scala
@@ -68,8 +68,8 @@ final class SummaryReport extends SummaryReporting {
   private val reproduceInstructions = new java.util.concurrent.ConcurrentLinkedDeque[String]
   private val cleanUps = new java.util.concurrent.ConcurrentLinkedDeque[() => Unit]
 
-  private[this] var passed = 0
-  private[this] var failed = 0
+  private var passed = 0
+  private var failed = 0
 
   def reportFailed(): Unit =
     failed += 1

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -331,7 +331,7 @@ LocalModifier     ::=  ‘abstract’
                     |  ‘lazy’
                     |  ‘inline’
 AccessModifier    ::=  (‘private’ | ‘protected’) [AccessQualifier]
-AccessQualifier   ::=  ‘[’ (id | ‘this’) ‘]’
+AccessQualifier   ::=  ‘[’ id ‘]’
 
 Annotation        ::=  ‘@’ SimpleType {ParArgumentExprs}                        Apply(tpe, args)
 

--- a/docs/docs/reference/dropped-features/this-qualifier.md
+++ b/docs/docs/reference/dropped-features/this-qualifier.md
@@ -1,0 +1,14 @@
+---
+layout: doc-page
+title: Dropped: private[this] and protected[this]
+---
+
+The `private[this]` and `protected[this]` access modifiers are deprecated and will be phased out.
+
+Previously, these modifier were needed
+
+ - for avoiding the generation of getters and setters
+ - for excluding code under a `private[this]` from variance checks. (Scala 2 also excludes `protected[this]` but this was found to be unsound and was therefore removed).
+
+The compiler now infers for `private` members the fact that they are only accessed via `this`. Such members are treated as if they had been declared `private[this]`. `protected[this]` is dropped without a replacement.
+

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -171,6 +171,8 @@ sidebar:
               url: docs/reference/dropped-features/weak-conformance.html
             - title: Nonlocal Returns
               url: docs/reference/dropped-features/nonlocal-returns.html
+            - title: `[this]` Qualifier
+              url: docs/reference/dropped-features/this-qualifier.html
     - title: Contributing
       subsection:
         - title: Contribute Knowledge

--- a/tests/neg-custom-args/matchtype-loop.scala
+++ b/tests/neg-custom-args/matchtype-loop.scala
@@ -2,7 +2,7 @@ object Test {
   type L[X] = X match {
     case Int => L[X]
   }
-  type LL[X] = X match {  // error: recursion limit exceeded
+  type LL[X] = X match {
     case Int => LL[LL[X]]
   }
   def a: L[Boolean] = ???
@@ -11,7 +11,7 @@ object Test {
   val x: Int = g[Int]     // error: found: L[Int], required: Int
 
   def aa: LL[Boolean] = ???
-  def bb: LL[Int] = ???   // error: recursion limit exceeded with  reduce type  LazyRef(Test.LL[Int]) match ... // error
+  def bb: LL[Int] = ???   // error: recursion limit exceeded with  reduce type  LazyRef(Test.LL[Int]) match ...
   def gg[X]: LL[X] = ???
   val xx: Int = gg[Int]   // error: recursion limit exceeded with  reduce type  LazyRef(Test.LL[Int]) match ...
 }

--- a/tests/neg/i4385.scala
+++ b/tests/neg/i4385.scala
@@ -1,6 +1,7 @@
 class i0 {
   class i1 { type i2 }
-  type i3 = i1.i2 // error
+  val i1 = new i1()
+  type i3 = i1.i2
   type i4 = i0 { type i1 <: i4 } // error: recursion limit exceeded
   // This test ensures the above stack overflow is reported and not hidden by the earlier error.
 }

--- a/tests/neg/i5202.scala
+++ b/tests/neg/i5202.scala
@@ -9,7 +9,7 @@ class Foo[A] {
   def foo(a: A): Unit = {}
 }
 class Co[+A] {
-  def foo(a: A): Unit = {} // error: contravariant occurs in covariant position
+  def foo(a: A): Unit = {}
   def bar: A = ???
 }
 class Contra[-A] {

--- a/tests/neg/i5202a.scala
+++ b/tests/neg/i5202a.scala
@@ -1,0 +1,4 @@
+class Co[+A] {
+  def foo(a: A): Unit = {} // error: contravariant occurs in covariant position
+  def bar: A = ???
+}

--- a/tests/neg/matchtype-loop2.scala
+++ b/tests/neg/matchtype-loop2.scala
@@ -1,0 +1,8 @@
+object Test {
+  type L[X] = X match {
+    case Int => L[X]
+  }
+  type LL[X] = X match {   // error: recursion limit exceeded
+    case Int => LL[LL[X]]
+  }
+}

--- a/tests/neg/toplevel-cyclic/defs_1.scala
+++ b/tests/neg/toplevel-cyclic/defs_1.scala
@@ -1,2 +1,2 @@
-type A = B  // error: recursion limit exceeded // error: recursion limit exceeded
+type A = B  // error: recursion limit exceeded
 

--- a/tests/neg/toplevel-cyclic/moredefs_1.scala
+++ b/tests/neg/toplevel-cyclic/moredefs_1.scala
@@ -1,1 +1,1 @@
-type B = A // error: recursion limit exceeded // error: recursion limit exceeded
+type B = A // error: recursion limit exceeded

--- a/tests/printing/i620.check
+++ b/tests/printing/i620.check
@@ -5,7 +5,7 @@ package O {
       class C() extends Object() {
         protected[D] def a: Int = 0
         private[D] def b: Int = 0
-        private def c: Int = 0
+        private[this] def c: Int = 0
         protected def d: Int = 0
         private[A] def e: Int = 0
         protected[A] def f: Int = 0
@@ -14,7 +14,7 @@ package O {
         def (c: D.this.C) g1: Int = 0
       }
       private[D] class E() extends Object() {}
-      private class F() extends Object() {}
+      private[this] class F() extends Object() {}
       private[A] class G() extends Object() {}
       protected[D] class H() extends Object() {}
       protected class I() extends Object() {}
@@ -22,7 +22,7 @@ package O {
       class K() extends Object() {}
       protected[D] val a: Int = 0
       private[D] val b: Int = 0
-      private val c: Int = 0
+      private[this] val c: Int = 0
       protected val d: Int = 0
       private[A] val e: Int = 0
       protected[A] val f: Int = 0

--- a/tests/run/i1692.scala
+++ b/tests/run/i1692.scala
@@ -16,6 +16,9 @@ class LazyNullable(a: => Int) {
   private [this] val e = "E"
   lazy val l4 = try e finally () // null out e
 
+  private val eInf = "E" // still nullable because private[this] is inferred
+  lazy val l4Inf = eInf
+
   private[this] val i = "I"
   // null out i even though the try ends up lifted, because the LazyVals phase runs before the LiftTry phase
   lazy val l5 = try i catch { case e: Exception => () }
@@ -38,9 +41,6 @@ class LazyNotNullable {
 
   private[this] lazy val d = "D" // not nullable because lazy
   lazy val l3 = d
-
-  private val e = "E" // not nullable because not private[this]
-  lazy val l4 = e
 
   private[this] val f = "F" // not nullable because used in mutiple lazy vals
   lazy val l5 = f
@@ -98,6 +98,9 @@ object Test {
     assert(lz.l4 == "E")
     assertNull("e")
 
+    assert(lz.l4Inf == "E")
+    assertNull("eInf")
+
     assert(lz.l5 == "I")
     assertNull("i")
 
@@ -123,9 +126,6 @@ object Test {
     assertNotNull("c")
 
     assert(lz.l3 == "D")
-
-    assert(lz.l4 == "E")
-    assertNotNull("e")
 
     assert(lz.l5 == "F")
     assert(lz.l6 == "F")

--- a/tests/run/i1692b.scala
+++ b/tests/run/i1692b.scala
@@ -18,6 +18,9 @@ class LazyNullable(a: => Int) {
   private [this] val e = "E"
   @threadUnsafe lazy val l4 = try e finally () // null out e
 
+  private val eInf = "E"
+  @threadUnsafe lazy val l4Inf = try eInf finally () // null out e, since private[this] is inferred
+
   private[this] val i = "I"
   // null out i even though the try ends up lifted, because the LazyVals phase runs before the LiftTry phase
   @threadUnsafe lazy val l5 = try i catch { case e: Exception => () }
@@ -40,9 +43,6 @@ class LazyNotNullable {
 
   @threadUnsafe private[this]  lazy val d = "D" // not nullable because lazy
   @threadUnsafe lazy val l3 = d
-
-  private val e = "E" // not nullable because not private[this]
-  @threadUnsafe lazy val l4 = e
 
   private[this] val f = "F" // not nullable because used in mutiple @threadUnsafe lazy vals
   @threadUnsafe lazy val l5 = f
@@ -100,6 +100,9 @@ object Test {
     assert(lz.l4 == "E")
     assertNull("e")
 
+    assert(lz.l4Inf == "E")
+    assertNull("eInf")
+
     assert(lz.l5 == "I")
     assertNull("i")
 
@@ -125,9 +128,6 @@ object Test {
     assertNotNull("c")
 
     assert(lz.l3 == "D")
-
-    assert(lz.l4 == "E")
-    assertNotNull("e")
 
     assert(lz.l5 == "F")
     assert(lz.l6 == "F")


### PR DESCRIPTION
Infer private[this] if all accesses are via this, even if it is not explicitly specified.

Deprecate usage of `private[this]` and `protected[this]` under -strict (i.e. for 3.1.).

The main reasons for dropping `private[this]` are:

 - it is syntactically an irregular case. A pair of brackets usually encloses a type, but `this` is a value. 
 - its effect over `private` is purely local and can be easily inferred
 - it leads to bike shedding: should I use `private` or `private[this]`? One is shorter but the other might be more efficient.

`protected[this]` by now influences compiler decisions in no way at all. Its delta over `protected` is small. `protected` by itself is niche (e.g. Don Syme has argued eloquently why it is _too_ niche for F#), so having two variants of it looks like overkill.
