### PR TITLE
Fix #8392: Remove parameter type bounds from scala.compiletime.ops.any types

### DIFF
--- a/library/src/scala/compiletime/ops/package.scala
+++ b/library/src/scala/compiletime/ops/package.scala
@@ -11,7 +11,7 @@ package object ops {
      * val eq3: "1" == "1" = true
      * ```
      */
-    @infix type ==[X <: AnyVal, Y <: AnyVal] <: Boolean
+    @infix type ==[X, Y] <: Boolean
 
     /** Inequality comparison of two singleton types.
      * ```scala
@@ -20,7 +20,7 @@ package object ops {
      * val eq3: "1" != "1" = false
      * ```
      */
-    @infix type !=[X <: AnyVal, Y <: AnyVal] <: Boolean
+    @infix type !=[X, Y] <: Boolean
   }
 
   object string {

--- a/tests/neg/singleton-ops-any.check
+++ b/tests/neg/singleton-ops-any.check
@@ -1,0 +1,20 @@
+-- [E007] Type Mismatch Error: tests/neg/singleton-ops-any.scala:6:23 --------------------------------------------------
+6 |  val t34: 10 == "5" = true // error
+  |                       ^^^^
+  |                       Found:    (true : Boolean)
+  |                       Required: (false : Boolean)
+-- [E007] Type Mismatch Error: tests/neg/singleton-ops-any.scala:7:22 --------------------------------------------------
+7 |  val t35: 10 == 10 = false // error
+  |                      ^^^^^
+  |                      Found:    (false : Boolean)
+  |                      Required: (true : Boolean)
+-- [E007] Type Mismatch Error: tests/neg/singleton-ops-any.scala:12:24 -------------------------------------------------
+12 |  val t38: false != 5 = false // error
+   |                        ^^^^^
+   |                        Found:    (false : Boolean)
+   |                        Required: (true : Boolean)
+-- [E007] Type Mismatch Error: tests/neg/singleton-ops-any.scala:13:22 -------------------------------------------------
+13 |  val t39: 10 != 10 = true // error
+   |                      ^^^^
+   |                      Found:    (true : Boolean)
+   |                      Required: (false : Boolean)

--- a/tests/neg/singleton-ops-any.scala
+++ b/tests/neg/singleton-ops-any.scala
@@ -5,6 +5,7 @@ object Test {
   val t33: 0 == false = false
   val t34: 10 == "5" = true // error
   val t35: 10 == 10 = false // error
+  val t35string: "10" == "10" = true
 
   val t36: 1 != 1 = false
   val t37: 0 != 1 = true


### PR DESCRIPTION
Fixes #8392

`String` is not a subtype of `AnyVal`, so the type `"" == ""` could not be applied. 

As discussed in the issue, having no type bound on the parameters of the `==` type is preferable to a type bound of `Singleton` as it maintains the ability to have an unapplied type `Int == Int`, and is more in line with the `any` package name.