### PR TITLE
fix #9052: throw CyclicReference if LazyRef is already set

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -490,7 +490,10 @@ object SymDenotations {
         def recur(self: Type): Unit = self match
           case RefinedType(parent, name, rinfo) => rinfo match
             case TypeAlias(lzy: LazyRef) if name == this.name =>
-              lzy.update(tp)
+              if !lzy.completed then
+                lzy.update(tp)
+              else
+                throw CyclicReference(this)
             case _ =>
               recur(parent)
         recur(owner.asClass.givenSelfType)

--- a/tests/neg/i9052/A.scala
+++ b/tests/neg/i9052/A.scala
@@ -1,0 +1,6 @@
+object impl:
+  case object UNone
+
+import impl._
+
+opaque type UOption[+A] = (A | UNone.type) // error: Cyclic Reference involving UOption

--- a/tests/neg/i9052/B.scala
+++ b/tests/neg/i9052/B.scala
@@ -1,0 +1,1 @@
+val UNone: UOption[Nothing] = ??? // error: Cyclic Reference involving UOption


### PR DESCRIPTION
fix #9052 

The other alternative would be to not call update if LazyRef is already computed, which would be inconsistent with what happens when you compile `tests/neg/i9052/A.scala` and `tests/neg/i9052/B.scala` in reverse alphabetical order