### PR TITLE
Fix broken link

### DIFF
--- a/docs/docs/reference/contextual/derivation-macro.md
+++ b/docs/docs/reference/contextual/derivation-macro.md
@@ -114,7 +114,7 @@ true
 
 ### Calling the derived method inside the macro
 
-Following the rules in [Macros](../metaprogramming.md) we create two methods.
+Following the rules in [Macros](../metaprogramming/toc.md) we create two methods.
 One that hosts the top-level splice `eqv` and one that is the implementation.
 Alternatively and what is shown below is that we can call the `eqv` method
 directly. The `eqGen` can trigger the derivation.


### PR DESCRIPTION
Found in https://travis-ci.org/nicolasstucki/dotty-website-linkcheck

```
|Getting links from: https://dotty.epfl.ch/docs/reference/contextual/derivation-macro.html
-├───OK─── https://github.com/lampepfl/dotty/edit/master/docs/docs/reference/contextual/derivation-macro.md
-├─BROKEN─ https://dotty.epfl.ch/docs/reference/metaprogramming.html (HTTP_404)
Finished! 344 links found. 342 excluded. 1 broken.
```