### PR TITLE
Disallow `?` as a type name

### DIFF
--- a/compiler/test-resources/type-printer/hkClass
+++ b/compiler/test-resources/type-printer/hkClass
@@ -1,4 +1,4 @@
-scala> case class Foo[M[?]](x: M[Int])
+scala> case class Foo[M[_]](x: M[Int])
 // defined case class Foo
 scala> Foo(Option(1))
 val res0: Foo[Option] = Foo(Some(1))

--- a/tests/neg/type-qmark.check
+++ b/tests/neg/type-qmark.check
@@ -1,0 +1,60 @@
+-- Error: tests/neg/type-qmark.scala:1:10 ------------------------------------------------------------------------------
+1 |class Foo[?] // error
+  |          ^
+  |          `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:2:12 ------------------------------------------------------------------------------
+2 |class Bar[M[?]] // error
+  |            ^
+  |            `?` is not a valid type name, use `_` to denote a higher-kinded type parameter
+-- Error: tests/neg/type-qmark.scala:13:7 ------------------------------------------------------------------------------
+13 |  case ?() // error
+   |       ^
+   |       `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:16:8 ------------------------------------------------------------------------------
+16 |  class ? { val x = 1 } // error
+   |        ^
+   |        `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:19:8 ------------------------------------------------------------------------------
+19 |  trait ? // error
+   |        ^
+   |        `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:22:7 ------------------------------------------------------------------------------
+22 |  type ? = Int // error
+   |       ^
+   |       `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:25:7 ------------------------------------------------------------------------------
+25 |  enum ? { // error
+   |       ^
+   |       `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:31:8 ------------------------------------------------------------------------------
+31 |  given ?[T] as Foo[T] {} // error
+   |        ^
+   |        `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:3:8 -------------------------------------------------------------------------------
+3 |def foo[?] = {} // error
+  |        ^
+  |        `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:4:10 ------------------------------------------------------------------------------
+4 |def bar[M[?]] = {} // error
+  |          ^
+  |          `?` is not a valid type name, use `_` to denote a higher-kinded type parameter
+-- Error: tests/neg/type-qmark.scala:6:7 -------------------------------------------------------------------------------
+6 |type A[?] = Int // error
+  |       ^
+  |       `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:7:10 ------------------------------------------------------------------------------
+7 |type B = [?] =>> Int // error
+  |          ^
+  |          `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:8:10 ------------------------------------------------------------------------------
+8 |type C = [?] => Int => Int // error
+  |          ^
+  |          `?` is not a valid type name
+-- Error: tests/neg/type-qmark.scala:9:12 ------------------------------------------------------------------------------
+9 |type D = [X[?]] =>> Int // error
+  |            ^
+  |            `?` is not a valid type name, use `_` to denote a higher-kinded type parameter
+-- Error: tests/neg/type-qmark.scala:10:12 -----------------------------------------------------------------------------
+10 |type E = [X[?]] => Int => Int // error
+   |            ^
+   |            `?` is not a valid type name, use `_` to denote a higher-kinded type parameter

--- a/tests/neg/type-qmark.scala
+++ b/tests/neg/type-qmark.scala
@@ -1,0 +1,32 @@
+class Foo[?] // error
+class Bar[M[?]] // error
+def foo[?] = {} // error
+def bar[M[?]] = {} // error
+
+type A[?] = Int // error
+type B = [?] =>> Int // error
+type C = [?] => Int => Int // error
+type D = [X[?]] =>> Int // error
+type E = [X[?]] => Int => Int // error
+
+enum F {
+  case ?() // error
+}
+object G {
+  class ? { val x = 1 } // error
+}
+object H {
+  trait ? // error
+}
+object I {
+  type ? = Int // error
+}
+object J {
+  enum ? { // error
+    case X
+  }
+}
+object K {
+  class Foo[T]
+  given ?[T] as Foo[T] {} // error
+}


### PR DESCRIPTION
Now that we use `?` for wildcards, we should treat it more like a
keyword for types and not allow it as a type name to avoid
confusion.