### PR TITLE
Fix #7876: Hold off with uniqueness checking for imports

### DIFF
--- a/tests/pos/i7876.scala
+++ b/tests/pos/i7876.scala
@@ -1,0 +1,6 @@
+object foo
+object bar
+
+import foo._, bar._
+
+object eq


### PR DESCRIPTION
Hold off checking uniqueness of imports with checkNewOrShadowed until
we have verified that there is no outer package level definition that
trumps the conflicting imports.