### PR TITLE
Make sure that inline val can be inlined

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1803,8 +1803,7 @@ class Typer extends Namer
     }
     val vdef1 = assignType(cpy.ValDef(vdef)(name, tpt1, rhs1), sym)
     checkSignatureRepeatedParam(sym)
-    if (sym.is(Inline, butNot = DeferredOrTermParamOrAccessor))
-      checkInlineConformant(rhs1, isFinal = sym.is(Final), em"right-hand side of inline $sym")
+    checkInlineConformant(tpt1, rhs1, sym)
     patchFinalVals(vdef1)
     vdef1.setDefTree
   }

--- a/tests/neg/i2421.scala
+++ b/tests/neg/i2421.scala
@@ -5,6 +5,6 @@ inline trait Qux // error: modifier(s) `inline' incompatible with type definitio
 
 object Quux {
   inline type T // error: modifier(s) `inline' incompatible with type definition
-  inline var x: Int = 42 // error: modifier(s) `inline' incompatible with var definition
-  inline lazy val y: Int = 43 // error: modifier(s) `inline' incompatible with lazy val definition
+  inline var x: 42 = 42 // error: modifier(s) `inline' incompatible with var definition
+  inline lazy val y: 43 = 43 // error: modifier(s) `inline' incompatible with lazy val definition
 }

--- a/tests/neg/inline-val.scala
+++ b/tests/neg/inline-val.scala
@@ -1,0 +1,4 @@
+
+inline val a = 1 : Int // error
+inline val b: Int = 1 // error
+inline val c = b // error


### PR DESCRIPTION
Inline vals are inlined based on their literal type. We only checked that the RHS
had a literal type that could be inlined, but we did not check if the type of the val
was also a literal. When it is not, the value will not be inlined.

This fixes one of the issues in #8714