### PR TITLE
Reject char literal of raw newline

### DIFF
--- a/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
@@ -49,6 +49,9 @@ class VulpixUnitTests extends ParallelTesting {
   @Test def negNoPositionAnnot: Unit =
     compileFile("tests/vulpix-tests/unit/negNoPositionAnnots.scala", defaultOptions).expectFailure.checkExpectedErrors()
 
+  @Test def negAnyPositionAnnot: Unit =
+    compileFile("tests/vulpix-tests/unit/negAnyPositionAnnots.scala", defaultOptions).checkExpectedErrors()
+
   @Test def runCompileFail: Unit =
     compileFile("tests/vulpix-tests/unit/posFail1Error.scala", defaultOptions).expectFailure.checkRuns()
 

--- a/tests/neg/t6810.check
+++ b/tests/neg/t6810.check
@@ -1,0 +1,24 @@
+-- Error: tests/neg/t6810.scala:5:10 -----------------------------------------------------------------------------------
+5 |  val y = '
+  |          ^
+  |          unclosed character literal
+-- Error: tests/neg/t6810.scala:12:10 ----------------------------------------------------------------------------------
+12 |  val Y = "
+   |          ^
+   |          unclosed string literal
+-- Error: tests/neg/t6810.scala:13:0 -----------------------------------------------------------------------------------
+13 |"                     // error obviously not
+   |^
+   |unclosed string literal
+-- Error: tests/neg/t6810.scala:24:6 -----------------------------------------------------------------------------------
+24 |  val `
+   |      ^
+   |      unclosed quoted identifier
+-- Error: tests/neg/t6810.scala:25:0 -----------------------------------------------------------------------------------
+25 |` = EOL               // error not raw string literals aka triple-quoted, multiline strings
+   |^
+   |unclosed quoted identifier
+-- Error: tests/neg/t6810.scala:30:10 ----------------------------------------------------------------------------------
+30 |  val b = '
+   |          ^
+   |          unclosed character literal

--- a/tests/neg/t6810.scala
+++ b/tests/neg/t6810.scala
@@ -1,0 +1,33 @@
+
+trait t6810 {
+  val x = '\u000A'    // char literals accept arbitrary unicode escapes
+                      // anypos-error so as not to interfere with the following bad syntax
+  val y = '
+'                     // but not embedded EOL sequences not represented as escapes
+  println();          // scanner firewall
+  val z = '\n'        // normally, expect this escape
+
+  val X = "\u000A"    // it's the same as ordinary string literals
+                      // anypos-error so as not to interfere with the following bad syntax
+  val Y = "
+"                     // error obviously not
+  val Z = "\n"        // normally, expect this escape
+
+  val A = """
+"""                   // which is what these are for
+  val B = s"""
+"""                   // or the same for interpolated strings
+
+  import System.{lineSeparator => EOL}
+  val `\u000A` = EOL  // backquoted identifiers are arbitrary string literals
+                      // anypos-error so as not to interfere with the following bad syntax
+  val `
+` = EOL               // error not raw string literals aka triple-quoted, multiline strings
+
+  val firebreak = 42  // help parser recovery, could also use rbrace
+
+  val a = '\u000D'    // similar treatment of CR
+  val b = ''        // anypos-error CR seen as EOL by scanner; FSR, error only on open quote, unlike `y`
+  println();          // scanner firewall
+  val c = '\r'        // traditionally
+}

--- a/tests/vulpix-tests/unit/negAnyPositionAnnots.scala
+++ b/tests/vulpix-tests/unit/negAnyPositionAnnots.scala
@@ -1,0 +1,5 @@
+object Foo {
+  def bar: Int = "LOL"
+
+  // anypos-error
+}


### PR DESCRIPTION
Don't allow char literal to span a natural line
ending, but do allow `'\u000A'` to mean `'\n'`.
The spec was updated to reflect that meaning,
and the direction is to eliminate Unicode escapes
outside quotes.

Update the test rig so that `// anypos-error` can be
used to match any position, since the test cannot
be expressed on one line with a trailing comment.

Forward port of fix on 2.12.

https://github.com/scala/scala/commit/d7547cb76d41da04c8448cf1de8a5b5686152d17