### PR TITLE
 Fix #8464: Refine recursion limits for printing

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -974,7 +974,7 @@ class DottyBackendInterface(outputDirectory: AbstractFile, val superCallsMap: Ma
       }
     }
 
-    def summaryString: String = tp.showSummary
+    def summaryString: String = tp.showSummary()
 
     def params: List[Symbol] =
       Nil // backend uses this to emit annotations on parameter lists of forwarders

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -636,7 +636,7 @@ object Contexts {
     owner = NoSymbol
     tree = untpd.EmptyTree
     typeAssigner = TypeAssigner
-    moreProperties = Map.empty
+    moreProperties = Map(MessageLimiter -> DefaultMessageLimiter())
     source = NoSource
     store = initialStore
       .updated(settingsStateLoc, settingsGroup.defaultState)
@@ -771,10 +771,6 @@ object Contexts {
     private[core] var nextDenotTransformerId: Array[Int] = _
 
     private[core] var denotTransformers: Array[DenotTransformer] = _
-
-    // Printers state
-    /** Number of recursive invocations of a show method on current stack */
-    private[dotc] var toTextRecursions: Int = 0
 
     // Reporters state
     private[dotc] var indent: Int = 0

--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -58,8 +58,8 @@ object Mode {
   /** Assume -language:strictEquality */
   val StrictEquality: Mode = newMode(9, "StrictEquality")
 
-  /** We are currently printing something: avoid to produce more logs about
-   *  the printing
+  /** We are currently printing something: avoid producing more logs about
+   *  the printing.
    */
   val Printing: Mode = newMode(10, "Printing")
 

--- a/compiler/src/dotty/tools/dotc/printing/MessageLimiter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/MessageLimiter.scala
@@ -1,0 +1,55 @@
+package dotty.tools
+package dotc
+package printing
+
+import core._
+import Contexts.Context
+import util.Property
+import Texts.Text
+
+abstract class MessageLimiter:
+
+  protected def recurseLimit = 100
+  protected var recurseCount: Int = 0
+
+  def register(str: String): Unit = ()
+
+  protected def recursionLimitExceeded()(using Context): Unit = ()
+
+  final def controlled(op: => Text)(using Context): Text =
+    if recurseCount < recurseLimit then
+      try
+        recurseCount += 1
+        op
+      finally
+        recurseCount -= 1
+    else
+      recursionLimitExceeded()
+      "..."
+
+object MessageLimiter extends Property.Key[MessageLimiter]
+
+class DefaultMessageLimiter extends MessageLimiter:
+  override def recursionLimitExceeded()(using ctx: Context): Unit =
+    if ctx.debug then
+      ctx.warning("Exceeded recursion depth attempting to print.")
+      Thread.dumpStack()
+
+class SummarizeMessageLimiter(depth: Int) extends MessageLimiter:
+  override val recurseLimit = recurseCount + depth
+  override def recursionLimitExceeded()(using ctx: Context): Unit = ()
+
+class ErrorMessageLimiter extends MessageLimiter:
+  private val initialRecurseLimit = 50
+  private val sizeLimit = 10000
+
+  private var textLength: Int = 0
+
+  override def register(str: String): Unit =
+    textLength += str.length
+
+  override def recurseLimit =
+    val freeFraction: Double = ((sizeLimit - textLength) max 0).toDouble / sizeLimit
+    (initialRecurseLimit * freeFraction).toInt
+
+

--- a/compiler/src/dotty/tools/dotc/printing/Printer.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Printer.scala
@@ -167,11 +167,6 @@ abstract class Printer {
   def toTextGlobal(elems: Traversable[Showable], sep: String): Text =
     atPrec(GlobalPrec) { toText(elems, sep) }
 
-  /** Perform string or text-producing operation `op` so that only a
-   *  summarized text with given recursion depth is shown
-   */
-  def summarized[T](depth: Int)(op: => T): T
-
   /** A plain printer without any embellishments */
   def plain: Printer
 }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -67,8 +67,6 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     case _ => false
   }
 
-  override protected def recursionLimitExceeded(): Unit = {}
-
   protected def PrintableFlags(isType: Boolean): FlagSet = {
     val fs =
       if (isType) TypeSourceModifierFlags | Module | Local  // DOTTY problem: cannot merge these two statements
@@ -467,7 +465,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           !homogenizedView && ctx.settings.XprintInline.value) ~
         blockText(bindings :+ body)
       case tpt: untpd.DerivedTypeTree =>
-        "<derived typetree watching " ~ summarized(toText(tpt.watched)) ~ ">"
+        "<derived typetree watching " ~ tpt.watched.showSummary() ~ ">"
       case TypeTree() =>
         typeText(toText(tree.typeOpt))
       case SingletonTypeTree(ref) =>

--- a/compiler/src/dotty/tools/dotc/printing/Showable.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Showable.scala
@@ -26,8 +26,6 @@ trait Showable extends Any {
    *  Recursion depth is limited to some smallish value. Default is
    *  Config.summarizeDepth.
    */
-  def showSummary(depth: Int)(implicit ctx: Context): String =
-    ctx.printer.summarized(depth)(show)
-
-  def showSummary(implicit ctx: Context): String = showSummary(summarizeDepth)
+  def showSummary(depth: Int = summarizeDepth)(using ctx: Context): String =
+    show(using ctx.fresh.setProperty(MessageLimiter, SummarizeMessageLimiter(depth)))
 }

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -120,6 +120,7 @@ class CompilationTests extends ParallelTesting {
       compileFilesInDir("tests/neg-custom-args/fatal-warnings", defaultOptions.and("-Xfatal-warnings")),
       compileFilesInDir("tests/neg-custom-args/erased", defaultOptions.and("-Yerased-terms")),
       compileFilesInDir("tests/neg-custom-args/allow-double-bindings", allowDoubleBindings),
+      compileFilesInDir("tests/neg-custom-args/allow-deep-subtypes", allowDeepSubtypes),
       compileFilesInDir("tests/neg-custom-args/explicit-nulls", defaultOptions.and("-Yexplicit-nulls")),
       compileDir("tests/neg-custom-args/impl-conv", defaultOptions.and("-Xfatal-warnings", "-feature")),
       compileFile("tests/neg-custom-args/implicit-conversions.scala", defaultOptions.and("-Xfatal-warnings", "-feature")),

--- a/tests/neg-custom-args/allow-deep-subtypes/i8464a.scala
+++ b/tests/neg-custom-args/allow-deep-subtypes/i8464a.scala
@@ -1,0 +1,19 @@
+type Id = String
+
+enum Kind {
+    case Type
+  }
+
+  enum Term[T <: Term[T, K], K] {
+    case Wrap(t: T)
+    case Fun(id: Id, tag: K, ret: Term[T, K])
+  }
+
+  enum Type {
+    case Var(id: Id)
+  }
+
+  val tExp: Term[Type, Kind] =
+    Term.Fun("x", Kind.Type, Term.Wrap(Type.Var("x")))  // error
+
+  def main(args: Array[String]): Unit = { }

--- a/tests/neg/i8464.scala
+++ b/tests/neg/i8464.scala
@@ -1,0 +1,11 @@
+enum Term[T <: Term[T]] {
+    case Wrap(t: T)
+    case Fun(id: Id, tag: K, ret: Term[T])  // error // error
+  }
+
+  enum Type {
+    case Var(id: Id)  // error
+  }
+
+  val tExp: Term[Type, Kind] =  // error
+    Term.Fun("x", Term.Wrap(Type.Var("x"))) // error


### PR DESCRIPTION
1. Refactor Printers to use explicit MessageLimiters for
   controlling recursion.

2. Have a message limiter for error messages that reduces
   allowed recursion depth in proportion to size of text
   generated so far.