### PR TITLE
Fix #9717: Fix typed tree copier for Selects over Nothing

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -584,7 +584,10 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           tree1.withTypeUnchecked(tree.tpe)
         case _ =>
           val tree2 = tree.tpe match {
-            case tpe: NamedType => tree1.withType(tpe.derivedSelect(qualifier.tpe.widenIfUnstable))
+            case tpe: NamedType =>
+              val qualType = qualifier.tpe.widenIfUnstable
+              if qualType.isBottomType then tree1.withTypeUnchecked(tree.tpe)
+              else tree1.withType(tpe.derivedSelect(qualType))
             case _ => tree1.withTypeUnchecked(tree.tpe)
           }
           ConstFold(tree2)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -268,7 +268,7 @@ object Types {
       case _ => false
     }
 
-      /** Is this type exactly Any (no vars, aliases, refinements etc allowed)? */
+    /** Is this type exactly Any (no vars, aliases, refinements etc allowed)? */
     def isTopType(using Context): Boolean = this match {
       case tp: TypeRef =>
         tp.name == tpnme.Any && (tp.symbol eq defn.AnyClass)

--- a/tests/pos/i9717/Test.scala
+++ b/tests/pos/i9717/Test.scala
@@ -1,0 +1,4 @@
+// minimized facade
+object Object {
+  def assign[T, U](target: T, source: U): T with U = js.native
+}

--- a/tests/pos/i9717/js.scala
+++ b/tests/pos/i9717/js.scala
@@ -1,0 +1,4 @@
+// minimized scala.js
+package object js {
+  def native: Nothing = ???
+}

--- a/tests/run-macros/tasty-extractors-3.check
+++ b/tests/run-macros/tasty-extractors-3.check
@@ -10,8 +10,6 @@ TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Any")
 
 TypeRef(NoPrefix(), "T")
 
-TypeRef(NoPrefix(), "T")
-
 TypeBounds(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int"), TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int"))
 
 TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")


### PR DESCRIPTION
Typed tree copier would assign a `a.b` where `a` has type `Nothing`
the type `Nothing`. This is wrong, for instance when `b` is $asInstanceOf$
over a value of type `Nothing`, which is the case in i9717.scala