### PR TITLE
Enable scalatestplus-scalacheck community project testing

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -160,7 +160,7 @@ object projects
 
   lazy val scalatestplusScalacheck = SbtCommunityProject(
     project = "scalatestplus-scalacheck",
-    sbtTestCommand = "scalatestPlusScalaCheckJVM/compile",  // TODO: compile only because tests are prone to java.lang.OutOfMemoryError: Metaspace
+    sbtTestCommand = "scalatestPlusScalaCheckJVM/test",
     sbtUpdateCommand = "scalatestPlusScalaCheckJVM/update",
     sbtPublishCommand = "scalatestPlusScalaCheckJVM/publishLocal",
     dependencies = List(scalatest, scalacheck)


### PR DESCRIPTION
The reason we only used to compile this test before
is because locally, it seems prone to OutOfMemory errors.
If the CI can't handle it, we should revert to compiling
this test only and investigating further.