### PR TITLE
Make sure that QuoteContext are stable

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -46,8 +46,12 @@ trait QuotesAndSplices {
       case _ =>
     }
     val qctx = inferImplicitArg(defn.QuoteContextClass.typeRef, tree.span)
-    if (level == 0 && qctx.tpe.isInstanceOf[SearchFailureType])
+
+    if qctx.tpe.isInstanceOf[SearchFailureType] then
       ctx.error(missingArgMsg(qctx, defn.QuoteContextClass.typeRef, ""), ctx.source.atSpan(tree.span))
+    else if !qctx.tpe.isStable then
+      ctx.error(em"Quotes require stable QuoteContext, but found non stable $qctx", qctx.sourcePos)
+
     val tree1 =
       if ctx.mode.is(Mode.Pattern) && level == 0 then
         typedQuotePattern(tree, pt, qctx)

--- a/tests/neg-macros/quote-this.scala
+++ b/tests/neg-macros/quote-this.scala
@@ -12,12 +12,14 @@ class Foo {
   }
 
   inline def i(): Unit = ${ Foo.impl[Any]('{
-    given QuoteContext = ???
+    val x: QuoteContext = ???
+    given x.type = x
     'this // error
   }) }
 
   inline def j(that: Foo): Unit = ${ Foo.impl[Any]('{
-     given QuoteContext = ???
+    val x: QuoteContext = ???
+    given x.type = x
     'that // error
   }) }
 

--- a/tests/neg/i4044a.scala
+++ b/tests/neg/i4044a.scala
@@ -4,11 +4,16 @@ def test(using QuoteContext) = {
 
   val a = '{1}
   '{
-    given QuoteContext = ???
+    val qctx: QuoteContext = ???
+    given qctx.type = qctx
     a // error
     $a
     '{$a} // error
-    '{ given QuoteContext = ???; '{$a} } // error
+    '{
+      val qctx: QuoteContext = ???
+      given qctx.type = qctx
+      '{$a} // error
+    }
   }
 
 }

--- a/tests/neg/i4044b.scala
+++ b/tests/neg/i4044b.scala
@@ -3,17 +3,23 @@ import scala.quoted._
 def test(using QuoteContext) = {
 
   '{
-    given QuoteContext = ???
+    val qctx: QuoteContext = ???
+    given qctx.type = qctx
 
     val b = '{3}
 
     '{
-      given QuoteContext = ???
+      val qctx: QuoteContext = ???
+      given qctx.type = qctx
 
       b // error
       ${b}
       ${ '{b} } // error
-      '{ given QuoteContext = ???; '{$b} } // error
+      '{
+        val qctx: QuoteContext = ???
+        given qctx.type = qctx
+        '{$b} // error
+      }
     }
 
   }

--- a/tests/neg/i7052b.scala
+++ b/tests/neg/i7052b.scala
@@ -1,7 +1,8 @@
 import scala.quoted._
 class Test {
   def foo(str: String)(using QuoteContext) = '{
-    given QuoteContext = ???
+    val qctx: QuoteContext = ???
+    given qctx.type = qctx
     '{
       @deprecated(str, "") // error
       def bar = ???

--- a/tests/neg/quote-0.scala
+++ b/tests/neg/quote-0.scala
@@ -5,7 +5,8 @@ def test(using QuoteContext) = {
   val x: Int = 0
 
   '{
-    given QuoteContext = ???
+    val qctx: QuoteContext = ???
+    given qctx.type = qctx
 
     '{x + 1}  // error: wrong staging level
 

--- a/tests/pos/i4380b.scala
+++ b/tests/pos/i4380b.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 
-object Test {
-  given QuoteContext = ???
+class Test(using qctx: QuoteContext) {
   def step(k: (String => Expr[Unit])): Expr[Unit] = '{}
   def meth(): Unit = '{
     (i: Int) => ${ step(el => '{} ) }

--- a/tests/pos/quote-1.scala
+++ b/tests/pos/quote-1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 
-object Test {
-  given QuoteContext = ???
+class Test(using QuoteContext) {
 
   def f[T](x: Expr[T])(implicit t: Type[T]) = '{
     val y: $t = $x

--- a/tests/pos/quote-lift.scala
+++ b/tests/pos/quote-lift.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
 
-object Test {
-  given QuoteContext = ???
+class Test(using QuoteContext) {
 
   '{ ${implicitly[Liftable[Int]].toExpr(1)} }
 

--- a/tests/pos/quoted-inline-quote.scala
+++ b/tests/pos/quoted-inline-quote.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
-class Foo {
+class Foo(using QuoteContext) {
   inline def foo(x: Expr[String])(using QuoteContext) = '{ println(${x}) }
 
-  given QuoteContext = ???
   foo('{"abc"})
 }


### PR DESCRIPTION
In the internal encoding of the splices we assume that these are stable and use them for some path-dependent types.  If they are not stable, some of the internal inferred types become less precise.