### PR TITLE
Revert "Use GitHub Actions to release nightly builds"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -91,53 +91,53 @@ steps:
     - tag
     - promote
 
-# - name: publish_nightly
-#   pull: default
-#   image: lampepfl/dotty:2020-01-22-2
-#   depends_on:
-#   - test
-#   - test_bootstrapped
-#   - community_build
-#   - test_sbt
-#   - test_java11
-#   commands:
-#   - ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease"
-#   environment:
-#     NIGHTLYBUILD: yes
-#     PGP_PW:
-#       from_secret: pgp_pw
-#     PGP_SECRET:
-#       from_secret: pgp_secret
-#     SONATYPE_PW:
-#       from_secret: sonatype_pw
-#     SONATYPE_USER:
-#       from_secret: sonatype_user
-#   when:
-#     event:
-#     - promote
-#     target:
-#     - nightly
+- name: publish_nightly
+  pull: default
+  image: lampepfl/dotty:2020-01-22-2
+  depends_on:
+  - test
+  - test_bootstrapped
+  - community_build
+  - test_sbt
+  - test_java11
+  commands:
+  - ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease"
+  environment:
+    NIGHTLYBUILD: yes
+    PGP_PW:
+      from_secret: pgp_pw
+    PGP_SECRET:
+      from_secret: pgp_secret
+    SONATYPE_PW:
+      from_secret: sonatype_pw
+    SONATYPE_USER:
+      from_secret: sonatype_user
+  when:
+    event:
+    - promote
+    target:
+    - nightly
 
-# - name: nightly_documentation
-#   pull: default
-#   image: lampepfl/dotty:2020-01-22-2
-#   depends_on:
-#   - test
-#   - test_bootstrapped
-#   - community_build
-#   - test_java11
-#   - publish_nightly
-#   commands:
-#   - ./project/scripts/genDocs -doc-snapshot
-#   environment:
-#     BOT_TOKEN:
-#       from_secret: bot_token
-#     NIGHTLYBUILD: yes
-#   when:
-#     event:
-#     - promote
-#     target:
-#     - nightly
+- name: nightly_documentation
+  pull: default
+  image: lampepfl/dotty:2020-01-22-2
+  depends_on:
+  - test
+  - test_bootstrapped
+  - community_build
+  - test_java11
+  - publish_nightly
+  commands:
+  - ./project/scripts/genDocs -doc-snapshot
+  environment:
+    BOT_TOKEN:
+      from_secret: bot_token
+    NIGHTLYBUILD: yes
+  when:
+    event:
+    - promote
+    target:
+    - nightly
 
 - name: publish_release
   pull: default

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,6 @@
 name: Dotty CI
 
-on:
-  push:
-  pull_request:
-  schedule:
-    - cron: '0 3 * * *'  # Every day at 3 AM
+on: [push, pull_request]
 
 env:
   DOTTY_CI_RUN: true
@@ -116,11 +112,8 @@ jobs:
   test_sbt:
     runs-on: self-hosted
     container: akmetiuk/dotty:2020-02-12
-    if: (
-          github.event_name == 'push' &&
-          startsWith(github.event.ref, 'refs/tags/')
-        ) ||
-        github.event_name == 'schedule'
+    if: github.event_name == 'push' &&
+        startsWith(github.event.ref, 'refs/tags/')
 
     steps:
       - name: Git Checkout
@@ -153,11 +146,8 @@ jobs:
   test_java11:
     runs-on: self-hosted
     container: akmetiuk/dotty:2020-02-12
-    if: (
-          github.event_name == 'push' &&
-          startsWith(github.event.ref, 'refs/tags/')
-        ) ||
-        github.event_name == 'schedule'
+    if: github.event_name == 'push' &&
+        startsWith(github.event.ref, 'refs/tags/')
 
     steps:
       - name: Git Checkout
@@ -188,84 +178,3 @@ jobs:
         run: |
           export PATH="/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH"
           ./project/scripts/sbt ";compile ;test"
-
-  publish_nightly:
-    runs-on: self-hosted
-    container: akmetiuk/dotty:2020-02-12
-    needs: [test, test_bootstrapped, community_build, test_sbt, test_java11]
-    if: github.event_name == 'schedule'
-    env:
-      NIGHTLYBUILD: yes
-      PGP_PW: ${{ secrets.PGP_PW }}  # PGP passphrase
-      PGP_SECRET: ${{ secrets.PGP_SECRET }}  # Export your private and public PGP key to an *.asc file, take the file's contents as a string
-      SONATYPE_PW: ${{ secrets.SONATYPE_PW }}
-      SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
-
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v2
-
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
-
-      - name: Publish Nightly
-        run: |
-          ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease"
-
-  nightly_documentation:
-    runs-on: self-hosted
-    container: akmetiuk/dotty:2020-02-12
-    needs: [publish_nightly]
-    if: github.event_name == 'schedule'
-    env:
-      NIGHTLYBUILD: yes
-      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}  # If you need to change this:
-                                           # Generate one at https://github.com/settings/tokens
-                                           # Make sure you have the write permissions to the repo: https://github.com/lampepfl/dotty-website
-
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v2
-
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
-
-      - name: Nightly Documentation
-        run: |
-          ./project/scripts/genDocs -doc-snapshot


### PR DESCRIPTION
Reverts lampepfl/dotty#8496

Currently GH Actions fail to handle PGP properly: see https://github.com/lampepfl/dotty/runs/503065800?check_suite_focus=true