### PR TITLE
Scala3doc: ensure all projects we're documenting are compiled

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1490,14 +1490,14 @@ object Build {
             generateDocumentation(classDirectory.in(Compile).value.getAbsolutePath, "scala3doc", "self", "-p documentation")
           }.value,
           generateScala3Documentation := Def.taskDyn {
-            val dottyJars = Seq(
-              // All projects below will be used to generated documentation for Scala 3
-              classDirectory.in(`scala3-interfaces`).in(Compile).value,
-              classDirectory.in(`tasty-core`).in(Compile).value,
-              classDirectory.in(`scala3-library`).in(Compile).value,
-              // TODO this one fails to load using TASTY
-              // classDirectory.in(`stdlib-bootstrapped`).in(Compile).value,
-            )
+            val dottyJars: Seq[java.io.File] = Seq(
+              (`scala3-interfaces`/Compile/products).value,
+              (`tasty-core`/Compile/products).value,
+              (`scala3-library`/Compile/products).value,
+              // TODO we can't load stdlib from Tasty
+              // (`stdlib-bootstrapped`/Compile/products).value,
+            ).flatten
+
             val roots = dottyJars.map(_.toString).mkString(java.io.File.pathSeparator)
 
             if (dottyJars.isEmpty) Def.task { streams.value.log.error("Dotty lib wasn't found") }


### PR DESCRIPTION
What it says in the title.