### PR TITLE
Remove constraints abstraction from Context

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/reflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/reflect/ReflectionCompilerInterface.scala
@@ -55,14 +55,15 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
   // Constraints //
   /////////////////
 
-  def Constraints_init(self: Context): Context =
-    self.fresh.setFreshGADTBounds.addMode(Mode.GadtConstraintInference)
+  def Constraints_context[T]: scala.quoted.QuoteContext =
+    val ctx1 = ctx.fresh.setFreshGADTBounds.addMode(Mode.GadtConstraintInference)
+    dotty.tools.dotc.quoted.QuoteContextImpl()(using ctx1)
 
-  def Constraints_add(self: Context)(syms: List[Symbol]): Boolean =
-    self.gadt.addToConstraint(syms)
+  def Constraints_add(syms: List[Symbol]): Boolean =
+    ctx.gadt.addToConstraint(syms)
 
-  def Constraints_approximation(self: Context)(sym: Symbol, fromBelow: Boolean): Type =
-    self.gadt.approximation(sym, fromBelow)
+  def Constraints_approximation(sym: Symbol, fromBelow: Boolean): Type =
+    ctx.gadt.approximation(sym, fromBelow)
 
   ////////////
   // Source //

--- a/library/src-bootstrapped/scala/internal/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/internal/quoted/Expr.scala
@@ -53,7 +53,10 @@ object Expr {
    */
   def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeExpr: scala.quoted.Expr[Any])(using patternExpr: scala.quoted.Expr[Any],
         hasTypeSplices: Boolean, qctx: QuoteContext): Option[Tup] = {
-    new Matcher.QuoteMatcher[qctx.type](qctx).termMatch(scrutineeExpr.unseal, patternExpr.unseal, hasTypeSplices).asInstanceOf[Option[Tup]]
+    val qctx1 = quoteContextWithCompilerInterface(qctx)
+    val qctx2 = if hasTypeSplices then qctx1.tasty.Constraints_context else qctx1
+    given qctx2.type = qctx2
+    new Matcher.QuoteMatcher[qctx2.type](qctx2).termMatch(scrutineeExpr.unseal, patternExpr.unseal, hasTypeSplices).asInstanceOf[Option[Tup]]
   }
 
   /** Returns a null expresssion equivalent to `'{null}` */

