### PR TITLE
Fix #7919: Make sure that quoted.Type does not have unexpected subclasses

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/core/quoted/PickledQuotes.scala
@@ -19,7 +19,6 @@ import dotty.tools.dotc.tastyreflect.{ReflectionImpl, TastyTreeExpr, TreeType}
 
 import dotty.tools.tasty.TastyString
 
-import scala.internal.quoted._
 import scala.reflect.ClassTag
 
 import scala.runtime.quoted.Unpickler._

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TastyTreeExpr.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TastyTreeExpr.scala
@@ -9,7 +9,7 @@ import dotty.tools.dotc.ast.tpd.Tree
  *
  *  May contain references to code defined outside this TastyTreeExpr instance.
  */
-final class TastyTreeExpr(val tree: Tree, val scopeId: Int) extends scala.quoted.Expr[Any] {
+final class TastyTreeExpr(val tree: Tree, val scopeId: Int) extends scala.internal.quoted.Expr[Any] {
   override def equals(that: Any): Boolean = that match {
     case that: TastyTreeExpr =>
       // TastyTreeExpr are wrappers around trees, therfore they are equals if their trees are equal.

--- a/compiler/src/dotty/tools/dotc/tastyreflect/TreeType.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/TreeType.scala
@@ -3,7 +3,7 @@ package dotty.tools.dotc.tastyreflect
 import dotty.tools.dotc.ast.tpd.Tree
 
 /** An Type backed by a tree */
-final class TreeType(val typeTree: Tree, val scopeId: Int) extends scala.quoted.Type[Any] {
+final class TreeType(val typeTree: Tree, val scopeId: Int) extends scala.internal.quoted.Type[Any] {
   override def equals(that: Any): Boolean = that match {
     case that: TreeType => typeTree ==
       // TastyTreeExpr are wrappers around trees, therfore they are equals if their trees are equal.

--- a/library/src/scala/internal/quoted/Expr.scala
+++ b/library/src/scala/internal/quoted/Expr.scala
@@ -2,6 +2,13 @@ package scala.internal.quoted
 
 import scala.quoted._
 
+/** Quoted expression of type `T`
+ *
+ *  Restriction: only the QuoteContext.tasty.internal implementation is allowed to extend this trait.
+ *  Any other implementation will result in an undefined behavior.
+ */
+class Expr[+T] extends scala.quoted.Expr[T]
+
 object Expr {
 
   /** Pattern matches an the scrutineeExpr against the patternExpr and returns a tuple
@@ -25,7 +32,7 @@ object Expr {
    *  @param qctx the current QuoteContext
    *  @return None if it did not match, `Some(tup)` if it matched where `tup` contains `Expr[Ti]``
    */
-  def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeExpr: Expr[_])(implicit patternExpr: Expr[_],
+  def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeExpr: scala.quoted.Expr[_])(implicit patternExpr: scala.quoted.Expr[_],
         hasTypeSplices: Boolean, qctx: QuoteContext): Option[Tup] = {
     import qctx.tasty.{_, given}
     new Matcher.QuoteMatcher[qctx.type].termMatch(scrutineeExpr.unseal, patternExpr.unseal, hasTypeSplices).asInstanceOf[Option[Tup]]

--- a/library/src/scala/internal/quoted/Type.scala
+++ b/library/src/scala/internal/quoted/Type.scala
@@ -2,6 +2,13 @@ package scala.internal.quoted
 
 import scala.quoted._
 
+/** Quoted type (or kind) `T`
+ *
+ *  Restriction: only the QuoteContext.tasty.internal implementation is allowed to extend this trait.
+ *  Any other implementation will result in an undefined behavior.
+ */
+class Type[T <: AnyKind] extends scala.quoted.Type[T]
+
 object Type {
 
   /** Pattern matches an the scrutineeType against the patternType and returns a tuple
@@ -17,7 +24,7 @@ object Type {
    *  @param qctx the current QuoteContext
    *  @return None if it did not match, `Some(tup)` if it matched where `tup` contains `Type[Ti]``
    */
-  def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeType: Type[_])(implicit patternType: Type[_],
+  def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeType: scala.quoted.Type[_])(implicit patternType: scala.quoted.Type[_],
         hasTypeSplices: Boolean, qctx: QuoteContext): Option[Tup] = {
     import qctx.tasty.{_, given}
     new Matcher.QuoteMatcher[qctx.type].typeTreeMatch(scrutineeType.unseal, patternType.unseal, hasTypeSplices).asInstanceOf[Option[Tup]]

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -2,12 +2,8 @@ package scala.quoted
 
 import scala.quoted.show.SyntaxHighlight
 
-/** Quoted expression of type `T`
- *
- *  Restriction: only the QuoteContext.tasty.internal implementation is allowed to extend this trait.
- *  Any other implementation will result in an undefined behavior.
- */
-trait Expr[+T] {
+/** Quoted expression of type `T` */
+class Expr[+T] private[scala] {
 
   /** Show a source code like representation of this expression without syntax highlight */
   def show(implicit qctx: QuoteContext): String = qctx.show(this, SyntaxHighlight.plain)
@@ -56,8 +52,6 @@ trait Expr[+T] {
 }
 
 object Expr {
-
-  import scala.internal.quoted._
 
   /** Converts a tuple `(T1, ..., Tn)` to `(Expr[T1], ..., Expr[Tn])` */
   type TupleOfExpr[Tup <: Tuple] = Tuple.Map[Tup, [X] =>> (given QuoteContext) => Expr[X]]

--- a/library/src/scala/quoted/Type.scala
+++ b/library/src/scala/quoted/Type.scala
@@ -2,12 +2,8 @@ package scala.quoted
 
 import scala.quoted.show.SyntaxHighlight
 
-/** Quoted type (or kind) `T`
- *
- *  Restriction: only the QuoteContext.tasty.internal implementation is allowed to extend this trait.
- *  Any other implementation will result in an undefined behavior.
- */
-trait Type[T <: AnyKind] {
+/** Quoted type (or kind) `T` */
+class Type[T <: AnyKind] private[scala] {
   type `$splice` = T
 
   /** Show a source code like representation of this type without syntax highlight */

--- a/tests/neg/i7919.scala
+++ b/tests/neg/i7919.scala
@@ -1,0 +1,20 @@
+import scala.quoted._
+
+object Test {
+  def staged[T](given qctx: QuoteContext) = {
+    import qctx.tasty.{_, given}
+    given typeT: quoted.Type[T] // error
+    val tTypeTree = typeT.unseal
+    val tt = typeOf[T]
+    '{ "in staged" }
+  }
+
+  given Expr[Int] // error
+  new Expr[Int] // error
+  class Expr2 extends Expr[Int] // error
+
+  given Type[Int] // error
+  new Type[Int] // error
+  class Type2 extends Type[Int] // error
+
+}


### PR DESCRIPTION
Now that quoted.Type and quoted.Expr are not sealed we make them have
private constructors to make sure users do not exten them (possibly by mistake).