### PR TITLE
Fix FileSystemException in AbstractFileTest.scala

### DIFF
--- a/compiler/test/dotty/tools/io/AbstractFileTest.scala
+++ b/compiler/test/dotty/tools/io/AbstractFileTest.scala
@@ -4,6 +4,7 @@ import org.junit.Test
 
 import dotty.tools.io.AbstractFile
 import java.nio.file.Files._
+import java.nio.file.attribute.PosixFilePermissions
 
 class AbstractFileTest {
   //
@@ -15,7 +16,11 @@ class AbstractFileTest {
   //
   private def exerciseSymbolicLinks(temp: Directory): Unit = {
     val base = {
-      val target = createTempDirectory(temp.jpath, "real")
+      val permissions = PosixFilePermissions.fromString("rwxrwxrwx")
+      val attributes = PosixFilePermissions.asFileAttribute(permissions)
+      // Specifying the 'attributes' parameter on Windows prevents a
+      // FileSystemException "A required privilege is not held by the client".
+      val target = createTempDirectory(temp.jpath, "real", attributes)
       val link   = temp.jpath.resolve("link")
       createSymbolicLink(link, target)     // may bail early if unsupported
       AbstractFile.getDirectory(link)


### PR DESCRIPTION
This fix solves one test case among several tests still failing on Windows (Win10/Java 8).

```
> sbt "testOnly dotty.tools.io.AbstractFileTest"
[info] Loading settings for project dotty-t6450-build-build from build.sbt ...
[info] Loading project definition from W:\dotty-t6450\project\project
[info] Loading settings for project dotty-t6450-build from build.sbt,plugins.sbt ...
[info] Loading project definition from W:\dotty-t6450\project
[info] Loading settings for project dotty from build.sbt ...
[info] Resolving key references (25620 settings) ...
[info] Set current project to dotty (in build file:/W:/dotty-t6450/)
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-interfaces / Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-library / Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for tasty-core / Test / testOnly
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-sbt-bridge / Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-doc / Test / testOnly
[info] Test run started
[info] Test dotty.tools.io.AbstractFileTest.t6450 started
[error] Test dotty.tools.io.AbstractFileTest.t6450 failed: java.nio.file.FileSystemException: %USERPROFILE%\AppData\Local\Temp\temp7457587145967456791\link: A required privilege is not held by the client.
[error] , took 0.485 sec
[error]     at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:86)
[error]     at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:97)
[error]     at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:102)
[error]     at sun.nio.fs.WindowsFileSystemProvider.createSymbolicLink(WindowsFileSystemProvider.java:585)
[error]     at java.nio.file.Files.createSymbolicLink(Files.java:1043)
[error]     at dotty.tools.io.AbstractFileTest.exerciseSymbolicLinks(AbstractFileTest.scala:25)
[error]     at dotty.tools.io.AbstractFileTest.t6450$$anonfun$1(AbstractFileTest.scala:44)
[error]     at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
[error]     at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
[error]     at dotty.tools.io.Directory$.inTempDirectory(Directory.scala:26)
[error]     at dotty.tools.io.AbstractFileTest.t6450(AbstractFileTest.scala:44)
[error]     ...
[info] Test run finished: 1 failed, 0 ignored, 1 total, 0.485s
[error] Failed: Total 1, Failed 1, Errors 0, Passed 0
[error] Failed tests:
[error]         dotty.tools.io.AbstractFileTest
[error] (dotty-compiler / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 8 s, completed 8 Feb. 2020 14:33:49
```
Extending the user access rights **locally** (using file attributes) does solve the issue:

```
> sbt "testOnly   dotty.tools.io.AbstractFileTest"
[info] Loading settings for project dotty-build-build from build.sbt ...
[info] Loading project definition from W:\dotty\project\project
[info] Loading settings for project dotty-build from build.sbt,plugins.sbt ...
[info] Loading project definition from W:\dotty\project
[info] Loading settings for project dotty from build.sbt ...
[info] Resolving key references (25620 settings) ...
[info] Set current project to dotty (in build file:/W:/dotty/)
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-interfaces / Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-library / Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for tasty-core / Test / testOnly
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for Test / testOnly
[info] Compiling 1 Scala source to W:\dotty\compiler\target\scala-0.22\test-classes ...
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-sbt-bridge / Test / testOnly
[info] Test run started
[info] Test dotty.tools.io.AbstractFileTest.t6450 started
[info] Test run finished: 0 failed, 0 ignored, 1 total, 0.719s
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-doc / Test / testOnly
[success] Total time: 18 s, completed 8 Feb 2020 14:25:44
```
