### PR TITLE
Remove Touched from FromStartFlags

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -439,7 +439,7 @@ object Flags {
   val FromStartFlags: FlagSet = commonFlags(
     Module, Package, Deferred, Method, Case,
     HigherKinded, Param, ParamAccessor,
-    Scala2ExistentialCommon, Mutable, Opaque, Touched, JavaStatic,
+    Scala2ExistentialCommon, Mutable, Opaque, JavaStatic,
     OuterOrCovariant, LabelOrContravariant, CaseAccessor,
     Extension, NonMember, Implicit, Given, Permanent, Synthetic,
     SuperAccessorOrScala2x, Inline, Macro)


### PR DESCRIPTION
It is an internal check flag used to track completion of lazy types and detect cyclic references. We cannot really say it is "computed by completion", hence we should not treat it as an ordinary flag wrt completion.