### PR TITLE
Fix: scalac should not call itself dotc

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -12,7 +12,7 @@ import scala.collection.JavaConverters._
 object CompilerCommand {
 
   /** The name of the command */
-  def cmdName: String = "dotc"
+  def cmdName: String = "scalac"
 
   private def explainAdvanced = """
     |-- Notes on option parsing --
@@ -137,7 +137,7 @@ object CompilerCommand {
 
     if (summary.errors.nonEmpty) {
       summary.errors foreach (report.error(_))
-      report.echo("  dotc -help  gives more information")
+      report.echo("  scalac -help  gives more information")
       Nil
     }
     else if (settings.version.value) {

--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -129,6 +129,6 @@ trait PropertiesTrait {
   def jdkHome: String               = envOrElse("JDK_HOME", envOrElse("JAVA_HOME", javaHome))
 
   def versionMsg: String            = "Scala %s %s -- %s".format(propCategory, versionString, copyrightString)
-  def scalaCmd: String              = if (isWin) "dotr.bat" else "dotr"
-  def scalacCmd: String             = if (isWin) "dotc.bat" else "dotc"
+  def scalaCmd: String              = if (isWin) "scala.bat" else "scala"
+  def scalacCmd: String             = if (isWin) "scalac.bat" else "scalac"
 }

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -263,7 +263,7 @@ object Phases {
      *  instance, it is possible to print trees after a given phase using:
      *
      *  ```bash
-     *  $ ./bin/dotc -Xprint:<phaseNameHere> sourceFile.scala
+     *  $ ./bin/scalac -Xprint:<phaseNameHere> sourceFile.scala
      *  ```
      */
     def phaseName: String

--- a/compiler/test/debug/Gen
+++ b/compiler/test/debug/Gen
@@ -6,8 +6,8 @@ SOURCE=$DIR/Gen.scala
 CLASS=./Gen.class
 
 if [ ! -e $CLASS ] || [ $SOURCE -nt $CLASS ]; then
-  ./bin/dotc $DIR/Gen.scala
+  ./bin/scalac $DIR/Gen.scala
 fi
 
-./bin/dotr Gen $@
+./bin/scala Gen $@
 

--- a/compiler/test/debug/test
+++ b/compiler/test/debug/test
@@ -4,8 +4,8 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 echo "start debug test..."
 for file in tests/debug/*.scala; do
-   ./bin/dotc $file || exit 1
-   ./bin/dotr -d Test > /dev/null &
+   ./bin/scalac $file || exit 1
+   ./bin/scala -d Test > /dev/null &
    $DIR/Gen $file > robot
    expect robot 2>&1 > /dev/null
 

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -16,7 +16,7 @@ class FromTastyTests {
   @Test def posTestFromTasty: Unit = {
     // Can be reproduced with
     // > sbt
-    // > dotc -Ythrough-tasty -Ycheck:all <source>
+    // > scalac -Ythrough-tasty -Ycheck:all <source>
 
     implicit val testGroup: TestGroup = TestGroup("posTestFromTasty")
     compileTastyInDir(s"tests${JFile.separator}pos", defaultOptions,
@@ -27,8 +27,8 @@ class FromTastyTests {
   @Test def runTestFromTasty: Unit = {
     // Can be reproduced with
     // > sbt
-    // > dotc -Ythrough-tasty -Ycheck:all <source>
-    // > dotr Test
+    // > scalac -Ythrough-tasty -Ycheck:all <source>
+    // > scala Test
 
     implicit val testGroup: TestGroup = TestGroup("runTestFromTasty")
     compileTastyInDir(s"tests${JFile.separator}run", defaultOptions,

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -104,7 +104,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
             |the test can be reproduced by running from SBT (prefix it with ./bin/ if you
             |want to run from the command line):""".stripMargin
       )
-      sb.append("\n\ndotc ")
+      sb.append("\n\nscalac ")
       flags.all.foreach { arg =>
         if (lineLen > maxLen) {
           sb.append(delimiter)


### PR DESCRIPTION
`bin/dotc` was recently renamed to `bin/scalac`, but it seems as though it's the last to know:

```
$ ./bin/scalac
Usage: dotc <options> <source files>
   ...
```

This PR also updates some other dangling references to `dotc` and `dotr`.