### PR TITLE
Clean GH Actions workspace before each job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
     container: akmetiuk/dotty:2020-02-12
 
     steps:
+      - name: Clean Workspace
+        uses: anatoliykmetyuk/action-clean@1.0.2
+
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -49,6 +52,9 @@ jobs:
     container: akmetiuk/dotty:2020-02-12
 
     steps:
+      - name: Clean Workspace
+        uses: anatoliykmetyuk/action-clean@1.0.2
+
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -83,6 +89,9 @@ jobs:
     container: akmetiuk/dotty:2020-02-12
 
     steps:
+      - name: Clean Workspace
+        uses: anatoliykmetyuk/action-clean@1.0.2
+
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -123,6 +132,9 @@ jobs:
         github.event_name == 'schedule'
 
     steps:
+      - name: Clean Workspace
+        uses: anatoliykmetyuk/action-clean@1.0.2
+
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -160,6 +172,9 @@ jobs:
         github.event_name == 'schedule'
 
     steps:
+      - name: Clean Workspace
+        uses: anatoliykmetyuk/action-clean@1.0.2
+
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -202,6 +217,9 @@ jobs:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
 
     steps:
+      - name: Clean Workspace
+        uses: anatoliykmetyuk/action-clean@1.0.2
+
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -242,6 +260,9 @@ jobs:
                                            # Make sure you have the write permissions to the repo: https://github.com/lampepfl/dotty-website
 
     steps:
+      - name: Clean Workspace
+        uses: anatoliykmetyuk/action-clean@1.0.2
+
       - name: Git Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
GH Actions mounts docker volumes and executes the jobs from
them. For some reason it doesn't clean these volumes
automatically after each run. We assume that each run happens
on a clean workspace and hence there are weird consequences
when this assumption is broken.

One of them, for example, is failure to publish documentation
to GH Pages website. To publish such a documentation, we first
add the website remote to the Dotty github repo. If the remote
already exists, which is the case on a dirty workspace,
we get an error.

This PR should fix the failure to publish docs: https://github.com/lampepfl/dotty/runs/518302696?check_suite_focus=true