### PR TITLE
Upgrade to Scala.js 1.0.0-RC2.

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -427,10 +427,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
 
   val Flag_SYNTHETIC: Flags = Flags.Synthetic.bits
   val Flag_METHOD: Flags = Flags.Method.bits
-  val ExcludedForwarderFlags: Flags = {
-      Flags.Specialized | Flags.Lifted | Flags.Protected | Flags.JavaStatic |
-      Flags.Private | Flags.Macro
-  }.bits
+  val ExcludedForwarderFlags: Flags = DottyBackendInterface.ExcludedForwarderFlags.bits
 
   def isQualifierSafeToElide(qual: Tree): Boolean = tpd.isIdempotentExpr(qual)
 
@@ -1194,4 +1191,11 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
   }
 
   def currentUnit: CompilationUnit = ctx.compilationUnit
+}
+
+object DottyBackendInterface {
+  val ExcludedForwarderFlags: Flags.FlagSet = {
+    Flags.Specialized | Flags.Lifted | Flags.Protected | Flags.JavaStatic |
+    Flags.Private | Flags.Macro
+  }
 }

--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -237,13 +237,17 @@ object JSEncoding {
     js.ClassIdent(encodeClassName(sym))
 
   def encodeClassName(sym: Symbol)(implicit ctx: Context): ClassName = {
-    if (sym == defn.BoxedUnitClass) {
+    val sym1 =
+      if (sym.isAllOf(ModuleClass | JavaDefined)) sym.linkedClass
+      else sym
+
+    if (sym1 == defn.BoxedUnitClass) {
       /* Rewire scala.runtime.BoxedUnit to java.lang.Void, as the IR expects.
        * BoxedUnit$ is a JVM artifact.
        */
       ir.Names.BoxedUnitClass
     } else {
-      ClassName(sym.fullName.mangledString)
+      ClassName(sym1.fullName.mangledString)
     }
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 //
 // e.g. addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-RC1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-RC2")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.6")
 


### PR DESCRIPTION
This includes changes to the contract of calling static methods in Java-defined classes. They are now actually called as static methods in the IR.

We also generate static forwarders for public methods in static objects.

These changes are a forward-port of https://github.com/scala-js/scala-js/commit/f94713bfe192b3426836f6c712855f8cc0ddb28b

The only real difference is that in scalac, we emit a compile error if the companion class contains *any* public static method, because scalac does not otherwise produce public static methods at the moment. Since dotty does generate public static methods for the bodies of SAMs, we only complain if there is an actual clash.