### PR TITLE
Fix #7414: Better approximation for class references

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4753,6 +4753,9 @@ object Types {
             // if H#x: y.type, then for any x in L..H, x.type =:= y.type,
             // hence we can replace with y.type under all variances
             reapply(info)
+          case info: ClassInfo =>
+            // For class types, we can fall back to a type projection P#C
+            tp.derivedSelect(pre.widen)
           case _ =>
             NoType
         }

--- a/tests/pos/i7414.scala
+++ b/tests/pos/i7414.scala
@@ -1,0 +1,10 @@
+object DepTest {
+  trait Trait {
+    case class Dependent()
+  }
+  object obj extends Trait
+  case class Dep[T <: Trait](t: T) {
+    def fun(q: t.Dependent): Unit = ()
+  }
+  Dep(obj).fun(obj.Dependent())
+}


### PR DESCRIPTION
What to do if there is an as-seen-from result of the form
```
  (Nothing .. T) # ref
```
i.a. a projection over a range? The fallback so far was the
range `(Nothing # ref .. T # ref)`. But if `ref` is a class,
we can probably replace it by widen(T) # ref instead. A type projection like that
is legal, and subsumes all possible types in the range.