### PR TITLE
Fix typo in extension method example

### DIFF
--- a/docs/docs/reference/contextual/extension-methods-new.md
+++ b/docs/docs/reference/contextual/extension-methods-new.md
@@ -8,7 +8,7 @@ Extension methods allow one to add methods to a type after the type is defined. 
 ```scala
 case class Circle(x: Double, y: Double, radius: Double)
 
-def (c: Circle) circumference: Double = c.radius * math.Pi * 2
+def (c: Circle).circumference: Double = c.radius * math.Pi * 2
 ```
 
 Like regular methods, extension methods can be invoked with infix `.`:

--- a/docs/docs/reference/contextual/extension-methods-new.md
+++ b/docs/docs/reference/contextual/extension-methods-new.md
@@ -8,7 +8,7 @@ Extension methods allow one to add methods to a type after the type is defined. 
 ```scala
 case class Circle(x: Double, y: Double, radius: Double)
 
-def (c: Circle).circumference: Double = c.radius * math.Pi * 2
+def (c: Circle) circumference: Double = c.radius * math.Pi * 2
 ```
 
 Like regular methods, extension methods can be invoked with infix `.`:

--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -143,7 +143,7 @@ extension listOps on [T](xs: List[T]) {
   def third: T = xs.tail.tail.head
 }
 
-extension on [T](xs: List[T]) with Ordering[T]) {
+extension on [T](xs: List[T]) with Ordering[T] {
   def largest(n: Int) = xs.sorted.takeRight(n)
 }
 ```

--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -11,7 +11,7 @@ Extension methods allow one to add methods to a type after the type is defined. 
 ```scala
 case class Circle(x: Double, y: Double, radius: Double)
 
-def (c: Circle).circumference: Double = c.radius * math.Pi * 2
+def (c: Circle) circumference: Double = c.radius * math.Pi * 2
 ```
 
 Like regular methods, extension methods can be invoked with infix `.`:


### PR DESCRIPTION
- Remove an extraneous ‘.’ in example code