### PR TITLE
Update gitignore for VS Code - Metals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,12 @@ local.sbt
 # npm
 node_modules
 
-# VS Code
+# VS Code 
 .vscode/
+# Metals
+.bloop/
 .metals/
+project/metals.sbt
 
 # Scala-IDE specific
 .scala_dependencies


### PR DESCRIPTION
Right now opening dotty project in VS Code generates files not ignored by git.
Changes:
- Update gitignore to not track Metals specific files.
- 'Metals' separated from VS Code block because metals can also be used with emacs/vim etc.

As described in docs:
https://scalameta.org/metals/docs/editors/vscode.html#gitignore-projectmetalssbt-metals-and-bloop