### PR TITLE
Don't publish to sonatype twice

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -107,7 +107,7 @@ steps:
   - test_sbt
   - test_java11
   commands:
-  - ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease ;project tasty-core-scala2; publishSigned ;sonatypeBundleRelease"
+  - ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease"
   environment:
     NIGHTLYBUILD: yes
     PGP_PW:
@@ -135,7 +135,7 @@ steps:
   - test_java11
   commands:
   - ./project/scripts/sbt dist-bootstrapped/packArchive
-  - ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease ;project tasty-core-scala2; publishSigned ;sonatypeBundleRelease"
+  - ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease"
   environment:
     PGP_PW:
       from_secret: pgp_pw


### PR DESCRIPTION
This is a quickfix to prevent CI from failing publish phases. Since other phases (such as github release) may depend on sonatype release, the fact that sonatype release fails may also fail these phases needlessly thus complicating the release process. We should do the publish of tasty core together with the other artefacts.