### PR TITLE
Fix #8632: Reveal "not found" message more often

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1060,13 +1060,14 @@ trait Applications extends Compatibility {
       tree
   }
 
-  /** Does `state` contain a single "NotAMember" or "MissingIdent" message as
-   *  pending error message that says `$memberName is not a member of ...` or
-   *  `Not found: $memberName`? If memberName is empty, any name will do.
+  /** Does `state` contain a  "NotAMember" or "MissingIdent" message as
+   *  first pending error message? That message would be
+   *  `$memberName is not a member of ...` or `Not found: $memberName`.
+   *  If memberName is empty, any name will do.
    */
   def saysNotFound(state: TyperState, memberName: Name)(using Context): Boolean =
     state.reporter.pendingMessages match
-      case dia :: Nil =>
+      case dia :: _ =>
         dia.msg match
           case msg: NotFoundMsg => memberName.isEmpty || msg.name == memberName
           case _ => false

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -490,10 +490,10 @@ class Typer extends Namer
         case _ => app
       }
     case qual =>
-      if (tree.name.isTypeName) checkStable(qual.tpe, qual.sourcePos, "type prefix")
       val select = assignType(cpy.Select(tree)(qual, tree.name), qual)
-
       val select1 = toNotNullTermRef(select, pt)
+
+      if (tree.name.isTypeName) checkStable(qual.tpe, qual.sourcePos, "type prefix")
 
       if (select1.tpe ne TryDynamicCallType) ConstFold(checkStableIdentPattern(select1, pt))
       else if (pt.isInstanceOf[FunOrPolyProto] || pt == AssignProto) select1

--- a/tests/neg/i8632.check
+++ b/tests/neg/i8632.check
@@ -1,0 +1,4 @@
+-- [E008] Not Found Error: tests/neg/i8632.scala:2:15 ------------------------------------------------------------------
+2 |  Nil.toString.foo(1) // error
+  |  ^^^^^^^^^^^^^^^^
+  |  value foo is not a member of String

--- a/tests/neg/i8632.scala
+++ b/tests/neg/i8632.scala
@@ -1,0 +1,3 @@
+object Test {
+  Nil.toString.foo(1)
+}

--- a/tests/neg/i8632.scala
+++ b/tests/neg/i8632.scala
@@ -1,3 +1,3 @@
 object Test {
-  Nil.toString.foo(1)
+  Nil.toString.foo(1) // error
 }


### PR DESCRIPTION
If a creator expression is tried, we want to make sure we see a "not found" message,
so that we fall back in this case to reporting the original select failure. To this
purpose

 - we check for stable path prefixes after doing the selection proper
 - we recognize leading not found messages also if they are following by other messages