### PR TITLE
SourcePosition#line: Avoid unnecessary IO

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -22,7 +22,7 @@ extends interfaces.SourcePosition with Showable {
 
   def point: Int = span.point
 
-  def line: Int = if (source.file.exists) source.offsetToLine(point) else -1
+  def line: Int = if (source.content().length != 0) source.offsetToLine(point) else -1
 
   /** Extracts the lines from the underlying source file as `Array[Char]`*/
   def linesSlice: Array[Char] =


### PR DESCRIPTION
Looks like I missed this in 99574e2b9dd01c85367550e8a848f03ff1ea674f.