### PR TITLE
Fix compiler crash when file path is invalid

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -111,7 +111,8 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   }
   catch {
     case NonFatal(ex) =>
-      runContext.echo(i"exception occurred while compiling $units%, %")
+      if units != null then runContext.echo(i"exception occurred while compiling $units%, %")
+      else runContext.echo(s"exception occurred while compiling ${fileNames.mkString(", ")}")
       throw ex
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -249,18 +249,16 @@ object Contexts {
     def getSource(path: TermName): SourceFile = base.sourceNamed.get(path) match {
       case Some(source) =>
         source
-      case None =>
-        val src = try {
-          val f = new PlainFile(Path(path.toString))
-          val s = getSource(f)
-          base.sourceNamed(path) = s
-          s
-        } catch {
-          case ex: InvalidPathException =>
-            ctx.error(s"invalid file path: ${ex.getMessage}")
-            NoSource
-        }
+      case None => try {
+        val f = new PlainFile(Path(path.toString))
+        val src = getSource(f)
+        base.sourceNamed(path) = src
         src
+      } catch {
+        case ex: InvalidPathException =>
+          ctx.error(s"invalid file path: ${ex.getMessage}")
+          NoSource
+      }
     }
 
     /** Sourcefile with given path, memoized */

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -36,6 +36,7 @@ import util.Store
 import xsbti.AnalysisCallback
 import plugins._
 import java.util.concurrent.atomic.AtomicInteger
+import java.nio.file.InvalidPathException
 
 object Contexts {
 
@@ -249,9 +250,16 @@ object Contexts {
       case Some(source) =>
         source
       case None =>
-        val f = new PlainFile(Path(path.toString))
-        val src = getSource(f)
-        base.sourceNamed(path) = src
+        val src = try {
+          val f = new PlainFile(Path(path.toString))
+          val s = getSource(f)
+          base.sourceNamed(path) = s
+          s
+        } catch {
+          case ex: InvalidPathException =>
+            ctx.error(s"invalid file path: ${ex.getMessage}")
+            NoSource
+        }
         src
     }
 


### PR DESCRIPTION
Compiler will crash when file path is invalid and throw `NullPointerException`, which doesn't contain any useful information.

Example:

```
sbt:dotty> dotc Xprint:all
```

Before fix:

```
java.lang.NullPointerException while compiling Xprint:all
Exception in thread "main" java.lang.NullPointerException
        at dotty.tools.dotc.printing.Formatting$StringFormatter.showArg(Formatting.scala:39)
        at dotty.tools.dotc.printing.Formatting$StringFormatter.treatArg(Formatting.scala:49)
        at dotty.tools.dotc.printing.Formatting$StringFormatter.$anonfun$2(Formatting.scala:62)
        at scala.collection.LazyZip2$$anon$1$$anon$2.next(LazyZipOps.scala:42)
        at scala.collection.mutable.Growable.addAll(Growable.scala:62)
        at scala.collection.mutable.Growable.addAll$(Growable.scala:59)
        at scala.collection.mutable.ArrayBuilder.addAll(ArrayBuilder.scala:69)
        at scala.collection.IterableOnceOps.toArray(IterableOnce.scala:1289)
        at scala.collection.IterableOnceOps.toArray$(IterableOnce.scala:1283)
        at scala.collection.AbstractIterable.toArray(Iterable.scala:920)
        at scala.Array$.from(Array.scala:59)
        at scala.collection.immutable.ArraySeq$.from(ArraySeq.scala:180)
        at scala.collection.immutable.ArraySeq$.from(ArraySeq.scala:171)
        at scala.collection.ClassTagIterableFactory$AnyIterableDelegate.from(Factory.scala:656)
        at scala.collection.BuildFromLowPriority2$$anon$11.fromSpecific(BuildFrom.scala:112)
        at scala.collection.BuildFromLowPriority2$$anon$11.fromSpecific(BuildFrom.scala:109)
        at scala.collection.LazyZip2.map(LazyZipOps.scala:37)
        at dotty.tools.dotc.printing.Formatting$StringFormatter.assemble(Formatting.scala:62)
        at dotty.tools.dotc.core.Decorators$StringInterpolators$.i$extension(Decorators.scala:215)
        at dotty.tools.dotc.Run.compile$$anonfun$1(Run.scala:114)
        at dotty.tools.dotc.reporting.NoExplanation.msg(Message.scala:122)
        at dotty.tools.dotc.reporting.Message.message(Message.scala:80)
        at dotty.tools.dotc.reporting.Message.isNonSensical(Message.scala:92)
        at dotty.tools.dotc.reporting.HideNonSensicalMessages.isHidden(HideNonSensicalMessages.scala:16)
        at dotty.tools.dotc.reporting.AbstractReporter.isHidden(AbstractReporter.scala:8)
        at dotty.tools.dotc.reporting.Reporter.report(Reporter.scala:265)
        at dotty.tools.dotc.reporting.Reporting.echo(Reporter.scala:78)
        at dotty.tools.dotc.core.Contexts$Context.echo(Contexts.scala:78)
        at dotty.tools.dotc.Run.compile(Run.scala:114)
        at dotty.tools.dotc.Driver.doCompile(Driver.scala:38)
        at dotty.tools.dotc.Driver.process(Driver.scala:194)
        at dotty.tools.dotc.Driver.process(Driver.scala:163)
        at dotty.tools.dotc.Driver.process(Driver.scala:175)
        at dotty.tools.dotc.Driver.main(Driver.scala:202)
        at dotty.tools.dotc.Main.main(Main.scala)
```

After fix:

```
invalid file path: Illegal char <:> at index 6: Xprint:all
1 error found
```