### PR TITLE
Fix #7820: Break cycle when computing completerTypeParams

### DIFF
--- a/tests/neg/i7820.scala
+++ b/tests/neg/i7820.scala
@@ -1,0 +1,3 @@
+trait A1 { type F[X <: F[_, _], Y] }  // error: cyclic reference involving type F
+trait A2 { type F[X <: F, Y] }        // error: cyclic reference involving type F
+trait A3 { type F[X >: F, Y] }        // error: cyclic reference involving type F


### PR DESCRIPTION
The following no longer crashes:

    class C { type F[X <: F[_, _], Y] }

But it is still flagged as a cyclic reference error, whereas nsc accepts it. I believe it would be
tricky/risky to change dotc's algorithms to accept it as well, and I am not sure it's
necessary. Generally, we want to get away from F-bounds, so just accepting the most
common use case (F-bounds in method type parameters) is hopefully OK.