### PR TITLE
Fix #8976: Do not instantiate type variables outside bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -192,3 +192,11 @@ class MergeError(val sym1: Symbol, val sym2: Symbol, val tp1: Type, val tp2: Typ
        """
   }
 }
+
+class NoInstance(param: TypeParamRef, val inst: Type, bounds: TypeBounds) extends TypeError:
+  override def produceMessage(using Context): Message =
+    i"""Type variable $param cannot be instantiated.
+       |Its attempted instantiation type $inst
+       |does not conform to its bounds $bounds}"""
+
+

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4035,7 +4035,7 @@ object Types {
      *        one check would be redundant. But maybe that's cheap enough.
      */
     def canInstantiateWith(inst: Type, fromBelow: Boolean)(using Context): Boolean =
-      if fromBelow then inst <:< this else this <:< inst
+      if fromBelow then inst frozen_<:< this else this frozen_<:< inst
   }
 
   private final class TypeParamRefImpl(binder: TypeLambda, paramNum: Int) extends TypeParamRef(binder, paramNum)
@@ -4229,6 +4229,7 @@ object Types {
       if instOK then
         instantiateWith(inst)
       else
+        typr.println(i"failure to instantiate $this with $inst")
         val bounds = ctx.typeComparer.fullBounds(origin)
         instantiateWith(inst) // instantiate anyway to prevent subsequent instantiation attempts and errors
         val noInstance = NoInstance(origin, inst, bounds)

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -120,6 +120,7 @@ object Inferencing {
         tvar.instantiateWith(inst)
         typr.println(i"forced instantiation of ${tvar.origin} = $inst")
       else
+        typr.println(i"failed forced instantiation of ${tvar.origin} = $inst")
         instancesOK = false
       inst
 
@@ -243,6 +244,8 @@ object Inferencing {
                 if param.canInstantiateWith(inst, fromBelow = true) then
                   typr.println(i"replace singleton $param := $inst")
                   accCtx.typerState.constraint = constraint.replace(param, inst)
+                else
+                  typr.println(i"failed to replace singleton $param $inst")
               case _ =>
             }
           case _ =>

--- a/tests/neg/i8976.scala
+++ b/tests/neg/i8976.scala
@@ -1,0 +1,5 @@
+trait Cons[X, Y]
+
+def solve[X, Y](using Cons[X, Y] =:= Cons[1, Cons[2, Y]]) = ()
+
+@main def main = solve // error: Type variable Y cannot be instantiated.


### PR DESCRIPTION
Avoid instantiations of type variables that do not fit their bounds. Throw a TypeError instead.
