### PR TITLE
Fix #8256: Disallow silent indent for template bodies

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -31,7 +31,7 @@ def exec(projectDir: Path, binary: String, arguments: String*): Int =
   exitCode
 
 
-sealed trait CommunityProject
+sealed trait CommunityProject:
   private var published = false
 
   val project: String
@@ -77,17 +77,23 @@ sealed trait CommunityProject
       published = true
 end CommunityProject
 
-final case class MillCommunityProject(project: String, baseCommand: String,
-  dependencies: List[CommunityProject] = Nil) extends CommunityProject
+final case class MillCommunityProject(
+    project: String,
+    baseCommand: String,
+    dependencies: List[CommunityProject] = Nil) extends CommunityProject:
   override val binaryName: String = "./mill"
   override val updateCommand = s"$baseCommand.compileClasspath"
   override val testCommand = s"$baseCommand.test"
   override val publishCommand = s"$baseCommand.publishLocal"
   override val runCommandsArgs = List("-i", "-D", s"dottyVersion=$compilerVersion")
 
-final case class SbtCommunityProject(project: String, sbtTestCommand: String,
-  sbtUpdateCommand: String, extraSbtArgs: List[String] = Nil,
-  dependencies: List[CommunityProject] = Nil, sbtPublishCommand: String = null) extends CommunityProject
+final case class SbtCommunityProject(
+    project: String,
+    sbtTestCommand: String,
+    sbtUpdateCommand: String,
+    extraSbtArgs: List[String] = Nil,
+    dependencies: List[CommunityProject] = Nil,
+    sbtPublishCommand: String = null) extends CommunityProject:
   override val binaryName: String = "sbt"
   private val baseCommand = s";clean ;set updateOptions in Global ~= (_.withLatestSnapshots(false)) ;++$compilerVersion! "
   override val testCommand = s"$baseCommand$sbtTestCommand"
@@ -103,7 +109,7 @@ final case class SbtCommunityProject(project: String, sbtTestCommand: String,
       "-sbt-version", "1.3.6",
       s"--addPluginSbtFile=$sbtPluginFilePath")
 
