### PR TITLE
Rename ValueOfExpr to Unliftable

### DIFF
--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -16,15 +16,15 @@ class Expr[+T] private[scala] {
    *  Returns `None` if the expression does not contain a value or contains side effects.
    *  Otherwise returns the `Some` of the value.
    */
-  final def getValue[U >: T](using qctx: QuoteContext, valueOf: ValueOfExpr[U]): Option[U] = valueOf(this)
+  final def getValue[U >: T](using qctx: QuoteContext, unlift: Unliftable[U]): Option[U] = unlift(this)
 
   /** Return the value of this expression.
    *
    *  Emits an error error and throws if the expression does not contain a value or contains side effects.
    *  Otherwise returns the value.
    */
-  final def value[U >: T](using qctx: QuoteContext, valueOf: ValueOfExpr[U]): U =
-    valueOf(this).getOrElse(qctx.throwError(s"Expected a known value. \n\nThe value of: $show\ncould not be recovered using $valueOf", this))
+  final def value[U >: T](using qctx: QuoteContext, unlift: Unliftable[U]): U =
+    unlift(this).getOrElse(qctx.throwError(s"Expected a known value. \n\nThe value of: $show\ncould not be recovered using $unlift", this))
 
   /** Pattern matches `this` against `that`. Effectively performing a deep equality check.
    *  It does the equivalent of

--- a/library/src/scala/quoted/Unliftable.scala
+++ b/library/src/scala/quoted/Unliftable.scala
@@ -1,7 +1,7 @@
 package scala.quoted
 
 /** A typeclass for types that can be turned from a `quoted.Expr[T]` to a `T` */
-trait ValueOfExpr[T] {
+trait Unliftable[T] {
 
   /** Return the value of the expression.
    *
@@ -12,270 +12,270 @@ trait ValueOfExpr[T] {
 
 }
 
-object ValueOfExpr {
+object Unliftable {
 
-  given ValueOfExpr_Unit_delegate as ValueOfExpr[Unit] = new PrimitiveValueOfExpr
-  given ValueOfExpr_Boolean_delegate as ValueOfExpr[Boolean] = new PrimitiveValueOfExpr
-  given ValueOfExpr_Byte_delegate as ValueOfExpr[Byte] = new PrimitiveValueOfExpr
-  given ValueOfExpr_Short_delegate as ValueOfExpr[Short] = new PrimitiveValueOfExpr
-  given ValueOfExpr_Int_delegate as ValueOfExpr[Int] = new PrimitiveValueOfExpr
-  given ValueOfExpr_Long_delegate as ValueOfExpr[Long] = new PrimitiveValueOfExpr
-  given ValueOfExpr_Float_delegate as ValueOfExpr[Float] = new PrimitiveValueOfExpr
-  given ValueOfExpr_Double_delegate as ValueOfExpr[Double] = new PrimitiveValueOfExpr
-  given ValueOfExpr_Char_delegate as ValueOfExpr[Char] = new PrimitiveValueOfExpr
-  given ValueOfExpr_String_delegate as ValueOfExpr[String] = new PrimitiveValueOfExpr
+  given Unliftable_Unit_delegate as Unliftable[Unit] = new PrimitiveUnliftable
+  given Unliftable_Boolean_delegate as Unliftable[Boolean] = new PrimitiveUnliftable
+  given Unliftable_Byte_delegate as Unliftable[Byte] = new PrimitiveUnliftable
+  given Unliftable_Short_delegate as Unliftable[Short] = new PrimitiveUnliftable
+  given Unliftable_Int_delegate as Unliftable[Int] = new PrimitiveUnliftable
+  given Unliftable_Long_delegate as Unliftable[Long] = new PrimitiveUnliftable
+  given Unliftable_Float_delegate as Unliftable[Float] = new PrimitiveUnliftable
+  given Unliftable_Double_delegate as Unliftable[Double] = new PrimitiveUnliftable
+  given Unliftable_Char_delegate as Unliftable[Char] = new PrimitiveUnliftable
+  given Unliftable_String_delegate as Unliftable[String] = new PrimitiveUnliftable
 
-  private class PrimitiveValueOfExpr[T <: Unit | Null | Int | Boolean | Byte | Short | Int | Long | Float | Double | Char | String] extends ValueOfExpr[T] {
+  private class PrimitiveUnliftable[T <: Unit | Null | Int | Boolean | Byte | Short | Int | Long | Float | Double | Char | String] extends Unliftable[T] {
     /** Lift a quoted primitive value `'{ n }` into `n` */
     def apply(x: Expr[T])(using qctx: QuoteContext): Option[T] = Const.unapply(x)
   }
 
-  given Option_delegate[T](using Type[T], ValueOfExpr[T]) as ValueOfExpr[Option[T]] = new {
+  given Option_delegate[T](using Type[T], Unliftable[T]) as Unliftable[Option[T]] = new {
     def apply(x: Expr[Option[T]])(using qctx: QuoteContext): Option[Option[T]] = x match {
       case '{ None: Option[T] } => Some(None) // FIXME: remove ascription, Matcher should be able to match this expression
       case '{ new Some[T](${Value(y)}) } => Some(Some(y))
       case '{     Some[T](${Value(y)}) } => Some(Some(y))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Option_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Option_delegate"
   }
 
-  given StringContext_delegate as ValueOfExpr[StringContext] = new {
+  given StringContext_delegate as Unliftable[StringContext] = new {
     def apply(x: Expr[StringContext])(using qctx: QuoteContext): Option[StringContext] = x match {
       case '{ new StringContext(${Varargs(Consts(args))}: _*) } => Some(StringContext(args: _*))
       case '{     StringContext(${Varargs(Consts(args))}: _*) } => Some(StringContext(args: _*))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple1_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple1_delegate"
   }
 
 
-  given Tuple1_delegate[T1](using Type[T1], ValueOfExpr[T1]) as ValueOfExpr[Tuple1[T1]] = new {
+  given Tuple1_delegate[T1](using Type[T1], Unliftable[T1]) as Unliftable[Tuple1[T1]] = new {
     def apply(x: Expr[Tuple1[T1]])(using qctx: QuoteContext): Option[Tuple1[T1]] = x match {
       case '{ new Tuple1[T1](${Value(y)}) } => Some(Tuple1(y))
       case '{     Tuple1[T1](${Value(y)}) } => Some(Tuple1(y))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple1_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple1_delegate"
   }
 
-  given Tuple2_delegate[T1, T2](using Type[T1], Type[T2], ValueOfExpr[T1], ValueOfExpr[T2]) as ValueOfExpr[Tuple2[T1, T2]] = new {
+  given Tuple2_delegate[T1, T2](using Type[T1], Type[T2], Unliftable[T1], Unliftable[T2]) as Unliftable[Tuple2[T1, T2]] = new {
     def apply(x: Expr[Tuple2[T1, T2]])(using qctx: QuoteContext): Option[Tuple2[T1, T2]] = x match {
       case '{ new Tuple2[T1, T2](${Value(y1)}, ${Value(y2)}) } => Some(Tuple2(y1, y2))
       case '{     Tuple2[T1, T2](${Value(y1)}, ${Value(y2)}) } => Some(Tuple2(y1, y2))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple2_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple2_delegate"
   }
 
 
-  given Tuple3_delegate[T1, T2, T3](using Type[T1], Type[T2], Type[T3], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3]) as ValueOfExpr[Tuple3[T1, T2, T3]] = new {
+  given Tuple3_delegate[T1, T2, T3](using Type[T1], Type[T2], Type[T3], Unliftable[T1], Unliftable[T2], Unliftable[T3]) as Unliftable[Tuple3[T1, T2, T3]] = new {
     def apply(x: Expr[Tuple3[T1, T2, T3]])(using qctx: QuoteContext): Option[Tuple3[T1, T2, T3]] = x match {
       case '{ new Tuple3[T1, T2, T3](${Value(y1)}, ${Value(y2)}, ${Value(y3)}) } => Some(Tuple3(y1, y2, y3))
       case '{     Tuple3[T1, T2, T3](${Value(y1)}, ${Value(y2)}, ${Value(y3)}) } => Some(Tuple3(y1, y2, y3))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple3_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple3_delegate"
   }
 
 
-  given Tuple4_delegate[T1, T2, T3, T4](using Type[T1], Type[T2], Type[T3], Type[T4], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4]) as ValueOfExpr[Tuple4[T1, T2, T3, T4]] = new {
+  given Tuple4_delegate[T1, T2, T3, T4](using Type[T1], Type[T2], Type[T3], Type[T4], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4]) as Unliftable[Tuple4[T1, T2, T3, T4]] = new {
     def apply(x: Expr[Tuple4[T1, T2, T3, T4]])(using qctx: QuoteContext): Option[Tuple4[T1, T2, T3, T4]] = x match {
       case '{ new Tuple4[T1, T2, T3, T4](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}) } => Some(Tuple4(y1, y2, y3, y4))
       case '{     Tuple4[T1, T2, T3, T4](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}) } => Some(Tuple4(y1, y2, y3, y4))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple4_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple4_delegate"
   }
 
 
-  given Tuple5_delegate[T1, T2, T3, T4, T5](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5]) as ValueOfExpr[Tuple5[T1, T2, T3, T4, T5]] = new {
+  given Tuple5_delegate[T1, T2, T3, T4, T5](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5]) as Unliftable[Tuple5[T1, T2, T3, T4, T5]] = new {
     def apply(x: Expr[Tuple5[T1, T2, T3, T4, T5]])(using qctx: QuoteContext): Option[Tuple5[T1, T2, T3, T4, T5]] = x match {
       case '{ new Tuple5[T1, T2, T3, T4, T5](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}) } => Some(Tuple5(y1, y2, y3, y4, y5))
       case '{     Tuple5[T1, T2, T3, T4, T5](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}) } => Some(Tuple5(y1, y2, y3, y4, y5))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple5_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple5_delegate"
   }
 
 
-  given Tuple6_delegate[T1, T2, T3, T4, T5, T6](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6]) as ValueOfExpr[Tuple6[T1, T2, T3, T4, T5, T6]] = new {
+  given Tuple6_delegate[T1, T2, T3, T4, T5, T6](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6]) as Unliftable[Tuple6[T1, T2, T3, T4, T5, T6]] = new {
     def apply(x: Expr[Tuple6[T1, T2, T3, T4, T5, T6]])(using qctx: QuoteContext): Option[Tuple6[T1, T2, T3, T4, T5, T6]] = x match {
       case '{ new Tuple6[T1, T2, T3, T4, T5, T6](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}) } => Some(Tuple6(y1, y2, y3, y4, y5, y6))
       case '{     Tuple6[T1, T2, T3, T4, T5, T6](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}) } => Some(Tuple6(y1, y2, y3, y4, y5, y6))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple6_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple6_delegate"
   }
 
 
-  given Tuple7_delegate[T1, T2, T3, T4, T5, T6, T7](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7]) as ValueOfExpr[Tuple7[T1, T2, T3, T4, T5, T6, T7]] = new {
+  given Tuple7_delegate[T1, T2, T3, T4, T5, T6, T7](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7]) as Unliftable[Tuple7[T1, T2, T3, T4, T5, T6, T7]] = new {
     def apply(x: Expr[Tuple7[T1, T2, T3, T4, T5, T6, T7]])(using qctx: QuoteContext): Option[Tuple7[T1, T2, T3, T4, T5, T6, T7]] = x match {
       case '{ new Tuple7[T1, T2, T3, T4, T5, T6, T7](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}) } => Some(Tuple7(y1, y2, y3, y4, y5, y6, y7))
       case '{     Tuple7[T1, T2, T3, T4, T5, T6, T7](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}) } => Some(Tuple7(y1, y2, y3, y4, y5, y6, y7))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple7_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple7_delegate"
   }
 
 
-  given Tuple8_delegate[T1, T2, T3, T4, T5, T6, T7, T8](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8]) as ValueOfExpr[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]] = new {
+  given Tuple8_delegate[T1, T2, T3, T4, T5, T6, T7, T8](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8]) as Unliftable[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]] = new {
     def apply(x: Expr[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]])(using qctx: QuoteContext): Option[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]] = x match {
       case '{ new Tuple8[T1, T2, T3, T4, T5, T6, T7, T8](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}) } => Some(Tuple8(y1, y2, y3, y4, y5, y6, y7, y8))
       case '{     Tuple8[T1, T2, T3, T4, T5, T6, T7, T8](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}) } => Some(Tuple8(y1, y2, y3, y4, y5, y6, y7, y8))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple8_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple8_delegate"
   }
 
 
-  given Tuple9_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9]) as ValueOfExpr[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] = new {
+  given Tuple9_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9]) as Unliftable[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] = new {
     def apply(x: Expr[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]])(using qctx: QuoteContext): Option[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] = x match {
       case '{ new Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}) } => Some(Tuple9(y1, y2, y3, y4, y5, y6, y7, y8, y9))
       case '{     Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}) } => Some(Tuple9(y1, y2, y3, y4, y5, y6, y7, y8, y9))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple9_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple9_delegate"
   }
 
 
-  given Tuple10_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10]) as ValueOfExpr[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] = new {
+  given Tuple10_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10]) as Unliftable[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] = new {
     def apply(x: Expr[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]])(using qctx: QuoteContext): Option[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] = x match {
       case '{ new Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}) } => Some(Tuple10(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10))
       case '{     Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}) } => Some(Tuple10(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple10_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple10_delegate"
   }
 
 
-  given Tuple11_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11]) as ValueOfExpr[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] = new {
+  given Tuple11_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11]) as Unliftable[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] = new {
     def apply(x: Expr[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]])(using qctx: QuoteContext): Option[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] = x match {
       case '{ new Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}) } => Some(Tuple11(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11))
       case '{     Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}) } => Some(Tuple11(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple11_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple11_delegate"
   }
 
 
