### PR TITLE
Fix #8042: add forgotten Java constructor type params

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -473,7 +473,7 @@ object desugar {
           decompose(
             defDef(
               addEvidenceParams(
-                cpy.DefDef(ddef)(tparams = constrTparams),
+                cpy.DefDef(ddef)(tparams = constrTparams ++ ddef.tparams),
                 evidenceParams(constr1).map(toDefParam(_, keepAnnotations = false)))))
         case stat =>
           stat

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -112,14 +112,17 @@ object JavaParsers {
         case nil => (EmptyTree, nil)
       }
       var (constr1, stats1) = pullOutFirstConstr(stats)
-      if (constr1 == EmptyTree) constr1 = makeConstructor(List(), tparams)
       // A dummy first constructor is needed for Java classes so that the real constructors see the
       // import of the companion object. The constructor has parameter of type Unit so no Java code
       // can call it.
       // This also avoids clashes between the constructor parameter names and member names.
       if (needsDummyConstr) {
+        if (constr1 == EmptyTree) constr1 = makeConstructor(List(), Nil)
         stats1 = constr1 :: stats1
         constr1 = makeConstructor(List(scalaDot(tpnme.Unit)), tparams, Flags.JavaDefined | Flags.PrivateLocal)
+      }
+      else if (constr1 == EmptyTree) {
+        constr1 = makeConstructor(List(), tparams)
       }
       Template(constr1.asInstanceOf[DefDef], parents, Nil, EmptyValDef, stats1)
     }
@@ -506,7 +509,7 @@ object JavaParsers {
         optThrows()
         List {
           atSpan(start) {
-            DefDef(nme.CONSTRUCTOR, parentTParams,
+            DefDef(nme.CONSTRUCTOR, tparams,
                 List(vparams), TypeTree(), methodBody()).withMods(mods)
           }
         }

--- a/tests/pos/i8042/Exception.java
+++ b/tests/pos/i8042/Exception.java
@@ -1,0 +1,6 @@
+public class Exception {
+    public <T> Exception(T actual, T matcher) { }
+
+    public <T> Object foo(T actual, T matcher) { return null; }
+
+}


### PR DESCRIPTION
Fix #8042: add forgotten Java constructor type params

For primary constructor, we always add the class parameters
during parsing. For secondary constructors, we add class parameters
during desugaring.

This is a blocker for #8040, where we need to add a such a test case as Java code.