### PR TITLE
Experimental Support for Dependent Type Arguments - Step 1: Parsing

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -486,8 +486,14 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     ValDef(nme.syntheticParamName(n), if (tpt == null) TypeTree() else tpt, EmptyTree)
       .withFlags(flags)
 
-  def lambdaAbstract(tparams: List[TypeDef], tpt: Tree)(implicit ctx: Context): Tree =
-    if (tparams.isEmpty) tpt else LambdaTypeTree(tparams, tpt)
+  def lambdaAbstract(params: List[ValDef] | List[TypeDef], tpt: Tree)(using Context): Tree =
+    params match
+      case Nil               => tpt
+      case (vd: ValDef) :: _ => TermLambdaTypeTree(params.asInstanceOf[List[ValDef]], tpt)
+      case _                 => LambdaTypeTree(params.asInstanceOf[List[TypeDef]], tpt)
+
+  def lambdaAbstractAll(paramss: List[List[ValDef] | List[TypeDef]], tpt: Tree)(using Context): Tree =
+    paramss.foldRight(tpt)(lambdaAbstract)
 
   /** A reference to given definition. If definition is a repeated
    *  parameter, the reference will be a repeated argument.

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -377,6 +377,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def RefinedTypeTree(tpt: Tree, refinements: List[Tree])(implicit src: SourceFile): RefinedTypeTree = new RefinedTypeTree(tpt, refinements)
   def AppliedTypeTree(tpt: Tree, args: List[Tree])(implicit src: SourceFile): AppliedTypeTree = new AppliedTypeTree(tpt, args)
   def LambdaTypeTree(tparams: List[TypeDef], body: Tree)(implicit src: SourceFile): LambdaTypeTree = new LambdaTypeTree(tparams, body)
+  def TermLambdaTypeTree(params: List[ValDef], body: Tree)(implicit src: SourceFile): TermLambdaTypeTree = new TermLambdaTypeTree(params, body)
   def MatchTypeTree(bound: Tree, selector: Tree, cases: List[CaseDef])(implicit src: SourceFile): MatchTypeTree = new MatchTypeTree(bound, selector, cases)
   def ByNameTypeTree(result: Tree)(implicit src: SourceFile): ByNameTypeTree = new ByNameTypeTree(result)
   def TypeBoundsTree(lo: Tree, hi: Tree, alias: Tree = EmptyTree)(implicit src: SourceFile): TypeBoundsTree = new TypeBoundsTree(lo, hi, alias)

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -3,7 +3,7 @@ package dotc
 package config
 
 import core._
-import Contexts._, Symbols._, Names._
+import Contexts._, Symbols._, Names._, NameOps._
 import StdNames.nme
 import Decorators.{given _}
 import util.SourcePosition
@@ -22,7 +22,7 @@ object Feature:
   def enabledBySetting(feature: TermName, owner: Symbol = NoSymbol)(using Context): Boolean =
     def toPrefix(sym: Symbol): String =
       if !sym.exists || sym == defn.LanguageModule.moduleClass then ""
-      else toPrefix(sym.owner) + sym.name + "."
+      else toPrefix(sym.owner) + sym.name.stripModuleClassSuffix + "."
     val prefix = if owner.exists then toPrefix(owner) else ""
     ctx.base.settings.language.value.contains(prefix + feature)
 
@@ -38,7 +38,7 @@ object Feature:
   def enabledByImport(feature: TermName, owner: Symbol = NoSymbol)(using Context): Boolean =
     ctx.atPhase(ctx.typerPhase) {
       ctx.importInfo != null
-      && ctx.importInfo.featureImported(feature.toTermName,
+      && ctx.importInfo.featureImported(feature,
           if owner.exists then owner else defn.LanguageModule.moduleClass)
     }
 
@@ -56,6 +56,9 @@ object Feature:
 
   def dynamicsEnabled(using Context): Boolean =
     enabled(nme.dynamics)
+
+  def dependentEnabled(using Context) =
+    enabled(nme.dependent, defn.LanguageExperimentalModule.moduleClass)
 
   def sourceVersionSetting(using Context): SourceVersion =
     SourceVersion.valueOf(ctx.settings.source.value)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -664,6 +664,7 @@ class Definitions {
   @tu lazy val Mirror_SingletonProxyClass: ClassSymbol = ctx.requiredClass("scala.deriving.Mirror.SingletonProxy")
 
   @tu lazy val LanguageModule: Symbol = ctx.requiredModule("scala.language")
+  @tu lazy val LanguageExperimentalModule: Symbol = ctx.requiredModule("scala.language.experimental")
   @tu lazy val NonLocalReturnControlClass: ClassSymbol = ctx.requiredClass("scala.runtime.NonLocalReturnControl")
   @tu lazy val SelectableClass: ClassSymbol = ctx.requiredClass("scala.Selectable")
 

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -441,6 +441,7 @@ object StdNames {
     val definitions: N          = "definitions"
     val delayedInit: N          = "delayedInit"
     val delayedInitArg: N       = "delayedInit$body"
+    val dependent: N            = "dependent"
     val derived: N              = "derived"
     val derives: N              = "derives"
     val drop: N                 = "drop"

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1580,7 +1580,8 @@ object Parsers {
 
     /**  SimpleType      ::=  SimpleLiteral
      *                     |  ‘?’ SubtypeBounds
-     *                     |  SimpleType1 { ‘(’ Singletons ‘)’ }
+     *                     |  SimpleType1
+     *                     |  SimpeType ‘(’ Singletons ‘)’  -- under language.experimental.dependent, checked in Typer
      *   Singletons      ::=  Singleton {‘,’ Singleton}
      */
     def simpleType(): Tree =

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2846,11 +2846,11 @@ object Parsers {
       else tree1
     }
 
