### PR TITLE
Remove old semanticdb project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,9 +47,6 @@
 [submodule "community-build/community-projects/xml-interpolator"]
 	path = community-build/community-projects/xml-interpolator
 	url = https://github.com/lampepfl/xml-interpolator.git
-[submodule "community-build/community-projects/semanticdb"]
-	path = community-build/community-projects/semanticdb
-	url = https://github.com/lampepfl/dotty-semanticdb.git
 [submodule "community-build/community-projects/effpi"]
 	path = community-build/community-projects/effpi
 	url = https://github.com/dotty-staging/effpi

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -233,12 +233,6 @@ object projects
     sbtUpdateCommand = "update"
   )
 
-  lazy val semanticdb = SbtCommunityProject(
-    project       = "semanticdb",
-    sbtTestCommand   = "test:compile",
-    sbtUpdateCommand = "update"
-  )
-
   lazy val effpi = SbtCommunityProject(
     project       = "effpi",
     // We set `useEffpiPlugin := false` because we don't want to run their
@@ -339,7 +333,6 @@ class CommunityBuildTest {
   @Test def stdLib213 = projects.stdLib213.run()
   @Test def shapeless = projects.shapeless.run()
   @Test def xmlInterpolator = projects.xmlInterpolator.run()
-  @Test def semanticdb = projects.semanticdb.run()
   @Test def effpi = projects.effpi.run()
   @Test def sconfig = projects.sconfig.run()
 }


### PR DESCRIPTION
Now that we have the `semanticdb.ExtractSemanticDB` phase this project will not be needed.