### PR TITLE
Make 1L == 1 an error under strict equality

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -975,7 +975,9 @@ trait Applications extends Compatibility {
         app match {
           case Apply(fn @ Select(left, _), right :: Nil) if fn.hasType =>
             val op = fn.symbol
-            if (op == defn.Any_== || op == defn.Any_!=)
+            if op == defn.Any_== ||
+                op == defn.Any_!= ||
+                (defn.ScalaNumericValueTypeList.contains(left.tpe.widen) && (op.name == nme.EQ || op.name == nme.NE)) then
               checkCanEqual(left.tpe.widen, right.tpe.widen, app.span)
           case _ =>
         }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -803,11 +803,12 @@ trait Implicits { self: Typer =>
       def canComparePredefinedClasses(cls1: ClassSymbol, cls2: ClassSymbol): Boolean = {
         def cmpWithBoxed(cls1: ClassSymbol, cls2: ClassSymbol) =
           cls2 == defn.boxedType(cls1.typeRef).symbol ||
-          cls1.isNumericValueClass && cls2.derivesFrom(defn.BoxedNumberClass)
+          (!strictEquality && cls1.isNumericValueClass && cls2.derivesFrom(defn.BoxedNumberClass))
 
         if (cls1.isPrimitiveValueClass)
           if (cls2.isPrimitiveValueClass)
-            cls1 == cls2 || cls1.isNumericValueClass && cls2.isNumericValueClass
+            cls1 == cls2 ||
+            (!strictEquality && cls1.isNumericValueClass && cls2.isNumericValueClass)
           else
             cmpWithBoxed(cls1, cls2)
         else if (cls2.isPrimitiveValueClass)

--- a/library/src/scala/Eql.scala
+++ b/library/src/scala/Eql.scala
@@ -23,7 +23,6 @@ object Eql {
   def eqlAny[L, R]: Eql[L, R] = derived
 
   // Instances of `Eql` for common Java types
-  given eqlNumber as Eql[Number, Number] = derived
   given eqlString as Eql[String, String] = derived
 
   // The next three definitions can go into the companion objects of classes


### PR DESCRIPTION
This is a PR for half of https://contributors.scala-lang.org/t/equal-protection-under-eq-law/4034 proposal.
