### PR TITLE
Fix #9457 and #9626: Remove TermRef to inline parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -673,7 +673,9 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
           def apply(t: Type) = t match {
             case t: ThisType => thisProxy.getOrElse(t.cls, t)
             case t: TypeRef => paramProxy.getOrElse(t, mapOver(t))
-            case t: SingletonType => paramProxy.getOrElse(t, mapOver(t))
+            case t: SingletonType =>
+              if t.termSymbol.isAllOf(Inline | Param) then mapOver(t.widenTermRefExpr)
+              else paramProxy.getOrElse(t, mapOver(t))
             case t => mapOver(t)
           }
           override def mapClassInfo(tp: ClassInfo) = mapFullClassInfo(tp)

--- a/tests/pos/i9457.scala
+++ b/tests/pos/i9457.scala
@@ -1,0 +1,6 @@
+object inlinetuple:
+  def test: Int =
+    f((1, 2))
+  inline def f(inline p: (Int, Int)): Int =
+    val (a, b) = p
+    a + b

--- a/tests/pos/i9626.scala
+++ b/tests/pos/i9626.scala
@@ -1,0 +1,4 @@
+inline def scaffolding(inline op: Unit): Unit =
+  val _ = op
+
+def test = scaffolding { println("foo") }


### PR DESCRIPTION
For inline parameters we do not need to reeplace the parameter TermRef
with the proxy TermRef as this one will immediately be removed.