### PR TITLE
Partition community build for faster CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
         run: sbt ";sjsJUnitTests/test ;sjsCompilerTests/test"
         shell: cmd
 
-  community_build:
+  community_build_a:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-09-08
@@ -133,7 +133,35 @@ jobs:
         run: |
           git submodule sync
           git submodule update --init --recursive --jobs 7
-          ./project/scripts/sbt community-build/test
+          ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestA"
+
+  community_build_b:
+    runs-on: [self-hosted, Linux]
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
+
+    steps:
+      - name: Checkout cleanup script
+        uses: actions/checkout@v2
+
+      - name: Cleanup
+        run: .github/workflows/cleanup.sh
+
+      - name: Git Checkout
+        uses: actions/checkout@v2
+
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
+
+      - name: Test
+        run: |
+          git submodule sync
+          git submodule update --init --recursive --jobs 7
+          ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestB"
 
   test_sbt:
     runs-on: [self-hosted, Linux]
@@ -208,7 +236,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
-    needs: [test, test_bootstrapped, community_build, test_sbt, test_java8]
+    needs: [test, test_bootstrapped, community_build_a, community_build_b, test_sbt, test_java8]
     if: github.event_name == 'schedule'
     env:
       NIGHTLYBUILD: yes
@@ -283,7 +311,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
-    needs: [test, test_bootstrapped, community_build, test_sbt, test_java8]
+    needs: [test, test_bootstrapped, community_build_a, community_build_b, test_sbt, test_java8]
     if: github.event_name == 'push' &&
         startsWith(github.event.ref, 'refs/tags/') &&
         !startsWith(github.event.ref, 'refs/tags/sbt-dotty-')
@@ -409,7 +437,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
-    needs: [community_build, test_sbt]
+    needs: [community_build_a, community_build_b, test_sbt]
     if: github.event_name == 'push' &&
         startsWith(github.event.ref, 'refs/tags/sbt-dotty-')
 

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -7,8 +7,7 @@ import org.junit.{Ignore, Test}
 import org.junit.Assert.{assertEquals, fail}
 import org.junit.experimental.categories.Category
 
