### PR TITLE
Use standard annotation format for dollarvalues

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -125,7 +125,7 @@ object DesugarEnums {
         // Singleton enum values always construct a new anonymous class, which will not be checked by the init-checker,
         // so this warning will always persist even if the implementation of the anonymous class is safe.
         // TODO: remove @unchecked after https://github.com/lampepfl/dotty-feature-requests/issues/135 is resolved.
-        Annotated(ArrayLiteral(enumValues, rawEnumClassRef), New(ref(defn.UncheckedAnnot.typeRef)))
+        Annotated(ArrayLiteral(enumValues, rawEnumClassRef), New(ref(defn.UncheckedAnnot.typeRef), Nil))
       ValDef(nme.DOLLAR_VALUES, TypeTree(), uncheckedValues)
         .withFlags(Private | Synthetic)
 


### PR DESCRIPTION
enum companions define the following:

```scala
val $values: Array[E] @unchecked = ...
```

currently the `@unchecked` annotation is represented as

```Scala
New(typeOf[scala.unchecked])
```

it should be

```scala
Apply(Select(New(typeOf[scala.unchecked]), <init>), Nil)
```

this ends up with a special case in TASTy