### PR TITLE
Only allow sound inline parameters in overrides

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Printers.scala
+++ b/compiler/src/dotty/tools/dotc/config/Printers.scala
@@ -7,7 +7,7 @@ object Printers {
   }
 
   object noPrinter extends Printer {
-    inline override def println(inline msg: => String): Unit = ()
+    inline override def println(msg: => String): Unit = ()
   }
 
   val default = new Printer

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -650,14 +650,16 @@ object Checking {
 
   /** Check the inline override methods only use inline parameters if they override an inline parameter. */
   def checkInlineOverrideParameters(sym: Symbol)(using Context): Unit =
-    val params = sym.paramSymss.flatten
-    if params.exists(_.is(Inline)) then
-      for
-        sym2 <- sym.allOverriddenSymbols
-        (p1, p2) <- params.lazyZip(sym2.paramSymss.flatten)
-        if p1.is(Inline) && !p2.is(Inline)
-      do
-        ctx.error("Cannot override non-inline parameter with an inline parameter", p1.sourcePos)
+    lazy val params = sym.paramSymss.flatten
+    for
+      sym2 <- sym.allOverriddenSymbols
+      (p1, p2) <- sym.paramSymss.flatten.lazyZip(sym2.paramSymss.flatten)
+      if p1.is(Inline) != p2.is(Inline)
+    do
+      ctx.error(
+          if p2.is(Inline) then "Cannot override inline parameter with a non-inline parameter"
+          else "Cannot override non-inline parameter with an inline parameter",
+          p1.sourcePos)
 
 }
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -451,7 +451,8 @@ object Checking {
           || sym.is(TermParam) && !sym.owner.isInlineMethod
           ))
       fail(ParamsNoInline(sym.owner))
