### PR TITLE
Fix #9972: Add missing span on implicit search failures

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -132,7 +132,7 @@ object ProtoTypes {
 
     // equals comes from case class; no need to redefine
   end IgnoredProto
-  
+
   final class CachedIgnoredProto(ignored: Type) extends IgnoredProto(ignored)
 
   object IgnoredProto:

--- a/tests/neg-macros/i9972/Macro_1.scala
+++ b/tests/neg-macros/i9972/Macro_1.scala
@@ -1,0 +1,7 @@
+package notmacro
+
+import scala.util.Not
+
+object Main extends App {
+  summon[Not[T[Int]]] // error
+}

--- a/tests/neg-macros/i9972/Test_2.scala
+++ b/tests/neg-macros/i9972/Test_2.scala
@@ -1,0 +1,12 @@
+package notmacro
+
+import scala.quoted._
+
+case class T[A <: AnyKind](s: String)
+
+object T {
+  implicit inline def derived[A <: AnyKind]: T[A] = ${ reprImpl[A] }
+
+  def reprImpl[A <: AnyKind](using t: Type[A])(using ctx: QuoteContext): Expr[T[A]] =
+    '{ T[A]("") }
+}

--- a/tests/neg-macros/i9972b/Macro_1.scala
+++ b/tests/neg-macros/i9972b/Macro_1.scala
@@ -1,0 +1,3 @@
+
+def test: Unit =
+  summon[scala.util.Not[T[Int]]] // error

--- a/tests/neg-macros/i9972b/Test_2.scala
+++ b/tests/neg-macros/i9972b/Test_2.scala
@@ -1,0 +1,5 @@
+
+class T[A]
+
+object T:
+  implicit inline def derived[A]: T[A] = new T[A]


### PR DESCRIPTION
These spans may be used by the an implicit search `scala.util.Not` and will propagate to other trees in the search.