### PR TITLE
Fix issue #8124

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -150,7 +150,8 @@ object Settings {
             update(output, args)
           }
         case (StringTag, arg2 :: args2) =>
-          update(arg2, args2)
+          if (arg2 startsWith "-") missingArg
+          else update(arg2, args2)
         case (IntTag, arg2 :: args2) =>
           try {
             val x = arg2.toInt

--- a/compiler/test/dotty/tools/dotc/SettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/SettingsTests.scala
@@ -28,4 +28,14 @@ class SettingsTests {
     assertEquals(0, reporter.errorCount)
     assertTrue(Files.exists(out))
   }
+
+  @Test def t8124: Unit = {
+    val source = Paths.get("tests/pos/Foo.scala").normalize
+    val outputDir = Paths.get("out/testSettings").normalize
+    if (Files.notExists(outputDir)) Files.createDirectory(outputDir)
+    val options = Array("-encoding", "-d", outputDir.toString, source.toString)
+    val reporter = Main.process(options)
+    assertEquals(1, reporter.errorCount)
+   }
+
 }

--- a/doc-tool/test/dotty/tools/dottydoc/SettingsTests.scala
+++ b/doc-tool/test/dotty/tools/dottydoc/SettingsTests.scala
@@ -1,0 +1,18 @@
+package dotty.tools
+package dottydoc
+
+import org.junit.Test
+import org.junit.Assert._
+
+class SettingsTests {
+
+  @Test def t8124: Unit = {
+    val source = "tests/pos/Foo.scala"
+    val url = "https://github.com/lampepfl/dotty/tree/master/tests"
+    val options = Array("-project", "-project-url", url, source)
+    val reporter = Main.process(options)
+    assertEquals(2, reporter.errorCount)
+    assertEquals("missing argument for option -project", reporter.allErrors.last.message)
+  }
+
+}


### PR DESCRIPTION
Also added two tests for `dotc` and `dotd`.


Updated behavior with `dotd` (crashed before fix):
```
> c:\opt\dotty-0.22.0-RC1\bin\dotd -project -project-url "http://" dummy.scala
-project -project-url "https://" dummy.scala
missing argument for option -project
  dotc -help  gives more information
Site project name not set. Use `-project <title>` to set the project name
```

Updated behavior with `dotc` (crashed before fix):
```
> c:\opt\dotty-0.22.0-RC1\bin\dotc -encoding -d c:\temp\classes dummy.scala
missing argument for option -encoding
  dotc -help  gives more information
```
