### PR TITLE
Fix #8101: Change partially-augmented signalling

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AugmentScala2Traits.scala
@@ -65,5 +65,6 @@ class AugmentScala2Traits extends MiniPhase with IdentityDenotTransformer { this
         sym.ensureNotPrivate.installAfter(thisPhase)
     }
     mixin.setFlag(Scala2xPartiallyAugmented)
+    mixin.transformAfter(thisPhase, d => { d.setFlag(Scala2xPartiallyAugmented); d })
   }
 }

--- a/tests/run/i8101/Foo.scala
+++ b/tests/run/i8101/Foo.scala
@@ -1,0 +1,3 @@
+trait Foo {
+  def f: String = ???
+}

--- a/tests/run/i8101/JavaFoo.java
+++ b/tests/run/i8101/JavaFoo.java
@@ -1,0 +1,3 @@
+public abstract class JavaFoo {
+    public abstract int read();
+}

--- a/tests/run/i8101/Test.scala
+++ b/tests/run/i8101/Test.scala
@@ -1,0 +1,6 @@
+class Bar extends JavaFoo with Foo {
+  def read(): Int = ???
+}
+
+@main def Test =
+  val stdout = new Bar


### PR DESCRIPTION
Flags can't be used as non-monotonic signals between phases
since denotations are phase-versioned and later denotations
might exist already when the flag of an earlier denotation is
set. Use two flags instead of one to avoid the non-monotonic change.

Note: I could not make the test fail before doing this change, so I could not
see whether it works now. The test files are in run/i8101. @anatoliykmetyuk can
you verify that this works now, and possibly turn it into a proper test?