### PR TITLE
More precise type for typed patterns, less precise for literal patterns

### DIFF
--- a/tests/neg/i3200b.scala
+++ b/tests/neg/i3200b.scala
@@ -1,5 +1,8 @@
 object Test {
   def main(args: Array[String]): Unit = {
-    val a : Nil.type = (Vector(): Any) match { case n @ Nil => n } // error
+    val a: Nil.type = (Vector(): Any) match { case n @ Nil => n } // error
+    val b: Nil.type = (Vector(): Any) match { case n @ (m @ Nil) => n } // error
+    val c: Int = (1.0: Any) match { case n @ 1 => n } // error
+    val d: Int = (1.0: Any) match { case n @ (m @ 1) => n } // error
   }
 }

--- a/tests/run/i3200c.scala
+++ b/tests/run/i3200c.scala
@@ -1,0 +1,28 @@
+sealed trait X
+case object Y extends X
+
+object Test {
+  def yIs1(proof: Y.type): Int = 1
+
+  def test(x: X) = x match {
+    case y: Y.type => yIs1(y)
+  }
+
+  def test2(x: X) = x match {
+    case y @ (yy: Y.type) =>
+      yIs1(y)
+      yIs1(yy)
+  }
+
+  def main(args: Array[String]): Unit = {
+    test(Y)
+
+    val a: Nil.type = (Vector(): Any) match {
+      case n: Nil.type =>
+        assert(false, "should not be reached")
+        n
+      case _ =>
+        Nil
+    }
+  }
+}


### PR DESCRIPTION
In `x @ Nil`, `Nil` is a _stable identifier pattern_ and will be compiled
to an `==` test, so the type of `x` is unrelated to the type of `Nil`.
This was handled correctly before this commit, but the check to use the
moe restrictive patten typing was too wide and also included typed
patterns like `x: Nil.type`, even though such patterns compile to `eq`
tests and therefore it's safe to assume that `x` has type `Nil.type`.

Additionally, a _literal pattern_ will also be compiled to an `==` test
and therefore should be less precisely typed, like a stable identifier
patterns.