### PR TITLE
Turn mismatch given errors into given not found errors

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -390,6 +390,7 @@ class Definitions {
     @tu lazy val Predef_undefined: Symbol = ScalaPredefModule.requiredMethod(nme.???)
 
   def SubTypeClass(implicit ctx: Context): ClassSymbol = ctx.requiredClass("scala.<:<")
+  @tu lazy val SubType_refl: Symbol = SubTypeClass.companionModule.requiredMethod(nme.refl)
 
   def DummyImplicitClass(implicit ctx: Context): ClassSymbol = ctx.requiredClass("scala.DummyImplicit")
 

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -549,6 +549,7 @@ object StdNames {
     val productIterator: N      = "productIterator"
     val productPrefix: N        = "productPrefix"
     val raw_ : N                = "raw"
+    val refl: N                 = "refl"
     val reflect: N              = "reflect"
     val reflectiveSelectable: N = "reflectiveSelectable"
     val reify : N               = "reify"

--- a/tests/neg/implicitSearch.check
+++ b/tests/neg/implicitSearch.check
@@ -1,0 +1,13 @@
+-- Error: tests/neg/implicitSearch.scala:13:12 -------------------------------------------------------------------------
+13 |    sort(xs)  // error (with a partially constructed implicit argument shown)
+   |            ^
+   |   no implicit argument of type Test.Ord[List[List[T]]] was found for parameter o of method sort in object Test.
+   |   I found:
+   |
+   |       Test.listOrd[T](Test.listOrd[T](/* missing */implicitly[Test.Ord[T]]))
+   |
+   |   But no implicit values were found that match type Test.Ord[T].
+-- Error: tests/neg/implicitSearch.scala:15:38 -------------------------------------------------------------------------
+15 |    listOrd(listOrd(implicitly[Ord[T]] /*not found*/)) // error
+   |                                      ^
+   |  no implicit argument of type Test.Ord[T] was found for parameter ev of method implicitly in object DottyPredef

--- a/tests/neg/implicitSearch.scala
+++ b/tests/neg/implicitSearch.scala
@@ -1,7 +1,5 @@
 object Test {
 
-  type T = String
-
   class Ord[T]
   implicit def listOrd[T](implicit o: Ord[T]): Ord[List[T]] = ???
   implicit def intOrd: Ord[Int] = ???

--- a/tests/neg/missing-implicit3.check
+++ b/tests/neg/missing-implicit3.check
@@ -1,0 +1,14 @@
+-- Error: tests/neg/missing-implicit3.scala:13:36 ----------------------------------------------------------------------
+13 |val sortedFoos = sort(List(new Foo)) // error
+   |                                    ^
+   |no implicit argument of type ord.Ord[ord.Foo] was found for an implicit parameter of method sort in package ord.
+   |I found:
+   |
+   |    ord.Ord.ordered[A](/* missing */implicitly[ord.Foo => Comparable[? >: ord.Foo]])
+   |
+   |But no implicit values were found that match type ord.Foo => Comparable[? >: ord.Foo].
+   |
+   |The following import might make progress towards fixing the problem:
+   |
+   |  import ord.Ord.ordered
+   |         

--- a/tests/neg/missing-implicit3.scala
+++ b/tests/neg/missing-implicit3.scala
@@ -1,0 +1,13 @@
+package ord
+
+trait Ord[A]
+
+object Ord {
+  given ordered[A](using A => java.lang.Comparable[? >: A]) as Ord[A] = ???
+}
+
+def sort[A: Ord](as: List[A]): List[A] = ???
+
+class Foo
+
+val sortedFoos = sort(List(new Foo)) // error

--- a/tests/neg/subtyping.check
+++ b/tests/neg/subtyping.check
@@ -1,18 +1,8 @@
 -- Error: tests/neg/subtyping.scala:8:27 -------------------------------------------------------------------------------
 8 |    implicitly[B#X <:< A#X] // error: no implicit argument
   |                           ^
-  |                           Cannot prove that B#X <:< A#X..
-  |                           I found:
-  |
-  |                               <:<.refl[Nothing]
-  |
-  |                           But method refl in object <:< does not match type B#X <:< A#X.
+  |                           Cannot prove that B#X <:< A#X.
 -- Error: tests/neg/subtyping.scala:12:27 ------------------------------------------------------------------------------
 12 |    implicitly[a.T <:< a.U] // error: no implicit argument
    |                           ^
-   |                           Cannot prove that a.T <:< a.U..
-   |                           I found:
-   |
-   |                               <:<.refl[Nothing]
-   |
-   |                           But method refl in object <:< does not match type a.T <:< a.U.
+   |                           Cannot prove that a.T <:< a.U.

--- a/tests/neg/summon-function.check
+++ b/tests/neg/summon-function.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/summon-function.scala:2:23 -------------------------------------------------------------------------
+2 |  summon[Int => String] // error
+  |                       ^
+  |                       No implicit view available from Int => String.

--- a/tests/neg/summon-function.scala
+++ b/tests/neg/summon-function.scala
@@ -1,0 +1,3 @@
+object Test {
+  summon[Int => String] // error
+}


### PR DESCRIPTION
Fixes #8053

When a given candidate turns out to not be applicable we used to report that
there is a mismatch between the candidate type and the expected type.

However, I believe that if there is a type mismatch, then the candidate should
not be a candidate in the first place.

I’ve changed the failure to be a `NoMatchingImplicitsFailure` instead of a mismatch.

Hopefully this won’t have a negative impact. I’ve added a couple of tests that used to
report a mismatch for the "candidate" `$conforms[Nothing]` and they now report that
no given could be found. One existing test was broken by my changes. This test was
very similar to the ones described in #8053, so I’ve changed the test expectation.