### PR TITLE
Fix latest-nightly-base file

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -397,7 +397,7 @@ object Build {
 
       // Make majorVersion available at dotty.epfl.ch/versions/latest-nightly-base
       // Used by sbt-dotty to resolve the latest nightly
-      val majorVersion = baseVersion.take(baseVersion.lastIndexOf('.'))
+      val majorVersion = (scalaBinaryVersion in LocalProject("scala3-library-bootstrapped")).value
       IO.write(file("./docs/_site/versions/latest-nightly-base"), majorVersion)
 
       // This file is used by GitHub Pages when the page is available in a custom domain


### PR DESCRIPTION
I misdiagnosed the problem in
https://github.com/lampepfl/dotty/pull/10021: the problem isn't that
there is no nightly for 3.0, it's that
https://dotty.epfl.ch/versions/latest-nightly-base which is used by
dottyLatestNightlyBuild contains "3.0" instead of "3.0.0-M1", this
commit fixes this.