### PR TITLE
Restrict Eta-reduction to Java-defined classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -606,10 +606,10 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
               return recur(tp1.EtaExpand(tparams1), tp2) || fourthTry
             tp2 match {
               case EtaExpansion(tycon2) if tycon2.symbol.isClass && tycon2.symbol.is(JavaDefined) =>
-                return recur(tp1, tycon2)
+                recur(tp1, tycon2) || fourthTry
               case _ =>
+                fourthTry
             }
-            fourthTry
         }
         compareTypeLambda
       case OrType(tp21, tp22) =>
@@ -774,6 +774,8 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
       case tp1: HKTypeLambda =>
         def compareHKLambda = tp1 match {
           case EtaExpansion(tycon1) if tycon1.symbol.isClass && tycon1.symbol.is(JavaDefined) =>
+            // It's a raw type that was mistakenly eta-expanded to a hk-type.
+            // This can happen because we do not cook types coming from Java sources
             recur(tycon1, tp2)
           case _ => tp2 match {
             case tp2: HKTypeLambda => false // this case was covered in thirdTry

--- a/tests/pending/pos/i4908.scala
+++ b/tests/pending/pos/i4908.scala
@@ -1,0 +1,41 @@
+object Test {
+  trait A
+  trait B
+  trait TestConstructor1 { type F[X <: A]
+    trait FromSet[C[_ <: A with B]]
+
+    trait MSetLike[X <: A with B, This <: MSet[X] with MSetLike[X, This]] {
+      def to[C[X <: A with B] <: MSet[X] with MSetLike[X, C[X]]](fi: FromSet[C]): C[X] = ???
+    }
+    trait MSet[X <: A with B] extends MSetLike[X, MSet[X]]
+    object MSetFactory extends FromSet[MSet]
+  }
+
+  trait TestConstructor4[D] {
+    trait TestConstructor5[E] {
+      trait FromSet[C[_ <: D with E]]
+
+      trait MSetLike[X <: D with E, This <: MSet[X] with MSetLike[X, This]] {
+        def to[C[X <: D with E] <: MSet[X] with MSetLike[X, C[X]]](fi: FromSet[C]): C[X] = ???
+      }
+      trait MSet[X <: D with E] extends MSetLike[X, MSet[X]]
+      object MSetFactory extends FromSet[MSet]
+    }
+  }
+
+  type C = A & B
+  val v1: TestConstructor1 => Unit = { f =>
+    type P[a <: A] = f.F[a]
+
+    type P1[c <: C] = f.MSet[c]
+      (f.MSetFactory: f.FromSet[f.MSet]): Unit
+      (x: P1[C]) => x.to(f.MSetFactory)
+  }
+
+  def f3(f: TestConstructor4[A])(g: f.TestConstructor5[B]): Unit = {
+    type P1[c <: C] = g.MSet[c]
+      (g.MSetFactory: g.FromSet[g.MSet]): Unit
+      (x: P1[C]) => x.to(g.MSetFactory)
+      (x: P1[C]) => x.to[g.MSet](g.MSetFactory)
+  }
+}

--- a/tests/pos/i4742.scala
+++ b/tests/pos/i4742.scala
@@ -1,0 +1,6 @@
+import scala.reflect.ClassTag
+
+class Test {
+  def foo[T <: String: ClassTag](f: T => Int) = 1
+  def bar(f: String => Int) = foo(f)
+}

--- a/tests/pos/i4854.scala
+++ b/tests/pos/i4854.scala
@@ -1,0 +1,5 @@
+class C {
+  def f(x: Int): Unit = ()
+  val f: String => Unit = s => ()
+  f("a")
+}

--- a/tests/pos/i4867.scala
+++ b/tests/pos/i4867.scala
@@ -1,0 +1,16 @@
+object UnionMapping {
+  private def parse(string: String): Int | Double = {
+    if(string.contains("."))
+      string.toDouble
+    else
+      string.toInt
+  }
+
+  def test_number = {
+    val strings: Seq[String] = Seq("123", "2.0", "42")
+    // Works
+    val asdf: Seq[AnyVal] = strings.map(parse(_))
+    // Fails to compile
+    val union: Seq[Int | Double] = strings.map(parse(_))
+  }
+}

--- a/tests/pos/i4906.scala
+++ b/tests/pos/i4906.scala
@@ -1,0 +1,36 @@
+object Test {
+  trait A
+  trait TestConstructor1 { type F[_ <: A] }
+  trait TestConstructor2[D] {
+    type F[_ <: D]
+    class G[X <: D]
+    trait TestConstructor3[E] {
+      type G[_ <: D & E]
+      class H[X <: D & E]
+    }
+  }
+
+  val v1: TestConstructor1 => Unit = { f =>
+    type P[a <: A] = f.F[a] // OK
+  }
+
+  val v2: TestConstructor2[A] => Unit = { f =>
+    type P[a <: A] = f.F[a] // Error! Type argument a does not conform to upper bound D
+  }
+
+  def f2(f: TestConstructor2[A]): Unit = {
+    type P[a <: A] = f.F[a] // Error! Type argument a does not conform to upper bound D
+  }
+
+  val v3: (f: TestConstructor2[A]) => (g: f.TestConstructor3[A]) => Unit = ??? // ok
+  val v4: (f: TestConstructor2[A]) => (g: f.TestConstructor3[A]) => Unit = {f => ???}
+  val v5: (f: TestConstructor2[A]) => (g: f.TestConstructor3[A]) => Unit = {(f: TestConstructor2[A]) => ???}
+                                                                                                                                           // }
+  def f3(f: TestConstructor2[A], g: f.TestConstructor3[A]): Unit = {
+    type P[a <: A] = f.F[a] // Error! Type argument a does not conform to upper bound D
+    type Q[a <: A] = g.G[a]
+    // type R[a <: A] = (f.F & g.G)[a] // compiler error
+    type R[a <: A] = ([X <: A] =>> f.F[X] & g.G[X])[a]
+    type S[a <: A] = f.G[a] & g.H[a]
+  }
+}


### PR DESCRIPTION
Collapse `[X] =>> C[X]` only if `C` is a Java-defined class. Since
Java does not have hk-types it must be a raw type in this case.