-object projects
+object projects:
   lazy val utest = MillCommunityProject(
     project = "utest",
     baseCommand = s"utest.jvm[$compilerVersion]",
@@ -265,7 +271,7 @@ object projects
 end projects
 
 @Category(Array(classOf[TestCategory]))
-class CommunityBuildTest {
+class CommunityBuildTest:
   given CommunityBuildTest = this
 
   /** Build the given project with the published local compiler and sbt plugin.
@@ -335,7 +341,7 @@ class CommunityBuildTest {
   @Test def xmlInterpolator = projects.xmlInterpolator.run()
   @Test def effpi = projects.effpi.run()
   @Test def sconfig = projects.sconfig.run()
-}
+end CommunityBuildTest
 
 class TestCategory
 class UpdateCategory

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -160,9 +160,6 @@ object Config {
   /** Assume -indent by default */
   final val defaultIndent = true
 
-  /** Assume indentation is significant after a class, object, ... signature */
-  final val silentTemplateIndent = true
-
   /** If set, prints a trace of all symbol completions */
   final val showCompletions = false
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -26,7 +26,6 @@ import Decorators._
 import scala.internal.Chars
 import scala.annotation.{tailrec, switch}
 import rewrites.Rewrites.{patch, overlapsPatch}
-import config.Config.silentTemplateIndent
 
 object Parsers {
 
@@ -1319,7 +1318,6 @@ object Parsers {
         if in.token != LBRACE && in.token != INDENT then
           syntaxError(i"indented definitions or `{` expected")
       else
-        if silentTemplateIndent && !isNew then in.observeIndented()
         newLineOptWhenFollowedBy(LBRACE)
 
     def endMarkerScope[T](pid: Tree)(op: => T): T = pid match {

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -197,7 +197,7 @@ object Inliner {
 
   object Intrinsics {
     import dotty.tools.dotc.reporting.diagnostic.messages.Error
-    private enum ErrorKind
+    private enum ErrorKind:
       case Parser, Typer
 
     private def compileForErrors(tree: Tree, stopAfterParser: Boolean)(using ctx: Context): List[(ErrorKind, Error)] =

--- a/compiler/src/dotty/tools/dotc/typer/Nullables.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Nullables.scala
@@ -16,13 +16,13 @@ import config.Printers.nullables
 import ast.{tpd, untpd}
 
 /** Operations for implementing a flow analysis for nullability */
-object Nullables with
+object Nullables:
   import ast.tpd._
 
   /** A set of val or var references that are known to be not null, plus a set of
    *  variable references that are not known (anymore) to be not null
    */
-  case class NotNullInfo(asserted: Set[TermRef], retracted: Set[TermRef])
+  case class NotNullInfo(asserted: Set[TermRef], retracted: Set[TermRef]):
     assert((asserted & retracted).isEmpty)
 
     def isEmpty = this eq NotNullInfo.empty
@@ -43,7 +43,7 @@ object Nullables with
     def alt(that: NotNullInfo): NotNullInfo =
       NotNullInfo(this.asserted.intersect(that.asserted), this.retracted.union(that.retracted))
 
-  object NotNullInfo with
+  object NotNullInfo:
     val empty = new NotNullInfo(Set(), Set())
     def apply(asserted: Set[TermRef], retracted: Set[TermRef]): NotNullInfo =
       if asserted.isEmpty && retracted.isEmpty then empty
@@ -51,10 +51,10 @@ object Nullables with
   end NotNullInfo
 
   /** A pair of not-null sets, depending on whether a condition is `true` or `false` */
-  case class NotNullConditional(ifTrue: Set[TermRef], ifFalse: Set[TermRef]) with
+  case class NotNullConditional(ifTrue: Set[TermRef], ifFalse: Set[TermRef]):
     def isEmpty = this eq NotNullConditional.empty
 
-  object NotNullConditional with
+  object NotNullConditional:
     val empty = new NotNullConditional(Set(), Set())
     def apply(ifTrue: Set[TermRef], ifFalse: Set[TermRef]): NotNullConditional =
       if ifTrue.isEmpty && ifFalse.isEmpty then empty
@@ -72,7 +72,7 @@ object Nullables with
   private[typer] val NNInfo = Property.StickyKey[NotNullInfo]
 
   /** An extractor for null comparisons */
-  object CompareNull with
+  object CompareNull:
 
     /** Matches one of
      *
@@ -97,7 +97,7 @@ object Nullables with
   end CompareNull
 
   /** An extractor for null-trackable references */
-  object TrackedRef
+  object TrackedRef:
     def unapply(tree: Tree)(using Context): Option[TermRef] = tree.typeOpt match
       case ref: TermRef if isTracked(ref) => Some(ref)
       case _ => None
@@ -160,7 +160,7 @@ object Nullables with
     // TODO: Add constant pattern if the constant type is not nullable
     case _ => false
 
-  extension notNullInfoOps on (infos: List[NotNullInfo]) with
+  extension notNullInfoOps on (infos: List[NotNullInfo]):
 
     /** Do the current not-null infos imply that `ref` is not null?
      *  Not-null infos are as a history where earlier assertions and retractions replace
@@ -191,7 +191,7 @@ object Nullables with
       infos.extendWith(NotNullInfo(Set(), mutables))
   // end notNullInfoOps
 
-  extension refOps on (ref: TermRef) with
+  extension refOps on (ref: TermRef):
 
     /** Is the use of a mutable variable out of order
      *
@@ -245,7 +245,7 @@ object Nullables with
       && refOwner.isTerm
       && recur(curCtx.owner)
 
-  extension treeOps on (tree: Tree) with
+  extension treeOps on (tree: Tree):
 
     /* The `tree` with added nullability attachment */
     def withNotNullInfo(info: NotNullInfo): tree.type =
@@ -335,7 +335,7 @@ object Nullables with
           tree.computeNullable()
       }.traverse(tree)
 
-  extension assignOps on (tree: Assign) with
+  extension assignOps on (tree: Assign):
     def computeAssignNullable()(using Context): tree.type = tree.lhs match
       case TrackedRef(ref) =>
         val rhstp = tree.rhs.typeOpt

--- a/library/src/scala/IArray.scala
+++ b/library/src/scala/IArray.scala
@@ -4,7 +4,7 @@ import reflect.ClassTag
 /** An immutable array. An `IArray[T]` has the same representation as an `Array[T]`,
  *  but it cannot be updated. Unlike regular arrays, immutable arrays are covariant.
  */
-object opaques
+object opaques:
   opaque type IArray[+T] = Array[_ <: T]
 
   /** Defines extension methods for immutable arrays */

--- a/library/src/scala/TupledFunction.scala
+++ b/library/src/scala/TupledFunction.scala
@@ -8,14 +8,12 @@ import scala.annotation.implicitNotFound
  *  @tparam G a tupled function type (function of arity 1 receiving a tuple as argument)
  */
 @implicitNotFound("${F} cannot be tupled as ${G}")
-sealed trait TupledFunction[F, G] {
+sealed trait TupledFunction[F, G]:
   def tupled(f: F): G
   def untupled(g: G): F
-}
 
-private[scala] object TupledFunction
+private[scala] object TupledFunction:
   def apply[F, G](tupledImpl: F => G, untupledImpl: G => F): TupledFunction[F, G] =
-    new TupledFunction[F, G] {
+    new TupledFunction[F, G]:
       def tupled(f: F): G = tupledImpl(f)
       def untupled(g: G): F = untupledImpl(g)
-    }

--- a/library/src/scala/compiletime/testing/ErrorKind.scala
+++ b/library/src/scala/compiletime/testing/ErrorKind.scala
@@ -2,6 +2,6 @@ package scala.compiletime.testing
 
 /** An error can be either a parse-time or a typecheck-time */
 sealed trait ErrorKind  // TODO make this enum, so far not doable because ScalaJS compilation fails on it
-object ErrorKind
+object ErrorKind:
   case object Parser extends ErrorKind
   case object Typer extends ErrorKind

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -1560,30 +1560,28 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
 
   given (using ctx: Context) as IsInstanceOf[SimpleSelector] = internal.isInstanceOfSimpleSelector
 
-  object SimpleSelector
+  object SimpleSelector:
     def unapply(x: SimpleSelector)(using ctx: Context): Option[Id] = Some(x.selection)
 
-  extension renameSelectorOps on (self: RenameSelector) {
+  extension renameSelectorOps on (self: RenameSelector):
     def from(using ctx: Context): Id =
       internal.RenameSelector_from(self)
 
     def to(using ctx: Context): Id =
       internal.RenameSelector_to(self)
-  }
 
   given (using ctx: Context) as IsInstanceOf[RenameSelector] = internal.isInstanceOfRenameSelector
 
-  object RenameSelector
+  object RenameSelector:
     def unapply(x: RenameSelector)(using ctx: Context): Option[(Id, Id)] = Some((x.from, x.to))
 
-  extension omitSelectorOps on (self: OmitSelector) {
+  extension omitSelectorOps on (self: OmitSelector):
     def omitted(using ctx: Context): Id =
       internal.SimpleSelector_omitted(self)
-  }
 
   given (using ctx: Context) as IsInstanceOf[OmitSelector] = internal.isInstanceOfOmitSelector
 
-  object OmitSelector
+  object OmitSelector:
     def unapply(x: OmitSelector)(using ctx: Context): Option[Id] = Some(x.omitted)
 
 
@@ -1980,7 +1978,7 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
 
   given (using ctx: Context) as IsInstanceOf[NoPrefix] = internal.isInstanceOfNoPrefix
 
-  object NoPrefix
+  object NoPrefix:
     def unapply(x: NoPrefix)(using ctx: Context): Boolean = true
 
 

--- a/tests/neg/endmarkers.scala
+++ b/tests/neg/endmarkers.scala
@@ -1,4 +1,4 @@
-object Test
+object Test:
 
   locally {
     var x = 0
@@ -43,11 +43,11 @@ object Test
     x < 10
   do ()
 
-class Test2
+class Test2:
   self =>
   def foo = 1
 
-  object x
+  object x:
     new Test2 {
       override def foo = 2
       end new               // error: misaligned end marker
@@ -56,16 +56,16 @@ class Test2
   end Test2                 // error: misaligned end marker
 end Test2
 
-class Test3
+class Test3:
  self =>
   def foo = 1
  end Test3  // error: misaligned end marker
 
 import collection.mutable.HashMap
 
-class Coder(words: List[String])
+class Coder(words: List[String]):
 
-  class Foo
+  class Foo:
     println()
     end Foo  // error: misaligned end marker
 

--- a/tests/neg/given-eta.scala
+++ b/tests/neg/given-eta.scala
@@ -1,5 +1,5 @@
 
-trait D
+trait D:
    type T
    def trans(other: T): T
 

--- a/tests/neg/i7359-b.scala
+++ b/tests/neg/i7359-b.scala
@@ -1,3 +1,3 @@
-trait SAMTrait
+trait SAMTrait:
   def first(): String
   def notifyAll(): Unit // error

--- a/tests/neg/i7359-c.scala
+++ b/tests/neg/i7359-c.scala
@@ -1,3 +1,3 @@
-trait SAMTrait
+trait SAMTrait:
   def first(): String
   def wait(): Unit // error

--- a/tests/neg/i7359-d.scala
+++ b/tests/neg/i7359-d.scala
@@ -1,3 +1,3 @@
-trait SAMTrait
+trait SAMTrait:
   def first(): String
   def wait(a: Long): Unit // error

--- a/tests/neg/i7359-e.scala
+++ b/tests/neg/i7359-e.scala
@@ -1,3 +1,3 @@
-trait SAMTrait
+trait SAMTrait:
   def first(): String
   def wait(a: Long, n: Int): Unit // error

--- a/tests/neg/i7359-f.check
+++ b/tests/neg/i7359-f.check
@@ -1,5 +1,5 @@
 -- [E120] Duplicate Symbol Error: tests/neg/i7359-f.scala:1:6 ----------------------------------------------------------
-1 |trait SAMTrait // error
+1 |trait SAMTrait: // error
   |      ^
   |      Name clash between inherited members:
   |      def equals: [T >: Boolean <: Boolean](obj: Any): T in trait SAMTrait at line 3 and

--- a/tests/neg/i7359-f.scala
+++ b/tests/neg/i7359-f.scala
@@ -1,3 +1,3 @@
-trait SAMTrait // error
+trait SAMTrait: // error
   def first(): String
   def equals[T >: Boolean <: Boolean](obj: Any): T

--- a/tests/neg/i7359-g.scala
+++ b/tests/neg/i7359-g.scala
@@ -1,4 +1,4 @@
-trait SAMTrait
+trait SAMTrait:
   def first(): String
   def equals(obj: Int): Boolean
 

--- a/tests/neg/i7359.scala
+++ b/tests/neg/i7359.scala
@@ -1,3 +1,3 @@
-trait SAMTrait
+trait SAMTrait:
   def first(): String
   def notify(): Unit // error

--- a/tests/neg/i7980.scala
+++ b/tests/neg/i7980.scala
@@ -1,7 +1,7 @@
 trait Evidence[X]
 
-trait Trait[X : Evidence]
+trait Trait[X : Evidence]:
   def method(x : X) : X
 
-given ev : Evidence[Int] = new Evidence[Int]{}
+given ev as Evidence[Int] = new Evidence[Int]{}
 val crash : Trait[Int] = (x: Int) => x          // error

--- a/tests/neg/i8069.scala
+++ b/tests/neg/i8069.scala
@@ -1,7 +1,7 @@
-trait A
+trait A:
   type B
 
-enum Test
+enum Test:
   case Test(a: A, b: a.B)   // error: Implementation restriction: case classes cannot have dependencies between parameters
 
 case class Test2(a: A, b: a.B) // error: Implementation restriction: case classes cannot have dependencies between parameters

--- a/tests/neg/override-inner-class.scala
+++ b/tests/neg/override-inner-class.scala
@@ -1,5 +1,5 @@
-class C
+class C:
   type T >: String <: Any
 
-class D extends C
+class D extends C:
   class T  // error

--- a/tests/neg/parser-stability-12.scala
+++ b/tests/neg/parser-stability-12.scala
@@ -1,4 +1,4 @@
-trait x0[]  // error
+trait x0[]:  // error
      trait x1[x1 <:x0]
      extends x1[  // error
 // error

--- a/tests/neg/parser-stability-19.scala
+++ b/tests/neg/parser-stability-19.scala
@@ -1,5 +1,5 @@
 object x0 {
-  case class x0[]()                     // error
+  case class x0[]():                  // error
     def x0( ) ]                       // error
     def x0 ( x0:x0 ):x0.type = x1 x0  // error // error
 // error

--- a/tests/neg/spaces-vs-tabs.scala
+++ b/tests/neg/spaces-vs-tabs.scala
@@ -1,4 +1,4 @@
-object Test
+object Test:
 
 	if true then
 		println(1)   // ok
@@ -7,7 +7,7 @@ object Test
 	  println(4)   // error
  else ()         // error
 
-	object Test2
+	object Test2:
 
 	    if true then
 	      1

--- a/tests/pos-special/fatal-warnings/patmat-exhaustive.scala
+++ b/tests/pos-special/fatal-warnings/patmat-exhaustive.scala
@@ -1,5 +1,5 @@
 def foo: Unit =
-  object O
+  object O:
     sealed abstract class A
   class B extends O.A
   class C extends O.A

--- a/tests/pos-special/i7296.scala
+++ b/tests/pos-special/i7296.scala
@@ -1,2 +1,2 @@
-class Foo
+class Foo:
   private var blah: Double = 0L

--- a/tests/pos-special/indent-colons.scala
+++ b/tests/pos-special/indent-colons.scala
@@ -1,4 +1,4 @@
-object Test
+object Test:
 
   locally:
     var x = 0
@@ -56,7 +56,7 @@ object Test
     x < 10
   do ()
 
-class Test2
+class Test2:
   self =>
   def foo = 1
 
@@ -67,15 +67,15 @@ class Test2
   end x
 end Test2
 
-class Test3
+class Test3:
  self =>
   def foo = 1
 
 import collection.mutable.HashMap
 
-class Coder(words: List[String])
+class Coder(words: List[String]):
 
-  class Foo
+  class Foo:
     println()
   end Foo
 
@@ -114,5 +114,5 @@ class Coder(words: List[String])
         case (digit, str) => str map (ltr => ltr -> digit)
 end Coder
 
-object Test22
+object Test22:
   def foo: Int = 22

--- a/tests/pos-special/sourcepath/outer/nested/indent1.scala
+++ b/tests/pos-special/sourcepath/outer/nested/indent1.scala
@@ -1,7 +1,7 @@
 package outer
 package nested
 
-object indent1
+object indent1:
   object inner:
     def x: Int = 1
   end inner

--- a/tests/pos/i7217.scala
+++ b/tests/pos/i7217.scala
@@ -1,4 +1,4 @@
-class Foo(p1: String, p2: String)
+class Foo(p1: String, p2: String):
   def this(p1: String) = this(p1, "blah")
 
 val x = { Foo("blah", "hah") }

--- a/tests/pos/i7359.scala
+++ b/tests/pos/i7359.scala
@@ -1,95 +1,95 @@
 package test
 
-trait ObjectInterface
+trait ObjectInterface:
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMPlain
+trait SAMPlain:
   def first(): String
 
-trait SAMPlainWithOverriddenObjectMethods
+trait SAMPlainWithOverriddenObjectMethods:
   def first(): String
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMPlainWithExtends extends ObjectInterface
+trait SAMPlainWithExtends extends ObjectInterface:
   def first(): String
 
-trait SAMPlainWithExtendsAndOverride extends ObjectInterface
+trait SAMPlainWithExtendsAndOverride extends ObjectInterface:
   def first(): String
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
   override def toString(): String
 
-trait SAMPlainCovariantOut[+O]
+trait SAMPlainCovariantOut[+O]:
   def first(): O
 
-trait SAMCovariantOut[+O]
+trait SAMCovariantOut[+O]:
   def first(): O
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMCovariantOutExtends[+O] extends ObjectInterface
+trait SAMCovariantOutExtends[+O] extends ObjectInterface:
   def first(): O
 
-trait SAMCovariantOutExtendsAndOverride[+O] extends ObjectInterface
+trait SAMCovariantOutExtendsAndOverride[+O] extends ObjectInterface:
   def first(): O
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
   override def toString(): String
 
-trait SAMPlainContravariantIn[-I]
+trait SAMPlainContravariantIn[-I]:
   def first(in: I): Unit
 
-trait SAMContravariantIn[-I]
+trait SAMContravariantIn[-I]:
   def first(in: I): Unit
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMContravariantInExtends[-I] extends ObjectInterface
+trait SAMContravariantInExtends[-I] extends ObjectInterface:
   def first(in: I): Unit
 
-trait SAMContravariantInExtendsAndOverride[-I] extends ObjectInterface
+trait SAMContravariantInExtendsAndOverride[-I] extends ObjectInterface:
   def first(in: I): Unit
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
   override def toString(): String
 
-trait SAMPlainInvariant[T]
+trait SAMPlainInvariant[T]:
   def first(in: T): T
 
-trait SAMInvariant[T]
+trait SAMInvariant[T]:
   def first(in: T): T
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMInvariantExtends[T] extends ObjectInterface
+trait SAMInvariantExtends[T] extends ObjectInterface:
   def first(in: T): T
 
-trait SAMInvariantExtendsAndOverride[T] extends ObjectInterface
+trait SAMInvariantExtendsAndOverride[T] extends ObjectInterface:
   def first(in: T): T
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
   override def toString(): String
 
-trait SAMPlainInOut[-I, +O]
+trait SAMPlainInOut[-I, +O]:
   def first(in: I): O
 
-trait SAMInOut[-I, +O]
+trait SAMInOut[-I, +O]:
   def first(in: I): O
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMInOutExtends[-I, +O] extends ObjectInterface
+trait SAMInOutExtends[-I, +O] extends ObjectInterface:
   def first(in: I): O
 
-trait SAMInOutExtendsAndOverride[-I, +O] extends ObjectInterface
+trait SAMInOutExtendsAndOverride[-I, +O] extends ObjectInterface:
   def first(in: I): O
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
@@ -99,13 +99,13 @@ type CustomString = String
 type CustomBoolean = Boolean
 type CustomInt = Int
 
-trait SAMWithCustomAliases
+trait SAMWithCustomAliases:
   def first(): String
   def equals(obj: Any): CustomBoolean
   def hashCode(): CustomInt
   def toString(): CustomString
 
-object Main
+object Main:
   def main(args: Array[String]) =
     val samPlain : SAMPlain = () => "Hello, World!"
     val samPlainWithOverriddenObjectMethods: SAMPlainWithOverriddenObjectMethods = () => "Hello, World!"

--- a/tests/pos/i7413.scala
+++ b/tests/pos/i7413.scala
@@ -2,23 +2,21 @@ import scala.language.implicitConversions
 
 trait Fixture[A] extends Conversion[0, A]
 
-trait TestFramework[A] {
+trait TestFramework[A]:
   def (testName: String).in(test: Fixture[A] ?=> Unit): Unit = ???
-}
 
-trait Greeter {
+trait Greeter:
   def greet(name: String): String = s"Hello $name"
-}
 
 case class MyFixture(name: String, greeter: Greeter)
 
 object Test1:
-  given conv as Conversion[0, Greeter]
+  given conv as Conversion[0, Greeter]:
     def apply(x: 0): Greeter = ???
   val g: Greeter = 0
 
-class MyTest extends TestFramework[MyFixture] {
+class MyTest extends TestFramework[MyFixture]:
   "say hello" in {
     assert(0.greeter.greet(0.name) == s"Hello ${0.name}")
   }
-}
+

--- a/tests/pos/i7428.scala
+++ b/tests/pos/i7428.scala
@@ -1,5 +1,5 @@
-class ABug
-  enum Tag
+class ABug:
+  enum Tag:
     case first
   import Tag.first
   val xx = first

--- a/tests/pos/i7757.scala
+++ b/tests/pos/i7757.scala
@@ -1,7 +1,7 @@
 val m: Map[Int, String] = ???
 val _ = m.map((a, b) => a + b.length)
 
-trait Foo
+trait Foo:
   def g(f: ((Int, Int)) => Int): Int = 1
   def g(f: ((Int, Int)) => (Int, Int)): String = "2"
 

--- a/tests/pos/i8256.scala
+++ b/tests/pos/i8256.scala
@@ -1,0 +1,10 @@
+val a = 1
+
+  trait Test[A]
+  object Test {
+    implicit def ev[A] : Test[A] = new Test[A]{}
+  }
+
+  val fetch = implicitly[Test[1]]
+
+@main def main() : Unit = {}

--- a/tests/pos/indent.scala
+++ b/tests/pos/indent.scala
@@ -1,4 +1,4 @@
-object Test
+object Test:
 
   locally {
     var x = 0
@@ -78,7 +78,7 @@ object Test
     x < 10
   do ()
 
-class Test2
+class Test2:
   self =>
   def foo = 1
 
@@ -89,15 +89,15 @@ class Test2
   end x
 end Test2
 
-class Test3
+class Test3:
  self =>
   def foo = 1
 
 import collection.mutable.HashMap
 
-class Coder(words: List[String])
+class Coder(words: List[String]):
 
-  class Foo
+  class Foo:
     println()
   end Foo
 
@@ -138,5 +138,5 @@ class Coder(words: List[String])
       }
 end Coder
 
-object Test22
+object Test22:
   def foo: Int = 22

--- a/tests/pos/indent2.scala
+++ b/tests/pos/indent2.scala
@@ -1,6 +1,6 @@
-object testindent
+object testindent:
 
-  class C
+  class C:
     val x = 0
 
   val c = new C

--- a/tests/pos/indent4.scala
+++ b/tests/pos/indent4.scala
@@ -1,4 +1,4 @@
-object testindent
+object testindent:
 
   if (true)
     val x = 1

--- a/tests/pos/tasty-tags-obscure.scala
+++ b/tests/pos/tasty-tags-obscure.scala
@@ -1,15 +1,15 @@
-object ObscureTasty
+object ObscureTasty:
 
   def foo(f: [t] => List[t] ?=> Unit) = ???
   def test1 = foo([t] => (a: List[t]) ?=> ()) // POLYtype => GIVENMETHODType
   def bar(f: [t] => List[t] => Unit) = ???
   def test2 = bar([t] => (a: List[t]) => ()) // POLYtype => METHODType
 
-  class Bar
+  class Bar:
     final val bar = "Bar.bar"
 
-  class Foo extends Bar
-    object A
+  class Foo extends Bar:
+    object A:
       def unapply(a: Any): Some[Foo.super.bar.type] = ???
 
     def foo =

--- a/tests/run-custom-args/tasty-inspector/i8163.scala
+++ b/tests/run-custom-args/tasty-inspector/i8163.scala
@@ -14,9 +14,9 @@ object Test {
   }
 }
 
-class TestInspector() extends TastyInspector
+class TestInspector() extends TastyInspector:
 
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit = 
+  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit =
     import reflect._
     inspectClass(reflect)(root)
 
@@ -44,5 +44,5 @@ class TestInspector() extends TastyInspector
         }
         assert(!shouldNotBePhoneType.isOpaqueAlias)
 
-      case x => 
+      case x =>
     }

--- a/tests/run-staging/shonan-hmm-simple.scala
+++ b/tests/run-staging/shonan-hmm-simple.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 import scala.quoted.autolift.{given _}
 
-trait Ring[T]
+trait Ring[T]:
   val zero: T
   val one: T
   val add: (x: T, y: T) => T
@@ -10,7 +10,7 @@ trait Ring[T]
   val mul: (x: T, y: T) => T
 end Ring
 
-class RingInt extends Ring[Int]
+class RingInt extends Ring[Int]:
   val zero = 0
   val one  = 1
   val add  = (x, y) => x + y
@@ -18,85 +18,73 @@ class RingInt extends Ring[Int]
   val mul  = (x, y) => x * y
 
 
-class RingIntExpr(using QuoteContext) extends Ring[Expr[Int]]
+class RingIntExpr(using QuoteContext) extends Ring[Expr[Int]]:
   val zero = '{0}
   val one  = '{1}
   val add  = (x, y) => '{$x + $y}
   val sub  = (x, y) => '{$x - $y}
   val mul  = (x, y) => '{$x * $y}
 
-class RingComplex[U](u: Ring[U]) extends Ring[Complex[U]] {
+class RingComplex[U](u: Ring[U]) extends Ring[Complex[U]]:
   val zero = Complex(u.zero, u.zero)
   val one  = Complex(u.one, u.zero)
   val add  = (x, y) => Complex(u.add(x.re, y.re), u.add(x.im, y.im))
   val sub  = (x, y) => Complex(u.sub(x.re, y.re), u.sub(x.im, y.im))
   val mul  = (x, y) => Complex(u.sub(u.mul(x.re, y.re), u.mul(x.im, y.im)), u.add(u.mul(x.re, y.im), u.mul(x.im, y.re)))
-}
 
-sealed trait PV[T]
+sealed trait PV[T]:
   def expr(using Liftable[T], QuoteContext): Expr[T]
 
-case class Sta[T](x: T) extends PV[T]
+case class Sta[T](x: T) extends PV[T]:
   def expr(using Liftable[T], QuoteContext): Expr[T] = x
 
-case class Dyn[T](x: Expr[T]) extends PV[T]
+case class Dyn[T](x: Expr[T]) extends PV[T]:
   def expr(using Liftable[T], QuoteContext): Expr[T] = x
 
-class RingPV[U: Liftable](u: Ring[U], eu: Ring[Expr[U]])(using QuoteContext) extends Ring[PV[U]] {
+class RingPV[U: Liftable](u: Ring[U], eu: Ring[Expr[U]])(using QuoteContext) extends Ring[PV[U]]:
   val zero: PV[U] = Sta(u.zero)
   val one: PV[U] = Sta(u.one)
-  val add = (x: PV[U], y: PV[U]) => (x, y) match {
+  val add = (x: PV[U], y: PV[U]) => (x, y) match
     case (Sta(u.zero), x) => x
     case (x, Sta(u.zero)) => x
     case (Sta(x), Sta(y)) => Sta(u.add(x, y))
     case (x, y) => Dyn(eu.add(x.expr, y.expr))
-  }
-  val sub = (x: PV[U], y: PV[U]) => (x, y) match {
+  val sub = (x: PV[U], y: PV[U]) => (x, y) match
     case (x, Sta(u.zero)) => x
     case (Sta(x), Sta(y)) => Sta(u.sub(x, y))
     case (x, y) => Dyn(eu.sub(x.expr, y.expr))
-  }
-  val mul = (x: PV[U], y: PV[U]) => (x, y) match {
+  val mul = (x: PV[U], y: PV[U]) => (x, y) match
     case (Sta(u.zero), _) => Sta(u.zero)
     case (_, Sta(u.zero)) => Sta(u.zero)
     case (Sta(u.one), x) => x
     case (x, Sta(u.one)) => x
     case (Sta(x), Sta(y)) => Sta(u.mul(x, y))
     case (x, y) => Dyn(eu.mul(x.expr, y.expr))
-  }
-}
-
 
 case class Complex[T](re: T, im: T)
 
-object Complex
-  implicit def isLiftable[T: Type: Liftable]: Liftable[Complex[T]] = new Liftable[Complex[T]] {
+object Complex:
+  implicit def isLiftable[T: Type: Liftable]: Liftable[Complex[T]] = new Liftable[Complex[T]]:
     def toExpr(comp: Complex[T]) = '{Complex(${comp.re}, ${comp.im})}
-  }
 
-case class Vec[Idx, T](size: Idx, get: Idx => T) {
+case class Vec[Idx, T](size: Idx, get: Idx => T):
   def map[U](f: T => U): Vec[Idx, U] = Vec(size, i => f(get(i)))
   def zipWith[U, V](other: Vec[Idx, U], f: (T, U) => V): Vec[Idx, V] = Vec(size, i => f(get(i), other.get(i)))
-}
 
-object Vec {
+object Vec:
   def from[T](elems: T*): Vec[Int, T] = new Vec(elems.size, i => elems(i))
-}
 
-trait VecOps[Idx, T] {
+trait VecOps[Idx, T]:
   val reduce: ((T, T) => T, T, Vec[Idx, T]) => T
-}
 
-class StaticVecOps[T] extends VecOps[Int, T] {
-  val reduce: ((T, T) => T, T, Vec[Int, T]) => T = (plus, zero, vec) => {
+class StaticVecOps[T] extends VecOps[Int, T]:
+  val reduce: ((T, T) => T, T, Vec[Int, T]) => T = (plus, zero, vec) =>
     var sum = zero
     for (i <- 0 until vec.size)
       sum = plus(sum, vec.get(i))
     sum
-  }
-}
 
-class ExprVecOps[T: Type](using QuoteContext) extends VecOps[Expr[Int], Expr[T]]
+class ExprVecOps[T: Type](using QuoteContext) extends VecOps[Expr[Int], Expr[T]]:
   val reduce: ((Expr[T], Expr[T]) => Expr[T], Expr[T], Vec[Expr[Int], Expr[T]]) => Expr[T] = (plus, zero, vec) => '{
     var sum = $zero
     var i = 0
@@ -106,14 +94,13 @@ class ExprVecOps[T: Type](using QuoteContext) extends VecOps[Expr[Int], Expr[T]]
     sum
   }
 
-class Blas1[Idx, T](r: Ring[T], ops: VecOps[Idx, T]) {
+class Blas1[Idx, T](r: Ring[T], ops: VecOps[Idx, T]):
   def dot(v1: Vec[Idx, T], v2: Vec[Idx, T]): T = ops.reduce(r.add, r.zero, v1.zipWith(v2, r.mul))
-}
 
-object Test {
+object Test:
 
   given Toolbox = Toolbox.make(getClass.getClassLoader)
-  def main(args: Array[String]): Unit = {
+  def main(args: Array[String]): Unit =
     val arr1 = Array(0, 1, 2, 4, 8)
     val arr2 = Array(1, 0, 1, 0, 1)
     val cmpxArr1 = Array(Complex(1, 0), Complex(2, 3), Complex(0, 2), Complex(3, 1))
@@ -211,6 +198,4 @@ object Test {
     def code(using QuoteContext) = '{(arr: Array[Int]) => ${dotIntOptExpr(Vec(5, i => Dyn('{arr(${i})})), staticVec).expr} }
     println(withQuoteContext(code.show))
     println()
-  }
 
-}

--- a/tests/run/given-eta.scala
+++ b/tests/run/given-eta.scala
@@ -1,6 +1,6 @@
 class C(val x: Int)
 
-trait D
+trait D:
    type T
    def trans(other: T): T
 
@@ -12,7 +12,7 @@ def g(x: Int)(using d: D) (y: d.T): d.T = d.trans(y)
   val x = f
   assert(x(2)(3) == 6)
 
-  given D
+  given D:
     type T = Int
     def trans(other: T) = 2 * other
   val y = g

--- a/tests/run/i7359.scala
+++ b/tests/run/i7359.scala
@@ -1,34 +1,34 @@
-trait ObjectInterface
+trait ObjectInterface:
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMPlainWithExtends extends ObjectInterface
+trait SAMPlainWithExtends extends ObjectInterface:
   def first(): String
 
-trait SAMCovariantOutExtends[+O] extends ObjectInterface
+trait SAMCovariantOutExtends[+O] extends ObjectInterface:
   def first(): O
 
-trait SAMContravariantInExtends[-I] extends ObjectInterface
+trait SAMContravariantInExtends[-I] extends ObjectInterface:
   def first(in: I): Unit
 
-trait SAMInvariantExtends[T] extends ObjectInterface
+trait SAMInvariantExtends[T] extends ObjectInterface:
   def first(in: T): T
 
-trait SAMInOutExtends[-I, +O] extends ObjectInterface
+trait SAMInOutExtends[-I, +O] extends ObjectInterface:
   def first(in: I): O
 
 type CustomString = String
 type CustomBoolean = Boolean
 type CustomInt = Int
 
-trait SAMWithCustomAliases
+trait SAMWithCustomAliases:
   def first(): String
   def equals(obj: Any): CustomBoolean
   def hashCode(): CustomInt
   def toString(): CustomString
 
-object Test
+object Test:
 
   def main(args: Array[String]): Unit =
     val samPlainWithExtends : SAMPlainWithExtends = () => "o"

--- a/tests/run/quoted-sematics-1.scala
+++ b/tests/run/quoted-sematics-1.scala
@@ -25,7 +25,7 @@ object Name {
 }
 
 
-enum Term
+enum Term:
   case Nat(n: Int)
   case Ref(name: Name)
   case Lambda(name: Name, tpe: Type, body: Term)
@@ -37,7 +37,7 @@ enum Term
   case Fix(term: Term)
 
 
-enum Pattern
+enum Pattern:
   case PNat(n: Int)
   case PRef(name: Name)
   case PApp(fun: Pattern, arg: Pattern)
@@ -46,7 +46,7 @@ enum Pattern
   case PFun(name: Name)
 
 
-enum Type
+enum Type:
   case NatType
   case LambdaType(arg: Type, res: Type)
   case BoxType(inner: Type)

--- a/tests/semanticdb/expect/Givens.expect.scala
+++ b/tests/semanticdb/expect/Givens.expect.scala
@@ -1,25 +1,25 @@
 package a
 package b
 
-object Givens/*<-a::b::Givens.*/
+object Givens/*<-a::b::Givens.*/:
 
-  given extension [A](any: A/*<-a::b::Givens.extension_sayHello_A.*//*<-a::b::Givens.extension_sayHello_A.sayHello().[A]*//*<-a::b::Givens.extension_sayHello_A.sayHello().(any)*//*->a::b::Givens.extension_sayHello_A.sayHello().[A]*/)
-    def sayHello/*<-a::b::Givens.extension_sayHello_A.sayHello().*/ = s"/*->scala::StringContext.apply().*/Hello, I am $any/*->a::b::Givens.extension_sayHello_A.sayHello().(any)*//*->scala::StringContext#s().*/"
+  extension on [A](any: A):
+    def /*<-a::b::Givens.extension_sayHello_A.*//*<-a::b::Givens.extension_sayHello_A.sayHello().[A]*//*<-a::b::Givens.extension_sayHello_A.sayHello().(any)*//*->a::b::Givens.extension_sayHello_A.sayHello().[A]*/sayHello/*<-a::b::Givens.extension_sayHello_A.sayHello().*/ = s"/*->scala::StringContext.apply().*/Hello, I am $any/*->a::b::Givens.extension_sayHello_A.sayHello().(any)*//*->scala::StringContext#s().*/"
 
-  given extension [B](any: B)
-/*<-a::b::Givens.extension_sayGoodbye_B.*//*<-a::b::Givens.extension_sayGoodbye_B.sayGoodbye().[B]*//*<-a::b::Givens.extension_sayGoodbye_B.saySoLong().[B]*//*<-a::b::Givens.extension_sayGoodbye_B.sayGoodbye().(any)*//*<-a::b::Givens.extension_sayGoodbye_B.saySoLong().(any)*//*->a::b::Givens.extension_sayGoodbye_B.sayGoodbye().[B]*//*->a::b::Givens.extension_sayGoodbye_B.saySoLong().[B]*/    def sayGoodbye/*<-a::b::Givens.extension_sayGoodbye_B.sayGoodbye().*/ = s"/*->scala::StringContext.apply().*/Goodbye, from $any/*->a::b::Givens.extension_sayGoodbye_B.sayGoodbye().(any)*//*->scala::StringContext#s().*/"
+  extension on [B](any: B):
+    def sa/*<-a::b::Givens.extension_sayGoodbye_B.*//*<-a::b::Givens.extension_sayGoodbye_B.sayGoodbye().[B]*//*<-a::b::Givens.extension_sayGoodbye_B.saySoLong().[B]*//*<-a::b::Givens.extension_sayGoodbye_B.sayGoodbye().(any)*//*<-a::b::Givens.extension_sayGoodbye_B.saySoLong().(any)*//*->a::b::Givens.extension_sayGoodbye_B.sayGoodbye().[B]*//*->a::b::Givens.extension_sayGoodbye_B.saySoLong().[B]*/yGoodbye/*<-a::b::Givens.extension_sayGoodbye_B.sayGoodbye().*/ = s"/*->scala::StringContext.apply().*/Goodbye, from $any/*->a::b::Givens.extension_sayGoodbye_B.sayGoodbye().(any)*//*->scala::StringContext#s().*/"
     def saySoLong/*<-a::b::Givens.extension_sayGoodbye_B.saySoLong().*/ = s"/*->scala::StringContext.apply().*/So Long, from $any/*->a::b::Givens.extension_sayGoodbye_B.saySoLong().(any)*//*->scala::StringContext#s().*/"
 
   val hello1/*<-a::b::Givens.hello1.*/ = /*->a::b::Givens.extension_sayHello_A.sayHello().*/1.sayHello
   val goodbye1/*<-a::b::Givens.goodbye1.*/ = /*->a::b::Givens.extension_sayGoodbye_B.sayGoodbye().*/1.sayGoodbye
   val soLong1/*<-a::b::Givens.soLong1.*/ = /*->a::b::Givens.extension_sayGoodbye_B.saySoLong().*/1.saySoLong
 
-  trait Monoid/*<-a::b::Givens.Monoid#*/[A/*<-a::b::Givens.Monoid#[A]*/]
+  trait Monoid/*<-a::b::Givens.Monoid#*/[A/*<-a::b::Givens.Monoid#[A]*/]:
     def empty/*<-a::b::Givens.Monoid#empty().*/: A/*->a::b::Givens.Monoid#[A]*/
     def (x: A)./*<-a::b::Givens.Monoid#combine().*//*<-a::b::Givens.Monoid#combine().(x)*//*->a::b::Givens.Monoid#[A]*/combine(y/*<-a::b::Givens.Monoid#combine().(y)*/: A/*->a::b::Givens.Monoid#[A]*/): A/*->a::b::Givens.Monoid#[A]*/
 
-  given Monoid[String]
-    /*<-a::b::Givens.given_Monoid_String.*//*->a::b::Givens.Monoid#*//*->scala::Predef.String#*/def empty/*<-a::b::Givens.given_Monoid_String.empty().*/ = ""
+  given Monoid[String]:
+   /*<-a::b::Givens.given_Monoid_String.*//*->a::b::Givens.Monoid#*//*->scala::Predef.String#*/ def empty/*<-a::b::Givens.given_Monoid_String.empty().*/ = ""
     def (x: Str/*<-a::b::Givens.given_Monoid_String.combine().*//*<-a::b::Givens.given_Monoid_String.combine().(x)*/ing/*->scala::Predef.String#*/).combine(y/*<-a::b::Givens.given_Monoid_String.combine().(y)*/: String/*->scala::Predef.String#*/) = x/*->a::b::Givens.given_Monoid_String.combine().(x)*/ +/*->java::lang::String#`+`().*/ y/*->a::b::Givens.given_Monoid_String.combine().(y)*/
 
   inline given int2String/*<-a::b::Givens.int2String().*/: Conversion/*->scala::Conversion#*/[Int/*->scala::Int#*/, String/*->scala::Predef.String#*/] = _.toString/*->scala::Any#toString().*/

--- a/tests/semanticdb/expect/Givens.scala
+++ b/tests/semanticdb/expect/Givens.scala
@@ -1,12 +1,12 @@
 package a
 package b
 
-object Givens
+object Givens:
 
-  given extension [A](any: A)
+  extension on [A](any: A):
     def sayHello = s"Hello, I am $any"
 
-  given extension [B](any: B)
+  extension on [B](any: B):
     def sayGoodbye = s"Goodbye, from $any"
     def saySoLong = s"So Long, from $any"
 
@@ -14,11 +14,11 @@ object Givens
   val goodbye1 = 1.sayGoodbye
   val soLong1 = 1.saySoLong
 
-  trait Monoid[A]
+  trait Monoid[A]:
     def empty: A
     def (x: A).combine(y: A): A
 
-  given Monoid[String]
+  given Monoid[String]:
     def empty = ""
     def (x: String).combine(y: String) = x + y
 

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -1308,21 +1308,21 @@ Occurrences:
 [0:8..0:9): a <- a/
 [1:8..1:9): b <- a/b/
 [3:7..3:13): Givens <- a/b/Givens.
-[5:8..5:28): extension [A](any: A <- a/b/Givens.extension_sayHello_A.
-[5:19..5:20): A <- a/b/Givens.extension_sayHello_A.sayHello().[A]
-[5:22..5:25): any <- a/b/Givens.extension_sayHello_A.sayHello().(any)
-[5:27..5:28): A -> a/b/Givens.extension_sayHello_A.sayHello().[A]
+[5:16..6:8): <- a/b/Givens.extension_sayHello_A.
+[5:16..5:17): A <- a/b/Givens.extension_sayHello_A.sayHello().[A]
+[5:19..5:22): any <- a/b/Givens.extension_sayHello_A.sayHello().(any)
+[5:24..5:25): A -> a/b/Givens.extension_sayHello_A.sayHello().[A]
 [6:8..6:16): sayHello <- a/b/Givens.extension_sayHello_A.sayHello().
 [6:21..6:21): -> scala/StringContext.apply().
 [6:34..6:37): any -> a/b/Givens.extension_sayHello_A.sayHello().(any)
 [6:37..6:37): -> scala/StringContext#s().
-[8:8..9:0): <- a/b/Givens.extension_sayGoodbye_B.
-[8:19..8:20): B <- a/b/Givens.extension_sayGoodbye_B.sayGoodbye().[B]
-[8:19..8:20): B <- a/b/Givens.extension_sayGoodbye_B.saySoLong().[B]
-[8:22..8:25): any <- a/b/Givens.extension_sayGoodbye_B.sayGoodbye().(any)
-[8:22..8:25): any <- a/b/Givens.extension_sayGoodbye_B.saySoLong().(any)
-[8:27..8:28): B -> a/b/Givens.extension_sayGoodbye_B.sayGoodbye().[B]
-[8:27..8:28): B -> a/b/Givens.extension_sayGoodbye_B.saySoLong().[B]
+[8:16..9:10): <- a/b/Givens.extension_sayGoodbye_B.
+[8:16..8:17): B <- a/b/Givens.extension_sayGoodbye_B.sayGoodbye().[B]
+[8:16..8:17): B <- a/b/Givens.extension_sayGoodbye_B.saySoLong().[B]
+[8:19..8:22): any <- a/b/Givens.extension_sayGoodbye_B.sayGoodbye().(any)
+[8:19..8:22): any <- a/b/Givens.extension_sayGoodbye_B.saySoLong().(any)
+[8:24..8:25): B -> a/b/Givens.extension_sayGoodbye_B.sayGoodbye().[B]
+[8:24..8:25): B -> a/b/Givens.extension_sayGoodbye_B.saySoLong().[B]
 [9:8..9:18): sayGoodbye <- a/b/Givens.extension_sayGoodbye_B.sayGoodbye().
 [9:23..9:23): -> scala/StringContext.apply().
 [9:38..9:41): any -> a/b/Givens.extension_sayGoodbye_B.sayGoodbye().(any)
@@ -1348,7 +1348,7 @@ Occurrences:
 [18:23..18:24): y <- a/b/Givens.Monoid#combine().(y)
 [18:26..18:27): A -> a/b/Givens.Monoid#[A]
 [18:30..18:31): A -> a/b/Givens.Monoid#[A]
-[20:8..21:4): <- a/b/Givens.given_Monoid_String.
+[20:8..21:3): <- a/b/Givens.given_Monoid_String.
 [20:8..20:14): Monoid -> a/b/Givens.Monoid#
 [20:15..20:21): String -> scala/Predef.String#
 [21:8..21:13): empty <- a/b/Givens.given_Monoid_String.empty().


### PR DESCRIPTION
The new syntax requires a `:`. The old syntax was still supported
under a Config option which was on by default. But the test is further
confirmation that silent identation without a specific leading token
is a bad idea.