### PR TITLE
Make inline vals effectively erased

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -213,8 +213,11 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
 
     private object dropInlines extends TreeMap {
       override def transform(tree: Tree)(implicit ctx: Context): Tree = tree match {
-        case Inlined(call, _, _) =>
-          cpy.Inlined(tree)(call, Nil, Typed(ref(defn.Predef_undefined), TypeTree(tree.tpe)).withSpan(tree.span))
+        case Inlined(call, _, expansion) =>
+          val newExpansion = tree.tpe match
+            case ConstantType(c) => Literal(c)
+            case _ => Typed(ref(defn.Predef_undefined), TypeTree(tree.tpe))
+          cpy.Inlined(tree)(call, Nil, newExpansion.withSpan(tree.span))
         case _ => super.transform(tree)
       }
     }

--- a/tests/run/erased-inline-vals.scala
+++ b/tests/run/erased-inline-vals.scala
@@ -1,0 +1,47 @@
+
+abstract class A:
+  def x: Int
+  val y: Int
+
+class B extends A:
+  inline def x: Int = 1
+  inline val y = 2
+
+class C extends A:
+  final val x: Int = 3
+  final val y = 4
+
+class D:
+  inline def x: Int = 5
+  inline val y = 6
+
+@main def Test =
+  val b: B = new B
+  assert(b.x == 1)
+  assert(b.y == 2)
+
+  val a: A = b
+  assert(a.x == 1)
+  assert(a.y == 2)
+
+  val c: C = new C
+  assert(c.x == 3)
+  assert(c.y == 4)
+
+  val a2: A = c
+  assert(a2.x == 3)
+  assert(a2.y == 4)
+
+  val d: D = new D
+  assert(d.x == 5)
+  assert(d.y == 6)
+
+
+  assert(classOf[B].getDeclaredMethods.size == 2)
+  assert(classOf[B].getDeclaredFields.isEmpty)
+
+  assert(classOf[C].getDeclaredMethods.size == 2)
+  assert(classOf[C].getDeclaredFields.size == 1)
+
+  assert(classOf[D].getDeclaredMethods.isEmpty)
+  assert(classOf[D].getFields.isEmpty)


### PR DESCRIPTION
Inline vals are erased unless they implement a non-inline interface.
This follows are the same rules used for defs.