### PR TITLE
Add toList method to Tuple

### DIFF
--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -11,6 +11,10 @@ sealed trait Tuple extends Product {
   inline def toArray: Array[Object] =
     scala.runtime.Tuple.toArray(this)
 
+  /** Create a copy this tuple as a List */
+  inline def toList: List[Object] =
+    toArray.toList
+
   /** Create a copy this tuple as an IArray */
   inline def toIArray: IArray[Object] =
     scala.runtime.Tuple.toIArray(this)

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -13,7 +13,8 @@ sealed trait Tuple extends Product {
 
   /** Create a copy this tuple as a List */
   inline def toList: List[Union[this.type]] =
-    toArray.toList.asInstanceOf[List[Union[this.type]]]
+    this.productIterator.toList
+      .asInstanceOf[List[Union[this.type]]]
 
   /** Create a copy this tuple as an IArray */
   inline def toIArray: IArray[Object] =

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -12,8 +12,8 @@ sealed trait Tuple extends Product {
     scala.runtime.Tuple.toArray(this)
 
   /** Create a copy this tuple as a List */
-  inline def toList: List[Object] =
-    toArray.toList
+  inline def toList: List[Union[this.type]] =
+    toArray.toList.asInstanceOf[List[Union[this.type]]]
 
   /** Create a copy this tuple as an IArray */
   inline def toIArray: IArray[Object] =
@@ -171,6 +171,11 @@ object Tuple {
    * `(Ti+1, ..., Tn)`.
    */
   type Split[T <: Tuple, N <: Int] = (Take[T, N], Drop[T, N])
+
+  /** Given a tuple `(T1, ..., Tn)`, returns a union of its
+   *  member types: `T1 | ... | Tn`.
+   */
+  type Union[T <: Tuple] = Fold[T, Nothing, [x, y] =>> x | y]
 
   /** Empty tuple */
   def apply(): EmptyTuple = EmptyTuple

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -174,7 +174,7 @@ object Tuple {
   type Split[T <: Tuple, N <: Int] = (Take[T, N], Drop[T, N])
 
   /** Given a tuple `(T1, ..., Tn)`, returns a union of its
-   *  member types: `T1 | ... | Tn`.
+   *  member types: `T1 | ... | Tn`. Returns `Nothing` if the tuple is empty.
    */
   type Union[T <: Tuple] = Fold[T, Nothing, [x, y] =>> x | y]
 

--- a/tests/run/toList.check
+++ b/tests/run/toList.check
@@ -1,0 +1,3 @@
+List(1, 2, 3)
+List(1, foo, 3)
+List(1, foo, 1)

--- a/tests/run/toList.scala
+++ b/tests/run/toList.scala
@@ -1,0 +1,7 @@
+@main def Test =
+  val l1: List[Int] = (1, 2, 3).toList
+  val l2: List[Int | String] = (1, "foo", 3).toList
+  val l3: List[Int | String | 1] = (1, "foo", 1).toList
+  println(l1)
+  println(l2)
+  println(l3)


### PR DESCRIPTION
Usually you do not want to work with Arrays
when doing typeclass derivation, you want Lists.
Currently the only way to get a List from a
Tuple is `toArray.toList`, which is cumbersome.