### PR TITLE
Fix #5005: Weaken assertion when trying to compute an ErasedValueType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -550,11 +550,12 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
   private def eraseDerivedValueClassRef(tref: TypeRef)(implicit ctx: Context): Type = {
     val cls = tref.symbol.asClass
     val underlying = underlyingOfValueClass(cls)
-    if (underlying.exists && !isCyclic(cls)) {
+    if underlying.exists && !isCyclic(cls) then
       val erasedValue = valueErasure(underlying)
-      assert(erasedValue.exists, i"no erasure for $underlying")
-      ErasedValueType(tref, erasedValue)
-    }
+      if erasedValue.exists then ErasedValueType(tref, erasedValue)
+      else
+        assert(ctx.reporter.errorsReported, i"no erasure for $underlying")
+        NoType
     else NoType
   }
 

--- a/tests/neg/i5005.scala
+++ b/tests/neg/i5005.scala
@@ -1,0 +1,6 @@
+
+case class i0 (i0: i1) extends AnyVal
+trait i1 extends i0   // error
+
+trait F[x] extends AnyVal    // error
+case class G[x](a: F[x]) extends F[x] // error // error


### PR DESCRIPTION
Allow for missing erased values when errors were reported previously