### PR TITLE
Move Scala.js-specific transforms to the subpackage transform.sjs.

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -7,7 +7,7 @@ import typer.{FrontEnd, RefChecks}
 import Phases.Phase
 import transform._
 import dotty.tools.backend.jvm.{CollectSuperCalls, GenBCode}
-import dotty.tools.backend.sjs
+import dotty.tools.backend
 import dotty.tools.dotc.transform.localopt.StringInterpolatorOpt
 
 /** The central class of the dotc compiler. The job of a compiler is to create
@@ -72,7 +72,7 @@ class Compiler {
     List(new ElimOpaque,             // Turn opaque into normal aliases
          new TryCatchPatterns,       // Compile cases in try/catch
          new PatternMatcher,         // Compile pattern matches
-         new ExplicitJSClasses,      // Make all JS classes explicit (Scala.js only)
+         new sjs.ExplicitJSClasses,  // Make all JS classes explicit (Scala.js only)
          new ExplicitOuter,          // Add accessors to outer classes from nested ones.
          new ExplicitSelf,           // Make references to non-trivial self types explicit as casts
          new StringInterpolatorOpt,  // Optimizes raw and s string interpolators by rewriting them to string concatentations
@@ -122,14 +122,14 @@ class Compiler {
          new ExpandPrivate,          // Widen private definitions accessed from nested classes
          new RestoreScopes,          // Repair scopes rendered invalid by moving definitions in prior phases of the group
          new SelectStatic,           // get rid of selects that would be compiled into GetStatic
-         new sjs.JUnitBootstrappers, // Generate JUnit-specific bootstrapper classes for Scala.js (not enabled by default)
+         new backend.sjs.JUnitBootstrappers, // Generate JUnit-specific bootstrapper classes for Scala.js (not enabled by default)
          new CollectSuperCalls) ::   // Find classes that are called with super
     Nil
 
   /** Generate the output of the compilation */
   protected def backendPhases: List[List[Phase]] =
-    List(new sjs.GenSJSIR) ::        // Generate .sjsir files for Scala.js (not enabled by default)
-    List(new GenBCode) ::            // Generate JVM bytecode
+    List(new backend.sjs.GenSJSIR) :: // Generate .sjsir files for Scala.js (not enabled by default)
+    List(new GenBCode) ::             // Generate JVM bytecode
     Nil
 
   var runId: Int = 1

--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -122,7 +122,7 @@ class Compiler {
          new ExpandPrivate,          // Widen private definitions accessed from nested classes
          new RestoreScopes,          // Repair scopes rendered invalid by moving definitions in prior phases of the group
          new SelectStatic,           // get rid of selects that would be compiled into GetStatic
-         new backend.sjs.JUnitBootstrappers, // Generate JUnit-specific bootstrapper classes for Scala.js (not enabled by default)
+         new sjs.JUnitBootstrappers, // Generate JUnit-specific bootstrapper classes for Scala.js (not enabled by default)
          new CollectSuperCalls) ::   // Find classes that are called with super
     Nil
 

--- a/compiler/src/dotty/tools/dotc/transform/sjs/ExplicitJSClasses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/ExplicitJSClasses.scala
@@ -1,6 +1,7 @@
 package dotty.tools
 package dotc
 package transform
+package sjs
 
 import MegaPhase._
 import core.DenotTransformers._

--- a/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
@@ -1,8 +1,8 @@
-package dotty.tools.backend.sjs
+package dotty.tools.dotc
+package transform
+package sjs
 
 import scala.annotation.tailrec
-
-import dotty.tools.dotc._
 
 import dotty.tools.dotc.core._
 import Constants._
@@ -18,6 +18,8 @@ import StdNames._
 import Types._
 
 import dotty.tools.dotc.transform.MegaPhase._
+
+import dotty.tools.backend.sjs.JSDefinitions.jsdefn
 
 /** Generates JUnit bootstrapper objects for Scala.js.
  *
@@ -108,7 +110,6 @@ import dotty.tools.dotc.transform.MegaPhase._
 class JUnitBootstrappers extends MiniPhase {
   import JUnitBootstrappers._
   import ast.tpd._
-  import JSDefinitions.jsdefn
 
   def phaseName: String = "junitBootstrappers"
 


### PR DESCRIPTION
We will keep Scala.js-specific phases in that subpackage.