### PR TITLE
[resubmitted] Fix #9061: Treat `type F <: [X] => G` like `type F[X] <: G`.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Variances.scala
+++ b/compiler/src/dotty/tools/dotc/core/Variances.scala
@@ -156,4 +156,6 @@ object Variances {
     if (v > 0) "+"
     else if (v < 0) "-"
     else ""
+
+  val alwaysInvariant: Any => Invariant.type = Function.const(Invariant)
 }

--- a/compiler/src/dotty/tools/dotc/util/common.scala
+++ b/compiler/src/dotty/tools/dotc/util/common.scala
@@ -6,8 +6,8 @@ import core.Types.WildcardType
 /** Common values hoisted out for performance */
 object common {
 
-  val alwaysTrue: Any => Boolean = Function.const(true) _
-  val alwaysFalse: Any => Boolean = Function.const(false) _
-  val alwaysZero: Any => Int = Function.const(0) _
-  val alwaysWildcardType: Any => WildcardType.type = Function.const(WildcardType) _
+  val alwaysTrue: Any => Boolean = Function.const(true)
+  val alwaysFalse: Any => Boolean = Function.const(false)
+  val alwaysZero: Any => Int = Function.const(0)
+  val alwaysWildcardType: Any => WildcardType.type = Function.const(WildcardType)
 }

--- a/tests/neg/i9061.scala
+++ b/tests/neg/i9061.scala
@@ -1,6 +1,8 @@
 case class Contra[-A](f: A => Int)
 
 case class Covarify[+F <: ([A] =>> Any), +A](fa: F[A]) // error: covariant type A occurs in invariant position in type F[A] of value fa
+case class Covarify2[+F[+X] <: ([A] =>> Any), +A](fa: F[Int][A]) // error: covariant type A occurs in invariant position in type F[A] of value fa
+case class Covarify3[+F <: [X] =>> [A] =>> Any, +A](fa: F[Int][A]) // error: covariant type A occurs in invariant position in type F[A] of value fa
 
 @main def main = {
   val x = Covarify[Contra, Int](Contra[Int](_ + 5))

--- a/tests/neg/i9061.scala
+++ b/tests/neg/i9061.scala
@@ -1,0 +1,9 @@
+case class Contra[-A](f: A => Int)
+
+case class Covarify[+F <: ([A] =>> Any), +A](fa: F[A]) // error: covariant type A occurs in invariant position in type F[A] of value fa
+
+@main def main = {
+  val x = Covarify[Contra, Int](Contra[Int](_ + 5))
+  val y: Covarify[Contra, Any] = x
+  println(y.fa.f("abc"))
+}


### PR DESCRIPTION
Accidentally merged in https://github.com/lampepfl/dotty/pull/9084, reverted and resubmitted because the community build started failing:
```scala
2020-05-30T15:04:52.6008148Z [info] Set current project to effpi (in build file:/__w/dotty/dotty/community-build/community-projects/effpi/)
2020-05-30T15:04:58.4723186Z [error] -- [E007] Type Mismatch Error: /__w/dotty/dotty/community-build/community-projects/effpi/src/main/scala/ActorDSL.scala:118:13 
2020-05-30T15:04:58.4723812Z [error] 118 |    pdsl.rec(RecA)(beh >> pdsl.loop(RecA))
2020-05-30T15:04:58.4724173Z [error]     |             ^^^^
2020-05-30T15:04:58.4724507Z [error]     |             Found:    effpi.actor.dsl.RecA.type
2020-05-30T15:04:58.4724861Z [error]     |             Required: effpi.process.RecVar[A]
2020-05-30T15:04:59.5859259Z [error] -- [E007] Type Mismatch Error: /__w/dotty/dotty/community-build/community-projects/effpi/src/main/scala/ActorDSL.scala:118:36 
2020-05-30T15:04:59.5859978Z [error] 118 |    pdsl.rec(RecA)(beh >> pdsl.loop(RecA))
2020-05-30T15:04:59.5860354Z [error]     |                                    ^^^^
2020-05-30T15:04:59.5860740Z [error]     |                                   Found:    effpi.actor.dsl.RecA.type
2020-05-30T15:04:59.5861157Z [error]     |                                   Required: effpi.process.RecVar[A]
2020-05-30T15:05:00.0746454Z [error] two errors found
2020-05-30T15:05:00.1342256Z [error] (Compile / compileIncremental) Compilation failed
```