### PR TITLE
Infrastructure to update tree fields in place

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -575,7 +575,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     def postProcess(tree: Tree, copied: untpd.MemberDef): copied.ThisTree[Type] =
       copied.withTypeUnchecked(tree.tpe)
 
-    protected val untpdCpy = untpd.cpy
+    protected val untpdCpy: untpd.TreeCopier = untpd.cpy
 
     override def Select(tree: Tree)(qualifier: Tree, name: Name)(using Context): Select = {
       val tree1 = untpdCpy.Select(tree)(qualifier, name)
@@ -759,7 +759,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       // Same remark as for Apply
 
     override def Closure(tree: Tree)(env: List[Tree], meth: Tree, tpt: Tree)(using Context): Closure =
-            ta.assignType(untpdCpy.Closure(tree)(env, meth, tpt), meth, tpt)
+      ta.assignType(untpdCpy.Closure(tree)(env, meth, tpt), meth, tpt)
 
     override def Closure(tree: Closure)(env: List[Tree] = tree.env, meth: Tree = tree.meth, tpt: Tree = tree.tpt)(using Context): Closure =
       Closure(tree: Tree)(env, meth, tpt)

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -653,87 +653,93 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     }
   }
 
-  object InPlaceCopier extends TreeCopier:
+  class InPlaceCopier(updated: util.HashSet[Tree])(using Context) extends TreeCopier:
     def postProcess(tree: Tree, copied: Tree): copied.ThisTree[Untyped] =
       copied.asInstanceOf[copied.ThisTree[Untyped]]
 
     def postProcess(tree: Tree, copied: MemberDef): copied.ThisTree[Untyped] =
       copied.asInstanceOf[copied.ThisTree[Untyped]]
 
+    private def done(tree: Tree) =
+      updated += tree
+      tree.envelope(tree.source)
+      //println(i"kEEP: $tree")
+      true
+
     override def keep(tree: Select)(qualifier: Tree): Boolean =
-      tree.update(qualifier); tree.setType(null); true
+      super.keep(tree)(qualifier) || { tree.update(qualifier); done(tree) }
     override def keep(tree: Super)(qual: Tree): Boolean =
-      tree.update(qual); tree.setType(null); true
+      super.keep(tree)(qual) || { tree.update(qual); done(tree) }
     override def keep(tree: Apply)(fun: Tree, args: List[Tree]): Boolean =
-      tree.update(fun, args); tree.setType(null); true
+      super.keep(tree)(fun, args) || { tree.update(fun, args); done(tree) }
     override def keep(tree: TypeApply)(fun: Tree, args: List[Tree]): Boolean =
-      tree.update(fun, args); tree.setType(null); true
+      super.keep(tree)(fun, args) || { tree.update(fun, args); done(tree) }
     override def keep(tree: New)(tpt: Tree): Boolean =
-      tree.update(tpt); tree.setType(null); true
+      super.keep(tree)(tpt) || { tree.update(tpt); done(tree) }
     override def keep(tree: Typed)(expr: Tree, tpt: Tree): Boolean =
-      tree.update(expr, tpt); tree.setType(null); true
+      super.keep(tree)(expr, tpt) || { tree.update(expr, tpt); done(tree) }
     override def keep(tree: NamedArg)(arg: Tree): Boolean =
-      tree.update(arg); tree.setType(null); true
+      super.keep(tree)(arg) || { tree.update(arg); done(tree) }
     override def keep(tree: Assign)(lhs: Tree, rhs: Tree): Boolean =
-      tree.update(lhs, rhs); tree.setType(null); true
+      super.keep(tree)(lhs, rhs) || { tree.update(lhs, rhs); done(tree) }
     override def keep(tree: Block)(stats: List[Tree], expr: Tree): Boolean =
-      tree.update(stats, expr); tree.setType(null); true
+      super.keep(tree)(stats, expr) || { tree.update(stats, expr); done(tree) }
     override def keep(tree: If)(cond: Tree, thenp: Tree, elsep: Tree): Boolean =
-      tree.update(cond, thenp, elsep); tree.setType(null); true
+      super.keep(tree)(cond, thenp, elsep) || { tree.update(cond, thenp, elsep); done(tree) }
     override def keep(tree: Closure)(env: List[Tree], meth: Tree, tpt: Tree): Boolean =
