### PR TITLE
Fix #7683: Fix CompilationUnit handling in Context#withSource

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -83,9 +83,14 @@ object CompilationUnit {
     unit1
   }
 
-  def apply(source: SourceFile)(implicit ctx: Context): CompilationUnit = {
+  /** Create a compilation unit corresponding to `source`.
+   *  If `mustExist` is true, this will fail if `source` does not exist.
+   */
+  def apply(source: SourceFile, mustExist: Boolean = true)(implicit ctx: Context): CompilationUnit = {
     val src =
-      if (source.file.isDirectory) {
+      if (!mustExist)
+        source
+      else if (source.file.isDirectory) {
         ctx.error(s"expected file, received directory '${source.file.path}'")
         NoSource
       }

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -468,7 +468,10 @@ object Contexts {
         else {
           val newCtx = fresh.setSource(source)
           if (newCtx.compilationUnit == null)
-            newCtx.setCompilationUnit(CompilationUnit(source))
+            // `source` might correspond to a file not necessarily
+            // in the current project (e.g. when inlining library code),
+            // so set `mustExist` to false.
+            newCtx.setCompilationUnit(CompilationUnit(source, mustExist = false))
           sourceCtx = sourceCtx.updated(source, newCtx)
           newCtx
         }

--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc.printing
+package dotty.tools.dotc
+package printing
 
 import dotty.tools.dotc.ast.untpd
 import dotty.tools.dotc.core.Contexts.Context
@@ -32,8 +33,10 @@ object SyntaxHighlighting {
     def freshCtx = ctx.fresh.setReporter(Reporter.NoReporter)
     if (in.isEmpty || ctx.settings.color.value == "never") in
     else {
-      implicit val ctx = freshCtx
       val source = SourceFile.virtual("<highlighting>", in)
+
+      implicit val ctx = freshCtx.setCompilationUnit(CompilationUnit(source, mustExist = false)(freshCtx))
+
       val colorAt = Array.fill(in.length)(NoColor)
 
       def highlightRange(from: Int, to: Int, color: String) =

--- a/compiler/test/dotty/tools/dotc/printing/SyntaxHighlightingTests.scala
+++ b/compiler/test/dotty/tools/dotc/printing/SyntaxHighlightingTests.scala
@@ -110,6 +110,8 @@ class SyntaxHighlightingTests extends DottyTest {
 
     test("def f1(x: Int) = 123", "<K|def> <V|f1>(<V|x>: <T|Int>) = <L|123>")
     test("def f2[T](x: T) = { 123 }", "<K|def> <V|f2>[<T|T>](<V|x>: <T|T>) = { <L|123> }")
+
+    test("def f3[T[_", "<K|def> <V|f3>[<T|T>[<T|_>")
   }
 
   @Test


### PR DESCRIPTION
In e07a72888d11d824a9076ba5c025e033c250c7fb, I changed
Context#withSource to set a new CompilationUnit based on the source if
no compilation unit is currently set (always having a CompilationUnit
set is now needed since I moved the fresh name generator inside
CompilationUnit), however CompilationUnit#apply will error out if the
source file does not exist, which might happen for library code.

Fixed by adding a parameter to disable this check, but this is not very
pretty and we should really try to design a better way to distinguish
between user source files and source files we happen to know the name of
because it's stored in Tasty.