### PR TITLE
Change order of override error checks

### DIFF
--- a/tests/neg/override-extension_normal-methods.check
+++ b/tests/neg/override-extension_normal-methods.check
@@ -1,0 +1,10 @@
+-- Error: tests/neg/override-extension_normal-methods.scala:6:6 --------------------------------------------------------
+6 |  def m[T](x: T): String  = "normal method" // error: normal method, cannot override an extension method. Also needs `override' modifier (but this error should be obfuscated).
+  |      ^
+  |      error overriding method m in trait A of type [T](t: T): String;
+  |        method m of type [T](x: T): String is a normal method, cannot override an extension method
+-- Error: tests/neg/override-extension_normal-methods.scala:14:6 -------------------------------------------------------
+14 |  def [T](t: T).m: String = "extrnsion method" // error: extension method, cannot override an normal method. Also needs `override' modifier (but this error should be obfuscated).
+   |      ^
+   |      error overriding method m in trait B of type [T](x: T): String;
+   |        method m of type [T](t: T): String is an extension method, cannot override a normal method

--- a/tests/neg/override-extension_normal-methods.scala
+++ b/tests/neg/override-extension_normal-methods.scala
@@ -1,0 +1,15 @@
+trait A {
+  def [T](t: T).m: String = "extrnsion method"
+}
+
+trait AAA extends A {
+  def m[T](x: T): String  = "normal method" // error: normal method, cannot override an extension method. Also needs `override' modifier (but this error should be obfuscated).
+}
+
+trait B {
+  def m[T](x: T): String  = "normal method"
+}
+
+trait BBB extends B {
+  def [T](t: T).m: String = "extrnsion method" // error: extension method, cannot override an normal method. Also needs `override' modifier (but this error should be obfuscated).
+}


### PR DESCRIPTION
The error check that is not possible to override an extension/normal
methods, because it should be as declared. Should come before the check
that the `override` modifier is needed.

Example of what the PR is trying to improve:
```scala
trait A { def [T](t: T).m: String = "trait"}
given A { def m[T](x: T): String  = "given" }
```

On the code above we will have the error:
```
error overriding method m in trait A of type [T](t: T): String;
method m of type [T](x: T): String needs `override` modifier
```

Just to discover after adding the `override` modifier that:
```
error overriding method m in trait A of type [T](t: T): String;
method m of type [T](x: T): String is a normal method, cannot override an extension method
```