### PR TITLE
Move out methods form reflect context

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -52,13 +52,17 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   def Context_owner(self: Context): Symbol = self.owner
 
 
-  def Context_GADT_setFreshGADTBounds(self: Context): Context =
+  /////////////////
+  // Constraints //
+  /////////////////
+
+  def Constraints_init(self: Context): Context =
     self.fresh.setFreshGADTBounds.addMode(Mode.GadtConstraintInference)
 
-  def Context_GADT_addToConstraint(self: Context)(syms: List[Symbol]): Boolean =
+  def Constraints_add(self: Context)(syms: List[Symbol]): Boolean =
     self.gadt.addToConstraint(syms)
 
-  def Context_GADT_approximation(self: Context)(sym: Symbol, fromBelow: Boolean): Type =
+  def Constraints_approximation(self: Context)(sym: Symbol, fromBelow: Boolean): Type =
     self.gadt.approximation(sym, fromBelow)
 
   ////////////

--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -62,10 +62,6 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   def Context_GADT_approximation(self: Context)(sym: Symbol, fromBelow: Boolean): Type =
     self.gadt.approximation(sym, fromBelow)
 
-  def Context_requiredPackage(self: Context)(path: String): Symbol = requiredPackage(path)(using self)
-  def Context_requiredClass(self: Context)(path: String): Symbol = requiredClass(path)(using self)
-  def Context_requiredModule(self: Context)(path: String): Symbol = requiredModule(path)(using self)
-  def Context_requiredMethod(self: Context)(path: String): Symbol = requiredMethod(path)(using self)
   def Context_isJavaCompilationUnit(self: Context): Boolean = self.compilationUnit.isInstanceOf[fromtasty.JavaCompilationUnit]
   def Context_isScala2CompilationUnit(self: Context): Boolean = self.compilationUnit.isInstanceOf[fromtasty.Scala2CompilationUnit]
   def Context_isAlreadyLoadedCompilationUnit(self: Context): Boolean = self.compilationUnit.isInstanceOf[fromtasty.AlreadyLoadedCompilationUnit]
@@ -1789,6 +1785,11 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
     self.children
 
   private def isField(sym: Symbol)(using Context): Boolean = sym.isTerm && !sym.is(Flags.Method)
+
+  def Symbol_requiredPackage(path: String)(using Context): Symbol = requiredPackage(path)
+  def Symbol_requiredClass(path: String)(using Context): Symbol = requiredClass(path)
+  def Symbol_requiredModule(path: String)(using Context): Symbol = requiredModule(path)
+  def Symbol_requiredMethod(path: String)(using Context): Symbol = requiredMethod(path)
 
   def Symbol_of(fullName: String)(using Context): Symbol =
     requiredClass(fullName)

--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -51,7 +51,6 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
 
   def Context_owner(self: Context): Symbol = self.owner
 
-  def Context_source(self: Context): java.nio.file.Path = self.compilationUnit.source.file.jpath
 
   def Context_GADT_setFreshGADTBounds(self: Context): Context =
     self.fresh.setFreshGADTBounds.addMode(Mode.GadtConstraintInference)
@@ -62,11 +61,16 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
   def Context_GADT_approximation(self: Context)(sym: Symbol, fromBelow: Boolean): Type =
     self.gadt.approximation(sym, fromBelow)
 
