### PR TITLE
Fix #9462: Identify inserted apply's more reliably in the Dynamic treatment.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1068,7 +1068,7 @@ object Build {
             -- "InteroperabilityTest.scala" // various compile errors
             -- "OptimizerTest.scala" // compile errors: false + string and () + string
             -- "ReflectionTest.scala" // tests fail
-            -- "RegressionJSTest.scala" // compile error with js.Dynamic.literal
+            -- "RegressionJSTest.scala" // non-native JS classes
             -- "RuntimeTypesTest.scala" // compile errors: no ClassTag for Null and Nothing
             )).get
 
@@ -1081,23 +1081,22 @@ object Build {
 
           ++ (dir / "js/src/test/scala/org/scalajs/testsuite/jsinterop" ** (("*.scala": FileFilter)
             -- "AsyncTest.scala" // needs PromiseMock.scala
-            -- "DynamicTest.scala" // compile error with js.Dynamic.literal
+            -- "DynamicTest.scala" // one test requires JS exports, all other tests pass
             -- "ExportsTest.scala" // JS exports
             -- "FunctionTest.scala" // IR checking errors
             -- "IterableTest.scala" // non-native JS classes
             -- "JSExportStaticTest.scala" // JS exports
-            -- "JSNameTest.scala" // compile error with js.Dynamic.literal
             -- "JSNativeInPackage.scala" // IR checking errors
             -- "JSOptionalTest.scala" // non-native JS classes
-            -- "JSSymbolTest.scala" // compile error with js.Dynamic.literal
-            -- "MiscInteropTest.scala" // compile error with js.Dynamic.literal
+            -- "JSSymbolTest.scala" // non-native JS classes
+            -- "MiscInteropTest.scala" // non-native JS classes
             -- "ModulesWithGlobalFallbackTest.scala" // non-native JS classes
             -- "NestedJSClassTest.scala" // non-native JS classes
             -- "NonNativeJSTypeTest.scala" // non-native JS classes
             -- "PromiseMock.scala" // non-native JS classes
-            -- "SpecialTest.scala" // compile error with js.Dynamic.literal
+            -- "SpecialTest.scala" // assertion error in ExpandSAMs
             -- "SymbolTest.scala" // IR checking errors
-            -- "ThisFunctionTest.scala" // compile error with js.Dynamic.literal
+            -- "ThisFunctionTest.scala" // assertion error in ExpandSAMs
             -- "UndefOrTest.scala" // StackOverflow in the compiler
             )).get
 
@@ -1118,10 +1117,7 @@ object Build {
             )).get
 
           ++ (dir / "js/src/test/scala/org/scalajs/testsuite/niobuffer" ** "*.scala").get
