### PR TITLE
Fix #7067: type avoidance should handle both ThisType and TypeRef

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -70,7 +70,9 @@ trait TypeAssigner {
         parent
     }
 
-    def close(tp: Type) = RecType.closeOver(rt => tp.substThis(cls, rt.recThis))
+    def close(tp: Type) = RecType.closeOver { rt =>
+      tp.subst(cls :: Nil, rt.recThis :: Nil).substThis(cls, rt.recThis)
+    }
 
     def isRefinable(sym: Symbol) = !sym.is(Private) && !sym.isConstructor
     val refinableDecls = info.decls.filter(isRefinable)

--- a/tests/pos/i7067.scala
+++ b/tests/pos/i7067.scala
@@ -1,0 +1,13 @@
+abstract class Foo[T] {
+  type Species
+  def foo(s: Species): Nothing = ???
+}
+
+class Test {
+def species[T] = {
+  class FooT extends Foo[T] {
+    type Species = FooT
+  }
+  new FooT()
+}
+}


### PR DESCRIPTION
Fix #7067: type avoidance should handle both ThisType and TypeRef

The test example shows that we could arrive at a type like
`A { type T = B }`, where `B <: A` and `B` is the type to avoid. Previously,
we only handle `ThisType(B)`, in this case we have `TypeRef(B)`.
The latter leads to loops in type avoidence.