### PR TITLE
Harden constraints so bounds can only be value types or lambdas

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -484,9 +484,7 @@ trait ConstraintHandling {
    *  way isSubType is organized.
    */
   protected def addConstraint(param: TypeParamRef, bound: Type, fromBelow: Boolean)(using Context): Boolean =
-    if !bound.isValueTypeOrLambda then
-      assert(ctx.reporter.errorsReported)
-      return false
+    if !bound.isValueTypeOrLambda then return false
 
     /** When comparing lambdas we might get constraints such as
      *  `A <: X0` or `A = List[X0]` where `A` is a constrained parameter


### PR DESCRIPTION
I observed a crash in replace when hacking ElimOpaque the compiler.It came down to the problem that a TermRef with a context function as underlying type was added to the context as lower bound after some errors were already
reported. I could not track down the exact chain of effects. But anyway it's
better to be defensive and not let junk enter the context.