### PR TITLE
Syntax Change: Allow '.' in front of extension method

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3105,7 +3105,7 @@ object Parsers {
      *            |  this ParamClause ParamClauses `=' ConstrExpr
      *  DefDcl  ::=  DefSig `:' Type
      *  DefSig  ::=  id [DefTypeParamClause] DefParamClauses
-     *            |  ExtParamClause [nl] id DefParamClauses
+     *            |  ExtParamClause [nl] [‘.’] id DefParamClauses
      */
     def defDefOrDcl(start: Offset, mods: Modifiers): Tree = atSpan(start, nameStart) {
       def scala2ProcedureSyntax(resultTypeStr: String) = {
@@ -3134,7 +3134,11 @@ object Parsers {
         makeConstructor(Nil, vparamss, rhs).withMods(mods).setComment(in.getDocComment(start))
       }
       else {
-        def extParamss() = try paramClause(0, prefix = true) :: Nil finally newLineOpt()
+        def extParamss() =
+          try paramClause(0, prefix = true) :: Nil
+          finally
+            if in.token == DOT then in.nextToken()
+            else newLineOpt()
         val (leadingTparams, leadingVparamss, flags) =
           if in.token == LBRACKET then
             (typeParamClause(ParamOwner.Def), extParamss(), Method | Extension)

--- a/docs/docs/contributing/debugging.md
+++ b/docs/docs/contributing/debugging.md
@@ -88,7 +88,7 @@ But you can also do:
 assertPositioned(tree.reporting(s"Tree is: $result"))
 ```
 
-`def (a: A) reporting(f: given WrappedResult[T] => String, p: Printer = Printers.default): A` is defined on all types. The function `f` can be written without the argument since the argument is `given`. The `result` variable is a part of the `WrapperResult` – a tiny framework powering the `reporting` function. Basically, whenever you are using `reporting` on an object `A`, you can use the `result: A` variable from this function and it will be equal to the object you are calling `reporting` on.
+`def (a: A).reporting(f: given WrappedResult[T] => String, p: Printer = Printers.default): A` is defined on all types. The function `f` can be written without the argument since the argument is `given`. The `result` variable is a part of the `WrapperResult` – a tiny framework powering the `reporting` function. Basically, whenever you are using `reporting` on an object `A`, you can use the `result: A` variable from this function and it will be equal to the object you are calling `reporting` on.
 
 ## Printing out trees after phases
 To print out the trees you are compiling after the FrontEnd (scanner, parser, namer, typer) phases:

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -358,7 +358,7 @@ ValDcl            ::=  ids ‘:’ Type                                         
 VarDcl            ::=  ids ‘:’ Type                                             PatDef(_, ids, tpe, EmptyTree)
 DefDcl            ::=  DefSig ‘:’ Type                                          DefDef(_, name, tparams, vparamss, tpe, EmptyTree)
 DefSig            ::=  id [DefTypeParamClause] DefParamClauses
-                    |  ExtParamClause [nl] id DefParamClauses
+                    |  ExtParamClause [nl] [‘.’] id DefParamClauses
 TypeDcl           ::=  id [TypeParamClause] SubtypeBounds [‘=’ Type]           TypeDefTree(_, name, tparams, bound
 
 Def               ::=  ‘val’ PatDef

--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -8,7 +8,7 @@ Extension methods allow one to add methods to a type after the type is defined. 
 ```scala
 case class Circle(x: Double, y: Double, radius: Double)
 
-def (c: Circle) circumference: Double = c.radius * math.Pi * 2
+def (c: Circle).circumference: Double = c.radius * math.Pi * 2
 ```
 
 Like regular methods, extension methods can be invoked with infix `.`:
@@ -42,7 +42,7 @@ As an example, consider an extension method `longestStrings` on `Seq[String]` de
 
 ```scala
 trait StringSeqOps {
-  def (xs: Seq[String]) longestStrings = {
+  def (xs: Seq[String]).longestStrings = {
     val maxLength = xs.map(_.length).max
     xs.filter(_.length == maxLength)
   }
@@ -80,22 +80,26 @@ So `circle.circumference` translates to `CircleOps.circumference(circle)`, provi
 
 ### Operators
 
-The extension method syntax also applies to the definition of operators.
-In each case the definition syntax mirrors the way the operator is applied.
+The extension method syntax also applies to the definition of operators. 
+In this case it is allowed and preferable to omit the period between the leading parameter list
+and the operator. In each case the definition syntax mirrors the way the operator is applied.
 Examples:
 ```scala
 def (x: String) < (y: String) = ...
 def (x: Elem) +: (xs: Seq[Elem]) = ...
+def (x: Number) min (y: Number) = ...
 
 "ab" < "c"
 1 +: List(2, 3)
+x min 3
 ```
-The two definitions above translate to
+The three definitions above translate to
 ```scala
 def < (x: String)(y: String) = ...
 def +: (xs: Seq[Elem])(x: Elem) = ...
+def min(x: Number)(y: Number) = ...
 ```
-Note that swap of the two parameters `x` and `xs` when translating
+Note the swap of the two parameters `x` and `xs` when translating
 the right-binding operator `+:` to an extension method. This is analogous
 to the implementation of right binding operators as normal methods.
 
@@ -144,7 +148,7 @@ If a given extension is anonymous (as in the last clause), its name is synthesiz
 The extensions above are equivalent to the following regular given instances where the implemented parent is `AnyRef` and the parameters in the `extension` clause are repeated in each extension method definition:
 ```scala
 given stringOps: AnyRef {
-  def (xs: Seq[String]) longestStrings: Seq[String] = {
+  def (xs: Seq[String]).longestStrings: Seq[String] = {
     val maxLength = xs.map(_.length).max
     xs.filter(_.length == maxLength)
   }
@@ -165,7 +169,7 @@ Here are the syntax changes for extension methods and given extensions relative
 to the [current syntax](../../internals/syntax.md). `extension` is a soft keyword, recognized only after a `given`. It can be used as an identifier everywhere else.
 ```
 DefSig            ::=  ...
-                    |  ExtParamClause [nl] id DefParamClauses
+                    |  ExtParamClause [nl] [‘.’] id DefParamClauses
 GivenDef          ::=  ...
                        [id ‘:’] ‘extension’ ExtParamClause {GivenParamClause} ExtMethods
 ExtParamClause    ::=  [DefTypeParamClause] ‘(’ DefParam ‘)’

--- a/docs/docs/reference/contextual/implicit-function-types.md
+++ b/docs/docs/reference/contextual/implicit-function-types.md
@@ -120,7 +120,7 @@ object PostConditions {
 
   def result[T](given r: WrappedResult[T]): T = r
 
-  def (x: T) ensuring[T](condition: (given WrappedResult[T]) => Boolean): T = {
+  def (x: T).ensuring[T](condition: (given WrappedResult[T]) => Boolean): T = {
     assert(condition(given x))
     x
   }

--- a/docs/docs/reference/contextual/relationship-implicits.md
+++ b/docs/docs/reference/contextual/relationship-implicits.md
@@ -104,7 +104,7 @@ will map to given clauses instead.
 
 Extension methods have no direct counterpart in Scala 2, but they can be simulated with implicit classes. For instance, the extension method
 ```scala
-def (c: Circle) circumference: Double = c.radius * math.Pi * 2
+def (c: Circle).circumference: Double = c.radius * math.Pi * 2
 ```
 could be simulated to some degree by
 ```scala

--- a/docs/docs/reference/contextual/typeclasses.md
+++ b/docs/docs/reference/contextual/typeclasses.md
@@ -11,7 +11,7 @@ with canonical implementations defined by given instances. Here are some example
 
 ```scala
 trait SemiGroup[T] with
-  def (x: T) combine (y: T): T
+  def (x: T).combine(y: T): T
 
 trait Monoid[T] extends SemiGroup[T] with
   def unit: T
@@ -20,11 +20,11 @@ object Monoid with
   def apply[T](given Monoid[T]) = summon[Monoid[T]]
 
 given Monoid[String] with
-  def (x: String) combine (y: String): String = x.concat(y)
+  def (x: String).combine(y: String): String = x.concat(y)
   def unit: String = ""
 
 given Monoid[Int] with
-  def (x: Int) combine (y: Int): Int = x + y
+  def (x: Int).combine(y: Int): Int = x + y
   def unit: Int = 0
 
 def sum[T: Monoid](xs: List[T]): T =

--- a/docs/docs/reference/dropped-features/package-objects.md
+++ b/docs/docs/reference/dropped-features/package-objects.md
@@ -22,7 +22,7 @@ def b = a._2
 case class C()
 
 implicit object Cops {
-  def (x: C) pair (y: C) = (x, y)
+  def (x: C).pair(y: C) = (x, y)
 }
 ```
 There may be several source files in a package containing such toplevel definitions, and source files can freely mix toplevel value, method, and type definitions with classes and objects.

--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -707,7 +707,7 @@ This might be used to then perform an implicit search as in:
 
 
 ```scala
-inline def (sc: StringContext) showMe(args: =>Any*): String = ${ showMeExpr('sc, 'args) }
+inline def (sc: StringContext).showMe(args: =>Any*): String = ${ showMeExpr('sc, 'args) }
 
 private def showMeExpr(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]])(given qctx: QuoteContext): Expr[String] = {
   argsExpr match {

--- a/docs/docs/reference/other-new-features/opaques.md
+++ b/docs/docs/reference/other-new-features/opaques.md
@@ -71,8 +71,8 @@ object Access {
 
   def (x: Permissions) & (y: Permissions): Permissions = x | y
   def (x: PermissionChoice) | (y: PermissionChoice): PermissionChoice = x | y
-  def (x: Permissions) is (y: Permissions) = (x & y) == y
-  def (x: Permissions) isOneOf (y: PermissionChoice) = (x & y) != 0
+  def (x: Permissions).is(y: Permissions) = (x & y) == y
+  def (x: Permissions).isOneOf(y: PermissionChoice) = (x & y) != 0
 
   val NoPermission: Permission = 0
   val ReadOnly: Permission = 1

--- a/docs/docs/reference/other-new-features/tupled-function.md
+++ b/docs/docs/reference/other-new-features/tupled-function.md
@@ -43,7 +43,7 @@ Examples
  *  @tparam Args the tuple type with the same types as the function arguments of F
  *  @tparam R the return type of F
  */
-def (f: F) tupled[F, Args <: Tuple, R](given tf: TupledFunction[F, Args => R]): Args => R = tf.tupled(f)
+def [F, Args <: Tuple, R](f: F).tupled(given tf: TupledFunction[F, Args => R]): Args => R = tf.tupled(f)
 ```
 
 `TupledFunction` can be used to generalize the `Function.untupled` methods to functions of any arities ([full example](https://github.com/lampepfl/dotty/blob/master/tests/run/tupled-function-untupled.scala))
@@ -58,7 +58,7 @@ def (f: F) tupled[F, Args <: Tuple, R](given tf: TupledFunction[F, Args => R]): 
  *  @tparam Args the tuple type with the same types as the function arguments of F
  *  @tparam R the return type of F
  */
-def (f: Args => R) untupled[F, Args <: Tuple, R](given tf: TupledFunction[F, Args => R]): F = tf.untupled(f)
+def [F, Args <: Tuple, R](f: Args => R).untupled(given tf: TupledFunction[F, Args => R]): F = tf.untupled(f)
 ```
 
 `TupledFunction` can also be used to generalize the [`Tuple1.compose`](https://github.com/lampepfl/dotty/blob/master/tests/run/tupled-function-compose.scala) and [`Tuple1.andThen`](https://github.com/lampepfl/dotty/blob/master/tests/run/tupled-function-andThen.scala) methods to compose functions of larger arities and with functions that return tuples.
@@ -72,7 +72,7 @@ def (f: Args => R) untupled[F, Args <: Tuple, R](given tf: TupledFunction[F, Arg
  *  @tparam GArgs the tuple type with the same types as the function arguments of G
  *  @tparam R the return type of F
  */
-def (f: F) compose[F, G, FArgs <: Tuple, GArgs <: Tuple, R](g: G)(given tg: TupledFunction[G, GArgs => FArgs], tf: TupledFunction[F, FArgs => R]): GArgs => R = {
+def [F, G, FArgs <: Tuple, GArgs <: Tuple, R](f: F).compose(g: G)(given tg: TupledFunction[G, GArgs => FArgs], tf: TupledFunction[F, FArgs => R]): GArgs => R = {
   (x: GArgs) => tf.tupled(f)(tg.tupled(g)(x))
 }
 ```

--- a/library/src-bootstrapped/scala/IArray.scala
+++ b/library/src-bootstrapped/scala/IArray.scala
@@ -16,27 +16,27 @@ object opaques
       *  @param n   the index of the element to select
       *  @return    the element of the array at the given index
       */
-    def (arr: IArray[Byte]) apply (n: Int): Byte = arr.asInstanceOf[Array[Byte]].apply(n)
-    def (arr: IArray[Short]) apply (n: Int): Short = arr.asInstanceOf[Array[Short]].apply(n)
-    def (arr: IArray[Char]) apply (n: Int): Char = arr.asInstanceOf[Array[Char]].apply(n)
-    def (arr: IArray[Int]) apply (n: Int): Int = arr.asInstanceOf[Array[Int]].apply(n)
-    def (arr: IArray[Long]) apply (n: Int): Long = arr.asInstanceOf[Array[Long]].apply(n)
-    def (arr: IArray[Float]) apply (n: Int): Float = arr.asInstanceOf[Array[Float]].apply(n)
-    def (arr: IArray[Double]) apply (n: Int): Double = arr.asInstanceOf[Array[Double]].apply(n)
+    def (arr: IArray[Byte]).apply(n: Int): Byte = arr.asInstanceOf[Array[Byte]].apply(n)
+    def (arr: IArray[Short]).apply(n: Int): Short = arr.asInstanceOf[Array[Short]].apply(n)
+    def (arr: IArray[Char]).apply(n: Int): Char = arr.asInstanceOf[Array[Char]].apply(n)
+    def (arr: IArray[Int]).apply(n: Int): Int = arr.asInstanceOf[Array[Int]].apply(n)
+    def (arr: IArray[Long]).apply(n: Int): Long = arr.asInstanceOf[Array[Long]].apply(n)
+    def (arr: IArray[Float]).apply(n: Int): Float = arr.asInstanceOf[Array[Float]].apply(n)
+    def (arr: IArray[Double]).apply(n: Int): Double = arr.asInstanceOf[Array[Double]].apply(n)
     def [T <: Object](arr: IArray[T]) apply (n: Int): T = arr.asInstanceOf[Array[T]].apply(n)
     def [T](arr: IArray[T]) apply (n: Int): T = arr.asInstanceOf[Array[T]].apply(n)
 
     /** The number of elements in an immutable array
       *  @param arr  the immutable array
       */
-    def (arr: IArray[Byte]) length: Int = arr.asInstanceOf[Array[Byte]].length
-    def (arr: IArray[Short]) length: Int = arr.asInstanceOf[Array[Short]].length
-    def (arr: IArray[Char]) length: Int = arr.asInstanceOf[Array[Char]].length
-    def (arr: IArray[Int]) length: Int = arr.asInstanceOf[Array[Int]].length
-    def (arr: IArray[Long]) length: Int = arr.asInstanceOf[Array[Long]].length
-    def (arr: IArray[Float]) length: Int = arr.asInstanceOf[Array[Float]].length
-    def (arr: IArray[Double]) length: Int = arr.asInstanceOf[Array[Double]].length
-    def (arr: IArray[Object]) length: Int = arr.asInstanceOf[Array[Object]].length
+    def (arr: IArray[Byte]).length: Int = arr.asInstanceOf[Array[Byte]].length
+    def (arr: IArray[Short]).length: Int = arr.asInstanceOf[Array[Short]].length
+    def (arr: IArray[Char]).length: Int = arr.asInstanceOf[Array[Char]].length
+    def (arr: IArray[Int]).length: Int = arr.asInstanceOf[Array[Int]].length
+    def (arr: IArray[Long]).length: Int = arr.asInstanceOf[Array[Long]].length
+    def (arr: IArray[Float]).length: Int = arr.asInstanceOf[Array[Float]].length
+    def (arr: IArray[Double]).length: Int = arr.asInstanceOf[Array[Double]].length
+    def (arr: IArray[Object]).length: Int = arr.asInstanceOf[Array[Object]].length
     def [T](arr: IArray[T]) length: Int = arr.asInstanceOf[Array[T]].length
 
     /** Returns this array concatenated with the given array. */

--- a/tests/neg-custom-args/extmethods-tparams.scala
+++ b/tests/neg-custom-args/extmethods-tparams.scala
@@ -1,2 +1,2 @@
-def (self: T) foo[T] = ??? // error
+def (self: T).foo[T] = ??? // error
 def [T1](self: T1) bar[T2] = ??? // error // error

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted.autolift.given
 import scala.quoted.matching._
 
 object Macro {
-  inline def (sc: => StringContext) foo (args: String*): Unit = ${ impl('sc) }
+  inline def (sc: => StringContext).foo(args: String*): Unit = ${ impl('sc) }
 
   def impl(sc: Expr[StringContext])(given qctx: QuoteContext): Expr[Unit] = {
     import qctx.tasty.{_, given}

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted.autolift.given
 import scala.quoted.matching._
 
 object Macro {
-  inline def (sc: => StringContext) foo (args: String*): Unit = ${ impl('sc) }
+  inline def (sc: => StringContext).foo(args: String*): Unit = ${ impl('sc) }
 
   def impl(sc: Expr[StringContext])(given qctx: QuoteContext): Expr[Unit] = {
     import qctx.tasty.{_, given}

--- a/tests/neg-macros/reflect-inline/assert_1.scala
+++ b/tests/neg-macros/reflect-inline/assert_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 
 object api {
-  inline def (inline x: String) stripMargin2: String =
+  inline def (inline x: String).stripMargin2: String =
     ${ stripImpl(x) }
 
   private def stripImpl(x: String)(given qctx: QuoteContext): Expr[String] =

--- a/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.language.implicitConversions
 
 object Macro {
 
-  implicit inline def (strCtx: => StringContext) f2 (args: =>Any*): String = ${FIntepolator.apply('strCtx, 'args)}
+  implicit inline def (strCtx: => StringContext).f2(args: =>Any*): String = ${FIntepolator.apply('strCtx, 'args)}
 
 }
 

--- a/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.language.implicitConversions
 
 object Macro {
 
-  implicit inline def (strCtx: => StringContext) f3 (args: =>Any*): String = ${FIntepolator.apply('strCtx, 'args)}
+  implicit inline def (strCtx: => StringContext).f3(args: =>Any*): String = ${FIntepolator.apply('strCtx, 'args)}
 
 }
 

--- a/tests/neg/extension-methods.scala
+++ b/tests/neg/extension-methods.scala
@@ -1,7 +1,7 @@
 object Test {
 
   implicit object O {
-    def (x: String) l1 = x.length
+    def (x: String).l1 = x.length
     def l1(x: Int) = x * x
     def l2(x: String) = x.length
   }
@@ -11,7 +11,7 @@ object Test {
   1.l1 // error
 
   given [T](xs: List[T]) extended with {
-    def (x: Int) f1: T = ???  // error: No extension method allowed here, since collective parameters are given
+    def (x: Int).f1: T = ???  // error: No extension method allowed here, since collective parameters are given
     def f2[T]: T = ???        // error: T is already defined as type T
     def f3(xs: List[T]) = ??? // error: xs is already defined as value xs
   }

--- a/tests/neg/extmethod-override.scala
+++ b/tests/neg/extmethod-override.scala
@@ -1,8 +1,8 @@
 class A {
   def f(x: Int)(y: Int): Int = 0
-  def (x: Int) g (y: Int): Int = 1
+  def (x: Int).g(y: Int): Int = 1
 }
 class B extends A {
-  override def (x: Int) f (y: Int): Int = 1  // error
+  override def (x: Int).f(y: Int): Int = 1  // error
   override def g(x: Int)(y: Int): Int = 0    // error
 }

--- a/tests/neg/i5773.scala
+++ b/tests/neg/i5773.scala
@@ -1,16 +1,16 @@
 trait Semigroup[T] {
-  def (lhs: T) append (rhs: T): T
-  def (lhs: Int) appendS (rhs: T): T = ???
+  def (lhs: T).append(rhs: T): T
+  def (lhs: Int).appendS(rhs: T): T = ???
 }
 
 object Semigroup {
   implicit object stringAppend extends Semigroup[String] {
-    override def (lhs: String) append (rhs: String): String = lhs + rhs
+    override def (lhs: String).append(rhs: String): String = lhs + rhs
   }
 
   implicit def sumSemigroup[N](implicit N: Numeric[N]): Semigroup[N] = new {
-    override def (lhs: N) append (rhs: N): N = N.plus(lhs, rhs)
-    def (lhs: Int) appendS (rhs: N): N = ??? // N.plus(lhs, rhs)
+    override def (lhs: N).append(rhs: N): N = N.plus(lhs, rhs)
+    def (lhs: Int).appendS(rhs: N): N = ??? // N.plus(lhs, rhs)
   }
 }
 

--- a/tests/neg/i6762b.scala
+++ b/tests/neg/i6762b.scala
@@ -9,5 +9,5 @@ type Liftable
 given Liftable = ???
 
 implicit object ExprOps {
-  def (x: T) toExpr[T](given Liftable): Expr[T] = ???
+  def (x: T).toExpr[T](given Liftable): Expr[T] = ???
 }

--- a/tests/neg/i6779.scala
+++ b/tests/neg/i6779.scala
@@ -3,7 +3,7 @@ type G[T]
 type Stuff
 given Stuff = ???
 
-def (x: T) f[T](given Stuff): F[T] = ???
+def (x: T).f[T](given Stuff): F[T] = ???
 
 
 def g1[T](x: T): F[G[T]] = x.f(given summon[Stuff]) // error

--- a/tests/neg/i7438.scala
+++ b/tests/neg/i7438.scala
@@ -1,7 +1,7 @@
 type Tr[+A]
-inline def (tr: Tr[A]) map[A, B](f: A => B): Tr[B] = ???
+inline def (tr: Tr[A]).map[A, B](f: A => B): Tr[B] = ???
 
-def (d: Double) func: None.type => Some[Double] = ???
+def (d: Double).func: None.type => Some[Double] = ???
 
 def run[A](query: None.type => Some[A]): Some[A] = ???
 

--- a/tests/neg/indent.scala
+++ b/tests/neg/indent.scala
@@ -1,6 +1,6 @@
 object Test {
 
-  def (x: Int) gt (y: Int) = x > y
+  def (x: Int).gt(y: Int) = x > y
   val y3 =
     if (1) max 10 gt 0  // error: end of statement expected but integer literal found // error // error // error
       1

--- a/tests/neg/opaque-bounds.scala
+++ b/tests/neg/opaque-bounds.scala
@@ -21,8 +21,8 @@ object Access {
 
   def (x: Permissions) & (y: Permissions): Permissions = x & y
   def (x: PermissionChoice) | (y: PermissionChoice): PermissionChoice = x | y
-  def (x: Permissions) is (y: Permissions) = (x & y) == y
-  def (x: Permissions) isOneOf (y: PermissionChoice) = (x & y) != 0
+  def (x: Permissions).is(y: Permissions) = (x & y) == y
+  def (x: Permissions).isOneOf(y: PermissionChoice) = (x & y) != 0
 
   val NoPermission: Permission = 0
   val ReadOnly: Permission = 1

--- a/tests/pos/combine.scala
+++ b/tests/pos/combine.scala
@@ -1,5 +1,5 @@
 trait Semigroup[A] {
-  def (x: A) combine (y: A): A
+  def (x: A).combine(y: A): A
 }
 given Semigroup[Int] = ???
 given [A, B]: Semigroup[A], Semigroup[B] => Semigroup[(A, B)]  = ???

--- a/tests/pos/consume.scala
+++ b/tests/pos/consume.scala
@@ -24,7 +24,7 @@ object math3 with
   trait Numeric[T] extends Ord[T] with
     def (x: T) + (y: T): T = ???
     def (x: T) - (y: T): T = ???
-    def (x: Int) numeric: T = ???
+    def (x: Int).numeric: T = ???
 end math3
 
 object Test3 with

--- a/tests/pos/i5773.scala
+++ b/tests/pos/i5773.scala
@@ -1,18 +1,18 @@
 trait Semigroup[T] {
-  def (lhs: T) append (rhs: T): T
+  def (lhs: T).append(rhs: T): T
 }
 
 object Semigroup {
   implicit object stringAppend extends Semigroup[String] {
-    override def (lhs: String) append (rhs: String): String = lhs + rhs
+    override def (lhs: String).append(rhs: String): String = lhs + rhs
   }
 
   implicit def sumSemigroup[N](implicit N: Numeric[N]): Semigroup[N] = new {
-    override def (lhs: N) append (rhs: N): N = ??? // N.plus(lhs, rhs)
+    override def (lhs: N).append(rhs: N): N = ??? // N.plus(lhs, rhs)
   }
 
   implicit class SumSemiGroupDeco[N](implicit N: Numeric[N]) extends Semigroup[N] {
-    override def (lhs: N) append (rhs: N): N = ??? // N.plus(lhs, rhs)
+    override def (lhs: N).append(rhs: N): N = ??? // N.plus(lhs, rhs)
   }
 }
 
@@ -26,7 +26,7 @@ object Main {
 
   def f2 = {
     implicit val intSumAppend: Semigroup[Int] = sumSemigroup[Int]
-    println(3 append 4) 
+    println(3 append 4)
   }
 
   def f3 = {

--- a/tests/pos/i5773a.scala
+++ b/tests/pos/i5773a.scala
@@ -1,12 +1,12 @@
 trait Semigroup[T] {
-  def (x: T) combine (y: T): T
+  def (x: T).combine(y: T): T
 }
 object Test {
   implicit val IntSemigroup: Semigroup[Int] = new {
-    def (x: Int) combine (y: Int): Int = x + y
+    def (x: Int).combine(y: Int): Int = x + y
   }
   implicit def OptionSemigroup[T: Semigroup]: Semigroup[Option[T]] = new {
-    def (x: Option[T]) combine (y: Option[T]): Option[T] = for {
+    def (x: Option[T]).combine(y: Option[T]): Option[T] = for {
       x0 <- x
       y0 <- y
     } yield x0.combine(y0)

--- a/tests/pos/i6395.scala
+++ b/tests/pos/i6395.scala
@@ -1,5 +1,5 @@
 object Foo {
-  inline def (self: Int) foo (that: Int): Int = 5
-  def (self: Int) bar: Int = self
+  inline def (self: Int).foo(that: Int): Int = 5
+  def (self: Int).bar: Int = self
   1.foo(2).bar
 }

--- a/tests/pos/i7070.scala
+++ b/tests/pos/i7070.scala
@@ -2,7 +2,7 @@ object Test {
 
   class C
 
-  def (str: String) foo: (given C) => Int = ???
+  def (str: String).foo: (given C) => Int = ???
 
   given C = ???
 

--- a/tests/pos/i7119.scala
+++ b/tests/pos/i7119.scala
@@ -1,6 +1,6 @@
 class Impl
 
-def (impl: Impl) prop(given Int) = ???//summon[Int]
+def (impl: Impl).prop(given Int) = ???//summon[Int]
 
 
 def main(args: Array[String]): Unit = {

--- a/tests/pos/i7413.scala
+++ b/tests/pos/i7413.scala
@@ -3,7 +3,7 @@ import scala.language.implicitConversions
 trait Fixture[A] extends Conversion[0, A]
 
 trait TestFramework[A] {
-  def (testName: String) in (test: (given Fixture[A]) => Unit): Unit = ???
+  def (testName: String).in(test: (given Fixture[A]) => Unit): Unit = ???
 }
 
 trait Greeter {

--- a/tests/pos/i7700.scala
+++ b/tests/pos/i7700.scala
@@ -4,7 +4,7 @@ trait Show[-A] with
   def show(a: A): String
 
 object Macros with
-  inline def (sc: StringContext) show(args: =>Any*): String = ???
+  inline def (sc: StringContext).show(args: =>Any*): String = ???
 
 object Show with
   def[A] (a: A) show(given S: Show[A]): String = S.show(a)

--- a/tests/pos/indent.scala
+++ b/tests/pos/indent.scala
@@ -28,7 +28,7 @@ object Test
         1
       else
         2
-    def (x: Int) gt (y: Int) = x > y
+    def (x: Int).gt(y: Int) = x > y
     val y3 =
       if (1) max 10 gt 0
 

--- a/tests/pos/opaque-propability-xm.scala
+++ b/tests/pos/opaque-propability-xm.scala
@@ -19,17 +19,17 @@ object prob {
     implicit val ordering: Ordering[Probability] =
       implicitly[Ordering[Double]]
 
-    def (p1: Probability) unary_~ : Probability = Certain - p1
+    def (p1: Probability).unary_~ : Probability = Certain - p1
     def (p1: Probability) & (p2: Probability): Probability = p1 * p2
     def (p1: Probability) | (p2: Probability): Probability = p1 + p2 - (p1 * p2)
 
-    def (p1: Probability) isImpossible: Boolean = p1 == Never
-    def (p1: Probability) isCertain: Boolean = p1 == Certain
+    def (p1: Probability).isImpossible: Boolean = p1 == Never
+    def (p1: Probability).isCertain: Boolean = p1 == Certain
 
     import scala.util.Random
 
-    def (p1: Probability) sample (r: Random = Random): Boolean = r.nextDouble <= p1
-    def (p1: Probability) toDouble: Double = p1
+    def (p1: Probability).sample(r: Random = Random): Boolean = r.nextDouble <= p1
+    def (p1: Probability).toDouble: Double = p1
   }
 
   val caughtTrain = Probability.unsafe(0.3)

--- a/tests/pos/opaque-xm.scala
+++ b/tests/pos/opaque-xm.scala
@@ -16,7 +16,7 @@ object opaquetypes {
     // Extension methods define opaque types' public APIs
 
     // This is the second way to unlift the logarithm type
-    def (x: Logarithm) toDouble: Double = math.exp(x)
+    def (x: Logarithm).toDouble: Double = math.exp(x)
     def (x: Logarithm) + (y: Logarithm) = Logarithm(math.exp(x) + math.exp(y))
     def (x: Logarithm) * (y: Logarithm): Logarithm = Logarithm(x + y)
   }

--- a/tests/pos/reference/delegates.scala
+++ b/tests/pos/reference/delegates.scala
@@ -1,15 +1,15 @@
 class Common with
 
   trait Ord[T] with
-    def (x: T) compareTo (y: T): Int
+    def (x: T).compareTo(y: T): Int
     def (x: T) < (y: T) = x.compareTo(y) < 0
     def (x: T) > (y: T) = x.compareTo(y) > 0
 
   trait Convertible[From, To] with
-    def (x: From) convert: To
+    def (x: From).convert: To
 
   trait SemiGroup[T] with
-    def (x: T) combine (y: T): T
+    def (x: T).combine(y: T): T
 
   trait Monoid[T] extends SemiGroup[T] with
     def unit: T
@@ -26,11 +26,11 @@ class Common with
 object Instances extends Common with
 
   given intOrd: Ord[Int] with
-    def (x: Int) compareTo (y: Int) =
+    def (x: Int).compareTo(y: Int) =
       if (x < y) -1 else if (x > y) +1 else 0
 
   given listOrd[T]: Ord[T] => Ord[List[T]] with
-    def (xs: List[T]) compareTo (ys: List[T]): Int = (xs, ys) match
+    def (xs: List[T]).compareTo(ys: List[T]): Int = (xs, ys).match
       case (Nil, Nil) => 0
       case (Nil, _) => -1
       case (_, Nil) => +1
@@ -64,7 +64,7 @@ object Instances extends Common with
     xs.reduceLeft((x, y) => if (x < y) y else x)
 
   def descending[T](given asc: Ord[T]): Ord[T] = new Ord[T] with
-    def (x: T) compareTo (y: T) = asc.compareTo(y)(x)
+    def (x: T).compareTo(y: T) = asc.compareTo(y)(x)
 
   def minimum[T](xs: List[T])(given Ord[T]) =
     maximum(xs)(given descending)
@@ -87,14 +87,14 @@ object Instances extends Common with
   trait TastyAPI with
     type Symbol
     trait SymDeco with
-      def (sym: Symbol) name: String
+      def (sym: Symbol).name: String
     def symDeco: SymDeco
     given SymDeco = symDeco
 
   object TastyImpl extends TastyAPI with
     type Symbol = String
     val symDeco = new SymDeco with
-      def (sym: Symbol) name = sym
+      def (sym: Symbol).name = sym
 
   class D[T]
 
@@ -141,11 +141,11 @@ end PostConditions
 
 object AnonymousInstances extends Common with
   given Ord[Int] with
-    def (x: Int) compareTo (y: Int) =
+    def (x: Int).compareTo(y: Int) =
       if (x < y) -1 else if (x > y) +1 else 0
 
   given [T: Ord] : Ord[List[T]] with
-    def (xs: List[T]) compareTo (ys: List[T]): Int = (xs, ys) match
+    def (xs: List[T]).compareTo(ys: List[T]): Int = (xs, ys).match
       case (Nil, Nil) => 0
       case (Nil, _) => -1
       case (_, Nil) => +1
@@ -162,10 +162,10 @@ object AnonymousInstances extends Common with
     def second = xs.tail.head
 
   given [From, To]: (c: Convertible[From, To]) => Convertible[List[From], List[To]] with
-    def (x: List[From]) convert: List[To] = x.map(c.convert)
+    def (x: List[From]).convert: List[To] = x.map(c.convert)
 
   given Monoid[String] with
-    def (x: String) combine (y: String): String = x.concat(y)
+    def (x: String).combine(y: String): String = x.concat(y)
     def unit: String = ""
 
   def sum[T: Monoid](xs: List[T]): T =
@@ -174,11 +174,11 @@ end AnonymousInstances
 
 object Implicits extends Common with
   implicit object IntOrd extends Ord[Int] with
-    def (x: Int) compareTo (y: Int) =
+    def (x: Int).compareTo(y: Int) =
       if (x < y) -1 else if (x > y) +1 else 0
 
   class ListOrd[T: Ord] extends Ord[List[T]] with
-    def (xs: List[T]) compareTo (ys: List[T]): Int = (xs, ys) match
+    def (xs: List[T]).compareTo(ys: List[T]): Int = (xs, ys).match
       case (Nil, Nil) => 0
       case (Nil, _) => -1
       case (_, Nil) => +1
@@ -189,7 +189,7 @@ object Implicits extends Common with
 
   class given_Convertible_List_List[From, To](implicit c: Convertible[From, To])
   extends Convertible[List[From], List[To]] with
-    def (x: List[From]) convert: List[To] = x.map(c.convert)
+    def (x: List[From]).convert: List[To] = x.map(c.convert)
   implicit def given_Convertible_List_List[From, To](implicit c: Convertible[From, To])
     : Convertible[List[From], List[To]] =
     new given_Convertible_List_List[From, To]
@@ -199,7 +199,7 @@ object Implicits extends Common with
     xs.reduceLeft((x, y) => if (x < y) y else x)
 
   def descending[T](implicit asc: Ord[T]): Ord[T] = new Ord[T] with
-    def (x: T) compareTo (y: T) = asc.compareTo(y)(x)
+    def (x: T).compareTo(y: T) = asc.compareTo(y)(x)
 
   def minimum[T](xs: List[T])(implicit cmp: Ord[T]) =
     maximum(xs)(descending)

--- a/tests/pos/reference/extension-methods.scala
+++ b/tests/pos/reference/extension-methods.scala
@@ -2,14 +2,14 @@ object ExtMethods with
 
   case class Circle(x: Double, y: Double, radius: Double)
 
-  def (c: Circle) circumference: Double = c.radius * math.Pi * 2
+  def (c: Circle).circumference: Double = c.radius * math.Pi * 2
 
   val circle = Circle(0, 0, 1)
   circle.circumference
   assert(circle.circumference == circumference(circle))
 
   trait StringSeqOps {
-    def (xs: Seq[String]) longestStrings = {
+    def (xs: Seq[String]).longestStrings = {
       val maxLength = xs.map(_.length).max
       xs.filter(_.length == maxLength)
     }
@@ -57,7 +57,7 @@ object ExtMethods with
     def largest(n: Int) = xs.sorted.takeRight(n)
 
   given stringOps1: AnyRef {
-    def (xs: Seq[String]) longestStrings: Seq[String] = {
+    def (xs: Seq[String]).longestStrings: Seq[String] = {
       val maxLength = xs.map(_.length).max
       xs.filter(_.length == maxLength)
     }

--- a/tests/pos/reference/opaque.scala
+++ b/tests/pos/reference/opaque.scala
@@ -38,8 +38,8 @@ object Access {
 
   def (x: Permissions) & (y: Permissions): Permissions = x & y
   def (x: PermissionChoice) | (y: PermissionChoice): PermissionChoice = x | y
-  def (x: Permissions) is (y: Permissions) = (x & y) == y
-  def (x: Permissions) isOneOf (y: PermissionChoice) = (x & y) != 0
+  def (x: Permissions).is(y: Permissions) = (x & y) == y
+  def (x: Permissions).isOneOf(y: PermissionChoice) = (x & y) != 0
 
   val NoPermission: Permission = 0
   val ReadOnly: Permission = 1

--- a/tests/pos/toplevel-opaque-xm/Logarithm_1.scala
+++ b/tests/pos/toplevel-opaque-xm/Logarithm_1.scala
@@ -16,7 +16,7 @@ implicit object Logarithm {
   // Extension methods define opaque types' public APIs
 
   // This is the second way to unlift the logarithm type
-  def (x: Logarithm) toDouble: Double = math.exp(x)
+  def (x: Logarithm).toDouble: Double = math.exp(x)
   def (x: Logarithm) + (y: Logarithm) = Logarithm(math.exp(x) + math.exp(y))
   def (x: Logarithm) * (y: Logarithm): Logarithm = Logarithm(x + y)
 }

--- a/tests/run-macros/f-interpolator-neg/Macros_1.scala
+++ b/tests/run-macros/f-interpolator-neg/Macros_1.scala
@@ -6,7 +6,7 @@ import scala.language.implicitConversions
 
 object TestFooErrors { // Defined in tests
   implicit object StringContextOps {
-    inline def (ctx: => StringContext) foo (args: => Any*): List[(Boolean, Int, Int, Int, String)] = ${ Macro.fooErrors('ctx, 'args) }
+    inline def (ctx: => StringContext).foo(args: => Any*): List[(Boolean, Int, Int, Int, String)] = ${ Macro.fooErrors('ctx, 'args) }
   }
 }
 

--- a/tests/run/Pouring.scala
+++ b/tests/run/Pouring.scala
@@ -8,7 +8,7 @@ class Pouring(capacity: Vector[Int]) with
       case Fill(g) => content.updated(g, capacity(g))
       case Pour(from, to) =>
         val amount = content(from) min (capacity(to) - content(to))
-        def (s: Content) adjust (g: Glass, delta: Int) = s.updated(g, s(g) + delta)
+        def (s: Content).adjust(g: Glass, delta: Int) = s.updated(g, s(g) + delta)
         content.adjust(from, -amount).adjust(to, amount)
 
     case Empty(glass: Glass)

--- a/tests/run/eq-xmethod.scala
+++ b/tests/run/eq-xmethod.scala
@@ -6,7 +6,7 @@ object Test extends App {
   class N
   object N extends N
 
-  def (x: N) _eq (y: R | N) = y eq N
+  def (x: N)._eq(y: R | N) = y eq N
 
   val r1, r2 = new R
   assert(r1 _eq r1)

--- a/tests/run/exports.scala
+++ b/tests/run/exports.scala
@@ -12,7 +12,7 @@ object Test extends App {
 
   class Scanner {
     def scan() = println("scanning")
-    def (x: Any) scanned = scan()
+    def (x: Any).scanned = scan()
   }
   object Scanner extends Scanner
 

--- a/tests/run/extension-methods.scala
+++ b/tests/run/extension-methods.scala
@@ -1,18 +1,18 @@
 object Test extends App {
 
-  def (x: Int) em: Boolean = x > 0
+  def (x: Int).em: Boolean = x > 0
 
   assert(1.em == em(1))
 
   case class Circle(x: Double, y: Double, radius: Double)
 
-  def (c: Circle) circumference: Double = c.radius * math.Pi * 2
+  def (c: Circle).circumference: Double = c.radius * math.Pi * 2
 
   val circle = new Circle(1, 1, 2.0)
 
   assert(circle.circumference == circumference(circle))
 
-  def (xs: Seq[String]) longestStrings: Seq[String] = {
+  def (xs: Seq[String]).longestStrings: Seq[String] = {
     val maxLength = xs.map(_.length).max
     xs.filter(_.length == maxLength)
   }
@@ -29,7 +29,7 @@ object Test extends App {
   assert(Nil.flattened == Nil)
 
   trait SemiGroup[T] {
-    def (x: T) combine (y: T): T
+    def (x: T).combine(y: T): T
   }
   trait Monoid[T] extends SemiGroup[T] {
     def unit: T
@@ -37,7 +37,7 @@ object Test extends App {
 
   // An instance declaration:
   implicit object StringMonoid extends Monoid[String] {
-    def (x: String) combine (y: String): String = x.concat(y)
+    def (x: String).combine(y: String): String = x.concat(y)
     def unit: String = ""
   }
 
@@ -48,14 +48,14 @@ object Test extends App {
   println(sum(names))
 
   trait Ord[T] {
-    def (x: T) compareTo (y: T): Int
+    def (x: T).compareTo(y: T): Int
     def (x: T) < (y: T) = x.compareTo(y) < 0
     def (x: T) > (y: T) = x.compareTo(y) > 0
     val minimum: T
   }
 
   implicit object IntOrd extends Ord[Int] {
-    def (x: Int) compareTo (y: Int) =
+    def (x: Int).compareTo(y: Int) =
       if (x < y) -1 else if (x > y) +1 else 0
     val minimum = Int.MinValue
   }

--- a/tests/run/extmethod-overload.scala
+++ b/tests/run/extmethod-overload.scala
@@ -88,13 +88,13 @@ object Test extends App {
   class C {
     def xx (x: Any) = 2
   }
-  def (c: C) xx (x: Int) = 1
+  def (c: C).xx(x: Int) = 1
 
   val c = new C
   assert(c.xx(1) == 2)  // member method takes precedence
 
   object D {
-    def (x: Int) yy (y: Int) = x + y
+    def (x: Int).yy(y: Int) = x + y
   }
 
   given (x: Int) extended with {
@@ -114,8 +114,8 @@ object Test extends App {
     def b: Long = a
   }
 
-  def (rectangle: Rectangle) area: Long = 0
-  def (square: Square) area: Long = square.a * square.a
+  def (rectangle: Rectangle).area: Long = 0
+  def (square: Square).area: Long = square.a * square.a
   val rectangles = List(GenericRectangle(2, 3), Square(5))
   val areas = rectangles.map(_.area)
   assert(areas.sum == 0)

--- a/tests/run/extmethods2.scala
+++ b/tests/run/extmethods2.scala
@@ -4,8 +4,8 @@ object Test extends App {
 
   given stringListOps: TC => Object {
     type T = List[String]
-    def (x: T) foo (y: T) = (x ++ y, summon[TC])
-    def (x: T) bar (y: Int) = (x(0)(y), summon[TC])
+    def (x: T).foo(y: T) = (x ++ y, summon[TC])
+    def (x: T).bar(y: Int) = (x(0)(y), summon[TC])
   }
 
   def test(given TC) = {

--- a/tests/run/instances-anonymous.scala
+++ b/tests/run/instances-anonymous.scala
@@ -1,7 +1,7 @@
 object Test extends App {
 
   implicit object O {
-    def (x: Int) em: Boolean = x > 0
+    def (x: Int).em: Boolean = x > 0
   }
 
   assert(1.em == O.em(1))
@@ -17,7 +17,7 @@ object Test extends App {
   println(circle.circumference)
 
   given AnyRef {
-    def (xs: Seq[String]) longestStrings: Seq[String] = {
+    def (xs: Seq[String]).longestStrings: Seq[String] = {
       val maxLength = xs.map(_.length).max
       xs.filter(_.length == maxLength)
     }
@@ -39,14 +39,14 @@ object Test extends App {
   assert(Nil.flattened == Nil)
 
   trait SemiGroup[T] {
-    def (x: T) combine (y: T): T
+    def (x: T).combine(y: T): T
   }
   trait Monoid[T] extends SemiGroup[T] {
     def unit: T
   }
 
   given Monoid[String] {
-    def (x: String) combine (y: String): String = x.concat(y)
+    def (x: String).combine(y: String): String = x.concat(y)
     def unit: String = ""
   }
 
@@ -57,20 +57,20 @@ object Test extends App {
   println(sum(names))
 
   trait Ord[T] {
-    def (x: T) compareTo (y: T): Int
+    def (x: T).compareTo(y: T): Int
     def (x: T) < (y: T) = x.compareTo(y) < 0
     def (x: T) > (y: T) = x.compareTo(y) > 0
     val minimum: T
   }
 
   given Ord[Int] {
-    def (x: Int) compareTo (y: Int) =
+    def (x: Int).compareTo(y: Int) =
       if (x < y) -1 else if (x > y) +1 else 0
     val minimum = Int.MinValue
   }
 
   given [T: Ord] : Ord[List[T]] {
-    def (xs: List[T]) compareTo (ys: List[T]): Int = (xs, ys) match {
+    def (xs: List[T]).compareTo(ys: List[T]): Int = (xs, ys).match {
       case (Nil, Nil) => 0
       case (Nil, _) => -1
       case (_, Nil) => +1

--- a/tests/run/instances.scala
+++ b/tests/run/instances.scala
@@ -1,7 +1,7 @@
 object Test extends App {
 
   implicit object O {
-    def (x: Int) em: Boolean = x > 0
+    def (x: Int).em: Boolean = x > 0
   }
 
   assert(1.em == O.em(1))
@@ -44,13 +44,13 @@ object Test extends App {
   assert(Nil.flattened == Nil)
 
   trait SemiGroup[T] with
-    def (x: T) combine (y: T): T
+    def (x: T).combine(y: T): T
 
   trait Monoid[T] extends SemiGroup[T] with
     def unit: T
 
   given StringMonoid : Monoid[String] with
-    def (x: String) combine (y: String): String = x.concat(y)
+    def (x: String).combine(y: String): String = x.concat(y)
     def unit: String = ""
 
   // Abstracting over a typeclass with a context bound:
@@ -60,19 +60,19 @@ object Test extends App {
   println(sum(names))
 
   trait Ord[T] with
-    def (x: T) compareTo (y: T): Int
+    def (x: T).compareTo(y: T): Int
     def (x: T) < (y: T) = x.compareTo(y) < 0
     def (x: T) > (y: T) = x.compareTo(y) > 0
     val minimum: T
   end Ord
 
   given Ord[Int] with
-    def (x: Int) compareTo (y: Int) =
+    def (x: Int).compareTo(y: Int) =
       if (x < y) -1 else if (x > y) +1 else 0
     val minimum = Int.MinValue
 
   given listOrd[T: Ord]: Ord[List[T]] with
-    def (xs: List[T]) compareTo (ys: List[T]): Int = (xs, ys) match
+    def (xs: List[T]).compareTo(ys: List[T]): Int = (xs, ys).match
       case (Nil, Nil) => 0
       case (Nil, _) => -1
       case (_, Nil) => +1

--- a/tests/run/string-context-implicits-with-conversion.scala
+++ b/tests/run/string-context-implicits-with-conversion.scala
@@ -1,6 +1,6 @@
 
 object Lib {
-  def (sc: StringContext) showMe(args: Showed*): String = sc.s(args: _*)
+  def (sc: StringContext).showMe(args: Showed*): String = sc.s(args: _*)
 
   opaque type Showed = String
 

--- a/tests/run/toplevel-implicits/a.b.scala
+++ b/tests/run/toplevel-implicits/a.b.scala
@@ -3,7 +3,7 @@ package implicits
 case class C()
 
 implicit object Cops {
-  def (x: C) pair (y: C) = (x, y)
+  def (x: C).pair(y: C) = (x, y)
 }
 
 class D {

--- a/tests/semanticdb/expect/Enums.expect.scala
+++ b/tests/semanticdb/expect/Enums.expect.scala
@@ -12,10 +12,10 @@ object Enums/*<-_empty_::Enums.*/ with
     case Hearts/*<-_empty_::Enums.Suits.Hearts.*/, Spades/*<-_empty_::Enums.Suits.Spades.*/, Clubs/*<-_empty_::Enums.Suits.Clubs.*/, Diamonds/*<-_empty_::Enums.Suits.Diamonds.*/
 
   object Suits/*<-_empty_::Enums.Suits.*/ with
-    def (suit/*<-_empty_::Enums.Suits.isRed().*//*<-_empty_::Enums.Suits.isRed().(suit)*/: Suits/*->_empty_::Enums.Suits#*/) isRed: Boolean/*->scala::Boolean#*/ =
+    def (suit/*<-_empty_::Enums.Suits.isRed().*//*<-_empty_::Enums.Suits.isRed().(suit)*/: Suits/*->_empty_::Enums.Suits#*/).isRed: Boolean/*->scala::Boolean#*/ =
       suit/*->_empty_::Enums.Suits.isRed().(suit)*/ ==/*->scala::Any#`==`().*/ Hearts/*->_empty_::Enums.Suits.Hearts.*/ ||/*->scala::Boolean#`||`().*/ suit/*->_empty_::Enums.Suits.isRed().(suit)*/ ==/*->scala::Any#`==`().*/ Diamonds/*->_empty_::Enums.Suits.Diamonds.*/
 
-    def (suit: /*<-_empty_::Enums.Suits.isBlack().*//*<-_empty_::Enums.Suits.isBlack().(suit)*/Suits/*->_empty_::Enums.Suits#*/) isBlack: Boolean/*->scala::Boolean#*/ = suit/*->_empty_::Enums.Suits.isBlack().(suit)*/ match
+    def (suit: /*<-_empty_::Enums.Suits.isBlack().*//*<-_empty_::Enums.Suits.isBlack().(suit)*/Suits/*->_empty_::Enums.Suits#*/).isBlack: Boolean/*->scala::Boolean#*/ = suit/*->_empty_::Enums.Suits.isBlack().(suit)*/ match
       case Spades/*->_empty_::Enums.Suits.Spades.*/ | Diamonds/*->_empty_::Enums.Suits.Diamonds.*/ => true
       case _                 => false
 

--- a/tests/semanticdb/expect/Enums.scala
+++ b/tests/semanticdb/expect/Enums.scala
@@ -12,10 +12,10 @@ object Enums with
     case Hearts, Spades, Clubs, Diamonds
 
   object Suits with
-    def (suit: Suits) isRed: Boolean =
+    def (suit: Suits).isRed: Boolean =
       suit == Hearts || suit == Diamonds
 
-    def (suit: Suits) isBlack: Boolean = suit match
+    def (suit: Suits).isBlack: Boolean = suit match
       case Spades | Diamonds => true
       case _                 => false
 

--- a/tests/semanticdb/expect/Givens.expect.scala
+++ b/tests/semanticdb/expect/Givens.expect.scala
@@ -16,11 +16,11 @@ object Givens/*<-a::b::Givens.*/
 
   trait Monoid/*<-a::b::Givens.Monoid#*/[A/*<-a::b::Givens.Monoid#[A]*/]
     def empty/*<-a::b::Givens.Monoid#empty().*/: A/*->a::b::Givens.Monoid#[A]*/
-    def (x: A) /*<-a::b::Givens.Monoid#combine().*//*<-a::b::Givens.Monoid#combine().(x)*//*->a::b::Givens.Monoid#[A]*/combine (y/*<-a::b::Givens.Monoid#combine().(y)*/: A/*->a::b::Givens.Monoid#[A]*/): A/*->a::b::Givens.Monoid#[A]*/
+    def (x: A)./*<-a::b::Givens.Monoid#combine().*//*<-a::b::Givens.Monoid#combine().(x)*//*->a::b::Givens.Monoid#[A]*/combine(y/*<-a::b::Givens.Monoid#combine().(y)*/: A/*->a::b::Givens.Monoid#[A]*/): A/*->a::b::Givens.Monoid#[A]*/
 
   given Monoid[String]
     /*<-a::b::Givens.given_Monoid_String.*//*->a::b::Givens.Monoid#*//*->scala::Predef.String#*/def empty/*<-a::b::Givens.given_Monoid_String.empty().*/ = ""
-    def (x: Str/*<-a::b::Givens.given_Monoid_String.combine().*//*<-a::b::Givens.given_Monoid_String.combine().(x)*/ing/*->scala::Predef.String#*/) combine (y/*<-a::b::Givens.given_Monoid_String.combine().(y)*/: String/*->scala::Predef.String#*/) = x/*->a::b::Givens.given_Monoid_String.combine().(x)*/ +/*->java::lang::String#`+`().*/ y/*->a::b::Givens.given_Monoid_String.combine().(y)*/
+    def (x: Str/*<-a::b::Givens.given_Monoid_String.combine().*//*<-a::b::Givens.given_Monoid_String.combine().(x)*/ing/*->scala::Predef.String#*/).combine(y/*<-a::b::Givens.given_Monoid_String.combine().(y)*/: String/*->scala::Predef.String#*/) = x/*->a::b::Givens.given_Monoid_String.combine().(x)*/ +/*->java::lang::String#`+`().*/ y/*->a::b::Givens.given_Monoid_String.combine().(y)*/
 
   inline given int2String/*<-a::b::Givens.int2String().*/: Conversion/*->scala::Conversion#*/[Int/*->scala::Int#*/, String/*->scala::Predef.String#*/] = _.toString/*->scala::Any#toString().*/
 

--- a/tests/semanticdb/expect/Givens.scala
+++ b/tests/semanticdb/expect/Givens.scala
@@ -16,11 +16,11 @@ object Givens
 
   trait Monoid[A]
     def empty: A
-    def (x: A) combine (y: A): A
+    def (x: A).combine(y: A): A
 
   given Monoid[String]
     def empty = ""
-    def (x: String) combine (y: String) = x + y
+    def (x: String).combine(y: String) = x + y
 
   inline given int2String: Conversion[Int, String] = _.toString
 

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -1342,12 +1342,12 @@ Occurrences:
 [16:15..16:16): A <- a/b/Givens.Monoid#[A]
 [17:8..17:13): empty <- a/b/Givens.Monoid#empty().
 [17:15..17:16): A -> a/b/Givens.Monoid#[A]
-[18:8..18:15): (x: A)  <- a/b/Givens.Monoid#combine().
+[18:8..18:15): (x: A). <- a/b/Givens.Monoid#combine().
 [18:9..18:10): x <- a/b/Givens.Monoid#combine().(x)
 [18:12..18:13): A -> a/b/Givens.Monoid#[A]
-[18:24..18:25): y <- a/b/Givens.Monoid#combine().(y)
-[18:27..18:28): A -> a/b/Givens.Monoid#[A]
-[18:31..18:32): A -> a/b/Givens.Monoid#[A]
+[18:23..18:24): y <- a/b/Givens.Monoid#combine().(y)
+[18:26..18:27): A -> a/b/Givens.Monoid#[A]
+[18:30..18:31): A -> a/b/Givens.Monoid#[A]
 [20:8..21:4): <- a/b/Givens.given_Monoid_String.
 [20:8..20:14): Monoid -> a/b/Givens.Monoid#
 [20:15..20:21): String -> scala/Predef.String#
@@ -1355,11 +1355,11 @@ Occurrences:
 [22:8..22:15): (x: Str <- a/b/Givens.given_Monoid_String.combine().
 [22:9..22:10): x <- a/b/Givens.given_Monoid_String.combine().(x)
 [22:12..22:18): String -> scala/Predef.String#
-[22:29..22:30): y <- a/b/Givens.given_Monoid_String.combine().(y)
-[22:32..22:38): String -> scala/Predef.String#
-[22:42..22:43): x -> a/b/Givens.given_Monoid_String.combine().(x)
-[22:44..22:45): + -> java/lang/String#`+`().
-[22:46..22:47): y -> a/b/Givens.given_Monoid_String.combine().(y)
+[22:28..22:29): y <- a/b/Givens.given_Monoid_String.combine().(y)
+[22:31..22:37): String -> scala/Predef.String#
+[22:41..22:42): x -> a/b/Givens.given_Monoid_String.combine().(x)
+[22:43..22:44): + -> java/lang/String#`+`().
+[22:45..22:46): y -> a/b/Givens.given_Monoid_String.combine().(y)
 [24:15..24:25): int2String <- a/b/Givens.int2String().
 [24:27..24:37): Conversion -> scala/Conversion#
 [24:38..24:41): Int -> scala/Int#
@@ -3565,3 +3565,4 @@ Occurrences:
 [2:46..2:47): z -> _empty_/toplevel$package.combine(+1).(z)
 [3:4..3:11): combine <- _empty_/toplevel$package.combine(+2).
 [4:4..4:7): foo <- _empty_/toplevel$package.foo().
+


### PR DESCRIPTION
Allow

    def (c: Circle).circumference: Double

alongside

    def (c: Circle) circumference: Double

The syntax with '.' is preferred for normal methods which have names
starting with a letter and which are not declared @infix. Right now,
this preference is not enforced.