### PR TITLE
Fix #6709: Correlate match types and match expression

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -26,6 +26,7 @@ matchtype.scala
 i7087.scala
 i7868.scala
 i7872.scala
+6709.scala
 
 # Opaque type
 i5720.scala

--- a/docs/docs/reference/new-types/match-types.md
+++ b/docs/docs/reference/new-types/match-types.md
@@ -3,7 +3,7 @@ layout: doc-page
 title: "Match Types"
 ---
 
-A match type reduces to one of a number of right hand sides, depending on a scrutinee type. Example:
+A match type reduces to one of its right-hand sides, depending on a scrutinee type. Example:
 
 ```scala
 type Elem[X] = X match {
@@ -12,23 +12,29 @@ type Elem[X] = X match {
   case Iterable[t] => t
 }
 ```
-This defines a type that, depending on the scrutinee type `X`, can reduce to one of its right hand sides. For instance,
+
+This defines a type that reduces as follows:
+
 ```scala
 Elem[String]       =:=  Char
 Elem[Array[Int]]   =:=  Int
 Elem[List[Float]]  =:=  Float
 Elem[Nil.type]     =:=  Nothing
 ```
+
 Here `=:=` is understood to mean that left and right hand sides are mutually subtypes of each other.
 
 In general, a match type is of the form
+
 ```scala
 S match { P1 => T1 ... Pn => Tn }
 ```
+
 where `S`, `T1`, ..., `Tn` are types and `P1`, ..., `Pn` are type patterns. Type variables
 in patterns start as usual with a lower case letter.
 
 Match types can form part of recursive type definitions. Example:
+
 ```scala
 type LeafElem[X] = X match {
   case String => Char
@@ -37,13 +43,16 @@ type LeafElem[X] = X match {
   case AnyVal => X
 }
 ```
+
 Recursive match type definitions can also be given an upper bound, like this:
+
 ```scala
 type Concat[Xs <: Tuple, +Ys <: Tuple] <: Tuple = Xs match {
   case Unit => Ys
   case x *: xs => x *: Concat[xs, Ys]
 }
 ```
+
 In this definition, every instance of `Concat[A, B]`, whether reducible or not, is known to be a subtype of `Tuple`. This is necessary to make the recursive invocation `x *: Concat[xs, Ys]` type check, since `*:` demands a `Tuple` as its right operand.
 
 ## Representation of Match Types

