### PR TITLE
Port remaining Desugar and Applications errors to the new scheme

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -558,7 +558,7 @@ object desugar {
       else if (originalTparams.isEmpty)
         appliedRef(enumClassRef)
       else {
-        ctx.error(i"explicit extends clause needed because both enum case and enum class have type parameters"
+        ctx.error(TypedCaseDoesNotExplicitlyExtendTypedEnum(enumClass, cdef)
             , cdef.sourcePos.startPos)
         appliedTypeTree(enumClassRef, constrTparams map (_ => anyRef))
       }
@@ -979,7 +979,7 @@ object desugar {
     if (name.isEmpty) name = name.likeSpaced(inventGivenOrExtensionName(impl))
     if (ctx.owner == defn.ScalaPackageClass && defn.reservedScalaClassNames.contains(name.toTypeName)) {
       def kind = if (name.isTypeName) "class" else "object"
-      ctx.error(em"illegal redefinition of standard $kind $name", mdef.sourcePos)
+      ctx.error(IllegalRedefinitionOfStandardKind(kind, name), mdef.sourcePos)
       name = name.errorName
     }
     name

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3470,17 +3470,6 @@ object Parsers {
       Template(constr, parents, Nil, EmptyValDef, Nil)
     }
 
-    def checkExtensionMethod(tparams: List[Tree], stat: Tree): Unit = stat match {
-      case stat: DefDef =>
-        if stat.mods.is(Extension) then
-          syntaxError(i"no extension method allowed here since leading parameter was already given", stat.span)
-        else if tparams.nonEmpty && stat.tparams.nonEmpty then
-          syntaxError(i"extension method cannot have type parameters since some were already given previously",
-            stat.tparams.head.span)
-      case stat =>
-        syntaxError(i"extension clause can only define methods", stat.span)
-    }
-
     /** GivenDef          ::=  [GivenSig] [‘_’ ‘<:’] Type ‘=’ Expr
      *                      |  [GivenSig] ConstrApps [TemplateBody]
      *  GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClauses} ‘as’
@@ -3541,7 +3530,6 @@ object Parsers {
         possibleTemplateStart()
         if !in.isNestedStart then syntaxError("Extension without extension methods")
         val templ = templateBodyOpt(makeConstructor(tparams, extParams :: givenParamss), Nil, Nil)
-        templ.body.foreach(checkExtensionMethod(tparams, _))
         val edef = ModuleDef(name, templ)
         finalizeDef(edef, addFlag(mods, Given), start)
       }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
@@ -155,7 +155,9 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     CaseClassMissingNonImplicitParamListID,
     EnumerationsShouldNotBeEmptyID,
     AbstractCannotBeUsedForObjectsID,
-    ModifierRedundantForObjectsID
+    ModifierRedundantForObjectsID,
+    TypedCaseDoesNotExplicitlyExtendTypedEnumID,
+    IllegalRedefinitionOfStandardKindID
 
   def errorNumber = ordinal - 2
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
@@ -157,7 +157,8 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     AbstractCannotBeUsedForObjectsID,
     ModifierRedundantForObjectsID,
     TypedCaseDoesNotExplicitlyExtendTypedEnumID,
-    IllegalRedefinitionOfStandardKindID
+    IllegalRedefinitionOfStandardKindID,
+    UnexpectedPatternForSummonFromID
 
   def errorNumber = ordinal - 2
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
@@ -161,7 +161,10 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     NoExtensionMethodAllowedID,
     ExtensionMethodCannotHaveTypeParamsID,
     ExtensionCanOnlyHaveDefsID,
-    UnexpectedPatternForSummonFromID
+    UnexpectedPatternForSummonFromID,
+    AnonymousInstanceCannotBeEmptyID,
+    TypeSpliceInValPatternID,
+    ModifierNotAllowedForDefinitionID
 
   def errorNumber = ordinal - 2
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
@@ -158,6 +158,9 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     ModifierRedundantForObjectsID,
     TypedCaseDoesNotExplicitlyExtendTypedEnumID,
     IllegalRedefinitionOfStandardKindID,
+    NoExtensionMethodAllowedID,
+    ExtensionMethodCannotHaveTypeParamsID,
+    ExtensionCanOnlyHaveDefsID,
     UnexpectedPatternForSummonFromID
 
   def errorNumber = ordinal - 2

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2526,4 +2526,34 @@ object messages {
            | }
            |""".stripMargin
   }
+
+  case class AnonymousInstanceCannotBeEmpty(impl:  untpd.Template)(implicit ctx: Context)
+    extends Message(AnonymousInstanceCannotBeEmptyID) {
+    val kind: String = "Syntax"
+    val msg: String = i"anonymous instance must implement a type or have at least one extension method"
+
+    val explanation: String =
+      em"""|Anonymous instances cannot be defined with an empty body. The block
+           |`${impl.show}` should either contain an implemented type or at least one extension method.
+           |""".stripMargin
+  }
+
+  case class TypeSpliceInValPattern(expr:  untpd.Tree)(implicit ctx: Context)
+    extends Message(TypeSpliceInValPatternID) {
+    val kind: String = "Syntax"
+    val msg: String = "Type splices cannot be used in val patterns. Consider using `match` instead."
+
+    val explanation: String =
+      em"""|Type splice: `$$${expr.show}` cannot be used in a `val` pattern. Consider rewriting the `val` pattern
+           |as a `match` with a corresponding `case` to replace the `val`.
+           |""".stripMargin
+  }
+
+  case class ModifierNotAllowedForDefinition(flag: Flag)(implicit ctx: Context)
+    extends Message(ModifierNotAllowedForDefinitionID) {
+    val kind: String = "Syntax"
+    val msg: String = s"Modifier `${flag.flagsString}` is not allowed for this definition"
+
+    val explanation: String = ""
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2443,4 +2443,30 @@ object messages {
            | ${hl("object")} ${mdef.name} { }
            |""".stripMargin
   }
+
+  case class TypedCaseDoesNotExplicitlyExtendTypedEnum(enumDef: Symbol, caseDef: untpd.TypeDef)(implicit ctx: Context)
+    extends Message(TypedCaseDoesNotExplicitlyExtendTypedEnumID) {
+    val kind: String = "Syntax"
+    val msg: String = i"explicit extends clause needed because both enum case and enum class have type parameters"
+
+    val explanation: String =
+      em"""Enumerations where the enum class as well as the enum case have type parameters need
+          |an explicit extends.
+          |for example:
+          | ${hl("enum")} ${enumDef.name}[T] {
+          |  ${hl("case")} ${caseDef.name}[U](u: U) ${hl("extends")} ${enumDef.name}[U]
+          | }
+          |""".stripMargin
+  }
+
+  case class IllegalRedefinitionOfStandardKind(kindType: String, name: Name)(implicit ctx: Context)
+    extends Message(IllegalRedefinitionOfStandardKindID) {
+    val kind: String = "Syntax"
+    val msg: String = em"illegal redefinition of standard $kindType $name"
+
+    val explanation: String =
+      em"""| "$name" is a standard Scala core `$kindType`
+           | Please choose a different name to avoid conflicts
+           |""".stripMargin
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2469,4 +2469,25 @@ object messages {
            | Please choose a different name to avoid conflicts
            |""".stripMargin
   }
+
+  case class UnexpectedPatternForSummonFrom(tree: Tree[_])(implicit ctx: Context)
+    extends Message(UnexpectedPatternForSummonFromID) {
+    val kind: String = "Syntax"
+    val msg: String = em"Unexpected pattern for summonFrom. Expected ${hl("`x: T`")} or ${hl("`_`")}"
+
+    val explanation: String =
+      em"""|The pattern "${tree.show}" provided in the ${hl("case")} expression of the ${hl("summonFrom")},
+           | needs to be of the form ${hl("`x: T`")} or ${hl("`_`")}.
+           |
+           | Example usage:
+           | inline def a = summonFrom {
+           |  case x: T => ???
+           | }
+           |
+           | or
+           | inline def a = summonFrom {
+           |  case _ => ???
+           | }
+           |""".stripMargin
+  }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -2470,6 +2470,42 @@ object messages {
            |""".stripMargin
   }
 
+ case class NoExtensionMethodAllowed(mdef: untpd.DefDef)(implicit ctx: Context)
+    extends Message(NoExtensionMethodAllowedID) {
+    val kind: String = "Syntax"
+    val msg: String = em"No extension method allowed here, since collective parameters are given"
+
+    val explanation: String =
+      em"""|Extension method:
+           |  `${mdef}`
+           |is defined inside an extension clause which has collective parameters.
+           |""".stripMargin
+  }
+
+ case class ExtensionMethodCannotHaveTypeParams(mdef: untpd.DefDef)(implicit ctx: Context)
+    extends Message(ExtensionMethodCannotHaveTypeParamsID) {
+    val kind: String = "Syntax"
+    val msg: String = i"Extension method cannot have type parameters since some were already given previously"
+
+    val explanation: String =
+      em"""|Extension method:
+           |  `${mdef}`
+           |has type parameters `[${mdef.tparams.map(_.show).mkString(",")}]`, while the extension clause has
+           |it's own type parameters. Please consider moving these to the extension clause's type parameter list.
+           |""".stripMargin
+  }
+
+ case class ExtensionCanOnlyHaveDefs(mdef: untpd.Tree)(implicit ctx: Context)
+    extends Message(ExtensionCanOnlyHaveDefsID) {
+    val kind: String = "Syntax"
+    val msg: String = em"Only methods allowed here, since collective parameters are given"
+
+    val explanation: String =
+      em"""Extension clauses can only have `def`s
+          | `${mdef.show}` is not a valid expression here.
+          |""".stripMargin
+  }
+
   case class UnexpectedPatternForSummonFrom(tree: Tree[_])(implicit ctx: Context)
     extends Message(UnexpectedPatternForSummonFromID) {
     val kind: String = "Syntax"

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1076,7 +1076,7 @@ trait Applications extends Compatibility {
       msgs match
         case msg :: Nil =>
           msg.contained match
-            case messages.NotAMember(_, nme.unapply, _, _) => return notAnExtractor(tree)
+            case NotAMember(_, nme.unapply, _, _) => return notAnExtractor(tree)
             case _ =>
         case _ =>
       msgs.foreach(ctx.reporter.report)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -28,7 +28,8 @@ import collection.mutable
 import config.Printers.{overload, typr, unapp}
 import TypeApplications._
 
-import reporting.diagnostic.{Message, messages}
+import reporting.diagnostic.Message
+import reporting.diagnostic.messages.{UnexpectedPatternForSummonFrom, NotAMember}
 import reporting.trace
 import Constants.{Constant, IntTag, LongTag}
 import dotty.tools.dotc.reporting.diagnostic.messages.{UnapplyInvalidReturnType, NotAnExtractor, UnapplyInvalidNumberOfArguments}
@@ -916,7 +917,7 @@ trait Applications extends Compatibility {
                   case CaseDef(Bind(_, Typed(_: Ident, _)), _, _) => // OK
                   case CaseDef(Ident(name), _, _) if name == nme.WILDCARD => // Ok
                   case CaseDef(pat, _, _) =>
-                    ctx.error("Unexpected pattern for summonFrom. Expected `x: T` or `_`", pat.sourcePos)
+                    ctx.error(UnexpectedPatternForSummonFrom(pat), pat.sourcePos)
                 }
                 typed(untpd.InlineMatch(EmptyTree, cases).withSpan(arg.span), pt)
               case _ =>

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTests.scala
@@ -1805,4 +1805,38 @@ class ErrorMessagesTests extends ErrorMessagesTest {
         assertEquals("class", kind)
         assertEquals("Any", name.toString)
       }
+
+  @Test def unexpectedPatternForSummonFrom =
+    checkMessagesAfter(RefChecks.name) {
+      """import compiletime.summonFrom
+        |inline def a = summonFrom {
+        |  case x => ???
+        |}
+      """.stripMargin
+    }
+      .expect { (ictx, messages) ⇒
+        implicit val ctx: Context = ictx
+        assertMessageCount(1, messages)
+        val errorMsg = messages.head.msg
+        val UnexpectedPatternForSummonFrom(x) :: Nil = messages
+        assertEquals("Unexpected pattern for summonFrom. Expected `x: T` or `_`", errorMsg)
+        assertEquals("x", x.show)
+      }
+
+  @Test def unexpectedPatternForSummonWithPatternBinder =
+    checkMessagesAfter(RefChecks.name) {
+      """import compiletime.summonFrom
+        |inline def a = summonFrom {
+        |  case x@String => ???
+        |}
+      """.stripMargin
+    }
+      .expect { (ictx, messages) ⇒
+        implicit val ctx: Context = ictx
+        assertMessageCount(1, messages)
+        val errorMsg = messages.head.msg
+        val UnexpectedPatternForSummonFrom(x) :: Nil = messages
+        assertEquals("Unexpected pattern for summonFrom. Expected `x: T` or `_`", errorMsg)
+        assertEquals("given x @ String", x.show)
+      }
 }

--- a/tests/neg/SummonFrom.check
+++ b/tests/neg/SummonFrom.check
@@ -1,0 +1,12 @@
+-- [E150] Syntax Error: tests/neg/SummonFrom.scala:4:7 -----------------------------------------------------------------
+4 |  case x => ??? // error
+  |       ^
+  |       Unexpected pattern for summonFrom. Expected `x: T` or `_`
+
+longer explanation available when compiling with `-explain`
+-- [E150] Syntax Error: tests/neg/SummonFrom.scala:8:7 -----------------------------------------------------------------
+8 |  case x@String => ??? // error
+  |       ^^^^^^^^
+  |       Unexpected pattern for summonFrom. Expected `x: T` or `_`
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/SummonFrom.check
+++ b/tests/neg/SummonFrom.check
@@ -1,10 +1,10 @@
--- [E150] Syntax Error: tests/neg/SummonFrom.scala:4:7 -----------------------------------------------------------------
+-- [E153] Syntax Error: tests/neg/SummonFrom.scala:4:7 -----------------------------------------------------------------
 4 |  case x => ??? // error
   |       ^
   |       Unexpected pattern for summonFrom. Expected `x: T` or `_`
 
 longer explanation available when compiling with `-explain`
--- [E150] Syntax Error: tests/neg/SummonFrom.scala:8:7 -----------------------------------------------------------------
+-- [E153] Syntax Error: tests/neg/SummonFrom.scala:8:7 -----------------------------------------------------------------
 8 |  case x@String => ??? // error
   |       ^^^^^^^^
   |       Unexpected pattern for summonFrom. Expected `x: T` or `_`

--- a/tests/neg/SummonFrom.scala
+++ b/tests/neg/SummonFrom.scala
@@ -1,0 +1,9 @@
+import compiletime.summonFrom
+
+inline def a = summonFrom {
+  case x => ??? // error
+}
+
+inline def b = summonFrom {
+  case x@String => ??? // error
+}

--- a/tests/neg/anonymous-instance-cannot-be-empty.check
+++ b/tests/neg/anonymous-instance-cannot-be-empty.check
@@ -1,0 +1,6 @@
+-- [E154] Syntax Error: tests/neg/anonymous-instance-cannot-be-empty.scala:2:15 ----------------------------------------
+2 |  extension on[T] (t: T) { } // error
+  |               ^^^^^^^^
+  |               anonymous instance must implement a type or have at least one extension method
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/anonymous-instance-cannot-be-empty.scala
+++ b/tests/neg/anonymous-instance-cannot-be-empty.scala
@@ -1,0 +1,3 @@
+object Test {
+  extension on[T] (t: T) { } // error
+}

--- a/tests/neg/enumWithType.check
+++ b/tests/neg/enumWithType.check
@@ -1,0 +1,6 @@
+-- [E148] Syntax Error: tests/neg/enumWithType.scala:2:2 ---------------------------------------------------------------
+2 |  case C[U](u: U) // error
+  |  ^
+  |  explicit extends clause needed because both enum case and enum class have type parameters
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/enumWithType.scala
+++ b/tests/neg/enumWithType.scala
@@ -1,0 +1,3 @@
+enum E[T] {
+  case C[U](u: U) // error
+}

--- a/tests/neg/extension-cannot-have-type.check
+++ b/tests/neg/extension-cannot-have-type.check
@@ -1,0 +1,6 @@
+-- [E151] Syntax Error: tests/neg/extension-cannot-have-type.scala:3:10 ------------------------------------------------
+3 |    def f[U](u: U): T = ??? // error : extension method cannot have type params
+  |          ^
+  |          Extension method cannot have type parameters since some were already given previously
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/extension-cannot-have-type.scala
+++ b/tests/neg/extension-cannot-have-type.scala
@@ -1,0 +1,5 @@
+object Test {
+  extension on[T] (t: T) {
+    def f[U](u: U): T = ??? // error : extension method cannot have type params
+  }
+}

--- a/tests/neg/extension-method-not-allowed.check
+++ b/tests/neg/extension-method-not-allowed.check
@@ -1,0 +1,6 @@
+-- [E150] Syntax Error: tests/neg/extension-method-not-allowed.scala:3:8 -----------------------------------------------
+3 |    def (c: T).f: T = ??? // error : No extension method allowed here
+  |    ^^^^^^^^^^^^^^^^^^^^^
+  |    No extension method allowed here, since collective parameters are given
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/extension-method-not-allowed.scala
+++ b/tests/neg/extension-method-not-allowed.scala
@@ -1,0 +1,5 @@
+object Test {
+  extension on[T] (t: T) {
+    def (c: T).f: T = ??? // error : No extension method allowed here
+  }
+}

--- a/tests/neg/extensions-can-only-have-defs.check
+++ b/tests/neg/extensions-can-only-have-defs.check
@@ -1,0 +1,6 @@
+-- [E152] Syntax Error: tests/neg/extensions-can-only-have-defs.scala:3:8 ----------------------------------------------
+3 |    val v: T = ??? // error : extensions can only have defs
+  |    ^^^^^^^^^^^^^^
+  |    Only methods allowed here, since collective parameters are given
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/extensions-can-only-have-defs.scala
+++ b/tests/neg/extensions-can-only-have-defs.scala
@@ -1,0 +1,5 @@
+object Test {
+  extension on[T] (t: T) {
+    val v: T = ??? // error : extensions can only have defs
+  }
+}

--- a/tests/neg/i6900.scala
+++ b/tests/neg/i6900.scala
@@ -4,12 +4,12 @@ object Test2 {
   extension on [A](a: A):
     def foo[C]: C => A = _ => a   // error: extension method cannot have type parameters
 
-  1.foo.foo
+  1.foo.foo                      // error: foo is undefined
 
   // ... but have to pass 2 parameters
-  1.foo.foo[Any => Int, String]
-  1.foo[Int, String].foo
-  1.foo[Int, String].foo[String => Int, String]
+  1.foo.foo[Any => Int, String]                  // error: foo is undefined
+  1.foo[Int, String].foo                         // error: foo is undefined
+  1.foo[Int, String].foo[String => Int, String]  // error: foo is undefined
 
 }
 

--- a/tests/neg/modifier-not-allowed.check
+++ b/tests/neg/modifier-not-allowed.check
@@ -1,0 +1,4 @@
+-- [E156] Syntax Error: tests/neg/modifier-not-allowed.scala:2:13 ------------------------------------------------------
+2 |  opaque def o: Int = 3 // error
+  |  ^^^^^^^^^^^^^^^^^^^^^
+  |  Modifier `opaque` is not allowed for this definition

--- a/tests/neg/modifier-not-allowed.scala
+++ b/tests/neg/modifier-not-allowed.scala
@@ -1,0 +1,3 @@
+object Test {
+  opaque def o: Int = 3 // error
+}

--- a/tests/neg/scalaStandardRedefinition.check
+++ b/tests/neg/scalaStandardRedefinition.check
@@ -1,0 +1,6 @@
+-- [E149] Syntax Error: tests/neg/scalaStandardRedefinition.scala:2:8 --------------------------------------------------
+2 |  class Any() // error
+  |  ^^^^^^^^^^^
+  |  illegal redefinition of standard class Any
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/scalaStandardRedefinition.scala
+++ b/tests/neg/scalaStandardRedefinition.scala
@@ -1,0 +1,3 @@
+package scala {
+  class Any() // error
+}

--- a/tests/neg/type-splice-in-val-pattern.check
+++ b/tests/neg/type-splice-in-val-pattern.check
@@ -1,0 +1,6 @@
+-- [E155] Syntax Error: tests/neg/type-splice-in-val-pattern.scala:5:14 ------------------------------------------------
+5 |    val '[ *:[$t] ] = ??? // error
+  |              ^^
+  |              Type splices cannot be used in val patterns. Consider using `match` instead.
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/type-splice-in-val-pattern.scala
+++ b/tests/neg/type-splice-in-val-pattern.scala
@@ -1,0 +1,7 @@
+import scala.quoted._
+object Foo {
+  def f(using q: QuoteContext) = {
+    val t: Type[Int] = ???
+    val '[ *:[$t] ] = ??? // error
+  }
+}


### PR DESCRIPTION
As described in #1589 
Tried porting a couple more of the Errors from Desugar. There are a couple more still remaining, but they seemed to take a bit longer to reproduce the errors for a minimal test case.