### PR TITLE
Fix #9916: Round-trip through sourceModule in scalacLinkedClass

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
   community_build:
     runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
-
+    if: false
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,11 +167,6 @@ jobs:
   test_sbt:
     runs-on: [self-hosted, Linux]
     container: lampepfl/dotty:2020-04-24
-    if: (
-          github.event_name == 'push' &&
-          startsWith(github.event.ref, 'refs/tags/')
-        ) ||
-        github.event_name == 'schedule'
 
     steps:
       - name: Checkout cleanup script

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1176,7 +1176,7 @@ object SymDenotations {
 
     final def scalacLinkedClass(using Context): Symbol =
       if (this.is(ModuleClass)) companionNamed(effectiveName.toTypeName)
-      else if (this.isClass) companionNamed(effectiveName.moduleClassName)
+      else if (this.isClass) companionNamed(effectiveName.moduleClassName).sourceModule.moduleClass
       else NoSymbol
 
     /** Find companion class symbol with given name, or NoSymbol if none exists.

--- a/sbt-dotty/sbt-test/scala2-compat/finagle/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/finagle/build.sbt
@@ -1,0 +1,4 @@
+scalaVersion := sys.props("plugin.scalaVersion")
+
+libraryDependencies +=
+  ("com.twitter" %% "finagle-core" % "20.9.0").withDottyCompat(scalaVersion.value)

--- a/sbt-dotty/sbt-test/scala2-compat/finagle/i9916.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/finagle/i9916.scala
@@ -1,0 +1,10 @@
+import com.twitter.finagle.Stack
+import com.twitter.finagle.liveness.FailureAccrualFactory
+
+trait T {
+  def p: FailureAccrualFactory.Param
+}
+
+class A {
+  val t = Stack.Param[FailureAccrualFactory.Param](FailureAccrualFactory.Param(???))
+}

--- a/sbt-dotty/sbt-test/scala2-compat/finagle/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/finagle/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))

--- a/sbt-dotty/sbt-test/scala2-compat/finagle/test
+++ b/sbt-dotty/sbt-test/scala2-compat/finagle/test
@@ -1,0 +1,1 @@
+> compile

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/build.sbt
@@ -1,0 +1,14 @@
+val scala3Version = sys.props("plugin.scalaVersion")
+val scala2Version = "2.13.3"
+
+ThisBuild / organization := "test.dotty"
+ThisBuild / version := "0.1.0-SNAPSHOT"
+
+lazy val `i9916a-lib` = (project in file ("lib"))
+  .settings(scalaVersion := scala2Version)
+
+lazy val `i9916a-test` = (project in file ("main"))
+  .settings(
+    scalaVersion := scala3Version,
+    libraryDependencies += (organization.value %% "i9916a-lib" % version.value).withDottyCompat(scalaVersion.value)
+  )

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/build.sbt
@@ -1,14 +1,15 @@
 val scala3Version = sys.props("plugin.scalaVersion")
 val scala2Version = "2.13.3"
 
-ThisBuild / organization := "test.dotty"
-ThisBuild / version := "0.1.0-SNAPSHOT"
-
 lazy val `i9916a-lib` = (project in file ("lib"))
   .settings(scalaVersion := scala2Version)
 
 lazy val `i9916a-test` = (project in file ("main"))
+  .dependsOn(`i9916a-lib`)
   .settings(
     scalaVersion := scala3Version,
-    libraryDependencies += (organization.value %% "i9916a-lib" % version.value).withDottyCompat(scalaVersion.value)
+    // https://github.com/sbt/sbt/issues/5369
+    projectDependencies := {
+      projectDependencies.value.map(_.withDottyCompat(scalaVersion.value))
+    }
   )

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/lib/i9916a-lib.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/lib/i9916a-lib.scala
@@ -1,0 +1,7 @@
+package i9916a
+
+object Lib {
+  trait P
+  object P
+  def P(x: Int): P = ???
+}

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/main/i9916a-test.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/main/i9916a-test.scala
@@ -1,0 +1,5 @@
+import i9916a.Lib
+
+trait Test {
+  def foo: Lib.P
+}

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/test
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/test
@@ -1,2 +1,1 @@
-> i9916a-lib/publishLocal
 > i9916a-test/compile

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/test
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/test
@@ -1,0 +1,2 @@
+> i9916a-lib/publishLocal
+> i9916a-test/compile

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/build.sbt
@@ -1,0 +1,14 @@
+val scala3Version = sys.props("plugin.scalaVersion")
+val scala2Version = "2.13.3"
+
+ThisBuild / organization := "test.dotty"
+ThisBuild / version := "0.1.0-SNAPSHOT"
+
+lazy val `i9916b-lib` = (project in file ("lib"))
+  .settings(scalaVersion := scala2Version)
+
+lazy val `i9916b-test` = (project in file ("main"))
+  .settings(
+    scalaVersion := scala3Version,
+    libraryDependencies += (organization.value %% "i9916b-lib" % version.value).withDottyCompat(scalaVersion.value)
+  )

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/build.sbt
@@ -1,14 +1,15 @@
 val scala3Version = sys.props("plugin.scalaVersion")
 val scala2Version = "2.13.3"
 
-ThisBuild / organization := "test.dotty"
-ThisBuild / version := "0.1.0-SNAPSHOT"
-
 lazy val `i9916b-lib` = (project in file ("lib"))
   .settings(scalaVersion := scala2Version)
 
 lazy val `i9916b-test` = (project in file ("main"))
+  .dependsOn(`i9916b-lib`)
   .settings(
     scalaVersion := scala3Version,
-    libraryDependencies += (organization.value %% "i9916b-lib" % version.value).withDottyCompat(scalaVersion.value)
+    // https://github.com/sbt/sbt/issues/5369
+    projectDependencies := {
+      projectDependencies.value.map(_.withDottyCompat(scalaVersion.value))
+    }
   )

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/lib/i9916b-lib.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/lib/i9916b-lib.scala
@@ -1,0 +1,7 @@
+package i9916b
+
+trait T {
+  class A
+  object A
+  def A(x: Int): Unit = ???
+}

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/main/i9916b-test.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/main/i9916b-test.scala
@@ -1,0 +1,5 @@
+import i9916b.T
+
+trait Test {
+  def foo: T
+}

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/test
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/test
@@ -1,2 +1,1 @@
-> i9916b-lib/publishLocal
 > i9916b-test/compile

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/test
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/test
@@ -1,0 +1,2 @@
+> i9916b-lib/publishLocal
+> i9916b-test/compile


### PR DESCRIPTION
Commit e88c5b7 introduced the regression documented in #9916.

The commit message states:
```
The round-trip is useless, and causes issues with some
Scala2-emitted modules that do not have module classes (seems to be
related to modules inside traits).
```

Do we have some concrete examples / test cases where the round-trip causes issues, to motivate finding a solution other than reverting the commit?  [Edit: see comments below for examples]

/cc @sjrd

Fixes #9916 (but breaks the examples below)