### PR TITLE
Fix for union-types-spec documentation

### DIFF
--- a/docs/docs/reference/new-types/union-types-spec.md
+++ b/docs/docs/reference/new-types/union-types-spec.md
@@ -134,6 +134,7 @@ trait A extends C with D
 trait B extends C with E
 
 def test(x: A | B) = x.hello // ok as `hello` is a member of the join of A | B which is C
+```
 
 ## Exhaustivity checking
 


### PR DESCRIPTION
There was a small issue with an unclosed code block making the rendering look weird: https://dotty.epfl.ch/docs/reference/new-types/union-types-spec.html