### PR TITLE
Fix #6183: Add regression test

### DIFF
--- a/tests/neg/i6183.check
+++ b/tests/neg/i6183.check
@@ -1,0 +1,16 @@
+-- [E008] Not Found Error: tests/neg/i6183.scala:5:5 -------------------------------------------------------------------
+5 |  42.render // error
+  |  ^^^^^^^^^
+  |  value render is not a member of Int.
+  |  An extension method was tried, but could not be fully constructed:
+  |
+  |      extension_render(42)
+-- [E051] Reference Error: tests/neg/i6183.scala:6:2 -------------------------------------------------------------------
+6 |  extension_render(42) // error
+  |  ^^^^^^^^^^^^^^^^
+  |  Ambiguous overload. The overloaded alternatives of method extension_render with types
+  |   [B](b: B)(using x$1: DummyImplicit): Char
+  |   [A](a: A): String
+  |  both match arguments ((42 : Int))
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i6183.scala
+++ b/tests/neg/i6183.scala
@@ -1,0 +1,7 @@
+extension [A](a: A) def render: String = "Hi"
+extension [B](b: B) def render(using DummyImplicit): Char = 'x'
+
+val test = {
+  42.render // error
+  extension_render(42) // error
+}


### PR DESCRIPTION
When the extension fails, the message shows the explicit version of the call.
Once replaced with the explicit version, the ambiguous overload is shown.