### PR TITLE
Fix analyzer-plugin scripted test

### DIFF
--- a/sbt-dotty/sbt-test/sbt-dotty/analyzer-plugin/plugin/Analyzer.scala
+++ b/sbt-dotty/sbt-test/sbt-dotty/analyzer-plugin/plugin/Analyzer.scala
@@ -13,7 +13,7 @@ import Decorators._
 import Symbols.Symbol
 import Constants.Constant
 import Types._
-import transform.{CheckStatic}
+import transform.CompleteJavaEnums
 
 class InitPlugin extends StandardPlugin {
   import tpd._
@@ -30,7 +30,7 @@ class InitChecker extends PluginPhase {
   val phaseName = "symbolTreeChecker"
 
   override val runsAfter = Set(SetDefTree.name)
-  override val runsBefore = Set(CheckStatic.name)
+  override val runsBefore = Set(CompleteJavaEnums.name)
 
   private def checkDef(tree: Tree)(implicit ctx: Context): Tree = {
     if (tree.symbol.defTree.isEmpty)


### PR DESCRIPTION
This was broken after the CheckStatic phase was moved in
f6f3b28cfcc1f79d002a8af950ef49a84bc88b07, it would be nice to make this
more robust but I don't know how.

I'll merge this as soon as the tests pass to unbreak the nightly builds.