### PR TITLE
Fix #7644: silence debug warnings in REPL

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -117,7 +117,7 @@ trait SymDenotations { this: Context =>
   /** Possibly accept stale symbol with warning if in IDE */
   def acceptStale(denot: SingleDenotation): Boolean =
     staleOK && {
-      ctx.echo(denot.staleSymbolMsg)
+      ctx.debugwarn(denot.staleSymbolMsg)
       true
     }
 }

--- a/compiler/test-resources/repl/i7644
+++ b/compiler/test-resources/repl/i7644
@@ -1,0 +1,14 @@
+scala> class T extends Eql
+1 | class T extends Eql
+  |       ^
+  |       Cannot extend sealed trait Eql in a different source file
+1 | class T extends Eql
+  |                 ^^^
+  |                 Missing type parameter for Eql
+scala> class T extends Eql
+1 | class T extends Eql
+  |       ^
+  |       Cannot extend sealed trait Eql in a different source file
+1 | class T extends Eql
+  |                 ^^^
+  |                 Missing type parameter for Eql


### PR DESCRIPTION
Fix #7644: silence debug warnings in REPL

Otherwise, we will print the following debug info in the REPL, which should not be the default.

```
stale symbol; module class rs$line$1$#2503 in module class <empty>, defined in Period(1..4, run = 2), is referred to in run Period(1..1, run = 3)
stale symbol; class T#3334 in module class rs$line$1$, defined in Period(1..4, run = 2), is referred to in run Period(1..1, run = 3)
```