### PR TITLE
Optimize large methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -3,7 +3,7 @@ package dotc
 package ast
 
 import util.Spans._
-import util.{SourceFile, NoSource, SourcePosition, SrcPos}
+import util.{SourceFile, NoSource, SourcePosition, SrcPos, Stats}
 import core.Contexts._
 import core.Decorators._
 import core.NameOps._
@@ -22,6 +22,8 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
 
   private var myUniqueId: Int = _
   private var mySpan: Span = _
+
+  Stats.record(s"Positioned/$getClass")
 
   /** A unique identifier. Among other things, used for determining the source file
    *  component of the position.

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -23,8 +23,8 @@ object Feature:
     def toPrefix(sym: Symbol): String =
       if !sym.exists || sym == defn.LanguageModule.moduleClass then ""
       else toPrefix(sym.owner) + sym.name.stripModuleClassSuffix + "."
-    val prefix = if owner ne NoSymbol then toPrefix(owner) else ""
-    ctx.base.settings.language.value.contains(prefix + feature)
+    val fullName = if owner ne NoSymbol then toPrefix(owner) + feature else feature.toString
+    ctx.base.settings.language.value.contains(fullName)
 
   /** Is `feature` enabled by by an import? This is the case if the feature
    *  is imported by a named import

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -181,6 +181,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val YnoDecodeStacktraces: Setting[Boolean] = BooleanSetting("-Yno-decode-stacktraces", "Show raw StackOverflow stacktraces, instead of decoding them into triggering operations.")
 
   val Yinstrument: Setting[Boolean] = BooleanSetting("-Yinstrument", "Add instrumentation code that counts allocations and closure creations.")
+  val YinstrumentDefs: Setting[Boolean] = BooleanSetting("-Yinstrument-defs", "Add instrumentation code that counts method calls; needs -Yinstrument to be set, too.")
 
   /** Dottydoc specific settings */
   val siteRoot: Setting[String] = StringSetting(

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -211,7 +211,9 @@ class TypeApplications(val self: Type) extends AnyVal {
    */
   def hkResult(using Context): Type = self.dealias match {
     case self: TypeRef =>
-      if (self.symbol == defn.AnyKindClass) self else self.info.hkResult
+      if self.symbol.isClass then
+        if self.symbol == defn.AnyKindClass then self else NoType
+      else self.info.hkResult
     case self: AppliedType =>
       if (self.tycon.typeSymbol.isClass) NoType else self.superType.hkResult
     case self: HKTypeLambda => self.resultType

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -565,7 +565,7 @@ object Scanners {
         lastOffset = prev.lastOffset
         lineOffset = prev.lineOffset
       }
-      token match {
+      (token: @switch) match {
         case CASE =>
           lookAhead()
           if (token == CLASS) fuse(CASECLASS)
@@ -601,8 +601,8 @@ object Scanners {
           if colonSyntax then observeColonEOL()
         case RBRACE | RPAREN | RBRACKET =>
           closeIndented()
-        case EOF if !source.maybeIncomplete =>
-          closeIndented()
+        case EOF =>
+          if !source.maybeIncomplete then closeIndented()
         case _ =>
       }
     }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2533,7 +2533,7 @@ class Typer extends Namer
         !tree.isInstanceOf[Applications.IntegratedTypeArgs])
           // don't interpolate in the middle of an extension method application
       if (!tree.tpe.widen.isInstanceOf[MethodOrPoly] // wait with simplifying until method is fully applied
-          || tree.isDef) {                             // ... unless tree is a definition
+          || tree.isDef) {                           // ... unless tree is a definition
         interpolateTypeVars(tree, pt, locked)
         tree.overwriteType(tree.tpe.simplified)
       }

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -9,7 +9,7 @@ import collection.mutable
 
 @sharable object Stats {
 
-  final val enabled = false
+  final val enabled = true
 
   var monitored: Boolean = false
 

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -9,7 +9,7 @@ import collection.mutable
 
 @sharable object Stats {
 
-  final val enabled = true
+  final val enabled = false
 
   var monitored: Boolean = false
 


### PR DESCRIPTION
Break some often-called large methods into smaller pieces while also optimizing order of pattern tests

