### PR TITLE
Fix #7744: Pre-type type parameters when copying them

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -282,14 +282,15 @@ trait Symbols { this: Context =>
     val tparamBuf = new mutable.ListBuffer[TypeSymbol]
     val trefBuf = new mutable.ListBuffer[TypeRef]
     for (name <- names) {
-      val tparam = newNakedSymbol[TypeName](owner.coord)
+      val tparam = newSymbol(
+        owner, name, flags | owner.typeParamCreationFlags, NoType, coord = owner.coord)
       tparamBuf += tparam
       trefBuf += TypeRef(owner.thisType, tparam)
     }
     val tparams = tparamBuf.toList
     val bounds = boundsFn(trefBuf.toList)
-    for ((name, tparam, bound) <- names.lazyZip(tparams).lazyZip(bounds))
-      tparam.denot = SymDenotation(tparam, owner, name, flags | owner.typeParamCreationFlags, bound)
+    for (tparam, bound) <- tparams.lazyZip(bounds) do
+      tparam.info = bound
     tparams
   }
 

--- a/tests/pos/i7744.scala
+++ b/tests/pos/i7744.scala
@@ -1,0 +1,1 @@
+class A[F[_], X <: F[Int]](x: X) extends AnyVal


### PR DESCRIPTION
When creating new type parameters that should be copies of existing
ones on a new symbol, initially assign a denotation with NoType as bounds
to them. This is needed to handle inter-parameter-dependencies in
subsequentl substitutions that compute the proper bounds.