### PR TITLE
Add quoted.Expr.asExprOf and Reflection.Tree.{asExprOf, isExpr}

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -272,8 +272,10 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
     override def unapply(x: Any): Option[Term] = x match
       case _ if Unapply_TypeTest.unapply(x).isDefined => None
       case _: tpd.PatternTree @unchecked => None
-      case x: tpd.SeqLiteral @unchecked => Some(x)
       case x: tpd.Tree @unchecked if x.isTerm => Some(x)
+      case x: tpd.SeqLiteral @unchecked => Some(x)
+      case x: tpd.Inlined @unchecked => Some(x)
+      case x: tpd.NamedArg @unchecked => Some(x)
       case _ => None
   }
 

--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -48,7 +48,6 @@ abstract class Expr[+T] private[scala] {
     val tree = this.unseal
     val expectedType = tp.unseal.tpe
     if (tree.tpe <:< expectedType)
-      this.asInstanceOf[scala.quoted.Expr[T]]
       this.asInstanceOf[scala.quoted.Expr[X]]
     else
       throw new scala.tasty.reflect.ExprCastError(

--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -41,11 +41,15 @@ abstract class Expr[+T] private[scala] {
     !scala.internal.quoted.Expr.unapply[EmptyTuple, EmptyTuple](this)(using that, false, qctx).isEmpty
 
   /** Checked cast to a `quoted.Expr[U]` */
-  def cast[U](using tp: scala.quoted.Type[U])(using qctx: QuoteContext): scala.quoted.Expr[U] = {
+  def cast[U](using tp: scala.quoted.Type[U])(using qctx: QuoteContext): scala.quoted.Expr[U] = asExprOf[U]
+
+  /** Convert this to an `quoted.Expr[X]` if this expression is a valid expression of type `X` or throws */
+  def asExprOf[X](using tp: scala.quoted.Type[X])(using qctx: QuoteContext): scala.quoted.Expr[X] = {
     val tree = this.unseal
     val expectedType = tp.unseal.tpe
     if (tree.tpe <:< expectedType)
-      this.asInstanceOf[scala.quoted.Expr[U]]
+      this.asInstanceOf[scala.quoted.Expr[T]]
+      this.asInstanceOf[scala.quoted.Expr[X]]
     else
       throw new scala.tasty.reflect.ExprCastError(
         s"""Expr: ${tree.show}
@@ -178,7 +182,7 @@ object Expr {
   /** Given a tuple of the form `(Expr[A1], ..., Expr[An])`, outputs a tuple `Expr[(A1, ..., An)]`. */
   def ofTuple[T <: Tuple: Tuple.IsMappedBy[Expr]: Type](tup: T)(using qctx: QuoteContext): Expr[Tuple.InverseMap[T, Expr]] = {
     val elems: Seq[Expr[Any]] = tup.asInstanceOf[Product].productIterator.toSeq.asInstanceOf[Seq[Expr[Any]]]
-    ofTupleFromSeq(elems).cast[Tuple.InverseMap[T, Expr]]
+    ofTupleFromSeq(elems).asExprOf[Tuple.InverseMap[T, Expr]]
   }
 
   /** Find an implicit of type `T` in the current scope given by `qctx`.

--- a/library/src-non-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-non-bootstrapped/scala/quoted/Expr.scala
@@ -2,3 +2,4 @@ package scala.quoted
 
 abstract class Expr[+T] private[scala]:
   def unseal(using qctx: QuoteContext): qctx.tasty.Term
+  def asExprOf[X](using tp: scala.quoted.Type[X])(using qctx: QuoteContext): scala.quoted.Expr[X] = ???


### PR DESCRIPTION
These methods allow checked casts from `Expr` or a `Tree`.
`Tree.asExprOf` is similar to `Trem.seal` with the difference that it also checks if the tree is a valid term.

Add `isExpr` and improve implemetation of `seal`, `sealOpt` and `ExprMap`.