### PR TITLE
Fix #8333: Check for duplicate symbols in exports

### DIFF
--- a/tests/neg/i8333.scala
+++ b/tests/neg/i8333.scala
@@ -1,0 +1,13 @@
+class A:
+  type T = Int // can also be class T
+class B(x: A, y: A):
+  export x._
+  export y._  // error: duplicate
+class C(x: A):
+  type T = String
+  export x._  // error: duplicate
+class D(x: A):
+  export x._  // error: duplicate
+  type T = String
+
+


### PR DESCRIPTION
Check for duplicate symbols when  creating export forwarders.