### PR TITLE
Fix #8839: Only warn if TASTy is not in sync with classfile

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -825,7 +825,7 @@ class ClassfileParser(
             val expectedUUID = new UUID(reader.readUncompressedLong(), reader.readUncompressedLong())
             val tastyUUID = new TastyHeaderUnpickler(tastyBytes).readHeader()
             if (expectedUUID != tastyUUID)
-              ctx.error(s"Tasty UUID ($tastyUUID) file did not correspond the tasty UUID ($expectedUUID) declared in the classfile $classfile.")
+              ctx.warning(s"$classfile is out of sync with its TASTy file. Loaded TASTy file. Try cleaning the project to fix this issue", NoSourcePosition)
             return unpickleTASTY(tastyBytes)
           }
         }


### PR DESCRIPTION
If they are not in sync, we warn and suggest to clean.
We assume that the TASTy is up to date (arbitrary choise) and load it regardless.
This way we are resiliant to the failiure if the loaded class API did not change or
did not have an impact on the code we are compiling.