### PR TITLE
Update Sourcecode to the latest Upstream and Dotty versions

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -176,11 +176,10 @@ class CommunityBuildTest {
     updateCommand = "dotty-community-build/update"
   )
 
-  // TODO: revert to sourcecodeJVM/test
-  @Test def sourcecode = testSbt(
-    project       = "sourcecode",
-    testCommand   = "sourcecode/compile;sourcecode/test:compile",
-    updateCommand = "sourcecode/update"
+  @Test def sourcecode = testMill(
+    project = "sourcecode",
+    testCommand = s"sourcecode.jvm[$compilerVersion].test",
+    extraMillArgs = List("-i", "-D", s"dottyVersion=$compilerVersion")
   )
 
   @Test def stdLib213 = testSbt(


### PR DESCRIPTION
Everything works in Sourcecode but `Args` which is supposed to retrieve the arguments – names and values – of the enclosing method. It doesn't work because in Scala 2 it relied on `paramss` operation on `MethodSymbol` which retrieved the parameter symbols of a method (from a macro). In Scala 3, we do not have an equivalent.

FTTB I'll leave it as is and proceed with porting the other libraries.