### PR TITLE
Fix #7139: Implement kind-projector compatibility

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -630,6 +630,7 @@ object StdNames {
       final val BAR  : N  = "|"
       final val DOLLAR: N = "$"
       final val GE: N     = ">="
+      final val LAMBDA: N = "λ"
       final val LE: N     = "<="
       final val MINUS: N  = "-"
       final val NE: N     = "!="

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -62,6 +62,7 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/pos-special/notNull.scala", defaultOptions.and("-Yexplicit-nulls")),
       compileDir("tests/pos-special/adhoc-extension", defaultOptions.and("-strict", "-feature", "-Xfatal-warnings")),
       compileFile("tests/pos-special/i7575.scala", defaultOptions.and("-language:dynamics")),
+      compileFile("tests/pos-special/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
     ).checkCompile()
   }
 
@@ -151,6 +152,7 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/neg-custom-args/extmethods-tparams.scala", defaultOptions.and("-deprecation", "-Xfatal-warnings")),
       compileDir("tests/neg-custom-args/adhoc-extension", defaultOptions.and("-strict", "-feature", "-Xfatal-warnings")),
       compileFile("tests/neg/i7575.scala", defaultOptions.and("-language:_")),
+      compileFile("tests/neg-custom-args/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
     ).checkExpectedErrors()
   }
 

--- a/tests/neg-custom-args/kind-projector.check
+++ b/tests/neg-custom-args/kind-projector.check
@@ -1,0 +1,12 @@
+-- Error: tests/neg-custom-args/kind-projector.scala:7:23 --------------------------------------------------------------
+7 |class Bar3 extends Foo[λ[List[x] => Int]] // error
+  |                       ^^^^^^^^^^^^^^^^^
+  |                       λ requires a single argument of the form X => ... or (X, Y) => ...
+-- Error: tests/neg-custom-args/kind-projector.scala:5:23 --------------------------------------------------------------
+5 |class Bar1 extends Foo[Either[*, *]] // error
+  |                       ^^^^^^^^^^^^
+  |                       Type argument Either has not the same kind as its bound  <: [_$1] => Any
+-- Error: tests/neg-custom-args/kind-projector.scala:6:22 --------------------------------------------------------------
+6 |class Bar2 extends Foo[*] // error
+  |                      ^
+  |                      Type argument _$4 has not the same kind as its bound  <: [_$1] => Any

--- a/tests/neg-custom-args/kind-projector.scala
+++ b/tests/neg-custom-args/kind-projector.scala
@@ -1,0 +1,7 @@
+package kind_projector_neg
+
+trait Foo[F[_]]
+
+class Bar1 extends Foo[Either[*, *]] // error
+class Bar2 extends Foo[*] // error
+class Bar3 extends Foo[λ[List[x] => Int]] // error

--- a/tests/pos-special/kind-projector.scala
+++ b/tests/pos-special/kind-projector.scala
@@ -1,0 +1,15 @@
+package kind_projector
+
+trait Foo[F[_]]
+trait Qux[F[_, _]]
+trait Baz[F[_], A, B]
+
+class Bar1 extends Foo[Either[Int, *]]
+class Bar2 extends Foo[Either[*, Int]]
+class Bar3 extends Foo[* => Int]
+class Bar4 extends Foo[Int => *]
+class Bar5 extends Foo[(Int, *, Int)]
+class Bar6 extends Foo[λ[x => Either[Int, x]]]
+class Bar7 extends Qux[λ[(x, y) => Either[y, x]]]
+class Bar8 extends Foo[Baz[Int => *, *, Int]]
+class Bar9 extends Foo[λ[x => Baz[x => *, Int, x]]]


### PR DESCRIPTION
This change adds support for a subset of [kind-projector](https://github.com/typelevel/kind-projector)'s syntax behind the existing `-Ykind-projector` flag (closing #7139).

It supports the following kind-projector features:

* `*` as a placeholder (`Functor[Either[L, *]]` is equivalent to `Functor[[x] => Either[L, x]]`).
* `*` as a placeholder in tuple types (`Functor[(A, *)]` is equivalent to `Functor[[x] => (A, x)]`).
* `*` as a placeholder in function types (both `Functor[S => *]` and `Functor[* => T]` work).
* `λ` syntax for naming parameters (` Functor[λ[x => (x, x)]]` for `Functor[[x] => (x, x)]`).

There are a few things kind-projector provides that this change doesn't support:

* `?` as a placeholder (since it collides with wildcards).
* `*` as a placeholder in infix types.
* `Lambda` as an alternative for `λ`.
* `λ` arguments of a kind other than `*` (e.g. `λ[f[_] => Functor[f]]` isn't supported).
* Variance annotations on either `*` or `λ` arguments.
* Polymorphic lambda values (`λ[Vector ~> List](_.toList)`).

I've prioritized supporting the kind-projector features needed in [Cats](https://github.com/typelevel/cats), and while we do use some of these features there, it's pretty easy to make small changes to avoid them without hurting readability (in most cases thse changes improve readability it, in my view—e.g. [getting rid of ``λ[`-α` => ...]``](https://github.com/typelevel/cats/pull/3207)).

The changes here have no effect on parsing if `-Ykind-projector` isn't enabled. ~~I enabled it generally in the test configuration since I didn't see a way to enable it for specific test files.~~