### PR TITLE
Fix #8313: special case typeparamCorrespondsToField

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2219,13 +2219,15 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
   /** Returns last check's debug mode, if explicitly enabled. */
   def lastTrace(): String = ""
 
+  /** Does `tycon` have a field with type `tparam`? Special cased for `scala.*:`
+   *  as that type is artificially added to tuples. */
   private def typeparamCorrespondsToField(tycon: Type, tparam: TypeParamInfo): Boolean =
     productSelectorTypes(tycon, null).exists {
       case tp: TypeRef =>
         tp.designator.eq(tparam) // Bingo!
       case _ =>
         false
-    }
+    } || tycon.derivesFrom(defn.PairClass)
 
   /** Is `tp` an empty type?
    *

--- a/tests/pos/8313.scala
+++ b/tests/pos/8313.scala
@@ -1,0 +1,9 @@
+object Test {
+  type DU[A <: Tuple] <: Tuple = A match {
+    case Unit => Unit
+    case Unit *: tl => DU[tl]
+    case hd *: tl => hd *: DU[tl]
+  }
+
+  (1, 2): DU[Int *: Int *: Unit]
+}


### PR DESCRIPTION
Special case `typeparamCorrespondsToField` to `scala.*:`. Since `*:` is artificially added to tuples, we also need to special case that logic to conclude that `*:[A, _]` and `*:[B, _]` are disjoint when knowing that `A` and `B` are disjoint.