### PR TITLE
Fix #7660: Drop unused `indent` parameter in `LookaheadScanner`

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -155,8 +155,9 @@ object Scanners {
       || ctx.settings.oldSyntax.value
       || isScala2CompatMode
     val indentSyntax =
-      (if (Config.defaultIndent) !noindentSyntax else ctx.settings.indent.value)
-      || rewriteNoIndent
+      ((if (Config.defaultIndent) !noindentSyntax else ctx.settings.indent.value)
+       || rewriteNoIndent)
+      && !isInstanceOf[LookaheadScanner]
     val colonSyntax =
       ctx.settings.YindentColons.value
       || rewriteNoIndent
@@ -881,8 +882,7 @@ object Scanners {
 
 // Lookahead ---------------------------------------------------------------
 
-    class LookaheadScanner(indent: Boolean = false) extends Scanner(source, offset) {
-      override val indentSyntax = indent
+    class LookaheadScanner() extends Scanner(source, offset) {
       override def skipEndMarker(width: IndentWidth) = ()
       override protected def printState() = {
         print("la:")


### PR DESCRIPTION
It was never passed explicitly, so was always false.

To fix the initialization error, don't override `val indentSyntax`,
but use a type test in the initializer instead.