### PR TITLE
Rename ctx values

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -69,7 +69,7 @@ object GenBCode {
   val name: String = "genBCode"
 }
 
-class GenBCodePipeline(val int: DottyBackendInterface)(implicit val ctx: Context) extends BCodeSyncAndTry {
+class GenBCodePipeline(val int: DottyBackendInterface)(implicit ctx: Context) extends BCodeSyncAndTry {
 
   private var tree: Tree = _
 

--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -64,17 +64,17 @@ class Driver {
   protected def sourcesRequired: Boolean = true
 
   def setup(args: Array[String], rootCtx: Context): (List[String], Context) = {
-    val ctx = rootCtx.fresh
-    val summary = CompilerCommand.distill(args)(ctx)
-    ctx.setSettings(summary.sstate)
-    MacroClassLoader.init(ctx)
-    Positioned.updateDebugPos(ctx)
+    val ictx = rootCtx.fresh
+    val summary = CompilerCommand.distill(args)(ictx)
+    ictx.setSettings(summary.sstate)
+    MacroClassLoader.init(ictx)
+    Positioned.updateDebugPos(ictx)
 
-    if (!ctx.settings.YdropComments.value(ctx) || ctx.mode.is(Mode.ReadComments))
-      ctx.setProperty(ContextDoc, new ContextDocstrings)
+    if (!ictx.settings.YdropComments.value(ictx) || ictx.mode.is(Mode.ReadComments))
+      ictx.setProperty(ContextDoc, new ContextDocstrings)
 
-    val fileNames = CompilerCommand.checkUsage(summary, sourcesRequired)(ctx)
-    fromTastySetup(fileNames, ctx)
+    val fileNames = CompilerCommand.checkUsage(summary, sourcesRequired)(ictx)
+    fromTastySetup(fileNames, ictx)
   }
 
   /** Setup extra classpath and figure out class names for tasty file inputs */

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -69,10 +69,8 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   private var myCtx = rootContext(ictx)
 
   /** The context created for this run */
-  def runContext: Context = myCtx
-
-  protected implicit def ctx: Context = myCtx
-  assert(ctx.runId <= Periods.MaxPossibleRunId)
+  given runContext[Dummy_so_its_a_def] as Context = myCtx
+  assert(runContext.runId <= Periods.MaxPossibleRunId)
 
   private var myUnits: List[CompilationUnit] = _
   private var myUnitsCached: List[CompilationUnit] = _
@@ -108,12 +106,12 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   private var finalizeActions = mutable.ListBuffer[() => Unit]()
 
   def compile(fileNames: List[String]): Unit = try {
-    val sources = fileNames.map(ctx.getSource(_))
+    val sources = fileNames.map(runContext.getSource(_))
     compileSources(sources)
   }
   catch {
     case NonFatal(ex) =>
-      ctx.echo(i"exception occurred while compiling $units%, %")
+      runContext.echo(i"exception occurred while compiling $units%, %")
       throw ex
   }
 
@@ -266,7 +264,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   /** Print summary; return # of errors encountered */
   def printSummary(): Unit = {
     printMaxConstraint()
-    val r = ctx.reporter
+    val r = runContext.reporter
     r.printSummary
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -112,7 +112,7 @@ object desugar {
         val originalOwner = sym.owner
         def apply(tp: Type) = tp match {
           case tp: NamedType if tp.symbol.exists && (tp.symbol.owner eq originalOwner) =>
-            val defctx = this.ctx.outersIterator.dropWhile(_.scope eq this.ctx.scope).next()
+            val defctx = mapCtx.outersIterator.dropWhile(_.scope eq mapCtx.scope).next()
             var local = defctx.denotNamed(tp.name).suchThat(_.isParamOrAccessor).symbol
             if (local.exists) (defctx.owner.thisType select local).dealiasKeepAnnots
             else {

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -84,7 +84,7 @@ object Contexts {
        with Plugins
        with Cloneable { thiscontext =>
 
-    implicit def ctx: Context = this
+    implicit def thisContext: Context = this
 
     /** All outer contexts, ending in `base.initialCtx` and then `NoContext` */
     def outersIterator: Iterator[Context] = new Iterator[Context] {
@@ -284,10 +284,10 @@ object Contexts {
       withPhase(phase.id)
 
     final def withPhaseNoLater(phase: Phase): Context =
-      if (phase.exists && ctx.phase.id > phase.id) withPhase(phase) else ctx
+      if (phase.exists && this.phase.id > phase.id) withPhase(phase) else this
 
     final def withPhaseNoEarlier(phase: Phase): Context =
-      if (phase.exists && ctx.phase.id < phase.id) withPhase(phase) else ctx
+      if (phase.exists && this.phase.id < phase.id) withPhase(phase) else this
 
     // `creationTrace`-related code. To enable, uncomment the code below and the
     // call to `setCreationTrace()` in this file.
@@ -399,7 +399,7 @@ object Contexts {
     def exprContext(stat: Tree[? >: Untyped], exprOwner: Symbol): Context =
       if (exprOwner == this.owner) this
       else if (untpd.isSuperConstrCall(stat) && this.owner.isClass) superCallContext
-      else ctx.fresh.setOwner(exprOwner)
+      else fresh.setOwner(exprOwner)
 
     /** A new context that summarizes an import statement */
     def importContext(imp: Import[?], sym: Symbol): FreshContext = {
@@ -407,7 +407,7 @@ object Contexts {
         case ref: RefTree[?] => Some(ref.name.asTermName)
         case _               => None
       }
-      ctx.fresh.setImportInfo(ImportInfo(sym, imp.selectors, impNameOpt))
+      fresh.setImportInfo(ImportInfo(sym, imp.selectors, impNameOpt))
     }
 
     /** Does current phase use an erased types interpretation? */

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -37,7 +37,8 @@ object Definitions {
 class Definitions {
   import Definitions._
 
-  private implicit var ctx: Context = _
+  private var initCtx: Context = _
+  private given ctx[Dummy_so_its_a_def] as Context = initCtx
 
   private def newSymbol[N <: Name](owner: Symbol, name: N, flags: FlagSet, info: Type) =
     ctx.newSymbol(owner, name, flags | Permanent, info)
@@ -1427,7 +1428,7 @@ class Definitions {
   private var isInitialized = false
 
   def init()(implicit ctx: Context): Unit = {
-    this.ctx = ctx
+    this.initCtx = ctx
     if (!isInitialized) {
       // Enter all symbols from the scalaShadowing package in the scala package
       for (m <- ScalaShadowingPackage.info.decls)

--- a/compiler/src/dotty/tools/dotc/core/Periods.scala
+++ b/compiler/src/dotty/tools/dotc/core/Periods.scala
@@ -7,7 +7,7 @@ import Contexts._
  *  run ids represent compiler runs
  *  phase ids represent compiler phases
  */
-abstract class Periods { self: Context =>
+abstract class Periods { thisCtx: Context =>
   import Periods._
 
   /** The current phase identifier */
@@ -18,11 +18,11 @@ abstract class Periods { self: Context =>
 
   /** Execute `op` at given period */
   def atPeriod[T](pd: Period)(op: Context => T): T =
-    op(ctx.fresh.setPeriod(pd))
+    op(thisCtx.fresh.setPeriod(pd))
 
   /** Execute `op` at given phase id */
   def atPhase[T](pid: PhaseId)(op: Context ?=> T): T =
-    op(using ctx.withPhase(pid))
+    op(using thisCtx.withPhase(pid))
 
   /** The period containing the current period where denotations do not change.
    *  We compute this by taking as first phase the first phase less or equal to
@@ -31,19 +31,19 @@ abstract class Periods { self: Context =>
    */
   def stablePeriod: Period = {
     var first = phaseId
-    val nxTrans = ctx.base.nextDenotTransformerId(first)
-    while (first - 1 > NoPhaseId && (ctx.base.nextDenotTransformerId(first - 1) == nxTrans))
+    val nxTrans = thisCtx.base.nextDenotTransformerId(first)
+    while (first - 1 > NoPhaseId && (thisCtx.base.nextDenotTransformerId(first - 1) == nxTrans))
       first -= 1
     Period(runId, first, nxTrans)
   }
 
   /** Are all base types in the current period guaranteed to be the same as in period `p`? */
   def hasSameBaseTypesAs(p: Period): Boolean = {
-    val period = this.period
+    val period = thisCtx.period
     period == p ||
     period.runId == p.runId &&
-      this.phases(period.phaseId).sameBaseTypesStartId ==
-      this.phases(p.phaseId).sameBaseTypesStartId
+      thisCtx.phases(period.phaseId).sameBaseTypesStartId ==
+      thisCtx.phases(p.phaseId).sameBaseTypesStartId
   }
 }
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -27,7 +27,7 @@ import transform.TypeUtils._
 
 import scala.annotation.internal.sharable
 
-trait SymDenotations { this: Context =>
+trait SymDenotations { thisCtx: Context =>
   import SymDenotations._
 
   /** Factory method for SymDenotion creation. All creations
@@ -53,9 +53,9 @@ trait SymDenotations { this: Context =>
     if (denot.isOneOf(ValidForeverFlags) || denot.isRefinementClass || denot.isImport) true
     else {
       val initial = denot.initial
-      val firstPhaseId = initial.validFor.firstPhaseId.max(ctx.typerPhase.id)
-      if ((initial ne denot) || ctx.phaseId != firstPhaseId)
-        ctx.withPhase(firstPhaseId).stillValidInOwner(initial)
+      val firstPhaseId = initial.validFor.firstPhaseId.max(thisCtx.typerPhase.id)
+      if ((initial ne denot) || thisCtx.phaseId != firstPhaseId)
+        thisCtx.withPhase(firstPhaseId).stillValidInOwner(initial)
       else
         stillValidInOwner(denot)
     }
@@ -78,7 +78,7 @@ trait SymDenotations { this: Context =>
   def traceInvalid(denot: Denotation): Boolean = {
     def show(d: Denotation) = s"$d#${d.symbol.id}"
     def explain(msg: String) = {
-      println(s"${show(denot)} is invalid at ${this.period} because $msg")
+      println(s"${show(denot)} is invalid at ${thisCtx.period} because $msg")
       false
     }
     denot match {
@@ -86,7 +86,7 @@ trait SymDenotations { this: Context =>
         def explainSym(msg: String) = explain(s"$msg\ndefined = ${denot.definedPeriodsString}")
         if (denot.isOneOf(ValidForeverFlags) || denot.isRefinementClass) true
         else {
-          implicit val ctx = this
+          implicit val ctx = thisCtx
           val initial = denot.initial
           if ((initial ne denot) || ctx.phaseId != initial.validFor.firstPhaseId)
             ctx.withPhase(initial.validFor.firstPhaseId).traceInvalid(initial)
@@ -116,7 +116,7 @@ trait SymDenotations { this: Context =>
   /** Possibly accept stale symbol with warning if in IDE */
   def acceptStale(denot: SingleDenotation): Boolean =
     staleOK && {
-      ctx.debugwarn(denot.staleSymbolMsg)
+      thisCtx.debugwarn(denot.staleSymbolMsg)
       true
     }
 }

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -33,7 +33,7 @@ import scala.annotation.internal.sharable
 import config.Printers.typr
 
 /** Creation methods for symbols */
-trait Symbols { this: Context =>
+trait Symbols { thisCtx: Context =>
 
 // ---- Factory methods for symbol creation ----------------------
 //
@@ -131,7 +131,7 @@ trait Symbols { this: Context =>
   }
 
   def newRefinedClassSymbol(coord: Coord = NoCoord): ClassSymbol =
-    newCompleteClassSymbol(ctx.owner, tpnme.REFINE_CLASS, NonMember, parents = Nil, coord = coord)
+    newCompleteClassSymbol(thisCtx.owner, tpnme.REFINE_CLASS, NonMember, parents = Nil, coord = coord)
 
   /** Create a module symbol with associated module class
    *  from its non-info fields and a function producing the info
@@ -268,7 +268,7 @@ trait Symbols { this: Context =>
 
   /** Create a symbol representing a selftype declaration for class `cls`. */
   def newSelfSym(cls: ClassSymbol, name: TermName = nme.WILDCARD, selfInfo: Type = NoType): TermSymbol =
-    ctx.newSymbol(cls, name, SelfSymFlags, selfInfo orElse cls.classInfo.selfType, coord = cls.coord)
+    newSymbol(cls, name, SelfSymFlags, selfInfo orElse cls.classInfo.selfType, coord = cls.coord)
 
   /** Create new type parameters with given owner, names, and flags.
    *  @param boundsFn  A function that, given type refs to the newly created

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4811,7 +4811,7 @@ object Types {
     }
   }
 
-  abstract class TypeMap(implicit protected val ctx: Context)
+  abstract class TypeMap(implicit protected val mapCtx: Context)
   extends VariantTraversal with (Type => Type) { thisMap =>
 
     protected def stopAtStatic: Boolean = true
@@ -4858,7 +4858,7 @@ object Types {
     def mapOver(tp: Type): Type = {
       record(s"mapOver ${getClass}")
       record("mapOver total")
-      implicit val ctx = this.ctx
+      implicit val ctx = this.mapCtx
       tp match {
         case tp: NamedType =>
           if (stopAtStatic && tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
@@ -4968,7 +4968,7 @@ object Types {
 
     private def treeTypeMap = new TreeTypeMap(typeMap = this)
 
-    def mapOver(syms: List[Symbol]): List[Symbol] = ctx.mapSymbols(syms, treeTypeMap)
+    def mapOver(syms: List[Symbol]): List[Symbol] = mapCtx.mapSymbols(syms, treeTypeMap)
 
     def mapOver(scope: Scope): Scope = {
       val elems = scope.toList
@@ -5271,7 +5271,7 @@ object Types {
 
   // ----- TypeAccumulators ----------------------------------------------------
 
-  abstract class TypeAccumulator[T](implicit protected val ctx: Context)
+  abstract class TypeAccumulator[T](implicit protected val accCtx: Context)
   extends VariantTraversal with ((T, Type) => T) {
 
     protected def stopAtStatic: Boolean = true

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -15,7 +15,11 @@ import scala.util.control.NonFatal
 import scala.annotation.switch
 
 class PlainPrinter(_ctx: Context) extends Printer {
+  /** The context of all public methods in Printer and subclasses.
+   *  Overridden in RefinedPrinter.
+   */
   protected implicit def ctx: Context = _ctx.addMode(Mode.Printing)
+
   protected def printDebug = ctx.settings.YprintDebug.value
 
   private var openRecs: List[RecType] = Nil

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -714,12 +714,12 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   }
 
   /** Print modifiers from symbols if tree has type, overriding the untpd behavior. */
-  implicit def modsDeco(mdef: untpd.DefTree)(implicit ctx: Context): untpd.ModsDecorator =
+  private implicit def modsDeco(mdef: untpd.DefTree): untpd.ModsDecorator =
     new untpd.ModsDecorator {
       def mods = if (mdef.hasType) Modifiers(mdef.symbol) else mdef.rawMods
     }
 
-  def Modifiers(sym: Symbol)(implicit ctx: Context): Modifiers = untpd.Modifiers(
+  private def Modifiers(sym: Symbol): Modifiers = untpd.Modifiers(
     sym.flags & (if (sym.isType) ModifierFlags | VarianceFlags else ModifierFlags),
     if (sym.privateWithin.exists) sym.privateWithin.asType.name else tpnme.EMPTY,
     sym.annotations.filterNot(ann => dropAnnotForModText(ann.symbol)).map(_.tree))

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -250,13 +250,13 @@ object messages {
     // these are usually easier to analyze.
     object reported extends TypeMap:
       def setVariance(v: Int) = variance = v
-      val constraint = this.ctx.typerState.constraint
+      val constraint = mapCtx.typerState.constraint
       def apply(tp: Type): Type = tp match
         case tp: TypeParamRef =>
           constraint.entry(tp) match
             case bounds: TypeBounds =>
-              if variance < 0 then apply(this.ctx.typeComparer.fullUpperBound(tp))
-              else if variance > 0 then apply(this.ctx.typeComparer.fullLowerBound(tp))
+              if variance < 0 then apply(mapCtx.typeComparer.fullUpperBound(tp))
+              else if variance > 0 then apply(mapCtx.typeComparer.fullLowerBound(tp))
               else tp
             case NoType => tp
             case instType => apply(instType)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2099,7 +2099,7 @@ object messages {
            |This mechanism is used for instance in pattern ${hl("case List(x1, ..., xn)")}""".stripMargin
   }
 
-  class MemberWithSameNameAsStatic()(implicit val ctx: Context)
+  class MemberWithSameNameAsStatic()(using ctx: Context)
     extends SyntaxMsg(MemberWithSameNameAsStaticID) {
     def msg = em"Companion classes cannot define members with same name as a ${hl("@static")} member"
     def explain = ""
@@ -2114,25 +2114,25 @@ object messages {
           |It can be removed without changing the semantics of the program. This may indicate an error.""".stripMargin
   }
 
-  class TraitCompanionWithMutableStatic()(implicit val ctx: Context)
+  class TraitCompanionWithMutableStatic()(using ctx: Context)
     extends SyntaxMsg(TraitCompanionWithMutableStaticID) {
     def msg = em"Companion of traits cannot define mutable @static fields"
     def explain = ""
   }
 
-  class LazyStaticField()(implicit val ctx: Context)
+  class LazyStaticField()(using ctx: Context)
     extends SyntaxMsg(LazyStaticFieldID) {
     def msg = em"Lazy @static fields are not supported"
     def explain = ""
   }
 
-  class StaticOverridingNonStaticMembers()(implicit val ctx: Context)
+  class StaticOverridingNonStaticMembers()(using ctx: Context)
     extends SyntaxMsg(StaticOverridingNonStaticMembersID) {
     def msg = em"${hl("@static")} members cannot override or implement non-static ones"
     def explain = ""
   }
 
-  class OverloadInRefinement(rsym: Symbol)(implicit val ctx: Context)
+  class OverloadInRefinement(rsym: Symbol)(using ctx: Context)
     extends DeclarationMsg(OverloadInRefinementID) {
     def msg = "Refinements cannot introduce overloaded definitions"
     def explain =
@@ -2141,14 +2141,14 @@ object messages {
   }
 
   class NoMatchingOverload(val alternatives: List[SingleDenotation], pt: Type)(
-    err: Errors)(implicit val ctx: Context)
+    err: Errors)(using ctx: Context)
     extends TypeMismatchMsg(NoMatchingOverloadID) {
     def msg =
       em"""None of the ${err.overloadedAltsStr(alternatives)}
           |match ${err.expectedTypeStr(pt)}"""
     def explain = ""
   }
-  class StableIdentPattern(tree: untpd.Tree, pt: Type)(implicit val ctx: Context)
+  class StableIdentPattern(tree: untpd.Tree, pt: Type)(using ctx: Context)
     extends TypeMsg(StableIdentPatternID) {
     def msg =
       em"""Stable identifier required, but $tree found"""
@@ -2157,7 +2157,7 @@ object messages {
 
   class IllegalSuperAccessor(base: Symbol, memberName: Name,
       acc: Symbol, accTp: Type,
-      other: Symbol, otherTp: Type)(implicit val ctx: Context) extends DeclarationMsg(IllegalSuperAccessorID) {
+      other: Symbol, otherTp: Type)(using ctx: Context) extends DeclarationMsg(IllegalSuperAccessorID) {
     def msg = {
       // The mixin containing a super-call that requires a super-accessor
       val accMixin = acc.owner
@@ -2210,7 +2210,7 @@ object messages {
     def explain = ""
   }
 
-  class TraitParameterUsedAsParentPrefix(cls: Symbol)(implicit val ctx: Context)
+  class TraitParameterUsedAsParentPrefix(cls: Symbol)(using ctx: Context)
     extends DeclarationMsg(TraitParameterUsedAsParentPrefixID) {
     def msg =
       s"${cls.show} cannot extend from a parent that is derived via its own parameters"
@@ -2225,7 +2225,7 @@ object messages {
           |""".stripMargin
   }
 
-  class UnknownNamedEnclosingClassOrObject(name: TypeName)(implicit val ctx: Context)
+  class UnknownNamedEnclosingClassOrObject(name: TypeName)(using ctx: Context)
     extends ReferenceMsg(UnknownNamedEnclosingClassOrObjectID) {
     def msg =
       em"""no enclosing class or object is named '${hl(name.show)}'"""
@@ -2238,13 +2238,13 @@ object messages {
       """.stripMargin
     }
 
-  class IllegalCyclicTypeReference(sym: Symbol, where: String, lastChecked: Type)(implicit val ctx: Context)
+  class IllegalCyclicTypeReference(sym: Symbol, where: String, lastChecked: Type)(using ctx: Context)
     extends CyclicMsg(IllegalCyclicTypeReferenceID) {
     def msg = i"illegal cyclic type reference: ${where} ${hl(lastChecked.show)} of $sym refers back to the type itself"
     def explain = ""
   }
 
-  class ErasedTypesCanOnlyBeFunctionTypes()(implicit val ctx: Context)
+  class ErasedTypesCanOnlyBeFunctionTypes()(using ctx: Context)
     extends SyntaxMsg(ErasedTypesCanOnlyBeFunctionTypesID) {
     def msg = "Types with erased keyword can only be function types `(erased ...) => ...`"
     def explain = ""

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -124,7 +124,7 @@ class ExtractAPI extends Phase {
  *  without going through an intermediate representation, see
  *  http://www.scala-sbt.org/0.13/docs/Understanding-Recompilation.html#Hashing+an+API+representation
  */
-private class ExtractAPICollector(implicit val ctx: Context) extends ThunkHolder {
+private class ExtractAPICollector(implicit ctx: Context) extends ThunkHolder {
   import tpd._
   import xsbti.api
 

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -346,6 +346,7 @@ object ExplicitOuter {
    *     no later than erasure.
    */
   class OuterOps(val ictx: Context) extends AnyVal {
+    /** The context of all operations of this class */
     private implicit def ctx: Context = ictx
 
     /** If `cls` has an outer parameter add one to the method type `tp`. */

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -138,7 +138,7 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
       tp match {
         case tp: TypeRef if tp.symbol.isSplice =>
           if (tp.isTerm)
-            this.ctx.error(i"splice outside quotes", pos)
+            mapCtx.error(i"splice outside quotes", pos)
           if level > 0 then getQuoteTypeTags.getTagRef(tp.prefix.asInstanceOf[TermRef])
           else tp
         case tp: TypeRef if tp.symbol == defn.QuotedTypeClass.typeParams.head =>

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -510,7 +510,7 @@ trait ImplicitRunInfo {
      *  opaque type aliases, and abstract types, but not type parameters or package objects.
      */
     def isAnchor(sym: Symbol) =
-      sym.isClass && !sym.is(Package) && (!sym.isPackageObject || ctx.scala2CompatMode)
+      sym.isClass && !sym.is(Package) && (!sym.isPackageObject || runContext.scala2CompatMode)
       || sym.isOpaqueAlias
       || sym.is(Deferred, butNot = Param)
 
@@ -579,12 +579,12 @@ trait ImplicitRunInfo {
             addPath(pre.cls.sourceModule.termRef)
           case pre: TermRef =>
             if (pre.symbol.is(Package)) {
-              if (ctx.scala2CompatMode) {
+              if (runContext.scala2CompatMode) {
                 addCompanion(pre, pre.member(nme.PACKAGE).symbol)
                 addPath(pre.prefix)
               }
             }
-            else if (!pre.symbol.isPackageObject || ctx.scala2CompatMode)  {
+            else if (!pre.symbol.isPackageObject || runContext.scala2CompatMode)  {
               comps += pre
               addPath(pre.prefix)
             }
@@ -624,7 +624,7 @@ trait ImplicitRunInfo {
           }
           else
             collectCompanions(tp)
-        val result = new OfTypeImplicits(tp, refs)(ctx)
+        val result = new OfTypeImplicits(tp, refs)(runContext)
         if (canCache &&
             ((tp eq rootTp) ||          // first type traversed is always cached
              !incomplete.contains(tp))) // other types are cached if they are not incomplete

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -528,7 +528,7 @@ trait ImplicitRunInfo {
      *  abstract types are eliminated.
      */
     object liftToAnchors extends TypeMap {
-      override implicit protected val ctx: Context = liftingCtx
+      override implicit protected val mapCtx: Context = liftingCtx
       override def stopAtStatic = true
 
       def apply(tp: Type) = tp.widenDealias match {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -414,7 +414,7 @@ object Implicits {
             case t: TypeParamRef =>
               constraint.entry(t) match {
                 case NoType => t
-                case bounds: TypeBounds => this.ctx.typeComparer.fullBounds(t)
+                case bounds: TypeBounds => mapCtx.typeComparer.fullBounds(t)
                 case t1 => t1
               }
             case t: TypeVar =>

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -79,7 +79,7 @@ object Implicits {
    *  represents a set of references to implicit definitions.
    */
   abstract class ImplicitRefs(initctx: Context) {
-    implicit val ctx: Context =
+    implicit val irefCtx: Context =
       if (initctx == NoContext) initctx else initctx retractMode Mode.ImplicitsEnabled
 
     /** The nesting level of this context. Non-zero only in ContextialImplicits */
@@ -274,9 +274,9 @@ object Implicits {
      */
     override val level: Int =
       if (outerImplicits == null) 1
-      else if (ctx.scala2CompatMode ||
-               (ctx.owner eq outerImplicits.ctx.owner) &&
-               (ctx.scope eq outerImplicits.ctx.scope) &&
+      else if (irefCtx.scala2CompatMode ||
+               (irefCtx.owner eq outerImplicits.irefCtx.owner) &&
+               (irefCtx.scope eq outerImplicits.irefCtx.scope) &&
                !refs.head.implicitName.is(LazyImplicitName)) outerImplicits.level
       else outerImplicits.level + 1
 
@@ -302,7 +302,7 @@ object Implicits {
           if (monitored) record(s"elided eligible refs", elided(this))
           eligibles
         }
-        else if (ctx eq NoContext) Nil
+        else if (irefCtx eq NoContext) Nil
         else {
           val result = computeEligible(tp)
           eligibleCache.put(tp, result)
@@ -311,7 +311,7 @@ object Implicits {
       }
 
     private def computeEligible(tp: Type): List[Candidate] = /*>|>*/ trace(i"computeEligible $tp in $refs%, %", implicitsDetailed) /*<|<*/ {
-      if (monitored) record(s"check eligible refs in ctx", refs.length)
+      if (monitored) record(s"check eligible refs in irefCtx", refs.length)
       val ownEligible = filterMatching(tp)
       if (isOuterMost) ownEligible
       else ownEligible ::: {
@@ -332,9 +332,9 @@ object Implicits {
       if (this == NoContext.implicits) this
       else {
         val outerExcluded = outerImplicits exclude root
-        if (ctx.importInfo.site.termSymbol == root) outerExcluded
+        if (irefCtx.importInfo.site.termSymbol == root) outerExcluded
         else if (outerExcluded eq outerImplicits) this
-        else new ContextualImplicits(refs, outerExcluded)(ctx)
+        else new ContextualImplicits(refs, outerExcluded)(irefCtx)
       }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -67,7 +67,7 @@ object Inferencing {
       def apply(tvars: Set[TypeVar], tp: Type) = tp match {
         case tp: TypeVar
         if !tp.isInstantiated &&
-            this.ctx.typeComparer.bounds(tp.origin)
+            accCtx.typeComparer.bounds(tp.origin)
               .namedPartsWith(ref => params.contains(ref.symbol))
               .nonEmpty =>
           tvars + tp
@@ -172,13 +172,13 @@ object Inferencing {
       def traverse(tp: Type): Unit = {
         tp match {
           case param: TypeParamRef =>
-            val constraint = this.ctx.typerState.constraint
+            val constraint = accCtx.typerState.constraint
             constraint.entry(param) match {
               case TypeBounds(lo, hi)
               if (hi frozen_<:< lo) =>
-                val inst = this.ctx.typeComparer.approximation(param, fromBelow = true)
+                val inst = accCtx.typeComparer.approximation(param, fromBelow = true)
                 typr.println(i"replace singleton $param := $inst")
-                this.ctx.typerState.constraint = constraint.replace(param, inst)
+                accCtx.typerState.constraint = constraint.replace(param, inst)
               case _ =>
             }
           case _ =>
@@ -333,7 +333,7 @@ object Inferencing {
       def setVariance(v: Int) = variance = v
       def apply(vmap: VarianceMap, t: Type): VarianceMap = t match {
         case t: TypeVar
-        if !t.isInstantiated && this.ctx.typerState.constraint.contains(t) =>
+        if !t.isInstantiated && accCtx.typerState.constraint.contains(t) =>
           val v = vmap(t)
           if (v == null) vmap.updated(t, variance)
           else if (v == variance || v == 0) vmap

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -24,11 +24,11 @@ import transform.SymUtils._
 import reporting.messages._
 
 trait NamerContextOps {
-  this: Context =>
+  thisCtx: Context =>
 
   import NamerContextOps._
 
-  def typer: Typer = ctx.typeAssigner match {
+  def typer: Typer = this.typeAssigner match {
     case typer: Typer => typer
     case _ => new Typer
   }
@@ -39,9 +39,9 @@ trait NamerContextOps {
    *  finger prints.
    */
   def enter(sym: Symbol): Symbol = {
-    ctx.owner match {
+    thisContext.owner match {
       case cls: ClassSymbol => cls.enter(sym)
-      case _ => this.scope.openForMutations.enter(sym)
+      case _ => thisCtx.scope.openForMutations.enter(sym)
     }
     sym
   }
@@ -105,7 +105,7 @@ trait NamerContextOps {
 
   /** A new context for the interior of a class */
   def inClassContext(selfInfo: TypeOrSymbol): Context = {
-    val localCtx: Context = ctx.fresh.setNewScope
+    val localCtx: Context = thisCtx.fresh.setNewScope
     selfInfo match {
       case sym: Symbol if sym.exists && sym.name != nme.WILDCARD => localCtx.scope.openForMutations.enter(sym)
       case _ =>
@@ -114,8 +114,8 @@ trait NamerContextOps {
   }
 
   def packageContext(tree: untpd.PackageDef, pkg: Symbol): Context =
-    if (pkg.is(Package)) ctx.fresh.setOwner(pkg.moduleClass).setTree(tree)
-    else ctx
+    if (pkg.is(Package)) thisCtx.fresh.setOwner(pkg.moduleClass).setTree(tree)
+    else thisCtx
 
   /** The given type, unless `sym` is a constructor, in which case the
    *  type of the constructed instance is returned

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -123,8 +123,8 @@ trait TypeAssigner {
           range(defn.NothingType, apply(classBound(tp.cls.classInfo)))
         case tp: SkolemType if partsToAvoid(mutable.Set.empty, tp.info).nonEmpty =>
           range(defn.NothingType, apply(tp.info))
-        case tp: TypeVar if this.ctx.typerState.constraint.contains(tp) =>
-          val lo = this.ctx.typeComparer.instanceType(
+        case tp: TypeVar if mapCtx.typerState.constraint.contains(tp) =>
+          val lo = mapCtx.typeComparer.instanceType(
             tp.origin, fromBelow = variance > 0 || variance == 0 && tp.hasLowerBound)
           val lo1 = apply(lo)
           if (lo1 ne lo) lo1 else tp

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -44,7 +44,7 @@ object VarianceChecker {
               .find(_.name.toTermName == paramName)
               .map(_.sourcePos)
               .getOrElse(tree.sourcePos)
-            this.ctx.error(em"${paramVarianceStr}variant type parameter $paramName occurs in ${occursStr}variant position in ${tl.resType}", pos)
+            accCtx.error(em"${paramVarianceStr}variant type parameter $paramName occurs in ${occursStr}variant position in ${tl.resType}", pos)
           }
           def apply(x: Boolean, t: Type) = x && {
             t match {
@@ -115,10 +115,10 @@ class VarianceChecker()(implicit ctx: Context) {
         val required = compose(relative, this.variance)
         def tvar_s = s"$tvar (${varianceLabel(tvar.flags)} ${tvar.showLocated})"
         def base_s = s"$base in ${base.owner}" + (if (base.owner.isClass) "" else " in " + base.owner.enclosingClass)
-        this.ctx.log(s"verifying $tvar_s is ${varianceLabel(required)} at $base_s")
-        this.ctx.log(s"relative variance: ${varianceLabel(relative)}")
-        this.ctx.log(s"current variance: ${this.variance}")
-        this.ctx.log(s"owner chain: ${base.ownersIterator.toList}")
+        accCtx.log(s"verifying $tvar_s is ${varianceLabel(required)} at $base_s")
+        accCtx.log(s"relative variance: ${varianceLabel(relative)}")
+        accCtx.log(s"current variance: ${this.variance}")
+        accCtx.log(s"owner chain: ${base.ownersIterator.toList}")
         if (tvar.isOneOf(required)) None
         else Some(VarianceError(tvar, required))
       }


### PR DESCRIPTION
We would like to distinguish between `ctx` referring to an enclosing parameter
and `ctx` referring to a field. This is so that we can at some point drop
`ctx` as a parameter name and just use (using Context). The `ctx` would then
go to an imported def in `Contexts`. But any other use of `ctx` does does not
follow strict nesting discipline can then change meaning, so we should
get these out of the way first.