### PR TITLE
Avoid lazy local contexts

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeMapWithImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeMapWithImplicits.scala
@@ -91,13 +91,14 @@ class TreeMapWithImplicits extends tpd.TreeMap {
       case tree: Block =>
         super.transform(tree)(using nestedScopeCtx(tree.stats))
       case tree: DefDef =>
-        given Context = localCtx
-        cpy.DefDef(tree)(
-          tree.name,
-          transformSub(tree.tparams),
-          tree.vparamss mapConserve (transformSub(_)),
-          transform(tree.tpt),
-          transform(tree.rhs)(using nestedScopeCtx(tree.vparamss.flatten)))
+        inContext(localCtx) {
+          cpy.DefDef(tree)(
+            tree.name,
+            transformSub(tree.tparams),
+            tree.vparamss mapConserve (transformSub(_)),
+            transform(tree.tpt),
+            transform(tree.rhs)(using nestedScopeCtx(tree.vparamss.flatten)))
+        }
       case EmptyValDef =>
         tree
       case _: PackageDef | _: MemberDef =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -597,9 +597,10 @@ class TreeUnpickler(reader: TastyReader,
       else if (sym.isInlineMethod)
         sym.addAnnotation(LazyBodyAnnotation { (using ctx0: Context) =>
           val ctx1 = localContext(sym)(using ctx0).addMode(Mode.ReadPositions)
-          given Context = sourceChangeContext(Addr(0))(using ctx1)
+          inContext(sourceChangeContext(Addr(0))(using ctx1)) {
             // avoids space leaks by not capturing the current context
-          forkAt(rhsStart).readTerm()
+            forkAt(rhsStart).readTerm()
+          }
         })
       goto(start)
       sym


### PR DESCRIPTION
These cause allocation of a LazyRef. It's better to use inContext,
which is an inline function that gives better code.