### PR TITLE
Fix #7472: Pass correct context in Child.later

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -154,12 +154,12 @@ object Annotations {
 
       /** A deferred annotation to the result of a given child computation */
       def later(delayedSym: (given Context) => Symbol, span: Span)(implicit ctx: Context): Annotation = {
-        def makeChildLater(implicit ctx: Context) = {
+        def makeChildLater(given ctx: Context) = {
           val sym = delayedSym
           New(defn.ChildAnnot.typeRef.appliedTo(sym.owner.thisType.select(sym.name, sym)), Nil)
             .withSpan(span)
         }
-        deferred(defn.ChildAnnot)(makeChildLater(ctx))
+        deferred(defn.ChildAnnot)(makeChildLater)
       }
 
       /** A regular, non-deferred Child annotation */

--- a/compiler/test-resources/repl/7472
+++ b/compiler/test-resources/repl/7472
@@ -1,0 +1,4 @@
+scala> val list = List(1, 2, 3)
+val list: List[Int] = List(1, 2, 3)
+scala> list.foldLeft(List.empty[Int]){ case (acc, n) => n :: acc }
+val res0: List[Int] = List(3, 2, 1)


### PR DESCRIPTION
There was an ovsersight when converting to IFTs.