### PR TITLE
Fix #8838: load Java enum members lazily to avoid cycles

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
@@ -362,6 +362,7 @@ object ClassfileConstants {
       res = addFlag(res, nflags & JAVA_ACC_FINAL)
       res = addFlag(res, nflags & JAVA_ACC_SYNTHETIC)
       res = addFlag(res, nflags & JAVA_ACC_STATIC)
+      res = addFlag(res, nflags & JAVA_ACC_ENUM)
       res = addFlag(res, nflags & JAVA_ACC_ABSTRACT)
       res = addFlag(res, nflags & JAVA_ACC_INTERFACE)
       res

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -201,12 +201,6 @@ class ClassfileParser(
         sym.markAbsent()
       }
 
-    // eager load enum definitions for exhaustivity check of pattern match
-    if (isEnum) {
-      instanceScope.toList.map(_.ensureCompleted())
-      staticScope.toList.map(_.ensureCompleted())
-    }
-
     result
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -192,6 +192,10 @@ class SymUtils(val self: Symbol) extends AnyVal {
   def children(implicit ctx: Context): List[Symbol] = {
     if (self.isType)
       self.setFlag(ChildrenQueried)
+
+    if (self.isAllOf(JavaEnumTrait))
+      self.linkedClass.info.decls.foreach(_.ensureCompleted())
+
     self.annotations.collect {
       case Annotation.Child(child) => child
     }.reverse

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -120,6 +120,9 @@ object TypeTestsCasts {
       maximizeType(P1, span, fromScala2x = false)
 
       val res = P1 <:< P
+
+      debug.println(TypeComparer.explained(P1 <:< P))
+
       debug.println("P1 : " + P1.show)
       debug.println("P1 <:< P = " + res)
 

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -603,9 +603,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
       case tp if tp.isRef(defn.UnitClass) =>
         Typ(ConstantType(Constant(())), true) :: Nil
       case tp if tp.classSymbol.isAllOf(JavaEnumTrait) =>
-        tp.classSymbol.linkedClass.info.decls.toList.map(_.ensureCompleted())
-        val children = tp.classSymbol.children
-        children.map(sym => Typ(sym.termRef, true))
+        tp.classSymbol.children.map(sym => Typ(sym.termRef, true))
       case tp =>
         val children = tp.classSymbol.children
         debug.println(s"candidates for ${tp.show} : [${children.map(_.show).mkString(", ")}]")

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -586,11 +586,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
   }
 
   /** Decompose a type into subspaces -- assume the type can be decomposed */
-  def decompose(tp: Type): List[Space] = {
-    val children = tp.classSymbol.children
-
-    debug.println(s"candidates for ${tp.show} : [${children.map(_.show).mkString(", ")}]")
-
+  def decompose(tp: Type): List[Space] =
     tp.dealias match {
       case AndType(tp1, tp2) =>
         intersect(Typ(tp1, false), Typ(tp2, false)) match {
@@ -607,8 +603,13 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
       case tp if tp.isRef(defn.UnitClass) =>
         Typ(ConstantType(Constant(())), true) :: Nil
       case tp if tp.classSymbol.isAllOf(JavaEnumTrait) =>
+        tp.classSymbol.linkedClass.info.decls.toList.map(_.ensureCompleted())
+        val children = tp.classSymbol.children
         children.map(sym => Typ(sym.termRef, true))
       case tp =>
+        val children = tp.classSymbol.children
+        debug.println(s"candidates for ${tp.show} : [${children.map(_.show).mkString(", ")}]")
+
         val parts = children.map { sym =>
           val sym1 = if (sym.is(ModuleClass)) sym.sourceModule else sym
           val refined = TypeOps.refineUsingParent(tp, sym1)
@@ -630,7 +631,7 @@ class SpaceEngine(implicit ctx: Context) extends SpaceLogic {
 
         parts.map(Typ(_, true))
     }
-  }
+
 
   /** Abstract sealed types, or-types, Boolean and Java enums can be decomposed */
   def canDecompose(tp: Type): Boolean = {


### PR DESCRIPTION
Fix #8838: load Java enum memers lazily to avoid cycles

It only happens in JDK 14.
