### PR TITLE
doc(macros): add missing `using QuoteContext`

### DIFF
--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -223,7 +223,7 @@ The compiler takes an environment that maps variable names to Scala `Expr`s.
 ```scala
 import scala.quoted.{given, _}
 
-def compile(e: Exp, env: Map[String, Expr[Int]]): Expr[Int] = e match {
+def compile(e: Exp, env: Map[String, Expr[Int]])(using QuoteContext): Expr[Int] = e match {
   case Num(n) =>
     Expr(n)
   case Plus(e1, e2) =>


### PR DESCRIPTION
I tried to run the example with scastie: https://scastie.scala-lang.org/9xO9TXZKS8ydfLsSo3ZJ0g
I guess the example is missing the `using QuoteContext`. 
Where do I get this context from initially?