### PR TITLE
Don't cache given aliases to `this`

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CacheAliasImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CacheAliasImplicits.scala
@@ -56,6 +56,7 @@ class CacheAliasImplicits extends MiniPhase with IdentityDenotTransformer { this
             if rhsTpe.isStable => false
             case rhsTpe @ TermRef(pre: ThisType, _)
             if rhsTpe.isStable && pre.cls == sym.owner.enclosingClass => false
+            case rhsTpe: ThisType => false
             case _ => true
           }
         case _ => false


### PR DESCRIPTION
A given alias

   given Foo = this

does not need to be cached in a lazy val since `this` is an immutable reference.