### PR TITLE
Fix #9439: Translate Java varargs `...T` into `T*` instead of `(T & Object)*`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1684,10 +1684,12 @@ object desugar {
         Apply(Select(Apply(scalaDot(nme.StringContext), strs), id).withSpan(tree.span), elems)
       case PostfixOp(t, op) =>
         if ((ctx.mode is Mode.Type) && !isBackquoted(op) && op.name == tpnme.raw.STAR) {
-          val seqType = if (ctx.compilationUnit.isJava) defn.ArrayType else defn.SeqType
-          Annotated(
-            AppliedTypeTree(ref(seqType), t),
-            New(ref(defn.RepeatedAnnot.typeRef), Nil :: Nil))
+          if ctx.compilationUnit.isJava then
+            AppliedTypeTree(ref(defn.RepeatedParamType), t)
+          else
+            Annotated(
+              AppliedTypeTree(ref(defn.SeqType), t),
+              New(ref(defn.RepeatedAnnot.typeRef), Nil :: Nil))
         }
         else {
           assert(ctx.mode.isExpr || ctx.reporter.errorsReported || ctx.mode.is(Mode.Interactive), ctx.mode)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -399,6 +399,8 @@ class Definitions {
     def runtimeMethodRef(name: PreName): TermRef = ScalaRuntimeModule.requiredMethodRef(name)
     def ScalaRuntime_drop: Symbol = runtimeMethodRef(nme.drop).symbol
     @tu lazy val ScalaRuntime__hashCode: Symbol = ScalaRuntimeModule.requiredMethod(nme._hashCode_)
+    @tu lazy val ScalaRuntime_toArray: Symbol = ScalaRuntimeModule.requiredMethod(nme.toArray)
+    @tu lazy val ScalaRuntime_toObjectArray: Symbol = ScalaRuntimeModule.requiredMethod(nme.toObjectArray)
 
   @tu lazy val BoxesRunTimeModule: Symbol = requiredModule("scala.runtime.BoxesRunTime")
     @tu lazy val BoxesRunTimeModule_externalEquals: Symbol = BoxesRunTimeModule.info.decl(nme.equals_).suchThat(toDenot(_).info.firstParamTypes.size == 2).symbol

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -423,7 +423,8 @@ class ClassfileParser(
               if isRepeatedParam(index) then
                 index += 1
                 val elemType = sig2type(tparams, skiptvs)
-                defn.RepeatedParamType.appliedTo(elemType.translateJavaArrayElementType)
+                // `ElimRepeated` is responsible for correctly erasing this.
+                defn.RepeatedParamType.appliedTo(elemType)
               else
                 objToAny(sig2type(tparams, skiptvs))
             }

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -59,21 +59,6 @@ object Scala2Unpickler {
     denot.info = PolyType.fromParams(denot.owner.typeParams, denot.info)
   }
 
-  /** Convert array parameters denoting a repeated parameter of a Java method
-   *  to `RepeatedParamClass` types.
-   */
-  def arrayToRepeated(tp: Type)(using Context): Type = tp match {
-    case tp: MethodType =>
-      val lastArg = tp.paramInfos.last
-      assert(lastArg isRef defn.ArrayClass)
-      tp.derivedLambdaType(
-        tp.paramNames,
-        tp.paramInfos.init :+ lastArg.translateParameterized(defn.ArrayClass, defn.RepeatedParamClass),
-        tp.resultType)
-    case tp: PolyType =>
-      tp.derivedLambdaType(tp.paramNames, tp.paramInfos, arrayToRepeated(tp.resultType))
-  }
-
   def ensureConstructor(cls: ClassSymbol, scope: Scope)(using Context): Unit = {
     if (scope.lookup(nme.CONSTRUCTOR) == NoSymbol) {
       val constr = newDefaultConstructor(cls)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1723,7 +1723,7 @@ class Typer extends Namer
         checkedArgs = checkedArgs.mapconserve(arg =>
           checkSimpleKinded(checkNoWildcard(arg)))
       else if (ctx.compilationUnit.isJava)
-        if (tpt1.symbol eq defn.ArrayClass) || (tpt1.symbol eq defn.RepeatedParamClass) then
+        if (tpt1.symbol eq defn.ArrayClass) then
           checkedArgs match {
             case List(arg) =>
               val elemtp = arg.tpe.translateJavaArrayElementType

--- a/tests/neg/i533/Test.scala
+++ b/tests/neg/i533/Test.scala
@@ -3,6 +3,6 @@ object Test {
     val x = new Array[Int](1)
     x(0) = 10
     println(JA.get(x)) // error
-    println(JA.getVarargs(x: _*)) // error
+    println(JA.getVarargs(x: _*)) // now OK.
   }
 }

--- a/tests/pos/arrays2.scala
+++ b/tests/pos/arrays2.scala
@@ -24,4 +24,5 @@ one warning found
 // #2461
 object arrays3 {
   def apply[X <: AnyRef](xs : X*) : java.util.List[X] = java.util.Arrays.asList(xs: _*)
+  def apply2[X](xs : X*) : java.util.List[X] = java.util.Arrays.asList(xs: _*)
 }

--- a/tests/run/i9439.scala
+++ b/tests/run/i9439.scala
@@ -1,0 +1,17 @@
+object Test {
+  // First example with a concrete type <: AnyVal
+  def main(args: Array[String]): Unit = {
+    val coll = new java.util.ArrayList[Int]()
+    java.util.Collections.addAll(coll, 5, 6)
+    println(coll.size())
+
+    foo(5, 6)
+  }
+
+  // Second example with an abstract type not known to be <: AnyRef
+  def foo[A](a1: A, a2: A): Unit = {
+    val coll = new java.util.ArrayList[A]()
+    java.util.Collections.addAll(coll, a1, a2)
+    println(coll.size())
+  }
+}

--- a/tests/run/java-varargs-2/A.java
+++ b/tests/run/java-varargs-2/A.java
@@ -1,4 +1,4 @@
-class A_1 {
+class A {
   public static void foo(int... args) {
   }
 

--- a/tests/run/java-varargs-2/Test.scala
+++ b/tests/run/java-varargs-2/Test.scala
@@ -1,0 +1,13 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    A.foo(1)
+    A.foo(Array(1): _*)
+    A.foo(Seq(1): _*)
+    A.gen(1)
+    A.gen(Array(1): _*)
+    A.gen(Seq(1): _*)
+    A.gen2("")
+    A.gen2(Array(""): _*)
+    A.gen2(Seq(""): _*)
+  }
+}

--- a/tests/run/java-varargs/Test_2.scala
+++ b/tests/run/java-varargs/Test_2.scala
@@ -1,8 +1,13 @@
 object Test {
   def main(args: Array[String]): Unit = {
+    A_1.foo(1)
     A_1.foo(Array(1): _*)
     A_1.foo(Seq(1): _*)
+    A_1.gen(1)
     A_1.gen(Array(1): _*)
     A_1.gen(Seq(1): _*)
+    A_1.gen2("")
+    A_1.gen2(Array(""): _*)
+    A_1.gen2(Seq(""): _*)
   }
 }


### PR DESCRIPTION
This is much more convenient for users but is more complicated for the
compiler since we still need to translate the varargs into an `Object[]`
in bytecode. Since ElimRepeated was already responsible for doing some
adaptation of repeated arguments, it now also takes care of this (this
differs from Scala 2 which handles this at Erasure).