### PR TITLE
Fix #6635: Improve subtype tests for aliases and singleton types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2403,6 +2403,33 @@ object Types {
     type ThisType = TypeRef
     type ThisName = TypeName
 
+    private var myCanDropAliasPeriod: Period = Nowhere
+    private var myCanDropAlias: Boolean = _
+
+    /** Given an alias type `type A = B` where a recursive comparison with `B` yields
+     *  `false`, can we conclude that the comparison is definitely false?
+     *  This could not be the case if `A` overrides some abstract type. Example:
+     *
+     *    class C { type A }
+     *    class D { type A = Int }
+     *    val c: C
+     *    val d: D & c.type
+     *    c.A <:< d.A   ?
+     *
+     *  The test should return true, by performing the logic in the bottom half of
+     *  firstTry (where we check the names of types). But just following the alias
+     *  from d.A to Int reduces the problem to `c.A <:< Int`, which returns `false`.
+     *  So we can't drop the alias here, we need to do the backtracking to the name-
+     *  based tests.
+     */
+    def canDropAlias(using ctx: Context) =
+      if myCanDropAliasPeriod != ctx.period then
+        myCanDropAlias =
+          !symbol.canMatchInheritedSymbols
+          || !prefix.baseClasses.exists(_.info.decls.lookup(name).is(Deferred))
+        myCanDropAliasPeriod = ctx.period
+      myCanDropAlias
+
     override def designator: Designator = myDesignator
     override protected def designator_=(d: Designator): Unit = myDesignator = d
 

--- a/tests/pos/i6635.scala
+++ b/tests/pos/i6635.scala
@@ -1,0 +1,46 @@
+object Test {
+  abstract class ExprBase { s =>
+    type A
+  }
+
+  abstract class Lit extends ExprBase { s =>
+    type A = Int
+    val n: A
+  }
+
+  abstract class LitU extends ExprBase { s =>
+    type A <: Int
+    val n: A
+  }
+
+  abstract class LitL extends ExprBase { s =>
+    type A <: Int
+    val n: A
+  }
+
+  def castTest1(e1: ExprBase)(e2: e1.type)(x: e1.A): e2.A = x
+  def castTest2(e1: ExprBase { type A = Int })(e2: e1.type)(x: e1.A): e2.A = x
+  def castTest3(e1: ExprBase)(e2: ExprBase with e1.type)(x: e2.A): e1.A = x
+
+  def castTest4(e1: ExprBase { type A = Int })(e2: ExprBase with e1.type)(x: e2.A): e1.A = x
+
+  def castTest5a(e1: ExprBase)(e2: LitU with e1.type)(x: e2.A): e1.A = x
+  def castTest5b(e1: ExprBase)(e2: LitL with e1.type)(x: e2.A): e1.A = x
+
+  //fail:
+  def castTestFail1(e1: ExprBase)(e2: Lit with e1.type)(x: e2.A): e1.A = x // this is like castTest5a/b, but with Lit instead of LitU/LitL
+  // the other direction never works:
+  def castTestFail2a(e1: ExprBase)(e2: Lit with e1.type)(x: e1.A): e2.A = x
+  def castTestFail2b(e1: ExprBase)(e2: LitL with e1.type)(x: e1.A): e2.A = x
+  def castTestFail2c(e1: ExprBase)(e2: LitU with e1.type)(x: e1.A): e2.A = x
+
+  // the problem isn't about order of intersections.
+  def castTestFail2bFlip(e1: ExprBase)(e2: e1.type with LitL)(x: e1.A): e2.A = x
+  def castTestFail2cFlip(e1: ExprBase)(e2: e1.type with LitU)(x: e1.A): e2.A = x
+
+  def castTestFail3(e1: ExprBase)(e2: Lit with e1.type)(x: e1.A): e2.A = {
+    val y: e1.type with e2.type = e2
+    val z = x: y.A
+    z
+  }
+}


### PR DESCRIPTION
 1. backtrack in more cases when we fail after dealiasing
 2. fall back to atoms comparisons when comparing two singleton types

