### PR TITLE
Fix #9772: Normalize value definitions

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -147,26 +147,32 @@ object desugar {
 
 // ----- Desugar methods -------------------------------------------------
 
+  /** Setter generation is needed for:
+   *    - non-private class members
+   *    - all trait members
+   *    - all package object members
+   */
+  def isSetterNeeded(valDef: ValDef)(using Context): Boolean = {
+    val mods = valDef.mods
+    mods.is(Mutable)
+      && ctx.owner.isClass
+      && (!mods.is(Private) || ctx.owner.is(Trait) || ctx.owner.isPackageObject)
+  }
+
   /**   var x: Int = expr
    *  ==>
    *    def x: Int = expr
    *    def x_=($1: <TypeTree()>): Unit = ()
    *
-   *  Generate the setter only for
-   *    - non-private class members
-   *    - all trait members
-   *    - all package object members
+   *  Generate setter where needed
    */
   def valDef(vdef0: ValDef)(using Context): Tree = {
     val vdef @ ValDef(_, tpt, rhs) = vdef0
     val mods = vdef.mods
-    val setterNeeded =
-      mods.is(Mutable)
-      && ctx.owner.isClass
-      && (!mods.is(Private) || ctx.owner.is(Trait) || ctx.owner.isPackageObject)
+
     val valName = normalizeName(vdef, tpt).asTermName
 
-    if (setterNeeded) {
+    if (isSetterNeeded(vdef)) {
       // TODO: copy of vdef as getter needed?
       // val getter = ValDef(mods, name, tpt, rhs) withPos vdef.pos?
       // right now vdef maps via expandedTree to a thicket which concerns itself.
@@ -937,7 +943,7 @@ object desugar {
       name = name.errorName
     }
     mdef match {
-      case vdef: ValDef if name.isExtension && vdef.mods.is(Mutable) =>
+      case vdef: ValDef if name.isExtension && isSetterNeeded(vdef)  =>
         report.error(em"illegal setter name: `extension_=`", errPos)
       case memDef if name.isExtensionName && !mdef.mods.is(ExtensionMethod) =>
         report.error(em"illegal name: $name may not start with `extension_`", errPos)

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -158,14 +158,15 @@ object desugar {
    *    - all package object members
    */
   def valDef(vdef0: ValDef)(using Context): Tree = {
-    val vdef @ ValDef(name, tpt, rhs) = vdef0
+    val vdef @ ValDef(_, tpt, rhs) = vdef0
     val mods = vdef.mods
     val setterNeeded =
       mods.is(Mutable)
       && ctx.owner.isClass
       && (!mods.is(Private) || ctx.owner.is(Trait) || ctx.owner.isPackageObject)
+    val valName = normalizeName(vdef, tpt).asTermName
+
     if (setterNeeded) {
-      val valName = normalizeName(vdef, tpt).asTermName
       // TODO: copy of vdef as getter needed?
       // val getter = ValDef(mods, name, tpt, rhs) withPos vdef.pos?
       // right now vdef maps via expandedTree to a thicket which concerns itself.
@@ -888,7 +889,7 @@ object desugar {
           mdef.tparams.head.srcPos)
       defDef(
         cpy.DefDef(mdef)(
-          name = mdef.name.toExtensionName,
+          name = normalizeName(mdef, ext).toExtensionName,
           tparams = ext.tparams ++ mdef.tparams,
           vparamss = mdef.vparamss match
             case vparams1 :: vparamss1 if mdef.name.isRightAssocOperatorName =>
@@ -938,7 +939,7 @@ object desugar {
     mdef match {
       case vdef: ValDef if name.isExtension && vdef.mods.is(Mutable) =>
         report.error(em"illegal variable name: `extension`", errPos)
-      case memDef if name.isExtensionName && (!mdef.mods.is(ExtensionMethod) || name.dropExtension.isExtensionName) =>
+      case memDef if name.isExtensionName && !mdef.mods.is(ExtensionMethod) =>
         report.error(em"illegal name: $name may not start with `extension_`", errPos)
       case _ =>
     }

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -938,7 +938,7 @@ object desugar {
     }
     mdef match {
       case vdef: ValDef if name.isExtension && vdef.mods.is(Mutable) =>
-        report.error(em"illegal variable name: `extension`", errPos)
+        report.error(em"illegal setter name: `extension_=`", errPos)
       case memDef if name.isExtensionName && !mdef.mods.is(ExtensionMethod) =>
         report.error(em"illegal name: $name may not start with `extension_`", errPos)
       case _ =>

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -133,6 +133,9 @@ object NameOps {
       else name.toTermName
     }
 
+    /** Does the name match `extension`? */
+    def isExtension: Boolean = name.toString == "extension"
+
     /** Does this name start with `extension_`? */
     def isExtensionName: Boolean = name match
       case name: SimpleName => name.startsWith("extension_")

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -134,7 +134,10 @@ object NameOps {
     }
 
     /** Does the name match `extension`? */
-    def isExtension: Boolean = name.toString == "extension"
+    def isExtension: Boolean = name match
+      case name: SimpleName =>
+        name.length == "extension".length && name.startsWith("extension")
+      case _ => false
 
     /** Does this name start with `extension_`? */
     def isExtensionName: Boolean = name match

--- a/tests/neg/illegal-extension.check
+++ b/tests/neg/illegal-extension.check
@@ -1,8 +1,16 @@
 -- Error: tests/neg/illegal-extension.scala:2:6 ------------------------------------------------------------------------
-2 |  def extension_n: String = "illegal method" // error: illegal method name: extension_n may not start with `extension_`
+2 |  def extension_n: String = "illegal method" // error: illegal name: extension_n may not start with `extension_`
   |      ^^^^^^^^^^^
-  |      illegal method name: extension_n may not start with `extension_`
+  |      illegal name: extension_n may not start with `extension_`
 -- Error: tests/neg/illegal-extension.scala:4:6 ------------------------------------------------------------------------
-4 |  var extension_val = 23 // error: illegal value name: extension_val may not start with `extension_`
+4 |  val extension_val = 23 // error: illegal name: extension_val may not start with `extension_`
   |      ^^^^^^^^^^^^^
-  |      illegal value name: extension_val may not start with `extension_`
+  |      illegal name: extension_val may not start with `extension_`
+-- Error: tests/neg/illegal-extension.scala:5:14 -----------------------------------------------------------------------
+5 |  private var extension = Nil // error: not allowed because it matches `extension`
+  |              ^^^^^^^^^
+  |              illegal variable name: `extension`
+-- Error: tests/neg/illegal-extension.scala:8:23 -----------------------------------------------------------------------
+8 |extension (x: Any) def extension_foo: String = "foo" // error: illegal name: extension_foo may not start with `extension_`
+  |                       ^^^^^^^^^^^^^
+  |                       illegal name: extension_foo may not start with `extension_`

--- a/tests/neg/illegal-extension.check
+++ b/tests/neg/illegal-extension.check
@@ -1,0 +1,8 @@
+-- Error: tests/neg/illegal-extension.scala:2:6 ------------------------------------------------------------------------
+2 |  def extension_n: String = "illegal method" // error: illegal method name: extension_n may not start with `extension_`
+  |      ^^^^^^^^^^^
+  |      illegal method name: extension_n may not start with `extension_`
+-- Error: tests/neg/illegal-extension.scala:4:6 ------------------------------------------------------------------------
+4 |  var extension_val = 23 // error: illegal value name: extension_val may not start with `extension_`
+  |      ^^^^^^^^^^^^^
+  |      illegal value name: extension_val may not start with `extension_`

--- a/tests/neg/illegal-extension.check
+++ b/tests/neg/illegal-extension.check
@@ -7,10 +7,14 @@
   |      ^^^^^^^^^^^^^
   |      illegal name: extension_val may not start with `extension_`
 -- Error: tests/neg/illegal-extension.scala:5:14 -----------------------------------------------------------------------
-5 |  private var extension = Nil // error: not allowed because it matches `extension`
+5 |  private var extension = Nil // error: illegal setter name: `extension_=`
   |              ^^^^^^^^^
-  |              illegal variable name: `extension`
--- Error: tests/neg/illegal-extension.scala:8:23 -----------------------------------------------------------------------
-8 |extension (x: Any) def extension_foo: String = "foo" // error: illegal name: extension_foo may not start with `extension_`
-  |                       ^^^^^^^^^^^^^
-  |                       illegal name: extension_foo may not start with `extension_`
+  |              illegal setter name: `extension_=`
+-- Error: tests/neg/illegal-extension.scala:16:23 ----------------------------------------------------------------------
+16 |extension (x: Any) def extension_foo: String = "foo" // error: illegal name: extension_foo may not start with `extension_`
+   |                       ^^^^^^^^^^^^^
+   |                       illegal name: extension_foo may not start with `extension_`
+-- Error: tests/neg/illegal-extension.scala:9:6 ------------------------------------------------------------------------
+9 |  var extension = 1337 // error: illegal setter name: `extension_=`
+  |      ^^^^^^^^^
+  |      illegal setter name: `extension_=`

--- a/tests/neg/illegal-extension.scala
+++ b/tests/neg/illegal-extension.scala
@@ -1,11 +1,9 @@
 trait A {
-  def extension_n: String = "illegal method" // error: illegal method name: extension_n may not start with `extension_`
-  type extension_type = Int
-  var extension_val = 23 // error: illegal value name: extension_val may not start with `extension_`
-  val extension_private = "good" // allowed because it's immutable
+  def extension_n: String = "illegal method" // error: illegal name: extension_n may not start with `extension_`
+  type extension_type = Int // allowed because it's a type alias
+  val extension_val = 23 // error: illegal name: extension_val may not start with `extension_`
+  private var extension = Nil // error: not allowed because it matches `extension`
 }
 
-extension (x: Any) def extension_foo: String = "foo" // error: illegal method name: extension_foo may not start with `extension_`
-class B {
-  private var extension_private_var = "good" // allowed because the owner is a class
-}
+extension (x: Any) def extension_foo: String = "foo" // error: illegal name: extension_foo may not start with `extension_`
+extension (some: Any) def valid_extension_name: String = "bar"

--- a/tests/neg/illegal-extension.scala
+++ b/tests/neg/illegal-extension.scala
@@ -1,5 +1,11 @@
 trait A {
   def extension_n: String = "illegal method" // error: illegal method name: extension_n may not start with `extension_`
+  type extension_type = Int
+  var extension_val = 23 // error: illegal value name: extension_val may not start with `extension_`
+  val extension_private = "good" // allowed because it's immutable
 }
 
 extension (x: Any) def extension_foo: String = "foo" // error: illegal method name: extension_foo may not start with `extension_`
+class B {
+  private var extension_private_var = "good" // allowed because the owner is a class
+}

--- a/tests/neg/illegal-extension.scala
+++ b/tests/neg/illegal-extension.scala
@@ -2,8 +2,19 @@ trait A {
   def extension_n: String = "illegal method" // error: illegal name: extension_n may not start with `extension_`
   type extension_type = Int // allowed because it's a type alias
   val extension_val = 23 // error: illegal name: extension_val may not start with `extension_`
-  private var extension = Nil // error: not allowed because it matches `extension`
+  private var extension = Nil // error: illegal setter name: `extension_=`
+}
+
+class B {
+  var extension = 1337 // error: illegal setter name: `extension_=`
+}
+
+class C {
+  private var extension = "OK" // allowed because it does not require a setter
 }
 
 extension (x: Any) def extension_foo: String = "foo" // error: illegal name: extension_foo may not start with `extension_`
-extension (some: Any) def valid_extension_name: String = "bar"
+extension (some: Any) def valid_extension_name: String = {
+  var extension = "foo" // `extension` name allowed because it doesn't require a setter
+  s"$extension bar"
+}


### PR DESCRIPTION
* Disallow `extension_` name prefix for value definitions
* Make `extension` variable names illegal (addressing https://github.com/lampepfl/dotty/issues/9926) 
