### PR TITLE
Fix #8427: Disallow SerialVersionUID on a trait

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -796,11 +796,16 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
       for (f <- toDenot(sym).info.decls.toList if f.isMethod && f.isTerm && !f.isModule) yield f
     def serialVUID: Option[Long] =
       sym.getAnnotation(defn.SerialVersionUIDAnnot).flatMap { annot =>
-        val vuid = annot.argumentConstant(0).map(_.longValue)
-        if (vuid.isEmpty)
-          ctx.error("The argument passed to @SerialVersionUID must be a constant",
-            annot.argument(0).getOrElse(annot.tree).sourcePos)
-        vuid
+        if (sym.is(Flags.Trait)) {
+          ctx.error("@SerialVersionUID does nothing on a trait", annot.tree.sourcePos)
+          None
+        } else {
+          val vuid = annot.argumentConstant(0).map(_.longValue)
+          if (vuid.isEmpty)
+            ctx.error("The argument passed to @SerialVersionUID must be a constant",
+              annot.argument(0).getOrElse(annot.tree).sourcePos)
+          vuid
+        }
       }
 
     def freshLocal(cunit: CompilationUnit, name: String, tpe: Type, pos: Position, flags: Flags): Symbol = {

--- a/tests/neg/i8427.scala
+++ b/tests/neg/i8427.scala
@@ -1,0 +1,7 @@
+@SerialVersionUID(1L) // error
+trait T
+
+object Test {
+  var t: T = _
+  def main(args: Array[String]) = println("hi")
+}


### PR DESCRIPTION
It's not meaningful since it's supposed to compile to a static field,
but traits compile to interfaces and interfaces cannot have fields.