### PR TITLE
Fully compile primitive value classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -270,11 +270,12 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
       parents = impl.parents.map(p => TypeTree(p.tpe).withSpan(p.span)),
       body =
         if (cls.is(Trait)) traitDefs(impl.body)
-        else {
+        else if (!cls.isPrimitiveValueClass) {
           val mixInits = mixins.flatMap { mixin =>
             flatten(traitInits(mixin)) ::: superCallOpt(mixin) ::: setters(mixin) ::: mixinForwarders(mixin)
           }
           superCallOpt(superCls) ::: mixInits ::: impl.body
-        })
+        }
+        else impl.body)
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -86,7 +86,7 @@ class FrontEnd extends Phase {
   }
 
   protected def discardAfterTyper(unit: CompilationUnit)(implicit ctx: Context): Boolean =
-    unit.isJava || firstTopLevelDef(unit.tpdTree :: Nil).isPrimitiveValueClass
+    unit.isJava
 
   override def runOn(units: List[CompilationUnit])(implicit ctx: Context): List[CompilationUnit] = {
     val unitContexts = for (unit <- units) yield {

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -790,7 +790,14 @@ object RefChecks {
           case Nil =>
             ctx.error(OverridesNothing(member), member.sourcePos)
           case ms =>
-            ctx.error(OverridesNothingButNameExists(member, ms), member.sourcePos)
+            // getClass in primitive value classes is defined in the standard library as:
+            //     override def getClass(): Class[Int] = ???
+            // However, it's not actually an override in Dotty because our Any#getClass
+            // is polymorphic (see `Definitions#Any_getClass`), so since we can't change
+            // the standard library, we need to drop the override flag without reporting
+            // an error.
+            if (!(member.name == nme.getClass_ && clazz.isPrimitiveValueClass))
+              ctx.error(OverridesNothingButNameExists(member, ms), member.sourcePos)
         }
         member.resetFlag(Override)
         member.resetFlag(AbsOverride)


### PR DESCRIPTION
We used to drop compilation units for primitives after frontend, but
this meant that a standard library compiled by dotty was not usable by
dotty, because the primitive value classes were missing from the
classpath: even though these classes are never loaded at runtime,
they're unpickled at compile-time.

Getting this to work required two changes: silence an error in
refchecks (see comment) and turn off some computations in mixins that
require cls.superClass to exist (primitives have no superclasses after
erasure)