-    /** Annotation        ::=  `@' SimpleType {ParArgumentExprs}
+    /** Annotation        ::=  `@' SimpleType1 {ParArgumentExprs}
      */
     def annot(): Tree =
       adjustStart(accept(AT)) {
-        ensureApplied(parArgumentExprss(wrapNew(simpleType())))
+        ensureApplied(parArgumentExprss(wrapNew(simpleType1())))
       }
 
     def annotations(skipNewLines: Boolean = false): List[Tree] = {

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -900,7 +900,10 @@ object Scanners {
 // Lookahead ---------------------------------------------------------------
 
     /** The next token after this one.
+     *  The token is computed via fetchToken, so complex two word
+     *  tokens such as CASECLASS are not recognized.
      *  Newlines and indent/unindent tokens are skipped.
+     *
      */
      def lookahead: TokenData =
       if next.token == EMPTY then

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -98,6 +98,13 @@ object Scanners {
       this.strVal = td.strVal
       this.base = td.base
     }
+
+    def isNewLine = token == NEWLINE || token == NEWLINES
+    def isIdent = token == IDENTIFIER || token == BACKQUOTED_IDENT
+    def isIdent(name: Name) = token == IDENTIFIER && this.name == name
+
+    def isNestedStart = token == LBRACE || token == INDENT
+    def isNestedEnd = token == RBRACE || token == OUTDENT
   }
 
   abstract class ScannerCommon(source: SourceFile)(implicit ctx: Context) extends CharArrayReader with TokenData {
@@ -535,7 +542,7 @@ object Scanners {
 
     def observeColonEOL(): Unit =
       if token == COLON then
-        lookahead()
+        lookAhead()
         val atEOL = isAfterLineEnd || token == EOF
         reset()
         if atEOL then token = COLONEOL
@@ -562,7 +569,7 @@ object Scanners {
         insert(OUTDENT, offset)
       case _ =>
 
-    def lookahead() = {
+    def lookAhead() = {
       prev.copyFrom(this)
       lastOffset = lastCharOffset
       fetchToken()
@@ -591,12 +598,12 @@ object Scanners {
       }
       token match {
         case CASE =>
-          lookahead()
+          lookAhead()
           if (token == CLASS) fuse(CASECLASS)
           else if (token == OBJECT) fuse(CASEOBJECT)
           else reset()
         case SEMI =>
-          lookahead()
+          lookAhead()
           if (token != ELSE) reset()
         case COMMA =>
           def isEnclosedInParens(r: Region): Boolean = r match
@@ -608,7 +615,7 @@ object Scanners {
               insert(OUTDENT, offset)
               currentRegion = r.outer
             case _ =>
-              lookahead()
+              lookAhead()
               if isAfterLineEnd
                  && (token == RPAREN || token == RBRACKET || token == RBRACE || token == OUTDENT)
               then
@@ -892,6 +899,15 @@ object Scanners {
 
 // Lookahead ---------------------------------------------------------------
 
+    /** The next token after this one.
+     *  Newlines and indent/unindent tokens are skipped.
+     */
+     def lookahead: TokenData =
+      if next.token == EMPTY then
+        lookAhead()
+        reset()
+      next
+
     class LookaheadScanner() extends Scanner(source, offset)
 
     /** Skip matching pairs of `(...)` or `[...]` parentheses.
@@ -903,17 +919,6 @@ object Scanners {
       while token != EOF && token != opening + 1 do
         if token == opening && multiple then skipParens() else nextToken()
       nextToken()
-
-    /** Is the token following the current one in `tokens`? */
-    def lookaheadIn(follow: BitSet | TermName): Boolean =
-      val lookahead = LookaheadScanner()
-      while
-        lookahead.nextToken()
-        lookahead.isNewLine
-      do ()
-      follow match
-        case tokens: BitSet => tokens.contains(lookahead.token)
-        case name: TermName => lookahead.token == IDENTIFIER && lookahead.name == name
 
     /** Is the current token in a position where a modifier is allowed? */
     def inModifierPosition(): Boolean = {
@@ -1010,14 +1015,7 @@ object Scanners {
       isSoftModifier && inModifierPosition()
 
     def isSoftModifierInParamModifierPosition: Boolean =
-      isSoftModifier && !lookaheadIn(BitSet(COLON))
-
-    def isNewLine = token == NEWLINE || token == NEWLINES
-    def isIdent = token == IDENTIFIER || token == BACKQUOTED_IDENT
-    def isIdent(name: Name) = token == IDENTIFIER && this.name == name
-
-    def isNestedStart = token == LBRACE || token == INDENT
-    def isNestedEnd = token == RBRACE || token == OUTDENT
+      isSoftModifier && lookahead.token != COLON
 
     def canStartStatTokens =
       if migrateTo3 then canStartStatTokens2 else canStartStatTokens3

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -477,8 +477,11 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           changePrec(OrTypePrec) { toText(args(0)) ~ " | " ~ atPrec(OrTypePrec + 1) { toText(args(1)) } }
         else if (tpt.symbol == defn.andType && args.length == 2)
           changePrec(AndTypePrec) { toText(args(0)) ~ " & " ~ atPrec(AndTypePrec + 1) { toText(args(1)) } }
-        else
-          toTextLocal(tpt) ~ "[" ~ Text(args map argText, ", ") ~ "]"
+        else args match
+          case arg :: _ if arg.isTerm =>
+            toTextLocal(tpt) ~ "(" ~ Text(args.map(argText), ", ") ~ ")"
+          case _ =>
+            toTextLocal(tpt) ~ "[" ~ Text(args.map(argText), ", ") ~ "]"
       case LambdaTypeTree(tparams, body) =>
         changePrec(GlobalPrec) {
           tparamsText(tparams) ~ " =>> " ~ toText(body)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -486,6 +486,10 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         changePrec(GlobalPrec) {
           tparamsText(tparams) ~ " =>> " ~ toText(body)
         }
+      case TermLambdaTypeTree(params, body) =>
+        changePrec(GlobalPrec) {
+          paramsText(params) ~ " =>> " ~ toText(body)
+        }
       case MatchTypeTree(bound, sel, cases) =>
         changePrec(GlobalPrec) {
           toText(sel) ~ keywordStr(" match ") ~ blockText(cases) ~

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -146,5 +146,9 @@ object ErrorReporting {
       else ""
   }
 
+  def dependentStr =
+    """Term-dependent types are experimental,
+      |they must be enabled with a `experimental.dependent` language import or setting""".stripMargin
+
   def err(using Context): Errors = new Errors
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1578,6 +1578,14 @@ class Typer extends Namer
   }
 
   def typedAppliedTypeTree(tree: untpd.AppliedTypeTree)(using Context): Tree = {
+    tree.args match
+      case arg :: _ if arg.isTerm =>
+        if dependentEnabled then
+          return errorTree(tree, i"Not yet implemented: T(...)")
+        else
+          return errorTree(tree, dependentStr)
+      case _ =>
+
     val tpt1 = typed(tree.tpt, AnyTypeConstructorProto)(using ctx.retractMode(Mode.Pattern))
     val tparams = tpt1.tpe.typeParams
     if (tparams.isEmpty) {
@@ -1653,6 +1661,12 @@ class Typer extends Namer
     val body1 = typedType(tree.body)
     assignType(cpy.LambdaTypeTree(tree)(tparams1, body1), tparams1, body1)
   }
+
+  def typedTermLambdaTypeTree(tree: untpd.TermLambdaTypeTree)(using Context): Tree =
+    if dependentEnabled then
+      errorTree(tree, i"Not yet implemented: (...) =>> ...")
+    else
+      errorTree(tree, dependentStr)
 
   def typedMatchTypeTree(tree: untpd.MatchTypeTree, pt: Type)(using Context): Tree = {
     val bound1 =
@@ -2369,6 +2383,7 @@ class Typer extends Namer
           case tree: untpd.RefinedTypeTree => typedRefinedTypeTree(tree)
           case tree: untpd.AppliedTypeTree => typedAppliedTypeTree(tree)
           case tree: untpd.LambdaTypeTree => typedLambdaTypeTree(tree)(using ctx.localContext(tree, NoSymbol).setNewScope)
+          case tree: untpd.TermLambdaTypeTree => typedTermLambdaTypeTree(tree)(using ctx.localContext(tree, NoSymbol).setNewScope)
           case tree: untpd.MatchTypeTree => typedMatchTypeTree(tree, pt)
           case tree: untpd.ByNameTypeTree => typedByNameTypeTree(tree)
           case tree: untpd.TypeBoundsTree => typedTypeBoundsTree(tree, pt)

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -100,7 +100,7 @@ class TabcompleteTests extends ReplTest {
   @Test def importScala = fromInitialState { implicit s =>
     val comp = tabComplete("import scala.")
     // check that there are no special symbols leaked: <byname>, <special-ops>, ...
-    assertEquals(comp.find(_.startsWith("<")), Some("<:<"))
+    assertEquals(Some("<:<"), comp.find(_.startsWith("<")))
     assert(!comp.contains("package"))
   }
 

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -341,7 +341,7 @@ LocalModifier     ::=  ‘abstract’
 AccessModifier    ::=  (‘private’ | ‘protected’) [AccessQualifier]
 AccessQualifier   ::=  ‘[’ id ‘]’
 
-Annotation        ::=  ‘@’ SimpleType {ParArgumentExprs}                        Apply(tpe, args)
+Annotation        ::=  ‘@’ SimpleType1 {ParArgumentExprs}                        Apply(tpe, args)
 
 Import            ::=  ‘import’ ImportExpr {‘,’ ImportExpr}
 ImportExpr        ::=  SimpleRef {‘.’ id} ‘.’ ImportSpec                          Import(expr, sels)

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -139,13 +139,15 @@ ClassQualifier    ::=  ‘[’ id ‘]’
 ```ebnf
 Type              ::=  FunType
                     |  HkTypeParamClause ‘=>>’ Type                             TypeLambda(ps, t)
+                    |  ‘(’ TypedFunParams ‘)’ ‘=>>’ Type                        TypeLambda(ps, t)
                     |  MatchType
                     |  InfixType
 FunType           ::=  FunArgTypes (‘=>’ | ‘?=>’) Type                          Function(ts, t)
                     |  HKTypeParamClause '=>' Type                              PolyFunction(ps, t)
 FunArgTypes       ::=  InfixType
                     |  ‘(’ [ FunArgType {‘,’ FunArgType } ] ‘)’
-                    |  ‘(’ TypedFunParam {‘,’ TypedFunParam } ‘)’
+                    |  ‘(’ TypedFunParams ‘)’
+TypedFunParams    ::=  TypedFunParam {‘,’ TypedFunParam }
 TypedFunParam     ::=  id ‘:’ Type
 MatchType         ::=  InfixType `match` ‘{’ TypeCaseClauses ‘}’
 InfixType         ::=  RefinedType {id [nl] RefinedType}                        InfixOp(t1, op, t2)
@@ -155,8 +157,7 @@ AnnotType         ::=  SimpleType {Annotation}                                  
 
 SimpleType        ::=  SimpleLiteral                                            SingletonTypeTree(l)
                     |  ‘?’ SubtypeBounds
-                    |  SimpleType ‘(’ Singletons ‘)’
-                    |  SimpleType1
+                    |  SimpleType1 { ‘(’ Singletons ‘)’ }
 SimpleType1       ::=  id                                                       Ident(name)
                     |  Singleton ‘.’ id                                         Select(t, name)
                     |  Singleton ‘.’ ‘type’                                     SingletonTypeTree(p)
@@ -166,6 +167,7 @@ SimpleType1       ::=  id                                                       
                     |  SimpleType1 TypeArgs                                     AppliedTypeTree(t, args)
                     |  SimpleType1 ‘#’ id                                       Select(t, name)
 Singleton         ::=  SimpleRef
+                    |  SimpleLiteral
                     |  Singleton ‘.’ id
 -- not yet          |  Singleton ‘(’ Singletons ‘)’
 -- not yet          |  Singleton ‘[’ ArgTypes ‘]’

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -138,16 +138,16 @@ ClassQualifier    ::=  ‘[’ id ‘]’
 ### Types
 ```ebnf
 Type              ::=  FunType
-                    |  HkTypeParamClause ‘=>>’ Type                             TypeLambda(ps, t)
-                    |  ‘(’ TypedFunParams ‘)’ ‘=>>’ Type                        TypeLambda(ps, t)
+                    |  HkTypeParamClause ‘=>>’ Type                             LambdaTypeTree(ps, t)
+                    |  FunParamClause ‘=>>’ Type                                TermLambdaTypeTree(ps, t)
                     |  MatchType
                     |  InfixType
 FunType           ::=  FunArgTypes (‘=>’ | ‘?=>’) Type                          Function(ts, t)
                     |  HKTypeParamClause '=>' Type                              PolyFunction(ps, t)
 FunArgTypes       ::=  InfixType
                     |  ‘(’ [ FunArgType {‘,’ FunArgType } ] ‘)’
-                    |  ‘(’ TypedFunParams ‘)’
-TypedFunParams    ::=  TypedFunParam {‘,’ TypedFunParam }
+                    |  FunParamClause
+FunParamClause    ::=  ‘(’ TypedFunParam {‘,’ TypedFunParam } ‘)’
 TypedFunParam     ::=  id ‘:’ Type
 MatchType         ::=  InfixType `match` ‘{’ TypeCaseClauses ‘}’
 InfixType         ::=  RefinedType {id [nl] RefinedType}                        InfixOp(t1, op, t2)
@@ -372,7 +372,8 @@ VarDcl            ::=  ids ‘:’ Type                                         
 DefDcl            ::=  DefSig ‘:’ Type                                          DefDef(_, name, tparams, vparamss, tpe, EmptyTree)
 DefSig            ::=  id [DefTypeParamClause] DefParamClauses
                     |  ExtParamClause {nl} [‘.’] id DefParamClauses
-TypeDcl           ::=  id [TypeParamClause] SubtypeBounds [‘=’ Type]           TypeDefTree(_, name, tparams, bound
+TypeDcl           ::=  id [TypeParamClause] {FunParamClause} SubtypeBounds      TypeDefTree(_, name, tparams, bound
+                       [‘=’ Type]
 
 Def               ::=  ‘val’ PatDef
                     |  ‘var’ VarDef

--- a/library/src/scalaShadowing/language.scala
+++ b/library/src/scalaShadowing/language.scala
@@ -210,6 +210,9 @@ object language {
      *  to debug and understand.
      */
     implicit lazy val macros: macros = languageFeature.experimental.macros
+
+    /** Experimental support for richer dependent types */
+    object dependent
   }
 
   /** Where imported, a backwards compatibility mode for Scala2 is enabled */
@@ -238,6 +241,9 @@ object language {
    *  That's why the language import is required for them.
    */
   object adhocExtensions
+
+  /** Experimental support for richer dependent types */
+  object dependent
 
   /** Source version */
   object `3.0-migration`

--- a/tests/neg/deptypes-badsyntax.scala
+++ b/tests/neg/deptypes-badsyntax.scala
@@ -1,0 +1,2 @@
+
+type Bad1[T] = () =>> Array[T] // error

--- a/tests/neg/deptypes.scala
+++ b/tests/neg/deptypes.scala
@@ -1,5 +1,10 @@
 
 type Vec[T] = (n: Int) =>> Array[T] // error: needs to be enabled
+
+type Matrix[T](m: Int, n: Int) = Vec[Vec[T](n)](m)  // error: needs to be enabled
+
+type Tensor2[T](m: Int)(n: Int) = Matrix[T](m, n)   // error: needs to be enabled
+
 val x: Vec[Int](10) = ???  // error: needs to be enabled
 val n = 10
 type T = Vec[String](n)  // error: needs to be enabled

--- a/tests/neg/deptypes.scala
+++ b/tests/neg/deptypes.scala
@@ -1,0 +1,5 @@
+
+type Vec[T] = (n: Int) =>> Array[T] // error: needs to be enabled
+val x: Vec[Int](10) = ???  // error: needs to be enabled
+val n = 10
+type T = Vec[String](n)  // error: needs to be enabled

--- a/tests/neg/i4373.scala
+++ b/tests/neg/i4373.scala
@@ -9,13 +9,13 @@ class X5[A >: _ with X5[_]] // error
 class X6[A >: X6[_] with _] // error
 
 class A1 extends _ // error
-class A2 extends _ with _ // error // error
+class A2 extends _ with _ // error
 class A3 extends Base with _ // error
 class A4 extends _ with Base // error
 
 object Test {
   type T1 = _ // error
-  type T2 = _[Int] // error
+  type T2 = _[Int] // error // error
   type T3 = _ { type S } // error
   type T4 = [X] =>> _ // error
 

--- a/tests/neg/i4373c.scala
+++ b/tests/neg/i4373c.scala
@@ -1,4 +1,4 @@
 // ==> 18b253a4a89a84c5674165c6fc3efafad535eee3.scala <==
 object x0 {
-  def x1[x2 <:_[ // error // error
+  def x1[x2 <:_[ // error
 // error


### PR DESCRIPTION
This PR introduces syntax and parsing for dependent type arguments. The plan is that these additions should eventually replace the current unsafe use of `Singleton`.

Two syntax forms:

Application: Types like

    Vec[String](n)
    Vec[String](10)

Type Abstraction :

    type Vec[T] = (x: Int) =>> ...
    type Vec[T](n: Int) = ...

Together:

    type Matrix[T](m: Int, n: Int) = Vec[Vec[T](n)](m)

This is supported only under -language:experimental.dependent or the corresponding language import

    import language.experimental.dependent

Types and typing rules are still missing, so actually using any of these (with the setting) will currently give "not yet implemented" errors in Typer.

Based on #8855

