### PR TITLE
Fix #7428: Don't make enum values JavaStatic

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -274,23 +274,6 @@ trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] 
     case _ => tree
   }
 
-  /** True iff definition is a val or def with no right-hand-side, or it
-   *  is an abstract typoe declaration
-   */
-  def lacksDefinition(mdef: MemberDef)(implicit ctx: Context): Boolean = mdef match {
-    case mdef: ValOrDefDef =>
-      mdef.unforcedRhs == EmptyTree && !mdef.name.isConstructorName && !mdef.mods.isOneOf(TermParamOrAccessor)
-    case mdef: TypeDef =>
-      def isBounds(rhs: Tree): Boolean = rhs match {
-        case _: TypeBoundsTree => true
-        case _: MatchTypeTree => true // Typedefs with Match rhs classify as abstract
-        case LambdaTypeTree(_, body) => isBounds(body)
-        case _ => false
-      }
-      mdef.rhs.isEmpty || isBounds(mdef.rhs)
-    case _ => false
-  }
-
   def functionWithUnknownParamType(tree: Tree): Option[Tree] = tree match {
     case Function(args, _) =>
       if (args.exists {

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -526,7 +526,7 @@ object Flags {
   val DeferredOrLazyOrMethod: FlagSet        = Deferred | Lazy | Method
   val DeferredOrTermParamOrAccessor: FlagSet = Deferred | ParamAccessor | TermParam           // term symbols without right-hand sides
   val DeferredOrTypeParam: FlagSet           = Deferred | TypeParam                           // type symbols without right-hand sides
-  val EnumValue: FlagSet                     = Enum | JavaStatic | StableRealizable           // A Scala enum value
+  val EnumValue: FlagSet                     = Enum | StableRealizable           // A Scala enum value
   val StableOrErased: FlagSet                = Erased | StableRealizable                      // Assumed to be pure
   val ExtensionMethod: FlagSet               = Extension | Method
   val FinalOrInline: FlagSet                 = Final | Inline

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -75,12 +75,8 @@ class Erasure extends Phase with DenotTransformer {
         val newInfo = transformInfo(oldSymbol, oldInfo)
         val oldFlags = ref.flags
         val newFlags =
-          if oldSymbol.is(Flags.TermParam) && isCompacted(oldSymbol.owner) then
-            oldFlags &~ Flags.Param
-          else if oldSymbol.isAllOf(Flags.EnumValue) && oldSymbol.isStatic then
-            oldFlags | Flags.JavaStatic
-          else
-            oldFlags &~ Flags.HasDefaultParamsFlags // HasDefaultParamsFlags needs to be dropped because overriding might become overloading
+          if (oldSymbol.is(Flags.TermParam) && isCompacted(oldSymbol.owner)) oldFlags &~ Flags.Param
+          else oldFlags &~ Flags.HasDefaultParamsFlags // HasDefaultParamsFlags needs to be dropped because overriding might become overloading
 
         // TODO: define derivedSymDenotation?
         if ((oldSymbol eq newSymbol) && (oldOwner eq newOwner) && (oldName eq newName) && (oldInfo eq newInfo) && (oldFlags == newFlags))

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -75,8 +75,12 @@ class Erasure extends Phase with DenotTransformer {
         val newInfo = transformInfo(oldSymbol, oldInfo)
         val oldFlags = ref.flags
         val newFlags =
-          if (oldSymbol.is(Flags.TermParam) && isCompacted(oldSymbol.owner)) oldFlags &~ Flags.Param
-          else oldFlags &~ Flags.HasDefaultParamsFlags // HasDefaultParamsFlags needs to be dropped because overriding might become overloading
+          if oldSymbol.is(Flags.TermParam) && isCompacted(oldSymbol.owner) then
+            oldFlags &~ Flags.Param
+          else if oldSymbol.isAllOf(Flags.EnumValue) && oldSymbol.isStatic then
+            oldFlags | Flags.JavaStatic
+          else
+            oldFlags &~ Flags.HasDefaultParamsFlags // HasDefaultParamsFlags needs to be dropped because overriding might become overloading
 
         // TODO: define derivedSymDenotation?
         if ((oldSymbol eq newSymbol) && (oldOwner eq newOwner) && (oldName eq newName) && (oldInfo eq newInfo) && (oldFlags == newFlags))

--- a/tests/pos/i7428.scala
+++ b/tests/pos/i7428.scala
@@ -1,4 +1,4 @@
-object ABug
+class ABug
   enum Tag
     case first
   import Tag.first

--- a/tests/pos/i7428.scala
+++ b/tests/pos/i7428.scala
@@ -1,0 +1,6 @@
+object ABug
+  enum Tag
+    case first
+  import Tag.first
+  val xx = first
+


### PR DESCRIPTION
It leads to backend crashes if the enum is defined in a class and does
not seem to be needed anyway.