### PR TITLE
Encode QuoteContext hashing directly in hashCode

### DIFF
--- a/library/src-bootstrapped/scala/internal/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/internal/quoted/Expr.scala
@@ -20,7 +20,7 @@ import scala.internal.tasty.CompilerInterface.quoteContextWithCompilerInterface
   }
 
   def unseal(using qctx: QuoteContext): qctx.tasty.Term =
-    if (quoteContextWithCompilerInterface(qctx).tasty.compilerId != scopeId)
+    if (qctx.hashCode != scopeId)
       throw new scala.quoted.ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
     tree.asInstanceOf[qctx.tasty.Term]
 

--- a/library/src-bootstrapped/scala/internal/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/internal/quoted/Type.scala
@@ -15,7 +15,7 @@ final class Type[Tree](val typeTree: Tree, val scopeId: Int) extends scala.quote
 
   /** View this expression `quoted.Type[T]` as a `TypeTree` */
   def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree =
-    if (quoteContextWithCompilerInterface(qctx).tasty.compilerId != scopeId)
+    if (qctx.hashCode != scopeId)
       throw new scala.quoted.ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
     typeTree.asInstanceOf[qctx.tasty.TypeTree]
 

--- a/library/src-bootstrapped/scala/internal/quoted/Unpickler.scala
+++ b/library/src-bootstrapped/scala/internal/quoted/Unpickler.scala
@@ -15,7 +15,7 @@ object Unpickler {
   def unpickleExpr[T](repr: PickledQuote, args: PickledArgs): QuoteContext ?=> Expr[T] =
     val qctx = quoteContextWithCompilerInterface(summon[QuoteContext])
     val tree = qctx.tasty.unpickleExpr(repr, args)
-    new scala.internal.quoted.Expr(tree, qctx.tasty.compilerId).asInstanceOf[Expr[T]]
+    new scala.internal.quoted.Expr(tree, qctx.hashCode).asInstanceOf[Expr[T]]
 
   /** Unpickle `repr` which represents a pickled `Type` tree,
    *  replacing splice nodes with `args`
@@ -23,6 +23,6 @@ object Unpickler {
   def unpickleType[T](repr: PickledQuote, args: PickledArgs): QuoteContext ?=> Type[T] =
     val qctx = quoteContextWithCompilerInterface(summon[QuoteContext])
     val tree = qctx.tasty.unpickleType(repr, args)
-    new scala.internal.quoted.Type(tree, qctx.tasty.compilerId).asInstanceOf[Type[T]]
+    new scala.internal.quoted.Type(tree, qctx.hashCode).asInstanceOf[Type[T]]
 
 }

--- a/library/src-non-bootstrapped/scala/internal/quoted/Expr.scala
+++ b/library/src-non-bootstrapped/scala/internal/quoted/Expr.scala
@@ -20,7 +20,7 @@ import scala.internal.tasty.CompilerInterface.quoteContextWithCompilerInterface
   }
 
   def unseal(using qctx: QuoteContext): qctx.tasty.Term =
-    if (quoteContextWithCompilerInterface(qctx).tasty.compilerId != scopeId)
+    if (qctx.hashCode != scopeId)
       throw new scala.quoted.ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
     tree.asInstanceOf[qctx.tasty.Term]
 

--- a/library/src-non-bootstrapped/scala/internal/quoted/Type.scala
+++ b/library/src-non-bootstrapped/scala/internal/quoted/Type.scala
@@ -15,7 +15,7 @@ final class Type[Tree](val typeTree: Tree, val scopeId: Int) extends scala.quote
 
   /** View this expression `quoted.Type[T]` as a `TypeTree` */
   def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree =
-    if (quoteContextWithCompilerInterface(qctx).tasty.compilerId != scopeId)
+    if (qctx.hashCode != scopeId)
       throw new scala.quoted.ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
     typeTree.asInstanceOf[qctx.tasty.TypeTree]
 

--- a/library/src/scala/internal/tasty/CompilerInterface.scala
+++ b/library/src/scala/internal/tasty/CompilerInterface.scala
@@ -51,17 +51,11 @@ trait CompilerInterface { self: scala.tasty.Reflection =>
    */
   def typeTreeMatch(scrutinee: TypeTree, pattern: TypeTree): Option[Tuple]
 
-  //
-  // TYPES
-  //
-
   /** Symbol of scala.internal.quoted.Patterns.patternHole */
-  def Definitions_InternalQuotedPatterns_patternHole: Symbol
+  def Definitions_InternalQuotedPatterns_patternHole: Symbol // TODO remove
 
   /** Symbol of scala.internal.quoted.Patterns.higherOrderHole */
-  def Definitions_InternalQuotedPatterns_higherOrderHole: Symbol
-
-  def compilerId: Int
+  def Definitions_InternalQuotedPatterns_higherOrderHole: Symbol // TODO remove
 
 }
 


### PR DESCRIPTION
This hash is used to detect scope extrusions across compiler instances and runs.