### PR TITLE
Fix #8032: Make import suggestions less chatty

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -61,6 +61,8 @@ object ProtoTypes {
 
     private def disregardProto(pt: Type)(implicit ctx: Context): Boolean = pt.dealias match {
       case _: OrType => true
+        // Don't constrain results with union types, since comparison with a union
+        // type on the right might commit too early into one side.
       case pt => pt.isRef(defn.UnitClass)
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -283,6 +283,7 @@ trait TypeAssigner {
                  |Note that `$name` is treated as an infix operator in Scala 3.
                  |If you do not want that, insert a `;` or empty line in front
                  |or drop any spaces behind the operator."""
+            else if qualType.isBottomType then ""
             else
               var add = importSuggestionAddendum(
                 ViewProto(qualType.widen,

--- a/tests/neg/i8032.check
+++ b/tests/neg/i8032.check
@@ -1,0 +1,9 @@
+-- [E007] Type Mismatch Error: tests/neg/i8032.scala:1:15 --------------------------------------------------------------
+1 |val x: 1 | 2 = 3 // error
+  |               ^
+  |               Found:    (3 : Int)
+  |               Required: (1 : Int) | (2 : Int)
+-- [E008] Member Not Found Error: tests/neg/i8032.scala:3:12 -----------------------------------------------------------
+3 |val y = ???.map // error
+  |        ^^^^^^^
+  |        value map is not a member of Nothing

--- a/tests/neg/i8032.scala
+++ b/tests/neg/i8032.scala
@@ -1,0 +1,3 @@
+val x: 1 | 2 = 3 // error
+
+val y = ???.map // error


### PR DESCRIPTION
Two improvements:

 - Properly constrain union types as result types
 - Don't suggest members of Nothing