### PR TITLE
Fixes typo in documentation to erased terms

### DIFF
--- a/docs/docs/reference/metaprogramming/erased-terms.md
+++ b/docs/docs/reference/metaprogramming/erased-terms.md
@@ -18,7 +18,7 @@ sealed trait State
 final class On extends State
 final class Off extends State
 
-@implicitNotFound("State is must be Off")
+@implicitNotFound("State must be Off")
 class IsOff[S <: State]
 object IsOff {
   implicit def isOff: IsOff[Off] = new IsOff[Off]
@@ -32,7 +32,7 @@ val m = new Machine[Off]
 m.turnedOn
 m.turnedOn.turnedOn // ERROR
 //                 ^
-//                  State is must be Off
+//                  State must be Off
 ```
 
 Note that in the code above the actual context arguments for `IsOff` are never
@@ -118,14 +118,14 @@ sealed trait State
 final class On extends State
 final class Off extends State
 
-@implicitNotFound("State is must be Off")
+@implicitNotFound("State must be Off")
 class IsOff[S <: State]
 object IsOff {
   // will not be called at runtime for turnedOn, the compiler will only require that this evidence exists
   given IsOff[Off] = new IsOff[Off]
 }
 
-@implicitNotFound("State is must be On")
+@implicitNotFound("State must be On")
 class IsOn[S <: State]
 object IsOn {
   // will not exist at runtime, the compiler will only require that this evidence exists at compile time
@@ -150,11 +150,11 @@ object Test {
 
     // m.turnedOff
     //            ^
-    //            State is must be On
+    //            State must be On
 
     // m.turnedOn.turnedOn
     //                    ^
-    //                    State is must be Off
+    //                    State must be Off
   }
 }
 ```

--- a/tests/run-custom-args/erased/erased-machine-state.scala
+++ b/tests/run-custom-args/erased/erased-machine-state.scala
@@ -4,7 +4,7 @@ sealed trait State
 final class On extends State
 final class Off extends State
 
-@implicitNotFound("State is must be Off")
+@implicitNotFound("State must be Off")
 class IsOff[S <: State]
 object IsOff {
   implicit def isOff: IsOff[Off] = {
@@ -13,7 +13,7 @@ object IsOff {
   }
 }
 
-@implicitNotFound("State is must be On")
+@implicitNotFound("State must be On")
 class IsOn[S <: State]
 object IsOn {
   implicit def isOn: IsOn[On] = {
@@ -48,10 +48,10 @@ object Test {
 
     // m.turnedOff
     //            ^
-    //            State is must be On
+    //            State must be On
 
     // m.turnedOn.turnedOn
     //                    ^
-    //                    State is must be Off
+    //                    State must be Off
   }
 }


### PR DESCRIPTION
Fix of a code typo in erased terms documentation and in a related test.