### PR TITLE
Fix #8306: Ensure the inliner can elide effectively pure case class applications in various situations

### DIFF
--- a/tests/run/i8306.check
+++ b/tests/run/i8306.check
@@ -1,0 +1,25 @@
+compile-time: 3
+run-time: 3
+compile-time: 3
+run-time: 3
+compile-time: 3
+run-time: 3
+compile-time: 3
+run-time: 3
+compile-time: {
+  val $elem9: A = Test.a
+  val $elem10: Int = $elem9.i
+  val i: Int = $elem10
+  i:Int
+}
+run-time: 3
+compile-time: 3
+run-time: 3
+compile-time: 3
+run-time: 3
+compile-time: 3
+run-time: 3
+compile-time: 3
+run-time: 3
+compile-time: 3
+run-time: 3

--- a/tests/run/i8306.scala
+++ b/tests/run/i8306.scala
@@ -1,0 +1,93 @@
+import scala.compiletime._
+
+case class A(i: Int)
+case class B(a: A)
+case class C[T](t: T)
+
+trait Test8 {
+  inline def test8: Int =
+    inline A(3) match {
+      case A(i) => i
+    }
+}
+
+object Test extends Test8 {
+
+  inline def test1: Int =
+    inline A(3) match {
+      case A(i) => i
+    }
+
+  inline def test2: Int =
+    inline (A(3) : A) match {
+      case A(i) => i
+    }
+
+  inline def test3: Int =
+    inline B(A(3)) match {
+      case B(A(i)) => i
+    }
+
+  inline def test4: Int =
+    A(3).i
+
+  val a = A(3)
+  inline def test5: Int =
+    inline new B(a) match {
+      case B(A(i)) => i
+    }
+
+  inline def test6: Int =
+    inline B(A(3)).a match {
+      case A(i) => i
+    }
+
+  inline def test7: Int =
+    inline new A(3) match {
+      case A(i) => i
+    }
+
+  inline def test9: Int =
+    B(A(3)).a.i
+
+  inline def test10: Int =
+    inline C(3) match {
+      case C(t) => t
+    }
+
+  def main(argv: Array[String]): Unit = {
+    println(code"compile-time: ${test1}")
+    println(s"run-time: ${test1}")
+
+    println(code"compile-time: ${test2}")
+    println(s"run-time: ${test2}")
+
+    println(code"compile-time: ${test3}")
+    println(s"run-time: ${test3}")
+
+    println(code"compile-time: ${test4}")
+    println(s"run-time: ${test4}")
+
+    // this is the only test that should not be possible to fully inline,
+    // because it references a non-inline value
+    println(code"compile-time: ${test5}")
+    println(s"run-time: ${test5}")
+
+    println(code"compile-time: ${test6}")
+    println(s"run-time: ${test6}")
+
+    println(code"compile-time: ${test7}")
+    println(s"run-time: ${test7}")
+
+    println(code"compile-time: ${test8}")
+    println(s"run-time: ${test8}")
+
+    println(code"compile-time: ${test9}")
+    println(s"run-time: ${test9}")
+
+    // with type parameter
+    println(code"compile-time: ${test10}")
+    println(s"run-time: ${test10}")
+  }
+}
+


### PR DESCRIPTION
This is a collection of related changes, all to ensure that the inliner is capable of properly eliding case class constructions in various situations.

While I have made sure to avoid breaking anything, these changes do noticeably change Dotty's behaviour in common situations. Feedback on the direction of these changes is appreciated. See the issue for some more rationale.

Specific intended changes:
- allow NewInstance.unapply to look past type ascriptions
- change all purity checks to consider, for the inliner only, case class applications (when the apply method is synthetic and the case class has no constructor body) pure, or "elideable", despite the fact that the operation is almost always idempotent in the general case.
- make reduceInlineMatch's reduceSubPatterns procedure set the defTree for the accessor projections it generates, so nested Unapply patterns can look in defTree to find and possibly inline the appropriate subtree of the scrutinee expression
- make the typedSelect override able to reduce projections without a corresponding inline match, so that if inlining produces SomeCaseClass(x=3).x the case class construction has a chance to be elided (only in an inline context)

This PR also includes a series of test cases which use compiletime.show to pretty-print the resulting inlined AST of a series of inline expansions. To avoid cases where a malformed AST pretty-prints but causes bad codegen, the computed run-time value is also printed.

One last thing I tested manually was that the bytecode matched the pretty-printing. Mid-work on this commit I found that the pretty printer was hiding several cases where redundant code was left in but not showing up when pretty-printed. This is partially tested by the case where full inlining is not possible, which would also include a redundant binding for the scrutinee if that issue were still present.