### PR TITLE
Fix #8881: Lift lets over applications

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -93,6 +93,7 @@ class Compiler {
          new FunctionXXLForwarders,  // Add forwarders for FunctionXXL apply method
          new ParamForwarding,        // Add forwarders for aliases of superclass parameters
          new TupleOptimizations,     // Optimize generic operations on tuples
+         new LetOverApply,            // Lift blocks from receivers of applications
          new ArrayConstructors) ::   // Intercept creation of (non-generic) arrays and intrinsify.
     List(new Erasure) ::             // Rewrite types to JVM model, erasing all type parameters, abstract types and refinements.
     List(new ElimErasedValueType,    // Expand erased value types to their underlying implmementation types

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -749,14 +749,13 @@ object Erasure {
         val origFunType = origFun.tpe.widen(using preErasureCtx)
         val ownArgs = if origFunType.isErasedMethod then Nil else args
         val fun1 = typedExpr(fun, AnyFunctionProto)
-        val fun1core = stripBlock(fun1)
         fun1.tpe.widen match
           case mt: MethodType =>
             val (xmt,        // A method type like `mt` but with bunched arguments expanded to individual ones
                  bunchArgs,  // whether arguments are bunched
                  outers) =   // the outer reference parameter(s)
-              if fun1core.isInstanceOf[Apply] then
-                (mt, fun1core.removeAttachment(BunchedArgs).isDefined, Nil)
+              if fun1.isInstanceOf[Apply] then
+                (mt, fun1.removeAttachment(BunchedArgs).isDefined, Nil)
               else
                 val xmt = expandedMethodType(mt, origFun)
                 (xmt, xmt ne mt, outer.args(origFun))

--- a/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
@@ -1,0 +1,37 @@
+package dotty.tools
+package dotc
+package transform
+
+import core._
+import MegaPhase._
+import Contexts.Context
+import Symbols._, Decorators._, Types._
+import ast.Trees._
+import dotty.tools.dotc.ast.tpd
+
+
+import scala.collection.immutable.::
+
+
+/** Rewrite `{ stats; expr}.f(args) }` to `{ stats; expr.f(args) }` before
+ *  proceeding, but leave closures alone. This is necessary to be able to
+ *  collapse applies of IFTs.
+ */
+class LetOverApply extends MiniPhase:
+  import ast.tpd._
+
+  override def phaseName: String = "letOverApply"
+
+  override def transformApply(tree: tpd.Apply)(using Context): tpd.Tree =
+    tree.fun match
+      case Select(blk @ Block(stats, expr), name) if !expr.isInstanceOf[Closure] =>
+        cpy.Block(blk)(stats,
+          cpy.Apply(tree)(
+            cpy.Select(tree.fun)(expr, name), tree.args))
+      case Block(stats, expr) =>
+        cpy.Block(tree.fun)(stats,
+          cpy.Apply(tree)(expr, tree.args))
+      case _ =>
+        tree
+
+end LetOverApply

--- a/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
@@ -3,15 +3,9 @@ package dotc
 package transform
 
 import core._
+import Contexts.Context, Symbols._, Decorators._
 import MegaPhase._
-import Contexts.Context
-import Symbols._, Decorators._, Types._
 import ast.Trees._
-import dotty.tools.dotc.ast.tpd
-
-
-import scala.collection.immutable.::
-
 
 /** Rewrite `{ stats; expr}.f(args) }` to `{ stats; expr.f(args) }` before
  *  proceeding, but leave closures alone. This is necessary to be able to
@@ -22,7 +16,7 @@ class LetOverApply extends MiniPhase:
 
   override def phaseName: String = "letOverApply"
 
-  override def transformApply(tree: tpd.Apply)(using Context): tpd.Tree =
+  override def transformApply(tree: Apply)(using Context): Tree =
     tree.fun match
       case Select(blk @ Block(stats, expr), name) if !expr.isInstanceOf[Closure] =>
         cpy.Block(blk)(stats,

--- a/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
@@ -7,8 +7,9 @@ import Contexts.Context, Symbols._, Decorators._
 import MegaPhase._
 import ast.Trees._
 
-/** Rewrite `{ stats; expr}.f(args) }` to `{ stats; expr.f(args) }` before
- *  proceeding, but leave closures alone. This is necessary to be able to
+/** Rewrite `{ stats; expr}.f(args)` to `{ stats; expr.f(args) }` and
+ *  `{ stats; expr }(args)` to `{ stats; expr(args) }` before proceeding,
+ *  but leave closures alone. This is necessary to be able to
  *  collapse applies of IFTs (this is done in Erasure).
  */
 class LetOverApply extends MiniPhase:

--- a/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
@@ -9,7 +9,7 @@ import ast.Trees._
 
 /** Rewrite `{ stats; expr}.f(args) }` to `{ stats; expr.f(args) }` before
  *  proceeding, but leave closures alone. This is necessary to be able to
- *  collapse applies of IFTs.
+ *  collapse applies of IFTs (this is done in Erasure).
  */
 class LetOverApply extends MiniPhase:
   import ast.tpd._

--- a/tests/pos/i8881.scala
+++ b/tests/pos/i8881.scala
@@ -1,0 +1,5 @@
+object Crash {
+  def f(a: String, b: String, c: Int = 0): Int ?=> String = ""
+  given Int = ???
+  f(b = "b", a = "a")
+}


### PR DESCRIPTION
This is needed to correctly deal with bunched arguments arising from IFTs.
It's necessary in particular for let-bindings introduced by the compiler,
e.g. when passing default arguments. User-defined blocks are not the
problem since they get already eta expanded in typer.