### PR TITLE
Fix #9000: Avoid spurious cyclic errors for toplevel matches

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -10,6 +10,7 @@ import Decorators._
 import util.Stats._
 import Names._
 import NameOps._
+import Flags.Module
 import Variances.variancesConform
 import dotty.tools.dotc.config.Config
 
@@ -145,7 +146,11 @@ class TypeApplications(val self: Type) extends AnyVal {
   final def typeParams(implicit ctx: Context): List[TypeParamInfo] = {
     record("typeParams")
     def isTrivial(prefix: Type, tycon: Symbol) = prefix match {
-      case prefix: ThisType => prefix.cls `eq` tycon.owner
+      case prefix: ThisType =>
+        prefix.cls eq tycon.owner
+      case prefix: TermRef =>
+        val sym = prefix.symbol
+        sym.is(Module) && sym.isStatic && (sym.moduleClass eq tycon.owner)
       case NoPrefix => true
       case _ => false
     }

--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -154,8 +154,8 @@ class CyclicReference private (val denot: SymDenotation) extends TypeError {
 object CyclicReference {
   def apply(denot: SymDenotation)(implicit ctx: Context): CyclicReference = {
     val ex = new CyclicReference(denot)
-    if (!(ctx.mode is Mode.CheckCyclic)) {
-      cyclicErrors.println(s"Cyclic reference involving $denot")
+    if (!(ctx.mode is Mode.CheckCyclic) || ctx.settings.Ydebug.value) {
+      cyclicErrors.println(s"Cyclic reference involving! $denot")
       for (elem <- ex.getStackTrace take 200)
         cyclicErrors.println(elem.toString)
     }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2238,7 +2238,11 @@ object messages {
 
   class IllegalCyclicTypeReference(sym: Symbol, where: String, lastChecked: Type)(using ctx: Context)
     extends CyclicMsg(IllegalCyclicTypeReferenceID) {
-    def msg = i"illegal cyclic type reference: ${where} ${hl(lastChecked.show)} of $sym refers back to the type itself"
+    def msg =
+      val lastCheckedStr =
+        try lastChecked.show
+        catch case ex: CyclicReference => "..."
+      i"illegal cyclic type reference: ${where} ${hl(lastCheckedStr)} of $sym refers back to the type itself"
     def explain = ""
   }
 

--- a/tests/neg/toplevel-cyclic/defs_1.scala
+++ b/tests/neg/toplevel-cyclic/defs_1.scala
@@ -1,2 +1,1 @@
-type A = B  // error: recursion limit exceeded
-
+type A = B

--- a/tests/pos/toplevel-match.scala
+++ b/tests/pos/toplevel-match.scala
@@ -1,0 +1,14 @@
+class A
+class B
+
+trait HList
+class HCons[A, As <: HList] extends HList
+class HNil[A] extends HList
+
+type AtoB[Xs <: HList] <: HList = Xs match
+  case HNil[a] => HNil[B]
+  case HCons[a, as] => HCons[B, AtoB[as]]
+
+//type A2B[Xs <: Tuple] <: Tuple = Xs match
+//  case Unit => Unit
+//  case a *: as => B *: A2B[as]


### PR DESCRIPTION

I still don't know why the match type
```
type A2B[Xs <: Tuple] <: Tuple = Xs match
  case Unit => Unit
  case a *: as => B *: A2B[as]
```
compiled OK if it appeared in a user defined object, but failed with a cyclic
reference when written on the top level. But the logic for cyclic detection was
clearly very fragile, and unadapted to the case at hand. Essentially, it's a
type map that inserts LazyRefs when it detects legal cycles. The problem is that
these insertions cause recomputations of applied types in the TypeMap. And these
fail since the type constructor (A2B in this case) has not yet been completed.
So after a LazyRef was inserted, the cycle checker fails again in an unrecoverable
way because it tries to get the type parameters of an uncompleted type constructor.
So the question would be rather - why did this work if the match type appears in
a user-defined object? I could not answer that question, but I could fix the logic
to handle these cases.
