### PR TITLE
Add scala.compiletime.requireConst

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -226,6 +226,7 @@ class Definitions {
   @tu lazy val CompiletimePackageObject: Symbol = requiredModule("scala.compiletime.package")
     @tu lazy val Compiletime_erasedValue  : Symbol = CompiletimePackageObject.requiredMethod("erasedValue")
     @tu lazy val Compiletime_error        : Symbol = CompiletimePackageObject.requiredMethod(nme.error)
+    @tu lazy val Compiletime_requireConst: Symbol = CompiletimePackageObject.requiredMethod("requireConst")
     @tu lazy val Compiletime_constValue   : Symbol = CompiletimePackageObject.requiredMethod("constValue")
     @tu lazy val Compiletime_constValueOpt: Symbol = CompiletimePackageObject.requiredMethod("constValueOpt")
     @tu lazy val Compiletime_code         : Symbol = CompiletimePackageObject.requiredMethod("extension_code")

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -51,12 +51,12 @@ package object compiletime {
   end extension
 
   /** Checks at compiletime that the provided values is a constant after
-   *  inlining and constant folding and returns the value.
+   *  inlining and constant folding.
    *
    *  Usage:
    *  ```scala
    *  inline def twice(inline n: Int): Int =
-   *    requireConst(n) // static assertion that the parameter `n` is a constant
+   *    requireConst(n) // compile-time assertion that the parameter `n` is a constant
    *    n + n
    *
    *  twice(1)

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -50,6 +50,22 @@ package object compiletime {
       ${ dotty.internal.CompileTimeMacros.codeExpr('self, 'args) }
   end extension
 
+  /** Checks at compiletime that the provided values is a constant after
+   *  inlining and constant folding and returns the value.
+   *
+   *  Usage:
+   *  ```scala
+   *  inline def twice(inline n: Int): Int =
+   *    requireConst(n) // static assertion that the parameter `n` is a constant
+   *    n + n
+   *
+   *  twice(1)
+   *  val m: Int = ...
+   *  twice(m) // error: expected a constant value but found: m
+   *  ```
+   */
+  inline def requireConst(inline x: Boolean | Byte | Short | Int | Long | Float | Double | Char | String): Unit = ()
+
   /** Same as `constValue` but returns a `None` if a constant value
    *  cannot be constructed from the provided type. Otherwise returns
    *  that value wrapped in `Some`.

--- a/tests/neg/compiletime-const.scala
+++ b/tests/neg/compiletime-const.scala
@@ -1,0 +1,48 @@
+import scala.compiletime.requireConst
+
+object Test {
+
+  requireConst(true)
+  requireConst(1)
+  requireConst(1L)
+  requireConst(1d)
+  requireConst(1f)
+  requireConst('a')
+  requireConst("abc")
+
+  requireConst(1 + 3)
+  requireConst("abc" + "cde")
+
+  val a: Int = 2
+  inline val b = 2
+
+  requireConst(a) // error: expected a requireConstant value but found: Test.a
+  requireConst(b)
+  requireConst(b + b)
+  requireConst(b - b)
+  requireConst(b / b)
+  requireConst(b % b)
+
+  inline def f(inline n: Int): Int = 4 + n
+
+  requireConst(f(1))
+  requireConst(f(a)) // error: expected a requireConstant value but found: 4.+(Test.a):Int
+  requireConst(f(b))
+  requireConst(f(b + b))
+
+  def g(n: Int): n.type = n
+
+  requireConst(g(1))
+  requireConst(g(a)) // error: expected a requireConstant value but found: Test.a
+  requireConst(g(b))
+
+
+  inline def twice(inline n: Int): Int =
+    requireConst(n) // static assertion that n is a requireConstant
+    n + n
+
+  twice(1)
+  twice(a) // error: expected a requireConstant value but found: Test.a
+  twice(b)
+
+}


### PR DESCRIPTION
`requireConst` checks at compiletime that the provided values is a constant after inlining and constant folding.

Usage:
```scala
inline def twice(inline n: Int): Int =
  requireConst(n) // static assertion that the parameter `n` is a constant
  n + n

twice(1)
val m: Int = ...
twice(m) // error: expected a constant value but found: m
```
