### PR TITLE
Fix #9295: Avoid recursive Dynamics conversion

### DIFF
--- a/tests/neg/i9295a.scala
+++ b/tests/neg/i9295a.scala
@@ -1,0 +1,9 @@
+import scala.language.dynamics
+
+class Foo extends Dynamic {
+  def applyDynamic(arg: Any): Foo = ???
+}
+object F {
+  val foo = new Foo
+  def baz = foo.blah(43) // error: method applyDynamic in class Foo does not take more parameters
+}

--- a/tests/neg/i9295b.scala
+++ b/tests/neg/i9295b.scala
@@ -1,0 +1,14 @@
+import scala.language.dynamics
+
+class Foo extends Dynamic {
+  def applyDynamic(arg: Any): Bar = ???
+}
+class Bar extends Dynamic {
+  def applyDynamic(arg: Any)(x: Int): Int = ???
+}
+object F {
+  val foo = new Foo
+  def baz = foo.blah(43) // error: method applyDynamic in class Foo does not take more parameters
+  def qux = foo.blah.blah(43) // error: value selectDynamic is not a member of Foo
+  def quxx = foo.blah().blah(43) // error: method applyDynamic in class Foo does not take more parameters
+}

--- a/tests/neg/i9295c.scala
+++ b/tests/neg/i9295c.scala
@@ -1,0 +1,12 @@
+import scala.language.dynamics
+
+class Foo extends Dynamic {
+  def selectDynamic(name: String)(using DummyImplicit): Bar = ???
+}
+
+class Bar extends Dynamic {
+  def applyDynamic(name: String)(x: Int) = ???
+}
+
+val foo = new Foo
+def baz = foo.blah(42) // error

--- a/tests/neg/i9295d.scala
+++ b/tests/neg/i9295d.scala
@@ -1,0 +1,12 @@
+import scala.language.dynamics
+
+class Foo extends Dynamic {
+  def applyDynamic(name: String)(): DummyImplicit ?=> Bar = ???
+}
+
+class Bar extends Dynamic {
+  def applyDynamic(name: String)(x: Int) = ???
+}
+
+val foo = new Foo
+def baz = foo.blah()(42) // error

--- a/tests/pos/i9295.scala
+++ b/tests/pos/i9295.scala
@@ -1,0 +1,12 @@
+import scala.language.dynamics
+
+class Foo extends Dynamic {
+  def applyDynamic(name: String)(): Bar = ???
+}
+
+class Bar extends Dynamic {
+  def applyDynamic(name: String)(x: Int) = ???
+}
+
+val foo = new Foo
+def baz = foo.blah().apply(42)

--- a/tests/pos/i9295b.scala
+++ b/tests/pos/i9295b.scala
@@ -1,0 +1,12 @@
+import scala.language.dynamics
+
+class Foo extends Dynamic {
+  def applyDynamic(name: String)()(using DummyImplicit): Bar = ???
+}
+
+class Bar extends Dynamic {
+  def applyDynamic(name: String)(x: Int) = ???
+}
+
+val foo = new Foo
+def baz = foo.blah().apply(42)

--- a/tests/pos/i9295c.scala
+++ b/tests/pos/i9295c.scala
@@ -1,0 +1,12 @@
+import scala.language.dynamics
+
+class Foo extends Dynamic {
+  def selectDynamic(name: String)(using DummyImplicit): Bar = ???
+}
+
+class Bar extends Dynamic {
+  def applyDynamic(name: String)(x: Int) = ???
+}
+
+val foo = new Foo
+def baz = foo.blah.apply(42)

--- a/tests/pos/i9295d.scala
+++ b/tests/pos/i9295d.scala
@@ -1,0 +1,12 @@
+import scala.language.dynamics
+
+class Foo extends Dynamic {
+  def applyDynamic(name: String)(): DummyImplicit ?=> DummyImplicit ?=> Bar = ???
+}
+
+class Bar extends Dynamic {
+  def applyDynamic(name: String)(x: Int) = ???
+}
+
+val foo = new Foo
+def baz = foo.blah().apply(42)


### PR DESCRIPTION
Avoid trying to apply `Dynamic` transformation on `apply` with a qualifier that already has
a been handled by the `Dynamic` transformation.