### PR TITLE
Fix #6475: Print type lambdas in type defs

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -522,19 +522,19 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
             (varianceText(tree.mods) ~ typeText(nameIdText(tree))) ~
             withEnclosingDef(tree) { tparamsText ~ rhsText }
           }
-        def recur(rhs: Tree, tparamsTxt: => Text): Text = rhs match {
+        def recur(rhs: Tree, tparamsTxt: => Text, printMemberArgs: Boolean): Text = rhs match {
           case impl: Template =>
             templateText(tree, impl)
           case rhs: TypeBoundsTree =>
             typeDefText(tparamsTxt, toText(rhs))
-          case LambdaTypeTree(tparams, body) =>
-            recur(body, tparamsText(tparams))
+          case LambdaTypeTree(tparams, body) if printMemberArgs =>
+            recur(body, tparamsText(tparams), false)
           case rhs: TypeTree if isBounds(rhs.typeOpt) =>
             typeDefText(tparamsTxt, toText(rhs))
           case rhs =>
             typeDefText(tparamsTxt, optText(rhs)(" = " ~ _))
         }
-        recur(rhs, "")
+        recur(rhs, "", true)
       case Import(expr, selectors) =>
         keywordText("import ") ~ importText(expr, selectors)
       case Export(expr, selectors) =>

--- a/tests/pos/i6475.scala
+++ b/tests/pos/i6475.scala
@@ -1,0 +1,4 @@
+object Foo1 { type T[+A] = (A, Int) }
+object Foo2 { type T[+A] = [+B] =>> (A, B) }
+object Foo3 { type T[+A] = [+B] =>> [C] =>> (A, B) }
+object Foo4 { type T = [+A] =>> [+B] =>> [C] =>> (A, B) }


### PR DESCRIPTION

`dotc  -Xprint:frontend tests/pos/i6475.scala` will print 
```scala
package <empty> {
  final lazy module val Foo1: Foo1$ = new Foo1$()
  final module class Foo1$() extends Object(), _root_.scala.Serializable { 
    this: Foo1.type =>
    type T[+A >: Nothing <: Any] = Tuple2[A, Int]
  }
  final lazy module val Foo2: Foo2$ = new Foo2$()
  final module class Foo2$() extends Object(), _root_.scala.Serializable { 
    this: Foo2.type =>
    type T[+A >: Nothing <: Any] = [+B >: Nothing <: Any] =>> Tuple2[A, B]
  }
  final lazy module val Foo3: Foo3$ = new Foo3$()
  final module class Foo3$() extends Object(), _root_.scala.Serializable { 
    this: Foo3.type =>
    type T[+A >: Nothing <: Any] = 
      [+B >: Nothing <: Any] =>> [C >: Nothing <: Any] =>> Tuple2[A, B]
  }
  final lazy module val Foo4: Foo4$ = new Foo4$()
  final module class Foo4$() extends Object(), _root_.scala.Serializable { 
    this: Foo4.type =>
    type T[+A >: Nothing <: Any] = 
      [+B >: Nothing <: Any] =>> [C >: Nothing <: Any] =>> Tuple2[A, B]
  }
}
```