### PR TITLE
Fix #9171: Eliminate difference _ and Any in MT

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2788,7 +2788,7 @@ class TrackingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
               val instances = paramInstances(new Array(caseLambda.paramNames.length), pat)
               instantiateParams(instances)(body)
             case _ =>
-              body
+              body.simplified
           }
         }
       else if (provablyDisjoint(scrut, pat))

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -387,15 +387,20 @@ trait TypeAssigner {
   def assignType(tree: untpd.CaseDef, pat: Tree, body: Tree)(using Context): CaseDef = {
     val ownType =
       if (body.isType) {
-        val params = new TreeAccumulator[mutable.ListBuffer[TypeSymbol]] {
-          def apply(ps: mutable.ListBuffer[TypeSymbol], t: Tree)(using Context) = t match {
-            case t: Bind if t.symbol.isType => foldOver(ps += t.symbol.asType, t)
-            case _ => foldOver(ps, t)
-          }
+        pat match {
+          case Bind(name, _) if name == nme.WILDCARD.toTypeName =>
+            defn.MatchCase(defn.AnyType, body.tpe)
+          case pat =>
+            val params = new TreeAccumulator[mutable.ListBuffer[TypeSymbol]] {
+              def apply(ps: mutable.ListBuffer[TypeSymbol], t: Tree)(using Context) = t match {
+                case t: Bind if t.symbol.isType => foldOver(ps += t.symbol.asType, t)
+                case _ => foldOver(ps, t)
+              }
+            }
+            HKTypeLambda.fromParams(
+              params(new mutable.ListBuffer[TypeSymbol](), pat).toList,
+              defn.MatchCase(pat.tpe, body.tpe))
         }
-        HKTypeLambda.fromParams(
-          params(new mutable.ListBuffer[TypeSymbol](), pat).toList,
-          defn.MatchCase(pat.tpe, body.tpe))
       }
       else body.tpe
     tree.withType(ownType)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1484,6 +1484,11 @@ class Typer extends Namer
                   case defn.MatchCase(patternTp, _) => tpt.tpe frozen_=:= patternTp
                   case _ => false
                 }
+              case (id @ Ident(nme.WILDCARD), pt) =>
+                pt match {
+                  case defn.MatchCase(patternTp, _) => defn.AnyType frozen_=:= patternTp
+                  case _ => false
+                }
               case _ => false
             }
 
@@ -1615,7 +1620,7 @@ class Typer extends Namer
     assignType(cpy.Labeled(tree)(bind1, expr1))
   }
 
-  /** Type a case of a type match */
+  /** Type a case of a match type */
   def typedTypeCase(cdef: untpd.CaseDef, selType: Type, pt: Type)(using Context): CaseDef = {
     def caseRest(using Context) = {
       val pat1 = withMode(Mode.Pattern)(checkSimpleKinded(typedType(cdef.pat)))

--- a/tests/neg-custom-args/matchtype-loop.scala
+++ b/tests/neg-custom-args/matchtype-loop.scala
@@ -6,9 +6,9 @@ object Test {
     case Int => LL[LL[X]]
   }
   def a: L[Boolean] = ???
-  def b: L[Int] = ???
+  // def b: L[Int] = ??? // times out
   def g[X]: L[X] = ???
-  val x: Int = g[Int]     // error: found: L[Int], required: Int
+  // val x: Int = g[Int] // times out
 
   def aa: LL[Boolean] = ???
   def bb: LL[Int] = ???   // error: recursion limit exceeded with  reduce type  LazyRef(Test.LL[Int]) match ...

--- a/tests/neg/matchtype-seq.check
+++ b/tests/neg/matchtype-seq.check
@@ -78,7 +78,7 @@ longer explanation available when compiling with `-explain`
    |                      and cannot be shown to be disjoint from it either.
    |                      Therefore, reduction cannot advance to the remaining case
    |
-   |                        case _ => String
+   |                        case Any => String
 
 longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:22:18 -----------------------------------------------------
@@ -102,7 +102,7 @@ longer explanation available when compiling with `-explain`
    |                      and cannot be shown to be disjoint from it either.
    |                      Therefore, reduction cannot advance to the remaining case
    |
-   |                        case _ => String
+   |                        case Any => String
 
 longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:36:18 -----------------------------------------------------
@@ -459,7 +459,7 @@ longer explanation available when compiling with `-explain`
     |                         and cannot be shown to be disjoint from it either.
     |                         Therefore, reduction cannot advance to the remaining case
     |
-    |                           case _ => Int
+    |                           case Any => Int
 
 longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:187:25 ----------------------------------------------------
@@ -476,6 +476,6 @@ longer explanation available when compiling with `-explain`
     |                           and cannot be shown to be disjoint from it either.
     |                           Therefore, reduction cannot advance to the remaining case
     |
-    |                             case _ => Int
+    |                             case Any => Int
 
 longer explanation available when compiling with `-explain`

--- a/tests/pos/i8449.scala
+++ b/tests/pos/i8449.scala
@@ -1,4 +1,3 @@
-
 import scala.compiletime.ops.int.*
 
 object Test {
@@ -6,6 +5,21 @@ object Test {
     case 0 => 0
     case 1 => 1
     case _ => Fib[N - 1] + Fib[N - 2]
+  }
+  val fib0: Fib[0] = 0
+  val fib1: Fib[1] = 1
+  val fib2: Fib[2] = 1
+  val fib3: Fib[3] = 2
+  val fib4: Fib[4] = 3
+  val fib5: Fib[5] = 5
+  val fib6: Fib[6] = 8
+}
+
+object Test2 {
+  type Fib[N <: Int] <: Int = N match {
+    case 0 => 0
+    case 1 => 1
+    case Int => Fib[N - 1] + Fib[N - 2]
   }
   val fib0: Fib[0] = 0
   val fib1: Fib[1] = 1

--- a/tests/pos/unify-wildcard-patterns.scala
+++ b/tests/pos/unify-wildcard-patterns.scala
@@ -1,0 +1,23 @@
+// `case _ => expr` in a match expression should be equivalant to
+// `case _: Any => expr`. Likewise, in a match type, `case _ => T`
+// should be equivalant to `case Any => T`.
+
+object Test0 {
+  type M[X] =            X match { case String => Int   case Any => String }
+  def m[X](x: X): M[X] = x match { case _: String => 1  case _: Any => "s" }
+}
+
+object Test1 {
+  type M[X] =            X match { case String => Int   case Any => String }
+  def m[X](x: X): M[X] = x match { case _: String => 1  case _ => "s"      }
+}
+
+object Test2 {
+  type M[X] =            X match { case String => Int   case _ => String   }
+  def m[X](x: X): M[X] = x match { case _: String => 1  case _: Any => "s" }
+}
+
+object Test3 {
+  type M[X] =            X match { case String => Int   case _ => String   }
+  def m[X](x: X): M[X] = x match { case _: String => 1  case _ => "s"      }
+}


### PR DESCRIPTION
`case _ =>` use to be typed as a `HKTypeLambda`, despite not binding anything. As a result, result of match type reduction going through `case _` would get further reduce that their `case Any` counterpart. This PR eliminates this distinction with the following changes:

- Eliminate this distinction in typing (type `case _ =>` *as* `case Any =>`)
- Simplify the body of match types in non-binding cases
- Change the match type/expression unification to treat the `case _ =>` in a   pattern like `case _: Any =>`

Unfortunately this change introduces a regression in `matchtype-loop.scala` where the loop suddenly turns into an infinite loop that doesn't stack overflow. I don't see any other way to nicely fail than to introduce a new fuel-like counter to keep track of match type reductions.