### PR TITLE
Fix #8349: Generic signatures of generic arrays

### DIFF
--- a/tests/generic-java-signatures/arrayBound.check
+++ b/tests/generic-java-signatures/arrayBound.check
@@ -3,3 +3,6 @@ U <: T[]
 V <: java.util.List<T[]>
 W <: java.util.List<? extends java.util.Date>
 X <: java.util.HashMap<java.lang.Object, java.util.ArrayList<? extends java.util.Date>>
+T1 <: java.lang.Object
+U1 <: java.lang.Object
+V1 <: java.lang.Object[]

--- a/tests/generic-java-signatures/arrayBound.scala
+++ b/tests/generic-java-signatures/arrayBound.scala
@@ -1,7 +1,16 @@
-class Foo[T <: Array[_], U <: Array[T], V <: java.util.List[Array[T]], W <: java.util.List[_ <: java.util.Date], X <: java.util.HashMap[Array[_], java.util.ArrayList[_ <: java.util.Date]]]
+class Foo[
+  T <: Array[_],
+  U <: Array[T],
+  V <: java.util.List[Array[T]],
+  W <: java.util.List[_ <: java.util.Date],
+  X <: java.util.HashMap[Array[_], java.util.ArrayList[_ <: java.util.Date]],
+  T1,
+  U1 <: Array[T1],
+  V1 <: Array[Array[T1]]
+]
 object Test {
   def main(args: Array[String]): Unit = {
-    val tParams = classOf[Foo[_, _, _, _, _]].getTypeParameters()
+    val tParams = classOf[Foo[_, _, _, _, _, _, _, _]].getTypeParameters()
     tParams.foreach { tp =>
       println(tp.getName + " <: " + tp.getBounds.map(_.getTypeName).mkString(", "))
     }

--- a/tests/generic-java-signatures/primitives.check
+++ b/tests/generic-java-signatures/primitives.check
@@ -6,4 +6,4 @@ E <: int[]
 F <: long[]
 G <: short[]
 H <: boolean[]
-I <: java.lang.Object
+I <: byte[]


### PR DESCRIPTION
When T[] is erased to Object, it should get a Java generic signature of
Object and not of T<>. Fixed by reusing the same logic we have in
TypeErasure which replaces a bunch of weird code imported from scalac.

The new behavior differs in one case from scalac: `Array[_ <: Byte]`
gets a generic signature of `byte[]` instead of `Object`, but this is
consistent with how we handle erasure (which I think is OK because as
far as I can tell, we can't construct a value of type `Array[Nothing]`
with Dotty).