### PR TITLE
WIP: Update CI cache to include Scala.js artifacts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,7 +27,7 @@ steps:
 
 - name: test
   pull: default
-  image: lampepfl/dotty:2020-01-09
+  image: lampepfl/dotty:2020-01-22-2
   depends_on: [ clone ]
   commands:
   - cp -R . /tmp/1/ && cd /tmp/1/
@@ -36,7 +36,7 @@ steps:
 
 - name: test_bootstrapped
   pull: default
-  image: lampepfl/dotty:2020-01-09
+  image: lampepfl/dotty:2020-01-22-2
   depends_on: [ clone ]
   commands:
   - cp -R . /tmp/2/ && cd /tmp/2/
@@ -45,7 +45,7 @@ steps:
 
 - name: community_build
   pull: default
-  image: lampepfl/dotty:2020-01-09
+  image: lampepfl/dotty:2020-01-22-2
   depends_on: [ clone ]
   commands:
   - cp -R . /tmp/3/ && cd /tmp/3/
@@ -55,7 +55,7 @@ steps:
 
 - name: test_sbt
   pull: default
-  image: lampepfl/dotty:2020-01-09
+  image: lampepfl/dotty:2020-01-22-2
   depends_on: [ clone ]
   commands:
   - cp -R . /tmp/4/ && cd /tmp/4/
@@ -67,7 +67,7 @@ steps:
 
 - name: test_java11
   pull: default
-  image: lampepfl/dotty:2020-01-09
+  image: lampepfl/dotty:2020-01-22-2
   depends_on: [ clone ]
   commands:
   - export PATH="/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH"
@@ -80,7 +80,7 @@ steps:
 
 - name: documentation
   pull: default
-  image: lampepfl/dotty:2020-01-09
+  image: lampepfl/dotty:2020-01-22-2
   depends_on:
   - test
   - test_bootstrapped
@@ -99,7 +99,7 @@ steps:
 
 - name: publish_nightly
   pull: default
-  image: lampepfl/dotty:2020-01-09
+  image: lampepfl/dotty:2020-01-22-2
   depends_on:
   - test
   - test_bootstrapped
@@ -126,7 +126,7 @@ steps:
 
 - name: publish_release
   pull: default
-  image: lampepfl/dotty:2020-01-09
+  image: lampepfl/dotty:2020-01-22-2
   depends_on:
   - test
   - test_bootstrapped
@@ -169,7 +169,7 @@ steps:
 
 - name: publish_sbt_release
   pull: default
-  image: lampepfl/dotty:2020-01-09
+  image: lampepfl/dotty:2020-01-22-2
   depends_on:
   - test
   - test_bootstrapped

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,9 @@
 //
 // e.g. addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
 
+// DO NOT update this plugin without regenerating our Docker
+// image (https://github.com/lampepfl/dotty-drone) or fixing
+// https://github.com/lampepfl/dotty/issues/3146.
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-RC2")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.6")


### PR DESCRIPTION
The scala-js sbt plugin downloads artifacts directly from maven,
bypassing our proxy (set using
https://github.com/lampepfl/dotty-drone/blob/master/dotty-docker/repositories),
this lead to us being banned from maven. I regenerated a docker image
with a cache containing these artfiacts.