### PR TITLE
Drop implicit `toClassDenot` conversion

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
@@ -94,7 +94,7 @@ class BTypesFromSymbols[I <: DottyBackendInterface](val int: I) extends BTypes {
 
   private def setClassInfo(classSym: Symbol, classBType: ClassBType): ClassBType = {
     val superClassSym: Symbol =  {
-      val t = classSym.asClass.superClass
+      val t = classSym.classDenot.superClass
       if (t.exists) t
       else if (classSym.is(ModuleClass)) {
         // workaround #371
@@ -124,7 +124,7 @@ class BTypesFromSymbols[I <: DottyBackendInterface](val int: I) extends BTypes {
     def (sym: Symbol).superInterfaces: List[Symbol] = {
       val directlyInheritedTraits = sym.directlyInheritedTraits
       val directlyInheritedTraitsSet = directlyInheritedTraits.toSet
-      val allBaseClasses = directlyInheritedTraits.iterator.flatMap(_.asClass.baseClasses.drop(1)).toSet
+      val allBaseClasses = directlyInheritedTraits.iterator.flatMap(_.classDenot.baseClasses.drop(1)).toSet
       val superCalls = superCallsMap.getOrElse(sym, Set.empty)
       val additional = (superCalls -- directlyInheritedTraitsSet).filter(_.is(Trait))
 //      if (additional.nonEmpty)

--- a/compiler/src/dotty/tools/backend/sjs/JUnitBootstrappers.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JUnitBootstrappers.scala
@@ -122,13 +122,14 @@ class JUnitBootstrappers extends MiniPhase {
 
     @tailrec
     def hasTests(sym: ClassSymbol): Boolean = {
-      sym.info.decls.exists(m => m.is(Method) && m.hasAnnotation(junitdefn.TestAnnotClass)) ||
-      sym.superClass.exists && hasTests(sym.superClass.asClass)
+      val symd = sym.classDenot
+      symd.info.decls.exists(m => m.is(Method) && m.hasAnnotation(junitdefn.TestAnnotClass)) ||
+      symd.superClass.exists && hasTests(symd.superClass.asClass)
     }
 
     def isTestClass(sym: Symbol): Boolean = {
       sym.isClass &&
-      !sym.isOneOf(ModuleClass | Abstract | Trait) &&
+      !sym.denot.isOneOf(ModuleClass | Abstract | Trait) &&
       hasTests(sym.asClass)
     }
 

--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -78,9 +78,9 @@ object CompilationUnit {
 
   class SuspendException extends Exception
 
-  /** Make a compilation unit for top class `clsd` with the contents of the `unpickled` tree */
-  def apply(clsd: ClassDenotation, unpickled: Tree, forceTrees: Boolean)(implicit ctx: Context): CompilationUnit =
-    apply(new SourceFile(clsd.symbol.associatedFile, Array.empty[Char]), unpickled, forceTrees)
+  /** Make a compilation unit for top class `cls` with the contents of the `unpickled` tree */
+  def apply(cls: ClassSymbol, unpickled: Tree, forceTrees: Boolean)(implicit ctx: Context): CompilationUnit =
+    apply(new SourceFile(cls.associatedFile, Array.empty[Char]), unpickled, forceTrees)
 
   /** Make a compilation unit, given picked bytes and unpickled tree */
   def apply(source: SourceFile, unpickled: Tree, forceTrees: Boolean)(implicit ctx: Context): CompilationUnit = {

--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -69,8 +69,8 @@ class TreeTypeMap(
         case pdef: MemberDef =>
           val prevSym = pdef.symbol
           val newSym = newStats.head.symbol
-          val newCls = newSym.owner.asClass
-          if (prevSym != newSym) newCls.replace(prevSym, newSym)
+          if prevSym != newSym then
+            newSym.owner.classDenot.replace(prevSym, newSym)
         case _ =>
       }
       updateDecls(prevStats.tail, newStats.tail)
@@ -191,7 +191,7 @@ class TreeTypeMap(
       val mappedDcls = ctx.mapSymbols(origDcls, tmap)
       val tmap1 = tmap.withMappedSyms(origDcls, mappedDcls)
       if (symsChanged)
-        origDcls.lazyZip(mappedDcls).foreach(cls.asClass.replace)
+        origDcls.lazyZip(mappedDcls).foreach(cls.classDenot.replace)
       tmap1
     }
     if (symsChanged || (fullMap eq substMap)) fullMap

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -310,14 +310,15 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   }
 
   def ClassDefWithParents(cls: ClassSymbol, constr: DefDef, parents: List[Tree], body: List[Tree])(implicit ctx: Context): TypeDef = {
+    val clsd = cls.classDenot
     val selfType =
-      if (cls.classInfo.selfInfo ne NoType) ValDef(ctx.newSelfSym(cls))
+      if (clsd.classInfo.selfInfo ne NoType) ValDef(ctx.newSelfSym(cls))
       else EmptyValDef
     def isOwnTypeParam(stat: Tree) =
       stat.symbol.is(TypeParam) && stat.symbol.owner == cls
     val bodyTypeParams = body filter isOwnTypeParam map (_.symbol)
     val newTypeParams =
-      for (tparam <- cls.typeParams if !(bodyTypeParams contains tparam))
+      for (tparam <- clsd.typeParams if !(bodyTypeParams contains tparam))
       yield TypeDef(tparam)
     val findLocalDummy = FindLocalDummyAccumulator(cls)
     val localDummy = body.foldLeft(NoSymbol: Symbol)(findLocalDummy.apply)

--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -39,11 +39,12 @@ class JavaPlatform extends Platform {
 
   /** Is the SAMType `cls` also a SAM under the rules of the JVM? */
   def isSam(cls: ClassSymbol)(implicit ctx: Context): Boolean =
-    cls.isAllOf(NoInitsTrait) &&
-    cls.superClass == defn.ObjectClass &&
-    cls.directlyInheritedTraits.forall(_.is(NoInits)) &&
+    val clsd = cls.classDenot
+    clsd.isAllOf(NoInitsTrait) &&
+    clsd.superClass == defn.ObjectClass &&
+    clsd.directlyInheritedTraits.forall(_.is(NoInits)) &&
     !ExplicitOuter.needsOuterIfReferenced(cls) &&
-    cls.typeRef.fields.isEmpty // Superaccessors already show up as abstract methods here, so no test necessary
+    clsd.typeRef.fields.isEmpty // Superaccessors already show up as abstract methods here, so no test necessary
 
   /** We could get away with excluding BoxedBooleanClass for the
    *  purpose of equality testing since it need not compare equal

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -174,7 +174,7 @@ class CheckRealizable(implicit ctx: Context) {
         }
     }
     val baseProblems =
-      tp.baseClasses.map(_.baseTypeOf(tp)).flatMap(baseTypeProblems)
+      tp.baseClasses.map(_.classDenot.baseTypeOf(tp)).flatMap(baseTypeProblems)
 
     baseProblems.foldLeft(
       refinementProblems.foldLeft(

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -375,7 +375,7 @@ object Contexts {
      *    from constructor parameters to class parameter accessors.
      */
     def superCallContext: Context = {
-      val locals = newScopeWith(owner.typeParams ++ owner.asClass.paramAccessors: _*)
+      val locals = newScopeWith(owner.typeParams ++ owner.classDenot.paramAccessors: _*)
       superOrThisCallContext(owner.primaryConstructor, locals)
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -15,12 +15,18 @@ import printing.Formatting._
 /** This object provides useful implicit decorators for types defined elsewhere */
 object Decorators {
 
-  /** Turns Strings into PreNames, adding toType/TermName methods */
-  implicit class PreNamedString(val s: String) extends AnyVal with PreName {
-    def toTypeName: TypeName = typeName(s)
-    def toTermName: TermName = termName(s)
-    def toText(printer: Printer): Text = Str(s)
-  }
+  /** Extension methods for toType/TermName methods on strings.
+   *  They are in an implicit object for now, so that we can import decorators
+   *  with a normal wildcard. In the future, once #9255 is in trunk, replace with
+   *  a simple collective extension.
+   */
+  implicit object PreNamedString:
+    def (pn: PreName).toTypeName: TypeName = pn match
+      case s: String => typeName(s)
+      case n: Name => n.toTypeName
+    def (pn: PreName).toTermName: TermName = pn match
+      case s: String => termName(s)
+      case n: Name => n.toTermName
 
   implicit class StringDecorator(val s: String) extends AnyVal {
     def splitWhere(f: Char => Boolean, doDropIndex: Boolean): Option[(String, String)] = {

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -853,7 +853,7 @@ class Definitions {
     "lombok.NonNull" ::
     "reactor.util.annotation.NonNull" ::
     "reactor.util.annotation.NonNullApi" ::
-    "io.reactivex.annotations.NonNull" :: Nil map PreNamedString)
+    "io.reactivex.annotations.NonNull" :: Nil)
 
   // convenient one-parameter method types
   def methOfAny(tp: Type): MethodType = MethodType(List(AnyType), tp)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1478,7 +1478,7 @@ class Definitions {
     if (!isInitialized) {
       // Enter all symbols from the scalaShadowing package in the scala package
       for (m <- ScalaShadowingPackage.info.decls)
-        ScalaPackageClass.enter(m)
+        ScalaPackageClass.classDenot.enter(m)
 
       // force initialization of every symbol that is synthesized or hijacked by the compiler
       val forced = syntheticCoreClasses ++ syntheticCoreMethods ++ ScalaValueClasses() :+ JavaEnumClass

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -17,13 +17,10 @@ import scala.annotation.internal.sharable
 object Names {
   import NameKinds._
 
-  /** A common class for things that can be turned into names.
-   *  Instances are both names and strings, the latter via a decorator.
+  /** Things that can be turned into names with `totermName` and `toTypeName`
+   *  Decorators defines implements these as extension methods for strings.
    */
-  trait PreName extends Any with Showable {
-    def toTypeName: TypeName
-    def toTermName: TermName
-  }
+  type PreName = Name | String
 
   /** A common superclass of Name and Symbol. After bootstrap, this should be
    *  just the type alias Name | Symbol
@@ -35,7 +32,7 @@ object Names {
    *  in a name table. A derived term name adds a tag, and possibly a number
    *  or a further simple name to some other name.
    */
-  abstract class Name extends Designator, PreName derives Eql {
+  abstract class Name extends Designator, Showable derives Eql {
 
     /** A type for names of the same kind as this name */
     type ThisName <: Name

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -495,7 +495,7 @@ object SymDenotations {
                 throw CyclicReference(this)
             case _ =>
               recur(parent)
-        recur(owner.asClass.givenSelfType)
+        recur(owner.classDenot.givenSelfType)
       end setAlias
 
       def bounds(t: tpd.Tree): TypeBounds = t match
@@ -1295,7 +1295,7 @@ object SymDenotations {
         case _ =>
           NoType
       }
-      recur(owner.asClass.givenSelfType)
+      recur(owner.classDenot.givenSelfType)
     }
 
     /** The non-private symbol whose name and type matches the type of this symbol
@@ -1357,7 +1357,7 @@ object SymDenotations {
     /** Returns all matching symbols defined in parents of the selftype. */
     final def extendedOverriddenSymbols(implicit ctx: Context): Iterator[Symbol] =
       if (!canMatchInheritedSymbols) Iterator.empty
-      else overriddenFromType(owner.asClass.classInfo.selfType)
+      else overriddenFromType(owner.classDenot.classInfo.selfType)
 
     private def overriddenFromType(tp: Type)(implicit ctx: Context): Iterator[Symbol] =
       tp.baseClasses match {
@@ -1822,7 +1822,7 @@ object SymDenotations {
       def traverse(parents: List[Type]): Unit = parents match {
         case p :: parents1 =>
           p.classSymbol match {
-            case pcls: ClassSymbol => builder.addAll(pcls.baseClasses)
+            case pcls: ClassSymbol => builder.addAll(pcls.classDenot.baseClasses)
             case _ => assert(isRefinementClass || p.isError || ctx.mode.is(Mode.Interactive), s"$this has non-class parent: $p")
           }
           traverse(parents1)
@@ -1878,7 +1878,7 @@ object SymDenotations {
         if (nxt.validFor.code > this.validFor.code)
           this.nextInRun.asSymDenotation.asClass.enter(sym)
         if (defn.isScalaShadowingPackageClass(sym.owner))
-          defn.ScalaPackageClass.enter(sym)  // ScalaShadowing members are mirrored in ScalaPackage
+          defn.ScalaPackageClass.classDenot.enter(sym)  // ScalaShadowing members are mirrored in ScalaPackage
       }
     }
 
@@ -2143,7 +2143,7 @@ object SymDenotations {
       def maybeAdd(name: Name) = if (keepOnly(thisType, name)) names += name
       try {
         for (p <- classParents if p.classSymbol.isClass)
-          for (name <- p.classSymbol.asClass.memberNames(keepOnly))
+          for (name <- p.classSymbol.classDenot.memberNames(keepOnly))
             maybeAdd(name)
         val ownSyms =
           if (keepOnly eq implicitFilter)

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -9,7 +9,7 @@ import config.Config
 import Contexts._, Symbols._, Flags._, SymDenotations._, Types._, Scopes._, Names._
 import NameOps._
 import StdNames.str
-import Decorators.{PreNamedString, StringInterpolators}
+import Decorators.StringInterpolators
 import classfile.ClassfileParser
 import util.Stats
 import Decorators._

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -37,7 +37,7 @@ object SymbolLoaders {
       completer.isInstanceOf[SourcefileLoader]
     assert(comesFromScan || scope.lookup(member.name) == NoSymbol,
            s"${owner.fullName}.${member.name} already has a symbol")
-    owner.asClass.enter(member, scope)
+    owner.classDenot.enter(member, scope)
     member
   }
 
@@ -77,7 +77,7 @@ object SymbolLoaders {
       if (ctx.settings.YtermConflict.value == "package" || ctx.mode.is(Mode.Interactive)) {
         ctx.warning(
           s"Resolving package/object name conflict in favor of package ${preExisting.fullName}. The object will be inaccessible.")
-        owner.asClass.delete(preExisting)
+        owner.classDenot.delete(preExisting)
       }
       else if (ctx.settings.YtermConflict.value == "object") {
         ctx.warning(

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -843,8 +843,8 @@ class TypeComparer(initctx: Context) extends ConstraintHandling[AbsentContext] w
         case pre1: ThisType =>
           pre2 match
             case pre2: ThisType =>
-              if pre1.cls.classInfo.selfType.derivesFrom(pre2.cls)
-                 && pre2.cls.classInfo.selfType.derivesFrom(pre1.cls)
+              if pre1.cls.classDenot.classInfo.selfType.derivesFrom(pre2.cls)
+                 && pre2.cls.classDenot.classInfo.selfType.derivesFrom(pre1.cls)
               then
                 subtyping.println(i"assume equal prefixes $pre1 $pre2")
                 return true

--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -30,7 +30,7 @@ class MalformedType(pre: Type, denot: Denotation, absMembers: Set[Name]) extends
 
 class MissingType(pre: Type, name: Name) extends TypeError {
   private def otherReason(pre: Type)(implicit ctx: Context): String = pre match {
-    case pre: ThisType if pre.cls.givenSelfType.exists =>
+    case pre: ThisType if pre.cls.classDenot.givenSelfType.exists =>
       i"\nor the self type of $pre might not contain all transitive dependencies"
     case _ => ""
   }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -190,7 +190,7 @@ object TypeOps:
     def dominators(cs: List[ClassSymbol], accu: List[ClassSymbol]): List[ClassSymbol] = (cs: @unchecked) match {
       case c :: rest =>
         val accu1 = if (accu exists (_ derivesFrom c)) accu else c :: accu
-        if (cs == c.baseClasses) accu1 else dominators(rest, accu1)
+        if (cs == c.classDenot.baseClasses) accu1 else dominators(rest, accu1)
       case Nil => // this case can happen because after erasure we do not have a top class anymore
         assert(ctx.erasedTypes || ctx.reporter.errorsReported)
         defn.ObjectClass :: Nil
@@ -416,7 +416,7 @@ object TypeOps:
               emptyRange // should happen only in error cases
           }
         case tp: ThisType if toAvoid(tp.cls) =>
-          range(defn.NothingType, apply(classBound(tp.cls.classInfo)))
+          range(defn.NothingType, apply(classBound(tp.cls.classDenot.classInfo)))
         case tp: SkolemType if partsToAvoid(mutable.Set.empty, tp.info).nonEmpty =>
           range(defn.NothingType, apply(tp.info))
         case tp: TypeVar if mapCtx.typerState.constraint.contains(tp) =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -495,7 +495,7 @@ object Types {
         case tp: TypeProxy =>
           tp.underlying.baseClasses
         case tp: ClassInfo =>
-          tp.cls.baseClasses
+          tp.cls.classDenot.baseClasses
         case _ => Nil
       }
     }
@@ -776,7 +776,7 @@ object Types {
      */
     final def memberNames(keepOnly: NameFilter, pre: Type = this)(implicit ctx: Context): Set[Name] = this match {
       case tp: ClassInfo =>
-        tp.cls.memberNames(keepOnly) filter (keepOnly(pre, _))
+        tp.cls.classDenot.memberNames(keepOnly) filter (keepOnly(pre, _))
       case tp: RefinedType =>
         val ns = tp.parent.memberNames(keepOnly, pre)
         if (keepOnly(pre, tp.refinedName)) ns + tp.refinedName else ns
@@ -2124,7 +2124,7 @@ object Types {
 
     private def checkSymAssign(sym: Symbol)(implicit ctx: Context) = {
       def selfTypeOf(sym: Symbol) =
-        if (sym.isClass) sym.asClass.givenSelfType else NoType
+        if (sym.isClass) sym.classDenot.givenSelfType else NoType
       assert(
         (lastSymbol eq sym)
         ||
@@ -4371,11 +4371,12 @@ object Types {
      *   - the fully applied reference to the class itself.
      */
     def selfType(implicit ctx: Context): Type = {
+      val clsd = cls.classDenot
       if (selfTypeCache == null)
         selfTypeCache = {
-          val givenSelf = cls.givenSelfType
+          val givenSelf = clsd.givenSelfType
           if (!givenSelf.isValueType) appliedRef
-          else if (cls.is(Module)) givenSelf
+          else if (clsd.is(Module)) givenSelf
           else if (ctx.erasedTypes) appliedRef
           else AndType(givenSelf, appliedRef)
         }
@@ -4385,7 +4386,7 @@ object Types {
     def appliedRef(implicit ctx: Context): Type = {
       if (appliedRefCache == null)
         appliedRefCache =
-          TypeRef(prefix, cls).appliedTo(cls.typeParams.map(_.typeRef))
+          TypeRef(prefix, cls).appliedTo(cls.classDenot.typeParams.map(_.typeRef))
       appliedRefCache
     }
 

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -196,10 +196,10 @@ class ClassfileParser(
     }
     else if (result == Some(NoEmbedded))
       for (sym <- List(moduleRoot.sourceModule, moduleRoot.symbol, classRoot.symbol)) {
-        classRoot.owner.asClass.delete(sym)
+        classRoot.owner.classDenot.delete(sym)
         if (classRoot.owner == defn.ScalaShadowingPackage.moduleClass)
           // Symbols in scalaShadowing are also added to scala
-          defn.ScalaPackageClass.delete(sym)
+          defn.ScalaPackageClass.classDenot.delete(sym)
         sym.markAbsent()
       }
 
@@ -454,7 +454,7 @@ class ClassfileParser(
         val s = ctx.newSymbol(
           owner, tpname, owner.typeParamCreationFlags,
           typeParamCompleter(index), coord = indexCoord(index))
-        if (owner.isClass) owner.asClass.enter(s)
+        if owner.isClass then owner.classDenot.enter(s)
         tparams = tparams + (tpname -> s)
         sig2typeBounds(tparams, skiptvs = true)
         newTParams += s

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -582,7 +582,7 @@ class TreeUnpickler(reader: TastyReader,
       if sym.isOpaqueAlias then sym.setFlag(Deferred)
       val isScala2MacroDefinedInScala3 = flags.is(Macro, butNot = Inline) && flags.is(Erased)
       ctx.owner match {
-        case cls: ClassSymbol if !isScala2MacroDefinedInScala3 => cls.enter(sym)
+        case cls: ClassSymbol if !isScala2MacroDefinedInScala3 => cls.classDenot.enter(sym)
         case _ =>
       }
       registerSym(start, sym)

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -79,7 +79,7 @@ object Scala2Unpickler {
     if (scope.lookup(nme.CONSTRUCTOR) == NoSymbol) {
       val constr = ctx.newDefaultConstructor(cls)
       addConstructorTypeParams(constr)
-      cls.enter(constr, scope)
+      cls.classDenot.enter(constr, scope)
     }
   }
 
@@ -491,7 +491,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       if (!(isRefinementClass(sym) || isUnpickleRoot(sym) || sym.is(Scala2Existential))) {
         val owner = sym.owner
         if (owner.isClass)
-          owner.asClass.enter(sym, symScope(owner))
+          owner.classDenot.enter(sym, symScope(owner))
         else if (isRefinementClass(owner))
           symScope(owner).openForMutations.enter(sym)
       }

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -181,7 +181,7 @@ object Completion {
     def addScopeCompletions(implicit ctx: Context): Unit = {
       if (ctx.owner.isClass) {
         addAccessibleMembers(ctx.owner.thisType)
-        ctx.owner.asClass.classInfo.selfInfo match {
+        ctx.owner.classDenot.classInfo.selfInfo match {
           case selfSym: Symbol => add(selfSym, selfSym.name)
           case _ =>
         }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -326,7 +326,7 @@ object messages {
       // to the name of the missing member
       def closest: List[(Int, String)] = candidates
         .toList
-        .map(n => (distance(n.show, missing), n))
+        .map(n => (distance(n, missing), n))
         .filter((d, n) => d <= maxDist && d < missing.length && d < n.length)
         .sorted  // sort by distance first, alphabetically second
 

--- a/compiler/src/dotty/tools/dotc/tastyreflect/FromSymbol.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/FromSymbol.scala
@@ -26,13 +26,14 @@ object FromSymbol {
   def classDef(cls: ClassSymbol)(implicit ctx: Context): tpd.TypeDef = cls.defTree match {
     case tree: tpd.TypeDef => tree
     case tpd.EmptyTree =>
-      val constrSym = cls.unforcedDecls.find(_.isPrimaryConstructor).orElse(
+      val clsd = cls.classDenot
+      val constrSym = clsd.unforcedDecls.find(_.isPrimaryConstructor).orElse(
         // Dummy constructor for classes such as `<refinement>`
         ctx.newSymbol(cls, nme.CONSTRUCTOR, EmptyFlags, NoType)
       )
       val constr = tpd.DefDef(constrSym.asTerm)
-      val parents = cls.classParents.map(tpd.TypeTree(_))
-      val body = cls.unforcedDecls.filter(!_.isPrimaryConstructor).map(s => definitionFromSym(s))
+      val parents = clsd.classParents.map(tpd.TypeTree(_))
+      val body = clsd.unforcedDecls.filter(!_.isPrimaryConstructor).map(s => definitionFromSym(s))
       tpd.ClassDefWithParents(cls, constr, parents, body)
   }
 

--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -1775,7 +1775,7 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
 
   def Symbol_caseFields(self: Symbol)(using ctx: Context): List[Symbol] =
     if (!self.isClass) Nil
-    else self.asClass.paramAccessors.collect {
+    else self.classDenot.paramAccessors.collect {
       case sym if sym.is(Flags.CaseAccessor) => sym.asTerm
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -25,7 +25,7 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(implicit ctx: Cont
      *  are also counted. This is necessary because we generate bridge methods
      *  only in classes, never in traits.
      */
-    override def parents = Array(root.superClass)
+    override def parents = Array(root.classDenot.superClass)
 
     override def exclude(sym: Symbol) =
       !sym.isOneOf(MethodOrModule) || super.exclude(sym)
@@ -94,7 +94,7 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(implicit ctx: Cont
     bridgesScope.enter(bridge)
 
     if (other.owner == root) {
-      root.delete(other)
+      root.classDenot.delete(other)
       toBeRemoved += other
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
@@ -65,7 +65,7 @@ class CheckReentrant extends MiniPhase {
     if (!seen.contains(cls) && !isIgnored(cls)) {
       seen += cls
       scanning(cls) {
-        for (sym <- cls.classInfo.decls)
+        for (sym <- cls.classDenot.classInfo.decls)
           if (sym.isTerm && !sym.isSetter && !isIgnored(sym))
             if (sym.is(Mutable)) {
               ctx.error(
@@ -77,7 +77,7 @@ class CheckReentrant extends MiniPhase {
               scanning(sym) {
                 sym.info.widenExpr.classSymbols.foreach(addVars)
               }
-        for (parent <- cls.classInfo.classParents)
+        for (parent <- cls.classDenot.classInfo.classParents)
           addVars(parent.classSymbol.asClass)
       }
     }

--- a/compiler/src/dotty/tools/dotc/transform/CheckStatic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckStatic.scala
@@ -41,7 +41,7 @@ class CheckStatic extends MiniPhase {
           ctx.error(StaticFieldsShouldPrecedeNonStatic(defn.symbol, defns), defn.sourcePos)
 
         val companion = ctx.owner.companionClass
-        def clashes = companion.asClass.membersNamed(defn.name)
+        def clashes = companion.classDenot.membersNamed(defn.name)
 
         if (!companion.exists)
           ctx.error(MissingCompanionForStatic(defn.symbol), defn.sourcePos)

--- a/compiler/src/dotty/tools/dotc/transform/ElimOpaque.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimOpaque.scala
@@ -41,7 +41,7 @@ class ElimOpaque extends MiniPhase with DenotTransformer {
           if ref.info.decl(rname).symbol.isOpaqueAlias => stripOpaqueRefinements(parent)
           case _ => tp
         }
-        val cinfo = sym.asClass.classInfo
+        val cinfo = sym.classDenot.classInfo
         val strippedSelfType = stripOpaqueRefinements(cinfo.selfType)
         ref.copySymDenotation(
           info = cinfo.derivedClassInfo(selfInfo = strippedSelfType),

--- a/compiler/src/dotty/tools/dotc/transform/ElimPolyFunction.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimPolyFunction.scala
@@ -52,7 +52,7 @@ class ElimPolyFunction extends MiniPhase with DenotTransformer {
   override def transformTemplate(tree: Template)(implicit ctx: Context): Tree = {
     val newParents = tree.parents.mapconserve(parent =>
       if (parent.tpe.typeSymbol == defn.PolyFunctionClass) {
-        val cinfo = tree.symbol.owner.asClass.classInfo
+        val cinfo = tree.symbol.owner.classDenot.classInfo
         tpd.TypeTree(functionTypeOfPoly(cinfo))
       }
       else

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -60,7 +60,7 @@ class Erasure extends Phase with DenotTransformer {
         // After erasure, all former Any members are now Object members
         val ClassInfo(pre, _, ps, decls, selfInfo) = ref.info
         val extendedScope = decls.cloneScope
-        for (decl <- defn.AnyClass.classInfo.decls)
+        for (decl <- defn.AnyClass.classDenot.classInfo.decls)
           if (!decl.isConstructor) extendedScope.enter(decl)
         ref.copySymDenotation(
           info = transformInfo(ref.symbol,

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -142,7 +142,7 @@ object ExplicitOuter {
   private def outerClass(cls: ClassSymbol)(implicit ctx: Context): Symbol = {
     val encl = cls.owner.enclosingClass
     if (cls.is(Scala2x))
-      encl.asClass.classInfo.selfInfo match {
+      encl.classDenot.classInfo.selfInfo match {
         case tp: TypeRef => tp.classSymbol
         case self: Symbol => self
         case _ => encl

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitSelf.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitSelf.scala
@@ -35,9 +35,9 @@ class ExplicitSelf extends MiniPhase {
 
   override def transformSelect(tree: Select)(implicit ctx: Context): Tree = tree match {
     case Select(thiz: This, name) if name.isTermName =>
-      val cls = thiz.symbol.asClass
-      if (cls.givenSelfType.exists && !cls.derivesFrom(tree.symbol.owner))
-        cpy.Select(tree)(thiz.cast(AndType(cls.classInfo.selfType, thiz.tpe)), name)
+      val clsd = thiz.symbol.classDenot
+      if (clsd.givenSelfType.exists && !clsd.derivesFrom(tree.symbol.owner))
+        cpy.Select(tree)(thiz.cast(AndType(clsd.classInfo.selfType, thiz.tpe)), name)
       else tree
     case _ => tree
   }

--- a/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -91,18 +91,19 @@ trait FullParameterization {
    *                            This is needed if created member stays inside scope of Foo(as in tailrec)
    */
   def fullyParameterizedType(info: Type, clazz: ClassSymbol, abstractOverClass: Boolean = true, liftThisType: Boolean = false)(implicit ctx: Context): Type = {
+    val classd = clazz.classDenot
     val (mtparamCount, origResult) = info match {
       case info: PolyType => (info.paramNames.length, info.resultType)
       case info: ExprType => (0, info.resultType)
       case _ => (0, info)
     }
-    val ctparams = if (abstractOverClass) clazz.typeParams else Nil
+    val ctparams = if (abstractOverClass) classd.typeParams else Nil
     val ctnames = ctparams.map(_.name)
 
     /** The method result type */
     def resultType(mapClassParams: Type => Type) = {
-      val thisParamType = mapClassParams(clazz.classInfo.selfType)
-      val firstArgType = if (liftThisType) thisParamType & clazz.thisType else thisParamType
+      val thisParamType = mapClassParams(classd.classInfo.selfType)
+      val firstArgType = if (liftThisType) thisParamType & classd.thisType else thisParamType
       MethodType(nme.SELF :: Nil)(
           mt => firstArgType :: Nil,
           mt => mapClassParams(origResult).substThisUnlessStatic(clazz, mt.newParamRef(0)))

--- a/compiler/src/dotty/tools/dotc/transform/MoveStatics.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MoveStatics.scala
@@ -26,8 +26,8 @@ class MoveStatics extends MiniPhase with SymTransformer {
   def transformSym(sym: SymDenotation)(implicit ctx: Context): SymDenotation =
     if (sym.hasAnnotation(defn.ScalaStaticAnnot) && sym.owner.is(Flags.Module) && sym.owner.companionClass.exists &&
         (sym.is(Flags.Method) || !(sym.is(Flags.Mutable) && sym.owner.companionClass.is(Flags.Trait)))) {
-      sym.owner.asClass.delete(sym.symbol)
-      sym.owner.companionClass.asClass.enter(sym.symbol)
+      sym.owner.classDenot.delete(sym.symbol)
+      sym.owner.companionClass.classDenot.enter(sym.symbol)
       sym.copySymDenotation(owner = sym.owner.companionClass)
     }
     else sym

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -41,7 +41,7 @@ class ParamForwarding extends MiniPhase with IdentityDenotTransformer:
   def transformIfParamAlias(mdef: ValOrDefDef)(using Context): Tree =
 
     def inheritedAccessor(sym: Symbol)(using Context): Symbol =
-      val candidate = sym.owner.asClass.superClass
+      val candidate = sym.owner.classDenot.superClass
         .info.decl(sym.name).suchThat(_.is(ParamAccessor, butNot = Mutable))
         .symbol
       if !candidate.is(Private)  // candidate might be private and accessible if it is in an outer class

--- a/compiler/src/dotty/tools/dotc/transform/RestoreScopes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/RestoreScopes.scala
@@ -38,12 +38,11 @@ class RestoreScopes extends MiniPhase with IdentityDenotTransformer { thisPhase 
           restoredDecls.enter(stat.symbol)
       // Enter class in enclosing package scope, in case it was an inner class before flatten.
       // For top-level classes this does nothing.
-      val cls = tree.symbol.asClass
-      val pkg = cls.owner.asClass
-
-      pkg.enter(cls)
+      val cls = tree.symbol
+      val clsd = cls.classDenot
+      clsd.owner.classDenot.enter(cls)
       tree.symbol.copySymDenotation(
-        info =  cls.classInfo.derivedClassInfo(
+        info =  clsd.classInfo.derivedClassInfo(
           decls = restoredDecls: Scope)).installAfter(thisPhase)
       tree
     case tree => tree

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -136,8 +136,8 @@ class SuperAccessors(thisPhase: DenotTransformer) {
           def hasClassOverride(member: Symbol, subCls: ClassSymbol): Boolean =
             if (subCls == defn.ObjectClass || subCls == member.owner) false
             else if (member.overridingSymbol(subCls).exists) true
-            else hasClassOverride(member, subCls.superClass.asClass)
-          val superCls = clazz.asClass.superClass.asClass
+            else hasClassOverride(member, subCls.classDenot.superClass.asClass)
+          val superCls = clazz.classDenot.superClass.asClass
           if (owner != superCls && hasClassOverride(sym, superCls))
             ctx.error(
               em"""Super call cannot be emitted: the selected $sym is declared in $owner, which is not the direct superclass of $clazz.

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -31,8 +31,8 @@ class SymUtils(val self: Symbol) extends AnyVal {
 
   /** All traits implemented by a class or trait except for those inherited through the superclass. */
   def directlyInheritedTraits(implicit ctx: Context): List[ClassSymbol] = {
-    val superCls = self.asClass.superClass
-    val baseClasses = self.asClass.baseClasses
+    val superCls = self.classDenot.superClass
+    val baseClasses = self.classDenot.baseClasses
     if (baseClasses.isEmpty) Nil
     else baseClasses.tail.takeWhile(_ ne superCls).reverse
   }
@@ -243,5 +243,5 @@ class SymUtils(val self: Symbol) extends AnyVal {
         parent.stripOpaques
       case _ =>
         tp
-    self.asClass.givenSelfType.stripOpaques.asSeenFrom(site, self)
+    self.classDenot.givenSelfType.stripOpaques.asSeenFrom(site, self)
 }

--- a/compiler/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TailRec.scala
@@ -216,7 +216,6 @@ class TailRec extends MiniPhase {
   }
 
   class TailRecElimination(method: Symbol, enclosingClass: ClassSymbol, paramSyms: List[Symbol], isMandatory: Boolean) extends TreeMap {
-
     var rewrote: Boolean = false
     var failureReported: Boolean = false
 
@@ -236,12 +235,13 @@ class TailRec extends MiniPhase {
     var varsForRewrittenParamSyms: List[Symbol] = Nil
 
     private def getVarForRewrittenThis()(implicit ctx: Context): Symbol =
+      val enclosingClassDenot = enclosingClass.classDenot
       varForRewrittenThis match {
         case Some(sym) => sym
         case none =>
           val tpe =
-            if (enclosingClass.is(Module)) enclosingClass.thisType
-            else enclosingClass.classInfo.selfType
+            if (enclosingClassDenot.is(Module)) enclosingClassDenot.thisType
+            else enclosingClassDenot.classInfo.selfType
           val sym = ctx.newSymbol(method, nme.SELF, Synthetic | Mutable, tpe)
           varForRewrittenThis = Some(sym)
           sym
@@ -321,7 +321,7 @@ class TailRec extends MiniPhase {
         val isRecursiveCall = calledMethod eq method
         def isRecursiveSuperCall = (method.name eq calledMethod.name) &&
           method.matches(calledMethod) &&
-          enclosingClass.appliedRef.widen <:< prefix.tpe.widenDealias
+          enclosingClass.classDenot.appliedRef.widen <:< prefix.tpe.widenDealias
 
         if (isRecursiveCall)
           if (inTailPosition) {

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -150,7 +150,7 @@ object TypeTestsCasts {
           case _ =>
             // always false test warnings are emitted elsewhere
             X.classSymbol.exists && P.classSymbol.exists &&
-              !X.classSymbol.asClass.mayHaveCommonChild(P.classSymbol.asClass) ||
+              !X.classSymbol.classDenot.mayHaveCommonChild(P.classSymbol.asClass) ||
             // first try without striping type parameters for performance
             typeArgsTrivial(X, tpe) ||
             typeArgsTrivial(stripTypeParam(X), tpe)

--- a/compiler/src/dotty/tools/dotc/transform/ValueClasses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ValueClasses.scala
@@ -35,21 +35,21 @@ object ValueClasses {
   /** The member of a derived value class that unboxes it. */
   def valueClassUnbox(cls: ClassSymbol)(implicit ctx: Context): Symbol =
     // (info.decl(nme.unbox)).orElse(...)      uncomment once we accept unbox methods
-    cls.classInfo.decls.find(_.is(ParamAccessor))
+    cls.classDenot.classInfo.decls.find(_.is(ParamAccessor))
 
   /** For a value class `d`, this returns the synthetic cast from the underlying type to
    *  ErasedValueType defined in the companion module. This method is added to the module
    *  and further described in [[ExtensionMethods]].
    */
   def u2evt(cls: ClassSymbol)(implicit ctx: Context): Symbol =
-    cls.linkedClass.info.decl(nme.U2EVT).symbol
+    cls.classDenot.linkedClass.info.decl(nme.U2EVT).symbol
 
   /** For a value class `d`, this returns the synthetic cast from ErasedValueType to the
    *  underlying type defined in the companion module. This method is added to the module
    *  and further described in [[ExtensionMethods]].
    */
   def evt2u(cls: ClassSymbol)(implicit ctx: Context): Symbol =
-    cls.linkedClass.info.decl(nme.EVT2U).symbol
+    cls.classDenot.linkedClass.info.decl(nme.EVT2U).symbol
 
   /** The unboxed type that underlies a derived value class */
   def underlyingOfValueClass(sym: ClassSymbol)(implicit ctx: Context): Type =

--- a/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
@@ -34,13 +34,14 @@ class Checker extends MiniPhase {
     if (!tree.isClassDef) return tree
 
     val cls = tree.symbol.asClass
+    val clsd = cls.classDenot
     val instantiable: Boolean =
-      cls.is(Flags.Module) ||
-      !cls.isOneOf(Flags.AbstractOrTrait) && {
+      clsd.is(Flags.Module) ||
+      !clsd.isOneOf(Flags.AbstractOrTrait) && {
         // see `Checking.checkInstantiable` in typer
-        val tp = cls.appliedRef
+        val tp = clsd.appliedRef
         val stp = SkolemType(tp)
-        val selfType = cls.givenSelfType.asSeenFrom(stp, cls)
+        val selfType = clsd.givenSelfType.asSeenFrom(stp, cls)
         !selfType.exists || stp <:< selfType
       }
 

--- a/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
@@ -86,11 +86,11 @@ object Checking {
         if (ctor.isPrimaryConstructor) checkClassBody(classDef.asInstanceOf[TypeDef])
         else checkSecondaryConstructor(ctor)
       }
-      else if (!cls.isOneOf(Flags.EffectivelyOpenFlags))
+      else if (!cls.denot.isOneOf(Flags.EffectivelyOpenFlags))
         ctx.warning("Inheriting non-open class may cause initialization errors", source.sourcePos)
     }
 
-    cls.paramAccessors.foreach { acc =>
+    cls.classDenot.paramAccessors.foreach { acc =>
       if (!acc.is(Flags.Method)) {
         traceIndented(acc.show + " initialized", init)
         state.fieldsInited += acc
@@ -112,8 +112,9 @@ object Checking {
 
       case ref =>
         val cls = ref.tpe.classSymbol.asClass
-        if (!state.parentsInited.contains(cls) && cls.primaryConstructor.exists)
-          checkCtor(cls.primaryConstructor, ref.tpe, ref)
+        val clsd = cls.classDenot
+        if (!state.parentsInited.contains(cls) && clsd.primaryConstructor.exists)
+          checkCtor(clsd.primaryConstructor, ref.tpe, ref)
     }
 
     // check class body

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -554,7 +554,7 @@ trait Applications extends Compatibility {
 
             val defaultExpr =
               if (isJavaAnnotConstr(sym)) {
-                val cinfo = sym.owner.asClass.classInfo
+                val cinfo = sym.owner.classDenot.classInfo
                 val pname = methodType.paramNames(n)
                 val hasDefault = cinfo.member(pname)
                   .suchThat(d => d.is(Method) && d.hasAnnotation(defn.AnnotationDefaultAnnot)).exists

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -823,7 +823,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
                   false
               }
             }
-          val idx = cls.asClass.paramAccessors.indexWhere(matches(_, tree.symbol))
+          val idx = cls.classDenot.paramAccessors.indexWhere(matches(_, tree.symbol))
           if (idx >= 0 && idx < args.length) {
             def finish(arg: Tree) =
               new TreeTypeMap().transform(arg) // make sure local bindings in argument have fresh symbols
@@ -1102,11 +1102,11 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
                 }
 
                 val paramType = mt.paramInfos.head
-                val paramCls = paramType.classSymbol
-                if (paramCls.is(Case) && unapp.symbol.is(Synthetic) && scrut <:< paramType) {
+                val paramClsD = paramType.classSymbol.classDenot
+                if (paramClsD.is(Case) && unapp.symbol.is(Synthetic) && scrut <:< paramType) {
                   val caseAccessors =
-                    if (paramCls.is(Scala2x)) paramCls.caseAccessors.filter(_.is(Method))
-                    else paramCls.asClass.paramAccessors
+                    if (paramClsD.is(Scala2x)) paramClsD.caseAccessors.filter(_.is(Method))
+                    else paramClsD.paramAccessors
                   val selectors =
                     for (accessor <- caseAccessors)
                     yield constToLiteral(reduceProjection(ref(scrut).select(accessor).ensureApplied))

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -235,6 +235,7 @@ trait TypeAssigner {
       case err: ErrorType => untpd.cpy.Super(tree)(qual, mix).withType(err)
       case qtype @ ThisType(_) =>
         val cls = qtype.cls
+        val clsd = cls.classDenot
         def findMixinSuper(site: Type): Type = site.parents filter (_.typeSymbol.name == mix.name) match {
           case p :: Nil =>
             p.typeConstructor
@@ -245,13 +246,13 @@ trait TypeAssigner {
         }
         val owntype =
           if (mixinClass.exists) mixinClass.appliedRef
-          else if (!mix.isEmpty) findMixinSuper(cls.info)
-          else if (ctx.erasedTypes) cls.info.firstParent.typeConstructor
+          else if (!mix.isEmpty) findMixinSuper(clsd.info)
+          else if (ctx.erasedTypes) clsd.info.firstParent.typeConstructor
           else {
-            val ps = cls.classInfo.parents
+            val ps = clsd.classInfo.parents
             if (ps.isEmpty) defn.AnyType else ps.reduceLeft((x: Type, y: Type) => x & y)
           }
-        tree.withType(SuperType(cls.thisType, owntype))
+        tree.withType(SuperType(clsd.thisType, owntype))
     }
   }
 

--- a/staging/src/scala/quoted/staging/QuoteCompiler.scala
+++ b/staging/src/scala/quoted/staging/QuoteCompiler.scala
@@ -64,7 +64,7 @@ private class QuoteCompiler extends Compiler:
           // `package __root__ { class ' { def apply: Any = <expr> } }`
           val cls = unitCtx.newCompleteClassSymbol(defn.RootClass, outputClassName, EmptyFlags,
             defn.ObjectType :: Nil, newScope, coord = pos, assocFile = assocFile).entered.asClass
-          cls.enter(unitCtx.newDefaultConstructor(cls), EmptyScope)
+          cls.classDenot.enter(unitCtx.newDefaultConstructor(cls), EmptyScope)
           val meth = unitCtx.newSymbol(cls, nme.apply, Method, ExprType(defn.AnyType), coord = pos).entered
 
           val quoted =


### PR DESCRIPTION

Add all conversions manually. That allows us to remove some duplication.
Not sure it will help performance, but it's worth a try.