### PR TITLE
`: _*` is only valid when the parameter is repeated

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -9,6 +9,7 @@ import util.Stats.record
 import util.{SrcPos, NoSourcePosition, SourceFile}
 import Trees.Untyped
 import Contexts._
+import Phases._
 import Flags._
 import Symbols._
 import Denotations.Denotation
@@ -539,6 +540,8 @@ trait Applications extends Compatibility {
            *           in the remaining formal parameters.
            */
           def addTyped(arg: Arg, formal: Type): List[Type] =
+            if !ctx.isAfterTyper && isVarArg(arg) && !formal.isRepeatedParam then
+              fail(i"Sequence argument type annotation `: _*` cannot be used here: the corresponding parameter has type $formal which is not a repeated parameter type", arg)
             addArg(typedArg(arg, formal), formal)
             if methodType.isParamDependent && typeOfArg(arg).exists then
               // `typeOfArg(arg)` could be missing because the evaluation of `arg` produced type errors

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -407,7 +407,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
         wrapArray(arg1, arg0.tpe.elemType)
       case _ => arg0
     }
-    val argtpe = arg.tpe.dealiasKeepAnnots
+    val argtpe = arg.tpe.dealiasKeepAnnots.translateFromRepeated(toArray = false)
     val isByName = paramtp.dealias.isInstanceOf[ExprType]
     var inlineFlags: FlagSet = InlineProxy
     if (paramtp.widenExpr.hasAnnotation(defn.InlineParamAnnot)) inlineFlags |= Inline

--- a/tests/neg/i9749.scala
+++ b/tests/neg/i9749.scala
@@ -1,0 +1,7 @@
+class A {
+  def f(x: Any) = 1
+
+  def foo(x: List[String]): Unit = {
+    f(x: _*) // error
+  }
+}

--- a/tests/pos-java-interop/i9912/JavaLogger.java
+++ b/tests/pos-java-interop/i9912/JavaLogger.java
@@ -1,0 +1,5 @@
+public class JavaLogger {
+    public void info(String format, Object arg) {}
+
+    public void info(String in, Object... args){}
+}

--- a/tests/pos-java-interop/i9912/Test.scala
+++ b/tests/pos-java-interop/i9912/Test.scala
@@ -1,0 +1,9 @@
+class Test {
+  val logger = new JavaLogger
+  def log(): Unit = {
+      logger.info(
+        "My {} String {} with multiple args {}",
+        Array("a", "b", "c"): _*
+      )
+  }
+}

--- a/tests/pos/i9749.scala
+++ b/tests/pos/i9749.scala
@@ -1,0 +1,8 @@
+class A {
+  def f(x: Any) = 1
+  def f(x: String*) = 1
+
+  def foo(x: List[String]): Unit = {
+    f(x: _*)
+  }
+}

--- a/tests/pos/test-desugar.scala
+++ b/tests/pos/test-desugar.scala
@@ -76,7 +76,6 @@ object desugar {
     val pair: Int ~ String = 1 -> "abc"
     def foo(xs: Int*) = xs.length
     foo(list: _*)
-    println(list: _*)
     (list length)
     - desugar.x
     def bar(x: => Int) = x


### PR DESCRIPTION
Fixes #9749.
Fixes #9912.