### PR TITLE
Fix #7783: Widen AnyVal to Any when checking class relation

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -168,7 +168,8 @@ object TypeTestsCasts {
           cpy.TypeApply(tree)(expr1.select(sym).withSpan(expr.span), List(TypeTree(tp)))
 
         def effectiveClass(tp: Type): Symbol =
-          if (tp.isRef(defn.PairClass)) effectiveClass(erasure(tp))
+          if tp.isRef(defn.PairClass) then effectiveClass(erasure(tp))
+          else if tp.isRef(defn.AnyValClass) then defn.AnyClass
           else tp.classSymbol
 
         def foundCls = effectiveClass(expr.tpe.widen)

--- a/tests/run/i7783.scala
+++ b/tests/run/i7783.scala
@@ -1,0 +1,6 @@
+object Test extends App {
+  def foo(t: AnyVal): Unit = t match {
+    case _: Int =>
+  }
+  foo(3)
+}


### PR DESCRIPTION
Widen AnyVal to Any when checking in TypeTestsCasts whether two
classes are related.