### PR TITLE
Turn TypeOps into an object

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -78,7 +78,6 @@ object Contexts {
   abstract class Context(val base: ContextBase)
     extends Periods
        with Substituters
-       with TypeOps
        with Phases
        with Printers
        with Symbols

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -5,6 +5,7 @@ package core
 import Types._, Contexts._, Symbols._, Flags._, Names._, NameOps._, Denotations._
 import Decorators._
 import StdNames.nme
+import TypeOps.refineUsingParent
 import collection.mutable
 import util.Stats
 import config.Config
@@ -2306,7 +2307,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
      *  denote the same set of values.
      */
     def decompose(sym: Symbol, tp: Type): List[Type] =
-      sym.children.map(x => ctx.refineUsingParent(tp, x)).filter(_.exists)
+      sym.children.map(x => refineUsingParent(tp, x)).filter(_.exists)
 
     (tp1.dealias, tp2.dealias) match {
       case (tp1: TypeRef, tp2: TypeRef) if tp1.symbol == defn.SingletonClass || tp2.symbol == defn.SingletonClass =>

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -5,6 +5,7 @@ package core
 import Symbols._, Types._, Contexts._, Flags._, Names._, StdNames._
 import Flags.JavaDefined
 import Uniques.unique
+import TypeOps.makePackageObjPrefixExplicit
 import transform.ExplicitOuter._
 import transform.ValueClasses._
 import transform.TypeUtils._
@@ -166,7 +167,7 @@ object TypeErasure {
   def erasedRef(tp: Type)(implicit ctx: Context): Type = tp match {
     case tp: TermRef =>
       assert(tp.symbol.exists, tp)
-      val tp1 = ctx.makePackageObjPrefixExplicit(tp)
+      val tp1 = makePackageObjPrefixExplicit(tp)
       if (tp1 ne tp) erasedRef(tp1)
       else TermRef(erasedRef(tp.prefix), tp.symbol.asTerm)
     case tp: ThisType =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -898,7 +898,7 @@ object Types {
     final def asSeenFrom(pre: Type, cls: Symbol)(implicit ctx: Context): Type = {
       record("asSeenFrom")
       if (!cls.membersNeedAsSeenFrom(pre)) this
-      else ctx.asSeenFrom(this, pre, cls)
+      else TypeOps.asSeenFrom(this, pre, cls)
     }
 
 // ----- Subtype-related --------------------------------------------
@@ -1668,7 +1668,7 @@ object Types {
      *  after the type variables are instantiated. Finally, it
      *  maps poly params in the current constraint set back to their type vars.
      */
-    def simplified(implicit ctx: Context): Type = ctx.simplify(this, null)
+    def simplified(implicit ctx: Context): Type = TypeOps.simplify(this, null)
 
     /** Compare `this == that`, assuming corresponding binders in `bs` are equal.
      *  The normal `equals` should be equivalent to `equals(that, null`)`.
@@ -2948,7 +2948,7 @@ object Types {
     /** Replace or type by the closest non-or type above it */
     def join(implicit ctx: Context): Type = {
       if (myJoinPeriod != ctx.period) {
-        myJoin = ctx.orDominator(this)
+        myJoin = TypeOps.orDominator(this)
         core.println(i"join of $this == $myJoin")
         assert(myJoin != this)
         myJoinPeriod = ctx.period
@@ -4165,7 +4165,7 @@ object Types {
       val problems = problemSyms(Set.empty, tp)
       if problems.isEmpty then tp
       else
-        val atp = ctx.typer.avoid(tp, problems.toList)
+        val atp = TypeOps.avoid(tp, problems.toList)
         def msg = i"Inaccessible variables captured in instantation of type variable $this.\n$tp was fixed to $atp"
         typr.println(msg)
         val bound = ctx.typeComparer.fullUpperBound(origin)

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -76,7 +76,7 @@ class ReifyQuotes extends MacroTransform {
 
   override def checkPostCondition(tree: Tree)(implicit ctx: Context): Unit =
     tree match {
-      case tree: RefTree if !ctx.inInlineMethod =>
+      case tree: RefTree if !Inliner.inInlineMethod =>
         assert(!tree.symbol.isQuote)
         assert(!tree.symbol.isSplice)
       case _ : TypeDef =>

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -605,7 +605,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
       case tp =>
         val parts = children.map { sym =>
           val sym1 = if (sym.is(ModuleClass)) sym.sourceModule else sym
-          val refined = ctx.refineUsingParent(tp, sym1)
+          val refined = TypeOps.refineUsingParent(tp, sym1)
 
           def inhabited(tp: Type): Boolean =
             tp.dealias match {

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -69,7 +69,7 @@ object Checking {
         errorTree(arg,
           showInferred(MissingTypeParameterInTypeApp(arg.tpe), app, tpt))
     }
-    for (arg, which, bound) <- ctx.boundsViolations(args, boundss, instantiate, app) do
+    for (arg, which, bound) <- TypeOps.boundsViolations(args, boundss, instantiate, app) do
       ctx.error(
           showInferred(DoesNotConformToBound(arg.tpe, which, bound),
               app, tpt),
@@ -884,7 +884,7 @@ trait Checking {
 
   /** Check that `tree` can be right hand-side or argument to `inline` value or parameter. */
   def checkInlineConformant(tpt: Tree, tree: Tree, sym: Symbol)(using Context): Unit = {
-    if sym.is(Inline, butNot = DeferredOrTermParamOrAccessor) && !ctx.erasedTypes && !ctx.inInlineMethod then
+    if sym.is(Inline, butNot = DeferredOrTermParamOrAccessor) && !ctx.erasedTypes && !Inliner.inInlineMethod then
       // final vals can be marked inline even if they're not pure, see Typer#patchFinalVals
       val purityLevel = if (sym.is(Final)) Idempotent else Pure
       tpt.tpe.widenTermRefExpr.dealias.normalized match
@@ -1088,7 +1088,7 @@ trait Checking {
 
   /** Check that we are in an inline context (inside an inline method or in inline code) */
   def checkInInlineContext(what: String, posd: Positioned)(using Context): Unit =
-    if !ctx.inInlineMethod && !ctx.isInlineContext then
+    if !Inliner.inInlineMethod && !ctx.isInlineContext then
       ctx.error(em"$what can only be used in an inline method", posd.sourcePos)
 
   /** 1. Check that all case classes that extend `scala.Enum` are `enum` cases

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -48,9 +48,13 @@ object Inliner {
     else
       EmptyTree
 
+  /** Are we in an inline method body? */
+  def inInlineMethod(using Context): Boolean =
+    ctx.owner.ownersIterator.exists(_.isInlineMethod)
+
   /** Should call to method `meth` be inlined in this context? */
   def isInlineable(meth: Symbol)(using Context): Boolean =
-    meth.is(Inline) && meth.hasAnnotation(defn.BodyAnnot) && !ctx.inInlineMethod
+    meth.is(Inline) && meth.hasAnnotation(defn.BodyAnnot) && !inInlineMethod
 
   /** Should call be inlined in this context? */
   def isInlineable(tree: Tree)(using Context): Boolean = tree match {

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1510,7 +1510,7 @@ class Namer { typer: Typer =>
             // are better ways to achieve this. It would be good if we could get rid of this code.
             // It seems at least partially redundant with the nesting level checking on TypeVar
             // instantiation.
-            val hygienicType = avoid(rhsType, paramss.flatten)
+            val hygienicType = TypeOps.avoid(rhsType, paramss.flatten)
             if (!hygienicType.isValueType || !(hygienicType <:< tpt.tpe))
               ctx.error(i"return type ${tpt.tpe} of lambda cannot be made hygienic;\n" +
                 i"it is not a supertype of the hygienic type $hygienicType", mdef.sourcePos)

--- a/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
@@ -244,7 +244,7 @@ object PrepareInlineable {
   def checkInlineMethod(inlined: Symbol, body: Tree)(using Context): Unit = {
     if (inlined.owner.isClass && inlined.owner.seesOpaques)
       ctx.error(em"Implementation restriction: No inline methods allowed where opaque type aliases are in scope", inlined.sourcePos)
-    if (ctx.outer.inInlineMethod)
+    if Inliner.inInlineMethod(using ctx.outer) then
       ctx.error(ex"Implementation restriction: nested inline methods are not supported", inlined.sourcePos)
 
     if (inlined.is(Macro) && !ctx.isAfterTyper) {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3083,7 +3083,7 @@ class Typer extends Namer
         checkEqualityEvidence(tree, pt)
         tree
       }
-      else if (methPart(tree).symbol.isAllOf(Inline | Deferred) && !ctx.inInlineMethod) then
+      else if (methPart(tree).symbol.isAllOf(Inline | Deferred) && !Inliner.inInlineMethod) then
         errorTree(tree, i"Deferred inline ${methPart(tree).symbol.showLocated} cannot be invoked")
       else if (Inliner.isInlineable(tree) &&
                !ctx.settings.YnoInline.value &&

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -885,7 +885,7 @@ class Typer extends Namer
     if (noLeaks(tree)) tree
     else {
       fullyDefinedType(tree.tpe, "block", tree.span)
-      var avoidingType = avoid(tree.tpe, localSyms)
+      var avoidingType = TypeOps.avoid(tree.tpe, localSyms)
       val ptDefined = isFullyDefined(pt, ForceDegree.none)
       if (ptDefined && !(avoidingType.widenExpr <:< pt)) avoidingType = pt
       val tree1 = ascribeType(tree, avoidingType)


### PR DESCRIPTION

Also, move `avoid` from TypeAssigner to TypeOps, since we
need to refer to it in Types.

Based on #8867
