### PR TITLE
Properly erase Java intersections

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -156,6 +156,8 @@ object TypeOps:
       case _: AppliedType | _: MatchType =>
         val normed = tp.tryNormalize
         if (normed.exists) normed else mapOver
+      case tp: MethodicType =>
+        tp // See documentation of `Types#simplified`
       case _ =>
         mapOver
     }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1667,6 +1667,13 @@ object Types {
      *  what was a union or intersection of type variables might be a simpler type
      *  after the type variables are instantiated. Finally, it
      *  maps poly params in the current constraint set back to their type vars.
+     *
+     *  NOTE: Simplifying an intersection type might change its erasure (for
+     *  example, the Java erasure of `Object & Serializable` is `Object`,
+     *  but its simplification is `Serializable`). This means that simplification
+     *  should never be used in a `MethodicType`, because that could
+     *  lead to a different `signature`. Since this isn't very useful anyway,
+     *  this method handles this by never simplifying inside a `MethodicType`.
      */
     def simplified(implicit ctx: Context): Type = TypeOps.simplify(this, null)
 

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -434,7 +434,8 @@ class ClassfileParser(
         if (sig(index) != ':') // guard against empty class bound
           ts += objToAny(sig2type(tparams, skiptvs))
       }
-      TypeBounds.upper(ts.foldLeft(NoType: Type)(_ & _) orElse defn.AnyType)
+      val bound = if ts.isEmpty then defn.AnyType else ts.reduceLeft(AndType.apply)
+      TypeBounds.upper(bound)
     }
 
     var tparams = classTParams

--- a/tests/run/java-intersection/A_1.java
+++ b/tests/run/java-intersection/A_1.java
@@ -1,0 +1,3 @@
+public class A_1 {
+  public <T extends Object & java.io.Serializable> void foo(T x) {}
+}

--- a/tests/run/java-intersection/Test_2.scala
+++ b/tests/run/java-intersection/Test_2.scala
@@ -1,0 +1,7 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val a = new A_1
+    val x = new java.io.Serializable {}
+    a.foo(x)
+  }
+}


### PR DESCRIPTION
Java intersections erase to their first member which is always a class
type. To enforce this we need to:
- Make sure we don't use `&` when creating these intersections
- Make sure `simplified` does not simplify intersections
  which appear in method types.