### PR TITLE
Fix #9067: avoid instantiate child parameters to Wildcard if possible 

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -686,14 +686,12 @@ object TypeOps:
       }
     }
 
-    def isPatternTypeSymbol(sym: Symbol) = !sym.isClass && sym.is(Case)
-
     // replace uninstantiated type vars with WildcardType, check tests/patmat/3333.scala
     def instUndetMap(implicit ctx: Context) = new TypeMap {
       def apply(t: Type): Type = t match {
         case tvar: TypeVar if !tvar.isInstantiated =>
           WildcardType(tvar.origin.underlying.bounds)
-        case tref: TypeRef if isPatternTypeSymbol(tref.typeSymbol) =>
+        case tref: TypeRef if tref.typeSymbol.isPatternBound =>
           WildcardType(tref.underlying.bounds)
         case _ => mapOver(t)
       }

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -55,22 +55,20 @@ object TypeTestsCasts {
    */
   def checkable(X: Type, P: Type, span: Span)(using Context): Boolean = {
     def isAbstract(P: Type) = !P.dealias.typeSymbol.isClass
-    def isPatternTypeSymbol(sym: Symbol) = !sym.isClass && sym.is(Case)
 
     def replaceP(tp: Type)(implicit ctx: Context) = new TypeMap {
       def apply(tp: Type) = tp match {
-        case tref: TypeRef
-        if isPatternTypeSymbol(tref.typeSymbol) => WildcardType
-        case AnnotatedType(_, annot)
-        if annot.symbol == defn.UncheckedAnnot => WildcardType
+        case tref: TypeRef if tref.typeSymbol.isPatternBound =>
+          WildcardType
+        case AnnotatedType(_, annot) if annot.symbol == defn.UncheckedAnnot =>
+          WildcardType
         case _ => mapOver(tp)
       }
     }.apply(tp)
 
     def replaceX(tp: Type)(implicit ctx: Context) = new TypeMap {
       def apply(tp: Type) = tp match {
-        case tref: TypeRef
-        if isPatternTypeSymbol(tref.typeSymbol) =>
+        case tref: TypeRef if tref.typeSymbol.isPatternBound =>
           if (variance == 1) tref.info.hiBound
           else if (variance == -1) tref.info.loBound
           else OrType(defn.AnyType, defn.NothingType)

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -464,7 +464,6 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
    *     }
    */
   private def erase(tp: Type, inArray: Boolean = false): Type = trace(i"$tp erased to", debug) {
-    def isPatternTypeSymbol(sym: Symbol) = !sym.isClass && sym.is(Case)
 
     tp match {
       case tp @ AppliedType(tycon, args) =>
@@ -476,7 +475,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
         AndType(erase(tp1, inArray), erase(tp2, inArray))
       case tp @ RefinedType(parent, _, _) =>
         erase(parent)
-      case tref: TypeRef if isPatternTypeSymbol(tref.typeSymbol) =>
+      case tref: TypeRef if tref.typeSymbol.isPatternBound =>
         if (inArray) tref.underlying else WildcardType
       case _ => tp
     }

--- a/tests/patmat/i3938.check
+++ b/tests/patmat/i3938.check
@@ -1,0 +1,1 @@
+34: Pattern Match Exhaustivity: bar.C()

--- a/tests/patmat/i3938.scala
+++ b/tests/patmat/i3938.scala
@@ -23,10 +23,15 @@ class Test {
   val foo = new Foo
   import foo.bar._
 
-  def test(a: A) = {
+  def h(a: A) = {
     a match {
       case B() => 1
       case _ => 2 // unreachable code
     }
   }
+
+  def f(a: A) =
+    a match {
+      case B() => 1
+    }
 }

--- a/tests/patmat/i9067.scala
+++ b/tests/patmat/i9067.scala
@@ -1,0 +1,4 @@
+sealed trait Base[A, +B]
+case class Foo[A, +B](f: A => B) extends Base[A, B]
+
+def bar(x: Base[Any, Any]): Unit = x match { case Foo(_) => }


### PR DESCRIPTION
Fix #9067: avoid instantiate child parameters to Wildcard if possible 

In tests/patmat/i9067.scala, for `Foo[X1, X2] <: Base[Any, Any]`,
`X1` and `X2` can both be `Any` instead of `Wildcard`.
Inferring `Wildcard` will lead to the signature of `Foo.unapply`
be inferred as `Nothing => Nothing`, which causes the checker
to issue a false unexhaustive warning.
