### PR TITLE
safe_&: handle higher-kinded arguments like regular &

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2078,7 +2078,7 @@ class TypeComparer(using val comparerCtx: Context) extends ConstraintHandling wi
    *
    *    [X1, ..., Xn] -> op(tp1[X1, ..., Xn], tp2[X1, ..., Xn])
    */
-  private def liftIfHK(tp1: Type, tp2: Type,
+  def liftIfHK(tp1: Type, tp2: Type,
       op: (Type, Type) => Type, original: (Type, Type) => Type, combineVariance: (Variance, Variance) => Variance) = {
     val tparams1 = tp1.typeParams
     val tparams2 = tp2.typeParams

--- a/tests/pending/pos/i9346.scala
+++ b/tests/pending/pos/i9346.scala
@@ -1,0 +1,9 @@
+trait Foo[+A] {
+  type Repr[+O] <: Foo[O] {
+    type Repr[+OO] = Foo.this.Repr[OO]
+  }
+
+  def foo: Repr[A]
+
+  def bar: Repr[A] = this.foo.foo
+}


### PR DESCRIPTION
Unfortunately, i9346.scala has to be put in pending because it
still crashes (due to a cycle involving a LazyRef) after this fix, and
because `safe_&` is only called from `recoverable_&` when there is some
sort of cycle in the first place, I haven't been able to make another
testcase that exercises this codepath.

It would be good if we could figure out how to get i9346.scala to
compile (see also #9346 for discussions). It is is a minimization of a pattern heavily used in
akka-stream, similar to the use of the `CC` type parameter in the
scala-library collections but using a type member instead.
Unfortunately, it seems that Dotty is not really prepared to handle
F-bounds in type members currently. I was able to get the testcase as
well as akka-stream to compile by tweaking `findMember` to not compute
an intersection when the refinement is an alias:

```diff
--- compiler/src/dotty/tools/dotc/core/Types.scala
+++ compiler/src/dotty/tools/dotc/core/Types.scala
@@ -671,7 +671,8 @@ object Types {
         val rinfo = tp.refinedInfo
         if (name.isTypeName && !pinfo.isInstanceOf[ClassInfo]) { // simplified case that runs more efficiently
           val jointInfo =
-            if (ctx.base.pendingMemberSearches.contains(name)) pinfo safe_& rinfo
+            if (rinfo.isInstanceOf[TypeAlias]) rinfo
+            else if (ctx.base.pendingMemberSearches.contains(name)) pinfo safe_& rinfo
             else pinfo recoverable_& rinfo
           pdenot.asSingleDenotation.derivedSingleDenotation(pdenot.symbol, jointInfo)
         }
```

This seems to work, but to be sound it means that we need to check for
invalid bounds in PostTyper (see tests/neg/i5556.scala for an example where
this matter), like we do for type parameters in `checkAppliedType`.