### PR TITLE
Fix #9509: Reveal further arguments in extension method applications

### DIFF
--- a/tests/pos/i9509.scala
+++ b/tests/pos/i9509.scala
@@ -1,0 +1,11 @@
+enum AList[+A] {
+  case Cons(head: A, tail: AList[A])
+  case Nil
+}
+
+object AList {
+  extension [A](l: AList[A]) def sum(using numeric: Numeric[A]): A = l match {
+    case Cons(x, xs) => numeric.plus(x, xs.sum(using numeric))
+    case Nil         => numeric.zero
+  }
+}

--- a/tests/pos/i9509.scala
+++ b/tests/pos/i9509.scala
@@ -1,5 +1,5 @@
 enum AList[+A] {
-  case Cons(head: A, tail: AList[A])
+  case Cons[X](head: X, tail: AList[X]) extends AList[X]
   case Nil
 }
 


### PR DESCRIPTION
They were hidden in an IgnroedProto before for fear that we might need an implicit
conversion. But none is possible at this point.