### PR TITLE
Fix #10143 and test stdlib from TASTy directly from Jar and TASTy files

### DIFF
--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -86,7 +86,7 @@ class Driver {
   protected def fromTastySetup(fileNames0: List[String], ctx0: Context): (List[String], Context) =
     given Context = ctx0
     if (ctx0.settings.fromTasty.value) {
-      val fromTastyBlacklist = ctx0.settings.YfromTastyBlacklist.value.toSet
+      val fromTastyIgnoreList = ctx0.settings.YfromTastyIgnoreList.value.toSet
       // Resolve classpath and class names of tasty files
       val (classPaths, classNames) = fileNames0.flatMap { name =>
         val path = Paths.get(name)
@@ -97,7 +97,7 @@ class Driver {
           Nil
         else if name.endsWith(".jar") then
           new dotty.tools.io.Jar(File(name)).toList.collect {
-            case e if e.getName.endsWith(".tasty") && !fromTastyBlacklist(e.getName) =>
+            case e if e.getName.endsWith(".tasty") && !fromTastyIgnoreList(e.getName) =>
               (name, e.getName.stripSuffix(".tasty").replace("/", "."))
           }
         else

--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -86,6 +86,7 @@ class Driver {
   protected def fromTastySetup(fileNames0: List[String], ctx0: Context): (List[String], Context) =
     given Context = ctx0
     if (ctx0.settings.fromTasty.value) {
+      val fromTastyBlacklist = ctx0.settings.YfromTastyBlacklist.value.toSet
       // Resolve classpath and class names of tasty files
       val (classPaths, classNames) = fileNames0.flatMap { name =>
         val path = Paths.get(name)
@@ -96,7 +97,7 @@ class Driver {
           Nil
         else if name.endsWith(".jar") then
           new dotty.tools.io.Jar(File(name)).toList.collect {
-            case e if e.getName.endsWith(".tasty") =>
+            case e if e.getName.endsWith(".tasty") && !fromTastyBlacklist(e.getName) =>
               (name, e.getName.stripSuffix(".tasty").replace("/", "."))
           }
         else

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -158,7 +158,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val YretainTrees: Setting[Boolean] = BooleanSetting("-Yretain-trees", "Retain trees for top-level classes, accessible from ClassSymbol#tree")
   val Ysemanticdb: Setting[Boolean] = BooleanSetting("-Ysemanticdb", "Store information in SemanticDB.")
   val YshowTreeIds: Setting[Boolean] = BooleanSetting("-Yshow-tree-ids", "Uniquely tag all tree nodes in debugging output.")
-  val YfromTastyBlacklist: Setting[List[String]] = MultiStringSetting("-Yfrom-tasty-blacklist", "file", "List of `tasty` files in jar files that will not be loaded when using -from-tasty")
+  val YfromTastyIgnoreList: Setting[List[String]] = MultiStringSetting("-Yfrom-tasty-ignore-list", "file", "List of `tasty` files in jar files that will not be loaded when using -from-tasty")
 
   val YprofileEnabled: Setting[Boolean] = BooleanSetting("-Yprofile-enabled", "Enable profiling.")
   val YprofileDestination: Setting[String] = StringSetting("-Yprofile-destination", "file", "Where to send profiling output - specify a file, default is to the console.", "")

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -45,7 +45,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.") withAbbreviation "--language"
   val rewrite: Setting[Option[Rewrites]] = OptionSetting[Rewrites]("-rewrite", "When used in conjunction with a `...-migration` source version, rewrites sources to migrate to new version.") withAbbreviation "--rewrite"
   val silentWarnings: Setting[Boolean] = BooleanSetting("-nowarn", "Silence all warnings.") withAbbreviation "--no-warnings"
-  val fromTasty: Setting[Boolean] = BooleanSetting("-from-tasty", "Compile classes from tasty in classpath. The arguments are used as class names.") withAbbreviation "--from-tasty"
+  val fromTasty: Setting[Boolean] = BooleanSetting("-from-tasty", "Compile classes from tasty files. The arguments are .tasty or .jar files.") withAbbreviation "--from-tasty"
 
   val newSyntax: Setting[Boolean] = BooleanSetting("-new-syntax", "Require `then` and `do` in control expressions.")
   val oldSyntax: Setting[Boolean] = BooleanSetting("-old-syntax", "Require `(...)` around conditions.")
@@ -158,6 +158,7 @@ class ScalaSettings extends Settings.SettingGroup {
   val YretainTrees: Setting[Boolean] = BooleanSetting("-Yretain-trees", "Retain trees for top-level classes, accessible from ClassSymbol#tree")
   val Ysemanticdb: Setting[Boolean] = BooleanSetting("-Ysemanticdb", "Store information in SemanticDB.")
   val YshowTreeIds: Setting[Boolean] = BooleanSetting("-Yshow-tree-ids", "Uniquely tag all tree nodes in debugging output.")
+  val YfromTastyBlacklist: Setting[List[String]] = MultiStringSetting("-Yfrom-tasty-blacklist", "file", "List of `tasty` files in jar files that will not be loaded when using -from-tasty")
 
   val YprofileEnabled: Setting[Boolean] = BooleanSetting("-Yprofile-enabled", "Enable profiling.")
   val YprofileDestination: Setting[String] = StringSetting("-Yprofile-destination", "file", "Where to send profiling output - specify a file, default is to the console.", "")

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyClassName.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyClassName.scala
@@ -25,10 +25,6 @@ class TastyClassName(bytes: Array[Byte]) {
     import dotty.tools.tasty.TastyFormat._
     def unpickle(reader: TastyReader, tastyName: NameTable): (TermName, TermName) = {
       import reader._
-      def readName() = {
-        val idx = readNat()
-        nameAtRef(NameRef(idx))
-      }
       def readNames(packageName: TermName): (TermName, TermName) = {
         val tag = readByte()
         if (tag >= firstLengthTreeTag) {
@@ -36,7 +32,7 @@ class TastyClassName(bytes: Array[Byte]) {
           val end = currentAddr + len
           tag match {
             case TYPEDEF =>
-              val className = readName()
+              val className = reader.readName()
               goto(end)
               (packageName, className)
             case IMPORT | VALDEF =>
@@ -48,7 +44,14 @@ class TastyClassName(bytes: Array[Byte]) {
         }
         else tag match {
           case TERMREFpkg | TYPEREFpkg =>
-            val subPackageName = readName()
+            val subPackageName = reader.readName()
+            readNames(subPackageName)
+          case SHAREDtype =>
+            val addr = reader.readAddr()
+            val reader2 = reader.subReader(addr, reader.endAddr)
+            val tag2 = reader2.readByte()
+            assert(tag2 == TERMREFpkg || tag2 == TYPEREFpkg)
+            val subPackageName = reader2.readName()
             readNames(subPackageName)
           case _ =>
             readNames(packageName)
@@ -56,5 +59,11 @@ class TastyClassName(bytes: Array[Byte]) {
       }
       readNames(nme.EMPTY_PACKAGE)
     }
+
+    extension (reader: TastyReader) def readName() = {
+      val idx = reader.readNat()
+      nameAtRef(NameRef(idx))
+    }
   }
+
 }

--- a/stdlib-bootstrapped-tasty-tests/test/BootstrappedStdLibTASYyTest.scala
+++ b/stdlib-bootstrapped-tasty-tests/test/BootstrappedStdLibTASYyTest.scala
@@ -94,13 +94,6 @@ object BootstrappedStdLibTASYyTest:
   def scalaLibClassesPath =
     java.nio.file.Paths.get(scalaLibJarPath).getParent.resolve("classes").normalize
 
-  val scalaLibJarTastyClassNames = {
-    val scalaLibJar = Jar(new File(java.nio.file.Paths.get(scalaLibJarPath)))
-    scalaLibJar.toList.map(_.toString).filter(_.endsWith(".tasty"))
-      .map(_.stripSuffix(".tasty").replace("/", "."))
-      .sorted
-  }
-
   val scalaLibTastyPaths =
     new Directory(scalaLibClassesPath).deepFiles
       .filter(_.`extension` == "tasty")
@@ -113,8 +106,8 @@ object BootstrappedStdLibTASYyTest:
         root.showExtractors // Check that we can traverse the full tree
         ()
     }
-    val classNames = scalaLibJarTastyClassNames.filterNot(blacklisted.map(_.stripSuffix(".tasty").replace("/", ".")))
-    val hasErrors = inspector.inspectTastyFilesInJar(scalaLibJarPath)
+    val tastyFiles = scalaLibTastyPaths.filterNot(blacklisted)
+    val hasErrors = inspector.inspectTastyFiles(tastyFiles.map(x => scalaLibClassesPath.resolve(x).toString))
     assert(!hasErrors, "Errors reported while loading from TASTy")
 
   def compileFromTastyInJar(blacklisted: Set[String]): Unit = {

--- a/stdlib-bootstrapped-tasty-tests/test/BootstrappedStdLibTASYyTest.scala
+++ b/stdlib-bootstrapped-tasty-tests/test/BootstrappedStdLibTASYyTest.scala
@@ -120,7 +120,7 @@ object BootstrappedStdLibTASYyTest:
   def compileFromTastyInJar(blacklisted: Set[String]): Unit = {
     val driver = new dotty.tools.dotc.Driver
     val yFromTastyBlacklist =
-      blacklisted.mkString("-Yfrom-tasty-blacklist:", ",", "")
+      blacklisted.mkString("-Yfrom-tasty-ignore-list:", ",", "")
     val args = Array(
       "-classpath", ClasspathFromClassloader(getClass.getClassLoader),
       "-from-tasty",


### PR DESCRIPTION
Now we test that the `-from-tasty` compilation works on the std lib for a jar or individual tasty files.

We also fix #10143 as this failure shows up in the second set of tests. We did not parse correctly the name of the package if it was represented with a `SHAREDtype` in TASTy. Now we follow the shared type and read its name.