### PR TITLE
Fix TreeMap's transformTerm wrt UnApply

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -110,7 +110,7 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
 
   def matchStatement(tree: Tree)(given Context): Option[Statement] = tree match {
     case _: PatternTree => None
-    case tree if tree.isTerm => Some(tree)
+    case tree if tree.isTerm => matchTerm(tree)
     case _ => matchDefinition(tree)
   }
 
@@ -226,6 +226,7 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   type Term = tpd.Tree
 
   def matchTerm(tree: Tree)(given Context): Option[Term] = tree match {
+    case _ if matchTree_Unapply(tree).isDefined => None
     case _: PatternTree => None
     case x: tpd.SeqLiteral => Some(tree)
     case _ if tree.isTerm => Some(tree)

--- a/tests/pos-macros/treemap-unapply/Macro.scala
+++ b/tests/pos-macros/treemap-unapply/Macro.scala
@@ -1,0 +1,8 @@
+import scala.quoted.{ given, _ }
+
+inline def mcr(x: => Unit): Unit = ${mcrImpl('x)}
+def mcrImpl(x: Expr[Unit])(given ctx: QuoteContext): Expr[Unit] =
+  import ctx.tasty.{ given, _ }
+  val tr: Term = x.unseal
+  object m extends TreeMap
+  m.transformTerm(tr).seal.cast[Unit]

--- a/tests/pos-macros/treemap-unapply/Test.scala
+++ b/tests/pos-macros/treemap-unapply/Test.scala
@@ -1,0 +1,4 @@
+@main def Test = mcr {
+  val (a, b) = ???
+  println(s"Foo bar")
+}


### PR DESCRIPTION
UnApply <: Term however it cannot appear where
a term can. Hence we do not transform it from
transformTerm and guard against it getting into
transformTerm to prevent MatchErrors.