### PR TITLE
Fix #8203: handle intersection type in parent registration

### DIFF
--- a/tests/patmat/i8203.scala
+++ b/tests/patmat/i8203.scala
@@ -1,0 +1,19 @@
+sealed trait Pretty { self: Color => }
+sealed trait Dull { self: Color => }
+enum Color  {
+  case Pink extends Color with Pretty
+  case Red extends Color with Dull
+}
+
+def describe(c: Color) = c match {
+  case Color.Pink => "Amazing!"
+  case Color.Red => "Yawn..."
+}
+
+def describe2(c: Pretty) = c match {
+  case Color.Pink => "Amazing!"
+}
+
+def describe3(c: Dull) = c match {
+  case Color.Red => "Yawn..."
+}


### PR DESCRIPTION
Fix #8203: handle intersection type in parent registration

An enum value may have the type `A & B`, in such cases we
need to register for both `A` and `B`.