### PR TITLE
Simplify import of tasty unseal

### DIFF
--- a/docs/docs/reference/contextual/derivation-macro.md
+++ b/docs/docs/reference/contextual/derivation-macro.md
@@ -42,7 +42,7 @@ from the signature. The body of the `derived` method is shown below:
 
 ```scala
 given derived[T: Type](using qctx: QuoteContext) as Expr[Eq[T]] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
 
   val ev: Expr[Mirror.Of[T]] = summonExpr(using '[Mirror.Of[T]]).get
 
@@ -176,7 +176,7 @@ object Eq {
   }
 
   given derived[T: Type](using qctx: QuoteContext) as Expr[Eq[T]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val ev: Expr[Mirror.Of[T]] = summonExpr(using '[Mirror.Of[T]]).get
 

--- a/docs/docs/reference/metaprogramming/tasty-reflect.md
+++ b/docs/docs/reference/metaprogramming/tasty-reflect.md
@@ -61,7 +61,7 @@ def natConstImpl(x: Expr[Int])(using qctx: QuoteContext): Expr[Int] = {
 To easily know which extractors are needed, the `showExtractors` method on a
 `qctx.tasty.Term` returns the string representation of the extractors.
 
-The method `qctx.tasty.Term.seal[T]` provides a way to go back to a
+The method `qctx.tasty.Term.seal` provides a way to go back to a
 `quoted.Expr[Any]`. Note that the type is `Expr[Any]`. Consequently, the type
 must be set explicitly with a checked `cast` call. If the type does not conform
 to it an exception will be thrown. In the code above, we could have replaced

--- a/docs/docs/reference/metaprogramming/tasty-reflect.md
+++ b/docs/docs/reference/metaprogramming/tasty-reflect.md
@@ -29,22 +29,19 @@ import scala.quoted._
 inline def natConst(x: => Int): Int = ${natConstImpl('{x})}
 
 def natConstImpl(x: Expr[Int])(using qctx: QuoteContext): Expr[Int] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   ...
 }
 ```
 
-### Sealing and Unsealing
+### Extractors
 
