### PR TITLE
Avoid time travel when handling of LazyRefs

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -337,7 +337,7 @@ class TypeApplications(val self: Type) extends AnyVal {
       case dealiased: TypeBounds =>
         dealiased.derivedTypeBounds(dealiased.lo.appliedTo(args), dealiased.hi.appliedTo(args))
       case dealiased: LazyRef =>
-        LazyRef(c => dealiased.ref(c).appliedTo(args))
+        LazyRef(c => dealiased.ref(c).appliedTo(args)(using c))
       case dealiased: WildcardType =>
         WildcardType(dealiased.optBounds.orElse(TypeBounds.empty).appliedTo(args).bounds)
       case dealiased: TypeRef if dealiased.symbol == defn.NothingClass =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4862,7 +4862,7 @@ object Types {
     }
   }
 
-  abstract class TypeMap(implicit protected val mapCtx: Context)
+  abstract class TypeMap(implicit protected var mapCtx: Context)
   extends VariantTraversal with (Type => Type) { thisMap =>
 
     protected def stopAtStatic: Boolean = true
@@ -4979,7 +4979,12 @@ object Types {
           derivedSuperType(tp, this(thistp), this(supertp))
 
         case tp: LazyRef =>
-          LazyRef(_ => this(tp.ref))
+          LazyRef { c =>
+            val saved = mapCtx
+            mapCtx = c
+            try this(tp.ref(using c))
+            finally mapCtx = saved
+          }
 
         case tp: ClassInfo =>
           mapClassInfo(tp)


### PR DESCRIPTION
The idea of LazyRefs is that they are always completed in the current context.
But that did not work if the LazyRef is mapped in a type map. Here, the TypeMap's
context was used to do the remap. We now use the context that forced the LazyVal
instead.

The problem manifested itself with failing replTests when the new implicitScope
scheme was used.