### PR TITLE
Fix #8748: Verify symbol is a param by querying the reftree

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -91,7 +91,7 @@ class TreeTypeMap(
         case id: Ident if tpd.needsSelect(id.tpe) =>
           ref(id.tpe.asInstanceOf[TermRef]).withSpan(id.span)
         case ddef @ DefDef(name, tparams, vparamss, tpt, _) =>
-          val (tmap1, tparams1) = transformDefs(ddef.tparams)
+          val (tmap1, tparams1) = transformDefs(tparams)
           val (tmap2, vparamss1) = tmap1.transformVParamss(vparamss)
           val res = cpy.DefDef(ddef)(name, tparams1, vparamss1, tmap2.transform(tpt), tmap2.transform(ddef.rhs))
           res.symbol.setParamssFromDefs(tparams1, vparamss1)

--- a/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
@@ -33,7 +33,7 @@ object HoistSuperArgs {
  *
  *  An argument is complex if it contains a method or template definition, a this or a new,
  *  or it contains an identifier which needs a `this` prefix to be accessed. This is the case
- *  if the identifer neither a global reference nor a reference to a parameter of the enclosing class.
+ *  if the identifier has neither a global reference nor a reference to a parameter of the enclosing class.
  *  @see needsHoist for an implementation.
  *
  *  A hoisted argument definition gets the parameters of the class it is hoisted from
@@ -127,7 +127,7 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
       arg match {
         case Apply(fn, arg1 :: Nil) if fn.symbol == defn.cbnArg =>
           cpy.Apply(arg)(fn, hoistSuperArg(arg1, cdef) :: Nil)
-        case _ if (arg.existsSubTree(needsHoist)) =>
+        case _ if arg.existsSubTree(needsHoist) =>
           val superMeth = newSuperArgMethod(arg.tpe)
           val superArgDef = polyDefDef(superMeth, trefs => vrefss => {
             val paramSyms = trefs.map(_.typeSymbol) ::: vrefss.flatten.map(_.symbol)

--- a/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
@@ -116,6 +116,13 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
         case _                    => false
       }
 
+      /** Only rewire types that are owned by the current Hoister and is an param or accessor */
+      def needsRewire(tp: Type) = tp match {
+        case ntp: NamedType =>
+          (ntp.symbol.owner == cls || ntp.symbol.owner == constr) && ntp.symbol.isParamOrAccessor
+        case _ => false
+      }
+
       // begin hoistSuperArg
       arg match {
         case Apply(fn, arg1 :: Nil) if fn.symbol == defn.cbnArg =>
@@ -128,9 +135,7 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
               typeMap = new TypeMap {
                 lazy val origToParam = origParams.zip(paramSyms).toMap
                 def apply(tp: Type) = tp match {
-                  case tp: NamedType
-                  if (tp.symbol.owner == cls || tp.symbol.owner == constr) &&
-                     tp.symbol.isParamOrAccessor =>
+                  case tp: NamedType if needsRewire(tp) =>
                     origToParam.get(tp.symbol) match {
                       case Some(mappedSym) => if (tp.symbol.isType) mappedSym.typeRef else mappedSym.termRef
                       case None => mapOver(tp)
@@ -140,7 +145,7 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
                 }
               },
               treeMap = {
-                case tree: RefTree if paramSyms.contains(tree.symbol) =>
+                case tree: RefTree if needsRewire(tree.tpe) =>
                   cpy.Ident(tree)(tree.name).withType(tree.tpe)
                 case tree =>
                   tree

--- a/compiler/src/dotty/tools/dotc/transform/ProtectedAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ProtectedAccessors.scala
@@ -10,7 +10,7 @@ import MegaPhase.MiniPhase
 import config.Printers.transforms
 
 /** Add accessors for all protected accesses. An accessor is needed if
- *  according to the rules of the JVM a protected class member is not accesissible
+ *  according to the rules of the JVM a protected class member is not accessible
  *  from the point of access, but is accessible if the access is from an enclosing
  *  class. In this point a public access method is placed in that enclosing class.
  */

--- a/tests/pos/i8748.scala
+++ b/tests/pos/i8748.scala
@@ -1,0 +1,9 @@
+class A(a: String) extends B(new C {
+  override def get(): String = a
+})
+
+class B(c: C)
+
+trait C {
+  def get(): String
+}

--- a/tests/pos/i8786.scala
+++ b/tests/pos/i8786.scala
@@ -1,0 +1,7 @@
+class B(y: Int) extends A(new C(y){})
+
+class A(c: C)
+
+abstract class C(y: Int) {
+  def x: Int = y
+}


### PR DESCRIPTION
Verify symbol is a param by querying the reftree

In the HoistSuperArgs phase we have established which tree should be
hoisted, and replace all references in the Tree with params that are
accessible in the hoisted tree.

When the Tree contains an anonymous class without parameters,
the paramSyms of that class refer to the created 'fresh' super symbol
(e.g. `B$superArg$1`), while the RefTree symbol belongs to the superclass `B`.
This meant that the conditional was never satisfied, and the type was
never replaced by the primary constructor argument of the generated
superArg class.
This is mitigated by replacing the check, to only take params or
accessors into account in the scope of the hoisted tree.


Closes #8748 and closes #8786 

I've run `dotty-compiler/test` and `testCompilation` and all is green on my machine. 

/cc @liufengyun 
