### PR TITLE
Restore test check function

### DIFF
--- a/tests/run/literals.scala
+++ b/tests/run/literals.scala
@@ -1,24 +1,13 @@
-// scalac: -deprecation
-//
-//############################################################################
-// Literals
-//############################################################################
 
-//############################################################################
+import scala.util.{Failure, Success, Try}
 
 object Test {
 
-  def check_success[A](name: String, closure: => A, expected: A): Unit = {
-    val res: Option[String] =
-      try {
-        val actual: A = closure
-        if (actual == expected) None  //print(" was successful")
-        else Some(s" failed: expected $expected, found $actual")
-      } catch {
-        case exception: Throwable => Some(s" raised exception $exception")
-      }
-    for (e <- res) println(s"test $name $e")
-  }
+  def check_success[A](name: String, closure: => A, expected: A): Unit =
+    Try(closure) match {
+      case Success(actual) => assert(actual == expected, s"test $name failed: expected $expected, found $actual")
+      case Failure(error)  => throw new AssertionError(s"test $name raised exception $error")
+    }
 
   def main(args: Array[String]): Unit = {
     // char
@@ -83,6 +72,7 @@ object Test {
     check_success("01.23f == 1.23f", 01.23f, 1.23f)
     check_success("3.14f == 3.14f", 3.14f, 3.14f)
     check_success("6.022e23f == 6.022e23f", 6.022e23f, 6.022e23f)
+    check_success("9f == 9.0f", 9f, 9.0f)
     check_success("09f == 9.0f", 09f, 9.0f)
     check_success("1.00000017881393421514957253748434595763683319091796875001f == 1.0000001f",
       1.00000017881393421514957253748434595763683319091796875001f,
@@ -114,5 +104,3 @@ object Test {
     check_success("\"\".length()", "\u001a".length(), 1)
   }
 }
-
-//############################################################################


### PR DESCRIPTION
Vulpix only checks output if there is an existing check file.
Note that partest pos tests used to accept an optional check
file, but the confusing behavior is that if you delete the
check file, it always passes, unlike a neg test which takes
a missing check file as an empty one.

In this case, a semantic merge conflict resulted in a neg test
with println instead of assert, but with no check file.
Happily, such a test can never fail. Sadly, sometimes our
code is broken.