### PR TITLE
Re-architecture staging phase and fix all known issues of that phase

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -301,7 +301,7 @@ class ReifyQuotes extends MacroTransform {
 
     /** Returns true if this tree will be captured by `makeLambda`. Checks phase consistency and presence of capturer. */
     private def isCaptured(sym: Symbol, level: Int)(implicit ctx: Context): Boolean =
-      level == 1 && levelOf(sym).contains(1) && capturers.contains(sym)
+      level == 1 && levelOf(sym) == 1 && capturers.contains(sym)
 
     /** Transform `tree` and return the resulting tree and all `embedded` quotes
      *  or splices as a pair.

--- a/compiler/src/dotty/tools/dotc/transform/Staging.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Staging.scala
@@ -43,19 +43,19 @@ class Staging extends MacroTransform {
       tree match {
         case PackageDef(pid, _) if tree.symbol.owner == defn.RootClass =>
           val checker = new PCPCheckAndHeal(freshStagingContext) {
-            override protected def tryHeal(sym: Symbol, tp: TypeRef, pos: SourcePosition)(implicit ctx: Context): Option[tpd.Tree] = {
+            override protected def tryHeal(sym: Symbol, tp: TypeRef, pos: SourcePosition)(implicit ctx: Context): TypeRef = {
               def symStr =
                 if (sym.is(ModuleClass)) sym.sourceModule.show
                 else i"${sym.name}.this"
               val errMsg = s"\nin ${ctx.owner.fullName}"
               assert(
                 ctx.owner.hasAnnotation(defn.InternalQuoted_QuoteTypeTagAnnot) ||
-                (sym.isType && levelOf(sym).getOrElse(0) > 0),
+                (sym.isType && levelOf(sym) > 0),
                 em"""access to $symStr from wrong staging level:
-                    | - the definition is at level ${levelOf(sym).getOrElse(0)},
+                    | - the definition is at level ${levelOf(sym)},
                     | - but the access is at level $level.$errMsg""")
 
-              None
+              tp
             }
           }
           checker.transform(tree)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -38,7 +38,6 @@ import config.Feature._
 import config.SourceVersion._
 import rewrites.Rewrites.patch
 import NavigateAST._
-import dotty.tools.dotc.transform.{PCPCheckAndHeal, Staging, TreeMapWithStages}
 import transform.SymUtils._
 import transform.TypeUtils._
 import reporting.trace

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -40,3 +40,6 @@ nullable.scala
 
 # parameter untupling with overloaded functions (see comment in Applications.normArg)
 i7757.scala
+
+# splice type tag dealiased in this reference
+i8651b.scala

--- a/tests/neg-macros/quote-this-a.scala
+++ b/tests/neg-macros/quote-this-a.scala
@@ -1,0 +1,14 @@
+import scala.quoted._
+
+class Foo {
+
+  def f(using QuoteContext): Unit = '{
+    def bar[T](x: T): T = x
+    bar[
+      this.type  // error
+      ] {
+      this  // error
+    }
+  }
+
+}

--- a/tests/neg-macros/quote-this-c.scala
+++ b/tests/neg-macros/quote-this-c.scala
@@ -2,15 +2,6 @@ import scala.quoted._
 
 class Foo {
 
-  def f(using QuoteContext): Unit = '{
-    def bar[T](x: T): T = x
-    bar[
-      this.type  // error
-      ] {
-      this  // error
-    }
-  }
-
   inline def i(): Unit = ${ Foo.impl[Any]('{
     val x: QuoteContext = ???
     given x.type = x

--- a/tests/neg/i7892.scala
+++ b/tests/neg/i7892.scala
@@ -1,0 +1,12 @@
+import scala.quoted._
+
+package x {
+  class CExprResult1[T]
+}
+
+def run(using qctx: QuoteContext): Unit = {
+  val cpsLeft: x.CExprResult1[?] = ???
+  run1(cpsLeft) // error
+}
+
+def run1[L:Type](cpsLeft: x.CExprResult1[L]): Unit = ???

--- a/tests/pos-macros/i6140.scala
+++ b/tests/pos-macros/i6140.scala
@@ -1,0 +1,8 @@
+import scala.quoted._
+sealed trait Trait[T] {
+  type t = T
+}
+
+object O {
+  def fn[T:Type](t : Trait[T])(using QuoteContext): Type[T] = '[t.t]
+}

--- a/tests/pos-macros/i7030/Macros_1.scala
+++ b/tests/pos-macros/i7030/Macros_1.scala
@@ -1,0 +1,11 @@
+import scala.quoted._
+
+inline def inner(exprs: Any): Any = ${innerImpl('exprs)}
+def innerImpl(exprs: Expr[Any])(using QuoteContext): Expr[Any] =
+  '{$exprs ; ()}
+
+inline def outer(expr: => Any): Any = ${outerImpl('expr)}
+def outerImpl(body: Expr[Any])(using ctx: QuoteContext): Expr[Any] = {
+  import ctx.tasty._
+  body.unseal.underlyingArgument.seal
+}

--- a/tests/pos-macros/i7030/Test_2.scala
+++ b/tests/pos-macros/i7030/Test_2.scala
@@ -1,0 +1,1 @@
+val x = outer(inner(???))

--- a/tests/pos-macros/i8100.scala
+++ b/tests/pos-macros/i8100.scala
@@ -1,0 +1,21 @@
+import scala.quoted._
+
+class M {
+  type E
+}
+
+def f[T: Type](using QuoteContext) =
+  Expr.summon[M] match
+    case Some('{ $mm : $tt }) =>
+      '{
+        val m = $mm
+        type ME = m.E
+        ${ g[ME](using '[ME]) }
+        ${ g[m.E](using '[ME]) }
+        ${ g[ME](using '[m.E]) }
+        ${ g[m.E](using '[m.E]) }
+        // ${ g[ME] } // FIXME: issue seems to be in ReifyQuotes
+        // ${ g[m.E] } // FIXME: issue seems to be in ReifyQuotes
+      }
+
+def g[T](using Type[T]) = ???

--- a/tests/pos/i7997.scala
+++ b/tests/pos/i7997.scala
@@ -1,0 +1,4 @@
+import scala.quoted._
+def oops(using QuoteContext) = {
+  val q = '{ class Foo { val x = 3; ${ val v = 'x; '{} }  }}
+}

--- a/tests/pos/i8651a.scala
+++ b/tests/pos/i8651a.scala
@@ -1,0 +1,8 @@
+import scala.quoted._
+def coroutineImpl(using QuoteContext): Expr[Any] =
+  '{
+    new {
+      def state: Int = 0
+      ${identity('state)}
+    }
+  }

--- a/tests/pos/i8651b.scala
+++ b/tests/pos/i8651b.scala
@@ -1,0 +1,31 @@
+abstract class Coroutine[+T] {
+  def continue: Option[T]
+}
+
+object Macros {
+
+ import scala.quoted._
+ import scala.quoted.matching._
+
+
+ inline def coroutine[T](inline body: Any): Coroutine[T] = ${ coroutineImpl('{body}) }
+
+ def coroutineImpl[T: Type](expr: Expr[_ <: Any])(implicit qtx: QuoteContext): Expr[Coroutine[T]] = {
+   import qtx.tasty.{_, given _}
+
+   '{
+     new Coroutine[T] {
+       var state: Int = 0
+
+       def continue: Option[T] = ${
+         '{
+           state = 1 //if this line is commented there are no compile errors anymore!!!
+           None
+         }
+       }
+
+     }
+   }
+
+ }
+}

--- a/tests/pos/quote-type-with-param.scala
+++ b/tests/pos/quote-type-with-param.scala
@@ -1,0 +1,4 @@
+import scala.quoted._
+
+def f(using QuoteContext): Unit =
+  '{ type T[X] = List[X] }

--- a/tests/run-macros/i6772/Macro_1.scala
+++ b/tests/run-macros/i6772/Macro_1.scala
@@ -1,0 +1,14 @@
+import scala.quoted._
+
+object Macros {
+
+  inline def m() : Any = ${  mImpl() }
+
+  def mImpl()(using QuoteContext): Expr[Any] =
+    List(Expr(1), Expr(2), Expr(3)).toExprOfList
+
+  def (list: List[Expr[T]]).toExprOfList[T](using Type[T], QuoteContext): Expr[List[T]] = '{
+    val buff = List.newBuilder[T]
+    ${ Expr.block(list.map(v => '{ buff +=  $v }), '{ buff.result() }) }
+  }
+}

--- a/tests/run-macros/i6772/Test_2.scala
+++ b/tests/run-macros/i6772/Test_2.scala
@@ -1,0 +1,8 @@
+import scala.quoted._
+import Macros._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    println(m())
+  }
+}


### PR DESCRIPTION
Fix #6140, fix #6772, fix #7030, fix #7892, fix #7997, fix #8651 and improve #8100.
    
Differences with previous implementation
* Only track and check levels within quotes or splices
* Track levels of all symbols not at level 0
* Split level checking into specialized variants for types and terms (healType/healTermType)
* Detect inconsistent types rather than try to detect consistent ones
* Check/heal term inconsistencies only on leaf nodes (TypeTree, RefTree, Ident, This)
