### PR TITLE
sbt-dotty: Use default dependency resolution, release 0.4.1

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -103,10 +103,11 @@ final case class SbtCommunityProject(
   override val runCommandsArgs: List[String] =
     // Run the sbt command with the compiler version and sbt plugin set in the build
     val sbtProps = Option(System.getProperty("sbt.ivy.home")) match
-      case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome", "-Dsbt.supershell=false")
+      case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
     extraSbtArgs ++ sbtProps ++ List(
       "-sbt-version", "1.3.8",
+       "-Dsbt.supershell=false",
       s"--addPluginSbtFile=$sbtPluginFilePath")
 
 object projects:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -65,7 +65,7 @@ object Build {
   val referenceVersion = "0.24.0-bin-20200325-37eec14-NIGHTLY"
 
   val baseVersion = "0.24.0"
-  val baseSbtDottyVersion = "0.4.0"
+  val baseSbtDottyVersion = "0.4.1"
 
   // Versions used by the vscode extension to create a new project
   // This should be the latest published releases.

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -405,15 +405,10 @@ object DottyPlugin extends AutoPlugin {
 
   /** Create a scalaInstance task that uses Dotty based on `moduleName`. */
   def dottyScalaInstanceTask(moduleName: String): Initialize[Task[ScalaInstance]] = Def.task {
-    val ivyConfig0 = Classpaths.mkIvyConfiguration.value
-    // When compiling non-bootstrapped projects in the build of Dotty itself,
-    // dependency resolution might pick a local project which is not what we
-    // want. We avoid this by dropping the inter-project resolver.
-    val ivyConfig1 = ivyConfig0.withResolvers(ivyConfig0.resolvers.filter(_.name != "inter-project"))
     val updateReport =
       fetchArtifactsOf(
         scalaOrganization.value %% moduleName % scalaVersion.value,
-        ivy.IvyDependencyResolution(ivyConfig1),
+        dependencyResolution.value,
         scalaModuleInfo.value,
         updateConfiguration.value,
         (unresolvedWarningConfiguration in update).value,


### PR DESCRIPTION
@anatoliykmetyuk With drone I was able to release a new sbt-dotty version by running `rone build promote lampepfl/dotty NNNN sbt_release`, how do I do that with github-release ? (Switching to making a release when a special tag like `sbt-dotty-v...` is pushed would be fine too)