### PR TITLE
Issue templates: Crash reports: Add `itype:crash` label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -15,5 +15,3 @@ println("hello, world")
 
 
 ## expectation
-
-

--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -2,7 +2,7 @@
 name: "\U0001F4A5 Crash report"
 about: Report a Dotty Compiler compiler crash
 title: ''
-labels: itype:bug
+labels: itype:bug, itype:crash
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,12 +2,9 @@
 name: "\U0001F389 Suggest a feature"
 about: Please create a feature request here https://github.com/lampepfl/dotty-feature-requests
 title: ''
-labels:
+labels: ''
 assignees: ''
 
 ---
 
 Please create a feature request here: [lampepfl/dotty-feature-requests](https://github.com/lampepfl/dotty-feature-requests).
-
-
-

--- a/.github/ISSUE_TEMPLATE/syntax-highlight.md
+++ b/.github/ISSUE_TEMPLATE/syntax-highlight.md
@@ -1,13 +1,10 @@
 ---
-name: "Syntax highlighting"
+name: Syntax highlighting
 about: Please create a syntax highlighting issue here https://github.com/scala/vscode-scala-syntax/issues
 title: ''
-labels:
+labels: ''
 assignees: ''
 
 ---
 
 Please create a syntax highlighting issue here: [scala/vscode-scala-syntax](https://github.com/scala/vscode-scala-syntax/issues).
-
-
-


### PR DESCRIPTION
Noticed while reporting a crash.

Beware: The only change I intended was adding `itype:crash`, the rest was done automatically by the GitHub interface... 