-  given Tuple12_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12]) as ValueOfExpr[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] = new {
+  given Tuple12_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12]) as Unliftable[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] = new {
     def apply(x: Expr[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]])(using qctx: QuoteContext): Option[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] = x match {
       case '{ new Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}) } => Some(Tuple12(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12))
       case '{     Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}) } => Some(Tuple12(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple12_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple12_delegate"
   }
 
 
-  given Tuple13_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12], ValueOfExpr[T13]) as ValueOfExpr[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] = new {
+  given Tuple13_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12], Unliftable[T13]) as Unliftable[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] = new {
     def apply(x: Expr[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]])(using qctx: QuoteContext): Option[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] = x match {
       case '{ new Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}) } => Some(Tuple13(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13))
       case '{     Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}) } => Some(Tuple13(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple13_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple13_delegate"
   }
 
 
-  given Tuple14_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12], ValueOfExpr[T13], ValueOfExpr[T14]) as ValueOfExpr[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] = new {
+  given Tuple14_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12], Unliftable[T13], Unliftable[T14]) as Unliftable[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] = new {
     def apply(x: Expr[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]])(using qctx: QuoteContext): Option[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] = x match {
       case '{ new Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}) } => Some(Tuple14(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14))
       case '{     Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}) } => Some(Tuple14(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple14_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple14_delegate"
   }
 
 
