### PR TITLE
Fix #9102: printing of by-name params in the repl

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -222,8 +222,6 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
             case _ => super.toText(tp)
           }
         else super.toText(tp)
-      case tp: ExprType =>
-        exprToText(tp)
       case ErasedValueType(tycon, underlying) =>
         "ErasedValueType(" ~ toText(tycon) ~ ", " ~ toText(underlying) ~ ")"
       case tp: ClassInfo =>

--- a/compiler/src/dotty/tools/dotc/printing/ReplPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/ReplPrinter.scala
@@ -19,10 +19,6 @@ class ReplPrinter(_ctx: Context) extends DecompilerPrinter(_ctx) {
     if (name.isReplAssignName) name.decode.toString.takeWhile(_ != '$')
     else super.nameString(name)
 
-  override protected def exprToText(tp: ExprType): Text =
-    if (debugPrint) super.exprToText(tp)
-    else ": " ~ toText(tp.resType)
-
   override def toText(sym: Symbol): Text =
     if (sym.name.isReplAssignName) nameString(sym.name)
     else if (debugPrint) super.toText(sym)
@@ -38,7 +34,12 @@ class ReplPrinter(_ctx: Context) extends DecompilerPrinter(_ctx) {
   override def dclText(sym: Symbol): Text = if (debugPrint) super.dclText(sym) else
     ("lazy": Text).provided(sym.is(Lazy)) ~~
     toText(sym) ~ {
-      if (sym.is(Method)) toText(sym.info)
+      if (sym.is(Method)) {
+        sym.info match {
+          case tp: ExprType => ":" ~~ toText(tp.resType)
+          case _ => toText(sym.info)
+        }
+      }
       else if (sym.isType && sym.info.isTypeAlias) toText(sym.info)
       else if (sym.isType || sym.isClass) ""
       else ":" ~~ toText(sym.info)

--- a/compiler/test-resources/repl/i9102
+++ b/compiler/test-resources/repl/i9102
@@ -1,0 +1,8 @@
+scala> def foo(x: => Int) = x.toString
+def foo(x: => Int): String
+scala> def bar: (=> Int) => String = x => x.toString
+def bar: (=> Int) => String
+scala> def baz: (Int => String) = x => x.toString
+def baz: Int => String
+scala> lazy val qux: ((=> Int) => String) = x => x.toString
+lazy val qux: (=> Int) => String


### PR DESCRIPTION
By-name param types are printed correctly in the repl now:

```scala
scala> def foo(x: => Int) = x.toString
def foo(x: => Int): String

scala> foo                                                                     
val res0: (=> Int) => String = Lambda$8017/710782087@713e0527

scala> def bar: (=> Int) => String = x => x.toString                           
def bar: (=> Int) => String

scala> bar                                                                     
val res1: (=> Int) => String = Lambda$8031/1337976273@91c70f7
```