### PR TITLE
Fix #7759: Rename JavaNull -> UncheckedNull

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -355,20 +355,20 @@ class Definitions {
   @tu lazy val RuntimeNullModuleRef: TermRef = ctx.requiredModuleRef("scala.runtime.Null")
 
   /** An alias for null values that originate in Java code.
-   *  This type gets special treatment in the Typer. Specifically, `JavaNull` can be selected through:
+   *  This type gets special treatment in the Typer. Specifically, `UncheckedNull` can be selected through:
    *  e.g.
    *  ```
    *  // x: String|Null
    *  x.length // error: `Null` has no `length` field
-   *  // x2: String|JavaNull
+   *  // x2: String|UncheckedNull
    *  x2.length // allowed by the Typer, but unsound (might throw NPE)
    *  ```
    */
-  lazy val JavaNullAlias: TypeSymbol = {
+  lazy val UncheckedNullAlias: TypeSymbol = {
     assert(ctx.explicitNulls)
-    enterAliasType(tpnme.JavaNull, NullType)
+    enterAliasType(tpnme.UncheckedNull, NullType)
   }
-  def JavaNullAliasType: TypeRef = JavaNullAlias.typeRef
+  def UncheckedNullAliasType: TypeRef = UncheckedNullAlias.typeRef
 
   @tu lazy val ImplicitScrutineeTypeSym =
     newSymbol(ScalaPackageClass, tpnme.IMPLICITkw, EmptyFlags, TypeBounds.empty).entered
@@ -1371,7 +1371,7 @@ class Definitions {
       NothingClass,
       SingletonClass)
 
-    if (ctx.explicitNulls) synth :+ JavaNullAlias else synth
+    if (ctx.explicitNulls) synth :+ UncheckedNullAlias else synth
   }
 
   @tu lazy val syntheticCoreClasses: List[Symbol] = syntheticScalaClasses ++ List(

--- a/compiler/src/dotty/tools/dotc/core/NullOpsDecorator.scala
+++ b/compiler/src/dotty/tools/dotc/core/NullOpsDecorator.scala
@@ -8,27 +8,27 @@ import dotty.tools.dotc.core.Types._
 object NullOpsDecorator {
 
   implicit class NullOps(val self: Type) {
-    /** Is this type exactly `JavaNull` (no vars, aliases, refinements etc allowed)? */
-    def isJavaNullType(implicit ctx: Context): Boolean = {
+    /** Is this type exactly `UncheckedNull` (no vars, aliases, refinements etc allowed)? */
+    def isUncheckedNullType(implicit ctx: Context): Boolean = {
       assert(ctx.explicitNulls)
-      // We can't do `self == defn.JavaNull` because when trees are unpickled new references
-      // to `JavaNull` could be created that are different from `defn.JavaNull`.
+      // We can't do `self == defn.UncheckedNull` because when trees are unpickled new references
+      // to `UncheckedNull` could be created that are different from `defn.UncheckedNull`.
       // Instead, we compare the symbol.
-      self.isDirectRef(defn.JavaNullAlias)
+      self.isDirectRef(defn.UncheckedNullAlias)
     }
 
     /** Syntactically strips the nullability from this type.
-     *  If the type is `T1 | ... | Tn`, and `Ti` references to `Null` (or `JavaNull`),
+     *  If the type is `T1 | ... | Tn`, and `Ti` references to `Null` (or `UncheckedNull`),
      *  then return `T1 | ... | Ti-1 | Ti+1 | ... | Tn`.
      *  If this type isn't (syntactically) nullable, then returns the type unchanged.
      *
-     *  @param onlyJavaNull whether we only remove `JavaNull`, the default value is false
+     *  @param onlyUncheckedNull whether we only remove `UncheckedNull`, the default value is false
      */
-    def stripNull(onlyJavaNull: Boolean = false)(implicit ctx: Context): Type = {
+    def stripNull(onlyUncheckedNull: Boolean = false)(implicit ctx: Context): Type = {
       assert(ctx.explicitNulls)
 
       def isNull(tp: Type) =
-        if (onlyJavaNull) tp.isJavaNullType
+        if (onlyUncheckedNull) tp.isUncheckedNullType
         else tp.isNullType
 
       def strip(tp: Type): Type = tp match {
@@ -55,15 +55,15 @@ object NullOpsDecorator {
       if (stripped ne self1) stripped else self
     }
 
-    /** Like `stripNull`, but removes only the `JavaNull`s. */
-    def stripJavaNull(implicit ctx: Context): Type = self.stripNull(true)
+    /** Like `stripNull`, but removes only the `UncheckedNull`s. */
+    def stripUncheckedNull(implicit ctx: Context): Type = self.stripNull(true)
 
-    /** Collapses all `JavaNull` unions within this type, and not just the outermost ones (as `stripJavaNull` does).
-     *  e.g. (Array[String|JavaNull]|JavaNull).stripJavaNull => Array[String|JavaNull]
-     *       (Array[String|JavaNull]|JavaNull).stripAllJavaNull => Array[String]
-     *  If no `JavaNull` unions are found within the type, then returns the input type unchanged.
+    /** Collapses all `UncheckedNull` unions within this type, and not just the outermost ones (as `stripUncheckedNull` does).
+     *  e.g. (Array[String|UncheckedNull]|UncheckedNull).stripUncheckedNull => Array[String|UncheckedNull]
+     *       (Array[String|UncheckedNull]|UncheckedNull).stripAllUncheckedNull => Array[String]
+     *  If no `UncheckedNull` unions are found within the type, then returns the input type unchanged.
      */
-    def stripAllJavaNull(implicit ctx: Context): Type = {
+    def stripAllUncheckedNull(implicit ctx: Context): Type = {
       object RemoveNulls extends TypeMap {
         override def apply(tp: Type): Type = mapOver(tp.stripNull(true))
       }
@@ -77,8 +77,8 @@ object NullOpsDecorator {
       stripped ne self
     }
 
-    /** Is self (after widening and dealiasing) a type of the form `T | JavaNull`? */
-    def isJavaNullableUnion(implicit ctx: Context): Boolean = {
+    /** Is self (after widening and dealiasing) a type of the form `T | UncheckedNull`? */
+    def isUncheckedNullableUnion(implicit ctx: Context): Boolean = {
       val stripped = self.stripNull(true)
       stripped ne self
     }

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -197,7 +197,7 @@ object StdNames {
     final val Nothing: N             = "Nothing"
     final val NotNull: N             = "NotNull"
     final val Null: N                = "Null"
-    final val JavaNull: N            = "JavaNull"
+    final val UncheckedNull: N            = "UncheckedNull"
     final val Object: N              = "Object"
     final val Product: N             = "Product"
     final val PartialFunction: N     = "PartialFunction"

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -712,12 +712,12 @@ object Types {
         go(l) & (go(r), pre, safeIntersection = ctx.base.pendingMemberSearches.contains(name))
 
       def goOr(tp: OrType) = tp match {
-        case OrJavaNull(tp1) =>
-          // Selecting `name` from a type `T|JavaNull` is like selecting `name` from `T`.
+        case OrUncheckedNull(tp1) =>
+          // Selecting `name` from a type `T|UncheckedNull` is like selecting `name` from `T`.
           // This can throw at runtime, but we trade soundness for usability.
-          // We need to strip `JavaNull` from both the type and the prefix so that
+          // We need to strip `UncheckedNull` from both the type and the prefix so that
           // `pre <: tp` continues to hold.
-          tp1.findMember(name, pre.stripJavaNull, required, excluded)
+          tp1.findMember(name, pre.stripUncheckedNull, required, excluded)
         case _ =>
           // we need to keep the invariant that `pre <: tp`. Branch `union-types-narrow-prefix`
           // achieved that by narrowing `pre` to each alternative, but it led to merge errors in
@@ -2963,15 +2963,15 @@ object Types {
    *  e.g.
    *
    *  (tp: Type) match
-   *    case OrJavaNull(tp1) => // tp had the form `tp1 | JavaNull`
+   *    case OrUncheckedNull(tp1) => // tp had the form `tp1 | UncheckedNull`
    *    case _ => // tp was not a Java-nullable union
    */
-  object OrJavaNull {
+  object OrUncheckedNull {
     def apply(tp: Type)(given Context) =
-      OrType(tp, defn.JavaNullAliasType)
+      OrType(tp, defn.UncheckedNullAliasType)
     def unapply(tp: Type)(given ctx: Context): Option[Type] =
       if (ctx.explicitNulls) {
-        val tp1 = tp.stripJavaNull
+        val tp1 = tp.stripUncheckedNull
         if tp1 ne tp then Some(tp1) else None
       }
       else None

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -52,17 +52,17 @@ class FirstTransform extends MiniPhase with InfoTransformer { thisPhase =>
     tree match {
       case Select(qual, name) if !name.is(OuterSelectName) && tree.symbol.exists =>
         val qualTpe = if (ctx.explicitNulls) {
-          // `JavaNull` is already special-cased in the Typer, but needs to be handled here as well.
-          // We need `stripAllJavaNull` and not `stripJavaNull` because of the following case:
+          // `UncheckedNull` is already special-cased in the Typer, but needs to be handled here as well.
+          // We need `stripAllUncheckedNull` and not `stripUncheckedNull` because of the following case:
           //
-          //   val s: (String|JavaNull)&(String|JavaNull) = "hello"
+          //   val s: (String|UncheckedNull)&(String|UncheckedNull) = "hello"
           //   val l = s.length
           //
-          // The invariant below is that the type of `s`, which isn't a top-level JavaNull union,
+          // The invariant below is that the type of `s`, which isn't a top-level UncheckedNull union,
           // must derive from the type of the owner of `length`, which is `String`. Because we don't
-          // know which `JavaNull`s were used to find the `length` member, we conservatively remove
+          // know which `UncheckedNull`s were used to find the `length` member, we conservatively remove
           // all of them.
-          qual.tpe.stripAllJavaNull
+          qual.tpe.stripAllUncheckedNull
         } else {
           qual.tpe
         }

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -189,7 +189,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       // Second constructor of ioob that takes a String argument
       def filterStringConstructor(s: Symbol): Boolean = s.info match {
         case m: MethodType if s.isConstructor && m.paramInfos.size == 1 =>
-          val pinfo = if (ctx.explicitNulls) m.paramInfos.head.stripJavaNull else m.paramInfos.head
+          val pinfo = if (ctx.explicitNulls) m.paramInfos.head.stripUncheckedNull else m.paramInfos.head
           pinfo == defn.StringType
         case _ => false
       }

--- a/tests/explicit-nulls/neg/interop-javanull.scala
+++ b/tests/explicit-nulls/neg/interop-javanull.scala
@@ -1,5 +1,5 @@
 
-// Test that JavaNull can be assigned to Null.
+// Test that UncheckedNull can be assigned to Null.
 class Foo {
   import java.util.ArrayList
   val l = new ArrayList[String]()

--- a/tests/explicit-nulls/neg/interop-propagate.scala
+++ b/tests/explicit-nulls/neg/interop-propagate.scala
@@ -1,7 +1,7 @@
  class Foo {
   import java.util.ArrayList
 
-  // Test that as we extract return values, we're missing the |JavaNull in the return type.
+  // Test that as we extract return values, we're missing the |UncheckedNull in the return type.
   // i.e. test that the nullability is propagated to nested containers.
   val ll = new ArrayList[ArrayList[ArrayList[String]]]
   val level1: ArrayList[ArrayList[String]] = ll.get(0) // error

--- a/tests/explicit-nulls/neg/interop-return.scala
+++ b/tests/explicit-nulls/neg/interop-return.scala
@@ -5,10 +5,10 @@ class Foo {
   def foo = {
     import java.util.ArrayList
     val x = new ArrayList[String]()
-    val r: String = x.get(0) // error: got String|JavaNull instead of String
+    val r: String = x.get(0) // error: got String|UncheckedNull instead of String
 
     val x2 = new ArrayList[Int]()
     val r2: Int = x2.get(0) // error: even though Int is non-nullable in Scala, its counterpart
-    // (for purposes of generics) in Java (Integer) is. So we're missing |JavaNull
+    // (for purposes of generics) in Java (Integer) is. So we're missing |UncheckedNull
   }
 }

--- a/tests/explicit-nulls/neg/java-null.scala
+++ b/tests/explicit-nulls/neg/java-null.scala
@@ -1,10 +1,10 @@
-// Test that `JavaNull` is see-through, but `Null` isn't.
+// Test that `UncheckedNull` is see-through, but `Null` isn't.
 
 class Test {
   val s: String|Null = "hello"
   val l = s.length // error: `Null` isn't "see-through"
 
-  val s2: String|JavaNull = "world"
+  val s2: String|UncheckedNull = "world"
   val l2 = s2.length // ok
 }
 

--- a/tests/explicit-nulls/neg/nullnull.scala
+++ b/tests/explicit-nulls/neg/nullnull.scala
@@ -11,7 +11,7 @@ class Foo {
   }
 
   def foo2: Unit = {
-    val x: JavaNull | String | Null = ???
+    val x: UncheckedNull | String | Null = ???
     if (x == null) return ()
     val y = x.length // ok: x: String is inferred
   }

--- a/tests/explicit-nulls/pos-separate/notnull/S_3.scala
+++ b/tests/explicit-nulls/pos-separate/notnull/S_3.scala
@@ -10,6 +10,6 @@ class S_3 {
   def ff(i: Int): String = J_2.f(i)
   def gg(i: Int): String = J_2.g(i)
   def hh(i: Int): String = (new J_2).h(i)
-  def genericff(a: String | Null): Array[String | JavaNull] = (new J_2).genericf(a)
+  def genericff(a: String | Null): Array[String | UncheckedNull] = (new J_2).genericf(a)
   def genericgg(a: String | Null): java.util.List[String] = (new J_2).genericg(a)
 }

--- a/tests/explicit-nulls/pos/interop-javanull-src/S.scala
+++ b/tests/explicit-nulls/pos/interop-javanull-src/S.scala
@@ -1,5 +1,5 @@
 
-// Test that JavaNull is "see through"
+// Test that UncheckedNull is "see through"
 class S {
   val j: J2 = new J2()
   j.getJ1().getJ2().getJ1().getJ2().getJ1().getJ2()

--- a/tests/explicit-nulls/pos/interop-javanull.scala
+++ b/tests/explicit-nulls/pos/interop-javanull.scala
@@ -1,10 +1,10 @@
 
-// Tests that the "JavaNull" type added to Java types is "see through" w.r.t member selections.
+// Tests that the "UncheckedNull" type added to Java types is "see through" w.r.t member selections.
 class Foo {
   import java.util.ArrayList
   import java.util.Iterator
 
-  // Test that we can select through "|JavaNull" (unsoundly).
+  // Test that we can select through "|UncheckedNull" (unsoundly).
   val x3 = new ArrayList[ArrayList[ArrayList[String]]]()
   val x4: Int = x3.get(0).get(0).get(0).length()
 }

--- a/tests/explicit-nulls/pos/interop-valuetypes.scala
+++ b/tests/explicit-nulls/pos/interop-valuetypes.scala
@@ -1,6 +1,6 @@
 
 // Tests that value (non-reference) types aren't nullified by the Java transform.
-class Foo { 
+class Foo {
   val x: java.lang.String = ""
-  val len: Int = x.length() // type is Int and not Int|JavaNull
+  val len: Int = x.length() // type is Int and not Int|UncheckedNull
 }

--- a/tests/explicit-nulls/pos/java-null.scala
+++ b/tests/explicit-nulls/pos/java-null.scala
@@ -1,16 +1,16 @@
-// Test that `JavaNull`able unions are transparent
+// Test that `UncheckedNull`able unions are transparent
 // w.r.t member selections.
 
 class Test {
-  val s: String|JavaNull = "hello"
-  val l: Int = s.length // ok: `JavaNull` allows (unsound) member selections.
+  val s: String|UncheckedNull = "hello"
+  val l: Int = s.length // ok: `UncheckedNull` allows (unsound) member selections.
 
-  val s2: JavaNull|String = "world"
+  val s2: UncheckedNull|String = "world"
   val l2: Int = s2.length
 
-  val s3: JavaNull|String|JavaNull = "hello"
+  val s3: UncheckedNull|String|UncheckedNull = "hello"
   val l3: Int = s3.length
 
-  val s4: (String|JavaNull)&(JavaNull|String) = "hello"
+  val s4: (String|UncheckedNull)&(UncheckedNull|String) = "hello"
   val l4 = s4.length
 }

--- a/tests/explicit-nulls/pos/java-varargs.scala
+++ b/tests/explicit-nulls/pos/java-varargs.scala
@@ -9,7 +9,7 @@ class S {
   // is a varargs: https://docs.oracle.com/javase/8/docs/api/java/nio/file/Paths.html
   // static Path get(String first, String... more)
   // The Scala compiler converts this signature into
-  // def get(first: String|JavaNUll, more: (String|JavaNull)*)
+  // def get(first: String|JavaNUll, more: (String|UncheckedNull)*)
 
   // Test that we can avoid providing the varargs argument altogether.
   Paths.get("out").toAbsolutePath

--- a/tests/explicit-nulls/pos/notnull/S.scala
+++ b/tests/explicit-nulls/pos/notnull/S.scala
@@ -10,6 +10,6 @@ class S_3 {
   def ff(i: Int): String = J.f(i)
   def gg(i: Int): String = J.g(i)
   def hh(i: Int): String = (new J).h(i)
-  def genericff(a: String | Null): Array[String | JavaNull] = (new J).genericf(a)
+  def genericff(a: String | Null): Array[String | UncheckedNull] = (new J).genericf(a)
   def genericgg(a: String | Null): java.util.List[String] = (new J).genericg(a)
 }

--- a/tests/explicit-nulls/run/java-null.scala
+++ b/tests/explicit-nulls/run/java-null.scala
@@ -1,17 +1,17 @@
-// Check that selecting a member from a `JavaNull`able union is unsound.
+// Check that selecting a member from a `UncheckedNull`able union is unsound.
 
 object Test {
   def main(args: Array[String]): Unit = {
-    val s: String|JavaNull = "hello"
+    val s: String|UncheckedNull = "hello"
     assert(s.length == 5)
 
-    val s2: String|JavaNull = null
+    val s2: String|UncheckedNull = null
     try {
       s2.length // should throw
       assert(false)
     } catch {
       case e: NullPointerException =>
-        // ok: selecting on a JavaNull can throw
+        // ok: selecting on a UncheckedNull can throw
     }
   }
 }


### PR DESCRIPTION
Before releasing the Dotty version with explicit nulls later this week, we want to make sure we get the names right, since these are hard to fix once people have started using them. 

@abeln @olhotak @noti0na1 are you OK with `UncheckedNull`?

