### PR TITLE
Fix Scala2Compat language import

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -358,7 +358,6 @@ object StdNames {
     val Ref: N                  = "Ref"
     val RootPackage: N          = "RootPackage"
     val RootClass: N            = "RootClass"
-    val Scala2: N               = "Scala2"
     val Scala2Compat: N         = "Scala2Compat"
     val Select: N               = "Select"
     val Shape: N                = "Shape"

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -501,12 +501,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
     !featureEnabled(nme.noAutoTupling)
 
   def scala2CompatMode: Boolean =
-    featureEnabled(nme.Scala2Compat) || {
-      val scala2 = featureEnabled(nme.Scala2)
-      if scala2 then ctx.warning("Use `-language:Scala2Compat` or `import scala.Scala2Compat` instead of `-language:Scala2` or `import scala.Scala2`")
-      scala2
-    }
-
+    featureEnabled(nme.Scala2Compat)
 
   def dynamicsEnabled: Boolean =
     featureEnabled(nme.dynamics)
@@ -523,11 +518,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
    *  This test is used when we are too early in the pipeline to consider imports.
    */
   def scala2CompatSetting: Boolean =
-    ctx.settings.language.value.contains(nme.Scala2Compat.toString) || {
-      val scala2 = ctx.settings.language.value.contains(nme.Scala2.toString)
-      if scala2 then ctx.warning("Use -language:Scala2Compat instead of -language:Scala2")
-      scala2
-    }
+    ctx.settings.language.value.contains(nme.Scala2Compat.toString)
 
   /** Refine child based on parent
    *

--- a/library/src/scalaShadowing/language.scala
+++ b/library/src/scalaShadowing/language.scala
@@ -213,7 +213,7 @@ object language {
   }
 
   /** Where imported, a backwards compatibility mode for Scala2 is enabled */
-  object Scala2
+  object Scala2Compat
 
   /** Where imported, auto-tupling is disabled */
   object noAutoTupling


### PR DESCRIPTION
It used to be

    import language.Scala2

even though the setting was Scala2Compat.