### PR TITLE
Remove dead code in CompilerInterface

### DIFF
--- a/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/tastyreflect/ReflectionCompilerInterface.scala
@@ -26,8 +26,6 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
 
   private given core.Contexts.Context = rootContext
 
-  def settings: Settings = rootContext.settings
-
   def rootPosition: util.SourcePosition =
     tastyreflect.MacroExpansion.position.getOrElse(SourcePosition(rootContext.source, Spans.NoSpan))
 
@@ -93,15 +91,6 @@ class ReflectionCompilerInterface(val rootContext: core.Contexts.Context) extend
 
   def warning(msg: => String, sourceFile: SourceFile, start: Int, end: Int)(using Context): Unit =
     report.error(msg, util.SourcePosition(sourceFile, util.Spans.Span(start, end)))
-
-
-  //////////////
-  // Settings //
-  //////////////
-
-  type Settings = config.ScalaSettings
-
-  def Settings_color(self: Settings): Boolean = self.color.value(using rootContext) == "always"
 
 
   ///////////

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -115,9 +115,6 @@ class Reflection(private[scala] val internal: CompilerInterface) { self =>
   /** Compilation context */
   type Context = internal.Context
 
-  /** Settings */
-  type Settings = internal.Settings
-
   /** Tree representing code written in the source */
   type Tree = internal.Tree
 

--- a/library/src/scala/tasty/reflect/CompilerInterface.scala
+++ b/library/src/scala/tasty/reflect/CompilerInterface.scala
@@ -115,8 +115,6 @@ trait CompilerInterface {
   /** Root position of this tasty context. For macros it corresponds to the expansion site. */
   def rootPosition: Position
 
-  def settings: Settings
-
 
   //////////////////////
   // QUOTE UNPICKLING //
@@ -190,16 +188,6 @@ trait CompilerInterface {
 
   /** Report a compilation warning with the given message at the given position range */
   def warning(msg: => String, source: SourceFile, start: Int, end: Int)(using ctx: Context): Unit
-
-
-  //////////////
-  // Settings //
-  //////////////
-
-  /** Settings */
-  type Settings <: AnyRef
-
-  def Settings_color(self: Settings): Boolean
 
 
   /////////////


### PR DESCRIPTION
Settings were removed a while ago from `scala.tasty.Reflection` but we forgot to remove it from the internal interface.