### PR TITLE
Fix #8531: Annnotations on class value parameters go to the constructor

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -804,7 +804,7 @@ class Definitions {
   @tu lazy val TASTYLongSignatureAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.internal.TASTYLongSignature")
   @tu lazy val TailrecAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.tailrec")
   @tu lazy val ThreadUnsafeAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.threadUnsafe")
-  @tu lazy val TransientParamAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.constructorOnly")
+  @tu lazy val ConstructorOnlyAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.constructorOnly")
   @tu lazy val CompileTimeOnlyAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.compileTimeOnly")
   @tu lazy val SwitchAnnot: ClassSymbol = ctx.requiredClass("scala.annotation.switch")
   @tu lazy val ThrowsAnnot: ClassSymbol = ctx.requiredClass("scala.throws")

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -387,7 +387,7 @@ object SymDenotations {
     final def setParamssFromDefs(tparams: List[TypeDef[?]], vparamss: List[List[ValDef[?]]])(using Context): Unit =
       setParamss(tparams.map(_.symbol), vparamss.map(_.map(_.symbol)))
 
-    /** A pair consistsing of type paremeter symbols and value parameter symbol lists
+    /** A pair consisting of type parameter symbols and value parameter symbol lists
      *  of this method definition, or (Nil, Nil) for other symbols.
      *  Makes use of `rawParamss` when present, or constructs fresh parameter symbols otherwise.
      *  This method can be allocation-heavy.

--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -1752,6 +1752,9 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   def Symbol_paramSymss(self: Symbol)(using ctx: Context): (List[Symbol], List[List[Symbol]]) =
     self.paramSymss
 
+  def Symbol_primaryConstructor(self: Symbol)(using Context): Symbol =
+    self.primaryConstructor
+
   def Symbol_caseFields(self: Symbol)(using ctx: Context): List[Symbol] =
     if (!self.isClass) Nil
     else self.asClass.paramAccessors.collect {

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -228,12 +228,12 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
         Nil
       }
       else {
-        if (acc.hasAnnotation(defn.ConstructorOnlyAnnot))
+        val param = acc.subst(accessors, paramSyms)
+        if (param.hasAnnotation(defn.ConstructorOnlyAnnot))
           ctx.error(em"${acc.name} is marked `@constructorOnly` but it is retained as a field in ${acc.owner}", acc.sourcePos)
         val target = if (acc.is(Method)) acc.field else acc
         if (!target.exists) Nil // this case arises when the parameter accessor is an alias
         else {
-          val param = acc.subst(accessors, paramSyms)
           val assigns = Assign(ref(target), ref(param)).withSpan(tree.span) :: Nil
           if (acc.name != nme.OUTER) assigns
           else {

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -228,8 +228,8 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
         Nil
       }
       else {
-        if (acc.hasAnnotation(defn.TransientParamAnnot))
-          ctx.error(em"transient parameter $acc is retained as field in class ${acc.owner}", acc.sourcePos)
+        if (acc.hasAnnotation(defn.ConstructorOnlyAnnot))
+          ctx.error(em"${acc.name} is marked `@constructorOnly` but it is retained as a field in ${acc.owner}", acc.sourcePos)
         val target = if (acc.is(Method)) acc.field else acc
         if (!target.exists) Nil // this case arises when the parameter accessor is an alias
         else {

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -2223,11 +2223,15 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
     def methods(using ctx: Context): List[Symbol] =
       internal.Symbol_methods(sym)
 
-    /** A pair consistsing of type paremeter symbols and value parameter symbol lists
+    /** A pair consisting of type parameter symbols and value parameter symbol lists
      *  of this method definition, or (Nil, Nil) for other symbols.
      */
     def paramSymss(using ctx: Context): (List[Symbol], List[List[Symbol]]) =
       internal.Symbol_paramSymss(sym)
+
+    /** The primary constructor of a class or trait, `noSymbol` if not applicable. */
+    def primaryConstructor(using Context): Symbol =
+      internal.Symbol_primaryConstructor(sym)
 
     /** Fields of a case class type -- only the ones declared in primary constructor */
     def caseFields(using ctx: Context): List[Symbol] =

--- a/library/src/scala/tasty/reflect/CompilerInterface.scala
+++ b/library/src/scala/tasty/reflect/CompilerInterface.scala
@@ -1305,10 +1305,13 @@ trait CompilerInterface {
   /** Get all non-private methods declared or inherited */
   def Symbol_methods(self: Symbol)(using ctx: Context): List[Symbol]
 
-  /** A pair consistsing of type paremeter symbols and value parameter symbol lists
+  /** A pair consisting of type parameter symbols and value parameter symbol lists
    *  of this method definition, or (Nil, Nil) for other symbols.
    */
   def Symbol_paramSymss(self: Symbol)(using ctx: Context): (List[Symbol], List[List[Symbol]])
+
+  /** The primary constructor of a class or trait, `noSymbol` if not applicable. */
+  def Symbol_primaryConstructor(self: Symbol)(using Context): Symbol
 
   /** Fields of a case class type -- only the ones declared in primary constructor */
   def Symbol_caseFields(self: Symbol)(using ctx: Context): List[Symbol]

--- a/tests/run/i8531/Named.java
+++ b/tests/run/i8531/Named.java
@@ -1,0 +1,5 @@
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Named {}

--- a/tests/run/i8531/Test.scala
+++ b/tests/run/i8531/Test.scala
@@ -1,0 +1,9 @@
+class Foo(@Named s: String)
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val ctor = classOf[Foo].getDeclaredConstructors()(0)
+    val annots = ctor.getParameterAnnotations()(0)
+    assert(annots.length == 1, annots.length)
+  }
+}


### PR DESCRIPTION
Mimic the behavior of Scala 2: an annotation on a class value
parameters (but not on a type parameter) is moved to the constructor
parameter and not to any of the derived parameters.