### PR TITLE
Fix dottyLatestNightlyBuild following scala3 renaming

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -56,14 +56,14 @@ object Build {
   val referenceVersion = "0.27.0-RC1"
 
   val baseVersion = "3.0.0-M1"
-  val baseSbtDottyVersion = "0.4.3"
+  val baseSbtDottyVersion = "0.4.4"
 
   // Versions used by the vscode extension to create a new project
   // This should be the latest published releases.
   // TODO: Have the vscode extension fetch these numbers from the Internet
   // instead of hardcoding them ?
   val publishedDottyVersion = referenceVersion
-  val publishedSbtDottyVersion = "0.4.2"
+  val publishedSbtDottyVersion = "0.4.3"
 
   /** scala-library version required to compile Dotty.
    *

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -49,7 +49,7 @@ object DottyPlugin extends AutoPlugin {
             else fetchSource(s"$major.${minor.toInt - 1}")
           }
         val (source1, majorVersion) = fetchSource(majorVersionFromWebsite)
-        val Version = s"      <version>($majorVersion\\..*-bin.*)</version>".r
+        val Version = s"      <version>($majorVersion.*-bin.*)</version>".r
         val nightly = source1
           .getLines()
           .collect { case Version(version) => version }


### PR DESCRIPTION
The regexp was too specific.

Also restore the shapeless build before its use of
dottyLatestNightlyBuild was disabled in
https://github.com/lampepfl/dotty/pull/10021