### PR TITLE
Keep track of method parameter symbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -94,6 +94,7 @@ class TreeTypeMap(
           val (tmap1, tparams1) = transformDefs(ddef.tparams)
           val (tmap2, vparamss1) = tmap1.transformVParamss(vparamss)
           val res = cpy.DefDef(ddef)(name, tparams1, vparamss1, tmap2.transform(tpt), tmap2.transform(ddef.rhs))
+          res.symbol.setParamssFromDefs(tparams1, vparamss1)
           res.symbol.transformAnnotations {
             case ann: BodyAnnotation => ann.derivedAnnotation(transform(ann.tree))
             case ann => ann

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -227,21 +227,21 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   /** A DefDef with given method symbol `sym`.
    *  @rhsFn  A function from type parameter types and term parameter references
    *          to the method's right-hand side.
-   *  Parameter symbols are taken from the `paramss` field of `sym`, or
-   *  are freshly generated if `paramss` is empty.
+   *  Parameter symbols are taken from the `rawParamss` field of `sym`, or
+   *  are freshly generated if `rawParamss` is empty.
    */
   def polyDefDef(sym: TermSymbol, rhsFn: List[Type] => List[List[Tree]] => Tree)(implicit ctx: Context): DefDef = {
 
     val (tparams, existingParamss, mtp) = sym.info match {
       case tp: PolyType =>
-        val (tparams, existingParamss) = sym.paramss match
+        val (tparams, existingParamss) = sym.rawParamss match
           case tparams :: vparamss =>
             assert(tparams.hasSameLengthAs(tp.paramNames) && tparams.head.isType)
             (tparams.asInstanceOf[List[TypeSymbol]], vparamss)
           case _ =>
             (ctx.newTypeParams(sym, tp.paramNames, EmptyFlags, tp.instantiateParamInfos(_)), Nil)
         (tparams, existingParamss, tp.instantiate(tparams map (_.typeRef)))
-      case tp => (Nil, sym.paramss, tp)
+      case tp => (Nil, sym.rawParamss, tp)
     }
 
     def valueParamss(tp: Type, existingParamss: List[List[Symbol]]): (List[List[TermSymbol]], Type) = tp match {

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -208,6 +208,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   def DefDef(sym: TermSymbol, tparams: List[TypeSymbol], vparamss: List[List[TermSymbol]],
              resultType: Type, rhs: Tree)(implicit ctx: Context): DefDef =
+    sym.setParamss(tparams, vparamss)
     ta.assignType(
       untpd.DefDef(
         sym.name,
@@ -223,15 +224,27 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def DefDef(sym: TermSymbol, rhsFn: List[List[Tree]] => Tree)(implicit ctx: Context): DefDef =
     polyDefDef(sym, Function.const(rhsFn))
 
+  /** A DefDef with given method symbol `sym`.
+   *  @rhsFn  A function from type parameter types and term parameter references
+   *          to the method's right-hand side.
+   *  Parameter symbols are taken from the `paramss` field of `sym`, or
+   *  are freshly generated if `paramss` is empty.
+   */
   def polyDefDef(sym: TermSymbol, rhsFn: List[Type] => List[List[Tree]] => Tree)(implicit ctx: Context): DefDef = {
-    val (tparams, mtp) = sym.info match {
+
+    val (tparams, existingParamss, mtp) = sym.info match {
       case tp: PolyType =>
-        val tparams = ctx.newTypeParams(sym, tp.paramNames, EmptyFlags, tp.instantiateParamInfos(_))
-        (tparams, tp.instantiate(tparams map (_.typeRef)))
-      case tp => (Nil, tp)
+        val (tparams, existingParamss) = sym.paramss match
+          case tparams :: vparamss =>
+            assert(tparams.hasSameLengthAs(tp.paramNames) && tparams.head.isType)
+            (tparams.asInstanceOf[List[TypeSymbol]], vparamss)
+          case _ =>
+            (ctx.newTypeParams(sym, tp.paramNames, EmptyFlags, tp.instantiateParamInfos(_)), Nil)
+        (tparams, existingParamss, tp.instantiate(tparams map (_.typeRef)))
+      case tp => (Nil, sym.paramss, tp)
     }
 
-    def valueParamss(tp: Type): (List[List[TermSymbol]], Type) = tp match {
+    def valueParamss(tp: Type, existingParamss: List[List[Symbol]]): (List[List[TermSymbol]], Type) = tp match {
       case tp: MethodType =>
         val isParamDependent = tp.isParamDependent
         val previousParamRefs = if (isParamDependent) mutable.ListBuffer[TermRef]() else null
@@ -254,14 +267,23 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
             makeSym(origInfo)
         }
 
-        val params = tp.paramNames.lazyZip(tp.paramInfos).map(valueParam)
-        val (paramss, rtp) = valueParamss(tp.instantiate(params map (_.termRef)))
+        val (params, existingParamss1) =
+          if tp.paramInfos.isEmpty then (Nil, existingParamss)
+          else existingParamss match
+            case vparams :: existingParamss1 =>
+              assert(vparams.hasSameLengthAs(tp.paramNames) && vparams.head.isTerm)
+              (vparams.asInstanceOf[List[TermSymbol]], existingParamss1)
+            case _ =>
+              (tp.paramNames.lazyZip(tp.paramInfos).map(valueParam), Nil)
+        val (paramss, rtp) =
+          valueParamss(tp.instantiate(params map (_.termRef)), existingParamss1)
         (params :: paramss, rtp)
       case tp => (Nil, tp.widenExpr)
     }
-    val (vparamss, rtp) = valueParamss(mtp)
+    val (vparamss, rtp) = valueParamss(mtp, existingParamss)
     val targs = tparams map (_.typeRef)
     val argss = vparamss.nestedMap(vparam => Ident(vparam.termRef))
+    sym.setParamss(tparams, vparamss)
     DefDef(sym, tparams, vparamss, rtp, rhsFn(targs)(argss))
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -576,6 +576,7 @@ object Flags {
   val SyntheticGivenMethod: FlagSet          = Synthetic | Given | Method
   val SyntheticModule: FlagSet               = Synthetic | Module
   val SyntheticOpaque: FlagSet               = Synthetic | Opaque
+  val SyntheticParam: FlagSet                = Synthetic | Param
   val SyntheticTermParam: FlagSet            = Synthetic | TermParam
   val SyntheticTypeParam: FlagSet            = Synthetic | TypeParam
 }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -786,9 +786,10 @@ class TreeUnpickler(reader: TastyReader,
         ta.assignType(untpd.ValDef(sym.name.asTermName, tpt, readRhs(localCtx)), sym)
 
       def DefDef(tparams: List[TypeDef], vparamss: List[List[ValDef]], tpt: Tree) =
-         ta.assignType(
-            untpd.DefDef(sym.name.asTermName, tparams, vparamss, tpt, readRhs(localCtx)),
-            sym)
+        sym.setParamssFromDefs(tparams, vparamss)
+        ta.assignType(
+          untpd.DefDef(sym.name.asTermName, tparams, vparamss, tpt, readRhs(localCtx)),
+          sym)
 
       def TypeDef(rhs: Tree) =
         ta.assignType(untpd.TypeDef(sym.name.asTypeName, rhs), sym)

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -176,7 +176,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
   /** A map from symbols to their associated `decls` scopes */
   private val symScopes = mutable.AnyRefMap[Symbol, Scope]()
 
-  /** A dummy buffer to pass to `readType` when no `paramss` are collected */
+  /** A dummy buffer to pass to `readType` when no `rawParamss` are collected */
   private val throwAwayBuffer = new ListBuffer[List[Symbol]]
 
   protected def errorBadSignature(msg: String, original: Option[RuntimeException] = None)(implicit ctx: Context): Nothing = {
@@ -581,7 +581,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
           if denot.is(Method) then new ListBuffer[List[Symbol]]
           else throwAwayBuffer
         val tp = at(inforef, () => readType(paramssBuf)(ctx))
-        if denot.is(Method) then denot.paramss = paramssBuf.toList
+        if denot.is(Method) then denot.rawParamss = paramssBuf.toList
 
         denot match {
           case denot: ClassDenotation if !isRefinementClass(denot.symbol) =>

--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -89,7 +89,7 @@ abstract class Message(val errorId: ErrorMessageID) { self =>
    *  they look weird and are normally follow-up errors to something that was
    *  diagnosed before.
    */
-   def isNonSensical: Boolean = { message; myIsNonSensical }
+  def isNonSensical: Boolean = { message; myIsNonSensical }
 
   /** The implicit `Context` in messages is a large thing that we don't want
     * persisted. This method gets around that by duplicating the message,

--- a/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
@@ -97,8 +97,10 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
   override def transformDefDef(tree: DefDef)(implicit ctx: Context): DefDef = {
     val sym = tree.symbol
     if (sym.isConstructor && sym.owner.derivesFromJavaEnum)
-      cpy.DefDef(tree)(
+      val tree1 = cpy.DefDef(tree)(
         vparamss = tree.vparamss.init :+ (tree.vparamss.last ++ addedParams(sym, Param)))
+      sym.setParamssFromDefs(tree1.tparams, tree1.vparamss)
+      tree1
     else if (sym.name == nme.DOLLAR_NEW && sym.owner.linkedClass.derivesFromJavaEnum) {
       val Block((tdef @ TypeDef(tpnme.ANON_CLASS, templ: Template)) :: Nil, call) = tree.rhs
       val args = tree.vparamss.last.takeRight(2).map(param => ref(param.symbol)).reverse

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -422,6 +422,14 @@ class TreeChecker extends Phase with SymTransformer {
     }
 
     override def typedDefDef(ddef: untpd.DefDef, sym: Symbol)(implicit ctx: Context): Tree =
+      def defParamss =
+        (ddef.tparams :: ddef.vparamss).filter(!_.isEmpty).map(_.map(_.symbol))
+      def layout(symss: List[List[Symbol]]): String =
+        symss.map(syms => i"($syms%, %)").mkString
+      assert(ctx.erasedTypes || sym.paramss == defParamss,
+        i"""param mismatch for ${sym.showLocated}:
+           |defined in tree  = ${layout(defParamss)}
+           |stored in symbol = ${layout(sym.paramss)}""")
       withDefinedSyms(ddef.tparams) {
         withDefinedSyms(ddef.vparamss.flatten) {
           if (!sym.isClassConstructor && !(sym.name eq nme.STATIC_CONSTRUCTOR))

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -426,10 +426,10 @@ class TreeChecker extends Phase with SymTransformer {
         (ddef.tparams :: ddef.vparamss).filter(!_.isEmpty).map(_.map(_.symbol))
       def layout(symss: List[List[Symbol]]): String =
         symss.map(syms => i"($syms%, %)").mkString
-      assert(ctx.erasedTypes || sym.paramss == defParamss,
+      assert(ctx.erasedTypes || sym.rawParamss == defParamss,
         i"""param mismatch for ${sym.showLocated}:
            |defined in tree  = ${layout(defParamss)}
-           |stored in symbol = ${layout(sym.paramss)}""")
+           |stored in symbol = ${layout(sym.rawParamss)}""")
       withDefinedSyms(ddef.tparams) {
         withDefinedSyms(ddef.vparamss.flatten) {
           if (!sym.isClassConstructor && !(sym.name eq nme.STATIC_CONSTRUCTOR))

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1553,6 +1553,7 @@ class Namer { typer: Typer =>
     vparamss foreach completeParams
     def typeParams = tparams map symbolOfTree
     val termParamss = ctx.normalizeIfConstructor(vparamss.nestedMap(symbolOfTree), isConstructor)
+    sym.setParamss(typeParams, termParamss)
     def wrapMethType(restpe: Type): Type = {
       instantiateDependent(restpe, typeParams, termParamss)
       ctx.methodType(tparams map symbolOfTree, termParamss, restpe, isJava = ddef.mods.is(JavaDefined))


### PR DESCRIPTION
Store the parameter symbols of a method in a `paramss`
field of the method symbol.

Parameter symbols are kept up-to-date until erasure.