### PR TITLE
Fix #9068: Don't duplicate _N selectors

### DIFF
--- a/tests/run/i9068.scala
+++ b/tests/run/i9068.scala
@@ -1,0 +1,12 @@
+case class MyClass(v1: Int, v2: Int, v3: Int, v4: Int) extends Product3[Int, Int, Int]:
+  val _1: Int = v2
+  def _2: Int = v3
+  var _3: Int = v4
+  def _4(x: Boolean): Int = 0
+
+@main def Test =
+  val c = MyClass(1, 2, 3, 4)
+  assert(c._1 == 2)
+  assert(c._2 == 3)
+  assert(c._3 == 4)
+  assert(c._4 == 4)


### PR DESCRIPTION
Don't generate _N selectors for case classes if a parameterless selector
is defined in same class.