### PR TITLE
Fetch maven metadata from Dotty plugin via HTTPS

### DIFF
--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -34,7 +34,7 @@ object DottyPlugin extends AutoPlugin {
 
         // get latest nightly version from maven
         def fetchSource(version: String): (scala.io.BufferedSource, String) =
-          try Source.fromURL(s"http://repo1.maven.org/maven2/ch/epfl/lamp/dotty_$version/maven-metadata.xml") -> version
+          try Source.fromURL(s"https://repo1.maven.org/maven2/ch/epfl/lamp/dotty_$version/maven-metadata.xml") -> version
           catch { case t: java.io.FileNotFoundException =>
             val major :: minor :: Nil = version.split('.').toList
             if (minor.toInt <= 0) throw t


### PR DESCRIPTION
Dotty example project build failed: https://travis-ci.org/lampepfl/dotty-example-project/builds/637646517?utm_medium=notification&utm_source=email

Because it tries to fetch the maven metadata via http and it is no longer supported: http://repo1.maven.org/maven2/ch/epfl/lamp/dotty_0.22/maven-metadata.xml