### PR TITLE
Load tasty files directly in -from-tasty tests

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -740,10 +740,9 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   def sliceTopLevel(tree: Tree, cls: ClassSymbol)(using Context): List[Tree] = tree match {
     case PackageDef(pid, stats) =>
       val slicedStats = stats.flatMap(sliceTopLevel(_, cls))
-      if (!slicedStats.isEmpty)
-        cpy.PackageDef(tree)(pid, slicedStats) :: Nil
-      else
-        Nil
+      val isEffectivelyEmpty = slicedStats.forall(_.isInstanceOf[Import])
+      if isEffectivelyEmpty then Nil
+      else cpy.PackageDef(tree)(pid, slicedStats) :: Nil
     case tdef: TypeDef =>
       val sym = tdef.symbol
       assert(sym.isClass)

--- a/compiler/test/dotc/pos-from-tasty.blacklist
+++ b/compiler/test/dotc/pos-from-tasty.blacklist
@@ -16,3 +16,6 @@ notNull.scala
 
 # cyclic reference involving @uncheckedVariance
 annot-bootstrap.scala
+
+# missing position
+rbtree.scala

--- a/compiler/test/dotc/pos-from-tasty.blacklist
+++ b/compiler/test/dotc/pos-from-tasty.blacklist
@@ -1,21 +1,10 @@
-# has location not matching its contents: contains class mixins.Collections
-collections_1.scala
-
 # Infinite loop
 t3612.scala
 
-# Other failure
+# java.lang.AssertionError: assertion failed:
+# Found:    (File.this.parens0 : => Test.this.parens.BraceImpl)
+# Required: ((Test.this.parens : Test.this.ParensImpl) | (Test.this.bracks : Test.this.BracksImpl))#BraceImpl
 t802.scala
-
-# Matchtype
-i7087.scala
-
-# Nullability
-nullable.scala
-notNull.scala
-
-# cyclic reference involving @uncheckedVariance
-annot-bootstrap.scala
 
 # missing position
 rbtree.scala

--- a/compiler/test/dotc/run-from-tasty.blacklist
+++ b/compiler/test/dotc/run-from-tasty.blacklist
@@ -1,5 +1,0 @@
-# Closure type miss match
-eff-dependent.scala
-
-# We get: class Foo needs to be abstract, since implicit val x$1: TC is not defined
-i2567.scala

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -504,11 +504,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
       tastyOutput.mkdir()
       val flags = flags0 and ("-d", tastyOutput.getPath) and "-from-tasty"
 
-      def tastyFileToClassName(f: JFile): String = {
-        val pathStr = targetDir.toPath.relativize(f.toPath).toString.replace(JFile.separatorChar, '.')
-        pathStr.stripSuffix(".tasty").stripSuffix(".hasTasty")
-      }
-      val classes = flattenFiles(targetDir).filter(isTastyFile).map(tastyFileToClassName)
+      val classes = flattenFiles(targetDir).filter(isTastyFile).map(_.toString)
 
       val reporter =
         TestReporter.reporter(realStdout, logLevel =


### PR DESCRIPTION
* Load tasty files directly in -from-tasty tests
* Avoid pickling nested packages with only imports, which fix an unrelated bug discovered by the first change
