### PR TITLE
Fix #9529: Desugar ExtMethods in expression position

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1715,6 +1715,8 @@ object desugar {
       case PatDef(mods, pats, tpt, rhs) =>
         val pats1 = if (tpt.isEmpty) pats else pats map (Typed(_, tpt))
         flatTree(pats1 map (makePatDef(tree, mods, _, rhs)))
+      case ext: ExtMethods =>
+        Block(List(ext), Literal(Constant(())).withSpan(ext.span))
     }
     desugared.withSpan(tree.span)
   }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3654,7 +3654,7 @@ object Parsers {
           newLineOptWhenFollowedBy(LBRACE)
           if in.isNestedStart then inDefScopeBraces(extMethods())
           else { syntaxError("Extension without extension methods"); Nil }
-      val result = ExtMethods(tparams, extParams :: givenParamss, methods)
+      val result = atSpan(start)(ExtMethods(tparams, extParams :: givenParamss, methods))
       val comment = in.getDocComment(start)
       if comment.isDefined then
         for meth <- methods do

--- a/tests/neg/i9529.scala
+++ b/tests/neg/i9529.scala
@@ -1,0 +1,4 @@
+given Int = { // should have been `given AnyRef {`
+  extension (n: Int) // error
+    def plus(m: Int): Int = n + m
+}

--- a/tests/neg/i9529b.scala
+++ b/tests/neg/i9529b.scala
@@ -1,0 +1,2 @@
+def f1: Int = { def g = 0 } // error: Found: Unit   Required: Int
+def f2: Int = { extension (x: Int) def g = 0 } // error: Found: Unit   Required: Int

--- a/tests/pos/i9529.scala
+++ b/tests/pos/i9529.scala
@@ -1,0 +1,2 @@
+def f1: Unit = { def g = 0 }
+def f2: Unit = { extension (x: Int) def g = 0 }


### PR DESCRIPTION
Desugar the extension method into a block with a Unit expression.
Also set a missing position for the ExtMethods tree.