### PR TITLE
remove outdated difference of match types with typescript's conditional types

### DIFF
--- a/docs/docs/reference/new-types/match-types.md
+++ b/docs/docs/reference/new-types/match-types.md
@@ -243,7 +243,6 @@ main differences here are:
 
  - Conditional types only reduce if both the scrutinee and pattern are ground,
    whereas match types also work for type parameters and abstract types.
- - Match types can bind variables in type patterns.
  - Match types support direct recursion.
  - Conditional types distribute through union types.
 


### PR DESCRIPTION
I think the part about match types supporting variables within the pattern is no longer a difference. Typescript supports binding of variables within the pattern. I've written up a small example: 

https://www.typescriptlang.org/play?#code/C4TwDgpgBAogNhAthAdsA8gMwDwA0B8UAvFAFBQVS5QQAewqAJgM5QAUAliphAE6wBKANoBdKAH5YUAFzlK1OgxQsoAbyEBrCCGlRmwXlwDmI3Z259BAXwlTdKCADc+AblKkAxgHsU+mgEZdeCRUDBwUAFdEACM+UUISAGY3b19gGgAmIIRkNCxsdS0dPQNjUxLDFCMrBKgAIkwvLzqUnz8IROyQvJx9SqN44ihkoA

Is the difference outdated or am I just misunderstanding what "Match types can bind variables in type patterns" means?