### PR TITLE
Fix doc of ConstraintHandling#approximation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -243,10 +243,10 @@ trait ConstraintHandling[AbstractContext] {
   /** Solve constraint set for given type parameter `param`.
    *  If `fromBelow` is true the parameter is approximated by its lower bound,
    *  otherwise it is approximated by its upper bound, unless the upper bound
-   *  contains a reference to the parameter itself (`addOneBound` ensures that
-   *  such reference never occur in the lower bound).
+   *  contains a reference to the parameter itself (such occurrences can arise
+   *  for F-bounded types, `addOneBound` ensures that they never occur in the
+   *  lower bound).
    *  Wildcard types in bounds are approximated by their upper or lower bounds.
-   *  (Such occurrences can arise for F-bounded types).
    *  The constraint is left unchanged.
    *  @return the instantiating type
    *  @pre `param` is in the constraint's domain.


### PR DESCRIPTION
Move the "Such occurences can arise for F-bounded types" comment one
line above: it refers to "unless the upper bound contains a reference to
the parameter itself", and is unrelated to wildcards.