### PR TITLE
Cosmetic adjustments in syntax

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1471,7 +1471,7 @@ trait Applications extends Compatibility {
         case tp1: MethodType => // (1)
           tp1.paramInfos.isEmpty && tp2.isInstanceOf[LambdaType]
           || {
-            if tp1.isVarArgsMethod
+            if tp1.isVarArgsMethod then
               tp2.isVarArgsMethod
               && isApplicableMethodRef(alt2, tp1.paramInfos.map(_.repeatedToSingle), WildcardType)
             else

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -315,7 +315,7 @@ object Implicits:
 
     /** The implicit references that are eligible for type `tp`. */
     def eligible(tp: Type): List[Candidate] =
-      if (tp.hash == NotCached)
+      if tp.hash == NotCached then
         Stats.record(i"compute eligible not cached ${tp.getClass}")
         Stats.record(i"compute eligible not cached")
         computeEligible(tp)


### PR DESCRIPTION
mainly indenting match-case code:
```scala
expr match {
  case cond =>
     expr1   // indenting it to not align with case
}
```
Looks more like dotty where case block must be indented.