### PR TITLE
Fix all the redirection links in deprecated docs

### DIFF
--- a/docs/docs/reference/contextual/delegates.md
+++ b/docs/docs/reference/contextual/delegates.md
@@ -3,4 +3,4 @@ layout: doc-page
 title: "Given Instances"
 ---
 
-The contents of this page have [moved](./givens.html).
+The contents of this page have [moved](./givens.md).

--- a/docs/docs/reference/contextual/given-clauses.md
+++ b/docs/docs/reference/contextual/given-clauses.md
@@ -3,5 +3,5 @@ layout: doc-page
 title: "Given Parameters"
 ---
 
-The contents of this page have [moved](./using-clauses.html).
+The contents of this page have [moved](./using-clauses.md).
 

--- a/docs/docs/reference/contextual/implicit-by-name-parameters.md
+++ b/docs/docs/reference/contextual/implicit-by-name-parameters.md
@@ -3,5 +3,5 @@ layout: doc-page
 title: "Implicit By-Name Parameters"
 ---
 
-The contents of this page have [moved](./by-name-context-parameters.html).
+The contents of this page have [moved](./by-name-context-parameters.md).
 

--- a/docs/docs/reference/contextual/implicit-function-types-spec.md
+++ b/docs/docs/reference/contextual/implicit-function-types-spec.md
@@ -3,5 +3,5 @@ layout: doc-page
 title: "Implicit Function Types - More Details"
 ---
 
-The contents of this page have [moved](./context-functions-spec.html).
+The contents of this page have [moved](./context-functions-spec.md).
 

--- a/docs/docs/reference/contextual/implicit-function-types.md
+++ b/docs/docs/reference/contextual/implicit-function-types.md
@@ -3,4 +3,4 @@ layout: doc-page
 title: "Implicit Function Types"
 ---
 
-The contents of this page have [moved](./context-functions.html).
+The contents of this page have [moved](./context-functions.md).

--- a/docs/docs/reference/contextual/import-delegate.md
+++ b/docs/docs/reference/contextual/import-delegate.md
@@ -3,5 +3,5 @@ layout: doc-page
 title: "Import Given"
 ---
 
-The contents of this page have [moved](./given-imports.html).
+The contents of this page have [moved](./given-imports.md).
 

--- a/docs/docs/reference/contextual/import-implied.md
+++ b/docs/docs/reference/contextual/import-implied.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./given-imports.html).
+The contents of this page have [moved](./given-imports.md).

--- a/docs/docs/reference/contextual/inferable-by-name-parameters.md
+++ b/docs/docs/reference/contextual/inferable-by-name-parameters.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./by-name-context-parameters.html).
+The contents of this page have [moved](./by-name-context-parameters.md).

--- a/docs/docs/reference/contextual/inferable-params.md
+++ b/docs/docs/reference/contextual/inferable-params.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./using-clauses.html).
+The contents of this page have [moved](./using-clauses.md).

--- a/docs/docs/reference/contextual/instance-defs.md
+++ b/docs/docs/reference/contextual/instance-defs.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./givens.html).
+The contents of this page have [moved](./givens.md).

--- a/docs/docs/reference/contextual/query-types-spec.md
+++ b/docs/docs/reference/contextual/query-types-spec.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./context-functions-spec.html).
+The contents of this page have [moved](./context-functions-spec.md).

--- a/docs/docs/reference/contextual/query-types.md
+++ b/docs/docs/reference/contextual/query-types.md
@@ -1,1 +1,1 @@
-The contents of this page have [moved](./context-functions.html).
+The contents of this page have [moved](./context-functions.md).

--- a/docs/docs/reference/other-new-features/implicit-by-name-parameters.md
+++ b/docs/docs/reference/other-new-features/implicit-by-name-parameters.md
@@ -2,4 +2,4 @@
 layout: doc-page
 title: "Implicit By-Name Parameters"
 ---
-The contents of this page have [moved](../contextual/by-name-context-parameters.html).
+The contents of this page have [moved](../contextual/by-name-context-parameters.md).


### PR DESCRIPTION
All the [moved] links should point to .md files instead of .html files