### PR TITLE
Fix blog images

### DIFF
--- a/doc-tool/resources/_layouts/blog-page.html
+++ b/doc-tool/resources/_layouts/blog-page.html
@@ -26,7 +26,7 @@ layout: main
     {% if page.author and page.authorImg %}
     <hr/>
     <footer>
-        <img id="author-img" src="{{ site.baseurl }}/{{ page.authorImg }}">
+        <img id="author-img" src="{{ site.baseurl }}{{ page.authorImg }}">
         <span id="author-signature">
             {{ page.author }}
         </span>


### PR DESCRIPTION
The slash is not needed because it is already included in the
base URL of the website.