### PR TITLE
Improve error messages for -from-tasty compilation

### DIFF
--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -89,24 +89,23 @@ class Driver {
       // Resolve classpath and class names of tasty files
       val (classPaths, classNames) = fileNames0.flatMap { name =>
         val path = Paths.get(name)
-        if name.endsWith(".jar") then
+        if !name.endsWith(".jar") && !name.endsWith(".tasty") then // is class name
+          ("", name) :: Nil // TODO remove this case. We cannot rely on an expected tasty file beeing loaded.
+        else if !Files.exists(path) then
+          report.error(s"File does not exist: $name")
+          Nil
+        else if name.endsWith(".jar") then
           new dotty.tools.io.Jar(File(name)).toList.collect {
             case e if e.getName.endsWith(".tasty") =>
               (name, e.getName.stripSuffix(".tasty").replace("/", "."))
           }
-        else if (!name.endsWith(".tasty"))
-          ("", name) :: Nil
-        else if Files.exists(path) then
-          TastyFileUtil.getClassName(path) match {
-            case Some(res) => res:: Nil
+        else
+          assert(name.endsWith(".tasty"))
+          TastyFileUtil.getClassName(path) match
+            case Some(res) => res :: Nil
             case _ =>
               report.error(s"Could not load classname from: $name")
               Nil
-          }
-        else {
-          report.error(s"File does not exist: $name")
-          Nil
-        }
       }.unzip
       val ctx1 = ctx0.fresh
       val classPaths1 = classPaths.distinct.filter(_ != "")

--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -89,23 +89,23 @@ class Driver {
       // Resolve classpath and class names of tasty files
       val (classPaths, classNames) = fileNames0.flatMap { name =>
         val path = Paths.get(name)
-        if (name.endsWith(".jar"))
+        if name.endsWith(".jar") then
           new dotty.tools.io.Jar(File(name)).toList.collect {
             case e if e.getName.endsWith(".tasty") =>
               (name, e.getName.stripSuffix(".tasty").replace("/", "."))
           }
         else if (!name.endsWith(".tasty"))
           ("", name) :: Nil
-        else if (Files.exists(path))
+        else if Files.exists(path) then
           TastyFileUtil.getClassName(path) match {
             case Some(res) => res:: Nil
             case _ =>
-              report.error(s"Could not load classname from $name.")
-              ("", name) :: Nil
+              report.error(s"Could not load classname from: $name")
+              Nil
           }
         else {
-          report.error(s"File $name does not exist.")
-          ("", name) :: Nil
+          report.error(s"File does not exist: $name")
+          Nil
         }
       }.unzip
       val ctx1 = ctx0.fresh


### PR DESCRIPTION
There is no point trying to load the tasty file after we have emitted the error.
Loading it only end up in a second error that shadows the root of the problem.

Also improve readabllility of the error message.