### PR TITLE
[do not merge] Demonstrate that signature caching is broken

### DIFF
--- a/compiler/test/dotty/tools/SignaturesTests.scala
+++ b/compiler/test/dotty/tools/SignaturesTests.scala
@@ -1,0 +1,28 @@
+package dotty.tools
+
+import vulpix.TestConfiguration
+
+import org.junit.Test
+
+import dotc.ast.Trees._
+import dotc.core.Decorators._
+import dotc.core.Contexts._
+import dotc.core.Types._
+
+import java.io.File
+import java.nio.file._
+
+class SignaturesTest:
+  @Test def signatureCaching: Unit =
+    inCompilerContext(TestConfiguration.basicClasspath, "case class Foo(value: Unit)") {
+      val defn = ctx.definitions
+      val leftCls = ctx.requiredClass("Foo")
+      val ref = leftCls.requiredMethod("value").termRef
+
+      def checkSig()(using Context): Unit =
+        val denot = ref.denot
+        assert(ref.signature == denot.signature, i"Wrong cached signature at phase ${ctx.phase} for $ref.\nActual denotation signature: ${denot.signature}\nCached ref signature: ${ref.signature}")
+
+      checkSig()
+      checkSig()(using ctx.withPhase(ctx.erasurePhase.next))
+    }

--- a/compiler/test/dotty/tools/compilerSupport.scala
+++ b/compiler/test/dotty/tools/compilerSupport.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 
 import javax.tools._
-import java.io.File
+import java.io._
 import java.nio.file._
 import java.net.URI
 import scala.jdk.CollectionConverters._
@@ -10,13 +10,25 @@ import core._
 import core.Contexts._
 import dotc.core.Comments.{ContextDoc, ContextDocstrings}
 
+// TODO: refactor, copy-pasted from Run#compileFromStrings
+private def sourceFile(source: String, isJava: Boolean): util.SourceFile = {
+  val uuid = java.util.UUID.randomUUID().toString
+  val ext = if (isJava) ".java" else ".scala"
+  val virtualFile = new io.VirtualFile(s"compileFromString-$uuid.$ext")
+  val writer = new BufferedWriter(new OutputStreamWriter(virtualFile.output, "UTF-8")) // buffering is still advised by javadoc
+  writer.write(source)
+  writer.close()
+  new util.SourceFile(virtualFile, scala.io.Codec.UTF8)
+}
+
 /** Initialize a compiler context with the given classpath and
  *  pass it to `op`.
  */
-def inCompilerContext[T](classpath: String)(op: Context ?=> T): T =
+def inCompilerContext[T](classpath: String, scalaSources: String*)(op: Context ?=> T): T =
   val compiler = Compiler()
   val run = compiler.newRun(initCtx(classpath))
-  run.compileUnits(Nil) // Initialize phases
+  run.compileUnits(scalaSources.toList.map(s =>
+    CompilationUnit(sourceFile(s, isJava = false))(using run.runContext)))
   op(using run.runContext)
 
 private def initCtx(classpath: String): Context =


### PR DESCRIPTION
See #8799 for more information.

The test currently fails with:

Wrong cached signature at phase elimErasedValueType for (Foo.this.value : (): scala.runtime.BoxedUnit).
Actual denotation signature: Signature(List(),scala.runtime.BoxedUnit)
Cached ref signature: Signature(List(),),

The test passes if I tweak NamedType to not cache signatures.