### PR TITLE
Fix #9306: Don't allow inline functions with errors in bodies

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1492,7 +1492,8 @@ class Namer { typer: Typer =>
         rhsCtx.setFreshGADTBounds
         rhsCtx.gadt.addToConstraint(typeParams)
       }
-      def rhsType = typedAheadExpr(mdef.rhs, (inherited orElse rhsProto).widenExpr)(using rhsCtx).tpe
+      def rhsType = PrepareInlineable.dropInlineIfError(sym,
+        typedAheadExpr(mdef.rhs, (inherited orElse rhsProto).widenExpr)(using rhsCtx)).tpe
 
       // Approximate a type `tp` with a type that does not contain skolem types.
       val deskolemize = new ApproximatingTypeMap {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1936,11 +1936,11 @@ class Typer extends Namer
     }
 
     if (sym.isInlineMethod) rhsCtx.addMode(Mode.InlineableBody)
-    val rhs1 =
+    val rhs1 = PrepareInlineable.dropInlineIfError(sym,
       if sym.isScala2Macro then typedScala2MacroBody(ddef.rhs)(using rhsCtx)
-      else typedExpr(ddef.rhs, tpt1.tpe.widenExpr)(using rhsCtx)
+      else typedExpr(ddef.rhs, tpt1.tpe.widenExpr)(using rhsCtx))
 
-    if (sym.isInlineMethod)
+    if sym.isInlineMethod then
       val rhsToInline = PrepareInlineable.wrapRHS(ddef, tpt1, rhs1)
       PrepareInlineable.registerInlineInfo(sym, rhsToInline)
 

--- a/tests/neg-macros/i6530.scala
+++ b/tests/neg-macros/i6530.scala
@@ -1,4 +1,4 @@
 object Macros {
   inline def q : Int = ${ '[ Int ] } // error
-  val x : Int = 1 + q // error
+  val x : Int = 1 + q
 }

--- a/tests/neg/i7294-a.scala
+++ b/tests/neg/i7294-a.scala
@@ -6,4 +6,4 @@ inline given f[T <: Foo] as T = ??? match {
   case x: T => x.g(10) // error
 }
 
-@main def Test = f // error // error
+@main def Test = f

--- a/tests/neg/i7294-b.scala
+++ b/tests/neg/i7294-b.scala
@@ -6,4 +6,4 @@ inline given f[T <: Foo] as T = ??? match {
   case x: T => x.g(10) // error
 }
 
-@main def Test = f // error // error
+@main def Test = f

--- a/tests/neg/i9308.scala
+++ b/tests/neg/i9308.scala
@@ -1,0 +1,17 @@
+
+object Baz {
+  class Foo {
+    private var v = 0
+    inline def run1 = {
+      v += { v = 1 }  // error
+      v
+    }
+    inline def run2: Int = {
+      v += { v = 1 }  // error
+      v
+    }
+  }
+  val foo = new Foo
+  foo.run1
+  foo.run2
+}


### PR DESCRIPTION
This was done previously only for one scenario: where a lazy inline body
was updated. But there were two more scenarios where errors could creep
in before the lazy annotation was forced.