### PR TITLE
Change Tasty parameter encoding

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyFormat.scala
@@ -71,7 +71,7 @@ Standard-Section: "ASTs" TopLevelStat*
   TypeParam     = TYPEPARAM      Length NameRef type_Term Modifier*                -- modifiers name bounds
   Param         = PARAM          Length NameRef type_Term rhs_Term? Modifier*      -- modifiers name : type (= rhs_Term)?. `rhsTerm` is present in the case of an aliased class parameter
                   PARAMEND                                                         -- ends a parameter clause
-                  																   -- needed if previous parameter clause is empty or another parameter clause follows
+                                                																   -- needed if previous parameter clause is empty or another parameter clause follows
   Template      = TEMPLATE       Length TypeParam* Param* parent_Term* Self? Stat* -- [typeparams] paramss extends parents { self => stats }, where Stat* always starts with the primary constructor.
   Self          = SELFDEF               selfName_NameRef selfType_Term             -- selfName : selfType
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -494,13 +494,15 @@ class TreePickler(pickler: TastyPickler) {
         case tree: ValDef =>
           pickleDef(VALDEF, tree.symbol, tree.tpt, tree.rhs)
         case tree: DefDef =>
-          def pickleAllParams = {
+          def pickleParamss(paramss: List[List[ValDef]]): Unit = paramss match
+            case Nil =>
+            case params :: rest =>
+              pickleParams(params)
+              if params.isEmpty || rest.nonEmpty then writeByte(PARAMEND)
+              pickleParamss(rest)
+          def pickleAllParams =
             pickleParams(tree.tparams)
-            for (vparams <- tree.vparamss) {
-              writeByte(PARAMS)
-              withLength { pickleParams(vparams) }
-            }
-          }
+            pickleParamss(tree.vparamss)
           pickleDef(DEFDEF, tree.symbol, tree.tpt, tree.rhs, pickleAllParams)
         case tree: TypeDef =>
           pickleDef(TYPEDEF, tree.symbol, tree.rhs)


### PR DESCRIPTION
The new scheme is to drop PARAMS and to have PARAM, TYPEPARAM, and PARAMEND tags instead. 

A PARAMEND is needed to mark a preceding empty parameter section,
or a following parameter section.

The advantage of the new scheme is that it also accommodates a possible generalisation of the language that allows interspersed type params and normal params as well as curried type params.
If we ever want to allow this, we can simply relax the posisble order of these sections; no new tags would be needed.

Bumps Tasty version.