### PR TITLE
Remove scala.quoted.autolift implicit conversion

### DIFF
--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -328,10 +328,6 @@ def showExpr[T](expr: Expr[T])(using QuoteContext): Expr[String] = {
 That is, the `showExpr` method converts its `Expr` argument to a string (`code`), and lifts
 the result back to an `Expr[String]` using `Expr.apply`.
 
-**Note**: Lifting `String` to `Expr[String]` using `Expr(code)` can be omitted by importing an implicit
-conversion with `import scala.quoted.autolift`. The programmer is able to
-declutter slightly the code at the cost of readable _phase distinction_ between
-stages.
 
 ### Lifting Types
 
@@ -376,7 +372,8 @@ object Macros {
     ${ assertImpl('expr) }
 
   def assertImpl(expr: Expr[Boolean])(using QuoteContext) =
-    '{ if !($expr) then throw new AssertionError("failed assertion: " + ${expr.show}) }  // autolift is applied
+    val failMsg: Expr[String] = Expr("failed assertion: " + expr.show)
+    '{ if !($expr) then throw new AssertionError($failMsg) }
 }
 
 object App {

--- a/library/src-bootstrapped/scala/quoted/autolift.scala
+++ b/library/src-bootstrapped/scala/quoted/autolift.scala
@@ -1,4 +1,0 @@
-package scala.quoted
-
-/** Implicit conversion from a term of type `T` to an expression of type `Expr[T]` */
-given autolift[T](using Liftable[T], QuoteContext) as Conversion[T, Expr[T]] = Expr(_)

--- a/tests/disabled/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
+++ b/tests/disabled/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 

--- a/tests/disabled/run/xml-interpolation-3/XmlQuote_1.scala
+++ b/tests/disabled/run/xml-interpolation-3/XmlQuote_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 import scala.language.implicitConversions
 

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -1,6 +1,5 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 
 object Macro {

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -1,6 +1,5 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 
 object Macro {

--- a/tests/neg-macros/inline-macro-staged-interpreter/Macro_1.scala
+++ b/tests/neg-macros/inline-macro-staged-interpreter/Macro_1.scala
@@ -1,6 +1,5 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 
 object E {
@@ -27,7 +26,7 @@ trait E[T] {
 }
 
 case class I(n: Int) extends E[Int] {
-  def lift (using QuoteContext): Expr[Int] = n
+  def lift (using QuoteContext): Expr[Int] = Expr(n)
 }
 
 case class Plus[T](x: E[T], y: E[T])(implicit op: Plus2[T]) extends E[T] {

--- a/tests/neg-macros/inline-tuples-1/Macro_1.scala
+++ b/tests/neg-macros/inline-tuples-1/Macro_1.scala
@@ -1,28 +1,27 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
-  def tup1(tup: Expr[Tuple1[Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup2(tup: Expr[Tuple2[Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup3(tup: Expr[Tuple3[Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup4(tup: Expr[Tuple4[Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup5(tup: Expr[Tuple5[Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup6(tup: Expr[Tuple6[Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup7(tup: Expr[Tuple7[Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup8(tup: Expr[Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup9(tup: Expr[Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup10(tup: Expr[Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup11(tup: Expr[Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup12(tup: Expr[Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup13(tup: Expr[Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup14(tup: Expr[Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup15(tup: Expr[Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup16(tup: Expr[Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup17(tup: Expr[Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup18(tup: Expr[Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup19(tup: Expr[Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup20(tup: Expr[Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup21(tup: Expr[Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup22(tup: Expr[Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup1(tup: Expr[Tuple1[Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup2(tup: Expr[Tuple2[Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup3(tup: Expr[Tuple3[Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup4(tup: Expr[Tuple4[Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup5(tup: Expr[Tuple5[Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup6(tup: Expr[Tuple6[Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup7(tup: Expr[Tuple7[Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup8(tup: Expr[Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup9(tup: Expr[Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup10(tup: Expr[Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup11(tup: Expr[Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup12(tup: Expr[Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup13(tup: Expr[Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup14(tup: Expr[Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup15(tup: Expr[Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup16(tup: Expr[Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup17(tup: Expr[Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup18(tup: Expr[Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup19(tup: Expr[Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup20(tup: Expr[Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup21(tup: Expr[Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup22(tup: Expr[Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
 }

--- a/tests/neg-macros/quote-interpolator-core-old.scala
+++ b/tests/neg-macros/quote-interpolator-core-old.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 // This test checks the correct interpretation of the inlined value class
 
@@ -18,7 +17,7 @@ object FInterpolation {
   }
 
   def fInterpolation(sc: StringContext, args: Seq[Expr[Any]])(using QuoteContext): Expr[String] = {
-    val str: Expr[String] = sc.parts.mkString("")
+    val str: Expr[String] = Expr(sc.parts.mkString(""))
     val args1: Expr[Seq[Any]] = liftSeq(args)
     '{ $str.format($args1: _*) }
   }

--- a/tests/neg-macros/quote-macro-splice.scala
+++ b/tests/neg-macros/quote-macro-splice.scala
@@ -1,16 +1,15 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Test {
 
   inline def foo1: Int = { // error
     println()
-    ${ impl(1) }
+    ${ impl('{1}) }
   }
 
   inline def foo2: Int = { // error
-    ${ impl(1) }
-    ${ impl(2) }
+    ${ impl('{1}) }
+    ${ impl('{2}) }
   }
 
   inline def foo3: Int = { // error

--- a/tests/neg-macros/splice-in-top-level-splice-1.scala
+++ b/tests/neg-macros/splice-in-top-level-splice-1.scala
@@ -1,8 +1,7 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Foo {
   inline def foo(): Int = ${bar(${x})} // error
   def x(using QuoteContext): Expr[Int] = '{1}
-  def bar(i: Int)(using QuoteContext): Expr[Int] = i
+  def bar(i: Int)(using QuoteContext): Expr[Int] = Expr(i)
 }

--- a/tests/neg-staging/quote-run-in-macro-1/quoted_1.scala
+++ b/tests/neg-staging/quote-run-in-macro-1/quoted_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -8,6 +7,6 @@ object Macros {
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
   def fooImpl(i: Expr[Int])(using QuoteContext): Expr[Int] = {
     val y: Int = run(i)
-    y
+    Expr(y)
   }
 }

--- a/tests/pending/run/tasty-comments/quoted_1.scala
+++ b/tests/pending/run/tasty-comments/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 
 object Macros {

--- a/tests/pos-macros/i6803b/Macro_1.scala
+++ b/tests/pos-macros/i6803b/Macro_1.scala
@@ -2,7 +2,6 @@ package blah
 
 import scala.language.implicitConversions
 import scala.quoted._
-import scala.quoted.autolift
 
 object AsObject {
   final class LineNo(val lineNo: Int)
@@ -11,7 +10,7 @@ object AsObject {
     inline given x as LineNo = ${impl}
     private def impl(using qctx: QuoteContext) : Expr[LineNo] = {
       import qctx.tasty._
-      '{unsafe(${rootPosition.startLine})}
+      '{unsafe(${Expr(rootPosition.startLine)})}
     }
   }
 }

--- a/tests/pos-macros/quote-nested-object/Macro_1.scala
+++ b/tests/pos-macros/quote-nested-object/Macro_1.scala
@@ -1,6 +1,5 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macro {
 

--- a/tests/pos-staging/quote-0.scala
+++ b/tests/pos-staging/quote-0.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -12,7 +11,7 @@ object Macros {
     '{ if !($expr) then throw new AssertionError(s"failed assertion: ${${showExpr(expr)}}") }
 
 
-  def showExpr[T](expr: Expr[T])(using QuoteContext): Expr[String] = expr.toString
+  def showExpr[T](expr: Expr[T])(using QuoteContext): Expr[String] = Expr(expr.toString)
 
   inline def power(inline n: Int, x: Double) = ${ powerCode('n, 'x) }
 

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Foo {
 
@@ -9,8 +8,8 @@ object Foo {
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
     x.unseal match {
-      case Inlined(None, Nil, arg) => arg.symbol.tree.showExtractors
-      case arg => arg.symbol.tree.showExtractors // TODO should all by name parameters be in an inline node?
+      case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
+      case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?
     }
   }
 

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Foo {
 
@@ -9,8 +8,8 @@ object Foo {
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
     x.unseal match {
-      case Inlined(None, Nil, arg) => arg.symbol.tree.showExtractors
-      case arg => arg.symbol.tree.showExtractors // TODO should all by name parameters be in an inline node?
+      case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
+      case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?
     }
   }
 }

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -15,7 +14,7 @@ object Macros {
 
     val tree = x.unseal
     output.traverseTree(tree)
-    '{print(${buff.result()})}
+    '{print(${Expr(buff.result())})}
   }
 
   class MyTraverser[R <: scala.tasty.Reflection & Singleton](val reflect: R)(buff: StringBuilder) extends scala.tasty.reflect.TreeTraverser {

--- a/tests/run-macros/f-interpolation-1/FQuote_1.scala
+++ b/tests/run-macros/f-interpolation-1/FQuote_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 import scala.language.implicitConversions
 
@@ -48,12 +47,12 @@ object FQuote {
 
     for ((arg, part) <- allArgs.zip(parts.tail)) {
       if (part.startsWith("%d") && !(arg.tpe <:< defn.IntType)) {
-        return '{s"`${${arg.show}}` is not of type Int"}
+        return '{s"`${${Expr(arg.show)}}` is not of type Int"}
       }
 
     }
 
     val string = parts.mkString("")
-    '{ new collection.immutable.StringOps(${string}).format($args: _*) }
+    '{ new collection.immutable.StringOps(${Expr(string)}).format($args: _*) }
   }
 }

--- a/tests/run-macros/f-interpolator-neg/Macros_1.scala
+++ b/tests/run-macros/f-interpolator-neg/Macros_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 
 import scala.language.implicitConversions
@@ -33,25 +32,25 @@ object Macro {
       private[this] var oldReported = false
       def partError(message : String, index : Int, offset : Int) : Unit = {
         reported = true
-        errors += '{ Tuple5(true, 0, $index, $offset, $message) }
+        errors += '{ Tuple5(true, 0, ${Expr(index)}, ${Expr(offset)}, ${Expr(message)}) }
       }
       def partWarning(message : String, index : Int, offset : Int) : Unit = {
         reported = true
-        errors += '{ Tuple5(false, 0, $index, $offset, $message) }
+        errors += '{ Tuple5(false, 0, ${Expr(index)}, ${Expr(offset)}, ${Expr(message)}) }
       }
 
       def argError(message : String, index : Int) : Unit = {
         reported = true
-        errors += '{ Tuple5(true, 1, $index, 0, $message) }
+        errors += '{ Tuple5(true, 1, ${Expr(index)}, 0, ${Expr(message)}) }
       }
 
       def strCtxError(message : String) : Unit = {
         reported = true
-        errors += '{ Tuple5(true, 2, -1, 0, $message) }
+        errors += '{ Tuple5(true, 2, -1, 0, ${Expr(message)}) }
       }
       def argsError(message : String) : Unit = {
         reported = true
-        errors += '{ Tuple5(true, 3, -1, 0, $message) }
+        errors += '{ Tuple5(true, 3, -1, 0, ${Expr(message)}) }
       }
 
       def hasReported() : Boolean = {

--- a/tests/run-macros/i4734/Macro_1.scala
+++ b/tests/run-macros/i4734/Macro_1.scala
@@ -1,6 +1,5 @@
 import scala.annotation.tailrec
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
   inline def unrolledForeach(seq: IndexedSeq[Int], f: => Int => Unit, inline unrollSize: Int): Unit = // or f: Int => Unit
@@ -11,17 +10,17 @@ object Macros {
 
   def unrolledForeachImpl(seq: Expr[IndexedSeq[Int]], f: Expr[Int => Unit], unrollSize: Int)(using QuoteContext): Expr[Unit] = '{
     val size = ($seq).length
-    assert(size % (${unrollSize}) == 0) // for simplicity of the implementation
+    assert(size % (${Expr(unrollSize)}) == 0) // for simplicity of the implementation
     var i = 0
     while (i < size) {
       ${
         for (j <- new UnrolledRange(0, unrollSize)) '{
-          val index = i + $j
+          val index = i + ${Expr(j)}
           val element = ($seq)(index)
           ${ Expr.betaReduce(f)('element) } // or `($f)(element)` if `f` should not be inlined
         }
       }
-      i += ${unrollSize}
+      i += ${Expr(unrollSize)}
     }
 
   }

--- a/tests/run-macros/i4735/Macro_1.scala
+++ b/tests/run-macros/i4735/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.annotation.tailrec
-import scala.quoted.autolift
 
 import scala.quoted._
 
@@ -16,7 +15,7 @@ object Macro {
       println("<log> start loop")
       ${
         for (j <- new UnrolledRange(0, unrollSize.unliftOrError)) '{
-          val element = ($seq)(i + ${j})
+          val element = ($seq)(i + ${Expr(j)})
           ${Expr.betaReduce(f)('element)} // or `($f)(element)` if `f` should not be inlined
         }
       }

--- a/tests/run-macros/i5119/Macro_1.scala
+++ b/tests/run-macros/i5119/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macro {
   class StringContextOps(sc: => StringContext) {
@@ -8,6 +7,6 @@ object Macro {
   implicit inline def XmlQuote(inline sc: StringContext): StringContextOps = new StringContextOps(sc)
   def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    (sc.unseal.underlyingArgument.showExtractors + "\n" + args.unseal.underlyingArgument.showExtractors)
+    Expr(sc.unseal.underlyingArgument.showExtractors + "\n" + args.unseal.underlyingArgument.showExtractors)
   }
 }

--- a/tests/run-macros/i5119b/Macro_1.scala
+++ b/tests/run-macros/i5119b/Macro_1.scala
@@ -1,14 +1,11 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 
 object Macro {
 
   inline def ff(arg1: Any,  arg2: Any): String = ${ Macro.impl('{arg1}, '{arg2}) }
 
-  def impl(arg1: Expr[Any], arg2: Expr[Any])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
-    (arg1.unseal.underlyingArgument.showExtractors + "\n" + arg2.unseal.underlyingArgument.showExtractors)
-  }
+  def impl(arg1: Expr[Any], arg2: Expr[Any])(using qctx: QuoteContext) : Expr[String] =
+    Expr(arg1.unseal.underlyingArgument.showExtractors + "\n" + arg2.unseal.underlyingArgument.showExtractors)
 
 }

--- a/tests/run-macros/i5188a/Macro_1.scala
+++ b/tests/run-macros/i5188a/Macro_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Lib {
   inline def sum(inline args: Int*): Int = ${ impl('args) }
-  def impl(args: Expr[Seq[Int]]) (using QuoteContext): Expr[Int] = args.unliftOrError.sum
+  def impl(args: Expr[Seq[Int]]) (using QuoteContext): Expr[Int] = Expr(args.unliftOrError.sum)
 }

--- a/tests/run-macros/i6518/Macro_1.scala
+++ b/tests/run-macros/i6518/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -11,7 +10,7 @@ object Macros {
     classSym.classMethod("apply")
     classSym.classMethods
     classSym.method("apply")
-    classSym.methods.map(_.name).sorted.mkString("\n")
+    Expr(classSym.methods.map(_.name).sorted.mkString("\n"))
   }
 
 }

--- a/tests/run-macros/inferred-repeated-result/test_1.scala
+++ b/tests/run-macros/inferred-repeated-result/test_1.scala
@@ -1,6 +1,5 @@
 object Macros {
   import scala.quoted._
-  import scala.quoted.autolift
 
   inline def go[T](inline t: T) = ${ impl('t) }
   def impl[T](expr: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
@@ -17,6 +16,6 @@ object Macros {
             s"$name : $returnType"
       }.sorted
 
-    methods.foldLeft('{}) { (res, m) => '{ $res; println(${m}) } }
+    methods.foldLeft('{}) { (res, m) => '{ $res; println(${Expr(m)}) } }
   }
 }

--- a/tests/run-macros/inline-option/Macro_1.scala
+++ b/tests/run-macros/inline-option/Macro_1.scala
@@ -1,14 +1,13 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
   def impl(opt: Expr[Option[Int]]) (using QuoteContext): Expr[Int] = opt.unliftOrError match {
-    case Some(i) => i
+    case Some(i) => Expr(i)
     case None => '{-1}
   }
 
-  def impl2(opt: Expr[Option[Option[Int]]]) (using QuoteContext): Expr[Int] = impl(opt.unliftOrError.flatten)
+  def impl2(opt: Expr[Option[Option[Int]]]) (using QuoteContext): Expr[Int] = impl(Expr(opt.unliftOrError.flatten))
 
 }

--- a/tests/run-macros/inline-tuples-1/Macro_1.scala
+++ b/tests/run-macros/inline-tuples-1/Macro_1.scala
@@ -1,28 +1,27 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
-  def tup1(tup: Expr[Tuple1[Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup2(tup: Expr[Tuple2[Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup3(tup: Expr[Tuple3[Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup4(tup: Expr[Tuple4[Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup5(tup: Expr[Tuple5[Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup6(tup: Expr[Tuple6[Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup7(tup: Expr[Tuple7[Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup8(tup: Expr[Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup9(tup: Expr[Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup10(tup: Expr[Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup11(tup: Expr[Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup12(tup: Expr[Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup13(tup: Expr[Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup14(tup: Expr[Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup15(tup: Expr[Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup16(tup: Expr[Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup17(tup: Expr[Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup18(tup: Expr[Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup19(tup: Expr[Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup20(tup: Expr[Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup21(tup: Expr[Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
-  def tup22(tup: Expr[Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum
+  def tup1(tup: Expr[Tuple1[Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup2(tup: Expr[Tuple2[Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup3(tup: Expr[Tuple3[Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup4(tup: Expr[Tuple4[Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup5(tup: Expr[Tuple5[Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup6(tup: Expr[Tuple6[Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup7(tup: Expr[Tuple7[Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup8(tup: Expr[Tuple8[Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup9(tup: Expr[Tuple9[Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup10(tup: Expr[Tuple10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup11(tup: Expr[Tuple11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup12(tup: Expr[Tuple12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup13(tup: Expr[Tuple13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup14(tup: Expr[Tuple14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup15(tup: Expr[Tuple15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup16(tup: Expr[Tuple16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup17(tup: Expr[Tuple17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup18(tup: Expr[Tuple18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup19(tup: Expr[Tuple19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup20(tup: Expr[Tuple20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup21(tup: Expr[Tuple21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
+  def tup22(tup: Expr[Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError.productIterator.map(_.asInstanceOf[Int]).sum)
 }

--- a/tests/run-macros/inline-tuples-2/Macro_1.scala
+++ b/tests/run-macros/inline-tuples-2/Macro_1.scala
@@ -1,11 +1,10 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
-  def impl(tup: Expr[Tuple1[Int]]) (using QuoteContext): Expr[Int] = tup.unliftOrError._1
+  def impl(tup: Expr[Tuple1[Int]]) (using QuoteContext): Expr[Int] = Expr(tup.unliftOrError._1)
 
-  def impl2(tup: Expr[Tuple1[Tuple1[Int]]]) (using QuoteContext): Expr[Int] = impl(tup.unliftOrError._1)
+  def impl2(tup: Expr[Tuple1[Tuple1[Int]]]) (using QuoteContext): Expr[Int] = impl(Expr(tup.unliftOrError._1))
 
 }

--- a/tests/run-macros/inline-varargs-1/Macro_1.scala
+++ b/tests/run-macros/inline-varargs-1/Macro_1.scala
@@ -1,7 +1,6 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
-  def sum(nums: Expr[Int]*) (using QuoteContext): Expr[Int] = nums.map(_.unliftOrError).sum
+  def sum(nums: Expr[Int]*) (using QuoteContext): Expr[Int] = Expr(nums.map(_.unliftOrError).sum)
 }

--- a/tests/run-macros/quote-force/quoted_1.scala
+++ b/tests/run-macros/quote-force/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 case class Location(owners: List[String])
 
@@ -8,7 +7,7 @@ object Location {
   implicit inline def location: Location = ${impl}
 
   def impl(using QuoteContext): Expr[Location] = {
-    val list = List("a", "b", "c", "d", "e", "f")
+    val list = Expr(List("a", "b", "c", "d", "e", "f"))
     '{new Location(${list})}
   }
 

--- a/tests/run-macros/quote-impure-by-name/quoted_1.scala
+++ b/tests/run-macros/quote-impure-by-name/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 
 class Index[K, Keys](val index: String) extends AnyVal {
@@ -13,6 +12,6 @@ object Index {
 
   def succImpl[K: Type, H: Type, T: Type](prev: Expr[Index[K, T]])(using QuoteContext): Expr[Index[K, (H, T)]] = {
     val value = s"1 + {${prev.show}}"
-    '{new Index(${value})}
+    '{new Index(${Expr(value)})}
   }
 }

--- a/tests/run-macros/quote-inline-function/quoted_1.scala
+++ b/tests/run-macros/quote-inline-function/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -22,6 +21,6 @@ object Macros {
         i < j
       } do ()
     }
-    res.show
+    Expr(res.show)
   }
 }

--- a/tests/run-macros/quote-matching-optimize-1/Macro_1.scala
+++ b/tests/run-macros/quote-matching-optimize-1/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macro {
 
@@ -24,8 +23,8 @@ object Macro {
 
     '{
       val result = $res
-      val originalCode = ${x.show}
-      val optimizeCode = ${res.show}
+      val originalCode = ${Expr(x.show)}
+      val optimizeCode = ${Expr(res.show)}
       println("Original: " + originalCode)
       println("Optimized: " + optimizeCode)
       println("Result: " + result)

--- a/tests/run-macros/quote-matching-optimize-2/Macro_1.scala
+++ b/tests/run-macros/quote-matching-optimize-2/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macro {
 
@@ -24,8 +23,8 @@ object Macro {
 
     '{
       val result = $res
-      val originalCode = ${x.show}
-      val optimizeCode = ${res.show}
+      val originalCode = ${Expr(x.show)}
+      val optimizeCode = ${Expr(res.show)}
       println("Original: " + originalCode)
       println("Optimized: " + optimizeCode)
       println("Result: " + result)

--- a/tests/run-macros/quote-matching-optimize-3/Macro_1.scala
+++ b/tests/run-macros/quote-matching-optimize-3/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macro {
 
@@ -24,8 +23,8 @@ object Macro {
 
     '{
       val result = $res
-      val originalCode = ${x.show}
-      val optimizeCode = ${res.show}
+      val originalCode = ${Expr(x.show)}
+      val optimizeCode = ${Expr(res.show)}
       println("Original: " + originalCode)
       println("Optimized: " + optimizeCode)
       println("Result: " + result)

--- a/tests/run-macros/quote-simple-macro/quoted_1.scala
+++ b/tests/run-macros/quote-simple-macro/quoted_1.scala
@@ -1,7 +1,6 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
   inline def foo(inline i: Int, dummy: Int, j: Int): Int = ${ bar('i, 'j) }
-  def bar(x: Expr[Int], y: Expr[Int]) (using QuoteContext): Expr[Int] = '{ ${x.unliftOrError} + $y }
+  def bar(x: Expr[Int], y: Expr[Int]) (using QuoteContext): Expr[Int] = '{ ${Expr(x.unliftOrError)} + $y }
 }

--- a/tests/run-macros/quote-unrolled-foreach/quoted_1.scala
+++ b/tests/run-macros/quote-unrolled-foreach/quoted_1.scala
@@ -1,6 +1,5 @@
 import scala.annotation.tailrec
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macro {
 
@@ -12,17 +11,17 @@ object Macro {
 
   private def unrolledForeachImpl(unrollSize: Int, seq: Expr[Array[Int]], f: Expr[Int => Unit])(using QuoteContext): Expr[Unit] = '{
     val size = $seq.length
-    assert(size % (${unrollSize}) == 0) // for simplicity of the implementation
+    assert(size % (${Expr(unrollSize)}) == 0) // for simplicity of the implementation
     var i = 0
     while (i < size) {
       println("<log> start loop")
       ${
         @tailrec def loop(j: Int, acc: Expr[Unit]): Expr[Unit] =
-        if (j >= 0) loop(j - 1, '{ ${Expr.betaReduce(f)('{$seq(i + ${j})})}; $acc })
+        if (j >= 0) loop(j - 1, '{ ${Expr.betaReduce(f)('{$seq(i + ${Expr(j)})})}; $acc })
         else acc
         loop(unrollSize - 1, '{})
       }
-      i += ${unrollSize}
+      i += ${Expr(unrollSize)}
     }
   }
 }

--- a/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -10,8 +9,8 @@ object Macros {
     val tree = x.unseal
     '{
       println()
-      println("tree: " + ${tree.showExtractors})
-      println("tree deref. vals: " + ${tree.underlying.showExtractors})
+      println("tree: " + ${Expr(tree.showExtractors)})
+      println("tree deref. vals: " + ${Expr(tree.underlying.showExtractors)})
     }
   }
 }

--- a/tests/run-macros/tasty-custom-show/quoted_1.scala
+++ b/tests/run-macros/tasty-custom-show/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 
 object Macros {
@@ -35,7 +34,7 @@ object Macros {
 
     val tree = x.unseal
     output.traverseTree(tree)
-    '{print(${buff.result()})}
+    '{print(${Expr(buff.result())})}
   }
 
   def dummyShow(using qctx: QuoteContext) : scala.tasty.reflect.Printer[qctx.tasty.type] = {

--- a/tests/run-macros/tasty-definitions-1/quoted_1.scala
+++ b/tests/run-macros/tasty-definitions-1/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -92,7 +91,7 @@ object Macros {
     printout(defn.StringType.showExtractors)
 
 
-    '{println(${buff.result().mkString("\n")})}
+    '{println(${Expr(buff.result().mkString("\n"))})}
   }
 
 }

--- a/tests/run-macros/tasty-eval/quoted_1.scala
+++ b/tests/run-macros/tasty-eval/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -7,7 +6,7 @@ object Macros {
     ${ impl('i) }
 
   def impl(i: Expr[Int]) (using QuoteContext): Expr[String] = {
-    value(i).toString
+    Expr(value(i).toString)
   }
 
   inline implicit def value[X](e: Expr[X])(implicit qctx: QuoteContext, ev: Valuable[X]): Option[X] = ev.value(e)

--- a/tests/run-macros/tasty-extractors-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-1/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -10,8 +9,8 @@ object Macros {
     import qctx.tasty._
 
     val tree = x.unseal
-    val treeStr = tree.showExtractors
-    val treeTpeStr = tree.tpe.showExtractors
+    val treeStr = Expr(tree.showExtractors)
+    val treeTpeStr = Expr(tree.tpe.showExtractors)
 
     '{
       println(${treeStr})

--- a/tests/run-macros/tasty-extractors-2/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-2/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -11,8 +10,8 @@ object Macros {
 
     val tree = x.unseal
 
-    val treeStr = tree.showExtractors
-    val treeTpeStr = tree.tpe.showExtractors
+    val treeStr = Expr(tree.showExtractors)
+    val treeTpeStr = Expr(tree.tpe.showExtractors)
 
     '{
       println(${treeStr})

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 
-import scala.quoted.autolift
 
 object Macros {
 
@@ -28,6 +27,6 @@ object Macros {
 
     val tree = x.unseal
     traverser.traverseTree(tree)
-    '{print(${buff.result()})}
+    '{print(${Expr(buff.result())})}
   }
 }

--- a/tests/run-macros/tasty-extractors-constants-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-constants-1/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 
 
@@ -19,6 +18,6 @@ object Macros {
 
     '{new Object} match { case Const(n) => println(n); case _ => stagedPrintln("OK") }
 
-    '{print(${buff.result()})}
+    '{print(${Expr(buff.result())})}
   }
 }

--- a/tests/run-macros/tasty-extractors-types/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-types/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -10,8 +9,8 @@ object Macros {
 
     val tree = x.unseal
     '{
-      println(${tree.showExtractors})
-      println(${tree.tpe.showExtractors})
+      println(${Expr(tree.showExtractors)})
+      println(${Expr(tree.tpe.showExtractors)})
       println()
     }
   }

--- a/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object SourceFiles {
 
@@ -12,7 +11,7 @@ object SourceFiles {
   def getThisFileImpl: Macro[String] = {
     val qctx = tastyContext
     import qctx.tasty._
-    rootContext.source.getFileName.toString
+    Expr(rootContext.source.getFileName.toString)
   }
 
 }

--- a/tests/run-macros/tasty-getfile/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 
 object SourceFiles {
@@ -9,7 +8,7 @@ object SourceFiles {
 
   private def getThisFileImpl(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    summon[Context].source.getFileName.toString
+    Expr(summon[Context].source.getFileName.toString)
   }
 
 }

--- a/tests/run-macros/tasty-indexed-map/quoted_1.scala
+++ b/tests/run-macros/tasty-indexed-map/quoted_1.scala
@@ -1,6 +1,5 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 class MyMap[Keys](private val underlying: Array[Int]) extends AnyVal {
   def get[K <: String](implicit i: Index[K, Keys]): Int = underlying(i.index)
@@ -42,6 +41,6 @@ object Index {
 
     val index = keys.indexOf(key)
 
-    '{new Index(${index})}
+    '{new Index(${Expr(index)})}
   }
 }

--- a/tests/run-macros/tasty-interpolation-1/Macro.scala
+++ b/tests/run-macros/tasty-interpolation-1/Macro.scala
@@ -1,7 +1,6 @@
 
 import scala.quoted._
 import scala.language.implicitConversions
-import scala.quoted.autolift
 import scala.quoted.Reporting.error
 
 object Macro {
@@ -16,17 +15,17 @@ object Macro {
 
 object SIntepolator extends MacroStringInterpolator[String] {
   protected def interpolate(strCtx: StringContext, args: List[Expr[Any]]) (using QuoteContext): Expr[String] =
-    '{(${strCtx}).s(${Expr.ofList(args)}: _*)}
+    '{(${Expr(strCtx)}).s(${Expr.ofList(args)}: _*)}
 }
 
 object RawIntepolator extends MacroStringInterpolator[String] {
   protected def interpolate(strCtx: StringContext, args: List[Expr[Any]]) (using QuoteContext): Expr[String] =
-    '{(${strCtx}).raw(${Expr.ofList(args)}: _*)}
+    '{(${Expr(strCtx)}).raw(${Expr.ofList(args)}: _*)}
 }
 
 object FooIntepolator extends MacroStringInterpolator[String] {
   protected def interpolate(strCtx: StringContext, args: List[Expr[Any]]) (using QuoteContext): Expr[String] =
-    '{(${strCtx}).s(${Expr.ofList(args.map(_ => '{"foo"}))}: _*)}
+    '{(${Expr(strCtx)}).s(${Expr.ofList(args.map(_ => '{"foo"}))}: _*)}
 }
 
 // TODO put this class in the stdlib or separate project?
@@ -78,7 +77,7 @@ abstract class MacroStringInterpolator[T] {
   }
 
   protected implicit def StringContextIsLiftable: Liftable[StringContext] = new Liftable[StringContext] {
-    def toExpr(strCtx: StringContext) = '{StringContext(${strCtx.parts.toSeq}: _*)}
+    def toExpr(strCtx: StringContext) = '{StringContext(${Expr(strCtx.parts.toSeq)}: _*)}
   }
 
   protected class NotStaticlyKnownError(msg: String, expr: Expr[Any]) extends Exception(msg)

--- a/tests/run-macros/tasty-linenumber-2/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber-2/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 class LineNumber(val value: Int) {
   override def toString: String = value.toString
@@ -11,7 +10,7 @@ object LineNumber {
 
   def lineImpl(using QuoteContext) : Expr[LineNumber] = {
     import qctx.tasty._
-    '{new LineNumber(${rootPosition.startLine})}
+    '{new LineNumber(${Expr(rootPosition.startLine)})}
   }
 
 }

--- a/tests/run-macros/tasty-linenumber/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 class LineNumber(val value: Int) {
   override def toString: String = value.toString
@@ -12,7 +11,7 @@ object LineNumber {
 
   def lineImpl(x: Type[Unit])(using QuoteContext) : Expr[LineNumber] = {
     import qctx.tasty._
-    '{new LineNumber(${rootPosition.startLine})}
+    '{new LineNumber(${Expr(rootPosition.startLine)})}
   }
 
 }

--- a/tests/run-macros/tasty-location/quoted_1.scala
+++ b/tests/run-macros/tasty-location/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 case class Location(owners: List[String])
 
@@ -15,7 +14,7 @@ object Location {
       else listOwnerNames(sym.owner, sym.name :: acc)
 
     val list = listOwnerNames(rootContext.owner, Nil)
-    '{new Location(${list})}
+    '{new Location(${Expr(list)})}
   }
 
 }

--- a/tests/run-macros/tasty-original-source/Macros_1.scala
+++ b/tests/run-macros/tasty-original-source/Macros_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -7,7 +6,7 @@ object Macros {
 
   private def impl(arg: Expr[Any])(using qctx: QuoteContext) : Expr[(String, Any)] = {
     import qctx.tasty._
-    val source = arg.unseal.underlyingArgument.pos.sourceCode.toString
+    val source = Expr(arg.unseal.underlyingArgument.pos.sourceCode.toString)
     '{Tuple2($source, $arg)}
   }
 

--- a/tests/run-macros/tasty-positioned/quoted_1.scala
+++ b/tests/run-macros/tasty-positioned/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 case class Position(path: String, start: Int, end: Int,
     startLine: Int, startColumn: Int, endLine: Int, endColumn: Int)
@@ -14,13 +13,13 @@ object Positioned {
     import qctx.tasty.{Position => _, _}
     val pos = rootPosition
 
-    val path = pos.sourceFile.jpath.toString
-    val start = pos.start
-    val end = pos.end
-    val startLine = pos.startLine
-    val endLine = pos.endLine
-    val startColumn = pos.startColumn
-    val endColumn = pos.endColumn
+    val path = Expr(pos.sourceFile.jpath.toString)
+    val start = Expr(pos.start)
+    val end = Expr(pos.end)
+    val startLine = Expr(pos.startLine)
+    val endLine = Expr(pos.endLine)
+    val startColumn = Expr(pos.startColumn)
+    val endColumn = Expr(pos.endColumn)
 
     val liftedPosition = '{new Position($path, $start, $end, $startLine, $startColumn, $endLine, $endColumn)}
     '{Positioned[T]($x, $liftedPosition)}

--- a/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
+++ b/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 
 import scala.language.implicitConversions
@@ -40,7 +39,7 @@ object Macro {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
             import qctx.tasty._
             val pos = parts(partIdx).unseal.pos
-            errors += '{ Tuple4($partIdx, ${pos.start}, ${pos.end}, $msg) }
+            errors += '{ Tuple4(${Expr(partIdx)}, ${Expr(pos.start)}, ${Expr(pos.end)}, ${Expr(msg)}) }
           }
         }
         fooCore(parts, args, reporter) // Discard result

--- a/tests/run-macros/tasty-subtyping/quoted_1.scala
+++ b/tests/run-macros/tasty-subtyping/quoted_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -12,12 +11,12 @@ object Macros {
   def isTypeEqualImpl[T, U](t: Type[T], u: Type[U])(using QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
     val isTypeEqual = t.unseal.tpe =:= u.unseal.tpe
-    isTypeEqual
+    Expr(isTypeEqual)
   }
 
   def isSubTypeOfImpl[T, U](t: Type[T], u: Type[U])(using QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
     val isTypeEqual = t.unseal.tpe <:< u.unseal.tpe
-    isTypeEqual
+    Expr(isTypeEqual)
   }
 }

--- a/tests/run-macros/tasty-typeof/Macro_1.scala
+++ b/tests/run-macros/tasty-typeof/Macro_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -8,25 +7,25 @@ object Macros {
   private def testTypeOfImpl(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
     '{
-      assert(${(typeOf[Unit] =:= defn.UnitType)}, "Unit")
-      assert(${(typeOf[Byte] =:= defn.ByteType)}, "Byte")
-      assert(${(typeOf[Short] =:= defn.ShortType)}, "Short")
-      assert(${(typeOf[Int] =:= defn.IntType)}, "Int")
-      assert(${(typeOf[Long] =:= defn.LongType)}, "Long")
-      assert(${(typeOf[Float] =:= defn.FloatType)}, "Float")
-      assert(${(typeOf[Double] =:= defn.DoubleType)}, "Double")
-      assert(${(typeOf[Char] =:= defn.CharType)}, "Char")
-      assert(${(typeOf[String] =:= defn.StringType)}, "String")
+      assert(${Expr(typeOf[Unit] =:= defn.UnitType)}, "Unit")
+      assert(${Expr(typeOf[Byte] =:= defn.ByteType)}, "Byte")
+      assert(${Expr(typeOf[Short] =:= defn.ShortType)}, "Short")
+      assert(${Expr(typeOf[Int] =:= defn.IntType)}, "Int")
+      assert(${Expr(typeOf[Long] =:= defn.LongType)}, "Long")
+      assert(${Expr(typeOf[Float] =:= defn.FloatType)}, "Float")
+      assert(${Expr(typeOf[Double] =:= defn.DoubleType)}, "Double")
+      assert(${Expr(typeOf[Char] =:= defn.CharType)}, "Char")
+      assert(${Expr(typeOf[String] =:= defn.StringType)}, "String")
 
-      assert(${(typeOf[Any] =:= defn.AnyType)}, "Any")
-      assert(${(typeOf[AnyRef] =:= defn.AnyRefType)}, "AnyRef")
-      assert(${(typeOf[AnyVal] =:= defn.AnyValType)}, "AnyVal")
-      assert(${(typeOf[Object] =:= defn.ObjectType)}, "Object")
-      assert(${(typeOf[Nothing] =:= defn.NothingType)}, "Nothing")
+      assert(${Expr(typeOf[Any] =:= defn.AnyType)}, "Any")
+      assert(${Expr(typeOf[AnyRef] =:= defn.AnyRefType)}, "AnyRef")
+      assert(${Expr(typeOf[AnyVal] =:= defn.AnyValType)}, "AnyVal")
+      assert(${Expr(typeOf[Object] =:= defn.ObjectType)}, "Object")
+      assert(${Expr(typeOf[Nothing] =:= defn.NothingType)}, "Nothing")
 
-      println(${typeOf[List[Int]].show})
-      println(${typeOf[Macros].show})
-      println(${typeOf[Macros.type].show})
+      println(${Expr(typeOf[List[Int]].show)})
+      println(${Expr(typeOf[Macros].show)})
+      println(${Expr(typeOf[Macros.type].show)})
     }
   }
 

--- a/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 
 import scala.language.implicitConversions
@@ -57,6 +56,6 @@ object XmlQuote {
     val Typed(Repeated(args0, _), _) = args.unseal.underlyingArgument
 
     val string = parts.mkString("??")
-    '{new Xml(${string}, ${liftListOfAny(args0)})}
+    '{new Xml(${Expr(string)}, ${liftListOfAny(args0)})}
   }
 }

--- a/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
@@ -1,6 +1,5 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 
 import scala.language.implicitConversions
@@ -65,7 +64,7 @@ object XmlQuote {
 
     }
 
-    val string = parts.mkString("??")
+    val string = Expr(parts.mkString("??"))
     '{new Xml(${string}, $args2)}
   }
 }

--- a/tests/run-macros/xml-interpolation-3/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-3/XmlQuote_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 import scala.language.implicitConversions
 
@@ -14,6 +13,6 @@ object XmlQuote {
 
   def impl(receiver: Expr[StringContext], args: Expr[Seq[Any]])(using QuoteContext): Expr[Xml] = {
     val string = receiver.unliftOrError.parts.mkString("??")
-    '{new Xml(${string}, $args.toList)}
+    '{new Xml(${Expr(string)}, $args.toList)}
   }
 }

--- a/tests/run-macros/xml-interpolation-4/Macros_1.scala
+++ b/tests/run-macros/xml-interpolation-4/Macros_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 import scala.language.implicitConversions
 

--- a/tests/run-macros/xml-interpolation-5/Macros_1.scala
+++ b/tests/run-macros/xml-interpolation-5/Macros_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 import scala.language.implicitConversions
 
@@ -27,7 +26,7 @@ object XmlQuote {
 
   def impl(receiver: Expr[SCOps.StringContext], args: Expr[Seq[Any]])(using QuoteContext): Expr[Xml] = {
     val string = receiver match {
-      case '{ SCOps(${Unlifted(sc)}) } => sc.parts.mkString("??")
+      case '{ SCOps(${Unlifted(sc)}) } => Expr(sc.parts.mkString("??"))
     }
     '{new Xml(${string}, $args.toList)}
   }

--- a/tests/run-macros/xml-interpolation-6/Macros_1.scala
+++ b/tests/run-macros/xml-interpolation-6/Macros_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 import scala.language.implicitConversions
 
@@ -29,6 +28,6 @@ object XmlQuote {
     val string = receiver match {
       case '{ SCOps(${Unlifted(sc)}): SCOps.StringContext } => sc.parts.mkString("??")
     }
-    '{new Xml(${string}, $args.toList)}
+    '{new Xml(${Expr(string)}, $args.toList)}
   }
 }

--- a/tests/run-macros/xml-interpolation-7/Macros_1.scala
+++ b/tests/run-macros/xml-interpolation-7/Macros_1.scala
@@ -1,5 +1,4 @@
 import scala.quoted._
-import scala.quoted.autolift
 
 import scala.language.implicitConversions
 
@@ -29,6 +28,6 @@ object XmlQuote {
     val string = receiver match {
       case '{ XMLOps.extension_xml(${Unlifted(sc)}) } => sc.parts.mkString("??")
     }
-    '{new Xml(${string}, $args.toList)}
+    '{new Xml(${Expr(string)}, $args.toList)}
   }
 }

--- a/tests/run-staging/quote-lib.scala
+++ b/tests/run-staging/quote-lib.scala
@@ -1,7 +1,6 @@
 
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.autolift
 
 import liftable.Units._
 import liftable.Lets._
@@ -21,10 +20,10 @@ object Test {
     liftedWhile('{true})('{ println(1) }).show
     liftedDoWhile('{ println(1) })('{true}).show
 
-    val t1: Expr[Tuple1[Int]] = Tuple1(4)
-    val t2: Expr[(Int, Int)] = (2, 3)
-    val t3: Expr[(Int, Int, Int)] = (2, 3, 4)
-    val t4: Expr[(Int, Int, Int, Int)] = (2, 3, 4, 5)
+    val t1: Expr[Tuple1[Int]] = Expr(Tuple1(4))
+    val t2: Expr[(Int, Int)] = Expr((2, 3))
+    val t3: Expr[(Int, Int, Int)] = Expr((2, 3, 4))
+    val t4: Expr[(Int, Int, Int, Int)] = Expr((2, 3, 4, 5))
     Expr((1, 2, 3, 4))
     Expr((1, 2, 3, 4, 5))
     Expr((1, 2, 3, 4, 5, 6))
@@ -49,25 +48,25 @@ object Test {
     Expr((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25))
 
     val list: List[Int] = List(1, 2, 3)
-    val liftedList: Expr[List[Int]] = list
+    val liftedList: Expr[List[Int]] = Expr(list)
 
     val seq: Seq[Int] = Seq(1, 2, 3)
-    val liftedSeq: Expr[Seq[Int]] = seq
+    val liftedSeq: Expr[Seq[Int]] = Expr(seq)
 
     val set: Set[Int] = Set(1, 2, 3)
-    val liftedSet: Expr[Set[Int]] = set
+    val liftedSet: Expr[Set[Int]] = Expr(set)
 
     val map: Map[Int, Char] = Map(1 -> 'a', 2 -> 'b', 3 -> 'c')
-    val liftedMap: Expr[Map[Int, Char]] = map
+    val liftedMap: Expr[Map[Int, Char]] = Expr(map)
 
-    liftedList.foldLeft[Int](0)('{ (acc: Int, x: Int) => acc + x }).show
+    liftedList.foldLeft[Int]('{0})('{ (acc: Int, x: Int) => acc + x }).show
     liftedList.foreach('{ (x: Int) => println(x) }).show
 
-    list.unrolledFoldLeft[Int](0)('{ (acc: Int, x: Int) => acc + x }).show
+    list.unrolledFoldLeft[Int]('{0})('{ (acc: Int, x: Int) => acc + x }).show
     list.unrolledForeach('{ (x: Int) => println(x) }).show
 
     val iarray: IArray[Int] = IArray(1, 2, 3)
-    val liftedIArray: Expr[IArray[Int]] = iarray
+    val liftedIArray: Expr[IArray[Int]] = Expr(iarray)
 
     val iarray2: IArray[String] = IArray("a", "b", "c")
     Expr(iarray2)
@@ -83,7 +82,7 @@ object Test {
     Expr(IArray((1, 3)))
 
     val array: Array[Int] = Array(1, 2, 3)
-    val liftedArray: Expr[Array[Int]] = array
+    val liftedArray: Expr[Array[Int]] = Expr(array)
 
     Expr(Array(false))
     Expr(Array(1: Byte))
@@ -97,8 +96,8 @@ object Test {
 
     val some: Option[Int] = Some(2)
     val none: Option[Int] = Some(2)
-    val liftedSome: Expr[Option[Int]] = some
-    val liftedNone: Expr[Option[Int]] = none
+    val liftedSome: Expr[Option[Int]] = Expr(some)
+    val liftedNone: Expr[Option[Int]] = Expr(none)
 
     val left: Either[Int, Long] = Left(1)
     val right: Either[Int, Long] = Right(2L)
@@ -153,11 +152,11 @@ package liftable {
 
     implicit class UnrolledOps[T: Liftable](list: List[T])(implicit t: Type[T], qctx: QuoteContext) {
       def unrolledFoldLeft[U](acc: Expr[U])(f: Expr[(U, T) => U])(implicit u: Type[U]): Expr[U] = list match {
-        case x :: xs => xs.unrolledFoldLeft('{ ($f).apply($acc, ${x}) })(f)
+        case x :: xs => xs.unrolledFoldLeft('{ ($f).apply($acc, ${Expr(x)}) })(f)
         case Nil => acc
       }
        def unrolledForeach(f: Expr[T => Unit]): Expr[Unit] = list match {
-         case x :: xs => '{ ($f).apply(${x}); ${ xs.unrolledForeach(f) } }
+         case x :: xs => '{ ($f).apply(${Expr(x)}); ${ xs.unrolledForeach(f) } }
          case Nil => '{}
        }
     }

--- a/tests/run-staging/quote-lift-Array.scala
+++ b/tests/run-staging/quote-lift-Array.scala
@@ -1,7 +1,5 @@
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.autolift
-
 object Test {
   implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
@@ -9,25 +7,25 @@ object Test {
       def p[T](arr: Array[T]): Unit = {
         println(arr.asInstanceOf[Array[_]].mkString("[", ", ", "]"))
       }
-      p(${Array.empty[Boolean]})
-      p(${Array.empty[Byte]})
-      p(${Array.empty[Short]})
-      p(${Array.empty[Char]})
-      p(${Array.empty[Int]})
-      p(${Array.empty[Long]})
-      p(${Array.empty[Float]})
-      p(${Array.empty[Double]})
-      p(${Array.empty[String]})
+      p(${Expr(Array.empty[Boolean])})
+      p(${Expr(Array.empty[Byte])})
+      p(${Expr(Array.empty[Short])})
+      p(${Expr(Array.empty[Char])})
+      p(${Expr(Array.empty[Int])})
+      p(${Expr(Array.empty[Long])})
+      p(${Expr(Array.empty[Float])})
+      p(${Expr(Array.empty[Double])})
+      p(${Expr(Array.empty[String])})
       println()
-      p(${Array(true)})
-      p(${Array[Byte](1, 2)})
-      p(${Array[Short](2, 3)})
-      p(${Array[Char]('a', 'b')})
-      p(${Array[Int](4, 5)})
-      p(${Array[Long](6L, 7L)})
-      p(${Array[Float](2.1f, 3.2f)})
-      p(${Array[Double](2.2, 3.3)})
-      p(${Array("abc", "xyz")})
+      p(${Expr(Array(true))})
+      p(${Expr(Array[Byte](1, 2))})
+      p(${Expr(Array[Short](2, 3))})
+      p(${Expr(Array[Char]('a', 'b'))})
+      p(${Expr(Array[Int](4, 5))})
+      p(${Expr(Array[Long](6L, 7L))})
+      p(${Expr(Array[Float](2.1f, 3.2f))})
+      p(${Expr(Array[Double](2.2, 3.3))})
+      p(${Expr(Array("abc", "xyz"))})
     }
   }
 }

--- a/tests/run-staging/quote-lift-IArray.scala
+++ b/tests/run-staging/quote-lift-IArray.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.autolift
 
 object Test {
   implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
@@ -9,25 +8,25 @@ object Test {
       def p[T](arr: IArray[T]): Unit = {
         println(arr.asInstanceOf[Array[_]].mkString("[", ", ", "]"))
       }
-      p(${IArray.empty[Boolean]})
-      p(${IArray.empty[Byte]})
-      p(${IArray.empty[Short]})
-      p(${IArray.empty[Char]})
-      p(${IArray.empty[Int]})
-      p(${IArray.empty[Long]})
-      p(${IArray.empty[Float]})
-      p(${IArray.empty[Double]})
-      p(${IArray.empty[String]})
+      p(${Expr(IArray.empty[Boolean])})
+      p(${Expr(IArray.empty[Byte])})
+      p(${Expr(IArray.empty[Short])})
+      p(${Expr(IArray.empty[Char])})
+      p(${Expr(IArray.empty[Int])})
+      p(${Expr(IArray.empty[Long])})
+      p(${Expr(IArray.empty[Float])})
+      p(${Expr(IArray.empty[Double])})
+      p(${Expr(IArray.empty[String])})
       println()
-      p(${IArray(true)})
-      p(${IArray[Byte](1, 2)})
-      p(${IArray[Short](2, 3)})
-      p(${IArray[Char]('a', 'b')})
-      p(${IArray[Int](4, 5)})
-      p(${IArray[Long](6L, 7L)})
-      p(${IArray[Float](2.1f, 3.2f)})
-      p(${IArray[Double](2.2, 3.3)})
-      p(${IArray("abc", "xyz")})
+      p(${Expr(IArray(true))})
+      p(${Expr(IArray[Byte](1, 2))})
+      p(${Expr(IArray[Short](2, 3))})
+      p(${Expr(IArray[Char]('a', 'b'))})
+      p(${Expr(IArray[Int](4, 5))})
+      p(${Expr(IArray[Long](6L, 7L))})
+      p(${Expr(IArray[Float](2.1f, 3.2f))})
+      p(${Expr(IArray[Double](2.2, 3.3))})
+      p(${Expr(IArray("abc", "xyz"))})
     }
   }
 }

--- a/tests/run-staging/quote-run-constants.scala
+++ b/tests/run-staging/quote-run-constants.scala
@@ -1,5 +1,4 @@
 
-import scala.quoted.autolift
 
 import scala.quoted._
 import scala.quoted.staging._
@@ -9,40 +8,40 @@ object Test {
     given Toolbox = Toolbox.make(getClass.getClassLoader)
     def runAndPrint[T](expr: QuoteContext ?=> Expr[T]): Unit = println(run(expr))
 
-    runAndPrint(true)
-    runAndPrint('a')
-    runAndPrint('\n')
-    runAndPrint('"')
-    runAndPrint('\'')
-    runAndPrint('\\')
-    runAndPrint(1)
-    runAndPrint(2)
-    runAndPrint(3L)
-    runAndPrint(4.0f)
-    runAndPrint(5.0d)
-    runAndPrint("xyz")
+    runAndPrint(Expr(true))
+    runAndPrint(Expr('a'))
+    runAndPrint(Expr('\n'))
+    runAndPrint(Expr('"'))
+    runAndPrint(Expr('\''))
+    runAndPrint(Expr('\\'))
+    runAndPrint(Expr(1))
+    runAndPrint(Expr(2))
+    runAndPrint(Expr(3L))
+    runAndPrint(Expr(4.0f))
+    runAndPrint(Expr(5.0d))
+    runAndPrint(Expr("xyz"))
 
     println("======")
 
     withQuoteContext {
       def show[T](expr: Expr[T]): Unit = println(expr.show)
 
-      show(true)
-      show('a')
-      show('\n')
-      show('"')
-      show('\'')
-      show('\\')
-      show(1)
-      show(2)
-      show(3L)
-      show(4.0f)
-      show(5.0d)
-      show("xyz")
-      show("\n\\\"'")
-      show(
+      show(Expr(true))
+      show(Expr('a'))
+      show(Expr('\n'))
+      show(Expr('"'))
+      show(Expr('\''))
+      show(Expr('\\'))
+      show(Expr(1))
+      show(Expr(2))
+      show(Expr(3L))
+      show(Expr(4.0f))
+      show(Expr(5.0d))
+      show(Expr("xyz"))
+      show(Expr("\n\\\"'"))
+      show(Expr(
         """abc
-         xyz""")
+         xyz"""))
     }
   }
 }

--- a/tests/run-staging/quote-run-many.scala
+++ b/tests/run-staging/quote-run-many.scala
@@ -1,12 +1,11 @@
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.autolift
 
 object Test {
   def main(args: Array[String]): Unit = {
     given Toolbox = Toolbox.make(getClass.getClassLoader)
     def expr(i: Int)(using QuoteContext) = '{
-      val a = 3 + ${i}
+      val a = 3 + ${Expr(i)}
       2 + a
     }
     for (i <- 0 to 100)

--- a/tests/run-staging/quote-run-staged-interpreter.scala
+++ b/tests/run-staging/quote-run-staged-interpreter.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.autolift
 
 enum Exp {
   case Num(n: Int)
@@ -14,7 +13,7 @@ object Test {
 
   def compile(e: Exp, env: Map[String, Expr[Int]], keepLets: Boolean)(using QuoteContext): Expr[Int] = {
     def compileImpl(e: Exp, env: Map[String, Expr[Int]]): Expr[Int] = e match {
-      case Num(n) => n
+      case Num(n) => Expr(n)
       case Plus(e1, e2) => '{${compileImpl(e1, env)} + ${compileImpl(e2, env)}}
       case Var(x) => env(x)
       case Let(x, e, body) =>

--- a/tests/run-staging/quote-show-blocks.scala
+++ b/tests/run-staging/quote-show-blocks.scala
@@ -1,20 +1,19 @@
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.autolift
 
 object Test {
   given Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def a(n: Int, x: Expr[Unit]): Expr[Unit] =
       if (n == 0) x
-      else a(n - 1, '{ println(${n}); $x })
+      else a(n - 1, '{ println(${Expr(n)}); $x })
 
     println(a(5, '{}).show)
 
 
     def b(n: Int, x: Expr[Unit]): Expr[Unit] =
       if (n == 0) x
-      else b(n - 1, '{ $x; println(${n}) })
+      else b(n - 1, '{ $x; println(${Expr(n)}) })
 
     println(b(5, '{}).show)
     '{}

--- a/tests/run-staging/quote-unrolled-foreach.scala
+++ b/tests/run-staging/quote-unrolled-foreach.scala
@@ -1,7 +1,6 @@
 import scala.annotation.tailrec
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.autolift
 
 object Test {
   given Toolbox = Toolbox.make(getClass.getClassLoader)
@@ -30,13 +29,13 @@ object Test {
     println(code4.show)
     println()
 
-    def liftedArray(using QuoteContext): Expr[Array[Int]] = Array(1, 2, 3, 4)
+    def liftedArray(using QuoteContext): Expr[Array[Int]] = Expr(Array(1, 2, 3, 4))
     println(liftedArray.show)
     println()
 
 
     def printAll(arr: Array[Int]) = '{
-      val arr1 = ${ arr }
+      val arr1 = ${ Expr(arr) }
       ${ foreach1('arr1, '{x => println(x)}) }
     }
 
@@ -111,17 +110,17 @@ object Test {
   def foreach4(arrRef: Expr[Array[Int]], f: Expr[Int => Unit], unrollSize: Int)(using QuoteContext): Expr[Unit] = '{
     val size = ($arrRef).length
     var i = 0
-    if (size % ${unrollSize} != 0) throw new Exception("...") // for simplicity of the implementation
+    if (size % ${Expr(unrollSize)} != 0) throw new Exception("...") // for simplicity of the implementation
     while (i < size) {
-      ${ foreachInRange(0, unrollSize)(j => '{ ($f)(($arrRef)(i + ${j})) }) }
-      i += ${unrollSize}
+      ${ foreachInRange(0, unrollSize)(j => '{ ($f)(($arrRef)(i + ${Expr(j)})) }) }
+      i += ${Expr(unrollSize)}
     }
   }
 
   implicit object ArrayIntIsLiftable extends Liftable[Array[Int]] {
     override def toExpr(x: Array[Int]) = '{
-      val array = new Array[Int](${x.length})
-      ${ foreachInRange(0, x.length)(i => '{ array(${i}) = ${x(i)}}) }
+      val array = new Array[Int](${Expr(x.length)})
+      ${ foreachInRange(0, x.length)(i => '{ array(${Expr(i)}) = ${Expr(x(i))}}) }
       array
     }
   }

--- a/tests/run-staging/shonan-hmm/Lifters.scala
+++ b/tests/run-staging/shonan-hmm/Lifters.scala
@@ -3,23 +3,22 @@ import UnrolledExpr._
 
 import scala.reflect.ClassTag
 import scala.quoted._
-import scala.quoted.autolift
 
 object Lifters {
   implicit def LiftedClassTag[T: Type: ClassTag] (using QuoteContext): Expr[ClassTag[T]] = {
-    '{ ClassTag(${summon[ClassTag[T]].runtimeClass })}
+    '{ ClassTag(${Expr(summon[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]])}) }
   }
 
   implicit def ArrayIsLiftable[T : Type: ClassTag](implicit l: Liftable[T]): Liftable[Array[T]] = new Liftable[Array[T]] {
     def toExpr(x: Array[T]) = '{
-      val array = new Array[T](${x.length})(${implicitly[Expr[ClassTag[T]]]})
+      val array = new Array[T](${Expr(x.length)})(${implicitly[Expr[ClassTag[T]]]})
       ${initArray(x, 'array)}
     }
   }
 
   implicit def IntArrayIsLiftable: Liftable[Array[Int]] = new Liftable[Array[Int]] {
     def toExpr(x: Array[Int]) = '{
-      val array = new Array[Int](${x.length})
+      val array = new Array[Int](${Expr(x.length)})
       ${initArray(x, 'array)}
     }
   }
@@ -27,7 +26,7 @@ object Lifters {
   private def initArray[T : Liftable : Type](arr: Array[T], array: Expr[Array[T]])(using QuoteContext): Expr[Array[T]] = {
     UnrolledExpr.block(
       arr.zipWithIndex.map {
-        case (x, i) => '{ $array(${i}) = ${x} }
+        case (x, i) => '{ $array(${Expr(i)}) = ${Expr(x)} }
       }.toList,
       array)
   }

--- a/tests/run-staging/shonan-hmm/PV.scala
+++ b/tests/run-staging/shonan-hmm/PV.scala
@@ -7,6 +7,9 @@ case class Sta[T](x: T) extends PV[T]
 
 case class Dyn[T](x: Expr[T]) extends PV[T]
 
+object Dyn:
+  def apply[T: Liftable](x: T)(using QuoteContext): Dyn[T] = Dyn(Expr(x))
+
 object Dyns {
   def dyn[T: Liftable](pv: PV[T])(using QuoteContext): Expr[T] = pv match {
     case Sta(x) => Expr(x)

--- a/tests/run-staging/shonan-hmm/VecROp.scala
+++ b/tests/run-staging/shonan-hmm/VecROp.scala
@@ -1,6 +1,5 @@
 
 import scala.quoted._
-import scala.quoted.autolift
 
 trait VecROp[Idx, T, Unt] extends VecOp[Idx, Unt] {
   def reduce: ((T, T) => T, T, Vec[Idx, T]) => T

--- a/tests/run-staging/staged-streams_1.scala
+++ b/tests/run-staging/staged-streams_1.scala
@@ -1,8 +1,6 @@
 import scala.quoted._
 import scala.quoted.staging._
 import scala.quoted.util._
-import scala.quoted.autolift
-
 /**
   * Port of the strymonas library as described in O. Kiselyov et al., Stream fusion, to completeness (POPL 2017)
   */
@@ -580,7 +578,7 @@ object Test {
 
         def init(k: St => Expr[Unit]): E[Unit] = {
           Var('{($arr).length}) { n =>
-            Var(0){ i =>
+            Var('{0}){ i =>
               k((i, n, arr))
             }
           }

--- a/tests/run-staging/tasty-extractors-constants-2/quoted_1.scala
+++ b/tests/run-staging/tasty-extractors-constants-2/quoted_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.autolift
 
 object Macros {
 
@@ -9,35 +8,35 @@ object Macros {
   def impl(using QuoteContext): Expr[Unit] = {
     given Toolbox = Toolbox.make(getClass.getClassLoader)
     // 2 is a lifted constant
-    val show1 = withQuoteContext(power(2, 3.0).show)
-    val run1  = run(power(2, 3.0))
+    val show1 = withQuoteContext(power('{2}, '{3.0}).show)
+    val run1  = run(power('{2}, '{3.0}))
 
     // n is a lifted constant
     val n = 2
-    val show2 = withQuoteContext(power(n, 4.0).show)
-    val run2  = run(power(n, 4.0))
+    val show2 = withQuoteContext(power(Expr(n), '{4.0}).show)
+    val run2  = run(power(Expr(n), '{4.0}))
 
     // n is a constant in a quote
-    val show3 = withQuoteContext(power('{2}, 5.0).show)
-    val run3 =  run(power('{2}, 5.0))
+    val show3 = withQuoteContext(power('{2}, '{5.0}).show)
+    val run3  = run(power('{2}, '{5.0}))
 
     // n2 is not a constant
     def n2(using QuoteContext) = '{ println("foo"); 2 }
-    val show4 = withQuoteContext(power(n2, 6.0).show)
-    val run4  = run(power(n2, 6.0))
+    val show4 = withQuoteContext(power(n2, '{6.0}).show)
+    val run4  = run(power(n2, '{6.0}))
 
     '{
-      println(${show1})
-      println(${run1})
+      println(${Expr(show1)})
+      println(${Expr(run1)})
       println()
-      println(${show2})
-      println(${run2})
+      println(${Expr(show2)})
+      println(${Expr(run2)})
       println()
-      println(${show3})
-      println(${run3})
+      println(${Expr(show3)})
+      println(${Expr(run3)})
       println()
-      println(${show4})
-      println(${run4})
+      println(${Expr(show4)})
+      println(${Expr(run4)})
     }
   }
 


### PR DESCRIPTION
It has been discouraged to use this implicit conversion for a while as it interacts poorly
with type inference. To avoid further issues we will simply remove it from the library.

Note: Anyone could implement it in their project with a single line of code