### PR TITLE
Better handling of ctrl-c while the compiler is running

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -3,6 +3,7 @@ package dotc
 package core
 
 import java.io.{IOException, File}
+import java.nio.channels.ClosedByInterruptException
 import scala.compat.Platform.currentTime
 import dotty.tools.io.{ ClassPath, ClassRepresentation, AbstractFile }
 import config.Config
@@ -343,6 +344,10 @@ abstract class SymbolLoader extends LazyType { self =>
       report.informTime("loaded " + description, start)
     }
     catch {
+      case ex: InterruptedException =>
+        throw ex
+      case ex: ClosedByInterruptException =>
+        throw new InterruptedException
       case ex: IOException =>
         signalError(ex)
       case NonFatal(ex: TypeError) =>


### PR DESCRIPTION
Previously, the compiler tried its best to continue working after
ctrl-c, which usually resulted in a flood of error messages. This commit
takes inspiration from https://github.com/scala/scala/pull/6479 to
handle ClosedByInterruptException and InterruptedException gracefully
and avoid this.

Note that the Scala 2 PR goes further: it checks `Thread.interrupted()`
to set a global `cancelled` flag (Should we do the same with our
`Run#isCancelled` ?) and it also catches InterruptedException at the
top-level so that ctrl-c does not end up printing a stacktrace, but this
is beyond what I have the time to look at currently.