### PR TITLE
Remove incorrect type simplification

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -137,14 +137,8 @@ object TypeOps:
           case tp1 => tp1
         }
       case tp: TypeParamRef =>
-        if (tp.paramName.is(DepParamName)) {
-          val bounds = ctx.typeComparer.bounds(tp)
-          if (bounds.lo.isRef(defn.NothingClass)) bounds.hi else bounds.lo
-        }
-        else {
-          val tvar = ctx.typerState.constraint.typeVarOfParam(tp)
-          if (tvar.exists) tvar else tp
-        }
+        val tvar = ctx.typerState.constraint.typeVarOfParam(tp)
+        if (tvar.exists) tvar else tp
       case  _: ThisType | _: BoundType =>
         tp
       case tp: AliasingBounds =>


### PR DESCRIPTION
`TypeOps#simplify` is supposed to produce a type `=:=` the original
type, but it replaced type variables created using `newTypeVar` by one
of their bound, this is wrong since that type variable might get
instantiated to a different type later. This simplification was added
in #2209 to prevent a pickling crash in tests/pos/i2152.scala but does
not appear to be needed anymore: an uninstantiated type variable being
preserved after typer is always wrong, so the underlying bug must have
been fixed since then.