### PR TITLE
Fix #8128: Fix atoms computations

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -141,6 +141,12 @@ object Config {
    */
   final val checkUnerased = false
 
+  /** Check that atoms-based comparisons match regular comparisons that do not
+   *  take atoms into account. The two have to give the same results, since
+   *  atoms comparison is intended to be just an optimization.
+   */
+  final val checkAtomsComparisons = false
+
   /** In `derivedSelect`, rewrite
    *
    *      (S & T)#A  -->  S#A & T#A

--- a/compiler/src/dotty/tools/dotc/core/Atoms.scala
+++ b/compiler/src/dotty/tools/dotc/core/Atoms.scala
@@ -1,0 +1,33 @@
+package dotty.tools
+package dotc
+package core
+
+import Types._
+
+/** Indicates the singleton types that a type must or may consist of.
+ *  @param lo   The lower bound: singleton types in this set are guaranteed
+ *              to be in the carrier type.
+ *  @param hi   The upper bound: all singleton types in the carrier type are
+ *              guaranteed to be in this set
+ *  If the underlying type of a singleton type is another singleton type,
+ *  only the latter type ends up in the sets.
+ */
+enum Atoms:
+  case Range(lo: Set[Type], hi: Set[Type])
+  case Unknown
+
+  def & (that: Atoms): Atoms = this match
+    case Range(lo1, hi1) =>
+      that match
+        case Range(lo2, hi2) => Range(lo1 & lo2, hi1 & hi2)
+        case Unknown => this
+    case Unknown => that
+
+  def | (that: Atoms): Atoms = this match
+    case Range(lo1, hi1) =>
+      that match
+        case Range(lo2, hi2) => Range(lo1 | lo2, hi1 | hi2)
+        case Unknown => Unknown
+    case Unknown => Unknown
+
+end Atoms

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1183,7 +1183,8 @@ object Types {
           case _ => tp
         tp.underlying.atoms match
           case as @ Atoms.Range(lo, hi) =>
-            if hi.size == 1 then as else Atoms.Range(Set.empty, hi)
+            if hi.size == 1 then as // if there's just one atom, there's no uncertainty which one it is
+            else Atoms.Range(Set.empty, hi)
           case Atoms.Unknown =>
             if tp.isStable then
               val single = Set.empty + normalize(tp)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1188,8 +1188,9 @@ object Types {
           case _ => tp
         }
         val underlyingAtoms = tp.underlying.atoms(widenOK)
-        if (underlyingAtoms.isEmpty && tp.isStable) Set.empty + normalize(tp)
-        else underlyingAtoms
+        if underlyingAtoms.isEmpty && tp.isStable then Set.empty + normalize(tp)
+        else if underlyingAtoms.size == 1 || widenOK then underlyingAtoms
+        else Set.empty
       case tp: ExprType => tp.resType.atoms(widenOK)
       case tp: OrType => tp.atoms(widenOK) // `atoms` overridden in OrType
       case tp: AndType => tp.tp1.atoms(widenOK) & tp.tp2.atoms(widenOK)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -146,7 +146,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
         else
           toTextPrefix(tp.prefix) ~ selectionString(tp)
       case tp: TermParamRef =>
-        ParamRefNameString(tp) ~ ".type"
+        ParamRefNameString(tp) ~ lambdaHash(tp.binder) ~ ".type"
       case tp: TypeParamRef =>
         ParamRefNameString(tp) ~ lambdaHash(tp.binder)
       case tp: SingletonType =>
@@ -237,9 +237,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
   def toTextSingleton(tp: SingletonType): Text =
     "(" ~ toTextRef(tp) ~ " : " ~ toTextGlobal(tp.underlying) ~ ")"
 
-  protected def paramsText(tp: LambdaType): Text = {
-    def paramText(name: Name, tp: Type) = toText(name) ~ toTextRHS(tp)
-    Text(tp.paramNames.lazyZip(tp.paramInfos).map(paramText), ", ")
+  protected def paramsText(lam: LambdaType): Text = {
+    def paramText(name: Name, tp: Type) =
+      toText(name) ~ lambdaHash(lam) ~ toTextRHS(tp)
+    Text(lam.paramNames.lazyZip(lam.paramInfos).map(paramText), ", ")
   }
 
   protected def ParamRefNameString(name: Name): String = name.toString

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -212,7 +212,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         toTextInfixType(tpnme.raw.BAR, tp1, tp2) { toText(tpnme.raw.BAR) }
       case EtaExpansion(tycon) if !printDebug =>
         toText(tycon)
-      case tp: RefinedType if defn.isFunctionType(tp) =>
+      case tp: RefinedType if defn.isFunctionType(tp) && !printDebug =>
         toTextDependentFunction(tp.refinedInfo.asInstanceOf[MethodType])
       case tp: TypeRef =>
         if (tp.symbol.isAnonymousClass && !ctx.settings.uniqid.value)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -926,27 +926,21 @@ class Typer extends Namer
         isContextual = funFlags.is(Given), isErased = funFlags.is(Erased))
 
     /** Typechecks dependent function type with given parameters `params` */
-    def typedDependent(params: List[ValDef])(implicit ctx: Context): Tree = {
-      completeParams(params)
-      val params1 = params.map(typedExpr(_).asInstanceOf[ValDef])
-      if (!funFlags.isEmpty)
-        params1.foreach(_.symbol.setFlag(funFlags))
-      val resultTpt = typed(body)
-      val companion = MethodType.companion(
-          isContextual = funFlags.is(Given), isErased = funFlags.is(Erased))
-      val mt = companion.fromSymbols(params1.map(_.symbol), resultTpt.tpe)
+    def typedDependent(params: List[ValDef])(implicit ctx: Context): Tree =
+      val params1 =
+        if funFlags.is(Given) then params.map(_.withAddedFlags(Given))
+        else params
+      val appDef0 = untpd.DefDef(nme.apply, Nil, List(params1), body, EmptyTree).withSpan(tree.span)
+      index(appDef0 :: Nil)
+      val appDef = typed(appDef0).asInstanceOf[DefDef]
+      val mt = appDef.symbol.info.asInstanceOf[MethodType]
       if (mt.isParamDependent)
         ctx.error(i"$mt is an illegal function type because it has inter-parameter dependencies", tree.sourcePos)
       val resTpt = TypeTree(mt.nonDependentResultApprox).withSpan(body.span)
-      val typeArgs = params1.map(_.tpt) :+ resTpt
+      val typeArgs = appDef.vparamss.head.map(_.tpt) :+ resTpt
       val tycon = TypeTree(funCls.typeRef)
-      val core = assignType(cpy.AppliedTypeTree(tree)(tycon, typeArgs), tycon, typeArgs)
-      val appMeth = ctx.newSymbol(ctx.owner, nme.apply, Synthetic | Method | Deferred, mt, coord = body.span)
-      val appDef = assignType(
-        untpd.DefDef(appMeth.name, Nil, List(params1), resultTpt, EmptyTree),
-        appMeth).withSpan(body.span)
+      val core = AppliedTypeTree(tycon, typeArgs)
       RefinedTypeTree(core, List(appDef), ctx.owner.asClass)
-    }
 
     args match {
       case ValDef(_, _, _) :: _ =>

--- a/tests/pos/i8128.scala
+++ b/tests/pos/i8128.scala
@@ -1,5 +1,5 @@
 object Test {
-  def id: (x: 1 | 0) => x.type = ??? // x => x does not work yet
+  def id: (x: 1 | 0) => x.type = x => x
   id(0): 0   // ok
 
   def id2: Function1[1 | 0, 1 | 0] {

--- a/tests/pos/i8128.scala
+++ b/tests/pos/i8128.scala
@@ -1,4 +1,14 @@
 object Test {
   def id: (x: 1 | 0) => x.type = x => x
-  id(0): 0
+  id(0): 0   // fails
+
+  def id2: Function1[1 | 0, 1 | 0] {
+    def apply(x: 1 | 0): x.type
+  } = ???
+  id2(0): 0  // fails
+
+  def id3: Function1[1 | 0, Int] {
+    def apply(x: 1 | 0): x.type
+  } = ???
+  id3(0): 0  // ok
 }

--- a/tests/pos/i8128.scala
+++ b/tests/pos/i8128.scala
@@ -1,0 +1,4 @@
+object Test {
+  def id: (x: 1 | 0) => x.type = x => x
+  id(0): 0
+}

--- a/tests/pos/i8128.scala
+++ b/tests/pos/i8128.scala
@@ -1,11 +1,11 @@
 object Test {
-  def id: (x: 1 | 0) => x.type = x => x
-  id(0): 0   // fails
+  def id: (x: 1 | 0) => x.type = ???
+  id(0): 0   // ok
 
   def id2: Function1[1 | 0, 1 | 0] {
     def apply(x: 1 | 0): x.type
   } = ???
-  id2(0): 0  // fails
+  id2(0): 0  // ok
 
   def id3: Function1[1 | 0, Int] {
     def apply(x: 1 | 0): x.type

--- a/tests/pos/i8128.scala
+++ b/tests/pos/i8128.scala
@@ -1,5 +1,5 @@
 object Test {
-  def id: (x: 1 | 0) => x.type = ???
+  def id: (x: 1 | 0) => x.type = ??? // x => x does not work yet
   id(0): 0   // ok
 
   def id2: Function1[1 | 0, 1 | 0] {
@@ -11,4 +11,9 @@ object Test {
     def apply(x: 1 | 0): x.type
   } = ???
   id3(0): 0  // ok
+
+  var x: 0 = 0
+  var y: (1 & 0) | 0 = 0
+  x = y
+  y = x
 }


### PR DESCRIPTION
Several fixes related to how atoms are computed, which fixes some problems when comparing unions of singleton types. It's a partial fix of #8128. There's still some problem with typing dependent functions over singleton types (see commented out code in i8128.scala). This problem does not look related to atoms, however. 

Since I won't have time to work on this right now, it's better to get the fixes in this PR in independently.

UPDATE: I managed to find and fix the remaining problem. The fix meant that all intermediate commits were superseded because the structure to compute atoms had to be changed again. So this is best reviewed without looking at individual commits.
