### PR TITLE
Fix LazyRef#ref error recovery

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2509,7 +2509,7 @@ object Types {
           // if errors were reported previously handle this by throwing a CyclicReference
           // instead of crashing immediately. A test case is neg/i6057.scala.
           assert(ctx.reporter.errorsReported)
-          CyclicReference(NoDenotation)
+          throw CyclicReference(NoDenotation)
         }
       }
       else {


### PR DESCRIPTION
The `throw` keyword was missing, so the call to `CyclicReference` did
not actually do anything. This means that LazyRef#ref could return null
when typechecking broken code, which could lead to a
NullPointerException (I observed this while compiling some code but
didn't manage to minimize it).