### PR TITLE
Use quote context for in tasty inspector

### DIFF
--- a/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
+++ b/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
@@ -1,6 +1,6 @@
 package scala.tasty.inspector
 
-import scala.tasty.Reflection
+import scala.quoted._
 
 import dotty.tools.dotc.Compiler
 import dotty.tools.dotc.Driver
@@ -18,7 +18,7 @@ trait TastyInspector:
   self =>
 
   /** Process a TASTy file using TASTy reflect */
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit
 
   /** Load and process TASTy files using TASTy reflect
    *
@@ -58,7 +58,7 @@ trait TastyInspector:
 
       override def run(implicit ctx: Context): Unit =
         val qctx = QuoteContextImpl()
-        self.processCompilationUnit(qctx.tasty)(ctx.compilationUnit.tpdTree.asInstanceOf[qctx.tasty.Tree])
+        self.processCompilationUnit(using qctx)(ctx.compilationUnit.tpdTree.asInstanceOf[qctx.tasty.Tree])
 
     end TastyInspectorPhase
 

--- a/tastydoc/src/dotty/tastydoc/TastyTypeConverter.scala
+++ b/tastydoc/src/dotty/tastydoc/TastyTypeConverter.scala
@@ -1,13 +1,13 @@
 package dotty.tastydoc
 
-import scala.tasty.Reflection
+import scala.quoted._
 import dotty.tastydoc.references._
 
 /** Trait containing methods for converting from Reflect types to References */
 trait TastyTypeConverter {
 
-  def convertTypeOrBoundsToReference(reflect: Reflection)(typeOrBounds: reflect.TypeOrBounds): Reference = {
-    import reflect.{given _, _}
+  def convertTypeOrBoundsToReference(using QuoteContext)(typeOrBounds: qctx.tasty.TypeOrBounds): Reference = {
+    import qctx.tasty._
 
     def anyOrNothing(reference: Reference): Boolean = reference match {
       case TypeReference("Any", "/scala", _, _) => true
@@ -16,24 +16,24 @@ trait TastyTypeConverter {
     }
 
     typeOrBounds match {
-      case tpe: Type => convertTypeToReference(reflect)(tpe)
+      case tpe: Type => convertTypeToReference(tpe)
       case TypeBounds(low, hi) =>
-        val lowRef = convertTypeToReference(reflect)(low)
-        val hiRef = convertTypeToReference(reflect)(hi)
+        val lowRef = convertTypeToReference(low)
+        val hiRef = convertTypeToReference(hi)
         if(hiRef == lowRef){
           hiRef
         }else{
           BoundsReference(lowRef, hiRef)
         }
-      case reflect.NoPrefix() => EmptyReference
+      case NoPrefix() => EmptyReference
     }
   }
 
-  def convertTypeToReference(reflect: Reflection)(tp: reflect.Type): Reference = {
-    import reflect.{given _, _}
+  def convertTypeToReference(using QuoteContext)(tp: qctx.tasty.Type): Reference = {
+    import qctx.tasty._
 
     //Inner method to avoid passing the reflection each time
-    def inner(tp: reflect.Type): Reference = tp match {
+    def inner(tp: Type): Reference = tp match {
       case OrType(left, right) => OrTypeReference(inner(left), inner(right))
       case AndType(left, right) => AndTypeReference(inner(left), inner(right))
       case ByNameType(tpe) => ByNameReference(inner(tpe))
@@ -42,13 +42,13 @@ trait TastyTypeConverter {
       case AnnotatedType(tpe, _) => inner(tpe)
       case TypeLambda(paramNames, paramTypes, resType) => ConstantReference(tp.show) //TOFIX
       case Refinement(parent, name, info) =>
-        val tuple = convertTypeOrBoundsToReference(reflect)(info) match {
+        val tuple = convertTypeOrBoundsToReference(info) match {
           case r if (info match {case info: TypeBounds => true case _ => false}) => ("type", name, r)
           case r@TypeReference(_, _, _, _) => ("val", name, r)
           case ByNameReference(rChild) => ("def", name, rChild)
           case r => throw new Exception("Match error in info of Refinement. This should not happen, please open an issue. " + r)
         }
-        convertTypeToReference(reflect)(parent) match {
+        convertTypeToReference(parent) match {
           case RefinedReference(p, ls) =>
             RefinedReference(p, ls:+tuple)
           case t => RefinedReference(t, List(tuple))
@@ -58,51 +58,51 @@ trait TastyTypeConverter {
           case TypeReference(label, link, _, hasOwnFile) =>
             if(link == "/scala"){
               if(label.matches("Function[1-9]") || label.matches("Function[1-9][0-9]")){
-                val argsAndReturn = typeOrBoundsList.map(convertTypeOrBoundsToReference(reflect)(_))
+                val argsAndReturn = typeOrBoundsList.map(convertTypeOrBoundsToReference(_))
                 FunctionReference(argsAndReturn.take(argsAndReturn.size - 1), argsAndReturn.last, false)
               }else if(label.matches("Tuple[1-9]") || label.matches("Tuple[1-9][0-9]")){
-                TupleReference(typeOrBoundsList.map(convertTypeOrBoundsToReference(reflect)(_)))
+                TupleReference(typeOrBoundsList.map(convertTypeOrBoundsToReference(_)))
               }else{
-                TypeReference(label, link, typeOrBoundsList.map(convertTypeOrBoundsToReference(reflect)(_)), hasOwnFile)
+                TypeReference(label, link, typeOrBoundsList.map(convertTypeOrBoundsToReference(_)), hasOwnFile)
               }
             }else{
-              TypeReference(label, link, typeOrBoundsList.map(convertTypeOrBoundsToReference(reflect)(_)), hasOwnFile)
+              TypeReference(label, link, typeOrBoundsList.map(convertTypeOrBoundsToReference(_)), hasOwnFile)
             }
           case _ => throw Exception("Match error in AppliedType. This should not happen, please open an issue. " + tp)
         }
       case tp @ TypeRef(qual, typeName) =>
-        convertTypeOrBoundsToReference(reflect)(qual) match {
+        convertTypeOrBoundsToReference(qual) match {
           case TypeReference(label, link, xs, _) => TypeReference(typeName, link + "/" + label, xs, true)
           case EmptyReference => TypeReference(typeName, "", Nil, true)
           case _ if tp.typeSymbol.exists =>
             tp.typeSymbol match {
               // NOTE: Only TypeRefs can reference ClassDefSymbols
               case sym if sym.isClassDef => //Need to be split because these types have their own file
-                convertTypeOrBoundsToReference(reflect)(qual) match {
+                convertTypeOrBoundsToReference(qual) match {
                   case TypeReference(label, link, xs, _) => TypeReference(sym.name, link + "/" + label, xs, true)
                   case EmptyReference if sym.name == "<root>" | sym.name == "_root_" => EmptyReference
                   case EmptyReference => TypeReference(sym.name, "", Nil, true)
-                  case _ => throw Exception("Match error in SymRef/TypeOrBounds/ClassDef. This should not happen, please open an issue. " + convertTypeOrBoundsToReference(reflect)(qual))
+                  case _ => throw Exception("Match error in SymRef/TypeOrBounds/ClassDef. This should not happen, please open an issue. " + convertTypeOrBoundsToReference(qual))
                 }
 
               // NOTE: This branch handles packages, which are now TypeRefs
               case sym if sym.isTerm || sym.isTypeDef =>
-                convertTypeOrBoundsToReference(reflect)(qual) match {
+                convertTypeOrBoundsToReference(qual) match {
                   case TypeReference(label, link, xs, _) => TypeReference(sym.name, link + "/" + label, xs)
                   case EmptyReference if sym.name == "<root>" | sym.name == "_root_" => EmptyReference
                   case EmptyReference => TypeReference(sym.name, "", Nil)
-                  case _ => throw Exception("Match error in SymRef/TypeOrBounds/Other. This should not happen, please open an issue. " + convertTypeOrBoundsToReference(reflect)(qual))
+                  case _ => throw Exception("Match error in SymRef/TypeOrBounds/Other. This should not happen, please open an issue. " + convertTypeOrBoundsToReference(qual))
                 }
               case sym => throw Exception("Match error in SymRef. This should not happen, please open an issue. " + sym)
             }
           case _ =>
-            throw Exception("Match error in TypeRef. This should not happen, please open an issue. " + convertTypeOrBoundsToReference(reflect)(qual))
+            throw Exception("Match error in TypeRef. This should not happen, please open an issue. " + convertTypeOrBoundsToReference(qual))
         }
       case TermRef(qual, typeName) =>
-        convertTypeOrBoundsToReference(reflect)(qual) match {
+        convertTypeOrBoundsToReference(qual) match {
           case TypeReference(label, link, xs, _) => TypeReference(typeName + "$", link + "/" + label, xs)
           case EmptyReference => TypeReference(typeName, "", Nil)
-          case _ => throw Exception("Match error in TermRef. This should not happen, please open an issue. " + convertTypeOrBoundsToReference(reflect)(qual))
+          case _ => throw Exception("Match error in TermRef. This should not happen, please open an issue. " + convertTypeOrBoundsToReference(qual))
         }
 
       // NOTE: old SymRefs are now either TypeRefs or TermRefs - the logic here needs to be moved into above branches

--- a/tastydoc/src/dotty/tastydoc/TastydocInspector.scala
+++ b/tastydoc/src/dotty/tastydoc/TastydocInspector.scala
@@ -12,6 +12,6 @@ import dotty.tastydoc.representations._
 class TastydocInspector(mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends TastyInspector {
 
   protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit = {
-    representations.convertToRepresentation(qctx.tasty)(root, None)(using mutablePackagesMap)
+    representations.convertToRepresentation(root, None)(using mutablePackagesMap)
   }
 }

--- a/tastydoc/src/dotty/tastydoc/TastydocInspector.scala
+++ b/tastydoc/src/dotty/tastydoc/TastydocInspector.scala
@@ -1,6 +1,6 @@
 package dotty.tastydoc
 
-import scala.tasty.Reflection
+import scala.quoted._
 import scala.tasty.inspector.TastyInspector
 
 import dotty.tastydoc.representations._
@@ -11,9 +11,7 @@ import dotty.tastydoc.representations._
  */
 class TastydocInspector(mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends TastyInspector {
 
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit = {
-    import reflect._
-
-    representations.convertToRepresentation(reflect)(root, None)(using mutablePackagesMap)
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit = {
+    representations.convertToRepresentation(qctx.tasty)(root, None)(using mutablePackagesMap)
   }
 }

--- a/tastydoc/src/dotty/tastydoc/representations.scala
+++ b/tastydoc/src/dotty/tastydoc/representations.scala
@@ -5,6 +5,8 @@ import scala.annotation.tailrec
 import dotty.tastydoc.comment.Comment
 import dotty.tastydoc.references._
 
+// TODO pass QuoteContext around insead of Reflection
+
 object representations extends TastyExtractor {
 
   trait Representation {

--- a/tastydoc/src/dotty/tastydoc/representations.scala
+++ b/tastydoc/src/dotty/tastydoc/representations.scala
@@ -1,11 +1,9 @@
 package dotty.tastydoc
 
-import scala.tasty.Reflection
+import scala.quoted._
 import scala.annotation.tailrec
 import dotty.tastydoc.comment.Comment
 import dotty.tastydoc.references._
-
-// TODO pass QuoteContext around insead of Reflection
 
 object representations extends TastyExtractor {
 
@@ -84,18 +82,18 @@ object representations extends TastyExtractor {
     }
   }
 
-  class PackageRepresentation(reflect: Reflection, internal: reflect.PackageClause, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Members {
-    import reflect.{given _, _}
+  class PackageRepresentation(using QuoteContext)(internal: qctx.tasty.PackageClause, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Members {
+    import qctx.tasty._
 
     override val (name, path) = extractPackageNameAndPath(internal.pid.show)
-    override val members = internal.stats.map(convertToRepresentation(reflect)(_, Some(this)))
-    override val annotations = extractAnnotations(reflect)(internal.symbol.annots)
+    override val members = internal.stats.map(convertToRepresentation(_, Some(this)))
+    override val annotations = extractAnnotations(internal.symbol.annots)
 
-    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(reflect)(internal.symbol.comment, this)(packages, userDocSyntax)
+    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.comment, this)(packages, userDocSyntax)
   }
 
-  class ImportRepresentation(reflect: Reflection, internal: reflect.Import, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation {
-    import reflect.{given _, _}
+  class ImportRepresentation(using QuoteContext)(internal: qctx.tasty.Import, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation {
+    import qctx.tasty._
 
     override val name = if (internal.selectors.size > 1){
         internal.selectors.map(_.toString).mkString("{", ", ", "}")
@@ -103,101 +101,101 @@ object representations extends TastyExtractor {
         internal.selectors.head.toString
       }
     override val path = internal.expr.symbol.show.split("\\.").toList
-    override val annotations = extractAnnotations(reflect)(internal.symbol.annots)
+    override val annotations = extractAnnotations(internal.symbol.annots)
 
-    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(reflect)(internal.symbol.comment, this)(packages, userDocSyntax)
+    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.comment, this)(packages, userDocSyntax)
   }
 
-  class ClassRepresentation(reflect: Reflection, internal: reflect.ClassDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Members with Parents with Modifiers with Companion with Constructors with TypeParams {
-    import reflect.{given _, _}
+  class ClassRepresentation(using QuoteContext)(internal: qctx.tasty.ClassDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Members with Parents with Modifiers with Companion with Constructors with TypeParams {
+    import qctx.tasty._
 
-    override val path = extractPath(reflect)(internal.symbol)
-    override val parents = extractParents(reflect)(internal.parents)
-    override val (modifiers, privateWithin, protectedWithin) = extractModifiers(reflect)(internal.symbol.flags, internal.symbol.privateWithin, internal.symbol.protectedWithin)
+    override val path = extractPath(internal.symbol)
+    override val parents = extractParents(internal.parents)
+    override val (modifiers, privateWithin, protectedWithin) = extractModifiers(internal.symbol.flags, internal.symbol.privateWithin, internal.symbol.protectedWithin)
     override val constructors =
-      (convertToRepresentation(reflect)(internal.constructor, Some(this)) ::
+      (convertToRepresentation(internal.constructor, Some(this)) ::
       (internal.body.flatMap{_ match {
-        case d: reflect.DefDef => if(d.name == "<init>") Some(d) else None
+        case d: DefDef => if(d.name == "<init>") Some(d) else None
         case _ => None
         }
-      }.map(convertToRepresentation(reflect)(_, Some(this)))
+      }.map(convertToRepresentation(_, Some(this)))
       )).flatMap{r => r match {
         case r: DefRepresentation => Some(r)
         case _ => None
         }
       }
     override val typeParams = internal.constructor.typeParams.map(x => x.show.stripPrefix("type "))
-    override val annotations = extractAnnotations(reflect)(internal.symbol.annots)
+    override val annotations = extractAnnotations(internal.symbol.annots)
     var knownSubclasses: List[Reference] = Nil
 
-    val (isCase, isTrait, isObject, kind) = extractKind(reflect)(internal.symbol.flags)
+    val (isCase, isTrait, isObject, kind) = extractKind(internal.symbol.flags)
 
     override val name = internal.name
 
-    override val companion = extractCompanion(reflect)(
+    override val companion = extractCompanion(
       Some(internal.symbol.companionModule).filter(_.exists), // TODO: refactor later, there is now a NoSymbol
       Some(internal.symbol.companionClass).filter(_.exists), // TODO: refactor later, there is now a NoSymbol
       !isObject
     )
-    override val members: List[Representation with Modifiers] = extractClassMembers(reflect)(internal.body, internal.symbol, Some(this))
+    override val members: List[Representation with Modifiers] = extractClassMembers(internal.body, internal.symbol, Some(this))
 
-    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(reflect)(internal.symbol.comment, this)(packages, userDocSyntax)
+    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.comment, this)(packages, userDocSyntax)
   }
 
-  class DefRepresentation(reflect: Reflection, internal: reflect.DefDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with TypeParams with MultipleParamList with ReturnValue {
-    import reflect.{given _, _}
+  class DefRepresentation(using QuoteContext)(internal: qctx.tasty.DefDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with TypeParams with MultipleParamList with ReturnValue {
+    import qctx.tasty._
 
     override val name = internal.name
-    override val path = extractPath(reflect)(internal.symbol)
-    override val (modifiers, privateWithin, protectedWithin) = extractModifiers(reflect)(internal.symbol.flags, internal.symbol.privateWithin, internal.symbol.protectedWithin)
+    override val path = extractPath(internal.symbol)
+    override val (modifiers, privateWithin, protectedWithin) = extractModifiers(internal.symbol.flags, internal.symbol.privateWithin, internal.symbol.protectedWithin)
     override val typeParams = internal.typeParams.map(x => x.show.stripPrefix("type "))
 
     override val paramLists = internal.paramss.map{p =>
       new ParamList {
-        override val list = p.map(x => NamedReference(x.name, convertTypeToReference(reflect)(x.tpt.tpe)))
+        override val list = p.map(x => NamedReference(x.name, convertTypeToReference(x.tpt.tpe)))
         override val isImplicit = if(p.nonEmpty) p.head.symbol.flags.is(Flags.Implicit) else false
       }
     }
-    override val returnValue = convertTypeToReference(reflect)(internal.returnTpt.tpe)
-    override val annotations = extractAnnotations(reflect)(internal.symbol.annots)
-    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(reflect)(internal.symbol.comment, this)(packages, userDocSyntax)
+    override val returnValue = convertTypeToReference(internal.returnTpt.tpe)
+    override val annotations = extractAnnotations(internal.symbol.annots)
+    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.comment, this)(packages, userDocSyntax)
   }
 
-  class ValRepresentation(reflect: Reflection, internal: reflect.ValDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with ReturnValue {
-    import reflect.{given _, _}
+  class ValRepresentation(using QuoteContext)(internal: qctx.tasty.ValDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with ReturnValue {
+    import qctx.tasty._
 
     override val name = internal.name
-    override val path = extractPath(reflect)(internal.symbol)
-    override val (modifiers, privateWithin, protectedWithin) = extractModifiers(reflect)(internal.symbol.flags, internal.symbol.privateWithin, internal.symbol.protectedWithin)
-    override val returnValue = convertTypeToReference(reflect)(internal.tpt.tpe)
-    override val annotations = extractAnnotations(reflect)(internal.symbol.annots)
+    override val path = extractPath(internal.symbol)
+    override val (modifiers, privateWithin, protectedWithin) = extractModifiers(internal.symbol.flags, internal.symbol.privateWithin, internal.symbol.protectedWithin)
+    override val returnValue = convertTypeToReference(internal.tpt.tpe)
+    override val annotations = extractAnnotations(internal.symbol.annots)
     val isVar: Boolean = internal.symbol.flags.is(Flags.Mutable)
 
-    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(reflect)(internal.symbol.comment, this)(packages, userDocSyntax)
+    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.comment, this)(packages, userDocSyntax)
   }
 
-  class TypeRepresentation(reflect: Reflection, internal: reflect.TypeDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with TypeParams {
-    import reflect.{given _, _}
+  class TypeRepresentation(using QuoteContext)(internal: qctx.tasty.TypeDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with TypeParams {
+    import qctx.tasty._
 
     override val name = internal.name
-    override val path = extractPath(reflect)(internal.symbol)
-    override val (modifiers, privateWithin, protectedWithin) = extractModifiers(reflect)(internal.symbol.flags, internal.symbol.privateWithin, internal.symbol.protectedWithin)
+    override val path = extractPath(internal.symbol)
+    override val (modifiers, privateWithin, protectedWithin) = extractModifiers(internal.symbol.flags, internal.symbol.privateWithin, internal.symbol.protectedWithin)
     override val typeParams = Nil
-    override val annotations = extractAnnotations(reflect)(internal.symbol.annots)
+    override val annotations = extractAnnotations(internal.symbol.annots)
     val alias: Option[Reference] = internal.rhs match{
-      case t: TypeBoundsTree => Some(convertTypeOrBoundsToReference(reflect)(t.tpe))
-      case t: TypeTree => Some(convertTypeOrBoundsToReference(reflect)(t.tpe.asInstanceOf[reflect.TypeOrBounds]))
+      case t: TypeBoundsTree => Some(convertTypeOrBoundsToReference(t.tpe))
+      case t: TypeTree => Some(convertTypeOrBoundsToReference(t.tpe.asInstanceOf[TypeOrBounds]))
       case _ => None
     }
     override def isAbstract: Boolean = !alias.isDefined
-    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(reflect)(internal.symbol.comment, this)(packages, userDocSyntax)
+    override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.comment, this)(packages, userDocSyntax)
   }
 
-  def convertToRepresentation(reflect: Reflection)(tree: reflect.Tree, parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]): Representation = {
-    import reflect.{given _, _}
+  def convertToRepresentation(using QuoteContext)(tree: qctx.tasty.Tree, parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]): Representation = {
+    import qctx.tasty._
 
     tree match {
-      case t: reflect.PackageClause =>
+      case t: PackageClause =>
         val noColorPid = t.pid.symbol.show
         val emulatedPackage = mutablePackagesMap.get(noColorPid) match {
           case Some(x) => x
@@ -207,19 +205,19 @@ object representations extends TastyExtractor {
             mutablePackagesMap += ((noColorPid, x))
             x
         }
-        val r = new PackageRepresentation(reflect, t, parentRepresentation)
+        val r = new PackageRepresentation()(t, parentRepresentation)
         emulatedPackage.packagesMembers = r :: emulatedPackage.packagesMembers
         r
 
-      case t: reflect.Import => new ImportRepresentation(reflect, t, parentRepresentation)
+      case t: Import => new ImportRepresentation()(t, parentRepresentation)
 
-      case t: reflect.ClassDef => new ClassRepresentation(reflect, t, parentRepresentation)
+      case t: ClassDef => new ClassRepresentation()(t, parentRepresentation)
 
-      case t: reflect.DefDef => new DefRepresentation(reflect, t, parentRepresentation)
+      case t: DefDef => new DefRepresentation()(t, parentRepresentation)
 
-      case t: reflect.ValDef => new ValRepresentation(reflect, t, parentRepresentation)
+      case t: ValDef => new ValRepresentation()(t, parentRepresentation)
 
-      case t: reflect.TypeDef => new TypeRepresentation(reflect, t, parentRepresentation)
+      case t: TypeDef => new TypeRepresentation()(t, parentRepresentation)
 
       case _ => throw new Exception("Tree match error in conversion to representation. Please open an issue. " + tree)
   }}

--- a/tests/run-custom-args/tasty-inspector/i8163.scala
+++ b/tests/run-custom-args/tasty-inspector/i8163.scala
@@ -1,4 +1,4 @@
-import scala.tasty.Reflection
+import scala.quoted._
 import scala.tasty.inspector._
 
 opaque type PhoneNumber = String
@@ -16,16 +16,15 @@ object Test {
 
 class TestInspector() extends TastyInspector:
 
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit =
-    import reflect._
-    inspectClass(reflect)(root)
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit =
+    inspectClass(root)
 
-  private def inspectClass(reflect: Reflection)(tree: reflect.Tree): Unit =
-    import reflect.{given _, _}
+  private def inspectClass(using QuoteContext)(tree: qctx.tasty.Tree): Unit =
+    import qctx.tasty._
     tree match {
-      case t: reflect.PackageClause =>
-        t.stats.map( m => inspectClass(reflect)(m) )
-      case t: reflect.ClassDef if !t.name.endsWith("$") =>
+      case t: PackageClause =>
+        t.stats.map( m => inspectClass(m) )
+      case t: ClassDef if !t.name.endsWith("$") =>
         val interestingVals = t.body.collect {
           case v: ValDef => v
         }

--- a/tests/run-custom-args/tasty-inspector/i8215.scala
+++ b/tests/run-custom-args/tasty-inspector/i8215.scala
@@ -1,4 +1,4 @@
-import scala.tasty.Reflection
+import scala.quoted._
 import scala.tasty.inspector._
 
 case class I8215(id: String)
@@ -35,7 +35,7 @@ class TestInspector_NonTasty() extends TastyInspector:
   var isScala2: Boolean = false
   var className: String = ""
 
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit =
-    isJava = reflect.Source.isJavaCompilationUnit
-    isScala2 = reflect.Source.isScala2CompilationUnit
-    className = reflect.Source.compilationUnitClassname
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit =
+    isJava = qctx.tasty.Source.isJavaCompilationUnit
+    isScala2 = qctx.tasty.Source.isScala2CompilationUnit
+    className = qctx.tasty.Source.compilationUnitClassname

--- a/tests/run-custom-args/tasty-inspector/i8364.scala
+++ b/tests/run-custom-args/tasty-inspector/i8364.scala
@@ -1,10 +1,9 @@
-import scala.tasty._
+import scala.quoted._
 import scala.tasty.inspector._
 
 @main def Test = {
   val inspector = new TastyInspector {
-    def processCompilationUnit(reflect: Reflection)(tree: reflect.Tree): Unit = {
-      import reflect.{_, given _}
+    protected def processCompilationUnit(using QuoteContext)(tree: qctx.tasty.Tree): Unit = {
       println(tree.show)
     }
   }

--- a/tests/run-custom-args/tasty-inspector/i8389.scala
+++ b/tests/run-custom-args/tasty-inspector/i8389.scala
@@ -1,11 +1,10 @@
-import scala.tasty._
+import scala.quoted._
 import scala.tasty.inspector._
 
 @main def Test = {
   // in dotty-example-project
   val inspector = new TastyInspector {
-    def processCompilationUnit(reflect: Reflection)(tree: reflect.Tree): Unit = {
-      import reflect.{_, given _}
+    protected def processCompilationUnit(using QuoteContext)(tree: qctx.tasty.Tree): Unit = {
       println(tree.show)
     }
   }

--- a/tests/run-custom-args/tasty-inspector/i8460.scala
+++ b/tests/run-custom-args/tasty-inspector/i8460.scala
@@ -1,4 +1,4 @@
-import scala.tasty.Reflection
+import scala.quoted._
 import scala.tasty.inspector._
 
 // Ambiguous member names
@@ -32,16 +32,16 @@ class TestInspector_Children() extends TastyInspector:
 
   var kids: List[String] = Nil
 
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit =
-    import reflect._
-    inspectClass(reflect)(root)
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit =
+    import qctx.tasty._
+    inspectClass(root)
 
-  private def inspectClass(reflect: Reflection)(tree: reflect.Tree): Unit =
-    import reflect.{given _, _}
+  private def inspectClass(using QuoteContext)(tree: qctx.tasty.Tree): Unit =
+    import qctx.tasty._
     tree match {
-      case t: reflect.PackageClause =>
-        t.stats.map( m => inspectClass(reflect)(m) )
-      case t: reflect.ClassDef =>
+      case t: PackageClause =>
+        t.stats.map( m => inspectClass(m) )
+      case t: ClassDef =>
         kids = t.symbol.children.map(_.fullName)
 
       case x =>

--- a/tests/run-custom-args/tasty-inspector/i8558.scala
+++ b/tests/run-custom-args/tasty-inspector/i8558.scala
@@ -1,4 +1,4 @@
-import scala.tasty.Reflection
+import scala.quoted._
 import scala.tasty.inspector._
 
 object Test {
@@ -17,6 +17,6 @@ class TestInspector_NonTasty() extends TastyInspector:
   var isAlreadyLoaded: Boolean = false
   var className: String = ""
 
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit =
-    isAlreadyLoaded = reflect.Source.isAlreadyLoadedCompilationUnit
-    className = reflect.Source.compilationUnitClassname
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit =
+    isAlreadyLoaded = qctx.tasty.Source.isAlreadyLoadedCompilationUnit
+    className = qctx.tasty.Source.compilationUnitClassname

--- a/tests/run-custom-args/tasty-inspector/tasty-comment-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-comment-inspector/Test.scala
@@ -1,4 +1,4 @@
-import scala.tasty.Reflection
+import scala.quoted._
 import scala.tasty.inspector._
 
 object Test {
@@ -9,8 +9,8 @@ object Test {
 
 class CommentInspector extends TastyInspector {
 
-  def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit = {
-    import reflect.{_, given _}
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit = {
+    import qctx.tasty._
     object Traverser extends TreeTraverser {
 
       override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
@@ -25,7 +25,7 @@ class CommentInspector extends TastyInspector {
       }
 
     }
-    Traverser.traverseTree(root)(reflect.rootContext)
+    Traverser.traverseTree(root)
   }
 
 }

--- a/tests/run-custom-args/tasty-inspector/tasty-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-inspector/Test.scala
@@ -1,4 +1,4 @@
-import scala.tasty.Reflection
+import scala.quoted._
 import scala.tasty.inspector._
 
 object Test {
@@ -9,8 +9,8 @@ object Test {
 
 class DBInspector extends TastyInspector {
 
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit = {
-    import reflect.{_, given _}
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit = {
+    import qctx.tasty._
     object Traverser extends TreeTraverser {
 
       override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
@@ -22,7 +22,7 @@ class DBInspector extends TastyInspector {
       }
 
     }
-    Traverser.traverseTree(root)(reflect.rootContext)
+    Traverser.traverseTree(root)
   }
 
 }

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
@@ -1,12 +1,12 @@
 package scala.tasty.interpreter
 
-import scala.tasty.Reflection
+import scala.quoted._
 import scala.tasty.inspector.TastyInspector
 
 class TastyInterpreter extends TastyInspector {
 
-  protected def processCompilationUnit(reflect: Reflection)(root: reflect.Tree): Unit = {
-    import reflect.{_, given _}
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit = {
+    import qctx.tasty._
     object Traverser extends TreeTraverser {
 
       override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
@@ -20,6 +20,6 @@ class TastyInterpreter extends TastyInspector {
           super.traverseTree(tree)
       }
     }
-    Traverser.traverseTree(root)(reflect.rootContext)
+    Traverser.traverseTree(root)
   }
 }


### PR DESCRIPTION
* Align API with other metaprogramming APIs
* Allow use of extractors from `scala.quoted` and quoted pattern
* Enable use of `Reflection.typeOf`
* Adapt code of tastydoc to use `QuoteContext`