-  given Tuple15_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12], ValueOfExpr[T13], ValueOfExpr[T14], ValueOfExpr[T15]) as ValueOfExpr[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]] = new {
+  given Tuple15_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12], Unliftable[T13], Unliftable[T14], Unliftable[T15]) as Unliftable[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]] = new {
     def apply(x: Expr[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]])(using qctx: QuoteContext): Option[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]] = x match {
       case '{ new Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}) } => Some(Tuple15(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15))
       case '{     Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}) } => Some(Tuple15(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple15_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple15_delegate"
   }
 
 
-  given Tuple16_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12], ValueOfExpr[T13], ValueOfExpr[T14], ValueOfExpr[T15], ValueOfExpr[T16]) as ValueOfExpr[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]] = new {
+  given Tuple16_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12], Unliftable[T13], Unliftable[T14], Unliftable[T15], Unliftable[T16]) as Unliftable[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]] = new {
     def apply(x: Expr[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]])(using qctx: QuoteContext): Option[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]] = x match {
       case '{ new Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}) } => Some(Tuple16(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16))
       case '{     Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}) } => Some(Tuple16(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple16_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple16_delegate"
   }
 
 
-  given Tuple17_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12], ValueOfExpr[T13], ValueOfExpr[T14], ValueOfExpr[T15], ValueOfExpr[T16], ValueOfExpr[T17]) as ValueOfExpr[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]] = new {
+  given Tuple17_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12], Unliftable[T13], Unliftable[T14], Unliftable[T15], Unliftable[T16], Unliftable[T17]) as Unliftable[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]] = new {
     def apply(x: Expr[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]])(using qctx: QuoteContext): Option[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]] = x match {
       case '{ new Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}) } => Some(Tuple17(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17))
       case '{     Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}) } => Some(Tuple17(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple17_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple17_delegate"
   }
 
 
