### PR TITLE
Use sparse arrays instead of maps for pickling

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -16,7 +16,7 @@ import Contexts._, Symbols._, Annotations._, Decorators._
 import collection.mutable
 import util.Spans._
 
-class PositionPickler(pickler: TastyPickler, addrOfTree: untpd.Tree => Addr) {
+class PositionPickler(pickler: TastyPickler, addrOfTree: PositionPickler.TreeToAddr) {
   val buf: TastyBuffer = new TastyBuffer(5000)
   pickler.newSection("Positions", buf)
   import ast.tpd._
@@ -121,3 +121,8 @@ class PositionPickler(pickler: TastyPickler, addrOfTree: untpd.Tree => Addr) {
       traverse(root, NoSource)
   }
 }
+object PositionPickler:
+  // Note: This could be just TreeToAddr => Addr if functions are specialized to value classes.
+  // We use a SAM type to avoid boxing of Addr
+  @FunctionalInterface trait TreeToAddr:
+    def apply(x: untpd.Tree): Addr

--- a/compiler/src/dotty/tools/dotc/util/SparseIntArray.scala
+++ b/compiler/src/dotty/tools/dotc/util/SparseIntArray.scala
@@ -52,7 +52,7 @@ class SparseIntArray:
   /** Transform each defined value with transformation `op`.
    *  The transformation takes the element index and value as parameters.
    */
-  def transform(op: (Int, Value) => Value): Unit =
+  def transform(op: Transform): Unit =
     root.transform(op, 0)
 
   /** Access to some info about low-level representation */
@@ -70,6 +70,9 @@ class SparseIntArray:
 
 object SparseIntArray:
   type Value = Int
+
+  trait Transform:
+    def apply(key: Int, v: Value): Value
 
   private inline val NodeSizeLog = 5
   private inline val NodeSize = 1 << NodeSizeLog
@@ -91,7 +94,7 @@ object SparseIntArray:
     def isEmpty: Boolean
     def keysIterator(offset: Int): Iterator[Int]
     def foreachBinding(op: (Int, Value) => Unit, offset: Int): Unit
-    def transform(op: (Int, Value) => Value, offset: Int): Unit
+    def transform(op: Transform, offset: Int): Unit
     def nodeCount: Int
   end Node
 
@@ -136,7 +139,7 @@ object SparseIntArray:
         if contains(i) then op(offset + i, elems(i))
         i += 1
 
-    def transform(op: (Int, Value) => Value, offset: Int): Unit =
+    def transform(op: Transform, offset: Int): Unit =
       var i = 0
       while i < NodeSize do
         if contains(i) then elems(i) = op(offset + i, elems(i))
@@ -210,7 +213,7 @@ object SparseIntArray:
           elems(i).foreachBinding(op, offset + i * elemSize)
         i += 1
 
-    def transform(op: (Int, Value) => Value, offset: Int): Unit =
+    def transform(op: Transform, offset: Int): Unit =
       var i = 0
       while i < NodeSize do
         if elems(i) != null then

--- a/compiler/src/dotty/tools/dotc/util/SparseIntArray.scala
+++ b/compiler/src/dotty/tools/dotc/util/SparseIntArray.scala
@@ -28,7 +28,9 @@ class SparseIntArray:
 
   def update(index: Int, value: Value): Unit =
     require(index >= 0)
-    while capacity <= index do grow()
+    while capacity <= index do
+      require(root.level < MaxLevels, "array index too large, maximum is 2^30 - 1")
+      grow()
     if !root.update(index, value) then siz += 1
 
   /** Remove element at `index` if it is present
@@ -76,6 +78,7 @@ object SparseIntArray:
 
   private inline val NodeSizeLog = 5
   private inline val NodeSize = 1 << NodeSizeLog
+  private inline val MaxLevels = 5  // max size is 2 ^ ((MaxLevels + 1) * NodeSizeLog) = 2 ^ 30
 
   /** The exposed representation. Should be used just for nodeCount and
    *  low-level toString.

--- a/compiler/src/dotty/tools/dotc/util/SparseIntArray.scala
+++ b/compiler/src/dotty/tools/dotc/util/SparseIntArray.scala
@@ -50,7 +50,7 @@ class SparseIntArray:
     root.foreachBinding(op, 0)
 
   /** Transform each defined value with transformation `op`.
-   *  The transformation gets the element index and value as parameters.
+   *  The transformation takes the element index and value as parameters.
    */
   def transform(op: (Int, Value) => Value): Unit =
     root.transform(op, 0)
@@ -189,6 +189,9 @@ object SparseIntArray:
     private def skipUndefined(i: Int): Int =
       if i < NodeSize && elems(i) == null then skipUndefined(i + 1) else i
 
+    // Note: This takes (depth of tree) recursive steps to produce the
+    // next index. It could be more efficient if we kept all active iterators
+    // in a path.
     def keysIterator(offset: Int) = new Iterator[Value]:
       private var curIdx = skipUndefined(0)
       private var elemIt = Iterator.empty[Int]
@@ -228,35 +231,3 @@ object SparseIntArray:
     if level == 0 then LeafNode() else InnerNode(level)
 
 end SparseIntArray
-
-@main def Test =
-  val a = SparseIntArray()
-  println(s"a = $a")
-  a(1) = 22
-  println(s"a = $a")
-  a(222) = 33
-  println(s"a = $a")
-  a(55555) = 44
-  println(s"a = $a")
-  println(s"iterator of a yields ${a.keysIterator.toList}")
-  assert(a.size == 3, a)
-  assert(a.contains(1), a)
-  assert(a.contains(222), a)
-  assert(a.contains(55555), a)
-  assert(!a.contains(2))
-  assert(!a.contains(20000000))
-  a(222) = 44
-  assert(a.size == 3)
-  assert(a(1) == 22)
-  assert(a(222) == 44)
-  assert(a(55555) == 44)
-  assert(a.remove(1))
-  println(s"a = $a")
-  assert(a(222) == 44, a)
-  assert(a.remove(55555))
-  assert(a(222) == 44, a)
-  assert(a.size == 1)
-  assert(!a.contains(1))
-  assert(!a.remove(55555))
-  assert(a.remove(222))
-  assert(a.size == 0)

--- a/compiler/src/dotty/tools/dotc/util/SparseIntArray.scala
+++ b/compiler/src/dotty/tools/dotc/util/SparseIntArray.scala
@@ -1,0 +1,228 @@
+package dotty.tools.dotc
+package util
+
+import java.util.NoSuchElementException
+
+class SparseIntArray:
+  import SparseIntArray._
+
+  private var siz: Int = 0
+  private var root: Node = LeafNode()
+
+  private def grow() =
+    val newRoot = InnerNode(root.level + 1)
+    newRoot.elems(0) = root
+    root = newRoot
+
+  private def capacity: Int = root.elemSize * NodeSize
+
+  def size = siz
+
+  def contains(index: Int): Boolean =
+    0 <= index && index < capacity && root.contains(index)
+
+  def apply(index: Int): Value =
+    require(index >= 0)
+    if index >= capacity then throw NoSuchElementException()
+    root.apply(index)
+
+  def update(index: Int, value: Value): Unit =
+    require(index >= 0)
+    while capacity <= index do grow()
+    if !root.update(index, value) then siz += 1
+
+  /** Remove element at `index` if it is present
+   *  @return element was present
+   */
+  def remove(index: Int): Boolean =
+    require(index >= 0)
+    index < capacity && {
+      val result = root.remove(index)
+      if result then siz -= 1
+      result
+    }
+
+  def foreachBinding(op: (Int, Value) => Unit): Unit =
+    root.foreachBinding(op, 0)
+
+  def transform(op: (Int, Value) => Value): Unit =
+    root.transform(op, 0)
+
+  /** Access to some info about low-level representation */
+  def repr: Repr = root
+
+  override def toString =
+    val b = StringBuilder() ++= "SparseIntArray("
+    var first = true
+    foreachBinding { (idx, elem) =>
+      if first then first = false else b ++= ", "
+      b ++= s"$idx -> $elem"
+    }
+    b ++= ")"
+    b.toString
+
+object SparseIntArray:
+  type Value = Int
+
+  private inline val NodeSizeLog = 5
+  private inline val NodeSize = 1 << NodeSizeLog
+
+  /** The exposed representation. Should be used just for nodeCount and
+   *  low-level toString.
+   */
+  abstract class Repr:
+    def nodeCount: Int
+
+  private abstract class Node(val level: Int) extends Repr:
+    private[SparseIntArray] def elemShift = level * NodeSizeLog
+    private[SparseIntArray] def elemSize = 1 << elemShift
+    private[SparseIntArray] def elemMask = elemSize - 1
+    def contains(index: Int): Boolean
+    def apply(index: Int): Value
+    def update(index: Int, value: Value): Boolean
+    def remove(index: Int): Boolean
+    def isEmpty: Boolean
+    def foreachBinding(op: (Int, Value) => Unit, offset: Int): Unit
+    def transform(op: (Int, Value) => Value, offset: Int): Unit
+    def nodeCount: Int
+  end Node
+
+  private class LeafNode extends Node(0):
+    private val elems = new Array[Value](NodeSize)
+    private var present: Int = 0
+
+    def contains(index: Int): Boolean =
+      (present & (1 << index)) != 0
+
+    def apply(index: Int) =
+      if !contains(index) then throw NoSuchElementException()
+      elems(index)
+
+    def update(index: Int, value: Value): Boolean =
+      elems(index) = value
+      val result = contains(index)
+      present = present | (1 << index)
+      result
+
+    def remove(index: Int): Boolean =
+      val result = contains(index)
+      present = present & ~(1 << index)
+      result
+
+    def isEmpty = present == 0
+
+    def foreachBinding(op: (Int, Value) => Unit, offset: Int): Unit =
+      var i = 0
+      while i < NodeSize do
+        if contains(i) then op(offset + i, elems(i))
+        i += 1
+
+    def transform(op: (Int, Value) => Value, offset: Int): Unit =
+      var i = 0
+      while i < NodeSize do
+        if contains(i) then elems(i) = op(offset + i, elems(i))
+        i += 1
+
+    def nodeCount = 1
+
+    override def toString =
+      elems
+        .zipWithIndex
+        .filter((elem, idx) => contains(idx))
+        .map((elem, idx) => s"$idx -> $elem").mkString(s"0#(", ", ", ")")
+  end LeafNode
+
+  private class InnerNode(level: Int) extends Node(level):
+    private[SparseIntArray] val elems = new Array[Node](NodeSize)
+    private var empty: Boolean = true
+
+    def contains(index: Int): Boolean =
+      val elem = elems(index >>> elemShift)
+      elem != null && elem.contains(index & elemMask)
+
+    def apply(index: Int): Value =
+      val elem = elems(index >>> elemShift)
+      if elem == null then throw NoSuchElementException()
+      elem.apply(index & elemMask)
+
+    def update(index: Int, value: Value): Boolean =
+      empty = false
+      var elem = elems(index >>> elemShift)
+      if elem == null then
+        elem = newNode(level - 1)
+        elems(index >>> elemShift) = elem
+      elem.update(index & elemMask, value)
+
+    def remove(index: Int): Boolean =
+      val elem = elems(index >>> elemShift)
+      if elem == null then false
+      else
+        val result = elem.remove(index & elemMask)
+        if elem.isEmpty then
+          elems(index >>> elemShift) = null
+          var i = 0
+          while i < NodeSize && elems(i) == null do i += 1
+          if i == NodeSize then empty = true
+        result
+
+    def isEmpty = empty
+
+    def foreachBinding(op: (Int, Value) => Unit, offset: Int): Unit =
+      var i = 0
+      while i < NodeSize do
+        if elems(i) != null then
+          elems(i).foreachBinding(op, offset + i * elemSize)
+        i += 1
+
+    def transform(op: (Int, Value) => Value, offset: Int): Unit =
+      var i = 0
+      while i < NodeSize do
+        if elems(i) != null then
+          elems(i).transform(op, offset + i * elemSize)
+        i += 1
+
+    def nodeCount =
+      1 + elems.filter(_ != null).map(_.nodeCount).sum
+
+    override def toString =
+      elems
+        .zipWithIndex
+        .filter((elem, idx) => elem != null)
+        .map((elem, idx) => s"$idx -> $elem").mkString(s"$level#(", ", ", ")")
+  end InnerNode
+
+  private def newNode(level: Int): Node =
+    if level == 0 then LeafNode() else InnerNode(level)
+
+end SparseIntArray
+
+@main def Test =
+  val a = SparseIntArray()
+  println(s"a = $a")
+  a(1) = 22
+  println(s"a = $a")
+  a(222) = 33
+  println(s"a = $a")
+  a(55555) = 44
+  println(s"a = $a")
+  assert(a.size == 3, a)
+  assert(a.contains(1), a)
+  assert(a.contains(222), a)
+  assert(a.contains(55555), a)
+  assert(!a.contains(2))
+  assert(!a.contains(20000000))
+  a(222) = 44
+  assert(a.size == 3)
+  assert(a(1) == 22)
+  assert(a(222) == 44)
+  assert(a(55555) == 44)
+  assert(a.remove(1))
+  println(s"a = $a")
+  assert(a(222) == 44, a)
+  assert(a.remove(55555))
+  assert(a(222) == 44, a)
+  assert(a.size == 1)
+  assert(!a.contains(1))
+  assert(!a.remove(55555))
+  assert(a.remove(222))
+  assert(a.size == 0)

--- a/compiler/test/dotty/tools/dotc/util/SparseIntArrayTests.scala
+++ b/compiler/test/dotty/tools/dotc/util/SparseIntArrayTests.scala
@@ -1,0 +1,38 @@
+package dotty.tools.dotc.util
+
+import org.junit.Assert._
+import org.junit.Test
+
+class SparseIntArrayTests:
+  @Test
+  def sparseArrayTests: Unit =
+    val a = SparseIntArray()
+    assert(a.toString == "SparseIntArray()")
+    a(1) = 22
+    assert(a.toString == "SparseIntArray(1 -> 22)")
+    a(222) = 33
+    assert(a.toString == "SparseIntArray(1 -> 22, 222 -> 33)")
+    a(55555) = 44
+    assert(a.toString == "SparseIntArray(1 -> 22, 222 -> 33, 55555 -> 44)")
+    assert(a.keysIterator.toList == List(1, 222, 55555))
+    assert(a.size == 3, a)
+    assert(a.contains(1), a)
+    assert(a.contains(222), a)
+    assert(a.contains(55555), a)
+    assert(!a.contains(2))
+    assert(!a.contains(20000000))
+    a(222) = 44
+    assert(a.size == 3)
+    assert(a(1) == 22)
+    assert(a(222) == 44)
+    assert(a(55555) == 44)
+    assert(a.remove(1))
+    assert(a.toString == "SparseIntArray(222 -> 44, 55555 -> 44)")
+    assert(a(222) == 44, a)
+    assert(a.remove(55555))
+    assert(a(222) == 44, a)
+    assert(a.size == 1)
+    assert(!a.contains(1))
+    assert(!a.remove(55555))
+    assert(a.remove(222))
+    assert(a.size == 0)


### PR DESCRIPTION
Pickling keeps a large map of trees to addresses, which can be seen as a map from Ints (unique ids of trees) to Int (address index) which is fairly dense. We get a more compact representation by switching from a HashMap to a SparseIntArray.
