### PR TITLE
Rename Type.T to Type.Underlying

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -830,7 +830,7 @@ class Definitions {
     @tu lazy val InternalQuotedType_unapply: Symbol = InternalQuotedTypeModule.requiredMethod(nme.unapply)
 
   @tu lazy val QuotedTypeClass: ClassSymbol = requiredClass("scala.quoted.Type")
-    @tu lazy val QuotedType_splice: Symbol = QuotedTypeClass.requiredType(tpnme.spliceType)
+    @tu lazy val QuotedType_splice: Symbol = QuotedTypeClass.requiredType(tpnme.Underlying)
 
   @tu lazy val QuotedTypeModule: Symbol = QuotedTypeClass.companionModule
     @tu lazy val QuotedTypeModule_apply: Symbol = QuotedTypeModule.requiredMethod("apply")

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -242,6 +242,7 @@ object StdNames {
     final val Tree: N                = "Tree"
     final val Type : N               = "Type"
     final val TypeTree: N            = "TypeTree"
+    final val Underlying: N          = "Underlying"
 
     // Annotation simple names, used in Namer
     final val BeanPropertyAnnot: N = "BeanProperty"
@@ -583,7 +584,6 @@ object StdNames {
     val setSymbol: N            = "setSymbol"
     val setType: N              = "setType"
     val setTypeSignature: N     = "setTypeSignature"
-    val spliceType: N           = "T"
     val standardInterpolator: N = "standardInterpolator"
     val staticClass : N         = "staticClass"
     val staticModule : N        = "staticModule"

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -271,13 +271,13 @@ object PCPCheckAndHeal {
 
     private def mkTagSymbolAndAssignType(spliced: TermRef): TypeDef = {
       val splicedTree = tpd.ref(spliced).withSpan(span)
-      val rhs = splicedTree.select(tpnme.spliceType).withSpan(span)
+      val rhs = splicedTree.select(tpnme.Underlying).withSpan(span)
       val alias = ctx.typeAssigner.assignType(untpd.TypeBoundsTree(rhs, rhs), rhs, rhs, EmptyTree)
       val local = newSymbol(
         owner = ctx.owner,
         name = UniqueName.fresh((splicedTree.symbol.name.toString + "$_").toTermName).toTypeName,
         flags = Synthetic,
-        info = TypeAlias(splicedTree.tpe.select(tpnme.spliceType)),
+        info = TypeAlias(splicedTree.tpe.select(tpnme.Underlying)),
         coord = span).asType
       local.addAnnotation(Annotation(defn.InternalQuoted_QuoteTypeTagAnnot))
       ctx.typeAssigner.assignType(untpd.TypeDef(local.name, alias), local)

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -370,7 +370,7 @@ class ReifyQuotes extends MacroTransform {
           case tree: RefTree if isCaptured(tree.symbol, level) =>
             val body = capturers(tree.symbol).apply(tree)
             if (tree.isType)
-              transformSpliceType(body, body.select(tpnme.spliceType))
+              transformSpliceType(body, body.select(tpnme.Underlying))
             else
               val splice = ref(defn.InternalQuoted_exprSplice).appliedToType(tree.tpe).appliedTo(body)
               transformSplice(body, splice)

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -176,9 +176,9 @@ trait QuotesAndSplices {
       typeSym.addAnnotation(Annotation(New(ref(defn.InternalQuotedPatterns_patternTypeAnnot.typeRef)).withSpan(tree.expr.span)))
       val pat = typedPattern(expr, defn.QuotedTypeClass.typeRef.appliedTo(typeSym.typeRef))(
           using spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
-      pat.select(tpnme.spliceType)
+      pat.select(tpnme.Underlying)
     else
-      val tree1 = typedSelect(untpd.Select(tree.expr, tpnme.spliceType), pt)(using spliceContext).withSpan(tree.span)
+      val tree1 = typedSelect(untpd.Select(tree.expr, tpnme.Underlying), pt)(using spliceContext).withSpan(tree.span)
       val msg = em"Consider using canonical type reference ${tree1.tpe} instead"
       if sourceVersion.isAtLeast(`3.1-migration`) then report.error(msg, tree.srcPos)
       else report.warning(msg, tree.srcPos)

--- a/library/src-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/quoted/Type.scala
@@ -4,8 +4,10 @@ import scala.annotation.compileTimeOnly
 import scala.quoted.show.SyntaxHighlight
 
 /** Quoted type (or kind) `T` */
-abstract class Type[X <: AnyKind] private[scala] {
-  type T = X
+abstract class Type[T <: AnyKind] private[scala] {
+
+  /** The type represented `Type` */
+  type Underlying = T
 
   /** Show a source code like representation of this type without syntax highlight */
   def show(using qctx: QuoteContext): String =

--- a/library/src-non-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-non-bootstrapped/scala/quoted/Type.scala
@@ -2,8 +2,9 @@ package scala.quoted
 
 import scala.annotation.compileTimeOnly
 
-abstract class Type[X <: AnyKind] private[scala]:
-  type T = X
+abstract class Type[T <: AnyKind] private[scala]:
+  type Underlying = T
+
   def unseal(using qctx: QuoteContext): qctx.reflect.TypeTree
 
 object Type:

--- a/tests/pos-macros/i9518/Macro_1.scala
+++ b/tests/pos-macros/i9518/Macro_1.scala
@@ -11,7 +11,7 @@ def shiftTerm(using QuoteContext): Expr[Unit] = {
   val tp1 = '[CB[Int]].unseal.tpe
   val tp2 = '[([X] =>> CB[X])[Int]].unseal.tpe
   val ta = '[[X] =>> CB[X]]
-  val tp3 = '[ta.T[Int]].unseal.tpe
+  val tp3 = '[ta.Underlying[Int]].unseal.tpe
   val tp4 = '[CB].unseal.tpe.appliedTo(TypeRepr.of[Int])
   assert(nTree.tpe <:< tp1)
   assert(nTree.tpe <:< tp2)


### PR DESCRIPTION
After #10045 we do not have any cases where we need to use this type reference explicitly in the source code.
We rename it to have a descriptive name to improve error messages and to push users to use the canonical representation of types and never use them explicilty.