### PR TITLE
Remove unnecessary evals, escape extra params

### DIFF
--- a/bin/common
+++ b/bin/common
@@ -20,4 +20,4 @@ if [ ! -f "$version" ] || [ ! -z "$new_files" ]; then
   (cd $ROOT && sbt "dist/pack")
 fi
 
-eval "$target" "$@"
+"$target" "$@"

--- a/bin/dotc
+++ b/bin/dotc
@@ -2,4 +2,4 @@
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/.."
 
-eval "$ROOT/bin/common" "$ROOT/dist/target/pack/bin/dotc" "$@"
+"$ROOT/bin/common" "$ROOT/dist/target/pack/bin/dotc" "$@"

--- a/bin/dotd
+++ b/bin/dotd
@@ -2,4 +2,4 @@
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/.."
 
-eval "$ROOT/bin/common" "$ROOT/dist/target/pack/bin/dotd" "$@"
+"$ROOT/bin/common" "$ROOT/dist/target/pack/bin/dotd" "$@"

--- a/bin/dotr
+++ b/bin/dotr
@@ -2,4 +2,4 @@
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/.."
 
-eval "$ROOT/bin/common" "$ROOT/dist/target/pack/bin/dotr" "$@"
+"$ROOT/bin/common" "$ROOT/dist/target/pack/bin/dotr" "$@"

--- a/dist/bin/dotc
+++ b/dist/bin/dotc
@@ -37,13 +37,13 @@ ReplMain=dotty.tools.repl.Main
 PROG_NAME=$CompilerMain
 
 addJava () {
-  java_args+=("$1")
+  java_args+=("'$1'")
 }
 addScala () {
-  scala_args+=("$1")
+  scala_args+=("'$1'")
 }
 addResidual () {
-  residual_args+=("$1")
+  residual_args+=("'$1'")
 }
 
 classpathArgs () {

--- a/dist/bin/dotr
+++ b/dist/bin/dotr
@@ -28,11 +28,11 @@ if [ -z "$PROG_HOME" ] ; then
 fi
 
 addJvmOptions () {
-  jvm_options+=("$1")
+  jvm_options+=("'$1'")
 }
 
 addDotcOptions () {
-  java_options+=("$1")
+  java_options+=("'$1'")
 }
 
 source "$PROG_HOME/bin/common"


### PR DESCRIPTION
I think I found the source(s) of the escaping problems.

I think I also found out why the `eval exec` is needed: to split JAVA_OPTS into separate arguments.