### PR TITLE
Refactor type splice logic

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -887,7 +887,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
       if tree.symbol.isSplice then Some(tree.args.head) else None
   }
 
-  /** Extractors for splices */
+  /** Extractors for type splices */
   object SplicedType {
     /** Extracts the content of a spliced type tree.
       *  The result can be the contents of a type splice, which

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -879,15 +879,22 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
 
   /** Extractors for splices */
   object Spliced {
-    /** Extracts the content of a spliced tree.
-     *  The result can be the contents of a term or type splice, which
-     *  will return a term or type tree respectively.
+    /** Extracts the content of a spliced expresion tree.
+     *  The result can be the contents of a term splice, which
+     *  will return a term tree.
      */
-    def unapply(tree: tpd.Tree)(using Context): Option[tpd.Tree] = tree match {
-      case tree: tpd.Apply if tree.symbol.isSplice => Some(tree.args.head)
-      case tree: tpd.Select if tree.symbol.isSplice => Some(tree.qualifier)
-      case _ => None
-    }
+    def unapply(tree: tpd.Apply)(using Context): Option[tpd.Tree] =
+      if tree.symbol.isSplice then Some(tree.args.head) else None
+  }
+
+  /** Extractors for splices */
+  object SplicedType {
+    /** Extracts the content of a spliced type tree.
+      *  The result can be the contents of a type splice, which
+      *  will return a type tree.
+      */
+    def unapply(tree: tpd.Select)(using Context): Option[tpd.Tree] =
+      if tree.symbol.isSplice then Some(tree.qualifier) else None
   }
 
   /** Extractor for not-null assertions.

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -891,11 +891,11 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       selectWithSig(sym.name, sym.signature)
 
     /** A unary apply node with given argument: `tree(arg)` */
-    def appliedTo(arg: Tree)(using Context): Tree =
+    def appliedTo(arg: Tree)(using Context): Apply =
       appliedToArgs(arg :: Nil)
 
     /** An apply node with given arguments: `tree(arg, args0, ..., argsN)` */
-    def appliedTo(arg: Tree, args: Tree*)(using Context): Tree =
+    def appliedTo(arg: Tree, args: Tree*)(using Context): Apply =
       appliedToArgs(arg :: args.toList)
 
     /** An apply node with given argument list `tree(args(0), ..., args(args.length - 1))` */
@@ -903,7 +903,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       Apply(tree, args)
 
     /** An applied node that accepts only varargs as arguments */
-    def appliedToVarargs(args: List[Tree], tpt: Tree)(using Context): Tree =
+    def appliedToVarargs(args: List[Tree], tpt: Tree)(using Context): Apply =
       appliedTo(repeated(args, tpt))
 
     /** The current tree applied to given argument lists:

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -710,7 +710,7 @@ class Definitions {
     @tu lazy val InternalQuotedType_unapply: Symbol = InternalQuotedTypeModule.requiredMethod(nme.unapply)
 
   @tu lazy val QuotedTypeClass: ClassSymbol = ctx.requiredClass("scala.quoted.Type")
-    @tu lazy val QuotedType_splice: Symbol = QuotedTypeClass.requiredType(tpnme.splice)
+    @tu lazy val QuotedType_splice: Symbol = QuotedTypeClass.requiredType(tpnme.spliceType)
 
   @tu lazy val QuotedTypeModule: Symbol = QuotedTypeClass.companionModule
 

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -578,7 +578,7 @@ object StdNames {
     val setSymbol: N            = "setSymbol"
     val setType: N              = "setType"
     val setTypeSignature: N     = "setTypeSignature"
-    val splice: N               = "$splice"
+    val spliceType: N           = "T"
     val standardInterpolator: N = "standardInterpolator"
     val staticClass : N         = "staticClass"
     val staticModule : N        = "staticModule"

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -270,13 +270,13 @@ object PCPCheckAndHeal {
 
     private def mkTagSymbolAndAssignType(spliced: TermRef): TypeDef = {
       val splicedTree = tpd.ref(spliced).withSpan(span)
-      val rhs = splicedTree.select(tpnme.splice).withSpan(span)
+      val rhs = splicedTree.select(tpnme.spliceType).withSpan(span)
       val alias = ctx.typeAssigner.assignType(untpd.TypeBoundsTree(rhs, rhs), rhs, rhs, EmptyTree)
       val local = ctx.newSymbol(
         owner = ctx.owner,
         name = UniqueName.fresh((splicedTree.symbol.name.toString + "$_").toTermName).toTypeName,
         flags = Synthetic,
-        info = TypeAlias(splicedTree.tpe.select(tpnme.splice)),
+        info = TypeAlias(splicedTree.tpe.select(tpnme.spliceType)),
         coord = span).asType
       local.addAnnotation(Annotation(defn.InternalQuoted_QuoteTypeTagAnnot))
       ctx.typeAssigner.assignType(untpd.TypeDef(local.name, alias), local)

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -123,23 +123,26 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
    *  - If inside inlined code, expand the macro code.
    *  - If inside of a macro definition, check the validity of the macro.
    */
-  protected def transformSplice(body: Tree, splice: Tree)(using Context): Tree = {
+  protected def transformSplice(body: Tree, splice: Apply)(using Context): Tree = {
     val body1 = transform(body)(using spliceContext)
-    splice match {
-      case Apply(fun @ TypeApply(_, _ :: Nil), _) if splice.isTerm =>
+    splice.fun match {
+      case fun @ TypeApply(_, _ :: Nil) =>
         // Type of the splice itsel must also be healed
         // internal.Quoted.expr[F[T]](... T ...)  -->  internal.Quoted.expr[F[$t]](... T ...)
         val tp = healType(splice.sourcePos)(splice.tpe.widenTermRefExpr)
         cpy.Apply(splice)(cpy.TypeApply(fun)(fun.fun, tpd.TypeTree(tp) :: Nil), body1 :: Nil)
-      case Apply(f @ Apply(fun @ TypeApply(_, _), qctx :: Nil), _) if splice.isTerm =>
+      case f @ Apply(fun @ TypeApply(_, _), qctx :: Nil) =>
         // Type of the splice itsel must also be healed
         // internal.Quoted.expr[F[T]](... T ...)  -->  internal.Quoted.expr[F[$t]](... T ...)
         val tp = healType(splice.sourcePos)(splice.tpe.widenTermRefExpr)
         cpy.Apply(splice)(cpy.Apply(f)(cpy.TypeApply(fun)(fun.fun, tpd.TypeTree(tp) :: Nil), qctx :: Nil), body1 :: Nil)
-      case splice: Select =>
-        val tagRef = getQuoteTypeTags.getTagRef(splice.qualifier.tpe.asInstanceOf[TermRef])
-        ref(tagRef).withSpan(splice.span)
     }
+  }
+
+  protected def transformSpliceType(body: Tree, splice: Select)(using Context): Tree = {
+    val body1 = transform(body)(using spliceContext)
+    val tagRef = getQuoteTypeTags.getTagRef(splice.qualifier.tpe.asInstanceOf[TermRef])
+    ref(tagRef).withSpan(splice.span)
   }
 
   /** Check that annotations do not contain quotes and and that splices are valid */

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -372,7 +372,7 @@ class ReifyQuotes extends MacroTransform {
             if (tree.isType)
               transformSpliceType(body, body.select(tpnme.spliceType))
             else
-              val splice = ref(defn.InternalQuoted_exprSplice).appliedToType(tree.tpe).appliedTo(body).asInstanceOf[Apply]
+              val splice = ref(defn.InternalQuoted_exprSplice).appliedToType(tree.tpe).appliedTo(body)
               transformSplice(body, splice)
 
           case tree: DefDef if tree.symbol.is(Macro) && level == 0 =>

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -370,7 +370,7 @@ class ReifyQuotes extends MacroTransform {
           case tree: RefTree if isCaptured(tree.symbol, level) =>
             val body = capturers(tree.symbol).apply(tree)
             if (tree.isType)
-              transformSpliceType(body, body.select(tpnme.splice))
+              transformSpliceType(body, body.select(tpnme.spliceType))
             else
               val splice = ref(defn.InternalQuoted_exprSplice).appliedToType(tree.tpe).appliedTo(body).asInstanceOf[Apply]
               transformSplice(body, splice)

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -1450,6 +1450,10 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
             level -= 1
             try apply(syms, body)
             finally level += 1
+          case SplicedType(body) =>
+            level -= 1
+            try apply(syms, body)
+            finally level += 1
           case _ =>
             foldOver(syms, tree)
         }

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -170,9 +170,9 @@ trait QuotesAndSplices {
       typeSym.addAnnotation(Annotation(New(ref(defn.InternalQuotedMatcher_patternTypeAnnot.typeRef)).withSpan(tree.expr.span)))
       val pat = typedPattern(tree.expr, defn.QuotedTypeClass.typeRef.appliedTo(typeSym.typeRef))(
           using spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
-      pat.select(tpnme.splice)
+      pat.select(tpnme.spliceType)
     else
-      typedSelect(untpd.Select(tree.expr, tpnme.splice), pt)(using spliceContext).withSpan(tree.span)
+      typedSelect(untpd.Select(tree.expr, tpnme.spliceType), pt)(using spliceContext).withSpan(tree.span)
   }
 
   private def checkSpliceOutsideQuote(tree: untpd.Tree)(using Context): Unit =

--- a/library/src-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/quoted/Type.scala
@@ -3,8 +3,8 @@ package scala.quoted
 import scala.quoted.show.SyntaxHighlight
 
 /** Quoted type (or kind) `T` */
-abstract class Type[T <: AnyKind] private[scala] {
-  type `$splice` = T
+abstract class Type[X <: AnyKind] private[scala] {
+  type T = X
 
   /** Show a source code like representation of this type without syntax highlight */
   def show(using qctx: QuoteContext): String =


### PR DESCRIPTION
* Specialize the matching and handling of term/type splices. This avoids unnecessary operations on either.
* Replace `scala.quoted.Type.$splice` to `T`