### PR TITLE
Update dotty-cps-async 2020-06-15

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -384,8 +384,7 @@ class CommunityBuildTest:
   @Test def scodecBits = projects.scodecBits.run()
   @Test def scodec = projects.scodec.run()
   @Test def scalaParserCombinators = projects.scalaParserCombinators.run()
-  // blocked on #9074
-  //@Test def dottyCpsAsync = projects.dottyCpsAsync.run()
+  @Test def dottyCpsAsync = projects.dottyCpsAsync.run()
   @Test def scalaz = projects.scalaz.run()
   @Test def endpoints = projects.endpoints.run()
 end CommunityBuildTest


### PR DESCRIPTION
implement a workaround for #9704;  update to the latest published state.