-  def Context_isJavaCompilationUnit(self: Context): Boolean = self.compilationUnit.isInstanceOf[fromtasty.JavaCompilationUnit]
-  def Context_isScala2CompilationUnit(self: Context): Boolean = self.compilationUnit.isInstanceOf[fromtasty.Scala2CompilationUnit]
-  def Context_isAlreadyLoadedCompilationUnit(self: Context): Boolean = self.compilationUnit.isInstanceOf[fromtasty.AlreadyLoadedCompilationUnit]
-  def Context_compilationUnitClassname(self: Context): String =
-    self.compilationUnit match {
+  ////////////
+  // Source //
+  ////////////
+
+  def Source_path(using Context): java.nio.file.Path = ctx.compilationUnit.source.file.jpath
+  def Source_isJavaCompilationUnit(using Context): Boolean = ctx.compilationUnit.isInstanceOf[fromtasty.JavaCompilationUnit]
+  def Source_isScala2CompilationUnit(using Context): Boolean = ctx.compilationUnit.isInstanceOf[fromtasty.Scala2CompilationUnit]
+  def Source_isAlreadyLoadedCompilationUnit(using Context): Boolean = ctx.compilationUnit.isInstanceOf[fromtasty.AlreadyLoadedCompilationUnit]
+  def Source_compilationUnitClassname(using Context): String =
+    ctx.compilationUnit match {
       case cu: fromtasty.JavaCompilationUnit => cu.className
       case cu: fromtasty.Scala2CompilationUnit => cu.className
       case cu: fromtasty.AlreadyLoadedCompilationUnit => cu.className

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -429,23 +429,32 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
     extension (self: Context):
       /** Returns the owner of the context */
       def owner: Symbol = internal.Context_owner(self)
-
-      /** Returns the source file being compiled. The path is relative to the current working directory. */
-      def source: java.nio.file.Path = internal.Context_source(self)
-
-      /** Returns true if we've tried to reflect on a Java class. */
-      def isJavaCompilationUnit(): Boolean = internal Context_isJavaCompilationUnit(self)
-
-      /** Returns true if we've tried to reflect on a Scala2 (non-Tasty) class. */
-      def isScala2CompilationUnit(): Boolean = internal Context_isScala2CompilationUnit(self)
-
-      /** Returns true if we've tried to reflect on a class that's already loaded (e.g. Option). */
-      def isAlreadyLoadedCompilationUnit(): Boolean = internal.Context_isAlreadyLoadedCompilationUnit(self)
-
-      /** Class name of the current CompilationUnit */
-      def compilationUnitClassname(): String = internal.Context_compilationUnitClassname(self)
     end extension
   end Context
+
+
+  ///////////////
+  //   Source  //
+  ///////////////
+
+  object Source:
+
+    /** Returns the source file being compiled. The path is relative to the current working directory. */
+    def path(using ctx: Context): java.nio.file.Path = internal.Source_path
+
+    /** Returns true if we've tried to reflect on a Java class. */
+    def isJavaCompilationUnit(using ctx: Context): Boolean = internal.Source_isJavaCompilationUnit
+
+    /** Returns true if we've tried to reflect on a Scala2 (non-Tasty) class. */
+    def isScala2CompilationUnit(using ctx: Context): Boolean = internal.Source_isScala2CompilationUnit
+
+    /** Returns true if we've tried to reflect on a class that's already loaded (e.g. Option). */
+    def isAlreadyLoadedCompilationUnit(using ctx: Context): Boolean = internal.Source_isAlreadyLoadedCompilationUnit
+
+    /** Class name of the current CompilationUnit */
+    def compilationUnitClassname(using ctx: Context): String = internal.Source_compilationUnitClassname
+
+  end Source
 
 
   ///////////////

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -433,18 +433,6 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
       /** Returns the source file being compiled. The path is relative to the current working directory. */
       def source: java.nio.file.Path = internal.Context_source(self)
 
-      /** Get package symbol if package is either defined in current compilation run or present on classpath. */
-      def requiredPackage(path: String): Symbol = internal.Context_requiredPackage(self)(path)
-
-      /** Get class symbol if class is either defined in current compilation run or present on classpath. */
-      def requiredClass(path: String): Symbol = internal.Context_requiredClass(self)(path)
-
-      /** Get module symbol if module is either defined in current compilation run or present on classpath. */
-      def requiredModule(path: String): Symbol = internal.Context_requiredModule(self)(path)
-
-      /** Get method symbol if method is either defined in current compilation run or present on classpath. Throws if the method has an overload. */
-      def requiredMethod(path: String): Symbol = internal.Context_requiredMethod(self)(path)
-
       /** Returns true if we've tried to reflect on a Java class. */
       def isJavaCompilationUnit(): Boolean = internal Context_isJavaCompilationUnit(self)
 
@@ -2309,6 +2297,19 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
   given SymbolOps as Symbol.type = Symbol
 
   object Symbol:
+
+    /** Get package symbol if package is either defined in current compilation run or present on classpath. */
+    def requiredPackage(path: String)(using ctx: Context): Symbol = internal.Symbol_requiredPackage(path)
+
+    /** Get class symbol if class is either defined in current compilation run or present on classpath. */
+    def requiredClass(path: String)(using ctx: Context): Symbol = internal.Symbol_requiredClass(path)
+
+    /** Get module symbol if module is either defined in current compilation run or present on classpath. */
+    def requiredModule(path: String)(using ctx: Context): Symbol = internal.Symbol_requiredModule(path)
+
+    /** Get method symbol if method is either defined in current compilation run or present on classpath. Throws if the method has an overload. */
+    def requiredMethod(path: String)(using ctx: Context): Symbol = internal.Symbol_requiredMethod(path)
+
     /** The class Symbol of a global class definition */
     def classSymbol(fullName: String)(using ctx: Context): Symbol =
       internal.Symbol_of(fullName)

--- a/library/src/scala/tasty/reflect/CompilerInterface.scala
+++ b/library/src/scala/tasty/reflect/CompilerInterface.scala
@@ -143,25 +143,29 @@ trait CompilerInterface {
   /** Returns the owner of the context */
   def Context_owner(self: Context): Symbol
 
-  /** Returns the source file being compiled. The path is relative to the current working directory. */
-  def Context_source(self: Context): java.nio.file.Path
-
   def Context_GADT_setFreshGADTBounds(self: Context): Context
   def Context_GADT_addToConstraint(self: Context)(syms: List[Symbol]): Boolean
   def Context_GADT_approximation(self: Context)(sym: Symbol, fromBelow: Boolean): Type
 
+
+  ////////////
+  // Source //
+  ////////////
+
+  /** Returns the source file being compiled. The path is relative to the current working directory. */
+  def Source_path(using ctx: Context): java.nio.file.Path
+
   /** Returns true if we've tried to reflect on a Java class. */
-  def Context_isJavaCompilationUnit(self: Context): Boolean
+  def Source_isJavaCompilationUnit(using ctx: Context): Boolean
 
   /** Returns true if we've tried to reflect on a Scala2 (non-Tasty) class. */
-  def Context_isScala2CompilationUnit(self: Context): Boolean
+  def Source_isScala2CompilationUnit(using ctx: Context): Boolean
 
   /** Returns true if we've tried to reflect on a class that's already loaded (e.g. Option). */
-  def Context_isAlreadyLoadedCompilationUnit(self: Context): Boolean
+  def Source_isAlreadyLoadedCompilationUnit(using ctx: Context): Boolean
 
   /** Class name of the current CompilationUnit */
-  def Context_compilationUnitClassname(self: Context): String
-
+  def Source_compilationUnitClassname(using ctx: Context): String
 
   ///////////////
   // REPORTING //

--- a/library/src/scala/tasty/reflect/CompilerInterface.scala
+++ b/library/src/scala/tasty/reflect/CompilerInterface.scala
@@ -143,10 +143,13 @@ trait CompilerInterface {
   /** Returns the owner of the context */
   def Context_owner(self: Context): Symbol
 
-  def Context_GADT_setFreshGADTBounds(self: Context): Context
-  def Context_GADT_addToConstraint(self: Context)(syms: List[Symbol]): Boolean
-  def Context_GADT_approximation(self: Context)(sym: Symbol, fromBelow: Boolean): Type
+  /////////////////
+  // Constraints //
+  /////////////////
 
+  def Constraints_init(self: Context): Context
+  def Constraints_add(self: Context)(syms: List[Symbol]): Boolean
+  def Constraints_approximation(self: Context)(sym: Symbol, fromBelow: Boolean): Type
 
   ////////////
   // Source //

--- a/library/src/scala/tasty/reflect/CompilerInterface.scala
+++ b/library/src/scala/tasty/reflect/CompilerInterface.scala
@@ -150,18 +150,6 @@ trait CompilerInterface {
   def Context_GADT_addToConstraint(self: Context)(syms: List[Symbol]): Boolean
   def Context_GADT_approximation(self: Context)(sym: Symbol, fromBelow: Boolean): Type
 
-  /** Get package symbol if package is either defined in current compilation run or present on classpath. */
-  def Context_requiredPackage(self: Context)(path: String): Symbol
-
-  /** Get class symbol if class is either defined in current compilation run or present on classpath. */
-  def Context_requiredClass(self: Context)(path: String): Symbol
-
-  /** Get module symbol if module is either defined in current compilation run or present on classpath. */
-  def Context_requiredModule(self: Context)(path: String): Symbol
-
-  /** Get method symbol if method is either defined in current compilation run or present on classpath. Throws if the method has an overload. */
-  def Context_requiredMethod(self: Context)(path: String): Symbol
-
   /** Returns true if we've tried to reflect on a Java class. */
   def Context_isJavaCompilationUnit(self: Context): Boolean
 
@@ -1341,6 +1329,18 @@ trait CompilerInterface {
 
   /** Fields of a case class type -- only the ones declared in primary constructor */
   def Symbol_caseFields(self: Symbol)(using ctx: Context): List[Symbol]
+
+  /** Get package symbol if package is either defined in current compilation run or present on classpath. */
+  def Symbol_requiredPackage(path: String)(using ctx: Context): Symbol
+
+  /** Get class symbol if class is either defined in current compilation run or present on classpath. */
+  def Symbol_requiredClass(path: String)(using ctx: Context): Symbol
+
+  /** Get module symbol if module is either defined in current compilation run or present on classpath. */
+  def Symbol_requiredModule(path: String)(using ctx: Context): Symbol
+
+  /** Get method symbol if method is either defined in current compilation run or present on classpath. Throws if the method has an overload. */
+  def Symbol_requiredMethod(path: String)(using ctx: Context): Symbol
 
   def Symbol_of(fullName: String)(using ctx: Context): Symbol
 

--- a/tests/run-custom-args/tasty-inspector/i8215.scala
+++ b/tests/run-custom-args/tasty-inspector/i8215.scala
@@ -35,8 +35,7 @@ class TestInspector_NonTasty() extends TastyInspector:
   var isScala2: Boolean = false
   var className: String = ""
 
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit = 
-    import reflect.{_, given _}
-    isJava = reflect.rootContext.isJavaCompilationUnit()
-    isScala2 = reflect.rootContext.isScala2CompilationUnit()
-    className = reflect.rootContext.compilationUnitClassname()
+  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit =
+    isJava = reflect.Source.isJavaCompilationUnit
+    isScala2 = reflect.Source.isScala2CompilationUnit
+    className = reflect.Source.compilationUnitClassname

--- a/tests/run-custom-args/tasty-inspector/i8558.scala
+++ b/tests/run-custom-args/tasty-inspector/i8558.scala
@@ -17,7 +17,6 @@ class TestInspector_NonTasty() extends TastyInspector:
   var isAlreadyLoaded: Boolean = false
   var className: String = ""
 
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit = 
-    import reflect.{_, given _}
-    isAlreadyLoaded = reflect.rootContext.isAlreadyLoadedCompilationUnit()
-    className = reflect.rootContext.compilationUnitClassname()
+  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit =
+    isAlreadyLoaded = reflect.Source.isAlreadyLoadedCompilationUnit
+    className = reflect.Source.compilationUnitClassname

--- a/tests/run-macros/requiredSymbols/Macro_1.scala
+++ b/tests/run-macros/requiredSymbols/Macro_1.scala
@@ -5,22 +5,22 @@ object Macro {
   def fooImpl(using qctx: QuoteContext) : Expr[String] = {
     import qctx.tasty._
     val list = List(
-      rootContext.requiredPackage("java"),
-      rootContext.requiredPackage("java.lang"),
-      rootContext.requiredPackage("scala"),
-      rootContext.requiredPackage("scala.collection"),
+      Symbol.requiredPackage("java"),
+      Symbol.requiredPackage("java.lang"),
+      Symbol.requiredPackage("scala"),
+      Symbol.requiredPackage("scala.collection"),
 
-      rootContext.requiredClass("java.lang.Object"),
-      rootContext.requiredClass("scala.Any"),
-      rootContext.requiredClass("scala.AnyRef"),
-      rootContext.requiredClass("scala.AnyVal"),
-      rootContext.requiredClass("scala.Unit"),
-      rootContext.requiredClass("scala.Null"),
+      Symbol.requiredClass("java.lang.Object"),
+      Symbol.requiredClass("scala.Any"),
+      Symbol.requiredClass("scala.AnyRef"),
+      Symbol.requiredClass("scala.AnyVal"),
+      Symbol.requiredClass("scala.Unit"),
+      Symbol.requiredClass("scala.Null"),
 
-      rootContext.requiredModule("scala.None"),
-      rootContext.requiredModule("scala.Nil"),
+      Symbol.requiredModule("scala.None"),
+      Symbol.requiredModule("scala.Nil"),
 
-      rootContext.requiredMethod("scala.List.empty"),
+      Symbol.requiredMethod("scala.List.empty"),
     )
     Expr(list.map(_.fullName).mkString("\n"))
   }

--- a/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
@@ -10,8 +10,7 @@ object SourceFiles {
 
   def getThisFileImpl: Macro[String] = {
     val qctx = tastyContext
-    import qctx.tasty._
-    Expr(rootContext.source.getFileName.toString)
+    Expr(qctx.tasty.Source.path.getFileName.toString)
   }
 
 }

--- a/tests/run-macros/tasty-getfile/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile/Macro_1.scala
@@ -6,9 +6,7 @@ object SourceFiles {
   implicit inline def getThisFile: String =
     ${getThisFileImpl}
 
-  private def getThisFileImpl(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
-    Expr(summon[Context].source.getFileName.toString)
-  }
+  private def getThisFileImpl(using qctx: QuoteContext) : Expr[String] =
+    Expr(qctx.tasty.Source.path.getFileName.toString)
 
 }


### PR DESCRIPTION
These methods are not really related to the `Context`. We added them there because that was where they where in them compiler at the time we added them. With this change we move them to places where they make sense semantically: getting symbols is in `Symbol` and getting info about the source is in `Source`