### PR TITLE
Add scala.quoted.qctx

### DIFF
--- a/library/src-bootstrapped/scala/quoted/qctx.scala
+++ b/library/src-bootstrapped/scala/quoted/qctx.scala
@@ -1,0 +1,4 @@
+package scala.quoted
+
+/** Current QuoteContext in scope */
+def qctx(using qctx: QuoteContext): qctx.type = qctx

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -4,7 +4,7 @@ object scalatest {
 
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
-  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
+  def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
     import util._
 

--- a/tests/run-macros/tasty-linenumber-2/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber-2/quoted_1.scala
@@ -9,7 +9,7 @@ object LineNumber {
 
   implicit inline def line: LineNumber = ${lineImpl}
 
-  def lineImpl(using qctx: QuoteContext) : Expr[LineNumber] = {
+  def lineImpl(using QuoteContext) : Expr[LineNumber] = {
     import qctx.tasty._
     '{new LineNumber(${rootPosition.startLine})}
   }

--- a/tests/run-macros/tasty-linenumber/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber/quoted_1.scala
@@ -10,7 +10,7 @@ object LineNumber {
   implicit inline def line[T >: Unit <: Unit]: LineNumber =
     ${lineImpl('[T])}
 
-  def lineImpl(x: Type[Unit])(using qctx: QuoteContext) : Expr[LineNumber] = {
+  def lineImpl(x: Type[Unit])(using QuoteContext) : Expr[LineNumber] = {
     import qctx.tasty._
     '{new LineNumber(${rootPosition.startLine})}
   }

--- a/tests/run-macros/tasty-subtyping/quoted_1.scala
+++ b/tests/run-macros/tasty-subtyping/quoted_1.scala
@@ -9,13 +9,13 @@ object Macros {
   inline def isSubTypeOf[T, U]: Boolean =
     ${isSubTypeOfImpl('[T], '[U])}
 
-  def isTypeEqualImpl[T, U](t: Type[T], u: Type[U])(using qctx: QuoteContext) : Expr[Boolean] = {
+  def isTypeEqualImpl[T, U](t: Type[T], u: Type[U])(using QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
     val isTypeEqual = t.unseal.tpe =:= u.unseal.tpe
     isTypeEqual
   }
 
-  def isSubTypeOfImpl[T, U](t: Type[T], u: Type[U])(using qctx: QuoteContext) : Expr[Boolean] = {
+  def isSubTypeOfImpl[T, U](t: Type[T], u: Type[U])(using QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
     val isTypeEqual = t.unseal.tpe <:< u.unseal.tpe
     isTypeEqual

--- a/tests/run-staging/staged-tuples/StagedTuple.scala
+++ b/tests/run-staging/staged-tuples/StagedTuple.scala
@@ -126,7 +126,6 @@ object StagedTuple {
   }
 
   def applyStaged[Tup <: NonEmptyTuple : Type, N <: Int : Type](tup: Expr[Tup], size: Option[Int], n: Expr[N], nValue: Option[Int])(using qctx: QuoteContext): Expr[Elem[Tup, N]] = {
-    import reflect._
 
     if (!specialize) '{dynamicApply($tup, $n)}
     else {


### PR DESCRIPTION
This method allows to get the current QuoteContext without naming it.

```scala
def f(using QuoteContext) = {
	...
	qctx // equivalent to summon[QuoteContext]
	...
}
```

Also allows `import qctx.tasty._`