### PR TITLE
Optimize toBits in FlagSet

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -24,7 +24,7 @@ object Flags {
 
   extension (x: FlagSet) {
 
-    def bits: Long = opaques.toBits(x)
+    inline def bits: Long = opaques.toBits(x)
 
     /** The union of the given flag sets.
      *  Combining two FlagSets with `|` will give a FlagSet


### PR DESCRIPTION
async-profiles have shown that toBits was not inlined by the JVM. Helping the JVM a bit here by
making bits inline, so that toBits is one fewer call away.

Not that we cannot inline toBits at typer since it is in the scope of an opaque type.