### PR TITLE
Fix #8769: change dottydoc root to docs/ subdirectory

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -187,7 +187,7 @@ class ScalaSettings extends Settings.SettingGroup {
     "-siteroot",
     "site root",
     "A directory containing static files from which to generate documentation.",
-    sys.props("user.dir")
+    "./docs"
   )
 
 

--- a/doc-tool/src/dotty/tools/dottydoc/DocDriver.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/DocDriver.scala
@@ -56,8 +56,10 @@ class DocDriver extends Driver {
 
     if (projectName.isEmpty)
       report.error(s"Site project name not set. Use `-project <title>` to set the project name")
-    else if (!siteRoot.exists || !siteRoot.isDirectory)
-      report.error(s"Site root does not exist: $siteRoot")
+    else if (!siteRoot.exists)
+      report.echo(s"Site root (`-siteroot`) does not exist: $siteRoot, no documentation will be generated.")
+    else if (!siteRoot.isDirectory)
+      report.error(s"Site root (`-siteroot`) is not a directory: $siteRoot")
     else {
       def generateSite(outDir: File, baseUrl: String) =
         Site(siteRoot, outDir, projectName, projectVersion, projectUrl, projectLogo, ctx.docbase.packages, baseUrl)


### PR DESCRIPTION
Previously it defaulted to the project root which lead to various
issues, notably it meant that the whope project ended up being copied in
_site when running `sbt doc`, what's even more fun is that when I tried
using sbt 1.4.0-RC1 this caused a compiler crash because it ended up
trying to copy a socket file that sbt had created in `target/`.

Usincs "docs/" like this still doesn't really make sense when multiple
subprojects exist since we'll try using the same directory for all of
them, but it's less worse than what we had before and it doesn't seem
worth investing more time in dottydoc since it's getting replaced.