### PR TITLE
Avoid nonsensical error message in processByNameArgs

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -89,7 +89,6 @@ object ErrorReporting {
       if (tree.tpe.widen.exists)
         i"${exprStr(tree)} does not take ${kind}parameters"
       else {
-        if (ctx.settings.Ydebug.value) new FatalError("").printStackTrace()
         i"undefined: $tree # ${tree.uniqueId}: ${tree.tpe.toString} at ${ctx.phase}"
       }
 

--- a/compiler/src/dotty/tools/dotc/typer/Nullables.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Nullables.scala
@@ -507,7 +507,10 @@ object Nullables with
 
             def recur(formals: List[Type], args: List[Tree]): List[Tree] = (formals, args) match
               case (formal :: formalsRest, arg :: argsRest) =>
-                val arg1 = postProcess(formal.widenExpr.repeatedToSingle, arg)
+                val arg1 =
+                  if formal.isInstanceOf[ExprType]
+                  then postProcess(formal.widenExpr.repeatedToSingle, arg)
+                  else arg
                 val argsRest1 = recur(
                   if formal.isRepeatedParam then formals else formalsRest,
                   argsRest)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -411,6 +411,7 @@ trait TypeAssigner {
         else
           errorType(i"wrong number of arguments at ${ctx.phase.prev} for $fntpe: ${fn.tpe}, expected: ${fntpe.paramInfos.length}, found: ${args.length}", tree.sourcePos)
       case t =>
+        if (ctx.settings.Ydebug.value) new FatalError("").printStackTrace()
         errorType(err.takesNoParamsStr(fn, ""), tree.sourcePos)
     }
     ConstFold(tree.withType(ownType))

--- a/tests/neg-custom-args/explicit-nulls/byname-nullables1.check
+++ b/tests/neg-custom-args/explicit-nulls/byname-nullables1.check
@@ -1,0 +1,8 @@
+-- Error: tests/neg-custom-args/explicit-nulls/byname-nullables1.scala:9:22 --------------------------------------------
+9 |  if x != null then f(x.fld != null) // error
+  |                      ^^^^^^^^^^^^^
+  |                      This argument was typed using flow assumptions about mutable variables
+  |                      but it is passed to a by-name parameter where such flow assumptions are unsound.
+  |                      Wrapping the argument in `byName(...)` fixes the problem by disabling the flow assumptions.
+  |
+  |                      `byName` needs to be imported from the `scala.compiletime` package.

--- a/tests/neg-custom-args/explicit-nulls/byname-nullables1.check
+++ b/tests/neg-custom-args/explicit-nulls/byname-nullables1.check
@@ -1,8 +1,8 @@
--- Error: tests/neg-custom-args/explicit-nulls/byname-nullables1.scala:9:22 --------------------------------------------
-9 |  if x != null then f(x.fld != null) // error
-  |                      ^^^^^^^^^^^^^
-  |                      This argument was typed using flow assumptions about mutable variables
-  |                      but it is passed to a by-name parameter where such flow assumptions are unsound.
-  |                      Wrapping the argument in `byName(...)` fixes the problem by disabling the flow assumptions.
-  |
-  |                      `byName` needs to be imported from the `scala.compiletime` package.
+-- Error: tests/neg-custom-args/explicit-nulls/byname-nullables1.scala:10:6 --------------------------------------------
+10 |    f(x.fld != null) // error
+   |      ^^^^^^^^^^^^^
+   |      This argument was typed using flow assumptions about mutable variables
+   |      but it is passed to a by-name parameter where such flow assumptions are unsound.
+   |      Wrapping the argument in `byName(...)` fixes the problem by disabling the flow assumptions.
+   |
+   |      `byName` needs to be imported from the `scala.compiletime` package.

--- a/tests/neg-custom-args/explicit-nulls/byname-nullables1.scala
+++ b/tests/neg-custom-args/explicit-nulls/byname-nullables1.scala
@@ -1,0 +1,9 @@
+def f(op: => Boolean): Unit = ()
+def f(op: Int): Unit = ()
+
+class C with
+  var fld: String | Null = null
+
+def test() =
+  var x: C | Null = C()
+  if x != null then f(x.fld != null) // error

--- a/tests/neg-custom-args/explicit-nulls/byname-nullables1.scala
+++ b/tests/neg-custom-args/explicit-nulls/byname-nullables1.scala
@@ -6,4 +6,6 @@ class C with
 
 def test() =
   var x: C | Null = C()
-  if x != null then f(x.fld != null) // error
+  if x != null then
+    f(x.fld != null) // error
+    require(x.fld != null, "error")    // ok


### PR DESCRIPTION
Transforming the argument can already cause errors coming from
TypeAssigner that need to be caught instead of being issued.