-  given Tuple18_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Type[T18], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12], ValueOfExpr[T13], ValueOfExpr[T14], ValueOfExpr[T15], ValueOfExpr[T16], ValueOfExpr[T17], ValueOfExpr[T18]) as ValueOfExpr[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]] = new {
+  given Tuple18_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Type[T18], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12], Unliftable[T13], Unliftable[T14], Unliftable[T15], Unliftable[T16], Unliftable[T17], Unliftable[T18]) as Unliftable[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]] = new {
     def apply(x: Expr[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]])(using qctx: QuoteContext): Option[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]] = x match {
       case '{ new Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}, ${Value(y18)}) } => Some(Tuple18(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17, y18))
       case '{     Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}, ${Value(y18)}) } => Some(Tuple18(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17, y18))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple18_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple18_delegate"
   }
 
 
-  given Tuple19_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Type[T18], Type[T19], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12], ValueOfExpr[T13], ValueOfExpr[T14], ValueOfExpr[T15], ValueOfExpr[T16], ValueOfExpr[T17], ValueOfExpr[T18], ValueOfExpr[T19]) as ValueOfExpr[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]] = new {
+  given Tuple19_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Type[T18], Type[T19], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12], Unliftable[T13], Unliftable[T14], Unliftable[T15], Unliftable[T16], Unliftable[T17], Unliftable[T18], Unliftable[T19]) as Unliftable[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]] = new {
     def apply(x: Expr[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]])(using qctx: QuoteContext): Option[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]] = x match {
       case '{ new Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}, ${Value(y18)}, ${Value(y19)}) } => Some(Tuple19(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17, y18, y19))
       case '{     Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}, ${Value(y18)}, ${Value(y19)}) } => Some(Tuple19(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17, y18, y19))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple19_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple19_delegate"
   }
 
 
