### PR TITLE
Explicitly provide the given QuoteContext of the splice

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -90,8 +90,8 @@ trait QuotesAndSplices {
       //  * Provide meaningful names for QuoteContext synthesized by within `${ ... }`
       //  * TODO preserve QuoteContext.tasty path dependent type (see comment below and #8045)
       val qctxParamName = NameKinds.UniqueName.fresh(s"qctx${level - 1}_".toTermName)
-      // TODO: Refine QuoteContext with the tasty context that the quote reacived
-      //       If encoloseing quote recieves `qctx` then this type should be `QuoteContext { val tasty: qxtx.tasty.type }`
+      // TODO: Refine QuoteContext with the tasty context that the quote received
+      //       If encoloseing quote receives `qctx` then this type should be `QuoteContext { val tasty: qxtx.tasty.type }`
       val qctxParamTpt = untpd.TypedSplice(TypeTree(defn.QuoteContextClass.typeRef))
       val qctxParam = untpd.makeParameter(qctxParamName, qctxParamTpt, untpd.Modifiers(Given))
       val expr = untpd.Function(List(qctxParam), tree.expr).withSpan(tree.span)
@@ -392,4 +392,3 @@ trait QuotesAndSplices {
       proto = quoteClass.typeRef.appliedTo(replaceBindings(quoted1.tpe) & quotedPt))
   }
 }
-

--- a/tests/run-staging/quote-nested-2.check
+++ b/tests/run-staging/quote-nested-2.check
@@ -1,4 +1,4 @@
 ((qctx: scala.quoted.QuoteContext) => {
   val a: scala.quoted.Expr[scala.Int] = scala.internal.quoted.CompileTime.exprQuote[scala.Int](4) given (qctx)
-  ((evidence$2: scala.quoted.QuoteContext) => a) given (qctx)
+  ((qctx1_$1: scala.quoted.QuoteContext) => a) given (qctx)
 })

--- a/tests/run-staging/quote-nested-5.check
+++ b/tests/run-staging/quote-nested-5.check
@@ -1,4 +1,4 @@
 ((qctx: scala.quoted.QuoteContext) => {
   val a: scala.quoted.Expr[scala.Int] = scala.internal.quoted.CompileTime.exprQuote[scala.Int](4) given (qctx)
-  ((qctx2: scala.quoted.QuoteContext) => ((evidence$3: scala.quoted.QuoteContext) => a) given (qctx2)) given (qctx)
+  ((qctx2: scala.quoted.QuoteContext) => ((qctx1_$1: scala.quoted.QuoteContext) => a) given (qctx2)) given (qctx)
 })


### PR DESCRIPTION
 * Avoids leaking implementation details of scala.internal.quoted.CompileTime.exprSplice,
   such as exprSplice taking a ?=> function argument
 * Provide meaningful names for QuoteContext synthesized by within `${ ... }`