### PR TITLE
Fix #9892: Add span when translating `with` to an and type

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1549,7 +1549,7 @@ object Parsers {
         else
           if sourceVersion.isAtLeast(`3.1`) then
             deprecationWarning(DeprecatedWithOperator(), withOffset)
-          makeAndType(t, withType())
+          atSpan(startOffset(t)) { makeAndType(t, withType()) }
       else t
 
     /** AnnotType ::= SimpleType {Annotation}

--- a/tests/neg-scalajs/js-native-members.check
+++ b/tests/neg-scalajs/js-native-members.check
@@ -86,15 +86,15 @@
 57 |  val bar = js.native // error
    |  ^^^^^^^^^^^^^^^^^^^
    |  The type of bar must be explicitly specified because it is JS native.
--- Error: tests/neg-scalajs/js-native-members.scala:65:8 ---------------------------------------------------------------
-65 |    def apply: Int = js.native // error
+-- Error: tests/neg-scalajs/js-native-members.scala:66:8 ---------------------------------------------------------------
+66 |    def apply: Int = js.native // error
    |        ^
    |A member named apply represents function application in JavaScript. A parameterless member should be exported as a property. You must add @JSName("apply")
--- Error: tests/neg-scalajs/js-native-members.scala:76:8 ---------------------------------------------------------------
-76 |    val apply: Int = js.native // error
+-- Error: tests/neg-scalajs/js-native-members.scala:77:8 ---------------------------------------------------------------
+77 |    val apply: Int = js.native // error
    |        ^
    |A member named apply represents function application in JavaScript. A parameterless member should be exported as a property. You must add @JSName("apply")
--- Error: tests/neg-scalajs/js-native-members.scala:87:8 ---------------------------------------------------------------
-87 |    var apply: Int = js.native // error
+-- Error: tests/neg-scalajs/js-native-members.scala:88:8 ---------------------------------------------------------------
+88 |    var apply: Int = js.native // error
    |        ^
    |A member named apply represents function application in JavaScript. A parameterless member should be exported as a property. You must add @JSName("apply")

--- a/tests/neg-scalajs/js-native-members.scala
+++ b/tests/neg-scalajs/js-native-members.scala
@@ -55,6 +55,7 @@ object A3 {
 class A4 extends js.Object {
   def foo = js.native // error
   val bar = js.native // error
+  def assign[T, U](target: T, source: U): T with U = js.native // ok
 }
 
 // Members named `apply`


### PR DESCRIPTION
Fix https://github.com/lampepfl/dotty/issues/9892

Without adding the span it is thought to be synthetic, which causes scalaJS to throw an error.