### PR TITLE
Avoid uses of `quoted.Expr[_]`

### DIFF
--- a/docs/blog/_posts/2019-08-30-18th-dotty-milestone-release.md
+++ b/docs/blog/_posts/2019-08-30-18th-dotty-milestone-release.md
@@ -256,7 +256,7 @@ For precise rules, semantics and a larger example of `BigFloat`, see [the docume
 ## Metaprogramming Progress
 We are making steady progress with the language metaprogramming features. The metaprogramming spotlights of this release are as follows:
 
-- `toExprOfTuple` method which allows converting a `Seq[Expr[_]]` to `Expr[Tuple]`. The types of the expressions will be preserved in the tuple. See [#7037](https://github.com/lampepfl/dotty/pull/7037) and [#7076](https://github.com/lampepfl/dotty/pull/7076) for the details.
+- `toExprOfTuple` method which allows converting a `Seq[Expr[Any]]` to `Expr[Tuple]`. The types of the expressions will be preserved in the tuple. See [#7037](https://github.com/lampepfl/dotty/pull/7037) and [#7076](https://github.com/lampepfl/dotty/pull/7076) for the details.
 - `toExprOfTuple` method that converts a tuple of expressions to an expression of tuple – see [#7047](https://github.com/lampepfl/dotty/pull/7047).
 - `toExprOfSeq` which converts an `Seq[Expr[A]]` to `Expr[Seq[A]]` – see [#6935](https://github.com/lampepfl/dotty/pull/6935).
 - More `Liftable` instances – for Tuples of arity greater than 22, `BigInt` and `BigDecimal` – see [#6947](https://github.com/lampepfl/dotty/pull/6947) and [#6944](https://github.com/lampepfl/dotty/pull/6944).

--- a/docs/docs/reference/metaprogramming/macros-spec.md
+++ b/docs/docs/reference/metaprogramming/macros-spec.md
@@ -211,13 +211,13 @@ through quotes. Most likely, those constructors would work over `Expr`
 types which lack a known type argument. For instance, an `Apply`
 constructor could be typed as follows:
 ```scala
-def Apply(fn: Expr[_], args: List[Expr[_]]): Expr[_]
+def Apply(fn: Expr[Any], args: List[Expr[Any]]): Expr[Any]
 ```
 This would allow constructing applications from lists of arguments
 without having to match the arguments one-by-one with the
 corresponding formal parameter types of the function. We then need "at
-the end" a method to convert an `Expr[_]` to an `Expr[T]` where `T` is
-given from the outside. E.g. if `code` yields a `Expr[_]`, then
+the end" a method to convert an `Expr[Any]` to an `Expr[T]` where `T` is
+given from the outside. E.g. if `code` yields a `Expr[Any]`, then
 `code.atType[T]` yields an `Expr[T]`. The `atType` method has to be
 implemented as a primitive; it would check that the computed type
 structure of `Expr` is a subtype of the type structure representing

--- a/docs/docs/reference/other-new-features/quoted-pattern-spec.md
+++ b/docs/docs/reference/other-new-features/quoted-pattern-spec.md
@@ -32,7 +32,7 @@ def foo(x: Expr[Int])(using tasty.Reflect): Expr[Int] = x match {
 At runtime to a `quoted.Expr` can be matched to another using `scala.internal.quoted.Expr.unapply`.
 
 ```scala
-def unapply[Tup <: Tuple](scrutineeExpr: Expr[_])(implicit patternExpr: Expr[_], reflection: Reflection): Option[Tup]
+def unapply[Tup <: Tuple](scrutineeExpr: Expr[Any])(implicit patternExpr: Expr[Any], reflection: Reflection): Option[Tup]
 ```
 
 The `scrutineeExpr` is a normal quoted expression while `patternExpr` may contain holes representing splices.

--- a/library/src/scala/internal/quoted/Expr.scala
+++ b/library/src/scala/internal/quoted/Expr.scala
@@ -26,13 +26,13 @@ object Expr {
    *    - scala.internal.Quoted.patternHole[T]: hole that matches an expression `x` of type `Expr[U]`
    *                                            if `U <:< T` and returns `x` as part of the match.
    *
-   *  @param scrutineeExpr `Expr[_]` on which we are pattern matching
-   *  @param patternExpr `Expr[_]` containing the pattern tree
+   *  @param scrutineeExpr `Expr[Any]` on which we are pattern matching
+   *  @param patternExpr `Expr[Any]` containing the pattern tree
    *  @param hasTypeSplices `Boolean` notify if the pattern has type splices (if so we use a GADT context)
    *  @param qctx the current QuoteContext
    *  @return None if it did not match, `Some(tup)` if it matched where `tup` contains `Expr[Ti]``
    */
-  def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeExpr: scala.quoted.Expr[_])(using patternExpr: scala.quoted.Expr[_],
+  def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeExpr: scala.quoted.Expr[Any])(using patternExpr: scala.quoted.Expr[Any],
         hasTypeSplices: Boolean, qctx: QuoteContext): Option[Tup] = {
     new Matcher.QuoteMatcher[qctx.type].termMatch(scrutineeExpr.unseal, patternExpr.unseal, hasTypeSplices).asInstanceOf[Option[Tup]]
   }

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -80,7 +80,7 @@ object Expr {
    *   ```
    */
   def betaReduce[F, Args <: Tuple, R, G](f: Expr[F])(using tf: TupledFunction[F, Args => R], tg: TupledFunction[G, TupleOfExpr[Args] => Expr[R]], qctx: QuoteContext): G =
-    tg.untupled(args => qctx.tasty.internal.betaReduce(f.unseal, args.toArray.toList.map(_.asInstanceOf[QuoteContext => Expr[_]](qctx).unseal)).seal.asInstanceOf[Expr[R]])
+    tg.untupled(args => qctx.tasty.internal.betaReduce(f.unseal, args.toArray.toList.map(_.asInstanceOf[QuoteContext => Expr[Any]](qctx).unseal)).seal.asInstanceOf[Expr[R]])
 
   /** `Expr.betaReduceGiven(f)(x1, ..., xn)` is functionally the same as `'{($f)(using $x1, ..., $xn)}`, however it optimizes this call
    *   by returning the result of beta-reducing `f(using x1, ..., xn)` if `f` is a known lambda expression.
@@ -91,7 +91,7 @@ object Expr {
    *   ```
    */
   def betaReduceGiven[F, Args <: Tuple, R, G](f: Expr[F])(using tf: TupledFunction[F, Args ?=> R], tg: TupledFunction[G, TupleOfExpr[Args] => Expr[R]], qctx: QuoteContext): G =
-    tg.untupled(args => qctx.tasty.internal.betaReduce(f.unseal, args.toArray.toList.map(_.asInstanceOf[QuoteContext => Expr[_]](qctx).unseal)).seal.asInstanceOf[Expr[R]])
+    tg.untupled(args => qctx.tasty.internal.betaReduce(f.unseal, args.toArray.toList.map(_.asInstanceOf[QuoteContext => Expr[Any]](qctx).unseal)).seal.asInstanceOf[Expr[R]])
 
   /** Returns a null expresssion equivalent to `'{null}` */
   def nullExpr: QuoteContext ?=> Expr[Null] = qctx ?=> {
@@ -109,7 +109,7 @@ object Expr {
    *  Given list of statements `s1 :: s2 :: ... :: Nil` and an expression `e` the resulting expression
    *  will be equivalent to `'{ $s1; $s2; ...; $e }`.
    */
-  def block[T](statements: List[Expr[_]], expr: Expr[T])(using qctx: QuoteContext): Expr[T] = {
+  def block[T](statements: List[Expr[Any]], expr: Expr[T])(using qctx: QuoteContext): Expr[T] = {
     import qctx.tasty._
     Block(statements.map(_.unseal), expr.unseal).seal.asInstanceOf[Expr[T]]
   }
@@ -140,11 +140,11 @@ object Expr {
   /** Lifts this sequence of expressions into an expression of a tuple
    *
    *  Transforms a sequence of expression
-   *    `Seq(e1, e2, ...)` where `ei: Expr[_]`
+   *    `Seq(e1, e2, ...)` where `ei: Expr[Any]`
    *  to an expression equivalent to
    *    `'{ ($e1, $e2, ...) }` typed as an `Expr[Tuple]`
    */
-  def ofTuple(seq: Seq[Expr[_]])(using qctx: QuoteContext): Expr[Tuple] = {
+  def ofTuple(seq: Seq[Expr[Any]])(using qctx: QuoteContext): Expr[Tuple] = {
     seq match {
       case Seq() =>
         unitExpr
@@ -199,7 +199,7 @@ object Expr {
 
   /** Given a tuple of the form `(Expr[A1], ..., Expr[An])`, outputs a tuple `Expr[(A1, ..., An)]`. */
   def ofTuple[T <: Tuple: Tuple.IsMappedBy[Expr]: Type](tup: T)(using qctx: QuoteContext): Expr[Tuple.InverseMap[T, Expr]] = {
-    val elems: Seq[Expr[_]] = tup.asInstanceOf[Product].productIterator.toSeq.asInstanceOf[Seq[Expr[_]]]
+    val elems: Seq[Expr[Any]] = tup.asInstanceOf[Product].productIterator.toSeq.asInstanceOf[Seq[Expr[Any]]]
     ofTuple(elems).cast[Tuple.InverseMap[T, Expr]]
   }
 

--- a/library/src/scala/quoted/QuoteContext.scala
+++ b/library/src/scala/quoted/QuoteContext.scala
@@ -53,7 +53,7 @@ class QuoteContext(val tasty: scala.tasty.Reflection) { self =>
     tasty.warning(msg, tasty.rootPosition)
 
   /** Report a warning at the on the position of `expr` */
-  def warning(msg: => String, expr: Expr[_]): Unit =
+  def warning(msg: => String, expr: Expr[Any]): Unit =
     tasty.warning(msg, expr.unseal(using this).pos)
 
 }

--- a/library/src/scala/tasty/reflect/CompilerInterface.scala
+++ b/library/src/scala/tasty/reflect/CompilerInterface.scala
@@ -125,7 +125,7 @@ trait CompilerInterface {
   /** Unpickle `repr` which represents a pickled `Expr` tree,
    *  replacing splice nodes with `args`
    */
-  def unpickleExpr(repr: Unpickler.PickledQuote, args: Unpickler.PickledArgs): scala.quoted.Expr[_]
+  def unpickleExpr(repr: Unpickler.PickledQuote, args: Unpickler.PickledArgs): scala.quoted.Expr[Any]
 
   /** Unpickle `repr` which represents a pickled `Type` tree,
    *  replacing splice nodes with `args`
@@ -1425,11 +1425,11 @@ trait CompilerInterface {
   // QUOTED SEAL/UNSEAL //
   ////////////////////////
 
-  /** View this expression `quoted.Expr[_]` as a `Term` */
-  def QuotedExpr_unseal(self: scala.quoted.Expr[_])(using ctx: Context): Term
+  /** View this expression `quoted.Expr[Any]` as a `Term` */
+  def QuotedExpr_unseal(self: scala.quoted.Expr[Any])(using ctx: Context): Term
 
   /** Checked cast to a `quoted.Expr[U]` */
-  def QuotedExpr_cast[U](self: scala.quoted.Expr[_])(using tp: scala.quoted.Type[U], ctx: Context): scala.quoted.Expr[U]
+  def QuotedExpr_cast[U](self: scala.quoted.Expr[Any])(using tp: scala.quoted.Type[U], ctx: Context): scala.quoted.Expr[U]
 
   /** View this expression `quoted.Type[T]` as a `TypeTree` */
   def QuotedType_unseal(self: scala.quoted.Type[_])(using ctx: Context): TypeTree


### PR DESCRIPTION
These may end up requiring a `quoted.Type[_]` which cannot be provided.

All uses where sound, but it is better to give a good example.