### PR TITLE
Expose ofErasedClass in Reflection

### DIFF
--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -1353,7 +1353,7 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
     def of[T <: AnyKind](using qtype: scala.quoted.Type[T]): Type =
       qtype.asInstanceOf[scala.internal.quoted.Type[TypeTree]].typeTree.tpe
 
-    def ofErasedClass(clazz: Class[_]): Type =
+    def typeConstructorOf(clazz: Class[_]): Type =
       reflectSelf.Type_ofErasedClass(clazz)
   end Type
 

--- a/library/src/scala/tasty/Reflection.scala
+++ b/library/src/scala/tasty/Reflection.scala
@@ -1353,6 +1353,8 @@ trait Reflection extends reflect.Types { reflectSelf: CompilerInterface =>
     def of[T <: AnyKind](using qtype: scala.quoted.Type[T]): Type =
       qtype.asInstanceOf[scala.internal.quoted.Type[TypeTree]].typeTree.tpe
 
+    def ofErasedClass(clazz: Class[_]): Type =
+      reflectSelf.Type_ofErasedClass(clazz)
   end Type
 
   given TypeOps as AnyRef:


### PR DESCRIPTION
Resolves #9850 

Change to expose Reflection.Type.ofErasedClass, which was already present in CompilerInterface.  I need a way to create a Type from a class instance, which broke when Reflection.Type.apply() was recently removed.  This change re-introduces the functionality with the naming already present in the interface.