### PR TITLE
Drop ConstrainResult mode bit

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -60,9 +60,6 @@ object Mode {
    */
   val Printing: Mode = newMode(10, "Printing")
 
-  /** We are constraining a method based on its expected type. */
-  val ConstrainResult: Mode = newMode(11, "ConstrainResult")
-
   /** We are currently in a `viewExists` check. In that case, ambiguous
    *  implicits checks are disabled and we succeed with the first implicit
    *  found.


### PR DESCRIPTION
Use a TypeComparer variable instead. This saves ~60K fresh contexts
on typer/*.scala, which is roughtly 10%. It's also cleaner since it
avoids a global mode bit.