### PR TITLE
Fix #7965: Deal with AndTypes in joins

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -223,7 +223,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
           tp2 match {
             case tp2 @ TypeRef(pre2, _) if tp1.name eq tp2.name =>
               tp1.derivedSelect(pre1 | pre2)
-            case _ => fail
+            case _ => fallback
           }
         case AndType(tp11, tp12) =>
           mergeRefinedOrApplied(tp11, tp2) & mergeRefinedOrApplied(tp12, tp2)

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -212,6 +212,8 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
               tp1.derivedAppliedType(
                 mergeRefinedOrApplied(tycon1, tycon2),
                 ctx.typeComparer.lubArgs(args1, args2, tycon1.typeParams))
+            case AndType(tp21, tp22) =>
+              mergeRefinedOrApplied(tp1, tp21) & mergeRefinedOrApplied(tp1, tp22)
             case _ => fail
           }
         case tp1 @ TypeRef(pre1, _) =>
@@ -220,6 +222,8 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
               tp1.derivedSelect(pre1 | pre2)
             case _ => fail
           }
+        case AndType(tp11, tp12) =>
+          mergeRefinedOrApplied(tp11, tp2) & mergeRefinedOrApplied(tp12, tp2)
         case _ => fail
       }
     }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -198,13 +198,18 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
 
     def mergeRefinedOrApplied(tp1: Type, tp2: Type): Type = {
       def fail = throw new AssertionError(i"Failure to join alternatives $tp1 and $tp2")
+      def fallback = tp2 match
+        case AndType(tp21, tp22) =>
+          mergeRefinedOrApplied(tp1, tp21) & mergeRefinedOrApplied(tp1, tp22)
+        case _ =>
+          fail
       tp1 match {
         case tp1 @ RefinedType(parent1, name1, rinfo1) =>
           tp2 match {
             case RefinedType(parent2, `name1`, rinfo2) =>
               tp1.derivedRefinedType(
                 mergeRefinedOrApplied(parent1, parent2), name1, rinfo1 | rinfo2)
-            case _ => fail
+            case _ => fallback
           }
         case tp1 @ AppliedType(tycon1, args1) =>
           tp2 match {
@@ -212,9 +217,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
               tp1.derivedAppliedType(
                 mergeRefinedOrApplied(tycon1, tycon2),
                 ctx.typeComparer.lubArgs(args1, args2, tycon1.typeParams))
-            case AndType(tp21, tp22) =>
-              mergeRefinedOrApplied(tp1, tp21) & mergeRefinedOrApplied(tp1, tp22)
-            case _ => fail
+            case _ => fallback
           }
         case tp1 @ TypeRef(pre1, _) =>
           tp2 match {

--- a/tests/pos/i7965.scala
+++ b/tests/pos/i7965.scala
@@ -1,0 +1,46 @@
+class Has[A]
+trait X
+trait Y
+trait Z
+
+abstract class Test {
+  val x: Has[X] | (Has[Y] & Has[Z])
+  def foo[T <: Has[_]](has: T): T = has
+  foo(x)
+}
+
+trait ZLayer[-RIn, +E, +ROut <: Has[_]] {
+  def >>>[E1 >: E, ROut2 <: Has[_]](that: ZLayer[ROut, E1, ROut2]): ZLayer[RIn, E1, ROut2]
+  def ++[E1 >: E, RIn2, ROut1 >: ROut <: Has[_], ROut2 <: Has[_]](that: ZLayer[RIn2, E1, ROut2]): ZLayer[RIn with RIn2, E1, ROut1 with ROut2]
+}
+object ZLayer {
+  type NoDeps[+E, +B <: Has[_]] = ZLayer[Any, E, B]
+}
+
+type ServiceA = Has[ServiceA.Service]
+object ServiceA {
+  trait Service
+  val live: ZLayer.NoDeps[Nothing, ServiceA] = ???
+}
+
+type ServiceB = Has[ServiceB.Service]
+object ServiceB {
+  trait Service
+  val live: ZLayer.NoDeps[Nothing, ServiceB] = ???
+}
+
+type ServiceC = Has[ServiceC.Service]
+object ServiceC {
+  trait Service
+  val live: ZLayer.NoDeps[Nothing, ServiceC] = ???
+}
+
+type ServiceD = Has[ServiceD.Service]
+object ServiceD {
+  trait Service
+  val live: ZLayer.NoDeps[ServiceC, ServiceD with ServiceC] = ???
+}
+
+val combined =
+    ServiceA.live >>>
+      (ServiceB.live ++ (ServiceC.live >>> ServiceD.live))

--- a/tests/pos/i7965.scala
+++ b/tests/pos/i7965.scala
@@ -4,7 +4,9 @@ trait Y
 trait Z
 
 abstract class Test {
-  val x: Has[X] | (Has[Y] & Has[Z])
+  def x: Has[X] | (Has[Y] & Has[Z])
+  val y: Has[? >: (X & Y) | (X & Z) <: (X | Y) & (X | Z)] = x
+
   def foo[T <: Has[_]](has: T): T = has
   foo(x)
 }

--- a/tests/pos/i7965.scala
+++ b/tests/pos/i7965.scala
@@ -11,6 +11,8 @@ abstract class Test {
   foo(x)
 }
 
+// -------------------------------------------
+
 trait ZLayer[-RIn, +E, +ROut <: Has[_]] {
   def >>>[E1 >: E, ROut2 <: Has[_]](that: ZLayer[ROut, E1, ROut2]): ZLayer[RIn, E1, ROut2]
   def ++[E1 >: E, RIn2, ROut1 >: ROut <: Has[_], ROut2 <: Has[_]](that: ZLayer[RIn2, E1, ROut2]): ZLayer[RIn with RIn2, E1, ROut1 with ROut2]
@@ -46,3 +48,19 @@ object ServiceD {
 val combined =
     ServiceA.live >>>
       (ServiceB.live ++ (ServiceC.live >>> ServiceD.live))
+
+// -------------------------------------------
+
+class Outer {
+  class Elem
+}
+
+abstract class Test2 {
+  val o1: Outer = ???
+  val o2: Outer = ???
+  val o3: Outer = ???
+
+  val x: o1.Elem | (o2.Elem & o3.Elem)
+  def foo[T <: Outer#Elem](has: T): T = ???
+  foo(x)
+}


### PR DESCRIPTION
Allow that the base type of a join may be a conjunction.