### PR TITLE
Change implicit conversions warnings

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3490,7 +3490,7 @@ class Typer extends Namer
           case SearchSuccess(found: ExtMethodApply, _, _) =>
             found // nothing to check or adapt for extension method applications
           case SearchSuccess(found, _, _) =>
-            checkImplicitConversionUseOK(found.symbol, tree.srcPos)
+            checkImplicitConversionUseOK(found)
             withoutMode(Mode.ImplicitsEnabled)(readapt(found))
           case failure: SearchFailure =>
             if (pt.isInstanceOf[ProtoType] && !failure.isAmbiguous) then

--- a/library/src/scala/Conversion.scala
+++ b/library/src/scala/Conversion.scala
@@ -19,4 +19,5 @@ package scala
 *  from two to one.
 */
 @java.lang.FunctionalInterface
-abstract class Conversion[-T, +U] extends Function1[T, U]
+abstract class Conversion[-T, +U] extends Function1[T, U]:
+  def apply(x: T): U

--- a/tests/neg-custom-args/impl-conv/A.scala
+++ b/tests/neg-custom-args/impl-conv/A.scala
@@ -3,7 +3,7 @@ package implConv
 object A {
 
   implicit def s2i(x: String): Int = Integer.parseInt(x) // error: feature
-  implicit val i2s: Conversion[Int, String] = _.toString // error: feature
+  given i2s as Conversion[Int, String] = _.toString // ok
 
   implicit class Foo(x: String) {
     def foo = x.length

--- a/tests/neg-custom-args/impl-conv/B.scala
+++ b/tests/neg-custom-args/impl-conv/B.scala
@@ -1,11 +1,10 @@
 package implConv
 
 object B {
-  import A._
+  import A.{_, given _}
 
   "".foo
 
-  val x: Int = ""  // error: feature
+  val x: Int = ""  // ok
   val y: String = 1 // error: feature
-
 }

--- a/tests/neg-custom-args/implicit-conversions-old.scala
+++ b/tests/neg-custom-args/implicit-conversions-old.scala
@@ -18,6 +18,6 @@ object Test {
   import D._
 
   val x1: A = new B
-  val x2: B = new A  // error under -Xfatal-warnings -feature
-  val x3: C = new A  // error under -Xfatal-warnings -feature
+  val x2: B = new A  // ok, since it's an old-style comversion
+  val x3: C = new A  // ok, since it's an old-style comversion
 }

--- a/tests/neg-custom-args/implicit-conversions.scala
+++ b/tests/neg-custom-args/implicit-conversions.scala
@@ -23,7 +23,7 @@ object D {
 object Test {
   import D.{given _}
 
-  val x1: A = new B
+  val x1: A = new B  // error under -Xfatal-warnings -feature
   val x2: B = new A  // error under -Xfatal-warnings -feature
   val x3: C = new A  // error under -Xfatal-warnings -feature
 }


### PR DESCRIPTION
Warn with a feature warning if

 - an old-style implicit def conversion is defined, or
 - a new style scala.Conversion instance is used as an implicit conversion

Do not warn if an old-style conversion is used. There are too many warnings
for this to work well. Instead, rely on the fact that old-style implicit
conversions will be deprecated over time.