### PR TITLE
Fix #8619: Demand `transparent` for whitebox inlines

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -203,13 +203,7 @@ object desugar {
    *      def f$default$1[T] = 1
    *      def f$default$2[T](x: Int) = x + "m"
    *
-   *  3. Convert <: T to : T in specializing inline methods. E.g.
-   *
-   *      inline def f(x: Boolean) <: Any = if (x) 1 else ""
-   *  ==>
-   *      inline def f(x: Boolean): Any = if (x) 1 else ""
-   *
-   *  4. Upcast non-specializing inline methods. E.g.
+   *  3. Upcast non-specializing inline methods. E.g.
    *
    *      inline def f(x: Boolean): Any = if (x) 1 else ""
    *  ==>

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -247,17 +247,8 @@ object desugar {
       cpy.TypeDef(tparam)(rhs = desugarContextBounds(tparam.rhs))
     }
 
-    var meth1 = addEvidenceParams(
+    val meth1 = addEvidenceParams(
       cpy.DefDef(meth)(name = methName, tparams = tparams1), epbuf.toList)
-
-    if (meth1.mods.is(Inline))
-      meth1.tpt match {
-        case TypeBoundsTree(_, tpt1, _) =>
-          meth1 = cpy.DefDef(meth1)(tpt = tpt1)
-        case tpt if !tpt.isEmpty && !meth1.rhs.isEmpty =>
-          meth1 = cpy.DefDef(meth1)(rhs = Typed(meth1.rhs, tpt))
-        case _ =>
-      }
 
     /** The longest prefix of parameter lists in vparamss whose total length does not exceed `n` */
     def takeUpTo(vparamss: List[List[ValDef]], n: Int): List[List[ValDef]] = vparamss match {

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -202,12 +202,6 @@ object desugar {
    *      def f[T](x: Int)(y: String)(implicit evidence$0: B[T]) = ...
    *      def f$default$1[T] = 1
    *      def f$default$2[T](x: Int) = x + "m"
-   *
-   *  3. Upcast non-specializing inline methods. E.g.
-   *
-   *      inline def f(x: Boolean): Any = if (x) 1 else ""
-   *  ==>
-   *      inline def f(x: Boolean): Any = (if (x) 1 else ""): Any
    */
   private def defDef(meth0: DefDef, isPrimaryConstructor: Boolean = false)(implicit ctx: Context): Tree = {
     val meth @ DefDef(_, tparams, vparamss, tpt, rhs) = transformQuotedPatternName(meth0)

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -195,6 +195,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     case class Lazy()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Lazy)
 
     case class Inline()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Inline)
+
+    case class Transparent()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.EmptyFlags)
   }
 
   /** Modifiers and annotations for definitions
@@ -326,7 +328,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     def derivedTree(originalSym: Symbol)(implicit ctx: Context): tpd.Tree
   }
 
-    /** Property key containing TypeTrees whose type is computed
+  /** Property key containing TypeTrees whose type is computed
    *  from the symbol in this type. These type trees have marker trees
    *  TypeRefOfSym or InfoOfSym as their originals.
    */

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -593,6 +593,7 @@ object StdNames {
     val toString_ : N           = "toString"
     val toTypeConstructor: N    = "toTypeConstructor"
     val tpe : N                 = "tpe"
+    val transparent : N         = "transparent"
     val tree : N                = "tree"
     val true_ : N               = "true"
     val typedProductIterator: N = "typedProductIterator"

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -33,6 +33,8 @@ object Parsers {
   import reporting.Message
   import reporting.messages._
 
+  val AllowOldWhiteboxSyntax = true
+
   case class OpInfo(operand: Tree, operator: Ident, offset: Offset)
 
   class ParensCounters {
@@ -3253,7 +3255,7 @@ object Parsers {
           case rparamss =>
             leadingVparamss ::: rparamss
         var tpt = fromWithinReturnType {
-          if in.token == SUBTYPE && mods.is(Inline) then
+          if in.token == SUBTYPE && mods.is(Inline) && AllowOldWhiteboxSyntax then
             in.nextToken()
             mods1 = addMod(mods1, Mod.Transparent())
             toplevelTyp()
@@ -3522,7 +3524,7 @@ object Parsers {
           accept(EQUALS)
           mods1 |= Final
           DefDef(name, tparams, vparamss, tpt, subExpr())
-        if in.token == USCORE then
+        if in.token == USCORE && AllowOldWhiteboxSyntax then
           if !mods.is(Inline) then
             syntaxError("`_ <:` is only allowed for given with `inline` modifier")
           in.nextToken()

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2692,6 +2692,7 @@ object Parsers {
           case nme.inline => Mod.Inline()
           case nme.opaque => Mod.Opaque()
           case nme.open => Mod.Open()
+          case nme.transparent => Mod.Transparent()
         }
     }
 
@@ -2748,7 +2749,7 @@ object Parsers {
      *                  |  AccessModifier
      *                  |  override
      *                  |  opaque
-     *  LocalModifier  ::= abstract | final | sealed | open | implicit | lazy | erased | inline
+     *  LocalModifier  ::= abstract | final | sealed | open | implicit | lazy | erased | inline | transparent
      */
     def modifiers(allowed: BitSet = modifierTokens, start: Modifiers = Modifiers()): Modifiers = {
       @tailrec
@@ -2766,7 +2767,11 @@ object Parsers {
         }
         else
           mods
-      normalize(loop(start))
+      val result = normalize(loop(start))
+      for case mod @ Mod.Transparent() <- result.mods do
+        if !result.is(Inline) then
+          syntaxError(em"`transparent` can only be used in conjunction with `inline`", mod.span)
+      result
     }
 
     val funTypeArgMods: BitSet = BitSet(ERASED)
@@ -3250,7 +3255,8 @@ object Parsers {
         var tpt = fromWithinReturnType {
           if in.token == SUBTYPE && mods.is(Inline) then
             in.nextToken()
-            TypeBoundsTree(EmptyTree, toplevelTyp())
+            mods1 = addMod(mods1, Mod.Transparent())
+            toplevelTyp()
           else typedOpt()
         }
         if (in.isScala2CompatMode) newLineOptWhenFollowedBy(LBRACE)
@@ -3521,7 +3527,8 @@ object Parsers {
             syntaxError("`_ <:` is only allowed for given with `inline` modifier")
           in.nextToken()
           accept(SUBTYPE)
-          givenAlias(TypeBoundsTree(EmptyTree, toplevelTyp()))
+          mods1 = addMod(mods1, Mod.Transparent())
+          givenAlias(toplevelTyp())
         else
           val parents = constrApps(commaOK = true, templateCanFollow = true)
           if in.token == EQUALS && parents.length == 1 && parents.head.isType then

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -282,5 +282,5 @@ object Tokens extends TokensCommon {
 
   final val scala3keywords = BitSet(ENUM, ERASED, GIVEN)
 
-  final val softModifierNames = Set(nme.inline, nme.opaque, nme.open)
+  final val softModifierNames = Set(nme.inline, nme.opaque, nme.open, nme.transparent)
 }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -864,7 +864,9 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     val rawFlags = if (sym.exists) sym.flags else mods.flags
     if (rawFlags.is(Param)) flagMask = flagMask &~ Given
     val flags = rawFlags & flagMask
-    val flagsText = toTextFlags(sym, flags)
+    var flagsText = toTextFlags(sym, flags)
+    if mods.hasMod(classOf[untpd.Mod.Transparent]) then
+      flagsText = "transparent " ~ flagsText
     val annotations =
       if (sym.exists) sym.annotations.filterNot(ann => dropAnnotForModText(ann.symbol)).map(_.tree)
       else mods.annotations.filterNot(tree => dropAnnotForModText(tree.symbol))

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -865,8 +865,7 @@ class Namer { typer: Typer =>
       case original: untpd.DefDef if sym.isInlineMethod =>
         def rhsToInline(using Context): tpd.Tree =
           val mdef = typedAheadExpr(original).asInstanceOf[tpd.DefDef]
-          if original.mods.hasMod(classOf[untpd.Mod.Transparent]) then mdef.rhs
-          else tpd.Typed(mdef.rhs, mdef.tpt)
+          PrepareInlineable.wrapRHS(original, mdef.tpt, mdef.rhs)
         PrepareInlineable.registerInlineInfo(sym, rhsToInline)(localContext(sym))
       case _ =>
     }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -863,10 +863,11 @@ class Namer { typer: Typer =>
 
     private def addInlineInfo(sym: Symbol) = original match {
       case original: untpd.DefDef if sym.isInlineMethod =>
-        PrepareInlineable.registerInlineInfo(
-            sym,
-            implicit ctx => typedAheadExpr(original).asInstanceOf[tpd.DefDef].rhs
-          )(localContext(sym))
+        def rhsToInline(using Context): tpd.Tree =
+          val mdef = typedAheadExpr(original).asInstanceOf[tpd.DefDef]
+          if original.mods.hasMod(classOf[untpd.Mod.Transparent]) then mdef.rhs
+          else tpd.Typed(mdef.rhs, mdef.tpt)
+        PrepareInlineable.registerInlineInfo(sym, rhsToInline)(localContext(sym))
       case _ =>
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
@@ -206,7 +206,7 @@ object PrepareInlineable {
 
   /** The type ascription `rhs: tpt`, unless `original` is `transparent`. */
   def wrapRHS(original: untpd.DefDef, tpt: Tree, rhs: Tree)(using Context): Tree =
-    if original.mods.mods.exists(_.isInstanceOf[untpd.Mod.Transparent]) then rhs
+    if original.mods.hasMod(classOf[untpd.Mod.Transparent]) then rhs
     else Typed(rhs, tpt)
 
   /** Register inline info for given inlineable method `sym`.
@@ -228,7 +228,7 @@ object PrepareInlineable {
           inlined.updateAnnotation(LazyBodyAnnotation {
             given ctx as Context = inlineCtx
             val initialErrorCount = ctx.reporter.errorCount
-            var inlinedBody = treeExpr(using ctx)
+            var inlinedBody = treeExpr
             if (ctx.reporter.errorCount == initialErrorCount) {
               inlinedBody = ctx.compilationUnit.inlineAccessors.makeInlineable(inlinedBody)
               checkInlineMethod(inlined, inlinedBody)

--- a/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
@@ -204,6 +204,11 @@ object PrepareInlineable {
   def isLocal(sym: Symbol, inlineMethod: Symbol)(implicit ctx: Context): Boolean =
     isLocalOrParam(sym, inlineMethod) && !(sym.is(Param) && sym.owner == inlineMethod)
 
+  /** The type ascription `rhs: tpt`, unless `original` is `transparent`. */
+  def wrapRHS(original: untpd.DefDef, tpt: Tree, rhs: Tree)(using Context): Tree =
+    if original.mods.mods.exists(_.isInstanceOf[untpd.Mod.Transparent]) then rhs
+    else Typed(rhs, tpt)
+
   /** Register inline info for given inlineable method `sym`.
    *
    *  @param sym         The symbol denotation of the inlineable method for which info is registered
@@ -213,7 +218,7 @@ object PrepareInlineable {
    *                     to have the inline method as owner.
    */
   def registerInlineInfo(
-      inlined: Symbol, treeExpr: Context => Tree)(implicit ctx: Context): Unit =
+      inlined: Symbol, treeExpr: Context ?=> Tree)(implicit ctx: Context): Unit =
     inlined.unforcedAnnotation(defn.BodyAnnot) match {
       case Some(ann: ConcreteBodyAnnotation) =>
       case Some(ann: LazyBodyAnnotation) if ann.isEvaluated || ann.isEvaluating =>
@@ -223,7 +228,7 @@ object PrepareInlineable {
           inlined.updateAnnotation(LazyBodyAnnotation {
             given ctx as Context = inlineCtx
             val initialErrorCount = ctx.reporter.errorCount
-            var inlinedBody = treeExpr(ctx)
+            var inlinedBody = treeExpr(using ctx)
             if (ctx.reporter.errorCount == initialErrorCount) {
               inlinedBody = ctx.compilationUnit.inlineAccessors.makeInlineable(inlinedBody)
               checkInlineMethod(inlined, inlinedBody)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1735,9 +1735,10 @@ class Typer extends Namer
 
     if (sym.isInlineMethod) rhsCtx.addMode(Mode.InlineableBody)
     val rhs1 = typedExpr(ddef.rhs, tpt1.tpe.widenExpr)(rhsCtx)
+    val rhsToInline = PrepareInlineable.wrapRHS(ddef, tpt1, rhs1)
 
     if (sym.isInlineMethod)
-      PrepareInlineable.registerInlineInfo(sym, _ => rhs1)
+      PrepareInlineable.registerInlineInfo(sym, rhsToInline)
 
     if (sym.isConstructor && !sym.isPrimaryConstructor) {
       val ename = sym.erasedName

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -356,7 +356,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
     val source = """class Test:
                    |  given Int = 0
                    |  def f(): Int ?=> Boolean = true : (Int ?=> Boolean)
-                   |  inline def g(): Int ?=> Boolean = true
+                   |  transparent inline def g(): Int ?=> Boolean = true
                    |  def test = g()
                  """.stripMargin
 

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -75,7 +75,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
 
   @Test def i4947 = {
     val source = """class Foo {
-                   |  inline def track[T](inline f: T) <: T = {
+                   |  transparent inline def track[T](inline f: T): T = {
                    |    foo("tracking") // line 3
                    |    f // line 4
                    |  }
@@ -134,11 +134,11 @@ class InlineBytecodeTests extends DottyBytecodeTest {
 
   @Test def i4947b = {
     val source = """class Foo {
-                   |  inline def track2[T](inline f: T) <: T = {
+                   |  transparent inline def track2[T](inline f: T): T = {
                    |    foo("tracking2") // line 3
                    |    f // line 4
                    |  }
-                   |  inline def track[T](inline f: T) <: T = {
+                   |  transparent inline def track[T](inline f: T): T = {
                    |    foo("tracking") // line 7
                    |    track2 { // line 8
                    |      f // line 9
@@ -194,11 +194,11 @@ class InlineBytecodeTests extends DottyBytecodeTest {
 
   @Test def i4947c = {
     val source = """class Foo {
-                   |  inline def track2[T](inline f: T) <: T = {
+                   |  transparent inline def track2[T](inline f: T): T = {
                    |    foo("tracking2") // line 3
                    |    f // line 4
                    |  }
-                   |  inline def track[T](inline f: T) <: T = {
+                   |  transparent inline def track[T](inline f: T): T = {
                    |    track2 { // line 7
                    |      foo("fgh") // line 8
                    |      f // line 9
@@ -254,11 +254,11 @@ class InlineBytecodeTests extends DottyBytecodeTest {
 
   @Test def i4947d = {
     val source = """class Foo {
-                   |  inline def track2[T](inline f: T) <: T = {
+                   |  transparent inline def track2[T](inline f: T): T = {
                    |    foo("tracking2") // line 3
                    |    f // line 4
                    |  }
-                   |  inline def track[T](inline f: T) <: T = {
+                   |  transparent inline def track[T](inline f: T): T = {
                    |    track2 { // line 7
                    |      track2 { // line 8
                    |        f // line 9
@@ -319,7 +319,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                    |  def test: Int = {
                    |    var a = 10
                    |
-                   |    inline def f() = {
+                   |    transparent inline def f() = {
                    |      a += 1
                    |    }
                    |

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -104,7 +104,8 @@ yield
 ### Soft keywords
 
 ```
-as        derives   extension inline    on        opaque    open      using
+as        derives   extension inline    on        opaque    open      transparent
+using
 *         +         -
 ```
 

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -79,17 +79,16 @@ given (using config: Config) as Factory = MemoizingFactory(config)
 An alias given can have type parameters and context parameters just like any other given,
 but it can only implement a single type.
 
-## Given Whitebox Macro Instances
+## Given Macros
 
-An `inline` alias given can be marked as a whitebox macro by writing
-`_ <:` in front of the implemented type. Example:
+Given aliases can have the `inline` and `transparent` modifiers.
+Example:
 ```scala
-inline given mkAnnotations[A, T] as _ <: Annotations[A, T] = ${
+transparent inline given mkAnnotations[A, T] as Annotations[A, T] = ${
   // code producing a value of a subtype of Annotations
 }
 ```
-The type of an application of `mkAnnotations` is the type of its right hand side,
-which can be a proper subtype of the declared result type `Annotations[A, T]`.
+Since `mkAnnotations` is `transparent`, the type of an application is the type of its right hand side, which can be a proper subtype of the declared result type `Annotations[A, T]`.
 
 ## Given Instance Initialization
 
@@ -104,7 +103,7 @@ Here is the new syntax for given instances, seen as a delta from the [standard c
 ```
 TmplDef           ::=  ...
                    |   ‘given’ GivenDef
-GivenDef          ::=  [GivenSig] [‘_’ ‘<:’] Type ‘=’ Expr
+GivenDef          ::=  [GivenSig] Type ‘=’ Expr
                    |   [GivenSig] ConstrApp {‘,’ ConstrApp } [TemplateBody]
 GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘as’
 ```

--- a/docs/docs/reference/metaprogramming/erased-terms.md
+++ b/docs/docs/reference/metaprogramming/erased-terms.md
@@ -171,11 +171,11 @@ final class On extends State
 final class Off extends State
 
 class Machine[S <: State] {
-  inline def turnOn() <: Machine[On] = inline erasedValue[S] match {
+  transparent inline def turnOn(): Machine[On] = inline erasedValue[S] match {
     case _: Off  => new Machine[On]
     case _: On   => error("Turning on an already turned on machine")
   }
-  inline def turnOff() <: Machine[Off] = inline erasedValue[S] match {
+  transparent inline def turnOff(): Machine[Off] = inline erasedValue[S] match {
     case _: On  => new Machine[Off]
     case _: Off   => error("Turning off an already turned off machine")
   }

--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -601,7 +601,7 @@ inline method that can calculate either a value of type `Int` or a value of type
 `String`.
 
 ```scala
-inline def defaultOf(inline str: String) <: Any = ${ defaultOfImpl('str) }
+transparent inline def defaultOf(inline str: String) = ${ defaultOfImpl('str) }
 
 def defaultOfImpl(strExpr: Expr[String])(using QuoteContext): Expr[Any] =
   strExpr.unliftOrError match

--- a/tests/disabled/pos/quote-whitebox/Macro_1.scala
+++ b/tests/disabled/pos/quote-whitebox/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 
 object Macro {
 
-  inline def charOrString(inline str: String) <: Char | String = ${ impl(str) }
+  transparent inline def charOrString(inline str: String): Char | String = ${ impl(str) }
 
   def impl(str: String) = if (str.length == 1) Expr(str.charAt(0)) else Expr(str)
 

--- a/tests/explicit-nulls/pos/flow4.scala
+++ b/tests/explicit-nulls/pos/flow4.scala
@@ -6,7 +6,8 @@ class TreeOps {
   abstract class Tree[A, B](val key: A, val value: B)
   class RedTree[A, B](override val key: A, override val value: B) extends Tree[A, B](key, value)
 
-  private[this] inline def isRedTree(tree: Tree[_, _] | Null) = (tree != null) && tree.isInstanceOf[RedTree[_, _]]
+  private transparent inline def isRedTree(tree: Tree[_, _] | Null) =
+    (tree != null) && tree.isInstanceOf[RedTree[_, _]]
 
   def foo[A, B](tree: Tree[A, B] | Null): Unit = {
     if (isRedTree(tree)) {

--- a/tests/invalid/run/typelevel-patmat.scala
+++ b/tests/invalid/run/typelevel-patmat.scala
@@ -21,7 +21,7 @@ object Test extends App {
   type HNil = HNil.type
   type Z = Z.type
 
-  inline def ToNat(inline n: Int) <: Typed[Nat] =
+  transparent inline def ToNat(inline n: Int): Typed[Nat] =
     if n == 0 then Typed(Z)
     else Typed(S(ToNat(n - 1).value))
 
@@ -35,7 +35,7 @@ object Test extends App {
   println(x1)
   println(x2)
 
-  inline def toInt(n: Nat) <: Int = inline n match {
+  transparent inline def toInt(n: Nat): Int = inline n match {
     case Z => 0
     case S(n1) => toInt(n1) + 1
   }

--- a/tests/neg/i7078.scala
+++ b/tests/neg/i7078.scala
@@ -1,7 +1,7 @@
 trait A
 class B extends A
 
-given g1 as _ <: A = B()  // error: `_ <:' is only allowed for given with `inline' modifier // error
+given g1 as _ <: A = B()  // error: `_ <:' is only allowed for given with `inline' modifier
 
 inline given g2 as _ <: A:  // error: `=' expected
   def foo = 2

--- a/tests/neg/specializing-inline.scala
+++ b/tests/neg/specializing-inline.scala
@@ -2,7 +2,7 @@ object Test {
 
   inline def h(x: Boolean) = if (x) 1 else ""
   val z = h(true)
-  val zc: Int = z
+  val zc: Int = z // error
 
   inline def g <: Any = 1
   val y = g

--- a/tests/neg/transparent-inline.scala
+++ b/tests/neg/transparent-inline.scala
@@ -1,0 +1,37 @@
+transparent def bar: Any = 2  // error: transparent can be used only with inline
+
+object test1:
+
+  def x: Int = baz(true) // error: type mismatch
+  inline def baz(x: Boolean): Any =
+    if x then 1 else ""
+  inline def bam(x: Boolean): Any =
+    if x then 1 else ""
+  def y: Int = bam(true) // error: type mismatch
+
+object test2:
+
+  def x: 1 = baz(true) // OK
+  transparent inline def baz(x: Boolean) =
+    if x then 1 else ""
+  transparent inline def bam(x: Boolean) =
+    if x then 1 else ""
+  def y: 1 = bam(true) // OK
+
+object test3:
+
+  def x: Int = baz(true) // error: type mismatch
+  inline def baz(x: Boolean) =
+    if x then 1 else ""
+  inline def bam(x: Boolean) =
+    if x then 1 else ""
+  def y: Int = bam(true) // error: type mismatch
+
+object test4:
+
+  def x: 1 = baz(true) // OK
+  transparent inline def baz(x: Boolean): Any =
+    if x then 1 else ""
+  transparent inline def bam(x: Boolean): Any =
+    if x then 1 else ""
+  def y: 1 = bam(true) // OK

--- a/tests/pos/inline-rewrite.scala
+++ b/tests/pos/inline-rewrite.scala
@@ -1,6 +1,6 @@
 object Test {
 
-  inline def f(x: Int) = inline x match {
+  transparent inline def f(x: Int) = inline x match {
     case 1 => "a"
     case 2 => 22
   }
@@ -9,7 +9,7 @@ object Test {
   val y = f(2)
   val yc: Int = y
 
-  inline def g(x: Any) = inline x match {
+  transparent inline def g(x: Any) = inline x match {
     case x: String => (x, x)
     case x: Double => x
   }

--- a/tests/pos/transparent-inline.scala
+++ b/tests/pos/transparent-inline.scala
@@ -1,0 +1,4 @@
+inline def foo: Any = 1
+inline transparent def bar: Any = 2
+val x: 2 = bar
+

--- a/tests/pos/whitebox-given.scala
+++ b/tests/pos/whitebox-given.scala
@@ -1,0 +1,2 @@
+transparent inline given Int = 1
+val x: 1 = summon[Int]

--- a/tests/run-macros/i7887/Macro_1.scala
+++ b/tests/run-macros/i7887/Macro_1.scala
@@ -12,6 +12,6 @@ def myMacroImpl(a: quoted.Expr[_])(using qctx: quoted.QuoteContext) = {
 }
 
 
-inline def myMacro(a: => Any) = ${
+inline transparent def myMacro(a: => Any) = ${
   myMacroImpl('a)
 }


### PR DESCRIPTION
Previously, whitebox inlines could be declared in three different ways

 1. writing `inline def f <: T = ...` for inline methods
 2. writing `inline given f as _ <: T` = ...` for inline givens
 3. leaving out the result type for inline methods

The last was an oversight, not backed by the spec. It turned out that it
was not that easy to prevent (3), so it was not done, and afterwards
code exploited the loophole.

In the new scheme, "whitebox" inlines demand `transparent`. The result type
can be given or left out, the effect is the same. The old `<:` result type
syntax will be phased out in a subseqent PR once the new syntax is in a release.

`transparent` is a soft modifier. It is valid only together with `inline`. Why not
allow `transparent` on its own and let it subsume `inline`? The point is that
we should steer users firmly towards blackbox macros, since they are much
easier to deal with for tooling. This means we want to make whitebox macros
strictly more verbose than blackbox macros. Otherwise someone might find
`transparent` "nicer" than `inline` and simply use it on these grounds without
realizing (or caring about) the consequences.

For the same reason I did not follow the (otherwise tempting) idea to simply
re-use `opaque` instead of `transparent`. An opaque inline keeps its type on
expansion whereas a transparent one gets the type of its expansion. But that
would have nudged to user to prefer `inline` over `opaque inline`, so would
again have gjven the wrong incentive.

On the other hand, `transparent` as a dual of `opaque` is nice. It fits into
the same terminology. It's simply that type aliases are transparent by default
and have to be made opaque with a modifier, whereas inline methods are opaque
by default, and have to be made transparent by a modifier.