-  given Tuple20_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Type[T18], Type[T19], Type[T20], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12], ValueOfExpr[T13], ValueOfExpr[T14], ValueOfExpr[T15], ValueOfExpr[T16], ValueOfExpr[T17], ValueOfExpr[T18], ValueOfExpr[T19], ValueOfExpr[T20]) as ValueOfExpr[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]] = new {
+  given Tuple20_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Type[T18], Type[T19], Type[T20], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12], Unliftable[T13], Unliftable[T14], Unliftable[T15], Unliftable[T16], Unliftable[T17], Unliftable[T18], Unliftable[T19], Unliftable[T20]) as Unliftable[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]] = new {
     def apply(x: Expr[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]])(using qctx: QuoteContext): Option[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]] = x match {
       case '{ new Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}, ${Value(y18)}, ${Value(y19)}, ${Value(y20)}) } => Some(Tuple20(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17, y18, y19, y20))
       case '{     Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}, ${Value(y18)}, ${Value(y19)}, ${Value(y20)}) } => Some(Tuple20(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17, y18, y19, y20))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple20_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple20_delegate"
   }
 
 
-  given Tuple21_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Type[T18], Type[T19], Type[T20], Type[T21], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12], ValueOfExpr[T13], ValueOfExpr[T14], ValueOfExpr[T15], ValueOfExpr[T16], ValueOfExpr[T17], ValueOfExpr[T18], ValueOfExpr[T19], ValueOfExpr[T20], ValueOfExpr[T21]) as ValueOfExpr[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]] = new {
+  given Tuple21_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Type[T18], Type[T19], Type[T20], Type[T21], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12], Unliftable[T13], Unliftable[T14], Unliftable[T15], Unliftable[T16], Unliftable[T17], Unliftable[T18], Unliftable[T19], Unliftable[T20], Unliftable[T21]) as Unliftable[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]] = new {
     def apply(x: Expr[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]])(using qctx: QuoteContext): Option[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]] = x match {
       case '{ new Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}, ${Value(y18)}, ${Value(y19)}, ${Value(y20)}, ${Value(y21)}) } => Some(Tuple21(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17, y18, y19, y20, y21))
       case '{     Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}, ${Value(y18)}, ${Value(y19)}, ${Value(y20)}, ${Value(y21)}) } => Some(Tuple21(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17, y18, y19, y20, y21))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple21_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple21_delegate"
   }
 
 
