### PR TITLE
Fix #8799: Make sure signatures are computed before erasure

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -61,8 +61,7 @@ class Compiler {
          new CheckStatic,            // Check restrictions that apply to @static members
          new BetaReduce,             // Reduce closure applications
          new init.Checker) ::        // Check initialization of objects
-    List(new CompleteJavaEnums,      // Fill in constructors for Java enums
-         new ElimRepeated,           // Rewrite vararg parameters and arguments
+    List(new ElimRepeated,           // Rewrite vararg parameters and arguments
          new ExpandSAMs,             // Expand single abstract method closures to anonymous classes
          new ProtectedAccessors,     // Add accessors for protected members
          new ExtensionMethods,       // Expand methods of value classes with extension methods
@@ -101,6 +100,7 @@ class Compiler {
          new ArrayApply,             // Optimize `scala.Array.apply([....])` and `scala.Array.apply(..., [....])` into `[...]`
          new ElimPolyFunction,       // Rewrite PolyFunction subclasses to FunctionN subclasses
          new TailRec,                // Rewrite tail recursion to loops
+         new CompleteJavaEnums,      // Fill in constructors for Java enums
          new Mixin,                  // Expand trait fields and trait initializers
          new LazyVals,               // Expand lazy vals
          new Memoize,                // Add private fields to getters and setters

--- a/compiler/src/dotty/tools/dotc/core/Signature.scala
+++ b/compiler/src/dotty/tools/dotc/core/Signature.scala
@@ -141,7 +141,7 @@ object Signature {
   export MatchDegree._
 
   /** The signature of everything that's not a method, i.e. that has
-   *  a type different from PolyType, MethodType, or ExprType.
+   *  a type different from PolyType or MethodType.
    */
   val NotAMethod: Signature = Signature(List(), EmptyTypeName)
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1902,9 +1902,8 @@ object Types {
      */
     protected def computeSignature(implicit ctx: Context): Signature =
       val lastd = lastDenotation
-      val isErased = ctx.erasedTypes
-      if lastd != null && !isErased then lastd.signature
-      else if isErased then computeSignature(using ctx.withPhase(ctx.erasurePhase))
+      if lastd != null && lastd.validFor.firstPhaseId <= ctx.erasurePhase.id then lastd.signature
+      else if ctx.erasedTypes then computeSignature(using ctx.withPhase(ctx.erasurePhase))
       else symbol.asSeenFrom(prefix).signature
 
     /** The signature of the current denotation if it is known without forcing.
@@ -1915,9 +1914,8 @@ object Types {
       if ctx.runId == mySignatureRunId then mySignature
       else
         val lastd = lastDenotation
-        val isErased = ctx.erasedTypes
-        if lastd != null && !isErased then lastd.signature
-        else if isErased then currentSignature(using ctx.withPhase(ctx.erasurePhase))
+        if lastd != null && lastd.validFor.firstPhaseId <= ctx.erasurePhase.id then lastd.signature
+        else if ctx.erasedTypes then currentSignature(using ctx.withPhase(ctx.erasurePhase))
         else
           val sym = currentSymbol
           if sym.exists then sym.asSeenFrom(prefix).signature

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3075,7 +3075,7 @@ object Types {
     }
   }
 
-  trait MethodicType extends SignatureCachingType {
+  trait MethodicType extends TermType {
     protected def resultSignature(implicit ctx: Context): Signature = try resultType match {
       case rtp: MethodicType => rtp.signature
       case tp =>
@@ -3095,7 +3095,7 @@ object Types {
     override def resultType(implicit ctx: Context): Type = resType
     override def underlying(implicit ctx: Context): Type = resType
 
-    def computeSignature(implicit ctx: Context): Signature = resultSignature
+    override def signature(implicit ctx: Context): Signature = Signature.NotAMethod
 
     def derivedExprType(resType: Type)(implicit ctx: Context): ExprType =
       if (resType eq this.resType) this else ExprType(resType)
@@ -3201,7 +3201,7 @@ object Types {
     final override def equals(that: Any): Boolean = equals(that, null)
   }
 
-  abstract class MethodOrPoly extends UncachedGroundType with LambdaType with MethodicType {
+  abstract class MethodOrPoly extends UncachedGroundType with LambdaType with MethodicType with SignatureCachingType {
     final override def hashCode: Int = System.identityHashCode(this)
 
     final override def equals(that: Any): Boolean = equals(that, null)

--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -112,7 +112,10 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
   override def relaxedTypingInGroup: Boolean = true
     // Because it changes number of parameters in trait initializers
 
-  override def runsAfter: Set[String] = Set(Erasure.name)
+  override def runsAfter: Set[String] = Set(
+    Erasure.name,
+    CompleteJavaEnums.name // This phase changes constructor parameters which Mixin translates into super-calls
+  )
 
   override def changesMembers: Boolean = true  // the phase adds implementions of mixin accessors
 

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -87,6 +87,19 @@ class TreeChecker extends Phase with SymTransformer {
 
     checkCompanion(symd)
 
+    // Signatures are used to disambiguate overloads and need to stay stable
+    // until erasure, see the comment above `Compiler#phases`.
+    if (ctx.phaseId <= ctx.erasurePhase.id) {
+      val cur = symd.info
+      val initial = symd.initial.info
+      assert(cur.signature == initial.signature,
+        i"""Signature of $symd changed at phase ${ctx.phase}
+           |Initial info: ${initial}
+           |Initial sig : ${initial.signature}
+           |Current info: ${cur}
+           |Current sig : ${cur.signature}""")
+    }
+
     symd
   }
 

--- a/compiler/test/dotty/tools/SignatureTest.scala
+++ b/compiler/test/dotty/tools/SignatureTest.scala
@@ -1,0 +1,38 @@
+package dotty.tools
+
+import vulpix.TestConfiguration
+
+import org.junit.Test
+
+import dotc.ast.Trees._
+import dotc.core.Decorators._
+import dotc.core.Contexts._
+import dotc.core.Types._
+
+import java.io.File
+import java.nio.file._
+
+class SignatureTest:
+  @Test def signatureCaching: Unit =
+    inCompilerContext(TestConfiguration.basicClasspath, separateRun = true, "case class Foo(value: Unit)") {
+      val (ref, refSig) = ctx.atPhase(ctx.erasurePhase.next) {
+        val cls = ctx.requiredClass("Foo")
+        val ref = cls.requiredMethod("value").termRef
+        (ref, ref.signature)
+      }
+      ctx.atPhase(ctx.typerPhase) {
+        // NamedType#signature is always computed before erasure, which ensures
+        // that it stays stable and therefore can be cached as long as
+        // signatures are guaranteed to be stable before erasure, see the
+        // comment above `Compiler#phases`.
+        assert(refSig == ref.signature,
+          s"""The signature of a type should never change but the signature of $ref was:
+             |${ref.signature} at typer, whereas it was:
+             |${refSig} after erasure""".stripMargin)
+        assert(ref.signature == ref.denot.signature,
+          s"""Before erasure, the signature of a TypeRef should be the signature of its denotation,
+             |but the cached signature of $ref was:
+             |${ref.signature}, whereas its denotation signature at typer was:
+             |${ref.denot.signature}""".stripMargin)
+      }
+    }


### PR DESCRIPTION
Some symbols change their signatures after erasure,
e.g. getters with Unit type or constructors taking an outer parameter.
Since signatures are assumed to be stable for a complete run,
we need to always compute signatures for NamedTypes before erasure.