### PR TITLE
Don't lose info in bounds when pruning

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -15,13 +15,6 @@ object Config {
    */
   final val checkConstraintsNonCyclic = false
 
-  /** Make sure none of the bounds of a parameter in an OrderingConstraint
-   *  contains this parameter at its toplevel (i.e. as an operand of a
-   *  combination of &'s and |'s.). The check is performed each time a new bound
-   *  is added to the constraint.
-   */
-  final val checkConstraintsSeparated = false
-
   /** Check that each constraint resulting from a subtype test
    *  is satisfiable.
    */

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -13,7 +13,7 @@ object Config {
   /** When updating a constraint bound, check that the constrained parameter
    *  does not appear at the top-level of either of its bounds.
    */
-  final val checkConstraintsNonCyclic = false
+  final val checkConstraintsNonCyclic = true
 
   /** Check that each constraint resulting from a subtype test
    *  is satisfiable.

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -13,7 +13,7 @@ object Config {
   /** When updating a constraint bound, check that the constrained parameter
    *  does not appear at the top-level of either of its bounds.
    */
-  final val checkConstraintsNonCyclic = true
+  final val checkConstraintsNonCyclic = false
 
   /** Check that each constraint resulting from a subtype test
    *  is satisfiable.

--- a/compiler/src/dotty/tools/dotc/core/Constraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constraint.scala
@@ -151,7 +151,7 @@ abstract class Constraint extends Showable {
   def & (other: Constraint, otherHasErrors: Boolean)(implicit ctx: Context): Constraint
 
   /** Check that no constrained parameter contains itself as a bound */
-  def checkNonCyclic()(implicit ctx: Context): Unit
+  def checkNonCyclic()(implicit ctx: Context): this.type
 
   /** Check that constraint only refers to TypeParamRefs bound by itself */
   def checkClosed()(implicit ctx: Context): Unit

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -308,9 +308,6 @@ trait ConstraintHandling[AbstractContext] {
             //  from above  | hi  lo  lo
             //
             if (variance == 0 || fromBelow == (variance < 0)) bounds.lo else bounds.hi
-          case `param` =>
-            if variance == 0 || fromBelow == (variance < 0) then defn.AnyType
-            else defn.NothingType
           case _ => tp
         }
       }

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -109,10 +109,12 @@ trait ConstraintHandling[AbstractContext] {
         val p2 = adjust(tp.tp2)
         if p1.exists && p2.exists then tp.derivedAndOrType(p1, p2) else NoType
       case tp: TypeParamRef =>
+        if constraint.contains(tp) then
+          constr.println(i"${if tp eq param then "stripping" else "keeping"} $tp from $rawBound, upper = $isUpper in $constraint")
         if tp eq param then // (1)
-          //println(i"stripping $tp from $rawBound, upper = $isUpper in $constraint")
           if isUpper then defn.AnyType else defn.NothingType
         else constraint.entry(tp) match  // (3)
+          case NoType => tp
           case TypeBounds(lo, hi) => if lo eq hi then adjust(lo) else tp
           case inst => adjust(inst)
       case tp: TypeVar => // (2)

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -155,8 +155,7 @@ final class ProperGadtConstraint private(
           else if (isUpper) addLess(symTvar.origin, boundTvar.origin)
           else addLess(boundTvar.origin, symTvar.origin)
         case bound =>
-          if (isUpper) addUpperBound(symTvar.origin, bound)
-          else addLowerBound(symTvar.origin, bound)
+          addBoundTransitively(symTvar.origin, bound, isUpper)
       }
     ).reporting({
       val descr = if (isUpper) "upper" else "lower"
@@ -271,7 +270,7 @@ final class ProperGadtConstraint private(
 
   // ---- Debug ------------------------------------------------------------
 
-  override def constr_println(msg: => String): Unit = gadtsConstr.println(msg)
+  override def constr = gadtsConstr
 
   override def toText(printer: Printer): Texts.Text = constraint.toText(printer)
 

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -326,7 +326,15 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
       case tp: TypeVar =>
         val underlying1 = recur(tp.underlying, fromBelow)
         if underlying1 ne tp.underlying then underlying1 else tp
-      case _ => tp
+      case tp: AnnotatedType =>
+        val parent1 = recur(tp.parent, fromBelow)
+        if parent1 ne tp.parent then tp.derivedAnnotatedType(parent1, tp.annot) else tp
+      case _ =>
+        val tp1 = tp.dealiasKeepAnnots
+        if tp1 ne tp then
+          val tp2 = recur(tp1, fromBelow)
+          if tp2 ne tp1 then tp2 else tp
+        else tp
 
     inst match
       case bounds: TypeBounds =>
@@ -608,6 +616,8 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
         recur(lo)
         recur(hi)
       case _ =>
+        val tp1 = tp.dealias
+        if tp1 ne tp then recur(tp1)
 
     recur(entry(param))
   end checkNonCyclic

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -263,7 +263,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
   private def normalizedType(tp: Type, paramBuf: mutable.ListBuffer[TypeParamRef],
       isUpper: Boolean)(implicit ctx: Context): Type =
     stripParams(tp, paramBuf, isUpper)
-      .orElse(if (isUpper) defn.AnyType else defn.NothingType)
+      .orElse(if (isUpper) defn.AnyKindType else defn.NothingType)
 
   def add(poly: TypeLambda, tvars: List[TypeVar])(implicit ctx: Context): This = {
     assert(!contains(poly))

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -26,6 +26,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
   protected def maxToTextRecursions: Int = 100
 
+  protected def showUniqueIds = ctx.settings.uniqid.value || Printer.debugPrintUnique
+
   protected final def limiter: MessageLimiter = ctx.property(MessageLimiter).get
 
   protected def controlled(op: => Text): Text = limiter.controlled(op)
@@ -248,14 +250,14 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
   /** If -uniqid is set, the hashcode of the lambda type, after a # */
   protected def lambdaHash(pt: LambdaType): Text =
-    if (ctx.settings.uniqid.value)
+    if (showUniqueIds)
       try "#" + pt.hashCode
       catch { case ex: NullPointerException => "" }
     else ""
 
   /** If -uniqid is set, the unique id of symbol, after a # */
   protected def idString(sym: Symbol): String =
-    if (ctx.settings.uniqid.value || Printer.debugPrintUnique) "#" + sym.id else ""
+    if (showUniqueIds || Printer.debugPrintUnique) "#" + sym.id else ""
 
   def nameString(sym: Symbol): String =
     simpleNameString(sym) + idString(sym) // + "<" + (if (sym.exists) sym.owner else "") + ">"

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -213,7 +213,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case tp: RefinedType if defn.isFunctionType(tp) && !printDebug =>
         toTextDependentFunction(tp.refinedInfo.asInstanceOf[MethodType])
       case tp: TypeRef =>
-        if (tp.symbol.isAnonymousClass && !ctx.settings.uniqid.value)
+        if (tp.symbol.isAnonymousClass && !showUniqueIds)
           toText(tp.info)
         else if (tp.symbol.is(Param))
           tp.prefix match {
@@ -729,7 +729,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   protected def optAscription[T >: Untyped](tpt: Tree[T]): Text = optText(tpt)(": " ~ _)
 
   private def idText(tree: untpd.Tree): Text =
-    if ((ctx.settings.uniqid.value || Printer.debugPrintUnique) && tree.hasType && tree.symbol.exists) s"#${tree.symbol.id}" else ""
+    if showUniqueIds && tree.hasType && tree.symbol.exists then s"#${tree.symbol.id}" else ""
 
   private def useSymbol(tree: untpd.Tree) =
     tree.hasType && tree.symbol.exists && ctx.settings.YprintSyms.value

--- a/tests/pos/i6565.scala
+++ b/tests/pos/i6565.scala
@@ -12,6 +12,6 @@ lazy val ok: Lifted[String] = { // ok despite map returning a union
   point("a").map(_ => if true then "foo" else error) // ok
 }
 
-lazy val bad: Lifted[String] = { // found Lifted[Object]
-  point("a").flatMap(_ => point("b").map(_ => if true then "foo" else error)) // error
+lazy val nowAlsoOK: Lifted[String] = {
+  point("a").flatMap(_ => point("b").map(_ => if true then "foo" else error))
 }


### PR DESCRIPTION
A refactoring of the code for constraints and constraint handling. No more solutions are lost when adding a bound to a constraint. This means that the only source of cutoff of the solution space is now `either`, which is well understood.

The improvements were made possible by systematically avoiding cyclic constraints in `Constraint` itself.
"Cyclic" means that a type parameter `A` appears in its own bound at the toplevel (i.e. as a factor in some combination of `&` and `|` types. Any such occurrences can be replaced by the bottom or top types without loss of solutions. E.g.,
```
   A <: A | T  <=>  A <: AnyKind | T  <=>  A <: AnyKind
   A <: A & T  <=>  A <: AnyKind & T  <=>  A <: T
   A | T <: A  <=>  Nothing | T <: A  <=>  T <: A
   A & T <: A  <=>  A & Nothing <: A  <=>  Nothing <: A
```
