### PR TITLE
Fix #7537 "cannot be represented as URI" in JDK 13

### DIFF
--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -179,7 +179,7 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
     if (inPackage == "") ClassPathEntries(packages(inPackage), Nil)
     else ClassPathEntries(packages(inPackage), classes(inPackage))
 
-  def asURLs: Seq[URL] = Seq(dir.toUri.toURL)
+  def asURLs: Seq[URL] = Seq(new URL("jrt:/"))
   // We don't yet have a scheme to represent the JDK modules in our `-classpath`.
   // java models them as entries in the new "module path", we'll probably need to follow this.
   def asClassPathStrings: Seq[String] = Nil


### PR DESCRIPTION
Fix #7537 
Taken from https://github.com/scala/scala/pull/8210.

