### PR TITLE
Try some more optimizations

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1021,9 +1021,15 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
       }
     }
 
-    def genLoadArguments(args: List[Tree], btpes: List[BType]): Unit = {
-      (args zip btpes) foreach { case (arg, btpe) => genLoad(arg, btpe) }
-    }
+    def genLoadArguments(args: List[Tree], btpes: List[BType]): Unit =
+      args match
+        case arg :: args1 =>
+          btpes match
+            case btpe :: btpes1 =>
+              genLoad(arg, btpe)
+              genLoadArguments(args1, btpes1)
+            case _ =>
+        case _ =>
 
     def genLoadModule(tree: Tree): BType = {
       val module = (

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -39,7 +39,7 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
   import coreBTypes._
   import BCodeBodyBuilder._
 
-  private val primitives = new DottyPrimitives(ctx)
+  protected val primitives: DottyPrimitives
 
   /*
    * Functionality to build the body of ASM MethodNode, except for `synchronized` and `try` expressions.

--- a/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
@@ -35,10 +35,10 @@ trait BCodeIdiomatic {
   lazy val majorVersion: Int = (classfileVersion & 0xFF)
   lazy val emitStackMapFrame = (majorVersion >= 50)
 
-  val extraProc: Int = GenBCodeOps.mkFlags(
-    asm.ClassWriter.COMPUTE_MAXS,
-    if (emitStackMapFrame) asm.ClassWriter.COMPUTE_FRAMES else 0
-  )
+  val extraProc: Int =
+    import GenBCodeOps.addFlagIf
+    asm.ClassWriter.COMPUTE_MAXS
+      .addFlagIf(emitStackMapFrame, asm.ClassWriter.COMPUTE_FRAMES)
 
   lazy val JavaStringBuilderClassName = jlStringBuilderRef.internalName
 

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -535,7 +535,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
     }
     def lineNumber(tree: Tree): Unit = {
       if (!emitLines || !tree.span.exists) return;
-      val nr = ctx.source.atSpan(tree.span).line + 1
+      val nr = ctx.source.offsetToLine(tree.span.point) + 1
       if (nr != lastEmittedLineNr) {
         lastEmittedLineNr = nr
         lastInsn match {

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -690,12 +690,12 @@ trait BCodeSkelBuilder extends BCodeHelpers {
 
       val isNative         = methSymbol.hasAnnotation(NativeAttr)
       val isAbstractMethod = (methSymbol.is(Deferred) || (methSymbol.owner.isInterface && ((methSymbol.is(Deferred))  || methSymbol.isClassConstructor)))
-      val flags = GenBCodeOps.mkFlags(
-        javaFlags(methSymbol),
-        if (isAbstractMethod)        asm.Opcodes.ACC_ABSTRACT   else 0,
-        if (false /*methSymbol.isStrictFP*/)   asm.Opcodes.ACC_STRICT     else 0,
-        if (isNative)                asm.Opcodes.ACC_NATIVE     else 0  // native methods of objects are generated in mirror classes
-      )
+      val flags =
+        import GenBCodeOps.addFlagIf
+        javaFlags(methSymbol)
+          .addFlagIf(isAbstractMethod, asm.Opcodes.ACC_ABSTRACT)
+          .addFlagIf(false /*methSymbol.isStrictFP*/, asm.Opcodes.ACC_STRICT)
+          .addFlagIf(isNative, asm.Opcodes.ACC_NATIVE) // native methods of objects are generated in mirror classes
 
       // TODO needed? for(ann <- m.symbol.annotations) { ann.symbol.initialize }
       initJMethod(flags, params.map(p => p.symbol.annotations))

