### PR TITLE
Use indentation to control newline insertion before parentheses

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1054,10 +1054,9 @@ class TreeUnpickler(reader: TastyReader,
         ConstFold(untpd.Select(qual, name).withType(tpe))
       }
 
-      def readQualId(): (untpd.Ident, TypeRef) = {
+      def readQualId(): (untpd.Ident, TypeRef) =
         val qual = readTerm().asInstanceOf[untpd.Ident]
-         (untpd.Ident(qual.name).withSpan(qual.span), qual.tpe.asInstanceOf[TypeRef])
-      }
+        (untpd.Ident(qual.name).withSpan(qual.span), qual.tpe.asInstanceOf[TypeRef])
 
       def accessibleDenot(qualType: Type, name: Name, sig: Signature) = {
         val pre = ctx.typeAssigner.maybeSkolemizePrefix(qualType, name)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1280,7 +1280,7 @@ object Parsers {
 
     def argumentStart(): Unit =
       colonAtEOLOpt()
-      if in.isScala2CompatMode && in.isNewLine && in.next.token == LBRACE then
+      if in.isScala2CompatMode && in.token == NEWLINE && in.next.token == LBRACE then
         in.nextToken()
         if in.indentWidth(in.offset) == in.currentRegion.indentWidth then
           in.errorOrMigrationWarning(

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2804,7 +2804,7 @@ object Parsers {
       }
 
     def annotations(skipNewLines: Boolean = false): List[Tree] = {
-      if (skipNewLines) newLineOptWhenFollowedBy(AT)
+      if (skipNewLines) newLinesOptWhenFollowedBy(AT)
       if (in.token == AT) annot() :: annotations(skipNewLines)
       else Nil
     }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1280,13 +1280,14 @@ object Parsers {
 
     def argumentStart(): Unit =
       colonAtEOLOpt()
-      if in.isScala2CompatMode && in.token == NEWLINE && in.next.token == LBRACE then
+      if migrateTo3 && in.token == NEWLINE && in.next.token == LBRACE then
         in.nextToken()
         if in.indentWidth(in.offset) == in.currentRegion.indentWidth then
-          in.errorOrMigrationWarning(
+          ctx.errorOrMigrationWarning(
             i"""This opening brace will start a new statement in Scala 3.
                |It needs to be indented to the right to keep being treated as
-               |an argument to the previous expression.${rewriteNotice()}""")
+               |an argument to the previous expression.${rewriteNotice()}""",
+            in.sourcePos())
           patch(source, Span(in.offset), "  ")
 
     def possibleTemplateStart(isNew: Boolean = false): Unit =

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1278,11 +1278,6 @@ object Parsers {
       if (in.token == COLONEOL) in.nextToken()
     }
 
-    def possibleBracesStart(): Unit = {
-      colonAtEOLOpt()
-      newLineOptWhenFollowedBy(LBRACE)
-    }
-
     def possibleTemplateStart(isNew: Boolean = false): Unit =
       in.observeColonEOL()
       if in.token == COLONEOL then
@@ -1473,7 +1468,7 @@ object Parsers {
     val refinedType: () => Tree = () => refinedTypeRest(withType())
 
     def refinedTypeRest(t: Tree): Tree = {
-      possibleBracesStart()
+      colonAtEOLOpt()
       if (in.isNestedStart)
         refinedTypeRest(atSpan(startOffset(t)) { RefinedTypeTree(rejectWildcardType(t), refinement()) })
       else t
@@ -2227,7 +2222,7 @@ object Parsers {
     }
 
     def simpleExprRest(t: Tree, canApply: Boolean = true): Tree = {
-      if (canApply) possibleBracesStart()
+      if canApply then colonAtEOLOpt()
       in.token match {
         case DOT =>
           in.nextToken()
@@ -2303,7 +2298,7 @@ object Parsers {
     /** ArgumentExprss ::= {ArgumentExprs}
      */
     def argumentExprss(fn: Tree): Tree = {
-      possibleBracesStart()
+      colonAtEOLOpt()
       if (in.token == LPAREN || in.isNestedStart) argumentExprss(mkApply(fn, argumentExprs()))
       else fn
     }
@@ -3328,7 +3323,7 @@ object Parsers {
      */
     def selfInvocation(): Tree =
       atSpan(accept(THIS)) {
-        possibleBracesStart()
+        colonAtEOLOpt()
         argumentExprss(mkApply(Ident(nme.CONSTRUCTOR), argumentExprs()))
       }
 

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -409,7 +409,7 @@ object Scanners {
       *     and a token that can start an expression.
       *  If a leading infix operator is found and the source version is `3.0-migration`, emit a change warning.
       */
-    def isLeadingInfixOperator(inConditional: Boolean = true) = (
+    def isLeadingInfixOperator(inConditional: Boolean = true) =
       allowLeadingInfixOperators
       && (  token == BACKQUOTED_IDENT
          || token == IDENTIFIER && isOperatorPart(name(name.length - 1)))
@@ -434,7 +434,6 @@ object Scanners {
             sourcePos())
         true
       }
-    )
 
     /** The indentation width of the given offset */
     def indentWidth(offset: Offset): IndentWidth = {
@@ -533,6 +532,7 @@ object Scanners {
          && canEndStatTokens.contains(lastToken)
          && canStartStatTokens.contains(token)
          && !isLeadingInfixOperator()
+         && !(openParensTokens.contains(token) && lastWidth < nextWidth && !pastBlankLine)
       then
         insert(if (pastBlankLine) NEWLINES else NEWLINE, lineOffset)
         skipEndMarker(nextWidth)

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -435,6 +435,9 @@ object Scanners {
         true
       }
 
+    def isContinuingParens() =
+      openParensTokens.contains(token) && !pastBlankLine && !isScala2Mode
+
     /** The indentation width of the given offset */
     def indentWidth(offset: Offset): IndentWidth = {
       import IndentWidth.{Run, Conc}
@@ -532,7 +535,7 @@ object Scanners {
          && canEndStatTokens.contains(lastToken)
          && canStartStatTokens.contains(token)
          && !isLeadingInfixOperator()
-         && !(openParensTokens.contains(token) && lastWidth < nextWidth && !pastBlankLine)
+         && !(lastWidth < nextWidth && isContinuingParens())
       then
         insert(if (pastBlankLine) NEWLINES else NEWLINE, lineOffset)
         skipEndMarker(nextWidth)

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -436,7 +436,7 @@ object Scanners {
       }
 
     def isContinuingParens() =
-      openParensTokens.contains(token) && !pastBlankLine && !isScala2Mode
+      openParensTokens.contains(token) && !pastBlankLine && !isScala2CompatMode
 
     /** The indentation width of the given offset */
     def indentWidth(offset: Offset): IndentWidth = {

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -436,7 +436,10 @@ object Scanners {
       }
 
     def isContinuingParens() =
-      openParensTokens.contains(token) && !pastBlankLine && !isScala2CompatMode
+      openParensTokens.contains(token)
+      && !pastBlankLine
+      && !isScala2CompatMode
+      && !noindentSyntax
 
     /** The indentation width of the given offset */
     def indentWidth(offset: Offset): IndentWidth = {

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -438,7 +438,7 @@ object Scanners {
     def isContinuingParens() =
       openParensTokens.contains(token)
       && !pastBlankLine
-      && !isScala2CompatMode
+      && !migrateTo3
       && !noindentSyntax
 
     /** The indentation width of the given offset */

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -221,8 +221,12 @@ object Tokens extends TokensCommon {
   final val atomicExprTokens: TokenSet = literalTokens | identifierTokens | BitSet(
     USCORE, NULL, THIS, SUPER, TRUE, FALSE, RETURN, QUOTEID, XMLSTART)
 
-  final val canStartExprTokens3: TokenSet = atomicExprTokens | BitSet(
-    LBRACE, LPAREN, LBRACKET, INDENT, QUOTE, IF, WHILE, FOR, NEW, TRY, THROW)
+  final val openParensTokens = BitSet(LBRACE, LPAREN, LBRACKET)
+
+  final val canStartExprTokens3: TokenSet =
+      atomicExprTokens
+    | openParensTokens
+    | BitSet(INDENT, QUOTE, IF, WHILE, FOR, NEW, TRY, THROW)
 
   final val canStartExprTokens2: TokenSet = canStartExprTokens3 | BitSet(DO)
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -129,6 +129,7 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/neg-custom-args/i3246.scala", scala2CompatMode),
       compileFile("tests/neg-custom-args/overrideClass.scala", scala2CompatMode),
       compileFile("tests/neg-custom-args/ovlazy.scala", scala2CompatMode.and("-migration", "-Xfatal-warnings")),
+      compileFile("tests/neg-custom-args/newline-braces.scala", scala2CompatMode.and("-migration", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/autoTuplingTest.scala", defaultOptions.andLanguageFeature("noAutoTupling")),
       compileFile("tests/neg-custom-args/nopredef.scala", defaultOptions.and("-Yno-predef")),
       compileFile("tests/neg-custom-args/noimports.scala", defaultOptions.and("-Yno-imports")),

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -234,12 +234,12 @@ ExprInParens      ::=  PostfixExpr ‘:’ Type                                 
 ParArgumentExprs  ::=  ‘(’ [‘using’] ExprsInParens ‘)’                          exprs
                     |  ‘(’ [ExprsInParens ‘,’] PostfixExpr ‘:’ ‘_’ ‘*’ ‘)’      exprs :+ Typed(expr, Ident(wildcardStar))
 ArgumentExprs     ::=  ParArgumentExprs
-                    |  [nl] BlockExpr
+                    |  BlockExpr
 BlockExpr         ::=  ‘{’ (CaseClauses | Block) ‘}’
 Block             ::=  {BlockStat semi} [BlockResult]                           Block(stats, expr?)
 BlockStat         ::=  Import
-                    |  {Annotation [nl]} [‘implicit’ | ‘lazy’] Def
-                    |  {Annotation [nl]} {LocalModifier} TmplDef
+                    |  {Annotation {nl}} [‘implicit’ | ‘lazy’] Def
+                    |  {Annotation {nl}} {LocalModifier} TmplDef
                     |  Expr1
 
 ForExpr           ::=  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’)        ForYield(enums, expr)
@@ -358,7 +358,7 @@ ValDcl            ::=  ids ‘:’ Type                                         
 VarDcl            ::=  ids ‘:’ Type                                             PatDef(_, ids, tpe, EmptyTree)
 DefDcl            ::=  DefSig ‘:’ Type                                          DefDef(_, name, tparams, vparamss, tpe, EmptyTree)
 DefSig            ::=  id [DefTypeParamClause] DefParamClauses
-                    |  ExtParamClause [nl] [‘.’] id DefParamClauses
+                    |  ExtParamClause {nl} [‘.’] id DefParamClauses
 TypeDcl           ::=  id [TypeParamClause] SubtypeBounds [‘=’ Type]           TypeDefTree(_, name, tparams, bound
 
 Def               ::=  ‘val’ PatDef

--- a/tests/neg-custom-args/newline-braces.check
+++ b/tests/neg-custom-args/newline-braces.check
@@ -1,0 +1,7 @@
+-- Error: tests/neg-custom-args/newline-braces.scala:3:2 ---------------------------------------------------------------
+3 |  { x =>    // error (migration)
+  |  ^
+  |  This opening brace will start a new statement in Scala 3.
+  |  It needs to be indented to the right to keep being treated as
+  |  an argument to the previous expression.
+  |  This construct can be rewritten automatically under -rewrite.

--- a/tests/neg-custom-args/newline-braces.scala
+++ b/tests/neg-custom-args/newline-braces.scala
@@ -1,0 +1,6 @@
+def f: List[Int] = {
+  List(1, 2, 3).map  // no newline inserted here in Scala-2 compat mode
+  { x =>    // error (migration)
+    x + 1
+  }
+}

--- a/tests/neg/i1707.scala
+++ b/tests/neg/i1707.scala
@@ -16,7 +16,7 @@ object DepBug {
     import d._
     a m (b)
   }
-  {   // error: Null does not take parameters (follow on)
+  {
     import dep._
     a m (b) // error: not found: a
   }

--- a/tests/pos-scala2/indented-parens.scala
+++ b/tests/pos-scala2/indented-parens.scala
@@ -1,0 +1,13 @@
+val (x, y) =
+  try {
+    ???
+    (1, 2)
+  }
+  catch {
+    case e if !true =>
+      val x = 2
+      val foo = e match {
+        case e: java.io.IOException => ???
+      }
+      (1, 2)
+  }

--- a/tests/pos-scala2/newline-braces.scala
+++ b/tests/pos-scala2/newline-braces.scala
@@ -1,0 +1,6 @@
+def f: List[Int] = {
+  List(1, 2, 3).map  // no newline inserted here in Scala-2 compat mode
+  { x =>
+    x + 1
+  }
+}

--- a/tests/pos/indented-parens.scala
+++ b/tests/pos/indented-parens.scala
@@ -1,0 +1,11 @@
+def f(x: Int)
+     (y: Int): Int = x + y
+
+
+@main def Test =
+  val x = f(1)
+    (2)
+    + f(1)
+       {2}
+  { println(x) }
+

--- a/tests/pos/newline-braces.scala
+++ b/tests/pos/newline-braces.scala
@@ -14,3 +14,10 @@ def f: Int => Int =
   { (x: Int) =>
     x + 1
   }
+
+val x =
+    true &&          // newline inserted here but skipped because of trailing &&
+    {
+      val xyz = true
+      xyz && false
+    }

--- a/tests/pos/newline-braces.scala
+++ b/tests/pos/newline-braces.scala
@@ -1,0 +1,16 @@
+class Foo
+{
+  val x: Int = 5
+}
+
+def bar(): Int =
+{
+  val x = ???
+  x
+}
+
+def f: Int => Int =
+  List(1, 2, 3).map  // newline inserted here
+  { (x: Int) =>
+    x + 1
+  }

--- a/tests/pos/path-from-class.scala
+++ b/tests/pos/path-from-class.scala
@@ -1,0 +1,18 @@
+// Paths rooted in outer classes. Not sure to what degree we
+// want to support them.
+class Outer {
+  type Bar
+  object inner {
+    type Foo
+    def foo: Foo = ???
+  }
+  def bar: Bar = ???
+}
+
+object Main {
+  val a = new Outer
+  val b = new Outer
+  def all = List(a.inner.foo, a.inner.foo)
+    // The inferred type is [Outer#inner.Foo], but this cannot be written in source
+  def bars: Outer # Bar = identity(a.bar)
+}

--- a/tests/pos/tailcall/t6891.scala
+++ b/tests/pos/tailcall/t6891.scala
@@ -15,7 +15,7 @@ object O6891 {
     def beppy[C](c: => C) = {
       () => c
       @tailrec def loop(x: value.type): Unit = loop(x)
-        () => c
+      () => c
       ()
     }
   }

--- a/tests/run/Pouring.scala
+++ b/tests/run/Pouring.scala
@@ -18,8 +18,8 @@ class Pouring(capacity: Vector[Int]):
 
   val moves =
     val glasses = 0 until capacity.length
-    
-	   (for g <- glasses yield Move.Empty(g))
+
+       (for g <- glasses yield Move.Empty(g))
     ++ (for g <- glasses yield Move.Fill(g))
     ++ (for g1 <- glasses; g2 <- glasses if g1 != g2 yield Move.Pour(g1, g2))
 

--- a/tests/run/Pouring.scala
+++ b/tests/run/Pouring.scala
@@ -18,7 +18,8 @@ class Pouring(capacity: Vector[Int]):
 
   val moves =
     val glasses = 0 until capacity.length
-       (for g <- glasses yield Move.Empty(g))
+    
+	   (for g <- glasses yield Move.Empty(g))
     ++ (for g <- glasses yield Move.Fill(g))
     ++ (for g1 <- glasses; g2 <- glasses if g1 != g2 yield Move.Pour(g1, g2))
 


### PR DESCRIPTION
Fixes #7559

Scala currently uses an ad-hoc set of rules to determine whether a line
starting with an opening `(`, `[`, or `{` is an argument to the previous
line or starts a new statement. Specifically, a new line is always
inserted but is then skipped at some places (which include applications)
if the next token is a `{`. On the other hand, lines starting with `[` and `(` 
always start a new statement. This leads to the gotchas that
```
val x= foo
{ ... }
```
treats the braces as an argument to `foo`. A blank line is required to avoid this.
On the other hand,
```
foo(arg1)
  (arg2)
  (arg3)
```
does not work; the following lines are interpreted as separate statements.

In this PR, indentation is used instead to determine whether a following line starting
with `(`, `[`, or `{` is an argument or a separate statement. In the first example, it
is a separate statement, since it is not indented. In the second example, it is treated
as an argument, since it is indented.

If we are past a blank line, we always assume the newline. For instance, this
example from Pouring.scala works:
```scala
  val moves =
    val glasses = 0 until capacity.length

       (for g <- glasses yield Move.Empty(g))
    ++ (for g <- glasses yield Move.Fill(g))
    ++ (for g1 <- glasses; g2 <- glasses if g1 != g2 yield Move.Pour(g1, g2))
```
Without the blank line, the `(for g <- ...` expression would be treated as an additional
argument to `capacity.length`.