### PR TITLE
Fix #9321: Make not-null detection more robust

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -907,7 +907,11 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
     def unapply(tree: tpd.TypeApply)(using Context): Option[tpd.Tree] = tree match
       case TypeApply(Select(qual: RefTree, nme.asInstanceOfPM), arg :: Nil) =>
         arg.tpe match
-          case AndType(ref, _) if qual.tpe eq ref => Some(qual)
+          case AndType(ref, nn1) if qual.tpe eq ref =>
+            qual.tpe.widen match
+              case OrNull(nn2) if nn1 eq nn2 =>
+              	Some(qual)
+              case _ => None
           case _ => None
       case _ => None
   end AssertNotNull

--- a/tests/pos-macros/i9321/macros.scala
+++ b/tests/pos-macros/i9321/macros.scala
@@ -13,4 +13,4 @@ def mcr2Impl(using ctx: QuoteContext): Expr[Unit] =
     '{ (esx: Seq[Foo]) => varargsFunc(esx: _*) }
   val trees: Expr[Seq[Foo]] =
     '{Nil}
-  Expr.betaReduce(func)(trees)
+  Expr.betaReduce('{$func($trees)})

--- a/tests/pos-macros/i9321/macros.scala
+++ b/tests/pos-macros/i9321/macros.scala
@@ -1,0 +1,16 @@
+import scala.quoted._
+
+type Foo
+type F[X]
+def varargsFunc(funcs0: Foo*) = ???
+
+inline def mcr1: F[String] = ${ mcr1Impl }
+def mcr1Impl(using QuoteContext): Expr[F[String]] = '{???}
+
+inline def mcr2: Unit = ${mcr2Impl}
+def mcr2Impl(using ctx: QuoteContext): Expr[Unit] =
+  val func: Expr[Seq[Foo] => Unit] =
+    '{ (esx: Seq[Foo]) => varargsFunc(esx: _*) }
+  val trees: Expr[Seq[Foo]] =
+    '{Nil}
+  Expr.betaReduce(func)(trees)

--- a/tests/pos-macros/i9321/test.scala
+++ b/tests/pos-macros/i9321/test.scala
@@ -1,0 +1,5 @@
+def f(x: => Any) = ???
+def g = f {
+  mcr1
+  mcr2
+}


### PR DESCRIPTION
We can't rely on a test whether a tree transform yields the same tree,
since typed tree copiers do not always map equal sub-trees to equal results.