### PR TITLE
Fix diff utils for coloring

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/DiffUtil.scala
+++ b/compiler/src/dotty/tools/dotc/util/DiffUtil.scala
@@ -191,7 +191,7 @@ object DiffUtil {
   }
 
   private def needlemanWunsch(x: Array[String], y: Array[String], builder: mutable.ArrayBuilder[Patch]): Unit = {
-    def similarity(a: String, b: String) = if (a == b) 2 else -1
+    def similarity(a: String, b: String) = if (a == b) 3 else -1
     val d = 1
     val score = Array.tabulate(x.length + 1, y.length + 1) { (i, j) =>
       if (i == 0) d * j

--- a/compiler/test/dotty/tools/dotc/util/DiffUtilTests.scala
+++ b/compiler/test/dotty/tools/dotc/util/DiffUtilTests.scala
@@ -1,0 +1,57 @@
+package dotty.tools.dotc.util
+
+import org.junit.Assert._
+import org.junit.Test
+
+class DiffUtilTests {
+
+  def testExpected(found: String, expected: String, foundColoring: String, expectedColoring: String): Unit = {
+    def humanAscii(str: String): String =
+      str
+        .replace(Console.RESET, ">")
+        .replace(Console.BOLD,  "")
+        .replace(Console.RED,   "<R|")
+        .replace(Console.GREEN, "<G|")
+        // merging two aligning colors
+        .replace("><R|", "")
+        .replace("><G|", "")
+
+    val diff = DiffUtil.mkColoredTypeDiff(found, expected)
+    val fnd = humanAscii(diff._1)
+    val exp = humanAscii(diff._2)
+
+    if (fnd != foundColoring)    fail(s"expected(found):\n$foundColoring but was: \n$fnd")
+    if (exp != expectedColoring) fail(s"expected(expected): \n$expectedColoring but was: \n$exp")
+  }
+
+  @Test
+  def simpleString(): Unit = {
+    testExpected("Foo", "Bar", "<R|Foo>", "<G|Bar>")
+    testExpected("Bar", "Foo", "<R|Bar>", "<G|Foo>")
+  }
+
+  @Test
+  def tuple(): Unit = {
+    testExpected("(Foo, Bar)", "(Bar, Foo)", "(<R|Foo>, <R|Bar>)", "(<G|Bar>, <G|Foo>)")
+    testExpected("(Int, Bar, Float)", "Bar", "<R|(Int, >Bar<R|, Float)>", "Bar")
+  }
+
+  @Test
+  def tupleSeq(): Unit = {
+    testExpected("(Foo, Seq[Bar])", "Seq[Bar]", "<R|(Foo, >Seq[Bar]<R|)>", "Seq[Bar]")
+    testExpected("Seq[Bar]", "(Foo, Seq[Bar])", "Seq[Bar]", "<G|(Foo, >Seq[Bar]<G|)>")
+  }
+
+  @Test
+  def seqTuple(): Unit = {
+    testExpected("Seq[(Foo, Bar)]", "Seq[Bar]", "Seq[<R|(Foo, >Bar<R|)>]", "Seq[Bar]")
+    testExpected("Seq[Bar]", "Seq[(Foo, Bar)]", "Seq[Bar]", "Seq[<G|(Foo, >Bar<G|)>]")
+  }
+
+  @Test
+  def seqSeq(): Unit = {
+    testExpected("Seq[Seq[Seq[Foo]]]", "Seq[List[Seq[(Bar, Foo)]]]", "Seq[<R|Seq>[Seq[Foo]]]", "Seq[<G|List>[Seq[<G|(Bar, >Foo<G|)>]]]")
+    testExpected("Seq[List[Seq[(Bar, Foo)]]]", "Seq[Seq[Seq[Foo]]]", "Seq[<R|List>[Seq[<R|(Bar, >Foo<R|)>]]]", "Seq[<G|Seq>[Seq[Foo]]]")
+  }
+
+}


### PR DESCRIPTION
besides the fix for #8980, other changes are also colored more "aggressively" now:

before:
![tuple-coloring-before](https://user-images.githubusercontent.com/2222044/82128885-e896d180-97be-11ea-813e-bba49b9281ae.png)
after:
![tuple-coloring-after](https://user-images.githubusercontent.com/2222044/82128887-ecc2ef00-97be-11ea-9772-e1f771828ca4.png)
