### PR TITLE
Fix #7986: Warn on cyclic references when looking for extension methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3501,7 +3501,7 @@ class Typer extends Namer
             catch case ex: TypeError =>
               ex match
                 case ex: CyclicReference if ex.denot.is(Extension) && ex.denot.name == selName =>
-                  report.warning(
+                  report.error(
                     em"""An extension method for `.$selName` was tried but could not be fully constructed
                         |since there was a cyclic reference involving ${ex.denot.symbol.showLocated}""",
                     tree.srcPos)(using origCtx)

--- a/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
@@ -5,6 +5,7 @@ import org.jetbrains.dokka.model._
 import collection.JavaConverters._
 import dotty.dokka._
 import dotty.dokka.model.api.Annotation
+import doc.DocumentationNode
 import dotty.dokka.model.api.TastyDocumentableSource
 
 trait BasicSupport:
@@ -34,10 +35,11 @@ trait BasicSupport:
 
 
   extension (sym: Symbol):
-    def documentation(using cxt: Context) = sym.documentation match
-      case Some(comment) =>
+    def documentation(using cxt: Context): Map[SourceSetWrapper, DocumentationNode] =
+      qctx.reflect.SymbolMethods.documentation(sym) match
+        case Some(comment) =>
           Map(sourceSet -> parseComment(comment, sym.tree))
-      case None =>
+        case None =>
           Map.empty
 
     def source(using ctx: Context) =

--- a/tests/neg/i7986.check
+++ b/tests/neg/i7986.check
@@ -1,4 +1,5 @@
--- [E008] Not Found Error: tests/neg/i7986.scala:3:61 ------------------------------------------------------------------
+-- Error: tests/neg/i7986.scala:3:56 -----------------------------------------------------------------------------------
 3 |extension (project: Project) def dependencies = project.name.dependencies // error, following a cyclic reference warning
-  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
-  |                                                value dependencies is not a member of String
+  |                                                ^^^^^^^^^^^^
+  |                              An extension method for `.dependencies` was tried but could not be fully constructed
+  |                              since there was a cyclic reference involving method dependencies

--- a/tests/neg/i7986.check
+++ b/tests/neg/i7986.check
@@ -1,0 +1,4 @@
+-- [E008] Not Found Error: tests/neg/i7986.scala:3:61 ------------------------------------------------------------------
+3 |extension (project: Project) def dependencies = project.name.dependencies // error, following a cyclic reference warning
+  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                                                value dependencies is not a member of String

--- a/tests/neg/i7986.scala
+++ b/tests/neg/i7986.scala
@@ -1,0 +1,3 @@
+case class Project(name: String)
+extension (name: String) def dependencies = ???
+extension (project: Project) def dependencies = project.name.dependencies // error, following a cyclic reference warning

--- a/tests/pos/i7986.scala
+++ b/tests/pos/i7986.scala
@@ -1,0 +1,3 @@
+case class Project(name: String)
+extension (name: String) def dependencies: String = ???
+extension (project: Project) def dependencies: String = project.name.dependencies

--- a/tests/pos/i8256.scala
+++ b/tests/pos/i8256.scala
@@ -7,4 +7,4 @@ val a = 1
 
   val fetch = implicitly[Test[1]]
 
-@main def main() : Unit = {}
+@main def test() : Unit = {}


### PR DESCRIPTION
Propagate cyclic reference errors when searching extension methods