### PR TITLE
Add tasty Reflect benchmark

### DIFF
--- a/tests/bench/string-interpolation-macro/Macro.scala
+++ b/tests/bench/string-interpolation-macro/Macro.scala
@@ -1,0 +1,18 @@
+import scala.quoted._
+
+object Macro {
+
+  extension (inline sc: StringContext):
+    inline def x(inline args: Int*): String = ${ code('sc, 'args) }
+
+  def code(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Int]])(using QuoteContext): Expr[String] =
+    var res: Expr[String] = null
+    for _ <- 0 to 5_000 do
+      (strCtxExpr, argsExpr) match {
+        case ('{ StringContext(${Varargs(Consts(parts))}: _*) }, Varargs(Consts(args))) =>
+          res = Expr(StringContext(parts: _*).s(args: _*))
+        case _ => ???
+      }
+    res
+
+}

--- a/tests/bench/string-interpolation-macro/Test.scala
+++ b/tests/bench/string-interpolation-macro/Test.scala
@@ -1,0 +1,4 @@
+import Macro._
+
+class Test:
+  def test: String = x"a${1}b${2}c${3}d${4}e${5}f"


### PR DESCRIPTION
This benchmark calls eextractors that use tasty.Reflect internally.