### PR TITLE
Fix #7998: Treat `)` as token that can end a statement

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -194,7 +194,7 @@ object Parsers {
     def isNumericLit = numericLitTokens contains in.token
     def isTemplateIntro = templateIntroTokens contains in.token
     def isDclIntro = dclIntroTokens contains in.token
-    def isStatSeqEnd = in.isNestedEnd || in.token == EOF
+    def isStatSeqEnd = in.isNestedEnd || in.token == EOF || in.token == RPAREN
     def mustStartStat = mustStartStatTokens contains in.token
 
     /** Is current token a hard or soft modifier (in modifier position or not)? */

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1274,7 +1274,7 @@ class ErrorMessagesTests extends ErrorMessagesTest {
     checkMessagesAfter(FrontEnd.name) {
       """
         |object Test {
-        |  { ) }
+        |  { with }
         |  { private ) }
         |}
       """.stripMargin

--- a/tests/neg/i4934.scala
+++ b/tests/neg/i4934.scala
@@ -1,6 +1,3 @@
-object Foo {
-  val a = ""); // error: end of statement expected
-}
 // From #5824:
 object Main {
   def main(args: Array[String]): Unit = {
@@ -8,3 +5,7 @@ object Main {
     println(foo)
   }
 }
+
+object Foo {
+  val a = ""); // error: `}` expected but `)` found
+} // error: eof expected

--- a/tests/neg/parser-stability-4.scala
+++ b/tests/neg/parser-stability-4.scala
@@ -1,3 +1,2 @@
 class x0{
       def x0: x0 = (x0 => x0) => x0)  // error // error
-// error

--- a/tests/pos/i7998.scala
+++ b/tests/pos/i7998.scala
@@ -1,0 +1,6 @@
+@main def Test =
+  (
+    try 1
+    catch
+      case _: Throwable => 2
+  )


### PR DESCRIPTION
Fix #7998: Treat `)` as token that can end a statement