### PR TITLE
Replace deprecated package

### DIFF
--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -157,7 +157,7 @@ object ClassPath {
     catch { case _: MalformedURLException => None }
 
   def manifests: List[java.net.URL] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters.EnumerationHasAsScala
     val resources = Thread.currentThread().getContextClassLoader().getResources("META-INF/MANIFEST.MF")
     resources.asScala.filter(_.getProtocol == "jar").toList
   }


### PR DESCRIPTION
According to [Scala Standard Library](https://www.scala-lang.org/api/current/scala/collection/JavaConverters$.html), JavaConverters has deprecated since Scala version 2.13.0, so I replaced it.
Also, I imported only the needed resources, instead of all of it.

