### PR TITLE
Don't run the Java 11 CI tests on open PRs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -75,7 +75,6 @@ steps:
   - ./project/scripts/sbt ";compile ;test"
   when:
     event:
-    - push
     - tag
     - promote
 


### PR DESCRIPTION
Java 11 only failures are very rare, so running the CI tests on Java 11
for every commit pushed to an open PR doesn't seem worth it. Instead,
only run these tests on merged commits and release builds.