### PR TITLE
Check implicitNotFound annotations for invalid type variable references

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -165,7 +165,8 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     AnonymousInstanceCannotBeEmptyID,
     TypeSpliceInValPatternID,
     ModifierNotAllowedForDefinitionID,
-    CannotExtendJavaEnumID
+    CannotExtendJavaEnumID,
+    InvalidReferenceInImplicitNotFoundAnnotationID
 
   def errorNumber = ordinal - 2
 }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2404,3 +2404,11 @@ import ast.tpd
     def msg = s"Modifier `${flag.flagsString}` is not allowed for this definition"
     def explain = ""
   }
+
+  class InvalidReferenceInImplicitNotFoundAnnotation(typeVar: String, owner: String)(using Context)
+    extends ReferenceMsg(InvalidReferenceInImplicitNotFoundAnnotationID) {
+    def msg = em"""|Invalid reference to a type variable "${hl(typeVar)}" found in the annotation argument.
+                   |The variable does not occur in the signature of ${hl(owner)}.
+                   |""".stripMargin
+    def explain = ""
+  }

--- a/tests/neg-custom-args/fatal-warnings/i4008.check
+++ b/tests/neg-custom-args/fatal-warnings/i4008.check
@@ -1,0 +1,40 @@
+-- [E158] Reference Error: tests/neg-custom-args/fatal-warnings/i4008.scala:5:56 ---------------------------------------
+5 |@annotation.implicitNotFound("An implicit ShouldWarn1[${B}] is not in scope") // error
+  |                                                        ^
+  |                                        Invalid reference to a type variable "B" found in the annotation argument.
+  |                                        The variable does not occur in the signature of ShouldWarn1.
+-- [E158] Reference Error: tests/neg-custom-args/fatal-warnings/i4008.scala:9:56 ---------------------------------------
+9 |@annotation.implicitNotFound("An implicit ShouldWarn2[${A}] is not in scope") // error
+  |                                                        ^
+  |                                        Invalid reference to a type variable "A" found in the annotation argument.
+  |                                        The variable does not occur in the signature of ShouldWarn2.
+-- [E158] Reference Error: tests/neg-custom-args/fatal-warnings/i4008.scala:13:56 --------------------------------------
+13 |@annotation.implicitNotFound("An implicit ShouldWarn3[${A},${B}] is not in scope") // error
+   |                                                        ^
+   |                                      Invalid reference to a type variable "A" found in the annotation argument.
+   |                                      The variable does not occur in the signature of ShouldWarn3.
+-- [E158] Reference Error: tests/neg-custom-args/fatal-warnings/i4008.scala:17:56 --------------------------------------
+17 |@annotation.implicitNotFound("An implicit ShouldWarn4[${A},${B}] is not in scope") // error // error
+   |                                                        ^
+   |                                      Invalid reference to a type variable "A" found in the annotation argument.
+   |                                      The variable does not occur in the signature of ShouldWarn4.
+-- [E158] Reference Error: tests/neg-custom-args/fatal-warnings/i4008.scala:17:61 --------------------------------------
+17 |@annotation.implicitNotFound("An implicit ShouldWarn4[${A},${B}] is not in scope") // error // error
+   |                                                             ^
+   |                                      Invalid reference to a type variable "B" found in the annotation argument.
+   |                                      The variable does not occur in the signature of ShouldWarn4.
+-- [E158] Reference Error: tests/neg-custom-args/fatal-warnings/i4008.scala:21:61 --------------------------------------
+21 |@annotation.implicitNotFound("An implicit ShouldWarn5[${C},${Abc}] is not in scope") // error
+   |                                                             ^
+   |                                    Invalid reference to a type variable "Abc" found in the annotation argument.
+   |                                    The variable does not occur in the signature of ShouldWarn5.
+-- [E158] Reference Error: tests/neg-custom-args/fatal-warnings/i4008.scala:44:54 --------------------------------------
+44 |class C[A](using @annotation.implicitNotFound("No C[${B}] found") c: Class[A]) // error
+   |                                                      ^
+   |                                      Invalid reference to a type variable "B" found in the annotation argument.
+   |                                      The variable does not occur in the signature of the constructor.
+-- [E158] Reference Error: tests/neg-custom-args/fatal-warnings/i4008.scala:46:62 --------------------------------------
+46 |def someMethod1[A](using @annotation.implicitNotFound("No C[${B}] found") sc: C[A]) = 0 // error
+   |                                                              ^
+   |                                      Invalid reference to a type variable "B" found in the annotation argument.
+   |                                      The variable does not occur in the signature of someMethod1.

--- a/tests/neg-custom-args/fatal-warnings/i4008.scala
+++ b/tests/neg-custom-args/fatal-warnings/i4008.scala
@@ -1,0 +1,48 @@
+// ===== Template annotations =====
+
+
+// class, 1TP, invalid ref
+@annotation.implicitNotFound("An implicit ShouldWarn1[${B}] is not in scope") // error
+class ShouldWarn1[A]
+
+// trait, 1TP, invalid ref
+@annotation.implicitNotFound("An implicit ShouldWarn2[${A}] is not in scope") // error
+trait ShouldWarn2[B]
+
+// trait, 2TP, 1 invalid ref
+@annotation.implicitNotFound("An implicit ShouldWarn3[${A},${B}] is not in scope") // error
+trait ShouldWarn3[B, C]
+
+// class, 2TP, 2 invalid refs
+@annotation.implicitNotFound("An implicit ShouldWarn4[${A},${B}] is not in scope") // error // error
+class ShouldWarn4[C, D]
+
+// class, 2TP, 1 invalid multi-char refs
+@annotation.implicitNotFound("An implicit ShouldWarn5[${C},${Abc}] is not in scope") // error
+class ShouldWarn5[C, D]
+
+// trait, 1TP, valid ref
+@annotation.implicitNotFound("An implicit ShouldntWarn1[${A}] is not in scope")
+trait ShouldntWarn1[A]
+
+// class, 2TP, only one ref but that one is valid
+@annotation.implicitNotFound("An implicit ShouldntWarn2[${A}, ...] is not in scope")
+class ShouldntWarn2[A, B]
+
+// trait, 2TP, 2 valid refs
+@annotation.implicitNotFound("An implicit ShouldntWarn3[${A}, ${B}] is not in scope")
+trait ShouldntWarn3[A, B]
+
+// class, 2TP, 2 valid refs
+@annotation.implicitNotFound("An implicit ShouldntWarn4[${Hello},${World}] is not in scope")
+class ShouldntWarn4[Hello, World]
+
+// ===== DefDef param annotations =====
+
+
+@annotation.implicitNotFound("Hopefully you don't see this!")
+class C[A](using @annotation.implicitNotFound("No C[${B}] found") c: Class[A]) // error
+
+def someMethod1[A](using @annotation.implicitNotFound("No C[${B}] found") sc: C[A]) = 0 // error
+
+def someMethod2[A](using @annotation.implicitNotFound("No C[${A}] found") sc: C[A]) = ""


### PR DESCRIPTION
Implements the behavior requested in #4008.

Trees which are checked:

- annotations on `Template`s (classes and traits)
- annotations on implicit parameters of `DefDef`s (including constructors)