### PR TITLE
Fix #10082: show friendly error message related to  type inference

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -508,7 +508,8 @@ trait Inferencing { this: Typer =>
         //     found   : Int(1)
         //     required: String
         //     val y: List[List[String]] = List(List(1))
-        val hasUnreportedErrors = state.reporter.hasUnreportedErrors
+        if state.reporter.hasUnreportedErrors then return tree
+
         def constraint = state.constraint
         type InstantiateQueue = mutable.ListBuffer[(TypeVar, Boolean)]
         val toInstantiate = new InstantiateQueue
@@ -521,7 +522,7 @@ trait Inferencing { this: Typer =>
               typr.println(i"interpolate non-occurring $tvar in $state in $tree: $tp, fromBelow = ${tvar.hasLowerBound}, $constraint")
               toInstantiate += ((tvar, tvar.hasLowerBound))
             }
-            else if (!hasUnreportedErrors)
+            else
               if (v.intValue != 0) {
                 typr.println(i"interpolate $tvar in $state in $tree: $tp, fromBelow = ${v.intValue == 1}, $constraint")
                 toInstantiate += ((tvar, v.intValue == 1))

--- a/tests/neg/i10082.scala
+++ b/tests/neg/i10082.scala
@@ -1,0 +1,7 @@
+object Kotlin:
+  def it[T](using t: T) = t
+  def fun[T, U](fn: T ?=> U)(x: T): U = fn(using x)
+
+import Kotlin.{fun, it}
+
+def Test = List(1).map(fun(it + 1)) // error

--- a/tests/neg/i9568.check
+++ b/tests/neg/i9568.check
@@ -1,9 +1,9 @@
 -- Error: tests/neg/i9568.scala:13:10 ----------------------------------------------------------------------------------
 13 |  blaMonad.foo(bla) // error: diverges
    |          ^
-   |no implicit argument of type => Monad[([_$3] =>> Any)] was found for parameter ev of method blaMonad in object Test.
-   |I found:
+   |          no implicit argument of type => Monad[F] was found for parameter ev of method blaMonad in object Test.
+   |          I found:
    |
-   |    Test.blaMonad[Nothing, S](Test.blaMonad[F, S])
+   |              Test.blaMonad[Nothing, S](Test.blaMonad[F, S])
    |
-   |But method blaMonad in object Test does not match type => Monad[Nothing].
+   |          But method blaMonad in object Test does not match type => Monad[Nothing].


### PR DESCRIPTION
Fix #10082: show friendly error message related to  type inference
