### PR TITLE
Scala.js: Fix `classOf[Null]` and `classOf[Nothing]`.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1055,7 +1055,7 @@ object Build {
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/junit" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niobuffer" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niocharset" ** (("*.scala": FileFilter)  -- "BaseCharsetTest.scala" -- "Latin1Test.scala" -- "USASCIITest.scala" -- "UTF16Test.scala" -- "UTF8Test.scala")).get
-          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/scalalib" ** (("*.scala": FileFilter)  -- "ArrayBuilderTest.scala" -- "ClassTagTest.scala" -- "EnumerationTest.scala" -- "SymbolTest.scala")).get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/scalalib" ** (("*.scala": FileFilter) -- "EnumerationTest.scala" -- "SymbolTest.scala")).get
           ++ (dir / "shared/src/test/require-sam" ** "*.scala").get
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/compiler" ** (("*.scala": FileFilter) -- "DefaultMethodsTest.scala")).get
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang" ** "*.scala").get


### PR DESCRIPTION
For almost all purposes, `Null` and `Nothing` should be erased to `scala.runtime.{Null$,Nothing$}`, so we directly change `encodeClassName` to do that.

The only place where they should be encoded as the special IR TypeRefs `NullRef` and `NothingRef` is in param and result types of `MethodName`s, which was already taken care of by `paramOrResultTypeRef` but that was adjusted to compensate for the changes in `encodeClassName`. The new `paramOrResultTypeRef` is now equivalent to the one in scalac.