### PR TITLE
Refine atoms computation on intersection types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Atoms.scala
+++ b/compiler/src/dotty/tools/dotc/core/Atoms.scala
@@ -20,8 +20,11 @@ enum Atoms:
     case Range(lo1, hi1) =>
       that match
         case Range(lo2, hi2) => Range(lo1 & lo2, hi1 & hi2)
-        case Unknown => this
-    case Unknown => that
+        case Unknown => Range(Set.empty, hi1)
+    case Unknown =>
+      that match
+        case Range(lo2, hi2) => Range(Set.empty, hi2)
+        case Unknown => Unknown
 
   def | (that: Atoms): Atoms = this match
     case Range(lo1, hi1) =>


### PR DESCRIPTION
The previous computation was unsound. For instance, if 

    p: A & q.type

where `A`'s atoms are `Unknown`, then the upper bound of `p`'s atoms is `q`, but the lower bound
is empty since `q.type`  and `A` might not intersect. Previously, the lower bound was also `q`.


