### PR TITLE
Fix #9751: Fix Inline purity checks

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -454,12 +454,14 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   def refPurity(tree: Tree)(using Context): PurityLevel = {
     val sym = tree.symbol
     if (!tree.hasType) Impure
-    else if (!tree.tpe.widen.isParameterless || sym.isEffectivelyErased) PurePath
+    else if !tree.tpe.widen.isParameterless then PurePath
+    else if sym.is(Erased) then PurePath
     else if tree.tpe.isInstanceOf[ConstantType] then PurePath
     else if (!sym.isStableMember) Impure
     else if (sym.is(Module))
       if (sym.moduleClass.isNoInitsClass) PurePath else IdempotentPath
     else if (sym.is(Lazy)) IdempotentPath
+    else if sym.isAllOf(Inline | Param) then Impure
     else PurePath
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/TransformByNameApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TransformByNameApply.scala
@@ -47,7 +47,7 @@ abstract class TransformByNameApply extends MiniPhase { thisPhase: DenotTransfor
             ref(defn.cbnArg).appliedToType(argType).appliedTo(arg).withSpan(arg.span)
           arg match {
             case Apply(Select(qual, nme.apply), Nil)
-            if qual.tpe.derivesFrom(defn.FunctionClass(0)) && isPureExpr(qual) =>
+            if qual.tpe.derivesFrom(defn.FunctionClass(0)) && (isPureExpr(qual) || qual.symbol.isAllOf(Inline | Param)) =>
               wrap(qual)
             case _ =>
               if (isByNameRef(arg) || arg.symbol == defn.cbnArg) arg

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -521,7 +521,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
          | Literal(_) =>
         true
       case Ident(_) =>
-        isPureRef(tree)
+        isPureRef(tree) || tree.symbol.isAllOf(Inline | Param)
       case Select(qual, _) =>
         if (tree.symbol.is(Erased)) true
         else isPureRef(tree) && apply(qual)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3629,8 +3629,12 @@ class Typer extends Namer
     }
 
   private def checkStatementPurity(tree: tpd.Tree)(original: untpd.Tree, exprOwner: Symbol)(using Context): Unit =
-    if (!tree.tpe.isErroneous && !ctx.isAfterTyper && isPureExpr(tree) &&
-        !tree.tpe.isRef(defn.UnitClass) && !isSelfOrSuperConstrCall(tree))
+    if !tree.tpe.isErroneous
+      && !ctx.isAfterTyper
+      && !tree.isInstanceOf[Inlined]
+      && isPureExpr(tree)
+      && !isSelfOrSuperConstrCall(tree)
+    then
       report.warning(PureExpressionInStatementPosition(original, exprOwner), original.srcPos)
 
   /** Types the body Scala 2 macro declaration `def f = macro <body>` */

--- a/tests/neg-custom-args/fatal-warnings/i9751.scala
+++ b/tests/neg-custom-args/fatal-warnings/i9751.scala
@@ -1,0 +1,9 @@
+def f(): Unit = {
+  () // error
+  ()
+}
+
+inline def g(): Unit = {
+  () // error
+  ()
+}

--- a/tests/pos-special/fatal-warnings/i9751.scala
+++ b/tests/pos-special/fatal-warnings/i9751.scala
@@ -1,0 +1,11 @@
+object Test {
+  extension (x: Int)
+    inline def times(inline op: Unit): Unit = {
+      var count = 0
+      while count < x do
+        op
+        count += 1
+    }
+
+  10.times { println("hello") }
+}

--- a/tests/pos-special/fatal-warnings/i9751b.scala
+++ b/tests/pos-special/fatal-warnings/i9751b.scala
@@ -1,0 +1,13 @@
+object Test {
+  inline def f(inline x: Boolean): Unit =
+    inline if x then println()
+
+  f(true)
+  f(false)
+
+  inline def g(inline x: => Boolean): Unit =
+    inline if x then println()
+
+  g(true)
+  g(false)
+}


### PR DESCRIPTION
We wrongly identified most inline references as pure as they are effectively erased.
Only erased terms are always pure.
Most of the purity of inline references follows from the normal purity rules except for inline parameters.
These parameters lose their binding when inlined and no purity guaranty can be ensured from the reference.