### PR TITLE
Fix #7602: Avoid infinite loop with anonymous projection

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -614,6 +614,7 @@ object Types {
       }
       def goRec(tp: RecType) =
         if (tp.parent == null) NoDenotation
+        else if (tp eq pre) go(tp.parent)
         else {
           //println(s"find member $pre . $name in $tp")
 

--- a/tests/pos/i7602.scala
+++ b/tests/pos/i7602.scala
@@ -1,0 +1,7 @@
+object Test {
+  type X[T] = ({ type F[_]; type R = F[T]})#R
+
+  trait Monad[F[_]]
+  type of[M[_[_]], T] = ({ type F[_]; type R = (given M[F]) => F[T]})#R
+  def foo(a: of[Monad, String]) = ???
+}


### PR DESCRIPTION
`Type#findMember` has very careful logic for doing prefix substitution
with a recursive type, but it turns out we don't need to run any of that
if the prefix is already correct, and it avoids infinite loops in the
added testcase.