### PR TITLE
Give private dollarvalues val in enum companion synthetic flag

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -99,7 +99,7 @@ object DesugarEnums {
     val privateValuesDef =
       ValDef(nme.DOLLAR_VALUES, TypeTree(),
         New(TypeTree(defn.EnumValuesClass.typeRef.appliedTo(enumClass.typeRef :: Nil)), ListOfNil))
-        .withFlags(Private)
+        .withFlags(Private | Synthetic)
 
     val valuesOfExnMessage = Apply(
       Select(Literal(Constant("key not found: ")), "concat".toTermName),


### PR DESCRIPTION
all the other enum boilerplate has synthetic flag except `$values` which holds the `EnumValues` field