### PR TITLE
Fix printed file path in PrintingTest.scala

### DIFF
--- a/compiler/test/dotty/tools/vulpix/FileDiff.scala
+++ b/compiler/test/dotty/tools/vulpix/FileDiff.scala
@@ -3,6 +3,7 @@ package dotty.tools.vulpix
 import scala.io.Source
 import java.io.File
 import java.lang.System.{lineSeparator => EOL}
+import java.nio.file.{Files, Paths}
 
 object FileDiff {
   def diffMessage(expectFile: String, actualFile: String): String =
@@ -34,15 +35,20 @@ object FileDiff {
     outFile.writeAll(content.mkString("", EOL, EOL))
   }
 
-  def checkAndDump(sourceTitle: String, actualLines: Seq[String], checkFilePath: String): Boolean =
+  def checkAndDump(sourceTitle: String, actualLines: Seq[String], checkFilePath: String): Boolean = {
+    val outFilePath = checkFilePath + ".out"
     FileDiff.check(sourceTitle, actualLines, checkFilePath) match {
       case Some(msg) =>
-        val outFilePath = checkFilePath + ".out"
         FileDiff.dump(outFilePath, actualLines)
         println(msg)
         println(FileDiff.diffMessage(checkFilePath, outFilePath))
         false
       case _ =>
+        val jOutFilePath = Paths.get(outFilePath)
+        if (Files.exists(jOutFilePath))
+          try { Files.delete(jOutFilePath) } catch { case _: Exception => () }
         true
     }
+  }
+
 }

--- a/compiler/test/dotty/tools/vulpix/FileDiff.scala
+++ b/compiler/test/dotty/tools/vulpix/FileDiff.scala
@@ -45,8 +45,7 @@ object FileDiff {
         false
       case _ =>
         val jOutFilePath = Paths.get(outFilePath)
-        if (Files.exists(jOutFilePath))
-          try { Files.delete(jOutFilePath) } catch { case _: Exception => () }
+        Files.deleteIfExists(jOutFilePath)
         true
     }
   }


### PR DESCRIPTION

This fix solves one test case among several tests still failing on Windows (Win10/Java 8).
```
> sbt "testOnly dotty.tools.dotc.PrintingTest"
[info] Loading settings for project dotty-build-build from build.sbt ...
[info] Loading project definition from W:\dotty\project\project
[info] Loading settings for project dotty-build from build.sbt,plugins.sbt ...
[info] Loading project definition from W:\dotty\project
[info] Loading settings for project dotty from build.sbt ...
[info] Resolving key references (25620 settings) ...
[info] Set current project to dotty (in build file:/W:/dotty/)
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-interfaces / Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-library / Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for tasty-core / Test / testOnly
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for Test / testOnly
[info] Compiling 1 Scala source to W:\dotty\compiler\target\scala-0.22\test-classes ...
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-sbt-bridge / Test / testOnly
[info] Test run started
[info] Test dotty.tools.dotc.PrintingTest.printing started
Output from 'tests\printing\i620.scala' did not match check file. Actual output:
result of tests\printing\i620.scala after typer:
package O {
  package O.A {
    class D() extends Object() {
      class C() extends Object() {
        protected[D] def a: Int = 0
        private[D] def b: Int = 0
        private[this] def c: Int = 0
        protected def d: Int = 0
        private[A] def e: Int = 0
        protected[A] def f: Int = 0
        def g: Int = 0
        def g1(t: Int): Int = 0
        def (c: D.this.C) g1: Int = 0
      }
      private[D] class E() extends Object() {}
      private[this] class F() extends Object() {}
      private[A] class G() extends Object() {}
      protected[D] class H() extends Object() {}
      protected class I() extends Object() {}
      protected[A] class J() extends Object() {}
      class K() extends Object() {}
      protected[D] val a: Int = 0
      private[D] val b: Int = 0
      private[this] val c: Int = 0
      protected val d: Int = 0
      private[A] val e: Int = 0
      protected[A] val f: Int = 0
      val g: Int = 0
    }
  }
}


[error] Test dotty.tools.dotc.PrintingTest.printing failed: java.lang.AssertionError: assertion failed: Pass: 0, Failed: 1, took 4.0 sec
Test output dumped in: tests\printing\i620.check.out
  See diff of the checkfile (`brew install icdiff` for colored diff)
    > diff tests\printing\i620.check tests\printing\i620.check.out
  Replace checkfile with current output
    > mv tests\printing\i620.check.out tests\printing\i620.check

[error]     at dotty.DottyPredef$.assertFail(DottyPredef.scala:17)
[error]     at dotty.tools.dotc.PrintingTest.printing(PrintingTest.scala:59)
[error]     ...
[info] Test run finished: 1 failed, 0 ignored, 1 total, 4.391s
[error] Failed: Total 1, Failed 1, Errors 0, Passed 0
[error] Failed tests:
[error]         dotty.tools.dotc.PrintingTest
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-doc / Test / testOnly
[error] (dotty-compiler / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 19 s, completed 11 Feb 2020 21:28:11
```
On Windows both files differ only in the first line for test `i620.scala` :
- 1st line in check file: `result of tests/printing/i620.scala after typer:`
- 1st line in output file: `result of tests\printing\i620.scala after typer:`

Replacing selectively the file separator on Windows does solve the issue:
```
> sbt "testOnly dotty.tools.dotc.PrintingTest"
[info] Loading settings for project dotty-i620-build-build from build.sbt ...
[info] Loading project definition from W:\dotty-i620\project\project
[info] Loading settings for project dotty-i620-build from build.sbt,plugins.sbt ...
[info] Loading project definition from W:\dotty-i620\project
[info] Loading settings for project dotty from build.sbt ...
[info] Resolving key references (25620 settings) ...
[info] Set current project to dotty (in build file:/W:/dotty-i620/)
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-library / Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-interfaces / Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for tasty-core / Test / testOnly
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-sbt-bridge / Test / testOnly
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for dotty-doc / Test / testOnly
[info] Test run started
[info] Test dotty.tools.dotc.PrintingTest.printing started
Pass: 1, Failed: 0
[info] Test run finished: 0 failed, 0 ignored, 1 total, 4.0s
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 12 s, completed 11 Feb 2020 21:25:30
```