### PR TITLE
fix #9324: forbid no-arg java.lang.Enum ctor

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -167,7 +167,8 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     ModifierNotAllowedForDefinitionID,
     CannotExtendJavaEnumID,
     InvalidReferenceInImplicitNotFoundAnnotationID,
-    TraitMayNotDefineNativeMethodID
+    TraitMayNotDefineNativeMethodID,
+    JavaEnumParentArgsID
 
   def errorNumber = ordinal - 2
 }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1528,6 +1528,12 @@ import transform.SymUtils._
       def explain = ""
     }
 
+  class JavaEnumParentArgs(parent: Type)(using Context)
+    extends TypeMsg(JavaEnumParentArgsID) {
+      def msg = em"""not enough arguments for constructor Enum: ${hl("(name: String, ordinal: Int)")}: ${hl(parent.show)}"""
+      def explain = ""
+    }
+
   class CannotHaveSameNameAs(sym: Symbol, cls: Symbol, reason: CannotHaveSameNameAs.Reason)(using Context)
     extends SyntaxMsg(CannotHaveSameNameAsID) {
     import CannotHaveSameNameAs._

--- a/tests/neg/extend-java-enum-migration.check
+++ b/tests/neg/extend-java-enum-migration.check
@@ -10,3 +10,7 @@
 14 |class Sub extends T // error
    |      ^
    |      not enough arguments for constructor Enum: (name: String, ordinal: Int): Enum[T]
+-- [E160] Type Error: tests/neg/extend-java-enum-migration.scala:17:10 -------------------------------------------------
+17 |val foo = new java.lang.Enum[Color] {} // error
+   |          ^
+   |          not enough arguments for constructor Enum: (name: String, ordinal: Int): Enum[Color]

--- a/tests/neg/extend-java-enum-migration.check
+++ b/tests/neg/extend-java-enum-migration.check
@@ -1,0 +1,12 @@
+-- [E160] Type Error: tests/neg/extend-java-enum-migration.scala:9:12 --------------------------------------------------
+9 |final class C extends jl.Enum[C] // error
+  |            ^
+  |            not enough arguments for constructor Enum: (name: String, ordinal: Int): Enum[C]
+-- [E160] Type Error: tests/neg/extend-java-enum-migration.scala:11:7 --------------------------------------------------
+11 |object O extends jl.Enum[O.type] // error
+   |       ^
+   |       not enough arguments for constructor Enum: (name: String, ordinal: Int): Enum[O.type]
+-- [E160] Type Error: tests/neg/extend-java-enum-migration.scala:14:6 --------------------------------------------------
+14 |class Sub extends T // error
+   |      ^
+   |      not enough arguments for constructor Enum: (name: String, ordinal: Int): Enum[T]

--- a/tests/neg/extend-java-enum-migration.scala
+++ b/tests/neg/extend-java-enum-migration.scala
@@ -1,0 +1,14 @@
+import java.{lang => jl}
+
+import language.`3.0-migration`
+
+// This file is different from `tests/neg/extend-java-enum.scala` as we
+// are testing that it is illegal to *not* pass arguments to jl.Enum
+// in 3.0-migration
+
+final class C extends jl.Enum[C] // error
+
+object O extends jl.Enum[O.type] // error
+
+trait T extends jl.Enum[T] // ok
+class Sub extends T // error

--- a/tests/neg/extend-java-enum-migration.scala
+++ b/tests/neg/extend-java-enum-migration.scala
@@ -12,3 +12,6 @@ object O extends jl.Enum[O.type] // error
 
 trait T extends jl.Enum[T] // ok
 class Sub extends T // error
+
+abstract class Color(name: String, ordinal: Int) extends java.lang.Enum[Color](name, ordinal) // ok
+val foo = new java.lang.Enum[Color] {} // error


### PR DESCRIPTION
pretend the no-arg constructor does not exist unless called from an enum parent