### PR TITLE
Elide calls `Printers.noPrinter.println`

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Printers.scala
+++ b/compiler/src/dotty/tools/dotc/config/Printers.scala
@@ -7,42 +7,42 @@ object Printers {
   }
 
   object noPrinter extends Printer {
-    override def println(msg: => String): Unit = ()
+    inline override def println(inline msg: => String): Unit = ()
   }
 
-  val default: Printer = new Printer
+  val default = new Printer
 
-  val constr: Printer = noPrinter
-  val core: Printer = noPrinter
-  val checks: Printer = noPrinter
-  val config: Printer = noPrinter
-  val cyclicErrors: Printer = noPrinter
-  val debug = noPrinter             // no type annotation here to force inlining
-  val derive: Printer = noPrinter
-  val desugar: Printer = noPrinter
-  val dottydoc: Printer = noPrinter
-  val exhaustivity: Printer = noPrinter
-  val gadts: Printer = noPrinter
-  val gadtsConstr: Printer = noPrinter
-  val hk: Printer = noPrinter
-  val implicits: Printer = noPrinter
-  val implicitsDetailed: Printer = noPrinter
-  val lexical: Printer = noPrinter
-  val init: Printer = noPrinter
-  val inlining: Printer = noPrinter
-  val interactiv: Printer = noPrinter
-  val nullables: Printer = noPrinter
-  val overload: Printer = noPrinter
-  val patmatch: Printer = noPrinter
-  val pickling: Printer = noPrinter
-  val quotePickling: Printer = noPrinter
-  val plugins: Printer = noPrinter
-  val simplify: Printer = noPrinter
-  val staging: Printer = noPrinter
-  val subtyping: Printer = noPrinter
-  val tailrec: Printer = noPrinter
-  val transforms: Printer = noPrinter
-  val typr: Printer = noPrinter
-  val unapp: Printer = noPrinter
-  val variances: Printer = noPrinter
+  val constr = noPrinter
+  val core = noPrinter
+  val checks = noPrinter
+  val config = noPrinter
+  val cyclicErrors = noPrinter
+  val debug = noPrinter
+  val derive = noPrinter
+  val desugar = noPrinter
+  val dottydoc = noPrinter
+  val exhaustivity = noPrinter
+  val gadts = noPrinter
+  val gadtsConstr = noPrinter
+  val hk = noPrinter
+  val implicits = noPrinter
+  val implicitsDetailed = noPrinter
+  val lexical = noPrinter
+  val init = noPrinter
+  val inlining = noPrinter
+  val interactiv = noPrinter
+  val nullables = noPrinter
+  val overload = noPrinter
+  val patmatch = noPrinter
+  val pickling = noPrinter
+  val quotePickling = noPrinter
+  val plugins = noPrinter
+  val simplify = noPrinter
+  val staging = noPrinter
+  val subtyping = noPrinter
+  val tailrec = noPrinter
+  val transforms = noPrinter
+  val typr = noPrinter
+  val unapp = noPrinter
+  val variances = noPrinter
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -62,7 +62,7 @@ object MyScalaJSPlugin extends AutoPlugin {
 }
 
 object Build {
-  val referenceVersion = "0.24.0-bin-20200321-4df9b6f-NIGHTLY"
+  val referenceVersion = "0.24.0-bin-20200325-37eec14-NIGHTLY"
 
   val baseVersion = "0.24.0"
   val baseSbtDottyVersion = "0.4.0"


### PR DESCRIPTION
Eliminates any explicit call to `myPrinter.println` if we know that `myPrinter: noPrinter.type`. This happens for all the printers defined in `Printers.scala`.