### PR TITLE
sort output of definitions in repl, fixes #8677

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -24,9 +24,9 @@ object Message {
   * consumed by a subclass of `Reporter`. However, the error position is only
   * part of `Diagnostic`, not `Message`.
   *
-  * NOTE: you should not be persisting  Most messages take an implicit
-  * `Context` and these contexts weigh in at about 4mb per instance, as such
-  * persisting these will result in a memory leak.
+  * NOTE: you should not persist a message directly, because most messages take
+  * an implicit `Context` and these contexts weigh in at about 4mb per instance.
+  * Therefore, persisting these will result in a memory leak.
   *
   * Instead use the `persist` method to create an instance that does not keep a
   * reference to these contexts.

--- a/compiler/src/dotty/tools/dotc/util/Spans.scala
+++ b/compiler/src/dotty/tools/dotc/util/Spans.scala
@@ -5,9 +5,9 @@ import language.implicitConversions
 /** The offsets part of a full position, consisting of 2 or 3 entries:
  *    - start:  the start offset of the span, in characters from start of file
  *    - end  :  the end offset of the span
- *    - point:  if given, the offset where a sing;le `^` would be logically placed
+ *    - point:  if given, the offset where a single `^` would be logically placed
  *
- &  Spans are encoded according to the following format in little endian:
+ *  Spans are encoded according to the following format in little endian:
  *  Start: unsigned 26 Bits (works for source files up to 64M)
  *  End: unsigned 26 Bits
  *  Point: unsigned 12 Bits relative to start
@@ -30,8 +30,8 @@ object Spans {
 
   /** A span indicates a range between a start offset and an end offset.
    *  Spans can be synthetic or source-derived. A source-derived span
-   *  has in addition a point lies somewhere between start and end. The point
-   *  is roughly where the ^ would go if an error was diagnosed at that position.
+   *  has in addition a point. The point lies somewhere between start and end. The point
+   *  is roughly where the `^` would go if an error was diagnosed at that position.
    *  All quantities are encoded opaquely in a Long.
    */
   class Span(val coords: Long) extends AnyVal {

--- a/compiler/src/dotty/tools/repl/package.scala
+++ b/compiler/src/dotty/tools/repl/package.scala
@@ -1,8 +1,5 @@
 package dotty.tools
 
-import dotc.core.Contexts.Context
-import dotc.core.Symbols.Symbol
-import dotc.printing.ReplPrinter
 import dotc.reporting.{HideNonSensicalMessages, StoreReporter, UniqueMessagePositions}
 
 package object repl {
@@ -10,12 +7,4 @@ package object repl {
   private[repl] def newStoreReporter: StoreReporter =
     new StoreReporter(null)
     with UniqueMessagePositions with HideNonSensicalMessages
-
-  private[repl] implicit class ShowUser(val s: Symbol) extends AnyVal {
-    def showUser(implicit ctx: Context): String = {
-      val printer = new ReplPrinter(ctx)
-      val text = printer.dclText(s)
-      text.mkString(ctx.settings.pageWidth.value, ctx.settings.printLines.value)
-    }
-  }
 }

--- a/compiler/test-resources/repl/top-level-block
+++ b/compiler/test-resources/repl/top-level-block
@@ -17,6 +17,6 @@ scala> f + g
 val res3: Int = 10
 
 scala> { val x = 3; 4; val y = 5 }
-val res4: Int = 4
 val x: Int = 3
+val res4: Int = 4
 val y: Int = 5

--- a/compiler/test/dotty/tools/repl/LoadTests.scala
+++ b/compiler/test/dotty/tools/repl/LoadTests.scala
@@ -42,8 +42,8 @@ class LoadTests extends ReplTest {
     file    = """|@main def helloWorld = println("Hello, World!")
                  |@main def helloTo(name: String) = println(s"Hello, $name!")
                  |""".stripMargin,
-    defs    = """|def helloTo(name: String): Unit
-                 |def helloWorld: Unit
+    defs    = """|def helloWorld: Unit
+                 |def helloTo(name: String): Unit
                  |
                  |
                  |""".stripMargin,

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -51,10 +51,10 @@ class ReplCompilerTests extends ReplTest {
 
     val expected = List(
       "def foo: Int",
-      "val res0: Int = 2",
-      "val res1: Int = 20",
       "val x: Int = 10",
-      "var y: Int = 5"
+      "val res0: Int = 2",
+      "var y: Int = 5",
+      "val res1: Int = 20"
     )
 
     assertEquals(expected, lines())
@@ -83,6 +83,25 @@ class ReplCompilerTests extends ReplTest {
       run("x = 10")
       assertEquals("x: Int = 10", storedOutput().trim)
     }
+
+  @Test def i8677 = fromInitialState { implicit state =>
+    run {
+      """|sealed trait T1
+         |case class X() extends T1
+         |case class Y() extends T1
+         | case object O extends T1
+         """.stripMargin
+    }
+
+    val expected = List(
+     "// defined trait T1",
+     "// defined case class X",
+     "// defined case class Y",
+     "// defined case object O"
+    )
+
+    assertEquals(expected, lines())
+  }
 
   // FIXME: Tests are not run in isolation, the classloader is corrupted after the first exception
   @Ignore @Test def i3305: Unit = {

--- a/language-server/test/dotty/tools/languageserver/WorksheetTest.scala
+++ b/language-server/test/dotty/tools/languageserver/WorksheetTest.scala
@@ -96,7 +96,7 @@ class WorksheetTest {
   @Test def patternMatching1: Unit = {
     ws"""${m1}val (foo, bar) = (1, 2)${m2}""".withSource
       .run(m1,
-        ((m1 to m2), s"val bar: Int = 2${nl}val foo: Int = 1"))
+        ((m1 to m2), s"val foo: Int = 1${nl}val bar: Int = 2"))
   }
 
   @Test def evaluationException: Unit = {


### PR DESCRIPTION
As opposed to the earlier version, this PR now only fixes #8677, which makes it much smaller.

Note that this change basically reverts https://github.com/lampepfl/dotty/commit/d9549face6c39c4526901ae6392fc4223db5ca03, which order output on a lower level, but the new order should still be deterministic. This is the reason I had to change some of the tests: the order is no longer alphabetical there.

