### PR TITLE
Remove Reflect.MatchCaseType 

### DIFF
--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -1642,15 +1642,6 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
     end extension
   end MatchTypeOps
 
-  // TODO remove this definition from here
-  /**
-   * An accessor for `scala.internal.MatchCase[_,_]`, the representation of a `MatchType` case.
-   */
-  def MatchCaseType(using ctx: Context): Type = {
-    import scala.internal.MatchCase
-    Type(classOf[MatchCase[_,_]])
-  }
-
   given (using ctx: Context) as TypeTest[Type, ByNameType] = reflectSelf.ByNameType_TypeTest
 
   object ByNameType:

--- a/tests/run-macros/tasty-construct-types/Macro_1.scala
+++ b/tests/run-macros/tasty-construct-types/Macro_1.scala
@@ -37,7 +37,7 @@ object Macros {
           TypeLambda(
             List("t"),
             _ => List(TypeBounds(Type.of[Nothing], Type.of[Any])),
-            tl => MatchCaseType.appliedTo(List(Type.of[List].appliedTo(tl.param(0)), tl.param(0)))))
+            tl => Type.of[scala.internal.MatchCase].appliedTo(List(Type.of[List].appliedTo(tl.param(0)), tl.param(0)))))
       )
 
     assert(x1T =:= '[1].unseal.tpe)


### PR DESCRIPTION
Can be replaced with `Type.of[scala.internal.MatchCase]`