### PR TITLE
Properly recover from nested ambiguous implicit search failures

### DIFF
--- a/tests/pos/i9793.scala
+++ b/tests/pos/i9793.scala
@@ -1,0 +1,20 @@
+trait Foo[F[_]]
+
+trait Bar[F[_]] extends Foo[F]
+trait Baz[F[_]] extends Foo[F]
+
+case class Applied[F[_], A](a: F[A])
+
+
+object Applied extends AppliedLowPrio {
+  implicit def barApplied[F[_]: Baz]: Baz[({ type L[X] = Applied[F, X] })#L] = ???
+}
+
+trait AppliedLowPrio {
+  implicit def bazApplied[F[_]: Foo]: Foo[({ type L[X] = Applied[F, X] })#L] = ???
+}
+
+
+object Test {
+  def test[F[_]](implicit bar: Bar[F], baz: Baz[F]) = implicitly[Foo[({ type L[X] = Applied[F, X] })#L]]
+}


### PR DESCRIPTION
From
http://dotty.epfl.ch/docs/reference/changed-features/implicit-resolution.html:

> The treatment of ambiguity errors has changed. If an ambiguity is
> encountered in some recursive step of an implicit search, the ambiguity
> is propagated to the caller.

This is supposed to be handled by `healAmbiguous` but the implementation
was incorrect: it compared pending candidates against the two ambiguous
results from the search, but this doesn't make sense when the failure
happened in a nested search: for example in `i9793`, the failure is:

    Applied.bazApplied[F](/* ambiguous: both value baz and value bar match type Foo[F] */summon[Foo[F])

We should be able to recover from this failure because `barApplied` is
more specific than `bazApplied`, but before this commit we ended up
comparing `barApplied` to `baz` and `bar` which isn't meaningful.

Fixes #9793.