### PR TITLE
Fix #7949: sbt test discovery should not run traits

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -583,8 +583,8 @@ private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder
 
   def apiModifiers(sym: Symbol): api.Modifiers = {
     val absOver = sym.is(AbsOverride)
-    val abs = sym.is(Abstract) || sym.is(Deferred) || absOver
-    val over = sym.is(Override) || absOver
+    val abs = absOver || sym.isOneOf(Trait | Abstract | Deferred)
+    val over = absOver || sym.is(Override)
     new api.Modifiers(abs, over, sym.is(Final), sym.is(Sealed),
       sym.isOneOf(GivenOrImplicit), sym.is(Lazy), sym.is(Macro), sym.isSuperAccessor)
   }

--- a/sbt-dotty/sbt-test/discovery/test-discovery/src/test/scala/AbstractClassTest.scala
+++ b/sbt-dotty/sbt-test/discovery/test-discovery/src/test/scala/AbstractClassTest.scala
@@ -1,0 +1,9 @@
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+// Test discovery should not pick this up because it's abstract
+abstract class AbstractClassTest {
+  @Test def foo = {
+    ???
+  }
+}

--- a/sbt-dotty/sbt-test/discovery/test-discovery/src/test/scala/TraitTest.scala
+++ b/sbt-dotty/sbt-test/discovery/test-discovery/src/test/scala/TraitTest.scala
@@ -1,0 +1,9 @@
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+// Test discovery should not pick this up because it's a trait
+trait TraitTest {
+  @Test def foo = {
+    ???
+  }
+}


### PR DESCRIPTION
Traits don't have the `Abstract` flag set, so we need to also check for
the `Trait` flag, otherwise
https://github.com/sbt/zinc/blob/cdd2a20f110e1eb4a713597b553d57b823466f75/internal/zinc-apiinfo/src/main/scala/xsbt/api/Discovery.scala#L74
will return true for traits, making them eligible for test discovery.

Also reorder checks to short-circuit checking for flags when possible.