### PR TITLE
Handle some explicit paths in quotes

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -231,8 +231,7 @@ class ReifyQuotes extends MacroTransform {
           if (isType) ref(defn.Unpickler_unpickleType).appliedToType(originalTp)
           else ref(defn.Unpickler_unpickleExpr).appliedToType(originalTp.widen)
         val spliceResType =
-          if (isType) defn.QuotedTypeClass.typeRef.appliedTo(WildcardType)
-          else defn.FunctionType(1, isContextual = true).appliedTo(defn.QuoteContextClass.typeRef, defn.QuotedExprClass.typeRef.appliedTo(defn.AnyType)) | defn.QuotedTypeClass.typeRef.appliedTo(WildcardType)
+          defn.FunctionType(1, isContextual = true).appliedTo(defn.QuoteContextClass.typeRef, defn.QuotedExprClass.typeRef.appliedTo(defn.AnyType)) | defn.QuotedTypeClass.typeRef.appliedTo(WildcardType)
         val pickledQuoteStrings = liftList(PickledQuotes.pickleQuote(body).map(x => Literal(Constant(x))), defn.StringType)
         val splicesList = liftList(splices, defn.FunctionType(1).appliedTo(defn.SeqType.appliedTo(defn.AnyType), spliceResType))
         meth.appliedTo(pickledQuoteStrings, splicesList)

--- a/library/src/scala/internal/quoted/Unpickler.scala
+++ b/library/src/scala/internal/quoted/Unpickler.scala
@@ -7,7 +7,7 @@ object Unpickler {
 
   type PickledQuote = List[String]
   type PickledExprArgs = Seq[Seq[Any] => ((QuoteContext ?=> Expr[Any]) | Type[_])]
-  type PickledTypeArgs = Seq[Seq[Any] => Type[_]]
+  type PickledTypeArgs = Seq[Seq[Any] => ((QuoteContext ?=> Expr[Any]) | Type[_])]
 
   /** Unpickle `repr` which represents a pickled `Expr` tree,
    *  replacing splice nodes with `args`

--- a/tests/neg/i8100.scala
+++ b/tests/neg/i8100.scala
@@ -1,0 +1,21 @@
+
+import scala.quoted._
+import scala.quoted.matching._
+
+class M {
+  type E
+}
+
+def f[T: Type](using QuoteContext) =
+  summonExpr[M] match
+    case Some('{ $mm : $tt }) =>
+      '{
+        val m = $mm
+        ${ val b: m.type =
+          m // error
+          ???
+        }
+      }
+
+
+def g[T](using Type[T]) = ???

--- a/tests/pos/i8100.scala
+++ b/tests/pos/i8100.scala
@@ -1,0 +1,25 @@
+
+import scala.quoted._
+import scala.quoted.matching._
+
+class M {
+  type E
+}
+
+def f(using QuoteContext): Expr[Any] =
+  val mm: Expr[M] = ???
+  '{
+    val m: M = $mm
+    type ME = m.E
+    ${ g[ME](using '[ME]) }
+    ${ g[m.E](using '[ME]) }
+    ${ g[ME](using '[m.E]) }
+    ${ g[m.E](using '[m.E]) }
+    // ${ g[ME] } // FIXME
+    // ${ g[m.E] } // FIXME
+    ${ g(using '[ME]) }
+    ${ g(using '[m.E]) }
+  }
+
+
+def g[T](using Type[T]) = ???


### PR DESCRIPTION
Towards fixing #8100

This is an extension of #7682 that handles path-dependent types used in lower levels. 