### PR TITLE
fix #9667: recurse on classBound for local classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -359,7 +359,13 @@ object TypeOps:
               parent.derivesFrom(defn.SelectableClass)
           }
       if needsRefinement then
-        RefinedType(parent, decl.name, decl.info)
+        var refinfo = decl.info
+        val tpSym = refinfo.typeSymbol
+        if tpSym.exists && tpSym.isClass && tpSym.ownersIterator.exists(_ eq cls) then
+          val clsImpl = refinfo.classSymbol
+          if clsImpl.exists then
+            refinfo = classBound(clsImpl.asClass.classInfo) // if decl.info is a locally defined class then recur
+        RefinedType(parent, decl.name, refinfo)
           .reporting(i"add ref $parent $decl --> " + result, typr)
       else parent
     }

--- a/tests/neg/i9667.scala
+++ b/tests/neg/i9667.scala
@@ -1,0 +1,21 @@
+trait Bundle extends reflect.Selectable
+
+val foo = new Bundle {
+  object Foo {
+    def bar = 23
+  }
+}
+
+val bar = new Bundle {
+  class Xyz extends Bundle { def xyz = 31 }
+  val ref: Xyx = Xyz() // error: Not found: type Xyx
+}
+
+val baz = new Bundle {
+  class Xyz { def xyz = 31 }
+  val ref: Xyz = Xyz()
+}
+
+def test =
+  assert(foo.Foo.bar == 23) // error: bar is not a member of Object
+  assert(baz.ref.xyz) // error: xyz is not a member of Object

--- a/tests/run/i9667.scala
+++ b/tests/run/i9667.scala
@@ -1,0 +1,31 @@
+trait Bundle extends reflect.Selectable
+
+trait HasFoo { def foo = 23 }
+
+@main def Test: Unit =
+  val foo = new Bundle { object Foo extends HasFoo }
+  val bar = new Bundle { object Bar extends Bundle { def bar = 47 } }
+  val baz = new Bundle {
+    class Xyz extends Bundle { def xyz = 31 }
+    val ref: Xyz = Xyz()
+  }
+  val qux = new Bundle {
+    object Deferred {
+      class Qux extends Bundle {
+        def qux = 71
+      }
+    }
+    val Qux = Deferred.Qux()
+  }
+  val quux = new Bundle {
+    object Deferred extends Bundle {
+      object Quux extends Bundle {
+        def quux = 93
+      }
+    }
+  }
+  assert(foo.Foo.foo == 23)
+  assert(bar.Bar.bar == 47)
+  assert(baz.ref.xyz == 31)
+  assert(qux.Qux.qux == 71)
+  assert(quux.Deferred.Quux.quux == 93)


### PR DESCRIPTION
what is done here is to infer the upper bound of values in a refinement that refer to locally defined classes by using the same rules

fixes #9667 