-
-          ++ (dir / "js/src/test/scala/org/scalajs/testsuite/scalalib" ** (("*.scala": FileFilter)
-            -- "ScalaRunTimeJSTest.scala" // compile error with js.Dynamic.literal
-            )).get
+          ++ (dir / "js/src/test/scala/org/scalajs/testsuite/scalalib" ** "*.scala").get
 
           ++ (dir / "js/src/test/scala/org/scalajs/testsuite/typedarray" ** (("*.scala": FileFilter)
             -- "TypedArrayTest.scala" // assertion error in ExpandSAMs

--- a/tests/run/dynamicDynamicTests.scala
+++ b/tests/run/dynamicDynamicTests.scala
@@ -49,6 +49,7 @@ object Test {
   def main(args: Array[String]): Unit = {
     runFooTests1()
     runFooTests2()
+    runFooTests3()
     runBarTests()
     runBazTests()
     runQuxTests()
@@ -100,6 +101,63 @@ object Test {
     assertEquals("Bar.bazApplyNamed(1, abc)", foo.bazApplyNamed(a = 1, "abc"))
 
     assertEquals("selectDynamic(bazSelectUpdate).update(key, value)", foo.bazSelectUpdate("key") = "value")
+  }
+
+  /** Test apply insertions kick in before dynamic calls. */
+  def runFooTests3() = {
+    val foo = new Foo
+
+    assertEquals("applyDynamic(apply)()", foo())
+    assertEquals("applyDynamic(apply)(1)", foo(1))
+    assertEquals("applyDynamic(apply)(1, 2, 3)", foo(1, 2, 3))
+    assertEquals("applyDynamic(apply)(1, 2, a)", foo(1, 2, "a"))
+    assertEquals("applyDynamic(apply)(1, 2, a)", foo(List(1, 2, "a"): _*))
+
+    assertEquals("applyDynamicNamed(apply)((a,1))", foo(a = 1))
+    assertEquals("applyDynamicNamed(apply)((a,1), (b,2))", foo(a = 1, b = 2))
+    assertEquals("applyDynamicNamed(apply)((a,1), (,0))", foo(a = 1, 0))
+    assertEquals("applyDynamicNamed(apply)((a,1), (a,5))", foo(a = 1, a = 5))
+    assertEquals("applyDynamicNamed(apply)((,d), (a,1), (,5), (a,c))", foo("d", a = 1, 5, a = 'c'))
+
+    assertEquals("applyDynamic(apply)()", foo.apply())
+    assertEquals("applyDynamic(apply)(1)", foo.apply(1))
+    assertEquals("applyDynamic(apply)(1, 2, 3)", foo.apply(1, 2, 3))
+    assertEquals("applyDynamic(apply)(1, 2, a)", foo.apply(1, 2, "a"))
+    assertEquals("applyDynamic(apply)(1, 2, a)", foo.apply(List(1, 2, "a"): _*))
+
+    assertEquals("applyDynamicNamed(apply)((a,1))", foo.apply(a = 1))
+    assertEquals("applyDynamicNamed(apply)((a,1), (b,2))", foo.apply(a = 1, b = 2))
+    assertEquals("applyDynamicNamed(apply)((a,1), (,0))", foo.apply(a = 1, 0))
+    assertEquals("applyDynamicNamed(apply)((a,1), (a,5))", foo.apply(a = 1, a = 5))
+    assertEquals("applyDynamicNamed(apply)((,d), (a,1), (,5), (a,c))", foo.apply("d", a = 1, 5, a = 'c'))
+
+    object bar {
+      val foo: Foo = new Foo
+    }
+
+    assertEquals("applyDynamic(apply)()", bar.foo())
+    assertEquals("applyDynamic(apply)(1)", bar.foo(1))
+    assertEquals("applyDynamic(apply)(1, 2, 3)", bar.foo(1, 2, 3))
+    assertEquals("applyDynamic(apply)(1, 2, a)", bar.foo(1, 2, "a"))
+    assertEquals("applyDynamic(apply)(1, 2, a)", bar.foo(List(1, 2, "a"): _*))
+
+    assertEquals("applyDynamicNamed(apply)((a,1))", bar.foo(a = 1))
+    assertEquals("applyDynamicNamed(apply)((a,1), (b,2))", bar.foo(a = 1, b = 2))
+    assertEquals("applyDynamicNamed(apply)((a,1), (,0))", bar.foo(a = 1, 0))
+    assertEquals("applyDynamicNamed(apply)((a,1), (a,5))", bar.foo(a = 1, a = 5))
+    assertEquals("applyDynamicNamed(apply)((,d), (a,1), (,5), (a,c))", bar.foo("d", a = 1, 5, a = 'c'))
+
+    assertEquals("applyDynamic(apply)()", bar.foo.apply())
+    assertEquals("applyDynamic(apply)(1)", bar.foo.apply(1))
+    assertEquals("applyDynamic(apply)(1, 2, 3)", bar.foo.apply(1, 2, 3))
+    assertEquals("applyDynamic(apply)(1, 2, a)", bar.foo.apply(1, 2, "a"))
+    assertEquals("applyDynamic(apply)(1, 2, a)", bar.foo.apply(List(1, 2, "a"): _*))
+
+    assertEquals("applyDynamicNamed(apply)((a,1))", bar.foo.apply(a = 1))
+    assertEquals("applyDynamicNamed(apply)((a,1), (b,2))", bar.foo.apply(a = 1, b = 2))
+    assertEquals("applyDynamicNamed(apply)((a,1), (,0))", bar.foo.apply(a = 1, 0))
+    assertEquals("applyDynamicNamed(apply)((a,1), (a,5))", bar.foo.apply(a = 1, a = 5))
+    assertEquals("applyDynamicNamed(apply)((,d), (a,1), (,5), (a,c))", bar.foo.apply("d", a = 1, 5, a = 'c'))
   }
 
   /** Test cains of dynamic calls. */


### PR DESCRIPTION
Previously, identifying when there was an inserted apply, which had to be carried through the Dynamic treatment, was done on a syntactical basis. This would mishandle cases written as
```scala
  someContainer.someDynamic()
```
as it would think that this was an explicit dynamic call for `"someDynamic"` on `someContainer` (although `someContainer` is not even a `scala.Dynamic` itself, but `someContainer.someDynamic` is).

We now reliably detect inserted applys by looking at the result of the pre-type-checking of the function part, and testing whether there is a synthetic `Select(_, nme.apply)` node.