### PR TITLE
Fix #8982: Insert colons when rewriting classes to indentation syntax

### DIFF
--- a/tests/pos/i8982.scala
+++ b/tests/pos/i8982.scala
@@ -1,0 +1,14 @@
+
+object Foo {
+  def bar(x: Int): Unit = {
+    println(x)
+  }
+}
+
+class Baz(n: Int) {
+  def printRepeat(repeat: Int) = {
+    for {
+      x <- 1 to repeat
+    } println(s"$x - ${n * x}")
+  }
+}

--- a/tests/run/rainwater.check
+++ b/tests/run/rainwater.check
@@ -1,0 +1,1 @@
+rainWater captured by List(0, 1, 0, 2, 1, 0, 1, 3, 2, 1, 2, 1) = 6

--- a/tests/run/rainwater.scala
+++ b/tests/run/rainwater.scala
@@ -1,0 +1,21 @@
+
+def rainWater(vec: List[Int]): Int =
+  if vec.isEmpty then 0
+  else
+    val mx = vec.max
+    val split = vec.indexWhere(_ == mx)
+      rainWater1(0, vec.take(split + 1))
+    + rainWater1(0, vec.drop(split).reverse)
+
+def rainWater1(mx: Int, xs: List[Int]): Int = xs match
+  case x :: rest =>
+    val newMx = x max mx
+    newMx - x + rainWater1(newMx, rest)
+  case _ =>
+    0
+
+def test(xs: Int*) =
+  println(s"rainWater captured by ${xs.toList} = ${rainWater(xs.toList)}")
+
+@main def Test =
+  test(0,1,0,2,1,0,1,3,2,1,2,1)


### PR DESCRIPTION
Also, allow `for {` under -new-syntax