### PR TITLE
Fix passing Seq or Array as a repeated argument when its type is union type

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -586,7 +586,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           val tree2: Select = tree.tpe match {
             case tpe: NamedType =>
               val qualType = qualifier.tpe.widenIfUnstable
-              if qualType.isNothingType then tree1.withTypeUnchecked(tree.tpe)
+              if qualType.isNothing then tree1.withTypeUnchecked(tree.tpe)
               else tree1.withType(tpe.derivedSelect(qualType))
             case _ => tree1.withTypeUnchecked(tree.tpe)
           }

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -586,7 +586,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           val tree2: Select = tree.tpe match {
             case tpe: NamedType =>
               val qualType = qualifier.tpe.widenIfUnstable
-              if qualType.isBottomType then tree1.withTypeUnchecked(tree.tpe)
+              if qualType.isNothingType then tree1.withTypeUnchecked(tree.tpe)
               else tree1.withType(tpe.derivedSelect(qualType))
             case _ => tree1.withTypeUnchecked(tree.tpe)
           }

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -406,7 +406,11 @@ class TypeApplications(val self: Type) extends AnyVal {
     case _ =>
       if (self.derivesFrom(from)) {
         def elemType(tp: Type): Type = tp.widenDealias match
-          case tp: AndOrType => tp.derivedAndOrType(elemType(tp.tp1), elemType(tp.tp2))
+          case tp: OrType =>
+            if defn.isBottomType(tp.tp1) then elemType(tp.tp2)
+            else if defn.isBottomType(tp.tp2) then elemType(tp.tp1)
+            else tp.derivedOrType(elemType(tp.tp1), elemType(tp.tp2))
+          case tp: AndType => tp.derivedAndType(elemType(tp.tp1), elemType(tp.tp2))
           case _ => tp.baseType(from).argInfos.headOption.getOrElse(defn.NothingType)
         val arg = elemType(self)
         val arg1 = if (wildcardArg) TypeBounds.upper(arg) else arg
@@ -499,6 +503,8 @@ class TypeApplications(val self: Type) extends AnyVal {
   def elemType(using Context): Type = self.widenDealias match {
     case defn.ArrayOf(elemtp) => elemtp
     case JavaArrayType(elemtp) => elemtp
+    case tp: OrType if defn.isBottomType(tp.tp1) => tp.tp2.elemType
+    case tp: OrType if defn.isBottomType(tp.tp2) => tp.tp1.elemType
     case _ => self.baseType(defn.SeqClass).argInfos.headOption.getOrElse(NoType)
   }
 }

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2325,7 +2325,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
    */
   def provablyEmpty(tp: Type): Boolean =
     tp.dealias match {
-      case tp if tp.isBottomType => true
+      case tp if tp.isNothingType => true
       case AndType(tp1, tp2) => provablyDisjoint(tp1, tp2)
       case OrType(tp1, tp2) => provablyEmpty(tp1) && provablyEmpty(tp2)
       case at @ AppliedType(tycon, args) =>

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2325,7 +2325,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
    */
   def provablyEmpty(tp: Type): Boolean =
     tp.dealias match {
-      case tp if tp.isNothingType => true
+      case tp if tp.isNothing => true
       case AndType(tp1, tp2) => provablyDisjoint(tp1, tp2)
       case OrType(tp1, tp2) => provablyEmpty(tp1) && provablyEmpty(tp2)
       case at @ AppliedType(tycon, args) =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -266,7 +266,7 @@ object Types {
       }
 
     /** Is this type exactly Nothing (no vars, aliases, refinements etc allowed)? */
-    def isNothingType(using Context): Boolean = this match {
+    def isNothing(using Context): Boolean = this match {
       case tp: TypeRef =>
         tp.name == tpnme.Nothing && (tp.symbol eq defn.NothingClass)
       case _ => false
@@ -2126,7 +2126,7 @@ object Types {
           case arg: TypeBounds =>
             val v = param.paramVarianceSign
             val pbounds = param.paramInfo
-            if (v > 0 && pbounds.loBound.dealiasKeepAnnots.isNothingType) TypeAlias(arg.hiBound & rebase(pbounds.hiBound))
+            if (v > 0 && pbounds.loBound.dealiasKeepAnnots.isNothing) TypeAlias(arg.hiBound & rebase(pbounds.hiBound))
             else if (v < 0 && pbounds.hiBound.dealiasKeepAnnots.isTopType) TypeAlias(arg.loBound | rebase(pbounds.loBound))
             else arg recoverable_& rebase(pbounds)
           case arg => TypeAlias(arg)
@@ -2289,7 +2289,7 @@ object Types {
           if (base.isAnd == variance >= 0) tp1 & tp2 else tp1 | tp2
         case _ =>
           if (pre.termSymbol.is(Package)) argForParam(pre.select(nme.PACKAGE))
-          else if (pre.isNothingType) pre
+          else if (pre.isNothing) pre
           else NoType
       }
     }
@@ -2308,7 +2308,7 @@ object Types {
      */
     def derivedSelect(prefix: Type)(using Context): Type =
       if (prefix eq this.prefix) this
-      else if (prefix.isNothingType) prefix
+      else if (prefix.isNothing) prefix
       else {
         if (isType) {
           val res =
@@ -4292,7 +4292,7 @@ object Types {
 
     /** For uninstantiated type variables: Is the lower bound different from Nothing? */
     def hasLowerBound(using Context): Boolean =
-      !ctx.typerState.constraint.entry(origin).loBound.isNothingType
+      !ctx.typerState.constraint.entry(origin).loBound.isNothing
 
     /** For uninstantiated type variables: Is the upper bound different from Any? */
     def hasUpperBound(using Context): Boolean =
@@ -5297,7 +5297,7 @@ object Types {
         case _ =>
           def propagate(lo: Type, hi: Type) =
             range(derivedRefinedType(tp, parent, lo), derivedRefinedType(tp, parent, hi))
-          if (parent.isNothingType) parent
+          if (parent.isNothing) parent
           else info match {
             case Range(infoLo: TypeBounds, infoHi: TypeBounds) =>
               assert(variance == 0)
@@ -5390,7 +5390,7 @@ object Types {
         case Range(lo, hi) =>
           range(tp.derivedAnnotatedType(lo, annot), tp.derivedAnnotatedType(hi, annot))
         case _ =>
-          if (underlying.isNothingType) underlying
+          if (underlying.isNothing) underlying
           else tp.derivedAnnotatedType(underlying, annot)
       }
     override protected def derivedWildcardType(tp: WildcardType, bounds: Type): WildcardType =
@@ -5638,7 +5638,7 @@ object Types {
       else {
         seen += tp
         tp match {
-          case tp if tp.isTopType || tp.isNothingType =>
+          case tp if tp.isTopType || tp.isNothing =>
             cs
           case tp: AppliedType =>
             foldOver(cs + tp.typeSymbol, tp)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -239,7 +239,11 @@ object Types {
         case tp: AndType =>
           loop(tp.tp1) || loop(tp.tp2)
         case tp: OrType =>
-          loop(tp.tp1) && loop(tp.tp2)
+          // If the type is `T | Null` or `T | Nothing`, and `T` derivesFrom the class,
+          // then the OrType derivesFrom the class. Otherwise, we need to check both sides
+          // derivesFrom the class.
+          if defn.isBottomType(tp.tp1) then loop(tp.tp2)
+          else loop(tp.tp1) && (defn.isBottomType(tp.tp2) || loop(tp.tp2))
         case tp: JavaArrayType =>
           cls == defn.ObjectClass
         case _ =>
@@ -262,7 +266,7 @@ object Types {
       }
 
     /** Is this type exactly Nothing (no vars, aliases, refinements etc allowed)? */
-    def isBottomType(using Context): Boolean = this match {
+    def isNothingType(using Context): Boolean = this match {
       case tp: TypeRef =>
         tp.name == tpnme.Nothing && (tp.symbol eq defn.NothingClass)
       case _ => false
@@ -2122,7 +2126,7 @@ object Types {
           case arg: TypeBounds =>
             val v = param.paramVarianceSign
             val pbounds = param.paramInfo
-            if (v > 0 && pbounds.loBound.dealiasKeepAnnots.isBottomType) TypeAlias(arg.hiBound & rebase(pbounds.hiBound))
+            if (v > 0 && pbounds.loBound.dealiasKeepAnnots.isNothingType) TypeAlias(arg.hiBound & rebase(pbounds.hiBound))
             else if (v < 0 && pbounds.hiBound.dealiasKeepAnnots.isTopType) TypeAlias(arg.loBound | rebase(pbounds.loBound))
             else arg recoverable_& rebase(pbounds)
           case arg => TypeAlias(arg)
@@ -2285,7 +2289,7 @@ object Types {
           if (base.isAnd == variance >= 0) tp1 & tp2 else tp1 | tp2
         case _ =>
           if (pre.termSymbol.is(Package)) argForParam(pre.select(nme.PACKAGE))
-          else if (pre.isBottomType) pre
+          else if (pre.isNothingType) pre
           else NoType
       }
     }
@@ -2304,7 +2308,7 @@ object Types {
      */
     def derivedSelect(prefix: Type)(using Context): Type =
       if (prefix eq this.prefix) this
-      else if (prefix.isBottomType) prefix
+      else if (prefix.isNothingType) prefix
       else {
         if (isType) {
           val res =
@@ -4288,7 +4292,7 @@ object Types {
 
     /** For uninstantiated type variables: Is the lower bound different from Nothing? */
     def hasLowerBound(using Context): Boolean =
-      !ctx.typerState.constraint.entry(origin).loBound.isBottomType
+      !ctx.typerState.constraint.entry(origin).loBound.isNothingType
 
     /** For uninstantiated type variables: Is the upper bound different from Any? */
     def hasUpperBound(using Context): Boolean =
@@ -5293,7 +5297,7 @@ object Types {
         case _ =>
           def propagate(lo: Type, hi: Type) =
             range(derivedRefinedType(tp, parent, lo), derivedRefinedType(tp, parent, hi))
-          if (parent.isBottomType) parent
+          if (parent.isNothingType) parent
           else info match {
             case Range(infoLo: TypeBounds, infoHi: TypeBounds) =>
               assert(variance == 0)
@@ -5386,7 +5390,7 @@ object Types {
         case Range(lo, hi) =>
           range(tp.derivedAnnotatedType(lo, annot), tp.derivedAnnotatedType(hi, annot))
         case _ =>
-          if (underlying.isBottomType) underlying
+          if (underlying.isNothingType) underlying
           else tp.derivedAnnotatedType(underlying, annot)
       }
     override protected def derivedWildcardType(tp: WildcardType, bounds: Type): WildcardType =
@@ -5634,7 +5638,7 @@ object Types {
       else {
         seen += tp
         tp match {
-          case tp if tp.isTopType || tp.isBottomType =>
+          case tp if tp.isTopType || tp.isNothingType =>
             cs
           case tp: AppliedType =>
             foldOver(cs + tp.typeSymbol, tp)

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -205,7 +205,7 @@ object Completion {
      * considered.
      */
     def addMemberCompletions(qual: Tree)(using Context): Unit =
-      if (!qual.tpe.widenDealias.isBottomType) {
+      if (!qual.tpe.widenDealias.isNothingType) {
         addAccessibleMembers(qual.tpe)
         if (!mode.is(Mode.Import) && !qual.tpe.isNullType)
           // Implicit conversions do not kick in when importing

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -205,7 +205,7 @@ object Completion {
      * considered.
      */
     def addMemberCompletions(qual: Tree)(using Context): Unit =
-      if (!qual.tpe.widenDealias.isNothingType) {
+      if (!qual.tpe.widenDealias.isNothing) {
         addAccessibleMembers(qual.tpe)
         if (!mode.is(Mode.Import) && !qual.tpe.isNullType)
           // Implicit conversions do not kick in when importing

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -171,10 +171,9 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
    *        of generic Java varargs in `elimRepeated`.
    */
   private def adaptToArray(tree: Tree, elemPt: Type)(implicit ctx: Context): Tree =
-    val treeTpe = tree.tpe.widenUnion
-    val elemTp = treeTpe.elemType
+    val elemTp = tree.tpe.elemType
     val elemTpMatches = elemTp <:< elemPt
-    val treeIsArray = treeTpe.derivesFrom(defn.ArrayClass)
+    val treeIsArray = tree.tpe.derivesFrom(defn.ArrayClass)
     if elemTpMatches && treeIsArray then
       tree // No adaptation necessary
     else tree match

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -171,9 +171,10 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
    *        of generic Java varargs in `elimRepeated`.
    */
   private def adaptToArray(tree: Tree, elemPt: Type)(implicit ctx: Context): Tree =
-    val elemTp = tree.tpe.elemType
+    val treeTpe = tree.tpe.widenUnion
+    val elemTp = treeTpe.elemType
     val elemTpMatches = elemTp <:< elemPt
-    val treeIsArray = tree.tpe.derivesFrom(defn.ArrayClass)
+    val treeIsArray = treeTpe.derivesFrom(defn.ArrayClass)
     if elemTpMatches && treeIsArray then
       tree // No adaptation necessary
     else tree match

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -169,7 +169,7 @@ object ErrorReporting {
            |Note that `${tree.name}` is treated as an infix operator in Scala 3.
            |If you do not want that, insert a `;` or empty line in front
            |or drop any spaces behind the operator."""
-      else if qualType.isBottomType then
+      else if qualType.isNothingType then
         ""
       else
         val add = suggestImports(

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -169,7 +169,7 @@ object ErrorReporting {
            |Note that `${tree.name}` is treated as an infix operator in Scala 3.
            |If you do not want that, insert a `;` or empty line in front
            |or drop any spaces behind the operator."""
-      else if qualType.isNothingType then
+      else if qualType.isNothing then
         ""
       else
         val add = suggestImports(

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -754,9 +754,8 @@ class Typer extends Namer
           else pt.translateFromRepeated(toArray = false, translateWildcard = true) |
                pt.translateFromRepeated(toArray = true,  translateWildcard = true)
         val expr1 = typedExpr(tree.expr, ptArg)
-        val exprTpeWiden = expr1.tpe.widenUnion
-        val fromCls = if exprTpeWiden.derivesFrom(defn.ArrayClass) then defn.ArrayClass else defn.SeqClass
-        val tpt1 = TypeTree(exprTpeWiden.translateToRepeated(fromCls)).withSpan(tree.tpt.span)
+        val fromCls = if expr1.tpe.derivesFrom(defn.ArrayClass) then defn.ArrayClass else defn.SeqClass
+        val tpt1 = TypeTree(expr1.tpe.widen.translateToRepeated(fromCls)).withSpan(tree.tpt.span)
         assignType(cpy.Typed(tree)(expr1, tpt1), tpt1)
       }
       cases(

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -753,10 +753,10 @@ class Typer extends Namer
           if (ctx.mode.is(Mode.QuotedPattern)) pt.translateFromRepeated(toArray = false, translateWildcard = true)
           else pt.translateFromRepeated(toArray = false, translateWildcard = true) |
                pt.translateFromRepeated(toArray = true,  translateWildcard = true)
-        val tpdExpr = typedExpr(tree.expr, ptArg)
         val expr1 = typedExpr(tree.expr, ptArg)
-        val fromCls = if expr1.tpe.derivesFrom(defn.ArrayClass) then defn.ArrayClass else defn.SeqClass
-        val tpt1 = TypeTree(expr1.tpe.widen.translateToRepeated(fromCls)).withSpan(tree.tpt.span)
+        val exprTpeWiden = expr1.tpe.widenUnion
+        val fromCls = if exprTpeWiden.derivesFrom(defn.ArrayClass) then defn.ArrayClass else defn.SeqClass
+        val tpt1 = TypeTree(exprTpeWiden.translateToRepeated(fromCls)).withSpan(tree.tpt.span)
         assignType(cpy.Typed(tree)(expr1, tpt1), tpt1)
       }
       cases(

--- a/tests/neg/repeatedArgs213.scala
+++ b/tests/neg/repeatedArgs213.scala
@@ -15,4 +15,16 @@ class repeatedArgs {
     Paths.get("Hello", ys: _*) // error: immutable.Seq expected, found Seq
     Paths.get("Hello", zs: _*)
   }
+
+  def test2(xs: immutable.Seq[String] | Null, ys: collection.Seq[String] | Null, zs: Array[String] | Null): Unit = {
+    bar("a", "b", "c")
+    bar(xs: _*)
+    bar(ys: _*) // error: immutable.Seq expected, found Seq
+    bar(zs: _*) // old-error: Remove (compiler generated) Array to Seq conversion in 2.13?
+
+    Paths.get("Hello", "World")
+    Paths.get("Hello", xs: _*)
+    Paths.get("Hello", ys: _*) // error: immutable.Seq expected, found Seq
+    Paths.get("Hello", zs: _*)
+  }
 }

--- a/tests/pos/repeatedArgs213.scala
+++ b/tests/pos/repeatedArgs213.scala
@@ -15,4 +15,15 @@ class repeatedArgs {
     val List(_, others: _*) = xs.toList // toList should not be needed, see #4790
     val x: immutable.Seq[String] = others
   }
+
+  def test2(xs: immutable.Seq[String] | Null): Unit = {
+    bar("a", "b", "c")
+    bar(xs: _*)
+
+    Paths.get("Hello", "World")
+    Paths.get("Hello", xs: _*)
+
+    val List(_, others: _*) = xs.toList // toList should not be needed, see #4790
+    val x: immutable.Seq[String] = others
+  }
 }


### PR DESCRIPTION
In the following example, the type of `s` is `Seq[String] | Null`, which is equivalent to `Seq[String]`. Hence, we should be allowed to pass it as a repeated argument.

```scala
import java.nio.file.Paths
def f = {
  val s: Seq[String] | Null = null
  Paths.get("", s: _*)
}
```

Without this fix, we will get a Type Mismatch Error:

```
Found:    Seq[String]
Required: String*
```