### PR TITLE
Cleanup inlined positions implementation 

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1957,7 +1957,7 @@ final class SearchRoot extends SearchHistory {
             // Substitute dictionary references into dictionary entry RHSs
             val rhsMap = new TreeTypeMap(treeMap = {
               case id: Ident if vsymMap.contains(id.symbol) =>
-                tpd.ref(vsymMap(id.symbol))
+                tpd.ref(vsymMap(id.symbol))(ctx.withSource(id.source)).withSpan(id.span)
               case tree => tree
             })
             val nrhss = rhss.map(rhsMap(_))
@@ -1981,7 +1981,7 @@ final class SearchRoot extends SearchHistory {
 
             val res = resMap(tree)
 
-            val blk = Inliner.reposition(Block(classDef :: inst :: Nil, res), span)
+            val blk = Block(classDef :: inst :: Nil, res).withSpan(span)
 
             success.copy(tree = blk)(success.tstate, success.gstate)
           }

--- a/library/src/scala/internal/quoted/Matcher.scala
+++ b/library/src/scala/internal/quoted/Matcher.scala
@@ -24,7 +24,7 @@ private[quoted] object Matcher {
      */
     private type Env = Map[Symbol, Symbol]
 
-    inline private def withEnv[T](env: Env)(body: => Env ?=> T): T = body(using env)
+    inline private def withEnv[T](env: Env)(inline body: Env ?=> T): T = body(using env)
 
     class SymBinding(val sym: Symbol, val fromAbove: Boolean)
 


### PR DESCRIPTION
Trees now have sources that can be used directly without the need of `enclosingInlineds`
to track the current source. This new implemetation simply uses the tree positions
directly and does not need to keep the context in sync with the `enclosingInlineds`.