### PR TITLE
Overloading: always prefer non-varargs to varargs

### DIFF
--- a/tests/run/overload_repeated/A_1.java
+++ b/tests/run/overload_repeated/A_1.java
@@ -1,0 +1,23 @@
+class A_1 {
+  public static int foo1(String x) { return 1; }
+  public static int foo1(Object... x) { return 2; }
+
+  public static int foo2(Object x) { return 1; }
+  public static int foo2(Object... x) { return 2; }
+
+  public static <T> int foo3(T x) { return 1; }
+  public static <T> int foo3(T... x) { return 2; }
+
+  public static <T> int foo4(T x) { return 1; }
+  public static <T> int foo4(T x, T... y) { return 2; }
+
+  public static boolean check() {
+    // Java prefers non-varargs to varargs:
+    // https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2
+    return
+        foo1("") == 1 &&
+        foo2("") == 1 &&
+        foo3("") == 1 &&
+        foo4("") == 1;
+  }
+}

--- a/tests/run/overload_repeated/B_2.scala
+++ b/tests/run/overload_repeated/B_2.scala
@@ -1,0 +1,31 @@
+object Test {
+  def bar1(x: Any) = 1
+  def bar1(x: String*) = 2
+
+  def bar2(x: Any) = 1
+  def bar2(x: Any*) = 2
+
+  def bar3[T](x: T): Int = 1
+  def bar3[T](x: T*): Int = 2
+
+  def bar4[T](x: T): Int = 1
+  def bar4[T](x: T, xs: T*): Int = 2
+
+  def main(args: Array[String]): Unit = {
+    // Java, Scala 2 and Dotty all agree that Java varargs are
+    // less specific than Java non-varargs:
+    assert(A_1.check())
+    assert(A_1.foo1("") == 1) // Same as in Java and Scala 2
+    assert(A_1.foo2("") == 1) // Same as in Java and Scala 2
+    assert(A_1.foo3("") == 1) // Same as in Java and Scala 2
+    assert(A_1.foo4("") == 1) // Same as in Java and Scala 2
+
+    // ... but Scala 2 seems to treat Scala varargs specially
+    // (or maybe it's Object coming from Java which is treated
+    // specially), in Dotty this doesn't make a difference:
+    assert(bar1("") == 1) // ambiguous in Scala 2
+    assert(bar2("") == 1) // same in Scala 2
+    assert(bar3("") == 1) // same in Scala 2
+    assert(bar4("") == 1) // same in Scala 2
+  }
+}

--- a/tests/run/t8197.scala
+++ b/tests/run/t8197.scala
@@ -10,7 +10,7 @@ class Foo(val x: A = null) {
 
 object Test extends App {
   // both constructors of `Foo` are applicable. Overloading resolution
-  // will eliminate the alternative that uses a default argument, therefore
-  // the vararg constructor is chosen.
-  assert((new Foo).x != null)
+  // used to select the varargs alternative, but we now always
+  // prefer non-varargs to varargs overloads.
+  assert((new Foo).x == null)
 }


### PR DESCRIPTION
We recently merged #9601 which unified our handling of `Object` coming
from Java methods, an unintended consequence of that change is that some
existing Java APIs can no longer be called without running into
ambiguity errors, for example log4j defines two overloads for
`Logger.error`:

    (x: String, y: Object): Unit
    (x: String, y: Object*): Unit

previously we translated `Object` to `Any` but left `Object*` alone, now
they're both treated the same way (translated to a special alias of
`Object`) and so neither method ends up being more specific than the
other, so `error("foo: {}, 1)` is now ambiguous.

Clearly the problem lies with how we handle varargs in overloading
resolution, but this has been a source of issues for years with no clear
resolution (hah!):
- https://github.com/scala/bug/issues/8342
- https://github.com/scala/bug/issues/4728
- https://github.com/scala/bug/issues/8344
- #6230

This PR cuts the Gordian knot by simply declaring that non-varargs
methods are always more specific than varargs. This has several
advantages:
- It's an easy rule to remember
- It matches what Java does (see
  https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2)
- It avoids unnecessary wrapping of arguments

The downside is that it doesn't match what Scala 2 does, but our current
behavior isn't a perfect match either (also it seems that Scala 2
handles Java varargs and Scala varargs differently in overloading
resolution which is another source of complexity best avoided, see
`tests/run/overload_repeated`).

Fixes #9688, supercedes #6230.