### PR TITLE
Fix issue 8558 expose AlreadyLoaded via Reflection

### DIFF
--- a/compiler/src/dotty/tools/dotc/fromtasty/AlreadyLoadedCompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/AlreadyLoadedCompilationUnit.scala
@@ -1,0 +1,10 @@
+package dotty.tools.dotc.fromtasty
+
+import dotty.tools.dotc.CompilationUnit
+import dotty.tools.dotc.util.NoSource
+
+/** A marker CompilationUnit to return up the call stack from ReadTasty.  This will tell us that we've
+ *  encountered, and attempted to inspect, something that has already been loaded, for example a Scala primitive or a
+ *  library class like Option.
+ */
+class AlreadyLoadedCompilationUnit(val className: String) extends CompilationUnit(NoSource)

--- a/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
@@ -32,11 +32,6 @@ class ReadTasty extends Phase {
         None
       }
 
-      def alreadyLoaded(): None.type = {
-        ctx.warning(s"class $className cannot be unpickled because it is already loaded")
-        None
-      }
-
       def compilationUnit(cls: Symbol): Option[CompilationUnit] = cls match {
         case cls: ClassSymbol =>
           (cls.rootTreeOrProvider: @unchecked) match {
@@ -51,7 +46,7 @@ class ReadTasty extends Phase {
               cls.denot.infoOrCompleter match {
                 case _: NoLoader => Some(Scala2CompilationUnit(cls.fullName.toString))
                 case _ if cls.flags.is(Flags.JavaDefined) => Some(JavaCompilationUnit(cls.fullName.toString))
-                case _ => alreadyLoaded()
+                case _ => Some(AlreadyLoadedCompilationUnit(cls.denot.fullName.toString))
               }
             case _ =>
               cannotUnpickle(s"its class file does not have a TASTY attribute")

--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -67,10 +67,12 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   def Context_requiredMethod(self: Context)(path: String): Symbol = self.requiredMethod(path)
   def Context_isJavaCompilationUnit(self: Context): Boolean = self.compilationUnit.isInstanceOf[fromtasty.JavaCompilationUnit]
   def Context_isScala2CompilationUnit(self: Context): Boolean = self.compilationUnit.isInstanceOf[fromtasty.Scala2CompilationUnit]
+  def Context_isAlreadyLoadedCompilationUnit(self: Context): Boolean = self.compilationUnit.isInstanceOf[fromtasty.AlreadyLoadedCompilationUnit]
   def Context_compilationUnitClassname(self: Context): String =
     self.compilationUnit match {
       case cu: fromtasty.JavaCompilationUnit => cu.className
       case cu: fromtasty.Scala2CompilationUnit => cu.className
+      case cu: fromtasty.AlreadyLoadedCompilationUnit => cu.className
       case cu => ""
     }
 

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -448,6 +448,9 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
     /** Returns true if we've tried to reflect on a Scala2 (non-Tasty) class. */
     def isScala2CompilationUnit(): Boolean = internal Context_isScala2CompilationUnit(self)
 
+    /** Returns true if we've tried to reflect on a class that's already loaded (e.g. Option). */
+    def isAlreadyLoadedCompilationUnit(): Boolean = internal.Context_isAlreadyLoadedCompilationUnit(self)
+
     /** Class name of the current CompilationUnit */
     def compilationUnitClassname(): String = internal.Context_compilationUnitClassname(self)
   }

--- a/library/src/scala/tasty/reflect/CompilerInterface.scala
+++ b/library/src/scala/tasty/reflect/CompilerInterface.scala
@@ -168,6 +168,9 @@ trait CompilerInterface {
   /** Returns true if we've tried to reflect on a Scala2 (non-Tasty) class. */
   def Context_isScala2CompilationUnit(self: Context): Boolean
 
+  /** Returns true if we've tried to reflect on a class that's already loaded (e.g. Option). */
+  def Context_isAlreadyLoadedCompilationUnit(self: Context): Boolean
+
   /** Class name of the current CompilationUnit */
   def Context_compilationUnitClassname(self: Context): String
 

--- a/tests/run-custom-args/tasty-inspector/i8558.scala
+++ b/tests/run-custom-args/tasty-inspector/i8558.scala
@@ -1,0 +1,23 @@
+import scala.tasty.Reflection
+import scala.tasty.inspector._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+
+    // Tasty Scala Class
+    val inspector = new TestInspector_NonTasty()
+    inspector.inspect("", List("scala.Option"))
+    assert(inspector.isAlreadyLoaded)
+    assert(inspector.className == "scala.Option")
+  }
+}
+
+class TestInspector_NonTasty() extends TastyInspector:
+
+  var isAlreadyLoaded: Boolean = false
+  var className: String = ""
+
+  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit = 
+    import reflect.{_, given _}
+    isAlreadyLoaded = reflect.rootContext.isAlreadyLoadedCompilationUnit()
+    className = reflect.rootContext.compilationUnitClassname()


### PR DESCRIPTION
Today ReadTasty (Tasty inspection) just emits a warning message to the console when you attempt to inspect a class that's already loaded, e.g. Option or Scala primitive.  The message is not useful to the end-user and there's nothing pushed upstream to tell the caller that something unexpected happened.  This fix implements a change that returns an AlreadyLoadedCompilationUnit from ReadTasty, which callers can either respond to or ignore--but at least they know something happened.  This information is exposed via the Reflection API according to established pattern.

Fixes #8558