### PR TITLE
Fix #8726: test Boolean match with subtype check

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -319,7 +319,7 @@ object PatternMatcher {
 
         if (isSyntheticScala2Unapply(unapp.symbol) && caseAccessors.length == args.length)
           matchArgsPlan(caseAccessors.map(ref(scrutinee).select(_)), args, onSuccess)
-        else if (unapp.tpe.widenSingleton.isRef(defn.BooleanClass))
+        else if (unapp.tpe <:< (defn.BooleanType))
           TestPlan(GuardTest, unapp, unapp.span, onSuccess)
         else
           letAbstract(unapp) { unappResult =>

--- a/tests/run/i8726.scala
+++ b/tests/run/i8726.scala
@@ -1,0 +1,5 @@
+case class A(a: Int)
+object C { def unapply(a: A): true | true = true }
+
+@main
+def Test =  (A(1): A | A) match { case C() => "OK" }


### PR DESCRIPTION
Fix #8726: test Boolean match with subtype check

The result type could be `true | true`, subtype check
is much simpler and robust than symbolic check.