### PR TITLE
Fix #9525: compilation of stdlib

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -367,10 +367,10 @@ object JavaParsers {
       // assumed true unless we see public/private/protected
       var isPackageAccess = true
       var annots = new ListBuffer[Tree]
-      def addAnnot(sym: ClassSymbol) =
+      def addAnnot(tpt: Tree) =
         annots += atSpan(in.offset) {
           in.nextToken()
-          New(TypeTree(sym.typeRef))
+          New(tpt)
         }
 
       while (true)
@@ -404,11 +404,11 @@ object JavaParsers {
             flags |= Flags.DefaultMethod
             in.nextToken()
           case NATIVE =>
-            addAnnot(NativeAnnot)
+            addAnnot(scalaDot(jtpnme.NATIVEkw))
           case TRANSIENT =>
-            addAnnot(TransientAnnot)
+            addAnnot(scalaDot(jtpnme.TRANSIENTkw))
           case VOLATILE =>
-            addAnnot(VolatileAnnot)
+            addAnnot(scalaDot(jtpnme.VOLATILEkw))
           case SYNCHRONIZED | STRICTFP =>
             in.nextToken()
           case _ =>

--- a/project/scripts/bootstrapCmdTests
+++ b/project/scripts/bootstrapCmdTests
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 source $(dirname $0)/cmdTestsCommon.inc.sh
 
 # check that benchmarks can run

--- a/tests/pos/i9525/VolatileByteRef.java
+++ b/tests/pos/i9525/VolatileByteRef.java
@@ -1,0 +1,3 @@
+public final class VolatileByteRef implements java.io.Serializable {
+    volatile public byte elem;
+}

--- a/tests/pos/i9525/volatile.scala
+++ b/tests/pos/i9525/volatile.scala
@@ -1,0 +1,3 @@
+package scala
+
+final class volatile extends scala.annotation.StaticAnnotation


### PR DESCRIPTION
Fix #9525: use untyped tree to avoid double vision of symbols