### PR TITLE
Use EmptyTuple instead of Unit in typeclass derivation docs

### DIFF
--- a/docs/docs/reference/contextual/derivation-macro.md
+++ b/docs/docs/reference/contextual/derivation-macro.md
@@ -95,7 +95,7 @@ have the given instances for our primitive types:
     case '[String *: $tpes] => '{ summon[Eq[String]] }  :: summonAll(tpes)
     case '[Int *: $tpes]    => '{ summon[Eq[Int]] }     :: summonAll(tpes)
     case '[$tpe *: $tpes]   => derived(using tpe, qctx) :: summonAll(tpes)
-    case '[Unit] => Nil
+    case '[EmptyTuple] => Nil
   }
 ```
 
@@ -173,7 +173,7 @@ object Eq {
     case '[String *: $tpes] => '{ summon[Eq[String]] }  :: summonAll(tpes)
     case '[Int *: $tpes]    => '{ summon[Eq[Int]] }     :: summonAll(tpes)
     case '[$tpe *: $tpes]   => derived(using tpe, qctx) :: summonAll(tpes)
-    case '[Unit] => Nil
+    case '[EmptyTuple] => Nil
   }
 
   given derived[T: Type](using qctx: QuoteContext) as Expr[Eq[T]] = {

--- a/docs/docs/reference/contextual/derivation.md
+++ b/docs/docs/reference/contextual/derivation.md
@@ -200,7 +200,7 @@ implementation of `summonAll` is `inline` and uses Dotty's `summonInline` constr
 ```scala
 
 inline def summonAll[T <: Tuple]: List[Eq[_]] = inline erasedValue[T] match {
-  case _: Unit => Nil
+  case _: EmptyTuple => Nil
   case _: (t *: ts) => summonInline[Eq[t]] :: summonAll[ts]
 }
 ```
@@ -244,7 +244,7 @@ import scala.deriving._
 import scala.compiletime.{erasedValue, summonInline}
 
 inline def summonAll[T <: Tuple]: List[Eq[_]] = inline erasedValue[T] match {
-  case _: Unit => Nil
+  case _: EmptyTuple => Nil
   case _: (t *: ts) => summonInline[Eq[t]] :: summonAll[ts]
 }
 


### PR DESCRIPTION
Since `EmptyTuple`'s being used instead of `Unit`, pattern matching won't work with `Unit`. Compiling the example from the [type class derivation page](https://dotty.epfl.ch/docs/reference/contextual/derivation.html) results in an [error](https://scastie.scala-lang.org/tw00qOdARpeiRwFfqBssTw).