### PR TITLE
Fix #9266: Offer rewrites for parentheses in implicit closures

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2169,11 +2169,11 @@ object Parsers {
                 // Don't error in non-strict mode, as the alternative syntax "implicit (x: T) => ... "
                 // is not supported by Scala2.x
               report.errorOrMigrationWarning(
-                s"This syntax is no longer supported; parameter needs to be enclosed in (...)",
+                s"This syntax is no longer supported; parameter needs to be enclosed in (...)${rewriteNotice()}",
                 in.sourcePos())
             in.nextToken()
             val t = infixType()
-            if (false && migrateTo3) {
+            if (sourceVersion == `3.1-migration`) {
               patch(source, Span(start), "(")
               patch(source, Span(in.lastOffset), ")")
             }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2170,7 +2170,7 @@ object Parsers {
                 // is not supported by Scala2.x
               report.errorOrMigrationWarning(
                 s"This syntax is no longer supported; parameter needs to be enclosed in (...)${rewriteNotice()}",
-                Span(start, in.lastOffset))
+                source.atSpan(Span(start, in.lastOffset)))
             in.nextToken()
             val t = infixType()
             if (sourceVersion == `3.1-migration`) {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2170,7 +2170,7 @@ object Parsers {
                 // is not supported by Scala2.x
               report.errorOrMigrationWarning(
                 s"This syntax is no longer supported; parameter needs to be enclosed in (...)${rewriteNotice()}",
-                in.sourcePos())
+                Span(start, in.lastOffset))
             in.nextToken()
             val t = infixType()
             if (sourceVersion == `3.1-migration`) {

--- a/tests/neg-custom-args/fatal-warnings/i9266.check
+++ b/tests/neg-custom-args/fatal-warnings/i9266.check
@@ -1,0 +1,5 @@
+-- Error: tests/neg-custom-args/fatal-warnings/i9266.scala:3:22 --------------------------------------------------------
+3 |def test = { implicit x: Int => x + x } // error
+  |                      ^
+  |                      This syntax is no longer supported; parameter needs to be enclosed in (...)
+  |                      This construct can be rewritten automatically under -rewrite.

--- a/tests/neg-custom-args/fatal-warnings/i9266.scala
+++ b/tests/neg-custom-args/fatal-warnings/i9266.scala
@@ -1,0 +1,3 @@
+import language.`3.1-migration`
+
+def test = { implicit x: Int => x + x } // error

--- a/tests/pos/i9266.scala
+++ b/tests/pos/i9266.scala
@@ -1,0 +1,3 @@
+import language.`3.1-migration`
+
+def test = { implicit x: Int => x + x }

--- a/tests/pos/i9266.scala
+++ b/tests/pos/i9266.scala
@@ -1,3 +1,0 @@
-import language.`3.1-migration`
-
-def test = { implicit x: Int => x + x }


### PR DESCRIPTION
I don't have the time to write a proper test for this. I verified manually
that it does what it should:
```
-- Migration Warning: i9266.scala:3:23 -----------------------------------------
3 |def test = { implicit x: Int => x + x }
  |                       ^
  |This syntax is no longer supported; parameter needs to be enclosed in (...)
  |This construct can be rewritten automatically under -rewrite.
1 warning found
```