### PR TITLE
Fix #8069: Disallow parameter dependent case classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -747,4 +747,12 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   class UntypedDeepFolder[X](f: (X, Tree) => X) extends UntypedTreeAccumulator[X] {
     def apply(x: X, tree: Tree)(implicit ctx: Context): X = foldOver(f(x, tree), tree)
   }
+
+  /** Is there a subtree of this tree that satisfies predicate `p`? */
+  def (tree: Tree).existsSubTree(p: Tree => Boolean)(implicit ctx: Context): Boolean = {
+    val acc = new UntypedTreeAccumulator[Boolean] {
+      def apply(x: Boolean, t: Tree)(implicit ctx: Context) = x || p(t) || foldOver(x, t)
+    }
+    acc(false, tree)
+  }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1130,8 +1130,13 @@ class Namer { typer: Typer =>
 
       index(constr)
       index(rest)(localCtx)
-      symbolOfTree(constr).ensureCompleted()
-
+      symbolOfTree(constr).info.stripPoly match // Completes constr symbol as a side effect
+        case mt: MethodType if cls.is(Case) && mt.isParamDependent =>
+          // See issue #8073 for background
+          ctx.error(
+              i"""Implementation restriction: case classes cannot have dependencies between parameters""",
+              cls.sourcePos)
+        case _ =>
       denot.info = savedInfo
     }
 

--- a/tests/neg/i8069.scala
+++ b/tests/neg/i8069.scala
@@ -1,0 +1,8 @@
+trait A
+  type B
+
+enum Test
+  case Test(a: A, b: a.B)   // error: Implementation restriction: case classes cannot have dependencies between parameters
+
+case class Test2(a: A, b: a.B) // error: Implementation restriction: case classes cannot have dependencies between parameters
+

--- a/tests/pos/i8069.scala
+++ b/tests/pos/i8069.scala
@@ -1,0 +1,12 @@
+class A {
+  class B
+}
+
+class C(val a: A, val b: a.B)
+
+@main def Test =
+  val a = A()
+  val b = a.B()
+  val c = C(a, b)
+  val d = c.b
+  val d1: c.a.B = d


### PR DESCRIPTION
This avoids the crash but intorduces an implementation restriction. I have opened
#8073, which suggests a full implementation of parameter dependent case classes
so that the restriction can be dropped.