-      tree.update(env, meth, tpt); tree.setType(null); true
+      super.keep(tree)(env, meth, tpt) || { tree.update(env, meth, tpt); done(tree) }
     override def keep(tree: Match)(selector: Tree, cases: List[CaseDef]): Boolean =
-      tree.update(selector, cases); tree.setType(null); true
+      super.keep(tree)(selector, cases) || { tree.update(selector, cases); done(tree) }
     override def keep(tree: CaseDef)(pat: Tree, guard: Tree, body: Tree): Boolean =
-      tree.update(pat, guard, body); tree.setType(null); true
+      super.keep(tree)(pat, guard, body) || { tree.update(pat, guard, body); done(tree) }
     override def keep(tree: Labeled)(bind: Bind, expr: Tree): Boolean =
-      tree.update(bind, expr); tree.setType(null); true
+      super.keep(tree)(bind, expr) || { tree.update(bind, expr); done(tree) }
     override def keep(tree: Return)(expr: Tree, from: Tree): Boolean =
-      tree.update(expr, from); tree.setType(null); true
+      super.keep(tree)(expr, from) || { tree.update(expr, from); done(tree) }
     override def keep(tree: WhileDo)(cond: Tree, body: Tree): Boolean =
-      tree.update(cond, body); tree.setType(null); true
+      super.keep(tree)(cond, body) || { tree.update(cond, body); done(tree) }
     override def keep(tree: Try)(expr: Tree, cases: List[CaseDef], finalizer: Tree): Boolean =
-      tree.update(expr, cases, finalizer); tree.setType(null); true
+      super.keep(tree)(expr, cases, finalizer) || { tree.update(expr, cases, finalizer); done(tree) }
     override def keep(tree: SeqLiteral)(elems: List[Tree], elemtpt: Tree): Boolean =
-      tree.update(elems, elemtpt); tree.setType(null); true
+      super.keep(tree)(elems, elemtpt) || { tree.update(elems, elemtpt); done(tree) }
     override def keep(tree: Inlined)(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree): Boolean =
-      tree.update(call, bindings, expansion); tree.setType(null); true
+      super.keep(tree)(call, bindings, expansion) || { tree.update(call, bindings, expansion); done(tree) }
     override def keep(tree: SingletonTypeTree)(ref: Tree): Boolean =
-      tree.update(ref); tree.setType(null); true
+      super.keep(tree)(ref) || { tree.update(ref); done(tree) }
     override def keep(tree: RefinedTypeTree)(tpt: Tree, refinements: List[Tree]): Boolean =
-      tree.update(tpt, refinements); tree.setType(null); true
+      super.keep(tree)(tpt, refinements) || { tree.update(tpt, refinements); done(tree) }
     override def keep(tree: AppliedTypeTree)(tpt: Tree, args: List[Tree]): Boolean =
-      tree.update(tpt, args); tree.setType(null); true
+      super.keep(tree)(tpt, args) || { tree.update(tpt, args); done(tree) }
     override def keep(tree: LambdaTypeTree)(tparams: List[TypeDef], body: Tree): Boolean =
-      tree.update(tparams, body); tree.setType(null); true
+      super.keep(tree)(tparams, body) || { tree.update(tparams, body); done(tree) }
     override def keep(tree: TermLambdaTypeTree)(params: List[ValDef], body: Tree): Boolean =
-      tree.update(params, body); tree.setType(null); true
+      super.keep(tree)(params, body) || { tree.update(params, body); done(tree) }
     override def keep(tree: MatchTypeTree)(bound: Tree, selector: Tree, cases: List[CaseDef]): Boolean =
-      tree.update(bound, selector, cases); tree.setType(null); true
+      super.keep(tree)(bound, selector, cases) || { tree.update(bound, selector, cases); done(tree) }
     override def keep(tree: ByNameTypeTree)(result: Tree): Boolean =
-      tree.update(result); tree.setType(null); true
+      super.keep(tree)(result) || { tree.update(result); done(tree) }
     override def keep(tree: TypeBoundsTree)(lo: Tree, hi: Tree, alias: Tree): Boolean =
-      tree.update(lo, hi, alias); tree.setType(null); true
+      super.keep(tree)(lo, hi, alias) || { tree.update(lo, hi, alias); done(tree) }
     override def keep(tree: Bind)(body: Tree): Boolean =
