### PR TITLE
Simplify import of qctx.tasty.rootContext

### DIFF
--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -452,7 +452,8 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
   //////////////
 
   /** Context of the macro expansion */
-  given rootContext as Context = internal.rootContext // TODO: Use given // TODO: Should this be moved to QuoteContext?
+  def rootContext: Context = internal.rootContext // TODO: Should this be moved to QuoteContext?
+  given Context = rootContext // TODO: Should be an implicit converion from QuoteContext to Context
 
   extension ContextOps on (self: Context) {
     /** Returns the owner of the context */

--- a/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
@@ -11,7 +11,7 @@ object SourceFiles {
 
   def getThisFileImpl: Macro[String] = {
     val qctx = tastyContext
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     rootContext.source.getFileName.toString
   }
 

--- a/tests/run-macros/tasty-getfile/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile/Macro_1.scala
@@ -8,8 +8,8 @@ object SourceFiles {
     ${getThisFileImpl}
 
   private def getThisFileImpl(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
-    rootContext.source.getFileName.toString
+    import qctx.tasty._
+    summon[Context].source.getFileName.toString
   }
 
 }


### PR DESCRIPTION
Allow `rootContext` with `import qctx.tasty._` (no given import)

This takes advantage of the change introduced in #8410