### PR TITLE
Fix analyzer-plugins scripted test after phase move

### DIFF
--- a/sbt-dotty/sbt-test/sbt-dotty/analyzer-plugin/plugin/Analyzer.scala
+++ b/sbt-dotty/sbt-test/sbt-dotty/analyzer-plugin/plugin/Analyzer.scala
@@ -13,7 +13,7 @@ import Decorators._
 import Symbols.Symbol
 import Constants.Constant
 import Types._
-import transform.CompleteJavaEnums
+import transform.ElimRepeated
 
 class InitPlugin extends StandardPlugin {
   import tpd._
@@ -30,7 +30,7 @@ class InitChecker extends PluginPhase {
   val phaseName = "symbolTreeChecker"
 
   override val runsAfter = Set(SetDefTree.name)
-  override val runsBefore = Set(CompleteJavaEnums.name)
+  override val runsBefore = Set(ElimRepeated.name)
 
   private def checkDef(tree: Tree)(implicit ctx: Context): Tree = {
     if (tree.symbol.defTree.isEmpty)


### PR DESCRIPTION
CompleteJavaEnums was moved after erasure in
1818b99f7cec44e70ea75eb41e63e4fd0b7d7647 which broke this test.