### PR TITLE
Refactor compiler io

### DIFF
--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -106,8 +106,8 @@ object ClassPath {
       dir.list.filter(x => filt(x.name) && (x.isDirectory || isJarOrZip(x))).map(_.path).toList
 
     if (pattern == "*") lsDir(Directory("."))
-    else if (pattern endsWith wildSuffix) lsDir(Directory(pattern dropRight 2))
-    else if (pattern contains '*') {
+    else if (pattern.endsWith(wildSuffix)) lsDir(Directory(pattern dropRight 2))
+    else if (pattern.contains('*')) {
       try {
         val regexp = ("^" + pattern.replace("""\*""", """.*""") + "$").r
         lsDir(Directory(pattern).parent, regexp.findFirstIn(_).isDefined)
@@ -118,17 +118,17 @@ object ClassPath {
   }
 
   /** Split classpath using platform-dependent path separator */
-  def split(path: String): List[String] = (path split pathSeparator).toList.filterNot(_ == "").distinct
+  def split(path: String): List[String] = path.split(pathSeparator).toList.filterNot(_ == "").distinct
 
   /** Join classpath using platform-dependent path separator */
-  def join(paths: String*): String  = paths filterNot (_ == "") mkString pathSeparator
+  def join(paths: String*): String  = paths.filterNot(_ == "").mkString(pathSeparator)
 
   /** Split the classpath, apply a transformation function, and reassemble it. */
   def map(cp: String, f: String => String): String = join(split(cp) map f: _*)
 
   /** Expand path and possibly expanding stars */
   def expandPath(path: String, expandStar: Boolean = true): List[String] =
-    if (expandStar) split(path) flatMap expandS
+    if (expandStar) split(path).flatMap(expandS)
     else split(path)
 
   /** Expand dir out to contents, a la extdir */

--- a/compiler/src/dotty/tools/io/Jar.scala
+++ b/compiler/src/dotty/tools/io/Jar.scala
@@ -46,12 +46,12 @@ class Jar(file: File) {
   lazy val jarFile: JarFile  = new JarFile(file.jpath.toFile)
   lazy val manifest: Option[Manifest] = withJarInput(s => Option(s.getManifest))
 
-  def mainClass: Option[String]     = manifest map (f => f(Name.MAIN_CLASS))
+  def mainClass: Option[String]     = manifest.map(_(Name.MAIN_CLASS))
   /** The manifest-defined classpath String if available. */
   def classPathString: Option[String] =
-    for (m <- manifest ; cp <- m.attrs get Name.CLASS_PATH) yield cp
+    for (m <- manifest ; cp <- m.attrs.get(Name.CLASS_PATH)) yield cp
   def classPathElements: List[String] = classPathString match {
-    case Some(s)  => s split "\\s+" toList
+    case Some(s)  => s.split("\\s+").toList
     case _        => Nil
   }
 

--- a/compiler/src/dotty/tools/io/Jar.scala
+++ b/compiler/src/dotty/tools/io/Jar.scala
@@ -9,7 +9,7 @@ package io
 
 import java.io.{ InputStream, OutputStream, DataOutputStream }
 import java.util.jar._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import Attributes.Name
 import scala.language.postfixOps

--- a/compiler/src/dotty/tools/io/JarArchive.scala
+++ b/compiler/src/dotty/tools/io/JarArchive.scala
@@ -2,7 +2,7 @@ package dotty.tools.io
 
 import java.nio.file.{FileSystemAlreadyExistsException, FileSystems}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * This class implements an [[AbstractFile]] backed by a jar

--- a/compiler/src/dotty/tools/io/Path.scala
+++ b/compiler/src/dotty/tools/io/Path.scala
@@ -44,9 +44,9 @@ object Path {
     else name.substring(i + 1).toLowerCase
   }
 
-  def onlyDirs(xs: Iterator[Path]): Iterator[Directory] = xs filter (_.isDirectory) map (_.toDirectory)
-  def onlyDirs(xs: List[Path]): List[Directory] = xs filter (_.isDirectory) map (_.toDirectory)
-  def onlyFiles(xs: Iterator[Path]): Iterator[File] = xs filter (_.isFile) map (_.toFile)
+  def onlyDirs(xs: Iterator[Path]): Iterator[Directory] = xs.filter(_.isDirectory).map(_.toDirectory)
+  def onlyDirs(xs: List[Path]): List[Directory] = xs.filter(_.isDirectory).map(_.toDirectory)
+  def onlyFiles(xs: Iterator[Path]): Iterator[File] = xs.filter(_.isFile).map(_.toFile)
 
   def roots: List[Path] = FileSystems.getDefault.getRootDirectories.iterator().asScala.map(Path.apply).toList
 
@@ -103,7 +103,7 @@ class Path private[io] (val jpath: JPath) {
    */
   def walkFilter(cond: Path => Boolean): Iterator[Path] =
     if (isFile) toFile walkFilter cond
-    else if (isDirectory) toDirectory walkFilter cond
+    else if (isDirectory) toDirectory.walkFilter(cond)
     else Iterator.empty
 
   /** Equivalent to walkFilter(_ => true).

--- a/compiler/src/dotty/tools/io/Path.scala
+++ b/compiler/src/dotty/tools/io/Path.scala
@@ -10,9 +10,7 @@ import java.nio.file._
 import java.net.{URI, URL}
 import java.nio.file.attribute.{BasicFileAttributes, FileTime}
 import java.io.IOException
-
-import scala.collection.JavaConverters._
-
+import scala.jdk.CollectionConverters._
 import scala.util.Random.alphanumeric
 
 /** An abstraction for filesystem paths.  The differences between

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -11,7 +11,7 @@ import java.io.{InputStream, OutputStream}
 /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 class PlainDirectory(givenPath: Directory) extends PlainFile(givenPath) {
   override def isDirectory: Boolean = true
-  override def iterator(): Iterator[PlainFile] = givenPath.list filter (_.exists) map (x => new PlainFile(x))
+  override def iterator(): Iterator[PlainFile] = givenPath.list.filter(_.exists).map(new PlainFile(_))
   override def delete(): Unit = givenPath.deleteRecursively()
 }
 


### PR DESCRIPTION
According to [Scala Standard Library](https://www.scala-lang.org/api/current/scala/collection/JavaConverters$.html),`JavaConverters` has deprecated since Scala version 2.13.0, so I replaced it. 

Also, I refactored some code formats to clear method chains and arguments.