### PR TITLE
Disable named type arguments by default

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -60,6 +60,9 @@ object Feature:
   def dependentEnabled(using Context) =
     enabled(nme.dependent, defn.LanguageExperimentalModule.moduleClass)
 
+  def namedTypeArgsEnabled(using Context) =
+    enabled(nme.namedTypeArguments, defn.LanguageExperimentalModule.moduleClass)
+
   def scala2ExperimentalMacroEnabled(using Context) =
     enabled("macros".toTermName, defn.LanguageExperimentalModule.moduleClass)
 

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -528,6 +528,7 @@ object StdNames {
     val moduleClass : N         = "moduleClass"
     val name: N                 = "name"
     val nameDollar: N           = "$name"
+    val namedTypeArguments: N   = "namedTypeArguments"
     val ne: N                   = "ne"
     val newFreeTerm: N          = "newFreeTerm"
     val newFreeType: N          = "newFreeType"

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1057,6 +1057,11 @@ trait Applications extends Compatibility {
 
   def typedNamedArgs(args: List[untpd.Tree])(using Context): List[NamedArg] =
     for (arg @ NamedArg(id, argtpt) <- args) yield {
+      if !Feature.namedTypeArgsEnabled then
+        report.error(
+          i"""Named type arguments are experimental,
+             |they must be enabled with a `experimental.namedTypeArguments` language import or setting""",
+          arg.srcPos)
       val argtpt1 = typedType(argtpt)
       cpy.NamedArg(arg)(id, argtpt1).withType(argtpt1.tpe)
     }

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -161,7 +161,7 @@ SimpleType        ::=  SimpleLiteral                                            
 SimpleType1       ::=  id                                                       Ident(name)
                     |  Singleton ‘.’ id                                         Select(t, name)
                     |  Singleton ‘.’ ‘type’                                     SingletonTypeTree(p)
-                    |  ‘(’ Types ‘)’                                         Tuple(ts)
+                    |  ‘(’ Types ‘)’                                            Tuple(ts)
                     |  Refinement                                               RefinedTypeTree(EmptyTree, refinement)
                     |  ‘$’ ‘{’ Block ‘}’
                     |  SimpleType1 TypeArgs                                     AppliedTypeTree(t, args)

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -161,7 +161,7 @@ SimpleType        ::=  SimpleLiteral                                            
 SimpleType1       ::=  id                                                       Ident(name)
                     |  Singleton ‘.’ id                                         Select(t, name)
                     |  Singleton ‘.’ ‘type’                                     SingletonTypeTree(p)
-                    |  ‘(’ ArgTypes ‘)’                                         Tuple(ts)
+                    |  ‘(’ Types ‘)’                                         Tuple(ts)
                     |  Refinement                                               RefinedTypeTree(EmptyTree, refinement)
                     |  ‘$’ ‘{’ Block ‘}’
                     |  SimpleType1 TypeArgs                                     AppliedTypeTree(t, args)
@@ -170,16 +170,13 @@ Singleton         ::=  SimpleRef
                     |  SimpleLiteral
                     |  Singleton ‘.’ id
 -- not yet          |  Singleton ‘(’ Singletons ‘)’
--- not yet          |  Singleton ‘[’ ArgTypes ‘]’
+-- not yet          |  Singleton ‘[’ Types ‘]’
 Singletons        ::=  Singleton { ‘,’ Singleton }
-ArgTypes          ::=  Types
 FunArgType        ::=  Type
                     |  ‘=>’ Type                                                PrefixOp(=>, t)
 ParamType         ::=  [‘=>’] ParamValueType
 ParamValueType    ::=  Type [‘*’]                                               PostfixOp(t, "*")
-TypeArgs          ::=  ‘[’ ArgTypes ‘]’                                         ts
-NamedTypeArg      ::=  id ‘=’ Type                                              NamedArg(id, t)
-NamedTypeArgs     ::=  ‘[’ NamedTypeArg {‘,’ NamedTypeArg} ‘]’                  nts
+TypeArgs          ::=  ‘[’ Types ‘]’                                         ts
 Refinement        ::=  ‘{’ [RefineDcl] {semi [RefineDcl]} ‘}’                   ds
 TypeBounds        ::=  [‘>:’ Type] [‘<:’ Type]                                  TypeBoundsTree(lo, hi)
 TypeParamBounds   ::=  TypeBounds {‘:’ Type}                                    ContextBounds(typeBounds, tps)

--- a/library/src/scalaShadowing/language.scala
+++ b/library/src/scalaShadowing/language.scala
@@ -213,6 +213,9 @@ object language {
 
     /** Experimental support for richer dependent types */
     object dependent
+
+    /** Experimental support for named type arguments */
+    object namedTypeArguments
   }
 
   /** Where imported, a backwards compatibility mode for Scala2 is enabled */
@@ -241,9 +244,6 @@ object language {
    *  That's why the language import is required for them.
    */
   object adhocExtensions
-
-  /** Experimental support for richer dependent types */
-  object dependent
 
   /** Source version */
   object `3.0-migration`

--- a/tests/neg/i2771.scala
+++ b/tests/neg/i2771.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 trait A { type L[X] }
 trait B { type L }
 trait C { type M <: A }

--- a/tests/neg/i5328.scala
+++ b/tests/neg/i5328.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 class C[X, Y] { def apply[Z](x: X, y: Y, z: Z) = (x, y, z) }
 
 object Test {

--- a/tests/neg/namedTypeParams.scala
+++ b/tests/neg/namedTypeParams.scala
@@ -1,7 +1,12 @@
 class C[T]
 class D[type T] // error: identifier expected, but `type` found
 
+object Test0:
+  def f[X, Y](x: X, y: Y): Int = ???
+  f[X = Int, Y = Int](1, 2) // error: experimental // error: experimental
+
 object Test {
+  import language.experimental.namedTypeArguments
 
   val x: C[T = Int] = // error:  ']' expected, but `=` found // error
     new C[T = Int] // error:  ']' expected, but `=` found // error

--- a/tests/pos-custom-args/erased/i7868.scala
+++ b/tests/pos-custom-args/erased/i7868.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 import scala.compiletime._
 
 final case class Coproduct[+Set, +Value, Index <: Int](value: Value & Set, index: Index)

--- a/tests/pos/gadt-GadtStlc.scala
+++ b/tests/pos/gadt-GadtStlc.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 object GadtStlc {
   // creates type-level "strings" like M[M[M[W]]]
   object W

--- a/tests/pos/gadt-TypeSafeLambda.scala
+++ b/tests/pos/gadt-TypeSafeLambda.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 object TypeSafeLambda {
 
   trait Category[Arr[_, _]] {

--- a/tests/pos/i3666-gadt.scala
+++ b/tests/pos/i3666-gadt.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 object i3666 {
   sealed trait Exp[T]
   case class Num(n: Int) extends Exp[Int]

--- a/tests/pos/i3955.scala
+++ b/tests/pos/i3955.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 object Foo {
   inline def f[S, T](x: S): T = ???
   def g(x: Int) = f[T = Any](x)

--- a/tests/pos/i5328.scala
+++ b/tests/pos/i5328.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 class C[X, Y] { def apply[Z](x: X, y: Y, z: Z) = (x, y, z) }
 
 object Test {

--- a/tests/pos/kindPolySemiGroup.scala
+++ b/tests/pos/kindPolySemiGroup.scala
@@ -1,4 +1,5 @@
 // Adapted from github:mandubian/kind-polymorphic-semigroup.scala
+import language.experimental.namedTypeArguments
 sealed trait HList
 case class HCons[+HD, +TL](hd: HD, tl: TL) extends HList
 case object HNil extends HList

--- a/tests/pos/named-typeargs.scala
+++ b/tests/pos/named-typeargs.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 package namedTypeArgsR {
 
 object t1 {

--- a/tests/pos/namedTypeParams.scala
+++ b/tests/pos/namedTypeParams.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 object Test {
 
   def f[X, Y](x: X, y: Y): Int = ???

--- a/tests/pos/t1513a.scala
+++ b/tests/pos/t1513a.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 object Test {
   // Heterogeneous lists and natural numbers as defined in shapeless.
 

--- a/tests/pos/t1513b.scala
+++ b/tests/pos/t1513b.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 object Test {
   def f[
     T1 <: String,

--- a/tests/pos/typeclass-encoding3.scala
+++ b/tests/pos/typeclass-encoding3.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 object Test {
 
 /* --------------------------------------------------------------------------

--- a/tests/run-staging/staged-streams_1.scala
+++ b/tests/run-staging/staged-streams_1.scala
@@ -1,6 +1,8 @@
 import scala.quoted._
 import scala.quoted.staging._
 import scala.quoted.util._
+import language.experimental.namedTypeArguments
+
 /**
   * Port of the strymonas library as described in O. Kiselyov et al., Stream fusion, to completeness (POPL 2017)
   */

--- a/tests/run/creator-applys.scala
+++ b/tests/run/creator-applys.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 object Test extends App {
   class A {
     def run = "A"

--- a/tests/run/hmap-covariant.scala
+++ b/tests/run/hmap-covariant.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 trait Tuple
 case class TCons[+H, +T <: Tuple](h: H, t: T) extends Tuple
 case object TNil extends Tuple

--- a/tests/run/hmap.scala
+++ b/tests/run/hmap.scala
@@ -1,3 +1,5 @@
+import language.experimental.namedTypeArguments
+
 trait Tuple
 case class TCons[H, T <: Tuple](h: H, t: T) extends Tuple
 case object TNil extends Tuple

--- a/tests/run/polymorphic-functions.scala
+++ b/tests/run/polymorphic-functions.scala
@@ -1,3 +1,4 @@
+import language.experimental.namedTypeArguments
 object Test extends App {
   // Types
   type F0 = [T] => List[T] => Option[T]


### PR DESCRIPTION
Named type arguments are now available only under language import

    import scala.language.experimental.namedTypeArguments