### PR TITLE
Align statements - cosmetic

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
@@ -106,8 +106,8 @@ object PickledQuotes {
             }
           end if
 
-         val tree1 = super.transform(tree)
-         tree1.withType(mapAnnots(tree1.tpe))
+          val tree1 = super.transform(tree)
+          tree1.withType(mapAnnots(tree1.tpe))
       }
 
       // Evaluate holes in type annotations


### PR DESCRIPTION
Alignment :P

Will investigate later why scalameta parser expects it to be aligned as it is old match-case scenario.