### PR TITLE
Performance tweaks

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -23,7 +23,7 @@ object Feature:
     def toPrefix(sym: Symbol): String =
       if !sym.exists || sym == defn.LanguageModule.moduleClass then ""
       else toPrefix(sym.owner) + sym.name.stripModuleClassSuffix + "."
-    val prefix = if owner.exists then toPrefix(owner) else ""
+    val prefix = if owner ne NoSymbol then toPrefix(owner) else ""
     ctx.base.settings.language.value.contains(prefix + feature)
 
   /** Is `feature` enabled by by an import? This is the case if the feature

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -252,15 +252,21 @@ object NameOps {
     }
 
     def unmangle(kind: NameKind): N = likeSpacedN {
-      name replace {
-        case unmangled: SimpleName =>
-          kind.unmangle(unmangled)
-        case ExpandedName(prefix, last) =>
-          kind.unmangle(last) replace {
-            case kernel: SimpleName =>
-              ExpandedName(prefix, kernel)
+      name match
+        case name: SimpleName =>
+          kind.unmangle(name)
+        case name: TypeName =>
+          name.toTermName.unmangle(kind).toTypeName
+        case _ =>
+          name replace {
+            case unmangled: SimpleName =>
+              kind.unmangle(unmangled)
+            case ExpandedName(prefix, last) =>
+              kind.unmangle(last) replace {
+                case kernel: SimpleName =>
+                  ExpandedName(prefix, kernel)
+              }
           }
-      }
     }
 
     def unmangle(kinds: List[NameKind]): N = {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -191,23 +191,26 @@ class Typer extends Namer
         if found eq previous then checkNewOrShadowed(found, prevPrec)
         else found
 
-      def selection(imp: ImportInfo, name: Name, checkBounds: Boolean) =
-        if imp.sym.isCompleting then
-          report.warning(i"cyclic ${imp.sym}, ignored", pos)
-          NoType
-        else if unimported.nonEmpty && unimported.contains(imp.site.termSymbol) then
-          NoType
-        else
-          val pre = imp.site
-          var denot = pre.memberBasedOnFlags(name, required, EmptyFlags)
-            .accessibleFrom(pre)(using refctx)
+      def selection(imp: ImportInfo, name: Name, checkBounds: Boolean): Type =
+        imp.sym.info match
+          case ImportType(expr) =>
+            val pre = expr.tpe
+            var denot = pre.memberBasedOnFlags(name, required, EmptyFlags)
+              .accessibleFrom(pre)(using refctx)
             // Pass refctx so that any errors are reported in the context of the
             // reference instead of the context of the import scope
-          if checkBounds && denot.exists then
-            denot = denot.filterWithPredicate { mbr =>
-              mbr.matchesImportBound(if mbr.symbol.is(Given) then imp.givenBound else imp.wildcardBound)
-            }
-          if reallyExists(denot) then pre.select(name, denot) else NoType
+            if denot.exists then
+              if checkBounds then
+                denot = denot.filterWithPredicate { mbr =>
+                  mbr.matchesImportBound(if mbr.symbol.is(Given) then imp.givenBound else imp.wildcardBound)
+                }
+              if reallyExists(denot) then
+                if unimported.isEmpty || !unimported.contains(pre.termSymbol) then
+                  return pre.select(name, denot)
+          case _ =>
+            if imp.sym.isCompleting then
+              report.warning(i"cyclic ${imp.sym}, ignored", pos)
+        NoType
 
       /** The type representing a named import with enclosing name when imported
        *  from given `site` and `selectors`.
@@ -356,7 +359,7 @@ class Typer extends Namer
               if !curOwner.is(Package) || isDefinedInCurrentUnit(defDenot) then
                 result = checkNewOrShadowed(found, Definition) // no need to go further out, we found highest prec entry
                 found match
-                  case found: NamedType if ctx.owner.isClass && isInherited(found.denot) =>
+                  case found: NamedType if curOwner.isClass && isInherited(found.denot) =>
                     checkNoOuterDefs(found.denot, ctx, ctx)
                   case _ =>
               else
@@ -373,8 +376,8 @@ class Typer extends Namer
             val outer = ctx.outer
             val curImport = ctx.importInfo
             def updateUnimported() =
-              if (curImport.unimported.exists) unimported += curImport.unimported
-            if (ctx.owner.is(Package) && curImport != null && curImport.isRootImport && previous.exists)
+              if (curImport.unimported ne NoSymbol) unimported += curImport.unimported
+            if (curOwner.is(Package) && curImport != null && curImport.isRootImport && previous.exists)
               previous // no more conflicts possible in this case
             else if (isPossibleImport(NamedImport) && (curImport ne outer.importInfo)) {
               val namedImp = namedImportRef(curImport)


### PR DESCRIPTION
Some performance tweaks for warm methods. Essentially, try to test cheap conditions that narrow the possibilities
first and avoid some allocations.
