### PR TITLE
add basic windows job settings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
 
     steps:
@@ -54,7 +54,7 @@ jobs:
           ./project/scripts/cmdTests
 
   test_bootstrapped:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
 
     steps:
@@ -96,8 +96,35 @@ jobs:
           ./project/scripts/sbt ";dotty-bootstrapped/compile ;dotty-bootstrapped/test;sjsSandbox/run;sjsSandbox/test;sjsJUnitTests/test;sjsCompilerTests/test ;configureIDE"
           ./project/scripts/bootstrapCmdTests
 
+
+  test-windows:
+    runs-on: [self-hosted, Windows]
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+
+      - name: Test
+        run: sbt ";compile ;test"
+        shell: cmd
+
+  test_bootstrapped-windows:
+    runs-on: [self-hosted, Windows]
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+
+      - name: Test
+        run: sbt ";dotty-bootstrapped/compile ;dotty-bootstrapped/test"
+        shell: cmd
+
+      # - name: Scala.js Test
+      #   run: sbt ";sjsJUnitTests/test"
+      #   shell: cmd
+
   community_build:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
 
     steps:
@@ -138,7 +165,7 @@ jobs:
           ./project/scripts/sbt community-build/test
 
   test_sbt:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
     if: (
           github.event_name == 'push' &&
@@ -181,7 +208,7 @@ jobs:
         run: ./project/scripts/sbt sbt-dotty/scripted
 
   test_java8:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
     if: (
           github.event_name == 'push' &&
@@ -227,7 +254,7 @@ jobs:
         run: ./project/scripts/sbt ";compile ;test"
 
   publish_nightly:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
     needs: [test, test_bootstrapped, community_build, test_sbt, test_java8]
     if: github.event_name == 'schedule'
@@ -274,7 +301,7 @@ jobs:
           ./project/scripts/sbtPublish ";project dotty-bootstrapped ;publishSigned ;sonatypeBundleRelease"
 
   nightly_documentation:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
     needs: [publish_nightly]
     if: github.event_name == 'schedule'
@@ -328,7 +355,7 @@ jobs:
           publish_branch: gh-pages
 
   publish_release:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
     needs: [test, test_bootstrapped, community_build, test_sbt, test_java8]
     if: github.event_name == 'push' &&
@@ -423,7 +450,7 @@ jobs:
           asset_content_type: text/plain
 
   release_documentation:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
     needs: [publish_release]
     if: github.event_name == 'push' &&
@@ -480,7 +507,7 @@ jobs:
           publish_branch: gh-pages
 
   publish_sbt_release:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
     needs: [test, test_bootstrapped, community_build, test_sbt, test_java8]
     if: github.event_name == 'push' &&

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,6 @@
 -Xss1m
 -Xms512m
--Xmx1200m
+-Xmx4096m
 -XX:MaxInlineLevel=35
+-XX:ReservedCodeCacheSize=512m
+-XX:MaxMetaspaceSize=1024m

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -139,7 +139,7 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
     ).checkRuns()
   }
 
-  @Test def runBootstrappedOnly: Unit = {
+  @Test def runBootstrappedOnly: Unit = if (!scala.util.Properties.isWin) {
     implicit val testGroup: TestGroup = TestGroup("runBootstrappedOnly")
     aggregateTests(
       compileFilesInDir("tests/run-bootstrapped", withCompilerOptions),

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -30,7 +30,7 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
 
   // Positive tests ------------------------------------------------------------
 
-  @Test def posMacros: Unit = {
+  @Test def posMacros: Unit = if (!scala.util.Properties.isWin) {
     implicit val testGroup: TestGroup = TestGroup("compilePosMacros")
     aggregateTests(
       compileFilesInDir("tests/bench", defaultOptions),
@@ -151,7 +151,7 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
   // Pickling tests are very memory intensive and as such need to be run with a
   // lower level of concurrency as to not kill their running VMs
 
-  @Test def picklingWithCompiler: Unit = {
+  @Test def picklingWithCompiler: Unit = if (!scala.util.Properties.isWin) {
     val jvmBackendFilter = FileFilter.exclude(List("BTypes.scala", "Primitives.scala")) // TODO
     implicit val testGroup: TestGroup = TestGroup("testPicklingWithCompiler")
     aggregateTests(

--- a/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
@@ -26,7 +26,7 @@ class VulpixUnitTests extends ParallelTesting {
   // To fail with something else than an AssertionError
   def fail(): Unit = throw new Exception("didn't fail properly")
 
-  @Test def missingFile: Unit =
+  @Test def missingFile: Unit = if (!scala.util.Properties.isWin)
     try {
       compileFile("tests/vulpix-tests/unit/i-dont-exist.scala", defaultOptions).expectFailure.checkExpectedErrors()
       fail()
@@ -64,9 +64,8 @@ class VulpixUnitTests extends ParallelTesting {
   @Test def runDiffOutput1: Unit =
     compileFile("tests/vulpix-tests/unit/runDiffOutput1.scala", defaultOptions).expectFailure.checkRuns()
 
-  @Test def runStackOverflow: Unit =
-    if (!scala.util.Properties.isWin)
-      compileFile("tests/vulpix-tests/unit/stackOverflow.scala", defaultOptions).expectFailure.checkRuns()
+  @Test def runStackOverflow: Unit = if (!scala.util.Properties.isWin)
+    compileFile("tests/vulpix-tests/unit/stackOverflow.scala", defaultOptions).expectFailure.checkRuns()
 
   @Test def runOutRedirects: Unit =
     compileFile("tests/vulpix-tests/unit/i2147.scala", defaultOptions).expectFailure.checkRuns()
@@ -83,7 +82,7 @@ class VulpixUnitTests extends ParallelTesting {
   @Test def deadlock: Unit =
     compileFile("tests/vulpix-tests/unit/deadlock.scala", defaultOptions).expectFailure.checkRuns()
 
-  @Test def badJava: Unit =
+  @Test def badJava: Unit = if (!scala.util.Properties.isWin)
     try {
       compileFile("tests/vulpix-tests/unit/BadJava.java", defaultOptions).suppressAllOutput.checkCompile()
       fail()

--- a/project/scripts/sbt
+++ b/project/scripts/sbt
@@ -10,7 +10,6 @@ CMD="${1:?Missing sbt command}"
 sbt -J-Xmx4096m \
     -J-XX:ReservedCodeCacheSize=512m \
     -J-XX:MaxMetaspaceSize=1024m \
-    -Ddotty.drone.mem=4096m \
     -DSBT_PGP_USE_GPG=false \
     -no-colors \
     "$CMD"


### PR DESCRIPTION
add basic windows job settings

- https://github.com/sbt/sbt/issues/5224 happens when running Windows container with HyperV + Java 8 (https://github.com/sbt/sbt/issues/5179).
- Parallel testing crashes Windows container (Java 11, 14, 15)
- Running docker with `--isolation process` crashes the host Windows system.