### PR TITLE
Fix #7739: Handle private toplevel vars.

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -150,13 +150,18 @@ object desugar {
    *    def x: Int = expr
    *    def x_=($1: <TypeTree()>): Unit = ()
    *
-   *  Generate the setter only for non-private class members and all trait members.
+   *  Generate the setter only for
+   *    - non-private class members
+   *    - all trait members
+   *    - all package object members
    */
   def valDef(vdef0: ValDef)(implicit ctx: Context): Tree = {
     val vdef @ ValDef(name, tpt, rhs) = transformQuotedPatternName(vdef0)
     val mods = vdef.mods
     val setterNeeded =
-      mods.is(Mutable) && ctx.owner.isClass && (!mods.is(Private) || ctx.owner.is(Trait))
+      mods.is(Mutable)
+      && ctx.owner.isClass
+      && (!mods.is(Private) || ctx.owner.is(Trait) || ctx.owner.isPackageObject)
     if (setterNeeded) {
       // TODO: copy of vdef as getter needed?
       // val getter = ValDef(mods, name, tpt, rhs) withPos vdef.pos?

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -358,7 +358,7 @@ class Namer { typer: Typer =>
       val effectiveOwner = owner.skipWeakOwner
       if (flags.is(Private) && effectiveOwner.is(Package)) {
         // If effective owner is a package p, widen private to private[p]
-        flags1 = flags1 &~ Private
+        flags1 = flags1 &~ PrivateLocal
         privateWithin = effectiveOwner
       }
 

--- a/tests/pos/i7739.scala
+++ b/tests/pos/i7739.scala
@@ -1,0 +1,1 @@
+private var a: Int = 1


### PR DESCRIPTION
These get a setter even though they are declared private, since
the private is implicitly widened to private[\<enclosing package>].