### PR TITLE
Use simpler desugaring for splices

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -53,7 +53,7 @@ trait QuotesAndSplices {
       ctx.error(em"Quotes require stable QuoteContext, but found non stable $qctx", qctx.sourcePos)
 
     val tree1 =
-      if ctx.mode.is(Mode.Pattern) && level == 0 then
+      if ctx.mode.is(Mode.Pattern) then
         typedQuotePattern(tree, pt, qctx)
       else if (tree.quoted.isType)
         typedTypeApply(untpd.TypeApply(untpd.ref(defn.InternalQuoted_typeQuote.termRef), tree.quoted :: Nil), pt)(using quoteContext)
@@ -72,7 +72,7 @@ trait QuotesAndSplices {
         ctx.warning("Canceled quote directly inside a splice. ${ '{ XYZ } } is equivalent to XYZ.", tree.sourcePos)
       case _ =>
     }
-    if (ctx.mode.is(Mode.QuotedPattern) && level == 1)
+    if (ctx.mode.is(Mode.QuotedPattern))
       if (isFullyDefined(pt, ForceDegree.all)) {
         def spliceOwner(ctx: Context): Symbol =
           if (ctx.mode.is(Mode.QuotedPattern)) spliceOwner(ctx.outer) else ctx.owner

--- a/tests/neg/i8052.scala
+++ b/tests/neg/i8052.scala
@@ -11,7 +11,7 @@ object Macro2 {
     def derived[T: Type](ev: Expr[Mirror.Of[T]])(using qctx: QuoteContext): Expr[TC[T]] = '{
       new TC[T] {
         def encode(): Unit = $ev match {
-          case '{ $m: Mirror.ProductOf[T] } => ??? // error
+          case '{ $m: Mirror.ProductOf[T] } => ??? // error // error
         }
       }
     }

--- a/tests/neg/i8052.scala
+++ b/tests/neg/i8052.scala
@@ -11,7 +11,7 @@ object Macro2 {
     def derived[T: Type](ev: Expr[Mirror.Of[T]])(using qctx: QuoteContext): Expr[TC[T]] = '{
       new TC[T] {
         def encode(): Unit = $ev match {
-          case '{ $m: Mirror.ProductOf[T] } => ??? // error // error
+          case '{ $m: Mirror.ProductOf[T] } => ??? // error
         }
       }
     }

--- a/tests/pos/splice-with-explicit-context.scala
+++ b/tests/pos/splice-with-explicit-context.scala
@@ -1,0 +1,7 @@
+import scala.quoted._
+
+def f(a: Expr[Int])(using qctx: QuoteContext): Unit =
+
+  '{ val x: Int = ${ (using qctx2) => a } }
+
+  '{ val x: Int = ${ (using qctx2: qctx.NestedContext) => a } }

--- a/tests/run-staging/quote-nested-2.check
+++ b/tests/run-staging/quote-nested-2.check
@@ -1,4 +1,4 @@
 ((qctx: scala.quoted.QuoteContext) ?=> {
   val a: scala.quoted.Expr[scala.Int] = scala.internal.quoted.CompileTime.exprQuote[scala.Int](4).apply(using qctx)
-  ((qctx1_$1: qctx.NestedContext) ?=> a).asInstanceOf[scala.ContextFunction1[scala.quoted.QuoteContext, scala.quoted.Expr[scala.Int]]].apply(using qctx)
+  ((evidence$2: qctx.NestedContext) ?=> a).asInstanceOf[scala.ContextFunction1[scala.quoted.QuoteContext, scala.quoted.Expr[scala.Int]]].apply(using qctx)
 })

--- a/tests/run-staging/quote-nested-5.check
+++ b/tests/run-staging/quote-nested-5.check
@@ -1,4 +1,4 @@
 ((qctx: scala.quoted.QuoteContext) ?=> {
   val a: scala.quoted.Expr[scala.Int] = scala.internal.quoted.CompileTime.exprQuote[scala.Int](4).apply(using qctx)
-  ((qctx2: scala.quoted.QuoteContext) ?=> ((qctx1_$1: qctx2.NestedContext) ?=> a).asInstanceOf[scala.ContextFunction1[scala.quoted.QuoteContext, scala.quoted.Expr[scala.Int]]].apply(using qctx2)).apply(using qctx)
+  ((qctx2: scala.quoted.QuoteContext) ?=> ((evidence$3: qctx2.NestedContext) ?=> a).asInstanceOf[scala.ContextFunction1[scala.quoted.QuoteContext, scala.quoted.Expr[scala.Int]]].apply(using qctx2)).apply(using qctx)
 })


### PR DESCRIPTION
This allows writing explicitly the context function of a splice. It will make the desugaring simpler to explain as one can write it explicitly.

The downside is that each nested context will get a generic "evidence" name which might be visible to the users. Though this is general limitation of context functions that might need a general fix.