### PR TITLE
Add regression test

### DIFF
--- a/tests/pos-macros/f64Pow5Split/Lib.scala
+++ b/tests/pos-macros/f64Pow5Split/Lib.scala
@@ -1,0 +1,2 @@
+
+private final val f64Pow5Split: Array[Long] = Macro.f64Pow5Split

--- a/tests/pos-macros/f64Pow5Split/Macro.scala
+++ b/tests/pos-macros/f64Pow5Split/Macro.scala
@@ -1,0 +1,19 @@
+import scala.quoted._
+
+object Macro {
+
+  inline def f64Pow5Split: Array[Long] = ${ f64Pow5SplitExpr }
+  private def f64Pow5SplitExpr(using QuoteContext): Expr[Array[Long]] = Expr {
+    val ss = new Array[Long](652)
+    var pow5 = BigInt(1)
+    var i = 0
+    while (i < 652) {
+      ss(i) = (pow5 >> (pow5.bitLength - 121)).longValue & 0x3FFFFFFFFFFFFFFFL
+      ss(i + 1) = (pow5 >> (pow5.bitLength - 59)).longValue & 0x3FFFFFFFFFFFFFFFL
+      pow5 *= 5
+      i += 2
+    }
+    ss
+  }
+
+}


### PR DESCRIPTION
The generated code contains the creation of the precomputed array. 
<details>

