### PR TITLE
Fix #7416: Don't emit signatures of fields of primitive types

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -535,8 +535,10 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
 
   private def getGenericSignature(sym: Symbol, owner: Symbol, memberTpe: Type)(implicit ctx: Context): Option[String] =
     if (needsGenericSignature(sym)) {
-      val erasedTypeSym = sym.denot.info.typeSymbol
+      val erasedTypeSym = TypeErasure.fullErasure(sym.denot.info).typeSymbol
       if (erasedTypeSym.isPrimitiveValueClass) {
+        // Suppress signatures for symbols whose types erase in the end to primitive
+        // value types. This is needed to fix #7416.
         None
       } else {
         val jsOpt = GenericSignatures.javaSig(sym, memberTpe)

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -147,6 +147,12 @@ object TypeErasure {
   def valueErasure(tp: Type)(implicit ctx: Context): Type =
     erasureFn(isJava = false, semiEraseVCs = true, isConstructor = false, wildcardOK = false)(tp)(erasureCtx)
 
+  /** Like value class erasure, but value classes erase to their underlying type erasure */
+  def fullErasure(tp: Type)(implicit ctx: Context): Type =
+    valueErasure(tp) match
+      case ErasedValueType(_, underlying) => erasure(underlying)
+      case etp => etp
+
   def sigName(tp: Type, isJava: Boolean)(implicit ctx: Context): TypeName = {
     val normTp = tp.underlyingIfRepeated(isJava)
     val erase = erasureFn(isJava, semiEraseVCs = false, isConstructor = false, wildcardOK = true)

--- a/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
@@ -23,7 +23,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
   /** the following two members override abstract members in Transform */
   val phaseName: String = "capturedVars"
 
-  private var Captured: Store.Location[collection.Set[Symbol]] = _
+  private[this] var Captured: Store.Location[collection.Set[Symbol]] = _
   private def captured(implicit ctx: Context) = ctx.store(Captured)
 
   override def initContext(ctx: FreshContext): Unit =
@@ -82,7 +82,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
     */
   def refClass(cls: Symbol, isVolatile: Boolean)(implicit ctx: Context): Symbol = {
     val refMap = if (isVolatile) refInfo.volatileRefClass else refInfo.refClass
-    if (cls.isClass) 
+    if (cls.isClass)
       refMap.getOrElse(cls, refMap(defn.ObjectClass))
     else refMap(defn.ObjectClass)
   }

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -9,13 +9,14 @@ import core.Flags._
 import core.Names.{DerivedName, Name, SimpleName, TypeName}
 import core.Symbols._
 import core.TypeApplications.TypeParamInfo
-import core.TypeErasure.erasure
+import core.TypeErasure.{erasure, fullErasure}
 import core.Types._
 import core.classfile.ClassfileConstants
 import ast.Trees._
 import SymUtils._
 import TypeUtils._
 import java.lang.StringBuilder
+import core.Decorators._
 
 import scala.annotation.tailrec
 
@@ -33,7 +34,12 @@ object GenericSignatures {
    */
   def javaSig(sym0: Symbol, info: Type)(implicit ctx: Context): Option[String] =
     // Avoid generating a signature for local symbols.
-    if (sym0.isLocal) None
+    // Also suppress signatures for private symbols whose types erase in the end to primitive
+    // value types. This is done to fix #7416. Since I do not know GenericSignatures well,
+    // I did a minimal fix that lets #7416 pass. Maybe it can be generalized
+    if sym0.isLocal
+       || sym0.is(Private) && fullErasure(info).isPrimitiveValueType
+    then None
     else javaSig0(sym0, info)(ctx.withPhase(ctx.erasurePhase))
 
   @noinline

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -9,14 +9,13 @@ import core.Flags._
 import core.Names.{DerivedName, Name, SimpleName, TypeName}
 import core.Symbols._
 import core.TypeApplications.TypeParamInfo
-import core.TypeErasure.{erasure, fullErasure}
+import core.TypeErasure.erasure
 import core.Types._
 import core.classfile.ClassfileConstants
 import ast.Trees._
 import SymUtils._
 import TypeUtils._
 import java.lang.StringBuilder
-import core.Decorators._
 
 import scala.annotation.tailrec
 
@@ -34,12 +33,7 @@ object GenericSignatures {
    */
   def javaSig(sym0: Symbol, info: Type)(implicit ctx: Context): Option[String] =
     // Avoid generating a signature for local symbols.
-    // Also suppress signatures for private symbols whose types erase in the end to primitive
-    // value types. This is done to fix #7416. Since I do not know GenericSignatures well,
-    // I did a minimal fix that lets #7416 pass. Maybe it can be generalized
-    if sym0.isLocal
-       || sym0.is(Private) && fullErasure(info).isPrimitiveValueType
-    then None
+    if (sym0.isLocal) None
     else javaSig0(sym0, info)(ctx.withPhase(ctx.erasurePhase))
 
   @noinline


### PR DESCRIPTION
Don't emit signatures for private fields of primitive type.

Maybe there's a better fix for this?