-
+    if sym.isInlineMethod && !sym.is(Deferred) && sym.allOverriddenSymbols.nonEmpty then
+      checkInlineOverrideParameters(sym)
     if (sym.isOneOf(GivenOrImplicit)) {
       if (sym.owner.is(Package))
         fail(TopLevelCantBeImplicit(sym))
@@ -646,6 +647,18 @@ object Checking {
       val enumCls = enumCase.owner.linkedClass
       if !cls.info.parents.exists(_.typeSymbol == enumCls) then
         ctx.error(i"enum case does not extend its enum $enumCls", enumCase.sourcePos)
+
+  /** Check the inline override methods only use inline parameteres if they override an inline parameter. */
+  def checkInlineOverrideParameters(sym: Symbol)(using Context): Unit =
+    val params = sym.paramSymss.flatten
+    if params.exists(_.is(Inline)) then
+      for
+        sym2 <- sym.allOverriddenSymbols
+        (p1, p2) <- params.lazyZip(sym2.paramSymss.flatten)
+        if p1.is(Inline) && !p2.is(Inline)
+      do
+        ctx.error("Cannot override non-inline parameter with and inline parameter", p1.sourcePos)
+
 }
 
 trait Checking {

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -648,7 +648,7 @@ object Checking {
       if !cls.info.parents.exists(_.typeSymbol == enumCls) then
         ctx.error(i"enum case does not extend its enum $enumCls", enumCase.sourcePos)
 
-  /** Check the inline override methods only use inline parameteres if they override an inline parameter. */
+  /** Check the inline override methods only use inline parameters if they override an inline parameter. */
   def checkInlineOverrideParameters(sym: Symbol)(using Context): Unit =
     val params = sym.paramSymss.flatten
     if params.exists(_.is(Inline)) then

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -657,7 +657,7 @@ object Checking {
         (p1, p2) <- params.lazyZip(sym2.paramSymss.flatten)
         if p1.is(Inline) && !p2.is(Inline)
       do
-        ctx.error("Cannot override non-inline parameter with and inline parameter", p1.sourcePos)
+        ctx.error("Cannot override non-inline parameter with an inline parameter", p1.sourcePos)
 
 }
 

--- a/tests/neg/inline-parameter-override.scala
+++ b/tests/neg/inline-parameter-override.scala
@@ -1,0 +1,35 @@
+
+
+abstract class Logger {
+  def log1(msg: String): Unit
+  inline def log2(msg: String): Unit
+  inline def log3(inline msg: String): Unit
+}
+
+class Logger1 extends Logger {
+  inline def log1(msg: String): Unit = ()
+  inline def log2(msg: String): Unit = ()
+  inline def log3(msg: String): Unit = ()
+}
+
+class Logger2 extends Logger {
+  inline def log1(inline msg: String): Unit = () // error: Cannot override non-inline parameter with and inline parameter
+  inline def log2(inline msg: String): Unit = () // error: Cannot override non-inline parameter with and inline parameter
+  inline def log3(inline msg: String): Unit = ()
+}
+
+trait A {
+  inline def f(inline a: Int): Int
+}
+
+trait B {
+  def f(a: Int): Int
+}
+
+class C extends A, B {
+  inline def f(inline a: Int): Int = 3 // error: Cannot override non-inline parameter with and inline parameter
+}
+
+class D extends B, A {
+  inline def f(inline a: Int): Int = 3 // error: Cannot override non-inline parameter with and inline parameter
+}

--- a/tests/neg/inline-parameter-override.scala
+++ b/tests/neg/inline-parameter-override.scala
@@ -9,7 +9,7 @@ abstract class Logger {
 class Logger1 extends Logger {
   inline def log1(msg: String): Unit = ()
   inline def log2(msg: String): Unit = ()
-  inline def log3(msg: String): Unit = ()
+  inline def log3(msg: String): Unit = () // error: Cannot override inline parameter with a non-inline parameter
 }
 
 class Logger2 extends Logger {

--- a/tests/neg/inline-parameter-override.scala
+++ b/tests/neg/inline-parameter-override.scala
@@ -13,8 +13,8 @@ class Logger1 extends Logger {
 }
 
 class Logger2 extends Logger {
-  inline def log1(inline msg: String): Unit = () // error: Cannot override non-inline parameter with and inline parameter
-  inline def log2(inline msg: String): Unit = () // error: Cannot override non-inline parameter with and inline parameter
+  inline def log1(inline msg: String): Unit = () // error: Cannot override non-inline parameter with an inline parameter
+  inline def log2(inline msg: String): Unit = () // error: Cannot override non-inline parameter with an inline parameter
   inline def log3(inline msg: String): Unit = ()
 }
 

--- a/tests/run/inline-override-num.scala
+++ b/tests/run/inline-override-num.scala
@@ -4,7 +4,7 @@ trait Num[T] {
 
 object Num {
   class IntNum extends Num[Int] {
-    inline def plus(inline x: Int, inline y: Int): Int = x + y
+    inline def plus(x: Int, y: Int): Int = x + y
   }
   given IntNum
 

--- a/tests/run/typeclass-derivation2b.scala
+++ b/tests/run/typeclass-derivation2b.scala
@@ -26,7 +26,7 @@ object TypeLevel {
 
   abstract class GenericSum[S] extends Generic[S] {
     def ordinal(x: S): Int
-    inline def alternative(n: Int): GenericProduct[_ <: S]
+    inline def alternative(inline n: Int): GenericProduct[_ <: S]
   }
 
   abstract class GenericProduct[P] extends Generic[P] {
@@ -49,7 +49,7 @@ object Lst {
       case x: Cons[_] => 0
       case Nil => 1
     }
-    inline override def alternative(inline n: Int) <: GenericProduct[_ <: Lst[T]] =
+    inline def alternative(inline n: Int) <: GenericProduct[_ <: Lst[T]] =
       inline n match {
         case 0 => Cons.GenericCons[T]
         case 1 => Nil.GenericNil


### PR DESCRIPTION
Inline overrides can only use inline parameters if the overriden parameter is inline.