### PR TITLE
Fix #8084: Fix atoms computation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1158,7 +1158,7 @@ object Types {
      *  Overridden and cached in OrType.
      */
     def atoms(implicit ctx: Context): Set[Type] = dealias match {
-      case tp: SingletonType if tp.isStable =>
+      case tp: SingletonType =>
         def normalize(tp: Type): Type = tp match {
           case tp: SingletonType =>
             tp.underlying.dealias match {
@@ -1172,7 +1172,7 @@ object Types {
           case _ => tp
         }
         val underlyingAtoms = tp.underlying.atoms
-        if (underlyingAtoms.isEmpty) Set.empty + normalize(tp)
+        if (underlyingAtoms.isEmpty && tp.isStable) Set.empty + normalize(tp)
         else underlyingAtoms
       case tp: ExprType => tp.resType.atoms
       case tp: OrType => tp.atoms // `atoms` overridden in OrType

--- a/tests/pos/i8084.scala
+++ b/tests/pos/i8084.scala
@@ -1,0 +1,14 @@
+class Z
+class O
+object Test0 {
+  def foo(x: Z | O) = ()
+  def bar: Z | O = O()
+  foo(bar)
+}
+
+object Test {
+  def foo(x: 0 | 1) = ()
+  def bar: 0 | 1 = 0
+  foo(bar)
+}
+


### PR DESCRIPTION
The `isStable` test was at the wrong place.