### PR TITLE
Fix #8571: A new source version and migration scheme

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -13,6 +13,7 @@ import typer.PrepareInlineable.InlineAccessors
 import typer.Nullables
 import transform.SymUtils._
 import core.Decorators.{given _}
+import config.SourceVersion
 
 class CompilationUnit protected (val source: SourceFile) {
 
@@ -23,6 +24,9 @@ class CompilationUnit protected (val source: SourceFile) {
   var tpdTree: tpd.Tree = tpd.EmptyTree
 
   def isJava: Boolean = source.file.name.endsWith(".java")
+
+  /** The source version for this unit, as determined by a language import */
+  var sourceVersion: Option[SourceVersion] = None
 
   /** Pickled TASTY binaries, indexed by class. */
   var pickled: Map[ClassSymbol, Array[Byte]] = Map()

--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -75,7 +75,7 @@ class Driver {
     inContext(ictx) {
       if !ctx.settings.YdropComments.value || ctx.mode.is(Mode.ReadComments) then
         ictx.setProperty(ContextDoc, new ContextDocstrings)
-      if Feature.enabledBySetting(nme.Scala2Compat) && false then // TODO: enable
+      if Feature.enabledBySetting(nme.Scala2Compat) && false then // enable when -language:Scala2compat has been purged from the builds
         ctx.warning("-language:Scala2Compat will go away; use -source 3.0-migration instead")
       val fileNames = CompilerCommand.checkUsage(summary, sourcesRequired)
       fromTastySetup(fileNames, ctx)

--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -75,7 +75,7 @@ class Driver {
     inContext(ictx) {
       if !ctx.settings.YdropComments.value || ctx.mode.is(Mode.ReadComments) then
         ictx.setProperty(ContextDoc, new ContextDocstrings)
-      if Feature.enabledBySetting(nme.Scala2Compat) && false then // enable when -language:Scala2compat has been purged from the builds
+      if Feature.enabledBySetting(nme.Scala2Compat) && false then // TODO: enable
         ctx.warning("-language:Scala2Compat will go away; use -source 3.0-migration instead")
       val fileNames = CompilerCommand.checkUsage(summary, sourcesRequired)
       fromTastySetup(fileNames, ctx)

--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -75,7 +75,7 @@ class Driver {
     inContext(ictx) {
       if !ctx.settings.YdropComments.value || ctx.mode.is(Mode.ReadComments) then
         ictx.setProperty(ContextDoc, new ContextDocstrings)
-      if Feature.enabledBySetting(nme.Scala2Compat) then
+      if Feature.enabledBySetting(nme.Scala2Compat) && false then // TODO: enable
         ctx.warning("-language:Scala2Compat will go away; use -source 3.0-migration instead")
       val fileNames = CompilerCommand.checkUsage(summary, sourcesRequired)
       fromTastySetup(fileNames, ctx)

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -9,6 +9,7 @@ import Decorators.{given _}, transform.SymUtils._
 import NameKinds.{UniqueName, EvidenceParamName, DefaultGetterName}
 import typer.{FrontEnd, Namer}
 import util.{Property, SourceFile, SourcePosition}
+import config.Feature
 import collection.mutable.ListBuffer
 import reporting.messages._
 import reporting.trace
@@ -560,7 +561,7 @@ object desugar {
       ensureApplied(nu)
     }
 
-    val copiedAccessFlags = if (ctx.scala2CompatSetting) EmptyFlags else AccessFlags
+    val copiedAccessFlags = if Feature.migrateTo3 then EmptyFlags else AccessFlags
 
     // Methods to add to a case class C[..](p1: T1, ..., pN: Tn)(moreParams)
     //     def _1: T1 = this.p1
@@ -1659,7 +1660,7 @@ object desugar {
         }
         else {
           assert(ctx.mode.isExpr || ctx.reporter.errorsReported || ctx.mode.is(Mode.Interactive), ctx.mode)
-          if (!ctx.featureEnabled(nme.postfixOps)) {
+          if (!Feature.enabled(nme.postfixOps)) {
             ctx.error(
               s"""postfix operator `${op.name}` needs to be enabled
                  |by making the implicit value scala.language.postfixOps visible.

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -408,8 +408,8 @@ object desugar {
       case _ => false
     }
     def isScala(tree: Tree): Boolean = tree match {
-      case Ident(nme.scala_) => true
-      case Select(Ident(nme.ROOTPKG), nme.scala_) => true
+      case Ident(nme.scala) => true
+      case Select(Ident(nme.ROOTPKG), nme.scala) => true
       case _ => false
     }
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -154,7 +154,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   enum GenCheckMode {
     case Ignore       // neither filter nor check since filtering was done before
     case Check        // check that pattern is irrefutable
-    case FilterNow    //filter out non-matching elements since we are not yet in 3.1
+    case FilterNow    // filter out non-matching elements since we are not yet in 3.1
     case FilterAlways // filter out non-matching elements since pattern is prefixed by `case`
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -154,7 +154,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   enum GenCheckMode {
     case Ignore       // neither filter nor check since filtering was done before
     case Check        // check that pattern is irrefutable
-    case FilterNow    //filter out non-matching elements since we are not in -strict
+    case FilterNow    //filter out non-matching elements since we are not yet in 3.1
     case FilterAlways // filter out non-matching elements since pattern is prefixed by `case`
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -447,7 +447,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     TypedSplice(tpd.ref(tp))
 
   def rootDot(name: Name)(implicit src: SourceFile): Select = Select(Ident(nme.ROOTPKG), name)
-  def scalaDot(name: Name)(implicit src: SourceFile): Select = Select(rootDot(nme.scala_), name)
+  def scalaDot(name: Name)(implicit src: SourceFile): Select = Select(rootDot(nme.scala), name)
   def scalaAnnotationDot(name: Name)(using SourceFile): Select = Select(scalaDot(nme.annotation), name)
   def scalaUnit(implicit src: SourceFile): Select = scalaDot(tpnme.Unit)
   def scalaAny(implicit src: SourceFile): Select = scalaDot(tpnme.Any)

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -61,8 +61,8 @@ object Feature:
     SourceVersion.valueOf(ctx.settings.source.value)
 
   def sourceVersion(using Context): SourceVersion =
-    if ctx.importInfo == null then sourceVersionSetting
-    else ctx.importInfo.sourceVersion.getOrElse(sourceVersionSetting)
+    if ctx.compilationUnit == null then sourceVersionSetting
+    else ctx.compilationUnit.sourceVersion.getOrElse(sourceVersionSetting)
 
   def migrateTo3(using Context): Boolean =
     sourceVersion == `3.0-migration` || enabledBySetting(nme.Scala2Compat)

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -72,7 +72,9 @@ object Feature:
    */
   def warnOnMigration(msg: Message, pos: SourcePosition,
       version: SourceVersion = defaultSourceVersion)(using Context): Boolean =
-    if sourceVersion.isMigrating && sourceVersion.stable == version then
+    if sourceVersion.isMigrating && sourceVersion.stable == version
+       || version == `3.0` && migrateTo3
+    then
       ctx.migrationWarning(msg, pos)
       true
     else

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -1,0 +1,81 @@
+package dotty.tools
+package dotc
+package config
+
+import core._
+import Contexts._, Symbols._, Names._
+import StdNames.nme
+import Decorators.{given _}
+import util.SourcePosition
+import SourceVersion._
+import reporting.Message
+
+object Feature:
+
+/** Is `feature` enabled by by a command-line setting? The enabling setting is
+   *
+   *       -language:<prefix>feature
+   *
+   *  where <prefix> is the fully qualified name of `owner`, followed by a ".",
+   *  but subtracting the prefix `scala.language.` at the front.
+   */
+  def enabledBySetting(feature: TermName, owner: Symbol = NoSymbol)(using Context): Boolean =
+    def toPrefix(sym: Symbol): String =
+      if !sym.exists || sym == defn.LanguageModule.moduleClass then ""
+      else toPrefix(sym.owner) + sym.name + "."
+    val prefix = if owner.exists then toPrefix(owner) else ""
+    ctx.base.settings.language.value.contains(prefix + feature)
+
+  /** Is `feature` enabled by by an import? This is the case if the feature
+   *  is imported by a named import
+   *
+   *       import owner.feature
+   *
+   *  and there is no visible nested import that excludes the feature, as in
+   *
+   *       import owner.{ feature => _ }
+   */
+  def enabledByImport(feature: TermName, owner: Symbol = NoSymbol)(using Context): Boolean =
+    ctx.atPhase(ctx.typerPhase) {
+      ctx.importInfo != null
+      && ctx.importInfo.featureImported(feature.toTermName,
+          if owner.exists then owner else defn.LanguageModule.moduleClass)
+    }
+
+  /** Is `feature` enabled by either a command line setting or an import?
+   *  @param  feature   The name of the feature
+   *  @param  owner     The prefix symbol (nested in `scala.language`) where the
+   *                    feature is defined.
+   */
+  def enabled(feature: TermName, owner: Symbol = NoSymbol)(using Context): Boolean =
+    enabledBySetting(feature, owner) || enabledByImport(feature, owner)
+
+  /** Is auto-tupling enabled? */
+  def autoTuplingEnabled(using Context): Boolean =
+    !enabled(nme.noAutoTupling)
+
+  def dynamicsEnabled(using Context): Boolean =
+    enabled(nme.dynamics)
+
+  def sourceVersionSetting(using Context): SourceVersion =
+    SourceVersion.valueOf(ctx.settings.source.value)
+
+  def sourceVersion(using Context): SourceVersion =
+    if ctx.importInfo == null then sourceVersionSetting
+    else ctx.importInfo.sourceVersion.getOrElse(sourceVersionSetting)
+
+  def migrateTo3(using Context): Boolean =
+    sourceVersion == `3.0-migration` || enabledBySetting(nme.Scala2Compat)
+
+  /** If current source migrates to `version`, issue given warning message
+   *  and return `true`, otherwise return `false`.
+   */
+  def warnOnMigration(msg: Message, pos: SourcePosition,
+      version: SourceVersion = defaultSourceVersion)(using Context): Boolean =
+    if sourceVersion.isMigrating && sourceVersion.stable == version then
+      ctx.migrationWarning(msg, pos)
+      true
+    else
+      false
+
+end Feature

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -34,6 +34,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val feature: Setting[Boolean] = BooleanSetting("-feature", "Emit warning and location for usages of features that should be imported explicitly.") withAbbreviation "--feature"
   val help: Setting[Boolean] = BooleanSetting("-help", "Print a synopsis of standard options.") withAbbreviation "--help"
   val color: Setting[String] = ChoiceSetting("-color", "mode", "Colored output", List("always", "never"/*, "auto"*/), "always"/* "auto"*/) withAbbreviation "--color"
+  val source: Setting[String] = ChoiceSetting("-source", "source version", "source version", List("3.0", "3.1", "3.0-migration", "3.1-migration"), "3.0").withAbbreviation("--source")
   val target: Setting[String] = ChoiceSetting("-target", "target", "Target platform for object files. All JVM 1.5 targets are deprecated.",
     List("jvm-1.5", "jvm-1.5-fjbg", "jvm-1.5-asm", "jvm-1.6", "jvm-1.7", "jvm-1.8", "msil"), "jvm-1.8") withAbbreviation "--target"
   val scalajs: Setting[Boolean] = BooleanSetting("-scalajs", "Compile in Scala.js mode (requires scalajs-library.jar on the classpath).") withAbbreviation "--scalajs"
@@ -45,7 +46,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val pageWidth: Setting[Int] = IntSetting("-pagewidth", "Set page width", 80) withAbbreviation "--page-width"
   val strict: Setting[Boolean] = BooleanSetting("-strict", "Use strict type rules, which means some formerly legal code does not typecheck anymore.") withAbbreviation "--strict"
   val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.") withAbbreviation "--language"
-  val rewrite: Setting[Option[Rewrites]] = OptionSetting[Rewrites]("-rewrite", "When used in conjunction with -language:Scala2Compat rewrites sources to migrate to new syntax.") withAbbreviation "--rewrite"
+  val rewrite: Setting[Option[Rewrites]] = OptionSetting[Rewrites]("-rewrite", "When used in conjunction with a `...-migration` source version, rewrites sources to migrate to new version.") withAbbreviation "--rewrite"
   val silentWarnings: Setting[Boolean] = BooleanSetting("-nowarn", "Silence all warnings.") withAbbreviation "--no-warnings"
   val fromTasty: Setting[Boolean] = BooleanSetting("-from-tasty", "Compile classes from tasty in classpath. The arguments are used as class names.") withAbbreviation "--from-tasty"
 

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -44,7 +44,6 @@ class ScalaSettings extends Settings.SettingGroup {
   val verbose: Setting[Boolean] = BooleanSetting("-verbose", "Output messages about what the compiler is doing.") withAbbreviation "--verbose"
   val version: Setting[Boolean] = BooleanSetting("-version", "Print product version and exit.") withAbbreviation "--version"
   val pageWidth: Setting[Int] = IntSetting("-pagewidth", "Set page width", 80) withAbbreviation "--page-width"
-  val strict: Setting[Boolean] = BooleanSetting("-strict", "Use strict type rules, which means some formerly legal code does not typecheck anymore.") withAbbreviation "--strict"
   val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.") withAbbreviation "--language"
   val rewrite: Setting[Option[Rewrites]] = OptionSetting[Rewrites]("-rewrite", "When used in conjunction with a `...-migration` source version, rewrites sources to migrate to new version.") withAbbreviation "--rewrite"
   val silentWarnings: Setting[Boolean] = BooleanSetting("-nowarn", "Silence all warnings.") withAbbreviation "--no-warnings"

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -135,11 +135,13 @@ object Settings {
         case (ListTag, _) =>
           if (argRest.isEmpty) missingArg
           else update((argRest split ",").toList, args)
-        case (StringTag, _) if choices.nonEmpty =>
-          if (argRest.isEmpty) missingArg
-          else if (!choices.contains(argRest))
+        case (StringTag, _) if choices.nonEmpty && argRest.nonEmpty =>
+          if (!choices.contains(argRest))
             fail(s"$arg is not a valid choice for $name", args)
           else update(argRest, args)
+        case (StringTag, arg2 :: args2) =>
+          if (arg2 startsWith "-") missingArg
+          else update(arg2, args2)
         case (OutputTag, arg :: args) =>
           val path = Directory(arg)
           val isJar = path.extension == "jar"
@@ -149,9 +151,6 @@ object Settings {
             val output = if (isJar) JarArchive.create(path) else new PlainDirectory(path)
             update(output, args)
           }
-        case (StringTag, arg2 :: args2) =>
-          if (arg2 startsWith "-") missingArg
-          else update(arg2, args2)
         case (IntTag, arg2 :: args2) =>
           try {
             val x = arg2.toInt

--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -1,0 +1,25 @@
+package dotty.tools
+package dotc
+package config
+
+import core.Contexts.{Context, ctx}
+import core.Names.TermName
+import core.StdNames.nme
+import core.Decorators.{given _}
+import util.Property
+
+enum SourceVersion:
+  case `3.0-migration`, `3.0`, `3.1-migration`, `3.1`
+
+  val isMigrating: Boolean = toString.endsWith("-migration")
+
+  def stable: SourceVersion =
+    if isMigrating then SourceVersion.values(ordinal + 1) else this
+
+  def isAtLeast(v: SourceVersion) = stable.ordinal >= v.ordinal
+
+object SourceVersion extends Property.Key[SourceVersion]:
+  def defaultSourceVersion = `3.0`
+
+  val allSourceVersionNames = values.toList.map(_.toString.toTermName)
+end SourceVersion

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -6,6 +6,8 @@ import Contexts._, Types._, Symbols._, Names._, Flags._
 import Denotations.SingleDenotation
 import Decorators._
 import collection.mutable
+import config.SourceVersion.`3.1`
+import config.Feature.sourceVersion
 
 /** Realizability status */
 object CheckRealizable {
@@ -197,7 +199,7 @@ class CheckRealizable(implicit ctx: Context) {
           realizability(fld.info).mapError(r => new HasProblemField(fld, r))
         }
       }
-    if (ctx.settings.strict.value)
+    if sourceVersion.isAtLeast(`3.1`) then
       // check fields only under strict mode for now.
       // Reason: An embedded field could well be nullable, which means it
       // should not be part of a path and need not be checked; but we cannot recognize

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -200,7 +200,7 @@ class CheckRealizable(implicit ctx: Context) {
         }
       }
     if sourceVersion.isAtLeast(`3.1`) then
-      // check fields only under strict mode for now.
+      // check fields only from version 3.1.
       // Reason: An embedded field could well be nullable, which means it
       // should not be part of a path and need not be checked; but we cannot recognize
       // this situation until we have a typesystem that tracks nullability.

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -116,7 +116,7 @@ class Definitions {
         val cls = denot.asClass.classSymbol
         val decls = newScope
         val arity = name.functionArity
-        val paramNamePrefix = tpnme.scala_ ++ str.NAME_JOIN ++ name ++ str.EXPAND_SEPARATOR
+        val paramNamePrefix = tpnme.scala ++ str.NAME_JOIN ++ name ++ str.EXPAND_SEPARATOR
         val argParamRefs = List.tabulate(arity) { i =>
           enterTypeParam(cls, paramNamePrefix ++ "T" ++ (i + 1).toString, Contravariant, decls).typeRef
         }
@@ -199,7 +199,7 @@ class Definitions {
   @tu lazy val OpsPackageVal: TermSymbol = ctx.newCompletePackageSymbol(RootClass, nme.OPS_PACKAGE).entered
   @tu lazy val OpsPackageClass: ClassSymbol = OpsPackageVal.moduleClass.asClass
 
-  @tu lazy val ScalaPackageVal: TermSymbol = ctx.requiredPackage(nme.scala_)
+  @tu lazy val ScalaPackageVal: TermSymbol = ctx.requiredPackage(nme.scala)
   @tu lazy val ScalaMathPackageVal: TermSymbol = ctx.requiredPackage("scala.math")
   @tu lazy val ScalaPackageClass: ClassSymbol = {
     val cls = ScalaPackageVal.moduleClass.asClass
@@ -1370,7 +1370,7 @@ class Definitions {
 
 //  /** The `Class[?]` of a primitive value type name */
 //  def valueTypeNameToJavaType(name: TypeName)(implicit ctx: Context): Option[Class[?]] =
-//    valueTypeNamesToJavaType.get(if (name.firstPart eq nme.scala_) name.lastPart.toTypeName else name)
+//    valueTypeNamesToJavaType.get(if (name.firstPart eq nme.scala) name.lastPart.toTypeName else name)
 
   type PrimitiveClassEnc = Int
 

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1356,7 +1356,7 @@ object Denotations {
         def isPackageFromCoreLibMissing: Boolean =
           owner.symbol == defn.RootClass &&
           (
-            selector == nme.scala_ || // if the scala package is missing, the stdlib must be missing
+            selector == nme.scala || // if the scala package is missing, the stdlib must be missing
             selector == nme.scalaShadowing // if the scalaShadowing package is missing, the dotty library must be missing
           )
         if (owner.exists) {

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -17,6 +17,7 @@ import Decorators._
 import printing.Texts._
 import printing.Printer
 import io.AbstractFile
+import config.Feature.migrateTo3
 import config.Config
 import util.common._
 import typer.ProtoTypes.NoViewsAllowed
@@ -489,7 +490,7 @@ object Denotations {
                   // things, starting with the return type of this method.
                   if (preferSym(sym2, sym1)) info2
                   else if (preferSym(sym1, sym2)) info1
-                  else if (pre.widen.classSymbol.is(Scala2x) || ctx.scala2CompatMode)
+                  else if (pre.widen.classSymbol.is(Scala2x) || migrateTo3)
                     info1 // follow Scala2 linearization -
                   // compare with way merge is performed in SymDenotation#computeMembersNamed
                   else throw new MergeError(ex.sym1, ex.sym2, ex.tp1, ex.tp2, pre)

--- a/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
+++ b/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
@@ -7,6 +7,7 @@ import Symbols._
 import Types._
 import Flags._
 import dotty.tools.dotc.reporting.trace
+import config.Feature.migrateTo3
 import config.Printers._
 
 trait PatternTypeConstrainer { self: TypeComparer =>
@@ -199,7 +200,9 @@ trait PatternTypeConstrainer { self: TypeComparer =>
       }
     }
 
-    val widePt = if (ctx.scala2CompatMode || refinementIsInvariant(patternTp)) scrutineeTp else widenVariantParams(scrutineeTp)
+    val widePt =
+      if migrateTo3 || refinementIsInvariant(patternTp) then scrutineeTp
+      else widenVariantParams(scrutineeTp)
     val narrowTp = SkolemType(patternTp)
     trace(i"constraining simple pattern type $narrowTp <:< $widePt", gadts, res => s"$res\ngadt = ${ctx.gadt.debugBoundsDescription}") {
       isSubType(narrowTp, widePt)

--- a/compiler/src/dotty/tools/dotc/core/Periods.scala
+++ b/compiler/src/dotty/tools/dotc/core/Periods.scala
@@ -21,7 +21,7 @@ abstract class Periods { thisCtx: Context =>
     op(thisCtx.fresh.setPeriod(pd))
 
   /** Execute `op` at given phase id */
-  def atPhase[T](pid: PhaseId)(op: Context ?=> T): T =
+  inline def atPhase[T](pid: PhaseId)(inline op: Context ?=> T): T =
     op(using thisCtx.withPhase(pid))
 
   /** The period containing the current period where denotations do not change.

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -31,7 +31,7 @@ trait Phases {
     }
 
   /** Execute `op` at given phase */
-  def atPhase[T](phase: Phase)(op: Context ?=> T): T =
+  inline def atPhase[T](phase: Phase)(inline op: Context ?=> T): T =
     atPhase(phase.id)(op)
 
   def atNextPhase[T](op: Context ?=> T): T = atPhase(phase.next)(op)

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -502,6 +502,7 @@ object StdNames {
     val java: N                 = "java"
     val key: N                  = "key"
     val lang: N                 = "lang"
+    val language: N             = "language"
     val length: N               = "length"
     val lengthCompare: N        = "lengthCompare"
     val macroThis : N           = "_this"

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -156,8 +156,8 @@ object StdNames {
     final val Short: N   = "Short"
     final val Unit: N    = "Unit"
 
-    final val ScalaValueNames: scala.List[N] =
-      scala.List(Byte, Char, Short, Int, Long, Float, Double, Boolean, Unit)
+    final val ScalaValueNames: _root_.scala.List[N] =
+      _root_.scala.List(Byte, Char, Short, Int, Long, Float, Double, Boolean, Unit)
 
     // some types whose companions we utilize
     final val AnyRef: N     = "AnyRef"
@@ -562,7 +562,7 @@ object StdNames {
     val runtimeMirror: N        = "runtimeMirror"
     val s: N                    = "s"
     val sameElements: N         = "sameElements"
-    val scala_ : N              = "scala"
+    val scala : N               = "scala"
     val scalaShadowing : N      = "scalaShadowing"
     val selectDynamic: N        = "selectDynamic"
     val selectOverloadedMethod: N = "selectOverloadedMethod"

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -8,6 +8,7 @@ import StdNames.nme
 import collection.mutable
 import util.Stats
 import config.Config
+import config.Feature.migrateTo3
 import config.Printers.{constr, subtyping, gadts, noPrinter}
 import TypeErasure.{erasedLub, erasedGlb}
 import TypeApplications._
@@ -584,7 +585,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
             * am not sure how, since the code is buried so deep in subtyping logic.
             */
             def boundsOK =
-              ctx.scala2CompatMode ||
+              migrateTo3 ||
               tp1.typeParams.corresponds(tp2.typeParams)((tparam1, tparam2) =>
                 isSubType(tparam2.paramInfo.subst(tp2, tp1), tparam1.paramInfo))
             val saved = comparedTypeLambdas
@@ -1826,7 +1827,8 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
   /** The greatest lower bound of a list types */
   final def glb(tps: List[Type]): Type = tps.foldLeft(AnyType: Type)(glb)
 
-  def widenInUnions(implicit ctx: Context): Boolean = ctx.scala2CompatMode || ctx.erasedTypes
+  def widenInUnions(implicit ctx: Context): Boolean =
+    migrateTo3 || ctx.erasedTypes
 
   /** The least upper bound of two types
    *  @param canConstrain  If true, new constraints might be added to simplify the lub.

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -149,7 +149,7 @@ object Parsers {
       ctx.error(msg, source.atSpan(span))
 
     def unimplementedExpr(implicit ctx: Context): Select =
-      Select(Select(rootDot(nme.scala_), nme.Predef), nme.???)
+      Select(Select(rootDot(nme.scala), nme.Predef), nme.???)
   }
 
   trait OutlineParserCommon extends ParserCommon {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1891,7 +1891,7 @@ object Parsers {
       case DO =>
         ctx.errorOrMigrationWarning(
           i"""`do <body> while <cond>` is no longer supported,
-             |use `while <body> ; <cond>} do ()` instead.${rewriteNotice()}""",
+             |use `while <body> ; <cond> do ()` instead.${rewriteNotice()}""",
           in.sourcePos())
         val start = in.skipToken()
         atSpan(start) {

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -7,6 +7,7 @@ import core.StdNames._, core.Comments._
 import util.SourceFile
 import java.lang.Character.isDigit
 import scala.internal.Chars._
+import util.SourcePosition
 import util.Spans.Span
 import config.Config
 import config.Printers.lexical
@@ -16,6 +17,9 @@ import scala.annotation.{switch, tailrec}
 import scala.collection.mutable
 import scala.collection.immutable.{SortedMap, BitSet}
 import rewrites.Rewrites.patch
+import config.{Feature, SourceVersion}
+import SourceVersion._
+import reporting.Message
 
 object Cbufs {
   import java.lang.StringBuilder
@@ -117,14 +121,17 @@ object Scanners {
     }
 
     def errorButContinue(msg: String, off: Offset = offset): Unit =
-      ctx.error(msg, source atSpan Span(off))
+      ctx.error(msg, sourcePos(off))
 
     /** signal an error where the input ended in the middle of a token */
     def incompleteInputError(msg: String): Unit = {
-      ctx.incompleteInputError(msg, source atSpan Span(offset))
+      ctx.incompleteInputError(msg, sourcePos())
       token = EOF
       errOffset = offset
     }
+
+    def sourcePos(off: Offset = offset): SourcePosition =
+      source.atSpan(Span(off))
 
     // Setting token data ----------------------------------------------------
 
@@ -174,7 +181,15 @@ object Scanners {
     /** A switch whether operators at the start of lines can be infix operators */
     private[Scanners] var allowLeadingInfixOperators = true
 
-    val isScala2CompatMode: Boolean = ctx.scala2CompatSetting
+    var sourceVersion: SourceVersion = // TODO: overwrite when parsing language imports
+      if Feature.enabledBySetting(nme.Scala2Compat) then `3.0-migration`
+      else Feature.sourceVersion
+
+    def migrateTo3 = sourceVersion == `3.0-migration`
+
+    def errorOrMigrationWarning(msg: Message, span: Span = Span(offset))(using Context) =
+      if migrateTo3 then ctx.migrationWarning(msg, source.atSpan(span))
+      else ctx.error(msg, source.atSpan(span))
 
     val rewrite = ctx.settings.rewrite.value.isDefined
     val oldSyntax = ctx.settings.oldSyntax.value
@@ -186,7 +201,7 @@ object Scanners {
     val noindentSyntax =
       ctx.settings.noindent.value
       || ctx.settings.oldSyntax.value
-      || isScala2CompatMode
+      || migrateTo3
     val indentSyntax =
       ((if (Config.defaultIndent) !noindentSyntax else ctx.settings.indent.value)
        || rewriteNoIndent)
@@ -232,17 +247,15 @@ object Scanners {
     private val commentBuf = Cbuf()
 
     private def handleMigration(keyword: Token): Token =
-      if (keyword == ERASED && !ctx.settings.YerasedTerms.value) IDENTIFIER
-      else if (!isScala2CompatMode) keyword
-      else if (scala3keywords.contains(keyword)) treatAsIdent()
+      if keyword == ERASED && !ctx.settings.YerasedTerms.value then IDENTIFIER
+      else if scala3keywords.contains(keyword) && migrateTo3 then treatAsIdent()
       else keyword
 
-    private def treatAsIdent() = {
-      testScala2CompatMode(i"$name is now a keyword, write `$name` instead of $name to keep it as an identifier")
+    private def treatAsIdent(): Token =
+      errorOrMigrationWarning(i"$name is now a keyword, write `$name` instead of $name to keep it as an identifier")
       patch(source, Span(offset), "`")
       patch(source, Span(offset + name.length), "`")
       IDENTIFIER
-    }
 
     def toToken(name: SimpleName): Token = {
       val idx = name.start
@@ -262,19 +275,6 @@ object Scanners {
 
     /** The number of open end marker scopes */
     var openEndMarkers: List[(EndMarkerTag, IndentWidth)] = Nil
-
-// Scala 2 compatibility
-
-    /** Cannot use ctx.featureEnabled because accessing the context would force too much */
-    def testScala2CompatMode(msg: String, span: Span = Span(offset)): Boolean = {
-      if (isScala2CompatMode) ctx.migrationWarning(msg, source.atSpan(span))
-      isScala2CompatMode
-    }
-
-    /** A migration warning if in Scala-2 mode, an error otherwise */
-    def errorOrMigrationWarning(msg: String, span: Span = Span(offset)): Unit =
-      if (isScala2CompatMode) ctx.migrationWarning(msg, source.atSpan(span))
-      else ctx.error(msg, source.atSpan(span))
 
 // Get next token ------------------------------------------------------------
 
@@ -415,8 +415,7 @@ object Scanners {
       *   - it does not follow a blank line, and
       *   - it is followed on the same line by at least one ' '
       *     and a token that can start an expression.
-      *  If a leading infix operator is found and -language:Scala2Compat or -old-syntax is set,
-      *  emit a change warning.
+      *  If a leading infix operator is found and the source version is `3.0-migration`, emit a change warning.
       */
     def isLeadingInfixOperator(inConditional: Boolean = true) = (
       allowLeadingInfixOperators
@@ -432,14 +431,13 @@ object Scanners {
         canStartExprTokens.contains(lookahead.token)
       }
       && {
-        if isScala2CompatMode || oldSyntax && !rewrite then
+        if migrateTo3 then
           val (what, previous) =
             if inConditional then ("Rest of line", "previous expression in parentheses")
             else ("Line", "expression on the previous line")
-          ctx.warning(em"""$what starts with an operator;
-                          |it is now treated as a continuation of the $previous,
-                          |not as a separate statement.""",
-                      source.atSpan(Span(offset)))
+          errorOrMigrationWarning(em"""$what starts with an operator;
+                                      |it is now treated as a continuation of the $previous,
+                                      |not as a separate statement.""")
         true
       }
     )
@@ -1070,10 +1068,10 @@ object Scanners {
     def isNestedEnd = token == RBRACE || token == OUTDENT
 
     def canStartStatTokens =
-      if isScala2CompatMode then canStartStatTokens2 else canStartStatTokens3
+      if migrateTo3 then canStartStatTokens2 else canStartStatTokens3
 
     def canStartExprTokens =
-      if isScala2CompatMode then canStartExprTokens2 else canStartExprTokens3
+      if migrateTo3 then canStartExprTokens2 else canStartExprTokens3
 
 // Literals -----------------------------------------------------------------
 

--- a/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
@@ -72,7 +72,7 @@ object Diagnostic:
   class MigrationWarning(
     msg: Message,
     pos: SourcePosition
-  ) extends ConditionalWarning(msg, pos) {
+  ) extends Warning(msg, pos) {
     def enablingOption(implicit ctx: Context): Setting[Boolean] = ctx.settings.migration
   }
 

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -15,6 +15,8 @@ import Diagnostic._
 import ast.{tpd, Trees}
 import Message._
 import core.Decorators._
+import config.Feature.sourceVersion
+import config.SourceVersion
 
 import java.lang.System.currentTimeMillis
 import java.io.{ BufferedReader, PrintWriter }
@@ -138,8 +140,11 @@ trait Reporting { thisCtx: Context =>
       ex.printStackTrace()
   }
 
-  def errorOrMigrationWarning(msg: Message, pos: SourcePosition = NoSourcePosition): Unit =
-    if (thisCtx.scala2CompatMode) migrationWarning(msg, pos) else error(msg, pos)
+  def errorOrMigrationWarning(msg: Message, pos: SourcePosition = NoSourcePosition,
+      from: SourceVersion = SourceVersion.defaultSourceVersion): Unit =
+    if sourceVersion.isAtLeast(from) then
+      if sourceVersion.isMigrating then migrationWarning(msg, pos)
+      else error(msg, pos)
 
   def restrictionError(msg: Message, pos: SourcePosition = NoSourcePosition): Unit =
     error(msg.mapMsg("Implementation restriction: " + _), pos)

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -124,10 +124,6 @@ trait Reporting { thisCtx: Context =>
   def warning(msg: Message, pos: SourcePosition = NoSourcePosition): Unit =
     reportWarning(new Warning(msg, addInlineds(pos)))
 
-  def strictWarning(msg: Message, pos: SourcePosition = NoSourcePosition): Unit =
-    if (thisCtx.settings.strict.value) error(msg, pos)
-    else warning(msg.append("\n(This would be an error under strict mode)"), pos)
-
   def error(msg: Message, pos: SourcePosition = NoSourcePosition, sticky: Boolean = false): Unit = {
     val fullPos = addInlineds(pos)
     reporter.report(if (sticky) new StickyError(msg, fullPos) else new Error(msg, fullPos))

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -14,7 +14,7 @@ import printing.Highlighting._
 import printing.Formatting
 import ErrorMessageID._
 import ast.Trees
-import config.ScalaVersion
+import config.{Feature, ScalaVersion}
 import typer.ErrorReporting.{Errors, err}
 import typer.ProtoTypes.ViewProto
 import scala.util.control.NonFatal
@@ -1810,8 +1810,8 @@ object messages {
     extends DeclarationMsg(UnapplyInvalidReturnTypeID) {
     def msg =
       val addendum =
-        if (ctx.scala2CompatMode && unapplyName == nme.unapplySeq)
-          "\nYou might want to try to rewrite the extractor to use `unapply` instead."
+        if Feature.migrateTo3 && unapplyName == nme.unapplySeq
+        then "\nYou might want to try to rewrite the extractor to use `unapply` instead."
         else ""
       em"""| ${Red(i"$unapplyResult")} is not a valid result type of an $unapplyName method of an ${Magenta("extractor")}.$addendum"""
     def explain = if (unapplyName.show == "unapply")

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -5,6 +5,8 @@ import core._
 import Contexts._, Symbols._, Types._, Flags._, StdNames._
 import MegaPhase._
 import NameKinds.NonLocalReturnKeyName
+import config.Feature.sourceVersion
+import config.SourceVersion._
 
 object NonLocalReturns {
   import ast.tpd._
@@ -87,10 +89,9 @@ class NonLocalReturns extends MiniPhase {
     }
 
   override def transformReturn(tree: Return)(implicit ctx: Context): Tree =
-    if (isNonLocalReturn(tree)) {
-      if (!ctx.scala2CompatMode)
-        ctx.strictWarning("Non local returns are deprecated; use scala.util.control.NonLocalReturns instead", tree.sourcePos)
+    if isNonLocalReturn(tree) then
+      if sourceVersion.isAtLeast(`3.1`) then
+        ctx.errorOrMigrationWarning("Non local returns are no longer supported; use scala.util.control.NonLocalReturns instead", tree.sourcePos)
       nonLocalReturnThrow(tree.expr, tree.from.symbol).withSpan(tree.span)
-    }
     else tree
 }

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -379,8 +379,8 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
       }
 
     /** Transforms the rhs tree into a its default tree if it is in an `erased` val/def.
-    *  Performed to shrink the tree that is known to be erased later.
-    */
+     *  Performed to shrink the tree that is known to be erased later.
+     */
     private def normalizeErasedRhs(rhs: Tree, sym: Symbol)(implicit ctx: Context) =
       if (sym.isEffectivelyErased) dropInlines.transform(rhs) else rhs
   }

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -23,6 +23,7 @@ import ProtoTypes._
 import Inferencing._
 import transform.TypeUtils._
 import Nullables.{postProcessByNameArgs, given _}
+import config.Feature
 
 import collection.mutable
 import config.Printers.{overload, typr, unapp}
@@ -1231,7 +1232,7 @@ trait Applications extends Compatibility {
         for (argType <- argTypes) assert(!isBounds(argType), unapplyApp.tpe.show)
         val bunchedArgs = argTypes match {
           case argType :: Nil =>
-            if (args.lengthCompare(1) > 0 && ctx.canAutoTuple) untpd.Tuple(args) :: Nil
+            if (args.lengthCompare(1) > 0 && Feature.autoTuplingEnabled) untpd.Tuple(args) :: Nil
             else args
           case _ => args
         }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -32,7 +32,7 @@ import NameOps._
 import SymDenotations.{NoCompleter, NoDenotation}
 import Applications.unapplyArgs
 import transform.patmat.SpaceEngine.isIrrefutableUnapply
-
+import config.Feature
 
 import collection.mutable
 import reporting.Message
@@ -831,7 +831,7 @@ trait Checking {
                    description: => String,
                    featureUseSite: Symbol,
                    pos: SourcePosition)(using Context): Unit =
-    if (!ctx.featureEnabled(name))
+    if !Feature.enabled(name) then
       ctx.featureWarning(name.toString, description, featureUseSite, required = false, pos)
 
   /** Check that `tp` is a class type and that any top-level type arguments in this type

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -32,7 +32,8 @@ import NameOps._
 import SymDenotations.{NoCompleter, NoDenotation}
 import Applications.unapplyArgs
 import transform.patmat.SpaceEngine.isIrrefutableUnapply
-import config.Feature
+import config.Feature._
+import config.SourceVersion._
 
 import collection.mutable
 import reporting.Message
@@ -309,7 +310,8 @@ object Checking {
     }
   }
 
-  /** If `sym` has an operator name, check that it has an @alpha annotation under -strict */
+  /** If `sym` has an operator name, check that it has an @alpha annotation in 3.1 and later
+   */
   def checkValidOperator(sym: Symbol)(using Context): Unit =
     sym.name.toTermName match {
       case name: SimpleName
@@ -318,7 +320,7 @@ object Checking {
          && !name.isConstructorName
          && !sym.getAnnotation(defn.AlphaAnnot).isDefined
          && !sym.is(Synthetic)
-         && ctx.settings.strict.value =>
+         && sourceVersion.isAtLeast(`3.1`) =>
         ctx.deprecationWarning(
           i"$sym has an operator name; it should come with an @alpha annotation", sym.sourcePos)
       case _ =>
@@ -683,7 +685,7 @@ trait Checking {
     def check(pat: Tree, pt: Type): Boolean = (pt <:< pat.tpe) || fail(pat, pt)
 
     def recur(pat: Tree, pt: Type): Boolean =
-      !ctx.settings.strict.value || // only in -strict mode for now since mitigations work only after this PR
+      !sourceVersion.isAtLeast(`3.1`) || // only for 3.1 for now since mitigations work only after this PR
       pat.tpe.widen.hasAnnotation(defn.UncheckedAnnot) || {
         patmatch.println(i"check irrefutable $pat: ${pat.tpe} against $pt")
         pat match {
@@ -804,7 +806,7 @@ trait Checking {
              !isInfix(meth) &&
              !meth.maybeOwner.is(Scala2x) &&
              !infixOKSinceFollowedBy(tree.right) &&
-             ctx.settings.strict.value =>
+             sourceVersion.isAtLeast(`3.1`) =>
             val (kind, alternative) =
               if (ctx.mode.is(Mode.Type))
                 ("type", (n: Name) => s"prefix syntax $n[...]")
@@ -831,7 +833,7 @@ trait Checking {
                    description: => String,
                    featureUseSite: Symbol,
                    pos: SourcePosition)(using Context): Unit =
-    if !Feature.enabled(name) then
+    if !enabled(name) then
       ctx.featureWarning(name.toString, description, featureUseSite, required = false, pos)
 
   /** Check that `tp` is a class type and that any top-level type arguments in this type

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -8,6 +8,7 @@ import Types._, ProtoTypes._, Contexts._, Decorators._, Denotations._, Symbols._
 import Implicits._, Flags._, Constants.Constant
 import util.Spans._
 import util.SourcePosition
+import config.Feature
 import java.util.regex.Matcher.quoteReplacement
 import reporting.Message
 import reporting.messages._
@@ -141,7 +142,7 @@ object ErrorReporting {
     }
 
     def rewriteNotice: String =
-      if (ctx.scala2CompatMode) "\nThis patch can be inserted automatically under -rewrite."
+      if Feature.migrateTo3 then "\nThis patch can be inserted automatically under -rewrite."
       else ""
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -174,9 +174,7 @@ class ImportInfo(symf: Context ?=> Symbol,
   private var myOwner: Symbol = null
   private var myResults: SimpleIdentityMap[TermName, java.lang.Boolean] = SimpleIdentityMap.Empty
 
-  /** Does this import clause or a preceding import clause import `owner.feature`?
-   *  if `feature` is empty, we are looking for a source designator instead.
-   */
+  /** Does this import clause or a preceding import clause import `owner.feature`? */
   def featureImported(feature: TermName, owner: Symbol)(using Context): Boolean =
 
     def compute =

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -15,7 +15,7 @@ import util.Spans._
 import util.Property
 import collection.mutable
 import tpd.ListOfTreeDecorator
-import config.Config
+import config.{Config, Feature}
 import config.Printers.typr
 import Annotations._
 import Inferencing._
@@ -1247,7 +1247,7 @@ class Namer { typer: Typer =>
               traitReq = parent ne parents.head, stablePrefixReq = true)
           if (pt.derivesFrom(cls)) {
             val addendum = parent match {
-              case Select(qual: Super, _) if completerCtx.scala2CompatMode =>
+              case Select(qual: Super, _) if Feature.migrateTo3 =>
                 "\n(Note that inheriting a class of the same name is no longer allowed)"
               case _ => ""
             }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -23,6 +23,8 @@ import transform.ValueClasses._
 import transform.TypeUtils._
 import transform.SymUtils._
 import reporting.messages._
+import config.Feature.sourceVersion
+import config.SourceVersion._
 
 trait NamerContextOps {
   thisCtx: Context =>
@@ -1261,7 +1263,7 @@ class Namer { typer: Typer =>
             else if pclazz.isEffectivelySealed && pclazz.associatedFile != cls.associatedFile then
               if pclazz.is(Sealed) then
                 completerCtx.error(UnableToExtendSealedClass(pclazz), cls.sourcePos)
-              else if completerCtx.settings.strict.value then
+              else if sourceVersion.isAtLeast(`3.1`) then
                 checkFeature(nme.adhocExtensions,
                   i"Unless $pclazz is declared 'open', its extension in a separate file",
                   cls.topLevelClass,

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -18,6 +18,7 @@ import scala.util.Failure
 import config.NoScalaVersion
 import Decorators._
 import typer.ErrorReporting._
+import config.Feature.warnOnMigration
 
 object RefChecks {
   import tpd._
@@ -279,7 +280,7 @@ object RefChecks {
             member.name.is(DefaultGetterName) || // default getters are not checked for compatibility
             memberTp.overrides(otherTp,
                 member.matchNullaryLoosely || other.matchNullaryLoosely ||
-                ctx.testScala2CompatMode(overrideErrorMsg("no longer has compatible type"),
+                warnOnMigration(overrideErrorMsg("no longer has compatible type"),
                    (if (member.owner == clazz) member else clazz).sourcePos))
         catch {
           case ex: MissingType =>
@@ -351,7 +352,7 @@ object RefChecks {
         // Also excluded under Scala2 mode are overrides of default methods of Java traits.
         if (autoOverride(member) ||
             other.owner.isAllOf(JavaInterface) &&
-            ctx.testScala2CompatMode("`override` modifier required when a Java 8 default method is re-implemented", member.sourcePos))
+            warnOnMigration("`override` modifier required when a Java 8 default method is re-implemented", member.sourcePos))
           member.setFlag(Override)
         else if (member.isType && self.memberInfo(member) =:= self.memberInfo(other))
           () // OK, don't complain about type aliases which are equal
@@ -385,7 +386,7 @@ object RefChecks {
       else if (member.is(ModuleVal) && !other.isRealMethod && !other.isOneOf(Deferred | Lazy))
         overrideError("may not override a concrete non-lazy value")
       else if (member.is(Lazy, butNot = Module) && !other.isRealMethod && !other.is(Lazy) &&
-                 !ctx.testScala2CompatMode(overrideErrorMsg("may not override a non-lazy value"), member.sourcePos))
+                 !warnOnMigration(overrideErrorMsg("may not override a non-lazy value"), member.sourcePos))
         overrideError("may not override a non-lazy value")
       else if (other.is(Lazy) && !other.isRealMethod && !member.is(Lazy))
         overrideError("must be declared lazy to override a lazy value")

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -10,6 +10,7 @@ import NameKinds._
 import util.Spans._
 import util.SourcePosition
 import config.Printers.variances
+import config.Feature.migrateTo3
 import reporting.trace
 
 /** Provides `check` method to check that all top-level definitions
@@ -166,7 +167,7 @@ class VarianceChecker(using Context) {
     def checkVariance(sym: Symbol, pos: SourcePosition) = Validator.validateDefinition(sym) match {
       case Some(VarianceError(tvar, required)) =>
         def msg = i"${varianceLabel(tvar.flags)} $tvar occurs in ${varianceLabel(required)} position in type ${sym.info} of $sym"
-        if (ctx.scala2CompatMode &&
+        if (migrateTo3 &&
             (sym.owner.isConstructor || sym.ownersIterator.exists(_.isAllOf(ProtectedLocal))))
           ctx.migrationWarning(
             s"According to new variance rules, this is no longer accepted; need to annotate with @uncheckedVariance:\n$msg",

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -58,9 +58,9 @@ class CompilationTests extends ParallelTesting {
       ),
       compileFile("tests/pos-special/typeclass-scaling.scala", defaultOptions.and("-Xmax-inlines", "40")),
       compileFile("tests/pos-special/indent-colons.scala", defaultOptions.and("-Yindent-colons")),
-      compileFile("tests/pos-special/i7296.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings")),
+      compileFile("tests/pos-special/i7296.scala", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/pos-special/notNull.scala", defaultOptions.and("-Yexplicit-nulls")),
-      compileDir("tests/pos-special/adhoc-extension", defaultOptions.and("-strict", "-feature", "-Xfatal-warnings")),
+      compileDir("tests/pos-special/adhoc-extension", defaultOptions.and("-source", "3.1", "-feature", "-Xfatal-warnings")),
       compileFile("tests/pos-special/i7575.scala", defaultOptions.andLanguageFeature("dynamics")),
       compileFile("tests/pos-special/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
       compileFile("tests/run/i5606.scala", defaultOptions.and("-Yretain-trees")),
@@ -115,7 +115,7 @@ class CompilationTests extends ParallelTesting {
     aggregateTests(
       compileFilesInDir("tests/neg", defaultOptions),
       compileFilesInDir("tests/neg-tailcall", defaultOptions),
-      compileFilesInDir("tests/neg-strict", defaultOptions.and("-strict")),
+      compileFilesInDir("tests/neg-strict", defaultOptions.and("-source", "3.1")),
       compileFilesInDir("tests/neg-no-kind-polymorphism", defaultOptions and "-Yno-kind-polymorphism"),
       compileFilesInDir("tests/neg-custom-args/deprecation", defaultOptions.and("-Xfatal-warnings", "-deprecation")),
       compileFilesInDir("tests/neg-custom-args/fatal-warnings", defaultOptions.and("-Xfatal-warnings")),
@@ -149,12 +149,12 @@ class CompilationTests extends ParallelTesting {
         "tests/neg-custom-args/toplevel-samesource/nested/S.scala"),
         defaultOptions),
       compileFile("tests/neg-custom-args/i6300.scala", allowDeepSubtypes),
-      compileFile("tests/neg-custom-args/infix.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings")),
-      compileFile("tests/neg-custom-args/missing-alpha.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings")),
-      compileFile("tests/neg-custom-args/wildcards.scala", defaultOptions.and("-strict", "-deprecation", "-Xfatal-warnings")),
+      compileFile("tests/neg-custom-args/infix.scala", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
+      compileFile("tests/neg-custom-args/missing-alpha.scala", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
+      compileFile("tests/neg-custom-args/wildcards.scala", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/indentRight.scala", defaultOptions.and("-noindent", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/extmethods-tparams.scala", defaultOptions.and("-deprecation", "-Xfatal-warnings")),
-      compileDir("tests/neg-custom-args/adhoc-extension", defaultOptions.and("-strict", "-feature", "-Xfatal-warnings")),
+      compileDir("tests/neg-custom-args/adhoc-extension", defaultOptions.and("-source", "3.1", "-feature", "-Xfatal-warnings")),
       compileFile("tests/neg/i7575.scala", defaultOptions.withoutLanguageFeatures.and("-language:_")),
       compileFile("tests/neg-custom-args/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
       compileFile("tests/neg-custom-args/typeclass-derivation2.scala", defaultOptions.and("-Yerased-terms")),
@@ -174,7 +174,7 @@ class CompilationTests extends ParallelTesting {
     aggregateTests(
       compileFile("tests/run-custom-args/tuple-cons.scala", allowDeepSubtypes),
       compileFile("tests/run-custom-args/i5256.scala", allowDeepSubtypes),
-      compileFile("tests/run-custom-args/fors.scala", defaultOptions and "-strict"),
+      compileFile("tests/run-custom-args/fors.scala", defaultOptions.and("-source", "3.1")),
       compileFile("tests/run-custom-args/no-useless-forwarders.scala", defaultOptions and "-Xmixin-force-forwarders:false"),
       compileFilesInDir("tests/run-custom-args/erased", defaultOptions.and("-Yerased-terms")),
       compileFilesInDir("tests/run-deep-subtype", allowDeepSubtypes),
@@ -236,7 +236,7 @@ class CompilationTests extends ParallelTesting {
       compileList("lib", librarySources,
         defaultOptions.and("-Ycheck-reentrant",
           "-Yerased-terms", // support declaration of scala.compiletime.erasedValue
-          //  "-strict",  // TODO: re-enable once we allow : @unchecked in pattern definitions. Right now, lots of narrowing pattern definitions fail.
+          //  "-source", "3.1",  // TODO: re-enable once we allow : @unchecked in pattern definitions. Right now, lots of narrowing pattern definitions fail.
           "-priorityclasspath", defaultOutputDir))(libGroup)
 
     val tastyCoreSources = sources(Paths.get("tasty/src"))

--- a/compiler/test/dotty/tools/dotc/reporting/TestMessageLaziness.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestMessageLaziness.scala
@@ -26,5 +26,5 @@ class TestMessageLaziness extends DottyTest {
     ctx.error(LazyError())
 
   @Test def assureLazyExtendMessage =
-    ctx.strictWarning(LazyError())
+    ctx.errorOrMigrationWarning(LazyError(), from = config.SourceVersion.`3.1`)
 }

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -69,7 +69,7 @@ object TestConfiguration {
   )
   val picklingWithCompilerOptions =
     picklingOptions.withClasspath(withCompilerClasspath).withRunClasspath(withCompilerClasspath)
-  val scala2CompatMode = defaultOptions.andLanguageFeature("Scala2Compat")
+  val scala2CompatMode = defaultOptions.and("-source", "3.0-migration")
   val explicitUTF8 = defaultOptions and ("-encoding", "UTF8")
   val explicitUTF16 = defaultOptions and ("-encoding", "UTF16")
 

--- a/doc-tool/test/dotty/tools/dottydoc/GenDocs.scala
+++ b/doc-tool/test/dotty/tools/dottydoc/GenDocs.scala
@@ -20,12 +20,11 @@ trait LocalResources extends DocDriver {
     else Array()
 
   def withClasspath(files: Array[String]) =
-    "-siteroot" +: "../docs" +:
-    "-project" +: "Dotty" +:
-    "-language:Scala2Compat" +:
-    "-classpath" +:
-    TestConfiguration.basicClasspath +:
-    files
+       "-siteroot" +: "../docs"
+    +: "-project" +: "Dotty"
+    +: "-source" +: "3.0-migration"
+    +: "-classpath" +: TestConfiguration.basicClasspath
+    +: files
 }
 
 object GenDottyDocs extends LocalResources {

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -104,6 +104,6 @@ Here is the new syntax for given instances, seen as a delta from the [standard c
 TmplDef           ::=  ...
                    |   ‘given’ GivenDef
 GivenDef          ::=  [GivenSig] Type ‘=’ Expr
-                   |   [GivenSig] ConstrApp {‘,’ ConstrApp } [TemplateBody]
+                   |   [GivenSig] ConstrApps [TemplateBody]
 GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘as’
 ```

--- a/docs/docs/reference/dropped-features/auto-apply.md
+++ b/docs/docs/reference/dropped-features/auto-apply.md
@@ -75,7 +75,7 @@ requirement.
 ### Migrating code
 
 Existing Scala code with inconsistent parameters can still be compiled
-in Dotty under `-language:Scala2Compat`. When paired with the `-rewrite`
+in Dotty under `-source 3.0-migration`. When paired with the `-rewrite`
 option, the code will be automatically rewritten to conform to Dotty's
 stricter checking.
 

--- a/docs/docs/reference/dropped-features/procedure-syntax.md
+++ b/docs/docs/reference/dropped-features/procedure-syntax.md
@@ -12,7 +12,7 @@ has been dropped. You need to write one of the following instead:
 def f() = { ... }
 def f(): Unit = { ... }
 ```
-Dotty will accept the old syntax under the `-language:Scala2Compat` option.
+Dotty will accept the old syntax under the `-source:3.0-migration` option.
 If the `-migration` option is set, it can even rewrite old syntax to new.
 The [ScalaFix](https://scalacenter.github.io/scalafix/) tool also
 can rewrite procedure syntax to make it Dotty-compatible.

--- a/docs/docs/reference/features-classification.md
+++ b/docs/docs/reference/features-classification.md
@@ -76,7 +76,7 @@ These constructs are restricted to make the language safer.
  - [@infix and @alpha](https://github.com/lampepfl/dotty/pull/5975)
  make method application syntax uniform across code bases and require alphanumeric aliases for all symbolic names (proposed, not implemented).
 
-Unrestricted implicit conversions continue to be available in Scala 3.0, but will be deprecated and removed later. Unrestricted versions of the other constructs in the list above are available only under `-language:Scala2Compat`.
+Unrestricted implicit conversions continue to be available in Scala 3.0, but will be deprecated and removed later. Unrestricted versions of the other constructs in the list above are available only under `-source 3.0-migration`.
 
 **Status: now or never**
 
@@ -107,7 +107,7 @@ The date when these constructs are dropped varies. The current status is:
 
  - Not implemented at all:
    - DelayedInit, existential types, weak conformance.
- - Supported under `-language:Scala2Compat`:
+ - Supported under `-source 3.0-migration`:
    - procedure syntax, class shadowing, symbol literals, auto application, auto tupling in a restricted form.
  - Supported in 3.0, to be deprecated and phased out later:
    - XML literals, compound types.
@@ -132,7 +132,7 @@ These constructs have undergone changes to make them more regular and useful.
  - [Eta expansion](changed-features/eta-expansion.md) is now performed universally also in the absence of an expected type. The postfix `_` operator is thus made redundant. It will be deprecated and dropped after Scala 3.0.
  - [Implicit Resolution](changed-features/implicit-resolution.md): The implicit resolution rules have been cleaned up to make them more useful and less surprising. Implicit scope is restricted to no longer include package prefixes.
 
-Most aspects of old-style implicit resolution are still available under `-language:Scala2Compat`. The other changes in this list are applied unconditionally.
+Most aspects of old-style implicit resolution are still available under `-source 3.0-migration`. The other changes in this list are applied unconditionally.
 
 **Status: strongly advisable**
 

--- a/docs/docs/reference/overview.md
+++ b/docs/docs/reference/overview.md
@@ -61,7 +61,7 @@ These constructs are restricted to make the language safer.
  - [@infix and @alpha](https://github.com/lampepfl/dotty/pull/5975)
  make method application syntax uniform across code bases and require alphanumeric aliases for all symbolic names (proposed, not implemented).
 
-Unrestricted implicit conversions continue to be available in Scala 3.0, but will be deprecated and removed later. Unrestricted versions of the other constructs in the list above are available only under `-language:Scala2Compat`.
+Unrestricted implicit conversions continue to be available in Scala 3.0, but will be deprecated and removed later. Unrestricted versions of the other constructs in the list above are available only under `-source 3.0-migration`.
 
 
 ## Dropped Constructs
@@ -83,7 +83,7 @@ The date when these constructs are dropped varies. The current status is:
 
  - Not implemented at all:
    - DelayedInit, existential types, weak conformance.
- - Supported under `-language:Scala2Compat`:
+ - Supported under `-source 3.0-migration`:
    - procedure syntax, class shadowing, symbol literals, auto application, auto tupling in a restricted form.
  - Supported in 3.0, to be deprecated and phased out later:
    - XML literals, compound types.
@@ -98,7 +98,7 @@ These constructs have undergone changes to make them more regular and useful.
  - [Eta expansion](changed-features/eta-expansion.md) is now performed universally also in the absence of an expected type. The postfix `_` operator is thus made redundant. It will be deprecated and dropped after Scala 3.0.
  - [Implicit Resolution](changed-features/implicit-resolution.md): The implicit resolution rules have been cleaned up to make them more useful and less surprising. Implicit scope is restricted to no longer include package prefixes.
 
-Most aspects of old-style implicit resolution are still available under `-language:Scala2Compat`. The other changes in this list are applied unconditionally.
+Most aspects of old-style implicit resolution are still available under `-source 3.0-migration`. The other changes in this list are applied unconditionally.
 
 ## New Constructs
 

--- a/docs/docs/usage/language-versions.md
+++ b/docs/docs/usage/language-versions.md
@@ -14,7 +14,7 @@ The default Scala language version currently supported by the Dotty compiler is 
     - gives some additional warnings where the semantics has changed between Scala 2.13 and 3.0
     - in conjunction with `-rewrite`, offer code rewrites from Scala 2.13 to 3.0.
 
- - `3.1-migration: Same as `3.1` but with additional helps to migrate from `3.0`. The helpers are similar to, but less extensive than, the ones for `3.0-migration`.
+ - `3.1-migration: Same as `3.1` but with additional helpers to migrate from `3.0`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
 
 There are two ways to specify a language version.
 

--- a/docs/docs/usage/language-versions.md
+++ b/docs/docs/usage/language-versions.md
@@ -1,0 +1,31 @@
+---
+layout: doc-page
+title: "Language Versions"
+---
+
+The default Scala language version currently supported by the Dotty compiler is `3.0`. There are also other language versions that can be specified instead:
+
+ - `3.1`: A preview of changes introduced in the next version after 3.0. Some Scala-2 specific idioms will be dropped in this version. The feature set supported by this version will be refined over time  as we approach its release.
+
+ - `3.0-migration`: Same as `3.0` but with a Scala 2 compatibility mode that helps moving Scala 2.13 sources over to Scala 3. In particular, it
+
+    - flags some Scala 2 constructs that are disallowed in Scala 3 as migration warnings instead of hard errors,
+    - changes some rules to be more lenient and backwards compatible with Scala 2.13
+    - gives some additional warnings where the semantics has changed between Scala 2.13 and 3.0
+    - in conjunction with `-rewrite`, offer code rewrites from Scala 2.13 to 3.0.
+
+ - `3.1-migration: Same as `3.1` but with additional helps to migrate from `3.0`. The helpers are similar to, but less extensive than, the ones for `3.0-migration`.
+
+There are two ways to specify a language version.
+
+ - With a `-source` command line setting, e.g. `-source 3.0-migration`.
+ - With a `scala.language` import at the top of a compilation unit, e.g:
+
+```scala
+package p
+import scala.language.`3.1`
+
+class C { ... }
+```
+
+Language imports supersede command-line settings in the compilation units where they are specified. Only one language import is allowed in a compilation unit, and it must come before any definitions in that unit.

--- a/docs/docs/usage/language-versions.md
+++ b/docs/docs/usage/language-versions.md
@@ -14,7 +14,7 @@ The default Scala language version currently supported by the Dotty compiler is 
     - gives some additional warnings where the semantics has changed between Scala 2.13 and 3.0
     - in conjunction with `-rewrite`, offer code rewrites from Scala 2.13 to 3.0.
 
- - `3.1-migration: Same as `3.1` but with additional helpers to migrate from `3.0`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
+ - `3.1-migration`: Same as `3.1` but with additional helpers to migrate from `3.0`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
 
 There are two ways to specify a language version.
 

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -11,6 +11,8 @@ sidebar:
           url: docs/usage/ide-support.html
         - title: Worksheet mode in Dotty IDE
           url: docs/usage/worksheet-mode.html
+        - title: Language Versions
+          url: docs/usage/language-versions.html
         - title: cbt-projects
           url: docs/usage/cbt-projects.html
         - title: Dottydoc

--- a/library/src/scalaShadowing/language.scala
+++ b/library/src/scalaShadowing/language.scala
@@ -238,4 +238,10 @@ object language {
    *  That's why the language import is required for them.
    */
   object adhocExtensions
+
+  /** Source version */
+  object `3.0-migration`
+  object `3.0`
+  object `3.1-migration`
+  object `3.1`
 }

--- a/library/src/scalaShadowing/language.scala
+++ b/library/src/scalaShadowing/language.scala
@@ -213,7 +213,7 @@ object language {
   }
 
   /** Where imported, a backwards compatibility mode for Scala2 is enabled */
-  @deprecated object Scala2Compat
+  object Scala2Compat
 
   /** Where imported, auto-tupling is disabled */
   object noAutoTupling

--- a/library/src/scalaShadowing/language.scala
+++ b/library/src/scalaShadowing/language.scala
@@ -213,7 +213,7 @@ object language {
   }
 
   /** Where imported, a backwards compatibility mode for Scala2 is enabled */
-  object Scala2Compat
+  @deprecated object Scala2Compat
 
   /** Where imported, auto-tupling is disabled */
   object noAutoTupling

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -785,7 +785,7 @@ object Build {
   lazy val tastyCoreSettings = Seq(
     scalacOptions ~= { old =>
       val (language, other) = old.partition(_.startsWith("-language:"))
-      other :+ (language.headOption.map(_ + ",Scala2Compat").getOrElse("-language:Scala2Compat"))
+      other :+ (language.headOption.map(_ + ",Scala2Compat").getOrElse("-source:3.0-migration"))
     }
   )
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -783,7 +783,10 @@ object Build {
     )
 
   lazy val tastyCoreSettings = Seq(
-    scalacOptions ~= (_ :+ "-source:3.0-migration")
+    scalacOptions ~= { old =>
+      val (language, other) = old.partition(_.startsWith("-language:"))
+      other :+ (language.headOption.map(_ + ",Scala2Compat").getOrElse("-source:3.0-migration"))
+    }
   )
 
   lazy val `tasty-core` = project.in(file("tasty")).asTastyCore(NonBootstrapped)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -783,10 +783,7 @@ object Build {
     )
 
   lazy val tastyCoreSettings = Seq(
-    scalacOptions ~= { old =>
-      val (language, other) = old.partition(_.startsWith("-language:"))
-      other :+ (language.headOption.map(_ + ",Scala2Compat").getOrElse("-source:3.0-migration"))
-    }
+    scalacOptions ~= (_ :+ "-source:3.0-migration")
   )
 
   lazy val `tasty-core` = project.in(file("tasty")).asTastyCore(NonBootstrapped)

--- a/sbt-dotty/sbt-test/compilerReporter/simple/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/compilerReporter/simple/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/discovery/test-discovery/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/discovery/test-discovery/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/abstract-override/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/abstract-override/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/abstract-type-override/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/abstract-type-override/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/abstract-type/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/abstract-type/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/added/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/added/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/anon-class-java-depends-on-scala/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/anon-class-java-depends-on-scala/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/anon-java-scala-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/anon-java-scala-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/as-seen-from-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/as-seen-from-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/as-seen-from-b/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/as-seen-from-b/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/backtick-quoted-names/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/backtick-quoted-names/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/binary/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/binary/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/by-name/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/by-name/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/canon/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/canon/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/changedTypeOfChildOfSealed/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/changedTypeOfChildOfSealed/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/check-classes/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/check-classes/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/check-dependencies/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/check-dependencies/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/check-products/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/check-products/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/check-recompilations/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/check-recompilations/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/class-based-inheritance/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/class-based-inheritance/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/class-based-memberRef/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/class-based-memberRef/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/compactify/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/compactify/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/constants/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/constants/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/constructors-unrelated/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/constructors-unrelated/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/continuations/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/continuations/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/cross-source/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/cross-source/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/default-params/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/default-params/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/dup-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/dup-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/empty-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/empty-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/empty-modified-names/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/empty-modified-names/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/empty-package/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/empty-package/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/erasure/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/erasure/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/expanded-type-projection/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/expanded-type-projection/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/export-jars/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-jars/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/export-jars2/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-jars2/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/false-error/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/false-error/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/fbounded-existentials/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/fbounded-existentials/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/implicit-params/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit-params/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/implicit-search-companion-scope/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit-search-companion-scope/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/implicit-search-higher-kinded/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit-search-higher-kinded/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/implicit-search/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit-search/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/implicit/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/implicit/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/import-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/import-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/import-package/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/import-package/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/inherited-deps-java/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/inherited-deps-java/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/inherited_type_params/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/inherited_type_params/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/inner-class-java-depends-on-scala/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/inner-class-java-depends-on-scala/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/intermediate-error/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/intermediate-error/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-analysis-serialization-error/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-analysis-serialization-error/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2CompatCompat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-anonymous/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-anonymous/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-basic/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-basic/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-enum/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-enum/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-generic-workaround/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-generic-workaround/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-inner/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-inner/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-lambda-typeparams/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-lambda-typeparams/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-mixed/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-mixed/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-name-with-dollars/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-name-with-dollars/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/java-static/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/java-static/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/lazy-val/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/lazy-val/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/less-inter-inv-java/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/less-inter-inv-java/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/less-inter-inv/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/less-inter-inv/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/linearization/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/linearization/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/local-class-inheritance-from-java/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/local-class-inheritance-from-java/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/local-class-inheritance/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/local-class-inheritance/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/malformed-class-name-with-dollar/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/malformed-class-name-with-dollar/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/malformed-class-name/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/malformed-class-name/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/named/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/named/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/nested-case-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/nested-case-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/nested-type-params/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/nested-type-params/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/new-cyclic/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/new-cyclic/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/new-pkg-dep/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/new-pkg-dep/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/override/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/override/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-implicit/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-name/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-name/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/package-object-nested-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/package-object-nested-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/packageobject-and-traits/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/packageobject-and-traits/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/parent-change/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/parent-change/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/parent-member-change/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/parent-member-change/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/pkg-private-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/pkg-private-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/pkg-self/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/pkg-self/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/qualified-access/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/qualified-access/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/recorded-products/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/recorded-products/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/remove-test-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/remove-test-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/remove-test-b/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/remove-test-b/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/repeated-parameters/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/repeated-parameters/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/replace-test-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/replace-test-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/resident-java/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/resident-java/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/resident-package-object/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/resident-package-object/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/restore-classes/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/restore-classes/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/same-file-used-names/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/same-file-used-names/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/sealed/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/sealed/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/signature-change/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/signature-change/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/specialized/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/specialized/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/stability-change/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/stability-change/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/struct-projection/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/struct-projection/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/struct-usage/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/struct-usage/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/struct/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/struct/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/synthetic-companion/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/synthetic-companion/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/trait-member-modified/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/trait-member-modified/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/trait-private-object/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/trait-private-object/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/trait-private-val/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/trait-private-val/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/trait-private-var/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/trait-private-var/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/trait-super/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/trait-super/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-b/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-b/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-inherit-java/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-inherit-java/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-inherit/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-inherit/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/transitive-memberRef/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/transitive-memberRef/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/type-alias/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/type-alias/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/type-member-nested-object/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/type-member-nested-object/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/type-parameter/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/type-parameter/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/typeargref/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/typeargref/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/typeref-only/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/typeref-only/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/typeref-return/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/typeref-return/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/types-in-used-names-a/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/types-in-used-names-a/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/types-in-used-names-b/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/types-in-used-names-b/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/unexpanded-names/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/unexpanded-names/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/value-class-underlying/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/value-class-underlying/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/value-class/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/value-class/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/var/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/var/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/sbt-dotty/sbt-test/source-dependencies/variance/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/variance/project/DottyInjectedPlugin.scala
@@ -7,6 +7,6 @@ object DottyInjectedPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     scalaVersion := sys.props("plugin.scalaVersion"),
-    scalacOptions += "-language:Scala2Compat"
+    scalacOptions += "-source:3.0-migration"
   )
 }

--- a/tests/neg/i6056.scala
+++ b/tests/neg/i6056.scala
@@ -1,7 +1,7 @@
 object i0{
     import i0.i0   // error
     def i0={
-        import _  // error // error
-        import    // error
+        import _  // error
+        import
     }             // error
 }

--- a/tests/neg/source-import.scala
+++ b/tests/neg/source-import.scala
@@ -1,0 +1,6 @@
+import language.`3.0`
+import language.`3.0` // error
+
+class C:
+  import language.`3.0-migration` // error
+

--- a/tests/pos-scala2/i4762.scala
+++ b/tests/pos-scala2/i4762.scala
@@ -1,3 +1,0 @@
-class Foo {
-  inline def foo = 1
-}

--- a/tests/pos/doWhile.scala
+++ b/tests/pos/doWhile.scala
@@ -1,0 +1,31 @@
+import language.`3.0-migration`
+class Test {
+  do {
+    val x = 1
+    println(x)
+  } while {
+    val x = "a"
+    println(x)
+    true
+  }
+
+  do {
+    val x = 1
+  } while {
+    val x = "a"
+    true
+  }
+}
+class Test2 {
+  val x: Int = 3
+  do {
+    val x = ""
+  } while (x == 2)
+
+  do (x == 3)
+  while {
+    val x = "a"
+    true
+  }
+
+}

--- a/tests/pos/type-projection.scala
+++ b/tests/pos/type-projection.scala
@@ -1,3 +1,8 @@
+package p
+package q
+import java.lang._
+import language.`3.0-migration`
+
 trait Txn[S <: Sys[S]] {
   def system: S
 

--- a/tests/pos/variances-constr.scala
+++ b/tests/pos/variances-constr.scala
@@ -1,3 +1,5 @@
+import language.`3.0-migration`
+
 class C[+A] {
 
   private[this] var y: A = _


### PR DESCRIPTION
Unlike originally proposed in #8571, we now just use -source, the separate
-migration setting is gone. We replace it by having source versions for migrations.
So, right now, we have

 3.0, 3.1, 3.0-migration and 3.1-migration.

A X-migration source level means that migration warnings and changes in preparation
for the X source level are enabled.

So, the scenarios in #8571 would map as follows:

 - I want to cross compile between Scala 2 and Scala 3: not yet implemented, but it would be -source 2x3
 - I want help with migration to Scala 3: -source 3.0-migration
 - I want help with migration to the cross-compilable subset: not yet implemented, but it would be -source 2x3-migration
 - I want to make sure my code is future-proof for 3.1: -source 3.1
 - I want help making my code future-proof for 3.1: -source 3.1-migration
 - My compiler's version is3.1, but I want to stick to the more lenient 3.0 version for the moment: -source 3.0.
 - My compiler's version is 3.1, but I want to stick to the cross-compilable subset: not yet implemented, but it would be -source 2x3