### PR TITLE
An alternative scheme for precise apply methods of enums

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -658,15 +658,6 @@ object desugar {
     // For all other classes, the parent is AnyRef.
     val companions =
       if (isCaseClass) {
-        // The return type of the `apply` method, and an (empty or singleton) list
-        // of widening coercions
-        val (applyResultTpt, widenDefs) =
-          if (!isEnumCase)
-            (TypeTree(), Nil)
-          else if (parents.isEmpty || enumClass.typeParams.isEmpty)
-            (enumClassTypeRef, Nil)
-          else
-            enumApplyResult(cdef, parents, derivedEnumParams, appliedRef(enumClassRef, derivedEnumParams))
 
         // true if access to the apply method has to be restricted
         // i.e. if the case class constructor is either private or qualified private
@@ -697,8 +688,6 @@ object desugar {
           then anyRef
           else
             constrVparamss.foldRight(classTypeRef)((vparams, restpe) => Function(vparams map (_.tpt), restpe))
-        def widenedCreatorExpr =
-          widenDefs.foldLeft(creatorExpr)((rhs, meth) => Apply(Ident(meth.name), rhs :: Nil))
         val applyMeths =
           if (mods.is(Abstract)) Nil
           else {
@@ -711,9 +700,8 @@ object desugar {
             val appParamss =
               derivedVparamss.nestedZipWithConserve(constrVparamss)((ap, cp) =>
                 ap.withMods(ap.mods | (cp.mods.flags & HasDefault)))
-            val app = DefDef(nme.apply, derivedTparams, appParamss, applyResultTpt, widenedCreatorExpr)
-              .withMods(appMods)
-            app :: widenDefs
+            DefDef(nme.apply, derivedTparams, appParamss, TypeTree(), creatorExpr)
+              .withMods(appMods) :: Nil
           }
         val unapplyMeth = {
           val hasRepeatedParam = constrVparamss.head.exists {

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2625,6 +2625,9 @@ object TypeComparer {
   def widenInferred(inst: Type, bound: Type)(using Context): Type =
     comparing(_.widenInferred(inst, bound))
 
+  def dropSuperTraits(tp: Type, bound: Type)(using Context): Type =
+    comparing(_.dropSuperTraits(tp, bound))
+
   def constrainPatternType(pat: Type, scrut: Type)(using Context): Boolean =
     comparing(_.constrainPatternType(pat, scrut))
 

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -160,6 +160,9 @@ object SymUtils {
   def isField(using Context): Boolean =
     self.isTerm && !self.is(Method)
 
+  def isEnumCase(using Context): Boolean =
+    self.isAllOf(EnumCase, butNot = JavaDefined)
+
   def annotationsCarrying(meta: ClassSymbol)(using Context): List[Annotation] =
     self.annotations.filter(_.symbol.hasAnnotation(meta))
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1112,8 +1112,8 @@ trait Applications extends Compatibility {
 
   /** If `tree` is a complete application of a compiler-generated `apply`
    *  or `copy` method of an enum case, widen its type to the underlying
-   *  type by means of a type ascription, unless the expected type is an
-   *  enum case itself.
+   *  type by means of a type ascription, as long as the widened type is
+   *  still compatible with the expected type.
    *  The underlying type is the intersection of all class parents of the
    *  orginal type.
    */

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -132,6 +132,9 @@ class ReTyper extends Typer with ReChecking {
   override def inferView(from: Tree, to: Type)(using Context): Implicits.SearchResult =
     Implicits.NoMatchingImplicitsFailure
   override def checkCanEqual(ltp: Type, rtp: Type, span: Span)(using Context): Unit = ()
+
+  override def widenEnumCase(tree: Tree, pt: Type)(using Context): Tree = tree
+
   override protected def addAccessorDefs(cls: Symbol, body: List[Tree])(using Context): List[Tree] = body
   override protected def checkEqualityEvidence(tree: tpd.Tree, pt: Type)(using Context): Unit = ()
   override protected def matchingApply(methType: MethodOrPoly, pt: FunProto)(using Context): Boolean = true

--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -52,11 +52,15 @@ Note that the type of the expressions above is always `Option`. That
 is, the implementation case classes are not visible in the result
 types of their `apply` methods. This is a subtle difference with
 respect to normal case classes. The classes making up the cases do
-exist, and can be unveiled by constructing them directly with a `new`.
+exist, and can be unveiled, either by constructing them directly with a `new`,
+or by explicitly providing an expected type.
+
 
 ```scala
 scala> new Option.Some(2)
-val res3: t2.Option.Some[Int] = Some(2)
+val res3: Option.Some[Int] = Some(2)
+scala> val x: Option.Some[Int] = Option.Some(3)
+val res4: Option.Some[Int] = Some(3)
 ```
 
 As all other enums, ADTs can define methods. For instance, here is `Option` again, with an

--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -48,13 +48,7 @@ scala> Option.None
 val res2: t2.Option[Nothing] = None
 ```
 
-Note that the type of the expressions above is always `Option`. That
-is, the implementation case classes are not visible in the result
-types of their `apply` methods. This is a subtle difference with
-respect to normal case classes. The classes making up the cases do
-exist, and can be unveiled, either by constructing them directly with a `new`,
-or by explicitly providing an expected type.
-
+Note that the type of the expressions above is always `Option`. Generally, the type of a enum case constructor application will be widened to the underlying enum type, unless a more specific type is expected. This is a subtle difference with respect to normal case classes. The classes making up the cases do exist, and can be unveiled, either by constructing them directly with a `new`, or by explicitly providing an expected type.
 
 ```scala
 scala> new Option.Some(2)

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -139,10 +139,7 @@ map into `case class`es or `val`s.
    ```scala
    final case class C <params> extends <parents>
    ```
-   However, unlike for a regular case class, the return type of the associated
-   `apply` method is a fully parameterized type instance of the enum class `E`
-   itself instead of `C`.  Also the enum case defines an `ordinal` method of
-   the form
+   The enum case defines an `ordinal` method of the form
    ```scala
    def ordinal = n
    ```
@@ -153,6 +150,14 @@ map into `case class`es or `val`s.
    in a parameter type in `<params>` or in a type argument of `<parents>`, unless that parameter is already
    a type parameter of the case, i.e. the parameter name is defined in `<params>`.
 
+   The compiler-generated `apply` and `copy` methods of an enum case
+   ```scala
+   case C(ps) extends P1, ..., Pn
+   ```
+   are treated specially. A call `C(ts)` of the apply method is ascribed the underlying type
+   `P1 & ... & Pn` (dropping any [super traits](../other-new-features/super-traits.html))
+   as long as that type is still compatible with the expected type at the point of application.
+   A call `t.copy(ts)` of `C`'s `copy` method is treated in the same way.
 
 ### Translation of Enums with Singleton Cases
 

--- a/tests/pos/enum-widen.scala
+++ b/tests/pos/enum-widen.scala
@@ -13,4 +13,9 @@ object test:
   x = None
   xc = None
 
+  enum Nat:
+    case Z
+    case S[N <: Z.type | S[_]](pred: N)
+  import Nat._
 
+  val two = S(S(Z))

--- a/tests/pos/enum-widen.scala
+++ b/tests/pos/enum-widen.scala
@@ -1,0 +1,16 @@
+object test:
+
+  enum Option[+T]:
+    case Some[T](x: T) extends Option[T]
+    case None
+
+  import Option._
+
+  var x = Some(1)
+  val y: Some[Int] = Some(2)
+  var xc = y.copy(3)
+  val yc: Some[Int] = y.copy(3)
+  x = None
+  xc = None
+
+

--- a/tests/pos/i3935.scala
+++ b/tests/pos/i3935.scala
@@ -1,0 +1,10 @@
+enum Foo3[T](x: T) {
+  case Bar[S, T](y: T) extends Foo3[y.type](y)
+}
+
+val foo: Foo3.Bar[Nothing, 3] = Foo3.Bar(3)
+val bar = foo
+
+def baz[T](f: Foo3[T]): f.type = f
+
+val qux = baz(bar) // existentials are back in Dotty?

--- a/tests/run-macros/enum-nat-macro/Macros_2.scala
+++ b/tests/run-macros/enum-nat-macro/Macros_2.scala
@@ -1,0 +1,30 @@
+import Nat._
+
+ inline def toIntMacro(inline nat: Nat): Int = ${ Macros.toIntImpl('nat) }
+ inline def ZeroMacro: Zero.type = ${ Macros.natZero }
+ transparent inline def toNatMacro(inline int: Int): Nat = ${ Macros.toNatImpl('int) }
+
+ object Macros:
+   import quoted._
+
+   def toIntImpl(nat: Expr[Nat])(using QuoteContext): Expr[Int] =
+
+     def inner(nat: Expr[Nat], acc: Int): Int = nat match
+       case '{ Succ($nat) } => inner(nat, acc + 1)
+       case '{ Zero       } => acc
+
+     Expr(inner(nat, 0))
+
+   def natZero(using QuoteContext): Expr[Nat.Zero.type] = '{Zero}
+
+   def toNatImpl(int: Expr[Int])(using QuoteContext): Expr[Nat] =
+
+     // it seems even with the bound that the arg will always widen to Expr[Nat] unless explicit
+
+     def inner[N <: Nat: Type](int: Int, acc: Expr[N]): Expr[Nat] = int match
+       case 0 => acc
+       case n => inner[Succ[N]](n - 1, '{Succ($acc)})
+
+     val Const(i) = int
+     require(i >= 0)
+     inner[Zero.type](i, '{Zero})

--- a/tests/run-macros/enum-nat-macro/Nat_1.scala
+++ b/tests/run-macros/enum-nat-macro/Nat_1.scala
@@ -1,0 +1,3 @@
+enum Nat:
+  case Zero
+  case Succ[N <: Nat](n: N)

--- a/tests/run-macros/enum-nat-macro/Test_3.scala
+++ b/tests/run-macros/enum-nat-macro/Test_3.scala
@@ -1,0 +1,9 @@
+import Nat._
+
+@main def Test: Unit =
+  assert(toIntMacro(Succ(Succ(Succ(Zero)))) == 3)
+  assert(toNatMacro(3) == Succ(Succ(Succ(Zero))))
+  val zero: Zero.type = ZeroMacro
+  assert(zero == Zero)
+  assert(toIntMacro(toNatMacro(3)) == 3)
+  val n: Succ[Succ[Succ[Zero.type]]] = toNatMacro(3)

--- a/tests/run-macros/i8007.check
+++ b/tests/run-macros/i8007.check
@@ -11,5 +11,7 @@ true
 
 true
 
+true
+
 false
 

--- a/tests/run-macros/i8007/Macro_3.scala
+++ b/tests/run-macros/i8007/Macro_3.scala
@@ -73,7 +73,7 @@ object Eq {
 }
 
 object Macro3 {
-  extension [T](x: =>T) inline def === (y: =>T)(using eq: Eq[T]): Boolean = eq.eqv(x, y)
+  extension [T](inline x: T) inline def === (inline y: T)(using eq: Eq[T]): Boolean = eq.eqv(x, y)
 
   implicit inline def eqGen[T]: Eq[T] = ${ Eq.derived[T] }
 }

--- a/tests/run-macros/i8007/Test_4.scala
+++ b/tests/run-macros/i8007/Test_4.scala
@@ -6,7 +6,12 @@ import Macro3.eqGen
 case class Person(name: String, age: Int)
 
 enum Opt[+T] {
-  case Sm[T](t: T) extends Opt[T]
+  case Sm(t: T)
+  case Nn
+}
+
+enum OptInv[+T] {
+  case Sm[T](t: T) extends OptInv[T]
   case Nn
 }
 
@@ -31,6 +36,11 @@ enum Opt[+T] {
   println
 
   val t5 = Sm(23) === Sm(23)
+  println(t5) // true
+  println
+
+  // Here invariant case without explicit type parameter will instantiate T to OptInv[Any]
+  val t5_2 = OptInv.Sm[Int](23) === OptInv.Sm(23)
   println(t5) // true
   println
 

--- a/tests/run-macros/i8007/Test_4.scala
+++ b/tests/run-macros/i8007/Test_4.scala
@@ -39,9 +39,8 @@ enum OptInv[+T] {
   println(t5) // true
   println
 
-  // Here invariant case without explicit type parameter will instantiate T to OptInv[Any]
-  val t5_2 = OptInv.Sm[Int](23) === OptInv.Sm(23)
-  println(t5) // true
+  val t5_2 = OptInv.Sm(23) === OptInv.Sm(23)
+  println(t5_2) // true
   println
 
   val t6 = Sm(Person("Test", 23)) === Sm(Person("Test", 23))

--- a/tests/run/enums-precise.scala
+++ b/tests/run/enums-precise.scala
@@ -1,0 +1,31 @@
+enum NonEmptyList[+T]:
+  case Many[+U](head: U, tail: NonEmptyList[U]) extends NonEmptyList[U]
+  case One [+U](value: U)                       extends NonEmptyList[U]
+
+enum Ast:
+  case Binding(name: String, tpe: String)
+  case Lambda(args: NonEmptyList[Binding], rhs: Ast) // reference to another case of the enum
+  case Ident(name: String)
+  case Apply(fn: Ast, args: NonEmptyList[Ast])
+
+import NonEmptyList._
+import Ast._
+
+// This example showcases the widening when inferring enum case types.
+// With scala 2 case class hierarchies, if One.apply(1) returns One[Int] and Many.apply(2, One(3)) returns Many[Int]
+// then the `foldRight` expression below would complain that Many[Binding] is not One[Binding]. With Scala 3 enums,
+// .apply on the companion returns the precise class, but type inference will widen to NonEmptyList[Binding] unless
+// the precise class is expected.
+def Bindings(arg: (String, String), args: (String, String)*): NonEmptyList[Binding] =
+  def Bind(arg: (String, String)): Binding =
+    val (name, tpe) = arg
+    Binding(name, tpe)
+
+  args.foldRight(One[Binding](Bind(arg)))((arg, acc) => Many(Bind(arg), acc))
+
+@main def Test: Unit =
+  val OneOfOne: One[1] = One[1](1)
+  val True = Lambda(Bindings("x" -> "T", "y" -> "T"), Ident("x"))
+  val Const = Lambda(One(Binding("x", "T")), Lambda(One(Binding("y", "U")), Ident("x"))) // precise type is forwarded
+
+  assert(OneOfOne.value == 1)


### PR DESCRIPTION
Keeps many elements from #9922 but the modality where we do the
widening is different. The new rule is as follows:

In an application of a compiler-generated apply or copy method of an enum case,
widen its type to the underlying supertype of the enum case by means of a type
ascription as long as the widened type is still compatible with the expected type.