### PR TITLE
Emit "deprecated" bytecode attribute

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
@@ -298,10 +298,9 @@ class BTypesFromSymbols[I <: DottyBackendInterface](val int: I) extends BTypes {
    */
   final def javaFlags(sym: Symbol): Int = {
 
-
     val privateFlag = sym.is(Private) || (sym.isPrimaryConstructor && sym.owner.isTopLevelModuleClass)
 
-    val finalFlag = sym.is(Final) &&  !toDenot(sym).isClassConstructor && !(sym.is(Mutable)) &&  !(sym.enclosingClass.is(Trait))
+    val finalFlag = sym.is(Final) && !toDenot(sym).isClassConstructor && !sym.is(Mutable) && !sym.enclosingClass.is(Trait)
 
     import asm.Opcodes._
     GenBCodeOps.mkFlags(
@@ -318,6 +317,7 @@ class BTypesFromSymbols[I <: DottyBackendInterface](val int: I) extends BTypes {
         //  Mixin forwarders are bridges and can be final, but final bridges confuse some frameworks
         !sym.is(Bridge))
         ACC_FINAL else 0,
+
       if (sym.isStaticMember) ACC_STATIC else 0,
       if (sym.is(Bridge)) ACC_BRIDGE | ACC_SYNTHETIC else 0,
       if (sym.is(Artifact)) ACC_SYNTHETIC else 0,
@@ -325,16 +325,17 @@ class BTypesFromSymbols[I <: DottyBackendInterface](val int: I) extends BTypes {
       if (sym.isAllOf(JavaEnumTrait)) ACC_ENUM else 0,
       if (sym.is(JavaVarargs)) ACC_VARARGS else 0,
       if (sym.is(Synchronized)) ACC_SYNCHRONIZED else 0,
-      if (false /*sym.isDeprecated*/) asm.Opcodes.ACC_DEPRECATED else 0, // TODO: add an isDeprecated method in SymUtils
-      if (sym.is(Enum)) asm.Opcodes.ACC_ENUM else 0
+      if (sym.isDeprecated) ACC_DEPRECATED else 0,
+      if (sym.is(Enum)) ACC_ENUM else 0
     )
   }
 
   def javaFieldFlags(sym: Symbol) = {
+    import asm.Opcodes._
     javaFlags(sym) | GenBCodeOps.mkFlags(
-      if (sym hasAnnotation TransientAttr) asm.Opcodes.ACC_TRANSIENT else 0,
-      if (sym hasAnnotation VolatileAttr)  asm.Opcodes.ACC_VOLATILE  else 0,
-      if (sym.is(Mutable)) 0 else asm.Opcodes.ACC_FINAL
+      if (sym.hasAnnotation(TransientAttr)) ACC_TRANSIENT else 0,
+      if (sym.hasAnnotation(VolatileAttr)) ACC_VOLATILE else 0,
+      if (sym.is(Mutable)) 0 else ACC_FINAL
     )
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -211,9 +211,6 @@ object Annotations {
    */
   implicit class AnnotInfo(val sym: Symbol) extends AnyVal {
 
-    def isDeprecated(using Context): Boolean =
-      sym.hasAnnotation(defn.DeprecatedAnnot)
-
     def deprecationMessage(using Context): Option[String] =
       for {
         annot <- sym.getAnnotation(defn.DeprecatedAnnot)

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -206,33 +206,6 @@ object Annotations {
     Annotation(defn.ThrowsAnnot.typeRef.appliedTo(tref), Ident(tref))
   }
 
-  /** A decorator that provides queries for specific annotations
-   *  of a symbol.
-   */
-  implicit class AnnotInfo(val sym: Symbol) extends AnyVal {
-
-    def deprecationMessage(using Context): Option[String] =
-      for {
-        annot <- sym.getAnnotation(defn.DeprecatedAnnot)
-        arg <- annot.argumentConstant(0)
-      }
-      yield arg.stringValue
-
-    def migrationVersion(using Context): Option[Try[ScalaVersion]] =
-      for {
-        annot <- sym.getAnnotation(defn.MigrationAnnot)
-        arg <- annot.argumentConstant(1)
-      }
-      yield ScalaVersion.parse(arg.stringValue)
-
-    def migrationMessage(using Context): Option[Try[ScalaVersion]] =
-      for {
-        annot <- sym.getAnnotation(defn.MigrationAnnot)
-        arg <- annot.argumentConstant(0)
-      }
-      yield ScalaVersion.parse(arg.stringValue)
-  }
-
   /** Extracts the type of the thrown exception from an annotation.
    *
    *  Supports both "old-style" `@throws(classOf[Exception])`

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1925,22 +1925,21 @@ object messages {
     def explain = "A sealed class or trait can only be extended in the same file as its declaration"
   }
 
-  class SymbolHasUnparsableVersionNumber(symbol: Symbol, migrationMessage: => String)(using Context)
+  class SymbolHasUnparsableVersionNumber(symbol: Symbol, migrationVersion: String)(using Context)
   extends SyntaxMsg(SymbolHasUnparsableVersionNumberID) {
-    def msg = em"${symbol.showLocated} has an unparsable version number: $migrationMessage"
+    def msg = em"${symbol.showLocated} has an unparsable version number: $migrationVersion"
     def explain =
-      em"""$migrationMessage
-          |
-          |The ${symbol.showLocated} is marked with ${hl("@migration")} indicating it has changed semantics
+      em"""The ${symbol.showLocated} is marked with ${hl("@migration")} indicating it has changed semantics
           |between versions and the ${hl("-Xmigration")} settings is used to warn about constructs
           |whose behavior may have changed since version change."""
   }
 
   class SymbolChangedSemanticsInVersion(
     symbol: Symbol,
-    migrationVersion: ScalaVersion
+    migrationVersion: ScalaVersion,
+    migrationMessage: String
   )(using Context) extends SyntaxMsg(SymbolChangedSemanticsInVersionID) {
-    def msg = em"${symbol.showLocated} has changed semantics in version $migrationVersion"
+    def msg = em"${symbol.showLocated} has changed semantics in version $migrationVersion: $migrationMessage"
     def explain = {
       em"""The ${symbol.showLocated} is marked with ${hl("@migration")} indicating it has changed semantics
           |between versions and the ${hl("-Xmigration")} settings is used to warn about constructs

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1925,9 +1925,9 @@ object messages {
     def explain = "A sealed class or trait can only be extended in the same file as its declaration"
   }
 
-  class SymbolHasUnparsableVersionNumber(symbol: Symbol, migrationVersion: String)(using Context)
+  class SymbolHasUnparsableVersionNumber(symbol: Symbol, errorMessage: String)(using Context)
   extends SyntaxMsg(SymbolHasUnparsableVersionNumberID) {
-    def msg = em"${symbol.showLocated} has an unparsable version number: $migrationVersion"
+    def msg = em"${symbol.showLocated} has an unparsable version number: $errorMessage"
     def explain =
       em"""The ${symbol.showLocated} is marked with ${hl("@migration")} indicating it has changed semantics
           |between versions and the ${hl("-Xmigration")} settings is used to warn about constructs
@@ -1940,11 +1940,10 @@ object messages {
     migrationMessage: String
   )(using Context) extends SyntaxMsg(SymbolChangedSemanticsInVersionID) {
     def msg = em"${symbol.showLocated} has changed semantics in version $migrationVersion: $migrationMessage"
-    def explain = {
+    def explain =
       em"""The ${symbol.showLocated} is marked with ${hl("@migration")} indicating it has changed semantics
           |between versions and the ${hl("-Xmigration")} settings is used to warn about constructs
           |whose behavior may have changed since version change."""
-    }
   }
 
   class UnableToEmitSwitch(tooFewCases: Boolean)(using Context)

--- a/compiler/src/dotty/tools/dotc/transform/Memoize.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Memoize.scala
@@ -100,7 +100,8 @@ class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
       if (sym.annotations.nonEmpty) {
         val cpy = sym.copySymDenotation()
         // Keep @deprecated annotation so that accessors can
-        // be marked as deprecated in the bytecode
+        // be marked as deprecated in the bytecode.
+        // TODO check the meta-annotations to know what to keep
         cpy.filterAnnotations(_.matches(defn.DeprecatedAnnot))
         cpy.installAfter(thisPhase)
       }

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -223,7 +223,10 @@ class SymUtils(val self: Symbol) extends AnyVal {
     self.is(ModuleClass) && self.sourceModule.is(Extension) && !self.sourceModule.isExtensionMethod
 
   def isScalaStatic(using Context): Boolean =
-    self.hasAnnotation(ctx.definitions.ScalaStaticAnnot)
+    self.hasAnnotation(defn.ScalaStaticAnnot)
+
+  def isDeprecated(using Context): Boolean =
+    self.hasAnnotation(defn.DeprecatedAnnot)
 
   /** Is symbol assumed or declared as an infix symbol? */
   def isDeclaredInfix(using Context): Boolean =

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -938,13 +938,30 @@ class TestBCode extends DottyBytecodeTest {
         |
         |}
       """.stripMargin
-    checkBCode(List(code)) { dir =>
+    checkBCode(code) { dir =>
       val c = loadClassNode(dir.lookupName("C.class", directory = false).input)
 
       assertInvoke(getMethod(c, "f1"), "[Ljava/lang/String;", "clone") // array descriptor as receiver
       assertInvoke(getMethod(c, "f2"), "java/lang/Object", "hashCode") // object receiver
       assertInvoke(getMethod(c, "f3"), "java/lang/Object", "hashCode")
       assertInvoke(getMethod(c, "f4"), "java/lang/Object", "toString")
+    }
+  }
+
+  @Test
+  def deprecation(): Unit = {
+    val code =
+      """@deprecated
+        |class Test {
+        |  @deprecated("do not use this function!")
+        |  def f(): Unit = ()
+        |}
+      """.stripMargin
+
+    checkBCode(code) { dir =>
+      val c = loadClassNode(dir.lookupName("Test.class", directory = false).input)
+      assert((c.access & Opcodes.ACC_DEPRECATED) != 0)
+      assert((getMethod(c, "f").access & Opcodes.ACC_DEPRECATED) != 0)
     }
   }
 }

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -953,6 +953,12 @@ class TestBCode extends DottyBytecodeTest {
     val code =
       """@deprecated
         |class Test {
+        |  @deprecated
+        |  val v = 0
+        |
+        |  @deprecated
+        |  var x = 0
+        |
         |  @deprecated("do not use this function!")
         |  def f(): Unit = ()
         |}
@@ -962,6 +968,13 @@ class TestBCode extends DottyBytecodeTest {
       val c = loadClassNode(dir.lookupName("Test.class", directory = false).input)
       assert((c.access & Opcodes.ACC_DEPRECATED) != 0)
       assert((getMethod(c, "f").access & Opcodes.ACC_DEPRECATED) != 0)
+
+      assert((getField(c, "v").access & Opcodes.ACC_DEPRECATED) != 0)
+      assert((getMethod(c, "v").access & Opcodes.ACC_DEPRECATED) != 0)
+
+      assert((getField(c, "x").access & Opcodes.ACC_DEPRECATED) != 0)
+      assert((getMethod(c, "x").access & Opcodes.ACC_DEPRECATED) != 0)
+      assert((getMethod(c, "x_$eq").access & Opcodes.ACC_DEPRECATED) != 0)
     }
   }
 }

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -19,7 +19,6 @@ import scala.io.Codec
 import dotc._
 import ast.{Trees, tpd, untpd}
 import core._, core.Decorators._
-import Annotations.AnnotInfo
 import Comments._, Constants._, Contexts._, Flags._, Names._, NameOps._, Symbols._, SymDenotations._, Trees._, Types._
 import classpath.ClassPathEntries
 import reporting._
@@ -856,7 +855,7 @@ object DottyLanguageServer {
       item.setDocumentation(hoverContent(None, documentation))
     }
 
-    item.setDeprecated(completion.symbols.forall(_.isDeprecated))
+    item.setDeprecated(completion.symbols.forall(_.hasAnnotation(defn.DeprecatedAnnot)))
     completion.symbols.headOption.foreach(s => item.setKind(completionItemKind(s)))
     item
   }


### PR DESCRIPTION
Set `ACC_DEPRECATED` when `@deprecated` is present. The warning message is also improved.

The `memoize` phase used to remove all annotations from accessors, it now keeps `@deprecated`. This way, getters and setters of deprecated fields get the deprecated bytecode attribute, and java can see the deprecation.