### PR TITLE
Fix #8801: Update registeredCompanion when mapping symbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -17,6 +17,7 @@ import util.Spans._
 import DenotTransformers._
 import StdNames._
 import NameOps._
+import transform.SymUtils._
 import NameKinds.LazyImplicitName
 import ast.tpd
 import tpd.{Tree, TreeProvider, TreeOps}
@@ -351,6 +352,8 @@ trait Symbols { thisCtx: Context =>
           info = completer,
           privateWithin = ttmap1.mapOwner(odenot.privateWithin), // since this refers to outer symbols, need not include copies (from->to) in ownermap here.
           annotations = odenot.annotations)
+        copy.registeredCompanion =
+          copy.registeredCompanion.subst(originals, copies)
       }
 
       copies.foreach(_.ensureCompleted()) // avoid memory leak

--- a/tests/pos/i8801.scala
+++ b/tests/pos/i8801.scala
@@ -1,0 +1,4 @@
+object Foo:
+ locally {
+    case class Baz()
+  }

--- a/tests/pos/i8801.scala
+++ b/tests/pos/i8801.scala
@@ -2,3 +2,8 @@ object Foo:
  locally {
     case class Baz()
   }
+
+class Foo2 {
+  def foo(x: Any = 3, y: Any = 9): Any = x
+  val a = foo(y = { case class Bar(x: Int) }, x = ())
+}


### PR DESCRIPTION
The body of the `locally` undergoes a TreeTypeMap. When mapping symbols this broke the link between a class and its companion. The two would refer to stale classes in the inline call instead.
