### PR TITLE
fix union type sample code to compile

### DIFF
--- a/docs/docs/reference/new-types/union-types-spec.md
+++ b/docs/docs/reference/new-types/union-types-spec.md
@@ -71,6 +71,7 @@ Given
 ```scala
 trait C[+T]
 trait D
+trait E
 class A extends C[A] with D
 class B extends C[B] with D with E
 ```


### PR DESCRIPTION
This fixes typo to make Union Type sample code in its document to compile.