-`import qctx.tasty.{_, given _}` will provide an `unseal` extension method on `quoted.Expr`
-and `quoted.Type` which returns a `qctx.tasty.Term` that represents the tree of
-the expression and `qctx.tasty.TypeTree` that represents the tree of the type
-respectively. It will also import all extractors and methods on TASTy Reflect
+`import qctx.tasty._` will provide all extractors and methods on TASTy Reflect
 trees. For example the `Literal(_)` extractor used below.
 
 ```scala
 def natConstImpl(x: Expr[Int])(using qctx: QuoteContext): Expr[Int] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   val xTree: Term = x.unseal
   xTree match {
     case Inlined(_, _, Literal(Constant(n: Int))) =>
@@ -81,7 +78,7 @@ operation expression passed while calling the `macro` below.
 inline def macro(param: => Boolean): Unit = ${ macroImpl('param) }
 
 def macroImpl(param: Expr[Boolean])(using qctx: QuoteContext): Expr[Unit] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   import util._
 
   param.unseal.underlyingArgument match {
@@ -103,7 +100,7 @@ point.
 
 ```scala
 def macroImpl()(qctx: QuoteContext): Expr[Unit] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   val pos = rootPosition
 
   val path = pos.sourceFile.jpath.toString

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -37,6 +37,14 @@ class Expr[+T] private[scala] {
   final def matches(that: Expr[Any])(using qctx: QuoteContext): Boolean =
     !scala.internal.quoted.Expr.unapply[Unit, Unit](this)(using that, false, qctx).isEmpty
 
+  /** Checked cast to a `quoted.Expr[U]` */
+  def cast[U](using tp: scala.quoted.Type[U])(using qctx: QuoteContext): scala.quoted.Expr[U] =
+    qctx.tasty.internal.QuotedExpr_cast[U](this)(using tp, qctx.tasty.rootContext)
+
+  /** View this expression `quoted.Expr[T]` as a `Term` */
+  def unseal(using qctx: QuoteContext): qctx.tasty.Term =
+    qctx.tasty.internal.QuotedExpr_unseal(this)(using qctx.tasty.rootContext)
+
 }
 
 object Expr {
@@ -108,7 +116,7 @@ object Expr {
    */
   def ofSeq[T](xs: Seq[Expr[T]])(using tp: Type[T], qctx: QuoteContext): Expr[Seq[T]] = {
     import qctx.tasty.{_, given _}
-    Repeated(xs.map(_.unseal).toList, tp.unseal).seal.asInstanceOf[Expr[Seq[T]]]
+    Repeated(xs.map[Term](_.unseal).toList, tp.unseal).seal.asInstanceOf[Expr[Seq[T]]]
   }
 
 

--- a/library/src/scala/quoted/QuoteContext.scala
+++ b/library/src/scala/quoted/QuoteContext.scala
@@ -32,13 +32,13 @@ class QuoteContext(val tasty: scala.tasty.Reflection) { self =>
   /** Show the fully elaborated source code representation of an expression */
   def show(expr: Expr[_], syntaxHighlight: SyntaxHighlight): String = {
     import tasty.{_, given _}
-    expr.unseal.showWith(syntaxHighlight)
+    expr.unseal(using this).showWith(syntaxHighlight)
   }
 
   /** Show the fully elaborated source code representation of a type */
   def show(tpe: Type[_], syntaxHighlight: SyntaxHighlight): String = {
     import tasty.{_, given _}
-    tpe.unseal.showWith(syntaxHighlight)
+    tpe.unseal(using this).showWith(syntaxHighlight)
   }
 
   /** Report an error at the position of the macro expansion */
@@ -50,7 +50,7 @@ class QuoteContext(val tasty: scala.tasty.Reflection) { self =>
   /** Report an error at the on the position of `expr` */
   def error(msg: => String, expr: Expr[Any]): Unit = {
     import tasty.{_, given _}
-    tasty.error(msg, expr.unseal.pos)
+    tasty.error(msg, expr.unseal(using this).pos)
   }
 
   /** Report an error at the position of the macro expansion and throws a StopQuotedContext */
@@ -73,7 +73,7 @@ class QuoteContext(val tasty: scala.tasty.Reflection) { self =>
   /** Report a warning at the on the position of `expr` */
   def warning(msg: => String, expr: Expr[_]): Unit = {
     import tasty.{_, given _}
-    tasty.warning(msg, expr.unseal.pos)
+    tasty.warning(msg, expr.unseal(using this).pos)
   }
 
 }

--- a/library/src/scala/quoted/Type.scala
+++ b/library/src/scala/quoted/Type.scala
@@ -12,6 +12,10 @@ class Type[T <: AnyKind] private[scala] {
   /** Show a source code like representation of this type */
   def show(syntaxHighlight: SyntaxHighlight)(using qctx: QuoteContext): String = qctx.show(this, syntaxHighlight)
 
+  /** View this expression `quoted.Type[T]` as a `TypeTree` */
+  def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree =
+    qctx.tasty.internal.QuotedType_unseal(this)(using qctx.tasty.rootContext)
+
 }
 
 /** Some basic type tags, currently incomplete */

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -415,26 +415,6 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
   type AmbiguousImplicits = internal.AmbiguousImplicits
 
 
-  ////////////////
-  //   QUOTES   //
-  ////////////////
-
-  extension QuotedExprOps on (expr: scala.quoted.Expr[?]) {
-    /** View this expression `quoted.Expr[T]` as a `Term` */
-    def unseal(using ctx: Context): Term =
-      internal.QuotedExpr_unseal(expr)
-
-    /** Checked cast to a `quoted.Expr[U]` */
-    def cast[U](using tp: scala.quoted.Type[U], ctx: Context): scala.quoted.Expr[U] =
-      internal.QuotedExpr_cast[U](expr)
-  }
-
-  extension QuotedTypeOps on [T <: AnyKind](tpe: scala.quoted.Type[T]) {
-    /** View this expression `quoted.Type[T]` as a `TypeTree` */
-    def unseal(using ctx: Context): TypeTree =
-      internal.QuotedType_unseal(tpe)
-  }
-
   //////////////
   // CONTEXTS //
   //////////////
@@ -1592,7 +1572,8 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
   ///////////////
 
   /** Returns the type (Type) of T */
-  def typeOf[T](using qtype: scala.quoted.Type[T], ctx: Context): Type = qtype.unseal.tpe
+  def typeOf[T](using qtype: scala.quoted.Type[T], ctx: Context): Type =
+    internal.QuotedType_unseal(qtype).tpe
 
   /** Members of `TypeOrBounds` */
   extension TypeOrBoundsOps on (tpe: TypeOrBounds) {

--- a/tests/neg-macros/delegate-match-1/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-1/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted.matching._
 inline def f: Any = ${ fImpl }
 
 private def fImpl(using qctx: QuoteContext): Expr[Unit] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   searchImplicit(('[A]).unseal.tpe) match {
     case x: ImplicitSearchSuccess =>
       '{}

--- a/tests/neg-macros/delegate-match-2/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-2/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted.matching._
 inline def f: Any = ${ fImpl }
 
 private def fImpl (using qctx: QuoteContext) : Expr[Unit] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   searchImplicit(('[A]).unseal.tpe) match {
     case x: ImplicitSearchSuccess =>
       '{}

--- a/tests/neg-macros/delegate-match-3/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-3/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted.matching._
 inline def f: Any = ${ fImpl }
 
 private def fImpl(using qctx: QuoteContext) : Expr[Unit] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   searchImplicit(('[A]).unseal.tpe) match {
     case x: ImplicitSearchSuccess =>
       '{}

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -7,7 +7,7 @@ object Macro {
   inline def (sc: => StringContext).foo(args: String*): Unit = ${ impl('sc) }
 
   def impl(sc: Expr[StringContext])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     sc match {
       case '{ StringContext(${ExprSeq(parts)}: _*) } =>
         for (part @ Const(s) <- parts)

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -7,7 +7,7 @@ object Macro {
   inline def (sc: => StringContext).foo(args: String*): Unit = ${ impl('sc) }
 
   def impl(sc: Expr[StringContext])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     sc match {
       case '{ StringContext(${ExprSeq(parts)}: _*) } =>
         for (part @ Const(s) <- parts)

--- a/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
@@ -13,7 +13,7 @@ object Asserts {
     ${impl('cond)}
 
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val tree = cond.unseal
 

--- a/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
@@ -13,7 +13,7 @@ object Asserts {
     ${ impl('cond) }
 
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val tree = cond.unseal
 

--- a/tests/neg-macros/tasty-macro-error/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-error/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def fun(x: Any): Unit = ${ impl('x) }
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     error("here is the the argument is " + x.unseal.underlyingArgument.show, x.unseal.underlyingArgument.pos)
     '{}
   }

--- a/tests/neg-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-positions/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def fun(x: Any): Unit = ${ impl('x) }
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val pos = x.unseal.underlyingArgument.pos
     error("here is the the argument is " + x.unseal.underlyingArgument.show, pos)
     error("here (+5) is the the argument is " + x.unseal.underlyingArgument.show, pos.sourceFile, pos.start + 5, pos.end + 5)

--- a/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
 object FIntepolator {
 
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     error("there are no parts", strCtxExpr.unseal.underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }

--- a/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
@@ -9,7 +9,7 @@ object Macro {
 
 object FIntepolator {
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     error("there are no args", argsExpr.unseal.underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }

--- a/tests/neg-staging/i5941/macro_1.scala
+++ b/tests/neg-staging/i5941/macro_1.scala
@@ -13,7 +13,7 @@ object Lens {
 
   def impl[S: Type, T: Type](getter: Expr[S => T])(using qctx: QuoteContext): Expr[Lens[S, T]] = {
     implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(this.getClass.getClassLoader)
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
     // obj.copy(field = value)
     def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =

--- a/tests/neg/i7919.scala
+++ b/tests/neg/i7919.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object Test {
   def staged[T](using qctx: QuoteContext) = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     given typeT as quoted.Type[T] // error
     val tTypeTree = typeT.unseal
     val tt = typeOf[T]

--- a/tests/pending/run/tasty-comments/quoted_1.scala
+++ b/tests/pending/run/tasty-comments/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
     ${ impl('t) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val tree = x.unseal
     tree.symbol.comment.map(_.raw) match {

--- a/tests/pos-macros/i6171/Macro_1.scala
+++ b/tests/pos-macros/i6171/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(x: => Any): Unit = ${ assertImpl('x) }
 
   def assertImpl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     x.unseal.underlyingArgument
     '{ () }
   }

--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition) }
 
   def assertImpl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     cond.unseal.underlyingArgument match {

--- a/tests/pos-macros/i6803b/Macro_1.scala
+++ b/tests/pos-macros/i6803b/Macro_1.scala
@@ -10,7 +10,7 @@ object AsObject {
     def unsafe(i: Int): LineNo = new LineNo(i)
     inline given x as LineNo = ${impl}
     private def impl(using qctx: QuoteContext) : Expr[LineNo] = {
-      import qctx.tasty.{_, given _}
+      import qctx.tasty._
       '{unsafe(${rootPosition.startLine})}
     }
   }

--- a/tests/pos-macros/tasty-constant-type/Macro_1.scala
+++ b/tests/pos-macros/tasty-constant-type/Macro_1.scala
@@ -7,7 +7,7 @@ object Macro {
   inline def ff[A <: Int, B <: Int]() <: AddInt[A, B] = ${ impl('[A], '[B]) }
 
   def impl[A <: Int : Type, B <: Int : Type](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[AddInt[A, B]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val ConstantType(Constant(v1: Int)) = a.unseal.tpe
     val ConstantType(Constant(v2: Int)) = b.unseal.tpe

--- a/tests/pos/i7204.scala
+++ b/tests/pos/i7204.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object Foo {
   def impl(using qctx: QuoteContext) : Unit = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val Select(_, _) = (??? : Term)
   }
 }

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -7,7 +7,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     x.unseal match {
       case Inlined(None, Nil, arg) => arg.symbol.tree.showExtractors
       case arg => arg.symbol.tree.showExtractors // TODO should all by name parameters be in an inline node?

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -7,7 +7,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     x.unseal match {
       case Inlined(None, Nil, arg) => arg.symbol.tree.showExtractors
       case arg => arg.symbol.tree.showExtractors // TODO should all by name parameters be in an inline node?

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val buff = new StringBuilder
 

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
@@ -7,7 +7,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     def definitionString(sym: Symbol): Expr[String] =
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.showExtractors)

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
@@ -6,7 +6,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     def definitionString(sym: Symbol): Expr[String] =
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.showExtractors)

--- a/tests/run-custom-args/run-macros-erased/reflect-isFunctionType/macro_1.scala
+++ b/tests/run-custom-args/run-macros-erased/reflect-isFunctionType/macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 inline def isFunctionType[T:Type]: Boolean = ${ isFunctionTypeImpl('[T]) }
 
 def isFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   Expr(tp.unseal.tpe.isFunctionType)
 }
 
@@ -12,7 +12,7 @@ def isFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean]
 inline def isContextFunctionType[T:Type]: Boolean = ${ isContextFunctionTypeImpl('[T]) }
 
 def isContextFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   Expr(tp.unseal.tpe.isContextFunctionType)
 }
 
@@ -20,14 +20,14 @@ def isContextFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[B
 inline def isErasedFunctionType[T:Type]: Boolean = ${ isErasedFunctionTypeImpl('[T]) }
 
 def isErasedFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   Expr(tp.unseal.tpe.isErasedFunctionType)
 }
 
 inline def isDependentFunctionType[T:Type]: Boolean = ${ isDependentFunctionTypeImpl('[T]) }
 
 def isDependentFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   Expr(tp.unseal.tpe.isDependentFunctionType)
 }
 

--- a/tests/run-macros/f-interpolation-1/FQuote_1.scala
+++ b/tests/run-macros/f-interpolation-1/FQuote_1.scala
@@ -10,7 +10,7 @@ object FQuote {
   }
 
   /*private*/ def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     def liftListOfAny(lst: List[Term]): Expr[List[Any]] = lst match {
       case x :: xs  =>

--- a/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
+++ b/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
@@ -7,28 +7,28 @@ object TypeToolbox {
   /** are the two types equal? */
   inline def =:=[A, B]: Boolean = ${tpEqImpl('[A], '[B])}
   private def tpEqImpl[A, B](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(a.unseal.tpe =:= b.unseal.tpe)
   }
 
   /** is `tp1` a subtype of `tp2` */
   inline def <:<[A, B]: Boolean = ${tpLEqImpl('[A], '[B])}
   private def tpLEqImpl[A, B](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(a.unseal.tpe <:< b.unseal.tpe)
   }
 
   /** type associated with the tree */
   inline def typeOf[T, Expected](a: T): Boolean = ${typeOfImpl('a, '[Expected])}
   private def typeOfImpl(a: Expr[_], expected: Type[_])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(a.unseal.tpe =:= expected.unseal.tpe)
   }
 
   /** does the type refer to a case class? */
   inline def isCaseClass[A]: Boolean = ${isCaseClassImpl('[A])}
   private def isCaseClassImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val sym = tp.unseal.symbol
     Expr(sym.isClassDef && sym.flags.is(Flags.Case))
   }
@@ -36,66 +36,66 @@ object TypeToolbox {
   /** val fields of a case class Type -- only the ones declared in primary constructor */
   inline def caseFields[T]: List[String] = ${caseFieldsImpl('[T])}
   private def caseFieldsImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[List[String]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val fields = tp.unseal.symbol.caseFields.map(_.name)
     Expr(fields)
   }
 
   inline def fieldIn[T](inline mem: String): String = ${fieldInImpl('[T], 'mem)}
   private def fieldInImpl(t: Type[_], mem: Expr[String])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val field = t.unseal.symbol.field(mem.value)
     Expr(if field.isNoSymbol then "" else field.name)
   }
 
   inline def fieldsIn[T]: Seq[String] = ${fieldsInImpl('[T])}
   private def fieldsInImpl(t: Type[_])(using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val fields = t.unseal.symbol.fields
     Expr(fields.map(_.name).toList)
   }
 
   inline def methodIn[T](inline mem: String): Seq[String] = ${methodInImpl('[T], 'mem)}
   private def methodInImpl(t: Type[_], mem: Expr[String])(using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(t.unseal.symbol.classMethod(mem.value).map(_.name))
   }
 
   inline def methodsIn[T]: Seq[String] = ${methodsInImpl('[T])}
   private def methodsInImpl(t: Type[_])(using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(t.unseal.symbol.classMethods.map(_.name))
   }
 
   inline def method[T](inline mem: String): Seq[String] = ${methodImpl('[T], 'mem)}
   private def methodImpl(t: Type[_], mem: Expr[String])(using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(t.unseal.symbol.method(mem.value).map(_.name))
   }
 
   inline def methods[T]: Seq[String] = ${methodsImpl('[T])}
   private def methodsImpl(t: Type[_])(using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(t.unseal.symbol.methods.map(_.name))
   }
 
   inline def typeTag[T](x: T): String = ${typeTagImpl('[T])}
   private def typeTagImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val res = tp.unseal.tpe.show
     Expr(res)
   }
 
   inline def companion[T1, T2]: Boolean = ${companionImpl('[T1], '[T2])}
   private def companionImpl(t1: Type[_], t2: Type[_])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val res = t1.unseal.symbol.companionModule == t2.unseal.symbol
     Expr(res)
   }
 
   inline def companionName[T1]: String = ${companionNameImpl('[T1])}
   private def companionNameImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val sym = tp.unseal.symbol
     val companionClass =
       if sym.isClassDef then sym.companionModule.companionClass

--- a/tests/run-macros/i5119/Macro_1.scala
+++ b/tests/run-macros/i5119/Macro_1.scala
@@ -7,7 +7,7 @@ object Macro {
   }
   implicit inline def XmlQuote(sc: => StringContext): StringContextOps = new StringContextOps(sc)
   def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     (sc.unseal.underlyingArgument.showExtractors + "\n" + args.unseal.underlyingArgument.showExtractors)
   }
 }

--- a/tests/run-macros/i5119b/Macro_1.scala
+++ b/tests/run-macros/i5119b/Macro_1.scala
@@ -7,7 +7,7 @@ object Macro {
   inline def ff(arg1: Any,  arg2: Any): String = ${ Macro.impl('{arg1}, '{arg2}) }
 
   def impl(arg1: Expr[Any], arg2: Expr[Any])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     (arg1.unseal.underlyingArgument.showExtractors + "\n" + arg2.unseal.underlyingArgument.showExtractors)
   }
 

--- a/tests/run-macros/i5533/Macro_1.scala
+++ b/tests/run-macros/i5533/Macro_1.scala
@@ -8,7 +8,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val tree = condition.unseal
 

--- a/tests/run-macros/i5533b/Macro_1.scala
+++ b/tests/run-macros/i5533b/Macro_1.scala
@@ -7,7 +7,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val tree = condition.unseal
     def exprStr: String = condition.show
 

--- a/tests/run-macros/i5536/Macro_1.scala
+++ b/tests/run-macros/i5536/Macro_1.scala
@@ -4,7 +4,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val tree = condition.unseal
     def exprStr: String = condition.show
 

--- a/tests/run-macros/i5629/Macro_1.scala
+++ b/tests/run-macros/i5629/Macro_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('{condition}, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val b = cond.unseal.underlyingArgument.seal.cast[Boolean]
     '{ scala.Predef.assert($b) }
   }
@@ -13,7 +13,7 @@ object Macros {
   inline def thisLineNumber = ${ thisLineNumberImpl }
 
   def thisLineNumberImpl(using qctx: QuoteContext) : Expr[Int] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(rootPosition.startLine)
   }
 }

--- a/tests/run-macros/i5715/Macro_1.scala
+++ b/tests/run-macros/i5715/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     cond.unseal.underlyingArgument match {
       case app @ Apply(select @ Select(lhs, op), rhs :: Nil) =>

--- a/tests/run-macros/i5941/macro_1.scala
+++ b/tests/run-macros/i5941/macro_1.scala
@@ -12,7 +12,7 @@ object Lens {
   }
 
   def impl[S: Type, T: Type](getter: Expr[S => T])(using qctx: QuoteContext) : Expr[Lens[S, T]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     // obj.copy(a = obj.a.copy(b = a.b.copy(c = v)))
@@ -85,7 +85,7 @@ object Iso {
   }
 
   def impl[S: Type, A: Type](using qctx: QuoteContext) : Expr[Iso[S, A]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     val tpS = typeOf[S]
@@ -124,7 +124,7 @@ object Iso {
   }
 
   def implUnit[S: Type](using qctx: QuoteContext) : Expr[Iso[S, 1]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     val tpS = typeOf[S]
@@ -196,7 +196,7 @@ object Prism {
   }
 
   def impl[S: Type, A <: S : Type](using qctx: QuoteContext) : Expr[Prism[S, A]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     '{

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/i6270/Macro_1.scala
+++ b/tests/run-macros/i6270/Macro_1.scala
@@ -6,7 +6,7 @@ object api {
     ${ reflImpl('x) }
 
   private def reflImpl(x: Expr[String])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(x.show)
   }
 
@@ -14,7 +14,7 @@ object api {
     ${ reflImplColor('x) }
 
   private def reflImplColor(x: Expr[String])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(x.show(ANSI))
   }
 }

--- a/tests/run-macros/i6518/Macro_1.scala
+++ b/tests/run-macros/i6518/Macro_1.scala
@@ -6,7 +6,7 @@ object Macros {
   inline def test(): String = ${ testImpl }
 
   private def testImpl(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val classSym = typeOf[Function1[_, _]].classSymbol.get
     classSym.classMethod("apply")
     classSym.classMethods

--- a/tests/run-macros/i6679/Macro_1.scala
+++ b/tests/run-macros/i6679/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 
 def makeMatch[A: Type](head : Expr[A])(using qctx : QuoteContext) : Expr[Unit] = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
 
   val sacrifice = '{ $head match { case _ => ??? } }
   sacrifice.unseal

--- a/tests/run-macros/i6765/Macro_1.scala
+++ b/tests/run-macros/i6765/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted.{given _}
 inline def foo = ${fooImpl}
 
 def fooImpl(using qctx: QuoteContext) = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   val res = Expr.ofList(List('{"One"}))
   Expr(res.show)
 }

--- a/tests/run-macros/i6988/FirstArg_1.scala
+++ b/tests/run-macros/i6988/FirstArg_1.scala
@@ -9,7 +9,7 @@ object Macros {
   import scala.quoted._
 
   def argsImpl(using qctx: QuoteContext) : Expr[FirstArg] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     def enclosingClass(cur: Symbol = rootContext.owner): Symbol =
       if (cur.isClassDef) cur

--- a/tests/run-macros/i7887/Macro_1.scala
+++ b/tests/run-macros/i7887/Macro_1.scala
@@ -1,5 +1,5 @@
 def myMacroImpl(a: quoted.Expr[_])(using qctx: quoted.QuoteContext) = {
-  import qctx.tasty.{_, given _}
+  import qctx.tasty._
   def typed[A] = {
     implicit val t: quoted.Type[A] = a.unseal.tpe.widen.seal.asInstanceOf[quoted.Type[A]]
     '{

--- a/tests/run-macros/i7898/Macro_1.scala
+++ b/tests/run-macros/i7898/Macro_1.scala
@@ -3,7 +3,7 @@ import quoted.unsafe._
 object Main {
 
   def myMacroImpl(body: Expr[_])(using qctx: QuoteContext) : Expr[_] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val bodyTerm = UnsafeExpr.underlyingArgument(body).unseal
     val showed = bodyTerm.show
     '{

--- a/tests/run-macros/i8007/Macro_1.scala
+++ b/tests/run-macros/i8007/Macro_1.scala
@@ -17,7 +17,7 @@ object Macro1 {
     ${ test1Impl('value) }
 
   def test1Impl[T: Type](value: Expr[T])(using qctx: QuoteContext): Expr[List[String]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val mirrorTpe = '[Mirror.Of[T]]
 

--- a/tests/run-macros/i8007/Macro_2.scala
+++ b/tests/run-macros/i8007/Macro_2.scala
@@ -21,7 +21,7 @@ object Macro2 {
         }
 
     def derived[T: Type](ev: Expr[Mirror.Of[T]])(using qctx: QuoteContext): Expr[JsonEncoder[T]] = {
-      import qctx.tasty.{_, given _}
+      import qctx.tasty._
 
       val fields = ev match {
         case '{ $m: Mirror.ProductOf[T] { type MirroredElemLabels = $t } } =>
@@ -43,7 +43,7 @@ object Macro2 {
   inline def test2[T](value: =>T): Unit = ${ test2Impl('value) }
 
   def test2Impl[T: Type](value: Expr[T])(using qctx: QuoteContext): Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val mirrorTpe = '[Mirror.Of[T]]
     val mirrorExpr = summonExpr(using mirrorTpe).get

--- a/tests/run-macros/i8007/Macro_3.scala
+++ b/tests/run-macros/i8007/Macro_3.scala
@@ -33,7 +33,7 @@ object Eq {
   }
 
   given derived[T: Type](using qctx: QuoteContext) as Expr[Eq[T]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val ev: Expr[Mirror.Of[T]] = summonExpr(using '[Mirror.Of[T]]).get
 

--- a/tests/run-macros/inferred-repeated-result/test_1.scala
+++ b/tests/run-macros/inferred-repeated-result/test_1.scala
@@ -4,7 +4,7 @@ object Macros {
 
   inline def go[T](inline t: T) = ${ impl('t) }
   def impl[T](expr: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val tree = expr.unseal
 

--- a/tests/run-macros/no-symbol/1.scala
+++ b/tests/run-macros/no-symbol/1.scala
@@ -9,7 +9,7 @@ object Macro {
     ${ fooImpl[T] }
 
   def fooImpl[T](implicit t: Type[T], qctx: QuoteContext): Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val sym = t.unseal.symbol
     if sym.isClassDef then '{ "symbol" }
     else if sym.isNoSymbol then '{ "no symbol" }

--- a/tests/run-macros/quote-inline-function/quoted_1.scala
+++ b/tests/run-macros/quote-inline-function/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
   inline def foreach3(start: Int, end: Int, inline f: Int => Unit): String = ${impl('start, 'end, 'f)}
 
   def impl(start: Expr[Int], end: Expr[Int], f: Expr[Int => Unit])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val res = '{
       var i = $start
       val j = $end

--- a/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
@@ -20,7 +20,7 @@ object Macros {
         '{ $sym.times(${lift(x)}, ${lift(y)}) }
 
       case _ =>
-        import qctx.tasty.{_, given _}
+        import qctx.tasty._
         error("Expected explicit DSL", e.unseal.pos)
         '{ ??? }
 

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -31,7 +31,7 @@ object Macros {
       case '{ envVar(${Const(i)}) } => env(i)
 
       case _ =>
-        import qctx.tasty.{_, given _}
+        import qctx.tasty._
         error("Expected explicit DSL " + e.show, e.unseal.pos)
         ???
     }
@@ -45,7 +45,7 @@ object Macros {
           }
         )
       case _ =>
-        import qctx.tasty.{_, given _}
+        import qctx.tasty._
         error("Expected explicit DSL => DSL "  + e.show, e.unseal.pos)
         ???
     }

--- a/tests/run-macros/quote-toExprOfTuple/Macro_1.scala
+++ b/tests/run-macros/quote-toExprOfTuple/Macro_1.scala
@@ -4,7 +4,7 @@ object Macro {
   inline def t2[T0, T1](t0: T0, t1: T1): (T0, T1) = ${ impl2('{t0}, '{t1}) }
 
   def impl2[T0: Type, T1: Type](t0: Expr[T0], t1: Expr[T1])(using qctx: QuoteContext) : Expr[(T0, T1)] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     val seq = List(t0, t1)

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext): Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/reflect-lambda/assert_1.scala
+++ b/tests/run-macros/reflect-lambda/assert_1.scala
@@ -5,7 +5,7 @@ object lib {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     cond.unseal.underlyingArgument match {

--- a/tests/run-macros/reflect-pos-fun/assert_1.scala
+++ b/tests/run-macros/reflect-pos-fun/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition) }
 
   def assertImpl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     cond.unseal.underlyingArgument match {

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/reflect-select-copy-2/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy-2/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/reflect-select-copy/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     cond.unseal.underlyingArgument match {
       case Apply(select @ Select(lhs, op), rhs :: Nil) =>

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/reflect-sourceCode/Macro_1.scala
+++ b/tests/run-macros/reflect-sourceCode/Macro_1.scala
@@ -5,7 +5,7 @@ object api {
     ${ reflImpl('x) }
 
   private def reflImpl[T](x: Expr[T])(implicit qctx: QuoteContext): Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(x.unseal.pos.sourceCode)
   }
 }

--- a/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
   inline def inspect[T](x: T): Unit = ${ impl('x) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val tree = x.unseal
     '{
       println()

--- a/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
+++ b/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def theTestBlock : Unit = ${ theTestBlockImpl }
 
   def theTestBlockImpl(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     // simple smoke test
     val sym1 : Symbol = Symbol.newMethod(

--- a/tests/run-macros/tasty-custom-show/quoted_1.scala
+++ b/tests/run-macros/tasty-custom-show/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val buff = new StringBuilder
 
@@ -41,7 +41,7 @@ object Macros {
   def dummyShow(using qctx: QuoteContext) : scala.tasty.reflect.Printer[qctx.tasty.type] = {
     new scala.tasty.reflect.Printer {
       val tasty = qctx.tasty
-      import qctx.tasty.{_, given _}
+      import qctx.tasty._
       def showTree(tree: Tree)(implicit ctx: Context): String = "Tree"
       def showTypeOrBounds(tpe: TypeOrBounds)(implicit ctx: Context): String = "TypeOrBounds"
       def showConstant(const: Constant)(implicit ctx: Context): String = "Constant"

--- a/tests/run-macros/tasty-dealias/quoted_1.scala
+++ b/tests/run-macros/tasty-dealias/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def dealias[T]: String = ${ impl('[T]) }
 
   def impl[T](x: quoted.Type[T])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(x.unseal.tpe.dealias.show)
   }
 }

--- a/tests/run-macros/tasty-definitions-1/quoted_1.scala
+++ b/tests/run-macros/tasty-definitions-1/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
   inline def testDefinitions(): Unit = ${testDefinitionsImpl}
 
   def testDefinitionsImpl(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val buff = List.newBuilder[String]
     def printout(x: => String): Unit = {

--- a/tests/run-macros/tasty-eval/quoted_1.scala
+++ b/tests/run-macros/tasty-eval/quoted_1.scala
@@ -18,7 +18,7 @@ object Macros {
 
   implicit def intIsEvalable: Valuable[Int] = new Valuable[Int] {
     override def value(e: Expr[Int])(using qctx: QuoteContext) : Option[Int] = {
-      import qctx.tasty.{_, given _}
+      import qctx.tasty._
 
       e.unseal.tpe match {
         case pre: TermRef if pre.termSymbol.isValDef =>

--- a/tests/run-macros/tasty-extractors-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-1/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val tree = x.unseal
     val treeStr = tree.showExtractors

--- a/tests/run-macros/tasty-extractors-2/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-2/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val tree = x.unseal
 

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
     ${impl('x)}
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val buff = new StringBuilder
     val traverser = new TreeTraverser {

--- a/tests/run-macros/tasty-extractors-types/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-types/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
   implicit inline def printType[T]: Unit = ${ impl('[T]) }
 
   def impl[T](x: Type[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val tree = x.unseal
     '{

--- a/tests/run-macros/tasty-indexed-map/quoted_1.scala
+++ b/tests/run-macros/tasty-indexed-map/quoted_1.scala
@@ -26,7 +26,7 @@ object Index {
   implicit inline def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ${succImpl[K, H, T]}
 
   def succImpl[K, H, T](implicit qctx: QuoteContext, k: Type[K], h: Type[H], t: Type[T]): Expr[Index[K, (H, T)]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     def name(tp: TypeOrBounds): String = tp match {
       case ConstantType(Constant(str: String)) => str

--- a/tests/run-macros/tasty-interpolation-1/Macro.scala
+++ b/tests/run-macros/tasty-interpolation-1/Macro.scala
@@ -55,7 +55,7 @@ abstract class MacroStringInterpolator[T] {
   protected def interpolate(strCtx: StringContext, argExprs: List[Expr[Any]]) (using QuoteContext): Expr[T]
 
   protected def getStaticStringContext(strCtxExpr: Expr[StringContext])(using qctx: QuoteContext) : StringContext = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     strCtxExpr.unseal.underlyingArgument match {
       case Select(Typed(Apply(_, List(Apply(_, List(Typed(Repeated(strCtxArgTrees, _), Inferred()))))), _), _) =>
         val strCtxArgs = strCtxArgTrees.map {
@@ -69,7 +69,7 @@ abstract class MacroStringInterpolator[T] {
   }
 
   protected def getArgsList(argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : List[Expr[Any]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     argsExpr.unseal.underlyingArgument match {
       case Typed(Repeated(args, _), _) => args.map(_.seal)
       case tree => throw new NotStaticlyKnownError("Expected statically known argument list", tree.seal)

--- a/tests/run-macros/tasty-linenumber-2/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber-2/quoted_1.scala
@@ -10,7 +10,7 @@ object LineNumber {
   implicit inline def line: LineNumber = ${lineImpl}
 
   def lineImpl(using qctx: QuoteContext) : Expr[LineNumber] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     '{new LineNumber(${rootPosition.startLine})}
   }
 

--- a/tests/run-macros/tasty-linenumber/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber/quoted_1.scala
@@ -11,7 +11,7 @@ object LineNumber {
     ${lineImpl('[T])}
 
   def lineImpl(x: Type[Unit])(using qctx: QuoteContext) : Expr[LineNumber] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     '{new LineNumber(${rootPosition.startLine})}
   }
 

--- a/tests/run-macros/tasty-location/quoted_1.scala
+++ b/tests/run-macros/tasty-location/quoted_1.scala
@@ -8,7 +8,7 @@ object Location {
   implicit inline def location: Location = ${impl}
 
   def impl(using qctx: QuoteContext) : Expr[Location] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     def listOwnerNames(sym: Symbol, acc: List[String]): List[String] =
       if (sym == defn.RootClass || sym == defn.EmptyPackageClass) acc

--- a/tests/run-macros/tasty-macro-assert/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-assert/quoted_1.scala
@@ -13,7 +13,7 @@ object Asserts {
     ${impl('cond)}
 
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val tree = cond.unseal
 

--- a/tests/run-macros/tasty-macro-const/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-const/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def natConst(x: Int): Int = ${ natConstImpl('x) }
 
   def natConstImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[Int] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val xTree: Term = x.unseal
     xTree match {
       case Inlined(_, _, Literal(Constant(n: Int))) =>

--- a/tests/run-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-positions/quoted_1.scala
@@ -9,7 +9,7 @@ object Macros {
   inline def fun3[T]: Unit = ${ impl2('[T]) }
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val pos = x.unseal.underlyingArgument.pos
     val code = x.unseal.underlyingArgument.show
     '{
@@ -19,7 +19,7 @@ object Macros {
   }
 
   def impl2[T](x: quoted.Type[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val pos = x.unseal.pos
     val code = x.unseal.show
     '{
@@ -30,7 +30,7 @@ object Macros {
 
   def posStr(qctx: QuoteContext)(pos: qctx.tasty.Position): Expr[String] = {
     given QuoteContext = qctx
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(s"${pos.sourceFile.jpath.getFileName.toString}:[${pos.start}..${pos.end}]")
   }
 }

--- a/tests/run-macros/tasty-original-source/Macros_1.scala
+++ b/tests/run-macros/tasty-original-source/Macros_1.scala
@@ -6,7 +6,7 @@ object Macros {
   implicit inline def withSource(arg: Any): (String, Any) = ${ impl('arg) }
 
   private def impl(arg: Expr[Any])(using qctx: QuoteContext) : Expr[(String, Any)] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val source = arg.unseal.underlyingArgument.pos.sourceCode.toString
     '{Tuple2($source, $arg)}
   }

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -7,7 +7,7 @@ object Asserts {
 
   /** Replaces last argument list by 0s */
   def zeroLastArgsImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[Int] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
     x.unseal.underlyingArgument match {
       case Apply(fn, args) =>
@@ -29,7 +29,7 @@ object Asserts {
 
   /** Replaces all argument list by 0s */
   def zeroAllArgsImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[Int] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
     def rec(term: Term): Term = term match {
       case Apply(fn, args) =>

--- a/tests/run-macros/tasty-simplified/quoted_1.scala
+++ b/tests/run-macros/tasty-simplified/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
   inline def simplified[T <: Tuple]: Seq[String] = ${ impl[T] }
 
   def impl[T: Type](using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     def unpackTuple(tp: Type): List[Type] = {
       @tailrec

--- a/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
+++ b/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
@@ -24,7 +24,7 @@ object Macro {
       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args)) =>
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
-            import qctx.tasty.{_, given _}
+            import qctx.tasty._
             error(msg, parts(partIdx).unseal.pos)
           }
         }
@@ -38,7 +38,7 @@ object Macro {
         val errors = List.newBuilder[Expr[(Int, Int, Int, String)]]
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
-            import qctx.tasty.{_, given _}
+            import qctx.tasty._
             val pos = parts(partIdx).unseal.pos
             errors += '{ Tuple4($partIdx, ${pos.start}, ${pos.end}, $msg) }
           }

--- a/tests/run-macros/tasty-subtyping/quoted_1.scala
+++ b/tests/run-macros/tasty-subtyping/quoted_1.scala
@@ -10,13 +10,13 @@ object Macros {
     ${isSubTypeOfImpl('[T], '[U])}
 
   def isTypeEqualImpl[T, U](t: Type[T], u: Type[U])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val isTypeEqual = t.unseal.tpe =:= u.unseal.tpe
     isTypeEqual
   }
 
   def isSubTypeOfImpl[T, U](t: Type[T], u: Type[U])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     val isTypeEqual = t.unseal.tpe <:< u.unseal.tpe
     isTypeEqual
   }

--- a/tests/run-macros/tasty-typeof/Macro_1.scala
+++ b/tests/run-macros/tasty-typeof/Macro_1.scala
@@ -6,7 +6,7 @@ object Macros {
   inline def testTypeOf(): Unit = ${ testTypeOfImpl }
 
   private def testTypeOfImpl(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     '{
       assert(${(typeOf[Unit] =:= defn.UnitType)}, "Unit")
       assert(${(typeOf[Byte] =:= defn.ByteType)}, "Byte")

--- a/tests/run-macros/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-macros/tasty-unsafe-let/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
     ${ impl('rhs, 'body) }
 
   private def impl[T](rhs: Expr[T], body: Expr[T => Unit])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     val rhsTerm = rhs.unseal
 

--- a/tests/run-macros/type-show/Macro_1.scala
+++ b/tests/run-macros/type-show/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 object TypeToolbox {
   inline def show[A]: String = ${ showImpl('[A]) }
   private def showImpl[A, B](a: Type[A])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
     Expr(a.show)
   }
 }

--- a/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
@@ -14,7 +14,7 @@ object XmlQuote {
 
   def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])
           (using qctx: QuoteContext) : Expr[Xml] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     // for debugging purpose
     def pp(tree: Tree): Unit = {

--- a/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
@@ -15,7 +15,7 @@ object XmlQuote {
   implicit inline def SCOps(ctx: => StringContext): SCOps = new SCOps(ctx)
 
   def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[Xml] = {
-    import qctx.tasty.{_, given _}
+    import qctx.tasty._
 
     // for debugging purpose
     def pp(tree: Tree): Unit = {


### PR DESCRIPTION
Make the reflection API not require the given import `import qctx.tasty.{given _}`.   `import qctx.tasty._` is still used but not required