### PR TITLE
Avoid overloading of Expr.ofTuple

### DIFF
--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -128,7 +128,7 @@ object Expr {
    *  to an expression equivalent to
    *    `'{ ($e1, $e2, ...) }` typed as an `Expr[Tuple]`
    */
-  def ofTuple(seq: Seq[Expr[Any]])(using qctx: QuoteContext): Expr[Tuple] = {
+  def ofTupleFromSeq(seq: Seq[Expr[Any]])(using qctx: QuoteContext): Expr[Tuple] = {
     seq match {
       case Seq() =>
         '{ Tuple() }
@@ -184,7 +184,7 @@ object Expr {
   /** Given a tuple of the form `(Expr[A1], ..., Expr[An])`, outputs a tuple `Expr[(A1, ..., An)]`. */
   def ofTuple[T <: Tuple: Tuple.IsMappedBy[Expr]: Type](tup: T)(using qctx: QuoteContext): Expr[Tuple.InverseMap[T, Expr]] = {
     val elems: Seq[Expr[Any]] = tup.asInstanceOf[Product].productIterator.toSeq.asInstanceOf[Seq[Expr[Any]]]
-    ofTuple(elems).cast[Tuple.InverseMap[T, Expr]]
+    ofTupleFromSeq(elems).cast[Tuple.InverseMap[T, Expr]]
   }
 
   /** Find an implicit of type `T` in the current scope given by `qctx`.

--- a/tests/run-macros/quote-toExprOfTuple/Macro_1.scala
+++ b/tests/run-macros/quote-toExprOfTuple/Macro_1.scala
@@ -8,7 +8,7 @@ object Macro {
     import util._
 
     val seq = List(t0, t1)
-    val res = Expr.ofTuple(seq)
+    val res = Expr.ofTupleFromSeq(seq)
     res.cast[(T0, T1)]
   }
 }

--- a/tests/run-macros/refined-selectable-macro/Macro_1.scala
+++ b/tests/run-macros/refined-selectable-macro/Macro_1.scala
@@ -36,13 +36,13 @@ object Macro {
     def tupleElem(name: String, info: Type): Expr[Any] = {
       val nameExpr = Expr(name)
       info.seal match { case '[$qType] =>
-          Expr.ofTuple(Seq(nameExpr, '{ $s.selectDynamic($nameExpr).asInstanceOf[$qType] }))
+          Expr.ofTupleFromSeq(Seq(nameExpr, '{ $s.selectDynamic($nameExpr).asInstanceOf[$qType] }))
       }
     }
 
     val ret = rec(repr).reverse.map(e => tupleElem(e._1, e._2))
 
-    Expr.ofTuple(ret)
+    Expr.ofTupleFromSeq(ret)
   }
 
   private def fromTupleImpl[T: Type](s: Expr[Tuple], newRecord: Expr[Array[(String, Any)] => T])(using qctx:QuoteContext) : Expr[Any] = {

--- a/tests/run-staging/quote-toExprOfTuple.scala
+++ b/tests/run-staging/quote-toExprOfTuple.scala
@@ -7,7 +7,7 @@ object Test {
   def main(args: Array[String]): Unit = {
     for (n <- 0 to 25) {
       prev = 0
-      println(run { Expr.ofTuple(Seq.fill(n)('{next})) })
+      println(run { Expr.ofTupleFromSeq(Seq.fill(n)('{next})) })
     }
   }
   var prev = 0


### PR DESCRIPTION
This will improve error messages when implicits are missing or the complex type match constraints fail.