### PR TITLE
Fix #8730: support structural unapply

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1354,6 +1354,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def repeated(trees: List[Tree], tpt: Tree)(using Context): Tree =
     ctx.typeAssigner.arrayToRepeated(JavaSeqLiteral(trees, tpt))
 
+  def seqRepeated(trees: List[Tree], tpt: Tree)(using Context): Tree =
+    ctx.typeAssigner.seqToRepeated(SeqLiteral(trees, tpt))
+
   /** Create a tree representing a list containing all
    *  the elements of the argument list. A "list of tree to
    *  tree of list" conversion.

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1806,7 +1806,7 @@ object messages {
         |""".stripMargin
   }
 
-  class UnapplyInvalidReturnType(unapplyResult: Type, unapplyName: Symbol#ThisName)(implicit ctx: Context)
+  class UnapplyInvalidReturnType(unapplyResult: Type, unapplyName: Name)(implicit ctx: Context)
     extends DeclarationMsg(UnapplyInvalidReturnTypeID) {
     def msg =
       val addendum =
@@ -2088,7 +2088,7 @@ object messages {
   }
 
   class NotAnExtractor(tree: untpd.Tree)(implicit ctx: Context) extends SyntaxMsg(NotAnExtractorID) {
-    def msg = em"$tree cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method"
+    def msg = em"$tree cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method."
     def explain =
       em"""|An ${hl("unapply")} method should be defined in an ${hl("object")} as follow:
            |  - If it is just a test, return a ${hl("Boolean")}. For example ${hl("case even()")}

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2088,7 +2088,7 @@ object messages {
   }
 
   class NotAnExtractor(tree: untpd.Tree)(implicit ctx: Context) extends SyntaxMsg(NotAnExtractorID) {
-    def msg = em"$tree cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method."
+    def msg = em"$tree cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method"
     def explain =
       em"""|An ${hl("unapply")} method should be defined in an ${hl("object")} as follow:
            |  - If it is just a test, return a ${hl("Boolean")}. For example ${hl("case even()")}

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -150,7 +150,10 @@ object Applications {
 
   def unapplyArgs(unapplyResult: Type, unapplyFn: Tree, args: List[untpd.Tree], pos: SourcePosition)(using Context): List[Type] = {
 
-    val unapplyName = unapplyFn.asInstanceOf[RefTree].name
+    val unapplyName = unapplyFn match
+      case TypeApply(fn: RefTree, _) => fn.name
+      case fn: RefTree => fn.name
+
     def getTp = extractorMemberType(unapplyResult, nme.get, pos)
 
     def fail = {

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -150,7 +150,7 @@ object Applications {
 
   def unapplyArgs(unapplyResult: Type, unapplyFn: Tree, args: List[untpd.Tree], pos: SourcePosition)(using Context): List[Type] = {
 
-    val unapplyName = unapplyFn.symbol.name
+    val unapplyName = unapplyFn.asInstanceOf[RefTree].name
     def getTp = extractorMemberType(unapplyResult, nme.get, pos)
 
     def fail = {
@@ -171,7 +171,7 @@ object Applications {
         else fail
       }
     else {
-      assert(unapplyName == nme.unapply)
+      assert(unapplyName == nme.unapply, "expected `unapply`, found = " + unapplyName)
       if (isProductMatch(unapplyResult, args.length, pos))
         productSelectorTypes(unapplyResult, pos)
       else if (isGetMatch(unapplyResult, pos))
@@ -1225,6 +1225,7 @@ trait Applications extends Compatibility {
           case Apply(Apply(unapply, `dummyArg` :: Nil), args2) => assert(args2.nonEmpty); args2
           case Apply(unapply, `dummyArg` :: Nil) => Nil
           case Inlined(u, _, _) => unapplyImplicits(u)
+          case DynamicUnapply(args) => args
           case _ => Nil.assertingErrorsReported
         }
 

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -22,6 +22,17 @@ object Dynamic {
     name == nme.applyDynamic || name == nme.selectDynamic || name == nme.updateDynamic || name == nme.applyDynamicNamed
 }
 
+object DynamicUnapply {
+  def unapply(tree: tpd.Tree): Option[List[tpd.Tree]] = tree match
+    case TypeApply(Select(qual, name), _) if name == nme.asInstanceOfPM =>
+      unapply(qual)
+    case Apply(Apply(Select(selectable, fname), Literal(Constant(name)) :: ctag :: Nil), _ :: implicits)
+    if fname == nme.applyDynamic && (name == "unapply" || name == "unapplySeq") =>
+      Some(selectable :: ctag :: implicits)
+    case _ =>
+      None
+}
+
 /** Handles programmable member selections of `Dynamic` instances and values
  *  with structural types. Two functionalities:
  *

--- a/tests/run/i8730.scala
+++ b/tests/run/i8730.scala
@@ -1,0 +1,17 @@
+import reflect.Selectable.reflectiveSelectable
+
+class Nat(val x: Int) {
+  def get: Int = x
+  def isEmpty = x < 0
+}
+
+val SomeExtractorBuilder: { def unapply(x: Int): Nat } = new {
+  def unapply(x: Int): Nat = new Nat(x)
+}
+
+
+@main
+def Test = 5 match {
+  case SomeExtractorBuilder(n) => println(s"$n is a natural number")
+  case _      => ()
+}


### PR DESCRIPTION
Fix #8730: support structural unapply

It's supported in Scala 2, so we need to be compatible.