### PR TITLE
Replace "-strict" with "-source 3.1" in docs

### DIFF
--- a/docs/docs/reference/changed-features/operators.md
+++ b/docs/docs/reference/changed-features/operators.md
@@ -133,7 +133,7 @@ The purpose of the `@infix` annotation is to achieve consistency across a code b
     can be applied using infix syntax, i.e. `A op B`.
 
  5. To smooth migration to Scala 3.0, alphanumeric operators will only be deprecated from Scala 3.1 onwards,
-or if the `-strict` option is given in Dotty/Scala 3.
+or if the `-source 3.1` option is given in Dotty/Scala 3.
 
 ## Syntax Change
 

--- a/docs/docs/reference/changed-features/pattern-bindings.md
+++ b/docs/docs/reference/changed-features/pattern-bindings.md
@@ -15,7 +15,7 @@ val xs: List[Any] = List(1, 2, 3)
 val (x: String) :: _ = xs   // error: pattern's type String is more specialized
                             // than the right hand side expression's type Any
 ```
-This code gives a compile-time error in Scala 3.1 (and also in Scala 3.0 under the `-strict` setting) whereas it will fail at runtime with a `ClassCastException` in Scala 2. In Scala 3.1, a pattern binding is only allowed if the pattern is _irrefutable_, that is, if the right-hand side's type conforms to the pattern's type. For instance, the following is OK:
+This code gives a compile-time error in Scala 3.1 (and also in Scala 3.0 under the `-source 3.1` setting) whereas it will fail at runtime with a `ClassCastException` in Scala 2. In Scala 3.1, a pattern binding is only allowed if the pattern is _irrefutable_, that is, if the right-hand side's type conforms to the pattern's type. For instance, the following is OK:
 ```scala
   val pair = (1, true)
   val (x, y) = pair
@@ -58,4 +58,4 @@ Generator      ::=  [‘case’] Pattern1 ‘<-’ Expr
 
 ## Migration
 
-The new syntax is supported in Dotty and Scala 3.0. However, to enable smooth cross compilation between Scala 2 and Scala 3, the changed behavior and additional type checks are only enabled under the `-strict` setting. They will be enabled by default in version 3.1 of the language.
+The new syntax is supported in Dotty and Scala 3.0. However, to enable smooth cross compilation between Scala 2 and Scala 3, the changed behavior and additional type checks are only enabled under the `-source 3.1` setting. They will be enabled by default in version 3.1 of the language.

--- a/docs/docs/reference/changed-features/vararg-patterns.md
+++ b/docs/docs/reference/changed-features/vararg-patterns.md
@@ -37,7 +37,7 @@ The change to the grammar is:
 ## Compatibility considerations
 
 To enable smooth cross compilation between Scala 2 and Scala 3, Dotty will
-accept both the old and the new syntax. Under the `-strict` setting, an error
+accept both the old and the new syntax. Under the `-source 3.1` setting, an error
 will be emitted when the old syntax is encountered. They will be enabled by
 default in version 3.1 of the language.
 

--- a/docs/docs/reference/changed-features/wildcards.md
+++ b/docs/docs/reference/changed-features/wildcards.md
@@ -30,7 +30,7 @@ A step-by-step migration is made possible with the following measures:
  2. In Scala 3.1, `_` is deprecated in favor of `?` as a name for a wildcard. A `-rewrite` option is
     available to rewrite one to the other.
  3. In Scala 3.2, the meaning of `_` changes from wildcard to placeholder for type parameter.
- 4. The Scala 3.1 behavior is already available today under the `-strict` setting.
+ 4. The Scala 3.1 behavior is already available today under the `-source 3.1` setting.
 
 To smooth the transition for codebases that use kind-projector, we adopt the following measures under the command line
 option `-Ykind-projector`:

--- a/docs/docs/reference/other-new-features/open-classes.md
+++ b/docs/docs/reference/other-new-features/open-classes.md
@@ -76,4 +76,4 @@ A class that is neither `abstract` nor `open` is similar to a `sealed` class: it
 
 ### Migration
 
-`open` is a new modifier in Scala 3. To allow cross compilation between Scala 2.13 and Scala 3.0 without warnings, the feature warning for ad-hoc extensions is produced only under `-strict`. It will be produced by default from Scala 3.1 on.
+`open` is a new modifier in Scala 3. To allow cross compilation between Scala 2.13 and Scala 3.0 without warnings, the feature warning for ad-hoc extensions is produced only under `-source 3.1`. It will be produced by default from Scala 3.1 on.


### PR DESCRIPTION
https://github.com/lampepfl/dotty/commit/278a8225f7dd5f839b2336554564ba99db691060

```
$ dotc -version
Dotty compiler version 0.26.0-RC1 -- Copyright 2002-2020, LAMP/EPFL
$ dotc -strict A.scala
bad option '-strict' was ignored
1 warning found
$ dotc -source 3.1 A.scala
```