### PR TITLE
Don't write `(using ctx: Context)`

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/scalaPrimitives.scala
+++ b/compiler/src/dotty/tools/backend/jvm/scalaPrimitives.scala
@@ -4,7 +4,7 @@ package backend.jvm
 import dotc.ast.Trees.Select
 import dotc.ast.tpd._
 import dotc.core._
-import Contexts.Context
+import Contexts.{Context, ctx}
 import Names.TermName, StdNames._
 import Types.{JavaArrayType, UnspecifiedErrorType, Type}
 import Symbols.{Symbol, NoSymbol}
@@ -49,7 +49,7 @@ class DottyPrimitives(ictx: Context) {
    * @param tpe The type of the receiver object. It is used only for array
    *            operations
    */
-  def getPrimitive(app: Apply, tpe: Type)(implicit ctx: Context): Int = {
+  def getPrimitive(app: Apply, tpe: Type)(using Context): Int = {
     val fun = app.fun.symbol
     val defn = ctx.definitions
     val code = app.fun match {
@@ -130,7 +130,7 @@ class DottyPrimitives(ictx: Context) {
       primitives(s) = code
     }
 
-    def addPrimitives(cls: Symbol, method: TermName, code: Int)(implicit ctx: Context): Unit = {
+    def addPrimitives(cls: Symbol, method: TermName, code: Int)(using Context): Unit = {
       val alts = cls.info.member(method).alternatives.map(_.symbol)
       if (alts.isEmpty)
         ctx.error(s"Unknown primitive method $cls.$method")

--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 
 import core._
-import Contexts.{Context, curCtx}
+import Contexts.{Context, ctx}
 import SymDenotations.ClassDenotation
 import Symbols._
 import util.{FreshNameCreator, SourceFile, NoSource}
@@ -45,10 +45,10 @@ class CompilationUnit protected (val source: SourceFile) {
 
   def suspend()(using Context): Nothing =
     if !suspended then
-      if (curCtx.settings.XprintSuspension.value)
-        curCtx.echo(i"suspended: $this")
+      if (ctx.settings.XprintSuspension.value)
+        ctx.echo(i"suspended: $this")
       suspended = true
-      curCtx.run.suspendedUnits += this
+      ctx.run.suspendedUnits += this
     throw CompilationUnit.SuspendException()
 
   private var myAssignmentSpans: Map[Int, List[Span]] = null

--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -1,18 +1,18 @@
 package dotty.tools
 package dotc
 
-import util.{FreshNameCreator, SourceFile}
+import core._
+import Contexts.{Context, curCtx}
+import SymDenotations.ClassDenotation
+import Symbols._
+import util.{FreshNameCreator, SourceFile, NoSource}
+import util.Spans.Span
 import ast.{tpd, untpd}
 import tpd.{Tree, TreeTraverser}
 import typer.PrepareInlineable.InlineAccessors
 import typer.Nullables
-import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.core.SymDenotations.ClassDenotation
-import dotty.tools.dotc.core.Symbols._
-import dotty.tools.dotc.transform.SymUtils._
-import util.{NoSource, SourceFile}
-import util.Spans.Span
-import core.Decorators._
+import transform.SymUtils._
+import core.Decorators.{given _}
 
 class CompilationUnit protected (val source: SourceFile) {
 
@@ -43,12 +43,12 @@ class CompilationUnit protected (val source: SourceFile) {
 
   var suspended: Boolean = false
 
-  def suspend()(using ctx: Context): Nothing =
+  def suspend()(using Context): Nothing =
     if !suspended then
-      if (ctx.settings.XprintSuspension.value)
-        ctx.echo(i"suspended: $this")
+      if (curCtx.settings.XprintSuspension.value)
+        curCtx.echo(i"suspended: $this")
       suspended = true
-      ctx.run.suspendedUnits += this
+      curCtx.run.suspendedUnits += this
     throw CompilationUnit.SuspendException()
 
   private var myAssignmentSpans: Map[Int, List[Span]] = null

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -60,7 +60,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
       .setTyperState(new TyperState(ctx.typerState))
     ctx.initialize()(start) // re-initialize the base context with start
     def addImport(ctx: Context, rootRef: ImportInfo.RootRef) =
-      ctx.fresh.setImportInfo(ImportInfo.rootImport(rootRef)(ctx))
+      ctx.fresh.setImportInfo(ImportInfo.rootImport(rootRef))
     defn.RootImportFns.foldLeft(start.setRun(this))(addImport)
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -980,7 +980,7 @@ object desugar {
             case Some(DefDef(name, _, (vparam :: _) :: _, _, _)) =>
               s"extension_${name}_${inventTypeName(vparam.tpt)}"
             case _ =>
-              curCtx.error(AnonymousInstanceCannotBeEmpty(impl), impl.sourcePos)
+              ctx.error(AnonymousInstanceCannotBeEmpty(impl), impl.sourcePos)
               nme.ERROR.toString
         else
           impl.parents.map(inventTypeName(_)).mkString("given_", "_", "")

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -919,7 +919,7 @@ object desugar {
    *      <extension> def g[Ts](x: T)(using C)(z: T) = f(z)
    */
   def collectiveExtensionBody(stats: List[Tree],
-      tparams: List[TypeDef], vparamss: List[List[ValDef]])(using ctx: Context): List[Tree] =
+      tparams: List[TypeDef], vparamss: List[List[ValDef]])(using Context): List[Tree] =
     for stat <- stats yield
       stat match
         case mdef: DefDef =>
@@ -968,7 +968,7 @@ object desugar {
   }
 
   /** Invent a name for an anonympus given or extension of type or template `impl`. */
-  def inventGivenOrExtensionName(impl: Tree)(using ctx: Context): SimpleName =
+  def inventGivenOrExtensionName(impl: Tree)(using Context): SimpleName =
     val str = impl match
       case impl: Template =>
         if impl.parents.isEmpty then
@@ -980,7 +980,7 @@ object desugar {
             case Some(DefDef(name, _, (vparam :: _) :: _, _, _)) =>
               s"extension_${name}_${inventTypeName(vparam.tpt)}"
             case _ =>
-              ctx.error(AnonymousInstanceCannotBeEmpty(impl), impl.sourcePos)
+              curCtx.error(AnonymousInstanceCannotBeEmpty(impl), impl.sourcePos)
               nme.ERROR.toString
         else
           impl.parents.map(inventTypeName(_)).mkString("given_", "_", "")

--- a/compiler/src/dotty/tools/dotc/ast/MainProxies.scala
+++ b/compiler/src/dotty/tools/dotc/ast/MainProxies.scala
@@ -47,7 +47,7 @@ object MainProxies {
 
     def addArgs(call: untpd.Tree, mt: MethodType, idx: Int): untpd.Tree =
       if (mt.isImplicitMethod) {
-        curCtx.error(s"@main method cannot have implicit parameters", pos)
+        ctx.error(s"@main method cannot have implicit parameters", pos)
         call
       }
       else {
@@ -65,7 +65,7 @@ object MainProxies {
         mt.resType match {
           case restpe: MethodType =>
             if (mt.paramInfos.lastOption.getOrElse(NoType).isRepeatedParam)
-              curCtx.error(s"varargs parameter of @main method must come last", pos)
+              ctx.error(s"varargs parameter of @main method must come last", pos)
             addArgs(call1, restpe, idx + args.length)
           case _ =>
             call1
@@ -74,7 +74,7 @@ object MainProxies {
 
     var result: List[TypeDef] = Nil
     if (!mainFun.owner.isStaticOwner)
-      curCtx.error(s"@main method is not statically accessible", pos)
+      ctx.error(s"@main method is not statically accessible", pos)
     else {
       var call = ref(mainFun.termRef)
       mainFun.info match {
@@ -82,9 +82,9 @@ object MainProxies {
         case mt: MethodType =>
           call = addArgs(call, mt, 0)
         case _: PolyType =>
-          curCtx.error(s"@main method cannot have type parameters", pos)
+          ctx.error(s"@main method cannot have type parameters", pos)
         case _ =>
-          curCtx.error(s"@main can only annotate a method", pos)
+          ctx.error(s"@main can only annotate a method", pos)
       }
       val errVar = Ident(nme.error)
       val handler = CaseDef(
@@ -99,7 +99,7 @@ object MainProxies {
       val mainTempl = Template(emptyConstructor, Nil, Nil, EmptyValDef, mainMeth :: Nil)
       val mainCls = TypeDef(mainFun.name.toTypeName, mainTempl)
         .withFlags(Final)
-      if (!curCtx.reporter.hasErrors) result = mainCls.withSpan(mainAnnotSpan) :: Nil
+      if (!ctx.reporter.hasErrors) result = mainCls.withSpan(mainAnnotSpan) :: Nil
     }
     result
   }

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1445,14 +1445,17 @@ object Trees {
             case UnApply(fun, implicits, patterns) =>
               this(this(this(x, fun), implicits), patterns)
             case tree @ ValDef(_, tpt, _) =>
-              implicit val ctx = localCtx
-              this(this(x, tpt), tree.rhs)
+              withContext(localCtx) {
+                this(this(x, tpt), tree.rhs)
+              }
             case tree @ DefDef(_, tparams, vparamss, tpt, _) =>
-              implicit val ctx = localCtx
-              this(this(vparamss.foldLeft(this(x, tparams))(apply), tpt), tree.rhs)
+              withContext(localCtx) {
+                this(this(vparamss.foldLeft(this(x, tparams))(apply), tpt), tree.rhs)
+              }
             case TypeDef(_, rhs) =>
-              implicit val ctx = localCtx
-              this(x, rhs)
+              withContext(localCtx) {
+                this(x, rhs)
+              }
             case tree @ Template(constr, parents, self, _) if tree.derived.isEmpty =>
               this(this(this(this(x, constr), parents), self), tree.body)
             case Import(expr, _) =>

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1235,111 +1235,116 @@ object Trees {
     protected def inlineContext(call: Tree)(implicit ctx: Context): Context = ctx
 
     abstract class TreeMap(val cpy: TreeCopier = inst.cpy) { self =>
-      def transform(tree: Tree)(implicit ctxLowPrio: Context): Tree = {
-        implicit val ctx: Context =
-          if (tree.source != ctxLowPrio.source && tree.source.exists)
-            ctxLowPrio.withSource(tree.source)
-          else ctxLowPrio
+      def transform(tree: Tree)(using Context): Tree = {
+        withContext(
+          if tree.source != ctx.source && tree.source.exists
+          then ctx.withSource(tree.source)
+          else ctx
+        ){
+          Stats.record(s"TreeMap.transform/$getClass")
+          def localCtx =
+            if (tree.hasType && tree.symbol.exists) ctx.withOwner(tree.symbol) else ctx
 
-        Stats.record(s"TreeMap.transform/$getClass")
-        def localCtx =
-          if (tree.hasType && tree.symbol.exists) ctx.withOwner(tree.symbol) else ctx
-
-        if (skipTransform(tree)) tree
-        else tree match {
-          case Ident(name) =>
-            tree
-          case Select(qualifier, name) =>
-            cpy.Select(tree)(transform(qualifier), name)
-          case This(qual) =>
-            tree
-          case Super(qual, mix) =>
-            cpy.Super(tree)(transform(qual), mix)
-          case Apply(fun, args) =>
-            cpy.Apply(tree)(transform(fun), transform(args))
-          case TypeApply(fun, args) =>
-            cpy.TypeApply(tree)(transform(fun), transform(args))
-          case Literal(const) =>
-            tree
-          case New(tpt) =>
-            cpy.New(tree)(transform(tpt))
-          case Typed(expr, tpt) =>
-            cpy.Typed(tree)(transform(expr), transform(tpt))
-          case NamedArg(name, arg) =>
-            cpy.NamedArg(tree)(name, transform(arg))
-          case Assign(lhs, rhs) =>
-            cpy.Assign(tree)(transform(lhs), transform(rhs))
-          case Block(stats, expr) =>
-            cpy.Block(tree)(transformStats(stats), transform(expr))
-          case If(cond, thenp, elsep) =>
-            cpy.If(tree)(transform(cond), transform(thenp), transform(elsep))
-          case Closure(env, meth, tpt) =>
-            cpy.Closure(tree)(transform(env), transform(meth), transform(tpt))
-          case Match(selector, cases) =>
-            cpy.Match(tree)(transform(selector), transformSub(cases))
-          case CaseDef(pat, guard, body) =>
-            cpy.CaseDef(tree)(transform(pat), transform(guard), transform(body))
-          case Labeled(bind, expr) =>
-            cpy.Labeled(tree)(transformSub(bind), transform(expr))
-          case Return(expr, from) =>
-            cpy.Return(tree)(transform(expr), transformSub(from))
-          case WhileDo(cond, body) =>
-            cpy.WhileDo(tree)(transform(cond), transform(body))
-          case Try(block, cases, finalizer) =>
-            cpy.Try(tree)(transform(block), transformSub(cases), transform(finalizer))
-          case SeqLiteral(elems, elemtpt) =>
-            cpy.SeqLiteral(tree)(transform(elems), transform(elemtpt))
-          case Inlined(call, bindings, expansion) =>
-            cpy.Inlined(tree)(call, transformSub(bindings), transform(expansion)(inlineContext(call)))
-          case TypeTree() =>
-            tree
-          case SingletonTypeTree(ref) =>
-            cpy.SingletonTypeTree(tree)(transform(ref))
-          case RefinedTypeTree(tpt, refinements) =>
-            cpy.RefinedTypeTree(tree)(transform(tpt), transformSub(refinements))
-          case AppliedTypeTree(tpt, args) =>
-            cpy.AppliedTypeTree(tree)(transform(tpt), transform(args))
-          case LambdaTypeTree(tparams, body) =>
-            implicit val ctx = localCtx
-            cpy.LambdaTypeTree(tree)(transformSub(tparams), transform(body))
-          case MatchTypeTree(bound, selector, cases) =>
-            cpy.MatchTypeTree(tree)(transform(bound), transform(selector), transformSub(cases))
-          case ByNameTypeTree(result) =>
-            cpy.ByNameTypeTree(tree)(transform(result))
-          case TypeBoundsTree(lo, hi, alias) =>
-            cpy.TypeBoundsTree(tree)(transform(lo), transform(hi), transform(alias))
-          case Bind(name, body) =>
-            cpy.Bind(tree)(name, transform(body))
-          case Alternative(trees) =>
-            cpy.Alternative(tree)(transform(trees))
-          case UnApply(fun, implicits, patterns) =>
-            cpy.UnApply(tree)(transform(fun), transform(implicits), transform(patterns))
-          case EmptyValDef =>
-            tree
-          case tree @ ValDef(name, tpt, _) =>
-            implicit val ctx = localCtx
-            val tpt1 = transform(tpt)
-            val rhs1 = transform(tree.rhs)
-            cpy.ValDef(tree)(name, tpt1, rhs1)
-          case tree @ DefDef(name, tparams, vparamss, tpt, _) =>
-            implicit val ctx = localCtx
-            cpy.DefDef(tree)(name, transformSub(tparams), vparamss mapConserve (transformSub(_)), transform(tpt), transform(tree.rhs))
-          case tree @ TypeDef(name, rhs) =>
-            implicit val ctx = localCtx
-            cpy.TypeDef(tree)(name, transform(rhs))
-          case tree @ Template(constr, parents, self, _) if tree.derived.isEmpty =>
-            cpy.Template(tree)(transformSub(constr), transform(tree.parents), Nil, transformSub(self), transformStats(tree.body))
-          case Import(expr, selectors) =>
-            cpy.Import(tree)(transform(expr), selectors)
-          case PackageDef(pid, stats) =>
-            cpy.PackageDef(tree)(transformSub(pid), transformStats(stats)(localCtx))
-          case Annotated(arg, annot) =>
-            cpy.Annotated(tree)(transform(arg), transform(annot))
-          case Thicket(trees) =>
-            val trees1 = transform(trees)
-            if (trees1 eq trees) tree else Thicket(trees1)
-          case _ =>
-            transformMoreCases(tree)
+          if (skipTransform(tree)) tree
+          else tree match {
+            case Ident(name) =>
+              tree
+            case Select(qualifier, name) =>
+              cpy.Select(tree)(transform(qualifier), name)
+            case This(qual) =>
+              tree
+            case Super(qual, mix) =>
+              cpy.Super(tree)(transform(qual), mix)
+            case Apply(fun, args) =>
+              cpy.Apply(tree)(transform(fun), transform(args))
+            case TypeApply(fun, args) =>
+              cpy.TypeApply(tree)(transform(fun), transform(args))
+            case Literal(const) =>
+              tree
+            case New(tpt) =>
+              cpy.New(tree)(transform(tpt))
+            case Typed(expr, tpt) =>
+              cpy.Typed(tree)(transform(expr), transform(tpt))
+            case NamedArg(name, arg) =>
+              cpy.NamedArg(tree)(name, transform(arg))
+            case Assign(lhs, rhs) =>
+              cpy.Assign(tree)(transform(lhs), transform(rhs))
+            case Block(stats, expr) =>
+              cpy.Block(tree)(transformStats(stats), transform(expr))
+            case If(cond, thenp, elsep) =>
+              cpy.If(tree)(transform(cond), transform(thenp), transform(elsep))
+            case Closure(env, meth, tpt) =>
+              cpy.Closure(tree)(transform(env), transform(meth), transform(tpt))
+            case Match(selector, cases) =>
+              cpy.Match(tree)(transform(selector), transformSub(cases))
+            case CaseDef(pat, guard, body) =>
+              cpy.CaseDef(tree)(transform(pat), transform(guard), transform(body))
+            case Labeled(bind, expr) =>
+              cpy.Labeled(tree)(transformSub(bind), transform(expr))
+            case Return(expr, from) =>
+              cpy.Return(tree)(transform(expr), transformSub(from))
+            case WhileDo(cond, body) =>
+              cpy.WhileDo(tree)(transform(cond), transform(body))
+            case Try(block, cases, finalizer) =>
+              cpy.Try(tree)(transform(block), transformSub(cases), transform(finalizer))
+            case SeqLiteral(elems, elemtpt) =>
+              cpy.SeqLiteral(tree)(transform(elems), transform(elemtpt))
+            case Inlined(call, bindings, expansion) =>
+              cpy.Inlined(tree)(call, transformSub(bindings), transform(expansion)(using inlineContext(call)))
+            case TypeTree() =>
+              tree
+            case SingletonTypeTree(ref) =>
+              cpy.SingletonTypeTree(tree)(transform(ref))
+            case RefinedTypeTree(tpt, refinements) =>
+              cpy.RefinedTypeTree(tree)(transform(tpt), transformSub(refinements))
+            case AppliedTypeTree(tpt, args) =>
+              cpy.AppliedTypeTree(tree)(transform(tpt), transform(args))
+            case LambdaTypeTree(tparams, body) =>
+              withContext(localCtx) {
+                cpy.LambdaTypeTree(tree)(transformSub(tparams), transform(body))
+              }
+            case MatchTypeTree(bound, selector, cases) =>
+              cpy.MatchTypeTree(tree)(transform(bound), transform(selector), transformSub(cases))
+            case ByNameTypeTree(result) =>
+              cpy.ByNameTypeTree(tree)(transform(result))
+            case TypeBoundsTree(lo, hi, alias) =>
+              cpy.TypeBoundsTree(tree)(transform(lo), transform(hi), transform(alias))
+            case Bind(name, body) =>
+              cpy.Bind(tree)(name, transform(body))
+            case Alternative(trees) =>
+              cpy.Alternative(tree)(transform(trees))
+            case UnApply(fun, implicits, patterns) =>
+              cpy.UnApply(tree)(transform(fun), transform(implicits), transform(patterns))
+            case EmptyValDef =>
+              tree
+            case tree @ ValDef(name, tpt, _) =>
+              withContext(localCtx) {
+                val tpt1 = transform(tpt)
+                val rhs1 = transform(tree.rhs)
+                cpy.ValDef(tree)(name, tpt1, rhs1)
+              }
+            case tree @ DefDef(name, tparams, vparamss, tpt, _) =>
+              withContext(localCtx) {
+                cpy.DefDef(tree)(name, transformSub(tparams), vparamss mapConserve (transformSub(_)), transform(tpt), transform(tree.rhs))
+              }
+            case tree @ TypeDef(name, rhs) =>
+              withContext(localCtx) {
+                cpy.TypeDef(tree)(name, transform(rhs))
+              }
+            case tree @ Template(constr, parents, self, _) if tree.derived.isEmpty =>
+              cpy.Template(tree)(transformSub(constr), transform(tree.parents), Nil, transformSub(self), transformStats(tree.body))
+            case Import(expr, selectors) =>
+              cpy.Import(tree)(transform(expr), selectors)
+            case PackageDef(pid, stats) =>
+              cpy.PackageDef(tree)(transformSub(pid), transformStats(stats)(localCtx))
+            case Annotated(arg, annot) =>
+              cpy.Annotated(tree)(transform(arg), transform(annot))
+            case Thicket(trees) =>
+              val trees1 = transform(trees)
+              if (trees1 eq trees) tree else Thicket(trees1)
+            case _ =>
+              transformMoreCases(tree)
+          }
         }
       }
 
@@ -1424,8 +1429,9 @@ object Trees {
             case AppliedTypeTree(tpt, args) =>
               this(this(x, tpt), args)
             case LambdaTypeTree(tparams, body) =>
-              implicit val ctx = localCtx
-              this(this(x, tparams), body)
+              withContext(localCtx) {
+                this(this(x, tparams), body)
+              }
             case MatchTypeTree(bound, selector, cases) =>
               this(this(this(x, bound), selector), cases)
             case ByNameTypeTree(result) =>

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1236,7 +1236,7 @@ object Trees {
 
     abstract class TreeMap(val cpy: TreeCopier = inst.cpy) { self =>
       def transform(tree: Tree)(using Context): Tree = {
-        withContext(
+        inContext(
           if tree.source != ctx.source && tree.source.exists
           then ctx.withSource(tree.source)
           else ctx
@@ -1300,7 +1300,7 @@ object Trees {
             case AppliedTypeTree(tpt, args) =>
               cpy.AppliedTypeTree(tree)(transform(tpt), transform(args))
             case LambdaTypeTree(tparams, body) =>
-              withContext(localCtx) {
+              inContext(localCtx) {
                 cpy.LambdaTypeTree(tree)(transformSub(tparams), transform(body))
               }
             case MatchTypeTree(bound, selector, cases) =>
@@ -1318,17 +1318,17 @@ object Trees {
             case EmptyValDef =>
               tree
             case tree @ ValDef(name, tpt, _) =>
-              withContext(localCtx) {
+              inContext(localCtx) {
                 val tpt1 = transform(tpt)
                 val rhs1 = transform(tree.rhs)
                 cpy.ValDef(tree)(name, tpt1, rhs1)
               }
             case tree @ DefDef(name, tparams, vparamss, tpt, _) =>
-              withContext(localCtx) {
+              inContext(localCtx) {
                 cpy.DefDef(tree)(name, transformSub(tparams), vparamss mapConserve (transformSub(_)), transform(tpt), transform(tree.rhs))
               }
             case tree @ TypeDef(name, rhs) =>
-              withContext(localCtx) {
+              inContext(localCtx) {
                 cpy.TypeDef(tree)(name, transform(rhs))
               }
             case tree @ Template(constr, parents, self, _) if tree.derived.isEmpty =>
@@ -1429,7 +1429,7 @@ object Trees {
             case AppliedTypeTree(tpt, args) =>
               this(this(x, tpt), args)
             case LambdaTypeTree(tparams, body) =>
-              withContext(localCtx) {
+              inContext(localCtx) {
                 this(this(x, tparams), body)
               }
             case MatchTypeTree(bound, selector, cases) =>
@@ -1445,15 +1445,15 @@ object Trees {
             case UnApply(fun, implicits, patterns) =>
               this(this(this(x, fun), implicits), patterns)
             case tree @ ValDef(_, tpt, _) =>
-              withContext(localCtx) {
+              inContext(localCtx) {
                 this(this(x, tpt), tree.rhs)
               }
             case tree @ DefDef(_, tparams, vparamss, tpt, _) =>
-              withContext(localCtx) {
+              inContext(localCtx) {
                 this(this(vparamss.foldLeft(this(x, tparams))(apply), tpt), tree.rhs)
               }
             case TypeDef(_, rhs) =>
-              withContext(localCtx) {
+              inContext(localCtx) {
                 this(x, rhs)
               }
             case tree @ Template(constr, parents, self, _) if tree.derived.isEmpty =>

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1351,8 +1351,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   /** Convert a list of trees to a vararg-compatible tree.
    *  Used to make arguments for methods that accept varargs.
    */
-  def repeated(trees: List[Tree], tpt: Tree)(using ctx: Context): Tree =
-    ctx.typeAssigner.arrayToRepeated(JavaSeqLiteral(trees, tpt))
+  def repeated(trees: List[Tree], tpt: Tree)(using Context): Tree =
+    curCtx.typeAssigner.arrayToRepeated(JavaSeqLiteral(trees, tpt))
 
   /** Create a tree representing a list containing all
    *  the elements of the argument list. A "list of tree to
@@ -1369,6 +1369,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       .appliedToVarargs(trees, tpe)
 
 
-  protected def FunProto(args: List[Tree], resType: Type)(using ctx: Context) =
-    ProtoTypes.FunProtoTyped(args, resType)(ctx.typer, isUsingApply = false)
+  protected def FunProto(args: List[Tree], resType: Type)(using Context) =
+    ProtoTypes.FunProtoTyped(args, resType)(curCtx.typer, isUsingApply = false)
 }

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1352,7 +1352,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    *  Used to make arguments for methods that accept varargs.
    */
   def repeated(trees: List[Tree], tpt: Tree)(using Context): Tree =
-    curCtx.typeAssigner.arrayToRepeated(JavaSeqLiteral(trees, tpt))
+    ctx.typeAssigner.arrayToRepeated(JavaSeqLiteral(trees, tpt))
 
   /** Create a tree representing a list containing all
    *  the elements of the argument list. A "list of tree to
@@ -1370,5 +1370,5 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
 
   protected def FunProto(args: List[Tree], resType: Type)(using Context) =
-    ProtoTypes.FunProtoTyped(args, resType)(curCtx.typer, isUsingApply = false)
+    ProtoTypes.FunProtoTyped(args, resType)(ctx.typer, isUsingApply = false)
 }

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -249,12 +249,12 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
      *  describe the core of a construct whereas the existing set are the modifiers
      *  given in the source.
      */
-    def withAddedFlags(flags: FlagSet, span: Span)(using ctx: Context): Modifiers =
+    def withAddedFlags(flags: FlagSet, span: Span)(using Context): Modifiers =
       if this.flags.isAllOf(flags) then this
       else if compatible(this.flags, flags) then this | flags
       else
         val what = if flags.isTermFlags then "values" else "types"
-        ctx.error(em"${(flags & ModifierFlags).flagsString} $what cannot be ${this.flags.flagsString}", ctx.source.atSpan(span))
+        curCtx.error(em"${(flags & ModifierFlags).flagsString} $what cannot be ${this.flags.flagsString}", curCtx.source.atSpan(span))
         Modifiers(flags)
 
     /** Modifiers with given list of Mods. It is checked that
@@ -760,6 +760,6 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     acc(false, tree)
   }
 
-  protected def FunProto(args: List[Tree], resType: Type)(using ctx: Context) =
-    ProtoTypes.FunProto(args, resType)(ctx.typer, isUsingApply = false)
+  protected def FunProto(args: List[Tree], resType: Type)(using Context) =
+    ProtoTypes.FunProto(args, resType)(curCtx.typer, isUsingApply = false)
 }

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -254,7 +254,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       else if compatible(this.flags, flags) then this | flags
       else
         val what = if flags.isTermFlags then "values" else "types"
-        curCtx.error(em"${(flags & ModifierFlags).flagsString} $what cannot be ${this.flags.flagsString}", curCtx.source.atSpan(span))
+        ctx.error(em"${(flags & ModifierFlags).flagsString} $what cannot be ${this.flags.flagsString}", ctx.source.atSpan(span))
         Modifiers(flags)
 
     /** Modifiers with given list of Mods. It is checked that
@@ -761,5 +761,5 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   }
 
   protected def FunProto(args: List[Tree], resType: Type)(using Context) =
-    ProtoTypes.FunProto(args, resType)(curCtx.typer, isUsingApply = false)
+    ProtoTypes.FunProto(args, resType)(ctx.typer, isUsingApply = false)
 }

--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -24,7 +24,7 @@ object PathResolver {
    */
   def makeAbsolute(cp: String): String = ClassPath.map(cp, x => Path(x).toAbsolute.path)
 
-  /** pretty print class path 
+  /** pretty print class path
    */
   def ppcp(s: String): String = split(s) match {
     case Nil      => ""
@@ -51,7 +51,7 @@ object PathResolver {
     def scalaHome: String           = propOrEmpty("scala.home")
     def scalaExtDirs: String        = propOrEmpty("scala.ext.dirs")
 
-    /** The java classpath and whether to use it. 
+    /** The java classpath and whether to use it.
      */
     def javaUserClassPath: String   = propOrElse("java.class.path", "")
     def useJavaClassPath: Boolean    = propOrFalse("scala.usejavacp")
@@ -134,7 +134,7 @@ object PathResolver {
   }
 
   /** Show values in Environment and Defaults when no argument is provided.
-   *  Otherwise, show values in Calculated as if those options had been given 
+   *  Otherwise, show values in Calculated as if those options had been given
    *  to a scala runner.
    */
   def main(args: Array[String]): Unit =
@@ -142,8 +142,7 @@ object PathResolver {
       println(Environment)
       println(Defaults)
     }
-    else {
-      implicit val ctx = (new ContextBase).initialCtx
+    else withContext(ContextBase().initialCtx) {
       val ArgsSummary(sstate, rest, errors, warnings) =
         ctx.settings.processArguments(args.toList, true)
       errors.foreach(println)
@@ -165,7 +164,7 @@ class PathResolver(implicit ctx: Context) {
 
   private val classPathFactory = new ClassPathFactory
 
-  private def cmdLineOrElse(name: String, alt: String) = 
+  private def cmdLineOrElse(name: String, alt: String) =
     commandLineFor(name) match {
       case Some("") | None => alt
       case Some(x)         => x

--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -142,7 +142,7 @@ object PathResolver {
       println(Environment)
       println(Defaults)
     }
-    else withContext(ContextBase().initialCtx) {
+    else inContext(ContextBase().initialCtx) {
       val ArgsSummary(sstate, rest, errors, warnings) =
         ctx.settings.processArguments(args.toList, true)
       errors.foreach(println)

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -55,10 +55,10 @@ object Annotations {
   private def annotCtx(using Context): Context =
     // We should always produce the same annotation tree, no matter when the
     // annotation is evaluated. Setting the phase to a pre-transformation phase
-    // seems to be enough to ensure this (note that after erasure, `curCtx.typer`
+    // seems to be enough to ensure this (note that after erasure, `ctx.typer`
     // will be the Erasure typer, but that doesn't seem to affect the annotation
     // trees we create, so we leave it as is)
-    curCtx.withPhaseNoLater(curCtx.picklerPhase)
+    ctx.withPhaseNoLater(ctx.picklerPhase)
 
   abstract class LazyAnnotation extends Annotation {
     protected var mySym: Symbol | (Context => Symbol)

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -52,13 +52,13 @@ object Annotations {
   }
 
   /** The context to use to evaluate an annotation */
-  private def annotCtx(using ctx: Context): Context =
+  private def annotCtx(using Context): Context =
     // We should always produce the same annotation tree, no matter when the
     // annotation is evaluated. Setting the phase to a pre-transformation phase
-    // seems to be enough to ensure this (note that after erasure, `ctx.typer`
+    // seems to be enough to ensure this (note that after erasure, `curCtx.typer`
     // will be the Erasure typer, but that doesn't seem to affect the annotation
     // trees we create, so we leave it as is)
-    ctx.withPhaseNoLater(ctx.picklerPhase)
+    curCtx.withPhaseNoLater(curCtx.picklerPhase)
 
   abstract class LazyAnnotation extends Annotation {
     protected var mySym: Symbol | (Context => Symbol)
@@ -178,7 +178,7 @@ object Annotations {
 
       /** A deferred annotation to the result of a given child computation */
       def later(delayedSym: Context ?=> Symbol, span: Span)(implicit ctx: Context): Annotation = {
-        def makeChildLater(using ctx: Context) = {
+        def makeChildLater(using Context) = {
           val sym = delayedSym
           New(defn.ChildAnnot.typeRef.appliedTo(sym.owner.thisType.select(sym.name, sym)), Nil)
             .withSpan(span)

--- a/compiler/src/dotty/tools/dotc/core/Comments.scala
+++ b/compiler/src/dotty/tools/dotc/core/Comments.scala
@@ -15,9 +15,8 @@ object Comments {
   val ContextDoc: Key[ContextDocstrings] = new Key[ContextDocstrings]
 
   /** Decorator for getting docbase out of context */
-  implicit class CommentsContext(val ctx: Context) extends AnyVal {
-    def docCtx: Option[ContextDocstrings] = ctx.property(ContextDoc)
-  }
+  extension CommentsContext on (c: Context):
+    def docCtx: Option[ContextDocstrings] = c.property(ContextDoc)
 
   /** Context for Docstrings, contains basic functionality for getting
     * docstrings via `Symbol` and expanding templates

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -52,6 +52,10 @@ object Contexts {
   /** The current context */
   def ctx(using ctx: Context): Context = ctx
 
+  /** Run `op` with given context */
+  inline def withContext[T](c: Context)(inline op: Context ?=> T): T =
+    op(using c)
+
   /** A context is passed basically everywhere in dotc.
    *  This is convenient but carries the risk of captured contexts in
    *  objects that turn into space leaks. To combat this risk, here are some

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -53,7 +53,7 @@ object Contexts {
   def ctx(using ctx: Context): Context = ctx
 
   /** Run `op` with given context */
-  inline def withContext[T](c: Context)(inline op: Context ?=> T): T =
+  inline def inContext[T](c: Context)(inline op: Context ?=> T): T =
     op(using c)
 
   /** A context is passed basically everywhere in dotc.

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -50,7 +50,7 @@ object Contexts {
   private val initialStore = store8
 
   /** The current context */
-  def curCtx(using ctx: Context): Context = ctx
+  def ctx(using ctx: Context): Context = ctx
 
   /** A context is passed basically everywhere in dotc.
    *  This is convenient but carries the risk of captured contexts in

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -88,7 +88,7 @@ object Contexts {
        with Plugins
        with Cloneable { thiscontext =>
 
-    implicit def thisContext: Context = this
+    given Context = this
 
     /** All outer contexts, ending in `base.initialCtx` and then `NoContext` */
     def outersIterator: Iterator[Context] = new Iterator[Context] {

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -38,7 +38,7 @@ class Definitions {
   import Definitions._
 
   private var initCtx: Context = _
-  private given ctx[Dummy_so_its_a_def] as Context = initCtx
+  private given currentContext[Dummy_so_its_a_def] as Context = initCtx
 
   private def newSymbol[N <: Name](owner: Symbol, name: N, flags: FlagSet, info: Type) =
     ctx.newSymbol(owner, name, flags | Permanent, info)
@@ -1275,8 +1275,8 @@ class Definitions {
    */
   object ContextFunctionType:
     def unapply(tp: Type)(using Context): Option[(List[Type], Type, Boolean)] =
-      if curCtx.erasedTypes then
-        unapply(tp)(using curCtx.withPhase(curCtx.erasurePhase))
+      if ctx.erasedTypes then
+        unapply(tp)(using ctx.withPhase(ctx.erasurePhase))
       else
         val tp1 = tp.dealias
         if isContextFunctionClass(tp1.typeSymbol) then

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1274,8 +1274,9 @@ class Definitions {
    *  types `As`, the result type `B` and a whether the type is an erased context function.
    */
   object ContextFunctionType:
-    def unapply(tp: Type)(using ctx: Context): Option[(List[Type], Type, Boolean)] =
-      if ctx.erasedTypes then unapply(tp)(using ctx.withPhase(ctx.erasurePhase))
+    def unapply(tp: Type)(using Context): Option[(List[Type], Type, Boolean)] =
+      if curCtx.erasedTypes then
+        unapply(tp)(using curCtx.withPhase(curCtx.erasurePhase))
       else
         val tp1 = tp.dealias
         if isContextFunctionClass(tp1.typeSymbol) then

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -85,8 +85,7 @@ trait SymDenotations { thisCtx: Context =>
       case denot: SymDenotation =>
         def explainSym(msg: String) = explain(s"$msg\ndefined = ${denot.definedPeriodsString}")
         if (denot.isOneOf(ValidForeverFlags) || denot.isRefinementClass) true
-        else {
-          implicit val ctx = thisCtx
+        else inContext(thisCtx) {
           val initial = denot.initial
           if ((initial ne denot) || ctx.phaseId != initial.validFor.firstPhaseId)
             ctx.withPhase(initial.validFor.firstPhaseId).traceInvalid(initial)

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -235,7 +235,8 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
     def firstTry: Boolean = tp2 match {
       case tp2: NamedType =>
         def compareNamed(tp1: Type, tp2: NamedType): Boolean =
-          implicit val ctx: Context = this.ctx
+          val ctx = this.ctx
+          given Context = ctx // optimization for performance
           val info2 = tp2.info
           info2 match
             case info2: TypeAlias =>

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -493,7 +493,7 @@ trait TypeOps { thisCtx: Context => // TODO: Make standalone object.
     def hasImport = {
       val owner1 = if (!owner.exists) defn.LanguageModule.moduleClass else owner
       thisCtx.importInfo != null &&
-      thisCtx.importInfo.featureImported(feature, owner1)(thisCtx.withPhase(thisCtx.typerPhase))
+      thisCtx.importInfo.featureImported(feature, owner1)(using thisCtx.withPhase(thisCtx.typerPhase))
     }
     val hasOption = {
       def toPrefix(sym: Symbol): String =

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2431,12 +2431,12 @@ object Types {
      *  So we can't drop the alias here, we need to do the backtracking to the name-
      *  based tests.
      */
-    def canDropAlias(using ctx: Context) =
-      if myCanDropAliasPeriod != ctx.period then
+    def canDropAlias(using Context) =
+      if myCanDropAliasPeriod != curCtx.period then
         myCanDropAlias =
           !symbol.canMatchInheritedSymbols
           || !prefix.baseClasses.exists(_.info.decls.lookup(name).is(Deferred))
-        myCanDropAliasPeriod = ctx.period
+        myCanDropAliasPeriod = curCtx.period
       myCanDropAlias
 
     override def designator: Designator = myDesignator
@@ -2632,8 +2632,8 @@ object Types {
     /** Update the value of the lazyref, discarding the compute function `refFn`
      *  Can be called only as long as the ref is still undefined.
      */
-    def update(tp: Type)(using ctx: Context) =
-      assert(myRef == null || ctx.reporter.errorsReported)
+    def update(tp: Type)(using Context) =
+      assert(myRef == null || curCtx.reporter.errorsReported)
       myRef = tp
       computed = true
       refFn = null
@@ -3011,8 +3011,8 @@ object Types {
   object OrNull {
     def apply(tp: Type)(using Context) =
       OrType(tp, defn.NullType)
-    def unapply(tp: Type)(using ctx: Context): Option[Type] =
-      if (ctx.explicitNulls) {
+    def unapply(tp: Type)(using Context): Option[Type] =
+      if (curCtx.explicitNulls) {
         val tp1 = tp.stripNull()
         if tp1 ne tp then Some(tp1) else None
       }
@@ -3029,8 +3029,8 @@ object Types {
   object OrUncheckedNull {
     def apply(tp: Type)(using Context) =
       OrType(tp, defn.UncheckedNullAliasType)
-    def unapply(tp: Type)(using ctx: Context): Option[Type] =
-      if (ctx.explicitNulls) {
+    def unapply(tp: Type)(using Context): Option[Type] =
+      if (curCtx.explicitNulls) {
         val tp1 = tp.stripUncheckedNull
         if tp1 ne tp then Some(tp1) else None
       }
@@ -4650,13 +4650,13 @@ object Types {
   }
 
   object ErrorType:
-    def apply(m: Message)(implicit ctx: Context): ErrorType =
+    def apply(m: Message)(using Context): ErrorType =
       val et = new ErrorType:
-        def msg(using ctx: Context): Message =
-          ctx.base.errorTypeMsg.get(this) match
+        def msg(using Context): Message =
+          curCtx.base.errorTypeMsg.get(this) match
             case Some(m) => m
             case None => "error message from previous run no longer available"
-      ctx.base.errorTypeMsg(et) = m
+      curCtx.base.errorTypeMsg(et) = m
       et
   end ErrorType
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2432,11 +2432,11 @@ object Types {
      *  based tests.
      */
     def canDropAlias(using Context) =
-      if myCanDropAliasPeriod != curCtx.period then
+      if myCanDropAliasPeriod != ctx.period then
         myCanDropAlias =
           !symbol.canMatchInheritedSymbols
           || !prefix.baseClasses.exists(_.info.decls.lookup(name).is(Deferred))
-        myCanDropAliasPeriod = curCtx.period
+        myCanDropAliasPeriod = ctx.period
       myCanDropAlias
 
     override def designator: Designator = myDesignator
@@ -2633,7 +2633,7 @@ object Types {
      *  Can be called only as long as the ref is still undefined.
      */
     def update(tp: Type)(using Context) =
-      assert(myRef == null || curCtx.reporter.errorsReported)
+      assert(myRef == null || ctx.reporter.errorsReported)
       myRef = tp
       computed = true
       refFn = null
@@ -3012,7 +3012,7 @@ object Types {
     def apply(tp: Type)(using Context) =
       OrType(tp, defn.NullType)
     def unapply(tp: Type)(using Context): Option[Type] =
-      if (curCtx.explicitNulls) {
+      if (ctx.explicitNulls) {
         val tp1 = tp.stripNull()
         if tp1 ne tp then Some(tp1) else None
       }
@@ -3030,7 +3030,7 @@ object Types {
     def apply(tp: Type)(using Context) =
       OrType(tp, defn.UncheckedNullAliasType)
     def unapply(tp: Type)(using Context): Option[Type] =
-      if (curCtx.explicitNulls) {
+      if (ctx.explicitNulls) {
         val tp1 = tp.stripUncheckedNull
         if tp1 ne tp then Some(tp1) else None
       }
@@ -4653,10 +4653,10 @@ object Types {
     def apply(m: Message)(using Context): ErrorType =
       val et = new ErrorType:
         def msg(using Context): Message =
-          curCtx.base.errorTypeMsg.get(this) match
+          ctx.base.errorTypeMsg.get(this) match
             case Some(m) => m
             case None => "error message from previous run no longer available"
-      curCtx.base.errorTypeMsg(et) = m
+      ctx.base.errorTypeMsg(et) = m
       et
   end ErrorType
 

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -256,9 +256,9 @@ object Formatting {
   }
 
   private def errorMessageCtx(using Context): Context =
-    curCtx.property(MessageLimiter) match
-      case Some(_: ErrorMessageLimiter) => curCtx
-      case _ => curCtx.fresh.setProperty(MessageLimiter, ErrorMessageLimiter())
+    ctx.property(MessageLimiter) match
+      case Some(_: ErrorMessageLimiter) => ctx
+      case _ => ctx.fresh.setProperty(MessageLimiter, ErrorMessageLimiter())
 
   /** Context with correct printer set for explanations */
   private def explainCtx(seen: Seen)(implicit ctx: Context): Context =

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -255,10 +255,10 @@ object Formatting {
     if (explainLines.isEmpty) "" else i"where:    $explainLines%\n          %\n"
   }
 
-  private def errorMessageCtx(using ctx: Context): Context =
-    ctx.property(MessageLimiter) match
-      case Some(_: ErrorMessageLimiter) => ctx
-      case _ => ctx.fresh.setProperty(MessageLimiter, ErrorMessageLimiter())
+  private def errorMessageCtx(using Context): Context =
+    curCtx.property(MessageLimiter) match
+      case Some(_: ErrorMessageLimiter) => curCtx
+      case _ => curCtx.fresh.setProperty(MessageLimiter, ErrorMessageLimiter())
 
   /** Context with correct printer set for explanations */
   private def explainCtx(seen: Seen)(implicit ctx: Context): Context =

--- a/compiler/src/dotty/tools/dotc/printing/MessageLimiter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/MessageLimiter.scala
@@ -3,7 +3,7 @@ package dotc
 package printing
 
 import core._
-import Contexts.Context
+import Contexts.{Context, curCtx}
 import util.Property
 import Texts.Text
 
@@ -30,14 +30,14 @@ abstract class MessageLimiter:
 object MessageLimiter extends Property.Key[MessageLimiter]
 
 class DefaultMessageLimiter extends MessageLimiter:
-  override def recursionLimitExceeded()(using ctx: Context): Unit =
-    if ctx.debug then
-      ctx.warning("Exceeded recursion depth attempting to print.")
+  override def recursionLimitExceeded()(using Context): Unit =
+    if curCtx.debug then
+      curCtx.warning("Exceeded recursion depth attempting to print.")
       Thread.dumpStack()
 
 class SummarizeMessageLimiter(depth: Int) extends MessageLimiter:
   override val recurseLimit = recurseCount + depth
-  override def recursionLimitExceeded()(using ctx: Context): Unit = ()
+  override def recursionLimitExceeded()(using Context): Unit = ()
 
 class ErrorMessageLimiter extends MessageLimiter:
   private val initialRecurseLimit = 50

--- a/compiler/src/dotty/tools/dotc/printing/MessageLimiter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/MessageLimiter.scala
@@ -3,7 +3,7 @@ package dotc
 package printing
 
 import core._
-import Contexts.{Context, curCtx}
+import Contexts.{Context, ctx}
 import util.Property
 import Texts.Text
 
@@ -31,8 +31,8 @@ object MessageLimiter extends Property.Key[MessageLimiter]
 
 class DefaultMessageLimiter extends MessageLimiter:
   override def recursionLimitExceeded()(using Context): Unit =
-    if curCtx.debug then
-      curCtx.warning("Exceeded recursion depth attempting to print.")
+    if ctx.debug then
+      ctx.warning("Exceeded recursion depth attempting to print.")
       Thread.dumpStack()
 
 class SummarizeMessageLimiter(depth: Int) extends MessageLimiter:

--- a/compiler/src/dotty/tools/dotc/printing/Showable.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Showable.scala
@@ -26,6 +26,6 @@ trait Showable extends Any {
    *  Recursion depth is limited to some smallish value. Default is
    *  Config.summarizeDepth.
    */
-  def showSummary(depth: Int = summarizeDepth)(using ctx: Context): String =
-    show(using ctx.fresh.setProperty(MessageLimiter, SummarizeMessageLimiter(depth)))
+  def showSummary(depth: Int = summarizeDepth)(using Context): String =
+    show(using curCtx.fresh.setProperty(MessageLimiter, SummarizeMessageLimiter(depth)))
 }

--- a/compiler/src/dotty/tools/dotc/printing/Showable.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Showable.scala
@@ -27,5 +27,5 @@ trait Showable extends Any {
    *  Config.summarizeDepth.
    */
   def showSummary(depth: Int = summarizeDepth)(using Context): String =
-    show(using curCtx.fresh.setProperty(MessageLimiter, SummarizeMessageLimiter(depth)))
+    show(using ctx.fresh.setProperty(MessageLimiter, SummarizeMessageLimiter(depth)))
 }

--- a/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
@@ -3,7 +3,7 @@ package dotc
 package reporting
 
 import util.SourcePosition
-import core.Contexts.Context
+import core.Contexts.{Context, ctx}
 import config.Settings.Setting
 import interfaces.Diagnostic.{ERROR, INFO, WARNING}
 
@@ -11,7 +11,7 @@ import java.util.Optional
 
 object Diagnostic:
 
-  def shouldExplain(dia: Diagnostic)(using ctx: Context): Boolean =
+  def shouldExplain(dia: Diagnostic)(using Context): Boolean =
     dia.msg.explanation.nonEmpty && ctx.settings.explain.value
 
   // `Diagnostics to be consumed by `Reporter` ---------------------- //

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -247,7 +247,7 @@ abstract class Reporter extends interfaces.ReporterResult {
    */
   def reportsErrorsFor(op: Context => Unit)(using Context): Boolean = {
     val initial = errorCount
-    op(curCtx)
+    op(ctx)
     errorCount > initial
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -245,9 +245,9 @@ abstract class Reporter extends interfaces.ReporterResult {
 
   /** Run `op` and return `true` if errors were reported by this reporter.
    */
-  def reportsErrorsFor(op: Context => Unit)(using ctx: Context): Boolean = {
+  def reportsErrorsFor(op: Context => Unit)(using Context): Boolean = {
     val initial = errorCount
-    op(ctx)
+    op(curCtx)
     errorCount > initial
   }
 

--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -3,7 +3,7 @@ package rewrites
 
 import util.{SourceFile, Spans}
 import Spans.Span
-import core.Contexts.Context
+import core.Contexts.{Context, curCtx}
 import collection.mutable
 import scala.annotation.tailrec
 import dotty.tools.dotc.reporting.Reporter
@@ -75,8 +75,8 @@ object Rewrites {
     patch(ctx.compilationUnit.source, span, replacement)
 
   /** Does `span` overlap with a patch region of `source`? */
-  def overlapsPatch(source: SourceFile, span: Span)(using ctx: Context): Boolean =
-    ctx.settings.rewrite.value.exists(rewrites =>
+  def overlapsPatch(source: SourceFile, span: Span)(using Context): Boolean =
+    curCtx.settings.rewrite.value.exists(rewrites =>
       rewrites.patched.get(source).exists(patches =>
         patches.pbuf.exists(patch => patch.span.overlaps(span))))
 

--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -3,7 +3,7 @@ package rewrites
 
 import util.{SourceFile, Spans}
 import Spans.Span
-import core.Contexts.{Context, curCtx}
+import core.Contexts.{Context, ctx}
 import collection.mutable
 import scala.annotation.tailrec
 import dotty.tools.dotc.reporting.Reporter
@@ -76,7 +76,7 @@ object Rewrites {
 
   /** Does `span` overlap with a patch region of `source`? */
   def overlapsPatch(source: SourceFile, span: Span)(using Context): Boolean =
-    curCtx.settings.rewrite.value.exists(rewrites =>
+    ctx.settings.rewrite.value.exists(rewrites =>
       rewrites.patched.get(source).exists(patches =>
         patches.pbuf.exists(patch => patch.span.overlaps(span))))
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -357,7 +357,7 @@ class ExtractSemanticDB extends Phase:
       addSymName(b, sym)
       b.toString
 
-    inline private def source(using Context) = curCtx.compilationUnit.source
+    inline private def source(using Context) = ctx.compilationUnit.source
 
     private def range(span: Span)(using Context): Option[Range] =
       def lineCol(offset: Int) = (source.offsetToLine(offset), source.column(offset))
@@ -580,11 +580,11 @@ object ExtractSemanticDB:
   def write(source: SourceFile, occurrences: List[SymbolOccurrence], symbolInfos: List[SymbolInformation])(using Context): Unit =
     def absolutePath(path: Path): Path = path.toAbsolutePath.normalize
     val sourcePath = absolutePath(source.file.jpath)
-    val sourceRoot = absolutePath(Paths.get(curCtx.settings.sourceroot.value))
+    val sourceRoot = absolutePath(Paths.get(ctx.settings.sourceroot.value))
     val semanticdbTarget =
-      val semanticdbTargetSetting = curCtx.settings.semanticdbTarget.value
+      val semanticdbTargetSetting = ctx.settings.semanticdbTarget.value
       absolutePath(
-        if semanticdbTargetSetting.isEmpty then curCtx.settings.outputDir.value.jpath
+        if semanticdbTargetSetting.isEmpty then ctx.settings.outputDir.value.jpath
         else Paths.get(semanticdbTargetSetting)
       )
     val relPath = sourceRoot.relativize(sourcePath)

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -281,7 +281,7 @@ class ExtractSemanticDB extends Phase:
         tree.nameSpan
 
     /** Add semanticdb name of the given symbol to string builder */
-    private def addSymName(b: StringBuilder, sym: Symbol)(using ctx: Context): Unit =
+    private def addSymName(b: StringBuilder, sym: Symbol)(using Context): Unit =
 
       def addName(name: Name) =
         val str = name.toString.unescapeUnicode
@@ -352,14 +352,14 @@ class ExtractSemanticDB extends Phase:
     end addSymName
 
     /** The semanticdb name of the given symbol */
-    private def symbolName(sym: Symbol)(using ctx: Context): String =
+    private def symbolName(sym: Symbol)(using Context): String =
       val b = StringBuilder(20)
       addSymName(b, sym)
       b.toString
 
-    inline private def source(using ctx: Context) = ctx.compilationUnit.source
+    inline private def source(using Context) = curCtx.compilationUnit.source
 
-    private def range(span: Span)(using ctx: Context): Option[Range] =
+    private def range(span: Span)(using Context): Option[Range] =
       def lineCol(offset: Int) = (source.offsetToLine(offset), source.column(offset))
       val (startLine, startCol) = lineCol(span.start)
       val (endLine, endCol) = lineCol(span.end)
@@ -577,14 +577,14 @@ object ExtractSemanticDB:
 
   val name: String = "extractSemanticDB"
 
-  def write(source: SourceFile, occurrences: List[SymbolOccurrence], symbolInfos: List[SymbolInformation])(using ctx: Context): Unit =
+  def write(source: SourceFile, occurrences: List[SymbolOccurrence], symbolInfos: List[SymbolInformation])(using Context): Unit =
     def absolutePath(path: Path): Path = path.toAbsolutePath.normalize
     val sourcePath = absolutePath(source.file.jpath)
-    val sourceRoot = absolutePath(Paths.get(ctx.settings.sourceroot.value))
+    val sourceRoot = absolutePath(Paths.get(curCtx.settings.sourceroot.value))
     val semanticdbTarget =
-      val semanticdbTargetSetting = ctx.settings.semanticdbTarget.value
+      val semanticdbTargetSetting = curCtx.settings.semanticdbTarget.value
       absolutePath(
-        if semanticdbTargetSetting.isEmpty then ctx.settings.outputDir.value.jpath
+        if semanticdbTargetSetting.isEmpty then curCtx.settings.outputDir.value.jpath
         else Paths.get(semanticdbTargetSetting)
       )
     val relPath = sourceRoot.relativize(sourcePath)

--- a/compiler/src/dotty/tools/dotc/transform/ContextFunctionResults.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ContextFunctionResults.scala
@@ -121,8 +121,8 @@ object ContextFunctionResults:
    *  @param `n` the select nodes seen in previous recursive iterations of this method
    */
   def integrateSelect(tree: untpd.Tree, n: Int = 0)(using Context): Boolean =
-    if curCtx.erasedTypes then
-      integrateSelect(tree, n)(using curCtx.withPhase(curCtx.erasurePhase))
+    if ctx.erasedTypes then
+      integrateSelect(tree, n)(using ctx.withPhase(ctx.erasurePhase))
     else tree match
       case Select(qual, name) =>
         if name == nme.apply && defn.isContextFunctionClass(tree.symbol.maybeOwner) then

--- a/compiler/src/dotty/tools/dotc/transform/ContextFunctionResults.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ContextFunctionResults.scala
@@ -100,7 +100,7 @@ object ContextFunctionResults:
    *  parameter count.
    */
   def contextFunctionResultTypeCovering(meth: Symbol, paramCount: Int)(using Context) =
-    withContext(ctx.withPhase(ctx.erasurePhase)) {
+    inContext(ctx.withPhase(ctx.erasurePhase)) {
       // Recursive instances return pairs of context types and the
       // # of parameters they represent.
       def missingCR(tp: Type, crCount: Int): (Type, Int) =

--- a/compiler/src/dotty/tools/dotc/transform/ContextFunctionResults.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ContextFunctionResults.scala
@@ -99,8 +99,8 @@ object ContextFunctionResults:
    *  Erased parameters are ignored; they contribute nothing to the
    *  parameter count.
    */
-  def contextFunctionResultTypeCovering(meth: Symbol, paramCount: Int)(using ctx: Context) =
-    given Context = ctx.withPhase(ctx.erasurePhase)
+  def contextFunctionResultTypeCovering(meth: Symbol, paramCount: Int)(using preCtx: Context) =
+    given Context = preCtx.withPhase(preCtx.erasurePhase)
 
     // Recursive instances return pairs of context types and the
     // # of parameters they represent.
@@ -120,9 +120,9 @@ object ContextFunctionResults:
    *  integrated in the  preceding method?
    *  @param `n` the select nodes seen in previous recursive iterations of this method
    */
-  def integrateSelect(tree: untpd.Tree, n: Int = 0)(using ctx: Context): Boolean =
-    if ctx.erasedTypes then
-      integrateSelect(tree, n)(using ctx.withPhase(ctx.erasurePhase))
+  def integrateSelect(tree: untpd.Tree, n: Int = 0)(using Context): Boolean =
+    if curCtx.erasedTypes then
+      integrateSelect(tree, n)(using curCtx.withPhase(curCtx.erasurePhase))
     else tree match
       case Select(qual, name) =>
         if name == nme.apply && defn.isContextFunctionClass(tree.symbol.maybeOwner) then

--- a/compiler/src/dotty/tools/dotc/transform/CookComments.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CookComments.scala
@@ -15,10 +15,10 @@ class CookComments extends MegaPhase.MiniPhase {
       val owner = template.self.symbol.orElse(cls)
 
       template.body.foreach { stat =>
-        Docstrings.cookComment(stat.symbol, owner)(cookingCtx)
+        Docstrings.cookComment(stat.symbol, owner)(using cookingCtx)
       }
 
-      Docstrings.cookComment(cls, cls)(cookingCtx)
+      Docstrings.cookComment(cls, cls)(using cookingCtx)
     }
 
     tree

--- a/compiler/src/dotty/tools/dotc/transform/DropOuterAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/DropOuterAccessors.scala
@@ -34,7 +34,7 @@ class DropOuterAccessors extends MiniPhase with IdentityDenotTransformer:
   override def changesMembers: Boolean = true // the phase drops outer accessors
 
   override def transformTemplate(impl: Template)(using Context): Tree =
-    val outerAccessCount = curCtx.base.countOuterAccessesPhase
+    val outerAccessCount = ctx.base.countOuterAccessesPhase
       .asInstanceOf[CountOuterAccesses]
       .outerAccessCount
 
@@ -80,7 +80,7 @@ class DropOuterAccessors extends MiniPhase with IdentityDenotTransformer:
         })
     assert(droppedParamAccessors.isEmpty,
       i"""Failed to eliminate: $droppedParamAccessors
-          when dropping outer accessors for ${curCtx.owner} with
+          when dropping outer accessors for ${ctx.owner} with
           $impl""")
     cpy.Template(impl)(constr = constr1, body = body1)
   end transformTemplate

--- a/compiler/src/dotty/tools/dotc/transform/DropOuterAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/DropOuterAccessors.scala
@@ -33,8 +33,8 @@ class DropOuterAccessors extends MiniPhase with IdentityDenotTransformer:
 
   override def changesMembers: Boolean = true // the phase drops outer accessors
 
-  override def transformTemplate(impl: Template)(using ctx: Context): Tree =
-    val outerAccessCount = ctx.base.countOuterAccessesPhase
+  override def transformTemplate(impl: Template)(using Context): Tree =
+    val outerAccessCount = curCtx.base.countOuterAccessesPhase
       .asInstanceOf[CountOuterAccesses]
       .outerAccessCount
 
@@ -80,7 +80,7 @@ class DropOuterAccessors extends MiniPhase with IdentityDenotTransformer:
         })
     assert(droppedParamAccessors.isEmpty,
       i"""Failed to eliminate: $droppedParamAccessors
-          when dropping outer accessors for ${ctx.owner} with
+          when dropping outer accessors for ${curCtx.owner} with
           $impl""")
     cpy.Template(impl)(constr = constr1, body = body1)
   end transformTemplate

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -454,7 +454,7 @@ object Erasure {
                 else implType.derivedLambdaType(resType = samResultType)
               val bridge = ctx.newSymbol(ctx.owner, AdaptedClosureName(meth.symbol.name.asTermName), Flags.Synthetic | Flags.Method, bridgeType)
               Closure(bridge, bridgeParamss =>
-                withContext(ctx.withOwner(bridge)) {
+                inContext(ctx.withOwner(bridge)) {
                   val List(bridgeParams) = bridgeParamss
                   assert(ctx.typer.isInstanceOf[Erasure.Typer])
                   val rhs = Apply(meth, bridgeParams.lazyZip(implParamTypes).map(ctx.typer.adapt(_, _)))

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -453,9 +453,8 @@ object Erasure {
                   else implType.derivedLambdaType(paramInfos = samParamTypes)
                 else implType.derivedLambdaType(resType = samResultType)
               val bridge = ctx.newSymbol(ctx.owner, AdaptedClosureName(meth.symbol.name.asTermName), Flags.Synthetic | Flags.Method, bridgeType)
-              val bridgeCtx = ctx.withOwner(bridge)
-              Closure(bridge, bridgeParamss => {
-                  given Context = bridgeCtx
+              Closure(bridge, bridgeParamss =>
+                withContext(ctx.withOwner(bridge)) {
                   val List(bridgeParams) = bridgeParamss
                   assert(ctx.typer.isInstanceOf[Erasure.Typer])
                   val rhs = Apply(meth, bridgeParams.lazyZip(implParamTypes).map(ctx.typer.adapt(_, _)))

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -45,7 +45,7 @@ class Erasure extends Phase with DenotTransformer {
   override def changesMembers: Boolean = true // the phase adds bridges
   override def changesParents: Boolean = true // the phase drops Any
 
-  def transform(ref: SingleDenotation)(implicit ctx: Context): SingleDenotation = ref match {
+  def transform(ref: SingleDenotation)(using Context): SingleDenotation = ref match {
     case ref: SymDenotation =>
       def isCompacted(sym: Symbol) =
         sym.isAnonymousFunction && {
@@ -116,12 +116,12 @@ class Erasure extends Phase with DenotTransformer {
 
   private val eraser = new Erasure.Typer(this)
 
-  def run(implicit ctx: Context): Unit = {
+  def run(using Context): Unit = {
     val unit = ctx.compilationUnit
     unit.tpdTree = eraser.typedExpr(unit.tpdTree)(using ctx.fresh.setTyper(eraser).setPhase(this.next))
   }
 
-  override def checkPostCondition(tree: tpd.Tree)(implicit ctx: Context): Unit = {
+  override def checkPostCondition(tree: tpd.Tree)(using Context): Unit = {
     assertErased(tree)
     tree match {
       case res: tpd.This =>
@@ -143,7 +143,7 @@ class Erasure extends Phase with DenotTransformer {
    *  they need not be reloaded using member; this would likely fail as signatures
    *  may change after erasure).
    */
-  def assertErased(tree: tpd.Tree)(implicit ctx: Context): Unit = {
+  def assertErased(tree: tpd.Tree)(using Context): Unit = {
     assertErased(tree.typeOpt, tree)
     if (!defn.isPolymorphicAfterErasure(tree.symbol))
       assertErased(tree.typeOpt.widen, tree)
@@ -157,7 +157,7 @@ class Erasure extends Phase with DenotTransformer {
       }
   }
 
-  def assertErased(tp: Type, tree: tpd.Tree = tpd.EmptyTree)(implicit ctx: Context): Unit = {
+  def assertErased(tp: Type, tree: tpd.Tree = tpd.EmptyTree)(using Context): Unit = {
     def isAllowed(cls: Symbol, sourceName: String) =
       tp.widen.typeSymbol == cls && ctx.compilationUnit.source.file.name == sourceName
     assert(isErasedType(tp) ||
@@ -207,15 +207,15 @@ object Erasure {
 
   object Boxing:
 
-    def isUnbox(sym: Symbol)(implicit ctx: Context): Boolean =
+    def isUnbox(sym: Symbol)(using Context): Boolean =
       sym.name == nme.unbox && sym.owner.linkedClass.isPrimitiveValueClass
 
-    def isBox(sym: Symbol)(implicit ctx: Context): Boolean =
+    def isBox(sym: Symbol)(using Context): Boolean =
       sym.name == nme.box && sym.owner.linkedClass.isPrimitiveValueClass
 
-    def boxMethod(cls: ClassSymbol)(implicit ctx: Context): Symbol =
+    def boxMethod(cls: ClassSymbol)(using Context): Symbol =
       cls.linkedClass.info.member(nme.box).symbol
-    def unboxMethod(cls: ClassSymbol)(implicit ctx: Context): Symbol =
+    def unboxMethod(cls: ClassSymbol)(using Context): Symbol =
       cls.linkedClass.info.member(nme.unbox).symbol
 
     /** Isf this tree is an unbox operation which can be safely removed
@@ -225,7 +225,7 @@ object Erasure {
      *  This is important for specialization: calls to the super constructor should not box/unbox specialized
      *  fields (see TupleX). (ID)
      */
-    private def safelyRemovableUnboxArg(tree: Tree)(implicit ctx: Context): Tree = tree match {
+    private def safelyRemovableUnboxArg(tree: Tree)(using Context): Tree = tree match {
       case Apply(fn, arg :: Nil)
       if isUnbox(fn.symbol) && defn.ScalaBoxedClasses().contains(arg.tpe.widen.typeSymbol) =>
         arg
@@ -233,10 +233,10 @@ object Erasure {
         EmptyTree
     }
 
-    def constant(tree: Tree, const: Tree)(implicit ctx: Context): Tree =
+    def constant(tree: Tree, const: Tree)(using Context): Tree =
       (if (isPureExpr(tree)) const else Block(tree :: Nil, const)).withSpan(tree.span)
 
-    final def box(tree: Tree, target: => String = "")(implicit ctx: Context): Tree = trace(i"boxing ${tree.showSummary}: ${tree.tpe} into $target") {
+    final def box(tree: Tree, target: => String = "")(using Context): Tree = trace(i"boxing ${tree.showSummary}: ${tree.tpe} into $target") {
       tree.tpe.widen match {
         case ErasedValueType(tycon, _) =>
           New(tycon, cast(tree, underlyingOfValueClass(tycon.symbol.asClass)) :: Nil) // todo: use adaptToType?
@@ -256,7 +256,7 @@ object Erasure {
       }
     }
 
-    def unbox(tree: Tree, pt: Type)(implicit ctx: Context): Tree = trace(i"unboxing ${tree.showSummary}: ${tree.tpe} as a $pt") {
+    def unbox(tree: Tree, pt: Type)(using Context): Tree = trace(i"unboxing ${tree.showSummary}: ${tree.tpe} as a $pt") {
       pt match {
         case ErasedValueType(tycon, underlying) =>
           def unboxedTree(t: Tree) =
@@ -299,7 +299,7 @@ object Erasure {
      *  Casts from and to ErasedValueType are special, see the explanation
      *  in ExtensionMethods#transform.
      */
-    def cast(tree: Tree, pt: Type)(implicit ctx: Context): Tree = trace(i"cast ${tree.tpe.widen} --> $pt", show = true) {
+    def cast(tree: Tree, pt: Type)(using Context): Tree = trace(i"cast ${tree.tpe.widen} --> $pt", show = true) {
 
       def wrap(tycon: TypeRef) =
         ref(u2evt(tycon.typeSymbol.asClass)).appliedTo(tree)
@@ -350,7 +350,7 @@ object Erasure {
      *    e -> unbox(e, PT)  if `PT` is a primitive type and `e` is not of primitive type
      *    e -> cast(e, PT)   otherwise
      */
-    def adaptToType(tree: Tree, pt: Type)(implicit ctx: Context): Tree = pt match
+    def adaptToType(tree: Tree, pt: Type)(using Context): Tree = pt match
       case _: FunProto | AnyFunctionProto => tree
       case _ => tree.tpe.widen match
         case mt: MethodType if tree.isTerm =>
@@ -529,7 +529,7 @@ object Erasure {
   class Typer(erasurePhase: DenotTransformer) extends typer.ReTyper with NoChecking {
     import Boxing._
 
-    def isErased(tree: Tree)(implicit ctx: Context): Boolean = tree match {
+    def isErased(tree: Tree)(using Context): Boolean = tree match {
       case TypeApply(Select(qual, _), _) if tree.symbol == defn.Any_typeCast =>
         isErased(qual)
       case _ => tree.symbol.isEffectivelyErased
@@ -537,7 +537,7 @@ object Erasure {
 
     /** Check that Java statics and packages can only be used in selections.
       */
-    private def checkValue(tree: Tree, proto: Type)(implicit ctx: Context): tree.type =
+    private def checkValue(tree: Tree, proto: Type)(using Context): tree.type =
       if (!proto.isInstanceOf[SelectionProto] && !proto.isInstanceOf[ApplyingProto]) then
         checkValue(tree)
       tree
@@ -549,7 +549,7 @@ object Erasure {
       then
         ctx.error(reporting.messages.JavaSymbolIsNotAValue(sym), tree.sourcePos)
 
-    private def checkNotErased(tree: Tree)(implicit ctx: Context): tree.type = {
+    private def checkNotErased(tree: Tree)(using Context): tree.type = {
       if (!ctx.mode.is(Mode.Type)) {
         if (isErased(tree))
           ctx.error(em"${tree.symbol} is declared as erased, but is in fact used", tree.sourcePos)
@@ -566,17 +566,17 @@ object Erasure {
       tree
     }
 
-    def erasedDef(sym: Symbol)(implicit ctx: Context): Thicket = {
+    def erasedDef(sym: Symbol)(using Context): Thicket = {
       if (sym.owner.isClass) sym.dropAfter(erasurePhase)
       tpd.EmptyTree
     }
 
-    def erasedType(tree: untpd.Tree)(implicit ctx: Context): Type = {
+    def erasedType(tree: untpd.Tree)(using Context): Type = {
       val tp = tree.typeOpt
       if (tree.isTerm) erasedRef(tp) else valueErasure(tp)
     }
 
-    override def promote(tree: untpd.Tree)(implicit ctx: Context): tree.ThisTree[Type] = {
+    override def promote(tree: untpd.Tree)(using Context): tree.ThisTree[Type] = {
       assert(tree.hasType)
       val erasedTp = erasedType(tree)
       ctx.log(s"promoting ${tree.show}: ${erasedTp.showWithUnderlying()}")
@@ -587,11 +587,11 @@ object Erasure {
      *  This is not the case for [[DefDef#tpt]], [[ValDef#tpt]] and [[Typed#tpt]], they
      *  are handled separately by [[typedDefDef]], [[typedValDef]] and [[typedTyped]].
      */
-    override def typedTypeTree(tree: untpd.TypeTree, pt: Type)(implicit ctx: Context): TypeTree =
+    override def typedTypeTree(tree: untpd.TypeTree, pt: Type)(using Context): TypeTree =
       tree.withType(erasure(tree.tpe))
 
     /** This override is only needed to semi-erase type ascriptions */
-    override def typedTyped(tree: untpd.Typed, pt: Type)(implicit ctx: Context): Tree = {
+    override def typedTyped(tree: untpd.Typed, pt: Type)(using Context): Tree = {
       val Typed(expr, tpt) = tree
       val tpt1 = tpt match {
         case Block(_, tpt) => tpt // erase type aliases (statements) from type block
@@ -602,7 +602,7 @@ object Erasure {
       assignType(untpd.cpy.Typed(tree)(expr1, tpt2), tpt2)
     }
 
-    override def typedLiteral(tree: untpd.Literal)(implicit ctx: Context): Tree =
+    override def typedLiteral(tree: untpd.Literal)(using Context): Tree =
       if (tree.typeOpt.isRef(defn.UnitClass))
         tree.withType(tree.typeOpt)
       else if (tree.const.tag == Constants.ClazzTag)
@@ -610,7 +610,7 @@ object Erasure {
       else
         super.typedLiteral(tree)
 
-    override def typedIdent(tree: untpd.Ident, pt: Type)(implicit ctx: Context): Tree =
+    override def typedIdent(tree: untpd.Ident, pt: Type)(using Context): Tree =
       checkValue(checkNotErased(super.typedIdent(tree, pt)), pt)
 
     /** Type check select nodes, applying the following rewritings exhaustively
@@ -633,7 +633,7 @@ object Erasure {
      *      e.clone -> e.clone'         where clone' is Object's clone method
      *      e.m -> e.[]m                if `m` is an array operation other than `clone`.
      */
-    override def typedSelect(tree: untpd.Select, pt: Type)(implicit ctx: Context): Tree = {
+    override def typedSelect(tree: untpd.Select, pt: Type)(using Context): Tree = {
       if tree.name == nme.apply && integrateSelect(tree) then
       	return typed(tree.qualifier, pt)
 
@@ -717,14 +717,14 @@ object Erasure {
       checkValue(checkNotErased(recur(qual1)), pt)
     }
 
-    override def typedThis(tree: untpd.This)(implicit ctx: Context): Tree =
+    override def typedThis(tree: untpd.This)(using Context): Tree =
       if (tree.symbol == ctx.owner.lexicallyEnclosingClass || tree.symbol.isStaticOwner) promote(tree)
       else {
         ctx.log(i"computing outer path from ${ctx.owner.ownersIterator.toList}%, % to ${tree.symbol}, encl class = ${ctx.owner.enclosingClass}")
         outer.path(toCls = tree.symbol)
       }
 
-    override def typedTypeApply(tree: untpd.TypeApply, pt: Type)(implicit ctx: Context): Tree = {
+    override def typedTypeApply(tree: untpd.TypeApply, pt: Type)(using Context): Tree = {
       val ntree = interceptTypeApply(tree.asInstanceOf[TypeApply])(ctx.withPhase(ctx.erasurePhase)).withSpan(tree.span)
 
       ntree match {
@@ -743,7 +743,7 @@ object Erasure {
     /** Besides normal typing, this method does uncurrying and collects parameters
      *  to anonymous functions of arity > 22.
      */
-    override def typedApply(tree: untpd.Apply, pt: Type)(implicit ctx: Context): Tree =
+    override def typedApply(tree: untpd.Apply, pt: Type)(using Context): Tree =
       val Apply(fun, args) = tree
       if fun.symbol == defn.cbnArg then
         typedUnadapted(args.head, pt)
@@ -794,31 +794,31 @@ object Erasure {
     // The following four methods take as the proto-type the erasure of the pre-existing type,
     // if the original proto-type is not a value type.
     // This makes all branches be adapted to the correct type.
-    override def typedSeqLiteral(tree: untpd.SeqLiteral, pt: Type)(implicit ctx: Context): SeqLiteral =
+    override def typedSeqLiteral(tree: untpd.SeqLiteral, pt: Type)(using Context): SeqLiteral =
       super.typedSeqLiteral(tree, erasure(tree.typeOpt))
         // proto type of typed seq literal is original type;
 
-    override def typedIf(tree: untpd.If, pt: Type)(implicit ctx: Context): Tree =
+    override def typedIf(tree: untpd.If, pt: Type)(using Context): Tree =
       super.typedIf(tree, adaptProto(tree, pt))
 
-    override def typedMatch(tree: untpd.Match, pt: Type)(implicit ctx: Context): Tree =
+    override def typedMatch(tree: untpd.Match, pt: Type)(using Context): Tree =
       super.typedMatch(tree, adaptProto(tree, pt))
 
-    override def typedTry(tree: untpd.Try, pt: Type)(implicit ctx: Context): Try =
+    override def typedTry(tree: untpd.Try, pt: Type)(using Context): Try =
       super.typedTry(tree, adaptProto(tree, pt))
 
-    private def adaptProto(tree: untpd.Tree, pt: Type)(implicit ctx: Context) =
+    private def adaptProto(tree: untpd.Tree, pt: Type)(using Context) =
       if (pt.isValueType) pt else
         if (tree.typeOpt.derivesFrom(ctx.definitions.UnitClass))
           tree.typeOpt
         else valueErasure(tree.typeOpt)
 
-    override def typedInlined(tree: untpd.Inlined, pt: Type)(implicit ctx: Context): Tree =
+    override def typedInlined(tree: untpd.Inlined, pt: Type)(using Context): Tree =
       super.typedInlined(tree, pt) match {
         case tree: Inlined => Inliner.dropInlined(tree)
       }
 
-    override def typedValDef(vdef: untpd.ValDef, sym: Symbol)(implicit ctx: Context): Tree =
+    override def typedValDef(vdef: untpd.ValDef, sym: Symbol)(using Context): Tree =
       if (sym.isEffectivelyErased) erasedDef(sym)
       else
         super.typedValDef(untpd.cpy.ValDef(vdef)(
@@ -828,7 +828,7 @@ object Erasure {
      *  with more than `MaxImplementedFunctionArity` parameters to use a single
      *  parameter of type `[]Object`.
      */
-    override def typedDefDef(ddef: untpd.DefDef, sym: Symbol)(implicit ctx: Context): Tree =
+    override def typedDefDef(ddef: untpd.DefDef, sym: Symbol)(using Context): Tree =
       if sym.isEffectivelyErased || sym.name.is(BodyRetainerName) then
         erasedDef(sym)
       else
@@ -935,20 +935,20 @@ object Erasure {
         case stat => stat
       }
 
-    override def typedClosure(tree: untpd.Closure, pt: Type)(implicit ctx: Context): Tree = {
+    override def typedClosure(tree: untpd.Closure, pt: Type)(using Context): Tree = {
       val xxl = defn.isXXLFunctionClass(tree.typeOpt.typeSymbol)
       var implClosure = super.typedClosure(tree, pt).asInstanceOf[Closure]
       if (xxl) implClosure = cpy.Closure(implClosure)(tpt = TypeTree(defn.FunctionXXLClass.typeRef))
       adaptClosure(implClosure)
     }
 
-    override def typedTypeDef(tdef: untpd.TypeDef, sym: Symbol)(implicit ctx: Context): Tree =
+    override def typedTypeDef(tdef: untpd.TypeDef, sym: Symbol)(using Context): Tree =
       EmptyTree
 
-    override def typedAnnotated(tree: untpd.Annotated, pt: Type)(implicit ctx: Context): Tree =
+    override def typedAnnotated(tree: untpd.Annotated, pt: Type)(using Context): Tree =
       typed(tree.arg, pt)
 
-    override def typedStats(stats: List[untpd.Tree], exprOwner: Symbol)(implicit ctx: Context): (List[Tree], Context) = {
+    override def typedStats(stats: List[untpd.Tree], exprOwner: Symbol)(using Context): (List[Tree], Context) = {
       val stats0 = addRetainedInlineBodies(stats)(using preErasureCtx)
       val stats1 =
         if (takesBridges(ctx.owner)) new Bridges(ctx.owner.asClass, erasurePhase).add(stats0)
@@ -957,7 +957,7 @@ object Erasure {
       (stats2.filter(!_.isEmpty), finalCtx)
     }
 
-    override def adapt(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): Tree =
+    override def adapt(tree: Tree, pt: Type, locked: TypeVars)(using Context): Tree =
       trace(i"adapting ${tree.showSummary}: ${tree.tpe} to $pt", show = true) {
         if ctx.phase != ctx.erasurePhase && ctx.phase != ctx.erasurePhase.next then
           // this can happen when reading annotations loaded during erasure,
@@ -968,9 +968,9 @@ object Erasure {
         else adaptToType(tree, pt)
       }
 
-    override def simplify(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): tree.type = tree
+    override def simplify(tree: Tree, pt: Type, locked: TypeVars)(using Context): tree.type = tree
   }
 
-  private def takesBridges(sym: Symbol)(implicit ctx: Context): Boolean =
+  private def takesBridges(sym: Symbol)(using Context): Boolean =
     sym.isClass && !sym.isOneOf(Flags.Trait | Flags.Package)
 }

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -118,7 +118,7 @@ class Erasure extends Phase with DenotTransformer {
 
   def run(implicit ctx: Context): Unit = {
     val unit = ctx.compilationUnit
-    unit.tpdTree = eraser.typedExpr(unit.tpdTree)(ctx.fresh.setTyper(eraser).setPhase(this.next))
+    unit.tpdTree = eraser.typedExpr(unit.tpdTree)(using ctx.fresh.setTyper(eraser).setPhase(this.next))
   }
 
   override def checkPostCondition(tree: tpd.Tree)(implicit ctx: Context): Unit = {

--- a/compiler/src/dotty/tools/dotc/transform/MacroTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroTransform.scala
@@ -18,7 +18,7 @@ abstract class MacroTransform extends Phase {
 
   override def run(implicit ctx: Context): Unit = {
     val unit = ctx.compilationUnit
-    unit.tpdTree = newTransformer.transform(unit.tpdTree)(ctx.withPhase(transformPhase))
+    unit.tpdTree = newTransformer.transform(unit.tpdTree)(using ctx.withPhase(transformPhase))
   }
 
   protected def newTransformer(implicit ctx: Context): Transformer
@@ -40,18 +40,18 @@ abstract class MacroTransform extends Phase {
     def transformStats(trees: List[Tree], exprOwner: Symbol)(implicit ctx: Context): List[Tree] = {
       def transformStat(stat: Tree): Tree = stat match {
         case _: Import | _: DefTree => transform(stat)
-        case _ => transform(stat)(ctx.exprContext(stat, exprOwner))
+        case _ => transform(stat)(using ctx.exprContext(stat, exprOwner))
       }
       flatten(trees.mapconserve(transformStat(_)))
     }
 
-    override def transform(tree: Tree)(implicit ctx: Context): Tree =
+    override def transform(tree: Tree)(using Context): Tree =
       try
         tree match {
           case EmptyValDef =>
             tree
           case _: PackageDef | _: MemberDef =>
-            super.transform(tree)(localCtx(tree))
+            super.transform(tree)(using localCtx(tree))
           case impl @ Template(constr, parents, self, _) =>
             cpy.Template(tree)(
               transformSub(constr),

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -270,7 +270,7 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
 object PCPCheckAndHeal {
   import tpd._
 
-  class QuoteTypeTags(span: Span)(using ctx: Context) {
+  class QuoteTypeTags(span: Span)(using Context) {
 
     private val tags = collection.mutable.LinkedHashMap.empty[Symbol, TypeDef]
 

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -38,7 +38,7 @@ class ParamForwarding extends MiniPhase with IdentityDenotTransformer:
 
   val phaseName: String = "paramForwarding"
 
-  def transformIfParamAlias(mdef: ValOrDefDef)(using ctx: Context): Tree =
+  def transformIfParamAlias(mdef: ValOrDefDef)(using Context): Tree =
 
     def inheritedAccessor(sym: Symbol)(using Context): Symbol =
       val candidate = sym.owner.asClass.superClass

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -229,7 +229,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
         case tree @ Select(qual, name) =>
           if (name.isTypeName) {
             Checking.checkRealizable(qual.tpe, qual.posd)
-            super.transform(tree)(ctx.addMode(Mode.Type))
+            super.transform(tree)(using ctx.addMode(Mode.Type))
           }
           else
             transformSelect(tree, Nil)
@@ -352,7 +352,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
             if !sel.isWildcard then checkIdent(sel)
           super.transform(tree)
         case Typed(Ident(nme.WILDCARD), _) =>
-          super.transform(tree)(ctx.addMode(Mode.Pattern))
+          super.transform(tree)(using ctx.addMode(Mode.Pattern))
             // The added mode signals that bounds in a pattern need not
             // conform to selector bounds. I.e. assume
             //     type Tree[T >: Null <: Type]
@@ -363,7 +363,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
         case m @ MatchTypeTree(bounds, selector, cases) =>
           // Analog to the case above for match types
           def tranformIgnoringBoundsCheck(x: CaseDef): CaseDef =
-            super.transform(x)(ctx.addMode(Mode.Pattern)).asInstanceOf[CaseDef]
+            super.transform(x)(using ctx.addMode(Mode.Pattern)).asInstanceOf[CaseDef]
           cpy.MatchTypeTree(tree)(
             super.transform(bounds),
             super.transform(selector),

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -149,7 +149,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
         case _ =>
       processMemberDef(tree)
 
-    private def checkInferredWellFormed(tree: Tree)(using ctx: Context): Unit = tree match
+    private def checkInferredWellFormed(tree: Tree)(using Context): Unit = tree match
       case tree: TypeTree
       if tree.span.isZeroExtent
           // don't check TypeTrees with non-zero extent;

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -277,8 +277,8 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
           }
         case Inlined(call, bindings, expansion) if !call.isEmpty =>
           val pos = call.sourcePos
-          val callTrace = Inliner.inlineCallTrace(call.symbol, pos)(ctx.withSource(pos.source))
-          cpy.Inlined(tree)(callTrace, transformSub(bindings), transform(expansion)(inlineContext(call)))
+          val callTrace = Inliner.inlineCallTrace(call.symbol, pos)(using ctx.withSource(pos.source))
+          cpy.Inlined(tree)(callTrace, transformSub(bindings), transform(expansion)(using inlineContext(call)))
         case templ: Template =>
           withNoCheckNews(templ.parents.flatMap(newPart)) {
             Checking.checkEnumParentOK(templ.symbol.owner)

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -43,7 +43,7 @@ object Splicer {
       val interpreter = new Interpreter(pos, classLoader)
       val macroOwner = ctx.newSymbol(ctx.owner, nme.MACROkw, Macro | Synthetic, defn.AnyType, coord = tree.span)
       try
-        withContext(ctx.withOwner(macroOwner)) {
+        inContext(ctx.withOwner(macroOwner)) {
           // Some parts of the macro are evaluated during the unpickling performed in quotedExprToTree
           val interpretedExpr = interpreter.interpret[scala.quoted.QuoteContext => scala.quoted.Expr[Any]](tree)
           val interpretedTree = interpretedExpr.fold(tree)(macroClosure => PickledQuotes.quotedExprToTree(macroClosure(QuoteContext())))

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -834,7 +834,7 @@ trait Applications extends Compatibility {
   def typedApply(tree: untpd.Apply, pt: Type)(using Context): Tree = {
 
     def realApply(using Context): Tree = {
-      val originalProto = new FunProto(tree.args, IgnoredProto(pt))(this, tree.isUsingApply)(argCtx(tree))
+      val originalProto = new FunProto(tree.args, IgnoredProto(pt))(this, tree.isUsingApply)(using argCtx(tree))
       record("typedApply")
       val fun1 = typedFunPart(tree.fun, originalProto)
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -987,7 +987,7 @@ trait Applications extends Compatibility {
   }
 
   /** Typecheck an Apply node with a typed function and possibly-typed arguments coming from `proto` */
-  def ApplyTo(app: untpd.Apply, fun: tpd.Tree, methRef: TermRef, proto: FunProto, resultType: Type)(using ctx: Context): tpd.Tree =
+  def ApplyTo(app: untpd.Apply, fun: tpd.Tree, methRef: TermRef, proto: FunProto, resultType: Type)(using Context): tpd.Tree =
     val typer = ctx.typer
     if (proto.allArgTypesAreCurrent())
       typer.ApplyToTyped(app, fun, methRef, proto.typedArgs(), resultType).result

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1104,7 +1104,7 @@ trait Applications extends Compatibility {
         case tree: untpd.RefTree =>
           val nestedCtx = ctx.fresh.setNewTyperState()
           val ttree =
-            typedType(untpd.rename(tree, tree.name.toTypeName))(nestedCtx)
+            typedType(untpd.rename(tree, tree.name.toTypeName))(using nestedCtx)
           ttree.tpe match {
             case alias: TypeRef if alias.info.isTypeAlias && !nestedCtx.reporter.hasErrors =>
               companionRef(alias) match {
@@ -2030,7 +2030,7 @@ trait Applications extends Compatibility {
     val (core, pt1) = integrateTypeArgs(pt)
     val app =
       typed(untpd.Apply(core, untpd.TypedSplice(receiver) :: Nil), pt1, ctx.typerState.ownedVars)(
-        ctx.addMode(Mode.SynthesizeExtMethodReceiver))
+        using ctx.addMode(Mode.SynthesizeExtMethodReceiver))
     def isExtension(tree: Tree): Boolean = methPart(tree) match {
       case Inlined(call, _, _) => isExtension(call)
       case tree @ Select(qual, nme.apply) => tree.symbol.is(Extension) || isExtension(qual)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1103,7 +1103,7 @@ trait Checking {
         // would have produced the same symbol without errors
         def allowAccess(name: Name, sym: Symbol): Boolean = {
           val testCtx = caseCtx.fresh.setNewTyperState()
-          val ref = ctx.typer.typedIdent(untpd.Ident(name), WildcardType)(testCtx)
+          val ref = ctx.typer.typedIdent(untpd.Ident(name), WildcardType)(using testCtx)
           ref.symbol == sym && !testCtx.reporter.hasErrors
         }
         checkRefsLegal(tree, cdef.symbol, allowAccess, "enum case")

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -62,7 +62,7 @@ object Checking {
    *  See TypeOps.boundsViolations for an explanation of the first four parameters.
    */
   def checkBounds(args: List[tpd.Tree], boundss: List[TypeBounds],
-    instantiate: (Type, List[Type]) => Type, app: Type = NoType, tpt: Tree = EmptyTree)(implicit ctx: Context): Unit =
+    instantiate: (Type, List[Type]) => Type, app: Type = NoType, tpt: Tree = EmptyTree)(using Context): Unit =
     args.lazyZip(boundss).foreach { (arg, bound) =>
       if !bound.isLambdaSub && !arg.tpe.hasSimpleKind then
         errorTree(arg,
@@ -78,7 +78,7 @@ object Checking {
    *  Note: This does not check the bounds of AppliedTypeTrees. These
    *  are handled by method checkAppliedType below.
    */
-  def checkBounds(args: List[tpd.Tree], tl: TypeLambda)(implicit ctx: Context): Unit =
+  def checkBounds(args: List[tpd.Tree], tl: TypeLambda)(using Context): Unit =
     checkBounds(args, tl.paramInfos, _.substParams(tl, _))
 
   /** Check applied type trees for well-formedness. This means
@@ -117,13 +117,13 @@ object Checking {
             tree.sourcePos)
       case _ =>
     }
-    def checkValidIfApply(implicit ctx: Context): Unit =
+    def checkValidIfApply(using Context): Unit =
       checkWildcardApply(tycon.tpe.appliedTo(args.map(_.tpe)))
-    checkValidIfApply(ctx.addMode(Mode.AllowLambdaWildcardApply))
+    checkValidIfApply(using ctx.addMode(Mode.AllowLambdaWildcardApply))
   }
 
   /** Check all applied type trees in inferred type `tpt` for well-formedness */
-  def checkAppliedTypesIn(tpt: TypeTree)(implicit ctx: Context): Unit =
+  def checkAppliedTypesIn(tpt: TypeTree)(using Context): Unit =
     val checker = new TypeTraverser:
       def traverse(tp: Type) =
         tp match
@@ -136,7 +136,7 @@ object Checking {
         traverseChildren(tp)
     checker.traverse(tpt.tpe)
 
-  def checkNoWildcard(tree: Tree)(implicit ctx: Context): Tree = tree.tpe match {
+  def checkNoWildcard(tree: Tree)(using Context): Tree = tree.tpe match {
     case tpe: TypeBounds => errorTree(tree, "no wildcard type allowed here")
     case _ => tree
   }
@@ -151,13 +151,13 @@ object Checking {
    *  Test cases are neg/i2771.scala and neg/i2771b.scala.
    *  A NoType paramBounds is used as a sign that checking should be suppressed.
    */
-  def preCheckKind(arg: Tree, paramBounds: Type)(implicit ctx: Context): Tree =
+  def preCheckKind(arg: Tree, paramBounds: Type)(using Context): Tree =
     if (arg.tpe.widen.isRef(defn.NothingClass) ||
         !paramBounds.exists ||
         arg.tpe.hasSameKindAs(paramBounds.bounds.hi)) arg
     else errorTree(arg, em"Type argument ${arg.tpe} has not the same kind as its bound $paramBounds")
 
-  def preCheckKinds(args: List[Tree], paramBoundss: List[Type])(implicit ctx: Context): List[Tree] = {
+  def preCheckKinds(args: List[Tree], paramBoundss: List[Type])(using Context): List[Tree] = {
     val args1 = args.zipWithConserve(paramBoundss)(preCheckKind)
     args1 ++ args.drop(paramBoundss.length)
       // add any arguments that do not correspond to a parameter back,
@@ -167,7 +167,7 @@ object Checking {
   /** Check that `tp` refers to a nonAbstract class
    *  and that the instance conforms to the self type of the created class.
    */
-  def checkInstantiable(tp: Type, posd: Positioned)(implicit ctx: Context): Unit =
+  def checkInstantiable(tp: Type, posd: Positioned)(using Context): Unit =
     tp.underlyingClassRef(refinementOK = false) match {
       case tref: TypeRef =>
         val cls = tref.symbol
@@ -185,7 +185,7 @@ object Checking {
     }
 
   /** Check that type `tp` is realizable. */
-  def checkRealizable(tp: Type, posd: Positioned, what: String = "path")(implicit ctx: Context): Unit = {
+  def checkRealizable(tp: Type, posd: Positioned, what: String = "path")(using Context): Unit = {
     val rstatus = realizability(tp)
     if (rstatus ne Realizable)
       ctx.errorOrMigrationWarning(em"$tp is not a legal $what\nsince it${rstatus.msg}", posd.sourcePos)
@@ -194,7 +194,7 @@ object Checking {
   /** A type map which checks that the only cycles in a type are F-bounds
    *  and that protects all F-bounded references by LazyRefs.
    */
-  class CheckNonCyclicMap(sym: Symbol, reportErrors: Boolean)(implicit ctx: Context) extends TypeMap {
+  class CheckNonCyclicMap(sym: Symbol, reportErrors: Boolean)(using Context) extends TypeMap {
 
     /** Set of type references whose info is currently checked */
     private val locked = mutable.Set[TypeRef]()
@@ -310,7 +310,7 @@ object Checking {
   }
 
   /** If `sym` has an operator name, check that it has an @alpha annotation under -strict */
-  def checkValidOperator(sym: Symbol)(implicit ctx: Context): Unit =
+  def checkValidOperator(sym: Symbol)(using Context): Unit =
     sym.name.toTermName match {
       case name: SimpleName
       if name.isOperatorName
@@ -329,8 +329,8 @@ object Checking {
    *  @return  `info` where every legal F-bounded reference is proctected
    *                  by a `LazyRef`, or `ErrorType` if a cycle was detected and reported.
    */
-  def checkNonCyclic(sym: Symbol, info: Type, reportErrors: Boolean)(implicit ctx: Context): Type = {
-    val checker = new CheckNonCyclicMap(sym, reportErrors)(ctx.addMode(Mode.CheckCyclic))
+  def checkNonCyclic(sym: Symbol, info: Type, reportErrors: Boolean)(using Context): Type = {
+    val checker = new CheckNonCyclicMap(sym, reportErrors)(using ctx.addMode(Mode.CheckCyclic))
     try checker.checkInfo(info)
     catch {
       case ex: CyclicReference =>
@@ -350,7 +350,7 @@ object Checking {
    *  deprecated warnings, not errors.
    */
   def checkRefinementNonCyclic(refinement: Tree, refineCls: ClassSymbol, seen: mutable.Set[Symbol])
-    (implicit ctx: Context): Unit = {
+    (using Context): Unit = {
     def flag(what: String, tree: Tree) =
       ctx.warning(i"$what reference in refinement is deprecated", tree.sourcePos)
     def forwardRef(tree: Tree) = flag("forward", tree)
@@ -358,7 +358,7 @@ object Checking {
     val checkTree = new TreeAccumulator[Unit] {
       def checkRef(tree: Tree, sym: Symbol) =
         if (sym.maybeOwner == refineCls && !seen(sym)) forwardRef(tree)
-      def apply(x: Unit, tree: Tree)(implicit ctx: Context) = tree match {
+      def apply(x: Unit, tree: Tree)(using Context) = tree match {
         case tree: MemberDef =>
           foldOver(x, tree)
           seen += tree.symbol
@@ -396,7 +396,7 @@ object Checking {
    *  unless a type with the same name already appears in `decls`.
    *  @return    true iff no cycles were detected
    */
-  def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, posd: Positioned)(implicit ctx: Context): Unit = {
+  def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, posd: Positioned)(using Context): Unit = {
     // If we don't have more than one parent, then there's nothing to check
     if (parents.lengthCompare(1) <= 0)
       return
@@ -424,7 +424,7 @@ object Checking {
   }
 
   /** Check that symbol's definition is well-formed. */
-  def checkWellFormed(sym: Symbol)(implicit ctx: Context): Unit = {
+  def checkWellFormed(sym: Symbol)(using Context): Unit = {
     def fail(msg: Message) = ctx.error(msg, sym.sourcePos)
 
     def checkWithDeferred(flag: FlagSet) =
@@ -516,7 +516,7 @@ object Checking {
    *
    *  @return The `info` of `sym`, with problematic aliases expanded away.
    */
-  def checkNoPrivateLeaks(sym: Symbol)(implicit ctx: Context): Type = {
+  def checkNoPrivateLeaks(sym: Symbol)(using Context): Type = {
     class NotPrivate extends TypeMap {
       var errors: List[() => String] = Nil
 
@@ -583,7 +583,7 @@ object Checking {
   }
 
   /** Verify classes extending AnyVal meet the requirements */
-  def checkDerivedValueClass(clazz: Symbol, stats: List[Tree])(implicit ctx: Context): Unit = {
+  def checkDerivedValueClass(clazz: Symbol, stats: List[Tree])(using Context): Unit = {
     def checkValueClassMember(stat: Tree) = stat match {
       case _: TypeDef if stat.symbol.isClass =>
         ctx.error(ValueClassesMayNotDefineInner(clazz, stat.symbol), stat.sourcePos)
@@ -644,18 +644,18 @@ trait Checking {
 
   import tpd._
 
-  def checkNonCyclic(sym: Symbol, info: TypeBounds, reportErrors: Boolean)(implicit ctx: Context): Type =
+  def checkNonCyclic(sym: Symbol, info: TypeBounds, reportErrors: Boolean)(using Context): Type =
     Checking.checkNonCyclic(sym, info, reportErrors)
 
-  def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, posd: Positioned)(implicit ctx: Context): Unit =
+  def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, posd: Positioned)(using Context): Unit =
     Checking.checkNonCyclicInherited(joint, parents, decls, posd)
 
   /** Check that type `tp` is stable. */
-  def checkStable(tp: Type, pos: SourcePosition, kind: String)(implicit ctx: Context): Unit =
+  def checkStable(tp: Type, pos: SourcePosition, kind: String)(using Context): Unit =
     if !tp.isStable then ctx.error(NotAPath(tp, kind), pos)
 
   /** Check that all type members of `tp` have realizable bounds */
-  def checkRealizableBounds(cls: Symbol, pos: SourcePosition)(implicit ctx: Context): Unit = {
+  def checkRealizableBounds(cls: Symbol, pos: SourcePosition)(using Context): Unit = {
     val rstatus = boundsRealizability(cls.thisType)
     if (rstatus ne Realizable)
       ctx.error(ex"$cls cannot be instantiated since it${rstatus.msg}", pos)
@@ -665,7 +665,7 @@ trait Checking {
    *  This means `pat` is either marked @unchecked or `pt` conforms to the
    *  pattern's type. If pattern is an UnApply, do the check recursively.
    */
-  def checkIrrefutable(pat: Tree, pt: Type, isPatDef: Boolean)(implicit ctx: Context): Boolean = {
+  def checkIrrefutable(pat: Tree, pt: Type, isPatDef: Boolean)(using Context): Boolean = {
 
     def fail(pat: Tree, pt: Type): Boolean = {
       var reportedPt = pt.dropAnnot(defn.UncheckedAnnot)
@@ -710,7 +710,7 @@ trait Checking {
   }
 
   /** Check that `path` is a legal prefix for an import or export clause */
-  def checkLegalImportPath(path: Tree)(implicit ctx: Context): Unit = {
+  def checkLegalImportPath(path: Tree)(using Context): Unit = {
     checkStable(path.tpe, path.sourcePos, "import prefix")
     if (!ctx.isAfterTyper) Checking.checkRealizable(path.tpe, path.posd)
   }
@@ -721,7 +721,7 @@ trait Checking {
   *   check that class prefix is stable.
    *  @return  `tp` itself if it is a class or trait ref, ObjectType if not.
    */
-  def checkClassType(tp: Type, pos: SourcePosition, traitReq: Boolean, stablePrefixReq: Boolean)(implicit ctx: Context): Type =
+  def checkClassType(tp: Type, pos: SourcePosition, traitReq: Boolean, stablePrefixReq: Boolean)(using Context): Type =
     tp.underlyingClassRef(refinementOK = false) match {
       case tref: TypeRef =>
         if (traitReq && !tref.symbol.is(Trait)) ctx.error(TraitIsExpected(tref.symbol), pos)
@@ -735,7 +735,7 @@ trait Checking {
   /** If `sym` is an implicit conversion, check that implicit conversions are enabled.
    *  @pre  sym.is(GivenOrImplicit)
    */
-  def checkImplicitConversionDefOK(sym: Symbol)(implicit ctx: Context): Unit = {
+  def checkImplicitConversionDefOK(sym: Symbol)(using Context): Unit = {
     def check(): Unit =
       checkFeature(
         nme.implicitConversions,
@@ -760,7 +760,7 @@ trait Checking {
    *    - it is defined in Predef
    *    - it is the scala.reflect.Selectable.reflectiveSelectable conversion
    */
-  def checkImplicitConversionUseOK(sym: Symbol, posd: Positioned)(implicit ctx: Context): Unit =
+  def checkImplicitConversionUseOK(sym: Symbol, posd: Positioned)(using Context): Unit =
     if (sym.exists) {
       val conv =
         if (sym.isOneOf(GivenOrImplicit) || sym.info.isErroneous) sym
@@ -786,7 +786,7 @@ trait Checking {
   /** Check that `tree` is a valid infix operation. That is, if the
    *  operator is alphanumeric, it must be declared `@infix`.
    */
-  def checkValidInfix(tree: untpd.InfixOp, meth: Symbol)(implicit ctx: Context): Unit = {
+  def checkValidInfix(tree: untpd.InfixOp, meth: Symbol)(using Context): Unit = {
 
     def isInfix(sym: Symbol): Boolean =
       sym.hasAnnotation(defn.InfixAnnot) ||
@@ -830,7 +830,7 @@ trait Checking {
   def checkFeature(name: TermName,
                    description: => String,
                    featureUseSite: Symbol,
-                   pos: SourcePosition)(implicit ctx: Context): Unit =
+                   pos: SourcePosition)(using Context): Unit =
     if (!ctx.featureEnabled(name))
       ctx.featureWarning(name.toString, description, featureUseSite, required = false, pos)
 
@@ -838,7 +838,7 @@ trait Checking {
    *  are feasible, i.e. that their lower bound conforms to their upper bound. If a type
    *  argument is infeasible, issue and error and continue with upper bound.
    */
-  def checkFeasibleParent(tp: Type, pos: SourcePosition, where: => String = "")(implicit ctx: Context): Type = {
+  def checkFeasibleParent(tp: Type, pos: SourcePosition, where: => String = "")(using Context): Type = {
     def checkGoodBounds(tp: Type) = tp match {
       case tp @ TypeBounds(lo, hi) if !(lo <:< hi) =>
         ctx.error(ex"no type exists between low bound $lo and high bound $hi$where", pos)
@@ -860,7 +860,7 @@ trait Checking {
   }
 
   /** Check that `tree` can be right hand-side or argument to `inline` value or parameter. */
-  def checkInlineConformant(tree: Tree, isFinal: Boolean, what: => String)(implicit ctx: Context): Unit = {
+  def checkInlineConformant(tree: Tree, isFinal: Boolean, what: => String)(using Context): Unit = {
     // final vals can be marked inline even if they're not pure, see Typer#patchFinalVals
     val purityLevel = if (isFinal) Idempotent else Pure
     tree.tpe.widenTermRefExpr match {
@@ -872,10 +872,10 @@ trait Checking {
   }
 
   /** A hook to exclude selected symbols from double declaration check */
-  def excludeFromDoubleDeclCheck(sym: Symbol)(implicit ctx: Context): Boolean = false
+  def excludeFromDoubleDeclCheck(sym: Symbol)(using Context): Boolean = false
 
   /** Check that class does not declare same symbol twice */
-  def checkNoDoubleDeclaration(cls: Symbol)(implicit ctx: Context): Unit = {
+  def checkNoDoubleDeclaration(cls: Symbol)(using Context): Unit = {
     val seen = new mutable.HashMap[Name, List[Symbol]] {
       override def default(key: Name) = Nil
     }
@@ -909,7 +909,7 @@ trait Checking {
     }
   }
 
-  def checkParentCall(call: Tree, caller: ClassSymbol)(implicit ctx: Context): Unit =
+  def checkParentCall(call: Tree, caller: ClassSymbol)(using Context): Unit =
     if (!ctx.isAfterTyper) {
       val called = call.tpe.classSymbol
       if (caller.is(Trait))
@@ -920,7 +920,7 @@ trait Checking {
 
       if (caller.is(Module)) {
         val traverser = new TreeTraverser {
-          def traverse(tree: Tree)(implicit ctx: Context) = tree match {
+          def traverse(tree: Tree)(using Context) = tree match {
             case tree: RefTree if tree.isTerm && (tree.tpe.widen.classSymbol eq caller) =>
               ctx.error("super constructor cannot be passed a self reference", tree.sourcePos)
             case _ =>
@@ -945,7 +945,7 @@ trait Checking {
     }
 
   /** Check that `tpt` does not define a higher-kinded type */
-  def checkSimpleKinded(tpt: Tree)(implicit ctx: Context): Tree =
+  def checkSimpleKinded(tpt: Tree)(using Context): Tree =
     if (!tpt.tpe.hasSimpleKind && !ctx.compilationUnit.isJava)
         // be more lenient with missing type params in Java,
         // needed to make pos/java-interop/t1196 work.
@@ -953,12 +953,12 @@ trait Checking {
     else tpt
 
   /** Check that the signature of the class mamber does not return a repeated parameter type */
-  def checkSignatureRepeatedParam(sym: Symbol)(implicit ctx: Context): Unit =
+  def checkSignatureRepeatedParam(sym: Symbol)(using Context): Unit =
     if (!sym.isOneOf(Synthetic | InlineProxy | Param) && sym.info.finalResultType.isRepeatedParam)
       ctx.error(em"Cannot return repeated parameter type ${sym.info.finalResultType}", sym.sourcePos)
 
   /** Verify classes extending AnyVal meet the requirements */
-  def checkDerivedValueClass(clazz: Symbol, stats: List[Tree])(implicit ctx: Context): Unit =
+  def checkDerivedValueClass(clazz: Symbol, stats: List[Tree])(using Context): Unit =
     Checking.checkDerivedValueClass(clazz, stats)
 
   /** Given a parent `parent` of a class `cls`, if `parent` is a trait check that
@@ -972,7 +972,7 @@ trait Checking {
    *
    *  The standard library relies on this idiom.
    */
-  def checkTraitInheritance(parent: Symbol, cls: ClassSymbol, pos: SourcePosition)(implicit ctx: Context): Unit =
+  def checkTraitInheritance(parent: Symbol, cls: ClassSymbol, pos: SourcePosition)(using Context): Unit =
     parent match {
       case parent: ClassSymbol if parent.is(Trait) =>
         val psuper = parent.superClass
@@ -987,7 +987,7 @@ trait Checking {
 
   /** Check that case classes are not inherited by case classes.
    */
-  def checkCaseInheritance(parent: Symbol, caseCls: ClassSymbol, pos: SourcePosition)(implicit ctx: Context): Unit =
+  def checkCaseInheritance(parent: Symbol, caseCls: ClassSymbol, pos: SourcePosition)(using Context): Unit =
     parent match {
       case parent: ClassSymbol =>
         if (parent.is(Case))
@@ -1000,10 +1000,10 @@ trait Checking {
   /** Check that method parameter types do not reference their own parameter
    *  or later parameters in the same parameter section.
    */
-  def checkNoForwardDependencies(vparams: List[ValDef])(implicit ctx: Context): Unit = vparams match {
+  def checkNoForwardDependencies(vparams: List[ValDef])(using Context): Unit = vparams match {
     case vparam :: vparams1 =>
       val check = new TreeTraverser {
-        def traverse(tree: Tree)(implicit ctx: Context) = tree match {
+        def traverse(tree: Tree)(using Context) = tree match {
           case id: Ident if vparams.exists(_.symbol == id.symbol) =>
             ctx.error("illegal forward reference to method parameter", id.sourcePos)
           case _ =>
@@ -1021,7 +1021,7 @@ trait Checking {
    *  of the self type, yet is no longer visible once the `this` has been replaced
    *  by some other prefix. See neg/i3083.scala
    */
-  def checkMembersOK(tp: Type, pos: SourcePosition)(implicit ctx: Context): Type = {
+  def checkMembersOK(tp: Type, pos: SourcePosition)(using Context): Type = {
     var ok = true
     val check: Type => Unit = {
       case ref: NamedType =>
@@ -1041,9 +1041,9 @@ trait Checking {
    *  `allowed`. Also check that there are no other explicit `this` references
    *  to `badOwner`.
    */
-  def checkRefsLegal(tree: tpd.Tree, badOwner: Symbol, allowed: (Name, Symbol) => Boolean, where: String)(implicit ctx: Context): Unit = {
+  def checkRefsLegal(tree: tpd.Tree, badOwner: Symbol, allowed: (Name, Symbol) => Boolean, where: String)(using Context): Unit = {
     val checker = new TreeTraverser {
-      def traverse(t: Tree)(implicit ctx: Context) = {
+      def traverse(t: Tree)(using Context) = {
         def check(owner: Symbol, checkedSym: Symbol) =
           if (t.span.isSourceDerived && owner == badOwner)
             t match {
@@ -1062,14 +1062,14 @@ trait Checking {
   }
 
   /** Check that we are in an inline context (inside an inline method or in inline code) */
-  def checkInInlineContext(what: String, posd: Positioned)(implicit ctx: Context): Unit =
+  def checkInInlineContext(what: String, posd: Positioned)(using Context): Unit =
     if !ctx.inInlineMethod && !ctx.isInlineContext then
       ctx.error(em"$what can only be used in an inline method", posd.sourcePos)
 
   /** 1. Check that all case classes that extend `scala.Enum` are `enum` cases
    *  2. Check that case class `enum` cases do not extend java.lang.Enum.
    */
-  def checkEnum(cdef: untpd.TypeDef, cls: Symbol, firstParent: Symbol)(implicit ctx: Context): Unit = {
+  def checkEnum(cdef: untpd.TypeDef, cls: Symbol, firstParent: Symbol)(using Context): Unit = {
     import untpd.modsDeco
     def isEnumAnonCls =
       cls.isAnonymousClass &&
@@ -1094,7 +1094,7 @@ trait Checking {
    *  @param  cdef     the enum companion object class
    *  @param  enumCtx  the context immediately enclosing the corresponding enum
    */
-  def checkEnumCaseRefsLegal(cdef: TypeDef, enumCtx: Context)(implicit ctx: Context): Unit = {
+  def checkEnumCaseRefsLegal(cdef: TypeDef, enumCtx: Context)(using Context): Unit = {
 
     def checkCaseOrDefault(stat: Tree, caseCtx: Context) = {
 
@@ -1165,7 +1165,7 @@ trait Checking {
     }
 
   /** Check that symbol's external name does not clash with symbols defined in the same scope */
-  def checkNoAlphaConflict(stats: List[Tree])(implicit ctx: Context): Unit = {
+  def checkNoAlphaConflict(stats: List[Tree])(using Context): Unit = {
     var seen = Set[Name]()
     for (stat <- stats) {
       val sym = stat.symbol
@@ -1182,31 +1182,31 @@ trait Checking {
 
 trait ReChecking extends Checking {
   import tpd._
-  override def checkEnum(cdef: untpd.TypeDef, cls: Symbol, firstParent: Symbol)(implicit ctx: Context): Unit = ()
-  override def checkRefsLegal(tree: tpd.Tree, badOwner: Symbol, allowed: (Name, Symbol) => Boolean, where: String)(implicit ctx: Context): Unit = ()
-  override def checkEnumCaseRefsLegal(cdef: TypeDef, enumCtx: Context)(implicit ctx: Context): Unit = ()
+  override def checkEnum(cdef: untpd.TypeDef, cls: Symbol, firstParent: Symbol)(using Context): Unit = ()
+  override def checkRefsLegal(tree: tpd.Tree, badOwner: Symbol, allowed: (Name, Symbol) => Boolean, where: String)(using Context): Unit = ()
+  override def checkEnumCaseRefsLegal(cdef: TypeDef, enumCtx: Context)(using Context): Unit = ()
   override def checkAnnotApplicable(annot: Tree, sym: Symbol)(using Context): Boolean = true
 }
 
 trait NoChecking extends ReChecking {
   import tpd._
-  override def checkNonCyclic(sym: Symbol, info: TypeBounds, reportErrors: Boolean)(implicit ctx: Context): Type = info
-  override def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, posd: Positioned)(implicit ctx: Context): Unit = ()
-  override def checkStable(tp: Type, pos: SourcePosition, kind: String)(implicit ctx: Context): Unit = ()
-  override def checkClassType(tp: Type, pos: SourcePosition, traitReq: Boolean, stablePrefixReq: Boolean)(implicit ctx: Context): Type = tp
-  override def checkImplicitConversionDefOK(sym: Symbol)(implicit ctx: Context): Unit = ()
-  override def checkImplicitConversionUseOK(sym: Symbol, posd: Positioned)(implicit ctx: Context): Unit = ()
-  override def checkFeasibleParent(tp: Type, pos: SourcePosition, where: => String = "")(implicit ctx: Context): Type = tp
-  override def checkInlineConformant(tree: Tree, isFinal: Boolean, what: => String)(implicit ctx: Context): Unit = ()
-  override def checkNoAlphaConflict(stats: List[Tree])(implicit ctx: Context): Unit = ()
-  override def checkParentCall(call: Tree, caller: ClassSymbol)(implicit ctx: Context): Unit = ()
-  override def checkSimpleKinded(tpt: Tree)(implicit ctx: Context): Tree = tpt
-  override def checkDerivedValueClass(clazz: Symbol, stats: List[Tree])(implicit ctx: Context): Unit = ()
-  override def checkTraitInheritance(parentSym: Symbol, cls: ClassSymbol, pos: SourcePosition)(implicit ctx: Context): Unit = ()
-  override def checkCaseInheritance(parentSym: Symbol, caseCls: ClassSymbol, pos: SourcePosition)(implicit ctx: Context): Unit = ()
-  override def checkNoForwardDependencies(vparams: List[ValDef])(implicit ctx: Context): Unit = ()
-  override def checkMembersOK(tp: Type, pos: SourcePosition)(implicit ctx: Context): Type = tp
-  override def checkInInlineContext(what: String, posd: Positioned)(implicit ctx: Context): Unit = ()
-  override def checkValidInfix(tree: untpd.InfixOp, meth: Symbol)(implicit ctx: Context): Unit = ()
-  override def checkFeature(name: TermName, description: => String, featureUseSite: Symbol, pos: SourcePosition)(implicit ctx: Context): Unit = ()
+  override def checkNonCyclic(sym: Symbol, info: TypeBounds, reportErrors: Boolean)(using Context): Type = info
+  override def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, posd: Positioned)(using Context): Unit = ()
+  override def checkStable(tp: Type, pos: SourcePosition, kind: String)(using Context): Unit = ()
+  override def checkClassType(tp: Type, pos: SourcePosition, traitReq: Boolean, stablePrefixReq: Boolean)(using Context): Type = tp
+  override def checkImplicitConversionDefOK(sym: Symbol)(using Context): Unit = ()
+  override def checkImplicitConversionUseOK(sym: Symbol, posd: Positioned)(using Context): Unit = ()
+  override def checkFeasibleParent(tp: Type, pos: SourcePosition, where: => String = "")(using Context): Type = tp
+  override def checkInlineConformant(tree: Tree, isFinal: Boolean, what: => String)(using Context): Unit = ()
+  override def checkNoAlphaConflict(stats: List[Tree])(using Context): Unit = ()
+  override def checkParentCall(call: Tree, caller: ClassSymbol)(using Context): Unit = ()
+  override def checkSimpleKinded(tpt: Tree)(using Context): Tree = tpt
+  override def checkDerivedValueClass(clazz: Symbol, stats: List[Tree])(using Context): Unit = ()
+  override def checkTraitInheritance(parentSym: Symbol, cls: ClassSymbol, pos: SourcePosition)(using Context): Unit = ()
+  override def checkCaseInheritance(parentSym: Symbol, caseCls: ClassSymbol, pos: SourcePosition)(using Context): Unit = ()
+  override def checkNoForwardDependencies(vparams: List[ValDef])(using Context): Unit = ()
+  override def checkMembersOK(tp: Type, pos: SourcePosition)(using Context): Type = tp
+  override def checkInInlineContext(what: String, posd: Positioned)(using Context): Unit = ()
+  override def checkValidInfix(tree: untpd.InfixOp, meth: Symbol)(using Context): Unit = ()
+  override def checkFeature(name: TermName, description: => String, featureUseSite: Symbol, pos: SourcePosition)(using Context): Unit = ()
 }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -47,7 +47,7 @@ object Checking {
    *   1. the full inferred type is a TypeTree node
    *   2. the applied type causing the error, if different from (1)
    */
-  private def showInferred(msg: Message, app: Type, tpt: Tree)(using ctx: Context): Message =
+  private def showInferred(msg: Message, app: Type, tpt: Tree)(using Context): Message =
     if tpt.isInstanceOf[TypeTree] then
       def subPart = if app eq tpt.tpe then "" else i" subpart $app of"
       msg.append(i" in$subPart inferred type ${tpt}")
@@ -91,7 +91,7 @@ object Checking {
    *  @param tpt  If `tree` is synthesized from a type in a TypeTree,
    *              the original TypeTree, or EmptyTree otherwise.
    */
-  def checkAppliedType(tree: AppliedTypeTree, tpt: Tree = EmptyTree)(using ctx: Context): Unit = {
+  def checkAppliedType(tree: AppliedTypeTree, tpt: Tree = EmptyTree)(using Context): Unit = {
     val AppliedTypeTree(tycon, args) = tree
     // If `args` is a list of named arguments, return corresponding type parameters,
     // otherwise return type parameters unchanged
@@ -629,7 +629,7 @@ object Checking {
   }
 
   /** Check that an enum case extends its enum class */
-  def checkEnumParentOK(cls: Symbol)(using ctx: Context): Unit =
+  def checkEnumParentOK(cls: Symbol)(using Context): Unit =
     val enumCase =
       if cls.isAllOf(EnumCase) then cls
       else if cls.isAnonymousClass && cls.owner.isAllOf(EnumCase) then cls.owner
@@ -1151,7 +1151,7 @@ trait Checking {
   }
 
   /** check that annotation `annot` is applicable to symbol `sym` */
-  def checkAnnotApplicable(annot: Tree, sym: Symbol)(using ctx: Context): Boolean =
+  def checkAnnotApplicable(annot: Tree, sym: Symbol)(using Context): Boolean =
     !ctx.reporter.reportsErrorsFor { implicit ctx =>
       val annotCls = Annotations.annotClass(annot)
       val pos = annot.sourcePos
@@ -1185,7 +1185,7 @@ trait ReChecking extends Checking {
   override def checkEnum(cdef: untpd.TypeDef, cls: Symbol, firstParent: Symbol)(implicit ctx: Context): Unit = ()
   override def checkRefsLegal(tree: tpd.Tree, badOwner: Symbol, allowed: (Name, Symbol) => Boolean, where: String)(implicit ctx: Context): Unit = ()
   override def checkEnumCaseRefsLegal(cdef: TypeDef, enumCtx: Context)(implicit ctx: Context): Unit = ()
-  override def checkAnnotApplicable(annot: Tree, sym: Symbol)(using ctx: Context): Boolean = true
+  override def checkAnnotApplicable(annot: Tree, sym: Symbol)(using Context): Boolean = true
 }
 
 trait NoChecking extends ReChecking {

--- a/compiler/src/dotty/tools/dotc/typer/Docstrings.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Docstrings.scala
@@ -20,12 +20,12 @@ object Docstrings {
    * @param sym   The symbol for which the comment is being cooked.
    * @param owner The class for which comments are being cooked.
    */
-  def cookComment(sym: Symbol, owner: Symbol)(implicit ctx: Context): Option[Comment] =
+  def cookComment(sym: Symbol, owner: Symbol)(using Context): Option[Comment] =
     ctx.docCtx.flatMap { docCtx =>
-      expand(sym, owner)(ctx, docCtx)
+      expand(sym, owner)(using ctx)(using docCtx)
     }
 
-  private def expand(sym: Symbol, owner: Symbol)(implicit ctx: Context, docCtx: ContextDocstrings): Option[Comment] =
+  private def expand(sym: Symbol, owner: Symbol)(using Context)(using docCtx: ContextDocstrings): Option[Comment] =
     docCtx.docstring(sym).flatMap {
       case cmt if cmt.isExpanded =>
         Some(cmt)
@@ -48,7 +48,7 @@ object Docstrings {
         }
     }
 
-  private def expandComment(sym: Symbol, owner: Symbol, comment: Comment)(implicit ctx: Context, docCtx: ContextDocstrings): Comment = {
+  private def expandComment(sym: Symbol, owner: Symbol, comment: Comment)(using Context)(using docCtx: ContextDocstrings): Comment = {
     val tplExp = docCtx.templateExpander
     tplExp.defineVariables(sym)
     val newComment = comment.expand(tplExp.expandedDocComment(sym, owner, _))

--- a/compiler/src/dotty/tools/dotc/typer/Docstrings.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Docstrings.scala
@@ -3,7 +3,7 @@ package dotc
 package typer
 
 import core._
-import Contexts._, Symbols._, Decorators._, Comments._
+import Contexts._, Symbols._, Decorators._, Comments.{_, given _}
 import ast.tpd
 
 object Docstrings {

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -50,7 +50,7 @@ trait Dynamic {
    *    foo.bar(x = bazX, y = bazY, baz, ...)          ~~> foo.applyDynamicNamed("bar")(("x", bazX), ("y", bazY), ("", baz), ...)
    *    foo.bar[T0, ...](x = bazX, y = bazY, baz, ...) ~~> foo.applyDynamicNamed[T0, ...]("bar")(("x", bazX), ("y", bazY), ("", baz), ...)
    */
-  def typedDynamicApply(tree: untpd.Apply, pt: Type)(implicit ctx: Context): Tree = {
+  def typedDynamicApply(tree: untpd.Apply, pt: Type)(using Context): Tree = {
     def typedDynamicApply(qual: untpd.Tree, name: Name, selSpan: Span, targs: List[untpd.Tree]): Tree = {
       def isNamedArg(arg: untpd.Tree): Boolean = arg match { case NamedArg(_, _) => true; case _ => false }
       val args = tree.args
@@ -87,13 +87,13 @@ trait Dynamic {
    *  Note: inner part of translation foo.bar(baz) = quux ~~> foo.selectDynamic(bar).update(baz, quux) is achieved
    *  through an existing transformation of in typedAssign [foo.bar(baz) = quux ~~> foo.bar.update(baz, quux)].
    */
-  def typedDynamicSelect(tree: untpd.Select, targs: List[Tree], pt: Type)(implicit ctx: Context): Tree =
+  def typedDynamicSelect(tree: untpd.Select, targs: List[Tree], pt: Type)(using Context): Tree =
     typedApply(coreDynamic(tree.qualifier, nme.selectDynamic, tree.name, tree.span, targs), pt)
 
   /** Translate selection that does not typecheck according to the normal rules into a updateDynamic.
    *    foo.bar = baz ~~> foo.updateDynamic(bar)(baz)
    */
-  def typedDynamicAssign(tree: untpd.Assign, pt: Type)(implicit ctx: Context): Tree = {
+  def typedDynamicAssign(tree: untpd.Assign, pt: Type)(using Context): Tree = {
     def typedDynamicAssign(qual: untpd.Tree, name: Name, selSpan: Span, targs: List[untpd.Tree]): Tree =
       typedApply(untpd.Apply(coreDynamic(qual, nme.updateDynamic, name, selSpan, targs), tree.rhs), pt)
     tree.lhs match {
@@ -106,7 +106,7 @@ trait Dynamic {
     }
   }
 
-  private def coreDynamic(qual: untpd.Tree, dynName: Name, name: Name, selSpan: Span, targs: List[untpd.Tree])(implicit ctx: Context): untpd.Apply = {
+  private def coreDynamic(qual: untpd.Tree, dynName: Name, name: Name, selSpan: Span, targs: List[untpd.Tree])(using Context): untpd.Apply = {
     val select = untpd.Select(qual, dynName).withSpan(selSpan)
     val selectWithTypes =
       if (targs.isEmpty) select
@@ -137,7 +137,7 @@ trait Dynamic {
    *  It's an error if U is neither a value nor a method type, or a dependent method
    *  type.
    */
-  def handleStructural(tree: Tree)(implicit ctx: Context): Tree = {
+  def handleStructural(tree: Tree)(using Context): Tree = {
     val (fun @ Select(qual, name), targs, vargss) = decomposeCall(tree)
 
     def structuralCall(selectorName: TermName, ctags: List[Tree]) = {

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -16,29 +16,29 @@ object ErrorReporting {
 
   import tpd._
 
-  def errorTree(tree: untpd.Tree, msg: Message, pos: SourcePosition)(implicit ctx: Context): tpd.Tree =
+  def errorTree(tree: untpd.Tree, msg: Message, pos: SourcePosition)(using Context): tpd.Tree =
     tree.withType(errorType(msg, pos))
 
-  def errorTree(tree: untpd.Tree, msg: Message)(implicit ctx: Context): tpd.Tree =
+  def errorTree(tree: untpd.Tree, msg: Message)(using Context): tpd.Tree =
     errorTree(tree, msg, tree.sourcePos)
 
-  def errorTree(tree: untpd.Tree, msg: TypeError, pos: SourcePosition)(implicit ctx: Context): tpd.Tree =
+  def errorTree(tree: untpd.Tree, msg: TypeError, pos: SourcePosition)(using Context): tpd.Tree =
     tree.withType(errorType(msg, pos))
 
-  def errorType(msg: Message, pos: SourcePosition)(implicit ctx: Context): ErrorType = {
+  def errorType(msg: Message, pos: SourcePosition)(using Context): ErrorType = {
     ctx.error(msg, pos)
     ErrorType(msg)
   }
 
-  def errorType(ex: TypeError, pos: SourcePosition)(implicit ctx: Context): ErrorType = {
+  def errorType(ex: TypeError, pos: SourcePosition)(using Context): ErrorType = {
     ctx.error(ex, pos)
     ErrorType(ex.toMessage)
   }
 
-  def wrongNumberOfTypeArgs(fntpe: Type, expectedArgs: List[ParamInfo], actual: List[untpd.Tree], pos: SourcePosition)(implicit ctx: Context): ErrorType =
+  def wrongNumberOfTypeArgs(fntpe: Type, expectedArgs: List[ParamInfo], actual: List[untpd.Tree], pos: SourcePosition)(using Context): ErrorType =
     errorType(WrongNumberOfTypeArgs(fntpe, expectedArgs, actual)(ctx), pos)
 
-  class Errors(implicit ctx: Context) {
+  class Errors(using Context) {
 
     /** An explanatory note to be added to error messages
      *  when there's a problem with abstract var defs */
@@ -141,5 +141,5 @@ object ErrorReporting {
       else ""
   }
 
-  def err(implicit ctx: Context): Errors = new Errors
+  def err(using Context): Errors = new Errors
 }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -11,7 +11,6 @@ import printing.Texts._
 import Contexts._
 import Types._
 import Flags._
-import TypeErasure.{erasure, hasStableErasure}
 import Mode.ImplicitsEnabled
 import NameOps._
 import NameKinds.{LazyImplicitName, EvidenceParamName}
@@ -29,9 +28,8 @@ import Inferencing.{fullyDefinedType, isFullyDefined}
 import Trees._
 import transform.SymUtils._
 import transform.TypeUtils._
-import transform.SyntheticMembers._
 import Hashable._
-import util.{Property, SourceFile, NoSource}
+import util.{SourceFile, NoSource}
 import config.Config
 import config.Printers.{implicits, implicitsDetailed}
 import collection.mutable
@@ -74,6 +72,9 @@ object Implicits {
     case SelectionProto(name, _, _, _) =>
       tp.memberBasedOnFlags(name, required = ExtensionMethod).exists
     case _ => false
+
+  def strictEquality(using Context): Boolean =
+    ctx.mode.is(Mode.StrictEquality) || ctx.featureEnabled(nme.strictEquality)
 
   /** A common base class of contextual implicits and of-type implicits which
    *  represents a set of references to implicit definitions.
@@ -688,395 +689,7 @@ trait Implicits { self: Typer =>
     }
   }
 
-  /** Handlers to synthesize implicits for special types */
-  type SpecialHandler = (Type, Span) => Context ?=> Tree
-  type SpecialHandlers = List[(ClassSymbol, SpecialHandler)]
-
-  lazy val synthesizedClassTag: SpecialHandler = (formal, span) =>
-    formal.argInfos match
-      case arg :: Nil =>
-        fullyDefinedType(arg, "ClassTag argument", span) match
-          case defn.ArrayOf(elemTp) =>
-            val etag = inferImplicitArg(defn.ClassTagClass.typeRef.appliedTo(elemTp), span)
-            if etag.tpe.isError then EmptyTree else etag.select(nme.wrap)
-          case tp if hasStableErasure(tp) && !defn.isBottomClass(tp.typeSymbol) =>
-            val sym = tp.typeSymbol
-            val classTag = ref(defn.ClassTagModule)
-            val tag =
-              if sym == defn.UnitClass
-                 || sym == defn.AnyClass
-                 || sym == defn.AnyValClass
-              then
-                classTag.select(sym.name.toTermName)
-              else
-                classTag.select(nme.apply).appliedToType(tp).appliedTo(clsOf(erasure(tp)))
-            tag.withSpan(span)
-          case tp => EmptyTree
-      case _ => EmptyTree
-  end synthesizedClassTag
-
-  /** Synthesize the tree for `'[T]` for an implicit `scala.quoted.Type[T]`.
-   *  `T` is deeply dealiased to avoid references to local type aliases.
-   */
-  lazy val synthesizedTypeTag: SpecialHandler = (formal, span) =>
-    def quotedType(t: Type) =
-      if StagingContext.level == 0 then
-        ctx.compilationUnit.needsStaging = true // We will need to run ReifyQuotes
-      ref(defn.InternalQuoted_typeQuote).appliedToType(t)
-    formal.argInfos match
-      case arg :: Nil  =>
-        val deepDealias = new TypeMap:
-          def apply(tp: Type): Type = mapOver(tp.dealias)
-        quotedType(deepDealias(arg))
-      case _ =>
-        EmptyTree
-  end synthesizedTypeTag
-
-  lazy val synthesizedTupleFunction: SpecialHandler = (formal, span) =>
-    formal match
-      case AppliedType(_, funArgs @ fun :: tupled :: Nil) =>
-        def functionTypeEqual(baseFun: Type, actualArgs: List[Type],
-            actualRet: Type, expected: Type) =
-          expected =:= defn.FunctionOf(actualArgs, actualRet,
-            defn.isContextFunctionType(baseFun), defn.isErasedFunctionType(baseFun))
-        val arity: Int =
-          if defn.isErasedFunctionType(fun) || defn.isErasedFunctionType(fun) then -1 // TODO support?
-          else if defn.isFunctionType(fun) then
-            // TupledFunction[(...) => R, ?]
-            fun.dropDependentRefinement.dealias.argInfos match
-              case funArgs :+ funRet
-              if functionTypeEqual(fun, defn.tupleType(funArgs) :: Nil, funRet, tupled) =>
-                // TupledFunction[(...funArgs...) => funRet, ?]
-                funArgs.size
-              case _ => -1
-          else if defn.isFunctionType(tupled) then
-            // TupledFunction[?, (...) => R]
-            tupled.dropDependentRefinement.dealias.argInfos match
-              case tupledArgs :: funRet :: Nil =>
-                defn.tupleTypes(tupledArgs.dealias) match
-                  case Some(funArgs) if functionTypeEqual(tupled, funArgs, funRet, fun) =>
-                    // TupledFunction[?, ((...funArgs...)) => funRet]
-                    funArgs.size
-                  case _ => -1
-              case _ => -1
-          else
-            // TupledFunction[?, ?]
-            -1
-        if arity == -1 then
-          EmptyTree
-        else if arity <= Definitions.MaxImplementedFunctionArity then
-          ref(defn.InternalTupleFunctionModule)
-            .select(s"tupledFunction$arity".toTermName)
-            .appliedToTypes(funArgs)
-        else
-          ref(defn.InternalTupleFunctionModule)
-            .select("tupledFunctionXXL".toTermName)
-            .appliedToTypes(funArgs)
-      case _ =>
-        EmptyTree
-  end synthesizedTupleFunction
-
-  /** If `formal` is of the form Eql[T, U], try to synthesize an
-    *  `Eql.eqlAny[T, U]` as solution.
-    */
-  lazy val synthesizedEql: SpecialHandler = (formal, span) =>
-
-    /** Is there an `Eql[T, T]` instance, assuming -strictEquality? */
-    def hasEq(tp: Type)(using Context): Boolean =
-      val inst = inferImplicitArg(defn.EqlClass.typeRef.appliedTo(tp, tp), span)
-      !inst.isEmpty && !inst.tpe.isError
-
-    /** Can we assume the eqlAny instance for `tp1`, `tp2`?
-      *  This is the case if assumedCanEqual(tp1, tp2), or
-      *  one of `tp1`, `tp2` has a reflexive `Eql` instance.
-      */
-    def validEqAnyArgs(tp1: Type, tp2: Type)(using Context) =
-      assumedCanEqual(tp1, tp2)
-       || inContext(ctx.addMode(Mode.StrictEquality)) {
-            !hasEq(tp1) && !hasEq(tp2)
-          }
-
-    /** Is an `Eql[cls1, cls2]` instance assumed for predefined classes `cls1`, cls2`? */
-    def canComparePredefinedClasses(cls1: ClassSymbol, cls2: ClassSymbol): Boolean =
-
-      def cmpWithBoxed(cls1: ClassSymbol, cls2: ClassSymbol) =
-        cls2 == defn.boxedType(cls1.typeRef).symbol
-        || cls1.isNumericValueClass && cls2.derivesFrom(defn.BoxedNumberClass)
-
-      if cls1.isPrimitiveValueClass then
-        if cls2.isPrimitiveValueClass then
-          cls1 == cls2 || cls1.isNumericValueClass && cls2.isNumericValueClass
-        else
-          cmpWithBoxed(cls1, cls2)
-      else if cls2.isPrimitiveValueClass then
-        cmpWithBoxed(cls2, cls1)
-      else if ctx.explicitNulls then
-        // If explicit nulls is enabled, we want to disallow comparison between Object and Null.
-        // If a nullable value has a non-nullable type, we can still cast it to nullable type
-        // then compare.
-        //
-        // Example:
-        // val x: String = null.asInstanceOf[String]
-        // if (x == null) {} // error: x is non-nullable
-        // if (x.asInstanceOf[String|Null] == null) {} // ok
-        cls1 == defn.NullClass && cls1 == cls2
-      else if cls1 == defn.NullClass then
-        cls1 == cls2 || cls2.derivesFrom(defn.ObjectClass)
-      else if cls2 == defn.NullClass then
-        cls1.derivesFrom(defn.ObjectClass)
-      else
-        false
-    end canComparePredefinedClasses
-
-    /** Some simulated `Eql` instances for predefined types. It's more efficient
-      *  to do this directly instead of setting up a lot of `Eql` instances to
-      *  interpret.
-      */
-    def canComparePredefined(tp1: Type, tp2: Type) =
-      tp1.classSymbols.exists(cls1 =>
-        tp2.classSymbols.exists(cls2 =>
-          canComparePredefinedClasses(cls1, cls2)))
-
-    formal.argTypes match
-      case args @ (arg1 :: arg2 :: Nil) =>
-        List(arg1, arg2).foreach(fullyDefinedType(_, "eq argument", span))
-        if canComparePredefined(arg1, arg2)
-            || !strictEquality && ctx.test(validEqAnyArgs(arg1, arg2))
-        then ref(defn.Eql_eqlAny).appliedToTypes(args).withSpan(span)
-        else EmptyTree
-      case _ => EmptyTree
-  end synthesizedEql
-
-  /** Creates a tree that will produce a ValueOf instance for the requested type.
-   * An EmptyTree is returned if materialization fails.
-   */
-  lazy val synthesizedValueOf: SpecialHandler = (formal, span) =>
-
-    def success(t: Tree) =
-      New(defn.ValueOfClass.typeRef.appliedTo(t.tpe), t :: Nil).withSpan(span)
-
-    formal.argInfos match
-      case arg :: Nil =>
-        fullyDefinedType(arg.dealias, "ValueOf argument", span).normalized match
-          case ConstantType(c: Constant) =>
-            success(Literal(c))
-          case TypeRef(_, sym) if sym == defn.UnitClass =>
-            success(Literal(Constant(())))
-          case n: TermRef =>
-            success(ref(n))
-          case tp =>
-            EmptyTree
-      case _ =>
-        EmptyTree
-  end synthesizedValueOf
-
-  /** Create an anonymous class `new Object { type MirroredMonoType = ... }`
-   *  and mark it with given attachment so that it is made into a mirror at PostTyper.
-   */
-  private def anonymousMirror(monoType: Type, attachment: Property.StickyKey[Unit], span: Span)(using Context) = {
-    val monoTypeDef = untpd.TypeDef(tpnme.MirroredMonoType, untpd.TypeTree(monoType))
-    val newImpl = untpd.Template(
-      constr = untpd.emptyConstructor,
-      parents = untpd.TypeTree(defn.ObjectType) :: Nil,
-      derived = Nil,
-      self = EmptyValDef,
-      body = monoTypeDef :: Nil
-    ).withAttachment(attachment, ())
-    typed(untpd.New(newImpl).withSpan(span))
-  }
-
-  /** The mirror type
-   *
-   *     <parent> {
-   *       MirroredMonoType = <monoType>
-   *       MirroredType = <mirroredType>
-   *       MirroredLabel = <label> }
-   *     }
-   */
-  private def mirrorCore(parentClass: ClassSymbol, monoType: Type, mirroredType: Type, label: Name, formal: Type)(using Context) =
-    formal & parentClass.typeRef
-      .refinedWith(tpnme.MirroredMonoType, TypeAlias(monoType))
-      .refinedWith(tpnme.MirroredType, TypeAlias(mirroredType))
-      .refinedWith(tpnme.MirroredLabel, TypeAlias(ConstantType(Constant(label.toString))))
-
-  /** A path referencing the companion of class type `clsType` */
-  private def companionPath(clsType: Type, span: Span)(using Context) = {
-    val ref = pathFor(clsType.companionRef)
-    assert(ref.symbol.is(Module) && (clsType.classSymbol.is(ModuleClass) || (ref.symbol.companionClass == clsType.classSymbol)))
-    ref.withSpan(span)
-  }
-
-  private def checkFormal(formal: Type)(using Context): Boolean = {
-    @tailrec
-    def loop(tp: Type): Boolean = tp match {
-      case RefinedType(parent, _, _: TypeBounds) => loop(parent)
-      case RefinedType(_, _, _) => false
-      case _ => true
-    }
-    loop(formal)
-  }
-
-  private def mkMirroredMonoType(mirroredType: HKTypeLambda)(using Context): Type = {
-    val monoMap = new TypeMap {
-      def apply(t: Type) = t match {
-        case TypeParamRef(lambda, n) if lambda eq mirroredType => mirroredType.paramInfos(n)
-        case t => mapOver(t)
-      }
-    }
-    monoMap(mirroredType.resultType)
-  }
-
-  private def productMirror(mirroredType: Type, formal: Type, span: Span)(using Context): Tree =
-    mirroredType match
-      case AndType(tp1, tp2) =>
-        productMirror(tp1, formal, span).orElse(productMirror(tp2, formal, span))
-      case _ =>
-        if mirroredType.termSymbol.is(CaseVal) then
-          val module = mirroredType.termSymbol
-          val modulePath = pathFor(mirroredType).withSpan(span)
-          if module.info.classSymbol.is(Scala2x) then
-            val mirrorType = mirrorCore(defn.Mirror_SingletonProxyClass, mirroredType, mirroredType, module.name, formal)
-            val mirrorRef = New(defn.Mirror_SingletonProxyClass.typeRef, modulePath :: Nil)
-            mirrorRef.cast(mirrorType)
-          else
-            val mirrorType = mirrorCore(defn.Mirror_SingletonClass, mirroredType, mirroredType, module.name, formal)
-            modulePath.cast(mirrorType)
-        else if mirroredType.classSymbol.isGenericProduct then
-          val cls = mirroredType.classSymbol
-          val accessors = cls.caseAccessors.filterNot(_.isAllOf(PrivateLocal))
-          val elemLabels = accessors.map(acc => ConstantType(Constant(acc.name.toString)))
-          val (monoType, elemsType) = mirroredType match
-            case mirroredType: HKTypeLambda =>
-              val elems =
-                mirroredType.derivedLambdaType(
-                  resType = TypeOps.nestedPairs(accessors.map(mirroredType.memberInfo(_).widenExpr))
-                )
-              (mkMirroredMonoType(mirroredType), elems)
-            case _ =>
-              val elems = TypeOps.nestedPairs(accessors.map(mirroredType.memberInfo(_).widenExpr))
-              (mirroredType, elems)
-          val mirrorType =
-            mirrorCore(defn.Mirror_ProductClass, monoType, mirroredType, cls.name, formal)
-              .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
-              .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
-          val mirrorRef =
-            if (cls.is(Scala2x)) anonymousMirror(monoType, ExtendsProductMirror, span)
-            else companionPath(mirroredType, span)
-          mirrorRef.cast(mirrorType)
-        else EmptyTree
-  end productMirror
-
-  private def sumMirror(mirroredType: Type, formal: Type, span: Span)(using Context): Tree =
-    if mirroredType.classSymbol.isGenericSum then
-      val cls = mirroredType.classSymbol
-      val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))
-
-      def solve(sym: Symbol): Type = sym match
-        case caseClass: ClassSymbol =>
-          assert(caseClass.is(Case))
-          if caseClass.is(Module) then
-            caseClass.sourceModule.termRef
-          else
-            caseClass.primaryConstructor.info match
-              case info: PolyType =>
-                // Compute the the full child type by solving the subtype constraint
-                // `C[X1, ..., Xn] <: P`, where
-                //
-                //   - P is the current `mirroredType`
-                //   - C is the child class, with type parameters X1, ..., Xn
-                //
-                // Contravariant type parameters are minimized, all other type parameters are maximized.
-                def instantiate(using Context) =
-                  val poly = constrained(info, untpd.EmptyTree)._1
-                  val resType = poly.finalResultType
-                  val target = mirroredType match
-                    case tp: HKTypeLambda => tp.resultType
-                    case tp => tp
-                  resType <:< target
-                  val tparams = poly.paramRefs
-                  val variances = caseClass.typeParams.map(_.paramVarianceSign)
-                  val instanceTypes = tparams.lazyZip(variances).map((tparam, variance) =>
-                    ctx.typeComparer.instanceType(tparam, fromBelow = variance < 0))
-                  resType.substParams(poly, instanceTypes)
-                instantiate(using ctx.fresh.setExploreTyperState().setOwner(caseClass))
-              case _ =>
-                caseClass.typeRef
-        case child => child.termRef
-      end solve
-
-      val (monoType, elemsType) = mirroredType match
-        case mirroredType: HKTypeLambda =>
-          val elems = mirroredType.derivedLambdaType(
-            resType = TypeOps.nestedPairs(cls.children.map(solve))
-          )
-          (mkMirroredMonoType(mirroredType), elems)
-        case _ =>
-          val elems = TypeOps.nestedPairs(cls.children.map(solve))
-          (mirroredType, elems)
-
-      val mirrorType =
-          mirrorCore(defn.Mirror_SumClass, monoType, mirroredType, cls.name, formal)
-          .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
-          .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
-      val mirrorRef =
-        if cls.linkedClass.exists && !cls.is(Scala2x)
-        then companionPath(mirroredType, span)
-        else anonymousMirror(monoType, ExtendsSumMirror, span)
-      mirrorRef.cast(mirrorType)
-    else EmptyTree
-  end sumMirror
-
-  def makeMirror
-      (synth: (Type, Type, Span) => Context ?=> Tree, formal: Type, span: Span)
-      (using Context): Tree =
-    if checkFormal(formal) then
-      formal.member(tpnme.MirroredType).info match
-        case TypeBounds(mirroredType, _) => synth(mirroredType.stripTypeVar, formal, span)
-        case other => EmptyTree
-    else EmptyTree
-
-  /** An implied instance for a type of the form `Mirror.Product { type MirroredType = T }`
-   *  where `T` is a generic product type or a case object or an enum case.
-   */
-  lazy val synthesizedProductMirror: SpecialHandler = (formal, span) =>
-    makeMirror(productMirror, formal, span)
-
-  /** An implied instance for a type of the form `Mirror.Sum { type MirroredType = T }`
-   *  where `T` is a generic sum type.
-   */
-  lazy val synthesizedSumMirror: SpecialHandler = (formal, span) =>
-    makeMirror(sumMirror, formal, span)
-
-  /** An implied instance for a type of the form `Mirror { type MirroredType = T }`
-   *  where `T` is a generic sum or product or singleton type.
-   */
-  lazy val synthesizedMirror: SpecialHandler = (formal, span) =>
-    formal.member(tpnme.MirroredType).info match
-      case TypeBounds(mirroredType, _) =>
-        if mirroredType.termSymbol.is(CaseVal)
-           || mirroredType.classSymbol.isGenericProduct
-        then
-          synthesizedProductMirror(formal, span)(using ctx)
-        else
-          synthesizedSumMirror(formal, span)(using ctx)
-      case _ => EmptyTree
-
-  private var mySpecialHandlers: SpecialHandlers = null
-
-  private def specialHandlers(using Context) = {
-    if (mySpecialHandlers == null)
-      mySpecialHandlers = List(
-        defn.ClassTagClass        -> synthesizedClassTag,
-        defn.QuotedTypeClass      -> synthesizedTypeTag,
-        defn.EqlClass             -> synthesizedEql,
-        defn.TupledFunctionClass  -> synthesizedTupleFunction,
-        defn.ValueOfClass         -> synthesizedValueOf,
-        defn.Mirror_ProductClass  -> synthesizedProductMirror,
-        defn.Mirror_SumClass      -> synthesizedSumMirror,
-        defn.MirrorClass          -> synthesizedMirror
-      )
-    mySpecialHandlers
-  }
+  lazy val synthesize = Synthesizer(this)
 
   /** Find an implicit argument for parameter `formal`.
    *  Return a failure as a SearchFailureType in the type of the returned tree.
@@ -1085,26 +698,8 @@ trait Implicits { self: Typer =>
     inferImplicit(formal, EmptyTree, span)(using ctx) match {
       case SearchSuccess(arg, _, _) => arg
       case fail @ SearchFailure(failed) =>
-        def trySpecialCases(handlers: SpecialHandlers): Tree = handlers match {
-          case (cls, handler) :: rest =>
-            def baseWithRefinements(tp: Type): Type = tp.dealias match {
-              case tp @ RefinedType(parent, rname, rinfo) =>
-                tp.derivedRefinedType(baseWithRefinements(parent), rname, rinfo)
-              case _ =>
-                tp.baseType(cls)
-            }
-            val base = baseWithRefinements(formal)
-            val result =
-              if (base <:< formal.widenExpr)
-                // With the subtype test we enforce that the searched type `formal` is of the right form
-                handler(base, span)(using ctx)
-              else EmptyTree
-            result.orElse(trySpecialCases(rest))
-          case Nil =>
-            failed
-        }
-        if (fail.isAmbiguous) failed
-        else trySpecialCases(specialHandlers)
+        if fail.isAmbiguous then failed
+        else synthesize.tryAll(formal, span).orElse(failed)
     }
 
   /** Search an implicit argument and report error if not found */
@@ -1246,15 +841,12 @@ trait Implicits { self: Typer =>
               else s"parameter $paramName" } of $methodStr"
     }
 
-  private def strictEquality(using Context): Boolean =
-    ctx.mode.is(Mode.StrictEquality) || ctx.featureEnabled(nme.strictEquality)
-
   /** An Eql[T, U] instance is assumed
    *   - if one of T, U is an error type, or
    *   - if one of T, U is a subtype of the lifted version of the other,
    *     unless strict equality is set.
    */
-  private def assumedCanEqual(ltp: Type, rtp: Type)(using Context) = {
+  def assumedCanEqual(ltp: Type, rtp: Type)(using Context) = {
     // Map all non-opaque abstract types to their upper bound.
     // This is done to check whether such types might plausibly be comparable to each other.
     val lift = new TypeMap {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -49,7 +49,7 @@ object Implicits {
    *  Gets generated if an implicit ref is imported via a renaming import.
    */
   class RenamedImplicitRef(val underlyingRef: TermRef, val alias: TermName) extends ImplicitRef {
-    def implicitName(implicit ctx: Context): TermName = alias
+    def implicitName(using Context): TermName = alias
   }
 
   /** An eligible implicit candidate, consisting of an implicit reference and a nesting level */
@@ -79,8 +79,9 @@ object Implicits {
    *  represents a set of references to implicit definitions.
    */
   abstract class ImplicitRefs(initctx: Context) {
-    implicit val irefCtx: Context =
-      if (initctx == NoContext) initctx else initctx retractMode Mode.ImplicitsEnabled
+    val irefCtx =
+      if (initctx == NoContext) initctx else initctx.retractMode(Mode.ImplicitsEnabled)
+    protected given Context = irefCtx
 
     /** The nesting level of this context. Non-zero only in ContextialImplicits */
     def level: Int = 0
@@ -91,17 +92,17 @@ object Implicits {
     private var SingletonClass: ClassSymbol = null
 
     /** Widen type so that it is neither a singleton type nor a type that inherits from scala.Singleton. */
-    private def widenSingleton(tp: Type)(implicit ctx: Context): Type = {
+    private def widenSingleton(tp: Type)(using Context): Type = {
       if (SingletonClass == null) SingletonClass = defn.SingletonClass
       val wtp = tp.widenSingleton
       if (wtp.derivesFrom(SingletonClass)) defn.AnyType else wtp
     }
 
     /** Return those references in `refs` that are compatible with type `pt`. */
-    protected def filterMatching(pt: Type)(implicit ctx: Context): List[Candidate] = {
+    protected def filterMatching(pt: Type)(using Context): List[Candidate] = {
       record("filterMatching")
 
-      def candidateKind(ref: TermRef)(implicit ctx: Context): Candidate.Kind = { /*trace(i"candidateKind $ref $pt")*/
+      def candidateKind(ref: TermRef)(using Context): Candidate.Kind = { /*trace(i"candidateKind $ref $pt")*/
 
         def viewCandidateKind(tpw: Type, argType: Type, resType: Type): Candidate.Kind = {
 
@@ -377,9 +378,9 @@ object Implicits {
     def argument: Tree
 
     /** A "massaging" function for displayed types to give better info in error diagnostics */
-    def clarify(tp: Type)(implicit ctx: Context): Type = tp
+    def clarify(tp: Type)(using Context): Type = tp
 
-    final protected def qualify(implicit ctx: Context): String = expectedType match {
+    final protected def qualify(using Context): String = expectedType match {
       case SelectionProto(name, mproto, _, _) if !argument.isEmpty =>
         em"provide an extension method `$name` on ${argument.tpe}"
       case NoType =>
@@ -391,14 +392,14 @@ object Implicits {
     }
 
     /** An explanation of the cause of the failure as a string */
-    def explanation(implicit ctx: Context): String
+    def explanation(using Context): String
 
-    def msg(implicit ctx: Context): Message = explanation
+    def msg(using Context): Message = explanation
 
     /** If search was for an implicit conversion, a note describing the failure
      *  in more detail - this is either empty or starts with a '\n'
      */
-    def whyNoConversion(implicit ctx: Context): String = ""
+    def whyNoConversion(using Context): String = ""
   }
 
   class NoMatchingImplicits(val expectedType: Type, val argument: Tree, constraint: Constraint = OrderingConstraint.empty)
@@ -407,8 +408,10 @@ object Implicits {
     /** Replace all type parameters in constraint by their bounds, to make it clearer
      *  what was expected
      */
-    override def clarify(tp: Type)(implicit ctx: Context): Type = {
-      def replace(implicit ctx: Context): Type = {
+    override def clarify(tp: Type)(using Context): Type =
+      val ctx1 = ctx.fresh.setExploreTyperState()
+      ctx1.typerState.constraint = constraint
+      inContext(ctx1) {
         val map = new TypeMap {
           def apply(t: Type): Type = t match {
             case t: TypeParamRef =>
@@ -426,12 +429,7 @@ object Implicits {
         map(tp)
       }
 
-      val ctx1 = ctx.fresh.setExploreTyperState()
-      ctx1.typerState.constraint = constraint
-      replace(ctx1)
-    }
-
-    def explanation(implicit ctx: Context): String =
+    def explanation(using Context): String =
       em"no implicit values were found that $qualify"
     override def toString = s"NoMatchingImplicits($expectedType, $argument)"
   }
@@ -443,9 +441,9 @@ object Implicits {
 
   /** An ambiguous implicits failure */
   class AmbiguousImplicits(val alt1: SearchSuccess, val alt2: SearchSuccess, val expectedType: Type, val argument: Tree) extends SearchFailureType {
-    def explanation(implicit ctx: Context): String =
+    def explanation(using Context): String =
       em"both ${err.refStr(alt1.ref)} and ${err.refStr(alt2.ref)} $qualify"
-    override def whyNoConversion(implicit ctx: Context): String = {
+    override def whyNoConversion(using Context): String = {
       val what = if (expectedType.isInstanceOf[SelectionProto]) "extension methods" else "conversions"
       i"""
          |Note that implicit $what cannot be applied because they are ambiguous;
@@ -456,14 +454,14 @@ object Implicits {
   class MismatchedImplicit(ref: TermRef,
                            val expectedType: Type,
                            val argument: Tree) extends SearchFailureType {
-    def explanation(implicit ctx: Context): String =
+    def explanation(using Context): String =
       em"${err.refStr(ref)} does not $qualify"
   }
 
   class DivergingImplicit(ref: TermRef,
                           val expectedType: Type,
                           val argument: Tree) extends SearchFailureType {
-    def explanation(implicit ctx: Context): String =
+    def explanation(using Context): String =
       em"${err.refStr(ref)} produces a diverging implicit search when trying to $qualify"
   }
 }
@@ -476,7 +474,7 @@ trait ImplicitRunInfo {
 
   private val implicitScopeCache = mutable.AnyRefMap[Type, OfTypeImplicits]()
 
-  private val EmptyTermRefSet = new TermRefSet()(NoContext)
+  private val EmptyTermRefSet = new TermRefSet(using NoContext)
 
   /** The implicit scope of a type `tp`, defined as follows:
    *
@@ -647,23 +645,22 @@ trait Implicits { self: Typer =>
 
   import tpd._
 
-  override def viewExists(from: Type, to: Type)(implicit ctx: Context): Boolean = (
+  override def viewExists(from: Type, to: Type)(using Context): Boolean =
        !from.isError
     && !to.isError
     && !ctx.isAfterTyper
-    && (ctx.mode is Mode.ImplicitsEnabled)
+    && ctx.mode.is(Mode.ImplicitsEnabled)
     && from.isValueType
     && (  from.isValueSubType(to)
        || inferView(dummyTreeOfType(from), to)
-            (ctx.fresh.addMode(Mode.ImplicitExploration).setExploreTyperState()).isSuccess
+            (using ctx.fresh.addMode(Mode.ImplicitExploration).setExploreTyperState()).isSuccess
           // TODO: investigate why we can't TyperState#test here
        )
-    )
 
   /** Find an implicit conversion to apply to given tree `from` so that the
    *  result is compatible with type `to`.
    */
-  def inferView(from: Tree, to: Type)(implicit ctx: Context): SearchResult = {
+  def inferView(from: Tree, to: Type)(using Context): SearchResult = {
     record("inferView")
     if    to.isAny
        || to.isAnyRef
@@ -692,199 +689,191 @@ trait Implicits { self: Typer =>
   }
 
   /** Handlers to synthesize implicits for special types */
-  type SpecialHandler = (Type, Span) => Context => Tree
+  type SpecialHandler = (Type, Span) => Context ?=> Tree
   type SpecialHandlers = List[(ClassSymbol, SpecialHandler)]
 
-  lazy val synthesizedClassTag: SpecialHandler =
-    (formal, span) => implicit ctx => formal.argInfos match {
+  lazy val synthesizedClassTag: SpecialHandler = (formal, span) =>
+    formal.argInfos match
       case arg :: Nil =>
-        fullyDefinedType(arg, "ClassTag argument", span) match {
+        fullyDefinedType(arg, "ClassTag argument", span) match
           case defn.ArrayOf(elemTp) =>
             val etag = inferImplicitArg(defn.ClassTagClass.typeRef.appliedTo(elemTp), span)
-            if (etag.tpe.isError) EmptyTree else etag.select(nme.wrap)
+            if etag.tpe.isError then EmptyTree else etag.select(nme.wrap)
           case tp if hasStableErasure(tp) && !defn.isBottomClass(tp.typeSymbol) =>
             val sym = tp.typeSymbol
             val classTag = ref(defn.ClassTagModule)
             val tag =
-              if (sym == defn.UnitClass || sym == defn.AnyClass || sym == defn.AnyValClass)
+              if sym == defn.UnitClass
+                 || sym == defn.AnyClass
+                 || sym == defn.AnyValClass
+              then
                 classTag.select(sym.name.toTermName)
               else
                 classTag.select(nme.apply).appliedToType(tp).appliedTo(clsOf(erasure(tp)))
             tag.withSpan(span)
-          case tp =>
-            EmptyTree
-        }
-      case _ =>
-        EmptyTree
-    }
+          case tp => EmptyTree
+      case _ => EmptyTree
+  end synthesizedClassTag
 
   /** Synthesize the tree for `'[T]` for an implicit `scala.quoted.Type[T]`.
    *  `T` is deeply dealiased to avoid references to local type aliases.
    */
-  lazy val synthesizedTypeTag: SpecialHandler = {
-    (formal, span) => implicit ctx => {
-      def quotedType(t: Type) = {
-        if (StagingContext.level == 0)
-          ctx.compilationUnit.needsStaging = true // We will need to run ReifyQuotes
-        ref(defn.InternalQuoted_typeQuote).appliedToType(t)
-      }
-      formal.argInfos match {
-        case arg :: Nil  =>
-          val deepDealias = new TypeMap {
-            def apply(tp: Type): Type = mapOver(tp.dealias)
-          }
-          quotedType(deepDealias(arg))
-        case _ =>
-          EmptyTree
-      }
-    }
-  }
+  lazy val synthesizedTypeTag: SpecialHandler = (formal, span) =>
+    def quotedType(t: Type) =
+      if StagingContext.level == 0 then
+        ctx.compilationUnit.needsStaging = true // We will need to run ReifyQuotes
+      ref(defn.InternalQuoted_typeQuote).appliedToType(t)
+    formal.argInfos match
+      case arg :: Nil  =>
+        val deepDealias = new TypeMap:
+          def apply(tp: Type): Type = mapOver(tp.dealias)
+        quotedType(deepDealias(arg))
+      case _ =>
+        EmptyTree
+  end synthesizedTypeTag
 
-  lazy val synthesizedTupleFunction: SpecialHandler =
-    (formal, span) => implicit ctx => formal match {
+  lazy val synthesizedTupleFunction: SpecialHandler = (formal, span) =>
+    formal match
       case AppliedType(_, funArgs @ fun :: tupled :: Nil) =>
-        def functionTypeEqual(baseFun: Type, actualArgs: List[Type], actualRet: Type, expected: Type) =
-          expected =:= defn.FunctionOf(actualArgs, actualRet, defn.isContextFunctionType(baseFun), defn.isErasedFunctionType(baseFun))
+        def functionTypeEqual(baseFun: Type, actualArgs: List[Type],
+            actualRet: Type, expected: Type) =
+          expected =:= defn.FunctionOf(actualArgs, actualRet,
+            defn.isContextFunctionType(baseFun), defn.isErasedFunctionType(baseFun))
         val arity: Int =
-          if (defn.isErasedFunctionType(fun) || defn.isErasedFunctionType(fun)) -1 // TODO support?
-          else if (defn.isFunctionType(fun))
+          if defn.isErasedFunctionType(fun) || defn.isErasedFunctionType(fun) then -1 // TODO support?
+          else if defn.isFunctionType(fun) then
             // TupledFunction[(...) => R, ?]
-            fun.dropDependentRefinement.dealias.argInfos match {
-              case funArgs :+ funRet if functionTypeEqual(fun, defn.tupleType(funArgs) :: Nil, funRet, tupled) =>
+            fun.dropDependentRefinement.dealias.argInfos match
+              case funArgs :+ funRet
+              if functionTypeEqual(fun, defn.tupleType(funArgs) :: Nil, funRet, tupled) =>
                 // TupledFunction[(...funArgs...) => funRet, ?]
                 funArgs.size
               case _ => -1
-            }
-          else if (defn.isFunctionType(tupled))
+          else if defn.isFunctionType(tupled) then
             // TupledFunction[?, (...) => R]
-            tupled.dropDependentRefinement.dealias.argInfos match {
+            tupled.dropDependentRefinement.dealias.argInfos match
               case tupledArgs :: funRet :: Nil =>
-                defn.tupleTypes(tupledArgs.dealias) match {
+                defn.tupleTypes(tupledArgs.dealias) match
                   case Some(funArgs) if functionTypeEqual(tupled, funArgs, funRet, fun) =>
                     // TupledFunction[?, ((...funArgs...)) => funRet]
                     funArgs.size
                   case _ => -1
-                }
               case _ => -1
-            }
           else
             // TupledFunction[?, ?]
             -1
-        if (arity == -1)
+        if arity == -1 then
           EmptyTree
-        else if (arity <= Definitions.MaxImplementedFunctionArity)
-          ref(defn.InternalTupleFunctionModule).select(s"tupledFunction$arity".toTermName).appliedToTypes(funArgs)
+        else if arity <= Definitions.MaxImplementedFunctionArity then
+          ref(defn.InternalTupleFunctionModule)
+            .select(s"tupledFunction$arity".toTermName)
+            .appliedToTypes(funArgs)
         else
-          ref(defn.InternalTupleFunctionModule).select("tupledFunctionXXL".toTermName).appliedToTypes(funArgs)
+          ref(defn.InternalTupleFunctionModule)
+            .select("tupledFunctionXXL".toTermName)
+            .appliedToTypes(funArgs)
       case _ =>
         EmptyTree
-    }
+  end synthesizedTupleFunction
 
   /** If `formal` is of the form Eql[T, U], try to synthesize an
     *  `Eql.eqlAny[T, U]` as solution.
     */
-  lazy val synthesizedEql: SpecialHandler = {
-    (formal, span) => implicit ctx => {
+  lazy val synthesizedEql: SpecialHandler = (formal, span) =>
 
-      /** Is there an `Eql[T, T]` instance, assuming -strictEquality? */
-      def hasEq(tp: Type)(implicit ctx: Context): Boolean = {
-        val inst = inferImplicitArg(defn.EqlClass.typeRef.appliedTo(tp, tp), span)
-        !inst.isEmpty && !inst.tpe.isError
-      }
+    /** Is there an `Eql[T, T]` instance, assuming -strictEquality? */
+    def hasEq(tp: Type)(using Context): Boolean =
+      val inst = inferImplicitArg(defn.EqlClass.typeRef.appliedTo(tp, tp), span)
+      !inst.isEmpty && !inst.tpe.isError
 
-      /** Can we assume the eqlAny instance for `tp1`, `tp2`?
-       *  This is the case if assumedCanEqual(tp1, tp2), or
-       *  one of `tp1`, `tp2` has a reflexive `Eql` instance.
-       */
-      def validEqAnyArgs(tp1: Type, tp2: Type)(implicit ctx: Context) =
-        assumedCanEqual(tp1, tp2) || {
-          val nestedCtx = ctx.fresh.addMode(Mode.StrictEquality)
-          !hasEq(tp1)(nestedCtx) && !hasEq(tp2)(nestedCtx)
-        }
+    /** Can we assume the eqlAny instance for `tp1`, `tp2`?
+      *  This is the case if assumedCanEqual(tp1, tp2), or
+      *  one of `tp1`, `tp2` has a reflexive `Eql` instance.
+      */
+    def validEqAnyArgs(tp1: Type, tp2: Type)(using Context) =
+      assumedCanEqual(tp1, tp2)
+       || inContext(ctx.addMode(Mode.StrictEquality)) {
+            !hasEq(tp1) && !hasEq(tp2)
+          }
 
-      /** Is an `Eql[cls1, cls2]` instance assumed for predefined classes `cls1`, cls2`? */
-      def canComparePredefinedClasses(cls1: ClassSymbol, cls2: ClassSymbol): Boolean = {
-        def cmpWithBoxed(cls1: ClassSymbol, cls2: ClassSymbol) =
-          cls2 == defn.boxedType(cls1.typeRef).symbol ||
-          cls1.isNumericValueClass && cls2.derivesFrom(defn.BoxedNumberClass)
+    /** Is an `Eql[cls1, cls2]` instance assumed for predefined classes `cls1`, cls2`? */
+    def canComparePredefinedClasses(cls1: ClassSymbol, cls2: ClassSymbol): Boolean =
 
-        if (cls1.isPrimitiveValueClass)
-          if (cls2.isPrimitiveValueClass)
-            cls1 == cls2 || cls1.isNumericValueClass && cls2.isNumericValueClass
-          else
-            cmpWithBoxed(cls1, cls2)
-        else if (cls2.isPrimitiveValueClass)
-          cmpWithBoxed(cls2, cls1)
-        else if (ctx.explicitNulls)
-          // If explicit nulls is enabled, we want to disallow comparison between Object and Null.
-          // If a nullable value has a non-nullable type, we can still cast it to nullable type
-          // then compare.
-          //
-          // Example:
-          // val x: String = null.asInstanceOf[String]
-          // if (x == null) {} // error: x is non-nullable
-          // if (x.asInstanceOf[String|Null] == null) {} // ok
-          cls1 == defn.NullClass && cls1 == cls2
-        else if (cls1 == defn.NullClass)
-          cls1 == cls2 || cls2.derivesFrom(defn.ObjectClass)
-        else if (cls2 == defn.NullClass)
-          cls1.derivesFrom(defn.ObjectClass)
+      def cmpWithBoxed(cls1: ClassSymbol, cls2: ClassSymbol) =
+        cls2 == defn.boxedType(cls1.typeRef).symbol
+        || cls1.isNumericValueClass && cls2.derivesFrom(defn.BoxedNumberClass)
+
+      if cls1.isPrimitiveValueClass then
+        if cls2.isPrimitiveValueClass then
+          cls1 == cls2 || cls1.isNumericValueClass && cls2.isNumericValueClass
         else
-          false
-      }
+          cmpWithBoxed(cls1, cls2)
+      else if cls2.isPrimitiveValueClass then
+        cmpWithBoxed(cls2, cls1)
+      else if ctx.explicitNulls then
+        // If explicit nulls is enabled, we want to disallow comparison between Object and Null.
+        // If a nullable value has a non-nullable type, we can still cast it to nullable type
+        // then compare.
+        //
+        // Example:
+        // val x: String = null.asInstanceOf[String]
+        // if (x == null) {} // error: x is non-nullable
+        // if (x.asInstanceOf[String|Null] == null) {} // ok
+        cls1 == defn.NullClass && cls1 == cls2
+      else if cls1 == defn.NullClass then
+        cls1 == cls2 || cls2.derivesFrom(defn.ObjectClass)
+      else if cls2 == defn.NullClass then
+        cls1.derivesFrom(defn.ObjectClass)
+      else
+        false
+    end canComparePredefinedClasses
 
-      /** Some simulated `Eql` instances for predefined types. It's more efficient
-       *  to do this directly instead of setting up a lot of `Eql` instances to
-       *  interpret.
-       */
-      def canComparePredefined(tp1: Type, tp2: Type) =
-        tp1.classSymbols.exists(cls1 =>
-          tp2.classSymbols.exists(cls2 => canComparePredefinedClasses(cls1, cls2)))
+    /** Some simulated `Eql` instances for predefined types. It's more efficient
+      *  to do this directly instead of setting up a lot of `Eql` instances to
+      *  interpret.
+      */
+    def canComparePredefined(tp1: Type, tp2: Type) =
+      tp1.classSymbols.exists(cls1 =>
+        tp2.classSymbols.exists(cls2 =>
+          canComparePredefinedClasses(cls1, cls2)))
 
-      formal.argTypes match {
-        case args @ (arg1 :: arg2 :: Nil) =>
-          List(arg1, arg2).foreach(fullyDefinedType(_, "eq argument", span))
-          if (canComparePredefined(arg1, arg2)
-              ||
-              !strictEquality &&
-              ctx.test(validEqAnyArgs(arg1, arg2)))
-            ref(defn.Eql_eqlAny).appliedToTypes(args).withSpan(span)
-          else EmptyTree
-        case _ =>
-          EmptyTree
-      }
-    }
-  }
+    formal.argTypes match
+      case args @ (arg1 :: arg2 :: Nil) =>
+        List(arg1, arg2).foreach(fullyDefinedType(_, "eq argument", span))
+        if canComparePredefined(arg1, arg2)
+            || !strictEquality && ctx.test(validEqAnyArgs(arg1, arg2))
+        then ref(defn.Eql_eqlAny).appliedToTypes(args).withSpan(span)
+        else EmptyTree
+      case _ => EmptyTree
+  end synthesizedEql
 
   /** Creates a tree that will produce a ValueOf instance for the requested type.
    * An EmptyTree is returned if materialization fails.
    */
-  lazy val synthesizedValueOf: SpecialHandler = {
-    (formal, span) => implicit ctx => {
-      def success(t: Tree) = New(defn.ValueOfClass.typeRef.appliedTo(t.tpe), t :: Nil).withSpan(span)
+  lazy val synthesizedValueOf: SpecialHandler = (formal, span) =>
 
-      formal.argInfos match {
-        case arg :: Nil =>
-          fullyDefinedType(arg.dealias, "ValueOf argument", span).normalized match {
-            case ConstantType(c: Constant) =>
-              success(Literal(c))
-            case TypeRef(_, sym) if sym == defn.UnitClass =>
-              success(Literal(Constant(())))
-            case n: TermRef =>
-              success(ref(n))
-            case tp =>
-              EmptyTree
-          }
-        case _ =>
-          EmptyTree
-      }
-    }
-  }
+    def success(t: Tree) =
+      New(defn.ValueOfClass.typeRef.appliedTo(t.tpe), t :: Nil).withSpan(span)
+
+    formal.argInfos match
+      case arg :: Nil =>
+        fullyDefinedType(arg.dealias, "ValueOf argument", span).normalized match
+          case ConstantType(c: Constant) =>
+            success(Literal(c))
+          case TypeRef(_, sym) if sym == defn.UnitClass =>
+            success(Literal(Constant(())))
+          case n: TermRef =>
+            success(ref(n))
+          case tp =>
+            EmptyTree
+      case _ =>
+        EmptyTree
+  end synthesizedValueOf
 
   /** Create an anonymous class `new Object { type MirroredMonoType = ... }`
    *  and mark it with given attachment so that it is made into a mirror at PostTyper.
    */
-  private def anonymousMirror(monoType: Type, attachment: Property.StickyKey[Unit], span: Span)(implicit ctx: Context) = {
+  private def anonymousMirror(monoType: Type, attachment: Property.StickyKey[Unit], span: Span)(using Context) = {
     val monoTypeDef = untpd.TypeDef(tpnme.MirroredMonoType, untpd.TypeTree(monoType))
     val newImpl = untpd.Template(
       constr = untpd.emptyConstructor,
@@ -904,20 +893,20 @@ trait Implicits { self: Typer =>
    *       MirroredLabel = <label> }
    *     }
    */
-  private def mirrorCore(parentClass: ClassSymbol, monoType: Type, mirroredType: Type, label: Name, formal: Type)(implicit ctx: Context) =
+  private def mirrorCore(parentClass: ClassSymbol, monoType: Type, mirroredType: Type, label: Name, formal: Type)(using Context) =
     formal & parentClass.typeRef
       .refinedWith(tpnme.MirroredMonoType, TypeAlias(monoType))
       .refinedWith(tpnme.MirroredType, TypeAlias(mirroredType))
       .refinedWith(tpnme.MirroredLabel, TypeAlias(ConstantType(Constant(label.toString))))
 
   /** A path referencing the companion of class type `clsType` */
-  private def companionPath(clsType: Type, span: Span)(implicit ctx: Context) = {
+  private def companionPath(clsType: Type, span: Span)(using Context) = {
     val ref = pathFor(clsType.companionRef)
     assert(ref.symbol.is(Module) && (clsType.classSymbol.is(ModuleClass) || (ref.symbol.companionClass == clsType.classSymbol)))
     ref.withSpan(span)
   }
 
-  private def checkFormal(formal: Type)(implicit ctx: Context): Boolean = {
+  private def checkFormal(formal: Type)(using Context): Boolean = {
     @tailrec
     def loop(tp: Type): Boolean = tp match {
       case RefinedType(parent, _, _: TypeBounds) => loop(parent)
@@ -927,7 +916,7 @@ trait Implicits { self: Typer =>
     loop(formal)
   }
 
-  private def mkMirroredMonoType(mirroredType: HKTypeLambda)(implicit ctx: Context): Type = {
+  private def mkMirroredMonoType(mirroredType: HKTypeLambda)(using Context): Type = {
     val monoMap = new TypeMap {
       def apply(t: Type) = t match {
         case TypeParamRef(lambda, n) if lambda eq mirroredType => mirroredType.paramInfos(n)
@@ -937,160 +926,144 @@ trait Implicits { self: Typer =>
     monoMap(mirroredType.resultType)
   }
 
+  private def productMirror(mirroredType: Type, formal: Type, span: Span)(using Context): Tree =
+    mirroredType match
+      case AndType(tp1, tp2) =>
+        productMirror(tp1, formal, span).orElse(productMirror(tp2, formal, span))
+      case _ =>
+        if mirroredType.termSymbol.is(CaseVal) then
+          val module = mirroredType.termSymbol
+          val modulePath = pathFor(mirroredType).withSpan(span)
+          if module.info.classSymbol.is(Scala2x) then
+            val mirrorType = mirrorCore(defn.Mirror_SingletonProxyClass, mirroredType, mirroredType, module.name, formal)
+            val mirrorRef = New(defn.Mirror_SingletonProxyClass.typeRef, modulePath :: Nil)
+            mirrorRef.cast(mirrorType)
+          else
+            val mirrorType = mirrorCore(defn.Mirror_SingletonClass, mirroredType, mirroredType, module.name, formal)
+            modulePath.cast(mirrorType)
+        else if mirroredType.classSymbol.isGenericProduct then
+          val cls = mirroredType.classSymbol
+          val accessors = cls.caseAccessors.filterNot(_.isAllOf(PrivateLocal))
+          val elemLabels = accessors.map(acc => ConstantType(Constant(acc.name.toString)))
+          val (monoType, elemsType) = mirroredType match
+            case mirroredType: HKTypeLambda =>
+              val elems =
+                mirroredType.derivedLambdaType(
+                  resType = TypeOps.nestedPairs(accessors.map(mirroredType.memberInfo(_).widenExpr))
+                )
+              (mkMirroredMonoType(mirroredType), elems)
+            case _ =>
+              val elems = TypeOps.nestedPairs(accessors.map(mirroredType.memberInfo(_).widenExpr))
+              (mirroredType, elems)
+          val mirrorType =
+            mirrorCore(defn.Mirror_ProductClass, monoType, mirroredType, cls.name, formal)
+              .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
+              .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
+          val mirrorRef =
+            if (cls.is(Scala2x)) anonymousMirror(monoType, ExtendsProductMirror, span)
+            else companionPath(mirroredType, span)
+          mirrorRef.cast(mirrorType)
+        else EmptyTree
+  end productMirror
+
+  private def sumMirror(mirroredType: Type, formal: Type, span: Span)(using Context): Tree =
+    if mirroredType.classSymbol.isGenericSum then
+      val cls = mirroredType.classSymbol
+      val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))
+
+      def solve(sym: Symbol): Type = sym match
+        case caseClass: ClassSymbol =>
+          assert(caseClass.is(Case))
+          if caseClass.is(Module) then
+            caseClass.sourceModule.termRef
+          else
+            caseClass.primaryConstructor.info match
+              case info: PolyType =>
+                // Compute the the full child type by solving the subtype constraint
+                // `C[X1, ..., Xn] <: P`, where
+                //
+                //   - P is the current `mirroredType`
+                //   - C is the child class, with type parameters X1, ..., Xn
+                //
+                // Contravariant type parameters are minimized, all other type parameters are maximized.
+                def instantiate(using Context) =
+                  val poly = constrained(info, untpd.EmptyTree)._1
+                  val resType = poly.finalResultType
+                  val target = mirroredType match
+                    case tp: HKTypeLambda => tp.resultType
+                    case tp => tp
+                  resType <:< target
+                  val tparams = poly.paramRefs
+                  val variances = caseClass.typeParams.map(_.paramVarianceSign)
+                  val instanceTypes = tparams.lazyZip(variances).map((tparam, variance) =>
+                    ctx.typeComparer.instanceType(tparam, fromBelow = variance < 0))
+                  resType.substParams(poly, instanceTypes)
+                instantiate(using ctx.fresh.setExploreTyperState().setOwner(caseClass))
+              case _ =>
+                caseClass.typeRef
+        case child => child.termRef
+      end solve
+
+      val (monoType, elemsType) = mirroredType match
+        case mirroredType: HKTypeLambda =>
+          val elems = mirroredType.derivedLambdaType(
+            resType = TypeOps.nestedPairs(cls.children.map(solve))
+          )
+          (mkMirroredMonoType(mirroredType), elems)
+        case _ =>
+          val elems = TypeOps.nestedPairs(cls.children.map(solve))
+          (mirroredType, elems)
+
+      val mirrorType =
+          mirrorCore(defn.Mirror_SumClass, monoType, mirroredType, cls.name, formal)
+          .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
+          .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
+      val mirrorRef =
+        if cls.linkedClass.exists && !cls.is(Scala2x)
+        then companionPath(mirroredType, span)
+        else anonymousMirror(monoType, ExtendsSumMirror, span)
+      mirrorRef.cast(mirrorType)
+    else EmptyTree
+  end sumMirror
+
+  def makeMirror
+      (synth: (Type, Type, Span) => Context ?=> Tree, formal: Type, span: Span)
+      (using Context): Tree =
+    if checkFormal(formal) then
+      formal.member(tpnme.MirroredType).info match
+        case TypeBounds(mirroredType, _) => synth(mirroredType.stripTypeVar, formal, span)
+        case other => EmptyTree
+    else EmptyTree
+
   /** An implied instance for a type of the form `Mirror.Product { type MirroredType = T }`
    *  where `T` is a generic product type or a case object or an enum case.
    */
-  lazy val synthesizedProductMirror: SpecialHandler = {
-    (formal, span) => implicit ctx => {
-      def mirrorFor(mirroredType0: Type): Tree = {
-        val mirroredType = mirroredType0.stripTypeVar
-        mirroredType match {
-          case AndType(tp1, tp2) =>
-            mirrorFor(tp1).orElse(mirrorFor(tp2))
-          case _ =>
-            if (mirroredType.termSymbol.is(CaseVal)) {
-              val module = mirroredType.termSymbol
-              val modulePath = pathFor(mirroredType).withSpan(span)
-              if (module.info.classSymbol.is(Scala2x)) {
-                val mirrorType = mirrorCore(defn.Mirror_SingletonProxyClass, mirroredType, mirroredType, module.name, formal)
-                val mirrorRef = New(defn.Mirror_SingletonProxyClass.typeRef, modulePath :: Nil)
-                mirrorRef.cast(mirrorType)
-              }
-              else {
-                val mirrorType = mirrorCore(defn.Mirror_SingletonClass, mirroredType, mirroredType, module.name, formal)
-                modulePath.cast(mirrorType)
-              }
-            }
-            else if (mirroredType.classSymbol.isGenericProduct) {
-              val cls = mirroredType.classSymbol
-              val accessors = cls.caseAccessors.filterNot(_.isAllOf(PrivateLocal))
-              val elemLabels = accessors.map(acc => ConstantType(Constant(acc.name.toString)))
-              val (monoType, elemsType) = mirroredType match {
-                case mirroredType: HKTypeLambda =>
-                  val elems =
-                    mirroredType.derivedLambdaType(
-                      resType = TypeOps.nestedPairs(accessors.map(mirroredType.memberInfo(_).widenExpr))
-                    )
-                  (mkMirroredMonoType(mirroredType), elems)
-                case _ =>
-                  val elems = TypeOps.nestedPairs(accessors.map(mirroredType.memberInfo(_).widenExpr))
-                  (mirroredType, elems)
-              }
-              val mirrorType =
-                mirrorCore(defn.Mirror_ProductClass, monoType, mirroredType, cls.name, formal)
-                  .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
-                  .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
-              val mirrorRef =
-                if (cls.is(Scala2x)) anonymousMirror(monoType, ExtendsProductMirror, span)
-                else companionPath(mirroredType, span)
-              mirrorRef.cast(mirrorType)
-            }
-            else EmptyTree
-        }
-      }
-
-      if (!checkFormal(formal)) EmptyTree
-      else
-        formal.member(tpnme.MirroredType).info match {
-          case TypeBounds(mirroredType, _) => mirrorFor(mirroredType)
-          case other => EmptyTree
-        }
-    }
-  }
+  lazy val synthesizedProductMirror: SpecialHandler = (formal, span) =>
+    makeMirror(productMirror, formal, span)
 
   /** An implied instance for a type of the form `Mirror.Sum { type MirroredType = T }`
    *  where `T` is a generic sum type.
    */
-  lazy val synthesizedSumMirror: SpecialHandler =
-    (formal, span) => implicit ctx => {
-      if (!checkFormal(formal)) EmptyTree
-      else
-        formal.member(tpnme.MirroredType).info match {
-          case TypeBounds(mirroredType0, _) =>
-            val mirroredType = mirroredType0.stripTypeVar
-            if (mirroredType.classSymbol.isGenericSum) {
-              val cls = mirroredType.classSymbol
-              val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))
-
-              def solve(sym: Symbol): Type = sym match {
-                case caseClass: ClassSymbol =>
-                  assert(caseClass.is(Case))
-                  if (caseClass.is(Module))
-                    caseClass.sourceModule.termRef
-                  else
-                    caseClass.primaryConstructor.info match {
-                      case info: PolyType =>
-                        // Compute the the full child type by solving the subtype constraint
-                        // `C[X1, ..., Xn] <: P`, where
-                        //
-                        //   - P is the current `mirroredType`
-                        //   - C is the child class, with type parameters X1, ..., Xn
-                        //
-                        // Contravariant type parameters are minimized, all other type parameters are maximized.
-                        def instantiate(implicit ctx: Context) = {
-                          val poly = constrained(info, untpd.EmptyTree)._1
-                          val resType = poly.finalResultType
-                          val target = mirroredType match {
-                            case tp: HKTypeLambda => tp.resultType
-                            case tp => tp
-                          }
-                          resType <:< target
-                          val tparams = poly.paramRefs
-                          val variances = caseClass.typeParams.map(_.paramVarianceSign)
-                          val instanceTypes = tparams.lazyZip(variances).map((tparam, variance) =>
-                            ctx.typeComparer.instanceType(tparam, fromBelow = variance < 0))
-                          resType.substParams(poly, instanceTypes)
-                        }
-                        instantiate(ctx.fresh.setExploreTyperState().setOwner(caseClass))
-                      case _ =>
-                        caseClass.typeRef
-                    }
-                case child => child.termRef
-              }
-
-              val (monoType, elemsType) = mirroredType match {
-                case mirroredType: HKTypeLambda =>
-                  val elems = mirroredType.derivedLambdaType(
-                    resType = TypeOps.nestedPairs(cls.children.map(solve))
-                  )
-                  (mkMirroredMonoType(mirroredType), elems)
-                case _ =>
-                  val elems = TypeOps.nestedPairs(cls.children.map(solve))
-                  (mirroredType, elems)
-              }
-
-              val mirrorType =
-                 mirrorCore(defn.Mirror_SumClass, monoType, mirroredType, cls.name, formal)
-                  .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
-                  .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
-              val mirrorRef =
-                if (cls.linkedClass.exists && !cls.is(Scala2x)) companionPath(mirroredType, span)
-                else anonymousMirror(monoType, ExtendsSumMirror, span)
-              mirrorRef.cast(mirrorType)
-            }
-            else EmptyTree
-          case _ => EmptyTree
-        }
-    }
+  lazy val synthesizedSumMirror: SpecialHandler = (formal, span) =>
+    makeMirror(sumMirror, formal, span)
 
   /** An implied instance for a type of the form `Mirror { type MirroredType = T }`
    *  where `T` is a generic sum or product or singleton type.
    */
-  lazy val synthesizedMirror: SpecialHandler =
-    (formal, span) => implicit ctx => {
-      formal.member(tpnme.MirroredType).info match {
-        case TypeBounds(mirroredType, _) =>
-          if (mirroredType.termSymbol.is(CaseVal) || mirroredType.classSymbol.isGenericProduct)
-            synthesizedProductMirror(formal, span)(ctx)
-          else
-            synthesizedSumMirror(formal, span)(ctx)
-        case _ => EmptyTree
-      }
-    }
+  lazy val synthesizedMirror: SpecialHandler = (formal, span) =>
+    formal.member(tpnme.MirroredType).info match
+      case TypeBounds(mirroredType, _) =>
+        if mirroredType.termSymbol.is(CaseVal)
+           || mirroredType.classSymbol.isGenericProduct
+        then
+          synthesizedProductMirror(formal, span)(using ctx)
+        else
+          synthesizedSumMirror(formal, span)(using ctx)
+      case _ => EmptyTree
 
   private var mySpecialHandlers: SpecialHandlers = null
 
-  private def specialHandlers(implicit ctx: Context) = {
+  private def specialHandlers(using Context) = {
     if (mySpecialHandlers == null)
       mySpecialHandlers = List(
         defn.ClassTagClass        -> synthesizedClassTag,
@@ -1108,8 +1081,8 @@ trait Implicits { self: Typer =>
   /** Find an implicit argument for parameter `formal`.
    *  Return a failure as a SearchFailureType in the type of the returned tree.
    */
-  def inferImplicitArg(formal: Type, span: Span)(implicit ctx: Context): Tree =
-    inferImplicit(formal, EmptyTree, span)(ctx) match {
+  def inferImplicitArg(formal: Type, span: Span)(using Context): Tree =
+    inferImplicit(formal, EmptyTree, span)(using ctx) match {
       case SearchSuccess(arg, _, _) => arg
       case fail @ SearchFailure(failed) =>
         def trySpecialCases(handlers: SpecialHandlers): Tree = handlers match {
@@ -1124,7 +1097,7 @@ trait Implicits { self: Typer =>
             val result =
               if (base <:< formal.widenExpr)
                 // With the subtype test we enforce that the searched type `formal` is of the right form
-                handler(base, span)(ctx)
+                handler(base, span)(using ctx)
               else EmptyTree
             result.orElse(trySpecialCases(rest))
           case Nil =>
@@ -1135,14 +1108,14 @@ trait Implicits { self: Typer =>
     }
 
   /** Search an implicit argument and report error if not found */
-  def implicitArgTree(formal: Type, span: Span)(implicit ctx: Context): Tree = {
+  def implicitArgTree(formal: Type, span: Span)(using Context): Tree = {
     val arg = inferImplicitArg(formal, span)
     if (arg.tpe.isInstanceOf[SearchFailureType])
       ctx.error(missingArgMsg(arg, formal, ""), ctx.source.atSpan(span))
     arg
   }
 
-  def missingArgMsg(arg: Tree, pt: Type, where: String)(implicit ctx: Context): String = {
+  def missingArgMsg(arg: Tree, pt: Type, where: String)(using Context): String = {
 
     def msg(shortForm: String)(headline: String = shortForm) = arg match {
       case arg: Trees.SearchFailureIdent[?] =>
@@ -1186,7 +1159,7 @@ trait Implicits { self: Typer =>
             case p: PolyType => p.paramNames.map(_.toString)
             case _           => Nil
           }
-          def resolveTypes(targs: List[Tree])(implicit ctx: Context) =
+          def resolveTypes(targs: List[Tree])(using Context) =
             targs.map(a => fullyDefinedType(a.tpe, "type argument", a.span))
 
           // We can extract type arguments from:
@@ -1202,7 +1175,7 @@ trait Implicits { self: Typer =>
 
           val call = closureBody(alt.tree) // the tree itself if not a closure
           val (_, targs, _) = decomposeCall(call)
-          val args = resolveTypes(targs)(ctx.fresh.setTyperState(alt.tstate))
+          val args = resolveTypes(targs)(using ctx.fresh.setTyperState(alt.tstate))
           err.userDefinedErrorString(raw, params, args)
         }
 
@@ -1228,15 +1201,15 @@ trait Implicits { self: Typer =>
           def hiddenImplicitNote(s: SearchSuccess) =
             em"\n\nNote: given instance ${s.ref.symbol.showLocated} was not considered because it was not imported with `import given`."
 
-          def FindHiddenImplicitsCtx(ctx: Context): Context =
-            if (ctx == NoContext) ctx
-            else ctx.freshOver(FindHiddenImplicitsCtx(ctx.outer)).addMode(Mode.FindHiddenImplicits)
+          def findHiddenImplicitsCtx(c: Context): Context =
+            if c == NoContext then c
+            else c.freshOver(findHiddenImplicitsCtx(c.outer)).addMode(Mode.FindHiddenImplicits)
 
           val normalImports = arg.tpe match
             case fail: SearchFailureType =>
               if (fail.expectedType eq pt) || isFullyDefined(fail.expectedType, ForceDegree.none) then
                 inferImplicit(fail.expectedType, fail.argument, arg.span)(
-                  FindHiddenImplicitsCtx(ctx)) match {
+                  using findHiddenImplicitsCtx(ctx)) match {
                   case s: SearchSuccess => hiddenImplicitNote(s)
                   case f: SearchFailure =>
                     f.reason match {
@@ -1261,7 +1234,7 @@ trait Implicits { self: Typer =>
   }
 
   /** A string indicating the formal parameter corresponding to a  missing argument */
-  def implicitParamString(paramName: TermName, methodStr: String, tree: Tree)(implicit ctx: Context): String =
+  def implicitParamString(paramName: TermName, methodStr: String, tree: Tree)(using Context): String =
     tree match {
       case Select(qual, nme.apply) if defn.isFunctionType(qual.tpe.widen) =>
         val qt = qual.tpe.widen
@@ -1273,16 +1246,15 @@ trait Implicits { self: Typer =>
               else s"parameter $paramName" } of $methodStr"
     }
 
-  private def strictEquality(implicit ctx: Context): Boolean =
-    ctx.mode.is(Mode.StrictEquality) ||
-    ctx.featureEnabled(nme.strictEquality)
+  private def strictEquality(using Context): Boolean =
+    ctx.mode.is(Mode.StrictEquality) || ctx.featureEnabled(nme.strictEquality)
 
   /** An Eql[T, U] instance is assumed
    *   - if one of T, U is an error type, or
    *   - if one of T, U is a subtype of the lifted version of the other,
    *     unless strict equality is set.
    */
-  private def assumedCanEqual(ltp: Type, rtp: Type)(implicit ctx: Context) = {
+  private def assumedCanEqual(ltp: Type, rtp: Type)(using Context) = {
     // Map all non-opaque abstract types to their upper bound.
     // This is done to check whether such types might plausibly be comparable to each other.
     val lift = new TypeMap {
@@ -1299,16 +1271,13 @@ trait Implicits { self: Typer =>
       }
     }
 
-    ltp.isError ||
-    rtp.isError ||
-    !strictEquality && {
-      ltp <:< lift(rtp) ||
-      rtp <:< lift(ltp)
-    }
+    ltp.isError
+    || rtp.isError
+    || !strictEquality && (ltp <:< lift(rtp) || rtp <:< lift(ltp))
   }
 
   /** Check that equality tests between types `ltp` and `rtp` make sense */
-  def checkCanEqual(ltp: Type, rtp: Type, span: Span)(implicit ctx: Context): Unit =
+  def checkCanEqual(ltp: Type, rtp: Type, span: Span)(using Context): Unit =
     if (!ctx.isAfterTyper && !assumedCanEqual(ltp, rtp)) {
       val res = implicitArgTree(defn.EqlClass.typeRef.appliedTo(ltp, rtp), span)
       implicits.println(i"Eql witness found for $ltp / $rtp: $res: ${res.tpe}")
@@ -1320,7 +1289,7 @@ trait Implicits { self: Typer =>
    *                         it should be applied, EmptyTree otherwise.
    *  @param span            The position where errors should be reported.
    */
-  def inferImplicit(pt: Type, argument: Tree, span: Span)(implicit ctx: Context): SearchResult =
+  def inferImplicit(pt: Type, argument: Tree, span: Span)(using Context): SearchResult =
     trace(s"search implicit ${pt.show}, arg = ${argument.show}: ${argument.tpe.show}", implicits, show = true) {
       record("inferImplicit")
       assert(ctx.phase.allowsImplicitSearch,
@@ -1347,7 +1316,7 @@ trait Implicits { self: Typer =>
             val deepPt = pt.deepenProto
             if (deepPt ne pt) inferImplicit(deepPt, argument, span)
             else if (ctx.scala2CompatMode && !ctx.mode.is(Mode.OldOverloadingResolution))
-              inferImplicit(pt, argument, span)(ctx.addMode(Mode.OldOverloadingResolution)) match {
+              inferImplicit(pt, argument, span)(using ctx.addMode(Mode.OldOverloadingResolution)) match {
                 case altResult: SearchSuccess =>
                   ctx.migrationWarning(
                     s"According to new implicit resolution rules, this will be ambiguous:\n${result.reason.explanation}",
@@ -1367,7 +1336,7 @@ trait Implicits { self: Typer =>
     }
 
   /** Try to typecheck an implicit reference */
-  def typedImplicit(cand: Candidate, pt: Type, argument: Tree, span: Span)(implicit ctx: Context): SearchResult =  trace(i"typed implicit ${cand.ref}, pt = $pt, implicitsEnabled == ${ctx.mode is ImplicitsEnabled}", implicits, show = true) {
+  def typedImplicit(cand: Candidate, pt: Type, argument: Tree, span: Span)(using Context): SearchResult =  trace(i"typed implicit ${cand.ref}, pt = $pt, implicitsEnabled == ${ctx.mode is ImplicitsEnabled}", implicits, show = true) {
     if ctx.run.isCancelled then NoMatchingImplicitsFailure
     else
       record("typedImplicit")
@@ -1379,7 +1348,7 @@ trait Implicits { self: Typer =>
           adapt(generated, pt.widenExpr, locked)
         else {
           def untpdGenerated = untpd.TypedSplice(generated)
-          def tryConversion(implicit ctx: Context) = {
+          def tryConversion(using Context) = {
             val untpdConv =
               if (ref.symbol.is(Given))
                 untpd.Select(
@@ -1398,7 +1367,7 @@ trait Implicits { self: Typer =>
               val result = extMethodApply(untpd.Select(untpdGenerated, name), argument, mbrType)
               if !ctx.reporter.hasErrors && cand.isConversion then
                 val testCtx = ctx.fresh.setExploreTyperState()
-                tryConversion(testCtx)
+                tryConversion(using testCtx)
                 if testCtx.reporter.hasErrors then
                   ctx.error(em"ambiguous implicit: $generated is eligible both as an implicit conversion and as an extension method container")
               result
@@ -1423,7 +1392,7 @@ trait Implicits { self: Typer =>
     }
 
   /** An implicit search; parameters as in `inferImplicit` */
-  class ImplicitSearch(protected val pt: Type, protected val argument: Tree, span: Span)(implicit ctx: Context) {
+  class ImplicitSearch(protected val pt: Type, protected val argument: Tree, span: Span)(using Context) {
     assert(argument.isEmpty || argument.tpe.isValueType || argument.tpe.isInstanceOf[ExprType],
         em"found: $argument: ${argument.tpe}, expected: $pt")
 
@@ -1455,7 +1424,7 @@ trait Implicits { self: Typer =>
       else {
         val history = ctx.searchHistory.nest(cand, pt)
         val result =
-          typedImplicit(cand, pt, argument, span)(nestedContext().setNewTyperState().setFreshGADTBounds.setSearchHistory(history))
+          typedImplicit(cand, pt, argument, span)(using nestedContext().setNewTyperState().setFreshGADTBounds.setSearchHistory(history))
         result match {
           case res: SearchSuccess =>
             ctx.searchHistory.defineBynameImplicit(pt.widenExpr, res)
@@ -1710,7 +1679,7 @@ abstract class SearchHistory { outer =>
    * @param pt   The target type for the above candidate.
    * @result     The nested history.
    */
-  def nest(cand: Candidate, pt: Type)(implicit ctx: Context): SearchHistory =
+  def nest(cand: Candidate, pt: Type)(using Context): SearchHistory =
     new SearchHistory {
       val root = outer.root
       val open = (cand, pt) :: outer.open
@@ -1727,7 +1696,7 @@ abstract class SearchHistory { outer =>
    * @param pt   The target type for the above candidate.
    * @result     True if this candidate/pt are divergent, false otherwise.
    */
-  def checkDivergence(cand: Candidate, pt: Type)(implicit ctx: Context): Boolean = {
+  def checkDivergence(cand: Candidate, pt: Type)(using Context): Boolean = {
     // For full details of the algorithm see the SIP:
     //   https://docs.scala-lang.org/sips/byname-implicits.html
 
@@ -1781,7 +1750,7 @@ abstract class SearchHistory { outer =>
    * @param pt  The target type being searched for.
    * @result    The corresponding dictionary reference if any, NoType otherwise.
    */
-  def recursiveRef(pt: Type)(implicit ctx: Context): Type = {
+  def recursiveRef(pt: Type)(using Context): Type = {
     val widePt = pt.widenExpr
 
     refBynameImplicit(widePt).orElse {
@@ -1809,12 +1778,15 @@ abstract class SearchHistory { outer =>
   }
 
   // The following are delegated to the root of this search history.
-  def linkBynameImplicit(tpe: Type)(implicit ctx: Context): TermRef = root.linkBynameImplicit(tpe)
-  def refBynameImplicit(tpe: Type)(implicit ctx: Context): Type = root.refBynameImplicit(tpe)
-  def defineBynameImplicit(tpe: Type, result: SearchSuccess)(implicit ctx: Context): SearchResult = root.defineBynameImplicit(tpe, result)
+  def linkBynameImplicit(tpe: Type)(using Context): TermRef =
+    root.linkBynameImplicit(tpe)
+  def refBynameImplicit(tpe: Type)(using Context): Type =
+    root.refBynameImplicit(tpe)
+  def defineBynameImplicit(tpe: Type, result: SearchSuccess)(using Context): SearchResult =
+    root.defineBynameImplicit(tpe, result)
 
   // This is NOOP unless at the root of this search history.
-  def emitDictionary(span: Span, result: SearchResult)(implicit ctx: Context): SearchResult = result
+  def emitDictionary(span: Span, result: SearchResult)(using Context): SearchResult = result
 
   override def toString: String = s"SearchHistory(open = $open, byname = $byname)"
 }
@@ -1843,7 +1815,7 @@ final class SearchRoot extends SearchHistory {
    * @param tpe  The type to link.
    * @result     The TermRef of the corresponding dictionary entry.
    */
-  override def linkBynameImplicit(tpe: Type)(implicit ctx: Context): TermRef =
+  override def linkBynameImplicit(tpe: Type)(using Context): TermRef =
     implicitDictionary.get(tpe) match {
       case Some((ref, _)) => ref
       case None =>
@@ -1862,7 +1834,7 @@ final class SearchRoot extends SearchHistory {
    * @param tpe The type to look up.
    * @result    The corresponding TermRef, or NoType if none.
    */
-  override def refBynameImplicit(tpe: Type)(implicit ctx: Context): Type =
+  override def refBynameImplicit(tpe: Type)(using Context): Type =
     implicitDictionary.get(tpe).map(_._1).getOrElse(NoType)
 
   /**
@@ -1878,7 +1850,7 @@ final class SearchRoot extends SearchHistory {
    * @result        A SearchResult referring to the newly created dictionary entry if tpe
    *                is an under-construction by name implicit, the provided result otherwise.
    */
-  override def defineBynameImplicit(tpe: Type, result: SearchSuccess)(implicit ctx: Context): SearchResult =
+  override def defineBynameImplicit(tpe: Type, result: SearchSuccess)(using Context): SearchResult =
     implicitDictionary.get(tpe) match {
       case Some((ref, _)) =>
         implicitDictionary.put(tpe, (ref, result.tree))
@@ -1894,7 +1866,7 @@ final class SearchRoot extends SearchHistory {
    * @result       The elaborated result, comprising the implicit dictionary and a result tree
    *               substituted with references into the dictionary.
    */
-  override def emitDictionary(span: Span, result: SearchResult)(implicit ctx: Context): SearchResult =
+  override def emitDictionary(span: Span, result: SearchResult)(using Context): SearchResult =
     if (implicitDictionary == null || implicitDictionary.isEmpty) result
     else
       result match {
@@ -1989,7 +1961,7 @@ final class SearchRoot extends SearchHistory {
 }
 
 /** A set of term references where equality is =:= */
-final class TermRefSet(implicit ctx: Context) {
+final class TermRefSet(using Context) {
   private val elems = new java.util.LinkedHashMap[TermSymbol, List[Type]]
 
   def += (ref: TermRef): Unit = {

--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -149,8 +149,7 @@ trait ImportSuggestions:
      */
     def shallowTest(ref: TermRef): Boolean =
       System.currentTimeMillis < deadLine
-      && {
-        given Context = ctx.fresh.setExploreTyperState()
+      && withContext(ctx.fresh.setExploreTyperState()) {
         def test(pt: Type): Boolean = pt match
           case ViewProto(argType, OrType(rt1, rt2)) =>
             // Union types do not constrain results, since comparison with a union

--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -105,7 +105,7 @@ trait ImportSuggestions:
       case ref: TermRef => rootsIn(ref) ::: rootsOnPath(ref.prefix)
       case _ => Nil
 
-    def recur(using ctx: Context): List[TermRef] =
+    def recur(using Context): List[TermRef] =
       if ctx.owner.exists then
         val defined =
           if ctx.owner.isClass then
@@ -140,7 +140,7 @@ trait ImportSuggestions:
    *   return instead a list of all possible references to extension methods named
    *   `name` that are applicable to `T`.
    */
-  private def importSuggestions(pt: Type)(using ctx: Context): (List[TermRef], List[TermRef]) =
+  private def importSuggestions(pt: Type)(using Context): (List[TermRef], List[TermRef]) =
     val timer = new Timer()
     val deadLine = System.currentTimeMillis() + suggestImplicitTimeOut
 
@@ -241,7 +241,7 @@ trait ImportSuggestions:
    *  The addendum suggests given imports that might fix the problem.
    *  If there's nothing to suggest, an empty string is returned.
    */
-  override def importSuggestionAddendum(pt: Type)(using ctx: Context): String =
+  override def importSuggestionAddendum(pt: Type)(using Context): String =
     val (fullMatches, headMatches) =
       importSuggestions(pt)(using ctx.fresh.setExploreTyperState())
     implicits.println(i"suggestions for $pt in ${ctx.owner} = ($fullMatches%, %, $headMatches%, %)")

--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -149,7 +149,7 @@ trait ImportSuggestions:
      */
     def shallowTest(ref: TermRef): Boolean =
       System.currentTimeMillis < deadLine
-      && withContext(ctx.fresh.setExploreTyperState()) {
+      && inContext(ctx.fresh.setExploreTyperState()) {
         def test(pt: Type): Boolean = pt match
           case ViewProto(argType, OrType(rt1, rt2)) =>
             // Union types do not constrain results, since comparison with a union

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -158,7 +158,7 @@ object Inliner {
 
     val unappplySym = ctx.newSymbol(cls, sym.name.toTermName, Synthetic | Method, unapplyInfo, coord = sym.coord).entered
     val unapply = DefDef(unappplySym, argss =>
-      inlineCall(fun.appliedToArgss(argss).withSpan(unapp.span))(ctx.withOwner(unappplySym))
+      inlineCall(fun.appliedToArgss(argss).withSpan(unapp.span))(using ctx.withOwner(unappplySym))
     )
     val cdef = ClassDef(cls, DefDef(constr), List(unapply))
     val newUnapply = Block(cdef :: Nil, New(cls.typeRef, Nil))

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -13,7 +13,7 @@ import Constants._
 import StagingContext._
 import StdNames._
 import transform.SymUtils._
-import Contexts.Context
+import Contexts.{Context, withContext, ctx}
 import Names.{Name, TermName}
 import NameKinds.{InlineAccessorName, InlineBinderName, InlineScrutineeName, BodyRetainerName}
 import ProtoTypes.selectionProto
@@ -1341,8 +1341,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
           ctx.echo(i"suspension triggered by macro call to ${sym.showLocated} in ${sym.associatedFile}", call.sourcePos)
       ctx.compilationUnit.suspend() // this throws a SuspendException
 
-    val evaluatedSplice = {
-      given Context = tastyreflect.MacroExpansion.context(inlinedFrom)(using ctx)
+    val evaluatedSplice = withContext(tastyreflect.MacroExpansion.context(inlinedFrom)) {
       Splicer.splice(body, inlinedFrom.sourcePos, MacroClassLoader.fromContext)
     }
     val inlinedNormailizer = new TreeMap {

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -36,24 +36,24 @@ object Inliner {
 
   /** `sym` is an inline method with a known body to inline.
    */
-  def hasBodyToInline(sym: SymDenotation)(implicit ctx: Context): Boolean =
+  def hasBodyToInline(sym: SymDenotation)(using Context): Boolean =
     sym.isInlineMethod && sym.hasAnnotation(defn.BodyAnnot)
 
   /** The body to inline for method `sym`, or `EmptyTree` if none exists.
    *  @pre  hasBodyToInline(sym)
    */
-  def bodyToInline(sym: SymDenotation)(implicit ctx: Context): Tree =
+  def bodyToInline(sym: SymDenotation)(using Context): Tree =
     if (sym.isInlineMethod && sym.hasAnnotation(defn.BodyAnnot))
       sym.getAnnotation(defn.BodyAnnot).get.tree
     else
       EmptyTree
 
   /** Should call to method `meth` be inlined in this context? */
-  def isInlineable(meth: Symbol)(implicit ctx: Context): Boolean =
+  def isInlineable(meth: Symbol)(using Context): Boolean =
     meth.is(Inline) && meth.hasAnnotation(defn.BodyAnnot) && !ctx.inInlineMethod
 
   /** Should call be inlined in this context? */
-  def isInlineable(tree: Tree)(implicit ctx: Context): Boolean = tree match {
+  def isInlineable(tree: Tree)(using Context): Boolean = tree match {
     case Block(_, expr) => isInlineable(expr)
     case _ => isInlineable(tree.symbol) && !tree.tpe.isInstanceOf[MethodOrPoly]
   }
@@ -66,7 +66,7 @@ object Inliner {
    *  @return   An `Inlined` node that refers to the original call and the inlined bindings
    *            and body that replace it.
    */
-  def inlineCall(tree: Tree)(implicit ctx: Context): Tree = {
+  def inlineCall(tree: Tree)(using Context): Tree = {
     if tree.symbol.denot != SymDenotations.NoDenotation && tree.symbol.owner.companionModule == defn.CompiletimeTestingPackageObject
       if (tree.symbol == defn.CompiletimeTesting_typeChecks) return Intrinsics.typeChecks(tree)
       if (tree.symbol == defn.CompiletimeTesting_typeCheckErrors) return Intrinsics.typeCheckErrors(tree)
@@ -76,7 +76,7 @@ object Inliner {
     *  when lifting bindings from the expansion to the outside of the call.
     */
     def liftFromInlined(call: Tree) = new TreeMap {
-      override def transform(t: Tree)(implicit ctx: Context) =
+      override def transform(t: Tree)(using Context) =
         t match {
           case Inlined(t, Nil, expr) if t.isEmpty => expr
           case _ => super.transform(t.withSpan(call.span))
@@ -253,7 +253,7 @@ object Inliner {
    *  The trace has enough info to completely reconstruct positions.
    *  Note: For macros it returns a Select and for other inline methods it returns an Ident (this distinction is only temporary to be able to run YCheckPositions)
    */
-  def inlineCallTrace(callSym: Symbol, pos: SourcePosition)(implicit ctx: Context): Tree = {
+  def inlineCallTrace(callSym: Symbol, pos: SourcePosition)(using Context): Tree = {
     assert(ctx.source == pos.source)
     if (callSym.is(Macro)) ref(callSym.topLevelClass.owner).select(callSym.topLevelClass.name).withSpan(pos.span)
     else Ident(callSym.topLevelClass.typeRef).withSpan(pos.span)
@@ -326,7 +326,7 @@ object Inliner {
  *  @param  call         the original call to an inlineable method
  *  @param  rhsToInline  the body of the inlineable method that replaces the call.
  */
-class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
+class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
   import tpd._
   import Inliner._
 
@@ -376,7 +376,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
   /** A buffer for bindings that define proxies for actual arguments */
   private val bindingsBuf = new mutable.ListBuffer[ValOrDefDef]
 
-  private def newSym(name: Name, flags: FlagSet, info: Type)(implicit ctx: Context): Symbol =
+  private def newSym(name: Name, flags: FlagSet, info: Type)(using Context): Symbol =
     ctx.newSymbol(ctx.owner, name, flags, info, coord = call.span)
 
   /** A binding for the parameter of an inline method. This is a `val` def for
@@ -389,7 +389,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
    *  @param bindingsBuf the buffer to which the definition should be appended
    */
   private def paramBindingDef(name: Name, paramtp: Type, arg0: Tree,
-                              bindingsBuf: mutable.ListBuffer[ValOrDefDef])(implicit ctx: Context): ValOrDefDef = {
+                              bindingsBuf: mutable.ListBuffer[ValOrDefDef])(using Context): ValOrDefDef = {
     val arg = arg0 match {
       case Typed(arg1, tpt) if tpt.tpe.isRepeatedParam && arg1.tpe.derivesFrom(defn.ArrayClass) =>
         wrapArray(arg1, arg0.tpe.elemType)
@@ -522,7 +522,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
    *  from its `originalOwner`, and, if it comes from outside the inlined method
    *  itself, it has to be marked as an inlined argument.
    */
-  def integrate(tree: Tree, originalOwner: Symbol)(implicit ctx: Context): Tree =
+  def integrate(tree: Tree, originalOwner: Symbol)(using Context): Tree =
     tree.changeOwner(originalOwner, ctx.owner)
 
   def tryConstValue: Tree =
@@ -633,13 +633,13 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
         // report bad inputs at the point of call instead of revealing its internals.
         val callToReport = if (enclosingInlineds.nonEmpty) enclosingInlineds.last else call
         val ctxToReport = ctx.outersIterator.dropWhile(enclosingInlineds(_).nonEmpty).next
-        def issueInCtx(implicit ctx: Context) =
+        inContext(ctxToReport) {
           ctx.error(message, callToReport.sourcePos)
-        issueInCtx(ctxToReport)
+        }
       case _ =>
     }
 
-    def issueCode()(implicit ctx: Context): Literal = {
+    def issueCode()(using Context): Literal = {
       def decompose(arg: Tree): String = arg match {
         case Typed(arg, _) => decompose(arg)
         case SeqLiteral(elems, _) => elems.map(decompose).mkString(", ")
@@ -680,7 +680,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       bindingsBuf.mapInPlace { binding =>
         // Set trees to symbols allow macros to see the definition tree.
         // This is used by `underlyingArgument`.
-        reducer.normalizeBinding(binding)(inlineCtx).setDefTree
+        reducer.normalizeBinding(binding)(using inlineCtx).setDefTree
       }
 
       // Run a typing pass over the inlined tree. See InlineTyper for details.
@@ -698,7 +698,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       if (inlinedMethod == defn.Compiletime_error) issueError()
 
       if (inlinedMethod == defn.Compiletime_code)
-        issueCode()(ctx.fresh.setSetting(ctx.settings.color, "never"))
+        issueCode()(using ctx.fresh.setSetting(ctx.settings.color, "never"))
       else
         // Take care that only argument bindings go into `bindings`, since positions are
         // different for bindings from arguments and bindings from body.
@@ -720,7 +720,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
      *             - whether the instance creation is precomputed or by-name
      */
     private object NewInstance {
-      def unapply(tree: Tree)(implicit ctx: Context): Option[(Symbol, List[Tree], List[Tree], Boolean)] = {
+      def unapply(tree: Tree)(using Context): Option[(Symbol, List[Tree], List[Tree], Boolean)] = {
         def unapplyLet(bindings: List[Tree], expr: Tree) =
           unapply(expr) map {
             case (cls, reduced, prefix, precomputed) => (cls, reduced, bindings ::: prefix, precomputed)
@@ -759,7 +759,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
      *  arguments `args`, the corresponding argument, otherwise `tree` itself.
      *  Side effects of original arguments need to be preserved.
      */
-    def reduceProjection(tree: Tree)(implicit ctx: Context): Tree = {
+    def reduceProjection(tree: Tree)(using Context): Tree = {
       if (ctx.debug) inlining.println(i"try reduce projection $tree")
       tree match {
         case Select(NewInstance(cls, args, prefix, precomputed), field) if cls.isNoInitsClass =>
@@ -805,7 +805,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
      *   - reduce its rhs if it is a projection and adjust its type accordingly,
      *   - record symbol -> rhs in the InlineBindings context propery.
      */
-    def normalizeBinding(binding: ValOrDefDef)(implicit ctx: Context) = {
+    def normalizeBinding(binding: ValOrDefDef)(using Context) = {
       val binding1 = binding match {
         case binding: ValDef =>
           val rhs1 = reduceProjection(binding.rhs)
@@ -827,7 +827,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
      */
     private object InlineableArg {
       lazy val paramProxies = paramProxy.values.toSet
-      def unapply(tree: Trees.Ident[?])(implicit ctx: Context): Option[Tree] = {
+      def unapply(tree: Trees.Ident[?])(using Context): Option[Tree] = {
         def search(buf: mutable.ListBuffer[ValOrDefDef]) = buf.find(_.name == tree.name)
         if (paramProxies.contains(tree.typeOpt))
           search(bindingsBuf) match {
@@ -840,13 +840,13 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
     }
 
     object ConstantValue {
-      def unapply(tree: Tree)(implicit ctx: Context): Option[Any] = tree.tpe.widenTermRefExpr.normalized match {
+      def unapply(tree: Tree)(using Context): Option[Any] = tree.tpe.widenTermRefExpr.normalized match {
         case ConstantType(Constant(x)) => Some(x)
         case _ => None
       }
     }
 
-    def tryInline(tree: Tree)(implicit ctx: Context): Tree = tree match {
+    def tryInline(tree: Tree)(using Context): Tree = tree match {
       case InlineableArg(rhs) =>
         inlining.println(i"inline arg $tree -> $rhs")
         rhs
@@ -865,7 +865,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       *  where `def` is used for call-by-name parameters. However, we shortcut any NoPrefix
       *  refs among the ei's directly without creating an intermediate binding.
       */
-    def betaReduce(tree: Tree)(implicit ctx: Context): Tree = tree match {
+    def betaReduce(tree: Tree)(using Context): Tree = tree match {
       case Apply(Select(cl @ closureDef(ddef), nme.apply), args) if defn.isFunctionType(cl.tpe) =>
         ddef.tpe.widen match {
           case mt: MethodType if ddef.vparamss.head.length == args.length =>
@@ -873,7 +873,10 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
             val argSyms = mt.paramNames.lazyZip(mt.paramInfos).lazyZip(args).map { (name, paramtp, arg) =>
               arg.tpe.dealias match {
                 case ref @ TermRef(NoPrefix, _) => ref.symbol
-                case _ => paramBindingDef(name, paramtp, arg, bindingsBuf)(ctx.withSource(cl.source)).symbol
+                case _ =>
+                  paramBindingDef(name, paramtp, arg, bindingsBuf)(
+                    using ctx.withSource(cl.source)
+                  ).symbol
               }
             }
             val expander = new TreeTypeMap(
@@ -903,7 +906,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
      *   @return    optionally, if match can be reduced to a matching case: A pair of
      *              bindings for all pattern-bound variables and the RHS of the case.
      */
-    def reduceInlineMatch(scrutinee: Tree, scrutType: Type, cases: List[CaseDef], typer: Typer)(implicit ctx: Context): MatchRedux = {
+    def reduceInlineMatch(scrutinee: Tree, scrutType: Type, cases: List[CaseDef], typer: Typer)(using Context): MatchRedux = {
 
       val isImplicit = scrutinee.isEmpty
 
@@ -914,7 +917,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
         caseBindingMap: mutable.ListBuffer[(Symbol, MemberDef)],
         scrut: TermRef,
         pat: Tree
-      )(implicit ctx: Context): Boolean = {
+      )(using Context): Boolean = {
 
       	/** Create a binding of a pattern bound variable with matching part of
       	 *  scrutinee as RHS and type that corresponds to RHS.
@@ -950,7 +953,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
 
         def getTypeBindsMap(pat: Tree, tpt: Tree): TypeBindsMap = {
           val getBinds = new TreeAccumulator[Set[TypeSymbol]] {
-            def apply(syms: Set[TypeSymbol], t: Tree)(implicit ctx: Context): Set[TypeSymbol] = {
+            def apply(syms: Set[TypeSymbol], t: Tree)(using Context): Set[TypeSymbol] = {
               val syms1 = t match {
                 case t: Bind if t.symbol.isType =>
                   syms + t.symbol.asType
@@ -991,12 +994,12 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
           extractBindVariance(SimpleIdentityMap.Empty, tpt.tpe)
         }
 
-        def addTypeBindings(typeBinds: TypeBindsMap)(implicit ctx: Context): Unit =
+        def addTypeBindings(typeBinds: TypeBindsMap)(using Context): Unit =
           typeBinds.foreachBinding { case (sym, shouldBeMinimized) =>
             newTypeBinding(sym, ctx.gadt.approximation(sym, fromBelow = shouldBeMinimized))
           }
 
-        def registerAsGadtSyms(typeBinds: TypeBindsMap)(implicit ctx: Context): Unit =
+        def registerAsGadtSyms(typeBinds: TypeBindsMap)(using Context): Unit =
           if (typeBinds.size > 0) ctx.gadt.addToConstraint(typeBinds.keys)
 
         pat match {
@@ -1087,7 +1090,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
 
         if (!isImplicit) caseBindingMap += ((NoSymbol, scrutineeBinding))
         val gadtCtx = ctx.fresh.setFreshGADTBounds.addMode(Mode.GadtConstraintInference)
-        if (reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(gadtCtx)) {
+        if (reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using gadtCtx)) {
           val (caseBindings, from, to) = substBindings(caseBindingMap.toList, mutable.ListBuffer(), Nil, Nil)
           val guardOK = cdef.guard.isEmpty || {
             typer.typed(cdef.guard.subst(from, to), defn.BooleanType) match {
@@ -1122,7 +1125,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
   class InlineTyper(initialErrorCount: Int) extends ReTyper {
     import reducer._
 
-    override def ensureAccessible(tpe: Type, superAccess: Boolean, pos: SourcePosition)(implicit ctx: Context): Type = {
+    override def ensureAccessible(tpe: Type, superAccess: Boolean, pos: SourcePosition)(using Context): Type = {
       tpe match {
         case tpe: NamedType if tpe.symbol.exists && !tpe.symbol.isAccessibleFrom(tpe.prefix, superAccess) =>
           tpe.info match {
@@ -1135,10 +1138,10 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       super.ensureAccessible(tpe, superAccess, pos)
     }
 
-    override def typedIdent(tree: untpd.Ident, pt: Type)(implicit ctx: Context): Tree =
+    override def typedIdent(tree: untpd.Ident, pt: Type)(using Context): Tree =
       tryInline(tree.asInstanceOf[tpd.Tree]) `orElse` super.typedIdent(tree, pt)
 
-    override def typedSelect(tree: untpd.Select, pt: Type)(implicit ctx: Context): Tree = {
+    override def typedSelect(tree: untpd.Select, pt: Type)(using Context): Tree = {
       assert(tree.hasType, tree)
       val qual1 = typed(tree.qualifier, selectionProto(tree.name, pt, this))
       val res = constToLiteral(untpd.cpy.Select(tree)(qual1, tree.name).withType(tree.typeOpt))
@@ -1146,7 +1149,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       res
     }
 
-    override def typedIf(tree: untpd.If, pt: Type)(implicit ctx: Context): Tree =
+    override def typedIf(tree: untpd.If, pt: Type)(using Context): Tree =
       typed(tree.cond, defn.BooleanType) match {
         case cond1 @ ConstantValue(b: Boolean) =>
           val selected0 = if (b) tree.thenp else tree.elsep
@@ -1164,7 +1167,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
             super.typedIf(if1, pt)
       }
 
-    override def typedApply(tree: untpd.Apply, pt: Type)(implicit ctx: Context): Tree =
+    override def typedApply(tree: untpd.Apply, pt: Type)(using Context): Tree =
       constToLiteral(betaReduce(super.typedApply(tree, pt))) match {
         case res: Apply if res.symbol == defn.InternalQuoted_exprSplice
                         && level == 0
@@ -1174,7 +1177,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
         case res => res
       }
 
-    override def typedMatchFinish(tree: untpd.Match, sel: Tree, wideSelType: Type, cases: List[untpd.CaseDef], pt: Type)(implicit ctx: Context) =
+    override def typedMatchFinish(tree: untpd.Match, sel: Tree, wideSelType: Type, cases: List[untpd.CaseDef], pt: Type)(using Context) =
       if (!tree.isInline || ctx.owner.isInlineMethod) // don't reduce match of nested inline method yet
         super.typedMatchFinish(tree, sel, wideSelType, cases, pt)
       else {
@@ -1227,7 +1230,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
   /** Drop any side-effect-free bindings that are unused in expansion or other reachable bindings.
    *  Inline def bindings that are used only once.
    */
-  def dropUnusedDefs(bindings: List[MemberDef], tree: Tree)(implicit ctx: Context): (List[MemberDef], Tree) = {
+  def dropUnusedDefs(bindings: List[MemberDef], tree: Tree)(using Context): (List[MemberDef], Tree) = {
     // inlining.println(i"drop unused $bindings%, % in $tree")
     val (termBindings, typeBindings) = bindings.partition(_.symbol.isTerm)
     if (typeBindings.nonEmpty) {
@@ -1266,7 +1269,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       }
 
       val countRefs = new TreeTraverser {
-        override def traverse(t: Tree)(implicit ctx: Context) = {
+        override def traverse(t: Tree)(using Context) = {
           def updateRefCount(sym: Symbol, inc: Int) =
             for (x <- refCount.get(sym)) refCount(sym) = x + inc
           def updateTermRefCounts(t: Tree) =
@@ -1297,7 +1300,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       } && !boundSym.is(Inline)
 
       val inlineBindings = new TreeMap {
-        override def transform(t: Tree)(implicit ctx: Context) = t match {
+        override def transform(t: Tree)(using Context) = t match {
           case t: RefTree =>
             val sym = t.symbol
             val t1 = refCount.get(sym) match {
@@ -1328,7 +1331,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
     }
   }
 
-  private def expandMacro(body: Tree, span: Span)(implicit ctx: Context) = {
+  private def expandMacro(body: Tree, span: Span)(using Context) = {
     assert(level == 0)
     val inlinedFrom = enclosingInlineds.last
     val dependencies = macroDependencies(body)
@@ -1345,7 +1348,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       Splicer.splice(body, inlinedFrom.sourcePos, MacroClassLoader.fromContext)
     }
     val inlinedNormailizer = new TreeMap {
-      override def transform(tree: tpd.Tree)(implicit ctx: Context): tpd.Tree = tree match {
+      override def transform(tree: tpd.Tree)(using Context): tpd.Tree = tree match {
         case Inlined(EmptyTree, Nil, expr) if enclosingInlineds.isEmpty => transform(expr)
         case _ => super.transform(tree)
       }
@@ -1358,10 +1361,10 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
   /** Return the set of symbols that are referred at level -1 by the tree and defined in the current run.
    *  This corresponds to the symbols that will need to be interpreted.
    */
-  private def macroDependencies(tree: Tree)(implicit ctx: Context) =
+  private def macroDependencies(tree: Tree)(using Context) =
     new TreeAccumulator[List[Symbol]] {
       private var level = -1
-      override def apply(syms: List[Symbol], tree: tpd.Tree)(implicit ctx: Context): List[Symbol] =
+      override def apply(syms: List[Symbol], tree: tpd.Tree)(using Context): List[Symbol] =
         if (level != -1) foldOver(syms, tree)
         else tree match {
           case tree: RefTree if level == -1 && tree.symbol.isDefinedInCurrentRun && !tree.symbol.isLocal =>

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -178,7 +178,7 @@ object Inliner {
    *  where the call `f(x)` is inline-expanded. This body is then transferred
    *  back to `f` at erasure, using method addRetainedInlineBodies.
    */
-  def bodyRetainer(mdef: DefDef)(using ctx: Context): DefDef =
+  def bodyRetainer(mdef: DefDef)(using Context): DefDef =
     val meth = mdef.symbol.asTerm
 
     val retainer = meth.copy(
@@ -264,7 +264,7 @@ object Inliner {
     private enum ErrorKind:
       case Parser, Typer
 
-    private def compileForErrors(tree: Tree, stopAfterParser: Boolean)(using ctx: Context): List[(ErrorKind, Error)] =
+    private def compileForErrors(tree: Tree, stopAfterParser: Boolean)(using Context): List[(ErrorKind, Error)] =
       assert(tree.symbol == defn.CompiletimeTesting_typeChecks || tree.symbol == defn.CompiletimeTesting_typeCheckErrors)
       def stripTyped(t: Tree): Tree = t match {
         case Typed(t2, _) => stripTyped(t2)
@@ -1220,7 +1220,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
     override def newLikeThis: Typer = new InlineTyper(initialErrorCount)
 
     /** Suppress further inlining if this inline typer has already issued errors */
-    override def suppressInline(using ctx: Context) =
+    override def suppressInline(using Context) =
       ctx.reporter.errorCount > initialErrorCount || super.suppressInline
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -13,7 +13,7 @@ import Constants._
 import StagingContext._
 import StdNames._
 import transform.SymUtils._
-import Contexts.{Context, withContext, ctx}
+import Contexts.{Context, inContext, ctx}
 import Names.{Name, TermName}
 import NameKinds.{InlineAccessorName, InlineBinderName, InlineScrutineeName, BodyRetainerName}
 import ProtoTypes.selectionProto
@@ -1341,7 +1341,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
           ctx.echo(i"suspension triggered by macro call to ${sym.showLocated} in ${sym.associatedFile}", call.sourcePos)
       ctx.compilationUnit.suspend() // this throws a SuspendException
 
-    val evaluatedSplice = withContext(tastyreflect.MacroExpansion.context(inlinedFrom)) {
+    val evaluatedSplice = inContext(tastyreflect.MacroExpansion.context(inlinedFrom)) {
       Splicer.splice(body, inlinedFrom.sourcePos, MacroClassLoader.fromContext)
     }
     val inlinedNormailizer = new TreeMap {

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -283,7 +283,7 @@ object Inliner {
           val parseErrors = ctx2.reporter.allErrors.toList
           res ++= parseErrors.map(e => ErrorKind.Parser -> e)
           if !stopAfterParser || res.isEmpty
-            ctx2.typer.typed(tree2)(ctx2)
+            ctx2.typer.typed(tree2)(using ctx2)
             val typerErrors = ctx2.reporter.allErrors.filterNot(parseErrors.contains)
             res ++= typerErrors.map(e => ErrorKind.Typer -> e)
           res.toList
@@ -684,7 +684,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(implicit ctx: Context) {
       }
 
       // Run a typing pass over the inlined tree. See InlineTyper for details.
-      val expansion1 = inlineTyper.typed(expansion)(inlineCtx)
+      val expansion1 = inlineTyper.typed(expansion)(using inlineCtx)
 
       if (ctx.settings.verbose.value) {
         inlining.println(i"to inline = $rhsToInline")

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -935,7 +935,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
         def searchImplicit(sym: TermSymbol, tpt: Tree) = {
           val evTyper = new Typer
           val evCtx = ctx.fresh.setTyper(evTyper)
-          val evidence = evTyper.inferImplicitArg(tpt.tpe, tpt.span)(evCtx)
+          val evidence = evTyper.inferImplicitArg(tpt.tpe, tpt.span)(using evCtx)
           evidence.tpe match {
             case fail: Implicits.AmbiguousImplicits =>
               ctx.error(evTyper.missingArgMsg(evidence, tpt.tpe, ""), tpt.sourcePos)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -39,13 +39,11 @@ trait NamerContextOps {
    *  in order to make sure that updates to class members are reflected in
    *  finger prints.
    */
-  def enter(sym: Symbol): Symbol = {
-    thisContext.owner match {
+  def enter(sym: Symbol): Symbol =
+    thisCtx.owner match
       case cls: ClassSymbol => cls.enter(sym)
       case _ => thisCtx.scope.openForMutations.enter(sym)
-    }
     sym
-  }
 
   /** The denotation with the given `name` and all `required` flags in current context
    */

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1323,10 +1323,10 @@ class Namer { typer: Typer =>
   }
 
   def typedAheadType(tree: Tree, pt: Type = WildcardType)(implicit ctx: Context): tpd.Tree =
-    typedAhead(tree, typer.typed(_, pt)(ctx retractMode Mode.PatternOrTypeBits addMode Mode.Type))
+    typedAhead(tree, typer.typed(_, pt)(using ctx.retractMode(Mode.PatternOrTypeBits).addMode(Mode.Type)))
 
   def typedAheadExpr(tree: Tree, pt: Type = WildcardType)(implicit ctx: Context): tpd.Tree =
-    typedAhead(tree, typer.typed(_, pt)(ctx retractMode Mode.PatternOrTypeBits))
+    typedAhead(tree, typer.typed(_, pt)(using ctx.retractMode(Mode.PatternOrTypeBits)))
 
   def typedAheadAnnotation(tree: Tree)(implicit ctx: Context): tpd.Tree =
     typedAheadExpr(tree, defn.AnnotationClass.typeRef)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -4,9 +4,9 @@ package typer
 
 import core._
 import ast._
-import Trees._, StdNames._, Scopes._, Denotations._, Comments._
+import Trees._, StdNames._, Scopes._, Denotations._
 import Contexts._, Symbols._, Types._, SymDenotations._, Names._, NameOps._, Flags._
-import Decorators.{given _}
+import Decorators.{given _}, Comments.{_, given _}
 import NameKinds.DefaultGetterName
 import TypeApplications.TypeParamInfo
 import ast.desugar, ast.desugar._

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -272,7 +272,7 @@ class Namer { typer: Typer =>
    *  The logic here is very subtle and fragile due to the fact that
    *  we are not allowed to force anything.
    */
-  def checkNoConflict(name: Name, isPrivate: Boolean, span: Span)(using ctx: Context): Name =
+  def checkNoConflict(name: Name, isPrivate: Boolean, span: Span)(using Context): Name =
     val owner = ctx.owner
     var conflictsDetected = false
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -867,7 +867,7 @@ class Namer { typer: Typer =>
         def rhsToInline(using Context): tpd.Tree =
           val mdef = typedAheadExpr(original).asInstanceOf[tpd.DefDef]
           PrepareInlineable.wrapRHS(original, mdef.tpt, mdef.rhs)
-        PrepareInlineable.registerInlineInfo(sym, rhsToInline)(localContext(sym))
+        PrepareInlineable.registerInlineInfo(sym, rhsToInline)(using localContext(sym))
       case _ =>
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -71,8 +71,8 @@ trait NamerContextOps {
 
   /** The symbol (stored in some typer's symTree) of an enclosing context definition */
   def symOfContextTree(tree: untpd.Tree): Symbol = {
-    def go(ctx: Context): Symbol =
-      ctx.typeAssigner match {
+    def go(contxt: Context): Symbol =
+      contxt.typeAssigner match {
         case typer: Typer =>
           tree.getAttachment(typer.SymOfTree) match {
             case Some(sym) => sym
@@ -132,7 +132,7 @@ trait NamerContextOps {
       termParamss
 
   /** The method type corresponding to given parameters and result type */
-  def methodType(typeParams: List[Symbol], valueParamss: List[List[Symbol]], resultType: Type, isJava: Boolean = false)(implicit ctx: Context): Type = {
+  def methodType(typeParams: List[Symbol], valueParamss: List[List[Symbol]], resultType: Type, isJava: Boolean = false)(using Context): Type = {
     val monotpe =
       valueParamss.foldRight(resultType) { (params, resultType) =>
         val (isContextual, isImplicit, isErased) =
@@ -163,7 +163,7 @@ trait NamerContextOps {
 
 object NamerContextOps {
   /** Find moduleClass/sourceModule in effective scope */
-  private def findModuleBuddy(name: Name, scope: Scope)(implicit ctx: Context) = {
+  private def findModuleBuddy(name: Name, scope: Scope)(using Context) = {
     val it = scope.lookupAll(name).filter(_.is(Module))
     if (it.hasNext) it.next()
     else NoSymbol.assertingErrorsReported(s"no companion $name in $scope")
@@ -239,7 +239,7 @@ class Namer { typer: Typer =>
   private var lateCompile = false
 
   /** The symbol of the given expanded tree. */
-  def symbolOfTree(tree: Tree)(implicit ctx: Context): Symbol = {
+  def symbolOfTree(tree: Tree)(using Context): Symbol = {
     val xtree = expanded(tree)
     xtree.getAttachment(TypedAhead) match {
       case Some(ttree) => ttree.symbol
@@ -248,7 +248,7 @@ class Namer { typer: Typer =>
   }
 
   /** The enclosing class with given name; error if none exists */
-  def enclosingClassNamed(name: TypeName, span: Span)(implicit ctx: Context): Symbol =
+  def enclosingClassNamed(name: TypeName, span: Span)(using Context): Symbol =
     if (name.isEmpty) NoSymbol
     else {
       val cls = ctx.owner.enclosingClassNamed(name)
@@ -258,7 +258,7 @@ class Namer { typer: Typer =>
     }
 
   /** Record `sym` as the symbol defined by `tree` */
-  def recordSym(sym: Symbol, tree: Tree)(implicit ctx: Context): Symbol = {
+  def recordSym(sym: Symbol, tree: Tree)(using Context): Symbol = {
     for (refs <- tree.removeAttachment(References); ref <- refs) ref.watching(sym)
     tree.pushAttachment(SymOfTree, sym)
     sym
@@ -310,7 +310,7 @@ class Namer { typer: Typer =>
   /** If this tree is a member def or an import, create a symbol of it
    *  and store in symOfTree map.
    */
-  def createSymbol(tree: Tree)(implicit ctx: Context): Symbol = {
+  def createSymbol(tree: Tree)(using Context): Symbol = {
 
     def privateWithinClass(mods: Modifiers) =
       enclosingClassNamed(mods.privateWithin, tree.span)
@@ -423,7 +423,7 @@ class Namer { typer: Typer =>
         createOrRefine[Symbol](tree, name, flags, ctx.owner, _ => info,
           (fs, _, pwithin) => ctx.newSymbol(ctx.owner, name, fs, info, pwithin, tree.nameSpan))
       case tree: Import =>
-        recordSym(ctx.newImportSymbol(ctx.owner, new Completer(tree), tree.span), tree)
+        recordSym(ctx.newImportSymbol(ctx.owner, Completer(tree)(ctx), tree.span), tree)
       case _ =>
         NoSymbol
     }
@@ -432,7 +432,7 @@ class Namer { typer: Typer =>
    /** If `sym` exists, enter it in effective scope. Check that
     *  package members are not entered twice in the same run.
     */
-  def enterSymbol(sym: Symbol)(implicit ctx: Context): Symbol = {
+  def enterSymbol(sym: Symbol)(using Context): Symbol = {
     if (sym.exists) {
       typr.println(s"entered: $sym in ${ctx.owner}")
       ctx.enter(sym)
@@ -441,7 +441,7 @@ class Namer { typer: Typer =>
   }
 
   /** Create package if it does not yet exist. */
-  private def createPackageSymbol(pid: RefTree)(implicit ctx: Context): Symbol = {
+  private def createPackageSymbol(pid: RefTree)(using Context): Symbol = {
     val pkgOwner = pid match {
       case Ident(_) => if (ctx.owner eq defn.EmptyPackageClass) defn.RootClass else ctx.owner
       case Select(qual: RefTree, _) => createPackageSymbol(qual).moduleClass
@@ -470,7 +470,7 @@ class Namer { typer: Typer =>
   }
 
   /** Expand tree and store in `expandedTree` */
-  def expand(tree: Tree)(implicit ctx: Context): Unit = {
+  def expand(tree: Tree)(using Context): Unit = {
     def record(expanded: Tree) =
       if (expanded `ne` tree) {
         typr.println(i"Expansion: $tree expands to $expanded")
@@ -484,7 +484,7 @@ class Namer { typer: Typer =>
   }
 
   /** The expanded version of this tree, or tree itself if not expanded */
-  def expanded(tree: Tree)(implicit ctx: Context): Tree = tree match {
+  def expanded(tree: Tree)(using Context): Tree = tree match {
     case _: DefTree | _: PackageDef => tree.attachmentOrElse(ExpandedTree, tree)
     case _ => tree
   }
@@ -493,7 +493,7 @@ class Namer { typer: Typer =>
     * not also defined in `xstats`, invalidate it by setting its info to
     * NoType.
     */
-  def invalidateCompanions(pkg: Symbol, xstats: List[untpd.Tree])(implicit ctx: Context): Unit = {
+  def invalidateCompanions(pkg: Symbol, xstats: List[untpd.Tree])(using Context): Unit = {
     val definedNames = xstats collect { case stat: NameTree => stat.name }
     def invalidate(name: TypeName) =
       if (!(definedNames contains name)) {
@@ -508,7 +508,7 @@ class Namer { typer: Typer =>
   }
 
   /** Expand tree and create top-level symbols for statement and enter them into symbol table */
-  def index(stat: Tree)(implicit ctx: Context): Context = {
+  def index(stat: Tree)(using Context): Context = {
     expand(stat)
     indexExpanded(stat)
   }
@@ -516,11 +516,11 @@ class Namer { typer: Typer =>
   /** Create top-level symbols for all statements in the expansion of this statement and
    *  enter them into symbol table
    */
-  def indexExpanded(origStat: Tree)(implicit ctx: Context): Context = {
+  def indexExpanded(origStat: Tree)(using Context): Context = {
     def recur(stat: Tree): Context = stat match {
       case pcl: PackageDef =>
         val pkg = createPackageSymbol(pcl.pid)
-        index(pcl.stats)(ctx.fresh.setOwner(pkg.moduleClass))
+        index(pcl.stats)(using ctx.fresh.setOwner(pkg.moduleClass))
         invalidateCompanions(pkg, Trees.flatten(pcl.stats map expanded))
         setDocstring(pkg, stat)
         ctx
@@ -541,7 +541,7 @@ class Namer { typer: Typer =>
   }
 
   /** Determines whether this field holds an enum constant. */
-  def isEnumConstant(vd: ValDef)(implicit ctx: Context): Boolean =
+  def isEnumConstant(vd: ValDef)(using Context): Boolean =
     vd.mods.isAllOf(JavaEnumValue)
 
   /** Add child annotation for `child` to annotations of `cls`. The annotation
@@ -549,7 +549,7 @@ class Namer { typer: Typer =>
    *  in reverse order of their start positions.
    *  @pre `child` must have a position.
    */
-  final def addChild(cls: Symbol, child: Symbol)(implicit ctx: Context): Unit = {
+  final def addChild(cls: Symbol, child: Symbol)(using Context): Unit = {
     val childStart = if (child.span.exists) child.span.start else -1
     def insertInto(annots: List[Annotation]): List[Annotation] =
       annots.find(_.symbol == defn.ChildAnnot) match {
@@ -568,7 +568,7 @@ class Namer { typer: Typer =>
   }
 
   /** Add java enum constants */
-  def addEnumConstants(mdef: DefTree, sym: Symbol)(implicit ctx: Context): Unit = mdef match {
+  def addEnumConstants(mdef: DefTree, sym: Symbol)(using Context): Unit = mdef match {
     case vdef: ValDef if (isEnumConstant(vdef)) =>
       val enumClass = sym.owner.linkedClass
       if (!enumClass.is(Sealed)) enumClass.setFlag(Flags.AbstractSealed)
@@ -576,7 +576,7 @@ class Namer { typer: Typer =>
     case _ =>
   }
 
-  def setDocstring(sym: Symbol, tree: Tree)(implicit ctx: Context): Unit = tree match {
+  def setDocstring(sym: Symbol, tree: Tree)(using Context): Unit = tree match {
     case t: MemberDef if t.rawComment.isDefined =>
       ctx.docCtx.foreach(_.addDocstring(sym, t.rawComment))
     case _ => ()
@@ -585,7 +585,7 @@ class Namer { typer: Typer =>
   /** Create top-level symbols for statements and enter them into symbol table
    *  @return A context that reflects all imports in `stats`.
    */
-  def index(stats: List[Tree])(implicit ctx: Context): Context = {
+  def index(stats: List[Tree])(using Context): Context = {
 
     // module name -> (stat, moduleCls | moduleVal)
     val moduleClsDef = mutable.Map[TypeName, (Tree, TypeDef)]()
@@ -693,14 +693,14 @@ class Namer { typer: Typer =>
     }
 
     /** Create links between companion object and companion class */
-    def createLinks(classTree: TypeDef, moduleTree: TypeDef)(implicit ctx: Context) = {
+    def createLinks(classTree: TypeDef, moduleTree: TypeDef)(using Context) = {
       val claz = ctx.effectiveScope.lookup(classTree.name)
       val modl = ctx.effectiveScope.lookup(moduleTree.name)
       modl.registerCompanion(claz)
       claz.registerCompanion(modl)
     }
 
-    def createCompanionLinks(implicit ctx: Context): Unit = {
+    def createCompanionLinks(using Context): Unit = {
       val classDef  = mutable.Map[TypeName, TypeDef]()
       val moduleDef = mutable.Map[TypeName, TypeDef]()
 
@@ -760,8 +760,8 @@ class Namer { typer: Typer =>
 
     stats.foreach(expand)
     mergeCompanionDefs()
-    val ctxWithStats = stats.foldLeft(ctx)((ctx, stat) => indexExpanded(stat)(ctx))
-    createCompanionLinks(ctxWithStats)
+    val ctxWithStats = stats.foldLeft(ctx)((ctx, stat) => indexExpanded(stat)(using ctx))
+    createCompanionLinks(using ctxWithStats)
     ctxWithStats
   }
 
@@ -769,7 +769,7 @@ class Namer { typer: Typer =>
    *  This will cause any old top-level symbol with the same fully qualified
    *  name as a newly created symbol to be replaced.
    */
-  def lateEnter(tree: Tree)(implicit ctx: Context): Context = {
+  def lateEnter(tree: Tree)(using Context): Context = {
     val saved = lateCompile
     lateCompile = true
     try index(tree :: Nil) finally lateCompile = saved
@@ -779,7 +779,7 @@ class Namer { typer: Typer =>
    *    Nothing  if no wildcard imports of this kind exist
    *    Any      if there are unbounded wildcard imports of this kind
    */
-  def importBound(sels: List[untpd.ImportSelector], isGiven: Boolean)(implicit ctx: Context): Type =
+  def importBound(sels: List[untpd.ImportSelector], isGiven: Boolean)(using Context): Type =
     sels.foldLeft(defn.NothingType: Type) { (bound, sel) =>
       if sel.isWildcard && sel.isGiven == isGiven then
         if sel.bound.isEmpty then defn.AnyType
@@ -787,19 +787,19 @@ class Namer { typer: Typer =>
       else bound
     }
 
-  def missingType(sym: Symbol, modifier: String)(implicit ctx: Context): Unit = {
+  def missingType(sym: Symbol, modifier: String)(using Context): Unit = {
     ctx.error(s"${modifier}type of implicit definition needs to be given explicitly", sym.sourcePos)
     sym.resetFlag(GivenOrImplicit)
   }
 
   /** The completer of a symbol defined by a member def or import (except ClassSymbols) */
-  class Completer(val original: Tree)(implicit ctx: Context) extends LazyType with SymbolLoaders.SecondCompleter {
+  class Completer(val original: Tree)(ictx: Context) extends LazyType with SymbolLoaders.SecondCompleter {
 
     protected def localContext(owner: Symbol): FreshContext = ctx.fresh.setOwner(owner).setTree(original)
 
     /** The context with which this completer was created */
-    def creationContext: Context = ctx
-    ctx.typerState.markShared()
+    given creationContext as Context = ictx
+    ictx.typerState.markShared()
 
     protected def typeSig(sym: Symbol): Type = original match {
       case original: ValDef =>
@@ -821,10 +821,10 @@ class Namer { typer: Typer =>
         }
     }
 
-    final override def complete(denot: SymDenotation)(implicit ctx: Context): Unit = {
-      if (Config.showCompletions && ctx.typerState != this.ctx.typerState) {
+    final override def complete(denot: SymDenotation)(using Context): Unit = {
+      if (Config.showCompletions && ctx.typerState != creationContext.typerState) {
         def levels(c: Context): Int =
-          if (c.typerState eq this.ctx.typerState) 0
+          if (c.typerState eq creationContext.typerState) 0
           else if (c.typerState == null) -1
           else if (c.outer.typerState == c.typerState) levels(c.outer)
           else levels(c.outer) + 1
@@ -1189,7 +1189,7 @@ class Namer { typer: Typer =>
       localCtx = completerCtx.inClassContext(selfInfo)
 
       index(constr)
-      index(rest)(localCtx)
+      index(rest)(using localCtx)
 
       symbolOfTree(constr).info.stripPoly match // Completes constr symbol as a side effect
         case mt: MethodType if cls.is(Case) && mt.isParamDependent =>
@@ -1225,7 +1225,7 @@ class Namer { typer: Typer =>
               if (ptype.typeParams.isEmpty) ptype
               else {
                 if (denot.is(ModuleClass) && denot.sourceModule.isOneOf(GivenOrImplicit))
-                  missingType(denot.symbol, "parent ")(creationContext)
+                  missingType(denot.symbol, "parent ")(using creationContext)
                 fullyDefinedType(typedAheadExpr(parent).tpe, "class parent", parent.span)
               }
             case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Nullables.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Nullables.scala
@@ -330,7 +330,7 @@ object Nullables:
     /** Compute nullability information for this tree and all its subtrees */
     def computeNullableDeeply()(using Context): Unit =
       new TreeTraverser {
-        def traverse(tree: Tree)(implicit ctx: Context) =
+        def traverse(tree: Tree)(using Context) =
           traverseChildren(tree)
           tree.computeNullable()
       }.traverse(tree)
@@ -385,7 +385,7 @@ object Nullables:
        */
       var reachable: Set[Name] = Set.empty
 
-      def traverse(tree: Tree)(implicit ctx: Context) =
+      def traverse(tree: Tree)(using Context) =
         val savedReachable = reachable
         tree match
           case Block(stats, expr) =>
@@ -482,7 +482,7 @@ object Nullables:
                 case _ => super.transform(t)
 
             object retyper extends ReTyper:
-              override def typedUnadapted(t: untpd.Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): Tree = t match
+              override def typedUnadapted(t: untpd.Tree, pt: Type, locked: TypeVars)(using Context): Tree = t match
                 case t: ValDef if !t.symbol.is(Lazy) => super.typedUnadapted(t, pt, locked)
                 case t: MemberDef => promote(t)
                 case _ => super.typedUnadapted(t, pt, locked)

--- a/compiler/src/dotty/tools/dotc/typer/Nullables.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Nullables.scala
@@ -135,8 +135,8 @@ object Nullables:
     || { val sym = ref.symbol
          !ref.usedOutOfOrder
          && sym.span.exists
-         && curCtx.compilationUnit != null // could be null under -Ytest-pickler
-         && curCtx.compilationUnit.assignmentSpans.contains(sym.span.start)
+         && ctx.compilationUnit != null // could be null under -Ytest-pickler
+         && ctx.compilationUnit.assignmentSpans.contains(sym.span.start)
       }
 
   /** The nullability context to be used after a case that matches pattern `pat`.
@@ -243,7 +243,7 @@ object Nullables:
 
       refSym.is(Mutable) // if it is immutable, we don't need to check the rest conditions
       && refOwner.isTerm
-      && recur(curCtx.owner)
+      && recur(ctx.owner)
 
   extension treeOps on (tree: Tree):
 
@@ -255,7 +255,7 @@ object Nullables:
     /* The nullability info of `tree` */
     def notNullInfo(using Context): NotNullInfo =
       stripInlined(tree).getAttachment(NNInfo) match
-        case Some(info) if !curCtx.erasedTypes => info
+        case Some(info) if !ctx.erasedTypes => info
         case _ => NotNullInfo.empty
 
     /* The nullability info of `tree`, assuming it is a condition that evaluates to `c` */
@@ -270,13 +270,13 @@ object Nullables:
      */
     def notNullConditional(using Context): NotNullConditional =
       stripBlock(tree).getAttachment(NNConditional) match
-        case Some(cond) if !curCtx.erasedTypes => cond
+        case Some(cond) if !ctx.erasedTypes => cond
         case _ => NotNullConditional.empty
 
     /** The current context augmented with nullability information of `tree` */
     def nullableContext(using Context): Context =
       val info = tree.notNullInfo
-      if info.isEmpty then curCtx else curCtx.addNotNullInfo(info)
+      if info.isEmpty then ctx else ctx.addNotNullInfo(info)
 
     /** The current context augmented with nullability information,
      *  assuming the result of the condition represented by `tree` is the same as
@@ -284,18 +284,18 @@ object Nullables:
      */
     def nullableContextIf(c: Boolean)(using Context): Context =
       val info = tree.notNullInfoIf(c)
-      if info.isEmpty then curCtx else curCtx.addNotNullInfo(info)
+      if info.isEmpty then ctx else ctx.addNotNullInfo(info)
 
     /** The context to use for the arguments of the function represented by `tree`.
      *  This is the current context, augmented with nullability information
      *  of the left argument, if the application is a boolean `&&` or `||`.
      */
     def nullableInArgContext(using Context): Context = tree match
-      case Select(x, _) if !curCtx.erasedTypes =>
+      case Select(x, _) if !ctx.erasedTypes =>
         if tree.symbol == defn.Boolean_&& then x.nullableContextIf(true)
         else if tree.symbol == defn.Boolean_|| then x.nullableContextIf(false)
-        else curCtx
-      case _ => curCtx
+        else ctx
+      case _ => ctx
 
     /** The `tree` augmented with nullability information in an attachment.
      *  The following operations lead to nullability info being recorded:
@@ -307,7 +307,7 @@ object Nullables:
     def computeNullable()(using Context): tree.type =
       def setConditional(ifTrue: Set[TermRef], ifFalse: Set[TermRef]) =
         tree.putAttachment(NNConditional, NotNullConditional(ifTrue, ifFalse))
-      if !curCtx.erasedTypes && analyzedOps.contains(tree.symbol.name.toTermName) then
+      if !ctx.erasedTypes && analyzedOps.contains(tree.symbol.name.toTermName) then
         tree match
           case CompareNull(TrackedRef(ref), testEqual) =>
             if testEqual then setConditional(Set(), Set(ref))
@@ -339,7 +339,7 @@ object Nullables:
     def computeAssignNullable()(using Context): tree.type = tree.lhs match
       case TrackedRef(ref) =>
         val rhstp = tree.rhs.typeOpt
-        if curCtx.explicitNulls && ref.isNullableUnion then
+        if ctx.explicitNulls && ref.isNullableUnion then
           if rhstp.isNullType || rhstp.isNullableUnion then
             // If the type of rhs is nullable (`T|Null` or `Null`), then the nullability of the
             // lhs variable is no longer trackable. We don't need to check whether the type `T`
@@ -413,7 +413,7 @@ object Nullables:
             traverseChildren(tree)
         reachable = savedReachable
 
-    populate.traverse(curCtx.compilationUnit.untpdTree)
+    populate.traverse(ctx.compilationUnit.untpdTree)
     populate.tracked
   end assignmentSpans
 
@@ -448,9 +448,9 @@ object Nullables:
       val sym = ref.symbol
       sym.span.exists
       && assignmentSpans.getOrElse(sym.span.start, Nil).exists(whileSpan.contains(_))
-      && curCtx.notNullInfos.impliesNotNull(ref)
-    val retractedVars = curCtx.notNullInfos.flatMap(_.asserted.filter(isRetracted)).toSet
-    curCtx.addNotNullInfo(NotNullInfo(Set(), retractedVars))
+      && ctx.notNullInfos.impliesNotNull(ref)
+    val retractedVars = ctx.notNullInfos.flatMap(_.asserted.filter(isRetracted)).toSet
+    ctx.addNotNullInfo(NotNullInfo(Set(), retractedVars))
 
   /** Post process all arguments to by-name parameters by removing any not-null
    *  info that was used when typing them. Concretely:

--- a/compiler/src/dotty/tools/dotc/typer/Nullables.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Nullables.scala
@@ -142,7 +142,7 @@ object Nullables:
   /** The nullability context to be used after a case that matches pattern `pat`.
    *  If `pat` is `null`, this will assert that the selector `sel` is not null afterwards.
    */
-  def afterPatternContext(sel: Tree, pat: Tree)(using ctx: Context) = (sel, pat) match
+  def afterPatternContext(sel: Tree, pat: Tree)(using Context) = (sel, pat) match
     case (TrackedRef(ref), Literal(Constant(null))) => ctx.addNotNullRefs(Set(ref))
     case _ => ctx
 
@@ -150,7 +150,7 @@ object Nullables:
    *  given pattern `pat`. If the pattern can only match non-null values, this
    *  will assert that the selector `sel` is not null in these regions.
    */
-  def caseContext(sel: Tree, pat: Tree)(using ctx: Context): Context = sel match
+  def caseContext(sel: Tree, pat: Tree)(using Context): Context = sel match
     case TrackedRef(ref) if matchesNotNull(pat) => ctx.addNotNullRefs(Set(ref))
     case _ => ctx
 
@@ -462,7 +462,7 @@ object Nullables:
    *  flow assumptions about mutable variables and suggest that it is enclosed
    *  in a `byName(...)` call instead.
    */
-  def postProcessByNameArgs(fn: TermRef, app: Tree)(using ctx: Context): Tree =
+  def postProcessByNameArgs(fn: TermRef, app: Tree)(using Context): Tree =
     fn.widen match
       case mt: MethodType
       if mt.paramInfos.exists(_.isInstanceOf[ExprType]) && !fn.symbol.is(Inline) =>

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -24,7 +24,7 @@ object ProtoTypes {
   trait Compatibility {
 
     /** Is there an implicit conversion from `tp` to `pt`? */
-    def viewExists(tp: Type, pt: Type)(implicit ctx: Context): Boolean
+    def viewExists(tp: Type, pt: Type)(using Context): Boolean
 
     /** A type `tp` is compatible with a type `pt` if one of the following holds:
      *    1. `tp` is a subtype of `pt`
@@ -33,14 +33,14 @@ object ProtoTypes {
      *    4. `tp` is a numeric subtype of `pt` (this case applies even if implicit conversions are disabled)
      *  If `pt` is a by-name type, we compare against the underlying type instead.
      */
-    def isCompatible(tp: Type, pt: Type)(implicit ctx: Context): Boolean =
+    def isCompatible(tp: Type, pt: Type)(using Context): Boolean =
       (tp.widenExpr relaxed_<:< pt.widenExpr) || viewExists(tp, pt)
 
     /** Test compatibility after normalization.
      *  Do this in a fresh typerstate unless `keepConstraint` is true.
      */
-    def normalizedCompatible(tp: Type, pt: Type, keepConstraint: Boolean)(implicit ctx: Context): Boolean = {
-      def testCompat(implicit ctx: Context): Boolean = {
+    def normalizedCompatible(tp: Type, pt: Type, keepConstraint: Boolean)(using Context): Boolean = {
+      def testCompat(using Context): Boolean = {
         val normTp = normalize(tp, pt)
         isCompatible(normTp, pt) || pt.isRef(defn.UnitClass) && normTp.isParameterless
       }
@@ -59,14 +59,14 @@ object ProtoTypes {
       else ctx.test(testCompat)
     }
 
-    private def disregardProto(pt: Type)(implicit ctx: Context): Boolean =
+    private def disregardProto(pt: Type)(using Context): Boolean =
       pt.dealias.isRef(defn.UnitClass)
 
     /** Check that the result type of the current method
      *  fits the given expected result type.
      */
-    def constrainResult(mt: Type, pt: Type)(implicit parentCtx: Context): Boolean = {
-      given ctx as Context = parentCtx.addMode(Mode.ConstrainResult)
+    def constrainResult(mt: Type, pt: Type)(using Context): Boolean =
+      inContext(ctx.addMode(Mode.ConstrainResult)) {
       val savedConstraint = ctx.typerState.constraint
       val res = pt.widenExpr match {
         case pt: FunProto =>
@@ -91,7 +91,7 @@ object ProtoTypes {
      *  However, we should constrain parameters of the declared return type. This distinction is
      *  achieved by replacing expected type parameters with wildcards.
      */
-    def constrainResult(meth: Symbol, mt: Type, pt: Type)(implicit ctx: Context): Boolean =
+    def constrainResult(meth: Symbol, mt: Type, pt: Type)(using Context): Boolean =
       if (Inliner.isInlineable(meth)) {
         constrainResult(mt, wildApprox(pt))
         true
@@ -100,21 +100,21 @@ object ProtoTypes {
   }
 
   object NoViewsAllowed extends Compatibility {
-    override def viewExists(tp: Type, pt: Type)(implicit ctx: Context): Boolean = false
+    override def viewExists(tp: Type, pt: Type)(using Context): Boolean = false
   }
 
   /** A trait for prototypes that match all types */
   trait MatchAlways extends ProtoType {
-    def isMatchedBy(tp1: Type, keepConstraint: Boolean)(implicit ctx: Context): Boolean = true
-    def map(tm: TypeMap)(implicit ctx: Context): ProtoType = this
-    def fold[T](x: T, ta: TypeAccumulator[T])(implicit ctx: Context): T = x
+    def isMatchedBy(tp1: Type, keepConstraint: Boolean)(using Context): Boolean = true
+    def map(tm: TypeMap)(using Context): ProtoType = this
+    def fold[T](x: T, ta: TypeAccumulator[T])(using Context): T = x
     override def toString: String = getClass.toString
   }
 
   /** A class marking ignored prototypes that can be revealed by `deepenProto` */
   case class IgnoredProto(ignored: Type) extends UncachedGroundType with MatchAlways:
     override def revealIgnored = ignored
-    override def deepenProto(implicit ctx: Context): Type = ignored
+    override def deepenProto(using Context): Type = ignored
 
   object IgnoredProto:
     def apply(ignored: Type): IgnoredProto = ignored match
@@ -133,7 +133,7 @@ object ProtoTypes {
      *  2. The type has an uninstantiated TypeVar as a prefix or underlying type,
      *  or as an upper bound of a prefix or underlying type.
      */
-    private def hasUnknownMembers(tp: Type)(implicit ctx: Context): Boolean = tp match {
+    private def hasUnknownMembers(tp: Type)(using Context): Boolean = tp match {
       case tp: TypeVar => !tp.isInstantiated
       case tp: WildcardType => true
       case NoType => true
@@ -151,7 +151,7 @@ object ProtoTypes {
       case _ => false
     }
 
-    override def isMatchedBy(tp1: Type, keepConstraint: Boolean)(implicit ctx: Context): Boolean =
+    override def isMatchedBy(tp1: Type, keepConstraint: Boolean)(using Context): Boolean =
       name == nme.WILDCARD || hasUnknownMembers(tp1) ||
       {
         val mbr = if (privateOK) tp1.member(name) else tp1.nonPrivateMember(name)
@@ -166,9 +166,9 @@ object ProtoTypes {
         }
       }
 
-    def underlying(implicit ctx: Context): Type = WildcardType
+    def underlying(using Context): Type = WildcardType
 
-    def derivedSelectionProto(name: Name, memberProto: Type, compat: Compatibility)(implicit ctx: Context): SelectionProto =
+    def derivedSelectionProto(name: Name, memberProto: Type, compat: Compatibility)(using Context): SelectionProto =
       if ((name eq this.name) && (memberProto eq this.memberProto) && (compat eq this.compat)) this
       else SelectionProto(name, memberProto, compat, privateOK)
 
@@ -179,10 +179,10 @@ object ProtoTypes {
         false
     }
 
-    def map(tm: TypeMap)(implicit ctx: Context): SelectionProto = derivedSelectionProto(name, tm(memberProto), compat)
-    def fold[T](x: T, ta: TypeAccumulator[T])(implicit ctx: Context): T = ta(x, memberProto)
+    def map(tm: TypeMap)(using Context): SelectionProto = derivedSelectionProto(name, tm(memberProto), compat)
+    def fold[T](x: T, ta: TypeAccumulator[T])(using Context): T = ta(x, memberProto)
 
-    override def deepenProto(implicit ctx: Context): SelectionProto = derivedSelectionProto(name, memberProto.deepenProto, compat)
+    override def deepenProto(using Context): SelectionProto = derivedSelectionProto(name, memberProto.deepenProto, compat)
 
     override def computeHash(bs: Hashable.Binders): Int = {
       val delta = (if (compat eq NoViewsAllowed) 1 else 0) | (if (privateOK) 2 else 0)
@@ -194,7 +194,7 @@ object ProtoTypes {
   extends SelectionProto(name, memberProto, compat, privateOK)
 
   object SelectionProto {
-    def apply(name: Name, memberProto: Type, compat: Compatibility, privateOK: Boolean)(implicit ctx: Context): SelectionProto = {
+    def apply(name: Name, memberProto: Type, compat: Compatibility, privateOK: Boolean)(using Context): SelectionProto = {
       val selproto = new CachedSelectionProto(name, memberProto, compat, privateOK)
       if (compat eq NoViewsAllowed) unique(selproto) else selproto
     }
@@ -203,7 +203,7 @@ object ProtoTypes {
   /** Create a selection proto-type, but only one level deep;
    *  treat constructors specially
    */
-  def selectionProto(name: Name, tp: Type, typer: Typer)(implicit ctx: Context): TermType =
+  def selectionProto(name: Name, tp: Type, typer: Typer)(using Context): TermType =
     if (name.isConstructorName) WildcardType
     else tp match {
       case tp: UnapplyFunProto => new UnapplySelectionProto(name)
@@ -248,11 +248,11 @@ object ProtoTypes {
    *  [](args): resultType
    */
   case class FunProto(args: List[untpd.Tree], resType: Type)(typer: Typer,
-    override val isUsingApply: Boolean, state: FunProtoState = new FunProtoState)(implicit protoCtx: Context)
+    override val isUsingApply: Boolean, state: FunProtoState = new FunProtoState)(using protoCtx: Context)
   extends UncachedGroundType with ApplyingProto with FunOrPolyProto {
-    override def resultType(implicit ctx: Context): Type = resType
+    override def resultType(using Context): Type = resType
 
-    def isMatchedBy(tp: Type, keepConstraint: Boolean)(implicit ctx: Context): Boolean = {
+    def isMatchedBy(tp: Type, keepConstraint: Boolean)(using Context): Boolean = {
       val args = typedArgs()
       def isPoly(tree: Tree) = tree.tpe.widenSingleton.isInstanceOf[PolyType]
       // See remark in normalizedCompatible for why we can't keep the constraint
@@ -266,7 +266,7 @@ object ProtoTypes {
 
     /** @return True if all arguments have types.
      */
-    def allArgTypesAreCurrent()(implicit ctx: Context): Boolean =
+    def allArgTypesAreCurrent()(using Context): Boolean =
       state.typedArg.size == args.length
 
     private def isUndefined(tp: Type): Boolean = tp match {
@@ -275,7 +275,7 @@ object ProtoTypes {
       case _ => false
     }
 
-    private def cacheTypedArg(arg: untpd.Tree, typerFn: untpd.Tree => Tree, force: Boolean)(implicit ctx: Context): Tree = {
+    private def cacheTypedArg(arg: untpd.Tree, typerFn: untpd.Tree => Tree, force: Boolean)(using Context): Tree = {
       var targ = state.typedArg(arg)
       if (targ == null)
         untpd.functionWithUnknownParamType(arg) match {
@@ -307,18 +307,18 @@ object ProtoTypes {
      *  @param norm   a normalization function that is applied to an untyped argument tree
      *                before it is typed. The second Int parameter is the parameter index.
      */
-    def typedArgs(norm: (untpd.Tree, Int) => untpd.Tree = sameTree)(implicit ctx: Context): List[Tree] =
+    def typedArgs(norm: (untpd.Tree, Int) => untpd.Tree = sameTree)(using Context): List[Tree] =
       if (state.typedArgs.size == args.length) state.typedArgs
       else {
         val prevConstraint = protoCtx.typerState.constraint
 
-        try {
-          implicit val ctx = protoCtx
-          val args1 = args.mapWithIndexConserve((arg, idx) =>
-            cacheTypedArg(arg, arg => typer.typed(norm(arg, idx)), force = false))
-          if (!args1.exists(arg => isUndefined(arg.tpe))) state.typedArgs = args1
-          args1
-        }
+        try
+          inContext(protoCtx) {
+            val args1 = args.mapWithIndexConserve((arg, idx) =>
+              cacheTypedArg(arg, arg => typer.typed(norm(arg, idx)), force = false))
+            if !args1.exists(arg => isUndefined(arg.tpe)) then state.typedArgs = args1
+            args1
+          }
         finally
           if (protoCtx.typerState.constraint ne prevConstraint)
             ctx.typerState.mergeConstraintWith(protoCtx.typerState)
@@ -327,7 +327,7 @@ object ProtoTypes {
     /** Type single argument and remember the unadapted result in `myTypedArg`.
      *  used to avoid repeated typings of trees when backtracking.
      */
-    def typedArg(arg: untpd.Tree, formal: Type)(implicit ctx: Context): Tree = {
+    def typedArg(arg: untpd.Tree, formal: Type)(using Context): Tree = {
       val wideFormal = formal.widenExpr
       val argCtx =
         if wideFormal eq formal then ctx
@@ -342,7 +342,7 @@ object ProtoTypes {
     /** The type of the argument `arg`, or `NoType` if `arg` has not been typed before
      *  or if `arg`'s typing produced a type error.
      */
-    def typeOfArg(arg: untpd.Tree)(implicit ctx: Context): Type = {
+    def typeOfArg(arg: untpd.Tree)(using Context): Type = {
       val t = state.typedArg(arg)
       if (t == null) NoType else t.tpe
     }
@@ -372,34 +372,34 @@ object ProtoTypes {
 
     def isDropped: Boolean = state.toDrop
 
-    override def isErroneous(implicit ctx: Context): Boolean =
+    override def isErroneous(using Context): Boolean =
       state.typedArgs.tpes.exists(_.isErroneous)
 
     override def toString: String = s"FunProto(${args mkString ","} => $resultType)"
 
-    def map(tm: TypeMap)(implicit ctx: Context): FunProto =
+    def map(tm: TypeMap)(using Context): FunProto =
       derivedFunProto(args, tm(resultType), typer)
 
-    def fold[T](x: T, ta: TypeAccumulator[T])(implicit ctx: Context): T =
+    def fold[T](x: T, ta: TypeAccumulator[T])(using Context): T =
       ta(ta.foldOver(x, typedArgs().tpes), resultType)
 
-    override def deepenProto(implicit ctx: Context): FunProto = derivedFunProto(args, resultType.deepenProto, typer)
+    override def deepenProto(using Context): FunProto = derivedFunProto(args, resultType.deepenProto, typer)
 
     override def withContext(newCtx: Context): ProtoType =
       if newCtx `eq` protoCtx then this
-      else new FunProto(args, resType)(typer, isUsingApply, state)(newCtx)
+      else new FunProto(args, resType)(typer, isUsingApply, state)(using newCtx)
   }
 
   /** A prototype for expressions that appear in function position
    *
    *  [](args): resultType, where args are known to be typed
    */
-  class FunProtoTyped(args: List[tpd.Tree], resultType: Type)(typer: Typer, isUsingApply: Boolean)(implicit ctx: Context) extends FunProto(args, resultType)(typer, isUsingApply)(ctx) {
-    override def typedArgs(norm: (untpd.Tree, Int) => untpd.Tree)(implicit ctx: Context): List[tpd.Tree] = args
-    override def typedArg(arg: untpd.Tree, formal: Type)(implicit ctx: Context): tpd.Tree = arg.asInstanceOf[tpd.Tree]
-    override def allArgTypesAreCurrent()(implicit ctx: Context): Boolean = true
+  class FunProtoTyped(args: List[tpd.Tree], resultType: Type)(typer: Typer, isUsingApply: Boolean)(using Context)
+  extends FunProto(args, resultType)(typer, isUsingApply):
+    override def typedArgs(norm: (untpd.Tree, Int) => untpd.Tree)(using Context): List[tpd.Tree] = args
+    override def typedArg(arg: untpd.Tree, formal: Type)(using Context): tpd.Tree = arg.asInstanceOf[tpd.Tree]
+    override def allArgTypesAreCurrent()(using Context): Boolean = true
     override def withContext(ctx: Context): FunProtoTyped = this
-  }
 
   /** A prototype for implicitly inferred views:
    *
@@ -408,9 +408,9 @@ object ProtoTypes {
   abstract case class ViewProto(argType: Type, resType: Type)
   extends CachedGroundType with ApplyingProto {
 
-    override def resultType(implicit ctx: Context): Type = resType
+    override def resultType(using Context): Type = resType
 
-    def isMatchedBy(tp: Type, keepConstraint: Boolean)(implicit ctx: Context): Boolean =
+    def isMatchedBy(tp: Type, keepConstraint: Boolean)(using Context): Boolean =
       ctx.typer.isApplicableType(tp, argType :: Nil, resultType) || {
         resType match {
           case SelectionProto(name: TermName, mbrType, _, _) =>
@@ -421,16 +421,16 @@ object ProtoTypes {
         }
       }
 
-    def derivedViewProto(argType: Type, resultType: Type)(implicit ctx: Context): ViewProto =
+    def derivedViewProto(argType: Type, resultType: Type)(using Context): ViewProto =
       if ((argType eq this.argType) && (resultType eq this.resultType)) this
       else ViewProto(argType, resultType)
 
-    def map(tm: TypeMap)(implicit ctx: Context): ViewProto = derivedViewProto(tm(argType), tm(resultType))
+    def map(tm: TypeMap)(using Context): ViewProto = derivedViewProto(tm(argType), tm(resultType))
 
-    def fold[T](x: T, ta: TypeAccumulator[T])(implicit ctx: Context): T =
+    def fold[T](x: T, ta: TypeAccumulator[T])(using Context): T =
       ta(ta(x, argType), resultType)
 
-    override def deepenProto(implicit ctx: Context): ViewProto = derivedViewProto(argType, resultType.deepenProto)
+    override def deepenProto(using Context): ViewProto = derivedViewProto(argType, resultType.deepenProto)
   }
 
   class CachedViewProto(argType: Type, resultType: Type) extends ViewProto(argType, resultType) {
@@ -438,11 +438,11 @@ object ProtoTypes {
   }
 
   object ViewProto {
-    def apply(argType: Type, resultType: Type)(implicit ctx: Context): ViewProto =
+    def apply(argType: Type, resultType: Type)(using Context): ViewProto =
       unique(new CachedViewProto(argType, resultType))
   }
 
-  class UnapplyFunProto(argType: Type, typer: Typer)(implicit ctx: Context) extends FunProto(
+  class UnapplyFunProto(argType: Type, typer: Typer)(using Context) extends FunProto(
     untpd.TypedSplice(dummyTreeOfType(argType)(ctx.source))(ctx) :: Nil, WildcardType)(typer, isUsingApply = false)
 
   /** A prototype for expressions [] that are type-parameterized:
@@ -451,26 +451,26 @@ object ProtoTypes {
    */
   case class PolyProto(targs: List[Tree], resType: Type) extends UncachedGroundType with FunOrPolyProto {
 
-    override def resultType(implicit ctx: Context): Type = resType
+    override def resultType(using Context): Type = resType
 
     def canInstantiate(tp: Type)(using Context) = tp.widen match
       case tp: PolyType => tp.paramNames.length == targs.length
       case _ => false
 
-    override def isMatchedBy(tp: Type, keepConstraint: Boolean)(implicit ctx: Context): Boolean =
+    override def isMatchedBy(tp: Type, keepConstraint: Boolean)(using Context): Boolean =
       canInstantiate(tp) || tp.member(nme.apply).hasAltWith(d => canInstantiate(d.info))
 
     def derivedPolyProto(targs: List[Tree], resultType: Type): PolyProto =
       if ((targs eq this.targs) && (resType eq this.resType)) this
       else PolyProto(targs, resType)
 
-    def map(tm: TypeMap)(implicit ctx: Context): PolyProto =
+    def map(tm: TypeMap)(using Context): PolyProto =
       derivedPolyProto(targs, tm(resultType))
 
-    def fold[T](x: T, ta: TypeAccumulator[T])(implicit ctx: Context): T =
+    def fold[T](x: T, ta: TypeAccumulator[T])(using Context): T =
       ta(ta.foldOver(x, targs.tpes), resultType)
 
-    override def deepenProto(implicit ctx: Context): PolyProto = derivedPolyProto(targs, resultType.deepenProto)
+    override def deepenProto(using Context): PolyProto = derivedPolyProto(targs, resultType.deepenProto)
   }
 
   /** A prototype for expressions [] that are known to be functions:
@@ -490,7 +490,7 @@ object ProtoTypes {
    *  for each parameter.
    *  @return  The added type lambda, and the list of created type variables.
    */
-  def constrained(tl: TypeLambda, owningTree: untpd.Tree, alwaysAddTypeVars: Boolean)(implicit ctx: Context): (TypeLambda, List[TypeTree]) = {
+  def constrained(tl: TypeLambda, owningTree: untpd.Tree, alwaysAddTypeVars: Boolean)(using Context): (TypeLambda, List[TypeTree]) = {
     val state = ctx.typerState
     val addTypeVars = alwaysAddTypeVars || !owningTree.isEmpty
     if (tl.isInstanceOf[PolyType])
@@ -513,15 +513,15 @@ object ProtoTypes {
     (added, tvars)
   }
 
-  def constrained(tl: TypeLambda, owningTree: untpd.Tree)(implicit ctx: Context): (TypeLambda, List[TypeTree]) =
+  def constrained(tl: TypeLambda, owningTree: untpd.Tree)(using Context): (TypeLambda, List[TypeTree]) =
     constrained(tl, owningTree,
       alwaysAddTypeVars = tl.isInstanceOf[PolyType] && ctx.typerState.isCommittable)
 
   /**  Same as `constrained(tl, EmptyTree)`, but returns just the created type lambda */
-  def constrained(tl: TypeLambda)(implicit ctx: Context): TypeLambda =
+  def constrained(tl: TypeLambda)(using Context): TypeLambda =
     constrained(tl, EmptyTree)._1
 
-  def newTypeVar(bounds: TypeBounds)(implicit ctx: Context): TypeVar = {
+  def newTypeVar(bounds: TypeBounds)(using Context): TypeVar = {
     val poly = PolyType(DepParamName.fresh().toTypeName :: Nil)(
         pt => bounds :: Nil,
         pt => defn.AnyType)
@@ -530,13 +530,13 @@ object ProtoTypes {
   }
 
   /** Create a new TypeVar that represents a dependent method parameter singleton */
-  def newDepTypeVar(tp: Type)(implicit ctx: Context): TypeVar =
+  def newDepTypeVar(tp: Type)(using Context): TypeVar =
     newTypeVar(TypeBounds.upper(AndType(tp.widenExpr, defn.SingletonClass.typeRef)))
 
   /** The result type of `mt`, where all references to parameters of `mt` are
    *  replaced by either wildcards (if typevarsMissContext) or TypeParamRefs.
    */
-  def resultTypeApprox(mt: MethodType)(implicit ctx: Context): Type =
+  def resultTypeApprox(mt: MethodType)(using Context): Type =
     if (mt.isResultDependent) {
       def replacement(tp: Type) =
         if (ctx.mode.is(Mode.TypevarsMissContext) ||
@@ -562,7 +562,7 @@ object ProtoTypes {
    * of toString method. The problem is solved by dereferencing nullary method types if the corresponding
    * function type is not compatible with the prototype.
    */
-  def normalize(tp: Type, pt: Type)(implicit ctx: Context): Type = {
+  def normalize(tp: Type, pt: Type)(using Context): Type = {
     Stats.record("normalize")
     tp.widenSingleton match {
       case poly: PolyType =>
@@ -594,7 +594,7 @@ object ProtoTypes {
   /** Approximate occurrences of parameter types and uninstantiated typevars
    *  by wildcard types.
    */
-  private def wildApprox(tp: Type, theMap: WildApproxMap, seen: Set[TypeParamRef], internal: Set[TypeLambda])(implicit ctx: Context): Type = tp match {
+  private def wildApprox(tp: Type, theMap: WildApproxMap, seen: Set[TypeParamRef], internal: Set[TypeLambda])(using Context): Type = tp match {
     case tp: NamedType => // default case, inlined for speed
       val isPatternBoundTypeRef = tp.isInstanceOf[TypeRef] && tp.symbol.is(Flags.Case) && !tp.symbol.isClass
       if (isPatternBoundTypeRef) WildcardType(tp.underlying.bounds)
@@ -673,11 +673,11 @@ object ProtoTypes {
         .mapOver(tp)
   }
 
-  final def wildApprox(tp: Type)(implicit ctx: Context): Type = wildApprox(tp, null, Set.empty, Set.empty)
+  final def wildApprox(tp: Type)(using Context): Type = wildApprox(tp, null, Set.empty, Set.empty)
 
   @sharable object AssignProto extends UncachedGroundType with MatchAlways
 
-  private[ProtoTypes] class WildApproxMap(val seen: Set[TypeParamRef], val internal: Set[TypeLambda])(implicit ctx: Context) extends TypeMap {
+  private[ProtoTypes] class WildApproxMap(val seen: Set[TypeParamRef], val internal: Set[TypeLambda])(using Context) extends TypeMap {
     def apply(tp: Type): Type = wildApprox(tp, this, seen, internal)
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -67,23 +67,23 @@ object ProtoTypes {
      */
     def constrainResult(mt: Type, pt: Type)(using Context): Boolean =
       inContext(ctx.addMode(Mode.ConstrainResult)) {
-      val savedConstraint = ctx.typerState.constraint
-      val res = pt.widenExpr match {
-        case pt: FunProto =>
-          mt match {
-            case mt: MethodType => constrainResult(resultTypeApprox(mt), pt.resultType)
-            case _ => true
-          }
-        case _: ValueTypeOrProto if !disregardProto(pt) =>
-          isCompatible(normalize(mt, pt), pt)
-        case pt: WildcardType if pt.optBounds.exists =>
-          isCompatible(normalize(mt, pt), pt)
-        case _ =>
-          true
+        val savedConstraint = ctx.typerState.constraint
+        val res = pt.widenExpr match {
+          case pt: FunProto =>
+            mt match {
+              case mt: MethodType => constrainResult(resultTypeApprox(mt), pt.resultType)
+              case _ => true
+            }
+          case _: ValueTypeOrProto if !disregardProto(pt) =>
+            isCompatible(normalize(mt, pt), pt)
+          case pt: WildcardType if pt.optBounds.exists =>
+            isCompatible(normalize(mt, pt), pt)
+          case _ =>
+            true
+        }
+        if (!res) ctx.typerState.resetConstraintTo(savedConstraint)
+        res
       }
-      if (!res) ctx.typerState.resetConstraintTo(savedConstraint)
-      res
-    }
 
     /** Constrain result with special case if `meth` is an inlineable method in an inlineable context.
      *  In that case, we should always succeed and not constrain type parameters in the expected type,

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -77,7 +77,7 @@ trait QuotesAndSplices {
         def spliceOwner(ctx: Context): Symbol =
           if (ctx.mode.is(Mode.QuotedPattern)) spliceOwner(ctx.outer) else ctx.owner
         val pat = typedPattern(tree.expr, defn.QuotedExprClass.typeRef.appliedTo(pt))(
-          spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
+          using spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
         val baseType = pat.tpe.baseType(defn.QuotedExprClass)
         val argType = if baseType != NoType then baseType.argTypesHi.head else defn.NothingType
         ref(defn.InternalQuoted_exprSplice).appliedToType(argType).appliedTo(pat)
@@ -149,10 +149,10 @@ trait QuotesAndSplices {
       val typeSym = ctx.newSymbol(spliceOwner(ctx), name, EmptyFlags, typeSymInfo, NoSymbol, tree.expr.span)
       typeSym.addAnnotation(Annotation(New(ref(defn.InternalQuoted_patternBindHoleAnnot.typeRef)).withSpan(tree.expr.span)))
       val pat = typedPattern(tree.expr, defn.QuotedTypeClass.typeRef.appliedTo(typeSym.typeRef))(
-          spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
+          using spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
       pat.select(tpnme.splice)
     else
-      typedSelect(untpd.Select(tree.expr, tpnme.splice), pt)(spliceContext).withSpan(tree.span)
+      typedSelect(untpd.Select(tree.expr, tpnme.splice), pt)(using spliceContext).withSpan(tree.span)
   }
 
   private def checkSpliceOutsideQuote(tree: untpd.Tree)(implicit ctx: Context): Unit =
@@ -362,8 +362,8 @@ trait QuotesAndSplices {
     val quoted0 = desugar.quotedPattern(quoted, untpd.TypedSplice(TypeTree(quotedPt)))
     val quoteCtx = quoteContext.addMode(Mode.QuotedPattern)
     val quoted1 =
-      if quoted.isType then typedType(quoted0, WildcardType)(quoteCtx)
-      else typedExpr(quoted0, WildcardType)(quoteCtx)
+      if quoted.isType then typedType(quoted0, WildcardType)(using quoteCtx)
+      else typedExpr(quoted0, WildcardType)(using quoteCtx)
 
     val (typeBindings, shape, splices) = splitQuotePattern(quoted1)
 

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -24,34 +24,34 @@ import util.Spans.Span
 class ReTyper extends Typer with ReChecking {
   import tpd._
 
-  private def assertTyped(tree: untpd.Tree)(implicit ctx: Context): Unit =
+  private def assertTyped(tree: untpd.Tree)(using Context): Unit =
     assert(tree.hasType, i"$tree ${tree.getClass} ${tree.uniqueId}")
 
   /** Checks that the given tree has been typed */
-  protected def promote(tree: untpd.Tree)(implicit ctx: Context): tree.ThisTree[Type] = {
+  protected def promote(tree: untpd.Tree)(using Context): tree.ThisTree[Type] = {
     assertTyped(tree)
     tree.withType(tree.typeOpt)
   }
 
-  override def typedIdent(tree: untpd.Ident, pt: Type)(implicit ctx: Context): Tree =
+  override def typedIdent(tree: untpd.Ident, pt: Type)(using Context): Tree =
     promote(tree)
 
-  override def typedSelect(tree: untpd.Select, pt: Type)(implicit ctx: Context): Tree = {
+  override def typedSelect(tree: untpd.Select, pt: Type)(using Context): Tree = {
     assertTyped(tree)
-    val qual1 = typed(tree.qualifier, AnySelectionProto)(ctx.retractMode(Mode.Pattern))
+    val qual1 = typed(tree.qualifier, AnySelectionProto)(using ctx.retractMode(Mode.Pattern))
     untpd.cpy.Select(tree)(qual1, tree.name).withType(tree.typeOpt)
   }
 
   override def typedLiteral(tree: untpd.Literal)(implicit ctc: Context): Tree =
     promote(tree)
 
-  override def typedThis(tree: untpd.This)(implicit ctx: Context): Tree =
+  override def typedThis(tree: untpd.This)(using Context): Tree =
     promote(tree)
 
-  override def typedSuper(tree: untpd.Super, pt: Type)(implicit ctx: Context): Tree =
+  override def typedSuper(tree: untpd.Super, pt: Type)(using Context): Tree =
     promote(tree)
 
-  override def typedTyped(tree: untpd.Typed, pt: Type)(implicit ctx: Context): Tree = {
+  override def typedTyped(tree: untpd.Typed, pt: Type)(using Context): Tree = {
     assertTyped(tree)
     val tpt1 = checkSimpleKinded(typedType(tree.tpt))
     val expr1 = tree.expr match {
@@ -62,57 +62,57 @@ class ReTyper extends Typer with ReChecking {
     untpd.cpy.Typed(tree)(expr1, tpt1).withType(tree.typeOpt)
   }
 
-  override def typedTypeTree(tree: untpd.TypeTree, pt: Type)(implicit ctx: Context): TypeTree =
+  override def typedTypeTree(tree: untpd.TypeTree, pt: Type)(using Context): TypeTree =
     promote(tree)
 
-  override def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(implicit ctx: Context): TypTree =
+  override def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(using Context): TypTree =
     promote(TypeTree(tree.tpe).withSpan(tree.span))
 
-  override def typedFunPart(fn: untpd.Tree, pt: Type)(implicit ctx: Context): Tree =
+  override def typedFunPart(fn: untpd.Tree, pt: Type)(using Context): Tree =
     typedExpr(fn, pt)
 
-  override def typedBind(tree: untpd.Bind, pt: Type)(implicit ctx: Context): Bind = {
+  override def typedBind(tree: untpd.Bind, pt: Type)(using Context): Bind = {
     assertTyped(tree)
     val body1 = typed(tree.body, pt)
     untpd.cpy.Bind(tree)(tree.name, body1).withType(tree.typeOpt)
   }
 
-  override def typedUnApply(tree: untpd.UnApply, selType: Type)(implicit ctx: Context): UnApply = {
+  override def typedUnApply(tree: untpd.UnApply, selType: Type)(using Context): UnApply = {
     val fun1 = {
       // retract PatternOrTypeBits like in typedExpr
       val ctx1 = ctx.retractMode(Mode.PatternOrTypeBits)
-      typedUnadapted(tree.fun, AnyFunctionProto)(ctx1)
+      typedUnadapted(tree.fun, AnyFunctionProto)(using ctx1)
     }
     val implicits1 = tree.implicits.map(typedExpr(_))
     val patterns1 = tree.patterns.mapconserve(pat => typed(pat, pat.tpe))
     untpd.cpy.UnApply(tree)(fun1, implicits1, patterns1).withType(tree.tpe)
   }
 
-  override def typedUnApply(tree: untpd.Apply, selType: Type)(implicit ctx: Context): Tree =
+  override def typedUnApply(tree: untpd.Apply, selType: Type)(using Context): Tree =
     typedApply(tree, selType)
 
-  override def localDummy(cls: ClassSymbol, impl: untpd.Template)(implicit ctx: Context): Symbol = impl.symbol
+  override def localDummy(cls: ClassSymbol, impl: untpd.Template)(using Context): Symbol = impl.symbol
 
-  override def retrieveSym(tree: untpd.Tree)(implicit ctx: Context): Symbol = tree.symbol
-  override def symbolOfTree(tree: untpd.Tree)(implicit ctx: Context): Symbol = tree.symbol
+  override def retrieveSym(tree: untpd.Tree)(using Context): Symbol = tree.symbol
+  override def symbolOfTree(tree: untpd.Tree)(using Context): Symbol = tree.symbol
 
   override def localTyper(sym: Symbol): Typer = this
 
-  override def index(trees: List[untpd.Tree])(implicit ctx: Context): Context = ctx
+  override def index(trees: List[untpd.Tree])(using Context): Context = ctx
 
-  override def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType, locked: TypeVars)(fallBack: => Tree)(implicit ctx: Context): Tree =
+  override def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType, locked: TypeVars)(fallBack: => Tree)(using Context): Tree =
     fallBack
 
   override def tryNew[T >: Untyped <: Type]
-    (treesInst: Instance[T])(tree: Trees.Tree[T], pt: Type, fallBack: TyperState => Tree)(implicit ctx: Context): Tree =
+    (treesInst: Instance[T])(tree: Trees.Tree[T], pt: Type, fallBack: TyperState => Tree)(using Context): Tree =
       fallBack(ctx.typerState)
 
-  override def completeAnnotations(mdef: untpd.MemberDef, sym: Symbol)(implicit ctx: Context): Unit = ()
+  override def completeAnnotations(mdef: untpd.MemberDef, sym: Symbol)(using Context): Unit = ()
 
-  override def ensureConstrCall(cls: ClassSymbol, parents: List[Tree])(implicit ctx: Context): List[Tree] =
+  override def ensureConstrCall(cls: ClassSymbol, parents: List[Tree])(using Context): List[Tree] =
     parents
 
-  override def handleUnexpectedFunType(tree: untpd.Apply, fun: Tree)(implicit ctx: Context): Tree = fun.tpe match {
+  override def handleUnexpectedFunType(tree: untpd.Apply, fun: Tree)(using Context): Tree = fun.tpe match {
     case mt: MethodType =>
       val args: List[Tree] = tree.args.zipWithConserve(mt.paramInfos)(typedExpr(_, _)).asInstanceOf[List[Tree]]
       assignType(untpd.cpy.Apply(tree)(fun, args), fun, args)
@@ -120,7 +120,7 @@ class ReTyper extends Typer with ReChecking {
       super.handleUnexpectedFunType(tree, fun)
   }
 
-  override def typedUnadapted(tree: untpd.Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): Tree =
+  override def typedUnadapted(tree: untpd.Tree, pt: Type, locked: TypeVars)(using Context): Tree =
     try super.typedUnadapted(tree, pt, locked)
     catch {
       case NonFatal(ex) =>
@@ -129,12 +129,12 @@ class ReTyper extends Typer with ReChecking {
         throw ex
     }
 
-  override def inlineExpansion(mdef: DefDef)(implicit ctx: Context): List[Tree] = mdef :: Nil
+  override def inlineExpansion(mdef: DefDef)(using Context): List[Tree] = mdef :: Nil
 
-  override def inferView(from: Tree, to: Type)(implicit ctx: Context): Implicits.SearchResult =
+  override def inferView(from: Tree, to: Type)(using Context): Implicits.SearchResult =
     Implicits.NoMatchingImplicitsFailure
-  override def checkCanEqual(ltp: Type, rtp: Type, span: Span)(implicit ctx: Context): Unit = ()
-  override protected def addAccessorDefs(cls: Symbol, body: List[Tree])(implicit ctx: Context): List[Tree] = body
-  override protected def checkEqualityEvidence(tree: tpd.Tree, pt: Type)(implicit ctx: Context): Unit = ()
-  override protected def matchingApply(methType: MethodOrPoly, pt: FunProto)(implicit ctx: Context): Boolean = true
+  override def checkCanEqual(ltp: Type, rtp: Type, span: Span)(using Context): Unit = ()
+  override protected def addAccessorDefs(cls: Symbol, body: List[Tree])(using Context): List[Tree] = body
+  override protected def checkEqualityEvidence(tree: tpd.Tree, pt: Type)(using Context): Unit = ()
+  override protected def matchingApply(methType: MethodOrPoly, pt: FunProto)(using Context): Boolean = true
 }

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -874,7 +874,7 @@ object RefChecks {
    *  surprising names at runtime. E.g. in neg/i4564a.scala, a private
    *  case class `apply` method would have to be renamed to something else.
    */
-  def checkNoPrivateOverrides(tree: Tree)(using ctx: Context): Unit =
+  def checkNoPrivateOverrides(tree: Tree)(using Context): Unit =
     val sym = tree.symbol
     if sym.owner.isClass
        && sym.is(Private)

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -26,11 +26,11 @@ object RefChecks {
   val name: String = "refchecks"
 
   private val defaultMethodFilter = new NameFilter {
-    def apply(pre: Type, name: Name)(implicit ctx: Context): Boolean = name.is(DefaultGetterName)
+    def apply(pre: Type, name: Name)(using Context): Boolean = name.is(DefaultGetterName)
   }
 
   /** Only one overloaded alternative is allowed to define default arguments */
-  private def checkOverloadedRestrictions(clazz: Symbol)(implicit ctx: Context): Unit = {
+  private def checkOverloadedRestrictions(clazz: Symbol)(using Context): Unit = {
     // Using the default getters (such as methodName$default$1) as a cheap way of
     // finding methods with default parameters. This way, we can limit the members to
     // those with the DEFAULTPARAM flag, and infer the methods. Looking for the methods
@@ -81,7 +81,7 @@ object RefChecks {
    *  This one used to succeed only if forwarding parameters is on.
    *  (Forwarding tends to hide problems by binding parameter names).
    */
-  private def upwardsThisType(cls: Symbol)(implicit ctx: Context) = cls.info match {
+  private def upwardsThisType(cls: Symbol)(using Context) = cls.info match {
     case ClassInfo(_, _, _, _, tp: Type) if (tp ne cls.typeRef) && !cls.isOneOf(FinalOrModuleClass) =>
       SkolemType(cls.appliedRef).withName(nme.this_)
     case _ =>
@@ -91,7 +91,7 @@ object RefChecks {
   /** Check that self type of this class conforms to self types of parents.
    *  and required classes.
    */
-  private def checkParents(cls: Symbol)(implicit ctx: Context): Unit = cls.info match {
+  private def checkParents(cls: Symbol)(using Context): Unit = cls.info match {
     case cinfo: ClassInfo =>
       def checkSelfConforms(other: ClassSymbol, category: String, relation: String) = {
         val otherSelf = other.givenSelfType.asSeenFrom(cls.thisType, other.classSymbol)
@@ -111,7 +111,7 @@ object RefChecks {
    *  The rationale is to ensure outer-related NPE never happen in Scala.
    *  Otherwise, outer NPE may happen, see tests/neg/i5083.scala
    */
-  private def checkParentPrefix(cls: Symbol, parent: Tree)(implicit ctx: Context): Unit =
+  private def checkParentPrefix(cls: Symbol, parent: Tree)(using Context): Unit =
     parent.tpe.typeConstructor match {
       case TypeRef(ref: TermRef, _) =>
         val paramRefs = ref.namedPartsWith(ntp => ntp.symbol.enclosingClass == cls)
@@ -123,7 +123,7 @@ object RefChecks {
   /** Check that a class and its companion object to not both define
    *  a class or module with same name
    */
-  private def checkCompanionNameClashes(cls: Symbol)(implicit ctx: Context): Unit =
+  private def checkCompanionNameClashes(cls: Symbol)(using Context): Unit =
     if (!cls.owner.is(ModuleClass)) {
       def clashes(sym: Symbol) =
         sym.isClass &&
@@ -168,7 +168,7 @@ object RefChecks {
    *  TODO This still needs to be cleaned up; the current version is a straight port of what was there
    *       before, but it looks too complicated and method bodies are far too large.
    */
-  private def checkAllOverrides(clazz: ClassSymbol)(implicit ctx: Context): Unit = {
+  private def checkAllOverrides(clazz: ClassSymbol)(using Context): Unit = {
     val self = clazz.thisType
     val upwardsSelf = upwardsThisType(clazz)
     var hasErrors = false
@@ -828,7 +828,7 @@ object RefChecks {
   // I assume that's a consequence of some code trying to avoid noise by suppressing
   // warnings after the first, but I think it'd be better if we didn't have to
   // arbitrarily choose one as more important than the other.
-  private def checkUndesiredProperties(sym: Symbol, pos: SourcePosition)(implicit ctx: Context): Unit = {
+  private def checkUndesiredProperties(sym: Symbol, pos: SourcePosition)(using Context): Unit = {
     // If symbol is deprecated, and the point of reference is not enclosed
     // in either a deprecated member or a scala bridge method, issue a warning.
     if (sym.isDeprecated && !ctx.owner.ownersIterator.exists(_.isDeprecated))
@@ -851,7 +851,7 @@ object RefChecks {
    *  concrete, non-deprecated method.  If it does, then
    *  deprecation is meaningless.
    */
-  private def checkDeprecatedOvers(tree: Tree)(implicit ctx: Context): Unit = {
+  private def checkDeprecatedOvers(tree: Tree)(using Context): Unit = {
     val symbol = tree.symbol
     if (symbol.isDeprecated) {
       val concrOvers =
@@ -896,7 +896,7 @@ object RefChecks {
   }
 
   /** A class to help in forward reference checking */
-  class LevelInfo(outerLevelAndIndex: LevelAndIndex, stats: List[Tree])(implicit ctx: Context)
+  class LevelInfo(outerLevelAndIndex: LevelAndIndex, stats: List[Tree])(using Context)
   extends OptLevelInfo {
     override val levelAndIndex: LevelAndIndex =
       stats.foldLeft(outerLevelAndIndex, 0) {(mi, stat) =>
@@ -968,17 +968,17 @@ class RefChecks extends MiniPhase { thisPhase =>
   override def runsAfter: Set[String] = Set(ElimRepeated.name)
 
   private var LevelInfo: Store.Location[OptLevelInfo] = _
-  private def currentLevel(implicit ctx: Context): OptLevelInfo = ctx.store(LevelInfo)
+  private def currentLevel(using Context): OptLevelInfo = ctx.store(LevelInfo)
 
   override def initContext(ctx: FreshContext): Unit =
     LevelInfo = ctx.addLocation(NoLevelInfo)
 
-  override def prepareForStats(trees: List[Tree])(implicit ctx: Context): Context =
+  override def prepareForStats(trees: List[Tree])(using Context): Context =
     if (ctx.owner.isTerm)
       ctx.fresh.updateStore(LevelInfo, new LevelInfo(currentLevel.levelAndIndex, trees))
     else ctx
 
-  override def transformValDef(tree: ValDef)(implicit ctx: Context): ValDef = {
+  override def transformValDef(tree: ValDef)(using Context): ValDef = {
     checkNoPrivateOverrides(tree)
     checkDeprecatedOvers(tree)
     val sym = tree.symbol
@@ -998,13 +998,13 @@ class RefChecks extends MiniPhase { thisPhase =>
     tree
   }
 
-  override def transformDefDef(tree: DefDef)(implicit ctx: Context): DefDef = {
+  override def transformDefDef(tree: DefDef)(using Context): DefDef = {
     checkNoPrivateOverrides(tree)
     checkDeprecatedOvers(tree)
     tree
   }
 
-  override def transformTemplate(tree: Template)(implicit ctx: Context): Tree = try {
+  override def transformTemplate(tree: Template)(using Context): Tree = try {
     val cls = ctx.owner.asClass
     checkOverloadedRestrictions(cls)
     checkParents(cls)
@@ -1019,18 +1019,18 @@ class RefChecks extends MiniPhase { thisPhase =>
       tree
   }
 
-  override def transformIdent(tree: Ident)(implicit ctx: Context): Ident = {
+  override def transformIdent(tree: Ident)(using Context): Ident = {
     checkUndesiredProperties(tree.symbol, tree.sourcePos)
     currentLevel.enterReference(tree.symbol, tree.span)
     tree
   }
 
-  override def transformSelect(tree: Select)(implicit ctx: Context): Select = {
+  override def transformSelect(tree: Select)(using Context): Select = {
     checkUndesiredProperties(tree.symbol, tree.sourcePos)
     tree
   }
 
-  override def transformApply(tree: Apply)(implicit ctx: Context): Apply = {
+  override def transformApply(tree: Apply)(using Context): Apply = {
     if (isSelfConstrCall(tree)) {
       assert(currentLevel.isInstanceOf[LevelInfo], s"${ctx.owner}/" + i"$tree")
       val level = currentLevel.asInstanceOf[LevelInfo]
@@ -1044,7 +1044,7 @@ class RefChecks extends MiniPhase { thisPhase =>
     tree
   }
 
-  override def transformNew(tree: New)(implicit ctx: Context): New = {
+  override def transformNew(tree: New)(using Context): New = {
     val tpe = tree.tpe
     val sym = tpe.typeSymbol
     checkUndesiredProperties(sym, tree.sourcePos)

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -1,0 +1,424 @@
+package dotty.tools
+package dotc
+package typer
+
+import core._
+import util.Spans.Span
+import Contexts._
+import Types._, Flags._, Symbols._, Types._, Names._, StdNames._, Constants._
+import TypeErasure.{erasure, hasStableErasure}
+import Decorators._
+import ProtoTypes._
+import Inferencing.{fullyDefinedType, isFullyDefined}
+import ast.untpd
+import transform.SymUtils._
+import transform.TypeUtils._
+import transform.SyntheticMembers._
+import util.Property
+import annotation.tailrec
+
+/** Synthesize terms for special classes */
+class Synthesizer(typer: Typer):
+  import ast.tpd._
+
+  /** Handlers to synthesize implicits for special types */
+  type SpecialHandler = (Type, Span) => Context ?=> Tree
+  type SpecialHandlers = List[(ClassSymbol, SpecialHandler)]
+
+  lazy val synthesizedClassTag: SpecialHandler = (formal, span) =>
+    formal.argInfos match
+      case arg :: Nil =>
+        fullyDefinedType(arg, "ClassTag argument", span) match
+          case defn.ArrayOf(elemTp) =>
+            val etag = typer.inferImplicitArg(defn.ClassTagClass.typeRef.appliedTo(elemTp), span)
+            if etag.tpe.isError then EmptyTree else etag.select(nme.wrap)
+          case tp if hasStableErasure(tp) && !defn.isBottomClass(tp.typeSymbol) =>
+            val sym = tp.typeSymbol
+            val classTag = ref(defn.ClassTagModule)
+            val tag =
+              if sym == defn.UnitClass
+                 || sym == defn.AnyClass
+                 || sym == defn.AnyValClass
+              then
+                classTag.select(sym.name.toTermName)
+              else
+                classTag.select(nme.apply).appliedToType(tp).appliedTo(clsOf(erasure(tp)))
+            tag.withSpan(span)
+          case tp => EmptyTree
+      case _ => EmptyTree
+  end synthesizedClassTag
+
+  /** Synthesize the tree for `'[T]` for an implicit `scala.quoted.Type[T]`.
+   *  `T` is deeply dealiased to avoid references to local type aliases.
+   */
+  lazy val synthesizedTypeTag: SpecialHandler = (formal, span) =>
+    def quotedType(t: Type) =
+      if StagingContext.level == 0 then
+        ctx.compilationUnit.needsStaging = true // We will need to run ReifyQuotes
+      ref(defn.InternalQuoted_typeQuote).appliedToType(t)
+    formal.argInfos match
+      case arg :: Nil =>
+        val deepDealias = new TypeMap:
+          def apply(tp: Type): Type = mapOver(tp.dealias)
+        quotedType(deepDealias(arg))
+      case _ =>
+        EmptyTree
+  end synthesizedTypeTag
+
+  lazy val synthesizedTupleFunction: SpecialHandler = (formal, span) =>
+    formal match
+      case AppliedType(_, funArgs @ fun :: tupled :: Nil) =>
+        def functionTypeEqual(baseFun: Type, actualArgs: List[Type],
+            actualRet: Type, expected: Type) =
+          expected =:= defn.FunctionOf(actualArgs, actualRet,
+            defn.isContextFunctionType(baseFun), defn.isErasedFunctionType(baseFun))
+        val arity: Int =
+          if defn.isErasedFunctionType(fun) || defn.isErasedFunctionType(fun) then -1 // TODO support?
+          else if defn.isFunctionType(fun) then
+            // TupledFunction[(...) => R, ?]
+            fun.dropDependentRefinement.dealias.argInfos match
+              case funArgs :+ funRet
+              if functionTypeEqual(fun, defn.tupleType(funArgs) :: Nil, funRet, tupled) =>
+                // TupledFunction[(...funArgs...) => funRet, ?]
+                funArgs.size
+              case _ => -1
+          else if defn.isFunctionType(tupled) then
+            // TupledFunction[?, (...) => R]
+            tupled.dropDependentRefinement.dealias.argInfos match
+              case tupledArgs :: funRet :: Nil =>
+                defn.tupleTypes(tupledArgs.dealias) match
+                  case Some(funArgs) if functionTypeEqual(tupled, funArgs, funRet, fun) =>
+                    // TupledFunction[?, ((...funArgs...)) => funRet]
+                    funArgs.size
+                  case _ => -1
+              case _ => -1
+          else
+            // TupledFunction[?, ?]
+            -1
+        if arity == -1 then
+          EmptyTree
+        else if arity <= Definitions.MaxImplementedFunctionArity then
+          ref(defn.InternalTupleFunctionModule)
+            .select(s"tupledFunction$arity".toTermName)
+            .appliedToTypes(funArgs)
+        else
+          ref(defn.InternalTupleFunctionModule)
+            .select("tupledFunctionXXL".toTermName)
+            .appliedToTypes(funArgs)
+      case _ =>
+        EmptyTree
+  end synthesizedTupleFunction
+
+  /** If `formal` is of the form Eql[T, U], try to synthesize an
+    *  `Eql.eqlAny[T, U]` as solution.
+    */
+  lazy val synthesizedEql: SpecialHandler = (formal, span) =>
+
+    /** Is there an `Eql[T, T]` instance, assuming -strictEquality? */
+    def hasEq(tp: Type)(using Context): Boolean =
+      val inst = typer.inferImplicitArg(defn.EqlClass.typeRef.appliedTo(tp, tp), span)
+      !inst.isEmpty && !inst.tpe.isError
+
+    /** Can we assume the eqlAny instance for `tp1`, `tp2`?
+      *  This is the case if assumedCanEqual(tp1, tp2), or
+      *  one of `tp1`, `tp2` has a reflexive `Eql` instance.
+      */
+    def validEqAnyArgs(tp1: Type, tp2: Type)(using Context) =
+      typer.assumedCanEqual(tp1, tp2)
+       || inContext(ctx.addMode(Mode.StrictEquality)) {
+            !hasEq(tp1) && !hasEq(tp2)
+          }
+
+    /** Is an `Eql[cls1, cls2]` instance assumed for predefined classes `cls1`, cls2`? */
+    def canComparePredefinedClasses(cls1: ClassSymbol, cls2: ClassSymbol): Boolean =
+
+      def cmpWithBoxed(cls1: ClassSymbol, cls2: ClassSymbol) =
+        cls2 == defn.boxedType(cls1.typeRef).symbol
+        || cls1.isNumericValueClass && cls2.derivesFrom(defn.BoxedNumberClass)
+
+      if cls1.isPrimitiveValueClass then
+        if cls2.isPrimitiveValueClass then
+          cls1 == cls2 || cls1.isNumericValueClass && cls2.isNumericValueClass
+        else
+          cmpWithBoxed(cls1, cls2)
+      else if cls2.isPrimitiveValueClass then
+        cmpWithBoxed(cls2, cls1)
+      else if ctx.explicitNulls then
+        // If explicit nulls is enabled, we want to disallow comparison between Object and Null.
+        // If a nullable value has a non-nullable type, we can still cast it to nullable type
+        // then compare.
+        //
+        // Example:
+        // val x: String = null.asInstanceOf[String]
+        // if (x == null) {} // error: x is non-nullable
+        // if (x.asInstanceOf[String|Null] == null) {} // ok
+        cls1 == defn.NullClass && cls1 == cls2
+      else if cls1 == defn.NullClass then
+        cls1 == cls2 || cls2.derivesFrom(defn.ObjectClass)
+      else if cls2 == defn.NullClass then
+        cls1.derivesFrom(defn.ObjectClass)
+      else
+        false
+    end canComparePredefinedClasses
+
+    /** Some simulated `Eql` instances for predefined types. It's more efficient
+      *  to do this directly instead of setting up a lot of `Eql` instances to
+      *  interpret.
+      */
+    def canComparePredefined(tp1: Type, tp2: Type) =
+      tp1.classSymbols.exists(cls1 =>
+        tp2.classSymbols.exists(cls2 =>
+          canComparePredefinedClasses(cls1, cls2)))
+
+    formal.argTypes match
+      case args @ (arg1 :: arg2 :: Nil) =>
+        List(arg1, arg2).foreach(fullyDefinedType(_, "eq argument", span))
+        if canComparePredefined(arg1, arg2)
+            || !Implicits.strictEquality && ctx.test(validEqAnyArgs(arg1, arg2))
+        then ref(defn.Eql_eqlAny).appliedToTypes(args).withSpan(span)
+        else EmptyTree
+      case _ => EmptyTree
+  end synthesizedEql
+
+  /** Creates a tree that will produce a ValueOf instance for the requested type.
+   * An EmptyTree is returned if materialization fails.
+   */
+  lazy val synthesizedValueOf: SpecialHandler = (formal, span) =>
+
+    def success(t: Tree) =
+      New(defn.ValueOfClass.typeRef.appliedTo(t.tpe), t :: Nil).withSpan(span)
+
+    formal.argInfos match
+      case arg :: Nil =>
+        fullyDefinedType(arg.dealias, "ValueOf argument", span).normalized match
+          case ConstantType(c: Constant) =>
+            success(Literal(c))
+          case TypeRef(_, sym) if sym == defn.UnitClass =>
+            success(Literal(Constant(())))
+          case n: TermRef =>
+            success(ref(n))
+          case tp =>
+            EmptyTree
+      case _ =>
+        EmptyTree
+  end synthesizedValueOf
+
+  /** Create an anonymous class `new Object { type MirroredMonoType = ... }`
+   *  and mark it with given attachment so that it is made into a mirror at PostTyper.
+   */
+  private def anonymousMirror(monoType: Type, attachment: Property.StickyKey[Unit], span: Span)(using Context) =
+    val monoTypeDef = untpd.TypeDef(tpnme.MirroredMonoType, untpd.TypeTree(monoType))
+    val newImpl = untpd.Template(
+      constr = untpd.emptyConstructor,
+      parents = untpd.TypeTree(defn.ObjectType) :: Nil,
+      derived = Nil,
+      self = EmptyValDef,
+      body = monoTypeDef :: Nil
+    ).withAttachment(attachment, ())
+    typer.typed(untpd.New(newImpl).withSpan(span))
+
+  /** The mirror type
+   *
+   *     <parent> {
+   *       MirroredMonoType = <monoType>
+   *       MirroredType = <mirroredType>
+   *       MirroredLabel = <label> }
+   *     }
+   */
+  private def mirrorCore(parentClass: ClassSymbol, monoType: Type, mirroredType: Type, label: Name, formal: Type)(using Context) =
+    formal & parentClass.typeRef
+      .refinedWith(tpnme.MirroredMonoType, TypeAlias(monoType))
+      .refinedWith(tpnme.MirroredType, TypeAlias(mirroredType))
+      .refinedWith(tpnme.MirroredLabel, TypeAlias(ConstantType(Constant(label.toString))))
+
+  /** A path referencing the companion of class type `clsType` */
+  private def companionPath(clsType: Type, span: Span)(using Context) =
+    val ref = pathFor(clsType.companionRef)
+    assert(ref.symbol.is(Module) && (clsType.classSymbol.is(ModuleClass) || (ref.symbol.companionClass == clsType.classSymbol)))
+    ref.withSpan(span)
+
+  private def checkFormal(formal: Type)(using Context): Boolean =
+    @tailrec
+    def loop(tp: Type): Boolean = tp match
+      case RefinedType(parent, _, _: TypeBounds) => loop(parent)
+      case RefinedType(_, _, _) => false
+      case _ => true
+    loop(formal)
+
+  private def mkMirroredMonoType(mirroredType: HKTypeLambda)(using Context): Type =
+    val monoMap = new TypeMap:
+      def apply(t: Type) = t match
+        case TypeParamRef(lambda, n) if lambda eq mirroredType => mirroredType.paramInfos(n)
+        case t => mapOver(t)
+    monoMap(mirroredType.resultType)
+
+  private def productMirror(mirroredType: Type, formal: Type, span: Span)(using Context): Tree =
+    mirroredType match
+      case AndType(tp1, tp2) =>
+        productMirror(tp1, formal, span).orElse(productMirror(tp2, formal, span))
+      case _ =>
+        if mirroredType.termSymbol.is(CaseVal) then
+          val module = mirroredType.termSymbol
+          val modulePath = pathFor(mirroredType).withSpan(span)
+          if module.info.classSymbol.is(Scala2x) then
+            val mirrorType = mirrorCore(defn.Mirror_SingletonProxyClass, mirroredType, mirroredType, module.name, formal)
+            val mirrorRef = New(defn.Mirror_SingletonProxyClass.typeRef, modulePath :: Nil)
+            mirrorRef.cast(mirrorType)
+          else
+            val mirrorType = mirrorCore(defn.Mirror_SingletonClass, mirroredType, mirroredType, module.name, formal)
+            modulePath.cast(mirrorType)
+        else if mirroredType.classSymbol.isGenericProduct then
+          val cls = mirroredType.classSymbol
+          val accessors = cls.caseAccessors.filterNot(_.isAllOf(PrivateLocal))
+          val elemLabels = accessors.map(acc => ConstantType(Constant(acc.name.toString)))
+          val (monoType, elemsType) = mirroredType match
+            case mirroredType: HKTypeLambda =>
+              val elems =
+                mirroredType.derivedLambdaType(
+                  resType = TypeOps.nestedPairs(accessors.map(mirroredType.memberInfo(_).widenExpr))
+                )
+              (mkMirroredMonoType(mirroredType), elems)
+            case _ =>
+              val elems = TypeOps.nestedPairs(accessors.map(mirroredType.memberInfo(_).widenExpr))
+              (mirroredType, elems)
+          val mirrorType =
+            mirrorCore(defn.Mirror_ProductClass, monoType, mirroredType, cls.name, formal)
+              .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
+              .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
+          val mirrorRef =
+            if (cls.is(Scala2x)) anonymousMirror(monoType, ExtendsProductMirror, span)
+            else companionPath(mirroredType, span)
+          mirrorRef.cast(mirrorType)
+        else EmptyTree
+  end productMirror
+
+  private def sumMirror(mirroredType: Type, formal: Type, span: Span)(using Context): Tree =
+    if mirroredType.classSymbol.isGenericSum then
+      val cls = mirroredType.classSymbol
+      val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))
+
+      def solve(sym: Symbol): Type = sym match
+        case caseClass: ClassSymbol =>
+          assert(caseClass.is(Case))
+          if caseClass.is(Module) then
+            caseClass.sourceModule.termRef
+          else
+            caseClass.primaryConstructor.info match
+              case info: PolyType =>
+                // Compute the the full child type by solving the subtype constraint
+                // `C[X1, ..., Xn] <: P`, where
+                //
+                //   - P is the current `mirroredType`
+                //   - C is the child class, with type parameters X1, ..., Xn
+                //
+                // Contravariant type parameters are minimized, all other type parameters are maximized.
+                def instantiate(using Context) =
+                  val poly = constrained(info, untpd.EmptyTree)._1
+                  val resType = poly.finalResultType
+                  val target = mirroredType match
+                    case tp: HKTypeLambda => tp.resultType
+                    case tp => tp
+                  resType <:< target
+                  val tparams = poly.paramRefs
+                  val variances = caseClass.typeParams.map(_.paramVarianceSign)
+                  val instanceTypes = tparams.lazyZip(variances).map((tparam, variance) =>
+                    ctx.typeComparer.instanceType(tparam, fromBelow = variance < 0))
+                  resType.substParams(poly, instanceTypes)
+                instantiate(using ctx.fresh.setExploreTyperState().setOwner(caseClass))
+              case _ =>
+                caseClass.typeRef
+        case child => child.termRef
+      end solve
+
+      val (monoType, elemsType) = mirroredType match
+        case mirroredType: HKTypeLambda =>
+          val elems = mirroredType.derivedLambdaType(
+            resType = TypeOps.nestedPairs(cls.children.map(solve))
+          )
+          (mkMirroredMonoType(mirroredType), elems)
+        case _ =>
+          val elems = TypeOps.nestedPairs(cls.children.map(solve))
+          (mirroredType, elems)
+
+      val mirrorType =
+          mirrorCore(defn.Mirror_SumClass, monoType, mirroredType, cls.name, formal)
+          .refinedWith(tpnme.MirroredElemTypes, TypeAlias(elemsType))
+          .refinedWith(tpnme.MirroredElemLabels, TypeAlias(TypeOps.nestedPairs(elemLabels)))
+      val mirrorRef =
+        if cls.linkedClass.exists && !cls.is(Scala2x)
+        then companionPath(mirroredType, span)
+        else anonymousMirror(monoType, ExtendsSumMirror, span)
+      mirrorRef.cast(mirrorType)
+    else EmptyTree
+  end sumMirror
+
+  def makeMirror
+      (synth: (Type, Type, Span) => Context ?=> Tree, formal: Type, span: Span)
+      (using Context): Tree =
+    if checkFormal(formal) then
+      formal.member(tpnme.MirroredType).info match
+        case TypeBounds(mirroredType, _) => synth(mirroredType.stripTypeVar, formal, span)
+        case other => EmptyTree
+    else EmptyTree
+
+  /** An implied instance for a type of the form `Mirror.Product { type MirroredType = T }`
+   *  where `T` is a generic product type or a case object or an enum case.
+   */
+  lazy val synthesizedProductMirror: SpecialHandler = (formal, span) =>
+    makeMirror(productMirror, formal, span)
+
+  /** An implied instance for a type of the form `Mirror.Sum { type MirroredType = T }`
+   *  where `T` is a generic sum type.
+   */
+  lazy val synthesizedSumMirror: SpecialHandler = (formal, span) =>
+    makeMirror(sumMirror, formal, span)
+
+  /** An implied instance for a type of the form `Mirror { type MirroredType = T }`
+   *  where `T` is a generic sum or product or singleton type.
+   */
+  lazy val synthesizedMirror: SpecialHandler = (formal, span) =>
+    formal.member(tpnme.MirroredType).info match
+      case TypeBounds(mirroredType, _) =>
+        if mirroredType.termSymbol.is(CaseVal)
+           || mirroredType.classSymbol.isGenericProduct
+        then
+          synthesizedProductMirror(formal, span)(using ctx)
+        else
+          synthesizedSumMirror(formal, span)(using ctx)
+      case _ => EmptyTree
+
+  private var mySpecialHandlers: SpecialHandlers = null
+
+  private def specialHandlers(using Context) =
+    if mySpecialHandlers == null then
+      mySpecialHandlers = List(
+        defn.ClassTagClass        -> synthesizedClassTag,
+        defn.QuotedTypeClass      -> synthesizedTypeTag,
+        defn.EqlClass             -> synthesizedEql,
+        defn.TupledFunctionClass  -> synthesizedTupleFunction,
+        defn.ValueOfClass         -> synthesizedValueOf,
+        defn.Mirror_ProductClass  -> synthesizedProductMirror,
+        defn.Mirror_SumClass      -> synthesizedSumMirror,
+        defn.MirrorClass          -> synthesizedMirror)
+    mySpecialHandlers
+
+  def tryAll(formal: Type, span: Span)(using Context): Tree =
+    def recur(handlers: SpecialHandlers): Tree = handlers match
+      case (cls, handler) :: rest =>
+        def baseWithRefinements(tp: Type): Type = tp.dealias match
+          case tp @ RefinedType(parent, rname, rinfo) =>
+            tp.derivedRefinedType(baseWithRefinements(parent), rname, rinfo)
+          case _ =>
+            tp.baseType(cls)
+        val base = baseWithRefinements(formal)
+        val result =
+          if (base <:< formal.widenExpr)
+            // With the subtype test we enforce that the searched type `formal` is of the right form
+            handler(base, span)
+          else EmptyTree
+        result.orElse(recur(rest))
+      case Nil =>
+        EmptyTree
+    recur(specialHandlers)
+
+end Synthesizer

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -213,19 +213,19 @@ trait TypeAssigner {
           else {
             val alts = tpe.denot.alternatives.map(_.symbol).filter(_.exists)
             var packageAccess = false
-            val what = alts match {
+            val whatCanNot = alts match {
               case Nil =>
-                name.toString
+                em"$name cannot"
               case sym :: Nil =>
-                if (sym.owner == pre.typeSymbol) sym.show else sym.showLocated
+                em"${if (sym.owner == pre.typeSymbol) sym.show else sym.showLocated} cannot"
               case _ =>
-                em"none of the overloaded alternatives named $name"
+                em"none of the overloaded alternatives named $name can"
             }
             val where = if (ctx.owner.exists) s" from ${ctx.owner.enclosingClass}" else ""
             val whyNot = new StringBuffer
             alts foreach (_.isAccessibleFrom(pre, superAccess, whyNot))
             if (tpe.isError) tpe
-            else errorType(ex"$what cannot be accessed as a member of $pre$where.$whyNot", pos)
+            else errorType(ex"$whatCanNot be accessed as a member of $pre$where.$whyNot", pos)
           }
         }
         else ctx.makePackageObjPrefixExplicit(tpe withDenot d)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -770,7 +770,7 @@ class Typer extends Namer
     case tref: TypeRef if !tref.symbol.isClass && !ctx.isAfterTyper && !(tref =:= pt) =>
       require(ctx.mode.is(Mode.Pattern))
       inferImplicit(defn.ClassTagClass.typeRef.appliedTo(tref),
-                    EmptyTree, tree.tpt.span)(ctx.retractMode(Mode.Pattern)) match {
+                    EmptyTree, tree.tpt.span)(using ctx.retractMode(Mode.Pattern)) match {
         case SearchSuccess(clsTag, _, _) =>
           typed(untpd.Apply(untpd.TypedSplice(clsTag), untpd.TypedSplice(tree.expr)), pt)
         case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1068,13 +1068,14 @@ class Typer extends Namer
             case untpd.TypedSplice(expr1) =>
               expr1.tpe
             case _ =>
+              val curCtx = ctx
               given nestedCtx as Context = ctx.fresh.setNewTyperState()
               val protoArgs = args map (_ withType WildcardType)
               val callProto = FunProto(protoArgs, WildcardType)(this, app.isUsingApply)
               val expr1 = typedExpr(expr, callProto)
               if nestedCtx.reporter.hasErrors then NoType
               else
-                given Context = ctx
+                given Context = curCtx
                 nestedCtx.typerState.commit()
                 fnBody = cpy.Apply(fnBody)(untpd.TypedSplice(expr1), args)
                 expr1.tpe

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -351,7 +351,7 @@ class Typer extends Namer
                 if (defDenot.symbol.is(Package))
                   result = checkNewOrShadowed(previous orElse found, PackageClause)
                 else if (prevPrec.ordinal < PackageClause.ordinal)
-                  result = findRefRecur(found, PackageClause, ctx)(ctx.outer)
+                  result = findRefRecur(found, PackageClause, ctx)(using ctx.outer)
             }
 
           if result.exists then result

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2438,7 +2438,7 @@ class Typer extends Namer
             // in preceding statements (unless the DefTree is completed ahead of time,
             // then it is impossible).
             sym.info = Completer(completer.original)(
-              using completer.creationContext.withNotNullInfos(ctx.notNullInfos))
+              completer.creationContext.withNotNullInfos(ctx.notNullInfos))
           true
         case _ =>
           // If it has been completed, then it must be because there is a forward reference

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -55,7 +55,7 @@ object Typer {
   }
 
   /** Assert tree has a position, unless it is empty or a typed splice */
-  def assertPositioned(tree: untpd.Tree)(implicit ctx: Context): Unit =
+  def assertPositioned(tree: untpd.Tree)(using Context): Unit =
     if (!tree.isEmpty && !tree.isInstanceOf[untpd.TypedSplice] && ctx.typerState.isGlobalCommittable)
       assert(tree.span.exists, i"position not set for $tree # ${tree.uniqueId} of ${tree.getClass} in ${tree.source}")
 
@@ -121,7 +121,7 @@ class Typer extends Namer
    *   @param required   flags the result's symbol must have
    *   @param posd       indicates position to use for error reporting
    */
-  def findRef(name: Name, pt: Type, required: FlagSet, posd: Positioned)(implicit ctx: Context): Type = {
+  def findRef(name: Name, pt: Type, required: FlagSet, posd: Positioned)(using Context): Type = {
     val refctx = ctx
     val noImports = ctx.mode.is(Mode.InPackageClauseName)
 
@@ -147,7 +147,7 @@ class Typer extends Namer
      *  @param prevCtx     The context of the previous denotation,
      *                     or else `NoContext` if nothing was found yet.
      */
-    def findRefRecur(previous: Type, prevPrec: BindingPrec, prevCtx: Context)(implicit ctx: Context): Type = {
+    def findRefRecur(previous: Type, prevPrec: BindingPrec, prevCtx: Context)(using Context): Type = {
       import BindingPrec._
 
       /** Check that any previously found result from an inner context
@@ -204,7 +204,7 @@ class Typer extends Namer
       /** The type representing a named import with enclosing name when imported
        *  from given `site` and `selectors`.
        */
-      def namedImportRef(imp: ImportInfo)(implicit ctx: Context): Type = {
+      def namedImportRef(imp: ImportInfo)(using Context): Type = {
         val termName = name.toTermName
 
         def recur(selectors: List[untpd.ImportSelector]): Type = selectors match
@@ -233,7 +233,7 @@ class Typer extends Namer
       /** The type representing a wildcard import with enclosing name when imported
        *  from given import info
        */
-      def wildImportRef(imp: ImportInfo)(implicit ctx: Context): Type =
+      def wildImportRef(imp: ImportInfo)(using Context): Type =
         if (imp.isWildcardImport && !imp.excluded.contains(name.toTermName) && name != nme.CONSTRUCTOR)
           selection(imp, name, checkBounds = true)
         else NoType
@@ -241,23 +241,23 @@ class Typer extends Namer
       /** Is (some alternative of) the given predenotation `denot`
        *  defined in current compilation unit?
        */
-      def isDefinedInCurrentUnit(denot: Denotation)(implicit ctx: Context): Boolean = denot match {
+      def isDefinedInCurrentUnit(denot: Denotation)(using Context): Boolean = denot match {
         case MultiDenotation(d1, d2) => isDefinedInCurrentUnit(d1) || isDefinedInCurrentUnit(d2)
         case denot: SingleDenotation => denot.symbol.source == ctx.compilationUnit.source
       }
 
       /** Is `denot` the denotation of a self symbol? */
-      def isSelfDenot(denot: Denotation)(implicit ctx: Context) = denot match {
+      def isSelfDenot(denot: Denotation)(using Context) = denot match {
         case denot: SymDenotation => denot.is(SelfName)
         case _ => false
       }
 
       /** Would import of kind `prec` be not shadowed by a nested higher-precedence definition? */
-      def isPossibleImport(prec: BindingPrec)(implicit ctx: Context) =
+      def isPossibleImport(prec: BindingPrec)(using Context) =
         !noImports &&
         (prevPrec.ordinal < prec.ordinal || prevPrec == prec && (prevCtx.scope eq ctx.scope))
 
-      @tailrec def loop(lastCtx: Context)(implicit ctx: Context): Type =
+      @tailrec def loop(lastCtx: Context)(using Context): Type =
         if (ctx.scope == null) previous
         else {
           var result: Type = NoType
@@ -372,20 +372,20 @@ class Typer extends Namer
                   recurAndCheckNewOrShadowed(wildImp, WildImport, ctx)(using outer)
                 else {
                   updateUnimported()
-                  loop(ctx)(outer)
+                  loop(ctx)(using outer)
                 }
               }
               else {
                 updateUnimported()
-                loop(ctx)(outer)
+                loop(ctx)(using outer)
               }
             }
-            else loop(ctx)(outer)
+            else loop(ctx)(using outer)
           }
         }
 
       // begin findRefRecur
-      loop(NoContext)(ctx)
+      loop(NoContext)
     }
 
     findRefRecur(NoType, BindingPrec.NothingBound, NoContext)
@@ -398,7 +398,7 @@ class Typer extends Namer
    *  If x is a trackable reference and we know x is not null at this point,
    *  (x: T | Null) => x.$asInstanceOf$[x.type & T]
    */
-  def toNotNullTermRef(tree: Tree, pt: Type)(implicit ctx: Context): Tree = tree.tpe match
+  def toNotNullTermRef(tree: Tree, pt: Type)(using Context): Tree = tree.tpe match
     case ref @ OrNull(tpnn) : TermRef
     if pt != AssignProto && // Ensure it is not the lhs of Assign
     ctx.notNullInfos.impliesNotNull(ref) &&
@@ -416,7 +416,7 @@ class Typer extends Namer
    *                   (2) Change imported symbols to selections.
    *                   (3) Change pattern Idents id (but not wildcards) to id @ _
    */
-  def typedIdent(tree: untpd.Ident, pt: Type)(implicit ctx: Context): Tree = {
+  def typedIdent(tree: untpd.Ident, pt: Type)(using Context): Tree = {
     record("typedIdent")
     val name = tree.name
     def kind = if (name.isTermName) "" else "type "
@@ -504,7 +504,7 @@ class Typer extends Namer
 
   /** Check that a stable identifier pattern is indeed stable (SLS 8.1.5)
    */
-  private def checkStableIdentPattern(tree: Tree, pt: Type)(implicit ctx: Context): tree.type = {
+  private def checkStableIdentPattern(tree: Tree, pt: Type)(using Context): tree.type = {
     if (ctx.mode.is(Mode.Pattern) &&
         !tree.isType &&
         !pt.isInstanceOf[ApplyingProto] &&
@@ -515,7 +515,7 @@ class Typer extends Namer
     tree
   }
 
-  def typedSelect(tree: untpd.Select, pt: Type, qual: Tree)(implicit ctx: Context): Tree = qual match {
+  def typedSelect(tree: untpd.Select, pt: Type, qual: Tree)(using Context): Tree = qual match {
     case qual @ IntegratedTypeArgs(app) =>
       pt.revealIgnored match {
         case _: PolyProto => qual // keep the IntegratedTypeArgs to strip at next typedTypeApply
@@ -532,17 +532,17 @@ class Typer extends Namer
       else typedDynamicSelect(tree, Nil, pt)
   }
 
-  def typedSelect(tree: untpd.Select, pt: Type)(implicit ctx: Context): Tree = {
+  def typedSelect(tree: untpd.Select, pt: Type)(using Context): Tree = {
     record("typedSelect")
 
-    def typeSelectOnTerm(implicit ctx: Context): Tree =
+    def typeSelectOnTerm(using Context): Tree =
       typedSelect(tree, pt, typedExpr(tree.qualifier, selectionProto(tree.name, pt, this)))
         .computeNullable()
 
-    def typeSelectOnType(qual: untpd.Tree)(implicit ctx: Context) =
+    def typeSelectOnType(qual: untpd.Tree)(using Context) =
       typedSelect(untpd.cpy.Select(tree)(qual, tree.name.toTypeName), pt)
 
-    def tryJavaSelectOnType(implicit ctx: Context): Tree = tree.qualifier match {
+    def tryJavaSelectOnType(using Context): Tree = tree.qualifier match {
       case Select(qual, name) => typeSelectOnType(untpd.Select(qual, name.toTypeName))
       case Ident(name)        => typeSelectOnType(untpd.Ident(name.toTypeName))
       case _                  => errorTree(tree, "cannot convert to type selection") // will never be printed due to fallback
@@ -560,15 +560,15 @@ class Typer extends Namer
       // value A and from the type A. We have to try both.
       selectWithFallback(tryJavaSelectOnType) // !!! possibly exponential bcs of qualifier retyping
     else
-      typeSelectOnTerm(ctx)
+      typeSelectOnTerm
   }
 
-  def typedThis(tree: untpd.This)(implicit ctx: Context): Tree = {
+  def typedThis(tree: untpd.This)(using Context): Tree = {
     record("typedThis")
     assignType(tree)
   }
 
-  def typedSuper(tree: untpd.Super, pt: Type)(implicit ctx: Context): Tree = {
+  def typedSuper(tree: untpd.Super, pt: Type)(using Context): Tree = {
     val qual1 = typed(tree.qual)
     val enclosingInlineable = ctx.owner.ownersIterator.findSymbol(_.isInlineMethod)
     if (enclosingInlineable.exists && !PrepareInlineable.isLocal(qual1.symbol, enclosingInlineable))
@@ -581,7 +581,7 @@ class Typer extends Namer
     }
   }
 
-  def typedNumber(tree: untpd.Number, pt: Type)(implicit ctx: Context): Tree = {
+  def typedNumber(tree: untpd.Number, pt: Type)(using Context): Tree = {
     import scala.util.FromDigits._
     import untpd.NumberKind._
     record("typedNumber")
@@ -651,13 +651,13 @@ class Typer extends Namer
     }
   }
 
-  def typedLiteral(tree: untpd.Literal)(implicit ctx: Context): Tree = {
+  def typedLiteral(tree: untpd.Literal)(using Context): Tree = {
     val tree1 = assignType(tree)
     if (ctx.mode.is(Mode.Type)) tpd.SingletonTypeTree(tree1) // this ensures that tree is classified as a type tree
     else tree1
   }
 
-  def typedNew(tree: untpd.New, pt: Type)(implicit ctx: Context): Tree =
+  def typedNew(tree: untpd.New, pt: Type)(using Context): Tree =
     tree.tpt match {
       case templ: untpd.Template =>
         import untpd._
@@ -693,7 +693,7 @@ class Typer extends Namer
         assignType(cpy.New(tree)(tpt1), tpt1)
     }
 
-  def typedTyped(tree: untpd.Typed, pt: Type)(implicit ctx: Context): Tree = {
+  def typedTyped(tree: untpd.Typed, pt: Type)(using Context): Tree = {
 
     /*  Handles three cases:
      *  @param  ifPat    how to handle a pattern (_: T)
@@ -766,7 +766,7 @@ class Typer extends Namer
    *  exists, rewrite to `ctag(e)`.
    *  @pre We are in pattern-matching mode (Mode.Pattern)
    */
-  def tryWithClassTag(tree: Typed, pt: Type)(implicit ctx: Context): Tree = tree.tpt.tpe.dealias match {
+  def tryWithClassTag(tree: Typed, pt: Type)(using Context): Tree = tree.tpt.tpe.dealias match {
     case tref: TypeRef if !tref.symbol.isClass && !ctx.isAfterTyper && !(tref =:= pt) =>
       require(ctx.mode.is(Mode.Pattern))
       inferImplicit(defn.ClassTagClass.typeRef.appliedTo(tref),
@@ -779,12 +779,12 @@ class Typer extends Namer
     case _ => tree
   }
 
-  def typedNamedArg(tree: untpd.NamedArg, pt: Type)(implicit ctx: Context): NamedArg = {
+  def typedNamedArg(tree: untpd.NamedArg, pt: Type)(using Context): NamedArg = {
     val arg1 = typed(tree.arg, pt)
     assignType(cpy.NamedArg(tree)(tree.name, arg1), arg1)
   }
 
-  def typedAssign(tree: untpd.Assign, pt: Type)(implicit ctx: Context): Tree =
+  def typedAssign(tree: untpd.Assign, pt: Type)(using Context): Tree =
     tree.lhs match {
       case lhs @ Apply(fn, args) =>
         typed(untpd.Apply(untpd.Select(fn, nme.update), args :+ tree.rhs), pt)
@@ -843,11 +843,11 @@ class Typer extends Namer
         }
     }
 
-  def typedBlockStats(stats: List[untpd.Tree])(implicit ctx: Context): (List[tpd.Tree], Context) =
+  def typedBlockStats(stats: List[untpd.Tree])(using Context): (List[tpd.Tree], Context) =
     index(stats)
     typedStats(stats, ctx.owner)
 
-  def typedBlock(tree: untpd.Block, pt: Type)(implicit ctx: Context): Tree = {
+  def typedBlock(tree: untpd.Block, pt: Type)(using Context): Tree = {
     val localCtx = ctx.retractMode(Mode.Pattern)
     val (stats1, exprCtx) = typedBlockStats(tree.stats)(using localCtx)
     val expr1 = typedExpr(tree.expr, pt.dropIfProto)(using exprCtx)
@@ -858,7 +858,7 @@ class Typer extends Namer
       pt, localSyms(stats1))
   }
 
-  def escapingRefs(block: Tree, localSyms: => List[Symbol])(implicit ctx: Context): collection.Set[NamedType] = {
+  def escapingRefs(block: Tree, localSyms: => List[Symbol])(using Context): collection.Set[NamedType] = {
     lazy val locals = localSyms.toSet
     block.tpe.namedPartsWith(tp => locals.contains(tp.symbol) && !tp.isErroneous)
   }
@@ -873,7 +873,7 @@ class Typer extends Namer
    *  expected type of a block is the anonymous class defined inside it. In that
    *  case there's technically a leak which is not removed by the ascription.
    */
-  protected def ensureNoLocalRefs(tree: Tree, pt: Type, localSyms: => List[Symbol])(implicit ctx: Context): Tree = {
+  protected def ensureNoLocalRefs(tree: Tree, pt: Type, localSyms: => List[Symbol])(using Context): Tree = {
     def ascribeType(tree: Tree, pt: Type): Tree = tree match {
       case block @ Block(stats, expr) if !expr.isInstanceOf[Closure] =>
         val expr1 = ascribeType(expr, pt)
@@ -896,7 +896,7 @@ class Typer extends Namer
     }
   }
 
-  def typedIf(tree: untpd.If, pt: Type)(implicit ctx: Context): Tree =
+  def typedIf(tree: untpd.If, pt: Type)(using Context): Tree =
     if tree.isInline then checkInInlineContext("inline if", tree.posd)
     val cond1 = typed(tree.cond, defn.BooleanType)
 
@@ -931,7 +931,7 @@ class Typer extends Namer
    *     def double(x: Char): String = s"$x$x"
    *     "abc" flatMap double
    */
-  private def decomposeProtoFunction(pt: Type, defaultArity: Int)(implicit ctx: Context): (List[Type], untpd.Tree) = {
+  private def decomposeProtoFunction(pt: Type, defaultArity: Int)(using Context): (List[Type], untpd.Tree) = {
     def typeTree(tp: Type) = tp match {
       case _: WildcardType => untpd.TypeTree()
       case _ => untpd.TypeTree(tp)
@@ -961,11 +961,11 @@ class Typer extends Namer
     }
   }
 
-  def typedFunction(tree: untpd.Function, pt: Type)(implicit ctx: Context): Tree =
+  def typedFunction(tree: untpd.Function, pt: Type)(using Context): Tree =
     if (ctx.mode is Mode.Type) typedFunctionType(tree, pt)
     else typedFunctionValue(tree, pt)
 
-  def typedFunctionType(tree: untpd.Function, pt: Type)(implicit ctx: Context): Tree = {
+  def typedFunctionType(tree: untpd.Function, pt: Type)(using Context): Tree = {
     val untpd.Function(args, body) = tree
     var funFlags = tree match {
       case tree: untpd.FunctionWithMods => tree.mods.flags
@@ -978,7 +978,7 @@ class Typer extends Namer
         isContextual = funFlags.is(Given), isErased = funFlags.is(Erased))
 
     /** Typechecks dependent function type with given parameters `params` */
-    def typedDependent(params: List[untpd.ValDef])(implicit ctx: Context): Tree =
+    def typedDependent(params: List[untpd.ValDef])(using Context): Tree =
       val fixThis = new untpd.UntypedTreeMap:
         // pretype all references of this in outer context,
         // so that they do not refer to the refined type being constructed
@@ -1006,13 +1006,13 @@ class Typer extends Namer
     args match {
       case ValDef(_, _, _) :: _ =>
         typedDependent(args.asInstanceOf[List[untpd.ValDef]])(
-          ctx.fresh.setOwner(ctx.newRefinedClassSymbol(tree.span)).setNewScope)
+          using ctx.fresh.setOwner(ctx.newRefinedClassSymbol(tree.span)).setNewScope)
       case _ =>
         typed(cpy.AppliedTypeTree(tree)(untpd.TypeTree(funCls.typeRef), args :+ body), pt)
     }
   }
 
-  def typedFunctionValue(tree: untpd.Function, pt: Type)(implicit ctx: Context): Tree = {
+  def typedFunctionValue(tree: untpd.Function, pt: Type)(using Context): Tree = {
     val untpd.Function(params: List[untpd.ValDef] @unchecked, _) = tree
 
     val isContextual = tree match {
@@ -1068,17 +1068,19 @@ class Typer extends Namer
             case untpd.TypedSplice(expr1) =>
               expr1.tpe
             case _ =>
-              val curCtx = ctx
-              given nestedCtx as Context = ctx.fresh.setNewTyperState()
-              val protoArgs = args map (_ withType WildcardType)
-              val callProto = FunProto(protoArgs, WildcardType)(this, app.isUsingApply)
-              val expr1 = typedExpr(expr, callProto)
-              if nestedCtx.reporter.hasErrors then NoType
-              else
-                given Context = curCtx
-                nestedCtx.typerState.commit()
-                fnBody = cpy.Apply(fnBody)(untpd.TypedSplice(expr1), args)
-                expr1.tpe
+              val outerCtx = ctx
+              val nestedCtx = outerCtx.fresh.setNewTyperState()
+              inContext(nestedCtx) {
+                val protoArgs = args map (_ withType WildcardType)
+                val callProto = FunProto(protoArgs, WildcardType)(this, app.isUsingApply)
+                val expr1 = typedExpr(expr, callProto)
+                if nestedCtx.reporter.hasErrors then NoType
+                else inContext(outerCtx) {
+                  nestedCtx.typerState.commit()
+                  fnBody = cpy.Apply(fnBody)(untpd.TypedSplice(expr1), args)
+                  expr1.tpe
+                }
+              }
         else NoType
       case _ =>
         NoType
@@ -1160,7 +1162,7 @@ class Typer extends Namer
     typed(desugared, pt)
   }
 
-  def typedClosure(tree: untpd.Closure, pt: Type)(implicit ctx: Context): Tree = {
+  def typedClosure(tree: untpd.Closure, pt: Type)(using Context): Tree = {
     val env1 = tree.env mapconserve (typed(_))
     val meth1 = typedUnadapted(tree.meth)
     val target =
@@ -1208,7 +1210,7 @@ class Typer extends Namer
     assignType(cpy.Closure(tree)(env1, meth1, target), meth1, target)
   }
 
-  def typedMatch(tree: untpd.Match, pt: Type)(implicit ctx: Context): Tree =
+  def typedMatch(tree: untpd.Match, pt: Type)(using Context): Tree =
     tree.selector match {
       case EmptyTree =>
         if (tree.isInline) {
@@ -1249,13 +1251,13 @@ class Typer extends Namer
     }
 
   // Overridden in InlineTyper for inline matches
-  def typedMatchFinish(tree: untpd.Match, sel: Tree, wideSelType: Type, cases: List[untpd.CaseDef], pt: Type)(implicit ctx: Context): Tree = {
+  def typedMatchFinish(tree: untpd.Match, sel: Tree, wideSelType: Type, cases: List[untpd.CaseDef], pt: Type)(using Context): Tree = {
     val cases1 = harmonic(harmonize, pt)(typedCases(cases, sel, wideSelType, pt.dropIfProto))
       .asInstanceOf[List[CaseDef]]
     assignType(cpy.Match(tree)(sel, cases1), sel, cases1)
   }
 
-  def typedCases(cases: List[untpd.CaseDef], sel: Tree, wideSelType: Type, pt: Type)(implicit ctx: Context): List[CaseDef] =
+  def typedCases(cases: List[untpd.CaseDef], sel: Tree, wideSelType: Type, pt: Type)(using Context): List[CaseDef] =
     var caseCtx = ctx
     cases.mapconserve { cas =>
       val case1 = typedCase(cas, sel, wideSelType, pt)(using caseCtx)
@@ -1267,11 +1269,11 @@ class Typer extends Namer
     *    run/reducable.scala is a test case that shows stripping typevars is necessary.
     *  - enter all symbols introduced by a Bind in current scope
     */
-  private def indexPattern(cdef: untpd.CaseDef)(implicit ctx: Context) = new TreeMap {
+  private def indexPattern(cdef: untpd.CaseDef)(using Context) = new TreeMap {
     val stripTypeVars = new TypeMap {
       def apply(t: Type) = mapOver(t)
     }
-    override def transform(trt: Tree)(implicit ctx: Context) =
+    override def transform(trt: Tree)(using Context) =
       super.transform(trt.withType(stripTypeVars(trt.tpe))) match {
         case b: Bind =>
           val sym = b.symbol
@@ -1289,11 +1291,11 @@ class Typer extends Namer
   }
 
   /** Type a case. */
-  def typedCase(tree: untpd.CaseDef, sel: Tree, wideSelType: Type, pt: Type)(implicit ctx: Context): CaseDef = {
+  def typedCase(tree: untpd.CaseDef, sel: Tree, wideSelType: Type, pt: Type)(using Context): CaseDef = {
     val originalCtx = ctx
     val gadtCtx: Context = ctx.fresh.setFreshGADTBounds
 
-    def caseRest(pat: Tree)(implicit ctx: Context) = {
+    def caseRest(pat: Tree)(using Context) = {
       val pat1 = indexPattern(tree).transform(pat)
       val guard1 = typedExpr(tree.guard, defn.BooleanType)
       var body1 = ensureNoLocalRefs(typedExpr(tree.body, pt), pt, ctx.scope.toList)
@@ -1302,22 +1304,22 @@ class Typer extends Namer
       assignType(cpy.CaseDef(tree)(pat1, guard1, body1), pat1, body1)
     }
 
-    val pat1 = typedPattern(tree.pat, wideSelType)(gadtCtx)
+    val pat1 = typedPattern(tree.pat, wideSelType)(using gadtCtx)
     caseRest(pat1)(
       using Nullables.caseContext(sel, pat1)(
         using gadtCtx.fresh.setNewScope))
   }
 
-  def typedLabeled(tree: untpd.Labeled)(implicit ctx: Context): Labeled = {
+  def typedLabeled(tree: untpd.Labeled)(using Context): Labeled = {
     val bind1 = typedBind(tree.bind, WildcardType).asInstanceOf[Bind]
     val expr1 = typed(tree.expr, bind1.symbol.info)
     assignType(cpy.Labeled(tree)(bind1, expr1))
   }
 
   /** Type a case of a type match */
-  def typedTypeCase(cdef: untpd.CaseDef, selType: Type, pt: Type)(implicit ctx: Context): CaseDef = {
-    def caseRest(implicit ctx: Context) = {
-      val pat1 = checkSimpleKinded(typedType(cdef.pat)(ctx.addMode(Mode.Pattern)))
+  def typedTypeCase(cdef: untpd.CaseDef, selType: Type, pt: Type)(using Context): CaseDef = {
+    def caseRest(using Context) = {
+      val pat1 = checkSimpleKinded(typedType(cdef.pat)(using ctx.addMode(Mode.Pattern)))
       val pat2 = indexPattern(cdef).transform(pat1)
       var body1 = typedType(cdef.body, pt)
       if !body1.isType then
@@ -1325,10 +1327,10 @@ class Typer extends Namer
         body1 = TypeTree(errorType("<error: not a type>", cdef.sourcePos))
       assignType(cpy.CaseDef(cdef)(pat2, EmptyTree, body1), pat2, body1)
     }
-    caseRest(ctx.fresh.setFreshGADTBounds.setNewScope)
+    caseRest(using ctx.fresh.setFreshGADTBounds.setNewScope)
   }
 
-  def typedReturn(tree: untpd.Return)(implicit ctx: Context): Return = {
+  def typedReturn(tree: untpd.Return)(using Context): Return = {
     def returnProto(owner: Symbol, locals: Scope): Type =
       if (owner.isConstructor) defn.UnitType
       else owner.info match {
@@ -1373,17 +1375,17 @@ class Typer extends Namer
     assignType(cpy.Return(tree)(expr1, from))
   }
 
-  def typedWhileDo(tree: untpd.WhileDo)(implicit ctx: Context): Tree = {
-    given whileCtx as Context = Nullables.whileContext(tree.span)(using ctx)
-    val cond1 =
-      if (tree.cond eq EmptyTree) EmptyTree
-      else typed(tree.cond, defn.BooleanType)
-    val body1 = typed(tree.body, defn.UnitType)(using cond1.nullableContextIf(true))
-    assignType(cpy.WhileDo(tree)(cond1, body1))
-      .withNotNullInfo(body1.notNullInfo.retractedInfo.seq(cond1.notNullInfoIf(false)))
-  }
+  def typedWhileDo(tree: untpd.WhileDo)(using Context): Tree =
+    inContext(Nullables.whileContext(tree.span)) {
+      val cond1 =
+        if (tree.cond eq EmptyTree) EmptyTree
+        else typed(tree.cond, defn.BooleanType)
+      val body1 = typed(tree.body, defn.UnitType)(using cond1.nullableContextIf(true))
+      assignType(cpy.WhileDo(tree)(cond1, body1))
+        .withNotNullInfo(body1.notNullInfo.retractedInfo.seq(cond1.notNullInfoIf(false)))
+    }
 
-  def typedTry(tree: untpd.Try, pt: Type)(implicit ctx: Context): Try = {
+  def typedTry(tree: untpd.Try, pt: Type)(using Context): Try = {
     val expr2 :: cases2x = harmonic(harmonize, pt) {
       val expr1 = typed(tree.expr, pt.dropIfProto)
       val cases1 = typedCases(tree.cases, EmptyTree, defn.ThrowableType, pt.dropIfProto)
@@ -1394,12 +1396,12 @@ class Typer extends Namer
     assignType(cpy.Try(tree)(expr2, cases2, finalizer1), expr2, cases2)
   }
 
-  def typedThrow(tree: untpd.Throw)(implicit ctx: Context): Tree = {
+  def typedThrow(tree: untpd.Throw)(using Context): Tree = {
     val expr1 = typed(tree.expr, defn.ThrowableType)
     Throw(expr1).withSpan(tree.span)
   }
 
-  def typedSeqLiteral(tree: untpd.SeqLiteral, pt: Type)(implicit ctx: Context): SeqLiteral = {
+  def typedSeqLiteral(tree: untpd.SeqLiteral, pt: Type)(using Context): SeqLiteral = {
     val elemProto = pt.elemType match {
       case NoType => WildcardType
       case bounds: TypeBounds => WildcardType(bounds)
@@ -1428,14 +1430,14 @@ class Typer extends Namer
     }
   }
 
-  def typedInlined(tree: untpd.Inlined, pt: Type)(implicit ctx: Context): Tree = {
+  def typedInlined(tree: untpd.Inlined, pt: Type)(using Context): Tree = {
     val (bindings1, exprCtx) = typedBlockStats(tree.bindings)
-    val expansion1 = typed(tree.expansion, pt)(inlineContext(tree.call)(exprCtx))
+    val expansion1 = typed(tree.expansion, pt)(using inlineContext(tree.call)(exprCtx))
     assignType(cpy.Inlined(tree)(tree.call, bindings1.asInstanceOf[List[MemberDef]], expansion1),
         bindings1, expansion1)
   }
 
-  def typedTypeTree(tree: untpd.TypeTree, pt: Type)(implicit ctx: Context): Tree =
+  def typedTypeTree(tree: untpd.TypeTree, pt: Type)(using Context): Tree =
     tree match {
       case tree: untpd.DerivedTypeTree =>
         tree.ensureCompletions
@@ -1456,13 +1458,13 @@ class Typer extends Namer
           else errorType(i"cannot infer type; expected type $pt is not fully defined", tree.sourcePos))
     }
 
-  def typedSingletonTypeTree(tree: untpd.SingletonTypeTree)(implicit ctx: Context): SingletonTypeTree = {
+  def typedSingletonTypeTree(tree: untpd.SingletonTypeTree)(using Context): SingletonTypeTree = {
     val ref1 = typedExpr(tree.ref)
     checkStable(ref1.tpe, tree.sourcePos, "singleton type")
     assignType(cpy.SingletonTypeTree(tree)(ref1), ref1)
   }
 
-  def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(implicit ctx: Context): TypTree = {
+  def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(using Context): TypTree = {
     val tpt1 = if (tree.tpt.isEmpty) TypeTree(defn.ObjectType) else typedAheadType(tree.tpt)
     val refineClsDef = desugar.refinedTypeToClass(tpt1, tree.refinements).withSpan(tree.span)
     val refineCls = createSymbol(refineClsDef).asClass
@@ -1486,8 +1488,8 @@ class Typer extends Namer
     assignType(cpy.RefinedTypeTree(tree)(tpt1, refinements1), tpt1, refinements1, refineCls)
   }
 
-  def typedAppliedTypeTree(tree: untpd.AppliedTypeTree)(implicit ctx: Context): Tree = {
-    val tpt1 = typed(tree.tpt, AnyTypeConstructorProto)(ctx.retractMode(Mode.Pattern))
+  def typedAppliedTypeTree(tree: untpd.AppliedTypeTree)(using Context): Tree = {
+    val tpt1 = typed(tree.tpt, AnyTypeConstructorProto)(using ctx.retractMode(Mode.Pattern))
     val tparams = tpt1.tpe.typeParams
     if (tparams.isEmpty) {
       ctx.error(TypeDoesNotTakeParameters(tpt1.tpe, tree.args), tree.sourcePos)
@@ -1555,7 +1557,7 @@ class Typer extends Namer
     }
   }
 
-  def typedLambdaTypeTree(tree: untpd.LambdaTypeTree)(implicit ctx: Context): Tree = {
+  def typedLambdaTypeTree(tree: untpd.LambdaTypeTree)(using Context): Tree = {
     val LambdaTypeTree(tparams, body) = tree
     index(tparams)
     val tparams1 = tparams.mapconserve(typed(_).asInstanceOf[TypeDef])
@@ -1563,7 +1565,7 @@ class Typer extends Namer
     assignType(cpy.LambdaTypeTree(tree)(tparams1, body1), tparams1, body1)
   }
 
-  def typedMatchTypeTree(tree: untpd.MatchTypeTree, pt: Type)(implicit ctx: Context): Tree = {
+  def typedMatchTypeTree(tree: untpd.MatchTypeTree, pt: Type)(using Context): Tree = {
     val bound1 =
       if (tree.bound.isEmpty && isFullyDefined(pt, ForceDegree.none)) TypeTree(pt)
       else typed(tree.bound)
@@ -1573,12 +1575,12 @@ class Typer extends Namer
     assignType(cpy.MatchTypeTree(tree)(bound1, sel1, cases1), bound1, sel1, cases1)
   }
 
-  def typedByNameTypeTree(tree: untpd.ByNameTypeTree)(implicit ctx: Context): ByNameTypeTree = {
+  def typedByNameTypeTree(tree: untpd.ByNameTypeTree)(using Context): ByNameTypeTree = {
     val result1 = typed(tree.result)
     assignType(cpy.ByNameTypeTree(tree)(result1), result1)
   }
 
-  def typedTypeBoundsTree(tree: untpd.TypeBoundsTree, pt: Type)(implicit ctx: Context): Tree = {
+  def typedTypeBoundsTree(tree: untpd.TypeBoundsTree, pt: Type)(using Context): Tree = {
     val TypeBoundsTree(lo, hi, alias) = tree
     val lo1 = typed(lo)
     val hi1 = typed(hi)
@@ -1608,7 +1610,7 @@ class Typer extends Namer
     else tree1
   }
 
-  def typedBind(tree: untpd.Bind, pt: Type)(implicit ctx: Context): Tree = {
+  def typedBind(tree: untpd.Bind, pt: Type)(using Context): Tree = {
     if !isFullyDefined(pt, ForceDegree.all) then
       return errorTree(tree, i"expected type of $tree is not fully defined")
     val body1 = typed(tree.body, pt)
@@ -1655,14 +1657,14 @@ class Typer extends Namer
     }
   }
 
-  def typedAlternative(tree: untpd.Alternative, pt: Type)(implicit ctx: Context): Alternative = {
+  def typedAlternative(tree: untpd.Alternative, pt: Type)(using Context): Alternative = {
     val nestedCtx = ctx.addMode(Mode.InPatternAlternative)
     def ensureValueTypeOrWildcard(tree: Tree) =
       if tree.tpe.isValueTypeOrWildcard then tree
       else
         assert(ctx.reporter.errorsReported)
         tree.withType(defn.AnyType)
-    val trees1 = tree.trees.mapconserve(typed(_, pt)(nestedCtx))
+    val trees1 = tree.trees.mapconserve(typed(_, pt)(using nestedCtx))
       .mapconserve(ensureValueTypeOrWildcard)
     assignType(cpy.Alternative(tree)(trees1), trees1)
   }
@@ -1674,7 +1676,7 @@ class Typer extends Namer
    *  since classes defined in a such arguments should not be entered into the
    *  enclosing class.
    */
-  def annotContext(mdef: untpd.Tree, sym: Symbol)(implicit ctx: Context): Context = {
+  def annotContext(mdef: untpd.Tree, sym: Symbol)(using Context): Context = {
     def isInner(owner: Symbol) = owner == sym || sym.is(Param) && owner == sym.owner
     val c = ctx.outersIterator.dropWhile(c => isInner(c.owner)).next()
     c.property(ExprOwner) match {
@@ -1683,19 +1685,19 @@ class Typer extends Namer
     }
   }
 
-  def completeAnnotations(mdef: untpd.MemberDef, sym: Symbol)(implicit ctx: Context): Unit = {
+  def completeAnnotations(mdef: untpd.MemberDef, sym: Symbol)(using Context): Unit = {
     // necessary to force annotation trees to be computed.
     sym.annotations.foreach(_.ensureCompleted)
     lazy val annotCtx = annotContext(mdef, sym)
     // necessary in order to mark the typed ahead annotations as definitely typed:
     for (annot <- untpd.modsDeco(mdef).mods.annotations)
-      checkAnnotApplicable(typedAnnotation(annot)(annotCtx), sym)
+      checkAnnotApplicable(typedAnnotation(annot)(using annotCtx), sym)
   }
 
-  def typedAnnotation(annot: untpd.Tree)(implicit ctx: Context): Tree =
+  def typedAnnotation(annot: untpd.Tree)(using Context): Tree =
     typed(annot, defn.AnnotationClass.typeRef)
 
-  def typedValDef(vdef: untpd.ValDef, sym: Symbol)(implicit ctx: Context): Tree = {
+  def typedValDef(vdef: untpd.ValDef, sym: Symbol)(using Context): Tree = {
     val ValDef(name, tpt, _) = vdef
     completeAnnotations(vdef, sym)
     if (sym.isOneOf(GivenOrImplicit)) checkImplicitConversionDefOK(sym)
@@ -1720,7 +1722,7 @@ class Typer extends Namer
    *
    *  see remark about idempotency in TreeInfo#constToLiteral
    */
-  private def patchFinalVals(vdef: ValDef)(implicit ctx: Context): Unit = {
+  private def patchFinalVals(vdef: ValDef)(using Context): Unit = {
     def isFinalInlinableVal(sym: Symbol): Boolean =
       sym.is(Final, butNot = Mutable) &&
       isIdempotentExpr(vdef.rhs) /* &&
@@ -1732,7 +1734,7 @@ class Typer extends Namer
     }
   }
 
-  def typedDefDef(ddef: untpd.DefDef, sym: Symbol)(implicit ctx: Context): Tree = {
+  def typedDefDef(ddef: untpd.DefDef, sym: Symbol)(using Context): Tree = {
     if (!sym.info.exists) { // it's a discarded synthetic case class method, drop it
       assert(sym.is(Synthetic) && desugar.isRetractableCaseClassMethodName(sym.name))
       sym.owner.info.decls.openForMutations.unlink(sym)
@@ -1768,7 +1770,7 @@ class Typer extends Namer
     }
 
     if (sym.isInlineMethod) rhsCtx.addMode(Mode.InlineableBody)
-    val rhs1 = typedExpr(ddef.rhs, tpt1.tpe.widenExpr)(rhsCtx)
+    val rhs1 = typedExpr(ddef.rhs, tpt1.tpe.widenExpr)(using rhsCtx)
     val rhsToInline = PrepareInlineable.wrapRHS(ddef, tpt1, rhs1)
 
     if (sym.isInlineMethod)
@@ -1798,7 +1800,7 @@ class Typer extends Namer
       //todo: make sure dependent method types do not depend on implicits or by-name params
   }
 
-  def typedTypeDef(tdef: untpd.TypeDef, sym: Symbol)(implicit ctx: Context): Tree = {
+  def typedTypeDef(tdef: untpd.TypeDef, sym: Symbol)(using Context): Tree = {
     val TypeDef(name, rhs) = tdef
     completeAnnotations(tdef, sym)
     val rhs1 = tdef.rhs match {
@@ -1812,7 +1814,7 @@ class Typer extends Namer
     assignType(cpy.TypeDef(tdef)(name, rhs1), sym)
   }
 
-  def typedClassDef(cdef: untpd.TypeDef, cls: ClassSymbol)(implicit ctx: Context): Tree = {
+  def typedClassDef(cdef: untpd.TypeDef, cls: ClassSymbol)(using Context): Tree = {
     if (!cls.info.isInstanceOf[ClassInfo]) return EmptyTree.assertingErrorsReported
 
     val TypeDef(name, impl @ Template(constr, _, self, _)) = cdef
@@ -1830,7 +1832,7 @@ class Typer extends Namer
      */
     def maybeCall(ref: Tree, psym: Symbol, cinfo: Type): Tree = cinfo.stripPoly match {
       case cinfo @ MethodType(Nil) if cinfo.resultType.isImplicitMethod =>
-        typedExpr(untpd.New(untpd.TypedSplice(ref)(superCtx), Nil))(superCtx)
+        typedExpr(untpd.New(untpd.TypedSplice(ref)(superCtx), Nil))(using superCtx)
       case cinfo @ MethodType(Nil) if !cinfo.resultType.isInstanceOf[MethodType] =>
         ref
       case cinfo: MethodType =>
@@ -1850,7 +1852,9 @@ class Typer extends Namer
         case _: untpd.Apply => false
         case _ => true
       }
-      var result = if (isTreeType(tree)) typedType(tree)(superCtx) else typedExpr(tree)(superCtx)
+      var result =
+        if isTreeType(tree) then typedType(tree)(using superCtx)
+        else typedExpr(tree)(using superCtx)
       val psym = result.tpe.dealias.typeSymbol
       if (seenParents.contains(psym) && !cls.isRefinementClass) {
         // Desugaring can adds parents to classes, but we don't want to emit an
@@ -1893,16 +1897,16 @@ class Typer extends Namer
     completeAnnotations(cdef, cls)
     val constr1 = typed(constr).asInstanceOf[DefDef]
     val parentsWithClass = ensureFirstTreeIsClass(parents.mapconserve(typedParent).filterConserve(!_.isEmpty), cdef.nameSpan)
-    val parents1 = ensureConstrCall(cls, parentsWithClass)(superCtx)
+    val parents1 = ensureConstrCall(cls, parentsWithClass)(using superCtx)
 
-    val self1 = typed(self)(ctx.outer).asInstanceOf[ValDef] // outer context where class members are not visible
+    val self1 = typed(self)(using ctx.outer).asInstanceOf[ValDef] // outer context where class members are not visible
     if (self1.tpt.tpe.isError || classExistsOnSelf(cls.unforcedDecls, self1))
       // fail fast to avoid typing the body with an error type
       cdef.withType(UnspecifiedErrorType)
     else {
       val dummy = localDummy(cls, impl)
       val body1 = addAccessorDefs(cls,
-        typedStats(impl.body, dummy)(ctx.inClassContext(self1.symbol))._1)
+        typedStats(impl.body, dummy)(using ctx.inClassContext(self1.symbol))._1)
 
       checkNoDoubleDeclaration(cls)
       val impl1 = cpy.Template(impl)(constr1, parents1, Nil, self1, body1)
@@ -1957,7 +1961,7 @@ class Typer extends Namer
       // 3. Types do not override classes.
       // 4. Polymorphic type defs override nothing.
 
-  protected def addAccessorDefs(cls: Symbol, body: List[Tree])(implicit ctx: Context): List[Tree] =
+  protected def addAccessorDefs(cls: Symbol, body: List[Tree])(using Context): List[Tree] =
     ctx.compilationUnit.inlineAccessors.addAccessorDefs(cls, body)
 
   /** Ensure that the first type in a list of parent types Ps points to a non-trait class.
@@ -1969,7 +1973,7 @@ class Typer extends Namer
    *  - has C as its class symbol, and
    *  - for all parents P_i: If P_i derives from C then P_i <:< CT.
    */
-  def ensureFirstIsClass(parents: List[Type], span: Span)(implicit ctx: Context): List[Type] = {
+  def ensureFirstIsClass(parents: List[Type], span: Span)(using Context): List[Type] = {
     def realClassParent(cls: Symbol): ClassSymbol =
       if (!cls.isClass) defn.ObjectClass
       else if (!cls.is(Trait)) cls.asClass
@@ -1992,7 +1996,7 @@ class Typer extends Namer
   }
 
   /** Ensure that first parent tree refers to a real class. */
-  def ensureFirstTreeIsClass(parents: List[Tree], span: Span)(implicit ctx: Context): List[Tree] = parents match {
+  def ensureFirstTreeIsClass(parents: List[Tree], span: Span)(using Context): List[Tree] = parents match {
     case p :: ps if p.tpe.classSymbol.isRealClass => parents
     case _ => TypeTree(ensureFirstIsClass(parents.tpes, span).head).withSpan(span.focus) :: parents
   }
@@ -2000,17 +2004,17 @@ class Typer extends Namer
   /** If this is a real class, make sure its first parent is a
    *  constructor call. Cannot simply use a type. Overridden in ReTyper.
    */
-  def ensureConstrCall(cls: ClassSymbol, parents: List[Tree])(implicit ctx: Context): List[Tree] = {
+  def ensureConstrCall(cls: ClassSymbol, parents: List[Tree])(using Context): List[Tree] = {
     val firstParent :: otherParents = parents
     if (firstParent.isType && !cls.is(Trait) && !cls.is(JavaDefined))
       typed(untpd.New(untpd.TypedSplice(firstParent), Nil)) :: otherParents
     else parents
   }
 
-  def localDummy(cls: ClassSymbol, impl: untpd.Template)(implicit ctx: Context): Symbol =
+  def localDummy(cls: ClassSymbol, impl: untpd.Template)(using Context): Symbol =
     ctx.newLocalDummy(cls, impl.span)
 
-  def typedImport(imp: untpd.Import, sym: Symbol)(implicit ctx: Context): Import = {
+  def typedImport(imp: untpd.Import, sym: Symbol)(using Context): Import = {
     val expr1 = typedExpr(imp.expr, AnySelectionProto)
     checkLegalImportPath(expr1)
     val selectors1: List[untpd.ImportSelector] = imp.selectors.mapConserve { sel =>
@@ -2022,15 +2026,15 @@ class Typer extends Namer
     assignType(cpy.Import(imp)(expr1, selectors1), sym)
   }
 
-  def typedPackageDef(tree: untpd.PackageDef)(implicit ctx: Context): Tree =
-    val pid1 = typedExpr(tree.pid, AnySelectionProto)(ctx.addMode(Mode.InPackageClauseName))
+  def typedPackageDef(tree: untpd.PackageDef)(using Context): Tree =
+    val pid1 = typedExpr(tree.pid, AnySelectionProto)(using ctx.addMode(Mode.InPackageClauseName))
     val pkg = pid1.symbol
     pid1 match
       case pid1: RefTree if pkg.is(Package) =>
         val packageCtx = ctx.packageContext(tree, pkg)
-        var stats1 = typedStats(tree.stats, pkg.moduleClass)(packageCtx)._1
+        var stats1 = typedStats(tree.stats, pkg.moduleClass)(using packageCtx)._1
         if (!ctx.isAfterTyper)
-          stats1 = stats1 ++ typedBlockStats(MainProxies.mainProxies(stats1))(packageCtx)._1
+          stats1 = stats1 ++ typedBlockStats(MainProxies.mainProxies(stats1))(using packageCtx)._1
         cpy.PackageDef(tree)(pid1, stats1).withType(pkg.termRef)
       case _ =>
         // Package will not exist if a duplicate type has already been entered, see `tests/neg/1708.scala`
@@ -2039,7 +2043,7 @@ class Typer extends Namer
           else i"package ${tree.pid.name} does not exist")
   end typedPackageDef
 
-  def typedAnnotated(tree: untpd.Annotated, pt: Type)(implicit ctx: Context): Tree = {
+  def typedAnnotated(tree: untpd.Annotated, pt: Type)(using Context): Tree = {
     val annot1 = typedExpr(tree.annot, defn.AnnotationClass.typeRef)
     val arg1 = typed(tree.arg, pt)
     if (ctx.mode is Mode.Type) {
@@ -2069,7 +2073,7 @@ class Typer extends Namer
     }
   }
 
-  def typedTypedSplice(tree: untpd.TypedSplice)(implicit ctx: Context): Tree =
+  def typedTypedSplice(tree: untpd.TypedSplice)(using Context): Tree =
     tree.splice match {
       case tree1: TypeTree => tree1  // no change owner necessary here ...
       case tree1: Ident => tree1     // ... or here, since these trees cannot contain bindings
@@ -2078,15 +2082,15 @@ class Typer extends Namer
         else tree1
     }
 
-  def typedAsFunction(tree: untpd.PostfixOp, pt: Type)(implicit ctx: Context): Tree = {
+  def typedAsFunction(tree: untpd.PostfixOp, pt: Type)(using Context): Tree = {
     val untpd.PostfixOp(qual, Ident(nme.WILDCARD)) = tree
     val pt1 = if (defn.isFunctionType(pt)) pt else AnyFunctionProto
     val nestedCtx = ctx.fresh.setNewTyperState()
-    val res = typed(qual, pt1)(nestedCtx)
+    val res = typed(qual, pt1)(using nestedCtx)
     res match {
       case closure(_, _, _) =>
       case _ =>
-        val recovered = typed(qual)(ctx.fresh.setExploreTyperState())
+        val recovered = typed(qual)(using ctx.fresh.setExploreTyperState())
         ctx.errorOrMigrationWarning(OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen), tree.sourcePos)
         if (ctx.scala2CompatMode) {
           // Under -rewrite, patch `x _` to `(() => x)`
@@ -2126,7 +2130,7 @@ class Typer extends Namer
    *  Translate infix type    `l op r` to `op[l, r]`
    *  Translate infix pattern `l op r` to `op(l, r)`
    */
-  def typedInfixOp(tree: untpd.InfixOp, pt: Type)(implicit ctx: Context): Tree = {
+  def typedInfixOp(tree: untpd.InfixOp, pt: Type)(using Context): Tree = {
     val untpd.InfixOp(l, op, r) = tree
     val result =
       if (ctx.mode.is(Mode.Type))
@@ -2155,7 +2159,7 @@ class Typer extends Namer
   }
 
   /** Translate tuples of all arities */
-  def typedTuple(tree: untpd.Tuple, pt: Type)(implicit ctx: Context): Tree = {
+  def typedTuple(tree: untpd.Tuple, pt: Type)(using Context): Tree = {
     val arity = tree.trees.length
     if (arity <= Definitions.MaxTupleArity)
       typed(desugar.smallTuple(tree).withSpan(tree.span), pt)
@@ -2185,7 +2189,7 @@ class Typer extends Namer
   }
 
   /** Retrieve symbol attached to given tree */
-  protected def retrieveSym(tree: untpd.Tree)(implicit ctx: Context): Symbol = tree.removeAttachment(SymOfTree) match {
+  protected def retrieveSym(tree: untpd.Tree)(using Context): Symbol = tree.removeAttachment(SymOfTree) match {
     case Some(sym) =>
       sym.ensureCompleted()
       sym
@@ -2195,7 +2199,7 @@ class Typer extends Namer
 
   protected def localTyper(sym: Symbol): Typer = nestedTyper.remove(sym).get
 
-  def typedUnadapted(initTree: untpd.Tree, pt: Type = WildcardType)(implicit ctx: Context): Tree =
+  def typedUnadapted(initTree: untpd.Tree, pt: Type = WildcardType)(using Context): Tree =
     typedUnadapted(initTree, pt, ctx.typerState.ownedVars)
 
   /** Typecheck tree without adapting it, returning a typed tree.
@@ -2204,14 +2208,14 @@ class Typer extends Namer
    *  @param locked      the set of type variables of the current typer state that cannot be interpolated
    *                     at the present time
    */
-  def typedUnadapted(initTree: untpd.Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): Tree = {
+  def typedUnadapted(initTree: untpd.Tree, pt: Type, locked: TypeVars)(using Context): Tree = {
     record("typedUnadapted")
     val xtree = expanded(initTree)
     xtree.removeAttachment(TypedAhead) match {
       case Some(ttree) => ttree
       case none =>
 
-        def typedNamed(tree: untpd.NameTree, pt: Type)(implicit ctx: Context): Tree = {
+        def typedNamed(tree: untpd.NameTree, pt: Type)(using Context): Tree = {
           val sym = retrieveSym(xtree)
           tree match {
             case tree: untpd.Ident => typedIdent(tree, pt)
@@ -2219,15 +2223,15 @@ class Typer extends Namer
             case tree: untpd.Bind => typedBind(tree, pt)
             case tree: untpd.ValDef =>
               if (tree.isEmpty) tpd.EmptyValDef
-              else typedValDef(tree, sym)(ctx.localContext(tree, sym).setNewScope)
+              else typedValDef(tree, sym)(using ctx.localContext(tree, sym).setNewScope)
             case tree: untpd.DefDef =>
               val typer1 = localTyper(sym)
-              typer1.typedDefDef(tree, sym)(ctx.localContext(tree, sym).setTyper(typer1))
+              typer1.typedDefDef(tree, sym)(using ctx.localContext(tree, sym).setTyper(typer1))
             case tree: untpd.TypeDef =>
               if (tree.isClassDef)
-                typedClassDef(tree, sym.asClass)(ctx.localContext(tree, sym))
+                typedClassDef(tree, sym.asClass)(using ctx.localContext(tree, sym))
               else
-                typedTypeDef(tree, sym)(ctx.localContext(tree, sym).setNewScope)
+                typedTypeDef(tree, sym)(using ctx.localContext(tree, sym).setNewScope)
             case tree: untpd.Labeled => typedLabeled(tree)
             case _ => typedUnadapted(desugar(tree), pt, locked)
           }
@@ -2243,7 +2247,7 @@ class Typer extends Namer
           case tree: untpd.Typed => typedTyped(tree, pt)
           case tree: untpd.NamedArg => typedNamedArg(tree, pt)
           case tree: untpd.Assign => typedAssign(tree, pt)
-          case tree: untpd.Block => typedBlock(desugar.block(tree), pt)(ctx.fresh.setNewScope)
+          case tree: untpd.Block => typedBlock(desugar.block(tree), pt)(using ctx.fresh.setNewScope)
           case tree: untpd.If => typedIf(tree, pt)
           case tree: untpd.Function => typedFunction(tree, pt)
           case tree: untpd.Closure => typedClosure(tree, pt)
@@ -2261,7 +2265,7 @@ class Typer extends Namer
           case tree: untpd.SingletonTypeTree => typedSingletonTypeTree(tree)
           case tree: untpd.RefinedTypeTree => typedRefinedTypeTree(tree)
           case tree: untpd.AppliedTypeTree => typedAppliedTypeTree(tree)
-          case tree: untpd.LambdaTypeTree => typedLambdaTypeTree(tree)(ctx.localContext(tree, NoSymbol).setNewScope)
+          case tree: untpd.LambdaTypeTree => typedLambdaTypeTree(tree)(using ctx.localContext(tree, NoSymbol).setNewScope)
           case tree: untpd.MatchTypeTree => typedMatchTypeTree(tree, pt)
           case tree: untpd.ByNameTypeTree => typedByNameTypeTree(tree)
           case tree: untpd.TypeBoundsTree => typedTypeBoundsTree(tree, pt)
@@ -2300,7 +2304,7 @@ class Typer extends Namer
   }
 
   /** Interpolate and simplify the type of the given tree. */
-  protected def simplify(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): tree.type = {
+  protected def simplify(tree: Tree, pt: Type, locked: TypeVars)(using Context): tree.type = {
     if (!tree.denot.isOverloaded &&
           // for overloaded trees: resolve overloading before simplifying
         !tree.isInstanceOf[Applications.IntegratedTypeArgs])
@@ -2313,7 +2317,7 @@ class Typer extends Namer
     tree
   }
 
-  protected def makeContextualFunction(tree: untpd.Tree, pt: Type)(implicit ctx: Context): Tree = {
+  protected def makeContextualFunction(tree: untpd.Tree, pt: Type)(using Context): Tree = {
     val defn.FunctionOf(formals, _, true, _) = pt.dropDependentRefinement
     val ifun = desugar.makeContextualFunction(formals, tree, defn.isErasedFunctionType(pt))
     typr.println(i"make contextual function $tree / $pt ---> $ifun")
@@ -2321,14 +2325,14 @@ class Typer extends Namer
   }
 
   /** Typecheck and adapt tree, returning a typed tree. Parameters as for `typedUnadapted` */
-  def typed(tree: untpd.Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): Tree =
+  def typed(tree: untpd.Tree, pt: Type, locked: TypeVars)(using Context): Tree =
     trace(i"typing $tree, pt = $pt", typr, show = true) {
       record(s"typed $getClass")
       record("typed total")
       if (ctx.phase.isTyper)
         assertPositioned(tree)
       if (tree.source != ctx.source && tree.source.exists)
-        typed(tree, pt, locked)(ctx.withSource(tree.source))
+        typed(tree, pt, locked)(using ctx.withSource(tree.source))
       else
         try
           if ctx.run.isCancelled then tree.withType(WildcardType)
@@ -2343,22 +2347,22 @@ class Typer extends Namer
         }
     }
 
-  def typed(tree: untpd.Tree, pt: Type = WildcardType)(implicit ctx: Context): Tree =
+  def typed(tree: untpd.Tree, pt: Type = WildcardType)(using Context): Tree =
     typed(tree, pt, ctx.typerState.ownedVars)
 
-  def typedTrees(trees: List[untpd.Tree])(implicit ctx: Context): List[Tree] =
+  def typedTrees(trees: List[untpd.Tree])(using Context): List[Tree] =
     trees mapconserve (typed(_))
 
-  def typedStats(stats: List[untpd.Tree], exprOwner: Symbol)(implicit ctx: Context): (List[Tree], Context) = {
+  def typedStats(stats: List[untpd.Tree], exprOwner: Symbol)(using Context): (List[Tree], Context) = {
     val buf = new mutable.ListBuffer[Tree]
     val enumContexts = new mutable.HashMap[Symbol, Context]
     val initialNotNullInfos = ctx.notNullInfos
       // A map from `enum` symbols to the contexts enclosing their definitions
-    @tailrec def traverse(stats: List[untpd.Tree])(implicit ctx: Context): (List[Tree], Context) = stats match {
+    @tailrec def traverse(stats: List[untpd.Tree])(using Context): (List[Tree], Context) = stats match {
       case (imp: untpd.Import) :: rest =>
         val imp1 = typed(imp)
         buf += imp1
-        traverse(rest)(ctx.importContext(imp, imp1.symbol))
+        traverse(rest)(using ctx.importContext(imp, imp1.symbol))
       case (mdef: untpd.DefTree) :: rest =>
         mdef.removeAttachment(ExpandedTree) match {
           case Some(xtree) =>
@@ -2389,7 +2393,7 @@ class Typer extends Namer
           // no attachment can happen in case of cyclic references
         traverse(rest)
       case stat :: rest =>
-        val stat1 = typed(stat)(ctx.exprContext(stat, exprOwner))
+        val stat1 = typed(stat)(using ctx.exprContext(stat, exprOwner))
         checkStatementPurity(stat1)(stat, exprOwner)
         buf += stat1
         traverse(rest)(using stat1.nullableContext)
@@ -2400,7 +2404,7 @@ class Typer extends Namer
       val exprOwnerOpt = if (exprOwner == ctx.owner) None else Some(exprOwner)
       ctx.withProperty(ExprOwner, exprOwnerOpt)
     }
-    def finalize(stat: Tree)(implicit ctx: Context): Tree = stat match {
+    def finalize(stat: Tree)(using Context): Tree = stat match {
       case stat: TypeDef if stat.symbol.is(Module) =>
         for (enumContext <- enumContexts.get(stat.symbol.linkedClass))
           checkEnumCaseRefsLegal(stat, enumContext)
@@ -2411,7 +2415,7 @@ class Typer extends Namer
       case _ =>
         stat
     }
-    val (stats0, finalCtx) = traverse(stats)(localCtx)
+    val (stats0, finalCtx) = traverse(stats)(using localCtx)
     val stats1 = stats0.mapConserve(finalize)
     if (ctx.owner == exprOwner) checkNoAlphaConflict(stats1)
     (stats1, finalCtx)
@@ -2421,7 +2425,7 @@ class Typer extends Namer
    *  returns whether the adaption took place. An adaption only takes place if the
    *  DefTree has a symbol and it has not been completed (is not forward referenced).
    */
-  def adaptCreationContext(mdef: untpd.DefTree)(implicit ctx: Context): Boolean =
+  def adaptCreationContext(mdef: untpd.DefTree)(using Context): Boolean =
     // Keep preceding not null facts in the current context only if `mdef`
     // cannot be executed out-of-sequence.
     // We have to check the Completer of symbol befor typedValDef,
@@ -2450,18 +2454,18 @@ class Typer extends Namer
    *  is retained, add a method to record the retained version of the body.
    *  Overwritten in Retyper to return `mdef` unchanged.
    */
-  protected def inlineExpansion(mdef: DefDef)(implicit ctx: Context): List[Tree] =
+  protected def inlineExpansion(mdef: DefDef)(using Context): List[Tree] =
     tpd.cpy.DefDef(mdef)(rhs = Inliner.bodyToInline(mdef.symbol))
     :: (if mdef.symbol.isRetainedInlineMethod then Inliner.bodyRetainer(mdef) :: Nil else Nil)
 
-  def typedExpr(tree: untpd.Tree, pt: Type = WildcardType)(implicit ctx: Context): Tree =
-    typed(tree, pt)(ctx retractMode Mode.PatternOrTypeBits)
-  def typedType(tree: untpd.Tree, pt: Type = WildcardType)(implicit ctx: Context): Tree = // todo: retract mode between Type and Pattern?
-    typed(tree, pt)(ctx addMode Mode.Type)
-  def typedPattern(tree: untpd.Tree, selType: Type = WildcardType)(implicit ctx: Context): Tree =
-    typed(tree, selType)(ctx addMode Mode.Pattern)
+  def typedExpr(tree: untpd.Tree, pt: Type = WildcardType)(using Context): Tree =
+    typed(tree, pt)(using ctx.retractMode(Mode.PatternOrTypeBits))
+  def typedType(tree: untpd.Tree, pt: Type = WildcardType)(using Context): Tree = // todo: retract mode between Type and Pattern?
+    typed(tree, pt)(using ctx.addMode(Mode.Type))
+  def typedPattern(tree: untpd.Tree, selType: Type = WildcardType)(using Context): Tree =
+    typed(tree, selType)(using ctx.addMode(Mode.Pattern))
 
-  def tryEither[T](op: Context ?=> T)(fallBack: (T, TyperState) => T)(implicit ctx: Context): T = {
+  def tryEither[T](op: Context ?=> T)(fallBack: (T, TyperState) => T)(using Context): T = {
     val nestedCtx = ctx.fresh.setNewTyperState()
     val result = op(using nestedCtx)
     if (nestedCtx.reporter.hasErrors && !nestedCtx.reporter.hasStickyErrors) {
@@ -2478,7 +2482,7 @@ class Typer extends Namer
   /** Try `op1`, if there are errors, try `op2`, if `op2` also causes errors, fall back
    *  to errors and result of `op1`.
    */
-  def tryAlternatively[T](op1: Context ?=> T)(op2: Context ?=> T)(implicit ctx: Context): T =
+  def tryAlternatively[T](op1: Context ?=> T)(op2: Context ?=> T)(using Context): T =
     tryEither(op1) { (failedVal, failedState) =>
       tryEither(op2) { (_, _) =>
         failedState.commit()
@@ -2487,7 +2491,7 @@ class Typer extends Namer
     }
 
   /** Is `pt` a prototype of an `apply` selection, or a parameterless function yielding one? */
-  def isApplyProto(pt: Type)(implicit ctx: Context): Boolean = pt.revealIgnored match {
+  def isApplyProto(pt: Type)(using Context): Boolean = pt.revealIgnored match {
     case pt: SelectionProto => pt.name == nme.apply
     case pt: FunProto       => pt.args.isEmpty && isApplyProto(pt.resultType)
     case _                  => false
@@ -2500,7 +2504,7 @@ class Typer extends Namer
    *  is more efficient since it re-uses the prefix `p` in typed form.
    */
   def tryNew[T >: Untyped <: Type]
-    (treesInst: Instance[T])(tree: Trees.Tree[T], pt: Type, fallBack: TyperState => Tree)(implicit ctx: Context): Tree = {
+    (treesInst: Instance[T])(tree: Trees.Tree[T], pt: Type, fallBack: TyperState => Tree)(using Context): Tree = {
 
     def tryWithType(tpt: untpd.Tree): Tree =
       tryEither {
@@ -2563,7 +2567,7 @@ class Typer extends Namer
    *  if an apply insertion was tried and `tree` has an `apply` method, or continues
    *  with `fallBack` otherwise. `fallBack` is supposed to always give an error.
    */
-  def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType, locked: TypeVars)(fallBack: => Tree)(implicit ctx: Context): Tree = {
+  def tryInsertApplyOrImplicit(tree: Tree, pt: ProtoType, locked: TypeVars)(fallBack: => Tree)(using Context): Tree = {
     def isMethod(tree: Tree) = tree.tpe match {
       case ref: TermRef => ref.denot.alternatives.forall(_.info.widen.isInstanceOf[MethodicType])
       case _ => false
@@ -2574,7 +2578,7 @@ class Typer extends Namer
       case _ => false
     }
 
-    def tryApply(implicit ctx: Context) = {
+    def tryApply(using Context) = {
       val pt1 = pt.withContext(ctx)
       val sel = typedSelect(untpd.Select(untpd.TypedSplice(tree), nme.apply), pt1)
         .withAttachment(InsertedApply, ())
@@ -2614,7 +2618,7 @@ class Typer extends Namer
   /** If this tree is a select node `qual.name`, try to insert an implicit conversion
    *  `c` around `qual` so that `c(qual).name` conforms to `pt`.
    */
-  def tryInsertImplicitOnQualifier(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): Option[Tree] = trace(i"try insert impl on qualifier $tree $pt") {
+  def tryInsertImplicitOnQualifier(tree: Tree, pt: Type, locked: TypeVars)(using Context): Option[Tree] = trace(i"try insert impl on qualifier $tree $pt") {
     tree match {
       case Select(qual, name) if name != nme.CONSTRUCTOR =>
         val qualProto = SelectionProto(name, pt, NoViewsAllowed, privateOK = false)
@@ -2663,21 +2667,21 @@ class Typer extends Namer
    *  If all this fails, error
    *  Parameters as for `typedUnadapted`.
    */
-  def adapt(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): Tree =
+  def adapt(tree: Tree, pt: Type, locked: TypeVars)(using Context): Tree =
     trace(i"adapting $tree to $pt", typr, show = true) {
       record("adapt")
       adapt1(tree, pt, locked)
     }
 
-  final def adapt(tree: Tree, pt: Type)(implicit ctx: Context): Tree =
+  final def adapt(tree: Tree, pt: Type)(using Context): Tree =
     adapt(tree, pt, ctx.typerState.ownedVars)
 
-  private def adapt1(tree: Tree, pt: Type, locked: TypeVars)(implicit ctx: Context): Tree = {
+  private def adapt1(tree: Tree, pt: Type, locked: TypeVars)(using Context): Tree = {
     assert(pt.exists && !pt.isInstanceOf[ExprType] || ctx.reporter.errorsReported)
     def methodStr = err.refStr(methPart(tree).tpe)
 
-    def readapt(tree: Tree)(implicit ctx: Context) = adapt(tree, pt, locked)
-    def readaptSimplified(tree: Tree)(implicit ctx: Context) = readapt(simplify(tree, pt, locked))
+    def readapt(tree: Tree)(using Context) = adapt(tree, pt, locked)
+    def readaptSimplified(tree: Tree)(using Context) = readapt(simplify(tree, pt, locked))
 
     def missingArgs(mt: MethodType) = {
       val meth = methPart(tree).symbol
@@ -2781,7 +2785,7 @@ class Typer extends Namer
 
       def dummyArg(tp: Type) = untpd.Ident(nme.???).withTypeUnchecked(tp)
 
-      def addImplicitArgs(implicit ctx: Context) = {
+      def addImplicitArgs(using Context) = {
         def implicitArgs(formals: List[Type], argIndex: Int, pt: Type): List[Tree] = formals match {
           case Nil => Nil
           case formal :: formals1 =>
@@ -2875,7 +2879,7 @@ class Typer extends Namer
           // See for instance #7119.
           tree
         case _ =>
-          addImplicitArgs(argCtx(tree))
+          addImplicitArgs(using argCtx(tree))
       }
     }
 
@@ -3097,7 +3101,7 @@ class Typer extends Namer
      *  $i is a skolem of type `scala.internal.TypeBox`, and `CAP` is its
      *  type member. See the documentation of `TypeBox` for a rationale why we do this.
      */
-    def captureWildcards(tp: Type)(implicit ctx: Context): Type = tp match {
+    def captureWildcards(tp: Type)(using Context): Type = tp match {
       case tp: AndOrType => tp.derivedAndOrType(captureWildcards(tp.tp1), captureWildcards(tp.tp2))
       case tp: RefinedType => tp.derivedRefinedType(captureWildcards(tp.parent), tp.refinedName, tp.refinedInfo)
       case tp: RecType => tp.derivedRecType(captureWildcards(tp.parent))
@@ -3162,7 +3166,7 @@ class Typer extends Namer
       // try an extension method in scope
       pt match {
         case SelectionProto(name, mbrType, _, _) =>
-          def tryExtension(implicit ctx: Context): Tree =
+          def tryExtension(using Context): Tree =
             try
               findRef(name, WildcardType, ExtensionMethod, tree.posd) match {
                 case ref: TermRef =>
@@ -3173,7 +3177,7 @@ class Typer extends Namer
               case ex: TypeError => errorTree(tree, ex, tree.sourcePos)
             }
           val nestedCtx = ctx.fresh.setNewTyperState()
-          val app = tryExtension(nestedCtx)
+          val app = tryExtension(using nestedCtx)
           if (!app.isEmpty && !nestedCtx.reporter.hasErrors) {
             nestedCtx.typerState.commit()
             return ExtMethodApply(app)
@@ -3195,7 +3199,7 @@ class Typer extends Namer
             found // nothing to check or adapt for extension method applications
           case SearchSuccess(found, _, _) =>
             checkImplicitConversionUseOK(found.symbol, tree.posd)
-            readapt(found)(ctx.retractMode(Mode.ImplicitsEnabled))
+            readapt(found)(using ctx.retractMode(Mode.ImplicitsEnabled))
           case failure: SearchFailure =>
             if (pt.isInstanceOf[ProtoType] && !failure.isAmbiguous) {
               // don't report the failure but return the tree unchanged. This
@@ -3297,7 +3301,7 @@ class Typer extends Namer
    *  with old-style context functions.
    *  Overridden in `ReTyper`, where all applications are treated the same
    */
-  protected def matchingApply(methType: MethodOrPoly, pt: FunProto)(implicit ctx: Context): Boolean =
+  protected def matchingApply(methType: MethodOrPoly, pt: FunProto)(using Context): Boolean =
     methType.isContextualMethod == pt.isUsingApply ||
     methType.isImplicitMethod && pt.isUsingApply // for a transition allow `with` arguments for regular implicit parameters
 
@@ -3307,7 +3311,7 @@ class Typer extends Namer
    *
    *  Overwritten to no-op in ReTyper.
    */
-  protected def checkEqualityEvidence(tree: tpd.Tree, pt: Type)(implicit ctx: Context) : Unit =
+  protected def checkEqualityEvidence(tree: tpd.Tree, pt: Type)(using Context) : Unit =
     tree match {
       case _: RefTree | _: Literal
         if !isVarPattern(tree) &&
@@ -3321,7 +3325,7 @@ class Typer extends Namer
       case _ =>
     }
 
-  private def checkStatementPurity(tree: tpd.Tree)(original: untpd.Tree, exprOwner: Symbol)(implicit ctx: Context): Unit =
+  private def checkStatementPurity(tree: tpd.Tree)(original: untpd.Tree, exprOwner: Symbol)(using Context): Unit =
     if (!tree.tpe.isErroneous && !ctx.isAfterTyper && isPureExpr(tree) &&
         !tree.tpe.isRef(defn.UnitClass) && !isSelfOrSuperConstrCall(tree))
       ctx.warning(PureExpressionInStatementPosition(original, exprOwner), original.sourcePos)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3286,7 +3286,7 @@ class Typer extends Namer
   }
 
   // Overridden in InlineTyper
-  def suppressInline(using ctx: Context): Boolean = ctx.isAfterTyper
+  def suppressInline(using Context): Boolean = ctx.isAfterTyper
 
   /** Does the "contextuality" of the method type `methType` match the one of the prototype `pt`?
    *  This is the case if

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -18,14 +18,14 @@ import reporting.trace
  */
 object VarianceChecker {
   case class VarianceError(tvar: Symbol, required: Variance)
-  def check(tree: tpd.Tree)(implicit ctx: Context): Unit =
-    new VarianceChecker()(ctx).Traverser.traverse(tree)
+  def check(tree: tpd.Tree)(using Context): Unit =
+    new VarianceChecker(using ctx).Traverser.traverse(tree)
 
   /** Check that variances of type lambda correspond to their occurrences in its body.
    *  Note: this is achieved by a mechanism separate from checking class type parameters.
    *  Question: Can the two mechanisms be combined in one?
    */
-  def checkLambda(tree: tpd.LambdaTypeTree, bounds: TypeBounds)(implicit ctx: Context): Unit =
+  def checkLambda(tree: tpd.LambdaTypeTree, bounds: TypeBounds)(using Context): Unit =
     def checkType(tpe: Type): Unit = tpe match
       case tl: HKTypeLambda if tl.isDeclaredVarianceLambda =>
         val checkOK = new TypeAccumulator[Boolean] {
@@ -72,7 +72,7 @@ object VarianceChecker {
     else "invariant"
 }
 
-class VarianceChecker()(implicit ctx: Context) {
+class VarianceChecker(using Context) {
   import VarianceChecker._
   import tpd._
 
@@ -179,7 +179,7 @@ class VarianceChecker()(implicit ctx: Context) {
       case None =>
     }
 
-    override def traverse(tree: Tree)(implicit ctx: Context) = {
+    override def traverse(tree: Tree)(using Context) = {
       def sym = tree.symbol
       // No variance check for private/protected[this] methods/values.
       def skip = !sym.exists

--- a/compiler/src/dotty/tools/repl/ReplFrontEnd.scala
+++ b/compiler/src/dotty/tools/repl/ReplFrontEnd.scala
@@ -19,8 +19,8 @@ private[repl] class REPLFrontEnd extends FrontEnd {
     assert(units.size == 1) // REPl runs one compilation unit at a time
 
     val unitContext = ctx.fresh.setCompilationUnit(units.head)
-    enterSyms(unitContext)
-    typeCheck(unitContext)
+    enterSyms(using unitContext)
+    typeCheck(using unitContext)
     List(unitContext.compilationUnit)
   }
 }

--- a/compiler/test/dotty/tools/AnnotationsTests.scala
+++ b/compiler/test/dotty/tools/AnnotationsTests.scala
@@ -20,7 +20,6 @@ class AnnotationsTest:
       VirtualJavaSource("A.java",
         "@Annot(values = {}) public class A {}")) { javaOutputDir =>
       inCompilerContext(javaOutputDir.toString + File.pathSeparator + TestConfiguration.basicClasspath) {
-        (using ctx: Context) =>
         val defn = ctx.definitions
         val cls = ctx.requiredClass("A")
         val annotCls = ctx.requiredClass("Annot")

--- a/compiler/test/dotty/tools/AnnotationsTests.scala
+++ b/compiler/test/dotty/tools/AnnotationsTests.scala
@@ -19,7 +19,7 @@ class AnnotationsTest:
         "public @interface Annot { String[] values() default {}; }"),
       VirtualJavaSource("A.java",
         "@Annot(values = {}) public class A {}")) { javaOutputDir =>
-      withCompilerContext(javaOutputDir.toString + File.pathSeparator + TestConfiguration.basicClasspath) {
+      inCompilerContext(javaOutputDir.toString + File.pathSeparator + TestConfiguration.basicClasspath) {
         (using ctx: Context) =>
         val defn = ctx.definitions
         val cls = ctx.requiredClass("A")

--- a/compiler/test/dotty/tools/AnnotationsTests.scala
+++ b/compiler/test/dotty/tools/AnnotationsTests.scala
@@ -19,7 +19,7 @@ class AnnotationsTest:
         "public @interface Annot { String[] values() default {}; }"),
       VirtualJavaSource("A.java",
         "@Annot(values = {}) public class A {}")) { javaOutputDir =>
-      withContext(javaOutputDir.toString + File.pathSeparator + TestConfiguration.basicClasspath) {
+      withCompilerContext(javaOutputDir.toString + File.pathSeparator + TestConfiguration.basicClasspath) {
         (using ctx: Context) =>
         val defn = ctx.definitions
         val cls = ctx.requiredClass("A")

--- a/compiler/test/dotty/tools/compilerSupport.scala
+++ b/compiler/test/dotty/tools/compilerSupport.scala
@@ -13,7 +13,7 @@ import dotc.core.Comments.{ContextDoc, ContextDocstrings}
 /** Initialize a compiler context with the given classpath and
  *  pass it to `op`.
  */
-def withContext[T](classpath: String)(op: Context ?=> T): T =
+def withCompilerContext[T](classpath: String)(op: Context ?=> T): T =
   val compiler = Compiler()
   val run = compiler.newRun(initCtx(classpath))
   run.compileUnits(Nil) // Initialize phases

--- a/compiler/test/dotty/tools/compilerSupport.scala
+++ b/compiler/test/dotty/tools/compilerSupport.scala
@@ -13,7 +13,7 @@ import dotc.core.Comments.{ContextDoc, ContextDocstrings}
 /** Initialize a compiler context with the given classpath and
  *  pass it to `op`.
  */
-def withCompilerContext[T](classpath: String)(op: Context ?=> T): T =
+def inCompilerContext[T](classpath: String)(op: Context ?=> T): T =
   val compiler = Compiler()
   val run = compiler.newRun(initCtx(classpath))
   run.compileUnits(Nil) // Initialize phases

--- a/doc-tool/src/dotty/tools/dottydoc/util/syntax.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/util/syntax.scala
@@ -3,7 +3,7 @@ package dottydoc
 package util
 
 import dotc.core.Contexts.Context
-import dotc.core.Comments._
+import dotc.core.Comments.{_, given _}
 import model.Package
 import core.ContextDottydoc
 import dotc.core.Symbols._

--- a/tests/run/given-var.scala
+++ b/tests/run/given-var.scala
@@ -1,0 +1,12 @@
+// Demonstrates that monomorphic givens are cached
+object a:
+  private var x = 1
+  given Int = x
+  def init(x: Int) = this.x = x
+  def cur = summon[Int]
+
+@main def Test =
+  a.init(1)
+  assert(a.cur == 1)
+  a.init(2)
+  assert(a.cur == 1)


### PR DESCRIPTION
The new way we organize context passing has one downside. We start with `(using Context)`
because it is less cluttered, but then if in the body we have to refer to the current
context we go back to `(using ctx: Context)`. I have also seen occurrences of `(using ctx: Context)`
without an actual usage of `ctx` in the body.

This going back and forth is awkward. Fortunately, there's an alternative: `Contexts` contains
a method `curCtx` which summons the current context. We should always use `curCtx` instead of
`ctx`, which means we never need to write `(using ctx: Context)`.

Or maybe we can even go back renaming `curCtx` to `ctx`? Then we could simply drop all `ctx` names
in parameters and hopefully get the same meaning and performance.