### PR TITLE
Fix #9967: Don't add forwarders for super accessors

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -517,6 +517,8 @@ object Flags {
   val AccessorOrDeferred: FlagSet            = Accessor | Deferred
   val PrivateAccessor: FlagSet               = Accessor | Private
   val AccessorOrSynthetic: FlagSet           = Accessor | Synthetic
+  val JavaOrPrivateOrSynthetic: FlagSet      = Artifact | JavaDefined | Private | Synthetic
+  val PrivateOrSynthetic: FlagSet            = Artifact | Private | Synthetic
   val EnumCase: FlagSet                      = Case | Enum
   val CovariantLocal: FlagSet                = Covariant | Local                              // A covariant type parameter
   val ContravariantLocal: FlagSet            = Contravariant | Local                          // A contravariant type parameter
@@ -540,7 +542,6 @@ object Flags {
   val InlineByNameProxy: FlagSet             = InlineProxy | Method
   val JavaEnumTrait: FlagSet                 = JavaDefined | Enum                             // A Java enum trait
   val JavaEnumValue: FlagSet                 = JavaDefined | EnumValue                        // A Java enum value
-  val JavaOrPrivateOrSynthetic: FlagSet      = JavaDefined | Private | Synthetic
   val StaticProtected: FlagSet               = JavaDefined | JavaStatic | Protected           // Java symbol which is `protected` and `static`
   val JavaModule: FlagSet                    = JavaDefined | Module                           // A Java companion object
   val JavaInterface: FlagSet                 = JavaDefined | NoInits | Trait
@@ -561,7 +562,6 @@ object Flags {
   val ValidForeverFlags: FlagSet             = Package | Permanent | Scala2SpecialFlags
   val TermParamOrAccessor: FlagSet           = Param | ParamAccessor
   val PrivateParamAccessor: FlagSet          = ParamAccessor | Private
-  val PrivateOrSynthetic: FlagSet            = Private | Synthetic
   val PrivateOrArtifact: FlagSet             = Private | Artifact
   val ClassTypeParam: FlagSet                = Private | TypeParam
   val Scala2Trait: FlagSet                   = Scala2x | Trait

--- a/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
@@ -60,7 +60,7 @@ class ResolveSuper extends MiniPhase with IdentityDenotTransformer { thisPhase =
   override def transformDefDef(ddef: DefDef)(using Context): Tree = {
     val meth = ddef.symbol.asTerm
     if (meth.isSuperAccessor && !meth.is(Deferred)) {
-      assert(ddef.rhs.isEmpty)
+      assert(ddef.rhs.isEmpty, ddef.symbol)
       val cls = meth.owner.asClass
       val ops = new MixinOps(cls, thisPhase)
       import ops._

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1029,10 +1029,13 @@ class Namer { typer: Typer =>
 
         def addWildcardForwarders(seen: List[TermName], span: Span): Unit =
           for mbr <- path.tpe.membersBasedOnFlags(required = EmptyFlags, excluded = PrivateOrSynthetic) do
-            val alias = mbr.name.toTermName
-            if !seen.contains(alias)
-               && mbr.matchesImportBound(if mbr.symbol.is(Given) then givenBound else wildcardBound)
-            then addForwarder(alias, mbr, span)
+            if !mbr.symbol.isSuperAccessor then
+              // Scala 2 superaccessors have neither Synthetic nor Artfact set, so we
+              // need to filter them out here (by contrast, Scala 3 superaccessors are Artifacts)
+              val alias = mbr.name.toTermName
+              if !seen.contains(alias)
+                && mbr.matchesImportBound(if mbr.symbol.is(Given) then givenBound else wildcardBound)
+              then addForwarder(alias, mbr, span)
 
         def addForwarders(sels: List[untpd.ImportSelector], seen: List[TermName]): Unit = sels match
           case sel :: sels1 =>

--- a/tests/pos/i9967.scala
+++ b/tests/pos/i9967.scala
@@ -1,0 +1,6 @@
+import collection.mutable
+
+class MaxSizeMap[K, V](maxSize: Int)(using o: Ordering[K]):
+  val sortedMap: mutable.TreeMap[K, V] = mutable.TreeMap.empty[K, V](o)
+
+  export sortedMap._


### PR DESCRIPTION
Super accessors are flagged as Artifact in dotty, but not in nsc. So
We need to weed them out separately when creating export forwarders.