### PR TITLE
Drop PreName and its associated implicit conversions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -15,12 +15,18 @@ import printing.Formatting._
 /** This object provides useful implicit decorators for types defined elsewhere */
 object Decorators {
 
-  /** Turns Strings into PreNames, adding toType/TermName methods */
-  implicit class PreNamedString(val s: String) extends AnyVal with PreName {
-    def toTypeName: TypeName = typeName(s)
-    def toTermName: TermName = termName(s)
-    def toText(printer: Printer): Text = Str(s)
-  }
+  /** Extension methods for toType/TermName methods on strings.
+   *  They are in an implicit object for now, so that we can import decorators
+   *  with a normal wildcard. In the future, once #9255 is in trunk, replace with
+   *  a simple collective extension.
+   */
+  implicit object PreNamedString:
+    def (pn: PreName).toTypeName: TypeName = pn match
+      case s: String => typeName(s)
+      case n: Name => n.toTypeName
+    def (pn: PreName).toTermName: TermName = pn match
+      case s: String => termName(s)
+      case n: Name => n.toTermName
 
   implicit class StringDecorator(val s: String) extends AnyVal {
     def splitWhere(f: Char => Boolean, doDropIndex: Boolean): Option[(String, String)] = {

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -853,7 +853,7 @@ class Definitions {
     "lombok.NonNull" ::
     "reactor.util.annotation.NonNull" ::
     "reactor.util.annotation.NonNullApi" ::
-    "io.reactivex.annotations.NonNull" :: Nil map PreNamedString)
+    "io.reactivex.annotations.NonNull" :: Nil)
 
   // convenient one-parameter method types
   def methOfAny(tp: Type): MethodType = MethodType(List(AnyType), tp)

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -17,13 +17,10 @@ import scala.annotation.internal.sharable
 object Names {
   import NameKinds._
 
-  /** A common class for things that can be turned into names.
-   *  Instances are both names and strings, the latter via a decorator.
+  /** Things that can be turned into names with `totermName` and `toTypeName`
+   *  Decorators defines implements these as extension methods for strings.
    */
-  trait PreName extends Any with Showable {
-    def toTypeName: TypeName
-    def toTermName: TermName
-  }
+  type PreName = Name | String
 
   /** A common superclass of Name and Symbol. After bootstrap, this should be
    *  just the type alias Name | Symbol
@@ -35,7 +32,7 @@ object Names {
    *  in a name table. A derived term name adds a tag, and possibly a number
    *  or a further simple name to some other name.
    */
-  abstract class Name extends Designator, PreName derives Eql {
+  abstract class Name extends Designator, Showable derives Eql {
 
     /** A type for names of the same kind as this name */
     type ThisName <: Name

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -9,7 +9,7 @@ import config.Config
 import Contexts._, Symbols._, Flags._, SymDenotations._, Types._, Scopes._, Names._
 import NameOps._
 import StdNames.str
-import Decorators.{PreNamedString, StringInterpolators}
+import Decorators.StringInterpolators
 import classfile.ClassfileParser
 import util.Stats
 import Decorators._

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -326,7 +326,7 @@ object messages {
       // to the name of the missing member
       def closest: List[(Int, String)] = candidates
         .toList
-        .map(n => (distance(n.show, missing), n))
+        .map(n => (distance(n, missing), n))
         .filter((d, n) => d <= maxDist && d < missing.length && d < n.length)
         .sorted  // sort by distance first, alphabetically second
 


### PR DESCRIPTION
That was not so hard. We can make PreName a union type and
add `toTermName` and `toTypeName` as extension methods on strings.

