### PR TITLE
make an error message wording more idiomatic

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -156,7 +156,7 @@ object Checking {
     if (arg.tpe.widen.isRef(defn.NothingClass) ||
         !paramBounds.exists ||
         arg.tpe.hasSameKindAs(paramBounds.bounds.hi)) arg
-    else errorTree(arg, em"Type argument ${arg.tpe} has not the same kind as its bound $paramBounds")
+    else errorTree(arg, em"Type argument ${arg.tpe} does not have the same kind as its bound $paramBounds")
 
   def preCheckKinds(args: List[Tree], paramBoundss: List[Type])(using Context): List[Tree] = {
     val args1 = args.zipWithConserve(paramBoundss)(preCheckKind)

--- a/tests/neg-custom-args/kind-projector.check
+++ b/tests/neg-custom-args/kind-projector.check
@@ -5,8 +5,8 @@
 -- Error: tests/neg-custom-args/kind-projector.scala:5:23 --------------------------------------------------------------
 5 |class Bar1 extends Foo[Either[*, *]] // error
   |                       ^^^^^^^^^^^^
-  |                       Type argument Either has not the same kind as its bound [_$1]
+  |                       Type argument Either does not have the same kind as its bound [_$1]
 -- Error: tests/neg-custom-args/kind-projector.scala:6:22 --------------------------------------------------------------
 6 |class Bar2 extends Foo[*] // error
   |                      ^
-  |                      Type argument _$4 has not the same kind as its bound [_$1]
+  |                      Type argument _$4 does not have the same kind as its bound [_$1]

--- a/tests/neg/kinds1.scala
+++ b/tests/neg/kinds1.scala
@@ -5,7 +5,7 @@ object Test {
 
   class B
 
-  val x: C[C] = ??? // error: Type argument has not the same kind as its bound
+  val x: C[C] = ??? // error: Type argument does not have the same kind as its bound
   val y: C2[C] = ???
 
   def f[T] = ???

--- a/tests/pending/neg/kinds1.check
+++ b/tests/pending/neg/kinds1.check
@@ -1,2 +1,2 @@
 [68..69] in kinds1.scala
-Type argument Test.C has not the same kind as its bound
+Type argument Test.C does not have the same kind as its bound


### PR DESCRIPTION
we don't say "has not the" in English

~~the fix I've chosen is to change "has" to "is", but if someone feels I've damaged the meaning while improving the grammar, I could go with "doesn't have the same kind" instead. lmk~~