### PR TITLE
Fix #5498: error for postfixOps if language feature not enabled

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1675,6 +1675,16 @@ object desugar {
         }
         else {
           assert(ctx.mode.isExpr || ctx.reporter.errorsReported || ctx.mode.is(Mode.Interactive), ctx.mode)
+          if (!ctx.featureEnabled(nme.postfixOps)) {
+            ctx.error(
+              s"""postfix operator `${op.name}` needs to be enabled
+                 |by making the implicit value scala.language.postfixOps visible.
+                 |----
+                 |This can be achieved by adding the import clause 'import scala.language.postfixOps'
+                 |or by setting the compiler option -language:postfixOps.
+                 |See the Scaladoc for value scala.language.postfixOps for a discussion
+                 |why the feature needs to be explicitly enabled.""".stripMargin, t.sourcePos)
+          }
           Select(t, op.name)
         }
       case PrefixOp(op, t) =>

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -540,6 +540,7 @@ object StdNames {
     val ordinalDollar_ : N      = "_$ordinal"
     val origin: N               = "origin"
     val parts: N                = "parts"
+    val postfixOps: N           = "postfixOps"
     val prefix : N              = "prefix"
     val processEscapes: N       = "processEscapes"
     val productArity: N         = "productArity"

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2201,6 +2201,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
 
   /** Show subtype goal that led to an assertion failure */
   def showGoal(tp1: Type, tp2: Type)(implicit ctx: Context): Unit = {
+    //TODO shouldn't this be a ctx.echo as well?
     println(i"assertion failure for ${show(tp1)} <:< ${show(tp2)}, frozen = $frozenConstraint")
     def explainPoly(tp: Type) = tp match {
       case tp: TypeParamRef => ctx.echo(s"TypeParamRef ${tp.show} found in ${tp.binder.show}")

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2201,8 +2201,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
 
   /** Show subtype goal that led to an assertion failure */
   def showGoal(tp1: Type, tp2: Type)(implicit ctx: Context): Unit = {
-    //TODO shouldn't this be a ctx.echo as well?
-    println(i"assertion failure for ${show(tp1)} <:< ${show(tp2)}, frozen = $frozenConstraint")
+    ctx.echo(i"assertion failure for ${show(tp1)} <:< ${show(tp2)}, frozen = $frozenConstraint")
     def explainPoly(tp: Type) = tp match {
       case tp: TypeParamRef => ctx.echo(s"TypeParamRef ${tp.show} found in ${tp.binder.show}")
       case tp: TypeRef if tp.symbol.exists => ctx.echo(s"typeref ${tp.show} found in ${tp.symbol.owner.show}")

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -500,7 +500,7 @@ trait TypeOps { this: Context => // TODO: Make standalone object.
         if (!sym.exists) ""
         else toPrefix(sym.owner) + sym.name + "."
       val featureName = toPrefix(owner) + feature
-      ctx.base.settings.language.value exists (s => s == featureName)
+      ctx.base.settings.language.value contains featureName
     }
     hasOption || hasImport
   }

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -135,7 +135,7 @@ trait Reporting { this: Context =>
   def error(ex: TypeError, pos: SourcePosition): Unit = {
     error(ex.toMessage, pos, sticky = true)
     if (ctx.settings.YdebugTypeError.value)
-      ex.printStackTrace
+      ex.printStackTrace()
   }
 
   def errorOrMigrationWarning(msg: Message, pos: SourcePosition = NoSourcePosition): Unit =

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -61,9 +61,10 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/pos-special/i7296.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/pos-special/notNull.scala", defaultOptions.and("-Yexplicit-nulls")),
       compileDir("tests/pos-special/adhoc-extension", defaultOptions.and("-strict", "-feature", "-Xfatal-warnings")),
-      compileFile("tests/pos-special/i7575.scala", defaultOptions.and("-language:dynamics")),
+      compileFile("tests/pos-special/i7575.scala", defaultOptions.andLanguageFeature("dynamics")),
       compileFile("tests/pos-special/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
       compileFile("tests/run/i5606.scala", defaultOptions.and("-Yretain-trees")),
+      compileFile("tests/pos-custom-args/i5498-postfixOps.scala", defaultOptions withoutLanguageFeature "postfixOps"),
     ).checkCompile()
   }
 
@@ -128,7 +129,7 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/neg-custom-args/i3246.scala", scala2CompatMode),
       compileFile("tests/neg-custom-args/overrideClass.scala", scala2CompatMode),
       compileFile("tests/neg-custom-args/ovlazy.scala", scala2CompatMode.and("-migration", "-Xfatal-warnings")),
-      compileFile("tests/neg-custom-args/autoTuplingTest.scala", defaultOptions.and("-language:noAutoTupling")),
+      compileFile("tests/neg-custom-args/autoTuplingTest.scala", defaultOptions.andLanguageFeature("noAutoTupling")),
       compileFile("tests/neg-custom-args/nopredef.scala", defaultOptions.and("-Yno-predef")),
       compileFile("tests/neg-custom-args/noimports.scala", defaultOptions.and("-Yno-imports")),
       compileFile("tests/neg-custom-args/noimports2.scala", defaultOptions.and("-Yno-imports")),
@@ -153,9 +154,10 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/neg-custom-args/indentRight.scala", defaultOptions.and("-noindent", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/extmethods-tparams.scala", defaultOptions.and("-deprecation", "-Xfatal-warnings")),
       compileDir("tests/neg-custom-args/adhoc-extension", defaultOptions.and("-strict", "-feature", "-Xfatal-warnings")),
-      compileFile("tests/neg/i7575.scala", defaultOptions.and("-language:_")),
+      compileFile("tests/neg/i7575.scala", defaultOptions.withoutLanguageFeatures.and("-language:_")),
       compileFile("tests/neg-custom-args/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
       compileFile("tests/neg-custom-args/typeclass-derivation2.scala", defaultOptions.and("-Yerased-terms")),
+      compileFile("tests/neg-custom-args/i5498-postfixOps.scala", defaultOptions withoutLanguageFeature "postfixOps"),
     ).checkExpectedErrors()
   }
 
@@ -223,7 +225,7 @@ class CompilationTests extends ParallelTesting {
         Properties.compilerInterface, Properties.scalaLibrary, Properties.scalaAsm,
         Properties.dottyInterfaces, Properties.jlineTerminal, Properties.jlineReader,
       ).mkString(File.pathSeparator),
-      Array("-Ycheck-reentrant", "-Yemit-tasty-in-class")
+      Array("-Ycheck-reentrant", "-Yemit-tasty-in-class", "-language:postfixOps")
     )
 
     val libraryDirs = List(Paths.get("library/src"), Paths.get("library/src-bootstrapped"))

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -51,7 +51,7 @@ object TestConfiguration {
 
   val yCheckOptions = Array("-Ycheck:all")
 
-  val commonOptions = Array("-indent") ++ checkOptions ++ noCheckOptions ++ yCheckOptions
+  val commonOptions = Array("-indent", "-language:postfixOps") ++ checkOptions ++ noCheckOptions ++ yCheckOptions
   val defaultOptions = TestFlags(basicClasspath, commonOptions)
   val withCompilerOptions =
     defaultOptions.withClasspath(withCompilerClasspath).withRunClasspath(withCompilerClasspath)
@@ -69,7 +69,7 @@ object TestConfiguration {
   )
   val picklingWithCompilerOptions =
     picklingOptions.withClasspath(withCompilerClasspath).withRunClasspath(withCompilerClasspath)
-  val scala2CompatMode = defaultOptions and "-language:Scala2Compat"
+  val scala2CompatMode = defaultOptions.andLanguageFeature("Scala2Compat")
   val explicitUTF8 = defaultOptions and ("-encoding", "UTF8")
   val explicitUTF16 = defaultOptions and ("-encoding", "UTF16")
 

--- a/compiler/test/dotty/tools/vulpix/TestFlags.scala
+++ b/compiler/test/dotty/tools/vulpix/TestFlags.scala
@@ -21,6 +21,29 @@ final case class TestFlags(
 
   def all: Array[String] = Array("-classpath", defaultClassPath) ++ options
 
+  def withoutLanguageFeatures: TestFlags = copy(options = withoutLanguageFeaturesOptions)
+
+  private val languageFeatureFlag = "-language:"
+  private def withoutLanguageFeaturesOptions = options.filterNot(_.startsWith(languageFeatureFlag))
+
+  // TODO simplify to add `-language:feature` to `options` once
+  //      https://github.com/lampepfl/dotty-feature-requests/issues/107 is implemented
+  def andLanguageFeature(feature: String) = {
+    val (languageFeatures, rest) = options.partition(_.startsWith(languageFeatureFlag))
+    val existingFeatures = if (languageFeatures.isEmpty) languageFeatures.mkString(",") + "," else ""
+    copy(options = rest ++ Array(languageFeatureFlag + existingFeatures + feature))
+  }
+
+  def withoutLanguageFeature(feature: String) = {
+    val (languageFeatures, rest) = options.partition(_.startsWith(languageFeatureFlag))
+    val filteredFeatures = languageFeatures.filter(_ == feature)
+    val newOptions =
+      if (filteredFeatures.isEmpty) rest
+      else rest ++ Array(languageFeatureFlag + filteredFeatures.mkString(","))
+
+    copy(options = newOptions)
+  }
+
   /** Subset of the flags that should be passed to javac. */
   def javacFlags: Array[String] = {
     val flags = all

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -159,7 +159,7 @@ object Build {
       "-unchecked",
       "-Xfatal-warnings",
       "-encoding", "UTF8",
-      "-language:existentials,higherKinds,implicitConversions"
+      "-language:existentials,higherKinds,implicitConversions,postfixOps"
     ),
 
     javacOptions in (Compile, compile) ++= Seq("-Xlint:unchecked", "-Xlint:deprecation"),

--- a/tests/neg-custom-args/i5498-postfixOps.check
+++ b/tests/neg-custom-args/i5498-postfixOps.check
@@ -1,0 +1,20 @@
+-- Error: tests/neg-custom-args/i5498-postfixOps.scala:4:2 -------------------------------------------------------------
+4 |  1 second // error: usage of postfix operator
+  |  ^
+  |  postfix operator `second` needs to be enabled
+  |  by making the implicit value scala.language.postfixOps visible.
+  |  ----
+  |  This can be achieved by adding the import clause 'import scala.language.postfixOps'
+  |  or by setting the compiler option -language:postfixOps.
+  |  See the Scaladoc for value scala.language.postfixOps for a discussion
+  |  why the feature needs to be explicitly enabled.
+-- Error: tests/neg-custom-args/i5498-postfixOps.scala:6:23 ------------------------------------------------------------
+6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator
+  |                   ^^^^^^^^^
+  |                   postfix operator `contains` needs to be enabled
+  |                   by making the implicit value scala.language.postfixOps visible.
+  |                   ----
+  |                   This can be achieved by adding the import clause 'import scala.language.postfixOps'
+  |                   or by setting the compiler option -language:postfixOps.
+  |                   See the Scaladoc for value scala.language.postfixOps for a discussion
+  |                   why the feature needs to be explicitly enabled.

--- a/tests/neg-custom-args/i5498-postfixOps.scala
+++ b/tests/neg-custom-args/i5498-postfixOps.scala
@@ -1,0 +1,7 @@
+import scala.concurrent.duration._
+
+def test() = {
+  1 second // error: usage of postfix operator
+
+  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator
+}

--- a/tests/pos-custom-args/i5498-postfixOps.scala
+++ b/tests/pos-custom-args/i5498-postfixOps.scala
@@ -1,0 +1,9 @@
+import scala.concurrent.duration._
+
+import scala.language.postfixOps
+
+def test() = {
+  1 second
+
+  Seq(1, 2) filter (List(1,2) contains)
+}

--- a/tests/pos/i5498-postfixOps.scala
+++ b/tests/pos/i5498-postfixOps.scala
@@ -1,0 +1,8 @@
+import scala.concurrent.duration._
+
+def test() = {
+  // only OK since the defaultOptions in the TestConfiguration includes -language:postfixOps
+  1 second
+
+  Seq(1, 2).filter(List(1,2) contains)
+}


### PR DESCRIPTION
resolves #5498. It seems like dotty does not output a warning any more (see for instance: https://scastie.scala-lang.org/L8epbiXgQryCYHRWgbx69g)
I saw that PostFixOp is de-sugared in Desugar and hence not available in Typer (where I would have put the check). That's also the reason why I have put the check in Desugar

Following things to consider:
1. it's my first PR to the compiler
2.  the neg-test fails (putting the same test into pos fails as expected, so I am not sure what's wrong there) => *Edit*: I found my mistake, I improved the error messages in tests so that others will not fall over this problem
3. there are build failures due the new check, so it seems to work - shall I enable the feature or rewrite the code? => *Edit*: I enabled postfixOps for dotty.