### PR TITLE
Fix #6291: Rename Scala2 language setting to Scala2Compat

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -576,7 +576,7 @@ object desugar {
       ensureApplied(nu)
     }
 
-    val copiedAccessFlags = if (ctx.scala2Setting) EmptyFlags else AccessFlags
+    val copiedAccessFlags = if (ctx.scala2CompatSetting) EmptyFlags else AccessFlags
 
     // Methods to add to a case class C[..](p1: T1, ..., pN: Tn)(moreParams)
     //     def _1: T1 = this.p1

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -44,7 +44,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val pageWidth: Setting[Int] = IntSetting("-pagewidth", "Set page width", 80) withAbbreviation "--page-width"
   val strict: Setting[Boolean] = BooleanSetting("-strict", "Use strict type rules, which means some formerly legal code does not typecheck anymore.") withAbbreviation "--strict"
   val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.") withAbbreviation "--language"
-  val rewrite: Setting[Option[Rewrites]] = OptionSetting[Rewrites]("-rewrite", "When used in conjunction with -language:Scala2 rewrites sources to migrate to new syntax") withAbbreviation "--rewrite"
+  val rewrite: Setting[Option[Rewrites]] = OptionSetting[Rewrites]("-rewrite", "When used in conjunction with -language:Scala2Compat rewrites sources to migrate to new syntax") withAbbreviation "--rewrite"
   val silentWarnings: Setting[Boolean] = BooleanSetting("-nowarn", "Silence all warnings.") withAbbreviation "--no-warnings"
   val fromTasty: Setting[Boolean] = BooleanSetting("-from-tasty", "Compile classes from tasty in classpath. The arguments are used as class names.") withAbbreviation "--from-tasty"
 

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -486,7 +486,7 @@ object Denotations {
                   // things, starting with the return type of this method.
                   if (preferSym(sym2, sym1)) info2
                   else if (preferSym(sym1, sym2)) info1
-                  else if (pre.widen.classSymbol.is(Scala2x) || ctx.scala2Mode)
+                  else if (pre.widen.classSymbol.is(Scala2x) || ctx.scala2CompatMode)
                     info1 // follow Scala2 linearization -
                   // compare with way merge is performed in SymDenotation#computeMembersNamed
                   else throw new MergeError(ex.sym1, ex.sym2, ex.tp1, ex.tp2, pre)

--- a/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
+++ b/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
@@ -199,7 +199,7 @@ trait PatternTypeConstrainer { self: TypeComparer =>
       }
     }
 