```scala
package <empty> {
  @scala.annotation.internal.SourceFile(
    "tests/pos-macros/f64Pow5Split/Lib.scala"
  ) final module class App$ extends Object, java.io.Serializable {
    def <init>(): Unit = 
      {
        super()
        final val f64Pow5Split: Long[] = 
          [0L,288230376151711744L,0L,360287970189639680L,0L,450359962737049600L,
            0L
          ,562949953421312000L,0L,351843720888320000L,0L,439804651110400000L,0L,
            549755813888000000L
          ,0L,343597383680000000L,0L,429496729600000000L,0L,536870912000000000L,
            0L
          ,335544320000000000L,0L,419430400000000000L,0L,524288000000000000L,0L,
            327680000000000000L
          ,0L,409600000000000000L,0L,512000000000000000L,0L,320000000000000000L,
            0L
          ,400000000000000000L,0L,500000000000000000L,0L,312500000000000000L,0L,
            390625000000000000L
          ,0L,488281250000000000L,0L,305175781250000000L,0L,381469726562500000L,
            0L
          ,476837158203125000L,0L,298023223876953125L,1152921504606846976L,
            372529029846191406L
          ,3746994889972252672L,465661287307739257L,612489549322387456L,
            291038304567337036L
          ,765611936652984320L,363797880709171295L,4415779434636771328L,
            454747350886464118L
          ,3213881284082270208L,568434188608080148L,4314518811765112832L,
            355271367880050092L
          ,781462496279003136L,444089209850062616L,976828120348753920L,
            555111512312578270L
          ,4069282089038512128L,346944695195361418L,2780759602084446208L,
            433680868994201773L
          ,17184988785016832L,542101086242752217L,2893044379507752960L,
            338813178901720135L
          ,2463383969777844224L,423516473627150169L,4232151466829152256L,
            529395592033937711L
          ,4374476923678490624L,330872245021211069L,2009331640777572352L,
            413590306276513837L
          ,3664586055578812416L,516987882845642296L,2290366284736757760L,
            323117426778526435L
          ,1710036351314100224L,403896783473158044L,2137545439142625280L,
            504870979341447555L
          ,759505147160717312L,315544362088404722L,3255224443164590592L,
            394430452610505902L
          ,1763187544742044288L,493038065763132378L,2254913720070624656L,
            308148791101957736L
          ,2818642150088280820L,385185988877447170L,1217459678396657073L,
            481482486096808963L
          ,184451546694487182L,300926553810505602L,2536407442581802930L,
            376158192263132002L
          ,864666294013559710L,470197740328915003L,4575641699882439235L,
            293873587705571876L
          ,1107866106425661140L,367341984631964846L,3690675642245770377L,
            459177480789956057L
          ,1154580038986672043L,573971850987445072L,721612524366670027L,
            358732406867153170L
          ,3207858664672031485L,448415508583941462L,1703980321626345405L,
            560519385729926828L
          ,3370830710230159830L,350324616081204267L,3060616883180852811L,
            437905770101505334L
          ,1519928094762372062L,547382212626881668L,3255798068440176491L,
            342113882891801042L
          ,1763904576336526662L,427642353614751303L,1051959215813811351L,
            534552942018439129L
          ,3539778271400749534L,334095588761524455L,3271801334644089942L,
            417619485951905569L
          ,630987154484571500L,522024357439881962L,1547288476159704163L,
            326265223399926226L
          ,4239953604413324156L,407831529249907782L,2994098996302961243L,
            509789411562384728L
          ,1871311872689350777L,318618382226490455L,1186218336254841495L,
            398272977783113069L
          ,2635694424925398845L,497841222228891336L,1647309015578374278L,
            311150763893057085L
          ,3212057774079814824L,388938454866321356L,4015072217599768530L,
            486173068582901695L
          ,4238802392910125795L,303858167864313559L,4145581486530810268L,
            379822709830391949L
          ,1723212344342971907L,474778387287989937L,3959311476731474881L,
            296736492054993710L
          ,2643296336700649650L,370920615068742138L,998277411662118111L,
            463650768835927673L
          ,3506227143805941259L,289781730522454795L,3229862425150579598L,
            362227163153068494L
          ,1731485022224530545L,452783953941335618L,4470199286994357134L,
            565979942426669522L
          ,3946796058978320184L,353737464016668451L,3780573569116053255L,
            442171830020835564L
          ,114030942967678664L,552714787526044456L,71269339354799165L,
            345446742203777785L
          ,1242008178800345932L,431808427754722231L,399588718893585440L,
            539760534693402789L
          ,826203701611914388L,337350334183376743L,4491519140835433913L,
            421687917729220928L
          ,1002712907616904487L,527109897161526161L,3508999328777682744L,
            329443685725953850L
          ,2080406151758409478L,411804607157442313L,3753429194304858824L,
            514755758946802891L
          ,1769432494137113277L,321722349341751807L,1058869113064544620L,
            402152936677189759L
          ,170664886723833799L,502691170846487199L,1836047811112666588L,
            314181981779054499L
          ,1142138259283986260L,392727477223818124L,1427672824104982825L,
            490909346529772655L
          ,2621677771975884729L,306818341581107909L,4430018719576702888L,
            383522926976384886L
          ,3231680390257184658L,479403658720481108L,4325643253124434363L,
            299627286700300692L
          ,795368047978155050L,374534108375375866L,3300053069186387764L,
            468167635469219832L
          ,2062533168241492352L,292604772168262395L,1425244955695018465L,
            365755965210327994L
          ,4087399203832467033L,457194956512909992L,497562986363195887L,
            571493695641137491L
          ,4346202132600961845L,357183559775710931L,4279831161144355331L,
            446479449719638664L
          ,738102933003056260L,558099312149548331L,4496539599250874578L,
            348812070093467706L
          ,3314831489849899271L,436015087616834633L,684774848491833161L,
            545018859521043292L
          ,2733827289521089677L,340636787200652057L,4570205616508209073L,
            425795984000815071L
          ,4559835516028414365L,532244980001018839L,4579279454428029442L,
            332653112500636774L
          ,3418256308821342851L,415816390625795968L,4272820386026678563L,
            519770488282244960L
          ,2670512741266674102L,324856555176403100L,3338140926583342627L,
            406070693970503875L
          ,3019754653622331308L,507588367463129844L,4193189667727651020L,
            317242729664456152L
          ,629801066232175871L,396553412080570191L,4246015846610760766L,
            495691765100712738L
          ,3806681408738572455L,309807353187945461L,1299587247102674641L,
            387259191484931827L
          ,471562554271496325L,484073989356164784L,294726596419685203L,
            302546243347602990L
          ,2674251254738300456L,378182804184503737L,4495735573029722546L,
            472728505230629671L
          ,4539216990053847055L,295455315769143544L,1062335219139920915L,
            369319144711429431L
          ,174997519318054168L,461648930889286789L,685834201877207343L,
            288530581805804243L
          ,4316057266167050106L,360663227257255303L,4242150078101965657L,
            450829034071569129L
          ,1843923083806916143L,563536292589461412L,3458294936593016541L,
            352210182868413382L
          ,2017025661527576725L,440262728585516728L,2521282076909470906L,
            550328410731895910L
          ,422879793461572340L,343955256707434944L,528599741826965425L,
            429944070884293680L
          ,660749677283706782L,537430088605367100L,2718811557516010691L,
            335893805378354437L
          ,4551435951501860339L,419867256722943046L,3383451930163631472L,
            524834070903678808L
          ,2114657456352269670L,328021294314799255L,1490400315833490112L,
            410026617893499069L
          ,3015921899398709616L,512533272366873836L,4190794196337887462L,
            320333295229296147L
          ,4085571240815512351L,400416619036620184L,495278032592002535L,
            500520773795775231L
          ,2038931027280272048L,312825483622359519L,1395742279493493084L,
            391031854527949399L
          ,591756344760019380L,488789818159936749L,946308467778435600L,
            305493636349960468L
          ,1182885584723044500L,381867045437450585L,2631528485510652601L,
            477333806796813231L
          ,3374087560354428340L,298333629248008269L,758844936622494497L,
            372917036560010337L
          ,2101477675384965097L,466146295700012921L,4195727308632720625L,
            291341434812508075L
          ,4091737631184053806L,364176793515635094L,2808829029766373305L,
            455220991894543868L
          ,3511036287207966632L,569026239868179835L,1617936927201555657L,
            355641399917612397L
          ,3175342663608791547L,444551749897015496L,3969178329510989434L,
            555689687371269370L
          ,3633657960551215372L,347306054607043356L,4542072450689019215L,
            434132568258804195L
          ,4524669058754427043L,542665710323505244L,522075152507822950L,
            339166068952190778L
          ,2958436949848472639L,423957586190238472L,3698046187310590799L,
            529946982737798090L
          ,3464200371675966225L,331216864211123806L,2024407455381263830L,
            414021080263904758L
          ,224666310012885835L,517526350329880948L,2446259452971747599L,
            323453968956175592L
          ,3057824316214684499L,404317461195219490L,1516437386054661672L,
            505396826494024363L
          ,371312613980740057L,315873016558765227L,3922905281296465999L,
            394841270698456533L
          ,1444867087800041571L,493551588373070667L,326581177571602494L,
            308469742733169167L
          ,3866990985785044045L,385587178416461458L,2527895723017611104L,
            481983973020576823L
          ,3309317083796277404L,301239983137860514L,1830803345531652803L,
            376549978922325643L
          ,1135582677307719028L,470687473652907054L,4168503687137865320L,
            294179671033066908L
          ,598943590494943747L,367724588791333636L,748679488118679683L,
            459655735989167045L
          ,2088770864755196580L,574569669986458806L,152560285865150887L,
            359106043741536754L
          ,2496543366545132560L,448882554676920942L,814836198967721749L,
            561103193346151178L
          ,1662194128961673069L,350689495841344486L,4383585670415785288L,
            438361869801680607L
          ,4326560583412884634L,547952337252100759L,4433482621543323360L,
            342470210782562974L
          ,3236010267715460248L,428087763478203718L,1739169825430631358L,
            535109704347754648L
          ,1086981140894144599L,334443565217346655L,205804921510833773L,
            418054456521683319L
          ,3716020665709083144L,522568070652104148L,16669906854483013L,
            326605044157565093L
          ,1173758888174950742L,408256305196956366L,3773041619432382380L,
            510320381496195457L
          ,628768755234968523L,318950238435122161L,1938882448650557630L,
            398687798043902701L
          ,3576524565420044014L,498359747554878376L,2235327853387527508L,
            311474842221798985L
          ,3947081321341256362L,389343552777248731L,3780930147069723476L,
            486679440971560914L
          ,3516002846525424148L,304174650607225571L,3242082053549933210L,
            380218313259031964L
          ,4052602566937416512L,475272891573789955L,1956415852032461832L,
            297045557233618722L
          ,139676805826883338L,371306946542023403L,3633360521104145101L,
            464133683177529253L
          ,2847311077993514176L,290083551985955783L,2406217342885045744L,
            362604439982444729L
          ,4160693183213154156L,453255549978055911L,4047944974409595719L,
            566569437472569889L
          ,800583352095726860L,354105898420356181L,2153650694726505551L,
            442632373025445226L
          ,386220359194437987L,553290466281806533L,817848476799947230L,
            345806541426129083L
          ,4481075109820474965L,432258176782661353L,2142579373455052779L,
            540322720978326692L
          ,3644955117623101939L,337701700611454182L,2250350887815183471L,
            422127125764317728L
          ,2812938609768979339L,527658907205397160L,1758086631105612087L,
            329786817003373225L
          ,3350529793488862085L,412233521254216531L,3035240737254230630L,
            515291901567770664L
          ,1897025460783894144L,322057438479856665L,3524203330586714656L,
            402571798099820831L
          ,3252332658626546344L,503214747624776039L,3762090168551861929L,
            314509217265485024L
          ,90926692262439507L,393136521581856281L,1266579869934896360L,
            491420651977320351L
          ,2520994675619580689L,307137907485825219L,1998321839917628885L,
            383922384357281524L
          ,2497902299897036106L,479902980446601905L,4443492698952765006L,
            299939362779126190L
          ,3248522864477262306L,374924203473907738L,1754810571382883931L,
            468655254342384673L
          ,3979060368631419896L,292909533963990420L,362139442361886967L,
            366136917454988026L
          ,2758517312166052660L,457671146818735032L,3448146640207565826L,
            572088933523418790L
          ,1002170145522881665L,357555583452136744L,1252712681903602081L,
            446944479315170930L
          ,3871733861593196554L,558680599143963662L,1266912158888900870L,
            349175374464977289L
          ,2736561703217973063L,436469218081221611L,2267780624415619353L,
            545586522601527014L
          ,264441385652915120L,340991576625954384L,330551732066143900L,
            426239470782442980L
          ,413189665082679875L,532799338478053725L,834704292980098410L,
            332999586548783578L
          ,3349223375438816964L,416249483185979472L,4186529219298521205L,
            520311853982474340L
          ,310737752847881801L,325194908739046463L,3847186704880393179L,
            406493635923808078L
          ,2503140371886797522L,508117044904760098L,2717384237036095427L,
            317573153065475061L
          ,4549651800901966260L,396966441331843826L,3381221741913763873L,
            496208051664804783L
          ,3842645845606372885L,310130032290502989L,1344542793187425178L,
            387662540363128737L
          ,2833599996091128449L,484578175453910921L,41617740646684816L,
            302861359658694326L
          ,2357865185022049972L,378576699573367907L,1794409976670715490L,
            473220874466709884L
          ,3427349244632891133L,295763046541693677L,825422041970572988L,
            369703808177117097L
          ,2184699057070063211L,462129760221396371L,788976158365366019L,
            288831100138372732L
          ,986220197956707524L,361038875172965915L,79853742839037429L,
            451298593966207394L
          ,2405660187762490738L,564123242457759242L,2656459121958403687L,
            352577026536099526L
          ,1014730893234310657L,440721283170124408L,1268413616542888321L,
            550901603962655510L
          ,4251523024159846129L,344313502476659693L,1855639266379266733L,
            430391878095824617L
          ,3472470587580930392L,537989847619780771L,1593833364934658007L,
            336243654762362982L
          ,4298134715382016461L,420304568452953727L,4219746889620673600L,
            525380710566192159L
          ,4366724062923191464L,328362944103870099L,4305483574047142354L,
            410453680129837624L
          ,770168449131540039L,513067100162297031L,2210737537617482988L,
            320666937601435644L
          ,2763421922021853735L,400833672001794555L,2301355897920470193L,
            501042090002243194L
          ,2591268940807140847L,313151306251401996L,3239086176008926058L,
            391439132814252495L
          ,2895936215404310597L,489298916017815619L,1233499382324270635L,
            305811822511134762L
          ,3847717237119032246L,382264778138918452L,197960527971402403L,
            477830972673648066L
          ,1276646834588973478L,298644357921030041L,2748730047843063824L,
            373305447401287551L
          ,2282991055196982804L,466631809251609439L,3156251666408384716L,
            291644880782255899L
          ,2792393078403633919L,364556100977819874L,1184648338790848447L,
            455695126222274843L
          ,327888918881713583L,569618907777843554L,1357852078907917965L,
            356011817361152221L
          ,2850236603241744433L,445014771701440276L : Long]:Long[]
        ()
      }
    private def writeReplace(): Object = 
      new scala.runtime.ModuleSerializationProxy(classOf[App$])
  }
  final lazy module val App: App$ = new App$()
}
```

</details>