### PR TITLE
Fix #9572: Workaround issue #9655

### DIFF
--- a/library/src/dotty/DottyPredef.scala
+++ b/library/src/dotty/DottyPredef.scala
@@ -47,7 +47,7 @@ object DottyPredef {
    *           }}}
    *  @group utilities
    */
-  inline def locally[T](inline body: T): T = body
+  inline def locally[T](/*inline*/ body: T): T = body // FIXME add `inline` param when #9655 is fixed
 
   /**
    * Retrieve the single value of a type with a unique inhabitant.

--- a/tests/pos/i9572.scala
+++ b/tests/pos/i9572.scala
@@ -1,0 +1,6 @@
+trait JsonSchemas {
+  locally {
+    sealed trait Status
+    case object Active extends Status
+  }
+}


### PR DESCRIPTION
Support for `Predef.locally` is more pressing than the general bug fix as this can be encountered in Scala 2 code.