### PR TITLE
Add naming schema change article

### DIFF
--- a/docs/blog/_posts/2020-09-21-naming-schema-change.md
+++ b/docs/blog/_posts/2020-09-21-naming-schema-change.md
@@ -8,4 +8,4 @@ date: 2020-09-21
 
 This article is a heads-up for the upcoming change in the naming of Dotty artefacts (as published to Maven). Currently, the organization name is “ch.epfl.lamp” which will become “org.scala-lang”. The artefact names will be changed from “dotty-xxx” to “scala3-xxx”.
 
-The change, naturally, will break the existing build tools that work with Dotty. Hence, tooling maintainers need to be prepared to migrate the tooling to the new naming schema. We are planning to introduce the change by October 1st in a form of the next Dotty release, Scala 3.0-M1. The major tooling will be migrated shortly after the release is on Maven.
+This change will be part of the next Dotty release planned for October 1st which will be known as Scala 3.0.0-M1. We encourage maintainers of tooling (IDEs, build tools, ...) to prepare for this change now by special-casing the way they handle the compiler when its version number starts with `3.` just like they already had to special-case versions starting with `0.` to support existing Dotty releases.

--- a/docs/blog/_posts/2020-09-21-naming-schema-change.md
+++ b/docs/blog/_posts/2020-09-21-naming-schema-change.md
@@ -1,0 +1,11 @@
+---
+layout: blog-page
+title: Dotty becomes Scala 3
+author: Anatolii Kmetiuk
+authorImg: /images/anatolii.png
+date: 2020-09-21
+---
+
+This article is a heads-up for the upcoming change in the naming of Dotty artefacts (as published to Maven). Currently, the organization name is “ch.epfl.lamp” which will become “org.scala-lang”. The artefact names will be changed from “dotty-xxx” to “scala3-xxx”.
+
+The change, naturally, will break the existing build tools that work with Dotty. Hence, tooling maintainers need to be prepared to migrate the tooling to the new naming schema. We are planning to introduce the change by October 1st in a form of the next Dotty release, Scala 3.0-M1. The major tooling will be migrated shortly after the release is on Maven.


### PR DESCRIPTION
We should publish it by Monday, 21st of September. After that, we should tweet it and publish it to the contributors mailing list so that people can see it. This will give the community tooling maintainers that are not already aware of the change a 1.5-weeks heads-up before the change is made.