### PR TITLE
Warn users on non canonical type references

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -57,7 +57,8 @@ trait QuotesAndSplices {
     val tree1 =
       if ctx.mode.is(Mode.Pattern) then
         typedQuotePattern(tree, pt, qctx)
-      else if (tree.quoted.isType)
+      else if tree.quoted.isType then
+        report.warning(em"Consider using canonical type constructor scala.quoted.Type[${tree.quoted}] instead", tree.srcPos)
         typedTypeApply(untpd.TypeApply(untpd.ref(defn.QuotedTypeModule_apply.termRef), tree.quoted :: Nil), pt)(using quoteContext).select(nme.apply).appliedTo(qctx)
       else
         typedApply(untpd.Apply(untpd.ref(defn.InternalQuoted_exprQuote.termRef), tree.quoted), pt)(using pushQuoteContext(qctx)).select(nme.apply).appliedTo(qctx)
@@ -171,7 +172,9 @@ trait QuotesAndSplices {
           using spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
       pat.select(tpnme.spliceType)
     else
-      typedSelect(untpd.Select(tree.expr, tpnme.spliceType), pt)(using spliceContext).withSpan(tree.span)
+      val tree1 = typedSelect(untpd.Select(tree.expr, tpnme.spliceType), pt)(using spliceContext).withSpan(tree.span)
+      report.warning(em"Consider using canonical type reference ${tree1.tpe.show} instead", tree.srcPos)
+      tree1
   }
 
   private def checkSpliceOutsideQuote(tree: untpd.Tree)(using Context): Unit =

--- a/tests/patmat/i9489.scala
+++ b/tests/patmat/i9489.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
-def summonTypedType[T : Type](using QuoteContext): String = '[T] match {
+def summonTypedType[T : Type](using QuoteContext): String = Type[T] match {
   case '[Boolean] => "Boolean"
   case '[Byte] => "Byte"
   case _ => "Other"

--- a/tests/patmat/i9489b.scala
+++ b/tests/patmat/i9489b.scala
@@ -1,0 +1,7 @@
+import scala.quoted._
+
+def summonTypedType[T : Type](using QuoteContext): String = '{ ??? : T } match {
+  case '{ $_ : Boolean } => "Boolean"
+  case '{ $_ : Byte } => "Byte"
+  case _ => "Other"
+}


### PR DESCRIPTION
Help users write the correct variant of the quoted type encoding.
Explicit construction of a `scala.quoted.Type[_]` should be done with its constructor.
Explicit construction of types in not encouraged as it should be created implicitly.
Creating an `Type` explicitly is only useful for debugging purposes.
Likewise, we encourage the use of the explicit inner type reference.