--- a/docs/docs/reference/new-types/match-types.md
+++ b/docs/docs/reference/new-types/match-types.md
@@ -55,6 +55,26 @@ type Concat[Xs <: Tuple, +Ys <: Tuple] <: Tuple = Xs match {
 
 In this definition, every instance of `Concat[A, B]`, whether reducible or not, is known to be a subtype of `Tuple`. This is necessary to make the recursive invocation `x *: Concat[xs, Ys]` type check, since `*:` demands a `Tuple` as its right operand.
 
+## Dependent typing
+
+Match types can be used to define dependently type methods. For instance, here is value level counterpart to the`LeafElem` defined above (note the use of the match type as return type):
+
+```scala
+def leafElem[X](x: X): LeafElem[X] = x match {
+  case x: String      => x.charAt(0)
+  case x: Array[t]    => leafElem(x(9))
+  case x: Iterable[t] => leafElem(x.next())
+  case x: AnyVal      => x
+}
+```
+
+This special mode of typing for match expressions is only used when the following conditions are met:
+
+1. The match expression patterns do not have guards
+2. The match expression scrutinee's type is a subtype of the match type scrutinee's type
+3. The match expression and the match type have the same number of cases
+4. The match expression patterns are all [Typed Patterns](https://scala-lang.org/files/archive/spec/2.13/08-pattern-matching.html#typed-patterns), and these types are `=:=` to their corresponding type patterns in the match type
+
 ## Representation of Match Types
 
 The internal representation of a match type

--- a/docs/docs/reference/new-types/match-types.md
+++ b/docs/docs/reference/new-types/match-types.md
@@ -85,11 +85,11 @@ is `Match(S, C1, ..., Cn) <: B` where each case `Ci` is of the form
 ```
 [Xs] =>> P => T
 ```
+
 Here, `[Xs]` is a type parameter clause of the variables bound in pattern `Pi`. If there are no bound type variables in a case, the type parameter clause is omitted and only the function type `P => T` is kept. So each case is either a unary function type or a type lambda over a unary function type.
 
 `B` is the declared upper bound of the match type, or `Any` if no such bound is given.
 We will leave it out in places where it does not matter for the discussion. Scrutinee, bound and pattern types must be first-order types.
-
 
 ## Match type reduction
 
@@ -115,28 +115,36 @@ Disjointness proofs rely on the following properties of Scala types:
 The following rules apply to match types. For simplicity, we omit environments and constraints.
 
 The first rule is a structural comparison between two match types:
+
 ```
-Match(S, C1, ..., Cm) <: Match(T, D1, ..., Dn)
+S match { P1 => T1 ... Pm => Tm }  <:  T match { Q1 => U1 ... Qn => Un }
 ```
+
 if
+
 ```
-S <: T,  m >= n,  Ci <: Di for i in 1..n
+S =:= T,  m >= n,  Pi =:= Qi and Ti <: Ui for i in 1..n
 ```
-I.e. scrutinees and corresponding cases must be subtypes, no case re-ordering is allowed, but the subtype can have more cases than the supertype.
+
+I.e. scrutinees and patterns must be equal and the corresponding bodies must be subtypes. No case re-ordering is allowed, but the subtype can have more cases than the supertype.
 
 The second rule states that a match type and its redux are mutual subtypes
+
 ```
-  Match(S, Cs) <: T
-  T <: Match(S, Cs)
-```
-if
-```
-  Match(S, Cs)  reduces-to  T
+S match { P1 => T1 ... Pn => Tn }  <:  U
+U  <:  S match { P1 => T1 ... Pn => Tn }
 ```
 
-The third rule states that a match type conforms to its upper bound
+if
+
 ```
-  (Match(S, Cs) <: B)  <:  B
+S match { P1 => T1 ... Pn => Tn }  reduces-to  U
+```
+
+The third rule states that a match type conforms to its upper bound:
+
+```
+(S match { P1 => T1 ... Pn => Tn } <: B)  <:  B
 ```
 
 ## Variance Laws for Match Types

--- a/docs/docs/reference/new-types/match-types.md
+++ b/docs/docs/reference/new-types/match-types.md
@@ -101,7 +101,7 @@ The compiler implements the following reduction algorithm:
 - Sequentially consider each pattern `Pi`
     - If `S <: Pi` reduce to `Ti`.
     - Otherwise, try constructing a proof that `S` and `Pi` are disjoint, or, in other words, that no value `s` of type `S` is also of type `Pi`.
-    - If such proof is found, proceed to the case (`Pi+1`), otherwise, do not reduce.
+    - If such proof is found, proceed to the next case (`Pi+1`), otherwise, do not reduce.
 
 Disjointness proofs rely on the following properties of Scala types:
 
@@ -109,6 +109,9 @@ Disjointness proofs rely on the following properties of Scala types:
 2. Final classes cannot be extended
 3. Constant types with distinct values are nonintersecting
 
+Type parameters in patterns are minimally instantiated when computing `S <: Pi`. An instantiation `Is` is _minimal_ for `Xs` if all type variables in `Xs` that appear covariantly and nonvariantly in `Is` are as small as possible and all type variables in `Xs` that appear contravariantly in `Is` are as large as possible. Here, "small" and "large" are understood with respect to  `<:`.
+
+For simplicity, we have omitted constraint handling so far. The full formulation of subtyping tests describes them as a function from a constraint and a pair of types to either _success_ and a new constraint or _failure_. In the context of reduction, the subtyping test `S <: [Xs := Is] P` is understood to leave the bounds of all variables in the input constraint unchanged, i.e. existing variables in the constraint cannot be instantiated by matching the scrutinee against the patterns.
 
 ## Subtyping Rules for Match Types
 

--- a/docs/docs/reference/new-types/match-types.md
+++ b/docs/docs/reference/new-types/match-types.md
@@ -118,7 +118,6 @@ if
 Match(S, C1, ..., Cn)  can-reduce  i, T
 ```
 and, for `j` in `1..i-1`: `Cj` is disjoint from `Ci`, or else `S` cannot possibly match `Cj`.
-See the section on [overlapping patterns](#overlapping-patterns) for an elaboration of "disjoint" and "cannot possibly match".
 
 ## Subtyping Rules for Match Types
 
@@ -152,22 +151,6 @@ The third rule states that a match type conforms to its upper bound
 ## Variance Laws for Match Types
 
 Within a match type `Match(S, Cs) <: B`, all occurrences of type variables count as covariant. By the nature of the cases `Ci` this means that occurrences in pattern position are contravarant (since patterns are represented as function type arguments).
-
-## Overlapping Patterns
-
-A complete defininition of when two patterns or types overlap still needs to be worked out. Some examples we want to cover are:
-
- - Two classes overlap only if one is a subtype of the other
- - A final class `C` overlaps with a trait `T` only if `C` extends `T` directly or indirectly.
- - A class overlaps with a sealed trait `T` only if it overlaps with one of the known subclasses of `T`.
- - An abstract type or type parameter `A` overlaps with a type `B` only if `A`'s upper bound overlaps with `B`.
- - A union type `A1 | ... | An` overlaps with `B` only if at least one of `Ai` for `i` in `1..n` overlaps with `B`.
- - An intersection type `A1 & ... & An` overlaps with `B` only if all of `Ai` for `i` in `1..n` overlap with `B`.
- - If `C[X1, ..., Xn]` is a case class, then the instance type `C[A1, ..., An]` overlaps with the instance type `C[B1, ..., Bn]` only if for every index `i` in `1..n`,
- if `Xi` is the type of a parameter of the class, then `Ai` overlaps with `Bi`.
-
- The last rule in particular is needed to detect non-overlaps for cases where the scrutinee and the patterns are tuples. I.e. `(Int, String)` does not overlap `(Int, Int)` since
-`String` does not overlap `Int`.
 
 ## Handling Termination
 
@@ -224,8 +207,6 @@ Match types have similarities with [closed type families](https://wiki.haskell.o
 
   - Subtyping instead of type equalities.
   - Match type reduction does not tighten the underlying constraint, whereas type family reduction does unify. This difference in approach mirrors the difference between local type inference in Scala and global type inference in Haskell.
-  - No a-priori requirement that cases are non-overlapping. Uses parallel reduction
-    instead of always chosing a unique branch.
 
 Match types are also similar to Typescript's [conditional types](https://github.com/Microsoft/TypeScript/pull/21316). The main differences here are:
 

--- a/tests/neg/6709.scala
+++ b/tests/neg/6709.scala
@@ -1,0 +1,58 @@
+object Test {
+  type M[X] = X match {
+    case Int => String
+    case Double => Int
+  }
+
+  def m_OK[X](x: X): M[X] = x match {
+    case _: Int    => ""
+    case _: Double => 1
+  }
+
+  def m_error0[X](x: X): M[X] = x match {
+    case Some(i: Int) => "" // error
+    case _: Double => 1     // error
+  }
+
+  def m_error1[X](x: X): M[X] = x match {
+    case s: String => "" // error
+    case _: Double => 1  // error
+  }
+
+  def m_error2[X](x: X): M[X] = x match {
+    case _: Double => 1  // error
+    case _: Int    => "" // error
+  }
+
+  def m_error3[X](x: X): M[X] = x match {
+    case _: Int => "" // error
+  }
+
+  def m_error4[X](x: X): M[X] = x match {
+    case _: Int    => ""   // error
+    case _: Double => 1    // error
+    case _: String => true // error
+  }
+
+  def m_error5[X](x: X): M[X] = x match {
+    case _: Int if true => "" // error
+    case _: Double      => 1  // error
+  }
+
+  case class Blah[A, B](a: A, b: B)
+
+  type LeafElem[X] = X match {
+    case Array[t]   => t
+    case Blah[a, b] => a
+  }
+
+  def leafElem_ok[X](x: X): LeafElem[X] = x match {
+    case y: Array[t]   => y.apply(0)
+    case y: Blah[a, b] => y.a
+  }
+
+  def leafElem_error[X](x: X): LeafElem[X] = x match {
+    case y: Array[t]   => 0   // error
+    case y: Blah[a, b] => y.b // error
+  }
+}

--- a/tests/pos/6709.scala
+++ b/tests/pos/6709.scala
@@ -1,0 +1,71 @@
+object Foo {
+  type LeafElem[X] = X match {
+    case String      => Char
+    case Array[t]    => LeafElem[t]
+    case Iterable[t] => LeafElem[t]
+    case AnyVal      => X
+  }
+
+  def leafElem[X](x: X): LeafElem[X] =
+    x match {
+      case x: String      => x.charAt(0)
+      case x: Array[t]    => leafElem(x(0))
+      case x: Iterable[t] => leafElem(x.head)
+      case _: AnyVal      => x
+    }
+
+  def leafElem2[X](x: X): LeafElem[X] =
+    x match {
+      case _: String   => leafElem[X](x)
+      case w: Array[t] => leafElem[X](x)
+    }
+}
+
+object Bar {
+  import compiletime.S
+
+  type Plus[A <: Int, B <: Int] <: Int =
+    A match {
+      case 0    => B
+      case S[p] => S[Plus[p, B]]
+    }
+
+  def plus[A <: Int, B <: Int](a: A, b: B): Plus[A, B] =
+    a match {
+      case _: 0    => b
+      case a: S[p] => succ(plus(pred(a), b))
+    }
+
+  def pred[X <: Int](x: S[X]): X = (x - 1).asInstanceOf
+  def succ[X <: Int](x: X): S[X] = (x + 1).asInstanceOf
+
+  val nine: 9 = plus[4, 5](4, 5)
+}
+
+object Main {
+  enum BinNat {
+    case Zero
+    // 2n + 1
+    case Odd[N <: BinNat](n: N)
+    // 2(n + 1)
+    case Even[N <: BinNat](n: N)
+  }
+
+  import BinNat._
+
+  type Inc[N <: BinNat] <: BinNat =
+    N match {
+      case Zero.type => Odd[Zero.type]
+      case Odd[n]    => Even[n]
+      case Even[n]   => Odd[Inc[n]]
+    }
+
+  def inc[N <: BinNat](b: N): Inc[N] =
+    b match {
+      case _: Zero.type => new Odd(Zero)
+      case o: Odd[n]    => new Even(o.n)
+      case e: Even[n]   =>
+        // 2(n + 1) + 1 = 2(inc(n)) + 1
+        new Odd(inc(e.n))
+    }
+}


### PR DESCRIPTION
This PR adds a simple form of dependent typing by allowing match expressions to be typed as match types when their scrutinee type, pattern types, and body types align. Concretely, this means that we can define a value level counterpart to the `LeafElem` type from the match type documentation, and type check that expression with the match type: 

```scala
type LeafElem[X] = X match {
  case String      => Char
  case Array[t]    => LeafElem[t]
  case Iterable[t] => LeafElem[t]
  case AnyVal      => X
}

def leafElem[X](x: X): LeafElem[X] =
  x match {
    case x: String      => x.charAt(0)
    case x: Array[t]    => leafElem(x(0))
    case x: Iterable[t] => leafElem(x.head)
    case _: AnyVal      => x
  }
```

This special mode of typing for match expressions is only used when the following conditions are met: (that logic is implemented by the `isMatchTypeShaped` function in Typer.scala)

1. The match expression patterns do not have guards
2. The match expression scrutinee's type is a subtype of the match type scrutinee's type
3. The match expression and the match type have the same number of cases
4. The match expression patterns are all [Typed Patterns](https://scala-lang.org/files/archive/spec/2.13/08-pattern-matching.html#typed-patterns), and these types are `=:=` to their corresponding type patterns in the match type

Follow up work could potentially relax some of these conditions, for instance to support unapply patterns that are equivalent to typed patterns.