### PR TITLE
Avoid cycle between Java static class and outer class

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2199,7 +2199,10 @@ object SymDenotations {
       if (companion.isClass && !isAbsent(canForce = false) && !companion.isAbsent(canForce = false))
         myCompanion = companion
 
-    override def registeredCompanion(implicit ctx: Context) = { ensureCompleted(); myCompanion }
+    override def registeredCompanion(implicit ctx: Context) =
+      if !myCompanion.exists then
+        ensureCompleted()
+      myCompanion
     override def registeredCompanion_=(c: Symbol) = { myCompanion = c }
 
     private var myNestingLevel = -1

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -180,17 +180,19 @@ class ClassfileParser(
 
       for (i <- 0 until in.nextChar) parseMember(method = false)
       for (i <- 0 until in.nextChar) parseMember(method = true)
+
+      classRoot.registerCompanion(moduleRoot.symbol)
+      moduleRoot.registerCompanion(classRoot.symbol)
+
+      setClassInfo(moduleRoot, staticInfo, fromScala2 = false)
+
       classInfo = parseAttributes(classRoot.symbol, classInfo)
       if (isAnnotation)
         // classInfo must be a TempClassInfoType and not a TempPolyType,
         // because Java annotations cannot have type parameters.
         addAnnotationConstructor(classInfo.asInstanceOf[TempClassInfoType])
 
-      classRoot.registerCompanion(moduleRoot.symbol)
-      moduleRoot.registerCompanion(classRoot.symbol)
-
       setClassInfo(classRoot, classInfo, fromScala2 = false)
-      setClassInfo(moduleRoot, staticInfo, fromScala2 = false)
     }
     else if (result == Some(NoEmbedded))
       for (sym <- List(moduleRoot.sourceModule, moduleRoot.symbol, classRoot.symbol)) {
@@ -916,7 +918,7 @@ class ClassfileParser(
     }
 
     /** Return the class symbol for `entry`. It looks it up in its outer class.
-     *  Forces all outer class symbols to be completed.
+     *  This might force outer class symbols.
      */
     def classSymbol(entry: InnerClassEntry)(implicit ctx: Context): Symbol = {
       def getMember(sym: Symbol, name: Name)(implicit ctx: Context): Symbol =

--- a/tests/pos-java-interop-separate/static-cycle/A_1.java
+++ b/tests/pos-java-interop-separate/static-cycle/A_1.java
@@ -1,0 +1,5 @@
+class Foo<T extends Foo<T>> {}
+
+public class A_1 extends Foo<A_1.InnerClass> {
+  public static class InnerClass extends Foo<A_1.InnerClass> {}
+}

--- a/tests/pos-java-interop-separate/static-cycle/B_2.scala
+++ b/tests/pos-java-interop-separate/static-cycle/B_2.scala
@@ -1,0 +1,3 @@
+object B {
+  val a = new A_1
+}


### PR DESCRIPTION
Real world usecase is
https://www.javadoc.io/doc/software.amazon.awssdk/cloudwatchlogs/2.13.28/software/amazon/awssdk/services/cloudwatchlogs/model/GetLogEventsRequest.html

- When parsing a Java classfile, set the info of the companion (where
  inner static classes will be looked up) before reading the generic
  signature of the class.
- When looking for a companion, do not unnecessarily force denotations