### PR TITLE
Remove deprecated docs and links to them (#1)

### DIFF
--- a/docs/_includes/features.html
+++ b/docs/_includes/features.html
@@ -21,7 +21,7 @@
                         <td>Implemented</td>
                     </tr>
                     <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/implicit-function-types.html">Context query</a></td>
+                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/context-functions.html">Context query</a></td>
                         <td>Implemented</td>
                     </tr>
                     <tr>
@@ -29,11 +29,11 @@
                         <td>Implemented</td>
                     </tr>
                     <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/delegates.html">Implied Instances</a></td>
+                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/givens.html">Implied Instances</a></td>
                         <td>Implemented</td>
                     </tr>
                     <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/given-clauses.html">Inferable parameters</a></td>
+                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/using-clauses.html">Inferable parameters</a></td>
                         <td>Implemented</td>
                     </tr>
                     <tr>

--- a/docs/docs/reference/contextual/delegates.md
+++ b/docs/docs/reference/contextual/delegates.md
@@ -1,6 +1,0 @@
----
-layout: doc-page
-title: "Given Instances"
----
-
-The contents of this page have [moved](./givens.md).

--- a/docs/docs/reference/contextual/given-clauses.md
+++ b/docs/docs/reference/contextual/given-clauses.md
@@ -1,7 +1,0 @@
----
-layout: doc-page
-title: "Given Parameters"
----
-
-The contents of this page have [moved](./using-clauses.md).
-

--- a/docs/docs/reference/contextual/implicit-function-types-spec.md
+++ b/docs/docs/reference/contextual/implicit-function-types-spec.md
@@ -1,7 +1,0 @@
----
-layout: doc-page
-title: "Implicit Function Types - More Details"
----
-
-The contents of this page have [moved](./context-functions-spec.md).
-

--- a/docs/docs/reference/contextual/implicit-function-types.md
+++ b/docs/docs/reference/contextual/implicit-function-types.md
@@ -1,6 +1,0 @@
----
-layout: doc-page
-title: "Implicit Function Types"
----
-
-The contents of this page have [moved](./context-functions.md).

--- a/docs/docs/reference/features-classification.md
+++ b/docs/docs/reference/features-classification.md
@@ -20,7 +20,7 @@ These new constructs directly model core features of DOT, higher-kinded types, a
  - [Union types](new-types/union-types.md),
  - [Type lambdas](new-types/type-lambdas.md),
  replacing encodings using structural types and type projection.
- - [Implicit Function Types](contextual/implicit-function-types.md) offering abstraction over given parameters.
+ - [Context Functions](contextual/context-functions.md) offering abstraction over given parameters.
 
 **Status: essential**
 


### PR DESCRIPTION
* Use new links 

Right now, there are multiple features with links that just say "The contents of this page have moved." It'd be more convenient if the links directly went to the updated pages.

* Delete implicit-function-types-spec.md

* Delete implicit-function-types.md

* Delete delegates.md

* Delete given-clauses.md

* Update features-classification.md