### PR TITLE
Fix #8922: Performance tweak for space computation

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -812,16 +812,16 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
     }.apply(false, tp)
 
   def checkExhaustivity(_match: Match): Unit = {
-    val Match(sel, cases :+ last) = _match
+    val Match(sel, cases) = _match
     val selTyp = sel.tpe.widen.dealias
 
     if (!exhaustivityCheckable(sel)) return
 
-    val patternSpace = Or((last :: cases).map({ x =>
+    val patternSpace = Or(cases.foldLeft(List.empty[Space]) { (acc, x) =>
       val space = if (x.guard.isEmpty) project(x.pat) else Empty
       debug.println(s"${x.pat.show} ====> ${show(space)}")
-      space
-    }))
+      space :: acc
+    })
 
     val checkGADTSAT = shouldCheckExamples(selTyp)
 

--- a/tests/neg-custom-args/fatal-warnings/i8922b.scala
+++ b/tests/neg-custom-args/fatal-warnings/i8922b.scala
@@ -31,7 +31,7 @@ object Interpreter {
             case Binary(left, op, right) =>
                 val l = eval(left)
                 val r = eval(right)
-                (l, r, op.tokenType) match {
+                (l, r, op.tokenType) match {    // error
                     case (l: DoubleV, r: DoubleV, PLUS)          => ???
                     case (l: IntV, r: IntV, PLUS)                => ???
                     case (l: DoubleV, r: IntV, PLUS)             => ???

--- a/tests/patmat/gadt-covariant.check
+++ b/tests/patmat/gadt-covariant.check
@@ -1,1 +1,1 @@
-6: Pattern Match Exhaustivity: (BExpr(_), IExpr(_)), (IExpr(_), BExpr(_))
+6: Pattern Match Exhaustivity: (IExpr(_), BExpr(_)), (BExpr(_), IExpr(_))

--- a/tests/patmat/gadt4.check
+++ b/tests/patmat/gadt4.check
@@ -1,1 +1,1 @@
-12: Pattern Match Exhaustivity: (VC(_, _), VN()), (VN(), VC(_, _))
+12: Pattern Match Exhaustivity: (VN(), VC(_, _)), (VC(_, _), VN())

--- a/tests/patmat/gadt5.check
+++ b/tests/patmat/gadt5.check
@@ -1,1 +1,1 @@
-63: Pattern Match Exhaustivity: (Try3.VC(_, _), Try3.VN()), (Try3.VN(), Try3.VC(_, _))
+63: Pattern Match Exhaustivity: (Try3.VN(), Try3.VC(_, _)), (Try3.VC(_, _), Try3.VN())

--- a/tests/patmat/i7186.scala
+++ b/tests/patmat/i7186.scala
@@ -1,0 +1,241 @@
+import MIPS._
+
+object MIPS {
+  type Labels     = Label | ControlLabel
+  type Src        = Register | Constant
+  type LabelIds   = ElseLabel | Join
+  type Register   = Results | Arguments | Temporaries | SavedValues | Trap | Misc
+  type Addresses  = OffsetAddress | Labels
+  type Dest       = Addresses | Register
+  type Assembler  = ZeroAddr | OneAddr | TwoAddr | ThreeAddr | PseudoZero |
+                      PseudoUnary | Labels | Comment
+}
+
+enum Results { case V0, V1 }
+
+enum Arguments { case A0, A1, A2, A3 }
+
+enum Temporaries { case T0, T1, T2, T3, T4, T5, T6, T7, T8, T9 }
+
+enum SavedValues { case S0, S1, S2, S3, S4, S5, S6, S7, S8 }
+
+enum Trap { case K0, K1 }
+
+enum Misc { case Zero, Sp, Gp, Fp, Ra }
+
+enum ZeroAddr { case Syscall }
+
+enum OneAddr {
+  case Jal(dest: Labels)
+  case Jr(dest: Register)
+  case J(dest: Labels)
+}
+
+enum TwoAddr {
+  case Beqz(source: Register, breakTo: Labels)
+  case Move(dest: Register, source: Register)
+  case Li(dest: Register, source: Constant)
+  case Lw(dest: Register, source: Addresses)
+  case La(dest: Register, source: Addresses)
+  case Sw(source: Register, dest: Addresses)
+  case Not(dest: Register, r: Src)
+  case Neg(dest: Register, r: Src)
+}
+
+enum ThreeAddr {
+  case Add(dest: Register, l: Register, r: Src)
+  case Sub(dest: Register, l: Register, r: Src)
+  case Mul(dest: Register, l: Register, r: Src)
+  case Div(dest: Register, l: Register, r: Src)
+  case Rem(dest: Register, l: Register, r: Src)
+  case Seq(dest: Register, l: Register, r: Src)
+  case Sne(dest: Register, l: Register, r: Src)
+  case Slt(dest: Register, l: Register, r: Src)
+  case Sle(dest: Register, l: Register, r: Src)
+  case Sgt(dest: Register, l: Register, r: Src)
+  case Sge(dest: Register, l: Register, r: Src)
+}
+
+case class ElseLabel(id: Long)
+case class Join(id: Long)
+case class ControlLabel(id: LabelIds)
+case class Label(id: Scoped)
+case class OffsetAddress(address: Register, offset: Constant)
+
+case class Constant(value: Int)
+case class Scoped(id: Identifier, scope: Long)
+case class Identifier(id: String)
+
+enum PseudoZero { case Text, Data }
+
+enum PseudoUnary {
+  case Word(size: Constant)
+  case Globl(name: Scoped)
+  case Asciiz(value: String)
+}
+
+case class Comment(msg: String)
+
+object printMips {
+  import MIPS._
+  import Misc._
+  import PseudoZero._
+  import PseudoUnary._
+  import ZeroAddr._
+  import OneAddr._
+  import TwoAddr._
+  import ThreeAddr._
+
+  private val endl = System.lineSeparator
+
+  def apply(nodes: List[Assembler]): Unit = {
+    var symbCount = 0L
+    val symbols = new scala.collection.mutable.AnyRefMap[Scoped,Long]()
+
+    print(mipsNode(nodes, "  "))
+
+    def mipsNode
+      ( nodes: List[Assembler],
+        indent: String
+      ): String = {
+        (for (node <- nodes.view) yield astNode(node, indent)).mkString
+      }
+
+    def astNode
+      ( node: Assembler,
+        indent: String
+      ): String = {
+        node match {
+          case Text =>
+            s"$indent.text$endl"
+          case Comment(msg) =>
+            s"$indent#$msg$endl"
+          case Data =>
+            s"$indent.data$endl"
+          case Globl(Scoped(Identifier(id),_)) =>
+            s"$indent.globl $id$endl"
+          case Label(Scoped(Identifier(i),-1)) =>
+            s"$i:$endl"
+          case Label(s @ Scoped(Identifier(i), id)) =>
+            s"${getScopedLabel(s)}: #debug: $i~$id$endl"
+          case ControlLabel(id) =>
+            s"${evalLabels(id)}:$endl"
+          case Word(Constant(w)) =>
+            s"$indent.word $w$endl"
+          case Syscall =>
+            s"${indent}syscall$endl"
+          case jal: Jal =>
+            oneAddr(jal,indent)(_.dest)
+          case jr: Jr =>
+            oneAddr(jr,indent)(_.dest)
+          case j: J =>
+            oneAddr(j,indent)(_.dest)
+          case li: Li =>
+            twoAddr(li,indent)(_.dest,_.source)
+          case lw: Lw =>
+            twoAddr(lw,indent)(_.dest,_.source)
+          case neg: Neg =>
+            twoAddr(neg,indent)(_.dest,_.r)
+          case not: Not =>
+            twoAddr(not,indent)(_.dest,_.r)
+          case move: Move =>
+            twoAddr(move,indent)(_.dest,_.source)
+          case beqz: Beqz =>
+            twoAddr(beqz,indent)(_.source,_.breakTo)
+          case sw: Sw =>
+            twoAddr(sw,indent)(_.source,_.dest)
+          case add: Add =>
+            threeAddr(add,indent)(_.dest,_.l,_.r)
+          case sub: Sub =>
+            threeAddr(sub,indent)(_.dest,_.l,_.r)
+          case mul: Mul =>
+            threeAddr(mul,indent)(_.dest,_.l,_.r)
+          case div: Div =>
+            threeAddr(div,indent)(_.dest,_.l,_.r)
+          case rem: Rem =>
+            threeAddr(rem,indent)(_.dest,_.l,_.r)
+          case seq: Seq =>
+            threeAddr(seq,indent)(_.dest,_.l,_.r)
+          case sne: Sne =>
+            threeAddr(sne,indent)(_.dest,_.l,_.r)
+          case slt: Slt =>
+            threeAddr(slt,indent)(_.dest,_.l,_.r)
+          case sgt: Sgt =>
+            threeAddr(sgt,indent)(_.dest,_.l,_.r)
+          case sle: Sle =>
+            threeAddr(sle,indent)(_.dest,_.l,_.r)
+          case sge: Sge =>
+            threeAddr(sge,indent)(_.dest,_.l,_.r)
+          case _ => s"${indent}???$endl"
+        }
+      }
+
+    def oneAddr[O]
+      ( a: O, indent: String)
+      ( r: O => Dest,
+      ): String = {
+        val name = a.getClass.getSimpleName.toLowerCase
+        s"${indent}$name ${rsrc(r(a))}$endl"
+      }
+
+    def twoAddr[O]
+      ( a: O, indent: String)
+      ( d: O => Register,
+        r: O => Dest | Constant
+      ): String = {
+        val name = a.getClass.getSimpleName.toLowerCase
+        s"${indent}$name ${registers(d(a))}, ${rsrc(r(a))}$endl"
+      }
+
+    def threeAddr[O]
+      ( a: O,
+        indent: String )
+      ( d: O => Register,
+        l: O => Register,
+        r: O => Src
+      ): String = {
+        val name = a.getClass.getSimpleName.toLowerCase
+        s"${indent}$name ${registers(d(a))}, ${registers(l(a))}, ${rsrc(r(a))}$endl"
+      }
+
+    def rsrc(v: Constant | Dest): String = v match {
+      case Constant(c) => c.toString
+      case Label(Scoped(Identifier(i),-1)) => s"$i"
+      case Label(s: Scoped) => getScopedLabel(s)
+      case ControlLabel(id) => evalLabels(id)
+      case r: Register => registers(r)
+      case u => sys.error(s"rsrc: $u")
+    }
+
+    def registers(reg: Register): String = reg match {
+      case t: Temporaries =>
+        printEnum(Temporaries.valueOf, t, "$t")
+      case s: SavedValues =>
+        printEnum(SavedValues.valueOf, s, "$s")
+      case r: Results =>
+        printEnum(Results.valueOf, r, "$v")
+      case a: Arguments =>
+        printEnum(Arguments.valueOf, a, "$a")
+      case Ra =>
+        "$ra"
+      case _ =>
+        "$?_"
+    }
+
+    def evalLabels(v: LabelIds): String = v match {
+      case ElseLabel(c) => s"else$c"
+      case Join(ic) => s"join$ic"
+    }
+
+    def getScopedId(s: Scoped): Long =
+      symbols.getOrElseUpdate(s, { symbCount += 1; symbCount })
+
+    def getScopedLabel(s: Scoped): String =
+      "L" + getScopedId(s)
+
+    def printEnum[E](e: String => Enum, t: E, code: String) = {
+      val num = e(t.toString).ordinal
+        s"$code$num"
+    }
+  }
+}

--- a/tests/patmat/i8922.scala
+++ b/tests/patmat/i8922.scala
@@ -1,0 +1,64 @@
+case class Token(tokenType: TokenType, lexeme: String, line: Int)
+
+enum TokenType:
+  // Single-character tokens.
+  case MINUS, PLUS, SLASH, STAR,
+
+  // One or two character tokens.
+  BANG, BANG_EQUAL,
+  EQUAL, EQUAL_EQUAL,
+  GREATER, GREATER_EQUAL,
+  LESS, LESS_EQUAL
+
+enum Expr {
+    case Binary(left: Expr, operator: Token, right: Expr)
+}
+
+object Interpreter:
+    import Expr._
+    import TokenType._
+
+    def eval(expr: Expr): String | Int | Double | Boolean | Unit =
+        expr match
+            case Binary(left, op, right) =>
+                val l = eval(left)
+                val r = eval(right)
+                (l, r, op.tokenType) match
+                    case (l: Double, r: Double, PLUS) => l + r
+                    case (l: Int, r: Int, PLUS) => l + r
+                    case (l: Double, r: Int, PLUS) => l + r
+                    case (l: Int, r: Double, PLUS) => l + r
+                    case (l: String, r: String, PLUS) => l + r
+                    case (l: Double, r: Double, MINUS) => l - r
+                    case (l: Int, r: Int, MINUS) => l - r
+                    case (l: Double, r: Int, MINUS) => l - r
+                    case (l: Int, r: Double, MINUS) => l - r
+                    case (l: Double, r: Double, STAR) => l * r
+                    case (l: Int, r: Int, STAR) => l * r
+                    case (l: Double, r: Int, STAR) => l * r
+                    case (l: Int, r: Double, STAR) => l * r
+                    case (l: Double, r: Double, SLASH) => l / r
+                    case (l: Int, r: Int, SLASH) => l / r
+                    case (l: Double, r: Int, SLASH) => l / r
+                    case (l: Int, r: Double, SLASH) => l / r
+                    case (l: Double, r: Double, GREATER) => l > r
+                    case (l: Int, r: Int, GREATER) => l > r
+                    case (l: Double, r: Int, GREATER) => l > r
+                    case (l: Int, r: Double, GREATER) => l > r
+                    case (l: String, r: String, GREATER) => l > r
+                    case (l: Double, r: Double, LESS) => l < r
+                    case (l: Int, r: Int, LESS) => l < r
+                    case (l: Double, r: Int, LESS) => l < r
+                    case (l: Int, r: Double, LESS) => l < r
+                    case (l: String, r: String, LESS) => l < r
+                    case (l: Double, r: Double, LESS_EQUAL) => l <= r
+                    case (l: Int, r: Int, LESS_EQUAL) => l <= r
+                    case (l: Double, r: Int, LESS_EQUAL) => l <= r
+                    case (l: Int, r: Double, LESS_EQUAL) => l <= r
+                    case (l: String, r: String, LESS_EQUAL) => l <= r
+                    case (l: Double, r: Double, GREATER_EQUAL) => l >= r
+                    case (l: Int, r: Int, GREATER_EQUAL) => l >= r
+                    case (l: Double, r: Int, GREATER_EQUAL) => l >= r
+                    case (l: Int, r: Double, GREATER_EQUAL) => l >= r
+                    case (l: String, r: String, GREATER_EQUAL) => l >= r
+                    case _ => println("unsupported operation")

--- a/tests/patmat/i8922b.scala
+++ b/tests/patmat/i8922b.scala
@@ -1,0 +1,76 @@
+case class Token(tokenType: TokenType, lexeme: StringV, line: IntV)
+
+sealed trait TokenType
+  // Single-character tokens.
+object MINUS extends TokenType
+object PLUS extends TokenType
+object SLASH extends TokenType
+object STAR extends TokenType
+object BANG extends TokenType
+object BANG_EQUAL extends TokenType
+object EQUAL extends TokenType
+object EQUAL_EQUAL extends TokenType
+object GREATER extends TokenType
+object GREATER_EQUAL extends TokenType
+object LESS extends TokenType
+object LESS_EQUAL extends TokenType
+
+sealed trait Expr
+case class Binary(left: Expr, operator: Token, right: Expr) extends Expr
+
+sealed trait Value
+case class StringV(v: String) extends Value
+case class IntV(v: Int) extends Value
+case class DoubleV(v: Double) extends Value
+case class BooleanV(v: Boolean) extends Value
+case class UnitV() extends Value
+
+object Interpreter {
+    def eval(expr: Expr): Value =
+        expr match {
+            case Binary(left, op, right) =>
+                val l = eval(left)
+                val r = eval(right)
+                (l, r, op.tokenType) match {
+                    case (l: DoubleV, r: DoubleV, PLUS)          => ???
+                    case (l: IntV, r: IntV, PLUS)                => ???
+                    case (l: DoubleV, r: IntV, PLUS)             => ???
+                    case (l: IntV, r: DoubleV, PLUS)             => ???
+                    case (l: StringV, r: StringV, PLUS)          => ???
+                    case (l: DoubleV, r: DoubleV, MINUS)         => ???
+                    case (l: IntV, r: IntV, MINUS)               => ???
+                    case (l: DoubleV, r: IntV, MINUS)            => ???
+                    case (l: IntV, r: DoubleV, MINUS)            => ???
+                    case (l: DoubleV, r: DoubleV, STAR)          => ???
+                    case (l: IntV, r: IntV, STAR)                => ???
+                    case (l: DoubleV, r: IntV, STAR)             => ???
+                    case (l: IntV, r: DoubleV, STAR)             => ???
+                    case (l: DoubleV, r: DoubleV, SLASH)         => ???
+                    case (l: IntV, r: IntV, SLASH)               => ???
+                    case (l: DoubleV, r: IntV, SLASH)            => ???
+                    case (l: IntV, r: DoubleV, SLASH)            => ???
+                    case (l: DoubleV, r: DoubleV, GREATER)       => ???
+                    case (l: IntV, r: IntV, GREATER)             => ???
+                    case (l: DoubleV, r: IntV, GREATER)          => ???
+                    case (l: IntV, r: DoubleV, GREATER)          => ???
+                    case (l: StringV, r: StringV, GREATER)       => ???
+                    case (l: DoubleV, r: DoubleV, LESS)          => ???
+                    case (l: IntV, r: IntV, LESS)                => ???
+                    case (l: DoubleV, r: IntV, LESS)             => ???
+                    case (l: IntV, r: DoubleV, LESS)             => ???
+                    case (l: StringV, r: StringV, LESS)          => ???
+                    case (l: DoubleV, r: DoubleV, LESS_EQUAL)    => ???
+                    case (l: IntV, r: IntV, LESS_EQUAL)          => ???
+                    case (l: DoubleV, r: IntV, LESS_EQUAL)       => ???
+                    case (l: IntV, r: DoubleV, LESS_EQUAL)       => ???
+                    case (l: StringV, r: StringV, LESS_EQUAL)    => ???
+                    case (l: DoubleV, r: DoubleV, GREATER_EQUAL) => ???
+                    case (l: IntV, r: IntV, GREATER_EQUAL)       => ???
+                    case (l: DoubleV, r: IntV, GREATER_EQUAL)    => ???
+                    case (l: IntV, r: DoubleV, GREATER_EQUAL)    => ???
+                    case (l: StringV, r: StringV, GREATER_EQUAL) => ???
+                    // case _                                       => ???
+                }
+        }
+
+}

--- a/tests/patmat/i8922c.check
+++ b/tests/patmat/i8922c.check
@@ -1,0 +1,1 @@
+26: Pattern Match Exhaustivity: (_, _, _)

--- a/tests/patmat/i8922c.scala
+++ b/tests/patmat/i8922c.scala
@@ -1,0 +1,63 @@
+case class Token(tokenType: TokenType, lexeme: String, line: Int)
+
+enum TokenType:
+  // Single-character tokens.
+  case MINUS, PLUS, SLASH, STAR,
+
+  // One or two character tokens.
+  BANG, BANG_EQUAL,
+  EQUAL, EQUAL_EQUAL,
+  GREATER, GREATER_EQUAL,
+  LESS, LESS_EQUAL
+
+enum Expr {
+    case Binary(left: Expr, operator: Token, right: Expr)
+}
+
+object Interpreter:
+    import Expr._
+    import TokenType._
+
+    def eval(expr: Expr): String | Int | Double | Boolean | Unit =
+        expr match
+            case Binary(left, op, right) =>
+                val l = eval(left)
+                val r = eval(right)
+                (l, r, op.tokenType) match
+                    case (l: Double, r: Double, PLUS) => l + r
+                    case (l: Int, r: Int, PLUS) => l + r
+                    case (l: Double, r: Int, PLUS) => l + r
+                    case (l: Int, r: Double, PLUS) => l + r
+                    case (l: String, r: String, PLUS) => l + r
+                    case (l: Double, r: Double, MINUS) => l - r
+                    case (l: Int, r: Int, MINUS) => l - r
+                    case (l: Double, r: Int, MINUS) => l - r
+                    case (l: Int, r: Double, MINUS) => l - r
+                    case (l: Double, r: Double, STAR) => l * r
+                    case (l: Int, r: Int, STAR) => l * r
+                    case (l: Double, r: Int, STAR) => l * r
+                    case (l: Int, r: Double, STAR) => l * r
+                    case (l: Double, r: Double, SLASH) => l / r
+                    case (l: Int, r: Int, SLASH) => l / r
+                    case (l: Double, r: Int, SLASH) => l / r
+                    case (l: Int, r: Double, SLASH) => l / r
+                    case (l: Double, r: Double, GREATER) => l > r
+                    case (l: Int, r: Int, GREATER) => l > r
+                    case (l: Double, r: Int, GREATER) => l > r
+                    case (l: Int, r: Double, GREATER) => l > r
+                    case (l: String, r: String, GREATER) => l > r
+                    case (l: Double, r: Double, LESS) => l < r
+                    case (l: Int, r: Int, LESS) => l < r
+                    case (l: Double, r: Int, LESS) => l < r
+                    case (l: Int, r: Double, LESS) => l < r
+                    case (l: String, r: String, LESS) => l < r
+                    case (l: Double, r: Double, LESS_EQUAL) => l <= r
+                    case (l: Int, r: Int, LESS_EQUAL) => l <= r
+                    case (l: Double, r: Int, LESS_EQUAL) => l <= r
+                    case (l: Int, r: Double, LESS_EQUAL) => l <= r
+                    case (l: String, r: String, LESS_EQUAL) => l <= r
+                    case (l: Double, r: Double, GREATER_EQUAL) => l >= r
+                    case (l: Int, r: Int, GREATER_EQUAL) => l >= r
+                    case (l: Double, r: Int, GREATER_EQUAL) => l >= r
+                    case (l: Int, r: Double, GREATER_EQUAL) => l >= r
+                    case (l: String, r: String, GREATER_EQUAL) => l >= r

--- a/tests/patmat/patmat-adt.check
+++ b/tests/patmat/patmat-adt.check
@@ -1,5 +1,5 @@
 7: Pattern Match Exhaustivity: Good(Bad(_)), Bad(Good(_))
 19: Pattern Match Exhaustivity: Some(_)
 24: Pattern Match Exhaustivity: (_, Some(_))
-29: Pattern Match Exhaustivity: (None, None), (Some(_), Some(_))
+29: Pattern Match Exhaustivity: (Some(_), Some(_)), (None, None)
 50: Pattern Match Exhaustivity: LetL(IntLit), LetL(BooleanLit)

--- a/tests/patmat/patmatexhaust.check
+++ b/tests/patmat/patmatexhaust.check
@@ -1,6 +1,6 @@
 7: Pattern Match Exhaustivity: Baz
 11: Pattern Match Exhaustivity: Bar(_)
-23: Pattern Match Exhaustivity: (Qult(), Qult()), (Kult(_), Kult(_))
+23: Pattern Match Exhaustivity: (Kult(_), Kult(_)), (Qult(), Qult())
 49: Pattern Match Exhaustivity: _: Gp
 53: Pattern Match Exhaustivity: _: Gp
 59: Pattern Match Exhaustivity: Nil

--- a/tests/patmat/t10019.check
+++ b/tests/patmat/t10019.check
@@ -1,2 +1,2 @@
-2: Pattern Match Exhaustivity: (List(_, _: _*), List(_, _, _: _*)), (List(_, _: _*), Nil), (List(_, _, _: _*), List(_, _: _*)), (Nil, List(_, _: _*))
+2: Pattern Match Exhaustivity: (List(_, _, _: _*), List(_, _: _*)), (Nil, List(_, _: _*)), (List(_, _: _*), List(_, _, _: _*)), (List(_, _: _*), Nil)
 11: Pattern Match Exhaustivity: (Foo(None), Foo(_))

--- a/tests/patmat/t4526.check
+++ b/tests/patmat/t4526.check
@@ -1,3 +1,3 @@
 2: Pattern Match Exhaustivity: _: Int
 7: Pattern Match Exhaustivity: (_, _)
-12: Pattern Match Exhaustivity: (false, false), (true, true)
+12: Pattern Match Exhaustivity: (true, true), (false, false)

--- a/tests/patmat/t5440.check
+++ b/tests/patmat/t5440.check
@@ -1,1 +1,1 @@
-2: Pattern Match Exhaustivity: (Nil, List(_, _: _*)), (List(_, _: _*), Nil)
+2: Pattern Match Exhaustivity: (List(_, _: _*), Nil), (Nil, List(_, _: _*))

--- a/tests/patmat/t6420.check
+++ b/tests/patmat/t6420.check
@@ -1,1 +1,1 @@
-5: Pattern Match Exhaustivity: (List(true, _: _*), List(true, _: _*)), (List(true, _: _*), List(false, _: _*)), (List(true, _: _*), Nil), (List(false, _: _*), List(true, _: _*)), (List(false, _: _*), List(false, _: _*)), (List(false, _: _*), Nil), (Nil, List(true, _: _*)), (Nil, List(false, _: _*)), (Nil, Nil), (_: List, List(true, _: _*)), (_: List, List(false, _: _*)), (_: List, Nil)
+5: Pattern Match Exhaustivity: (_: List, _: List)

--- a/tests/patmat/t6420.scala
+++ b/tests/patmat/t6420.scala
@@ -8,4 +8,13 @@ object Test {
     case (`c1`::x, `c0`::y) => y
     case (`c1`::x, `c1`::y) => x
   }
+
+  def bar(x: List[Boolean], y: List[Boolean]) = (x,y) match {
+    case (false ::x, false ::y) => x
+    case (false ::x, true ::y) => y
+    case (true ::x, false ::y) => y
+    case (true ::x, true ::y) => x
+    case (Nil, _) => Nil
+    case (_, Nil) => Nil
+  }
 }

--- a/tests/patmat/t7466.check
+++ b/tests/patmat/t7466.check
@@ -1,1 +1,1 @@
-8: Pattern Match Exhaustivity: (true, true), (true, false), (false, true), (false, false), (_, true), (_, false)
+8: Pattern Match Exhaustivity: (_, _)

--- a/tests/patmat/t9232.check
+++ b/tests/patmat/t9232.check
@@ -1,3 +1,3 @@
 13: Pattern Match Exhaustivity: Node2()
-17: Pattern Match Exhaustivity: Node1(Foo(_, _: _*)), Node1(Foo()), Node2()
+17: Pattern Match Exhaustivity: Node1(_), Node2()
 21: Pattern Match Exhaustivity: Node1(Foo()), Node2()

--- a/tests/patmat/t9351.check
+++ b/tests/patmat/t9351.check
@@ -1,3 +1,3 @@
 8: Pattern Match Exhaustivity: _: A
-17: Pattern Match Exhaustivity: (_, None), (_, Some(_))
+17: Pattern Match Exhaustivity: (_, _)
 28: Pattern Match Exhaustivity: (_, _)


### PR DESCRIPTION
We first subtract the last pattern, usually, it's a wildcard, thus speeds up computation.

In computing `Prod(K, a1, a2, ..) - Prod(K, b1, b2, ..)`, if there exists one dimension that is
not reducible, i.e. `a_i < a_i - b_i`, then the result is just `Prod(K, a1, a2, ..)`.

Fixes #8922, #7186
