### PR TITLE
Fix #7840: Don't instantiateSelected to Nothing

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3930,6 +3930,10 @@ object Types {
     def hasLowerBound(implicit ctx: Context): Boolean =
       !ctx.typerState.constraint.entry(origin).loBound.isBottomType
 
+    /** For uninstantiated type variables: Is the upper bound different from Any? */
+    def hasUpperBound(implicit ctx: Context): Boolean =
+      !ctx.typerState.constraint.entry(origin).hiBound.isRef(defn.AnyClass)
+
     /** Unwrap to instance (if instantiated) or origin (if not), until result
      *  is no longer a TypeVar
      */

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -108,12 +108,9 @@ object Inferencing {
         && ctx.typerState.constraint.contains(tvar)
         && {
           val direction = instDirection(tvar.origin)
-          def avoidBottom =
-            !force.allowBottom &&
-            defn.isBottomType(ctx.typeComparer.approximation(tvar.origin, fromBelow = true))
           def preferMin =
-            force.minimizeAll && (!avoidBottom || !tvar.hasUpperBound)
-            || variance >= 0 && !avoidBottom
+            force.minimizeAll && (tvar.hasLowerBound || !tvar.hasUpperBound)
+            || variance >= 0 && (force.allowBottom || tvar.hasLowerBound)
           if (direction != 0) instantiate(tvar, direction < 0)
           else if (preferMin) instantiate(tvar, fromBelow = true)
           else toMaximize = true

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -111,7 +111,9 @@ object Inferencing {
           def avoidBottom =
             !force.allowBottom &&
             defn.isBottomType(ctx.typeComparer.approximation(tvar.origin, fromBelow = true))
-          def preferMin = (force.minimizeAll || variance >= 0) && !avoidBottom
+          def preferMin =
+            force.minimizeAll && (!avoidBottom || !tvar.hasUpperBound)
+            || variance >= 0 && !avoidBottom
           if (direction != 0) instantiate(tvar, direction < 0)
           else if (preferMin) instantiate(tvar, fromBelow = true)
           else toMaximize = true

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -46,7 +46,7 @@ object Inferencing {
   /** Instantiate selected type variables `tvars` in type `tp` */
   def instantiateSelected(tp: Type, tvars: List[Type])(implicit ctx: Context): Unit =
     if (tvars.nonEmpty)
-      new IsFullyDefinedAccumulator(new ForceDegree.Value(tvars.contains, minimizeAll = true)).process(tp)
+      new IsFullyDefinedAccumulator(new ForceDegree.Value(tvars.contains, minimizeAll = true, allowBottom = false)).process(tp)
 
   /** Instantiate any type variables in `tp` whose bounds contain a reference to
    *  one of the parameters in `tparams` or `vparamss`.
@@ -111,7 +111,7 @@ object Inferencing {
           def avoidBottom =
             !force.allowBottom &&
             defn.isBottomType(ctx.typeComparer.approximation(tvar.origin, fromBelow = true))
-          def preferMin = force.minimizeAll || variance >= 0 && !avoidBottom
+          def preferMin = (force.minimizeAll || variance >= 0) && !avoidBottom
           if (direction != 0) instantiate(tvar, direction < 0)
           else if (preferMin) instantiate(tvar, fromBelow = true)
           else toMaximize = true

--- a/tests/neg/i1802.scala
+++ b/tests/neg/i1802.scala
@@ -14,7 +14,7 @@ object Exception {
     def apply(x: Throwable): T = f(downcast(x).get)
   }
 
-  def mkThrowableCatcher[T](isDef: Throwable => Boolean, f: Throwable => T) = mkCatcher(isDef, f) // error: undetermined ClassTag
+  def mkThrowableCatcher[T](isDef: Throwable => Boolean, f: Throwable => T) = mkCatcher(isDef, f)
 
   implicit def throwableSubtypeToCatcher[Ex <: Throwable: ClassTag, T](pf: PartialFunction[Ex, T]) = // error: result type needs to be given
     mkCatcher(pf.isDefinedAt _, pf.apply _) // error: method needs return type

--- a/tests/neg/undet-classtag.scala
+++ b/tests/neg/undet-classtag.scala
@@ -3,7 +3,7 @@ import scala.reflect.ClassTag
 object Test {
   def f[T: reflect.ClassTag](x: T) = ???
 
-  f(???)
+  f(???) // error: undetermined ClassTag
 }
 
 // SI 9754
@@ -22,6 +22,6 @@ object Program {
 
 // SI 5353
 object t5353 {
-  if (false) Array("qwe") else Array()
+  if (false) Array("qwe") else Array() // error: undetermined ClassTag
 }
 

--- a/tests/neg/undet-classtag.scala
+++ b/tests/neg/undet-classtag.scala
@@ -3,7 +3,7 @@ import scala.reflect.ClassTag
 object Test {
   def f[T: reflect.ClassTag](x: T) = ???
 
-  f(???) // error: undetermined ClassTag
+  f(???)
 }
 
 // SI 9754
@@ -22,6 +22,6 @@ object Program {
 
 // SI 5353
 object t5353 {
-  if (false) Array("qwe") else Array() // error: undetermined ClassTag
+  if (false) Array("qwe") else Array()
 }
 

--- a/tests/pos/i7840.scala
+++ b/tests/pos/i7840.scala
@@ -1,0 +1,17 @@
+object Example extends App {
+
+  trait ZSink[-R, +E, +A0, -A, +B] {
+    def flatMap[R1 <: R, E1 >: E, A00 >: A0, A1 <: A, C](
+      f: B => ZSink[R1, E1, A00, A1, C]
+    )(implicit ev: A00 =:= A1, e2: A1 =:= A00): ZSink[R1, E1, A00, A1, C] =
+      ???
+  }
+
+  object ZSink {
+    def identity[A]: ZSink[Any, Unit, Nothing, A, A] = ???
+    def succeed[A, B](b: B): ZSink[Any, Nothing, A, A, B] = ???
+  }
+
+  // cannot prove that Int =:= Nothing
+  ZSink.identity[Int].flatMap(n => ZSink.succeed[Int, String](n.toString))
+}


### PR DESCRIPTION
When instantiating type variables ahead of an implicit search, avoid instantiating
them to Nothing.

These are really two changes:

 - Assert `avoidBottom` in `instantiateSelected`
 - Change FullyDefinedAccululator logic so that `avoidBottom` overrides `minimizeAll`.