### PR TITLE
Improve explain message when token expected

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1112,7 +1112,7 @@ object messages {
     def explain =
       if (Tokens.isIdentifier(expected) && Tokens.isKeyword(found))
         s"""
-         |If you want to use $foundText as identifier, you may put it in backticks: `$foundText`.""".stripMargin
+         |If you want to use $foundText as identifier, you may put it in backticks: `${Tokens.tokenString(found)}`.""".stripMargin
       else
         ""
   }


### PR DESCRIPTION
Print

```shell
If you want to use 'do' as identifier, you may put it in backticks: `do`.
```

Instead of

```shell
If you want to use 'do' as identifier, you may put it in backticks: `'do'`.
```