### PR TITLE
Fix #9828: Add missing case for adapt of ExpMethodApply results

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3581,6 +3581,9 @@ class Typer extends Namer
                 case _: IntegratedTypeArgs => tree
                 case _ =>  tryInsertApplyOrImplicit(tree, pt, locked)(tree) // error will be reported in typedTypeApply
               }
+            case pt: SelectionProto if tree.isInstanceOf[ExtMethodApply] =>
+              assert(pt.extensionName == tree.symbol.name)
+              tree
             case _ =>
               if (ctx.mode is Mode.Type) adaptType(tree.tpe)
               else adaptNoArgs(wtp)

--- a/tests/pos/i9828.scala
+++ b/tests/pos/i9828.scala
@@ -1,0 +1,8 @@
+
+
+
+extension (x: Int) inline def g (y: Int): Int = x + y
+extension [S](f: S => Int) inline def f(s: String) = "test"
+val z = 1.g(2)
+def testStuff =  ((s: String) => 42).f("foo")
+


### PR DESCRIPTION
ExtMethodApply needs to bypass adaptation until everything is integrated.