### PR TITLE
Fix #9538: repl crashes when :type and :doc are invoked with an empty expression

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -376,10 +376,14 @@ class ReplDriver(settings: Array[String],
       }
 
     case TypeOf(expr) =>
-      compiler.typeOf(expr)(newRun(state)).fold(
-        displayErrors,
-        res => out.println(SyntaxHighlighting.highlight(res)(using state.context))
-      )
+      expr match {
+        case "" => out.println(s":type <expression>.")
+        case _  =>
+          compiler.typeOf(expr)(newRun(state)).fold(
+            displayErrors,
+            res => out.println(SyntaxHighlighting.highlight(res)(using state.context))
+          )
+      }
       state
 
     case DocOf(expr) =>

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -387,10 +387,14 @@ class ReplDriver(settings: Array[String],
       state
 
     case DocOf(expr) =>
-      compiler.docOf(expr)(newRun(state)).fold(
-        displayErrors,
-        res => out.println(res)
-      )
+      expr match {
+        case "" => out.println(s":doc <expression>.")
+        case _  =>
+          compiler.docOf(expr)(newRun(state)).fold(
+            displayErrors,
+            res => out.println(res)
+          )
+      }
       state
 
     case Quit =>

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -377,7 +377,7 @@ class ReplDriver(settings: Array[String],
 
     case TypeOf(expr) =>
       expr match {
-        case "" => out.println(s":type <expression>.")
+        case "" => out.println(s":type <expression>")
         case _  =>
           compiler.typeOf(expr)(newRun(state)).fold(
             displayErrors,
@@ -388,7 +388,7 @@ class ReplDriver(settings: Array[String],
 
     case DocOf(expr) =>
       expr match {
-        case "" => out.println(s":doc <expression>.")
+        case "" => out.println(s":doc <expression>")
         case _  =>
           compiler.docOf(expr)(newRun(state)).fold(
             displayErrors,

--- a/compiler/test-resources/repl/i9538
+++ b/compiler/test-resources/repl/i9538
@@ -1,5 +1,5 @@
 scala>:type
-:type <expression>.
+:type <expression>
 
 scala>:doc
-:doc <expression>.
+:doc <expression>

--- a/compiler/test-resources/repl/i9538
+++ b/compiler/test-resources/repl/i9538
@@ -1,0 +1,2 @@
+scala>:type
+:type <expression>.

--- a/compiler/test-resources/repl/i9538
+++ b/compiler/test-resources/repl/i9538
@@ -1,2 +1,5 @@
 scala>:type
 :type <expression>.
+
+scala>:doc
+:doc <expression>.

--- a/compiler/test/dotty/tools/repl/DocTests.scala
+++ b/compiler/test/dotty/tools/repl/DocTests.scala
@@ -180,7 +180,7 @@ class DocTests extends ReplTest {
   @Test def docOfEmpty =
     fromInitialState { implicit s =>
     run(":doc")
-    assertEquals(":doc <expression>.", storedOutput().trim)
+    assertEquals(":doc <expression>", storedOutput().trim)
   }
 
   private def eval(code: String): State =

--- a/compiler/test/dotty/tools/repl/DocTests.scala
+++ b/compiler/test/dotty/tools/repl/DocTests.scala
@@ -177,6 +177,12 @@ class DocTests extends ReplTest {
       assertEquals("Expansion: some-value", doc("Foo.hello"))
     }
 
+  @Test def docOfEmpty =
+    fromInitialState { implicit s =>
+    run(":doc")
+    assertEquals(":doc <expression>.", storedOutput().trim)
+  }
+
   private def eval(code: String): State =
     fromInitialState { implicit s => run(code) }
 

--- a/compiler/test/dotty/tools/repl/TypeTests.scala
+++ b/compiler/test/dotty/tools/repl/TypeTests.scala
@@ -24,6 +24,6 @@ class TypeTests extends ReplTest {
 
   @Test def typeOfEmpty = fromInitialState { implicit s =>
     run(":type")
-    assertEquals(":type <expression>.", storedOutput().trim)
+    assertEquals(":type <expression>", storedOutput().trim)
   }
 }

--- a/compiler/test/dotty/tools/repl/TypeTests.scala
+++ b/compiler/test/dotty/tools/repl/TypeTests.scala
@@ -21,4 +21,9 @@ class TypeTests extends ReplTest {
       run(":type x")
       assertEquals("Int", storedOutput().trim)
     }
+
+  @Test def typeOfEmpty = fromInitialState { implicit s =>
+    run(":type")
+    assertEquals(":type <expression>.", storedOutput().trim)
+  }
 }


### PR DESCRIPTION
The `:type` and `:doc` commands now handle being invoked with an empty expression gracefully by printing the corresponding usage text, similar to the repl in Scala 2.
```scala
scala>:type
:type <expression>.

scala>:doc
:doc <expression>.
```