### PR TITLE
Use util Collections more widely

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -22,7 +22,7 @@ import Symbols._
 import Phases._
 
 import dotty.tools.dotc.util
-import dotty.tools.dotc.util.Spans
+import dotty.tools.dotc.util.{Spans, ReadOnlyMap}
 import dotty.tools.dotc.report
 
 import Decorators._
@@ -36,7 +36,7 @@ import Names.TermName
 import Annotations.Annotation
 import Names.Name
 
-class DottyBackendInterface(val outputDirectory: AbstractFile, val superCallsMap: Map[Symbol, Set[ClassSymbol]])(using val ctx: Context) {
+class DottyBackendInterface(val outputDirectory: AbstractFile, val superCallsMap: ReadOnlyMap[Symbol, Set[ClassSymbol]])(using val ctx: Context) {
 
   private val desugared = new java.util.IdentityHashMap[Type, tpd.Select]
 

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -36,7 +36,7 @@ import dotty.tools.io._
 class GenBCode extends Phase {
   def phaseName: String = GenBCode.name
 
-  private val superCallsMap = newMutableSymbolMap[Set[ClassSymbol]]
+  private val superCallsMap = new MutableSymbolMap[Set[ClassSymbol]]
   def registerSuperCall(sym: Symbol, calls: ClassSymbol): Unit = {
     val old = superCallsMap.getOrElse(sym, Set.empty)
     superCallsMap.update(sym, old + calls)
@@ -51,10 +51,8 @@ class GenBCode extends Phase {
   }
 
   def run(using Context): Unit =
-    new GenBCodePipeline(
-      new DottyBackendInterface(
-        outputDir, superCallsMap.toMap
-      )
+    GenBCodePipeline(
+      DottyBackendInterface(outputDir, superCallsMap)
     ).run(ctx.compilationUnit.tpdTree)
 
 

--- a/compiler/src/dotty/tools/backend/jvm/scalaPrimitives.scala
+++ b/compiler/src/dotty/tools/backend/jvm/scalaPrimitives.scala
@@ -9,6 +9,7 @@ import Names.TermName, StdNames._
 import Types.{JavaArrayType, UnspecifiedErrorType, Type}
 import Symbols.{Symbol, NoSymbol}
 import dotc.report
+import dotc.util.ReadOnlyMap
 
 import scala.annotation.threadUnsafe
 import scala.collection.immutable
@@ -34,7 +35,7 @@ import scala.collection.immutable
 class DottyPrimitives(ictx: Context) {
   import dotty.tools.backend.ScalaPrimitivesOps._
 
-  @threadUnsafe private lazy val primitives: immutable.Map[Symbol, Int] = init
+  @threadUnsafe private lazy val primitives: ReadOnlyMap[Symbol, Int] = init
 
   /** Return the code for the given symbol. */
   def getPrimitive(sym: Symbol): Int = {
@@ -118,12 +119,12 @@ class DottyPrimitives(ictx: Context) {
   }
 
   /** Initialize the primitive map */
-  private def init: immutable.Map[Symbol, Int]  = {
+  private def init: ReadOnlyMap[Symbol, Int]  = {
 
     given Context = ictx
 
     import Symbols.defn
-    val primitives = Symbols.newMutableSymbolMap[Int]
+    val primitives = Symbols.MutableSymbolMap[Int](512)
 
     /** Add a primitive operation to the map */
     def addPrimitive(s: Symbol, code: Int): Unit = {
@@ -394,7 +395,7 @@ class DottyPrimitives(ictx: Context) {
     addPrimitives(DoubleClass, nme.UNARY_-, NEG)
 
 
-    primitives.toMap
+    primitives
   }
 
   def isPrimitive(sym: Symbol): Boolean =

--- a/compiler/src/dotty/tools/backend/sjs/JSPrimitives.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSPrimitives.scala
@@ -10,6 +10,7 @@ import Symbols._
 import dotty.tools.dotc.ast.tpd._
 import dotty.tools.backend.jvm.DottyPrimitives
 import dotty.tools.dotc.report
+import dotty.tools.dotc.util.ReadOnlyMap
 
 import scala.collection.mutable
 
@@ -55,7 +56,7 @@ class JSPrimitives(ictx: Context) extends DottyPrimitives(ictx) {
   import JSPrimitives._
   import dotty.tools.backend.ScalaPrimitivesOps._
 
-  private lazy val jsPrimitives: Map[Symbol, Int] = initJSPrimitives(using ictx)
+  private lazy val jsPrimitives: ReadOnlyMap[Symbol, Int] = initJSPrimitives(using ictx)
 
   override def getPrimitive(sym: Symbol): Int =
     jsPrimitives.getOrElse(sym, super.getPrimitive(sym))
@@ -70,9 +71,9 @@ class JSPrimitives(ictx: Context) extends DottyPrimitives(ictx) {
     jsPrimitives.contains(fun.symbol(using ictx)) || super.isPrimitive(fun)
 
   /** Initialize the primitive map */
-  private def initJSPrimitives(using Context): Map[Symbol, Int] = {
+  private def initJSPrimitives(using Context): ReadOnlyMap[Symbol, Int] = {
 
-    val primitives = newMutableSymbolMap[Int]
+    val primitives = MutableSymbolMap[Int]()
 
     // !!! Code duplicate with DottyPrimitives
     /** Add a primitive operation to the map */
@@ -120,7 +121,7 @@ class JSPrimitives(ictx: Context) extends DottyPrimitives(ictx) {
     addPrimitive(jsdefn.ReflectSelectable_selectDynamic, REFLECT_SELECTABLE_SELECTDYN)
     addPrimitive(jsdefn.ReflectSelectable_applyDynamic, REFLECT_SELECTABLE_APPLYDYN)
 
-    primitives.toMap
+    primitives
   }
 
 }

--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -109,7 +109,7 @@ class Compiler {
     List(new Constructors,           // Collect initialization code in primary constructors
                                         // Note: constructors changes decls in transformTemplate, no InfoTransformers should be added after it
          new FunctionalInterfaces,   // Rewrites closures to implement @specialized types of Functions.
-         new Instrumentation) ::     // Count closure allocations under -Yinstrument-closures
+         new Instrumentation) ::     // Count calls and allocations under -Yinstrument
     List(new LambdaLift,             // Lifts out nested functions to class scope, storing free variables in environments
                                      // Note: in this mini-phase block scopes are incorrect. No phases that rely on scopes should be here
          new ElimStaticThis,         // Replace `this` references to static objects by global identifiers

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -7,6 +7,8 @@ import Periods._
 import Symbols._
 import Types._
 import Scopes._
+import Names.Name
+import Denotations.Denotation
 import typer.Typer
 import typer.ImportInfo._
 import Decorators._
@@ -115,6 +117,9 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
 
   /** The source files of all late entered symbols, as a set */
   private var lateFiles = mutable.Set[AbstractFile]()
+
+  /** A cache for static references to packages and classes */
+  val staticRefs = util.IdentityHashMap[Name, Denotation](initialCapacity = 1024)
 
   /** Actions that need to be performed at the end of the current compilation run */
   private var finalizeActions = mutable.ListBuffer[() => Unit]()

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -119,7 +119,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   private var lateFiles = mutable.Set[AbstractFile]()
 
   /** A cache for static references to packages and classes */
-  val staticRefs = util.IdentityHashMap[Name, Denotation](initialCapacity = 1024)
+  val staticRefs = util.EqHashMap[Name, Denotation](initialCapacity = 1024)
 
   /** Actions that need to be performed at the end of the current compilation run */
   private var finalizeActions = mutable.ListBuffer[() => Unit]()

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -14,7 +14,7 @@ import io.{AbstractFile, PlainFile}
 import Phases.unfusedPhases
 
 import scala.io.Codec
-import util.{Set => _, _}
+import util._
 import reporting.Reporter
 import rewrites.Rewrites
 import java.io.{BufferedWriter, OutputStreamWriter}

--- a/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
@@ -108,7 +108,7 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
   private def mergeClassesAndSources(entries: scala.collection.Seq[ClassRepresentation]): Seq[ClassRepresentation] = {
     // based on the implementation from MergedClassPath
     var count = 0
-    val indices = new collection.mutable.HashMap[String, Int]()
+    val indices = util.HashMap[String, Int]()
     val mergedEntries = new ArrayBuffer[ClassRepresentation](entries.size)
     for {
       entry <- entries

--- a/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
@@ -7,6 +7,7 @@ package dotc.classpath
 import java.net.URL
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.immutable.ArraySeq
+import dotc.util
 
 import dotty.tools.io.{ AbstractFile, ClassPath, ClassRepresentation, EfficientClassPath }
 
@@ -132,7 +133,7 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
   }
 
   private def getDistinctEntries[EntryType <: ClassRepresentation](getEntries: ClassPath => Seq[EntryType]): Seq[EntryType] = {
-    val seenNames = collection.mutable.HashSet[String]()
+    val seenNames = util.HashSet[String]()
     val entriesBuffer = new ArrayBuffer[EntryType](1024)
     for {
       cp <- aggregates

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -181,10 +181,10 @@ object Config {
   /** If set, enables tracing */
   inline val tracingEnabled = false
 
-  /** Initial capacity of uniques HashMap.
-   *  Note: This MUST BE a power of two to work with util.HashSet
+  /** Initial capacity of the uniques HashMap.
+   *  Note: This should be a power of two to work with util.HashSet
    */
-  inline val initialUniquesCapacity = 65536
+  inline val initialUniquesCapacity = 0x8000
 
   /** How many recursive calls to NamedType#underlying are performed before logging starts. */
   inline val LogPendingUnderlyingThreshold = 50

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -177,8 +177,7 @@ class ScalaSettings extends Settings.SettingGroup {
 
   val YnoDecodeStacktraces: Setting[Boolean] = BooleanSetting("-Yno-decode-stacktraces", "Show raw StackOverflow stacktraces, instead of decoding them into triggering operations.")
 
-  val YinstrumentClosures: Setting[Boolean] = BooleanSetting("-Yinstrument-closures", "Add instrumentation code that counts closure creations.")
-  val YinstrumentAllocations: Setting[Boolean] = BooleanSetting("-Yinstrument-allocations", "Add instrumentation code that counts allocations.")
+  val Yinstrument: Setting[Boolean] = BooleanSetting("-Yinstrument", "Add instrumentation code that counts allocations and closure creations.")
 
   /** Dottydoc specific settings */
   val siteRoot: Setting[String] = StringSetting(

--- a/compiler/src/dotty/tools/dotc/core/Comments.scala
+++ b/compiler/src/dotty/tools/dotc/core/Comments.scala
@@ -4,7 +4,7 @@ package core
 
 import ast.{ untpd, tpd }
 import Decorators._, Symbols._, Contexts._
-import util.SourceFile
+import util.{SourceFile, ReadOnlyMap}
 import util.Spans._
 import util.CommentParsing._
 import util.Property.Key
@@ -23,11 +23,11 @@ object Comments {
     */
   class ContextDocstrings {
 
-    private val _docstrings: MutableSymbolMap[Comment] = newMutableSymbolMap
+    private val _docstrings: MutableSymbolMap[Comment] = MutableSymbolMap[Comment](512) // FIXME: 2nd [Comment] needed or "not a class type"
 
     val templateExpander: CommentExpander = new CommentExpander
 
-    def docstrings: Map[Symbol, Comment] = _docstrings.toMap
+    def docstrings: ReadOnlyMap[Symbol, Comment] = _docstrings
 
     def docstring(sym: Symbol): Option[Comment] = _docstrings.get(sym)
 
@@ -180,7 +180,7 @@ object Comments {
     protected def superComment(sym: Symbol)(using Context): Option[String] =
       allInheritedOverriddenSymbols(sym).iterator map (x => cookedDocComment(x)) find (_ != "")
 
-    private val cookedDocComments = newMutableSymbolMap[String]
+    private val cookedDocComments = MutableSymbolMap[String]()
 
     /** The raw doc comment of symbol `sym`, minus usecase and define sections, augmented by
      *  missing sections of an inherited doc comment.

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -14,7 +14,7 @@ import Uniques._
 import ast.Trees._
 import ast.untpd
 import Flags.GivenOrImplicit
-import util.{NoSource, SimpleIdentityMap, SourceFile}
+import util.{NoSource, SimpleIdentityMap, SourceFile, HashSet}
 import typer.{Implicits, ImportInfo, Inliner, SearchHistory, SearchRoot, TypeAssigner, Typer, Nullables}
 import Nullables.{NotNullInfo, given _}
 import Implicits.ContextualImplicits
@@ -534,7 +534,7 @@ object Contexts {
     def settings: ScalaSettings            = base.settings
     def definitions: Definitions           = base.definitions
     def platform: Platform                 = base.platform
-    def pendingUnderlying: mutable.HashSet[Type]   = base.pendingUnderlying
+    def pendingUnderlying: util.HashSet[Type]      = base.pendingUnderlying
     def uniqueNamedTypes: Uniques.NamedTypeUniques = base.uniqueNamedTypes
     def uniques: util.HashSet[Type]                = base.uniques
 
@@ -838,8 +838,8 @@ object Contexts {
     def nextSymId: Int = { _nextSymId += 1; _nextSymId }
 
     /** Sources that were loaded */
-    val sources: mutable.HashMap[AbstractFile, SourceFile] = new mutable.HashMap[AbstractFile, SourceFile]
-    val sourceNamed: mutable.HashMap[TermName, SourceFile] = new mutable.HashMap[TermName, SourceFile]
+    val sources: util.HashMap[AbstractFile, SourceFile] = util.HashMap[AbstractFile, SourceFile]()
+    val sourceNamed: util.HashMap[TermName, SourceFile] = util.HashMap[TermName, SourceFile]()
 
     // Types state
     /** A table for hash consing unique types */
@@ -869,7 +869,7 @@ object Contexts {
 
     /** The set of named types on which a currently active invocation
      *  of underlying during a controlled operation exists. */
-    private[core] val pendingUnderlying: mutable.HashSet[Type] = new mutable.HashSet[Type]
+    private[core] val pendingUnderlying: util.HashSet[Type] = util.HashSet[Type]()
 
     /** A map from ErrorType to associated message. We use this map
      *  instead of storing messages directly in ErrorTypes in order

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -289,7 +289,7 @@ object Contexts {
     private def lookup(key: Phase | SourceFile): Context =
       util.Stats.record("Context.related.lookup")
       if related == null then
-        related = SimpleIdentityMap.Empty
+        related = SimpleIdentityMap.empty
         null
       else
         related(key)

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -843,25 +843,13 @@ object Contexts {
 
     // Types state
     /** A table for hash consing unique types */
-    private[core] val uniques: util.HashSet[Type] = new util.HashSet[Type](Config.initialUniquesCapacity) {
-      override def hash(x: Type): Int = x.hash
-      override def isEqual(x: Type, y: Type) = x.eql(y)
-    }
+    private[core] val uniques: Uniques = Uniques()
 
     /** A table for hash consing unique applied types */
-    private[dotc] val uniqueAppliedTypes: AppliedUniques = new AppliedUniques
+    private[dotc] val uniqueAppliedTypes: AppliedUniques = AppliedUniques()
 
     /** A table for hash consing unique named types */
-    private[core] val uniqueNamedTypes: NamedTypeUniques = new NamedTypeUniques
-
-    private def uniqueSets = Map(
-        "uniques" -> uniques,
-        "uniqueAppliedTypes" -> uniqueAppliedTypes,
-        "uniqueNamedTypes" -> uniqueNamedTypes)
-
-    /** A map that associates label and size of all uniques sets */
-    def uniquesSizes: Map[String, (Int, Int, Int)] =
-      uniqueSets.transform((_, s) => (s.size, s.accesses, s.misses))
+    private[core] val uniqueNamedTypes: NamedTypeUniques = NamedTypeUniques()
 
     var emptyTypeBounds: TypeBounds = null
     var emptyWildcardBounds: WildcardType = null
@@ -925,15 +913,16 @@ object Contexts {
         charArray = new Array[Char](charArray.length * 2)
       charArray
 
-    def reset(): Unit = {
-      for ((_, set) <- uniqueSets) set.clear()
+    def reset(): Unit =
+      uniques.clear()
+      uniqueAppliedTypes.clear()
+      uniqueNamedTypes.clear()
       emptyTypeBounds = null
       emptyWildcardBounds = null
       errorTypeMsg.clear()
       sources.clear()
       sourceNamed.clear()
       comparers.clear()  // forces re-evaluation of top and bottom classes in TypeComparer
-    }
 
     // Test that access is single threaded
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1603,7 +1603,7 @@ class Definitions {
     valueTypeEnc(sym2.asClass.name) % valueTypeEnc(sym1.asClass.name) == 0
 
   @tu lazy val specialErasure: SimpleIdentityMap[Symbol, ClassSymbol] =
-    SimpleIdentityMap.Empty[Symbol]
+    SimpleIdentityMap.empty[Symbol]
       .updated(AnyClass, ObjectClass)
       .updated(AnyValClass, ObjectClass)
       .updated(SingletonClass, ObjectClass)

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1259,7 +1259,8 @@ object Denotations {
         }
         recurSimple(path.length, wrap)
     }
-    recur(path)
+    if ctx.run == null then recur(path)
+    else ctx.run.staticRefs.getOrElseUpdate(path, recur(path))
   }
 
 

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -65,9 +65,9 @@ final class ProperGadtConstraint private(
   import dotty.tools.dotc.config.Printers.{gadts, gadtsConstr}
 
   def this() = this(
-    myConstraint = new OrderingConstraint(SimpleIdentityMap.Empty, SimpleIdentityMap.Empty, SimpleIdentityMap.Empty),
-    mapping = SimpleIdentityMap.Empty,
-    reverseMapping = SimpleIdentityMap.Empty
+    myConstraint = new OrderingConstraint(SimpleIdentityMap.empty, SimpleIdentityMap.empty, SimpleIdentityMap.empty),
+    mapping = SimpleIdentityMap.empty,
+    reverseMapping = SimpleIdentityMap.empty
   )
 
   /** Exposes ConstraintHandling.subsumes */

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -8,7 +8,6 @@ import StdNames._
 import NameTags._
 import Contexts._
 import Decorators._
-import collection.mutable
 
 import scala.annotation.internal.sharable
 
@@ -18,10 +17,10 @@ object NameKinds {
   // These are sharable since all NameKinds are created eagerly at the start of the program
   // before any concurrent threads are forked. for this to work, NameKinds should never
   // be created lazily or in modules that start running after compilers are forked.
-  @sharable private val simpleNameKinds = new mutable.HashMap[Int, ClassifiedNameKind]
-  @sharable private val qualifiedNameKinds = new mutable.HashMap[Int, QualifiedNameKind]
-  @sharable private val numberedNameKinds = new mutable.HashMap[Int, NumberedNameKind]
-  @sharable private val uniqueNameKinds = new mutable.HashMap[String, UniqueNameKind]
+  @sharable private val simpleNameKinds = util.HashMap[Int, ClassifiedNameKind]()
+  @sharable private val qualifiedNameKinds = util.HashMap[Int, QualifiedNameKind]()
+  @sharable private val numberedNameKinds = util.HashMap[Int, NumberedNameKind]()
+  @sharable private val uniqueNameKinds = util.HashMap[String, UniqueNameKind]()
 
   /** A class for the info stored in a derived name */
   abstract class NameInfo {
@@ -393,8 +392,8 @@ object NameKinds {
   val Scala2MethodNameKinds: List[NameKind] =
     List(DefaultGetterName, ExtMethName, UniqueExtMethName)
 
-  def simpleNameKindOfTag      : collection.Map[Int, ClassifiedNameKind] = simpleNameKinds
-  def qualifiedNameKindOfTag   : collection.Map[Int, QualifiedNameKind]  = qualifiedNameKinds
-  def numberedNameKindOfTag    : collection.Map[Int, NumberedNameKind]   = numberedNameKinds
-  def uniqueNameKindOfSeparator: collection.Map[String, UniqueNameKind]  = uniqueNameKinds
+  def simpleNameKindOfTag      : util.ReadOnlyMap[Int, ClassifiedNameKind] = simpleNameKinds
+  def qualifiedNameKindOfTag   : util.ReadOnlyMap[Int, QualifiedNameKind]  = qualifiedNameKinds
+  def numberedNameKindOfTag    : util.ReadOnlyMap[Int, NumberedNameKind]   = numberedNameKinds
+  def uniqueNameKindOfSeparator: util.ReadOnlyMap[String, UniqueNameKind]  = uniqueNameKinds
 }

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -185,7 +185,7 @@ object Names {
     private var derivedNames: LinearMap[NameInfo, DerivedName] = LinearMap.Empty
 
     private def add(info: NameInfo): TermName = synchronized {
-      derivedNames(info) match
+      derivedNames.lookup(info) match
         case null =>
           val derivedName = new DerivedName(this, info)
           derivedNames = derivedNames.updated(info, derivedName)

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -182,7 +182,7 @@ object Names {
     def underlying: TermName = unsupported("underlying")
 
     @sharable // because of synchronized block in `and`
-    private var derivedNames: LinearMap[NameInfo, DerivedName] = LinearMap.Empty
+    private var derivedNames: LinearMap[NameInfo, DerivedName] = LinearMap.empty
 
     private def add(info: NameInfo): TermName = synchronized {
       derivedNames.lookup(info) match

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -105,7 +105,7 @@ object OrderingConstraint {
   }
 
   @sharable
-  val empty = new OrderingConstraint(SimpleIdentityMap.Empty, SimpleIdentityMap.Empty, SimpleIdentityMap.Empty)
+  val empty = new OrderingConstraint(SimpleIdentityMap.empty, SimpleIdentityMap.empty, SimpleIdentityMap.empty)
 }
 
 import OrderingConstraint._

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1564,14 +1564,14 @@ object SymDenotations {
     initPrivateWithin: Symbol)
     extends SymDenotation(symbol, maybeOwner, name, initFlags, initInfo, initPrivateWithin) {
 
-    import util.IdentityHashMap
+    import util.EqHashMap
 
     // ----- caches -------------------------------------------------------
 
     private var myTypeParams: List[TypeSymbol] = null
     private var fullNameCache: SimpleIdentityMap[QualifiedNameKind, Name] = SimpleIdentityMap.empty
 
-    private var myMemberCache: IdentityHashMap[Name, PreDenotation] = null
+    private var myMemberCache: EqHashMap[Name, PreDenotation] = null
     private var myMemberCachePeriod: Period = Nowhere
 
     /** A cache from types T to baseType(T, C) */
@@ -1582,9 +1582,9 @@ object SymDenotations {
     private var baseDataCache: BaseData = BaseData.None
     private var memberNamesCache: MemberNames = MemberNames.None
 
-    private def memberCache(using Context): IdentityHashMap[Name, PreDenotation] = {
+    private def memberCache(using Context): EqHashMap[Name, PreDenotation] = {
       if (myMemberCachePeriod != ctx.period) {
-        myMemberCache = IdentityHashMap()
+        myMemberCache = EqHashMap()
         myMemberCachePeriod = ctx.period
       }
       myMemberCache

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1569,7 +1569,7 @@ object SymDenotations {
     // ----- caches -------------------------------------------------------
 
     private var myTypeParams: List[TypeSymbol] = null
-    private var fullNameCache: SimpleIdentityMap[QualifiedNameKind, Name] = SimpleIdentityMap.Empty
+    private var fullNameCache: SimpleIdentityMap[QualifiedNameKind, Name] = SimpleIdentityMap.empty
 
     private var myMemberCache: IdentityHashMap[Name, PreDenotation] = null
     private var myMemberCachePeriod: Period = Nowhere
@@ -2609,7 +2609,7 @@ object SymDenotations {
   }
 
   private class MemberNamesImpl(createdAt: Period) extends InheritedCacheImpl(createdAt) with MemberNames {
-    private var cache: SimpleIdentityMap[NameFilter, Set[Name]] = SimpleIdentityMap.Empty
+    private var cache: SimpleIdentityMap[NameFilter, Set[Name]] = SimpleIdentityMap.empty
 
     final def isValid(using Context): Boolean =
       cache != null && isValidAt(ctx.phase)
@@ -2622,7 +2622,7 @@ object SymDenotations {
      */
     def invalidate(): Unit =
       if (cache != null)
-        if (locked) cache = SimpleIdentityMap.Empty
+        if (locked) cache = SimpleIdentityMap.empty
         else {
           cache = null
           invalidateDependents()

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -30,7 +30,7 @@ import reporting.Message
 import collection.mutable
 import io.AbstractFile
 import language.implicitConversions
-import util.{SourceFile, NoSource, Property, SourcePosition, SrcPos}
+import util.{SourceFile, NoSource, Property, SourcePosition, SrcPos, IdentityHashMap}
 import scala.collection.JavaConverters._
 import scala.annotation.internal.sharable
 import config.Printers.typr
@@ -495,61 +495,7 @@ object Symbols {
   /** The current class */
   def currentClass(using Context): ClassSymbol = ctx.owner.enclosingClass.asClass
 
-  /* Mutable map from symbols any T */
-  class MutableSymbolMap[T](private[Symbols] val value: java.util.IdentityHashMap[Symbol, T]) extends AnyVal {
-
-    def apply(sym: Symbol): T = value.get(sym)
-
-    def get(sym: Symbol): Option[T] = Option(value.get(sym))
-
-    def getOrElse[U >: T](sym: Symbol, default: => U): U = {
-      val v = value.get(sym)
-      if (v != null) v else default
-    }
-
-    def getOrElseUpdate(sym: Symbol, op: => T): T = {
-      val v = value.get(sym)
-      if (v != null) v
-      else {
-        val v = op
-        assert(v != null)
-        value.put(sym, v)
-        v
-      }
-    }
-
-    def update(sym: Symbol, x: T): Unit = {
-      assert(x != null)
-      value.put(sym, x)
-    }
-    def put(sym: Symbol, x: T): T = {
-      assert(x != null)
-      value.put(sym, x)
-    }
-
-    def -=(sym: Symbol): Unit = value.remove(sym)
-    def remove(sym: Symbol): Option[T] = Option(value.remove(sym))
-
-    def contains(sym: Symbol): Boolean = value.containsKey(sym)
-
-    def isEmpty: Boolean = value.isEmpty
-
-    def clear(): Unit = value.clear()
-
-    def filter(p: ((Symbol, T)) => Boolean): Map[Symbol, T] =
-      value.asScala.toMap.filter(p)
-
-    def iterator: Iterator[(Symbol, T)] = value.asScala.iterator
-
-    def keysIterator: Iterator[Symbol] = value.keySet().asScala.iterator
-
-    def toMap: Map[Symbol, T] = value.asScala.toMap
-
-    override def toString: String = value.asScala.toString()
-  }
-
-  inline def newMutableSymbolMap[T]: MutableSymbolMap[T] =
-    new MutableSymbolMap(new java.util.IdentityHashMap[Symbol, T]())
+  type MutableSymbolMap[T] = IdentityHashMap[Symbol, T]
 
 // ---- Factory methods for symbol creation ----------------------
 //

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -30,7 +30,7 @@ import reporting.Message
 import collection.mutable
 import io.AbstractFile
 import language.implicitConversions
-import util.{SourceFile, NoSource, Property, SourcePosition, SrcPos, IdentityHashMap}
+import util.{SourceFile, NoSource, Property, SourcePosition, SrcPos, EqHashMap}
 import scala.collection.JavaConverters._
 import scala.annotation.internal.sharable
 import config.Printers.typr
@@ -495,7 +495,7 @@ object Symbols {
   /** The current class */
   def currentClass(using Context): ClassSymbol = ctx.owner.enclosingClass.asClass
 
-  type MutableSymbolMap[T] = IdentityHashMap[Symbol, T]
+  type MutableSymbolMap[T] = EqHashMap[Symbol, T]
 
 // ---- Factory methods for symbol creation ----------------------
 //

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -49,7 +49,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     needsGc = false
     if Config.checkTypeComparerReset then checkReset()
 
-  private var pendingSubTypes: mutable.Set[(Type, Type)] = null
+  private var pendingSubTypes: util.MutableSet[(Type, Type)] = null
   private var recCount = 0
   private var monitored = false
 
@@ -202,7 +202,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
 
     def monitoredIsSubType = {
       if (pendingSubTypes == null) {
-        pendingSubTypes = new mutable.HashSet[(Type, Type)]
+        pendingSubTypes = util.HashSet[(Type, Type)]()
         report.log(s"!!! deep subtype recursion involving ${tp1.show} <:< ${tp2.show}, constraint = ${state.constraint.show}")
         report.log(s"!!! constraint = ${constraint.show}")
         //if (ctx.settings.YnoDeepSubtypes.value) {
@@ -231,7 +231,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         }
       }
       val p = (normalize(tp1), normalize(tp2))
-      !pendingSubTypes(p) && {
+      !pendingSubTypes.contains(p) && {
         try {
           pendingSubTypes += p
           firstTry

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -187,7 +187,7 @@ object TypeOps:
     /** a faster version of cs1 intersect cs2 */
     def intersect(cs1: List[ClassSymbol], cs2: List[ClassSymbol]): List[ClassSymbol] = {
       val cs2AsSet = new util.HashSet[ClassSymbol](128)
-      cs2.foreach(cs2AsSet +=)
+      cs2.foreach(cs2AsSet += _)
       cs1.filter(cs2AsSet.contains)
     }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -187,7 +187,7 @@ object TypeOps:
     /** a faster version of cs1 intersect cs2 */
     def intersect(cs1: List[ClassSymbol], cs2: List[ClassSymbol]): List[ClassSymbol] = {
       val cs2AsSet = new util.HashSet[ClassSymbol](128)
-      cs2.foreach(cs2AsSet.addEntry)
+      cs2.foreach(cs2AsSet +=)
       cs1.filter(cs2AsSet.contains)
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5534,7 +5534,7 @@ object Types {
     def apply(xs: List[NamedType], tp: Type): List[NamedType] =
       if seen contains tp then xs
       else
-        seen.addEntry(tp)
+        seen += tp
         tp match
           case tp: TypeRef =>
             foldOver(maybeAdd(xs, tp), tp)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5568,11 +5568,11 @@ object Types {
   }
 
   class TypeSizeAccumulator(using Context) extends TypeAccumulator[Int] {
-    val seen = new java.util.IdentityHashMap[Type, Type]
+    var seen = util.HashSet[Type](initialCapacity = 8)
     def apply(n: Int, tp: Type): Int =
-      if (seen.get(tp) != null) n
+      if seen.contains(tp) then n
       else {
-        seen.put(tp, tp)
+        seen += tp
         tp match {
           case tp: AppliedType =>
             foldOver(n + 1, tp)
@@ -5589,11 +5589,11 @@ object Types {
   }
 
   class CoveringSetAccumulator(using Context) extends TypeAccumulator[Set[Symbol]] {
-    val seen = new java.util.IdentityHashMap[Type, Type]
+    var seen = util.HashSet[Type](initialCapacity = 8)
     def apply(cs: Set[Symbol], tp: Type): Set[Symbol] =
-      if (seen.get(tp) != null) cs
+      if seen.contains(tp) then cs
       else {
-        seen.put(tp, tp)
+        seen += tp
         tp match {
           case tp if tp.isTopType || tp.isBottomType =>
             cs

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4321,7 +4321,7 @@ object Types {
     def underlying(using Context): Type = bound
 
     private var myReduced: Type = null
-    private var reductionContext: mutable.Map[Type, Type] = null
+    private var reductionContext: util.MutableMap[Type, Type] = null
 
     override def tryNormalize(using Context): Type = reduced.normalized
 
@@ -4340,7 +4340,7 @@ object Types {
       }
 
       def updateReductionContext(footprint: collection.Set[Type]): Unit =
-        reductionContext = new mutable.HashMap
+        reductionContext = util.HashMap()
         for (tp <- footprint)
           reductionContext(tp) = contextInfo(tp)
         typr.println(i"footprint for $this $hashCode: ${footprint.toList.map(x => (x, contextInfo(x)))}%, %")

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5527,14 +5527,10 @@ object Types {
     def apply(x: Unit, tp: Type): Unit = foldOver(p(tp), tp)
   }
 
-  class TypeHashSet extends util.HashSet[Type](64):
-    override def hash(x: Type): Int = System.identityHashCode(x)
-    override def isEqual(x: Type, y: Type) = x.eq(y)
-
   class NamedPartsAccumulator(p: NamedType => Boolean)(using Context)
   extends TypeAccumulator[List[NamedType]]:
     def maybeAdd(xs: List[NamedType], tp: NamedType): List[NamedType] = if p(tp) then tp :: xs else xs
-    val seen = TypeHashSet()
+    val seen = util.HashSet[Type]()
     def apply(xs: List[NamedType], tp: Type): List[NamedType] =
       if seen contains tp then xs
       else

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3405,7 +3405,7 @@ object Types {
   abstract class LambdaTypeCompanion[N <: Name, PInfo <: Type, LT <: LambdaType] {
     def syntheticParamName(n: Int): N
 
-    @sharable private val memoizedNames = new mutable.HashMap[Int, List[N]]
+    @sharable private val memoizedNames = util.HashMap[Int, List[N]]()
     def syntheticParamNames(n: Int): List[N] = synchronized {
       memoizedNames.getOrElseUpdate(n, (0 until n).map(syntheticParamName).toList)
     }

--- a/compiler/src/dotty/tools/dotc/core/Uniques.scala
+++ b/compiler/src/dotty/tools/dotc/core/Uniques.scala
@@ -4,93 +4,71 @@ package core
 import Types._, Contexts._, util.Stats._, Hashable._, Names._
 import config.Config
 import Decorators._
-import util.HashSet
+import util.{HashSet, Stats}
+
+class Uniques extends HashSet[Type](Config.initialUniquesCapacity):
+  override def hash(x: Type): Int = x.hash
+  override def isEqual(x: Type, y: Type) = x.eql(y)
 
 /** Defines operation `unique` for hash-consing types.
  *  Also defines specialized hash sets for hash consing uniques of a specific type.
  *  All sets offer a `enterIfNew` method which checks whether a type
  *  with the given parts exists already and creates a new one if not.
  */
-object Uniques {
+object Uniques:
 
-  private def recordCaching(tp: Type): Unit = recordCaching(tp.hash, tp.getClass)
-  private def recordCaching(h: Int, clazz: Class[?]): Unit =
-    if (h == NotCached) {
-      record("uncached-types")
-      record(s"uncached: $clazz")
-    }
-    else {
-      record("cached-types")
-      record(s"cached: $clazz")
-    }
+  private inline def recordCaching(tp: Type): Unit = recordCaching(tp.hash, tp.getClass)
+  private inline def recordCaching(h: Int, clazz: Class[?]): Unit =
+    if monitored then
+      if h == NotCached then
+        record("uncached-types")
+        record(s"uncached: $clazz")
+      else
+        record("cached-types")
+        record(s"cached: $clazz")
 
-  def unique[T <: Type](tp: T)(using Context): T = {
-    if (monitored) recordCaching(tp)
-    if (tp.hash == NotCached) tp
-    else if (monitored) {
-      val size = ctx.uniques.size
-      val result = ctx.uniques.findEntryOrUpdate(tp).asInstanceOf[T]
-      if (ctx.uniques.size > size) record(s"fresh unique ${tp.getClass}")
-      result
-    }
-    else ctx.uniques.findEntryOrUpdate(tp).asInstanceOf[T]
-  }
-  /* !!! DEBUG
-  ensuring (
-    result => tp.toString == result.toString || {
-      println(s"cache mismatch; tp = $tp, cached = $result")
-      false
-    }
-  )
- */
+  def unique[T <: Type](tp: T)(using Context): T =
+    recordCaching(tp)
+    if tp.hash == NotCached then tp
+    else ctx.uniques.put(tp).asInstanceOf[T]
 
-  final class NamedTypeUniques extends HashSet[NamedType](Config.initialUniquesCapacity) with Hashable {
+  final class NamedTypeUniques extends HashSet[NamedType](Config.initialUniquesCapacity) with Hashable:
     override def hash(x: NamedType): Int = x.hash
 
-    private def findPrevious(h: Int, prefix: Type, designator: Designator): NamedType = {
-      var e = findEntryByHash(h)
-      while (e != null) {
-        if ((e.prefix eq prefix) && (e.designator eq designator)) return e
-        e = nextEntryByHash(h)
-      }
-      e
-    }
-
-    def enterIfNew(prefix: Type, designator: Designator, isTerm: Boolean)(using Context): NamedType = {
+    def enterIfNew(prefix: Type, designator: Designator, isTerm: Boolean)(using Context): NamedType =
       val h = doHash(null, designator, prefix)
-      if (monitored) recordCaching(h, classOf[NamedType])
+      if monitored then recordCaching(h, classOf[NamedType])
       def newType =
         if (isTerm) new CachedTermRef(prefix, designator, h)
         else new CachedTypeRef(prefix, designator, h)
-      if (h == NotCached) newType
-      else {
-        val r = findPrevious(h, prefix, designator)
-        if ((r ne null) && (r.isTerm == isTerm)) r else addEntryAfterScan(newType)
-      }
-    }
-  }
+      if h == NotCached then newType
+      else
+        Stats.record(statsItem("put"))
+        var idx = index(h)
+        var e = entryAt(idx)
+        while e != null do
+          if (e.prefix eq prefix) && (e.designator eq designator) && (e.isTerm == isTerm) then return e
+          idx = nextIndex(idx)
+          e = entryAt(idx)
+        addEntryAt(idx, newType)
+  end NamedTypeUniques
 
-  final class AppliedUniques extends HashSet[AppliedType](Config.initialUniquesCapacity) with Hashable {
+  final class AppliedUniques extends HashSet[AppliedType](Config.initialUniquesCapacity) with Hashable:
     override def hash(x: AppliedType): Int = x.hash
 
-    private def findPrevious(h: Int, tycon: Type, args: List[Type]): AppliedType = {
-      var e = findEntryByHash(h)
-      while (e != null) {
-        if ((e.tycon eq tycon) && e.args.eqElements(args)) return e
-        e = nextEntryByHash(h)
-      }
-      e
-    }
-
-    def enterIfNew(tycon: Type, args: List[Type]): AppliedType = {
+    def enterIfNew(tycon: Type, args: List[Type]): AppliedType =
       val h = doHash(null, tycon, args)
       def newType = new CachedAppliedType(tycon, args, h)
-      if (monitored) recordCaching(h, classOf[CachedAppliedType])
-      if (h == NotCached) newType
-      else {
-        val r = findPrevious(h, tycon, args)
-        if (r ne null) r else addEntryAfterScan(newType)
-      }
-    }
-  }
-}
+      if monitored then recordCaching(h, classOf[CachedAppliedType])
+      if h == NotCached then newType
+      else
+        Stats.record(statsItem("put"))
+        var idx = index(h)
+        var e = entryAt(idx)
+        while e != null do
+          if (e.tycon eq tycon) && e.args.eqElements(args) then return e
+          idx = nextIndex(idx)
+          e = entryAt(idx)
+        addEntryAt(idx, newType)
+  end AppliedUniques
+end Uniques

--- a/compiler/src/dotty/tools/dotc/core/Uniques.scala
+++ b/compiler/src/dotty/tools/dotc/core/Uniques.scala
@@ -32,7 +32,7 @@ object Uniques:
     if tp.hash == NotCached then tp
     else ctx.uniques.put(tp).asInstanceOf[T]
 
-  final class NamedTypeUniques extends HashSet[NamedType](Config.initialUniquesCapacity) with Hashable:
+  final class NamedTypeUniques extends HashSet[NamedType](Config.initialUniquesCapacity * 4) with Hashable:
     override def hash(x: NamedType): Int = x.hash
 
     def enterIfNew(prefix: Type, designator: Designator, isTerm: Boolean)(using Context): NamedType =
@@ -53,7 +53,7 @@ object Uniques:
         addEntryAt(idx, newType)
   end NamedTypeUniques
 
-  final class AppliedUniques extends HashSet[AppliedType](Config.initialUniquesCapacity) with Hashable:
+  final class AppliedUniques extends HashSet[AppliedType](Config.initialUniquesCapacity * 2) with Hashable:
     override def hash(x: AppliedType): Int = x.hash
 
     def enterIfNew(tycon: Type, args: List[Type]): AppliedType =

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -732,15 +732,13 @@ class ClassfileParser(
           classTranslation.flags(jflags),
           getScope(jflags))
 
-    for (entry <- innerClasses.values) {
+    for entry <- innerClasses.valuesIterator do
       // create a new class member for immediate inner classes
-      if (entry.outerName == currentClassName) {
+      if entry.outerName == currentClassName then
         val file = ctx.platform.classPath.findClassFile(entry.externalName.toString) getOrElse {
           throw new AssertionError(entry.externalName)
         }
         enterClassAndModule(entry, file, entry.jflags)
-      }
-    }
   }
 
   // Nothing$ and Null$ were incorrectly emitted with a Scala attribute
@@ -937,14 +935,14 @@ class ClassfileParser(
       s"$originalName in $outerName($externalName)"
   }
 
-  object innerClasses extends scala.collection.mutable.HashMap[Name, InnerClassEntry] {
+  object innerClasses extends util.HashMap[Name, InnerClassEntry] {
     /** Return the Symbol of the top level class enclosing `name`,
      *  or 'name's symbol if no entry found for `name`.
      */
     def topLevelClass(name: Name)(using Context): Symbol = {
-      val tlName = if (isDefinedAt(name)) {
+      val tlName = if (contains(name)) {
         var entry = this(name)
-        while (isDefinedAt(entry.outerName))
+        while (contains(entry.outerName))
           entry = this(entry.outerName)
         entry.outerName
       }

--- a/compiler/src/dotty/tools/dotc/core/tasty/CommentUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/CommentUnpickler.scala
@@ -1,19 +1,19 @@
-package dotty.tools.dotc.core.tasty
+package dotty.tools.dotc
+package core.tasty
 
-import dotty.tools.dotc.core.Comments.Comment
-import dotty.tools.dotc.util.Spans.Span
+import core.Comments.Comment
+import util.Spans.Span
+import util.HashMap
 
 import dotty.tools.tasty.{TastyReader, TastyBuffer}
 import TastyBuffer.Addr
-
-import scala.collection.mutable.HashMap
 
 import java.nio.charset.Charset
 
 class CommentUnpickler(reader: TastyReader) {
   import reader._
 
-  private[tasty] lazy val comments: Map[Addr, Comment] = {
+  private[tasty] lazy val comments: HashMap[Addr, Comment] = {
     val comments = new HashMap[Addr, Comment]
     while (!isAtEnd) {
       val addr = readAddr()
@@ -25,7 +25,7 @@ class CommentUnpickler(reader: TastyReader) {
         comments(addr) = Comment(position, rawComment)
       }
     }
-    comments.toMap
+    comments
   }
 
   def commentAt(addr: Addr): Option[Comment] =

--- a/compiler/src/dotty/tools/dotc/core/tasty/PositionUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/PositionUnpickler.scala
@@ -15,14 +15,14 @@ import Names.TermName
 class PositionUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName) {
   import reader._
 
-  private var mySpans: mutable.HashMap[Addr, Span] = _
-  private var mySourcePaths: mutable.HashMap[Addr, String] = _
+  private var mySpans: util.HashMap[Addr, Span] = _
+  private var mySourcePaths: util.HashMap[Addr, String] = _
   private var isDefined = false
 
   def ensureDefined(): Unit = {
     if (!isDefined) {
-      mySpans = new mutable.HashMap[Addr, Span]
-      mySourcePaths = new mutable.HashMap[Addr, String]
+      mySpans = util.HashMap[Addr, Span]()
+      mySourcePaths = util.HashMap[Addr, String]()
       var curIndex = 0
       var curStart = 0
       var curEnd = 0
@@ -50,12 +50,12 @@ class PositionUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName) {
     }
   }
 
-  private[tasty] def spans: Map[Addr, Span] = {
+  private[tasty] def spans: util.ReadOnlyMap[Addr, Span] = {
     ensureDefined()
     mySpans
   }
 
-  private[tasty] def sourcePaths: Map[Addr, String] = {
+  private[tasty] def sourcePaths: util.ReadOnlyMap[Addr, String] = {
     ensureDefined()
     mySourcePaths
   }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -44,19 +44,19 @@ class TreePickler(pickler: TastyPickler) {
 
   private val symRefs = Symbols.MutableSymbolMap[Addr](256)
   private val forwardSymRefs = Symbols.MutableSymbolMap[List[Addr]]()
-  private val pickledTypes = util.IdentityHashMap[Type, Addr]()
+  private val pickledTypes = util.EqHashMap[Type, Addr]()
 
   /** A list of annotation trees for every member definition, so that later
    *  parallel position pickling does not need to access and force symbols.
    */
-  private val annotTrees = util.IdentityHashMap[untpd.MemberDef, mutable.ListBuffer[Tree]]()
+  private val annotTrees = util.EqHashMap[untpd.MemberDef, mutable.ListBuffer[Tree]]()
 
   /** A map from member definitions to their doc comments, so that later
    *  parallel comment pickling does not need to access symbols of trees (which
    *  would involve accessing symbols of named types and possibly changing phases
    *  in doing so).
    */
-  private val docStrings = util.IdentityHashMap[untpd.MemberDef, Comment]()
+  private val docStrings = util.EqHashMap[untpd.MemberDef, Comment]()
 
   def treeAnnots(tree: untpd.MemberDef): List[Tree] =
     val ts = annotTrees.lookup(tree)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -42,8 +42,8 @@ class TreePickler(pickler: TastyPickler) {
   import pickler.nameBuffer.nameIndex
   import tpd._
 
-  private val symRefs = Symbols.newMutableSymbolMap[Addr]
-  private val forwardSymRefs = Symbols.newMutableSymbolMap[List[Addr]]
+  private val symRefs = Symbols.MutableSymbolMap[Addr](256)
+  private val forwardSymRefs = Symbols.MutableSymbolMap[List[Addr]]()
   private val pickledTypes = util.IdentityHashMap[Type, Addr]()
 
   /** A list of annotation trees for every member definition, so that later

--- a/compiler/src/dotty/tools/dotc/plugins/Plugin.scala
+++ b/compiler/src/dotty/tools/dotc/plugins/Plugin.scala
@@ -162,12 +162,12 @@ object Plugin {
       case Failure(e)  => Failure(e)
     })
 
-    val seen = mutable.HashSet[String]()
+    val seen = util.HashSet[String]()
     val enabled = (fromPaths ::: fromDirs) map(_.flatMap {
       case (classname, loader) =>
         Plugin.load(classname, loader).flatMap {  clazz =>
           val plugin = instantiate(clazz)
-          if (seen(classname))   // a nod to scala/bug#7494, take the plugin classes distinctly
+          if (seen.contains(classname))   // a nod to scala/bug#7494, take the plugin classes distinctly
             Failure(new PluginLoadException(plugin.name, s"Ignoring duplicate plugin ${plugin.name} (${classname})"))
           else if (ignoring contains plugin.name)
             Failure(new PluginLoadException(plugin.name, s"Disabling plugin ${plugin.name}"))

--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc
+package dotty.tools
+package dotc
 package transform
 
 import core._
@@ -23,7 +24,7 @@ abstract class AccessProxies {
   import AccessProxies._
 
   /** accessor -> accessed */
-  private val accessedBy = newMutableSymbolMap[Symbol]
+  private val accessedBy = MutableSymbolMap[Symbol]()
 
   /** Given the name of an accessor, is the receiver of the call to accessed obtained
    *  as a parameterer?
@@ -35,7 +36,7 @@ abstract class AccessProxies {
    *  So a second call of the same method will yield the empty list.
    */
   private def accessorDefs(cls: Symbol)(using Context): Iterator[DefDef] =
-    for (accessor <- cls.info.decls.iterator; accessed <- accessedBy.remove(accessor)) yield
+    for (accessor <- cls.info.decls.iterator; accessed <- accessedBy.remove(accessor).toOption) yield
       polyDefDef(accessor.asTerm, tps => argss => {
         def numTypeParams = accessed.info match {
           case info: PolyType => info.paramNames.length

--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -36,7 +36,7 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
   private var toBeRemoved = immutable.Set[Symbol]()
   private val bridges = mutable.ListBuffer[Tree]()
   private val bridgesScope = newScope
-  private val bridgeTarget = newMutableSymbolMap[Symbol]
+  private val bridgeTarget = MutableSymbolMap[Symbol]()
 
   def bridgePosFor(member: Symbol): SrcPos =
     (if (member.owner == root && member.span.exists) member else root).srcPos

--- a/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
@@ -26,11 +26,11 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
   override def runsAfterGroupsOf: Set[String] = Set(LiftTry.name)
     // lifting tries changes what variables are considered to be captured
 
-  private[this] var Captured: Store.Location[collection.Set[Symbol]] = _
+  private[this] var Captured: Store.Location[util.ReadOnlySet[Symbol]] = _
   private def captured(using Context) = ctx.store(Captured)
 
   override def initContext(ctx: FreshContext): Unit =
-    Captured = ctx.addLocation(Set.empty)
+    Captured = ctx.addLocation(util.ReadOnlySet.empty)
 
   private class RefInfo(using Context) {
     /** The classes for which a Ref type exists. */
@@ -54,7 +54,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
   }
 
   private class CollectCaptured extends TreeTraverser {
-    private val captured = mutable.HashSet[Symbol]()
+    private val captured = util.HashSet[Symbol]()
     def traverse(tree: Tree)(using Context) = tree match {
       case id: Ident =>
         val sym = id.symbol
@@ -68,7 +68,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer { thisPhase =
       case _ =>
         traverseChildren(tree)
     }
-    def runOver(tree: Tree)(using Context): collection.Set[Symbol] = {
+    def runOver(tree: Tree)(using Context): util.ReadOnlySet[Symbol] = {
       traverse(tree)
       captured
     }

--- a/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc
+package dotty.tools
+package dotc
 package transform
 
 import core._
@@ -115,13 +116,13 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
     && (((cls.owner.name eq nme.DOLLAR_NEW) && cls.owner.isAllOf(Private|Synthetic)) || cls.owner.isAllOf(EnumCase))
     && cls.owner.owner.linkedClass.derivesFromJavaEnum
 
-  private val enumCaseOrdinals: MutableSymbolMap[Int] = newMutableSymbolMap
+  private val enumCaseOrdinals = MutableSymbolMap[Int]()
 
   private def registerEnumClass(cls: Symbol)(using Context): Unit =
-    cls.children.zipWithIndex.foreach(enumCaseOrdinals.put)
+    cls.children.zipWithIndex.foreach(enumCaseOrdinals.update)
 
   private def ordinalFor(enumCase: Symbol): Int =
-    enumCaseOrdinals.remove(enumCase).get
+    enumCaseOrdinals.remove(enumCase).nn
 
   /** 1. If this is an enum class, add $name and $ordinal parameters to its
    *     parameter accessors and pass them on to the java.lang.Enum constructor.

--- a/compiler/src/dotty/tools/dotc/transform/Getters.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Getters.scala
@@ -91,7 +91,7 @@ class Getters extends MiniPhase with SymTransformer { thisPhase =>
   }
   private val NoGetterNeededFlags = Method | Param | JavaDefined | JavaStatic
 
-  val newSetters = mutable.HashSet[Symbol]()
+  val newSetters = util.HashSet[Symbol]()
 
   def ensureSetter(sym: TermSymbol)(using Context) =
     if !sym.setter.exists then

--- a/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
@@ -15,7 +15,7 @@ import Names._
 import Constants.Constant
 
 
-/** The phase is enabled if a -Yinstrument-... option is set.
+/** The phase is enabled if the -Yinstrument option is set.
  *  If enabled, it counts the number of closures or allocations for each source position.
  *  It does this by generating a call to dotty.tools.dotc.util.Stats.doRecord.
  */
@@ -25,8 +25,7 @@ class Instrumentation extends MiniPhase { thisPhase =>
   override def phaseName: String = "instrumentation"
 
   override def isEnabled(using Context) =
-    ctx.settings.YinstrumentClosures.value ||
-    ctx.settings.YinstrumentAllocations.value
+    ctx.settings.Yinstrument.value
 
   private val namesOfInterest = List(
     "::", "+=", "toString", "newArray", "box", "toCharArray",

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -35,7 +35,7 @@ class NonLocalReturns extends MiniPhase {
     nonLocalReturnControl.appliedTo(argtype)
 
   /** A hashmap from method symbols to non-local return keys */
-  private val nonLocalReturnKeys = newMutableSymbolMap[TermSymbol]
+  private val nonLocalReturnKeys = MutableSymbolMap[TermSymbol]()
 
   /** Return non-local return key for given method */
   private def nonLocalReturnKey(meth: Symbol)(using Context) =
@@ -83,10 +83,9 @@ class NonLocalReturns extends MiniPhase {
   }
 
   override def transformDefDef(tree: DefDef)(using Context): Tree =
-    nonLocalReturnKeys.remove(tree.symbol) match {
-      case Some(key) => cpy.DefDef(tree)(rhs = nonLocalReturnTry(tree.rhs, key, tree.symbol))
-      case _ => tree
-    }
+    nonLocalReturnKeys.remove(tree.symbol) match
+      case key: TermSymbol => cpy.DefDef(tree)(rhs = nonLocalReturnTry(tree.rhs, key, tree.symbol))
+      case null => tree
 
   override def transformReturn(tree: Return)(using Context): Tree =
     if isNonLocalReturn(tree) then

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -64,12 +64,11 @@ object OverridingPairs {
       decls
     }
 
-    private val subParents = {
-      val subParents = newMutableSymbolMap[BitSet]
+    private val subParents =
+      val subParents = MutableSymbolMap[BitSet]()
       for (bc <- base.info.baseClasses)
         subParents(bc) = BitSet(parents.indices.filter(parents(_).derivesFrom(bc)): _*)
       subParents
-    }
 
     private def hasCommonParentAsSubclass(cls1: Symbol, cls2: Symbol): Boolean =
       (subParents(cls1) intersect subParents(cls2)).nonEmpty

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -77,7 +77,7 @@ object OverridingPairs {
      *  (maybe excluded because of hasCommonParentAsSubclass).
      *  These will not appear as overriding
      */
-    private val visited = new mutable.HashSet[Symbol]
+    private val visited = util.HashSet[Symbol]()
 
     /** The current entry candidate for overriding
      */

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -92,7 +92,7 @@ object PatternMatcher {
     /** A map from variable symbols to their defining trees
      *  and from labels to their defining plans
      */
-    private val initializer = newMutableSymbolMap[Tree]
+    private val initializer = MutableSymbolMap[Tree]()
 
     private def newVar(rhs: Tree, flags: FlagSet): TermSymbol =
       newSymbol(ctx.owner, PatMatStdBinderName.fresh(), Synthetic | Case | flags,

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc
+package dotty.tools
+package dotc
 package transform
 
 import dotty.tools.dotc.ast.{Trees, tpd}
@@ -59,7 +60,7 @@ class SuperAccessors(thisPhase: DenotTransformer) {
     ctx.owner.enclosingClass != invalidEnclClass
 
   /** List buffers for new accessor definitions, indexed by class */
-  private val accDefs = newMutableSymbolMap[mutable.ListBuffer[Tree]]
+  private val accDefs = MutableSymbolMap[mutable.ListBuffer[Tree]]()
 
   /** A super accessor call corresponding to `sel` */
   private def superAccessorCall(sel: Select, mixName: Name = nme.EMPTY)(using Context) = {
@@ -205,7 +206,7 @@ class SuperAccessors(thisPhase: DenotTransformer) {
   def wrapTemplate(tree: Template)(op: Template => Template)(using Context): Template = {
     accDefs(currentClass) = new mutable.ListBuffer[Tree]
     val impl = op(tree)
-    val accessors = accDefs.remove(currentClass).get
+    val accessors = accDefs.remove(currentClass).nn
     if (accessors.isEmpty) impl
     else {
       val (params, rest) = impl.body span {

--- a/compiler/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TailRec.scala
@@ -13,6 +13,7 @@ import core.StdNames.nme
 import core.Symbols._
 import reporting._
 import transform.MegaPhase.MiniPhase
+import util.LinearSet
 
 import scala.collection.mutable
 
@@ -258,7 +259,7 @@ class TailRec extends MiniPhase {
       }
 
     /** Symbols of Labeled blocks that are in tail position. */
-    private val tailPositionLabeledSyms = new mutable.HashSet[Symbol]()
+    private var tailPositionLabeledSyms = LinearSet.empty[Symbol]
 
     private var inTailPosition = true
 
@@ -283,7 +284,7 @@ class TailRec extends MiniPhase {
      *  a recursive call of a @tailrec annotated method (i.e. `isMandatory`).
      */
     private def isTraversalNeeded =
-      isMandatory || tailPositionLabeledSyms.nonEmpty
+      isMandatory || tailPositionLabeledSyms.size > 0
 
     def noTailTransform(tree: Tree)(using Context): Tree =
       if (isTraversalNeeded) transform(tree, tailPosition = false)

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -160,8 +160,8 @@ class TreeChecker extends Phase with SymTransformer {
 
   class Checker(phasesToCheck: Seq[Phase]) extends ReTyper with Checking {
 
-    private val nowDefinedSyms = new mutable.HashSet[Symbol]
-    private val patBoundSyms = new mutable.HashSet[Symbol]
+    private val nowDefinedSyms = util.HashSet[Symbol]()
+    private val patBoundSyms = util.HashSet[Symbol]()
     private val everDefinedSyms = MutableSymbolMap[untpd.Tree]()
 
     // don't check value classes after typer, as the constraint about constructors doesn't hold after transform

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -162,7 +162,7 @@ class TreeChecker extends Phase with SymTransformer {
 
     private val nowDefinedSyms = new mutable.HashSet[Symbol]
     private val patBoundSyms = new mutable.HashSet[Symbol]
-    private val everDefinedSyms = newMutableSymbolMap[untpd.Tree]
+    private val everDefinedSyms = MutableSymbolMap[untpd.Tree]()
 
     // don't check value classes after typer, as the constraint about constructors doesn't hold after transform
     override def checkDerivedValueClass(clazz: Symbol, stats: List[Tree])(using Context): Unit = ()

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -28,7 +28,7 @@ import Trees._
 import transform.SymUtils._
 import transform.TypeUtils._
 import Hashable._
-import util.{SourceFile, NoSource, IdentityHashMap}
+import util.{SourceFile, NoSource, EqHashMap}
 import config.{Config, Feature}
 import Feature.migrateTo3
 import config.Printers.{implicits, implicitsDetailed}
@@ -289,7 +289,7 @@ object Implicits:
    *  @param outerCtx  the next outer context that makes visible further implicits
    */
   class ContextualImplicits(val refs: List[ImplicitRef], val outerImplicits: ContextualImplicits)(initctx: Context) extends ImplicitRefs(initctx) {
-    private val eligibleCache = IdentityHashMap[Type, List[Candidate]]()
+    private val eligibleCache = EqHashMap[Type, List[Candidate]]()
 
     /** The level increases if current context has a different owner or scope than
      *  the context of the next-outer ImplicitRefs. This is however disabled under

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -534,7 +534,7 @@ trait ImplicitRunInfo:
         if partSeen.contains(t) then ()
         else if implicitScopeCache.contains(t) then parts += t
         else
-          partSeen.addEntry(t)
+          partSeen += t
           t.dealias match
             case t: TypeRef =>
               if isAnchor(t.symbol) then
@@ -578,12 +578,12 @@ trait ImplicitRunInfo:
             is.companionRefs
           case None =>
             if seen.contains(t) then
-              incomplete.addEntry(tp) // all references for `t` will be accounted for in `seen` so we return `EmptySet`.
+              incomplete += tp // all references for `t` will be accounted for in `seen` so we return `EmptySet`.
               TermRefSet.empty        // on the other hand, the refs of `tp` are now inaccurate, so `tp` is marked incomplete.
             else
-              seen.addEntry(t)
+              seen += t
               val is = recur(t)
-              if !implicitScopeCache.contains(t) then incomplete.addEntry(tp)
+              if !implicitScopeCache.contains(t) then incomplete += tp
               is.companionRefs
       end iscopeRefs
 
@@ -693,7 +693,7 @@ trait ImplicitRunInfo:
             if seen.contains(t) then
               WildcardType
             else
-              seen.addEntry(t)
+              seen += t
               t.underlying match
                 case TypeBounds(lo, hi) =>
                   if defn.isBottomTypeAfterErasure(lo) then apply(hi)

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -99,8 +99,8 @@ class ImportInfo(symf: Context ?=> Symbol,
   /** Compute info relating to the selector list */
   private def ensureInitialized(): Unit = if myExcluded == null then
     myExcluded = Set()
-    myForwardMapping = SimpleIdentityMap.Empty
-    myReverseMapping = SimpleIdentityMap.Empty
+    myForwardMapping = SimpleIdentityMap.empty
+    myReverseMapping = SimpleIdentityMap.empty
     for sel <- selectors do
       if sel.isWildcard then
         myWildcardImport = true
@@ -180,7 +180,7 @@ class ImportInfo(symf: Context ?=> Symbol,
   private var myUnimported: Symbol = _
 
   private var myOwner: Symbol = null
-  private var myResults: SimpleIdentityMap[TermName, java.lang.Boolean] = SimpleIdentityMap.Empty
+  private var myResults: SimpleIdentityMap[TermName, java.lang.Boolean] = SimpleIdentityMap.empty
 
   /** Does this import clause or a preceding import clause import `owner.feature`? */
   def featureImported(feature: TermName, owner: Symbol)(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -438,7 +438,7 @@ object Inferencing {
       if (vmap1 eq vmap) vmap else propagate(vmap1)
     }
 
-    propagate(accu(SimpleIdentityMap.Empty, tp))
+    propagate(accu(SimpleIdentityMap.empty, tp))
   }
 }
 

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -21,7 +21,7 @@ import SymDenotations.SymDenotation
 import Inferencing.isFullyDefined
 import config.Printers.inlining
 import ErrorReporting.errorTree
-import dotty.tools.dotc.util.{SimpleIdentityMap, SimpleIdentitySet, IdentityHashMap, SourceFile, SourcePosition, SrcPos}
+import dotty.tools.dotc.util.{SimpleIdentityMap, SimpleIdentitySet, EqHashMap, SourceFile, SourcePosition, SrcPos}
 import dotty.tools.dotc.parsing.Parsers.Parser
 import Nullables.{given _}
 

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -1041,7 +1041,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
             }
           }
 
-          extractBindVariance(SimpleIdentityMap.Empty, tpt.tpe)
+          extractBindVariance(SimpleIdentityMap.empty, tpt.tpe)
         }
 
         def addTypeBindings(typeBinds: TypeBindsMap)(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -21,7 +21,7 @@ import SymDenotations.SymDenotation
 import Inferencing.isFullyDefined
 import config.Printers.inlining
 import ErrorReporting.errorTree
-import dotty.tools.dotc.util.{SimpleIdentityMap, SimpleIdentitySet, SourceFile, SourcePosition, SrcPos}
+import dotty.tools.dotc.util.{SimpleIdentityMap, SimpleIdentitySet, IdentityHashMap, SourceFile, SourcePosition, SrcPos}
 import dotty.tools.dotc.parsing.Parsers.Parser
 import Nullables.{given _}
 
@@ -1320,8 +1320,8 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
       dropUnusedDefs(termBindings1.asInstanceOf[List[ValOrDefDef]], tree1)
     }
     else {
-      val refCount = newMutableSymbolMap[Int]
-      val bindingOfSym = newMutableSymbolMap[MemberDef]
+      val refCount = MutableSymbolMap[Int]()
+      val bindingOfSym = MutableSymbolMap[MemberDef]()
 
       def isInlineable(binding: MemberDef) = binding match {
         case ddef @ DefDef(_, Nil, Nil, _, _) => isElideableExpr(ddef.rhs)

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -246,7 +246,7 @@ object ProtoTypes {
     var typedArgs: List[Tree] = Nil
 
     /** A map in which typed arguments can be stored to be later integrated in `typedArgs`. */
-    var typedArg: SimpleIdentityMap[untpd.Tree, Tree] = SimpleIdentityMap.Empty
+    var typedArg: SimpleIdentityMap[untpd.Tree, Tree] = SimpleIdentityMap.empty
 
     /** The tupled or untupled version of this prototype, if it has been computed */
     var tupledDual: Type = NoType

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -651,11 +651,11 @@ object RefChecks {
         val seenClasses = new util.HashSet[Symbol](256)
         def addDecls(cls: Symbol): Unit =
           if (!seenClasses.contains(cls)) {
-            seenClasses.addEntry(cls)
+            seenClasses += cls
             for (mbr <- cls.info.decls)
               if (mbr.isTerm && !mbr.isOneOf(Synthetic | Bridge) && mbr.memberCanMatchInheritedSymbols &&
                   !membersToCheck.contains(mbr.name))
-                membersToCheck.addEntry(mbr.name)
+                membersToCheck += mbr.name
             cls.info.parents.map(_.classSymbol)
               .filter(_.isOneOf(AbstractOrTrait))
               .dropWhile(_.isOneOf(JavaDefined | Scala2x))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2594,7 +2594,7 @@ class Typer extends Namer
 
   def typedStats(stats: List[untpd.Tree], exprOwner: Symbol)(using Context): (List[Tree], Context) = {
     val buf = new mutable.ListBuffer[Tree]
-    var enumContexts: SimpleIdentityMap[Symbol, Context] = SimpleIdentityMap.Empty
+    var enumContexts: SimpleIdentityMap[Symbol, Context] = SimpleIdentityMap.empty
     val initialNotNullInfos = ctx.notNullInfos
       // A map from `enum` symbols to the contexts enclosing their definitions
     @tailrec def traverse(stats: List[untpd.Tree])(using Context): (List[Tree], Context) = stats match {

--- a/compiler/src/dotty/tools/dotc/util/EqHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/EqHashMap.scala
@@ -3,7 +3,7 @@ package dotty.tools.dotc.util
 /** A specialized implementation of GenericHashMap with identity hash and `eq`
  *  as comparison.
  */
-class IdentityHashMap[Key, Value]
+class EqHashMap[Key, Value]
     (initialCapacity: Int = 8, capacityMultiple: Int = 2)
 extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   import GenericHashMap.DenseLimit
@@ -78,4 +78,4 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
         val key = oldTable(idx).asInstanceOf[Key]
         if key != null then addOld(key, oldTable(idx + 1).asInstanceOf[Value])
         idx += 2
-end IdentityHashMap
+end EqHashMap

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -22,9 +22,9 @@ object GenericHashMap:
  *                           However, a table of size up to DenseLimit will be re-sized only
  *                           once the number of elements reaches the table's size.
  */
-abstract class GenericHashMap[Key >: Null <: AnyRef, Value >: Null <: AnyRef]
+abstract class GenericHashMap[Key <: AnyRef, Value >: Null <: AnyRef]
     (protected val initialCapacity: Int = 8,
-     protected val capacityMultiple: Int = 3) extends Map[Key, Value]:
+     protected val capacityMultiple: Int = 3) extends MutableMap[Key, Value]:
   import GenericHashMap.DenseLimit
 
   protected var used: Int = _

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -66,9 +66,6 @@ abstract class GenericHashMap[Key >: Null <: AnyRef, Value >: Null <: AnyRef]
   private def keyAt(idx: Int): Key = table(idx).asInstanceOf[Key]
   private def valueAt(idx: Int): Value = table(idx + 1).asInstanceOf[Value]
 
-  /** Find entry such that `isEqual(x, entry)`. If it exists, return it.
-   *  If not, enter `x` in set and return `x`.
-   */
   def lookup(key: Key): Value =
     var idx = firstIndex(key)
     var k = keyAt(idx)

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -56,7 +56,7 @@ abstract class GenericHashMap[Key <: AnyRef, Value >: Null <: AnyRef]
   /** Equality, to be implemented in subclass */
   protected def isEqual(x: Key, y: Key): Boolean
 
-  /** Turn hashcode `x` into a table index */
+  /** Turn successor index or hash code `x` into a table index */
   private def index(x: Int): Int = x & (table.length - 2)
 
   private def firstIndex(key: Key) = if isDense then 0 else index(hash(key))

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -177,6 +177,9 @@ abstract class GenericHashMap[Key, Value]
   def keysIterator: Iterator[Key] = new EntryIterator:
     def entry(idx: Int) = keyAt(idx)
 
+  def valuesIterator: Iterator[Value] = new EntryIterator:
+    def entry(idx: Int) = valueAt(idx)
+
   override def toString: String =
     iterator.map((k, v) => s"$k -> $v").mkString("HashMap(", ", ", ")")
 

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -1,0 +1,146 @@
+package dotty.tools.dotc.util
+
+object GenericHashMap:
+
+  /** The number of elements up to which dense packing is used.
+   *  If the number of elements reaches `DenseLimit` a hash table is used instead
+   */
+  inline val DenseLimit = 8
+
+/** A hash table using open hashing with linear scan which is also very space efficient
+ *  at small sizes. The implementations of `hash` and `isEqual` are left open. They have
+ *  to be provided by subclasses.
+ *
+ *  @param  initialCapacity  Indicates the initial number of slots in the hash table.
+ *                           The actual number of slots is always a power of 2, so the
+ *                           initial size of the table will be the smallest power of two
+ *                           that is equal or greater than the given `initialCapacity`.
+ *                           Minimum value is 4.
+ *  @param  capacityMultiple The minimum multiple of capacity relative to used elements.
+ *                           The hash table will be re-sized once the number of elements
+ *                           multiplied by capacityMultiple exceeds the current size of the hash table.
+ *                           However, a table of size up to DenseLimit will be re-sized only
+ *                           once the number of elements reaches the table's size.
+ */
+abstract class GenericHashMap[Key >: Null <: AnyRef, Value >: Null <: AnyRef]
+    (protected val initialCapacity: Int = 8,
+     protected val capacityMultiple: Int = 3) extends Map[Key, Value]:
+  import GenericHashMap.DenseLimit
+
+  protected var used: Int = _
+  protected var limit: Int = _
+  protected var table: Array[AnyRef] = _
+  clear()
+
+  private def allocate(capacity: Int) =
+    table = new Array[AnyRef](capacity * 2)
+    limit = if capacity <= DenseLimit then capacity - 1 else capacity / capacityMultiple
+
+  private def roundToPower(n: Int) =
+    if n < 4 then 4
+    else if Integer.bitCount(n) == 1 then n
+    else 1 << (32 - Integer.numberOfLeadingZeros(n))
+
+  /** Remove all elements from this table and set back to initial configuration */
+  def clear(): Unit =
+    used = 0
+    allocate(roundToPower(initialCapacity))
+
+  /** The number of elements in the set */
+  def size: Int = used
+
+  protected def isDense = limit < DenseLimit
+
+  /** Hashcode, to be implemented in subclass */
+  protected def hash(x: Key): Int
+
+  /** Equality, to be implemented in subclass */
+  protected def isEqual(x: Key, y: Key): Boolean
+
+  /** Turn hashcode `x` into a table index */
+  private def index(x: Int): Int = x & (table.length - 2)
+
+  private def firstIndex(key: Key) = if isDense then 0 else index(hash(key))
+  private def nextIndex(idx: Int) = index(idx + 2)
+
+  private def keyAt(idx: Int): Key = table(idx).asInstanceOf[Key]
+  private def valueAt(idx: Int): Value = table(idx + 1).asInstanceOf[Value]
+
+  /** Find entry such that `isEqual(x, entry)`. If it exists, return it.
+   *  If not, enter `x` in set and return `x`.
+   */
+  def lookup(key: Key): Value =
+    var idx = firstIndex(key)
+    var k = keyAt(idx)
+    while k != null do
+      if isEqual(k, key) then return valueAt(idx)
+      idx = nextIndex(idx)
+      k = keyAt(idx)
+    null
+
+  def update(key: Key, value: Value): Unit =
+    var idx = firstIndex(key)
+    var k = keyAt(idx)
+    while k != null do
+      if isEqual(k, key) then
+        table(idx + 1) = value
+        return
+      idx = nextIndex(idx)
+      k = keyAt(idx)
+    table(idx) = key
+    table(idx + 1) = value
+    used += 1
+    if used > limit then growTable()
+
+  def remove(key: Key): Unit =
+    var idx = firstIndex(key)
+    var k = keyAt(idx)
+    while k != null do
+      if isEqual(k, key) then
+        var hole = idx
+        while
+          idx = nextIndex(idx)
+          k = keyAt(idx)
+          k != null && (isDense || index(hash(k)) != idx)
+        do
+          table(hole) = k
+          table(hole + 1) = valueAt(idx)
+          hole = idx
+        table(hole) = null
+        used -= 1
+        return
+      idx = nextIndex(idx)
+      k = keyAt(idx)
+
+  private def addOld(key: Key, value: AnyRef): Unit =
+    var idx = firstIndex(key)
+    var k = keyAt(idx)
+    while k != null do
+      idx = nextIndex(idx)
+      k = keyAt(idx)
+    table(idx) = key
+    table(idx + 1) = value
+
+  protected def growTable(): Unit =
+    val oldTable = table
+    val newLength =
+      if oldTable.length == DenseLimit then DenseLimit * 2 * roundToPower(capacityMultiple)
+      else table.length
+    allocate(newLength)
+    if isDense then
+      Array.copy(oldTable, 0, table, 0, oldTable.length)
+    else
+      var idx = 0
+      while idx < oldTable.length do
+        val key = oldTable(idx).asInstanceOf[Key]
+        if key != null then addOld(key, oldTable(idx + 1))
+        idx += 2
+
+  def iterator: Iterator[(Key, Value)] =
+    for idx <- (0 until table.length by 2).iterator
+        if keyAt(idx) != null
+    yield (keyAt(idx), valueAt(idx))
+
+  override def toString: String =
+    iterator.map((k, v) => s"$k -> $v").mkString("LinearTable(", ", ", ")")
+end GenericHashMap

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -106,7 +106,7 @@ abstract class GenericHashMap[Key <: AnyRef, Value >: Null <: AnyRef]
         do
           if isDense
             || index(hole - index(hash(k))) < limit * 2
-               // hash(k) is then logically at or after hole; can be moved forward to fill hole
+               // hash(k) is then logically at or before hole; can be moved forward to fill hole
           then
             table(hole) = k
             table(hole + 1) = valueAt(idx)

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -23,7 +23,7 @@ object GenericHashMap:
  *                           once the number of elements reaches the table's size.
  */
 abstract class GenericHashMap[Key <: AnyRef, Value >: Null <: AnyRef]
-    (initialCapacity: Int = 8, capacityMultiple: Int = 3) extends MutableMap[Key, Value]:
+    (initialCapacity: Int, capacityMultiple: Int) extends MutableMap[Key, Value]:
   import GenericHashMap.DenseLimit
 
   protected var used: Int = _
@@ -102,11 +102,15 @@ abstract class GenericHashMap[Key <: AnyRef, Value >: Null <: AnyRef]
         while
           idx = nextIndex(idx)
           k = keyAt(idx)
-          k != null && (isDense || index(hash(k)) != idx)
+          k != null
         do
-          table(hole) = k
-          table(hole + 1) = valueAt(idx)
-          hole = idx
+          if isDense
+            || index(hole - index(hash(k))) < limit * 2
+               // hash(k) is then logically at or after hole; can be moved forward to fill hole
+          then
+            table(hole) = k
+            table(hole + 1) = valueAt(idx)
+            hole = idx
         table(hole) = null
         used -= 1
         return

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -117,6 +117,11 @@ abstract class GenericHashMap[Key <: AnyRef, Value >: Null <: AnyRef]
       idx = nextIndex(idx)
       k = keyAt(idx)
 
+  def getOrElseUpdate(key: Key, value: => Value): Value =
+    var v = lookup(key)
+    if v == null then v = value
+    v
+
   private def addOld(key: Key, value: AnyRef): Unit =
     Stats.record(statsItem("re-enter"))
     var idx = firstIndex(key)

--- a/compiler/src/dotty/tools/dotc/util/HashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashMap.scala
@@ -3,7 +3,7 @@ package dotty.tools.dotc.util
 /** A specialized implementation of GenericHashMap with standard hashCode and equals
  *  as comparison
  */
-class HashMap[Key >: Null <: AnyRef, Value >: Null <: AnyRef]
+class HashMap[Key <: AnyRef, Value >: Null <: AnyRef]
     (initialCapacity: Int = 8, capacityMultiple: Int = 3)
 extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   import GenericHashMap.DenseLimit

--- a/compiler/src/dotty/tools/dotc/util/HashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashMap.scala
@@ -3,7 +3,7 @@ package dotty.tools.dotc.util
 /** A specialized implementation of GenericHashMap with standard hashCode and equals
  *  as comparison
  */
-class HashMap[Key <: AnyRef, Value]
+class HashMap[Key, Value]
     (initialCapacity: Int = 8, capacityMultiple: Int = 2)
 extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   import GenericHashMap.DenseLimit
@@ -17,6 +17,20 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
 
   // The following methods are duplicated from GenericHashMap
   // to avoid polymorphic dispatches
+  private def index(x: Int): Int = x & (table.length - 2)
+
+  private def firstIndex(key: Key) = if isDense then 0 else index(hash(key))
+  private def nextIndex(idx: Int) =
+    Stats.record(statsItem("miss"))
+    index(idx + 2)
+
+  private def keyAt(idx: Int): Key = table(idx).asInstanceOf[Key]
+  private def valueAt(idx: Int): Value = table(idx + 1).asInstanceOf[Value]
+
+  private def setKey(idx: Int, key: Key) =
+    table(idx) = key.asInstanceOf[AnyRef]
+  private def setValue(idx: Int, value: Value) =
+    table(idx + 1) = value.asInstanceOf[AnyRef]
 
   override def lookup(key: Key): Value | Null =
     Stats.record(statsItem("lookup"))
@@ -34,24 +48,24 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
     var k = keyAt(idx)
     while k != null do
       if isEqual(k, key) then
-        setTable(idx + 1, value)
+        setValue(idx, value)
         return
       idx = nextIndex(idx)
       k = keyAt(idx)
-    table(idx) = key
-    setTable(idx + 1, value)
+    setKey(idx, key)
+    setValue(idx, value)
     used += 1
     if used > limit then growTable()
 
-  private def addOld(key: Key, value: AnyRef): Unit =
+  private def addOld(key: Key, value: Value): Unit =
     Stats.record(statsItem("re-enter"))
     var idx = firstIndex(key)
     var k = keyAt(idx)
     while k != null do
       idx = nextIndex(idx)
       k = keyAt(idx)
-    table(idx) = key
-    table(idx + 1) = value
+    setKey(idx, key)
+    setValue(idx, value)
 
   override def copyFrom(oldTable: Array[AnyRef]): Unit =
     if isDense then
@@ -60,6 +74,6 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
       var idx = 0
       while idx < oldTable.length do
         val key = oldTable(idx).asInstanceOf[Key]
-        if key != null then addOld(key, oldTable(idx + 1))
+        if key != null then addOld(key, oldTable(idx + 1).asInstanceOf[Value])
         idx += 2
 end HashMap

--- a/compiler/src/dotty/tools/dotc/util/HashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashMap.scala
@@ -26,9 +26,6 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   private def keyAt(idx: Int): Key = table(idx).asInstanceOf[Key]
   private def valueAt(idx: Int): Value = table(idx + 1).asInstanceOf[Value]
 
-  /** Find entry such that `isEqual(x, entry)`. If it exists, return it.
-   *  If not, enter `x` in set and return `x`.
-   */
   override def lookup(key: Key): Value =
     var idx = firstIndex(key)
     var k = keyAt(idx)

--- a/compiler/src/dotty/tools/dotc/util/HashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashMap.scala
@@ -3,7 +3,7 @@ package dotty.tools.dotc.util
 /** A specialized implementation of GenericHashMap with standard hashCode and equals
  *  as comparison
  */
-class HashMap[Key <: AnyRef, Value >: Null <: AnyRef]
+class HashMap[Key <: AnyRef, Value]
     (initialCapacity: Int = 8, capacityMultiple: Int = 2)
 extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   import GenericHashMap.DenseLimit
@@ -18,18 +18,7 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   // The following methods are duplicated from GenericHashMap
   // to avoid polymorphic dispatches
 
-  /** Turn successor index or hash code `x` into a table index */
-  private def index(x: Int): Int = x & (table.length - 2)
-
-  private def firstIndex(key: Key) = if isDense then 0 else index(hash(key))
-  private def nextIndex(idx: Int) =
-    Stats.record(statsItem("miss"))
-    index(idx + 2)
-
-  private def keyAt(idx: Int): Key = table(idx).asInstanceOf[Key]
-  private def valueAt(idx: Int): Value = table(idx + 1).asInstanceOf[Value]
-
-  override def lookup(key: Key): Value =
+  override def lookup(key: Key): Value | Null =
     Stats.record(statsItem("lookup"))
     var idx = firstIndex(key)
     var k = keyAt(idx)
@@ -45,12 +34,12 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
     var k = keyAt(idx)
     while k != null do
       if isEqual(k, key) then
-        table(idx + 1) = value
+        setTable(idx + 1, value)
         return
       idx = nextIndex(idx)
       k = keyAt(idx)
     table(idx) = key
-    table(idx + 1) = value
+    setTable(idx + 1, value)
     used += 1
     if used > limit then growTable()
 

--- a/compiler/src/dotty/tools/dotc/util/HashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashMap.scala
@@ -1,18 +1,18 @@
 package dotty.tools.dotc.util
 
-/** A specialized implementation of GenericHashMap with identity hash and `eq`
- *  as comparison.
+/** A specialized implementation of GenericHashMap with standard hashCode and equals
+ *  as comparison
  */
-class IdentityHashMap[Key >: Null <: AnyRef, Value >: Null <: AnyRef]
+class HashMap[Key >: Null <: AnyRef, Value >: Null <: AnyRef]
     (initialCapacity: Int = 8, capacityMultiple: Int = 3)
 extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   import GenericHashMap.DenseLimit
 
   /** Hashcode, by default `System.identityHashCode`, but can be overriden */
-  final def hash(x: Key): Int = System.identityHashCode(x)
+  final def hash(x: Key): Int = x.hashCode
 
   /** Equality, by default `eq`,  but can be overridden */
-  final def isEqual(x: Key, y: Key): Boolean = x eq y
+  final def isEqual(x: Key, y: Key): Boolean = x.equals(y)
 
   // The following methdods are duplicated from GenericHashMap
   // to avoid polymorphic dispatches
@@ -51,4 +51,4 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
     table(idx + 1) = value
     used += 1
     if used > limit then growTable()
-end IdentityHashMap
+end HashMap

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -107,7 +107,7 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Mu
         while
           idx = nextIndex(idx)
           e = entryAt(idx)
-          e != null && (isDense || index(hash(e)) != idx)
+          e != null
         do
           if isDense
             || index(hole - index(hash(e))) < limit

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -19,7 +19,7 @@ object HashSet:
  *                           However, a table of size up to DenseLimit will be re-sized only
  *                           once the number of elements reaches the table's size.
  */
-class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends MutableSet[T] {
+class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends MutableSet[T] {
   import HashSet.DenseLimit
 
   private var used: Int = _
@@ -65,8 +65,9 @@ class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: I
     index(idx + 1)
 
   protected def entryAt(idx: Int) = table(idx).asInstanceOf[T]
+  protected def setEntry(idx: Int, x: T) = table(idx) = x.asInstanceOf[AnyRef]
 
-  def lookup(x: T): T =
+  def lookup(x: T): T | Null =
     Stats.record(statsItem("lookup"))
     var idx = firstIndex(x)
     var e = entryAt(idx)
@@ -79,7 +80,7 @@ class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: I
 /** Add entry at `x` at index `idx` */
   protected def addEntryAt(idx: Int, x: T): T =
     Stats.record(statsItem("addEntryAt"))
-    table(idx) = x
+    setEntry(idx, x)
     used += 1
     if used > limit then growTable()
     x
@@ -112,7 +113,7 @@ class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: I
             || index(hole - index(hash(e))) < limit
                // hash(k) is then logically at or before hole; can be moved forward to fill hole
           then
-            table(hole) = e
+            setEntry(hole, e)
             hole = idx
         table(hole) = null
         used -= 1
@@ -127,7 +128,7 @@ class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: I
     while e != null do
       idx = nextIndex(idx)
       e = entryAt(idx)
-    table(idx) = x
+    setEntry(idx, x)
 
   def copyFrom(oldTable: Array[AnyRef]): Unit =
     if isDense then

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -1,44 +1,41 @@
 package dotty.tools.dotc.util
 
+object HashSet:
+
+  /** The number of elements up to which dense packing is used.
+   *  If the number of elements reaches `DenseLimit` a hash table is used instead
+   */
+  inline val DenseLimit = 8
+
 /** A hash set that allows some privileged protected access to its internals
  *  @param  initialCapacity  Indicates the initial number of slots in the hash table.
  *                           The actual number of slots is always a power of 2, so the
  *                           initial size of the table will be the smallest power of two
  *                           that is equal or greater than the given `initialCapacity`.
- *  @param  loadFactor       The maximum fraction of used elements relative to capacity.
- *                           The hash table will be re-sized once the number of elements exceeds
- *                           the current size of the hash table multiplied by loadFactor.
- *  With the defaults given, the first resize of the table happens once the number of elements
- *  grows beyond 16.
+ *                           Minimum value is 4.
+*  @param  capacityMultiple The minimum multiple of capacity relative to used elements.
+ *                           The hash table will be re-sized once the number of elements
+ *                           multiplied by capacityMultiple exceeds the current size of the hash table.
+ *                           However, a table of size up to DenseLimit will be re-sized only
+ *                           once the number of elements reaches the table's size.
  */
-class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 16, loadFactor: Float = 0.25f) extends MutableSet[T] {
+class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: Int = 4) extends MutableSet[T] {
+  import HashSet.DenseLimit
+
   private var used: Int = _
   private var limit: Int = _
   private var table: Array[AnyRef] = _
 
-  private def roundToPower(n: Int) =
-    if Integer.bitCount(n) == 1 then n
-    else
-      def recur(n: Int): Int =
-        if n == 1 then 2
-        else recur(n >>> 1) << 1
-      recur(n)
-
-  protected def isEqual(x: T, y: T): Boolean = x.equals(y)
-
-  // Counters for Stats
-  var accesses: Int = 0
-  var misses: Int = 0
-
   clear()
 
-  /** The number of elements in the set */
-  def size: Int = used
+  private def allocate(capacity: Int) =
+    table = new Array[AnyRef](capacity)
+    limit = if capacity <= DenseLimit then capacity - 1 else capacity / capacityMultiple
 
-  private def allocate(size: Int) = {
-    table = new Array[AnyRef](size)
-    limit = (size * loadFactor).toInt
-  }
+  private def roundToPower(n: Int) =
+    if n < 4 then 4
+    else if Integer.bitCount(n) == 1 then n
+    else 1 << (32 - Integer.numberOfLeadingZeros(n))
 
   /** Remove all elements from this set and set back to initial configuration */
   def clear(): Unit = {
@@ -46,154 +43,122 @@ class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 16, loadFactor: Float 
     allocate(roundToPower(initialCapacity))
   }
 
+  /** The number of elements in the set */
+  def size: Int = used
+
+  protected def isDense = limit < DenseLimit
+
+  /** Hashcode, by defualt `x.hashCode`, can be overridden */
+  protected def hash(x: T): Int = x.hashCode
+
+  /** Hashcode, by default `equals`, can be overridden */
+  protected def isEqual(x: T, y: T): Boolean = x.equals(y)
+
   /** Turn hashcode `x` into a table index */
-  private def index(x: Int): Int = x & (table.length - 1)
+  protected def index(x: Int): Int = x & (table.length - 1)
 
-  /** Hashcode, can be overridden */
-  def hash(x: T): Int = x.hashCode
+  protected def firstIndex(x: T) = if isDense then 0 else index(hash(x))
+  protected def nextIndex(idx: Int) =
+    Stats.record(statsItem("miss"))
+    index(idx + 1)
 
-  private def entryAt(idx: Int) = table(idx).asInstanceOf[T]
+  protected def entryAt(idx: Int) = table(idx).asInstanceOf[T]
 
-  /** Find entry such that `isEqual(x, entry)`. If it exists, return it.
-   *  If not, enter `x` in set and return `x`.
-   */
-  def findEntryOrUpdate(x: T): T = {
-    if (Stats.enabled) accesses += 1
-    var h = index(hash(x))
-    var entry = entryAt(h)
-    while (entry ne null) {
-      if (isEqual(x, entry)) return entry
-      if (Stats.enabled) misses += 1
-      h = index(h + 1)
-      entry = entryAt(h)
-    }
-    addEntryAt(h, x)
-  }
+  def lookup(x: T): T =
+    Stats.record(statsItem("lookup"))
+    var idx = firstIndex(x)
+    var e = entryAt(idx)
+    while e != null do
+      if isEqual(e, x) then return e
+      idx = nextIndex(idx)
+      e = entryAt(idx)
+    null
 
-  /** Add entry at `x` at index `idx` */
-  private def addEntryAt(idx: Int, x: T) = {
+/** Add entry at `x` at index `idx` */
+  protected def addEntryAt(idx: Int, x: T): T =
+    Stats.record(statsItem("addEntryAt"))
     table(idx) = x
     used += 1
-    if (used > limit) growTable()
+    if used > limit then growTable()
     x
-  }
 
-  /** The entry in the set such that `isEqual(x, entry)`, or else `null`. */
-  def lookup(x: T): T = {
-    if (Stats.enabled) accesses += 1
-    var h = index(hash(x))
-    var entry = entryAt(h)
-    while ((entry ne null) && !isEqual(x, entry)) {
-      if (Stats.enabled) misses += 1
-      h = index(h + 1)
-      entry = entryAt(h)
-    }
-    entry.asInstanceOf[T]
-  }
+  def put(x: T): T =
+    Stats.record(statsItem("put"))
+    var idx = firstIndex(x)
+    var e = entryAt(idx)
+    while e != null do
+      if isEqual(e, x) then return e
+      idx = nextIndex(idx)
+      e = entryAt(idx)
+    addEntryAt(idx, x)
 
-  private var rover: Int = -1
-
-  /** Privileged access: Find first entry with given hashcode */
-  protected def findEntryByHash(hashCode: Int): T = {
-    rover = index(hashCode)
-    nextEntryByHash(hashCode)
-  }
-
-  /** Privileged access: Find next entry with given hashcode. Needs to immediately
-   *  follow a `findEntryByhash` or `nextEntryByHash` operation.
-   */
-  protected def nextEntryByHash(hashCode: Int): T = {
-    if (Stats.enabled) accesses += 1
-    var entry = table(rover)
-    while (entry ne null) {
-      rover = index(rover + 1)
-      if (hash(entry.asInstanceOf[T]) == hashCode) return entry.asInstanceOf[T]
-      if (Stats.enabled) misses += 1
-      entry = table(rover)
-    }
-    null
-  }
-
-  /** Privileged access: Add entry `x` at the last position where an unsuccsessful
-   *  `findEntryByHash` or `nextEntryByhash` operation returned. Needs to immediately
-   *  follow a `findEntryByhash` or `nextEntryByHash` operation that was unsuccessful,
-   *  i.e. that returned `null`.
-   */
-  protected def addEntryAfterScan(x: T): T = addEntryAt(rover, x)
-
-  private def addOldEntry(x: T): Unit = {
-    var h = index(hash(x))
-    var entry = entryAt(h)
-    while (entry ne null) {
-      h = index(h + 1)
-      entry = entryAt(h)
-    }
-    table(h) = x
-  }
-
-  private def growTable(): Unit = {
-    val oldtable = table
-    allocate(table.length * 2)
-    var i = 0
-    while (i < oldtable.length) {
-      val entry = oldtable(i)
-      if (entry ne null) addOldEntry(entry.asInstanceOf[T])
-      i += 1
-    }
-  }
-
-  /** Add entry `x` to set */
-  def += (x: T): Unit = {
-    if (Stats.enabled) accesses += 1
-    var h = index(hash(x))
-    var entry = entryAt(h)
-    while (entry ne null) {
-      if (isEqual(x, entry)) return
-      if (Stats.enabled) misses += 1
-      h = index(h + 1)
-      entry = entryAt(h)
-    }
-    table(h) = x
-    used += 1
-    if (used > (table.length >> 2)) growTable()
-  }
+  def +=(x: T): Unit = put(x)
 
   def -= (x: T): Unit =
-    if (Stats.enabled) accesses += 1
-    var h = index(hash(x))
-    var entry = entryAt(h)
-    while entry != null do
-      if isEqual(x, entry) then
-        var hole = h
+    Stats.record(statsItem("remove"))
+    var idx = firstIndex(x)
+    var e = entryAt(idx)
+    while e != null do
+      if isEqual(e, x) then
+        var hole = idx
         while
-          h = index(h + 1)
-          entry = entryAt(h)
-          entry != null && index(hash(entry)) != h
+          idx = nextIndex(idx)
+          e = entryAt(idx)
+          e != null && (isDense || index(hash(e)) != idx)
         do
-          table(hole) = entry
-          hole = h
+          table(hole) = e
+          hole = idx
         table(hole) = null
         used -= 1
         return
-      h = index(h + 1)
-      entry = entryAt(h)
-  end -=
+      idx = nextIndex(idx)
+      e = entryAt(idx)
 
-  /** Add all entries in `xs` to set */
-  def ++= (xs: IterableOnce[T]): Unit =
-    xs.iterator.foreach(this += _)
+  private def addOld(x: T) =
+    Stats.record(statsItem("re-enter"))
+    var idx = firstIndex(x)
+    var e = entryAt(idx)
+    while e != null do
+      idx = nextIndex(idx)
+      e = entryAt(idx)
+    table(idx) = x
 
-  /** The iterator of all elements in the set */
-  def iterator: Iterator[T] = new Iterator[T] {
-    private var i = 0
-    def hasNext: Boolean = {
-      while (i < table.length && (table(i) eq null)) i += 1
-      i < table.length
-    }
-    def next(): T =
-      if (hasNext) { i += 1; table(i - 1).asInstanceOf[T] }
-      else null
-  }
+  def copyFrom(oldTable: Array[AnyRef]): Unit =
+    if isDense then
+      Array.copy(oldTable, 0, table, 0, oldTable.length)
+    else
+      var idx = 0
+      while idx < oldTable.length do
+        val e = oldTable(idx).asInstanceOf[T]
+        if e != null then addOld(e)
+        idx += 1
 
-  override def toString(): String = "HashSet(%d / %d)".format(used, table.length)
+  protected def growTable(): Unit =
+    val oldTable = table
+    val newLength =
+      if oldTable.length == DenseLimit then DenseLimit * roundToPower(capacityMultiple)
+      else table.length * 2
+    allocate(newLength)
+    copyFrom(oldTable)
+
+  abstract class EntryIterator extends Iterator[T]:
+    def entry(idx: Int): T
+    private var idx = 0
+    def hasNext =
+      while idx < table.length && table(idx) == null do idx += 1
+      idx < table.length
+    def next() =
+      require(hasNext)
+      try entry(idx) finally idx += 1
+
+  def iterator: Iterator[T] = new EntryIterator():
+    def entry(idx: Int) = entryAt(idx)
+
+  override def toString: String =
+    iterator.mkString("HashSet(", ", ", ")")
+
+  protected def statsItem(op: String) =
+    val prefix = if isDense then "HashSet(dense)." else "HashSet."
+    val suffix = getClass.getSimpleName
+    s"$prefix$op $suffix"
 }

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -109,8 +109,8 @@ class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: I
           e != null && (isDense || index(hash(e)) != idx)
         do
           if isDense
-            || index(hole - index(hash(k))) < limit
-               // hash(k) is then logically at or after hole; can be moved forward to fill hole
+            || index(hole - index(hash(e))) < limit
+               // hash(k) is then logically at or before hole; can be moved forward to fill hole
           then
             table(hole) = e
             hole = idx

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -108,8 +108,12 @@ class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: I
           e = entryAt(idx)
           e != null && (isDense || index(hash(e)) != idx)
         do
-          table(hole) = e
-          hole = idx
+          if isDense
+            || index(hole - index(hash(k))) < limit
+               // hash(k) is then logically at or after hole; can be moved forward to fill hole
+          then
+            table(hole) = e
+            hole = idx
         table(hole) = null
         used -= 1
         return

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -19,7 +19,7 @@ object HashSet:
  *                           However, a table of size up to DenseLimit will be re-sized only
  *                           once the number of elements reaches the table's size.
  */
-class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: Int = 4) extends MutableSet[T] {
+class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends MutableSet[T] {
   import HashSet.DenseLimit
 
   private var used: Int = _
@@ -56,6 +56,8 @@ class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: I
 
   /** Turn hashcode `x` into a table index */
   protected def index(x: Int): Int = x & (table.length - 1)
+
+  protected def currentTable: Array[AnyRef] = table
 
   protected def firstIndex(x: T) = if isDense then 0 else index(hash(x))
   protected def nextIndex(idx: Int) =
@@ -136,7 +138,7 @@ class HashSet[T >: Null <: AnyRef](initialCapacity: Int = 8, capacityMultiple: I
   protected def growTable(): Unit =
     val oldTable = table
     val newLength =
-      if oldTable.length == DenseLimit then DenseLimit * roundToPower(capacityMultiple)
+      if oldTable.length == DenseLimit then DenseLimit * 2 * roundToPower(capacityMultiple)
       else table.length * 2
     allocate(newLength)
     copyFrom(oldTable)

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc.util
 
 /** A hash set that allows some privileged protected access to its internals
  */
-class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int, loadFactor: Float = 0.25f) extends Set[T] {
+class HashSet[T >: Null <: AnyRef](powerOfTwoInitialCapacity: Int = 16, loadFactor: Float = 0.25f) extends MutableSet[T] {
   private var used: Int = _
   private var limit: Int = _
   private var table: Array[AnyRef] = _

--- a/compiler/src/dotty/tools/dotc/util/IdentityHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/IdentityHashMap.scala
@@ -3,7 +3,7 @@ package dotty.tools.dotc.util
 /** A specialized implementation of GenericHashMap with identity hash and `eq`
  *  as comparison.
  */
-class IdentityHashMap[Key <: AnyRef, Value]
+class IdentityHashMap[Key, Value]
     (initialCapacity: Int = 8, capacityMultiple: Int = 2)
 extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   import GenericHashMap.DenseLimit
@@ -14,12 +14,25 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   final def hash(x: Key): Int = System.identityHashCode(x) << 1
 
   /** Equality, by default `eq`,  but can be overridden */
-  final def isEqual(x: Key, y: Key): Boolean = x eq y
+  final def isEqual(x: Key, y: Key): Boolean = x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
 
   // The following methods are duplicated from GenericHashMap
   // to avoid polymorphic dispatches.
   // Aside: It would be nice to have a @specialized annotation that does
   // this automatically
+
+  private def index(x: Int): Int = x & (table.length - 2)
+
+  private def firstIndex(key: Key) = if isDense then 0 else index(hash(key))
+  private def nextIndex(idx: Int) =
+    Stats.record(statsItem("miss"))
+    index(idx + 2)
+
+  private def keyAt(idx: Int): Key = table(idx).asInstanceOf[Key]
+  private def valueAt(idx: Int): Value = table(idx + 1).asInstanceOf[Value]
+
+  private def setKey(idx: Int, key: Key) = table(idx) = key.asInstanceOf[AnyRef]
+  private def setValue(idx: Int, value: Value) = table(idx + 1) = value.asInstanceOf[AnyRef]
 
   override def lookup(key: Key): Value | Null =
     Stats.record(statsItem("lookup"))
@@ -37,24 +50,24 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
     var k = keyAt(idx)
     while k != null do
       if isEqual(k, key) then
-        setTable(idx + 1, value)
+        setValue(idx, value)
         return
       idx = nextIndex(idx)
       k = keyAt(idx)
-    table(idx) = key
-    setTable(idx + 1, value)
+    setKey(idx, key)
+    setValue(idx, value)
     used += 1
     if used > limit then growTable()
 
-  private def addOld(key: Key, value: AnyRef): Unit =
+  private def addOld(key: Key, value: Value): Unit =
     Stats.record(statsItem("re-enter"))
     var idx = firstIndex(key)
     var k = keyAt(idx)
     while k != null do
       idx = nextIndex(idx)
       k = keyAt(idx)
-    table(idx) = key
-    table(idx + 1) = value
+    setKey(idx, key)
+    setValue(idx, value)
 
   override def copyFrom(oldTable: Array[AnyRef]): Unit =
     if isDense then
@@ -63,6 +76,6 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
       var idx = 0
       while idx < oldTable.length do
         val key = oldTable(idx).asInstanceOf[Key]
-        if key != null then addOld(key, oldTable(idx + 1))
+        if key != null then addOld(key, oldTable(idx + 1).asInstanceOf[Value])
         idx += 2
 end IdentityHashMap

--- a/compiler/src/dotty/tools/dotc/util/IdentityHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/IdentityHashMap.scala
@@ -3,7 +3,7 @@ package dotty.tools.dotc.util
 /** A specialized implementation of GenericHashMap with identity hash and `eq`
  *  as comparison.
  */
-class IdentityHashMap[Key >: Null <: AnyRef, Value >: Null <: AnyRef]
+class IdentityHashMap[Key <: AnyRef, Value >: Null <: AnyRef]
     (initialCapacity: Int = 8, capacityMultiple: Int = 3)
 extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   import GenericHashMap.DenseLimit

--- a/compiler/src/dotty/tools/dotc/util/IdentityHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/IdentityHashMap.scala
@@ -26,9 +26,6 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
   private def keyAt(idx: Int): Key = table(idx).asInstanceOf[Key]
   private def valueAt(idx: Int): Value = table(idx + 1).asInstanceOf[Value]
 
-  /** Find entry such that `isEqual(x, entry)`. If it exists, return it.
-   *  If not, enter `x` in set and return `x`.
-   */
   override def lookup(key: Key): Value =
     var idx = firstIndex(key)
     var k = keyAt(idx)

--- a/compiler/src/dotty/tools/dotc/util/LinearMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearMap.scala
@@ -12,19 +12,19 @@ opaque type LinearMap[K <: AnyRef, V >: Null <: AnyRef] =
 
 object LinearMap:
 
-  def Empty[K <: AnyRef, V >: Null <: AnyRef]: LinearMap[K, V] =
+  def empty[K <: AnyRef, V >: Null <: AnyRef]: LinearMap[K, V] =
     immutable.Map.empty[K, V]
 
   extension [K <: AnyRef, V >: Null <: AnyRef](m: LinearMap[K, V]):
 
-    def lookup(key: K): V /*| Null*/ = m match
-      case m: immutable.Map[K, V] @unchecked =>
+    def lookup(key: K): V /*| Null*/ = (m: @unchecked) match
+      case m: immutable.AbstractMap[K, V] @unchecked =>
         if m.contains(key) then m(key) else null
       case m: HashMap[K, V] @unchecked =>
         m.lookup(key)
 
-    def updated(key: K, value: V): LinearMap[K, V] = m match
-      case m: immutable.Map[K, V] @unchecked =>
+    def updated(key: K, value: V): LinearMap[K, V] = (m: @unchecked) match
+      case m: immutable.AbstractMap[K, V] @unchecked =>
         if m.size < 4 then
           m.updated(key, value)
         else
@@ -36,8 +36,8 @@ object LinearMap:
         m(key) = value
         m
 
-    def size = m match
-      case m: immutable.Map[K, V] @unchecked => m.size
+    def size = (m: @unchecked) match
+      case m: immutable.AbstractMap[K, V] @unchecked => m.size
       case m: HashMap[K, V] @unchecked => m.size
 
 end LinearMap

--- a/compiler/src/dotty/tools/dotc/util/LinearMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearMap.scala
@@ -17,11 +17,11 @@ object LinearMap:
 
   extension [K <: AnyRef, V >: Null <: AnyRef](m: LinearMap[K, V]):
 
-    def apply(key: K): V /*| Null*/ = m match
+    def lookup(key: K): V /*| Null*/ = m match
       case m: immutable.Map[K, V] @unchecked =>
         if m.contains(key) then m(key) else null
       case m: HashMap[K, V] @unchecked =>
-        m.get(key)
+        m.lookup(key)
 
     def updated(key: K, value: V): LinearMap[K, V] = m match
       case m: immutable.Map[K, V] @unchecked =>
@@ -29,11 +29,11 @@ object LinearMap:
           m.updated(key, value)
         else
           val m1 = HashMap[K, V]()
-          m.foreach(m1.put(_, _))
-          m1.put(key, value)
+          m.foreach(m1(_) = _)
+          m1(key) = value
           m1
       case m: HashMap[K, V] @unchecked =>
-        m.put(key, value)
+        m(key) = value
         m
 
     def size = m match

--- a/compiler/src/dotty/tools/dotc/util/LinearMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearMap.scala
@@ -1,0 +1,43 @@
+package dotty.tools.dotc.util
+
+import collection.immutable
+
+/** A linear map is a map where after an `updated` the previous map
+ *  value cannot be used anymore. The map is implemented as an immutable
+ *  map for sizes <= 4 (where immutable maps have specialized, compact
+ *  representations) and as a HashMap for larger sizes.
+ */
+opaque type LinearMap[K <: AnyRef, V >: Null <: AnyRef] =
+  immutable.Map[K, V] | HashMap[K, V]
+
+object LinearMap:
+
+  def Empty[K <: AnyRef, V >: Null <: AnyRef]: LinearMap[K, V] =
+    immutable.Map.empty[K, V]
+
+  extension [K <: AnyRef, V >: Null <: AnyRef](m: LinearMap[K, V]):
+
+    def apply(key: K): V /*| Null*/ = m match
+      case m: immutable.Map[K, V] @unchecked =>
+        if m.contains(key) then m(key) else null
+      case m: HashMap[K, V] @unchecked =>
+        m.get(key)
+
+    def updated(key: K, value: V): LinearMap[K, V] = m match
+      case m: immutable.Map[K, V] @unchecked =>
+        if m.size < 4 then
+          m.updated(key, value)
+        else
+          val m1 = HashMap[K, V]()
+          m.foreach(m1.put(_, _))
+          m1.put(key, value)
+          m1
+      case m: HashMap[K, V] @unchecked =>
+        m.put(key, value)
+        m
+
+    def size = m match
+      case m: immutable.Map[K, V] @unchecked => m.size
+      case m: HashMap[K, V] @unchecked => m.size
+
+end LinearMap

--- a/compiler/src/dotty/tools/dotc/util/LinearSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearSet.scala
@@ -1,0 +1,46 @@
+package dotty.tools.dotc.util
+import collection.immutable
+
+/** A linear identity set is a set that uses `eq` as the underlying
+ *  equality where after a `+` the previous set value cannot be used anymore.
+ *  The set is implemented as an immutable set for
+ *  sizes <= 4 and as a HashSet for larger sizes.
+ */
+opaque type LinearSet[Elem >: Null <: AnyRef] =
+  immutable.Set[Elem] | HashSet[Elem]
+
+object LinearSet:
+
+  def empty[Elem >: Null <: AnyRef]: LinearSet[Elem] = immutable.Set.empty[Elem]
+
+  extension [Elem >: Null <: AnyRef](s: LinearSet[Elem]):
+
+    def contains(elem: Elem): Boolean = (s: @unchecked) match
+      case s: immutable.AbstractSet[Elem] @unchecked => s.contains(elem)
+      case s: HashSet[Elem] @unchecked => s.contains(elem)
+
+    def + (elem: Elem): LinearSet[Elem] = (s: @unchecked) match
+      case s: immutable.AbstractSet[Elem] @unchecked =>
+        if s.size < 4 then
+          s + elem
+        else
+          val s1 = HashSet[Elem](initialCapacity = 8)
+          s.foreach(s1 += _)
+          s1 += elem
+          s1
+      case s: HashSet[Elem] @unchecked =>
+        s += elem
+        s
+
+    def - (elem: Elem): LinearSet[Elem] = (s: @unchecked) match
+      case s: immutable.AbstractSet[Elem] @unchecked =>
+        s - elem
+      case s: HashSet[Elem] @unchecked =>
+        s -= elem
+        s
+
+    def size = (s: @unchecked) match
+      case s: immutable.AbstractSet[Elem] @unchecked => s.size
+      case s: HashSet[Elem] @unchecked => s.size
+
+end LinearSet

--- a/compiler/src/dotty/tools/dotc/util/LinearSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearSet.scala
@@ -1,10 +1,9 @@
 package dotty.tools.dotc.util
 import collection.immutable
 
-/** A linear identity set is a set that uses `eq` as the underlying
- *  equality where after a `+` the previous set value cannot be used anymore.
- *  The set is implemented as an immutable set for
- *  sizes <= 4 and as a HashSet for larger sizes.
+/** A linear set is a set here after a `+` the previous set value cannot be
+ *  used anymore. The set is implemented as an immutable set for sizes <= 4
+ *  and as a HashSet for larger sizes.
  */
 opaque type LinearSet[Elem >: Null <: AnyRef] =
   immutable.Set[Elem] | HashSet[Elem]

--- a/compiler/src/dotty/tools/dotc/util/Map.scala
+++ b/compiler/src/dotty/tools/dotc/util/Map.scala
@@ -1,0 +1,19 @@
+package dotty.tools.dotc.util
+
+/** A common class for lightweight mutable maps.
+ */
+abstract class Map[Key >: Null <: AnyRef, Value >: Null <: AnyRef]:
+
+  def lookup(x: Key): Value /* | Null */
+
+  def update(k: Key, v: Value): Unit
+
+  def remove(k: Key): Unit
+
+  def size: Int
+
+  def clear(): Unit
+
+  def iterator: Iterator[(Key, Value)]
+
+  def get(x: Key): Option[Value] = Option(lookup(x))

--- a/compiler/src/dotty/tools/dotc/util/MutableMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableMap.scala
@@ -1,10 +1,11 @@
-package dotty.tools.dotc.util
+package dotty.tools
+package dotc.util
 
 /** A common class for lightweight mutable maps.
  */
-abstract class MutableMap[Key <: AnyRef, Value >: Null <: AnyRef]:
+abstract class MutableMap[Key <: AnyRef, Value]:
 
-  def lookup(x: Key): Value /* | Null */
+  def lookup(x: Key): Value | Null
 
   def update(k: Key, v: Value): Unit
 
@@ -16,5 +17,6 @@ abstract class MutableMap[Key <: AnyRef, Value >: Null <: AnyRef]:
 
   def iterator: Iterator[(Key, Value)]
 
-  def get(x: Key): Option[Value] = Option(lookup(x))
-
+  def get(x: Key): Option[Value] = lookup(x) match
+    case null => None
+    case v => Some(v.uncheckedNN)

--- a/compiler/src/dotty/tools/dotc/util/MutableMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableMap.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc.util
 
 /** A common class for lightweight mutable maps.
  */
-abstract class Map[Key >: Null <: AnyRef, Value >: Null <: AnyRef]:
+abstract class MutableMap[Key <: AnyRef, Value >: Null <: AnyRef]:
 
   def lookup(x: Key): Value /* | Null */
 
@@ -17,3 +17,4 @@ abstract class Map[Key >: Null <: AnyRef, Value >: Null <: AnyRef]:
   def iterator: Iterator[(Key, Value)]
 
   def get(x: Key): Option[Value] = Option(lookup(x))
+

--- a/compiler/src/dotty/tools/dotc/util/MutableMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableMap.scala
@@ -3,7 +3,7 @@ package dotc.util
 
 /** A common class for lightweight mutable maps.
  */
-abstract class MutableMap[Key <: AnyRef, Value]:
+abstract class MutableMap[Key, Value]:
 
   def lookup(x: Key): Value | Null
 

--- a/compiler/src/dotty/tools/dotc/util/MutableMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableMap.scala
@@ -3,20 +3,16 @@ package dotc.util
 
 /** A common class for lightweight mutable maps.
  */
-abstract class MutableMap[Key, Value]:
-
-  def lookup(x: Key): Value | Null
+abstract class MutableMap[Key, Value] extends ReadOnlyMap[Key, Value]:
 
   def update(k: Key, v: Value): Unit
 
-  def remove(k: Key): Unit
+  def remove(k: Key): Value | Null
 
-  def size: Int
+  def -=(k: Key): this.type =
+    remove(k)
+    this
 
   def clear(): Unit
 
-  def iterator: Iterator[(Key, Value)]
-
-  def get(x: Key): Option[Value] = lookup(x) match
-    case null => None
-    case v => Some(v.uncheckedNN)
+  def getOrElseUpdate(key: Key, value: => Value): Value

--- a/compiler/src/dotty/tools/dotc/util/MutableSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableSet.scala
@@ -1,8 +1,8 @@
 package dotty.tools.dotc.util
 
-/** A common class for lightweight sets.
+/** A common class for lightweight mutable sets.
  */
-abstract class Set[T >: Null] {
+abstract class MutableSet[T >: Null] {
 
   def findEntry(x: T): T
 

--- a/compiler/src/dotty/tools/dotc/util/MutableSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableSet.scala
@@ -4,20 +4,21 @@ package dotty.tools.dotc.util
  */
 abstract class MutableSet[T >: Null] {
 
-  def findEntry(x: T): T
+  /** The entry in the set such that `isEqual(x, entry)`, or else `null`. */
+  def lookup(x: T): T /* | Null */
 
-  def addEntry(x: T): Unit
+  def +=(x: T): Unit
+
+  def clear(): Unit
+
+  def size: Int
 
   def iterator: Iterator[T]
 
+  def contains(x: T): Boolean = lookup(x) != null
+
   def foreach[U](f: T => U): Unit = iterator foreach f
-
-  def apply(x: T): Boolean = contains(x)
-
-  def contains(x: T): Boolean =
-    findEntry(x) != null
 
   def toList: List[T] = iterator.toList
 
-  def clear(): Unit
 }

--- a/compiler/src/dotty/tools/dotc/util/MutableSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableSet.scala
@@ -2,10 +2,7 @@ package dotty.tools.dotc.util
 
 /** A common class for lightweight mutable sets.
  */
-abstract class MutableSet[T] {
-
-  /** The entry in the set such that `isEqual(x, entry)`, or else `null`. */
-  def lookup(x: T): T | Null
+abstract class MutableSet[T] extends ReadOnlySet[T]:
 
   /** Add element `x` to the set */
   def +=(x: T): Unit
@@ -17,14 +14,3 @@ abstract class MutableSet[T] {
 
   def clear(): Unit
 
-  def size: Int
-
-  def iterator: Iterator[T]
-
-  def contains(x: T): Boolean = lookup(x) != null
-
-  def foreach[U](f: T => U): Unit = iterator foreach f
-
-  def toList: List[T] = iterator.toList
-
-}

--- a/compiler/src/dotty/tools/dotc/util/MutableSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableSet.scala
@@ -12,5 +12,14 @@ abstract class MutableSet[T] extends ReadOnlySet[T]:
    */
   def put(x: T): T
 
+  /** Remove element `x` from the set */
+  def -=(x: T): Unit
+
   def clear(): Unit
+
+  def ++= (xs: IterableOnce[T]): Unit =
+    xs.iterator.foreach(this += _)
+
+  def --= (xs: IterableOnce[T]): Unit =
+    xs.iterator.foreach(this -= _)
 

--- a/compiler/src/dotty/tools/dotc/util/MutableSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableSet.scala
@@ -2,10 +2,10 @@ package dotty.tools.dotc.util
 
 /** A common class for lightweight mutable sets.
  */
-abstract class MutableSet[T >: Null] {
+abstract class MutableSet[T] {
 
   /** The entry in the set such that `isEqual(x, entry)`, or else `null`. */
-  def lookup(x: T): T /* | Null */
+  def lookup(x: T): T | Null
 
   /** Add element `x` to the set */
   def +=(x: T): Unit

--- a/compiler/src/dotty/tools/dotc/util/MutableSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableSet.scala
@@ -7,7 +7,13 @@ abstract class MutableSet[T >: Null] {
   /** The entry in the set such that `isEqual(x, entry)`, or else `null`. */
   def lookup(x: T): T /* | Null */
 
+  /** Add element `x` to the set */
   def +=(x: T): Unit
+
+  /** Like `+=` but return existing element equal to `x` of it exists,
+   *  `x` itself otherwose.
+   */
+  def put(x: T): T
 
   def clear(): Unit
 

--- a/compiler/src/dotty/tools/dotc/util/ReadOnlyMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/ReadOnlyMap.scala
@@ -11,6 +11,7 @@ abstract class ReadOnlyMap[Key, Value]:
 
   def iterator: Iterator[(Key, Value)]
   def keysIterator: Iterator[Key]
+  def valuesIterator: Iterator[Value]
 
   def isEmpty: Boolean = size == 0
 
@@ -27,3 +28,14 @@ abstract class ReadOnlyMap[Key, Value]:
   def apply(key: Key): Value = lookup(key) match
     case null => throw new NoSuchElementException(s"$key")
     case v => v.uncheckedNN
+
+  def toArray: Array[(Key, Value)] =
+    val result = new Array[(Key, Value)](size)
+    var idx = 0
+    for pair <- iterator do
+      result(idx) = pair
+      idx += 1
+    result
+
+  def toSeq: Seq[(Key, Value)] = toArray.toSeq
+

--- a/compiler/src/dotty/tools/dotc/util/ReadOnlyMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/ReadOnlyMap.scala
@@ -1,0 +1,29 @@
+package dotty.tools
+package dotc.util
+
+/** A class for the reading part of mutable or immutable maps.
+ */
+abstract class ReadOnlyMap[Key, Value]:
+
+  def lookup(x: Key): Value | Null
+
+  def size: Int
+
+  def iterator: Iterator[(Key, Value)]
+  def keysIterator: Iterator[Key]
+
+  def isEmpty: Boolean = size == 0
+
+  def get(key: Key): Option[Value] = lookup(key) match
+    case null => None
+    case v => Some(v.uncheckedNN)
+
+  def getOrElse(key: Key, value: => Value) = lookup(key) match
+    case null => value
+    case v => v.uncheckedNN
+
+  def contains(key: Key): Boolean = lookup(key) != null
+
+  def apply(key: Key): Value = lookup(key) match
+    case null => throw new NoSuchElementException(s"$key")
+    case v => v.uncheckedNN

--- a/compiler/src/dotty/tools/dotc/util/ReadOnlySet.scala
+++ b/compiler/src/dotty/tools/dotc/util/ReadOnlySet.scala
@@ -1,0 +1,24 @@
+package dotty.tools.dotc.util
+
+/** A class for the readonly part of mutable sets.
+ */
+abstract class ReadOnlySet[T]:
+
+  /** The entry in the set such that `isEqual(x, entry)`, or else `null`. */
+  def lookup(x: T): T | Null
+
+  def size: Int
+
+  def iterator: Iterator[T]
+
+  def contains(x: T): Boolean = lookup(x) != null
+
+  def foreach[U](f: T => U): Unit = iterator.foreach(f)
+
+  def toList: List[T] = iterator.toList
+
+  def isEmpty = size == 0
+
+object ReadOnlySet:
+  def empty[T]: ReadOnlySet[T] = HashSet[T](4)
+

--- a/compiler/src/dotty/tools/dotc/util/SimpleIdentityMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/SimpleIdentityMap.scala
@@ -41,7 +41,7 @@ object SimpleIdentityMap {
     def forallBinding(f: (AnyRef, Null) => Boolean) = true
   }
 
-  def Empty[K <: AnyRef]: SimpleIdentityMap[K, Null] = myEmpty.asInstanceOf[SimpleIdentityMap[K, Null]]
+  def empty[K <: AnyRef]: SimpleIdentityMap[K, Null] = myEmpty.asInstanceOf[SimpleIdentityMap[K, Null]]
 
   class Map1[K <: AnyRef, +V >: Null <: AnyRef] (k1: K, v1: V) extends SimpleIdentityMap[K, V] {
     def size: Int = 1
@@ -49,7 +49,7 @@ object SimpleIdentityMap {
       if (k eq k1) v1
       else null
     def remove(k: K): SimpleIdentityMap[K, V] =
-      if (k eq k1) Empty.asInstanceOf[SimpleIdentityMap[K, V]]
+      if (k eq k1) empty.asInstanceOf[SimpleIdentityMap[K, V]]
       else this
     def updated[V1 >: V <: AnyRef](k: K, v: V1): SimpleIdentityMap[K, V1] =
       if (k eq k1) new Map1(k, v)
@@ -162,7 +162,7 @@ object SimpleIdentityMap {
         if (bindings(i) eq k)
           return {
             if (size == CompactifyThreshold) {
-              var m: SimpleIdentityMap[K, V] = Empty[K]
+              var m: SimpleIdentityMap[K, V] = empty[K]
               for (j <- 0 until bindings.length by 2)
                 if (j != i) m = m.updated(key(j), value(j))
               m

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -58,7 +58,6 @@ import collection.mutable
         aggregate()
         println()
         println(hits.toList.sortBy(_._2).map{ case (x, y) => s"$x -> $y" } mkString "\n")
-        println(s"uniqueInfo (size, accesses, collisions): ${ctx.base.uniquesSizes}")
       }
     }
     else op

--- a/compiler/src/dotty/tools/package.scala
+++ b/compiler/src/dotty/tools/package.scala
@@ -24,6 +24,14 @@ package object tools {
   def unsupported(methodName: String): Nothing =
     throw new UnsupportedOperationException(methodName)
 
+  /** Forward-ported from the explicit-nulls branch.
+   *  Should be used when we know from the context that `x` is not null.
+   *  Flow-typing under explicit nulls will automatically insert many necessary
+   *  occurrences of uncheckedNN.
+   */
+  extension [T](x: T | Null)
+    inline def uncheckedNN: T = x.asInstanceOf[T]
+
   object resultWrapper {
     opaque type WrappedResult[T] = T
     private[tools] def unwrap[T](x: WrappedResult[T]): T = x

--- a/compiler/src/dotty/tools/package.scala
+++ b/compiler/src/dotty/tools/package.scala
@@ -24,13 +24,23 @@ package object tools {
   def unsupported(methodName: String): Nothing =
     throw new UnsupportedOperationException(methodName)
 
-  /** Forward-ported from the explicit-nulls branch.
-   *  Should be used when we know from the context that `x` is not null.
-   *  Flow-typing under explicit nulls will automatically insert many necessary
-   *  occurrences of uncheckedNN.
-   */
-  extension [T](x: T | Null)
+  /** Forward-ported from the explicit-nulls branch. */
+  extension [T](x: T | Null):
+
+    /** Assert `x` is non null and strip `Null` from type */
+    inline def nn: T =
+      assert(x != null)
+      x.asInstanceOf[T]
+
+    /** Should be used when we know from the context that `x` is not null.
+     *  Flow-typing under explicit nulls will automatically insert many necessary
+     *  occurrences of uncheckedNN.
+     */
     inline def uncheckedNN: T = x.asInstanceOf[T]
+
+    inline def toOption: Option[T] =
+      if x == null then None else Some(x.asInstanceOf[T])
+  end extension
 
   object resultWrapper {
     opaque type WrappedResult[T] = T

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -23,7 +23,7 @@ import Comments._, Constants._, Contexts._, Flags._, Names._, NameOps._, Symbols
 import classpath.ClassPathEntries
 import reporting._
 import typer.Typer
-import util.{Set => _, _}
+import util._
 import interactive._, interactive.InteractiveDriver._
 import decompiler.IDEDecompilerDriver
 import Interactive.Include

--- a/tests/neg-custom-args/i1650.scala
+++ b/tests/neg-custom-args/i1650.scala
@@ -1,5 +1,5 @@
 object Test {
-  test4(test4$default$1) // error: recursion limit exceeded
+  test4(test4$default$1)
   def test4[T[P]](x: T[T[List[T[X forSome { type X }]]]]) = ??? // error // error
   def test4$default$1[T[P]]: T[Int] = ???
 }

--- a/tests/run-with-compiler/maptest.scala
+++ b/tests/run-with-compiler/maptest.scala
@@ -1,0 +1,74 @@
+trait Generator[+T]:
+  self =>
+  def generate: T
+  def map[S](f: T => S) = new Generator[S]:
+    def generate: S = f(self.generate)
+  def flatMap[S](f: T => Generator[S]) = new Generator[S]:
+    def generate: S = f(self.generate).generate
+
+object Generator:
+  val NumLimit = 300
+  val Iterations = 10000
+
+  given integers as Generator[Int]:
+    val rand = new java.util.Random
+    def generate = rand.nextInt()
+
+  given booleans as Generator[Boolean] =
+    integers.map(x => x > 0)
+
+  def range(end: Int): Generator[Int] =
+    integers.map(x => (x % end).abs)
+
+  enum Op:
+    case Lookup, Update, Remove
+  export Op._
+
+  given ops as Generator[Op] =
+    range(10).map {
+      case 0 | 1 | 2 | 3 => Lookup
+      case 4 | 5 | 6 | 7 => Update
+      case 8 | 9         => Remove
+    }
+
+  val nums: Generator[Integer] = range(NumLimit).map(Integer(_))
+
+@main def Test =
+  import Generator._
+
+  val map1 = dotty.tools.dotc.util.HashMap[Integer, Integer]()
+  val map2 = scala.collection.mutable.HashMap[Integer, Integer]()
+
+  def checkSame() =
+    assert(map1.size == map2.size)
+    for (k, v) <- map1.iterator do
+      assert(map2.get(k) == Some(v))
+    for (k, v) <- map2.iterator do
+      assert(Option(map1.lookup(k)) == Some(v))
+
+  def lookupTest(num: Integer) =
+    //println(s"test lookup $num")
+    val res1 = Option(map1.lookup(num))
+    val res2 = map2.get(num)
+    assert(res1 == res2)
+
+  def updateTest(num: Integer) =
+    //println(s"test update $num")
+    lookupTest(num)
+    map1(num) = num
+    map2(num) = num
+    checkSame()
+
+  def removeTest(num: Integer) =
+    //println(s"test remove $num")
+    map1.remove(num)
+    map2.remove(num)
+    checkSame()
+
+  for i <- 0 until Iterations do
+    //if i % 1000 == 0 then println(map1.size)
+    val num = nums.generate
+    Generator.ops.generate match
+      case Lookup => lookupTest(num)
+      case Update => updateTest(num)
+      case Remove => removeTest(num)


### PR DESCRIPTION
We now have high performance mutable set and map implementations in dotc.util. Generalize them and use them more widely.
