### PR TITLE
Change issue templates to not hide stuff by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -13,12 +13,10 @@ assignees: ''
 println("hello, world")
 ```
 
-<details>
-<summary>Compilation output</summary>
+## Compilation output
 
 ```scala
-# TODO add compilation output here
+// TODO add compilation output here
 ```
-</details>
 
 ## expectation

--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -13,11 +13,10 @@ assignees: ''
 println("hello, world")
 ```
 
-
+## Crash output (click arrow to expand)
 <details>
-<summary>Stack trace</summary>
 
 ```scala
-# TODO add stack trace here
+// TODO add output here
 ```
 </details>

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -13,12 +13,10 @@ assignees: ''
 println("hello, world")
 ```
 
-<details>
-<summary>Compilation output</summary>
+## Compilation output
 
 ```scala
-# TODO add compilation output here
+// TODO add compilation output here
 ```
-</details>
 
 ## expectation


### PR DESCRIPTION
Using the "details" tag for all templates is excessive since most of the
time, the compilation output is quite small, and not seeing it at a
glance can be confusing. Only stack traces are worth hiding.