### PR TITLE
Fix CompilationUnit.apply

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -111,7 +111,7 @@ object CompilationUnit {
         NoSource
       }
       else source
-    new CompilationUnit(source)
+    new CompilationUnit(src)
   }
 
   /** Force the tree to be loaded */


### PR DESCRIPTION
I assume this is the way `CompilationUnit.apply` was intended to be implemented. 