--- a/compiler/src/dotty/tools/backend/jvm/BTypes.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypes.scala
@@ -649,14 +649,13 @@ abstract class BTypes {
 
     def innerClassAttributeEntry: Option[InnerClassEntry] = info.nestedInfo map {
       case NestedInfo(_, outerName, innerName, isStaticNestedClass) =>
+        import GenBCodeOps.addFlagIf
         InnerClassEntry(
           internalName,
           outerName.orNull,
           innerName.orNull,
-          GenBCodeOps.mkFlags(
-            info.flags,
-            if (isStaticNestedClass) asm.Opcodes.ACC_STATIC else 0
-          ) & ClassBType.INNER_CLASSES_FLAGS
+          info.flags.addFlagIf(isStaticNestedClass, asm.Opcodes.ACC_STATIC)
+            & ClassBType.INNER_CLASSES_FLAGS
         )
     }
 

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -50,9 +50,13 @@ class GenBCode extends Phase {
     myOutput
   }
 
+  private var myPrimitives: DottyPrimitives = null
+
   def run(using Context): Unit =
-    GenBCodePipeline(
-      DottyBackendInterface(outputDir, superCallsMap)
+    if myPrimitives == null then myPrimitives = new DottyPrimitives(ctx)
+    new GenBCodePipeline(
+      DottyBackendInterface(outputDir, superCallsMap),
+      myPrimitives
     ).run(ctx.compilationUnit.tpdTree)
 
 
@@ -74,7 +78,7 @@ object GenBCode {
   val name: String = "genBCode"
 }
 
-class GenBCodePipeline(val int: DottyBackendInterface)(using Context) extends BCodeSyncAndTry {
+class GenBCodePipeline(val int: DottyBackendInterface, val primitives: DottyPrimitives)(using Context) extends BCodeSyncAndTry {
   import DottyBackendInterface.symExtensions
 
   private var tree: Tree = _

--- a/compiler/src/dotty/tools/backend/jvm/GenBCodeOps.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCodeOps.scala
@@ -7,7 +7,8 @@ import scala.tools.asm
 object GenBCodeOps extends GenBCodeOps
 
 class GenBCodeOps {
-  def mkFlags(args: Int*) = args.foldLeft(0)(_ | _)
+  extension (flags: Int)
+    def addFlagIf(cond: Boolean, flag: Int): Int = if cond then flags | flag else flags
 
   final val PublicStatic      = asm.Opcodes.ACC_PUBLIC | asm.Opcodes.ACC_STATIC
   final val PublicStaticFinal = asm.Opcodes.ACC_PUBLIC | asm.Opcodes.ACC_STATIC | asm.Opcodes.ACC_FINAL

--- a/compiler/src/dotty/tools/backend/jvm/scalaPrimitives.scala
+++ b/compiler/src/dotty/tools/backend/jvm/scalaPrimitives.scala
@@ -133,16 +133,15 @@ class DottyPrimitives(ictx: Context) {
     }
 
     def addPrimitives(cls: Symbol, method: TermName, code: Int)(using Context): Unit = {
-      val alts = cls.info.member(method).alternatives.map(_.symbol)
-      if (alts.isEmpty)
+      val alts = cls.info.member(method).alternatives
+      if alts.isEmpty then
         report.error(s"Unknown primitive method $cls.$method")
-      else alts foreach (s =>
+      else for d <- alts do
+        val s = d.symbol
         addPrimitive(s,
-          s.info.paramInfoss match {
-            case List(tp :: _) if code == ADD && tp =:= ctx.definitions.StringType => CONCAT
-            case _                                          => code
-          }
-        )
+          s.info.paramInfoss match
+            case (tp :: _) :: Nil if code == ADD && tp =:= ctx.definitions.StringType => CONCAT
+            case _ => code
         )
     }
 

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -594,9 +594,9 @@ object desugar {
           (ordinalMethLit(ordinal) :: enumLabelLit(className.toString) :: Nil, scaffolding)
         else (Nil, Nil)
       def copyMeths = {
-        val hasRepeatedParam = constrVparamss.exists(_.exists {
+        val hasRepeatedParam = constrVparamss.nestedExists {
           case ValDef(_, tpt, _) => isRepeated(tpt)
-        })
+        }
         if (mods.is(Abstract) || hasRepeatedParam) Nil  // cannot have default arguments for repeated parameters, hence copy method is not issued
         else {
           def copyDefault(vparam: ValDef) =

--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -297,7 +297,7 @@ object DesugarEnums {
       case parent => parent.isType && typeHasRef(parent)
     }
 
-    vparamss.exists(_.exists(valDefHasRef)) || parents.exists(parentHasRef)
+    vparamss.nestedExists(valDefHasRef) || parents.exists(parentHasRef)
   }
 
   /** A pair consisting of

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -174,7 +174,7 @@ object Trees {
     def toList: List[Tree[T]] = this :: Nil
 
     /** if this tree is the empty tree, the alternative, else this tree */
-    def orElse[U >: Untyped <: T](that: => Tree[U]): Tree[U] =
+    inline def orElse[U >: Untyped <: T](inline that: Tree[U]): Tree[U] =
       if (this eq genericEmptyTree) that else this
 
     /** The number of nodes in this tree */

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -674,7 +674,7 @@ object Contexts {
     final def retractMode(mode: Mode): c.type = c.setMode(c.mode &~ mode)
   }
 
-  private def exploreCtx(using Context): Context =
+  private def exploreCtx(using Context): FreshContext =
     util.Stats.record("explore")
     val base = ctx.base
     import base._
@@ -698,6 +698,10 @@ object Contexts {
     ectx.base.exploresInUse -= 1
 
   inline def explore[T](inline op: Context ?=> T)(using Context): T =
+    val ectx = exploreCtx
+    try op(using ectx) finally wrapUpExplore(ectx)
+
+  inline def exploreInFreshCtx[T](inline op: FreshContext ?=> T)(using Context): T =
     val ectx = exploreCtx
     try op(using ectx) finally wrapUpExplore(ectx)
 

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -195,12 +195,16 @@ object Decorators {
   }
 
   extension [T, U](xss: List[List[T]])
-    def nestedMap(f: T => U): List[List[U]] =
-      xss.map(_.map(f))
+    def nestedMap(f: T => U): List[List[U]] = xss match
+      case xs :: xss1 => xs.map(f) :: xss1.nestedMap(f)
+      case nil => Nil
     def nestedMapConserve(f: T => U): List[List[U]] =
       xss.mapconserve(_.mapconserve(f))
     def nestedZipWithConserve(yss: List[List[U]])(f: (T, U) => T): List[List[T]] =
       xss.zipWithConserve(yss)((xs, ys) => xs.zipWithConserve(ys)(f))
+    def nestedExists(p: T => Boolean): Boolean = xss match
+      case xs :: xss1 => xs.exists(p) || xss1.nestedExists(p)
+      case nil => false
   end extension
 
   extension (text: Text)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -844,8 +844,6 @@ class Definitions {
     @tu lazy val Not_value: Symbol = NotClass.companionModule.requiredMethod(nme.value)
 
   @tu lazy val ValueOfClass: ClassSymbol = requiredClass("scala.ValueOf")
-  @tu lazy val StatsModule: Symbol = requiredModule("dotty.tools.dotc.util.Stats")
-    @tu lazy val Stats_doRecord: Symbol = StatsModule.requiredMethod("doRecord")
 
   @tu lazy val FromDigitsClass: ClassSymbol           = requiredClass("scala.util.FromDigits")
   @tu lazy val FromDigits_WithRadixClass: ClassSymbol = requiredClass("scala.util.FromDigits.WithRadix")

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -237,7 +237,7 @@ object Denotations {
     def mapInfo(f: Type => Type)(using Context): Denotation
 
     /** If this denotation does not exist, fallback to alternative */
-    final def orElse(that: => Denotation): Denotation = if (this.exists) this else that
+    inline def orElse(inline that: Denotation): Denotation = if (this.exists) this else that
 
     /** The set of alternative single-denotations making up this denotation */
     final def alternatives: List[SingleDenotation] = altsWith(alwaysTrue)
@@ -596,7 +596,7 @@ object Denotations {
     def mapInfo(f: Type => Type)(using Context): SingleDenotation =
       derivedSingleDenotation(symbol, f(info))
 
-    def orElse(that: => SingleDenotation): SingleDenotation = if (this.exists) this else that
+    inline def orElse(inline that: SingleDenotation): SingleDenotation = if (this.exists) this else that
 
     def altsWith(p: Symbol => Boolean): List[SingleDenotation] =
       if (exists && p(symbol)) this :: Nil else Nil

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -124,6 +124,7 @@ object NameKinds {
     case class QualInfo(name: SimpleName) extends Info with QualifiedInfo {
       override def map(f: SimpleName => SimpleName): NameInfo = new QualInfo(f(name))
       override def toString: String = s"$infoString $name"
+      override def hashCode = scala.runtime.ScalaRunTime._hashCode(this) * 31 + kind.hashCode
     }
 
     def apply(qual: TermName, name: SimpleName): TermName =
@@ -173,6 +174,7 @@ object NameKinds {
     type ThisInfo = NumberedInfo
     case class NumberedInfo(val num: Int) extends Info with NameKinds.NumberedInfo {
       override def toString: String = s"$infoString $num"
+      override def hashCode = scala.runtime.ScalaRunTime._hashCode(this) * 31 + kind.hashCode
     }
     def apply(qual: TermName, num: Int): TermName =
       qual.derived(new NumberedInfo(num))
@@ -371,6 +373,7 @@ object NameKinds {
     case class SignedInfo(sig: Signature) extends Info {
       assert(sig ne Signature.NotAMethod)
       override def toString: String = s"$infoString $sig"
+      override def hashCode = scala.runtime.ScalaRunTime._hashCode(this) * 31 + kind.hashCode
     }
     type ThisInfo = SignedInfo
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1549,7 +1549,13 @@ object SymDenotations {
           completeChildrenIn(companionClass)
           setFlag(ChildrenQueried)
 
-      annotations.collect { case Annotation.Child(child) => child }.reverse
+      /** The children recorded in `annots`, in reverse order */
+      def getChildren(annots: List[Annotation], acc: List[Symbol]): List[Symbol] = annots match
+        case Annotation.Child(child) :: annots1 => getChildren(annots1, child :: acc)
+        case _ :: annots1 => getChildren(annots1, acc)
+        case nil => acc
+
+      getChildren(annotations, Nil)
     end children
   }
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -892,7 +892,7 @@ object SymDenotations {
       else if is(NoDefaultParams) then false
       else
         val result =
-          rawParamss.exists(_.exists(_.is(HasDefault)))
+          rawParamss.nestedExists(_.is(HasDefault))
           || allOverriddenSymbols.exists(_.hasDefaultParams)
         setFlag(if result then HasDefaultParams else NoDefaultParams)
         result

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -239,7 +239,7 @@ object Symbols {
       }
 
     /** This symbol, if it exists, otherwise the result of evaluating `that` */
-    def orElse(that: => Symbol)(using Context): Symbol =
+    inline def orElse(inline that: Symbol)(using Context): Symbol =
       if (this.exists) this else that
 
     /** If this symbol satisfies predicate `p` this symbol, otherwise `NoSymbol` */

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -113,9 +113,12 @@ class TyperState() {
    * isApplicableSafe but also for (e.g. erased-lubs.scala) as well as
    * many parts of dotty itself.
    */
-  def commit()(using Context): Unit = {
-    Stats.record("typerState.commit")
+  def commit()(using Context): Unit =
     assert(isCommittable)
+    uncheckedCommit()
+
+  def uncheckedCommit()(using Context): Unit = {
+    Stats.record("typerState.commit")
     val targetState = ctx.typerState
     if constraint ne targetState.constraint then
       Stats.record("typerState.commit.new constraint")

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -786,7 +786,8 @@ object Types {
      */
     final def memberNames(keepOnly: NameFilter, pre: Type = this)(using Context): Set[Name] = this match {
       case tp: ClassInfo =>
-        tp.cls.classDenot.memberNames(keepOnly) filter (keepOnly(pre, _))
+        val names = tp.cls.classDenot.memberNames(keepOnly)
+        if keepOnly.isStable then names else names.filter(keepOnly(pre, _))
       case tp: RefinedType =>
         val ns = tp.parent.memberNames(keepOnly, pre)
         if (keepOnly(pre, tp.refinedName)) ns + tp.refinedName else ns
@@ -5642,6 +5643,11 @@ object Types {
    */
   abstract class NameFilter {
     def apply(pre: Type, name: Name)(using Context): Boolean
+
+    /** Filter does not need to be rechecked with full prefix, if it
+     *  has been already checked for the class denotation of the prefix
+     */
+    def isStable: Boolean
   }
 
   /** A filter for names of abstract types of a given type */
@@ -5651,6 +5657,7 @@ object Types {
         val mbr = pre.nonPrivateMember(name)
         mbr.symbol.is(Deferred) && mbr.info.isInstanceOf[RealTypeBounds]
       }
+    def isStable = false
   }
 
   /** A filter for names of abstract types of a given type */
@@ -5660,12 +5667,14 @@ object Types {
         val mbr = pre.member(name)
         mbr.symbol.isType && !mbr.symbol.isClass
       }
+    def isStable = false
   }
 
   /** A filter for names of deferred term definitions of a given type */
   object abstractTermNameFilter extends NameFilter {
     def apply(pre: Type, name: Name)(using Context): Boolean =
       name.isTermName && pre.nonPrivateMember(name).hasAltWith(_.symbol.is(Deferred))
+    def isStable = false
   }
 
   /** A filter for names of type aliases of a given type */
@@ -5675,19 +5684,23 @@ object Types {
         val mbr = pre.nonPrivateMember(name)
         mbr.symbol.isAliasType
       }
+    def isStable = false
   }
 
   object typeNameFilter extends NameFilter {
     def apply(pre: Type, name: Name)(using Context): Boolean = name.isTypeName
+    def isStable = true
   }
 
   object fieldFilter extends NameFilter {
     def apply(pre: Type, name: Name)(using Context): Boolean =
       name.isTermName && (pre member name).hasAltWith(!_.symbol.is(Method))
+    def isStable = true
   }
 
   object takeAllFilter extends NameFilter {
     def apply(pre: Type, name: Name)(using Context): Boolean = true
+    def isStable = true
   }
 
   object implicitFilter extends NameFilter {
@@ -5696,6 +5709,7 @@ object Types {
      *  no post-filtering is needed.
      */
     def apply(pre: Type, name: Name)(using Context): Boolean = true
+    def isStable = true
   }
 
   // ----- Debug ---------------------------------------------------------

--- a/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
@@ -97,14 +97,14 @@ class NameBuffer extends TastyBuffer(10000) {
     }
   }
 
-  override def assemble(): Unit = {
+  override def assemble(): Unit =
     var i = 0
-    for ((name, ref) <- nameRefs) {
+    val nr = nameRefs.iterator
+    while nr.hasNext do
+      val (name, ref) = nr.next()
       assert(ref.index == i)
       i += 1
       pickleNameContents(name)
-    }
-  }
 }
 
 object NameBuffer {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -31,7 +31,7 @@ class TastyUnpickler(reader: TastyReader) {
 
   def this(bytes: Array[Byte]) = this(new TastyReader(bytes))
 
-  private val sectionReader = new mutable.HashMap[String, TastyReader]
+  private val sectionReader = util.HashMap[String, TastyReader]()
   val nameAtRef: NameTable = new NameTable
 
   private def readName(): TermName = nameAtRef(readNameRef())

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -59,19 +59,19 @@ class TreeUnpickler(reader: TastyReader,
   import tpd._
 
   /** A map from addresses of definition entries to the symbols they define */
-  private val symAtAddr  = new mutable.HashMap[Addr, Symbol]
+  private val symAtAddr  = util.HashMap[Addr, Symbol]()
 
   /** A temporary map from addresses of definition entries to the trees they define.
    *  Used to remember trees of symbols that are created by a completion. Emptied
    *  once the tree is inlined into a larger tree.
    */
-  private val treeAtAddr = new mutable.HashMap[Addr, Tree]
+  private val treeAtAddr = util.HashMap[Addr, Tree]()
 
   /** A map from addresses of type entries to the types they define.
    *  Currently only populated for types that might be recursively referenced
    *  from within themselves (i.e. RecTypes, LambdaTypes).
    */
-  private val typeAtAddr = new mutable.HashMap[Addr, Type]
+  private val typeAtAddr = util.HashMap[Addr, Type]()
 
   /** The root symbol denotation which are defined by the Tasty file associated with this
    *  TreeUnpickler. Set by `enterTopLevel`.
@@ -751,11 +751,11 @@ class TreeUnpickler(reader: TastyReader,
      *  or else read definition.
      */
     def readIndexedDef()(using Context): Tree = treeAtAddr.remove(currentAddr) match {
-      case Some(tree) =>
+      case tree: Tree =>
         assert(tree != PoisonTree, s"Cyclic reference while unpickling definition at address ${currentAddr.index} in unit ${ctx.compilationUnit}")
         skipTree()
         tree
-      case none =>
+      case null =>
         val start = currentAddr
         treeAtAddr(start) = PoisonTree
         val tree = readNewDef()

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -319,6 +319,7 @@ object Completion {
     private object completionsFilter extends NameFilter {
       def apply(pre: Type, name: Name)(using Context): Boolean =
         !name.isConstructorName && name.toTermName.info.kind == SimpleNameKind
+      def isStable = true
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3856,7 +3856,7 @@ object Parsers {
         val problem = tree match
           case tree: MemberDef if !(tree.mods.flags & ModifierFlags).isEmpty =>
             i"refinement cannot be ${(tree.mods.flags & ModifierFlags).flagStrings().mkString("`", "`, `", "`")}"
-          case tree: DefDef if tree.vparamss.exists(_.exists(!_.rhs.isEmpty)) =>
+          case tree: DefDef if tree.vparamss.nestedExists(!_.rhs.isEmpty) =>
             i"refinement cannot have default arguments"
           case tree: ValOrDefDef =>
             if tree.rhs.isEmpty then ""

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -107,7 +107,7 @@ object Formatting {
   private type Recorded = Symbol | ParamRef | SkolemType
 
   private case class SeenKey(str: String, isType: Boolean)
-  private class Seen extends mutable.HashMap[SeenKey, List[Recorded]] {
+  private class Seen extends util.HashMap[SeenKey, List[Recorded]] {
 
     override def default(key: SeenKey) = Nil
 

--- a/compiler/src/dotty/tools/dotc/reporting/UniqueMessagePositions.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/UniqueMessagePositions.scala
@@ -2,7 +2,6 @@ package dotty.tools
 package dotc
 package reporting
 
-import scala.collection.mutable
 import util.SourceFile
 import core.Contexts._
 
@@ -10,7 +9,7 @@ import core.Contexts._
   * are suppressed, unless they are of increasing severity. */
 trait UniqueMessagePositions extends Reporter {
 
-  private val positions = new mutable.HashMap[(SourceFile, Int), Int]
+  private val positions = util.HashMap[(SourceFile, Int), Int]()
 
   /** Logs a position and returns true if it was already logged.
    *  @note  Two positions are considered identical for logging if they have the same point.

--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -10,7 +10,7 @@ import dotty.tools.dotc.reporting.Reporter
 
 /** Handles rewriting of Scala2 files to Dotty */
 object Rewrites {
-  private class PatchedFiles extends mutable.HashMap[SourceFile, Patches]
+  private class PatchedFiles extends util.HashMap[SourceFile, Patches]
 
   private case class Patch(span: Span, replacement: String) {
     def delta = replacement.length - (span.end - span.start)
@@ -83,7 +83,7 @@ object Rewrites {
   /** If -rewrite is set, apply all patches and overwrite patched source files.
    */
   def writeBack()(using Context): Unit =
-    for (rewrites <- ctx.settings.rewrite.value; source <- rewrites.patched.keys) {
+    for (rewrites <- ctx.settings.rewrite.value; source <- rewrites.patched.keysIterator) {
       report.echo(s"[patched file ${source.file.path}]")
       rewrites.patched(source).writeBack()
     }

--- a/compiler/src/dotty/tools/dotc/transform/CountOuterAccesses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CountOuterAccesses.scala
@@ -42,7 +42,7 @@ class CountOuterAccesses extends MiniPhase:
     // LambdaLift can create outer paths. These need to be known in this phase.
 
   /** The number of times an outer accessor that might be dropped is accessed */
-  val outerAccessCount = new mutable.HashMap[Symbol, Int] {
+  val outerAccessCount = new util.HashMap[Symbol, Int] {
     override def default(s: Symbol): Int = 0
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -237,7 +237,7 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
 
   /** Is there a repeated parameter in some parameter list? */
   private def hasRepeatedParams(sym: Symbol)(using Context): Boolean =
-    sym.info.paramInfoss.flatten.exists(_.isRepeatedParam)
+    sym.info.paramInfoss.nestedExists(_.isRepeatedParam)
 
   /** Is this the type of a method that has a repeated parameter type as
    *  its last parameter in the last parameter list?

--- a/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc
+package dotty.tools
+package dotc
 package transform
 
 import core._
@@ -27,24 +28,48 @@ class Instrumentation extends MiniPhase { thisPhase =>
   override def isEnabled(using Context) =
     ctx.settings.Yinstrument.value
 
-  private val namesOfInterest = List(
-    "::", "+=", "toString", "newArray", "box", "toCharArray",
-    "map", "flatMap", "filter", "withFilter", "collect", "foldLeft", "foldRight", "take",
-    "reverse", "mapConserve", "mapconserve", "filterConserve", "zip",
-    "denotsNamed", "lookup", "lookupEntry", "lookupAll", "toList")
-  private var namesToRecord: Set[Name] = _
+  private val collectionNamesOfInterest = List(
+    "map", "flatMap", "filter", "filterNot", "withFilter", "collect", "flatten", "foldLeft", "foldRight", "take",
+    "reverse", "zip", "++", ":::", ":+", "distinct", "dropRight", "takeRight", "groupBy", "groupMap", "init", "inits",
+    "interect", "mkString", "partition", "reverse_:::", "scanLeft", "scanRight",
+    "sortBy", "sortWith", "sorted", "span", "splitAt", "takeWhile", "transpose", "unzip", "unzip3",
+    "updated", "zipAll", "zipWithIndex",
+    "mapConserve", "mapconserve", "filterConserve", "zipWithConserve", "mapWithIndexConserve"
+  )
 
-  private var consName: TermName = _
-  private var consEqName: TermName = _
+  private val namesOfInterest = collectionNamesOfInterest ++ List(
+    "::", "+=", "toString", "newArray", "box", "toCharArray", "termName", "typeName",
+    "slice", "staticRef", "requiredClass")
+
+  private var namesToRecord: Set[Name] = _
+  private var collectionNamesToRecord: Set[Name] = _
+  private var Stats_doRecord: Symbol = _
+  private var Stats_doRecordSize: Symbol = _
+  private var CollectionIterableClass: ClassSymbol = _
 
   override def prepareForUnit(tree: Tree)(using Context): Context =
     namesToRecord = namesOfInterest.map(_.toTermName).toSet
+    collectionNamesToRecord = collectionNamesOfInterest.map(_.toTermName).toSet
+    val StatsModule = requiredModule("dotty.tools.dotc.util.Stats")
+    Stats_doRecord = StatsModule.requiredMethod("doRecord")
+    Stats_doRecordSize = StatsModule.requiredMethod("doRecordSize")
+    CollectionIterableClass = requiredClass("scala.collection.Iterable")
     ctx
 
   private def record(category: String, tree: Tree)(using Context): Tree = {
     val key = Literal(Constant(s"$category@${tree.sourcePos.show}"))
-    ref(defn.Stats_doRecord).appliedTo(key, Literal(Constant(1)))
+    ref(Stats_doRecord).appliedTo(key, Literal(Constant(1)))
   }
+
+  private def recordSize(tree: Apply)(using Context): Tree = tree.fun match
+    case sel @ Select(qual, name)
+    if collectionNamesToRecord.contains(name)
+       && qual.tpe.widen.derivesFrom(CollectionIterableClass) =>
+      val key = Literal(Constant(s"totalSize/${name} in ${qual.tpe.widen.classSymbol.name}@${tree.sourcePos.show}"))
+      val qual1 = ref(Stats_doRecordSize).appliedTo(key, qual).cast(qual.tpe.widen)
+      cpy.Apply(tree)(cpy.Select(sel)(qual1, name), tree.args)
+    case _ =>
+      tree
 
   private def ok(using Context) =
     !ctx.owner.ownersIterator.exists(_.name.toString.startsWith("Stats"))
@@ -53,7 +78,7 @@ class Instrumentation extends MiniPhase { thisPhase =>
     case Select(nu: New, _) =>
       cpy.Block(tree)(record(i"alloc/${nu.tpe}", tree) :: Nil, tree)
     case ref: RefTree if namesToRecord.contains(ref.name) && ok =>
-      cpy.Block(tree)(record(i"call/${ref.name}", tree) :: Nil, tree)
+      cpy.Block(tree)(record(i"call/${ref.name}", tree) :: Nil, recordSize(tree))
     case _ =>
       tree
   }

--- a/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
@@ -29,17 +29,17 @@ class Instrumentation extends MiniPhase { thisPhase =>
     ctx.settings.Yinstrument.value
 
   private val collectionNamesOfInterest = List(
-    "map", "flatMap", "filter", "filterNot", "withFilter", "collect", "flatten", "foldLeft", "foldRight", "take",
-    "reverse", "zip", "++", ":::", ":+", "distinct", "dropRight", "takeRight", "groupBy", "groupMap", "init", "inits",
-    "interect", "mkString", "partition", "reverse_:::", "scanLeft", "scanRight",
-    "sortBy", "sortWith", "sorted", "span", "splitAt", "takeWhile", "transpose", "unzip", "unzip3",
+    "map", "flatMap", "filter", "filterNot", "withFilter", "flatten", "take",
+    "reverse", "zip", "++", ":::", ":+", "distinct", "dropRight", "takeRight", "groupBy", "groupMap",
+    "interect", "mkString", "partition", "reverse_:::",
+    "sortBy", "sortWith", "sorted", "splitAt", "takeWhile", "transpose", "unzip", "unzip3",
     "updated", "zipAll", "zipWithIndex",
     "mapConserve", "mapconserve", "filterConserve", "zipWithConserve", "mapWithIndexConserve"
   )
 
   private val namesOfInterest = collectionNamesOfInterest ++ List(
     "::", "+=", "toString", "newArray", "box", "toCharArray", "termName", "typeName",
-    "slice", "staticRef", "requiredClass")
+    "toList", "fresh")
 
   private var namesToRecord: Set[Name] = _
   private var collectionNamesToRecord: Set[Name] = _

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -22,12 +22,19 @@ object SymUtils {
 
   extension (self: Symbol) {
 
-  /** All traits implemented by a class or trait except for those inherited through the superclass. */
+  /** All traits implemented by a class or trait except for those inherited
+   *  through the superclass. Traits are given in the order they appear in the
+   *  parents clause (which is the reverse of their order in baseClasses)
+   */
   def directlyInheritedTraits(using Context): List[ClassSymbol] = {
     val superCls = self.asClass.superClass
     val baseClasses = self.asClass.baseClasses
     if (baseClasses.isEmpty) Nil
-    else baseClasses.tail.takeWhile(_ ne superCls).reverse
+    else
+      def recur(bcs: List[ClassSymbol], acc: List[ClassSymbol]): List[ClassSymbol] = bcs match
+        case bc :: bcs1 => if bc eq superCls then acc else recur(bcs1, bc :: acc)
+        case nil => acc
+      recur(baseClasses.tail, Nil)
   }
 
   /** All traits implemented by a class, except for those inherited through the superclass.

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1647,7 +1647,7 @@ trait Applications extends Compatibility {
    *  Two trials: First, without implicits or SAM conversions enabled. Then,
    *  if the first finds no eligible candidates, with implicits and SAM conversions enabled.
    */
-  def resolveOverloaded(alts: List[TermRef], pt: Type)(using Context): List[TermRef] =
+  def resolveOverloaded(alts: List[TermRef], pt: Type)(using Context): List[TermRef] = util.Stats.trackTime("resolveOver ms") {
     record("resolveOverloaded")
 
     /** Is `alt` a method or polytype whose result type after the first value parameter
@@ -1745,6 +1745,7 @@ trait Applications extends Compatibility {
       resolve(expanded).map(retract)
     }
     else resolve(alts)
+  }
   end resolveOverloaded
 
   /** This private version of `resolveOverloaded` does the bulk of the work of

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -239,10 +239,12 @@ object Implicits:
       if refs.isEmpty && (!considerExtension || companionRefs.isEmpty) then
         Nil
       else
-        val nestedCtx = ctx.fresh.addMode(Mode.TypevarsMissContext)
         val candidates = new mutable.ListBuffer[Candidate]
         def tryCandidate(extensionOnly: Boolean)(ref: ImplicitRef) =
-          var ckind = explore(candidateKind(ref.underlyingRef))(using nestedCtx)
+          var ckind = exploreInFreshCtx { (using ctx: FreshContext) =>
+            ctx.setMode(ctx.mode | Mode.TypevarsMissContext)
+            candidateKind(ref.underlyingRef)
+          }
           if extensionOnly then ckind &= Candidate.Extension
           if ckind != Candidate.None then
             candidates += Candidate(ref, ckind, level)

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -31,12 +31,13 @@ object Inferencing {
    *  but only if the overall result of `isFullyDefined` is `true`.
    *  Variables that are successfully minimized do not count as uninstantiated.
    */
-  def isFullyDefined(tp: Type, force: ForceDegree.Value)(using Context): Boolean = {
-    val nestedCtx = ctx.fresh.setNewTyperState()
-    val result = new IsFullyDefinedAccumulator(force)(using nestedCtx).process(tp)
-    if (result) nestedCtx.typerState.commit()
-    result
-  }
+  def isFullyDefined(tp: Type, force: ForceDegree.Value)(using Context): Boolean =
+    val current = ctx
+    explore {
+      val result = IsFullyDefinedAccumulator(force).process(tp)
+      if result then ctx.typerState.uncheckedCommit()(using current)
+      result
+    }
 
   /** The fully defined type, where all type variables are forced.
    *  Throws an error if type contains wildcards.

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -29,6 +29,7 @@ object RefChecks {
 
   private val defaultMethodFilter = new NameFilter {
     def apply(pre: Type, name: Name)(using Context): Boolean = name.is(DefaultGetterName)
+    def isStable = true
   }
 
   /** Only one overloaded alternative is allowed to define default arguments */

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -491,10 +491,9 @@ object RefChecks {
        */
       def missingTermSymbols: List[Symbol] =
         val buf = new mutable.ListBuffer[Symbol]
-        for bc <- clazz.baseClasses
-            sym <- bc.info.decls.toList
-            if sym.is(DeferredTerm) && !isImplemented(sym) && !ignoreDeferred(sym)
-        do buf += sym
+        for bc <- clazz.baseClasses; sym <- bc.info.decls.toList do
+          if sym.is(DeferredTerm) && !isImplemented(sym) && !ignoreDeferred(sym)
+            buf += sym
         buf.toList
 
       // 2. Check that only abstract classes have deferred members

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -156,7 +156,7 @@ abstract class GenericHashMap[Key, Value]
   protected def growTable(): Unit =
     val oldTable = table
     val newLength =
-      if oldTable.length == DenseLimit then DenseLimit * 2 * roundToPower(capacityMultiple)
+      if table.length == DenseLimit * 2 then table.length * roundToPower(capacityMultiple)
       else table.length
     allocate(newLength)
     copyFrom(oldTable)

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -111,9 +111,11 @@ abstract class GenericHashMap[Key, Value]
           k = keyAt(idx)
           k != null
         do
+          val eidx = index(hash(k))
           if isDense
-            || index(hole - index(hash(k))) < limit * 2
-               // hash(k) is then logically at or before hole; can be moved forward to fill hole
+            || index(eidx - (hole + 2)) > index(idx - (hole + 2))
+               // entry `e` at `idx` can move unless `index(hash(e))` is in
+               // the (ring-)interval [hole + 2 .. idx]
           then
             setKey(hole, k)
             setValue(hole, valueAt(idx))

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -109,9 +109,11 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Mu
           e = entryAt(idx)
           e != null
         do
+          val eidx = index(hash(e))
           if isDense
-            || index(hole - index(hash(e))) < limit
-               // hash(k) is then logically at or before hole; can be moved forward to fill hole
+            || index(eidx - (hole + 1)) > index(idx - (hole + 1))
+               // entry `e` at `idx` can move unless `index(hash(e))` is in
+               // the (ring-)interval [hole + 1 .. idx]
           then
             setEntry(hole, e)
             hole = idx

--- a/compiler/src/dotty/tools/dotc/util/ReadOnlyMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/ReadOnlyMap.scala
@@ -1,5 +1,6 @@
 package dotty.tools
 package dotc.util
+import collection.mutable.ListBuffer
 
 /** A class for the reading part of mutable or immutable maps.
  */
@@ -26,8 +27,11 @@ abstract class ReadOnlyMap[Key, Value]:
   def contains(key: Key): Boolean = lookup(key) != null
 
   def apply(key: Key): Value = lookup(key) match
-    case null => throw new NoSuchElementException(s"$key")
+    case null => default(key)
     case v => v.uncheckedNN
+
+  protected def default(key: Key): Value =
+    throw new NoSuchElementException(s"$key")
 
   def toArray: Array[(Key, Value)] =
     val result = new Array[(Key, Value)](size)
@@ -36,6 +40,9 @@ abstract class ReadOnlyMap[Key, Value]:
       result(idx) = pair
       idx += 1
     result
+
+  def toList: List[(Key, Value)] =
+    (new ListBuffer[(Key, Value)]() ++= iterator).toList
 
   def toSeq: Seq[(Key, Value)] = toArray.toSeq
 

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -25,7 +25,7 @@ extends SrcPos, interfaces.SourcePosition, Showable {
 
   def point: Int = span.point
 
-  def line: Int = if (source.content().length != 0) source.offsetToLine(point) else -1
+  def line: Int = if (source.length != 0) source.offsetToLine(point) else -1
 
   /** Extracts the lines from the underlying source file as `Array[Char]`*/
   def linesSlice: Array[Char] =

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -28,6 +28,10 @@ import collection.mutable
       hits(name) += n
     }
 
+  def doRecordSize(fn: String, coll: scala.collection.Iterable[_]): coll.type =
+    doRecord(fn, coll.size)
+    coll
+
   inline def trackTime[T](fn: String)(inline op: T): T =
     if (enabled) doTrackTime(fn)(op) else op
 

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -9,7 +9,7 @@ import collection.mutable
 
 @sharable object Stats {
 
-  final val enabled = false
+  inline val enabled = false
 
   var monitored: Boolean = false
 

--- a/tests/pos-with-compiler/benchSets.scala
+++ b/tests/pos-with-compiler/benchSets.scala
@@ -1,0 +1,146 @@
+type Elem = Object
+
+def newElem() = new Object()
+
+val MissFactor = 2
+
+val Runs = 100          // number of runs to warm-up, and then number of runs to test
+val ItersPerRun = 1000
+val elems = Array.fill(1024 * MissFactor)(newElem())
+
+def testJava =
+  val set = java.util.HashMap[Elem, Elem]()
+  var count = 0
+  var iter = 0
+  while iter < ItersPerRun do
+    var i = 0
+    while i < elems.length do
+      val e = elems(i)
+      if i % MissFactor == 0 then
+        set.put(e, e)
+      i += 1
+    while i > 0 do
+      i -= 1
+      if set.containsKey(elems(i)) then
+        count += 1
+    iter += 1
+  count
+
+def testJavaId =
+  val set = java.util.IdentityHashMap[Elem, Elem]()
+  var count = 0
+  var iter = 0
+  while iter < ItersPerRun do
+    var i = 0
+    while i < elems.length do
+      val e = elems(i)
+      if i % MissFactor == 0 then
+        set.put(e, e)
+      i += 1
+    while i > 0 do
+      i -= 1
+      if set.containsKey(elems(i)) then
+        count += 1
+    iter += 1
+  count
+
+def testScalaMap =
+  val set = scala.collection.mutable.HashMap[Elem, Elem]()
+  var count = 0
+  var iter = 0
+  while iter < ItersPerRun do
+    var i = 0
+    while i < elems.length do
+      val e = elems(i)
+      if i % MissFactor == 0 then
+        set.update(e, e)
+      i += 1
+    while i > 0 do
+      i -= 1
+      if set.contains(elems(i)) then
+        count += 1
+    iter += 1
+  count
+
+def testDottySet =
+  val set = dotty.tools.dotc.util.HashSet[Elem](64)
+  var count = 0
+  var iter = 0
+  while iter < ItersPerRun do
+    var i = 0
+    while i < elems.length do
+      val e = elems(i)
+      if i % MissFactor == 0 then
+        set += e
+      i += 1
+    while i > 0 do
+      i -= 1
+      if set.contains(elems(i)) then
+        count += 1
+    iter += 1
+  count
+
+def testScalaSet =
+  val set = scala.collection.mutable.HashSet[Elem]()
+  var count = 0
+  var iter = 0
+  while iter < ItersPerRun do
+    var i = 0
+    while i < elems.length do
+      val e = elems(i)
+      if i % MissFactor == 0 then
+        set += e
+      i += 1
+    while i > 0 do
+      i -= 1
+      if set.contains(elems(i)) then
+        count += 1
+    iter += 1
+  count
+
+def testLinearSet =
+  var set = dotty.tools.dotc.util.LinearIdentitySet.empty[Elem]
+  var count = 0
+  var iter = 0
+  while iter < ItersPerRun do
+    var i = 0
+    while i < elems.length do
+      val e = elems(i)
+      if i % MissFactor == 0 then
+        set += e
+      i += 1
+    while i > 0 do
+      i -= 1
+      if set.contains(elems(i)) then
+        count += 1
+    iter += 1
+  count
+
+
+val expected = (elems.size / MissFactor) * ItersPerRun
+
+def profile(name: String, op: => Int) =
+  for i <- 0 until 100 do assert(op == expected)
+  //System.gc()
+  val start = System.nanoTime()
+  var count = 0
+  for i <- 0 until 100 do count += op
+  //println(count)
+  assert(count == expected * Runs)
+  println(f"$name took ${(System.nanoTime().toDouble - start)/1_000_000} ms")
+
+@main def Test =
+  profile("java.util.HashMap         ", testJava)
+  profile("java.util.IdentityHashMap ", testJavaId)
+  profile("scala.collection.HashMap  ", testScalaMap)
+  profile("scala.collection.HashSet  ", testScalaSet)
+  profile("dotty.tools.dotc.HashSet  ", testDottySet)
+  profile("dotty.tools.dotc.LinearSet", testLinearSet)
+
+  profile("dotty.tools.dotc.LinearSet", testLinearSet)
+  profile("dotty.tools.dotc.HashSet  ", testDottySet)
+  profile("scala.collection.HashSet  ", testScalaSet)
+  profile("scala.collection.HashMap  ", testScalaMap)
+  profile("java.util.IdentityHashMap ", testJavaId)
+  profile("java.util.HashMap         ", testJava)
+

--- a/tests/pos-with-compiler/benchSets.scala
+++ b/tests/pos-with-compiler/benchSets.scala
@@ -98,23 +98,6 @@ def testScalaSet =
     iter += 1
   count
 
-def testLinearSet =
-  var set = dotty.tools.dotc.util.LinearIdentitySet.empty[Elem]
-  var count = 0
-  var iter = 0
-  while iter < ItersPerRun do
-    var i = 0
-    while i < elems.length do
-      val e = elems(i)
-      if i % MissFactor == 0 then
-        set += e
-      i += 1
-    while i > 0 do
-      i -= 1
-      if set.contains(elems(i)) then
-        count += 1
-    iter += 1
-  count
 
 
 val expected = (elems.size / MissFactor) * ItersPerRun
@@ -135,9 +118,7 @@ def profile(name: String, op: => Int) =
   profile("scala.collection.HashMap  ", testScalaMap)
   profile("scala.collection.HashSet  ", testScalaSet)
   profile("dotty.tools.dotc.HashSet  ", testDottySet)
-  profile("dotty.tools.dotc.LinearSet", testLinearSet)
 
-  profile("dotty.tools.dotc.LinearSet", testLinearSet)
   profile("dotty.tools.dotc.HashSet  ", testDottySet)
   profile("scala.collection.HashSet  ", testScalaSet)
   profile("scala.collection.HashMap  ", testScalaMap)

--- a/tests/run-with-compiler/settest.scala
+++ b/tests/run-with-compiler/settest.scala
@@ -1,0 +1,71 @@
+trait Generator[+T]:
+  self =>
+  def generate: T
+  def map[S](f: T => S) = new Generator[S]:
+    def generate: S = f(self.generate)
+  def flatMap[S](f: T => Generator[S]) = new Generator[S]:
+    def generate: S = f(self.generate).generate
+
+object Generator:
+  val NumLimit = 300
+  val Iterations = 10000
+
+  given integers as Generator[Int]:
+    val rand = new java.util.Random
+    def generate = rand.nextInt()
+
+  given booleans as Generator[Boolean] =
+    integers.map(x => x > 0)
+
+  def range(end: Int): Generator[Int] =
+    integers.map(x => (x % end).abs)
+
+  enum Op:
+    case Lookup, Update, Remove
+  export Op._
+
+  given ops as Generator[Op] =
+    range(10).map {
+      case 0 | 1 | 2 | 3 => Lookup
+      case 4 | 5 | 6 | 7 => Update
+      case 8 | 9         => Remove
+    }
+
+  val nums: Generator[Integer] = range(NumLimit).map(Integer(_))
+
+@main def Test =
+  import Generator._
+
+  val set1 = dotty.tools.dotc.util.HashSet[Int]()
+  val set2 = scala.collection.mutable.HashSet[Int]()
+
+  def checkSame() =
+    assert(set1.size == set2.size)
+    for e <- set1.iterator do
+      assert(set2.contains(e))
+    for e <- set2.iterator do
+      assert(set1.contains(e))
+
+  def lookupTest(num: Integer) =
+    val res1 = set1.contains(num)
+    val res2 = set2.contains(num)
+    assert(res1 == res2)
+
+  def updateTest(num: Integer) =
+    lookupTest(num)
+    set1 += num
+    set2 += num
+    checkSame()
+
+  def removeTest(num: Integer) =
+    //println(s"test remove $num")
+    set1 -= num
+    set2 -= num
+    checkSame()
+
+  for i <- 0 until Iterations do
+    val num = nums.generate
+    Generator.ops.generate match
+      case Lookup => lookupTest(num)
+      case Update => updateTest(num)
+      case Remove => removeTest(num)


### PR DESCRIPTION
Based on #9405 and includes #9414. 

 - We further reduce context fields, so that I count now 14 fields overall: 06756eb
 - We reduce contexts created with new periods by about 3/4ths: 5aa5c1f
 - We eliminate several allocation hotspots (remaining commits)

Together with #9405 and #9343, this reduces total memory allocated to contexts by 2/3rds and total memory allocated to TypeComparers to practically nothing.
