### PR TITLE
Fix #6938: Expand tuples when synthesizing given names

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -963,7 +963,7 @@ object desugar {
           case Some(DefDef(name, _, (vparam :: _) :: _, _, _)) =>
             s"${name}_of_${inventTypeName(vparam.tpt)}"
           case _ =>
-            ctx.error(i"anonymous instance must have `as` part or must define at least one extension method", impl.sourcePos)
+            ctx.error(i"anonymous instance must implement a type or have at least one extension method", impl.sourcePos)
             nme.ERROR.toString
         }
       else
@@ -986,7 +986,7 @@ object desugar {
           case tree: LambdaTypeTree =>
             apply(x, tree.body)
           case tree: Tuple =>
-            if (followArgs) extractArgs(tree.trees) else "Tuple"
+            extractArgs(tree.trees)
           case tree: Function if tree.args.nonEmpty =>
             if (followArgs) s"${extractArgs(tree.args)}_to_${apply("", tree.body)}" else "Function"
           case _ => foldOver(x, tree)

--- a/docs/docs/reference/contextual/delegates.md
+++ b/docs/docs/reference/contextual/delegates.md
@@ -45,7 +45,7 @@ given Ord[Int] { ... }
 given [T](given Ord[T]): Ord[List[T]] { ... }
 ```
 If the name of a given is missing, the compiler will synthesize a name from
-the type(s) in the `as` clause.
+the implemented type(s).
 
 ## Alias Givens
 

--- a/docs/docs/reference/contextual/relationship-implicits.md
+++ b/docs/docs/reference/contextual/relationship-implicits.md
@@ -59,6 +59,9 @@ The synthesized type names are formed from
  - the simple name(s) of the implemented type(s), leaving out any prefixes,
  - the simple name(s) of the toplevel argument type constructors to these types.
 
+Tuples are treated as transparent, i.e. a type `F[(X, Y)]` would get the synthesized name
+`F_X_Y`. Directly implemented function types `A => B` are represented as `A_to_B`. Function types used as arguments to other type constructors are represented as `Function`.
+
 Anonymous given instances that define extension methods without also implementing a type
 get their name from the name of the first extension method and the toplevel type
 constructor of its first parameter. For example, the given instance

--- a/tests/pos/i6938.scala
+++ b/tests/pos/i6938.scala
@@ -1,0 +1,5 @@
+trait Foo[T]
+object Foo with
+  given [T]: Foo[Tuple1[T]]
+  given [T, U]: Foo[(T, U)]
+  given [T, U, V]: Foo[(T, U, V)]


### PR DESCRIPTION
Also: Add more explanations on how names are synthesized.