### PR TITLE
Fix incorrect code in phase Constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -270,7 +270,7 @@ object NameOps {
           original.fieldName
         }
         else getterName.fieldName
-      else FieldName(name)
+      else FieldName(name.toSimpleName)
 
     def stripScala2LocalSuffix: TermName =
       if (name.isScala2LocalSuffix) name.asSimpleName.dropRight(1) else name

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -578,7 +578,7 @@ class TreeUnpickler(reader: TastyReader,
             else
               ctx.newSymbol(ctx.owner, name, flags, completer, privateWithin, coord)
         }
-      sym.annotations = annotFns.map(_(sym))
+      sym.annotations = annotFns.map(_(sym.owner))
       if sym.isOpaqueAlias then sym.setFlag(Deferred)
       val isScala2MacroDefinedInScala3 = flags.is(Macro, butNot = Inline) && flags.is(Erased)
       ctx.owner match {

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -251,9 +251,9 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
     // Drop accessors that are not retained from class scope
     if (dropped.nonEmpty) {
       val clsInfo = cls.classInfo
-      cls.copy(
-        info = clsInfo.derivedClassInfo(
-          decls = clsInfo.decls.filteredScope(!dropped.contains(_))))
+      val decls = clsInfo.decls.filteredScope(!dropped.contains(_))
+      val clsInfo2 = clsInfo.derivedClassInfo(decls = decls)
+      cls.copySymDenotation(info = clsInfo2).installAfter(thisPhase)
       // TODO: this happens to work only because Constructors is the last phase in group
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
@@ -22,7 +22,7 @@ class MixinOps(cls: ClassSymbol, thisPhase: DenotTransformer)(implicit ctx: Cont
     val res = member.copy(
       owner = cls,
       name = member.name.stripScala2LocalSuffix,
-      flags = member.flags &~ Deferred | Synthetic | extraFlags,
+      flags = member.flags &~ Deferred &~ Module | Synthetic | extraFlags,
       info = cls.thisType.memberInfo(member)).enteredAfter(thisPhase).asTerm
     res.addAnnotations(member.annotations.filter(_.symbol != defn.TailrecAnnot))
     res

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -270,7 +270,7 @@ class ReifyQuotes extends MacroTransform {
 
       val tpe = MethodType(defn.SeqType.appliedTo(defn.AnyType) :: Nil, tree.tpe.widen)
       val meth = ctx.newSymbol(lambdaOwner, UniqueName.fresh(nme.ANON_FUN), Synthetic | Method, tpe)
-      Closure(meth, tss => body(tss.head.head)(ctx.withOwner(meth)).changeOwner(ctx.owner, meth)).withSpan(tree.span)
+      Closure(meth, tss => body(tss.head.head)(ctx.withOwner(meth)).changeNonLocalOwners(meth)).withSpan(tree.span)
     }
 
     private def transformWithCapturer(tree: Tree)(capturer: mutable.Map[Symbol, Tree] => Tree => Tree)(implicit ctx: Context): Tree = {

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -426,18 +426,19 @@ class TreeChecker extends Phase with SymTransformer {
       checkOwner(impl)
       checkOwner(impl.constr)
 
-      def isNonMagicalMethod(x: Symbol) =
-        x.is(Method) &&
+      def isNonMagicalMember(x: Symbol) =
           !x.isValueClassConvertMethod &&
-          !(x.is(Macro) && ctx.phase.refChecked) &&
           !x.name.is(DocArtifactName)
 
-      val symbolsNotDefined = cls.classInfo.decls.toList.toSet.filter(isNonMagicalMethod) -- impl.body.map(_.symbol) - constr.symbol
+      val decls   = cls.classInfo.decls.toList.toSet.filter(isNonMagicalMember)
+      val defined = impl.body.map(_.symbol)
+
+      val symbolsNotDefined = decls -- defined - constr.symbol
 
       assert(symbolsNotDefined.isEmpty,
           i" $cls tree does not define methods: ${symbolsNotDefined.toList}%, %\n" +
-          i"expected: ${cls.classInfo.decls.toList.toSet.filter(isNonMagicalMethod)}%, %\n" +
-          i"defined: ${impl.body.map(_.symbol)}%, %")
+          i"expected: $decls%, %\n" +
+          i"defined: $defined%, %")
 
       super.typedClassDef(cdef, cls)
     }

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -427,8 +427,8 @@ class TreeChecker extends Phase with SymTransformer {
       checkOwner(impl.constr)
 
       def isNonMagicalMember(x: Symbol) =
-          !x.isValueClassConvertMethod &&
-          !x.name.is(DocArtifactName)
+        !x.isValueClassConvertMethod &&
+        !x.name.is(DocArtifactName)
 
       val decls   = cls.classInfo.decls.toList.toSet.filter(isNonMagicalMember)
       val defined = impl.body.map(_.symbol)
@@ -436,9 +436,9 @@ class TreeChecker extends Phase with SymTransformer {
       val symbolsNotDefined = decls -- defined - constr.symbol
 
       assert(symbolsNotDefined.isEmpty,
-          i" $cls tree does not define methods: ${symbolsNotDefined.toList}%, %\n" +
-          i"expected: $decls%, %\n" +
-          i"defined: $defined%, %")
+          i" $cls tree does not define members: ${symbolsNotDefined.toList}%, %\n" +
+          i"expected: ${decls.toList}%, %\n" +
+          i"defined: ${defined}%, %")
 
       super.typedClassDef(cdef, cls)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -859,7 +859,7 @@ class Namer { typer: Typer =>
           if (cls eq sym)
             ctx.error("An annotation class cannot be annotated with iself", annotTree.sourcePos)
           else {
-            val ann = Annotation.deferred(cls)(typedAnnotation(annotTree)(using annotCtx))(using annotCtx)
+            val ann = Annotation.deferred(cls)(typedAheadAnnotation(annotTree)(using annotCtx))
             sym.addAnnotation(ann)
           }
         }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -859,7 +859,7 @@ class Namer { typer: Typer =>
           if (cls eq sym)
             ctx.error("An annotation class cannot be annotated with iself", annotTree.sourcePos)
           else {
-            val ann = Annotation.deferred(cls)(typedAnnotation(annotTree))
+            val ann = Annotation.deferred(cls)(typedAnnotation(annotTree)(using annotCtx))(using annotCtx)
             sym.addAnnotation(ann)
           }
         }


### PR DESCRIPTION
`cls.copy` creates an unused new symbol.
Instead, `cls.copySymDenotation` should be called.