### PR TITLE
Clean tests output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: Dotty CI
 
 on: [push, pull_request]
 
+env:
+  DOTTY_CI_RUN: true
+
 jobs:
   test:
     runs-on: self-hosted

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -11,8 +11,9 @@ object Properties {
     prop == null || prop == "TRUE"
   }
 
-  /** Are we running on the Drone CI? */
-  val isRunByDrone: Boolean = sys.env.isDefinedAt("DRONE")
+  /** Are we running on the CI? */
+  val isRunByCI: Boolean = sys.env.isDefinedAt("DOTTY_CI_RUN")
+  || sys.env.isDefinedAt("DRONE")  // TODO remove this when we drop Drone
 
   /** Tests should run interactive? */
   val testsInteractive: Boolean = propIsNullOrTrue("dotty.tests.interactive")

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -417,21 +417,15 @@ trait ParallelTesting extends RunnerOrchestration { self =>
      *  if it did, the test should automatically fail.
      */
     protected def tryCompile(testSource: TestSource)(op: => Unit): Unit =
-      try {
-        val testing = s"Testing ${testSource.title}"
-        summaryReport.echoToLog(testing)
-        if (!isInteractive) realStdout.println(testing)
-        op
-      } catch {
-        case e: Throwable => {
+      try op
+      catch
+        case e: Throwable =>
           // if an exception is thrown during compilation, the complete test
           // run should fail
           failTestSource(testSource)
           e.printStackTrace()
           registerCompletion()
           throw e
-        }
-      }
 
     protected def compile(files0: Array[JFile], flags0: TestFlags, suppressErrors: Boolean, targetDir: JFile): TestReporter = {
       val flags = flags0.and("-d", targetDir.getPath)

--- a/compiler/test/dotty/tools/vulpix/SummaryReport.scala
+++ b/compiler/test/dotty/tools/vulpix/SummaryReport.scala
@@ -147,5 +147,5 @@ final class SummaryReport extends SummaryReporting {
 }
 
 object SummaryReport {
-  val isInteractive = Properties.testsInteractive && !Properties.isRunByDrone
+  val isInteractive = Properties.testsInteractive && !Properties.isRunByCI
 }


### PR DESCRIPTION
An environmental variable is assumed to be set on CI runs to
distinguish them from local runs. Do not pollute the tests
output with statements that a certain test was executed.