### PR TITLE
Fix #7525: Allow static methods having body in JavaParser

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -521,7 +521,7 @@ object JavaParsers {
           val vparams = formalParams()
           if (!isVoid) rtpt = optArrayBrackets(rtpt)
           optThrows()
-          val bodyOk = !inInterface || mods.is(Flags.DefaultMethod) || mods.is(Flags.JavaStatic)
+          val bodyOk = !inInterface || mods.isOneOf(Flags.DefaultMethod | Flags.JavaStatic)
           val body =
             if (bodyOk && in.token == LBRACE)
               methodBody()

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -521,7 +521,7 @@ object JavaParsers {
           val vparams = formalParams()
           if (!isVoid) rtpt = optArrayBrackets(rtpt)
           optThrows()
-          val bodyOk = !inInterface || (mods.is(Flags.DefaultMethod))
+          val bodyOk = !inInterface || mods.is(Flags.DefaultMethod) || mods.is(Flags.JavaStatic)
           val body =
             if (bodyOk && in.token == LBRACE)
               methodBody()

--- a/tests/pos/i7525/Interface.java
+++ b/tests/pos/i7525/Interface.java
@@ -1,0 +1,5 @@
+// Test static methods in interface can also have body.
+
+public interface Interface {
+  static void s() {}
+}


### PR DESCRIPTION
Related issue: #7525 