### PR TITLE
Fix #8649: Remove @uncheckedVariance on defaults

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -550,13 +550,9 @@ object desugar {
     //     def _1: T1 = this.p1
     //     ...
     //     def _N: TN = this.pN
-    //     def copy(p1: T1 = p1: @uncheckedVariance, ...,
-    //              pN: TN = pN: @uncheckedVariance)(moreParams) =
+    //     def copy(p1: T1 = p1, ...,
+    //              pN: TN = pN)(moreParams) =
     //       new C[...](p1, ..., pN)(moreParams)
-    //
-    // Note: copy default parameters need @uncheckedVariance; see
-    // neg/t1843-variances.scala for a test case. The test would give
-    // two errors without @uncheckedVariance, one of them spurious.
     val caseClassMeths = {
       def syntheticProperty(name: TermName, tpt: Tree, rhs: Tree) =
         DefDef(name, Nil, Nil, tpt, rhs).withMods(synthetic)
@@ -573,10 +569,8 @@ object desugar {
         })
         if (mods.is(Abstract) || hasRepeatedParam) Nil  // cannot have default arguments for repeated parameters, hence copy method is not issued
         else {
-          def copyDefault(vparam: ValDef) =
-            makeAnnotated("scala.annotation.unchecked.uncheckedVariance", refOfDef(vparam))
           val copyFirstParams = derivedVparamss.head.map(vparam =>
-            cpy.ValDef(vparam)(rhs = copyDefault(vparam)))
+            cpy.ValDef(vparam)(rhs = refOfDef(vparam)))
           val copyRestParamss = derivedVparamss.tail.nestedMap(vparam =>
             cpy.ValDef(vparam)(rhs = EmptyTree))
           DefDef(nme.copy, derivedTparams, copyFirstParams :: copyRestParamss, TypeTree(), creatorExpr)

--- a/tests/pos/8649.scala
+++ b/tests/pos/8649.scala
@@ -1,0 +1,32 @@
+// This is crazy:
+type Get0 = OK[Int, Unit]
+def get0: Handler[Get0] = IO[Unit]()
+
+case class HandlerAlt[A](value: Handler[A])
+
+type Handler[API] = handler.Go[API]
+
+case class IO[A]()
+case class OK[A, B]()
+
+object handler:
+  // Starter for Handler reduction:
+  type Go[API] = API match
+    case _ =>
+      HandlerSingle[API]
+
+  type HandlerSingle[X] = X match
+    case OK[_, response] =>
+      IO[response]
+
+object Minimized {
+  case class HandlerAlt[A](value: M2[A])
+
+  type M1[X] = X match {
+    case _ => M2[X]
+  }
+
+  type M2[X] = X match {
+    case Int => String
+  }
+}


### PR DESCRIPTION
The comment in `Desugar.scala` doesn't apply (anymore?), `neg/t1843-variances.scala` has a single error at the expected place.

The generated code for these annotations had a weird type ascription that, I believe, cannot be written in source. Therefore this also fixes #8649.