-      tree.update(body); tree.setType(null); true
+      super.keep(tree)(body) || { tree.update(body); done(tree) }
     override def keep(tree: Alternative)(trees: List[Tree]): Boolean =
-      tree.update(trees); tree.setType(null); true
+      super.keep(tree)(trees) || { tree.update(trees); done(tree) }
     override def keep(tree: UnApply)(fun: Tree, implicits: List[Tree], patterns: List[Tree]): Boolean =
-      tree.update(fun, implicits, patterns); tree.setType(null); true
+      super.keep(tree)(fun, implicits, patterns) || { tree.update(fun, implicits, patterns); done(tree) }
     override def keep(tree: ValDef)(tpt: Tree, rhs: LazyTree): Boolean =
-      tree.update(tpt, rhs); tree.setType(null); true
+      super.keep(tree)(tpt, rhs) || { tree.update(tpt, rhs); done(tree) }
     override def keep(tree: DefDef)(tparams: List[TypeDef], vparamss: List[List[ValDef]], tpt: Tree, rhs: LazyTree): Boolean =
-      tree.update(tparams, vparamss, tpt, rhs); tree.setType(null); true
+      super.keep(tree)(tparams, vparamss, tpt, rhs) || { tree.update(tparams, vparamss, tpt, rhs); done(tree) }
     override def keep(tree: TypeDef)(rhs: Tree): Boolean =
-      tree.update(rhs); tree.setType(null); true
+      super.keep(tree)(rhs) || { tree.update(rhs); done(tree) }
     override def keep(tree: Template)(constr: DefDef, parents: List[Tree], derived: List[untpd.Tree], self: ValDef, body: LazyTreeList): Boolean =
-      tree.update(constr, parents ++ derived, self, body); tree.setType(null); true
+      super.keep(tree)(constr, parents, derived, self, body) || { tree.update(constr, parents ++ derived, self, body); done(tree) }
     override def keep(tree: Import)(expr: Tree, selectors: List[untpd.ImportSelector]): Boolean =
-      tree.update(expr, selectors); tree.setType(null); true
+      super.keep(tree)(expr, selectors) || { tree.update(expr, selectors); done(tree) }
     override def keep(tree: PackageDef)(pid: RefTree, stats: List[Tree]): Boolean =
-      tree.update(pid, stats); tree.setType(null); true
+      super.keep(tree)(pid, stats) || { tree.update(pid, stats); done(tree) }
     override def keep(tree: Annotated)(arg: Tree, annot: Tree): Boolean =
-      tree.update(arg, annot); tree.setType(null); true
+      super.keep(tree)(arg, annot) || { tree.update(arg, annot); done(tree) }
   end InPlaceCopier
 
   abstract class UntypedTreeMap(cpy: UntypedTreeCopier = untpd.cpy) extends TreeMap(cpy) {

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -653,6 +653,89 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     }
   }
 
