### PR TITLE
Fix #7970: `=> T` is not a subtype of a classtype T

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -482,7 +482,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
           }
           else if (cls2.is(JavaDefined)) {
             // If `cls2` is parameterized, we are seeing a raw type, so we need to compare only the symbol
-            val base = tp1.baseType(cls2)
+            val base = nonExprBaseType(tp1, cls2)
             if (base.typeSymbol == cls2) return true
           }
           else if (tp1.isLambdaSub && !tp1.isRef(AnyKindClass))
@@ -706,7 +706,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
     }
 
     def tryBaseType(cls2: Symbol) = {
-      val base = tp1.baseType(cls2)
+      val base = nonExprBaseType(tp1, cls2)
       if (base.exists && (base `ne` tp1))
         isSubType(base, tp2, if (tp1.isRef(cls2)) approx else approx.addLow) ||
         base.isInstanceOf[OrType] && fourthTry
@@ -930,8 +930,8 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
               val classBounds = tycon2.classSymbols
               def liftToBase(bcs: List[ClassSymbol]): Boolean = bcs match {
                 case bc :: bcs1 =>
-                  classBounds.exists(bc.derivesFrom) && appOK(tp1w.baseType(bc)) ||
-                  liftToBase(bcs1)
+                  classBounds.exists(bc.derivesFrom) && appOK(nonExprBaseType(tp1, bc))
+                  || liftToBase(bcs1)
                 case _ =>
                   false
               }
@@ -1106,6 +1106,10 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
       }
     }
   }
+
+  private def nonExprBaseType(tp: Type, cls: Symbol)(given Context): Type =
+    if tp.isInstanceOf[ExprType] then NoType
+    else tp.baseType(cls)
 
   /** If `tp` is an external reference to an enclosing module M that contains opaque types,
    *  convert to M.this.
@@ -1283,7 +1287,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
       case bc :: bcs1 =>
         (classBounds.exists(bc.derivesFrom) &&
           variancesConform(bc.typeParams, tparams) &&
-          p(tp1.baseType(bc))
+          p(nonExprBaseType(tp1, bc))
         ||
         recur(bcs1))
       case nil =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2888,7 +2888,7 @@ class Typer extends Namer
               |To turn this error into a warning, pass -Xignore-scala2-macros to the compiler""".stripMargin, tree.sourcePos.startPos)
           tree
         }
-      else if (tree.tpe <:< pt) {
+      else if (tree.tpe.widenExpr <:< pt) {
         if (pt.hasAnnotation(defn.InlineParamAnnot))
           checkInlineConformant(tree, isFinal = false, "argument to inline parameter")
         if (ctx.typeComparer.GADTused && pt.isValueType)

--- a/tests/neg/i7970.scala
+++ b/tests/neg/i7970.scala
@@ -1,0 +1,7 @@
+object O{
+  val a: Int => Int = x => x + 1
+  val b: (=> Int) => Int = a        // error
+  def m(i: String): String = i
+  def x(f: String => String): (=>String)=>String = f // error
+  def main(args: Array[String]): Unit = x(m)("X")
+}

--- a/tests/run-macros/refined-selectable-macro/Macro_1.scala
+++ b/tests/run-macros/refined-selectable-macro/Macro_1.scala
@@ -22,8 +22,8 @@ object Macro {
           info match {
             case _: TypeBounds =>
               rec(parent)
-            case _: MethodType | _: PolyType | _: TypeBounds =>
-              qctx.warning(s"Ignored $name as a field of the record", s)
+            case _: MethodType | _: PolyType | _: TypeBounds | _: ByNameType =>
+              qctx.warning(s"Ignored `$name` as a field of the record", s)
               rec(parent)
             case info: Type =>
               (name, info) :: rec(parent)


### PR DESCRIPTION
It slipped through before, since baseType on ExprType is defined.
This needs compensation in adapt.