### PR TITLE
Lazy strategy for evaluating flags on denotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -54,6 +54,12 @@ object Flags {
     def (x: FlagSet) ^ (y: FlagSet) =
       FlagSet((x.bits | y.bits) & KINDFLAGS | (x.bits ^ y.bits) & ~KINDFLAGS)
 
+    def (x: FlagSet) partitionByIntersection(y: FlagSet): (FlagSet, FlagSet) =
+      val intersection = x & y
+      val complement = x &~ y
+      (intersection, complement)
+
+
     /** Does the given flag set contain the given flag?
      *  This means that both the kind flags and the carrier bits have non-empty intersection.
      */

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -184,10 +184,16 @@ object SymDenotations {
         if (myFlags.is(Trait)) NoInitsInterface & bodyFlags // no parents are initialized from a trait
         else NoInits & bodyFlags & parentFlags)
 
+    /** Flags that are immutable at the current stage of
+     *  this denotation's lifecycle.
+     */
+    final def immutableFlags: FlagSet =
+      var result: FlagSet = AfterLoadFlags
+      if (myInfo.isInstanceOf[SymbolLoader]) result = FromStartFlags
+      result
+
     private def isCurrent(fs: FlagSet) =
-      fs <= (
-        if (myInfo.isInstanceOf[SymbolLoader]) FromStartFlags
-        else AfterLoadFlags)
+      fs <= immutableFlags
 
     final def relevantFlagsFor(fs: FlagSet)(implicit ctx: Context) =
       if (isCurrent(fs)) myFlags else flags


### PR DESCRIPTION
Make sure that we complete denotations only in case
we absolutely must to when evaluating predicates on flags.