### PR TITLE
Scala.js: Handle casts to `Null` and `Nothing`.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1065,7 +1065,7 @@ object Build {
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util" ** (("*.scala": FileFilter) -- "CollectionsOnCopyOnWriteArrayListTestOnJDK8.scala")).get
           ++ (dir / "shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/io" ** "*.scala").get
           ++ (dir / "shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang" ** "*.scala").get
-          ++ (dir / "shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util" ** (("*.scala": FileFilter) -- "ObjectsTestOnJDK7.scala")).get
+          ++ (dir / "shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util" ** "*.scala").get
         )
       }
     )


### PR DESCRIPTION
Directly copied from https://github.com/scala-js/scala-js/blob/06dc779548683d7106813f62ed596dd2b67827cd/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala#L3362-L3369