### PR TITLE
Fix #5955: Remove typelevel relationship doc

### DIFF
--- a/docs/docs/reference/metaprogramming/relationship-typelevel.md
+++ b/docs/docs/reference/metaprogramming/relationship-typelevel.md
@@ -1,3 +1,0 @@
-## Relationship to Typelevel Programming
-
-https://github.com/lampepfl/dotty/blob/master/docs/docs/typelevel.md


### PR DESCRIPTION
This PR removes an old doc file that was likely missed in https://github.com/lampepfl/dotty/pull/6896