### PR TITLE
Run scala2-compat scripted tests during test_bootstrapped in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Test
         run: |
-          ./project/scripts/sbt ";dotty-bootstrapped/compile ;dotty-bootstrapped/test;sjsSandbox/run;sjsSandbox/test;sjsJUnitTests/test;sjsCompilerTests/test ;configureIDE"
+          ./project/scripts/sbt ";dotty-bootstrapped/compile ;dotty-bootstrapped/test;sjsSandbox/run;sjsSandbox/test;sjsJUnitTests/test;sjsCompilerTests/test ;sbt-dotty/scripted scala2-compat/* ;configureIDE"
           ./project/scripts/bootstrapCmdTests
 
 


### PR DESCRIPTION
This PR adds the Scala 2 compatibility/interop tests to the `test_bootstrapped` job in CI. The status quo is that these tests are only run during the nightly scheduled CI (as part of `test_sbt`). 

Adding the tests to the `test_bootstrapped` job means any regressions are noticed sooner, and CI configuration overrides should not be needed when fixing Scala 2 interop issues such as #9916.

The tests are currently implemented as `sbt` scripted tests, which have a high per-test startup overhead, but the number of tests is small so the overall impact on CI runtime should be minimal (1-2 minutes).

An alternative to #9990.