### PR TITLE
Fix #9916: Properly unpickle non-toplevel Scala 2 objects

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -51,7 +51,7 @@ object NamerOps:
       completer.withSourceModule(findModuleBuddy(name.sourceModuleName, scope))
 
   /** Find moduleClass/sourceModule in effective scope */
-  private def findModuleBuddy(name: Name, scope: Scope)(using Context) = {
+  def findModuleBuddy(name: Name, scope: Scope)(using Context) = {
     val it = scope.lookupAll(name).filter(_.is(Module))
     if (it.hasNext) it.next()
     else NoSymbol.assertingErrorsReported(s"no companion $name in $scope")

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/build.sbt
@@ -1,0 +1,15 @@
+val scala3Version = sys.props("plugin.scalaVersion")
+val scala2Version = "2.13.3"
+
+lazy val `i9916a-lib` = (project in file ("lib"))
+  .settings(scalaVersion := scala2Version)
+
+lazy val `i9916a-test` = (project in file ("main"))
+  .dependsOn(`i9916a-lib`)
+  .settings(
+    scalaVersion := scala3Version,
+    // https://github.com/sbt/sbt/issues/5369
+    projectDependencies := {
+      projectDependencies.value.map(_.withDottyCompat(scalaVersion.value))
+    }
+  )

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/lib/i9916a-lib.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/lib/i9916a-lib.scala
@@ -1,0 +1,7 @@
+package i9916a
+
+object Lib {
+  trait P
+  object P
+  def P(x: Int): P = ???
+}

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/main/i9916a-test.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/main/i9916a-test.scala
@@ -1,0 +1,5 @@
+import i9916a.Lib
+
+trait Test {
+  def foo: Lib.P
+}

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/test
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/test
@@ -1,0 +1,1 @@
+> i9916a-test/compile

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/build.sbt
@@ -1,0 +1,15 @@
+val scala3Version = sys.props("plugin.scalaVersion")
+val scala2Version = "2.13.3"
+
+lazy val `i9916b-lib` = (project in file ("lib"))
+  .settings(scalaVersion := scala2Version)
+
+lazy val `i9916b-test` = (project in file ("main"))
+  .dependsOn(`i9916b-lib`)
+  .settings(
+    scalaVersion := scala3Version,
+    // https://github.com/sbt/sbt/issues/5369
+    projectDependencies := {
+      projectDependencies.value.map(_.withDottyCompat(scalaVersion.value))
+    }
+  )

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/lib/i9916b-lib.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/lib/i9916b-lib.scala
@@ -1,0 +1,7 @@
+package i9916b
+
+trait T {
+  class A
+  object A
+  def A(x: Int): Unit = ???
+}

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/main/i9916b-test.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/main/i9916b-test.scala
@@ -1,0 +1,5 @@
+import i9916b.T
+
+trait Test {
+  def foo: T
+}

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/test
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/test
@@ -1,0 +1,1 @@
+> i9916b-test/compile


### PR DESCRIPTION
Test cases from #9976.