### PR TITLE
Keep @alpha optional

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -172,6 +172,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val YexplicitNulls: Setting[Boolean] = BooleanSetting("-Yexplicit-nulls", "Make reference types non-nullable. Nullable types can be expressed with unions: e.g. String|Null.")
   val YerasedTerms: Setting[Boolean] = BooleanSetting("-Yerased-terms", "Allows the use of erased terms.")
   val YcheckInit: Setting[Boolean] = BooleanSetting("-Ycheck-init", "Check initialization of objects")
+  val YrequireAlpha: Setting[Boolean] = BooleanSetting("-Yrequire-alpha", "Warn if an operator is defined without an @alpha annotation")
 
   /** Area-specific debug output */
   val YexplainLowlevel: Setting[Boolean] = BooleanSetting("-Yexplain-lowlevel", "When explaining type errors, show types at a lower level.")

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -311,18 +311,17 @@ object Checking {
   /** If `sym` has an operator name, check that it has an @alpha annotation in 3.1 and later
    */
   def checkValidOperator(sym: Symbol)(using Context): Unit =
-    sym.name.toTermName match {
-      case name: SimpleName
-      if name.isOperatorName
-         && !name.isSetterName
-         && !name.isConstructorName
-         && !sym.getAnnotation(defn.AlphaAnnot).isDefined
-         && !sym.is(Synthetic)
-         && sourceVersion.isAtLeast(`3.1`) =>
-        report.deprecationWarning(
-          i"$sym has an operator name; it should come with an @alpha annotation", sym.srcPos)
-      case _ =>
-    }
+    if ctx.settings.YrequireAlpha.value then
+      sym.name.toTermName match
+        case name: SimpleName
+        if name.isOperatorName
+          && !name.isSetterName
+          && !name.isConstructorName
+          && !sym.getAnnotation(defn.AlphaAnnot).isDefined
+          && !sym.is(Synthetic) =>
+          report.warning(
+            i"$sym has an operator name; it should come with an @alpha annotation", sym.srcPos)
+        case _ =>
 
   /** Check that `info` of symbol `sym` is not cyclic.
    *  @pre     sym is not yet initialized (i.e. its type is a Completer).

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -153,7 +153,7 @@ class CompilationTests {
         defaultOptions),
       compileFile("tests/neg-custom-args/i6300.scala", allowDeepSubtypes),
       compileFile("tests/neg-custom-args/infix.scala", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
-      compileFile("tests/neg-custom-args/missing-alpha.scala", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
+      compileFile("tests/neg-custom-args/missing-alpha.scala", defaultOptions.and("-Yrequire-alpha", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/wildcards.scala", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/indentRight.scala", defaultOptions.and("-noindent", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/extmethods-tparams.scala", defaultOptions.and("-deprecation", "-Xfatal-warnings")),

--- a/docs/docs/reference/changed-features/operators.md
+++ b/docs/docs/reference/changed-features/operators.md
@@ -22,8 +22,6 @@ VecOps.append(vec1, vec2)
 ```
 The `@alpha` annotation has no bearing on Scala usages. Any application of that method in Scala has to use `++=`, not `append`.
 
-An `@alpha` annotation will be _mandatory_ if the method name is symbolic. Symbolic methods without `@alpha` annotations are deprecated.
-
 ### Motivation
 
 The `@alpha` annotation serves a dual purpose:


### PR DESCRIPTION
As suggested by the discussion in [contributors](https://contributors.scala-lang.org/t/the-alpha-notation),
we might want to keep `@alpha` optional for operators. Since no firm decision has been taken,
I have put the checking behavior under a -Yrequire-alpha flag for the moment.