### PR TITLE
Only allow jar and tasty as input for -from-tasty

### DIFF
--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -90,9 +90,7 @@ class Driver {
       // Resolve classpath and class names of tasty files
       val (classPaths, classNames) = fileNames0.flatMap { name =>
         val path = Paths.get(name)
-        if !name.endsWith(".jar") && !name.endsWith(".tasty") then // is class name
-          ("", name) :: Nil // TODO remove this case. We cannot rely on an expected tasty file beeing loaded.
-        else if !Files.exists(path) then
+        if !Files.exists(path) then
           report.error(s"File does not exist: $name")
           Nil
         else if name.endsWith(".jar") then
@@ -100,13 +98,15 @@ class Driver {
             case e if e.getName.endsWith(".tasty") && !fromTastyIgnoreList(e.getName) =>
               (name, e.getName.stripSuffix(".tasty").replace("/", "."))
           }
-        else
-          assert(name.endsWith(".tasty"))
+        else if name.endsWith(".tasty") then
           TastyFileUtil.getClassName(path) match
             case Some(res) => res :: Nil
             case _ =>
               report.error(s"Could not load classname from: $name")
               Nil
+        else
+          report.error(s"File extension is not `tasty` or `jar`: $name")
+          Nil
       }.unzip
       val ctx1 = ctx0.fresh
       val classPaths1 = classPaths.distinct.filter(_ != "")

--- a/project/scripts/bootstrapCmdTests
+++ b/project/scripts/bootstrapCmdTests
@@ -34,7 +34,7 @@ clear_out "$OUT"
 # check that `scalac -from-tasty` compiles and `scala` runs it
 echo "testing ./bin/scalac -from-tasty and scala -classpath"
 clear_out "$OUT1"
-./bin/scalac -from-tasty -classpath "$OUT" -d "$OUT1" "$MAIN"
+./bin/scalac -from-tasty -d "$OUT1" "$OUT/$TASTY"
 ./bin/scala -classpath "$OUT1" "$MAIN" > "$tmp"
 test "$EXPECTED_OUTPUT" = "$(cat "$tmp")"
 

--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -10,7 +10,7 @@ grep -qe "$EXPECTED_OUTPUT" "$tmp"
 # check that `sbt scalac` compiles and `sbt scala` runs it
 echo "testing sbt scalac -from-tasty and scala -classpath"
 clear_out "$OUT"
-"$SBT" ";scalac $SOURCE -d $OUT ;scalac -from-tasty -classpath $OUT -d $OUT1 $MAIN ;scala -classpath $OUT1 $MAIN" > "$tmp"
+"$SBT" ";scalac $SOURCE -d $OUT ;scalac -from-tasty -d $OUT1 $OUT/$TASTY ;scala -classpath $OUT1 $MAIN" > "$tmp"
 grep -qe "$EXPECTED_OUTPUT" "$tmp"
 
 echo "testing sbt scalac -from-tasty from a jar and scala -classpath"
@@ -19,12 +19,8 @@ clear_out "$OUT"
 grep -qe "$EXPECTED_OUTPUT" "$tmp"
 
 # check that `sbt scalac -decompile` runs
-echo "testing sbt scalac -decompile"
-"$SBT" ";scalac -decompile -color:never -classpath $OUT $MAIN" > "$tmp"
-grep -qe "def main(args: scala.Array\[scala.Predef.String\]): scala.Unit =" "$tmp"
-
 echo "testing sbt scalac -decompile from file"
-"$SBT" ";scalac -decompile -color:never -classpath $OUT $OUT/$TASTY" > "$tmp"
+"$SBT" ";scalac -decompile -color:never $OUT/$TASTY" > "$tmp"
 grep -qe "def main(args: scala.Array\[scala.Predef.String\]): scala.Unit =" "$tmp"
 
 echo "testing sbt scala with no -classpath"
@@ -34,7 +30,7 @@ grep -qe "$EXPECTED_OUTPUT" "$tmp"
 
 echo "testing loading tasty from .tasty file in jar"
 clear_out "$OUT"
-"$SBT" ";scalac -d $OUT/out.jar $SOURCE; scalac -decompile -classpath $OUT/out.jar -color:never $MAIN" > "$tmp"
+"$SBT" ";scalac -d $OUT/out.jar $SOURCE; scalac -decompile -color:never $OUT/out.jar" > "$tmp"
 grep -qe "def main(args: scala.Array\[scala.Predef.String\]): scala.Unit =" "$tmp"
 
 echo "testing sbt scalac with suspension"


### PR DESCRIPTION
This ensures that we don't accidentally load other versions of the classes that are on the current classpath.

TastyInspector and all tests have already been updated in previous PRs.