### PR TITLE
Prevent traits from extending java.lang.Enum

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1492,7 +1492,11 @@ import ast.tpd
 
   class CannotExtendJavaEnum(sym: Symbol)(using Context)
     extends SyntaxMsg(CannotExtendJavaEnumID) {
-      def msg = em"""$sym cannot extend ${hl("java.lang.Enum")}: only enums defined with the ${hl("enum")} syntax can"""
+      def msg =
+        val reason =
+          if Feature.migrateTo3 then i"only classes can (no ${hl("enum")} syntax in migration mode)"
+          else i"only enums defined with the ${hl("enum")} syntax can"
+        em"""$sym cannot extend ${hl("java.lang.Enum")}: $reason"""
       def explain = ""
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -109,10 +109,8 @@ object RefChecks {
         checkSelfConforms(reqd, "missing requirement", "required")
 
       // Prevent wrong `extends` of java.lang.Enum
-      if !migrateTo3 &&
-         !cls.isOneOf(Enum | Trait) &&
-         parents.exists(_.classSymbol == defn.JavaEnumClass)
-      then
+      val wrongJavaEnum = if migrateTo3 then cls.is(Trait) else !cls.is(Enum)
+      if wrongJavaEnum && parents.exists(_.classSymbol == defn.JavaEnumClass) then
         report.error(CannotExtendJavaEnum(cls), cls.sourcePos)
 
     case _ =>

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -171,6 +171,7 @@ class CompilationTests extends ParallelTesting {
       compileFile("tests/neg-custom-args/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
       compileFile("tests/neg-custom-args/typeclass-derivation2.scala", defaultOptions.and("-Yerased-terms")),
       compileFile("tests/neg-custom-args/i5498-postfixOps.scala", defaultOptions withoutLanguageFeature "postfixOps"),
+      compileFile("tests/neg-custom-args/trait-extend-java-enum.scala", defaultOptions.and("-source", "3.0-migration"))
     ).checkExpectedErrors()
   }
 

--- a/tests/neg-custom-args/trait-extend-java-enum.scala
+++ b/tests/neg-custom-args/trait-extend-java-enum.scala
@@ -1,0 +1,3 @@
+trait T extends java.lang.Enum[T] // error
+
+class E extends T

--- a/tests/neg/extend-java-enum.scala
+++ b/tests/neg/extend-java-enum.scala
@@ -4,6 +4,6 @@ class C1 extends jl.Enum[C1] // error: class C1 cannot extend java.lang.Enum
 
 class C2(name: String, ordinal: Int) extends jl.Enum[C2](name, ordinal) // error: class C2 cannot extend java.lang.Enum
 
-trait T extends jl.Enum[T] // ok
+trait T extends jl.Enum[T] // error: trait T cannot extend java.lang.Enum
 
 class C3 extends T // error: class C3 cannot extend java.lang.Enum

--- a/tests/pos/trait-java-enum.scala
+++ b/tests/pos/trait-java-enum.scala
@@ -1,5 +1,0 @@
-trait T extends java.lang.Enum[T]
-
-enum MyEnum extends T {
-  case A, B
-}


### PR DESCRIPTION
See https://github.com/lampepfl/dotty/pull/9487#issuecomment-673012353

This is also disallowed with `-source:3.0-migration` (but still allowed for classes in that mode).