### PR TITLE
Fix #8861: Avoid parameters when instantiating closure results

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -293,10 +293,10 @@ trait ConstraintHandling[AbstractContext] {
 
   /** Widen inferred type `inst` with upper `bound`, according to the following rules:
    *   1. If `inst` is a singleton type, or a union containing some singleton types,
-   *      widen (all) the singleton type(s), provied the result is a subtype of `bound`
+   *      widen (all) the singleton type(s), provided the result is a subtype of `bound`
    *      (i.e. `inst.widenSingletons <:< bound` succeeds with satisfiable constraint)
    *   2. If `inst` is a union type, approximate the union type from above by an intersection
-   *      of all common base types, provied the result is a subtype of `bound`.
+   *      of all common base types, provided the result is a subtype of `bound`.
    *
    *  Don't do these widenings if `bound` is a subtype of `scala.Singleton`.
    *  Also, if the result of these widenings is a TypeRef to a module class,
@@ -309,15 +309,17 @@ trait ConstraintHandling[AbstractContext] {
   def widenInferred(inst: Type, bound: Type)(implicit actx: AbstractContext): Type = {
     def widenOr(tp: Type) = {
       val tpw = tp.widenUnion
-      if ((tpw ne tp) && tpw <:< bound) tpw else tp
+      if (tpw ne tp) && (tpw <:< bound) then tpw else tp
     }
     def widenSingle(tp: Type) = {
       val tpw = tp.widenSingletons
-      if ((tpw ne tp) && tpw <:< bound) tpw else tp
+      if (tpw ne tp) && (tpw <:< bound) then tpw else tp
     }
+    def isSingleton(tp: Type): Boolean = tp match
+      case WildcardType(optBounds) => optBounds.exists && isSingleton(optBounds.bounds.hi)
+      case _ => isSubTypeWhenFrozen(tp, defn.SingletonType)
     val wideInst =
-      if (isSubTypeWhenFrozen(bound, defn.SingletonType)) inst
-      else widenOr(widenSingle(inst))
+      if isSingleton(bound) then inst else widenOr(widenSingle(inst))
     wideInst match
       case wideInst: TypeRef if wideInst.symbol.is(Module) =>
         TermRef(wideInst.prefix, wideInst.symbol.sourceModule)

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -116,7 +116,7 @@ final class ProperGadtConstraint private(
     )
 
     val tvars = params.lazyZip(poly1.paramRefs).map { (sym, paramRef) =>
-      val tv = new TypeVar(paramRef, creatorState = null, ctx.owner.ownersIterator.length)
+      val tv = TypeVar(paramRef, creatorState = null)
       mapping = mapping.updated(sym, tv)
       reverseMapping = reverseMapping.updated(tv.origin, sym)
       tv

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -116,7 +116,7 @@ final class ProperGadtConstraint private(
     )
 
     val tvars = params.lazyZip(poly1.paramRefs).map { (sym, paramRef) =>
-      val tv = new TypeVar(paramRef, creatorState = null)
+      val tv = new TypeVar(paramRef, creatorState = null, ctx.owner.ownersIterator.length)
       mapping = mapping.updated(sym, tv)
       reverseMapping = reverseMapping.updated(tv.origin, sym)
       tv

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1450,9 +1450,10 @@ object SymDenotations {
       else if is(Contravariant) then Contravariant
       else EmptyFlags
 
-    /** The length of the owner chain of this symbol. 0 for _root_, undefined for NoSymbol */
+    /** The length of the owner chain of this symbol. 1 for _root_, 0 for NoSymbol */
     def nestingLevel(using Context): Int =
       @tailrec def recur(d: SymDenotation, n: Int): Int = d match
+        case NoDenotation => n
         case d: ClassDenotation => d.nestingLevel + n // profit from the cache in ClassDenotation
         case _ => recur(d.owner, n + 1)
       recur(this, 0)
@@ -2162,8 +2163,7 @@ object SymDenotations {
     private var myNestingLevel = -1
 
     override def nestingLevel(using Context) =
-      if myNestingLevel == -1 then
-        myNestingLevel = if maybeOwner.exists then maybeOwner.nestingLevel + 1 else 0
+      if myNestingLevel == -1 then myNestingLevel = owner.nestingLevel + 1
       myNestingLevel
   }
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1450,7 +1450,7 @@ object SymDenotations {
       else if is(Contravariant) then Contravariant
       else EmptyFlags
 
-    /** The length of the owner chain of this symbol. 0 for NoSymbol, 1 for _root_ */
+    /** The length of the owner chain of this symbol. 0 for _root_, undefined for NoSymbol */
     def nestingLevel(using Context): Int =
       @tailrec def recur(d: SymDenotation, n: Int): Int = d match
         case d: ClassDenotation => d.nestingLevel + n // profit from the cache in ClassDenotation

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4166,7 +4166,7 @@ object Types {
       if problems.isEmpty then tp
       else
         val atp = ctx.typer.avoid(tp, problems.toList)
-        val msg = i"Inaccessible variables captured in instantation of type variable $this.\n$tp was fixed to $atp"
+        def msg = i"Inaccessible variables captured in instantation of type variable $this.\n$tp was fixed to $atp"
         typr.println(msg)
         val bound = ctx.typeComparer.fullUpperBound(origin)
         if !(atp <:< bound) then

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4167,7 +4167,7 @@ object Types {
       else
         val atp = ctx.typer.avoid(tp, problems.toList)
         val msg = i"Inaccessible variables captured in instantation of type variable $this.\n$tp was fixed to $atp"
-        println(msg)
+        typr.println(msg)
         val bound = ctx.typeComparer.fullUpperBound(origin)
         if !(atp <:< bound) then
           throw new TypeError(s"$msg,\nbut the latter type does not conform to the upper bound $bound")

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1496,7 +1496,19 @@ class Namer { typer: Typer =>
       case TypedSplice(tpt: TypeTree) if !isFullyDefined(tpt.tpe, ForceDegree.none) =>
         mdef match {
           case mdef: DefDef if mdef.name == nme.ANON_FUN =>
+            // This case applies if the closure result type contains uninstantiated
+            // type variables. In this case, constrain the closure result from below
+            // by the parameter-capture-avoiding type of the body.
             val rhsType = typedAheadExpr(mdef.rhs, tpt.tpe).tpe
+
+            // The following part is important since otherwise we might instantiate
+            // the closure result type with a plain functon type that refers
+            // to local parameters. An example where this happens in `dependent-closures.scala`
+            // If the code after `val rhsType` is commented out, this file fails pickling tests.
+            // AVOIDANCE TODO: Follow up why this happens, and whether there
+            // are better ways to achieve this. It would be good if we could get rid of this code.
+            // It seems at least partially redundant with the nesting level checking on TypeVar
+            // instantiation.
             val hygienicType = avoid(rhsType, paramss.flatten)
             if (!hygienicType.isValueType || !(hygienicType <:< tpt.tpe))
               ctx.error(i"return type ${tpt.tpe} of lambda cannot be made hygienic;\n" +

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1494,9 +1494,9 @@ class Namer { typer: Typer =>
         if (isFullyDefined(tpe, ForceDegree.none)) tpe
         else typedAheadExpr(mdef.rhs, tpe).tpe
       case TypedSplice(tpt: TypeTree) if !isFullyDefined(tpt.tpe, ForceDegree.none) =>
-        val rhsType = typedAheadExpr(mdef.rhs, tpt.tpe).tpe
         mdef match {
           case mdef: DefDef if mdef.name == nme.ANON_FUN =>
+            val rhsType = typedAheadExpr(mdef.rhs, tpt.tpe).tpe
             val hygienicType = avoid(rhsType, paramss.flatten)
             if (!hygienicType.isValueType || !(hygienicType <:< tpt.tpe))
               ctx.error(i"return type ${tpt.tpe} of lambda cannot be made hygienic;\n" +

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1439,18 +1439,10 @@ class Namer { typer: Typer =>
       // instead of widening to the underlying module class types.
       // We also drop the @Repeated annotation here to avoid leaking it in method result types
       // (see run/inferred-repeated-result).
-      def widenRhs(tp: Type): Type = {
-        val tp1 = tp.widenTermRefExpr.simplified match
+      def widenRhs(tp: Type): Type =
+        tp.widenTermRefExpr.simplified match
           case ctp: ConstantType if isInlineVal => ctp
-          case ref: TypeRef if ref.symbol.is(ModuleClass) => tp
-          case tp =>
-            if true then ctx.typeComparer.widenInferred(tp, rhsProto)
-            else rhsProto match {
-              case OrType(_, _) | WildcardType(TypeBounds(_, OrType(_, _))) => tp.widen
-              case _ => tp.widenUnion
-            }
-        tp1.dropRepeatedAnnot
-      }
+          case tp => ctx.typeComparer.widenInferred(tp, rhsProto)
 
       // Replace aliases to Unit by Unit itself. If we leave the alias in
       // it would be erased to BoxedUnit.

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -501,8 +501,8 @@ object ProtoTypes {
     def newTypeVars(tl: TypeLambda): List[TypeTree] =
       for (paramRef <- tl.paramRefs)
       yield {
-        val tt = new TypeVarBinder().withSpan(owningTree.span)
-        val tvar = new TypeVar(paramRef, state, ctx.owner.ownersIterator.length)
+        val tt = TypeVarBinder().withSpan(owningTree.span)
+        val tvar = TypeVar(paramRef, state)
         state.ownedVars += tvar
         tt.withType(tvar)
       }

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -502,7 +502,7 @@ object ProtoTypes {
       for (paramRef <- tl.paramRefs)
       yield {
         val tt = new TypeVarBinder().withSpan(owningTree.span)
-        val tvar = new TypeVar(paramRef, state)
+        val tvar = new TypeVar(paramRef, state, ctx.owner.ownersIterator.length)
         state.ownedVars += tvar
         tt.withType(tvar)
       }

--- a/tests/neg/i8861.scala
+++ b/tests/neg/i8861.scala
@@ -1,0 +1,31 @@
+object Test {
+  sealed trait Container { s =>
+    type A
+    def visit[R](int: IntV & s.type => R, str: StrV & s.type => R): R
+  }
+  final class IntV extends Container { s =>
+    type A = Int
+    val i: Int = 42
+    def visit[R](int: IntV & s.type => R, str: StrV & s.type => R): R = int(this)
+  }
+  final class StrV extends Container { s =>
+    type A = String
+    val t: String = "hello"
+    def visit[R](int: IntV & s.type => R, str: StrV & s.type => R): R = str(this)
+  }
+
+  def minimalOk[R](c: Container { type A = R }): R = c.visit[R](
+    int = vi => vi.i : vi.A,
+    str = vs => vs.t : vs.A
+  )
+  def minimalFail[M](c: Container { type A = M }): M = c.visit(
+    int = vi => vi.i : vi.A,
+    str = vs => vs.t : vs.A  // error
+  )
+
+  def main(args: Array[String]): Unit = {
+    val e: Container { type A = String } = new StrV
+    println(minimalOk(e)) // this one prints "hello"
+    println(minimalFail(e)) // this one fails with ClassCastException: class java.lang.String cannot be cast to class java.lang.Integer
+  }
+}

--- a/tests/pos/dependent-closures.scala
+++ b/tests/pos/dependent-closures.scala
@@ -1,0 +1,27 @@
+trait S { type N; def n: N }
+
+def newS[X](n: X): S { type N = X } = ???
+
+def test =
+  val ss: List[S] = ???
+  val cl1 = (s: S) => newS(s.n)
+  val cl2: (s: S) => S { type N = s.N } = cl1
+  def f[R](cl: (s: S) => R) = cl
+  val x = f(s => newS(s.n))
+  val x1: (s: S) => S = x
+    // If the code in `tptProto` of Namer that refers to this
+    // file is commented out, we see:
+    // pickling difference for the result type of the closure argument
+    // before pickling: S => S { type N = s.N }
+    // after pickling : (s: S) => S { type N = s.N }
+
+  ss.map(s => newS(s.n))
+    // If the code in `tptProto` of Namer that refers to this
+    // file is commented out, we see a pickling difference like the one above.
+
+  def g[R](cl: (s: S) => (S { type N = s.N }, R)) = ???
+  g(s => (newS(s.n), identity(1)))
+
+  def h(cl: (s: S) => S { type N = s.N }) = ???
+  h(s => newS(s.n))
+


### PR DESCRIPTION
This was much harder than I anticipated, probably the hardest thing to fix for the last year or so. 

The fundamental problem is that when typing closures, we pass a partially instantiated expected type down as the result type of the closure. Type variables in this type might get constraints polluted with local parameter references. If we instantiate these type variables to these local types
referring such local parameters, unsoundness results.

Now, the easy fix would to simply not pass uninstantiated variables into scopes where their constraints can be polluted. Approximate them with wildcards instead. Unfortunately this causes some projects to fail. Notably zio, and test `run-macros/quote-matcher-symantics-3` since type inference propagates not enough. So, while it's the safe route it's not really an option at this point. 

I also tried to apply avoidance to the whole constraint at the end of type checking the body of a closure, but that's tricky, in particular for curried closures. 

I finally tried various backtracking schemes to alternatively type check with wildcards or type variables, but none of them passed all the test and they all got messy quickly.

So, this PR tackles the problem at the root: When trying to instantiate a type variable, avoid all term references to parameters or local variables that are nested more deeply than the type variable itself. This means we have to keep track of nesting levels for symbols and type variables. If such avoidance gives an instance type that does not fit the constraint bounds, throw a type error. 

There might be other possible ways to deal with it. But in any case, the current PR is a useful defensive programming measure. No matter what we do, we should not instantiate a type variable
to references that are more deeply nested. So, arguably  it's useful in any case.

