### PR TITLE
Avoid unnecessary file IO when computing positions

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -42,16 +42,16 @@ extends interfaces.SourcePosition with Showable {
   def beforeAndAfterPoint: (List[Int], List[Int]) =
     lineOffsets.partition(_ <= point)
 
-  def column: Int = if (source.file.exists) source.column(point) else -1
+  def column: Int = if (source.content().length != 0) source.column(point) else -1
 
   def start: Int = span.start
-  def startLine: Int = if (source.file.exists) source.offsetToLine(start) else -1
-  def startColumn: Int = if (source.file.exists) source.column(start) else -1
+  def startLine: Int = if (source.content().length != 0) source.offsetToLine(start) else -1
+  def startColumn: Int = if (source.content().length != 0) source.column(start) else -1
   def startColumnPadding: String = source.startColumnPadding(start)
 
   def end: Int = span.end
-  def endLine: Int = if (source.file.exists) source.offsetToLine(end) else -1
-  def endColumn: Int = if (source.file.exists) source.column(end) else -1
+  def endLine: Int = if (source.content().length != 0) source.offsetToLine(end) else -1
+  def endColumn: Int = if (source.content().length != 0) source.column(end) else -1
 
   def withOuter(outer: SourcePosition): SourcePosition = SourcePosition(source, span, outer)
   def withSpan(range: Span) = SourcePosition(source, range, outer)

--- a/sbt-bridge/src/xsbt/DelegatingReporter.java
+++ b/sbt-bridge/src/xsbt/DelegatingReporter.java
@@ -91,7 +91,7 @@ final public class DelegatingReporter extends AbstractReporter {
           return Optional.ofNullable(src.file().file());
         }
         public Optional<Integer> line() {
-          if (!src.file().exists())
+          if (src.content().length == 0)
             return Optional.empty();
 
           int line = pos.line() + 1;
@@ -101,7 +101,7 @@ final public class DelegatingReporter extends AbstractReporter {
           return Optional.of(line);
         }
         public String lineContent() {
-          if (!src.file().exists())
+          if (src.content().length == 0)
             return "";
 
           String line = pos.lineContent();
@@ -116,13 +116,13 @@ final public class DelegatingReporter extends AbstractReporter {
           return Optional.of(pos.point());
         }
         public Optional<Integer> pointer() {
-          if (!src.file().exists())
+          if (src.content().length == 0)
             return Optional.empty();
 
           return Optional.of(pos.point() - src.startOfLine(pos.point()));
         }
         public Optional<String> pointerSpace() {
-          if (!src.file().exists())
+          if (src.content().length == 0)
             return Optional.empty();
 
           String lineContent = this.lineContent();


### PR DESCRIPTION
The exists call introduced in #8883 and #8897 lead to a slowdown
noticeable in benchmarks. Replace them by a check on the content length,
since SourceFile caches its content this should avoid any unnecessary
IO operation. This required changing the way SourceFile handles empty
files to have it return an empty string instead of crashing.