### PR TITLE
Fix #8750: Strip opaque refinements when checking self type

### DIFF
--- a/tests/pos/i8750.scala
+++ b/tests/pos/i8750.scala
@@ -1,0 +1,4 @@
+class Abc:
+  opaque type Log = Double
+
+val v : Abc = new Abc


### PR DESCRIPTION
Strip opaque refinements when checking that a class is instantiatable