### PR TITLE
Denotation#matches: avoid now-unnecessary slow path

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -972,20 +972,15 @@ object Denotations {
     final def matches(other: SingleDenotation)(implicit ctx: Context): Boolean =
       val d = signature.matchDegree(other.signature)
 
-      /** Slower check used if the signatures alone do not tell us enough to be sure about matching */
-      def slowCheck = info.matches(other.info)
-
       d match
         case FullMatch =>
-          if infoOrCompleter.isInstanceOf[PolyType] || other.infoOrCompleter.isInstanceOf[PolyType] then
-            slowCheck
-          else
-            true
+          true
         case MethodNotAMethodMatch =>
           // Java allows defining both a field and a zero-parameter method with the same name
           !ctx.erasedTypes && !(symbol.is(JavaDefined) && other.symbol.is(JavaDefined))
         case ParamMatch =>
-          !ctx.erasedTypes && slowCheck
+           // The signatures do not tell us enough to be sure about matching
+          !ctx.erasedTypes && info.matches(other.info)
         case noMatch =>
           false
     end matches


### PR DESCRIPTION
The slow path when matching on a PolyType was necessary when it was
added in 668a6375f37b24108002bc2b03247e706eea3a82, but since then
signatures were enhanced to also include the number of type parameters
(in f95153437ef989810b3095aa7d0aa789e620da15), thus making the extra
check unnecessary.