### PR TITLE
Support command prefixes in REPL

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -329,8 +329,8 @@ class ReplDriver(settings: Array[String],
       out.println(s"""Unknown command: "$cmd", run ":help" for a list of commands""")
       state
 
-    case AmbiguousCommand(cmd) =>
-      out.println(s""""$cmd" matches more than one command. Try typing a few more characters. Run ":help" for a list of commands""")
+    case AmbiguousCommand(cmd, matching) =>
+      out.println(s""""$cmd" matches ${matching.mkString(", ")}. Try typing a few more characters. Run ":help" for a list of commands""")
       state
 
     case Help =>

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -329,6 +329,10 @@ class ReplDriver(settings: Array[String],
       out.println(s"""Unknown command: "$cmd", run ":help" for a list of commands""")
       state
 
+    case AmbiguousCommand(cmd) =>
+      out.println(s""""$cmd" matches more than one command. Try typing a few more characters. Run ":help" for a list of commands""")
+      state
+
     case Help =>
       out.println(Help.text)
       state

--- a/compiler/test-resources/repl/commandPrefixes
+++ b/compiler/test-resources/repl/commandPrefixes
@@ -1,0 +1,6 @@
+scala>:t 123
+Int
+scala>:type 123
+Int
+scala>:typee 123
+Unknown command: ":typee", run ":help" for a list of commands


### PR DESCRIPTION
e.g. `:q` or `:qu` instead of `:quit`.

If exactly one command matching the prefix is found, it is executed.

If multiple matching commands are found, an error is shown. (Currently this is not possible, as each command starts with a different letter.)

~~I've tested manually but couldn't find any automated tests for the REPL. Happy to write a test if someone can point me to the right place.~~ Added a scripted test.