### PR TITLE
WIP: Fixes #7597 Return from next when there is a mistmatch between overriding and overridden

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -125,7 +125,7 @@ object OverridingPairs {
         if (nextEntry ne null)
           try {
             overridden = nextEntry.sym
-            if (overriding.owner != overridden.owner && matches(overriding, overridden)) {
+            if (overriding.owner != overridden.owner && !matches(overriding, overridden)) {
               visited += overridden
               if (!hasCommonParentAsSubclass(overriding.owner, overridden.owner)) return
             }


### PR DESCRIPTION
This is still a work in progress. The `next()` method in `OverridingPairs` calls itself recursively even when matching `lookupNextEntry` returns a non null entry. This leads to exhaustion of all the entries during initialisation  of `Cursor, [here](https://github.com/lampepfl/dotty/blob/2e3fbfdfc010cddeb6beb81839cf16ec6d735d88/compiler/src/dotty/tools/dotc/typer/RefChecks.scala#L427). And, because of that, [this](https://github.com/lampepfl/dotty/blob/2e3fbfdfc010cddeb6beb81839cf16ec6d735d88/compiler/src/dotty/tools/dotc/typer/RefChecks.scala#L429) is never reached. 