### PR TITLE
.jvmopts: Remove MaxMetaspaceSize setting

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,4 +3,3 @@
 -Xmx4096m
 -XX:MaxInlineLevel=35
 -XX:ReservedCodeCacheSize=512m
--XX:MaxMetaspaceSize=1024m

--- a/project/scripts/sbt
+++ b/project/scripts/sbt
@@ -9,7 +9,6 @@ CMD="${1:?Missing sbt command}"
 # run sbt with the supplied arg
 sbt -J-Xmx4096m \
     -J-XX:ReservedCodeCacheSize=512m \
-    -J-XX:MaxMetaspaceSize=1024m \
     -DSBT_PGP_USE_GPG=false \
     -no-colors \
     "$CMD"


### PR DESCRIPTION
The default on Java >= 8 is infinite metaspace, by introducing an
arbitrary limit we risk running out of metaspace (this might explain
some weird recent CI failures).