### PR TITLE
Update Syntax section in documentation of intersection types

### DIFF
--- a/docs/docs/reference/new-types/intersection-types-spec.md
+++ b/docs/docs/reference/new-types/intersection-types-spec.md
@@ -5,10 +5,11 @@ title: "Intersection Types - More Details"
 
 ## Syntax
 
-Syntactically, an intersection type `S & T` is similar to an infix type, where
-the infix operator is `&`. `&` is treated as a soft keyword. That is, it is a
-normal identifier with the usual precedence. But a type of the form `A & B` is
-always recognized as an intersection type, without trying to resolve `&`.
+Syntactically, the type `S & T` is an infix type, where the infix operator is `&`.
+The operator `&` is a normal identifier
+with the usual precedence and subject to usual resolving rules.
+Unless shadowed by another definition, it resolves to the type `scala.&`,
+which acts as a type alias to an internal representation of intersection types.
 
 ```
 Type              ::=  ...| InfixType


### PR DESCRIPTION
Following my suggestion in https://github.com/lampepfl/dotty/pull/8377#issuecomment-591397397, this PR updates the Syntax section of http://dotty.epfl.ch/docs/reference/new-types/intersection-types-spec.html, to state that `&` is just an normal identifier resolving to a type alias `scala.&`. At least that is my understanding of the current situation.