### PR TITLE
Fix #8920: Keep track of rawParamss when mapping symbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -298,7 +298,7 @@ object Flags {
   /** A Scala 2x super accessor / an unpickled Scala 2.x class */
   val (SuperParamAliasOrScala2x @ _, SuperParamAlias @ _, Scala2x @ _) = newFlags(26, "<super-param-alias>", "<scala-2.x>")
 
-  /** A method that has default params */
+  /** A parameter with a default value */
   val (_, HasDefault @ _, _) = newFlags(27, "<hasdefault>")
 
   /** An extension method, or a collective extension instance */

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1878,7 +1878,15 @@ trait Applications extends Compatibility {
     val reverseMapping = alts.flatMap { alt =>
       val t = f(alt)
       if t.exists then
-        Some((TermRef(NoPrefix, alt.symbol.asTerm.copy(info = t)), alt))
+        val mappedSym = alt.symbol.asTerm.copy(info = t)
+        mappedSym.rawParamss = alt.symbol.rawParamss
+          // we need rawParamss to find parameters with default arguments,
+          // but we do not need to be precise right now, since this is just a pre-test before
+          // we look up defult getters. If at some point we extract default arguments from the
+          // parameter symbols themselves, we have to find the right parameter by name, not position.
+          // That means it's OK to copy parameters wholesale rather than tailoring them to always
+          // correspond to the type transformation.
+        Some((TermRef(NoPrefix, mappedSym), alt))
       else
         None
     }

--- a/tests/pos/i8920/Qu_1.scala
+++ b/tests/pos/i8920/Qu_1.scala
@@ -1,0 +1,9 @@
+package scala.collection.mutable
+
+class Qu[A] protected (array: Array[AnyRef], start: Int, end: Int):
+  def this(initialSize: Int = ArrayDeque.DefaultInitialSize) =
+    this(ArrayDeque.alloc(initialSize), start = 0, end = 0)
+
+object Qu:
+  def f[A](array: Array[AnyRef], start: Int, end: Int) = 1
+  def f[A](initialSize: Int = 1) = 2

--- a/tests/pos/i8920/Test_2.scala
+++ b/tests/pos/i8920/Test_2.scala
@@ -1,0 +1,6 @@
+
+class Q[A] extends scala.collection.mutable.Queue[A]
+class Q1[A] extends scala.collection.mutable.Qu[A]
+
+def test = scala.collection.mutable.Qu.f()
+


### PR DESCRIPTION
Keep track of rawParamss when mapping symbols during overloading resolution