### PR TITLE
Fix #9268: Scala.js: Add support for switch-Matches.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1047,7 +1047,6 @@ object Build {
             -- "CollectionsOnSynchronizedSetTest.scala"
             -- "CollectionsTest.scala"
             -- "EventObjectTest.scala"
-            -- "FormatterTest.scala"
             -- "HashSetTest.scala"
             -- "LinkedHashSetTest.scala"
             -- "SortedSetTest.scala"


### PR DESCRIPTION
This implementation has been ported from the scalac backend, but is much simpler because it does not have to deal with hacks around scalac's LabelDefs.

---

As preliminary work: For switch-Matches in PatMap, convert scrutinee and alternatives to Int.

In JVM bytecode as well in Scala.js IR, switches only work with primitive ints. Therefore, it makes more sense to convert the scrutinee and alternatives of switch-Matches to Ints early.

This is also what scalac does. See `RegularSwitchMaker` in `patmat/MatchOptimization.scala`.

The JVM back-end tolerates non-ints due its aggressive and blind adaptations everywhere (not because of a deliberate action to support non-Ints). However, the Scala.js back-end does not like receiving non-Ints in `Match`es, because it is much more conservative in where it inserts adaptations (i.e., almost nowhere).