### PR TITLE
Fix #8396: Make prefixes of abstract types contribute to implicit scope

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -509,7 +509,10 @@ trait ImplicitRunInfo {
     /** Is `sym` an anchor type for which givens may exist? Anchor types are classes,
      *  opaque type aliases, and abstract types, but not type parameters
      */
-    def isAnchor(sym: Symbol) = sym.isClass && !sym.is(Package) || sym.isOpaqueAlias
+    def isAnchor(sym: Symbol) =
+      sym.isClass && !sym.is(Package)
+      || sym.isOpaqueAlias
+      || sym.is(Deferred, butNot = Param)
 
     def anchors(tp: Type): List[Type] = tp match {
       case tp: NamedType if isAnchor(tp.symbol) => tp :: Nil

--- a/tests/pos/quotedPatterns-4.scala
+++ b/tests/pos/quotedPatterns-4.scala
@@ -3,7 +3,7 @@ object Test {
   def impl(receiver: Expr[StringContext])(using qctx: scala.quoted.QuoteContext) = {
     import qctx.tasty.Repeated
     receiver match {
-      case '{ StringContext(${Repeated(parts)}: _*) } => // error
+      case '{ StringContext(${Repeated(parts)}: _*) } => // now OK
     }
   }
 }

--- a/tests/run/i8396.scala
+++ b/tests/run/i8396.scala
@@ -1,0 +1,16 @@
+trait Show[A]:
+  def show(a: A): String = a.toString
+
+object Prefix:
+  type AbstractType
+  type UpperBoundedType <: String
+  type FullyBoundedType >: String <: String
+
+  given A as Show[AbstractType]
+  given B as Show[UpperBoundedType]
+  given C as Show[FullyBoundedType]
+
+@main def Test =
+  summon[Show[Prefix.AbstractType]]
+  summon[Show[Prefix.UpperBoundedType]]
+  summon[Show[Prefix.FullyBoundedType]]


### PR DESCRIPTION
The comment already said the right thing -- abstract types are anchors --
but the implementation did not follow it.