### PR TITLE
Fix `Object.range` to intended `List.range`

### DIFF
--- a/docs/docs/usage/dottydoc.md
+++ b/docs/docs/usage/dottydoc.md
@@ -192,11 +192,11 @@ Linking to members is done in the same fashion:
 [Seq](scala.collection.immutable.Seq.isEmpty)
 ```
 
-Dottydoc denotes objects by ending their names in "$". To select `Object.range`
-you would therefore write:
+Dottydoc denotes objects by ending their names in "$". To select `List.range`
+you'd therefore write:
 
 ```markdown
-[Object.range](scala.collection.immutable.List$.range)
+[List.range](scala.collection.immutable.List$.range)
 ```
 
 Rendering Docstrings


### PR DESCRIPTION
I'm pretty certain that the changes here reflect the authors intentions, for two reasons:

1. `Object` does not have a `range` method
2. The link into the API documentation is pointing to `List.range`