--- a/library/src-bootstrapped/scala/internal/quoted/Matcher.scala
+++ b/library/src-bootstrapped/scala/internal/quoted/Matcher.scala
@@ -128,7 +128,7 @@ object Matcher {
 
     // TODO improve performance
 
-    // TODO use flag from qctx.tasty.rootContext. Maybe -debug or add -debug-macros
+    // TODO use flag from qctx.tasty. Maybe -debug or add -debug-macros
     private final val debug = false
 
     import qctx.tasty._
@@ -149,42 +149,34 @@ object Matcher {
 
     def termMatch(scrutineeTerm: Term, patternTerm: Term, hasTypeSplices: Boolean): Option[Tuple] = {
       given Env = Map.empty
-      if (hasTypeSplices) {
-        val ctx: Context = qctx.tasty.Constraints_init(rootContext)
-        given Context = ctx
-        val matchings = scrutineeTerm =?= patternTerm
+      val matchings = scrutineeTerm =?= patternTerm
+      if !hasTypeSplices then matchings
+      else {
         // After matching and doing all subtype checks, we have to approximate all the type bindings
         // that we have found and seal them in a quoted.Type
         matchings.asOptionOfTuple.map { tup =>
           Tuple.fromArray(tup.toArray.map { // TODO improve performance
-            case x: SymBinding => qctx.tasty.Constraints_approximation(summon[Context])(x.sym, !x.fromAbove).seal
+            case x: SymBinding => qctx.tasty.Constraints_approximation(x.sym, !x.fromAbove).seal
             case x => x
           })
         }
-      }
-      else {
-        scrutineeTerm =?= patternTerm
       }
     }
 
     // TODO factor out common logic with `termMatch`
     def typeTreeMatch(scrutineeTypeTree: TypeTree, patternTypeTree: TypeTree, hasTypeSplices: Boolean): Option[Tuple] = {
       given Env = Map.empty
-      if (hasTypeSplices) {
-        val ctx: Context = qctx.tasty.Constraints_init(rootContext)
-        given Context = ctx
-        val matchings = scrutineeTypeTree =?= patternTypeTree
+      val matchings = scrutineeTypeTree =?= patternTypeTree
+      if !hasTypeSplices then matchings
+      else {
         // After matching and doing all subtype checks, we have to approximate all the type bindings
         // that we have found and seal them in a quoted.Type
         matchings.asOptionOfTuple.map { tup =>
           Tuple.fromArray(tup.toArray.map { // TODO improve performance
-            case x: SymBinding => qctx.tasty.Constraints_approximation(summon[Context])(x.sym, !x.fromAbove).seal
+            case x: SymBinding => qctx.tasty.Constraints_approximation(x.sym, !x.fromAbove).seal
             case x => x
           })
         }
-      }
-      else {
-        scrutineeTypeTree =?= patternTypeTree
       }
     }
 
@@ -326,7 +318,7 @@ object Matcher {
             fn1 =?= fn2 &&& args1 =?= args2
 
           case (Block(stats1, expr1), Block(binding :: stats2, expr2)) if isTypeBinding(binding) =>
-            qctx.tasty.Constraints_add(summon[Context])(binding.symbol :: Nil)
+            qctx.tasty.Constraints_add(binding.symbol :: Nil)
             matched(new SymBinding(binding.symbol, hasFromAboveAnnotation(binding.symbol))) &&& Block(stats1, expr1) =?= Block(stats2, expr2)
 
           /* Match block */
@@ -343,7 +335,7 @@ object Matcher {
 
           case (scrutinee, Block(typeBindings, expr2)) if typeBindings.forall(isTypeBinding) =>
             val bindingSymbols = typeBindings.map(_.symbol)
-            qctx.tasty.Constraints_add(summon[Context])(bindingSymbols)
+            qctx.tasty.Constraints_add(bindingSymbols)
             bindingSymbols.foldRight(scrutinee =?= expr2)((x, acc) => matched(new SymBinding(x, hasFromAboveAnnotation(x))) &&& acc)
 
           /* Match if */

--- a/library/src-bootstrapped/scala/internal/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/internal/quoted/Type.scala
@@ -40,7 +40,10 @@ object Type {
    */
   def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeType: scala.quoted.Type[_])(using patternType: scala.quoted.Type[_],
         hasTypeSplices: Boolean, qctx: QuoteContext): Option[Tup] = {
-    new Matcher.QuoteMatcher[qctx.type](qctx).typeTreeMatch(scrutineeType.unseal, patternType.unseal, hasTypeSplices).asInstanceOf[Option[Tup]]
+    val qctx1 = quoteContextWithCompilerInterface(qctx)
+    val qctx2 = if hasTypeSplices then qctx1.tasty.Constraints_context else qctx1
+    given qctx2.type = qctx2
+    new Matcher.QuoteMatcher[qctx2.type](qctx2).typeTreeMatch(scrutineeType.unseal, patternType.unseal, hasTypeSplices).asInstanceOf[Option[Tup]]
   }
 
   def Unit: QuoteContext ?=> quoted.Type[Unit] =

--- a/library/src/scala/internal/tasty/CompilerInterface.scala
+++ b/library/src/scala/internal/tasty/CompilerInterface.scala
@@ -33,9 +33,9 @@ trait CompilerInterface extends scala.tasty.reflect.Types {
   // Constraints //
   /////////////////
 
-  def Constraints_init(self: Context): Context
-  def Constraints_add(self: Context)(syms: List[Symbol]): Boolean
-  def Constraints_approximation(self: Context)(sym: Symbol, fromBelow: Boolean): Type
+  def Constraints_context[T]: scala.quoted.QuoteContext
+  def Constraints_add(syms: List[Symbol]): Boolean
+  def Constraints_approximation(sym: Symbol, fromBelow: Boolean): Type
 
   ////////////
   // Source //


### PR DESCRIPTION
The constraints API is available durring the execution of the Matcher and initialized before the matching strats independently of the local contexts in the Matcher.