### PR TITLE
Emit inline errors at expansion site

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
@@ -33,7 +33,7 @@ trait MessageRendering {
     */
   def outer(pos: SourcePosition, prefix: String)(implicit ctx: Context): List[String] =
     if (pos.outer.exists)
-       i"$prefix| This location is in code that was inlined at ${pos.outer}" ::
+       i"$prefix| This location is in code that was inlined at $pos" ::
        outer(pos.outer, prefix)
     else Nil
 
@@ -149,9 +149,10 @@ trait MessageRendering {
     val posString = posStr(pos, diagnosticLevel, msg)
     if (posString.nonEmpty) sb.append(posString).append(EOL)
     if (pos.exists && pos.source.file.exists) {
-      val (srcBefore, srcAfter, offset) = sourceLines(pos, diagnosticLevel)
-      val marker = columnMarker(pos, offset, diagnosticLevel)
-      val err = errorMsg(pos, msg.msg, offset)
+      val pos1 = pos.nonInlined
+      val (srcBefore, srcAfter, offset) = sourceLines(pos1, diagnosticLevel)
+      val marker = columnMarker(pos1, offset, diagnosticLevel)
+      val err = errorMsg(pos1, msg.msg, offset)
       sb.append((srcBefore ::: marker :: err :: outer(pos, " " * (offset - 1)) ::: srcAfter).mkString(EOL))
     }
     else sb.append(msg.msg)

--- a/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
@@ -114,9 +114,9 @@ trait MessageRendering {
     */
   def posStr(pos: SourcePosition, diagnosticLevel: String, message: Message)(implicit ctx: Context): String =
     if (pos.exists) hl(diagnosticLevel)({
+      val pos1 = pos.nonInlined
       val file =
-        if (pos.source.file.exists) s"${pos.source.file.toString}:${pos.line + 1}:${pos.column}"
-        else s"${pos.source.file.toString}: offset ${pos.start} (missing source file)"
+        s"${pos1.source.file.toString}:${pos1.line + 1}:${pos1.column}"
       val errId =
         if (message.errorId ne ErrorMessageID.NoExplanationID) {
           val errorNumber = message.errorId.errorNumber

--- a/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
@@ -33,7 +33,7 @@ trait MessageRendering {
     */
   def outer(pos: SourcePosition, prefix: String)(implicit ctx: Context): List[String] =
     if (pos.outer.exists)
-       i"$prefix| This location is in code that was inlined at $pos" ::
+       i"$prefix| This location contains code that was inlined from $pos" ::
        outer(pos.outer, prefix)
     else Nil
 

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -64,6 +64,17 @@ extends interfaces.SourcePosition with Showable {
   def outermost: SourcePosition =
     if outer == null || outer == NoSourcePosition then this else outer.outermost
 
+  /** Inner most position that is contained within the `outermost` position.
+   *  Most precise position that that comes from the call site.
+   */
+  def nonInlined: SourcePosition = {
+    val om = outermost
+    def rec(self: SourcePosition): SourcePosition =
+      if outermost.contains(self) then self else rec(self.outer)
+    rec(this)
+  }
+
+
   override def toString: String =
     s"${if (source.exists) source.file.toString else "(no source)"}:$span"
 

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -70,7 +70,7 @@ extends interfaces.SourcePosition with Showable {
   def nonInlined: SourcePosition = {
     val om = outermost
     def rec(self: SourcePosition): SourcePosition =
-      if outermost.contains(self) then self else rec(self.outer)
+      if om.contains(self) then self else rec(self.outer)
     rec(this)
   }
 
@@ -86,4 +86,3 @@ extends interfaces.SourcePosition with Showable {
   override def toString: String = "?"
   override def withOuter(outer: SourcePosition): SourcePosition = outer
 }
-

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -679,11 +679,12 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     }
 
     def getMissingExpectedErrors(errorMap: HashMap[String, Integer], reporterErrors: Iterator[MessageContainer]) = !reporterErrors.forall { error =>
-      val key = if (error.pos.exists) {
+      val pos1 = error.pos.nonInlined
+      val key = if (pos1.exists) {
         def toRelative(path: String): String =  // For some reason, absolute paths leak from the compiler itself...
           path.split("/").dropWhile(_ != "tests").mkString("/")
-        val fileName = toRelative(error.pos.source.file.toString)
-        s"$fileName:${error.pos.line}"
+        val fileName = toRelative(pos1.source.file.toString)
+        s"$fileName:${pos1.line}"
 
       } else "nopos"
 
@@ -695,7 +696,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
         true
       }
       else {
-        echo(s"Error reported in ${error.pos.source}, but no annotation found")
+        echo(s"Error reported in ${pos1.source}, but no annotation found")
         false
       }
     }

--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -50,7 +50,7 @@ cp tests/neg/i6371/B_2.scala $OUT/B.scala
 "$SBT" "dotc $OUT/A.scala -d $OUT1"
 rm $OUT/A.scala
 "$SBT" "dotc -classpath $OUT1 -d $OUT1 $OUT/B.scala" > "$tmp" 2>&1 || echo "ok"
-grep -qe "A.scala: offset 63 (missing source file)" "$tmp"
+grep -qe "B.scala:2:7" "$tmp"
 
 
 ## Disabled because of flakeyness, should be changed to not depend on sbt

--- a/tests/neg-macros/delegate-match-1.check
+++ b/tests/neg-macros/delegate-match-1.check
@@ -4,4 +4,4 @@
   |  ^
   |  AmbiguousImplicits
   |  both value a1 in class Test1 and value a2 in class Test1 match type A
-  | This location is in code that was inlined at Test_2.scala:6
+  | This location contains code that was inlined from Test_2.scala:6

--- a/tests/neg-macros/delegate-match-2.check
+++ b/tests/neg-macros/delegate-match-2.check
@@ -4,4 +4,4 @@
   |  ^
   |  DivergingImplicit
   |  method a1 in class Test produces a diverging implicit search when trying to match type A
-  | This location is in code that was inlined at Test_2.scala:5
+  | This location contains code that was inlined from Test_2.scala:5

--- a/tests/neg-macros/delegate-match-3.check
+++ b/tests/neg-macros/delegate-match-3.check
@@ -4,4 +4,4 @@
   |  ^
   |  NoMatchingImplicits
   |  no implicit values were found that match type A
-  | This location is in code that was inlined at Test_2.scala:3
+  | This location contains code that was inlined from Test_2.scala:3

--- a/tests/neg-macros/i6432.check
+++ b/tests/neg-macros/i6432.check
@@ -3,14 +3,14 @@
 4 |  foo"abc${"123"}xyz${"456"}fgh" // error // error // error
   |      ^^^
   |      abc
-  | This location is in code that was inlined at Test_2.scala:4
+  | This location contains code that was inlined from Test_2.scala:4
 -- Error: tests/neg-macros/i6432/Test_2.scala:4:17 ---------------------------------------------------------------------
 4 |  foo"abc${"123"}xyz${"456"}fgh" // error // error // error
   |                 ^^^
   |                 xyz
-  | This location is in code that was inlined at Test_2.scala:4
+  | This location contains code that was inlined from Test_2.scala:4
 -- Error: tests/neg-macros/i6432/Test_2.scala:4:28 ---------------------------------------------------------------------
 4 |  foo"abc${"123"}xyz${"456"}fgh" // error // error // error
   |                            ^^^
   |                            fgh
-  | This location is in code that was inlined at Test_2.scala:4
+  | This location contains code that was inlined from Test_2.scala:4

--- a/tests/neg-macros/i6432b.check
+++ b/tests/neg-macros/i6432b.check
@@ -3,14 +3,14 @@
 4 |  foo"""abc${"123"}xyz${"456"}fgh""" // error // error // error
   |        ^^^
   |        abc
-  | This location is in code that was inlined at Test_2.scala:4
+  | This location contains code that was inlined from Test_2.scala:4
 -- Error: tests/neg-macros/i6432b/Test_2.scala:4:19 --------------------------------------------------------------------
 4 |  foo"""abc${"123"}xyz${"456"}fgh""" // error // error // error
   |                   ^^^
   |                   xyz
-  | This location is in code that was inlined at Test_2.scala:4
+  | This location contains code that was inlined from Test_2.scala:4
 -- Error: tests/neg-macros/i6432b/Test_2.scala:4:30 --------------------------------------------------------------------
 4 |  foo"""abc${"123"}xyz${"456"}fgh""" // error // error // error
   |                              ^^^
   |                              fgh
-  | This location is in code that was inlined at Test_2.scala:4
+  | This location contains code that was inlined from Test_2.scala:4

--- a/tests/neg-macros/i6976.check
+++ b/tests/neg-macros/i6976.check
@@ -6,4 +6,4 @@
   |    scala.MatchError: Inlined(EmptyTree,List(),Literal(Constant(2))) (of class dotty.tools.dotc.ast.Trees$Inlined)
   |    	at playground.macros$.mcrImpl(Macro_1.scala:12)
   |
-  | This location is in code that was inlined at Test_2.scala:5
+  | This location contains code that was inlined from Test_2.scala:5

--- a/tests/neg-macros/macro-class-not-found-1.check
+++ b/tests/neg-macros/macro-class-not-found-1.check
@@ -5,4 +5,4 @@
   |  java.lang.NoClassDefFoundError
   |  	at Foo$.aMacroImplementation(Foo.scala:8)
   |
-  | This location is in code that was inlined at Bar.scala:4
+  | This location contains code that was inlined from Bar.scala:4

--- a/tests/neg-macros/macro-class-not-found-2.check
+++ b/tests/neg-macros/macro-class-not-found-2.check
@@ -5,4 +5,4 @@
   |  java.lang.NoClassDefFoundError: this.is.not.a.Class
   |  	at Foo$.aMacroImplementation(Foo.scala:8)
   |
-  | This location is in code that was inlined at Bar.scala:4
+  | This location contains code that was inlined from Bar.scala:4

--- a/tests/neg-macros/macros-in-same-project-2.scala
+++ b/tests/neg-macros/macros-in-same-project-2.scala
@@ -3,9 +3,9 @@ import scala.quoted._
 
 object Bar {
 
-  myMacro()
+  myMacro() // error
 
-  inline def myMacro(): Unit = myMacro2() // error
+  inline def myMacro(): Unit = myMacro2()
   inline def myMacro2(): Unit = ${ aMacroImplementation }
 
   def aMacroImplementation(given QuoteContext): Expr[Unit] = '{}

--- a/tests/neg-macros/macros-in-same-project-6.check
+++ b/tests/neg-macros/macros-in-same-project-6.check
@@ -2,4 +2,4 @@
 4 |  Foo.myMacro() // error
   |  ^^^^^^^^^^^^^
   |  some error
-  | This location is in code that was inlined at Bar.scala:4
+  | This location contains code that was inlined from Bar.scala:4

--- a/tests/neg/cannot-reduce-inline-match.check
+++ b/tests/neg/cannot-reduce-inline-match.check
@@ -6,4 +6,4 @@
   |    "f"
   |  } : String("f")
   |   patterns :  case _:Int
-  | This location is in code that was inlined at cannot-reduce-inline-match.scala:3
+  | This location contains code that was inlined from cannot-reduce-inline-match.scala:3

--- a/tests/neg/cannot-reduce-inline-match.check
+++ b/tests/neg/cannot-reduce-inline-match.check
@@ -1,4 +1,4 @@
--- Error: tests/neg/cannot-reduce-inline-match.scala:3:13 --------------------------------------------------------------
+-- Error: tests/neg/cannot-reduce-inline-match.scala:9:5 ---------------------------------------------------------------
 9 |  foo("f") // error
   |  ^^^^^^^^
   |  cannot reduce inline match with

--- a/tests/neg/cannot-reduce-inline-match.check
+++ b/tests/neg/cannot-reduce-inline-match.check
@@ -1,11 +1,9 @@
 -- Error: tests/neg/cannot-reduce-inline-match.scala:3:13 --------------------------------------------------------------
-3 |    inline x match { // error
-  |           ^
-  |           cannot reduce inline match with
-  |            scrutinee:  {
-  |             "f"
-  |           } : String("f")
-  |            patterns :  case _:Int
-  | This location is in code that was inlined at cannot-reduce-inline-match.scala:9
-4 |      case _: Int =>
-5 |    }
+9 |  foo("f") // error
+  |  ^^^^^^^^
+  |  cannot reduce inline match with
+  |   scrutinee:  {
+  |    "f"
+  |  } : String("f")
+  |   patterns :  case _:Int
+  | This location is in code that was inlined at cannot-reduce-inline-match.scala:3

--- a/tests/neg/cannot-reduce-inline-match.scala
+++ b/tests/neg/cannot-reduce-inline-match.scala
@@ -1,11 +1,11 @@
 object Test {
   inline def foo[T](x: T) =
-    inline x match { // error
+    inline x match {
       case _: Int =>
     }
 
   foo(4)
 
-  foo("f")
+  foo("f") // error
 
 }

--- a/tests/neg/cannot-reduce-summonFrom.scala
+++ b/tests/neg/cannot-reduce-summonFrom.scala
@@ -1,7 +1,7 @@
 object Test {
 
   inline def bar() =
-    compiletime.summonFrom {  // error
+    compiletime.summonFrom {
       case _: Int =>
     }
 
@@ -10,5 +10,5 @@ object Test {
     bar()
   }
 
-  bar()
+  bar() // error
 }

--- a/tests/neg/i6371/A_1.scala
+++ b/tests/neg/i6371/A_1.scala
@@ -1,6 +1,6 @@
 object A {
   inline def foo(a: Any): Unit = a match {
-    case _: Int => // error
+    case _: Int =>
     case _ =>
   }
 }

--- a/tests/neg/i6371/B_2.scala
+++ b/tests/neg/i6371/B_2.scala
@@ -1,3 +1,3 @@
 object B {
-  A.foo("aa")
+  A.foo("aa") // error
 }

--- a/tests/neg/i7618.scala
+++ b/tests/neg/i7618.scala
@@ -12,7 +12,7 @@ enum Exp {
 object Compiler {
   import Exp._
 
-  inline def compile(e: Exp, env: Map[String, Expr[Int]])(given ctx: QuoteContext): Expr[Int] = inline e match { // error
+  inline def compile(e: Exp, env: Map[String, Expr[Int]])(given ctx: QuoteContext): Expr[Int] = inline e match {
     case Num(n) =>
       Expr(n)
     case Plus(e1, e2) =>
@@ -31,6 +31,6 @@ object Example {
     val exp = Plus(Plus(Num(2), Var("x")), Num(4))
     val letExp = Let("x", Num(3), exp)
 
-    Compiler.compile(letExp, Map.empty)(given QuoteContext.macroContext) // error
+    Compiler.compile(letExp, Map.empty)(given QuoteContext.macroContext) // error // error
   }
 }

--- a/tests/neg/i7618b.scala
+++ b/tests/neg/i7618b.scala
@@ -12,7 +12,7 @@ enum Exp {
 object Compiler {
   import Exp._
 
-  inline def compile(e: Exp, env: Map[String, Expr[Int]])(given ctx: QuoteContext): Expr[Int] = inline e match { // error
+  inline def compile(e: Exp, env: Map[String, Expr[Int]])(given ctx: QuoteContext): Expr[Int] = inline e match {
     case Num(n) =>
       Expr(n)
     case Plus(e1, e2) =>
@@ -31,6 +31,6 @@ object Example {
     val exp = Plus(Plus(Num(2), Var("x")), Num(4))
     val letExp = Let("x", Num(3), exp)
 
-    Compiler.compile(letExp, Map.empty)(given (??? : QuoteContext))
+    Compiler.compile(letExp, Map.empty)(given (??? : QuoteContext)) // error
   }
 }

--- a/tests/neg/inline-error-pos.check
+++ b/tests/neg/inline-error-pos.check
@@ -6,4 +6,4 @@
   |            2
   |          } : Int(2)
   |           patterns :  case 1
-  | This location is in code that was inlined at inline-error-pos.scala:3
+  | This location contains code that was inlined from inline-error-pos.scala:3

--- a/tests/neg/inline-error-pos.check
+++ b/tests/neg/inline-error-pos.check
@@ -1,4 +1,4 @@
--- Error: tests/neg/inline-error-pos.scala:3:11 ------------------------------------------------------------------------
+-- Error: tests/neg/inline-error-pos.scala:8:13 ------------------------------------------------------------------------
 8 |  val b = foo(2) // error
   |          ^^^^^^
   |          cannot reduce inline match with

--- a/tests/neg/inline-error-pos.check
+++ b/tests/neg/inline-error-pos.check
@@ -1,0 +1,9 @@
+-- Error: tests/neg/inline-error-pos.scala:3:11 ------------------------------------------------------------------------
+8 |  val b = foo(2) // error
+  |          ^^^^^^
+  |          cannot reduce inline match with
+  |           scrutinee:  {
+  |            2
+  |          } : Int(2)
+  |           patterns :  case 1
+  | This location is in code that was inlined at inline-error-pos.scala:3

--- a/tests/neg/inline-error-pos.scala
+++ b/tests/neg/inline-error-pos.scala
@@ -1,0 +1,9 @@
+
+inline def foo(x: Int): Int =
+  inline x match
+    case 1 => 9
+
+object Foo {
+  val a = foo(1)
+  val b = foo(2) // error
+}

--- a/tests/neg/inlineAccess/C_1.scala
+++ b/tests/neg/inlineAccess/C_1.scala
@@ -2,7 +2,7 @@ package p
 private class D
 class C {
   inline def inl(): Unit = {
-    val d = new D()     // error (when inlined): not accessible
+    val d = new D()
   }
 }
 

--- a/tests/neg/inlineAccess/Test_2.scala
+++ b/tests/neg/inlineAccess/Test_2.scala
@@ -2,6 +2,6 @@
 object Test {
   def main(args: Array[String]) = {
     val c = new p.C()
-    c.inl()
+    c.inl() // error (when inlined): not accessible
   }
 }

--- a/tests/neg/summonFrom-ambiguous-bind.scala
+++ b/tests/neg/summonFrom-ambiguous-bind.scala
@@ -3,7 +3,7 @@ object `implicit-match-ambiguous-bind` {
   implicit val ibox: Box[Int] = Box(0)
   implicit val sbox: Box[String] = Box("")
   inline def unbox = compiletime.summonFrom {
-    case b: Box[t] => b.value // error
+    case b: Box[t] => b.value
   }
-  val unboxed = unbox
+  val unboxed = unbox // error
 }

--- a/tests/neg/summonFrom-ambiguous.scala
+++ b/tests/neg/summonFrom-ambiguous.scala
@@ -5,8 +5,8 @@ object Test {
   implicit val a2: A = new A
 
   inline def f: Any = compiletime.summonFrom {
-    case _: A => ???  // error: ambiguous implicits
+    case _: A => ???
   }
 
-  f
+  f // error: ambiguous implicits
 }


### PR DESCRIPTION
This is more informative for users of an inline (or macro) method. It also avoids trying to load sources from libraries to show the position.