### PR TITLE
Move tasty.CompilerInterface to scala.internal

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -17,7 +17,7 @@ import dotty.tools.dotc.typer.Implicits.{AmbiguousImplicits, DivergingImplicit, 
 import dotty.tools.dotc.util.{SourceFile, SourcePosition, Spans}
 
 import scala.internal.quoted.Unpickler
-import scala.tasty.reflect.CompilerInterface
+import scala.internal.tasty.CompilerInterface
 
 import scala.tasty.reflect.TypeTest
 

--- a/library/src/scala/internal/tasty/CompilerInterface.scala
+++ b/library/src/scala/internal/tasty/CompilerInterface.scala
@@ -1,7 +1,7 @@
-package scala.tasty.reflect // TODO move to scala.internal.tasty.reflect
+package scala.internal.tasty
 
 import scala.quoted.QuoteContext
-import scala.tasty.Reflection
+import scala.tasty.reflect._
 import scala.internal.quoted.Unpickler
 
 /** Tasty reflect abstract types
@@ -57,7 +57,7 @@ import scala.internal.quoted.Unpickler
  *           |
  *           +- TypeBoundsTree
  *           +- WildcardTypeTree
-*            |
+ *           |
  *           +- CaseDef
  *           +- TypeCaseDef
  *           |

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -1,5 +1,7 @@
 package scala.tasty
 
+import scala.internal.tasty.CompilerInterface
+
 import scala.quoted.QuoteContext
 import scala.quoted.show.SyntaxHighlight
 import scala.tasty.reflect._


### PR DESCRIPTION
This class is not part of the user interface.