### PR TITLE
Fix #7897: Add all URLClassloader URL to the classpath

### DIFF
--- a/sbt-dotty/sbt-test/sbt-dotty/i7897/build-no-fork.sbt
+++ b/sbt-dotty/sbt-test/sbt-dotty/i7897/build-no-fork.sbt
@@ -1,0 +1,5 @@
+scalaVersion := sys.props("plugin.scalaVersion")
+
+libraryDependencies += "ch.epfl.lamp" %% "dotty-staging" % scalaVersion.value
+
+fork := false

--- a/sbt-dotty/sbt-test/sbt-dotty/i7897/build.sbt
+++ b/sbt-dotty/sbt-test/sbt-dotty/i7897/build.sbt
@@ -1,0 +1,5 @@
+scalaVersion := sys.props("plugin.scalaVersion")
+
+libraryDependencies += "ch.epfl.lamp" %% "dotty-staging" % scalaVersion.value
+
+fork := true

--- a/sbt-dotty/sbt-test/sbt-dotty/i7897/project/build.properties
+++ b/sbt-dotty/sbt-test/sbt-dotty/i7897/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.6

--- a/sbt-dotty/sbt-test/sbt-dotty/i7897/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/sbt-dotty/i7897/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))

--- a/sbt-dotty/sbt-test/sbt-dotty/i7897/src/main/scala/hello/i7897.scala
+++ b/sbt-dotty/sbt-test/sbt-dotty/i7897/src/main/scala/hello/i7897.scala
@@ -1,0 +1,14 @@
+import scala.quoted._, staging._
+
+given Toolbox = Toolbox.make(getClass.getClassLoader)
+
+val f: Array[Int] => Int = run {
+  val stagedSum: Expr[Array[Int] => Int] = '{ (arr: Array[Int]) => 6 }
+  println(stagedSum.show)
+  stagedSum
+}
+
+object Main {
+  def main(args: Array[String]): Unit =
+    f.apply(Array(1, 2, 3)) // Returns 6
+}

--- a/sbt-dotty/sbt-test/sbt-dotty/i7897/test
+++ b/sbt-dotty/sbt-test/sbt-dotty/i7897/test
@@ -1,0 +1,3 @@
+> run
+$ copy-file build-no-fork.sbt build.sbt
+> run


### PR DESCRIPTION
sbt 1.3 introduced the `sbt.internal.LayeredClassLoader` which is a `URLClassloader`
which layers the classpath into different Classloaders. To make sure we recover
`scala-library-XYZ.jar` we need to get the URLs from the parent classloaders as well.