### PR TITLE
Fix #7499: Prevent extending java.lang.Enum except from an enum

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -164,7 +164,8 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     UnexpectedPatternForSummonFromID,
     AnonymousInstanceCannotBeEmptyID,
     TypeSpliceInValPatternID,
-    ModifierNotAllowedForDefinitionID
+    ModifierNotAllowedForDefinitionID,
+    CannotExtendJavaEnumID
 
   def errorNumber = ordinal - 2
 }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1490,6 +1490,12 @@ import ast.tpd
           |"""
   }
 
+  class CannotExtendJavaEnum(sym: Symbol)(using Context)
+    extends SyntaxMsg(CannotExtendJavaEnumID) {
+      def msg = em"""$sym cannot extend ${hl("java.lang.Enum")}: only enums defined with the ${hl("enum")} syntax can"""
+      def explain = ""
+    }
+
   class CannotHaveSameNameAs(sym: Symbol, cls: Symbol, reason: CannotHaveSameNameAs.Reason)(using Context)
     extends SyntaxMsg(CannotHaveSameNameAsID) {
     import CannotHaveSameNameAs._

--- a/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
@@ -73,7 +73,10 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
    */
   private def addEnumConstrArgs(targetCls: Symbol, parents: List[Tree], args: List[Tree])(using Context): List[Tree] =
     parents.map {
-      case app @ Apply(fn, args0) if fn.symbol.owner == targetCls => cpy.Apply(app)(fn, args0 ++ args)
+      case app @ Apply(fn, args0) if fn.symbol.owner == targetCls =>
+        if args0.nonEmpty && targetCls == defn.JavaEnumClass then
+          report.error("the constructor of java.lang.Enum cannot be called explicitly", app.sourcePos)
+        cpy.Apply(app)(fn, args0 ++ args)
       case p => p
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -88,8 +88,9 @@ object RefChecks {
       cls.thisType
   }
 
-  /** Check that self type of this class conforms to self types of parents.
-   *  and required classes.
+  /** Check that self type of this class conforms to self types of parents
+   *  and required classes. Also check that only `enum` constructs extend
+   *  `java.lang.Enum`.
    */
   private def checkParents(cls: Symbol)(using Context): Unit = cls.info match {
     case cinfo: ClassInfo =>
@@ -99,10 +100,14 @@ object RefChecks {
           report.error(DoesNotConformToSelfType(category, cinfo.selfType, cls, otherSelf, relation, other.classSymbol),
             cls.sourcePos)
       }
-      for (parent <- cinfo.classParents)
+      val parents = cinfo.classParents
+      for (parent <- parents)
         checkSelfConforms(parent.classSymbol.asClass, "illegal inheritance", "parent")
       for (reqd <- cinfo.cls.givenSelfType.classSymbols)
         checkSelfConforms(reqd, "missing requirement", "required")
+
+      if !cls.is(Enum) && parents.exists(_.classSymbol == defn.JavaEnumClass) then
+        report.error(CannotExtendJavaEnum(cls), cls.sourcePos)
     case _ =>
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -17,7 +17,7 @@ import scala.util.{Try, Failure, Success}
 import config.{ScalaVersion, NoScalaVersion}
 import Decorators._
 import typer.ErrorReporting._
-import config.Feature.warnOnMigration
+import config.Feature.{warnOnMigration, migrateTo3}
 import reporting._
 
 object RefChecks {
@@ -106,8 +106,13 @@ object RefChecks {
       for (reqd <- cinfo.cls.givenSelfType.classSymbols)
         checkSelfConforms(reqd, "missing requirement", "required")
 
-      if !cls.is(Enum) && parents.exists(_.classSymbol == defn.JavaEnumClass) then
+      // Prevent wrong `extends` of java.lang.Enum
+      if !migrateTo3 &&
+         !cls.isOneOf(Enum | Trait) &&
+         parents.exists(_.classSymbol == defn.JavaEnumClass)
+      then
         report.error(CannotExtendJavaEnum(cls), cls.sourcePos)
+
     case _ =>
   }
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -66,6 +66,7 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/pos-custom-args/i5498-postfixOps.scala", defaultOptions withoutLanguageFeature "postfixOps"),
       compileFile("tests/pos-custom-args/i8875.scala", defaultOptions.and("-Xprint:getters")),
       compileFile("tests/pos-custom-args/i9267.scala", defaultOptions.and("-Ystop-after:erasure")),
+      compileFile("tests/pos-special/extend-java-enum.scala", defaultOptions.and("-source", "3.0-migration")),
     ).checkCompile()
   }
 

--- a/tests/neg/cannot-call-java-enum-constructor.scala
+++ b/tests/neg/cannot-call-java-enum-constructor.scala
@@ -1,0 +1,3 @@
+enum E extends java.lang.Enum[E]("name", 0) { // error
+  case A, B
+}

--- a/tests/neg/extend-java-enum.scala
+++ b/tests/neg/extend-java-enum.scala
@@ -4,4 +4,6 @@ class C1 extends jl.Enum[C1] // error: class C1 cannot extend java.lang.Enum
 
 class C2(name: String, ordinal: Int) extends jl.Enum[C2](name, ordinal) // error: class C2 cannot extend java.lang.Enum
 
-trait T extends jl.Enum[T] // error: trait T cannot extend java.lang.Enum
+trait T extends jl.Enum[T] // ok
+
+class C3 extends T // error: class C3 cannot extend java.lang.Enum

--- a/tests/neg/extend-java-enum.scala
+++ b/tests/neg/extend-java-enum.scala
@@ -1,0 +1,7 @@
+import java.{lang => jl}
+
+class C1 extends jl.Enum[C1] // error: class C1 cannot extend java.lang.Enum
+
+class C2(name: String, ordinal: Int) extends jl.Enum[C2](name, ordinal) // error: class C2 cannot extend java.lang.Enum
+
+trait T extends jl.Enum[T] // error: trait T cannot extend java.lang.Enum

--- a/tests/pos-special/extend-java-enum.scala
+++ b/tests/pos-special/extend-java-enum.scala
@@ -1,0 +1,21 @@
+import java.{lang => jl}
+
+final class ConfigSyntax private (name: String, ordinal: Int)
+  extends jl.Enum[ConfigSyntax](name, ordinal)
+
+object ConfigSyntax {
+
+  final val JSON = new ConfigSyntax("JSON", 0)
+  final val CONF = new ConfigSyntax("CONF", 1)
+  final val PROPERTIES = new ConfigSyntax("PROPERTIES", 2)
+
+  private[this] final val _values: Array[ConfigSyntax] =
+    Array(JSON, CONF, PROPERTIES)
+
+  def values: Array[ConfigSyntax] = _values.clone()
+
+  def valueOf(name: String): ConfigSyntax =
+    _values.find(_.name == name).getOrElse {
+      throw new IllegalArgumentException("No enum const ConfigSyntax." + name)
+    }
+}

--- a/tests/pos/trait-java-enum.scala
+++ b/tests/pos/trait-java-enum.scala
@@ -1,0 +1,5 @@
+trait T extends java.lang.Enum[T]
+
+enum MyEnum extends T {
+  case A, B
+}


### PR DESCRIPTION
With this PR, extending `java.lang.Enum` from a class or trait gives an error.
```scala
class C1 extends jl.Enum[C1]
      ^
class C1 cannot extend java.lang.Enum: only enums defined with the enum syntax can
```
(one of) The Scala2 way(s) of declaring a java-compatible enum is also covered:
```scala
class C2(name: String, ordinal: Int) extends jl.Enum[C2](name, ordinal)
      ^
class C2 cannot extend java.lang.Enum: only enums defined with the enum syntax can
```
To emit a nice error for the above case I made the two-arguments constructor of `Enum` visible (if there's a better way I'll be glad to change that), and I introduced a check in `CompleteJavaEnums` to prevent that constructor from being explicitely called.
```scala
enum E extends java.lang.Enum[E]("name", 0) {
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            the constructor of java.lang.Enum cannot be called explicitly
```