### PR TITLE
Fix #7195: Use superscripts instead of `'` for duplicated types

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -132,7 +132,22 @@ object Formatting {
         alts = entry :: existing
         update(key, alts)
       }
-      str + "'" * (alts.length - 1)
+      val suffix = alts.length match {
+        case 1 => ""
+        case n => n.toString.toCharArray.map {
+          case '0' => '⁰'
+          case '1' => '¹'
+          case '2' => '²'
+          case '3' => '³'
+          case '4' => '⁴'
+          case '5' => '⁵'
+          case '6' => '⁶'
+          case '7' => '⁷'
+          case '8' => '⁸'
+          case '9' => '⁹'
+        }.mkString
+      }
+      str + suffix
     }
   }
 

--- a/compiler/test-resources/repl/errmsgs
+++ b/compiler/test-resources/repl/errmsgs
@@ -33,17 +33,17 @@ scala> abstract class C { type T; val x: T; val s: Unit = { type T = String; var
 1 | abstract class C { type T; val x: T; val s: Unit = { type T = String; var y: T = x; locally { def f() = { type T = Int; val z: T = y }; f() } }; }
   |                                                                                  ^
   |Found:    C.this.T(C.this.x)
-  |Required: T'
+  |Required: T²
   |
   |where:    T  is a type in class C
-  |          T' is a type in the initializer of value s which is an alias of String
+  |          T² is a type in the initializer of value s which is an alias of String
 1 | abstract class C { type T; val x: T; val s: Unit = { type T = String; var y: T = x; locally { def f() = { type T = Int; val z: T = y }; f() } }; }
   |                                                                                                                                    ^
   |Found:    T(y)
-  |Required: T'
+  |Required: T²
   |
   |where:    T  is a type in the initializer of value s which is an alias of String
-  |          T' is a type in method f which is an alias of Int
+  |          T² is a type in method f which is an alias of Int
 scala> class Foo() { def bar: Int = 1 }; val foo = new Foo(); foo.barr
 1 | class Foo() { def bar: Int = 1 }; val foo = new Foo(); foo.barr
   |                                                        ^^^^^^^^

--- a/tests/neg/i7195.check
+++ b/tests/neg/i7195.check
@@ -1,0 +1,8 @@
+-- [E007] Type Mismatch Error: tests/neg/i7195.scala:10:8 --------------------------------------------------------------
+10 |  A.foo(??? : T) // error
+   |        ^^^^^^^
+   |        Found:    B.T
+   |        Required: A.T²
+   |
+   |        where:    T  is a type in object B
+   |                  T² is a type in object A

--- a/tests/neg/i7195.scala
+++ b/tests/neg/i7195.scala
@@ -1,0 +1,13 @@
+object A {
+  type T
+
+  def foo(a: T) = ()
+
+}
+
+object B {
+  type T
+  A.foo(??? : T) // error
+
+
+}


### PR DESCRIPTION
This makes vscode-scala-syntax (and GitHub) highlight error messages correctly.

Now it will print
```scala
   |        where:    T  is a type in object B
   |                  T² is a type in object A
```
instead of
```scala
   |        where:    T  is a type in object B
   |                  T' is a type in object A
```