### PR TITLE
Upgrade to sbt 1.3.8 from 1.3.6.

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -106,7 +106,7 @@ final case class SbtCommunityProject(
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
     extraSbtArgs ++ sbtProps ++ List(
-      "-sbt-version", "1.3.6",
+      "-sbt-version", "1.3.8",
       s"--addPluginSbtFile=$sbtPluginFilePath")
 
 object projects:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -196,9 +196,7 @@ object Build {
       state
     },
 
-    // Turn off the sbt supershell because it can mangle the output of some tasks
-    // (see https://github.com/sbt/sbt/issues/5122, https://github.com/sbt/sbt/issues/5352)
-    // and in general I find it more distracting than helpful anyway.
+    // I find supershell more distracting than helpful
     useSuperShell := false,
 
     // Credentials to release to Sonatype

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.3.8


### PR DESCRIPTION
* https://github.com/sbt/sbt/issues/5352 was fixed in 1.3.7, hence the change in the comment about supershell.
* https://github.com/sbt/sbt/issues/5224 was fixed in 1.3.8, which fixes the build on Windows.

---

This is a revival of #8027.
This change is necessary to be able to do *anything* on Windows.