### PR TITLE
Fix #8749: Error on $ at the start of a name in quoted patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -353,6 +353,12 @@ object Trees {
         }
       }
       else span
+
+    /** The source position of the name defined by this definition.
+     *  This is a point position if the definition is synthetic, or a range position
+     *  if the definition comes from source.
+     */
+    def namePos: SourcePosition = source.atSpan(nameSpan)
   }
 
   /** Tree defines a new symbol and carries modifiers.

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -229,6 +229,10 @@ trait QuotesAndSplices {
               }
             }
             cpy.AppliedTypeTree(tree)(transform(tpt), args1)
+        case tree: NamedDefTree =>
+          if tree.name.isTermName && !tree.nameSpan.isSynthetic && tree.name.startsWith("$") then
+            ctx.error("Names cannot start with $ quote pattern ", tree.namePos)
+          super.transform(tree)
         case _ =>
           super.transform(tree)
       }

--- a/tests/neg/i8749.scala
+++ b/tests/neg/i8749.scala
@@ -1,0 +1,9 @@
+import scala.quoted._
+
+object FunObject {
+  def fun(t: String => String) = t
+}
+
+def test(using QuoteContext)(x: Expr[String => String]) =
+  x match
+    case '{ FunObject.fun(($arg: String) => $out) } => // error

--- a/tests/neg/quotedPatterns-3.scala
+++ b/tests/neg/quotedPatterns-3.scala
@@ -1,10 +1,10 @@
 object Test {
   def test(x: quoted.Expr[Int])(using scala.quoted.QuoteContext) = x match {
-    case '{ val `$y`: Int = 2; 1 } =>
+    case '{ val `$y`: Int = 2; 1 } => // error
       y // error: Not found: y
-    case '{ ((`$y`: Int) => 3); 2 } =>
+    case '{ ((`$y`: Int) => 3); 2 } => // error
       y // error: Not found: y
-    case '{ def `$f`: Int = 8; 2 } =>
+    case '{ def `$f`: Int = 8; 2 } => // error
       f // error: Not found: f
     case _ =>
   }

--- a/tests/run/i8746b/Macro_1.scala
+++ b/tests/run/i8746b/Macro_1.scala
@@ -5,7 +5,7 @@ object Macro {
   inline def mac(inline tree: Any): String = ${ macImpl('tree) }
   def macImpl(tree: Expr[Any])(using qctx: QuoteContext): Expr[String] = {
     tree match {
-        case '{ ($in: $tpe1) => ($out: $tpe2) } => Expr(out.toString)
+        case '{ (in: $tpe1) => ($out: $tpe2) } => Expr(out.toString)
         case _ => Expr("not matched")
     }
   }


### PR DESCRIPTION
These are just part of the name.