### PR TITLE
Fix #9185: Look at multiple failures when trying an extension method

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -351,7 +351,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case id: Trees.SearchFailureIdent[?] =>
         tree.typeOpt match {
           case reason: Implicits.SearchFailureType =>
-            toText(id.name) ~ "implicitly[" ~ toText(reason.clarify(reason.expectedType)) ~ "]"
+            toText(id.name) ~ "summon[" ~ toText(reason.clarify(reason.expectedType)) ~ "]"
           case _ =>
             toText(id.name)
         }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -351,7 +351,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case id: Trees.SearchFailureIdent[?] =>
         tree.typeOpt match {
           case reason: Implicits.SearchFailureType =>
-            toText(id.name) ~ "summon[" ~ toText(reason.clarify(reason.expectedType)) ~ "]"
+            toText(id.name)
+            ~ ("summon[" ~ toText(reason.clarify(reason.expectedType)) ~ "]").close
           case _ =>
             toText(id.name)
         }

--- a/compiler/src/dotty/tools/dotc/printing/Showable.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Showable.scala
@@ -22,6 +22,11 @@ trait Showable extends Any {
   /** The string representation of this showable element. */
   def show(implicit ctx: Context): String = toText(ctx.printer).show
 
+  /** The string representation with each line after the first one indented
+   *  by the given given margin (in spaces).
+   */
+  def showIndented(margin: Int)(using Context): String = show.replace("\n", "\n" + " " * margin)
+
   /** The summarized string representation of this showable element.
    *  Recursion depth is limited to some smallish value. Default is
    *  Config.summarizeDepth.

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -379,10 +379,10 @@ object Implicits {
   }
 
   object SearchFailure {
-    def apply(tpe: SearchFailureType)(implicit src: SourceFile): SearchFailure = {
-      val id =
-        if (tpe.isInstanceOf[AmbiguousImplicits]) "/* ambiguous */"
-        else "/* missing */"
+    def apply(tpe: SearchFailureType)(using Context): SearchFailure = {
+      val id = tpe match
+        case tpe: AmbiguousImplicits => i"/* ambiguous: ${tpe.explanation} */"
+        case _ => "/* missing */"
       SearchFailure(untpd.SearchFailureIdent(id.toTermName).withTypeUnchecked(tpe))
     }
   }
