### PR TITLE
Refactor compiler io resources

### DIFF
--- a/compiler/src/dotty/tools/io/Directory.scala
+++ b/compiler/src/dotty/tools/io/Directory.scala
@@ -59,7 +59,7 @@ class Directory(jpath: JPath) extends Path(jpath) {
   def files: Iterator[File] = list collect { case x: File => x }
 
   override def walkFilter(cond: Path => Boolean): Iterator[Path] =
-    list filter cond flatMap (_ walkFilter cond)
+    list.filter(cond).flatMap(_.walkFilter(cond))
 
   def deepFiles: Iterator[File] = Path.onlyFiles(deepList())
 

--- a/compiler/src/dotty/tools/io/Directory.scala
+++ b/compiler/src/dotty/tools/io/Directory.scala
@@ -67,7 +67,7 @@ class Directory(jpath: JPath) extends Path(jpath) {
    *  until it runs out of contents.
    */
   def deepList(depth: Int = -1): Iterator[Path] =
-    if (depth < 0) list ++ (dirs flatMap (_ deepList (depth)))
+    if (depth < 0) list ++ (dirs flatMap (_ deepList depth))
     else if (depth == 0) Iterator.empty
     else list ++ (dirs flatMap (_ deepList (depth - 1)))
 }

--- a/compiler/src/dotty/tools/io/Directory.scala
+++ b/compiler/src/dotty/tools/io/Directory.scala
@@ -67,7 +67,7 @@ class Directory(jpath: JPath) extends Path(jpath) {
    *  until it runs out of contents.
    */
   def deepList(depth: Int = -1): Iterator[Path] =
-    if (depth < 0) list ++ (dirs flatMap (_ deepList depth))
+    if (depth < 0) list ++ dirs.flatMap(_.deepList(depth))
     else if (depth == 0) Iterator.empty
     else list ++ (dirs flatMap (_ deepList (depth - 1)))
 }

--- a/compiler/src/dotty/tools/io/Directory.scala
+++ b/compiler/src/dotty/tools/io/Directory.scala
@@ -69,5 +69,5 @@ class Directory(jpath: JPath) extends Path(jpath) {
   def deepList(depth: Int = -1): Iterator[Path] =
     if (depth < 0) list ++ dirs.flatMap(_.deepList(depth))
     else if (depth == 0) Iterator.empty
-    else list ++ (dirs flatMap (_ deepList (depth - 1)))
+    else list ++ dirs.flatMap(_.deepList(depth - 1))
 }

--- a/compiler/src/dotty/tools/io/Streamable.scala
+++ b/compiler/src/dotty/tools/io/Streamable.scala
@@ -125,9 +125,9 @@ object Streamable {
     finally stream.close()
 
   def bytes(is: => InputStream): Array[Byte] =
-    (new Bytes {
+    new Bytes {
       def inputStream() = is
-    }).toByteArray()
+    }.toByteArray()
 
   def slurp(is: => InputStream)(implicit codec: Codec): String =
     new Chars { def inputStream() = is } slurp codec

--- a/compiler/src/dotty/tools/io/VirtualDirectory.scala
+++ b/compiler/src/dotty/tools/io/VirtualDirectory.scala
@@ -18,7 +18,7 @@ extends AbstractFile {
   def path: String =
     maybeContainer match {
       case None => name
-      case Some(parent) => parent.path+'/'+ name
+      case Some(parent) => parent.path + '/' + name
     }
 
   def absolute: AbstractFile = this
@@ -54,7 +54,7 @@ extends AbstractFile {
 
   override def fileNamed(name: String): AbstractFile =
     Option(lookupName(name, directory = false)) getOrElse {
-      val newFile = new VirtualFile(name, path+'/'+name)
+      val newFile = new VirtualFile(name, path + '/' + name)
       files(name) = newFile
       newFile
     }

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -11,7 +11,7 @@ import java.nio.file.Files
 import java.util.zip.{ ZipEntry, ZipFile }
 import java.util.jar.Manifest
 import scala.collection.mutable
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** An abstraction for zip files and streams.  Everything is written the way
  *  it is for performance: we come through here a lot on every run.  Be careful

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -85,7 +85,7 @@ abstract class ZipArchive(override val jpath: JPath) extends AbstractFile with E
     }
   }
 
-  private def ensureDir(dirs: mutable.Map[String, DirEntry], path: String, zipEntry: ZipEntry): DirEntry =
+  private def ensureDir(dirs: mutable.Map[String, DirEntry], path: String): DirEntry =
     //OPT inlined from getOrElseUpdate; saves ~50K closures on test run.
     // was:
     // dirs.getOrElseUpdate(path, {
@@ -97,7 +97,7 @@ abstract class ZipArchive(override val jpath: JPath) extends AbstractFile with E
     dirs get path match {
       case Some(v) => v
       case None =>
-        val parent = ensureDir(dirs, dirName(path), null)
+        val parent = ensureDir(dirs, dirName(path))
         val dir    = new DirEntry(path, parent)
         parent.entries(baseName(path)) = dir
         dirs(path) = dir
@@ -105,8 +105,8 @@ abstract class ZipArchive(override val jpath: JPath) extends AbstractFile with E
     }
 
   protected def getDir(dirs: mutable.Map[String, DirEntry], entry: ZipEntry): DirEntry = {
-    if (entry.isDirectory) ensureDir(dirs, entry.getName, entry)
-    else ensureDir(dirs, dirName(entry.getName), null)
+    if (entry.isDirectory) ensureDir(dirs, entry.getName)
+    else ensureDir(dirs, dirName(entry.getName))
   }
 }
 /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -240,8 +240,8 @@ final class ManifestResources(val url: URL) extends ZipArchive(null) {
   private def resourceInputStream(path: String): InputStream = {
     new FilterInputStream(null) {
       override def read(): Int = {
-        if(in == null) in = Thread.currentThread().getContextClassLoader().getResourceAsStream(path)
-        if(in == null) throw new RuntimeException(path + " not found")
+        if (in == null) in = Thread.currentThread().getContextClassLoader().getResourceAsStream(path)
+        if (in == null) throw new RuntimeException(path + " not found")
         super.read()
       }
 


### PR DESCRIPTION
According to [Scala Standard Library](https://www.scala-lang.org/api/current/scala/collection/JavaConverters$.html), JavaConverters has deprecated since Scala version 2.13.0, so I replaced it.

Also, I refactored some code formats.