### PR TITLE
escape quote characters in interpolations with $

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -1068,7 +1068,7 @@ object Scanners {
         }
       else if (ch == '$') {
         nextRawChar()
-        if (ch == '$') {
+        if (ch == '$' || ch == '"') {
           putChar(ch)
           nextRawChar()
           getStringPart(multiLine)
@@ -1089,7 +1089,7 @@ object Scanners {
           finishNamed(target = next)
         }
         else
-          error("invalid string interpolation: `$$', `$'ident or `$'BlockExpr expected")
+          error("invalid string interpolation: `$$', `$\"`, `$'ident or `$'BlockExpr expected")
       }
       else {
         val isUnclosedLiteral = !isUnicodeEscape && (ch == SU || (!multiLine && (ch == CR || ch == LF)))

--- a/docs/docs/reference/changed-features/interpolation-escapes.md
+++ b/docs/docs/reference/changed-features/interpolation-escapes.md
@@ -1,0 +1,13 @@
+---
+layout: doc-page
+title: Escapes in interpolations
+---
+
+In Scala 2 there was no straightforward way to represnt a single quote character `"` in a single quoted interpolation. A \ character can't be used for that because interpolators themselves decide how to handle escaping, so the parser doesn't know whether or not the " shold be escaped or used as a terminator.
+
+In Dotty, you can use the `$` meta character of interpolations to escape a `"` character.
+
+```scala
+  val inventor = "Thomas Edison"
+  val interpolation = s"as $inventor said: $"The three great essentials to achieve anything worth while are: Hard work, Stick-to-itiveness, and Common sense.$""
+```

--- a/tests/run/t5856.scala
+++ b/tests/run/t5856.scala
@@ -7,4 +7,5 @@ object Test extends App {
   assert(s"$this.##" == "Test.##")
   assert(s"$this.toString" == "Test.toString")
   assert(s"$this=THIS" == "Test=THIS")
+  assert(raw"$"" == "\"")
 }


### PR DESCRIPTION
Dotty implementation for https://docs.scala-lang.org/sips/interpolation-quote-escape.html