### PR TITLE
Fix #9309: Don't set TypeErrors on trees that are desugared later

### DIFF
--- a/tests/neg/i9309.scala
+++ b/tests/neg/i9309.scala
@@ -1,0 +1,3 @@
+case class Foo(foo: Int) {
+  inline def foo = (foo) // error
+}


### PR DESCRIPTION
When setting the type of a tree to a type error, we have to make sure the
tree is not before desugaring. First, it does not make sense to add a type
to a tree that exists only in untyped form. Second, this might miss adding
a type to the desugared tree that needs one.

This is achieved by splitting the catch-all for TypeErrors between typedUnadapted
and adapt.