### PR TITLE
make error reporter customizable in REPL, fixes #8678

### DIFF
--- a/compiler/src/dotty/tools/repl/ParseResult.scala
+++ b/compiler/src/dotty/tools/repl/ParseResult.scala
@@ -7,7 +7,7 @@ import dotc.core.Contexts.Context
 import dotc.core.StdNames.str
 import dotc.parsing.Parsers.Parser
 import dotc.parsing.Tokens
-import dotc.reporting.Diagnostic
+import dotc.reporting.{Diagnostic, Reporter}
 import dotc.util.SourceFile
 
 import scala.annotation.internal.sharable
@@ -129,7 +129,7 @@ object ParseResult {
     DocOf.command -> (arg => DocOf(arg))
   )
 
-  def apply(source: SourceFile)(implicit state: State): ParseResult = {
+  def apply(source: SourceFile, reporter: Reporter)(implicit state: State): ParseResult = {
     val sourceCode = source.content().mkString
     sourceCode match {
       case "" => Newline
@@ -144,7 +144,6 @@ object ParseResult {
       case _ =>
         implicit val ctx: Context = state.context
 
-        val reporter = newStoreReporter
         val stats = parseStats(state.context.fresh.setReporter(reporter).withSource(source))
 
         if (reporter.hasErrors)
@@ -157,8 +156,11 @@ object ParseResult {
     }
   }
 
-  def apply(sourceCode: String)(implicit state: State): ParseResult =
-    apply(SourceFile.virtual(str.REPL_SESSION_LINE + (state.objectIndex + 1), sourceCode, maybeIncomplete = true))
+  def apply(sourceCode: String, reporter: Reporter)(implicit state: State): ParseResult =
+    apply(
+      SourceFile.virtual(str.REPL_SESSION_LINE + (state.objectIndex + 1), sourceCode, maybeIncomplete = true),
+      reporter
+    )
 
   /** Check if the input is incomplete.
    *

--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -11,7 +11,7 @@ import dotty.tools.dotc.core.Names._
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.core.StdNames._
 import dotty.tools.dotc.core.Symbols._
-import dotty.tools.dotc.reporting.{Diagnostic, Reporter}
+import dotty.tools.dotc.reporting.Diagnostic
 import dotty.tools.dotc.transform.{PostTyper, Staging}
 import dotty.tools.dotc.typer.ImportInfo
 import dotty.tools.dotc.util.Spans._
@@ -29,7 +29,7 @@ import scala.collection.mutable
  *  - provides utility to query the type of an expression
  *  - provides utility to query the documentation of an expression
  */
-class ReplCompiler(reporter: Reporter) extends Compiler {
+class ReplCompiler extends Compiler {
 
   override protected def frontendPhases: List[List[Phase]] = List(
     List(new REPLFrontEnd),
@@ -241,7 +241,9 @@ class ReplCompiler(reporter: Reporter) extends Compiler {
         PackageDef(Ident(nme.EMPTY_PACKAGE), List(wrapper))
       }
 
-      ParseResult(sourceFile, reporter)(state) match {
+      // use `StoreReporter` instead of `errorReporter` from `ReplDriver` here, because we don't
+      // want to report these errors
+      ParseResult(sourceFile, newStoreReporter)(state) match {
         case Parsed(_, trees) =>
           wrap(trees).result
         case SyntaxErrors(_, reported, trees) =>
@@ -275,7 +277,7 @@ class ReplCompiler(reporter: Reporter) extends Compiler {
 
     val src = SourceFile.virtual("<typecheck>", expr)
     implicit val ctx: Context = state.context.fresh
-      .setReporter(reporter)
+      .setReporter(newStoreReporter)
       .setSetting(state.context.settings.YstopAfter, List("typer"))
 
     wrapped(expr, src, state).flatMap { pkg =>

--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -11,7 +11,7 @@ import dotty.tools.dotc.core.Names._
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.core.StdNames._
 import dotty.tools.dotc.core.Symbols._
-import dotty.tools.dotc.reporting.Diagnostic
+import dotty.tools.dotc.reporting.{Diagnostic, Reporter}
 import dotty.tools.dotc.transform.{PostTyper, Staging}
 import dotty.tools.dotc.typer.ImportInfo
 import dotty.tools.dotc.util.Spans._
@@ -29,7 +29,7 @@ import scala.collection.mutable
  *  - provides utility to query the type of an expression
  *  - provides utility to query the documentation of an expression
  */
-class ReplCompiler extends Compiler {
+class ReplCompiler(reporter: Reporter) extends Compiler {
 
   override protected def frontendPhases: List[List[Phase]] = List(
     List(new REPLFrontEnd),
@@ -241,7 +241,7 @@ class ReplCompiler extends Compiler {
         PackageDef(Ident(nme.EMPTY_PACKAGE), List(wrapper))
       }
 
-      ParseResult(sourceFile)(state) match {
+      ParseResult(sourceFile, reporter)(state) match {
         case Parsed(_, trees) =>
           wrap(trees).result
         case SyntaxErrors(_, reported, trees) =>
@@ -275,7 +275,7 @@ class ReplCompiler extends Compiler {
 
     val src = SourceFile.virtual("<typecheck>", expr)
     implicit val ctx: Context = state.context.fresh
-      .setReporter(newStoreReporter)
+      .setReporter(reporter)
       .setSetting(state.context.settings.YstopAfter, List("typer"))
 
     wrapped(expr, src, state).flatMap { pkg =>

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -90,7 +90,7 @@ class ReplDriver(settings: Array[String],
     if (rootCtx.settings.outputDir.isDefault(rootCtx))
       rootCtx = rootCtx.fresh
         .setSetting(rootCtx.settings.outputDir, new VirtualDirectory("<REPL compilation output>"))
-    compiler = new ReplCompiler(newReporter)
+    compiler = new ReplCompiler
     rendering = new Rendering(classLoader)
   }
 

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -53,7 +53,7 @@ case class State(objectIndex: Int,
 /** Main REPL instance, orchestrating input, compilation and presentation.
  *
  * @param out where regular output (eg. "define trait Foo") is printed
- * @param errorReporter if set, this is reporter is passed to the parser and typer. Otherwise,
+ * @param errorReporter if set, this reporter is passed to the parser and typer. Otherwise,
  *        the warnings and errors are printed to `out` as well. Note, however, that REPL errors
  *        (eg. ":load" cannot find the file) are not reported with this reporter
  */

--- a/compiler/test/dotty/tools/repl/ErrorReporterTests.scala
+++ b/compiler/test/dotty/tools/repl/ErrorReporterTests.scala
@@ -21,6 +21,11 @@ class ErrorReporterTests:
     assertEquals("", output)
     assertEquals(List("Illegal start of statement", "unclosed string literal"), errors.map(_.msg.message))
 
+  @Test def testReplError =
+    val (output, errors) = eval(":load /home/rethab/nope/foo.scala")
+    assertEquals("", output)
+    assertEquals(List("Couldn't find file \"/home/rethab/nope/foo.scala\""), errors.map(_.msg.message))
+
   @Test def testWarning =
     val (output, errors) = eval("Option(42) match { case Some(x) => println(x) } ")
     assertEquals("42", output)

--- a/compiler/test/dotty/tools/repl/ErrorReporterTests.scala
+++ b/compiler/test/dotty/tools/repl/ErrorReporterTests.scala
@@ -1,0 +1,41 @@
+package dotty.tools.repl
+
+import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.reporting.{Diagnostic, Reporter}
+import java.nio.file.{Path, Files}
+import java.util.Comparator
+import java.util.regex.Pattern
+
+import org.junit.{Test, BeforeClass, AfterClass}
+import org.junit.Assert.assertEquals
+
+class ErrorReporterTests:
+
+  @Test def testCompilerError =
+    val (output, errors) = eval("asdf")
+    assertEquals("", output)
+    assertEquals(List("Not found: asdf"), errors.map(_.msg.message))
+
+  @Test def testParserError =
+    val (output, errors) = eval("\"asdf")
+    assertEquals("", output)
+    assertEquals(List("Illegal start of statement", "unclosed string literal"), errors.map(_.msg.message))
+
+  @Test def testWarning =
+    val (output, errors) = eval("Option(42) match { case Some(x) => println(x) } ")
+    assertEquals("42", output)
+    assertEquals(List("match may not be exhaustive.\n\nIt would fail on pattern case: None"), errors.map(_.msg.message))
+
+  private def eval(code: String): (String, List[Diagnostic]) =
+    var errors: List[Diagnostic] = List.empty
+    val reporter = new Reporter {
+      override def doReport(dia: Diagnostic)(implicit ctx: Context): Unit =
+        errors = dia :: errors
+    }
+
+    val driver = new ReplTest(errorReporter = Some(() => reporter))
+    val output = driver.fromInitialState { implicit s =>
+      driver.run(code)
+      driver.storedOutput().trim
+    }
+    (output, errors)

--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -10,12 +10,16 @@ import scala.util.Using
 
 import scala.collection.mutable.ArrayBuffer
 
-import dotty.tools.dotc.reporting.MessageRendering
+import dotty.tools.dotc.reporting.{MessageRendering, Reporter}
 import org.junit.{After, Before}
 import org.junit.Assert._
 
 
-class ReplTest(withStaging: Boolean = false, out: ByteArrayOutputStream = new ByteArrayOutputStream) extends ReplDriver(
+class ReplTest(
+  withStaging: Boolean = false,
+  out: ByteArrayOutputStream = new ByteArrayOutputStream,
+  errorReporter: Option[() => Reporter] = None
+) extends ReplDriver(
   Array(
     "-classpath",
     if (withStaging)
@@ -25,7 +29,8 @@ class ReplTest(withStaging: Boolean = false, out: ByteArrayOutputStream = new By
     "-color:never",
     "-Yerased-terms",
   ),
-  new PrintStream(out)
+  new PrintStream(out),
+  errorReporter
 ) with MessageRendering {
   /** Get the stored output from `out`, resetting the buffer */
   def storedOutput(): String = {

--- a/sbt-bridge/src/xsbt/ConsoleInterface.java
+++ b/sbt-bridge/src/xsbt/ConsoleInterface.java
@@ -6,6 +6,7 @@ package xsbt;
 import java.util.ArrayList;
 
 import scala.Some;
+import scala.Option;
 
 import xsbti.Logger;
 
@@ -40,7 +41,7 @@ public class ConsoleInterface {
     completeArgsList.add(classpathString);
     String[] completeArgs = completeArgsList.toArray(args);
 
-    ReplDriver driver = new ReplDriver(completeArgs, System.out, Some.apply(loader));
+    ReplDriver driver = new ReplDriver(completeArgs, System.out, Option.empty(), Some.apply(loader));
 
     State state = driver.initialState();
     assert bindNames.length == bindValues.length;


### PR DESCRIPTION
two things to note:
- this reporter is only used to report errors and warnings (eg. no "// defined trait Foo")
- ~this reporter is only used by the compiler and not the repl machinery (eg. if `:load` fails to load a file that is still printed to `out`~ --> not anymore

Please let me know if either of these is undersireable. 