### PR TITLE
Fix #9346: Add fallback on lazy ref cycles

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -671,7 +671,8 @@ object Types {
         val rinfo = tp.refinedInfo
         if (name.isTypeName && !pinfo.isInstanceOf[ClassInfo]) { // simplified case that runs more efficiently
           val jointInfo =
-            if (ctx.base.pendingMemberSearches.contains(name)) pinfo safe_& rinfo
+            if rinfo.isInstanceOf[TypeAlias] then rinfo
+            else if (ctx.base.pendingMemberSearches.contains(name)) pinfo safe_& rinfo
             else pinfo recoverable_& rinfo
           pdenot.asSingleDenotation.derivedSingleDenotation(pdenot.symbol, jointInfo)
         }

--- a/compiler/src/dotty/tools/dotc/core/Variances.scala
+++ b/compiler/src/dotty/tools/dotc/core/Variances.scala
@@ -118,7 +118,7 @@ object Variances {
           lam.typeParams(t.paramNum).storedVariance &= varianceFromInt(variance)
         case t: LazyRef =>
           try traverse(t.ref)
-          catch case _: LazyRefCycle =>
+          catch case _: CyclicReference =>
             () // can happen with deeply entangled F-bounds, such as in i9364.scala under -Ytest-pickler
         case _ =>
           traverseChildren(t)

--- a/compiler/src/dotty/tools/dotc/core/Variances.scala
+++ b/compiler/src/dotty/tools/dotc/core/Variances.scala
@@ -116,6 +116,10 @@ object Variances {
       def traverse(t: Type): Unit = t match
         case t: TypeParamRef if t.binder eq lam =>
           lam.typeParams(t.paramNum).storedVariance &= varianceFromInt(variance)
+        case t: LazyRef =>
+          try traverse(t.ref)
+          catch case _: LazyRefCycle =>
+            () // can happen with deeply entangled F-bounds, such as in i9364.scala under -Ytest-pickler
         case _ =>
           traverseChildren(t)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -123,6 +123,18 @@ object Checking {
     withMode(Mode.AllowLambdaWildcardApply)(checkValidIfApply)
   }
 
+  /** Check refined type for well-formedness. This means
+   *   - all arguments are within their corresponding bounds
+   *   - if type is a higher-kinded application with wildcard arguments,
+   *     check that it or one of its supertypes can be reduced to a normal application.
+   *     Unreducible applications correspond to general existentials, and we
+   *     cannot handle those.
+   *  @param tree The applied type tree to check
+   *  @param tpt  If `tree` is synthesized from a type in a TypeTree,
+   *              the original TypeTree, or EmptyTree otherwise.
+  def checkRefinedType(tp: RefinedType)
+   */
+
   /** Check all applied type trees in inferred type `tpt` for well-formedness */
   def checkAppliedTypesIn(tpt: TypeTree)(using Context): Unit =
     val checker = new TypeTraverser:

--- a/tests/neg/i6225.scala
+++ b/tests/neg/i6225.scala
@@ -1,11 +1,11 @@
-object O1 {  // error: cannot be instantiated
+object O1 {
   type A[X] = X
   opaque type T = A // error: opaque type alias must be fully applied
 }
 
 object O2 {
   opaque type A[X] = X
-  object A { // error: cannot be instantiated
+  object A {
     opaque type T = A  // error: opaque type alias must be fully applied
   }
 }

--- a/tests/pending/pos/i9346.scala
+++ b/tests/pending/pos/i9346.scala
@@ -1,9 +1,0 @@
-trait Foo[+A] {
-  type Repr[+O] <: Foo[O] {
-    type Repr[+OO] = Foo.this.Repr[OO]
-  }
-
-  def foo: Repr[A]
-
-  def bar: Repr[A] = this.foo.foo
-}

--- a/tests/pos-deep-subtype/i9346.scala
+++ b/tests/pos-deep-subtype/i9346.scala
@@ -1,0 +1,7 @@
+trait Foo {
+  type Repr[+O] <: Foo {
+    type Repr[+OO] = Foo.this.Repr[OO]
+  }
+
+  def foo[T](f: Repr[T]): f.Repr[T] = ???
+}


### PR DESCRIPTION
findMember of RefinedTypes had a fallback to safe_& in the case of cyclic references.
It also needs to handle the case where a LazyRef depends on itself during evaluation.
This fixes #9346 for normal compiles. Unpickling needs another fix in Variances.scala.