### PR TITLE
fix #10075: do not replace Polyfunction without apply

### DIFF
--- a/tests/pos/i10075.scala
+++ b/tests/pos/i10075.scala
@@ -1,0 +1,1 @@
+val foo = new PolyFunction {}


### PR DESCRIPTION
Its either just make a `new PolyFunction {}` as done here, or else make it an error to have any refinement other than apply/empty refinement