### PR TITLE
Fix #8371: Use bootstrapped genDocs

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -409,6 +409,8 @@ object Build {
 
     javaOptions ++= (javaOptions in `dotty-compiler`).value,
 
+    javaOptions += "-Xss3m",
+
     genDocs := Def.inputTaskDyn {
       val dottydocExtraArgs = spaceDelimited("<arg>").parsed
 

--- a/project/scripts/genDocs
+++ b/project/scripts/genDocs
@@ -19,7 +19,7 @@ echo "Working directory: $PWD"
 
 # this command will generate docs in $PWD/docs/_site
 SBT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/sbt"
-"$SBT" "genDocs $GENDOC_EXTRA_ARGS"
+"$SBT" "dotty-bootstrapped/genDocs $GENDOC_EXTRA_ARGS"
 
 # make sure that the previous command actually succeeded
 if [ ! -d "$PWD/docs/_site" ]; then


### PR DESCRIPTION
Fix issue generating nightly docs in https://github.com/lampepfl/dotty/runs/524910006?check_suite_focus=true