### PR TITLE
Fix #7735: Handle case of seq literals of singleton primitive types

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -453,10 +453,11 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    *  kind for the given element type in `elemTpe`.
    */
   def wrapArray(tree: Tree, elemtp: Type)(implicit ctx: Context): Tree =
-    ref(defn.getWrapVarargsArrayModule)
+    val wrapper = ref(defn.getWrapVarargsArrayModule)
       .select(wrapArrayMethodName(elemtp))
       .appliedToTypes(if (elemtp.isPrimitiveValueType) Nil else elemtp :: Nil)
-      .appliedTo(tree)
+    val actualElem = wrapper.tpe.widen.firstParamTypes.head
+    wrapper.appliedTo(tree.ensureConforms(actualElem))
 
   // ------ Creating typed equivalents of trees that exist only in untyped form -------
 

--- a/compiler/src/dotty/tools/dotc/transform/SeqLiterals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SeqLiterals.scala
@@ -31,6 +31,6 @@ class SeqLiterals extends MiniPhase {
       val arr = JavaSeqLiteral(tree.elems, tree.elemtpt)
       //println(i"trans seq $tree, arr = $arr: ${arr.tpe} ${arr.tpe.elemType}")
       val elemtp = tree.elemtpt.tpe
-      wrapArray(arr, elemtp).withSpan(tree.span)
+      wrapArray(arr, elemtp).withSpan(tree.span).ensureConforms(tree.tpe)
   }
 }

--- a/tests/pos/i7735.scala
+++ b/tests/pos/i7735.scala
@@ -1,0 +1,2 @@
+def foo[A](as: A*): Int = ???
+val a = foo[1]()

--- a/tests/run/toplevel-stale/B_2.scala
+++ b/tests/run/toplevel-stale/B_2.scala
@@ -36,3 +36,58 @@ val y3 = {
   val x7 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int)]]
   val x8 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int, Int)]]
 }
+
+val y4 = {
+  val x1 = summon[Ordering[Int]]
+  val x2 = summon[Ordering[(Int, Int)]]
+  val x3 = summon[Ordering[(Int, Int, Int)]]
+  val x4 = summon[Ordering[(Int, Int, Int, Int)]]
+  val x5 = summon[Ordering[(Int, Int, Int, Int, Int)]]
+  val x6 = summon[Ordering[(Int, Int, Int, Int, Int, Int)]]
+  val x7 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int)]]
+  val x8 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int, Int)]]
+}
+
+val y5 = {
+  val x1 = summon[Ordering[Int]]
+  val x2 = summon[Ordering[(Int, Int)]]
+  val x3 = summon[Ordering[(Int, Int, Int)]]
+  val x4 = summon[Ordering[(Int, Int, Int, Int)]]
+  val x5 = summon[Ordering[(Int, Int, Int, Int, Int)]]
+  val x6 = summon[Ordering[(Int, Int, Int, Int, Int, Int)]]
+  val x7 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int)]]
+  val x8 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int, Int)]]
+}
+
+val y6 = {
+  val x1 = summon[Ordering[Int]]
+  val x2 = summon[Ordering[(Int, Int)]]
+  val x3 = summon[Ordering[(Int, Int, Int)]]
+  val x4 = summon[Ordering[(Int, Int, Int, Int)]]
+  val x5 = summon[Ordering[(Int, Int, Int, Int, Int)]]
+  val x6 = summon[Ordering[(Int, Int, Int, Int, Int, Int)]]
+  val x7 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int)]]
+  val x8 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int, Int)]]
+}
+
+val y7 = {
+  val x1 = summon[Ordering[Int]]
+  val x2 = summon[Ordering[(Int, Int)]]
+  val x3 = summon[Ordering[(Int, Int, Int)]]
+  val x4 = summon[Ordering[(Int, Int, Int, Int)]]
+  val x5 = summon[Ordering[(Int, Int, Int, Int, Int)]]
+  val x6 = summon[Ordering[(Int, Int, Int, Int, Int, Int)]]
+  val x7 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int)]]
+  val x8 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int, Int)]]
+}
+
+val y8 = {
+  val x1 = summon[Ordering[Int]]
+  val x2 = summon[Ordering[(Int, Int)]]
+  val x3 = summon[Ordering[(Int, Int, Int)]]
+  val x4 = summon[Ordering[(Int, Int, Int, Int)]]
+  val x5 = summon[Ordering[(Int, Int, Int, Int, Int)]]
+  val x6 = summon[Ordering[(Int, Int, Int, Int, Int, Int)]]
+  val x7 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int)]]
+  val x8 = summon[Ordering[(Int, Int, Int, Int, Int, Int, Int, Int)]]
+}


### PR DESCRIPTION
This failed -Ycheck before, but after erasure everything is fine.
So this needs a couple of casts to work.