### PR TITLE
Improve type inference of quote pattern splices

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -73,7 +73,7 @@ trait QuotesAndSplices {
       case _ =>
     }
     if (ctx.mode.is(Mode.QuotedPattern))
-      if (isFullyDefined(pt, ForceDegree.all)) {
+      if (isFullyDefined(pt, ForceDegree.flipBottom)) {
         def spliceOwner(ctx: Context): Symbol =
           if (ctx.mode.is(Mode.QuotedPattern)) spliceOwner(ctx.outer) else ctx.owner
         val pat = typedPattern(tree.expr, defn.QuotedExprClass.typeRef.appliedTo(pt))(

--- a/tests/run-macros/quote-matcher-inference/Macro_1.scala
+++ b/tests/run-macros/quote-matcher-inference/Macro_1.scala
@@ -1,0 +1,15 @@
+import scala.quoted._
+
+
+object Macros {
+
+  inline def g(inline x: Unit): Unit = ${impl('x)}
+
+  private def impl(x: Expr[Any])(using QuoteContext): Expr[Any] = {
+    x match
+      case '{ println(f($y)) } => y
+  }
+
+}
+
+def f[T](x: T): T = x

--- a/tests/run-macros/quote-matcher-inference/Test_2.scala
+++ b/tests/run-macros/quote-matcher-inference/Test_2.scala
@@ -1,0 +1,10 @@
+import Macros._
+
+
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    g(println(f((5))))
+  }
+
+}


### PR DESCRIPTION
Infer higher bound for type splices. This means that when type information is not given
the pattern should match all terms that could fit in this hole.

These are a source of buggy patterns that look fine but only match when the content is of type `Nothing` (virtually never). This is never the intent of such code.