### PR TITLE
The atom of a module class is its module val

### DIFF
--- a/tests/patmat/outer-ref-checks.scala
+++ b/tests/patmat/outer-ref-checks.scala
@@ -16,7 +16,6 @@ class Outer {
 
   def belongsOtherOuter(a: Outer#Inner): Unit = a match {
     case Inner(s) => // unchecked warning
-    case O.Inner(s) => // unchecked warning
     case _ =>
   }
 }

--- a/tests/pos/object-union-inf.scala
+++ b/tests/pos/object-union-inf.scala
@@ -1,0 +1,19 @@
+class A
+object ObjA extends A
+class B
+object ObjB extends B
+
+object Test {
+  def foo[T <: A | B](t: T): List[T] = List(t)
+  val x: ObjA.type | ObjB.type = ObjA
+
+  // infers `T = ObjA$ | ObjB$` instead of `ObjA.type | ObjB.type` due to the
+  // use of `widenSingleton` in TypeComparer#secondTry when the lhs is a union
+  // type.
+  val y = foo(ObjA : ObjA.type | ObjB.type)
+
+  // This only compiles if `ObjA$ <:< ObjA.type`, there is a special-case in
+  // `firstTry` for that but we also need a special case in `atoms` since unions
+  // are involved.
+  val z: List[ObjA.type | ObjB.type] = y
+}


### PR DESCRIPTION
In `firstTry` we've long had the following special-case:

    if (sym1.is(ModuleClass) && sym2.is(ModuleVal))
      // For convenience we want X$ <:< X.type
      // This is safe because X$ self-type is X.type
      sym1 = sym1.companionModule

It turns out that this isn't enough nowadays because `atoms` on a module
class returned `Atoms.Unknown` so `X$ | Y$ <:< X.type | Y.type` returned
false. This commit fixes this by special-casing `atoms` for module
classes. Alternatively, we could drop all special-casing of module
classes and module vals in the subtype checker, but that would require
making sure that we never widen module vals anywhere which seems tricky.