### PR TITLE
Fix #9437: Skip $asInstanceOf$ in error message

### DIFF
--- a/tests/neg/i9437.check
+++ b/tests/neg/i9437.check
@@ -1,0 +1,6 @@
+-- [E050] Type Error: tests/neg/i9437.scala:7:10 -----------------------------------------------------------------------
+7 |  println(x.f1())  // error
+  |          ^^^^
+  |          method selectDynamic in trait Selectable does not take parameters
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i9437.scala
+++ b/tests/neg/i9437.scala
@@ -1,0 +1,7 @@
+class Bag extends reflect.Selectable
+
+@main def Test =
+  val x = new Bag:
+    val f1 = 23
+
+  println(x.f1())  // error


### PR DESCRIPTION
Skip synthetic typecase $asInstanceOf$ when showing method symbol in error message