### PR TITLE
Fix #8035: Add missing transformFollowing to VCInlineMethods

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/VCInlineMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/VCInlineMethods.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc
+package dotty.tools
+package dotc
 package transform
 
 import ast.{Trees, tpd}
@@ -71,10 +72,11 @@ class VCInlineMethods extends MiniPhase with IdentityDenotTransformer {
           evalOnce(qual) { ev =>
             val ctArgs = ctParams.map(tparam =>
               TypeTree(tparam.typeRef.asSeenFrom(ev.tpe, origCls)))
-            ref(extensionMeth)
+            transformFollowing(
+              ref(extensionMeth)
               .appliedToTypeTrees(mtArgs ++ ctArgs)
               .appliedTo(ev)
-              .appliedToArgss(mArgss)
+              .appliedToArgss(mArgss))
           }
         else
           ref(extensionMeth)

--- a/tests/run/i8035.scala
+++ b/tests/run/i8035.scala
@@ -2,7 +2,7 @@ implicit class Ops[A](val a: String) extends AnyVal {
   def foo(e: => String): Unit = ()
 }
 
-def bar(e: => String): Unit = (new Ops("")).foo(e)
-def baz(e: => String): Unit = "".foo(e)
+def bar(e1: => String): Unit = (new Ops("")).foo(e1)
+def baz(e2: => String): Unit = "".foo(e2)
 
 @main def Test = baz("")

--- a/tests/run/i8035.scala
+++ b/tests/run/i8035.scala
@@ -1,0 +1,8 @@
+implicit class Ops[A](val a: String) extends AnyVal {
+  def foo(e: => String): Unit = ()
+}
+
+def bar(e: => String): Unit = (new Ops("")).foo(e)
+def baz(e: => String): Unit = "".foo(e)
+
+@main def Test = baz("")


### PR DESCRIPTION
VCInlineMethods rewires function calls and sometimes pulls out the prefix
so the original call becomes a subnode. In that case it has to make sure
that the subnode call is still transformed by the following phases.