### PR TITLE
Remove Reflect.Context from methods that do not require it

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/reflect/ReflectionCompilerInterface.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/reflect/ReflectionCompilerInterface.scala
@@ -69,11 +69,11 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
   // Source //
   ////////////
 
-  def Source_path(using Context): java.nio.file.Path = ctx.compilationUnit.source.file.jpath
-  def Source_isJavaCompilationUnit(using Context): Boolean = ctx.compilationUnit.isInstanceOf[fromtasty.JavaCompilationUnit]
-  def Source_isScala2CompilationUnit(using Context): Boolean = ctx.compilationUnit.isInstanceOf[fromtasty.Scala2CompilationUnit]
-  def Source_isAlreadyLoadedCompilationUnit(using Context): Boolean = ctx.compilationUnit.isInstanceOf[fromtasty.AlreadyLoadedCompilationUnit]
-  def Source_compilationUnitClassname(using Context): String =
+  def Source_path: java.nio.file.Path = ctx.compilationUnit.source.file.jpath
+  def Source_isJavaCompilationUnit: Boolean = ctx.compilationUnit.isInstanceOf[fromtasty.JavaCompilationUnit]
+  def Source_isScala2CompilationUnit: Boolean = ctx.compilationUnit.isInstanceOf[fromtasty.Scala2CompilationUnit]
+  def Source_isAlreadyLoadedCompilationUnit: Boolean = ctx.compilationUnit.isInstanceOf[fromtasty.AlreadyLoadedCompilationUnit]
+  def Source_compilationUnitClassname: String =
     ctx.compilationUnit match {
       case cu: fromtasty.JavaCompilationUnit => cu.className
       case cu: fromtasty.Scala2CompilationUnit => cu.className
@@ -86,16 +86,16 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
   // REPORTING //
   ///////////////
 
-  def error(msg: => String, pos: Position)(using Context): Unit =
+  def error(msg: => String, pos: Position): Unit =
     report.error(msg, pos)
 
-  def error(msg: => String, sourceFile: SourceFile, start: Int, end: Int)(using Context): Unit =
+  def error(msg: => String, sourceFile: SourceFile, start: Int, end: Int): Unit =
     report.error(msg, util.SourcePosition(sourceFile, util.Spans.Span(start, end)))
 
-  def warning(msg: => String, pos: Position)(using Context): Unit =
+  def warning(msg: => String, pos: Position): Unit =
     report.warning(msg, pos)
 
-  def warning(msg: => String, sourceFile: SourceFile, start: Int, end: Int)(using Context): Unit =
+  def warning(msg: => String, sourceFile: SourceFile, start: Int, end: Int): Unit =
     report.error(msg, util.SourcePosition(sourceFile, util.Spans.Span(start, end)))
 
 
@@ -105,30 +105,30 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   type Tree = tpd.Tree
 
-  def Tree_pos(self: Tree)(using Context): Position = self.sourcePos
-  def Tree_symbol(self: Tree)(using Context): Symbol = self.symbol
+  def Tree_pos(self: Tree): Position = self.sourcePos
+  def Tree_symbol(self: Tree): Symbol = self.symbol
 
   type PackageClause = tpd.PackageDef
 
-  def PackageClause_TypeTest(using Context): TypeTest[Tree, PackageClause] = new {
+  def PackageClause_TypeTest: TypeTest[Tree, PackageClause] = new {
     def runtimeClass: Class[?] = classOf[PackageClause]
     override def unapply(x: Any): Option[PackageClause] = x match
       case x: tpd.PackageDef @unchecked => Some(x)
       case _ => None
   }
 
-  def PackageClause_pid(self: PackageClause)(using Context): Ref = self.pid
-  def PackageClause_stats(self: PackageClause)(using Context): List[Tree] = self.stats
+  def PackageClause_pid(self: PackageClause): Ref = self.pid
+  def PackageClause_stats(self: PackageClause): List[Tree] = self.stats
 
-  def PackageClause_apply(pid: Ref, stats: List[Tree])(using Context): PackageClause =
+  def PackageClause_apply(pid: Ref, stats: List[Tree]): PackageClause =
     withDefaultPos(tpd.PackageDef(pid.asInstanceOf[tpd.RefTree], stats))
 
-  def PackageClause_copy(original: Tree)(pid: Ref, stats: List[Tree])(using Context): PackageClause =
+  def PackageClause_copy(original: Tree)(pid: Ref, stats: List[Tree]): PackageClause =
     tpd.cpy.PackageDef(original)(pid, stats)
 
   type Statement = tpd.Tree
 
-  def Statement_TypeTest(using Context): TypeTest[Tree, Statement] = new {
+  def Statement_TypeTest: TypeTest[Tree, Statement] = new {
     def runtimeClass: Class[?] = classOf[Statement]
     override def unapply(x: Any): Option[Statement] = x match
       case _: PatternTree @unchecked => None
@@ -139,7 +139,7 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   type Import = tpd.Import
 
-  def Import_TypeTest(using Context): TypeTest[Tree, Import] = new {
+  def Import_TypeTest: TypeTest[Tree, Import] = new {
     def runtimeClass: Class[?] = classOf[Import]
     override def unapply(x: Any): Option[Import] = x match
       case tree: tpd.Import @unchecked => Some(tree)
@@ -147,18 +147,18 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
   }
 
   def Import_implied(self: Import): Boolean = false // TODO: adapt to new import scheme
-  def Import_expr(self: Import)(using Context): Tree = self.expr
-  def Import_selectors(self: Import)(using Context): List[ImportSelector] = self.selectors
+  def Import_expr(self: Import): Tree = self.expr
+  def Import_selectors(self: Import): List[ImportSelector] = self.selectors
 
-  def Import_apply(expr: Term, selectors: List[ImportSelector])(using Context): Import =
+  def Import_apply(expr: Term, selectors: List[ImportSelector]): Import =
     withDefaultPos(tpd.Import(expr, selectors))
 
-  def Import_copy(original: Tree)(expr: Term, selectors: List[ImportSelector])(using Context): Import =
+  def Import_copy(original: Tree)(expr: Term, selectors: List[ImportSelector]): Import =
     tpd.cpy.Import(original)(expr, selectors)
 
   type Definition = tpd.Tree
 
-  def Definition_TypeTest(using Context): TypeTest[Tree, Definition] = new {
+  def Definition_TypeTest: TypeTest[Tree, Definition] = new {
     def runtimeClass: Class[?] = classOf[Definition]
     override def unapply(x: Any): Option[Definition] = x match
       case x: tpd.MemberDef @unchecked => Some(x)
@@ -166,103 +166,103 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
       case _ => None
   }
 
-  def Definition_name(self: Definition)(using Context): String = self match {
+  def Definition_name(self: Definition): String = self match {
     case self: tpd.MemberDef => self.name.toString
     case self: PackageDefinition => self.symbol.name.toString // TODO make PackageDefinition a MemberDef or NameTree
   }
 
   type PackageDef = PackageDefinition
 
-  def PackageDef_TypeTest(using Context): TypeTest[Tree, PackageDef] = new {
+  def PackageDef_TypeTest: TypeTest[Tree, PackageDef] = new {
     def runtimeClass: Class[?] = classOf[PackageDef]
     override def unapply(x: Any): Option[PackageDef] = x match
       case x: PackageDefinition @unchecked => Some(x)
       case _ => None
   }
 
-  def PackageDef_owner(self: PackageDef)(using Context): PackageDef = packageDefFromSym(self.symbol.owner)
+  def PackageDef_owner(self: PackageDef): PackageDef = packageDefFromSym(self.symbol.owner)
 
-  def PackageDef_members(self: PackageDef)(using Context): List[Statement] =
+  def PackageDef_members(self: PackageDef): List[Statement] =
     if (self.symbol.is(core.Flags.JavaDefined)) Nil // FIXME should also support java packages
     else self.symbol.info.decls.iterator.map(definitionFromSym).toList
 
   type ClassDef = tpd.TypeDef
 
-  def ClassDef_TypeTest(using Context): TypeTest[Tree, ClassDef] = new {
+  def ClassDef_TypeTest: TypeTest[Tree, ClassDef] = new {
     def runtimeClass: Class[?] = classOf[ClassDef]
     override def unapply(x: Any): Option[ClassDef] = x match
       case x: tpd.TypeDef @unchecked if x.isClassDef => Some(x)
       case _ => None
   }
 
-  def ClassDef_constructor(self: ClassDef)(using Context): DefDef = ClassDef_rhs(self).constr
-  def ClassDef_parents(self: ClassDef)(using Context): List[Term | TypeTree] = ClassDef_rhs(self).parents
-  def ClassDef_derived(self: ClassDef)(using Context): List[TypeTree] = ClassDef_rhs(self).derived.asInstanceOf[List[TypeTree]]
-  def ClassDef_self(self: ClassDef)(using Context): Option[ValDef] = optional(ClassDef_rhs(self).self)
-  def ClassDef_body(self: ClassDef)(using Context): List[Statement] = ClassDef_rhs(self).body
+  def ClassDef_constructor(self: ClassDef): DefDef = ClassDef_rhs(self).constr
+  def ClassDef_parents(self: ClassDef): List[Term | TypeTree] = ClassDef_rhs(self).parents
+  def ClassDef_derived(self: ClassDef): List[TypeTree] = ClassDef_rhs(self).derived.asInstanceOf[List[TypeTree]]
+  def ClassDef_self(self: ClassDef): Option[ValDef] = optional(ClassDef_rhs(self).self)
+  def ClassDef_body(self: ClassDef): List[Statement] = ClassDef_rhs(self).body
   private def ClassDef_rhs(self: ClassDef) = self.rhs.asInstanceOf[tpd.Template]
 
-  def ClassDef_copy(original: Tree)(name: String, constr: DefDef, parents: List[Term | TypeTree], derived: List[TypeTree], selfOpt: Option[ValDef], body: List[Statement])(using Context): ClassDef = {
+  def ClassDef_copy(original: Tree)(name: String, constr: DefDef, parents: List[Term | TypeTree], derived: List[TypeTree], selfOpt: Option[ValDef], body: List[Statement]): ClassDef = {
     val Trees.TypeDef(_, originalImpl: tpd.Template) = original
     tpd.cpy.TypeDef(original)(name.toTypeName, tpd.cpy.Template(originalImpl)(constr, parents, derived, selfOpt.getOrElse(tpd.EmptyValDef), body))
   }
 
   type TypeDef = tpd.TypeDef
 
-  def TypeDef_TypeTest(using Context): TypeTest[Tree, TypeDef] = new {
+  def TypeDef_TypeTest: TypeTest[Tree, TypeDef] = new {
     def runtimeClass: Class[?] = classOf[TypeDef]
     override def unapply(x: Any): Option[TypeDef] = x match
       case x: tpd.TypeDef @unchecked if !x.isClassDef => Some(x)
       case _ => None
   }
 
-  def TypeDef_rhs(self: TypeDef)(using Context): TypeTree | TypeBoundsTree = self.rhs
+  def TypeDef_rhs(self: TypeDef): TypeTree | TypeBoundsTree = self.rhs
 
-  def TypeDef_apply(symbol: Symbol)(using Context): TypeDef = withDefaultPos(tpd.TypeDef(symbol.asType))
-  def TypeDef_copy(original: Tree)(name: String, rhs: TypeTree | TypeBoundsTree)(using Context): TypeDef =
+  def TypeDef_apply(symbol: Symbol): TypeDef = withDefaultPos(tpd.TypeDef(symbol.asType))
+  def TypeDef_copy(original: Tree)(name: String, rhs: TypeTree | TypeBoundsTree): TypeDef =
     tpd.cpy.TypeDef(original)(name.toTypeName, rhs)
 
   type DefDef = tpd.DefDef
 
-  def DefDef_TypeTest(using Context): TypeTest[Tree, DefDef] = new {
+  def DefDef_TypeTest: TypeTest[Tree, DefDef] = new {
     def runtimeClass: Class[?] = classOf[DefDef]
     override def unapply(x: Any): Option[DefDef] = x match
       case x: tpd.DefDef @unchecked => Some(x)
       case _ => None
   }
 
-  def DefDef_typeParams(self: DefDef)(using Context): List[TypeDef] = self.tparams
-  def DefDef_paramss(self: DefDef)(using Context): List[List[ValDef]] = self.vparamss
-  def DefDef_returnTpt(self: DefDef)(using Context): TypeTree = self.tpt
-  def DefDef_rhs(self: DefDef)(using Context): Option[Tree] = optional(self.rhs)
+  def DefDef_typeParams(self: DefDef): List[TypeDef] = self.tparams
+  def DefDef_paramss(self: DefDef): List[List[ValDef]] = self.vparamss
+  def DefDef_returnTpt(self: DefDef): TypeTree = self.tpt
+  def DefDef_rhs(self: DefDef): Option[Tree] = optional(self.rhs)
 
-  def DefDef_apply(symbol: Symbol, rhsFn: List[Type] => List[List[Term]] => Option[Term])(using Context): DefDef =
+  def DefDef_apply(symbol: Symbol, rhsFn: List[Type] => List[List[Term]] => Option[Term]): DefDef =
     withDefaultPos(tpd.polyDefDef(symbol.asTerm, tparams => vparamss => rhsFn(tparams)(vparamss).getOrElse(tpd.EmptyTree)))
 
-  def DefDef_copy(original: Tree)(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]], tpt: TypeTree, rhs: Option[Term])(using Context): DefDef =
+  def DefDef_copy(original: Tree)(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]], tpt: TypeTree, rhs: Option[Term]): DefDef =
     tpd.cpy.DefDef(original)(name.toTermName, typeParams, paramss, tpt, rhs.getOrElse(tpd.EmptyTree))
 
   type ValDef = tpd.ValDef
 
-  def ValDef_TypeTest(using Context): TypeTest[Tree, ValDef] = new {
+  def ValDef_TypeTest: TypeTest[Tree, ValDef] = new {
     def runtimeClass: Class[?] = classOf[ValDef]
     override def unapply(x: Any): Option[ValDef] = x match
       case x: tpd.ValDef @unchecked => Some(x)
       case _ => None
   }
 
-  def ValDef_tpt(self: ValDef)(using Context): TypeTree = self.tpt
-  def ValDef_rhs(self: ValDef)(using Context): Option[Tree] = optional(self.rhs)
+  def ValDef_tpt(self: ValDef): TypeTree = self.tpt
+  def ValDef_rhs(self: ValDef): Option[Tree] = optional(self.rhs)
 
-  def ValDef_apply(symbol: Symbol, rhs: Option[Term])(using Context): ValDef =
+  def ValDef_apply(symbol: Symbol, rhs: Option[Term]): ValDef =
     tpd.ValDef(symbol.asTerm, rhs.getOrElse(tpd.EmptyTree))
 
-  def ValDef_copy(original: Tree)(name: String, tpt: TypeTree, rhs: Option[Term])(using Context): ValDef =
+  def ValDef_copy(original: Tree)(name: String, tpt: TypeTree, rhs: Option[Term]): ValDef =
     tpd.cpy.ValDef(original)(name.toTermName, tpt, rhs.getOrElse(tpd.EmptyTree))
 
   type Term = tpd.Tree
 
-  def Term_TypeTest(using Context): TypeTest[Tree, Term] = new {
+  def Term_TypeTest: TypeTest[Tree, Term] = new {
     def runtimeClass: Class[?] = classOf[Term]
     override def unapply(x: Any): Option[Term] = x match
       case _ if Unapply_TypeTest.unapply(x).isDefined => None
@@ -274,11 +274,11 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
       case _ => None
   }
 
-  def Term_tpe(self: Term)(using Context): Type = self.tpe
-  def Term_underlyingArgument(self: Term)(using Context): Term = self.underlyingArgument
-  def Term_underlying(self: Term)(using Context): Term = self.underlying
+  def Term_tpe(self: Term): Type = self.tpe
+  def Term_underlyingArgument(self: Term): Term = self.underlyingArgument
+  def Term_underlying(self: Term): Term = self.underlying
 
-  def Term_etaExpand(term: Term)(using Context): Term = term.tpe.widen match {
+  def Term_etaExpand(term: Term): Term = term.tpe.widen match {
     case mtpe: Types.MethodType if !mtpe.isParamDependent =>
       val closureResType = mtpe.resType match {
         case t: Types.MethodType @unchecked => t.toFunctionType()
@@ -290,238 +290,238 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
     case _ => term
   }
 
-  def TypeRef_apply(sym: Symbol)(using Context): TypeTree = {
+  def TypeRef_apply(sym: Symbol): TypeTree = {
     assert(sym.isType)
     withDefaultPos(tpd.ref(sym).asInstanceOf[tpd.TypeTree])
   }
 
   type Ref = tpd.RefTree
 
-  def Ref_TypeTest(using Context): TypeTest[Tree, Ref] = new {
+  def Ref_TypeTest: TypeTest[Tree, Ref] = new {
     def runtimeClass: Class[?] = classOf[Ref]
     override def unapply(x: Any): Option[Ref] = x match
       case x: tpd.RefTree @unchecked if x.isTerm => Some(x)
       case _ => None
   }
 
-  def Ref_term(tp: TermRef)(using Context): Ref =
+  def Ref_term(tp: TermRef): Ref =
     withDefaultPos(tpd.ref(tp).asInstanceOf[tpd.RefTree])
 
-  def Ref_apply(sym: Symbol)(using Context): Ref = {
+  def Ref_apply(sym: Symbol): Ref = {
     assert(sym.isTerm)
     withDefaultPos(tpd.ref(sym).asInstanceOf[tpd.RefTree])
   }
 
   type Ident = tpd.Ident
 
-  def Ident_TypeTest(using Context): TypeTest[Tree, Ident] = new {
+  def Ident_TypeTest: TypeTest[Tree, Ident] = new {
     def runtimeClass: Class[?] = classOf[Ident]
     override def unapply(x: Any): Option[Ident] = x match
       case x: tpd.Ident @unchecked if x.isTerm => Some(x)
       case _ => None
   }
 
-  def Ident_name(self: Ident)(using Context): String = self.name.show
+  def Ident_name(self: Ident): String = self.name.show
 
-  def Ident_apply(tmref: TermRef)(using Context): Term =
+  def Ident_apply(tmref: TermRef): Term =
     withDefaultPos(tpd.ref(tmref).asInstanceOf[Term])
 
-  def Ident_copy(original: Tree)(name: String)(using Context): Ident =
+  def Ident_copy(original: Tree)(name: String): Ident =
     tpd.cpy.Ident(original)(name.toTermName)
 
   type Select = tpd.Select
 
-  def Select_TypeTest(using Context): TypeTest[Tree, Select] = new {
+  def Select_TypeTest: TypeTest[Tree, Select] = new {
     def runtimeClass: Class[?] = classOf[Select]
     override def unapply(x: Any): Option[Select] = x match
       case x: tpd.Select @unchecked if x.isTerm => Some(x)
       case _ => None
   }
 
-  def Select_qualifier(self: Select)(using Context): Term = self.qualifier
-  def Select_name(self: Select)(using Context): String = self.name.toString
-  def Select_signature(self: Select)(using Context): Option[Signature] =
+  def Select_qualifier(self: Select): Term = self.qualifier
+  def Select_name(self: Select): String = self.name.toString
+  def Select_signature(self: Select): Option[Signature] =
     if (self.symbol.signature == core.Signature.NotAMethod) None
     else Some(self.symbol.signature)
 
-  def Select_apply(qualifier: Term, symbol: Symbol)(using Context): Select =
+  def Select_apply(qualifier: Term, symbol: Symbol): Select =
     withDefaultPos(tpd.Select(qualifier, Types.TermRef(qualifier.tpe, symbol)))
 
-  def Select_unique(qualifier: Term, name: String)(using Context): Select = {
+  def Select_unique(qualifier: Term, name: String): Select = {
     val denot = qualifier.tpe.member(name.toTermName)
     assert(!denot.isOverloaded, s"The symbol `$name` is overloaded. The method Select.unique can only be used for non-overloaded symbols.")
     withDefaultPos(tpd.Select(qualifier, name.toTermName))
   }
 
   // TODO rename, this returns an Apply and not a Select
-  def Select_overloaded(qualifier: Term, name: String, targs: List[Type], args: List[Term])(using Context): Apply =
+  def Select_overloaded(qualifier: Term, name: String, targs: List[Type], args: List[Term]): Apply =
     withDefaultPos(tpd.applyOverloaded(qualifier, name.toTermName, args, targs, Types.WildcardType).asInstanceOf[Apply])
 
-  def Select_copy(original: Tree)(qualifier: Term, name: String)(using Context): Select =
+  def Select_copy(original: Tree)(qualifier: Term, name: String): Select =
     tpd.cpy.Select(original)(qualifier, name.toTermName)
 
   type Literal = tpd.Literal
 
-  def Literal_TypeTest(using Context): TypeTest[Tree, Literal] = new {
+  def Literal_TypeTest: TypeTest[Tree, Literal] = new {
     def runtimeClass: Class[?] = classOf[Literal]
     override def unapply(x: Any): Option[Literal] = x match
       case x: tpd.Literal @unchecked => Some(x)
       case _ => None
   }
 
-  def Literal_constant(self: Literal)(using Context): Constant = self.const
+  def Literal_constant(self: Literal): Constant = self.const
 
-  def Literal_apply(constant: Constant)(using Context): Literal =
+  def Literal_apply(constant: Constant): Literal =
     withDefaultPos(tpd.Literal(constant))
 
-  def Literal_copy(original: Tree)(constant: Constant)(using Context): Literal =
+  def Literal_copy(original: Tree)(constant: Constant): Literal =
     tpd.cpy.Literal(original)(constant)
 
   type This = tpd.This
 
-  def This_TypeTest(using Context): TypeTest[Tree, This] = new {
+  def This_TypeTest: TypeTest[Tree, This] = new {
     def runtimeClass: Class[?] = classOf[This]
     override def unapply(x: Any): Option[This] = x match
       case x: tpd.This @unchecked => Some(x)
       case _ => None
   }
 
-  def This_id(self: This)(using Context): Option[Id] = optional(self.qual)
+  def This_id(self: This): Option[Id] = optional(self.qual)
 
-  def This_apply(cls: Symbol)(using Context): This =
+  def This_apply(cls: Symbol): This =
     withDefaultPos(tpd.This(cls.asClass))
 
-  def This_copy(original: Tree)(qual: Option[Id])(using Context): This =
+  def This_copy(original: Tree)(qual: Option[Id]): This =
     tpd.cpy.This(original)(qual.getOrElse(untpd.EmptyTypeIdent))
 
   type New = tpd.New
 
-  def New_TypeTest(using Context): TypeTest[Tree, New] = new {
+  def New_TypeTest: TypeTest[Tree, New] = new {
     def runtimeClass: Class[?] = classOf[New]
     override def unapply(x: Any): Option[New] = x match
       case x: tpd.New @unchecked => Some(x)
       case _ => None
   }
 
-  def New_tpt(self: New)(using Context): TypeTree = self.tpt
+  def New_tpt(self: New): TypeTree = self.tpt
 
-  def New_apply(tpt: TypeTree)(using Context): New = withDefaultPos(tpd.New(tpt))
+  def New_apply(tpt: TypeTree): New = withDefaultPos(tpd.New(tpt))
 
-  def New_copy(original: Tree)(tpt: TypeTree)(using Context): New =
+  def New_copy(original: Tree)(tpt: TypeTree): New =
     tpd.cpy.New(original)(tpt)
 
   type NamedArg = tpd.NamedArg
 
-  def NamedArg_TypeTest(using Context): TypeTest[Tree, NamedArg] = new {
+  def NamedArg_TypeTest: TypeTest[Tree, NamedArg] = new {
     def runtimeClass: Class[?] = classOf[NamedArg]
     override def unapply(x: Any): Option[NamedArg] = x match
       case x: tpd.NamedArg @unchecked if x.name.isInstanceOf[core.Names.TermName] => Some(x) // TODO: Now, the name should alwas be a term name
       case _ => None
   }
 
-  def NamedArg_name(self: NamedArg)(using Context): String = self.name.toString
-  def NamedArg_value(self: NamedArg)(using Context): Term = self.arg
+  def NamedArg_name(self: NamedArg): String = self.name.toString
+  def NamedArg_value(self: NamedArg): Term = self.arg
 
-  def NamedArg_apply(name: String, arg: Term)(using Context): NamedArg =
+  def NamedArg_apply(name: String, arg: Term): NamedArg =
     withDefaultPos(tpd.NamedArg(name.toTermName, arg))
 
-  def NamedArg_copy(original: Tree)(name: String, arg: Term)(using Context): NamedArg =
+  def NamedArg_copy(original: Tree)(name: String, arg: Term): NamedArg =
     tpd.cpy.NamedArg(original)(name.toTermName, arg)
 
   type Apply = tpd.Apply
 
-  def Apply_TypeTest(using Context): TypeTest[Tree, Apply] = new {
+  def Apply_TypeTest: TypeTest[Tree, Apply] = new {
     def runtimeClass: Class[?] = classOf[Apply]
     override def unapply(x: Any): Option[Apply] = x match
       case x: tpd.Apply @unchecked => Some(x)
       case _ => None
   }
 
-  def Apply_fun(self: Apply)(using Context): Term = self.fun
-  def Apply_args(self: Apply)(using Context): List[Term] = self.args
+  def Apply_fun(self: Apply): Term = self.fun
+  def Apply_args(self: Apply): List[Term] = self.args
 
 
-  def Apply_apply(fn: Term, args: List[Term])(using Context): Apply =
+  def Apply_apply(fn: Term, args: List[Term]): Apply =
     withDefaultPos(tpd.Apply(fn, args))
 
-  def Apply_copy(original: Tree)(fun: Term, args: List[Term])(using Context): Apply =
+  def Apply_copy(original: Tree)(fun: Term, args: List[Term]): Apply =
     tpd.cpy.Apply(original)(fun, args)
 
   type TypeApply = tpd.TypeApply
 
-  def TypeApply_TypeTest(using Context): TypeTest[Tree, TypeApply] = new {
+  def TypeApply_TypeTest: TypeTest[Tree, TypeApply] = new {
     def runtimeClass: Class[?] = classOf[TypeApply]
     override def unapply(x: Any): Option[TypeApply] = x match
       case x: tpd.TypeApply @unchecked => Some(x)
       case _ => None
   }
 
-  def TypeApply_fun(self: TypeApply)(using Context): Term = self.fun
-  def TypeApply_args(self: TypeApply)(using Context): List[TypeTree] = self.args
+  def TypeApply_fun(self: TypeApply): Term = self.fun
+  def TypeApply_args(self: TypeApply): List[TypeTree] = self.args
 
-  def TypeApply_apply(fn: Term, args: List[TypeTree])(using Context): TypeApply =
+  def TypeApply_apply(fn: Term, args: List[TypeTree]): TypeApply =
     withDefaultPos(tpd.TypeApply(fn, args))
 
-  def TypeApply_copy(original: Tree)(fun: Term, args: List[TypeTree])(using Context): TypeApply =
+  def TypeApply_copy(original: Tree)(fun: Term, args: List[TypeTree]): TypeApply =
     tpd.cpy.TypeApply(original)(fun, args)
 
   type Super = tpd.Super
 
-  def Super_TypeTest(using Context): TypeTest[Tree, Super] = new {
+  def Super_TypeTest: TypeTest[Tree, Super] = new {
     def runtimeClass: Class[?] = classOf[Super]
     override def unapply(x: Any): Option[Super] = x match
       case x: tpd.Super @unchecked => Some(x)
       case _ => None
   }
 
-  def Super_qualifier(self: Super)(using Context): Term = self.qual
-  def Super_id(self: Super)(using Context): Option[Id] = optional(self.mix)
+  def Super_qualifier(self: Super): Term = self.qual
+  def Super_id(self: Super): Option[Id] = optional(self.mix)
 
-  def Super_apply(qual: Term, mix: Option[Id])(using Context): Super =
+  def Super_apply(qual: Term, mix: Option[Id]): Super =
     withDefaultPos(tpd.Super(qual, mix.getOrElse(untpd.EmptyTypeIdent), NoSymbol))
 
-  def Super_copy(original: Tree)(qual: Term, mix: Option[Id])(using Context): Super =
+  def Super_copy(original: Tree)(qual: Term, mix: Option[Id]): Super =
     tpd.cpy.Super(original)(qual, mix.getOrElse(untpd.EmptyTypeIdent))
 
   type Typed = tpd.Typed
 
-  def Typed_TypeTest(using Context): TypeTest[Tree, Typed] = new {
+  def Typed_TypeTest: TypeTest[Tree, Typed] = new {
     def runtimeClass: Class[?] = classOf[Typed]
     override def unapply(x: Any): Option[Typed] = x match
       case x: tpd.Typed @unchecked => Some(x)
       case _ => None
   }
 
-  def Typed_expr(self: Typed)(using Context): Term = self.expr
-  def Typed_tpt(self: Typed)(using Context): TypeTree = self.tpt
+  def Typed_expr(self: Typed): Term = self.expr
+  def Typed_tpt(self: Typed): TypeTree = self.tpt
 
-  def Typed_apply(expr: Term, tpt: TypeTree)(using Context): Typed =
+  def Typed_apply(expr: Term, tpt: TypeTree): Typed =
     withDefaultPos(tpd.Typed(expr, tpt))
 
-  def Typed_copy(original: Tree)(expr: Term, tpt: TypeTree)(using Context): Typed =
+  def Typed_copy(original: Tree)(expr: Term, tpt: TypeTree): Typed =
     tpd.cpy.Typed(original)(expr, tpt)
 
   type Assign = tpd.Assign
 
-  def Assign_TypeTest(using Context): TypeTest[Tree, Assign] = new {
+  def Assign_TypeTest: TypeTest[Tree, Assign] = new {
     def runtimeClass: Class[?] = classOf[Assign]
     override def unapply(x: Any): Option[Assign] = x match
       case x: tpd.Assign @unchecked => Some(x)
       case _ => None
   }
 
-  def Assign_lhs(self: Assign)(using Context): Term = self.lhs
-  def Assign_rhs(self: Assign)(using Context): Term = self.rhs
+  def Assign_lhs(self: Assign): Term = self.lhs
+  def Assign_rhs(self: Assign): Term = self.rhs
 
-  def Assign_apply(lhs: Term, rhs: Term)(using Context): Assign =
+  def Assign_apply(lhs: Term, rhs: Term): Assign =
     withDefaultPos(tpd.Assign(lhs, rhs))
 
-  def Assign_copy(original: Tree)(lhs: Term, rhs: Term)(using Context): Assign =
+  def Assign_copy(original: Tree)(lhs: Term, rhs: Term): Assign =
     tpd.cpy.Assign(original)(lhs, rhs)
 
   type Block = tpd.Block
 
-  def Block_TypeTest(using Context): TypeTest[Tree, Block] = new {
+  def Block_TypeTest: TypeTest[Tree, Block] = new {
     def runtimeClass: Class[?] = classOf[Block]
     override def unapply(x: Any): Option[Block] =
       x match
@@ -536,7 +536,7 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
    *  i) Put `while` loops in their own blocks: `{ def while$() = ...; while$() }`
    *  ii) Put closures in their own blocks: `{ def anon$() = ...; closure(anon$, ...) }`
    */
-  private def normalizedLoops(tree: tpd.Tree)(using Context): tpd.Tree = tree match {
+  private def normalizedLoops(tree: tpd.Tree): tpd.Tree = tree match {
     case block: tpd.Block if block.stats.size > 1 =>
       def normalizeInnerLoops(stats: List[tpd.Tree]): List[tpd.Tree] = stats match {
         case (x: tpd.DefDef) :: y :: xs if needsNormalization(y) =>
@@ -557,171 +557,171 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
   }
 
   /** If it is the second statement of a closure. See: `normalizedLoops` */
-  private def needsNormalization(tree: tpd.Tree)(using Context): Boolean = tree match {
+  private def needsNormalization(tree: tpd.Tree): Boolean = tree match {
     case _: tpd.Closure => true
     case _ => false
   }
 
-  def Block_statements(self: Block)(using Context): List[Statement] = self.stats
-  def Block_expr(self: Block)(using Context): Term = self.expr
+  def Block_statements(self: Block): List[Statement] = self.stats
+  def Block_expr(self: Block): Term = self.expr
 
-  def Block_apply(stats: List[Statement], expr: Term)(using Context): Block =
+  def Block_apply(stats: List[Statement], expr: Term): Block =
     withDefaultPos(tpd.Block(stats, expr))
 
-  def Block_copy(original: Tree)(stats: List[Statement], expr: Term)(using Context): Block =
+  def Block_copy(original: Tree)(stats: List[Statement], expr: Term): Block =
     tpd.cpy.Block(original)(stats, expr)
 
   type Inlined = tpd.Inlined
 
-  def Inlined_TypeTest(using Context): TypeTest[Tree, Inlined] = new {
+  def Inlined_TypeTest: TypeTest[Tree, Inlined] = new {
     def runtimeClass: Class[?] = classOf[Inlined]
     override def unapply(x: Any): Option[Inlined] = x match
       case x: tpd.Inlined @unchecked => Some(x)
       case _ => None
   }
 
-  def Inlined_call(self: Inlined)(using Context): Option[Term | TypeTree] = optional(self.call)
-  def Inlined_bindings(self: Inlined)(using Context): List[Definition] = self.bindings
-  def Inlined_body(self: Inlined)(using Context): Term = self.expansion
+  def Inlined_call(self: Inlined): Option[Term | TypeTree] = optional(self.call)
+  def Inlined_bindings(self: Inlined): List[Definition] = self.bindings
+  def Inlined_body(self: Inlined): Term = self.expansion
 
-  def Inlined_apply(call: Option[Term | TypeTree], bindings: List[Definition], expansion: Term)(using Context): Inlined =
+  def Inlined_apply(call: Option[Term | TypeTree], bindings: List[Definition], expansion: Term): Inlined =
     withDefaultPos(tpd.Inlined(call.getOrElse(tpd.EmptyTree), bindings.map { case b: tpd.MemberDef => b }, expansion))
 
-  def Inlined_copy(original: Tree)(call: Option[Term | TypeTree], bindings: List[Definition], expansion: Term)(using Context): Inlined =
+  def Inlined_copy(original: Tree)(call: Option[Term | TypeTree], bindings: List[Definition], expansion: Term): Inlined =
     tpd.cpy.Inlined(original)(call.getOrElse(tpd.EmptyTree), bindings.asInstanceOf[List[tpd.MemberDef]], expansion)
 
   type Closure = tpd.Closure
 
-  def Closure_TypeTest(using Context): TypeTest[Tree, Closure] = new {
+  def Closure_TypeTest: TypeTest[Tree, Closure] = new {
     def runtimeClass: Class[?] = classOf[Closure]
     override def unapply(x: Any): Option[Closure] = x match
       case x: tpd.Closure @unchecked => Some(x)
       case _ => None
   }
 
-  def Closure_meth(self: Closure)(using Context): Term = self.meth
-  def Closure_tpeOpt(self: Closure)(using Context): Option[Type] = optional(self.tpt).map(_.tpe)
+  def Closure_meth(self: Closure): Term = self.meth
+  def Closure_tpeOpt(self: Closure): Option[Type] = optional(self.tpt).map(_.tpe)
 
-  def Closure_apply(meth: Term, tpe: Option[Type])(using Context): Closure =
+  def Closure_apply(meth: Term, tpe: Option[Type]): Closure =
     withDefaultPos(tpd.Closure(Nil, meth, tpe.map(tpd.TypeTree(_)).getOrElse(tpd.EmptyTree)))
 
-  def Closure_copy(original: Tree)(meth: Tree, tpe: Option[Type])(using Context): Closure =
+  def Closure_copy(original: Tree)(meth: Tree, tpe: Option[Type]): Closure =
     tpd.cpy.Closure(original)(Nil, meth, tpe.map(tpd.TypeTree(_)).getOrElse(tpd.EmptyTree))
 
-  def Lambda_apply(tpe: MethodType, rhsFn: List[Tree] => Tree)(using Context): Block =
+  def Lambda_apply(tpe: MethodType, rhsFn: List[Tree] => Tree): Block =
     tpd.Lambda(tpe, rhsFn)
 
   type If = tpd.If
 
-  def If_TypeTest(using Context): TypeTest[Tree, If] = new {
+  def If_TypeTest: TypeTest[Tree, If] = new {
     def runtimeClass: Class[?] = classOf[If]
     override def unapply(x: Any): Option[If] = x match
       case x: tpd.If @unchecked => Some(x)
       case _ => None
   }
 
-  def If_cond(self: If)(using Context): Term = self.cond
-  def If_thenp(self: If)(using Context): Term = self.thenp
-  def If_elsep(self: If)(using Context): Term = self.elsep
+  def If_cond(self: If): Term = self.cond
+  def If_thenp(self: If): Term = self.thenp
+  def If_elsep(self: If): Term = self.elsep
 
-  def If_apply(cond: Term, thenp: Term, elsep: Term)(using Context): If =
+  def If_apply(cond: Term, thenp: Term, elsep: Term): If =
     withDefaultPos(tpd.If(cond, thenp, elsep))
 
-  def If_copy(original: Tree)(cond: Term, thenp: Term, elsep: Term)(using Context): If =
+  def If_copy(original: Tree)(cond: Term, thenp: Term, elsep: Term): If =
     tpd.cpy.If(original)(cond, thenp, elsep)
 
   type Match = tpd.Match
 
-  def Match_TypeTest(using Context): TypeTest[Tree, Match] = new {
+  def Match_TypeTest: TypeTest[Tree, Match] = new {
     def runtimeClass: Class[?] = classOf[Match]
     override def unapply(x: Any): Option[Match] = x match
       case x: tpd.Match @unchecked if !x.selector.isEmpty => Some(x)
       case _ => None
   }
 
-  def Match_scrutinee(self: Match)(using Context): Term = self.selector
-  def Match_cases(self: Match)(using Context): List[CaseDef] = self.cases
+  def Match_scrutinee(self: Match): Term = self.selector
+  def Match_cases(self: Match): List[CaseDef] = self.cases
 
-  def Match_apply(selector: Term, cases: List[CaseDef])(using Context): Match =
+  def Match_apply(selector: Term, cases: List[CaseDef]): Match =
     withDefaultPos(tpd.Match(selector, cases))
 
-  def Match_copy(original: Tree)(selector: Term, cases: List[CaseDef])(using Context): Match =
+  def Match_copy(original: Tree)(selector: Term, cases: List[CaseDef]): Match =
     tpd.cpy.Match(original)(selector, cases)
 
   type GivenMatch = tpd.Match
 
-  def GivenMatch_TypeTest(using Context): TypeTest[Tree, GivenMatch] = new {
+  def GivenMatch_TypeTest: TypeTest[Tree, GivenMatch] = new {
     def runtimeClass: Class[?] = classOf[GivenMatch]
     override def unapply(x: Any): Option[GivenMatch] = x match
       case x: tpd.Match @unchecked if x.selector.isEmpty => Some(x)
       case _ => None
   }
 
-  def GivenMatch_cases(self: Match)(using Context): List[CaseDef] = self.cases
+  def GivenMatch_cases(self: Match): List[CaseDef] = self.cases
 
-  def GivenMatch_apply(cases: List[CaseDef])(using Context): GivenMatch =
+  def GivenMatch_apply(cases: List[CaseDef]): GivenMatch =
     withDefaultPos(tpd.Match(tpd.EmptyTree, cases))
 
-  def GivenMatch_copy(original: Tree)(cases: List[CaseDef])(using Context): GivenMatch =
+  def GivenMatch_copy(original: Tree)(cases: List[CaseDef]): GivenMatch =
     tpd.cpy.Match(original)(tpd.EmptyTree, cases)
 
   type Try = tpd.Try
 
-  def Try_TypeTest(using Context): TypeTest[Tree, Try] = new {
+  def Try_TypeTest: TypeTest[Tree, Try] = new {
     def runtimeClass: Class[?] = classOf[Try]
     override def unapply(x: Any): Option[Try] = x match
       case x: tpd.Try @unchecked => Some(x)
       case _ => None
   }
 
-  def Try_body(self: Try)(using Context): Term = self.expr
-  def Try_cases(self: Try)(using Context): List[CaseDef] = self.cases
-  def Try_finalizer(self: Try)(using Context): Option[Term] = optional(self.finalizer)
+  def Try_body(self: Try): Term = self.expr
+  def Try_cases(self: Try): List[CaseDef] = self.cases
+  def Try_finalizer(self: Try): Option[Term] = optional(self.finalizer)
 
-  def Try_apply(expr: Term, cases: List[CaseDef], finalizer: Option[Term])(using Context): Try =
+  def Try_apply(expr: Term, cases: List[CaseDef], finalizer: Option[Term]): Try =
     withDefaultPos(tpd.Try(expr, cases, finalizer.getOrElse(tpd.EmptyTree)))
 
-  def Try_copy(original: Tree)(expr: Term, cases: List[CaseDef], finalizer: Option[Term])(using Context): Try =
+  def Try_copy(original: Tree)(expr: Term, cases: List[CaseDef], finalizer: Option[Term]): Try =
     tpd.cpy.Try(original)(expr, cases, finalizer.getOrElse(tpd.EmptyTree))
 
   type Return = tpd.Return
 
-  def Return_TypeTest(using Context): TypeTest[Tree, Return] = new {
+  def Return_TypeTest: TypeTest[Tree, Return] = new {
     def runtimeClass: Class[?] = classOf[Return]
     override def unapply(x: Any): Option[Return] = x match
       case x: tpd.Return @unchecked => Some(x)
       case _ => None
   }
 
-  def Return_expr(self: Return)(using Context): Term = self.expr
+  def Return_expr(self: Return): Term = self.expr
 
-  def Return_apply(expr: Term)(using Context): Return =
+  def Return_apply(expr: Term): Return =
     withDefaultPos(tpd.Return(expr, ctx.owner))
 
-  def Return_copy(original: Tree)(expr: Term)(using Context): Return =
+  def Return_copy(original: Tree)(expr: Term): Return =
     tpd.cpy.Return(original)(expr, tpd.ref(ctx.owner))
 
   type Repeated = tpd.SeqLiteral
 
-  def Repeated_TypeTest(using Context): TypeTest[Tree, Repeated] = new {
+  def Repeated_TypeTest: TypeTest[Tree, Repeated] = new {
     def runtimeClass: Class[?] = classOf[Repeated]
     override def unapply(x: Any): Option[Repeated] = x match
       case x: tpd.SeqLiteral @unchecked => Some(x)
       case _ => None
   }
 
-  def Repeated_elems(self: Repeated)(using Context): List[Term] = self.elems
-  def Repeated_elemtpt(self: Repeated)(using Context): TypeTree = self.elemtpt
+  def Repeated_elems(self: Repeated): List[Term] = self.elems
+  def Repeated_elemtpt(self: Repeated): TypeTree = self.elemtpt
 
-  def Repeated_apply(elems: List[Term], elemtpt: TypeTree)(using Context): Repeated =
+  def Repeated_apply(elems: List[Term], elemtpt: TypeTree): Repeated =
     withDefaultPos(tpd.SeqLiteral(elems, elemtpt))
 
-  def Repeated_copy(original: Tree)(elems: List[Term], elemtpt: TypeTree)(using Context): Repeated =
+  def Repeated_copy(original: Tree)(elems: List[Term], elemtpt: TypeTree): Repeated =
     tpd.cpy.SeqLiteral(original)(elems, elemtpt)
 
   type SelectOuter = tpd.Select
 
-  def SelectOuter_TypeTest(using Context): TypeTest[Tree, SelectOuter] = new {
+  def SelectOuter_TypeTest: TypeTest[Tree, SelectOuter] = new {
     def runtimeClass: Class[?] = classOf[SelectOuter]
     override def unapply(x: Any): Option[SelectOuter] = x match
     case x: tpd.Select @unchecked =>
@@ -731,39 +731,39 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
     case _ => None
   }
 
-  def SelectOuter_qualifier(self: SelectOuter)(using Context): Term = self.qualifier
-  def SelectOuter_level(self: SelectOuter)(using Context): Int = {
+  def SelectOuter_qualifier(self: SelectOuter): Term = self.qualifier
+  def SelectOuter_level(self: SelectOuter): Int = {
     val NameKinds.OuterSelectName(_, levels) = self.name
     levels
   }
 
-  def SelectOuter_apply(qualifier: Term, name: String, levels: Int)(using Context): SelectOuter =
+  def SelectOuter_apply(qualifier: Term, name: String, levels: Int): SelectOuter =
     withDefaultPos(tpd.Select(qualifier, NameKinds.OuterSelectName(name.toTermName, levels)))
 
-  def SelectOuter_copy(original: Tree)(qualifier: Term, name: String, levels: Int)(using Context): SelectOuter =
+  def SelectOuter_copy(original: Tree)(qualifier: Term, name: String, levels: Int): SelectOuter =
     tpd.cpy.Select(original)(qualifier, NameKinds.OuterSelectName(name.toTermName, levels))
 
   type While = tpd.WhileDo
 
-  def While_TypeTest(using Context): TypeTest[Tree, While] = new {
+  def While_TypeTest: TypeTest[Tree, While] = new {
     def runtimeClass: Class[?] = classOf[While]
     override def unapply(x: Any): Option[While] = x match
       case x: tpd.WhileDo @unchecked => Some(x)
       case _ => None
   }
 
-  def While_cond(self: While)(using Context): Term = self.cond
-  def While_body(self: While)(using Context): Term = self.body
+  def While_cond(self: While): Term = self.cond
+  def While_body(self: While): Term = self.body
 
-  def While_apply(cond: Term, body: Term)(using Context): While =
+  def While_apply(cond: Term, body: Term): While =
     withDefaultPos(tpd.WhileDo(cond, body))
 
-  def While_copy(original: Tree)(cond: Term, body: Term)(using Context): While =
+  def While_copy(original: Tree)(cond: Term, body: Term): While =
     tpd.cpy.WhileDo(original)(cond, body)
 
   type TypeTree = tpd.Tree
 
-  def TypeTree_TypeTest(using Context): TypeTest[Tree, TypeTree] = new {
+  def TypeTree_TypeTest: TypeTest[Tree, TypeTree] = new {
     def runtimeClass: Class[?] = classOf[TypeTree]
     override def unapply(x: Any): Option[TypeTree] = x match
       case x: tpd.TypeBoundsTree @unchecked => None
@@ -771,225 +771,225 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
       case _ => None
   }
 
-  def TypeTree_tpe(self: TypeTree)(using Context): Type = self.tpe.stripTypeVar
+  def TypeTree_tpe(self: TypeTree): Type = self.tpe.stripTypeVar
 
   type Inferred = tpd.TypeTree
 
-  def Inferred_TypeTest(using Context): TypeTest[Tree, Inferred] = new {
+  def Inferred_TypeTest: TypeTest[Tree, Inferred] = new {
     def runtimeClass: Class[?] = classOf[Inferred]
     override def unapply(x: Any): Option[Inferred] = x match
       case tpt: tpd.TypeTree @unchecked if !tpt.tpe.isInstanceOf[Types.TypeBounds] => Some(tpt)
       case _ => None
   }
 
-  def Inferred_apply(tpe: Type)(using Context): Inferred = withDefaultPos(tpd.TypeTree(tpe))
+  def Inferred_apply(tpe: Type): Inferred = withDefaultPos(tpd.TypeTree(tpe))
 
   type TypeIdent = tpd.Ident
 
-  def TypeIdent_TypeTest(using Context): TypeTest[Tree, TypeIdent] = new {
+  def TypeIdent_TypeTest: TypeTest[Tree, TypeIdent] = new {
     def runtimeClass: Class[?] = classOf[TypeIdent]
     override def unapply(x: Any): Option[TypeIdent] = x match
       case tpt: tpd.Ident @unchecked if tpt.isType => Some(tpt)
       case _ => None
   }
 
-  def TypeIdent_name(self: TypeIdent)(using Context): String = self.name.toString
+  def TypeIdent_name(self: TypeIdent): String = self.name.toString
 
-  def TypeIdent_copy(original: Tree)(name: String)(using Context): TypeIdent =
+  def TypeIdent_copy(original: Tree)(name: String): TypeIdent =
     tpd.cpy.Ident(original)(name.toTypeName)
 
   type TypeSelect = tpd.Select
 
-  def TypeSelect_TypeTest(using Context): TypeTest[Tree, TypeSelect] = new {
+  def TypeSelect_TypeTest: TypeTest[Tree, TypeSelect] = new {
     def runtimeClass: Class[?] = classOf[TypeSelect]
     override def unapply(x: Any): Option[TypeSelect] = x match
       case tpt: tpd.Select @unchecked if tpt.isType && tpt.qualifier.isTerm  => Some(tpt)
       case _ => None
   }
 
-  def TypeSelect_qualifier(self: TypeSelect)(using Context): Term = self.qualifier
-  def TypeSelect_name(self: TypeSelect)(using Context): String = self.name.toString
+  def TypeSelect_qualifier(self: TypeSelect): Term = self.qualifier
+  def TypeSelect_name(self: TypeSelect): String = self.name.toString
 
-  def TypeSelect_apply(qualifier: Term, name: String)(using Context): TypeSelect =
+  def TypeSelect_apply(qualifier: Term, name: String): TypeSelect =
     withDefaultPos(tpd.Select(qualifier, name.toTypeName))
 
-  def TypeSelect_copy(original: Tree)(qualifier: Term, name: String)(using Context): TypeSelect =
+  def TypeSelect_copy(original: Tree)(qualifier: Term, name: String): TypeSelect =
     tpd.cpy.Select(original)(qualifier, name.toTypeName)
 
 
   type Projection = tpd.Select
 
-  def Projection_TypeTest(using Context): TypeTest[Tree, Projection] = new {
+  def Projection_TypeTest: TypeTest[Tree, Projection] = new {
     def runtimeClass: Class[?] = classOf[Projection]
     override def unapply(x: Any): Option[Projection] = x match
       case tpt: tpd.Select @unchecked if tpt.isType && tpt.qualifier.isType => Some(tpt)
       case _ => None
   }
 
-  def Projection_qualifier(self: Projection)(using Context): TypeTree = self.qualifier
-  def Projection_name(self: Projection)(using Context): String = self.name.toString
+  def Projection_qualifier(self: Projection): TypeTree = self.qualifier
+  def Projection_name(self: Projection): String = self.name.toString
 
-  def Projection_copy(original: Tree)(qualifier: TypeTree, name: String)(using Context): Projection =
+  def Projection_copy(original: Tree)(qualifier: TypeTree, name: String): Projection =
     tpd.cpy.Select(original)(qualifier, name.toTypeName)
 
   type Singleton = tpd.SingletonTypeTree
 
-  def Singleton_TypeTest(using Context): TypeTest[Tree, Singleton] = new {
+  def Singleton_TypeTest: TypeTest[Tree, Singleton] = new {
     def runtimeClass: Class[?] = classOf[Singleton]
     override def unapply(x: Any): Option[Singleton] = x match
       case tpt: tpd.SingletonTypeTree @unchecked => Some(tpt)
       case _ => None
   }
 
-  def Singleton_ref(self: Singleton)(using Context): Term = self.ref
+  def Singleton_ref(self: Singleton): Term = self.ref
 
-  def Singleton_apply(ref: Term)(using Context): Singleton =
+  def Singleton_apply(ref: Term): Singleton =
     withDefaultPos(tpd.SingletonTypeTree(ref))
 
-  def Singleton_copy(original: Tree)(ref: Term)(using Context): Singleton =
+  def Singleton_copy(original: Tree)(ref: Term): Singleton =
     tpd.cpy.SingletonTypeTree(original)(ref)
 
   type Refined = tpd.RefinedTypeTree
 
-  def Refined_TypeTest(using Context): TypeTest[Tree, Refined] = new {
+  def Refined_TypeTest: TypeTest[Tree, Refined] = new {
     def runtimeClass: Class[?] = classOf[Refined]
     override def unapply(x: Any): Option[Refined] = x match
       case tpt: tpd.RefinedTypeTree @unchecked => Some(tpt)
       case _ => None
   }
 
-  def Refined_tpt(self: Refined)(using Context): TypeTree = self.tpt
-  def Refined_refinements(self: Refined)(using Context): List[Definition] = self.refinements
+  def Refined_tpt(self: Refined): TypeTree = self.tpt
+  def Refined_refinements(self: Refined): List[Definition] = self.refinements
 
-  def Refined_copy(original: Tree)(tpt: TypeTree, refinements: List[Definition])(using Context): Refined =
+  def Refined_copy(original: Tree)(tpt: TypeTree, refinements: List[Definition]): Refined =
     tpd.cpy.RefinedTypeTree(original)(tpt, refinements)
 
   type Applied = tpd.AppliedTypeTree
 
-  def Applied_TypeTest(using Context): TypeTest[Tree, Applied] = new {
+  def Applied_TypeTest: TypeTest[Tree, Applied] = new {
     def runtimeClass: Class[?] = classOf[Applied]
     override def unapply(x: Any): Option[Applied] = x match
       case tpt: tpd.AppliedTypeTree @unchecked => Some(tpt)
       case _ => None
   }
 
-  def Applied_tpt(self: Applied)(using Context): TypeTree = self.tpt
-  def Applied_args(self: Applied)(using Context): List[TypeTree | TypeBoundsTree] = self.args
+  def Applied_tpt(self: Applied): TypeTree = self.tpt
+  def Applied_args(self: Applied): List[TypeTree | TypeBoundsTree] = self.args
 
-  def Applied_apply(tpt: TypeTree, args: List[TypeTree | TypeBoundsTree])(using Context): Applied =
+  def Applied_apply(tpt: TypeTree, args: List[TypeTree | TypeBoundsTree]): Applied =
     withDefaultPos(tpd.AppliedTypeTree(tpt, args))
 
-  def Applied_copy(original: Tree)(tpt: TypeTree, args: List[TypeTree | TypeBoundsTree])(using Context): Applied =
+  def Applied_copy(original: Tree)(tpt: TypeTree, args: List[TypeTree | TypeBoundsTree]): Applied =
     tpd.cpy.AppliedTypeTree(original)(tpt, args)
 
   type Annotated = tpd.Annotated
 
-  def Annotated_TypeTest(using Context): TypeTest[Tree, Annotated] = new {
+  def Annotated_TypeTest: TypeTest[Tree, Annotated] = new {
     def runtimeClass: Class[?] = classOf[Annotated]
     override def unapply(x: Any): Option[Annotated] = x match
       case tpt: tpd.Annotated @unchecked => Some(tpt)
       case _ => None
   }
 
-  def Annotated_arg(self: Annotated)(using Context): TypeTree = self.arg
-  def Annotated_annotation(self: Annotated)(using Context): Term = self.annot
+  def Annotated_arg(self: Annotated): TypeTree = self.arg
+  def Annotated_annotation(self: Annotated): Term = self.annot
 
-  def Annotated_apply(arg: TypeTree, annotation: Term)(using Context): Annotated =
+  def Annotated_apply(arg: TypeTree, annotation: Term): Annotated =
     withDefaultPos(tpd.Annotated(arg, annotation))
 
-  def Annotated_copy(original: Tree)(arg: TypeTree, annotation: Term)(using Context): Annotated =
+  def Annotated_copy(original: Tree)(arg: TypeTree, annotation: Term): Annotated =
     tpd.cpy.Annotated(original)(arg, annotation)
 
   type MatchTypeTree = tpd.MatchTypeTree
 
-  def MatchTypeTree_TypeTest(using Context): TypeTest[Tree, MatchTypeTree] = new {
+  def MatchTypeTree_TypeTest: TypeTest[Tree, MatchTypeTree] = new {
     def runtimeClass: Class[?] = classOf[MatchTypeTree]
     override def unapply(x: Any): Option[MatchTypeTree] = x match
       case tpt: tpd.MatchTypeTree @unchecked => Some(tpt)
       case _ => None
   }
 
-  def MatchTypeTree_bound(self: MatchTypeTree)(using Context): Option[TypeTree] = if (self.bound == tpd.EmptyTree) None else Some(self.bound)
-  def MatchTypeTree_selector(self: MatchTypeTree)(using Context): TypeTree = self.selector
-  def MatchTypeTree_cases(self: MatchTypeTree)(using Context): List[CaseDef] = self.cases
+  def MatchTypeTree_bound(self: MatchTypeTree): Option[TypeTree] = if (self.bound == tpd.EmptyTree) None else Some(self.bound)
+  def MatchTypeTree_selector(self: MatchTypeTree): TypeTree = self.selector
+  def MatchTypeTree_cases(self: MatchTypeTree): List[CaseDef] = self.cases
 
-  def MatchTypeTree_apply(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef])(using Context): MatchTypeTree =
+  def MatchTypeTree_apply(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef]): MatchTypeTree =
     withDefaultPos(tpd.MatchTypeTree(bound.getOrElse(tpd.EmptyTree), selector, cases))
 
-  def MatchTypeTree_copy(original: Tree)(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef])(using Context): MatchTypeTree =
+  def MatchTypeTree_copy(original: Tree)(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef]): MatchTypeTree =
     tpd.cpy.MatchTypeTree(original)(bound.getOrElse(tpd.EmptyTree), selector, cases)
 
   type ByName = tpd.ByNameTypeTree
 
-  def ByName_TypeTest(using Context): TypeTest[Tree, ByName] = new {
+  def ByName_TypeTest: TypeTest[Tree, ByName] = new {
     def runtimeClass: Class[?] = classOf[ByName]
     override def unapply(x: Any): Option[ByName] = x match
       case tpt: tpd.ByNameTypeTree @unchecked => Some(tpt)
       case _ => None
   }
 
-  def ByName_result(self: ByName)(using Context): TypeTree = self.result
+  def ByName_result(self: ByName): TypeTree = self.result
 
-  def ByName_apply(result: TypeTree)(using Context): ByName =
+  def ByName_apply(result: TypeTree): ByName =
     withDefaultPos(tpd.ByNameTypeTree(result))
 
-  def ByName_copy(original: Tree)(result: TypeTree)(using Context): ByName =
+  def ByName_copy(original: Tree)(result: TypeTree): ByName =
     tpd.cpy.ByNameTypeTree(original)(result)
 
   type LambdaTypeTree = tpd.LambdaTypeTree
 
-  def LambdaTypeTree_TypeTest(using Context): TypeTest[Tree, LambdaTypeTree] = new {
+  def LambdaTypeTree_TypeTest: TypeTest[Tree, LambdaTypeTree] = new {
     def runtimeClass: Class[?] = classOf[LambdaTypeTree]
     override def unapply(x: Any): Option[LambdaTypeTree] = x match
       case tpt: tpd.LambdaTypeTree @unchecked => Some(tpt)
       case _ => None
   }
 
-  def Lambdatparams(self: LambdaTypeTree)(using Context): List[TypeDef] = self.tparams
-  def Lambdabody(self: LambdaTypeTree)(using Context): TypeTree | TypeBoundsTree = self.body
+  def Lambdatparams(self: LambdaTypeTree): List[TypeDef] = self.tparams
+  def Lambdabody(self: LambdaTypeTree): TypeTree | TypeBoundsTree = self.body
 
-  def Lambdaapply(tparams: List[TypeDef], body: TypeTree | TypeBoundsTree)(using Context): LambdaTypeTree =
+  def Lambdaapply(tparams: List[TypeDef], body: TypeTree | TypeBoundsTree): LambdaTypeTree =
     withDefaultPos(tpd.LambdaTypeTree(tparams, body))
 
-  def Lambdacopy(original: Tree)(tparams: List[TypeDef], body: TypeTree | TypeBoundsTree)(using Context): LambdaTypeTree =
+  def Lambdacopy(original: Tree)(tparams: List[TypeDef], body: TypeTree | TypeBoundsTree): LambdaTypeTree =
     tpd.cpy.LambdaTypeTree(original)(tparams, body)
 
   type TypeBind = tpd.Bind
 
-  def TypeBind_TypeTest(using Context): TypeTest[Tree, TypeBind] = new {
+  def TypeBind_TypeTest: TypeTest[Tree, TypeBind] = new {
     def runtimeClass: Class[?] = classOf[TypeBind]
     override def unapply(x: Any): Option[TypeBind] = x match
       case tpt: tpd.Bind @unchecked if tpt.name.isTypeName => Some(tpt)
       case _ => None
   }
 
-  def TypeBind_name(self: TypeBind)(using Context): String = self.name.toString
-  def TypeBind_body(self: TypeBind)(using Context): TypeTree | TypeBoundsTree = self.body
+  def TypeBind_name(self: TypeBind): String = self.name.toString
+  def TypeBind_body(self: TypeBind): TypeTree | TypeBoundsTree = self.body
 
-  def TypeBind_copy(original: Tree)(name: String, tpt: TypeTree | TypeBoundsTree)(using Context): TypeBind =
+  def TypeBind_copy(original: Tree)(name: String, tpt: TypeTree | TypeBoundsTree): TypeBind =
     tpd.cpy.Bind(original)(name.toTypeName, tpt)
 
   type TypeBlock = tpd.Block
 
-  def TypeBlock_TypeTest(using Context): TypeTest[Tree, TypeBlock] = new {
+  def TypeBlock_TypeTest: TypeTest[Tree, TypeBlock] = new {
     def runtimeClass: Class[?] = classOf[TypeBlock]
     override def unapply(x: Any): Option[TypeBlock] = x match
       case tpt: tpd.Block @unchecked => Some(tpt)
       case _ => None
   }
 
-  def TypeBlock_aliases(self: TypeBlock)(using Context): List[TypeDef] = self.stats.map { case alias: TypeDef => alias }
-  def TypeBlock_tpt(self: TypeBlock)(using Context): TypeTree = self.expr
+  def TypeBlock_aliases(self: TypeBlock): List[TypeDef] = self.stats.map { case alias: TypeDef => alias }
+  def TypeBlock_tpt(self: TypeBlock): TypeTree = self.expr
 
-  def TypeBlock_apply(aliases: List[TypeDef], tpt: TypeTree)(using Context): TypeBlock =
+  def TypeBlock_apply(aliases: List[TypeDef], tpt: TypeTree): TypeBlock =
     withDefaultPos(tpd.Block(aliases, tpt))
 
-  def TypeBlock_copy(original: Tree)(aliases: List[TypeDef], tpt: TypeTree)(using Context): TypeBlock =
+  def TypeBlock_copy(original: Tree)(aliases: List[TypeDef], tpt: TypeTree): TypeBlock =
     tpd.cpy.Block(original)(aliases, tpt)
 
   type TypeBoundsTree = tpd.TypeBoundsTree
 
-  def TypeBoundsTree_TypeTest(using Context): TypeTest[Tree, TypeBoundsTree] = new {
+  def TypeBoundsTree_TypeTest: TypeTest[Tree, TypeBoundsTree] = new {
     def runtimeClass: Class[?] = classOf[TypeBoundsTree]
     override def unapply(x: Any): Option[TypeBoundsTree] = x match
       case x: tpd.TypeBoundsTree @unchecked => Some(x)
@@ -1003,80 +1003,80 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
       case _ => None
   }
 
-  def TypeBoundsTree_tpe(self: TypeBoundsTree)(using Context): TypeBounds = self.tpe.asInstanceOf[Types.TypeBounds]
-  def TypeBoundsTree_low(self: TypeBoundsTree)(using Context): TypeTree = self.lo
-  def TypeBoundsTree_hi(self: TypeBoundsTree)(using Context): TypeTree = self.hi
+  def TypeBoundsTree_tpe(self: TypeBoundsTree): TypeBounds = self.tpe.asInstanceOf[Types.TypeBounds]
+  def TypeBoundsTree_low(self: TypeBoundsTree): TypeTree = self.lo
+  def TypeBoundsTree_hi(self: TypeBoundsTree): TypeTree = self.hi
 
   type WildcardTypeTree = tpd.Ident
 
-  def WildcardTypeTree_TypeTest(using Context): TypeTest[Tree, WildcardTypeTree] = new {
+  def WildcardTypeTree_TypeTest: TypeTest[Tree, WildcardTypeTree] = new {
     def runtimeClass: Class[?] = classOf[WildcardTypeTree]
     override def unapply(x: Any): Option[WildcardTypeTree] = x match
       case x: tpd.Ident @unchecked if x.name == nme.WILDCARD => Some(x)
       case _ => None
   }
 
-  def WildcardTypeTree_tpe(self: WildcardTypeTree)(using Context): Type = self.tpe.stripTypeVar
+  def WildcardTypeTree_tpe(self: WildcardTypeTree): Type = self.tpe.stripTypeVar
 
   type CaseDef = tpd.CaseDef
 
-  def CaseDef_TypeTest(using Context): TypeTest[Tree, CaseDef] = new {
+  def CaseDef_TypeTest: TypeTest[Tree, CaseDef] = new {
     def runtimeClass: Class[?] = classOf[CaseDef]
     override def unapply(x: Any): Option[CaseDef] = x match
       case tree: tpd.CaseDef @unchecked if tree.body.isTerm => Some(tree)
       case _ => None
   }
 
-  def CaseDef_pattern(self: CaseDef)(using Context): Tree = self.pat
-  def CaseDef_guard(self: CaseDef)(using Context): Option[Term] = optional(self.guard)
-  def CaseDef_rhs(self: CaseDef)(using Context): Term = self.body
+  def CaseDef_pattern(self: CaseDef): Tree = self.pat
+  def CaseDef_guard(self: CaseDef): Option[Term] = optional(self.guard)
+  def CaseDef_rhs(self: CaseDef): Term = self.body
 
-  def CaseDef_module_apply(pattern: Tree, guard: Option[Term], body: Term)(using Context): CaseDef =
+  def CaseDef_module_apply(pattern: Tree, guard: Option[Term], body: Term): CaseDef =
     tpd.CaseDef(pattern, guard.getOrElse(tpd.EmptyTree), body)
 
-  def CaseDef_module_copy(original: Tree)(pattern: Tree, guard: Option[Term], body: Term)(using Context): CaseDef =
+  def CaseDef_module_copy(original: Tree)(pattern: Tree, guard: Option[Term], body: Term): CaseDef =
     tpd.cpy.CaseDef(original)(pattern, guard.getOrElse(tpd.EmptyTree), body)
 
   type TypeCaseDef = tpd.CaseDef
 
-  def TypeCaseDef_TypeTest(using Context): TypeTest[Tree, TypeCaseDef] = new {
+  def TypeCaseDef_TypeTest: TypeTest[Tree, TypeCaseDef] = new {
     def runtimeClass: Class[?] = classOf[TypeCaseDef]
     override def unapply(x: Any): Option[TypeCaseDef] = x match
       case tree: tpd.CaseDef @unchecked if tree.body.isType => Some(tree)
       case _ => None
   }
 
-  def TypeCaseDef_pattern(self: TypeCaseDef)(using Context): TypeTree = self.pat
-  def TypeCaseDef_rhs(self: TypeCaseDef)(using Context): TypeTree = self.body
+  def TypeCaseDef_pattern(self: TypeCaseDef): TypeTree = self.pat
+  def TypeCaseDef_rhs(self: TypeCaseDef): TypeTree = self.body
 
-  def TypeCaseDef_module_apply(pattern: TypeTree, body: TypeTree)(using Context): TypeCaseDef =
+  def TypeCaseDef_module_apply(pattern: TypeTree, body: TypeTree): TypeCaseDef =
     tpd.CaseDef(pattern, tpd.EmptyTree, body)
 
-  def TypeCaseDef_module_copy(original: Tree)(pattern: TypeTree, body: TypeTree)(using Context): TypeCaseDef =
+  def TypeCaseDef_module_copy(original: Tree)(pattern: TypeTree, body: TypeTree): TypeCaseDef =
     tpd.cpy.CaseDef(original)(pattern, tpd.EmptyTree, body)
 
   type Bind = tpd.Bind
 
-  def Bind_TypeTest(using Context): TypeTest[Tree, Bind] = new {
+  def Bind_TypeTest: TypeTest[Tree, Bind] = new {
     def runtimeClass: Class[?] = classOf[Bind]
     override def unapply(x: Any): Option[Bind] = x match
       case x: tpd.Bind @unchecked if x.name.isTermName => Some(x)
       case _ => None
   }
 
-  def Tree_Bind_name(self: Bind)(using Context): String = self.name.toString
+  def Tree_Bind_name(self: Bind): String = self.name.toString
 
-  def Tree_Bind_pattern(self: Bind)(using Context): Tree = self.body
+  def Tree_Bind_pattern(self: Bind): Tree = self.body
 
-  def Tree_Bind_module_apply(sym: Symbol, body: Tree)(using Context): Bind =
+  def Tree_Bind_module_apply(sym: Symbol, body: Tree): Bind =
     tpd.Bind(sym, body)
 
-  def Tree_Bind_module_copy(original: Tree)(name: String, pattern: Tree)(using Context): Bind =
+  def Tree_Bind_module_copy(original: Tree)(name: String, pattern: Tree): Bind =
     withDefaultPos(tpd.cpy.Bind(original)(name.toTermName, pattern))
 
   type Unapply = tpd.UnApply
 
-  def Unapply_TypeTest(using Context): TypeTest[Tree, Unapply] = new {
+  def Unapply_TypeTest: TypeTest[Tree, Unapply] = new {
     def runtimeClass: Class[?] = classOf[Unapply]
     override def unapply(x: Any): Option[Unapply] = x match
       case pattern: tpd.UnApply @unchecked => Some(pattern)
@@ -1084,11 +1084,11 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
       case _ => None
   }
 
-  def Tree_Unapply_fun(self: Unapply)(using Context): Term = self.fun
-  def Tree_Unapply_implicits(self: Unapply)(using Context): List[Term] = self.implicits
-  def Tree_Unapply_patterns(self: Unapply)(using Context): List[Tree] = effectivePatterns(self.patterns)
+  def Tree_Unapply_fun(self: Unapply): Term = self.fun
+  def Tree_Unapply_implicits(self: Unapply): List[Term] = self.implicits
+  def Tree_Unapply_patterns(self: Unapply): List[Tree] = effectivePatterns(self.patterns)
 
-  def Tree_Unapply_module_copy(original: Tree)(fun: Term, implicits: List[Term], patterns: List[Tree])(using Context): Unapply =
+  def Tree_Unapply_module_copy(original: Tree)(fun: Term, implicits: List[Term], patterns: List[Tree]): Unapply =
     withDefaultPos(tpd.cpy.UnApply(original)(fun, implicits, patterns))
 
   private def effectivePatterns(patterns: List[Tree]): List[Tree] = patterns match {
@@ -1098,19 +1098,19 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   type Alternatives = tpd.Alternative
 
-  def Alternatives_TypeTest(using Context): TypeTest[Tree, Alternatives] = new {
+  def Alternatives_TypeTest: TypeTest[Tree, Alternatives] = new {
     def runtimeClass: Class[?] = classOf[Alternatives]
     override def unapply(x: Any): Option[Alternatives] = x match
       case x: tpd.Alternative @unchecked => Some(x)
       case _ => None
   }
 
-  def Tree_Alternatives_patterns(self: Alternatives)(using Context): List[Tree] = self.trees
+  def Tree_Alternatives_patterns(self: Alternatives): List[Tree] = self.trees
 
-  def Tree_Alternatives_module_apply(patterns: List[Tree])(using Context): Alternatives =
+  def Tree_Alternatives_module_apply(patterns: List[Tree]): Alternatives =
     withDefaultPos(tpd.Alternative(patterns))
 
-  def Tree_Alternatives_module_copy(original: Tree)(patterns: List[Tree])(using Context): Alternatives =
+  def Tree_Alternatives_module_copy(original: Tree)(patterns: List[Tree]): Alternatives =
     tpd.cpy.Alternative(original)(patterns)
 
 
@@ -1120,7 +1120,7 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   type Type = Types.Type
 
-  def Type_TypeTest(using Context): TypeTest[Type, Type] = new {
+  def Type_TypeTest: TypeTest[Type, Type] = new {
     def runtimeClass: Class[?] = classOf[Type]
     override def unapply(x: Any): Option[Type] = x match
       case x: TypeBounds => None
@@ -1128,7 +1128,7 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
       case _ => None
   }
 
-  def Type_ofErasedClass(clazz: Class[?])(using Context): Type =
+  def Type_ofErasedClass(clazz: Class[?]): Type =
     if (clazz.isPrimitive)
       if (clazz == classOf[Boolean]) defn.BooleanType
       else if (clazz == classOf[Byte]) defn.ByteType
@@ -1150,54 +1150,54 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
     }
     else getClassIfDefined(clazz.getCanonicalName).typeRef
 
-  def Type_isTypeEq(self: Type)(that: Type)(using Context): Boolean = self =:= that
+  def Type_isTypeEq(self: Type)(that: Type): Boolean = self =:= that
 
-  def Type_isSubType(self: Type)(that: Type)(using Context): Boolean = self <:< that
+  def Type_isSubType(self: Type)(that: Type): Boolean = self <:< that
 
-  def Type_widen(self: Type)(using Context): Type = self.widen
+  def Type_widen(self: Type): Type = self.widen
 
-  def Type_widenTermRefExpr(self: Type)(using Context): Type = self.widenTermRefExpr
+  def Type_widenTermRefExpr(self: Type): Type = self.widenTermRefExpr
 
-  def Type_dealias(self: Type)(using Context): Type = self.dealias
+  def Type_dealias(self: Type): Type = self.dealias
 
-  def Type_simplified(self: Type)(using Context): Type = self.simplified
+  def Type_simplified(self: Type): Type = self.simplified
 
-  def Type_classSymbol(self: Type)(using Context): Option[Symbol] =
+  def Type_classSymbol(self: Type): Option[Symbol] =
     if (self.classSymbol.exists) Some(self.classSymbol.asClass) else None
 
-  def Type_typeSymbol(self: Type)(using Context): Symbol = self.typeSymbol
+  def Type_typeSymbol(self: Type): Symbol = self.typeSymbol
 
-  def Type_termSymbol(self: Type)(using Context): Symbol = self.termSymbol
+  def Type_termSymbol(self: Type): Symbol = self.termSymbol
 
-  def Type_isSingleton(self: Type)(using Context): Boolean = self.isSingleton
+  def Type_isSingleton(self: Type): Boolean = self.isSingleton
 
-  def Type_memberType(self: Type)(member: Symbol)(using Context): Type =
+  def Type_memberType(self: Type)(member: Symbol): Type =
     member.info.asSeenFrom(self, member.owner)
 
-  def Type_baseClasses(self: Type)(using Context): List[Symbol] =
+  def Type_baseClasses(self: Type): List[Symbol] =
     self.baseClasses
 
-  def Type_baseType(self: Type)(cls: Symbol)(using Context): Type =
+  def Type_baseType(self: Type)(cls: Symbol): Type =
     self.baseType(cls)
 
-  def Type_derivesFrom(self: Type)(cls: Symbol)(using Context): Boolean =
+  def Type_derivesFrom(self: Type)(cls: Symbol): Boolean =
     self.derivesFrom(cls)
 
-  def Type_isFunctionType(self: Type)(using Context): Boolean =
+  def Type_isFunctionType(self: Type): Boolean =
     defn.isFunctionType(self)
 
-  def Type_isContextFunctionType(self: Type)(using Context): Boolean =
+  def Type_isContextFunctionType(self: Type): Boolean =
     defn.isContextFunctionType(self)
 
-  def Type_isErasedFunctionType(self: Type)(using Context): Boolean =
+  def Type_isErasedFunctionType(self: Type): Boolean =
     defn.isErasedFunctionType(self)
 
-  def Type_isDependentFunctionType(self: Type)(using Context): Boolean = {
+  def Type_isDependentFunctionType(self: Type): Boolean = {
     val tpNoRefinement = self.dropDependentRefinement
     tpNoRefinement != self && defn.isNonRefinedFunction(tpNoRefinement)
   }
 
-  def Type_select(self: Type)(sym: Symbol)(using Context): Type =
+  def Type_select(self: Type)(sym: Symbol): Type =
     self.select(sym)
 
   def Type_appliedTo(self: Type)(targs: List[Type]): Type =
@@ -1205,54 +1205,54 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   type ConstantType = Types.ConstantType
 
-  def ConstantType_TypeTest(using Context): TypeTest[Type, ConstantType] = new {
+  def ConstantType_TypeTest: TypeTest[Type, ConstantType] = new {
     def runtimeClass: Class[?] = classOf[ConstantType]
     override def unapply(x: Any): Option[ConstantType] = x match
       case tpe: Types.ConstantType => Some(tpe)
       case _ => None
   }
 
-  def ConstantType_apply(const: Constant)(using Context): ConstantType =
+  def ConstantType_apply(const: Constant): ConstantType =
     Types.ConstantType(const)
 
-  def ConstantType_constant(self: ConstantType)(using Context): Constant = self.value
+  def ConstantType_constant(self: ConstantType): Constant = self.value
 
   type TermRef = Types.NamedType
 
-  def TermRef_TypeTest(using Context): TypeTest[Type, TermRef] = new {
+  def TermRef_TypeTest: TypeTest[Type, TermRef] = new {
     def runtimeClass: Class[?] = classOf[TermRef]
     override def unapply(x: Any): Option[TermRef] = x match
       case tp: Types.TermRef => Some(tp)
       case _ => None
   }
 
-  def TermRef_apply(qual: Type, name: String)(using Context): TermRef =
+  def TermRef_apply(qual: Type, name: String): TermRef =
     Types.TermRef(qual, name.toTermName)
 
-  def TermRef_qualifier(self: TermRef)(using Context): Type = self.prefix
+  def TermRef_qualifier(self: TermRef): Type = self.prefix
 
-  def TermRef_name(self: TermRef)(using Context): String = self.name.toString
+  def TermRef_name(self: TermRef): String = self.name.toString
 
   type TypeRef = Types.NamedType
 
-  def TypeRef_TypeTest(using Context): TypeTest[Type, TypeRef] = new {
+  def TypeRef_TypeTest: TypeTest[Type, TypeRef] = new {
     def runtimeClass: Class[?] = classOf[TypeRef]
     override def unapply(x: Any): Option[TypeRef] = x match
       case tp: Types.TypeRef => Some(tp)
       case _ => None
   }
 
-  def TypeRef_qualifier(self: TypeRef)(using Context): Type = self.prefix
+  def TypeRef_qualifier(self: TypeRef): Type = self.prefix
 
-  def TypeRef_name(self: TypeRef)(using Context): String = self.name.toString
+  def TypeRef_name(self: TypeRef): String = self.name.toString
 
-  def TypeRef_isOpaqueAlias(self: TypeRef)(using Context): Boolean = self.symbol.isOpaqueAlias
+  def TypeRef_isOpaqueAlias(self: TypeRef): Boolean = self.symbol.isOpaqueAlias
 
-  def TypeRef_translucentSuperType(self: TypeRef)(using Context): Type = self.translucentSuperType
+  def TypeRef_translucentSuperType(self: TypeRef): Type = self.translucentSuperType
 
   type NamedTermRef = Types.NamedType
 
-  def NamedTermRef_TypeTest(using Context): TypeTest[Type, NamedTermRef] = new {
+  def NamedTermRef_TypeTest: TypeTest[Type, NamedTermRef] = new {
     def runtimeClass: Class[?] = classOf[NamedTermRef]
     override def unapply(x: Any): Option[NamedTermRef] = x match
       case tpe: Types.NamedType =>
@@ -1263,34 +1263,34 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
       case _ => None
   }
 
-  def NamedTermRef_name(self: NamedTermRef)(using Context): String = self.name.toString
-  def NamedTermRef_qualifier(self: NamedTermRef)(using Context): Type = self.prefix
+  def NamedTermRef_name(self: NamedTermRef): String = self.name.toString
+  def NamedTermRef_qualifier(self: NamedTermRef): Type = self.prefix
 
   type SuperType = Types.SuperType
 
-  def SuperType_TypeTest(using Context): TypeTest[Type, SuperType] = new {
+  def SuperType_TypeTest: TypeTest[Type, SuperType] = new {
     def runtimeClass: Class[?] = classOf[SuperType]
     override def unapply(x: Any): Option[SuperType] = x match
       case tpe: Types.SuperType => Some(tpe)
       case _ => None
   }
 
-  def SuperType_apply(thistpe: Type, supertpe: Type)(using Context): SuperType =
+  def SuperType_apply(thistpe: Type, supertpe: Type): SuperType =
     Types.SuperType(thistpe, supertpe)
 
-  def SuperType_thistpe(self: SuperType)(using Context): Type = self.thistpe
-  def SuperType_supertpe(self: SuperType)(using Context): Type = self.supertpe
+  def SuperType_thistpe(self: SuperType): Type = self.thistpe
+  def SuperType_supertpe(self: SuperType): Type = self.supertpe
 
   type Refinement = Types.RefinedType
 
-  def Refinement_TypeTest(using Context): TypeTest[Type, Refinement] = new {
+  def Refinement_TypeTest: TypeTest[Type, Refinement] = new {
     def runtimeClass: Class[?] = classOf[Refinement]
     override def unapply(x: Any): Option[Refinement] = x match
       case tpe: Types.RefinedType => Some(tpe)
       case _ => None
   }
 
-  def Refinement_apply(parent: Type, name: String, info: Type)(using Context): Refinement = {
+  def Refinement_apply(parent: Type, name: String, info: Type): Refinement = {
     val name1 =
       info match
         case _: TypeBounds => name.toTypeName
@@ -1298,99 +1298,99 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
     Types.RefinedType(parent, name1, info)
   }
 
-  def Refinement_parent(self: Refinement)(using Context): Type = self.parent
-  def Refinement_name(self: Refinement)(using Context): String = self.refinedName.toString
-  def Refinement_info(self: Refinement)(using Context): Type = self.refinedInfo
+  def Refinement_parent(self: Refinement): Type = self.parent
+  def Refinement_name(self: Refinement): String = self.refinedName.toString
+  def Refinement_info(self: Refinement): Type = self.refinedInfo
 
   type AppliedType = Types.AppliedType
 
-  def AppliedType_TypeTest(using Context): TypeTest[Type, AppliedType] = new {
+  def AppliedType_TypeTest: TypeTest[Type, AppliedType] = new {
     def runtimeClass: Class[?] = classOf[AppliedType]
     override def unapply(x: Any): Option[AppliedType] = x match
       case tpe: Types.AppliedType => Some(tpe)
       case _ => None
   }
 
-  def AppliedType_tycon(self: AppliedType)(using Context): Type = self.tycon
-  def AppliedType_args(self: AppliedType)(using Context): List[Type] = self.args
+  def AppliedType_tycon(self: AppliedType): Type = self.tycon
+  def AppliedType_args(self: AppliedType): List[Type] = self.args
 
   type AnnotatedType = Types.AnnotatedType
 
-  def AnnotatedType_TypeTest(using Context): TypeTest[Type, AnnotatedType] = new {
+  def AnnotatedType_TypeTest: TypeTest[Type, AnnotatedType] = new {
     def runtimeClass: Class[?] = classOf[AnnotatedType]
     override def unapply(x: Any): Option[AnnotatedType] = x match
       case tpe: Types.AnnotatedType => Some(tpe)
       case _ => None
   }
 
-  def AnnotatedType_apply(underlying: Type, annot: Term)(using Context): AnnotatedType =
+  def AnnotatedType_apply(underlying: Type, annot: Term): AnnotatedType =
     Types.AnnotatedType(underlying, Annotations.Annotation(annot))
 
-  def AnnotatedType_underlying(self: AnnotatedType)(using Context): Type = self.underlying.stripTypeVar
-  def AnnotatedType_annot(self: AnnotatedType)(using Context): Term = self.annot.tree
+  def AnnotatedType_underlying(self: AnnotatedType): Type = self.underlying.stripTypeVar
+  def AnnotatedType_annot(self: AnnotatedType): Term = self.annot.tree
 
   type AndType = Types.AndType
 
-  def AndType_TypeTest(using Context): TypeTest[Type, AndType] = new {
+  def AndType_TypeTest: TypeTest[Type, AndType] = new {
     def runtimeClass: Class[?] = classOf[AndType]
     override def unapply(x: Any): Option[AndType] = x match
       case tpe: Types.AndType => Some(tpe)
       case _ => None
   }
 
-  def AndType_apply(lhs: Type, rhs: Type)(using Context): AndType =
+  def AndType_apply(lhs: Type, rhs: Type): AndType =
     Types.AndType(lhs, rhs)
 
-  def AndType_left(self: AndType)(using Context): Type = self.tp1.stripTypeVar
-  def AndType_right(self: AndType)(using Context): Type = self.tp2.stripTypeVar
+  def AndType_left(self: AndType): Type = self.tp1.stripTypeVar
+  def AndType_right(self: AndType): Type = self.tp2.stripTypeVar
 
   type OrType = Types.OrType
 
-  def OrType_TypeTest(using Context): TypeTest[Type, OrType] = new {
+  def OrType_TypeTest: TypeTest[Type, OrType] = new {
     def runtimeClass: Class[?] = classOf[OrType]
     override def unapply(x: Any): Option[OrType] = x match
       case tpe: Types.OrType => Some(tpe)
       case _ => None
   }
 
-  def OrType_apply(lhs: Type, rhs: Type)(using Context): OrType =
+  def OrType_apply(lhs: Type, rhs: Type): OrType =
     Types.OrType(lhs, rhs)
 
-  def OrType_left(self: OrType)(using Context): Type = self.tp1.stripTypeVar
-  def OrType_right(self: OrType)(using Context): Type = self.tp2.stripTypeVar
+  def OrType_left(self: OrType): Type = self.tp1.stripTypeVar
+  def OrType_right(self: OrType): Type = self.tp2.stripTypeVar
 
   type MatchType = Types.MatchType
 
-  def MatchType_TypeTest(using Context): TypeTest[Type, MatchType] = new {
+  def MatchType_TypeTest: TypeTest[Type, MatchType] = new {
     def runtimeClass: Class[?] = classOf[MatchType]
     override def unapply(x: Any): Option[MatchType] = x match
       case tpe: Types.MatchType => Some(tpe)
       case _ => None
   }
 
-  def MatchType_apply(bound: Type, scrutinee: Type, cases: List[Type])(using Context): MatchType =
+  def MatchType_apply(bound: Type, scrutinee: Type, cases: List[Type]): MatchType =
     Types.MatchType(bound, scrutinee, cases)
 
-  def MatchType_bound(self: MatchType)(using Context): Type = self.bound
-  def MatchType_scrutinee(self: MatchType)(using Context): Type = self.scrutinee
-  def MatchType_cases(self: MatchType)(using Context): List[Type] = self.cases
+  def MatchType_bound(self: MatchType): Type = self.bound
+  def MatchType_scrutinee(self: MatchType): Type = self.scrutinee
+  def MatchType_cases(self: MatchType): List[Type] = self.cases
 
   type ByNameType = Types.ExprType
 
-  def ByNameType_TypeTest(using Context): TypeTest[Type, ByNameType] = new {
+  def ByNameType_TypeTest: TypeTest[Type, ByNameType] = new {
     def runtimeClass: Class[?] = classOf[ByNameType]
     override def unapply(x: Any): Option[ByNameType] = x match
       case tpe: Types.ExprType => Some(tpe)
       case _ => None
   }
 
-  def ByNameType_apply(underlying: Type)(using Context): Type = Types.ExprType(underlying)
+  def ByNameType_apply(underlying: Type): Type = Types.ExprType(underlying)
 
-  def ByNameType_underlying(self: ByNameType)(using Context): Type = self.resType.stripTypeVar
+  def ByNameType_underlying(self: ByNameType): Type = self.resType.stripTypeVar
 
   type ParamRef = Types.ParamRef
 
-  def ParamRef_TypeTest(using Context): TypeTest[Type, ParamRef] = new {
+  def ParamRef_TypeTest: TypeTest[Type, ParamRef] = new {
     def runtimeClass: Class[?] = classOf[ParamRef]
     override def unapply(x: Any): Option[ParamRef] = x match
       case tpe: Types.TypeParamRef => Some(tpe)
@@ -1398,53 +1398,53 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
       case _ => None
   }
 
-  def ParamRef_binder(self: ParamRef)(using Context): LambdaType =
+  def ParamRef_binder(self: ParamRef): LambdaType =
     self.binder.asInstanceOf[LambdaType] // Cast to tpd
-  def ParamRef_paramNum(self: ParamRef)(using Context): Int = self.paramNum
+  def ParamRef_paramNum(self: ParamRef): Int = self.paramNum
 
   type ThisType = Types.ThisType
 
-  def ThisType_TypeTest(using Context): TypeTest[Type, ThisType] = new {
+  def ThisType_TypeTest: TypeTest[Type, ThisType] = new {
     def runtimeClass: Class[?] = classOf[ThisType]
     override def unapply(x: Any): Option[ThisType] = x match
       case tpe: Types.ThisType => Some(tpe)
       case _ => None
   }
 
-  def ThisType_tref(self: ThisType)(using Context): Type = self.tref
+  def ThisType_tref(self: ThisType): Type = self.tref
 
   type RecursiveThis = Types.RecThis
 
-  def RecursiveThis_TypeTest(using Context): TypeTest[Type, RecursiveThis] = new {
+  def RecursiveThis_TypeTest: TypeTest[Type, RecursiveThis] = new {
     def runtimeClass: Class[?] = classOf[RecursiveThis]
     override def unapply(x: Any): Option[RecursiveThis] = x match
       case tpe: Types.RecThis => Some(tpe)
       case _ => None
   }
 
-  def RecursiveThis_binder(self: RecursiveThis)(using Context): RecursiveType = self.binder
+  def RecursiveThis_binder(self: RecursiveThis): RecursiveType = self.binder
 
   type RecursiveType = Types.RecType
 
-  def RecursiveType_TypeTest(using Context): TypeTest[Type, RecursiveType] = new {
+  def RecursiveType_TypeTest: TypeTest[Type, RecursiveType] = new {
     def runtimeClass: Class[?] = classOf[RecursiveType]
     override def unapply(x: Any): Option[RecursiveType] = x match
       case tpe: Types.RecType => Some(tpe)
       case _ => None
   }
 
-  def RecursiveType_apply(parentExp: RecursiveType => Type)(using Context): RecursiveType =
+  def RecursiveType_apply(parentExp: RecursiveType => Type): RecursiveType =
     Types.RecType(parentExp)
 
-  def RecursiveType_underlying(self: RecursiveType)(using Context): Type = self.underlying.stripTypeVar
+  def RecursiveType_underlying(self: RecursiveType): Type = self.underlying.stripTypeVar
 
-  def RecursiveThis_recThis(self: RecursiveType)(using Context): RecursiveThis = self.recThis
+  def RecursiveThis_recThis(self: RecursiveType): RecursiveThis = self.recThis
 
   type LambdaType = Types.LambdaType
 
   type MethodType = Types.MethodType
 
-  def MethodType_TypeTest(using Context): TypeTest[Type, MethodType] = new {
+  def MethodType_TypeTest: TypeTest[Type, MethodType] = new {
     def runtimeClass: Class[?] = classOf[MethodType]
     override def unapply(x: Any): Option[MethodType] = x match
       case tpe: Types.MethodType => Some(tpe)
@@ -1456,31 +1456,31 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   def MethodType_isErased(self: MethodType): Boolean = self.isErasedMethod
   def MethodType_isImplicit(self: MethodType): Boolean = self.isImplicitMethod
-  def MethodType_param(self: MethodType, idx: Int)(using Context): Type = self.newParamRef(idx)
-  def MethodType_paramNames(self: MethodType)(using Context): List[String] = self.paramNames.map(_.toString)
-  def MethodType_paramTypes(self: MethodType)(using Context): List[Type] = self.paramInfos
-  def MethodType_resType(self: MethodType)(using Context): Type = self.resType
+  def MethodType_param(self: MethodType, idx: Int): Type = self.newParamRef(idx)
+  def MethodType_paramNames(self: MethodType): List[String] = self.paramNames.map(_.toString)
+  def MethodType_paramTypes(self: MethodType): List[Type] = self.paramInfos
+  def MethodType_resType(self: MethodType): Type = self.resType
 
   type PolyType = Types.PolyType
 
-  def PolyType_TypeTest(using Context): TypeTest[Type, PolyType] = new {
+  def PolyType_TypeTest: TypeTest[Type, PolyType] = new {
     def runtimeClass: Class[?] = classOf[PolyType]
     override def unapply(x: Any): Option[PolyType] = x match
       case tpe: Types.PolyType => Some(tpe)
       case _ => None
   }
 
-  def PolyType_apply(paramNames: List[String])(paramBoundsExp: PolyType => List[TypeBounds], resultTypeExp: PolyType => Type)(using Context): PolyType =
+  def PolyType_apply(paramNames: List[String])(paramBoundsExp: PolyType => List[TypeBounds], resultTypeExp: PolyType => Type): PolyType =
     Types.PolyType(paramNames.map(_.toTypeName))(paramBoundsExp, resultTypeExp)
 
-  def PolyType_param(self: PolyType, idx: Int)(using Context): Type = self.newParamRef(idx)
-  def PolyType_paramNames(self: PolyType)(using Context): List[String] = self.paramNames.map(_.toString)
-  def PolyType_paramBounds(self: PolyType)(using Context): List[TypeBounds] = self.paramInfos
-  def PolyType_resType(self: PolyType)(using Context): Type = self.resType
+  def PolyType_param(self: PolyType, idx: Int): Type = self.newParamRef(idx)
+  def PolyType_paramNames(self: PolyType): List[String] = self.paramNames.map(_.toString)
+  def PolyType_paramBounds(self: PolyType): List[TypeBounds] = self.paramInfos
+  def PolyType_resType(self: PolyType): Type = self.resType
 
   type TypeLambda = Types.TypeLambda
 
-  def TypeLambda_TypeTest(using Context): TypeTest[Type, TypeLambda] = new {
+  def TypeLambda_TypeTest: TypeTest[Type, TypeLambda] = new {
     def runtimeClass: Class[?] = classOf[TypeLambda]
     override def unapply(x: Any): Option[TypeLambda] = x match
       case tpe: Types.TypeLambda => Some(tpe)
@@ -1490,15 +1490,15 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
   def TypeLambda_apply(paramNames: List[String], boundsFn: TypeLambda => List[TypeBounds], bodyFn: TypeLambda => Type): TypeLambda =
     Types.HKTypeLambda(paramNames.map(_.toTypeName))(boundsFn, bodyFn)
 
-  def TypeLambda_paramNames(self: TypeLambda)(using Context): List[String] = self.paramNames.map(_.toString)
-  def TypeLambda_paramBounds(self: TypeLambda)(using Context): List[TypeBounds] = self.paramInfos
-  def TypeLambda_param(self: TypeLambda, idx: Int)(using Context): Type =
+  def TypeLambda_paramNames(self: TypeLambda): List[String] = self.paramNames.map(_.toString)
+  def TypeLambda_paramBounds(self: TypeLambda): List[TypeBounds] = self.paramInfos
+  def TypeLambda_param(self: TypeLambda, idx: Int): Type =
     self.newParamRef(idx)
-  def TypeLambda_resType(self: TypeLambda)(using Context): Type = self.resType
+  def TypeLambda_resType(self: TypeLambda): Type = self.resType
 
   type NoPrefix = Types.NoPrefix.type
 
-  def NoPrefix_TypeTest(using Context): TypeTest[Type, NoPrefix] = new {
+  def NoPrefix_TypeTest: TypeTest[Type, NoPrefix] = new {
     def runtimeClass: Class[?] = classOf[Types.NoPrefix.type]
     override def unapply(x: Any): Option[NoPrefix] =
       if (x == Types.NoPrefix) Some(Types.NoPrefix) else None
@@ -1506,18 +1506,18 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   type TypeBounds = Types.TypeBounds
 
-  def TypeBounds_TypeTest(using Context): TypeTest[Type, TypeBounds] = new {
+  def TypeBounds_TypeTest: TypeTest[Type, TypeBounds] = new {
     def runtimeClass: Class[?] = classOf[TypeBounds]
     override def unapply(x: Any): Option[TypeBounds] = x match
       case x: Types.TypeBounds => Some(x)
       case _ => None
   }
 
-  def TypeBounds_apply(low: Type, hi: Type)(using Context): TypeBounds =
+  def TypeBounds_apply(low: Type, hi: Type): TypeBounds =
     Types.TypeBounds(low, hi)
 
-  def TypeBounds_low(self: TypeBounds)(using Context): Type = self.lo
-  def TypeBounds_hi(self: TypeBounds)(using Context): Type = self.hi
+  def TypeBounds_low(self: TypeBounds): Type = self.lo
+  def TypeBounds_hi(self: TypeBounds): Type = self.hi
 
   //////////////////////
   // IMPORT SELECTORS //
@@ -1527,32 +1527,32 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   type SimpleSelector = untpd.ImportSelector
 
-  def SimpleSelector_TypeTest(using Context): TypeTest[ImportSelector, SimpleSelector] = new {
+  def SimpleSelector_TypeTest: TypeTest[ImportSelector, SimpleSelector] = new {
     def runtimeClass: Class[?] = classOf[SimpleSelector]
     override def unapply(x: Any): Option[SimpleSelector] = x match
       case x: untpd.ImportSelector if x.renamed.isEmpty => Some(x)
       case _ => None // TODO: handle import bounds
   }
 
-  def SimpleSelector_selection(self: SimpleSelector)(using Context): Id = self.imported
+  def SimpleSelector_selection(self: SimpleSelector): Id = self.imported
 
   type RenameSelector = untpd.ImportSelector
 
-  def RenameSelector_TypeTest(using Context): TypeTest[ImportSelector, RenameSelector] = new {
+  def RenameSelector_TypeTest: TypeTest[ImportSelector, RenameSelector] = new {
     def runtimeClass: Class[?] = classOf[RenameSelector]
     override def unapply(x: Any): Option[RenameSelector] = x match
       case x: untpd.ImportSelector if !x.renamed.isEmpty => Some(x)
       case _ => None
   }
 
-  def RenameSelector_from(self: RenameSelector)(using Context): Id =
+  def RenameSelector_from(self: RenameSelector): Id =
     self.imported
-  def RenameSelector_to(self: RenameSelector)(using Context): Id =
+  def RenameSelector_to(self: RenameSelector): Id =
     self.renamed.asInstanceOf[untpd.Ident]
 
   type OmitSelector = untpd.ImportSelector
 
-  def OmitSelector_TypeTest(using Context): TypeTest[ImportSelector, OmitSelector] = new {
+  def OmitSelector_TypeTest: TypeTest[ImportSelector, OmitSelector] = new {
     def runtimeClass: Class[?] = classOf[OmitSelector]
     override def unapply(x: Any): Option[OmitSelector] = x match {
       case self: untpd.ImportSelector =>
@@ -1564,7 +1564,7 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   }
 
-  def SimpleSelector_omitted(self: OmitSelector)(using Context): Id =
+  def SimpleSelector_omitted(self: OmitSelector): Id =
     self.imported
 
 
@@ -1574,9 +1574,9 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   type Id = untpd.Ident
 
-  def Id_pos(self: Id)(using Context): Position = self.sourcePos
+  def Id_pos(self: Id): Position = self.sourcePos
 
-  def Id_name(self: Id)(using Context): String = self.name.toString
+  def Id_name(self: Id): String = self.name.toString
 
 
   ////////////////
@@ -1673,37 +1673,37 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   def Symbol_currentOwner(using ctx: Context): Symbol = ctx.owner
 
-  def Symbol_owner(self: Symbol)(using Context): Symbol = self.owner
-  def Symbol_maybeOwner(self: Symbol)(using Context): Symbol = self.maybeOwner
+  def Symbol_owner(self: Symbol): Symbol = self.owner
+  def Symbol_maybeOwner(self: Symbol): Symbol = self.maybeOwner
 
-  def Symbol_flags(self: Symbol)(using Context): Flags = self.flags
+  def Symbol_flags(self: Symbol): Flags = self.flags
 
-  def Symbol_tree(self: Symbol)(using Context): Tree =
+  def Symbol_tree(self: Symbol): Tree =
     FromSymbol.definitionFromSym(self)
 
-  def Symbol_privateWithin(self: Symbol)(using Context): Option[Type] = {
+  def Symbol_privateWithin(self: Symbol): Option[Type] = {
     val within = self.privateWithin
     if (within.exists && !self.is(core.Flags.Protected)) Some(within.typeRef)
     else None
   }
 
-  def Symbol_protectedWithin(self: Symbol)(using Context): Option[Type] = {
+  def Symbol_protectedWithin(self: Symbol): Option[Type] = {
     val within = self.privateWithin
     if (within.exists && self.is(core.Flags.Protected)) Some(within.typeRef)
     else None
   }
 
-  def Symbol_name(self: Symbol)(using Context): String = self.name.toString
+  def Symbol_name(self: Symbol): String = self.name.toString
 
-  def Symbol_fullName(self: Symbol)(using Context): String = self.fullName.toString
+  def Symbol_fullName(self: Symbol): String = self.fullName.toString
 
-  def Symbol_pos(self: Symbol)(using Context): Position = self.sourcePos
+  def Symbol_pos(self: Symbol): Position = self.sourcePos
 
-  def Symbol_localContext(self: Symbol)(using Context): Context =
+  def Symbol_localContext(self: Symbol): Context =
     if (self.exists) ctx.withOwner(self)
     else ctx
 
-  def Symbol_comment(self: Symbol)(using Context): Option[Comment] = {
+  def Symbol_comment(self: Symbol): Option[Comment] = {
     import dotty.tools.dotc.core.Comments.CommentsContext
     val docCtx = ctx.docCtx.getOrElse {
       throw new RuntimeException(
@@ -1712,134 +1712,134 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
     }
     docCtx.docstring(self)
   }
-  def Symbol_annots(self: Symbol)(using Context): List[Term] =
+  def Symbol_annots(self: Symbol): List[Term] =
     self.annotations.flatMap {
       case _: core.Annotations.BodyAnnotation => Nil
       case annot => annot.tree :: Nil
     }
 
-  def Symbol_isDefinedInCurrentRun(self: Symbol)(using Context): Boolean =
+  def Symbol_isDefinedInCurrentRun(self: Symbol): Boolean =
     self.topLevelClass.asClass.isDefinedInCurrentRun
 
-  def Symbol_isLocalDummy(self: Symbol)(using Context): Boolean = self.isLocalDummy
-  def Symbol_isRefinementClass(self: Symbol)(using Context): Boolean = self.isRefinementClass
-  def Symbol_isAliasType(self: Symbol)(using Context): Boolean = self.isAliasType
-  def Symbol_isAnonymousClass(self: Symbol)(using Context): Boolean = self.isAnonymousClass
-  def Symbol_isAnonymousFunction(self: Symbol)(using Context): Boolean = self.isAnonymousFunction
-  def Symbol_isAbstractType(self: Symbol)(using Context): Boolean = self.isAbstractType
-  def Symbol_isClassConstructor(self: Symbol)(using Context): Boolean = self.isClassConstructor
+  def Symbol_isLocalDummy(self: Symbol): Boolean = self.isLocalDummy
+  def Symbol_isRefinementClass(self: Symbol): Boolean = self.isRefinementClass
+  def Symbol_isAliasType(self: Symbol): Boolean = self.isAliasType
+  def Symbol_isAnonymousClass(self: Symbol): Boolean = self.isAnonymousClass
+  def Symbol_isAnonymousFunction(self: Symbol): Boolean = self.isAnonymousFunction
+  def Symbol_isAbstractType(self: Symbol): Boolean = self.isAbstractType
+  def Symbol_isClassConstructor(self: Symbol): Boolean = self.isClassConstructor
 
-  def Symbol_fields(self: Symbol)(using Context): List[Symbol] =
+  def Symbol_fields(self: Symbol): List[Symbol] =
     self.unforcedDecls.filter(isField)
 
-  def Symbol_field(self: Symbol)(name: String)(using Context): Symbol = {
+  def Symbol_field(self: Symbol)(name: String): Symbol = {
     val sym = self.unforcedDecls.find(sym => sym.name == name.toTermName)
     if (isField(sym)) sym else core.Symbols.NoSymbol
   }
 
-  def Symbol_classMethod(self: Symbol)(name: String)(using Context): List[Symbol] =
+  def Symbol_classMethod(self: Symbol)(name: String): List[Symbol] =
     self.typeRef.decls.iterator.collect {
       case sym if isMethod(sym) && sym.name.toString == name => sym.asTerm
     }.toList
 
-  def Symbol_typeMembers(self: Symbol)(using Context): List[Symbol] =
+  def Symbol_typeMembers(self: Symbol): List[Symbol] =
     self.unforcedDecls.filter(_.isType)
 
-  def Symbol_typeMember(self: Symbol)(name: String)(using Context): Symbol =
+  def Symbol_typeMember(self: Symbol)(name: String): Symbol =
     self.unforcedDecls.find(sym => sym.name == name.toTypeName)
 
-  def Symbol_classMethods(self: Symbol)(using Context): List[Symbol] =
+  def Symbol_classMethods(self: Symbol): List[Symbol] =
     self.typeRef.decls.iterator.collect {
       case sym if isMethod(sym) => sym.asTerm
     }.toList
 
   private def appliedTypeRef(sym: Symbol): Type = sym.typeRef.appliedTo(sym.typeParams.map(_.typeRef))
 
-  def Symbol_method(self: Symbol)(name: String)(using Context): List[Symbol] =
+  def Symbol_method(self: Symbol)(name: String): List[Symbol] =
     appliedTypeRef(self).allMembers.iterator.map(_.symbol).collect {
       case sym if isMethod(sym) && sym.name.toString == name => sym.asTerm
     }.toList
 
-  def Symbol_methods(self: Symbol)(using Context): List[Symbol] =
+  def Symbol_methods(self: Symbol): List[Symbol] =
     appliedTypeRef(self).allMembers.iterator.map(_.symbol).collect {
       case sym if isMethod(sym) => sym.asTerm
     }.toList
 
-  private def isMethod(sym: Symbol)(using Context): Boolean =
+  private def isMethod(sym: Symbol): Boolean =
     sym.isTerm && sym.is(Flags.Method) && !sym.isConstructor
 
-  def Symbol_paramSymss(self: Symbol)(using Context): List[List[Symbol]] =
+  def Symbol_paramSymss(self: Symbol): List[List[Symbol]] =
     self.paramSymss
 
-  def Symbol_primaryConstructor(self: Symbol)(using Context): Symbol =
+  def Symbol_primaryConstructor(self: Symbol): Symbol =
     self.primaryConstructor
 
-  def Symbol_caseFields(self: Symbol)(using Context): List[Symbol] =
+  def Symbol_caseFields(self: Symbol): List[Symbol] =
     if (!self.isClass) Nil
     else self.asClass.paramAccessors.collect {
       case sym if sym.is(Flags.CaseAccessor) => sym.asTerm
     }
 
-  def Symbol_children(self: Symbol)(using Context): List[Symbol] =
+  def Symbol_children(self: Symbol): List[Symbol] =
     self.children
 
-  private def isField(sym: Symbol)(using Context): Boolean = sym.isTerm && !sym.is(Flags.Method)
+  private def isField(sym: Symbol): Boolean = sym.isTerm && !sym.is(Flags.Method)
 
-  def Symbol_requiredPackage(path: String)(using Context): Symbol = requiredPackage(path)
-  def Symbol_requiredClass(path: String)(using Context): Symbol = requiredClass(path)
-  def Symbol_requiredModule(path: String)(using Context): Symbol = requiredModule(path)
-  def Symbol_requiredMethod(path: String)(using Context): Symbol = requiredMethod(path)
+  def Symbol_requiredPackage(path: String): Symbol = requiredPackage(path)
+  def Symbol_requiredClass(path: String): Symbol = requiredClass(path)
+  def Symbol_requiredModule(path: String): Symbol = requiredModule(path)
+  def Symbol_requiredMethod(path: String): Symbol = requiredMethod(path)
 
-  def Symbol_of(fullName: String)(using Context): Symbol =
+  def Symbol_of(fullName: String): Symbol =
     requiredClass(fullName)
 
-  def Symbol_newMethod(parent: Symbol, name: String, flags: Flags, tpe: Type, privateWithin: Symbol)(using Context): Symbol =
+  def Symbol_newMethod(parent: Symbol, name: String, flags: Flags, tpe: Type, privateWithin: Symbol): Symbol =
     newSymbol(parent, name.toTermName, flags | Flags.Method, tpe, privateWithin)
 
-  def Symbol_newVal(parent: Symbol, name: String, flags: Flags, tpe: Type, privateWithin: Symbol)(using Context): Symbol =
+  def Symbol_newVal(parent: Symbol, name: String, flags: Flags, tpe: Type, privateWithin: Symbol): Symbol =
     newSymbol(parent, name.toTermName, flags, tpe, privateWithin)
 
-  def Symbol_newBind(parent: Symbol, name: String, flags: Flags, tpe: Type)(using Context): Symbol =
+  def Symbol_newBind(parent: Symbol, name: String, flags: Flags, tpe: Type): Symbol =
     newSymbol(parent, name.toTermName, flags | Case, tpe)
 
-  def Symbol_isTypeParam(self: Symbol)(using Context): Boolean =
+  def Symbol_isTypeParam(self: Symbol): Boolean =
     self.isTypeParam
 
-  def Symbol_isType(symbol: Symbol)(using Context): Boolean =
+  def Symbol_isType(symbol: Symbol): Boolean =
     symbol.isType
 
-  def Symbol_isTerm(symbol: Symbol)(using Context): Boolean =
+  def Symbol_isTerm(symbol: Symbol): Boolean =
     symbol.isTerm
 
-  def Symbol_isPackageDef(symbol: Symbol)(using Context): Boolean =
+  def Symbol_isPackageDef(symbol: Symbol): Boolean =
     symbol.is(Flags.Package)
 
-  def Symbol_isClassDef(symbol: Symbol)(using Context): Boolean =
+  def Symbol_isClassDef(symbol: Symbol): Boolean =
     symbol.isClass
 
-  def Symbol_isTypeDef(symbol: Symbol)(using Context): Boolean =
+  def Symbol_isTypeDef(symbol: Symbol): Boolean =
     symbol.isType && !symbol.isClass && !symbol.is(Flags.Case)
 
-  def Symbol_isValDef(symbol: Symbol)(using Context): Boolean =
+  def Symbol_isValDef(symbol: Symbol): Boolean =
     symbol.isTerm && !symbol.is(core.Flags.Method) && !symbol.is(core.Flags.Case/*, FIXME add this check and fix sourcecode butNot = Enum | Module*/)
 
-  def Symbol_isDefDef(symbol: Symbol)(using Context): Boolean =
+  def Symbol_isDefDef(symbol: Symbol): Boolean =
     symbol.is(core.Flags.Method)
 
-  def Symbol_isBind(symbol: Symbol)(using Context): Boolean =
+  def Symbol_isBind(symbol: Symbol): Boolean =
     symbol.is(core.Flags.Case, butNot = Enum | Module) && !symbol.isClass
 
-  def Symbol_signature(self: Symbol)(using Context): Signature =
+  def Symbol_signature(self: Symbol): Signature =
     self.signature
 
 
-  def Symbol_moduleClass(self: Symbol)(using Context): Symbol = self.moduleClass
+  def Symbol_moduleClass(self: Symbol): Symbol = self.moduleClass
 
-  def Symbol_companionClass(self: Symbol)(using Context): Symbol = self.companionClass
+  def Symbol_companionClass(self: Symbol): Symbol = self.companionClass
 
-  def Symbol_companionModule(self: Symbol)(using Context): Symbol = self.companionModule
+  def Symbol_companionModule(self: Symbol): Symbol = self.companionModule
 
-  def Symbol_noSymbol(using Context): Symbol = core.Symbols.NoSymbol
+  def Symbol_noSymbol: Symbol = core.Symbols.NoSymbol
 
 
   ///////////
@@ -1987,11 +1987,11 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
 
   type ImplicitSearchResult = Tree
 
-  def searchImplicit(tpe: Type)(using Context): ImplicitSearchResult =
+  def searchImplicit(tpe: Type): ImplicitSearchResult =
     ctx.typer.inferImplicitArg(tpe, rootPosition.span)
 
   type ImplicitSearchSuccess = Tree
-  def ImplicitSearchSuccess_TypeTest(using Context): TypeTest[ImplicitSearchResult, ImplicitSearchSuccess] = new {
+  def ImplicitSearchSuccess_TypeTest: TypeTest[ImplicitSearchResult, ImplicitSearchSuccess] = new {
     def runtimeClass: Class[?] = classOf[ImplicitSearchSuccess]
     override def unapply(x: Any): Option[ImplicitSearchSuccess] = x match
       case x: Tree @unchecked =>
@@ -2000,10 +2000,10 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
           case _ => Some(x)
       case _ => None
   }
-  def ImplicitSearchSuccess_tree(self: ImplicitSearchSuccess)(using Context): Term = self
+  def ImplicitSearchSuccess_tree(self: ImplicitSearchSuccess): Term = self
 
   type ImplicitSearchFailure = Tree
-  def ImplicitSearchFailure_TypeTest(using Context): TypeTest[ImplicitSearchResult, ImplicitSearchFailure] = new {
+  def ImplicitSearchFailure_TypeTest: TypeTest[ImplicitSearchResult, ImplicitSearchFailure] = new {
     def runtimeClass: Class[?] = classOf[ImplicitSearchFailure]
     override def unapply(x: Any): Option[ImplicitSearchFailure] = x match
       case x: Tree @unchecked =>
@@ -2012,11 +2012,11 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
           case _ => None
       case _ => None
   }
-  def ImplicitSearchFailure_explanation(self: ImplicitSearchFailure)(using Context): String =
+  def ImplicitSearchFailure_explanation(self: ImplicitSearchFailure): String =
     self.tpe.asInstanceOf[SearchFailureType].explanation
 
   type DivergingImplicit = Tree
-  def DivergingImplicit_TypeTest(using Context): TypeTest[ImplicitSearchResult, DivergingImplicit] = new {
+  def DivergingImplicit_TypeTest: TypeTest[ImplicitSearchResult, DivergingImplicit] = new {
     def runtimeClass: Class[?] = classOf[DivergingImplicit]
     override def unapply(x: Any): Option[DivergingImplicit] = x match
       case x: Tree @unchecked =>
@@ -2027,7 +2027,7 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
   }
 
   type NoMatchingImplicits = Tree
-  def NoMatchingImplicits_TypeTest(using Context): TypeTest[ImplicitSearchResult, NoMatchingImplicits] = new {
+  def NoMatchingImplicits_TypeTest: TypeTest[ImplicitSearchResult, NoMatchingImplicits] = new {
     def runtimeClass: Class[?] = classOf[NoMatchingImplicits]
     override def unapply(x: Any): Option[NoMatchingImplicits] = x match
       case x: Tree @unchecked =>
@@ -2038,7 +2038,7 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
   }
 
   type AmbiguousImplicits = Tree
-  def AmbiguousImplicits_TypeTest(using Context): TypeTest[ImplicitSearchResult, AmbiguousImplicits] = new {
+  def AmbiguousImplicits_TypeTest: TypeTest[ImplicitSearchResult, AmbiguousImplicits] = new {
     def runtimeClass: Class[?] = classOf[AmbiguousImplicits]
     override def unapply(x: Any): Option[AmbiguousImplicits] = x match
       case x: Tree @unchecked =>
@@ -2048,7 +2048,7 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
       case _ => None
   }
 
-  def betaReduce(tree: Term)(using Context): Option[Term] =
+  def betaReduce(tree: Term): Option[Term] =
     tree match
       case app @ Apply(Select(fn, nme.apply), args) if defn.isFunctionType(fn.tpe) =>
         val app1 = transform.BetaReduce(app, fn, args)
@@ -2061,7 +2061,7 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
       case _ =>
         None
 
-  def lambdaExtractor(fn: Term, paramTypes: List[Type])(using Context): Option[List[Term] => Term] = {
+  def lambdaExtractor(fn: Term, paramTypes: List[Type]): Option[List[Term] => Term] = {
     def rec(fn: Term, transformBody: Term => Term): Option[List[Term] => Term] = {
       fn match {
         case Inlined(call, bindings, expansion) =>
@@ -2108,7 +2108,7 @@ class ReflectionCompilerInterface(val rootContext: Context) extends CompilerInte
   private def optional[T <: Trees.Tree[?]](tree: T): Option[tree.type] =
     if (tree.isEmpty) None else Some(tree)
 
-  private def withDefaultPos[T <: Tree](fn: Context ?=> T)(using Context): T =
+  private def withDefaultPos[T <: Tree](fn: Context ?=> T): T =
     fn(using ctx.withSource(rootPosition.source)).withSpan(rootPosition.span)
 
   def compilerId: Int = rootContext.outersIterator.toList.last.hashCode()

--- a/library/src/scala/internal/tasty/CompilerInterface.scala
+++ b/library/src/scala/internal/tasty/CompilerInterface.scala
@@ -42,489 +42,489 @@ trait CompilerInterface extends scala.tasty.reflect.Types {
   ////////////
 
   /** Returns the source file being compiled. The path is relative to the current working directory. */
-  def Source_path(using ctx: Context): java.nio.file.Path
+  def Source_path: java.nio.file.Path
 
   /** Returns true if we've tried to reflect on a Java class. */
-  def Source_isJavaCompilationUnit(using ctx: Context): Boolean
+  def Source_isJavaCompilationUnit: Boolean
 
   /** Returns true if we've tried to reflect on a Scala2 (non-Tasty) class. */
-  def Source_isScala2CompilationUnit(using ctx: Context): Boolean
+  def Source_isScala2CompilationUnit: Boolean
 
   /** Returns true if we've tried to reflect on a class that's already loaded (e.g. Option). */
-  def Source_isAlreadyLoadedCompilationUnit(using ctx: Context): Boolean
+  def Source_isAlreadyLoadedCompilationUnit: Boolean
 
   /** Class name of the current CompilationUnit */
-  def Source_compilationUnitClassname(using ctx: Context): String
+  def Source_compilationUnitClassname: String
 
   ///////////////
   // REPORTING //
   ///////////////
 
   /** Report a compilation error with the given message at the given position */
-  def error(msg: => String, pos: Position)(using ctx: Context): Unit
+  def error(msg: => String, pos: Position): Unit
 
   /** Report a compilation error with the given message at the given position range */
-  def error(msg: => String, source: SourceFile, start: Int, end: Int)(using ctx: Context): Unit
+  def error(msg: => String, source: SourceFile, start: Int, end: Int): Unit
 
   /** Report a compilation warning with the given message at the given position */
-  def warning(msg: => String, pos: Position)(using ctx: Context): Unit
+  def warning(msg: => String, pos: Position): Unit
 
   /** Report a compilation warning with the given message at the given position range */
-  def warning(msg: => String, source: SourceFile, start: Int, end: Int)(using ctx: Context): Unit
+  def warning(msg: => String, source: SourceFile, start: Int, end: Int): Unit
 
 
   /////////////
   //  TREES  //
   /////////////
 
-  def Tree_pos(self: Tree)(using ctx: Context): Position
-  def Tree_symbol(self: Tree)(using ctx: Context): Symbol
+  def Tree_pos(self: Tree): Position
+  def Tree_symbol(self: Tree): Symbol
 
-  def PackageClause_TypeTest(using ctx: Context): TypeTest[Tree, PackageClause]
+  def PackageClause_TypeTest: TypeTest[Tree, PackageClause]
 
-  def PackageClause_pid(self: PackageClause)(using ctx: Context): Ref
-  def PackageClause_stats(self: PackageClause)(using ctx: Context): List[Tree]
+  def PackageClause_pid(self: PackageClause): Ref
+  def PackageClause_stats(self: PackageClause): List[Tree]
 
-  def PackageClause_apply(pid: Ref, stats: List[Tree])(using ctx: Context): PackageClause
+  def PackageClause_apply(pid: Ref, stats: List[Tree]): PackageClause
 
-  def PackageClause_copy(original: Tree)(pid: Ref, stats: List[Tree])(using ctx: Context): PackageClause
+  def PackageClause_copy(original: Tree)(pid: Ref, stats: List[Tree]): PackageClause
 
-  def Statement_TypeTest(using ctx: Context): TypeTest[Tree, Statement]
+  def Statement_TypeTest: TypeTest[Tree, Statement]
 
-  def Import_TypeTest(using ctx: Context): TypeTest[Tree, Import]
+  def Import_TypeTest: TypeTest[Tree, Import]
 
   def Import_implied(self: Import): Boolean
-  def Import_expr(self: Import)(using ctx: Context): Term
-  def Import_selectors(self: Import)(using ctx: Context): List[ImportSelector]
+  def Import_expr(self: Import): Term
+  def Import_selectors(self: Import): List[ImportSelector]
 
-  def Import_apply(iexpr: Term, selectors: List[ImportSelector])(using ctx: Context): Import
+  def Import_apply(iexpr: Term, selectors: List[ImportSelector]): Import
 
-  def Import_copy(original: Tree)(expr: Term, selectors: List[ImportSelector])(using ctx: Context): Import
+  def Import_copy(original: Tree)(expr: Term, selectors: List[ImportSelector]): Import
 
-  def Definition_TypeTest(using ctx: Context): TypeTest[Tree, Definition]
+  def Definition_TypeTest: TypeTest[Tree, Definition]
 
-  def Definition_name(self: Definition)(using ctx: Context): String
+  def Definition_name(self: Definition): String
 
-  def PackageDef_TypeTest(using ctx: Context): TypeTest[Tree, PackageDef]
+  def PackageDef_TypeTest: TypeTest[Tree, PackageDef]
 
-  def PackageDef_owner(self: PackageDef)(using ctx: Context): PackageDef
-  def PackageDef_members(self: PackageDef)(using ctx: Context): List[Statement]
+  def PackageDef_owner(self: PackageDef): PackageDef
+  def PackageDef_members(self: PackageDef): List[Statement]
 
-  def ClassDef_TypeTest(using ctx: Context): TypeTest[Tree, ClassDef]
+  def ClassDef_TypeTest: TypeTest[Tree, ClassDef]
 
-  def ClassDef_constructor(self: ClassDef)(using ctx: Context): DefDef
-  def ClassDef_parents(self: ClassDef)(using ctx: Context): List[Tree/* Term | TypeTree */]
-  def ClassDef_derived(self: ClassDef)(using ctx: Context): List[TypeTree]
-  def ClassDef_self(self: ClassDef)(using ctx: Context): Option[ValDef]
-  def ClassDef_body(self: ClassDef)(using ctx: Context): List[Statement]
+  def ClassDef_constructor(self: ClassDef): DefDef
+  def ClassDef_parents(self: ClassDef): List[Tree/* Term | TypeTree */]
+  def ClassDef_derived(self: ClassDef): List[TypeTree]
+  def ClassDef_self(self: ClassDef): Option[ValDef]
+  def ClassDef_body(self: ClassDef): List[Statement]
 
-  def ClassDef_copy(original: Tree)(name: String, constr: DefDef, parents: List[Tree/* Term | TypeTree */], derived: List[TypeTree], selfOpt: Option[ValDef], body: List[Statement])(using ctx: Context): ClassDef
+  def ClassDef_copy(original: Tree)(name: String, constr: DefDef, parents: List[Tree/* Term | TypeTree */], derived: List[TypeTree], selfOpt: Option[ValDef], body: List[Statement]): ClassDef
 
-  def TypeDef_TypeTest(using ctx: Context): TypeTest[Tree, TypeDef]
+  def TypeDef_TypeTest: TypeTest[Tree, TypeDef]
 
-  def TypeDef_rhs(self: TypeDef)(using ctx: Context): Tree /*TypeTree | TypeBoundsTree*/
+  def TypeDef_rhs(self: TypeDef): Tree /*TypeTree | TypeBoundsTree*/
 
-  def TypeDef_apply(symbol: Symbol)(using ctx: Context): TypeDef
-  def TypeDef_copy(original: Tree)(name: String, rhs: Tree /*TypeTree | TypeBoundsTree*/)(using ctx: Context): TypeDef
+  def TypeDef_apply(symbol: Symbol): TypeDef
+  def TypeDef_copy(original: Tree)(name: String, rhs: Tree /*TypeTree | TypeBoundsTree*/): TypeDef
 
-  def DefDef_TypeTest(using ctx: Context): TypeTest[Tree, DefDef]
+  def DefDef_TypeTest: TypeTest[Tree, DefDef]
 
-  def DefDef_typeParams(self: DefDef)(using ctx: Context): List[TypeDef]
-  def DefDef_paramss(self: DefDef)(using ctx: Context): List[List[ValDef]]
-  def DefDef_returnTpt(self: DefDef)(using ctx: Context): TypeTree
-  def DefDef_rhs(self: DefDef)(using ctx: Context): Option[Term]
+  def DefDef_typeParams(self: DefDef): List[TypeDef]
+  def DefDef_paramss(self: DefDef): List[List[ValDef]]
+  def DefDef_returnTpt(self: DefDef): TypeTree
+  def DefDef_rhs(self: DefDef): Option[Term]
 
-  def DefDef_apply(symbol: Symbol, rhsFn: List[Type] => List[List[Term]] => Option[Term])(using ctx: Context): DefDef
-  def DefDef_copy(original: Tree)(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]], tpt: TypeTree, rhs: Option[Term])(using ctx: Context): DefDef
+  def DefDef_apply(symbol: Symbol, rhsFn: List[Type] => List[List[Term]] => Option[Term]): DefDef
+  def DefDef_copy(original: Tree)(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]], tpt: TypeTree, rhs: Option[Term]): DefDef
 
-  def ValDef_TypeTest(using ctx: Context): TypeTest[Tree, ValDef]
+  def ValDef_TypeTest: TypeTest[Tree, ValDef]
 
-  def ValDef_tpt(self: ValDef)(using ctx: Context): TypeTree
-  def ValDef_rhs(self: ValDef)(using ctx: Context): Option[Term]
+  def ValDef_tpt(self: ValDef): TypeTree
+  def ValDef_rhs(self: ValDef): Option[Term]
 
-  def ValDef_apply(symbol: Symbol, rhs: Option[Term])(using ctx: Context): ValDef
-  def ValDef_copy(original: Tree)(name: String, tpt: TypeTree, rhs: Option[Term])(using ctx: Context): ValDef
+  def ValDef_apply(symbol: Symbol, rhs: Option[Term]): ValDef
+  def ValDef_copy(original: Tree)(name: String, tpt: TypeTree, rhs: Option[Term]): ValDef
 
-  def Term_TypeTest(using ctx: Context): TypeTest[Tree, Term]
+  def Term_TypeTest: TypeTest[Tree, Term]
 
-  def Term_tpe(self: Term)(using ctx: Context): Type
-  def Term_underlyingArgument(self: Term)(using ctx: Context): Term
-  def Term_underlying(self: Term)(using ctx: Context): Term
-  def Term_etaExpand(term: Term)(using ctx: Context): Term
+  def Term_tpe(self: Term): Type
+  def Term_underlyingArgument(self: Term): Term
+  def Term_underlying(self: Term): Term
+  def Term_etaExpand(term: Term): Term
 
-  def Ref_TypeTest(using ctx: Context): TypeTest[Tree, Ref]
+  def Ref_TypeTest: TypeTest[Tree, Ref]
 
   /** A tree representing the same reference as the given type */
-  def Ref_term(tp: TermRef)(using ctx: Context): Ref
+  def Ref_term(tp: TermRef): Ref
 
-  def Ref_apply(sym: Symbol)(using ctx: Context): Ref
+  def Ref_apply(sym: Symbol): Ref
 
-  def Ident_TypeTest(using ctx: Context): TypeTest[Tree, Ident]
+  def Ident_TypeTest: TypeTest[Tree, Ident]
 
-  def Ident_name(self: Ident)(using ctx: Context): String
+  def Ident_name(self: Ident): String
 
-  def Ident_apply(tmref: TermRef)(using ctx: Context): Term
-  def Ident_copy(original: Tree)(name: String)(using ctx: Context): Ident
+  def Ident_apply(tmref: TermRef): Term
+  def Ident_copy(original: Tree)(name: String): Ident
 
-  def Select_TypeTest(using ctx: Context): TypeTest[Tree, Select]
+  def Select_TypeTest: TypeTest[Tree, Select]
 
-  def Select_qualifier(self: Select)(using ctx: Context): Term
-  def Select_name(self: Select)(using ctx: Context): String
-  def Select_signature(self: Select)(using ctx: Context): Option[Signature]
+  def Select_qualifier(self: Select): Term
+  def Select_name(self: Select): String
+  def Select_signature(self: Select): Option[Signature]
 
-  def Select_apply(qualifier: Term, symbol: Symbol)(using ctx: Context): Select
-  def Select_unique(qualifier: Term, name: String)(using ctx: Context): Select
+  def Select_apply(qualifier: Term, symbol: Symbol): Select
+  def Select_unique(qualifier: Term, name: String): Select
   // TODO rename, this returns an Apply and not a Select
-  def Select_overloaded(qualifier: Term, name: String, targs: List[Type], args: List[Term])(using ctx: Context): Apply
-  def Select_copy(original: Tree)(qualifier: Term, name: String)(using ctx: Context): Select
+  def Select_overloaded(qualifier: Term, name: String, targs: List[Type], args: List[Term]): Apply
+  def Select_copy(original: Tree)(qualifier: Term, name: String): Select
 
-  def Literal_TypeTest(using ctx: Context): TypeTest[Tree, Literal]
+  def Literal_TypeTest: TypeTest[Tree, Literal]
 
-  def Literal_constant(self: Literal)(using ctx: Context): Constant
+  def Literal_constant(self: Literal): Constant
 
-  def Literal_apply(constant: Constant)(using ctx: Context): Literal
-  def Literal_copy(original: Tree)(constant: Constant)(using ctx: Context): Literal
+  def Literal_apply(constant: Constant): Literal
+  def Literal_copy(original: Tree)(constant: Constant): Literal
 
-  def This_TypeTest(using ctx: Context): TypeTest[Tree, This]
+  def This_TypeTest: TypeTest[Tree, This]
 
-  def This_id(self: This)(using ctx: Context): Option[Id]
+  def This_id(self: This): Option[Id]
 
-  def This_apply(cls: Symbol)(using ctx: Context): This
-  def This_copy(original: Tree)(qual: Option[Id])(using ctx: Context): This
+  def This_apply(cls: Symbol): This
+  def This_copy(original: Tree)(qual: Option[Id]): This
 
-  def New_TypeTest(using ctx: Context): TypeTest[Tree, New]
+  def New_TypeTest: TypeTest[Tree, New]
 
-  def New_tpt(self: New)(using ctx: Context): TypeTree
+  def New_tpt(self: New): TypeTree
 
-  def New_apply(tpt: TypeTree)(using ctx: Context): New
-  def New_copy(original: Tree)(tpt: TypeTree)(using ctx: Context): New
+  def New_apply(tpt: TypeTree): New
+  def New_copy(original: Tree)(tpt: TypeTree): New
 
-  def NamedArg_TypeTest(using ctx: Context): TypeTest[Tree, NamedArg]
+  def NamedArg_TypeTest: TypeTest[Tree, NamedArg]
 
-  def NamedArg_name(self: NamedArg)(using ctx: Context): String
-  def NamedArg_value(self: NamedArg)(using ctx: Context): Term
+  def NamedArg_name(self: NamedArg): String
+  def NamedArg_value(self: NamedArg): Term
 
-  def NamedArg_apply(name: String, arg: Term)(using ctx: Context): NamedArg
-  def NamedArg_copy(original: Tree)(name: String, arg: Term)(using ctx: Context): NamedArg
+  def NamedArg_apply(name: String, arg: Term): NamedArg
+  def NamedArg_copy(original: Tree)(name: String, arg: Term): NamedArg
 
-  def Apply_TypeTest(using ctx: Context): TypeTest[Tree, Apply]
+  def Apply_TypeTest: TypeTest[Tree, Apply]
 
-  def Apply_fun(self: Apply)(using ctx: Context): Term
-  def Apply_args(self: Apply)(using ctx: Context): List[Term]
+  def Apply_fun(self: Apply): Term
+  def Apply_args(self: Apply): List[Term]
 
-  def Apply_apply(fn: Term, args: List[Term])(using ctx: Context): Apply
-  def Apply_copy(original: Tree)(fun: Term, args: List[Term])(using ctx: Context): Apply
+  def Apply_apply(fn: Term, args: List[Term]): Apply
+  def Apply_copy(original: Tree)(fun: Term, args: List[Term]): Apply
 
-  def TypeApply_TypeTest(using ctx: Context): TypeTest[Tree, TypeApply]
+  def TypeApply_TypeTest: TypeTest[Tree, TypeApply]
 
-  def TypeApply_fun(self: TypeApply)(using ctx: Context): Term
-  def TypeApply_args(self: TypeApply)(using ctx: Context): List[TypeTree]
+  def TypeApply_fun(self: TypeApply): Term
+  def TypeApply_args(self: TypeApply): List[TypeTree]
 
-  def TypeApply_apply(fn: Term, args: List[TypeTree])(using ctx: Context): TypeApply
-  def TypeApply_copy(original: Tree)(fun: Term, args: List[TypeTree])(using ctx: Context): TypeApply
+  def TypeApply_apply(fn: Term, args: List[TypeTree]): TypeApply
+  def TypeApply_copy(original: Tree)(fun: Term, args: List[TypeTree]): TypeApply
 
-  def Super_TypeTest(using ctx: Context): TypeTest[Tree, Super]
+  def Super_TypeTest: TypeTest[Tree, Super]
 
-  def Super_qualifier(self: Super)(using ctx: Context): Term
-  def Super_id(self: Super)(using ctx: Context): Option[Id]
+  def Super_qualifier(self: Super): Term
+  def Super_id(self: Super): Option[Id]
 
-  def Super_apply(qual: Term, mix: Option[Id])(using ctx: Context): Super
-  def Super_copy(original: Tree)(qual: Term, mix: Option[Id])(using ctx: Context): Super
+  def Super_apply(qual: Term, mix: Option[Id]): Super
+  def Super_copy(original: Tree)(qual: Term, mix: Option[Id]): Super
 
-  def Typed_TypeTest(using ctx: Context): TypeTest[Tree, Typed]
+  def Typed_TypeTest: TypeTest[Tree, Typed]
 
-  def Typed_expr(self: Typed)(using ctx: Context): Term
-  def Typed_tpt(self: Typed)(using ctx: Context): TypeTree
+  def Typed_expr(self: Typed): Term
+  def Typed_tpt(self: Typed): TypeTree
 
-  def Typed_apply(expr: Term, tpt: TypeTree)(using ctx: Context): Typed
-  def Typed_copy(original: Tree)(expr: Term, tpt: TypeTree)(using ctx: Context): Typed
+  def Typed_apply(expr: Term, tpt: TypeTree): Typed
+  def Typed_copy(original: Tree)(expr: Term, tpt: TypeTree): Typed
 
-  def Assign_TypeTest(using ctx: Context): TypeTest[Tree, Assign]
+  def Assign_TypeTest: TypeTest[Tree, Assign]
 
-  def Assign_lhs(self: Assign)(using ctx: Context): Term
-  def Assign_rhs(self: Assign)(using ctx: Context): Term
+  def Assign_lhs(self: Assign): Term
+  def Assign_rhs(self: Assign): Term
 
-  def Assign_apply(lhs: Term, rhs: Term)(using ctx: Context): Assign
-  def Assign_copy(original: Tree)(lhs: Term, rhs: Term)(using ctx: Context): Assign
+  def Assign_apply(lhs: Term, rhs: Term): Assign
+  def Assign_copy(original: Tree)(lhs: Term, rhs: Term): Assign
 
-  def Block_TypeTest(using ctx: Context): TypeTest[Tree, Block]
+  def Block_TypeTest: TypeTest[Tree, Block]
 
-  def Block_statements(self: Block)(using ctx: Context): List[Statement]
-  def Block_expr(self: Block)(using ctx: Context): Term
+  def Block_statements(self: Block): List[Statement]
+  def Block_expr(self: Block): Term
 
-  def Block_apply(stats: List[Statement], expr: Term)(using ctx: Context): Block
-  def Block_copy(original: Tree)(stats: List[Statement], expr: Term)(using ctx: Context): Block
+  def Block_apply(stats: List[Statement], expr: Term): Block
+  def Block_copy(original: Tree)(stats: List[Statement], expr: Term): Block
 
-  def Closure_TypeTest(using ctx: Context): TypeTest[Tree, Closure]
+  def Closure_TypeTest: TypeTest[Tree, Closure]
 
-  def Closure_meth(self: Closure)(using ctx: Context): Term
-  def Closure_tpeOpt(self: Closure)(using ctx: Context): Option[Type]
+  def Closure_meth(self: Closure): Term
+  def Closure_tpeOpt(self: Closure): Option[Type]
 
-  def Closure_apply(meth: Term, tpe: Option[Type])(using ctx: Context): Closure
-  def Closure_copy(original: Tree)(meth: Tree, tpe: Option[Type])(using ctx: Context): Closure
+  def Closure_apply(meth: Term, tpe: Option[Type]): Closure
+  def Closure_copy(original: Tree)(meth: Tree, tpe: Option[Type]): Closure
 
-  def Lambda_apply(tpe: MethodType, rhsFn: List[Tree] => Tree)(using ctx: Context): Block
+  def Lambda_apply(tpe: MethodType, rhsFn: List[Tree] => Tree): Block
 
-  def If_TypeTest(using ctx: Context): TypeTest[Tree, If]
+  def If_TypeTest: TypeTest[Tree, If]
 
-  def If_cond(self: If)(using ctx: Context): Term
-  def If_thenp(self: If)(using ctx: Context): Term
-  def If_elsep(self: If)(using ctx: Context): Term
+  def If_cond(self: If): Term
+  def If_thenp(self: If): Term
+  def If_elsep(self: If): Term
 
-  def If_apply(cond: Term, thenp: Term, elsep: Term)(using ctx: Context): If
-  def If_copy(original: Tree)(cond: Term, thenp: Term, elsep: Term)(using ctx: Context): If
+  def If_apply(cond: Term, thenp: Term, elsep: Term): If
+  def If_copy(original: Tree)(cond: Term, thenp: Term, elsep: Term): If
 
-  def Match_TypeTest(using ctx: Context): TypeTest[Tree, Match]
+  def Match_TypeTest: TypeTest[Tree, Match]
 
-  def Match_scrutinee(self: Match)(using ctx: Context): Term
-  def Match_cases(self: Match)(using ctx: Context): List[CaseDef]
+  def Match_scrutinee(self: Match): Term
+  def Match_cases(self: Match): List[CaseDef]
 
-  def Match_apply(selector: Term, cases: List[CaseDef])(using ctx: Context): Match
-  def Match_copy(original: Tree)(selector: Term, cases: List[CaseDef])(using ctx: Context): Match
+  def Match_apply(selector: Term, cases: List[CaseDef]): Match
+  def Match_copy(original: Tree)(selector: Term, cases: List[CaseDef]): Match
 
-  def GivenMatch_TypeTest(using ctx: Context): TypeTest[Tree, GivenMatch]
+  def GivenMatch_TypeTest: TypeTest[Tree, GivenMatch]
 
-  def GivenMatch_cases(self: GivenMatch)(using ctx: Context): List[CaseDef]
+  def GivenMatch_cases(self: GivenMatch): List[CaseDef]
 
-  def GivenMatch_apply(cases: List[CaseDef])(using ctx: Context): GivenMatch
-  def GivenMatch_copy(original: Tree)(cases: List[CaseDef])(using ctx: Context): GivenMatch
+  def GivenMatch_apply(cases: List[CaseDef]): GivenMatch
+  def GivenMatch_copy(original: Tree)(cases: List[CaseDef]): GivenMatch
 
-  def Try_TypeTest(using ctx: Context): TypeTest[Tree, Try]
+  def Try_TypeTest: TypeTest[Tree, Try]
 
-  def Try_body(self: Try)(using ctx: Context): Term
-  def Try_cases(self: Try)(using ctx: Context): List[CaseDef]
-  def Try_finalizer(self: Try)(using ctx: Context): Option[Term]
+  def Try_body(self: Try): Term
+  def Try_cases(self: Try): List[CaseDef]
+  def Try_finalizer(self: Try): Option[Term]
 
-  def Try_apply(expr: Term, cases: List[CaseDef], finalizer: Option[Term])(using ctx: Context): Try
-  def Try_copy(original: Tree)(expr: Term, cases: List[CaseDef], finalizer: Option[Term])(using ctx: Context): Try
+  def Try_apply(expr: Term, cases: List[CaseDef], finalizer: Option[Term]): Try
+  def Try_copy(original: Tree)(expr: Term, cases: List[CaseDef], finalizer: Option[Term]): Try
 
-  def Return_TypeTest(using ctx: Context): TypeTest[Tree, Return]
+  def Return_TypeTest: TypeTest[Tree, Return]
 
-  def Return_expr(self: Return)(using ctx: Context): Term
+  def Return_expr(self: Return): Term
 
-  def Return_apply(expr: Term)(using ctx: Context): Return
-  def Return_copy(original: Tree)(expr: Term)(using ctx: Context): Return
+  def Return_apply(expr: Term): Return
+  def Return_copy(original: Tree)(expr: Term): Return
 
-  def Repeated_TypeTest(using ctx: Context): TypeTest[Tree, Repeated]
+  def Repeated_TypeTest: TypeTest[Tree, Repeated]
 
-  def Repeated_elems(self: Repeated)(using ctx: Context): List[Term]
-  def Repeated_elemtpt(self: Repeated)(using ctx: Context): TypeTree
+  def Repeated_elems(self: Repeated): List[Term]
+  def Repeated_elemtpt(self: Repeated): TypeTree
 
-  def Repeated_apply(elems: List[Term], elemtpt: TypeTree)(using ctx: Context): Repeated
-  def Repeated_copy(original: Tree)(elems: List[Term], elemtpt: TypeTree)(using ctx: Context): Repeated
+  def Repeated_apply(elems: List[Term], elemtpt: TypeTree): Repeated
+  def Repeated_copy(original: Tree)(elems: List[Term], elemtpt: TypeTree): Repeated
 
-  def Inlined_TypeTest(using ctx: Context): TypeTest[Tree, Inlined]
+  def Inlined_TypeTest: TypeTest[Tree, Inlined]
 
-  def Inlined_call(self: Inlined)(using ctx: Context): Option[Tree/* Term | TypeTree */]
-  def Inlined_bindings(self: Inlined)(using ctx: Context): List[Definition]
-  def Inlined_body(self: Inlined)(using ctx: Context): Term
+  def Inlined_call(self: Inlined): Option[Tree/* Term | TypeTree */]
+  def Inlined_bindings(self: Inlined): List[Definition]
+  def Inlined_body(self: Inlined): Term
 
-  def Inlined_apply(call: Option[Tree/* Term | TypeTree */], bindings: List[Definition], expansion: Term)(using ctx: Context): Inlined
-  def Inlined_copy(original: Tree)(call: Option[Tree/* Term | TypeTree */], bindings: List[Definition], expansion: Term)(using ctx: Context): Inlined
+  def Inlined_apply(call: Option[Tree/* Term | TypeTree */], bindings: List[Definition], expansion: Term): Inlined
+  def Inlined_copy(original: Tree)(call: Option[Tree/* Term | TypeTree */], bindings: List[Definition], expansion: Term): Inlined
 
-  def SelectOuter_TypeTest(using ctx: Context): TypeTest[Tree, SelectOuter]
+  def SelectOuter_TypeTest: TypeTest[Tree, SelectOuter]
 
-  def SelectOuter_qualifier(self: SelectOuter)(using ctx: Context): Term
-  def SelectOuter_level(self: SelectOuter)(using ctx: Context): Int
+  def SelectOuter_qualifier(self: SelectOuter): Term
+  def SelectOuter_level(self: SelectOuter): Int
 
-  def SelectOuter_apply(qualifier: Term, name: String, levels: Int)(using ctx: Context): SelectOuter
-  def SelectOuter_copy(original: Tree)(qualifier: Term, name: String, levels: Int)(using ctx: Context): SelectOuter
+  def SelectOuter_apply(qualifier: Term, name: String, levels: Int): SelectOuter
+  def SelectOuter_copy(original: Tree)(qualifier: Term, name: String, levels: Int): SelectOuter
 
-  def While_TypeTest(using ctx: Context): TypeTest[Tree, While]
+  def While_TypeTest: TypeTest[Tree, While]
 
-  def While_cond(self: While)(using ctx: Context): Term
-  def While_body(self: While)(using ctx: Context): Term
+  def While_cond(self: While): Term
+  def While_body(self: While): Term
 
-  def While_apply(cond: Term, body: Term)(using ctx: Context): While
-  def While_copy(original: Tree)(cond: Term, body: Term)(using ctx: Context): While
+  def While_apply(cond: Term, body: Term): While
+  def While_copy(original: Tree)(cond: Term, body: Term): While
 
-  def TypeTree_TypeTest(using ctx: Context): TypeTest[Tree, TypeTree]
+  def TypeTree_TypeTest: TypeTest[Tree, TypeTree]
 
-  def TypeTree_tpe(self: TypeTree)(using ctx: Context): Type
+  def TypeTree_tpe(self: TypeTree): Type
 
-  def Inferred_TypeTest(using ctx: Context): TypeTest[Tree, Inferred]
+  def Inferred_TypeTest: TypeTest[Tree, Inferred]
 
-  def Inferred_apply(tpe: Type)(using ctx: Context): Inferred
+  def Inferred_apply(tpe: Type): Inferred
 
-  def TypeRef_apply(sym: Symbol)(using ctx: Context): TypeTree
+  def TypeRef_apply(sym: Symbol): TypeTree
 
-  def TypeIdent_TypeTest(using ctx: Context): TypeTest[Tree, TypeIdent]
+  def TypeIdent_TypeTest: TypeTest[Tree, TypeIdent]
 
-  def TypeIdent_name(self: TypeIdent)(using ctx: Context): String
+  def TypeIdent_name(self: TypeIdent): String
 
-  def TypeIdent_copy(original: Tree)(name: String)(using ctx: Context): TypeIdent
+  def TypeIdent_copy(original: Tree)(name: String): TypeIdent
 
-  def TypeSelect_TypeTest(using ctx: Context): TypeTest[Tree, TypeSelect]
+  def TypeSelect_TypeTest: TypeTest[Tree, TypeSelect]
 
-  def TypeSelect_qualifier(self: TypeSelect)(using ctx: Context): Term
-  def TypeSelect_name(self: TypeSelect)(using ctx: Context): String
+  def TypeSelect_qualifier(self: TypeSelect): Term
+  def TypeSelect_name(self: TypeSelect): String
 
-  def TypeSelect_apply(qualifier: Term, name: String)(using ctx: Context): TypeSelect
-  def TypeSelect_copy(original: Tree)(qualifier: Term, name: String)(using ctx: Context): TypeSelect
+  def TypeSelect_apply(qualifier: Term, name: String): TypeSelect
+  def TypeSelect_copy(original: Tree)(qualifier: Term, name: String): TypeSelect
 
-  def Projection_TypeTest(using ctx: Context): TypeTest[Tree, Projection]
+  def Projection_TypeTest: TypeTest[Tree, Projection]
 
-  def Projection_qualifier(self: Projection)(using ctx: Context): TypeTree
-  def Projection_name(self: Projection)(using ctx: Context): String
+  def Projection_qualifier(self: Projection): TypeTree
+  def Projection_name(self: Projection): String
 
-  def Projection_copy(original: Tree)(qualifier: TypeTree, name: String)(using ctx: Context): Projection
+  def Projection_copy(original: Tree)(qualifier: TypeTree, name: String): Projection
 
-  def Singleton_TypeTest(using ctx: Context): TypeTest[Tree, Singleton]
+  def Singleton_TypeTest: TypeTest[Tree, Singleton]
 
-  def Singleton_ref(self: Singleton)(using ctx: Context): Term
+  def Singleton_ref(self: Singleton): Term
 
-  def Singleton_apply(ref: Term)(using ctx: Context): Singleton
-  def Singleton_copy(original: Tree)(ref: Term)(using ctx: Context): Singleton
+  def Singleton_apply(ref: Term): Singleton
+  def Singleton_copy(original: Tree)(ref: Term): Singleton
 
-  def Refined_TypeTest(using ctx: Context): TypeTest[Tree, Refined]
+  def Refined_TypeTest: TypeTest[Tree, Refined]
 
-  def Refined_tpt(self: Refined)(using ctx: Context): TypeTree
-  def Refined_refinements(self: Refined)(using ctx: Context): List[Definition]
+  def Refined_tpt(self: Refined): TypeTree
+  def Refined_refinements(self: Refined): List[Definition]
 
-  def Refined_copy(original: Tree)(tpt: TypeTree, refinements: List[Definition])(using ctx: Context): Refined
+  def Refined_copy(original: Tree)(tpt: TypeTree, refinements: List[Definition]): Refined
 
-  def Applied_TypeTest(using ctx: Context): TypeTest[Tree, Applied]
+  def Applied_TypeTest: TypeTest[Tree, Applied]
 
-  def Applied_tpt(self: Applied)(using ctx: Context): TypeTree
-  def Applied_args(self: Applied)(using ctx: Context): List[Tree /*TypeTree | TypeBoundsTree*/]
+  def Applied_tpt(self: Applied): TypeTree
+  def Applied_args(self: Applied): List[Tree /*TypeTree | TypeBoundsTree*/]
 
-  def Applied_apply(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/])(using ctx: Context): Applied
-  def Applied_copy(original: Tree)(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/])(using ctx: Context): Applied
+  def Applied_apply(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/]): Applied
+  def Applied_copy(original: Tree)(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/]): Applied
 
-  def Annotated_TypeTest(using ctx: Context): TypeTest[Tree, Annotated]
+  def Annotated_TypeTest: TypeTest[Tree, Annotated]
 
-  def Annotated_arg(self: Annotated)(using ctx: Context): TypeTree
-  def Annotated_annotation(self: Annotated)(using ctx: Context): Term
+  def Annotated_arg(self: Annotated): TypeTree
+  def Annotated_annotation(self: Annotated): Term
 
-  def Annotated_apply(arg: TypeTree, annotation: Term)(using ctx: Context): Annotated
-  def Annotated_copy(original: Tree)(arg: TypeTree, annotation: Term)(using ctx: Context): Annotated
+  def Annotated_apply(arg: TypeTree, annotation: Term): Annotated
+  def Annotated_copy(original: Tree)(arg: TypeTree, annotation: Term): Annotated
 
-  def MatchTypeTree_TypeTest(using ctx: Context): TypeTest[Tree, MatchTypeTree]
+  def MatchTypeTree_TypeTest: TypeTest[Tree, MatchTypeTree]
 
-  def MatchTypeTree_bound(self: MatchTypeTree)(using ctx: Context): Option[TypeTree]
-  def MatchTypeTree_selector(self: MatchTypeTree)(using ctx: Context): TypeTree
-  def MatchTypeTree_cases(self: MatchTypeTree)(using ctx: Context): List[TypeCaseDef]
+  def MatchTypeTree_bound(self: MatchTypeTree): Option[TypeTree]
+  def MatchTypeTree_selector(self: MatchTypeTree): TypeTree
+  def MatchTypeTree_cases(self: MatchTypeTree): List[TypeCaseDef]
 
-  def MatchTypeTree_apply(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef])(using ctx: Context): MatchTypeTree
-  def MatchTypeTree_copy(original: Tree)(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef])(using ctx: Context): MatchTypeTree
+  def MatchTypeTree_apply(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef]): MatchTypeTree
+  def MatchTypeTree_copy(original: Tree)(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef]): MatchTypeTree
 
-  def ByName_result(self: ByName)(using ctx: Context): TypeTree
+  def ByName_result(self: ByName): TypeTree
 
-  def ByName_TypeTest(using ctx: Context): TypeTest[Tree, ByName]
+  def ByName_TypeTest: TypeTest[Tree, ByName]
 
-  def ByName_apply(result: TypeTree)(using ctx: Context): ByName
-  def ByName_copy(original: Tree)(result: TypeTree)(using ctx: Context): ByName
+  def ByName_apply(result: TypeTree): ByName
+  def ByName_copy(original: Tree)(result: TypeTree): ByName
 
-  def LambdaTypeTree_TypeTest(using ctx: Context): TypeTest[Tree, LambdaTypeTree]
+  def LambdaTypeTree_TypeTest: TypeTest[Tree, LambdaTypeTree]
 
-  def Lambdatparams(self: LambdaTypeTree)(using ctx: Context): List[TypeDef]
-  def Lambdabody(self: LambdaTypeTree)(using ctx: Context): Tree /*TypeTree | TypeBoundsTree*/
+  def Lambdatparams(self: LambdaTypeTree): List[TypeDef]
+  def Lambdabody(self: LambdaTypeTree): Tree /*TypeTree | TypeBoundsTree*/
 
-  def Lambdaapply(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/)(using ctx: Context): LambdaTypeTree
-  def Lambdacopy(original: Tree)(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/)(using ctx: Context): LambdaTypeTree
+  def Lambdaapply(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/): LambdaTypeTree
+  def Lambdacopy(original: Tree)(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/): LambdaTypeTree
 
-  def TypeBind_TypeTest(using ctx: Context): TypeTest[Tree, TypeBind]
+  def TypeBind_TypeTest: TypeTest[Tree, TypeBind]
 
-  def TypeBind_name(self: TypeBind)(using ctx: Context): String
-  def TypeBind_body(self: TypeBind)(using ctx: Context): Tree /*TypeTree | TypeBoundsTree*/
+  def TypeBind_name(self: TypeBind): String
+  def TypeBind_body(self: TypeBind): Tree /*TypeTree | TypeBoundsTree*/
 
-  def TypeBind_copy(original: Tree)(name: String, tpt: Tree /*TypeTree | TypeBoundsTree*/)(using ctx: Context): TypeBind
+  def TypeBind_copy(original: Tree)(name: String, tpt: Tree /*TypeTree | TypeBoundsTree*/): TypeBind
 
-  def TypeBlock_TypeTest(using ctx: Context): TypeTest[Tree, TypeBlock]
+  def TypeBlock_TypeTest: TypeTest[Tree, TypeBlock]
 
-  def TypeBlock_aliases(self: TypeBlock)(using ctx: Context): List[TypeDef]
-  def TypeBlock_tpt(self: TypeBlock)(using ctx: Context): TypeTree
+  def TypeBlock_aliases(self: TypeBlock): List[TypeDef]
+  def TypeBlock_tpt(self: TypeBlock): TypeTree
 
-  def TypeBlock_apply(aliases: List[TypeDef], tpt: TypeTree)(using ctx: Context): TypeBlock
-  def TypeBlock_copy(original: Tree)(aliases: List[TypeDef], tpt: TypeTree)(using ctx: Context): TypeBlock
+  def TypeBlock_apply(aliases: List[TypeDef], tpt: TypeTree): TypeBlock
+  def TypeBlock_copy(original: Tree)(aliases: List[TypeDef], tpt: TypeTree): TypeBlock
 
-  def TypeBoundsTree_TypeTest(using ctx: Context): TypeTest[Tree, TypeBoundsTree]
+  def TypeBoundsTree_TypeTest: TypeTest[Tree, TypeBoundsTree]
 
-  def TypeBoundsTree_tpe(self: TypeBoundsTree)(using ctx: Context): TypeBounds
-  def TypeBoundsTree_low(self: TypeBoundsTree)(using ctx: Context): TypeTree
-  def TypeBoundsTree_hi(self: TypeBoundsTree)(using ctx: Context): TypeTree
+  def TypeBoundsTree_tpe(self: TypeBoundsTree): TypeBounds
+  def TypeBoundsTree_low(self: TypeBoundsTree): TypeTree
+  def TypeBoundsTree_hi(self: TypeBoundsTree): TypeTree
 
-  def WildcardTypeTree_TypeTest(using ctx: Context): TypeTest[Tree, WildcardTypeTree]
+  def WildcardTypeTree_TypeTest: TypeTest[Tree, WildcardTypeTree]
 
-  def WildcardTypeTree_tpe(self: WildcardTypeTree)(using ctx: Context): Type
+  def WildcardTypeTree_tpe(self: WildcardTypeTree): Type
 
-  def CaseDef_TypeTest(using ctx: Context): TypeTest[Tree, CaseDef]
+  def CaseDef_TypeTest: TypeTest[Tree, CaseDef]
 
-  def CaseDef_pattern(self: CaseDef)(using ctx: Context): Tree
-  def CaseDef_guard(self: CaseDef)(using ctx: Context): Option[Term]
-  def CaseDef_rhs(self: CaseDef)(using ctx: Context): Term
+  def CaseDef_pattern(self: CaseDef): Tree
+  def CaseDef_guard(self: CaseDef): Option[Term]
+  def CaseDef_rhs(self: CaseDef): Term
 
-  def CaseDef_module_apply(pattern: Tree, guard: Option[Term], body: Term)(using ctx: Context): CaseDef
-  def CaseDef_module_copy(original: Tree)(pattern: Tree, guard: Option[Term], body: Term)(using ctx: Context): CaseDef
+  def CaseDef_module_apply(pattern: Tree, guard: Option[Term], body: Term): CaseDef
+  def CaseDef_module_copy(original: Tree)(pattern: Tree, guard: Option[Term], body: Term): CaseDef
 
-  def TypeCaseDef_TypeTest(using ctx: Context): TypeTest[Tree, TypeCaseDef]
+  def TypeCaseDef_TypeTest: TypeTest[Tree, TypeCaseDef]
 
-  def TypeCaseDef_pattern(self: TypeCaseDef)(using ctx: Context): TypeTree
-  def TypeCaseDef_rhs(self: TypeCaseDef)(using ctx: Context): TypeTree
+  def TypeCaseDef_pattern(self: TypeCaseDef): TypeTree
+  def TypeCaseDef_rhs(self: TypeCaseDef): TypeTree
 
-  def TypeCaseDef_module_apply(pattern: TypeTree, body: TypeTree)(using ctx: Context): TypeCaseDef
-  def TypeCaseDef_module_copy(original: Tree)(pattern: TypeTree, body: TypeTree)(using ctx: Context): TypeCaseDef
+  def TypeCaseDef_module_apply(pattern: TypeTree, body: TypeTree): TypeCaseDef
+  def TypeCaseDef_module_copy(original: Tree)(pattern: TypeTree, body: TypeTree): TypeCaseDef
 
   //
   // PATTERNS
   //
 
-  def Bind_TypeTest(using ctx: Context): TypeTest[Tree, Bind]
+  def Bind_TypeTest: TypeTest[Tree, Bind]
 
-  def Tree_Bind_name(self: Bind)(using ctx: Context): String
+  def Tree_Bind_name(self: Bind): String
 
-  def Tree_Bind_pattern(self: Bind)(using ctx: Context): Tree
+  def Tree_Bind_pattern(self: Bind): Tree
 
-  def Tree_Bind_module_apply(sym: Symbol, body: Tree)(using ctx: Context): Bind
+  def Tree_Bind_module_apply(sym: Symbol, body: Tree): Bind
 
-  def Tree_Bind_module_copy(original: Tree)(name: String, pattern: Tree)(using ctx: Context): Bind
+  def Tree_Bind_module_copy(original: Tree)(name: String, pattern: Tree): Bind
 
-  def Unapply_TypeTest(using ctx: Context): TypeTest[Tree, Unapply]
+  def Unapply_TypeTest: TypeTest[Tree, Unapply]
 
-  def Tree_Unapply_fun(self: Unapply)(using ctx: Context): Term
+  def Tree_Unapply_fun(self: Unapply): Term
 
-  def Tree_Unapply_implicits(self: Unapply)(using ctx: Context): List[Term]
+  def Tree_Unapply_implicits(self: Unapply): List[Term]
 
-  def Tree_Unapply_patterns(self: Unapply)(using ctx: Context): List[Tree]
+  def Tree_Unapply_patterns(self: Unapply): List[Tree]
 
-  def Tree_Unapply_module_copy(original: Tree)(fun: Term, implicits: List[Term], patterns: List[Tree])(using ctx: Context): Unapply
+  def Tree_Unapply_module_copy(original: Tree)(fun: Term, implicits: List[Term], patterns: List[Tree]): Unapply
 
-  def Alternatives_TypeTest(using ctx: Context): TypeTest[Tree, Alternatives]
+  def Alternatives_TypeTest: TypeTest[Tree, Alternatives]
 
-  def Tree_Alternatives_patterns(self: Alternatives)(using ctx: Context): List[Tree]
+  def Tree_Alternatives_patterns(self: Alternatives): List[Tree]
 
-  def Tree_Alternatives_module_apply(patterns: List[Tree])(using ctx: Context): Alternatives
-  def Tree_Alternatives_module_copy(original: Tree)(patterns: List[Tree])(using ctx: Context): Alternatives
+  def Tree_Alternatives_module_apply(patterns: List[Tree]): Alternatives
+  def Tree_Alternatives_module_copy(original: Tree)(patterns: List[Tree]): Alternatives
 
 
   //
   // TYPES
   //
 
-  def NoPrefix_TypeTest(using ctx: Context): TypeTest[Tree, NoPrefix]
+  def NoPrefix_TypeTest: TypeTest[Tree, NoPrefix]
 
-  def TypeBounds_TypeTest(using ctx: Context): TypeTest[Type, TypeBounds]
+  def TypeBounds_TypeTest: TypeTest[Type, TypeBounds]
 
-  def TypeBounds_apply(low: Type, hi: Type)(using ctx: Context): TypeBounds
+  def TypeBounds_apply(low: Type, hi: Type): TypeBounds
 
-  def TypeBounds_low(self: TypeBounds)(using ctx: Context): Type
-  def TypeBounds_hi(self: TypeBounds)(using ctx: Context): Type
+  def TypeBounds_low(self: TypeBounds): Type
+  def TypeBounds_hi(self: TypeBounds): Type
 
-  def Type_TypeTest(using ctx: Context): TypeTest[Type, Type]
+  def Type_TypeTest: TypeTest[Type, Type]
 
    /** Returns the type of the runtime class. This type is the erased representation
     *  that of the type that is used by arrays.
     *
     */
-  def Type_ofErasedClass(clazz: Class[_])(using ctx: Context): Type
+  def Type_ofErasedClass(clazz: Class[_]): Type
 
   /** Is `self` type the same as `that` type?
    *  This is the case iff `Type_isSubType(self, that)` and `Type_isSubType(that, self)`.
    */
-  def Type_isTypeEq(self: Type)(that: Type)(using ctx: Context): Boolean
+  def Type_isTypeEq(self: Type)(that: Type): Boolean
 
   /** Is this type a subtype of that type? */
-  def Type_isSubType(self: Type)(that: Type)(using ctx: Context): Boolean
+  def Type_isSubType(self: Type)(that: Type): Boolean
 
   /** Widen from singleton type to its underlying non-singleton
     *  base type by applying one or more `underlying` dereferences,
@@ -535,33 +535,33 @@ trait CompilerInterface extends scala.tasty.reflect.Types {
     *  def o: Outer
     *  <o.x.type>.widen = o.C
     */
-  def Type_widen(self: Type)(using ctx: Context): Type
+  def Type_widen(self: Type): Type
 
   /** Widen from TermRef to its underlying non-termref
    *  base type, while also skipping Expr types.
    */
-  def Type_widenTermRefExpr(self: Type)(using ctx: Context): Type
+  def Type_widenTermRefExpr(self: Type): Type
 
   /** Follow aliases and dereferences LazyRefs, annotated types and instantiated
    *  TypeVars until type is no longer alias type, annotated type, LazyRef,
    *  or instantiated type variable.
    */
-  def Type_dealias(self: Type)(using ctx: Context): Type
+  def Type_dealias(self: Type): Type
 
-  def Type_simplified(self: Type)(using ctx: Context): Type
+  def Type_simplified(self: Type): Type
 
-  def Type_classSymbol(self: Type)(using ctx: Context): Option[Symbol] // TODO remove Option and use NoSymbol
+  def Type_classSymbol(self: Type): Option[Symbol] // TODO remove Option and use NoSymbol
 
-  def Type_typeSymbol(self: Type)(using ctx: Context): Symbol
+  def Type_typeSymbol(self: Type): Symbol
 
-  def Type_termSymbol(self: Type)(using ctx: Context): Symbol
+  def Type_termSymbol(self: Type): Symbol
 
-  def Type_isSingleton(self: Type)(using ctx: Context): Boolean
+  def Type_isSingleton(self: Type): Boolean
 
-  def Type_memberType(self: Type)(member: Symbol)(using ctx: Context): Type
+  def Type_memberType(self: Type)(member: Symbol): Type
 
   /** The base classes of this type with the class itself as first element. */
-  def Type_baseClasses(self: Type)(using ctx: Context): List[Symbol]
+  def Type_baseClasses(self: Type): List[Symbol]
 
   /** The least type instance of given class which is a super-type
     *  of this type.  Example:
@@ -571,10 +571,10 @@ trait CompilerInterface extends scala.tasty.reflect.Types {
     *    ThisType(C).baseType(D) = p.D[Int]
     * }}}
     */
-  def Type_baseType(self: Type)(cls: Symbol)(using ctx: Context): Type
+  def Type_baseType(self: Type)(cls: Symbol): Type
 
   /** Is this type an instance of a non-bottom subclass of the given class `cls`? */
-  def Type_derivesFrom(self: Type)(cls: Symbol)(using ctx: Context): Boolean
+  def Type_derivesFrom(self: Type)(cls: Symbol): Boolean
 
   /** Is this type a function type?
    *
@@ -585,121 +585,121 @@ trait CompilerInterface extends scala.tasty.reflect.Types {
    *     - returns true for `given Int => Int` and `erased Int => Int`
    *     - returns false for `List[Int]`, despite that `List[Int] <:< Int => Int`.
    */
-  def Type_isFunctionType(self: Type)(using ctx: Context): Boolean
+  def Type_isFunctionType(self: Type): Boolean
 
   /** Is this type an context function type?
    *
    *  @see `Type_isFunctionType`
    */
-  def Type_isContextFunctionType(self: Type)(using ctx: Context): Boolean
+  def Type_isContextFunctionType(self: Type): Boolean
 
   /** Is this type an erased function type?
    *
    *  @see `Type_isFunctionType`
    */
-  def Type_isErasedFunctionType(self: Type)(using ctx: Context): Boolean
+  def Type_isErasedFunctionType(self: Type): Boolean
 
   /** Is this type a dependent function type?
    *
    *  @see `Type_isFunctionType`
    */
-  def Type_isDependentFunctionType(self: Type)(using ctx: Context): Boolean
+  def Type_isDependentFunctionType(self: Type): Boolean
 
   /** The type <this . sym>, reduced if possible */
-  def Type_select(self: Type)(sym: Symbol)(using ctx: Context): Type
+  def Type_select(self: Type)(sym: Symbol): Type
 
   /** The current type applied to given type arguments: `this[targ0, ..., targN]` */
   def Type_appliedTo(self: Type)(targs: List[Type]): Type
 
-  def ConstantType_TypeTest(using ctx: Context): TypeTest[Type, ConstantType]
+  def ConstantType_TypeTest: TypeTest[Type, ConstantType]
 
-  def ConstantType_apply(const : Constant)(using ctx : Context) : ConstantType
+  def ConstantType_apply(const : Constant): ConstantType
 
-  def ConstantType_constant(self: ConstantType)(using ctx: Context): Constant
+  def ConstantType_constant(self: ConstantType): Constant
 
-  def TermRef_TypeTest(using ctx: Context): TypeTest[Type, TermRef]
+  def TermRef_TypeTest: TypeTest[Type, TermRef]
 
-  def TermRef_apply(qual: Type, name: String)(using ctx: Context): TermRef
+  def TermRef_apply(qual: Type, name: String): TermRef
 
-  def TermRef_qualifier(self: TermRef)(using ctx: Context): Type
-  def TermRef_name(self: TermRef)(using ctx: Context): String
+  def TermRef_qualifier(self: TermRef): Type
+  def TermRef_name(self: TermRef): String
 
-  def TypeRef_TypeTest(using ctx: Context): TypeTest[Type, TypeRef]
+  def TypeRef_TypeTest: TypeTest[Type, TypeRef]
 
-  def TypeRef_qualifier(self: TypeRef)(using ctx: Context): Type
-  def TypeRef_name(self: TypeRef)(using ctx: Context): String
-  def TypeRef_isOpaqueAlias(self: TypeRef)(using ctx: Context): Boolean
-  def TypeRef_translucentSuperType(self: TypeRef)(using ctx: Context): Type
+  def TypeRef_qualifier(self: TypeRef): Type
+  def TypeRef_name(self: TypeRef): String
+  def TypeRef_isOpaqueAlias(self: TypeRef): Boolean
+  def TypeRef_translucentSuperType(self: TypeRef): Type
 
-  def SuperType_TypeTest(using ctx: Context): TypeTest[Type, SuperType]
+  def SuperType_TypeTest: TypeTest[Type, SuperType]
 
-  def SuperType_apply(thistpe: Type, supertpe: Type)(using ctx: Context): SuperType
+  def SuperType_apply(thistpe: Type, supertpe: Type): SuperType
 
-  def SuperType_thistpe(self: SuperType)(using ctx: Context): Type
-  def SuperType_supertpe(self: SuperType)(using ctx: Context): Type
+  def SuperType_thistpe(self: SuperType): Type
+  def SuperType_supertpe(self: SuperType): Type
 
-  def Refinement_TypeTest(using ctx: Context): TypeTest[Type, Refinement]
+  def Refinement_TypeTest: TypeTest[Type, Refinement]
 
-  def Refinement_apply(parent: Type, name: String, info: Type)(using ctx: Context): Refinement
+  def Refinement_apply(parent: Type, name: String, info: Type): Refinement
 
-  def Refinement_parent(self: Refinement)(using ctx: Context): Type
-  def Refinement_name(self: Refinement)(using ctx: Context): String
-  def Refinement_info(self: Refinement)(using ctx: Context): Type
+  def Refinement_parent(self: Refinement): Type
+  def Refinement_name(self: Refinement): String
+  def Refinement_info(self: Refinement): Type
 
-  def AppliedType_TypeTest(using ctx: Context): TypeTest[Type, AppliedType]
+  def AppliedType_TypeTest: TypeTest[Type, AppliedType]
 
-  def AppliedType_tycon(self: AppliedType)(using ctx: Context): Type
-  def AppliedType_args(self: AppliedType)(using ctx: Context): List[Type]
+  def AppliedType_tycon(self: AppliedType): Type
+  def AppliedType_args(self: AppliedType): List[Type]
 
-  def AnnotatedType_TypeTest(using ctx: Context): TypeTest[Type, AnnotatedType]
+  def AnnotatedType_TypeTest: TypeTest[Type, AnnotatedType]
 
-  def AnnotatedType_apply(underlying: Type, annot: Term)(using ctx: Context): AnnotatedType
+  def AnnotatedType_apply(underlying: Type, annot: Term): AnnotatedType
 
-  def AnnotatedType_underlying(self: AnnotatedType)(using ctx: Context): Type
-  def AnnotatedType_annot(self: AnnotatedType)(using ctx: Context): Term
+  def AnnotatedType_underlying(self: AnnotatedType): Type
+  def AnnotatedType_annot(self: AnnotatedType): Term
 
-  def AndType_TypeTest(using ctx: Context): TypeTest[Type, AndType]
+  def AndType_TypeTest: TypeTest[Type, AndType]
 
-  def AndType_apply(lhs: Type, rhs: Type)(using ctx: Context): AndType
+  def AndType_apply(lhs: Type, rhs: Type): AndType
 
-  def AndType_left(self: AndType)(using ctx: Context): Type
-  def AndType_right(self: AndType)(using ctx: Context): Type
+  def AndType_left(self: AndType): Type
+  def AndType_right(self: AndType): Type
 
-  def OrType_TypeTest(using ctx: Context): TypeTest[Type, OrType]
+  def OrType_TypeTest: TypeTest[Type, OrType]
 
-  def OrType_apply(lhs : Type, rhs : Type)(using ctx : Context): OrType
+  def OrType_apply(lhs : Type, rhs : Type): OrType
 
-  def OrType_left(self: OrType)(using ctx: Context): Type
-  def OrType_right(self: OrType)(using ctx: Context): Type
+  def OrType_left(self: OrType): Type
+  def OrType_right(self: OrType): Type
 
-  def MatchType_TypeTest(using ctx: Context): TypeTest[Type, MatchType]
+  def MatchType_TypeTest: TypeTest[Type, MatchType]
 
-  def MatchType_apply(bound: Type, scrutinee: Type, cases: List[Type])(using ctx: Context): MatchType
+  def MatchType_apply(bound: Type, scrutinee: Type, cases: List[Type]): MatchType
 
-  def MatchType_bound(self: MatchType)(using ctx: Context): Type
-  def MatchType_scrutinee(self: MatchType)(using ctx: Context): Type
-  def MatchType_cases(self: MatchType)(using ctx: Context): List[Type]
+  def MatchType_bound(self: MatchType): Type
+  def MatchType_scrutinee(self: MatchType): Type
+  def MatchType_cases(self: MatchType): List[Type]
 
-  def ByNameType_TypeTest(using ctx: Context): TypeTest[Type, ByNameType]
+  def ByNameType_TypeTest: TypeTest[Type, ByNameType]
 
-  def ByNameType_apply(underlying: Type)(using ctx: Context): Type
+  def ByNameType_apply(underlying: Type): Type
 
-  def ByNameType_underlying(self: ByNameType)(using ctx: Context): Type
+  def ByNameType_underlying(self: ByNameType): Type
 
-  def ParamRef_TypeTest(using ctx: Context): TypeTest[Type, ParamRef]
+  def ParamRef_TypeTest: TypeTest[Type, ParamRef]
 
-  def ParamRef_binder(self: ParamRef)(using ctx: Context): LambdaType
-  def ParamRef_paramNum(self: ParamRef)(using ctx: Context): Int
+  def ParamRef_binder(self: ParamRef): LambdaType
+  def ParamRef_paramNum(self: ParamRef): Int
 
-  def ThisType_TypeTest(using ctx: Context): TypeTest[Type, ThisType]
+  def ThisType_TypeTest: TypeTest[Type, ThisType]
 
-  def ThisType_tref(self: ThisType)(using ctx: Context): Type
+  def ThisType_tref(self: ThisType): Type
 
-  def RecursiveThis_TypeTest(using ctx: Context): TypeTest[Type, RecursiveThis]
+  def RecursiveThis_TypeTest: TypeTest[Type, RecursiveThis]
 
-  def RecursiveThis_binder(self: RecursiveThis)(using ctx: Context): RecursiveType
+  def RecursiveThis_binder(self: RecursiveThis): RecursiveType
 
-  def RecursiveType_TypeTest(using ctx: Context): TypeTest[Type, RecursiveType]
+  def RecursiveType_TypeTest: TypeTest[Type, RecursiveType]
 
   /** Create a RecType, normalizing its contents. This means:
    *
@@ -709,58 +709,58 @@ trait CompilerInterface extends scala.tasty.reflect.Types {
    *      `type T`. This avoids infinite recursions later when we
    *      try to follow these references.
    */
-  def RecursiveType_apply(parentExp: RecursiveType => Type)(using ctx: Context): RecursiveType
+  def RecursiveType_apply(parentExp: RecursiveType => Type): RecursiveType
 
-  def RecursiveType_underlying(self: RecursiveType)(using ctx: Context): Type
+  def RecursiveType_underlying(self: RecursiveType): Type
 
-  def RecursiveThis_recThis(self: RecursiveType)(using ctx: Context): RecursiveThis
+  def RecursiveThis_recThis(self: RecursiveType): RecursiveThis
 
-  def MethodType_TypeTest(using ctx: Context): TypeTest[Type, MethodType]
+  def MethodType_TypeTest: TypeTest[Type, MethodType]
 
   def MethodType_apply(paramNames: List[String])(paramInfosExp: MethodType => List[Type], resultTypeExp: MethodType => Type): MethodType
 
   def MethodType_isErased(self: MethodType): Boolean
   def MethodType_isImplicit(self: MethodType): Boolean
-  def MethodType_param(self: MethodType, ids: Int)(using ctx: Context): Type
-  def MethodType_paramNames(self: MethodType)(using ctx: Context): List[String]
-  def MethodType_paramTypes(self: MethodType)(using ctx: Context): List[Type]
-  def MethodType_resType(self: MethodType)(using ctx: Context): Type
+  def MethodType_param(self: MethodType, ids: Int): Type
+  def MethodType_paramNames(self: MethodType): List[String]
+  def MethodType_paramTypes(self: MethodType): List[Type]
+  def MethodType_resType(self: MethodType): Type
 
-  def PolyType_TypeTest(using ctx: Context): TypeTest[Type, PolyType]
+  def PolyType_TypeTest: TypeTest[Type, PolyType]
 
-  def PolyType_apply(paramNames: List[String])(paramBoundsExp: PolyType => List[TypeBounds], resultTypeExp: PolyType => Type)(using ctx: Context): PolyType
+  def PolyType_apply(paramNames: List[String])(paramBoundsExp: PolyType => List[TypeBounds], resultTypeExp: PolyType => Type): PolyType
 
-  def PolyType_param(self: PolyType, idx: Int)(using ctx: Context): Type
-  def PolyType_paramNames(self: PolyType)(using ctx: Context): List[String]
-  def PolyType_paramBounds(self: PolyType)(using ctx: Context): List[TypeBounds]
-  def PolyType_resType(self: PolyType)(using ctx: Context): Type
+  def PolyType_param(self: PolyType, idx: Int): Type
+  def PolyType_paramNames(self: PolyType): List[String]
+  def PolyType_paramBounds(self: PolyType): List[TypeBounds]
+  def PolyType_resType(self: PolyType): Type
 
-  def TypeLambda_TypeTest(using ctx: Context): TypeTest[Type, TypeLambda]
+  def TypeLambda_TypeTest: TypeTest[Type, TypeLambda]
 
   def TypeLambda_apply(paramNames: List[String], boundsFn: TypeLambda => List[TypeBounds], bodyFn: TypeLambda => Type): TypeLambda
 
-  def TypeLambda_paramNames(self: TypeLambda)(using ctx: Context): List[String]
-  def TypeLambda_paramBounds(self: TypeLambda)(using ctx: Context): List[TypeBounds]
-  def TypeLambda_param(self: TypeLambda, idx: Int)(using ctx: Context): Type
-  def TypeLambda_resType(self: TypeLambda)(using ctx: Context): Type
+  def TypeLambda_paramNames(self: TypeLambda): List[String]
+  def TypeLambda_paramBounds(self: TypeLambda): List[TypeBounds]
+  def TypeLambda_param(self: TypeLambda, idx: Int): Type
+  def TypeLambda_resType(self: TypeLambda): Type
 
 
   //////////////////////
   // IMPORT SELECTORS //
   //////////////////////
 
-  def SimpleSelector_TypeTest(using ctx: Context): TypeTest[ImportSelector, SimpleSelector]
+  def SimpleSelector_TypeTest: TypeTest[ImportSelector, SimpleSelector]
 
-  def SimpleSelector_selection(self: SimpleSelector)(using ctx: Context): Id
+  def SimpleSelector_selection(self: SimpleSelector): Id
 
-  def RenameSelector_TypeTest(using ctx: Context): TypeTest[ImportSelector, RenameSelector]
+  def RenameSelector_TypeTest: TypeTest[ImportSelector, RenameSelector]
 
-  def RenameSelector_from(self: RenameSelector)(using ctx: Context): Id
-  def RenameSelector_to(self: RenameSelector)(using ctx: Context): Id
+  def RenameSelector_from(self: RenameSelector): Id
+  def RenameSelector_to(self: RenameSelector): Id
 
-  def OmitSelector_TypeTest(using ctx: Context): TypeTest[ImportSelector, OmitSelector]
+  def OmitSelector_TypeTest: TypeTest[ImportSelector, OmitSelector]
 
-  def SimpleSelector_omitted(self: OmitSelector)(using ctx: Context): Id
+  def SimpleSelector_omitted(self: OmitSelector): Id
 
 
   /////////////////
@@ -768,10 +768,10 @@ trait CompilerInterface extends scala.tasty.reflect.Types {
   /////////////////
 
   /** Position in the source code */
-  def Id_pos(self: Id)(using ctx: Context): Position
+  def Id_pos(self: Id): Position
 
   /** Name of the identifier */
-  def Id_name(self: Id)(using ctx: Context): String
+  def Id_name(self: Id): String
 
 
   ////////////////
@@ -855,151 +855,151 @@ trait CompilerInterface extends scala.tasty.reflect.Types {
   def Symbol_currentOwner(using ctx: Context): Symbol
 
   /** Owner of this symbol. The owner is the symbol in which this symbol is defined. Throws if this symbol does not have an owner. */
-  def Symbol_owner(self: Symbol)(using ctx: Context): Symbol
+  def Symbol_owner(self: Symbol): Symbol
 
   /** Owner of this symbol. The owner is the symbol in which this symbol is defined. Returns `NoSymbol` if this symbol does not have an owner. */
-  def Symbol_maybeOwner(self: Symbol)(using ctx: Context): Symbol
+  def Symbol_maybeOwner(self: Symbol): Symbol
 
   /** Flags of this symbol */
-  def Symbol_flags(self: Symbol)(using ctx: Context): Flags
+  def Symbol_flags(self: Symbol): Flags
 
-  def Symbol_tree(self: Symbol)(using ctx: Context): Tree
+  def Symbol_tree(self: Symbol): Tree
 
-  def Symbol_isLocalDummy(self: Symbol)(using ctx: Context): Boolean
+  def Symbol_isLocalDummy(self: Symbol): Boolean
 
-  def Symbol_isRefinementClass(self: Symbol)(using ctx: Context): Boolean
+  def Symbol_isRefinementClass(self: Symbol): Boolean
 
-  def Symbol_isAliasType(self: Symbol)(using ctx: Context): Boolean
+  def Symbol_isAliasType(self: Symbol): Boolean
 
-  def Symbol_isAnonymousClass(self: Symbol)(using ctx: Context): Boolean
+  def Symbol_isAnonymousClass(self: Symbol): Boolean
 
-  def Symbol_isAnonymousFunction(self: Symbol)(using ctx: Context): Boolean
+  def Symbol_isAnonymousFunction(self: Symbol): Boolean
 
-  def Symbol_isAbstractType(self: Symbol)(using ctx: Context): Boolean
+  def Symbol_isAbstractType(self: Symbol): Boolean
 
-  def Symbol_isClassConstructor(self: Symbol)(using ctx: Context): Boolean
+  def Symbol_isClassConstructor(self: Symbol): Boolean
 
   /** This symbol is private within the resulting type. */
-  def Symbol_privateWithin(self: Symbol)(using ctx: Context): Option[Type]
+  def Symbol_privateWithin(self: Symbol): Option[Type]
 
   /** This symbol is protected within the resulting type. */
-  def Symbol_protectedWithin(self: Symbol)(using ctx: Context): Option[Type]
+  def Symbol_protectedWithin(self: Symbol): Option[Type]
 
   /** The name of this symbol. */
-  def Symbol_name(self: Symbol)(using ctx: Context): String
+  def Symbol_name(self: Symbol): String
 
   /** The full name of this symbol up to the root package. */
-  def Symbol_fullName(self: Symbol)(using ctx: Context): String
+  def Symbol_fullName(self: Symbol): String
 
   /** The position of this symbol */
-  def Symbol_pos(self: Symbol)(using ctx: Context): Position
+  def Symbol_pos(self: Symbol): Position
 
-  def Symbol_localContext(self: Symbol)(using ctx: Context): Context
+  def Symbol_localContext(self: Symbol): Context
 
   /** The comment of the symbol */
-  def Symbol_comment(self: Symbol)(using ctx: Context): Option[Comment]
+  def Symbol_comment(self: Symbol): Option[Comment]
 
   /** Annotations attached to this symbol */
-  def Symbol_annots(self: Symbol)(using ctx: Context): List[Term]
+  def Symbol_annots(self: Symbol): List[Term]
 
-  def Symbol_isDefinedInCurrentRun(self: Symbol)(using ctx: Context): Boolean
+  def Symbol_isDefinedInCurrentRun(self: Symbol): Boolean
 
   /** Fields directly declared in the class */
-  def Symbol_fields(self: Symbol)(using ctx: Context): List[Symbol]
+  def Symbol_fields(self: Symbol): List[Symbol]
 
   /** Field with the given name directly declared in the class */
-  def Symbol_field(self: Symbol)(name: String)(using ctx: Context): Symbol
+  def Symbol_field(self: Symbol)(name: String): Symbol
 
   /** Get non-private named methods defined directly inside the class */
-  def Symbol_classMethod(self: Symbol)(name: String)(using ctx: Context): List[Symbol]
+  def Symbol_classMethod(self: Symbol)(name: String): List[Symbol]
 
   /** Get all non-private methods defined directly inside the class, excluding constructors */
-  def Symbol_classMethods(self: Symbol)(using ctx: Context): List[Symbol]
+  def Symbol_classMethods(self: Symbol): List[Symbol]
 
   /** Get named non-private methods declared or inherited */
-  def Symbol_method(self: Symbol)(name: String)(using ctx: Context): List[Symbol]
+  def Symbol_method(self: Symbol)(name: String): List[Symbol]
 
   /** Get all non-private methods declared or inherited */
-  def Symbol_methods(self: Symbol)(using ctx: Context): List[Symbol]
+  def Symbol_methods(self: Symbol): List[Symbol]
 
   /** Type member directly declared in the class */
-  def Symbol_typeMembers(self: Symbol)(using ctx: Context): List[Symbol]
+  def Symbol_typeMembers(self: Symbol): List[Symbol]
 
   /** Type member with the given name directly declared in the class */
-  def Symbol_typeMember(self: Symbol)(name: String)(using ctx: Context): Symbol
+  def Symbol_typeMember(self: Symbol)(name: String): Symbol
 
   /** The symbols of each type parameter list and value parameter list of this
    *  method, or Nil if this isn't a method.
    */
-  def Symbol_paramSymss(self: Symbol)(using ctx: Context): List[List[Symbol]]
+  def Symbol_paramSymss(self: Symbol): List[List[Symbol]]
 
   /** The primary constructor of a class or trait, `noSymbol` if not applicable. */
-  def Symbol_primaryConstructor(self: Symbol)(using Context): Symbol
+  def Symbol_primaryConstructor(self: Symbol): Symbol
 
   /** Fields of a case class type -- only the ones declared in primary constructor */
-  def Symbol_caseFields(self: Symbol)(using ctx: Context): List[Symbol]
+  def Symbol_caseFields(self: Symbol): List[Symbol]
 
   /** Get package symbol if package is either defined in current compilation run or present on classpath. */
-  def Symbol_requiredPackage(path: String)(using ctx: Context): Symbol
+  def Symbol_requiredPackage(path: String): Symbol
 
   /** Get class symbol if class is either defined in current compilation run or present on classpath. */
-  def Symbol_requiredClass(path: String)(using ctx: Context): Symbol
+  def Symbol_requiredClass(path: String): Symbol
 
   /** Get module symbol if module is either defined in current compilation run or present on classpath. */
-  def Symbol_requiredModule(path: String)(using ctx: Context): Symbol
+  def Symbol_requiredModule(path: String): Symbol
 
   /** Get method symbol if method is either defined in current compilation run or present on classpath. Throws if the method has an overload. */
-  def Symbol_requiredMethod(path: String)(using ctx: Context): Symbol
+  def Symbol_requiredMethod(path: String): Symbol
 
-  def Symbol_of(fullName: String)(using ctx: Context): Symbol
+  def Symbol_of(fullName: String): Symbol
 
-  def Symbol_newMethod(parent: Symbol, name: String, flags: Flags, tpe: Type, privateWithin: Symbol)(using ctx: Context): Symbol
+  def Symbol_newMethod(parent: Symbol, name: String, flags: Flags, tpe: Type, privateWithin: Symbol): Symbol
 
-  def Symbol_newVal(parent: Symbol, name: String, flags: Flags, tpe: Type, privateWithin: Symbol)(using ctx: Context): Symbol
+  def Symbol_newVal(parent: Symbol, name: String, flags: Flags, tpe: Type, privateWithin: Symbol): Symbol
 
-  def Symbol_newBind(parent: Symbol, name: String, flags: Flags, tpe: Type)(using ctx: Context): Symbol
+  def Symbol_newBind(parent: Symbol, name: String, flags: Flags, tpe: Type): Symbol
 
-  def Symbol_isTypeParam(self: Symbol)(using ctx: Context): Boolean
+  def Symbol_isTypeParam(self: Symbol): Boolean
 
-  def Symbol_isPackageDef(symbol: Symbol)(using ctx: Context): Boolean
+  def Symbol_isPackageDef(symbol: Symbol): Boolean
 
   /** Is this the definition of a type? */
-  def Symbol_isType(symbol: Symbol)(using ctx: Context): Boolean
+  def Symbol_isType(symbol: Symbol): Boolean
 
   /** Is this the definition of a term? */
-  def Symbol_isTerm(symbol: Symbol)(using ctx: Context): Boolean
+  def Symbol_isTerm(symbol: Symbol): Boolean
 
   /** Is this the definition of a ClassDef tree? */
-  def Symbol_isClassDef(symbol: Symbol)(using ctx: Context): Boolean
+  def Symbol_isClassDef(symbol: Symbol): Boolean
 
   /** Is this the definition of a TypeDef tree? */
-  def Symbol_isTypeDef(symbol: Symbol)(using ctx: Context): Boolean
+  def Symbol_isTypeDef(symbol: Symbol): Boolean
 
   /** Is this the definition of a DefDef tree? */
-  def Symbol_isDefDef(symbol: Symbol)(using ctx: Context): Boolean
+  def Symbol_isDefDef(symbol: Symbol): Boolean
 
   /** Is this the definition of a ValDef tree? */
-  def Symbol_isValDef(symbol: Symbol)(using ctx: Context): Boolean
+  def Symbol_isValDef(symbol: Symbol): Boolean
 
   /** Is this the definition of a Bind pattern? */
-  def Symbol_isBind(symbol: Symbol)(using ctx: Context): Boolean
+  def Symbol_isBind(symbol: Symbol): Boolean
 
   /** Signature of this definition */
-  def Symbol_signature(self: Symbol)(using ctx: Context): Signature
+  def Symbol_signature(self: Symbol): Signature
 
   /** The class symbol of the companion module class */
-  def Symbol_moduleClass(self: Symbol)(using ctx: Context): Symbol
+  def Symbol_moduleClass(self: Symbol): Symbol
 
   /** The symbol of the companion class */
-  def Symbol_companionClass(self: Symbol)(using ctx: Context): Symbol
+  def Symbol_companionClass(self: Symbol): Symbol
 
   /** The symbol of the companion module */
-  def Symbol_companionModule(self: Symbol)(using ctx: Context): Symbol
+  def Symbol_companionModule(self: Symbol): Symbol
 
-  def Symbol_noSymbol(using ctx: Context): Symbol
+  def Symbol_noSymbol: Symbol
 
   /** Case class or case object children of a sealed trait */
-  def Symbol_children(self: Symbol)(using ctx: Context): List[Symbol]
+  def Symbol_children(self: Symbol): List[Symbol]
 
 
   ///////////
@@ -1190,17 +1190,17 @@ trait CompilerInterface extends scala.tasty.reflect.Types {
   // IMPLICITS //
   ///////////////
 
-  def ImplicitSearchSuccess_TypeTest(using ctx: Context): TypeTest[ImplicitSearchResult, ImplicitSearchSuccess]
-  def ImplicitSearchSuccess_tree(self: ImplicitSearchSuccess)(using ctx: Context): Term
+  def ImplicitSearchSuccess_TypeTest: TypeTest[ImplicitSearchResult, ImplicitSearchSuccess]
+  def ImplicitSearchSuccess_tree(self: ImplicitSearchSuccess): Term
 
-  def ImplicitSearchFailure_TypeTest(using ctx: Context): TypeTest[ImplicitSearchResult, ImplicitSearchFailure]
-  def ImplicitSearchFailure_explanation(self: ImplicitSearchFailure)(using ctx: Context): String
+  def ImplicitSearchFailure_TypeTest: TypeTest[ImplicitSearchResult, ImplicitSearchFailure]
+  def ImplicitSearchFailure_explanation(self: ImplicitSearchFailure): String
 
-  def DivergingImplicit_TypeTest(using ctx: Context): TypeTest[ImplicitSearchResult, DivergingImplicit]
+  def DivergingImplicit_TypeTest: TypeTest[ImplicitSearchResult, DivergingImplicit]
 
-  def NoMatchingImplicits_TypeTest(using ctx: Context): TypeTest[ImplicitSearchResult, NoMatchingImplicits]
+  def NoMatchingImplicits_TypeTest: TypeTest[ImplicitSearchResult, NoMatchingImplicits]
 
-  def AmbiguousImplicits_TypeTest(using ctx: Context): TypeTest[ImplicitSearchResult, AmbiguousImplicits]
+  def AmbiguousImplicits_TypeTest: TypeTest[ImplicitSearchResult, AmbiguousImplicits]
 
   /** Find an implicit of type `T` in the current scope given by `ctx`.
    *  Return an `ImplicitSearchResult`.
@@ -1208,12 +1208,12 @@ trait CompilerInterface extends scala.tasty.reflect.Types {
    *  @param tpe type of the implicit parameter
    *  @param ctx current context
    */
-  def searchImplicit(tpe: Type)(using ctx: Context): ImplicitSearchResult
+  def searchImplicit(tpe: Type): ImplicitSearchResult
 
   /** Returns Some with a beta-reduced application or None */
-  def betaReduce(tree: Term)(using Context): Option[Term]
+  def betaReduce(tree: Term): Option[Term]
 
-  def lambdaExtractor(term: Term, paramTypes: List[Type])(using ctx: Context): Option[List[Term] => Term]
+  def lambdaExtractor(term: Term, paramTypes: List[Type]): Option[List[Term] => Term]
 
   def compilerId: Int
 

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -28,19 +28,19 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
   object Source:
 
     /** Returns the source file being compiled. The path is relative to the current working directory. */
-    def path(using ctx: Context): java.nio.file.Path = reflectSelf.Source_path
+    def path: java.nio.file.Path = reflectSelf.Source_path
 
     /** Returns true if we've tried to reflect on a Java class. */
-    def isJavaCompilationUnit(using ctx: Context): Boolean = reflectSelf.Source_isJavaCompilationUnit
+    def isJavaCompilationUnit: Boolean = reflectSelf.Source_isJavaCompilationUnit
 
     /** Returns true if we've tried to reflect on a Scala2 (non-Tasty) class. */
-    def isScala2CompilationUnit(using ctx: Context): Boolean = reflectSelf.Source_isScala2CompilationUnit
+    def isScala2CompilationUnit: Boolean = reflectSelf.Source_isScala2CompilationUnit
 
     /** Returns true if we've tried to reflect on a class that's already loaded (e.g. Option). */
-    def isAlreadyLoadedCompilationUnit(using ctx: Context): Boolean = reflectSelf.Source_isAlreadyLoadedCompilationUnit
+    def isAlreadyLoadedCompilationUnit: Boolean = reflectSelf.Source_isAlreadyLoadedCompilationUnit
 
     /** Class name of the current CompilationUnit */
-    def compilationUnitClassname(using ctx: Context): String = reflectSelf.Source_compilationUnitClassname
+    def compilationUnitClassname: String = reflectSelf.Source_compilationUnitClassname
 
   end Source
 
@@ -56,25 +56,25 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
   given TreeOps as AnyRef:
     extension (tree: Tree):
       /** Position in the source code */
-      def pos(using ctx: Context): Position = reflectSelf.Tree_pos(tree)
+      def pos: Position = reflectSelf.Tree_pos(tree)
 
       /** Symbol of defined or referred by this tree */
-      def symbol(using ctx: Context): Symbol = reflectSelf.Tree_symbol(tree)
+      def symbol: Symbol = reflectSelf.Tree_symbol(tree)
 
       /** Shows the tree as extractors */
-      def showExtractors(using ctx: Context): String =
+      def showExtractors: String =
         new ExtractorsPrinter[reflectSelf.type](reflectSelf).showTree(tree)
 
       /** Shows the tree as fully typed source code */
-      def show(using ctx: Context): String =
+      def show: String =
         tree.showWith(SyntaxHighlight.plain)
 
       /** Shows the tree as fully typed source code */
-      def showWith(syntaxHighlight: SyntaxHighlight)(using ctx: Context): String =
+      def showWith(syntaxHighlight: SyntaxHighlight): String =
         new SourceCodePrinter[reflectSelf.type](reflectSelf)(syntaxHighlight).showTree(tree)
 
       /** Does this tree represent a valid expression? */
-      def isExpr(using ctx: Context): Boolean =
+      def isExpr: Boolean =
         tree match
           case tree: Term =>
             tree.tpe.widen match
@@ -95,157 +95,157 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
 
   end TreeOps
 
-  given (using ctx: Context) as TypeTest[Tree, PackageClause] = reflectSelf.PackageClause_TypeTest
+  given TypeTest[Tree, PackageClause] = reflectSelf.PackageClause_TypeTest
 
   object PackageClause:
-    def apply(pid: Ref, stats: List[Tree])(using ctx: Context): PackageClause =
+    def apply(pid: Ref, stats: List[Tree]): PackageClause =
       reflectSelf.PackageClause_apply(pid, stats)
-    def copy(original: Tree)(pid: Ref, stats: List[Tree])(using ctx: Context): PackageClause =
+    def copy(original: Tree)(pid: Ref, stats: List[Tree]): PackageClause =
       reflectSelf.PackageClause_copy(original)(pid, stats)
-    def unapply(tree: PackageClause)(using ctx: Context): Some[(Ref, List[Tree])] =
+    def unapply(tree: PackageClause): Some[(Ref, List[Tree])] =
       Some((tree.pid, tree.stats))
   end PackageClause
 
   given PackageClauseOps as AnyRef:
     extension (self: PackageClause):
-      def pid(using ctx: Context): Ref = reflectSelf.PackageClause_pid(self)
-      def stats(using ctx: Context): List[Tree] = reflectSelf.PackageClause_stats(self)
+      def pid: Ref = reflectSelf.PackageClause_pid(self)
+      def stats: List[Tree] = reflectSelf.PackageClause_stats(self)
     end extension
   end PackageClauseOps
 
-  given (using ctx: Context) as TypeTest[Tree, Import] = reflectSelf.Import_TypeTest
+  given TypeTest[Tree, Import] = reflectSelf.Import_TypeTest
 
   object Import:
-    def apply(expr: Term, selectors: List[ImportSelector])(using ctx: Context): Import =
+    def apply(expr: Term, selectors: List[ImportSelector]): Import =
       reflectSelf.Import_apply(expr, selectors)
-    def copy(original: Tree)(expr: Term, selectors: List[ImportSelector])(using ctx: Context): Import =
+    def copy(original: Tree)(expr: Term, selectors: List[ImportSelector]): Import =
       reflectSelf.Import_copy(original)(expr, selectors)
-    def unapply(tree: Import)(using ctx: Context): Option[(Term, List[ImportSelector])] =
+    def unapply(tree: Import): Option[(Term, List[ImportSelector])] =
       Some((tree.expr, tree.selectors))
   end Import
 
   given ImportOps as AnyRef:
     extension (self: Import):
-      def expr(using ctx: Context): Term = reflectSelf.Import_expr(self)
-      def selectors(using ctx: Context): List[ImportSelector] =
+      def expr: Term = reflectSelf.Import_expr(self)
+      def selectors: List[ImportSelector] =
         reflectSelf.Import_selectors(self)
     end extension
   end ImportOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Statement] = reflectSelf.Statement_TypeTest
+  given TypeTest[Tree, Statement] = reflectSelf.Statement_TypeTest
 
   // ----- Definitions ----------------------------------------------
 
-  given (using ctx: Context) as TypeTest[Tree, Definition] = reflectSelf.Definition_TypeTest
+  given TypeTest[Tree, Definition] = reflectSelf.Definition_TypeTest
 
   object Definition
 
   given DefinitionOps as AnyRef:
     extension (self: Definition):
-      def name(using ctx: Context): String = reflectSelf.Definition_name(self)
+      def name: String = reflectSelf.Definition_name(self)
     end extension
   end DefinitionOps
 
   // ClassDef
 
-  given (using ctx: Context) as TypeTest[Tree, ClassDef] = reflectSelf.ClassDef_TypeTest
+  given TypeTest[Tree, ClassDef] = reflectSelf.ClassDef_TypeTest
 
   object ClassDef:
-    // TODO def apply(name: String, constr: DefDef, parents: List[TermOrTypeTree], selfOpt: Option[ValDef], body: List[Statement])(using ctx: Context): ClassDef
-    def copy(original: Tree)(name: String, constr: DefDef, parents: List[Tree /* Term | TypeTree */], derived: List[TypeTree], selfOpt: Option[ValDef], body: List[Statement])(using ctx: Context): ClassDef =
+    // TODO def apply(name: String, constr: DefDef, parents: List[TermOrTypeTree], selfOpt: Option[ValDef], body: List[Statement]): ClassDef
+    def copy(original: Tree)(name: String, constr: DefDef, parents: List[Tree /* Term | TypeTree */], derived: List[TypeTree], selfOpt: Option[ValDef], body: List[Statement]): ClassDef =
       reflectSelf.ClassDef_copy(original)(name, constr, parents, derived, selfOpt, body)
-    def unapply(cdef: ClassDef)(using ctx: Context): Option[(String, DefDef, List[Tree /* Term | TypeTree */], List[TypeTree], Option[ValDef], List[Statement])] =
+    def unapply(cdef: ClassDef): Option[(String, DefDef, List[Tree /* Term | TypeTree */], List[TypeTree], Option[ValDef], List[Statement])] =
       Some((cdef.name, cdef.constructor, cdef.parents, cdef.derived, cdef.self, cdef.body))
   end ClassDef
 
   given ClassDefOps as AnyRef:
     extension (self: ClassDef):
-      def constructor(using ctx: Context): DefDef = reflectSelf.ClassDef_constructor(self)
-      def parents(using ctx: Context): List[Tree /* Term | TypeTree */] = reflectSelf.ClassDef_parents(self)
-      def derived(using ctx: Context): List[TypeTree] = reflectSelf.ClassDef_derived(self)
-      def self(using ctx: Context): Option[ValDef] = reflectSelf.ClassDef_self(self)
-      def body(using ctx: Context): List[Statement] = reflectSelf.ClassDef_body(self)
+      def constructor: DefDef = reflectSelf.ClassDef_constructor(self)
+      def parents: List[Tree /* Term | TypeTree */] = reflectSelf.ClassDef_parents(self)
+      def derived: List[TypeTree] = reflectSelf.ClassDef_derived(self)
+      def self: Option[ValDef] = reflectSelf.ClassDef_self(self)
+      def body: List[Statement] = reflectSelf.ClassDef_body(self)
     end extension
   end ClassDefOps
 
 
   // DefDef
 
-  given (using ctx: Context) as TypeTest[Tree, DefDef] = reflectSelf.DefDef_TypeTest
+  given TypeTest[Tree, DefDef] = reflectSelf.DefDef_TypeTest
 
   object DefDef:
-    def apply(symbol: Symbol, rhsFn: List[Type] => List[List[Term]] => Option[Term])(using ctx: Context): DefDef =
+    def apply(symbol: Symbol, rhsFn: List[Type] => List[List[Term]] => Option[Term]): DefDef =
       reflectSelf.DefDef_apply(symbol, rhsFn)
-    def copy(original: Tree)(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]], tpt: TypeTree, rhs: Option[Term])(using ctx: Context): DefDef =
+    def copy(original: Tree)(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]], tpt: TypeTree, rhs: Option[Term]): DefDef =
       reflectSelf.DefDef_copy(original)(name, typeParams, paramss, tpt, rhs)
-    def unapply(ddef: DefDef)(using ctx: Context): Option[(String, List[TypeDef], List[List[ValDef]], TypeTree, Option[Term])] =
+    def unapply(ddef: DefDef): Option[(String, List[TypeDef], List[List[ValDef]], TypeTree, Option[Term])] =
       Some((ddef.name, ddef.typeParams, ddef.paramss, ddef.returnTpt, ddef.rhs))
   end DefDef
 
   given DefDefOps as AnyRef:
     extension (self: DefDef):
-      def typeParams(using ctx: Context): List[TypeDef] = reflectSelf.DefDef_typeParams(self)
-      def paramss(using ctx: Context): List[List[ValDef]] = reflectSelf.DefDef_paramss(self)
-      def returnTpt(using ctx: Context): TypeTree = reflectSelf.DefDef_returnTpt(self) // TODO rename to tpt
-      def rhs(using ctx: Context): Option[Term] = reflectSelf.DefDef_rhs(self)
+      def typeParams: List[TypeDef] = reflectSelf.DefDef_typeParams(self)
+      def paramss: List[List[ValDef]] = reflectSelf.DefDef_paramss(self)
+      def returnTpt: TypeTree = reflectSelf.DefDef_returnTpt(self) // TODO rename to tpt
+      def rhs: Option[Term] = reflectSelf.DefDef_rhs(self)
     end extension
   end DefDefOps
 
 
   // ValDef
 
-  given (using ctx: Context) as TypeTest[Tree, ValDef] = reflectSelf.ValDef_TypeTest
+  given TypeTest[Tree, ValDef] = reflectSelf.ValDef_TypeTest
 
   object ValDef:
-    def apply(symbol: Symbol, rhs: Option[Term])(using ctx: Context): ValDef =
+    def apply(symbol: Symbol, rhs: Option[Term]): ValDef =
       reflectSelf.ValDef_apply(symbol, rhs)
-    def copy(original: Tree)(name: String, tpt: TypeTree, rhs: Option[Term])(using ctx: Context): ValDef =
+    def copy(original: Tree)(name: String, tpt: TypeTree, rhs: Option[Term]): ValDef =
       reflectSelf.ValDef_copy(original)(name, tpt, rhs)
-    def unapply(vdef: ValDef)(using ctx: Context): Option[(String, TypeTree, Option[Term])] =
+    def unapply(vdef: ValDef): Option[(String, TypeTree, Option[Term])] =
       Some((vdef.name, vdef.tpt, vdef.rhs))
   end ValDef
 
   given ValDefOps as AnyRef:
     extension (self: ValDef):
-      def tpt(using ctx: Context): TypeTree = reflectSelf.ValDef_tpt(self)
-      def rhs(using ctx: Context): Option[Term] = reflectSelf.ValDef_rhs(self)
+      def tpt: TypeTree = reflectSelf.ValDef_tpt(self)
+      def rhs: Option[Term] = reflectSelf.ValDef_rhs(self)
     end extension
   end ValDefOps
 
 
   // TypeDef
 
-  given (using ctx: Context) as TypeTest[Tree, TypeDef] = reflectSelf.TypeDef_TypeTest
+  given TypeTest[Tree, TypeDef] = reflectSelf.TypeDef_TypeTest
 
   object TypeDef:
-    def apply(symbol: Symbol)(using ctx: Context): TypeDef =
+    def apply(symbol: Symbol): TypeDef =
       reflectSelf.TypeDef_apply(symbol)
-    def copy(original: Tree)(name: String, rhs: Tree /*TypeTree | TypeBoundsTree*/)(using ctx: Context): TypeDef =
+    def copy(original: Tree)(name: String, rhs: Tree /*TypeTree | TypeBoundsTree*/): TypeDef =
       reflectSelf.TypeDef_copy(original)(name, rhs)
-    def unapply(tdef: TypeDef)(using ctx: Context): Option[(String, Tree /*TypeTree | TypeBoundsTree*/ /* TypeTree | TypeBoundsTree */)] =
+    def unapply(tdef: TypeDef): Option[(String, Tree /*TypeTree | TypeBoundsTree*/ /* TypeTree | TypeBoundsTree */)] =
       Some((tdef.name, tdef.rhs))
   end TypeDef
 
   given TypeDefOps as AnyRef:
     extension (self: TypeDef):
-      def rhs(using ctx: Context): Tree /*TypeTree | TypeBoundsTree*/ = reflectSelf.TypeDef_rhs(self)
+      def rhs: Tree /*TypeTree | TypeBoundsTree*/ = reflectSelf.TypeDef_rhs(self)
     end extension
   end TypeDefOps
 
   // PackageDef
 
-  given (using ctx: Context) as TypeTest[Tree, PackageDef] = reflectSelf.PackageDef_TypeTest
+  given TypeTest[Tree, PackageDef] = reflectSelf.PackageDef_TypeTest
 
   object PackageDef:
-    def unapply(tree: PackageDef)(using ctx: Context): Option[(String, PackageDef)] =
+    def unapply(tree: PackageDef): Option[(String, PackageDef)] =
       Some((tree.name, tree.owner))
   end PackageDef
 
   given PackageDefOps as AnyRef:
     extension (self: PackageDef):
-      def owner(using ctx: Context): PackageDef = reflectSelf.PackageDef_owner(self)
-      def members(using ctx: Context): List[Statement] = reflectSelf.PackageDef_members(self)
+      def owner: PackageDef = reflectSelf.PackageDef_owner(self)
+      def members: List[Statement] = reflectSelf.PackageDef_members(self)
     end extension
   end PackageDefOps
 
@@ -257,77 +257,77 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
     extension (self: Term):
 
       /** Convert `Term` to an `quoted.Expr[Any]` if the term is a valid expression or throws */
-      def seal(using ctx: Context): scala.quoted.Expr[Any] =
+      def seal: scala.quoted.Expr[Any] =
         if self.isExpr then new scala.internal.quoted.Expr(self, reflectSelf.compilerId)
         else throw new Exception("Cannot seal a partially applied Term. Try eta-expanding the term first.")
 
       /** Convert `Term` to an `quoted.Expr[Any]` if the term is a valid expression */
-      def sealOpt(using ctx: Context): Option[scala.quoted.Expr[Any]] =
+      def sealOpt: Option[scala.quoted.Expr[Any]] =
         if self.isExpr then Some(new scala.internal.quoted.Expr(self, reflectSelf.compilerId))
         else None
 
       /** Type of this term */
-      def tpe(using ctx: Context): Type = reflectSelf.Term_tpe(self)
+      def tpe: Type = reflectSelf.Term_tpe(self)
 
       /** Replace Inlined nodes and InlineProxy references to underlying arguments */
-      def underlyingArgument(using ctx: Context): Term = reflectSelf.Term_underlyingArgument(self)
+      def underlyingArgument: Term = reflectSelf.Term_underlyingArgument(self)
 
       /** Replace Ident nodes references to the underlying tree that defined them */
-      def underlying(using ctx: Context): Term = reflectSelf.Term_underlying(self)
+      def underlying: Term = reflectSelf.Term_underlying(self)
 
       /** Converts a partally applied term into a lambda expression */
-      def etaExpand(using ctx: Context): Term = reflectSelf.Term_etaExpand(self)
+      def etaExpand: Term = reflectSelf.Term_etaExpand(self)
 
       /** A unary apply node with given argument: `tree(arg)` */
-      def appliedTo(arg: Term)(using ctx: Context): Term =
+      def appliedTo(arg: Term): Term =
         self.appliedToArgs(arg :: Nil)
 
       /** An apply node with given arguments: `tree(arg, args0, ..., argsN)` */
-      def appliedTo(arg: Term, args: Term*)(using ctx: Context): Term =
+      def appliedTo(arg: Term, args: Term*): Term =
         self.appliedToArgs(arg :: args.toList)
 
       /** An apply node with given argument list `tree(args(0), ..., args(args.length - 1))` */
-      def appliedToArgs(args: List[Term])(using ctx: Context): Apply =
+      def appliedToArgs(args: List[Term]): Apply =
         Apply(self, args)
 
       /** The current tree applied to given argument lists:
       *  `tree (argss(0)) ... (argss(argss.length -1))`
       */
-      def appliedToArgss(argss: List[List[Term]])(using ctx: Context): Term =
+      def appliedToArgss(argss: List[List[Term]]): Term =
         argss.foldLeft(self: Term)(Apply(_, _))
 
       /** The current tree applied to (): `tree()` */
-      def appliedToNone(using ctx: Context): Apply =
+      def appliedToNone: Apply =
         self.appliedToArgs(Nil)
 
       /** The current tree applied to given type argument: `tree[targ]` */
-      def appliedToType(targ: Type)(using ctx: Context): Term =
+      def appliedToType(targ: Type): Term =
         self.appliedToTypes(targ :: Nil)
 
       /** The current tree applied to given type arguments: `tree[targ0, ..., targN]` */
-      def appliedToTypes(targs: List[Type])(using ctx: Context): Term =
+      def appliedToTypes(targs: List[Type]): Term =
         self.appliedToTypeTrees(targs map (Inferred(_)))
 
       /** The current tree applied to given type argument list: `tree[targs(0), ..., targs(targs.length - 1)]` */
-      def appliedToTypeTrees(targs: List[TypeTree])(using ctx: Context): Term =
+      def appliedToTypeTrees(targs: List[TypeTree]): Term =
         if (targs.isEmpty) self else TypeApply(self, targs)
 
       /** A select node that selects the given symbol.
       */
-      def select(sym: Symbol)(using ctx: Context): Select = Select(self, sym)
+      def select(sym: Symbol): Select = Select(self, sym)
 
     end extension
 
   end TermOps
 
-  given (using ctx: Context) as TypeTest[Tree, Term] = reflectSelf.Term_TypeTest
+  given TypeTest[Tree, Term] = reflectSelf.Term_TypeTest
 
-  given (using ctx: Context) as TypeTest[Tree, Ref] = reflectSelf.Ref_TypeTest
+  given TypeTest[Tree, Ref] = reflectSelf.Ref_TypeTest
 
   object Ref:
 
     /** A tree representing the same reference as the given type */
-    def term(tp: TermRef)(using ctx: Context): Ref =
+    def term(tp: TermRef): Ref =
       reflectSelf.Ref_term(tp)
 
     /** Create a reference tree from a symbol
@@ -344,37 +344,37 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
      *  the class body of `C`, or have `foo` outside the lexical
      *  scope for the definition of `foo`.
      */
-    def apply(sym: Symbol)(using ctx: Context): Ref =
+    def apply(sym: Symbol): Ref =
       reflectSelf.Ref_apply(sym)
   end Ref
 
-  given (using ctx: Context) as TypeTest[Tree, Ident] = reflectSelf.Ident_TypeTest
+  given TypeTest[Tree, Ident] = reflectSelf.Ident_TypeTest
 
   /** Scala term identifier */
   object Ident:
-    def apply(tmref: TermRef)(using ctx: Context): Term =
+    def apply(tmref: TermRef): Term =
       reflectSelf.Ident_apply(tmref)
 
-    def copy(original: Tree)(name: String)(using ctx: Context): Ident =
+    def copy(original: Tree)(name: String): Ident =
       reflectSelf.Ident_copy(original)(name)
 
     /** Matches a term identifier and returns its name */
-    def unapply(tree: Ident)(using ctx: Context): Option[String] =
+    def unapply(tree: Ident): Option[String] =
       Some(tree.name)
   end Ident
 
   given IdentOps as AnyRef:
     extension (self: Ident):
-      def name(using ctx: Context): String = reflectSelf.Ident_name(self)
+      def name: String = reflectSelf.Ident_name(self)
     end extension
   end IdentOps
 
-  given (using ctx: Context) as TypeTest[Tree, Select] = reflectSelf.Select_TypeTest
+  given TypeTest[Tree, Select] = reflectSelf.Select_TypeTest
 
   /** Scala term selection */
   object Select:
     /** Select a term member by symbol */
-    def apply(qualifier: Term, symbol: Symbol)(using ctx: Context): Select =
+    def apply(qualifier: Term, symbol: Symbol): Select =
       reflectSelf.Select_apply(qualifier, symbol)
 
     /** Select a field or a non-overloaded method by name
@@ -383,288 +383,288 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
      *        method is overloaded. The method `overloaded` should be used
      *        in that case.
      */
-    def unique(qualifier: Term, name: String)(using ctx: Context): Select =
+    def unique(qualifier: Term, name: String): Select =
       reflectSelf.Select_unique(qualifier, name)
 
     // TODO rename, this returns an Apply and not a Select
     /** Call an overloaded method with the given type and term parameters */
-    def overloaded(qualifier: Term, name: String, targs: List[Type], args: List[Term])(using ctx: Context): Apply =
+    def overloaded(qualifier: Term, name: String, targs: List[Type], args: List[Term]): Apply =
       reflectSelf.Select_overloaded(qualifier, name, targs, args)
 
-    def copy(original: Tree)(qualifier: Term, name: String)(using ctx: Context): Select =
+    def copy(original: Tree)(qualifier: Term, name: String): Select =
       reflectSelf.Select_copy(original)(qualifier, name)
 
     /** Matches `<qualifier: Term>.<name: String>` */
-    def unapply(x: Select)(using ctx: Context): Option[(Term, String)] =
+    def unapply(x: Select): Option[(Term, String)] =
       Some((x.qualifier, x.name))
   end Select
 
   given SelectOps as AnyRef:
     extension (self: Select):
-      def qualifier(using ctx: Context): Term = reflectSelf.Select_qualifier(self)
-      def name(using ctx: Context): String = reflectSelf.Select_name(self)
-      def signature(using ctx: Context): Option[Signature] = reflectSelf.Select_signature(self)
+      def qualifier: Term = reflectSelf.Select_qualifier(self)
+      def name: String = reflectSelf.Select_name(self)
+      def signature: Option[Signature] = reflectSelf.Select_signature(self)
     end extension
   end SelectOps
 
-  given (using ctx: Context) as TypeTest[Tree, Literal] =
+  given TypeTest[Tree, Literal] =
     reflectSelf.Literal_TypeTest
 
   /** Scala literal constant */
   object Literal:
 
     /** Create a literal constant */
-    def apply(constant: Constant)(using ctx: Context): Literal =
+    def apply(constant: Constant): Literal =
       reflectSelf.Literal_apply(constant)
 
-    def copy(original: Tree)(constant: Constant)(using ctx: Context): Literal =
+    def copy(original: Tree)(constant: Constant): Literal =
       reflectSelf.Literal_copy(original)(constant)
 
     /** Matches a literal constant */
-    def unapply(x: Literal)(using ctx: Context): Option[Constant] =
+    def unapply(x: Literal): Option[Constant] =
       Some(x.constant)
   end Literal
 
   given LiteralOps as AnyRef:
     extension (self: Literal):
-      def constant(using ctx: Context): Constant = reflectSelf.Literal_constant(self)
+      def constant: Constant = reflectSelf.Literal_constant(self)
     end extension
   end LiteralOps
 
-  given (using ctx: Context) as TypeTest[Tree, This] = reflectSelf.This_TypeTest
+  given TypeTest[Tree, This] = reflectSelf.This_TypeTest
 
   /** Scala `this` or `this[id]` */
   object This:
 
     /** Create a `this[<id: Id]>` */
-    def apply(cls: Symbol)(using ctx: Context): This =
+    def apply(cls: Symbol): This =
       reflectSelf.This_apply(cls)
 
-    def copy(original: Tree)(qual: Option[Id])(using ctx: Context): This =
+    def copy(original: Tree)(qual: Option[Id]): This =
       reflectSelf.This_copy(original)(qual)
 
     /** Matches `this[<id: Option[Id]>` */
-    def unapply(x: This)(using ctx: Context): Option[Option[Id]] = Some(x.id)
+    def unapply(x: This): Option[Option[Id]] = Some(x.id)
   end This
 
   given ThisOps as AnyRef:
     extension (self: This):
-      def id(using ctx: Context): Option[Id] = reflectSelf.This_id(self)
+      def id: Option[Id] = reflectSelf.This_id(self)
     end extension
   end ThisOps
 
-  given (using ctx: Context) as TypeTest[Tree, New] = reflectSelf.New_TypeTest
+  given TypeTest[Tree, New] = reflectSelf.New_TypeTest
 
   /** Scala `new` */
   object New:
 
     /** Create a `new <tpt: TypeTree>` */
-    def apply(tpt: TypeTree)(using ctx: Context): New =
+    def apply(tpt: TypeTree): New =
       reflectSelf.New_apply(tpt)
 
-    def copy(original: Tree)(tpt: TypeTree)(using ctx: Context): New =
+    def copy(original: Tree)(tpt: TypeTree): New =
       reflectSelf.New_copy(original)(tpt)
 
     /** Matches a `new <tpt: TypeTree>` */
-    def unapply(x: New)(using ctx: Context): Option[TypeTree] = Some(x.tpt)
+    def unapply(x: New): Option[TypeTree] = Some(x.tpt)
   end New
 
   given NewOps as AnyRef:
     extension (self: New):
-      def tpt(using ctx: Context): TypeTree = reflectSelf.New_tpt(self)
+      def tpt: TypeTree = reflectSelf.New_tpt(self)
     end extension
   end NewOps
 
-  given (using ctx: Context) as TypeTest[Tree, NamedArg] = reflectSelf.NamedArg_TypeTest
+  given  as TypeTest[Tree, NamedArg] = reflectSelf.NamedArg_TypeTest
 
   /** Scala named argument `x = y` in argument position */
   object NamedArg:
 
     /** Create a named argument `<name: String> = <value: Term>` */
-    def apply(name: String, arg: Term)(using ctx: Context): NamedArg =
+    def apply(name: String, arg: Term): NamedArg =
       reflectSelf.NamedArg_apply(name, arg)
 
-    def copy(original: Tree)(name: String, arg: Term)(using ctx: Context): NamedArg =
+    def copy(original: Tree)(name: String, arg: Term): NamedArg =
       reflectSelf.NamedArg_copy(original)(name, arg)
 
     /** Matches a named argument `<name: String> = <value: Term>` */
-    def unapply(x: NamedArg)(using ctx: Context): Option[(String, Term)] =
+    def unapply(x: NamedArg): Option[(String, Term)] =
       Some((x.name, x.value))
   end NamedArg
 
   given NamedArgOps as AnyRef:
     extension (self: NamedArg):
-      def name(using ctx: Context): String = reflectSelf.NamedArg_name(self)
-      def value(using ctx: Context): Term = reflectSelf.NamedArg_value(self)
+      def name: String = reflectSelf.NamedArg_name(self)
+      def value: Term = reflectSelf.NamedArg_value(self)
     end extension
   end NamedArgOps
 
-  given (using ctx: Context) as TypeTest[Tree, Apply] = reflectSelf.Apply_TypeTest
+  given TypeTest[Tree, Apply] = reflectSelf.Apply_TypeTest
 
   /** Scala parameter application */
   object Apply:
 
     /** Create a function application `<fun: Term>(<args: List[Term]>)` */
-    def apply(fun: Term, args: List[Term])(using ctx: Context): Apply =
+    def apply(fun: Term, args: List[Term]): Apply =
       reflectSelf.Apply_apply(fun, args)
 
-    def copy(original: Tree)(fun: Term, args: List[Term])(using ctx: Context): Apply =
+    def copy(original: Tree)(fun: Term, args: List[Term]): Apply =
       reflectSelf.Apply_copy(original)(fun, args)
 
     /** Matches a function application `<fun: Term>(<args: List[Term]>)` */
-    def unapply(x: Apply)(using ctx: Context): Option[(Term, List[Term])] =
+    def unapply(x: Apply): Option[(Term, List[Term])] =
       Some((x.fun, x.args))
   end Apply
 
   given ApplyOps as AnyRef:
     extension (self: Apply):
-      def fun(using ctx: Context): Term = reflectSelf.Apply_fun(self)
-      def args(using ctx: Context): List[Term] = reflectSelf.Apply_args(self)
+      def fun: Term = reflectSelf.Apply_fun(self)
+      def args: List[Term] = reflectSelf.Apply_args(self)
     end extension
   end ApplyOps
 
-  given (using ctx: Context) as TypeTest[Tree, TypeApply] = reflectSelf.TypeApply_TypeTest
+  given TypeTest[Tree, TypeApply] = reflectSelf.TypeApply_TypeTest
 
   /** Scala type parameter application */
   object TypeApply:
 
     /** Create a function type application `<fun: Term>[<args: List[TypeTree]>]` */
-    def apply(fun: Term, args: List[TypeTree])(using ctx: Context): TypeApply =
+    def apply(fun: Term, args: List[TypeTree]): TypeApply =
       reflectSelf.TypeApply_apply(fun, args)
 
-    def copy(original: Tree)(fun: Term, args: List[TypeTree])(using ctx: Context): TypeApply =
+    def copy(original: Tree)(fun: Term, args: List[TypeTree]): TypeApply =
       reflectSelf.TypeApply_copy(original)(fun, args)
 
     /** Matches a function type application `<fun: Term>[<args: List[TypeTree]>]` */
-    def unapply(x: TypeApply)(using ctx: Context): Option[(Term, List[TypeTree])] =
+    def unapply(x: TypeApply): Option[(Term, List[TypeTree])] =
       Some((x.fun, x.args))
   end TypeApply
 
   given TypeApplyOps as AnyRef:
     extension (self: TypeApply):
-      def fun(using ctx: Context): Term = reflectSelf.TypeApply_fun(self)
-      def args(using ctx: Context): List[TypeTree] = reflectSelf.TypeApply_args(self)
+      def fun: Term = reflectSelf.TypeApply_fun(self)
+      def args: List[TypeTree] = reflectSelf.TypeApply_args(self)
     end extension
   end TypeApplyOps
 
-  given (using ctx: Context) as TypeTest[Tree, Super] = reflectSelf.Super_TypeTest
+  given TypeTest[Tree, Super] = reflectSelf.Super_TypeTest
 
   /** Scala `x.super` or `x.super[id]` */
   object Super:
 
     /** Creates a `<qualifier: Term>.super[<id: Option[Id]>` */
-    def apply(qual: Term, mix: Option[Id])(using ctx: Context): Super =
+    def apply(qual: Term, mix: Option[Id]): Super =
       reflectSelf.Super_apply(qual, mix)
 
-    def copy(original: Tree)(qual: Term, mix: Option[Id])(using ctx: Context): Super =
+    def copy(original: Tree)(qual: Term, mix: Option[Id]): Super =
       reflectSelf.Super_copy(original)(qual, mix)
 
     /** Matches a `<qualifier: Term>.super[<id: Option[Id]>` */
-    def unapply(x: Super)(using ctx: Context): Option[(Term, Option[Id])] =
+    def unapply(x: Super): Option[(Term, Option[Id])] =
       Some((x.qualifier, x.id))
   end Super
 
   given SuperOps as AnyRef:
     extension (self: Super):
-      def qualifier(using ctx: Context): Term = reflectSelf.Super_qualifier(self)
-      def id(using ctx: Context): Option[Id] = reflectSelf.Super_id(self)
+      def qualifier: Term = reflectSelf.Super_qualifier(self)
+      def id: Option[Id] = reflectSelf.Super_id(self)
     end extension
   end SuperOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Typed] = reflectSelf.Typed_TypeTest
+  given TypeTest[Tree, Typed] = reflectSelf.Typed_TypeTest
 
   /** Scala ascription `x: T` */
   object Typed:
 
     /** Create a type ascription `<x: Term>: <tpt: TypeTree>` */
-    def apply(expr: Term, tpt: TypeTree)(using ctx: Context): Typed =
+    def apply(expr: Term, tpt: TypeTree): Typed =
       reflectSelf.Typed_apply(expr, tpt)
 
-    def copy(original: Tree)(expr: Term, tpt: TypeTree)(using ctx: Context): Typed =
+    def copy(original: Tree)(expr: Term, tpt: TypeTree): Typed =
       reflectSelf.Typed_copy(original)(expr, tpt)
 
     /** Matches `<expr: Term>: <tpt: TypeTree>` */
-    def unapply(x: Typed)(using ctx: Context): Option[(Term, TypeTree)] =
+    def unapply(x: Typed): Option[(Term, TypeTree)] =
       Some((x.expr, x.tpt))
   end Typed
 
   given TypedOps as AnyRef:
     extension (self: Typed):
-      def expr(using ctx: Context): Term = reflectSelf.Typed_expr(self)
-      def tpt(using ctx: Context): TypeTree = reflectSelf.Typed_tpt(self)
+      def expr: Term = reflectSelf.Typed_expr(self)
+      def tpt: TypeTree = reflectSelf.Typed_tpt(self)
     end extension
   end TypedOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Assign] = reflectSelf.Assign_TypeTest
+  given TypeTest[Tree, Assign] = reflectSelf.Assign_TypeTest
 
   /** Scala assign `x = y` */
   object Assign:
 
     /** Create an assignment `<lhs: Term> = <rhs: Term>` */
-    def apply(lhs: Term, rhs: Term)(using ctx: Context): Assign =
+    def apply(lhs: Term, rhs: Term): Assign =
       reflectSelf.Assign_apply(lhs, rhs)
 
-    def copy(original: Tree)(lhs: Term, rhs: Term)(using ctx: Context): Assign =
+    def copy(original: Tree)(lhs: Term, rhs: Term): Assign =
       reflectSelf.Assign_copy(original)(lhs, rhs)
 
     /** Matches an assignment `<lhs: Term> = <rhs: Term>` */
-    def unapply(x: Assign)(using ctx: Context): Option[(Term, Term)] =
+    def unapply(x: Assign): Option[(Term, Term)] =
       Some((x.lhs, x.rhs))
   end Assign
 
   given AssignOps as AnyRef:
     extension (self: Assign):
-      def lhs(using ctx: Context): Term = reflectSelf.Assign_lhs(self)
-      def rhs(using ctx: Context): Term = reflectSelf.Assign_rhs(self)
+      def lhs: Term = reflectSelf.Assign_lhs(self)
+      def rhs: Term = reflectSelf.Assign_rhs(self)
     end extension
   end AssignOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Block] = reflectSelf.Block_TypeTest
+  given TypeTest[Tree, Block] = reflectSelf.Block_TypeTest
 
   /** Scala code block `{ stat0; ...; statN; expr }` term */
   object Block:
 
     /** Creates a block `{ <statements: List[Statement]>; <expr: Term> }` */
-    def apply(stats: List[Statement], expr: Term)(using ctx: Context): Block =
+    def apply(stats: List[Statement], expr: Term): Block =
       reflectSelf.Block_apply(stats, expr)
 
-    def copy(original: Tree)(stats: List[Statement], expr: Term)(using ctx: Context): Block =
+    def copy(original: Tree)(stats: List[Statement], expr: Term): Block =
       reflectSelf.Block_copy(original)(stats, expr)
 
     /** Matches a block `{ <statements: List[Statement]>; <expr: Term> }` */
-    def unapply(x: Block)(using ctx: Context): Option[(List[Statement], Term)] =
+    def unapply(x: Block): Option[(List[Statement], Term)] =
       Some((x.statements, x.expr))
   end Block
 
   given BlockOps as AnyRef:
     extension (self: Block):
-      def statements(using ctx: Context): List[Statement] = reflectSelf.Block_statements(self)
-      def expr(using ctx: Context): Term = reflectSelf.Block_expr(self)
+      def statements: List[Statement] = reflectSelf.Block_statements(self)
+      def expr: Term = reflectSelf.Block_expr(self)
     end extension
   end BlockOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Closure] = reflectSelf.Closure_TypeTest
+  given TypeTest[Tree, Closure] = reflectSelf.Closure_TypeTest
 
   object Closure:
 
-    def apply(meth: Term, tpt: Option[Type])(using ctx: Context): Closure =
+    def apply(meth: Term, tpt: Option[Type]): Closure =
       reflectSelf.Closure_apply(meth, tpt)
 
-    def copy(original: Tree)(meth: Tree, tpt: Option[Type])(using ctx: Context): Closure =
+    def copy(original: Tree)(meth: Tree, tpt: Option[Type]): Closure =
       reflectSelf.Closure_copy(original)(meth, tpt)
 
-    def unapply(x: Closure)(using ctx: Context): Option[(Term, Option[Type])] =
+    def unapply(x: Closure): Option[(Term, Option[Type])] =
       Some((x.meth, x.tpeOpt))
   end Closure
 
   given ClosureOps as AnyRef:
     extension (self: Closure):
-      def meth(using ctx: Context): Term = reflectSelf.Closure_meth(self)
-      def tpeOpt(using ctx: Context): Option[Type] = reflectSelf.Closure_tpeOpt(self)
+      def meth: Term = reflectSelf.Closure_meth(self)
+      def tpeOpt: Option[Type] = reflectSelf.Closure_tpeOpt(self)
     end extension
   end ClosureOps
 
@@ -682,7 +682,7 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
    *        of `Lambda`.
    */
   object Lambda:
-    def unapply(tree: Block)(using ctx: Context): Option[(List[ValDef], Term)] = tree match {
+    def unapply(tree: Block): Option[(List[ValDef], Term)] = tree match {
       case Block((ddef @ DefDef(_, _, params :: Nil, _, Some(body))) :: Nil, Closure(meth, _))
       if ddef.symbol == meth.symbol =>
         Some(params, body)
@@ -690,602 +690,602 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
       case _ => None
     }
 
-    def apply(tpe: MethodType, rhsFn: List[Tree] => Tree)(using ctx: Context): Block =
+    def apply(tpe: MethodType, rhsFn: List[Tree] => Tree): Block =
       reflectSelf.Lambda_apply(tpe, rhsFn)
 
   end Lambda
 
-  given (using ctx: Context) as TypeTest[Tree, If] = reflectSelf.If_TypeTest
+  given  TypeTest[Tree, If] = reflectSelf.If_TypeTest
 
   /** Scala `if`/`else` term */
   object If:
 
     /** Create an if/then/else `if (<cond: Term>) <thenp: Term> else <elsep: Term>` */
-    def apply(cond: Term, thenp: Term, elsep: Term)(using ctx: Context): If =
+    def apply(cond: Term, thenp: Term, elsep: Term): If =
       reflectSelf.If_apply(cond, thenp, elsep)
 
-    def copy(original: Tree)(cond: Term, thenp: Term, elsep: Term)(using ctx: Context): If =
+    def copy(original: Tree)(cond: Term, thenp: Term, elsep: Term): If =
       reflectSelf.If_copy(original)(cond, thenp, elsep)
 
     /** Matches an if/then/else `if (<cond: Term>) <thenp: Term> else <elsep: Term>` */
-    def unapply(tree: If)(using ctx: Context): Option[(Term, Term, Term)] =
+    def unapply(tree: If): Option[(Term, Term, Term)] =
       Some((tree.cond, tree.thenp, tree.elsep))
   end If
 
   given IfOps as AnyRef:
     extension (self: If):
-      def cond(using ctx: Context): Term = reflectSelf.If_cond(self)
-      def thenp(using ctx: Context): Term = reflectSelf.If_thenp(self)
-      def elsep(using ctx: Context): Term = reflectSelf.If_elsep(self)
+      def cond: Term = reflectSelf.If_cond(self)
+      def thenp: Term = reflectSelf.If_thenp(self)
+      def elsep: Term = reflectSelf.If_elsep(self)
     end extension
   end IfOps
 
-  given (using ctx: Context) as TypeTest[Tree, Match] = reflectSelf.Match_TypeTest
+  given TypeTest[Tree, Match] = reflectSelf.Match_TypeTest
 
   /** Scala `match` term */
   object Match:
 
     /** Creates a pattern match `<scrutinee: Term> match { <cases: List[CaseDef]> }` */
-    def apply(selector: Term, cases: List[CaseDef])(using ctx: Context): Match =
+    def apply(selector: Term, cases: List[CaseDef]): Match =
       reflectSelf.Match_apply(selector, cases)
 
-    def copy(original: Tree)(selector: Term, cases: List[CaseDef])(using ctx: Context): Match =
+    def copy(original: Tree)(selector: Term, cases: List[CaseDef]): Match =
       reflectSelf.Match_copy(original)(selector, cases)
 
     /** Matches a pattern match `<scrutinee: Term> match { <cases: List[CaseDef]> }` */
-    def unapply(x: Match)(using ctx: Context): Option[(Term, List[CaseDef])] =
+    def unapply(x: Match): Option[(Term, List[CaseDef])] =
       Some((x.scrutinee, x.cases))
   end Match
 
   given MatchOps as AnyRef:
     extension (self: Match):
-      def scrutinee(using ctx: Context): Term = reflectSelf.Match_scrutinee(self)
-      def cases(using ctx: Context): List[CaseDef] = reflectSelf.Match_cases(self)
+      def scrutinee: Term = reflectSelf.Match_scrutinee(self)
+      def cases: List[CaseDef] = reflectSelf.Match_cases(self)
     end extension
   end MatchOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, GivenMatch] = reflectSelf.GivenMatch_TypeTest
+  given TypeTest[Tree, GivenMatch] = reflectSelf.GivenMatch_TypeTest
 
   /** Scala implicit `match` term */
   object GivenMatch:
 
     /** Creates a pattern match `given match { <cases: List[CaseDef]> }` */
-    def apply(cases: List[CaseDef])(using ctx: Context): GivenMatch =
+    def apply(cases: List[CaseDef]): GivenMatch =
       reflectSelf.GivenMatch_apply(cases)
 
-    def copy(original: Tree)(cases: List[CaseDef])(using ctx: Context): GivenMatch =
+    def copy(original: Tree)(cases: List[CaseDef]): GivenMatch =
       reflectSelf.GivenMatch_copy(original)(cases)
 
     /** Matches a pattern match `given match { <cases: List[CaseDef]> }` */
-    def unapply(x: GivenMatch)(using ctx: Context): Option[List[CaseDef]] = Some(x.cases)
+    def unapply(x: GivenMatch): Option[List[CaseDef]] = Some(x.cases)
   end GivenMatch
 
   given GivenMatchOps as AnyRef:
     extension (self: GivenMatch):
-      def cases(using ctx: Context): List[CaseDef] = reflectSelf.GivenMatch_cases(self)
+      def cases: List[CaseDef] = reflectSelf.GivenMatch_cases(self)
     end extension
   end GivenMatchOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Try] = reflectSelf.Try_TypeTest
+  given TypeTest[Tree, Try] = reflectSelf.Try_TypeTest
 
   /** Scala `try`/`catch`/`finally` term */
   object Try:
 
     /** Create a try/catch `try <body: Term> catch { <cases: List[CaseDef]> } finally <finalizer: Option[Term]>` */
-    def apply(expr: Term, cases: List[CaseDef], finalizer: Option[Term])(using ctx: Context): Try =
+    def apply(expr: Term, cases: List[CaseDef], finalizer: Option[Term]): Try =
       reflectSelf.Try_apply(expr, cases, finalizer)
 
-    def copy(original: Tree)(expr: Term, cases: List[CaseDef], finalizer: Option[Term])(using ctx: Context): Try =
+    def copy(original: Tree)(expr: Term, cases: List[CaseDef], finalizer: Option[Term]): Try =
       reflectSelf.Try_copy(original)(expr, cases, finalizer)
 
     /** Matches a try/catch `try <body: Term> catch { <cases: List[CaseDef]> } finally <finalizer: Option[Term]>` */
-    def unapply(x: Try)(using ctx: Context): Option[(Term, List[CaseDef], Option[Term])] =
+    def unapply(x: Try): Option[(Term, List[CaseDef], Option[Term])] =
       Some((x.body, x.cases, x.finalizer))
   end Try
 
   given TryOps as AnyRef:
     extension (self: Try):
-      def body(using ctx: Context): Term = reflectSelf.Try_body(self)
-      def cases(using ctx: Context): List[CaseDef] = reflectSelf.Try_cases(self)
-      def finalizer(using ctx: Context): Option[Term] = reflectSelf.Try_finalizer(self)
+      def body: Term = reflectSelf.Try_body(self)
+      def cases: List[CaseDef] = reflectSelf.Try_cases(self)
+      def finalizer: Option[Term] = reflectSelf.Try_finalizer(self)
     end extension
   end TryOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Return] = reflectSelf.Return_TypeTest
+  given TypeTest[Tree, Return] = reflectSelf.Return_TypeTest
 
   /** Scala local `return` */
   object Return:
 
     /** Creates `return <expr: Term>` */
-    def apply(expr: Term)(using ctx: Context): Return =
+    def apply(expr: Term): Return =
       reflectSelf.Return_apply(expr)
 
-    def copy(original: Tree)(expr: Term)(using ctx: Context): Return =
+    def copy(original: Tree)(expr: Term): Return =
       reflectSelf.Return_copy(original)(expr)
 
     /** Matches `return <expr: Term>` */
-    def unapply(x: Return)(using ctx: Context): Option[Term] = Some(x.expr)
+    def unapply(x: Return): Option[Term] = Some(x.expr)
   end Return
 
   given ReturnOps as AnyRef:
     extension (self: Return):
-      def expr(using ctx: Context): Term = reflectSelf.Return_expr(self)
+      def expr: Term = reflectSelf.Return_expr(self)
     end extension
   end ReturnOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Repeated] = reflectSelf.Repeated_TypeTest
+  given TypeTest[Tree, Repeated] = reflectSelf.Repeated_TypeTest
 
   object Repeated:
 
-    def apply(elems: List[Term], tpt: TypeTree)(using ctx: Context): Repeated =
+    def apply(elems: List[Term], tpt: TypeTree): Repeated =
       reflectSelf.Repeated_apply(elems, tpt)
 
-    def copy(original: Tree)(elems: List[Term], tpt: TypeTree)(using ctx: Context): Repeated =
+    def copy(original: Tree)(elems: List[Term], tpt: TypeTree): Repeated =
       reflectSelf.Repeated_copy(original)(elems, tpt)
 
-    def unapply(x: Repeated)(using ctx: Context): Option[(List[Term], TypeTree)] =
+    def unapply(x: Repeated): Option[(List[Term], TypeTree)] =
       Some((x.elems, x.elemtpt))
   end Repeated
 
   given RepeatedOps as AnyRef:
     extension (self: Repeated):
-      def elems(using ctx: Context): List[Term] = reflectSelf.Repeated_elems(self)
-      def elemtpt(using ctx: Context): TypeTree = reflectSelf.Repeated_elemtpt(self)
+      def elems: List[Term] = reflectSelf.Repeated_elems(self)
+      def elemtpt: TypeTree = reflectSelf.Repeated_elemtpt(self)
     end extension
   end RepeatedOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Inlined] = reflectSelf.Inlined_TypeTest
+  given TypeTest[Tree, Inlined] = reflectSelf.Inlined_TypeTest
 
   object Inlined:
 
-    def apply(call: Option[Tree /* Term | TypeTree */], bindings: List[Definition], expansion: Term)(using ctx: Context): Inlined =
+    def apply(call: Option[Tree /* Term | TypeTree */], bindings: List[Definition], expansion: Term): Inlined =
       reflectSelf.Inlined_apply(call, bindings, expansion)
 
-    def copy(original: Tree)(call: Option[Tree /* Term | TypeTree */], bindings: List[Definition], expansion: Term)(using ctx: Context): Inlined =
+    def copy(original: Tree)(call: Option[Tree /* Term | TypeTree */], bindings: List[Definition], expansion: Term): Inlined =
       reflectSelf.Inlined_copy(original)(call, bindings, expansion)
 
-    def unapply(x: Inlined)(using ctx: Context): Option[(Option[Tree /* Term | TypeTree */], List[Definition], Term)] =
+    def unapply(x: Inlined): Option[(Option[Tree /* Term | TypeTree */], List[Definition], Term)] =
       Some((x.call, x.bindings, x.body))
   end Inlined
 
   given InlinedOps as AnyRef:
     extension (self: Inlined):
-      def call(using ctx: Context): Option[Tree /* Term | TypeTree */] = reflectSelf.Inlined_call(self)
-      def bindings(using ctx: Context): List[Definition] = reflectSelf.Inlined_bindings(self)
-      def body(using ctx: Context): Term = reflectSelf.Inlined_body(self)
+      def call: Option[Tree /* Term | TypeTree */] = reflectSelf.Inlined_call(self)
+      def bindings: List[Definition] = reflectSelf.Inlined_bindings(self)
+      def body: Term = reflectSelf.Inlined_body(self)
     end extension
   end InlinedOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, SelectOuter] = reflectSelf.SelectOuter_TypeTest
+  given TypeTest[Tree, SelectOuter] = reflectSelf.SelectOuter_TypeTest
 
   object SelectOuter:
 
-    def apply(qualifier: Term, name: String, levels: Int)(using ctx: Context): SelectOuter =
+    def apply(qualifier: Term, name: String, levels: Int): SelectOuter =
       reflectSelf.SelectOuter_apply(qualifier, name, levels)
 
-    def copy(original: Tree)(qualifier: Term, name: String, levels: Int)(using ctx: Context): SelectOuter =
+    def copy(original: Tree)(qualifier: Term, name: String, levels: Int): SelectOuter =
       reflectSelf.SelectOuter_copy(original)(qualifier, name, levels)
 
-    def unapply(x: SelectOuter)(using ctx: Context): Option[(Term, Int, Type)] = // TODO homogenize order of parameters
+    def unapply(x: SelectOuter): Option[(Term, Int, Type)] = // TODO homogenize order of parameters
       Some((x.qualifier, x.level, x.tpe))
   end SelectOuter
 
   given SelectOuterOps as AnyRef:
     extension (self: SelectOuter):
-      def qualifier(using ctx: Context): Term = reflectSelf.SelectOuter_qualifier(self)
-      def level(using ctx: Context): Int = reflectSelf.SelectOuter_level(self)
+      def qualifier: Term = reflectSelf.SelectOuter_qualifier(self)
+      def level: Int = reflectSelf.SelectOuter_level(self)
     end extension
   end SelectOuterOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, While] = reflectSelf.While_TypeTest
+  given TypeTest[Tree, While] = reflectSelf.While_TypeTest
 
   object While:
 
     /** Creates a while loop `while (<cond>) <body>` and returns (<cond>, <body>) */
-    def apply(cond: Term, body: Term)(using ctx: Context): While =
+    def apply(cond: Term, body: Term): While =
       reflectSelf.While_apply(cond, body)
 
-    def copy(original: Tree)(cond: Term, body: Term)(using ctx: Context): While =
+    def copy(original: Tree)(cond: Term, body: Term): While =
       reflectSelf.While_copy(original)(cond, body)
 
     /** Extractor for while loops. Matches `while (<cond>) <body>` and returns (<cond>, <body>) */
-    def unapply(x: While)(using ctx: Context): Option[(Term, Term)] =
+    def unapply(x: While): Option[(Term, Term)] =
       Some((x.cond, x.body))
   end While
 
   given WhileOps as AnyRef:
     extension (self: While):
-      def cond(using ctx: Context): Term = reflectSelf.While_cond(self)
-      def body(using ctx: Context): Term = reflectSelf.While_body(self)
+      def cond: Term = reflectSelf.While_cond(self)
+      def body: Term = reflectSelf.While_body(self)
     end extension
   end WhileOps
 
 
   // ----- TypeTrees ------------------------------------------------
 
-  given (using ctx: Context) as TypeTest[Tree, TypeTree] = reflectSelf.TypeTree_TypeTest
+  given TypeTest[Tree, TypeTree] = reflectSelf.TypeTree_TypeTest
 
   object TypeTree
 
   given TypeTreeOps as AnyRef:
     extension (self: TypeTree):
       /** Type of this type tree */
-      def tpe(using ctx: Context): Type = reflectSelf.TypeTree_tpe(self)
+      def tpe: Type = reflectSelf.TypeTree_tpe(self)
     end extension
   end TypeTreeOps
 
-  given (using ctx: Context) as TypeTest[Tree, Inferred] = reflectSelf.Inferred_TypeTest
+  given TypeTest[Tree, Inferred] = reflectSelf.Inferred_TypeTest
 
   /** TypeTree containing an inferred type */
   object Inferred:
-    def apply(tpe: Type)(using ctx: Context): Inferred =
+    def apply(tpe: Type): Inferred =
       reflectSelf.Inferred_apply(tpe)
     /** Matches a TypeTree containing an inferred type */
-    def unapply(x: Inferred)(using ctx: Context): Boolean = true
+    def unapply(x: Inferred): Boolean = true
   end Inferred
 
-  given (using ctx: Context) as TypeTest[Tree, TypeIdent] = reflectSelf.TypeIdent_TypeTest
+  given TypeTest[Tree, TypeIdent] = reflectSelf.TypeIdent_TypeTest
 
   object TypeIdent:
-    def apply(sym: Symbol)(using ctx: Context): TypeTree =
+    def apply(sym: Symbol): TypeTree =
       reflectSelf.TypeRef_apply(sym)
-    def copy(original: Tree)(name: String)(using ctx: Context): TypeIdent =
+    def copy(original: Tree)(name: String): TypeIdent =
       reflectSelf.TypeIdent_copy(original)(name)
-    def unapply(x: TypeIdent)(using ctx: Context): Option[String] = Some(x.name)
+    def unapply(x: TypeIdent): Option[String] = Some(x.name)
   end TypeIdent
 
   given TypeIdentOps as AnyRef:
     extension (self: TypeIdent):
-      def name(using ctx: Context): String = reflectSelf.TypeIdent_name(self)
+      def name: String = reflectSelf.TypeIdent_name(self)
     end extension
   end TypeIdentOps
 
-  given (using ctx: Context) as TypeTest[Tree, TypeSelect] = reflectSelf.TypeSelect_TypeTest
+  given TypeTest[Tree, TypeSelect] = reflectSelf.TypeSelect_TypeTest
 
   object TypeSelect:
-    def apply(qualifier: Term, name: String)(using ctx: Context): TypeSelect =
+    def apply(qualifier: Term, name: String): TypeSelect =
       reflectSelf.TypeSelect_apply(qualifier, name)
-    def copy(original: Tree)(qualifier: Term, name: String)(using ctx: Context): TypeSelect =
+    def copy(original: Tree)(qualifier: Term, name: String): TypeSelect =
       reflectSelf.TypeSelect_copy(original)(qualifier, name)
-    def unapply(x: TypeSelect)(using ctx: Context): Option[(Term, String)] =
+    def unapply(x: TypeSelect): Option[(Term, String)] =
       Some((x.qualifier, x.name))
   end TypeSelect
 
   given TypeSelectOps as AnyRef:
     extension (self: TypeSelect):
-      def qualifier(using ctx: Context): Term = reflectSelf.TypeSelect_qualifier(self)
-      def name(using ctx: Context): String = reflectSelf.TypeSelect_name(self)
+      def qualifier: Term = reflectSelf.TypeSelect_qualifier(self)
+      def name: String = reflectSelf.TypeSelect_name(self)
     end extension
   end TypeSelectOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Projection] = reflectSelf.Projection_TypeTest
+  given TypeTest[Tree, Projection] = reflectSelf.Projection_TypeTest
 
   object Projection:
-    // TODO def apply(qualifier: TypeTree, name: String)(using ctx: Context): Project
-    def copy(original: Tree)(qualifier: TypeTree, name: String)(using ctx: Context): Projection =
+    // TODO def apply(qualifier: TypeTree, name: String): Project
+    def copy(original: Tree)(qualifier: TypeTree, name: String): Projection =
       reflectSelf.Projection_copy(original)(qualifier, name)
-    def unapply(x: Projection)(using ctx: Context): Option[(TypeTree, String)] =
+    def unapply(x: Projection): Option[(TypeTree, String)] =
       Some((x.qualifier, x.name))
   end Projection
 
   given ProjectionOps as AnyRef:
     extension (self: Projection):
-      def qualifier(using ctx: Context): TypeTree = reflectSelf.Projection_qualifier(self)
-      def name(using ctx: Context): String = reflectSelf.Projection_name(self)
+      def qualifier: TypeTree = reflectSelf.Projection_qualifier(self)
+      def name: String = reflectSelf.Projection_name(self)
     end extension
   end ProjectionOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Singleton] = reflectSelf.Singleton_TypeTest
+  given TypeTest[Tree, Singleton] = reflectSelf.Singleton_TypeTest
 
   object Singleton:
-    def apply(ref: Term)(using ctx: Context): Singleton =
+    def apply(ref: Term): Singleton =
       reflectSelf.Singleton_apply(ref)
-    def copy(original: Tree)(ref: Term)(using ctx: Context): Singleton =
+    def copy(original: Tree)(ref: Term): Singleton =
       reflectSelf.Singleton_copy(original)(ref)
-    def unapply(x: Singleton)(using ctx: Context): Option[Term] =
+    def unapply(x: Singleton): Option[Term] =
       Some(x.ref)
   end Singleton
 
   given SingletonOps as AnyRef:
     extension (self: Singleton):
-      def ref(using ctx: Context): Term = reflectSelf.Singleton_ref(self)
+      def ref: Term = reflectSelf.Singleton_ref(self)
     end extension
   end SingletonOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Refined] = reflectSelf.Refined_TypeTest
+  given TypeTest[Tree, Refined] = reflectSelf.Refined_TypeTest
 
   object Refined:
-    // TODO def apply(tpt: TypeTree, refinements: List[Definition])(using ctx: Context): Refined
-    def copy(original: Tree)(tpt: TypeTree, refinements: List[Definition])(using ctx: Context): Refined =
+    // TODO def apply(tpt: TypeTree, refinements: List[Definition]): Refined
+    def copy(original: Tree)(tpt: TypeTree, refinements: List[Definition]): Refined =
       reflectSelf.Refined_copy(original)(tpt, refinements)
-    def unapply(x: Refined)(using ctx: Context): Option[(TypeTree, List[Definition])] =
+    def unapply(x: Refined): Option[(TypeTree, List[Definition])] =
       Some((x.tpt, x.refinements))
   end Refined
 
   given RefinedOps as AnyRef:
     extension (self: Refined):
-      def tpt(using ctx: Context): TypeTree = reflectSelf.Refined_tpt(self)
-      def refinements(using ctx: Context): List[Definition] = reflectSelf.Refined_refinements(self)
+      def tpt: TypeTree = reflectSelf.Refined_tpt(self)
+      def refinements: List[Definition] = reflectSelf.Refined_refinements(self)
     end extension
   end RefinedOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Applied] = reflectSelf.Applied_TypeTest
+  given TypeTest[Tree, Applied] = reflectSelf.Applied_TypeTest
 
   object Applied:
-    def apply(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/])(using ctx: Context): Applied =
+    def apply(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/]): Applied =
       reflectSelf.Applied_apply(tpt, args)
-    def copy(original: Tree)(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/])(using ctx: Context): Applied =
+    def copy(original: Tree)(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/]): Applied =
       reflectSelf.Applied_copy(original)(tpt, args)
-    def unapply(x: Applied)(using ctx: Context): Option[(TypeTree, List[Tree /*TypeTree | TypeBoundsTree*/])] =
+    def unapply(x: Applied): Option[(TypeTree, List[Tree /*TypeTree | TypeBoundsTree*/])] =
       Some((x.tpt, x.args))
   end Applied
 
   given AppliedOps as AnyRef:
     extension (self: Applied):
-      def tpt(using ctx: Context): TypeTree = reflectSelf.Applied_tpt(self)
-      def args(using ctx: Context): List[Tree /*TypeTree | TypeBoundsTree*/] = reflectSelf.Applied_args(self)
+      def tpt: TypeTree = reflectSelf.Applied_tpt(self)
+      def args: List[Tree /*TypeTree | TypeBoundsTree*/] = reflectSelf.Applied_args(self)
     end extension
   end AppliedOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Annotated] =
+  given TypeTest[Tree, Annotated] =
     reflectSelf.Annotated_TypeTest
 
   object Annotated:
-    def apply(arg: TypeTree, annotation: Term)(using ctx: Context): Annotated =
+    def apply(arg: TypeTree, annotation: Term): Annotated =
       reflectSelf.Annotated_apply(arg, annotation)
-    def copy(original: Tree)(arg: TypeTree, annotation: Term)(using ctx: Context): Annotated =
+    def copy(original: Tree)(arg: TypeTree, annotation: Term): Annotated =
       reflectSelf.Annotated_copy(original)(arg, annotation)
-    def unapply(x: Annotated)(using ctx: Context): Option[(TypeTree, Term)] =
+    def unapply(x: Annotated): Option[(TypeTree, Term)] =
       Some((x.arg, x.annotation))
   end Annotated
 
   given AnnotatedOps as AnyRef:
     extension (self: Annotated):
-      def arg(using ctx: Context): TypeTree = reflectSelf.Annotated_arg(self)
-      def annotation(using ctx: Context): Term = reflectSelf.Annotated_annotation(self)
+      def arg: TypeTree = reflectSelf.Annotated_arg(self)
+      def annotation: Term = reflectSelf.Annotated_annotation(self)
     end extension
   end AnnotatedOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, MatchTypeTree] =
+  given  as TypeTest[Tree, MatchTypeTree] =
     reflectSelf.MatchTypeTree_TypeTest
 
   object MatchTypeTree:
-    def apply(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef])(using ctx: Context): MatchTypeTree =
+    def apply(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef]): MatchTypeTree =
       reflectSelf.MatchTypeTree_apply(bound, selector, cases)
-    def copy(original: Tree)(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef])(using ctx: Context): MatchTypeTree =
+    def copy(original: Tree)(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef]): MatchTypeTree =
       reflectSelf.MatchTypeTree_copy(original)(bound, selector, cases)
-    def unapply(x: MatchTypeTree)(using ctx: Context): Option[(Option[TypeTree], TypeTree, List[TypeCaseDef])] =
+    def unapply(x: MatchTypeTree): Option[(Option[TypeTree], TypeTree, List[TypeCaseDef])] =
       Some((x.bound, x.selector, x.cases))
   end MatchTypeTree
 
   given MatchTypeTreeOps as AnyRef:
     extension (self: MatchTypeTree):
-      def bound(using ctx: Context): Option[TypeTree] = reflectSelf.MatchTypeTree_bound(self)
-      def selector(using ctx: Context): TypeTree = reflectSelf.MatchTypeTree_selector(self)
-      def cases(using ctx: Context): List[TypeCaseDef] = reflectSelf.MatchTypeTree_cases(self)
+      def bound: Option[TypeTree] = reflectSelf.MatchTypeTree_bound(self)
+      def selector: TypeTree = reflectSelf.MatchTypeTree_selector(self)
+      def cases: List[TypeCaseDef] = reflectSelf.MatchTypeTree_cases(self)
     end extension
   end MatchTypeTreeOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, ByName] =
+  given TypeTest[Tree, ByName] =
     reflectSelf.ByName_TypeTest
 
   object ByName:
-    def apply(result: TypeTree)(using ctx: Context): ByName =
+    def apply(result: TypeTree): ByName =
       reflectSelf.ByName_apply(result)
-    def copy(original: Tree)(result: TypeTree)(using ctx: Context): ByName =
+    def copy(original: Tree)(result: TypeTree): ByName =
       reflectSelf.ByName_copy(original)(result)
-    def unapply(x: ByName)(using ctx: Context): Option[TypeTree] =
+    def unapply(x: ByName): Option[TypeTree] =
       Some(x.result)
   end ByName
 
   given ByNameOps as AnyRef:
     extension (self: ByName):
-      def result(using ctx: Context): TypeTree = reflectSelf.ByName_result(self)
+      def result: TypeTree = reflectSelf.ByName_result(self)
     end extension
   end ByNameOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, LambdaTypeTree] = reflectSelf.LambdaTypeTree_TypeTest
+  given TypeTest[Tree, LambdaTypeTree] = reflectSelf.LambdaTypeTree_TypeTest
 
   object LambdaTypeTree:
-    def apply(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/)(using ctx: Context): LambdaTypeTree =
+    def apply(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/): LambdaTypeTree =
       reflectSelf.Lambdaapply(tparams, body)
-    def copy(original: Tree)(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/)(using ctx: Context): LambdaTypeTree =
+    def copy(original: Tree)(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/): LambdaTypeTree =
       reflectSelf.Lambdacopy(original)(tparams, body)
-    def unapply(tree: LambdaTypeTree)(using ctx: Context): Option[(List[TypeDef], Tree /*TypeTree | TypeBoundsTree*/)] =
+    def unapply(tree: LambdaTypeTree): Option[(List[TypeDef], Tree /*TypeTree | TypeBoundsTree*/)] =
       Some((tree.tparams, tree.body))
   end LambdaTypeTree
 
   given LambdaTypeTreeOps as AnyRef:
     extension (self: LambdaTypeTree):
-      def tparams(using ctx: Context): List[TypeDef] = reflectSelf.Lambdatparams(self)
-      def body(using ctx: Context): Tree /*TypeTree | TypeBoundsTree*/ = reflectSelf.Lambdabody(self)
+      def tparams: List[TypeDef] = reflectSelf.Lambdatparams(self)
+      def body: Tree /*TypeTree | TypeBoundsTree*/ = reflectSelf.Lambdabody(self)
     end extension
   end LambdaTypeTreeOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, TypeBind] = reflectSelf.TypeBind_TypeTest
+  given TypeTest[Tree, TypeBind] = reflectSelf.TypeBind_TypeTest
 
   object TypeBind:
-    // TODO def apply(name: String, tree: Tree)(using ctx: Context): TypeBind
-    def copy(original: Tree)(name: String, tpt: Tree /*TypeTree | TypeBoundsTree*/)(using ctx: Context): TypeBind =
+    // TODO def apply(name: String, tree: Tree): TypeBind
+    def copy(original: Tree)(name: String, tpt: Tree /*TypeTree | TypeBoundsTree*/): TypeBind =
       reflectSelf.TypeBind_copy(original)(name, tpt)
-    def unapply(x: TypeBind)(using ctx: Context): Option[(String, Tree /*TypeTree | TypeBoundsTree*/)] =
+    def unapply(x: TypeBind): Option[(String, Tree /*TypeTree | TypeBoundsTree*/)] =
       Some((x.name, x.body))
   end TypeBind
 
   given TypeBindOps as AnyRef:
     extension (self: TypeBind):
-      def name(using ctx: Context): String = reflectSelf.TypeBind_name(self)
-      def body(using ctx: Context): Tree /*TypeTree | TypeBoundsTree*/ = reflectSelf.TypeBind_body(self)
+      def name: String = reflectSelf.TypeBind_name(self)
+      def body: Tree /*TypeTree | TypeBoundsTree*/ = reflectSelf.TypeBind_body(self)
     end extension
   end TypeBindOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, TypeBlock] = reflectSelf.TypeBlock_TypeTest
+  given TypeTest[Tree, TypeBlock] = reflectSelf.TypeBlock_TypeTest
 
   object TypeBlock:
-    def apply(aliases: List[TypeDef], tpt: TypeTree)(using ctx: Context): TypeBlock =
+    def apply(aliases: List[TypeDef], tpt: TypeTree): TypeBlock =
       reflectSelf.TypeBlock_apply(aliases, tpt)
-    def copy(original: Tree)(aliases: List[TypeDef], tpt: TypeTree)(using ctx: Context): TypeBlock =
+    def copy(original: Tree)(aliases: List[TypeDef], tpt: TypeTree): TypeBlock =
       reflectSelf.TypeBlock_copy(original)(aliases, tpt)
-    def unapply(x: TypeBlock)(using ctx: Context): Option[(List[TypeDef], TypeTree)] =
+    def unapply(x: TypeBlock): Option[(List[TypeDef], TypeTree)] =
       Some((x.aliases, x.tpt))
   end TypeBlock
 
   given TypeBlockOps as AnyRef:
     extension (self: TypeBlock):
-      def aliases(using ctx: Context): List[TypeDef] = reflectSelf.TypeBlock_aliases(self)
-      def tpt(using ctx: Context): TypeTree = reflectSelf.TypeBlock_tpt(self)
+      def aliases: List[TypeDef] = reflectSelf.TypeBlock_aliases(self)
+      def tpt: TypeTree = reflectSelf.TypeBlock_tpt(self)
     end extension
   end TypeBlockOps
 
 
   // ----- TypeBoundsTrees ------------------------------------------------
 
-  given (using ctx: Context) as TypeTest[Tree, TypeBoundsTree] = reflectSelf.TypeBoundsTree_TypeTest
+  given TypeTest[Tree, TypeBoundsTree] = reflectSelf.TypeBoundsTree_TypeTest
 
   object TypeBoundsTree:
-    def unapply(x: TypeBoundsTree)(using ctx: Context): Option[(TypeTree, TypeTree)] =
+    def unapply(x: TypeBoundsTree): Option[(TypeTree, TypeTree)] =
       Some((x.low, x.hi))
   end TypeBoundsTree
 
   given TypeBoundsTreeOps as AnyRef:
     extension (self: TypeBoundsTree):
-      def tpe(using ctx: Context): TypeBounds = reflectSelf.TypeBoundsTree_tpe(self)
-      def low(using ctx: Context): TypeTree = reflectSelf.TypeBoundsTree_low(self)
-      def hi(using ctx: Context): TypeTree = reflectSelf.TypeBoundsTree_hi(self)
+      def tpe: TypeBounds = reflectSelf.TypeBoundsTree_tpe(self)
+      def low: TypeTree = reflectSelf.TypeBoundsTree_low(self)
+      def hi: TypeTree = reflectSelf.TypeBoundsTree_hi(self)
     end extension
   end TypeBoundsTreeOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, WildcardTypeTree] = reflectSelf.WildcardTypeTree_TypeTest
+  given TypeTest[Tree, WildcardTypeTree] = reflectSelf.WildcardTypeTree_TypeTest
 
   object WildcardTypeTree:
     /** Matches a TypeBoundsTree containing wildcard type bounds */
-    def unapply(x: WildcardTypeTree)(using ctx: Context): Boolean = true
+    def unapply(x: WildcardTypeTree): Boolean = true
   end WildcardTypeTree
 
   given WildcardTypeTreeOps as AnyRef:
     extension (self: WildcardTypeTree):
-      def tpe(using ctx: Context): Type = reflectSelf.WildcardTypeTree_tpe(self)
+      def tpe: Type = reflectSelf.WildcardTypeTree_tpe(self)
     end extension
   end WildcardTypeTreeOps
 
   // ----- CaseDefs ------------------------------------------------
 
-  given (using ctx: Context) as TypeTest[Tree, CaseDef] = reflectSelf.CaseDef_TypeTest
+  given TypeTest[Tree, CaseDef] = reflectSelf.CaseDef_TypeTest
 
   object CaseDef:
-    def apply(pattern: Tree, guard: Option[Term], rhs: Term)(using ctx: Context): CaseDef =
+    def apply(pattern: Tree, guard: Option[Term], rhs: Term): CaseDef =
       reflectSelf.CaseDef_module_apply(pattern, guard, rhs)
 
-    def copy(original: Tree)(pattern: Tree, guard: Option[Term], rhs: Term)(using ctx: Context): CaseDef =
+    def copy(original: Tree)(pattern: Tree, guard: Option[Term], rhs: Term): CaseDef =
       reflectSelf.CaseDef_module_copy(original)(pattern, guard, rhs)
 
-    def unapply(x: CaseDef)(using ctx: Context): Option[(Tree, Option[Term], Term)] =
+    def unapply(x: CaseDef): Option[(Tree, Option[Term], Term)] =
       Some((x.pattern, x.guard, x.rhs))
   end CaseDef
 
   given CaseDefOps as AnyRef:
     extension (caseDef: CaseDef):
-      def pattern(using ctx: Context): Tree = reflectSelf.CaseDef_pattern(caseDef)
-      def guard(using ctx: Context): Option[Term] = reflectSelf.CaseDef_guard(caseDef)
-      def rhs(using ctx: Context): Term = reflectSelf.CaseDef_rhs(caseDef)
+      def pattern: Tree = reflectSelf.CaseDef_pattern(caseDef)
+      def guard: Option[Term] = reflectSelf.CaseDef_guard(caseDef)
+      def rhs: Term = reflectSelf.CaseDef_rhs(caseDef)
     end extension
   end CaseDefOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, TypeCaseDef] =
+  given TypeTest[Tree, TypeCaseDef] =
     reflectSelf.TypeCaseDef_TypeTest
 
 
   object TypeCaseDef:
-    def apply(pattern: TypeTree, rhs: TypeTree)(using ctx: Context): TypeCaseDef =
+    def apply(pattern: TypeTree, rhs: TypeTree): TypeCaseDef =
       reflectSelf.TypeCaseDef_module_apply(pattern, rhs)
 
-    def copy(original: Tree)(pattern: TypeTree, rhs: TypeTree)(using ctx: Context): TypeCaseDef =
+    def copy(original: Tree)(pattern: TypeTree, rhs: TypeTree): TypeCaseDef =
       reflectSelf.TypeCaseDef_module_copy(original)(pattern, rhs)
 
-    def unapply(tree: TypeCaseDef)(using ctx: Context): Option[(TypeTree, TypeTree)] =
+    def unapply(tree: TypeCaseDef): Option[(TypeTree, TypeTree)] =
       Some((tree.pattern, tree.rhs))
   end TypeCaseDef
 
   given TypeCaseDefOps as AnyRef:
     extension (caseDef: TypeCaseDef):
-      def pattern(using ctx: Context): TypeTree = reflectSelf.TypeCaseDef_pattern(caseDef)
-      def rhs(using ctx: Context): TypeTree = reflectSelf.TypeCaseDef_rhs(caseDef)
+      def pattern: TypeTree = reflectSelf.TypeCaseDef_pattern(caseDef)
+      def rhs: TypeTree = reflectSelf.TypeCaseDef_rhs(caseDef)
     end extension
   end TypeCaseDefOps
 
   // ----- Patterns ------------------------------------------------
 
-  given (using ctx: Context) as TypeTest[Tree, Bind] = reflectSelf.Bind_TypeTest
+  given TypeTest[Tree, Bind] = reflectSelf.Bind_TypeTest
 
   object Bind:
-    def apply(sym: Symbol, pattern: Tree)(using ctx: Context): Bind =
+    def apply(sym: Symbol, pattern: Tree): Bind =
       reflectSelf.Tree_Bind_module_apply(sym, pattern)
-    def copy(original: Tree)(name: String, pattern: Tree)(using ctx: Context): Bind =
+    def copy(original: Tree)(name: String, pattern: Tree): Bind =
       reflectSelf.Tree_Bind_module_copy(original)(name, pattern)
-    def unapply(pattern: Bind)(using ctx: Context): Option[(String, Tree)] =
+    def unapply(pattern: Bind): Option[(String, Tree)] =
       Some((pattern.name, pattern.pattern))
   end Bind
 
   given BindOps as AnyRef:
     extension (bind: Bind):
-      def name(using ctx: Context): String = reflectSelf.Tree_Bind_name(bind)
-      def pattern(using ctx: Context): Tree = reflectSelf.Tree_Bind_pattern(bind)
+      def name: String = reflectSelf.Tree_Bind_name(bind)
+      def pattern: Tree = reflectSelf.Tree_Bind_pattern(bind)
     end extension
   end BindOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Unapply] = reflectSelf.Unapply_TypeTest
+  given TypeTest[Tree, Unapply] = reflectSelf.Unapply_TypeTest
 
   object Unapply:
-    // TODO def apply(fun: Term, implicits: List[Term], patterns: List[Tree])(using ctx: Context): Unapply
-    def copy(original: Tree)(fun: Term, implicits: List[Term], patterns: List[Tree])(using ctx: Context): Unapply =
+    // TODO def apply(fun: Term, implicits: List[Term], patterns: List[Tree]): Unapply
+    def copy(original: Tree)(fun: Term, implicits: List[Term], patterns: List[Tree]): Unapply =
       reflectSelf.Tree_Unapply_module_copy(original)(fun, implicits, patterns)
-    def unapply(x: Unapply)(using ctx: Context): Option[(Term, List[Term], List[Tree])] =
+    def unapply(x: Unapply): Option[(Term, List[Term], List[Tree])] =
       Some((x.fun, x.implicits, x.patterns))
   end Unapply
 
   given UnapplyOps as AnyRef:
     extension (unapply: Unapply):
-      def fun(using ctx: Context): Term = reflectSelf.Tree_Unapply_fun(unapply)
-      def implicits(using ctx: Context): List[Term] = reflectSelf.Tree_Unapply_implicits(unapply)
-      def patterns(using ctx: Context): List[Tree] = reflectSelf.Tree_Unapply_patterns(unapply)
+      def fun: Term = reflectSelf.Tree_Unapply_fun(unapply)
+      def implicits: List[Term] = reflectSelf.Tree_Unapply_implicits(unapply)
+      def patterns: List[Tree] = reflectSelf.Tree_Unapply_patterns(unapply)
     end extension
   end UnapplyOps
 
 
-  given (using ctx: Context) as TypeTest[Tree, Alternatives] = reflectSelf.Alternatives_TypeTest
+  given TypeTest[Tree, Alternatives] = reflectSelf.Alternatives_TypeTest
 
   object Alternatives:
-    def apply(patterns: List[Tree])(using ctx: Context): Alternatives =
+    def apply(patterns: List[Tree]): Alternatives =
       reflectSelf.Tree_Alternatives_module_apply(patterns)
-    def copy(original: Tree)(patterns: List[Tree])(using ctx: Context): Alternatives =
+    def copy(original: Tree)(patterns: List[Tree]): Alternatives =
       reflectSelf.Tree_Alternatives_module_copy(original)(patterns)
-    def unapply(x: Alternatives)(using ctx: Context): Option[List[Tree]] =
+    def unapply(x: Alternatives): Option[List[Tree]] =
       Some(x.patterns)
   end Alternatives
 
   given AlternativesOps as AnyRef:
     extension (alternatives: Alternatives):
-      def patterns(using ctx: Context): List[Tree] = reflectSelf.Tree_Alternatives_patterns(alternatives)
+      def patterns: List[Tree] = reflectSelf.Tree_Alternatives_patterns(alternatives)
     end extension
   end AlternativesOps
 
@@ -1295,46 +1295,46 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
   // IMPORT SELECTORS //
   /////////////////////
 
-  given (using ctx: Context) as TypeTest[ImportSelector, SimpleSelector] = reflectSelf.SimpleSelector_TypeTest
+  given TypeTest[ImportSelector, SimpleSelector] = reflectSelf.SimpleSelector_TypeTest
 
   object SimpleSelector:
-    def unapply(x: SimpleSelector)(using ctx: Context): Option[Id] = Some(x.selection)
+    def unapply(x: SimpleSelector): Option[Id] = Some(x.selection)
   end SimpleSelector
 
   given SimpleSelectorOps as AnyRef:
     extension (self: SimpleSelector):
-      def selection(using ctx: Context): Id =
+      def selection: Id =
         reflectSelf.SimpleSelector_selection(self)
     end extension
   end SimpleSelectorOps
 
 
-  given (using ctx: Context) as TypeTest[ImportSelector, RenameSelector] = reflectSelf.RenameSelector_TypeTest
+  given TypeTest[ImportSelector, RenameSelector] = reflectSelf.RenameSelector_TypeTest
 
   object RenameSelector:
-    def unapply(x: RenameSelector)(using ctx: Context): Option[(Id, Id)] = Some((x.from, x.to))
+    def unapply(x: RenameSelector): Option[(Id, Id)] = Some((x.from, x.to))
   end RenameSelector
 
   given RenameSelectorOps as AnyRef:
     extension (self: RenameSelector):
-      def from(using ctx: Context): Id =
+      def from: Id =
         reflectSelf.RenameSelector_from(self)
 
-      def to(using ctx: Context): Id =
+      def to: Id =
         reflectSelf.RenameSelector_to(self)
     end extension
   end RenameSelectorOps
 
 
-  given (using ctx: Context) as TypeTest[ImportSelector, OmitSelector] = reflectSelf.OmitSelector_TypeTest
+  given TypeTest[ImportSelector, OmitSelector] = reflectSelf.OmitSelector_TypeTest
 
   object OmitSelector:
-    def unapply(x: OmitSelector)(using ctx: Context): Option[Id] = Some(x.omitted)
+    def unapply(x: OmitSelector): Option[Id] = Some(x.omitted)
   end OmitSelector
 
   given OmitSelectorOps as AnyRef:
     extension (self: OmitSelector):
-      def omitted(using ctx: Context): Id =
+      def omitted: Id =
         reflectSelf.SimpleSelector_omitted(self)
   end OmitSelectorOps
 
@@ -1345,12 +1345,12 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
 
   // ----- Types ----------------------------------------------------
 
-  given (using ctx: Context) as TypeTest[Type, Type] = reflectSelf.Type_TypeTest
+  given TypeTest[Type, Type] = reflectSelf.Type_TypeTest
 
   object Type:
 
     /** Returns the type or kind (Type) of T */
-    def of[T <: AnyKind](using qtype: scala.quoted.Type[T], ctx: Context): Type =
+    def of[T <: AnyKind](using qtype: scala.quoted.Type[T]): Type =
       qtype.asInstanceOf[scala.internal.quoted.Type[TypeTree]].typeTree.tpe
 
   end Type
@@ -1359,28 +1359,28 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
     extension (self: Type):
 
       /** Shows the tree as extractors */
-      def showExtractors(using ctx: Context): String =
+      def showExtractors: String =
         new ExtractorsPrinter[reflectSelf.type](reflectSelf).showType(self)
 
       /** Shows the tree as fully typed source code */
-      def show(using ctx: Context): String =
+      def show: String =
         self.showWith(SyntaxHighlight.plain)
 
       /** Shows the tree as fully typed source code */
-      def showWith(syntaxHighlight: SyntaxHighlight)(using ctx: Context): String =
+      def showWith(syntaxHighlight: SyntaxHighlight): String =
         new SourceCodePrinter[reflectSelf.type](reflectSelf)(syntaxHighlight).showType(self)
 
       /** Convert `Type` to an `quoted.Type[_]` */
-      def seal(using ctx: Context): scala.quoted.Type[_] =
+      def seal: scala.quoted.Type[_] =
         new scala.internal.quoted.Type(Inferred(self), reflectSelf.compilerId)
 
       /** Is `self` type the same as `that` type?
        *  This is the case iff `self <:< that` and `that <:< self`.
        */
-      def =:=(that: Type)(using ctx: Context): Boolean = reflectSelf.Type_isTypeEq(self)(that)
+      def =:=(that: Type): Boolean = reflectSelf.Type_isTypeEq(self)(that)
 
       /** Is this type a subtype of that type? */
-      def <:<(that: Type)(using ctx: Context): Boolean = reflectSelf.Type_isSubType(self)(that)
+      def <:<(that: Type): Boolean = reflectSelf.Type_isSubType(self)(that)
 
       /** Widen from singleton type to its underlying non-singleton
        *  base type by applying one or more `underlying` dereferences,
@@ -1391,32 +1391,32 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
        *  def o: Outer
        *  <o.x.type>.widen = o.C
        */
-      def widen(using ctx: Context): Type = reflectSelf.Type_widen(self)
+      def widen: Type = reflectSelf.Type_widen(self)
 
       /** Widen from TermRef to its underlying non-termref
         *  base type, while also skipping `=>T` types.
         */
-      def widenTermRefExpr(using ctx: Context): Type = reflectSelf.Type_widenTermRefExpr(self)
+      def widenTermRefExpr: Type = reflectSelf.Type_widenTermRefExpr(self)
 
       /** Follow aliases and dereferences LazyRefs, annotated types and instantiated
         *  TypeVars until type is no longer alias type, annotated type, LazyRef,
         *  or instantiated type variable.
         */
-      def dealias(using ctx: Context): Type = reflectSelf.Type_dealias(self)
+      def dealias: Type = reflectSelf.Type_dealias(self)
 
       /** A simplified version of this type which is equivalent wrt =:= to this type.
        *  Reduces typerefs, applied match types, and and or types.
        */
-      def simplified(using ctx: Context): Type = reflectSelf.Type_simplified(self)
+      def simplified: Type = reflectSelf.Type_simplified(self)
 
-      def classSymbol(using ctx: Context): Option[Symbol] = reflectSelf.Type_classSymbol(self)
-      def typeSymbol(using ctx: Context): Symbol = reflectSelf.Type_typeSymbol(self)
-      def termSymbol(using ctx: Context): Symbol = reflectSelf.Type_termSymbol(self)
-      def isSingleton(using ctx: Context): Boolean = reflectSelf.Type_isSingleton(self)
-      def memberType(member: Symbol)(using ctx: Context): Type = reflectSelf.Type_memberType(self)(member)
+      def classSymbol: Option[Symbol] = reflectSelf.Type_classSymbol(self)
+      def typeSymbol: Symbol = reflectSelf.Type_typeSymbol(self)
+      def termSymbol: Symbol = reflectSelf.Type_termSymbol(self)
+      def isSingleton: Boolean = reflectSelf.Type_isSingleton(self)
+      def memberType(member: Symbol): Type = reflectSelf.Type_memberType(self)(member)
 
       /** The base classes of this type with the class itself as first element. */
-      def baseClasses(using ctx: Context): List[Symbol] = reflectSelf.Type_baseClasses(self)
+      def baseClasses: List[Symbol] = reflectSelf.Type_baseClasses(self)
 
       /** The least type instance of given class which is a super-type
        *  of this type.  Example:
@@ -1426,10 +1426,10 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
        *    ThisType(C).baseType(D) = p.D[Int]
        * }}}
        */
-      def baseType(cls: Symbol)(using ctx: Context): Type = reflectSelf.Type_baseType(self)(cls)
+      def baseType(cls: Symbol): Type = reflectSelf.Type_baseType(self)(cls)
 
       /** Is this type an instance of a non-bottom subclass of the given class `cls`? */
-      def derivesFrom(cls: Symbol)(using ctx: Context): Boolean =
+      def derivesFrom(cls: Symbol): Boolean =
         reflectSelf.Type_derivesFrom(self)(cls)
 
       /** Is this type a function type?
@@ -1441,28 +1441,28 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
        *     - returns true for `given Int => Int` and `erased Int => Int`
        *     - returns false for `List[Int]`, despite that `List[Int] <:< Int => Int`.
        */
-      def isFunctionType(using ctx: Context): Boolean = reflectSelf.Type_isFunctionType(self)
+      def isFunctionType: Boolean = reflectSelf.Type_isFunctionType(self)
 
       /** Is this type an context function type?
        *
        *  @see `isFunctionType`
        */
-      def isContextFunctionType(using ctx: Context): Boolean = reflectSelf.Type_isContextFunctionType(self)
+      def isContextFunctionType: Boolean = reflectSelf.Type_isContextFunctionType(self)
 
       /** Is this type an erased function type?
        *
        *  @see `isFunctionType`
        */
-      def isErasedFunctionType(using ctx: Context): Boolean = reflectSelf.Type_isErasedFunctionType(self)
+      def isErasedFunctionType: Boolean = reflectSelf.Type_isErasedFunctionType(self)
 
       /** Is this type a dependent function type?
        *
        *  @see `isFunctionType`
        */
-      def isDependentFunctionType(using ctx: Context): Boolean = reflectSelf.Type_isDependentFunctionType(self)
+      def isDependentFunctionType: Boolean = reflectSelf.Type_isDependentFunctionType(self)
 
       /** The type <this . sym>, reduced if possible */
-      def select(sym: Symbol)(using ctx: Context): Type = reflectSelf.Type_select(self)(sym)
+      def select(sym: Symbol): Type = reflectSelf.Type_select(self)(sym)
 
       /** The current type applied to given type arguments: `this[targ]` */
       def appliedTo(targ: Type): Type = reflectSelf.Type_appliedTo(self)(List(targ))
@@ -1473,229 +1473,229 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
     end extension
   end TypeOps
 
-  given (using ctx: Context) as TypeTest[Type, ConstantType] = reflectSelf.ConstantType_TypeTest
+  given TypeTest[Type, ConstantType] = reflectSelf.ConstantType_TypeTest
 
   object ConstantType:
-    def apply(x : Constant)(using ctx: Context): ConstantType = reflectSelf.ConstantType_apply(x)
-    def unapply(x: ConstantType)(using ctx: Context): Option[Constant] = Some(x.constant)
+    def apply(x : Constant): ConstantType = reflectSelf.ConstantType_apply(x)
+    def unapply(x: ConstantType): Option[Constant] = Some(x.constant)
   end ConstantType
 
   given ConstantTypeOps as AnyRef:
     extension (self: ConstantType):
-      def constant(using ctx: Context): Constant = reflectSelf.ConstantType_constant(self)
+      def constant: Constant = reflectSelf.ConstantType_constant(self)
     end extension
   end ConstantTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, TermRef] = reflectSelf.TermRef_TypeTest
+  given TypeTest[Type, TermRef] = reflectSelf.TermRef_TypeTest
 
   object TermRef:
-    def apply(qual: Type, name: String)(using ctx: Context): TermRef =
+    def apply(qual: Type, name: String): TermRef =
       reflectSelf.TermRef_apply(qual, name)
-    def unapply(x: TermRef)(using ctx: Context): Option[(Type, String)] =
+    def unapply(x: TermRef): Option[(Type, String)] =
       Some((x.qualifier, x.name))
   end TermRef
 
   given TermRefOps as AnyRef:
     extension (self: TermRef):
-      def qualifier(using ctx: Context): Type = reflectSelf.TermRef_qualifier(self)
-      def name(using ctx: Context): String = reflectSelf.TermRef_name(self)
+      def qualifier: Type = reflectSelf.TermRef_qualifier(self)
+      def name: String = reflectSelf.TermRef_name(self)
     end extension
   end TermRefOps
 
 
-  given (using ctx: Context) as TypeTest[Type, TypeRef] = reflectSelf.TypeRef_TypeTest
+  given TypeTest[Type, TypeRef] = reflectSelf.TypeRef_TypeTest
 
   object TypeRef:
-    def unapply(x: TypeRef)(using ctx: Context): Option[(Type, String)] =
+    def unapply(x: TypeRef): Option[(Type, String)] =
       Some((x.qualifier, x.name))
   end TypeRef
 
   given TypeRefOps as AnyRef:
     extension (self: TypeRef):
-      def qualifier(using ctx: Context): Type = reflectSelf.TypeRef_qualifier(self)
-      def name(using ctx: Context): String = reflectSelf.TypeRef_name(self)
-      def isOpaqueAlias(using ctx: Context): Boolean = reflectSelf.TypeRef_isOpaqueAlias(self)
-      def translucentSuperType(using ctx: Context): Type = reflectSelf.TypeRef_translucentSuperType(self)
+      def qualifier: Type = reflectSelf.TypeRef_qualifier(self)
+      def name: String = reflectSelf.TypeRef_name(self)
+      def isOpaqueAlias: Boolean = reflectSelf.TypeRef_isOpaqueAlias(self)
+      def translucentSuperType: Type = reflectSelf.TypeRef_translucentSuperType(self)
     end extension
   end TypeRefOps
 
 
-  given (using ctx: Context) as TypeTest[Type, SuperType] = reflectSelf.SuperType_TypeTest
+  given TypeTest[Type, SuperType] = reflectSelf.SuperType_TypeTest
 
   object SuperType:
-    def apply(thistpe: Type, supertpe: Type)(using ctx: Context): SuperType =
+    def apply(thistpe: Type, supertpe: Type): SuperType =
       reflectSelf.SuperType_apply(thistpe, supertpe)
 
-    def unapply(x: SuperType)(using ctx: Context): Option[(Type, Type)] =
+    def unapply(x: SuperType): Option[(Type, Type)] =
       Some((x.thistpe, x.supertpe))
   end SuperType
 
   given SuperTypeOps as AnyRef:
     extension (self: SuperType):
-      def thistpe(using ctx: Context): Type = reflectSelf.SuperType_thistpe(self)
-      def supertpe(using ctx: Context): Type = reflectSelf.SuperType_supertpe(self)
+      def thistpe: Type = reflectSelf.SuperType_thistpe(self)
+      def supertpe: Type = reflectSelf.SuperType_supertpe(self)
     end extension
   end SuperTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, Refinement] = reflectSelf.Refinement_TypeTest
+  given TypeTest[Type, Refinement] = reflectSelf.Refinement_TypeTest
 
   object Refinement:
-    def apply(parent: Type, name: String, info: Type)(using ctx: Context): Refinement =
+    def apply(parent: Type, name: String, info: Type): Refinement =
       reflectSelf.Refinement_apply(parent, name, info)
 
-    def unapply(x: Refinement)(using ctx: Context): Option[(Type, String, Type)] =
+    def unapply(x: Refinement): Option[(Type, String, Type)] =
       Some((x.parent, x.name, x.info))
   end Refinement
 
   given RefinementOps as AnyRef:
     extension (self: Refinement):
-      def parent(using ctx: Context): Type = reflectSelf.Refinement_parent(self)
-      def name(using ctx: Context): String = reflectSelf.Refinement_name(self)
-      def info(using ctx: Context): Type = reflectSelf.Refinement_info(self)
+      def parent: Type = reflectSelf.Refinement_parent(self)
+      def name: String = reflectSelf.Refinement_name(self)
+      def info: Type = reflectSelf.Refinement_info(self)
     end extension
   end RefinementOps
 
 
-  given (using ctx: Context) as TypeTest[Type, AppliedType] = reflectSelf.AppliedType_TypeTest
+  given TypeTest[Type, AppliedType] = reflectSelf.AppliedType_TypeTest
 
   object AppliedType:
-    def unapply(x: AppliedType)(using ctx: Context): Option[(Type, List[Type])] =
+    def unapply(x: AppliedType): Option[(Type, List[Type])] =
       Some((x.tycon, x.args))
   end AppliedType
 
   given AppliedTypeOps as AnyRef:
     extension (self: AppliedType):
-      def tycon(using ctx: Context): Type = reflectSelf.AppliedType_tycon(self)
-      def args(using ctx: Context): List[Type] = reflectSelf.AppliedType_args(self)
+      def tycon: Type = reflectSelf.AppliedType_tycon(self)
+      def args: List[Type] = reflectSelf.AppliedType_args(self)
     end extension
   end AppliedTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, AnnotatedType] = reflectSelf.AnnotatedType_TypeTest
+  given TypeTest[Type, AnnotatedType] = reflectSelf.AnnotatedType_TypeTest
 
   object AnnotatedType:
-    def apply(underlying: Type, annot: Term)(using ctx: Context): AnnotatedType =
+    def apply(underlying: Type, annot: Term): AnnotatedType =
       reflectSelf.AnnotatedType_apply(underlying, annot)
-    def unapply(x: AnnotatedType)(using ctx: Context): Option[(Type, Term)] =
+    def unapply(x: AnnotatedType): Option[(Type, Term)] =
       Some((x.underlying, x.annot))
   end AnnotatedType
 
   given AnnotatedTypeOps as AnyRef:
     extension (self: AnnotatedType):
-      def underlying(using ctx: Context): Type = reflectSelf.AnnotatedType_underlying(self)
-      def annot(using ctx: Context): Term = reflectSelf.AnnotatedType_annot(self)
+      def underlying: Type = reflectSelf.AnnotatedType_underlying(self)
+      def annot: Term = reflectSelf.AnnotatedType_annot(self)
     end extension
   end AnnotatedTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, AndType] = reflectSelf.AndType_TypeTest
+  given TypeTest[Type, AndType] = reflectSelf.AndType_TypeTest
 
   object AndType:
-    def apply(lhs: Type, rhs: Type)(using ctx: Context): AndType =
+    def apply(lhs: Type, rhs: Type): AndType =
       reflectSelf.AndType_apply(lhs, rhs)
-    def unapply(x: AndType)(using ctx: Context): Option[(Type, Type)] =
+    def unapply(x: AndType): Option[(Type, Type)] =
       Some((x.left, x.right))
   end AndType
 
   given AndTypeOps as AnyRef:
     extension (self: AndType):
-      def left(using ctx: Context): Type = reflectSelf.AndType_left(self)
-      def right(using ctx: Context): Type = reflectSelf.AndType_right(self)
+      def left: Type = reflectSelf.AndType_left(self)
+      def right: Type = reflectSelf.AndType_right(self)
     end extension
   end AndTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, OrType] = reflectSelf.OrType_TypeTest
+  given TypeTest[Type, OrType] = reflectSelf.OrType_TypeTest
 
   object OrType:
-    def apply(lhs: Type, rhs: Type)(using ctx: Context): OrType = reflectSelf.OrType_apply(lhs, rhs)
-    def unapply(x: OrType)(using ctx: Context): Option[(Type, Type)] =
+    def apply(lhs: Type, rhs: Type): OrType = reflectSelf.OrType_apply(lhs, rhs)
+    def unapply(x: OrType): Option[(Type, Type)] =
       Some((x.left, x.right))
   end OrType
 
   given OrTypeOps as AnyRef:
     extension (self: OrType):
-      def left(using ctx: Context): Type = reflectSelf.OrType_left(self)
-      def right(using ctx: Context): Type = reflectSelf.OrType_right(self)
+      def left: Type = reflectSelf.OrType_left(self)
+      def right: Type = reflectSelf.OrType_right(self)
     end extension
   end OrTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, MatchType] = reflectSelf.MatchType_TypeTest
+  given TypeTest[Type, MatchType] = reflectSelf.MatchType_TypeTest
 
   object MatchType:
-    def apply(bound: Type, scrutinee: Type, cases: List[Type])(using ctx: Context): MatchType =
+    def apply(bound: Type, scrutinee: Type, cases: List[Type]): MatchType =
       reflectSelf.MatchType_apply(bound, scrutinee, cases)
-    def unapply(x: MatchType)(using ctx: Context): Option[(Type, Type, List[Type])] =
+    def unapply(x: MatchType): Option[(Type, Type, List[Type])] =
       Some((x.bound, x.scrutinee, x.cases))
   end MatchType
 
   given MatchTypeOps as AnyRef:
     extension (self: MatchType):
-      def bound(using ctx: Context): Type = reflectSelf.MatchType_bound(self)
-      def scrutinee(using ctx: Context): Type = reflectSelf.MatchType_scrutinee(self)
-      def cases(using ctx: Context): List[Type] = reflectSelf.MatchType_cases(self)
+      def bound: Type = reflectSelf.MatchType_bound(self)
+      def scrutinee: Type = reflectSelf.MatchType_scrutinee(self)
+      def cases: List[Type] = reflectSelf.MatchType_cases(self)
     end extension
   end MatchTypeOps
 
-  given (using ctx: Context) as TypeTest[Type, ByNameType] = reflectSelf.ByNameType_TypeTest
+  given TypeTest[Type, ByNameType] = reflectSelf.ByNameType_TypeTest
 
   object ByNameType:
-    def apply(underlying: Type)(using ctx: Context): Type = reflectSelf.ByNameType_apply(underlying)
-    def unapply(x: ByNameType)(using ctx: Context): Option[Type] = Some(x.underlying)
+    def apply(underlying: Type): Type = reflectSelf.ByNameType_apply(underlying)
+    def unapply(x: ByNameType): Option[Type] = Some(x.underlying)
   end ByNameType
 
   given ByNameTypeOps as AnyRef:
     extension (self: ByNameType):
-      def underlying(using ctx: Context): Type = reflectSelf.ByNameType_underlying(self)
+      def underlying: Type = reflectSelf.ByNameType_underlying(self)
     end extension
   end ByNameTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, ParamRef] = reflectSelf.ParamRef_TypeTest
+  given TypeTest[Type, ParamRef] = reflectSelf.ParamRef_TypeTest
 
   object ParamRef:
-    def unapply(x: ParamRef)(using ctx: Context): Option[(LambdaType, Int)] =
+    def unapply(x: ParamRef): Option[(LambdaType, Int)] =
       Some((x.binder, x.paramNum))
   end ParamRef
 
   given ParamRefOps as AnyRef:
     extension (self: ParamRef):
-      def binder(using ctx: Context): LambdaType = reflectSelf.ParamRef_binder(self)
-      def paramNum(using ctx: Context): Int = reflectSelf.ParamRef_paramNum(self)
+      def binder: LambdaType = reflectSelf.ParamRef_binder(self)
+      def paramNum: Int = reflectSelf.ParamRef_paramNum(self)
     end extension
   end ParamRefOps
 
 
-  given (using ctx: Context) as TypeTest[Type, ThisType] = reflectSelf.ThisType_TypeTest
+  given TypeTest[Type, ThisType] = reflectSelf.ThisType_TypeTest
 
   object ThisType:
-    def unapply(x: ThisType)(using ctx: Context): Option[Type] = Some(x.tref)
+    def unapply(x: ThisType): Option[Type] = Some(x.tref)
   end ThisType
 
   given ThisTypeOps as AnyRef:
     extension (self: ThisType):
-      def tref(using ctx: Context): Type = reflectSelf.ThisType_tref(self)
+      def tref: Type = reflectSelf.ThisType_tref(self)
     end extension
   end ThisTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, RecursiveThis] = reflectSelf.RecursiveThis_TypeTest
+  given TypeTest[Type, RecursiveThis] = reflectSelf.RecursiveThis_TypeTest
 
   object RecursiveThis:
-    def unapply(x: RecursiveThis)(using ctx: Context): Option[RecursiveType] = Some(x.binder)
+    def unapply(x: RecursiveThis): Option[RecursiveType] = Some(x.binder)
   end RecursiveThis
 
   given RecursiveThisOps as AnyRef:
     extension (self: RecursiveThis):
-      def binder(using ctx: Context): RecursiveType = reflectSelf.RecursiveThis_binder(self)
+      def binder: RecursiveType = reflectSelf.RecursiveThis_binder(self)
     end extension
   end RecursiveThisOps
 
 
-  given (using ctx: Context) as TypeTest[Type, RecursiveType] = reflectSelf.RecursiveType_TypeTest
+  given TypeTest[Type, RecursiveType] = reflectSelf.RecursiveType_TypeTest
 
   object RecursiveType:
 
@@ -1707,27 +1707,27 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
      *      `type T`. This avoids infinite recursions later when we
      *      try to follow these references.
      */
-    def apply(parentExp: RecursiveType => Type)(using ctx: Context): RecursiveType =
+    def apply(parentExp: RecursiveType => Type): RecursiveType =
       reflectSelf.RecursiveType_apply(parentExp)
 
-    def unapply(x: RecursiveType)(using ctx: Context): Option[Type] = Some(x.underlying)
+    def unapply(x: RecursiveType): Option[Type] = Some(x.underlying)
   end RecursiveType
 
   given RecursiveTypeOps as AnyRef:
     extension (self: RecursiveType):
-      def underlying(using ctx: Context): Type = reflectSelf.RecursiveType_underlying(self)
-      def recThis(using ctx: Context): RecursiveThis = reflectSelf.RecursiveThis_recThis(self)
+      def underlying: Type = reflectSelf.RecursiveType_underlying(self)
+      def recThis: RecursiveThis = reflectSelf.RecursiveThis_recThis(self)
     end extension
   end RecursiveTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, MethodType] = reflectSelf.MethodType_TypeTest
+  given TypeTest[Type, MethodType] = reflectSelf.MethodType_TypeTest
 
   object MethodType:
     def apply(paramNames: List[String])(paramInfosExp: MethodType => List[Type], resultTypeExp: MethodType => Type): MethodType =
       reflectSelf.MethodType_apply(paramNames)(paramInfosExp, resultTypeExp)
 
-    def unapply(x: MethodType)(using ctx: Context): Option[(List[String], List[Type], Type)] =
+    def unapply(x: MethodType): Option[(List[String], List[Type], Type)] =
       Some((x.paramNames, x.paramTypes, x.resType))
   end MethodType
 
@@ -1735,76 +1735,76 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
     extension (self: MethodType):
       def isImplicit: Boolean = reflectSelf.MethodType_isImplicit(self)
       def isErased: Boolean = reflectSelf.MethodType_isErased(self)
-      def param(idx: Int)(using ctx: Context): Type = reflectSelf.MethodType_param(self, idx)
-      def paramNames(using ctx: Context): List[String] = reflectSelf.MethodType_paramNames(self)
-      def paramTypes(using ctx: Context): List[Type] = reflectSelf.MethodType_paramTypes(self)
-      def resType(using ctx: Context): Type = reflectSelf.MethodType_resType(self)
+      def param(idx: Int): Type = reflectSelf.MethodType_param(self, idx)
+      def paramNames: List[String] = reflectSelf.MethodType_paramNames(self)
+      def paramTypes: List[Type] = reflectSelf.MethodType_paramTypes(self)
+      def resType: Type = reflectSelf.MethodType_resType(self)
     end extension
   end MethodTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, PolyType] = reflectSelf.PolyType_TypeTest
+  given TypeTest[Type, PolyType] = reflectSelf.PolyType_TypeTest
 
   object PolyType:
-    def apply(paramNames: List[String])(paramBoundsExp: PolyType => List[TypeBounds], resultTypeExp: PolyType => Type)(using ctx: Context): PolyType =
+    def apply(paramNames: List[String])(paramBoundsExp: PolyType => List[TypeBounds], resultTypeExp: PolyType => Type): PolyType =
       reflectSelf.PolyType_apply(paramNames)(paramBoundsExp, resultTypeExp)
-    def unapply(x: PolyType)(using ctx: Context): Option[(List[String], List[TypeBounds], Type)] =
+    def unapply(x: PolyType): Option[(List[String], List[TypeBounds], Type)] =
       Some((x.paramNames, x.paramBounds, x.resType))
   end PolyType
 
   given PolyTypeOps as AnyRef:
     extension (self: PolyType):
-      def param(idx: Int)(using ctx: Context): Type = reflectSelf.PolyType_param(self, idx)
-      def paramNames(using ctx: Context): List[String] = reflectSelf.PolyType_paramNames(self)
-      def paramBounds(using ctx: Context): List[TypeBounds] = reflectSelf.PolyType_paramBounds(self)
-      def resType(using ctx: Context): Type = reflectSelf.PolyType_resType(self)
+      def param(idx: Int): Type = reflectSelf.PolyType_param(self, idx)
+      def paramNames: List[String] = reflectSelf.PolyType_paramNames(self)
+      def paramBounds: List[TypeBounds] = reflectSelf.PolyType_paramBounds(self)
+      def resType: Type = reflectSelf.PolyType_resType(self)
     end extension
   end PolyTypeOps
 
 
-  given (using ctx: Context) as TypeTest[Type, TypeLambda] = reflectSelf.TypeLambda_TypeTest
+  given TypeTest[Type, TypeLambda] = reflectSelf.TypeLambda_TypeTest
 
   object TypeLambda:
     def apply(paramNames: List[String], boundsFn: TypeLambda => List[TypeBounds], bodyFn: TypeLambda => Type): TypeLambda =
       reflectSelf.TypeLambda_apply(paramNames, boundsFn, bodyFn)
-    def unapply(x: TypeLambda)(using ctx: Context): Option[(List[String], List[TypeBounds], Type)] =
+    def unapply(x: TypeLambda): Option[(List[String], List[TypeBounds], Type)] =
       Some((x.paramNames, x.paramBounds, x.resType))
   end TypeLambda
 
   given TypeLambdaOps as AnyRef:
     extension (self: TypeLambda):
-      def paramNames(using ctx: Context): List[String] = reflectSelf.TypeLambda_paramNames(self)
-      def paramBounds(using ctx: Context): List[TypeBounds] = reflectSelf.TypeLambda_paramBounds(self)
-      def param(idx: Int)(using ctx: Context) : Type = reflectSelf.TypeLambda_param(self, idx)
-      def resType(using ctx: Context): Type = reflectSelf.TypeLambda_resType(self)
+      def paramNames: List[String] = reflectSelf.TypeLambda_paramNames(self)
+      def paramBounds: List[TypeBounds] = reflectSelf.TypeLambda_paramBounds(self)
+      def param(idx: Int) : Type = reflectSelf.TypeLambda_param(self, idx)
+      def resType: Type = reflectSelf.TypeLambda_resType(self)
     end extension
   end TypeLambdaOps
 
 
   // ----- TypeBounds -----------------------------------------------
 
-  given (using ctx: Context) as TypeTest[Type, TypeBounds] = reflectSelf.TypeBounds_TypeTest
+  given TypeTest[Type, TypeBounds] = reflectSelf.TypeBounds_TypeTest
 
   object TypeBounds:
-    def apply(low: Type, hi: Type)(using ctx: Context): TypeBounds =
+    def apply(low: Type, hi: Type): TypeBounds =
       reflectSelf.TypeBounds_apply(low, hi)
-    def unapply(x: TypeBounds)(using ctx: Context): Option[(Type, Type)] = Some((x.low, x.hi))
+    def unapply(x: TypeBounds): Option[(Type, Type)] = Some((x.low, x.hi))
   end TypeBounds
 
   given TypeBoundsOps as AnyRef:
     extension (self: TypeBounds):
-      def low(using ctx: Context): Type = reflectSelf.TypeBounds_low(self)
-      def hi(using ctx: Context): Type = reflectSelf.TypeBounds_hi(self)
+      def low: Type = reflectSelf.TypeBounds_low(self)
+      def hi: Type = reflectSelf.TypeBounds_hi(self)
     end extension
   end TypeBoundsOps
 
 
   // ----- NoPrefix -------------------------------------------------
 
-  given (using ctx: Context) as TypeTest[Type, NoPrefix] = reflectSelf.NoPrefix_TypeTest
+  given TypeTest[Type, NoPrefix] = reflectSelf.NoPrefix_TypeTest
 
   object NoPrefix:
-    def unapply(x: NoPrefix)(using ctx: Context): Boolean = true
+    def unapply(x: NoPrefix): Boolean = true
 
 
   ///////////////
@@ -1839,15 +1839,15 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
       def value: Any = reflectSelf.Constant_value(const)
 
       /** Shows the tree as extractors */
-      def showExtractors(using ctx: Context): String =
+      def showExtractors: String =
         new ExtractorsPrinter[reflectSelf.type](reflectSelf).showConstant(const)
 
       /** Shows the tree as fully typed source code */
-      def show(using ctx: Context): String =
+      def show: String =
         const.showWith(SyntaxHighlight.plain)
 
       /** Shows the tree as fully typed source code */
-      def showWith(syntaxHighlight: SyntaxHighlight)(using ctx: Context): String =
+      def showWith(syntaxHighlight: SyntaxHighlight): String =
         new SourceCodePrinter[reflectSelf.type](reflectSelf)(syntaxHighlight).showConstant(const)
     end extension
   end ConstantOps
@@ -1859,16 +1859,16 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
 
 
   object Id:
-    def unapply(id: Id)(using ctx: Context): Option[String] = Some(id.name)
+    def unapply(id: Id): Option[String] = Some(id.name)
   end Id
 
   given IdOps as AnyRef:
     extension (id: Id):
       /** Position in the source code */
-      def pos(using ctx: Context): Position = reflectSelf.Id_pos(id)
+      def pos: Position = reflectSelf.Id_pos(id)
 
       /** Name of the identifier */
-      def name(using ctx: Context): String = reflectSelf.Id_name(id)
+      def name: String = reflectSelf.Id_name(id)
     end extension
   end IdOps
 
@@ -1877,29 +1877,29 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
   // IMPLICIT SEARCH //
   /////////////////////
 
-  def searchImplicit(tpe: Type)(using ctx: Context): ImplicitSearchResult
+  def searchImplicit(tpe: Type): ImplicitSearchResult
 
-  given (using ctx: Context) as TypeTest[ImplicitSearchResult, ImplicitSearchSuccess] = reflectSelf.ImplicitSearchSuccess_TypeTest
+  given TypeTest[ImplicitSearchResult, ImplicitSearchSuccess] = reflectSelf.ImplicitSearchSuccess_TypeTest
 
   given ImplicitSearchSuccessOps as AnyRef:
     extension (self: ImplicitSearchSuccess):
-      def tree(using ctx: Context): Term = reflectSelf.ImplicitSearchSuccess_tree(self)
+      def tree: Term = reflectSelf.ImplicitSearchSuccess_tree(self)
     end extension
   end ImplicitSearchSuccessOps
 
-  given (using ctx: Context) as TypeTest[ImplicitSearchResult, ImplicitSearchFailure] = reflectSelf.ImplicitSearchFailure_TypeTest
+  given TypeTest[ImplicitSearchResult, ImplicitSearchFailure] = reflectSelf.ImplicitSearchFailure_TypeTest
 
   given ImplicitSearchFailureOps as AnyRef:
     extension (self: ImplicitSearchFailure):
-      def explanation(using ctx: Context): String = reflectSelf.ImplicitSearchFailure_explanation(self)
+      def explanation: String = reflectSelf.ImplicitSearchFailure_explanation(self)
     end extension
   end ImplicitSearchFailureOps
 
-  given (using ctx: Context) as TypeTest[ImplicitSearchResult, DivergingImplicit] = reflectSelf.DivergingImplicit_TypeTest
+  given TypeTest[ImplicitSearchResult, DivergingImplicit] = reflectSelf.DivergingImplicit_TypeTest
 
-  given (using ctx: Context) as TypeTest[ImplicitSearchResult, NoMatchingImplicits] = reflectSelf.NoMatchingImplicits_TypeTest
+  given TypeTest[ImplicitSearchResult, NoMatchingImplicits] = reflectSelf.NoMatchingImplicits_TypeTest
 
-  given (using ctx: Context) as TypeTest[ImplicitSearchResult, AmbiguousImplicits] = reflectSelf.AmbiguousImplicits_TypeTest
+  given TypeTest[ImplicitSearchResult, AmbiguousImplicits] = reflectSelf.AmbiguousImplicits_TypeTest
 
 
   /////////////
@@ -1913,19 +1913,19 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
     def currentOwner(using ctx: Context): Symbol = reflectSelf.Symbol_currentOwner
 
     /** Get package symbol if package is either defined in current compilation run or present on classpath. */
-    def requiredPackage(path: String)(using ctx: Context): Symbol = reflectSelf.Symbol_requiredPackage(path)
+    def requiredPackage(path: String): Symbol = reflectSelf.Symbol_requiredPackage(path)
 
     /** Get class symbol if class is either defined in current compilation run or present on classpath. */
-    def requiredClass(path: String)(using ctx: Context): Symbol = reflectSelf.Symbol_requiredClass(path)
+    def requiredClass(path: String): Symbol = reflectSelf.Symbol_requiredClass(path)
 
     /** Get module symbol if module is either defined in current compilation run or present on classpath. */
-    def requiredModule(path: String)(using ctx: Context): Symbol = reflectSelf.Symbol_requiredModule(path)
+    def requiredModule(path: String): Symbol = reflectSelf.Symbol_requiredModule(path)
 
     /** Get method symbol if method is either defined in current compilation run or present on classpath. Throws if the method has an overload. */
-    def requiredMethod(path: String)(using ctx: Context): Symbol = reflectSelf.Symbol_requiredMethod(path)
+    def requiredMethod(path: String): Symbol = reflectSelf.Symbol_requiredMethod(path)
 
     /** The class Symbol of a global class definition */
-    def classSymbol(fullName: String)(using ctx: Context): Symbol =
+    def classSymbol(fullName: String): Symbol =
       reflectSelf.Symbol_of(fullName)
 
     /** Generates a new method symbol with the given parent, name and type.
@@ -1937,7 +1937,7 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
      *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
      *        direct or indirect children of the reflection context's owner.
      */
-    def newMethod(parent: Symbol, name: String, tpe: Type)(using ctx: Context): Symbol =
+    def newMethod(parent: Symbol, name: String, tpe: Type): Symbol =
       newMethod(parent, name, tpe, Flags.EmptyFlags, noSymbol)
 
     /** Works as the other newMethod, but with additional parameters.
@@ -1945,7 +1945,7 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
      *  @param flags extra flags to with which the symbol should be constructed
      *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
      */
-    def newMethod(parent: Symbol, name: String, tpe: Type, flags: Flags, privateWithin: Symbol)(using ctx: Context): Symbol =
+    def newMethod(parent: Symbol, name: String, tpe: Type, flags: Flags, privateWithin: Symbol): Symbol =
       reflectSelf.Symbol_newMethod(parent, name, flags, tpe, privateWithin)
 
     /** Generates a new val/var/lazy val symbol with the given parent, name and type.
@@ -1961,7 +1961,7 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
      *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
      *        direct or indirect children of the reflection context's owner.
      */
-    def newVal(parent: Symbol, name: String, tpe: Type, flags: Flags, privateWithin: Symbol)(using ctx: Context): Symbol =
+    def newVal(parent: Symbol, name: String, tpe: Type, flags: Flags, privateWithin: Symbol): Symbol =
       reflectSelf.Symbol_newVal(parent, name, flags, tpe, privateWithin)
 
     /** Generates a pattern bind symbol with the given parent, name and type.
@@ -1974,11 +1974,11 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
      *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
      *        direct or indirect children of the reflection context's owner.
      */
-    def newBind(parent: Symbol, name: String, flags: Flags, tpe: Type)(using ctx: Context): Symbol =
+    def newBind(parent: Symbol, name: String, flags: Flags, tpe: Type): Symbol =
       reflectSelf.Symbol_newBind(parent, name, flags, tpe)
 
     /** Definition not available */
-    def noSymbol(using ctx: Context): Symbol =
+    def noSymbol: Symbol =
       reflectSelf.Symbol_noSymbol
   end Symbol
 
@@ -1986,33 +1986,33 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
     extension (sym: Symbol):
 
       /** Owner of this symbol. The owner is the symbol in which this symbol is defined. Throws if this symbol does not have an owner. */
-      def owner(using ctx: Context): Symbol = reflectSelf.Symbol_owner(sym)
+      def owner: Symbol = reflectSelf.Symbol_owner(sym)
 
       /** Owner of this symbol. The owner is the symbol in which this symbol is defined. Returns `NoSymbol` if this symbol does not have an owner. */
-      def maybeOwner(using ctx: Context): Symbol = reflectSelf.Symbol_maybeOwner(sym)
+      def maybeOwner: Symbol = reflectSelf.Symbol_maybeOwner(sym)
 
       /** Flags of this symbol */
-      def flags(using ctx: Context): Flags = reflectSelf.Symbol_flags(sym)
+      def flags: Flags = reflectSelf.Symbol_flags(sym)
 
       /** This symbol is private within the resulting type */
-      def privateWithin(using ctx: Context): Option[Type] = reflectSelf.Symbol_privateWithin(sym)
+      def privateWithin: Option[Type] = reflectSelf.Symbol_privateWithin(sym)
 
       /** This symbol is protected within the resulting type */
-      def protectedWithin(using ctx: Context): Option[Type] = reflectSelf.Symbol_protectedWithin(sym)
+      def protectedWithin: Option[Type] = reflectSelf.Symbol_protectedWithin(sym)
 
       /** The name of this symbol */
-      def name(using ctx: Context): String = reflectSelf.Symbol_name(sym)
+      def name: String = reflectSelf.Symbol_name(sym)
 
       /** The full name of this symbol up to the root package */
-      def fullName(using ctx: Context): String = reflectSelf.Symbol_fullName(sym)
+      def fullName: String = reflectSelf.Symbol_fullName(sym)
 
       /** The position of this symbol */
-      def pos(using ctx: Context): Position = reflectSelf.Symbol_pos(sym)
+      def pos: Position = reflectSelf.Symbol_pos(sym)
 
-      def localContext(using ctx: Context): Context = reflectSelf.Symbol_localContext(sym)
+      def localContext: Context = reflectSelf.Symbol_localContext(sym)
 
       /** The comment for this symbol, if any */
-      def comment(using ctx: Context): Option[Comment] = reflectSelf.Symbol_comment(sym)
+      def comment: Option[Comment] = reflectSelf.Symbol_comment(sym)
 
       /** Tree of this definition
         *
@@ -2023,131 +2023,131 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
         * if this symbol `isDefDef` it will return a `DefDef`
         * if this symbol `isBind` it will return a `Bind`
         */
-      def tree(using ctx: Context): Tree =
+      def tree: Tree =
         reflectSelf.Symbol_tree(sym)
 
       /** Annotations attached to this symbol */
-      def annots(using ctx: Context): List[Term] = reflectSelf.Symbol_annots(sym)
+      def annots: List[Term] = reflectSelf.Symbol_annots(sym)
 
-      def isDefinedInCurrentRun(using ctx: Context): Boolean = reflectSelf.Symbol_isDefinedInCurrentRun(sym)
+      def isDefinedInCurrentRun: Boolean = reflectSelf.Symbol_isDefinedInCurrentRun(sym)
 
-      def isLocalDummy(using ctx: Context): Boolean = reflectSelf.Symbol_isLocalDummy(sym)
-      def isRefinementClass(using ctx: Context): Boolean = reflectSelf.Symbol_isRefinementClass(sym)
-      def isAliasType(using ctx: Context): Boolean = reflectSelf.Symbol_isAliasType(sym)
-      def isAnonymousClass(using ctx: Context): Boolean = reflectSelf.Symbol_isAnonymousClass(sym)
-      def isAnonymousFunction(using ctx: Context): Boolean = reflectSelf.Symbol_isAnonymousFunction(sym)
-      def isAbstractType(using ctx: Context): Boolean = reflectSelf.Symbol_isAbstractType(sym)
-      def isClassConstructor(using ctx: Context): Boolean = reflectSelf.Symbol_isClassConstructor(sym)
+      def isLocalDummy: Boolean = reflectSelf.Symbol_isLocalDummy(sym)
+      def isRefinementClass: Boolean = reflectSelf.Symbol_isRefinementClass(sym)
+      def isAliasType: Boolean = reflectSelf.Symbol_isAliasType(sym)
+      def isAnonymousClass: Boolean = reflectSelf.Symbol_isAnonymousClass(sym)
+      def isAnonymousFunction: Boolean = reflectSelf.Symbol_isAnonymousFunction(sym)
+      def isAbstractType: Boolean = reflectSelf.Symbol_isAbstractType(sym)
+      def isClassConstructor: Boolean = reflectSelf.Symbol_isClassConstructor(sym)
 
       /** Is this the definition of a type? */
-      def isType(using ctx: Context): Boolean = reflectSelf.Symbol_isType(sym)
+      def isType: Boolean = reflectSelf.Symbol_isType(sym)
 
       /** Is this the definition of a term? */
-      def isTerm(using ctx: Context): Boolean = reflectSelf.Symbol_isTerm(sym)
+      def isTerm: Boolean = reflectSelf.Symbol_isTerm(sym)
 
       /** Is this the definition of a PackageDef tree? */
-      def isPackageDef(using ctx: Context): Boolean = reflectSelf.Symbol_isPackageDef(sym)
+      def isPackageDef: Boolean = reflectSelf.Symbol_isPackageDef(sym)
 
       /** Is this the definition of a ClassDef tree? */
-      def isClassDef(using ctx: Context): Boolean = reflectSelf.Symbol_isClassDef(sym)
+      def isClassDef: Boolean = reflectSelf.Symbol_isClassDef(sym)
 
       /** Is this the definition of a TypeDef tree */
-      def isTypeDef(using ctx: Context): Boolean = reflectSelf.Symbol_isTypeDef(sym)
+      def isTypeDef: Boolean = reflectSelf.Symbol_isTypeDef(sym)
 
       /** Is this the definition of a ValDef tree? */
-      def isValDef(using ctx: Context): Boolean = reflectSelf.Symbol_isValDef(sym)
+      def isValDef: Boolean = reflectSelf.Symbol_isValDef(sym)
 
       /** Is this the definition of a DefDef tree? */
-      def isDefDef(using ctx: Context): Boolean = reflectSelf.Symbol_isDefDef(sym)
+      def isDefDef: Boolean = reflectSelf.Symbol_isDefDef(sym)
 
       /** Is this the definition of a Bind pattern? */
-      def isBind(using ctx: Context): Boolean = reflectSelf.Symbol_isBind(sym)
+      def isBind: Boolean = reflectSelf.Symbol_isBind(sym)
 
       /** Does this symbol represent a no definition? */
-      def isNoSymbol(using ctx: Context): Boolean = sym == Symbol.noSymbol
+      def isNoSymbol: Boolean = sym == Symbol.noSymbol
 
       /** Does this symbol represent a definition? */
-      def exists(using ctx: Context): Boolean = sym != Symbol.noSymbol
+      def exists: Boolean = sym != Symbol.noSymbol
 
       /** Fields directly declared in the class */
-      def fields(using ctx: Context): List[Symbol] =
+      def fields: List[Symbol] =
         reflectSelf.Symbol_fields(sym)
 
       /** Field with the given name directly declared in the class */
-      def field(name: String)(using ctx: Context): Symbol =
+      def field(name: String): Symbol =
         reflectSelf.Symbol_field(sym)(name)
 
       /** Get non-private named methods defined directly inside the class */
-      def classMethod(name: String)(using ctx: Context): List[Symbol] =
+      def classMethod(name: String): List[Symbol] =
         reflectSelf.Symbol_classMethod(sym)(name)
 
       /** Get all non-private methods defined directly inside the class, exluding constructors */
-      def classMethods(using ctx: Context): List[Symbol] =
+      def classMethods: List[Symbol] =
         reflectSelf.Symbol_classMethods(sym)
 
       /** Type member directly declared in the class */
-      def typeMembers(using ctx: Context): List[Symbol] =
+      def typeMembers: List[Symbol] =
         reflectSelf.Symbol_typeMembers(sym)
 
       /** Type member with the given name directly declared in the class */
-      def typeMember(name: String)(using ctx: Context): Symbol =
+      def typeMember(name: String): Symbol =
         reflectSelf.Symbol_typeMember(sym)(name)
 
       /** Get named non-private methods declared or inherited */
-      def method(name: String)(using ctx: Context): List[Symbol] =
+      def method(name: String): List[Symbol] =
         reflectSelf.Symbol_method(sym)(name)
 
       /** Get all non-private methods declared or inherited */
-      def methods(using ctx: Context): List[Symbol] =
+      def methods: List[Symbol] =
         reflectSelf.Symbol_methods(sym)
 
       /** The symbols of each type parameter list and value parameter list of this
         *  method, or Nil if this isn't a method.
         */
-      def paramSymss(using ctx: Context): List[List[Symbol]] =
+      def paramSymss: List[List[Symbol]] =
         reflectSelf.Symbol_paramSymss(sym)
 
       /** The primary constructor of a class or trait, `noSymbol` if not applicable. */
-      def primaryConstructor(using Context): Symbol =
+      def primaryConstructor: Symbol =
         reflectSelf.Symbol_primaryConstructor(sym)
 
       /** Fields of a case class type -- only the ones declared in primary constructor */
-      def caseFields(using ctx: Context): List[Symbol] =
+      def caseFields: List[Symbol] =
         reflectSelf.Symbol_caseFields(sym)
 
-      def isTypeParam(using ctx: Context): Boolean =
+      def isTypeParam: Boolean =
         reflectSelf.Symbol_isTypeParam(sym)
 
       /** Signature of this definition */
-      def signature(using ctx: Context): Signature =
+      def signature: Signature =
         reflectSelf.Symbol_signature(sym)
 
       /** The class symbol of the companion module class */
-      def moduleClass(using ctx: Context): Symbol =
+      def moduleClass: Symbol =
         reflectSelf.Symbol_moduleClass(sym)
 
       /** The symbol of the companion class */
-      def companionClass(using ctx: Context): Symbol =
+      def companionClass: Symbol =
         reflectSelf.Symbol_companionClass(sym)
 
       /** The symbol of the companion module */
-      def companionModule(using ctx: Context): Symbol =
+      def companionModule: Symbol =
         reflectSelf.Symbol_companionModule(sym)
 
       /** Shows the tree as extractors */
-      def showExtractors(using ctx: Context): String =
+      def showExtractors: String =
         new ExtractorsPrinter[reflectSelf.type](reflectSelf).showSymbol(sym)
 
       /** Shows the tree as fully typed source code */
-      def show(using ctx: Context): String =
+      def show: String =
         sym.showWith(SyntaxHighlight.plain)
 
       /** Shows the tree as fully typed source code */
-      def showWith(syntaxHighlight: SyntaxHighlight)(using ctx: Context): String =
+      def showWith(syntaxHighlight: SyntaxHighlight): String =
         new SourceCodePrinter[reflectSelf.type](reflectSelf)(syntaxHighlight).showSymbol(sym)
 
       /** Case class or case object children of a sealed trait */
-      def children(using ctx: Context): List[Symbol] =
+      def children: List[Symbol] =
         reflectSelf.Symbol_children(sym)
     end extension
   end SymbolOps
@@ -2163,7 +2163,7 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
   /** The signature of a method */
   object Signature:
     /** Matches the method signature and returns its parameters and result type. */
-    def unapply(sig: Signature)(using ctx: Context): Option[(List[String | Int], String)] =
+    def unapply(sig: Signature): Option[(List[String | Int], String)] =
       Some((sig.paramSigs, sig.resultSig))
   end Signature
 
@@ -2560,15 +2560,15 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
       def &(that: Flags): Flags = reflectSelf.Flags_and(flags)(that)
 
       /** Shows the tree as extractors */
-      def showExtractors(using ctx: Context): String =
+      def showExtractors: String =
         new ExtractorsPrinter[reflectSelf.type](reflectSelf).showFlags(flags)
 
       /** Shows the tree as fully typed source code */
-      def show(using ctx: Context): String =
+      def show: String =
         flags.showWith(SyntaxHighlight.plain)
 
       /** Shows the tree as fully typed source code */
-      def showWith(syntaxHighlight: SyntaxHighlight)(using ctx: Context): String =
+      def showWith(syntaxHighlight: SyntaxHighlight): String =
         new SourceCodePrinter[reflectSelf.type](reflectSelf)(syntaxHighlight).showFlags(flags)
 
     end extension
@@ -2639,16 +2639,16 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
   ///////////////
 
   /** Emits an error message */
-  def error(msg: => String, pos: Position)(using ctx: Context): Unit
+  def error(msg: => String, pos: Position): Unit
 
   /** Emits an error at a specific range of a file */
-  def error(msg: => String, source: SourceFile, start: Int, end: Int)(using ctx: Context): Unit
+  def error(msg: => String, source: SourceFile, start: Int, end: Int): Unit
 
   /** Emits an error message */
-  def warning(msg: => String, pos: Position)(using ctx: Context): Unit
+  def warning(msg: => String, pos: Position): Unit
 
   /** Emits a warning at a specific range of a file */
-  def warning(msg: => String, source: SourceFile, start: Int, end: Int)(using ctx: Context): Unit
+  def warning(msg: => String, source: SourceFile, start: Int, end: Int): Unit
 
 
   //////////////
@@ -2695,13 +2695,13 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
   // TODO extract from Reflection
 
   /** Bind the `rhs` to a `val` and use it in `body` */
-  def let(rhs: Term)(body: Ident => Term)(using ctx: Context): Term = {
+  def let(rhs: Term)(body: Ident => Term): Term = {
     val sym = Symbol.newVal(Symbol.currentOwner, "x", rhs.tpe.widen, Flags.EmptyFlags, Symbol.noSymbol)
     Block(List(ValDef(sym, Some(rhs))), body(Ref(sym).asInstanceOf[Ident]))
   }
 
   /** Bind the given `terms` to names and use them in the `body` */
-  def lets(terms: List[Term])(body: List[Term] => Term)(using ctx: Context): Term = {
+  def lets(terms: List[Term])(body: List[Term] => Term): Term = {
     def rec(xs: List[Term], acc: List[Term]): Term = xs match {
       case Nil => body(acc)
       case x :: xs => let(x) { (x: Term) => rec(xs, x :: acc) }

--- a/library/src/scala/tasty/reflect/ExtractorsPrinter.scala
+++ b/library/src/scala/tasty/reflect/ExtractorsPrinter.scala
@@ -4,19 +4,19 @@ package reflect
 class ExtractorsPrinter[R <: Reflection & Singleton](val tasty: R) extends Printer[R] {
   import tasty._
 
-  def showTree(tree: Tree)(using ctx: Context): String =
+  def showTree(tree: Tree): String =
     new Buffer().visitTree(tree).result()
 
-  def showType(tpe: Type)(using ctx: Context): String =
+  def showType(tpe: Type): String =
     new Buffer().visitType(tpe).result()
 
-  def showConstant(const: Constant)(using ctx: Context): String =
+  def showConstant(const: Constant): String =
     new Buffer().visitConstant(const).result()
 
-  def showSymbol(symbol: Symbol)(using ctx: Context): String =
+  def showSymbol(symbol: Symbol): String =
     new Buffer().visitSymbol(symbol).result()
 
-  def showFlags(flags: Flags)(using ctx: Context): String = {
+  def showFlags(flags: Flags): String = {
     val flagList = List.newBuilder[String]
     if (flags.is(Flags.Abstract)) flagList += "Flags.Abstract"
     if (flags.is(Flags.Artifact)) flagList += "Flags.Artifact"
@@ -55,7 +55,7 @@ class ExtractorsPrinter[R <: Reflection & Singleton](val tasty: R) extends Print
     flagList.result().mkString(" | ")
   }
 
-  private class Buffer(using ctx: Context) { self =>
+  private class Buffer { self =>
 
     private val sb: StringBuilder = new StringBuilder
 

--- a/library/src/scala/tasty/reflect/Printer.scala
+++ b/library/src/scala/tasty/reflect/Printer.scala
@@ -7,17 +7,17 @@ trait Printer[R <: Reflection & Singleton] {
   val tasty: R
 
   /** Show a String representation of a tasty.Tree */
-  def showTree(tree: tasty.Tree)(using ctx: tasty.Context): String
+  def showTree(tree: tasty.Tree): String
 
   /** Show a String representation of a tasty.Type */
-  def showType(tpe: tasty.Type)(using ctx: tasty.Context): String
+  def showType(tpe: tasty.Type): String
 
   /** Show a String representation of a tasty.Constant */
-  def showConstant(const: tasty.Constant)(using ctx: tasty.Context): String
+  def showConstant(const: tasty.Constant): String
 
   /** Show a String representation of a tasty.Symbol */
-  def showSymbol(symbol: tasty.Symbol)(using ctx: tasty.Context): String
+  def showSymbol(symbol: tasty.Symbol): String
 
   /** Show a String representation of a tasty.Flags */
-  def showFlags(flags: tasty.Flags)(using ctx: tasty.Context): String
+  def showFlags(flags: tasty.Flags): String
 }

--- a/library/src/scala/tasty/reflect/SourceCodePrinter.scala
+++ b/library/src/scala/tasty/reflect/SourceCodePrinter.scala
@@ -9,19 +9,19 @@ class SourceCodePrinter[R <: Reflection & Singleton](val tasty: R)(syntaxHighlig
   import tasty._
   import syntaxHighlight._
 
-  def showTree(tree: Tree)(using ctx: Context): String =
+  def showTree(tree: Tree): String =
     (new Buffer).printTree(tree).result()
 
-  def showType(tpe: Type)(using ctx: Context): String =
+  def showType(tpe: Type): String =
     (new Buffer).printType(tpe)(using None).result()
 
-  def showConstant(const: Constant)(using ctx: Context): String =
+  def showConstant(const: Constant): String =
     (new Buffer).printConstant(const).result()
 
-  def showSymbol(symbol: Symbol)(using ctx: Context): String =
+  def showSymbol(symbol: Symbol): String =
     symbol.fullName
 
-  def showFlags(flags: Flags)(using ctx: Context): String = {
+  def showFlags(flags: Flags): String = {
     val flagList = List.newBuilder[String]
     if (flags.is(Flags.Abstract)) flagList += "abstract"
     if (flags.is(Flags.Artifact)) flagList += "artifact"
@@ -60,7 +60,7 @@ class SourceCodePrinter[R <: Reflection & Singleton](val tasty: R)(syntaxHighlig
     flagList.result().mkString("/*", " ", "*/")
   }
 
-  private class Buffer(using ctx: Context) {
+  private class Buffer {
 
     private[this] val sb: StringBuilder = new StringBuilder
 
@@ -1413,7 +1413,7 @@ class SourceCodePrinter[R <: Reflection & Singleton](val tasty: R)(syntaxHighlig
   private[this] val names = collection.mutable.Map.empty[Symbol, String]
   private[this] val namesIndex = collection.mutable.Map.empty[String, Int]
 
-  private def splicedName(sym: Symbol)(using ctx: Context): Option[String] = {
+  private def splicedName(sym: Symbol): Option[String] = {
     sym.annots.find(_.symbol.owner == Symbol.requiredClass("scala.internal.quoted.showName")).flatMap {
       case Apply(_, Literal(Constant(c: String)) :: Nil) => Some(c)
       case Apply(_, Inlined(_, _, Literal(Constant(c: String))) :: Nil) => Some(c)
@@ -1434,7 +1434,7 @@ class SourceCodePrinter[R <: Reflection & Singleton](val tasty: R)(syntaxHighlig
   }
 
   private object SpecialOp {
-    def unapply(arg: Tree)(using ctx: Context): Option[(String, List[Term])] = arg match {
+    def unapply(arg: Tree): Option[(String, List[Term])] = arg match {
       case arg @ Apply(fn, args) =>
         fn.tpe match {
           case tpe @ TermRef(ThisType(TypeRef(_, name)), name2) if name == "<special-ops>" =>
@@ -1446,7 +1446,7 @@ class SourceCodePrinter[R <: Reflection & Singleton](val tasty: R)(syntaxHighlig
   }
 
   private object Annotation {
-    def unapply(arg: Tree)(using ctx: Context): Option[(TypeTree, List[Term])] = arg match {
+    def unapply(arg: Tree): Option[(TypeTree, List[Term])] = arg match {
       case New(annot) => Some((annot, Nil))
       case Apply(Select(New(annot), "<init>"), args) => Some((annot, args))
       case Apply(TypeApply(Select(New(annot), "<init>"), targs), args) => Some((annot, args))
@@ -1458,7 +1458,7 @@ class SourceCodePrinter[R <: Reflection & Singleton](val tasty: R)(syntaxHighlig
   private object Types {
 
     object Sequence {
-      def unapply(tpe: Type)(using ctx: Context): Option[Type] = tpe match {
+      def unapply(tpe: Type): Option[Type] = tpe match {
         case AppliedType(seq, (tp: Type) :: Nil)
             if seq.typeSymbol == Symbol.requiredClass("scala.collection.Seq") || seq.typeSymbol == Symbol.requiredClass("scala.collection.immutable.Seq") =>
           Some(tp)
@@ -1467,7 +1467,7 @@ class SourceCodePrinter[R <: Reflection & Singleton](val tasty: R)(syntaxHighlig
     }
 
     object Repeated {
-      def unapply(tpe: Type)(using ctx: Context): Option[Type] = tpe match {
+      def unapply(tpe: Type): Option[Type] = tpe match {
         case AppliedType(rep, (tp: Type) :: Nil) if rep.typeSymbol == Symbol.requiredClass("scala.<repeated>") => Some(tp)
         case _ => None
       }
@@ -1476,7 +1476,7 @@ class SourceCodePrinter[R <: Reflection & Singleton](val tasty: R)(syntaxHighlig
   }
 
   object PackageObject {
-    def unapply(tree: Tree)(using ctx: Context): Option[Tree] = tree match {
+    def unapply(tree: Tree): Option[Tree] = tree match {
       case PackageClause(_, ValDef("package", _, _) :: body :: Nil) => Some(body)
       case _ => None
     }

--- a/library/src/scala/tasty/reflect/TreeMap.scala
+++ b/library/src/scala/tasty/reflect/TreeMap.scala
@@ -132,7 +132,7 @@ trait TreeMap {
     case tree: ByName =>
       ByName.copy(tree)(transformTypeTree(tree.result))
     case tree: LambdaTypeTree =>
-      LambdaTypeTree.copy(tree)(transformSubTrees(tree.tparams), transformTree(tree.body))(using tree.symbol.localContext)
+      LambdaTypeTree.copy(tree)(transformSubTrees(tree.tparams), transformTree(tree.body))
     case tree: TypeBind =>
       TypeBind.copy(tree)(tree.name, tree.body)
     case tree: TypeBlock =>

--- a/tests/run-macros/tasty-custom-show/quoted_1.scala
+++ b/tests/run-macros/tasty-custom-show/quoted_1.scala
@@ -41,11 +41,11 @@ object Macros {
     new scala.tasty.reflect.Printer {
       val tasty = qctx.tasty
       import qctx.tasty._
-      def showTree(tree: Tree)(implicit ctx: Context): String = "Tree"
-      def showType(tpe: Type)(implicit ctx: Context): String = "Type"
-      def showConstant(const: Constant)(implicit ctx: Context): String = "Constant"
-      def showSymbol(symbol: Symbol)(implicit ctx: Context): String = "Symbol"
-      def showFlags(flags: Flags)(implicit ctx: Context): String = "Flags"
+      def showTree(tree: Tree): String = "Tree"
+      def showType(tpe: Type): String = "Type"
+      def showConstant(const: Constant): String = "Constant"
+      def showSymbol(symbol: Symbol): String = "Symbol"
+      def showFlags(flags: Flags): String = "Flags"
     }
   }
 


### PR DESCRIPTION
The Context only tracks the current owner. Most methods do not care implicitly about the current owner and can use the `rootContext` directly.