### PR TITLE
Fix quote match leak

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1234,12 +1234,15 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   override def inlineContext(call: Tree)(implicit ctx: Context): Context = {
     // We assume enclosingInlineds is already normalized, and only process the new call with the head.
     val oldIC = enclosingInlineds
-    val newIC = (call, oldIC) match {
-      case (t, t1 :: ts2) if t.isEmpty =>
-        assert(!t1.isEmpty)
-        ts2
-      case _ => call :: oldIC
-    }
+
+    val newIC =
+      if call.isEmpty then
+        oldIC match
+          case t1 :: ts2 => ts2
+          case _ => oldIC
+      else
+        call :: oldIC
+
     ctx.fresh.setProperty(InlinedCalls, newIC)
   }
 

--- a/library/src/scala/internal/quoted/Matcher.scala
+++ b/library/src/scala/internal/quoted/Matcher.scala
@@ -33,7 +33,7 @@ private[quoted] object Matcher {
       if (hasTypeSplices) {
         val ctx: Context = internal.Context_GADT_setFreshGADTBounds(rootContext)
         given Context = ctx
-        val matchings = scrutineeTerm.underlyingArgument =?= patternTerm.underlyingArgument
+        val matchings = scrutineeTerm =?= patternTerm
         // After matching and doing all subtype checks, we have to approximate all the type bindings
         // that we have found and seal them in a quoted.Type
         matchings.asOptionOfTuple.map { tup =>
@@ -44,7 +44,7 @@ private[quoted] object Matcher {
         }
       }
       else {
-        scrutineeTerm.underlyingArgument =?= patternTerm.underlyingArgument
+        scrutineeTerm =?= patternTerm
       }
     }
 
@@ -285,6 +285,9 @@ private[quoted] object Matcher {
             tpt =?= pattern
           case (_, Annotated(tpt, _)) =>
             scrutinee =?= tpt
+
+          case (NamedArg(name1, arg1), NamedArg(name2, arg2)) if name1 == name2 =>
+            arg1 =?= arg2
 
           // No Match
           case _ =>

--- a/tests/run-macros/i6253-c.check
+++ b/tests/run-macros/i6253-c.check
@@ -1,0 +1,2 @@
+ERROR
+ERROR

--- a/tests/run-macros/i6253-c.check
+++ b/tests/run-macros/i6253-c.check
@@ -1,2 +1,0 @@
-ERROR
-ERROR

--- a/tests/run-macros/i6253-c/quoted_1.scala
+++ b/tests/run-macros/i6253-c/quoted_1.scala
@@ -8,14 +8,10 @@ object Macros {
 
   private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(using QuoteContext): Expr[String] = {
     self match {
-      case '{ StringContext($parts: _*) } =>
-        '{
-          val p: Seq[String] = $parts
-          val a: Seq[Any] = $args ++ Seq("")
-          p.zip(a).map(_ + _.toString).mkString
-        }
+      case '{ StringContext($parts: _*) } => // Should not match as the parameter is not marked as inlined
+        '{ ??? }
       case _ =>
-        '{ "ERROR" }
+        '{ "Ok" }
     }
   }
 }

--- a/tests/run-macros/i6253-c/quoted_1.scala
+++ b/tests/run-macros/i6253-c/quoted_1.scala
@@ -1,0 +1,21 @@
+import scala.quoted._
+
+
+object Macros {
+
+  // Should be: inline def (inline self: StringContext) ...
+  inline def (self: => StringContext) xyz(args: => String*): String = ${impl('self, 'args)}
+
+  private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(using QuoteContext): Expr[String] = {
+    self match {
+      case '{ StringContext($parts: _*) } =>
+        '{
+          val p: Seq[String] = $parts
+          val a: Seq[Any] = $args ++ Seq("")
+          p.zip(a).map(_ + _.toString).mkString
+        }
+      case _ =>
+        '{ "ERROR" }
+    }
+  }
+}

--- a/tests/run-macros/i6253-c/quoted_2.scala
+++ b/tests/run-macros/i6253-c/quoted_2.scala
@@ -1,0 +1,10 @@
+import Macros._
+
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    println(xyz"Hello World")
+    println(xyz"Hello ${"World"}")
+  }
+
+}


### PR DESCRIPTION
Fix quote match leak due to use of `underlyingArgument` and make `inlineContext` resilient to previous errors (i.e. never add an empty call).

Tests were fixed in #8553 to not rely on `underlyingArgument`.