### PR TITLE
Fix #7987: Use normal typer when expanding a macro

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/MacroExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/MacroExpansion.scala
@@ -3,6 +3,7 @@ package dotty.tools.dotc.tastyreflect
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core._
 import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.typer.Typer
 import dotty.tools.dotc.util.{Property, SourcePosition, Spans}
 
 object MacroExpansion {
@@ -13,6 +14,6 @@ object MacroExpansion {
     ctx.property(MacroExpansionPosition)
 
   def context(inlinedFrom: tpd.Tree)(implicit ctx: Context): Context =
-    ctx.fresh.setProperty(MacroExpansionPosition, SourcePosition(inlinedFrom.source, inlinedFrom.span)).withSource(inlinedFrom.source)
+    ctx.fresh.setProperty(MacroExpansionPosition, SourcePosition(inlinedFrom.source, inlinedFrom.span)).setTypeAssigner(new Typer).withSource(inlinedFrom.source)
 }
 

--- a/tests/run-macros/i7987.check
+++ b/tests/run-macros/i7987.check
@@ -1,0 +1,12 @@
+scala.deriving.Mirror {
+  type MirroredType >: scala.Some[scala.Int] <: scala.Some[scala.Int]
+  type MirroredMonoType >: scala.Some[scala.Int] <: scala.Some[scala.Int]
+  type MirroredElemTypes >: scala.Nothing <: scala.Tuple
+} & scala.deriving.Mirror.Product {
+  type MirroredMonoType >: scala.Some[scala.Int] <: scala.Some[scala.Int]
+  type MirroredType >: scala.Some[scala.Int] <: scala.Some[scala.Int]
+  type MirroredLabel >: "Some" <: "Some"
+} {
+  type MirroredElemTypes >: scala.*:[scala.Int, scala.Unit] <: scala.*:[scala.Int, scala.Unit]
+  type MirroredElemLabels >: scala.*:["value", scala.Unit] <: scala.*:["value", scala.Unit]
+}

--- a/tests/run-macros/i7987/Macros_1.scala
+++ b/tests/run-macros/i7987/Macros_1.scala
@@ -1,0 +1,12 @@
+import scala.quoted._
+import scala.deriving._
+import scala.quoted.matching._
+
+object Macros {
+  inline def m(): String = ${ macroImpl() }
+
+  def macroImpl[T]()(given qctx: QuoteContext): Expr[String] = {
+    summonExpr[Mirror.Of[Some[Int]]] match
+      case Some('{ $_ : $t }) => Expr(t.show)
+  }
+}

--- a/tests/run-macros/i7987/Test_2.scala
+++ b/tests/run-macros/i7987/Test_2.scala
@@ -1,0 +1,3 @@
+@main def Test() = {
+  println(Macros.m())
+}


### PR DESCRIPTION
The current typer was an `InlineTyper` which was not doing the correct thing when synthesizing implicits.