### PR TITLE
Fix #9224: Refine stopAtStatic criterion

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -389,6 +389,14 @@ object TypeOps:
       @threadUnsafe lazy val forbidden = symsToAvoid.toSet
       def toAvoid(sym: Symbol) = !sym.isStatic && forbidden.contains(sym)
       def partsToAvoid = new NamedPartsAccumulator(tp => toAvoid(tp.symbol))
+
+      /** True iff all NamedTypes on this prefix are static */
+      override def isStaticPrefix(pre: Type)(using Context): Boolean = pre match
+        case pre: NamedType =>
+          val sym = pre.currentSymbol
+          sym.is(Package) || sym.isStatic && isStaticPrefix(pre.prefix)
+        case _ => true
+
       def apply(tp: Type): Type = tp match {
         case tp: TermRef
         if toAvoid(tp.symbol) || partsToAvoid(mutable.Set.empty, tp.info).nonEmpty =>

--- a/tests/pos/i9224.scala
+++ b/tests/pos/i9224.scala
@@ -1,0 +1,3 @@
+object foo { def test = 23 }
+
+def bar(x: Any) = x match { case m: foo.type => m.test } // need to call m.test


### PR DESCRIPTION
Refine stopAtStatic criterion for the avoid mao. We now stop only
if the symbol of a named type is static AND all named types on
the prefix have static symbols.