### PR TITLE
fix #10122: check parent types of references and types of parameters

### DIFF
--- a/tests/neg/i10122.scala
+++ b/tests/neg/i10122.scala
@@ -1,0 +1,17 @@
+import scala.annotation.compileTimeOnly
+
+@compileTimeOnly("FooBar can not be used as an expression") trait FooBar
+
+object foo extends FooBar // error
+
+val fooAnon = new FooBar {} // error // error
+val fooRef1: FooBar = ??? // error
+def fooRef2: FooBar = ??? // error
+def useFoo(foo: FooBar): foo.type = foo // error // error // error
+val bar = fooRef2 // error
+
+@compileTimeOnly("baz can not be used as an expression") val baz = 23
+val qux = baz // error
+
+@compileTimeOnly("quux can not be used as an expression") def quux = 47
+val quxx = quux // error


### PR DESCRIPTION
in scala 2 it seems the types of parameters and valdef results is also checked