### PR TITLE
Fix #8757: check wildcard star patterns by tree instead of type

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -481,8 +481,8 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
   def projectSeq(pats: List[Tree]): Space = {
     if (pats.isEmpty) return Typ(scalaNilType, false)
 
-    val (items, zero) = if (pats.last.tpe.isRepeatedParam)
-      (pats.init, Typ(scalaListType.appliedTo(pats.last.tpe.argTypes.head), false))
+    val (items, zero) = if (isWildcardStarArg(pats.last))
+      (pats.init, Typ(scalaListType.appliedTo(pats.last.tpe.elemType), false))
     else
       (pats, Typ(scalaNilType, false))
 

--- a/tests/patmat/i8757.check
+++ b/tests/patmat/i8757.check
@@ -1,0 +1,1 @@
+8: Pattern Match Exhaustivity: C()

--- a/tests/patmat/i8757.scala
+++ b/tests/patmat/i8757.scala
@@ -1,0 +1,10 @@
+sealed trait T
+
+case class C(xs: Int*) extends T
+
+def f(): Unit = (C(42): T) match { case C(xs: _*) => }
+def g(): Unit = (C(42): T) match { case C(_: _*) => }
+
+def h(): Unit = (C(42): T) match
+  case C(5, _: _*) =>
+  case C(x, xs: _*) =>


### PR DESCRIPTION
Fix #8757: check wildcard star patterns by tree instead of type