### PR TITLE
Syntax change for single cases

### DIFF
--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -147,7 +147,8 @@ FunArgTypes       ::=  InfixType
                     |  ‘(’ [ ‘[given]’ FunArgType {‘,’ FunArgType } ] ‘)’
                     |  ‘(’ ‘[given]’ TypedFunParam {‘,’ TypedFunParam } ‘)’
 TypedFunParam     ::=  id ‘:’ Type
-MatchType         ::=  InfixType `match` TypeCaseClauses
+MatchType         ::=  InfixType `match`
+                       (‘{’ TypeCaseClauses ‘}’ | TypeCaseClause)
 InfixType         ::=  RefinedType {id [nl] RefinedType}                        InfixOp(t1, op, t2)
 RefinedType       ::=  WithType {[nl | ‘with’] Refinement}                      RefinedTypeTree(t, ds)
 WithType          ::=  AnnotType {‘with’ AnnotType}                             (deprecated)
@@ -198,12 +199,12 @@ Expr1             ::=  ‘if’ ‘(’ Expr ‘)’ {nl}
                     |  [SimpleExpr ‘.’] id ‘=’ Expr                             Assign(expr, expr)
                     |  SimpleExpr1 ArgumentExprs ‘=’ Expr                       Assign(expr, expr)
                     |  Expr2
-                    |  [‘inline’] Expr2 ‘match’ ‘{’ CaseClauses ‘}’             Match(expr, cases) -- point on match
-                    |  ‘given’ ‘match’ ‘{’ ImplicitCaseClauses ‘}’
+                    |  [‘inline’] Expr2 ‘match’
+                       (‘{’ CaseClauses ‘}’ | CaseClause)                       Match(expr, cases) -- point on match
 Expr2             ::=  PostfixExpr [Ascription]
 Ascription        ::=  ‘:’ InfixType                                            Typed(expr, tp)
                     |  ‘:’ Annotation {Annotation}                              Typed(expr, Annotated(EmptyTree, annot)*)
-Catches           ::=  ‘catch’ Expr
+Catches           ::=  ‘catch’ (Expr | CaseClause)
 PostfixExpr       ::=  InfixExpr [id]                                           PostfixOp(expr, op)
 InfixExpr         ::=  PrefixExpr
                     |  InfixExpr id [nl] InfixExpr                              InfixOp(expr, op, expr)

--- a/tests/neg/case-semi.scala
+++ b/tests/neg/case-semi.scala
@@ -1,0 +1,9 @@
+object Test with
+  type X = Int
+  val x: X = 1
+
+  type T2 = X match { case Int => String case String => Int }
+  x match { case 1 => 3; case 2 => 4 }
+  x match { case 1 => 3 case 2 => 4 }
+
+  type T1 = X match { case Int => String; case String => Int } // error // error

--- a/tests/pos/single-case.scala
+++ b/tests/pos/single-case.scala
@@ -1,0 +1,11 @@
+object test with
+
+  type T[X] = X match case Int => X
+
+  try
+    println("hi")
+  catch case ex: java.io.IOException => println("ho")
+
+  1 match case x: Int => println(x)
+
+

--- a/tests/run-macros/tasty-tree-map/quoted_2.scala
+++ b/tests/run-macros/tasty-tree-map/quoted_2.scala
@@ -42,7 +42,7 @@ object Test {
     println(identityMaped({ val x: Int | Any = 60; x }))
     println(identityMaped({ def f(x: => Int): Int = x; f(61) }))
     println(identityMaped({ type T[X] = X; val x: T[Int] = 62; x }))
-    println(identityMaped({ type T[X] = X match { case Int => String; case String => Int }; val x: T[String] = 63; x }))
+    println(identityMaped({ type T[X] = X match { case Int => String case String => Int }; val x: T[String] = 63; x }))
     println(identityMaped((Nil: List[Int]) match { case _: List[t] => 64 }))
     println(identityMaped({ object F { type T = Int }; val x: F.T = 65; x }))
     println(identityMaped({ val x: Foo { type T = Int } = new Foo { type T = Int; def y: Int = 66 }; x.y }))


### PR DESCRIPTION
Allow a single case clause after a match or catch without requiring
braces or indent tokens around it. E.g.

    try ...
    catch case ex: Ex => ...

    s match case p => ...

Ratiionale: With indentation syntax, it feels natural to shorten

    try ...
    catch
      case ex: Ex => ...

to

    try ...
    catch case ex: Ex => ...