### PR TITLE
Fix #5309: Fix subtyping tests on constant types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -341,7 +341,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
         compareErasedValueType
       case ConstantType(v2) =>
         tp1 match {
-          case ConstantType(v1) => v1.value == v2.value
+          case ConstantType(v1) => v1.value == v2.value && recur(v1.tpe, v2.tpe)
           case _ => secondTry
         }
       case tp2: AnyConstantType =>

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1948,7 +1948,7 @@ trait Applications extends Compatibility {
   }
 
   /** If `trees` all have numeric value types, and they do not have all the same type,
-   *  pick a common numeric supertype and convert all constant trees to this type.
+   *  pick a common numeric supertype and try to convert all constant Int literals to this type.
    *  If the resulting trees all have the same type, return them instead of the original ones.
    */
   def harmonize(trees: List[Tree])(implicit ctx: Context): List[Tree] = {

--- a/tests/pos/i5309.scala
+++ b/tests/pos/i5309.scala
@@ -1,0 +1,10 @@
+object A {
+  def foo[T](x: T, y: T): Int = 55
+  def bar[T](x: T, y: T): List[T] = x :: y :: Nil
+  val x = foo(23, 23f)
+  val y = bar(23, 23f)
+  val z = List(23, 23f)
+  val x2 = foo(23.0, 23)
+  val y2 = bar(23.0, 23)
+  val z2 = List(23.0, 23)
+}


### PR DESCRIPTION
When comparing two constant types with `<:<` it's not enough to compare
values, we also need to compare the underlyong types. Otherwise it would
be the case that

    23f <:< 23