### PR TITLE
Fix #9029: Change whitebox macro syntax

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -223,4 +223,8 @@ class SymUtils(val self: Symbol) extends AnyVal {
 
   def isCollectiveExtensionClass(using Context): Boolean =
     self.is(ModuleClass) && self.sourceModule.is(Extension, butNot = Method)
+
+  /** The result type of this constructor */
+  def constructorResultType(typeParams: List[Symbol])(using Context): Type =
+    self.owner.typeRef.appliedTo(typeParams.map(_.typeRef))
 }

--- a/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
@@ -206,7 +206,9 @@ object PrepareInlineable {
 
   /** The type ascription `rhs: tpt`, unless `original` is `transparent`. */
   def wrapRHS(original: untpd.DefDef, tpt: Tree, rhs: Tree)(using Context): Tree =
-    if original.mods.hasMod(classOf[untpd.Mod.Transparent]) then rhs
+    if original.mods.hasMod(classOf[untpd.Mod.Transparent])
+       || tpt.isInstanceOf[TypeBoundsTree]
+    then rhs
     else Typed(rhs, tpt)
 
   /** Register inline info for given inlineable method `sym`.

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -104,7 +104,7 @@ yield
 ### Soft keywords
 
 ```
-as  derives  end  extension  inline  on  opaque  open  transparent  using
+as  derives  end  extension  inline  on  opaque  open  using
 *  +  -
 ```
 
@@ -154,7 +154,7 @@ WithType          ::=  AnnotType {‘with’ AnnotType}                         
 AnnotType         ::=  SimpleType {Annotation}                                  Annotated(t, annot)
 
 SimpleType        ::=  SimpleLiteral                                            SingletonTypeTree(l)
-                    |  ‘?’ SubtypeBounds
+                    |  ‘?’ TypeBounds
                     |  SimpleType ‘(’ Singletons ‘)’
                     |  SimpleType1
 SimpleType1       ::=  id                                                       Ident(name)
@@ -179,8 +179,9 @@ TypeArgs          ::=  ‘[’ ArgTypes ‘]’                                 
 NamedTypeArg      ::=  id ‘=’ Type                                              NamedArg(id, t)
 NamedTypeArgs     ::=  ‘[’ NamedTypeArg {‘,’ NamedTypeArg} ‘]’                  nts
 Refinement        ::=  ‘{’ [RefineDcl] {semi [RefineDcl]} ‘}’                   ds
-SubtypeBounds     ::=  [‘>:’ Type] [‘<:’ Type] | INT                            TypeBoundsTree(lo, hi)
-TypeParamBounds   ::=  SubtypeBounds {‘:’ Type}                                 ContextBounds(typeBounds, tps)
+TypeBounds        ::=  [‘>:’ Type] [‘<:’ Type]                                  TypeBoundsTree(lo, hi)
+TypeParamBounds   ::=  TypeBounds {‘:’ Type}                                    ContextBounds(typeBounds, tps)
+ResultType        ::=  [‘_’ ‘<:] Type
 Types             ::=  Type {‘,’ Type}
 ```
 
@@ -297,11 +298,11 @@ DefTypeParamClause::=  ‘[’ DefTypeParam {‘,’ DefTypeParam} ‘]’
 DefTypeParam      ::=  {Annotation} id [HkTypeParamClause] TypeParamBounds
 
 TypTypeParamClause::=  ‘[’ TypTypeParam {‘,’ TypTypeParam} ‘]’
-TypTypeParam      ::=  {Annotation} id [HkTypeParamClause] SubtypeBounds
+TypTypeParam      ::=  {Annotation} id [HkTypeParamClause] TypeBounds
 
 HkTypeParamClause ::=  ‘[’ HkTypeParam {‘,’ HkTypeParam} ‘]’
 HkTypeParam       ::=  {Annotation} [‘+’ | ‘-’] (id [HkTypeParamClause] | ‘_’)
-                       SubtypeBounds
+                       TypeBounds
 
 ClsParamClauses   ::=  {ClsParamClause} [[nl] ‘(’ [‘implicit’] ClsParams ‘)’]
 ClsParamClause    ::=  [nl] ‘(’ ClsParams ‘)’
@@ -370,7 +371,7 @@ VarDcl            ::=  ids ‘:’ Type                                         
 DefDcl            ::=  DefSig ‘:’ Type                                          DefDef(_, name, tparams, vparamss, tpe, EmptyTree)
 DefSig            ::=  id [DefTypeParamClause] DefParamClauses
                     |  ExtParamClause {nl} [‘.’] id DefParamClauses
-TypeDcl           ::=  id [TypeParamClause] SubtypeBounds [‘=’ Type]           TypeDefTree(_, name, tparams, bound
+TypeDcl           ::=  id [TypeParamClause] TypeBounds [‘=’ Type]              TypeDefTree(_, name, tparams, bound
 
 Def               ::=  ‘val’ PatDef
                     |  ‘var’ VarDef
@@ -378,11 +379,11 @@ Def               ::=  ‘val’ PatDef
                     |  ‘type’ {nl} TypeDcl
                     |  TmplDef
                     |  INT
-PatDef            ::=  ids [‘:’ Type] ‘=’ Expr
+PatDef            ::=  ids [‘:’ ResultType] ‘=’ Expr
                     |  Pattern2 [‘:’ Type | Ascription] ‘=’ Expr                PatDef(_, pats, tpe?, expr)
 VarDef            ::=  PatDef
                     |  ids ‘:’ Type ‘=’ ‘_’
-DefDef            ::=  DefSig [(‘:’ | ‘<:’) Type] ‘=’ Expr                      DefDef(_, name, tparams, vparamss, tpe, expr)
+DefDef            ::=  DefSig [‘:’ ResultType] ‘=’ Expr                         DefDef(_, name, tparams, vparamss, tpe, expr)
                     |  ‘this’ DefParamClause DefParamClauses ‘=’ ConstrExpr     DefDef(_, <init>, Nil, vparamss, EmptyTree, expr | Block)
 
 TmplDef           ::=  ([‘case’] ‘class’ | ‘trait’) ClassDef
@@ -395,7 +396,7 @@ ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses        
 ConstrMods        ::=  {Annotation} [AccessModifier]
 ObjectDef         ::=  id [Template]                                            ModuleDef(mods, name, template)  // no constructor
 EnumDef           ::=  id ClassConstr InheritClauses EnumBody                   EnumDef(mods, name, tparams, template)
-GivenDef          ::=  [GivenSig] [‘_’ ‘<:’] Type ‘=’ Expr
+GivenDef          ::=  [GivenSig] ResultType ‘=’ Expr
                     |  [GivenSig] ConstrApps [TemplateBody]
 GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘as’
 ExtensionDef      ::=  [id] [‘on’ ExtParamClause {UsingParamClause}]

--- a/tests/invalid/run/typelevel-patmat.scala
+++ b/tests/invalid/run/typelevel-patmat.scala
@@ -78,12 +78,12 @@ object Test extends App {
   val e1 = nth(r2, 1)
   val ce1: String = e1
 
-  inline def concatTyped(xs: HList, ys: HList) <: Typed[_ <: HList] = inline xs match {
+  inline def concatTyped(xs: HList, ys: HList): _ <: Typed[_ <: HList] = inline xs match {
     case HNil => Typed(ys)
     case HCons(x, xs1) => Typed(HCons(x, concatTyped(xs1, ys).value))
   }
 
-  def concatImpl(xs: HList, ys: HList) <: HList = xs match {
+  def concatImpl(xs: HList, ys: HList): _ <: HList = xs match {
     case HNil => ys
     case HCons(x, xs1) => HCons(x, concatImpl(xs1, ys))
   }

--- a/tests/neg-custom-args/erased/erased-machine-state-encoding-with-inline.scala
+++ b/tests/neg-custom-args/erased/erased-machine-state-encoding-with-inline.scala
@@ -5,11 +5,11 @@ final class On extends State
 final class Off extends State
 
 class Machine[S <: State] {
-  inline def turnOn() <: Machine[On] = inline erasedValue[S] match {
+  inline def turnOn(): _ <: Machine[On] = inline erasedValue[S] match {
     case _: Off  => new Machine[On]
     case _: On   => error("Turning on an already turned on machine")
   }
-  inline def turnOff() <: Machine[Off] = inline erasedValue[S] match {
+  inline def turnOff(): _ <: Machine[Off] = inline erasedValue[S] match {
     case _: On  => new Machine[Off]
     case _: Off   => error("Turning off an already turned off machine")
   }

--- a/tests/neg/machine-state-encoding-with-implicit-match.scala
+++ b/tests/neg/machine-state-encoding-with-implicit-match.scala
@@ -18,10 +18,10 @@ object IsOn {
 }
 
 class Machine[S <: State] {
-  inline def turnOn()(using s: IsOff[S]) <: Machine[On] = summonFrom {
+  inline def turnOn()(using s: IsOff[S]): _ <: Machine[On] = summonFrom {
     case _: IsOff[Off]  => new Machine[On]
   }
-  inline def turnOff()(using s: IsOn[S]) <: Machine[Off] = summonFrom {
+  inline def turnOff()(using s: IsOn[S]): _ <: Machine[Off] = summonFrom {
     case _: IsOn[On]    => new Machine[Off]
   }
 }

--- a/tests/pos-macros/tasty-constant-type/Macro_1.scala
+++ b/tests/pos-macros/tasty-constant-type/Macro_1.scala
@@ -4,7 +4,7 @@ object Macro {
 
   trait AddInt[A <: Int, B <: Int] { type Out <: Int }
 
-  inline def ff[A <: Int, B <: Int]() <: AddInt[A, B] = ${ impl('[A], '[B]) }
+  inline def ff[A <: Int, B <: Int](): _ <: AddInt[A, B] = ${ impl('[A], '[B]) }
 
   def impl[A <: Int : Type, B <: Int : Type](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[AddInt[A, B]] = {
     import qctx.tasty._

--- a/tests/pos/i5572.scala
+++ b/tests/pos/i5572.scala
@@ -1,6 +1,6 @@
 trait Foo {
   type Id[t] = t
-  inline def foo[T](t: T) <: Id[T] =
+  inline def foo[T](t: T): _ <: Id[T] =
     inline t match {
       case i: Int => (i+1).asInstanceOf[Id[T]]
       case _ => t

--- a/tests/pos/implicit-match-nested.scala
+++ b/tests/pos/implicit-match-nested.scala
@@ -8,7 +8,7 @@ object `implicit-match-nested` {
   implicit val b1: B[Int] = B[Int]()
   implicit val b2: B[String] = B[String]()
 
-  inline def locateB <: B[_] =
+  inline def locateB: _ <: B[_] =
     summonFrom {
       case _: A[t] =>
         summonFrom {

--- a/tests/pos/inline-match-specialize.scala
+++ b/tests/pos/inline-match-specialize.scala
@@ -1,6 +1,6 @@
 object `inline-match-specialize` {
   case class Box[+T](value: T)
-  inline def specialize[T](box: Box[T]) <: Box[T] = inline box match {
+  inline def specialize[T](box: Box[T]): _ <: Box[T] = inline box match {
     case box: Box[t] => box
   }
 

--- a/tests/pos/inline-named-typeargs.scala
+++ b/tests/pos/inline-named-typeargs.scala
@@ -1,4 +1,4 @@
 // Working version of inline-named-typedargs, the original is currently disabled
 object t1 {
-  inline def construct[Elem, Coll[_]](xs: List[Elem]) <: Coll[Elem] = ???
+  inline def construct[Elem, Coll[_]](xs: List[Elem]): _ <: Coll[Elem] = ???
 }

--- a/tests/pos/inline-vals.scala
+++ b/tests/pos/inline-vals.scala
@@ -21,3 +21,8 @@ object Constants extends InlineConstants {
   inline val myInlinedChar = 'a'
   inline val myInlinedString = "abc"
 }
+
+object Direct:
+  inline val byte: _ <: Byte = 1
+  val byte1: Byte = byte
+

--- a/tests/pos/reference/compile-time.scala
+++ b/tests/pos/reference/compile-time.scala
@@ -14,7 +14,7 @@ class Test:
 
   final val ctwo = toIntC[2]
 
-  inline def defaultValue[T] <: Option[Any] = inline erasedValue[T] match
+  inline def defaultValue[T]: _ <: Option[Any] = inline erasedValue[T] match
     case _: Byte => Some(0: Byte)
     case _: Char => Some(0: Char)
     case _: Short => Some(0: Short)

--- a/tests/pos/reference/delegate-match.scala
+++ b/tests/pos/reference/delegate-match.scala
@@ -4,7 +4,7 @@ class Test extends App:
   import scala.collection.immutable.{TreeSet, HashSet}
   import scala.compiletime.summonFrom
 
-  inline def setFor[T] <: Set[T] = summonFrom {
+  inline def setFor[T]: _ <: Set[T] = summonFrom {
     case given ord: Ordering[T] => new TreeSet[T]
     case _                      => new HashSet[T]
   }

--- a/tests/run-custom-args/typeclass-derivation2c.scala
+++ b/tests/run-custom-args/typeclass-derivation2c.scala
@@ -88,7 +88,7 @@ object Lst {
       case Nil => 1
     }
     inline override def numberOfCases = 2
-    inline override def alternative(n: Int) <: Generic[_ <: Lst[T]] =
+    inline override def alternative(n: Int): _ <: Generic[_ <: Lst[T]] =
       inline n match {
         case 0 => Cons.GenericCons[T]
         case 1 => Nil.GenericNil
@@ -153,7 +153,7 @@ object Either {
       case x: Right[_] => 1
     }
     inline override def numberOfCases = 2
-    inline override def alternative(n: Int) <: Generic[_ <: Either[L, R]] =
+    inline override def alternative(n: Int): _ <: Generic[_ <: Either[L, R]] =
       inline n match {
         case 0 => Left.GenericLeft[L]
         case 1 => Right.GenericRight[R]

--- a/tests/run-macros/xml-interpolation-5/Macros_1.scala
+++ b/tests/run-macros/xml-interpolation-5/Macros_1.scala
@@ -19,7 +19,7 @@ object XmlQuote {
     opaque type StringContext = scala.StringContext
     def apply(sc: scala.StringContext): StringContext = sc
   }
-  inline def (inline ctx: StringContext).xml <: SCOps.StringContext = SCOps(ctx)
+  inline def (inline ctx: StringContext).xml: _ <: SCOps.StringContext = SCOps(ctx)
   inline def (inline ctx: SCOps.StringContext).apply(inline args: Any*): Xml =
     ${XmlQuote.impl('ctx, 'args)}
   // inline def (inline ctx: SCOps.StringContext).unapplySeq(...): Xml = ...

--- a/tests/run/typeclass-derivation2b.scala
+++ b/tests/run/typeclass-derivation2b.scala
@@ -49,7 +49,7 @@ object Lst {
       case x: Cons[_] => 0
       case Nil => 1
     }
-    inline def alternative(inline n: Int) <: GenericProduct[_ <: Lst[T]] =
+    inline def alternative(inline n: Int): _ <: GenericProduct[_ <: Lst[T]] =
       inline n match {
         case 0 => Cons.GenericCons[T]
         case 1 => Nil.GenericNil


### PR DESCRIPTION
After deliberating some more, I believe that `_ <: T` is the best alternative
for expressing whitebox macros.