### PR TITLE
Fix #9404: Make sure to keep arguments of structural calls typed

### DIFF
--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -93,7 +93,7 @@ object report:
    */
   def log(msg: => String, pos: SourcePosition = NoSourcePosition)(using Context): Unit =
     if (ctx.settings.Ylog.value.containsPhase(ctx.phase))
-      echo(s"[log $ctx.phase] $msg", pos)
+      echo(s"[log ${ctx.phase}] $msg", pos)
 
   def debuglog(msg: => String)(using Context): Unit =
     if (ctx.debug) log(msg)

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -168,7 +168,7 @@ trait Dynamic {
 
       val scall =
         if (vargss.isEmpty) base
-        else untpd.Apply(base, vargss.flatten)
+        else untpd.Apply(base, vargss.flatten.map(untpd.TypedSplice(_)))
 
       // If function is an `applyDynamic` that takes a ClassTag* parameter,
       // add `ctags`.

--- a/tests/run/i9404.scala
+++ b/tests/run/i9404.scala
@@ -1,0 +1,29 @@
+import scala.reflect.Selectable.reflectiveSelectable
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    class Foo {
+      def makeInt: Int = 5
+      def testInt(x: Int): Unit = assert(5 == x)
+
+      def makeRef: Option[String] = Some("hi")
+      def testRef(x: Option[String]): Unit = assert(Some("hi") == x)
+    }
+
+    def test(foo: {
+      def makeInt: Int
+      def testInt(x: Int): Unit
+      def makeRef: Option[String]
+      def testRef(x: Option[String]): Unit
+    }): Unit = {
+      foo.testInt(foo.makeInt)
+               //            ^
+               // cannot infer type; expected type <?> is not fully defined
+      foo.testRef(foo.makeRef)
+               //            ^
+               // cannot infer type; expected type <?> is not fully defined
+    }
+
+    test(new Foo)
+  }
+}


### PR DESCRIPTION
The arguments lost their types previously, which made a TypeTree with type
Int regress to a TypeTree without type.