### PR TITLE
Don't use a special representation for Java enum values

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -488,7 +488,7 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
     // ---------------- emitting constant values ----------------
 
     /*
-     * For const.tag in {ClazzTag, EnumTag}
+     * For ClazzTag:
      *   must-single-thread
      * Otherwise it's safe to call from multiple threads.
      */
@@ -526,22 +526,6 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
             )
           else
             mnode.visitLdcInsn(tp.toASMType)
-
-        case EnumTag   =>
-          val sym       = const.symbolValue
-          val ownerName = internalName(sym.owner)
-          val fieldName = sym.javaSimpleName
-          val underlying = sym.info match { // TODO: Is this actually necessary? Could it be replaced by a call to widen?
-            case t: TypeProxy => t.underlying
-            case t => t
-          }
-          val fieldDesc = toTypeKind(underlying).descriptor
-          mnode.visitFieldInsn(
-            asm.Opcodes.GETSTATIC,
-            ownerName,
-            fieldName,
-            fieldDesc
-          )
 
         case _ => abort(s"Unknown constant value: $const")
       }

--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -377,14 +377,10 @@ trait BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
               assert(const.value != null, const) // TODO this invariant isn't documented in `case class Constant`
               av.visit(name, const.stringValue) // `stringValue` special-cases null, but that execution path isn't exercised for a const with StringTag
             case ClazzTag => av.visit(name, typeToTypeKind(TypeErasure.erasure(const.typeValue))(bcodeStore)(innerClasesStore).toASMType)
-            case EnumTag =>
-              val edesc = innerClasesStore.typeDescriptor(const.tpe) // the class descriptor of the enumeration class.
-              val evalue = const.symbolValue.javaSimpleName // value the actual enumeration value.
-              av.visitEnum(name, edesc, evalue)
           }
         case Ident(nme.WILDCARD) =>
           // An underscore argument indicates that we want to use the default value for this parameter, so do not emit anything
-        case t: tpd.RefTree if t.symbol.denot.owner.isAllOf(JavaEnumTrait) =>
+        case t: tpd.RefTree if t.symbol.owner.linkedClass.isAllOf(JavaEnumTrait) =>
           val edesc = innerClasesStore.typeDescriptor(t.tpe) // the class descriptor of the enumeration class.
           val evalue = t.symbol.javaSimpleName // value the actual enumeration value.
           av.visitEnum(name, edesc, evalue)
@@ -454,7 +450,7 @@ trait BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
 
     private def retentionPolicyOf(annot: Annotation): Symbol =
       annot.tree.tpe.typeSymbol.getAnnotation(AnnotationRetentionAttr).
