### PR TITLE
Fix #7477: Use correct owner in eta expansion

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -14,6 +14,7 @@ import NameKinds.UniqueName
 import util.Spans._
 import collection.mutable
 import Trees._
+import Decorators._
 
 /** A class that handles argument lifting. Argument lifting is needed in the following
  *  scenarios:
@@ -47,7 +48,10 @@ abstract class Lifter {
       var liftedType = expr.tpe.widen
       if (liftedFlags.is(Method)) liftedType = ExprType(liftedType)
       val lifted = ctx.newSymbol(ctx.owner, name, liftedFlags | Synthetic, liftedType, coord = spanCoord(expr.span))
-      defs += liftedDef(lifted, expr).withSpan(expr.span).setDefTree
+      defs += liftedDef(lifted, expr)
+        .withSpan(expr.span)
+        .changeNonLocalOwners(lifted)
+        .setDefTree
       ref(lifted.termRef).withSpan(expr.span.focus)
     }
 
@@ -179,7 +183,7 @@ object EtaExpansion extends LiftImpure {
    *  If `expr` has implicit function type, the arguments are passed with `given`.
    *  E.g. for (1):
    *
-   *      { val xs = es; (x1, ..., xn) => expr given (x1, ..., xn) }
+   *      { val xs = es; (x1, ..., xn) => expr(given x1, ..., xn) }
    *
    *  Case (3) applies if the method is curried, i.e. its result type is again a method
    *  type. Case (2) applies if the expected arity of the function type `xarity` differs

--- a/tests/pos/i7477.scala
+++ b/tests/pos/i7477.scala
@@ -1,0 +1,29 @@
+class Test1 {
+  def spawn(f: => Unit)(naming: Int = 4): Unit = ???
+  def test(): Unit = spawn {
+    val x: Int = 5
+    x
+  }()
+}
+package X {
+
+  import scala.concurrent._
+  import scala.concurrent.duration._
+
+  import scala.concurrent.ExecutionContext.Implicits._
+
+  class Test1 {
+
+    def spawn[T](f: => T)(given ec:ExecutionContext,  naming: Int = 3): Future[T] = ???
+
+    def await[T](f:Future[T], atMost: Duration = Duration.Inf)(given ec: ExecutionContext):T = ???
+
+    def test(): Unit = {
+      val promiseToWait = Promise[Int]()
+      val future1 = spawn{
+        val x = await(promiseToWait.future)
+        x+1
+      }
+    }
+  }
+}


### PR DESCRIPTION
When eta expanding arguments into separate definition, we need to change their
owner. This matters only for by-name arguments, since these are abstracted into
defs.