### PR TITLE
Fix #7877: Refine instantiation criterion before implicit search

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -555,17 +555,17 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
 
     val childTp = if (child.isTerm) child.termRef else child.typeRef
 
-    instantiate(childTp, parent)(ctx.fresh.setNewTyperState()).dealias
+    instantiateToSubType(childTp, parent)(ctx.fresh.setNewTyperState()).dealias
   }
 
   /** Instantiate type `tp1` to be a subtype of `tp2`
    *
-   *  Return the instantiated type if type parameters and this type
+   *  Return the instantiated type if type parameters in this type
    *  in `tp1` can be instantiated such that `tp1 <:< tp2`.
    *
    *  Otherwise, return NoType.
    */
-  private def instantiate(tp1: NamedType, tp2: Type)(implicit ctx: Context): Type = {
+  private def instantiateToSubType(tp1: NamedType, tp2: Type)(implicit ctx: Context): Type = {
     /** expose abstract type references to their bounds or tvars according to variance */
     class AbstractTypeMap(maximize: Boolean)(implicit ctx: Context) extends TypeMap {
       def expose(lo: Type, hi: Type): Type =
@@ -637,7 +637,6 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
       tvar =>
         !(ctx.typerState.constraint.entry(tvar.origin) `eq` tvar.origin.underlying) ||
         (tvar `eq` removeThisType.prefixTVar),
-      minimizeAll = false,
       allowBottom = false
     )
 

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -779,7 +779,7 @@ trait Implicits { self: Typer =>
   /** If `formal` is of the form Eql[T, U], try to synthesize an
     *  `Eql.eqlAny[T, U]` as solution.
     */
-  lazy val synthesizedEq: SpecialHandler = {
+  lazy val synthesizedEql: SpecialHandler = {
     (formal, span) => implicit ctx => {
 
       /** Is there an `Eql[T, T]` instance, assuming -strictEquality? */
@@ -1091,7 +1091,7 @@ trait Implicits { self: Typer =>
       mySpecialHandlers = List(
         defn.ClassTagClass        -> synthesizedClassTag,
         defn.QuotedTypeClass      -> synthesizedTypeTag,
-        defn.EqlClass             -> synthesizedEq,
+        defn.EqlClass             -> synthesizedEql,
         defn.TupledFunctionClass  -> synthesizedTupleFunction,
         defn.ValueOfClass         -> synthesizedValueOf,
         defn.Mirror_ProductClass  -> synthesizedProductMirror,

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -112,7 +112,9 @@ object Inferencing {
             force.minimizeAll && (tvar.hasLowerBound || !tvar.hasUpperBound)
             || variance >= 0 && (force.allowBottom || tvar.hasLowerBound)
           if (direction != 0) instantiate(tvar, direction < 0)
-          else if (preferMin) instantiate(tvar, fromBelow = true)
+          else if (preferMin)
+            if force.minimizeAll && !tvar.hasLowerBound then () // do nothing
+            else instantiate(tvar, fromBelow = true)
           else toMaximize = tvar :: toMaximize
           foldOver(x, tvar)
         }

--- a/library/src/scala/Eql.scala
+++ b/library/src/scala/Eql.scala
@@ -9,7 +9,7 @@ sealed trait Eql[-L, -R]
 
 /** Companion object containing a few universally known `Eql` instances.
  *  Eql instances involving primitive types or the Null type are handled directly in
- *  the compiler (see Implicits.synthesizedEq), so they are not included here.
+ *  the compiler (see Implicits.synthesizedEql), so they are not included here.
  */
 object Eql {
   /** A universal `Eql` instance. */

--- a/tests/pos/i7877.scala
+++ b/tests/pos/i7877.scala
@@ -1,0 +1,21 @@
+object Example extends App {
+
+  trait ZSink[-R, +E, +A0, -A, +B] {
+    def orElse[R1 <: R, E1, A00 >: A0, A1 <: A, C](
+      that: ZSink[R1, E1, A00, A1, C]
+    )(implicit ev: A1 =:= A00): ZSink[R1, E1, A00, A1, Either[B, C]] =
+      ???
+  }
+
+  object ZSink {
+    def identity[A]: ZSink[Any, Unit, Nothing, A, A] = ???
+    def fail[E](e: E): ZSink[Any, E, Nothing, Any, Nothing] = ???
+  }
+
+  // compiles
+  val a: ZSink[Any, String, Int, Int, Either[Int, Nothing]] =
+    ZSink.identity[Int].orElse(ZSink.fail("Ouch"))
+
+  // cannot prove that Int =:= Nothing
+  ZSink.identity[Int].orElse(ZSink.fail("Ouch"))
+}


### PR DESCRIPTION

Refine criterion when to instantiate before implicit search. Don't
instantiate typevars that are completely unconstrained. Rely instead
on resolving these typevars by the implicit search.
