### PR TITLE
Fix #10076: Allow application on function named `extension`

### DIFF
--- a/tests/neg/i10076.scala
+++ b/tests/neg/i10076.scala
@@ -1,0 +1,5 @@
+
+def test: Unit = {
+  def extension(a : Int) = 5
+  extension (1) // error
+} // error

--- a/tests/neg/i9928.scala
+++ b/tests/neg/i9928.scala
@@ -3,7 +3,7 @@ trait Magic[F]:
 
 object Magic:
   given Magic[String]:
-    extension(x: Int) def read: String =
+    extension (x: Int) def read: String =
       println("In string")
       s"$x"
 

--- a/tests/pos/i10076.scala
+++ b/tests/pos/i10076.scala
@@ -1,0 +1,5 @@
+
+def test: Unit = {
+  def extension(a : Int) = 5
+  extension(1)
+}

--- a/tests/run/i9928.scala
+++ b/tests/run/i9928.scala
@@ -3,7 +3,7 @@ trait Magic[F]:
 
 trait LowPrio:
   given Magic[String]:
-    extension(x: Int) def read: String =
+    extension (x: Int) def read: String =
       println("In string")
       s"$x"
 


### PR DESCRIPTION
We only parse an extension clause must have a whitespace between the `extension` and the arguments.

Syntax highlighting already helps to visually know if an extension is parsed as a declaration or application.
<img width="184" alt="Screenshot 2020-10-26 at 11 09 29" src="https://user-images.githubusercontent.com/3648029/97160086-1f184580-177c-11eb-96b9-3870e13ec058.png">
