### PR TITLE
Fix #7991: don't set JavaDefined for Dotty Enum module class

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -58,8 +58,8 @@ class Compiler {
          new CheckReentrant,         // Internal use only: Check that compiled program has no data races involving global vars
          new ElimPackagePrefixes,    // Eliminate references to package prefixes in Select nodes
          new CookComments,           // Cook the comments: expand variables, doc, etc.
-         new CompleteJavaEnums) ::   // Fill in constructors for Java enums
-    List(new CheckStatic,            // Check restrictions that apply to @static members
+         new CheckStatic) ::         // Check restrictions that apply to @static members
+    List(new CompleteJavaEnums,      // Fill in constructors for Java enums
          new ElimRepeated,           // Rewrite vararg parameters and arguments
          new ExpandSAMs,             // Expand single abstract method closures to anonymous classes
          new ProtectedAccessors,     // Add accessors for protected members

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
@@ -343,6 +343,7 @@ object ClassfileConstants {
       case JAVA_ACC_FINAL      => Final
       case JAVA_ACC_SYNTHETIC  => Synthetic
       case JAVA_ACC_STATIC     => JavaStatic
+      case JAVA_ACC_ENUM       => Enum
       case JAVA_ACC_ABSTRACT   => if (isClass) Abstract else Deferred
       case JAVA_ACC_INTERFACE  => PureInterfaceCreationFlags | JavaDefined
       case _                   => EmptyFlags

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -200,12 +200,13 @@ class ClassfileParser(
         sym.markAbsent()
       }
 
-    // eager load java enum definitions for exhaustivity check of pattern match
+    // eager load enum definitions for exhaustivity check of pattern match
     if (isEnum) {
       instanceScope.toList.map(_.ensureCompleted())
       staticScope.toList.map(_.ensureCompleted())
-      classRoot.setFlag(Flags.JavaEnumTrait)
-      moduleRoot.setFlag(Flags.JavaEnumTrait)
+      val flag = if moduleRoot.is(Flags.JavaDefined) then Flags.JavaEnumTrait else Flags.Enum
+      classRoot.setFlag(flag)
+      moduleRoot.setFlag(flag)
     }
 
     result

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -204,9 +204,6 @@ class ClassfileParser(
     if (isEnum) {
       instanceScope.toList.map(_.ensureCompleted())
       staticScope.toList.map(_.ensureCompleted())
-      val flag = if moduleRoot.is(Flags.JavaDefined) then Flags.JavaEnumTrait else Flags.Enum
-      classRoot.setFlag(flag)
-      moduleRoot.setFlag(flag)
     }
 
     result

--- a/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
@@ -117,10 +117,11 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
     val moduleCls = clazz.companionClass
     val moduleRef = ref(clazz.companionModule)
 
-    val enums = moduleCls.info.decls.filter(member => member.isTerm && member.isAllOf(EnumValue))
+    val enums = moduleCls.info.decls.filter(member => member.isAllOf(EnumValue))
     for { enumValue <- enums }
     yield {
-      val fieldSym = ctx.newSymbol(clazz, enumValue.name.asTermName, EnumValue, enumValue.info)
+      val fieldSym = ctx.newSymbol(clazz, enumValue.name.asTermName, EnumValue | JavaStatic, enumValue.info)
+      fieldSym.addAnnotation(Annotations.Annotation(defn.ScalaStaticAnnot))
       ValDef(fieldSym, moduleRef.select(enumValue))
     }
   }

--- a/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
@@ -110,11 +110,19 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
     else tree
   }
 
-  override def transformValDef(tree: ValDef)(implicit ctx: Context): ValDef = {
-    val sym = tree.symbol
-    if ((sym.isAllOf(EnumValue) || sym.name == nme.DOLLAR_VALUES) && sym.owner.linkedClass.derivesFromJavaEnum)
-      sym.addAnnotation(Annotations.Annotation(defn.ScalaStaticAnnot))
-    tree
+  /** Return a list of forwarders for enum values defined in the companion object
+   *  for java interop.
+   */
+  private def addedEnumForwarders(clazz: Symbol)(implicit ctx: Context): List[ValDef] = {
+    val moduleCls = clazz.companionClass
+    val moduleRef = ref(clazz.companionModule)
+
+    val enums = moduleCls.info.decls.filter(member => member.isTerm && member.isAllOf(EnumValue))
+    for { enumValue <- enums }
+    yield {
+      val fieldSym = ctx.newSymbol(clazz, enumValue.name.asTermName, EnumValue, enumValue.info)
+      ValDef(fieldSym, moduleRef.select(enumValue))
+    }
   }
 
   /** 1. If this is an enum class, add $name and $ordinal parameters to its
@@ -143,9 +151,10 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
       val (params, rest) = decomposeTemplateBody(templ.body)
       val addedDefs = addedParams(cls, ParamAccessor)
       val addedSyms = addedDefs.map(_.symbol.entered)
+      val addedForwarders = addedEnumForwarders(cls)
       cpy.Template(templ)(
         parents = addEnumConstrArgs(defn.JavaEnumClass, templ.parents, addedSyms.map(ref)),
-        body = params ++ addedDefs ++ rest)
+        body = params ++ addedDefs ++ addedForwarders ++ rest)
     }
     else if (cls.isAnonymousClass && cls.owner.isAllOf(EnumCase) && cls.owner.owner.linkedClass.derivesFromJavaEnum) {
       def rhsOf(name: TermName) =

--- a/compiler/test-resources/repl/i7410
+++ b/compiler/test-resources/repl/i7410
@@ -1,0 +1,4 @@
+> enum E { case A, B, C }
+// defined class E
+> E.A
+val res0: E = A

--- a/compiler/test-resources/repl/i7410
+++ b/compiler/test-resources/repl/i7410
@@ -1,4 +1,4 @@
-> enum E { case A, B, C }
+scala> enum E { case A, B, C }
 // defined class E
-> E.A
+scala> E.A
 val res0: E = A

--- a/tests/run/i6664/Bomb_1.scala
+++ b/tests/run/i6664/Bomb_1.scala
@@ -1,0 +1,4 @@
+enum Bomb
+{
+    case Kaboom
+}

--- a/tests/run/i6664/Detonator_2.scala
+++ b/tests/run/i6664/Detonator_2.scala
@@ -1,0 +1,5 @@
+object Test
+{
+    def boom: Unit = Bomb.valueOf("Kaboom")
+    def main(args: Array[String]): Unit = println("ok!")
+}

--- a/tests/run/i6664b/Bomb_1.scala
+++ b/tests/run/i6664b/Bomb_1.scala
@@ -1,0 +1,4 @@
+enum Bomb extends java.lang.Enum[Bomb]
+{
+    case Kaboom
+}

--- a/tests/run/i6664b/Detonator_2.scala
+++ b/tests/run/i6664b/Detonator_2.scala
@@ -1,0 +1,4 @@
+object Test
+{
+    def main(args: Array[String]): Unit = println(Bomb.Kaboom)
+}

--- a/tests/run/i6677/Enum_1.scala
+++ b/tests/run/i6677/Enum_1.scala
@@ -1,0 +1,3 @@
+enum Foo[A] {
+  case Bar extends Foo[Int]
+}

--- a/tests/run/i6677/Test_2.scala
+++ b/tests/run/i6677/Test_2.scala
@@ -1,0 +1,5 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    println(Foo.Bar)
+  }
+}

--- a/tests/run/i7287/Enum_1.scala
+++ b/tests/run/i7287/Enum_1.scala
@@ -1,0 +1,5 @@
+enum Color derives Eql {
+  case Unknown
+  case Blue(v: Int)
+  case Red(v: Int)
+}

--- a/tests/run/i7287/Test_2.scala
+++ b/tests/run/i7287/Test_2.scala
@@ -1,0 +1,6 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val testData = Seq(("blah", Color.Unknown), ("red", Color.Red(10)))
+    println(testData)
+  }
+}

--- a/tests/run/i7410/Enum_1.scala
+++ b/tests/run/i7410/Enum_1.scala
@@ -1,0 +1,3 @@
+enum E {
+  case A, B, C
+}

--- a/tests/run/i7410/Test_2.scala
+++ b/tests/run/i7410/Test_2.scala
@@ -1,0 +1,6 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val a = E.A
+    println(a)
+  }
+}

--- a/tests/run/i7424/Enum_1.scala
+++ b/tests/run/i7424/Enum_1.scala
@@ -1,0 +1,3 @@
+enum A {
+  case A1
+}

--- a/tests/run/i7424/Test_2.scala
+++ b/tests/run/i7424/Test_2.scala
@@ -1,0 +1,5 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    println(A.values)
+  }
+}

--- a/tests/run/i7991.scala
+++ b/tests/run/i7991.scala
@@ -1,0 +1,5 @@
+enum Num { case One }
+
+object Test extends App {
+  Num.One
+}

--- a/tests/run/i7991/Num_1.scala
+++ b/tests/run/i7991/Num_1.scala
@@ -1,0 +1,1 @@
+enum Num { case One }

--- a/tests/run/i7991/Test_2.scala
+++ b/tests/run/i7991/Test_2.scala
@@ -1,0 +1,3 @@
+object Test extends App {
+  Num.One
+}


### PR DESCRIPTION
Fix #7991: don't set JavaDefined for Dotty Enum module class

Top-level Dotty Enum classes have the flag JAVA_ACC_ENUM.
We cannot tell from the flag whether a class is JavaDefined or not.
The `moduleRoot` already has the flag `JavaDefined` set, it suffices
to test the flag.