### PR TITLE
Fix #9109: More precise override check

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -40,7 +40,7 @@ object OverridingPairs {
      *  relative to <base>.this do
      */
     protected def matches(sym1: Symbol, sym2: Symbol): Boolean =
-      sym1.isType || self.memberInfo(sym1).matches(self.memberInfo(sym2))
+      sym1.isType || sym1.asSeenFrom(self).matches(sym2.asSeenFrom(self))
 
     /** The symbols that can take part in an overriding pair */
     private val decls = {

--- a/tests/explicit-nulls/neg/override-java-object-arg2.scala
+++ b/tests/explicit-nulls/neg/override-java-object-arg2.scala
@@ -5,7 +5,7 @@ class Foo {
 
   def bar(): Unit = {
     val listener4 = new NotificationListener() { // error: duplicate symbol error
-      def handleNotification(n: Notification|Null, emitter: Object): Unit = {
+      def handleNotification(n: Notification|Null, emitter: Object): Unit = { // error
       }
     }
   }

--- a/tests/neg-custom-args/erased/erased-case-class.scala
+++ b/tests/neg-custom-args/erased/erased-case-class.scala
@@ -1,1 +1,1 @@
-case class Foo1(erased x: Int) // error
+case class Foo1(erased x: Int) // error // error

--- a/tests/neg/i7597.scala
+++ b/tests/neg/i7597.scala
@@ -1,13 +1,13 @@
 object Test extends App {
   def foo[S <: String]: String => Int =
-    new (String => Int) { def apply(s: S): Int = 0 } // error
+    new (String => Int) { def apply(s: S): Int = 0 } // error // error
 
   trait Fn[A, B] {
     def apply(x: A): B
   }
 
   class C[S <: String] extends Fn[String, Int] {  // error
-    def apply(s: S): Int = 0
+    def apply(s: S): Int = 0 // error
   }
 
   foo("")

--- a/tests/pos-java-interop/i9109/A.java
+++ b/tests/pos-java-interop/i9109/A.java
@@ -1,0 +1,4 @@
+public class A {
+  public <T extends java.io.Serializable> void foo(T x) {}
+  public <T extends Cloneable> void foo(T x) {}
+}

--- a/tests/pos-java-interop/i9109/B.scala
+++ b/tests/pos-java-interop/i9109/B.scala
@@ -1,0 +1,3 @@
+class B extends A {
+  override def foo[T <: Serializable](x: T): Unit = {}
+}

--- a/tests/pos/i9109.scala
+++ b/tests/pos/i9109.scala
@@ -1,0 +1,7 @@
+class A {
+  def foo[T <: Serializable](x: T): Unit = {}
+  def foo[T <: Cloneable](x: T): Unit = {}
+}
+class B extends A {
+  override def foo[T <: Serializable](x: T): Unit = {}
+}

--- a/tests/pos/zoo.scala
+++ b/tests/pos/zoo.scala
@@ -14,7 +14,7 @@ trait Animal {
 trait Cow extends Animal {
   type IsMeat = Any
   type Food <: Grass
-  def eats(food: Grass): Unit
+  def eats(food: Food): Unit
   def gets: Food
 }
 trait Lion extends Animal {


### PR DESCRIPTION
Use Denotation#matches instead of Types#matches, the former takes
signatures into account, in the testcase this is needed to ensure that
RefChecks does not emit an error about
`def foo[T <: Serializable](x: T): Unit` being an invalid override of
`def foo[T <: Cloneable](x: T): Unit`.

Note that our treatment of polymorphic methods differs from Scala 2
which seems to consider that two polymorphic methods with the same
number of type and term parameters always match and cannot be
overloads (see #8929), but it's closer to what Java does and allows us
to override some Java methods which scalac can't.