### PR TITLE
Rename Reflection `tasty` to `reflect`

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/Matcher.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/Matcher.scala
@@ -98,14 +98,14 @@ import scala.internal.tasty.CompilerInterface.quoteContextWithCompilerInterface
  */
 object Matcher {
 
-  abstract class QuoteMatcher[QCtx <: QuoteContext { val tasty: scala.internal.tasty.CompilerInterface } & Singleton](val qctx: QCtx) {
+  abstract class QuoteMatcher[QCtx <: QuoteContext { val reflect: scala.internal.tasty.CompilerInterface } & Singleton](val qctx: QCtx) {
 
     // TODO improve performance
 
-    // TODO use flag from qctx.tasty. Maybe -debug or add -debug-macros
+    // TODO use flag from qctx.reflect. Maybe -debug or add -debug-macros
     private final val debug = false
 
-    import qctx.tasty._
+    import qctx.reflect._
     import Matching._
 
     def patternHoleSymbol: Symbol

--- a/compiler/src/dotty/tools/dotc/quoted/QuoteContextImpl.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuoteContextImpl.scala
@@ -30,10 +30,10 @@ object QuoteContextImpl {
     val syntaxHighlight =
       if (ctx.settings.color.value == "always") SyntaxHighlight.ANSI
       else SyntaxHighlight.plain
-    show(using qctx)(tree.asInstanceOf[qctx.tasty.Tree], syntaxHighlight)(using ctx.asInstanceOf[qctx.tasty.Context])
+    show(using qctx)(tree.asInstanceOf[qctx.reflect.Tree], syntaxHighlight)(using ctx.asInstanceOf[qctx.reflect.Context])
   }
 
-  private def show(using qctx: QuoteContext)(tree: qctx.tasty.Tree, syntaxHighlight: SyntaxHighlight)(using qctx.tasty.Context) =
+  private def show(using qctx: QuoteContext)(tree: qctx.reflect.Tree, syntaxHighlight: SyntaxHighlight)(using qctx.reflect.Context) =
     tree.showWith(syntaxHighlight)
 
   private[dotty] def checkScopeId(id: ScopeId)(using Context): Unit =
@@ -49,7 +49,7 @@ object QuoteContextImpl {
 
 class QuoteContextImpl private (ctx: Context) extends QuoteContext:
 
-  object tasty extends scala.tasty.Reflection, scala.internal.tasty.CompilerInterface:
+  object reflect extends scala.tasty.Reflection, scala.internal.tasty.CompilerInterface:
 
     def rootContext: Context = ctx
 
@@ -67,11 +67,11 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext:
         def pos: Position = self.sourcePos
         def symbol: Symbol = self.symbol
         def showExtractors: String =
-          new ExtractorsPrinter[tasty.type](tasty).showTree(self)
+          new ExtractorsPrinter[reflect.type](reflect).showTree(self)
         def show: String =
           self.showWith(SyntaxHighlight.plain)
         def showWith(syntaxHighlight: SyntaxHighlight): String =
-          new SourceCodePrinter[tasty.type](tasty)(syntaxHighlight).showTree(self)
+          new SourceCodePrinter[reflect.type](reflect)(syntaxHighlight).showTree(self)
         def isExpr: Boolean =
           self match
             case TermTypeTest(self) =>
@@ -1584,13 +1584,13 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext:
     object TypeMethodsImpl extends TypeMethods:
       extension (self: Type):
         def showExtractors: String =
-          new ExtractorsPrinter[tasty.type](tasty).showType(self)
+          new ExtractorsPrinter[reflect.type](reflect).showType(self)
 
         def show: String =
           self.showWith(SyntaxHighlight.plain)
 
         def showWith(syntaxHighlight: SyntaxHighlight): String =
-          new SourceCodePrinter[tasty.type](tasty)(syntaxHighlight).showType(self)
+          new SourceCodePrinter[reflect.type](reflect)(syntaxHighlight).showType(self)
 
         def seal: scala.quoted.Type[_] =
           new scala.internal.quoted.Type(Inferred(self), QuoteContextImpl.this.hashCode)
@@ -2164,11 +2164,11 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext:
       extension (self: Constant):
         def value: Any = self.value
         def showExtractors: String =
-          new ExtractorsPrinter[tasty.type](tasty).showConstant(self)
+          new ExtractorsPrinter[reflect.type](reflect).showConstant(self)
         def show: String =
           self.showWith(SyntaxHighlight.plain)
         def showWith(syntaxHighlight: SyntaxHighlight): String =
-          new SourceCodePrinter[tasty.type](tasty)(syntaxHighlight).showConstant(self)
+          new SourceCodePrinter[reflect.type](reflect)(syntaxHighlight).showConstant(self)
       end extension
     end ConstantMethodsImpl
 
@@ -2387,11 +2387,11 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext:
         def children: List[Symbol] = self.denot.children
 
         def showExtractors: String =
-          new ExtractorsPrinter[tasty.type](tasty).showSymbol(self)
+          new ExtractorsPrinter[reflect.type](reflect).showSymbol(self)
         def show: String =
           self.showWith(SyntaxHighlight.plain)
         def showWith(syntaxHighlight: SyntaxHighlight): String =
-          new SourceCodePrinter[tasty.type](tasty)(syntaxHighlight).showSymbol(self)
+          new SourceCodePrinter[reflect.type](reflect)(syntaxHighlight).showSymbol(self)
 
       end extension
 
@@ -2523,11 +2523,11 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext:
         def |(that: Flags): Flags = dotc.core.Flags.extension_|(self)(that)
         def &(that: Flags): Flags = dotc.core.Flags.extension_&(self)(that)
         def showExtractors: String =
-          new ExtractorsPrinter[tasty.type](tasty).showFlags(self)
+          new ExtractorsPrinter[reflect.type](reflect).showFlags(self)
         def show: String =
           self.showWith(SyntaxHighlight.plain)
         def showWith(syntaxHighlight: SyntaxHighlight): String =
-          new SourceCodePrinter[tasty.type](tasty)(syntaxHighlight).showFlags(self)
+          new SourceCodePrinter[reflect.type](reflect)(syntaxHighlight).showFlags(self)
       end extension
     end FlagsMethodsImpl
 
@@ -2647,7 +2647,7 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext:
           ctx1
 
       val qctx1 = dotty.tools.dotc.quoted.QuoteContextImpl()(using ctx1)
-        .asInstanceOf[QuoteContext { val tasty: QuoteContextImpl.this.tasty.type }]
+        .asInstanceOf[QuoteContext { val reflect: QuoteContextImpl.this.reflect.type }]
 
       val matcher = new Matcher.QuoteMatcher[qctx1.type](qctx1) {
         def patternHoleSymbol: Symbol = dotc.core.Symbols.defn.InternalQuotedPatterns_patternHole
@@ -2671,7 +2671,7 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext:
       }
     }
 
-  end tasty
+  end reflect
 
   private[this] val hash = QuoteContextImpl.scopeId(using ctx)
   override def hashCode: Int = hash

--- a/docs/docs/reference/contextual/derivation-macro.md
+++ b/docs/docs/reference/contextual/derivation-macro.md
@@ -42,7 +42,7 @@ from the signature. The body of the `derived` method is shown below:
 
 ```scala
 given derived[T: Type](using qctx: QuoteContext) as Expr[Eq[T]] = {
-  import qctx.tasty._
+  import qctx.reflect._
 
   val ev: Expr[Mirror.Of[T]] = Expr.summon(using '[Mirror.Of[T]]).get
 
@@ -177,7 +177,7 @@ object Eq {
   }
 
   given derived[T: Type](using qctx: QuoteContext) as Expr[Eq[T]] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val ev: Expr[Mirror.Of[T]] = Expr.summon(using '[Mirror.Of[T]]).get
 

--- a/docs/docs/reference/metaprogramming/tasty-reflect.md
+++ b/docs/docs/reference/metaprogramming/tasty-reflect.md
@@ -20,7 +20,7 @@ guarantees and may fail at macro expansion time, hence additional explicit
 checks must be done.
 
 To provide reflection capabilities in macros we need to add an implicit
-parameter of type `scala.quoted.QuoteContext` and import `tasty._` from it in
+parameter of type `scala.quoted.QuoteContext` and import `qctx.reflect._` from it in
 the scope where it is used.
 
 ```scala
@@ -29,19 +29,19 @@ import scala.quoted._
 inline def natConst(x: => Int): Int = ${natConstImpl('{x})}
 
 def natConstImpl(x: Expr[Int])(using qctx: QuoteContext): Expr[Int] = {
-  import qctx.tasty._
+  import qctx.reflect._
   ...
 }
 ```
 
 ### Extractors
 
-`import qctx.tasty._` will provide all extractors and methods on TASTy Reflect
+`import qctx.reflect._` will provide all extractors and methods on TASTy Reflect
 trees. For example the `Literal(_)` extractor used below.
 
 ```scala
 def natConstImpl(x: Expr[Int])(using qctx: QuoteContext): Expr[Int] = {
-  import qctx.tasty._
+  import qctx.reflect._
   val xTree: Term = x.unseal
   xTree match {
     case Inlined(_, _, Literal(Constant(n: Int))) =>
@@ -59,9 +59,9 @@ def natConstImpl(x: Expr[Int])(using qctx: QuoteContext): Expr[Int] = {
 ```
 
 To easily know which extractors are needed, the `showExtractors` method on a
-`qctx.tasty.Term` returns the string representation of the extractors.
+`qctx.reflect.Term` returns the string representation of the extractors.
 
-The method `qctx.tasty.Term.seal` provides a way to go back to a
+The method `qctx.reflect.Term.seal` provides a way to go back to a
 `quoted.Expr[Any]`. Note that the type is `Expr[Any]`. Consequently, the type
 must be set explicitly with a checked `cast` call. If the type does not conform
 to it an exception will be thrown at runtime.
@@ -77,7 +77,7 @@ operation expression passed while calling the `macro` below.
 inline def macro(param: => Boolean): Unit = ${ macroImpl('param) }
 
 def macroImpl(param: Expr[Boolean])(using qctx: QuoteContext): Expr[Unit] = {
-  import qctx.tasty._
+  import qctx.reflect._
   import util._
 
   param.unseal.underlyingArgument match {
@@ -91,7 +91,7 @@ macro(this.checkCondition())
 
 ### Positions
 
-The tasty context provides a `rootPosition` value. It corresponds to
+The `ast` in the context provides a `rootPosition` value. It corresponds to
 the expansion site for macros. The macro authors can obtain various information about that
 expansion site. The example below shows how we can obtain position information
 such as the start line, the end line or even the source code at the expansion
@@ -99,7 +99,7 @@ point.
 
 ```scala
 def macroImpl()(qctx: QuoteContext): Expr[Unit] = {
-  import qctx.tasty._
+  import qctx.reflect._
   val pos = rootPosition
 
   val path = pos.sourceFile.jpath.toString

--- a/library/src-bootstrapped/scala/internal/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/internal/quoted/Expr.scala
@@ -19,10 +19,10 @@ import scala.internal.tasty.CompilerInterface.quoteContextWithCompilerInterface
     case _ => false
   }
 
-  def unseal(using qctx: QuoteContext): qctx.tasty.Term =
+  def unseal(using qctx: QuoteContext): qctx.reflect.Term =
     if (qctx.hashCode != scopeId)
       throw new scala.quoted.ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
-    tree.asInstanceOf[qctx.tasty.Term]
+    tree.asInstanceOf[qctx.reflect.Term]
 
   override def hashCode: Int = tree.hashCode
   override def toString: String = "'{ ... }"
@@ -54,18 +54,18 @@ object Expr {
   def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeExpr: scala.quoted.Expr[Any])
         (using patternExpr: scala.quoted.Expr[Any], qctx: QuoteContext): Option[Tup] = {
     val qctx1 = quoteContextWithCompilerInterface(qctx)
-    qctx1.tasty.termMatch(scrutineeExpr.unseal, patternExpr.unseal).asInstanceOf[Option[Tup]]
+    qctx1.reflect.termMatch(scrutineeExpr.unseal, patternExpr.unseal).asInstanceOf[Option[Tup]]
   }
 
   /** Returns a null expresssion equivalent to `'{null}` */
   def `null`: QuoteContext ?=> quoted.Expr[Null] = qctx ?=> {
-    import qctx.tasty._
+    import qctx.reflect._
     Literal(Constant.Null()).seal.asInstanceOf[quoted.Expr[Null]]
   }
 
   /** Returns a unit expresssion equivalent to `'{}` or `'{()}` */
   def Unit: QuoteContext ?=> quoted.Expr[Unit] = qctx ?=> {
-    import qctx.tasty._
+    import qctx.reflect._
     Literal(Constant.Unit()).seal.asInstanceOf[quoted.Expr[Unit]]
   }
 

--- a/library/src-bootstrapped/scala/internal/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/internal/quoted/Type.scala
@@ -14,10 +14,10 @@ final class Type[Tree](val typeTree: Tree, val scopeId: Int) extends scala.quote
   }
 
   /** View this expression `quoted.Type[T]` as a `TypeTree` */
-  def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree =
+  def unseal(using qctx: QuoteContext): qctx.reflect.TypeTree =
     if (qctx.hashCode != scopeId)
       throw new scala.quoted.ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
-    typeTree.asInstanceOf[qctx.tasty.TypeTree]
+    typeTree.asInstanceOf[qctx.reflect.TypeTree]
 
   override def hashCode: Int = typeTree.hashCode
   override def toString: String = "'[ ... ]"
@@ -37,37 +37,37 @@ object Type {
   def unapply[TypeBindings <: Tuple, Tup <: Tuple](scrutineeType: scala.quoted.Type[_])
       (using patternType: scala.quoted.Type[_], qctx: QuoteContext): Option[Tup] = {
     val qctx1 = quoteContextWithCompilerInterface(qctx)
-    qctx1.tasty.typeTreeMatch(scrutineeType.unseal, patternType.unseal).asInstanceOf[Option[Tup]]
+    qctx1.reflect.typeTreeMatch(scrutineeType.unseal, patternType.unseal).asInstanceOf[Option[Tup]]
   }
 
 
   // TODO generalize following optimizations for all classes without parameters
 
   def Unit: QuoteContext ?=> quoted.Type[Unit] =
-    qctx.tasty.Type.typeConstructorOf(classOf[Unit]).seal.asInstanceOf[quoted.Type[Unit]]
+    qctx.reflect.Type.typeConstructorOf(classOf[Unit]).seal.asInstanceOf[quoted.Type[Unit]]
 
   def Boolean: QuoteContext ?=> quoted.Type[Boolean] =
-    qctx.tasty.Type.typeConstructorOf(classOf[Boolean]).seal.asInstanceOf[quoted.Type[Boolean]]
+    qctx.reflect.Type.typeConstructorOf(classOf[Boolean]).seal.asInstanceOf[quoted.Type[Boolean]]
 
   def Byte: QuoteContext ?=> quoted.Type[Byte] =
-    qctx.tasty.Type.typeConstructorOf(classOf[Byte]).seal.asInstanceOf[quoted.Type[Byte]]
+    qctx.reflect.Type.typeConstructorOf(classOf[Byte]).seal.asInstanceOf[quoted.Type[Byte]]
 
   def Char: QuoteContext ?=> quoted.Type[Char] =
-    qctx.tasty.Type.typeConstructorOf(classOf[Char]).seal.asInstanceOf[quoted.Type[Char]]
+    qctx.reflect.Type.typeConstructorOf(classOf[Char]).seal.asInstanceOf[quoted.Type[Char]]
 
   def Short: QuoteContext ?=> quoted.Type[Short] =
-    qctx.tasty.Type.typeConstructorOf(classOf[Short]).seal.asInstanceOf[quoted.Type[Short]]
+    qctx.reflect.Type.typeConstructorOf(classOf[Short]).seal.asInstanceOf[quoted.Type[Short]]
 
   def Int: QuoteContext ?=> quoted.Type[Int] =
-    qctx.tasty.Type.typeConstructorOf(classOf[Int]).seal.asInstanceOf[quoted.Type[Int]]
+    qctx.reflect.Type.typeConstructorOf(classOf[Int]).seal.asInstanceOf[quoted.Type[Int]]
 
   def Long: QuoteContext ?=> quoted.Type[Long] =
-    qctx.tasty.Type.typeConstructorOf(classOf[Long]).seal.asInstanceOf[quoted.Type[Long]]
+    qctx.reflect.Type.typeConstructorOf(classOf[Long]).seal.asInstanceOf[quoted.Type[Long]]
 
   def Float: QuoteContext ?=> quoted.Type[Float] =
-    qctx.tasty.Type.typeConstructorOf(classOf[Float]).seal.asInstanceOf[quoted.Type[Float]]
+    qctx.reflect.Type.typeConstructorOf(classOf[Float]).seal.asInstanceOf[quoted.Type[Float]]
 
   def Double: QuoteContext ?=> quoted.Type[Double] =
-    qctx.tasty.Type.typeConstructorOf(classOf[Double]).seal.asInstanceOf[quoted.Type[Double]]
+    qctx.reflect.Type.typeConstructorOf(classOf[Double]).seal.asInstanceOf[quoted.Type[Double]]
 
 }

--- a/library/src-bootstrapped/scala/internal/quoted/Unpickler.scala
+++ b/library/src-bootstrapped/scala/internal/quoted/Unpickler.scala
@@ -14,7 +14,7 @@ object Unpickler {
    */
   def unpickleExpr[T](repr: PickledQuote, args: PickledArgs): QuoteContext ?=> Expr[T] =
     val qctx = quoteContextWithCompilerInterface(summon[QuoteContext])
-    val tree = qctx.tasty.unpickleExpr(repr, args)
+    val tree = qctx.reflect.unpickleExpr(repr, args)
     new scala.internal.quoted.Expr(tree, qctx.hashCode).asInstanceOf[Expr[T]]
 
   /** Unpickle `repr` which represents a pickled `Type` tree,
@@ -22,7 +22,7 @@ object Unpickler {
    */
   def unpickleType[T](repr: PickledQuote, args: PickledArgs): QuoteContext ?=> Type[T] =
     val qctx = quoteContextWithCompilerInterface(summon[QuoteContext])
-    val tree = qctx.tasty.unpickleType(repr, args)
+    val tree = qctx.reflect.unpickleType(repr, args)
     new scala.internal.quoted.Type(tree, qctx.hashCode).asInstanceOf[Type[T]]
 
 }

--- a/library/src-bootstrapped/scala/quoted/Const.scala
+++ b/library/src-bootstrapped/scala/quoted/Const.scala
@@ -15,7 +15,7 @@ object Const {
    *  ```
    */
   def unapply[T](expr: Expr[T])(using qctx: QuoteContext): Option[T] = {
-    import qctx.tasty._
+    import qctx.reflect._
     def rec(tree: Term): Option[T] = tree match {
       case Literal(c) => Some(c.value.asInstanceOf[T])
       case Block(Nil, e) => rec(e)

--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -44,7 +44,7 @@ abstract class Expr[+T] private[scala] {
   }
 
   /** View this expression `quoted.Expr[T]` as a `Term` */
-  def unseal(using qctx: QuoteContext): qctx.tasty.Term
+  def unseal(using qctx: QuoteContext): qctx.reflect.Term
 
 }
 
@@ -80,7 +80,7 @@ object Expr {
    *   Some bindings may be elided as an early optimization.
    */
   def betaReduce[T](expr: Expr[T])(using qctx: QuoteContext): Expr[T] =
-    qctx.tasty.Term.betaReduce(expr.unseal) match
+    qctx.reflect.Term.betaReduce(expr.unseal) match
       case Some(expr1) => expr1.seal.asInstanceOf[Expr[T]]
       case _ => expr
 
@@ -89,7 +89,7 @@ object Expr {
    *  will be equivalent to `'{ $s1; $s2; ...; $e }`.
    */
   def block[T](statements: List[Expr[Any]], expr: Expr[T])(using qctx: QuoteContext): Expr[T] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Block(statements.map(_.unseal), expr.unseal).seal.asInstanceOf[Expr[T]]
   }
 
@@ -191,7 +191,7 @@ object Expr {
    *  @param qctx current context
    */
   def summon[T](using tpe: Type[T])(using qctx: QuoteContext): Option[Expr[T]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Implicits.search(tpe.unseal.tpe) match {
       case iss: ImplicitSearchSuccess => Some(iss.tree.seal.asInstanceOf[Expr[T]])
       case isf: ImplicitSearchFailure => None

--- a/library/src-bootstrapped/scala/quoted/Liftable.scala
+++ b/library/src-bootstrapped/scala/quoted/Liftable.scala
@@ -24,70 +24,70 @@ object Liftable {
   /** Default liftable for Boolean */
   given BooleanLiftable[T <: Boolean] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.tasty._
+      import qctx.reflect._
       Literal(Constant.Boolean(x)).seal.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Byte */
   given ByteLiftable[T <: Byte] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.tasty._
+      import qctx.reflect._
       Literal(Constant.Byte(x)).seal.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Short */
   given ShortLiftable[T <: Short] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.tasty._
+      import qctx.reflect._
       Literal(Constant.Short(x)).seal.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Int */
   given IntLiftable[T <: Int] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.tasty._
+      import qctx.reflect._
       Literal(Constant.Int(x)).seal.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Long */
   given LongLiftable[T <: Long] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.tasty._
+      import qctx.reflect._
       Literal(Constant.Long(x)).seal.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Float */
   given FloatLiftable[T <: Float] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.tasty._
+      import qctx.reflect._
       Literal(Constant.Float(x)).seal.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Double */
   given DoubleLiftable[T <: Double] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.tasty._
+      import qctx.reflect._
       Literal(Constant.Double(x)).seal.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Char */
   given CharLiftable[T <: Char] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.tasty._
+      import qctx.reflect._
       Literal(Constant.Char(x)).seal.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for String */
   given StringLiftable[T <: String] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.tasty._
+      import qctx.reflect._
       Literal(Constant.String(x)).seal.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Class[T] */
   given ClassLiftable[T] as Liftable[Class[T]] = new Liftable[Class[T]] {
     def toExpr(x: Class[T]) = {
-      import qctx.tasty._
+      import qctx.reflect._
       Ref(defn.Predef_classOf).appliedToType(Type.typeConstructorOf(x)).seal.asInstanceOf[Expr[Class[T]]]
     }
   }

--- a/library/src-bootstrapped/scala/quoted/QuoteContext.scala
+++ b/library/src-bootstrapped/scala/quoted/QuoteContext.scala
@@ -5,17 +5,20 @@ import scala.quoted.show.SyntaxHighlight
 /** Quotation context provided by a macro expansion or in the scope of `scala.quoted.run`.
  *  Used to perform all operations on quoted `Expr` or `Type`.
  *
- *  It contains the low-level Typed AST API `tasty` metaprogramming API.
+ *  It contains the low-level Typed AST API metaprogramming API.
  *  This API does not have the static type guarantiees that `Expr` and `Type` provide.
  *
- *  @param tasty Typed AST API. Usage: `def f(qctx: QuoteContext) = { import qctx.tasty._; ... }`.
+ *  @param tasty Typed AST API. Usage: `def f(qctx: QuoteContext) = { import qctx.reflect._; ... }`.
  */
 trait QuoteContext { self =>
 
-  /** Low-level Typed AST API `tasty` metaprogramming API.
+  /** Low-level Typed AST API metaprogramming API.
    *  This API does not have the static type guarantiees that `Expr` and `Type` provide.
    */
-  val tasty: scala.tasty.Reflection
+  val reflect: scala.tasty.Reflection
+
+  @deprecated("Use `reflect` instead", "")
+  def tasty: reflect.type = reflect
 
   /** Type of a QuoteContext provided by a splice within a quote that took this context.
    *  It is only required if working with the reflection API.
@@ -24,14 +27,14 @@ trait QuoteContext { self =>
    *  to explicitly state that a context is nested as in the following example:
    *
    *  ```scala
-   *  def run(using qctx: QuoteContext)(tree: qctx.tasty.Tree): Unit =
+   *  def run(using qctx: QuoteContext)(tree: qctx.reflect.Tree): Unit =
    *    def nested()(using qctx.Nested): Expr[Int] = '{  ${ makeExpr(tree) } + 1  }
    *    '{  ${ nested() } + 2 }
-   *  def makeExpr(using qctx: QuoteContext)(tree: qctx.tasty.Tree): Expr[Int] = ???
+   *  def makeExpr(using qctx: QuoteContext)(tree: qctx.reflect.Tree): Expr[Int] = ???
    *  ```
    */
   type Nested = QuoteContext {
-    val tasty: self.tasty.type
+    val reflect: self.tasty.type
   }
 
 }

--- a/library/src-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/quoted/Type.scala
@@ -16,7 +16,7 @@ abstract class Type[X <: AnyKind] private[scala] {
     this.unseal.showWith(syntaxHighlight)
 
   /** View this expression `quoted.Type[T]` as a `TypeTree` */
-  def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree
+  def unseal(using qctx: QuoteContext): qctx.reflect.TypeTree
 
 }
 

--- a/library/src-bootstrapped/scala/quoted/Varargs.scala
+++ b/library/src-bootstrapped/scala/quoted/Varargs.scala
@@ -16,7 +16,7 @@ object Varargs {
    *  ```
    */
   def apply[T](xs: Seq[Expr[T]])(using tp: Type[T], qctx: QuoteContext): Expr[Seq[T]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Repeated(xs.map[Term](_.unseal).toList, tp.unseal).seal.asInstanceOf[Expr[Seq[T]]]
   }
 
@@ -33,7 +33,7 @@ object Varargs {
    *  ```
    */
   def unapply[T](expr: Expr[Seq[T]])(using qctx: QuoteContext): Option[Seq[Expr[T]]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     def rec(tree: Term): Option[Seq[Expr[T]]] = tree match {
       case Typed(Repeated(elems, _), _) => Some(elems.map(x => x.seal.asInstanceOf[Expr[T]]))
       case Block(Nil, e) => rec(e)

--- a/library/src-bootstrapped/scala/quoted/report.scala
+++ b/library/src-bootstrapped/scala/quoted/report.scala
@@ -4,11 +4,11 @@ object report:
 
   /** Report an error at the position of the macro expansion */
   def error(msg: => String)(using qctx: QuoteContext): Unit =
-    qctx.tasty.Reporting.error(msg, qctx.tasty.rootPosition)
+    qctx.reflect.Reporting.error(msg, qctx.reflect.rootPosition)
 
   /** Report an error at the on the position of `expr` */
   def error(msg: => String, expr: Expr[Any])(using qctx: QuoteContext): Unit =
-    qctx.tasty.Reporting.error(msg, expr.unseal.pos)
+    qctx.reflect.Reporting.error(msg, expr.unseal.pos)
 
   /** Report an error at the position of the macro expansion and throws a StopQuotedContext */
   def throwError(msg: => String)(using qctx: QuoteContext): Nothing = {
@@ -23,11 +23,11 @@ object report:
 
   /** Report a warning */
   def warning(msg: => String)(using qctx: QuoteContext): Unit =
-    qctx.tasty.Reporting.warning(msg, qctx.tasty.rootPosition)
+    qctx.reflect.Reporting.warning(msg, qctx.reflect.rootPosition)
 
   /** Report a warning at the on the position of `expr` */
   def warning(msg: => String, expr: Expr[_])(using qctx: QuoteContext): Unit =
-    qctx.tasty.Reporting.warning(msg, expr.unseal.pos)
+    qctx.reflect.Reporting.warning(msg, expr.unseal.pos)
 
   /** Throwable used to stop the expansion of a macro after an error was reported */
   class StopQuotedContext extends Throwable

--- a/library/src-bootstrapped/scala/quoted/unsafe/UnsafeExpr.scala
+++ b/library/src-bootstrapped/scala/quoted/unsafe/UnsafeExpr.scala
@@ -51,14 +51,14 @@ object UnsafeExpr {
     content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2], v3: Expr[T3]) => bodyFn[t](e.unseal, params, List(v1.unseal, v2.unseal, v3.unseal)).seal.asInstanceOf[Expr[t]])
   }
 
-  private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.tasty.ValDef], Expr[R]) = {
-    import qctx.tasty._
+  private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
+    import qctx.reflect._
     val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.unseal.etaExpand
     (params, body.seal.asInstanceOf[Expr[R]])
   }
 
-  private def bodyFn[t](using qctx: QuoteContext)(e: qctx.tasty.Term, params: List[qctx.tasty.ValDef], args: List[qctx.tasty.Term]): qctx.tasty.Term = {
-    import qctx.tasty._
+  private def bodyFn[t](using qctx: QuoteContext)(e: qctx.reflect.Term, params: List[qctx.reflect.ValDef], args: List[qctx.reflect.Term]): qctx.reflect.Term = {
+    import qctx.reflect._
     val map = params.map(_.symbol).zip(args).toMap
     new TreeMap {
       override def transformTerm(tree: Term)(using ctx: Context): Term =

--- a/library/src-bootstrapped/scala/quoted/util/ExprMap.scala
+++ b/library/src-bootstrapped/scala/quoted/util/ExprMap.scala
@@ -9,7 +9,7 @@ trait ExprMap {
 
   /** Map subexpressions an expression `e` with a type `tpe` */
   def transformChildren[T](e: Expr[T])(using qctx: QuoteContext, tpe: Type[T]): Expr[T] = {
-    import qctx.tasty._
+    import qctx.reflect._
     final class MapChildren() {
 
       def transformStatement(tree: Statement)(using ctx: Context): Statement = {

--- a/library/src-non-bootstrapped/scala/internal/quoted/Expr.scala
+++ b/library/src-non-bootstrapped/scala/internal/quoted/Expr.scala
@@ -19,10 +19,10 @@ import scala.internal.tasty.CompilerInterface.quoteContextWithCompilerInterface
     case _ => false
   }
 
-  def unseal(using qctx: QuoteContext): qctx.tasty.Term =
+  def unseal(using qctx: QuoteContext): qctx.reflect.Term =
     if (qctx.hashCode != scopeId)
       throw new scala.quoted.ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
-    tree.asInstanceOf[qctx.tasty.Term]
+    tree.asInstanceOf[qctx.reflect.Term]
 
   override def hashCode: Int = tree.hashCode
   override def toString: String = "'{ ... }"

--- a/library/src-non-bootstrapped/scala/internal/quoted/Type.scala
+++ b/library/src-non-bootstrapped/scala/internal/quoted/Type.scala
@@ -14,10 +14,10 @@ final class Type[Tree](val typeTree: Tree, val scopeId: Int) extends scala.quote
   }
 
   /** View this expression `quoted.Type[T]` as a `TypeTree` */
-  def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree =
+  def unseal(using qctx: QuoteContext): qctx.reflect.TypeTree =
     if (qctx.hashCode != scopeId)
       throw new scala.quoted.ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
-    typeTree.asInstanceOf[qctx.tasty.TypeTree]
+    typeTree.asInstanceOf[qctx.reflect.TypeTree]
 
   override def hashCode: Int = typeTree.hashCode
   override def toString: String = "'[ ... ]"

--- a/library/src-non-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-non-bootstrapped/scala/quoted/Expr.scala
@@ -1,5 +1,5 @@
 package scala.quoted
 
 abstract class Expr[+T] private[scala]:
-  def unseal(using qctx: QuoteContext): qctx.tasty.Term
+  def unseal(using qctx: QuoteContext): qctx.reflect.Term
   def asExprOf[X](using tp: scala.quoted.Type[X])(using qctx: QuoteContext): scala.quoted.Expr[X] = ???

--- a/library/src-non-bootstrapped/scala/quoted/QuoteContext.scala
+++ b/library/src-non-bootstrapped/scala/quoted/QuoteContext.scala
@@ -2,7 +2,8 @@ package scala.quoted
 
 trait QuoteContext { self =>
 
-  val tasty: scala.tasty.Reflection
+  val reflect: scala.tasty.Reflection
+  def tasty: reflect.type = reflect
 
   type Nested = QuoteContext {
     val tasty: self.tasty.type

--- a/library/src-non-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-non-bootstrapped/scala/quoted/Type.scala
@@ -4,7 +4,7 @@ import scala.annotation.compileTimeOnly
 
 abstract class Type[X <: AnyKind] private[scala]:
   type T = X
-  def unseal(using qctx: QuoteContext): qctx.tasty.TypeTree
+  def unseal(using qctx: QuoteContext): qctx.reflect.TypeTree
 
 object Type:
   @compileTimeOnly("Reference to `scala.quoted.Type.apply` was not handled by ReifyQuotes")

--- a/library/src/scala/internal/tasty/CompilerInterface.scala
+++ b/library/src/scala/internal/tasty/CompilerInterface.scala
@@ -56,7 +56,7 @@ trait CompilerInterface { self: scala.tasty.Reflection =>
 
 object CompilerInterface {
 
-  private[scala] def quoteContextWithCompilerInterface(qctx: QuoteContext): qctx.type { val tasty: qctx.tasty.type & scala.internal.tasty.CompilerInterface } =
-    qctx.asInstanceOf[qctx.type { val tasty: qctx.tasty.type & scala.internal.tasty.CompilerInterface }]
+  private[scala] def quoteContextWithCompilerInterface(qctx: QuoteContext): qctx.type { val reflect: qctx.reflect.type & scala.internal.tasty.CompilerInterface } =
+    qctx.asInstanceOf[qctx.type { val reflect: qctx.reflect.type & scala.internal.tasty.CompilerInterface }]
 
 }

--- a/library/src/scala/tasty/reflect/ExtractorsPrinter.scala
+++ b/library/src/scala/tasty/reflect/ExtractorsPrinter.scala
@@ -1,8 +1,8 @@
 package scala.tasty
 package reflect
 
-class ExtractorsPrinter[R <: Reflection & Singleton](val tasty: R) extends Printer[R] {
-  import tasty._
+class ExtractorsPrinter[R <: Reflection & Singleton](val reflect: R) extends Printer[R] {
+  import reflect._
 
   def showTree(tree: Tree): String =
     new Buffer().visitTree(tree).result()

--- a/library/src/scala/tasty/reflect/Printer.scala
+++ b/library/src/scala/tasty/reflect/Printer.scala
@@ -5,20 +5,21 @@ package reflect
 trait Printer[R <: Reflection & Singleton] {
 
   /** Instance of reflection interface */
-  val tasty: R
+  val reflect: R
+  import reflect._
 
-  /** Show a String representation of a tasty.Tree */
-  def showTree(tree: tasty.Tree): String
+  /** Show a String representation of a reflect.Tree */
+  def showTree(tree: Tree): String
 
-  /** Show a String representation of a tasty.Type */
-  def showType(tpe: tasty.Type): String
+  /** Show a String representation of a reflect.Type */
+  def showType(tpe: Type): String
 
-  /** Show a String representation of a tasty.Constant */
-  def showConstant(const: tasty.Constant): String
+  /** Show a String representation of a reflect.Constant */
+  def showConstant(const: Constant): String
 
-  /** Show a String representation of a tasty.Symbol */
-  def showSymbol(symbol: tasty.Symbol): String
+  /** Show a String representation of a reflect.Symbol */
+  def showSymbol(symbol: Symbol): String
 
-  /** Show a String representation of a tasty.Flags */
-  def showFlags(flags: tasty.Flags): String
+  /** Show a String representation of a reflect.Flags */
+  def showFlags(flags: Flags): String
 }

--- a/library/src/scala/tasty/reflect/SourceCodePrinter.scala
+++ b/library/src/scala/tasty/reflect/SourceCodePrinter.scala
@@ -5,8 +5,8 @@ import scala.annotation.switch
 import scala.quoted.show.SyntaxHighlight
 
 /** Printer for fully elaborated representation of the source code */
-class SourceCodePrinter[R <: Reflection & Singleton](val tasty: R)(syntaxHighlight: SyntaxHighlight) extends Printer[R] {
-  import tasty._
+class SourceCodePrinter[R <: Reflection & Singleton](val reflect: R)(syntaxHighlight: SyntaxHighlight) extends Printer[R] {
+  import reflect._
   import syntaxHighlight._
 
   def showTree(tree: Tree): String =

--- a/library/src/scala/tasty/reflect/TreeAccumulator.scala
+++ b/library/src/scala/tasty/reflect/TreeAccumulator.scala
@@ -7,7 +7,7 @@ package reflect
  *  ```
  *  class MyTreeAccumulator[R <: scala.tasty.Reflection & Singleton](val reflect: R)
  *      extends scala.tasty.reflect.TreeAccumulator[X] {
- *    import reflect.{given _, _}
+ *    import reflect._
  *    def foldTree(x: X, tree: Tree)(using ctx: Context): X = ...
  *  }
  *  ```
@@ -15,7 +15,7 @@ package reflect
 trait TreeAccumulator[X] {
 
   val reflect: Reflection
-  import reflect.{given _, _}
+  import reflect._
 
   // Ties the knot of the traversal: call `foldOver(x, tree))` to dive in the `tree` node.
   def foldTree(x: X, tree: Tree)(using ctx: Context): X

--- a/library/src/scala/tasty/reflect/TreeMap.scala
+++ b/library/src/scala/tasty/reflect/TreeMap.scala
@@ -7,7 +7,7 @@ package reflect
  *  ```
  *  class MyTreeMap[R <: scala.tasty.Reflection & Singleton](val reflect: R)
  *      extends scala.tasty.reflect.TreeMap {
- *    import reflect.{given _, _}
+ *    import reflect._
  *    override def transformTree(tree: Tree)(using ctx: Context): Tree = ...
  *  }
  *  ```
@@ -15,7 +15,7 @@ package reflect
 trait TreeMap {
 
   val reflect: Reflection
-  import reflect.{given _, _}
+  import reflect._
 
   def transformTree(tree: Tree)(using ctx: Context): Tree = {
     tree match {

--- a/library/src/scala/tasty/reflect/TreeTraverser.scala
+++ b/library/src/scala/tasty/reflect/TreeTraverser.scala
@@ -7,7 +7,7 @@ package reflect
  *  ```
  *  class MyTraverser[R <: scala.tasty.Reflection & Singleton](val reflect: R)
  *      extends scala.tasty.reflect.TreeTraverser {
- *    import reflect.{given _, _}
+ *    import reflect._
  *    override def traverseTree(tree: Tree)(using ctx: Context): Unit = ...
  *  }
  *  ```

--- a/tastydoc/src/dotty/tastydoc/TastyExtractor.scala
+++ b/tastydoc/src/dotty/tastydoc/TastyExtractor.scala
@@ -7,15 +7,15 @@ import dotty.tastydoc.representations._
 
 /** A trait containing useful methods for extracting information from the reflect API */
 trait TastyExtractor extends TastyTypeConverter with CommentParser with CommentCleaner{
-  def extractPath(using QuoteContext)(symbol: qctx.tasty.Symbol) : List[String] = {
-    import qctx.tasty._
+  def extractPath(using QuoteContext)(symbol: qctx.reflect.Symbol) : List[String] = {
+    import qctx.reflect._
 
     val pathArray = symbol.show.split("\\.") // NOTE: this should print w/o colors, inspect afterwards
     pathArray.iterator.slice(0, pathArray.length - 1).toList
   }
 
-  def extractModifiers(using QuoteContext)(flags: qctx.tasty.Flags, privateWithin: Option[qctx.tasty.Type], protectedWithin: Option[qctx.tasty.Type]) : (List[String], Option[Reference], Option[Reference]) = {
-    import qctx.tasty._
+  def extractModifiers(using QuoteContext)(flags: qctx.reflect.Flags, privateWithin: Option[qctx.reflect.Type], protectedWithin: Option[qctx.reflect.Type]) : (List[String], Option[Reference], Option[Reference]) = {
+    import qctx.reflect._
 
     (((if(flags.is(Flags.Override)) "override" else "") ::
     (if(flags.is(Flags.Private)) "private" else "")::
@@ -39,7 +39,7 @@ trait TastyExtractor extends TastyTypeConverter with CommentParser with CommentC
     })
   }
 
-  def extractComments(using QuoteContext)(comment: Option[qctx.tasty.Documentation], rep: Representation) : (Map[String, EmulatedPackageRepresentation], String) => Option[Comment] = {
+  def extractComments(using QuoteContext)(comment: Option[qctx.reflect.Documentation], rep: Representation) : (Map[String, EmulatedPackageRepresentation], String) => Option[Comment] = {
     comment match {
       case Some(com) =>
         (packages, userDocSyntax) => {
@@ -56,8 +56,8 @@ trait TastyExtractor extends TastyTypeConverter with CommentParser with CommentC
     }
   }
 
-  def extractClassMembers(using QuoteContext)(body: List[qctx.tasty.Statement], symbol: qctx.tasty.Symbol, parentRepresentation: Some[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) : List[Representation with Modifiers] = {
-    import qctx.tasty._
+  def extractClassMembers(using QuoteContext)(body: List[qctx.reflect.Statement], symbol: qctx.reflect.Symbol, parentRepresentation: Some[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) : List[Representation with Modifiers] = {
+    import qctx.reflect._
 
     /** Filter fields which shouldn't be displayed in the doc
      */
@@ -83,7 +83,7 @@ trait TastyExtractor extends TastyTypeConverter with CommentParser with CommentC
       filterSymbol(x)
     }.flatMap {
       case x if x.isValDef => Some(x)
-      // case qctx.tasty.IsValDefSymbol(x) => Some(x)
+      // case qctx.reflect.IsValDefSymbol(x) => Some(x)
       case _ => None
     }.map { x =>
       convertToRepresentation(x.tree, parentRepresentation)
@@ -96,8 +96,8 @@ trait TastyExtractor extends TastyTypeConverter with CommentParser with CommentC
     .sortBy(_.name)
   }
 
-  def extractParents(using QuoteContext)(parents: List[qctx.tasty.Tree]): List[Reference] = {
-    import qctx.tasty._
+  def extractParents(using QuoteContext)(parents: List[qctx.reflect.Tree]): List[Reference] = {
+    import qctx.reflect._
 
     val parentsReferences = parents.map{
       case c: TypeTree => convertTypeToReference(c.tpe)
@@ -115,8 +115,8 @@ trait TastyExtractor extends TastyTypeConverter with CommentParser with CommentC
   *
   * @return (is case, is a trait, is an object, the kind as a String)
   */
-  def extractKind(using QuoteContext)(flags: qctx.tasty.Flags): (Boolean, Boolean, Boolean, String) = {
-    import qctx.tasty._
+  def extractKind(using QuoteContext)(flags: qctx.reflect.Flags): (Boolean, Boolean, Boolean, String) = {
+    import qctx.reflect._
 
     val isCase = flags.is(Flags.Case)
     val isTrait = flags.is(Flags.Trait)
@@ -140,8 +140,8 @@ trait TastyExtractor extends TastyTypeConverter with CommentParser with CommentC
     (isCase, isTrait, isObject, kind)
   }
 
-  def extractCompanion(using QuoteContext)(companionModule: Option[qctx.tasty.Symbol], companionClass: Option[qctx.tasty.Symbol], companionIsObject: Boolean): Option[CompanionReference] = {
-    import qctx.tasty._
+  def extractCompanion(using QuoteContext)(companionModule: Option[qctx.reflect.Symbol], companionClass: Option[qctx.reflect.Symbol], companionIsObject: Boolean): Option[CompanionReference] = {
+    import qctx.reflect._
 
     if(companionIsObject){
       companionModule match {
@@ -162,8 +162,8 @@ trait TastyExtractor extends TastyTypeConverter with CommentParser with CommentC
     }
   }
 
-  def extractAnnotations(using QuoteContext)(annots: List[qctx.tasty.Term]): List[TypeReference] = {
-    import qctx.tasty._
+  def extractAnnotations(using QuoteContext)(annots: List[qctx.reflect.Term]): List[TypeReference] = {
+    import qctx.reflect._
 
     def keepAnnot(label: String, link: String): Boolean = {
       !(label == "SourceFile" && link == "/internal") &&

--- a/tastydoc/src/dotty/tastydoc/TastyTypeConverter.scala
+++ b/tastydoc/src/dotty/tastydoc/TastyTypeConverter.scala
@@ -6,8 +6,8 @@ import dotty.tastydoc.references._
 /** Trait containing methods for converting from Reflect types to References */
 trait TastyTypeConverter {
 
-  def convertTypeToReference(using QuoteContext)(tp: qctx.tasty.Type): Reference = {
-    import qctx.tasty._
+  def convertTypeToReference(using QuoteContext)(tp: qctx.reflect.Type): Reference = {
+    import qctx.reflect._
 
     //Inner method to avoid passing the reflection each time
     def inner(tp: Type): Reference = tp match {

--- a/tastydoc/src/dotty/tastydoc/representations.scala
+++ b/tastydoc/src/dotty/tastydoc/representations.scala
@@ -82,8 +82,8 @@ object representations extends TastyExtractor {
     }
   }
 
-  class PackageRepresentation(using QuoteContext)(internal: qctx.tasty.PackageClause, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Members {
-    import qctx.tasty._
+  class PackageRepresentation(using QuoteContext)(internal: qctx.reflect.PackageClause, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Members {
+    import qctx.reflect._
 
     override val (name, path) = extractPackageNameAndPath(internal.pid.show)
     override val members = internal.stats.map(convertToRepresentation(_, Some(this)))
@@ -92,8 +92,8 @@ object representations extends TastyExtractor {
     override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.documentation, this)(packages, userDocSyntax)
   }
 
-  class ImportRepresentation(using QuoteContext)(internal: qctx.tasty.Import, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation {
-    import qctx.tasty._
+  class ImportRepresentation(using QuoteContext)(internal: qctx.reflect.Import, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation {
+    import qctx.reflect._
 
     override val name = if (internal.selectors.size > 1){
         internal.selectors.map(_.toString).mkString("{", ", ", "}")
@@ -106,8 +106,8 @@ object representations extends TastyExtractor {
     override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.documentation, this)(packages, userDocSyntax)
   }
 
-  class ClassRepresentation(using QuoteContext)(internal: qctx.tasty.ClassDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Members with Parents with Modifiers with Companion with Constructors with TypeParams {
-    import qctx.tasty._
+  class ClassRepresentation(using QuoteContext)(internal: qctx.reflect.ClassDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Members with Parents with Modifiers with Companion with Constructors with TypeParams {
+    import qctx.reflect._
 
     override val path = extractPath(internal.symbol)
     override val parents = extractParents(internal.parents)
@@ -142,8 +142,8 @@ object representations extends TastyExtractor {
     override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.documentation, this)(packages, userDocSyntax)
   }
 
-  class DefRepresentation(using QuoteContext)(internal: qctx.tasty.DefDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with TypeParams with MultipleParamList with ReturnValue {
-    import qctx.tasty._
+  class DefRepresentation(using QuoteContext)(internal: qctx.reflect.DefDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with TypeParams with MultipleParamList with ReturnValue {
+    import qctx.reflect._
 
     override val name = internal.name
     override val path = extractPath(internal.symbol)
@@ -161,8 +161,8 @@ object representations extends TastyExtractor {
     override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.documentation, this)(packages, userDocSyntax)
   }
 
-  class ValRepresentation(using QuoteContext)(internal: qctx.tasty.ValDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with ReturnValue {
-    import qctx.tasty._
+  class ValRepresentation(using QuoteContext)(internal: qctx.reflect.ValDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with ReturnValue {
+    import qctx.reflect._
 
     override val name = internal.name
     override val path = extractPath(internal.symbol)
@@ -174,8 +174,8 @@ object representations extends TastyExtractor {
     override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.documentation, this)(packages, userDocSyntax)
   }
 
-  class TypeRepresentation(using QuoteContext)(internal: qctx.tasty.TypeDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with TypeParams {
-    import qctx.tasty._
+  class TypeRepresentation(using QuoteContext)(internal: qctx.reflect.TypeDef, override val parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]) extends Representation with Modifiers with TypeParams {
+    import qctx.reflect._
 
     override val name = internal.name
     override val path = extractPath(internal.symbol)
@@ -191,8 +191,8 @@ object representations extends TastyExtractor {
     override def comments(packages: Map[String, EmulatedPackageRepresentation], userDocSyntax: String) = extractComments(internal.symbol.documentation, this)(packages, userDocSyntax)
   }
 
-  def convertToRepresentation(using QuoteContext)(tree: qctx.tasty.Tree, parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]): Representation = {
-    import qctx.tasty._
+  def convertToRepresentation(using QuoteContext)(tree: qctx.reflect.Tree, parentRepresentation: Option[Representation])(using mutablePackagesMap: scala.collection.mutable.HashMap[String, EmulatedPackageRepresentation]): Representation = {
+    import qctx.reflect._
 
     tree match {
       case t: PackageClause =>

--- a/tests/disabled/pos-macros/i7853/SummonJsonEncoderTest_2.scala
+++ b/tests/disabled/pos-macros/i7853/SummonJsonEncoderTest_2.scala
@@ -7,7 +7,7 @@ object SummonJsonEncoderTest {
   inline def encodeAndMessAroundType[T](value: =>T): String = ${ encodeAndMessAroundTypeImpl('value) }
 
   def encodeAndMessAroundTypeImpl[T: Type](value: Expr[T])(using qctx: QuoteContext): Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val mirrorExpr = Expr.summon[Mirror.Of[T]] match {
       case Some(mirror) => mirror

--- a/tests/neg-macros/delegate-match-1/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-1/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 inline def f: Any = ${ fImpl }
 
 private def fImpl(using qctx: QuoteContext): Expr[Unit] = {
-  import qctx.tasty._
+  import qctx.reflect._
   Implicits.search(('[A]).unseal.tpe) match {
     case x: ImplicitSearchSuccess =>
       '{}

--- a/tests/neg-macros/delegate-match-2/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-2/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 inline def f: Any = ${ fImpl }
 
 private def fImpl (using qctx: QuoteContext) : Expr[Unit] = {
-  import qctx.tasty._
+  import qctx.reflect._
   Implicits.search(('[A]).unseal.tpe) match {
     case x: ImplicitSearchSuccess =>
       '{}

--- a/tests/neg-macros/delegate-match-3/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-3/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 inline def f: Any = ${ fImpl }
 
 private def fImpl(using qctx: QuoteContext) : Expr[Unit] = {
-  import qctx.tasty._
+  import qctx.reflect._
   Implicits.search(('[A]).unseal.tpe) match {
     case x: ImplicitSearchSuccess =>
       '{}

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -6,7 +6,7 @@ object Macro {
   extension (inline sc: StringContext) inline def foo(args: String*): Unit = ${ impl('sc) }
 
   def impl(sc: Expr[StringContext])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     sc match {
       case '{ StringContext(${Varargs(parts)}: _*) } =>
         for (part @ Const(s) <- parts)

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -6,7 +6,7 @@ object Macro {
   extension (inline sc: StringContext) inline def foo(args: String*): Unit = ${ impl('sc) }
 
   def impl(sc: Expr[StringContext])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     sc match {
       case '{ StringContext(${Varargs(parts)}: _*) } =>
         for (part @ Const(s) <- parts)

--- a/tests/neg-macros/i7919.scala
+++ b/tests/neg-macros/i7919.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object Test {
   def staged[T](using qctx: QuoteContext) = {
-    import qctx.tasty._
+    import qctx.reflect._
     given typeT as quoted.Type[T] // error
     val tTypeTree = typeT.unseal
     val tt = Type.of[T]

--- a/tests/neg-macros/i8871.scala
+++ b/tests/neg-macros/i8871.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 object Macro {
   def impl[A : Type](using qctx: QuoteContext): Unit = {
-    import qctx.tasty._
+    import qctx.reflect._
     val tpe = Type.of[A].seal.asInstanceOf[quoted.Type[_ <: AnyRef]]
     '{ (a: ${tpe}) => ???} // error
   }

--- a/tests/neg-macros/i8871b.scala
+++ b/tests/neg-macros/i8871b.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 object Macro {
   def impl[A : Type](using qctx: QuoteContext): Unit = {
-    import qctx.tasty._
+    import qctx.reflect._
     val tpe/*: quoted.Type[? <: AnyKind]*/ = Type.of[A].seal
     '{ f[$tpe] } // error
   }

--- a/tests/neg-macros/i9801/Macro_1.scala
+++ b/tests/neg-macros/i9801/Macro_1.scala
@@ -15,6 +15,6 @@ def impl(prog: Expr[Double])(using QuoteContext) : Expr[Double] =
     triggerStackOverflow(0)
   } catch {
     case e =>
-      qctx.tasty.Reporting.error(e.getMessage, prog.unseal.pos)
+      qctx.reflect.Reporting.error(e.getMessage, prog.unseal.pos)
       '{ 42.0 }
   }

--- a/tests/neg-macros/macros-in-same-project-6/Foo.scala
+++ b/tests/neg-macros/macros-in-same-project-6/Foo.scala
@@ -5,7 +5,7 @@ object Foo {
   inline def myMacro(): Unit = ${ aMacroImplementation }
 
   def aMacroImplementation(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Reporting.error("some error", rootPosition)
     throw new NoClassDefFoundError("Bar$")
   }

--- a/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
@@ -13,7 +13,7 @@ object Asserts {
     ${impl('cond)}
 
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val tree = cond.unseal
 

--- a/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
@@ -13,7 +13,7 @@ object Asserts {
     ${ impl('cond) }
 
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val tree = cond.unseal
 

--- a/tests/neg-macros/tasty-macro-error/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-error/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def fun(x: Any): Unit = ${ impl('x) }
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Reporting.error("here is the the argument is " + x.unseal.underlyingArgument.show, x.unseal.underlyingArgument.pos)
     '{}
   }

--- a/tests/neg-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-positions/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def fun(x: Any): Unit = ${ impl('x) }
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val pos = x.unseal.underlyingArgument.pos
     Reporting.error("here is the the argument is " + x.unseal.underlyingArgument.show, pos)
     Reporting.error("here (+5) is the the argument is " + x.unseal.underlyingArgument.show, pos.sourceFile, pos.start + 5, pos.end + 5)

--- a/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
 object FIntepolator {
 
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Reporting.error("there are no parts", strCtxExpr.unseal.underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }

--- a/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
@@ -9,7 +9,7 @@ object Macro {
 
 object FIntepolator {
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Reporting.error("there are no args", argsExpr.unseal.underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }

--- a/tests/neg-staging/i5941/macro_1.scala
+++ b/tests/neg-staging/i5941/macro_1.scala
@@ -13,7 +13,7 @@ object Lens {
 
   def impl[S: Type, T: Type](getter: Expr[S => T])(using qctx: QuoteContext): Expr[Lens[S, T]] = {
     implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(this.getClass.getClassLoader)
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
     // obj.copy(field = value)
     def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =

--- a/tests/pending/pos/cps-async-failure.scala
+++ b/tests/pending/pos/cps-async-failure.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 trait App[F[_],CT]:
   this: Base[F,CT] =>
 
-  import qctx.tasty._
+  import qctx.reflect._
 
   trait AA
 

--- a/tests/pending/run/tasty-comments/quoted_1.scala
+++ b/tests/pending/run/tasty-comments/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
     ${ impl('t) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val tree = x.unseal
     tree.symbol.comment.map(_.raw) match {

--- a/tests/pos-macros/i6171/Macro_1.scala
+++ b/tests/pos-macros/i6171/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(x: => Any): Unit = ${ assertImpl('x) }
 
   def assertImpl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     x.unseal.underlyingArgument
     '{ () }
   }

--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition) }
 
   def assertImpl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     cond.unseal.underlyingArgument match {

--- a/tests/pos-macros/i6803b/Macro_1.scala
+++ b/tests/pos-macros/i6803b/Macro_1.scala
@@ -9,7 +9,7 @@ object AsObject {
     def unsafe(i: Int): LineNo = new LineNo(i)
     inline given x as LineNo = ${impl}
     private def impl(using qctx: QuoteContext) : Expr[LineNo] = {
-      import qctx.tasty._
+      import qctx.reflect._
       '{unsafe(${Expr(rootPosition.startLine)})}
     }
   }

--- a/tests/pos-macros/i7204.scala
+++ b/tests/pos-macros/i7204.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object Foo {
   def impl(using qctx: QuoteContext) : Unit = {
-    import qctx.tasty._
+    import qctx.reflect._
     val Select(_, _) = (??? : Term)
   }
 }

--- a/tests/pos-macros/i7887.scala
+++ b/tests/pos-macros/i7887.scala
@@ -1,5 +1,5 @@
 def typed[A](using t: quoted.Type[A], qctx: quoted.QuoteContext): Unit = {
-  import qctx.tasty._
+  import qctx.reflect._
   '{
     type T = $t
     ${'{???}.cast[T]}

--- a/tests/pos-macros/i8045.scala
+++ b/tests/pos-macros/i8045.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Test
-  def run(using qctx: QuoteContext)(tree: qctx.tasty.Tree): Unit =
+  def run(using qctx: QuoteContext)(tree: qctx.reflect.Tree): Unit =
     '{  ${ makeExpr(tree) } + 1  }
-  def makeExpr(using qctx: QuoteContext)(tree: qctx.tasty.Tree): Expr[Int] = ???
+  def makeExpr(using qctx: QuoteContext)(tree: qctx.reflect.Tree): Expr[Int] = ???

--- a/tests/pos-macros/i8045b.scala
+++ b/tests/pos-macros/i8045b.scala
@@ -1,8 +1,8 @@
 import scala.quoted._
 object Test
-  def run(using qctx: QuoteContext)(tree: qctx.tasty.Tree): Unit =
+  def run(using qctx: QuoteContext)(tree: qctx.reflect.Tree): Unit =
     def nested()(using qctx.Nested): Expr[Int] =
       '{  ${ makeExpr(tree) } + 1  }
     '{  ${ nested() } + 2 }
 
-  def makeExpr(using qctx: QuoteContext)(tree: qctx.tasty.Tree): Expr[Int] = ???
+  def makeExpr(using qctx: QuoteContext)(tree: qctx.reflect.Tree): Expr[Int] = ???

--- a/tests/pos-macros/i8325/Macro_1.scala
+++ b/tests/pos-macros/i8325/Macro_1.scala
@@ -12,7 +12,7 @@ object A:
   def pure[A](a:A):A = ???
 
   def transformImplExpr[A:Type](using qctx: QuoteContext)(expr: Expr[A]): Expr[A] = {
-     import qctx.tasty._
+     import qctx.reflect._
      expr.unseal match {
          case Inlined(x,y,z) => transformImplExpr(z.seal.asInstanceOf[Expr[A]])
          case Apply(fun,args) =>  '{  A.pure(${Apply(fun,args).seal.asInstanceOf[Expr[A]]}) }

--- a/tests/pos-macros/i8325b/Macro_1.scala
+++ b/tests/pos-macros/i8325b/Macro_1.scala
@@ -12,7 +12,7 @@ object A:
   def pure[A](a:A):A = ???
 
   def transformImplExpr[A:Type](using qctx: QuoteContext)(expr: Expr[A]): Expr[A] = {
-     import qctx.tasty._
+     import qctx.reflect._
      expr.unseal match {
          case Inlined(x,y,z) => transformImplExpr(z.seal.asInstanceOf[Expr[A]])
          case r@Apply(fun,args) =>  '{

--- a/tests/pos-macros/i8521/Macro_1.scala
+++ b/tests/pos-macros/i8521/Macro_1.scala
@@ -4,7 +4,7 @@ object Foo {
   inline def foo[T <: AnyKind]: String = ${ bar[T] }
 
   def bar[T <: AnyKind : Type](using qctx: QuoteContext): Expr[String] = {
-    import qctx.tasty.{Type => _, _}
+    import qctx.reflect.{Type => _, _}
 
     def packageToName(sym: Symbol): Unit = {
       if sym.isPackageDef then

--- a/tests/pos-macros/i8866/Macro_1.scala
+++ b/tests/pos-macros/i8866/Macro_1.scala
@@ -12,7 +12,7 @@ object OtherMacro {
 object Macro {
 
   def impl(using qctx: QuoteContext): Expr[Int] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     let(
       Select.unique(

--- a/tests/pos-macros/i8866b/Macro_1.scala
+++ b/tests/pos-macros/i8866b/Macro_1.scala
@@ -7,7 +7,7 @@ object Other {
 object Macro {
 
   def impl(using qctx: QuoteContext): Expr[Int] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     let(
       Select.unique(

--- a/tests/pos-macros/i8879/Macro_1.scala
+++ b/tests/pos-macros/i8879/Macro_1.scala
@@ -6,7 +6,7 @@ object Test {
 
   def impl[T](t: T)(using qctx: QuoteContext, tt: Type[T]): Expr[Any] = {
 
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     val foo = Type.of[Foo[String]]

--- a/tests/pos-macros/i9240/Macro_1.scala
+++ b/tests/pos-macros/i9240/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.tasty._
 inline def diveInto[T]: String = ${ diveIntoImpl[T]() }
 
 def diveIntoImpl[T]()(implicit qctx: QuoteContext, ttype: scala.quoted.Type[T]): Expr[String] =
-  import qctx.tasty._
+  import qctx.reflect._
   Expr( unwindType(qctx.tasty)(Type.of[T]) )
 
 def unwindType(reflect: Reflection)(aType: reflect.Type): String =

--- a/tests/pos-macros/i9251/Macro_1.scala
+++ b/tests/pos-macros/i9251/Macro_1.scala
@@ -19,7 +19,7 @@ object Async {
 
 
   def checkPrintTypeImpl[F[_]:Type,T:Type](f: Expr[T])(using qctx: QuoteContext): Expr[Unit] =
-    import qctx.tasty._
+    import qctx.reflect._
 
     val fu = f.unseal
     fu match

--- a/tests/pos-macros/i9518/Macro_1.scala
+++ b/tests/pos-macros/i9518/Macro_1.scala
@@ -6,7 +6,7 @@ trait CB[T]
 inline def shift : Unit = ${ shiftTerm }
 
 def shiftTerm(using QuoteContext): Expr[Unit] = {
-  import qctx.tasty._
+  import qctx.reflect._
   val nTree = '{ ??? : CB[Int] }.unseal
   val tp1 = '[CB[Int]].unseal.tpe
   val tp2 = '[([X] =>> CB[X])[Int]].unseal.tpe

--- a/tests/pos-macros/i9570.scala
+++ b/tests/pos-macros/i9570.scala
@@ -8,7 +8,7 @@ object Macros {
     case object HNil extends HList
 
     private def sizeImpl(e: Expr[HList], n:Int)(using qctx:QuoteContext): Expr[Int] = {
-      import qctx.tasty._
+      import qctx.reflect._
       e match {
         case '{HCons(_,$t)} => // error if run with fatal warinings in BootstrappedOnlyCompilationTests
           sizeImpl(t,n+1)

--- a/tests/pos-macros/i9687/Macro_1.scala
+++ b/tests/pos-macros/i9687/Macro_1.scala
@@ -23,7 +23,7 @@ object X {
  }
 
  def transformImpl[A:Type](x:Expr[A])(using qctx: QuoteContext):Expr[A] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val slowPath = '{ SlowPath }.unseal
     val fastPath = '{ FastPath }.unseal
     val transformer = new TreeMap() {

--- a/tests/pos-macros/quotedPatterns-4.scala
+++ b/tests/pos-macros/quotedPatterns-4.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 object Test {
   def impl(receiver: Expr[StringContext])(using qctx: scala.quoted.QuoteContext) = {
-    import qctx.tasty.Repeated
+    import qctx.reflect.Repeated
     receiver match {
       case '{ StringContext(${Repeated(parts)}: _*) } => // now OK
     }

--- a/tests/pos-macros/scala2-macro-compat-1.scala
+++ b/tests/pos-macros/scala2-macro-compat-1.scala
@@ -20,7 +20,7 @@ object LineNumberMacro2 {
 object LineNumberMacro3 {
   import scala.quoted._
   def thisLineNumberExpr(using qctx: QuoteContext): Expr[Int] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(rootPosition.startLine + 1)
   }
 }

--- a/tests/pos-macros/tasty-constant-type/Macro_1.scala
+++ b/tests/pos-macros/tasty-constant-type/Macro_1.scala
@@ -7,7 +7,7 @@ object Macro {
   transparent inline def ff[A <: Int, B <: Int](): AddInt[A, B] = ${ impl('[A], '[B]) }
 
   def impl[A <: Int : Type, B <: Int : Type](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[AddInt[A, B]] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val ConstantType(Constant.Int(v1)) = a.unseal.tpe
     val ConstantType(Constant.Int(v2)) = b.unseal.tpe

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -6,7 +6,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     x.unseal match {
       case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
       case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -6,7 +6,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     x.unseal match {
       case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
       case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -6,11 +6,11 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val buff = new StringBuilder
 
-    val output = new MyTraverser(qctx.tasty)(buff)
+    val output = new MyTraverser(qctx.reflect)(buff)
 
     val tree = x.unseal
     output.traverseTree(tree)
@@ -18,7 +18,7 @@ object Macros {
   }
 
   class MyTraverser[R <: scala.tasty.Reflection & Singleton](val reflect: R)(buff: StringBuilder) extends scala.tasty.reflect.TreeTraverser {
-    import reflect.{given, _}
+    import reflect._
     override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = {
       tree match {
         case tree @ DefDef(name, _, _, _, _) =>

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
@@ -7,7 +7,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     def definitionString(sym: Symbol): Expr[String] =
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.showExtractors)

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
@@ -6,7 +6,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     def definitionString(sym: Symbol): Expr[String] =
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.showExtractors)

--- a/tests/run-custom-args/run-macros-erased/reflect-isFunctionType/macro_1.scala
+++ b/tests/run-custom-args/run-macros-erased/reflect-isFunctionType/macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 inline def isFunctionType[T]: Boolean = ${ isFunctionTypeImpl('[T]) }
 
 def isFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
-  import qctx.tasty._
+  import qctx.reflect._
   Expr(tp.unseal.tpe.isFunctionType)
 }
 
@@ -12,7 +12,7 @@ def isFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean]
 inline def isContextFunctionType[T]: Boolean = ${ isContextFunctionTypeImpl('[T]) }
 
 def isContextFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
-  import qctx.tasty._
+  import qctx.reflect._
   Expr(tp.unseal.tpe.isContextFunctionType)
 }
 
@@ -20,14 +20,14 @@ def isContextFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[B
 inline def isErasedFunctionType[T]: Boolean = ${ isErasedFunctionTypeImpl('[T]) }
 
 def isErasedFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
-  import qctx.tasty._
+  import qctx.reflect._
   Expr(tp.unseal.tpe.isErasedFunctionType)
 }
 
 inline def isDependentFunctionType[T]: Boolean = ${ isDependentFunctionTypeImpl('[T]) }
 
 def isDependentFunctionTypeImpl[T](tp: Type[T])(using qctx: QuoteContext) : Expr[Boolean] = {
-  import qctx.tasty._
+  import qctx.reflect._
   Expr(tp.unseal.tpe.isDependentFunctionType)
 }
 

--- a/tests/run-custom-args/tasty-inspector/i8163.scala
+++ b/tests/run-custom-args/tasty-inspector/i8163.scala
@@ -16,11 +16,11 @@ object Test {
 
 class TestInspector() extends TastyInspector:
 
-  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit =
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.reflect.Tree): Unit =
     inspectClass(root)
 
-  private def inspectClass(using QuoteContext)(tree: qctx.tasty.Tree): Unit =
-    import qctx.tasty._
+  private def inspectClass(using QuoteContext)(tree: qctx.reflect.Tree): Unit =
+    import qctx.reflect._
     tree match {
       case t: PackageClause =>
         t.stats.map( m => inspectClass(m) )

--- a/tests/run-custom-args/tasty-inspector/i8215.scala
+++ b/tests/run-custom-args/tasty-inspector/i8215.scala
@@ -35,7 +35,7 @@ class TestInspector_NonTasty() extends TastyInspector:
   var isScala2: Boolean = false
   var className: String = ""
 
-  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit =
-    isJava = qctx.tasty.Source.isJavaCompilationUnit
-    isScala2 = qctx.tasty.Source.isScala2CompilationUnit
-    className = qctx.tasty.Source.compilationUnitClassname
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.reflect.Tree): Unit =
+    isJava = qctx.reflect.Source.isJavaCompilationUnit
+    isScala2 = qctx.reflect.Source.isScala2CompilationUnit
+    className = qctx.reflect.Source.compilationUnitClassname

--- a/tests/run-custom-args/tasty-inspector/i8364.scala
+++ b/tests/run-custom-args/tasty-inspector/i8364.scala
@@ -3,7 +3,7 @@ import scala.tasty.inspector._
 
 @main def Test = {
   val inspector = new TastyInspector {
-    protected def processCompilationUnit(using QuoteContext)(tree: qctx.tasty.Tree): Unit = {
+    protected def processCompilationUnit(using QuoteContext)(tree: qctx.reflect.Tree): Unit = {
       println(tree.show)
     }
   }

--- a/tests/run-custom-args/tasty-inspector/i8389.scala
+++ b/tests/run-custom-args/tasty-inspector/i8389.scala
@@ -4,7 +4,7 @@ import scala.tasty.inspector._
 @main def Test = {
   // in dotty-example-project
   val inspector = new TastyInspector {
-    protected def processCompilationUnit(using QuoteContext)(tree: qctx.tasty.Tree): Unit = {
+    protected def processCompilationUnit(using QuoteContext)(tree: qctx.reflect.Tree): Unit = {
       println(tree.show)
     }
   }

--- a/tests/run-custom-args/tasty-inspector/i8460.scala
+++ b/tests/run-custom-args/tasty-inspector/i8460.scala
@@ -32,12 +32,12 @@ class TestInspector_Children() extends TastyInspector:
 
   var kids: List[String] = Nil
 
-  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit =
-    import qctx.tasty._
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.reflect.Tree): Unit =
+    import qctx.reflect._
     inspectClass(root)
 
-  private def inspectClass(using QuoteContext)(tree: qctx.tasty.Tree): Unit =
-    import qctx.tasty._
+  private def inspectClass(using QuoteContext)(tree: qctx.reflect.Tree): Unit =
+    import qctx.reflect._
     tree match {
       case t: PackageClause =>
         t.stats.map( m => inspectClass(m) )

--- a/tests/run-custom-args/tasty-inspector/i8558.scala
+++ b/tests/run-custom-args/tasty-inspector/i8558.scala
@@ -17,6 +17,6 @@ class TestInspector_NonTasty() extends TastyInspector:
   var isAlreadyLoaded: Boolean = false
   var className: String = ""
 
-  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit =
-    isAlreadyLoaded = qctx.tasty.Source.isAlreadyLoadedCompilationUnit
-    className = qctx.tasty.Source.compilationUnitClassname
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.reflect.Tree): Unit =
+    isAlreadyLoaded = qctx.reflect.Source.isAlreadyLoadedCompilationUnit
+    className = qctx.reflect.Source.compilationUnitClassname

--- a/tests/run-custom-args/tasty-inspector/tasty-documentation-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-documentation-inspector/Test.scala
@@ -9,8 +9,8 @@ object Test {
 
 class DocumentationInspector extends TastyInspector {
 
-  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit = {
-    import qctx.tasty._
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.reflect.Tree): Unit = {
+    import qctx.reflect._
     object Traverser extends TreeTraverser {
 
       override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {

--- a/tests/run-custom-args/tasty-inspector/tasty-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-inspector/Test.scala
@@ -9,8 +9,8 @@ object Test {
 
 class DBInspector extends TastyInspector {
 
-  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit = {
-    import qctx.tasty._
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.reflect.Tree): Unit = {
+    import qctx.reflect._
     object Traverser extends TreeTraverser {
 
       override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
@@ -5,8 +5,8 @@ import scala.tasty.inspector.TastyInspector
 
 class TastyInterpreter extends TastyInspector {
 
-  protected def processCompilationUnit(using QuoteContext)(root: qctx.tasty.Tree): Unit = {
-    import qctx.tasty._
+  protected def processCompilationUnit(using QuoteContext)(root: qctx.reflect.Tree): Unit = {
+    import qctx.reflect._
     object Traverser extends TreeTraverser {
 
       override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TreeInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TreeInterpreter.scala
@@ -5,7 +5,7 @@ import scala.tasty.interpreter.jvm.JVMReflection
 import scala.tasty.Reflection
 
 abstract class TreeInterpreter[QCtx <: QuoteContext & Singleton](using val qctx: QCtx) {
-  import qctx.tasty._
+  import qctx.reflect._
 
   final val LOG = false
 

--- a/tests/run-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
@@ -6,7 +6,7 @@ import scala.tasty.interpreter.jvm.JVMReflection
 import scala.tasty.Reflection
 
 class Interpreter[QCtx <: QuoteContext & Singleton](using qctx0: QCtx) extends TreeInterpreter[QCtx] {
-  import qctx.tasty._
+  import qctx.reflect._
 
   // All references are represented by themselves and values are boxed
   type AbstractAny = Any

--- a/tests/run-custom-args/tasty-interpreter/interpreter/jvm/JVMReflection.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/jvm/JVMReflection.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 import scala.tasty.Reflection
 
 class JVMReflection[QCtx <: QuoteContext & Singleton](using val tasty: QCtx) {
-  import qctx.tasty._
+  import qctx.reflect._
 
   import java.lang.reflect.{InvocationTargetException, Method}
   private val classLoader: ClassLoader = getClass.getClassLoader

--- a/tests/run-macros/f-interpolation-1/FQuote_1.scala
+++ b/tests/run-macros/f-interpolation-1/FQuote_1.scala
@@ -9,7 +9,7 @@ object FQuote {
   }
 
   /*private*/ def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     def liftListOfAny(lst: List[Term]): Expr[List[Any]] = lst match {
       case x :: xs  =>

--- a/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
+++ b/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
@@ -7,28 +7,28 @@ object TypeToolbox {
   /** are the two types equal? */
   inline def =:=[A, B]: Boolean = ${tpEqImpl('[A], '[B])}
   private def tpEqImpl[A, B](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(a.unseal.tpe =:= b.unseal.tpe)
   }
 
   /** is `tp1` a subtype of `tp2` */
   inline def <:<[A, B]: Boolean = ${tpLEqImpl('[A], '[B])}
   private def tpLEqImpl[A, B](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(a.unseal.tpe <:< b.unseal.tpe)
   }
 
   /** type associated with the tree */
   inline def typeOf[T, Expected](a: T): Boolean = ${typeOfImpl('a, '[Expected])}
   private def typeOfImpl(a: Expr[_], expected: Type[_])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(a.unseal.tpe =:= expected.unseal.tpe)
   }
 
   /** does the type refer to a case class? */
   inline def isCaseClass[A]: Boolean = ${isCaseClassImpl('[A])}
   private def isCaseClassImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val sym = tp.unseal.symbol
     Expr(sym.isClassDef && sym.flags.is(Flags.Case))
   }
@@ -36,66 +36,66 @@ object TypeToolbox {
   /** val fields of a case class Type -- only the ones declared in primary constructor */
   inline def caseFields[T]: List[String] = ${caseFieldsImpl('[T])}
   private def caseFieldsImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[List[String]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val fields = tp.unseal.symbol.caseFields.map(_.name)
     Expr(fields)
   }
 
   inline def fieldIn[T](inline mem: String): String = ${fieldInImpl('[T], 'mem)}
   private def fieldInImpl(t: Type[_], mem: Expr[String])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val field = t.unseal.symbol.field(mem.unliftOrError)
     Expr(if field.isNoSymbol then "" else field.name)
   }
 
   inline def fieldsIn[T]: Seq[String] = ${fieldsInImpl('[T])}
   private def fieldsInImpl(t: Type[_])(using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val fields = t.unseal.symbol.fields
     Expr(fields.map(_.name).toList)
   }
 
   inline def methodIn[T](inline mem: String): Seq[String] = ${methodInImpl('[T], 'mem)}
   private def methodInImpl(t: Type[_], mem: Expr[String])(using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(t.unseal.symbol.classMethod(mem.unliftOrError).map(_.name))
   }
 
   inline def methodsIn[T]: Seq[String] = ${methodsInImpl('[T])}
   private def methodsInImpl(t: Type[_])(using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(t.unseal.symbol.classMethods.map(_.name))
   }
 
   inline def method[T](inline mem: String): Seq[String] = ${methodImpl('[T], 'mem)}
   private def methodImpl(t: Type[_], mem: Expr[String])(using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(t.unseal.symbol.method(mem.unliftOrError).map(_.name))
   }
 
   inline def methods[T]: Seq[String] = ${methodsImpl('[T])}
   private def methodsImpl(t: Type[_])(using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(t.unseal.symbol.methods.map(_.name))
   }
 
   inline def typeTag[T](x: T): String = ${typeTagImpl('[T])}
   private def typeTagImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val res = tp.unseal.tpe.show
     Expr(res)
   }
 
   inline def companion[T1, T2]: Boolean = ${companionImpl('[T1], '[T2])}
   private def companionImpl(t1: Type[_], t2: Type[_])(using qctx: QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val res = t1.unseal.symbol.companionModule == t2.unseal.symbol
     Expr(res)
   }
 
   inline def companionName[T1]: String = ${companionNameImpl('[T1])}
   private def companionNameImpl(tp: Type[_])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val sym = tp.unseal.symbol
     val companionClass =
       if sym.isClassDef then sym.companionModule.companionClass

--- a/tests/run-macros/i5119/Macro_1.scala
+++ b/tests/run-macros/i5119/Macro_1.scala
@@ -6,7 +6,7 @@ object Macro {
   }
   implicit inline def XmlQuote(inline sc: StringContext): StringContextOps = new StringContextOps(sc)
   def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(sc.unseal.underlyingArgument.showExtractors + "\n" + args.unseal.underlyingArgument.showExtractors)
   }
 }

--- a/tests/run-macros/i5533/Macro_1.scala
+++ b/tests/run-macros/i5533/Macro_1.scala
@@ -8,7 +8,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val tree = condition.unseal
 

--- a/tests/run-macros/i5533b/Macro_1.scala
+++ b/tests/run-macros/i5533b/Macro_1.scala
@@ -7,7 +7,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val tree = condition.unseal
     def exprStr: String = condition.show
 

--- a/tests/run-macros/i5536/Macro_1.scala
+++ b/tests/run-macros/i5536/Macro_1.scala
@@ -4,7 +4,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val tree = condition.unseal
     def exprStr: String = condition.show
 

--- a/tests/run-macros/i5629/Macro_1.scala
+++ b/tests/run-macros/i5629/Macro_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('{condition}, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val b = cond.unseal.underlyingArgument.seal.cast[Boolean]
     '{ scala.Predef.assert($b) }
   }
@@ -13,7 +13,7 @@ object Macros {
   inline def thisLineNumber = ${ thisLineNumberImpl }
 
   def thisLineNumberImpl(using qctx: QuoteContext) : Expr[Int] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(rootPosition.startLine)
   }
 }

--- a/tests/run-macros/i5715/Macro_1.scala
+++ b/tests/run-macros/i5715/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     cond.unseal.underlyingArgument match {
       case app @ Apply(select @ Select(lhs, op), rhs :: Nil) =>

--- a/tests/run-macros/i5941/macro_1.scala
+++ b/tests/run-macros/i5941/macro_1.scala
@@ -12,7 +12,7 @@ object Lens {
   }
 
   def impl[S: Type, T: Type](getter: Expr[S => T])(using qctx: QuoteContext) : Expr[Lens[S, T]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     // obj.copy(a = obj.a.copy(b = a.b.copy(c = v)))
@@ -85,7 +85,7 @@ object Iso {
   }
 
   def impl[S: Type, A: Type](using qctx: QuoteContext) : Expr[Iso[S, A]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     val tpS = Type.of[S]
@@ -124,7 +124,7 @@ object Iso {
   }
 
   def implUnit[S: Type](using qctx: QuoteContext) : Expr[Iso[S, 1]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     val tpS = Type.of[S]
@@ -196,7 +196,7 @@ object Prism {
   }
 
   def impl[S: Type, A <: S : Type](using qctx: QuoteContext) : Expr[Prism[S, A]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     '{

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/i6270/Macro_1.scala
+++ b/tests/run-macros/i6270/Macro_1.scala
@@ -6,7 +6,7 @@ object api {
     ${ reflImpl('x) }
 
   private def reflImpl(x: Expr[String])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(x.show)
   }
 
@@ -14,7 +14,7 @@ object api {
     ${ reflImplColor('x) }
 
   private def reflImplColor(x: Expr[String])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(x.showWith(ANSI))
   }
 }

--- a/tests/run-macros/i6518/Macro_1.scala
+++ b/tests/run-macros/i6518/Macro_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def test(): String = ${ testImpl }
 
   private def testImpl(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val classSym = Type.of[Function1].classSymbol.get
     classSym.classMethod("apply")
     classSym.classMethods

--- a/tests/run-macros/i6679/Macro_1.scala
+++ b/tests/run-macros/i6679/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 
 def makeMatch[A: Type](head : Expr[A])(using qctx : QuoteContext) : Expr[Unit] = {
-  import qctx.tasty._
+  import qctx.reflect._
 
   val sacrifice = '{ $head match { case _ => ??? } }
   sacrifice.unseal

--- a/tests/run-macros/i6765/Macro_1.scala
+++ b/tests/run-macros/i6765/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 inline def foo = ${fooImpl}
 
 def fooImpl(using qctx: QuoteContext) = {
-  import qctx.tasty._
+  import qctx.reflect._
   val res = Expr.ofList(List('{"One"}))
   Expr(res.show)
 }

--- a/tests/run-macros/i6803/Macro_1.scala
+++ b/tests/run-macros/i6803/Macro_1.scala
@@ -9,7 +9,7 @@ object AsObject {
     def unsafe(i: Int): LineNo = new LineNo(i)
     inline given LineNo = ${impl}
     private def impl(using qctx: QuoteContext): Expr[LineNo] = {
-      import qctx.tasty._
+      import qctx.reflect._
       '{unsafe(${Expr(rootPosition.startLine)})}
     }
   }
@@ -21,7 +21,7 @@ package AsPackage {
     def unsafe(i: Int): LineNo = new LineNo(i)
     inline given LineNo = ${impl}
     private def impl(using qctx: QuoteContext): Expr[LineNo] = {
-      import qctx.tasty._
+      import qctx.reflect._
       '{unsafe(${Expr(rootPosition.startLine)})}
     }
   }

--- a/tests/run-macros/i6988/FirstArg_1.scala
+++ b/tests/run-macros/i6988/FirstArg_1.scala
@@ -9,7 +9,7 @@ object Macros {
   import scala.quoted._
 
   def argsImpl(using qctx: QuoteContext) : Expr[FirstArg] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     def enclosingClass(cur: Symbol = Symbol.currentOwner): Symbol =
       if (cur.isClassDef) cur

--- a/tests/run-macros/i7025/Macros_1.scala
+++ b/tests/run-macros/i7025/Macros_1.scala
@@ -4,7 +4,7 @@ object Macros {
   inline def debug: Unit = ${Macros.debugImpl}
 
   def debugImpl(using qctx: QuoteContext): Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     def nearestEnclosingDef(owner: Symbol): Symbol =
       if owner.isClassDef then owner

--- a/tests/run-macros/i7887/Macro_1.scala
+++ b/tests/run-macros/i7887/Macro_1.scala
@@ -1,5 +1,5 @@
 def myMacroImpl(a: quoted.Expr[_])(using qctx: quoted.QuoteContext) = {
-  import qctx.tasty._
+  import qctx.reflect._
   def typed[A] = {
     implicit val t: quoted.Type[A] = a.unseal.tpe.widen.seal.asInstanceOf[quoted.Type[A]]
     '{

--- a/tests/run-macros/i7898/Macro_1.scala
+++ b/tests/run-macros/i7898/Macro_1.scala
@@ -3,7 +3,7 @@ import quoted.unsafe._
 object Main {
 
   def myMacroImpl(body: Expr[_])(using qctx: QuoteContext) : Expr[_] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val bodyTerm = UnsafeExpr.underlyingArgument(body).unseal
     val showed = bodyTerm.show
     '{

--- a/tests/run-macros/i8007/Macro_1.scala
+++ b/tests/run-macros/i8007/Macro_1.scala
@@ -17,7 +17,7 @@ object Macro1 {
     ${ test1Impl('value) }
 
   def test1Impl[T: Type](value: Expr[T])(using qctx: QuoteContext): Expr[List[String]] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val mirrorTpe = '[Mirror.Of[T]]
 

--- a/tests/run-macros/i8007/Macro_2.scala
+++ b/tests/run-macros/i8007/Macro_2.scala
@@ -21,7 +21,7 @@ object Macro2 {
         }
 
     def derived[T: Type](ev: Expr[Mirror.Of[T]])(using qctx: QuoteContext): Expr[JsonEncoder[T]] = {
-      import qctx.tasty._
+      import qctx.reflect._
 
       val fields = ev match {
         case '{ $m: Mirror.ProductOf[T] { type MirroredElemLabels = $t } } =>
@@ -43,7 +43,7 @@ object Macro2 {
   inline def test2[T](value: =>T): Unit = ${ test2Impl('value) }
 
   def test2Impl[T: Type](value: Expr[T])(using qctx: QuoteContext): Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val mirrorTpe = '[Mirror.Of[T]]
     val mirrorExpr = Expr.summon(using mirrorTpe).get

--- a/tests/run-macros/i8007/Macro_3.scala
+++ b/tests/run-macros/i8007/Macro_3.scala
@@ -33,7 +33,7 @@ object Eq {
   }
 
   given derived[T: Type](using qctx: QuoteContext) as Expr[Eq[T]] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val ev: Expr[Mirror.Of[T]] = Expr.summon(using '[Mirror.Of[T]]).get
 

--- a/tests/run-macros/i8514/Macro_1.scala
+++ b/tests/run-macros/i8514/Macro_1.scala
@@ -7,7 +7,7 @@ class C extends B
 inline def test(): Unit = ${ testExpr }
 
 def testExpr(using QuoteContext): Expr[Unit] = {
-  import qctx.tasty._
+  import qctx.reflect._
 
   '{
     println(${Expr('[Object].unseal.tpe.baseClasses.toString)})

--- a/tests/run-macros/i8514b/Macro_1.scala
+++ b/tests/run-macros/i8514b/Macro_1.scala
@@ -7,7 +7,7 @@ class B extends A[P, String]
 inline def test(): Unit = ${ testExpr }
 
 def testExpr(using QuoteContext): Expr[Unit] = {
-  import qctx.tasty._
+  import qctx.reflect._
 
   val t = '[B].unseal.tpe
   val baseTypes = t.baseClasses.map(b => t.baseType(b))

--- a/tests/run-macros/i8520/Macro_1.scala
+++ b/tests/run-macros/i8520/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 inline def test[T[_]]: Unit = ${ testExpr[T] }
 
 def testExpr[T[_]: Type](using QuoteContext): Expr[Unit] = {
-  import qctx.tasty._
+  import qctx.reflect._
   def variance(f: Flags) =
      if f.is(Flags.Covariant) then "+"
      else if f.is(Flags.Contravariant) then "-"

--- a/tests/run-macros/i9570/Macro_1.scala
+++ b/tests/run-macros/i9570/Macro_1.scala
@@ -8,7 +8,7 @@ object Macros {
     case object HNil extends HList
 
     private def sizeImpl(e: Expr[HList], n:Int)(using qctx:QuoteContext): Expr[Int] = {
-      import qctx.tasty._
+      import qctx.reflect._
       e match {
         case '{HCons($_,$t)} =>
         //case '{HCons($a,$t)} =>

--- a/tests/run-macros/i9812b/Macro_1.scala
+++ b/tests/run-macros/i9812b/Macro_1.scala
@@ -28,7 +28,7 @@ case object NIL extends Lst[Nothing]
 
 given IntLiftable[T <: Int] as Liftable[T]:
   def toExpr(x: T): QuoteContext ?=> Expr[T] = qctx ?=> {
-    import qctx.tasty._
+    import qctx.reflect._
     Literal(Constant.Int(x)).seal.asInstanceOf[Expr[T]]
   }
 

--- a/tests/run-macros/inferred-repeated-result/test_1.scala
+++ b/tests/run-macros/inferred-repeated-result/test_1.scala
@@ -3,7 +3,7 @@ object Macros {
 
   inline def go[T](inline t: T) = ${ impl('t) }
   def impl[T](expr: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val tree = expr.unseal
 

--- a/tests/run-macros/no-symbol/1.scala
+++ b/tests/run-macros/no-symbol/1.scala
@@ -9,7 +9,7 @@ object Macro {
     ${ fooImpl[T] }
 
   def fooImpl[T](implicit t: Type[T], qctx: QuoteContext): Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val sym = t.unseal.symbol
     if sym.isClassDef then '{ "symbol" }
     else if sym.isNoSymbol then '{ "no symbol" }

--- a/tests/run-macros/quote-inline-function/quoted_1.scala
+++ b/tests/run-macros/quote-inline-function/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
   inline def foreach3(start: Int, end: Int, inline f: Int => Unit): String = ${impl('start, 'end, 'f)}
 
   def impl(start: Expr[Int], end: Expr[Int], f: Expr[Int => Unit])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val res = '{
       var i = $start
       val j = $end

--- a/tests/run-macros/quote-matcher-runtime/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-runtime/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def matches[A, B](inline a: A, inline b: B): Unit = ${impl('a, 'b)}
 
   private def impl[A, B](a: Expr[A], b: Expr[B])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val res = scala.internal.quoted.Expr.unapply[Tuple, Tuple](a)(using b, qctx).map { tup =>
       tup.toArray.toList.map {

--- a/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
@@ -20,7 +20,7 @@ object Macros {
         '{ $sym.times(${lift(x)}, ${lift(y)}) }
 
       case _ =>
-        import qctx.tasty._
+        import qctx.reflect._
         Reporting.error("Expected explicit DSL", e.unseal.pos)
         '{ ??? }
 

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -31,7 +31,7 @@ object Macros {
       case '{ envVar(${Const(i)}) } => env(i)
 
       case _ =>
-        import qctx.tasty._
+        import qctx.reflect._
         Reporting.error("Expected explicit DSL " + e.show, e.unseal.pos)
         ???
     }
@@ -45,7 +45,7 @@ object Macros {
           }
         )
       case _ =>
-        import qctx.tasty._
+        import qctx.reflect._
         Reporting.error("Expected explicit DSL => DSL "  + e.show, e.unseal.pos)
         ???
     }

--- a/tests/run-macros/quote-toExprOfTuple/Macro_1.scala
+++ b/tests/run-macros/quote-toExprOfTuple/Macro_1.scala
@@ -4,7 +4,7 @@ object Macro {
   inline def t2[T0, T1](t0: T0, t1: T1): (T0, T1) = ${ impl2('{t0}, '{t1}) }
 
   def impl2[T0: Type, T1: Type](t0: Expr[T0], t1: Expr[T1])(using qctx: QuoteContext) : Expr[(T0, T1)] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     val seq = List(t0, t1)

--- a/tests/run-macros/quote-type-matcher/quoted_1.scala
+++ b/tests/run-macros/quote-type-matcher/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def matches[A, B]: Unit = ${ matchesExpr('[A], '[B]) }
 
   private def matchesExpr[A, B](a: Type[A], b: Type[B])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val res = scala.internal.quoted.Type.unapply[Tuple, Tuple](a)(using b, qctx).map { tup =>
       tup.toArray.toList.map {

--- a/tests/run-macros/quoted-matching-docs/Macro_1.scala
+++ b/tests/run-macros/quoted-matching-docs/Macro_1.scala
@@ -10,7 +10,7 @@ private def sumExprShow(argsExpr: Expr[Seq[Int]]) (using QuoteContext): Expr[Str
   Expr(sumExpr(argsExpr).show)
 
 private def sumExpr(argsExpr: Expr[Seq[Int]])(using qctx: QuoteContext) : Expr[Int] = {
-  import qctx.tasty._
+  import qctx.reflect._
   UnsafeExpr.underlyingArgument(argsExpr) match {
     case Varargs(Consts(args)) => // args is of type Seq[Int]
       Expr(args.sum) // precompute result of sum

--- a/tests/run-macros/refined-selectable-macro/Macro_1.scala
+++ b/tests/run-macros/refined-selectable-macro/Macro_1.scala
@@ -15,7 +15,7 @@ object Macro {
   }
 
   private def toTupleImpl(s: Expr[Selectable])(using qctx:QuoteContext) : Expr[Tuple] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val repr = s.unseal.tpe.widenTermRefExpr.dealias
 
@@ -49,7 +49,7 @@ object Macro {
   }
 
   private def fromTupleImpl[T: Type](s: Expr[Tuple], newRecord: Expr[Array[(String, Any)] => T])(using qctx:QuoteContext) : Expr[Any] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val repr = s.unseal.tpe.widenTermRefExpr.dealias
 

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext): Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/reflect-lambda/assert_1.scala
+++ b/tests/run-macros/reflect-lambda/assert_1.scala
@@ -5,7 +5,7 @@ object lib {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     cond.unseal.underlyingArgument match {

--- a/tests/run-macros/reflect-pos-fun/assert_1.scala
+++ b/tests/run-macros/reflect-pos-fun/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition) }
 
   def assertImpl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     cond.unseal.underlyingArgument match {

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/reflect-select-copy-2/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy-2/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/reflect-select-copy/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     cond.unseal.underlyingArgument match {
       case Apply(select @ Select(lhs, op), rhs :: Nil) =>

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     import util._
 
     def isImplicitMethodType(tp: Type): Boolean = tp match

--- a/tests/run-macros/reflect-sourceCode/Macro_1.scala
+++ b/tests/run-macros/reflect-sourceCode/Macro_1.scala
@@ -5,7 +5,7 @@ object api {
     ${ reflImpl('x) }
 
   private def reflImpl[T](x: Expr[T])(implicit qctx: QuoteContext): Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(x.unseal.pos.sourceCode)
   }
 }

--- a/tests/run-macros/requiredSymbols/Macro_1.scala
+++ b/tests/run-macros/requiredSymbols/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 object Macro {
   inline def foo: String = ${ fooImpl }
   def fooImpl(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val list = List(
       Symbol.requiredPackage("java"),
       Symbol.requiredPackage("java.lang"),

--- a/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def inspect[T](x: T): Unit = ${ impl('x) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val tree = x.unseal
     '{
       println()

--- a/tests/run-macros/tasty-construct-types/Macro_1.scala
+++ b/tests/run-macros/tasty-construct-types/Macro_1.scala
@@ -12,7 +12,7 @@ object Macros {
   class TestAnnotation extends scala.annotation.Annotation
 
   def theTestBlockImpl(using qctx : QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val x1T = ConstantType(Constant.Int(1))
     val x2T = OrType(ConstantType(Constant.Int(1)), ConstantType(Constant.Int(2)))

--- a/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
+++ b/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def theTestBlock : Unit = ${ theTestBlockImpl }
 
   def theTestBlockImpl(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     // simple smoke test
     val sym1 : Symbol = Symbol.newMethod(

--- a/tests/run-macros/tasty-custom-show/quoted_1.scala
+++ b/tests/run-macros/tasty-custom-show/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val buff = new StringBuilder
 
@@ -37,10 +37,10 @@ object Macros {
     '{print(${Expr(buff.result())})}
   }
 
-  def dummyShow(using qctx: QuoteContext) : scala.tasty.reflect.Printer[qctx.tasty.type] = {
+  def dummyShow(using qctx: QuoteContext) : scala.tasty.reflect.Printer[qctx.reflect.type] = {
     new scala.tasty.reflect.Printer {
-      val tasty = qctx.tasty
-      import qctx.tasty._
+      val reflect = qctx.reflect
+      import qctx.reflect._
       def showTree(tree: Tree): String = "Tree"
       def showType(tpe: Type): String = "Type"
       def showConstant(const: Constant): String = "Constant"

--- a/tests/run-macros/tasty-dealias/quoted_1.scala
+++ b/tests/run-macros/tasty-dealias/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def dealias[T]: String = ${ impl('[T]) }
 
   def impl[T](x: quoted.Type[T])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(x.unseal.tpe.dealias.show)
   }
 }

--- a/tests/run-macros/tasty-definitions-1/quoted_1.scala
+++ b/tests/run-macros/tasty-definitions-1/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def testDefinitions(): Unit = ${testDefinitionsImpl}
 
   def testDefinitionsImpl(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val buff = List.newBuilder[String]
     def printout(x: => String): Unit = {

--- a/tests/run-macros/tasty-eval/quoted_1.scala
+++ b/tests/run-macros/tasty-eval/quoted_1.scala
@@ -17,7 +17,7 @@ object Macros {
 
   implicit def intIsEvalable: Valuable[Int] = new Valuable[Int] {
     override def value(e: Expr[Int])(using qctx: QuoteContext) : Option[Int] = {
-      import qctx.tasty._
+      import qctx.reflect._
 
       e.unseal.tpe match {
         case pre: TermRef if pre.termSymbol.isValDef =>

--- a/tests/run-macros/tasty-extractors-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-1/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val tree = x.unseal
     val treeStr = Expr(tree.showExtractors)

--- a/tests/run-macros/tasty-extractors-2/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-2/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val tree = x.unseal
 

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
     ${impl('x)}
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val buff = new StringBuilder
     val traverser = new TreeTraverser {

--- a/tests/run-macros/tasty-extractors-types/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-types/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   implicit inline def printType[T]: Unit = ${ impl('[T]) }
 
   def impl[T](x: Type[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val tree = x.unseal
     '{

--- a/tests/run-macros/tasty-getfile-implicit-by-name-fun-context/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile-implicit-by-name-fun-context/Macro_1.scala
@@ -8,6 +8,6 @@ object SourceFiles {
     ${getThisFileImpl}
 
   def getThisFileImpl: Macro[String] =
-    Expr(qctx.tasty.Source.path.getFileName.toString)
+    Expr(qctx.reflect.Source.path.getFileName.toString)
 
 }

--- a/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
@@ -10,7 +10,7 @@ object SourceFiles {
 
   def getThisFileImpl: Macro[String] = {
     val qctx = tastyContext
-    Expr(qctx.tasty.Source.path.getFileName.toString)
+    Expr(qctx.reflect.Source.path.getFileName.toString)
   }
 
 }

--- a/tests/run-macros/tasty-getfile/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile/Macro_1.scala
@@ -7,6 +7,6 @@ object SourceFiles {
     ${getThisFileImpl}
 
   private def getThisFileImpl(using qctx: QuoteContext) : Expr[String] =
-    Expr(qctx.tasty.Source.path.getFileName.toString)
+    Expr(qctx.reflect.Source.path.getFileName.toString)
 
 }

--- a/tests/run-macros/tasty-indexed-map/quoted_1.scala
+++ b/tests/run-macros/tasty-indexed-map/quoted_1.scala
@@ -25,7 +25,7 @@ object Index {
   implicit inline def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ${succImpl[K, H, T]}
 
   def succImpl[K, H, T](implicit qctx: QuoteContext, k: Type[K], h: Type[H], t: Type[T]): Expr[Index[K, (H, T)]] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     def name(tp: Type): String = tp match {
       case ConstantType(Constant.String(str)) => str

--- a/tests/run-macros/tasty-interpolation-1/Macro.scala
+++ b/tests/run-macros/tasty-interpolation-1/Macro.scala
@@ -55,7 +55,7 @@ abstract class MacroStringInterpolator[T] {
   protected def interpolate(strCtx: StringContext, argExprs: List[Expr[Any]]) (using QuoteContext): Expr[T]
 
   protected def getStaticStringContext(strCtxExpr: Expr[StringContext])(using qctx: QuoteContext) : StringContext = {
-    import qctx.tasty._
+    import qctx.reflect._
     strCtxExpr.unseal.underlyingArgument match {
       case Select(Typed(Apply(_, List(Apply(_, List(Typed(Repeated(strCtxArgTrees, _), Inferred()))))), _), _) =>
         val strCtxArgs = strCtxArgTrees.map {
@@ -69,7 +69,7 @@ abstract class MacroStringInterpolator[T] {
   }
 
   protected def getArgsList(argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : List[Expr[Any]] = {
-    import qctx.tasty._
+    import qctx.reflect._
     argsExpr.unseal.underlyingArgument match {
       case Typed(Repeated(args, _), _) => args.map(_.seal)
       case tree => throw new NotStaticlyKnownError("Expected statically known argument list", tree.seal)

--- a/tests/run-macros/tasty-linenumber-2/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber-2/quoted_1.scala
@@ -9,7 +9,7 @@ object LineNumber {
   implicit inline def line: LineNumber = ${lineImpl}
 
   def lineImpl(using QuoteContext) : Expr[LineNumber] = {
-    import qctx.tasty._
+    import qctx.reflect._
     '{new LineNumber(${Expr(rootPosition.startLine)})}
   }
 

--- a/tests/run-macros/tasty-linenumber/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber/quoted_1.scala
@@ -10,7 +10,7 @@ object LineNumber {
     ${lineImpl('[T])}
 
   def lineImpl(x: Type[Unit])(using QuoteContext) : Expr[LineNumber] = {
-    import qctx.tasty._
+    import qctx.reflect._
     '{new LineNumber(${Expr(rootPosition.startLine)})}
   }
 

--- a/tests/run-macros/tasty-location/quoted_1.scala
+++ b/tests/run-macros/tasty-location/quoted_1.scala
@@ -7,7 +7,7 @@ object Location {
   implicit inline def location: Location = ${impl}
 
   def impl(using qctx: QuoteContext) : Expr[Location] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     def listOwnerNames(sym: Symbol, acc: List[String]): List[String] =
       if (sym == defn.RootClass || sym == defn.EmptyPackageClass) acc

--- a/tests/run-macros/tasty-macro-assert/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-assert/quoted_1.scala
@@ -13,7 +13,7 @@ object Asserts {
     ${impl('cond)}
 
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val tree = cond.unseal
 

--- a/tests/run-macros/tasty-macro-const/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-const/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def natConst(x: Int): Int = ${ natConstImpl('x) }
 
   def natConstImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[Int] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val xTree: Term = x.unseal
     xTree match {
       case Inlined(_, _, Literal(Constant.Int(n))) =>

--- a/tests/run-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-positions/quoted_1.scala
@@ -9,7 +9,7 @@ object Macros {
   inline def fun3[T]: Unit = ${ impl2('[T]) }
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val pos = x.unseal.underlyingArgument.pos
     val code = x.unseal.underlyingArgument.show
     '{
@@ -19,7 +19,7 @@ object Macros {
   }
 
   def impl2[T](x: quoted.Type[T])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val pos = x.unseal.pos
     val code = x.unseal.show
     '{
@@ -28,9 +28,9 @@ object Macros {
     }
   }
 
-  def posStr(qctx: QuoteContext)(pos: qctx.tasty.Position): Expr[String] = {
+  def posStr(qctx: QuoteContext)(pos: qctx.reflect.Position): Expr[String] = {
     given QuoteContext = qctx
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(s"${pos.sourceFile.jpath.getFileName.toString}:[${pos.start}..${pos.end}]")
   }
 }

--- a/tests/run-macros/tasty-original-source/Macros_1.scala
+++ b/tests/run-macros/tasty-original-source/Macros_1.scala
@@ -5,7 +5,7 @@ object Macros {
   implicit inline def withSource(arg: Any): (String, Any) = ${ impl('arg) }
 
   private def impl(arg: Expr[Any])(using qctx: QuoteContext) : Expr[(String, Any)] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val source = Expr(arg.unseal.underlyingArgument.pos.sourceCode.toString)
     '{Tuple2($source, $arg)}
   }

--- a/tests/run-macros/tasty-positioned/quoted_1.scala
+++ b/tests/run-macros/tasty-positioned/quoted_1.scala
@@ -10,7 +10,7 @@ object Positioned {
   implicit inline def apply[T](x: => T): Positioned[T] = ${impl('x)}
 
   def impl[T](x: Expr[T])(implicit ev: Type[T], qctx: QuoteContext): Expr[Positioned[T]] = {
-    import qctx.tasty.{Position => _, _}
+    import qctx.reflect.{Position => _, _}
     val pos = rootPosition
 
     val path = Expr(pos.sourceFile.jpath.toString)

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -7,7 +7,7 @@ object Asserts {
 
   /** Replaces last argument list by 0s */
   def zeroLastArgsImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[Int] = {
-    import qctx.tasty._
+    import qctx.reflect._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
     x.unseal.underlyingArgument match {
       case Apply(fn, args) =>
@@ -29,7 +29,7 @@ object Asserts {
 
   /** Replaces all argument list by 0s */
   def zeroAllArgsImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[Int] = {
-    import qctx.tasty._
+    import qctx.reflect._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
     def rec(term: Term): Term = term match {
       case Apply(fn, args) =>

--- a/tests/run-macros/tasty-simplified/quoted_1.scala
+++ b/tests/run-macros/tasty-simplified/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
   inline def simplified[T <: Tuple]: Seq[String] = ${ impl[T] }
 
   def impl[T: Type](using qctx: QuoteContext) : Expr[Seq[String]] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     def unpackTuple(tp: Type): List[Type] = {
       @tailrec

--- a/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
+++ b/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
@@ -23,7 +23,7 @@ object Macro {
       case ('{ StringContext(${Varargs(parts)}: _*) }, Varargs(args)) =>
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
-            import qctx.tasty._
+            import qctx.reflect._
             Reporting.error(msg, parts(partIdx).unseal.pos)
           }
         }
@@ -37,7 +37,7 @@ object Macro {
         val errors = List.newBuilder[Expr[(Int, Int, Int, String)]]
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
-            import qctx.tasty._
+            import qctx.reflect._
             val pos = parts(partIdx).unseal.pos
             errors += '{ Tuple4(${Expr(partIdx)}, ${Expr(pos.start)}, ${Expr(pos.end)}, ${Expr(msg)}) }
           }

--- a/tests/run-macros/tasty-subtyping/quoted_1.scala
+++ b/tests/run-macros/tasty-subtyping/quoted_1.scala
@@ -9,13 +9,13 @@ object Macros {
     ${isSubTypeOfImpl('[T], '[U])}
 
   def isTypeEqualImpl[T, U](t: Type[T], u: Type[U])(using QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val isTypeEqual = t.unseal.tpe =:= u.unseal.tpe
     Expr(isTypeEqual)
   }
 
   def isSubTypeOfImpl[T, U](t: Type[T], u: Type[U])(using QuoteContext) : Expr[Boolean] = {
-    import qctx.tasty._
+    import qctx.reflect._
     val isTypeEqual = t.unseal.tpe <:< u.unseal.tpe
     Expr(isTypeEqual)
   }

--- a/tests/run-macros/tasty-tree-map/quoted_1.scala
+++ b/tests/run-macros/tasty-tree-map/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   implicit inline def identityMaped[T](x: => T): T = ${ impl('x) }
 
   def impl[T: Type](x: Expr[T])(using qctx: QuoteContext) : Expr[T] = {
-    import qctx.tasty.{_, given} // FIXME: #8919
+    import qctx.reflect.{_, given} // FIXME: #8919
     val identityMap = new TreeMap { }
     val transformed = identityMap.transformTerm(x.unseal).seal.cast[T]
     transformed

--- a/tests/run-macros/tasty-typeof/Macro_1.scala
+++ b/tests/run-macros/tasty-typeof/Macro_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def testTypeOf(): Unit = ${ testTypeOfImpl }
 
   private def testTypeOfImpl(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
     '{
       assert(${Expr(Type.of[Unit] =:= Type.of[Unit])}, "Unit")
       assert(${Expr(Type.of[Byte] =:= Type.of[Byte])}, "Byte")

--- a/tests/run-macros/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-macros/tasty-unsafe-let/quoted_1.scala
@@ -6,11 +6,11 @@ object Macros {
     ${ impl('rhs, 'body) }
 
   private def impl[T: Type](rhs: Expr[T], body: Expr[T => Unit])(using qctx: QuoteContext) : Expr[Unit] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     val rhsTerm = rhs.unseal
 
-    import qctx.tasty.{let => letTerm}
+    import qctx.reflect.{let => letTerm}
     letTerm(rhsTerm) { rhsId =>
       Expr.betaReduce('{$body(${rhsId.seal.asInstanceOf[Expr[T]]})}).unseal // Dangerous uncheked cast!
     }.seal.cast[Unit]

--- a/tests/run-macros/type-show/Macro_1.scala
+++ b/tests/run-macros/type-show/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 object TypeToolbox {
   inline def show[A]: String = ${ showImpl('[A]) }
   private def showImpl[A, B](a: Type[A])(using qctx: QuoteContext) : Expr[String] = {
-    import qctx.tasty._
+    import qctx.reflect._
     Expr(a.show)
   }
 }

--- a/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
@@ -13,7 +13,7 @@ object XmlQuote {
 
   def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])
           (using qctx: QuoteContext) : Expr[Xml] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     // for debugging purpose
     def pp(tree: Tree): Unit = {

--- a/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
@@ -14,7 +14,7 @@ object XmlQuote {
   implicit inline def SCOps(ctx: => StringContext): SCOps = new SCOps(ctx)
 
   def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[Xml] = {
-    import qctx.tasty._
+    import qctx.reflect._
 
     // for debugging purpose
     def pp(tree: Tree): Unit = {


### PR DESCRIPTION
Rename to give an intuitive name to access the AST based API and try to avoid confusion with the TASTy file format.
Keep `tasty` as a deprecated alias of `reflect`.