### PR TITLE
Workaround LazyRef CyclicReference in genDocs

### DIFF
--- a/library/src/scala/internal/quoted/Matcher.scala
+++ b/library/src/scala/internal/quoted/Matcher.scala
@@ -259,9 +259,11 @@ private[quoted] object Matcher {
               if (hasBindAnnotation(pattern.symbol)) bindingMatch(scrutinee.symbol)
               else matched
             def rhsEnv =
-              summon[Env] + (scrutinee.symbol -> pattern.symbol) ++
-                typeParams1.zip(typeParams2).map((tparam1, tparam2) => tparam1.symbol -> tparam2.symbol) ++
+              val oldEnv: Env = summon[Env]
+              val newEnv: List[(Symbol, Symbol)] =
+                (scrutinee.symbol -> pattern.symbol) :: typeParams1.zip(typeParams2).map((tparam1, tparam2) => tparam1.symbol -> tparam2.symbol) :::
                 paramss1.flatten.zip(paramss2.flatten).map((param1, param2) => param1.symbol -> param2.symbol)
+              oldEnv ++ newEnv
 
             bindMatch &&
               typeParams1 =?= typeParams2 &&

--- a/library/src/scala/quoted/unsafe/UnsafeExpr.scala
+++ b/library/src/scala/quoted/unsafe/UnsafeExpr.scala
@@ -40,23 +40,23 @@ object UnsafeExpr {
    */
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(given qctx: QuoteContext): X = {
     import qctx.tasty.{given, _}
-    val (params, bodyExpr) = paramsAndBody(f)
+    val (params, bodyExpr) = paramsAndBody[R](f)
     content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](e.unseal, params, List(v.unseal)).seal.asInstanceOf[Expr[t]])
   }
 
   def open[T1, T2, R, X](f: Expr[(T1, T2) => R])(content: (Expr[R], [t] => Expr[t] => (Expr[T1], Expr[T2]) => Expr[t]) => X)(given qctx: QuoteContext)(given DummyImplicit): X = {
     import qctx.tasty.{given, _}
-    val (params, bodyExpr) = paramsAndBody(f)
+    val (params, bodyExpr) = paramsAndBody[R](f)
     content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2]) => bodyFn[t](e.unseal, params, List(v1.unseal, v2.unseal)).seal.asInstanceOf[Expr[t]])
   }
 
   def open[T1, T2, T3, R, X](f: Expr[(T1, T2, T3) => R])(content: (Expr[R], [t] => Expr[t] => (Expr[T1], Expr[T2], Expr[T3]) => Expr[t]) => X)(given qctx: QuoteContext)(given DummyImplicit, DummyImplicit): X = {
     import qctx.tasty.{given, _}
-    val (params, bodyExpr) = paramsAndBody(f)
+    val (params, bodyExpr) = paramsAndBody[R](f)
     content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2], v3: Expr[T3]) => bodyFn[t](e.unseal, params, List(v1.unseal, v2.unseal, v3.unseal)).seal.asInstanceOf[Expr[t]])
   }
 
-  private def paramsAndBody[R](given qctx: QuoteContext)(f: Expr[Any]) = {
+  private def paramsAndBody[R](given qctx: QuoteContext)(f: Expr[Any]): (List[qctx.tasty.ValDef], Expr[R]) = {
     import qctx.tasty.{given, _}
     val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.unseal.etaExpand
     (params, body.seal.asInstanceOf[Expr[R]])


### PR DESCRIPTION
Add more explicit types to avoid inference involving type matches.
Also avoid recomputing tuple sizes.

This issue was present in both https://dotty-ci.epfl.ch/lampepfl/dotty/3729 and https://dotty-ci.epfl.ch/lampepfl/dotty/3730.