### PR TITLE
Add `isExpr`, `asExpr`, `asExprOf`, `asTerm`, `asTypeTree` and `asQuotedType`

### DIFF
--- a/library/src-bootstrapped/dotty/internal/StringContextMacro.scala
+++ b/library/src-bootstrapped/dotty/internal/StringContextMacro.scala
@@ -59,7 +59,7 @@ object StringContextMacro {
    */
   private def interpolate(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext): Expr[String] = {
     import qctx.tasty._
-    val sourceFile = strCtxExpr.unseal.pos.sourceFile
+    val sourceFile = strCtxExpr.asTerm.pos.sourceFile
 
     val (partsExpr, parts) = strCtxExpr match {
       case Expr.StringContext(p1 @ Consts(p2)) => (p1.toList, p2.toList)
@@ -76,28 +76,28 @@ object StringContextMacro {
       private[this] var oldReported = false
       def partError(message : String, index : Int, offset : Int) : Unit = {
         reported = true
-        val positionStart = partsExpr(index).unseal.pos.start + offset
+        val positionStart = partsExpr(index).asTerm.pos.start + offset
         error(message, sourceFile, positionStart, positionStart)
       }
       def partWarning(message : String, index : Int, offset : Int) : Unit = {
         reported = true
-        val positionStart = partsExpr(index).unseal.pos.start + offset
+        val positionStart = partsExpr(index).asTerm.pos.start + offset
         warning(message, sourceFile, positionStart, positionStart)
       }
 
       def argError(message : String, index : Int) : Unit = {
         reported = true
-        error(message, args(index).unseal.pos)
+        error(message, args(index).asTerm.pos)
       }
 
       def strCtxError(message : String) : Unit = {
         reported = true
-        val positionStart = strCtxExpr.unseal.pos.start
+        val positionStart = strCtxExpr.asTerm.pos.start
         error(message, sourceFile, positionStart, positionStart)
       }
       def argsError(message : String) : Unit = {
         reported = true
-        error(message, argsExpr.unseal.pos)
+        error(message, argsExpr.asTerm.pos)
       }
 
       def hasReported() : Boolean = {
@@ -658,7 +658,7 @@ object StringContextMacro {
           case Some(argIndex, arg) => {
             val (hasArgumentIndex, argumentIndex, flags, hasWidth, width, hasPrecision, precision, hasRelative, relativeIndex, conversion) = getFormatSpecifiers(part, argIndex, argIndex + 1, false, formattingStart)
             if (!reporter.hasReported()){
-              val conversionWithType = checkFormatSpecifiers(argIndex + 1, hasArgumentIndex, argumentIndex, Some(argIndex + 1), start == 0, maxArgumentIndex, hasRelative, hasWidth, width, hasPrecision, precision, flags, conversion, Some(arg.unseal.tpe), part)
+              val conversionWithType = checkFormatSpecifiers(argIndex + 1, hasArgumentIndex, argumentIndex, Some(argIndex + 1), start == 0, maxArgumentIndex, hasRelative, hasWidth, width, hasPrecision, precision, flags, conversion, Some(arg.asTerm.tpe), part)
               nextStart = conversion + 1
               conversionWithType :: checkPart(part, nextStart, argument, maxArgumentIndex)
             } else checkPart(part, conversion + 1, argument, maxArgumentIndex)

--- a/library/src-bootstrapped/scala/quoted/Const.scala
+++ b/library/src-bootstrapped/scala/quoted/Const.scala
@@ -23,7 +23,7 @@ object Const {
       case Inlined(_, Nil, e) => rec(e)
       case _  => None
     }
-    rec(expr.unseal)
+    rec(expr.asTerm)
   }
 
 }

--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -47,7 +47,7 @@ abstract class Expr[+T] private[scala] {
   /** Convert to an `quoted.Expr[X]` if this expression is a valid expression of type `X` or throws */
   def asExprOf[X](using tp: scala.quoted.Type[X])(using qctx: QuoteContext): scala.quoted.Expr[X] = {
     val tree = this.asTerm
-    val expectedType = tp.unseal.tpe
+    val expectedType = tp.asTypeTree.tpe
     if (tree.tpe <:< expectedType)
       this.asInstanceOf[scala.quoted.Expr[X]]
     else
@@ -199,7 +199,7 @@ object Expr {
    */
   def summon[T](using tpe: Type[T])(using qctx: QuoteContext): Option[Expr[T]] = {
     import qctx.tasty._
-    searchImplicit(tpe.unseal.tpe) match {
+    searchImplicit(tpe.asTypeTree.tpe) match {
       case iss: ImplicitSearchSuccess => Some(iss.tree.asExpr.asInstanceOf[Expr[T]])
       case isf: ImplicitSearchFailure => None
     }

--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -41,7 +41,6 @@ abstract class Expr[+T] private[scala] {
     !scala.internal.quoted.Expr.unapply[EmptyTuple, EmptyTuple](this)(using that, false, qctx).isEmpty
 
   /** Checked cast to a `quoted.Expr[U]` */
-  @deprecated("Replaced with `asExprOf`", "0.27.0")
   def cast[U](using tp: scala.quoted.Type[U])(using qctx: QuoteContext): scala.quoted.Expr[U] = asExprOf[U]
 
   /** Convert to an `quoted.Expr[X]` if this expression is a valid expression of type `X` or throws */
@@ -59,7 +58,6 @@ abstract class Expr[+T] private[scala] {
   }
 
   /** View this expression `quoted.Expr[T]` as a `Term` */
-  @deprecated("Replaced with `asTerm`", "0.27.0")
   def unseal(using qctx: QuoteContext): qctx.tasty.Term = asTerm
 
   /** View this expression `quoted.Expr[T]` as a `Term` */

--- a/library/src-bootstrapped/scala/quoted/Lambda.scala
+++ b/library/src-bootstrapped/scala/quoted/Lambda.scala
@@ -19,9 +19,9 @@ object Lambda {
     import qctx.tasty._
     val argTypes = functionType.unseal.tpe match
       case AppliedType(_, functionArguments) => functionArguments.init.asInstanceOf[List[Type]]
-    qctx.tasty.internal.lambdaExtractor(expr.unseal, argTypes).map { fn =>
+    qctx.tasty.internal.lambdaExtractor(expr.asTerm, argTypes).map { fn =>
       def f(args: Tuple.Map[Args, Expr]): Expr[Res] =
-        fn(args.toArray.toList.map(_.asInstanceOf[Expr[Any]].unseal)).seal.asInstanceOf[Expr[Res]]
+        fn(args.toArray.toList.map(_.asInstanceOf[Expr[Any]].asTerm)).asExpr.asInstanceOf[Expr[Res]]
       tg.untupled(f)
     }
 

--- a/library/src-bootstrapped/scala/quoted/Lambda.scala
+++ b/library/src-bootstrapped/scala/quoted/Lambda.scala
@@ -17,7 +17,7 @@ object Lambda {
    */
   def unapply[F, Args <: Tuple, Res, G](expr: Expr[F])(using qctx: QuoteContext, tf: TupledFunction[F, Args => Res], tg: TupledFunction[G, Tuple.Map[Args, Expr] => Expr[Res]], functionType: Type[F]): Option[/*QuoteContext ?=>*/ G] = {
     import qctx.tasty._
-    val argTypes = functionType.unseal.tpe match
+    val argTypes = functionType.asTypeTree.tpe match
       case AppliedType(_, functionArguments) => functionArguments.init.asInstanceOf[List[Type]]
     qctx.tasty.internal.lambdaExtractor(expr.asTerm, argTypes).map { fn =>
       def f(args: Tuple.Map[Args, Expr]): Expr[Res] =

--- a/library/src-bootstrapped/scala/quoted/Liftable.scala
+++ b/library/src-bootstrapped/scala/quoted/Liftable.scala
@@ -33,7 +33,7 @@ object Liftable {
     /** Lift a primitive value `n` into `'{ n }` */
     def toExpr(x: T) = qctx ?=> {
       import qctx.tasty._
-      Literal(Constant(x)).seal.asInstanceOf[Expr[T]]
+      Literal(Constant(x)).asExpr.asInstanceOf[Expr[T]]
     }
   }
 
@@ -41,7 +41,7 @@ object Liftable {
     /** Lift a `Class[T]` into `'{ classOf[T] }` */
     def toExpr(x: Class[T]) = qctx ?=> {
       import qctx.tasty._
-      Ref(defn.Predef_classOf).appliedToType(Type(x)).seal.asInstanceOf[Expr[Class[T]]]
+      Ref(defn.Predef_classOf).appliedToType(Type(x)).asExpr.asInstanceOf[Expr[Class[T]]]
     }
   }
 

--- a/library/src-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/quoted/Type.scala
@@ -9,14 +9,18 @@ abstract class Type[X <: AnyKind] private[scala] {
 
   /** Show a source code like representation of this type without syntax highlight */
   def show(using qctx: QuoteContext): String =
-    this.unseal.showWith(SyntaxHighlight.plain)
+    this.asTypeTree.showWith(SyntaxHighlight.plain)
 
   /** Show a source code like representation of this type */
   def showWith(syntaxHighlight: SyntaxHighlight)(using qctx: QuoteContext): String =
-    this.unseal.showWith(syntaxHighlight)
+    this.asTypeTree.showWith(syntaxHighlight)
 
   /** View this expression `quoted.Type[T]` as a `TypeTree` */
-  def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree
+  @deprecated("Replaced with `asExprOf`", "0.27.0")
+  def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree = asTypeTree
+
+  /** View this expression `quoted.Type[T]` as a `qctx.tasty.TypeTree` */
+  def asTypeTree(using qctx: QuoteContext): qctx.tasty.TypeTree
 
 }
 
@@ -28,30 +32,30 @@ object Type {
   given apply[T <: AnyKind] as (QuoteContext ?=> Type[T]) = ???
 
   def UnitTag: QuoteContext ?=> Type[Unit] =
-    qctx.tasty.defn.UnitType.seal.asInstanceOf[quoted.Type[Unit]]
+    qctx.tasty.defn.UnitType.asQuotedType.asInstanceOf[quoted.Type[Unit]]
 
   def BooleanTag: QuoteContext ?=> Type[Boolean] =
-    qctx.tasty.defn.BooleanType.seal.asInstanceOf[quoted.Type[Boolean]]
+    qctx.tasty.defn.BooleanType.asQuotedType.asInstanceOf[quoted.Type[Boolean]]
 
   def ByteTag: QuoteContext ?=> Type[Byte] =
-    qctx.tasty.defn.ByteType.seal.asInstanceOf[quoted.Type[Byte]]
+    qctx.tasty.defn.ByteType.asQuotedType.asInstanceOf[quoted.Type[Byte]]
 
   def CharTag: QuoteContext ?=> Type[Char] =
-    qctx.tasty.defn.CharType.seal.asInstanceOf[quoted.Type[Char]]
+    qctx.tasty.defn.CharType.asQuotedType.asInstanceOf[quoted.Type[Char]]
 
   def ShortTag: QuoteContext ?=> Type[Short] =
-    qctx.tasty.defn.ShortType.seal.asInstanceOf[quoted.Type[Short]]
+    qctx.tasty.defn.ShortType.asQuotedType.asInstanceOf[quoted.Type[Short]]
 
   def IntTag: QuoteContext ?=> Type[Int] =
-    qctx.tasty.defn.IntType.seal.asInstanceOf[quoted.Type[Int]]
+    qctx.tasty.defn.IntType.asQuotedType.asInstanceOf[quoted.Type[Int]]
 
   def LongTag: QuoteContext ?=> Type[Long] =
-    qctx.tasty.defn.LongType.seal.asInstanceOf[quoted.Type[Long]]
+    qctx.tasty.defn.LongType.asQuotedType.asInstanceOf[quoted.Type[Long]]
 
   def FloatTag: QuoteContext ?=> Type[Float] =
-    qctx.tasty.defn.FloatType.seal.asInstanceOf[quoted.Type[Float]]
+    qctx.tasty.defn.FloatType.asQuotedType.asInstanceOf[quoted.Type[Float]]
 
   def DoubleTag: QuoteContext ?=> Type[Double] =
-    qctx.tasty.defn.DoubleType.seal.asInstanceOf[quoted.Type[Double]]
+    qctx.tasty.defn.DoubleType.asQuotedType.asInstanceOf[quoted.Type[Double]]
 
 }

--- a/library/src-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/quoted/Type.scala
@@ -16,7 +16,6 @@ abstract class Type[X <: AnyKind] private[scala] {
     this.asTypeTree.showWith(syntaxHighlight)
 
   /** View this expression `quoted.Type[T]` as a `TypeTree` */
-  @deprecated("Replaced with `asExprOf`", "0.27.0")
   def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree = asTypeTree
 
   /** View this expression `quoted.Type[T]` as a `qctx.tasty.TypeTree` */

--- a/library/src-bootstrapped/scala/quoted/Varargs.scala
+++ b/library/src-bootstrapped/scala/quoted/Varargs.scala
@@ -17,7 +17,7 @@ object Varargs {
    */
   def apply[T](xs: Seq[Expr[T]])(using tp: Type[T], qctx: QuoteContext): Expr[Seq[T]] = {
     import qctx.tasty._
-    Repeated(xs.map[Term](_.asTerm).toList, tp.unseal).asExpr.asInstanceOf[Expr[Seq[T]]]
+    Repeated(xs.map[Term](_.asTerm).toList, tp.asTypeTree).asExpr.asInstanceOf[Expr[Seq[T]]]
   }
 
   /** Matches a literal sequence of expressions and return a sequence of expressions.

--- a/library/src-bootstrapped/scala/quoted/Varargs.scala
+++ b/library/src-bootstrapped/scala/quoted/Varargs.scala
@@ -17,7 +17,7 @@ object Varargs {
    */
   def apply[T](xs: Seq[Expr[T]])(using tp: Type[T], qctx: QuoteContext): Expr[Seq[T]] = {
     import qctx.tasty._
-    Repeated(xs.map[Term](_.unseal).toList, tp.unseal).seal.asInstanceOf[Expr[Seq[T]]]
+    Repeated(xs.map[Term](_.asTerm).toList, tp.unseal).asExpr.asInstanceOf[Expr[Seq[T]]]
   }
 
   /** Matches a literal sequence of expressions and return a sequence of expressions.
@@ -35,12 +35,12 @@ object Varargs {
   def unapply[T](expr: Expr[Seq[T]])(using qctx: QuoteContext): Option[Seq[Expr[T]]] = {
     import qctx.tasty._
     def rec(tree: Term): Option[Seq[Expr[T]]] = tree match {
-      case Typed(Repeated(elems, _), _) => Some(elems.map(x => x.seal.asInstanceOf[Expr[T]]))
+      case Typed(Repeated(elems, _), _) => Some(elems.map(x => x.asExpr.asInstanceOf[Expr[T]]))
       case Block(Nil, e) => rec(e)
       case Inlined(_, Nil, e) => rec(e)
       case _  => None
     }
-    rec(expr.unseal)
+    rec(expr.asTerm)
   }
 
 }

--- a/library/src-bootstrapped/scala/quoted/report.scala
+++ b/library/src-bootstrapped/scala/quoted/report.scala
@@ -8,7 +8,7 @@ object report:
 
   /** Report an error at the on the position of `expr` */
   def error(msg: => String, expr: Expr[Any])(using qctx: QuoteContext): Unit =
-    qctx.tasty.error(msg, expr.unseal.pos)
+    qctx.tasty.error(msg, expr.asTerm.pos)
 
   /** Report an error at the position of the macro expansion and throws a StopQuotedContext */
   def throwError(msg: => String)(using qctx: QuoteContext): Nothing = {
@@ -27,7 +27,7 @@ object report:
 
   /** Report a warning at the on the position of `expr` */
   def warning(msg: => String, expr: Expr[_])(using qctx: QuoteContext): Unit =
-    qctx.tasty.warning(msg, expr.unseal.pos)
+    qctx.tasty.warning(msg, expr.asTerm.pos)
 
   /** Throwable used to stop the expansion of a macro after an error was reported */
   class StopQuotedContext extends Throwable

--- a/library/src-bootstrapped/scala/quoted/unsafe/UnsafeExpr.scala
+++ b/library/src-bootstrapped/scala/quoted/unsafe/UnsafeExpr.scala
@@ -20,7 +20,7 @@ object UnsafeExpr {
   *           change the parameter semantics as by-value parameter could be re-evaluated.
   */
   def underlyingArgument[T](expr: Expr[T])(using qctx: QuoteContext): Expr[T] =
-    expr.unseal.underlyingArgument.seal.asInstanceOf[Expr[T]]
+    expr.asTerm.underlyingArgument.asExpr.asInstanceOf[Expr[T]]
 
   // TODO generalize for any function arity
   /** Allows inspection or transformation of the body of the expression of function.
@@ -38,23 +38,23 @@ object UnsafeExpr {
    */
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(using qctx: QuoteContext): X = {
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](e.unseal, params, List(v.unseal)).seal.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](e.asTerm, params, List(v.asTerm)).asExpr.asInstanceOf[Expr[t]])
   }
 
   def open[T1, T2, R, X](f: Expr[(T1, T2) => R])(content: (Expr[R], [t] => Expr[t] => (Expr[T1], Expr[T2]) => Expr[t]) => X)(using qctx: QuoteContext)(using DummyImplicit): X = {
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2]) => bodyFn[t](e.unseal, params, List(v1.unseal, v2.unseal)).seal.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2]) => bodyFn[t](e.asTerm, params, List(v1.asTerm, v2.asTerm)).asExpr.asInstanceOf[Expr[t]])
   }
 
   def open[T1, T2, T3, R, X](f: Expr[(T1, T2, T3) => R])(content: (Expr[R], [t] => Expr[t] => (Expr[T1], Expr[T2], Expr[T3]) => Expr[t]) => X)(using qctx: QuoteContext)(using DummyImplicit, DummyImplicit): X = {
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2], v3: Expr[T3]) => bodyFn[t](e.unseal, params, List(v1.unseal, v2.unseal, v3.unseal)).seal.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2], v3: Expr[T3]) => bodyFn[t](e.asTerm, params, List(v1.asTerm, v2.asTerm, v3.asTerm)).asExpr.asInstanceOf[Expr[t]])
   }
 
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.tasty.ValDef], Expr[R]) = {
     import qctx.tasty._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.unseal.etaExpand
-    (params, body.seal.asInstanceOf[Expr[R]])
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.asTerm.etaExpand
+    (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 
   private def bodyFn[t](using qctx: QuoteContext)(e: qctx.tasty.Term, params: List[qctx.tasty.ValDef], args: List[qctx.tasty.Term]): qctx.tasty.Term = {

--- a/library/src-bootstrapped/scala/quoted/util/ExprMap.scala
+++ b/library/src-bootstrapped/scala/quoted/util/ExprMap.scala
@@ -66,9 +66,9 @@ trait ExprMap {
             case AppliedType(TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "<repeated>"), List(tp0: Type)) =>
               // TODO rewrite without using quotes
               type T
-              val qtp: quoted.Type[T] = tp0.seal.asInstanceOf[quoted.Type[T]]
+              val qtp: quoted.Type[T] = tp0.asQuotedType.asInstanceOf[quoted.Type[T]]
               given qtp.type = qtp
-              '[Seq[T]].unseal.tpe
+              '[Seq[T]].asTypeTree.tpe
             case tp => tp
           Typed.copy(tree)(transformTerm(expr, tp), transformTypeTree(tpt))
         case tree: NamedArg =>
@@ -110,7 +110,7 @@ trait ExprMap {
         case _ if tree.isExpr =>
           type X
           val expr = tree.asExpr.asInstanceOf[Expr[X]]
-          val t = tpe.seal.asInstanceOf[quoted.Type[X]]
+          val t = tpe.asQuotedType.asInstanceOf[quoted.Type[X]]
           transform(expr)(using qctx, t).asTerm
         case _ =>
           transformTermChildren(tree, tpe)
@@ -152,7 +152,7 @@ trait ExprMap {
         trees mapConserve (transformTypeCaseDef(_))
 
     }
-    new MapChildren().transformTermChildren(e.asTerm, tpe.unseal.tpe).asExprOf[T]
+    new MapChildren().transformTermChildren(e.asTerm, tpe.asTypeTree.tpe).asExprOf[T]
   }
 
 }

--- a/library/src-non-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-non-bootstrapped/scala/quoted/Expr.scala
@@ -1,4 +1,7 @@
 package scala.quoted
 
 abstract class Expr[+T] private[scala]:
-  def unseal(using qctx: QuoteContext): qctx.tasty.Term
+  def unseal(using qctx: QuoteContext): qctx.tasty.Term = asTerm
+  def asTerm(using qctx: QuoteContext): qctx.tasty.Term
+  def asExprOf[U](using tp: scala.quoted.Type[U])(using qctx: QuoteContext): scala.quoted.Expr[U] =
+    throw new Exception("Non bootstrapped lib")

--- a/library/src-non-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-non-bootstrapped/scala/quoted/Type.scala
@@ -2,4 +2,4 @@ package scala.quoted
 
 abstract class Type[T <: AnyKind] private[scala]:
   type `$splice` = T
-  def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree
+  def asTypeTree(using qctx: QuoteContext): qctx.tasty.TypeTree

--- a/library/src/scala/internal/quoted/Expr.scala
+++ b/library/src/scala/internal/quoted/Expr.scala
@@ -18,7 +18,7 @@ import scala.quoted._
     case _ => false
   }
 
-  def unseal(using qctx: QuoteContext): qctx.tasty.Term =
+  def asTerm(using qctx: QuoteContext): qctx.tasty.Term =
     if (qctx.tasty.internal.compilerId != scopeId)
       throw new scala.quoted.ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
     tree.asInstanceOf[qctx.tasty.Term]
@@ -52,7 +52,7 @@ object Expr {
    */
   def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeExpr: scala.quoted.Expr[Any])(using patternExpr: scala.quoted.Expr[Any],
         hasTypeSplices: Boolean, qctx: QuoteContext): Option[Tup] = {
-    new Matcher.QuoteMatcher[qctx.type].termMatch(scrutineeExpr.unseal, patternExpr.unseal, hasTypeSplices).asInstanceOf[Option[Tup]]
+    new Matcher.QuoteMatcher[qctx.type].termMatch(scrutineeExpr.asTerm, patternExpr.asTerm, hasTypeSplices).asInstanceOf[Option[Tup]]
   }
 
 }

--- a/library/src/scala/internal/quoted/Matcher.scala
+++ b/library/src/scala/internal/quoted/Matcher.scala
@@ -154,7 +154,7 @@ object Matcher {
         // that we have found and seal them in a quoted.Type
         matchings.asOptionOfTuple.map { tup =>
           Tuple.fromArray(tup.toArray.map { // TODO improve performance
-            case x: SymBinding => internal.Context_GADT_approximation(summon[Context])(x.sym, !x.fromAbove).seal
+            case x: SymBinding => internal.Context_GADT_approximation(summon[Context])(x.sym, !x.fromAbove).asQuotedType
             case x => x
           })
         }
@@ -175,7 +175,7 @@ object Matcher {
         // that we have found and seal them in a quoted.Type
         matchings.asOptionOfTuple.map { tup =>
           Tuple.fromArray(tup.toArray.map { // TODO improve performance
-            case x: SymBinding => internal.Context_GADT_approximation(summon[Context])(x.sym, !x.fromAbove).seal
+            case x: SymBinding => internal.Context_GADT_approximation(summon[Context])(x.sym, !x.fromAbove).asQuotedType
             case x => x
           })
         }

--- a/library/src/scala/internal/quoted/Matcher.scala
+++ b/library/src/scala/internal/quoted/Matcher.scala
@@ -253,14 +253,14 @@ object Matcher {
               if patternHole.symbol == internal.Definitions_InternalQuotedMatcher_patternHole &&
                  s.tpe <:< tpt.tpe &&
                  tpt2.tpe.derivesFrom(defn.RepeatedParamClass) =>
-            matched(scrutinee.seal)
+            matched(scrutinee.asExpr)
 
           /* Term hole */
           // Match a scala.internal.Quoted.patternHole and return the scrutinee tree
           case (ClosedPatternTerm(scrutinee), TypeApply(patternHole, tpt :: Nil))
               if patternHole.symbol == internal.Definitions_InternalQuotedMatcher_patternHole &&
                  scrutinee.tpe <:< tpt.tpe =>
-            matched(scrutinee.seal)
+            matched(scrutinee.asExpr)
 
           /* Higher order term hole */
           // Matches an open term and wraps it into a lambda that provides the free variables
@@ -283,7 +283,7 @@ object Matcher {
             val argTypes = args.map(x => x.tpe.widenTermRefExpr)
             val resType = pattern.tpe
             val res = Lambda(MethodType(names)(_ => argTypes, _ => resType), bodyFn)
-            matched(res.seal)
+            matched(res.asExpr)
 
           //
           // Match two equivalent trees

--- a/library/src/scala/internal/quoted/Type.scala
+++ b/library/src/scala/internal/quoted/Type.scala
@@ -13,7 +13,7 @@ final class Type[Tree](val typeTree: Tree, val scopeId: Int) extends scala.quote
   }
 
   /** View this expression `quoted.Type[T]` as a `TypeTree` */
-  def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree =
+  def asTypeTree(using qctx: QuoteContext): qctx.tasty.TypeTree =
     if (qctx.tasty.internal.compilerId != scopeId)
       throw new scala.quoted.ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
     typeTree.asInstanceOf[qctx.tasty.TypeTree]
@@ -39,7 +39,7 @@ object Type {
    */
   def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeType: scala.quoted.Type[_])(using patternType: scala.quoted.Type[_],
         hasTypeSplices: Boolean, qctx: QuoteContext): Option[Tup] = {
-    new Matcher.QuoteMatcher[qctx.type].typeTreeMatch(scrutineeType.unseal, patternType.unseal, hasTypeSplices).asInstanceOf[Option[Tup]]
+    new Matcher.QuoteMatcher[qctx.type].typeTreeMatch(scrutineeType.asTypeTree, patternType.asTypeTree, hasTypeSplices).asInstanceOf[Option[Tup]]
   }
 
 }

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -675,14 +675,12 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
     extension (self: Term):
 
       /** Convert `Term` to an `quoted.Expr[Any]` if the term is a valid expression or throws */
-      @deprecated("Replaced with `asExpr` (or `asExprOf`)", "0.27.0")
       def seal(using ctx: Context): scala.quoted.Expr[Any] =
         sealOpt.getOrElse {
           throw new Exception("Cannot seal a partially applied Term. Try eta-expanding the term first.")
         }
 
       /** Convert `Term` to an `quoted.Expr[Any]` if the term is a valid expression */
-      @deprecated("Replaced with `isExpr` and `asExpr` (or `asExprOf`)", "0.27.0")
       def sealOpt(using ctx: Context): Option[scala.quoted.Expr[Any]] =
         self.tpe.widen match
           case _: MethodType | _: PolyType => None
@@ -1788,7 +1786,6 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
     extension (self: Type):
 
       /** Convert `Type` to an `quoted.Type[_]` */
-      @deprecated("Replaced with `asQuotedType`", "0.27.0")
       def seal(using ctx: Context): scala.quoted.Type[_] =
         new scala.internal.quoted.Type(Inferred(self), internal.compilerId)
 

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -500,7 +500,7 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
 
       /** Convert to an `quoted.Expr[Any]` if the tree is a valid expression or throws */
       def asExpr(using QuoteContext): scala.quoted.Expr[Any] =
-        assert(tree.isExpr, tree)
+        assert(tree.isExpr, tree.show)
         new scala.internal.quoted.Expr(tree, internal.compilerId)
 
     end extension
@@ -1788,7 +1788,12 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
     extension (self: Type):
 
       /** Convert `Type` to an `quoted.Type[_]` */
+      @deprecated("Replaced with `asQuotedType`", "0.27.0")
       def seal(using ctx: Context): scala.quoted.Type[_] =
+        new scala.internal.quoted.Type(Inferred(self), internal.compilerId)
+
+      /** Convert to a `quoted.Type[_]` */
+      def asQuotedType(using ctx: Context): scala.quoted.Type[_] =
         new scala.internal.quoted.Type(Inferred(self), internal.compilerId)
 
       /** Is `self` type the same as `that` type?

--- a/tests/neg-macros/delegate-match-1/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-1/Macro_1.scala
@@ -5,7 +5,7 @@ inline def f: Any = ${ fImpl }
 
 private def fImpl(using qctx: QuoteContext): Expr[Unit] = {
   import qctx.tasty._
-  searchImplicit(('[A]).unseal.tpe) match {
+  searchImplicit(('[A]).asTypeTree.tpe) match {
     case x: ImplicitSearchSuccess =>
       '{}
     case x: DivergingImplicit => '{}

--- a/tests/neg-macros/delegate-match-2/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-2/Macro_1.scala
@@ -5,7 +5,7 @@ inline def f: Any = ${ fImpl }
 
 private def fImpl (using qctx: QuoteContext) : Expr[Unit] = {
   import qctx.tasty._
-  searchImplicit(('[A]).unseal.tpe) match {
+  searchImplicit(('[A]).asTypeTree.tpe) match {
     case x: ImplicitSearchSuccess =>
       '{}
     case x: DivergingImplicit => '{}

--- a/tests/neg-macros/delegate-match-3/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-3/Macro_1.scala
@@ -5,7 +5,7 @@ inline def f: Any = ${ fImpl }
 
 private def fImpl(using qctx: QuoteContext) : Expr[Unit] = {
   import qctx.tasty._
-  searchImplicit(('[A]).unseal.tpe) match {
+  searchImplicit(('[A]).asTypeTree.tpe) match {
     case x: ImplicitSearchSuccess =>
       '{}
     case x: DivergingImplicit => '{}

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
     sc match {
       case '{ StringContext(${Varargs(parts)}: _*) } =>
         for (part @ Const(s) <- parts)
-          error(s, part.unseal.pos)
+          error(s, part.asTerm.pos)
     }
     '{}
   }

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
     sc match {
       case '{ StringContext(${Varargs(parts)}: _*) } =>
         for (part @ Const(s) <- parts)
-          error(s, part.unseal.pos)
+          error(s, part.asTerm.pos)
     }
     '{}
   }

--- a/tests/neg-macros/i6976/Macro_1.scala
+++ b/tests/neg-macros/i6976/Macro_1.scala
@@ -7,6 +7,6 @@ object macros {
 
   def mcrImpl(body: Expr[Any])(using ctx: QuoteContext) : Expr[Any] = {
     import ctx.tasty._
-    body.unseal match { case Block(_, _) => '{2} }
+    body.asTerm match { case Block(_, _) => '{2} }
   }
 }

--- a/tests/neg-macros/i7698.scala
+++ b/tests/neg-macros/i7698.scala
@@ -5,7 +5,7 @@ trait Show[T] {
 }
 
 def showInterpolatorImpl(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext): Expr[String] =
-  argsExpr.unseal match
+  argsExpr.asTerm match
     case '{ $arg: $t } => // error
     case '[ Int ] => // error
   ???

--- a/tests/neg-macros/i7919.scala
+++ b/tests/neg-macros/i7919.scala
@@ -4,7 +4,7 @@ object Test {
   def staged[T](using qctx: QuoteContext) = {
     import qctx.tasty._
     given typeT as quoted.Type[T] // error
-    val tTypeTree = typeT.unseal
+    val tTypeTree = typeT.asTypeTree
     val tt = typeOf[T]
     '{ "in staged" }
   }

--- a/tests/neg-macros/i8871.scala
+++ b/tests/neg-macros/i8871.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 object Macro {
   def impl[A : Type](using qctx: QuoteContext): Unit = {
     import qctx.tasty._
-    val tpe = typeOf[A].seal.asInstanceOf[quoted.Type[_ <: AnyRef]]
+    val tpe = typeOf[A].asQuotedType.asInstanceOf[quoted.Type[_ <: AnyRef]]
     '{ (a: ${tpe}) => ???} // error
   }
 }

--- a/tests/neg-macros/i8871b.scala
+++ b/tests/neg-macros/i8871b.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 object Macro {
   def impl[A : Type](using qctx: QuoteContext): Unit = {
     import qctx.tasty._
-    val tpe/*: quoted.Type[? <: AnyKind]*/ = typeOf[A].seal
+    val tpe/*: quoted.Type[? <: AnyKind]*/ = typeOf[A].asQuotedType
     '{ f[$tpe] } // error
   }
   def f[T <: AnyKind]: Unit = ()

--- a/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
@@ -15,7 +15,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    val tree = cond.unseal
+    val tree = cond.asTerm
 
     def isOps(tpe: TypeOrBounds): Boolean = tpe match {
       case tpe: TermRef => tpe.termSymbol.isDefDef && tpe.name == "Ops"// TODO check that the parent is Asserts
@@ -32,7 +32,7 @@ object Asserts {
 
     tree match {
       case Inlined(_, Nil, Apply(Select(OpsTree(left), op), right :: Nil)) =>
-        '{assertTrue(${left.seal.cast[Boolean]})} // Buggy code. To generate the errors
+        '{assertTrue(${left.asExprOf[Boolean]})} // Buggy code. To generate the errors
       case _ =>
         '{assertTrue($cond)}
     }

--- a/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
@@ -15,7 +15,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    val tree = cond.unseal
+    val tree = cond.asTerm
 
     def isOps(tpe: TypeOrBounds): Boolean = tpe match {
       case tpe: TermRef => tpe.termSymbol.isDefDef && tpe.name == "Ops"// TODO check that the parent is Asserts
@@ -32,7 +32,7 @@ object Asserts {
 
     tree match {
       case Inlined(_, Nil, Apply(Select(OpsTree(left), op), right :: Nil)) =>
-        '{assertTrue(${left.seal.cast[Boolean]})} // Buggy code. To generate the errors
+        '{assertTrue(${left.asExprOf[Boolean]})} // Buggy code. To generate the errors
       case _ =>
         '{assertTrue($cond)}
     }

--- a/tests/neg-macros/tasty-macro-error/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-error/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
-    error("here is the the argument is " + x.unseal.underlyingArgument.show, x.unseal.underlyingArgument.pos)
+    error("here is the the argument is " + x.asTerm.underlyingArgument.show, x.asTerm.underlyingArgument.pos)
     '{}
   }
 

--- a/tests/neg-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-positions/quoted_1.scala
@@ -6,9 +6,9 @@ object Macros {
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
-    val pos = x.unseal.underlyingArgument.pos
-    error("here is the the argument is " + x.unseal.underlyingArgument.show, pos)
-    error("here (+5) is the the argument is " + x.unseal.underlyingArgument.show, pos.sourceFile, pos.start + 5, pos.end + 5)
+    val pos = x.asTerm.underlyingArgument.pos
+    error("here is the the argument is " + x.asTerm.underlyingArgument.show, pos)
+    error("here (+5) is the the argument is " + x.asTerm.underlyingArgument.show, pos.sourceFile, pos.start + 5, pos.end + 5)
     '{}
   }
 

--- a/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
@@ -11,7 +11,7 @@ object FIntepolator {
 
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    error("there are no parts", strCtxExpr.unseal.underlyingArgument.pos)
+    error("there are no parts", strCtxExpr.asTerm.underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }
 

--- a/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
 object FIntepolator {
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    error("there are no args", argsExpr.unseal.underlyingArgument.pos)
+    error("there are no args", argsExpr.asTerm.underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }
 

--- a/tests/neg-staging/i5941/macro_1.scala
+++ b/tests/neg-staging/i5941/macro_1.scala
@@ -17,7 +17,7 @@ object Lens {
     import util._
     // obj.copy(field = value)
     def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =
-      Select.overloaded(obj.asTerm, "copy", Nil, NamedArg(field, value.asTerm) :: Nil).seal.cast[S]
+      Select.overloaded(obj.asTerm, "copy", Nil, NamedArg(field, value.asTerm) :: Nil).asExprOf[S]
 
     // exception: getter.asTerm.underlyingArgument
     getter.asTerm match {

--- a/tests/neg-staging/i5941/macro_1.scala
+++ b/tests/neg-staging/i5941/macro_1.scala
@@ -17,10 +17,10 @@ object Lens {
     import util._
     // obj.copy(field = value)
     def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =
-      Select.overloaded(obj.unseal, "copy", Nil, NamedArg(field, value.unseal) :: Nil).seal.cast[S]
+      Select.overloaded(obj.asTerm, "copy", Nil, NamedArg(field, value.asTerm) :: Nil).seal.cast[S]
 
-    // exception: getter.unseal.underlyingArgument
-    getter.unseal match {
+    // exception: getter.asTerm.underlyingArgument
+    getter.asTerm match {
       case Inlined(
         None, Nil,
         Block(

--- a/tests/pending/run/tasty-comments/quoted_1.scala
+++ b/tests/pending/run/tasty-comments/quoted_1.scala
@@ -9,7 +9,7 @@ object Macros {
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    val tree = x.unseal
+    val tree = x.asTerm
     tree.symbol.comment.map(_.raw) match {
       case Some(str) => '{ println(${str}) }
       case None => '{ println() }

--- a/tests/pos-macros/i6171/Macro_1.scala
+++ b/tests/pos-macros/i6171/Macro_1.scala
@@ -6,7 +6,7 @@ object scalatest {
 
   def assertImpl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
-    x.unseal.underlyingArgument
+    x.asTerm.underlyingArgument
     '{ () }
   }
 }

--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -8,20 +8,20 @@ object scalatest {
     import qctx.tasty._
     import util._
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
             let(app) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
     }
   }
 

--- a/tests/pos-macros/i7011/Macros_1.scala
+++ b/tests/pos-macros/i7011/Macros_1.scala
@@ -5,10 +5,10 @@ inline def mcr(body: => Any): Unit = ${mcrImpl('body)}
 def mcrImpl[T](body: Expr[Any])(using ctx: QuoteContext) : Expr[Any] = {
   import ctx.tasty.{_, given _}
 
-  val bTree = body.unseal
+  val bTree = body.asTerm
   val under = bTree.underlyingArgument
 
-  val res = '{Box(${under.asInstanceOf[Term].seal})}
+  val res = '{Box(${under.asInstanceOf[Term].asExpr})}
   res
 }
 

--- a/tests/pos-macros/i7030/Macros_1.scala
+++ b/tests/pos-macros/i7030/Macros_1.scala
@@ -7,5 +7,5 @@ def innerImpl(exprs: Expr[Any])(using QuoteContext): Expr[Any] =
 inline def outer(expr: => Any): Any = ${outerImpl('expr)}
 def outerImpl(body: Expr[Any])(using ctx: QuoteContext): Expr[Any] = {
   import ctx.tasty._
-  body.unseal.underlyingArgument.seal
+  body.asTerm.underlyingArgument.asExpr
 }

--- a/tests/pos-macros/i8325/Macro_1.scala
+++ b/tests/pos-macros/i8325/Macro_1.scala
@@ -13,9 +13,9 @@ object A:
 
   def transformImplExpr[A:Type](using qctx: QuoteContext)(expr: Expr[A]): Expr[A] = {
      import qctx.tasty._
-     expr.unseal match {
-         case Inlined(x,y,z) => transformImplExpr(z.seal.asInstanceOf[Expr[A]])
-         case Apply(fun,args) =>  '{  A.pure(${Apply(fun,args).seal.asInstanceOf[Expr[A]]}) }
+     expr.asTerm match {
+         case Inlined(x,y,z) => transformImplExpr(z.asExpr.asInstanceOf[Expr[A]])
+         case Apply(fun,args) =>  '{  A.pure(${Apply(fun,args).asExpr.asInstanceOf[Expr[A]]}) }
          case other => expr
      }
   }

--- a/tests/pos-macros/i8325b/Macro_1.scala
+++ b/tests/pos-macros/i8325b/Macro_1.scala
@@ -13,10 +13,10 @@ object A:
 
   def transformImplExpr[A:Type](using qctx: QuoteContext)(expr: Expr[A]): Expr[A] = {
      import qctx.tasty._
-     expr.unseal match {
-         case Inlined(x,y,z) => transformImplExpr(z.seal.asInstanceOf[Expr[A]])
+     expr.asTerm match {
+         case Inlined(x,y,z) => transformImplExpr(z.asExpr.asInstanceOf[Expr[A]])
          case r@Apply(fun,args) =>  '{
-              A.pure(${r.seal.asInstanceOf[Expr[A]]}) }
+              A.pure(${r.asExpr.asInstanceOf[Expr[A]]}) }
          case other => expr
      }
   }

--- a/tests/pos-macros/i9251/Macro_1.scala
+++ b/tests/pos-macros/i9251/Macro_1.scala
@@ -21,14 +21,14 @@ object Async {
   def checkPrintTypeImpl[F[_]:Type,T:Type](f: Expr[T])(using qctx: QuoteContext): Expr[Unit] =
     import qctx.tasty._
 
-    val fu = f.unseal
+    val fu = f.asTerm
     fu match
       case Inlined(_,_,Block(_,Apply(TypeApply(Select(q,n),tparams),List(param)))) =>
         param.tpe match
           case AppliedType(tp,tparams1) =>
             val fType = summon[quoted.Type[F]]
             val ptp = tparams1.tail.head
-            val ptpTree = Inferred(AppliedType(fType.unseal.tpe,List(ptp)))
+            val ptpTree = Inferred(AppliedType(fType.asTypeTree.tpe,List(ptp)))
             '{ println(${Expr(ptpTree.show)}) }
 
 }

--- a/tests/pos-macros/tasty-constant-type/Macro_1.scala
+++ b/tests/pos-macros/tasty-constant-type/Macro_1.scala
@@ -9,10 +9,10 @@ object Macro {
   def impl[A <: Int : Type, B <: Int : Type](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[AddInt[A, B]] = {
     import qctx.tasty._
 
-    val ConstantType(Constant(v1: Int)) = a.unseal.tpe
-    val ConstantType(Constant(v2: Int)) = b.unseal.tpe
+    val ConstantType(Constant(v1: Int)) = a.asTypeTree.tpe
+    val ConstantType(Constant(v2: Int)) = b.asTypeTree.tpe
 
-    Literal(Constant((v1 + v2): Int)).tpe.seal match
+    Literal(Constant((v1 + v2): Int)).tpe.asQuotedType match
       case '[$t] => '{ null: AddInt[$a, $b] { type Out = $t } }
   }
 }

--- a/tests/pos-macros/treemap-unapply/Macro.scala
+++ b/tests/pos-macros/treemap-unapply/Macro.scala
@@ -3,6 +3,6 @@ import scala.quoted._
 inline def mcr(x: => Unit): Unit = ${mcrImpl('x)}
 def mcrImpl(x: Expr[Unit])(using ctx: QuoteContext) : Expr[Unit] =
   import ctx.tasty.{ given _, _ }
-  val tr: Term = x.unseal
+  val tr: Term = x.asTerm
   object m extends TreeMap
-  m.transformTerm(tr).seal.cast[Unit]
+  m.transformTerm(tr).asExprOf[Unit]

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -7,7 +7,7 @@ object Foo {
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    x.unseal match {
+    x.asTerm match {
       case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
       case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -7,7 +7,7 @@ object Foo {
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    x.unseal match {
+    x.asTerm match {
       case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
       case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -12,7 +12,7 @@ object Macros {
 
     val output = new MyTraverser(qctx.tasty)(buff)
 
-    val tree = x.unseal
+    val tree = x.asTerm
     output.traverseTree(tree)
     '{print(${Expr(buff.result())})}
   }

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
@@ -13,7 +13,7 @@ object Foo {
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.showExtractors)
       else '{"NO DEFINTION"}
 
-    x.unseal match {
+    x.asTerm match {
       case Inlined(None, Nil, arg) => definitionString(arg.symbol)
       case arg => definitionString(arg.symbol) // TODO should all by name parameters be in an inline node
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
@@ -12,7 +12,7 @@ object Foo {
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.showExtractors)
       else '{"NO DEFINTION"}
 
-    x.unseal match {
+    x.asTerm match {
       case Inlined(None, Nil, arg) => definitionString(arg.symbol)
       case arg => definitionString(arg.symbol) // TODO should all by name parameters be in an inline node
     }

--- a/tests/run-custom-args/run-macros-erased/reflect-isFunctionType/macro_1.scala
+++ b/tests/run-custom-args/run-macros-erased/reflect-isFunctionType/macro_1.scala
@@ -5,7 +5,7 @@ inline def isFunctionType[T]: Boolean = ${ isFunctionTypeImpl('[T]) }
 
 def isFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
   import qctx.tasty._
-  Expr(tp.unseal.tpe.isFunctionType)
+  Expr(tp.asTypeTree.tpe.isFunctionType)
 }
 
 
@@ -13,7 +13,7 @@ inline def isContextFunctionType[T]: Boolean = ${ isContextFunctionTypeImpl('[T]
 
 def isContextFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
   import qctx.tasty._
-  Expr(tp.unseal.tpe.isContextFunctionType)
+  Expr(tp.asTypeTree.tpe.isContextFunctionType)
 }
 
 
@@ -21,13 +21,13 @@ inline def isErasedFunctionType[T]: Boolean = ${ isErasedFunctionTypeImpl('[T]) 
 
 def isErasedFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
   import qctx.tasty._
-  Expr(tp.unseal.tpe.isErasedFunctionType)
+  Expr(tp.asTypeTree.tpe.isErasedFunctionType)
 }
 
 inline def isDependentFunctionType[T]: Boolean = ${ isDependentFunctionTypeImpl('[T]) }
 
 def isDependentFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
   import qctx.tasty._
-  Expr(tp.unseal.tpe.isDependentFunctionType)
+  Expr(tp.asTypeTree.tpe.isDependentFunctionType)
 }
 

--- a/tests/run-macros/f-interpolation-1/FQuote_1.scala
+++ b/tests/run-macros/f-interpolation-1/FQuote_1.scala
@@ -13,7 +13,7 @@ object FQuote {
 
     def liftListOfAny(lst: List[Term]): Expr[List[Any]] = lst match {
       case x :: xs  =>
-        val head = x.seal
+        val head = x.asExpr
         val tail = liftListOfAny(xs)
         '{ $head :: $tail }
       case Nil => '{Nil}
@@ -31,7 +31,7 @@ object FQuote {
       tree.symbol.fullName == "scala.StringContext$.apply"
 
     // FQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts = receiver.unseal.underlyingArgument match {
+    val parts = receiver.asTerm.underlyingArgument match {
       case Apply(conv, List(Apply(fun, List(Typed(Repeated(values, _), _)))))
           if isSCOpsConversion(conv) &&
              isStringContextApply(fun) &&
@@ -43,7 +43,7 @@ object FQuote {
     }
 
     // [a0, ...]: Any*
-    val Typed(Repeated(allArgs, _), _) = args.unseal.underlyingArgument
+    val Typed(Repeated(allArgs, _), _) = args.asTerm.underlyingArgument
 
     for ((arg, part) <- allArgs.zip(parts.tail)) {
       if (part.startsWith("%d") && !(arg.tpe <:< defn.IntType)) {

--- a/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
+++ b/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
@@ -22,7 +22,7 @@ object TypeToolbox {
   inline def typeOf[T, Expected](a: T): Boolean = ${typeOfImpl('a, '[Expected])}
   private def typeOfImpl(a: Expr[_], expected: Type[_])(using qctx: QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
-    Expr(a.unseal.tpe =:= expected.unseal.tpe)
+    Expr(a.asTerm.tpe =:= expected.unseal.tpe)
   }
 
   /** does the type refer to a case class? */

--- a/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
+++ b/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
@@ -8,28 +8,28 @@ object TypeToolbox {
   inline def =:=[A, B]: Boolean = ${tpEqImpl('[A], '[B])}
   private def tpEqImpl[A, B](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
-    Expr(a.unseal.tpe =:= b.unseal.tpe)
+    Expr(a.asTypeTree.tpe =:= b.asTypeTree.tpe)
   }
 
   /** is `tp1` a subtype of `tp2` */
   inline def <:<[A, B]: Boolean = ${tpLEqImpl('[A], '[B])}
   private def tpLEqImpl[A, B](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
-    Expr(a.unseal.tpe <:< b.unseal.tpe)
+    Expr(a.asTypeTree.tpe <:< b.asTypeTree.tpe)
   }
 
   /** type associated with the tree */
   inline def typeOf[T, Expected](a: T): Boolean = ${typeOfImpl('a, '[Expected])}
   private def typeOfImpl(a: Expr[_], expected: Type[_])(using qctx: QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
-    Expr(a.asTerm.tpe =:= expected.unseal.tpe)
+    Expr(a.asTerm.tpe =:= expected.asTypeTree.tpe)
   }
 
   /** does the type refer to a case class? */
   inline def isCaseClass[A]: Boolean = ${isCaseClassImpl('[A])}
   private def isCaseClassImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
-    val sym = tp.unseal.symbol
+    val sym = tp.asTypeTree.symbol
     Expr(sym.isClassDef && sym.flags.is(Flags.Case))
   }
 
@@ -37,66 +37,66 @@ object TypeToolbox {
   inline def caseFields[T]: List[String] = ${caseFieldsImpl('[T])}
   private def caseFieldsImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[List[String]] = {
     import qctx.tasty._
-    val fields = tp.unseal.symbol.caseFields.map(_.name)
+    val fields = tp.asTypeTree.symbol.caseFields.map(_.name)
     Expr(fields)
   }
 
   inline def fieldIn[T](inline mem: String): String = ${fieldInImpl('[T], 'mem)}
   private def fieldInImpl(t: Type[_], mem: Expr[String])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    val field = t.unseal.symbol.field(mem.unliftOrError)
+    val field = t.asTypeTree.symbol.field(mem.unliftOrError)
     Expr(if field.isNoSymbol then "" else field.name)
   }
 
   inline def fieldsIn[T]: Seq[String] = ${fieldsInImpl('[T])}
   private def fieldsInImpl(t: Type[_])(using qctx: QuoteContext) : Expr[Seq[String]] = {
     import qctx.tasty._
-    val fields = t.unseal.symbol.fields
+    val fields = t.asTypeTree.symbol.fields
     Expr(fields.map(_.name).toList)
   }
 
   inline def methodIn[T](inline mem: String): Seq[String] = ${methodInImpl('[T], 'mem)}
   private def methodInImpl(t: Type[_], mem: Expr[String])(using qctx: QuoteContext) : Expr[Seq[String]] = {
     import qctx.tasty._
-    Expr(t.unseal.symbol.classMethod(mem.unliftOrError).map(_.name))
+    Expr(t.asTypeTree.symbol.classMethod(mem.unliftOrError).map(_.name))
   }
 
   inline def methodsIn[T]: Seq[String] = ${methodsInImpl('[T])}
   private def methodsInImpl(t: Type[_])(using qctx: QuoteContext) : Expr[Seq[String]] = {
     import qctx.tasty._
-    Expr(t.unseal.symbol.classMethods.map(_.name))
+    Expr(t.asTypeTree.symbol.classMethods.map(_.name))
   }
 
   inline def method[T](inline mem: String): Seq[String] = ${methodImpl('[T], 'mem)}
   private def methodImpl(t: Type[_], mem: Expr[String])(using qctx: QuoteContext) : Expr[Seq[String]] = {
     import qctx.tasty._
-    Expr(t.unseal.symbol.method(mem.unliftOrError).map(_.name))
+    Expr(t.asTypeTree.symbol.method(mem.unliftOrError).map(_.name))
   }
 
   inline def methods[T]: Seq[String] = ${methodsImpl('[T])}
   private def methodsImpl(t: Type[_])(using qctx: QuoteContext) : Expr[Seq[String]] = {
     import qctx.tasty._
-    Expr(t.unseal.symbol.methods.map(_.name))
+    Expr(t.asTypeTree.symbol.methods.map(_.name))
   }
 
   inline def typeTag[T](x: T): String = ${typeTagImpl('[T])}
   private def typeTagImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    val res = tp.unseal.tpe.show
+    val res = tp.asTypeTree.tpe.show
     Expr(res)
   }
 
   inline def companion[T1, T2]: Boolean = ${companionImpl('[T1], '[T2])}
   private def companionImpl(t1: Type[_], t2: Type[_])(using qctx: QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
-    val res = t1.unseal.symbol.companionModule == t2.unseal.symbol
+    val res = t1.asTypeTree.symbol.companionModule == t2.asTypeTree.symbol
     Expr(res)
   }
 
   inline def companionName[T1]: String = ${companionNameImpl('[T1])}
   private def companionNameImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    val sym = tp.unseal.symbol
+    val sym = tp.asTypeTree.symbol
     val companionClass =
       if sym.isClassDef then sym.companionModule.companionClass
       else if sym.isValDef then sym.companionClass

--- a/tests/run-macros/i5119/Macro_1.scala
+++ b/tests/run-macros/i5119/Macro_1.scala
@@ -7,6 +7,6 @@ object Macro {
   implicit inline def XmlQuote(inline sc: StringContext): StringContextOps = new StringContextOps(sc)
   def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    Expr(sc.unseal.underlyingArgument.showExtractors + "\n" + args.unseal.underlyingArgument.showExtractors)
+    Expr(sc.asTerm.underlyingArgument.showExtractors + "\n" + args.asTerm.underlyingArgument.showExtractors)
   }
 }

--- a/tests/run-macros/i5119b/Macro_1.scala
+++ b/tests/run-macros/i5119b/Macro_1.scala
@@ -6,6 +6,6 @@ object Macro {
   inline def ff(arg1: Any,  arg2: Any): String = ${ Macro.impl('{arg1}, '{arg2}) }
 
   def impl(arg1: Expr[Any], arg2: Expr[Any])(using qctx: QuoteContext) : Expr[String] =
-    Expr(arg1.unseal.underlyingArgument.showExtractors + "\n" + arg2.unseal.underlyingArgument.showExtractors)
+    Expr(arg1.asTerm.underlyingArgument.showExtractors + "\n" + arg2.asTerm.underlyingArgument.showExtractors)
 
 }

--- a/tests/run-macros/i5533/Macro_1.scala
+++ b/tests/run-macros/i5533/Macro_1.scala
@@ -10,9 +10,9 @@ object scalatest {
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    val tree = condition.unseal
+    val tree = condition.asTerm
 
-    val expr = tree.seal.cast[Boolean]
+    val expr = tree.asExprOf[Boolean]
 
     '{println($expr)}
   }

--- a/tests/run-macros/i5533b/Macro_1.scala
+++ b/tests/run-macros/i5533b/Macro_1.scala
@@ -8,13 +8,13 @@ object scalatest {
 
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
-    val tree = condition.unseal
+    val tree = condition.asTerm
     def exprStr: String = condition.show
 
     tree.underlyingArgument match {
       case Apply(Select(lhs, op), rhs :: Nil) =>
-        val left = lhs.seal
-        val right = rhs.seal
+        val left = lhs.asExpr
+        val right = rhs.asExpr
         op match {
           case "==" =>
         '{

--- a/tests/run-macros/i5536/Macro_1.scala
+++ b/tests/run-macros/i5536/Macro_1.scala
@@ -5,13 +5,13 @@ object scalatest {
 
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
-    val tree = condition.unseal
+    val tree = condition.asTerm
     def exprStr: String = condition.show
 
     tree.underlyingArgument match {
       case Apply(Select(lhs, op), rhs :: Nil) =>
-        val left = lhs.seal
-        val right = rhs.seal
+        val left = lhs.asExpr
+        val right = rhs.asExpr
         op match {
           case "===" =>
             '{

--- a/tests/run-macros/i5629/Macro_1.scala
+++ b/tests/run-macros/i5629/Macro_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
-    val b = cond.unseal.underlyingArgument.seal.cast[Boolean]
+    val b = cond.asTerm.underlyingArgument.asExprOf[Boolean]
     '{ scala.Predef.assert($b) }
   }
 

--- a/tests/run-macros/i5715/Macro_1.scala
+++ b/tests/run-macros/i5715/Macro_1.scala
@@ -7,9 +7,9 @@ object scalatest {
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case app @ Apply(select @ Select(lhs, op), rhs :: Nil) =>
-        val cond = Apply(Select.copy(select)(lhs, "exists"), rhs :: Nil).seal.cast[Boolean]
+        val cond = Apply(Select.copy(select)(lhs, "exists"), rhs :: Nil).asExprOf[Boolean]
         '{ scala.Predef.assert($cond) }
       case _ =>
         '{ scala.Predef.assert($cond) }

--- a/tests/run-macros/i5941/macro_1.scala
+++ b/tests/run-macros/i5941/macro_1.scala
@@ -45,11 +45,11 @@ object Lens {
       }
     }
 
-    // exception: getter.unseal.underlyingArgument
-    getter.unseal match {
+    // exception: getter.asTerm.underlyingArgument
+    getter.asTerm match {
       case Function(param :: Nil, Path(o, parts)) if o.symbol == param.symbol =>
         '{
-          val setter = (t: T) => (s: S) => ${ setterBody(('s).unseal, ('t).unseal, parts).seal.cast[S] }
+          val setter = (t: T) => (s: S) => ${ setterBody(('s).asTerm, ('t).asTerm, parts).asExprOf[S] }
           apply($getter)(setter)
         }
       case _ =>
@@ -116,9 +116,9 @@ object Iso {
       '{???}
     } else '{
       // (p: S) => p._1
-      val to = (p: S) =>  ${ Select.unique(('p).unseal, "_1").seal.cast[A] }
+      val to = (p: S) =>  ${ Select.unique(('p).asTerm, "_1").asExprOf[A] }
       // (p: A) => S(p)
-      val from = (p: A) =>  ${ Select.overloaded(Ident(companion), "apply", Nil, ('p).unseal :: Nil).seal.cast[S] }
+      val from = (p: A) =>  ${ Select.overloaded(Ident(companion), "apply", Nil, ('p).asTerm :: Nil).asExprOf[S] }
       apply(from)(to)
     }
   }
@@ -130,7 +130,7 @@ object Iso {
     val tpS = typeOf[S]
 
     if (tpS.isSingleton) {
-      val ident = Ident(tpS.asInstanceOf[TermRef]).seal.cast[S]
+      val ident = Ident(tpS.asInstanceOf[TermRef]).asExprOf[S]
       '{
         Iso[S, 1](Function.const($ident))(Function.const(1))
       }
@@ -147,7 +147,7 @@ object Iso {
         case TypeRef(prefix, name) => TermRef(prefix, name)
       }
 
-      val obj = Select.overloaded(Ident(companion), "apply", Nil, Nil).seal.cast[S]
+      val obj = Select.overloaded(Ident(companion), "apply", Nil, Nil).asExprOf[S]
 
       '{
         Iso[S, 1](Function.const($obj))(Function.const(1))

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -12,34 +12,34 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
             let(app) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
         if isImplicitMethodType(f.tpe) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
             let(Apply(app, implicits)) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
     }
   }
 }

--- a/tests/run-macros/i6679/Macro_1.scala
+++ b/tests/run-macros/i6679/Macro_1.scala
@@ -4,7 +4,7 @@ def makeMatch[A: Type](head : Expr[A])(using qctx : QuoteContext) : Expr[Unit] =
   import qctx.tasty._
 
   val sacrifice = '{ $head match { case _ => ??? } }
-  sacrifice.unseal
+  sacrifice.asTerm
 
   '{ println("Ok") }
 }

--- a/tests/run-macros/i6988/FirstArg_1.scala
+++ b/tests/run-macros/i6988/FirstArg_1.scala
@@ -23,10 +23,10 @@ object Macros {
       else enclosingParamList(owner.owner)
 
     def literal(value: String): Expr[String] =
-      Literal(Constant(value)).seal.asInstanceOf[Expr[String]]
+      Literal(Constant(value)).asExpr.asInstanceOf[Expr[String]]
     val paramss = enclosingParamList(rootContext.owner)
     val firstArg = paramss.flatten.head
     val ref = Select.unique(This(enclosingClass()), firstArg.name)
-    '{ FirstArg(${ref.seal}, ${Expr(firstArg.name)}) }
+    '{ FirstArg(${ref.asExpr}, ${Expr(firstArg.name)}) }
   }
 }

--- a/tests/run-macros/i7887/Macro_1.scala
+++ b/tests/run-macros/i7887/Macro_1.scala
@@ -1,7 +1,7 @@
 def myMacroImpl(a: quoted.Expr[_])(using qctx: quoted.QuoteContext) = {
   import qctx.tasty._
   def typed[A] = {
-    implicit val t: quoted.Type[A] = a.asTerm.tpe.widen.seal.asInstanceOf[quoted.Type[A]]
+    implicit val t: quoted.Type[A] = a.asTerm.tpe.widen.asQuotedType.asInstanceOf[quoted.Type[A]]
     '{
       type T = $t
       ${a.asTerm.asExprOf[T]}

--- a/tests/run-macros/i7887/Macro_1.scala
+++ b/tests/run-macros/i7887/Macro_1.scala
@@ -1,10 +1,10 @@
 def myMacroImpl(a: quoted.Expr[_])(using qctx: quoted.QuoteContext) = {
   import qctx.tasty._
   def typed[A] = {
-    implicit val t: quoted.Type[A] = a.unseal.tpe.widen.seal.asInstanceOf[quoted.Type[A]]
+    implicit val t: quoted.Type[A] = a.asTerm.tpe.widen.seal.asInstanceOf[quoted.Type[A]]
     '{
       type T = $t
-      ${a.unseal.seal.cast[T]}
+      ${a.asTerm.asExprOf[T]}
     }
   }
 

--- a/tests/run-macros/i7898/Macro_1.scala
+++ b/tests/run-macros/i7898/Macro_1.scala
@@ -4,11 +4,11 @@ object Main {
 
   def myMacroImpl(body: Expr[_])(using qctx: QuoteContext) : Expr[_] = {
     import qctx.tasty._
-    val bodyTerm = UnsafeExpr.underlyingArgument(body).unseal
+    val bodyTerm = UnsafeExpr.underlyingArgument(body).asTerm
     val showed = bodyTerm.show
     '{
       println(${Expr(showed)})
-      ${bodyTerm.seal}
+      ${bodyTerm.asExpr}
     }
   }
 

--- a/tests/run-macros/i8007/Macro_2.scala
+++ b/tests/run-macros/i8007/Macro_2.scala
@@ -30,7 +30,7 @@ object Macro2 {
 
       val body: Expr[T] => Expr[String] = elem =>
         fields.reverse.foldLeft(Expr("")){ (acc, field) =>
-          val res = Select.unique(elem.unseal, field).seal
+          val res = Select.unique(elem.asTerm, field).asExpr
           '{ $res.toString + " " + $acc }
         }
 

--- a/tests/run-macros/i8514/Macro_1.scala
+++ b/tests/run-macros/i8514/Macro_1.scala
@@ -10,9 +10,9 @@ def testExpr(using QuoteContext): Expr[Unit] = {
   import qctx.tasty._
 
   '{
-    println(${Expr('[Object].unseal.tpe.baseClasses.toString)})
-    println(${Expr('[A].unseal.tpe.baseClasses.toString)})
-    println(${Expr('[B].unseal.tpe.baseClasses.toString)})
-    println(${Expr('[C].unseal.tpe.baseClasses.toString)})
+    println(${Expr('[Object].asTypeTree.tpe.baseClasses.toString)})
+    println(${Expr('[A].asTypeTree.tpe.baseClasses.toString)})
+    println(${Expr('[B].asTypeTree.tpe.baseClasses.toString)})
+    println(${Expr('[C].asTypeTree.tpe.baseClasses.toString)})
   }
 }

--- a/tests/run-macros/i8514b/Macro_1.scala
+++ b/tests/run-macros/i8514b/Macro_1.scala
@@ -9,7 +9,7 @@ inline def test(): Unit = ${ testExpr }
 def testExpr(using QuoteContext): Expr[Unit] = {
   import qctx.tasty._
 
-  val t = '[B].unseal.tpe
+  val t = '[B].asTypeTree.tpe
   val baseTypes = t.baseClasses.map(b => t.baseType(b))
 
   '{

--- a/tests/run-macros/i8520/Macro_1.scala
+++ b/tests/run-macros/i8520/Macro_1.scala
@@ -8,6 +8,6 @@ def testExpr[T[_]: Type](using QuoteContext): Expr[Unit] = {
      if f.is(Flags.Covariant) then "+"
      else if f.is(Flags.Contravariant) then "-"
      else " "
-  val t = '[T].unseal.tpe.typeSymbol.typeMembers.map(x => (x.name, variance(x.flags)))
+  val t = '[T].asTypeTree.tpe.typeSymbol.typeMembers.map(x => (x.name, variance(x.flags)))
   '{ println(${Expr(t.toString)}) }
 }

--- a/tests/run-macros/i9206/Macros_1.scala
+++ b/tests/run-macros/i9206/Macros_1.scala
@@ -5,7 +5,7 @@ object Inspect {
   inline def inspect[T <: AnyKind]: String = ${ inspectTpe[T] }
 
   def inspectTpe[T <: AnyKind](using tpe: quoted.Type[T], qctx0: QuoteContext): Expr[String] = {
-    val tree = summon[quoted.Type[T]].unseal.tpe.typeSymbol.tree
+    val tree = summon[quoted.Type[T]].asTypeTree.tpe.typeSymbol.tree
     Expr(tree.show)
   }
 }

--- a/tests/run-macros/inferred-repeated-result/test_1.scala
+++ b/tests/run-macros/inferred-repeated-result/test_1.scala
@@ -5,7 +5,7 @@ object Macros {
   def impl[T](expr: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    val tree = expr.unseal
+    val tree = expr.asTerm
 
     val methods =
       tree.tpe.classSymbol.get.classMethods.map { m =>

--- a/tests/run-macros/no-symbol/1.scala
+++ b/tests/run-macros/no-symbol/1.scala
@@ -10,7 +10,7 @@ object Macro {
 
   def fooImpl[T](implicit t: Type[T], qctx: QuoteContext): Expr[String] = {
     import qctx.tasty._
-    val sym = t.unseal.symbol
+    val sym = t.asTypeTree.symbol
     if sym.isClassDef then '{ "symbol" }
     else if sym.isNoSymbol then '{ "no symbol" }
     else  '{ "match error" }

--- a/tests/run-macros/paramSymss/Macro_1.scala
+++ b/tests/run-macros/paramSymss/Macro_1.scala
@@ -5,7 +5,7 @@ inline def showParamSyms(inline x: Any): String =
 
 def showParamSymsExpr(using QuoteContext)(x: Expr[Any]): Expr[String] =
   val '{ $y: Any } = x // Drop Inlined not to access the symbol
-  val sym = y.unseal.symbol
+  val sym = y.asTerm.symbol
   Expr(
     s"""sym: ${sym.show}
        |paramSymss: ${sym.paramSymss.map(_.map(_.show))}

--- a/tests/run-macros/quote-matcher-runtime/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-runtime/quoted_1.scala
@@ -10,7 +10,7 @@ object Macros {
     val res = scala.internal.quoted.Expr.unapply[Tuple, Tuple](a)(using b, true, qctx).map { tup =>
       tup.toArray.toList.map {
         case r: Expr[_] =>
-          s"Expr(${r.unseal.show})"
+          s"Expr(${r.asTerm.show})"
         case r: quoted.Type[_] =>
           s"Type(${r.unseal.show})"
         case r: String =>
@@ -19,8 +19,8 @@ object Macros {
     }
 
     '{
-      println("Scrutinee: " + ${Expr(a.unseal.show)})
-      println("Pattern: " + ${Expr(b.unseal.show)})
+      println("Scrutinee: " + ${Expr(a.asTerm.show)})
+      println("Pattern: " + ${Expr(b.asTerm.show)})
       println("Result: " + ${Expr(res.toString)})
       println()
     }

--- a/tests/run-macros/quote-matcher-runtime/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-runtime/quoted_1.scala
@@ -12,7 +12,7 @@ object Macros {
         case r: Expr[_] =>
           s"Expr(${r.asTerm.show})"
         case r: quoted.Type[_] =>
-          s"Type(${r.unseal.show})"
+          s"Type(${r.asTypeTree.show})"
         case r: String =>
           s"String($r)"
       }

--- a/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
@@ -21,7 +21,7 @@ object Macros {
 
       case _ =>
         import qctx.tasty._
-        error("Expected explicit DSL", e.unseal.pos)
+        error("Expected explicit DSL", e.asTerm.pos)
         '{ ??? }
 
     }

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -32,7 +32,7 @@ object Macros {
 
       case _ =>
         import qctx.tasty._
-        error("Expected explicit DSL " + e.show, e.unseal.pos)
+        error("Expected explicit DSL " + e.show, e.asTerm.pos)
         ???
     }
 
@@ -46,7 +46,7 @@ object Macros {
         )
       case _ =>
         import qctx.tasty._
-        error("Expected explicit DSL => DSL "  + e.show, e.unseal.pos)
+        error("Expected explicit DSL => DSL "  + e.show, e.asTerm.pos)
         ???
     }
 

--- a/tests/run-macros/quote-type-matcher/quoted_1.scala
+++ b/tests/run-macros/quote-type-matcher/quoted_1.scala
@@ -10,15 +10,15 @@ object Macros {
     val res = scala.internal.quoted.Type.unapply[Tuple, Tuple](a)(using b, true, qctx).map { tup =>
       tup.toArray.toList.map {
         case r: quoted.Type[_] =>
-          s"Type(${r.unseal.show})"
+          s"Type(${r.asTypeTree.show})"
         case r: String =>
           s"String($r)"
       }
     }
 
     '{
-      println("Scrutinee: " + ${Expr(a.unseal.show)})
-      println("Pattern: " + ${Expr(b.unseal.show)})
+      println("Scrutinee: " + ${Expr(a.asTypeTree.show)})
+      println("Pattern: " + ${Expr(b.asTypeTree.show)})
       println("Result: " + ${Expr(res.toString)})
       println()
     }

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -12,34 +12,34 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = left.select(sel.symbol).appliedTo(right)
             let(app) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
       case Apply(f @ Apply(sel @ Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = qual.appliedTo(left).select(sel.symbol).appliedTo(right)
             let(Apply(app, implicits)) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
     }
   }
 

--- a/tests/run-macros/reflect-lambda/assert_1.scala
+++ b/tests/run-macros/reflect-lambda/assert_1.scala
@@ -8,7 +8,7 @@ object lib {
     import qctx.tasty._
     import util._
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(Select(lhs, op), Lambda(param :: Nil, Apply(Select(a, "=="), b :: Nil)) :: Nil)
       if a.symbol == param.symbol || b.symbol == param.symbol =>
         '{ scala.Predef.assert($cond) }

--- a/tests/run-macros/reflect-pos-fun/assert_1.scala
+++ b/tests/run-macros/reflect-pos-fun/assert_1.scala
@@ -8,15 +8,15 @@ object scalatest {
     import qctx.tasty._
     import util._
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(TypeApply(Select(lhs, op), targs), rhs) =>
         let(lhs) { left =>
           lets(rhs) { rs =>
             val app = Select.overloaded(left, op, targs.map(_.tpe), rs)
-            val b = app.seal.cast[Boolean]
-            '{ scala.Predef.assert($b) }.unseal
+            val b = app.asExprOf[Boolean]
+            '{ scala.Predef.assert($b) }.asTerm
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
     }
   }
 }

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -12,34 +12,34 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
             let(app) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
             let(Apply(app, implicits)) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
     }
   }
 

--- a/tests/run-macros/reflect-select-copy-2/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy-2/assert_1.scala
@@ -12,32 +12,32 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         let(lhs) { left =>
           let(rhs) { right =>
             let(Apply(Select.copy(sel)(left, op), right :: Nil)) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert(${b}) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
       case Apply(f @ Apply(sel @ Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
         let(lhs) { left =>
           let(rhs) { right =>
             let(Apply(Apply(Select.copy(sel)(Apply(qual, left :: Nil), op), right :: Nil), implicits)) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert(${b}) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
     }
   }
 

--- a/tests/run-macros/reflect-select-copy/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy/assert_1.scala
@@ -7,9 +7,9 @@ object scalatest {
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case Apply(select @ Select(lhs, op), rhs :: Nil) =>
-        val cond = Apply(Select.copy(select)(lhs, ">"), rhs :: Nil).seal.cast[Boolean]
+        val cond = Apply(Select.copy(select)(lhs, ">"), rhs :: Nil).asExprOf[Boolean]
         '{ scala.Predef.assert($cond) }
       case _ =>
         '{ scala.Predef.assert($cond) }

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -12,34 +12,34 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Apply(Select(left, sel.symbol), right :: Nil)
             let(app) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
       case Apply(f @ Apply(sel @ Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Apply(Select(Apply(qual, left :: Nil), sel.symbol), right :: Nil)
             let(Apply(app, implicits)) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
     }
   }
 

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -12,34 +12,34 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
             let(app) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
         let(lhs) { left =>
           let(rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
             let(Apply(app, implicits)) { result =>
-              val l = left.seal
-              val r = right.seal
-              val b = result.seal.cast[Boolean]
+              val l = left.asExpr
+              val r = right.asExpr
+              val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              code.asTerm
             }
           }
-        }.seal.cast[Unit]
+        }.asExprOf[Unit]
     }
   }
 

--- a/tests/run-macros/reflect-sourceCode/Macro_1.scala
+++ b/tests/run-macros/reflect-sourceCode/Macro_1.scala
@@ -6,6 +6,6 @@ object api {
 
   private def reflImpl[T](x: Expr[T])(implicit qctx: QuoteContext): Expr[String] = {
     import qctx.tasty._
-    Expr(x.unseal.pos.sourceCode)
+    Expr(x.asTerm.pos.sourceCode)
   }
 }

--- a/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
-    val tree = x.unseal
+    val tree = x.asTerm
     '{
       println()
       println("tree: " + ${Expr(tree.showExtractors)})

--- a/tests/run-macros/tasty-construct-types/Macro_1.scala
+++ b/tests/run-macros/tasty-construct-types/Macro_1.scala
@@ -28,7 +28,7 @@ object Macros {
         "T",
         TypeBounds(typeOf[Int], typeOf[Int]))
     val x6T = AppliedType(Type(classOf[List[_]]), List(typeOf[Int]))
-    val x7T = AnnotatedType(ConstantType(Constant(7)), '{ new TestAnnotation }.unseal)
+    val x7T = AnnotatedType(ConstantType(Constant(7)), '{ new TestAnnotation }.asTerm)
     val x8T =
       MatchType(
         typeOf[Int],

--- a/tests/run-macros/tasty-construct-types/Macro_1.scala
+++ b/tests/run-macros/tasty-construct-types/Macro_1.scala
@@ -40,14 +40,14 @@ object Macros {
             tl => AppliedType(MatchCaseType, List(AppliedType(Type(classOf[List[_]]), List(tl.param(0))), tl.param(0)))))
       )
 
-    assert(x1T =:= '[1].unseal.tpe)
-    assert(x2T =:= '[1|2].unseal.tpe)
-    assert(x3T =:= '[3&Any].unseal.tpe)
-    assert(x4T =:= '[[A,B] =>> B].unseal.tpe)
-    assert(x5T =:= '[RefineMe { type T = Int }].unseal.tpe)
-    assert(x6T =:= '[List[Int]].unseal.tpe)
-    assert(x7T =:= '[7 @TestAnnotation].unseal.tpe)
-    assert(x8T =:= '[List[8] match { case List[t] => t }].unseal.tpe)
+    assert(x1T =:= '[1].asTypeTree.tpe)
+    assert(x2T =:= '[1|2].asTypeTree.tpe)
+    assert(x3T =:= '[3&Any].asTypeTree.tpe)
+    assert(x4T =:= '[[A,B] =>> B].asTypeTree.tpe)
+    assert(x5T =:= '[RefineMe { type T = Int }].asTypeTree.tpe)
+    assert(x6T =:= '[List[Int]].asTypeTree.tpe)
+    assert(x7T =:= '[7 @TestAnnotation].asTypeTree.tpe)
+    assert(x8T =:= '[List[8] match { case List[t] => t }].asTypeTree.tpe)
 
     '{
       println("Ok")

--- a/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
+++ b/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
@@ -20,10 +20,10 @@ object Macros {
       DefDef(sym1, {
         case List() => {
           case List(List(a, b)) =>
-            Some('{ ${ a.seal.asInstanceOf[Expr[Int]] } - ${ b.seal.asInstanceOf[Expr[Int]] } }.unseal)
+            Some('{ ${ a.asExpr.asInstanceOf[Expr[Int]] } - ${ b.asExpr.asInstanceOf[Expr[Int]] } }.asTerm)
         }
       }),
-      '{ assert(${ Apply(Ref(sym1), List(Literal(Constant(2)), Literal(Constant(3)))).seal.asInstanceOf[Expr[Int]] } == -1) }.unseal)
+      '{ assert(${ Apply(Ref(sym1), List(Literal(Constant(2)), Literal(Constant(3)))).asExpr.asInstanceOf[Expr[Int]] } == -1) }.asTerm)
 
     // test for no argument list (no Apply node)
     val sym2 : Symbol = Symbol.newMethod(
@@ -39,7 +39,7 @@ object Macros {
             Some(Literal(Constant(2)))
         }
       }),
-      '{ assert(${ Ref(sym2).seal.asInstanceOf[Expr[Int]] } == 2) }.unseal)
+      '{ assert(${ Ref(sym2).asExpr.asInstanceOf[Expr[Int]] } == 2) }.asTerm)
 
    // test for multiple argument lists
    val sym3 : Symbol = Symbol.newMethod(
@@ -59,7 +59,7 @@ object Macros {
             Some(a)
         }
       }),
-      '{ assert(${ Apply(Apply(Ref(sym3), List(Literal(Constant(3)))), List(Literal(Constant(3)))).seal.asInstanceOf[Expr[Int]] } == 3) }.unseal)
+      '{ assert(${ Apply(Apply(Ref(sym3), List(Literal(Constant(3)))), List(Literal(Constant(3)))).asExpr.asInstanceOf[Expr[Int]] } == 3) }.asTerm)
 
     // test for recursive references
     val sym4 : Symbol = Symbol.newMethod(
@@ -75,13 +75,13 @@ object Macros {
         case List() => {
           case List(List(x)) =>
             Some('{
-              if ${ x.seal.asInstanceOf[Expr[Int]] } == 0
+              if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
               then 0
-              else ${ Apply(Ref(sym4), List('{ ${ x.seal.asInstanceOf[Expr[Int]] } - 1 }.unseal)).seal.asInstanceOf[Expr[Int]] }
-            }.unseal)
+              else ${ Apply(Ref(sym4), List('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }.asTerm)).asExpr.asInstanceOf[Expr[Int]] }
+            }.asTerm)
         }
       }),
-      '{ assert(${ Apply(Ref(sym4), List(Literal(Constant(4)))).seal.asInstanceOf[Expr[Int]] } == 0) }.unseal)
+      '{ assert(${ Apply(Ref(sym4), List(Literal(Constant(4)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }.asTerm)
 
     // test for nested functions (one symbol is the other's parent, and we use a Closure)
     val sym5 : Symbol = Symbol.newMethod(
@@ -108,14 +108,14 @@ object Macros {
                   DefDef(sym51, {
                     case List() => {
                       case List(List(xx)) =>
-                        Some('{ ${ x.seal.asInstanceOf[Expr[Int]] } - ${ xx.seal.asInstanceOf[Expr[Int]] } }.unseal)
+                        Some('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - ${ xx.asExpr.asInstanceOf[Expr[Int]] } }.asTerm)
                     }
                   })),
                 Closure(Ref(sym51), None))
             }
         }
       }),
-      '{ assert(${ Apply(Ref(sym5), List(Literal(Constant(5)))).seal.asInstanceOf[Expr[Int=>Int]] }(4) == 1) }.unseal)
+      '{ assert(${ Apply(Ref(sym5), List(Literal(Constant(5)))).asExpr.asInstanceOf[Expr[Int=>Int]] }(4) == 1) }.asTerm)
 
     // test mutually recursive definitions
     val sym6_1 : Symbol = Symbol.newMethod(
@@ -140,11 +140,11 @@ object Macros {
           case List(List(x)) =>
             Some {
               '{
-                println(s"sym6_1: ${ ${ x.seal.asInstanceOf[Expr[Int]] } }")
-                if ${ x.seal.asInstanceOf[Expr[Int]] } == 0
+                println(s"sym6_1: ${ ${ x.asExpr.asInstanceOf[Expr[Int]] } }")
+                if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
                 then 0
-                else ${ Apply(Ref(sym6_2), List('{ ${ x.seal.asInstanceOf[Expr[Int]] } - 1 }.unseal)).seal.asInstanceOf[Expr[Int]] }
-              }.unseal
+                else ${ Apply(Ref(sym6_2), List('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }.asTerm)).asExpr.asInstanceOf[Expr[Int]] }
+              }.asTerm
             }
         }
       }),
@@ -153,16 +153,16 @@ object Macros {
           case List(List(x)) =>
             Some {
               '{
-                println(s"sym6_2: ${ ${ x.seal.asInstanceOf[Expr[Int]] } }")
-                if ${ x.seal.asInstanceOf[Expr[Int]] } == 0
+                println(s"sym6_2: ${ ${ x.asExpr.asInstanceOf[Expr[Int]] } }")
+                if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
                 then 0
-                else ${ Apply(Ref(sym6_1), List('{ ${ x.seal.asInstanceOf[Expr[Int]] } - 1 }.unseal)).seal.asInstanceOf[Expr[Int]] }
-              }.unseal
+                else ${ Apply(Ref(sym6_1), List('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }.asTerm)).asExpr.asInstanceOf[Expr[Int]] }
+              }.asTerm
             }
         }
 
       }),
-      '{ assert(${ Apply(Ref(sym6_2), List(Literal(Constant(6)))).seal.asInstanceOf[Expr[Int]] } == 0) }.unseal)
+      '{ assert(${ Apply(Ref(sym6_2), List(Literal(Constant(6)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }.asTerm)
 
     // test polymorphic methods by synthesizing an identity method
     val sym7 : Symbol = Symbol.newMethod(
@@ -182,7 +182,7 @@ object Macros {
             Some(Typed(x, Inferred(t)))
         }
       }),
-      '{ assert(${ Apply(TypeApply(Ref(sym7), List(Inferred(typeOf[Int]))), List(Literal(Constant(7)))).seal.asInstanceOf[Expr[Int]] } == 7) }.unseal)
+      '{ assert(${ Apply(TypeApply(Ref(sym7), List(Inferred(typeOf[Int]))), List(Literal(Constant(7)))).asExpr.asInstanceOf[Expr[Int]] } == 7) }.asTerm)
 
     Block(
       sym1Statements ++
@@ -192,8 +192,8 @@ object Macros {
       sym5Statements ++
       sym6Statements ++
       sym7Statements ++
-      List('{ println("Ok") }.unseal),
-      Literal(Constant(()))).seal.asInstanceOf[Expr[Unit]]
+      List('{ println("Ok") }.asTerm),
+      Literal(Constant(()))).asExpr.asInstanceOf[Expr[Unit]]
   }
 }
 

--- a/tests/run-macros/tasty-custom-show/quoted_1.scala
+++ b/tests/run-macros/tasty-custom-show/quoted_1.scala
@@ -32,7 +32,7 @@ object Macros {
       }
     }
 
-    val tree = x.unseal
+    val tree = x.asTerm
     output.traverseTree(tree)
     '{print(${Expr(buff.result())})}
   }

--- a/tests/run-macros/tasty-dealias/quoted_1.scala
+++ b/tests/run-macros/tasty-dealias/quoted_1.scala
@@ -6,6 +6,6 @@ object Macros {
 
   def impl[T](x: quoted.Type[T])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
-    Expr(x.unseal.tpe.dealias.show)
+    Expr(x.asTypeTree.tpe.dealias.show)
   }
 }

--- a/tests/run-macros/tasty-eval/quoted_1.scala
+++ b/tests/run-macros/tasty-eval/quoted_1.scala
@@ -19,7 +19,7 @@ object Macros {
     override def value(e: Expr[Int])(using qctx: QuoteContext) : Option[Int] = {
       import qctx.tasty._
 
-      e.unseal.tpe match {
+      e.asTerm.tpe match {
         case pre: TermRef if pre.termSymbol.isValDef =>
           pre.termSymbol.tree match
             case t: ValDef =>

--- a/tests/run-macros/tasty-extractors-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-1/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    val tree = x.unseal
+    val tree = x.asTerm
     val treeStr = Expr(tree.showExtractors)
     val treeTpeStr = Expr(tree.tpe.showExtractors)
 

--- a/tests/run-macros/tasty-extractors-2/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-2/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    val tree = x.unseal
+    val tree = x.asTerm
 
     val treeStr = Expr(tree.showExtractors)
     val treeTpeStr = Expr(tree.tpe.showExtractors)

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -25,7 +25,7 @@ object Macros {
       }
     }
 
-    val tree = x.unseal
+    val tree = x.asTerm
     traverser.traverseTree(tree)
     '{print(${Expr(buff.result())})}
   }

--- a/tests/run-macros/tasty-extractors-types/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-types/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
   def impl[T](x: Type[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    val tree = x.unseal
+    val tree = x.asTypeTree
     '{
       println(${Expr(tree.showExtractors)})
       println(${Expr(tree.tpe.showExtractors)})

--- a/tests/run-macros/tasty-indexed-map/quoted_1.scala
+++ b/tests/run-macros/tasty-indexed-map/quoted_1.scala
@@ -36,8 +36,8 @@ object Index {
       case _ => Nil
     }
 
-    val key = name(k.unseal.tpe)
-    val keys = name(h.unseal.tpe) :: names(t.unseal.tpe)
+    val key = name(k.asTypeTree.tpe)
+    val keys = name(h.asTypeTree.tpe) :: names(t.asTypeTree.tpe)
 
     val index = keys.indexOf(key)
 

--- a/tests/run-macros/tasty-interpolation-1/Macro.scala
+++ b/tests/run-macros/tasty-interpolation-1/Macro.scala
@@ -56,23 +56,23 @@ abstract class MacroStringInterpolator[T] {
 
   protected def getStaticStringContext(strCtxExpr: Expr[StringContext])(using qctx: QuoteContext) : StringContext = {
     import qctx.tasty._
-    strCtxExpr.unseal.underlyingArgument match {
+    strCtxExpr.asTerm.underlyingArgument match {
       case Select(Typed(Apply(_, List(Apply(_, List(Typed(Repeated(strCtxArgTrees, _), Inferred()))))), _), _) =>
         val strCtxArgs = strCtxArgTrees.map {
           case Literal(Constant(str: String)) => str
-          case tree => throw new NotStaticlyKnownError("Expected statically known StringContext", tree.seal)
+          case tree => throw new NotStaticlyKnownError("Expected statically known StringContext", tree.asExpr)
         }
         StringContext(strCtxArgs: _*)
       case tree =>
-        throw new NotStaticlyKnownError("Expected statically known StringContext", tree.seal)
+        throw new NotStaticlyKnownError("Expected statically known StringContext", tree.asExpr)
     }
   }
 
   protected def getArgsList(argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : List[Expr[Any]] = {
     import qctx.tasty._
-    argsExpr.unseal.underlyingArgument match {
-      case Typed(Repeated(args, _), _) => args.map(_.seal)
-      case tree => throw new NotStaticlyKnownError("Expected statically known argument list", tree.seal)
+    argsExpr.asTerm.underlyingArgument match {
+      case Typed(Repeated(args, _), _) => args.map(_.asExpr)
+      case tree => throw new NotStaticlyKnownError("Expected statically known argument list", tree.asExpr)
     }
   }
 

--- a/tests/run-macros/tasty-macro-assert/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-assert/quoted_1.scala
@@ -15,7 +15,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    val tree = cond.unseal
+    val tree = cond.asTerm
 
     def isOps(tpe: TypeOrBounds): Boolean = tpe match {
       case tpe: TermRef => tpe.termSymbol.isDefDef && tpe.name == "Ops"// TODO check that the parent is Asserts
@@ -33,8 +33,8 @@ object Asserts {
     tree match {
       case Inlined(_, Nil, Apply(Select(OpsTree(left), op), right :: Nil)) =>
         op match {
-          case "===" => '{assertEquals(${left.seal}, ${right.seal})}
-          case "!==" => '{assertNotEquals(${left.seal}, ${right.seal})}
+          case "===" => '{assertEquals(${left.asExpr}, ${right.asExpr})}
+          case "!==" => '{assertNotEquals(${left.asExpr}, ${right.asExpr})}
         }
       case _ =>
         '{assertTrue($cond)}

--- a/tests/run-macros/tasty-macro-const/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-const/quoted_1.scala
@@ -6,14 +6,14 @@ object Macros {
 
   def natConstImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[Int] = {
     import qctx.tasty._
-    val xTree: Term = x.unseal
+    val xTree: Term = x.asTerm
     xTree match {
       case Inlined(_, _, Literal(Constant(n: Int))) =>
         if (n <= 0) {
           report.error("Parameter must be natural number")
           '{0}
         } else {
-          xTree.seal.cast[Int]
+          xTree.asExprOf[Int]
         }
       case _ =>
         report.error("Parameter must be a known constant")

--- a/tests/run-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-positions/quoted_1.scala
@@ -20,8 +20,8 @@ object Macros {
 
   def impl2[T](x: quoted.Type[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
-    val pos = x.unseal.pos
-    val code = x.unseal.show
+    val pos = x.asTypeTree.pos
+    val code = x.asTypeTree.show
     '{
       println(${posStr(qctx)(pos)})
       println(${Expr(code)})

--- a/tests/run-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-positions/quoted_1.scala
@@ -10,8 +10,8 @@ object Macros {
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
-    val pos = x.unseal.underlyingArgument.pos
-    val code = x.unseal.underlyingArgument.show
+    val pos = x.asTerm.underlyingArgument.pos
+    val code = x.asTerm.underlyingArgument.show
     '{
       println(${posStr(qctx)(pos)})
       println(${Expr(code)})

--- a/tests/run-macros/tasty-original-source/Macros_1.scala
+++ b/tests/run-macros/tasty-original-source/Macros_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   private def impl(arg: Expr[Any])(using qctx: QuoteContext) : Expr[(String, Any)] = {
     import qctx.tasty._
-    val source = Expr(arg.unseal.underlyingArgument.pos.sourceCode.toString)
+    val source = Expr(arg.asTerm.underlyingArgument.pos.sourceCode.toString)
     '{Tuple2($source, $arg)}
   }
 

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -9,15 +9,15 @@ object Asserts {
   def zeroLastArgsImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[Int] = {
     import qctx.tasty._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
-    x.unseal.underlyingArgument match {
+    x.asTerm.underlyingArgument match {
       case Apply(fn, args) =>
         fn.tpe.widen match {
           case _: MethodType =>
             args.size match {
-              case 0 => Expr.betaReduce('{ ${fn.etaExpand.seal.cast[() => Int]}() })
-              case 1 => Expr.betaReduce('{ ${fn.etaExpand.seal.cast[Int => Int]}(0) })
-              case 2 => Expr.betaReduce('{ ${fn.etaExpand.seal.cast[(Int, Int) => Int]}(0, 0) })
-              case 3 => Expr.betaReduce('{ ${fn.etaExpand.seal.cast[(Int, Int, Int) => Int]}(0, 0, 0) })
+              case 0 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[() => Int]}() })
+              case 1 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[Int => Int]}(0) })
+              case 2 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[(Int, Int) => Int]}(0, 0) })
+              case 3 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[(Int, Int, Int) => Int]}(0, 0, 0) })
             }
         }
       case _ => x
@@ -35,15 +35,15 @@ object Asserts {
       case Apply(fn, args) =>
         val pre = rec(fn)
         args.size match {
-          case 0 => Expr.betaReduce('{ ${pre.etaExpand.seal.cast[() => Any]}() }).unseal
-          case 1 => Expr.betaReduce('{ ${pre.etaExpand.seal.cast[Int => Any]}(0) }).unseal
-          case 2 => Expr.betaReduce('{ ${pre.etaExpand.seal.cast[(Int, Int) => Any]}(0, 0) }).unseal
-          case 3 => Expr.betaReduce('{ ${pre.etaExpand.seal.cast[(Int, Int, Int) => Any]}(0, 0, 0) }).unseal
+          case 0 => Expr.betaReduce('{ ${pre.etaExpand.asExprOf[() => Any]}() }).asTerm
+          case 1 => Expr.betaReduce('{ ${pre.etaExpand.asExprOf[Int => Any]}(0) }).asTerm
+          case 2 => Expr.betaReduce('{ ${pre.etaExpand.asExprOf[(Int, Int) => Any]}(0, 0) }).asTerm
+          case 3 => Expr.betaReduce('{ ${pre.etaExpand.asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }).asTerm
         }
       case _ => term
     }
 
-    rec(x.unseal.underlyingArgument).seal.cast[Int]
+    rec(x.asTerm.underlyingArgument).asExprOf[Int]
   }
 
 }

--- a/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
+++ b/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
@@ -24,7 +24,7 @@ object Macro {
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
             import qctx.tasty._
-            error(msg, parts(partIdx).unseal.pos)
+            error(msg, parts(partIdx).asTerm.pos)
           }
         }
         fooCore(parts, args, reporter)
@@ -38,7 +38,7 @@ object Macro {
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
             import qctx.tasty._
-            val pos = parts(partIdx).unseal.pos
+            val pos = parts(partIdx).asTerm.pos
             errors += '{ Tuple4(${Expr(partIdx)}, ${Expr(pos.start)}, ${Expr(pos.end)}, ${Expr(msg)}) }
           }
         }

--- a/tests/run-macros/tasty-subtyping/quoted_1.scala
+++ b/tests/run-macros/tasty-subtyping/quoted_1.scala
@@ -10,13 +10,13 @@ object Macros {
 
   def isTypeEqualImpl[T, U](t: Type[T], u: Type[U])(using QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
-    val isTypeEqual = t.unseal.tpe =:= u.unseal.tpe
+    val isTypeEqual = t.asTypeTree.tpe =:= u.asTypeTree.tpe
     Expr(isTypeEqual)
   }
 
   def isSubTypeOfImpl[T, U](t: Type[T], u: Type[U])(using QuoteContext) : Expr[Boolean] = {
     import qctx.tasty._
-    val isTypeEqual = t.unseal.tpe <:< u.unseal.tpe
+    val isTypeEqual = t.asTypeTree.tpe <:< u.asTypeTree.tpe
     Expr(isTypeEqual)
   }
 }

--- a/tests/run-macros/tasty-tree-map/quoted_1.scala
+++ b/tests/run-macros/tasty-tree-map/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
   def impl[T: Type](x: Expr[T])(using qctx: QuoteContext) : Expr[T] = {
     import qctx.tasty.{_, given _} // FIXME: #8919
     val identityMap = new TreeMap { }
-    val transformed = identityMap.transformTerm(x.unseal).seal.cast[T]
+    val transformed = identityMap.transformTerm(x.asTerm).asExprOf[T]
     transformed
   }
 

--- a/tests/run-macros/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-macros/tasty-unsafe-let/quoted_1.scala
@@ -8,12 +8,12 @@ object Macros {
   private def impl[T: Type](rhs: Expr[T], body: Expr[T => Unit])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.tasty._
 
-    val rhsTerm = rhs.unseal
+    val rhsTerm = rhs.asTerm
 
     import qctx.tasty.{let => letTerm}
     letTerm(rhsTerm) { rhsId =>
-      Expr.betaReduce('{$body(${rhsId.seal.asInstanceOf[Expr[T]]})}).unseal // Dangerous uncheked cast!
-    }.seal.cast[Unit]
+      Expr.betaReduce('{$body(${rhsId.asExpr.asInstanceOf[Expr[T]]})}).asTerm // Dangerous uncheked cast!
+    }.asExprOf[Unit]
   }
 
 

--- a/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
@@ -23,7 +23,7 @@ object XmlQuote {
 
     def liftListOfAny(lst: List[Term]): Expr[List[Any]] = lst match {
       case x :: xs  =>
-        val head = x.seal
+        val head = x.asExpr
         val tail = liftListOfAny(xs)
         '{ $head :: $tail }
       case Nil => '{Nil}
@@ -41,7 +41,7 @@ object XmlQuote {
       tree.symbol.fullName == "scala.StringContext$.apply"
 
     // XmlQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts = receiver.unseal.underlyingArgument match {
+    val parts = receiver.asTerm.underlyingArgument match {
       case Apply(conv, List(Apply(fun, List(Typed(Repeated(values, _), _)))))
           if isSCOpsConversion(conv) &&
              isStringContextApply(fun) &&
@@ -53,7 +53,7 @@ object XmlQuote {
     }
 
     // [a0, ...]: Any*
-    val Typed(Repeated(args0, _), _) = args.unseal.underlyingArgument
+    val Typed(Repeated(args0, _), _) = args.asTerm.underlyingArgument
 
     val string = parts.mkString("??")
     '{new Xml(${Expr(string)}, ${liftListOfAny(args0)})}

--- a/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
@@ -36,7 +36,7 @@ object XmlQuote {
     }
 
     // XmlQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts: List[String] = stripTyped(receiver.unseal.underlying) match {
+    val parts: List[String] = stripTyped(receiver.asTerm.underlying) match {
       case Apply(conv, List(ctx1)) if isSCOpsConversion(conv) =>
         ctx1 match {
           case Apply(fun, List(Typed(Repeated(values, _), _))) if isStringContextApply(fun) =>
@@ -56,9 +56,9 @@ object XmlQuote {
     }
 
     // [a0, ...]: Any*
-    val args2: Expr[List[Any]] = args.unseal.underlyingArgument match {
+    val args2: Expr[List[Any]] = args.asTerm.underlyingArgument match {
       case Typed(Repeated(args0, _), _) => // statically known args, make list directly
-        Expr.ofList(args0.map(_.seal))
+        Expr.ofList(args0.map(_.asExpr))
       case _ =>
         '{$args.toList}
 


### PR DESCRIPTION
These replace the `Expr` methods `seal`, `sealOpt` and `unseal` with equivalent methods with more intuitive names.
Instead of `sealOpt` we provide a more flexible `isExpr`. All these methods are defined directly on `Tree`
instead of `Term` to avoid the need to perform type test to a `Term` first.

We similarly replace `quoted.Type.seal` with `asTypeTree` and `reflect.Type.seal` with `asQuotedType`.

Note: #8940 would remove the `asTerm` and `asTypeTree` as there we have `Expr[T] <:< Term` and something similar for `Type`, but the others would still be relevant.