### PR TITLE
Fix #8005: Check private[C] members for accessibility when overriding

### DIFF
--- a/tests/neg/i8005.scala
+++ b/tests/neg/i8005.scala
@@ -1,0 +1,12 @@
+package nio
+abstract class Buffer {
+  val isReadOnly: Boolean
+  def foo(): Unit
+  def bar(): Unit
+}
+
+class ByteBuffer extends Buffer {  // error: ByteBufer needs to be abstract since `bar` is not defined
+  private[nio] val isReadOnly: Boolean = false // error
+  protected def foo(): Unit = ()  // error
+  private def bar(): Unit = ()
+}


### PR DESCRIPTION
This fell through the cracks before.