### PR TITLE
Fix #8758: strengthen the precondition for comparing extractors

### DIFF
--- a/tests/pos-special/fatal-warnings/i8758.scala
+++ b/tests/pos-special/fatal-warnings/i8758.scala
@@ -1,0 +1,5 @@
+def test = "?johndoe" match {
+  case s":$name" => println(s":name $name")
+  case s"{$name}" =>  println(s"{name} $name")
+  case s"?$pos" =>  println(s"pos $pos")
+}


### PR DESCRIPTION
Fix #8758: strengthen the precondition for comparing extractors

The extractor `StringContext#s.unapplySeq` may have different prefix,
thus we may not assume they are the same.