### PR TITLE
Fix #8731: Revise end markers scheme

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -369,6 +369,8 @@ object Trees {
       comment.map(putAttachment(DocComment, _))
       this
     }
+
+    def name: Name
   }
 
   /** A ValDef or DefDef tree */

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -25,8 +25,6 @@ object Names {
     def toTermName: TermName
   }
 
-  implicit def eqName: Eql[Name, Name] = Eql.derived
-
   /** A common superclass of Name and Symbol. After bootstrap, this should be
    *  just the type alias Name | Symbol
    */
@@ -37,7 +35,7 @@ object Names {
    *  in a name table. A derived term name adds a tag, and possibly a number
    *  or a further simple name to some other name.
    */
-  abstract class Name extends Designator with PreName {
+  abstract class Name extends Designator, PreName derives Eql {
 
     /** A type for names of the same kind as this name */
     type ThisName <: Name

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1325,7 +1325,7 @@ object Parsers {
           in.nextToken()
           if stats.isEmpty || !matches(stats.last) then
             syntaxError("misaligned end marker", Span(start, in.lastCharOffset))
-          in.token = IDENTIFIER
+          in.token = IDENTIFIER // Leaving it as the original token can confuse newline insertion
           in.nextToken()
     end checkEndMarker
 

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -256,8 +256,7 @@ object Tokens extends TokensCommon {
   final val canStartStatTokens3: TokenSet = canStartExprTokens3 | mustStartStatTokens | BitSet(
     AT, CASE)
 
-  final val canEndStatTokens: TokenSet = atomicExprTokens | BitSet(
-    TYPE, RPAREN, RBRACE, RBRACKET, OUTDENT) // TODO: remove GIVEN once old import syntax is dropped
+  final val canEndStatTokens: TokenSet = atomicExprTokens | BitSet(TYPE, RPAREN, RBRACE, RBRACKET, OUTDENT)
 
   /** Tokens that stop a lookahead scan search for a `<-`, `then`, or `do`.
    *  Used for disambiguating between old and new syntax.
@@ -281,6 +280,8 @@ object Tokens extends TokensCommon {
   final val startParamTokens: BitSet = modifierTokens | BitSet(VAL, VAR, AT)
 
   final val scala3keywords = BitSet(ENUM, ERASED, GIVEN)
+
+  final val endMarkerTokens = identifierTokens | BitSet(IF, WHILE, FOR, MATCH, TRY, NEW, GIVEN, VAL, THIS)
 
   final val softModifierNames = Set(nme.inline, nme.opaque, nme.open, nme.transparent)
 }

--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -50,9 +50,7 @@ object SyntaxHighlighting {
         else
           highlightRange(span.start, span.end, color)
 
-      val scanner = new Scanner(source) {
-        override protected def printState() = ()
-      }
+      val scanner = new Scanner(source)
       while (scanner.token != EOF) {
         val start = scanner.offset
         val token = scanner.token

--- a/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -53,6 +53,7 @@ class FrontEnd extends Phase {
       if (unit.isJava) new JavaParser(unit.source).parse()
       else {
         val p = new Parser(unit.source)
+       //  p.in.debugTokenStream = true
         val tree = p.parse()
         if (p.firstXmlPos.exists && !firstXmlPos.exists)
           firstXmlPos = p.firstXmlPos

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -104,9 +104,8 @@ yield
 ### Soft keywords
 
 ```
-as        derives   extension inline    on        opaque    open      transparent
-using
-*         +         -
+as  derives  end  extension  inline  on  opaque  open  transparent  using
+*  +  -
 ```
 
 ## Context-free Syntax
@@ -241,6 +240,7 @@ BlockStat         ::=  Import
                     |  {Annotation [nl]} [‘implicit’ | ‘lazy’] Def
                     |  {Annotation [nl]} {LocalModifier} TmplDef
                     |  Expr1
+                    |  EndMarker
 
 ForExpr           ::=  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’)        ForYield(enums, expr)
                        {nl} [‘yield’] Expr
@@ -344,6 +344,10 @@ ImportSelectors   ::=  id [‘=>’ id | ‘=>’ ‘_’] [‘,’ ImportSelect
 WildCardSelector  ::=  ‘given’ (‘_' | InfixType)
                     |  ‘_'
 Export            ::=  ‘export’ [‘given’] ImportExpr {‘,’ ImportExpr}
+
+EndMarker         ::=  ‘end’ EndMarkerTag    -- when followed by EOL
+EndMarkerTag      ::=  id | ‘if’ | ‘while’ | ‘for’ | ‘match’ | ‘try’
+                    |  ‘new’ | ‘this’ | ‘given’ | ‘extension’ | ‘val’
 ```
 
 ### Declarations and Definitions
@@ -406,6 +410,7 @@ TemplateStat      ::=  Import
                     |  {Annotation [nl]} {Modifier} Def
                     |  {Annotation [nl]} {Modifier} Dcl
                     |  Expr1
+                    |  EndMarker
                     |
 SelfType          ::=  id [‘:’ InfixType] ‘=>’                                  ValDef(_, name, tpt, _)
                     |  ‘this’ ‘:’ InfixType ‘=>’
@@ -422,6 +427,7 @@ TopStat           ::=  Import
                     |  {Annotation [nl]} {Modifier} Def
                     |  Packaging
                     |  PackageObject
+                    |  EndMarker
                     |
 Packaging         ::=  ‘package’ QualId [nl | colonEol] ‘{’ TopStatSeq ‘}’      Package(qid, stats)
 PackageObject     ::=  ‘package’ ‘object’ ObjectDef                             object with package in mods.

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -187,7 +187,7 @@ println(".")
 
 Indentation-based syntax has many advantages over other conventions. But one possible problem is that it makes it hard to discern when a large indentation region ends, since there is no specific token that delineates the end. Braces are not much better since a brace by itself also contains no information about what region is closed.
 
-To solve this problem, Scala 3 offers an optional `end` marker. Example
+To solve this problem, Scala 3 offers an optional `end` marker. Example:
 ```scala
 def largeMethod(...) =
     ...
@@ -214,9 +214,66 @@ End markers are allowed in statement sequences. The specifier token `s` of an en
  - If the statement is a package clause that refers to package `p`, then `s` must be the same identifier `p`.
  - If the statement is an `if`, `while`, `for`, `try`, or `match` statement, then `s` must be that same token.
 
-It is recommended that `end` markers are used for code where the extent of an indentation region is not immediately apparent "at a glance". Typically this is the case if an indentation region spans 20 lines or more.
+For instance, the following end markers are all legal:
+ ```scala
+  package p1.p2:
 
-**Syntax**
+    abstract class C():
+
+      def this(x: Int) =
+        this()
+        if x > 0 then
+          val a :: b =
+            x :: Nil
+          end val
+          var y =
+            x
+          end y
+          while y > 0 do
+            println(y)
+            y -= 1
+          end while
+          try
+            x match
+              case 0 => println("0")
+              case _ =>
+            end match
+          finally
+            println("done")
+          end try
+        end if
+      end this
+
+      def f: String
+    end C
+
+    object C:
+      given C =
+        new C:
+          def f = "!"
+          end f
+        end new
+      end given
+    end C
+
+    extension on (x: C):
+      def ff: String = x.f ++ x.f
+    end extension
+
+  end p2
+```
+
+#### When to Use End Markers
+
+It is recommended that `end` markers are used for code where the extent of an indentation region is not immediately apparent "at a glance". People will have different preferences what this means, but one can nevertheless give some guidelines that stem from experience. An end marker makes sense if
+
+ - the construct contains blank lines, or
+ - the construct is long, say 15-20 lines or more,
+ - the construct ends heavily indented, say 4 indentation levels or more.
+
+If none of these criteria apply, it's often better to not use an end marker since the code will be just as clear and more concise. If there are several ending regions that satisfy one of the criteria above, we usually need an end marker only for the outermost closed reason. So cascades of end markers as in the example above are usually better avoided.
+
+#### Syntax
 
 ```
 EndMarker         ::=  ‘end’ EndMarkerTag    -- when followed by EOL

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -190,12 +190,12 @@ Indentation-based syntax has many advantages over other conventions. But one pos
 To solve this problem, Scala 3 offers an optional `end` marker. Example:
 ```scala
 def largeMethod(...) =
-    ...
-    if ... then ...
-    else
-        ... // a large block
-    end if
-    ... // more code
+  ...
+  if ... then ...
+  else
+      ... // a large block
+  end if
+  ... // more code
 end largeMethod
 ```
 An `end` marker consists of the identifier `end` and a follow-on specifier token that together constitute all the tokes of a line. Possible specifier tokens are

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -198,15 +198,21 @@ def largeMethod(...) =
     ... // more code
 end largeMethod
 ```
-An `end` marker consists of the identifier `end` which follows an `<outdent>` token, and is in turn followed on the same line by exactly one other token, which is either an identifier or one of the reserved words
+An `end` marker consists of the identifier `end` and a follow-on specifier token that together constitute all the tokes of a line. Possible specifier tokens are
+identifiers or one of the following keywords
 ```scala
-if  while  for  match  try  new  given  extension
+if   while    for    match    try    new    this    val   given
 ```
-If `end` is followed by a reserved word, the compiler checks that the marker closes an indentation region belonging to a construct that starts with the reserved word. If it is followed by an identifier _id_, the compiler checks that the marker closes a definition
-that defines _id_ or a package clause that refers to _id_.
+End markers are allowed in statement sequences. The specifier token `s` of an end marker must correspond to the statement that precedes it. This means:
 
-`end` itself is a soft keyword. It is only treated as an `end` marker if it
-occurs at the start of a line and is followed by an identifier or one of the reserved words above.
+ - If the statement defines a member `x` then `s` must be the same identifier `x`.
+ - If the statement defines a constructor then `s` must be `this`.
+ - If the statement defines an anonymous given, then `s` must be `given`.
+ - If the statement defines an anonymous extension, then `s` must be `extension`.
+ - If the statement defines an anonymous class, then `s` must be `new`.
+ - If the statement is a `val` definition binding a pattern, then `s` must be `val`.
+ - If the statement is a package clause that refers to package `p`, then `s` must be the same identifier `p`.
+ - If the statement is an `if`, `while`, `for`, `try`, or `match` statement, then `s` must be that same token.
 
 It is recommended that `end` markers are used for code where the extent of an indentation region is not immediately apparent "at a glance". Typically this is the case if an indentation region spans 20 lines or more.
 

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -216,6 +216,17 @@ End markers are allowed in statement sequences. The specifier token `s` of an en
 
 It is recommended that `end` markers are used for code where the extent of an indentation region is not immediately apparent "at a glance". Typically this is the case if an indentation region spans 20 lines or more.
 
+**Syntax**
+
+```
+EndMarker         ::=  ‘end’ EndMarkerTag    -- when followed by EOL
+EndMarkerTag      ::=  id | ‘if’ | ‘while’ | ‘for’ | ‘match’ | ‘try’
+                    |  ‘new’ | ‘this’ | ‘given’ | ‘extension’ | ‘val’
+BlockStat         ::=  ... | EndMarker
+TemplateStat      ::=  ... | EndMarker
+TopStat           ::=  ... | EndMarker
+```
+
 ### Example
 
 Here is a (somewhat meta-circular) example of code using indentation. It provides a concrete representation of indentation widths as defined above together with efficient operations for constructing and comparing indentation widths.

--- a/docs/docs/reference/overview.md
+++ b/docs/docs/reference/overview.md
@@ -33,7 +33,7 @@ These constructs replace existing constructs with the aim of making the language
  - [Trait Parameters](other-new-features/trait-parameters.md) replace [early initializers](dropped-features/early-initializers.md) with a more generally useful construct.
  - [Given Instances](contextual/delegates.md)
    replace implicit objects and defs, focussing on intent over mechanism.
- - [Given Clauses](contextual/given-clauses.md) replace implicit parameters, avoiding their ambiguities.
+ - [Using Clauses](contextual/using-clauses.md) replace implicit parameters, avoiding their ambiguities.
  - [Extension Methods](contextual/extension-methods.md) replace implicit classes with a clearer and simpler mechanism.
  - [Opaque Type Aliases](other-new-features/opaques.md) replace most uses
    of value classes while guaranteeing absence of boxing.

--- a/tests/neg/endmarkers.scala
+++ b/tests/neg/endmarkers.scala
@@ -9,7 +9,7 @@ object Test:
       x += 1
       x < 10
     do ()
-  end while      // error: misaligned end marker
+  end while      // warning: line indented too far to the left
   }
 
   def f(x: Int): Int =

--- a/tests/neg/endmarkers1.scala
+++ b/tests/neg/endmarkers1.scala
@@ -14,5 +14,5 @@ end Test // error: misaligned end marker
 def f[T](x: Option[T]) = x match
   case Some(y) =>
   case None => "hello"
-  end f  // error: misaligned end marker
+ end f  // error: The start of this line does not match any of the previous indentation widths.
 

--- a/tests/neg/i8731.scala
+++ b/tests/neg/i8731.scala
@@ -1,0 +1,29 @@
+object test:
+
+  3 match
+  case 3 => ???
+  end match
+  case _ => () // error: missing parameter type
+  end match
+
+  if 3 == 3
+    ()
+  end if
+  else     // error: illegal start of definition
+    ()
+  end if
+
+  class Test {
+    val test = 3
+  end Test   // error: misaligned end marker
+  }
+
+  while
+    3 == 3
+  end while  // error: `do` expected
+  do ()
+
+  for
+    a <- Seq()
+  end for    // error: `yield` or `do` expected
+  do ()

--- a/tests/pos/endmarkers.scala
+++ b/tests/pos/endmarkers.scala
@@ -10,3 +10,49 @@ end T
 
 object T
 end T
+
+package p1.p2:
+
+  abstract class C():
+
+    def this(x: Int) =
+      this()
+      if x > 0 then
+        val a :: b =
+          x :: Nil
+        end val
+        var y =
+          x
+        end y
+        while y > 0 do
+          println(y)
+          y -= 1
+        end while
+        try
+          x match
+            case 0 => println("0")
+            case _ =>
+          end match
+        finally
+          println("done")
+        end try
+      end if
+    end this
+
+    def f: String
+  end C
+
+  object C:
+    given C =
+      new C:
+        def f = "!"
+        end f
+      end new
+    end given
+  end C
+
+  extension on (x: C):
+    def ff: String = x.f
+  end extension
+
+end p2

--- a/tests/pos/endmarkers.scala
+++ b/tests/pos/endmarkers.scala
@@ -1,0 +1,12 @@
+trait T:
+  object O:
+    def foo =
+      1
+    end foo
+    def bar = 2
+    end bar
+  end O
+end T
+
+object T
+end T


### PR DESCRIPTION

Handle end markers in parser instead of in Scanner, adding end markers
to the context free syntax.

