### PR TITLE
Fix #7312: Choose root imports based on the source file

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -14,6 +14,7 @@ import dotty.tools.dotc.transform.MegaPhase._
 import dotty.tools.dotc.transform._
 import Periods._
 import typer.{FrontEnd, RefChecks}
+import typer.ImportInfo.withRootImports
 import ast.tpd
 
 object Phases {
@@ -291,7 +292,7 @@ object Phases {
     /** @pre `isRunnable` returns true */
     def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] =
       units.map { unit =>
-        val unitCtx = ctx.fresh.setPhase(this.start).setCompilationUnit(unit)
+        val unitCtx = ctx.fresh.setPhase(this.start).setCompilationUnit(unit).withRootImports
         run(using unitCtx)
         unitCtx.compilationUnit
       }

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -101,7 +101,7 @@ object JavaParsers {
     def javaLangObject(): Tree = javaLangDot(tpnme.Object)
 
     def arrayOf(tpt: Tree): AppliedTypeTree =
-      AppliedTypeTree(Ident(nme.Array.toTypeName), List(tpt))
+      AppliedTypeTree(scalaDot(tpnme.Array), List(tpt))
 
     def makeTemplate(parents: List[Tree], stats: List[Tree], tparams: List[TypeDef], needsDummyConstr: Boolean): Template = {
       def pullOutFirstConstr(stats: List[Tree]): (Tree, List[Tree]) = stats match {

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -321,7 +321,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   }
 
   protected def isOmittablePrefix(sym: Symbol): Boolean =
-    defn.UnqualifiedOwnerTypes.exists(_.symbol == sym) || isEmptyPrefix(sym)
+    defn.unqualifiedOwnerTypes.exists(_.symbol == sym) || isEmptyPrefix(sym)
 
   protected def isEmptyPrefix(sym: Symbol): Boolean =
     sym.isEffectiveRoot || sym.isAnonymousClass || sym.name.isReplWrapperName

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -664,7 +664,7 @@ class SpaceEngine(using Context) extends SpaceLogic {
 
     def isOmittable(sym: Symbol) =
       sym.isEffectiveRoot || sym.isAnonymousClass || sym.name.isReplWrapperName ||
-        ctx.definitions.UnqualifiedOwnerTypes.exists(_.symbol == sym) ||
+        ctx.definitions.unqualifiedOwnerTypes.exists(_.symbol == sym) ||
         sym.showFullName.startsWith("scala.") ||
         sym == enclosingCls || sym == enclosingCls.sourceModule
 

--- a/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
+++ b/compiler/src/dotty/tools/dotc/typer/FrontEnd.scala
@@ -7,7 +7,8 @@ import Phases._
 import Contexts._
 import Symbols._
 import Decorators._
-import dotty.tools.dotc.parsing.JavaParsers.JavaParser
+import ImportInfo.withRootImports
+import parsing.JavaParsers.JavaParser
 import parsing.Parsers.Parser
 import config.Config
 import config.Printers.{typr, default}
@@ -98,7 +99,7 @@ class FrontEnd extends Phase {
     val unitContexts =
       for unit <- units yield
         report.inform(s"compiling ${unit.source}")
-        ctx.fresh.setCompilationUnit(unit)
+        ctx.fresh.setCompilationUnit(unit).withRootImports
     unitContexts.foreach(parse(using _))
     record("parsedTrees", ast.Trees.ntrees)
     remaining = unitContexts
@@ -123,7 +124,7 @@ class FrontEnd extends Phase {
                 |  ${suspendedUnits.toList}%, %
                 |"""
       val enableXprintSuspensionHint =
-        if (ctx.settings.XprintSuspension.value) ""
+        if ctx.settings.XprintSuspension.value then ""
         else "\n\nCompiling with  -Xprint-suspension   gives more information."
       report.error(em"""Cyclic macro dependencies $where
                     |Compilation stopped since no further progress can be made.

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -17,24 +17,32 @@ import Decorators._
 
 object ImportInfo {
 
-  type RootRef = (
-    () => TermRef,  // a lazy reference to the root module to be imported
-    Boolean         // true if this will refer to scala.Predef
-  )
+  case class RootRef(refFn: () => TermRef, isPredef: Boolean = false)
 
-  /** The import info for a root import from given symbol `sym` */
-  def rootImport(rootRef: RootRef)(using Context): ImportInfo =
-    val (refFn, isPredef) = rootRef
+  /** The import info for a root import */
+  def rootImport(ref: RootRef)(using Context): ImportInfo =
     var selectors =
       untpd.ImportSelector(untpd.Ident(nme.WILDCARD))  // import all normal members...
       :: untpd.ImportSelector(untpd.Ident(nme.EMPTY))  // ... and also all given members
       :: Nil
-    if isPredef then                                   // do not import any2stringadd
+    if ref.isPredef then                               // do not import any2stringadd
       selectors = untpd.ImportSelector(untpd.Ident(nme.any2stringadd), untpd.Ident(nme.WILDCARD))
         :: selectors
-    def expr(using Context) = tpd.Ident(refFn())
-    def imp(using Context) = tpd.Import(expr, selectors)
-    ImportInfo(imp.symbol, selectors, None, isRootImport = true)
+
+    def sym(using Context) =
+      val expr = tpd.Ident(ref.refFn()) // refFn must be called in the context of ImportInfo.sym
+      tpd.Import(expr, selectors).symbol
+
+    ImportInfo(sym, selectors, None, isRootImport = true)
+
+  extension (c: Context):
+    def withRootImports(rootRefs: List[RootRef])(using Context): Context =
+      rootRefs.foldLeft(c)((ctx, ref) => ctx.fresh.setImportInfo(rootImport(ref)))
+
+    def withRootImports: Context =
+      given Context = c
+      c.withRootImports(defn.rootImportFns)
+
 }
 
 /** Info relating to an import clause
@@ -164,7 +172,7 @@ class ImportInfo(symf: Context ?=> Symbol,
         case Some(symName) => defn.ShadowableImportNames.contains(symName)
         case None => false
       myUnimported =
-        if maybeShadowsRoot && defn.RootImportTypes.exists(_.symbol == sym) then sym
+        if maybeShadowsRoot && defn.rootImportTypes.exists(_.symbol == sym) then sym
         else NoSymbol
       assert(myUnimported != null)
     myUnimported

--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -226,7 +226,7 @@ trait ImportSuggestions:
 
     try
       val roots = suggestionRoots
-        .filterNot(root => defn.RootImportTypes.exists(_.symbol == root.symbol))
+        .filterNot(root => defn.rootImportTypes.exists(_.symbol == root.symbol))
           // don't suggest things that are imported by default
 
       def extensionImports = pt match

--- a/compiler/src/dotty/tools/repl/ReplFrontEnd.scala
+++ b/compiler/src/dotty/tools/repl/ReplFrontEnd.scala
@@ -4,6 +4,7 @@ package repl
 import dotc.typer.FrontEnd
 import dotc.CompilationUnit
 import dotc.core.Contexts._
+import dotc.typer.ImportInfo.withRootImports
 
 /** A customized `FrontEnd` for the REPL
  *
@@ -17,10 +18,10 @@ private[repl] class REPLFrontEnd extends FrontEnd {
 
   override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] = {
     assert(units.size == 1) // REPl runs one compilation unit at a time
-
-    val unitContext = ctx.fresh.setCompilationUnit(units.head)
+    val unit = units.head
+    val unitContext = ctx.fresh.setCompilationUnit(unit).withRootImports
     enterSyms(using unitContext)
     typeCheck(using unitContext)
-    List(unitContext.compilationUnit)
+    List(unit)
   }
 }

--- a/tests/run/java-no-scala-import/Config.java
+++ b/tests/run/java-no-scala-import/Config.java
@@ -1,0 +1,25 @@
+public class Config {
+  long longVal;
+  Long longObj;
+  Integer boxed;
+
+  public long getLongVal() {
+    return longVal;
+  }
+
+  public void setLongVal(long longVal) {
+    this.longVal = longVal;
+  }
+
+  public Long getLongObj() {
+    return longObj;
+  }
+
+  public void setLongObj(Long longObj) {
+    this.longObj = longObj;
+  }
+
+  public Long longLength(String str) {
+    return Long.valueOf(str.length());
+  }
+}

--- a/tests/run/java-no-scala-import/Test.scala
+++ b/tests/run/java-no-scala-import/Test.scala
@@ -1,0 +1,6 @@
+object Test extends App {
+  val c = new Config()
+  c.setLongObj(10)
+  println(c.getLongObj)
+  val l = c.longLength("test")
+}


### PR DESCRIPTION
Use different root imports for java and scala files, so that (for instance) `Long` means `java.lang.Long` when parsing java files (unless `scala.Long` is imported, of course).
This also paves the way for `-Yimports`.