### PR TITLE
Fix #9492: Avoid forcing nested annotation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -163,12 +163,6 @@ object Annotations {
         protected var myTree: Tree | (Context ?=> Tree) = (using ctx) => treeFn(using ctx)
       }
 
-    def deferred(atp: Type, args: List[Tree])(using Context): Annotation =
-      deferred(atp.classSymbol)(New(atp, args))
-
-    def deferredResolve(atp: Type, args: List[ast.untpd.Tree])(using Context): Annotation =
-      deferred(atp.classSymbol)(ast.untpd.resolveConstructor(atp, args))
-
     /** Extractor for child annotations */
     object Child {
 

--- a/tests/pos-java-interop-separate/i9492/A_1.java
+++ b/tests/pos-java-interop-separate/i9492/A_1.java
@@ -1,0 +1,15 @@
+import java.lang.annotation.*;
+
+@interface BaseClassAnn {
+    Type[] value();
+    @interface Type {
+        Class<?> value();
+    }
+}
+
+@BaseClassAnn({
+    @BaseClassAnn.Type(value=A_1.class)
+})
+abstract class BaseClass {}
+
+public class A_1 extends BaseClass {}

--- a/tests/pos-java-interop-separate/i9492/B_2.scala
+++ b/tests/pos-java-interop-separate/i9492/B_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  def oops: A_1 = ???
+}


### PR DESCRIPTION
Java allows annotations inside arrays inside annotations, when parsing
the outer annotation, we need to produce an untyped tree for the array
and therefore the nested annotations. Previously this was done using
`Annotation#tree` which actually produces a typed tree, this works since
typed trees can be used as untyped tree but it requires forcing the
content of the nested annotation which can lead to cycles.

Instead, we now use a dedicated subclass of Annotation with an extra
`untpdTree` method we use for the purpose of generating a tree for the
nested annotation without forcing anything.