### PR TITLE
Fix multiversal equality checks for pattern matching

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1594,7 +1594,9 @@ object Trees {
 
     def resolveConstructor(atp: Type, args: List[Tree])(using Context): tpd.Tree = {
       val targs = atp.argTypes
-      applyOverloaded(tpd.New(atp.typeConstructor), nme.CONSTRUCTOR, args, targs, atp)
+      withoutMode(Mode.PatternOrTypeBits) {
+        applyOverloaded(tpd.New(atp.typeConstructor), nme.CONSTRUCTOR, args, targs, atp)
+      }
     }
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3608,20 +3608,18 @@ class Typer extends Namer
    *  Overwritten to no-op in ReTyper.
    */
   protected def checkEqualityEvidence(tree: tpd.Tree, pt: Type)(using Context) : Unit =
-    tree match {
+    tree match
       case _: RefTree | _: Literal
-      if !isVarPattern(tree)
-         && !(pt <:< tree.tpe)
-         && !withMode(Mode.GadtConstraintInference) {
-              TypeComparer.constrainPatternType(tree.tpe, pt)
-            } =>
+      if !isVarPattern(tree) && !(pt <:< tree.tpe) =>
+        withMode(Mode.GadtConstraintInference) {
+          TypeComparer.constrainPatternType(tree.tpe, pt)
+        }
         val cmp =
           untpd.Apply(
             untpd.Select(untpd.TypedSplice(tree), nme.EQ),
             untpd.TypedSplice(dummyTreeOfType(pt)))
         typedExpr(cmp, defn.BooleanType)
       case _ =>
-    }
 
   private def checkStatementPurity(tree: tpd.Tree)(original: untpd.Tree, exprOwner: Symbol)(using Context): Unit =
     if !tree.tpe.isErroneous

--- a/tests/neg/eql.scala
+++ b/tests/neg/eql.scala
@@ -1,0 +1,25 @@
+object lst:
+  opaque type Lst[+T] = Any
+  object Lst:
+    given lstEql[T, U] as Eql[Lst[T], Lst[U]] = Eql.derived
+    val Empty: Lst[Nothing] = ???
+end lst
+
+import lst.Lst
+
+val xs: Lst[Int] = ???
+val ys: List[Int] = ???
+
+def test =
+  xs == ys                  // error: cannot be compared
+  ys == xs                  // error
+  xs == Nil                 // error
+  Nil == xs                 // error
+  ys == Lst.Empty           // error
+  Lst.Empty == ys           // error
+  xs match
+    case Nil => ???         // error, used to pass
+  ys match
+    case Lst.Empty => ???   // error, used to pass
+
+


### PR DESCRIPTION
Equality checks against constants in patterns were usually suppressed since they were only issued if
the GADT constrainer returned false. We now drop this as a condition.

This uncovered a missing position error, where we did a resolveOverloading when unpickling some
Scala 2 code in Pattern mode. The missing position was the tree in the equality check, which
is not surprising since was an annotation argument. The fix here was to make sure that we do
overloading resolution only in expression mode.