### PR TITLE
Fix #7893: Less eager forcing of expected types for functions

### DIFF
--- a/tests/pos/i7893.scala
+++ b/tests/pos/i7893.scala
@@ -2,6 +2,6 @@ object Test {
   val l1 = List(Predef.identity[Int](_))
   val lc1: List[Int => Int] = l1
 
-  val l2 = List(Predef.identity[Int](_))
+  val l2 = List(Predef.identity[Int])
   val lc2: List[Int => Int] = l2
 }

--- a/tests/pos/i7893.scala
+++ b/tests/pos/i7893.scala
@@ -1,0 +1,7 @@
+object Test {
+  val l1 = List(Predef.identity[Int](_))
+  val lc1: List[Int => Int] = l1
+
+  val l2 = List(Predef.identity[Int](_))
+  val lc2: List[Int => Int] = l2
+}


### PR DESCRIPTION
Don't force expected parameter types if the callee type of a closure
is known. In this case, we have enough info to fill in parameter types
from the callee.