### PR TITLE
Fix #8799: Use initial denotation for signatures

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1894,7 +1894,7 @@ object Types {
      */
     protected def computeSignature(implicit ctx: Context): Signature =
       lastDenotation match
-        case null => symbol.asSeenFrom(prefix).signature
+        case null => symbol.asSeenFrom(prefix).initial.signature
         case sd: SingleDenotation => sd.initial.signature
         case d => d.signature
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1892,11 +1892,11 @@ object Types {
     /** The signature of the last known denotation, or if there is none, the
      *  signature of the symbol
      */
-    protected def computeSignature(implicit ctx: Context): Signature = {
-      val lastd = lastDenotation
-      if (lastd != null) lastd.signature
-      else symbol.asSeenFrom(prefix).signature
-    }
+    protected def computeSignature(implicit ctx: Context): Signature =
+      lastDenotation match
+        case null => symbol.asSeenFrom(prefix).signature
+        case sd: SingleDenotation => sd.initial.signature
+        case d => d.signature
 
     /** The signature of the current denotation if it is known without forcing.
      *  Otherwise the signature of the current symbol if it is known without forcing.

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1904,15 +1904,13 @@ object Types {
      */
     private def currentSignature(implicit ctx: Context): Signature =
       if (ctx.runId == mySignatureRunId) mySignature
-      else {
-        val lastd = lastDenotation
-        if (lastd != null) lastd.signature
-        else {
+      else lastDenotation match
+        case null =>
           val sym = currentSymbol
-          if (sym.exists) sym.asSeenFrom(prefix).signature
+          if (sym.exists) sym.asSeenFrom(prefix).initial.signature
           else Signature.NotAMethod
-        }
-      }
+        case sd: SingleDenotation => sd.initial.signature
+        case d => d.signature
 
     final def symbol(implicit ctx: Context): Symbol =
       // We can rely on checkedPeriod (unlike in the definition of `denot` below)

--- a/compiler/test/dotty/tools/SignaturesTests.scala
+++ b/compiler/test/dotty/tools/SignaturesTests.scala
@@ -8,6 +8,7 @@ import dotc.ast.Trees._
 import dotc.core.Decorators._
 import dotc.core.Contexts._
 import dotc.core.Types._
+import dotc.core.Denotations._
 
 import java.io.File
 import java.nio.file._
@@ -20,7 +21,9 @@ class SignaturesTest:
       val ref = leftCls.requiredMethod("value").termRef
 
       def checkSig()(using Context): Unit =
-        val denot = ref.denot
+        val denot = ref.denot match
+          case sd: SingleDenotation => sd.initial
+          case d => d
         assert(ref.signature == denot.signature, i"Wrong cached signature at phase ${ctx.phase} for $ref.\nActual denotation signature: ${denot.signature}\nCached ref signature: ${ref.signature}")
 
       checkSig()

--- a/compiler/test/dotty/tools/SignaturesTests.scala
+++ b/compiler/test/dotty/tools/SignaturesTests.scala
@@ -1,0 +1,28 @@
+package dotty.tools
+
+import vulpix.TestConfiguration
+
+import org.junit.Test
+
+import dotc.ast.Trees._
+import dotc.core.Decorators._
+import dotc.core.Contexts._
+import dotc.core.Types._
+
+import java.io.File
+import java.nio.file._
+
+class SignaturesTest:
+  @Test def signatureCaching: Unit =
+    inCompilerContext(TestConfiguration.basicClasspath, "case class Foo(value: Unit)") {
+      val defn = ctx.definitions
+      val leftCls = ctx.requiredClass("Foo")
+      val ref = leftCls.requiredMethod("value").termRef
+
+      def checkSig()(using Context): Unit =
+        val denot = ref.denot
+        assert(ref.signature == denot.signature, i"Wrong cached signature at phase ${ctx.phase} for $ref.\nActual denotation signature: ${denot.signature}\nCached ref signature: ${ref.signature}")
+
+      checkSig()
+      checkSig()(using ctx.withPhase(ctx.erasurePhase.next))
+    }

--- a/compiler/test/dotty/tools/compilerSupport.scala
+++ b/compiler/test/dotty/tools/compilerSupport.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 
 import javax.tools._
-import java.io.File
+import java.io._
 import java.nio.file._
 import java.net.URI
 import scala.jdk.CollectionConverters._
@@ -10,13 +10,25 @@ import core._
 import core.Contexts._
 import dotc.core.Comments.{ContextDoc, ContextDocstrings}
 
+// TODO: refactor, copy-pasted from Run#compileFromStrings
+private def sourceFile(source: String, isJava: Boolean): util.SourceFile = {
+  val uuid = java.util.UUID.randomUUID().toString
+  val ext = if (isJava) ".java" else ".scala"
+  val virtualFile = new io.VirtualFile(s"compileFromString-$uuid.$ext")
+  val writer = new BufferedWriter(new OutputStreamWriter(virtualFile.output, "UTF-8")) // buffering is still advised by javadoc
+  writer.write(source)
+  writer.close()
+  new util.SourceFile(virtualFile, scala.io.Codec.UTF8)
+}
+
 /** Initialize a compiler context with the given classpath and
  *  pass it to `op`.
  */
-def inCompilerContext[T](classpath: String)(op: Context ?=> T): T =
+def inCompilerContext[T](classpath: String, scalaSources: String*)(op: Context ?=> T): T =
   val compiler = Compiler()
   val run = compiler.newRun(initCtx(classpath))
-  run.compileUnits(Nil) // Initialize phases
+  run.compileUnits(scalaSources.toList.map(s =>
+    CompilationUnit(sourceFile(s, isJava = false))(using run.runContext)))
   op(using run.runContext)
 
 private def initCtx(classpath: String): Context =


### PR DESCRIPTION

Use the initial denotation to compute the signature of a NamedType.