-  given Tuple22_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Type[T18], Type[T19], Type[T20], Type[T21], Type[T22], ValueOfExpr[T1], ValueOfExpr[T2], ValueOfExpr[T3], ValueOfExpr[T4], ValueOfExpr[T5], ValueOfExpr[T6], ValueOfExpr[T7], ValueOfExpr[T8], ValueOfExpr[T9], ValueOfExpr[T10], ValueOfExpr[T11], ValueOfExpr[T12], ValueOfExpr[T13], ValueOfExpr[T14], ValueOfExpr[T15], ValueOfExpr[T16], ValueOfExpr[T17], ValueOfExpr[T18], ValueOfExpr[T19], ValueOfExpr[T20], ValueOfExpr[T21], ValueOfExpr[T22]) as ValueOfExpr[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]] = new {
+  given Tuple22_delegate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](using Type[T1], Type[T2], Type[T3], Type[T4], Type[T5], Type[T6], Type[T7], Type[T8], Type[T9], Type[T10], Type[T11], Type[T12], Type[T13], Type[T14], Type[T15], Type[T16], Type[T17], Type[T18], Type[T19], Type[T20], Type[T21], Type[T22], Unliftable[T1], Unliftable[T2], Unliftable[T3], Unliftable[T4], Unliftable[T5], Unliftable[T6], Unliftable[T7], Unliftable[T8], Unliftable[T9], Unliftable[T10], Unliftable[T11], Unliftable[T12], Unliftable[T13], Unliftable[T14], Unliftable[T15], Unliftable[T16], Unliftable[T17], Unliftable[T18], Unliftable[T19], Unliftable[T20], Unliftable[T21], Unliftable[T22]) as Unliftable[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]] = new {
     def apply(x: Expr[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]])(using qctx: QuoteContext): Option[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]] = x match {
       case '{ new Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}, ${Value(y18)}, ${Value(y19)}, ${Value(y20)}, ${Value(y21)}, ${Value(y22)}) } => Some(Tuple22(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17, y18, y19, y20, y21, y22))
       case '{     Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](${Value(y1)}, ${Value(y2)}, ${Value(y3)}, ${Value(y4)}, ${Value(y5)}, ${Value(y6)}, ${Value(y7)}, ${Value(y8)}, ${Value(y9)}, ${Value(y10)}, ${Value(y11)}, ${Value(y12)}, ${Value(y13)}, ${Value(y14)}, ${Value(y15)}, ${Value(y16)}, ${Value(y17)}, ${Value(y18)}, ${Value(y19)}, ${Value(y20)}, ${Value(y21)}, ${Value(y22)}) } => Some(Tuple22(y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15, y16, y17, y18, y19, y20, y21, y22))
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Tuple22_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Tuple22_delegate"
   }
 
-  given Seq_delegate[T](using Type[T], ValueOfExpr[T]) as ValueOfExpr[Seq[T]] = new {
+  given Seq_delegate[T](using Type[T], Unliftable[T]) as Unliftable[Seq[T]] = new {
     def apply(x: Expr[Seq[T]])(using qctx: QuoteContext): Option[Seq[T]] = x match {
       case Varargs(Values(elems)) => Some(elems)
       case '{ scala.collection.Seq[T](${Varargs(Values(elems))}: _*) } => Some(elems)
       case '{ scala.collection.immutable.Seq[T](${Varargs(Values(elems))}: _*) } => Some(elems)
       case _ => None
     }
-    override def toString(): String = "scala.quoted.ValueOfExpr.Seq_delegate"
+    override def toString(): String = "scala.quoted.Unliftable.Seq_delegate"
   }
 
 }

