### PR TITLE
Upgrade to Scala.js 1.0.0.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,10 +2,7 @@
 //
 // e.g. addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
 
-// DO NOT update this plugin without regenerating our Docker
-// image (https://github.com/lampepfl/dotty-drone) or fixing
-// https://github.com/lampepfl/dotty/issues/3146.
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-RC2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.6")
 


### PR DESCRIPTION
Contrary to 1.0.0-RC2, Scala.js 1.0.0 respects custom repositories for resolving artifacts, so regenerating the Docket images is not necessary anymore.

@smarter Please double-check that the custom repositories are indeed taken into account.