### PR TITLE
Revert "Revert "Upgrade to ASM 7.0""

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/AsmUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/AsmUtils.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package backend
 package jvm
 
-import scala.tools.asm.tree.{AbstractInsnNode, ClassNode, MethodNode}
+import scala.tools.asm.tree.{AbstractInsnNode}
 import java.io.PrintWriter
 import scala.tools.asm.util.{TraceClassVisitor, TraceMethodVisitor, Textifier}
 import scala.tools.asm.ClassReader
@@ -31,7 +31,7 @@ object AsmUtils {
   final val traceSerializedClassEnabled = false
   final val traceSerializedClassPattern = ""
 
-  def traceMethod(mnode: MethodNode): Unit = {
+  def traceMethod(mnode: MethodNode1): Unit = {
     println(s"Bytecode for method ${mnode.name}")
     val p = new Textifier
     val tracer = new TraceMethodVisitor(p)
@@ -41,7 +41,7 @@ object AsmUtils {
     w.flush()
   }
 
-  def traceClass(cnode: ClassNode): Unit = {
+  def traceClass(cnode: ClassNode1): Unit = {
     println(s"Bytecode for class ${cnode.name}")
     val w = new PrintWriter(System.out)
     cnode.accept(new TraceClassVisitor(w))
@@ -50,8 +50,8 @@ object AsmUtils {
 
   def traceClass(bytes: Array[Byte]): Unit = traceClass(readClass(bytes))
 
-  def readClass(bytes: Array[Byte]): ClassNode = {
-    val node = new ClassNode()
+  def readClass(bytes: Array[Byte]): ClassNode1 = {
+    val node = new ClassNode1()
     new ClassReader(bytes).accept(node, 0)
     node
   }

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -53,7 +53,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
     final val MaximumJvmParameters = 254
 
     // current class
-    var cnode: asm.tree.ClassNode  = null
+    var cnode: ClassNode1          = null
     var thisName: String           = null // the internal name of the class being emitted
 
     var claszSymbol: Symbol        = null
@@ -88,7 +88,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
       isCZStaticModule  = claszSymbol.isStaticModuleClass
       thisName          = internalName(claszSymbol)
 
-      cnode = new asm.tree.ClassNode()
+      cnode = new ClassNode1()
 
       initJClass(cnode)
 
@@ -248,7 +248,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
     } // end of method addClassFields()
 
     // current method
-    var mnode: asm.tree.MethodNode = null
+    var mnode: MethodNode1         = null
     var jMethodName: String        = null
     var isMethSymStaticCtor        = false
     var returnType: BType          = null
@@ -526,7 +526,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
         mdesc,
         jgensig,
         mkArrayS(thrownExceptions)
-      ).asInstanceOf[asm.tree.MethodNode]
+      ).asInstanceOf[MethodNode1]
 
       // TODO param names: (m.params map (p => javaName(p.sym)))
 

--- a/compiler/src/dotty/tools/backend/jvm/BytecodeWriters.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BytecodeWriters.scala
@@ -82,7 +82,7 @@ trait BytecodeWriters {
     private def emitAsmp(jclassBytes: Array[Byte], asmpFile: dotty.tools.io.File): Unit = {
       val pw = asmpFile.printWriter()
       try {
-        val cnode = new asm.tree.ClassNode()
+        val cnode = new ClassNode1()
         val cr    = new asm.ClassReader(jclassBytes)
         cr.accept(cnode, 0)
         val trace = new scala.tools.asm.util.TraceClassVisitor(new java.io.PrintWriter(new java.io.StringWriter()))

--- a/compiler/src/dotty/tools/backend/jvm/ClassNode1.java
+++ b/compiler/src/dotty/tools/backend/jvm/ClassNode1.java
@@ -1,0 +1,39 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package dotty.tools.backend.jvm;
+
+import scala.tools.asm.MethodVisitor;
+import scala.tools.asm.Opcodes;
+import scala.tools.asm.tree.ClassNode;
+import scala.tools.asm.tree.MethodNode;
+
+/**
+ * A subclass of {@link ClassNode} to customize the representation of
+ * label nodes with {@link LabelNode1}.
+ */
+public class ClassNode1 extends ClassNode {
+    public ClassNode1() {
+        this(Opcodes.ASM6);
+    }
+
+    public ClassNode1(int api) {
+        super(api);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+        MethodNode method = new MethodNode1(access, name, descriptor, signature, exceptions);
+        methods.add(method);
+        return method;
+    }
+}

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -7,7 +7,6 @@ import dotty.tools.dotc.core.Phases.Phase
 
 import scala.collection.mutable
 import scala.collection.JavaConverters._
-import scala.tools.asm.CustomAttr
 import dotty.tools.dotc.transform.SymUtils._
 import dotty.tools.dotc.interfaces
 import dotty.tools.dotc.util.SourceFile
@@ -241,7 +240,7 @@ class GenBCodePipeline(val int: DottyBackendInterface)(implicit val ctx: Context
               getFileForClassfile(outF, store.name, ".hasTasty")
               binary
             }
-          val dataAttr = new CustomAttr(nme.TASTYATTR.mangledString, tasty)
+          val dataAttr = createJAttribute(nme.TASTYATTR.mangledString, tasty, 0, tasty.length)
           store.visitAttribute(dataAttr)
         }
 

--- a/compiler/src/dotty/tools/backend/jvm/LabelNode1.java
+++ b/compiler/src/dotty/tools/backend/jvm/LabelNode1.java
@@ -1,0 +1,31 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package dotty.tools.backend.jvm;
+
+import scala.tools.asm.Label;
+import scala.tools.asm.tree.ClassNode;
+import scala.tools.asm.tree.LabelNode;
+
+/**
+ * A subclass of {@link LabelNode} to add user-definable flags.
+ */
+public class LabelNode1 extends LabelNode {
+    public LabelNode1() {
+    }
+
+    public LabelNode1(Label label) {
+        super(label);
+    }
+
+    public int flags;
+}

--- a/compiler/src/dotty/tools/backend/jvm/MethodNode1.java
+++ b/compiler/src/dotty/tools/backend/jvm/MethodNode1.java
@@ -1,0 +1,47 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package dotty.tools.backend.jvm;
+
+import scala.tools.asm.Label;
+import scala.tools.asm.Opcodes;
+import scala.tools.asm.tree.LabelNode;
+import scala.tools.asm.tree.MethodNode;
+/**
+ * A subclass of {@link MethodNode} to customize the representation of
+ * label nodes with {@link LabelNode1}.
+ */
+public class MethodNode1 extends MethodNode {
+    public MethodNode1(int api, int access, String name, String descriptor, String signature, String[] exceptions) {
+        super(api, access, name, descriptor, signature, exceptions);
+    }
+
+    public MethodNode1(int access, String name, String descriptor, String signature, String[] exceptions) {
+        this(Opcodes.ASM6, access, name, descriptor, signature, exceptions);
+    }
+
+    public MethodNode1(int api) {
+        super(api);
+    }
+
+    public MethodNode1() {
+        this(Opcodes.ASM6);
+    }
+
+    @Override
+    protected LabelNode getLabelNode(Label label) {
+        if (!(label.info instanceof LabelNode)) {
+            label.info = new LabelNode1(label);
+        }
+        return (LabelNode) label.info;
+    }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -482,7 +482,7 @@ object Build {
 
       // get libraries onboard
       libraryDependencies ++= Seq(
-        "org.scala-lang.modules" % "scala-asm" % "6.0.0-scala-1", // used by the backend
+        "org.scala-lang.modules" % "scala-asm" % "7.0.0-scala-1", // used by the backend
         Dependencies.`compiler-interface`,
         "org.jline" % "jline-reader" % "3.9.0",   // used by the REPL
         "org.jline" % "jline-terminal" % "3.9.0",


### PR DESCRIPTION
This reverts commit 5a747185826bf2b178389b6f48880eb2e5d252a7 which
itself reverted 0abd0769bf27682e1bd62e9532afdafce2c92dfb.

Since #5936 is not fixed yet, we need to turn off one test in semanticdb
which uses parens in a class name.