### PR TITLE
Fix #9107: Restore constraints after MT reduction

### DIFF
--- a/tests/neg/6697-1.scala
+++ b/tests/neg/6697-1.scala
@@ -3,5 +3,6 @@ object Test {
   case class Of[sup, sub <: sup]() extends Off
   type Sup[O <: Off] = O match { case Of[sup, sub] => sup }
   type Sub[O <: Off] = O match { case Of[sup, sub] => sub }
-  type Copy[O <: Off] = Of[Sup[O], Sub[O]]
+  type Copy[O <: Off] = Of[Sup[O], Sub[O]] // error
+  // Type argument Test.Sub[O] does not conform to upper bound Test.Sup[O]
 }

--- a/tests/neg/6697-2.scala
+++ b/tests/neg/6697-2.scala
@@ -1,0 +1,18 @@
+object Test {
+  sealed trait Off
+  case class Of[sup, sub <: sup]() extends Off
+
+  def sup[O <: Off](o: O) = o match {
+    case _: Of[sup, sub] =>
+      val a: sub = null.asInstanceOf
+      // Even though we know that sub <: sup from Of's bounds, that knowledge
+      // is lost in the body of pattern matching expressions...
+
+      val b: sup = a // error
+      //  Found:    (a : sub)
+      //  Required: sup
+      //  where:    sub is a type in method sup with bounds <: Test.Of[?, ?]#sup
+
+      ()
+  }
+}

--- a/tests/neg/9107.scala
+++ b/tests/neg/9107.scala
@@ -1,0 +1,14 @@
+trait M[F[_]]
+trait Inv[T]
+
+object Test {
+  def ev[X] = implicitly[
+    (X match { case Inv[t] => Int }) =:=
+    (X match { case Inv[t] => t })
+  ] // error
+
+  def ev2[X] = implicitly[
+    (M[[t] =>> runtime.MatchCase[Inv[t], Int]])  =:=
+    (M[[t] =>> runtime.MatchCase[Inv[t], t]])
+  ] // error
+}

--- a/tests/pos/9890.scala
+++ b/tests/pos/9890.scala
@@ -1,0 +1,49 @@
+object Test {
+  import scala.compiletime.ops.int._
+
+  trait x
+
+  type Range[Min <: Int, Max <: Int] <: Tuple = Min match {
+    case Max => EmptyTuple
+    case _ => Min *: Range[Min + 1, Max]
+  }
+
+  type TupleMap[Tup <: Tuple, Bound, F[_ <: Bound]] <: Tuple = Tup match {
+    case EmptyTuple => EmptyTuple
+    case h *: t => F[h] *: TupleMap[t, Bound, F]
+  }
+  type TupleDedup[Tup <: Tuple, Mask] <: Tuple = Tup match {
+    case EmptyTuple => EmptyTuple
+    case h *: t => h match {
+      case Mask => TupleDedup[t, Mask]
+      case _ => h *: TupleDedup[t, h | Mask]
+    }
+  }
+
+  type CoordToPos[r <: Int, c <: Int] = r * 9 + c
+  type Cell[r <: Int, c <: Int, Board <: Tuple] = Tuple.Elem[Board, CoordToPos[r, c]]
+  type Col[c <: Int, Board <: Tuple] = TupleMap[Range[0, 9], Int, [r <: Int] =>> Cell[r, c, Board]]
+
+  type ColFromPos[Pos <: Int] = Pos % 9
+
+  type Sudoku1 = (
+    x, x, x,  x, 1, x,  4, x, 6,
+    8, x, 1,  6, 2, x,  x, x, 9,
+    x, 3, x,  x, x, 9,  x, 2, x,
+
+    5, x, 9,  1, 3, x,  x, 6, x,
+    x, 6, x,  9, x, 2,  x, 4, x,
+    x, 2, x,  x, 6, 7,  8, x, 5,
+
+    x, 9, x,  5, x, x,  x, 3, x,
+    3, x, x,  x, 4, 6,  9, x, 7,
+    6, x, 7,  x, 9, x,  x, x, x,
+  )
+
+  //compiles fine
+  summon[Col[ColFromPos[0], Sudoku1] =:= (x, 8, x,  5, x, x,  x, 3, 6)]
+
+  summon[TupleDedup[(x, 8, x,  5, x, x,  x, 3, 6), Nothing] =:= (x, 8, 5, 3, 6)]
+  //but this doesn't
+  summon[TupleDedup[Col[ColFromPos[0], Sudoku1], Nothing] =:= (x, 8, 5, 3, 6)]
+}


### PR DESCRIPTION
Because of `caseLambda = constrained(cas)` in `def matchCase`, subtyping wrongly things that it's OK to further constrain types introduced in match type patterns. This commit fixes the issue with a stronger version of `inFrozenConstraint` around match type reduction.