### PR TITLE
Fix #10107: Improve `inline if` constant condition detraction and reporting

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -1473,10 +1473,15 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
     }.apply(Nil, tree)
 
   object ConstantValue {
-    def unapply(tree: Tree)(using Context): Option[Any] = tree.tpe.widenTermRefExpr.normalized match {
-      case ConstantType(Constant(x)) => Some(x)
-      case _ => None
-    }
+    def unapply(tree: Tree)(using Context): Option[Any] =
+      tree match
+        case Typed(expr, _) => unapply(expr)
+        case Inlined(_, Nil, expr) => unapply(expr)
+        case Block(Nil, expr) => unapply(expr)
+        case _ =>
+          tree.tpe.widenTermRefExpr.normalized match
+            case ConstantType(Constant(x)) => Some(x)
+            case _ => None
   }
 
 }

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -1235,9 +1235,8 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
           else Block(cond1 :: Nil, selected)
         case cond1 =>
           if (tree.isInline)
-            errorTree(tree, em"""cannot reduce inline if
-                                | its condition   ${tree.cond}
-                                | is not a constant value""")
+            errorTree(tree,
+              em"Cannot reduce `inline if` because its condition is not a constant value: $cond1")
           else
             cond1.computeNullableDeeply()
             val if1 = untpd.cpy.If(tree)(cond = untpd.TypedSplice(cond1))

--- a/tests/pos-macros/i10107b/Macro_1.scala
+++ b/tests/pos-macros/i10107b/Macro_1.scala
@@ -1,0 +1,13 @@
+import scala.quoted._
+
+inline def isTrue: Boolean = ${ isTrueImpl }
+def isTrueImpl(using qctx: QuoteContext) = {
+  Expr(true)
+}
+
+inline def oneOf(): String = {
+  inline if isTrue then
+    "foo"
+  else
+    "bar"
+}

--- a/tests/pos-macros/i10107b/Test_2.scala
+++ b/tests/pos-macros/i10107b/Test_2.scala
@@ -1,0 +1,1 @@
+def test1 = oneOf()

--- a/tests/pos/i10107.scala
+++ b/tests/pos/i10107.scala
@@ -1,0 +1,4 @@
+inline def f() =
+  inline if true: Boolean then () else ()
+
+def test = f()


### PR DESCRIPTION
Showing the reduced condition is much more useful than showing the original condition.