### PR TITLE
Fix #9911: Remove Override flag from varargs forwarder when there is no forwarder to override

### DIFF
--- a/tests/pos/varargs-annot-override.scala
+++ b/tests/pos/varargs-annot-override.scala
@@ -1,0 +1,24 @@
+import scala.annotation.varargs
+
+abstract class NoAnnot {
+  // java varargs forwarder: no
+  def f(args: String*): Unit
+}
+class B1 extends NoAnnot {
+  // java varargs forwarder: no
+  override def f(args: String*) = ()
+}
+class B2 extends NoAnnot {
+  // java varargs forwarder: yes, but it doesn't override anything
+  @varargs
+  override def f(args: String*) = ()
+}
+class C1 extends B2 {
+  // java varargs forwarder: yes, overrides parent forwarder
+  override def f(args: String*) = ()
+}
+class C2 extends B2 {
+  // java varargs forwarder: yes, overrides parent forwarder
+  @varargs
+  override def f(args: String*) = ()
+}


### PR DESCRIPTION
When the method overrides something but the forwarder doesn't, it is wrong to mark the latter as `Override` in all cases. This PR removes the flag when necessary.