### PR TITLE
Future-proof paramSymss API

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -386,12 +386,15 @@ object SymDenotations {
     final def setParamssFromDefs(tparams: List[TypeDef[?]], vparamss: List[List[ValDef[?]]])(using Context): Unit =
       setParamss(tparams.map(_.symbol), vparamss.map(_.map(_.symbol)))
 
-    /** A pair consisting of type parameter symbols and value parameter symbol lists
-     *  of this method definition, or (Nil, Nil) for other symbols.
+
+    /** The symbols of each type parameter list and value parameter list of this
+     *  method, or Nil if this isn't a method.
+     *
+     *
      *  Makes use of `rawParamss` when present, or constructs fresh parameter symbols otherwise.
      *  This method can be allocation-heavy.
      */
-    final def paramSymss(using ctx: Context): (List[TypeSymbol], List[List[TermSymbol]]) =
+    final def paramSymss(using ctx: Context): List[List[Symbol]] =
 
       def recurWithParamss(info: Type, paramss: List[List[Symbol]]): List[List[Symbol]] =
         info match
@@ -412,17 +415,8 @@ object SymDenotations {
         case _ =>
           Nil
 
-      try
-        val allParamss =
-          if rawParamss.isEmpty then recurWithoutParamss(info)
-          else recurWithParamss(info, rawParamss)
-        val result = info match
-          case info: PolyType => (allParamss.head, allParamss.tail)
-          case _ => (Nil, allParamss)
-        result.asInstanceOf[(List[TypeSymbol], List[List[TermSymbol]])]
-      catch case NonFatal(ex) =>
-        println(i"paramSymss failure for $symbol, $info, $rawParamss")
-        throw ex
+      if rawParamss.isEmpty then recurWithoutParamss(info)
+      else recurWithParamss(info, rawParamss)
     end paramSymss
 
     /** The denotation is completed: info is not a lazy type and attributes have defined values */

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -339,7 +339,7 @@ private class ExtractAPICollector(implicit ctx: Context) extends ThunkHolder {
   def apiDef(sym: TermSymbol): api.Def = {
     def paramLists(t: Type, paramss: List[List[Symbol]]): List[api.ParameterList] = t match {
       case pt: TypeLambda =>
-        paramLists(pt.resultType, paramss)
+        paramLists(pt.resultType, paramss.drop(1))
       case mt @ MethodTpe(pnames, ptypes, restpe) =>
         assert(paramss.nonEmpty && paramss.head.hasSameLengthAs(pnames),
           i"mismatch for $sym, ${sym.info}, ${sym.paramSymss}")
@@ -359,7 +359,7 @@ private class ExtractAPICollector(implicit ctx: Context) extends ThunkHolder {
       case _ =>
         Nil
     }
-    val vparamss = paramLists(sym.info, sym.paramSymss._2)
+    val vparamss = paramLists(sym.info, sym.paramSymss)
     val retTp = sym.info.finalResultType.widenExpr
 
     api.Def.of(sym.name.toString, apiAccess(sym), apiModifiers(sym),

--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -1749,7 +1749,7 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   private def isMethod(sym: Symbol)(using ctx: Context): Boolean =
     sym.isTerm && sym.is(Flags.Method) && !sym.isConstructor
 
-  def Symbol_paramSymss(self: Symbol)(using ctx: Context): (List[Symbol], List[List[Symbol]]) =
+  def Symbol_paramSymss(self: Symbol)(using ctx: Context): List[List[Symbol]] =
     self.paramSymss
 
   def Symbol_primaryConstructor(self: Symbol)(using Context): Symbol =

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -2223,10 +2223,10 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
     def methods(using ctx: Context): List[Symbol] =
       internal.Symbol_methods(sym)
 
-    /** A pair consisting of type parameter symbols and value parameter symbol lists
-     *  of this method definition, or (Nil, Nil) for other symbols.
+    /** The symbols of each type parameter list and value parameter list of this
+     *  method, or Nil if this isn't a method.
      */
-    def paramSymss(using ctx: Context): (List[Symbol], List[List[Symbol]]) =
+    def paramSymss(using ctx: Context): List[List[Symbol]] =
       internal.Symbol_paramSymss(sym)
 
     /** The primary constructor of a class or trait, `noSymbol` if not applicable. */

--- a/library/src/scala/tasty/reflect/CompilerInterface.scala
+++ b/library/src/scala/tasty/reflect/CompilerInterface.scala
@@ -1305,10 +1305,10 @@ trait CompilerInterface {
   /** Get all non-private methods declared or inherited */
   def Symbol_methods(self: Symbol)(using ctx: Context): List[Symbol]
 
-  /** A pair consisting of type parameter symbols and value parameter symbol lists
-   *  of this method definition, or (Nil, Nil) for other symbols.
+  /** The symbols of each type parameter list and value parameter list of this
+   *  method, or Nil if this isn't a method.
    */
-  def Symbol_paramSymss(self: Symbol)(using ctx: Context): (List[Symbol], List[List[Symbol]])
+  def Symbol_paramSymss(self: Symbol)(using ctx: Context): List[List[Symbol]]
 
   /** The primary constructor of a class or trait, `noSymbol` if not applicable. */
   def Symbol_primaryConstructor(self: Symbol)(using Context): Symbol

--- a/tests/run-macros/paramSymss.check
+++ b/tests/run-macros/paramSymss.check
@@ -1,28 +1,21 @@
 sym: Test$.a
-tparams: List()
-vparamss: List()
+paramSymss: List()
 
 sym: Test$.b
-tparams: List()
-vparamss: List(List(Test$._$i))
+paramSymss: List(List(Test$._$i))
 
 sym: Test$.c
-tparams: List()
-vparamss: List(List(Test$._$x), List(Test$._$y), List(Test$._$z))
+paramSymss: List(List(Test$._$x), List(Test$._$y), List(Test$._$z))
 
 sym: Test$.d
-tparams: List(Test$._$T)
-vparamss: List()
+paramSymss: List(List(Test$._$T))
 
 sym: Test$.c
-tparams: List(Test$._$T, Test$._$U)
-vparamss: List(List(Test$._$x, Test$._$x2), List(Test$._$y), List(Test$._$z))
+paramSymss: List(List(Test$._$T, Test$._$U), List(Test$._$x, Test$._$x2), List(Test$._$y), List(Test$._$z))
 
 sym: Test.<init>
-tparams: List(Test._$T)
-vparamss: List(List(Test._$a))
+paramSymss: List(List(Test._$T), List(Test._$a))
 
 sym: Test.<init>
-tparams: List(Test._$T)
-vparamss: List(List(Test._$a, Test._$b))
+paramSymss: List(List(Test._$T), List(Test._$a, Test._$b))
 

--- a/tests/run-macros/paramSymss/Macro_1.scala
+++ b/tests/run-macros/paramSymss/Macro_1.scala
@@ -6,9 +6,7 @@ inline def showParamSyms(inline x: Any): String =
 def showParamSymsExpr(using QuoteContext)(x: Expr[Any]): Expr[String] =
   val '{ $y: Any } = x // Drop Inlined not to access the symbol
   val sym = y.unseal.symbol
-  val (tparams, vparamss) = sym.paramSymss
   Expr(
     s"""sym: ${sym.show}
-       |tparams: ${tparams.map(_.show)}
-       |vparamss: ${vparamss.map(_.map(_.show))}
+       |paramSymss: ${sym.paramSymss.map(_.map(_.show))}
        |""".stripMargin)


### PR DESCRIPTION
In the future, we might support arbitrary combination of type and term
parameter lists, so we shouldn't hardcode the assumption that there is
at most one type parameter list.

Also removed a debug println.