### PR TITLE
Fix #7793: Handle context parameters in resolveOverloaded

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -574,7 +574,7 @@ object desugar {
       val nu = vparamss.foldLeft(makeNew(classTypeRef)) { (nu, vparams) =>
         val app = Apply(nu, vparams.map(refOfDef))
         vparams match {
-          case vparam :: _ if vparam.mods.is(Given) => app.setGivenApply()
+          case vparam :: _ if vparam.mods.is(Given) => app.setUsingApply()
           case _ => app
         }
       }

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -439,8 +439,8 @@ object Trees {
     extends GenericApply[T] {
     type ThisTree[-T >: Untyped] = Apply[T]
 
-    def isGivenApply = hasAttachment(untpd.ApplyGiven)
-    def setGivenApply() = { putAttachment(untpd.ApplyGiven, ()); this }
+    def isUsingApply = hasAttachment(untpd.ApplyGiven)
+    def setUsingApply() = { putAttachment(untpd.ApplyGiven, ()); this }
   }
 
   /** fun[args] */

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3311,7 +3311,6 @@ object Types {
       companion.eq(ContextualMethodType) ||
       companion.eq(ErasedContextualMethodType)
 
-
     def computeSignature(implicit ctx: Context): Signature = {
       val params = if (isErasedMethod) Nil else paramInfos
       resultSignature.prependTermParams(params, isJavaMethod)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2293,7 +2293,7 @@ object Parsers {
 
     def mkApply(fn: Tree, args: (List[Tree], Boolean)): Tree =
       val res = Apply(fn, args._1)
-      if args._2 then res.setGivenApply()
+      if args._2 then res.setUsingApply()
       res
 
     val argumentExpr: () => Tree = () => exprInParens() match {

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -390,7 +390,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         else
           toTextLocal(fun)
           ~ "("
-          ~ Str("using ").provided(app.isGivenApply && !homogenizedView)
+          ~ Str("using ").provided(app.isUsingApply && !homogenizedView)
           ~ toTextGlobal(args, ", ")
           ~ ")"
       case tree: TypeApply =>

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -545,7 +545,7 @@ object Erasure {
       val Apply(fun, args) = tree
       if (fun.symbol == defn.cbnArg)
         typedUnadapted(args.head, pt)
-      else typedExpr(fun, FunProto(args, pt)(this, isGivenApply = false)) match {
+      else typedExpr(fun, FunProto(args, pt)(this, isUsingApply = false)) match {
         case fun1: Apply => // arguments passed in prototype were already passed
           fun1
         case fun1 =>

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -833,7 +833,7 @@ trait Applications extends Compatibility {
   def typedApply(tree: untpd.Apply, pt: Type)(implicit ctx: Context): Tree = {
 
     def realApply(implicit ctx: Context): Tree = {
-      val originalProto = new FunProto(tree.args, IgnoredProto(pt))(this, tree.isGivenApply)(argCtx(tree))
+      val originalProto = new FunProto(tree.args, IgnoredProto(pt))(this, tree.isUsingApply)(argCtx(tree))
       record("typedApply")
       val fun1 = typedFunPart(tree.fun, originalProto)
 
@@ -1763,7 +1763,7 @@ trait Applications extends Compatibility {
             alts2
         }
 
-        if pt.isGivenApply then
+        if pt.isUsingApply then
           val alts0 = alts.filterConserve { alt =>
             val mt = alt.widen.stripPoly
             mt.isImplicitMethod || mt.isContextualMethod

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -233,7 +233,7 @@ object EtaExpansion extends LiftImpure {
     if (mt.paramInfos.nonEmpty && mt.paramInfos.last.isRepeatedParam)
       ids = ids.init :+ repeated(ids.last)
     val app = Apply(lifted, ids)
-    if (mt.isContextualMethod) app.setGivenApply()
+    if (mt.isContextualMethod) app.setUsingApply()
     val body = if (isLastApplication) app else PostfixOp(app, Ident(nme.WILDCARD))
     val fn =
       if (mt.isContextualMethod) new untpd.FunctionWithMods(params, body, Modifiers(Given))

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -228,7 +228,7 @@ object ProtoTypes {
 
   trait ApplyingProto extends ProtoType   // common trait of ViewProto and FunProto
   trait FunOrPolyProto extends ProtoType { // common trait of PolyProto and FunProto
-    def isGivenApply: Boolean = false
+    def isUsingApply: Boolean = false
   }
 
   class FunProtoState {
@@ -251,7 +251,7 @@ object ProtoTypes {
    *  [](args): resultType
    */
   case class FunProto(args: List[untpd.Tree], resType: Type)(typer: Typer,
-    override val isGivenApply: Boolean, state: FunProtoState = new FunProtoState)(implicit val ctx: Context)
+    override val isUsingApply: Boolean, state: FunProtoState = new FunProtoState)(implicit val ctx: Context)
   extends UncachedGroundType with ApplyingProto with FunOrPolyProto {
     override def resultType(implicit ctx: Context): Type = resType
 
@@ -265,7 +265,7 @@ object ProtoTypes {
 
     def derivedFunProto(args: List[untpd.Tree] = this.args, resultType: Type, typer: Typer = this.typer): FunProto =
       if ((args eq this.args) && (resultType eq this.resultType) && (typer eq this.typer)) this
-      else new FunProto(args, resultType)(typer, isGivenApply)
+      else new FunProto(args, resultType)(typer, isUsingApply)
 
     /** @return True if all arguments have types.
      */
@@ -355,7 +355,7 @@ object ProtoTypes {
       case pt: FunProto =>
         pt
       case _ =>
-        state.tupled = new FunProto(untpd.Tuple(args) :: Nil, resultType)(typer, isGivenApply)
+        state.tupled = new FunProto(untpd.Tuple(args) :: Nil, resultType)(typer, isUsingApply)
         tupled
     }
 
@@ -390,14 +390,14 @@ object ProtoTypes {
 
     override def withContext(newCtx: Context): ProtoType =
       if (newCtx `eq` ctx) this
-      else new FunProto(args, resType)(typer, isGivenApply, state)(newCtx)
+      else new FunProto(args, resType)(typer, isUsingApply, state)(newCtx)
   }
 
   /** A prototype for expressions that appear in function position
    *
    *  [](args): resultType, where args are known to be typed
    */
-  class FunProtoTyped(args: List[tpd.Tree], resultType: Type)(typer: Typer, isGivenApply: Boolean)(implicit ctx: Context) extends FunProto(args, resultType)(typer, isGivenApply)(ctx) {
+  class FunProtoTyped(args: List[tpd.Tree], resultType: Type)(typer: Typer, isUsingApply: Boolean)(implicit ctx: Context) extends FunProto(args, resultType)(typer, isUsingApply)(ctx) {
     override def typedArgs(norm: (untpd.Tree, Int) => untpd.Tree)(implicit ctx: Context): List[tpd.Tree] = args
     override def withContext(ctx: Context): FunProtoTyped = this
   }
@@ -444,7 +444,7 @@ object ProtoTypes {
   }
 
   class UnapplyFunProto(argType: Type, typer: Typer)(implicit ctx: Context) extends FunProto(
-    untpd.TypedSplice(dummyTreeOfType(argType)(ctx.source))(ctx) :: Nil, WildcardType)(typer, isGivenApply = false)
+    untpd.TypedSplice(dummyTreeOfType(argType)(ctx.source))(ctx) :: Nil, WildcardType)(typer, isUsingApply = false)
 
   /** A prototype for expressions [] that are type-parameterized:
    *

--- a/tests/pos/i7793.scala
+++ b/tests/pos/i7793.scala
@@ -1,0 +1,9 @@
+trait Foo:
+  def g(f: Int => Int): Int = 1
+  def g(using String)(f: Int => String): String = "2"
+
+@main def Test =
+  val m: Foo = ???
+  given String = "foo"
+  m.g(x => "2")
+  m.g(using summon[String])(x => "2")


### PR DESCRIPTION
resolveOverloaded now takes into account whether arguments are using
clauses or regular arguments.