### PR TITLE
Change match syntax

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1945,7 +1945,7 @@ object Parsers {
         mkIf(cond, thenp, elsep)
       }
 
-    /**    MatchClause ::= `match' [‘inline’] `{' CaseClauses `}'
+    /**    MatchClause ::= `match' `{' CaseClauses `}'
      */
     def matchClause(t: Tree): Match =
       in.endMarkerScope(MATCH) {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1951,20 +1951,20 @@ object Parsers {
         mkIf(cond, thenp, elsep)
       }
 
-    /**    `match' (`{' CaseClauses `}' | CaseClause)
+    /**    `match' `{' CaseClauses `}'
      */
     def matchExpr(t: Tree, start: Offset, mkMatch: (Tree, List[CaseDef]) => Match) =
       in.endMarkerScope(MATCH) {
         atSpan(start, in.skipToken()) {
-          mkMatch(t, casesExpr(caseClause))
+          mkMatch(t, inBracesOrIndented(caseClauses(caseClause)))
         }
       }
 
-    /**    `match' (`{' TypeCaseClauses `}' | TypeCaseClause)
+    /**    `match' `{' TypeCaseClauses `}'
      */
     def matchType(t: Tree): MatchTypeTree =
       atSpan(t.span.start, accept(MATCH)) {
-        MatchTypeTree(EmptyTree, t, casesExpr(typeCaseClause))
+        MatchTypeTree(EmptyTree, t, inBracesOrIndented(caseClauses(typeCaseClause)))
       }
 
     /** FunParams         ::=  Bindings
@@ -2394,10 +2394,6 @@ object Parsers {
         }
       }
     }
-
-    def casesExpr(clause: () => CaseDef): List[CaseDef] =
-      if in.token == CASE then clause() :: Nil
-      else inBracesOrIndented(caseClauses(clause))
 
     /** CaseClauses         ::= CaseClause {CaseClause}
      *  TypeCaseClauses     ::= TypeCaseClause {TypeCaseClause}

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -525,7 +525,8 @@ object Scanners {
         else if (lastWidth != nextWidth)
           errorButContinue(spaceTabMismatchMsg(lastWidth, nextWidth))
       currentRegion match {
-        case Indented(curWidth, others, prefix, outer) if curWidth < nextWidth && !others.contains(nextWidth) =>
+        case Indented(curWidth, others, prefix, outer)
+        if curWidth < nextWidth && !others.contains(nextWidth) && nextWidth != lastWidth =>
           if (token == OUTDENT)
             errorButContinue(
               i"""The start of this line does not match any of the previous indentation widths.

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -147,8 +147,7 @@ FunArgTypes       ::=  InfixType
                     |  ‘(’ [ ‘[given]’ FunArgType {‘,’ FunArgType } ] ‘)’
                     |  ‘(’ ‘[given]’ TypedFunParam {‘,’ TypedFunParam } ‘)’
 TypedFunParam     ::=  id ‘:’ Type
-MatchType         ::=  InfixType `match`
-                       (‘{’ TypeCaseClauses ‘}’ | TypeCaseClause)
+MatchType         ::=  InfixType `match` ‘{’ TypeCaseClauses ‘}’
 InfixType         ::=  RefinedType {id [nl] RefinedType}                        InfixOp(t1, op, t2)
 RefinedType       ::=  WithType {[nl | ‘with’] Refinement}                      RefinedTypeTree(t, ds)
 WithType          ::=  AnnotType {‘with’ AnnotType}                             (deprecated)
@@ -199,8 +198,7 @@ Expr1             ::=  ‘if’ ‘(’ Expr ‘)’ {nl}
                     |  [SimpleExpr ‘.’] id ‘=’ Expr                             Assign(expr, expr)
                     |  SimpleExpr1 ArgumentExprs ‘=’ Expr                       Assign(expr, expr)
                     |  Expr2
-                    |  [‘inline’] Expr2 ‘match’
-                       (‘{’ CaseClauses ‘}’ | CaseClause)                       Match(expr, cases) -- point on match
+                    |  [‘inline’] Expr2 ‘match’ ‘{’ CaseClauses ‘}’             Match(expr, cases) -- point on match
 Expr2             ::=  PostfixExpr [Ascription]
 Ascription        ::=  ‘:’ InfixType                                            Typed(expr, tp)
                     |  ‘:’ Annotation {Annotation}                              Typed(expr, Annotated(EmptyTree, annot)*)

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -184,8 +184,8 @@ BlockResult       ::=  [‘implicit’] FunParams ‘=>’ Block
 FunParams         ::=  Bindings
                     |  id
                     |  ‘_’
-Expr1             ::=  ‘if’ [‘inline’]‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr] If(Parens(cond), thenp, elsep?)
-                    |  ‘if’ [‘inline’] Expr ‘then’ Expr [[semi] ‘else’ Expr]    If(cond, thenp, elsep?)
+Expr1             ::=  [‘inline’] ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr] If(Parens(cond), thenp, elsep?)
+                    |  [‘inline’] ‘if’  Expr ‘then’ Expr [[semi] ‘else’ Expr]    If(cond, thenp, elsep?)
                     |  ‘while’ ‘(’ Expr ‘)’ {nl} Expr                           WhileDo(Parens(cond), body)
                     |  ‘while’ Expr ‘do’ Expr                                   WhileDo(cond, body)
                     |  ‘try’ Expr Catches [‘finally’ Expr]                      Try(expr, catches, expr?)
@@ -196,8 +196,8 @@ Expr1             ::=  ‘if’ [‘inline’]‘(’ Expr ‘)’ {nl} Expr [[s
                     |  HkTypeParamClause ‘=>’ Expr                              PolyFunction(ts, expr)
                     |  [SimpleExpr ‘.’] id ‘=’ Expr                             Assign(expr, expr)
                     |  SimpleExpr1 ArgumentExprs ‘=’ Expr                       Assign(expr, expr)
-                    |  Expr2
-Expr2             ::=  PostfixExpr [Ascription]
+                    |  PostfixExpr [Ascription]
+                    |  ‘inline’ InfixExpr MatchClause
 Ascription        ::=  ‘:’ InfixType                                            Typed(expr, tp)
                     |  ‘:’ Annotation {Annotation}                              Typed(expr, Annotated(EmptyTree, annot)*)
 Catches           ::=  ‘catch’ (Expr | CaseClause)
@@ -205,7 +205,7 @@ PostfixExpr       ::=  InfixExpr [id]                                           
 InfixExpr         ::=  PrefixExpr
                     |  InfixExpr id [nl] InfixExpr                              InfixOp(expr, op, expr)
                     |  InfixExpr MatchClause
-MatchClause       ::=  ‘match’ [‘inline’] ‘{’ CaseClauses ‘}’                   Match(expr, cases)
+MatchClause       ::=  ‘match’ ‘{’ CaseClauses ‘}’                   Match(expr, cases)
 PrefixExpr        ::=  [‘-’ | ‘+’ | ‘~’ | ‘!’] SimpleExpr                       PrefixOp(expr, op)
 SimpleExpr        ::=  Path
                     |  Literal

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -184,9 +184,8 @@ BlockResult       ::=  [‘implicit’] FunParams ‘=>’ Block
 FunParams         ::=  Bindings
                     |  id
                     |  ‘_’
-Expr1             ::=  ‘if’ ‘(’ Expr ‘)’ {nl}
-                       Expr [[semi] ‘else’ Expr]                                If(Parens(cond), thenp, elsep?)
-                    |  ‘if’ Expr ‘then’ Expr [[semi] ‘else’ Expr]               If(cond, thenp, elsep?)
+Expr1             ::=  ‘if’ [‘inline’]‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr] If(Parens(cond), thenp, elsep?)
+                    |  ‘if’ [‘inline’] Expr ‘then’ Expr [[semi] ‘else’ Expr]    If(cond, thenp, elsep?)
                     |  ‘while’ ‘(’ Expr ‘)’ {nl} Expr                           WhileDo(Parens(cond), body)
                     |  ‘while’ Expr ‘do’ Expr                                   WhileDo(cond, body)
                     |  ‘try’ Expr Catches [‘finally’ Expr]                      Try(expr, catches, expr?)
@@ -198,7 +197,6 @@ Expr1             ::=  ‘if’ ‘(’ Expr ‘)’ {nl}
                     |  [SimpleExpr ‘.’] id ‘=’ Expr                             Assign(expr, expr)
                     |  SimpleExpr1 ArgumentExprs ‘=’ Expr                       Assign(expr, expr)
                     |  Expr2
-                    |  [‘inline’] Expr2 ‘match’ ‘{’ CaseClauses ‘}’             Match(expr, cases) -- point on match
 Expr2             ::=  PostfixExpr [Ascription]
 Ascription        ::=  ‘:’ InfixType                                            Typed(expr, tp)
                     |  ‘:’ Annotation {Annotation}                              Typed(expr, Annotated(EmptyTree, annot)*)
@@ -206,7 +204,8 @@ Catches           ::=  ‘catch’ (Expr | CaseClause)
 PostfixExpr       ::=  InfixExpr [id]                                           PostfixOp(expr, op)
 InfixExpr         ::=  PrefixExpr
                     |  InfixExpr id [nl] InfixExpr                              InfixOp(expr, op, expr)
-                    |  InfixExpr ‘given’ (InfixExpr | ParArgumentExprs)
+                    |  InfixExpr MatchClause
+MatchClause       ::=  ‘match’ [‘inline’] ‘{’ CaseClauses ‘}’                   Match(expr, cases)
 PrefixExpr        ::=  [‘-’ | ‘+’ | ‘~’ | ‘!’] SimpleExpr                       PrefixOp(expr, op)
 SimpleExpr        ::=  Path
                     |  Literal
@@ -219,6 +218,7 @@ SimpleExpr        ::=  Path
                     |  ‘new’ TemplateBody
                     |  ‘(’ ExprsInParens ‘)’                                    Parens(exprs)
                     |  SimpleExpr ‘.’ id                                        Select(expr, id)
+                    |  SimpleExpr ‘.’ MatchClause
                     |  SimpleExpr TypeArgs                                      TypeApply(expr, args)
                     |  SimpleExpr ArgumentExprs                                 Apply(expr, args)
                     |  SimpleExpr ‘_’                                           PostfixOp(expr, _)

--- a/docs/docs/reference/changed-features/match-syntax.md
+++ b/docs/docs/reference/changed-features/match-syntax.md
@@ -1,0 +1,43 @@
+---
+layout: doc-page
+title: Match Expressions
+---
+
+The syntactical precedence of match expressions has been changed.
+`match` is still a keyword, but it is used like an alphabetical operator. This has several consequences:
+
+ 1. `match` expressions can be chained:
+
+    ```scala
+    xs match {
+      case Nil => "empty"
+      case x :: xs1 => "nonempty"
+    } match {
+      case "empty" => 0
+      case "nonempty" => 1
+    }
+
+ 2. `match` may follow a period:
+
+     ```scala
+     if xsDefined
+        && xs.match {
+             case Nil => false
+             case _ => true
+           }
+     then "nonempty"
+     else "empty"
+
+ 3. The scrutinee of a match expression must be an `InfixExpr`. Previously the scrutinee could be followed by a type ascription `: T`, but this is no longer supported. So `x : T match { ... }` now has to be
+ written `(x: T) match { ... }`.
+
+## Syntax
+
+The new syntax of match expressions is as follows.
+```
+InfixExpr    ::=  ...
+               |  InfixExpr MatchClause
+SimpleExpr   ::=  ...
+               |  SimpleExpr ‘.’ MatchClause
+MatchClause  ::=  ‘match’ ‘{’ CaseClauses ‘}’
+```

--- a/docs/docs/reference/contextual/typeclasses.md
+++ b/docs/docs/reference/contextual/typeclasses.md
@@ -10,25 +10,22 @@ with canonical implementations defined by given instances. Here are some example
 ### Semigroups and monoids:
 
 ```scala
-trait SemiGroup[T] {
+trait SemiGroup[T] with
   def (x: T) combine (y: T): T
-}
-trait Monoid[T] extends SemiGroup[T] {
-  def unit: T
-}
-object Monoid {
-  def apply[T](given Monoid[T]) = summon[Monoid[T]]
-}
 
-given Monoid[String] {
+trait Monoid[T] extends SemiGroup[T] with
+  def unit: T
+
+object Monoid with
+  def apply[T](given Monoid[T]) = summon[Monoid[T]]
+
+given Monoid[String] with
   def (x: String) combine (y: String): String = x.concat(y)
   def unit: String = ""
-}
 
-given Monoid[Int] {
+given Monoid[Int] with
   def (x: Int) combine (y: Int): Int = x + y
   def unit: Int = 0
-}
 
 def sum[T: Monoid](xs: List[T]): T =
     xs.foldLeft(Monoid[T].unit)(_.combine(_))

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -127,6 +127,8 @@ sidebar:
               url: docs/reference/changed-features/implicit-conversions.html
             - title: Overload Resolution
               url: docs/reference/changed-features/overload-resolution.html
+            - title: Match Expressions
+              url: docs/reference/changed-features/match-syntax.html
             - title: Vararg Patterns
               url: docs/reference/changed-features/vararg-patterns.html
             - title: Pattern Bindings

--- a/tests/neg/cannot-reduce-inline-match.check
+++ b/tests/neg/cannot-reduce-inline-match.check
@@ -1,11 +1,11 @@
 -- Error: tests/neg/cannot-reduce-inline-match.scala:3:13 --------------------------------------------------------------
 3 |    inline x match { // error
-  |    ^
-  |    cannot reduce inline match with
-  |     scrutinee:  {
-  |      "f"
-  |    } : String("f")
-  |     patterns :  case _:Int
+  |           ^
+  |           cannot reduce inline match with
+  |            scrutinee:  {
+  |             "f"
+  |           } : String("f")
+  |            patterns :  case _:Int
   | This location is in code that was inlined at cannot-reduce-inline-match.scala:9
 4 |      case _: Int =>
 5 |    }

--- a/tests/pos-special/fatal-warnings/unchecked-scrutinee.scala
+++ b/tests/pos-special/fatal-warnings/unchecked-scrutinee.scala
@@ -1,5 +1,5 @@
 object Test {
-  List(1: @unchecked, 2, 3): @unchecked match {
+  (List(1: @unchecked, 2, 3): @unchecked) match {
     case a :: as =>
   }
 }

--- a/tests/pos/i6997c.scala
+++ b/tests/pos/i6997c.scala
@@ -4,11 +4,11 @@ import scala.quoted.{_, given}, scala.quoted.matching._
 
 inline def mcr(x: => Any): Any = ${mcrImpl('x)}
 
-def mcrImpl(body: Expr[Any])(given ctx: QuoteContext): Expr[Any] = {
-  body match case '{$x: $t} =>
-  '{
-    val tmp: $t = $x
-    println(tmp)
-    tmp
-  }
-}
+def mcrImpl(body: Expr[Any])(given ctx: QuoteContext): Expr[Any] =
+  body match
+    case '{$x: $t} =>
+      '{
+        val tmp: $t = $x
+        println(tmp)
+        tmp
+      }

--- a/tests/pos/matches.scala
+++ b/tests/pos/matches.scala
@@ -1,0 +1,20 @@
+package matches
+object Test with
+  2 min 3 match
+    case 2 => "OK"
+    case 3 => "?"
+  match
+    case "OK" =>
+    case "?" => assertFail()
+
+  val x = 4
+  if 2 < 3
+     || x.match
+          case 4 => true
+          case _ => false
+     || (2 + 2).match
+          case 4 => true
+          case _ => false
+  then
+    println("ok")
+end Test

--- a/tests/pos/multi-given.scala
+++ b/tests/pos/multi-given.scala
@@ -4,3 +4,5 @@ trait C
 
 def fancy(given a: A, b: B, c: C) = "Fancy!"
 def foo(implicit a: A, b: B, c: C) = "foo"
+
+given A, B {}

--- a/tests/pos/single-case.scala
+++ b/tests/pos/single-case.scala
@@ -1,11 +1,7 @@
 object test with
 
-  type T[X] = X match case Int => X
-
   try
     println("hi")
   catch case ex: java.io.IOException => println("ho")
-
-  1 match case x: Int => println(x)
 
 

--- a/tests/run-macros/expr-map-2/Macro_1.scala
+++ b/tests/run-macros/expr-map-2/Macro_1.scala
@@ -10,7 +10,8 @@ private object StringRewriter extends util.ExprMap {
 
   def transform[T](e: Expr[T])(given QuoteContext, Type[T]): Expr[T] = e match
     case '{ ($x: Foo).x } =>
-      '{ new Foo(4).x } match case '{ $e: T } => e
+      '{ new Foo(4).x } match
+        case '{ $e: T } => e
     case _ =>
       transformChildren(e)
 

--- a/tests/run-with-compiler-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
+++ b/tests/run-with-compiler-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
@@ -17,30 +17,30 @@ class Interpreter[R <: Reflection & Singleton](reflect0: R) extends TreeInterpre
       // Best effort to try to create a proxy
       val sym = fn.symbol.owner
       if (sym.isClassDef) {
-        sym.tree match case tree: ClassDef =>
-        val parentSymbols = tree.parents.tail.map(_.asInstanceOf[TypeTree].symbol).head
-        import java.lang.reflect._
-        val handler: InvocationHandler = new InvocationHandler() {
+        sym.tree match
+          case tree: ClassDef =>
+            val parentSymbols = tree.parents.tail.map(_.asInstanceOf[TypeTree].symbol).head
+            import java.lang.reflect._
+            val handler: InvocationHandler = new InvocationHandler() {
 
-          def invoke(proxy: Object, method: Method, args: scala.Array[Object]): Object = {
-            if (LOG) {
-              val proxyString = if (method.getName == "toString") method.invoke(this) else proxy.toString
-              println(s"%> proxy call `$method` on `$proxyString` with args=${if (args == null) Nil else args.toList}")
-            }
+              def invoke(proxy: Object, method: Method, args: scala.Array[Object]): Object = {
+                if (LOG) {
+                  val proxyString = if (method.getName == "toString") method.invoke(this) else proxy.toString
+                  println(s"%> proxy call `$method` on `$proxyString` with args=${if (args == null) Nil else args.toList}")
+                }
 
-            // println(method)
-            val symbol = sym.methods.find(_.name == method.getName).get
+                // println(method)
+                val symbol = sym.methods.find(_.name == method.getName).get
 
-            if (symbol.isDefinedInCurrentRun) {
-              val argsList = if (args == null) Nil else args.toList
-              interpretCall(this, symbol, argsList).asInstanceOf[Object]
-            }
-            else {
-              assert(method.getClass == classOf[Object])
-              method.invoke(this, args: _*)
-            }
-          }
-
+                if (symbol.isDefinedInCurrentRun) {
+                  val argsList = if (args == null) Nil else args.toList
+                  interpretCall(this, symbol, argsList).asInstanceOf[Object]
+                }
+                else {
+                  assert(method.getClass == classOf[Object])
+                  method.invoke(this, args: _*)
+                }
+              }
         }
         val proxyClass: Class[_] = Proxy.getProxyClass(getClass.getClassLoader, jvmReflection.loadClass(parentSymbols.fullName))
         proxyClass.getConstructor(classOf[InvocationHandler]).newInstance(handler);

--- a/tests/run-with-compiler-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
+++ b/tests/run-with-compiler-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
@@ -22,7 +22,6 @@ class Interpreter[R <: Reflection & Singleton](reflect0: R) extends TreeInterpre
             val parentSymbols = tree.parents.tail.map(_.asInstanceOf[TypeTree].symbol).head
             import java.lang.reflect._
             val handler: InvocationHandler = new InvocationHandler() {
-
               def invoke(proxy: Object, method: Method, args: scala.Array[Object]): Object = {
                 if (LOG) {
                   val proxyString = if (method.getName == "toString") method.invoke(this) else proxy.toString
@@ -41,9 +40,9 @@ class Interpreter[R <: Reflection & Singleton](reflect0: R) extends TreeInterpre
                   method.invoke(this, args: _*)
                 }
               }
-        }
-        val proxyClass: Class[_] = Proxy.getProxyClass(getClass.getClassLoader, jvmReflection.loadClass(parentSymbols.fullName))
-        proxyClass.getConstructor(classOf[InvocationHandler]).newInstance(handler);
+            }
+            val proxyClass: Class[_] = Proxy.getProxyClass(getClass.getClassLoader, jvmReflection.loadClass(parentSymbols.fullName))
+            proxyClass.getConstructor(classOf[InvocationHandler]).newInstance(handler);
       }
     }
     else jvmReflection.interpretNew(fn.symbol, evaluatedArgss(argss))

--- a/tests/run/typeclass-derivation2.scala
+++ b/tests/run/typeclass-derivation2.scala
@@ -293,7 +293,7 @@ object Pickler {
   }
 
   inline def pickleElems[Elems <: Tuple](buf: mutable.ListBuffer[Int], elems: Mirror, n: Int): Unit =
-    erasedValue[Elems] match inline {
+    inline erasedValue[Elems] match {
       case _: (elem *: elems1) =>
         tryPickle[elem](buf, elems(n).asInstanceOf[elem])
         pickleElems[elems1](buf, elems, n + 1)
@@ -304,9 +304,9 @@ object Pickler {
     pickleElems[Elems](buf, r.reflect(x), 0)
 
   inline def pickleCases[T, Alts <: Tuple](r: Reflected[T], buf: mutable.ListBuffer[Int], x: T, n: Int): Unit =
-    erasedValue[Alts] match inline {
+    inline erasedValue[Alts] match {
       case _: (Shape.Case[alt, elems] *: alts1) =>
-        typeOf[alt] match inline {
+        inline typeOf[alt] match {
           case _: Subtype[T] =>
             x match {
               case x: `alt` =>
@@ -326,7 +326,7 @@ object Pickler {
   }
 
   inline def unpickleElems[Elems <: Tuple](buf: mutable.ListBuffer[Int], elems: Array[AnyRef], n: Int): Unit =
-    erasedValue[Elems] match inline {
+    inline erasedValue[Elems] match {
       case _: (elem *: elems1) =>
         elems(n) = tryUnpickle[elem](buf).asInstanceOf[AnyRef]
         unpickleElems[elems1](buf, elems, n + 1)

--- a/tests/run/typeclass-derivation2.scala
+++ b/tests/run/typeclass-derivation2.scala
@@ -293,7 +293,7 @@ object Pickler {
   }
 
   inline def pickleElems[Elems <: Tuple](buf: mutable.ListBuffer[Int], elems: Mirror, n: Int): Unit =
-    inline erasedValue[Elems] match {
+    erasedValue[Elems] match inline {
       case _: (elem *: elems1) =>
         tryPickle[elem](buf, elems(n).asInstanceOf[elem])
         pickleElems[elems1](buf, elems, n + 1)
@@ -304,9 +304,9 @@ object Pickler {
     pickleElems[Elems](buf, r.reflect(x), 0)
 
   inline def pickleCases[T, Alts <: Tuple](r: Reflected[T], buf: mutable.ListBuffer[Int], x: T, n: Int): Unit =
-    inline erasedValue[Alts] match {
+    erasedValue[Alts] match inline {
       case _: (Shape.Case[alt, elems] *: alts1) =>
-        inline typeOf[alt] match {
+        typeOf[alt] match inline {
           case _: Subtype[T] =>
             x match {
               case x: `alt` =>
@@ -326,7 +326,7 @@ object Pickler {
   }
 
   inline def unpickleElems[Elems <: Tuple](buf: mutable.ListBuffer[Int], elems: Array[AnyRef], n: Int): Unit =
-    inline erasedValue[Elems] match {
+    erasedValue[Elems] match inline {
       case _: (elem *: elems1) =>
         elems(n) = tryUnpickle[elem](buf).asInstanceOf[AnyRef]
         unpickleElems[elems1](buf, elems, n + 1)


### PR DESCRIPTION
`match` is now treated like an alphabetic operator, it can be appear infix as
well as after `.`.

Motivation given in https://contributors.scala-lang.org/t/pre-sip-demote-match-keyword-to-a-method/2137/36?u=odersky