### PR TITLE
Unicode escapes are ordinary escape sequences

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/CharArrayReader.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/CharArrayReader.scala
@@ -10,7 +10,7 @@ abstract class CharArrayReader { self =>
   protected def startFrom: Int = 0
 
   /** Switch whether unicode should be decoded */
-  protected def decodeUni: Boolean = true
+  protected def decodeUni: Boolean = false
 
   /** An error routine to call on bad unicode escapes \\uxxxx. */
   protected def error(msg: String, offset: Int): Unit

--- a/compiler/src/dotty/tools/dotc/parsing/JavaScanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaScanners.scala
@@ -14,6 +14,8 @@ object JavaScanners {
 
   class JavaScanner(source: SourceFile, override val startFrom: Offset = 0)(implicit ctx: Context) extends ScannerCommon(source)(ctx) {
 
+    override def decodeUni: Boolean = true
+
     def toToken(name: SimpleName): Token = {
       val idx = name.start
       if (idx >= 0 && idx <= lastKeywordStart) kwArray(idx) else IDENTIFIER

--- a/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
@@ -63,6 +63,20 @@ class StringInterpolatorOpt extends MiniPhase {
     }
   }
 
+  //Extract the position from InvalidUnicodeEscapeException
+  //which due to bincompat reasons is unaccessible.
+  //TODO: remove once there is less restrictive bincompat
+  private object InvalidEscapePosition {
+    def unapply(t: Throwable): Option[Int] = t match {
+      case iee: StringContext.InvalidEscapeException => Some(iee.index)
+      case il: IllegalArgumentException => il.getMessage() match {
+          case s"""invalid unicode escape at index $index of $_""" => index.toIntOption
+          case _ => None
+      }
+      case _ => None
+    }
+  }
+
   /**
     * Match trees that resemble s and raw string interpolations. In the case of the s
     * interpolator, escapes the string constants. Exposes the string constants as well as
@@ -74,14 +88,23 @@ class StringInterpolatorOpt extends MiniPhase {
         case SOrRawInterpolator(strs, elems) =>
           if (tree.symbol == defn.StringContext_raw) Some(strs, elems)
           else { // tree.symbol == defn.StringContextS
+            import dotty.tools.dotc.util.SourcePosition
+            var stringPosition: SourcePosition = null
+            var offset: Int = 0
             try {
-              val escapedStrs = strs.map { str =>
-                val escapedValue = StringContext.processEscapes(str.const.stringValue)
-                cpy.Literal(str)(Constant(escapedValue))
-              }
+              val escapedStrs = strs.map(str => {
+                stringPosition = str.sourcePos
+                val escaped = StringContext.processEscapes(str.const.stringValue)
+                cpy.Literal(str)(Constant(escaped))
+              })
               Some(escapedStrs, elems)
             } catch {
-              case _: StringContext.InvalidEscapeException => None
+              case t @ InvalidEscapePosition(p) => {
+                val errorSpan = stringPosition.span.startPos.shift(p)
+                val errorPosition = stringPosition.withSpan(errorSpan)
+                ctx.error(t.getMessage() + "\n", errorPosition)
+                None
+              }
             }
           }
         case _ => None

--- a/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
@@ -90,7 +90,6 @@ class StringInterpolatorOpt extends MiniPhase {
           else { // tree.symbol == defn.StringContextS
             import dotty.tools.dotc.util.SourcePosition
             var stringPosition: SourcePosition = null
-            var offset: Int = 0
             try {
               val escapedStrs = strs.map(str => {
                 stringPosition = str.sourcePos

--- a/compiler/test/dotty/tools/dotc/parsing/StringInterpolationPositionTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/StringInterpolationPositionTest.scala
@@ -1,0 +1,43 @@
+package dotty.tools
+package dotc
+package parsing
+
+import ast.untpd._
+import org.junit.Test
+
+class StringInterpolationPositionTest extends ParserTest {
+
+  val tq = "\"\"\""
+  val program = s"""
+    |class A {
+    |  val expr = 42
+    |  val s0 = s"string1"
+    |  val s1 = s"string1$${expr}string2"
+    |  val s2 = s"string1$${expr}string2$${expr}string3"
+    |  val s0m = s${tq}string1${tq}
+    |  val s1m = s${tq}string1$${expr}string2${tq}
+    |  val s2m = s${tq}string1$${expr}string2$${expr}string3${tq}
+    |}""".stripMargin
+
+  @Test
+  def interpolationLiteralPosition: Unit = {
+    val t = parseText(program)
+    t match {
+      case PackageDef(_, List(TypeDef(_, Template(_, _, _, statements: List[Tree])))) => {
+        val interpolations = statements.collect{ case ValDef(_, _, InterpolatedString(_, int)) => int }
+        val lits = interpolations.flatten.flatMap {
+          case l @ Literal(_) => List(l)
+          case Thicket(trees) => trees.collect { case l @ Literal(_) => l }
+        }
+        for {
+          lit <- lits
+          Literal(c) = lit
+          str <- List(c.value).collect { case str: String => str}
+        } {
+          val fromPos = program.substring(lit.span.start, lit.span.end)
+          assert(fromPos == str, s"$fromPos == $str")
+        }
+      }
+    }
+  }
+}

--- a/tests/neg/firstError.scala
+++ b/tests/neg/firstError.scala
@@ -1,4 +1,1 @@
 . // error: expected class or object definition
-
-\u890u3084eu // error: error in unicode escape // error: illegal character '\uffff'
-

--- a/tests/neg/unicodeEscapes-interpolations.check
+++ b/tests/neg/unicodeEscapes-interpolations.check
@@ -1,0 +1,48 @@
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:2:27 -----------------------------------------------------------
+2 |  val badInters1 = s"foo \unope that's wrong" // error
+  |                           ^
+  |                           invalid unicode escape at index 6 of foo \unope that's wrong
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:3:32 -----------------------------------------------------------
+3 |  val badIntersEnd1 = s"foo \u12" // error
+  |                                ^
+  |                                invalid unicode escape at index 8 of foo \u12
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:4:29 -----------------------------------------------------------
+4 |  val badInters3 = s"""foo \unope that's wrong""" // error
+  |                             ^
+  |                             invalid unicode escape at index 6 of foo \unope that's wrong
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:5:28 -----------------------------------------------------------
+5 |  val caretPos1 = s"foo \u12x3 pos @ x" // error
+  |                            ^
+  |                            invalid unicode escape at index 8 of foo \u12x3 pos @ x
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:6:34 -----------------------------------------------------------
+6 |  val caretPos2 = s"foo \uuuuuuu12x3 pos @ x" // error
+  |                                  ^
+  |                                  invalid unicode escape at index 14 of foo \uuuuuuu12x3 pos @ x
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:7:30 -----------------------------------------------------------
+7 |  val caretPos3 = s"""foo \u12x3 pos @ x""" // error
+  |                              ^
+  |                              invalid unicode escape at index 8 of foo \u12x3 pos @ x
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:8:36 -----------------------------------------------------------
+8 |  val caretPos4 = s"""foo \uuuuuuu12x3 pos @ x""" // error
+  |                                    ^
+  |                                    invalid unicode escape at index 14 of foo \uuuuuuu12x3 pos @ x
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:10:53 ----------------------------------------------------------
+10 |  val badIntersmultiAfter = s"foo $placeholder bar \unope that's wrong" // error
+   |                                                     ^
+   |                                                   invalid unicode escape at index 7 of  bar \unope that's wrong
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:11:37 ----------------------------------------------------------
+11 |  val badIntersmultiBefore = s"foo \unope $placeholder that's wrong" // error
+   |                                     ^
+   |                                     invalid unicode escape at index 6 of foo \unope 
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:12:56 ----------------------------------------------------------
+12 |  val badInterstmultiAfter = s"""foo $placeholder bar \unope that's wrong""" // error
+   |                                                        ^
+   |                                                   invalid unicode escape at index 7 of  bar \unope that's wrong
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:13:40 ----------------------------------------------------------
+13 |  val badInterstmultiBefore = s"""foo \unope $placeholder that's wrong""" // error
+   |                                        ^
+   |                                        invalid unicode escape at index 6 of foo \unope 
+-- Error: tests/neg/unicodeEscapes-interpolations.scala:14:29 ----------------------------------------------------------
+14 |  val badInterother = s"this \p ain't legal either" // error
+   |                             ^
+   |invalid escape '\p' not one of [\b, \t, \n, \f, \r, \\, \", \', \uxxxx] at index 5 in "this \p ain't legal either". Use \\ for literal \.

--- a/tests/neg/unicodeEscapes-interpolations.scala
+++ b/tests/neg/unicodeEscapes-interpolations.scala
@@ -1,0 +1,15 @@
+object Example {
+  val badInters1 = s"foo \unope that's wrong" // error
+  val badIntersEnd1 = s"foo \u12" // error
+  val badInters3 = s"""foo \unope that's wrong""" // error
+  val caretPos1 = s"foo \u12x3 pos @ x" // error
+  val caretPos2 = s"foo \uuuuuuu12x3 pos @ x" // error
+  val caretPos3 = s"""foo \u12x3 pos @ x""" // error
+  val caretPos4 = s"""foo \uuuuuuu12x3 pos @ x""" // error
+  val placeholder = "place"
+  val badIntersmultiAfter = s"foo $placeholder bar \unope that's wrong" // error
+  val badIntersmultiBefore = s"foo \unope $placeholder that's wrong" // error
+  val badInterstmultiAfter = s"""foo $placeholder bar \unope that's wrong""" // error
+  val badInterstmultiBefore = s"""foo \unope $placeholder that's wrong""" // error
+  val badInterother = s"this \p ain't legal either" // error
+}

--- a/tests/neg/unicodeEscapes.check
+++ b/tests/neg/unicodeEscapes.check
@@ -1,0 +1,28 @@
+-- Error: tests/neg/unicodeEscapes.scala:3:25 --------------------------------------------------------------------------
+3 |  val badsingle = "foo \unope that's wrong" // error
+  |                         ^
+  |                         invalid character in unicode escape sequence
+-- Error: tests/neg/unicodeEscapes.scala:4:26 --------------------------------------------------------------------------
+4 |  val caretPos = "foo \u12x3 pos @ x" // error
+  |                          ^
+  |                          invalid character in unicode escape sequence
+-- Error: tests/neg/unicodeEscapes.scala:5:33 --------------------------------------------------------------------------
+5 |  val caretPos2 = "foo \uuuuuuu12x3 pos @ x" // error
+  |                                 ^
+  |                                 invalid character in unicode escape sequence
+-- Error: tests/neg/unicodeEscapes.scala:6:29 --------------------------------------------------------------------------
+6 |  val carPosTerm = "foo \u123" // error
+  |                             ^
+  |                             invalid character in unicode escape sequence
+-- Error: tests/neg/unicodeEscapes.scala:7:30 --------------------------------------------------------------------------
+7 |  val halfAnEscape = "foo \u12" // error
+  |                              ^
+  |                              invalid character in unicode escape sequence
+-- Error: tests/neg/unicodeEscapes.scala:8:30 --------------------------------------------------------------------------
+8 |  val halfAnEscapeChar = '\u45' // error
+  |                              ^
+  |                              invalid character in unicode escape sequence
+-- Error: tests/neg/unicodeEscapes.scala:9:29 --------------------------------------------------------------------------
+9 |  val `half An Identifier\u45` = "nope" // error
+  |                             ^
+  |                             invalid character in unicode escape sequence

--- a/tests/neg/unicodeEscapes.scala
+++ b/tests/neg/unicodeEscapes.scala
@@ -1,0 +1,10 @@
+
+object Example {
+  val badsingle = "foo \unope that's wrong" // error
+  val caretPos = "foo \u12x3 pos @ x" // error
+  val caretPos2 = "foo \uuuuuuu12x3 pos @ x" // error
+  val carPosTerm = "foo \u123" // error
+  val halfAnEscape = "foo \u12" // error
+  val halfAnEscapeChar = '\u45' // error
+  val `half An Identifier\u45` = "nope" // error
+}

--- a/tests/run/t3220-3.check
+++ b/tests/run/t3220-3.check
@@ -1,0 +1,9 @@
+processed...OK
+unprocessed...OK
+after backslashes
+List(\, \, u, 0, 0, 4, 0)
+List(\, u, 0, 0, 4, 0)
+List(\, \, u, 0, 0, 4, 0)
+List(\, u, 0, 0, 4, 0)
+List(", (, [, ^, ", \, x, 0, 0, -, \, x, 1, F, \, x, 7, F, \, \, ], |, \, \, [, \, \, ', ", b, f, n, r, t, ], |, \, \, u, [, a, -, f, A, -, F, 0, -, 9, ], {, 4, }, ), *, ")
+List(b, a, d, \)

--- a/tests/run/t3220-3.scala
+++ b/tests/run/t3220-3.scala
@@ -1,0 +1,85 @@
+object Literals {
+  //unicode escapes don't get expanded in comments
+  def comment = "comment" //\u000A is the bomb
+  //unicode escapes work in string
+  def inString = "\u000A"
+  def inTripleQuoted = """\u000A"""
+  def inRawInterpolation = raw"\u000A"
+  def inRawTripleQuoted = raw"""\u000A"""
+  def inChar = '\u000A'
+  def `in backtick quoted\u0020identifier` = "bueno"
+  //unicode escapes preceded by an odd number of backslash characters
+  //are not processed iff the backslashes themselves are escaped
+  def after2slashestriple = """\\u0040"""
+  def after2slashesplain = "\\u0040"
+  def after2slashesraw = raw"\\u0040"
+  def after2slashess = s"\\u0040"
+  def firstFailure = ("\""+"""([^"\x00-\x1F\x7F\\]|\\[\\'"bfnrt]|\\u[a-fA-F0-9]{4})*"""+"\"")
+  def badString = """bad\"""
+  def escapedQuotesInInterpolation = s"\u0022_\u0022"
+  def escapedQuotesInSingleQuotedString = "\u0022"
+  def escapedQuotesInCharLit = '\u0027'
+
+
+  def processed = List(
+    "literal tab in single quoted string" -> "tab	tab",
+    "tab escape char in single quoted string" -> "tab\ttab",
+    "tab unicode escape in single quoted string" -> "tab\u0009tab",
+    "literal tab in triple quoted string" -> """tab	tab""",
+    "literal tab in triple quoted raw interpolator" -> raw"""tab	tab""",
+    "literal tab in single quoted raw interpolator" -> raw"tab	tab",
+    "literal tab in triple quoted s interpolator" -> s"""tab	tab""",
+    "literal tab in single quoted s interpolator" -> s"tab	tab",
+    "tab escape char in triple quoted s interpolator" -> s"""tab\ttab""",
+    "tab escape char in single quoted s interpolator" -> s"""tab\ttab""",
+    "tab unicode escape in triple quoted s interpolator" -> s"""tab\u0009tab""",
+    "tab unicode escape in single quoted s interpolator" -> s"tab\u0009tab"
+  )
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val bueono = Literals.`in backtick quoted identifier`
+
+    def printways(ways: List[(String, String)]) =
+      ways.map(_._1).sorted.mkString(", ")
+
+    def printSegment(l: List[(String, String)]) =
+      l.groupBy(_._2).toList.foreach{
+       case (result, ways) => {
+         println(s"literals that result in $result:")
+         ways.foreach{case (x, _) => println(x)}
+         println()
+       }
+     }
+
+    print("processed...")
+
+    for {
+      case (description, format) <- Literals.processed
+    } {
+      assert(format == "tab\ttab", description)
+    }
+    println("OK")
+
+    print("unprocessed...")
+    assert("""t\tt""".toList == List('t', '\\', 't', 't'), "tab escape char in triple quoted string")
+    assert("""tab\ttab""" == raw"tab\ttab", "tab escape char in raw interpolator")
+    assert("""tab\ttab""" == raw"""tab\ttab""", "tab escape char in raw triple quoted interpolator")
+    println("OK")
+
+    println("after backslashes")
+    println(Literals.after2slashestriple.toList)
+    println(Literals.after2slashesplain.toList)
+    println(Literals.after2slashesraw.toList)
+    println(Literals.after2slashess.toList)
+    println(Literals.firstFailure.toList)
+    println(Literals.badString.toList)
+
+    val asList = List('\\', 'u', '0', '0', '0', 'A')
+    assert(asList == Literals.inTripleQuoted.toList)
+    assert(asList == Literals.inRawInterpolation.toList)
+    assert(asList == Literals.inRawTripleQuoted.toList)
+
+  }
+}

--- a/tests/run/t3835.scala
+++ b/tests/run/t3835.scala
@@ -2,8 +2,8 @@ object Test extends App {
   // work around optimizer bug SI-5672  -- generates wrong bytecode for switches in arguments
   // virtpatmat happily emits a switch for a one-case switch
   // this is not the focus of this test, hence the temporary workaround
-  def a = (1, 2, 3) match { case (r, \u03b8, \u03c6) => r + \u03b8 + \u03c6 }
+  def a = (1, 2, 3) match { case (r, θ, φ) => r + θ + φ }
   println(a)
-  def b = (1 match { case \u00e9 => \u00e9 })
+  def b = (1 match { case é => é })
   println(b)
 }

--- a/tests/run/t8015-ffc.scala
+++ b/tests/run/t8015-ffc.scala
@@ -1,6 +1,6 @@
 
 object Test extends App {
-  val ms = """This is a long multiline string
+  val ms = s"""This is a long multiline interpolation
   with \u000d\u000a CRLF embedded."""
   assert(ms.linesIterator.size == 3, s"lines.size ${ms.linesIterator.size}")
   assert(ms contains "\r\n CRLF", "no CRLF")

--- a/tests/run/unicodeEscapes.check
+++ b/tests/run/unicodeEscapes.check
@@ -1,0 +1,10 @@
+chars...OK
+char delim...OK
+string...OK
+string delim...OK
+back-quoted identifier...OK
+triple quoted string...OK
+single quoted s interpolation...OK
+triple quoted s interpolation...OK
+single quoted raw interpolation...OK
+triple quoted raw interpolation...OK

--- a/tests/run/unicodeEscapes.scala
+++ b/tests/run/unicodeEscapes.scala
@@ -1,0 +1,25 @@
+object Test {
+  def test(prelude: String, assertion: => Boolean): Unit = {
+    print(s"$prelude...")
+    assert(assertion)
+    print("OK")
+    print("\n")
+  }
+  def main(args: Array[String]): Unit = {
+    test("chars", 'a' == '\u0061')
+    test("char delim", '\'' == '\u0027')
+    test("string", "abcd" == "\u0061b\u0063d")
+    test("string delim", "\"" == "\u0022")
+    val `id\u0061` = 17
+    test("back-quoted identifier", ida == 17)
+    val abcescape = List('\\', 'u', '0', '0', '6', '1', 'b', 'c')
+    test("""triple quoted string""", """\u0061bc""".toList == abcescape)
+    val b = 'b'
+    test("single quoted s interpolation", "abc" == s"\u0061${b}c")
+    test("triple quoted s interpolation", "abc" == s"""\u0061${b}c""")
+    //test("f interpolation", "abc" == f"\u0061${b}c")
+    //raw is *NOT* processed (as it shouldn't be)
+    test("single quoted raw interpolation", raw"\u0061${b}c".toList == abcescape)
+    test("triple quoted raw interpolation", raw"""\u0061${b}c""".toList == abcescape)
+  }
+}


### PR DESCRIPTION
port of https://github.com/scala/scala/pull/8282

s/replaceAllLiterally/replace because it's deprecated in scala2

The implementation is a bit simpler overall because it no longer needs to allow unicode escapes in triple quoted strings and raw escapes that scala2 needed to be grandfathered in for a deprecation cycle.

