### PR TITLE
Fix vararg overloading

### DIFF
--- a/tests/neg/overload_repeated.scala
+++ b/tests/neg/overload_repeated.scala
@@ -1,0 +1,6 @@
+object Test {
+  def bar1(x: Any) = 1
+  def bar1(x: String*) = 2
+
+  assert(bar1("") == 1) // error: ambiguous in Scala 2 and Scala 3
+}

--- a/tests/run/overload_repeated/A_1.java
+++ b/tests/run/overload_repeated/A_1.java
@@ -1,0 +1,23 @@
+class A_1 {
+  public static int foo1(Object x) { return 1; }
+  public static int foo1(String... x) { return 2; }
+
+  public static int foo2(Object x) { return 1; }
+  public static int foo2(Object... x) { return 2; }
+
+  public static <T> int foo3(T x) { return 1; }
+  public static <T> int foo3(T... x) { return 2; }
+
+  public static <T> int foo4(T x) { return 1; }
+  public static <T> int foo4(T x, T... y) { return 2; }
+
+  public static boolean check() {
+    // Java prefers non-varargs to varargs:
+    // https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2
+    return
+        foo1("") == 1 &&
+        foo2("") == 1 &&
+        foo3("") == 1 &&
+        foo4("") == 1;
+  }
+}

--- a/tests/run/overload_repeated/B_2.scala
+++ b/tests/run/overload_repeated/B_2.scala
@@ -1,0 +1,30 @@
+object Test {
+  def bar1(x: Any) = 1
+  def bar1(x: String*) = 2
+
+  def bar2(x: Any) = 1
+  def bar2(x: Any*) = 2
+
+  def bar3[T](x: T): Int = 1
+  def bar3[T](x: T*): Int = 2
+
+  def bar4[T](x: T): Int = 1
+  def bar4[T](x: T, xs: T*): Int = 2
+
+  def main(args: Array[String]): Unit = {
+    // In Java, varargs are always less specific than non-varargs (see
+    // https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2),
+    // this isn't true in Scala which leads to `foo1` being ambiguous.
+    assert(A_1.check())
+    // assert(A_1.foo1("") == 1) // Works in Java, ambiguous in Scala 2 and Dotty
+    assert(A_1.foo2("") == 1) // Same as in Java and Scala 2
+    assert(A_1.foo3("") == 1) // Same as in Java and Scala 2
+    assert(A_1.foo4("") == 1) // Same as in Java and Scala 2
+
+    // Same with Scala varargs:
+    // assert(bar1("") == 1) // Works in Java, ambiguous in Scala 2 and Dotty
+    assert(bar2("") == 1) // same in Scala 2
+    assert(bar3("") == 1) // same in Scala 2
+    assert(bar4("") == 1) // same in Scala 2
+  }
+}

--- a/tests/run/t8197.scala
+++ b/tests/run/t8197.scala
@@ -9,8 +9,8 @@ class Foo(val x: A = null) {
 }
 
 object Test extends App {
-  // both constructors of `Foo` are applicable. Overloading resolution
-  // will eliminate the alternative that uses a default argument, therefore
-  // the vararg constructor is chosen.
+  // both constructors of `Foo` are applicable and neither is more specific
+  // than the other. As a fallback, overloading resolution will eliminate the
+  // alternative that uses a default argument, therefore the vararg constructor is chosen.
   assert((new Foo).x != null)
 }


### PR DESCRIPTION
Refine/clarify the rule when a method is applicable to a vararg parameter list.