### PR TITLE
Infer missing implicit args in using clause

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -540,7 +540,7 @@ object Denotations {
         tp2 match
           case tp2: MethodType
           if ctx.typeComparer.matchingMethodParams(tp1, tp2)
-             && (tp1.isImplicitMethod || tp1.isContextualMethod) == (tp2.isImplicitMethod || tp2.isContextualMethod)
+             && tp1.isImplicitMethod == tp2.isImplicitMethod
              && tp1.isErasedMethod == tp2.isErasedMethod =>
             val resType = infoMeet(tp1.resType, tp2.resType.subst(tp2, tp1), safeIntersection)
             if resType.exists then

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -380,7 +380,7 @@ object PatternMatcher {
           else {
             def applyImplicits(acc: Tree, implicits: List[Tree], mt: Type): Tree = mt match {
               case mt: MethodType =>
-                assert(mt.isImplicitMethod || mt.isContextualMethod)
+                assert(mt.isImplicitMethod)
                 val (args, rest) = implicits.splitAt(mt.paramNames.size)
                 applyImplicits(acc.appliedToArgs(args), rest, mt.resultType)
               case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -555,7 +555,7 @@ trait Applications extends Compatibility {
           def tryDefault(n: Int, args1: List[Arg]): Unit = {
             val sym = methRef.symbol
 
-            def defaultExpr =
+            val defaultArg =
               if (isJavaAnnotConstr(sym)) {
                 val cinfo = sym.owner.asClass.classInfo
                 val pname = methodType.paramNames(n)
@@ -584,14 +584,12 @@ trait Applications extends Compatibility {
 
             def implicitArg = implicitArgTree(formal, appPos.span)
 
-            if methodType.isContextualMethod && ctx.mode.is(Mode.ImplicitsEnabled) then
+            if !defaultArg.isEmpty then
+              matchArgs(args1, addTyped(treeToArg(defaultArg), formal), n + 1)
+            else if methodType.isContextualMethod && ctx.mode.is(Mode.ImplicitsEnabled) then
               matchArgs(args1, addTyped(treeToArg(implicitArg), formal), n + 1)
             else
-              val defaultArg = defaultExpr
-              if !defaultArg.isEmpty then
-                matchArgs(args1, addTyped(treeToArg(defaultArg), formal), n + 1)
-              else
-                missingArg(n)
+              missingArg(n)
           }
 
           if (formal.isRepeatedParam)

--- a/tests/run/extra-implicits.check
+++ b/tests/run/extra-implicits.check
@@ -1,0 +1,8 @@
+A(explicit)
+B(default)
+A(explicit)
+B(default)
+A(default)
+B(explicit)
+A(explicit)
+B(explicit)

--- a/tests/run/extra-implicits.scala
+++ b/tests/run/extra-implicits.scala
@@ -1,0 +1,18 @@
+
+case class A(x: String)
+case class B(x: String)
+given a1 as A("default")
+given b1 as B("default")
+val a2 = A("explicit")
+val b2 = B("explicit")
+
+def f(using a: A, b: B): Unit =
+  println(a)
+  println(b)
+
+@main def Test =
+  f(using a2)
+  f(using a = a2)
+  f(using b = b2)
+  f(using b = b2, a = a2)
+


### PR DESCRIPTION
If there are some missing arguments in a using argument clause, infer them
with implicit search.