-    val widePt = if (ctx.scala2Mode || refinementIsInvariant(patternTp)) scrutineeTp else widenVariantParams(scrutineeTp)
+    val widePt = if (ctx.scala2CompatMode || refinementIsInvariant(patternTp)) scrutineeTp else widenVariantParams(scrutineeTp)
     val narrowTp = SkolemType(patternTp)
     trace(i"constraining simple pattern type $narrowTp <:< $widePt", gadts, res => s"$res\ngadt = ${ctx.gadt.debugBoundsDescription}") {
       isSubType(narrowTp, widePt)

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -357,6 +357,7 @@ object StdNames {
     val RootPackage: N          = "RootPackage"
     val RootClass: N            = "RootClass"
     val Scala2: N               = "Scala2"
+    val Scala2Compat: N         = "Scala2Compat"
     val Select: N               = "Select"
     val Shape: N                = "Shape"
     val StringContext: N        = "StringContext"

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -573,7 +573,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
             * am not sure how, since the code is buried so deep in subtyping logic.
             */
             def boundsOK =
-              ctx.scala2Mode ||
+              ctx.scala2CompatMode ||
               tp1.typeParams.corresponds(tp2.typeParams)((tparam1, tparam2) =>
                 isSubType(tparam2.paramInfo.subst(tp2, tp1), tparam1.paramInfo))
             val saved = comparedTypeLambdas
@@ -1730,7 +1730,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
   /** The greatest lower bound of a list types */
   final def glb(tps: List[Type]): Type = tps.foldLeft(AnyType: Type)(glb)
 
-  def widenInUnions(implicit ctx: Context): Boolean = ctx.scala2Mode || ctx.erasedTypes
+  def widenInUnions(implicit ctx: Context): Boolean = ctx.scala2CompatMode || ctx.erasedTypes
 
   /** The least upper bound of two types
    *  @param canConstrain  If true, new constraints might be added to simplify the lub.

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -144,7 +144,7 @@ trait Reporting { this: Context =>
   }
 
   def errorOrMigrationWarning(msg: => Message, pos: SourcePosition = NoSourcePosition): Unit =
-    if (ctx.scala2Mode) migrationWarning(msg, pos) else error(msg, pos)
+    if (ctx.scala2CompatMode) migrationWarning(msg, pos) else error(msg, pos)
 
   def restrictionError(msg: => Message, pos: SourcePosition = NoSourcePosition): Unit =
     reporter.report {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1931,7 +1931,7 @@ object messages {
     extends Message(UnapplyInvalidReturnTypeID) {
     val kind = "Type Mismatch"
     val addendum =
-      if (ctx.scala2Mode && unapplyName == nme.unapplySeq)
+      if (ctx.scala2CompatMode && unapplyName == nme.unapplySeq)
         "\nYou might want to try to rewrite the extractor to use `unapply` instead."
       else ""
     val msg = em"""| ${Red(i"$unapplyResult")} is not a valid result type of an $unapplyName method of an ${Magenta("extractor")}.$addendum"""

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -88,7 +88,7 @@ class NonLocalReturns extends MiniPhase {
 
   override def transformReturn(tree: Return)(implicit ctx: Context): Tree =
     if (isNonLocalReturn(tree)) {
-      if (!ctx.scala2Mode)
+      if (!ctx.scala2CompatMode)
         ctx.strictWarning("Non local returns are deprecated; use scala.util.control.NonLocalReturns instead", tree.sourcePos)
       nonLocalReturnThrow(tree.expr, tree.from.symbol).withSpan(tree.span)
     }

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -167,7 +167,7 @@ object ErrorReporting {
     }
 
     def rewriteNotice: String =
-      if (ctx.scala2Mode) "\nThis patch can be inserted automatically under -rewrite."
+      if (ctx.scala2CompatMode) "\nThis patch can be inserted automatically under -rewrite."
       else ""
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -141,9 +141,9 @@ object Implicits {
               // The reason for leaving out `Predef_conforms` is that we know it adds
               // nothing since it only relates subtype with supertype.
               //
-              // We keep the old behavior under -language:Scala2.
+              // We keep the old behavior under -language:Scala2Compat.
               val isFunctionInS2 =
-                ctx.scala2Mode && tpw.derivesFrom(defn.FunctionClass(1)) && ref.symbol != defn.Predef_conforms
+                ctx.scala2CompatMode && tpw.derivesFrom(defn.FunctionClass(1)) && ref.symbol != defn.Predef_conforms
               val isImplicitConversion = tpw.derivesFrom(defn.ConversionClass)
               // An implementation of <:< counts as a view
               val isConforms = tpw.derivesFrom(defn.SubTypeClass)
@@ -265,7 +265,7 @@ object Implicits {
      */
     override val level: Int =
       if (outerImplicits == null) 1
-      else if (ctx.scala2Mode ||
+      else if (ctx.scala2CompatMode ||
                (ctx.owner eq outerImplicits.ctx.owner) &&
                (ctx.scope eq outerImplicits.ctx.scope) &&
                !refs.head.implicitName.is(LazyImplicitName)) outerImplicits.level
@@ -567,7 +567,7 @@ trait ImplicitRunInfo {
             addPath(pre.cls.sourceModule.termRef)
           case pre: TermRef =>
             if (pre.symbol.is(Package)) {
-              if (ctx.scala2Mode) {
+              if (ctx.scala2CompatMode) {
                 addCompanion(pre, pre.member(nme.PACKAGE).symbol)
                 addPath(pre.prefix)
               }
@@ -1323,7 +1323,7 @@ trait Implicits { self: Typer =>
           case result: SearchFailure if result.isAmbiguous =>
             val deepPt = pt.deepenProto
             if (deepPt ne pt) inferImplicit(deepPt, argument, span)
-            else if (ctx.scala2Mode && !ctx.mode.is(Mode.OldOverloadingResolution))
+            else if (ctx.scala2CompatMode && !ctx.mode.is(Mode.OldOverloadingResolution))
               inferImplicit(pt, argument, span)(ctx.addMode(Mode.OldOverloadingResolution)) match {
                 case altResult: SearchSuccess =>
                   ctx.migrationWarning(
@@ -1502,7 +1502,7 @@ trait Implicits { self: Typer =>
             negateIfNot(tryImplicit(cand, contextual)) match {
               case fail: SearchFailure =>
                 if (fail.isAmbiguous)
-                  if (ctx.scala2Mode) {
+                  if (ctx.scala2CompatMode) {
                     val result = rank(remaining, found, NoMatchingImplicitsFailure :: rfailures)
                     if (result.isSuccess)
                       warnAmbiguousNegation(fail.reason.asInstanceOf[AmbiguousImplicits])

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1151,7 +1151,7 @@ class Namer { typer: Typer =>
               traitReq = parent ne parents.head, stablePrefixReq = true)
           if (pt.derivesFrom(cls)) {
             val addendum = parent match {
-              case Select(qual: Super, _) if ctx.scala2Mode =>
+              case Select(qual: Super, _) if ctx.scala2CompatMode =>
                 "\n(Note that inheriting a class of the same name is no longer allowed)"
               case _ => ""
             }

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -280,7 +280,7 @@ object RefChecks {
             member.name.is(DefaultGetterName) || // default getters are not checked for compatibility
             memberTp.overrides(otherTp,
                 member.matchNullaryLoosely || other.matchNullaryLoosely ||
-                ctx.testScala2Mode(overrideErrorMsg("no longer has compatible type"),
+                ctx.testScala2CompatMode(overrideErrorMsg("no longer has compatible type"),
                    (if (member.owner == clazz) member else clazz).sourcePos))
         catch {
           case ex: MissingType =>
@@ -351,7 +351,7 @@ object RefChecks {
         // Also excluded under Scala2 mode are overrides of default methods of Java traits.
         if (autoOverride(member) ||
             other.owner.isAllOf(JavaInterface) &&
-            ctx.testScala2Mode("`override' modifier required when a Java 8 default method is re-implemented", member.sourcePos))
+            ctx.testScala2CompatMode("`override' modifier required when a Java 8 default method is re-implemented", member.sourcePos))
           member.setFlag(Override)
         else if (member.isType && self.memberInfo(member) =:= self.memberInfo(other))
           () // OK, don't complain about type aliases which are equal
@@ -383,7 +383,7 @@ object RefChecks {
       else if (member.is(ModuleVal) && !other.isRealMethod && !other.isOneOf(Deferred | Lazy))
         overrideError("may not override a concrete non-lazy value")
       else if (member.is(Lazy, butNot = Module) && !other.isRealMethod && !other.is(Lazy) &&
-                 !ctx.testScala2Mode(overrideErrorMsg("may not override a non-lazy value"), member.sourcePos))
+                 !ctx.testScala2CompatMode(overrideErrorMsg("may not override a non-lazy value"), member.sourcePos))
         overrideError("may not override a non-lazy value")
       else if (other.is(Lazy) && !other.isRealMethod && !member.is(Lazy))
         overrideError("must be declared lazy to override a lazy value")

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -301,7 +301,7 @@ class Typer extends Namer
               if (!curOwner.is(Package) || isDefinedInCurrentUnit(defDenot))
                 result = checkNewOrShadowed(found, Definition) // no need to go further out, we found highest prec entry
               else {
-                if (ctx.scala2Mode && !foundUnderScala2.exists)
+                if (ctx.scala2CompatMode && !foundUnderScala2.exists)
                   foundUnderScala2 = checkNewOrShadowed(found, Definition, scala2pkg = true)
                 if (defDenot.symbol.is(Package))
                   result = checkNewOrShadowed(previous orElse found, PackageClause)
@@ -382,8 +382,8 @@ class Typer extends Namer
         if (foundUnderScala2.exists && !(foundUnderScala2 =:= found)) {
           ctx.migrationWarning(
             ex"""Name resolution will change.
-              | currently selected                     : $foundUnderScala2
-              | in the future, without -language:Scala2: $found""", tree.sourcePos)
+              | currently selected                           : $foundUnderScala2
+              | in the future, without -language:Scala2Compat: $found""", tree.sourcePos)
           found = foundUnderScala2
         }
         found
@@ -1909,7 +1909,7 @@ class Typer extends Namer
       case _ =>
         val recovered = typed(qual)(ctx.fresh.setExploreTyperState())
         ctx.errorOrMigrationWarning(OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen), tree.sourcePos)
-        if (ctx.scala2Mode) {
+        if (ctx.scala2CompatMode) {
           // Under -rewrite, patch `x _` to `(() => x)`
           patch(Span(tree.span.start), "(() => ")
           patch(Span(qual.span.end, tree.span.end), ")")
@@ -1930,7 +1930,7 @@ class Typer extends Namer
         else s"use `$prefix<function>$suffix` instead"
       ctx.errorOrMigrationWarning(i"""The syntax `<function> _` is no longer supported;
                                      |you can $remedy""", tree.sourcePos)
-      if (ctx.scala2Mode) {
+      if (ctx.scala2CompatMode) {
         patch(Span(tree.span.start), prefix)
         patch(Span(qual.span.end, tree.span.end), suffix)
       }
@@ -2681,7 +2681,7 @@ class Typer extends Namer
       def isAutoApplied(sym: Symbol): Boolean =
         sym.isConstructor ||
         sym.matchNullaryLoosely ||
-        ctx.testScala2Mode(MissingEmptyArgumentList(sym), tree.sourcePos,
+        ctx.testScala2CompatMode(MissingEmptyArgumentList(sym), tree.sourcePos,
             patch(tree.span.endPos, "()"))
 
       // Reasons NOT to eta expand:

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -173,7 +173,7 @@ class VarianceChecker()(implicit ctx: Context) {
     def checkVariance(sym: Symbol, pos: SourcePosition) = Validator.validateDefinition(sym) match {
       case Some(VarianceError(tvar, required)) =>
         def msg = i"${varianceString(tvar.flags)} $tvar occurs in ${varianceString(required)} position in type ${sym.info} of $sym"
-        if (ctx.scala2Mode &&
+        if (ctx.scala2CompatMode &&
             (sym.owner.isConstructor || sym.ownersIterator.exists(_.isAllOf(ProtectedLocal))))
           ctx.migrationWarning(
             s"According to new variance rules, this is no longer accepted; need to annotate with @uncheckedVariance:\n$msg",

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -36,7 +36,7 @@ class CompilationTests extends ParallelTesting {
     implicit val testGroup: TestGroup = TestGroup("compilePos")
     aggregateTests(
       compileFile("tests/pos/nullarify.scala", defaultOptions.and("-Ycheck:nullarify")),
-      compileFile("tests/pos-scala2/rewrites.scala", scala2Mode.and("-rewrite")).copyToTarget(),
+      compileFile("tests/pos-scala2/rewrites.scala", scala2CompatMode.and("-rewrite")).copyToTarget(),
       compileFile("tests/pos-special/utf8encoded.scala", explicitUTF8),
       compileFile("tests/pos-special/utf16encoded.scala", explicitUTF16),
       compileFile("tests/pos-special/completeFromSource/Test.scala", defaultOptions.and("-sourcepath", "tests/pos-special")),
@@ -48,7 +48,7 @@ class CompilationTests extends ParallelTesting {
       compileFilesInDir("tests/pos-special/strawman-collections", defaultOptions),
       compileFilesInDir("tests/pos-special/isInstanceOf", allowDeepSubtypes.and("-Xfatal-warnings")),
       compileFilesInDir("tests/new", defaultOptions),
-      compileFilesInDir("tests/pos-scala2", scala2Mode),
+      compileFilesInDir("tests/pos-scala2", scala2CompatMode),
       compileFilesInDir("tests/pos", defaultOptions),
       compileFilesInDir("tests/pos-deep-subtype", allowDeepSubtypes),
       compileFile(
@@ -118,9 +118,9 @@ class CompilationTests extends ParallelTesting {
       compileDir("tests/neg-custom-args/impl-conv", defaultOptions.and("-Xfatal-warnings", "-feature")),
       compileFile("tests/neg-custom-args/implicit-conversions.scala", defaultOptions.and("-Xfatal-warnings", "-feature")),
       compileFile("tests/neg-custom-args/implicit-conversions-old.scala", defaultOptions.and("-Xfatal-warnings", "-feature")),
-      compileFile("tests/neg-custom-args/i3246.scala", scala2Mode),
-      compileFile("tests/neg-custom-args/overrideClass.scala", scala2Mode),
-      compileFile("tests/neg-custom-args/ovlazy.scala", scala2Mode.and("-migration", "-Xfatal-warnings")),
+      compileFile("tests/neg-custom-args/i3246.scala", scala2CompatMode),
+      compileFile("tests/neg-custom-args/overrideClass.scala", scala2CompatMode),
+      compileFile("tests/neg-custom-args/ovlazy.scala", scala2CompatMode.and("-migration", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/autoTuplingTest.scala", defaultOptions.and("-language:noAutoTupling")),
       compileFile("tests/neg-custom-args/nopredef.scala", defaultOptions.and("-Yno-predef")),
       compileFile("tests/neg-custom-args/noimports.scala", defaultOptions.and("-Yno-imports")),

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -63,7 +63,7 @@ object TestConfiguration {
   )
   val picklingWithCompilerOptions =
     picklingOptions.withClasspath(withCompilerClasspath).withRunClasspath(withCompilerClasspath)
-  val scala2Mode = defaultOptions and "-language:Scala2"
+  val scala2CompatMode = defaultOptions and "-language:Scala2Compat"
   val explicitUTF8 = defaultOptions and ("-encoding", "UTF8")
   val explicitUTF16 = defaultOptions and ("-encoding", "UTF16")
 }

--- a/doc-tool/test/dotty/tools/dottydoc/GenDocs.scala
+++ b/doc-tool/test/dotty/tools/dottydoc/GenDocs.scala
@@ -22,7 +22,7 @@ trait LocalResources extends DocDriver {
   def withClasspath(files: Array[String]) =
     "-siteroot" +: "../docs" +:
     "-project" +: "Dotty" +:
-    "-language:Scala2" +:
+    "-language:Scala2Compat" +:
     "-classpath" +:
     TestConfiguration.basicClasspath +:
     files

--- a/docs/blog/_posts/2016-02-17-scaling-dot-soundness.md
+++ b/docs/blog/_posts/2016-02-17-scaling-dot-soundness.md
@@ -144,7 +144,7 @@ arithmetic.
 To ease the transition, we will continue for a while to allow unrestricted type
 projections under a flag, even though they are potentially
 unsound. In the current Dotty compiler, that flag is a language import
-`-language:Scala2`, but it could be something different for other
+`-language:Scala2Compat`, but it could be something different for other
 compilers, e.g. `-unsafe`.  Maybe we can find rules that are less
 restrictive than the ones we have now, and are still sound.  But one
 aspect should be non-negotiable: Any fundamental deviations from the

--- a/docs/docs/reference/changed-features/vararg-patterns.md
+++ b/docs/docs/reference/changed-features/vararg-patterns.md
@@ -36,5 +36,5 @@ The change to the grammar is:
 
 ## Compatibility considerations
 
-Under the `-language:Scala2` option, Dotty will accept both the old and the new syntax.
+Under the `-language:Scala2Compat` option, Dotty will accept both the old and the new syntax.
 A migration warning will be emitted when the old syntax is encountered.

--- a/docs/docs/reference/dropped-features/auto-apply.md
+++ b/docs/docs/reference/dropped-features/auto-apply.md
@@ -75,7 +75,7 @@ requirement.
 ### Migrating code
 
 Existing Scala code with inconsistent parameters can still be compiled
-in Dotty under `-language:Scala2`. When paired with the `-rewrite`
+in Dotty under `-language:Scala2Compat`. When paired with the `-rewrite`
 option, the code will be automatically rewritten to conform to Dotty's
 stricter checking.
 

--- a/docs/docs/reference/dropped-features/procedure-syntax.md
+++ b/docs/docs/reference/dropped-features/procedure-syntax.md
@@ -12,7 +12,7 @@ has been dropped. You need to write one of the following instead:
 def f() = { ... }
 def f(): Unit = { ... }
 ```
-Dotty will accept the old syntax under the `-language:Scala2` option.
+Dotty will accept the old syntax under the `-language:Scala2Compat` option.
 If the `-migration` option is set, it can even rewrite old syntax to new.
 The [ScalaFix](https://scalacenter.github.io/scalafix/) tool also
 can rewrite procedure syntax to make it Dotty-compatible.

--- a/docs/docs/reference/features-classification.md
+++ b/docs/docs/reference/features-classification.md
@@ -77,7 +77,7 @@ These constructs are restricted to make the language safer.
  - [@infix and @alpha](https://github.com/lampepfl/dotty/pull/5975)
  make method application syntax uniform across code bases and require alphanumeric aliases for all symbolic names (proposed, not implemented).
 
-Unrestricted implicit conversions continue to be available in Scala 3.0, but will be deprecated and removed later. Unrestricted versions of the other constructs in the list above are available only under `-language:Scala2`.
+Unrestricted implicit conversions continue to be available in Scala 3.0, but will be deprecated and removed later. Unrestricted versions of the other constructs in the list above are available only under `-language:Scala2Compat`.
 
 **Status: now or never**
 
@@ -108,7 +108,7 @@ The date when these constructs are dropped varies. The current status is:
 
  - Not implemented at all:
    - DelayedInit, existential types, weak conformance.
- - Supported under `-language:Scala2`:
+ - Supported under `-language:Scala2Compat`:
    - procedure syntax, class shadowing, symbol literals, auto application, auto tupling in a restricted form.
  - Supported in 3.0, to be deprecated and phased out later:
    - XML literals, compound types.
@@ -133,7 +133,7 @@ These constructs have undergone changes to make them more regular and useful.
  - [Eta expansion](changed-features/eta-expansion.md) is now performed universally also in the absence of an expected type. The postfix `_` operator is thus made redundant. It will be deprecated and dropped after Scala 3.0.
  - [Implicit Resolution](changed-features/implicit-resolution.md): The implicit resolution rules have been cleaned up to make them more useful and less surprising. Implicit scope is restricted to no longer include package prefixes.
 
-Most aspects of old-style implicit resolution are still available under `-language:Scala2`. The other changes in this list are applied unconditionally.
+Most aspects of old-style implicit resolution are still available under `-language:Scala2Compat`. The other changes in this list are applied unconditionally.
 
 **Status: strongly advisable**
 

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -175,7 +175,7 @@ end IndentWidth
 
 ### Settings and Rewrites
 
-Significant indentation is enabled by default. It can be turned off by giving any of the options `-noindent`, `old-syntax` and `language:Scala2`. If indentation is turned off, it is nevertheless checked that indentation conforms to the logical program structure as defined by braces. If that is not the case, the compiler issues an error (or, in the case of `-language:Scala2`, a migration warning).
+Significant indentation is enabled by default. It can be turned off by giving any of the options `-noindent`, `old-syntax` and `language:Scala2`. If indentation is turned off, it is nevertheless checked that indentation conforms to the logical program structure as defined by braces. If that is not the case, the compiler issues an error (or, in the case of `-language:Scala2Compat`, a migration warning).
 
 The Dotty compiler can rewrite source code to indented code and back.
 When invoked with options `-rewrite -indent` it will rewrite braces to

--- a/docs/docs/reference/overview.md
+++ b/docs/docs/reference/overview.md
@@ -63,7 +63,7 @@ These constructs are restricted to make the language safer.
  - [@infix and @alpha](https://github.com/lampepfl/dotty/pull/5975)
  make method application syntax uniform across code bases and require alphanumeric aliases for all symbolic names (proposed, not implemented).
 
-Unrestricted implicit conversions continue to be available in Scala 3.0, but will be deprecated and removed later. Unrestricted versions of the other constructs in the list above are available only under `-language:Scala2`.
+Unrestricted implicit conversions continue to be available in Scala 3.0, but will be deprecated and removed later. Unrestricted versions of the other constructs in the list above are available only under `-language:Scala2Compat`.
 
 
 ## Dropped Constructs
@@ -85,7 +85,7 @@ The date when these constructs are dropped varies. The current status is:
 
  - Not implemented at all:
    - DelayedInit, existential types, weak conformance.
- - Supported under `-language:Scala2`:
+ - Supported under `-language:Scala2Compat`:
    - procedure syntax, class shadowing, symbol literals, auto application, auto tupling in a restricted form.
  - Supported in 3.0, to be deprecated and phased out later:
    - XML literals, compound types.
@@ -100,7 +100,7 @@ These constructs have undergone changes to make them more regular and useful.
  - [Eta expansion](changed-features/eta-expansion.md) is now performed universally also in the absence of an expected type. The postfix `_` operator is thus made redundant. It will be deprecated and dropped after Scala 3.0.
  - [Implicit Resolution](changed-features/implicit-resolution.md): The implicit resolution rules have been cleaned up to make them more useful and less surprising. Implicit scope is restricted to no longer include package prefixes.
 
-Most aspects of old-style implicit resolution are still available under `-language:Scala2`. The other changes in this list are applied unconditionally.
+Most aspects of old-style implicit resolution are still available under `-language:Scala2Compat`. The other changes in this list are applied unconditionally.
 
 ## New Constructs
 

--- a/sbt-dotty/sbt-test/compilerReporter/simple/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/compilerReporter/simple/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/discovery/test-discovery/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/discovery/test-discovery/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/abstract-override/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/abstract-override/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/abstract-type-override/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/abstract-type-override/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/abstract-type/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/abstract-type/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/added/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/added/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/anon-class-java-depends-on-scala/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/anon-class-java-depends-on-scala/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/anon-java-scala-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/anon-java-scala-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/as-seen-from-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/as-seen-from-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/as-seen-from-b/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/as-seen-from-b/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/backtick-quoted-names/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/backtick-quoted-names/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/binary/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/binary/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/by-name/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/by-name/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/canon/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/canon/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/changedTypeOfChildOfSealed/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/changedTypeOfChildOfSealed/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/check-classes/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/check-classes/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/check-dependencies/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/check-dependencies/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/check-products/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/check-products/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/check-recompilations/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/check-recompilations/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/class-based-inheritance/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/class-based-inheritance/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/class-based-memberRef/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/class-based-memberRef/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/compactify/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/compactify/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/constants/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/constants/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/constructors-unrelated/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/constructors-unrelated/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/continuations/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/continuations/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/cross-source/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/cross-source/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/default-params/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/default-params/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/dup-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/dup-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/empty-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/empty-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/empty-modified-names/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/empty-modified-names/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/empty-package/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/empty-package/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/erasure/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/erasure/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/expanded-type-projection/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/expanded-type-projection/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/export-jars/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-jars/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/false-error/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/false-error/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/fbounded-existentials/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/fbounded-existentials/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/implicit-params/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit-params/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/implicit-search-companion-scope/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit-search-companion-scope/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/implicit-search-higher-kinded/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit-search-higher-kinded/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/implicit-search/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit-search/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/implicit/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/import-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/import-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/import-package/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/import-package/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/inherited-deps-java/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/inherited-deps-java/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/inherited_type_params/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/inherited_type_params/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/inner-class-java-depends-on-scala/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/inner-class-java-depends-on-scala/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/intermediate-error/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/intermediate-error/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-analysis-serialization-error/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-analysis-serialization-error/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2CompatCompat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-anonymous/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-anonymous/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-basic/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-basic/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-enum/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-enum/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-generic-workaround/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-generic-workaround/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-inner/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-inner/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-lambda-typeparams/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-lambda-typeparams/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-mixed/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-mixed/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-name-with-dollars/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-name-with-dollars/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-static/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-static/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/lazy-val/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/lazy-val/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/less-inter-inv-java/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/less-inter-inv-java/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/less-inter-inv/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/less-inter-inv/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/linearization/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/linearization/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/local-class-inheritance-from-java/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/local-class-inheritance-from-java/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/local-class-inheritance/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/local-class-inheritance/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/malformed-class-name-with-dollar/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/malformed-class-name-with-dollar/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/malformed-class-name/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/malformed-class-name/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/named/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/named/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/nested-case-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/nested-case-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/nested-type-params/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/nested-type-params/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/new-cyclic/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/new-cyclic/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/new-pkg-dep/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/new-pkg-dep/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/override/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/override/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-name/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-name/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-nested-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-nested-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/packageobject-and-traits/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/packageobject-and-traits/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/parent-change/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/parent-change/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/parent-member-change/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/parent-member-change/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/pkg-private-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/pkg-private-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/pkg-self/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/pkg-self/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/qualified-access/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/qualified-access/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/recorded-products/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/recorded-products/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/relative-source-error/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/relative-source-error/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/remove-test-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/remove-test-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/remove-test-b/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/remove-test-b/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/repeated-parameters/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/repeated-parameters/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/replace-test-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/replace-test-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/resident-java/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/resident-java/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/resident-package-object/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/resident-package-object/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/restore-classes/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/restore-classes/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/same-file-used-names/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/same-file-used-names/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/sealed/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/sealed/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/signature-change/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/signature-change/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/specialized/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/specialized/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/stability-change/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/stability-change/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/struct-projection/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/struct-projection/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/struct-usage/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/struct-usage/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/struct/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/struct/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/synthetic-companion/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/synthetic-companion/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/trait-member-modified/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/trait-member-modified/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/trait-private-object/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/trait-private-object/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/trait-private-val/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/trait-private-val/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/trait-private-var/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/trait-private-var/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/trait-super/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/trait-super/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-b/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-b/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-inherit-java/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-inherit-java/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-inherit/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-inherit/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-memberRef/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-memberRef/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/type-alias/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/type-alias/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/type-member-nested-object/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/type-member-nested-object/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/type-parameter/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/type-parameter/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/typeargref/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/typeargref/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/typeref-only/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/typeref-only/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/typeref-return/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/typeref-return/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/types-in-used-names-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/types-in-used-names-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/types-in-used-names-b/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/types-in-used-names-b/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/unexpanded-names/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/unexpanded-names/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/value-class-underlying/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/value-class-underlying/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/value-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/value-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/var/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/var/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/variance/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/variance/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2"
+    scalacOptions += "-language:Scala2Compat"
   )
 }


### PR DESCRIPTION
The Scala2 language option is misleading. On several occasions I met people who had the impression that it would be a mode where Scala 2 is fully supported but none of the Scala 3 features would be accepted. Now we use

 ```
 -language:Scala2Compat
 ```
as a command line option and

```scala
import language.Scala2Compat
```
as an import.