### PR TITLE
Fix #8573: Fix higher-kinded bounded opaque types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -432,11 +432,13 @@ object SymDenotations {
      *  self type of the enclosing class.
      *  Otherwise return `info`
      *
-     *  @param info   Is assumed to be a (lambda-abstracted) right hand side TypeAlias
-     *                of the opaque type definition.
-     *  @param rhs    The right hand side tree of the type definition
+     *  @param info    Is assumed to be a (lambda-abstracted) right hand side TypeAlias
+     *                 of the opaque type definition.
+     *  @param rhs     The right hand side tree of the type definition
+     *  @param tparams The type parameters with which the right-hand side bounds should be abstracted
+     *
      */
-    def opaqueToBounds(info: Type, rhs: tpd.Tree)(using Context): Type =
+    def opaqueToBounds(info: Type, rhs: tpd.Tree, tparams: List[TypeParamInfo])(using Context): Type =
 
       def setAlias(tp: Type) =
         def recur(self: Type): Unit = self match
@@ -449,7 +451,7 @@ object SymDenotations {
       end setAlias
 
       def bounds(t: tpd.Tree): TypeBounds = t match
-        case LambdaTypeTree(_, body) =>
+        case LambdaTypeTree(tparams, body) =>
           bounds(body)
         case TypeBoundsTree(lo, hi, alias) =>
           assert(!alias.isEmpty)
@@ -460,7 +462,7 @@ object SymDenotations {
       info match
         case TypeAlias(alias) if isOpaqueAlias && owner.isClass =>
           setAlias(alias)
-          HKTypeLambda.boundsFromParams(alias.typeParams, bounds(rhs))
+          HKTypeLambda.boundsFromParams(tparams, bounds(rhs))
         case _ =>
           info
     end opaqueToBounds

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -839,7 +839,7 @@ class TreeUnpickler(reader: TastyReader,
                 case _: TypeBounds | _: ClassInfo => checkNonCyclic(sym, rhs.tpe, reportErrors = false)
                 case _ => rhs.tpe.toBounds
               },
-              rhs)
+              rhs, rhs.tpe.typeParams)
             if sym.isOpaqueAlias then sym.typeRef.recomputeDenot() // make sure we see the new bounds from now on
             sym.resetFlag(Provisional)
             TypeDef(rhs)

--- a/tests/neg/i6225.scala
+++ b/tests/neg/i6225.scala
@@ -1,12 +1,12 @@
-object O1 {
+object O1 {  // error: cannot be instantiated
   type A[X] = X
-  opaque type T = A
+  opaque type T = A // error: opaque type alias must be fully applied
 }
 
 object O2 {
   opaque type A[X] = X
-  object A {
-    opaque type T = A
+  object A { // error: cannot be instantiated
+    opaque type T = A  // error: opaque type alias must be fully applied
   }
 }
 

--- a/tests/pos/i8537.scala
+++ b/tests/pos/i8537.scala
@@ -1,0 +1,3 @@
+val f: Int => String = _ => "b"
+var g: Int => String = (_) => "b"  // workaround
+var h: Int => String = _ => "b"    // end of statement expected but '=>' found

--- a/tests/pos/i8573.scala
+++ b/tests/pos/i8573.scala
@@ -1,0 +1,7 @@
+object Example1 {
+  opaque type Foo[A] <: A = A
+}
+
+object Example2 {
+  opaque type Foo[A] >: A = A
+}


### PR DESCRIPTION
 - Fix the type parameters with which explicitly given bounds of a higher-kinded
   opaque type should be abstracted.

 - Explicitly disallow unapplied right-hand sides of opaque types. They will lead
   to bad bounds later anyway, so we should give an intelligible error message
   early on.

Open question: Should we disallow all unapplied right hand sides for all type aliases,
not just opaque ones?