### PR TITLE
Generalize TypeBoundsTree to bounded opaque aliases

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1156,7 +1156,8 @@ object desugar {
   val legalOpaque: MemberDefTest = {
     case TypeDef(_, rhs) =>
       def rhsOK(tree: Tree): Boolean = tree match {
-        case _: TypeBoundsTree | _: Template => false
+        case bounds: TypeBoundsTree => !bounds.alias.isEmpty
+        case _: Template => false
         case LambdaTypeTree(_, body) => rhsOK(body)
         case _ => true
       }

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -252,7 +252,7 @@ object desugar {
 
     if (meth1.mods.is(Inline))
       meth1.tpt match {
-        case TypeBoundsTree(_, tpt1) =>
+        case TypeBoundsTree(_, tpt1, _) =>
           meth1 = cpy.DefDef(meth1)(tpt = tpt1)
         case tpt if !tpt.isEmpty && !meth1.rhs.isEmpty =>
           meth1 = cpy.DefDef(meth1)(rhs = Typed(meth1.rhs, tpt))
@@ -684,7 +684,7 @@ object desugar {
           val mods = constr1.mods
           mods.is(Private) || (!mods.is(Protected) && mods.hasPrivateWithin)
         }
- 
+
         /** Does one of the parameter's types (in the first param clause)
          *  mention a preceding parameter?
          */

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -814,8 +814,6 @@ object Trees {
     extends ProxyTree[T] {
     type ThisTree[-T >: Untyped] = Annotated[T]
     def forwardTo: Tree[T] = arg
-    override def disableOverlapChecks = true
-      // disable overlaps checks since the WithBounds annotation swaps type and annotation.
   }
 
   trait WithoutTypeOrPos[-T >: Untyped] extends Tree[T] {

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -179,8 +179,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def MatchTypeTree(bound: Tree, selector: Tree, cases: List[CaseDef])(implicit ctx: Context): MatchTypeTree =
     ta.assignType(untpd.MatchTypeTree(bound, selector, cases), bound, selector, cases)
 
-  def TypeBoundsTree(lo: Tree, hi: Tree)(implicit ctx: Context): TypeBoundsTree =
-    ta.assignType(untpd.TypeBoundsTree(lo, hi), lo, hi)
+  def TypeBoundsTree(lo: Tree, hi: Tree, alias: Tree = EmptyTree)(implicit ctx: Context): TypeBoundsTree =
+    ta.assignType(untpd.TypeBoundsTree(lo, hi, alias), lo, hi, alias)
 
   def Bind(sym: Symbol, body: Tree)(implicit ctx: Context): Bind =
     ta.assignType(untpd.Bind(sym.name, body), sym)

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -376,7 +376,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def LambdaTypeTree(tparams: List[TypeDef], body: Tree)(implicit src: SourceFile): LambdaTypeTree = new LambdaTypeTree(tparams, body)
   def MatchTypeTree(bound: Tree, selector: Tree, cases: List[CaseDef])(implicit src: SourceFile): MatchTypeTree = new MatchTypeTree(bound, selector, cases)
   def ByNameTypeTree(result: Tree)(implicit src: SourceFile): ByNameTypeTree = new ByNameTypeTree(result)
-  def TypeBoundsTree(lo: Tree, hi: Tree)(implicit src: SourceFile): TypeBoundsTree = new TypeBoundsTree(lo, hi)
+  def TypeBoundsTree(lo: Tree, hi: Tree, alias: Tree = EmptyTree)(implicit src: SourceFile): TypeBoundsTree = new TypeBoundsTree(lo, hi, alias)
   def Bind(name: Name, body: Tree)(implicit src: SourceFile): Bind = new Bind(name, body)
   def Alternative(trees: List[Tree])(implicit src: SourceFile): Alternative = new Alternative(trees)
   def UnApply(fun: Tree, implicits: List[Tree], patterns: List[Tree])(implicit src: SourceFile): UnApply = new UnApply(fun, implicits, patterns)

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -173,22 +173,6 @@ object Annotations {
         else None
     }
 
-    /** Extractor for WithBounds[T] annotations */
-    object WithBounds {
-      def unapply(ann: Annotation)(implicit ctx: Context): Option[TypeBounds] =
-        if (ann.symbol == defn.WithBoundsAnnot) {
-          import ast.Trees._
-          // We need to extract the type of the type tree in the New itself.
-          // The annotation's type has been simplified as the type of an expression,
-          // which means that `&` or `|` might have been lost.
-          // Test in pos/reference/opaque.scala
-          val Apply(TypeApply(Select(New(tpt), nme.CONSTRUCTOR), _), Nil) = ann.tree
-          val AppliedType(_, lo :: hi :: Nil) = tpt.tpe
-          Some(TypeBounds(lo, hi))
-        }
-        else None
-    }
-
     def makeSourceFile(path: String)(implicit ctx: Context): Annotation =
       apply(defn.SourceFileAnnot, Literal(Constant(path)))
   }

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -784,7 +784,6 @@ class Definitions {
   @tu lazy val AnnotationDefaultAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.internal.AnnotationDefault")
   @tu lazy val BodyAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.internal.Body")
   @tu lazy val ChildAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.internal.Child")
-  @tu lazy val WithBoundsAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.internal.WithBounds")
   @tu lazy val CovariantBetweenAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.internal.CovariantBetween")
   @tu lazy val ContravariantBetweenAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.internal.ContravariantBetween")
   @tu lazy val DeprecatedAnnot: ClassSymbol = ctx.requiredClass("scala.deprecated")

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -588,11 +588,15 @@ class TreePickler(pickler: TastyPickler) {
         case LambdaTypeTree(tparams, body) =>
           writeByte(LAMBDAtpt)
           withLength { pickleParams(tparams); pickleTree(body) }
-        case TypeBoundsTree(lo, hi) =>
+        case TypeBoundsTree(lo, hi, alias) =>
           writeByte(TYPEBOUNDStpt)
           withLength {
             pickleTree(lo);
-            if (hi ne lo) pickleTree(hi)
+            if alias.isEmpty then
+              if hi ne lo then pickleTree(hi)
+            else
+              pickleTree(hi)
+              pickleTree(alias)
           }
         case Hole(_, idx, args) =>
           writeByte(HOLE)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -833,11 +833,12 @@ class TreeUnpickler(reader: TastyReader,
               override def completerTypeParams(sym: Symbol)(implicit ctx: Context) =
                 rhs.tpe.typeParams
             }
-            sym.info = sym.opaqueToBounds {
-              rhs.tpe match
+            sym.info = sym.opaqueToBounds(
+              rhs.tpe match {
                 case _: TypeBounds | _: ClassInfo => checkNonCyclic(sym, rhs.tpe, reportErrors = false)
                 case _ => rhs.tpe.toBounds
-            }
+              },
+              rhs)
             if sym.isOpaqueAlias then sym.typeRef.recomputeDenot() // make sure we see the new bounds from now on
             sym.resetFlag(Provisional)
             TypeDef(rhs)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1209,8 +1209,9 @@ class TreeUnpickler(reader: TastyReader,
               MatchTypeTree(bound, scrut, readCases(end))
             case TYPEBOUNDStpt =>
               val lo = readTpt()
-              val hi = if (currentAddr == end) lo else readTpt()
-              TypeBoundsTree(lo, hi)
+              val hi = if currentAddr == end then lo else readTpt()
+              val alias = if currentAddr == end then EmptyTree else readTpt()
+              TypeBoundsTree(lo, hi, alias)
             case HOLE =>
               readHole(end, isType = false)
             case _ =>

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3344,7 +3344,7 @@ object Parsers {
               rhs match {
                 case mtt: MatchTypeTree =>
                   bounds match {
-                    case TypeBoundsTree(EmptyTree, upper) =>
+                    case TypeBoundsTree(EmptyTree, upper, _) =>
                       rhs = MatchTypeTree(upper, mtt.selector, mtt.cases)
                     case _ =>
                       syntaxError(i"cannot combine lower bound and match type alias", eqOffset)
@@ -3568,7 +3568,7 @@ object Parsers {
             DefDef(name, tparams, vparamss, parents.head, subExpr())
           else
             parents match
-              case TypeBoundsTree(_, _) :: _ => syntaxError("`=` expected")
+              case (_: TypeBoundsTree) :: _ => syntaxError("`=` expected")
               case _ =>
             possibleTemplateStart()
             val tparams1 = tparams.map(tparam => tparam.withMods(tparam.mods | PrivateLocal))

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3350,14 +3350,10 @@ object Parsers {
                       syntaxError(i"cannot combine lower bound and match type alias", eqOffset)
                   }
                 case _ =>
-                  if (mods.is(Opaque)) {
-                    val annotType = AppliedTypeTree(
-                      TypeTree(defn.WithBoundsAnnot.typeRef),
-                        bounds.lo.orElse(TypeTree(defn.NothingType)) ::
-                        bounds.hi.orElse(TypeTree(defn.AnyType)) :: Nil)
-                    rhs = Annotated(rhs, ensureApplied(wrapNew(annotType)))
-                  }
-                  else syntaxError(i"cannot combine bound and alias", eqOffset)
+                  if mods.is(Opaque) then
+                    rhs = TypeBoundsTree(bounds.lo, bounds.hi, rhs)
+                  else
+                    syntaxError(i"cannot combine bound and alias", eqOffset)
               }
               makeTypeDef(rhs)
             }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -492,9 +492,9 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         }
       case ByNameTypeTree(tpt) =>
         "=> " ~ toTextLocal(tpt)
-      case TypeBoundsTree(lo, hi) =>
-        if (lo eq hi) optText(lo)(" = " ~ _)
-        else optText(lo)(" >: " ~ _) ~ optText(hi)(" <: " ~ _)
+      case TypeBoundsTree(lo, hi, alias) =>
+        if (lo eq hi) && alias.isEmpty then optText(lo)(" = " ~ _)
+        else optText(lo)(" >: " ~ _) ~ optText(hi)(" <: " ~ _) ~ optText(alias)(" = " ~ _)
       case Bind(name, body) =>
         keywordText("given ").provided(tree.symbol.isOneOf(GivenOrImplicit) && !homogenizedView) ~ // Used for scala.quoted.Type in quote patterns (not pickled)
         changePrec(InfixPrec) { toText(name) ~ " @ " ~ toText(body) }

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -136,7 +136,7 @@ class ReifyQuotes extends MacroTransform {
       def mkTagSymbolAndAssignType(spliced: TermRef): TypeDef = {
         val splicedTree = tpd.ref(spliced).withSpan(expr.span)
         val rhs = transform(splicedTree.select(tpnme.splice))
-        val alias = ctx.typeAssigner.assignType(untpd.TypeBoundsTree(rhs, rhs), rhs, rhs)
+        val alias = ctx.typeAssigner.assignType(untpd.TypeBoundsTree(rhs, rhs), rhs, rhs, EmptyTree)
         val local = ctx.newSymbol(
           owner = ctx.owner,
           name = UniqueName.fresh((splicedTree.symbol.name.toString + "$_").toTermName).toTypeName,

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -997,12 +997,13 @@ class Namer { typer: Typer =>
       }
       sym.info = dummyInfo2
 
-      val rhsBodyType: TypeBounds = typedAheadType(rhs).tpe.toBounds
+      val rhs1 = typedAheadType(rhs)
+      val rhsBodyType: TypeBounds = rhs1.tpe.toBounds
       val unsafeInfo = if (isDerived) rhsBodyType else abstracted(rhsBodyType)
       if (isDerived) sym.info = unsafeInfo
       else {
         sym.info = NoCompleter
-        sym.info = sym.opaqueToBounds(checkNonCyclic(sym, unsafeInfo, reportErrors = true))
+        sym.info = sym.opaqueToBounds(checkNonCyclic(sym, unsafeInfo, reportErrors = true), rhs1)
       }
       if sym.isOpaqueAlias then sym.typeRef.recomputeDenot() // make sure we see the new bounds from now on
       sym.resetFlag(Provisional)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -607,8 +607,11 @@ trait TypeAssigner {
   def assignType(tree: untpd.ByNameTypeTree, result: Tree)(implicit ctx: Context): ByNameTypeTree =
     tree.withType(ExprType(result.tpe))
 
-  def assignType(tree: untpd.TypeBoundsTree, lo: Tree, hi: Tree)(implicit ctx: Context): TypeBoundsTree =
-    tree.withType(if (lo eq hi) TypeAlias(lo.tpe) else TypeBounds(lo.tpe, hi.tpe))
+  def assignType(tree: untpd.TypeBoundsTree, lo: Tree, hi: Tree, alias: Tree)(implicit ctx: Context): TypeBoundsTree =
+    tree.withType(
+      if !alias.isEmpty then alias.tpe
+      else if lo eq hi then TypeAlias(lo.tpe)
+      else TypeBounds(lo.tpe, hi.tpe))
 
   def assignType(tree: untpd.Bind, sym: Symbol)(implicit ctx: Context): Bind =
     tree.withType(NamedType(NoPrefix, sym))

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -253,7 +253,7 @@ Standard Section: "Comments" Comment*
 object TastyFormat {
 
   final val header: Array[Int] = Array(0x5C, 0xA1, 0xAB, 0x1F)
-  val MajorVersion: Int = 19
+  val MajorVersion: Int = 20
   val MinorVersion: Int = 0
 
   /** Tags used to serialize names, should update [[nameTagToString]] if a new constant is added */


### PR DESCRIPTION

The RHS of an opaque type can consist of three parts:
```
  >: loBound <: hiBound = alias
```
This is encoded so far in a `WithBounds` annotation, but that mechanism means
hidden complexity for the Tasty standard. We now encode the alias directly,
as an optional third argument to a TypeBoundsTree structure.

Note: This needs an update of Tasty reader and Tasty reflection.