### PR TITLE
Fix genDoc script. Make sure main website is generated on snapshot.

### DIFF
--- a/doc-tool/src/dotty/tools/dottydoc/DocDriver.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/DocDriver.scala
@@ -46,25 +46,27 @@ class DocDriver extends Driver {
     val projectUrl = Option(ctx.settings.projectUrl.value).filter(_.nonEmpty)
     val projectLogo = Option(ctx.settings.projectLogo.value).filter(_.nonEmpty)
     val docSnapshot = ctx.settings.docSnapshot.value
-    var baseUrl = "/"
 
-    var outDir = File(siteRoot, "_site")
-    if docSnapshot then
-      val folderName = if projectVersion.endsWith("NIGHTLY") then "nightly" else projectVersion
-      outDir = File(outDir, folderName)
-      baseUrl = s"$baseUrl$folderName"
+    val baseUrl = "/"
+    val outDir = File(siteRoot, "_site")
+    val snapshotFolderName = if projectVersion.endsWith("NIGHTLY") then "nightly" else projectVersion
+    val snapshotOutDir = File(outDir, snapshotFolderName)
+    val snapshotBaseUrl = s"$baseUrl$snapshotFolderName"
 
     if (projectName.isEmpty)
       ctx.error(s"Site project name not set. Use `-project <title>` to set the project name")
     else if (!siteRoot.exists || !siteRoot.isDirectory)
       ctx.error(s"Site root does not exist: $siteRoot")
     else {
-      Site(siteRoot, outDir, projectName, projectVersion, projectUrl, projectLogo, ctx.docbase.packages, baseUrl)
-        .generateApiDocs()
-        .copyStaticFiles()
-        .generateHtmlFiles()
-        .generateBlog()
+      def generateSite(outDir: File, baseUrl: String) =
+        Site(siteRoot, outDir, projectName, projectVersion, projectUrl, projectLogo, ctx.docbase.packages, baseUrl)
+          .generateApiDocs()
+          .copyStaticFiles()
+          .generateHtmlFiles()
+          .generateBlog()
 
+      generateSite(outDir, baseUrl)
+      if docSnapshot then generateSite(snapshotOutDir, snapshotBaseUrl)
       ctx.docbase.printSummary()
     }
 

--- a/project/scripts/genDocs
+++ b/project/scripts/genDocs
@@ -41,7 +41,10 @@ git fetch doc-remote gh-pages
 git checkout gh-pages
 
 # save the old snapshots to the newly generated site
-mv 0.*/ $PWD/docs/_site
+# This command must never fail since failures short-circuit the script
+# The reason for failure is that no folder matches "0.*" pattern
+# because snapshots may not be generated yet
+(mv 0.*/ $PWD/docs/_site; true)
 
 # move newly generated _site dir to $PWD
 mv $PWD/docs/_site .


### PR DESCRIPTION
When building a snapshot of the documentation, we must
also build the main website. Essentially this means generating
the same website twice, one time in the root directory,
the second time in the $version/ subdirectory of the root.

This is so because the contents of the github website will be
completely overwritten by the result of the `genDocs` command.
Hence, when the command is run with `-doc-snapshot` flag,
we must not only capture the doc snapshot but also generate the valid
website.