### PR TITLE
Fix #7778: infer parameter type for contextual functions

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1336,9 +1336,9 @@ object desugar {
     Function(param :: Nil, Block(vdefs, body))
   }
 
-  def makeContextualFunction(formals: List[Type], body: Tree, isErased: Boolean)(implicit ctx: Context): Tree = {
+  def makeContextualFunction(formals: List[TypeTree], body: Tree, isErased: Boolean)(implicit ctx: Context): Function = {
     val mods = if (isErased) Given | Erased else Given
-    val params = makeImplicitParameters(formals.map(TypeTree), mods)
+    val params = makeImplicitParameters(formals, mods)
     FunctionWithMods(params, body, Modifiers(mods))
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1336,7 +1336,7 @@ object desugar {
     Function(param :: Nil, Block(vdefs, body))
   }
 
-  def makeContextualFunction(formals: List[TypeTree], body: Tree, isErased: Boolean)(implicit ctx: Context): Function = {
+  def makeContextualFunction(formals: List[Tree], body: Tree, isErased: Boolean)(implicit ctx: Context): Function = {
     val mods = if (isErased) Given | Erased else Given
     val params = makeImplicitParameters(formals, mods)
     FunctionWithMods(params, body, Modifiers(mods))

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -98,6 +98,11 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
     case _ => tree
   }
 
+  def stripAnnotated(tree: Tree): Tree = tree match {
+    case Annotated(arg, _) => arg
+    case _ => tree
+  }
+
   /** The number of arguments in an application */
   def numArgs(tree: Tree): Int = unsplice(tree) match {
     case Apply(fn, args) => numArgs(fn) + args.length

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -598,7 +598,7 @@ object ProtoTypes {
    */
   private def wildApprox(tp: Type, theMap: WildApproxMap, seen: Set[TypeParamRef], internal: Set[TypeLambda])(using Context): Type = tp match {
     case tp: NamedType => // default case, inlined for speed
-      val isPatternBoundTypeRef = tp.isInstanceOf[TypeRef] && tp.symbol.is(Flags.Case) && !tp.symbol.isClass
+      val isPatternBoundTypeRef = tp.isInstanceOf[TypeRef] && tp.symbol.isPatternBound
       if (isPatternBoundTypeRef) WildcardType(tp.underlying.bounds)
       else if (tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
       else tp.derivedSelect(wildApprox(tp.prefix, theMap, seen, internal))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1071,9 +1071,11 @@ class Typer extends Namer
      */
     lazy val calleeType: Type = untpd.stripAnnotated(fnBody) match {
       case ident: untpd.Ident if isContextual =>
-        val tp = typedIdent(ident, WildcardType).tpe.widen
+        val ident1 = typedIdent(ident, WildcardType)
+        val tp = ident1.tpe.widen
         if defn.isContextFunctionType(tp) && params.size == defn.functionArity(tp) then
           paramIndex = params.map(_.name).zipWithIndex.toMap
+          fnBody = untpd.TypedSplice(ident1)
           tp.select(nme.apply)
         else NoType
       case app @ Apply(expr, args) =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1049,10 +1049,22 @@ class Typer extends Namer
      */
     var paramIndex = Map[Name, Int]()
 
-     /** If function is of the form
+    /** Infer parameter type from the body of the function
+     *
+     *  1. If function is of the form
+     *
      *      (x1, ..., xN) => f(... x1, ..., XN, ...)
+     *
      *  where each `xi` occurs exactly once in the argument list of `f` (in
      *  any order), the type of `f`, otherwise NoType.
+     *
+     *  2. If the function is of the form
+     *
+     *     (using x1, ..., xN) => f
+     *
+     *  where `f` is a contextual function type of the form `(T1, ..., TN) ?=> T`,
+     *  then `xi` takes the type `Ti`.
+     *
      *  Updates `fnBody` and `paramIndex` as a side effect.
      *  @post: If result exists, `paramIndex` is defined for the name of
      *         every parameter in `params`.

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1072,8 +1072,7 @@ class Typer extends Namer
     lazy val calleeType: Type = untpd.stripAnnotated(fnBody) match {
       case ident: untpd.Ident if isContextual =>
         val tp = typedIdent(ident, WildcardType).tpe.widen
-        if defn.isContextFunctionType(tp) && params.size == defn.functionArity(tp)
-        then
+        if defn.isContextFunctionType(tp) && params.size == defn.functionArity(tp) then
           paramIndex = params.map(_.name).zipWithIndex.toMap
           tp.select(nme.apply)
         else NoType

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1070,7 +1070,7 @@ class Typer extends Namer
      *         every parameter in `params`.
      */
     lazy val calleeType: Type = untpd.stripAnnotated(fnBody) match {
-      case ident: Ident if isContextual =>
+      case ident: untpd.Ident if isContextual =>
         val tp = typedIdent(ident, WildcardType).tpe.widen
         if defn.isContextFunctionType(tp) && params.size == defn.functionArity(tp)
         then
@@ -2471,7 +2471,7 @@ class Typer extends Namer
     val defn.FunctionOf(formals, _, true, _) = pt.dropDependentRefinement
     val ifun = desugar.makeContextualFunction(formals.map(_ => untpd.TypeTree()), tree, defn.isErasedFunctionType(pt))
     typr.println(i"make contextual function $tree / $pt ---> $ifun")
-    typedFunctionValue(ifun, pt)
+    typed(ifun, pt)
   }
 
   /** Typecheck and adapt tree, returning a typed tree. Parameters as for `typedUnadapted` */

--- a/tests/pos/i7778.scala
+++ b/tests/pos/i7778.scala
@@ -1,0 +1,5 @@
+object Example extends App {
+  final case class Foo[A](run: A ?=> Int) {
+    // def copy[A]: this.A ?=> Int = (using a) => run
+  }
+}

--- a/tests/pos/i7778.scala
+++ b/tests/pos/i7778.scala
@@ -1,5 +1,12 @@
 object Example extends App {
-  final case class Foo[A](run: A ?=> Int) {
-    // def copy[A]: this.A ?=> Int = (using a) => run
-  }
+  final case class Foo[A](run: A ?=> Int)
+}
+
+object Example2 extends App {
+  final case class Foo[A, B](run: (A, B) ?=> Int)
+}
+
+
+object Example3 extends App {
+  final case class Foo[A, B](run: () ?=> Int)
 }

--- a/tests/pos/i7778b.scala
+++ b/tests/pos/i7778b.scala
@@ -1,0 +1,4 @@
+class Foo[A](run: A ?=> Int) {
+  def foo[T](f: T ?=> Int = run) = ()
+}
+


### PR DESCRIPTION
Fix #7778: infer parameter type for contextual functions

Given a contextual function of the form

    (using x1, ..., xN) => f

If `f` is a contextual function type of the form `(T1, ..., TN) ?=> T`,
then give the type `T1` to `x1` and so on.
