### PR TITLE
Fix #8729: Drop failing assertion in `enter`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -94,7 +94,7 @@ object DesugarEnums {
    */
   private def enumScaffolding(implicit ctx: Context): List[Tree] = {
     val valuesDef =
-      DefDef(nme.values, Nil, Nil, TypeTree(), Select(valuesDot(nme.values), nme.toArray))
+      DefDef(nme.values, Nil, Nil, TypeTree(defn.ArrayOf(enumClass.typeRef)), Select(valuesDot(nme.values), nme.toArray))
         .withFlags(Synthetic)
     val privateValuesDef =
       ValDef(nme.DOLLAR_VALUES, TypeTree(),

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1810,13 +1810,7 @@ object SymDenotations {
      */
     def enter(sym: Symbol, scope: Scope = EmptyScope)(implicit ctx: Context): Unit = {
       val mscope = scope match {
-        case scope: MutableScope =>
-          // if enter gets a scope as an argument,
-          // than this is a scope that will eventually become decls of this symbol.
-          // And this should only happen if this is first time the scope of symbol
-          // is computed, ie symbol yet has no future.
-          assert(this.nextInRun.validFor.code <= this.validFor.code)
-          scope
+        case scope: MutableScope => scope
         case _ => unforcedDecls.openForMutations
       }
       if (proceedWithEnter(sym, mscope)) {


### PR DESCRIPTION

The eliminated assertion looked weird -- it makes no sense to compare
the code (i.e. the bits) of two period encodings. It failed in innocuous
code, and dropping it did not cause follow-on errors.

Sorry, no test. If someone else wants to add a test, please do. But it is
such a weird case (and was such a weird assertion) that I am not sure we need
to have a test.