### PR TITLE
Add community build: Intent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,3 +53,6 @@
 [submodule "community-build/community-projects/effpi"]
 	path = community-build/community-projects/effpi
 	url = https://github.com/dotty-staging/effpi
+[submodule "community-build/community-projects/intent"]
+	path = community-build/community-projects/intent
+	url = https://github.com/factor10/intent.git

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -206,6 +206,12 @@ class CommunityBuildTest {
     updateCommand = ";set ThisBuild / useEffpiPlugin := false; effpi/test:update; benchmarks/test:update; examples/test:update; pluginBenchmarks/test:update"
   )
 
+  @Test def intent = test(
+    project       = "intent",
+    testCommand   = "test",
+    updateCommand = "update"
+  )
+
   // TODO @oderky? It got broken by #5458
   // @Test def pdbp = test(
   //   project       = "pdbp",


### PR DESCRIPTION
Intent is a test framework for Dotty: https://github.com/factor10/intent. @bishabosha suggested I should add it as a community build.

Two things:

1. It is not clear to me whether the test command should run tests or just compile (or test-compile). The existing projects differ in this regard.

2. I don't know if this PR works. When I run `sbt community-build/test`, I get:

```
[error] java.nio.file.InvalidPathException: Illegal char <:> at index 23: TypeOrBoundsOps$given_=:=_of_Type$.class
[error]         at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
[error]         at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
[error]         at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
[error]         at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
[error]         at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:229)
[error]         at java.base/java.nio.file.Path.resolve(Path.java:515)
[error]         at dotty.tools.io.Path.$div(Path.scala:93)
[error]         at dotty.tools.io.PlainFile.lookupName(PlainFile.scala:78)
[error]         at dotty.tools.io.AbstractFile.fileOrSubdirectoryNamed(AbstractFile.scala:239)
[error]         at dotty.tools.io.AbstractFile.fileNamed(AbstractFile.scala:256)
[error]         at dotty.tools.backend.jvm.BytecodeWriters.getFile(BytecodeWriters.scala:31)
[error]         at dotty.tools.backend.jvm.GenBCodePipeline.getFile(GenBCode.scala:69)
[error]         at dotty.tools.backend.jvm.BCodeHelpers.getFileForClassfile(BCodeHelpers.scala:33)
[error]         at dotty.tools.backend.jvm.GenBCodePipeline.getFileForClassfile(GenBCode.scala:69)
[error]         at dotty.tools.backend.jvm.GenBCodePipeline$Worker1.liftedTree1$1(GenBCode.scala:256)
[error]         at dotty.tools.backend.jvm.GenBCodePipeline$Worker1.$anonfun$2(GenBCode.scala:261)
[error]         at scala.collection.immutable.List.map(List.scala:223)
[error]         at dotty.tools.backend.jvm.GenBCodePipeline$Worker1.visit(GenBCode.scala:262)
[error]         at dotty.tools.backend.jvm.GenBCodePipeline$Worker1.run(GenBCode.scala:181)
[error]         at dotty.tools.backend.jvm.GenBCodePipeline.buildAndSendToDisk(GenBCode.scala:511)
[error]         at dotty.tools.backend.jvm.GenBCodePipeline.run(GenBCode.scala:477)
[error]         at dotty.tools.backend.jvm.GenBCode.run(GenBCode.scala:52)
[error]         at dotty.tools.dotc.core.Phases$Phase.runOn$$anonfun$1(Phases.scala:315)
[error]         at scala.collection.immutable.List.map(List.scala:223)
[error]         at dotty.tools.dotc.core.Phases$Phase.runOn(Phases.scala:316)
[error]         at dotty.tools.backend.jvm.GenBCode.runOn(GenBCode.scala:56)
[error]         at dotty.tools.dotc.Run.runPhases$4$$anonfun$4(Run.scala:159)
[error]         at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
[error]         at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
[error]         at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1323)
[error]         at dotty.tools.dotc.Run.runPhases$5(Run.scala:169)
[error]         at dotty.tools.dotc.Run.compileUnits$$anonfun$1(Run.scala:177)
[error]         at dotty.runtime.function.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[error]         at dotty.tools.dotc.util.Stats$.maybeMonitored(Stats.scala:67)
[error]         at dotty.tools.dotc.Run.compileUnits(Run.scala:184)
[error]         at dotty.tools.dotc.Run.compileSources(Run.scala:121)
[error]         at dotty.tools.dotc.Run.compile(Run.scala:104)
[error]         at dotty.tools.dotc.Driver.doCompile(Driver.scala:35)
[error]         at dotty.tools.dotc.Driver.process(Driver.scala:178)
[error]         at dotty.tools.dotc.Main.process(Main.scala)
[error]         at xsbt.CachedCompilerImpl.run(CachedCompilerImpl.java:69)
[error]         at xsbt.CompilerInterface.run(CompilerInterface.java:41)
[error]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error]         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]         at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[error]         at sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:237)
[error]         at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:111)
[error]         at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:90)
[error]         at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3(MixedAnalyzingCompiler.scala:82)
[error]         at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[error]         at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:133)
[error]         at sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:73)
[error]         at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:116)
[error]         at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:307)
[error]         at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:307)
[error]         at sbt.internal.inc.Incremental$.doCompile(Incremental.scala:106)
[error]         at sbt.internal.inc.Incremental$.$anonfun$compile$4(Incremental.scala:87)
[error]         at sbt.internal.inc.IncrementalCommon.recompileClasses(IncrementalCommon.scala:116)
[error]         at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:63)
[error]         at sbt.internal.inc.Incremental$.$anonfun$compile$3(Incremental.scala:89)
[error]         at sbt.internal.inc.Incremental$.manageClassfiles(Incremental.scala:134)
[error]         at sbt.internal.inc.Incremental$.compile(Incremental.scala:80)
[error]         at sbt.internal.inc.IncrementalCompile$.apply(Compile.scala:67)
[error]         at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:311)
[error]         at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:269)
[error]         at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:159)
[error]         at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:238)
[error]         at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:69)
[error]         at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:1549)
[error]         at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:1523)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40)
[error]         at sbt.std.Transform$$anon$4.work(System.scala:67)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error]         at sbt.Execute.work(Execute.scala:278)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error]         at java.base/java.lang.Thread.run(Thread.java:834)
[error] (dotty-library / Compile / compileIncremental) java.nio.file.InvalidPathException: Illegal char <:> at index 23: TypeOrBoundsOps$given_=:=_of_Type$.class
```

Any suggestions to get past the error?