### PR TITLE
Fix #7618: Remove QuoteContext.macroContext

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -645,8 +645,6 @@ class Definitions {
     @tu lazy val QuotedExprModule_unitExpr: Symbol = QuotedExprModule.requiredMethod(nme.unitExpr)
 
   @tu lazy val QuoteContextClass: ClassSymbol = ctx.requiredClass("scala.quoted.QuoteContext")
-  @tu lazy val QuoteContextModule: Symbol = QuoteContextClass.companionModule
-    @tu lazy val QuoteContext_macroContext: Symbol = QuoteContextModule.requiredMethod("macroContext")
 
   @tu lazy val LiftableModule: Symbol = ctx.requiredModule("scala.quoted.Liftable")
     @tu lazy val LiftableModule_BooleanIsLiftable: Symbol = LiftableModule.requiredMethod("BooleanIsLiftable")

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -192,7 +192,6 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
     case Some(l) =>
       l == level ||
         level == -1 && (
-          sym == defn.QuoteContext_macroContext ||
             // here we assume that Splicer.canBeSpliced was true before going to level -1,
             // this implies that all non-inline arguments are quoted and that the following two cases are checked
             // on inline parameters or type parameters.

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -98,9 +98,6 @@ object Splicer {
         case Literal(Constant(value)) =>
           // OK
 
-        case _ if tree.symbol == defn.QuoteContext_macroContext =>
-          // OK
-
         case Call(fn, args)
             if (fn.symbol.isConstructor && fn.symbol.owner.owner.is(Package)) ||
                fn.symbol.is(Module) || fn.symbol.isStatic ||
@@ -191,9 +188,6 @@ object Splicer {
       case Literal(Constant(value)) =>
         interpretLiteral(value)
 
-      case _ if tree.symbol == defn.QuoteContext_macroContext =>
-        interpretQuoteContext()
-
       // TODO disallow interpreted method calls as arguments
       case Call(fn, args) =>
         if (fn.symbol.isConstructor && fn.symbol.owner.owner.is(Package))
@@ -262,9 +256,6 @@ object Splicer {
 
     private def interpretVarargs(args: List[Object])(implicit env: Env): Object =
       args.toSeq
-
-    private def interpretQuoteContext()(implicit env: Env): Object =
-      QuoteContext()
 
     private def interpretedStaticMethodCall(moduleClass: Symbol, fn: Symbol)(implicit env: Env): List[Object] => Object = {
       val (inst, clazz) =

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -732,11 +732,6 @@ trait Implicits { self: Typer =>
     }
   }
 
-  lazy val synthesizedQuoteContext: SpecialHandler =
-    (formal, span) => implicit ctx =>
-      if (ctx.inMacro || enclosingInlineds.nonEmpty) ref(defn.QuoteContext_macroContext)
-      else EmptyTree
-
   lazy val synthesizedTupleFunction: SpecialHandler =
     (formal, span) => implicit ctx => formal match {
       case AppliedType(_, funArgs @ fun :: tupled :: Nil) =>
@@ -1082,7 +1077,6 @@ trait Implicits { self: Typer =>
       mySpecialHandlers = List(
         defn.ClassTagClass        -> synthesizedClassTag,
         defn.QuotedTypeClass      -> synthesizedTypeTag,
-        defn.QuoteContextClass    -> synthesizedQuoteContext,
         defn.EqlClass             -> synthesizedEq,
         defn.TupledFunctionClass  -> synthesizedTupleFunction,
         defn.ValueOfClass         -> synthesizedValueOf,
@@ -1464,7 +1458,6 @@ trait Implicits { self: Typer =>
         case alt1: SearchSuccess =>
           var diff = compareCandidate(alt1, alt2.ref, alt2.level)
           assert(diff <= 0)   // diff > 0 candidates should already have been eliminated in `rank`
-          
           if diff == 0 then
             // Fall back: if both results are extension method applications,
             // compare the extension methods instead of their wrappers.

--- a/library/src/scala/quoted/QuoteContext.scala
+++ b/library/src/scala/quoted/QuoteContext.scala
@@ -47,7 +47,3 @@ class QuoteContext(val tasty: scala.tasty.Reflection) {
   }
 
 }
-
-object QuoteContext {
-  def macroContext: QuoteContext = throw new Exception("Not in inline macro.")
-}

--- a/tests/neg/i7618.scala
+++ b/tests/neg/i7618.scala
@@ -1,0 +1,36 @@
+package macros
+
+import scala.quoted.{given, _}
+
+enum Exp {
+  case Num(n: Int)
+  case Plus(e1: Exp, e2: Exp)
+  case Var(x: String)
+  case Let(x: String, e: Exp, in: Exp)
+}
+
+object Compiler {
+  import Exp._
+
+  inline def compile(e: Exp, env: Map[String, Expr[Int]])(given ctx: QuoteContext): Expr[Int] = inline e match { // error
+    case Num(n) =>
+      Expr(n)
+    case Plus(e1, e2) =>
+      '{ ${ compile(e1, env) } + ${ compile(e2, env) } }
+    case Var(x) =>
+      env(x)
+    case Let(x, e, body) =>
+      '{ val y = ${ compile(e, env) }; ${ compile(body, env + (x -> 'y)) } }
+  }
+}
+
+object Example {
+  def run(): Unit = {
+    import Exp._
+
+    val exp = Plus(Plus(Num(2), Var("x")), Num(4))
+    val letExp = Let("x", Num(3), exp)
+
+    Compiler.compile(letExp, Map.empty)(given QuoteContext.macroContext) // error
+  }
+}

--- a/tests/neg/i7618b.scala
+++ b/tests/neg/i7618b.scala
@@ -1,0 +1,36 @@
+package macros
+
+import scala.quoted.{given, _}
+
+enum Exp {
+  case Num(n: Int)
+  case Plus(e1: Exp, e2: Exp)
+  case Var(x: String)
+  case Let(x: String, e: Exp, in: Exp)
+}
+
+object Compiler {
+  import Exp._
+
+  inline def compile(e: Exp, env: Map[String, Expr[Int]])(given ctx: QuoteContext): Expr[Int] = inline e match { // error
+    case Num(n) =>
+      Expr(n)
+    case Plus(e1, e2) =>
+      '{ ${ compile(e1, env) } + ${ compile(e2, env) } }
+    case Var(x) =>
+      env(x)
+    case Let(x, e, body) =>
+      '{ val y = ${ compile(e, env) }; ${ compile(body, env + (x -> 'y)) } }
+  }
+}
+
+object Example {
+  def run(): Unit = {
+    import Exp._
+
+    val exp = Plus(Plus(Num(2), Var("x")), Num(4))
+    val letExp = Let("x", Num(3), exp)
+
+    Compiler.compile(letExp, Map.empty)(given (??? : QuoteContext))
+  }
+}

