### PR TITLE
Fix #8105: Make check aware of case objects

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -909,7 +909,7 @@ trait Implicits { self: Typer =>
   /** A path referencing the companion of class type `clsType` */
   private def companionPath(clsType: Type, span: Span)(implicit ctx: Context) = {
     val ref = pathFor(clsType.companionRef)
-    assert(ref.symbol.is(Module) && ref.symbol.companionClass == clsType.classSymbol)
+    assert(ref.symbol.is(Module) && (clsType.classSymbol.is(ModuleClass) || (ref.symbol.companionClass == clsType.classSymbol)))
     ref.withSpan(span)
   }
 

--- a/tests/run/typeclass-derivation3.scala
+++ b/tests/run/typeclass-derivation3.scala
@@ -19,6 +19,9 @@ object datatypes {
   sealed trait Either[+L, +R] extends Product with Serializable derives Eq, Pickler, Show
   case class Left[L](x: L) extends Either[L, Nothing]
   case class Right[R](x: R) extends Either[Nothing, R]
+
+  // a case object
+  case object Thing derives Eq, Pickler, Show
 }
 
 object typeclasses {


### PR DESCRIPTION
I don't have a lot of context here, but this fixes #8105 and seems reasonable—before checking that the companion class of the companion reference is the class itself, we make sure we're not dealing with a case object.