### PR TITLE
Scala.js: Handle private inner JS classes.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -3384,8 +3384,15 @@ class JSCodeGen()(using genCtx: Context) {
         } else {
           val captureValues = {
             if (code == CREATE_INNER_JS_CLASS) {
+              /* Private inner classes that do not actually access their outer
+               * pointer do not receive an outer argument. We therefore count
+               * the number of constructors that have non-empty param list to
+               * know how many times we need to pass `this`.
+               */
+              val requiredThisParams =
+                classSym.info.decls.lookupAll(nme.CONSTRUCTOR).count(_.info.paramInfoss.head.nonEmpty)
               val outer = genThis()
-              List.fill(classSym.info.decls.lookupAll(nme.CONSTRUCTOR).size)(outer)
+              List.fill(requiredThisParams)(outer)
             } else {
               val fakeNewInstances = args(2).asInstanceOf[JavaSeqLiteral].elems
               fakeNewInstances.flatMap(genCaptureValuesFromFakeNewInstance(_))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1101,7 +1101,6 @@ object Build {
           ++ (dir / "shared/src/test/require-jdk7" ** "*.scala").get
 
           ++ (dir / "js/src/test/scala" ** (("*.scala": FileFilter)
-            -- "ExportsTest.scala" // JS exports + IR checking error
             -- "ObjectTest.scala" // compile errors caused by #9588
             -- "StackTraceTest.scala" // would require `npm install source-map-support`
             -- "UnionTypeTest.scala" // requires the Scala 2 macro defined in Typechecking*.scala
@@ -1118,6 +1117,7 @@ object Build {
       Test / testOptions += Tests.Filter { name =>
         !Set[String](
           "org.scalajs.testsuite.jsinterop.AsyncTest", // needs JS exports in PromiseMock.scala
+          "org.scalajs.testsuite.jsinterop.ExportsTest", // JS exports
           "org.scalajs.testsuite.jsinterop.JSExportStaticTest", // JS exports
 
           // Not investigated so far


### PR DESCRIPTION
Sometimes, a private inner JS class doesn't need an outer pointer at all, and hence its constructor doesn't take any argument. This corner case needs to be handled in the codegen for `createInnerJSClass`.