### PR TITLE
Fix #7959: Don't check Java symbols for private leaks

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -544,6 +544,7 @@ object Flags {
   val InlineByNameProxy: FlagSet             = InlineProxy | Method
   val JavaEnumTrait: FlagSet                 = JavaDefined | Enum                             // A Java enum trait
   val JavaEnumValue: FlagSet                 = JavaDefined | EnumValue                        // A Java enum value
+  val JavaOrPrivateOrSynthetic: FlagSet      = JavaDefined | Private | Synthetic
   val StaticProtected: FlagSet               = JavaDefined | JavaStatic | Protected           // Java symbol which is `protected` and `static`
   val JavaModule: FlagSet                    = JavaDefined | Module                           // A Java companion object
   val JavaInterface: FlagSet                 = JavaDefined | NoInits | Trait

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -161,7 +161,8 @@ trait TypeAssigner {
     avoid(expr.tpe, localSyms(bindings).filter(_.isTerm))
 
   def avoidPrivateLeaks(sym: Symbol)(implicit ctx: Context): Type =
-    if (!sym.isOneOf(PrivateOrSynthetic) && sym.owner.isClass) checkNoPrivateLeaks(sym)
+    if sym.owner.isClass && !sym.isOneOf(JavaOrPrivateOrSynthetic)
+    then checkNoPrivateLeaks(sym)
     else sym.info
 
   private def toRepeated(tree: Tree, from: ClassSymbol)(implicit ctx: Context): Tree =

--- a/tests/pos/i7959.java
+++ b/tests/pos/i7959.java
@@ -1,4 +1,4 @@
-public class Test {
+public class i7959 {
   private static class Foo {
     Foo() { }
   }

--- a/tests/pos/i7959.java
+++ b/tests/pos/i7959.java
@@ -1,0 +1,5 @@
+public class Test {
+  private static class Foo {
+    Foo() { }
+  }
+}


### PR DESCRIPTION
Java does not have the same rules as Scala here. Also, there are problems
with package[private] which is translated to private[pkg]. In the test case,
the constructor is assumed to be visible up to the package (because it
is always annotated as such) which is further than the enclosing private class.