### PR TITLE
doc(inline): improve recursive example

### DIFF
--- a/docs/docs/reference/metaprogramming/inline.md
+++ b/docs/docs/reference/metaprogramming/inline.md
@@ -121,23 +121,29 @@ power(expr, 10)
 ```
 
 Parameters of inline methods can have an `inline` modifier as well. This means
-that actual arguments to these parameters will be inlined in the body of the `inline def`.
-`inline` parameter have call semantics equivalent to by-name parameters but allows for duplication
-of the code in the argument. It is usualy useful constant values need to be propagated to allow
-further optimizations/reductions.
+that actual arguments to these parameters will be inlined in the body of the 
+`inline def`. `inline` parameters have call semantics equivalent to by-name parameters 
+but allow for duplication of the code in the argument. It is usualy useful constant 
+values need to be propagated to allow further optimizations/reductions.
 
 The following example shows the difference in translation between by-value, by-name and `inline`
 parameters:
 
 ```scala
-inline def sumTwice(a: Int, b: =>Int, inline c: Int) = a + a + b + b + c + c
+inline def specialSum(a: Int, b: =>Int, inline c: Int) =
+ (if(a < 2) a else 0) + 
+ (if(a < 2) b + b else 0) + 
+ (if(a < 2) c + c else 0)
+}
 
-sumTwice(f(), g(), h())
+specialSum(f(), g(), h())
 // translates to
 //
 //    val a = f()
-//    def b = g()
-//    a + a + b + b + h() + h()
+//    lazy val b = g()
+//    (if(a < 2) a else 0) + 
+//    (if(a < 2) b + b else 0) + 
+//    (if(a < 2) h() + h() else 0)
 ```
 
 ### Relationship to @inline

--- a/docs/docs/reference/metaprogramming/inline.md
+++ b/docs/docs/reference/metaprogramming/inline.md
@@ -130,20 +130,17 @@ The following example shows the difference in translation between by-value, by-n
 parameters:
 
 ```scala
-inline def specialSum(a: Int, b: =>Int, inline c: Int) =
- (if(a < 2) a else 0) + 
- (if(a < 2) b + b else 0) + 
- (if(a < 2) c + c else 0)
-}
+inline def funkyAssertEquals(actual: Double, expected: =>Double, inline delta: Double): Unit =
+  if (actual - expected).abs > delta then
+    throw new AssertionError(s"difference between ${expected} and ${actual} was larger than ${delta}")
 
-specialSum(f(), g(), h())
+funkyAssertEquals(computeActual(), f() + g(), h() + i() - j())
 // translates to
 //
-//    val a = f()
-//    lazy val b = g()
-//    (if(a < 2) a else 0) + 
-//    (if(a < 2) b + b else 0) + 
-//    (if(a < 2) h() + h() else 0)
+//    val actual = computeActual()
+//    def expected = f() + g()
+//    if (actual - expected).abs > h() + i() - j() then
+//      throw new AssertionError(s"difference between ${expected} and ${actual} was larger than ${h() + i() - j()}")
 ```
 
 ### Relationship to @inline

--- a/docs/docs/reference/metaprogramming/inline.md
+++ b/docs/docs/reference/metaprogramming/inline.md
@@ -123,7 +123,7 @@ power(expr, 10)
 Parameters of inline methods can have an `inline` modifier as well. This means
 that actual arguments to these parameters will be inlined in the body of the 
 `inline def`. `inline` parameters have call semantics equivalent to by-name parameters 
-but allow for duplication of the code in the argument. It is usualy useful constant 
+but allow for duplication of the code in the argument. It is usually useful when constant 
 values need to be propagated to allow further optimizations/reductions.
 
 The following example shows the difference in translation between by-value, by-name and `inline`


### PR DESCRIPTION
Either my assumption about by-name parameters in the context of inline functions is wrong, i.e. they are not lazily evaluated or the example was wrong. 
I have changed the example. Its more complicated but hopefully the difference between inline and by-name is more obvious this way.

I have put `inline def` on a new line as there was no space, it looks as follows on the website `inline def`.`inline`