### PR TITLE
Enable cross-compilation tests for Mill libraries

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -48,6 +48,7 @@ steps:
   image: lampepfl/dotty:2019-10-17
   depends_on: [ clone ]
   commands:
+  - curl https://raw.githubusercontent.com/scala-native/scala-native/b7851c4dc2a22c9fd9202aea3d97e2a68910b918/scripts/travis_setup.sh | bash -x
   - cp -R . /tmp/3/ && cd /tmp/3/
   - git submodule sync
   - git submodule update --init --recursive --jobs 7

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -106,29 +106,29 @@ final case class SbtCommunityProject(project: String, sbtTestCommand: String,
 object projects
   lazy val utest = MillCommunityProject(
     project = "utest",
-    baseCommand = s"utest.jvm[$compilerVersion]",
+    baseCommand = "__.__",
   )
 
   lazy val sourcecode = MillCommunityProject(
     project = "sourcecode",
-    baseCommand = s"sourcecode.jvm[$compilerVersion]",
+    baseCommand = "__.__",
   )
 
   lazy val oslib = MillCommunityProject(
     project = "os-lib",
-    baseCommand = s"os[$compilerVersion]",
+    baseCommand = "os[__]",
     dependencies = List(utest, sourcecode)
   )
 
   lazy val oslibWatch = MillCommunityProject(
     project = "os-lib",
-    baseCommand = s"os.watch[$compilerVersion]",
+    baseCommand = "os.watch[__]",
     dependencies = List(utest, sourcecode)
   )
 
   lazy val ujson = MillCommunityProject(
     project = "upickle",
-    baseCommand = s"ujson.jvm[$compilerVersion]",
+    baseCommand = "ujson.__",
     dependencies = List(scalatest, scalacheck, scalatestplusScalacheck)
   )
 


### PR DESCRIPTION
Also, add a DroneCI setting to download the Scala Native
dependencies.

Cross-compilation tests, even though unrelated to Dotty, are needed to see if we don't break the Scala 2 versions of the libraries while porting them to Dotty.