### PR TITLE
Fix #9464: Fix computation of expected type in a return

### DIFF
--- a/tests/pos/i9464.scala
+++ b/tests/pos/i9464.scala
@@ -1,0 +1,6 @@
+trait T:
+  type X
+  def x: X
+
+def test1(t: T): t.X = t.x
+def test2(t: T): t.X = return t.x


### PR DESCRIPTION
We need to substitute type as well as term parameters in the expected
type of a return to handle dependent methods correctly.