@@ -451,7 +451,7 @@ object Implicits {
   @sharable object NoMatchingImplicits extends NoMatchingImplicits(NoType, EmptyTree, OrderingConstraint.empty)
 
   @sharable val NoMatchingImplicitsFailure: SearchFailure =
-    SearchFailure(NoMatchingImplicits)(NoSource)
+    SearchFailure(NoMatchingImplicits)(using NoContext)
 
   /** An ambiguous implicits failure */
   class AmbiguousImplicits(val alt1: SearchSuccess, val alt2: SearchSuccess, val expectedType: Type, val argument: Tree) extends SearchFailureType {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -478,6 +478,10 @@ object Implicits {
     def explanation(using Context): String =
       em"${err.refStr(ref)} produces a diverging implicit search when trying to $qualify"
   }
+
+  class FailedExtension(extApp: Tree, val expectedType: Type) extends SearchFailureType:
+    def argument = EmptyTree
+    def explanation(using Context) = em"$extApp does not $qualify"
 }
 
 import Implicits._

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -150,38 +150,7 @@ trait TypeAssigner {
       errorType(ex"$qualType does not have a constructor", tree.sourcePos)
     else {
       val kind = if (name.isTypeName) "type" else "value"
-      def addendum =
-        val attempts: List[Tree] = qual1.getAttachment(Typer.HiddenSearchFailure) match
-          case Some(failures) =>
-            for failure <- failures
-                if !failure.reason.isInstanceOf[Implicits.NoMatchingImplicits]
-            yield failure.tree
-          case _ => Nil
-        if qualType.derivesFrom(defn.DynamicClass) then
-          "\npossible cause: maybe a wrong Dynamic method signature?"
-        else if attempts.nonEmpty then
-          val extMethods =
-            if attempts.length > 1 then "Extension methods were"
-            else "An extension method was"
-          val attemptStrings = attempts.map(_.showIndented(4))
-          i""".
-            |$extMethods tried, but could not be fully constructed:
-            |
-            |    $attemptStrings%\nor\n    %"""
-        else if tree.hasAttachment(desugar.MultiLineInfix) then
-          i""".
-              |Note that `$name` is treated as an infix operator in Scala 3.
-              |If you do not want that, insert a `;` or empty line in front
-              |or drop any spaces behind the operator."""
-        else if qualType.isBottomType then
-          ""
-        else
-          val add = importSuggestionAddendum(
-            ViewProto(qualType.widen,
-              SelectionProto(name, WildcardType, NoViewsAllowed, privateOK = false)))
-          if add.isEmpty then ""
-          else ", but could be made available as an extension method." ++ add
-      end addendum
+      def addendum = err.selectErrorAddendum(tree, qual1, qualType, importSuggestionAddendum)
       errorType(NotAMember(qualType, name, kind, addendum), tree.sourcePos)
     }
   }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -151,27 +151,36 @@ trait TypeAssigner {
     else {
       val kind = if (name.isTypeName) "type" else "value"
       def addendum =
-        if (qualType.derivesFrom(defn.DynamicClass))
+        val attempts: List[Tree] = qual1.getAttachment(Typer.HiddenSearchFailure) match
+          case Some(failures) =>
+            for failure <- failures
+                if !failure.reason.isInstanceOf[Implicits.NoMatchingImplicits]
+            yield failure.tree
+          case _ => Nil
+        if qualType.derivesFrom(defn.DynamicClass) then
           "\npossible cause: maybe a wrong Dynamic method signature?"
-        else qual1.getAttachment(Typer.HiddenSearchFailure) match
-          case Some(failure) if !failure.reason.isInstanceOf[Implicits.NoMatchingImplicits] =>
-            i""".
-              |An extension method was tried, but could not be fully constructed:
-              |
-              |    ${failure.tree.show.replace("\n", "\n    ")}"""
-          case _ =>
-            if (tree.hasAttachment(desugar.MultiLineInfix))
-              i""".
-                 |Note that `$name` is treated as an infix operator in Scala 3.
-                 |If you do not want that, insert a `;` or empty line in front
-                 |or drop any spaces behind the operator."""
-            else if qualType.isBottomType then ""
-            else
-              var add = importSuggestionAddendum(
-                ViewProto(qualType.widen,
-                  SelectionProto(name, WildcardType, NoViewsAllowed, privateOK = false)))
-              if add.isEmpty then ""
-              else ", but could be made available as an extension method." ++ add
+        else if attempts.nonEmpty then
+          val extMethods =
+            if attempts.length > 1 then "Extension methods were"
+            else "An extension method was"
+          val attemptStrings = attempts.map(_.showIndented(4))
+          i""".
+            |$extMethods tried, but could not be fully constructed:
+            |
+            |    $attemptStrings%\nor\n    %"""
+        else if tree.hasAttachment(desugar.MultiLineInfix) then
+          i""".
+              |Note that `$name` is treated as an infix operator in Scala 3.
+              |If you do not want that, insert a `;` or empty line in front
+              |or drop any spaces behind the operator."""
+        else if qualType.isBottomType then
+          ""
+        else
+          val add = importSuggestionAddendum(
+            ViewProto(qualType.widen,
+              SelectionProto(name, WildcardType, NoViewsAllowed, privateOK = false)))
+          if add.isEmpty then ""
+          else ", but could be made available as an extension method." ++ add
       end addendum
       errorType(NotAMember(qualType, name, kind, addendum), tree.sourcePos)
     }

--- a/tests/neg/i9185.check
+++ b/tests/neg/i9185.check
@@ -1,0 +1,18 @@
+-- [E008] Not Found Error: tests/neg/i9185.scala:7:21 ------------------------------------------------------------------
+7 |  val value2 = "ola".pure  // error
+  |               ^^^^^^^^^^
+  |               value pure is not a member of String.
+  |               An extension method was tried, but could not be fully constructed:
+  |
+  |                   M.pure[A, F]("ola")(/* ambiguous */summon[M[F]])
+-- Error: tests/neg/i9185.scala:8:26 -----------------------------------------------------------------------------------
+8 |  val value3 = pure("ola") // error
+  |                          ^
+  |ambiguous implicit arguments: both object listMonad in object M and object optionMonad in object M match type M[F] of parameter m of method pure in object M
+-- [E008] Not Found Error: tests/neg/i9185.scala:11:16 -----------------------------------------------------------------
+11 |  val l = "abc".len  // error
+   |          ^^^^^^^^^
+   |          value len is not a member of String.
+   |          An extension method was tried, but could not be fully constructed:
+   |
+   |              M.len("abc")

--- a/tests/neg/i9185.check
+++ b/tests/neg/i9185.check
@@ -1,10 +1,12 @@
 -- [E008] Not Found Error: tests/neg/i9185.scala:7:21 ------------------------------------------------------------------
 7 |  val value2 = "ola".pure  // error
   |               ^^^^^^^^^^
-  |               value pure is not a member of String.
-  |               An extension method was tried, but could not be fully constructed:
+  |value pure is not a member of String.
+  |An extension method was tried, but could not be fully constructed:
   |
-  |                   M.pure[A, F]("ola")(/* ambiguous */summon[M[F]])
+  |    M.pure[A, F]("ola")(
+  |      /* ambiguous: both object listMonad in object M and object optionMonad in object M match type M[F] */summon[M[F]]
+  |    )
 -- Error: tests/neg/i9185.scala:8:26 -----------------------------------------------------------------------------------
 8 |  val value3 = pure("ola") // error
   |                          ^

--- a/tests/neg/i9185.scala
+++ b/tests/neg/i9185.scala
@@ -1,0 +1,12 @@
+trait M[F[_]] { def pure[A](x: A): F[A] }
+object M {
+  def [A, F[A]](x: A).pure(using m: M[F]): F[A] = m.pure(x)
+  given listMonad as M[List] { def pure[A](x: A): List[A] = List(x) }
+  given optionMonad as M[Option] { def pure[A](x: A): Option[A] = Some(x) }
+  val value1: List[String] = "ola".pure
+  val value2 = "ola".pure  // error
+  val value3 = pure("ola") // error
+
+  def (x: Int).len: Int = x
+  val l = "abc".len  // error
+}

--- a/tests/neg/implicitSearch.check
+++ b/tests/neg/implicitSearch.check
@@ -4,7 +4,7 @@
    |   no implicit argument of type Test.Ord[List[List[T]]] was found for parameter o of method sort in object Test.
    |   I found:
    |
-   |       Test.listOrd[T](Test.listOrd[T](/* missing */implicitly[Test.Ord[T]]))
+   |       Test.listOrd[T](Test.listOrd[T](/* missing */summon[Test.Ord[T]]))
    |
    |   But no implicit values were found that match type Test.Ord[T].
 -- Error: tests/neg/implicitSearch.scala:15:38 -------------------------------------------------------------------------

--- a/tests/neg/missing-implicit1.check
+++ b/tests/neg/missing-implicit1.check
@@ -47,30 +47,3 @@
 28 |  Array(1, 2, 3).first // error, no hint
    |  ^^^^^^^^^^^^^^^^^^^^
    |  value first is not a member of Array[Int]
--- Error: tests/neg/missing-implicit1.scala:44:4 -----------------------------------------------------------------------
-44 |  ff // error
-   |    ^
-   |    no implicit argument of type Zip[Option] was found for parameter xs of method ff
-   |
-   |    The following import might fix the problem:
-   |
-   |      import instances.zipOption
-   |
--- [E008] Not Found Error: tests/neg/missing-implicit1.scala:46:16 -----------------------------------------------------
-46 |  List(1, 2, 3).traverse(x => Option(x)) // error
-   |  ^^^^^^^^^^^^^^^^^^^^^^
-   |  value traverse is not a member of List[Int], but could be made available as an extension method.
-   |
-   |  The following import might make progress towards fixing the problem:
-   |
-   |    import instances.traverseList
-   |
--- Error: tests/neg/missing-implicit1.scala:50:42 ----------------------------------------------------------------------
-50 |    List(1, 2, 3).traverse(x => Option(x)) // error
-   |                                          ^
-   |no implicit argument of type Zip[Option] was found for an implicit parameter of method traverse in trait Traverse
-   |
-   |The following import might fix the problem:
-   |
-   |  import instances.zipOption
-   |

--- a/tests/neg/missing-implicit1.check
+++ b/tests/neg/missing-implicit1.check
@@ -25,25 +25,3 @@
    |
    |  import testObjectInstance.instances.zipOption
    |
--- [E008] Not Found Error: tests/neg/missing-implicit1.scala:26:16 -----------------------------------------------------
-26 |  List(1, 2, 3).first // error
-   |  ^^^^^^^^^^^^^^^^^^^
-   |  value first is not a member of List[Int], but could be made available as an extension method.
-   |
-   |  The following import might fix the problem:
-   |
-   |    import testObjectInstance.instances.first
-   |
--- [E008] Not Found Error: tests/neg/missing-implicit1.scala:27:16 -----------------------------------------------------
-27 |  List(1, 2, 3).second // error
-   |  ^^^^^^^^^^^^^^^^^^^^
-   |  value second is not a member of List[Int], but could be made available as an extension method.
-   |
-   |  The following import might fix the problem:
-   |
-   |    import testObjectInstance.instances.listExtension
-   |
--- [E008] Not Found Error: tests/neg/missing-implicit1.scala:28:17 -----------------------------------------------------
-28 |  Array(1, 2, 3).first // error, no hint
-   |  ^^^^^^^^^^^^^^^^^^^^
-   |  value first is not a member of Array[Int]

--- a/tests/neg/missing-implicit3.check
+++ b/tests/neg/missing-implicit3.check
@@ -4,6 +4,6 @@
    |no implicit argument of type ord.Ord[ord.Foo] was found for an implicit parameter of method sort in package ord.
    |I found:
    |
-   |    ord.Ord.ordered[A](/* missing */implicitly[ord.Foo => Comparable[? >: ord.Foo]])
+   |    ord.Ord.ordered[A](/* missing */summon[ord.Foo => Comparable[? >: ord.Foo]])
    |
    |But no implicit values were found that match type ord.Foo => Comparable[? >: ord.Foo].

--- a/tests/neg/missing-implicit4.check
+++ b/tests/neg/missing-implicit4.check
@@ -1,0 +1,27 @@
+-- Error: tests/neg/missing-implicit4.scala:14:4 -----------------------------------------------------------------------
+14 |  ff // error
+   |    ^
+   |    no implicit argument of type Zip[Option] was found for parameter xs of method ff
+   |
+   |    The following import might fix the problem:
+   |
+   |      import instances.zipOption
+   |
+-- [E008] Not Found Error: tests/neg/missing-implicit4.scala:16:16 -----------------------------------------------------
+16 |  List(1, 2, 3).traverse(x => Option(x)) // error
+   |  ^^^^^^^^^^^^^^^^^^^^^^
+   |  value traverse is not a member of List[Int], but could be made available as an extension method.
+   |
+   |  The following import might make progress towards fixing the problem:
+   |
+   |    import instances.traverseList
+   |
+-- Error: tests/neg/missing-implicit4.scala:20:42 ----------------------------------------------------------------------
+20 |    List(1, 2, 3).traverse(x => Option(x)) // error
+   |                                          ^
+   |no implicit argument of type Zip[Option] was found for an implicit parameter of method traverse in trait Traverse
+   |
+   |The following import might fix the problem:
+   |
+   |  import instances.zipOption
+   |

--- a/tests/neg/missing-implicit4.scala
+++ b/tests/neg/missing-implicit4.scala
@@ -1,4 +1,4 @@
-object testObjectInstance:
+def testLocalInstance =
   trait Zip[F[_]]
   trait Traverse[F[_]] {
     def [A, B, G[_] : Zip](fa: F[A]) traverse(f: A => G[B]): G[F[B]]
@@ -7,9 +7,6 @@ object testObjectInstance:
   object instances {
     given zipOption as Zip[Option] = ???
     given traverseList as Traverse[List] = ???
-    extension listExtension on [T](xs: List[T]):
-      def second: T = xs.tail.head
-    def [T](xs: List[T]) first: T = xs.head
   }
 
   def ff(using xs: Zip[Option]) = ???
@@ -22,8 +19,4 @@ object testObjectInstance:
     import instances.traverseList
     List(1, 2, 3).traverse(x => Option(x)) // error
   }
-
-  List(1, 2, 3).first // error
-  List(1, 2, 3).second // error
-  Array(1, 2, 3).first // error, no hint
-end testObjectInstance
+end testLocalInstance

--- a/tests/neg/missing-implicit5.check
+++ b/tests/neg/missing-implicit5.check
@@ -1,0 +1,22 @@
+-- [E008] Not Found Error: tests/neg/missing-implicit5.scala:15:16 -----------------------------------------------------
+15 |  List(1, 2, 3).first // error
+   |  ^^^^^^^^^^^^^^^^^^^
+   |  value first is not a member of List[Int], but could be made available as an extension method.
+   |
+   |  The following import might fix the problem:
+   |
+   |    import testObjectInstance.instances.first
+   |
+-- [E008] Not Found Error: tests/neg/missing-implicit5.scala:16:16 -----------------------------------------------------
+16 |  List(1, 2, 3).second // error
+   |  ^^^^^^^^^^^^^^^^^^^^
+   |  value second is not a member of List[Int], but could be made available as an extension method.
+   |
+   |  The following import might fix the problem:
+   |
+   |    import testObjectInstance.instances.listExtension
+   |
+-- [E008] Not Found Error: tests/neg/missing-implicit5.scala:17:17 -----------------------------------------------------
+17 |  Array(1, 2, 3).first // error, no hint
+   |  ^^^^^^^^^^^^^^^^^^^^
+   |  value first is not a member of Array[Int]

--- a/tests/neg/missing-implicit5.scala
+++ b/tests/neg/missing-implicit5.scala
@@ -12,14 +12,7 @@ object testObjectInstance:
     def [T](xs: List[T]) first: T = xs.head
   }
 
-  def ff(using xs: Zip[Option]) = ???
-
-  ff // error
-
-  List(1, 2, 3).traverse(x => Option(x)) // error
-
-  locally {
-    import instances.traverseList
-    List(1, 2, 3).traverse(x => Option(x)) // error
-  }
+  List(1, 2, 3).first // error
+  List(1, 2, 3).second // error
+  Array(1, 2, 3).first // error, no hint
 end testObjectInstance


### PR DESCRIPTION
Also: 

 - change `implicitly[...]` to `summon[...]` in error message
 - issue "extension method was tried" addendums also when no implicits were searched.