### PR TITLE
Publish dotty-library-bootstrappedJS for sbt-dotty/scripted.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1192,6 +1192,7 @@ object Build {
         publishLocal in `dotty-interfaces`,
         publishLocal in `dotty-compiler-bootstrapped`,
         publishLocal in `dotty-library-bootstrapped`,
+        publishLocal in `dotty-library-bootstrappedJS`,
         publishLocal in `tasty-core-bootstrapped`,
         publishLocal in `dotty-staging`,
         publishLocal in `dotty-tasty-inspector`,


### PR DESCRIPTION
I tested that locally from a clean `.ivy2/local` and clean build. But to be sure, is there a way to run the `test_sbt` workflow for this PR?