### PR TITLE
Fix #8111: Use better algorithms to infer parameter types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -19,6 +19,7 @@ import typer.Applications._
 import typer.ProtoTypes._
 import typer.ForceDegree
 import typer.Inferencing.isFullyDefined
+import typer.IfBottom
 
 import scala.annotation.internal.sharable
 
@@ -644,7 +645,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
       tvar =>
         !(ctx.typerState.constraint.entry(tvar.origin) `eq` tvar.origin.underlying) ||
         (tvar `eq` removeThisType.prefixTVar),
-      allowBottom = false
+      IfBottom.flip
     )
 
     // If parent contains a reference to an abstract type, then we should

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1865,7 +1865,7 @@ trait Applications extends Compatibility {
                 if (isPartial) defn.PartialFunctionOf(commonParamTypes.head, WildcardType)
                 else defn.FunctionOf(commonParamTypes, WildcardType)
               overload.println(i"pretype arg $arg with expected type $commonFormal")
-              if (commonParamTypes.forall(isFullyDefined(_, ForceDegree.noBottom)))
+              if (commonParamTypes.forall(isFullyDefined(_, ForceDegree.flipBottom)))
                 pt.typedArg(arg, commonFormal)(ctx.addMode(Mode.ImplicitsEnabled))
             }
           case None =>

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -150,9 +150,14 @@ object Inferencing {
           if !tvar.isInstantiated then
             instantiate(tvar, fromBelow = false)
         case nil =>
-      val res = apply(true, tp)
-      if res then maximize(toMaximize)
-      res
+      apply(true, tp)
+      && (
+        toMaximize.isEmpty
+        || { maximize(toMaximize)
+             toMaximize = Nil       // Do another round since the maximixing instances
+             process(tp)            // might have type uninstantiated variables themselves.
+           }
+      )
   }
 
   /** For all type parameters occurring in `tp`:

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -276,7 +276,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
   // Make sure all type arguments to the call are fully determined,
   // but continue if that's not achievable (or else i7459.scala would crash).
   for arg <- callTypeArgs do
-    isFullyDefined(arg.tpe, ForceDegree.noBottom)
+    isFullyDefined(arg.tpe, ForceDegree.flipBottom)
 
   /** A map from parameter names of the inlineable method to references of the actual arguments.
    *  For a type argument this is the full argument type.

--- a/tests/pos/i8111.scala
+++ b/tests/pos/i8111.scala
@@ -1,0 +1,10 @@
+object Example extends App {
+
+  def assertLazy[A, B](f: (A) => B): Boolean = ???
+
+  def fromEither[E, F](eea: Either[E, F]): Unit = ???
+
+  lazy val result = assertLazy(fromEither)
+
+  println("It compiles!")
+}


### PR DESCRIPTION
An inferred parameter type I has two possible sources:

 - the type S known from the context
 - the type T known from the callee `f` if the lambda is of a form like `x => f(x)`

If `T` exists, we know that `S <: I <: T`. In this commit we make use of this information in order
to be more intelligent how the type I is inferred.

This change required two other fixes. 

First, we need to be more precise in `IsFullyDefinedAccumulator`. Previously, a maximized type variable could be instantiated to a type that contains more type variables. These have to be instantiated
in turn, but were not. 5e59f87

Second, we need to make `calleeType`  retractable since it is no longer just a part of last-ditch effort with no alternatives remaining.. Previously, it was not. 4c84ee8
