### PR TITLE
Fix #7516: Don't insert `<unindent>` in front of `case`

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -555,9 +555,14 @@ object Scanners {
           token = INDENT
     end observeIndented
 
-    /** Insert an <outdent> token if next token closes an indentation region */
+    /** Insert an <outdent> token if next token closes an indentation region.
+     *  Exception: continue if indentation region belongs to a `match` and next token is `case`.
+     */
     def observeOutdented(): Unit = currentRegion match
-      case r: Indented if !r.isOutermost && closingRegionTokens.contains(token) =>
+      case r: Indented
+      if !r.isOutermost
+         && closingRegionTokens.contains(token)
+         && !(token == CASE && r.prefix == MATCH) =>
         currentRegion = r.enclosing
         insert(OUTDENT, offset)
       case _ =>

--- a/tests/pos/i7516.scala
+++ b/tests/pos/i7516.scala
@@ -1,0 +1,3 @@
+val foo: Int => Int = Some(7) match
+  case Some(y) => x => y
+  case None => identity[Int]


### PR DESCRIPTION
Don't insert outdent in front of CASE if indentation region belongs to a MATCH.