### PR TITLE
fix #8954 use tree source, look inside byname arguments

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -49,6 +49,7 @@ class CompilationTests extends ParallelTesting {
       compileFilesInDir("tests/new", defaultOptions),
       compileFilesInDir("tests/pos-scala2", scala2CompatMode),
       compileFilesInDir("tests/pos-custom-args/erased", defaultOptions.and("-Yerased-terms")),
+      compileFilesInDir("tests/pos-custom-args/semanticdb", defaultOptions.and("-Ysemanticdb")),
       compileFilesInDir("tests/pos", defaultOptions),
       compileFilesInDir("tests/pos-deep-subtype", allowDeepSubtypes),
       compileFile(

--- a/tests/pos-custom-args/semanticdb/ctorByName.scala
+++ b/tests/pos-custom-args/semanticdb/ctorByName.scala
@@ -1,0 +1,3 @@
+object Macro {
+  class StringContextOps(sc: => StringContext)
+}

--- a/tests/pos-custom-args/semanticdb/macro-pos/example_1.scala
+++ b/tests/pos-custom-args/semanticdb/macro-pos/example_1.scala
@@ -1,0 +1,5 @@
+import quoted._
+
+object CodeImpl {
+  def codeExpr(using qctx: QuoteContext): Expr[String] = '{""}
+}

--- a/tests/pos-custom-args/semanticdb/macro-pos/example_2.scala
+++ b/tests/pos-custom-args/semanticdb/macro-pos/example_2.scala
@@ -1,0 +1,10 @@
+import quoted._
+
+object TestImpl {
+  transparent inline def fun (inline arg: String): String =
+    /*
+    Pad out the file
+    Lorem ipsum dolor sit amet consectetur adipiscing elit tincidunt id augue, facilisi dignissim nibh litora lectus quam senectus fringilla molestie sollicitudin, nunc ullamcorper auctor turpis integer netus fermentum mattis magna. Nullam potenti diam tellus bibendum odio tristique felis, pharetra posuere at imperdiet suspendisse aenean, eu lobortis sapien eleifend aptent sociosqu.
+    */
+    ${ CodeImpl.codeExpr }
+}

--- a/tests/pos-custom-args/semanticdb/macro-pos/example_3.scala
+++ b/tests/pos-custom-args/semanticdb/macro-pos/example_3.scala
@@ -1,0 +1,5 @@
+object Test {
+
+  def test = TestImpl.fun("")
+
+}


### PR DESCRIPTION
Edit: one strange inconsistency is that the original issue with compiling `library/src-bootstrapped/scala/quoted/autolift.scala` only exists when emitting SemanticDB for as part of `dotty-bootstrapped/compile`, and not that file in isolation.