### PR TITLE
Fix #10038: Always emit mixin forwarders for readResolve/writeReplace

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -179,6 +179,7 @@ class CompilationTests {
       compileFile("tests/run-custom-args/i5256.scala", allowDeepSubtypes),
       compileFile("tests/run-custom-args/fors.scala", defaultOptions.and("-source", "3.1")),
       compileFile("tests/run-custom-args/no-useless-forwarders.scala", defaultOptions and "-Xmixin-force-forwarders:false"),
+      compileFile("tests/run-custom-args/defaults-serizaliable-no-forwarders.scala", defaultOptions and "-Xmixin-force-forwarders:false"),
       compileFilesInDir("tests/run-custom-args/erased", defaultOptions.and("-Yerased-terms")),
       compileFilesInDir("tests/run-deep-subtype", allowDeepSubtypes),
       compileFilesInDir("tests/run", defaultOptions)

--- a/tests/run-custom-args/defaults-serizaliable-no-forwarders.scala
+++ b/tests/run-custom-args/defaults-serizaliable-no-forwarders.scala
@@ -1,0 +1,26 @@
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+trait T1 extends Serializable {
+  def writeReplace(): AnyRef = new SerializationProxy(this.asInstanceOf[C].s)
+}
+trait T2 {
+  def readResolve: AnyRef = new C(this.asInstanceOf[SerializationProxy].s.toLowerCase)
+}
+class C(val s: String) extends T1
+class SerializationProxy(val s: String) extends T2 with Serializable
+
+object Test {
+  def serializeDeserialize[T <: AnyRef](obj: T) = {
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject.asInstanceOf[T]
+  }
+
+  def main(args: Array[String]): Unit = {
+    val c1 = new C("TEXT")
+    val c2 = serializeDeserialize(c1)
+    assert(c2.s == "text")
+  }
+}

--- a/tests/run/defaults-serizaliable-with-forwarders.scala
+++ b/tests/run/defaults-serizaliable-with-forwarders.scala
@@ -1,0 +1,26 @@
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+trait T1 extends Serializable {
+  def writeReplace(): AnyRef = new SerializationProxy(this.asInstanceOf[C].s)
+}
+trait T2 {
+  def readResolve: AnyRef = new C(this.asInstanceOf[SerializationProxy].s.toLowerCase)
+}
+class C(val s: String) extends T1
+class SerializationProxy(val s: String) extends T2 with Serializable
+
+object Test {
+  def serializeDeserialize[T <: AnyRef](obj: T) = {
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject.asInstanceOf[T]
+  }
+
+  def main(args: Array[String]): Unit = {
+    val c1 = new C("TEXT")
+    val c2 = serializeDeserialize(c1)
+    assert(c2.s == "text")
+  }
+}


### PR DESCRIPTION
Adapted from https://github.com/scala/scala/pull/9253. Just like in
Scala 2 this isn't a big deal since `-Xmixin-force-forwarders:false` is
not the default and not commonly used.

Co-Authored-By: Jason Zaugg <jzaugg@gmail.com>