### PR TITLE
fix #8398 - dont parse hex literals as floating point

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -558,9 +558,15 @@ class Typer extends Namer
           case _ =>
         }
       else if (target.isRef(defn.FloatClass))
-        return lit(floatFromDigits(digits))
+        tree.kind match {
+          case Whole(16) => // cant parse hex literal as float
+          case _         => return lit(floatFromDigits(digits))
+        }
       else if (target.isRef(defn.DoubleClass))
-        return lit(doubleFromDigits(digits))
+        tree.kind match {
+          case Whole(16) => // cant parse hex literal as double
+          case _         => return lit(doubleFromDigits(digits))
+        }
       else if (target.isValueType && isFullyDefined(target, ForceDegree.none)) {
         // If expected type is defined with a FromDigits instance, use that one
         val fromDigitsCls = tree.kind match {

--- a/tests/run/i8398.scala
+++ b/tests/run/i8398.scala
@@ -1,0 +1,3 @@
+@main def Test =
+  assert((0x7FFF_FFFF : Float) == 2.14748365E9f)
+  assert((0x7FFF_FFFF : Double) == 2.147483647E9)


### PR DESCRIPTION
The linked issue also suggests warning whenever a lossy implicit conversion from int to floating point may be applied, which is not tackled here