### PR TITLE
Rename "frontend" phase to "typer"

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -23,7 +23,7 @@ object CompilerCommand {
     |  - (partial) phase names with an optional "+" suffix to include the next phase
     |  - the string "all"
     |  example: -Xprint:all prints all phases.
-    |  example: -Xprint:front,mixin prints the frontend and mixin phases.
+    |  example: -Xprint:typer,mixin prints the typer and mixin phases.
     |  example: -Ylog:erasure+ logs the erasure phase and the phase after the erasure phase.
     |           This is useful because during the tree transform of phase X, we often
     |           already are in phase X + 1.

--- a/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -136,5 +136,5 @@ class FrontEnd extends Phase {
 }
 
 object FrontEnd {
-  val name: String = "frontend"
+  val name: String = "typer"
 }

--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -276,7 +276,7 @@ class ReplCompiler extends Compiler {
     val src = SourceFile.virtual("<typecheck>", expr)
     implicit val ctx: Context = state.context.fresh
       .setReporter(newStoreReporter)
-      .setSetting(state.context.settings.YstopAfter, List("frontend"))
+      .setSetting(state.context.settings.YstopAfter, List("typer"))
 
     wrapped(expr, src, state).flatMap { pkg =>
       val unit = CompilationUnit(src)

--- a/compiler/test/dotc/comptest.scala
+++ b/compiler/test/dotc/comptest.scala
@@ -25,6 +25,6 @@ object comptest extends ParallelTesting {
         dotcDir + "tools/dotc/core/Types.scala",
         dotcDir + "tools/dotc/ast/Trees.scala"
       ),
-      TestFlags("", Array("-Ylog:frontend", "-Xprompt"))
+      TestFlags("", Array("-Ylog:typer", "-Xprompt"))
   )(TestGroup("comptest"))
 }

--- a/compiler/test/dotty/tools/DottyTest.scala
+++ b/compiler/test/dotty/tools/DottyTest.scala
@@ -77,7 +77,7 @@ trait DottyTest extends ContextEscapeDetection {
     val dummyName = "x_x_x"
     val vals = typeStringss.flatten.zipWithIndex.map{case (s, x)=> s"val ${dummyName}$x: $s = ???"}.mkString("\n")
     val gatheredSource = s" ${source}\n object A$dummyName {$vals}"
-    checkCompile("frontend", gatheredSource) {
+    checkCompile("typer", gatheredSource) {
       (tree, context) =>
         implicit val ctx = context
         val findValDef: (List[tpd.ValDef], tpd.Tree) => List[tpd.ValDef] =

--- a/compiler/test/dotty/tools/DottyTypeStealer.scala
+++ b/compiler/test/dotty/tools/DottyTypeStealer.scala
@@ -14,7 +14,7 @@ object DottyTypeStealer extends DottyTest {
     val gatheredSource = s" ${source}\n object A$dummyName {$vals}"
     var scontext : Context = null
     var tp: List[Type] = null
-    checkCompile("frontend", gatheredSource) {
+    checkCompile("typer", gatheredSource) {
       (tree, context) =>
         implicit val ctx = context
         val findValDef: (List[ValDef], tpd.Tree) => List[ValDef] =

--- a/compiler/test/dotty/tools/dotc/ast/AttachmentsTest.scala
+++ b/compiler/test/dotty/tools/dotc/ast/AttachmentsTest.scala
@@ -16,7 +16,7 @@ class AttachmentsTests extends DottyTest {
 
   @Test
   def attachmentsAreNotCopiedOver: Unit = {
-    checkCompile("frontend", "class A") {
+    checkCompile("typer", "class A") {
       case (PackageDef(_, (clazz: tpd.TypeDef) :: Nil), context) =>
         assertTrue("Attachment shouldn't be present", clazz.getAttachment(TestKey).isEmpty)
 
@@ -35,7 +35,7 @@ class AttachmentsTests extends DottyTest {
 
   @Test
   def stickyAttachmentsAreCopiedOver: Unit = {
-    checkCompile("frontend", "class A") {
+    checkCompile("typer", "class A") {
       case (PackageDef(_, (clazz: tpd.TypeDef) :: Nil), context) =>
         assertTrue("Attachment shouldn't be present", clazz.getAttachment(StickyTestKey).isEmpty)
         assertTrue("Attachment shouldn't be present", clazz.getAttachment(StickyTestKey2).isEmpty)

--- a/compiler/test/dotty/tools/dotc/ast/DesugarTests.scala
+++ b/compiler/test/dotty/tools/dotc/ast/DesugarTests.scala
@@ -22,7 +22,7 @@ class DesugarTests extends DottyTest {
   }
 
   @Test def caseClassHasCorrectMembers: Unit =
-    checkCompile("frontend", "case class Foo(x: Int, y: String)") { (tree, context) =>
+    checkCompile("typer", "case class Foo(x: Int, y: String)") { (tree, context) =>
       implicit val ctx = context
       val ccTree = tree.find(tree => tree.symbol.name == typeName("Foo")).get
       val List(_, foo) = defPath(ccTree.symbol, tree).map(_.symbol.info)
@@ -37,7 +37,7 @@ class DesugarTests extends DottyTest {
     }
 
   @Test def caseClassCompanionHasCorrectMembers: Unit =
-    checkCompile("frontend", "case class Foo(x: Int, y: String)") { (tree, context) =>
+    checkCompile("typer", "case class Foo(x: Int, y: String)") { (tree, context) =>
       implicit val ctx = context
       val ccTree = tree.find(tree => tree.symbol.name == termName("Foo")).get
       val List(_, foo) = defPath(ccTree.symbol, tree).map(_.symbol.info)

--- a/compiler/test/dotty/tools/dotc/ast/TreeInfoTest.scala
+++ b/compiler/test/dotty/tools/dotc/ast/TreeInfoTest.scala
@@ -14,7 +14,7 @@ class TreeInfoTest extends DottyTest {
   import tpd._
 
   @Test
-  def testDefPath: Unit = checkCompile("frontend", "class A { def bar = { val x = { val z = 0; 0} }} ") {
+  def testDefPath: Unit = checkCompile("typer", "class A { def bar = { val x = { val z = 0; 0} }} ") {
     (tree, context) =>
       implicit val ctx = context
       val xTree = tree.find(tree => tree.symbol.name == termName("x")).get

--- a/compiler/test/dotty/tools/dotc/parsing/DocstringTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/DocstringTest.scala
@@ -25,7 +25,7 @@ trait DocstringTest extends DottyTest {
   }
 
   def checkFrontend(source: String)(docAssert: PartialFunction[Tree[Untyped], Unit]): Unit = {
-    checkCompile("frontend", source) { (_, ctx) =>
+    checkCompile("typer", source) { (_, ctx) =>
       implicit val c: Context = ctx
       (docAssert orElse defaultAssertion)(ctx.compilationUnit.untpdTree)
     }

--- a/compiler/test/dotty/tools/dotc/parsing/DocstringTests.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/DocstringTests.scala
@@ -61,7 +61,7 @@ class DocstringTests extends DocstringTest {
       |class Class2(val x: String)
       """.stripMargin
 
-    checkCompile("frontend", source) { (_, ctx) =>
+    checkCompile("typer", source) { (_, ctx) =>
       ctx.compilationUnit.untpdTree match {
         case PackageDef(_, Seq(c1 @ TypeDef(_,_), c2 @ TypeDef(_,_))) => {
           checkDocString(c1.rawComment.map(_.raw), "/** Class1 docstring */")

--- a/compiler/test/dotty/tools/dotc/printing/PrinterTests.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrinterTests.scala
@@ -25,7 +25,7 @@ class PrinterTests extends DottyTest {
       }
     """
 
-    checkCompile("frontend", source) { (tree, context) =>
+    checkCompile("typer", source) { (tree, context) =>
       implicit val ctx = context
       val bar = tree.find(tree => tree.symbol.name == termName("bar")).get
       assertEquals("package object foo", bar.symbol.owner.show)
@@ -42,7 +42,7 @@ class PrinterTests extends DottyTest {
       |}
     """.stripMargin
 
-    checkCompile("frontend", source) { (tree, context) =>
+    checkCompile("typer", source) { (tree, context) =>
       implicit val ctx = context
       val bar @ Trees.DefDef(_, _, _, _, _) = tree.find(tree => tree.symbol.name == termName("bar2")).get
       assertEquals("Int & (Boolean | String)", bar.tpt.show)

--- a/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 
 class PrintingTest {
   val testsDir = "tests/printing"
-  val options = List("-Xprint:frontend", "-color:never", "-classpath", TestConfiguration.basicClasspath)
+  val options = List("-Xprint:typer", "-color:never", "-classpath", TestConfiguration.basicClasspath)
 
   private def fileContent(filePath: String): List[String] =
     if (new File(filePath).exists)

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1366,7 +1366,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
       }
 
   @Test def unapplyInvalidReturnType =
-    checkMessagesAfter("frontend") {
+    checkMessagesAfter("typer") {
       """
         |class A(val i: Int)
         |
@@ -1386,7 +1386,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
     }
 
   @Test def unapplySeqInvalidReturnType =
-    checkMessagesAfter("frontend") {
+    checkMessagesAfter("typer") {
       """
         |class A(val i: Int)
         |

--- a/compiler/test/dotty/tools/dotc/reporting/UserDefinedErrorMessages.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/UserDefinedErrorMessages.scala
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class UserDefinedErrorMessages extends ErrorMessagesTest {
   @Test def userDefinedImplicitAmbiguous1 =
-    checkMessagesAfter("frontend") {
+    checkMessagesAfter("typer") {
       """
         |object Test {
         |  trait =!=[C, D]
@@ -34,7 +34,7 @@ class UserDefinedErrorMessages extends ErrorMessagesTest {
     }
 
   @Test def userDefinedImplicitAmbiguous2 =
-    checkMessagesAfter("frontend") {
+    checkMessagesAfter("typer") {
       """
         |object Test {
         |  trait =!=[C, D]
@@ -59,7 +59,7 @@ class UserDefinedErrorMessages extends ErrorMessagesTest {
     }
 
   @Test def userDefinedImplicitAmbiguous3 =
-    checkMessagesAfter("frontend") {
+    checkMessagesAfter("typer") {
       """
         |object Test {
         |  trait =!=[C, D]
@@ -85,7 +85,7 @@ class UserDefinedErrorMessages extends ErrorMessagesTest {
     }
 
   @Test def userDefinedImplicitAmbiguous4 =
-    checkMessagesAfter("frontend") {
+    checkMessagesAfter("typer") {
       """
         |class C {
         |  import scala.language.implicitConversions
@@ -108,7 +108,7 @@ class UserDefinedErrorMessages extends ErrorMessagesTest {
     }
 
   @Test def userDefinedImplicitAmbiguous5 =
-    checkMessagesAfter("frontend") {
+    checkMessagesAfter("typer") {
       """
         |class C {
         |  @annotation.implicitAmbiguous("msg A=${A}")

--- a/compiler/test/dotty/tools/dotc/transform/CreateCompanionObjectsTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/CreateCompanionObjectsTest.scala
@@ -23,7 +23,7 @@ class CreateCompanionObjectsTest extends DottyTest {
   type PostTyperTransformer = TreeTransformer // FIXME do without
 
   @Test
-  def shouldCreateNonExistingObjectsInPackage = checkCompile("frontend", "class A{} ") {
+  def shouldCreateNonExistingObjectsInPackage = checkCompile("typer", "class A{} ") {
     (tree, context) =>
       implicit val ctx = context
 
@@ -49,7 +49,7 @@ class CreateCompanionObjectsTest extends DottyTest {
   }
 
   @Test
-  def shouldCreateNonExistingObjectsInBlock = checkCompile("frontend", "class D {def p = {class A{}; 1}} ") {
+  def shouldCreateNonExistingObjectsInBlock = checkCompile("typer", "class D {def p = {class A{}; 1}} ") {
     (tree, context) =>
       implicit val ctx = context
       val transformer = new PostTyperTransformer {
@@ -74,7 +74,7 @@ class CreateCompanionObjectsTest extends DottyTest {
   }
 
   @Test
-  def shouldCreateNonExistingObjectsInTemplate = checkCompile("frontend", "class D {class A{}; } ") {
+  def shouldCreateNonExistingObjectsInTemplate = checkCompile("typer", "class D {class A{}; } ") {
     (tree, context) =>
       implicit val ctx = context
       val transformer = new PostTyperTransformer {
@@ -98,7 +98,7 @@ class CreateCompanionObjectsTest extends DottyTest {
   }
 
   @Test
-  def shouldCreateOnlyIfAskedFor = checkCompile("frontend", "class DONT {class CREATE{}; } ") {
+  def shouldCreateOnlyIfAskedFor = checkCompile("typer", "class DONT {class CREATE{}; } ") {
     (tree, context) =>
       implicit val ctx = context
       val transformer = new PostTyperTransformer {

--- a/compiler/test/dotty/tools/dotc/transform/PostTyperTransformerTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/PostTyperTransformerTest.scala
@@ -18,7 +18,7 @@ class PostTyperTransformerTest extends DottyTest {
   /* FIXME: re-enable after adapting to new scheme
 
   @Test
-  def shouldStripImports = checkCompile("frontend", "class A{ import scala.collection.mutable._; val d = 1}") {
+  def shouldStripImports = checkCompile("typer", "class A{ import scala.collection.mutable._; val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       class EmptyTransform extends TreeTransform {
@@ -38,7 +38,7 @@ class PostTyperTransformerTest extends DottyTest {
   }
 
   @Test
-  def shouldStripNamedArgs = checkCompile("frontend", "class A{ def p(x:Int, y:Int= 2) = 1; p(1, y = 2)}") {
+  def shouldStripNamedArgs = checkCompile("typer", "class A{ def p(x:Int, y:Int= 2) = 1; p(1, y = 2)}") {
     (tree, context) =>
       implicit val ctx = context
       class EmptyTransform extends TreeTransform {
@@ -58,7 +58,7 @@ class PostTyperTransformerTest extends DottyTest {
   }
 
   @Test
-  def shouldReorderExistingObjectsInPackage = checkCompile("frontend", "object A{}; class A{} ") {
+  def shouldReorderExistingObjectsInPackage = checkCompile("typer", "object A{}; class A{} ") {
     (tree, context) =>
       implicit val ctx = context
       class EmptyTransform extends TreeTransform {
@@ -82,7 +82,7 @@ class PostTyperTransformerTest extends DottyTest {
   }
 
   @Test
-  def shouldReorderExistingObjectsInBlock = checkCompile("frontend", "class D {def p = {object A{}; class A{}; 1}} ") {
+  def shouldReorderExistingObjectsInBlock = checkCompile("typer", "class D {def p = {object A{}; class A{}; 1}} ") {
     (tree, context) =>
       implicit val ctx = context
       class EmptyTransform extends TreeTransform {
@@ -106,7 +106,7 @@ class PostTyperTransformerTest extends DottyTest {
   }
 
   @Test
-  def shouldReorderExistingObjectsInTemplate = checkCompile("frontend", "class D {object A{}; class A{}; } ") {
+  def shouldReorderExistingObjectsInTemplate = checkCompile("typer", "class D {object A{}; class A{}; } ") {
     (tree, context) =>
       implicit val ctx = context
       class EmptyTransform extends TreeTransform {

--- a/compiler/test/dotty/tools/dotc/transform/TreeTransformerTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/TreeTransformerTest.scala
@@ -11,7 +11,7 @@ import core.Contexts.Context
 class TreeTransformerTest extends DottyTest {
 
   @Test
-  def shouldReturnSameTreeIfUnchanged: Unit = checkCompile("frontend", "class A{ val d = 1}") {
+  def shouldReturnSameTreeIfUnchanged: Unit = checkCompile("typer", "class A{ val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       class EmptyTransform extends MiniPhase {
@@ -27,7 +27,7 @@ class TreeTransformerTest extends DottyTest {
   }
 
   // Disabled, awaiting resolution. @Test
-  def canReplaceConstant: Unit = checkCompile("frontend", "class A{ val d = 1}") {
+  def canReplaceConstant: Unit = checkCompile("typer", "class A{ val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       class ConstantTransform extends MiniPhase {
@@ -45,7 +45,7 @@ class TreeTransformerTest extends DottyTest {
   }
 
   @Test
-  def canOverwrite: Unit = checkCompile("frontend", "class A{ val d = 1}") {
+  def canOverwrite: Unit = checkCompile("typer", "class A{ val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       class Transformation extends MiniPhase {
@@ -71,7 +71,7 @@ class TreeTransformerTest extends DottyTest {
   }
 
   @Test
-  def transformationOrder: Unit = checkCompile("frontend", "class A{ val d = 1}") {
+  def transformationOrder: Unit = checkCompile("typer", "class A{ val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       class Transformation1 extends MiniPhase {
@@ -113,7 +113,7 @@ class TreeTransformerTest extends DottyTest {
   }
 
   @Test
-  def invocationCount: Unit = checkCompile("frontend", "class A{ val d = 1}") {
+  def invocationCount: Unit = checkCompile("typer", "class A{ val d = 1}") {
     (tree, context) =>
       implicit val ctx = context
       var transformed1 = 0

--- a/compiler/test/dotty/tools/dotc/typer/SubtypingInvariantTests.scala
+++ b/compiler/test/dotty/tools/dotc/typer/SubtypingInvariantTests.scala
@@ -10,7 +10,7 @@ class SubtypingInvariantTests extends DottyTest {
 
   @Test
   def typeVarInvariant(): Unit = {
-    checkCompile("frontend", "class A") { (_, ctx0) =>
+    checkCompile("typer", "class A") { (_, ctx0) =>
       implicit val ctx: Context = ctx0
       val a = newTypeVar(TypeBounds.empty)
       val b = newTypeVar(TypeBounds.empty)

--- a/docs/docs/contributing/debugging.md
+++ b/docs/docs/contributing/debugging.md
@@ -91,16 +91,16 @@ assertPositioned(tree.reporting(s"Tree is: $result"))
 `def (a: A) reporting(f: given WrappedResult[T] => String, p: Printer = Printers.default): A` is defined on all types. The function `f` can be written without the argument since the argument is `given`. The `result` variable is a part of the `WrapperResult` – a tiny framework powering the `reporting` function. Basically, whenever you are using `reporting` on an object `A`, you can use the `result: A` variable from this function and it will be equal to the object you are calling `reporting` on.
 
 ## Printing out trees after phases
-To print out the trees you are compiling after Frontend (scanner, parser, namer, typer) phase:
+To print out the trees you are compiling after the FrontEnd (scanner, parser, namer, typer) phases:
 
 ```shell
-dotc -Xprint:frontend ../issues/Playground.scala
+dotc -Xprint:typer ../issues/Playground.scala
 ```
 
 To print out the trees after Frontend and CollectSuperCalls phases:
 
 ```shell
-dotc -Xprint:frontend,collectSuperCalls ../issues/Playground.scala
+dotc -Xprint:typer,collectSuperCalls ../issues/Playground.scala
 ```
 
 To print out the trees after all phases:
@@ -176,7 +176,7 @@ And is to be used as:
 dotc -Yprint-pos  ../issues/Playground.scala
 ```
 
-If used, all the trees output with `show` or via `-Xprint:frontend` will also have positions attached to them, e.g.:
+If used, all the trees output with `show` or via `-Xprint:typer` will also have positions attached to them, e.g.:
 
 ```scala
 package <empty>@<Playground.scala:1> {
@@ -204,7 +204,7 @@ package <empty>@<Playground.scala:1> {
 Every [Positioned](https://github.com/lampepfl/dotty/blob/10526a7d0aa8910729b6036ee51942e05b71abf6/compiler/src/dotty/tools/dotc/ast/Positioned.scala) (a parent class of `Tree`) object has a `uniqueId` field. It is an integer that is unique for that tree and doesn't change from compile run to compile run. You can output these IDs from any printer (such as the ones used by `.show` and `-Xprint`) via `-Yshow-tree-ids` flag, e.g.:
 
 ```shell
-dotc -Xprint:frontend -Yshow-tree-ids  ../issues/Playground.scala
+dotc -Xprint:typer -Yshow-tree-ids  ../issues/Playground.scala
 ```
 
 Gives:
@@ -363,4 +363,4 @@ trace.force(i"typing $tree", typr, show = true) { // ...
 ```
 
 ### Reporter
-Defined in [Reporter.scala](https://github.com/lampepfl/dotty/blob/10526a7d0aa8910729b6036ee51942e05b71abf6/compiler/src/dotty/tools/dotc/reporting/Reporter.scala). Enables calls such as `ctx.log`, `ctx.error` etc. To enable, run dotc with `-Ylog:frontend` option.
+Defined in [Reporter.scala](https://github.com/lampepfl/dotty/blob/10526a7d0aa8910729b6036ee51942e05b71abf6/compiler/src/dotty/tools/dotc/reporting/Reporter.scala). Enables calls such as `ctx.log`, `ctx.error` etc. To enable, run dotc with `-Ylog:typer` option.

--- a/tests/pos-special/typeclass-scaling.scala
+++ b/tests/pos-special/typeclass-scaling.scala
@@ -3,7 +3,7 @@ import scala.annotation.tailrec
 
 // The following command:
 //
-//     sc typeclass-scaling.scala -Xmax-inlines 100 -Xprint:front -color:never -pagewidth 1000 >& x
+//     sc typeclass-scaling.scala -Xmax-inlines 100 -Xprint:typer -color:never -pagewidth 1000 >& x
 //
 // produces an output file with `wc` measures (lines/words/chars):
 //

--- a/tests/pos/implicits2.scala
+++ b/tests/pos/implicits2.scala
@@ -1,6 +1,6 @@
 /* Compile with
 
-    dotc implicits2.scala -Xprint:front -Xprint-types -verbose
+    dotc implicits2.scala -Xprint:typer -Xprint-types -verbose
 
     and verify that the inserted wrapString comes from Predef. You should see
 

--- a/tests/pos/printbounds.scala
+++ b/tests/pos/printbounds.scala
@@ -5,7 +5,7 @@ class Test {
 
   val x: Tree[_] = ???
 
-  val y = x // With -Xprint:front this should print  val x: Tree[_] = x
+  val y = x // With -Xprint:typer this should print  val x: Tree[_] = x
             // used to print Tree[Nothing], which is confusing.
 
 }

--- a/tests/printing/i620.check
+++ b/tests/printing/i620.check
@@ -1,4 +1,4 @@
-result of tests/printing/i620.scala after frontend:
+result of tests/printing/i620.scala after typer:
 package O {
   package O.A {
     class D() extends Object() {


### PR DESCRIPTION
That makes it the same as for scalac. Aligning terminology helps switching between
the two codebases. Also, "frontend" is a bit off, since it is technically two phases,
not one.