### PR TITLE
Make fresh name generation per file instead of global

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc
 
-import util.SourceFile
+import util.{FreshNameCreator, SourceFile}
 import ast.{tpd, untpd}
 import tpd.{Tree, TreeTraverser}
 import typer.PrepareInlineable.InlineAccessors
@@ -26,6 +26,12 @@ class CompilationUnit protected (val source: SourceFile) {
 
   /** Pickled TASTY binaries, indexed by class. */
   var pickled: Map[ClassSymbol, Array[Byte]] = Map()
+
+  /** The fresh name creator for the current unit.
+   *  FIXME(#7661): This is not fine-grained enough to enable reproducible builds,
+   *  see https://github.com/scala/scala/commit/f50ec3c866263448d803139e119b33afb04ec2bc
+   */
+  val freshNames: FreshNameCreator = new FreshNameCreator.Default
 
   /** Will be set to `true` if contains `Quote`.
    *  The information is used in phase `Staging` in order to avoid traversing trees that need no transformations.

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -52,7 +52,6 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
       .setTyper(new Typer)
       .addMode(Mode.ImplicitsEnabled)
       .setTyperState(new TyperState(ctx.typerState))
-      .setFreshNames(new FreshNameCreator.Default)
     ctx.initialize()(start) // re-initialize the base context with start
     def addImport(ctx: Context, rootRef: ImportInfo.RootRef) =
       ctx.fresh.setImportInfo(ImportInfo.rootImport(rootRef)(ctx))
@@ -241,12 +240,15 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
     }
   }
 
-  def compileFromString(sourceCode: String): Unit = {
-    val virtualFile = new VirtualFile("compileFromString-${java.util.UUID.randomUUID().toString}")
-    val writer = new BufferedWriter(new OutputStreamWriter(virtualFile.output, "UTF-8")) // buffering is still advised by javadoc
-    writer.write(sourceCode)
-    writer.close()
-    compileSources(List(new SourceFile(virtualFile, Codec.UTF8)))
+  def compileFromStrings(sourceCodes: String*): Unit = {
+    val sourceFiles = sourceCodes.map {sourceCode =>
+      val virtualFile = new VirtualFile("compileFromString-${java.util.UUID.randomUUID().toString}")
+      val writer = new BufferedWriter(new OutputStreamWriter(virtualFile.output, "UTF-8")) // buffering is still advised by javadoc
+      writer.write(sourceCode)
+      writer.close()
+      new SourceFile(virtualFile, Codec.UTF8)
+    }
+    compileSources(sourceFiles.toList)
   }
 
   /** Print summary; return # of errors encountered */

--- a/compiler/src/dotty/tools/dotc/core/Comments.scala
+++ b/compiler/src/dotty/tools/dotc/core/Comments.scala
@@ -121,7 +121,7 @@ object Comments {
         val tree = new Parser(SourceFile.virtual("<usecase>", code)).localDef(codePos.start)
         tree match {
           case tree: untpd.DefDef =>
-            val newName = ctx.freshNames.newName(tree.name, NameKinds.DocArtifactName)
+            val newName = ctx.compilationUnit.freshNames.newName(tree.name, NameKinds.DocArtifactName)
             untpd.cpy.DefDef(tree)(name = newName)
           case _ =>
             ctx.error(ProperDefinitionNotFound(), ctx.source.atSpan(codePos))

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -215,7 +215,7 @@ object NameKinds {
 
     /** Generate fresh unique term name of this kind with given prefix name */
     def fresh(prefix: TermName = EmptyTermName)(implicit ctx: Context): TermName =
-      ctx.freshNames.newName(prefix, this)
+      ctx.compilationUnit.freshNames.newName(prefix, this)
 
     /** Generate fresh unique type name of this kind with given prefix name */
     def fresh(prefix: TypeName)(implicit ctx: Context): TypeName =

--- a/compiler/test/dotty/tools/DottyTest.scala
+++ b/compiler/test/dotty/tools/DottyTest.scala
@@ -64,7 +64,7 @@ trait DottyTest extends ContextEscapeDetection {
   def checkCompile(checkAfterPhase: String, source: String)(assertion: (tpd.Tree, Context) => Unit): Context = {
     val c = compilerWithChecker(checkAfterPhase)(assertion)
     val run = c.newRun
-    run.compileFromString(source)
+    run.compileFromStrings(source)
     run.runContext
   }
 

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTest.scala
@@ -52,13 +52,13 @@ trait DottyBytecodeTest {
     ctx0.setSetting(ctx0.settings.outputDir, outputDir)
   }
 
-  /** Checks source code from raw string */
-  def checkBCode(source: String)(checkOutput: AbstractFile => Unit): Unit = {
+  /** Checks source code from raw strings */
+  def checkBCode(sources: String*)(checkOutput: AbstractFile => Unit): Unit = {
     implicit val ctx: Context = initCtx
 
     val compiler = new Compiler
     val run = compiler.newRun
-    compiler.newRun.compileFromString(source)
+    compiler.newRun.compileFromStrings(sources: _*)
 
     checkOutput(ctx.settings.outputDir.value)
   }


### PR DESCRIPTION
This makes the compiler output more stable and avoids overcompilation
during incremental compilation due to context bounds parameters changing
name. This is still not fine-grained enough as noted in the
documentation of CompilationUnit#freshNames.

To work properly, this requires us to always have a compilation unit set
in the context before compiling code, which is a good idea anyway (would
be nice to improve the API to make this harder to screw up).