-        flatMap(_.argumentConstant(0).map(_.symbolValue)).getOrElse(AnnotationRetentionClassAttr)
+        flatMap(_.argument(0).map(_.tpe.termSymbol)).getOrElse(AnnotationRetentionClassAttr)
 
     private def assocsFromApply(tree: Tree): List[(Name, Tree)] = {
       tree match {

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -1223,8 +1223,6 @@ class JSCodeGen()(using genCtx: Context) {
             js.Null()
           case ClazzTag =>
             genClassConstant(value.typeValue)
-          case EnumTag =>
-            genLoadStaticField(value.symbolValue)
         }
 
       case Block(stats, expr) =>

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -460,6 +460,9 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def ref(tp: NamedType)(using Context): Tree =
     TypedSplice(tpd.ref(tp))
 
+  def ref(sym: Symbol)(using Context): Tree =
+    TypedSplice(tpd.ref(sym))
+
   def rawRef(tp: NamedType)(using Context): Tree =
     if tp.typeParams.isEmpty then ref(tp)
     else AppliedTypeTree(ref(tp), tp.typeParams.map(_ => WildcardTypeBoundsTree()))

--- a/compiler/src/dotty/tools/dotc/core/Constants.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constants.scala
@@ -20,8 +20,6 @@ object Constants {
   final val StringTag  = 10
   final val NullTag    = 11
   final val ClazzTag   = 12
-  // For supporting java enumerations inside java annotations (see ClassfileParser)
-  final val EnumTag    = 13
 
   class Constant(val value: Any, val tag: Int) extends printing.Showable with Product1[Any] {
     import java.lang.Double.doubleToRawLongBits
@@ -50,7 +48,6 @@ object Constants {
       case StringTag      => defn.StringType
       case NullTag        => defn.NullType
       case ClazzTag       => defn.ClassType(typeValue)
-      case EnumTag        => defn.EnumType(symbolValue)
     }
 
     /** We need the equals method to take account of tags as well as values.
@@ -190,7 +187,6 @@ object Constants {
     def toText(printer: Printer): Text = printer.toText(this)
 
     def typeValue: Type     = value.asInstanceOf[Type]
-    def symbolValue: Symbol = value.asInstanceOf[Symbol]
 
     /**
      * Consider two `NaN`s to be identical, despite non-equality
@@ -237,7 +233,6 @@ object Constants {
     def apply(x: String): Constant       = new Constant(x, StringTag)
     def apply(x: Char): Constant         = new Constant(x, CharTag)
     def apply(x: Type): Constant         = new Constant(x, ClazzTag)
-    def apply(x: Symbol): Constant       = new Constant(x, EnumTag)
     def apply(value: Any): Constant      =
       new Constant(value,
         value match {
@@ -253,7 +248,6 @@ object Constants {
           case x: String       => StringTag
           case x: Char         => CharTag
           case x: Type         => ClazzTag
-          case x: Symbol       => EnumTag
         }
       )
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -152,9 +152,6 @@ class TreePickler(pickler: TastyPickler) {
     case ClazzTag =>
       writeByte(CLASSconst)
       pickleType(c.typeValue)
-    case EnumTag =>
-      writeByte(ENUMconst)
-      pickleType(c.symbolValue.termRef)
   }
 
   def pickleVariances(tp: Type)(using Context): Unit = tp match

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -286,8 +286,6 @@ class TreeUnpickler(reader: TastyReader,
         Constant(null)
       case CLASSconst =>
         Constant(readType())
-      case ENUMconst =>
-        Constant(readTermRef().termSymbol)
     }
 
     /** Read a type */

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -528,7 +528,6 @@ class PlainPrinter(_ctx: Context) extends Printer {
     case ClazzTag => "classOf[" ~ toText(const.typeValue) ~ "]"
     case CharTag => literalText(s"'${escapedChar(const.charValue)}'")
     case LongTag => literalText(const.longValue.toString + "L")
-    case EnumTag => literalText(const.symbolValue.name.toString)
     case _ => literalText(String.valueOf(const.value))
   }
 

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -141,7 +141,6 @@ Standard-Section: "ASTs" TopLevelStat*
                   STRINGconst           NameRef                                    -- A string literal
                   NULLconst                                                        -- null
                   CLASSconst            Type                                       -- classOf[Type]
-                  ENUMconst             Path                                       -- An enum constant
 
   Type          = Path                                                             -- Paths represent both types and terms
                   TYPEREFdirect         sym_ASTRef                                 -- A reference to a local symbol (without a prefix). Reference is to definition node of symbol.
@@ -254,7 +253,7 @@ Standard Section: "Comments" Comment*
 object TastyFormat {
 
   final val header: Array[Int] = Array(0x5C, 0xA1, 0xAB, 0x1F)
-  val MajorVersion: Int = 23
+  val MajorVersion: Int = 24
   val MinorVersion: Int = 0
 
   /** Tags used to serialize names, should update [[nameTagToString]] if a new constant is added */
@@ -387,17 +386,16 @@ object TastyFormat {
   final val THIS = 80
   final val QUALTHIS = 81
   final val CLASSconst = 82
-  final val ENUMconst = 83
-  final val BYNAMEtype = 84
-  final val BYNAMEtpt = 85
-  final val NEW = 86
-  final val THROW = 87
-  final val IMPLICITarg = 88
-  final val PRIVATEqualified = 89
-  final val PROTECTEDqualified = 90
-  final val RECtype = 91
-  final val SINGLETONtpt = 92
-  final val BOUNDED = 93
+  final val BYNAMEtype = 83
+  final val BYNAMEtpt = 84
+  final val NEW = 85
+  final val THROW = 86
+  final val IMPLICITarg = 87
+  final val PRIVATEqualified = 88
+  final val PROTECTEDqualified = 89
+  final val RECtype = 90
+  final val SINGLETONtpt = 91
+  final val BOUNDED = 92
 
   // Cat. 4:    tag Nat AST
 
@@ -651,7 +649,6 @@ object TastyFormat {
     case QUALTHIS => "QUALTHIS"
     case SUPER => "SUPER"
     case CLASSconst => "CLASSconst"
-    case ENUMconst => "ENUMconst"
     case SINGLETONtpt => "SINGLETONtpt"
     case SUPERtype => "SUPERtype"
     case TERMREFin => "TERMREFin"


### PR DESCRIPTION
In Java, annotation arguments must be constants, so enum values are
treated specially. In Scala, annotation arguments can be whatever tree
we want, so we don't really need to represent them as
`Literal(Constant(enumValueSymbol))` and can just use a `TermRef` to the
enum value instead.

This commit implements this change, this has several advantages compared
to the status quo:
- The handling of Java enum values and Scala enum values is now less
  different.
- We can drop the handling of symbols in `Constant`
- ... and therefore remove one tag from Tasty.
- In turn, this means we don't have to worry about how to expose
  this in tasty-reflect.

This commit breaks the Tasty format and therefore bump its major version
to 24.