### PR TITLE
Fix #7575: Drop support of -language:_

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -491,7 +491,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         if (!sym.exists) ""
         else toPrefix(sym.owner) + sym.name + "."
       val featureName = toPrefix(owner) + feature
-      ctx.base.settings.language.value exists (s => s == featureName || s == "_")
+      ctx.base.settings.language.value exists (s => s == featureName)
     }
     hasOption || hasImport
   }

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -60,7 +60,8 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/pos-special/indent-colons.scala", defaultOptions.and("-Yindent-colons")),
       compileFile("tests/pos-special/i7296.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/pos-special/nullable.scala", defaultOptions.and("-Yexplicit-nulls")),
-      compileDir("tests/pos-special/adhoc-extension", defaultOptions.and("-strict", "-feature", "-Xfatal-warnings"))
+      compileDir("tests/pos-special/adhoc-extension", defaultOptions.and("-strict", "-feature", "-Xfatal-warnings")),
+      compileFile("tests/pos-special/i7575.scala", defaultOptions.and("-language:dynamics")),
     ).checkCompile()
   }
 
@@ -145,7 +146,8 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/neg-custom-args/wildcards.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/indentRight.scala", defaultOptions.and("-noindent", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/extmethods-tparams.scala", defaultOptions.and("-deprecation", "-Xfatal-warnings")),
-      compileDir("tests/neg-custom-args/adhoc-extension", defaultOptions.and("-strict", "-feature", "-Xfatal-warnings"))
+      compileDir("tests/neg-custom-args/adhoc-extension", defaultOptions.and("-strict", "-feature", "-Xfatal-warnings")),
+      compileFile("tests/neg/i7575.scala", defaultOptions.and("-language:_")),
     ).checkExpectedErrors()
   }
 

--- a/tests/neg/i7575.scala
+++ b/tests/neg/i7575.scala
@@ -1,0 +1,2 @@
+class Foo() extends Dynamic // error: extension of type scala.Dynamic needs to be enabled
+// tested as is and with -language:_

--- a/tests/neg/i7575b.scala
+++ b/tests/neg/i7575b.scala
@@ -1,0 +1,2 @@
+import scala.language._
+class Foo() extends Dynamic // error: extension of type scala.Dynamic needs to be enabled

--- a/tests/pos-special/i7575.scala
+++ b/tests/pos-special/i7575.scala
@@ -1,0 +1,1 @@
+class Foo() extends Dynamic // tested with -language:dynamics


### PR DESCRIPTION
Aligns the behaviour of `import scala.language._` with `-language:_`