+  object InPlaceCopier extends TreeCopier:
+    def postProcess(tree: Tree, copied: Tree): copied.ThisTree[Untyped] =
+      copied.asInstanceOf[copied.ThisTree[Untyped]]
+
+    def postProcess(tree: Tree, copied: MemberDef): copied.ThisTree[Untyped] =
+      copied.asInstanceOf[copied.ThisTree[Untyped]]
+
+    override def keep(tree: Select)(qualifier: Tree): Boolean =
+      tree.update(qualifier); tree.setType(null); true
+    override def keep(tree: Super)(qual: Tree): Boolean =
+      tree.update(qual); tree.setType(null); true
+    override def keep(tree: Apply)(fun: Tree, args: List[Tree]): Boolean =
+      tree.update(fun, args); tree.setType(null); true
+    override def keep(tree: TypeApply)(fun: Tree, args: List[Tree]): Boolean =
+      tree.update(fun, args); tree.setType(null); true
+    override def keep(tree: New)(tpt: Tree): Boolean =
+      tree.update(tpt); tree.setType(null); true
+    override def keep(tree: Typed)(expr: Tree, tpt: Tree): Boolean =
+      tree.update(expr, tpt); tree.setType(null); true
+    override def keep(tree: NamedArg)(arg: Tree): Boolean =
+      tree.update(arg); tree.setType(null); true
+    override def keep(tree: Assign)(lhs: Tree, rhs: Tree): Boolean =
+      tree.update(lhs, rhs); tree.setType(null); true
+    override def keep(tree: Block)(stats: List[Tree], expr: Tree): Boolean =
+      tree.update(stats, expr); tree.setType(null); true
+    override def keep(tree: If)(cond: Tree, thenp: Tree, elsep: Tree): Boolean =
+      tree.update(cond, thenp, elsep); tree.setType(null); true
+    override def keep(tree: Closure)(env: List[Tree], meth: Tree, tpt: Tree): Boolean =
+      tree.update(env, meth, tpt); tree.setType(null); true
+    override def keep(tree: Match)(selector: Tree, cases: List[CaseDef]): Boolean =
+      tree.update(selector, cases); tree.setType(null); true
+    override def keep(tree: CaseDef)(pat: Tree, guard: Tree, body: Tree): Boolean =
+      tree.update(pat, guard, body); tree.setType(null); true
+    override def keep(tree: Labeled)(bind: Bind, expr: Tree): Boolean =
+      tree.update(bind, expr); tree.setType(null); true
+    override def keep(tree: Return)(expr: Tree, from: Tree): Boolean =
+      tree.update(expr, from); tree.setType(null); true
+    override def keep(tree: WhileDo)(cond: Tree, body: Tree): Boolean =
+      tree.update(cond, body); tree.setType(null); true
+    override def keep(tree: Try)(expr: Tree, cases: List[CaseDef], finalizer: Tree): Boolean =
+      tree.update(expr, cases, finalizer); tree.setType(null); true
+    override def keep(tree: SeqLiteral)(elems: List[Tree], elemtpt: Tree): Boolean =
+      tree.update(elems, elemtpt); tree.setType(null); true
+    override def keep(tree: Inlined)(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree): Boolean =
+      tree.update(call, bindings, expansion); tree.setType(null); true
+    override def keep(tree: SingletonTypeTree)(ref: Tree): Boolean =
+      tree.update(ref); tree.setType(null); true
+    override def keep(tree: RefinedTypeTree)(tpt: Tree, refinements: List[Tree]): Boolean =
+      tree.update(tpt, refinements); tree.setType(null); true
+    override def keep(tree: AppliedTypeTree)(tpt: Tree, args: List[Tree]): Boolean =
+      tree.update(tpt, args); tree.setType(null); true
+    override def keep(tree: LambdaTypeTree)(tparams: List[TypeDef], body: Tree): Boolean =
+      tree.update(tparams, body); tree.setType(null); true
+    override def keep(tree: TermLambdaTypeTree)(params: List[ValDef], body: Tree): Boolean =
+      tree.update(params, body); tree.setType(null); true
+    override def keep(tree: MatchTypeTree)(bound: Tree, selector: Tree, cases: List[CaseDef]): Boolean =
+      tree.update(bound, selector, cases); tree.setType(null); true
+    override def keep(tree: ByNameTypeTree)(result: Tree): Boolean =
+      tree.update(result); tree.setType(null); true
+    override def keep(tree: TypeBoundsTree)(lo: Tree, hi: Tree, alias: Tree): Boolean =
+      tree.update(lo, hi, alias); tree.setType(null); true
+    override def keep(tree: Bind)(body: Tree): Boolean =
+      tree.update(body); tree.setType(null); true
+    override def keep(tree: Alternative)(trees: List[Tree]): Boolean =
+      tree.update(trees); tree.setType(null); true
+    override def keep(tree: UnApply)(fun: Tree, implicits: List[Tree], patterns: List[Tree]): Boolean =
+      tree.update(fun, implicits, patterns); tree.setType(null); true
+    override def keep(tree: ValDef)(tpt: Tree, rhs: LazyTree): Boolean =
+      tree.update(tpt, rhs); tree.setType(null); true
+    override def keep(tree: DefDef)(tparams: List[TypeDef], vparamss: List[List[ValDef]], tpt: Tree, rhs: LazyTree): Boolean =
+      tree.update(tparams, vparamss, tpt, rhs); tree.setType(null); true
+    override def keep(tree: TypeDef)(rhs: Tree): Boolean =
+      tree.update(rhs); tree.setType(null); true
+    override def keep(tree: Template)(constr: DefDef, parents: List[Tree], derived: List[untpd.Tree], self: ValDef, body: LazyTreeList): Boolean =
+      tree.update(constr, parents ++ derived, self, body); tree.setType(null); true
+    override def keep(tree: Import)(expr: Tree, selectors: List[untpd.ImportSelector]): Boolean =
+      tree.update(expr, selectors); tree.setType(null); true
+    override def keep(tree: PackageDef)(pid: RefTree, stats: List[Tree]): Boolean =
+      tree.update(pid, stats); tree.setType(null); true
+    override def keep(tree: Annotated)(arg: Tree, annot: Tree): Boolean =
+      tree.update(arg, annot); tree.setType(null); true
+  end InPlaceCopier
+
   abstract class UntypedTreeMap(cpy: UntypedTreeCopier = untpd.cpy) extends TreeMap(cpy) {
     override def transformMoreCases(tree: Tree)(using Context): Tree = tree match {
       case ModuleDef(name, impl) =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1247,7 +1247,7 @@ class TreeUnpickler(reader: TastyReader,
 
       val tree = if (tag < firstLengthTreeTag) readSimpleTerm() else readLengthTerm()
       if (!tree.isInstanceOf[TypTree]) // FIXME: Necessary to avoid self-type cyclic reference in tasty_tools
-        tree.overwriteType(tree.tpe.simplified)
+        tree.setType(tree.tpe.simplified)
       setSpan(start, tree)
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -226,7 +226,7 @@ object Applications {
    */
   class ExtMethodApply(app: Tree)(implicit @constructorOnly src: SourceFile)
   extends IntegratedTypeArgs(app) {
-    overwriteType(WildcardType)
+    setType(WildcardType)
       // ExtMethodApply always has wildcard type in order not to prompt any further adaptations
       // such as eta expansion before the method is fully applied.
   }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2536,7 +2536,7 @@ class Typer extends Namer
       if (!tree.tpe.widen.isInstanceOf[MethodOrPoly] // wait with simplifying until method is fully applied
           || tree.isDef) {                             // ... unless tree is a definition
         interpolateTypeVars(tree, pt, locked)
-        tree.overwriteType(tree.tpe.simplified)
+        tree.setType(tree.tpe.simplified)
       }
     tree
   }

--- a/tests/new/test.scala
+++ b/tests/new/test.scala
@@ -1,3 +1,9 @@
-trait T {
-  object O
-}
+    /*val x33: String => String = x22 => x22 match {
+      case "abc" => ""
+      case x34 => x34
+    }*/
+    val y: PartialFunction[String, String] = x => x match {
+      case "abc" => ""
+      case _ => x
+    }
+


### PR DESCRIPTION
The purpose of this PR is to avoid copying trees when transforming them in MiniPhases. Right now, we have to copy
a tree if any of its descendants has changed, recursively. That means we end up copying the whole path from the root
to a tree that has changed. Since lists of statements are represented linearly, such paths can have considerable length. 
E.g. a change that appears in the 10th statement of the 10th method of the top-level object that follows 10 imports has path length 34, even though it is conceptually only nested twice.

But it turns out doing this is really hard, and I am not sure there is a feasible solution yet. The problem is that in general 
our trees are really DAGs; they can contain shared nodes. So copy-in-place is conceptually wrong since accesses are not linear. 

The first way to fix this is to require trees to be proper trees without shared nodes. This can be checked in Ycheck. It requires fixes in many parts of the compiler, but conceptually they are not that hard to do. However, the problem are user-generated trees coming from inlined macro code. It seems too restrictive and fragile to demand that there's no sharing within or between inlined trees.

The alternative would be to embrace sharing and change our mini-phase framework to deal with it. But that's also very hard to do. One typical problem is in lambda lift, where we convert trees to point to proxies instead of original variables. LambdaLift has to deal with shared snippets, for instance ones generated in LazyVals. The snippets need to be substituted, mapping original references to proxy references. But the proxy references are different in different methods. The proxy reference itself is generated by lambdaLift's copier which is a regular copier. But the enclosing application nodes are copied by the in-place copier of MegaPhase, and that way we get mixed up. In the end, there is no alternative to traverse the original shared tree twice, which means we cannot overwrite it on the first traversal.

An alternative that remains to be explored would be to enforce tree-ness after inlining. But that's also not cheap. So it remains to be seen whether the wins are worth the complications.


