### PR TITLE
Fix crash on implicit search involving higher-kinded types

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -675,12 +675,11 @@ trait ImplicitRunInfo:
           WildcardType
         else
           seen.addEntry(t)
-          apply(
-            t.underlying match
-              case TypeBounds(lo, hi) =>
-                if defn.isBottomTypeAfterErasure(lo) then hi
-                else AndType.make(lo, hi)
-              case u => u)
+          t.underlying match
+            case TypeBounds(lo, hi) =>
+              if defn.isBottomTypeAfterErasure(lo) then apply(hi)
+              else AndType.make(apply(lo), apply(hi))
+            case u => apply(u)
 
       def apply(t: Type) = t.dealias match
         case t: TypeRef =>

--- a/tests/pos/liftToAnchors-hk.scala
+++ b/tests/pos/liftToAnchors-hk.scala
@@ -1,0 +1,4 @@
+class Foo[F[_], F2[X] >: F[X]] {
+  def foo[A](using F[A] <:< F2[A]): Unit = {}
+  foo
+}


### PR DESCRIPTION
Previously, the test case crashed because it tried to create an
AndType of `[X] =>> <?>` and `[X] =>> Any`, but AndTypes can only
contain value types. Fixed by moving the AndType creation after having
recursively simplified the bounds with `apply` which always produces a
value type.