### PR TITLE
Fix #4987: Avoid widening instantiations to module classes

### DIFF
--- a/tests/neg/module-class-name.check
+++ b/tests/neg/module-class-name.check
@@ -1,20 +1,20 @@
 -- [E007] Type Mismatch Error: tests/neg/module-class-name.scala:7:13 --------------------------------------------------
-7 |  val x: C = C    // error: Found:    Test.C.type
+7 |  val x: C = C    // error
   |             ^
   |             Found:    Test.C.type
   |             Required: Test.C
 -- [E007] Type Mismatch Error: tests/neg/module-class-name.scala:9:15 --------------------------------------------------
-9 |  val y: C = f(C) // error: Found:    Test.C.type
+9 |  val y: C = f(C) // error
   |               ^
   |               Found:    Test.C.type
   |               Required: Test.C
 -- [E007] Type Mismatch Error: tests/neg/module-class-name.scala:12:14 -------------------------------------------------
-12 |  val z1: C = z    // error: Found:    object Test.C
+12 |  val z1: C = z    // error
    |              ^
    |              Found:    Test.C.type
    |              Required: Test.C
 -- [E007] Type Mismatch Error: tests/neg/module-class-name.scala:13:16 -------------------------------------------------
-13 |  val z2: Int = z  // error: Found:    object Test.C
+13 |  val z2: Int = z  // error
    |                ^
    |                Found:    Test.C.type
    |                Required: Int

--- a/tests/neg/module-class-name.check
+++ b/tests/neg/module-class-name.check
@@ -11,12 +11,12 @@
 -- [E007] Type Mismatch Error: tests/neg/module-class-name.scala:12:14 -------------------------------------------------
 12 |  val z1: C = z    // error: Found:    object Test.C
    |              ^
-   |              Found:    object Test.C
+   |              Found:    Test.C.type
    |              Required: Test.C
 -- [E007] Type Mismatch Error: tests/neg/module-class-name.scala:13:16 -------------------------------------------------
 13 |  val z2: Int = z  // error: Found:    object Test.C
    |                ^
-   |                Found:    object Test.C
+   |                Found:    Test.C.type
    |                Required: Int
 -- [E008] Member Not Found Error: tests/neg/module-class-name.scala:15:4 -----------------------------------------------
 15 |  C.foo  // error: value foo is not a member of object Test.C

--- a/tests/neg/module-class-name.scala
+++ b/tests/neg/module-class-name.scala
@@ -4,13 +4,13 @@ object Test {
 
   def f[T](x: T): T = x
 
-  val x: C = C    // error: Found:    Test.C.type
+  val x: C = C    // error
 
-  val y: C = f(C) // error: Found:    Test.C.type
+  val y: C = f(C) // error
 
   def z = f(C)
-  val z1: C = z    // error: Found:    object Test.C
-  val z2: Int = z  // error: Found:    object Test.C
+  val z1: C = z    // error
+  val z2: Int = z  // error
 
   C.foo  // error: value foo is not a member of object Test.C
 }

--- a/tests/pos/i4987.scala
+++ b/tests/pos/i4987.scala
@@ -1,0 +1,18 @@
+object Foo {
+
+  class Expr[T]
+
+  abstract class Liftable[T] {
+    def toExpr(x: T): Expr[T]
+  }
+
+  implicit class LiftExprOps[T](val x: T) extends AnyVal {
+    def toExpr(implicit ev: Liftable[T]): Expr[T] = ev.toExpr(x)
+  }
+
+  implicit def NilIsLiftable: Liftable[Nil.type] = ???
+
+  Nil.toExpr(NilIsLiftable)
+  (Nil.toExpr: Expr[Nil.type])
+  Nil.toExpr
+}


### PR DESCRIPTION
When instantiating a type variable, avoid widening to a module class reference.
Widen to the source module instead.