### PR TITLE
Re-enable parallel pickling

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/CommentPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/CommentPickler.scala
@@ -1,6 +1,6 @@
 package dotty.tools.dotc.core.tasty
 
-import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.ast.{tpd, untpd}
 import dotty.tools.dotc.core.Comments.{Comment, CommentsContext, ContextDocstrings}
 import dotty.tools.dotc.core.Contexts._
 
@@ -9,36 +9,36 @@ import TastyBuffer.{Addr, NoAddr}
 
 import java.nio.charset.Charset
 
-class CommentPickler(pickler: TastyPickler, addrOfTree: tpd.Tree => Addr)(using Context) {
+class CommentPickler(pickler: TastyPickler, addrOfTree: tpd.Tree => Addr, docString: untpd.MemberDef => Option[Comment]):
   private val buf = new TastyBuffer(5000)
   pickler.newSection("Comments", buf)
 
-  def pickleComment(root: tpd.Tree): Unit = {
-    assert(ctx.docCtx.isDefined, "Trying to pickle comments, but there's no `docCtx`.")
-    new Traverser(ctx.docCtx.get).traverse(root)
-  }
+  def pickleComment(root: tpd.Tree): Unit = traverse(root)
 
-  def pickleComment(addr: Addr, comment: Option[Comment]): Unit = comment match {
-    case Some(cmt) if addr != NoAddr =>
-      val bytes = cmt.raw.getBytes(Charset.forName("UTF-8"))
+  private def pickleComment(addr: Addr, comment: Comment): Unit =
+    if addr != NoAddr then
+      val bytes = comment.raw.getBytes(Charset.forName("UTF-8"))
       val length = bytes.length
       buf.writeAddr(addr)
       buf.writeNat(length)
       buf.writeBytes(bytes, length)
-      buf.writeLongInt(cmt.span.coords)
-    case other =>
-      ()
-  }
+      buf.writeLongInt(comment.span.coords)
 
-  private class Traverser(docCtx: ContextDocstrings) extends tpd.TreeTraverser {
-    override def traverse(tree: tpd.Tree)(using Context): Unit =
-      tree match {
-        case md: tpd.MemberDef =>
-          val comment = docCtx.docstring(md.symbol)
-          pickleComment(addrOfTree(md), comment)
-          traverseChildren(md)
+  private def traverse(x: Any): Unit = x match
+    case x: untpd.Tree @unchecked =>
+      x match
+        case x: tpd.MemberDef @unchecked => // at this point all MembderDefs are t(y)p(e)d.
+          for comment <- docString(x) do pickleComment(addrOfTree(x), comment)
         case _ =>
-          traverseChildren(tree)
-      }
-  }
-}
+      val limit = x.productArity
+      var n = 0
+      while n < limit do
+        traverse(x.productElement(n))
+        n += 1
+    case y :: ys =>
+      traverse(y)
+      traverse(ys)
+    case _ =>
+
+end CommentPickler
+

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
@@ -177,12 +177,11 @@ class TreeBuffer extends TastyBuffer(50000) {
     //println(s"offsets: ${offsets.take(numOffsets).deep}")
     //println(s"deltas: ${delta.take(numOffsets).deep}")
     var saved = 0
-    while ({
+    while
       saved = adjustDeltas()
       pickling.println(s"adjusting deltas, saved = $saved")
       saved > 0 && length / saved < 100
-    })
-    ()
+    do ()
     adjustOffsets()
     adjustTreeAddrs()
     val wasted = compress()

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -51,41 +51,48 @@ class Pickler extends Phase {
     val unit = ctx.compilationUnit
     pickling.println(i"unpickling in run ${ctx.runId}")
 
-    for {
+    for
       cls <- dropCompanionModuleClasses(topLevelClasses(unit.tpdTree))
       tree <- sliceTopLevel(unit.tpdTree, cls)
-    }
-    {
+    do
       val pickler = new TastyPickler(cls)
       if ctx.settings.YtestPickler.value then
         beforePickling(cls) = tree.show
         picklers(cls) = pickler
       val treePkl = pickler.treePkl
       treePkl.pickle(tree :: Nil)
-      val pickledF = Future {
-        treePkl.compactify()
-        if tree.span.exists then
-          new PositionPickler(pickler, treePkl.buf.addrOfTree).picklePositions(tree :: Nil)
+      val positionWarnings = new mutable.ListBuffer[String]()
+      val parContext = ctx.fresh // TODO refine
+      val pickledF = inContext(parContext) {
+        Future {
+          treePkl.compactify()
+          if tree.span.exists then
+            new PositionPickler(pickler, treePkl.buf.addrOfTree, treePkl.treeAnnots)
+              .picklePositions(tree :: Nil, positionWarnings)
 
-        if !ctx.settings.YdropComments.value then
-          new CommentPickler(pickler, treePkl.buf.addrOfTree).pickleComment(tree)
+          if !ctx.settings.YdropComments.value then
+            new CommentPickler(pickler, treePkl.buf.addrOfTree).pickleComment(tree)
 
-        val pickled = pickler.assembleParts()
+          val pickled = pickler.assembleParts()
 
-        def rawBytes = // not needed right now, but useful to print raw format.
-          pickled.iterator.grouped(10).toList.zipWithIndex.map {
-            case (row, i) => s"${i}0: ${row.mkString(" ")}"
-          }
+          def rawBytes = // not needed right now, but useful to print raw format.
+            pickled.iterator.grouped(10).toList.zipWithIndex.map {
+              case (row, i) => s"${i}0: ${row.mkString(" ")}"
+            }
 
-        // println(i"rawBytes = \n$rawBytes%\n%") // DEBUG
-        if pickling ne noPrinter then
-          pickling.synchronized {
-            println(i"**** pickled info of $cls")
-            println(new TastyPrinter(pickled).printContents())
-          }
-        pickled
-      }(using ExecutionContext.global)
-      def force(): Array[Byte] = Await.result(pickledF, Duration.Inf)
+          // println(i"rawBytes = \n$rawBytes%\n%") // DEBUG
+          if pickling ne noPrinter then
+            pickling.synchronized {
+              println(i"**** pickled info of $cls")
+              println(new TastyPrinter(pickled).printContents())
+            }
+          pickled
+        }(using ExecutionContext.global)
+      }
+      def force(): Array[Byte] =
+        val result = Await.result(pickledF, Duration.Inf)
+        positionWarnings.foreach(report.warning(_))
+        result
 
       // Turn off parallelism because it lead to non-deterministic CI failures:
       // - https://github.com/lampepfl/dotty/runs/1029579877?check_suite_focus=true#step:10:967
@@ -98,7 +105,7 @@ class Pickler extends Phase {
       if !ctx.settings.YparallelPickler.value then force()
 
       unit.pickled += (cls -> force)
-    }
+    end for
   }
 
   override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] = {

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -62,8 +62,7 @@ class Pickler extends Phase {
       val treePkl = pickler.treePkl
       treePkl.pickle(tree :: Nil)
       val positionWarnings = new mutable.ListBuffer[String]()
-      val parContext = ctx.fresh // TODO refine
-      val pickledF = inContext(parContext) {
+      val pickledF = inContext(ctx.fresh) {
         Future {
           treePkl.compactify()
           if tree.span.exists then
@@ -71,7 +70,8 @@ class Pickler extends Phase {
               .picklePositions(tree :: Nil, positionWarnings)
 
           if !ctx.settings.YdropComments.value then
-            new CommentPickler(pickler, treePkl.buf.addrOfTree).pickleComment(tree)
+            new CommentPickler(pickler, treePkl.buf.addrOfTree, treePkl.docString)
+              .pickleComment(tree)
 
           val pickled = pickler.assembleParts()
 


### PR DESCRIPTION
Both position and comment pickler accessed symbols in trees. Position pickler also accessed denotations through symbols.
This is a potential race since both operations depend on phase-indexed caches, which are not protected. 

We now avoid the problem by pre-computing everything position and comment pickler need from symbols, and passing it separately to them. Neither position nor tree pickler takes a context anymore, which means they cannot possibly interfere
with the rest -- or, rather, they can interfere only through global variables, the same way a parallel compiler testing thread does. But we have that well under control through the existing static race detection mechanism.

