### PR TITLE
Specify order of MirroredElemTypes for Mirror.SumOf

### DIFF
--- a/docs/docs/reference/contextual/derivation.md
+++ b/docs/docs/reference/contextual/derivation.md
@@ -129,6 +129,10 @@ Note the following properties of `Mirror` types,
   Scala 2 versions of shapeless). Instead the collection of child types of a data type is represented by an ordinary,
   possibly parameterized, tuple type. Dotty's metaprogramming facilities can be used to work with these tuple types
   as-is, and higher level libraries can be built on top of them.
++ For both product and sum types, the elements of `MirroredElemTypes` are arranged in definition order (i.e. `Branch[T]`
+  precedes `Leaf[T]` in `MirroredElemTypes` for `Tree` because `Branch` is defined before `Leaf` in the source file).
+  This means that `Mirror.Sum` differs in this respect from shapeless's generic representation for ADTs in Scala 2,
+  where the constructors are ordered alphabetically by name.
 + The methods `ordinal` and `fromProduct` are defined in terms of `MirroredMonoType` which is the type of kind-`*`
   which is obtained from `MirroredType` by wildcarding its type parameters.
 

--- a/tests/run/deriving-constructor-order.scala
+++ b/tests/run/deriving-constructor-order.scala
@@ -1,0 +1,24 @@
+import scala.compiletime.erasedValue
+import scala.deriving.Mirror
+
+object Test extends App {
+  inline def checkElems[A, T](using inline A: Mirror.SumOf[A]): Unit =
+    inline erasedValue[A.MirroredElemTypes] match {
+      case _: T => ()
+    }
+
+  sealed trait Base1
+  case class Foo() extends Base1
+  case object Bar extends Base1
+  case class Qux(i: Int) extends Base1
+
+  checkElems[Base1, (Foo, Bar.type, Qux)]
+
+  enum Tree[+T] {
+    case Empty
+    case Branch[T](left: Tree[T], right: Tree[T]) extends Tree[T]
+    case Leaf[T](elem: T) extends Tree[T]
+  }
+
+  checkElems[Tree[String], (Tree.Empty.type, Tree.Branch[String], Tree.Leaf[String])]
+}


### PR DESCRIPTION
For sum types, the order of elements in `MirrorElemTypes` currently follows the order of definitions in the file. I'd like to be able to rely on this order (which wasn't exposed to macro authors in Scala 2), so I've specified it in the docs and added a couple of test cases.

Related discussion [on Gitter](https://gitter.im/lampepfl/dotty?at=5e57b1b986e6ec2f5c620131):

@smarter:
> Don't think it's specified, but you could make a PR to specify it in the doc and add a testcase :)
> what's the usecase ?

@travisbrown:
> In Haskell for example you often see code like this:
> ```scala
> data N = One | Two | Three deriving (Eq, Ord)
> ```
> In Scala that hasn't been possible because `knownDirectSubclasses` returned a `Set` (which Shapeless's Generic sorted by constructor name, so you'd have `Three < Two`).
>
> Also comes up for things like deriving `Semigroup` for ADTs, where you want a stable and meaningful way to decide how to combine non-same-constructor values.
>
> "First defined takes precedence" feels a lot more sensible than "keep the one with the name that comes first in the alphabet".