### PR TITLE
Port 'unknown named enclosing class or object' error to new scheme

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
@@ -146,7 +146,8 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     StableIdentPatternID,
     StaticFieldsShouldPrecedeNonStaticID,
     IllegalSuperAccessorID,
-    TraitParameterUsedAsParentPrefixID
+    TraitParameterUsedAsParentPrefixID,
+    UnknownNamedEnclosingClassOrObjectID
 
   def errorNumber = ordinal - 2
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2378,4 +2378,18 @@ object messages {
           |than obtaining it from the parameters of ${cls.show}.
           |""".stripMargin
   }
+
+  case class UnknownNamedEnclosingClassOrObject(name: TypeName)(implicit val ctx: Context)
+    extends Message(UnknownNamedEnclosingClassOrObjectID) {
+    val kind: String = "Reference"
+    val msg: String =
+      em"""no enclosing class or object is named '${hl(name.show)}'"""
+    val explanation: String =
+      ex"""
+      |The class or object named '${hl(name.show)}' was used a visibility
+      |modifier, but could not be resolved. Make sure that
+      |'${hl(name.show)}' is not misspelled and has been imported into the
+      |current scope.
+      """.stripMargin
+    }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2386,7 +2386,7 @@ object messages {
       em"""no enclosing class or object is named '${hl(name.show)}'"""
     val explanation: String =
       ex"""
-      |The class or object named '${hl(name.show)}' was used a visibility
+      |The class or object named '${hl(name.show)}' was used as a visibility
       |modifier, but could not be resolved. Make sure that
       |'${hl(name.show)}' is not misspelled and has been imported into the
       |current scope.

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -254,7 +254,7 @@ class Namer { typer: Typer =>
     else {
       val cls = ctx.owner.enclosingClassNamed(name)
       if (!cls.exists)
-        ctx.error(s"no enclosing class or object is named $name", ctx.source.atSpan(span))
+        ctx.error(UnknownNamedEnclosingClassOrObject(name), ctx.source.atSpan(span))
       cls
     }
 

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1657,4 +1657,19 @@ class ErrorMessagesTests extends ErrorMessagesTest {
           messages.head.msg
         )
     }
+
+  @Test def unknownNamedEnclosingClassOrObject() =
+    checkMessagesAfter(RefChecks.name) {
+      """
+        |class TestObject {
+        |  private[doesNotExist] def test: Int = 5
+        |}
+      """.stripMargin
+    }
+    .expect { (ictx, messages) =>
+      implicit val ctx: Context = ictx
+      assertMessageCount(1, messages)
+      val UnknownNamedEnclosingClassOrObject(name) :: Nil = messages
+      assertEquals("doesNotExist", name.show)
+    }
 }


### PR DESCRIPTION
Part of the effort documented in #1589 to port all error messages to
the new scheme.

This is my first dotty PR 🎉 Feedback very welcome!