### PR TITLE
Fix #6987: don't generate assignment for dropped fields

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -212,7 +212,6 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
         }
         splitStats(stats1)
       case Nil =>
-        (Nil, Nil)
     }
     splitStats(tree.body)
 
@@ -220,6 +219,10 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
     val copyParams = accessors flatMap { acc =>
       if (!isRetained(acc)) {
         dropped += acc
+        Nil
+      }
+      else if (!isRetained(acc.field)) { // It may happen for unit fields, tests/run/i6987.scala
+        dropped += acc.field
         Nil
       }
       else {

--- a/tests/run/i6987.scala
+++ b/tests/run/i6987.scala
@@ -1,0 +1,3 @@
+class A(val u: Unit)
+
+@main def Test = A(())

--- a/tests/run/i6987b.scala
+++ b/tests/run/i6987b.scala
@@ -1,0 +1,18 @@
+enum SingleCase {
+  case TheCase1(u: Unit)
+}
+
+case class TheCase2(u: Unit)
+
+case class TheCase3(s: String, u: Unit)
+
+class TheCase4(val u: Unit)
+
+abstract class TheCase5(val u: Unit)
+
+@main def Test =
+  SingleCase.TheCase1(())
+  TheCase2(())
+  TheCase3("", ())
+  TheCase4(())
+  new TheCase5(()) {}


### PR DESCRIPTION
Fix #6987: don't generate assignment for dropped fields