### PR TITLE
Fix typo in typeclass derivation

### DIFF
--- a/docs/docs/reference/contextual/derivation.md
+++ b/docs/docs/reference/contextual/derivation.md
@@ -253,7 +253,7 @@ trait Eq[T] {
 }
 
 object Eq {
-  given Eq[Int] as {
+  given Eq[Int] {
     def eqv(x: Int, y: Int) = x == y
   }
 


### PR DESCRIPTION
Fix typo in typeclass derivation

Otherwise, the code does not compile.