### PR TITLE
Remove test that triggers an OutOfMemoryError

### DIFF
--- a/tests/run/t7880.scala
+++ b/tests/run/t7880.scala
@@ -1,7 +1,0 @@
-object Test extends App {
-  // This should terminate in one way or another, but it shouldn't loop forever.
-  try {
-    val buffer = collection.mutable.ArrayBuffer.fill(Int.MaxValue / 2 + 1)(0)
-    buffer += 1
-  } catch { case _: OutOfMemoryError => }
-}


### PR DESCRIPTION
This lead to timeouts on the Windows CI, and in any case this test has
nothing to do here: it tests the library, not the compiler, so it should
be a JUnit test in scala-library.