### PR TITLE
withDottyCompat: correctly handle dotty-{library,compiler}

### DIFF
--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -90,8 +90,8 @@ object DottyPlugin extends AutoPlugin {
        *  with Dotty this will change the cross-version to a Scala 2.x one. This
        *  works because Dotty is currently retro-compatible with Scala 2.x.
        *
-       *  NOTE: As a special-case, the cross-version of dotty-library, dotty-compiler and
-       *  dotty will never be rewritten because we know that they're Dotty-only.
+       *  NOTE: As a special-case, the cross-version of scala3-library and scala3-compiler
+       *  will never be rewritten because we know that they're Scala 3 only.
        *  This makes it possible to do something like:
        *  {{{
        *  libraryDependencies ~= (_.map(_.withDottyCompat(scalaVersion.value)))
@@ -99,7 +99,8 @@ object DottyPlugin extends AutoPlugin {
        */
       def withDottyCompat(scalaVersion: String): ModuleID = {
         val name = moduleID.name
-        if (name != "scala3" && name != "scala3-library" && name != "scala3-compiler")
+        if (name != "scala3-library" && name != "scala3-compiler" &&
+            name != "dotty" && name != "dotty-library" && name != "dotty-compiler")
           moduleID.crossVersion match {
             case binary: librarymanagement.Binary =>
               val compatVersion =


### PR DESCRIPTION
Support for them got dropped when we did the renaming, but the latest
sbt-dotty is supposed to still work with older dotty versions, so we
should keep supporting this. Also removed the "scala3" special-case
since we never published an artefact named "scala3".