### PR TITLE
Fix #9735: Tighten opaque types check

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -888,7 +888,7 @@ class Namer { typer: Typer =>
       val unsafeInfo = if (isDerived) rhsBodyType else abstracted(rhsBodyType)
 
       def opaqueToBounds(info: Type): Type =
-        if sym.isOpaqueAlias && tparamSyms.isEmpty && info.typeParams.nonEmpty then
+        if sym.isOpaqueAlias && info.typeParams.nonEmpty then
           report.error(em"opaque type alias must be fully applied", rhs.srcPos)
         sym.opaqueToBounds(info, rhs1, tparamSyms)
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -888,8 +888,8 @@ class Namer { typer: Typer =>
       val unsafeInfo = if (isDerived) rhsBodyType else abstracted(rhsBodyType)
 
       def opaqueToBounds(info: Type): Type =
-        if sym.isOpaqueAlias && info.typeParams.nonEmpty then
-          report.error(em"opaque type alias must be fully applied", rhs.srcPos)
+        if sym.isOpaqueAlias && info.typeParams.nonEmpty && info.hkResult.typeParams.nonEmpty then
+          report.error(em"opaque type alias cannot have multiple type parameter lists", rhs.srcPos)
         sym.opaqueToBounds(info, rhs1, tparamSyms)
 
       if (isDerived) sym.info = unsafeInfo

--- a/docs/docs/reference/other-new-features/opaques-details.md
+++ b/docs/docs/reference/other-new-features/opaques-details.md
@@ -46,6 +46,20 @@ object o {
 def id(x: o.T): o.T = x
 ```
 
+### Type Parameters of Opaque Types
+
+Opaque type aliases can have a single type parameter list. The following aliases
+are well-formed
+```scala
+opaque type F[T] = (T, T)
+opaque type G = [T] =>> List[T]
+```
+but the following are not:
+```scala
+opaque type BadF[T] = [U] =>> (T, U)
+opaque type BadG = [T] =>> [U] => (T, U)
+```
+
 ### Translation of Equality
 
 Comparing two values of opaque type with `==` or `!=` normally uses universal equality,

--- a/tests/neg/i9735.scala
+++ b/tests/neg/i9735.scala
@@ -1,6 +1,7 @@
 trait Two[A, B]
 
-opaque type U[A] = [B] =>> Two[A, B] // error: opaque type alias must be fully applied // error: cannot instantiate
-opaque type T[A] = [B] =>> String // error: opaque type alias must be fully applied
-opaque type S = [B] =>> String // error: opaque type alias must be fully applied
-
+opaque type U[A] = [B] =>> Two[A, B] // error: opaque type alias cannot have multiple type parameter lists // error: cannot instantiate
+opaque type T = [A] =>> [B] =>> String // error: opaque type alias cannot have multiple type parameter lists
+opaque type S = [B] =>> String // ok
+opaque type IArray[+T] = Array[? <: T] // ok
+opaque type S2[B] = String // ok

--- a/tests/neg/i9735.scala
+++ b/tests/neg/i9735.scala
@@ -1,0 +1,6 @@
+trait Two[A, B]
+
+opaque type U[A] = [B] =>> Two[A, B] // error: opaque type alias must be fully applied // error: cannot instantiate
+opaque type T[A] = [B] =>> String // error: opaque type alias must be fully applied
+opaque type S = [B] =>> String // error: opaque type alias must be fully applied
+

--- a/tests/neg/i9735.scala
+++ b/tests/neg/i9735.scala
@@ -5,3 +5,8 @@ opaque type T = [A] =>> [B] =>> String // error: opaque type alias cannot have m
 opaque type S = [B] =>> String // ok
 opaque type IArray[+T] = Array[? <: T] // ok
 opaque type S2[B] = String // ok
+
+opaque type BadF[T] = [U] =>> (T, U)    // error
+opaque type BadG = [T] =>> [U] =>> (T, U) // error
+
+


### PR DESCRIPTION
We already had a check that opaque type aliases must be fully applied, but
that check did not kick in when the opaque type has type parameters.