### PR TITLE
Fix #9489: skip redundancy check for Type[T]

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -839,12 +839,14 @@ class SpaceEngine(using Context) extends SpaceLogic {
   }
 
   private def redundancyCheckable(sel: Tree): Boolean =
-    // Ignore Expr for unreachability as a special case.
+    // Ignore Expr[T] and Type[T] for unreachability as a special case.
     // Quote patterns produce repeated calls to the same unapply method, but with different implicit parameters.
     // Since we assume that repeated calls to the same unapply method overlap
     // and implicit parameters cannot normally differ between two patterns in one `match`,
-    // the easiest solution is just to ignore Expr.
-    !sel.tpe.hasAnnotation(defn.UncheckedAnnot) && !sel.tpe.widen.isRef(defn.QuotedExprClass)
+    // the easiest solution is just to ignore Expr[T] and Type[T].
+    !sel.tpe.hasAnnotation(defn.UncheckedAnnot)
+    && !sel.tpe.widen.isRef(defn.QuotedExprClass)
+    && !sel.tpe.widen.isRef(defn.QuotedTypeClass)
 
   def checkRedundancy(_match: Match): Unit = {
     val Match(sel, cases) = _match

--- a/tests/patmat/i9489.scala
+++ b/tests/patmat/i9489.scala
@@ -1,0 +1,7 @@
+import scala.quoted._
+
+def summonTypedType[T : Type](using QuoteContext): String = '[T] match {
+  case '[Boolean] => "Boolean"
+  case '[Byte] => "Byte"
+  case _ => "Other"
+}


### PR DESCRIPTION
Fix #9489: skip redundancy check for Type[T]