### PR TITLE
Give reasonable error messages when classfiles are not found

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -832,9 +832,10 @@ object Denotations {
 
     private def updateValidity()(implicit ctx: Context): this.type = {
       assert(
-        ctx.runId >= validFor.runId ||
-        ctx.settings.YtestPickler.value || // mixing test pickler with debug printing can travel back in time
-        symbol.is(Permanent),              // Permanent symbols are valid in all runIds
+        ctx.runId >= validFor.runId
+        || ctx.settings.YtestPickler.value // mixing test pickler with debug printing can travel back in time
+        || ctx.mode.is(Mode.Printing)  // no use to be picky when printing error messages
+        || symbol.isOneOf(ValidForeverFlags),
         s"denotation $this invalid in run ${ctx.runId}. ValidFor: $validFor")
       var d: SingleDenotation = this
       while ({

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -606,6 +606,8 @@ class TreePickler(pickler: TastyPickler) {
           }
       }
       catch {
+        case ex: TypeError =>
+          ctx.error(ex.toMessage, tree.sourcePos.focus)
         case ex: AssertionError =>
           println(i"error when pickling tree $tree")
           throw ex

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/Message.scala
@@ -124,7 +124,7 @@ class NoExplanation(val msg: String) extends Message(ErrorMessageID.NoExplanatio
   val explanation: String = ""
   val kind: String = ""
 
-  override def toString(): String = s"NoExplanation($msg)"
+  override def toString(): String = msg
 }
 
 /** The extractor for `NoExplanation` can be used to check whether any error

--- a/tests/neg/i6501.scala
+++ b/tests/neg/i6501.scala
@@ -1,0 +1,24 @@
+import scala.collection.immutable.HashMap
+
+trait MapImpl {
+  type Key
+  type Value
+  type Map
+  val lookup: Map => Key => Value
+}
+class HashMapImpl[K, V] extends MapImpl {
+  type Key = K
+  type Value = V
+  type Map = HashMap[K, V]
+  val lookup: Map => Key => Value = m => k => m(k)
+}
+object Foo {
+  val Server0:
+    (mImpl: MapImpl) => mImpl.Map => mImpl.Key => mImpl.Value
+    = mImpl => mImpl.lookup
+  val Client:
+    (server: (mImpl: MapImpl & {type Key = String} & {type Value = Int}) => mImpl.Map => String => Int) => Int =
+    // server => server(??? : (HashMapImpl[String, Int]))(???)("test lookup key") //works
+    // server => server(HashMapImpl[String, Int])(???)("") //works
+    server => server(???)(???)("test lookup key") // error
+}

--- a/tests/neg/i8405.scala
+++ b/tests/neg/i8405.scala
@@ -1,0 +1,11 @@
+class ActorRef
+trait ActorEventBus {
+  type Subscriber = ActorRef
+}
+trait ManagedActorClassification { this: ActorEventBus =>
+  def unsubscribe(subscriber: Subscriber): Unit = ???
+}
+class ActorClassificationUnsubscriber(bus: ManagedActorClassification) {
+  val actor = ???
+  bus.unsubscribe(actor)  // error
+}


### PR DESCRIPTION
Fixes #6501
Fixes #8405

Both tests exercise corner cases where a type seems to be present at first
but then is missing. It took some effort to dig out the useful error message
from excetiopn handling code.