### PR TITLE
Simplify TypeComparer

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -49,6 +49,9 @@ object Config {
    */
   final val checkBackendNames = false
 
+  /** Check that re-used type comparers are in their initialization state */
+  final val checkTypeComparerReset = true
+
   /** Type comparer will fail with an assert if the upper bound
    *  of a constrained parameter becomes Nothing. This should be turned
    *  on only for specific debugging as normally instantiation to Nothing

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -50,7 +50,7 @@ object Config {
   final val checkBackendNames = false
 
   /** Check that re-used type comparers are in their initialization state */
-  final val checkTypeComparerReset = true
+  final val checkTypeComparerReset = false
 
   /** Type comparer will fail with an assert if the upper bound
    *  of a constrained parameter becomes Nothing. This should be turned

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -54,11 +54,18 @@ trait ConstraintHandling {
    */
   protected var comparedTypeLambdas: Set[TypeLambda] = Set.empty
 
+  def checkReset() =
+    assert(addConstraintInvocations == 0)
+    assert(frozenConstraint == false)
+    assert(caseLambda == NoType)
+    assert(homogenizeArgs == false)
+    assert(comparedTypeLambdas == Set.empty)
+
   /** Gives for each instantiated type var that does not yet have its `inst` field
-    *  set, the instance value stored in the constraint. Storing instances in constraints
-    *  is done only in a temporary way for contexts that may be retracted
-    *  without also retracting the type var as a whole.
-    */
+   *  set, the instance value stored in the constraint. Storing instances in constraints
+   *  is done only in a temporary way for contexts that may be retracted
+   *  without also retracting the type var as a whole.
+   */
   def instType(tvar: TypeVar): Type = constraint.entry(tvar.origin) match {
     case _: TypeBounds => NoType
     case tp: TypeParamRef =>

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -731,7 +731,7 @@ object Contexts {
       result.init(ctx)
       result
 
-  def comparing[T](op: TypeComparer => T)(using Context): T =
+  inline def comparing[T](inline op: TypeComparer => T)(using Context): T =
     val saved = ctx.base.comparersInUse
     try op(comparer)
     finally ctx.base.comparersInUse = saved

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1324,7 +1324,7 @@ class Definitions {
   def asContextFunctionType(tp: Type)(using Context): Type =
     tp.stripTypeVar.dealias match {
       case tp1: TypeParamRef if ctx.typerState.constraint.contains(tp1) =>
-        asContextFunctionType(ctx.typeComparer.bounds(tp1).hiBound)
+        asContextFunctionType(TypeComparer.bounds(tp1).hiBound)
       case tp1 =>
         if (isFunctionType(tp1) && tp1.typeSymbol.name.isContextFunction) tp1
         else NoType

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -539,7 +539,7 @@ object Denotations {
       case tp1: MethodType =>
         tp2 match
           case tp2: MethodType
-          if ctx.typeComparer.matchingMethodParams(tp1, tp2)
+          if TypeComparer.matchingMethodParams(tp1, tp2)
              && tp1.isImplicitMethod == tp2.isImplicitMethod
              && tp1.isErasedMethod == tp2.isErasedMethod =>
             val resType = infoMeet(tp1.resType, tp2.resType.subst(tp2, tp1), safeIntersection)

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -220,8 +220,8 @@ final class ProperGadtConstraint private(
   override protected def constraint = myConstraint
   override protected def constraint_=(c: Constraint) = myConstraint = c
 
-  override protected def isSub(tp1: Type, tp2: Type)(using Context): Boolean = ctx.typeComparer.isSubType(tp1, tp2)
-  override protected def isSame(tp1: Type, tp2: Type)(using Context): Boolean = ctx.typeComparer.isSameType(tp1, tp2)
+  override protected def isSub(tp1: Type, tp2: Type)(using Context): Boolean = TypeComparer.isSubType(tp1, tp2)
+  override protected def isSame(tp1: Type, tp2: Type)(using Context): Boolean = TypeComparer.isSameType(tp1, tp2)
 
    override def nonParamBounds(param: TypeParamRef)(using Context): TypeBounds =
      constraint.nonParamBounds(param) match {

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1991,7 +1991,7 @@ object SymDenotations {
             computeApplied
 
           case tp: TypeParamRef =>  // uncachable, since baseType depends on context bounds
-            recur(ctx.typeComparer.bounds(tp).hi)
+            recur(TypeComparer.bounds(tp).hi)
 
           case tp: TypeProxy =>
             def computeTypeProxy = {

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2591,6 +2591,11 @@ object TypeComparer {
   def provablyDisjoint(tp1: Type, tp2: Type)(using Context): Boolean =
     comparing(_.provablyDisjoint(tp1, tp2))
 
+  def liftIfHK(tp1: Type, tp2: Type,
+      op: (Type, Type) => Type, original: (Type, Type) => Type,
+      combineVariance: (Variance, Variance) => Variance)(using Context): Type =
+    comparing(_.liftIfHK(tp1, tp2, op, original, combineVariance))
+
   def constValue(tp: Type)(using Context): Option[Constant] =
     comparing(_.constValue(tp))
 

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -133,6 +133,12 @@ class TypeComparer(using val comparerCtx: Context) extends ConstraintHandling wi
     }
   }
 
+  def testSubType(tp1: Type, tp2: Type): CompareResult =
+    GADTused = false
+    if !topLevelSubType(tp1, tp2) then CompareResult.Fail
+    else if GADTused then CompareResult.OKwithGADTUsed
+    else CompareResult.OK
+
   /** The current approximation state. See `ApproxState`. */
   private var approx: ApproxState = FreshApprox
   protected def approxState: ApproxState = approx
@@ -141,7 +147,7 @@ class TypeComparer(using val comparerCtx: Context) extends ConstraintHandling wi
    *  every time we compare components of the previous pair of types.
    *  This type is used for capture conversion in `isSubArgs`.
    */
-  private [this] var leftRoot: Type = _
+  private [this] var leftRoot: Type = null
 
   /** Are we forbidden from recording GADT constraints? */
   private var frozenGadt = false
@@ -2492,6 +2498,9 @@ class TypeComparer(using val comparerCtx: Context) extends ConstraintHandling wi
 }
 
 object TypeComparer {
+
+  enum CompareResult:
+    case OK, Fail, OKwithGADTUsed
 
   /** Class for unification variables used in `natValue`. */
   private class AnyConstantType extends UncachedGroundType with ValueType {

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -468,7 +468,7 @@ class TypeErasure(isJava: Boolean, semiEraseVCs: Boolean, isConstructor: Boolean
     case AndType(tp1, tp2) =>
       erasedGlb(this(tp1), this(tp2), isJava)
     case OrType(tp1, tp2) =>
-      ctx.typeComparer.orType(this(tp1), this(tp2), isErased = true)
+      TypeComparer.orType(this(tp1), this(tp2), isErased = true)
     case tp: MethodType =>
       def paramErasure(tpToErase: Type) =
         erasureFn(tp.isJavaMethod, semiEraseVCs, isConstructor, wildcardOK)(tpToErase)

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -216,7 +216,7 @@ object TypeOps:
             case AppliedType(tycon2, args2) =>
               tp1.derivedAppliedType(
                 mergeRefinedOrApplied(tycon1, tycon2),
-                ctx.typeComparer.lubArgs(args1, args2, tycon1.typeParams))
+                TypeComparer.lubArgs(args1, args2, tycon1.typeParams))
             case _ => fallback
           }
         case tp1 @ TypeRef(pre1, _) =>
@@ -334,7 +334,7 @@ object TypeOps:
    */
   def classBound(info: ClassInfo)(using Context): Type = {
     val cls = info.cls
-    val parentType = info.parents.reduceLeft(ctx.typeComparer.andType(_, _))
+    val parentType = info.parents.reduceLeft(TypeComparer.andType(_, _))
 
     def addRefinement(parent: Type, decl: Symbol) = {
       val inherited =
@@ -420,8 +420,8 @@ object TypeOps:
         case tp: SkolemType if partsToAvoid(mutable.Set.empty, tp.info).nonEmpty =>
           range(defn.NothingType, apply(tp.info))
         case tp: TypeVar if mapCtx.typerState.constraint.contains(tp) =>
-          val lo = mapCtx.typeComparer.instanceType(
-            tp.origin, fromBelow = variance > 0 || variance == 0 && tp.hasLowerBound)
+          val lo = TypeComparer.instanceType(
+            tp.origin, fromBelow = variance > 0 || variance == 0 && tp.hasLowerBound)(using mapCtx)
           val lo1 = apply(lo)
           if (lo1 ne lo) lo1 else tp
         case _ =>

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -141,7 +141,7 @@ class TyperState() {
     val toCollect = new mutable.ListBuffer[TypeLambda]
     constraint foreachTypeVar { tvar =>
       if (!tvar.inst.exists) {
-        val inst = ctx.typeComparer.instType(tvar)
+        val inst = TypeComparer.instType(tvar)
         if (inst.exists && (tvar.owningState.get eq this)) {
           tvar.inst = inst
           val lam = tvar.origin.binder

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -915,13 +915,13 @@ object Types {
     /** Is this type a subtype of that type? */
     final def <:<(that: Type)(using Context): Boolean = {
       record("<:<")
-      ctx.typeComparer.topLevelSubType(this, that)
+      TypeComparer.topLevelSubType(this, that)
     }
 
     /** Is this type a subtype of that type? */
     final def frozen_<:<(that: Type)(using Context): Boolean = {
       record("frozen_<:<")
-      ctx.typeComparer.isSubTypeWhenFrozen(this, that)
+      TypeComparer.isSubTypeWhenFrozen(this, that)
     }
 
     /** Is this type the same as that type?
@@ -929,11 +929,11 @@ object Types {
      */
     final def =:=(that: Type)(using Context): Boolean = {
       record("=:=")
-      ctx.typeComparer.isSameType(this, that)
+      TypeComparer.isSameType(this, that)
     }
 
     final def frozen_=:=(that: Type)(using Context): Boolean =
-      ctx.typeComparer.isSameTypeWhenFrozen(this, that)
+      TypeComparer.isSameTypeWhenFrozen(this, that)
 
     /** Is this type a primitive value type which can be widened to the primitive value type `that`? */
     def isValueSubType(that: Type)(using Context): Boolean = widen match {
@@ -988,7 +988,7 @@ object Types {
      */
     def matches(that: Type)(using Context): Boolean = {
       record("matches")
-      ctx.typeComparer.matchesType(this, that, relaxed = !ctx.phase.erasedTypes)
+      TypeComparer.matchesType(this, that, relaxed = !ctx.phase.erasedTypes)
     }
 
     /** This is the same as `matches` except that it also matches => T with T and
@@ -1012,7 +1012,7 @@ object Types {
 
     def & (that: Type)(using Context): Type = {
       record("&")
-      ctx.typeComparer.glb(this, that)
+      TypeComparer.glb(this, that)
     }
 
     /** Safer version of `&`.
@@ -1046,7 +1046,7 @@ object Types {
 
     def | (that: Type)(using Context): Type = {
       record("|")
-      ctx.typeComparer.lub(this, that)
+      TypeComparer.lub(this, that)
     }
 
 // ----- Unwrapping types -----------------------------------------------
@@ -1156,7 +1156,7 @@ object Types {
 
     def widenUnionWithoutNull(using Context): Type = widen match {
       case tp @ OrType(lhs, rhs) =>
-        ctx.typeComparer.lub(lhs.widenUnionWithoutNull, rhs.widenUnionWithoutNull, canConstrain = true) match {
+        TypeComparer.lub(lhs.widenUnionWithoutNull, rhs.widenUnionWithoutNull, canConstrain = true) match {
           case union: OrType => union.join
           case res => res
         }
@@ -4184,7 +4184,7 @@ object Types {
      *  uninstantiated
      */
     def instanceOpt(using Context): Type =
-      if (inst.exists) inst else ctx.typeComparer.instType(this)
+      if (inst.exists) inst else TypeComparer.instType(this)
 
     /** Is the variable already instantiated? */
     def isInstantiated(using Context): Boolean = instanceOpt.exists
@@ -4208,7 +4208,7 @@ object Types {
         val atp = TypeOps.avoid(tp, problems.toList)
         def msg = i"Inaccessible variables captured in instantation of type variable $this.\n$tp was fixed to $atp"
         typr.println(msg)
-        val bound = ctx.typeComparer.fullUpperBound(origin)
+        val bound = TypeComparer.fullUpperBound(origin)
         if !(atp <:< bound) then
           throw new TypeError(s"$msg,\nbut the latter type does not conform to the upper bound $bound")
         atp
@@ -4223,7 +4223,7 @@ object Types {
     def instantiateWith(tp: Type)(using Context): Type = {
       assert(tp ne this, s"self instantiation of ${tp.show}, constraint = ${ctx.typerState.constraint.show}")
       typr.println(s"instantiating ${this.show} with ${tp.show}")
-      if ((ctx.typerState eq owningState.get) && !ctx.typeComparer.subtypeCheckInProgress)
+      if ((ctx.typerState eq owningState.get) && !TypeComparer.subtypeCheckInProgress)
         inst = tp
       ctx.typerState.constraint = ctx.typerState.constraint.replace(origin, tp)
       tp
@@ -4237,7 +4237,7 @@ object Types {
      *  is also a singleton type.
      */
     def instantiate(fromBelow: Boolean)(using Context): Type =
-      instantiateWith(avoidCaptures(ctx.typeComparer.instanceType(origin, fromBelow)))
+      instantiateWith(avoidCaptures(TypeComparer.instanceType(origin, fromBelow)))
 
     /** For uninstantiated type variables: Is the lower bound different from Nothing? */
     def hasLowerBound(using Context): Boolean =
@@ -4304,13 +4304,11 @@ object Types {
     override def tryNormalize(using Context): Type = reduced.normalized
 
     def reduced(using Context): Type = {
-      val trackingCtx = ctx.fresh.setTypeComparerFn(new TrackingTypeComparer(using _))
-      val typeComparer = trackingCtx.typeComparer.asInstanceOf[TrackingTypeComparer]
 
       def contextInfo(tp: Type): Type = tp match {
         case tp: TypeParamRef =>
           val constraint = ctx.typerState.constraint
-          if (constraint.entry(tp).exists) ctx.typeComparer.fullBounds(tp)
+          if (constraint.entry(tp).exists) TypeComparer.fullBounds(tp)
           else NoType
         case tp: TypeRef =>
           val bounds = ctx.gadt.fullBounds(tp.symbol)
@@ -4319,12 +4317,11 @@ object Types {
           tp.underlying
       }
 
-      def updateReductionContext(): Unit = {
+      def updateReductionContext(footprint: collection.Set[Type]): Unit =
         reductionContext = new mutable.HashMap
-        for (tp <- typeComparer.footprint)
+        for (tp <- footprint)
           reductionContext(tp) = contextInfo(tp)
-        typr.println(i"footprint for $this $hashCode: ${typeComparer.footprint.toList.map(x => (x, contextInfo(x)))}%, %")
-      }
+        typr.println(i"footprint for $this $hashCode: ${footprint.toList.map(x => (x, contextInfo(x)))}%, %")
 
       def isUpToDate: Boolean =
         reductionContext.keysIterator.forall { tp =>
@@ -4337,14 +4334,13 @@ object Types {
         if (myReduced != null) record("MatchType.reduce cache miss")
         myReduced =
           trace(i"reduce match type $this $hashCode", typr, show = true) {
-            try
-              typeComparer.matchCases(scrutinee.normalized, cases)(using trackingCtx)
-            catch {
-              case ex: Throwable =>
+            def matchCases(cmp: TrackingTypeComparer): Type =
+              try cmp.matchCases(scrutinee.normalized, cases)
+              catch case ex: Throwable =>
                 handleRecursive("reduce type ", i"$scrutinee match ...", ex)
-            }
+              finally updateReductionContext(cmp.footprint)
+            TypeComparer.tracked(matchCases)
           }
-        updateReductionContext()
       }
       myReduced
     }
@@ -5553,7 +5549,7 @@ object Types {
           case tp: TypeRef if tp.info.isTypeAlias =>
             apply(n, tp.superType)
           case tp: TypeParamRef =>
-            apply(n, ctx.typeComparer.bounds(tp))
+            apply(n, TypeComparer.bounds(tp))
           case _ =>
             foldOver(n, tp)
         }
@@ -5581,7 +5577,7 @@ object Types {
             val tsym = if (tp.termSymbol.is(Param)) tp.underlying.typeSymbol else tp.termSymbol
             foldOver(cs + tsym, tp)
           case tp: TypeParamRef =>
-            apply(cs, ctx.typeComparer.bounds(tp))
+            apply(cs, TypeComparer.bounds(tp))
           case other =>
             foldOver(cs, tp)
         }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2948,7 +2948,7 @@ object Types {
 
     /** Like `make`, but also supports higher-kinded types as argument */
     def makeHk(tp1: Type, tp2: Type)(using Context): Type =
-      ctx.typeComparer.liftIfHK(tp1, tp2, AndType.make(_, _, checkValid = false), makeHk, _ | _)
+      TypeComparer.liftIfHK(tp1, tp2, AndType.make(_, _, checkValid = false), makeHk, _ | _)
   }
 
   abstract case class OrType(tp1: Type, tp2: Type) extends AndOrType {
@@ -3038,7 +3038,7 @@ object Types {
 
     /** Like `make`, but also supports higher-kinded types as argument */
     def makeHk(tp1: Type, tp2: Type)(using Context): Type =
-      ctx.typeComparer.liftIfHK(tp1, tp2, OrType(_, _), makeHk, _ & _)
+      TypeComparer.liftIfHK(tp1, tp2, OrType(_, _), makeHk, _ & _)
   }
 
   /** An extractor object to pattern match against a nullable union.

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -199,7 +199,7 @@ object Formatting {
 
     entry match {
       case param: TypeParamRef =>
-        s"is a type variable${addendum("constraint", ctx.typeComparer.bounds(param))}"
+        s"is a type variable${addendum("constraint", TypeComparer.bounds(param))}"
       case param: TermParamRef =>
         s"is a reference to a value parameter"
       case sym: Symbol =>

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -216,7 +216,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
           val constr = ctx.typerState.constraint
           val bounds =
             if constr.contains(tp) then
-              withMode(Mode.Printing)(ctx.typeComparer.fullBounds(tp.origin))
+              withMode(Mode.Printing)(TypeComparer.fullBounds(tp.origin))
             else
               TypeBounds.empty
           if (bounds.isTypeAlias) toText(bounds.lo) ~ (Str("^") provided printDebug)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -248,8 +248,8 @@ import ast.tpd
         case tp: TypeParamRef =>
           constraint.entry(tp) match
             case bounds: TypeBounds =>
-              if variance < 0 then apply(mapCtx.typeComparer.fullUpperBound(tp))
-              else if variance > 0 then apply(mapCtx.typeComparer.fullLowerBound(tp))
+              if variance < 0 then apply(TypeComparer.fullUpperBound(tp))
+              else if variance > 0 then apply(TypeComparer.fullLowerBound(tp))
               else tp
             case NoType => tp
             case instType => apply(instType)

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -341,7 +341,7 @@ class TreeChecker extends Phase with SymTransformer {
                |Original tree : ${tree.show}
                |After checking: ${tree1.show}
                |Why different :
-             """.stripMargin + core.TypeComparer.explained(tp1 <:< tp2)
+             """.stripMargin + core.TypeComparer.explained(_.isSubType(tp1, tp2))
           if (tree.hasType) // it might not be typed because Typer sometimes constructs new untyped trees and resubmits them to typedUnadapted
             assert(isSubType(tree1.tpe, tree.typeOpt), divergenceMsg(tree1.tpe, tree.typeOpt))
           tree1

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -120,7 +120,7 @@ object TypeTestsCasts {
 
       val res = P1 <:< P
 
-      debug.println(TypeComparer.explained(P1 <:< P))
+      debug.println(TypeComparer.explained(_.isSubType(P1, P)))
 
       debug.println("P1 : " + P1.show)
       debug.println("P1 <:< P = " + res)

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -345,7 +345,7 @@ class SpaceEngine(using Context) extends SpaceLogic {
       Empty
     }
     else {
-      val res = ctx.typeComparer.provablyDisjoint(tp1, tp2)
+      val res = TypeComparer.provablyDisjoint(tp1, tp2)
 
       if (res) Empty
       else if (tp1.isSingleton) Typ(tp1, true)
@@ -499,7 +499,7 @@ class SpaceEngine(using Context) extends SpaceLogic {
 
   /** Is `tp1` a subtype of `tp2`?  */
   def isSubType(tp1: Type, tp2: Type): Boolean = {
-    debug.println(TypeComparer.explained(tp1 <:< tp2))
+    debug.println(TypeComparer.explained(_.isSubType(tp1, tp2)))
     val res = if (ctx.explicitNulls) {
       tp1 <:< tp2
     } else {
@@ -612,7 +612,7 @@ class SpaceEngine(using Context) extends SpaceLogic {
 
           def inhabited(tp: Type): Boolean =
             tp.dealias match {
-              case AndType(tp1, tp2) => !ctx.typeComparer.provablyDisjoint(tp1, tp2)
+              case AndType(tp1, tp2) => !TypeComparer.provablyDisjoint(tp1, tp2)
               case OrType(tp1, tp2) => inhabited(tp1) || inhabited(tp2)
               case tp: RefinedType => inhabited(tp.parent)
               case tp: TypeRef => inhabited(tp.prefix)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1242,7 +1242,7 @@ trait Applications extends Compatibility {
             // We ignore whether constraining the pattern succeeded.
             // Constraining only fails if the pattern cannot possibly match,
             // but useless pattern checks detect more such cases, so we simply rely on them instead.
-            withMode(Mode.GadtConstraintInference)(ctx.typeComparer.constrainPatternType(unapplyArgType, selType))
+            withMode(Mode.GadtConstraintInference)(TypeComparer.constrainPatternType(unapplyArgType, selType))
             val patternBound = maximizeType(unapplyArgType, tree.span, fromScala2x)
             if (patternBound.nonEmpty) unapplyFn = addBinders(unapplyFn, patternBound)
             unapp.println(i"case 2 $unapplyArgType ${ctx.typerState.constraint}")

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -122,7 +122,7 @@ object ErrorReporting {
       else if (ctx.settings.explainTypes.value)
         i"""
            |${ctx.typerState.constraint}
-           |${TypeComparer.explained(found <:< expected)}"""
+           |${TypeComparer.explained(_.isSubType(found, expected))}"""
       else
         ""
     }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -443,7 +443,7 @@ object Implicits:
             case t: TypeParamRef =>
               constraint.entry(t) match {
                 case NoType => t
-                case bounds: TypeBounds => mapCtx.typeComparer.fullBounds(t)
+                case bounds: TypeBounds => TypeComparer.fullBounds(t)
                 case t1 => t1
               }
             case t: TypeVar =>
@@ -760,7 +760,7 @@ trait Implicits:
         case ex: AssertionError =>
           implicits.println(s"view $from ==> $to")
           implicits.println(ctx.typerState.constraint.show)
-          implicits.println(TypeComparer.explained(from.tpe <:< to))
+          implicits.println(TypeComparer.explained(_.isSubType(from.tpe, to)))
           throw ex
       }
     }

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -69,7 +69,7 @@ object Inferencing {
       def apply(tvars: Set[TypeVar], tp: Type) = tp match {
         case tp: TypeVar
         if !tp.isInstantiated &&
-            accCtx.typeComparer.bounds(tp.origin)
+            TypeComparer.bounds(tp.origin)
               .namedPartsWith(ref => params.contains(ref.symbol))
               .nonEmpty =>
           tvars + tp
@@ -242,7 +242,7 @@ object Inferencing {
             constraint.entry(param) match {
               case TypeBounds(lo, hi)
               if (hi frozen_<:< lo) =>
-                val inst = accCtx.typeComparer.approximation(param, fromBelow = true)
+                val inst = TypeComparer.approximation(param, fromBelow = true)
                 typr.println(i"replace singleton $param := $inst")
                 accCtx.typerState.constraint = constraint.replace(param, inst)
               case _ =>
@@ -319,9 +319,9 @@ object Inferencing {
    *            0 if unconstrained, or constraint is from below and above.
    */
   private def instDirection(param: TypeParamRef)(using Context): Int = {
-    val constrained = ctx.typeComparer.fullBounds(param)
+    val constrained = TypeComparer.fullBounds(param)
     val original = param.binder.paramInfos(param.paramNum)
-    val cmp = ctx.typeComparer
+    val cmp = TypeComparer
     val approxBelow =
       if (!cmp.isSubTypeWhenFrozen(constrained.lo, original.lo)) 1 else 0
     val approxAbove =
@@ -355,7 +355,7 @@ object Inferencing {
       if (v == 1) tvar.instantiate(fromBelow = false)
       else if (v == -1) tvar.instantiate(fromBelow = true)
       else {
-        val bounds = ctx.typeComparer.fullBounds(tvar.origin)
+        val bounds = TypeComparer.fullBounds(tvar.origin)
         if (bounds.hi <:< bounds.lo || bounds.hi.classSymbol.is(Final) || fromScala2x)
           tvar.instantiate(fromBelow = false)
         else {

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -611,7 +611,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
     tree.changeOwner(originalOwner, ctx.owner)
 
   def tryConstValue: Tree =
-    ctx.typeComparer.constValue(callTypeArgs.head.tpe) match {
+    TypeComparer.constValue(callTypeArgs.head.tpe) match {
       case Some(c) => Literal(c).withSpan(call.span)
       case _ => EmptyTree
     }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1343,7 +1343,7 @@ class Namer { typer: Typer =>
       def widenRhs(tp: Type): Type =
         tp.widenTermRefExpr.simplified match
           case ctp: ConstantType if isInlineVal => ctp
-          case tp => ctx.typeComparer.widenInferred(tp, rhsProto)
+          case tp => TypeComparer.widenInferred(tp, rhsProto)
 
       // Replace aliases to Unit by Unit itself. If we leave the alias in
       // it would be erased to BoxedUnit.

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -512,7 +512,7 @@ object ProtoTypes {
 
     val added = state.constraint.ensureFresh(tl)
     val tvars = if (addTypeVars) newTypeVars(added) else Nil
-    ctx.typeComparer.addToConstraint(added, tvars.tpes.asInstanceOf[List[TypeVar]])
+    TypeComparer.addToConstraint(added, tvars.tpes.asInstanceOf[List[TypeVar]])
     (added, tvars)
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -307,7 +307,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
                   val tparams = poly.paramRefs
                   val variances = caseClass.typeParams.map(_.paramVarianceSign)
                   val instanceTypes = tparams.lazyZip(variances).map((tparam, variance) =>
-                    ctx.typeComparer.instanceType(tparam, fromBelow = variance < 0))
+                    TypeComparer.instanceType(tparam, fromBelow = variance < 0))
                   resType.substParams(poly, instanceTypes)
                 instantiate(using ctx.fresh.setExploreTyperState().setOwner(caseClass))
               case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -413,7 +413,7 @@ trait TypeAssigner {
   }
 
   def assignType(tree: untpd.Match, scrutinee: Tree, cases: List[CaseDef])(using Context): Match =
-    tree.withType(ctx.typeComparer.lub(cases.tpes))
+    tree.withType(TypeComparer.lub(cases.tpes))
 
   def assignType(tree: untpd.Labeled)(using Context): Labeled =
     tree.withType(tree.bind.symbol.info)
@@ -426,7 +426,7 @@ trait TypeAssigner {
 
   def assignType(tree: untpd.Try, expr: Tree, cases: List[CaseDef])(using Context): Try =
     if (cases.isEmpty) tree.withType(expr.tpe)
-    else tree.withType(ctx.typeComparer.lub(expr.tpe :: cases.tpes))
+    else tree.withType(TypeComparer.lub(expr.tpe :: cases.tpes))
 
   def assignType(tree: untpd.SeqLiteral, elems: List[Tree], elemtpt: Tree)(using Context): SeqLiteral = {
     val ownType = tree match {
@@ -487,7 +487,7 @@ trait TypeAssigner {
     tree.withType(NamedType(NoPrefix, sym))
 
   def assignType(tree: untpd.Alternative, trees: List[Tree])(using Context): Alternative =
-    tree.withType(ctx.typeComparer.lub(trees.tpes))
+    tree.withType(TypeComparer.lub(trees.tpes))
 
   def assignType(tree: untpd.UnApply, proto: Type)(using Context): UnApply =
     tree.withType(proto)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -168,7 +168,7 @@ class Typer extends Namer
        *                   the previous (inner) definition. This models what scalac does.
        */
       def checkNewOrShadowed(found: Type, newPrec: BindingPrec, scala2pkg: Boolean = false)(using Context): Type =
-        if !previous.exists || ctx.typeComparer.isSameRef(previous, found) then
+        if !previous.exists || TypeComparer.isSameRef(previous, found) then
            found
         else if (prevCtx.scope eq ctx.scope)
                 && (newPrec == Definition || newPrec == NamedImport && prevPrec == WildImport)
@@ -768,7 +768,9 @@ class Typer extends Namer
       def handlePattern: Tree = {
         val tpt1 = typedTpt
         if (!ctx.isAfterTyper && pt != defn.ImplicitScrutineeTypeRef)
-          withMode(Mode.GadtConstraintInference)(ctx.typeComparer.constrainPatternType(tpt1.tpe, pt))
+          withMode(Mode.GadtConstraintInference) {
+            TypeComparer.constrainPatternType(tpt1.tpe, pt)
+          }
         // special case for an abstract type that comes with a class tag
         tryWithClassTag(ascription(tpt1, isWildcard = true), pt)
       }
@@ -1616,7 +1618,7 @@ class Typer extends Namer
         else if (tree.elems.isEmpty && tree.isInstanceOf[Trees.JavaSeqLiteral[?]])
           defn.ObjectType // generic empty Java varargs are of type Object[]
         else
-          ctx.typeComparer.lub(elems1.tpes)
+          TypeComparer.lub(elems1.tpes)
       val elemtpt1 = typed(tree.elemtpt, elemtptType)
       assign(elems1, elemtpt1)
     }
@@ -2195,7 +2197,7 @@ class Typer extends Namer
       case _ =>
         val pcls = parents.foldLeft(defn.ObjectClass)(improve)
         typr.println(i"ensure first is class $parents%, % --> ${parents map (_ baseType pcls)}%, %")
-        val first = ctx.typeComparer.glb(defn.ObjectType :: parents.map(_.baseType(pcls)))
+        val first = TypeComparer.glb(defn.ObjectType :: parents.map(_.baseType(pcls)))
         checkFeasibleParent(first, ctx.source.atSpan(span), em" in inferred superclass $first") :: parents
     }
   }
@@ -2384,7 +2386,7 @@ class Typer extends Namer
         if (ctx.mode.is(Mode.Pattern)) app1
         else {
           val elemTpes = elems.lazyZip(pts).map((elem, pt) =>
-            ctx.typeComparer.widenInferred(elem.tpe, pt))
+            TypeComparer.widenInferred(elem.tpe, pt))
           val resTpe = TypeOps.nestedPairs(elemTpes)
           app1.cast(resTpe)
         }
@@ -3228,7 +3230,6 @@ class Typer extends Namer
     }
 
     def adaptNoArgsOther(wtp: Type): Tree = {
-      ctx.typeComparer.GADTused = false
       if (isContextFunctionRef(wtp) &&
           !untpd.isContextualClosure(tree) &&
           !isApplyProto(pt) &&
@@ -3283,7 +3284,7 @@ class Typer extends Namer
               |To turn this error into a warning, pass -Xignore-scala2-macros to the compiler""".stripMargin, tree.srcPos.startPos)
           tree
         }
-      else ctx.typeComparer.testSubType(tree.tpe.widenExpr, pt) match
+      else TypeComparer.testSubType(tree.tpe.widenExpr, pt) match
         case CompareResult.Fail =>
           wtp match
             case wtp: MethodType => missingArgs(wtp)
@@ -3307,7 +3308,7 @@ class Typer extends Namer
     def underlyingApplied(tp: Type): Type = tp.stripTypeVar match {
       case tp: RefinedType => tp
       case tp: AppliedType => tp
-      case tp: TypeParamRef => underlyingApplied(ctx.typeComparer.bounds(tp).hi)
+      case tp: TypeParamRef => underlyingApplied(TypeComparer.bounds(tp).hi)
       case tp: TypeProxy => underlyingApplied(tp.superType)
       case _ => tp
     }
@@ -3615,9 +3616,11 @@ class Typer extends Namer
   protected def checkEqualityEvidence(tree: tpd.Tree, pt: Type)(using Context) : Unit =
     tree match {
       case _: RefTree | _: Literal
-        if !isVarPattern(tree) &&
-           !(pt <:< tree.tpe) &&
-           !withMode(Mode.GadtConstraintInference)(ctx.typeComparer.constrainPatternType(tree.tpe, pt)) =>
+      if !isVarPattern(tree)
+         && !(pt <:< tree.tpe)
+         && !withMode(Mode.GadtConstraintInference) {
+              TypeComparer.constrainPatternType(tree.tpe, pt)
+            } =>
         val cmp =
           untpd.Apply(
             untpd.Select(untpd.TypedSplice(tree), nme.EQ),

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -153,7 +153,6 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/neg-custom-args/conditionalWarnings.scala", allowDeepSubtypes.and("-deprecation").and("-Xfatal-warnings")),
       compileFilesInDir("tests/neg-custom-args/isInstanceOf", allowDeepSubtypes and "-Xfatal-warnings"),
       compileFile("tests/neg-custom-args/i3627.scala", allowDeepSubtypes),
-      compileFile("tests/neg-custom-args/matchtype-loop.scala", allowDeepSubtypes),
       compileFile("tests/neg-custom-args/sourcepath/outer/nested/Test1.scala", defaultOptions.and("-sourcepath", "tests/neg-custom-args/sourcepath")),
       compileDir("tests/neg-custom-args/sourcepath2/hi", defaultOptions.and("-sourcepath", "tests/neg-custom-args/sourcepath2", "-Xfatal-warnings")),
       compileList("duplicate source", List(

--- a/tests/neg-custom-args/allow-deep-subtypes/matchtype-loop2.scala
+++ b/tests/neg-custom-args/allow-deep-subtypes/matchtype-loop2.scala
@@ -2,7 +2,8 @@ object Test {
   type L[X] = X match {
     case Int => L[X]
   }
-  type LL[X] = X match {   // error: recursion limit exceeded
+  type LL[X] = X match {
     case Int => LL[LL[X]]
   }
+  val x: LL[Int] = 2   // error
 }


### PR DESCRIPTION
We create by accident a TypeComparer for every context. In my typer/*.scala benchmark, that created a million TypeComparers. Each of them has about 20 fields. We now create 3 TypeComparers overall for the same benchmark. This is done by having a stack of TypeComparers in use and re-using TypeComparers that were popped from the stack before.
