### PR TITLE
Fix #8569: Better error message for erroneous creator applications

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -327,4 +327,7 @@ abstract class Reporter extends interfaces.ReporterResult {
   /** Issue all error messages in this reporter to next outer one, or make sure they are written. */
   def flush()(implicit ctx: Context): Unit =
     removeBufferedMessages.foreach(ctx.reporter.report)
+
+  /** If this reporter buffers messages, all buffered messages, otherwise Nil */
+  def pendingMessages(using Context): List[MessageContainer] = Nil
 }

--- a/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
@@ -38,5 +38,7 @@ class StoreReporter(outer: Reporter) extends Reporter {
     if (infos != null) try infos.toList finally infos = null
     else Nil
 
+  override def pendingMessages(using Context): List[MessageContainer] = infos.toList
+
   override def errorsReported: Boolean = hasErrors || (outer != null && outer.errorsReported)
 }

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/ErrorMessageID.scala
@@ -91,7 +91,7 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     ExpectedTopLevelDefID,
     AnonymousFunctionMissingParamTypeID,
     SuperCallsNotAllowedInlineableID,
-    UNUSED1,  // not used anymore, but left so that error numbers stay the same
+    NotAPathID,
     WildcardOnTypeArgumentNotAllowedOnNewID,
     FunctionTypeNeedsNonEmptyParameterListID,
     WrongNumberOfParametersID,

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -1701,9 +1701,18 @@ object messages {
   case class SuperCallsNotAllowedInlineable(symbol: Symbol)(implicit ctx: Context)
     extends Message(SuperCallsNotAllowedInlineableID) {
     val kind: String = "Syntax"
-    val msg: String = s"Super call not allowed in inlineable $symbol"
+    val msg: String = em"Super call not allowed in inlineable $symbol"
     val explanation: String = "Method inlining prohibits calling superclass methods, as it may lead to confusion about which super is being called."
   }
+
+  case class NotAPath(tp: Type, usage: String)(using Context) extends Message(NotAPathID):
+    val kind: String = "Type"
+    val msg: String = em"$tp is not a valid $usage, since it is not an immutable path"
+    val explanation: String =
+      i"""An immutable path is
+         | - a reference to an immutable value, or
+         | - a reference to `this`, or
+         | - a selection of an immutable path with an immutable value."""
 
   case class WrongNumberOfParameters(expected: Int)(implicit ctx: Context)
     extends Message(WrongNumberOfParametersID) {

--- a/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/diagnostic/messages.scala
@@ -279,7 +279,7 @@ object messages {
     }
   }
 
-  case class MissingIdent(tree: untpd.Ident, treeKind: String, name: String)(implicit ctx: Context)
+  case class MissingIdent(tree: untpd.Ident, treeKind: String, name: Name)(implicit ctx: Context)
   extends Message(MissingIdentID) {
     val kind: String = "Unbound Identifier"
     val msg: String = em"Not found: $treeKind$name"

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -239,7 +239,7 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
 
     tag.tpe match
       case tp: TermRef =>
-        checkStable(tp, pos)
+        checkStable(tp, pos, "type witness")
         Some(ref(getQuoteTypeTags.getTagRef(tp)))
       case _: SearchFailureType =>
         levelError(sym, tp, pos,

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1068,7 +1068,7 @@ trait Applications extends Compatibility {
           case NotAMember(_, name, _, _) =>
             memberName.isEmpty || name == memberName
           case MissingIdent(_, _, name) =>
-            memberName.isEmpty || name == memberName.toString
+            memberName.isEmpty || name == memberName
           case _ => false
       case _ => false
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -652,8 +652,8 @@ trait Checking {
     Checking.checkNonCyclicInherited(joint, parents, decls, posd)
 
   /** Check that type `tp` is stable. */
-  def checkStable(tp: Type, pos: SourcePosition)(implicit ctx: Context): Unit =
-    if (!tp.isStable) ctx.error(ex"$tp is not stable", pos)
+  def checkStable(tp: Type, pos: SourcePosition, kind: String)(implicit ctx: Context): Unit =
+    if !tp.isStable then ctx.error(NotAPath(tp, kind), pos)
 
   /** Check that all type members of `tp` have realizable bounds */
   def checkRealizableBounds(cls: Symbol, pos: SourcePosition)(implicit ctx: Context): Unit = {
@@ -712,7 +712,7 @@ trait Checking {
 
   /** Check that `path` is a legal prefix for an import or export clause */
   def checkLegalImportPath(path: Tree)(implicit ctx: Context): Unit = {
-    checkStable(path.tpe, path.sourcePos)
+    checkStable(path.tpe, path.sourcePos, "import prefix")
     if (!ctx.isAfterTyper) Checking.checkRealizable(path.tpe, path.posd)
   }
 
@@ -726,7 +726,7 @@ trait Checking {
     tp.underlyingClassRef(refinementOK = false) match {
       case tref: TypeRef =>
         if (traitReq && !tref.symbol.is(Trait)) ctx.error(TraitIsExpected(tref.symbol), pos)
-        if (stablePrefixReq && ctx.phase <= ctx.refchecksPhase) checkStable(tref.prefix, pos)
+        if (stablePrefixReq && ctx.phase <= ctx.refchecksPhase) checkStable(tref.prefix, pos, "class prefix")
         tp
       case _ =>
         ctx.error(ex"$tp is not a class type", pos)
@@ -1194,7 +1194,7 @@ trait NoChecking extends ReChecking {
   import tpd._
   override def checkNonCyclic(sym: Symbol, info: TypeBounds, reportErrors: Boolean)(implicit ctx: Context): Type = info
   override def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, posd: Positioned)(implicit ctx: Context): Unit = ()
-  override def checkStable(tp: Type, pos: SourcePosition)(implicit ctx: Context): Unit = ()
+  override def checkStable(tp: Type, pos: SourcePosition, kind: String)(implicit ctx: Context): Unit = ()
   override def checkClassType(tp: Type, pos: SourcePosition, traitReq: Boolean, stablePrefixReq: Boolean)(implicit ctx: Context): Type = tp
   override def checkImplicitConversionDefOK(sym: Symbol)(implicit ctx: Context): Unit = ()
   override def checkImplicitConversionUseOK(sym: Symbol, posd: Positioned)(implicit ctx: Context): Unit = ()

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -104,7 +104,8 @@ class ReTyper extends Typer with ReChecking {
     fallBack
 
   override def tryNew[T >: Untyped <: Type]
-    (treesInst: Instance[T])(tree: Trees.Tree[T], pt: Type, fallBack: => Tree)(implicit ctx: Context): Tree = fallBack
+    (treesInst: Instance[T])(tree: Trees.Tree[T], pt: Type, fallBack: TyperState => Tree)(implicit ctx: Context): Tree =
+      fallBack(ctx.typerState)
 
   override def completeAnnotations(mdef: untpd.MemberDef, sym: Symbol)(implicit ctx: Context): Unit = ()
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -451,7 +451,7 @@ class Typer extends Namer
         // of a this(...) constructor call
         errorType(ex"$tree is not accessible from constructor arguments", tree.sourcePos)
       else
-        errorType(new MissingIdent(tree, kind, name.show), tree.sourcePos)
+        errorType(new MissingIdent(tree, kind, name), tree.sourcePos)
 
     val tree1 = ownType match {
       case ownType: NamedType =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -491,7 +491,7 @@ class Typer extends Namer
         case _ => app
       }
     case qual =>
-      if (tree.name.isTypeName) checkStable(qual.tpe, qual.sourcePos)
+      if (tree.name.isTypeName) checkStable(qual.tpe, qual.sourcePos, "type prefix")
       val select = assignType(cpy.Select(tree)(qual, tree.name), qual)
 
       val select1 = toNotNullTermRef(select, pt)
@@ -1429,7 +1429,7 @@ class Typer extends Namer
 
   def typedSingletonTypeTree(tree: untpd.SingletonTypeTree)(implicit ctx: Context): SingletonTypeTree = {
     val ref1 = typedExpr(tree.ref)
-    checkStable(ref1.tpe, tree.sourcePos)
+    checkStable(ref1.tpe, tree.sourcePos, "singleton type")
     assignType(cpy.SingletonTypeTree(tree)(ref1), ref1)
   }
 

--- a/tests/neg-custom-args/explicit-nulls/i7883.check
+++ b/tests/neg-custom-args/explicit-nulls/i7883.check
@@ -1,0 +1,20 @@
+-- [E134] Type Mismatch Error: tests/neg-custom-args/explicit-nulls/i7883.scala:6:11 -----------------------------------
+6 |      case r(hd, tl) => Some((hd, tl))  // error // error // error
+  |           ^
+  |           None of the overloaded alternatives of method unapplySeq in class Regex with types
+  |            (m: scala.util.matching.Regex.Match): Option[List[String]]
+  |            (c: Char): Option[List[Char]]
+  |            (s: CharSequence): Option[List[String]]
+  |           match arguments (String | UncheckedNull)
+-- [E006] Unbound Identifier Error: tests/neg-custom-args/explicit-nulls/i7883.scala:6:30 ------------------------------
+6 |      case r(hd, tl) => Some((hd, tl))  // error // error // error
+  |                              ^^
+  |                              Not found: hd
+
+longer explanation available when compiling with `-explain`
+-- [E006] Unbound Identifier Error: tests/neg-custom-args/explicit-nulls/i7883.scala:6:34 ------------------------------
+6 |      case r(hd, tl) => Some((hd, tl))  // error // error // error
+  |                                  ^^
+  |                                  Not found: tl
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/explicit-nulls/i7883.scala
+++ b/tests/neg-custom-args/explicit-nulls/i7883.scala
@@ -1,0 +1,9 @@
+import scala.util.matching.Regex
+
+object Test extends App {
+  def head(s: String, r: Regex): Option[(String, String)] =
+    s.trim match {
+      case r(hd, tl) => Some((hd, tl))  // error // error // error
+      case _ => None
+    }
+}

--- a/tests/neg/i8569.check
+++ b/tests/neg/i8569.check
@@ -1,8 +1,12 @@
--- Error: tests/neg/i8569.scala:8:2 ------------------------------------------------------------------------------------
+-- [E083] Type Error: tests/neg/i8569.scala:8:2 ------------------------------------------------------------------------
 8 |  outer.Inner(2) // error
   |  ^^^^^
-  |  (Test.outer : => Outer) is not a valid path
--- Error: tests/neg/i8569.scala:9:6 ------------------------------------------------------------------------------------
+  |  (Test.outer : => Outer) is not a valid type prefix, since it is not an immutable path
+
+longer explanation available when compiling with `-explain`
+-- [E083] Type Error: tests/neg/i8569.scala:9:6 ------------------------------------------------------------------------
 9 |  new outer.Inner(2) // error
   |      ^^^^^
-  |      (Test.outer : => Outer) is not a valid path
+  |      (Test.outer : => Outer) is not a valid type prefix, since it is not an immutable path
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i8569.check
+++ b/tests/neg/i8569.check
@@ -1,0 +1,8 @@
+-- Error: tests/neg/i8569.scala:8:2 ------------------------------------------------------------------------------------
+8 |  outer.Inner(2) // error
+  |  ^^^^^
+  |  (Test.outer : => Outer) is not a valid path
+-- Error: tests/neg/i8569.scala:9:6 ------------------------------------------------------------------------------------
+9 |  new outer.Inner(2) // error
+  |      ^^^^^
+  |      (Test.outer : => Outer) is not a valid path

--- a/tests/neg/i8569.scala
+++ b/tests/neg/i8569.scala
@@ -1,0 +1,10 @@
+class Outer(x: Int) {
+  class Inner(y: Int) {
+  }
+}
+object Test {
+  def outer = Outer(1)
+
+  outer.Inner(2) // error
+  new outer.Inner(2) // error
+}


### PR DESCRIPTION
Don't just fall-back to say "not a member".