-@Category(Array(classOf[TestCategory]))
-class CommunityBuildTest:
+abstract class CommunityBuildTest:
   given CommunityBuildTest = this
 
   /** Depending on the mode of operation, either
@@ -79,7 +78,30 @@ class CommunityBuildTest:
           |""".stripMargin)
     }
   }
+end CommunityBuildTest
 
+@Category(Array(classOf[TestCategory]))
+class CommunityBuildTestA extends CommunityBuildTest:
+  @Test def fansi = projects.fansi.run()
+  @Test def fastparse = projects.fastparse.run()
+  @Test def geny = projects.geny.run()
+  @Test def oslib = projects.oslib.run()
+  // @Test def oslibWatch = projects.oslibWatch.run()
+  @Test def pprint = projects.pprint.run()
+  @Test def requests = projects.requests.run()
+  @Test def scalacheck = projects.scalacheck.run()
+  @Test def scalatest = projects.scalatest.run()
+  @Test def scalatestplusScalacheck = projects.scalatestplusScalacheck.run()
+  @Test def sourcecode = projects.sourcecode.run()
+  @Test def scodec = projects.scodec.run()
+  @Test def scodecBits = projects.scodecBits.run()
+  @Test def ujson = projects.ujson.run()
+  @Test def upickle = projects.upickle.run()
+  @Test def utest = projects.utest.run()
+end CommunityBuildTestA
+
+@Category(Array(classOf[TestCategory]))
+class CommunityBuildTestB extends CommunityBuildTest:
   @Test def algebra = projects.algebra.run()
   @Test def betterfiles = projects.betterfiles.run()
   @Test def catsEffect2 = projects.catsEffect2.run()
@@ -88,38 +110,22 @@ class CommunityBuildTest:
   // @Test def dottyCpsAsync = projects.dottyCpsAsync.run()
   @Test def effpi = projects.effpi.run()
   @Test def endpoints4s = projects.endpoints4s.run()
-  @Test def fansi = projects.fansi.run()
-  @Test def fastparse = projects.fastparse.run()
-  @Test def geny = projects.geny.run()
   @Test def intent = projects.intent.run()
   @Test def minitest = projects.minitest.run()
   @Test def munit = projects.munit.run()
-  @Test def oslib = projects.oslib.run()
-  // @Test def oslibWatch = projects.oslibWatch.run()
-  @Test def pprint = projects.pprint.run()
-  @Test def requests = projects.requests.run()
-  @Test def scalacheck = projects.scalacheck.run()
   @Test def scalap = projects.scalap.run()
   @Test def scalaParserCombinators = projects.scalaParserCombinators.run()
   @Test def ScalaPB = projects.ScalaPB.run()
-  @Test def scalatest = projects.scalatest.run()
-  @Test def scalatestplusScalacheck = projects.scalatestplusScalacheck.run()
   @Test def scalaXml = projects.scalaXml.run()
   @Test def scalaz = projects.scalaz.run()
   @Test def scas = projects.scas.run()
-  @Test def scodec = projects.scodec.run()
-  @Test def scodecBits = projects.scodecBits.run()
   @Test def sconfig = projects.sconfig.run()
   @Test def scopt = projects.scopt.run()
   @Test def shapeless = projects.shapeless.run()
-  @Test def sourcecode = projects.sourcecode.run()
   @Test def squants = projects.squants.run()
   @Test def stdLib213 = projects.stdLib213.run()
-  @Test def ujson = projects.ujson.run()
-  @Test def upickle = projects.upickle.run()
-  @Test def utest = projects.utest.run()
   @Test def xmlInterpolator = projects.xmlInterpolator.run()
   @Test def zio = projects.zio.run()
-end CommunityBuildTest
+end CommunityBuildTestB
 
 class TestCategory


### PR DESCRIPTION
Partition member selection is driven by the goal to minimize the running time of the longest running partition.

If this gets merged, the required status checks for pull requests will need updating, as the job named `community_build` will no longer exist.

**Results of some test runs**:

The projects in the community build can be partitioned nicely such that the testing of each partition has approximately the same running time (23-27 minutes).  Moving some short running projects between the two partitions is mostly a noise-level change.

The real issue that is preventing big wins here is the wide variance in the running time of the GitHub `actions/cache@v1.1.2` steps (e.g. `Cache Ivy`, `Cache SBT`, etc.) that are embedded in each job.  These steps can run for as little as a few seconds to 20 minutes or more, and their running time seems to be unpredictable.  This issue is not particular to this PR and I have noticed it happening on other PRs and merges. Occasionally these long running cache restoration steps will display a warning/error message such as:

```
gzip: stdin: unexpected end of file
/usr/bin/tar: Unexpected EOF in archive
/usr/bin/tar: Unexpected EOF in archive
/usr/bin/tar: Error is not recoverable: exiting now
Warning: Tar failed with error: The process '/usr/bin/tar' failed with exit code 2
```

but do not actually set a failure status or abort the job.

Curiously, `actions/cache@v1.1.2` is not supported for scheduled events (says: `Warning: Event Validation Error: The event type schedule is not supported. Only push, pull_request events are supported at this time.`), and those steps do not perform any action during the nightly scheduled CI.

These cache management steps are causing a big performance hit (counterintuitively), and not being used at all in the nightly run (nor the new Windows CI jobs) indicates they may not be necessary. In my last few test runs I modified `ci.yaml` to remove them, and saw much better results: a full PR/merge CI run in under 30 minutes (see runs [5516](https://github.com/lampepfl/dotty/actions/runs/313020466), [5517](https://github.com/lampepfl/dotty/actions/runs/313072303), [5518](https://github.com/lampepfl/dotty/actions/runs/313117542)).

The table below summarizes the running time of each test run. Columns `Test A` and `Test B` are the timings for only the `Test` step of the community_build_*x* job, and the corresponding `Cache A` and `Cache B` columns indicate the additional time spent for that job on `Cache` steps.  The `Workflow` column is the running time for the entire workflow, and is only given for those runs where all jobs are enabled (for the the first seven rows of the table, the workflow only ran the new community build jobs, with varying choices for the partition members).

<table>
  <tr>
    <th>&nbsp;</th>
    <th>CI #</th>
    <th>Test A</th>
    <th>Test B</th>
    <th>Cache A</th>
    <th>Cache B</th>
    <th>Workflow</th>
    <th align="left">Notes</th>
  </tr>
  <tr>
    <td colspan="8">Only community_build_<i>x</i> jobs enabled:</td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/312579425">5507</a></td>
    <td align="right">26:29</td>
    <td align="right">21:33</td>
    <td align="right">5:09</td>
    <td align="right">20:11</td>
    <td>&nbsp;</td>
    <td>Original partition selection</td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/312658023">5509</a></td>
    <td align="right">27:50</td>
    <td align="right">21:29</td>
    <td align="right">4:08</td>
    <td align="right">20:26</td>
    <td>&nbsp;</td>
    <td>(as above)</td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/312702895">5510</a></td>
    <td align="right">23:16</td>
    <td align="right">25:02</td>
    <td align="right">2:33</td>
    <td align="right">4:59</td>
    <td>&nbsp;</td>
    <td>Move algebra, fastparse, ScalaPB to partition B</td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/312756242">5511</a></td>
    <td align="right">Fail*</td>
    <td align="right">23:42</td>
    <td align="right">2:19</td>
    <td align="right">2:21</td>
    <td>&nbsp;</td>
    <td>(as above)</td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/312787201">5512</a></td>
    <td align="right">23:20</td>
    <td align="right">27:33</td>
    <td align="right">29:19</td>
    <td align="right">1:33</td>
    <td>&nbsp;</td>
    <td>(as above)</td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/312852915">5513</a></td>
    <td align="right">22:50</td>
    <td align="right">26:53</td>
    <td align="right">3:49</td>
    <td align="right">1:43</td>
    <td>&nbsp;</td>
    <td>Move fastparse back to partition A</td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/312902478">5514</a></td>
    <td align="right">26:08</td>
    <td align="right">23:03</td>
    <td align="right">16:54</td>
    <td align="right">5:00</td>
    <td>&nbsp;</td>
    <td>(as above)</td>
  </tr>
  <tr>
    <td colspan="8">All normal CI jobs enabled:</td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/312947349">5515</as></td>
    <td align="right">22:58</td>
    <td align="right">26:22</td>
    <td align="right">7:33</td>
    <td align="right">27:09</td>
    <td align="right">1:00:14</td>
    <td></td>
  </tr>
  <tr>
    <td colspan="8">All normal CI jobs enabled; steps using <b>actions/cache@v1.1.2</b> removed:</td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/313020466">5516</a></td>
    <td align="right">23:15</td>
    <td align="right">29:04</td>
    <td align="center">-</td>
    <td align="center">-</td>
    <td align="right">29:42</td>
    <td></td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/313072303">5517</a></td>
    <td align="right">27:36</td>
    <td align="right">23:18</td>
    <td align="center">-</td>
    <td align="center">-</td>
    <td align="right">28:20</td>
    <td></td>
  </tr>
  <tr>
    <td></td>
    <td align="center"><a href="https://github.com/lampepfl/dotty/actions/runs/313117542">5518</a></td>
    <td align="right">26:05</td>
    <td align="right">26:29</td>
    <td align="center">-</td>
    <td align="center">-</td>
    <td align="right">27:08</td>
    <td></td>
  </tr>
</table>

<br>&nbsp;* Spurious failure

I am cautiously reluctant to recommend removing all the `actions/cache@v1.1.2` steps without at least a better understanding of what's going on and some idea of what, if any benefits they bring. I also notice that the [most current available version of the action](https://github.com/actions/cache) is `v2.1.2`, which may fix some issues?

EDIT: cache issues have been fixed by #10197.

Fixes #9599