### PR TITLE
Fix #9533: handle nested TypeParamRef in bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -223,27 +223,27 @@ final class ProperGadtConstraint private(
   override protected def isSub(tp1: Type, tp2: Type)(using Context): Boolean = TypeComparer.isSubType(tp1, tp2)
   override protected def isSame(tp1: Type, tp2: Type)(using Context): Boolean = TypeComparer.isSameType(tp1, tp2)
 
-   override def nonParamBounds(param: TypeParamRef)(using Context): TypeBounds =
-     val externalizeMap = new TypeMap {
-       def apply(tp: Type): Type = tp match {
-         case tpr: TypeParamRef => externalize(tpr)
-         case tp => mapOver(tp)
-       }
-     }
-     externalizeMap(constraint.nonParamBounds(param)).bounds
+  override def nonParamBounds(param: TypeParamRef)(using Context): TypeBounds =
+    val externalizeMap = new TypeMap {
+      def apply(tp: Type): Type = tp match {
+        case tpr: TypeParamRef => externalize(tpr)
+        case tp => mapOver(tp)
+      }
+    }
+    externalizeMap(constraint.nonParamBounds(param)).bounds
 
-   override def fullLowerBound(param: TypeParamRef)(using Context): Type =
-     constraint.minLower(param).foldLeft(nonParamBounds(param).lo) {
-       (t, u) => t | externalize(u)
-     }
+  override def fullLowerBound(param: TypeParamRef)(using Context): Type =
+    constraint.minLower(param).foldLeft(nonParamBounds(param).lo) {
+      (t, u) => t | externalize(u)
+    }
 
-   override def fullUpperBound(param: TypeParamRef)(using Context): Type =
-     constraint.minUpper(param).foldLeft(nonParamBounds(param).hi) { (t, u) =>
-       val eu = externalize(u)
-       // Any as the upper bound means "no bound", but if F is higher-kinded,
-       // Any & F = F[_]; this is wrong for us so we need to short-circuit
-       if t.isAny then eu else t & eu
-     }
+  override def fullUpperBound(param: TypeParamRef)(using Context): Type =
+    constraint.minUpper(param).foldLeft(nonParamBounds(param).hi) { (t, u) =>
+      val eu = externalize(u)
+      // Any as the upper bound means "no bound", but if F is higher-kinded,
+      // Any & F = F[_]; this is wrong for us so we need to short-circuit
+      if t.isAny then eu else t & eu
+    }
 
   // ---- Private ----------------------------------------------------------
 

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -173,7 +173,7 @@ final class ProperGadtConstraint private(
       case null => null
       case tv =>
         fullBounds(tv.origin)
-          .ensuring(containsNoInternalTypes(_))
+          // .ensuring(containsNoInternalTypes(_))
     }
 
   override def bounds(sym: Symbol)(using Context): TypeBounds =

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -224,10 +224,13 @@ final class ProperGadtConstraint private(
   override protected def isSame(tp1: Type, tp2: Type)(using Context): Boolean = TypeComparer.isSameType(tp1, tp2)
 
    override def nonParamBounds(param: TypeParamRef)(using Context): TypeBounds =
-     constraint.nonParamBounds(param) match {
-       case TypeAlias(tpr: TypeParamRef) => TypeAlias(externalize(tpr))
-       case tb => tb
+     val externalizeMap = new TypeMap {
+       def apply(tp: Type): Type = tp match {
+         case tpr: TypeParamRef => externalize(tpr)
+         case tp => mapOver(tp)
+       }
      }
+     externalizeMap(constraint.nonParamBounds(param)).bounds
 
    override def fullLowerBound(param: TypeParamRef)(using Context): Type =
      constraint.minLower(param).foldLeft(nonParamBounds(param).lo) {

--- a/tests/pos/i9533.scala
+++ b/tests/pos/i9533.scala
@@ -1,0 +1,10 @@
+object Test {
+  sealed trait Base[-X]
+  case class Child[X]() extends Base[X]
+
+  def apply[A, B](r: Base[A with B]): Unit = {
+    r match {
+      case Child() => ()
+    }
+  }
+}


### PR DESCRIPTION
Fix #9533: handle nested TypeParamRef in bounds