### PR TITLE
Type constant annotation arguments correctly

### DIFF
--- a/tests/pos-special/fatal-warnings/annot-constant/Annot_1.java
+++ b/tests/pos-special/fatal-warnings/annot-constant/Annot_1.java
@@ -1,0 +1,5 @@
+package pkg;
+
+@interface Annot_1 {
+  boolean BOOL();
+}

--- a/tests/pos-special/fatal-warnings/annot-constant/Constants_1.java
+++ b/tests/pos-special/fatal-warnings/annot-constant/Constants_1.java
@@ -1,0 +1,9 @@
+package pkg;
+
+class Constants_1 {
+  // javac will produce a ConstantValue 1 for the annotation argument
+  @Annot_1(BOOL=true) static void foo() {};
+
+  // ...and reuse it here for the ConstantValue attribute
+  static final byte BYTE  = 1;
+}

--- a/tests/pos-special/fatal-warnings/annot-constant/Test_2.scala
+++ b/tests/pos-special/fatal-warnings/annot-constant/Test_2.scala
@@ -1,0 +1,6 @@
+package pkg
+
+object U {
+  println(Constants_1.foo()) // The same constant in the constant pool is first unpickled here as a boolean
+  println(Constants_1.BYTE) // ... and here as a byte
+}


### PR DESCRIPTION
An annotation argument of type boolean, byte, char or short will be
represented as a CONSTANT_Integer in the classfile, so back in
3b882c295dafd45c88022e5419df63875fc4636a I made sure that we took this
type into account when creating a `Constant`, but this is not enough: we
store parsed constants in a `values` cache, and the same constant might
be used with different expected types, so the conversion needs to be
done on demand.