### PR TITLE
Fix #8072: Synchronize cancelling timer task properly

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -186,8 +186,11 @@ trait ImportSuggestions with
           typedImplicit(candidate, expectedType, argument, span)(
             given ctx.fresh.setExploreTyperState()).isSuccess
         finally
-          task.cancel()
-          ctx.run.isCancelled = false
+          if task.cancel() then // timer task has not run yet
+            assert(!ctx.run.isCancelled)
+          else
+            while !ctx.run.isCancelled do () // wait until timer task has run to completion
+            ctx.run.isCancelled = false
       }
     end deepTest
 


### PR DESCRIPTION
Concurrent programming is hard ...

I tested that it works now by setting the timeout from 500 to 1. I gots lots of
cancellations but no discrepancies in the error counts.