### PR TITLE
Use sbt-scalajs 1.2.0 in the tests of sbt-dotty.

### DIFF
--- a/sbt-dotty/sbt-test/scalajs/basic/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/scalajs/basic/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.2.0")


### PR DESCRIPTION
This was forgotten in 1ed50db745adbc15971444a413fb31150c98387c.