### PR TITLE
Minimal enums with precise apply methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1146,6 +1146,11 @@ object Types {
       case _ => this
     }
 
+    /** if this type is a reference to a class case of an enum, replace it by its first parent */
+    final def widenEnumCase(using Context): Type = this match
+      case tp: (TypeRef | AppliedType) if tp.classSymbol.isAllOf(EnumCase) => tp.parents.head
+      case _ => this
+
     /** Widen this type and if the result contains embedded union types, replace
      *  them by their joins.
      *  "Embedded" means: inside type lambdas, intersections or recursive types, or in prefixes of refined types.

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -1399,8 +1399,8 @@ object Scanners {
 
   object IndentWidth {
     private inline val MaxCached = 40
-    private val spaces = Array.tabulate(MaxCached + 1)(new Run(' ', _))
-    private val tabs = Array.tabulate(MaxCached + 1)(new Run('\t', _))
+    private val spaces = Array.tabulate[Run](MaxCached + 1)(new Run(' ', _)) // TODO: remove new after bootstrap
+    private val tabs = Array.tabulate[Run](MaxCached + 1)(new Run('\t', _)) // TODO: remove new after bootstrap
 
     def Run(ch: Char, n: Int): Run =
       if (n <= MaxCached && ch == ' ') spaces(n)

--- a/compiler/test-resources/type-printer/enum-precise
+++ b/compiler/test-resources/type-printer/enum-precise
@@ -1,0 +1,12 @@
+scala> enum Maybe[+T] { case Something(value: T); case EmptyValue }; import Maybe._
+// defined class Maybe
+
+scala> List(Something(1))
+val res0: List[Maybe[Int]] = List(Something(1))
+
+scala> def listOfSomething[O <: Maybe.Something[_]](listOfSomething: List[O]): listOfSomething.type = listOfSomething
+def listOfSomething
+  [O <: Maybe.Something[?]](listOfSomething: List[O]): listOfSomething.type
+
+scala> listOfSomething(List(Something(1)))
+val res1: List[Maybe.Something[Int]] = List(Something(1))

--- a/tests/patmat/i7186.scala
+++ b/tests/patmat/i7186.scala
@@ -172,7 +172,7 @@ object printMips {
 
     def oneAddr[O]
       ( a: O, indent: String)
-      ( r: O => Dest,
+      ( r: a.type => Dest,
       ): String = {
         val name = a.getClass.getSimpleName.toLowerCase
         s"${indent}$name ${rsrc(r(a))}$endl"
@@ -180,8 +180,8 @@ object printMips {
 
     def twoAddr[O]
       ( a: O, indent: String)
-      ( d: O => Register,
-        r: O => Dest | Constant
+      ( d: a.type => Register,
+        r: a.type => Dest | Constant
       ): String = {
         val name = a.getClass.getSimpleName.toLowerCase
         s"${indent}$name ${registers(d(a))}, ${rsrc(r(a))}$endl"
@@ -190,9 +190,9 @@ object printMips {
     def threeAddr[O]
       ( a: O,
         indent: String )
-      ( d: O => Register,
-        l: O => Register,
-        r: O => Src
+      ( d: a.type => Register,
+        l: a.type => Register,
+        r: a.type => Src
       ): String = {
         val name = a.getClass.getSimpleName.toLowerCase
         s"${indent}$name ${registers(d(a))}, ${registers(l(a))}, ${rsrc(r(a))}$endl"

--- a/tests/pos/i3935.scala
+++ b/tests/pos/i3935.scala
@@ -1,0 +1,10 @@
+enum Foo3[T](x: T) {
+  case Bar[S, T](y: T) extends Foo3[y.type](y)
+}
+
+val foo: Foo3.Bar[Nothing, 3] = Foo3.Bar(3)
+val bar = foo
+
+def baz[T](f: Foo3[T]): f.type = f
+
+val qux = baz(bar) // existentials are back in Dotty?

--- a/tests/run-macros/enum-nat-macro/Macros_2.scala
+++ b/tests/run-macros/enum-nat-macro/Macros_2.scala
@@ -1,0 +1,30 @@
+import Nat._
+
+ inline def toIntMacro(inline nat: Nat): Int = ${ Macros.toIntImpl('nat) }
+ inline def ZeroMacro: Zero.type = ${ Macros.natZero }
+ transparent inline def toNatMacro(inline int: Int): Nat = ${ Macros.toNatImpl('int) }
+
+ object Macros:
+   import quoted._
+
+   def toIntImpl(nat: Expr[Nat])(using QuoteContext): Expr[Int] =
+
+     def inner(nat: Expr[Nat], acc: Int): Int = nat match
+       case '{ Succ($nat) } => inner(nat, acc + 1)
+       case '{ Zero       } => acc
+
+     Expr(inner(nat, 0))
+
+   def natZero(using QuoteContext): Expr[Nat.Zero.type] = '{Zero}
+
+   def toNatImpl(int: Expr[Int])(using QuoteContext): Expr[Nat] =
+
+     // it seems even with the bound that the arg will always widen to Expr[Nat] unless explicit
+
+     def inner[N <: Nat: Type](int: Int, acc: Expr[N]): Expr[Nat] = int match
+       case 0 => acc
+       case n => inner[Succ[N]](n - 1, '{Succ($acc)})
+
+     val Const(i) = int
+     require(i >= 0)
+     inner[Zero.type](i, '{Zero})

--- a/tests/run-macros/enum-nat-macro/Nat_1.scala
+++ b/tests/run-macros/enum-nat-macro/Nat_1.scala
@@ -1,0 +1,3 @@
+enum Nat:
+  case Zero
+  case Succ[N <: Nat](n: N)

--- a/tests/run-macros/enum-nat-macro/Test_3.scala
+++ b/tests/run-macros/enum-nat-macro/Test_3.scala
@@ -1,0 +1,9 @@
+import Nat._
+
+@main def Test: Unit =
+  assert(toIntMacro(Succ(Succ(Succ(Zero)))) == 3)
+  assert(toNatMacro(3) == Succ(Succ(Succ(Zero))))
+  val zero: Zero.type = ZeroMacro
+  assert(zero == Zero)
+  assert(toIntMacro(toNatMacro(3)) == 3)
+  val n: Succ[Succ[Succ[Zero.type]]] = toNatMacro(3)

--- a/tests/run-macros/i8007.check
+++ b/tests/run-macros/i8007.check
@@ -11,5 +11,7 @@ true
 
 true
 
+true
+
 false
 

--- a/tests/run-macros/i8007/Macro_3.scala
+++ b/tests/run-macros/i8007/Macro_3.scala
@@ -73,7 +73,7 @@ object Eq {
 }
 
 object Macro3 {
-  extension [T](x: =>T) inline def === (y: =>T)(using eq: Eq[T]): Boolean = eq.eqv(x, y)
+  extension [T](inline x: T) inline def === (inline y: T)(using eq: Eq[T]): Boolean = eq.eqv(x, y)
 
   implicit inline def eqGen[T]: Eq[T] = ${ Eq.derived[T] }
 }

--- a/tests/run-macros/i8007/Test_4.scala
+++ b/tests/run-macros/i8007/Test_4.scala
@@ -6,7 +6,12 @@ import Macro3.eqGen
 case class Person(name: String, age: Int)
 
 enum Opt[+T] {
-  case Sm[T](t: T) extends Opt[T]
+  case Sm(t: T)
+  case Nn
+}
+
+enum OptInv[+T] {
+  case Sm[T](t: T) extends OptInv[T]
   case Nn
 }
 
@@ -31,6 +36,11 @@ enum Opt[+T] {
   println
 
   val t5 = Sm(23) === Sm(23)
+  println(t5) // true
+  println
+
+  // Here invariant case without explicit type parameter will instantiate T to OptInv[Any]
+  val t5_2 = OptInv.Sm[Int](23) === OptInv.Sm(23)
   println(t5) // true
   println
 

--- a/tests/run/enums-precise.scala
+++ b/tests/run/enums-precise.scala
@@ -1,0 +1,31 @@
+enum NonEmptyList[+T]:
+  case Many[+U](head: U, tail: NonEmptyList[U]) extends NonEmptyList[U]
+  case One [+U](value: U)                       extends NonEmptyList[U]
+
+enum Ast:
+  case Binding(name: String, tpe: String)
+  case Lambda(args: NonEmptyList[Binding], rhs: Ast) // reference to another case of the enum
+  case Ident(name: String)
+  case Apply(fn: Ast, args: NonEmptyList[Ast])
+
+import NonEmptyList._
+import Ast._
+
+// This example showcases the widening when inferring enum case types.
+// With scala 2 case class hierarchies, if One.apply(1) returns One[Int] and Many.apply(2, One(3)) returns Many[Int]
+// then the `foldRight` expression below would complain that Many[Binding] is not One[Binding]. With Scala 3 enums,
+// .apply on the companion returns the precise class, but type inference will widen to NonEmptyList[Binding] unless
+// the precise class is expected.
+def Bindings(arg: (String, String), args: (String, String)*): NonEmptyList[Binding] =
+  def Bind(arg: (String, String)): Binding =
+    val (name, tpe) = arg
+    Binding(name, tpe)
+
+  args.foldRight(One[Binding](Bind(arg)))((arg, acc) => Many(Bind(arg), acc))
+
+@main def Test: Unit =
+  val OneOfOne: One[1] = One[1](1)
+  val True = Lambda(Bindings("x" -> "T", "y" -> "T"), Ident("x"))
+  val Const = Lambda(One(Binding("x", "T")), Lambda(One(Binding("y", "U")), Ident("x"))) // precise type is forwarded
+
+  assert(OneOfOne.value == 1)


### PR DESCRIPTION
This is a reworking of #9728 with the complete semantics detailed below:

- All case class companions generate `copy`, `apply` and `unapply` with explicit result types, including when they are an enum. This result type is a fully applied reference to the case class.

- In type inference, after widening singleton types and union types, check the upper bound. If the upper bound is a class enum case, keep the type, else replace top-level reference to a class enum case with a reference to its parent enum type.

Included in the tests are some demonstrations of reducing enums with quoted pattern match, and some type inference checks

**Non Goals in this PR:**
- make recursive enums such as type level `Nat` work with inline match