### PR TITLE
Fix #7711: Allow RefinedTpts to be shared

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -552,6 +552,7 @@ class TreePickler(pickler: TastyPickler) {
           if (refinements.isEmpty) pickleTree(parent)
           else {
             val refineCls = refinements.head.symbol.owner.asClass
+            registerDef(refineCls)
             pickledTypes.put(refineCls.typeRef, currentAddr)
             writeByte(REFINEDtpt)
             refinements.foreach(preRegister)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1167,7 +1167,9 @@ class TreeUnpickler(reader: TastyReader,
               val argPats = until(end)(readTerm())
               UnApply(fn, implicitArgs, argPats, patType)
             case REFINEDtpt =>
-              val refineCls = ctx.newRefinedClassSymbol(coordAt(start))
+              val refineCls = symAtAddr.getOrElse(start,
+                ctx.newRefinedClassSymbol(coordAt(start))).asClass
+              registerSym(start, refineCls)
               typeAtAddr(start) = refineCls.typeRef
               val parent = readTpt()
               val refinements = readStats(refineCls, end)(localContext(refineCls))

--- a/tests/pos/i7711/crash1_1.scala
+++ b/tests/pos/i7711/crash1_1.scala
@@ -1,0 +1,9 @@
+package scalaLibV
+
+import reflect.Selectable.reflectiveSelectable
+
+// Church-encoded Booleans, in DOT.
+type IFT = (x : { type IFTA }) => x.IFTA => x.IFTA => x.IFTA
+
+val iftTrue : IFT =
+  x => t => f => t

--- a/tests/pos/i7711/crash2_1.scala
+++ b/tests/pos/i7711/crash2_1.scala
@@ -1,0 +1,8 @@
+package listV
+
+//import reflect.Selectable.reflectiveSelectable
+import scalaLibV._
+
+object sci {
+  val isEmpty = iftTrue
+}

--- a/tests/pos/i7711/crash2_2.scala
+++ b/tests/pos/i7711/crash2_2.scala
@@ -1,0 +1,8 @@
+package listV
+
+//import reflect.Selectable.reflectiveSelectable
+import scalaLibV._
+
+object sci {
+  val isEmpty = iftTrue // 1nd try
+}


### PR DESCRIPTION
Previously, each reference to a shared refined type created
its own RefinementClass.