### PR TITLE
Fix typos in language.scala

### DIFF
--- a/library/src/scalaShadowing/language.scala
+++ b/library/src/scalaShadowing/language.scala
@@ -225,7 +225,7 @@ object language {
    *  compilation units are allowed.
    *
    *  '''Why control the feature?''' Ad-hoc extensions should usually be avoided
-   *  since they typically cannot reply on an "internal" contract between a class
+   *  since they typically cannot rely on an "internal" contract between a class
    *  and its extensions. Only open classes need to specify such a contract.
    *  Ad-hoc extensions might break for future versions of the extended class,
    *  since the extended class is free to change its implementation without

--- a/library/src/scalaShadowing/language.scala
+++ b/library/src/scalaShadowing/language.scala
@@ -28,7 +28,7 @@ package scalaShadowing
  *
  *  and, for dotty:
  *
- *   - [[Scala2              `Scala2`]               backwards compatibility mode for Scala2
+ *   - [[Scala2              `Scala2`]]              backwards compatibility mode for Scala2
  *   - [[noAtoTupling        `noAutoTupling`]]       disable auto-tupling
  *   - [[strictEquality      `strictEquality`]]      enable strick equality
  *

--- a/library/src/scalaShadowing/language.scala
+++ b/library/src/scalaShadowing/language.scala
@@ -29,7 +29,7 @@ package scalaShadowing
  *  and, for dotty:
  *
  *   - [[Scala2              `Scala2`]]              backwards compatibility mode for Scala2
- *   - [[noAtoTupling        `noAutoTupling`]]       disable auto-tupling
+ *   - [[noAutoTupling       `noAutoTupling`]]       disable auto-tupling
  *   - [[strictEquality      `strictEquality`]]      enable strick equality
  *
  *  @groupname production   Language Features


### PR DESCRIPTION
This PR fixes some simple typos in `language.scala`