### PR TITLE
Disambiguate quoted and tasty Type

### DIFF
--- a/library/src-bootstrapped/dotty/internal/StringContextMacro.scala
+++ b/library/src-bootstrapped/dotty/internal/StringContextMacro.scala
@@ -354,7 +354,7 @@ object StringContextMacro {
      *  @return reports a type mismatch error if the actual type is not a subtype of any of the possibilities,
      *  nothing otherwise
      */
-    def checkSubtype(actualType : Type, expectedType : String, argIndex : Int, possibilities : Type*) = {
+    def checkSubtype(actualType : Tpe, expectedType : String, argIndex : Int, possibilities : Tpe*) = {
       if (possibilities.find(actualType <:< _).isEmpty)
         reporter.argError("type mismatch;\n found   : " + actualType.widen.show.stripPrefix("scala.Predef.").stripPrefix("java.lang.").stripPrefix("scala.") + "\n required: " + expectedType, argIndex)
     }
@@ -452,7 +452,7 @@ object StringContextMacro {
      *  ’d’: only ’#’ is allowed,
      *  ’o’, ’x’, ’X’: ’-’, ’#’, ’0’ are always allowed, depending on the type, this will be checked in the type check step
      */
-    def checkIntegralConversion(partIndex : Int, argType : Option[Type], conversionChar : Char, flags : List[(Char, Int)], hasPrecision : Boolean, precision : Int) = {
+    def checkIntegralConversion(partIndex : Int, argType : Option[Tpe], conversionChar : Char, flags : List[(Char, Int)], hasPrecision : Boolean, precision : Int) = {
       if (conversionChar == 'd')
         checkFlags(partIndex, flags, ('#', true,  "# not allowed for d conversion"))
 
@@ -526,7 +526,7 @@ object StringContextMacro {
      *  @return reports an error
      *  if '#' flag is used or if any other flag is used
      */
-    def checkGeneralConversion(partIndex : Int, argType : Option[Type], conversionChar : Char, flags : List[(Char, Int)]) = {
+    def checkGeneralConversion(partIndex : Int, argType : Option[Tpe], conversionChar : Char, flags : List[(Char, Int)]) = {
       for {flag <- flags ; if (flag._1 != '-' && flag._1 != '#')}
         reporter.partError("Illegal flag '" + flag._1 + "'", partIndex, flag._2)
     }
@@ -578,7 +578,7 @@ object StringContextMacro {
      *  reports an error/warning if the formatting parameters are not allowed/wrong, nothing otherwise
      */
     def checkFormatSpecifiers(partIndex : Int, hasArgumentIndex : Boolean, actualArgumentIndex : Int, expectedArgumentIndex : Option[Int], firstFormattingSubstring : Boolean, maxArgumentIndex : Option[Int],
-      hasRelative : Boolean, hasWidth : Boolean, width : Int, hasPrecision : Boolean, precision : Int, flags : List[(Char, Int)], conversion : Int, argType : Option[Type], part : String) : (Option[(Type, Int)], Char, List[(Char, Int)])= {
+      hasRelative : Boolean, hasWidth : Boolean, width : Int, hasPrecision : Boolean, precision : Int, flags : List[(Char, Int)], conversion : Int, argType : Option[Tpe], part : String) : (Option[(Tpe, Int)], Char, List[(Char, Int)])= {
       val conversionChar = part.charAt(conversion)
 
       if (hasArgumentIndex && expectedArgumentIndex.nonEmpty && maxArgumentIndex.nonEmpty && firstFormattingSubstring)
@@ -608,7 +608,7 @@ object StringContextMacro {
      *  @param formattingStart the index in the part where the formatting substring starts, i.e. where the '%' is
      *  @return reports an error/warning if the formatting parameters are not allowed/wrong depending on the type, nothing otherwise
      */
-    def checkArgTypeWithConversion(partIndex : Int, conversionChar : Char, argument : Option[(Type, Int)], flags : List[(Char, Int)], formattingStart : Int) = {
+    def checkArgTypeWithConversion(partIndex : Int, conversionChar : Char, argument : Option[(Tpe, Int)], flags : List[(Char, Int)], formattingStart : Int) = {
       if (argument.nonEmpty)
         checkTypeWithArgs(argument.get, conversionChar, partIndex, flags)
       else
@@ -624,7 +624,7 @@ object StringContextMacro {
      *  @return reports an error if the argument type does not correspond with the conversion character,
      *  nothing otherwise
      */
-    def checkTypeWithArgs(argument : (Type, Int), conversionChar : Char, partIndex : Int, flags : List[(Char, Int)]) = {
+    def checkTypeWithArgs(argument : (Tpe, Int), conversionChar : Char, partIndex : Int, flags : List[(Char, Int)]) = {
       val booleans = List(defn.BooleanType, defn.NullType)
       val dates = List(defn.LongType, typeOf[java.util.Calendar], typeOf[java.util.Date])
       val floatingPoints = List(defn.DoubleType, defn.FloatType, typeOf[java.math.BigDecimal])
@@ -687,7 +687,7 @@ object StringContextMacro {
      *  @param maxArgumentIndex an Option containing the maximum argument index possible, None if no args are specified
      *  @return a list with all the elements of the conversion per formatting string
      */
-    def checkPart(part : String, start : Int, argument : Option[(Int, Expr[Any])], maxArgumentIndex : Option[Int]) : List[(Option[(Type, Int)], Char, List[(Char, Int)])] = {
+    def checkPart(part : String, start : Int, argument : Option[(Int, Expr[Any])], maxArgumentIndex : Option[Int]) : List[(Option[(Tpe, Int)], Char, List[(Char, Int)])] = {
       reporter.resetReported()
       val hasFormattingSubstring = getFormattingSubstring(part, part.size, start)
       if (hasFormattingSubstring.nonEmpty) {

--- a/library/src-bootstrapped/scala/quoted/Liftable.scala
+++ b/library/src-bootstrapped/scala/quoted/Liftable.scala
@@ -41,7 +41,7 @@ object Liftable {
     /** Lift a `Class[T]` into `'{ classOf[T] }` */
     def toExpr(x: Class[T]) = (given qctx) => {
       import qctx.tasty.{_, given}
-      Ref(defn.Predef_classOf).appliedToType(Type(x)).seal.asInstanceOf[Expr[Class[T]]]
+      Ref(defn.Predef_classOf).appliedToType(Tpe(x)).seal.asInstanceOf[Expr[Class[T]]]
     }
   }
 

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -1,6 +1,5 @@
 package scala.tasty
 
-import scala.quoted.QuoteContext
 import scala.tasty.reflect._
 
 class Reflection(private[scala] val internal: CompilerInterface)
@@ -24,7 +23,7 @@ class Reflection(private[scala] val internal: CompilerInterface)
     with TreeUtils
     with TypeOrBoundsOps { self =>
 
-  def typeOf[T: scala.quoted.Type]: Type =
+  def typeOf[T: scala.quoted.Type]: Tpe =
     implicitly[scala.quoted.Type[T]].unseal.tpe
 
 }

--- a/library/src/scala/tasty/reflect/ConstantOps.scala
+++ b/library/src/scala/tasty/reflect/ConstantOps.scala
@@ -10,20 +10,20 @@ trait ConstantOps extends Core {
   /** Module of Constant literals */
   object Constant {
 
-    def apply(x: Unit | Null | Int | Boolean | Byte | Short | Int | Long | Float | Double | Char | String | Type): Constant =
+    def apply(x: Unit | Null | Int | Boolean | Byte | Short | Int | Long | Float | Double | Char | String | Tpe): Constant =
       internal.Constant_apply(x)
 
-    def unapply(constant: Constant): Option[Unit | Null | Int | Boolean | Byte | Short | Int | Long | Float | Double | Char | String | Type] =
+    def unapply(constant: Constant): Option[Unit | Null | Int | Boolean | Byte | Short | Int | Long | Float | Double | Char | String | Tpe] =
       internal.matchConstant(constant)
 
     /** Module of ClassTag literals */
     object ClassTag {
       /** scala.reflect.ClassTag literal */
-      def apply[T](given x: Type): Constant =
+      def apply[T](given x: Tpe): Constant =
         internal.Constant_ClassTag_apply(x)
 
       /** Extractor for ClassTag literals */
-      def unapply(constant: Constant): Option[Type] =
+      def unapply(constant: Constant): Option[Tpe] =
         internal.matchConstant_ClassTag(constant)
     }
   }

--- a/library/src/scala/tasty/reflect/Core.scala
+++ b/library/src/scala/tasty/reflect/Core.scala
@@ -66,7 +66,7 @@ package scala.tasty.reflect
  *                   +- NoPrefix
  *  +- TypeOrBounds -+- TypeBounds
  *                   |
- *                   +- Type -------+- ConstantType
+ *                   +- Tpe --------+- ConstantType
  *                                  +- TermRef
  *                                  +- TypeRef
  *                                  +- SuperType
@@ -301,7 +301,7 @@ trait Core {
     type TypeBounds = internal.TypeBounds
 
     /** A type */
-    type Type = internal.Type
+    type Tpe = internal.Type
 
       /** A singleton type representing a known constant value */
       type ConstantType = internal.ConstantType

--- a/library/src/scala/tasty/reflect/ImplicitsOps.scala
+++ b/library/src/scala/tasty/reflect/ImplicitsOps.scala
@@ -2,7 +2,7 @@ package scala.tasty.reflect
 
 trait ImplicitsOps extends Core {
 
-  def searchImplicit(tpe: Type)(given ctx: Context): ImplicitSearchResult =
+  def searchImplicit(tpe: Tpe)(given ctx: Context): ImplicitSearchResult =
     internal.searchImplicit(tpe)
 
   object IsImplicitSearchSuccess {

--- a/library/src/scala/tasty/reflect/QuotedOps.scala
+++ b/library/src/scala/tasty/reflect/QuotedOps.scala
@@ -25,7 +25,7 @@ trait QuotedOps extends Core {
       internal.QuotedExpr_seal(term)
   }
 
-  implicit class TypeToQuotedAPI(tpe: Type) {
+  implicit class TypeToQuotedAPI(tpe: Tpe) {
     /** Convert `Type` to an `quoted.Type[_]` */
     def seal(given ctx: Context): scala.quoted.Type[_] =
       internal.QuotedType_seal(tpe)

--- a/library/src/scala/tasty/reflect/StandardDefinitions.scala
+++ b/library/src/scala/tasty/reflect/StandardDefinitions.scala
@@ -177,51 +177,51 @@ trait StandardDefinitions extends Core {
     */
   trait StandardTypes {
     /** The type of primitive type `Unit`. */
-    def UnitType: Type = internal.Definitions_UnitType
+    def UnitType: Tpe = internal.Definitions_UnitType
 
     /** The type of primitive type `Byte`. */
-    def ByteType: Type = internal.Definitions_ByteType
+    def ByteType: Tpe = internal.Definitions_ByteType
 
     /** The type of primitive type `Short`. */
-    def ShortType: Type = internal.Definitions_ShortType
+    def ShortType: Tpe = internal.Definitions_ShortType
 
     /** The type of primitive type `Char`. */
-    def CharType: Type = internal.Definitions_CharType
+    def CharType: Tpe = internal.Definitions_CharType
 
     /** The type of primitive type `Int`. */
-    def IntType: Type = internal.Definitions_IntType
+    def IntType: Tpe = internal.Definitions_IntType
 
     /** The type of primitive type `Long`. */
-    def LongType: Type = internal.Definitions_LongType
+    def LongType: Tpe = internal.Definitions_LongType
 
     /** The type of primitive type `Float`. */
-    def FloatType: Type = internal.Definitions_FloatType
+    def FloatType: Tpe = internal.Definitions_FloatType
 
     /** The type of primitive type `Double`. */
-    def DoubleType: Type = internal.Definitions_DoubleType
+    def DoubleType: Tpe = internal.Definitions_DoubleType
 
     /** The type of primitive type `Boolean`. */
-    def BooleanType: Type = internal.Definitions_BooleanType
+    def BooleanType: Tpe = internal.Definitions_BooleanType
 
     /** The type of core type `Any`. */
-    def AnyType: Type = internal.Definitions_AnyType
+    def AnyType: Tpe = internal.Definitions_AnyType
 
     /** The type of core type `AnyVal`. */
-    def AnyValType: Type = internal.Definitions_AnyValType
+    def AnyValType: Tpe = internal.Definitions_AnyValType
 
     /** The type of core type `AnyRef`. */
-    def AnyRefType: Type = internal.Definitions_AnyRefType
+    def AnyRefType: Tpe = internal.Definitions_AnyRefType
 
     /** The type of core type `Object`. */
-    def ObjectType: Type = internal.Definitions_ObjectType
+    def ObjectType: Tpe = internal.Definitions_ObjectType
 
     /** The type of core type `Nothing`. */
-    def NothingType: Type = internal.Definitions_NothingType
+    def NothingType: Tpe = internal.Definitions_NothingType
 
     /** The type of core type `Null`. */
-    def NullType: Type = internal.Definitions_NullType
+    def NullType: Tpe = internal.Definitions_NullType
 
     /** The type for `scala.String`. */
-    def StringType: Type = internal.Definitions_StringType
+    def StringType: Tpe = internal.Definitions_StringType
   }
 }

--- a/library/src/scala/tasty/reflect/SymbolOps.scala
+++ b/library/src/scala/tasty/reflect/SymbolOps.scala
@@ -23,10 +23,10 @@ trait SymbolOps extends Core { selfSymbolOps: FlagsOps =>
     def flags(given ctx: Context): Flags = internal.Symbol_flags(self)
 
     /** This symbol is private within the resulting type */
-    def privateWithin(given ctx: Context): Option[Type] = internal.Symbol_privateWithin(self)
+    def privateWithin(given ctx: Context): Option[Tpe] = internal.Symbol_privateWithin(self)
 
     /** This symbol is protected within the resulting type */
-    def protectedWithin(given ctx: Context): Option[Type] = internal.Symbol_protectedWithin(self)
+    def protectedWithin(given ctx: Context): Option[Tpe] = internal.Symbol_protectedWithin(self)
 
     /** The name of this symbol */
     def name(given ctx: Context): String = internal.Symbol_name(self)

--- a/library/src/scala/tasty/reflect/TreeOps.scala
+++ b/library/src/scala/tasty/reflect/TreeOps.scala
@@ -95,7 +95,7 @@ trait TreeOps extends Core {
   }
 
   object DefDef {
-    def apply(symbol: Symbol, rhsFn: List[Type] => List[List[Term]] => Option[Term])(given ctx: Context): DefDef =
+    def apply(symbol: Symbol, rhsFn: List[Tpe] => List[List[Term]] => Option[Term])(given ctx: Context): DefDef =
       internal.DefDef_apply(symbol, rhsFn)
     def copy(original: Tree)(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]], tpt: TypeTree, rhs: Option[Term])(given ctx: Context): DefDef =
       internal.DefDef_copy(original)(name, typeParams, paramss, tpt, rhs)
@@ -169,7 +169,7 @@ trait TreeOps extends Core {
   // ----- Terms ----------------------------------------------------
 
   given (self: Term) {
-    def tpe(given ctx: Context): Type = internal.Term_tpe(self)
+    def tpe(given ctx: Context): Tpe = internal.Term_tpe(self)
     def underlyingArgument(given ctx: Context): Term = internal.Term_underlyingArgument(self)
     def underlying(given ctx: Context): Term = internal.Term_underlying(self)
 
@@ -196,11 +196,11 @@ trait TreeOps extends Core {
       self.appliedToArgs(Nil)
 
     /** The current tree applied to given type argument: `tree[targ]` */
-    def appliedToType(targ: Type)(given ctx: Context): Term =
+    def appliedToType(targ: Tpe)(given ctx: Context): Term =
       self.appliedToTypes(targ :: Nil)
 
     /** The current tree applied to given type arguments: `tree[targ0, ..., targN]` */
-    def appliedToTypes(targs: List[Type])(given ctx: Context): Term =
+    def appliedToTypes(targs: List[Tpe])(given ctx: Context): Term =
       self.appliedToTypeTrees(targs map (Inferred(_)))
 
     /** The current tree applied to given type argument list: `tree[targs(0), ..., targs(targs.length - 1)]` */
@@ -277,7 +277,7 @@ trait TreeOps extends Core {
 
     // TODO rename, this returns an Apply and not a Select
     /** Call an overloaded method with the given type and term parameters */
-    def overloaded(qualifier: Term, name: String, targs: List[Type], args: List[Term])(given ctx: Context): Apply =
+    def overloaded(qualifier: Term, name: String, targs: List[Tpe], args: List[Term])(given ctx: Context): Apply =
       internal.Select_overloaded(qualifier, name, targs, args)
 
     def copy(original: Tree)(qualifier: Term, name: String)(given ctx: Context): Select =
@@ -553,19 +553,19 @@ trait TreeOps extends Core {
 
   object Closure {
 
-    def apply(meth: Term, tpt: Option[Type])(given ctx: Context): Closure =
+    def apply(meth: Term, tpt: Option[Tpe])(given ctx: Context): Closure =
       internal.Closure_apply(meth, tpt)
 
-    def copy(original: Tree)(meth: Tree, tpt: Option[Type])(given ctx: Context): Closure =
+    def copy(original: Tree)(meth: Tree, tpt: Option[Tpe])(given ctx: Context): Closure =
       internal.Closure_copy(original)(meth, tpt)
 
-    def unapply(tree: Tree)(given ctx: Context): Option[(Term, Option[Type])] =
+    def unapply(tree: Tree)(given ctx: Context): Option[(Term, Option[Tpe])] =
       internal.matchClosure(tree).map(x => (x.meth, x.tpeOpt))
   }
 
   given (self: Closure) {
     def meth(given ctx: Context): Term = internal.Closure_meth(self)
-    def tpeOpt(given ctx: Context): Option[Type] = internal.Closure_tpeOpt(self)
+    def tpeOpt(given ctx: Context): Option[Tpe] = internal.Closure_tpeOpt(self)
   }
 
   /** A lambda `(...) => ...` in the source code is represented as
@@ -780,7 +780,7 @@ trait TreeOps extends Core {
     def copy(original: Tree)(qualifier: Term, name: String, levels: Int)(given ctx: Context): SelectOuter =
       internal.SelectOuter_copy(original)(qualifier, name, levels)
 
-    def unapply(tree: Tree)(given ctx: Context): Option[(Term, Int, Type)] = // TODO homogenize order of parameters
+    def unapply(tree: Tree)(given ctx: Context): Option[(Term, Int, Tpe)] = // TODO homogenize order of parameters
       internal.matchSelectOuter(tree).map(x => (x.qualifier, x.level, x.tpe))
 
   }
@@ -818,8 +818,8 @@ trait TreeOps extends Core {
   // ----- TypeTrees ------------------------------------------------
 
   given (self: TypeTree) {
-    /** Type of this type tree */
-    def tpe(given ctx: Context): Type = internal.TypeTree_tpe(self)
+    /** Tpe of this type tree */
+    def tpe(given ctx: Context): Tpe = internal.TypeTree_tpe(self)
   }
 
   object IsTypeTree {
@@ -835,7 +835,7 @@ trait TreeOps extends Core {
 
   /** TypeTree containing an inferred type */
   object Inferred {
-    def apply(tpe: Type)(given ctx: Context): Inferred =
+    def apply(tpe: Tpe)(given ctx: Context): Inferred =
       internal.Inferred_apply(tpe)
     /** Matches a TypeTree containing an inferred type */
     def unapply(tree: Tree)(given ctx: Context): Boolean =

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -8,7 +8,7 @@ object scalatest {
     import qctx.tasty.{_, given}
     import util._
 
-    def isImplicitMethodType(tp: Type): Boolean =
+    def isImplicitMethodType(tp: Tpe): Boolean =
       IsMethodType.unapply(tp).flatMap(tp => if tp.isImplicit then Some(true) else None).nonEmpty
     cond.unseal.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -8,7 +8,7 @@ object scalatest {
     import qctx.tasty.{_, given}
     import util._
 
-    def isImplicitMethodType(tp: Type): Boolean =
+    def isImplicitMethodType(tp: Tpe): Boolean =
       IsMethodType.unapply(tp).flatMap(tp => if tp.isImplicit then Some(true) else None).nonEmpty
 
     cond.unseal.underlyingArgument match {

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -8,7 +8,7 @@ object scalatest {
     import qctx.tasty.{_, given}
     import util._
 
-    def isImplicitMethodType(tp: Type): Boolean =
+    def isImplicitMethodType(tp: Tpe): Boolean =
       IsMethodType.unapply(tp).flatMap(tp => if tp.isImplicit then Some(true) else None).nonEmpty
 
     cond.unseal.underlyingArgument match {

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -8,7 +8,7 @@ object scalatest {
     import qctx.tasty.{_, given}
     import util._
 
-    def isImplicitMethodType(tp: Type): Boolean =
+    def isImplicitMethodType(tp: Tpe): Boolean =
       IsMethodType.unapply(tp).flatMap(tp => if tp.isImplicit then Some(true) else None).nonEmpty
 
     cond.unseal.underlyingArgument match {

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -8,7 +8,7 @@ object scalatest {
     import qctx.tasty.{_, given}
     import util._
 
-    def isImplicitMethodType(tp: Type): Boolean =
+    def isImplicitMethodType(tp: Tpe): Boolean =
       IsMethodType.unapply(tp).flatMap(tp => if tp.isImplicit then Some(true) else None).nonEmpty
 
     cond.unseal.underlyingArgument match {

--- a/tests/run-macros/tasty-simplified/quoted_1.scala
+++ b/tests/run-macros/tasty-simplified/quoted_1.scala
@@ -8,10 +8,10 @@ object Macros {
   def impl[T: Type](given qctx: QuoteContext): Expr[Seq[String]] = {
     import qctx.tasty.{_, given}
 
-    def unpackTuple(tp: Type): List[Type] = {
+    def unpackTuple(tp: Tpe): List[Tpe] = {
       @tailrec
-      def loop(tp: Type, acc: List[Type]): List[Type] = tp.dealias.simplified match {
-        case AppliedType(_, List(IsType(hd), IsType(tl))) =>
+      def loop(tp: Tpe, acc: List[Tpe]): List[Tpe] = tp.dealias.simplified match {
+        case AppliedType(_, List(IsTpe(hd), IsTpe(tl))) =>
           loop(tl, hd.dealias.simplified :: acc)
         case other => acc
       }

--- a/tests/run-with-compiler-custom-args/tasty-interpreter/interpreter/TreeInterpreter.scala
+++ b/tests/run-with-compiler-custom-args/tasty-interpreter/interpreter/TreeInterpreter.scala
@@ -190,10 +190,10 @@ abstract class TreeInterpreter[R <: Reflection & Singleton](val reflect: R) {
     }
   }
 
-  private def isNumericPrimitive(tpe: Type): Boolean =
+  private def isNumericPrimitive(tpe: Tpe): Boolean =
     isIntegralPrimitive(tpe) || isFractionalPrimitive(tpe)
 
-  private def isIntegralPrimitive(tpe: Type): Boolean = {
+  private def isIntegralPrimitive(tpe: Tpe): Boolean = {
     tpe <:< defn.ByteType ||
     tpe <:< defn.CharType ||
     tpe <:< defn.ShortType ||
@@ -201,7 +201,7 @@ abstract class TreeInterpreter[R <: Reflection & Singleton](val reflect: R) {
     tpe <:< defn.LongType
   }
 
-  private def isFractionalPrimitive(tpe: Type): Boolean =
+  private def isFractionalPrimitive(tpe: Tpe): Boolean =
     tpe <:< defn.FloatType || tpe <:< defn.DoubleType
 
 


### PR DESCRIPTION
This ambiguity can be seen in the following code

```scala
import scala.quoted._
def f[T: Type](given qctx: QuoteContext) = {
  import qctx.tasty._
  ...
  summon[Type[T]] // qctx.tasty.Type instead of scala.quoted.Type
  ...
}
```

To avoid the ambiguity we simply rename qctx.tasty.Type to Tpe.

This is the alternative to #7409