### PR TITLE
Pretend that BoxedUnit does not extend java.io.Serializable.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -306,6 +306,7 @@ object StdNames {
     final val Nil: N                = "Nil"
     final val Predef: N             = "Predef"
     final val ScalaRunTime: N       = "ScalaRunTime"
+    final val BoxedUnit: N          = "BoxedUnit"
     final val Some: N               = "Some"
 
     val x_0 : N  = "x$0"

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -98,10 +98,11 @@ object Scala2Unpickler {
     val tempInfo = new TempClassInfo(denot.owner.thisType, cls, decls, ost)
     denot.info = tempInfo // first rough info to avoid CyclicReferences
     val parents1 = if (parents.isEmpty) defn.ObjectType :: Nil else parents.map(_.dealias)
-    // Add extra parents to the tuple classes from the standard library
+    // Adjust parents of the tuple classes and BoxedUnit from the standard library
+    // If from Scala 2, adjust for tuple classes; if not, it's from Java, and adjust for BoxedUnit
     val normalizedParents =
       if (fromScala2) defn.adjustForTuple(cls, tparams, parents1)
-      else parents1 // We are setting the info of a Java class, so it cannot be one of the tuple classes
+      else defn.adjustForBoxedUnit(cls, parents1)
     for (tparam <- tparams) {
       val tsym = decls.lookup(tparam.name)
       if (tsym.exists) tsym.setFlag(TypeParam)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1170,7 +1170,10 @@ class Namer { typer: Typer =>
       denot.info = tempInfo
 
       val parentTypes = defn.adjustForTuple(cls, cls.typeParams,
-        ensureFirstIsClass(parents.map(checkedParentType(_)), cls.span))
+        defn.adjustForBoxedUnit(cls,
+          ensureFirstIsClass(parents.map(checkedParentType(_)), cls.span)
+        )
+      )
       typr.println(i"completing $denot, parents = $parents%, %, parentTypes = $parentTypes%, %")
 
       if (impl.derived.nonEmpty) {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1054,7 +1054,7 @@ object Build {
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/utils" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/junit" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niobuffer" ** "*.scala").get
-          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niocharset" ** (("*.scala": FileFilter)  -- "BaseCharsetTest.scala" -- "Latin1Test.scala" -- "USASCIITest.scala" -- "UTF16Test.scala" -- "UTF8Test.scala")).get
+          ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/niocharset" ** "*.scala").get
           ++ (dir / "shared/src/test/scala/org/scalajs/testsuite/scalalib" ** (("*.scala": FileFilter) -- "EnumerationTest.scala" -- "SymbolTest.scala")).get
           ++ (dir / "shared/src/test/require-sam" ** "*.scala").get
           ++ (dir / "shared/src/test/require-jdk8/org/scalajs/testsuite/compiler" ** "*.scala").get


### PR DESCRIPTION
Unit does not extend Serializable, but scala.runtime.BoxedUnit does. Because of that, erasing `SomeSerializable | Unit` yields `java.io.Serializable` instead of `Object`.

This is problematic for Scala.js, because the run-time representation of `()` in Scala.js is *not* `BoxedUnit` (which is a JVM artifact) but the JavaScript value `undefined`, the only instance of `java.lang.Void`. The latter however does not extend `java.io.Serializable`, so trying to assign `()` to a `SomeSerializable | Unit` will result in invalid IR that fails to pass the IR checker.

We solve this issue by patching the parents of `BoxedUnit` during unpickling to remove `java.io.Serializable`. This is done in the same way as adding parents to Tuple classes.