--- a/library/src/scala/quoted/Value.scala
+++ b/library/src/scala/quoted/Value.scala
@@ -12,7 +12,7 @@ object Value {
    *  }
    *  ```
    */
-  def unapply[T](expr: Expr[T])(using valueOf: ValueOfExpr[T], qxtc: QuoteContext): Option[T] =
-    valueOf(expr)
+  def unapply[T](expr: Expr[T])(using unlift: Unliftable[T], qxtc: QuoteContext): Option[T] =
+    unlift(expr)
 
 }

--- a/library/src/scala/quoted/Values.scala
+++ b/library/src/scala/quoted/Values.scala
@@ -15,7 +15,7 @@ object Values {
    *  }
    *  ```
    */
-  def unapply[T](exprs: Seq[Expr[T]])(using valueOf: ValueOfExpr[T], qctx: QuoteContext): Option[Seq[T]] =
+  def unapply[T](exprs: Seq[Expr[T]])(using unlift: Unliftable[T], qctx: QuoteContext): Option[Seq[T]] =
     exprs.foldRight(Option(List.empty[T])) { (elem, acc) =>
       (elem, acc) match {
         case (Value(value), Some(lst)) => Some(value :: lst)

--- a/library/src/scala/quoted/matching/ValueSeq.scala
+++ b/library/src/scala/quoted/matching/ValueSeq.scala
@@ -17,7 +17,7 @@ object ValueSeq {
    *  ```
    */
   @deprecated("use scala.quoted.Varargs(scala.quoted.Value(_)) instead", "0.23.0")
-  def unapply[T](expr: Expr[Seq[T]])(using valueOf: ValueOfExpr[T], qctx: QuoteContext): Option[Seq[T]] =
+  def unapply[T](expr: Expr[Seq[T]])(using unlift: Unliftable[T], qctx: QuoteContext): Option[Seq[T]] =
     import scala.quoted.Const
     expr match
       case Varargs(Values(elems)) => Some(elems)

--- a/library/src/scala/quoted/matching/package.scala
+++ b/library/src/scala/quoted/matching/package.scala
@@ -26,7 +26,7 @@ package object matching {
   @deprecated("use scala.quoted.Value instead", "0.23.0")
   val Value: quoted.Value.type = quoted.Value
 
-  @deprecated("use scala.quoted.ValueOfExpr instead", "0.23.0")
-  val ValueOfExpr: quoted.ValueOfExpr.type = quoted.ValueOfExpr
+  @deprecated("use scala.quoted.Value instead", "0.23.0")
+  val ValueOfExpr: quoted.Value.type = quoted.Value
 
 }

--- a/tests/neg-macros/inline-macro-staged-interpreter/Macro_1.scala
+++ b/tests/neg-macros/inline-macro-staged-interpreter/Macro_1.scala
@@ -9,7 +9,7 @@ object E {
 
   def impl[T: Type](x: Expr[E[T]]) (using QuoteContext): Expr[T] = x.value.lift
 
-  implicit def ev1[T: Type]: ValueOfExpr[E[T]] = new ValueOfExpr {
+  implicit def ev1[T: Type]: Unliftable[E[T]] = new Unliftable {
     def apply(x: Expr[E[T]]) (using QuoteContext): Option[E[T]] = x match {
       case '{ I(${Const(n)}) } => Some(I(n).asInstanceOf[E[T]])
       case '{ Plus[T](${Value(x)}, ${Value(y)})(using $op) } if op.matches('{Plus2.IPlus}) => Some(Plus(x, y)(using Plus2.IPlus.asInstanceOf[Plus2[T]]).asInstanceOf[E[T]])
@@ -18,7 +18,7 @@ object E {
   }
 
   object Value {
-    def unapply[T, U >: T](expr: Expr[T])(using ValueOfExpr[U], QuoteContext): Option[U] = expr.getValue
+    def unapply[T, U >: T](expr: Expr[T])(using Unliftable[U], QuoteContext): Option[U] = expr.getValue
   }
 }
 

--- a/tests/run-macros/i7964/Macro_1.scala
+++ b/tests/run-macros/i7964/Macro_1.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
-enum Num { // TODO derive a quoted.ValueOfExpr
+enum Num { // TODO derive a quoted.Unliftable
   case One
   case Two
 }

--- a/tests/run-macros/inline-macro-staged-interpreter/Macro_1.scala
+++ b/tests/run-macros/inline-macro-staged-interpreter/Macro_1.scala
@@ -9,7 +9,7 @@ object E {
   def impl[T: Type](expr: Expr[E[T]]) (using QuoteContext): Expr[T] =
     expr.value.lift
 
-  implicit def ev1[T: Type]: ValueOfExpr[E[T]] = new ValueOfExpr { // TODO use type class derivation
+  implicit def ev1[T: Type]: Unliftable[E[T]] = new Unliftable { // TODO use type class derivation
     def apply(x: Expr[E[T]]) (using QuoteContext): Option[E[T]] = (x match {
       case '{ I(${Const(n)}) } => Some(I(n))
       case '{ D(${Const(n)}) } => Some(D(n))
@@ -22,7 +22,7 @@ object E {
   }
 
   object Value {
-    def unapply[T, U >: T](expr: Expr[T])(using ValueOfExpr[U], QuoteContext): Option[U] = expr.getValue
+    def unapply[T, U >: T](expr: Expr[T])(using Unliftable[U], QuoteContext): Option[U] = expr.getValue
   }
 
 }

--- a/tests/run-staging/quote-valueof-list.scala
+++ b/tests/run-staging/quote-valueof-list.scala
@@ -7,7 +7,7 @@ object Test {
 
   def main(args: Array[String]): Unit = withQuoteContext {
 
-    implicit def ValueOfExprInt: ValueOfExpr[Int] = new {
+    implicit def UnliftableInt: Unliftable[Int] = new {
       def apply(n: Expr[Int])(using QuoteContext): Option[Int] = n match {
         case '{ 0 } => Some(0)
         case '{ 1 } => Some(1)
@@ -16,7 +16,7 @@ object Test {
       }
     }
 
-    implicit def ValueOfExprBoolean: ValueOfExpr[Boolean] = new ValueOfExpr[Boolean] {
+    implicit def UnliftableBoolean: Unliftable[Boolean] = new Unliftable[Boolean] {
       def apply(b: Expr[Boolean])(using QuoteContext): Option[Boolean] = b match {
         case '{ true } => Some(true)
         case '{ false } => Some(false)
@@ -24,7 +24,7 @@ object Test {
       }
     }
 
-    implicit def ValueOfExprList[T: ValueOfExpr: Type]: ValueOfExpr[List[T]] = new {
+    implicit def UnliftableList[T: Unliftable: Type]: Unliftable[List[T]] = new {
       def apply(xs: Expr[List[T]])(using QuoteContext): Option[List[T]] = (xs: Expr[Any]) match {
         case '{ ($xs1: List[T]).::($x) } =>
           for { head <- x.getValue; tail <- xs1.getValue }
@@ -34,7 +34,7 @@ object Test {
       }
     }
 
-    implicit def ValueOfExprOption[T: ValueOfExpr: Type]: ValueOfExpr[Option[T]] = new {
+    implicit def UnliftableOption[T: Unliftable: Type]: Unliftable[Option[T]] = new {
       def apply(expr: Expr[Option[T]])(using QuoteContext): Option[Option[T]] = expr match {
         case '{ Some[T]($x) } => for (v <- x.getValue) yield Some(v)
         case '{ None } => Some(None)


### PR DESCRIPTION
As the dual of Liftable, the concept should be named Unliftable.
Additionally when programmers did not know about ValueOfExpr, they have been asking is the was
an unliftable/unlift.

For a future PR: Should the `Value.unapply` extractor be renamed to `Unlift.unapply` or `Expr.unapply` (as `Expr.apply` is lifting)? See #8504