### PR TITLE
Fix typos

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -76,7 +76,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
 
     override def getCurrentCUnit(): CompilationUnit = { cunit }
 
-    /* ---------------- helper utils for generating classes and fiels ---------------- */
+    /* ---------------- helper utils for generating classes and fields ---------------- */
 
     def genPlainClass(cd: ClassDef) = cd match {
       case ClassDef(_, _, _, impl) =>

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSyncAndTry.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSyncAndTry.scala
@@ -310,7 +310,7 @@ trait BCodeSyncAndTry extends BCodeBodyBuilder {
        * ------
        */
 
-      // a note on terminology: this is not "postHandlers", despite appearences.
+      // a note on terminology: this is not "postHandlers", despite appearances.
       // "postHandlers" as in the source-code view. And from that perspective, both (3.A) and (3.B) are invisible implementation artifacts.
       if (hasFinally) withFreshCleanupScope {
         nopIfNeeded(startTryBody)

--- a/compiler/src/dotty/tools/backend/jvm/BTypes.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypes.scala
@@ -362,7 +362,7 @@ abstract class BTypes {
    *
    *  - Initializer block (JLS 8.6 / 8.7): block of statements in a java class
    *    - static initializer: executed before constructor body
-   *    - instance initializer: exectued when class is initialized (instance creation, static
+   *    - instance initializer: executed when class is initialized (instance creation, static
    *      field access, ...)
    *
    *  - A static nested class can be defined as

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -133,7 +133,7 @@ object Flags {
         strs filter (_.nonEmpty)
       }
 
-    /** The list of non-empty names of flags that are set in teh given flag set */
+    /** The list of non-empty names of flags that are set in the given flag set */
     def flagStrings(privateWithin: String): Seq[String] = {
       var rawStrings = (2 to MaxFlag).flatMap(x.flagString(_)) // DOTTY problem: cannot drop with (_)
       if (!privateWithin.isEmpty && !x.is(Protected))

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -137,7 +137,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
   protected def approxState: ApproxState = approx
 
   /** The original left-hand type of the comparison. Gets reset
-   *  everytime we compare components of the previous pair of types.
+   *  every time we compare components of the previous pair of types.
    *  This type is used for capture conversion in `isSubArgs`.
    */
   private [this] var leftRoot: Type = _

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -468,7 +468,7 @@ class ClassfileParser(
         classTParams = tparams
         val parents = new ListBuffer[Type]()
         while (index < end)
-          parents += sig2type(tparams, skiptvs = false)  // here the variance doesnt'matter
+          parents += sig2type(tparams, skiptvs = false)  // here the variance doesn't matter
         TempClassInfoType(parents.toList, instanceScope, owner)
       }
     if (ownTypeParams.isEmpty) tpe else TempPolyType(ownTypeParams, tpe)

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -24,7 +24,7 @@ class Pickler extends Phase {
 
   override def phaseName: String = Pickler.name
 
-  // No need to repickle trees comming from TASTY
+  // No need to repickle trees coming from TASTY
   override def isRunnable(implicit ctx: Context): Boolean =
     super.isRunnable && !ctx.settings.fromTasty.value
 

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -328,7 +328,7 @@ class ReifyQuotes extends MacroTransform {
           }
         )
       }
-      /* Lambdas are generated outside the quote that is beeing reified (i.e. in outer.owner).
+      /* Lambdas are generated outside the quote that is being reified (i.e. in outer.owner).
        * In case the case that level == -1 the code is not in a quote, it is in an inline method,
        * hence we should take that as owner directly.
        */

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -1296,7 +1296,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
     else normalizedSplice.withSpan(span)
   }
 
-  /** Return the set of symbols that are refered at level -1 by the tree and defined in the current run.
+  /** Return the set of symbols that are referred at level -1 by the tree and defined in the current run.
    *  This corresponds to the symbols that will need to be interpreted.
    */
   private def macroDependencies(tree: Tree)(implicit ctx: Context) =

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -270,7 +270,7 @@ trait QuotesAndSplices {
    *  will also transform it into a call to `scala.internal.quoted.Expr.unapply`.
    *
    *  Code directly inside the quote is typed as an expression using Mode.QuotedPattern. Splices
-   *  within the quotes become patterns again and typed acordingly.
+   *  within the quotes become patterns again and typed accordingly.
    *
    *  ```
    *  case '{ ($ls: List[$t]) } =>

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -40,7 +40,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None) {
       myClassLoader = new AbstractFileClassLoader(ctx.settings.outputDir.value, parent)
       myReplStringOf = {
         // We need to use the ScalaRunTime class coming from the scala-library
-        // on the user classpath, and not the one avilable in the current
+        // on the user classpath, and not the one available in the current
         // classloader, so we use reflection instead of simply calling
         // `ScalaRunTime.replStringOf`.
         val scalaRuntime = Class.forName("scala.runtime.ScalaRunTime", true, myClassLoader)

--- a/compiler/test/dotty/tools/ContextEscapeDetector.java
+++ b/compiler/test/dotty/tools/ContextEscapeDetector.java
@@ -67,7 +67,7 @@ public class ContextEscapeDetector extends RunListener {
 
     private static synchronized void forceGCHeuristic2() {
         try {
-            Object[] arr = new Object[1024]; // upto 8 GB
+            Object[] arr = new Object[1024]; // up to 8 GB
             WeakReference<Object> ref = new WeakReference<>(arr);
             o = arr; // make sure array isn't optimized away
 

--- a/docs/docs/contributing/debugging.md
+++ b/docs/docs/contributing/debugging.md
@@ -49,7 +49,7 @@ Then:
 dotc ../issues/Playground.scala
 ```
 
-The techniques discussed below can be tried out in place of `println("Hello Debug")` in that location. They are of course applicable thoughout the codebase.
+The techniques discussed below can be tried out in place of `println("Hello Debug")` in that location. They are of course applicable throughout the codebase.
 
 ## Show for human readable output
 Many objects in the compiler have a `show` method available on them via implicit rich wrapper:

--- a/docs/docs/reference/contextual/derivation.md
+++ b/docs/docs/reference/contextual/derivation.md
@@ -211,7 +211,7 @@ types refined as revealed by the match.
 
 In the sum case, `eqSum`, we use the runtime `ordinal` values of the arguments to `eqv` to first check if the two
 values are of the same subtype of the ADT (3) and then, if they are, to further test for equality based on the `Eq`
-instance for the appropriate ADT subtype using the auxilliary method `check` (4).
+instance for the appropriate ADT subtype using the auxiliary method `check` (4).
 
 ```scala
 def eqSum[T](s: Mirror.SumOf[T], elems: List[Eq[_]]): Eq[T] =

--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -311,7 +311,7 @@ def showExpr[T](expr: Expr[T]): Expr[String] = {
 That is, the `showExpr` method converts its `Expr` argument to a string (`code`), and lifts
 the result back to an `Expr[String]` using `Expr.apply`.
 
-**Note**: Lifting `String` to `Expr[String]` using `Expr(code)` can be ommited by importing an implicit
+**Note**: Lifting `String` to `Expr[String]` using `Expr(code)` can be omitted by importing an implicit
 conversion with `import scala.quoted.autolift.given`. The programmer is able to
 declutter slightly the code at the cost of readable _phase distinction_ between
 stages.

--- a/docs/docs/reference/new-types/dependent-function-types-spec.md
+++ b/docs/docs/reference/new-types/dependent-function-types-spec.md
@@ -34,7 +34,7 @@ where the result type parameter `R'` is the least upper approximation of the
 precise result type `R` without any referance to value parameters `x1, ..., xN`.
 
 The syntax and sementics of anonymous dependent functions is identical to the
-one of regular functions. Eta expansion is naturaly generalized to produce
+one of regular functions. Eta expansion is naturally generalized to produce
 dependent function types for methods with dependent result types.
 
 Dependent functions can be implicit, and generalize to arity `N > 22` in the

--- a/library/src-bootstrapped/scala/quoted/util/Var.scala
+++ b/library/src-bootstrapped/scala/quoted/util/Var.scala
@@ -15,7 +15,7 @@ sealed trait Var[T] {
 
 object Var {
   /** Create a variable initialized with `init` and used in `body`.
-   *  `body` recieves a `Var[T]` argument which exposes `get` and `update`.
+   *  `body` receives a `Var[T]` argument which exposes `get` and `update`.
    *
    *  Var('{7}) {
    *    x => '{

--- a/library/src/scala/internal/Quoted.scala
+++ b/library/src/scala/internal/Quoted.scala
@@ -35,7 +35,7 @@ object Quoted {
    *
    *  During quote reification a quote `'{ ... F[$t] ... }` will be transformed into
    *  `'{ @quoteTypeTag type T$1 = $t ... F[T$1] ... }` to have a tree for `$t`.
-   *  This artifact is removed durring quote unpickling.
+   *  This artifact is removed during quote unpickling.
    *
    *  See ReifyQuotes.scala and PickledQuotes.scala
    */

--- a/library/src/scala/tasty/reflect/CompilerInterface.scala
+++ b/library/src/scala/tasty/reflect/CompilerInterface.scala
@@ -886,7 +886,7 @@ trait CompilerInterface {
   def TypeRef_qualifier(self: TypeRef)(given ctx: Context): TypeOrBounds
   def TypeRef_name(self: TypeRef)(given Context): String
 
-  /** Type of a `super` refernce */
+  /** Type of a `super` reference */
   type SuperType <: Type
 
   def isInstanceOfSuperType(given ctx: Context): IsInstanceOf[SuperType]

--- a/library/src/scala/tasty/reflect/Core.scala
+++ b/library/src/scala/tasty/reflect/Core.scala
@@ -312,7 +312,7 @@ trait Core {
       /** Type of a reference to a type symbol */
       type TypeRef = internal.TypeRef
 
-      /** Type of a `super` refernce */
+      /** Type of a `super` reference */
       type SuperType = internal.SuperType
 
       /** A type with a type refinement `T { type U }` */

--- a/library/src/scala/tasty/reflect/FlagsOps.scala
+++ b/library/src/scala/tasty/reflect/FlagsOps.scala
@@ -56,7 +56,7 @@ trait FlagsOps extends Core {
     /** Is this symbol `inline` */
     def Inline: Flags = internal.Flags_Inline
 
-    /** Is this symbol markes as a macro. An inline method containing toplevel splices */
+    /** Is this symbol marked as a macro. An inline method containing toplevel splices */
     def Macro: Flags = internal.Flags_Macro
 
     /** Is this symbol marked as static. Mapped to static Java member */

--- a/library/src/scala/tasty/reflect/SymbolOps.scala
+++ b/library/src/scala/tasty/reflect/SymbolOps.scala
@@ -128,7 +128,7 @@ trait SymbolOps extends Core { selfSymbolOps: FlagsOps =>
     def isTypeParam(given ctx: Context): Boolean =
       internal.Symbol_isTypeParam(self)
 
-    /** Signature of this defintion */
+    /** Signature of this definition */
     def signature(given ctx: Context): Signature =
       internal.Symbol_signature(self)
 

--- a/tastydoc/src/dotty/tastydoc/TastyTypeConverter.scala
+++ b/tastydoc/src/dotty/tastydoc/TastyTypeConverter.scala
@@ -46,7 +46,7 @@ trait TastyTypeConverter {
           case r if (info match {case reflect.IsTypeBounds(info) => true case _ => false}) => ("type", name, r)
           case r@TypeReference(_, _, _, _) => ("val", name, r)
           case ByNameReference(rChild) => ("def", name, rChild)
-          case r => throw new Exception("Match error in info of Refinement. This should not happend, please open an issue. " + r)
+          case r => throw new Exception("Match error in info of Refinement. This should not happen, please open an issue. " + r)
         }
         convertTypeToReference(reflect)(parent) match {
           case RefinedReference(p, ls) =>

--- a/tests/disabled/reflect/run/t8190.scala
+++ b/tests/disabled/reflect/run/t8190.scala
@@ -1,7 +1,7 @@
 import scala.reflect.runtime.universe._
 
 trait Overloads {
-  // makes sure noone erases to Any or AnyRef
+  // makes sure no one erases to Any or AnyRef
   def test(x: AnyRef) = "AnyRef"
   def test(x: Annotation) = "Annotation"
   def test(x: Constant) = "Constant"

--- a/tests/neg/repeatedArgs213.scala
+++ b/tests/neg/repeatedArgs213.scala
@@ -8,7 +8,7 @@ class repeatedArgs {
     bar("a", "b", "c")
     bar(xs: _*)
     bar(ys: _*) // error: immutable.Seq expected, found Seq
-    bar(zs: _*) // old-error: Remove (compiler generated) Array to Seq convertion in 2.13?
+    bar(zs: _*) // old-error: Remove (compiler generated) Array to Seq conversion in 2.13?
 
     Paths.get("Hello", "World")
     Paths.get("Hello", xs: _*)

--- a/tests/pos/givenIn.scala
+++ b/tests/pos/givenIn.scala
@@ -12,7 +12,7 @@ object Test {
   def g(given Context) = ()
   ctx.givenIn(g)
 
-/* The last three statements shoudl generate the following code:
+/* The last three statements should generate the following code:
 
     def ctx: Test.Context = new Test.Context()
     def g(implicit x$1: Test.Context): Unit = ()

--- a/tests/run-with-compiler-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
+++ b/tests/run-with-compiler-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
@@ -7,7 +7,7 @@ import scala.tasty.Reflection
 class Interpreter[R <: Reflection & Singleton](reflect0: R) extends TreeInterpreter[R](reflect0) {
   import reflect.{_, given}
 
-  // All references are represented by themselfs and values are boxed
+  // All references are represented by themselves and values are boxed
   type AbstractAny = Any
 
   val jvmReflection = new JVMReflection(reflect)

--- a/tests/untried/neg/structural.scala
+++ b/tests/untried/neg/structural.scala
@@ -11,13 +11,13 @@ object Test extends App {
     def f2[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: B): Object; val x: B }) = x.m[Tata](x.x) //fail
     def f3[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: C): Object; val x: C }) = x.m[Tata](x.x) //fail
     def f4[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: D): Object; val x: D }) = x.m[Tata](x.x) //fail
-    def f5[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: E): Object; val x: Tata }) = x.m[Tata](x.x) //suceed
+    def f5[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: E): Object; val x: Tata }) = x.m[Tata](x.x) //succeed
 
-    def f6[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: Object): A }) = x.m[Tata](null) //suceed
-    def f7[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: Object): B }) = x.m[Tata](null) //suceed
-    def f8[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: Object): C }) = x.m[Tata](null) //suceed
+    def f6[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: Object): A }) = x.m[Tata](null) //succeed
+    def f7[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: Object): B }) = x.m[Tata](null) //succeed
+    def f8[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: Object): C }) = x.m[Tata](null) //succeed
     def f9[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: Object): D }) = x.m[Tata](null) //fail
-    def f0[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: Object): E }) = x.m[Tata](null) //suceed
+    def f0[C <: Object](x: Object{ type D <: Object; def m[E >: Null <: Object](x: Object): E }) = x.m[Tata](null) //succeed
 
   }
 


### PR DESCRIPTION
Should be non-semantic spelling fixes.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.