### PR TITLE
Fix #7597: Refine checks whether a deferred term member is implemented

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2377,7 +2377,7 @@ object SymDenotations {
     /** is the cache valid in current run at given phase? */
     def isValidAt(phase: Phase)(implicit ctx: Context): Boolean
 
-    /** Render invalid this cache and all cache that depend on it */
+    /** Render invalid this cache and all caches that depend on it */
     def invalidate(): Unit
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -6,7 +6,7 @@ import core._
 import Contexts._, Types._, Symbols._, Names._, Decorators._, ProtoTypes._
 import Flags._
 import NameKinds.FlatName
-import config.Printers.implicits
+import config.Printers.{implicits, implicitsDetailed}
 import util.Spans.Span
 import ast.{untpd, tpd}
 import Implicits.{hasExtMethod, Candidate}
@@ -94,7 +94,7 @@ trait ImportSuggestions:
     def rootsIn(ref: TermRef)(using Context): List[TermRef] =
       if seen.contains(ref) then Nil
       else
-        implicits.println(i"search for suggestions in ${ref.symbol.fullName}")
+        implicitsDetailed.println(i"search for suggestions in ${ref.symbol.fullName}")
         seen += ref
         ref :: rootsStrictlyIn(ref)
 

--- a/tests/explicit-nulls/neg/override-java-object-arg.scala
+++ b/tests/explicit-nulls/neg/override-java-object-arg.scala
@@ -7,7 +7,7 @@ import javax.management.{Notification, NotificationEmitter, NotificationListener
 class Foo {
 
   def bar(): Unit = {
-    val listener = new NotificationListener() {
+    val listener = new NotificationListener() { // error: object creation impossible
       override def handleNotification(n: Notification|Null, emitter: Object): Unit = { // error: method handleNotification overrides nothing
       }
     }
@@ -17,7 +17,7 @@ class Foo {
       }
     }
 
-    val listener3 = new NotificationListener() {
+    val listener3 = new NotificationListener() { // error: object creation impossible
       override def handleNotification(n: Notification, emitter: Object|Null): Unit = { // error: method handleNotification overrides nothing
       }
     }

--- a/tests/neg-custom-args/erased/erased-case-class.scala
+++ b/tests/neg-custom-args/erased/erased-case-class.scala
@@ -1,1 +1,1 @@
-case class Foo1(erased x: Int) // error // error
+case class Foo1(erased x: Int) // error

--- a/tests/neg/i7597.scala
+++ b/tests/neg/i7597.scala
@@ -1,0 +1,14 @@
+object Test extends App {
+  def foo[S <: String]: String => Int =
+    new (String => Int) { def apply(s: S): Int = 0 } // error
+
+  trait Fn[A, B] {
+    def apply(x: A): B
+  }
+
+  class C[S <: String] extends Fn[String, Int] {  // error
+    def apply(s: S): Int = 0
+  }
+
+  foo("")
+}


### PR DESCRIPTION
The check for a concrete class used to be simply that its `abstractTermMembers`
are empty. However, i7597.scala shows that this is not enough. The problem is
that abstractTermMembers is based on signatures. It will not include a member
as long as there is a concrete member with the same signature.

But as #7597 shows it's possible for a concrete member to have the same signature
as an abstract one but still not have a matching type.