### PR TITLE
Avoid infinite loop in type variable instantiation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Constraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constraint.scala
@@ -153,6 +153,12 @@ abstract class Constraint extends Showable {
   /** Check that no constrained parameter contains itself as a bound */
   def checkNonCyclic()(implicit ctx: Context): this.type
 
+  /** Does `param` occur at the toplevel in `tp` ?
+   *  Toplevel means: the type itself or a factor in some
+   *  combination of `&` or `|` types.
+   */
+  def occursAtToplevel(param: TypeParamRef, tp: Type)(using Context): Boolean
+
   /** Check that constraint only refers to TypeParamRefs bound by itself */
   def checkClosed()(implicit ctx: Context): Unit
 

--- a/tests/neg/widenInst-cycle.scala
+++ b/tests/neg/widenInst-cycle.scala
@@ -1,0 +1,12 @@
+import scala.reflect.ClassTag
+
+class Test {
+  def foo[N >: C | D <: C, C, D](implicit ct: ClassTag[N]): Unit = {}
+  // This used to lead to an infinite loop, because:
+  // widenInferred(?C | ?D, ?N)
+  // returns ?C, with the following extra constraints:
+  // ?C := ?N
+  // ?D := ?N
+  // So we ended up trying to instantiate ?N with ?N.
+  foo // error
+}


### PR DESCRIPTION
Rename `checkNonCyclic` to `occursAtToplevel` and refactor it to return
a boolean, use it in `ConstraintHandling#instanceType` to make sure we
do not introduce a cycle when instantiating a type variable.

Some alternatives I considered:
- Run `widenInferred` inside frozen constraints: this prevents
  `Set[A] | Set[Int]` to be widened to `Set[Int]` after instantiating
  `A := Int`
- Run `widenInferred` with the upper bound of `param` instead of `param`
  itself as a bound: I think this is still not safe because the upper
  bound of `param` might recursively refer to `param`, it also breaks
  type inference of one expression in ZIO.