### PR TITLE
Rename confusing method

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -749,7 +749,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   }
 
   /** Is there a subtree of this tree that satisfies predicate `p`? */
-  def (tree: Tree).existsSubTree(p: Tree => Boolean)(implicit ctx: Context): Boolean = {
+  def (tree: Tree) existsSubTree(p: Tree => Boolean)(implicit ctx: Context): Boolean = {
     val acc = new UntypedTreeAccumulator[Boolean] {
       def apply(x: Boolean, t: Tree)(implicit ctx: Context) = x || p(t) || foldOver(x, t)
     }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3745,7 +3745,7 @@ object Types {
         NoType
     }
 
-    def typeParams(implicit ctx: Context): List[ParamInfo] = {
+    def tyconTypeParams(implicit ctx: Context): List[ParamInfo] = {
       val tparams = tycon.typeParams
       if (tparams.isEmpty) HKTypeLambda.any(args.length).typeParams else tparams
     }
@@ -4693,7 +4693,7 @@ object Types {
             case nil =>
               nil
           }
-          derivedAppliedType(tp, this(tp.tycon), mapArgs(tp.args, tp.typeParams))
+          derivedAppliedType(tp, this(tp.tycon), mapArgs(tp.args, tp.tyconTypeParams))
 
         case tp: RefinedType =>
           derivedRefinedType(tp, this(tp.parent), this(tp.refinedInfo))
@@ -5000,7 +5000,7 @@ object Types {
                 case nil =>
                   true
               }
-              if (distributeArgs(args, tp.typeParams))
+              if (distributeArgs(args, tp.tyconTypeParams))
                 range(tp.derivedAppliedType(tycon, loBuf.toList),
                       tp.derivedAppliedType(tycon, hiBuf.toList))
               else range(defn.NothingType, defn.AnyType)
@@ -5109,7 +5109,7 @@ object Types {
             }
             foldArgs(acc, tparams.tail, args.tail)
           }
-        foldArgs(this(x, tycon), tp.typeParams, args)
+        foldArgs(this(x, tycon), tp.tyconTypeParams, args)
 
       case _: BoundType | _: ThisType => x
 


### PR DESCRIPTION
TypeApplicatons.typeParams and AppliedType.typeParams both exist on types,
but did different things.

Also: Retract syntax that is not supported yet in released version. This caused vscode to refuse to launch.