### PR TITLE
Prevent numeric separator after leading zero

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -695,7 +695,7 @@ object Scanners {
                *  to let it be base-10 because of history.  Should it be an error? Is
                *  there a realistic situation where one would need it?
                */
-              if (isDigit(ch))
+              if (isDigit(ch) || (isNumberSeparator(ch) && isDigit(lookaheadChar())))
                 error("Non-zero numbers may not have a leading zero.")
               base = 10
             }

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -47,17 +47,15 @@ idrest           ::=  {letter | digit} [‘_’ op]
 quoteId          ::=  ‘'’ alphaid
 
 integerLiteral   ::=  (decimalNumeral | hexNumeral) [‘L’ | ‘l’]
-decimalNumeral   ::=  ‘0’ | nonZeroDigit {digit}
-hexNumeral       ::=  ‘0’ (‘x’ | ‘X’) hexDigit {hexDigit}
-digit            ::=  ‘0’ | nonZeroDigit
+decimalNumeral   ::=  ‘0’ | nonZeroDigit [{digit | ‘_’} digit]
+hexNumeral       ::=  ‘0’ (‘x’ | ‘X’) hexDigit [{hexDigit | ‘_’} hexDigit]
 nonZeroDigit     ::=  ‘1’ | … | ‘9’
 
 floatingPointLiteral
-                 ::=  digit {digit} ‘.’ {digit} [exponentPart] [floatType]
-                   |  ‘.’ digit {digit} [exponentPart] [floatType]
-                   |  digit {digit} exponentPart [floatType]
-                   |  digit {digit} [exponentPart] floatType
-exponentPart     ::=  (‘E’ | ‘e’) [‘+’ | ‘-’] digit {digit}
+                 ::=  [decimalNumeral] ‘.’ digit [{digit | ‘_’} digit] [exponentPart] [floatType]
+                   |  decimalNumeral exponentPart [floatType]
+                   |  decimalNumeral floatType
+exponentPart     ::=  (‘E’ | ‘e’) [‘+’ | ‘-’] digit [{digit | ‘_’} digit]
 floatType        ::=  ‘F’ | ‘f’ | ‘D’ | ‘d’
 
 booleanLiteral   ::=  ‘true’ | ‘false’

--- a/tests/neg/t6124.check
+++ b/tests/neg/t6124.check
@@ -54,6 +54,22 @@
 26 |  val x8 = 0x52_ // error
    |              ^
    |              trailing separator is not allowed
+-- Error: tests/neg/t6124.scala:27:11 ----------------------------------------------------------------------------------
+27 |  val x9 = 0_52 // error
+   |           ^
+   |           Non-zero numbers may not have a leading zero.
+-- Error: tests/neg/t6124.scala:28:12 ----------------------------------------------------------------------------------
+28 |  val x10 = 052 // error
+   |            ^
+   |            Non-zero numbers may not have a leading zero.
+-- Error: tests/neg/t6124.scala:29:12 ----------------------------------------------------------------------------------
+29 |  val x11 = 0_0.52 // error
+   |            ^
+   |            Non-zero numbers may not have a leading zero.
+-- Error: tests/neg/t6124.scala:30:12 ----------------------------------------------------------------------------------
+30 |  val x12 = 00.52 // error
+   |            ^
+   |            Non-zero numbers may not have a leading zero.
 -- Error: tests/neg/t6124.scala:12:17 ----------------------------------------------------------------------------------
 12 |  def tooSmall = 1.0E-325 // error
    |                 ^^^^^^^^

--- a/tests/neg/t6124.scala
+++ b/tests/neg/t6124.scala
@@ -24,6 +24,10 @@ trait T {
   val x5 = 0_x52 // error
   val x6 = 0x_52 // error
   val x8 = 0x52_ // error
+  val x9 = 0_52 // error
+  val x10 = 052 // error
+  val x11 = 0_0.52 // error
+  val x12 = 00.52 // error
 
   def z = 0
 }


### PR DESCRIPTION
fixes #7440 

Also patches the syntax document to account for numeric separators.