### PR TITLE
Provide a context ClassLoader to macros

### DIFF
--- a/tests/pos-macros/macro-classloaders/Caller.scala
+++ b/tests/pos-macros/macro-classloaders/Caller.scala
@@ -1,0 +1,3 @@
+object Caller {
+  Macro.f
+}

--- a/tests/pos-macros/macro-classloaders/Macro.scala
+++ b/tests/pos-macros/macro-classloaders/Macro.scala
@@ -1,0 +1,15 @@
+import java.net.URLClassLoader
+
+import scala.quoted._
+
+object Macro { self =>
+  inline def f: Any = ${ impl }
+
+  def impl(using QuoteContext): Expr[Any] = {
+    //println("======== "+self.getClass.getClassLoader.asInstanceOf[URLClassLoader].getURLs.mkString("; "))
+    //println("  ====== "+Thread.currentThread().getContextClassLoader.asInstanceOf[URLClassLoader].getURLs.mkString("; "))
+    assert(getClass.getClassLoader eq Thread.currentThread().getContextClassLoader,
+      "Macro ClassLoader should be available as context ClassLoader")
+    '{""}
+  }
+}


### PR DESCRIPTION
Install the macro ClassLoader as the context ClassLoader during macro
interpretation. This ClassLoader is used, for example, by Typesafe
Config for loading application.conf.

Currently macros see the default context ClassLoader which contains the
compiler's class path, not the compilation class path.