### PR TITLE
Consistent override checking

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -762,8 +762,10 @@ object RefChecks {
        */
     def hasMatchingSym(inclazz: Symbol, member: Symbol): Boolean = {
 
-      def isSignatureMatch(sym: Symbol) = !sym.isTerm ||
-        clazz.thisType.memberInfo(sym).matchesLoosely(member.info)
+      def isSignatureMatch(sym: Symbol) = sym.isType || {
+        val self = clazz.thisType
+        sym.asSeenFrom(self).matches(member.asSeenFrom(self))
+      }
 
       /* The rules for accessing members which have an access boundary are more
          * restrictive in java than scala.  Since java has no concept of package nesting,

--- a/tests/neg/i9109.scala
+++ b/tests/neg/i9109.scala
@@ -1,0 +1,6 @@
+class A {
+  def foo[T <: Cloneable](x: T): Unit = {}
+}
+class B extends A {
+  override def foo[T <: Serializable](x: T): Unit = {} // error: method foo has a different signature than the overridden declaration
+}


### PR DESCRIPTION
In 7964d17506a152a38c5b482475a51947b251ca78,
`OverridingPairs.Cursor#matches` was changed to use Denotations#matches
instead of Types#matches to make the override check more precise, but
the same was not done in
`RefChecks#checkAllOverrides#hasMatchingSym#isSignatureMatch`, which
lead to inconsistencies: in the added testcase, the definition of `foo`
in `B` doesn't override anything, but because OverridingPairs and
RefChecks disagreed on what an override was, that did not produce any
error.