### PR TITLE
[Prototype] Better type inference for lambdas (e.g., as used in folds)

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -681,7 +681,12 @@ object desugar {
               if (restrictedAccess) mods.withPrivateWithin(constr1.mods.privateWithin)
               else mods
             }
-            val appParamss =
+            // FIXME: This now infers `List[List[DefTree]]`, the issue
+            // is that `withMods` is defined in `DefTree` so that becomes the
+            // upper bound of the type variable (see logic in `constrainSelectionQualifier`),
+            // but the result type of `withMods` is a type member which is
+            // refined in `ValDef`.
+            val appParamss: List[List[ValDef]] =
               derivedVparamss.nestedZipWithConserve(constrVparamss)((ap, cp) =>
                 ap.withMods(ap.mods | (cp.mods.flags & HasDefault)))
             val app = DefDef(nme.apply, derivedTparams, appParamss, applyResultTpt, widenedCreatorExpr)

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -445,8 +445,9 @@ trait ConstraintHandling[AbstractContext] {
             if lower.nonEmpty && !bounds.lo.isRef(defn.NothingClass)
                || upper.nonEmpty && !bounds.hi.isAny
             then constr.println(i"INIT*** $tl")
-            lower.forall(addOneBound(_, bounds.hi, isUpper = true)) &&
-              upper.forall(addOneBound(_, bounds.lo, isUpper = false))
+
+               lower.forall(loParam => addOneBound(loParam, bounds.hi, isUpper =  true) && addOneBound(param, constraint.nonParamBounds(loParam).lo, isUpper = false))
+            && upper.forall(upParam => addOneBound(upParam, bounds.lo, isUpper = false) && addOneBound(param, constraint.nonParamBounds(upParam).hi, isUpper =  true))
           case _ =>
             // Happens if param was already solved while processing earlier params of the same TypeLambda.
             // See #4720.

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -232,7 +232,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
    *  @param isUpper   If true, `bound` is an upper bound, else a lower bound.
    */
   private def stripParams(tp: Type, paramBuf: mutable.ListBuffer[TypeParamRef],
-      isUpper: Boolean)(implicit ctx: Context): Type = tp match {
+      isUpper: Boolean)(implicit ctx: Context): Type = tp.stripTypeVar match {
     case param: TypeParamRef if contains(param) =>
       if (!paramBuf.contains(param)) paramBuf += param
       NoType
@@ -365,7 +365,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
    *    Q <: tp  implies  Q <: P      and isUpper = true, or
    *    tp <: Q  implies  P <: Q      and isUpper = false
    */
-  private def dependentParams(tp: Type, isUpper: Boolean): List[TypeParamRef] = tp match
+  private def dependentParams(tp: Type, isUpper: Boolean)(using Context): List[TypeParamRef] = tp.stripTypeVar match
     case param: TypeParamRef if contains(param) =>
       param :: (if (isUpper) upper(param) else lower(param))
     case tp: AndType if isUpper  =>

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -310,6 +310,9 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
   private def ensureNonCyclic(param: TypeParamRef, inst: Type)(using Context): Type =
 
     def recur(tp: Type, fromBelow: Boolean): Type = tp match
+      case tp: NamedType =>
+        val underlying1 = recur(tp.underlying, fromBelow)
+        if underlying1 ne tp.underlying then underlying1 else tp
       case tp: AndOrType =>
         val r1 = recur(tp.tp1, fromBelow)
         val r2 = recur(tp.tp2, fromBelow)
@@ -613,6 +616,8 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
   def occursAtToplevel(param: TypeParamRef, inst: Type)(implicit ctx: Context): Boolean =
 
     def occurs(tp: Type)(using Context): Boolean = tp match
+      case tp: NamedType =>
+        occurs(tp.underlying)
       case tp: AndOrType =>
         occurs(tp.tp1) || occurs(tp.tp2)
       case tp: TypeParamRef =>

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -479,6 +479,12 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
         case (e1: TypeBounds, _) if e1 contains e2 => e2
         case (_, e2: TypeBounds) if e2 contains e1 => e1
         case (tv1: TypeVar, tv2: TypeVar) if tv1 eq tv2 => e1
+
+        // Should this be based on the merged entries instead of
+        // using this.entry/other.entry ?
+        case (e1: TypeParamRef, e2) if  this.entry(e1).bounds.contains(e2) => e2
+        case (e1, e2: TypeParamRef) if other.entry(e2).bounds.contains(e1) => e1
+
         case _ =>
           if (otherHasErrors)
             e1

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1983,8 +1983,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
   /** Merge `t1` into `tp2` if t1 is a subtype of some &-summand of tp2.
    */
   private def mergeIfSub(tp1: Type, tp2: Type): Type =
-    if (isSubTypeWhenFrozen(tp1, tp2))
-      if (isSubTypeWhenFrozen(tp2, tp1)) tp2 else tp1 // keep existing type if possible
+    if (isSubTypeWhenFrozen(tp1, tp2)) tp1
     else tp2 match {
       case tp2 @ AndType(tp21, tp22) =>
         val lower1 = mergeIfSub(tp1, tp21)
@@ -2004,8 +2003,7 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
    *  @param canConstrain  If true, new constraints might be added to make the merge possible.
    */
   private def mergeIfSuper(tp1: Type, tp2: Type, canConstrain: Boolean): Type =
-    if (isSubType(tp2, tp1, whenFrozen = !canConstrain))
-      if (isSubType(tp1, tp2, whenFrozen = !canConstrain)) tp2 else tp1 // keep existing type if possible
+    if (isSubType(tp2, tp1, whenFrozen = !canConstrain)) tp1
     else tp2 match {
       case tp2 @ OrType(tp21, tp22) =>
         val higher1 = mergeIfSuper(tp1, tp21, canConstrain)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3927,7 +3927,7 @@ object Types {
         NoType
     }
 
-    def tyconTypeParams(implicit ctx: Context): List[ParamInfo] = {
+    def tyconTypeParams(implicit ctx: Context): List[TypeApplications.TypeParamInfo] = {
       val tparams = tycon.typeParams
       if (tparams.isEmpty) HKTypeLambda.any(args.length).typeParams else tparams
     }

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -60,6 +60,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
         case tp @ AppliedType(tycon, args) =>
           if (defn.isCompiletimeAppliedType(tycon.typeSymbol)) tp.tryCompiletimeConstantFold
           else tycon.dealias.appliedTo(args)
+        // Workaround for https://github.com/lampepfl/dotty/issues/8988
+        case tp @ AnnotatedType(underlying @ AnnotatedType(_, annot2), annot1)
+            if (annot1.symbol eq defn.UncheckedVarianceAnnot) && (annot1.symbol eq annot2.symbol) =>
+          homogenize(underlying)
         case _ =>
           tp
       }

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -381,7 +381,7 @@ object Inferencing {
    *
    *  we want to instantiate U to x.type right away. No need to wait further.
    */
-  private def variances(tp: Type)(using Context): VarianceMap = {
+  def variances(tp: Type)(using Context): VarianceMap = {
     Stats.record("variances")
     val constraint = ctx.typerState.constraint
 

--- a/tests/neg/i4564.scala
+++ b/tests/neg/i4564.scala
@@ -42,5 +42,4 @@ class BaseCNSP[T] {
 }
 
 object ClashNoSigPoly extends BaseCNSP[Int]
-// TODO: improve error message
-case class ClashNoSigPoly private(x: Int)  // error: found: ClashNoSigPoly required: Nothing
+case class ClashNoSigPoly private(x: Int)

--- a/tests/neg/i5735.scala
+++ b/tests/neg/i5735.scala
@@ -8,5 +8,5 @@ object Test {
   class Foo[T] { def apply[Y >: T <: Nested[T, Tuple2, Unit]](t: T): T = t }
   def foo[T] = new Foo[T]
 
-  foo.apply((21, ()))
+  foo.apply((21, ())) // error
 }

--- a/tests/neg/type-match-fbounds.scala
+++ b/tests/neg/type-match-fbounds.scala
@@ -1,0 +1,28 @@
+class A {
+  type Foo[T] = T match {
+    case Int => String
+    case T => T
+  }
+
+  // FIXME: These cases are not disallowed currently and cause
+  // infinite loops
+  /*
+  def a1[T <: (T match {
+    case Int => String
+    case T => T
+  })]: T = ???
+  a1
+
+  def a2[T, U >: T <: (T match {
+    case Int => String
+    case T => T
+  })]: T = ???
+  a2
+
+  def a3[T <: Foo[T]]: T = ???
+  a3
+  */
+
+  def a4[T, U >: T <: Foo[T]]: T = ???
+  a4 // error
+}

--- a/tests/pos/dependent-typevar.scala
+++ b/tests/pos/dependent-typevar.scala
@@ -1,0 +1,8 @@
+class Foo[A] {
+  // Previously, we did not record the constraint ordering `A <: B` here
+  def bar[B >: A <: String]: String = ""
+}
+object Test {
+  // ... which prevented the following from typechecking.
+  val ret = (new Foo).bar
+}

--- a/tests/pos/fold-infer-2.scala
+++ b/tests/pos/fold-infer-2.scala
@@ -1,0 +1,32 @@
+class Foo[A, B <: A] {
+  def get: A = ???
+  def hi: Foo[A, B] = this
+}
+class A {
+  def foo[T <: Foo[_, _]]: T = ???
+  foo.get // OK
+
+  def list[T <: List[_]]: T = ???
+  list.head: Int
+  list.::(1)
+
+  def foldLeft1[B <: List[_]](op: (B, Int) => B): B = ???
+  val l = foldLeft1((acc, i) => acc.::(i))
+
+  def foldLeft2[B >: Nil.type](op: (B, Int) => B): B = ???
+
+  val l2 = foldLeft2((acc, i) => acc.::(i))
+
+  extension fooOps on (x: List[Int]) {
+    def hi: Int = 0
+  }
+
+  def foo1[B >: Foo[Int, Int]](op: B => B) = ???
+  foo1(b => b.hi)
+
+  def foo2[B >: List[Int]](op: B => Int) = ???
+  foo2(b => b.hi)
+
+  def foo3(xs: Seq[Option[List[Int]]]) =
+    xs.map(_.getOrElse(Nil)).reduceLeft(_ ++ _)
+}

--- a/tests/pos/fold-infer-uncheckedVariance.scala
+++ b/tests/pos/fold-infer-uncheckedVariance.scala
@@ -1,0 +1,19 @@
+import scala.annotation.unchecked.uncheckedVariance
+
+class Bar
+
+class Foo[-T >: Null] {
+  def tpe: T @uncheckedVariance = ???
+}
+
+object Test {
+  def foo(xs: List[Int], x: Foo[Bar]): Unit = {
+    val r = xs.foldLeft(x) { (acc, x) =>
+      // B >: Foo[Bar] <: Foo[T]
+      // T >: Null <: Bar
+      val m = acc.tpe
+      acc
+    }
+    val s: Foo[Bar] = r
+  }
+}

--- a/tests/pos/fold-infer.scala
+++ b/tests/pos/fold-infer.scala
@@ -1,0 +1,29 @@
+object Test {
+  val li = List(1, 2, 3).foldLeft(Nil)((acc, x) => x :: acc)
+  val cli: List[Int] = li
+
+  val li2 = List(1, 2, 3).foldLeft(Nil)((acc, x) => acc)
+  val cli2: List[Int] = li2
+
+  val ld = List(1, 2, 3).foldLeft(Nil)((acc, x) => x.toDouble :: acc)
+  val cld: List[Double] = ld
+
+  val si = Seq(1, 2, 3).foldLeft(Set())((acc, x) => acc + x)
+  val csi: Set[Int] = si
+
+  val si2 = Seq(1, 2, 3).foldLeft(Set())((acc, x) => acc ++ Set(x))
+  val csi2: Set[Int] = si2
+
+  val ssi = Seq(1, 2, 3).foldLeft(Set())((acc, x) => acc + Set(x))
+  val cssi: Set[Set[Int]] = ssi
+}
+
+object NotWorking {
+  /*
+  val ld2 = List(1, 2, 3).foldLeft(Nil)((acc, x) => {
+    val y = x.toDouble :: acc
+    y // error: found: List[Double], required: List[Nothing]
+  })
+  val cld2: List[Double] = ld2
+  */
+}

--- a/tests/pos/merge-constraint.scala
+++ b/tests/pos/merge-constraint.scala
@@ -1,0 +1,11 @@
+class Hi
+class Lo extends Hi
+
+object Test {
+  def foo[T, U <: T](t: T, f: T => U): U = ???
+
+  def test(hi: Hi, lo: Lo): Unit = {
+    val ret = foo(hi, x => lo) // This used to infer U := Hi
+    val y: Lo = ret
+  }
+}


### PR DESCRIPTION
No version of Scala has ever been able to infer the following:

```scala
val xs = List(1, 2, 3)
xs.foldLeft(Nil)((acc, x) => x :: acc)
```

To understand why, let's have a look at the signature of `List[A]#foldLeft`:

```scala
def foldLeft[B](z: B)(op: (B, A) => B): B
```

When typing the foldLeft call in the previous expression, the compiler
starts by creating an unconstrained type variable ?B, the challenge is then to
successfully type the expression and instantiate `?B := List[Int]`.

Typing the first argument is easy: `Nil` is a valid argument if we add a
constraint:

```scala
?B >: Nil.type
```

Typing the second argument is where we get stuck normally: we need to choose a type
for the binding `acc`, but `?B` is a type variable and not a fully-defined type,
this is solved by instantiating `?B` to one of its bound, but no matter what
bound we choose, the rest of the expression won't typecheck:
- if we instantiate `?B := Nil.type`, then the body of the lambda `x :: acc` is
  not a subtype of the expected result type `?B`.
- if we instantiate `?B := Any`, then the body of the lambda does not
  typecheck since there is no method `::` on `Any`.

But... what if we just let `acc` have type `?B` without instantiating it first?
This is not completely meaningless: `?B` behaves like an abstract type except
that its bounds might be refined as we typecheck code, as long as narrowing
holds (#), this should be safe.

The remaining challenge then is to type the body of the lambda `x :: acc` which
desugars to `acc.::(x)`, this won't typecheck as-is since `::` is not defined on
the upper bound of `?B`, so we need to refine this upper bound somehow, the
heuristic we use is:

1) Look for `::` in the lower bound of `?B >: Nil.type`, Nil does have such a member!
2) Find the class where this member is defined: it's `List`
3) If the class has type parameters, create one fresh type variable
   for each parameter slot, the resulting type is our new upper bound,
   so here we get `?B <: List[?X]` where `?X` is a fresh type variable.

We can then proceed to type the body of the lambda:

```scala
acc.::(x)
```

This first creates a type variable `?B2 >: ?X`, because `::` has type:

```scala
def :: [B >: A](elem: B): List[B]
```

Because the result type of the lambda is `?B`, we get an additional constraint:

```scala
List[?B2] <: ?B
```
  
We know that `?B <: List[?X]` so this means that `?B2 <: ?X`, but we 
also know that `B2 >: ?X`, so we can instantiate `?B2 := ?X` and `?B := List[?X]`.

Finally,  because `x` has type Int we have `?B2 >: Int` which simplifies to:

```scala
?X >: Int
```

Therefore, the result type of the foldLeft is `List[?X]` where `?X >: Int`,
because `List` is covariant, we instantiate `?X := Int` to get the most precise
result type `List[Int]`.

Note that the the use of fresh type variables in 3) was crucial here: if we had
instead used wildcards and added an upper bound `?B <: List[_]`, then we would
have been able to type `acc.::(x)`, but the result would have type `List[Any]`,
meaning the result of the foldLeft call would be `List[Any]` when we wanted
`List[Int]`.

# Status

All the compiler tests pass, including bootstrapping, but one of third of the
community build breaks currently. 

Even if this PR never makes it in, it has been very useful for stress-testing
our constraint solver and lead to several PRs I made over the past few days:
#9012, #9019, #9030, #9053, and there's some more changes in the early commits
of this PR that would be worth getting in by themselves.

# Open questions

- Is this actually sound?
- Are there other compelling examples where this useful, besides folds?
- Is the performance impact of this stuff acceptable?
- How do we deal with overloads?
- How do we deal with overrides?
- How does this interact with implicit conversions?
- How does this interact with implicit search in general, we might find one
  implicit at a given point, but then as we add more constraints to the same
  type variable, the same implicit search could find a different result. How big
  of a problem is that?

(#): narrowing in fact does not hold when `@uncheckedVariance` is used, which is
     why we special-case it in `constrainSelectionQualifier`