### PR TITLE
Closes #8873: Remove the outdated dist subproject

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -368,8 +368,8 @@ jobs:
 
       - name: Publish Release
         run: |
-          ./project/scripts/sbt dist-bootstrapped/packArchive
-          sha256sum dist-bootstrapped/target/dotty-* > dist-bootstrapped/target/sha256sum.txt
+          ./project/scripts/sbt dist/packArchive
+          sha256sum dist/target/dotty-* > dist/target/sha256sum.txt
           ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease"
           echo "::set-env name=RELEASE_TAG::${GITHUB_REF#*refs/tags/}"
 
@@ -391,7 +391,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
-          asset_path: ./dist-bootstrapped/target/dotty-${{ env.RELEASE_TAG }}.zip
+          asset_path: ./dist/target/dotty-${{ env.RELEASE_TAG }}.zip
           asset_name: dotty-${{ env.RELEASE_TAG }}.zip
           asset_content_type: application/zip
 
@@ -401,7 +401,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
-          asset_path: ./dist-bootstrapped/target/dotty-${{ env.RELEASE_TAG }}.tar.gz
+          asset_path: ./dist/target/dotty-${{ env.RELEASE_TAG }}.tar.gz
           asset_name: dotty-${{ env.RELEASE_TAG }}.tar.gz
           asset_content_type: application/gzip
 
@@ -411,7 +411,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
-          asset_path: ./dist-bootstrapped/target/sha256sum.txt
+          asset_path: ./dist/target/sha256sum.txt
           asset_name: sha256sum.txt
           asset_content_type: text/plain
 

--- a/bin/common
+++ b/bin/common
@@ -10,14 +10,14 @@ target="$1"
 shift # Mutates $@ by deleting the first element ($1)
 
 # Marker file used to obtain the date of latest call to sbt-back
-version="$ROOT/dist-bootstrapped/target/pack/VERSION"
+version="$ROOT/dist/target/pack/VERSION"
 
 # Create the target if absent or if file changed in ROOT/compiler
 new_files="$(find "$ROOT/compiler" \( -iname "*.scala" -o -iname "*.java" \) -newer "$version" 2> /dev/null)"
 
 if [ ! -f "$version" ] || [ ! -z "$new_files" ]; then
   echo "Building Dotty..."
-  (cd $ROOT && sbt "dist-bootstrapped/pack")
+  (cd $ROOT && sbt "dist/pack")
 fi
 
 eval "$target" "$@"

--- a/bin/dotc
+++ b/bin/dotc
@@ -2,4 +2,4 @@
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/.."
 
-eval "$ROOT/bin/common" "$ROOT/dist-bootstrapped/target/pack/bin/dotc" "$@"
+eval "$ROOT/bin/common" "$ROOT/dist/target/pack/bin/dotc" "$@"

--- a/bin/dotd
+++ b/bin/dotd
@@ -2,4 +2,4 @@
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/.."
 
-eval "$ROOT/bin/common" "$ROOT/dist-bootstrapped/target/pack/bin/dotd" "$@"
+eval "$ROOT/bin/common" "$ROOT/dist/target/pack/bin/dotd" "$@"

--- a/bin/dotr
+++ b/bin/dotr
@@ -2,4 +2,4 @@
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/.."
 
-eval "$ROOT/bin/common" "$ROOT/dist-bootstrapped/target/pack/bin/dotr" "$@"
+eval "$ROOT/bin/common" "$ROOT/dist/target/pack/bin/dotr" "$@"

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,6 @@ val `scala-compiler` = Build.`scala-compiler`
 val `scala-reflect` = Build.`scala-reflect`
 val scalap = Build.scalap
 val dist = Build.dist
-val `dist-bootstrapped` = Build.`dist-bootstrapped`
 val `community-build` = Build.`community-build`
 
 val sjsSandbox = Build.sjsSandbox

--- a/docs/docs/contributing/testing.md
+++ b/docs/docs/contributing/testing.md
@@ -9,6 +9,17 @@ Running all tests in Dotty is as simple as:
 $ sbt test
 ```
 
+Specifically, `sbt test` runs all tests that do _not_ require a bootstrapped 
+compiler. In practice, this means that it runs all compilation tests meeting 
+this criterion, as well as all non-compiler tests. 
+
+The entire suite of tests can be run using the bootstrapped compiler as follows:
+
+```bash
+$ sbt
+> dotty-bootstrapped/test
+```
+
 There are currently several forms of tests in Dotty. These can be split into
 two categories:
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1315,13 +1315,9 @@ object Build {
     packArchiveName := "dotty-" + dottyVersion
   )
 
-  lazy val dist = project.asDist(NonBootstrapped)
+  lazy val dist = project.asDist(Bootstrapped)
     .settings(
       packResourceDir += (baseDirectory.value / "bin" -> "bin"),
-    )
-  lazy val `dist-bootstrapped` = project.asDist(Bootstrapped)
-    .settings(
-      packResourceDir += ((baseDirectory in dist).value / "bin" -> "bin"),
     )
 
   implicit class ProjectDefinitions(val project: Project) extends AnyVal {

--- a/project/scripts/bootstrapCmdTests
+++ b/project/scripts/bootstrapCmdTests
@@ -14,7 +14,7 @@ grep -qe "val a: scala.Int = 3" "$tmp"
 
 
 # setup for `dotc`/`dotr` script tests
-"$SBT" dist-bootstrapped/pack
+"$SBT" dist/pack
 
 # check that `dotc` compiles and `dotr` runs it
 echo "testing ./bin/dotc and ./bin/dotr"
@@ -36,7 +36,7 @@ clear_out "$OUT1"
 ./bin/dotr -classpath "$OUT1" "$MAIN" > "$tmp"
 test "$EXPECTED_OUTPUT" = "$(cat "$tmp")"
 
-# echo ":quit" | ./dist-bootstrapped/target/pack/bin/dotr  # not supported by CI
+# echo ":quit" | ./dist/target/pack/bin/dotr  # not supported by CI
 
 echo "testing ./bin/dotd"
 clear_out "$OUT"


### PR DESCRIPTION
1. Removes the `dist` subproject as it was unused in the main and had
   bitrotted to an unworking state. This was preventing a successful
   `sbt update`, and hence import into some IDEs.
2. Renames the working `dist-bootstrapped` project to `dist` as the
   latter no longer exists.
3. Adds some clarifications to the documentation on testing about
   which tests are run when running `test` vs.
   `dotty-bootstrapped/test`.

Closes #8873
Review by @smarter