### PR TITLE
Fix xml-interpolator module reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,7 +46,7 @@
 	branch = shapeless-3-staging
 [submodule "community-build/community-projects/xml-interpolator"]
 	path = community-build/community-projects/xml-interpolator
-	url = https://github.com/lampepfl/xml-interpolator.git
+	url = https://github.com/dotty-staging/xml-interpolator.git
 [submodule "community-build/community-projects/effpi"]
 	path = community-build/community-projects/effpi
 	url = https://github.com/dotty-staging/effpi


### PR DESCRIPTION
We started having it on in `lampepfl` but now that we need to update it from type to time
we use the fork in `dotty-staging`. For some reason this reference was never updated.