### PR TITLE
Multivalued setting can be set multiply

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -22,7 +22,7 @@ object Settings {
   val OutputTag: ClassTag[AbstractFile]  = ClassTag(classOf[AbstractFile])
 
   class SettingsState(initialValues: Seq[Any]) {
-    private var values = ArrayBuffer(initialValues: _*)
+    private val values = ArrayBuffer(initialValues: _*)
     private var _wasRead: Boolean = false
 
     override def toString: String = s"SettingsState(values: ${values.toList})"
@@ -89,26 +89,26 @@ object Settings {
     def isDefaultIn(state: SettingsState): Boolean = valueIn(state) == default
 
     def legalChoices: String =
-      if (choices.isEmpty) ""
-      else choices match {
-        case r: Range => s"${r.head}..${r.last}"
-        case xs: List[?] => xs.mkString(", ")
+      choices match {
+        case xs if xs.isEmpty => ""
+        case r: Range         => s"${r.head}..${r.last}"
+        case xs: List[?]      => xs.toString
       }
 
     def isLegal(arg: Any): Boolean =
-      if (choices.isEmpty)
-        arg match {
-          case _: T => true
-          case _ => false
-        }
-      else choices match {
+      choices match {
+        case xs if xs.isEmpty =>
+          arg match {
+            case _: T => true
+            case _ => false
+          }
         case r: Range =>
           arg match {
             case x: Int => r.head <= x && x <= r.last
             case _ => false
           }
         case xs: List[?] =>
-          xs contains arg
+          xs.contains(arg)
       }
 
     def tryToSet(state: ArgsSummary): ArgsSummary = {

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -1,18 +1,15 @@
 package dotty.tools.dotc
 package config
 
-import collection.mutable.ArrayBuffer
-import scala.util.{ Success, Failure }
-import reflect.ClassTag
 import core.Contexts._
-import scala.annotation.tailrec
-import dotty.tools.io.{ AbstractFile, Directory, JarArchive, PlainDirectory }
 
-// import annotation.unchecked
-  // Dotty deviation: Imports take precedence over definitions in enclosing package
-  // (Note that @unchecked is in scala, not annotation, so annotation.unchecked gives
-  // us a package, which is not what was intended anyway).
+import dotty.tools.io.{AbstractFile, Directory, JarArchive, PlainDirectory}
+
+import annotation.tailrec
+import collection.mutable.ArrayBuffer
 import language.existentials
+import reflect.ClassTag
+import scala.util.{Success, Failure}
 
 object Settings {
 

--- a/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
@@ -17,7 +17,7 @@ import Diagnostic._
   * - The reporter is not flushed and the message containers capture a
   *   `Context` (about 4MB)
   */
-class StoreReporter(outer: Reporter) extends Reporter {
+class StoreReporter(outer: Reporter = null) extends Reporter {
 
   protected var infos: mutable.ListBuffer[Diagnostic] = null
 

--- a/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/StoreReporter.scala
@@ -17,7 +17,7 @@ import Diagnostic._
   * - The reporter is not flushed and the message containers capture a
   *   `Context` (about 4MB)
   */
-class StoreReporter(outer: Reporter = null) extends Reporter {
+class StoreReporter(outer: Reporter = Reporter.NoReporter) extends Reporter {
 
   protected var infos: mutable.ListBuffer[Diagnostic] = null
 

--- a/compiler/test/dotty/tools/dotc/SettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/SettingsTests.scala
@@ -29,11 +29,11 @@ class SettingsTests {
     assertTrue(Files.exists(out))
   }
 
-  @Test def t8124: Unit =
+  @Test def `t8124 Don't crash on missing argument`: Unit =
     val source    = Paths.get("tests/pos/Foo.scala").normalize
     val outputDir = Paths.get("out/testSettings").normalize
-    if Files.notExists(outputDir)
-      Files.createDirectory(outputDir)
+    if Files.notExists(outputDir) then Files.createDirectory(outputDir)
+    // -encoding takes an arg!
     val options  = Array("-encoding", "-d", outputDir.toString, source.toString)
     val reporter = Main.process(options, reporter = StoreReporter())
     assertEquals(1, reporter.errorCount)

--- a/compiler/test/dotty/tools/dotc/SettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/SettingsTests.scala
@@ -1,23 +1,23 @@
 package dotty.tools
 package dotc
 
+import reporting.StoreReporter
 import vulpix.TestConfiguration
+
+import dotty.tools.vulpix.TestConfiguration.mkClasspath
+
+import java.nio.file._
 
 import org.junit.Test
 import org.junit.Assert._
 
-import java.nio.file._
-
-import dotty.tools.vulpix.TestConfiguration.mkClasspath
-
 class SettingsTests {
 
-  @Test def missingOutputDir: Unit = {
+  @Test def missingOutputDir: Unit =
     val options = Array("-d", "not_here")
-    val reporter = Main.process(options)
+    val reporter = Main.process(options, reporter = StoreReporter())
     assertEquals(1, reporter.errorCount)
     assertEquals("'not_here' does not exist or is not a directory or .jar file", reporter.allErrors.head.message)
-  }
 
   @Test def jarOutput: Unit = {
     val source = "tests/pos/Foo.scala"
@@ -29,13 +29,12 @@ class SettingsTests {
     assertTrue(Files.exists(out))
   }
 
-  @Test def t8124: Unit = {
-    val source = Paths.get("tests/pos/Foo.scala").normalize
+  @Test def t8124: Unit =
+    val source    = Paths.get("tests/pos/Foo.scala").normalize
     val outputDir = Paths.get("out/testSettings").normalize
-    if (Files.notExists(outputDir)) Files.createDirectory(outputDir)
-    val options = Array("-encoding", "-d", outputDir.toString, source.toString)
-    val reporter = Main.process(options)
+    if Files.notExists(outputDir)
+      Files.createDirectory(outputDir)
+    val options  = Array("-encoding", "-d", outputDir.toString, source.toString)
+    val reporter = Main.process(options, reporter = StoreReporter())
     assertEquals(1, reporter.errorCount)
-   }
-
 }

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -1,0 +1,54 @@
+package dotty.tools.dotc
+package config
+
+import CommandLineParser.tokenize
+import Settings._
+
+import org.junit.Test
+import org.junit.Assert._
+
+class ScalaSettingsTests:
+
+  @Test def `A multistring setting is multivalued`: Unit =
+    class SUT extends SettingGroup:
+      val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.")
+    val sut  = SUT()
+    val args = tokenize("-language:implicitConversions,dynamics")
+    val sumy = ArgsSummary(sut.defaultState, args, errors = Nil, warnings = Nil)
+    val res  = sut.processArguments(sumy, processAll = true, skipped = Nil)
+    val set  = sut.language.valueIn(res.sstate)
+    assertEquals(1, args.length)
+    assertTrue("No warnings!", res.warnings.isEmpty)
+    assertTrue("No errors!", res.errors.isEmpty)
+    assertTrue("Has the feature", set.contains("implicitConversions"))
+    assertTrue("Has the feature", set.contains("dynamics"))
+
+  @Test def `t9719 Apply -language more than once`: Unit =
+    class SUT extends SettingGroup:
+      val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.")
+    val sut  = SUT()
+    val args = tokenize("-language:implicitConversions -language:dynamics")
+    val sumy = ArgsSummary(sut.defaultState, args, errors = Nil, warnings = Nil)
+    val res  = sut.processArguments(sumy, processAll = true, skipped = Nil)
+    val set  = sut.language.valueIn(res.sstate)
+    assertEquals(2, args.length)
+    assertTrue("No warnings!", res.warnings.isEmpty)
+    assertTrue("No errors!", res.errors.isEmpty)
+    assertTrue("Has the feature", set.contains("implicitConversions"))
+    assertTrue("Has the feature", set.contains("dynamics"))
+
+  @Test def `Warn if multistring element is supplied multiply`: Unit =
+    class SUT extends SettingGroup:
+      val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.")
+    val sut  = SUT()
+    val args = tokenize("-language:dynamics -language:implicitConversions -language:dynamics")
+    val sumy = ArgsSummary(sut.defaultState, args, errors = Nil, warnings = Nil)
+    val res  = sut.processArguments(sumy, processAll = true, skipped = Nil)
+    val set  = sut.language.valueIn(res.sstate)
+    assertEquals(3, args.length)
+    assertEquals("Must warn", 1, res.warnings.length)
+    assertTrue("No errors!", res.errors.isEmpty)
+    assertTrue("Has the feature", set.contains("implicitConversions"))
+    assertTrue("Has the feature", set.contains("dynamics"))
+
+end ScalaSettingsTests


### PR DESCRIPTION
Permit `-language:foo -language:bar` to mean `-language:foo,bar`,
and similarly for other settings which are multivalued (i.e.,
have a value which is a list). Such settings include `-Xplugin`
and `-Xprint`. There is no mechanism to distinguish phase names
from other string settings.

Learning again how to run a junit test is a big win.

Fixes #9719 