### PR TITLE
Fix #9045: kinding issue in rawTypeRef

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4600,6 +4600,7 @@ object Types {
     def apply(lo: Type, hi: Type)(implicit ctx: Context): TypeBounds =
       unique(new RealTypeBounds(lo, hi))
     def empty(implicit ctx: Context): TypeBounds = apply(defn.NothingType, defn.AnyType)
+    def emptyPolyKind(implicit ctx: Context): TypeBounds = apply(defn.NothingType, defn.AnyKindType)
     def upper(hi: Type)(implicit ctx: Context): TypeBounds = apply(defn.NothingType, hi)
     def lower(lo: Type)(implicit ctx: Context): TypeBounds = apply(lo, defn.AnyType)
   }

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -211,7 +211,7 @@ class SymUtils(val self: Symbol) extends AnyVal {
 
   /** The typeRef with wildcard arguments for each type parameter */
   def rawTypeRef(implicit ctx: Context) =
-    self.typeRef.appliedTo(self.typeParams.map(_ => TypeBounds.empty))
+    self.typeRef.appliedTo(self.typeParams.map(_ => TypeBounds.emptyPolyKind))
 
   /** Is symbol a quote operation? */
   def isQuote(implicit ctx: Context): Boolean =

--- a/tests/pos/i9045.scala
+++ b/tests/pos/i9045.scala
@@ -1,0 +1,4 @@
+sealed trait Test[F[_]]
+object Test {
+  final case class Completed[F[_]]() extends Test[F]
+}


### PR DESCRIPTION
Because the interval for the wildcard was upper-bounded by Any, any
usage of `rawTypeRef` on a type with higher-kinded type parameters was
ill-typed, in particular this caused false warnings in TypeTestCasts.