### PR TITLE
Fix #7413: Adjust singleton arguments for new conversions

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -182,9 +182,9 @@ object Implicits {
             tp.derivedLambdaType(paramInfos = tp.paramInfos.mapConserve(widenSingleton))
           case _ =>
             tp.baseType(defn.ConversionClass) match
-              case app @ AppliedType(tycon, from :: to :: Nil) =>
+              case app @ AppliedType(tycon, from :: rest) =>
                 val wideFrom = from.widenSingleton
-                if wideFrom ne from then app.derivedAppliedType(tycon, wideFrom :: to :: Nil)
+                if wideFrom ne from then app.derivedAppliedType(tycon, wideFrom :: rest)
                 else tp
               case _ => tp
 

--- a/tests/pos/i7413.scala
+++ b/tests/pos/i7413.scala
@@ -1,0 +1,24 @@
+import scala.language.implicitConversions
+
+trait Fixture[A] extends Conversion[0, A]
+
+trait TestFramework[A] {
+  def (testName: String) in (test: (given Fixture[A]) => Unit): Unit = ???
+}
+
+trait Greeter {
+  def greet(name: String): String = s"Hello $name"
+}
+
+case class MyFixture(name: String, greeter: Greeter)
+
+object Test1 with
+  given conv: Conversion[0, Greeter]
+    def apply(x: 0): Greeter = ???
+  val g: Greeter = 0
+
+class MyTest extends TestFramework[MyFixture] {
+  "say hello" in {
+    assert(0.greeter.greet(0.name) == s"Hello ${0.name}")
+  }
+}


### PR DESCRIPTION
The types of old-style implicit conversion methods were massaged in `adjustSingletonArgs` to
become eligible for singleton arguments (which are widened, in order to get better cache hits
ratios). The same is now done for new style Conversion instances.