--- a/tests/pos/i7358.scala
+++ b/tests/pos/i7358.scala
@@ -3,7 +3,7 @@ package test
 import scala.quoted._
 import scala.compiletime._
 
-inline def summonT[Tp <: Tuple] <: Tuple = inline erasedValue[Tp] match {
+inline def summonT[Tp <: Tuple](given QuoteContext) <: Tuple = inline erasedValue[Tp] match {
   case _ : Unit => ()
   case _ : (hd *: tl) => {
     type H = hd
@@ -13,4 +13,4 @@ inline def summonT[Tp <: Tuple] <: Tuple = inline erasedValue[Tp] match {
   }
 }
 
-def test[T : Type] = summonT[Tuple1[List[T]]]
+def test[T : Type](given QuoteContext) = summonT[Tuple1[List[T]]]

--- a/tests/run-staging/quote-macro-in-splice/quoted_2.scala
+++ b/tests/run-staging/quote-macro-in-splice/quoted_2.scala
@@ -8,14 +8,11 @@ object Test {
     val x = '{
       val y = 1
       ${
-        // FIXME remove context when $ will provide one
-        // Currently we would accidentally capture the one from withQuoteContext
-        inline def a(z: Int): Int = ${ impl('z)(given QuoteContext.macroContext) }
+        inline def a(z: Int): Int = ${ impl('z) }
         val b = Expr(a(7))
         '{ y + $b }
       }
     }
     println(x.show)
   }
-
 }


### PR DESCRIPTION
This was an old context that was synthesized for macros before we used implicit function types within splices to provide the context.