### PR TITLE
Fix #9014: On implicit search failure print original inline call

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -786,10 +786,14 @@ trait Implicits { self: Typer =>
       case _ =>
         arg.tpe match {
           case tpe: SearchFailureType =>
+            val original = arg match
+              case Inlined(call, _, _) => call
+              case _ => arg
+
             i"""$headline.
               |I found:
               |
-              |    ${arg.show.replace("\n", "\n    ")}
+              |    ${original.show.replace("\n", "\n    ")}
               |
               |But ${tpe.explanation}."""
         }

--- a/tests/neg-macros/i9014.check
+++ b/tests/neg-macros/i9014.check
@@ -1,0 +1,10 @@
+
+-- Error: tests/neg-macros/i9014/Test_2.scala:1:23 ---------------------------------------------------------------------
+1 |val tests = summon[Bar] // error
+  |                       ^
+  |                no implicit argument of type Bar was found for parameter x of method summon in object DottyPredef.
+  |                I found:
+  |
+  |                    given_Bar
+  |
+  |                But method given_Bar does not match type Bar.

--- a/tests/neg-macros/i9014/Macros_1.scala
+++ b/tests/neg-macros/i9014/Macros_1.scala
@@ -1,0 +1,4 @@
+import scala.quoted._
+trait Bar
+inline given as Bar = ${ impl }
+def impl(using qctx: QuoteContext): Expr[Bar] = qctx.throwError("Failed to expand!")

--- a/tests/neg-macros/i9014/Test_2.scala
+++ b/tests/neg-macros/i9014/Test_2.scala
@@ -1,0 +1,1 @@
+val tests = summon[Bar] // error

--- a/tests/neg/i9014.check
+++ b/tests/neg/i9014.check
@@ -1,0 +1,9 @@
+-- Error: tests/neg/i9014.scala:4:25 -----------------------------------------------------------------------------------
+4 |  val tests = summon[Bar] // error
+  |                         ^
+  |                no implicit argument of type Bar was found for parameter x of method summon in object DottyPredef.
+  |                I found:
+  |
+  |                    Bar.given_Bar
+  |
+  |                But method given_Bar in object Bar does not match type Bar.

--- a/tests/neg/i9014.scala
+++ b/tests/neg/i9014.scala
@@ -1,0 +1,4 @@
+trait Bar
+object Bar:
+  inline given as Bar = compiletime.error("Failed to expand!")
+  val tests = summon[Bar] // error


### PR DESCRIPTION
This it is possible to copy/paste the original call that failed and get the error message.