### PR TITLE
Rename QuoteContext.NestedContext to QuoteContext.Nested

### DIFF
--- a/library/src/scala/internal/quoted/CompileTime.scala
+++ b/library/src/scala/internal/quoted/CompileTime.scala
@@ -18,7 +18,7 @@ object CompileTime {
    *  `ctx` is the `QuoteContext` that the quote of this splice uses.
    */
   @compileTimeOnly("Illegal reference to `scala.internal.quoted.CompileTime.exprNestedSplice`")
-  def exprNestedSplice[T](ctx: QuoteContext)(x: ctx.NestedContext ?=> Expr[T]): T = ???
+  def exprNestedSplice[T](ctx: QuoteContext)(x: ctx.Nested ?=> Expr[T]): T = ???
 
   /** A type quote is desugared by the compiler into a call to this method */
   @compileTimeOnly("Illegal reference to `scala.internal.quoted.CompileTime.typeQuote`")

--- a/library/src/scala/quoted/QuoteContext.scala
+++ b/library/src/scala/quoted/QuoteContext.scala
@@ -20,12 +20,12 @@ class QuoteContext(val tasty: scala.tasty.Reflection) { self =>
    *
    *  ```scala
    *  def run(using qctx: QuoteContext)(tree: qctx.tasty.Tree): Unit =
-   *    def nested()(using qctx.NestedContext): Expr[Int] = '{  ${ makeExpr(tree) } + 1  }
+   *    def nested()(using qctx.Nested): Expr[Int] = '{  ${ makeExpr(tree) } + 1  }
    *    '{  ${ nested() } + 2 }
    *  def makeExpr(using qctx: QuoteContext)(tree: qctx.tasty.Tree): Expr[Int] = ???
    *  ```
    */
-  type NestedContext = QuoteContext {
+  type Nested = QuoteContext {
     val tasty: self.tasty.type
   }
 

--- a/tests/pos/i8045b.scala
+++ b/tests/pos/i8045b.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 object Test
   def run(using qctx: QuoteContext)(tree: qctx.tasty.Tree): Unit =
-    def nested()(using qctx.NestedContext): Expr[Int] =
+    def nested()(using qctx.Nested): Expr[Int] =
       '{  ${ makeExpr(tree) } + 1  }
     '{  ${ nested() } + 2 }
 

--- a/tests/pos/splice-with-explicit-context.scala
+++ b/tests/pos/splice-with-explicit-context.scala
@@ -4,4 +4,4 @@ def f(a: Expr[Int])(using qctx: QuoteContext): Unit =
 
   '{ val x: Int = ${ (using qctx2) => a } }
 
-  '{ val x: Int = ${ (using qctx2: qctx.NestedContext) => a } }
+  '{ val x: Int = ${ (using qctx2: qctx.Nested) => a } }

--- a/tests/run-staging/quote-nested-2.check
+++ b/tests/run-staging/quote-nested-2.check
@@ -1,4 +1,4 @@
 ((qctx: scala.quoted.QuoteContext) ?=> {
   val a: scala.quoted.Expr[scala.Int] = scala.internal.quoted.CompileTime.exprQuote[scala.Int](4).apply(using qctx)
-  ((evidence$2: qctx.NestedContext) ?=> a).asInstanceOf[scala.ContextFunction1[scala.quoted.QuoteContext, scala.quoted.Expr[scala.Int]]].apply(using qctx)
+  ((evidence$2: qctx.Nested) ?=> a).asInstanceOf[scala.ContextFunction1[scala.quoted.QuoteContext, scala.quoted.Expr[scala.Int]]].apply(using qctx)
 })

--- a/tests/run-staging/quote-nested-5.check
+++ b/tests/run-staging/quote-nested-5.check
@@ -1,4 +1,4 @@
 ((qctx: scala.quoted.QuoteContext) ?=> {
   val a: scala.quoted.Expr[scala.Int] = scala.internal.quoted.CompileTime.exprQuote[scala.Int](4).apply(using qctx)
-  ((qctx2: scala.quoted.QuoteContext) ?=> ((evidence$3: qctx2.NestedContext) ?=> a).asInstanceOf[scala.ContextFunction1[scala.quoted.QuoteContext, scala.quoted.Expr[scala.Int]]].apply(using qctx2)).apply(using qctx)
+  ((qctx2: scala.quoted.QuoteContext) ?=> ((evidence$3: qctx2.Nested) ?=> a).asInstanceOf[scala.ContextFunction1[scala.quoted.QuoteContext, scala.quoted.Expr[scala.Int]]].apply(using qctx2)).apply(using qctx)
 })


### PR DESCRIPTION
The `Context` suffix is redundant and a bit long. We change the name to make it shorter and simpler to use.