### PR TITLE
Don't move worksheet decoration when adding new line

### DIFF
--- a/vscode-dotty/src/worksheet.ts
+++ b/vscode-dotty/src/worksheet.ts
@@ -194,6 +194,7 @@ class Worksheet implements Disposable {
   private createDecoration(margin: number, text: string) {
     return vscode.window.createTextEditorDecorationType({
       isWholeLine: true,
+      rangeBehavior: vscode.DecorationRangeBehavior.OpenClosed,
       after: {
         contentText: text,
         margin: `0px 0px 0px ${margin}ch`,


### PR DESCRIPTION
Previously, when using worksheets, the evaluated code would move to the
next line when adding a new line. Now, the evaluated code stays on the
original line.
![2019-11-03 09 02 22](https://user-images.githubusercontent.com/1408093/68082781-ae647480-fe18-11e9-9e15-2a85d832f5f3.gif)

