### PR TITLE
Add MUnit to the community build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -71,3 +71,6 @@
 [submodule "community-build/community-projects/zio"]
 	path = community-build/community-projects/zio
 	url = https://github.com/dotty-staging/zio.git
+[submodule "community-build/community-projects/munit"]
+	path = community-build/community-projects/munit
+	url = https://github.com/dotty-staging/munit.git

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -274,6 +274,13 @@ object projects:
     sbtTestCommand = "testJVMDotty",
     sbtUpdateCommand = "update"
   )
+
+  lazy val munit = SbtCommunityProject(
+    project          = "munit",
+    sbtTestCommand   = "testsJVM/test",
+    sbtUpdateCommand = "munitJVM/update",
+  )
+
 end projects
 
 @Category(Array(classOf[TestCategory]))
@@ -348,6 +355,7 @@ class CommunityBuildTest:
   @Test def effpi = projects.effpi.run()
   @Test def sconfig = projects.sconfig.run()
   @Test def zio = projects.zio.run()
+  @Test def munit = projects.munit.run()
 end CommunityBuildTest
 
 class TestCategory

--- a/community-build/test/scala/dotty/communitybuild/readme.md
+++ b/community-build/test/scala/dotty/communitybuild/readme.md
@@ -14,4 +14,4 @@ To add your project to the community build you can follow these steps:
 2. Open a PR against this repo that:
      - Adds your project as a new git submodule
        - `git submodule add https://github.com/lampepfl/XYZ.git community-build/community-projects/XYZ`
-     - Adds a test in [CommunityBuildTest.scala](https://github.com/lampepfl/dotty/blob/master/src/test/scala/dotty/community-build/src/test/scala/dotty/communitybuild/CommunityBuildTest.scala)
+     - Adds a test in [CommunityBuildTest.scala](https://github.com/lampepfl/dotty/blob/master/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala)


### PR DESCRIPTION
Question: should the project be built against Dotty 0.21 or 0.22? ~MUnit is currently built against 0.21, but there's an open PR that upgrades to 0.22 https://github.com/scalameta/munit/pull/44~ MUnit is now built against 0.22