### PR TITLE
Remove unneccassary cast to URLClassLoader, which breaks on JDK 11

### DIFF
--- a/sbt-bridge/src/xsbt/CompilerClassLoader.java
+++ b/sbt-bridge/src/xsbt/CompilerClassLoader.java
@@ -110,7 +110,7 @@ public class CompilerClassLoader extends URLClassLoader {
       Field parentBField = dualLoaderClass.getDeclaredField("parentB");
       parentBField.setAccessible(true);
       URLClassLoader scalaLoader = (URLClassLoader) parentAField.get(dualLoader);
-      URLClassLoader sbtLoader = (URLClassLoader) parentBField.get(dualLoader);
+      ClassLoader sbtLoader = (ClassLoader) parentBField.get(dualLoader);
 
       URL[] bridgeURLs = urlBridgeLoader.getURLs();
       return new URLClassLoader(bridgeURLs,


### PR DESCRIPTION
This is related to test failures on https://github.com/scalacenter/bloop/pull/1165 and came up as a part of our work on making Metals work for Scala 3

Let me know if we should fix it a different way.
